### PR TITLE
Desktop-panel mode for the Dynamic Island

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Added a Z.ai vendor quota adapter: when a `zai-coding` provider is
+  configured, account usage now reports real plan windows (5-hour, weekly,
+  token quota) with reset times from Z.ai's key-authenticated quota API,
+  plus a dashboard link. Alibaba plan and Ollama Cloud accounts stay
+  local-only by design — their vendor dashboards are session-gated and the
+  router never imports browser cookies — but now carry a `dashboardUrl` so
+  companion UIs can deep-link to the official usage pages.
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- The Dynamic Island setting is now a three-way mode: Off, Notch (the
+  existing top-of-screen overlay), or Desktop — a draggable widget-style
+  panel pinned just above the desktop icons that always shows live router
+  activity, every connected provider's vendor quota bars with reset
+  countdowns, and the 7-day token trend, with its position remembered.
 - Added a Z.ai vendor quota adapter: when a `zai-coding` provider is
   configured, account usage now reports real plan windows (5-hour, weekly,
   token quota) with reset times from Z.ai's key-authenticated quota API,

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -814,6 +814,9 @@ private struct ProviderIcon: View {
     if providerID.hasPrefix("kimi") { return "Kimi" }
     if providerID == "deepseek" { return "DeepSeek" }
     if providerID == "anthropic-api" { return "Anthropic" }
+    if providerID == "zai-coding" { return "GLM" }
+    if providerID == "qwen-plan" { return "Qwen" }
+    if providerID == "ollama-cloud" { return "Ollama" }
     return "Model provider"
   }
 }

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -1295,3 +1295,174 @@ private struct MetricTile: View {
     )
   }
 }
+
+@MainActor
+final class DesktopPanelWindowController {
+  static let panelSize = CGSize(width: 340, height: 432)
+  private static let frameName = "ModelRouterTray.desktopPanel"
+  private let window: NSPanel
+
+  init(store: RouterStore) {
+    window = NSPanel(
+      contentRect: NSRect(origin: .zero, size: Self.panelSize),
+      styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
+      backing: .buffered,
+      defer: false
+    )
+    window.isOpaque = false
+    window.backgroundColor = .clear
+    window.hasShadow = true
+    // Sit just above the desktop icons so the panel behaves like a widget:
+    // always readable on the desktop, never covering application windows.
+    window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.desktopIconWindow)) + 1)
+    window.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+    window.isMovable = true
+    window.isMovableByWindowBackground = true
+    window.hidesOnDeactivate = false
+    window.contentView = NSHostingView(
+      rootView: DesktopPanelView(store: store)
+        .frame(width: Self.panelSize.width, height: Self.panelSize.height)
+        .preferredColorScheme(.dark)
+    )
+    window.setFrameAutosaveName(Self.frameName)
+  }
+
+  func setVisible(_ visible: Bool) {
+    if visible {
+      if !window.setFrameUsingName(Self.frameName), let screen = NSScreen.main {
+        let frame = screen.visibleFrame
+        window.setFrameOrigin(NSPoint(
+          x: frame.maxX - Self.panelSize.width - 24,
+          y: frame.maxY - Self.panelSize.height - 24
+        ))
+      }
+      window.orderFrontRegardless()
+    } else {
+      window.orderOut(nil)
+    }
+  }
+}
+
+private struct DesktopPanelView: View {
+  @ObservedObject var store: RouterStore
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 11) {
+      HStack(spacing: 10) {
+        LiveOrb(state: store.activityState, count: store.activeRequestCount)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(store.activityState.label)
+            .font(.system(size: 14, weight: .semibold, design: .rounded))
+          Text(store.activitySummaryLabel)
+            .font(.system(size: 9, weight: .medium, design: .rounded))
+            .foregroundStyle(store.activityState.tint)
+            .lineLimit(1)
+        }
+        Spacer()
+        Text("ROUTER")
+          .font(.system(size: 8, weight: .bold, design: .monospaced))
+          .tracking(1.1)
+          .foregroundStyle(routerMuted)
+      }
+
+      if store.hasConcurrentActivity {
+        ActiveRequestList(store: store, limit: 3, compact: true)
+      }
+
+      Text("QUOTAS")
+        .font(.system(size: 8, weight: .semibold, design: .monospaced))
+        .tracking(0.8)
+        .foregroundStyle(routerMuted)
+
+      if store.desktopQuotaRows.isEmpty {
+        Text("Connect a provider to see its quota here.")
+          .font(.system(size: 10, design: .rounded))
+          .foregroundStyle(routerMuted)
+      } else {
+        ScrollView(.vertical, showsIndicators: false) {
+          VStack(spacing: 8) {
+            ForEach(store.desktopQuotaRows) { row in
+              DesktopQuotaBarRow(row: row)
+            }
+          }
+        }
+        .frame(maxHeight: 190)
+      }
+
+      Spacer(minLength: 0)
+
+      HStack(alignment: .firstTextBaseline) {
+        Text("DAILY TOKENS")
+          .font(.system(size: 8, weight: .semibold, design: .monospaced))
+          .tracking(0.8)
+          .foregroundStyle(routerMuted)
+        Spacer()
+        Text("LAST 7 DAYS")
+          .font(.system(size: 8, weight: .semibold, design: .monospaced))
+          .tracking(0.6)
+          .foregroundStyle(routerMuted)
+      }
+      IslandUsageLineChart(points: store.dailyUsage(days: 7), tint: routerAccent)
+        .frame(height: 54)
+    }
+    .padding(16)
+    .background(
+      RoundedRectangle(cornerRadius: 20, style: .continuous)
+        .fill(islandBezel.opacity(0.97))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 20, style: .continuous)
+        .stroke(Color.white.opacity(0.09), lineWidth: 0.8)
+    )
+  }
+}
+
+private struct DesktopQuotaBarRow: View {
+  let row: DesktopQuotaRow
+
+  private var tint: Color {
+    if row.usedPercent >= 90 { return routerRed }
+    if row.usedPercent >= 70 { return routerYellow }
+    return routerMint
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 3) {
+      HStack(spacing: 6) {
+        ProviderIcon(providerID: row.providerID, size: 14)
+        Text("\(row.providerName) · \(row.label)")
+          .font(.system(size: 10, weight: .medium, design: .rounded))
+          .lineLimit(1)
+        Spacer()
+        if let resetAt = row.resetAt {
+          Text(desktopResetLabel(resetAt))
+            .font(.system(size: 8, design: .rounded))
+            .foregroundStyle(routerMuted)
+        }
+        Text("\(Int(row.usedPercent.rounded()))%")
+          .font(.system(size: 10, weight: .semibold, design: .rounded))
+          .monospacedDigit()
+          .foregroundStyle(tint)
+      }
+      GeometryReader { geometry in
+        ZStack(alignment: .leading) {
+          Capsule().fill(Color.white.opacity(0.08))
+          Capsule()
+            .fill(tint)
+            .frame(width: max(3, geometry.size.width * min(1, row.usedPercent / 100)))
+        }
+      }
+      .frame(height: 4)
+    }
+  }
+}
+
+private func desktopResetLabel(_ epoch: TimeInterval) -> String {
+  let seconds = epoch - Date().timeIntervalSince1970
+  if seconds <= 0 { return "resets soon" }
+  let minutes = Int(seconds / 60)
+  if minutes < 60 { return "resets in \(minutes)m" }
+  let hours = minutes / 60
+  if hours < 24 { return "resets in \(hours)h" }
+  return "resets in \(hours / 24)d \(hours % 24)h"
+}

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -54,14 +54,19 @@ struct ModelRouterTrayApp: App {
 final class AppDelegate: NSObject, NSApplicationDelegate {
   let store = RouterStore()
   private var islandController: IslandWindowController?
+  private var desktopPanelController: DesktopPanelWindowController?
   private var islandVisibility: AnyCancellable?
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     NSApp.setActivationPolicy(.accessory)
     islandController = IslandWindowController(store: store)
-    islandVisibility = store.$islandVisible
+    desktopPanelController = DesktopPanelWindowController(store: store)
+    islandVisibility = store.$islandMode
       .removeDuplicates()
-      .sink { [weak self] visible in self?.islandController?.setVisible(visible) }
+      .sink { [weak self] mode in
+        self?.islandController?.setVisible(mode == .notch)
+        self?.desktopPanelController?.setVisible(mode == .desktop)
+      }
     Task { await store.startPolling() }
     Task { await store.startActivityPolling() }
     Task { await store.startAccountUsagePolling() }
@@ -87,7 +92,7 @@ final class RouterStore: ObservableObject {
   @Published private(set) var providerUsageError: String?
   @Published private(set) var providerSetup: [String: ProviderSetupState] = [:]
   @Published private(set) var providerOperation: String?
-  @Published private(set) var islandVisible: Bool
+  @Published private(set) var islandMode: IslandMode
 
   private var polling = false
   private var activityPolling = false
@@ -95,6 +100,7 @@ final class RouterStore: ObservableObject {
   private var providerPolling = false
   private let defaults = UserDefaults.standard
   private let islandVisibilityKey = "ModelRouterTray.islandVisible"
+  private let islandModeKey = "ModelRouterTray.islandMode"
   private var accountUsageResolved = false
   private var hasResolvedInitialUsageProvider = false
   private var hasObservedActiveProvider = false
@@ -103,9 +109,14 @@ final class RouterStore: ObservableObject {
 
   init() {
     selectedUsageProviderID = "openai"
-    islandVisible = defaults.object(forKey: islandVisibilityKey) == nil
-      ? true
-      : defaults.bool(forKey: islandVisibilityKey)
+    if let raw = defaults.string(forKey: islandModeKey), let mode = IslandMode(rawValue: raw) {
+      islandMode = mode
+    } else if defaults.object(forKey: islandVisibilityKey) == nil {
+      islandMode = .notch
+    } else {
+      // Migrate the pre-desktop-mode boolean setting.
+      islandMode = defaults.bool(forKey: islandVisibilityKey) ? .notch : .off
+    }
   }
 
   var codexActive: Bool {
@@ -390,9 +401,42 @@ final class RouterStore: ObservableObject {
     }
   }
 
-  func setIslandVisible(_ visible: Bool) {
-    islandVisible = visible
-    defaults.set(visible, forKey: islandVisibilityKey)
+  func setIslandMode(_ mode: IslandMode) {
+    islandMode = mode
+    defaults.set(mode.rawValue, forKey: islandModeKey)
+  }
+
+  // Every vendor quota window the desktop panel can show at a glance:
+  // the ChatGPT rate-limit windows plus each connected provider's account
+  // quota metrics.
+  var desktopQuotaRows: [DesktopQuotaRow] {
+    var rows: [DesktopQuotaRow] = []
+    if let account = accountUsage {
+      for (suffix, window) in [("primary", account.primary), ("secondary", account.secondary)] {
+        guard let window else { continue }
+        rows.append(DesktopQuotaRow(
+          id: "openai-\(suffix)",
+          providerID: "openai",
+          providerName: "ChatGPT",
+          label: window.durationLabel,
+          usedPercent: Double(window.usedPercent),
+          resetAt: window.resetsAt))
+      }
+    }
+    for provider in usageProviderChoices where provider.id != "openai" && provider.isEnabled {
+      guard let usage = providerUsage(for: provider.id) else { continue }
+      for (index, metric) in usage.account.metrics.enumerated() where metric.kind == "quota" {
+        guard let used = metric.usedPercent else { continue }
+        rows.append(DesktopQuotaRow(
+          id: "\(provider.id)-\(index)",
+          providerID: provider.id,
+          providerName: provider.shortName,
+          label: metric.label,
+          usedPercent: used,
+          resetAt: metric.resetAt))
+      }
+    }
+    return rows
   }
 
   func startAccountUsagePolling() async {
@@ -1037,6 +1081,30 @@ struct UsageProviderChoice: Identifiable {
   let isEnabled: Bool
 }
 
+enum IslandMode: String, CaseIterable, Identifiable {
+  case off
+  case notch
+  case desktop
+
+  var id: String { rawValue }
+  var label: String {
+    switch self {
+    case .off: return "Off"
+    case .notch: return "Notch"
+    case .desktop: return "Desktop"
+    }
+  }
+}
+
+struct DesktopQuotaRow: Identifiable {
+  let id: String
+  let providerID: String
+  let providerName: String
+  let label: String
+  let usedPercent: Double
+  let resetAt: TimeInterval?
+}
+
 struct UsageOverviewCard: Identifiable {
   let id: String
   let provider: UsageProviderChoice
@@ -1155,14 +1223,30 @@ private struct TrayView: View {
           sectionLabel("All usage", detail: "7-day snapshot")
           AllProviderUsageGrid(store: store)
         }
-        settingRow(
-          title: "Dynamic Island",
-          detail: "Show provider usage and activity status",
-          isOn: Binding(
-            get: { store.islandVisible },
-            set: { store.setIslandVisible($0) }
-          )
-        )
+        HStack(spacing: 12) {
+          VStack(alignment: .leading, spacing: 3) {
+            Text("Dynamic Island")
+              .font(.system(size: 12, weight: .medium))
+            Text(store.islandMode == .desktop
+              ? "Quotas and live activity pinned to the desktop"
+              : "Show provider usage and activity status")
+              .font(.system(size: 10))
+              .foregroundStyle(.secondary)
+          }
+          Spacer()
+          Picker("", selection: Binding(
+            get: { store.islandMode },
+            set: { store.setIslandMode($0) }
+          )) {
+            ForEach(IslandMode.allCases) { mode in
+              Text(mode.label).tag(mode)
+            }
+          }
+          .pickerStyle(.segmented)
+          .labelsHidden()
+          .frame(width: 168)
+        }
+        .padding(.vertical, 2)
         settingRow(
           title: "Use without OpenAI login",
           detail: store.loginFree

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -116,17 +116,47 @@ final class RouterStore: ObservableObject {
     snapshot.targets["codex"]?.loginFree == true
   }
 
+  private static let providerShortNames: [String: String] = [
+    "grok-oauth": "Grok",
+    "kimi-oauth": "Kimi",
+    "deepseek": "DeepSeek",
+    "grok-api": "Grok API",
+    "kimi-api": "Kimi API",
+    "anthropic-api": "Claude",
+    "zai-coding": "GLM",
+    "qwen-plan": "Qwen",
+    "ollama-cloud": "Ollama",
+  ]
+
+  static func shortName(forRegistryProvider provider: RouterProviderInfo) -> String {
+    if let short = providerShortNames[provider.id] { return short }
+    let base = provider.displayName.split(separator: "(").first.map(String.init)
+      ?? provider.displayName
+    let trimmed = base.trimmingCharacters(in: .whitespaces)
+    return trimmed.count > 12 ? String(trimmed.prefix(12)) : trimmed
+  }
+
+  // Provider choices come from the router's registry snapshot so newly added
+  // providers appear without a tray update; the static list is only a
+  // fallback for routers that predate the snapshot's providers field.
   var usageProviderChoices: [UsageProviderChoice] {
-    let enabled = Set(snapshot.targets["codex"]?.enabledProviders ?? [])
-    return [
-      UsageProviderChoice(id: "openai", displayName: "ChatGPT", shortName: "ChatGPT", detail: "Codex subscription", isEnabled: true),
-      UsageProviderChoice(id: "grok-oauth", displayName: "Grok OAuth", shortName: "Grok", detail: providerDetail("grok-oauth", enabled: enabled), isEnabled: enabled.contains("grok-oauth")),
-      UsageProviderChoice(id: "kimi-oauth", displayName: "Kimi OAuth", shortName: "Kimi", detail: providerDetail("kimi-oauth", enabled: enabled), isEnabled: enabled.contains("kimi-oauth")),
-      UsageProviderChoice(id: "deepseek", displayName: "DeepSeek API", shortName: "DeepSeek", detail: providerDetail("deepseek", enabled: enabled), isEnabled: enabled.contains("deepseek")),
-      UsageProviderChoice(id: "grok-api", displayName: "Grok API", shortName: "Grok API", detail: providerDetail("grok-api", enabled: enabled), isEnabled: enabled.contains("grok-api")),
-      UsageProviderChoice(id: "kimi-api", displayName: "Kimi API", shortName: "Kimi API", detail: providerDetail("kimi-api", enabled: enabled), isEnabled: enabled.contains("kimi-api")),
-      UsageProviderChoice(id: "anthropic-api", displayName: "Anthropic API", shortName: "Claude", detail: providerDetail("anthropic-api", enabled: enabled), isEnabled: enabled.contains("anthropic-api")),
+    let target = snapshot.targets["codex"]
+    let enabled = Set(target?.enabledProviders ?? [])
+    let registryProviders = target?.providers ?? RouterProviderInfo.legacyFallback
+    var choices = [
+      UsageProviderChoice(
+        id: "openai", displayName: "ChatGPT", shortName: "ChatGPT",
+        detail: "Codex subscription", isEnabled: true),
     ]
+    for provider in registryProviders {
+      choices.append(UsageProviderChoice(
+        id: provider.id,
+        displayName: provider.displayName,
+        shortName: Self.shortName(forRegistryProvider: provider),
+        detail: providerDetail(provider.id, enabled: enabled),
+        isEnabled: enabled.contains(provider.id)))
+    }
+    return choices
   }
 
   var selectedUsageProvider: UsageProviderChoice {
@@ -935,6 +965,8 @@ struct ProviderAccountUsage: Decodable {
   let source: String
   let metrics: [ProviderAccountMetric]
   let message: String?
+  let plan: String?
+  let dashboardUrl: String?
 }
 
 struct ProviderAccountMetric: Decodable {
@@ -966,11 +998,27 @@ struct RouterTarget: Decodable {
   let configured: Bool
   let active: Bool
   let enabledProviders: [String]
+  let providers: [RouterProviderInfo]?
   let models: [RouterModel]
   let selectedModel: String?
   let loginFree: Bool?
   let loginFreeManaged: Bool?
   let nativeAliases: [String: String]?
+}
+
+struct RouterProviderInfo: Decodable {
+  let id: String
+  let displayName: String
+  let kind: String?
+
+  static let legacyFallback: [RouterProviderInfo] = [
+    .init(id: "grok-oauth", displayName: "Grok OAuth", kind: "oauth"),
+    .init(id: "kimi-oauth", displayName: "Kimi OAuth", kind: "oauth"),
+    .init(id: "deepseek", displayName: "DeepSeek API", kind: "openai-compatible"),
+    .init(id: "grok-api", displayName: "Grok API", kind: "openai-compatible"),
+    .init(id: "kimi-api", displayName: "Kimi API", kind: "openai-compatible"),
+    .init(id: "anthropic-api", displayName: "Anthropic API", kind: "openai-compatible"),
+  ]
 }
 
 struct RouterModel: Decodable, Identifiable {
@@ -1452,8 +1500,23 @@ private struct ProviderUsageSection: View {
           .foregroundStyle(routerMuted)
           .lineLimit(2)
       }
+
+      if let dashboardURL {
+        Button("Open usage dashboard") {
+          NSWorkspace.shared.open(dashboardURL)
+        }
+        .buttonStyle(.link)
+        .font(.system(size: 9))
+      }
     }
     .padding(.vertical, 2)
+  }
+
+  private var dashboardURL: URL? {
+    guard !store.selectedUsageUsesChatGPT,
+          let raw = store.selectedProviderUsage?.account.dashboardUrl
+    else { return nil }
+    return URL(string: raw)
   }
 
   private var sectionTitle: String {

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -82,7 +82,7 @@ async function emitProbe() {
     PROVIDER_SELECTION_PATH,
   } = await import("./paths.mjs");
   const { readProviderSelection } = await import("./provider-selection.mjs");
-  const { LISTED_MODELS } = await import("./model-registry.mjs");
+  const { LISTED_MODELS, PROVIDERS } = await import("./model-registry.mjs");
   const { readNativeAliases } = await import("./native-alias.mjs");
 
   const enabledProviders = readProviderSelection();
@@ -108,6 +108,11 @@ async function emitProbe() {
       configured: existsSync(PROVIDER_SELECTION_PATH),
       active: targetIsActive(TARGET),
       enabledProviders,
+      providers: [...PROVIDERS.values()].map((provider) => ({
+        id: provider.id,
+        displayName: provider.displayName,
+        kind: provider.kind,
+      })),
       models,
       ...(selectedModel ? { selectedModel } : {}),
       ...(codexConfig

--- a/src/provider-account-usage.mjs
+++ b/src/provider-account-usage.mjs
@@ -283,6 +283,92 @@ function localOnly(message) {
   return { status: "local-only", source: "local-router", metrics: [], message };
 }
 
+const ZAI_QUOTA_URL =
+  process.env.ZAI_QUOTA_URL || "https://api.z.ai/api/monitor/usage/quota/limit";
+const ZAI_PLAN_DASHBOARD_URL = "https://z.ai/manage-apikey/coding-plan/personal/my-plan";
+const QWEN_PLAN_DASHBOARD_URL =
+  "https://modelstudio.console.alibabacloud.com/ap-southeast-1/?tab=plan#/efm/subscription/token-plan";
+const OLLAMA_DASHBOARD_URL = "https://ollama.com/settings";
+
+function zaiWindowLabel(unit, number) {
+  if (unit === 6) return number === 1 ? "Weekly limit" : `${number}-week limit`;
+  if (unit === 1) return number === 1 ? "Daily limit" : `${number}-day limit`;
+  if (unit === 3) return number === 1 ? "Hourly limit" : `${number}-hour limit`;
+  if (unit === 5) return `${number}-minute limit`;
+  return undefined;
+}
+
+// Z.ai quota entries carry either explicit counters (usage = allowance,
+// currentValue = consumed) or a pre-computed percentage; counters win because
+// the percentage field is sometimes stale or zero.
+export function zaiQuotaMetrics(data) {
+  const metrics = [];
+  for (const raw of data?.limits || []) {
+    if (!raw || typeof raw !== "object") continue;
+    // A one-minute TIME_LIMIT entry is z.ai's MCP monthly marker, not a
+    // usable rate window.
+    if (raw.type === "TIME_LIMIT" && raw.unit === 5 && raw.number === 1) continue;
+    const allowance = numberValue(raw.usage);
+    const consumed = numberValue(raw.currentValue);
+    const computed =
+      allowance !== undefined && allowance > 0 && consumed !== undefined
+        ? (consumed / allowance) * 100
+        : undefined;
+    const percent = computed ?? numberValue(raw.percentage);
+    if (percent === undefined) continue;
+    const usedPercent = Math.min(100, Math.max(0, percent));
+    const label =
+      raw.type === "TOKENS_LIMIT" ? "Token quota" : zaiWindowLabel(raw.unit, raw.number);
+    if (!label) continue;
+    const metric = {
+      kind: "quota",
+      label,
+      usedPercent,
+      remainingPercent: 100 - usedPercent,
+      used: usedPercent,
+      limit: 100,
+      remaining: 100 - usedPercent,
+      unit: "percent",
+    };
+    const resetAt = numberValue(raw.nextResetTime);
+    if (resetAt !== undefined) metric.resetAt = resetAt / 1_000;
+    metrics.push(metric);
+  }
+  return metrics;
+}
+
+async function zaiCodingAccount(fetchImpl) {
+  const credential = resolveProviderCredential("zai-coding");
+  if (!credential) return { status: "not-configured", source: "official-api", metrics: [] };
+  const response = await fetchImpl(ZAI_QUOTA_URL, {
+    headers: {
+      Authorization: `Bearer ${credential.value}`,
+      "User-Agent": `codex-router/${VERSION}`,
+    },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload?.success !== true || payload?.code !== 200) {
+    throw new Error(
+      typeof payload?.msg === "string" && payload.msg
+        ? payload.msg
+        : `Z.ai quota API returned HTTP ${response.status}`,
+    );
+  }
+  const metrics = zaiQuotaMetrics(payload.data);
+  if (!metrics.length) throw new Error("Z.ai quota response was incomplete");
+  const account = {
+    status: "available",
+    source: "official-api",
+    metrics,
+    dashboardUrl: ZAI_PLAN_DASHBOARD_URL,
+  };
+  if (typeof payload.data?.planName === "string" && payload.data.planName) {
+    account.plan = payload.data.planName;
+  }
+  return account;
+}
+
 async function accountUsageFor(providerId, fetchImpl) {
   try {
     if (providerId === "deepseek") return await deepSeekAccount(fetchImpl);
@@ -297,6 +383,25 @@ async function accountUsageFor(providerId, fetchImpl) {
     if (providerId === "anthropic-api") {
       return resolveProviderCredential("anthropic-api")
         ? localOnly("Anthropic API account balance is unavailable; showing router traffic")
+        : { status: "not-configured", source: "official-api", metrics: [] };
+    }
+    if (providerId === "zai-coding") return await zaiCodingAccount(fetchImpl);
+    if (providerId === "qwen-plan") {
+      // Alibaba plan quotas are only visible behind a console session; never
+      // import browser cookies. Link to the console instead.
+      return resolveProviderCredential("qwen-plan")
+        ? {
+            ...localOnly("Alibaba shows plan quotas only in its console; showing router traffic"),
+            dashboardUrl: QWEN_PLAN_DASHBOARD_URL,
+          }
+        : { status: "not-configured", source: "official-api", metrics: [] };
+    }
+    if (providerId === "ollama-cloud") {
+      return resolveProviderCredential("ollama-cloud")
+        ? {
+            ...localOnly("Ollama shows account usage only on ollama.com; showing router traffic"),
+            dashboardUrl: OLLAMA_DASHBOARD_URL,
+          }
         : { status: "not-configured", source: "official-api", metrics: [] };
     }
     return localOnly("Showing router traffic");

--- a/src/provider-account-usage.mjs
+++ b/src/provider-account-usage.mjs
@@ -317,8 +317,13 @@ export function zaiQuotaMetrics(data) {
     const percent = computed ?? numberValue(raw.percentage);
     if (percent === undefined) continue;
     const usedPercent = Math.min(100, Math.max(0, percent));
+    const windowLabel = zaiWindowLabel(raw.unit, raw.number);
     const label =
-      raw.type === "TOKENS_LIMIT" ? "Token quota" : zaiWindowLabel(raw.unit, raw.number);
+      raw.type === "TOKENS_LIMIT"
+        ? windowLabel
+          ? windowLabel.replace(" limit", " tokens")
+          : "Token quota"
+        : windowLabel;
     if (!label) continue;
     const metric = {
       kind: "quota",

--- a/test/vendor-quota-adapters.test.mjs
+++ b/test/vendor-quota-adapters.test.mjs
@@ -109,7 +109,7 @@ test("normalizes z.ai time and token quota windows", () => {
     },
     {
       kind: "quota",
-      label: "Token quota",
+      label: "Daily tokens",
       usedPercent: 25,
       remainingPercent: 75,
       used: 25,
@@ -117,6 +117,21 @@ test("normalizes z.ai time and token quota windows", () => {
       remaining: 75,
       unit: "percent",
     },
+  ]);
+});
+
+test("z.ai token windows keep their window in the label", () => {
+  const metrics = zaiQuotaMetrics({
+    limits: [
+      { type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 1 },
+      { type: "TOKENS_LIMIT", unit: 6, number: 1, percentage: 8 },
+      { type: "TOKENS_LIMIT", unit: 0, number: 0, percentage: 12 },
+    ],
+  });
+  assert.deepEqual(metrics.map((metric) => metric.label), [
+    "5-hour tokens",
+    "Weekly tokens",
+    "Token quota",
   ]);
 });
 

--- a/test/vendor-quota-adapters.test.mjs
+++ b/test/vendor-quota-adapters.test.mjs
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "vendor-quota-state-"));
+const registryPath = path.join(stateDir, "registry.json");
+writeFileSync(registryPath, JSON.stringify({
+  version: 1,
+  providers: [
+    {
+      id: "zai-coding",
+      displayName: "Z.ai GLM Coding Plan",
+      kind: "openai-compatible",
+      ownedBy: "zai",
+      baseUrl: "https://api.z.ai/api/coding/paas/v4",
+      baseUrlEnv: "ZAI_CODING_BASE_URL",
+      credential: {
+        environment: ["ZAI_API_KEY"],
+        file: "zai-coding-api-key.secret",
+        prompt: "Z.ai GLM Coding Plan API key",
+      },
+    },
+    {
+      id: "qwen-plan",
+      displayName: "Qwen (Alibaba Plan)",
+      kind: "openai-compatible",
+      ownedBy: "alibaba",
+      baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+      baseUrlEnv: "QWEN_PLAN_BASE_URL",
+      credential: {
+        environment: ["QWEN_PLAN_API_KEY"],
+        file: "qwen-plan-api-key.secret",
+        prompt: "Alibaba Model Studio plan API key",
+      },
+    },
+    {
+      id: "ollama-cloud",
+      displayName: "Ollama Cloud",
+      kind: "openai-compatible",
+      ownedBy: "ollama",
+      baseUrl: "https://ollama.com/v1",
+      baseUrlEnv: "OLLAMA_CLOUD_BASE_URL",
+      credential: {
+        environment: ["OLLAMA_API_KEY"],
+        file: "ollama-cloud-api-key.secret",
+        prompt: "Ollama Cloud API key",
+      },
+    },
+  ],
+  models: [],
+}));
+process.env.CODEX_ROUTER_STATE_DIR = stateDir;
+process.env.CODEX_ROUTER_REGISTRY = registryPath;
+
+const {
+  providerAccountUsageSnapshot,
+  zaiQuotaMetrics,
+} = await import("../src/provider-account-usage.mjs");
+
+test("normalizes z.ai time and token quota windows", () => {
+  assert.deepEqual(zaiQuotaMetrics({
+    planName: "GLM Coding Pro",
+    limits: [
+      {
+        type: "TIME_LIMIT",
+        unit: 3,
+        number: 5,
+        usage: 100,
+        currentValue: 37,
+        remaining: 63,
+        percentage: 37,
+        nextResetTime: 1785258177000,
+      },
+      { type: "TIME_LIMIT", unit: 6, number: 1, percentage: 52 },
+      {
+        type: "TOKENS_LIMIT",
+        unit: 1,
+        number: 1,
+        usage: 4000000,
+        currentValue: 1000000,
+        remaining: 3000000,
+        percentage: 0,
+      },
+      { type: "TIME_LIMIT", unit: 5, number: 1, percentage: 88 },
+    ],
+  }), [
+    {
+      kind: "quota",
+      label: "5-hour limit",
+      usedPercent: 37,
+      remainingPercent: 63,
+      used: 37,
+      limit: 100,
+      remaining: 63,
+      unit: "percent",
+      resetAt: 1785258177,
+    },
+    {
+      kind: "quota",
+      label: "Weekly limit",
+      usedPercent: 52,
+      remainingPercent: 48,
+      used: 52,
+      limit: 100,
+      remaining: 48,
+      unit: "percent",
+    },
+    {
+      kind: "quota",
+      label: "Token quota",
+      usedPercent: 25,
+      remainingPercent: 75,
+      used: 25,
+      limit: 100,
+      remaining: 75,
+      unit: "percent",
+    },
+  ]);
+});
+
+test("z.ai account fetch uses the stored plan key and quota endpoint", async () => {
+  writeFileSync(path.join(stateDir, "zai-coding-api-key.secret"), "TEST_ZAI_QUOTA_KEY\n", {
+    mode: 0o600,
+  });
+  const requests = [];
+  const snapshot = await providerAccountUsageSnapshot({
+    providerIds: ["zai-coding"],
+    fetchImpl: async (url, options) => {
+      requests.push({ url: String(url), auth: options?.headers?.Authorization });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          code: 200,
+          success: true,
+          data: {
+            planName: "GLM Coding Pro",
+            limits: [
+              { type: "TIME_LIMIT", unit: 3, number: 5, percentage: 41, nextResetTime: 1785258177000 },
+            ],
+          },
+        }),
+      };
+    },
+  });
+  assert.equal(requests.length, 1);
+  assert.ok(requests[0].url.includes("api.z.ai/api/monitor/usage/quota/limit"));
+  assert.equal(requests[0].auth, "Bearer TEST_ZAI_QUOTA_KEY");
+  const account = snapshot["zai-coding"];
+  assert.equal(account.status, "available");
+  assert.equal(account.plan, "GLM Coding Pro");
+  assert.equal(account.metrics[0].label, "5-hour limit");
+  assert.equal(account.metrics[0].usedPercent, 41);
+  assert.ok(account.dashboardUrl.startsWith("https://z.ai/"));
+});
+
+test("qwen and ollama stay local-only but carry a dashboard link", async () => {
+  writeFileSync(path.join(stateDir, "qwen-plan-api-key.secret"), "TEST_QWEN_QUOTA_KEY\n", {
+    mode: 0o600,
+  });
+  const snapshot = await providerAccountUsageSnapshot({
+    providerIds: ["qwen-plan", "ollama-cloud"],
+    fetchImpl: async () => {
+      throw new Error("local-only providers must not reach the network");
+    },
+  });
+  assert.equal(snapshot["qwen-plan"].status, "local-only");
+  assert.ok(snapshot["qwen-plan"].dashboardUrl.includes("modelstudio.console.alibabacloud.com"));
+  assert.equal(snapshot["ollama-cloud"].status, "not-configured");
+  assert.equal(snapshot["ollama-cloud"].dashboardUrl, undefined);
+});


### PR DESCRIPTION
**Builds on #19** (uses its registry-driven provider choices and quota payloads; the [last commit](https://github.com/duolahypercho/codex-router/pull/21/commits) is this PR's change).

## What

The Dynamic Island toggle becomes a three-way mode — **Off / Notch / Desktop** (segmented control in the tray; the old boolean setting migrates):

- **Desktop** pins a draggable, widget-style panel just above the desktop icons (`CGWindowLevelForKey(.desktopIconWindow) + 1`) — always readable on the desktop, never covering application windows, position remembered via frame autosave.
- Content: live activity header (Thinking Orb, state, concurrent session list), a **quota section with one bar per vendor quota window** across every connected provider — ChatGPT's rate-limit windows plus each provider's account quota metrics (e.g. Grok weekly, Z.ai 5-hour/weekly token windows from #18) — tinted green/amber/red by utilization with reset countdowns, and the 7-day token trend chart.
- Reuses the Island's existing components (orb, request list, line chart) and the store's 30 s/350 ms polling — data is live, unlike WidgetKit's ~5-minute refresh floor, which is why this is a panel rather than an app-extension widget.

## Verification

Swift package builds clean (Xcode 26.6). Verified live: panel shows ChatGPT weekly, Grok weekly, and Z.ai 5-hour + weekly token bars with resets, follows generation activity in real time, drags and restores position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
