### PR TITLE
Fix Windows CI and update Actions runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/model-discovery.yml
+++ b/.github/workflows/model-discovery.yml
@@ -18,8 +18,8 @@ jobs:
   discover:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "24"
           cache: npm
@@ -38,7 +38,7 @@ jobs:
           git archive --format=zip --prefix="$prefix" -o "dist/codex-router-${GITHUB_REF_NAME#v}.zip" "$GITHUB_REF_NAME"
           cd dist
           sha256sum codex-router-* > SHA256SUMS
-      - uses: actions/attest-build-provenance@v2
+      - uses: actions/attest-build-provenance@v4
         with:
           subject-path: "dist/*"
       - name: Publish GitHub release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Fixed Windows private-file ACL grants for numeric user SIDs and corrected
+  router-status detection for escaped Windows catalog paths.
+
 ## 0.3.0
 
 - Added guided, provider-aware setup for Kimi OAuth, Kimi API, and DeepSeek API.

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -55,14 +55,23 @@ function trimBlankEdges(lines) {
   return copy;
 }
 
-function rootValue(lines, key) {
-  const match = lines.find((line) => new RegExp(`^\\s*${key}\\s*=`).test(line));
-  if (!match) return undefined;
-  return match.split("=").slice(1).join("=").trim().replace(/^["']|["']$/g, "");
+function assignmentValue(line) {
+  const raw = line.split("=").slice(1).join("=").trim();
+  if (raw.startsWith('"') && raw.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      // Preserve the previous best-effort behavior for malformed user config.
+    }
+  }
+  if (raw.startsWith("'") && raw.endsWith("'")) return raw.slice(1, -1);
+  return raw.replace(/^(["'])|(["'])$/g, "");
 }
 
-function assignmentValue(line) {
-  return line.split("=").slice(1).join("=").trim().replace(/^(["'])|(["'])$/g, "");
+function rootValue(lines, key) {
+  const match = lines.find((line) => new RegExp(`^\\s*${key}\\s*=`).test(line));
+  return match ? assignmentValue(match) : undefined;
 }
 
 function clean(contents) {

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -42,9 +42,11 @@ export function privateFileIsProtected(target) {
   if (process.platform !== "win32") return (statSync(target).mode & 0o777) === 0o600;
   const script = [
     "$acl = Get-Acl -LiteralPath $env:CODEX_ROUTER_PRIVATE_FILE",
-    "$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value",
+    "$identity = [Security.Principal.WindowsIdentity]::GetCurrent()",
+    "$sid = $identity.User.Value",
+    "$name = $identity.Name",
     "$allowed = $false",
-    "foreach ($rule in $acl.Access) { try { $ruleSid = $rule.IdentityReference.Translate([Security.Principal.SecurityIdentifier]).Value } catch { continue }; if ($ruleSid -eq $sid -and $rule.AccessControlType -eq 'Allow') { $allowed = $true } }",
+    "foreach ($rule in $acl.Access) { $ruleIdentity = $rule.IdentityReference.Value; $matches = $ruleIdentity -eq $sid -or $ruleIdentity -eq $name; if (-not $matches) { try { $matches = $rule.IdentityReference.Translate([Security.Principal.SecurityIdentifier]).Value -eq $sid } catch { $matches = $false } }; if ($matches -and $rule.AccessControlType -eq 'Allow') { $allowed = $true } }",
     "[Console]::Out.Write(($acl.AreAccessRulesProtected -and $allowed).ToString())",
   ].join("; ");
   try {

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -41,7 +41,10 @@ export function privateFileIsProtected(target) {
   if (!existsSync(target)) return false;
   if (process.platform !== "win32") return (statSync(target).mode & 0o777) === 0o600;
   const script = [
-    "$acl = Get-Acl -LiteralPath $env:CODEX_ROUTER_PRIVATE_FILE",
+    // Get-Acl lazy-loads Microsoft.PowerShell.Security, which can fail under
+    // concurrent Windows processes. The .NET API returns the same FileSecurity
+    // object without importing a PowerShell module.
+    "$acl = [System.IO.File]::GetAccessControl($env:CODEX_ROUTER_PRIVATE_FILE)",
     "$identity = [Security.Principal.WindowsIdentity]::GetCurrent()",
     "$sid = $identity.User.Value",
     "$name = $identity.Name",

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -16,13 +16,22 @@ function currentWindowsSid() {
   return windowsSid;
 }
 
+export function windowsFullControlGrant(sid) {
+  if (!/^S-\d+(?:-\d+)+$/i.test(sid)) {
+    throw new Error("Could not format an invalid Windows user SID.");
+  }
+  // icacls requires an asterisk before a numeric SID so it is not resolved as
+  // an account name. Without it, hosted runners fail with system error 1332.
+  return `*${sid}:(F)`;
+}
+
 export function protectPrivateFile(target) {
   chmodSync(target, 0o600);
   if (process.platform !== "win32") return target;
   const sid = currentWindowsSid();
   execFileSync(
     "icacls.exe",
-    [target, "/inheritance:r", "/grant:r", `${sid}:(F)`],
+    [target, "/inheritance:r", "/grant:r", windowsFullControlGrant(sid)],
     { stdio: "ignore" },
   );
   return target;

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const manager = path.join(root, "src", "config-manager.mjs");
 
-function run(command, codexHome) {
+function run(command, codexHome, stateDir = path.join(codexHome, "router-state")) {
   return JSON.parse(
     execFileSync(process.execPath, [manager, command], {
       cwd: root,
@@ -22,7 +22,7 @@ function run(command, codexHome) {
       env: {
         ...process.env,
         CODEX_HOME: codexHome,
-        CODEX_ROUTER_STATE_DIR: path.join(codexHome, "router-state"),
+        CODEX_ROUTER_STATE_DIR: stateDir,
         CODEX_ROUTER_PORT: "46192",
       },
     }),
@@ -67,6 +67,20 @@ approval_policy = "never"
     assert.match(restored, /model_provider = "openai"/);
     assert.match(restored, /model_reasoning_effort = "xhigh"/);
     assert.match(restored, /\[profiles\.work\]/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager decodes escaped catalog paths", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-escaped-path-"));
+  const stateDir = path.join(codexHome, "router\\state");
+
+  try {
+    const enabled = run("enable", codexHome, stateDir);
+    assert.equal(enabled.mode, "router");
+    assert.equal(enabled.model_catalog_json, path.join(stateDir, "merged-models.json"));
+    assert.equal(run("status", codexHome, stateDir).mode, "router");
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }

--- a/test/file-security.test.mjs
+++ b/test/file-security.test.mjs
@@ -1,0 +1,12 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { windowsFullControlGrant } from "../src/file-security.mjs";
+
+test("Windows numeric SID grants use the icacls SID prefix", () => {
+  assert.equal(
+    windowsFullControlGrant("S-1-5-21-1742564184-1656218818-310408600-500"),
+    "*S-1-5-21-1742564184-1656218818-310408600-500:(F)",
+  );
+  assert.throws(() => windowsFullControlGrant("runner@example.com"), /invalid Windows user SID/);
+});

--- a/test/file-security.test.mjs
+++ b/test/file-security.test.mjs
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
-import { windowsFullControlGrant } from "../src/file-security.mjs";
+import {
+  privateFileIsProtected,
+  protectPrivateFile,
+  windowsFullControlGrant,
+} from "../src/file-security.mjs";
 
 test("Windows numeric SID grants use the icacls SID prefix", () => {
   assert.equal(
@@ -10,3 +18,33 @@ test("Windows numeric SID grants use the icacls SID prefix", () => {
   );
   assert.throws(() => windowsFullControlGrant("runner@example.com"), /invalid Windows user SID/);
 });
+
+test(
+  "Windows private-file ACL is protected for the current identity",
+  { skip: process.platform !== "win32" },
+  () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-acl-"));
+    const target = path.join(directory, "private.secret");
+    writeFileSync(target, "TEST_ONLY\n");
+    try {
+      protectPrivateFile(target);
+      const script = [
+        "$acl = Get-Acl -LiteralPath $env:CODEX_ROUTER_PRIVATE_FILE",
+        "$identity = [Security.Principal.WindowsIdentity]::GetCurrent()",
+        "$rules = @($acl.Access | ForEach-Object { [pscustomobject]@{ identity = $_.IdentityReference.Value; type = $_.AccessControlType.ToString(); inherited = $_.IsInherited } })",
+        "[pscustomobject]@{ protected = $acl.AreAccessRulesProtected; currentSid = $identity.User.Value; currentName = $identity.Name; rules = $rules } | ConvertTo-Json -Compress -Depth 4",
+      ].join("; ");
+      const acl = execFileSync(
+        "powershell.exe",
+        ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        {
+          encoding: "utf8",
+          env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target },
+        },
+      ).trim();
+      assert.equal(privateFileIsProtected(target), true, acl);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/file-security.test.mjs
+++ b/test/file-security.test.mjs
@@ -29,7 +29,7 @@ test(
     try {
       protectPrivateFile(target);
       const script = [
-        "$acl = Get-Acl -LiteralPath $env:CODEX_ROUTER_PRIVATE_FILE",
+        "$acl = [System.IO.File]::GetAccessControl($env:CODEX_ROUTER_PRIVATE_FILE)",
         "$identity = [Security.Principal.WindowsIdentity]::GetCurrent()",
         "$rules = @($acl.Access | ForEach-Object { [pscustomobject]@{ identity = $_.IdentityReference.Value; type = $_.AccessControlType.ToString(); inherited = $_.IsInherited } })",
         "[pscustomobject]@{ protected = $acl.AreAccessRulesProtected; currentSid = $identity.User.Value; currentName = $identity.Name; rules = $rules } | ConvertTo-Json -Compress -Depth 4",


### PR DESCRIPTION
## What changed

- Prefix numeric Windows user SIDs with `*` for `icacls` grants.
- Verify Windows file ACLs without loading the flaky `Microsoft.PowerShell.Security` module.
- Decode quoted TOML strings before comparing Windows catalog paths.
- Add native Windows ACL and escaped-path regression coverage.
- Upgrade GitHub Actions to their Node 24-based releases across CI, discovery, and release workflows.
- Document the fixes in the changelog.

## Root cause

Windows `icacls` treats an unprefixed numeric SID as an account name and fails with system error 1332. Generated Windows paths are also escaped in `config.toml`, while the previous status comparison used undecoded source text. After fixing the grant, concurrent Windows tests exposed a separate `Get-Acl` module-loading failure, so ACL verification now uses the equivalent .NET `FileSecurity` API directly.

## Impact

Protected credential, migration, provider-selection, setup, and support-bundle files now receive and verify the intended current-user-only Windows ACL. Codex Router also recognizes its generated model catalog on Windows, and its workflows no longer emit the Node 20 action-runtime warning.

## Validation

- GitHub Actions: Ubuntu, macOS, and Windows all pass
- Windows-native ACL regression passes on `windows-latest`
- `npm run check`
- `npm test` — 20 passing locally, 1 Windows-only test skipped
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- POSIX shell syntax and installer help checks pass
- PowerShell installer parsing passes on Windows
- GitGuardian security check passes
