### PR TITLE
fix(api-forwarder): coalesce consecutive assistant messages for strict providers

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -55,6 +55,55 @@ function deepSeekEffort(value) {
   return ["xhigh", "max", "ultra"].includes(value) ? "max" : "high";
 }
 
+// Strict chat-completions providers (e.g. MiniMax) reject a turn whose tool
+// result messages do not immediately follow the assistant message carrying the
+// matching tool_calls. When the upstream Responses-API history is translated to
+// chat completions, an assistant turn that produced both tool_calls and a text
+// message can arrive as two consecutive assistant messages (one with
+// tool_calls, one with the text), so the tool results no longer follow the
+// tool-call-bearing assistant. Coalesce runs of consecutive assistant messages
+// into a single assistant message (combining content and tool_calls) so the
+// chat-completions contract holds. This is a safe normalization: consecutive
+// assistant messages are not a valid multi-turn shape, so merging them cannot
+// change a well-formed conversation.
+function combineAssistantContent(target, source) {
+  const sourceContent = source.content;
+  if (sourceContent === undefined || sourceContent === null) return;
+  const targetContent = target.content;
+  if (targetContent === undefined || targetContent === null || targetContent === "") {
+    target.content = sourceContent;
+    return;
+  }
+  if (typeof targetContent === "string" && typeof sourceContent === "string") {
+    target.content = `${targetContent}\n${sourceContent}`;
+    return;
+  }
+  const targetBlocks = Array.isArray(targetContent) ? targetContent : [targetContent];
+  const sourceBlocks = Array.isArray(sourceContent) ? sourceContent : [sourceContent];
+  target.content = [...targetBlocks, ...sourceBlocks];
+}
+
+function coalesceAssistantMessages(messages) {
+  if (!Array.isArray(messages) || messages.length < 2) return messages;
+  const coalesced = [];
+  for (const message of messages) {
+    const previous = coalesced[coalesced.length - 1];
+    if (
+      message?.role === "assistant" &&
+      previous?.role === "assistant" &&
+      (Array.isArray(previous.tool_calls) || Array.isArray(message.tool_calls))
+    ) {
+      combineAssistantContent(previous, message);
+      if (Array.isArray(message.tool_calls) && message.tool_calls.length) {
+        previous.tool_calls = [...(previous.tool_calls || []), ...message.tool_calls];
+      }
+      continue;
+    }
+    coalesced.push(message);
+  }
+  return coalesced;
+}
+
 function normalizeBody(buffer, contentType, route) {
   if (!buffer.length || !String(contentType || "").includes("application/json")) {
     const error = new Error("API-provider requests require a JSON body.");
@@ -82,6 +131,9 @@ function normalizeBody(buffer, contentType, route) {
   }
 
   payload.model = model.upstreamModel;
+  if (Array.isArray(payload.messages)) {
+    payload.messages = coalesceAssistantMessages(payload.messages);
+  }
   if (model.requestProfile === "kimi-k3") {
     payload.reasoning_effort = "max";
     delete payload.thinking;

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -794,6 +794,67 @@ test("API forwarder supports all DeepSeek V4 models and normalizes thinking", as
   }
 });
 
+test("API forwarder coalesces consecutive assistant messages so tool results follow tool calls", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    DEEPSEEK_API_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    DEEPSEEK_API_KEY: "TEST_DEEPSEEK_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    // Mimics a Responses->chat-completions translation that split one assistant
+    // turn into a tool-call message and a separate text message, followed by the
+    // tool results. Strict providers (e.g. MiniMax) reject this with
+    // "tool call result does not follow tool call" because the tool results no
+    // longer follow the tool-call-bearing assistant message.
+    const toolCall = {
+      id: "call_A",
+      type: "function",
+      function: { name: "exec_command", arguments: "{}" },
+    };
+    const response = await fetch(
+      `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "deepseek-v4-pro",
+          messages: [
+            { role: "user", content: "run it" },
+            { role: "assistant", tool_calls: [toolCall] },
+            { role: "assistant", content: "Running the command now." },
+            { role: "tool", tool_call_id: "call_A", content: "done" },
+          ],
+        }),
+      },
+    );
+    assert.equal(response.status, 200);
+    const messages = upstreamRequests[0].body.messages;
+    assert.equal(messages.length, 3);
+    assert.equal(messages[1].role, "assistant");
+    assert.equal(messages[1].content, "Running the command now.");
+    assert.deepEqual(messages[1].tool_calls, [toolCall]);
+    assert.equal(messages[2].role, "tool");
+    assert.equal(messages[2].tool_call_id, "call_A");
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder routes Ollama Cloud models without unsupported parameters", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
## What

Coalesce consecutive assistant messages in `api-forwarder`'s `normalizeBody` so tool-result messages always follow the assistant message carrying the matching `tool_calls`.

## Why

Strict chat-completions providers (e.g. MiniMax) reject a turn whose tool-result messages do not immediately follow the assistant message with the matching `tool_calls`. When the upstream Responses-API history is translated to chat completions, an assistant turn that produced both tool calls and a text message can arrive as two consecutive assistant messages — one with `tool_calls`, one with the visible text — so the subsequent `tool`-role results no longer follow the tool-call-bearing assistant. MiniMax then rejects the whole request:

```
litellm.BadRequestError: OpenAIException - invalid params,
tool call result does not follow tool call (2013).
Received Model Group=minimax-token-plan-minimax-m3
```

This also breaks the routed compaction path, since the compaction request replays the same tool-bearing history through the same translation.

Coalesce runs of consecutive assistant messages into a single assistant message (combining content, unioning `tool_calls`) before forwarding. Coalescing only triggers when at least one adjacent assistant message carries `tool_calls`, so:
- it is a no-op for the Anthropic `/messages` path (which uses content-block `tool_use`, not a `tool_calls` field), and
- it does not change a well-formed single-assistant turn.

## Validation

- `node --check src/api-forwarder.mjs`
- `node --test test/routing.test.mjs` (new test sends `assistant(tool_calls)` + `assistant(content)` + `tool(result)` and asserts the upstream receives one coalesced assistant with both `content` and `tool_calls`, followed by the tool result; all existing tests still pass)
- Full suite: only the 7 pre-existing environmental failures (kimi-oauth, provider-account-usage, provider-usage, service-operation-lock, startup, vendor-quota-adapters) remain, unchanged from `main`.
