### PR TITLE
Add Z.ai GLM Coding Plan provider (GLM-5.2, GLM-5-Turbo)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ user.
 3. Never ask the user to paste OAuth tokens or API keys into chat, command
    arguments, logs, environment snippets, or tracked files.
 4. Determine which provider IDs the user requested: `anthropic-api`,
-   `kimi-oauth`, `kimi-api`, `deepseek`, and/or `grok-api`. If they did not specify and credentials already exist, use
+   `kimi-oauth`, `kimi-api`, `deepseek`, `grok-api`, and/or `zai-coding`. If they did not specify and credentials already exist, use
    `configured` rather than showing providers that cannot authenticate.
 5. For Kimi OAuth, reuse a valid `kimi login` session. If login is needed, run
    the official CLI only in an interactive terminal. For API providers, invoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   after each entry, challenges input that looks like the same key pasted
   twice before saving, and re-prompts instead of failing on empty input, so a
   paste with terminal echo disabled is no longer a silent leap of faith.
+- Added a Z.ai GLM Coding Plan provider (`zai-coding`) with GLM-5.2 and
+  GLM-5-Turbo picker models. Requests use the plan's dedicated coding endpoint,
+  enable thinking, map Codex's maximum reasoning tier to Z.ai's `max` effort,
+  and drop sampling overrides that conflict with thinking mode.
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Linux installations support the Codex CLI and the Cursor target's local gateway.
 | Grok 4.5 (OAuth) | `grok-oauth/grok-4.5` | Official Grok CLI OAuth session |
 | Grok 4.5 (API) | `grok-api/grok-4.5` | Separately billed xAI API key |
 | Claude Opus 4.8 (API) | `anthropic-api/claude-opus-4.8` | Separately billed Anthropic API key |
+| GLM-5.2 (Coding Plan) | `zai-coding/glm-5.2` | Z.ai GLM Coding Plan API key |
+| GLM-5-Turbo (Coding Plan) | `zai-coding/glm-5-turbo` | Z.ai GLM Coding Plan API key |
 
 The Codex catalog is credential-aware. It includes models only from enabled
 external providers with a stored API key or valid OAuth session. Native GPT
@@ -102,6 +104,11 @@ ChatGPT OAuth provider in the router.
 Kimi Code OAuth and Kimi Platform API access are separate authentication and
 billing systems. The two Kimi entries intentionally coexist. Older DeepSeek
 aliases remain hidden compatibility routes and are not advertised to new users.
+
+The Z.ai entries use the GLM Coding Plan's dedicated endpoint and its
+subscription API key. That key is not interchangeable with general Z.ai
+platform keys, and Z.ai reserves the coding endpoint for interactive coding
+tools.
 
 Only enabled providers appear in an app's picker. Each target has its own
 selection and API-key files:

--- a/config/providers.json
+++ b/config/providers.json
@@ -75,6 +75,21 @@
         "keychainServices": ["codex-router-anthropic-api"],
         "prompt": "Anthropic API key"
       }
+    },
+    {
+      "id": "zai-coding",
+      "displayName": "Z.ai GLM Coding Plan",
+      "kind": "openai-compatible",
+      "ownedBy": "zai",
+      "baseUrl": "https://api.z.ai/api/coding/paas/v4",
+      "baseUrlEnv": "ZAI_CODING_BASE_URL",
+      "credential": {
+        "environment": ["ZAI_API_KEY", "ZAI_CODING_API_KEY"],
+        "file": "zai-coding-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": ["codex-router-zai-coding"],
+        "prompt": "Z.ai GLM Coding Plan API key"
+      }
     }
   ],
   "models": [
@@ -272,6 +287,46 @@
       "inputModalities": ["text", "image"],
       "requestProfile": "anthropic-reasoning",
       "compHash": "anthropic-api-claude-opus-4-8-v1"
+    },
+    {
+      "slug": "zai-coding/glm-5.2",
+      "gatewayModel": "zai-coding-glm-5-2",
+      "upstreamModel": "glm-5.2",
+      "provider": "zai-coding",
+      "listed": true,
+      "displayName": "GLM-5.2 (Coding Plan)",
+      "description": "GLM-5.2 through the Z.ai GLM Coding Plan subscription with agentic coding, tool calls, and a 1M context window.",
+      "priority": 10,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        { "effort": "high", "description": "Deep reasoning with thinking enabled" },
+        { "effort": "max", "description": "Maximum reasoning depth" }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 900000,
+      "inputModalities": ["text"],
+      "requestProfile": "glm-thinking",
+      "compHash": "zai-coding-glm-5-2-v1"
+    },
+    {
+      "slug": "zai-coding/glm-5-turbo",
+      "gatewayModel": "zai-coding-glm-5-turbo",
+      "upstreamModel": "glm-5-turbo",
+      "provider": "zai-coding",
+      "listed": true,
+      "displayName": "GLM-5-Turbo (Coding Plan)",
+      "description": "GLM-5-Turbo through the Z.ai GLM Coding Plan subscription; faster responses with a 200k context window.",
+      "priority": 11,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        { "effort": "high", "description": "Deep reasoning with thinking enabled" },
+        { "effort": "max", "description": "Maximum reasoning depth" }
+      ],
+      "contextWindow": 204800,
+      "autoCompact": 180000,
+      "inputModalities": ["text"],
+      "requestProfile": "glm-thinking",
+      "compHash": "zai-coding-glm-5-turbo-v1"
     }
   ]
 }

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -90,6 +90,8 @@ map, which restores native GPT routing.
 | Grok 4.5 OAuth | `grok-oauth/grok-4.5` | `grok-oauth-grok-4-5` | `grok-4.5` |
 | Grok 4.5 | `grok-api/grok-4.5` | `grok-api-grok-4-5` | `grok-4.5` |
 | Claude Opus 4.8 | `anthropic-api/claude-opus-4.8` | `anthropic-api-claude-opus-4-8` | `claude-opus-4-8` |
+| GLM-5.2 Coding Plan | `zai-coding/glm-5.2` | `zai-coding-glm-5-2` | `glm-5.2` |
+| GLM-5-Turbo Coding Plan | `zai-coding/glm-5-turbo` | `zai-coding-glm-5-turbo` | `glm-5-turbo` |
 
 The native catalog objects are preserved rather than reconstructed, which keeps
 current instructions and capability metadata from the installed Codex build.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -88,6 +88,7 @@ API-key providers use hidden prompts:
 ./bin/provider-key deepseek set
 ./bin/provider-key grok-api set
 ./bin/provider-key anthropic-api set
+./bin/provider-key zai-coding set
 ```
 
 Grok OAuth uses the official Grok CLI session:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -84,7 +84,9 @@ Setting or rotating it takes effect on the next request; the background service
 does not need a restart.
 
 Confirm the key belongs to the named system. Kimi Code OAuth, Kimi Platform,
-DeepSeek, and Anthropic do not share credentials or billing.
+DeepSeek, Anthropic, and the Z.ai GLM Coding Plan do not share credentials or
+billing. The Z.ai coding key is also distinct from general Z.ai platform keys;
+only the Coding Plan subscription key works with the coding endpoint.
 
 ## A provider changed its model IDs
 

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -95,6 +95,19 @@ function normalizeBody(buffer, contentType, route) {
   } else if (model.requestProfile === "deepseek-nonthinking") {
     payload.thinking = { type: "disabled" };
     delete payload.reasoning_effort;
+  } else if (model.requestProfile === "glm-thinking") {
+    payload.thinking = { type: "enabled" };
+    if (["xhigh", "max", "ultra"].includes(payload.reasoning_effort)) {
+      payload.reasoning_effort = "max";
+    } else {
+      // Z.ai documents only the maximum tier; leave other levels to the
+      // upstream default rather than sending an unsupported value.
+      delete payload.reasoning_effort;
+    }
+    // Z.ai requires temperature 1.0 with thinking enabled; drop sampling
+    // overrides so the upstream default applies.
+    delete payload.temperature;
+    delete payload.top_p;
   } else if (model.requestProfile === "xai-reasoning") {
     if (!["low", "medium", "high"].includes(payload.reasoning_effort)) {
       payload.reasoning_effort = "high";

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -35,6 +35,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
       "grok-oauth",
       "grok-api",
       "anthropic-api",
+      "zai-coding",
     ]);
     process.env.KIMI_API_KEY = "TEST_ENVIRONMENT_ONLY_KEY";
     assert.deepEqual(configuredProviderIds(), []);

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -23,9 +23,15 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "grok-oauth/grok-4.5",
       "grok-api/grok-4.5",
       "anthropic-api/claude-opus-4.8",
+      "zai-coding/glm-5.2",
+      "zai-coding/glm-5-turbo",
     ],
   );
   assert.equal(PROVIDERS.get("deepseek").baseUrl, "https://api.deepseek.com");
+  assert.equal(
+    PROVIDERS.get("zai-coding").baseUrl,
+    "https://api.z.ai/api/coding/paas/v4",
+  );
   assert.equal(PROVIDERS.get("grok-api").baseUrl, "https://api.x.ai/v1");
   assert.equal(PROVIDERS.get("grok-oauth").proxyBaseEnv, "GROK_OAUTH_FORWARD_BASE_URL");
   assert.equal(PROVIDERS.get("anthropic-api").protocol, "anthropic");

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -794,6 +794,64 @@ test("API forwarder supports all DeepSeek V4 models and normalizes thinking", as
   }
 });
 
+test("API forwarder routes GLM coding-plan models with thinking enabled", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    ZAI_CODING_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    ZAI_API_KEY: "TEST_ZAI_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    for (const [gatewayModel, upstreamModel, sentEffort, expectedEffort] of [
+      ["zai-coding-glm-5-2", "glm-5.2", "xhigh", "max"],
+      ["zai-coding-glm-5-turbo", "glm-5-turbo", "low", undefined],
+    ]) {
+      const response = await fetch(
+        `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${INTERNAL_KEY}`,
+            "ChatGPT-Account-Id": "must-not-forward",
+            "X-Codex-Installation-Id": "must-not-forward",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: gatewayModel,
+            reasoning_effort: sentEffort,
+            temperature: 0.7,
+            top_p: 0.9,
+            messages: [{ role: "user", content: "test" }],
+          }),
+        },
+      );
+      assert.equal(response.status, 200);
+      const request = upstreamRequests.at(-1);
+      assert.equal(request.headers.authorization, "Bearer TEST_ZAI_API_KEY");
+      assert.equal(request.headers["chatgpt-account-id"], undefined);
+      assert.equal(request.headers["x-codex-installation-id"], undefined);
+      assert.equal(request.body.model, upstreamModel);
+      assert.deepEqual(request.body.thinking, { type: "enabled" });
+      assert.equal(request.body.reasoning_effort, expectedEffort);
+      assert.equal(request.body.temperature, undefined);
+      assert.equal(request.body.top_p, undefined);
+    }
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder routes Grok 4.5 with supported xAI reasoning effort", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
## What

Adds a credential-isolated `zai-coding` provider so GLM Coding Plan subscribers can use GLM models in the Codex picker:

- Provider uses the plan's dedicated OpenAI-compatible endpoint (`https://api.z.ai/api/coding/paas/v4`), overridable via `ZAI_CODING_BASE_URL`. Per Z.ai's docs the coding endpoint and the general `api/paas/v4` endpoint are not interchangeable; docs updated to say so.
- Listed models: **GLM-5.2** (1M context, 128K output) and **GLM-5-Turbo** (200k context), both `priority`-ordered after the existing catalog.
- New `glm-thinking` request profile in the shared API forwarder: enables `thinking: {type: enabled}`, maps Codex's maximum reasoning tier to Z.ai's documented `max` `reasoning_effort` (other tiers fall back to the upstream default rather than sending an undocumented value), and removes `temperature`/`top_p`, which Z.ai documents as fixed under thinking mode.
- Credential storage/enable/disable, catalog, LiteLLM route generation, guided setup listing, tray onboarding rows, and `bin/discover-models zai-coding` all come from the registry entry.

## Tests

- New forwarder integration test (mirrors the DeepSeek one): asserts upstream model rewrite (`zai-coding-glm-5-2` → `glm-5.2`), thinking normalization, effort mapping (`xhigh` → `max`, `low` → removed), sampling-param removal, provider key injection, and Codex identity-header stripping.
- Registry and provider-selection expectations extended.
- `npm run check`, full suite (120 tests, 0 fail), `npm audit --omit=dev` clean.

## Live validation status

Written from Z.ai's published API reference. I have a Coding Plan subscription and will run `bin/discover-models zai-coding` and `bin/test-model zai-coding/glm-5.2 --live --yes` (text, streaming, tools, compaction) and report results on this PR before it merges, per DEVELOPMENT.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)