### PR TITLE
Add Qwen provider for Alibaba Model Studio plans (Qwen3.7 Max/Plus)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ user.
 3. Never ask the user to paste OAuth tokens or API keys into chat, command
    arguments, logs, environment snippets, or tracked files.
 4. Determine which provider IDs the user requested: `anthropic-api`,
-   `kimi-oauth`, `kimi-api`, `deepseek`, and/or `grok-api`. If they did not specify and credentials already exist, use
+   `kimi-oauth`, `kimi-api`, `deepseek`, `grok-api`, and/or `qwen-plan`. If
+   they did not specify and credentials already exist, use
    `configured` rather than showing providers that cannot authenticate.
 5. For Kimi OAuth, reuse a valid `kimi login` session. If login is needed, run
    the official CLI only in an interactive terminal. For API providers, invoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   after each entry, challenges input that looks like the same key pasted
   twice before saving, and re-prompts instead of failing on empty input, so a
   paste with terminal echo disabled is no longer a silent leap of faith.
+- Added a Qwen provider (`qwen-plan`) for Alibaba Model Studio Token and
+  Coding Plan subscriptions with Qwen3.7 Max and Qwen3.7 Plus picker models,
+  defaulting to the Singapore Token Plan endpoint with an environment override
+  for other regions or plans.
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Linux installations support the Codex CLI and the Cursor target's local gateway.
 | Grok 4.5 (OAuth) | `grok-oauth/grok-4.5` | Official Grok CLI OAuth session |
 | Grok 4.5 (API) | `grok-api/grok-4.5` | Separately billed xAI API key |
 | Claude Opus 4.8 (API) | `anthropic-api/claude-opus-4.8` | Separately billed Anthropic API key |
+| Qwen3.7 Max (Plan) | `qwen-plan/qwen3.7-max` | Alibaba Model Studio plan API key |
+| Qwen3.7 Plus (Plan) | `qwen-plan/qwen3.7-plus` | Alibaba Model Studio plan API key |
 
 The Codex catalog is credential-aware. It includes models only from enabled
 external providers with a stored API key or valid OAuth session. Native GPT
@@ -102,6 +104,13 @@ ChatGPT OAuth provider in the router.
 Kimi Code OAuth and Kimi Platform API access are separate authentication and
 billing systems. The two Kimi entries intentionally coexist. Older DeepSeek
 aliases remain hidden compatibility routes and are not advertised to new users.
+
+
+The Qwen entries default to the Alibaba Model Studio Token Plan endpoint in
+the Singapore region. Coding Plan subscribers or other regions can point
+`QWEN_PLAN_BASE_URL` at their dashboard-issued base URL. Plan keys use the
+`sk-sp-` prefix and are separate from pay-as-you-go Model Studio keys; Alibaba
+reserves plan endpoints for interactive coding tools.
 
 Only enabled providers appear in an app's picker. Each target has its own
 selection and API-key files:

--- a/config/providers.json
+++ b/config/providers.json
@@ -16,10 +16,18 @@
       "baseUrl": "https://api.moonshot.cn/v1",
       "baseUrlEnv": "KIMI_API_BASE_URL",
       "credential": {
-        "environment": ["KIMI_API_KEY", "MOONSHOT_API_KEY"],
+        "environment": [
+          "KIMI_API_KEY",
+          "MOONSHOT_API_KEY"
+        ],
         "file": "kimi-api-key.secret",
-        "legacyFiles": ["api-key.secret"],
-        "keychainServices": ["codex-router-kimi-api", "kimi-codex-api"],
+        "legacyFiles": [
+          "api-key.secret"
+        ],
+        "keychainServices": [
+          "codex-router-kimi-api",
+          "kimi-codex-api"
+        ],
         "prompt": "Kimi Platform API key"
       }
     },
@@ -31,10 +39,14 @@
       "baseUrl": "https://api.deepseek.com",
       "baseUrlEnv": "DEEPSEEK_API_BASE_URL",
       "credential": {
-        "environment": ["DEEPSEEK_API_KEY"],
+        "environment": [
+          "DEEPSEEK_API_KEY"
+        ],
         "file": "deepseek-api-key.secret",
         "legacyFiles": [],
-        "keychainServices": ["codex-router-deepseek-api"],
+        "keychainServices": [
+          "codex-router-deepseek-api"
+        ],
         "prompt": "DeepSeek API key"
       }
     },
@@ -53,10 +65,15 @@
       "baseUrl": "https://api.x.ai/v1",
       "baseUrlEnv": "XAI_API_BASE_URL",
       "credential": {
-        "environment": ["XAI_API_KEY", "GROK_API_KEY"],
+        "environment": [
+          "XAI_API_KEY",
+          "GROK_API_KEY"
+        ],
         "file": "xai-api-key.secret",
         "legacyFiles": [],
-        "keychainServices": ["codex-router-xai-api"],
+        "keychainServices": [
+          "codex-router-xai-api"
+        ],
         "prompt": "xAI API key"
       }
     },
@@ -69,11 +86,35 @@
       "baseUrl": "https://api.anthropic.com/v1",
       "baseUrlEnv": "ANTHROPIC_API_BASE_URL",
       "credential": {
-        "environment": ["ANTHROPIC_API_KEY"],
+        "environment": [
+          "ANTHROPIC_API_KEY"
+        ],
         "file": "anthropic-api-key.secret",
         "legacyFiles": [],
-        "keychainServices": ["codex-router-anthropic-api"],
+        "keychainServices": [
+          "codex-router-anthropic-api"
+        ],
         "prompt": "Anthropic API key"
+      }
+    },
+    {
+      "id": "qwen-plan",
+      "displayName": "Qwen (Alibaba Plan)",
+      "kind": "openai-compatible",
+      "ownedBy": "alibaba",
+      "baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+      "baseUrlEnv": "QWEN_PLAN_BASE_URL",
+      "credential": {
+        "environment": [
+          "QWEN_PLAN_API_KEY",
+          "DASHSCOPE_API_KEY"
+        ],
+        "file": "qwen-plan-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-qwen-plan"
+        ],
+        "prompt": "Alibaba Model Studio plan API key"
       }
     }
   ],
@@ -89,11 +130,17 @@
       "priority": 2,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Always-on coding reasoning" }
+        {
+          "effort": "high",
+          "description": "Always-on coding reasoning"
+        }
       ],
       "contextWindow": 262144,
       "autoCompact": 235000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "kimi-oauth",
       "compHash": "kimi-oauth-kimi-for-coding-v1"
     },
@@ -108,11 +155,17 @@
       "priority": 3,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Always-on coding reasoning" }
+        {
+          "effort": "high",
+          "description": "Always-on coding reasoning"
+        }
       ],
       "contextWindow": 262144,
       "autoCompact": 235000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "kimi-oauth",
       "compHash": "kimi-oauth-kimi-for-coding-highspeed-v1"
     },
@@ -127,13 +180,25 @@
       "priority": 4,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "low", "description": "Faster reasoning" },
-        { "effort": "high", "description": "Balanced deep reasoning" },
-        { "effort": "max", "description": "Maximum reasoning depth" }
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Balanced deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning depth"
+        }
       ],
       "contextWindow": 262144,
       "autoCompact": 235000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "kimi-oauth",
       "compHash": "kimi-oauth-k3-v2"
     },
@@ -148,11 +213,17 @@
       "priority": 5,
       "defaultEffort": "max",
       "reasoningLevels": [
-        { "effort": "max", "description": "Maximum reasoning required by the Kimi K3 API" }
+        {
+          "effort": "max",
+          "description": "Maximum reasoning required by the Kimi K3 API"
+        }
       ],
       "contextWindow": 1048576,
       "autoCompact": 900000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "kimi-k3",
       "compHash": "kimi-api-k3-v2"
     },
@@ -167,12 +238,20 @@
       "priority": 6,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Deep reasoning" },
-        { "effort": "max", "description": "Maximum reasoning for complex agent work" }
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning for complex agent work"
+        }
       ],
       "contextWindow": 1048576,
       "autoCompact": 900000,
-      "inputModalities": ["text"],
+      "inputModalities": [
+        "text"
+      ],
       "requestProfile": "deepseek-thinking",
       "compHash": "deepseek-v4-flash-v1"
     },
@@ -187,12 +266,20 @@
       "priority": 7,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Deep reasoning" },
-        { "effort": "max", "description": "Maximum reasoning for complex agent work" }
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning for complex agent work"
+        }
       ],
       "contextWindow": 1048576,
       "autoCompact": 900000,
-      "inputModalities": ["text"],
+      "inputModalities": [
+        "text"
+      ],
       "requestProfile": "deepseek-thinking",
       "compHash": "deepseek-v4-pro-v1"
     },
@@ -223,13 +310,25 @@
       "priority": 1,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "low", "description": "Faster reasoning" },
-        { "effort": "medium", "description": "Balanced reasoning" },
-        { "effort": "high", "description": "Deep reasoning" }
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "medium",
+          "description": "Balanced reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        }
       ],
       "contextWindow": 500000,
       "autoCompact": 440000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "xai-reasoning",
       "compHash": "grok-oauth-grok-4-5-v1"
     },
@@ -244,13 +343,25 @@
       "priority": 8,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "low", "description": "Faster reasoning" },
-        { "effort": "medium", "description": "Balanced reasoning" },
-        { "effort": "high", "description": "Deep reasoning" }
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "medium",
+          "description": "Balanced reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        }
       ],
       "contextWindow": 500000,
       "autoCompact": 440000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "xai-reasoning",
       "compHash": "grok-api-grok-4-5-v1"
     },
@@ -265,13 +376,67 @@
       "priority": 9,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Adaptive deep reasoning for agentic work" }
+        {
+          "effort": "high",
+          "description": "Adaptive deep reasoning for agentic work"
+        }
       ],
       "contextWindow": 1048576,
       "autoCompact": 900000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "anthropic-reasoning",
       "compHash": "anthropic-api-claude-opus-4-8-v1"
+    },
+    {
+      "slug": "qwen-plan/qwen3.7-max",
+      "gatewayModel": "qwen-plan-qwen3-7-max",
+      "upstreamModel": "qwen3.7-max",
+      "provider": "qwen-plan",
+      "listed": true,
+      "displayName": "Qwen3.7 Max (Plan)",
+      "description": "Qwen3.7 Max through an Alibaba Model Studio Token or Coding Plan subscription for deep agentic coding.",
+      "priority": 12,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "high",
+          "description": "Adaptive deep reasoning"
+        }
+      ],
+      "contextWindow": 262144,
+      "autoCompact": 235000,
+      "inputModalities": [
+        "text"
+      ],
+      "requestProfile": "qwen-plan",
+      "compHash": "qwen-plan-qwen3-7-max-v1"
+    },
+    {
+      "slug": "qwen-plan/qwen3.7-plus",
+      "gatewayModel": "qwen-plan-qwen3-7-plus",
+      "upstreamModel": "qwen3.7-plus",
+      "provider": "qwen-plan",
+      "listed": true,
+      "displayName": "Qwen3.7 Plus (Plan)",
+      "description": "Qwen3.7 Plus through an Alibaba Model Studio Token or Coding Plan subscription; balanced speed and reasoning.",
+      "priority": 13,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "high",
+          "description": "Adaptive deep reasoning"
+        }
+      ],
+      "contextWindow": 262144,
+      "autoCompact": 235000,
+      "inputModalities": [
+        "text"
+      ],
+      "requestProfile": "qwen-plan",
+      "compHash": "qwen-plan-qwen3-7-plus-v1"
     }
   ]
 }

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -90,6 +90,8 @@ map, which restores native GPT routing.
 | Grok 4.5 OAuth | `grok-oauth/grok-4.5` | `grok-oauth-grok-4-5` | `grok-4.5` |
 | Grok 4.5 | `grok-api/grok-4.5` | `grok-api-grok-4-5` | `grok-4.5` |
 | Claude Opus 4.8 | `anthropic-api/claude-opus-4.8` | `anthropic-api-claude-opus-4-8` | `claude-opus-4-8` |
+| Qwen3.7 Max Plan | `qwen-plan/qwen3.7-max` | `qwen-plan-qwen3-7-max` | `qwen3.7-max` |
+| Qwen3.7 Plus Plan | `qwen-plan/qwen3.7-plus` | `qwen-plan-qwen3-7-plus` | `qwen3.7-plus` |
 
 The native catalog objects are preserved rather than reconstructed, which keeps
 current instructions and capability metadata from the installed Codex build.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -88,6 +88,7 @@ API-key providers use hidden prompts:
 ./bin/provider-key deepseek set
 ./bin/provider-key grok-api set
 ./bin/provider-key anthropic-api set
+./bin/provider-key qwen-plan set
 ```
 
 Grok OAuth uses the official Grok CLI session:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -84,7 +84,10 @@ Setting or rotating it takes effect on the next request; the background service
 does not need a restart.
 
 Confirm the key belongs to the named system. Kimi Code OAuth, Kimi Platform,
-DeepSeek, and Anthropic do not share credentials or billing.
+DeepSeek, Anthropic, and Alibaba Model Studio plans do not share credentials
+or billing. Alibaba plan keys (`sk-sp-` prefix) are separate from
+pay-as-you-go Model Studio keys and only work with the plan's dedicated base
+URL.
 
 ## A provider changed its model IDs
 

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -95,6 +95,17 @@ function normalizeBody(buffer, contentType, route) {
   } else if (model.requestProfile === "deepseek-nonthinking") {
     payload.thinking = { type: "disabled" };
     delete payload.reasoning_effort;
+  } else if (model.requestProfile === "qwen-plan") {
+    // DashScope's OpenAI-compatible mode does not document reasoning_effort;
+    // Qwen3.7 models reason adaptively by default, so drop the parameter
+    // rather than risk an invalid-parameter rejection.
+    delete payload.reasoning_effort;
+    // Qwen rejects forced tool choices in thinking mode
+    // ("tool_choice ... does not support being set to required or object");
+    // downgrade to auto so tool calls stay available.
+    if (payload.tool_choice !== undefined && payload.tool_choice !== "none") {
+      payload.tool_choice = "auto";
+    }
   } else if (model.requestProfile === "xai-reasoning") {
     if (!["low", "medium", "high"].includes(payload.reasoning_effort)) {
       payload.reasoning_effort = "high";

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -35,6 +35,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
       "grok-oauth",
       "grok-api",
       "anthropic-api",
+      "qwen-plan",
     ]);
     process.env.KIMI_API_KEY = "TEST_ENVIRONMENT_ONLY_KEY";
     assert.deepEqual(configuredProviderIds(), []);

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -23,9 +23,15 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "grok-oauth/grok-4.5",
       "grok-api/grok-4.5",
       "anthropic-api/claude-opus-4.8",
+      "qwen-plan/qwen3.7-max",
+      "qwen-plan/qwen3.7-plus",
     ],
   );
   assert.equal(PROVIDERS.get("deepseek").baseUrl, "https://api.deepseek.com");
+  assert.equal(
+    PROVIDERS.get("qwen-plan").baseUrl,
+    "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+  );
   assert.equal(PROVIDERS.get("grok-api").baseUrl, "https://api.x.ai/v1");
   assert.equal(PROVIDERS.get("grok-oauth").proxyBaseEnv, "GROK_OAUTH_FORWARD_BASE_URL");
   assert.equal(PROVIDERS.get("anthropic-api").protocol, "anthropic");

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -794,6 +794,61 @@ test("API forwarder supports all DeepSeek V4 models and normalizes thinking", as
   }
 });
 
+test("API forwarder routes Qwen plan models without unsupported parameters", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    QWEN_PLAN_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    QWEN_PLAN_API_KEY: "TEST_QWEN_PLAN_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    for (const [gatewayModel, upstreamModel] of [
+      ["qwen-plan-qwen3-7-max", "qwen3.7-max"],
+      ["qwen-plan-qwen3-7-plus", "qwen3.7-plus"],
+    ]) {
+      const response = await fetch(
+        `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${INTERNAL_KEY}`,
+            "ChatGPT-Account-Id": "must-not-forward",
+            "X-Codex-Installation-Id": "must-not-forward",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: gatewayModel,
+            reasoning_effort: "high",
+            tool_choice: "required",
+            messages: [{ role: "user", content: "test" }],
+          }),
+        },
+      );
+      assert.equal(response.status, 200);
+      const request = upstreamRequests.at(-1);
+      assert.equal(request.headers.authorization, "Bearer TEST_QWEN_PLAN_KEY");
+      assert.equal(request.headers["chatgpt-account-id"], undefined);
+      assert.equal(request.headers["x-codex-installation-id"], undefined);
+      assert.equal(request.body.model, upstreamModel);
+      assert.equal(request.body.reasoning_effort, undefined);
+      assert.equal(request.body.tool_choice, "auto");
+    }
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder routes Grok 4.5 with supported xAI reasoning effort", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
Standalone against main — no dependency on other open PRs. If another provider PR merges first, I'll rebase this one immediately to clear the trivial adjacent-line conflicts in the registry and docs.

## What

Adds a credential-isolated `qwen-plan` provider for Alibaba Model Studio **Token Plan** and **Coding Plan** subscriptions:

- Default base URL is the Token Plan endpoint (Singapore region), overridable via `QWEN_PLAN_BASE_URL` for other regions or the Coding Plan endpoint. Plan keys (`sk-sp-` prefix) are separate from pay-as-you-go Model Studio keys; docs note the interactive-tools-only ToS.
- Listed models: **Qwen3.7 Max** and **Qwen3.7 Plus** (256k contexts).
- `qwen-plan` request profile: drops `reasoning_effort` (undocumented on DashScope's OpenAI-compatible mode; Qwen3.7 reasons adaptively) and downgrades forced `tool_choice` (`required`/object) to `auto`, which Qwen's thinking mode rejects with `invalid_parameter_error`.

## Live validation (already run, real Token Plan subscription)

- `bin/discover-models qwen-plan`: both registered ids present on the plan endpoint, none unavailable.
- `bin/test-model --live --yes`: **qwen3.7-max 4/4, qwen3.7-plus 4/4** (text, streaming, tool calls, compaction). The tool-call phase is what motivated the `tool_choice` downgrade — it fails with a 400 without it.

Tests: forwarder integration test (model rewrite, parameter normalization incl. `tool_choice`, key injection, Codex identity-header stripping) plus registry/provider-selection expectations. Full suite green (120 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)