### PR TITLE
Confirm hidden API-key entry and catch doubled pastes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
   flips router health into the eight-second error state, so tray and island
   status indicators stop flashing red on ordinary cancels. Errors the router
   or an upstream actually produced still surface.
+- The hidden API-key prompt now confirms how many characters were captured
+  after each entry, challenges input that looks like the same key pasted
+  twice before saving, and re-prompts instead of failing on empty input, so a
+  paste with terminal echo disabled is no longer a silent leap of faith.
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -76,7 +76,10 @@ token into Codex config, an API-key file, or an environment variable.
 ./bin/provider-key anthropic-api status
 ```
 
-Input is hidden. A key written by the helper is protected for the current user.
+Input is hidden. After you press Enter, the prompt reports how many characters
+it received, so you can tell a paste registered, and it asks before saving a
+value that looks like the same key pasted twice. A key written by the helper is
+protected for the current user.
 Setting or rotating it takes effect on the next request; the background service
 does not need a restart.
 

--- a/src/provider-key.mjs
+++ b/src/provider-key.mjs
@@ -9,6 +9,7 @@ import {
   writeProviderCredential,
 } from "./provider-credentials.mjs";
 import { disableProvider, enableProvider } from "./provider-selection.mjs";
+import { secretEntryFeedback, secretEntryProblem } from "./secret-entry.mjs";
 import {
   refreshTargetPickerIfInstalled,
   targetPickerName,
@@ -114,6 +115,80 @@ function hiddenPrompt(label) {
   }
 }
 
+function visiblePrompt(label) {
+  if (process.platform === "win32") {
+    const script = "[Console]::Out.Write((Read-Host $env:CODEX_ROUTER_PROMPT_LABEL))";
+    let lastError;
+    for (const executable of ["powershell.exe", "pwsh.exe"]) {
+      try {
+        return execFileSync(
+          executable,
+          ["-NoLogo", "-NoProfile", "-Command", script],
+          {
+            encoding: "utf8",
+            env: { ...process.env, CODEX_ROUTER_PROMPT_LABEL: label },
+            stdio: ["inherit", "pipe", "inherit"],
+          },
+        );
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw lastError || new Error("PowerShell is required for interactive confirmation.");
+  }
+  let descriptor;
+  try {
+    descriptor = openSync("/dev/tty", "r+");
+  } catch {
+    throw new Error("An interactive terminal is required to confirm the entered key.");
+  }
+  try {
+    writeSync(descriptor, `${label}: `);
+    const chunks = [];
+    const byte = Buffer.alloc(1);
+    while (readSync(descriptor, byte, 0, 1) === 1) {
+      if (byte[0] === 10 || byte[0] === 13) break;
+      chunks.push(Buffer.from(byte));
+    }
+    return Buffer.concat(chunks).toString("utf8");
+  } finally {
+    try {
+      closeSync(descriptor);
+    } catch {
+      // The descriptor may already be closed after an interrupted terminal.
+    }
+  }
+}
+
+const MAX_KEY_ATTEMPTS = 3;
+
+// The hidden prompt disables terminal echo, so a paste gives no visual
+// feedback; report the captured length and challenge input that looks like the
+// same key pasted twice before anything is saved.
+function promptForKey(label) {
+  for (let attempt = 1; attempt <= MAX_KEY_ATTEMPTS; attempt += 1) {
+    const value = hiddenPrompt(label);
+    process.stdout.write(`${secretEntryFeedback(value)}\n`);
+    const problem = secretEntryProblem(value);
+    if (!problem) return value;
+    let reason;
+    if (problem === "empty") {
+      reason = "No key was captured.";
+    } else {
+      const answer = visiblePrompt(
+        "The input looks like the same key pasted twice. Save it anyway? [y/N]",
+      ).trim();
+      if (/^y(es)?$/i.test(answer)) return value;
+      reason = "Discarded the doubled input.";
+    }
+    if (attempt === MAX_KEY_ATTEMPTS) {
+      process.stdout.write(`${reason} Nothing was saved.\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`${reason} Paste or type the key again.\n`);
+  }
+}
+
 if (command === "status") {
   const status = credentialStatus(provider);
   process.stdout.write(
@@ -127,7 +202,7 @@ if (command === "status") {
   );
   if (!status.configured) process.exitCode = 1;
 } else if (command === "set") {
-  const value = hiddenPrompt(provider.credential.prompt || `${provider.displayName} API key`);
+  const value = promptForKey(provider.credential.prompt || `${provider.displayName} API key`);
   const target = writeProviderCredential(provider, value);
   enableProvider(provider.id);
   const refreshed = refreshTargetPickerIfInstalled();

--- a/src/secret-entry.mjs
+++ b/src/secret-entry.mjs
@@ -1,0 +1,35 @@
+// Pure helpers that describe a just-captured secret so interactive prompts can
+// confirm a paste registered without ever echoing or persisting the value.
+// The hidden key prompt reads with terminal echo disabled, so a paste gives no
+// visual feedback; reporting the captured length and flagging an input that
+// looks like the same value pasted twice prevents silent doubled keys.
+
+export const MIN_DOUBLED_SECRET_LENGTH = 8;
+
+function normalized(value) {
+  return String(value ?? "").trim();
+}
+
+export function secretEntryFeedback(value) {
+  const key = normalized(value);
+  if (!key) return "No characters were received.";
+  const characters = [...key].length;
+  return `Received ${characters} character${characters === 1 ? "" : "s"}.`;
+}
+
+export function secretEntryProblem(value) {
+  if (!normalized(value)) return "empty";
+  if (looksDoubledSecret(value)) return "doubled";
+  return undefined;
+}
+
+export function looksDoubledSecret(value) {
+  const key = normalized(value);
+  if (key.length < MIN_DOUBLED_SECRET_LENGTH) return false;
+  if (key.length % 2 === 0) {
+    const half = key.length / 2;
+    return key.slice(0, half) === key.slice(half);
+  }
+  const middle = (key.length - 1) / 2;
+  return /\s/.test(key[middle]) && key.slice(0, middle) === key.slice(middle + 1);
+}

--- a/test/secret-entry.test.mjs
+++ b/test/secret-entry.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  MIN_DOUBLED_SECRET_LENGTH,
+  looksDoubledSecret,
+  secretEntryFeedback,
+  secretEntryProblem,
+} from "../src/secret-entry.mjs";
+
+test("secretEntryFeedback reports how many characters were captured", () => {
+  assert.equal(secretEntryFeedback("example-key"), "Received 11 characters.");
+});
+
+test("secretEntryFeedback counts the trimmed value that will be saved", () => {
+  assert.equal(secretEntryFeedback("  example-key  \r"), "Received 11 characters.");
+});
+
+test("secretEntryFeedback uses a singular label for one character", () => {
+  assert.equal(secretEntryFeedback("k"), "Received 1 character.");
+});
+
+test("secretEntryFeedback reports empty input without failing", () => {
+  assert.equal(secretEntryFeedback(""), "No characters were received.");
+  assert.equal(secretEntryFeedback("   "), "No characters were received.");
+  assert.equal(secretEntryFeedback(undefined), "No characters were received.");
+});
+
+test("secretEntryFeedback counts characters, not UTF-8 bytes", () => {
+  assert.equal(secretEntryFeedback("k€y-¢ode"), "Received 8 characters.");
+});
+
+test("looksDoubledSecret detects the same value pasted twice back-to-back", () => {
+  assert.equal(looksDoubledSecret("test-key-1234test-key-1234"), true);
+});
+
+test("looksDoubledSecret detects a doubled paste separated by whitespace", () => {
+  assert.equal(looksDoubledSecret("test-key-1234 test-key-1234"), true);
+});
+
+test("looksDoubledSecret trims before checking", () => {
+  assert.equal(looksDoubledSecret("  test-key-1234test-key-1234  "), true);
+});
+
+test("looksDoubledSecret accepts normal keys", () => {
+  assert.equal(looksDoubledSecret("test-key-1234"), false);
+  assert.equal(looksDoubledSecret("plan-key-example-value"), false);
+  assert.equal(looksDoubledSecret(""), false);
+});
+
+test("looksDoubledSecret ignores short repeated fragments", () => {
+  assert.equal(looksDoubledSecret("abab"), false);
+  assert.equal(looksDoubledSecret("aa"), false);
+});
+
+test("looksDoubledSecret requires the halves to match exactly", () => {
+  assert.equal(looksDoubledSecret("test-key-1234test-key-9999"), false);
+  assert.equal(looksDoubledSecret("test-key-1234_test-key-1234"), false);
+});
+
+test("secretEntryProblem flags empty input", () => {
+  assert.equal(secretEntryProblem(""), "empty");
+  assert.equal(secretEntryProblem("   "), "empty");
+  assert.equal(secretEntryProblem(undefined), "empty");
+});
+
+test("secretEntryProblem flags doubled input", () => {
+  assert.equal(secretEntryProblem("test-key-1234test-key-1234"), "doubled");
+});
+
+test("secretEntryProblem accepts a normal key", () => {
+  assert.equal(secretEntryProblem("test-key-1234"), undefined);
+});
+
+test("MIN_DOUBLED_SECRET_LENGTH is a positive integer", () => {
+  assert.ok(
+    Number.isInteger(MIN_DOUBLED_SECRET_LENGTH) && MIN_DOUBLED_SECRET_LENGTH > 0,
+  );
+});


### PR DESCRIPTION
## Problem

The hidden API-key prompt (`bin/provider-key <id> set`) disables terminal echo, so pasting a key gives no indication that anything was captured. Pasting twice by accident saves a silently broken doubled credential that only surfaces later as an upstream auth failure. Empty input crashed with a raw stack trace from `writeProviderCredential`.

## Change

After each entry the prompt now:

- reports how many characters were received (`Received 42 characters.`) — the value itself is never echoed or logged, matching the existing zero-knowledge posture;
- challenges input whose halves are identical — the doubled-paste signature, back-to-back or whitespace-separated — with an explicit `Save it anyway? [y/N]` before anything is written;
- re-prompts up to three times on empty or discarded input instead of failing with a stack trace.

The Windows `Read-Host -AsSecureString` path already shows masked feedback while typing; the post-entry confirmation now behaves identically on all platforms.

Detection and feedback are pure functions in a new `src/secret-entry.mjs` with unit tests (`test/secret-entry.test.mjs`), following the `kimi-oauth-onboarding.mjs` pattern; `provider-key.mjs` keeps only the terminal wiring.

## Verification

- `npm run check`, `npm test` (134 tests, 0 fail), `sh -n install.sh` + all `bin/*`, `npm audit --omit=dev` clean.
- Interactive flows exercised in a real PTY (`expect`) against an isolated `CODEX_ROUTER_STATE_DIR`: normal entry, doubled paste → decline → retry → save, and three declined attempts → `Nothing was saved.` + exit 1 with no file written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)