### PR TITLE
Add Ollama Cloud provider with curated coding models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,8 @@ user.
 3. Never ask the user to paste OAuth tokens or API keys into chat, command
    arguments, logs, environment snippets, or tracked files.
 4. Determine which provider IDs the user requested: `anthropic-api`,
-   `kimi-oauth`, `kimi-api`, `deepseek`, and/or `grok-api`. If they did not specify and credentials already exist, use
+   `kimi-oauth`, `kimi-api`, `deepseek`, `grok-api`, and/or `ollama-cloud`.
+   If they did not specify and credentials already exist, use
    `configured` rather than showing providers that cannot authenticate.
 5. For Kimi OAuth, reuse a valid `kimi login` session. If login is needed, run
    the official CLI only in an interactive terminal. For API providers, invoke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   after each entry, challenges input that looks like the same key pasted
   twice before saving, and re-prompts instead of failing on empty input, so a
   paste with terminal echo disabled is no longer a silent leap of faith.
+- Added an Ollama Cloud provider (`ollama-cloud`) with GLM-5.2, Kimi K2.7
+  Code, MiniMax M3, and DeepSeek V4 Pro picker models, using ollama.com's
+  OpenAI-compatible API with an account API key and context windows read from
+  Ollama's published model metadata.
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Linux installations support the Codex CLI and the Cursor target's local gateway.
 | Grok 4.5 (OAuth) | `grok-oauth/grok-4.5` | Official Grok CLI OAuth session |
 | Grok 4.5 (API) | `grok-api/grok-4.5` | Separately billed xAI API key |
 | Claude Opus 4.8 (API) | `anthropic-api/claude-opus-4.8` | Separately billed Anthropic API key |
+| GLM-5.2 (Ollama Cloud) | `ollama-cloud/glm-5.2` | Ollama Cloud API key |
+| Kimi K2.7 Code (Ollama Cloud) | `ollama-cloud/kimi-k2.7-code` | Ollama Cloud API key |
+| MiniMax M3 (Ollama Cloud) | `ollama-cloud/minimax-m3` | Ollama Cloud API key |
+| DeepSeek V4 Pro (Ollama Cloud) | `ollama-cloud/deepseek-v4-pro` | Ollama Cloud API key |
 
 The Codex catalog is credential-aware. It includes models only from enabled
 external providers with a stored API key or valid OAuth session. Native GPT
@@ -102,6 +106,13 @@ ChatGPT OAuth provider in the router.
 Kimi Code OAuth and Kimi Platform API access are separate authentication and
 billing systems. The two Kimi entries intentionally coexist. Older DeepSeek
 aliases remain hidden compatibility routes and are not advertised to new users.
+
+
+
+The Ollama Cloud entries bill through an ollama.com account and can host the
+same model families as other providers under separate quota. Matching entries
+(for example DeepSeek V4 Pro) intentionally coexist with the vendor-direct
+providers because credentials and billing differ.
 
 Only enabled providers appear in an app's picker. Each target has its own
 selection and API-key files:

--- a/config/providers.json
+++ b/config/providers.json
@@ -16,10 +16,18 @@
       "baseUrl": "https://api.moonshot.cn/v1",
       "baseUrlEnv": "KIMI_API_BASE_URL",
       "credential": {
-        "environment": ["KIMI_API_KEY", "MOONSHOT_API_KEY"],
+        "environment": [
+          "KIMI_API_KEY",
+          "MOONSHOT_API_KEY"
+        ],
         "file": "kimi-api-key.secret",
-        "legacyFiles": ["api-key.secret"],
-        "keychainServices": ["codex-router-kimi-api", "kimi-codex-api"],
+        "legacyFiles": [
+          "api-key.secret"
+        ],
+        "keychainServices": [
+          "codex-router-kimi-api",
+          "kimi-codex-api"
+        ],
         "prompt": "Kimi Platform API key"
       }
     },
@@ -31,10 +39,14 @@
       "baseUrl": "https://api.deepseek.com",
       "baseUrlEnv": "DEEPSEEK_API_BASE_URL",
       "credential": {
-        "environment": ["DEEPSEEK_API_KEY"],
+        "environment": [
+          "DEEPSEEK_API_KEY"
+        ],
         "file": "deepseek-api-key.secret",
         "legacyFiles": [],
-        "keychainServices": ["codex-router-deepseek-api"],
+        "keychainServices": [
+          "codex-router-deepseek-api"
+        ],
         "prompt": "DeepSeek API key"
       }
     },
@@ -53,10 +65,15 @@
       "baseUrl": "https://api.x.ai/v1",
       "baseUrlEnv": "XAI_API_BASE_URL",
       "credential": {
-        "environment": ["XAI_API_KEY", "GROK_API_KEY"],
+        "environment": [
+          "XAI_API_KEY",
+          "GROK_API_KEY"
+        ],
         "file": "xai-api-key.secret",
         "legacyFiles": [],
-        "keychainServices": ["codex-router-xai-api"],
+        "keychainServices": [
+          "codex-router-xai-api"
+        ],
         "prompt": "xAI API key"
       }
     },
@@ -69,11 +86,35 @@
       "baseUrl": "https://api.anthropic.com/v1",
       "baseUrlEnv": "ANTHROPIC_API_BASE_URL",
       "credential": {
-        "environment": ["ANTHROPIC_API_KEY"],
+        "environment": [
+          "ANTHROPIC_API_KEY"
+        ],
         "file": "anthropic-api-key.secret",
         "legacyFiles": [],
-        "keychainServices": ["codex-router-anthropic-api"],
+        "keychainServices": [
+          "codex-router-anthropic-api"
+        ],
         "prompt": "Anthropic API key"
+      }
+    },
+    {
+      "id": "ollama-cloud",
+      "displayName": "Ollama Cloud",
+      "kind": "openai-compatible",
+      "ownedBy": "ollama",
+      "baseUrl": "https://ollama.com/v1",
+      "baseUrlEnv": "OLLAMA_CLOUD_BASE_URL",
+      "credential": {
+        "environment": [
+          "OLLAMA_API_KEY",
+          "OLLAMA_CLOUD_API_KEY"
+        ],
+        "file": "ollama-cloud-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-ollama-cloud"
+        ],
+        "prompt": "Ollama Cloud API key"
       }
     }
   ],
@@ -89,11 +130,17 @@
       "priority": 2,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Always-on coding reasoning" }
+        {
+          "effort": "high",
+          "description": "Always-on coding reasoning"
+        }
       ],
       "contextWindow": 262144,
       "autoCompact": 235000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "kimi-oauth",
       "compHash": "kimi-oauth-kimi-for-coding-v1"
     },
@@ -108,11 +155,17 @@
       "priority": 3,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Always-on coding reasoning" }
+        {
+          "effort": "high",
+          "description": "Always-on coding reasoning"
+        }
       ],
       "contextWindow": 262144,
       "autoCompact": 235000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "kimi-oauth",
       "compHash": "kimi-oauth-kimi-for-coding-highspeed-v1"
     },
@@ -127,13 +180,25 @@
       "priority": 4,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "low", "description": "Faster reasoning" },
-        { "effort": "high", "description": "Balanced deep reasoning" },
-        { "effort": "max", "description": "Maximum reasoning depth" }
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Balanced deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning depth"
+        }
       ],
       "contextWindow": 262144,
       "autoCompact": 235000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "kimi-oauth",
       "compHash": "kimi-oauth-k3-v2"
     },
@@ -148,11 +213,17 @@
       "priority": 5,
       "defaultEffort": "max",
       "reasoningLevels": [
-        { "effort": "max", "description": "Maximum reasoning required by the Kimi K3 API" }
+        {
+          "effort": "max",
+          "description": "Maximum reasoning required by the Kimi K3 API"
+        }
       ],
       "contextWindow": 1048576,
       "autoCompact": 900000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "kimi-k3",
       "compHash": "kimi-api-k3-v2"
     },
@@ -167,12 +238,20 @@
       "priority": 6,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Deep reasoning" },
-        { "effort": "max", "description": "Maximum reasoning for complex agent work" }
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning for complex agent work"
+        }
       ],
       "contextWindow": 1048576,
       "autoCompact": 900000,
-      "inputModalities": ["text"],
+      "inputModalities": [
+        "text"
+      ],
       "requestProfile": "deepseek-thinking",
       "compHash": "deepseek-v4-flash-v1"
     },
@@ -187,12 +266,20 @@
       "priority": 7,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Deep reasoning" },
-        { "effort": "max", "description": "Maximum reasoning for complex agent work" }
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning for complex agent work"
+        }
       ],
       "contextWindow": 1048576,
       "autoCompact": 900000,
-      "inputModalities": ["text"],
+      "inputModalities": [
+        "text"
+      ],
       "requestProfile": "deepseek-thinking",
       "compHash": "deepseek-v4-pro-v1"
     },
@@ -223,13 +310,25 @@
       "priority": 1,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "low", "description": "Faster reasoning" },
-        { "effort": "medium", "description": "Balanced reasoning" },
-        { "effort": "high", "description": "Deep reasoning" }
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "medium",
+          "description": "Balanced reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        }
       ],
       "contextWindow": 500000,
       "autoCompact": 440000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "xai-reasoning",
       "compHash": "grok-oauth-grok-4-5-v1"
     },
@@ -244,13 +343,25 @@
       "priority": 8,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "low", "description": "Faster reasoning" },
-        { "effort": "medium", "description": "Balanced reasoning" },
-        { "effort": "high", "description": "Deep reasoning" }
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "medium",
+          "description": "Balanced reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        }
       ],
       "contextWindow": 500000,
       "autoCompact": 440000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "xai-reasoning",
       "compHash": "grok-api-grok-4-5-v1"
     },
@@ -265,13 +376,115 @@
       "priority": 9,
       "defaultEffort": "high",
       "reasoningLevels": [
-        { "effort": "high", "description": "Adaptive deep reasoning for agentic work" }
+        {
+          "effort": "high",
+          "description": "Adaptive deep reasoning for agentic work"
+        }
       ],
       "contextWindow": 1048576,
       "autoCompact": 900000,
-      "inputModalities": ["text", "image"],
+      "inputModalities": [
+        "text",
+        "image"
+      ],
       "requestProfile": "anthropic-reasoning",
       "compHash": "anthropic-api-claude-opus-4-8-v1"
+    },
+    {
+      "slug": "ollama-cloud/glm-5.2",
+      "gatewayModel": "ollama-cloud-glm-5-2",
+      "upstreamModel": "glm-5.2",
+      "provider": "ollama-cloud",
+      "listed": true,
+      "displayName": "GLM-5.2 (Ollama Cloud)",
+      "description": "GLM-5.2 hosted on Ollama Cloud with agentic coding and a 1M context window.",
+      "priority": 14,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "high",
+          "description": "Adaptive deep reasoning"
+        }
+      ],
+      "contextWindow": 1000000,
+      "autoCompact": 880000,
+      "inputModalities": [
+        "text"
+      ],
+      "requestProfile": "ollama-cloud",
+      "compHash": "ollama-cloud-glm-5-2-v1"
+    },
+    {
+      "slug": "ollama-cloud/kimi-k2.7-code",
+      "gatewayModel": "ollama-cloud-kimi-k2-7-code",
+      "upstreamModel": "kimi-k2.7-code",
+      "provider": "ollama-cloud",
+      "listed": true,
+      "displayName": "Kimi K2.7 Code (Ollama Cloud)",
+      "description": "Kimi K2.7 Code hosted on Ollama Cloud for coding agents with a 256k context window.",
+      "priority": 15,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "high",
+          "description": "Always-on coding reasoning"
+        }
+      ],
+      "contextWindow": 262144,
+      "autoCompact": 235000,
+      "inputModalities": [
+        "text"
+      ],
+      "requestProfile": "ollama-cloud",
+      "compHash": "ollama-cloud-kimi-k2-7-code-v1"
+    },
+    {
+      "slug": "ollama-cloud/minimax-m3",
+      "gatewayModel": "ollama-cloud-minimax-m3",
+      "upstreamModel": "minimax-m3",
+      "provider": "ollama-cloud",
+      "listed": true,
+      "displayName": "MiniMax M3 (Ollama Cloud)",
+      "description": "MiniMax M3 hosted on Ollama Cloud for coding with a 512k context window.",
+      "priority": 16,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "high",
+          "description": "Adaptive deep reasoning"
+        }
+      ],
+      "contextWindow": 524288,
+      "autoCompact": 470000,
+      "inputModalities": [
+        "text"
+      ],
+      "requestProfile": "ollama-cloud",
+      "compHash": "ollama-cloud-minimax-m3-v1"
+    },
+    {
+      "slug": "ollama-cloud/deepseek-v4-pro",
+      "gatewayModel": "ollama-cloud-deepseek-v4-pro",
+      "upstreamModel": "deepseek-v4-pro",
+      "provider": "ollama-cloud",
+      "listed": true,
+      "displayName": "DeepSeek V4 Pro (Ollama Cloud)",
+      "description": "DeepSeek V4 Pro hosted on Ollama Cloud with reasoning and a 512k context window.",
+      "priority": 17,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "high",
+          "description": "Adaptive deep reasoning"
+        }
+      ],
+      "contextWindow": 524288,
+      "autoCompact": 470000,
+      "inputModalities": [
+        "text"
+      ],
+      "requestProfile": "ollama-cloud",
+      "compHash": "ollama-cloud-deepseek-v4-pro-v1"
     }
   ]
 }

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -90,6 +90,10 @@ map, which restores native GPT routing.
 | Grok 4.5 OAuth | `grok-oauth/grok-4.5` | `grok-oauth-grok-4-5` | `grok-4.5` |
 | Grok 4.5 | `grok-api/grok-4.5` | `grok-api-grok-4-5` | `grok-4.5` |
 | Claude Opus 4.8 | `anthropic-api/claude-opus-4.8` | `anthropic-api-claude-opus-4-8` | `claude-opus-4-8` |
+| GLM-5.2 Ollama Cloud | `ollama-cloud/glm-5.2` | `ollama-cloud-glm-5-2` | `glm-5.2` |
+| Kimi K2.7 Code Ollama Cloud | `ollama-cloud/kimi-k2.7-code` | `ollama-cloud-kimi-k2-7-code` | `kimi-k2.7-code` |
+| MiniMax M3 Ollama Cloud | `ollama-cloud/minimax-m3` | `ollama-cloud-minimax-m3` | `minimax-m3` |
+| DeepSeek V4 Pro Ollama Cloud | `ollama-cloud/deepseek-v4-pro` | `ollama-cloud-deepseek-v4-pro` | `deepseek-v4-pro` |
 
 The native catalog objects are preserved rather than reconstructed, which keeps
 current instructions and capability metadata from the installed Codex build.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -88,6 +88,7 @@ API-key providers use hidden prompts:
 ./bin/provider-key deepseek set
 ./bin/provider-key grok-api set
 ./bin/provider-key anthropic-api set
+./bin/provider-key ollama-cloud set
 ```
 
 Grok OAuth uses the official Grok CLI session:

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -95,6 +95,10 @@ function normalizeBody(buffer, contentType, route) {
   } else if (model.requestProfile === "deepseek-nonthinking") {
     payload.thinking = { type: "disabled" };
     delete payload.reasoning_effort;
+  } else if (model.requestProfile === "ollama-cloud") {
+    // Ollama's OpenAI-compatible surface does not document reasoning_effort;
+    // hosted models reason by default, so drop the parameter.
+    delete payload.reasoning_effort;
   } else if (model.requestProfile === "xai-reasoning") {
     if (!["low", "medium", "high"].includes(payload.reasoning_effort)) {
       payload.reasoning_effort = "high";

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -35,6 +35,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
       "grok-oauth",
       "grok-api",
       "anthropic-api",
+      "ollama-cloud",
     ]);
     process.env.KIMI_API_KEY = "TEST_ENVIRONMENT_ONLY_KEY";
     assert.deepEqual(configuredProviderIds(), []);

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -23,9 +23,14 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "grok-oauth/grok-4.5",
       "grok-api/grok-4.5",
       "anthropic-api/claude-opus-4.8",
+      "ollama-cloud/glm-5.2",
+      "ollama-cloud/kimi-k2.7-code",
+      "ollama-cloud/minimax-m3",
+      "ollama-cloud/deepseek-v4-pro",
     ],
   );
   assert.equal(PROVIDERS.get("deepseek").baseUrl, "https://api.deepseek.com");
+  assert.equal(PROVIDERS.get("ollama-cloud").baseUrl, "https://ollama.com/v1");
   assert.equal(PROVIDERS.get("grok-api").baseUrl, "https://api.x.ai/v1");
   assert.equal(PROVIDERS.get("grok-oauth").proxyBaseEnv, "GROK_OAUTH_FORWARD_BASE_URL");
   assert.equal(PROVIDERS.get("anthropic-api").protocol, "anthropic");

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -794,6 +794,59 @@ test("API forwarder supports all DeepSeek V4 models and normalizes thinking", as
   }
 });
 
+test("API forwarder routes Ollama Cloud models without unsupported parameters", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    OLLAMA_CLOUD_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OLLAMA_API_KEY: "TEST_OLLAMA_CLOUD_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    for (const [gatewayModel, upstreamModel] of [
+      ["ollama-cloud-glm-5-2", "glm-5.2"],
+      ["ollama-cloud-kimi-k2-7-code", "kimi-k2.7-code"],
+    ]) {
+      const response = await fetch(
+        `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${INTERNAL_KEY}`,
+            "ChatGPT-Account-Id": "must-not-forward",
+            "X-Codex-Installation-Id": "must-not-forward",
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: gatewayModel,
+            reasoning_effort: "high",
+            messages: [{ role: "user", content: "test" }],
+          }),
+        },
+      );
+      assert.equal(response.status, 200);
+      const request = upstreamRequests.at(-1);
+      assert.equal(request.headers.authorization, "Bearer TEST_OLLAMA_CLOUD_KEY");
+      assert.equal(request.headers["chatgpt-account-id"], undefined);
+      assert.equal(request.headers["x-codex-installation-id"], undefined);
+      assert.equal(request.body.model, upstreamModel);
+      assert.equal(request.body.reasoning_effort, undefined);
+    }
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder routes Grok 4.5 with supported xAI reasoning effort", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
Standalone against main — no dependency on other open PRs. If another provider PR merges first, I'll rebase this one immediately to clear the trivial adjacent-line conflicts in the registry and docs.

## What

Adds a credential-isolated `ollama-cloud` provider using ollama.com's OpenAI-compatible API (`https://ollama.com/v1`) with an account API key (`OLLAMA_API_KEY`):

- Curated coding-focused picker models: **GLM-5.2**, **Kimi K2.7 Code**, **MiniMax M3**, **DeepSeek V4 Pro**.
- Model IDs verified against the live `/v1/models` endpoint; context windows (1M / 256k / 512k / 512k) read from Ollama's published `/api/show` model metadata rather than guessed.
- `ollama-cloud` request profile drops `reasoning_effort` (undocumented on Ollama's OpenAI-compatible surface; hosted models reason by default).
- Overlapping model families (e.g. DeepSeek V4 Pro) intentionally coexist with vendor-direct providers — separate credentials, billing, and quota; README explains this.

## Live validation (already run, real Ollama Cloud account)

- `bin/discover-models ollama-cloud`: 18 models discovered, all four registered ids present.
- `bin/test-model --live --yes`: **all four models 4/4** (text, streaming, tool calls, compaction), first attempt.

Tests: forwarder integration test plus registry/provider-selection expectations. Full suite green (120 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)