### PR TITLE
Keep router health responsive

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -15,6 +15,7 @@ import {
   PROVIDERS,
   providerForModel,
 } from "./model-registry.mjs";
+import { readProviderSelection } from "./provider-selection.mjs";
 import {
   credentialStatus,
   resolveProviderCredential,
@@ -135,8 +136,9 @@ function upstreamHeaders(requestHeaders, body, apiKey, provider) {
 
 function healthPayload() {
   const providers = {};
+  const enabled = new Set(readProviderSelection());
   for (const provider of PROVIDERS.values()) {
-    if (provider.kind !== "openai-compatible") continue;
+    if (provider.kind !== "openai-compatible" || !enabled.has(provider.id)) continue;
     const status = credentialStatus(provider);
     providers[provider.id] = {
       credential_present: status.configured,

--- a/src/cursor-router.mjs
+++ b/src/cursor-router.mjs
@@ -182,7 +182,7 @@ async function serviceHealth(url) {
   try {
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
-      signal: AbortSignal.timeout(1_000),
+      signal: AbortSignal.timeout(3_000),
     });
     const raw = await response.json().catch(() => undefined);
     const payload = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};

--- a/src/router-health.mjs
+++ b/src/router-health.mjs
@@ -9,7 +9,7 @@ export async function waitForRouterHealth({
   target = TARGET,
   url = loopback(PORTS.router, "/health"),
   timeoutMs = 30_000,
-  requestTimeoutMs = 1_000,
+  requestTimeoutMs = 4_000,
   intervalMs = 250,
   fetchImpl = fetch,
 } = {}) {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -21,7 +21,7 @@ import {
   writeJson,
 } from "./http-utils.mjs";
 import { MERGED_CATALOG_PATH, PORTS, loopback } from "./paths.mjs";
-import { MODEL_BY_SLUG, providerForModel } from "./model-registry.mjs";
+import { MODEL_BY_SLUG, PROVIDERS, providerForModel } from "./model-registry.mjs";
 import { readNativeAliases } from "./native-alias.mjs";
 import { readProviderSelection } from "./provider-selection.mjs";
 import { ResponseUsageTransform } from "./response-usage.mjs";
@@ -259,9 +259,15 @@ async function serviceHealth(url) {
 }
 
 async function healthPayload() {
+  const enabled = new Set(readProviderSelection());
+  const apiEnabled = [...PROVIDERS.values()].some(
+    (provider) => enabled.has(provider.id) && provider.kind === "openai-compatible",
+  );
   const [oauth, api, gateway] = await Promise.all([
-    serviceHealth(OAUTH_HEALTH),
-    serviceHealth(API_HEALTH),
+    enabled.has("kimi-oauth")
+      ? serviceHealth(OAUTH_HEALTH)
+      : { reachable: true, enabled: false },
+    apiEnabled ? serviceHealth(API_HEALTH) : { reachable: true, enabled: false },
     serviceHealth(GATEWAY_HEALTH),
   ]);
   return {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -248,7 +248,7 @@ async function serviceHealth(url) {
   try {
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
-      signal: AbortSignal.timeout(1_000),
+      signal: AbortSignal.timeout(3_000),
     });
     const raw = await response.json().catch(() => undefined);
     const payload = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};

--- a/src/update.mjs
+++ b/src/update.mjs
@@ -7,10 +7,11 @@ import { readInstallManifest } from "./install-manifest.mjs";
 import { SOURCE_ROOT, TARGET } from "./paths.mjs";
 
 function git(args, options = {}) {
-  return execFileSync("git", ["-C", SOURCE_ROOT, ...args], {
+  const output = execFileSync("git", ["-C", SOURCE_ROOT, ...args], {
     encoding: "utf8",
     stdio: options.inherit ? "inherit" : ["ignore", "pipe", "pipe"],
-  }).trim();
+  });
+  return typeof output === "string" ? output.trim() : "";
 }
 
 function requireManagedCheckout() {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -114,14 +114,17 @@ async function closeServer(server) {
   await new Promise((resolve) => server.close(resolve));
 }
 
-test("router health ignores disabled forwarders", async () => {
+test("router health waits for enabled dependencies and ignores disabled forwarders", async () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "router-health-selection-"));
   writeFileSync(
     path.join(testRoot, "enabled-providers.json"),
     `${JSON.stringify({ version: 1, providers: ["kimi-oauth"] })}\n`,
     { mode: 0o600 },
   );
-  const healthy = await mockServer((request, response) => {
+  const healthy = await mockServer(async (request, response) => {
+    if (request.url === "/oauth-health") {
+      await new Promise((resolve) => setTimeout(resolve, 1_200));
+    }
     json(response, 200, { ok: true });
   });
   const unavailableApiPort = await openPort();
@@ -130,9 +133,9 @@ test("router health ignores disabled forwarders", async () => {
     CODEX_ROUTER_PORT: String(routerPort),
     CODEX_ROUTER_STATE_DIR: testRoot,
     CODEX_ROUTER_SHOW_ALL_MODELS: "0",
-    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${healthy.port}/health`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${healthy.port}/oauth-health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${unavailableApiPort}/health`,
-    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${healthy.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${healthy.port}/gateway-health`,
     CODEX_ROUTER_QUIET: "1",
   });
 

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -114,6 +114,39 @@ async function closeServer(server) {
   await new Promise((resolve) => server.close(resolve));
 }
 
+test("router health ignores disabled forwarders", async () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "router-health-selection-"));
+  writeFileSync(
+    path.join(testRoot, "enabled-providers.json"),
+    `${JSON.stringify({ version: 1, providers: ["kimi-oauth"] })}\n`,
+    { mode: 0o600 },
+  );
+  const healthy = await mockServer((request, response) => {
+    json(response, 200, { ok: true });
+  });
+  const unavailableApiPort = await openPort();
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_STATE_DIR: testRoot,
+    CODEX_ROUTER_SHOW_ALL_MODELS: "0",
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${healthy.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${unavailableApiPort}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${healthy.port}/health`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, router);
+    const response = await fetch(`http://127.0.0.1:${routerPort}/health`);
+    assert.equal(response.status, 200);
+  } finally {
+    await stopChild(router);
+    await closeServer(healthy.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("router requires the configured path capability before any model route", async () => {
   const sessionDirectory = mkdtempSync(path.join(os.tmpdir(), "model-router-session-"));
   const sessionIndex = path.join(sessionDirectory, "session_index.jsonl");

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -619,6 +619,37 @@ test("API forwarder replaces caller auth and enforces Kimi K3 API parameters", a
   }
 });
 
+test("API forwarder health omits disabled API providers", async () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "api-forwarder-health-"));
+  writeFileSync(
+    path.join(testRoot, "enabled-providers.json"),
+    `${JSON.stringify({ version: 1, providers: ["kimi-oauth"] })}\n`,
+    { mode: 0o600 },
+  );
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    CODEX_ROUTER_STATE_DIR: testRoot,
+    CODEX_ROUTER_SHOW_ALL_MODELS: "0",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/health`, {
+      headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.deepEqual(payload.providers, {});
+  } finally {
+    await stopChild(forwarder);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("API forwarder supports all DeepSeek V4 models and normalizes thinking", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
## What changed

- Limit API-forwarder credential health checks to enabled providers.
- Skip disabled forwarders in aggregate router health.
- Allow enabled health dependencies three seconds and the supervising probe four seconds.
- Handle inherited Git output safely during updates.
- Add regression coverage for disabled and delayed health dependencies.

## Why

The API health endpoint synchronously checked every registered macOS Keychain credential, including disabled providers. Those checks exceeded the router's one-second dependency timeout, causing intermittent HTTP 503 responses even while routed model requests succeeded. Enabled Kimi OAuth health can also legitimately take more than one second. The updater separately called trim() on null after a successful inherited fast-forward, aborting before reinstall.

## Impact

Health checks only gate on services required by enabled models, tolerate normal credential-probe latency, and keep credential details scoped to enabled API providers. Fast-forward updates now continue into installation.

## Validation

- npm run check
- npm test (117 passed, 2 skipped)
- Live daemon doctor: 0 failures
- Live health stress: 100/100 HTTP 200, slowest 1.574 seconds