### PR TITLE
Stepped guided setup with toggleable provider list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
   after each entry, challenges input that looks like the same key pasted
   twice before saving, and re-prompts instead of failing on empty input, so a
   paste with terminal echo disabled is no longer a silent leap of faith.
+- Rebuilt the guided setup as a stepped wizard: numbered progress headers, a
+  toggleable provider list with live ready/needs-key/needs-sign-in status,
+  `a`/`n` select-all/none shortcuts, invalid-input recovery instead of
+  aborting, color when the terminal supports it (respecting `NO_COLOR`), and a
+  review summary with explicit confirmation before anything is installed.
+- Guided Codex setup can now onboard Grok OAuth (and offers to `npm install`
+  a missing official provider CLI), matching what the Cursor setup and tray
+  already supported.
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -72,6 +72,12 @@ Set-Location codex-router
 ./install.ps1 -Guided
 ```
 
+Guided setup walks through numbered steps: a provider list you toggle by
+number (`a` selects all, `n` clears, Enter continues) with a live
+ready/needs-key/needs-sign-in status per provider, credential onboarding for
+anything you selected that is not connected yet, and a review summary before
+any change is made.
+
 ## Authentication choices
 
 Kimi Code OAuth reuses the official CLI session. Guided setup offers to run the

--- a/src/setup-shared.mjs
+++ b/src/setup-shared.mjs
@@ -15,7 +15,9 @@ import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
+import { providerOnboardingSnapshot } from "./provider-onboarding.mjs";
 import { configuredProviderIds, validateProviderIds } from "./provider-selection.mjs";
+import { renderProviderChoices, toggleSelection } from "./setup-ui.mjs";
 
 // Target-agnostic setup helpers shared by every target's <target>-setup.mjs.
 // Only the app name, the provider-key command hint, and the install/doctor
@@ -166,27 +168,32 @@ function tryRun(command, commandArgs) {
 
 function guidedSelection(appName) {
   const providers = [...PROVIDERS.values()];
-  process.stdout.write(`\nChoose the providers to show in ${appName}:\n`);
-  providers.forEach((provider, index) => {
-    process.stdout.write(
-      `  ${index + 1}. ${provider.displayName} ${
-        providerConfigured(provider) ? "(ready)" : "(setup required)"
-      }\n`,
-    );
-  });
-  process.stdout.write(
-    "\nOAuth entries reuse official Kimi or Grok CLI sessions; API entries use a provider key.\n",
+  const snapshots = providerOnboardingSnapshot().providers;
+  const colorEnabled = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+  let selected = new Set(
+    snapshots
+      .map((snapshot, index) => (snapshot.action === "ready" ? index + 1 : undefined))
+      .filter(Boolean),
   );
-  const readyIndexes = providers
-    .map((provider, index) => (providerConfigured(provider) ? String(index + 1) : undefined))
-    .filter(Boolean)
-    .join(",");
-  const raw = promptLine("Enter numbers separated by commas", readyIndexes || "1");
-  const selected = raw.split(",").map((value) => Number(value.trim()));
-  if (selected.some((value) => !Number.isInteger(value) || value < 1 || value > providers.length)) {
-    throw new Error("Provider selection contains an invalid number.");
+  if (selected.size === 0) selected = new Set([1]);
+  process.stdout.write(`\nChoose the providers to show in ${appName}:\n`);
+  process.stdout.write(
+    "OAuth entries reuse official Kimi or Grok CLI sessions; API entries use a provider key.\n",
+  );
+  for (;;) {
+    process.stdout.write(`${renderProviderChoices(snapshots, selected, colorEnabled)}\n`);
+    const raw = promptLine("Toggle numbers (comma-separated), a=all, n=none; Enter to continue");
+    const result = toggleSelection(selected, raw, snapshots.length);
+    selected = result.selected;
+    if (result.error) {
+      process.stdout.write(`${result.error}\n`);
+    } else if (result.done) {
+      break;
+    }
   }
-  return validateProviderIds(selected.map((value) => providers[value - 1].id));
+  return validateProviderIds(
+    [...selected].sort((a, b) => a - b).map((position) => providers[position - 1].id),
+  );
 }
 
 // Resolve which provider ids to enable from --providers, or interactively.

--- a/src/setup-ui.mjs
+++ b/src/setup-ui.mjs
@@ -1,0 +1,78 @@
+// Pure helpers for the guided-setup terminal UI. Rendering and selection
+// state carry no terminal I/O so both target setups share them and unit
+// tests can cover every interaction without a PTY.
+
+const ACTION_LABELS = Object.freeze({
+  ready: "ready",
+  "add-key": "needs API key",
+  login: "needs CLI sign-in",
+  install: "needs CLI install",
+});
+
+const COLOR_CODES = Object.freeze({
+  green: "32",
+  yellow: "33",
+  red: "31",
+  cyan: "36",
+});
+
+export function stepHeader(step, total, title) {
+  return `\n--- Step ${step} of ${total}: ${title} ---\n`;
+}
+
+export function providerStatusLabel(snapshot) {
+  return ACTION_LABELS[snapshot.action] || "setup required";
+}
+
+export function colorize(text, color, enabled) {
+  const code = COLOR_CODES[color];
+  if (!enabled || !code) return text;
+  return `\u001b[${code}m${text}\u001b[0m`;
+}
+
+export function renderProviderChoices(snapshots, selected, colorEnabled = false) {
+  return snapshots
+    .map((snapshot, index) => {
+      const position = index + 1;
+      const mark = selected.has(position) ? "[x]" : "[ ]";
+      const label = providerStatusLabel(snapshot);
+      const colored = colorize(
+        label,
+        snapshot.action === "ready" ? "green" : "yellow",
+        colorEnabled,
+      );
+      return `  ${mark} ${position}. ${snapshot.displayName} — ${colored}`;
+    })
+    .join("\n");
+}
+
+export function toggleSelection(selected, input, count) {
+  const trimmed = String(input || "").trim().toLowerCase();
+  if (trimmed === "") {
+    if (selected.size === 0) {
+      return { selected, error: "Select at least one provider." };
+    }
+    return { selected, done: true };
+  }
+  if (trimmed === "a" || trimmed === "all") {
+    const all = new Set();
+    for (let position = 1; position <= count; position += 1) all.add(position);
+    return { selected: all };
+  }
+  if (trimmed === "n" || trimmed === "none") {
+    return { selected: new Set() };
+  }
+  const next = new Set(selected);
+  for (const part of trimmed.split(",")) {
+    const value = Number(part.trim());
+    if (!Number.isInteger(value) || value < 1 || value > count) {
+      return { selected, error: `Invalid choice: ${part.trim()}` };
+    }
+    if (next.has(value)) {
+      next.delete(value);
+    } else {
+      next.add(value);
+    }
+  }
+  return { selected: next };
+}

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -3,10 +3,18 @@ import { closeSync, openSync, readSync, writeSync } from "node:fs";
 import path from "node:path";
 
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
+import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
+import {
+  installOauthCli,
+  oauthCliPath,
+  oauthLoginArgs,
+  providerOnboardingSnapshot,
+} from "./provider-onboarding.mjs";
+import { renderProviderChoices, stepHeader, toggleSelection } from "./setup-ui.mjs";
 import {
   configuredProviderIds,
   validateProviderIds,
@@ -117,29 +125,40 @@ function confirm(label, defaultYes = true) {
 }
 
 function providerConfigured(provider) {
-  return provider.kind === "oauth"
-    ? provider.id === "kimi-oauth" && kimiOAuthStatus().configured
-    : credentialStatus(provider, { persistent: true }).configured;
+  if (provider.kind === "oauth") {
+    if (provider.id === "kimi-oauth") return kimiOAuthStatus().configured;
+    if (provider.id === "grok-oauth") return grokOAuthStatus().configured;
+    return false;
+  }
+  return credentialStatus(provider, { persistent: true }).configured;
 }
+
+const colorEnabled = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
 
 function guidedSelection() {
   const providers = [...PROVIDERS.values()];
+  const snapshots = providerOnboardingSnapshot().providers;
+  let selected = new Set(
+    snapshots
+      .map((snapshot, index) => (snapshot.action === "ready" ? index + 1 : undefined))
+      .filter(Boolean),
+  );
+  if (selected.size === 0) selected = new Set([1]);
   process.stdout.write("\nChoose the providers to show in Codex:\n");
-  providers.forEach((provider, index) => {
-    process.stdout.write(
-      `  ${index + 1}. ${provider.displayName} ${providerConfigured(provider) ? "(ready)" : "(setup required)"}\n`,
-    );
-  });
-  const readyIndexes = providers
-    .map((provider, index) => (providerConfigured(provider) ? String(index + 1) : undefined))
-    .filter(Boolean)
-    .join(",");
-  const raw = promptLine("Enter numbers separated by commas", readyIndexes || "1");
-  const selected = raw.split(",").map((value) => Number(value.trim()));
-  if (selected.some((value) => !Number.isInteger(value) || value < 1 || value > providers.length)) {
-    throw new Error("Provider selection contains an invalid number.");
+  for (;;) {
+    process.stdout.write(`${renderProviderChoices(snapshots, selected, colorEnabled)}\n`);
+    const raw = promptLine("Toggle numbers (comma-separated), a=all, n=none; Enter to continue");
+    const result = toggleSelection(selected, raw, snapshots.length);
+    selected = result.selected;
+    if (result.error) {
+      process.stdout.write(`${result.error}\n`);
+    } else if (result.done) {
+      break;
+    }
   }
-  return validateProviderIds(selected.map((value) => providers[value - 1].id));
+  return validateProviderIds(
+    [...selected].sort((a, b) => a - b).map((position) => providers[position - 1].id),
+  );
 }
 
 function requestedSelection() {
@@ -150,17 +169,6 @@ function requestedSelection() {
     return validateProviderIds(requested.split(","));
   }
   return guided ? guidedSelection() : configuredProviderIds();
-}
-
-function executable(name) {
-  const finder = process.platform === "win32" ? "where.exe" : "which";
-  try {
-    return execFileSync(finder, [name], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] })
-      .trim()
-      .split(/\r?\n/)[0];
-  } catch {
-    return undefined;
-  }
 }
 
 function run(command, commandArgs, options = {}) {
@@ -181,20 +189,28 @@ function configureProvider(provider) {
   if (!guided) {
     const setup =
       provider.kind === "oauth"
-        ? "run `kimi login`"
+        ? "sign in with the provider's official CLI"
         : `run \`./bin/provider-key ${provider.id} set\``;
     throw new Error(`${provider.displayName} is selected but not configured; ${setup} first.`);
   }
   if (provider.kind === "oauth") {
-    const kimi = executable("kimi");
-    if (!kimi) {
-      throw new Error(
-        "Kimi Code CLI is required for OAuth. Install it from https://www.kimi.com/help/kimi-code/cli-getting-started, then run setup again.",
-      );
+    let cli = oauthCliPath(provider.id);
+    if (!cli) {
+      if (!confirm(`Install the official ${provider.displayName} CLI with npm now?`)) {
+        throw new Error(
+          `${provider.displayName} needs its official CLI; install it and run setup again.`,
+        );
+      }
+      installOauthCli(provider.id);
+      cli = oauthCliPath(provider.id);
     }
-    if (!confirm("Run `kimi login` now?")) throw new Error("Kimi OAuth setup was cancelled.");
-    run(kimi, ["login"]);
-    if (!kimiOAuthStatus().configured) throw new Error("Kimi OAuth login did not produce a usable credential.");
+    if (!confirm(`Sign in to ${provider.displayName} now?`)) {
+      throw new Error(`${provider.displayName} sign-in was cancelled.`);
+    }
+    run(cli, oauthLoginArgs(provider.id));
+    if (!providerConfigured(provider)) {
+      throw new Error(`${provider.displayName} sign-in did not produce a usable credential.`);
+    }
   } else {
     if (!confirm(`Enter a ${provider.displayName} key securely now?`)) {
       throw new Error(`${provider.displayName} setup was cancelled.`);
@@ -211,17 +227,29 @@ async function main() {
       `An unknown model router owns ${legacy.config.modelCatalogJson}; automatic setup will not replace it.`,
     );
   }
+  const stepTitles = ["Choose providers", "Connect credentials"];
+  if (legacy.installations.length) stepTitles.push("Migrate older router");
+  stepTitles.push("Review and install");
+  let stepIndex = 0;
+  const nextStep = (title) => {
+    stepIndex += 1;
+    if (guided) process.stdout.write(stepHeader(stepIndex, stepTitles.length, title));
+  };
+
+  nextStep("Choose providers");
   const providers = requestedSelection();
   if (providers.length === 0) {
     throw new Error(
       "No configured provider was found. Run `./bin/setup --guided` or pass `--providers` after configuring credentials.",
     );
   }
+  nextStep("Connect credentials");
   for (const id of providers) configureProvider(PROVIDERS.get(id));
   writeProviderSelection(providers);
 
   let migration;
   if (legacy.installations.length) {
+    nextStep("Migrate older router");
     const approved = migrateKnown || (guided && confirm(
       `Safely migrate ${legacy.installations.map((item) => item.id).join(", ")} and keep a rollback snapshot?`,
     ));
@@ -234,6 +262,19 @@ async function main() {
   if (selectionOnly) {
     process.stdout.write(`${JSON.stringify({ providers, migration }, null, 2)}\n`);
     return;
+  }
+
+  nextStep("Review and install");
+  if (guided) {
+    process.stdout.write(
+      `\nReady to install:\n` +
+        `  Providers: ${providers.join(", ")}\n` +
+        `  Migration: ${migration ? "recognized older router (rollback snapshot kept)" : "none needed"}\n` +
+        `  Changes: per-user background service and the managed Codex config block\n`,
+    );
+    if (!confirm("Proceed?")) {
+      throw new Error("Setup was cancelled before installing the service.");
+    }
   }
 
   try {

--- a/test/setup-ui.test.mjs
+++ b/test/setup-ui.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  colorize,
+  providerStatusLabel,
+  renderProviderChoices,
+  stepHeader,
+  toggleSelection,
+} from "../src/setup-ui.mjs";
+
+const SNAPSHOTS = [
+  { id: "kimi-oauth", displayName: "Kimi Code OAuth", kind: "oauth", action: "ready" },
+  { id: "deepseek", displayName: "DeepSeek API", kind: "api", action: "add-key" },
+  { id: "grok-oauth", displayName: "xAI Grok OAuth", kind: "oauth", action: "install" },
+];
+
+test("stepHeader shows position and title", () => {
+  assert.equal(stepHeader(2, 5, "Choose providers"), "\n--- Step 2 of 5: Choose providers ---\n");
+});
+
+test("providerStatusLabel maps onboarding actions to friendly text", () => {
+  assert.equal(providerStatusLabel({ action: "ready" }), "ready");
+  assert.equal(providerStatusLabel({ action: "add-key" }), "needs API key");
+  assert.equal(providerStatusLabel({ action: "login" }), "needs CLI sign-in");
+  assert.equal(providerStatusLabel({ action: "install" }), "needs CLI install");
+  assert.equal(providerStatusLabel({ action: "mystery" }), "setup required");
+});
+
+test("renderProviderChoices marks selected rows and shows status", () => {
+  const rendered = renderProviderChoices(SNAPSHOTS, new Set([1, 3]));
+  const lines = rendered.split("\n");
+  assert.equal(lines[0], "  [x] 1. Kimi Code OAuth — ready");
+  assert.equal(lines[1], "  [ ] 2. DeepSeek API — needs API key");
+  assert.equal(lines[2], "  [x] 3. xAI Grok OAuth — needs CLI install");
+});
+
+test("toggleSelection toggles numbers on and off", () => {
+  let state = toggleSelection(new Set(), "1,3", 3);
+  assert.deepEqual([...state.selected].sort(), [1, 3]);
+  assert.equal(state.done, undefined);
+  state = toggleSelection(state.selected, "3", 3);
+  assert.deepEqual([...state.selected], [1]);
+});
+
+test("toggleSelection supports all and none shortcuts", () => {
+  const all = toggleSelection(new Set([2]), "a", 3);
+  assert.deepEqual([...all.selected].sort(), [1, 2, 3]);
+  const none = toggleSelection(all.selected, "n", 3);
+  assert.deepEqual([...none.selected], []);
+});
+
+test("toggleSelection finishes on empty input with a non-empty selection", () => {
+  const state = toggleSelection(new Set([2]), "", 3);
+  assert.equal(state.done, true);
+  assert.deepEqual([...state.selected], [2]);
+});
+
+test("toggleSelection refuses to finish with nothing selected", () => {
+  const state = toggleSelection(new Set(), "", 3);
+  assert.equal(state.done, undefined);
+  assert.ok(state.error.includes("at least one"));
+});
+
+test("toggleSelection reports invalid input without changing the selection", () => {
+  const state = toggleSelection(new Set([1]), "0,nope", 3);
+  assert.ok(state.error);
+  assert.deepEqual([...state.selected], [1]);
+});
+
+test("colorize wraps only when enabled", () => {
+  assert.equal(colorize("ready", "green", false), "ready");
+  assert.equal(colorize("ready", "green", true), "\u001b[32mready\u001b[0m");
+  assert.equal(colorize("ready", "unknown-color", true), "ready");
+});


### PR DESCRIPTION
Independent of the provider PRs — based directly on main.

## What

Rebuilds the guided setup as a numbered wizard while keeping the zero-dependency, line-oriented design (no readline/prompt libraries, same /dev/tty + PowerShell paths):

- **Step headers**: `--- Step 1 of 3: Choose providers ---` so users know where they are.
- **Toggleable provider list**: re-rendered checkbox rows driven by `providerOnboardingSnapshot()`, showing per-provider status (`ready` / `needs API key` / `needs CLI sign-in` / `needs CLI install`), with `a`/`n` select-all/none shortcuts. Invalid input reports and re-prompts instead of aborting the whole setup.
- **Review summary**: guided installs now show providers + migration plan + what will change, with explicit confirmation before the service or Codex config is touched.
- **Color** only on capable terminals, honoring `NO_COLOR`.
- **Bug fix**: Codex guided setup hardcoded Kimi as the only OAuth flow, so `grok-oauth` could never onboard through it (`providerConfigured` returned false and `configureProvider` demanded the Kimi CLI). It now uses the shared onboarding helpers — including offering `npm install -g` for a missing official CLI — matching the Cursor setup and tray behavior.

Rendering and selection-state logic live in a new pure `src/setup-ui.mjs` shared by both target setups, with unit tests covering every interaction (toggle, all/none, finish-guard, invalid input, color gating).

## Verification

- `npm run check`, full suite green (128 tests, 0 fail).
- Interactive flow exercised in a real PTY (`expect`) against isolated state: preselection of ready providers, toggling on/off, invalid-input recovery, step transitions, and the `--selection-only` JSON output matching the toggled selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)