### PR TITLE
Fix unhandled ECONNRESET crash on upgrade rejection

### DIFF
--- a/src/cursor-router.mjs
+++ b/src/cursor-router.mjs
@@ -327,6 +327,7 @@ const server = http.createServer((request, response) => {
 });
 
 server.on("upgrade", (_request, socket) => {
+  socket.on("error", () => {});
   socket.end(
     "HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
   );

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -709,6 +709,7 @@ const server = http.createServer((request, response) => {
 });
 
 server.on("upgrade", (_request, socket) => {
+  socket.on("error", () => {});
   socket.end(
     "HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
   );


### PR DESCRIPTION
## Summary
- `server.on("upgrade", ...)` in both `src/router.mjs` and `src/cursor-router.mjs` calls `socket.end(...)` to reject the upgrade with a 426, but never attaches an `error` listener to that socket first.
- If the peer has already reset the connection by the time this fires, the write throws `ECONNRESET`. With no listener on the socket's `error` event, Node treats it as an unhandled exception and kills the entire process — not just that connection, but every other in-flight request the router/gateway was serving at the time.

Observed crash:
```
node:events:486
      throw er; // Unhandled 'error' event
      ^

Error: write ECONNRESET
    at afterWriteDispatched (node:internal/stream_base_commons:159:15)
    ...
    at Server.<anonymous> (file:///.../src/router.mjs:699:10)
    at Server.emit (node:events:508:20)
Emitted 'error' event on Socket instance at:
    at emitErrorNT (node:internal/streams/destroy:170:8)
    ...
[codex-router] Codex router exited (code=1, signal=null).
```

This reproduced reliably enough to cause repeated "Reconnecting" / "stream disconnected before completion" failures in the Codex app, requiring a manual `enable`/restart each time.

## Fix
Attach a no-op `error` listener on the socket before writing/ending it, so an already-reset connection no longer takes down the whole process. Applied identically to both frontends since they share the exact same pattern.

## Test plan
- [x] Reproduced the crash locally via `router.log` with the exact stack trace above
- [x] Applied the fix, restarted the service, confirmed `/health` returns `{"ok":true,...}` and the process no longer exits on subsequent connection resets
- [ ] Maintainer to confirm no other socket-handling call sites need the same treatment