### PR TITLE
feat: show weekly quota remaining instead of used

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -240,11 +240,11 @@ private struct IslandOverlayView: View {
       }
       if let weeklyUsedPercent {
         VStack(alignment: .trailing, spacing: 0) {
-          Text("\(Int(weeklyUsedPercent.rounded()))%")
+          Text("\(Int((100 - weeklyUsedPercent).rounded()))%")
             .font(.system(size: 10, weight: .semibold, design: .monospaced))
             .foregroundStyle(.white.opacity(0.9))
             .monospacedDigit()
-          Text("WEEKLY USED")
+          Text("WEEKLY LEFT")
             .font(.system(size: 6.5, weight: .semibold, design: .monospaced))
             .foregroundStyle(routerMuted)
         }


### PR DESCRIPTION
## Summary

The island overlay's weekly readout showed **consumed** quota, which reads backwards next to the surrounding countdown-style indicators. This inverts the value and relabels it.

- Value: `weeklyUsedPercent` → `100 - weeklyUsedPercent`
- Label: `WEEKLY USED` → `WEEKLY LEFT`

An 80%-consumed week now displays `20%` / `WEEKLY LEFT`.

## Test plan

- [x] `./scripts/build-macos-tray-app.sh` builds clean
- [x] Rebuilt bundle launches and the overlay renders
- [ ] Confirm the percentage matches the menu-bar quota figure on a partially-consumed week
- [ ] Confirm behavior at the 0% and 100% boundaries

## Notes

The backing property is still named `weeklyUsedPercent` while now displaying remaining — worth renaming in a follow-up to keep the semantics honest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)