### PR TITLE
Support native Codex voice passthrough

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -221,6 +221,23 @@ function nativeHeaders(request) {
   return headers;
 }
 
+function nativeLiveHeaders(request) {
+  const headers = nativeHeaders(request);
+  const contentType = request.headers["content-type"];
+  if (contentType !== undefined) {
+    headers["Content-Type"] = Array.isArray(contentType)
+      ? contentType.join(", ")
+      : contentType;
+  }
+  for (const name of ["accept", "content-encoding"]) {
+    const value = request.headers[name];
+    if (value !== undefined) {
+      headers[name] = Array.isArray(value) ? value.join(", ") : value;
+    }
+  }
+  return headers;
+}
+
 function routedHeaders() {
   return {
     Authorization: `Bearer ${INTERNAL_KEY}`,
@@ -632,6 +649,55 @@ async function handleResponses(request, response, requestUrl) {
   }
 }
 
+async function handleNativeLive(request, response, requestUrl) {
+  const activity = beginRequestActivity();
+  let clientGone = false;
+  try {
+    if (request.headers.origin || request.headers["sec-fetch-site"]) {
+      writeJson(response, 403, {
+        error: {
+          type: "browser_request_rejected",
+          message: "Browser-originated requests are not accepted by the local model router.",
+        },
+      });
+      return;
+    }
+    const body = await readRequestBody(request);
+    activity.setRoute({
+      provider: "openai",
+      model: "voice",
+      sessionName: sessionNameFromHeaders(request.headers),
+    });
+    const controller = new AbortController();
+    request.once("aborted", () => {
+      clientGone = true;
+      controller.abort();
+    });
+    response.once("close", () => {
+      if (!response.writableEnded) {
+        clientGone = true;
+        controller.abort();
+      }
+    });
+    const upstream = await fetch(nativeTarget(requestUrl.pathname, requestUrl.search), {
+      method: "POST",
+      headers: nativeLiveHeaders(request),
+      body,
+      signal: controller.signal,
+    });
+    await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS);
+  } catch (error) {
+    if (clientGone) {
+      activity.finish(0);
+      return;
+    }
+    activity.finish(500);
+    throw error;
+  } finally {
+    activity.finish(response.statusCode);
+  }
+}
+
 async function handleRequest(request, response) {
   const requestUrl = new URL(
     request.url || "/",
@@ -684,6 +750,13 @@ async function handleRequest(request, response) {
     )
   ) {
     await handleResponses(request, response, requestUrl);
+    return;
+  }
+  if (
+    request.method === "POST" &&
+    ["/live", "/v1/live"].includes(requestUrl.pathname)
+  ) {
+    await handleNativeLive(request, response, requestUrl);
     return;
   }
   writeJson(response, 404, {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -549,6 +549,80 @@ test("router preserves native auth and isolates every external route", async () 
   }
 });
 
+test("router passes live voice directly to native OpenAI without affecting Kimi", async () => {
+  const nativeRequests = [];
+  const routedRequests = [];
+  const native = await mockServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    nativeRequests.push({
+      url: request.url,
+      headers: request.headers,
+      body: Buffer.concat(chunks).toString("utf8"),
+    });
+    response.writeHead(200, { "Content-Type": "application/sdp" });
+    response.write("answer-");
+    response.end("sdp");
+  });
+  const gateway = await mockServer(async (request, response) => {
+    routedRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { route: "external" });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const unauthenticated = await fetch(`http://127.0.0.1:${routerPort}/v1/live`, {
+      method: "POST",
+      headers: { "Content-Type": "application/sdp" },
+      body: "blocked-offer",
+    });
+    assert.equal(unauthenticated.status, 401);
+
+    const live = await fetch(`${routerBase(routerPort)}/live?channels=1`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "ChatGPT-Account-Id": "account-secret",
+        "Content-Type": "application/sdp",
+        Accept: "application/sdp",
+        "X-Private-Header": "must-not-forward",
+      },
+      body: "offer-sdp",
+    });
+    assert.equal(live.status, 200);
+    assert.equal(live.headers.get("content-type"), "application/sdp");
+    assert.equal(await live.text(), "answer-sdp");
+    assert.equal(nativeRequests.length, 1);
+    assert.equal(nativeRequests[0].url, "/backend-api/codex/live?channels=1");
+    assert.equal(nativeRequests[0].headers.authorization, "Bearer CODEX_CALLER_SECRET");
+    assert.equal(nativeRequests[0].headers["chatgpt-account-id"], "account-secret");
+    assert.equal(nativeRequests[0].headers["content-type"], "application/sdp");
+    assert.equal(nativeRequests[0].headers.accept, "application/sdp");
+    assert.equal(nativeRequests[0].headers["x-private-header"], undefined);
+    assert.equal(nativeRequests[0].body, "offer-sdp");
+    assert.equal(routedRequests.length, 0);
+
+    const kimi = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "kimi-oauth/k3", input: "keep routing" }),
+    });
+    assert.equal(kimi.status, 200);
+    assert.equal(routedRequests.length, 1);
+    assert.equal(routedRequests[0].body.model, "kimi-oauth-k3");
+  } finally {
+    await stopChild(router);
+    await Promise.all([closeServer(native.server), closeServer(gateway.server)]);
+  }
+});
+
 test("router synthesizes routed compaction and safely replays it to native models", async () => {
   const gatewayRequests = [];
   const gateway = await mockServer(async (request, response) => {


### PR DESCRIPTION
## Summary
- pass `/v1/live` directly to the native Codex backend
- preserve voice request content negotiation and native OpenAI authentication
- keep external model routing, including Kimi K3, isolated to Responses routes

## Verification
- `npm run check`
- `npm test` (164 passed, 2 skipped)