### PR TITLE
Interactive model curation with a protected user-model overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   after each entry, challenges input that looks like the same key pasted
   twice before saving, and re-prompts instead of failing on empty input, so a
   paste with terminal echo disabled is no longer a silent leap of faith.
+- Added interactive model curation: `bin/curate-models PROVIDER` discovers the
+  provider's live model list, lets the user toggle models the registry does
+  not ship, and stores them as protected local user models with conservative
+  default metadata. User models overlay the registry at load time; invalid or
+  colliding entries are skipped with warnings instead of failing the router,
+  and the command can rebuild routes and restart the service on request.
 - Rebuilt the guided setup as a stepped wizard: numbered progress headers, a
   toggleable provider list with live ready/needs-key/needs-sign-in status,
   `a`/`n` select-all/none shortcuts, invalid-input recovery instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
   after each entry, challenges input that looks like the same key pasted
   twice before saving, and re-prompts instead of failing on empty input, so a
   paste with terminal echo disabled is no longer a silent leap of faith.
+- Rebuilt the guided setup as a stepped wizard: numbered progress headers, a
+  toggleable provider list with live ready/needs-key/needs-sign-in status,
+  `a`/`n` select-all/none shortcuts, invalid-input recovery instead of
+  aborting, color when the terminal supports it (respecting `NO_COLOR`), and a
+  review summary with explicit confirmation before anything is installed.
+- Guided Codex setup can now onboard Grok OAuth (and offers to `npm install`
+  a missing official provider CLI), matching what the Cursor setup and tray
+  already supported.
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ Kimi Code OAuth and Kimi Platform API access are separate authentication and
 billing systems. The two Kimi entries intentionally coexist. Older DeepSeek
 aliases remain hidden compatibility routes and are not advertised to new users.
 
+Beyond the built-in models, each API-key provider's live catalog can be
+curated interactively: `./bin/curate-models PROVIDER` lists the models the
+provider currently advertises that are not in the registry, lets you toggle
+the ones you want, and stores them as user models with conservative default
+metadata in protected state (surviving updates, editable in place, and
+removable by re-running the command and deselecting). Curated models are
+local to your machine and are not vetted by the repository's compatibility
+tests.
+
 Only enabled providers appear in an app's picker. Each target has its own
 selection and API-key files:
 

--- a/bin/curate-models
+++ b/bin/curate-models
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+exec node "$repo_dir/src/curate-models.mjs" "$@"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -58,6 +58,14 @@ An alternate registry can be tested in a development process with
 `CODEX_ROUTER_REGISTRY=/path/file.json`. Installed background services use the
 checked-in registry.
 
+User-curated models (`user-models.json` in the state directory, written by
+`bin/curate-models`) overlay the checked-in registry at load time. They pass
+the same per-model validation, but a problem — including a collision with a
+model a registry update later ships — skips the entry and surfaces it in
+`USER_MODEL_WARNINGS` instead of failing the load, so a stale user file can
+never take the router down. The listed-model live-test requirement applies to
+registry submissions; curated entries are explicitly local-only.
+
 ## Tests
 
 ```sh

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -72,6 +72,12 @@ Set-Location codex-router
 ./install.ps1 -Guided
 ```
 
+Guided setup walks through numbered steps: a provider list you toggle by
+number (`a` selects all, `n` clears, Enter continues) with a live
+ready/needs-key/needs-sign-in status per provider, credential onboarding for
+anything you selected that is not connected yet, and a review summary before
+any change is made.
+
 ## Authentication choices
 
 Kimi Code OAuth reuses the official CLI session. Guided setup offers to run the

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -106,6 +106,18 @@ tools, and compaction:
 Open a provider request with the official documentation and test results. Do
 not add an untested model directly to every user's picker.
 
+To use a newly discovered model locally without waiting for a registry
+release, curate it for your own machine:
+
+```sh
+./bin/curate-models deepseek
+```
+
+Curated entries live in the state directory's `user-models.json` with
+conservative default metadata, are skipped automatically if a later registry
+update ships the same model, and are removed by re-running the command and
+deselecting them.
+
 ## Native GPT models stopped working
 
 Temporarily return Codex to its native base URL:

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -1,0 +1,158 @@
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { discoverProviderModels } from "./model-discovery.mjs";
+import { MODELS, PROVIDERS, USER_MODEL_WARNINGS } from "./model-registry.mjs";
+import { SOURCE_ROOT } from "./paths.mjs";
+import { confirm, promptLine } from "./setup-shared.mjs";
+import { toggleSelection } from "./setup-ui.mjs";
+import { readUserModels, userModelEntry, writeUserModels } from "./user-models.mjs";
+
+// Interactive curation: list the provider's live models that are not part of
+// the checked-in registry, let the user toggle the ones they want, and persist
+// them as user models. Discovery never edits config/providers.json.
+
+const providerId = process.argv[2];
+const modelsOption = (() => {
+  const index = process.argv.indexOf("--models");
+  return index === -1 ? undefined : process.argv[index + 1];
+})();
+const apply = process.argv.includes("--apply");
+const noApply = process.argv.includes("--no-apply");
+
+function usage() {
+  console.error(
+    "Usage: curate-models.mjs PROVIDER [--models id1,id2 | interactive] [--apply|--no-apply]",
+  );
+  process.exit(2);
+}
+
+if (!providerId) usage();
+const provider = PROVIDERS.get(providerId);
+if (!provider) {
+  console.error(`Unknown provider: ${providerId}`);
+  process.exit(2);
+}
+
+function renderRows(candidates, curated, selected) {
+  return candidates
+    .map((id, index) => {
+      const mark = selected.has(index + 1) ? "[x]" : "[ ]";
+      const note = curated.has(id) ? "currently curated" : "new";
+      return `  ${mark} ${index + 1}. ${id} (${note})`;
+    })
+    .join("\n");
+}
+
+function chooseInteractively(candidates, curated) {
+  let selected = new Set(
+    candidates.map((id, index) => (curated.has(id) ? index + 1 : undefined)).filter(Boolean),
+  );
+  process.stdout.write(
+    `\nChoose ${provider.displayName} models to add to the picker.\n` +
+      "Curated models keep conservative default metadata you can edit later.\n",
+  );
+  for (;;) {
+    process.stdout.write(`${renderRows(candidates, curated, selected)}\n`);
+    const raw = promptLine("Toggle numbers (comma-separated), a=all, n=none; Enter to continue");
+    const result = toggleSelection(selected, raw, candidates.length, { allowEmpty: true });
+    selected = result.selected;
+    if (result.error) {
+      process.stdout.write(`${result.error}\n`);
+    } else if (result.done) {
+      break;
+    }
+  }
+  return [...selected].sort((a, b) => a - b).map((position) => candidates[position - 1]);
+}
+
+function applyInstall() {
+  const result =
+    process.platform === "win32"
+      ? spawnSync(
+          "powershell.exe",
+          [
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            path.join(SOURCE_ROOT, "install.ps1"),
+            "-CheckoutInstall",
+          ],
+          { stdio: "inherit" },
+        )
+      : spawnSync(path.join(SOURCE_ROOT, "bin", "install"), [], { stdio: "inherit" });
+  if (result.status !== 0) {
+    throw new Error("Applying the curated models did not finish; run the install command manually.");
+  }
+}
+
+async function main() {
+  for (const warning of USER_MODEL_WARNINGS) console.error(warning);
+  const discovery = await discoverProviderModels(providerId);
+  const existing = readUserModels();
+  const mine = existing.filter((model) => model.provider === providerId);
+  const others = existing.filter((model) => model.provider !== providerId);
+  const curated = new Set(mine.map((model) => model.upstreamModel));
+  const candidates = [...new Set([...discovery.unregistered, ...curated])].sort();
+
+  if (candidates.length === 0) {
+    process.stdout.write(
+      `Every model ${provider.displayName} advertises is already in the registry.\n`,
+    );
+    return;
+  }
+
+  const chosen = modelsOption
+    ? modelsOption.split(",").map((value) => value.trim()).filter(Boolean)
+    : chooseInteractively(candidates, curated);
+  for (const id of chosen) {
+    if (!candidates.includes(id)) {
+      throw new Error(
+        `${id} is not an available candidate for ${providerId}. Candidates: ${candidates.join(", ")}`,
+      );
+    }
+  }
+
+  const inheritedProfile = MODELS.find(
+    (model) => model.provider === providerId && model.requestProfile,
+  )?.requestProfile;
+  const byUpstream = new Map(mine.map((model) => [model.upstreamModel, model]));
+  const nextMine = chosen.map(
+    (id, index) =>
+      byUpstream.get(id) ||
+      userModelEntry({
+        providerId,
+        upstreamId: id,
+        requestProfile: inheritedProfile,
+        priority: 100 + index,
+      }),
+  );
+  const target = writeUserModels([...others, ...nextMine]);
+  const added = nextMine.filter((model) => !curated.has(model.upstreamModel)).length;
+  const removed = mine.length - (nextMine.length - added);
+  process.stdout.write(
+    `Saved ${nextMine.length} curated ${provider.displayName} model${
+      nextMine.length === 1 ? "" : "s"
+    } (${added} added, ${removed} removed) to ${target}.\n`,
+  );
+
+  if (noApply) {
+    process.stdout.write("Run ./bin/install to regenerate routes and the picker catalog.\n");
+    return;
+  }
+  const wantsApply =
+    apply ||
+    confirm("Apply now? This rebuilds gateway routes and restarts the background service.");
+  if (wantsApply) {
+    applyInstall();
+    process.stdout.write("Curated models are live. Fully quit and reopen the app to refresh its picker.\n");
+  } else {
+    process.stdout.write("Run ./bin/install to regenerate routes and the picker catalog.\n");
+  }
+}
+
+main().catch((error) => {
+  console.error(`codex-router curate-models: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 
 import { SOURCE_ROOT } from "./paths.mjs";
+import { readUserModels } from "./user-models.mjs";
 
 export const REGISTRY_PATH =
   process.env.MODEL_ROUTER_REGISTRY ||
@@ -61,70 +62,8 @@ function loadRegistry() {
   const slugs = new Set();
   const gatewayModels = new Set();
   const models = parsed.models.map((model) => {
-    if (!model || typeof model !== "object" || Array.isArray(model)) {
-      fail("every model must be an object");
-    }
-    for (const field of ["slug", "gatewayModel", "upstreamModel", "provider"]) {
-      if (typeof model[field] !== "string" || !model[field]) {
-        fail(`model is missing ${field}`);
-      }
-    }
-    if (!providers.has(model.provider)) {
-      fail(`model ${model.slug} references unknown provider ${model.provider}`);
-    }
-    if (!model.slug.startsWith(`${model.provider}/`)) {
-      fail(`model ${model.slug} must be namespaced under ${model.provider}/`);
-    }
-    if (model.requestProfile !== undefined && typeof model.requestProfile !== "string") {
-      fail(`model ${model.slug} has an invalid requestProfile`);
-    }
-    if (slugs.has(model.slug)) fail(`duplicate model slug ${model.slug}`);
-    if (gatewayModels.has(model.gatewayModel)) {
-      fail(`duplicate gateway model ${model.gatewayModel}`);
-    }
-    if (model.listed) {
-      for (const field of ["displayName", "description", "defaultEffort", "compHash"]) {
-        if (typeof model[field] !== "string" || !model[field]) {
-          fail(`listed model ${model.slug} is missing ${field}`);
-        }
-      }
-      if (!Array.isArray(model.reasoningLevels) || model.reasoningLevels.length === 0) {
-        fail(`listed model ${model.slug} requires reasoningLevels`);
-      }
-      if (!Number.isInteger(model.contextWindow) || model.contextWindow < 1) {
-        fail(`listed model ${model.slug} requires contextWindow`);
-      }
-      if (!Number.isInteger(model.priority)) {
-        fail(`listed model ${model.slug} requires an integer priority`);
-      }
-      if (
-        !Number.isInteger(model.autoCompact) ||
-        model.autoCompact < 1 ||
-        model.autoCompact > model.contextWindow
-      ) {
-        fail(`listed model ${model.slug} requires a valid autoCompact limit`);
-      }
-      if (
-        !Array.isArray(model.inputModalities) ||
-        model.inputModalities.length === 0 ||
-        model.inputModalities.some((value) => !["text", "image"].includes(value))
-      ) {
-        fail(`listed model ${model.slug} requires supported inputModalities`);
-      }
-      if (
-        model.reasoningLevels.some(
-          (level) =>
-            !level ||
-            typeof level.effort !== "string" ||
-            !level.effort ||
-            typeof level.description !== "string" ||
-            !level.description,
-        ) ||
-        !model.reasoningLevels.some((level) => level.effort === model.defaultEffort)
-      ) {
-        fail(`listed model ${model.slug} has invalid reasoningLevels`);
-      }
-    }
+    const problem = modelProblem(model, providers, slugs, gatewayModels);
+    if (problem) fail(problem);
     slugs.add(model.slug);
     gatewayModels.add(model.gatewayModel);
     return Object.freeze(model);
@@ -136,10 +75,103 @@ function loadRegistry() {
   };
 }
 
+// Returns a problem description instead of throwing so the strict registry
+// loader can fail hard while the user-model overlay skips with a warning.
+function modelProblem(model, providers, slugs, gatewayModels) {
+  if (!model || typeof model !== "object" || Array.isArray(model)) {
+    return "every model must be an object";
+  }
+  for (const field of ["slug", "gatewayModel", "upstreamModel", "provider"]) {
+    if (typeof model[field] !== "string" || !model[field]) {
+      return `model is missing ${field}`;
+    }
+  }
+  if (!providers.has(model.provider)) {
+    return `model ${model.slug} references unknown provider ${model.provider}`;
+  }
+  if (!model.slug.startsWith(`${model.provider}/`)) {
+    return `model ${model.slug} must be namespaced under ${model.provider}/`;
+  }
+  if (model.requestProfile !== undefined && typeof model.requestProfile !== "string") {
+    return `model ${model.slug} has an invalid requestProfile`;
+  }
+  if (slugs.has(model.slug)) return `duplicate model slug ${model.slug}`;
+  if (gatewayModels.has(model.gatewayModel)) {
+    return `duplicate gateway model ${model.gatewayModel}`;
+  }
+  if (model.listed) {
+    for (const field of ["displayName", "description", "defaultEffort", "compHash"]) {
+      if (typeof model[field] !== "string" || !model[field]) {
+        return `listed model ${model.slug} is missing ${field}`;
+      }
+    }
+    if (!Array.isArray(model.reasoningLevels) || model.reasoningLevels.length === 0) {
+      return `listed model ${model.slug} requires reasoningLevels`;
+    }
+    if (!Number.isInteger(model.contextWindow) || model.contextWindow < 1) {
+      return `listed model ${model.slug} requires contextWindow`;
+    }
+    if (!Number.isInteger(model.priority)) {
+      return `listed model ${model.slug} requires an integer priority`;
+    }
+    if (
+      !Number.isInteger(model.autoCompact) ||
+      model.autoCompact < 1 ||
+      model.autoCompact > model.contextWindow
+    ) {
+      return `listed model ${model.slug} requires a valid autoCompact limit`;
+    }
+    if (
+      !Array.isArray(model.inputModalities) ||
+      model.inputModalities.length === 0 ||
+      model.inputModalities.some((value) => !["text", "image"].includes(value))
+    ) {
+      return `listed model ${model.slug} requires supported inputModalities`;
+    }
+    if (
+      model.reasoningLevels.some(
+        (level) =>
+          !level ||
+          typeof level.effort !== "string" ||
+          !level.effort ||
+          typeof level.description !== "string" ||
+          !level.description,
+      ) ||
+      !model.reasoningLevels.some((level) => level.effort === model.defaultEffort)
+    ) {
+      return `listed model ${model.slug} has invalid reasoningLevels`;
+    }
+  }
+  return undefined;
+}
+
+// User-curated models extend the checked-in registry. A broken entry (or a
+// collision after an upstream update ships the same model) must never take
+// the whole router down, so problems skip the entry and surface as warnings.
+function mergeUserModels(base) {
+  const warnings = [];
+  const models = [...base.models];
+  const slugs = new Set(models.map((model) => model.slug));
+  const gatewayModels = new Set(models.map((model) => model.gatewayModel));
+  for (const model of readUserModels()) {
+    const problem = modelProblem(model, base.providers, slugs, gatewayModels);
+    if (problem) {
+      warnings.push(`Skipped user model: ${problem}`);
+      continue;
+    }
+    slugs.add(model.slug);
+    gatewayModels.add(model.gatewayModel);
+    models.push(Object.freeze(model));
+  }
+  return { models: Object.freeze(models), warnings: Object.freeze(warnings) };
+}
+
 const registry = loadRegistry();
+const merged = mergeUserModels(registry);
 
 export const PROVIDERS = registry.providers;
-export const MODELS = registry.models;
+export const MODELS = merged.models;
+export const USER_MODEL_WARNINGS = merged.warnings;
 export const LISTED_MODELS = Object.freeze(MODELS.filter((model) => model.listed));
 export const API_MODELS = Object.freeze(
   MODELS.filter((model) => PROVIDERS.get(model.provider)?.kind === "openai-compatible"),

--- a/src/setup-shared.mjs
+++ b/src/setup-shared.mjs
@@ -15,7 +15,9 @@ import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
+import { providerOnboardingSnapshot } from "./provider-onboarding.mjs";
 import { configuredProviderIds, validateProviderIds } from "./provider-selection.mjs";
+import { renderProviderChoices, toggleSelection } from "./setup-ui.mjs";
 
 // Target-agnostic setup helpers shared by every target's <target>-setup.mjs.
 // Only the app name, the provider-key command hint, and the install/doctor
@@ -166,27 +168,32 @@ function tryRun(command, commandArgs) {
 
 function guidedSelection(appName) {
   const providers = [...PROVIDERS.values()];
-  process.stdout.write(`\nChoose the providers to show in ${appName}:\n`);
-  providers.forEach((provider, index) => {
-    process.stdout.write(
-      `  ${index + 1}. ${provider.displayName} ${
-        providerConfigured(provider) ? "(ready)" : "(setup required)"
-      }\n`,
-    );
-  });
-  process.stdout.write(
-    "\nOAuth entries reuse official Kimi or Grok CLI sessions; API entries use a provider key.\n",
+  const snapshots = providerOnboardingSnapshot().providers;
+  const colorEnabled = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
+  let selected = new Set(
+    snapshots
+      .map((snapshot, index) => (snapshot.action === "ready" ? index + 1 : undefined))
+      .filter(Boolean),
   );
-  const readyIndexes = providers
-    .map((provider, index) => (providerConfigured(provider) ? String(index + 1) : undefined))
-    .filter(Boolean)
-    .join(",");
-  const raw = promptLine("Enter numbers separated by commas", readyIndexes || "1");
-  const selected = raw.split(",").map((value) => Number(value.trim()));
-  if (selected.some((value) => !Number.isInteger(value) || value < 1 || value > providers.length)) {
-    throw new Error("Provider selection contains an invalid number.");
+  if (selected.size === 0) selected = new Set([1]);
+  process.stdout.write(`\nChoose the providers to show in ${appName}:\n`);
+  process.stdout.write(
+    "OAuth entries reuse official Kimi or Grok CLI sessions; API entries use a provider key.\n",
+  );
+  for (;;) {
+    process.stdout.write(`${renderProviderChoices(snapshots, selected, colorEnabled)}\n`);
+    const raw = promptLine("Toggle numbers (comma-separated), a=all, n=none; Enter to continue");
+    const result = toggleSelection(selected, raw, snapshots.length);
+    selected = result.selected;
+    if (result.error) {
+      process.stdout.write(`${result.error}\n`);
+    } else if (result.done) {
+      break;
+    }
   }
-  return validateProviderIds(selected.map((value) => providers[value - 1].id));
+  return validateProviderIds(
+    [...selected].sort((a, b) => a - b).map((position) => providers[position - 1].id),
+  );
 }
 
 // Resolve which provider ids to enable from --providers, or interactively.

--- a/src/setup-ui.mjs
+++ b/src/setup-ui.mjs
@@ -46,10 +46,10 @@ export function renderProviderChoices(snapshots, selected, colorEnabled = false)
     .join("\n");
 }
 
-export function toggleSelection(selected, input, count) {
+export function toggleSelection(selected, input, count, { allowEmpty = false } = {}) {
   const trimmed = String(input || "").trim().toLowerCase();
   if (trimmed === "") {
-    if (selected.size === 0) {
+    if (selected.size === 0 && !allowEmpty) {
       return { selected, error: "Select at least one provider." };
     }
     return { selected, done: true };

--- a/src/setup-ui.mjs
+++ b/src/setup-ui.mjs
@@ -1,0 +1,78 @@
+// Pure helpers for the guided-setup terminal UI. Rendering and selection
+// state carry no terminal I/O so both target setups share them and unit
+// tests can cover every interaction without a PTY.
+
+const ACTION_LABELS = Object.freeze({
+  ready: "ready",
+  "add-key": "needs API key",
+  login: "needs CLI sign-in",
+  install: "needs CLI install",
+});
+
+const COLOR_CODES = Object.freeze({
+  green: "32",
+  yellow: "33",
+  red: "31",
+  cyan: "36",
+});
+
+export function stepHeader(step, total, title) {
+  return `\n--- Step ${step} of ${total}: ${title} ---\n`;
+}
+
+export function providerStatusLabel(snapshot) {
+  return ACTION_LABELS[snapshot.action] || "setup required";
+}
+
+export function colorize(text, color, enabled) {
+  const code = COLOR_CODES[color];
+  if (!enabled || !code) return text;
+  return `\u001b[${code}m${text}\u001b[0m`;
+}
+
+export function renderProviderChoices(snapshots, selected, colorEnabled = false) {
+  return snapshots
+    .map((snapshot, index) => {
+      const position = index + 1;
+      const mark = selected.has(position) ? "[x]" : "[ ]";
+      const label = providerStatusLabel(snapshot);
+      const colored = colorize(
+        label,
+        snapshot.action === "ready" ? "green" : "yellow",
+        colorEnabled,
+      );
+      return `  ${mark} ${position}. ${snapshot.displayName} — ${colored}`;
+    })
+    .join("\n");
+}
+
+export function toggleSelection(selected, input, count) {
+  const trimmed = String(input || "").trim().toLowerCase();
+  if (trimmed === "") {
+    if (selected.size === 0) {
+      return { selected, error: "Select at least one provider." };
+    }
+    return { selected, done: true };
+  }
+  if (trimmed === "a" || trimmed === "all") {
+    const all = new Set();
+    for (let position = 1; position <= count; position += 1) all.add(position);
+    return { selected: all };
+  }
+  if (trimmed === "n" || trimmed === "none") {
+    return { selected: new Set() };
+  }
+  const next = new Set(selected);
+  for (const part of trimmed.split(",")) {
+    const value = Number(part.trim());
+    if (!Number.isInteger(value) || value < 1 || value > count) {
+      return { selected, error: `Invalid choice: ${part.trim()}` };
+    }
+    if (next.has(value)) {
+      next.delete(value);
+    } else {
+      next.add(value);
+    }
+  }
+  return { selected: next };
+}

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -3,10 +3,18 @@ import { closeSync, openSync, readSync, writeSync } from "node:fs";
 import path from "node:path";
 
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
+import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
+import {
+  installOauthCli,
+  oauthCliPath,
+  oauthLoginArgs,
+  providerOnboardingSnapshot,
+} from "./provider-onboarding.mjs";
+import { renderProviderChoices, stepHeader, toggleSelection } from "./setup-ui.mjs";
 import {
   configuredProviderIds,
   validateProviderIds,
@@ -117,29 +125,40 @@ function confirm(label, defaultYes = true) {
 }
 
 function providerConfigured(provider) {
-  return provider.kind === "oauth"
-    ? provider.id === "kimi-oauth" && kimiOAuthStatus().configured
-    : credentialStatus(provider, { persistent: true }).configured;
+  if (provider.kind === "oauth") {
+    if (provider.id === "kimi-oauth") return kimiOAuthStatus().configured;
+    if (provider.id === "grok-oauth") return grokOAuthStatus().configured;
+    return false;
+  }
+  return credentialStatus(provider, { persistent: true }).configured;
 }
+
+const colorEnabled = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
 
 function guidedSelection() {
   const providers = [...PROVIDERS.values()];
+  const snapshots = providerOnboardingSnapshot().providers;
+  let selected = new Set(
+    snapshots
+      .map((snapshot, index) => (snapshot.action === "ready" ? index + 1 : undefined))
+      .filter(Boolean),
+  );
+  if (selected.size === 0) selected = new Set([1]);
   process.stdout.write("\nChoose the providers to show in Codex:\n");
-  providers.forEach((provider, index) => {
-    process.stdout.write(
-      `  ${index + 1}. ${provider.displayName} ${providerConfigured(provider) ? "(ready)" : "(setup required)"}\n`,
-    );
-  });
-  const readyIndexes = providers
-    .map((provider, index) => (providerConfigured(provider) ? String(index + 1) : undefined))
-    .filter(Boolean)
-    .join(",");
-  const raw = promptLine("Enter numbers separated by commas", readyIndexes || "1");
-  const selected = raw.split(",").map((value) => Number(value.trim()));
-  if (selected.some((value) => !Number.isInteger(value) || value < 1 || value > providers.length)) {
-    throw new Error("Provider selection contains an invalid number.");
+  for (;;) {
+    process.stdout.write(`${renderProviderChoices(snapshots, selected, colorEnabled)}\n`);
+    const raw = promptLine("Toggle numbers (comma-separated), a=all, n=none; Enter to continue");
+    const result = toggleSelection(selected, raw, snapshots.length);
+    selected = result.selected;
+    if (result.error) {
+      process.stdout.write(`${result.error}\n`);
+    } else if (result.done) {
+      break;
+    }
   }
-  return validateProviderIds(selected.map((value) => providers[value - 1].id));
+  return validateProviderIds(
+    [...selected].sort((a, b) => a - b).map((position) => providers[position - 1].id),
+  );
 }
 
 function requestedSelection() {
@@ -150,17 +169,6 @@ function requestedSelection() {
     return validateProviderIds(requested.split(","));
   }
   return guided ? guidedSelection() : configuredProviderIds();
-}
-
-function executable(name) {
-  const finder = process.platform === "win32" ? "where.exe" : "which";
-  try {
-    return execFileSync(finder, [name], { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] })
-      .trim()
-      .split(/\r?\n/)[0];
-  } catch {
-    return undefined;
-  }
 }
 
 function run(command, commandArgs, options = {}) {
@@ -181,20 +189,28 @@ function configureProvider(provider) {
   if (!guided) {
     const setup =
       provider.kind === "oauth"
-        ? "run `kimi login`"
+        ? "sign in with the provider's official CLI"
         : `run \`./bin/provider-key ${provider.id} set\``;
     throw new Error(`${provider.displayName} is selected but not configured; ${setup} first.`);
   }
   if (provider.kind === "oauth") {
-    const kimi = executable("kimi");
-    if (!kimi) {
-      throw new Error(
-        "Kimi Code CLI is required for OAuth. Install it from https://www.kimi.com/help/kimi-code/cli-getting-started, then run setup again.",
-      );
+    let cli = oauthCliPath(provider.id);
+    if (!cli) {
+      if (!confirm(`Install the official ${provider.displayName} CLI with npm now?`)) {
+        throw new Error(
+          `${provider.displayName} needs its official CLI; install it and run setup again.`,
+        );
+      }
+      installOauthCli(provider.id);
+      cli = oauthCliPath(provider.id);
     }
-    if (!confirm("Run `kimi login` now?")) throw new Error("Kimi OAuth setup was cancelled.");
-    run(kimi, ["login"]);
-    if (!kimiOAuthStatus().configured) throw new Error("Kimi OAuth login did not produce a usable credential.");
+    if (!confirm(`Sign in to ${provider.displayName} now?`)) {
+      throw new Error(`${provider.displayName} sign-in was cancelled.`);
+    }
+    run(cli, oauthLoginArgs(provider.id));
+    if (!providerConfigured(provider)) {
+      throw new Error(`${provider.displayName} sign-in did not produce a usable credential.`);
+    }
   } else {
     if (!confirm(`Enter a ${provider.displayName} key securely now?`)) {
       throw new Error(`${provider.displayName} setup was cancelled.`);
@@ -211,17 +227,29 @@ async function main() {
       `An unknown model router owns ${legacy.config.modelCatalogJson}; automatic setup will not replace it.`,
     );
   }
+  const stepTitles = ["Choose providers", "Connect credentials"];
+  if (legacy.installations.length) stepTitles.push("Migrate older router");
+  stepTitles.push("Review and install");
+  let stepIndex = 0;
+  const nextStep = (title) => {
+    stepIndex += 1;
+    if (guided) process.stdout.write(stepHeader(stepIndex, stepTitles.length, title));
+  };
+
+  nextStep("Choose providers");
   const providers = requestedSelection();
   if (providers.length === 0) {
     throw new Error(
       "No configured provider was found. Run `./bin/setup --guided` or pass `--providers` after configuring credentials.",
     );
   }
+  nextStep("Connect credentials");
   for (const id of providers) configureProvider(PROVIDERS.get(id));
   writeProviderSelection(providers);
 
   let migration;
   if (legacy.installations.length) {
+    nextStep("Migrate older router");
     const approved = migrateKnown || (guided && confirm(
       `Safely migrate ${legacy.installations.map((item) => item.id).join(", ")} and keep a rollback snapshot?`,
     ));
@@ -234,6 +262,19 @@ async function main() {
   if (selectionOnly) {
     process.stdout.write(`${JSON.stringify({ providers, migration }, null, 2)}\n`);
     return;
+  }
+
+  nextStep("Review and install");
+  if (guided) {
+    process.stdout.write(
+      `\nReady to install:\n` +
+        `  Providers: ${providers.join(", ")}\n` +
+        `  Migration: ${migration ? "recognized older router (rollback snapshot kept)" : "none needed"}\n` +
+        `  Changes: per-user background service and the managed Codex config block\n`,
+    );
+    if (!confirm("Proceed?")) {
+      throw new Error("Setup was cancelled before installing the service.");
+    }
   }
 
   try {

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -1,0 +1,73 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { protectPrivateFile } from "./file-security.mjs";
+import { STATE_DIR } from "./paths.mjs";
+
+// User-curated models live outside config/providers.json so a checkout update
+// never discards them. Entries carry the same shape as registry models;
+// metadata uses conservative defaults the user can edit in place.
+
+export const USER_MODELS_PATH =
+  process.env.MODEL_ROUTER_USER_MODELS || path.join(STATE_DIR, "user-models.json");
+
+const DEFAULT_CONTEXT_WINDOW = 131072;
+const DEFAULT_AUTO_COMPACT = 110000;
+
+function gatewaySafe(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function userModelEntry({ providerId, upstreamId, requestProfile, priority }) {
+  const gatewayModel = `${gatewaySafe(providerId)}-${gatewaySafe(upstreamId)}`;
+  const entry = {
+    slug: `${providerId}/${upstreamId}`,
+    gatewayModel,
+    upstreamModel: upstreamId,
+    provider: providerId,
+    listed: true,
+    displayName: `${upstreamId} (curated)`,
+    description: `User-curated ${providerId} model; conservative default metadata that can be edited in the user model file.`,
+    priority,
+    defaultEffort: "high",
+    reasoningLevels: [{ effort: "high", description: "Adaptive reasoning" }],
+    contextWindow: DEFAULT_CONTEXT_WINDOW,
+    autoCompact: DEFAULT_AUTO_COMPACT,
+    inputModalities: ["text"],
+    compHash: `${gatewayModel}-user-v1`,
+  };
+  if (requestProfile) entry.requestProfile = requestProfile;
+  return entry;
+}
+
+export function readUserModels() {
+  if (!existsSync(USER_MODELS_PATH)) return [];
+  try {
+    const payload = JSON.parse(readFileSync(USER_MODELS_PATH, "utf8"));
+    return Array.isArray(payload?.models) ? payload.models : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeUserModels(models) {
+  mkdirSync(path.dirname(USER_MODELS_PATH), { recursive: true, mode: 0o700 });
+  const temporary = `${USER_MODELS_PATH}.tmp.${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify({ version: 1, models }, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  try {
+    protectPrivateFile(temporary);
+    renameSync(temporary, USER_MODELS_PATH);
+    protectPrivateFile(USER_MODELS_PATH);
+  } catch (error) {
+    if (existsSync(temporary)) unlinkSync(temporary);
+    throw error;
+  }
+  return USER_MODELS_PATH;
+}

--- a/test/setup-ui.test.mjs
+++ b/test/setup-ui.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  colorize,
+  providerStatusLabel,
+  renderProviderChoices,
+  stepHeader,
+  toggleSelection,
+} from "../src/setup-ui.mjs";
+
+const SNAPSHOTS = [
+  { id: "kimi-oauth", displayName: "Kimi Code OAuth", kind: "oauth", action: "ready" },
+  { id: "deepseek", displayName: "DeepSeek API", kind: "api", action: "add-key" },
+  { id: "grok-oauth", displayName: "xAI Grok OAuth", kind: "oauth", action: "install" },
+];
+
+test("stepHeader shows position and title", () => {
+  assert.equal(stepHeader(2, 5, "Choose providers"), "\n--- Step 2 of 5: Choose providers ---\n");
+});
+
+test("providerStatusLabel maps onboarding actions to friendly text", () => {
+  assert.equal(providerStatusLabel({ action: "ready" }), "ready");
+  assert.equal(providerStatusLabel({ action: "add-key" }), "needs API key");
+  assert.equal(providerStatusLabel({ action: "login" }), "needs CLI sign-in");
+  assert.equal(providerStatusLabel({ action: "install" }), "needs CLI install");
+  assert.equal(providerStatusLabel({ action: "mystery" }), "setup required");
+});
+
+test("renderProviderChoices marks selected rows and shows status", () => {
+  const rendered = renderProviderChoices(SNAPSHOTS, new Set([1, 3]));
+  const lines = rendered.split("\n");
+  assert.equal(lines[0], "  [x] 1. Kimi Code OAuth — ready");
+  assert.equal(lines[1], "  [ ] 2. DeepSeek API — needs API key");
+  assert.equal(lines[2], "  [x] 3. xAI Grok OAuth — needs CLI install");
+});
+
+test("toggleSelection toggles numbers on and off", () => {
+  let state = toggleSelection(new Set(), "1,3", 3);
+  assert.deepEqual([...state.selected].sort(), [1, 3]);
+  assert.equal(state.done, undefined);
+  state = toggleSelection(state.selected, "3", 3);
+  assert.deepEqual([...state.selected], [1]);
+});
+
+test("toggleSelection supports all and none shortcuts", () => {
+  const all = toggleSelection(new Set([2]), "a", 3);
+  assert.deepEqual([...all.selected].sort(), [1, 2, 3]);
+  const none = toggleSelection(all.selected, "n", 3);
+  assert.deepEqual([...none.selected], []);
+});
+
+test("toggleSelection finishes on empty input with a non-empty selection", () => {
+  const state = toggleSelection(new Set([2]), "", 3);
+  assert.equal(state.done, true);
+  assert.deepEqual([...state.selected], [2]);
+});
+
+test("toggleSelection refuses to finish with nothing selected", () => {
+  const state = toggleSelection(new Set(), "", 3);
+  assert.equal(state.done, undefined);
+  assert.ok(state.error.includes("at least one"));
+});
+
+test("toggleSelection reports invalid input without changing the selection", () => {
+  const state = toggleSelection(new Set([1]), "0,nope", 3);
+  assert.ok(state.error);
+  assert.deepEqual([...state.selected], [1]);
+});
+
+test("colorize wraps only when enabled", () => {
+  assert.equal(colorize("ready", "green", false), "ready");
+  assert.equal(colorize("ready", "green", true), "\u001b[32mready\u001b[0m");
+  assert.equal(colorize("ready", "unknown-color", true), "ready");
+});

--- a/test/setup-ui.test.mjs
+++ b/test/setup-ui.test.mjs
@@ -62,6 +62,12 @@ test("toggleSelection refuses to finish with nothing selected", () => {
   assert.ok(state.error.includes("at least one"));
 });
 
+test("toggleSelection can finish empty when allowEmpty is set", () => {
+  const state = toggleSelection(new Set(), "", 3, { allowEmpty: true });
+  assert.equal(state.done, true);
+  assert.deepEqual([...state.selected], []);
+});
+
 test("toggleSelection reports invalid input without changing the selection", () => {
   const state = toggleSelection(new Set([1]), "0,nope", 3);
   assert.ok(state.error);

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "user-models-test-"));
+process.env.CODEX_ROUTER_STATE_DIR = stateDir;
+
+const { userModelEntry, readUserModels, writeUserModels, USER_MODELS_PATH } = await import(
+  "../src/user-models.mjs"
+);
+
+test("userModelEntry fills conservative picker metadata", () => {
+  const entry = userModelEntry({
+    providerId: "ollama-cloud",
+    upstreamId: "gpt-oss:120b",
+    requestProfile: "ollama-cloud",
+    priority: 101,
+  });
+  assert.equal(entry.slug, "ollama-cloud/gpt-oss:120b");
+  assert.equal(entry.gatewayModel, "ollama-cloud-gpt-oss-120b");
+  assert.equal(entry.upstreamModel, "gpt-oss:120b");
+  assert.equal(entry.provider, "ollama-cloud");
+  assert.equal(entry.listed, true);
+  assert.equal(entry.priority, 101);
+  assert.equal(entry.requestProfile, "ollama-cloud");
+  assert.equal(entry.defaultEffort, "high");
+  assert.ok(entry.reasoningLevels.some((level) => level.effort === "high"));
+  assert.ok(Number.isInteger(entry.contextWindow) && entry.contextWindow >= 1);
+  assert.ok(entry.autoCompact >= 1 && entry.autoCompact <= entry.contextWindow);
+  assert.deepEqual(entry.inputModalities, ["text"]);
+  assert.equal(entry.compHash, "ollama-cloud-gpt-oss-120b-user-v1");
+  assert.ok(entry.displayName.includes("gpt-oss:120b"));
+  assert.ok(entry.description.length > 0);
+});
+
+test("userModelEntry omits requestProfile when the provider has none", () => {
+  const entry = userModelEntry({
+    providerId: "zai-coding",
+    upstreamId: "glm-4.7",
+    priority: 100,
+  });
+  assert.equal(entry.requestProfile, undefined);
+});
+
+test("user models round-trip through the protected state file", () => {
+  const entries = [
+    userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-vl-test", priority: 100 }),
+  ];
+  writeUserModels(entries);
+  assert.deepEqual(readUserModels(), entries);
+  assert.ok(USER_MODELS_PATH.startsWith(stateDir));
+});
+
+test("readUserModels returns an empty list when the file is absent or invalid", () => {
+  writeFileSync(USER_MODELS_PATH, "not-json\n");
+  assert.deepEqual(readUserModels(), []);
+});
+
+test("registry merges valid user models and skips collisions", async () => {
+  const entries = [
+    userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-user-test", priority: 100 }),
+    // Collides with a built-in slug and must be skipped, not fatal.
+    { ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-v4-pro", priority: 101 }) },
+    // Unknown provider must be skipped, not fatal.
+    userModelEntry({ providerId: "no-such-provider", upstreamId: "x-model", priority: 102 }),
+  ];
+  writeUserModels(entries);
+  const registry = await import("../src/model-registry.mjs");
+  const slugs = registry.MODELS.map((model) => model.slug);
+  assert.ok(slugs.includes("deepseek/deepseek-user-test"));
+  assert.equal(slugs.filter((slug) => slug === "deepseek/deepseek-v4-pro").length, 1);
+  assert.ok(!slugs.includes("no-such-provider/x-model"));
+  assert.ok(registry.MODEL_BY_GATEWAY_ID.has("deepseek-deepseek-user-test"));
+  assert.ok(registry.USER_MODEL_WARNINGS.length >= 2);
+  const merged = registry.MODEL_BY_SLUG.get("deepseek/deepseek-user-test");
+  assert.equal(merged.listed, true);
+});


### PR DESCRIPTION
**Builds on #15** (it reuses the shared toggle-select UI introduced there), so this branch contains #15's commit plus one new commit — reviewing the [last commit](https://github.com/duolahypercho/codex-router/pull/17/commits) shows exactly this PR's change. I'll rebase onto main the moment #15 merges. Opened ready rather than draft so both can be reviewed in one pass.

## What

`./bin/curate-models PROVIDER` lets a user extend their own picker from the provider's **live** model list without waiting for a registry release:

- Discovers via the existing `model-discovery` path (`--fixture` supported for tests), shows models the checked-in registry does not ship plus currently curated ones (preselected), toggled with the same list UI as guided setup (`a`/`n`, deselect-all removes curation).
- Selections persist as **user models** in the state directory's protected `user-models.json`: conservative default metadata (128k context, adaptive-high reasoning, sanitized gateway id — `gpt-oss:120b` → `...-gpt-oss-120b`), request profile inherited from the provider's registry models, editable in place, surviving checkout updates.
- `--models a,b` for non-interactive use; `--apply`/`--no-apply` control the rebuild-and-restart step.

## Registry overlay semantics

Model validation is extracted into a shared non-throwing checker: the checked-in registry still **fails hard** on any problem, while user entries that are invalid or collide (e.g. a later registry update ships the same model) are **skipped and surfaced via `USER_MODEL_WARNINGS`** — a stale user file can never take the router or forwarders down. Everything downstream (LiteLLM route generation, catalog merge, forwarders, doctor, discovery) picks user models up automatically because they join `MODELS` at load time.

Curated entries are explicitly local-only; DEVELOPMENT.md now states the listed-model live-test bar applies to registry submissions, not personal curation.

## Verification

- Unit tests: entry-default generation (incl. gateway-id sanitization and autoCompact bounds), state-file round-trip, corrupt-file tolerance, and registry merge with collision/unknown-provider skips.
- `npm run check`, full suite (134 tests, 0 fail), `sh -n` on all `bin/*`.
- End-to-end against a discovery fixture in isolated state: scripted `--models` mode and the interactive PTY flow (select-all, save, file contents, registry pickup with zero warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)