### PR TITLE
fix(router): strip non-OpenAI reasoning encrypted_content before native replay

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -318,9 +318,29 @@ function normalizeRoutedInput(input) {
     });
 }
 
+// OpenAI-issued reasoning `encrypted_content` is an opaque token (Fernet-style,
+// e.g. "gAAAAAB...") with no whitespace. Some local Responses providers (notably
+// Ollama) mimic the reasoning-item shape but fill `encrypted_content` with the
+// plain-text reasoning summary. Codex stores those items, and when the
+// conversation is later replayed to OpenAI's native Responses API, OpenAI
+// rejects the undecryptable blob with "Encrypted content could not be decrypted
+// or parsed." Strip the non-opaque value before sending to native; the item's
+// `summary` still carries the readable reasoning.
+function isOpaqueEncryptedContent(value) {
+  return typeof value === "string" && value.length > 0 && !/\s/.test(value);
+}
+
+function sanitizeReasoningForNative(item) {
+  if (item?.encrypted_content === undefined) return item;
+  if (isOpaqueEncryptedContent(item.encrypted_content)) return item;
+  const { encrypted_content, ...rest } = item;
+  return rest;
+}
+
 function normalizeNativeInput(input) {
   if (!Array.isArray(input)) return input;
   return input.map((item) => {
+    if (item?.type === "reasoning") return sanitizeReasoningForNative(item);
     if (item?.type !== "compaction") return item;
     const summary = decodeSummary(item.encrypted_content);
     return summary === undefined

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -645,6 +645,68 @@ test("router synthesizes routed compaction and safely replays it to native model
   }
 });
 
+test("router strips non-OpenAI reasoning encrypted_content before replaying to native", async () => {
+  const nativeRequests = [];
+  const native = await mockServer(async (request, response) => {
+    nativeRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { route: "native" });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const headers = {
+    Authorization: "Bearer CODEX_CALLER_SECRET",
+    "Content-Type": "application/json",
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    // Mimics an Ollama local-responses reasoning item: encrypted_content holds
+    // the plain-text reasoning instead of an OpenAI-issued opaque blob.
+    const bogusReasoning = {
+      type: "reasoning",
+      id: "rs_518653",
+      summary: [{ type: "summary_text", text: "The user is frustrated." }],
+      content: null,
+      encrypted_content: "The user is frustrated.",
+    };
+    const genuineReasoning = {
+      type: "reasoning",
+      id: "rs_real",
+      summary: [],
+      content: null,
+      encrypted_content: "gAAAAABkZmtM7cT9w_XY_zThisIsAnOpaqueBlobWithNoWhitespace",
+    };
+    const userMessage = {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "continue" }],
+    };
+    const replay = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "gpt-5.6-sol",
+        input: [bogusReasoning, genuineReasoning, userMessage],
+      }),
+    });
+    assert.equal(replay.status, 200);
+    const sent = nativeRequests[0].body.input;
+    const sentBogus = sent.find((item) => item?.id === "rs_518653");
+    const sentGenuine = sent.find((item) => item?.id === "rs_real");
+    assert.equal(sentBogus.type, "reasoning");
+    assert.equal(sentBogus.encrypted_content, undefined);
+    assert.deepEqual(sentBogus.summary, bogusReasoning.summary);
+    assert.equal(sentGenuine.encrypted_content, genuineReasoning.encrypted_content);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+  }
+});
+
 test("API forwarder replaces caller auth and enforces Kimi K3 API parameters", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
## What

Strip non-OpenAI reasoning `encrypted_content` before replaying a conversation to OpenAI's native Responses API.

## Why

Some non-OpenAI Responses providers (notably the local Ollama Responses API reached via the `local-responses` path) emit `reasoning` items whose `encrypted_content` holds the plain-text reasoning summary instead of an OpenAI-issued opaque blob. Codex stores those items. When the conversation is later replayed to OpenAI's native Responses API — e.g. after the user switches the chat to a native GPT model — OpenAI tries to decrypt the plain-text blob and rejects the whole turn with:

```
The encrypted content for item rs_518653 could not be verified.
Reason: Encrypted content could not be decrypted or parsed.
```

`normalizeNativeInput` already decodes codex-router's own `kcr1:` compaction items before native replay. This extends the same path to reason about `reasoning` items: when `encrypted_content` is not an opaque token (no whitespace), drop it and keep the item's `summary` so reasoning context is preserved. Opaque OpenAI-issued blobs (Fernet-style `gAAAAA…`, no whitespace) pass through unchanged.

This is a defensive fix on the native-outgoing path, independent of which provider introduced the bogus value, so it also protects against any future non-OpenAI source that fills `encrypted_content` with readable text.

## Validation

- `node --check src/router.mjs`
- `node --test test/routing.test.mjs` (new test asserts a plain-text `encrypted_content` reasoning item is stripped while an opaque blob is preserved on native replay; the existing compaction/native-replay test still passes)
- Full suite: only the 7 pre-existing environmental failures (kimi-oauth, provider-account-usage, provider-usage, service-operation-lock, startup, vendor-quota-adapters) remain, unchanged from `main`.
