### PR TITLE
Add MiniMax Token Plan support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Linux installations support the Codex CLI and the Cursor target's local gateway.
 | Kimi K2.7 Code (Ollama Cloud) | `ollama-cloud/kimi-k2.7-code` | Ollama Cloud API key |
 | MiniMax M3 (Ollama Cloud) | `ollama-cloud/minimax-m3` | Ollama Cloud API key |
 | DeepSeek V4 Pro (Ollama Cloud) | `ollama-cloud/deepseek-v4-pro` | Ollama Cloud API key |
+| MiniMax M3 | `minimax-token-plan/minimax-m3` | MiniMax Token Plan API key |
 | Qwen3.7 Max (Plan) | `qwen-plan/qwen3.7-max` | Alibaba Model Studio plan API key |
 | Qwen3.7 Plus (Plan) | `qwen-plan/qwen3.7-plus` | Alibaba Model Studio plan API key |
 | GLM-5.2 (Coding Plan) | `zai-coding/glm-5.2` | Z.ai GLM Coding Plan API key |

--- a/config/providers.json
+++ b/config/providers.json
@@ -156,6 +156,26 @@
         ],
         "prompt": "Ollama Cloud API key"
       }
+    },
+    {
+      "id": "minimax-token-plan",
+      "displayName": "MiniMax Token Plan",
+      "kind": "openai-compatible",
+      "ownedBy": "minimax",
+      "baseUrl": "https://api.minimax.io/v1",
+      "baseUrlEnv": "MINIMAX_BASE_URL",
+      "credential": {
+        "environment": [
+          "MINIMAX_API_KEY",
+          "MINIMAX_TOKEN_PLAN_API_KEY"
+        ],
+        "file": "minimax-token-plan-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-minimax-token-plan"
+        ],
+        "prompt": "MiniMax Token Plan API key"
+      }
     }
   ],
   "models": [
@@ -629,6 +649,31 @@
       ],
       "requestProfile": "ollama-cloud",
       "compHash": "ollama-cloud-deepseek-v4-pro-v1"
+    },
+    {
+      "slug": "minimax-token-plan/minimax-m3",
+      "gatewayModel": "minimax-token-plan-minimax-m3",
+      "upstreamModel": "MiniMax-M3",
+      "provider": "minimax-token-plan",
+      "listed": true,
+      "displayName": "MiniMax M3",
+      "description": "MiniMax M3 using a MiniMax Token Plan API key.",
+      "priority": 18,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "high",
+          "description": "Adaptive reasoning for agentic coding"
+        }
+      ],
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "requestProfile": "minimax-m3",
+      "compHash": "minimax-token-plan-minimax-m3-v1"
     }
   ]
 }

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -134,6 +134,11 @@ function normalizeBody(buffer, contentType, route) {
     delete payload.reasoning_effort;
     payload.thinking = { type: "adaptive" };
     payload.output_config = { effort: "high" };
+  } else if (model.requestProfile === "minimax-m3") {
+    // MiniMax uses its own thinking control on the OpenAI-compatible
+    // Chat Completions endpoint instead of reasoning_effort.
+    delete payload.reasoning_effort;
+    payload.thinking = { type: "adaptive" };
   }
   return { body: Buffer.from(JSON.stringify(payload), "utf8"), model, provider };
 }

--- a/test/provider-onboarding.test.mjs
+++ b/test/provider-onboarding.test.mjs
@@ -38,6 +38,8 @@ function isolatedEnvironment(testRoot) {
     KIMI_API_KEY: "",
     MOONSHOT_API_KEY: "",
     DEEPSEEK_API_KEY: "",
+    MINIMAX_API_KEY: "",
+    MINIMAX_TOKEN_PLAN_API_KEY: "",
     XAI_API_KEY: "",
     GROK_API_KEY: "",
     ANTHROPIC_API_KEY: "",
@@ -60,6 +62,7 @@ test("provider onboarding reports install, login, and API key actions without se
     assert.equal(byId["kimi-api"].action, "add-key");
     assert.equal(byId["grok-api"].action, "add-key");
     assert.equal(byId["anthropic-api"].action, "add-key");
+    assert.equal(byId["minimax-token-plan"].action, "add-key");
     assert.equal("source" in byId["kimi-api"], false);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -9,7 +9,7 @@ process.env.CODEX_HOME = path.join(testRoot, "codex");
 process.env.CODEX_ROUTER_STATE_DIR = path.join(testRoot, "state");
 process.env.KIMI_CODE_HOME = path.join(testRoot, "kimi-code");
 process.env.GROK_AUTH_PATH = path.join(testRoot, "grok", "auth.json");
-for (const name of ["ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY", "KIMI_API_KEY", "MOONSHOT_API_KEY", "XAI_API_KEY", "GROK_API_KEY"]) {
+for (const name of ["ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY", "KIMI_API_KEY", "MINIMAX_API_KEY", "MINIMAX_TOKEN_PLAN_API_KEY", "MOONSHOT_API_KEY", "XAI_API_KEY", "GROK_API_KEY"]) {
   delete process.env[name];
 }
 
@@ -38,6 +38,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
       "zai-coding",
       "qwen-plan",
       "ollama-cloud",
+      "minimax-token-plan",
     ]);
     process.env.KIMI_API_KEY = "TEST_ENVIRONMENT_ONLY_KEY";
     assert.deepEqual(configuredProviderIds(), []);

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -31,6 +31,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "ollama-cloud/kimi-k2.7-code",
       "ollama-cloud/minimax-m3",
       "ollama-cloud/deepseek-v4-pro",
+      "minimax-token-plan/minimax-m3",
     ],
   );
   assert.equal(PROVIDERS.get("deepseek").baseUrl, "https://api.deepseek.com");
@@ -43,6 +44,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
     "https://api.z.ai/api/coding/paas/v4",
   );
   assert.equal(PROVIDERS.get("ollama-cloud").baseUrl, "https://ollama.com/v1");
+  assert.equal(PROVIDERS.get("minimax-token-plan").baseUrl, "https://api.minimax.io/v1");
   assert.equal(PROVIDERS.get("grok-api").baseUrl, "https://api.x.ai/v1");
   assert.equal(PROVIDERS.get("grok-oauth").proxyBaseEnv, "GROK_OAUTH_FORWARD_BASE_URL");
   assert.equal(PROVIDERS.get("anthropic-api").protocol, "anthropic");
@@ -56,6 +58,10 @@ test("provider registry exposes configured API and OAuth model families", () => 
       { effort: "high", description: "Always-on coding reasoning" },
     ]);
   }
+  const minimax = MODEL_BY_SLUG.get("minimax-token-plan/minimax-m3");
+  assert.equal(minimax.contextWindow, 1_000_000);
+  assert.equal(minimax.autoCompact, 900_000);
+  assert.deepEqual(minimax.inputModalities, ["text", "image"]);
   assert.deepEqual(
     MODEL_BY_SLUG.get("anthropic-api/claude-opus-4.8").reasoningLevels,
     [{ effort: "high", description: "Adaptive deep reasoning for agentic work" }],

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -904,6 +904,84 @@ test("API forwarder routes Qwen plan models without unsupported parameters", asy
 });
 
 
+test("API forwarder routes MiniMax M3 streaming tool calls with adaptive thinking", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({
+      url: request.url,
+      headers: request.headers,
+      body: await bodyJson(request),
+    });
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(
+      'data: {"choices":[{"delta":{"tool_calls":[{"function":{"arguments":"{\\"city\\":\\"Berlin\\"}"}}]}}]}\n\ndata: [DONE]\n\n',
+    );
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    MINIMAX_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    MINIMAX_API_KEY: "TEST_MINIMAX_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "ChatGPT-Account-Id": "must-not-forward",
+          "X-Codex-Installation-Id": "must-not-forward",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "minimax-token-plan-minimax-m3",
+          reasoning_effort: "high",
+          stream: true,
+          messages: [{ role: "user", content: "What is the weather?" }],
+          tools: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                parameters: {
+                  type: "object",
+                  properties: { city: { type: "string" } },
+                  required: ["city"],
+                },
+              },
+            },
+          ],
+        }),
+      },
+    );
+
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /text\/event-stream/);
+    assert.match(await response.text(), /\\"city\\":\\"Berlin\\"/);
+    const request = upstreamRequests[0];
+    assert.equal(request.url, "/v1/chat/completions");
+    assert.equal(request.headers.authorization, "Bearer TEST_MINIMAX_API_KEY");
+    assert.equal(request.headers["chatgpt-account-id"], undefined);
+    assert.equal(request.headers["x-codex-installation-id"], undefined);
+    assert.equal(request.body.model, "MiniMax-M3");
+    assert.equal(request.body.stream, true);
+    assert.equal(request.body.reasoning_effort, undefined);
+    assert.deepEqual(request.body.thinking, { type: "adaptive" });
+    assert.equal(request.body.tools[0].function.name, "get_weather");
+    assert.deepEqual(request.body.tools[0].function.parameters.required, ["city"]);
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
+
 test("API forwarder routes GLM coding-plan models with thinking enabled", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {

--- a/test/setup.test.mjs
+++ b/test/setup.test.mjs
@@ -35,6 +35,8 @@ test("automatic selection-only setup exposes only configured providers", () => {
           DEEPSEEK_API_KEY: "",
           KIMI_API_KEY: "",
           MOONSHOT_API_KEY: "",
+          MINIMAX_API_KEY: "",
+          MINIMAX_TOKEN_PLAN_API_KEY: "",
           XAI_API_KEY: "",
           GROK_API_KEY: "",
         },


### PR DESCRIPTION
## Summary

- add MiniMax Token Plan as an OpenAI-compatible provider
- expose MiniMax M3 with its documented 1M-token context window and text/image inputs
- translate Codex reasoning requests to MiniMax adaptive thinking
- cover credential onboarding, provider selection, registry metadata, streaming, and tool-call forwarding

## Why

MiniMax M3 is not currently available as a direct provider even though MiniMax documents an OpenAI-compatible API suitable for Codex routing. The provider uses the official international endpoint and keeps credentials in the router's existing protected credential store.

Fixes #20.

Official references:
- https://platform.minimax.io/docs/api-reference/text-openai-api
- https://platform.minimax.io/docs/guides/text-generation

## Validation

- `npm run check`
- focused provider/registry/setup/routing tests: 24 passed
- `npm test`: 164 passed, 2 skipped
- `git diff --check`
- staged additions scanned for common credential signatures; no matches

A local MiniMax M3 smoke test was reported successful. No real API key or credential file is included in this branch.