### PR TITLE
Fix Codex Voice routing through native realtime endpoints

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -225,6 +225,16 @@ This is expected. Codex Router declines the optional Responses WebSocket
 upgrade, and current Codex falls back to compressed HTTP. A warning alone is not
 a failed model request.
 
+## Voice Mode reports an unsupported `/v1/live` route
+
+Codex Voice uses native realtime endpoints that are separate from the Responses
+API. Current installs keep the WebRTC call and its sideband WebSocket on Codex's
+native endpoints instead of sending them through the Responses-only router.
+
+Run `./bin/enable` again after updating, fully quit Codex, and reopen it so the
+managed realtime overrides take effect. User-owned realtime endpoint overrides
+are preserved.
+
 ## Uninstall retained files
 
 This is intentional. `./bin/uninstall` removes only the active integration and

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -36,6 +36,10 @@ const endMarker = "# END codex-router-managed";
 const providerStartMarker = "# BEGIN codex-router-provider-managed";
 const providerEndMarker = "# END codex-router-provider-managed";
 const routerProviderId = "codex-router";
+const defaultChatgptBaseUrl = "https://chatgpt.com/backend-api";
+const defaultRealtimeWebsocketBaseUrl = "https://api.openai.com/v1";
+const realtimeCallBaseUrlKey = "experimental_realtime_webrtc_call_base_url";
+const realtimeWebsocketBaseUrlKey = "experimental_realtime_ws_base_url";
 const markerPairs = [
   [startMarker, endMarker],
   [providerStartMarker, providerEndMarker],
@@ -124,6 +128,15 @@ function rootValue(lines, key) {
 
 function rootHasValue(lines, key) {
   return lines.some((line) => new RegExp(`^\\s*${key}\\s*=`).test(line));
+}
+
+function nativeRealtimeCallBaseUrl(lines) {
+  const chatgptBaseUrl = (
+    rootValue(lines, "chatgpt_base_url") || defaultChatgptBaseUrl
+  ).replace(/\/+$/, "");
+  return chatgptBaseUrl.endsWith("/codex")
+    ? chatgptBaseUrl
+    : `${chatgptBaseUrl}/codex`;
 }
 
 function replaceRootValue(contents, key, value) {
@@ -314,11 +327,25 @@ function enabledContents(contents) {
   if (existingCatalog && existingCatalog !== MERGED_CATALOG_PATH) {
     throw new Error(`Refusing to replace user-owned model_catalog_json: ${existingCatalog}`);
   }
+  const managedRealtimeOverrides = [];
+  // Codex Voice uses a WebRTC call plus a sideband WebSocket. Keep both on
+  // Codex's native endpoints instead of inheriting the Responses-only router URL.
+  if (!rootHasValue(rootLines, realtimeCallBaseUrlKey)) {
+    managedRealtimeOverrides.push(
+      `${realtimeCallBaseUrlKey} = ${JSON.stringify(nativeRealtimeCallBaseUrl(rootLines))}`,
+    );
+  }
+  if (!rootHasValue(rootLines, realtimeWebsocketBaseUrlKey)) {
+    managedRealtimeOverrides.push(
+      `${realtimeWebsocketBaseUrlKey} = ${JSON.stringify(defaultRealtimeWebsocketBaseUrl)}`,
+    );
+  }
   rootLines.push(
     "",
     startMarker,
     `openai_base_url = ${JSON.stringify(routerBaseUrl)}`,
     `model_catalog_json = ${JSON.stringify(MERGED_CATALOG_PATH)}`,
+    ...managedRealtimeOverrides,
     endMarker,
   );
   const tableLines = trimBlankEdges(cleaned.tableLines);

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -79,6 +79,14 @@ approval_policy = "never"
         `openai_base_url = "http://127.0.0.1:46192/_codex-router/${CALLER_KEY}/v1"`,
       ),
     );
+    assert.match(
+      configured,
+      /^experimental_realtime_webrtc_call_base_url = "https:\/\/chatgpt\.com\/backend-api\/codex"$/m,
+    );
+    assert.match(
+      configured,
+      /^experimental_realtime_ws_base_url = "https:\/\/api\.openai\.com\/v1"$/m,
+    );
     assert.match(configured, /model_reasoning_effort = "xhigh"/);
     assert.match(configured, /\[profiles\.work\]/);
     assert.match(configured, /approval_policy = "never"/);
@@ -106,12 +114,71 @@ approval_policy = "never"
     const restored = readFileSync(configPath, "utf8");
     assert.doesNotMatch(
       restored,
-      /codex-router-(?:provider-)?managed|openai_base_url|model_catalog_json/,
+      /codex-router-(?:provider-)?managed|openai_base_url|model_catalog_json|experimental_realtime_(?:webrtc_call|ws)_base_url/,
     );
     assert.match(restored, /model = "gpt-5\.6-sol"/);
     assert.match(restored, /model_provider = "openai"/);
     assert.match(restored, /model_reasoning_effort = "xhigh"/);
     assert.match(restored, /\[profiles\.work\]/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager preserves user-owned realtime endpoints", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-realtime-"));
+  const configPath = path.join(codexHome, "config.toml");
+  const original = `experimental_realtime_webrtc_call_base_url = "https://voice.example/calls"
+experimental_realtime_ws_base_url = "wss://voice.example/live"
+chatgpt_base_url = "https://chat.example/backend-api/"
+`;
+  writeFileSync(configPath, original, { mode: 0o600 });
+
+  try {
+    run("enable", codexHome);
+    const enabled = readFileSync(configPath, "utf8");
+    assert.equal(
+      (enabled.match(/^experimental_realtime_webrtc_call_base_url\s*=/gm) || []).length,
+      1,
+    );
+    assert.equal(
+      (enabled.match(/^experimental_realtime_ws_base_url\s*=/gm) || []).length,
+      1,
+    );
+    assert.match(enabled, /experimental_realtime_webrtc_call_base_url = "https:\/\/voice\.example\/calls"/);
+    assert.match(enabled, /experimental_realtime_ws_base_url = "wss:\/\/voice\.example\/live"/);
+
+    run("disable", codexHome);
+    assert.equal(readFileSync(configPath, "utf8"), original);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager derives native Voice calls from a custom ChatGPT base URL", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-voice-base-"));
+  const configPath = path.join(codexHome, "config.toml");
+  writeFileSync(
+    configPath,
+    `chatgpt_base_url = "https://chat.example/backend-api/"
+`,
+    { mode: 0o600 },
+  );
+
+  try {
+    run("enable", codexHome);
+    const enabled = readFileSync(configPath, "utf8");
+    assert.match(
+      enabled,
+      /^experimental_realtime_webrtc_call_base_url = "https:\/\/chat\.example\/backend-api\/codex"$/m,
+    );
+
+    run("disable", codexHome);
+    assert.equal(
+      readFileSync(configPath, "utf8"),
+      `chatgpt_base_url = "https://chat.example/backend-api/"
+`,
+    );
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- keep Codex Voice WebRTC call creation on the native ChatGPT backend
- keep the Voice sideband WebSocket on OpenAI's native realtime endpoint
- preserve user-owned realtime endpoint overrides and custom ChatGPT base URLs
- document the update/re-enable workflow for existing installations

## Root cause

Codex Router manages `openai_base_url` so Responses API traffic can be dispatched between native and external models. The new Voice flow inherited that Responses-only router URL for its separate realtime transports, causing WebRTC call creation to request `/v1/live` from a router that does not implement the endpoint.

The managed configuration now supplies transport-specific native realtime endpoints. Normal model inference continues through Codex Router, while Voice avoids the incompatible Responses-only route.

## Validation

- `npm run check`
- `node --test test/config-manager.test.mjs` — 13 passed
- `npm test` — 165 passed, 2 skipped

Fixes #24
