### PR TITLE
Offer the desktop companion app during guided setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
   after each entry, challenges input that looks like the same key pasted
   twice before saving, and re-prompts instead of failing on empty input, so a
   paste with terminal echo disabled is no longer a silent leap of faith.
+- Guided setup now offers to build and launch the desktop companion app as a
+  final step on macOS (menu bar, installed into `~/Applications`) and Linux
+  (tray), with `--with-tray`/`--no-tray` overrides on `install.sh` and
+  `bin/setup`. A missing toolchain or failed build warns and continues; it
+  never fails the router install.
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -72,6 +72,13 @@ Set-Location codex-router
 ./install.ps1 -Guided
 ```
 
+On macOS and Linux, guided setup also offers to build and launch the desktop
+companion (the macOS menu bar app or the Windows/Linux tray). `--with-tray`
+installs it without asking, `--no-tray` never offers it, and automatic mode
+skips it. On macOS the app bundle is placed in `~/Applications` and needs the
+Swift toolchain; a missing toolchain skips the step with guidance instead of
+failing setup. Windows still builds the tray manually with
+`scripts/build-desktop-tray.ps1`.
 ## Authentication choices
 
 Kimi Code OAuth reuses the official CLI session. Guided setup offers to run the

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,8 @@ guided=auto
 providers=
 migrate_known=false
 smoke_test=false
+with_tray=false
+no_tray=false
 previous_revision=
 target=codex
 
@@ -33,6 +35,8 @@ Options:
   --providers LIST   Enable comma-separated provider ids (or "configured")
   --migrate-known    Snapshot and replace recognized earlier router installs
   --smoke-test       Make one small billed request per enabled provider
+  --with-tray        Also build and launch the desktop companion app
+  --no-tray          Never offer the desktop companion app
   -h, --help          Show this help
 
 When run from a checkout, this script installs that checkout. When piped from
@@ -94,6 +98,14 @@ while [ "$#" -gt 0 ]; do
       providers=$2
       guided=false
       shift 2
+      ;;
+    --with-tray)
+      with_tray=true
+      shift
+      ;;
+    --no-tray)
+      no_tray=true
+      shift
       ;;
     --migrate-known)
       migrate_known=true
@@ -195,6 +207,8 @@ if [ "$guided" = true ]; then set -- "$@" --guided; fi
 if [ -n "$providers" ]; then set -- "$@" --providers "$providers"; fi
 if [ "$migrate_known" = true ]; then set -- "$@" --migrate-known; fi
 if [ "$smoke_test" = true ]; then set -- "$@" --smoke-test; fi
+if [ "$with_tray" = true ]; then set -- "$@" --with-tray; fi
+if [ "$no_tray" = true ]; then set -- "$@" --no-tray; fi
 if ! "$repo_dir/bin/setup" "$@"; then
   if [ -n "$previous_revision" ]; then
     git -C "$repo_dir" switch --detach "$previous_revision" >/dev/null 2>&1 || true

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { closeSync, openSync, readSync, writeSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
@@ -12,12 +13,15 @@ import {
   validateProviderIds,
   writeProviderSelection,
 } from "./provider-selection.mjs";
+import { trayBundleDir, trayDecision } from "./tray-install.mjs";
 
 const args = process.argv.slice(2);
 const guided = args.includes("--guided");
 const migrateKnown = args.includes("--migrate-known");
 const runSmoke = args.includes("--smoke-test");
 const selectionOnly = args.includes("--selection-only");
+const withTray = args.includes("--with-tray");
+const noTray = args.includes("--no-tray");
 
 const flagOptions = new Set([
   "--guided",
@@ -25,6 +29,8 @@ const flagOptions = new Set([
   "--migrate-known",
   "--smoke-test",
   "--selection-only",
+  "--with-tray",
+  "--no-tray",
   "--help",
 ]);
 let setupArgumentError;
@@ -59,6 +65,8 @@ Options:
   --migrate-known      Safely migrate recognized earlier Codex Router installs
   --smoke-test         Make one small live request per enabled provider
   --selection-only     Save provider selection without installing (development)
+  --with-tray          Also build and launch the desktop companion app
+  --no-tray            Never offer the desktop companion app
   --help               Show this help
 
 Providers: ${[...PROVIDERS.keys()].join(", ")}
@@ -203,6 +211,38 @@ function configureProvider(provider) {
   }
 }
 
+// Best-effort: the router install has already succeeded, so a companion-app
+// build failure warns and continues instead of failing the whole setup.
+function installTray() {
+  try {
+    if (process.platform === "darwin") {
+      try {
+        execFileSync("xcrun", ["--find", "swift"], { stdio: "ignore" });
+      } catch {
+        process.stdout.write(
+          "The Swift toolchain is missing; run `xcode-select --install`, then `./bin/model-router-tray` to add the companion later.\n",
+        );
+        return;
+      }
+      const bundleDir = trayBundleDir("darwin", os.homedir());
+      run(path.join(SOURCE_ROOT, "scripts", "build-macos-tray-app.sh"), [bundleDir]);
+      run("open", [bundleDir]);
+      process.stdout.write(`Menu-bar companion installed at ${bundleDir} and opened.\n`);
+    } else {
+      run(path.join(SOURCE_ROOT, "bin", "model-router-tray"), []);
+      process.stdout.write("Desktop companion built and launched.\n");
+    }
+  } catch (error) {
+    process.stdout.write(
+      `Desktop companion install did not finish: ${error instanceof Error ? error.message : String(error)}\n` +
+        (process.platform === "darwin"
+          ? "Recent macOS SDKs need the full Xcode app (not only the Command Line Tools) to build the menu-bar companion's SwiftUI macros.\n"
+          : "") +
+        "The router itself is installed; retry later with ./bin/model-router-tray.\n",
+    );
+  }
+}
+
 async function main() {
   if (setupArgumentError) throw new Error(setupArgumentError);
   const legacy = detectLegacyInstallations();
@@ -252,6 +292,14 @@ async function main() {
   } catch (error) {
     if (migration?.migrated) rollbackLatestMigration();
     throw error;
+  }
+
+  const trayStep = trayDecision({ platform: process.platform, withTray, noTray, guided });
+  if (trayStep !== "skip") {
+    const wanted =
+      trayStep === "install" ||
+      confirm("Install the desktop companion app (menu-bar usage meters and provider switcher)?");
+    if (wanted) installTray();
   }
 
   if (runSmoke || (guided && confirm("Run one small live request per enabled provider?", false))) {

--- a/src/tray-install.mjs
+++ b/src/tray-install.mjs
@@ -1,0 +1,17 @@
+import path from "node:path";
+
+// Pure decision helpers for offering the desktop/menu-bar companion during
+// guided setup. Kept free of process state so the flag/platform matrix is
+// unit-testable; setup.mjs owns the actual build and launch.
+
+export function trayDecision({ platform, withTray, noTray, guided }) {
+  if (noTray) return "skip";
+  if (platform !== "darwin" && platform !== "linux") return "skip";
+  if (withTray) return "install";
+  return guided ? "ask" : "skip";
+}
+
+export function trayBundleDir(platform, home) {
+  if (platform !== "darwin") return undefined;
+  return path.join(home, "Applications", "Model Router.app");
+}

--- a/test/tray-install.test.mjs
+++ b/test/tray-install.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { trayBundleDir, trayDecision } from "../src/tray-install.mjs";
+
+test("trayDecision skips when --no-tray is passed", () => {
+  assert.equal(
+    trayDecision({ platform: "darwin", withTray: true, noTray: true, guided: true }),
+    "skip",
+  );
+});
+
+test("trayDecision skips on Windows where no launcher exists yet", () => {
+  assert.equal(
+    trayDecision({ platform: "win32", withTray: true, noTray: false, guided: true }),
+    "skip",
+  );
+});
+
+test("trayDecision installs without asking when --with-tray is passed", () => {
+  assert.equal(
+    trayDecision({ platform: "darwin", withTray: true, noTray: false, guided: false }),
+    "install",
+  );
+  assert.equal(
+    trayDecision({ platform: "linux", withTray: true, noTray: false, guided: true }),
+    "install",
+  );
+});
+
+test("trayDecision asks during guided setup", () => {
+  assert.equal(
+    trayDecision({ platform: "darwin", withTray: false, noTray: false, guided: true }),
+    "ask",
+  );
+});
+
+test("trayDecision skips silently in automatic mode", () => {
+  assert.equal(
+    trayDecision({ platform: "darwin", withTray: false, noTray: false, guided: false }),
+    "skip",
+  );
+});
+
+test("trayBundleDir places the macOS bundle in the user's Applications folder", () => {
+  assert.equal(
+    trayBundleDir("darwin", "/Users/example"),
+    "/Users/example/Applications/Model Router.app",
+  );
+});
+
+test("trayBundleDir is undefined on other platforms", () => {
+  assert.equal(trayBundleDir("linux", "/home/example"), undefined);
+});


### PR DESCRIPTION
Standalone against main — no dependency on other open PRs. (If #15's guided-setup wizard merges first, I'll fold the companion step into its numbered-step flow in a trivial follow-up rebase; the two compose cleanly.)

## What

Adds a **Desktop companion** step to guided setup on macOS and Linux:

- Asks once (`Install the desktop companion app (menu-bar usage meters and provider switcher)?`), builds the native tray with the existing `scripts/build-macos-tray-app.sh` / `bin/model-router-tray` paths, and opens it.
- macOS bundles install into `~/Applications/Model Router.app` — a stable location — instead of the checkout's `dist/`.
- `--with-tray` installs without asking, `--no-tray` suppresses the offer, automatic (non-guided) installs skip it. `install.sh` forwards both flags.
- **Strictly best-effort**: a missing Swift toolchain skips with guidance; any build failure warns and continues — including the real-world case where only the Command Line Tools are installed and recent macOS SDKs cannot build the SwiftUI macros without full Xcode (hit and verified on a live machine). The router install itself never fails because of the companion.

Decision logic is a pure `src/tray-install.mjs` with unit tests covering the flag/platform matrix. Windows keeps the documented manual `scripts/build-desktop-tray.ps1` path for now.

## Verification

`npm run check`, full suite (126 tests, 0 fail), `sh -n install.sh`. The macOS failure path was exercised for real on a CLT-only machine (build fails → warning + guidance, setup continues); the build/open path uses the same script invocation as the existing `bin/model-router-tray`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)