### PR TITLE
Don't enter the error state when the client cancels a request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Canceling a generation (or any client disconnect mid-request) no longer
+  flips router health into the eight-second error state, so tray and island
+  status indicators stop flashing red on ordinary cancels. Errors the router
+  or an upstream actually produced still surface.
 - Added a reversible tray toggle that lets signed-out Codex CLI/App sessions
   use connected external providers through a managed custom model provider,
   while preserving ChatGPT credentials and restoring the prior provider mode.

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -521,6 +521,7 @@ function requireCodexTransport(request, response) {
 async function handleResponses(request, response, requestUrl) {
   const startedAt = Date.now();
   const activity = beginRequestActivity();
+  let clientGone = false;
   try {
     if (!requireCodexTransport(request, response)) return;
     const encoded = await readRequestBody(request);
@@ -555,9 +556,15 @@ async function handleResponses(request, response, requestUrl) {
       payload.input.at(-1)?.type === "compaction_trigger";
 
     const controller = new AbortController();
-    request.once("aborted", () => controller.abort());
+    request.once("aborted", () => {
+      clientGone = true;
+      controller.abort();
+    });
     response.once("close", () => {
-      if (!response.writableEnded) controller.abort();
+      if (!response.writableEnded) {
+        clientGone = true;
+        controller.abort();
+      }
     });
 
     if (route && (compactV1 || compactV2)) {
@@ -612,6 +619,12 @@ async function handleResponses(request, response, requestUrl) {
       );
     }
   } catch (error) {
+    // A client that walked away (canceled generation, closed stream) is not
+    // a router failure; only surface errors the router or upstream produced.
+    if (clientGone) {
+      activity.finish(0);
+      return;
+    }
     activity.finish(500);
     throw error;
   } finally {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -324,6 +324,58 @@ test("router requires the configured path capability before any model route", as
   }
 });
 
+test("a canceled request does not flip activity into the error state", async () => {
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      json(response, 200, { ok: true, credential_present: true });
+      return;
+    }
+    const body = await bodyJson(request);
+    if (body.input === "hang") {
+      // Hold the request open until the router aborts it, then finish so the
+      // mock server can close cleanly.
+      await new Promise((resolve) => {
+        request.once("close", resolve);
+        response.once("close", resolve);
+      });
+      return;
+    }
+    json(response, 200, { route: "external" });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const canceler = new AbortController();
+    const held = fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "deepseek/deepseek-v4-pro", input: "hang" }),
+      signal: canceler.signal,
+    }).catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    canceler.abort();
+    await held;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    const health = await fetch(`http://127.0.0.1:${routerPort}/health`);
+    const payload = await health.json();
+    assert.equal(payload.activity.state, "idle");
+    assert.equal(payload.activity.activeCount, 0);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 test("router refuses a known model whose provider is hidden", async () => {
   const gatewayRequests = [];
   const gateway = await mockServer(async (request, response) => {


### PR DESCRIPTION
Standalone against main.

## Problem

`handleResponses` wraps every model request in the activity tracker, and its catch path recorded any thrown error as `finish(500)`. A client that cancels a generation (or otherwise disconnects mid-request) aborts the upstream fetch via the existing listeners, the abort throws, and router health reports `state: "error"` for eight seconds. Status UIs (menu-bar beacon, Island) flash red on every ordinary cancel — easily mistaken for the router losing its connection, and especially visible with the always-on desktop panel.

## Change

Client departure is tracked with an explicit flag set by the same `request aborted`/`response close` listeners that already abort the upstream request. When the client is gone, the request finishes with no error mark and no response attempt. Real failures — upstream errors, transport-validation rejections like the 415 path — still set the error state.

(First attempt keyed on `request.destroyed`, which is true for any fully-read request body on Node 22 and silently swallowed genuine error responses; the flag approach avoids that, and the previously hanging capability test guards it.)

## Verification

New test: cancel a routed request mid-flight, assert `/health` reports `idle` with zero active requests (fails with `actual: "error"` before the fix). Full suite green — 120 tests, 0 failures — including the existing assertion that a 415 transport rejection still surfaces as an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)