### PR TITLE
fix: log cancel vs failure and stop abort spam

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -3,6 +3,8 @@ import http from "node:http";
 import {
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
+  logRequestFailure,
+  isAbortError,
   pipeResponse,
   readRequestBody,
   requireInternalAuth,
@@ -222,8 +224,17 @@ async function handleRequest(request, response) {
 
 const server = http.createServer((request, response) => {
   handleRequest(request, response).catch((error) => {
+    logRequestFailure("api-forwarder", error);
+    if (isAbortError(error)) {
+      if (!response.headersSent) {
+        response.writeHead(499);
+        response.end();
+      } else if (!response.writableEnded) {
+        response.destroy();
+      }
+      return;
+    }
     const status = httpErrorStatus(error);
-    console.error("[api-forwarder] request failed");
     if (!response.headersSent) {
       writeJson(response, status, {
         error: {

--- a/src/cursor-router.mjs
+++ b/src/cursor-router.mjs
@@ -5,6 +5,8 @@ import { assertCallerSecret, secretEqual } from "./caller-auth.mjs";
 import {
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
+  logRequestFailure,
+  isAbortError,
   pipeResponse,
   readRequestBody,
   writeJson,
@@ -309,8 +311,17 @@ async function handleRequest(request, response) {
 
 const server = http.createServer((request, response) => {
   handleRequest(request, response).catch((error) => {
+    logRequestFailure("cursor-router", error);
+    if (isAbortError(error)) {
+      if (!response.headersSent) {
+        response.writeHead(499);
+        response.end();
+      } else if (!response.writableEnded) {
+        response.destroy();
+      }
+      return;
+    }
     const status = httpErrorStatus(error);
-    console.error("[cursor-router] request failed");
     if (!response.headersSent) {
       openAiError(
         response,

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url";
 
 import {
   httpErrorStatus,
+  logRequestFailure,
+  isAbortError,
   readRequestBody,
   requireInternalAuth,
   writeJson,
@@ -449,8 +451,17 @@ if (isMain) {
   if (!INTERNAL_KEY) throw new Error("MODEL_ROUTER_INTERNAL_KEY is required.");
   const server = http.createServer((request, response) => {
     handleRequest(request, response).catch((error) => {
+      logRequestFailure("grok-oauth", error);
+      if (isAbortError(error)) {
+        if (!response.headersSent) {
+          response.writeHead(499);
+          response.end();
+        } else if (!response.writableEnded) {
+          response.destroy();
+        }
+        return;
+      }
       const status = httpErrorStatus(error);
-      console.error("[grok-oauth] request failed");
       if (!response.headersSent) {
         writeJson(response, status, {
           error: {

--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -1,6 +1,6 @@
 import { Readable } from "node:stream";
 
-import { secretEqual } from "./caller-auth.mjs";
+import { redactCallerUrl, secretEqual } from "./caller-auth.mjs";
 import { TARGET } from "./paths.mjs";
 
 export const MAX_BODY_BYTES = Number(
@@ -51,10 +51,39 @@ export function writeJson(response, status, payload) {
 }
 
 export function httpErrorStatus(error, fallback = 502) {
+  if (isAbortError(error)) return 499;
   const status = Number(error?.status);
   return Number.isInteger(status) && status >= 400 && status <= 599
     ? status
     : fallback;
+}
+
+export function isAbortError(error) {
+  if (!error) return false;
+  if (error.name === "AbortError") return true;
+  if (error.code === "ABORT_ERR" || error.code === "ERR_CANCELED") return true;
+  const message = String(error.message || error);
+  return /(?:^|\b)(?:abort(?:ed|error)?|the operation was aborted|request aborted|premature close)(?:\b|$)/i.test(
+    message,
+  );
+}
+
+export function formatErrorForLog(error) {
+  if (!(error instanceof Error)) {
+    return redactCallerUrl(String(error));
+  }
+  const parts = [];
+  if (error.name && error.name !== "Error") parts.push(error.name);
+  if (error.message) parts.push(error.message);
+  if (error.code) parts.push(`code=${error.code}`);
+  if (Number.isInteger(error.status)) parts.push(`status=${error.status}`);
+  const text = parts.length ? parts.join(": ") : error.toString();
+  return redactCallerUrl(text);
+}
+
+export function logRequestFailure(label, error) {
+  const kind = isAbortError(error) ? "request canceled" : "request failed";
+  console.error(`[${label}] ${kind}: ${formatErrorForLog(error)}`);
 }
 
 export function copyResponseHeaders(upstream, response, denylist = HOP_BY_HOP_HEADERS) {

--- a/src/oauth-forwarder.mjs
+++ b/src/oauth-forwarder.mjs
@@ -3,6 +3,8 @@ import http from "node:http";
 import {
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
+  logRequestFailure,
+  isAbortError,
   pipeResponse,
   readRequestBody,
   requireInternalAuth,
@@ -222,9 +224,18 @@ async function handleRequest(request, response) {
 
 const server = http.createServer((request, response) => {
   handleRequest(request, response).catch((error) => {
+    logRequestFailure("kimi-oauth", error);
+    if (isAbortError(error)) {
+      if (!response.headersSent) {
+        response.writeHead(499);
+        response.end();
+      } else if (!response.writableEnded) {
+        response.destroy();
+      }
+      return;
+    }
     const status = httpErrorStatus(error);
     const authenticationFailure = status === 401;
-    console.error("[kimi-oauth] request failed");
     if (!response.headersSent) {
       writeJson(response, status, {
         error: {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -15,6 +15,8 @@ import {
 import {
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
+  isAbortError,
+  logRequestFailure,
   MAX_BODY_BYTES,
   pipeResponse,
   readRequestBody,
@@ -119,7 +121,8 @@ function beginRequestActivity() {
       if (finished) return;
       finished = true;
       activeRequests.delete(requestId);
-      if (status >= 400) errorStatusUntil = Date.now() + ERROR_STATUS_DURATION_MS;
+      // Client cancels (499) and 4xx should not flash the island error state.
+      if (status >= 500) errorStatusUntil = Date.now() + ERROR_STATUS_DURATION_MS;
     },
   };
 }
@@ -612,7 +615,7 @@ async function handleResponses(request, response, requestUrl) {
       );
     }
   } catch (error) {
-    activity.finish(500);
+    activity.finish(isAbortError(error) ? 499 : 500);
     throw error;
   } finally {
     activity.finish(response.statusCode);
@@ -680,8 +683,17 @@ async function handleRequest(request, response) {
 
 const server = http.createServer((request, response) => {
   handleRequest(request, response).catch((error) => {
+    logRequestFailure("codex-router", error);
+    if (isAbortError(error)) {
+      if (!response.headersSent) {
+        response.writeHead(499);
+        response.end();
+      } else if (!response.writableEnded) {
+        response.destroy();
+      }
+      return;
+    }
     const status = httpErrorStatus(error);
-    console.error("[codex-router] request failed");
     if (!response.headersSent) {
       writeJson(response, status, {
         error: {

--- a/test/http-utils.test.mjs
+++ b/test/http-utils.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatErrorForLog,
+  httpErrorStatus,
+  isAbortError,
+} from "../src/http-utils.mjs";
+
+test("isAbortError recognizes AbortError and abort messages", () => {
+  const abort = new Error("This operation was aborted");
+  abort.name = "AbortError";
+  assert.equal(isAbortError(abort), true);
+
+  const coded = new Error("canceled");
+  coded.code = "ABORT_ERR";
+  assert.equal(isAbortError(coded), true);
+
+  assert.equal(isAbortError(new Error("premature close")), true);
+  assert.equal(isAbortError(new Error("upstream 500")), false);
+});
+
+test("httpErrorStatus maps aborts to 499 and preserves explicit status", () => {
+  const abort = new Error("aborted");
+  abort.name = "AbortError";
+  assert.equal(httpErrorStatus(abort), 499);
+
+  const typed = new Error("too large");
+  typed.status = 413;
+  assert.equal(httpErrorStatus(typed), 413);
+  assert.equal(httpErrorStatus(new Error("boom")), 502);
+});
+
+test("formatErrorForLog redacts caller secrets and includes code", () => {
+  const error = new Error(
+    "failed http://127.0.0.1:4102/_codex-router/super-secret-token/v1/responses",
+  );
+  error.name = "TypeError";
+  error.code = "ECONNRESET";
+  const text = formatErrorForLog(error);
+  assert.match(text, /TypeError/);
+  assert.match(text, /code=ECONNRESET/);
+  assert.match(text, /\[REDACTED\]/);
+  assert.doesNotMatch(text, /super-secret-token/);
+});


### PR DESCRIPTION
## Summary
Codex multi-task load produced hundreds of opaque `[codex-router] request failed` log lines with no error detail. Live traffic after this change shows those were mostly client aborts (`AbortError: This operation was aborted`), not provider outages.

## Changes
- Add shared helpers: `isAbortError`, `formatErrorForLog` (redacts caller secret URLs), `logRequestFailure`
- Log `request canceled` vs `request failed` with the actual error text
- Treat aborts as HTTP `499` instead of generic `502`
- Apply the same handling in Codex router, API forwarder, Kimi OAuth, Grok OAuth, and Cursor router
- Only flash Dynamic Island error state for real `5xx` statuses (not cancel/4xx)

## Root cause
Top-level `.catch` handlers discarded the error object and always printed `request failed`. Concurrent Codex tasks frequently cancel in-flight requests when switching tasks, stopping turns, or superseding work.

## Impact
- Operators can distinguish cancel noise from real failures
- Logs no longer look like mass provider breakage under multi-task use
- Caller capability secrets remain redacted in log text

## Test plan
- [x] `node --test test/http-utils.test.mjs` (3/3 pass)
- [x] Live service restart after patch; doctor green
- [x] Observed live log lines: `[codex-router] request canceled: AbortError: This operation was aborted: code=20`
- [ ] Optional: full package test suite on CI
