### PR TITLE
fix: Windows CI — use POSIX join for the macOS tray bundle path

### DIFF
--- a/src/tray-install.mjs
+++ b/src/tray-install.mjs
@@ -13,5 +13,8 @@ export function trayDecision({ platform, withTray, noTray, guided }) {
 
 export function trayBundleDir(platform, home) {
   if (platform !== "darwin") return undefined;
-  return path.join(home, "Applications", "Model Router.app");
+  // Always a macOS path, so use POSIX joins — path.join would emit backslashes
+  // when this code runs on a Windows host (e.g. CI), producing a wrong bundle
+  // path and breaking the test cross-platform.
+  return path.posix.join(home, "Applications", "Model Router.app");
 }

--- a/test/tray-install.test.mjs
+++ b/test/tray-install.test.mjs
@@ -49,6 +49,13 @@ test("trayBundleDir places the macOS bundle in the user's Applications folder", 
   );
 });
 
+test("trayBundleDir uses forward slashes regardless of the host OS", () => {
+  // A macOS bundle path must never contain backslashes even when the tooling
+  // runs on Windows (CI); guards the path.posix join.
+  const result = trayBundleDir("darwin", "/Users/example");
+  assert.ok(!result.includes("\\"), `expected no backslashes in ${result}`);
+});
+
 test("trayBundleDir is undefined on other platforms", () => {
   assert.equal(trayBundleDir("linux", "/home/example"), undefined);
 });


### PR DESCRIPTION
Follow-up bugfix to #16, which merged with the Windows `test` job failing. `main` currently has a red Windows check because of this.

## Problem

`trayBundleDir` builds the macOS companion-app bundle path with `path.join(home, "Applications", "Model Router.app")`. On a Windows host (the `test (windows-latest)` CI job), `path.join` uses backslash separators, so the function returns `…\Applications\Model Router.app` and the test — which expects the forward-slash macOS path — fails. The value is only ever used on macOS, so the host OS should not affect it.

## Fix

Use `path.posix.join`, which always emits forward slashes. Output is byte-identical on macOS/Linux (already green) and now correct on Windows. Added a regression test asserting the result never contains a backslash.

## Verification

`node --test test/tray-install.test.mjs` green (8 tests), `npm run check` clean. The fix is host-independent by construction, so it resolves the Windows job without needing a Windows runner locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)