### PR TITLE
fix: surface startup failure reason in service logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Service startup failures now include the underlying bounded, non-sensitive
+  error message (for example which health check timed out or which service
+  exited early) instead of a generic failure line.
+
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -211,9 +211,10 @@ async function main() {
 let exitCode = 0;
 try {
   exitCode = await main();
-} catch {
+} catch (error) {
   if (!shuttingDown) {
-    console.error("[model-router] startup failed; inspect the service logs above for details.");
+    const reason = (error instanceof Error && error.message) || String(error);
+    console.error(`[model-router] startup failed: ${reason}; inspect the service logs above for details.`);
     exitCode = 1;
   }
 } finally {

--- a/test/startup-cleanup.test.mjs
+++ b/test/startup-cleanup.test.mjs
@@ -74,6 +74,10 @@ test("startup failure terminates services that already became healthy", { timeou
     assert.equal(exit.signal, null);
     assert.equal(exit.code, 1, errors);
     assert.match(errors, /\[model-router\] startup failed/);
+    assert.match(
+      errors,
+      /startup failed: Service exited before becoming healthy at http:\/\/127\.0\.0\.1:\d+\/health\/liveliness/,
+    );
     assert.doesNotMatch(errors, /startup-internal-key-with-sufficient-length/);
     assert.doesNotMatch(errors, /startup-caller-key-with-sufficient-length/);
     for (const port of [oauthPort, apiPort, grokOauthPort]) {


### PR DESCRIPTION
## Summary

`src/start.mjs` caught startup errors with a bare `catch {}` and printed only a generic `[model-router] startup failed; inspect the service logs above for details.` line, discarding the actual error. During real debugging this hid which health wait failed.

This change binds the error and includes `error.message` in the failure line, e.g.:

```
[model-router] startup failed: Service exited before becoming healthy at http://127.0.0.1:PORT/health/liveliness; inspect the service logs above for details.
```

The surfaced messages come from `waitForHealth` and child-spawn failures, which are already bounded and non-sensitive (loopback URLs, no keys), consistent with the changelog's bounded, non-sensitive error policy.

## Changes

- `src/start.mjs`: bind the caught error and print its message in the startup-failure line.
- `test/startup-cleanup.test.mjs`: assert the underlying reason appears in stderr (written first, watched fail, then fixed). The existing assertions that secrets never appear in stderr now also cover the new message path.
- `CHANGELOG.md`: Unreleased entry.

## Testing

- `npm test`: 117 pass, 0 fail (2 conditional skips).
- `npm run check`: syntax checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)