### PR TITLE
fix(linux): unquote WorkingDirectory in systemd unit (was breaking install --guided)

### DIFF
--- a/bin/enable
+++ b/bin/enable
@@ -15,6 +15,6 @@ rollback() {
 }
 trap rollback EXIT HUP INT TERM
 node src/service.mjs install
-node src/wait-health.mjs
+node src/wait-health.mjs '' 90000
 trap - EXIT HUP INT TERM
 echo "External model routes enabled. Fully quit and reopen Codex."

--- a/bin/install
+++ b/bin/install
@@ -97,7 +97,7 @@ node src/config-manager.mjs enable
 config_enabled=true
 service_installed=true
 node src/service.mjs install
-node src/wait-health.mjs
+node src/wait-health.mjs '' 90000
 node src/install-manifest.mjs record >/dev/null
 config_enabled=false
 service_installed=false

--- a/src/service-linux.mjs
+++ b/src/service-linux.mjs
@@ -58,7 +58,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-WorkingDirectory=${systemdQuote(SOURCE_ROOT)}
+WorkingDirectory=${SOURCE_ROOT}
 ExecStart=${systemdQuote(process.execPath)} ${systemdQuote(start)}
 Restart=always
 RestartSec=5


### PR DESCRIPTION
On Linux with systemd, the guided installer always failed with:

```
Timed out waiting for http://127.0.0.1:4102/health: fetch failed
```

Root cause: `src/service-linux.mjs` wraps `WorkingDirectory` with `systemdQuote()`, producing `WorkingDirectory="/home/user/..."`. systemd rejected this with:

```
WorkingDirectory= path is not absolute: "/home/ktz/.local/share/codex-router"
```

so the unit never started, and the healthcheck timeout was the only visible symptom. Manually starting litellm confirmed the app itself was fine — the bug was purely in the generated unit file.

Fix: drop the quoting for `WorkingDirectory` (ExecStart quoting is unaffected and still needed there).

Also included a small bump of the wait-health timeout (30s -> 90s) during --guided setup, since cold start can be slow on first run — separate commit, happy to drop if out of scope.