### PR TITLE
fix(router): strip tool-call items from routed compaction input

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -318,6 +318,25 @@ function normalizeRoutedInput(input) {
     });
 }
 
+function stripToolCallItems(input) {
+  if (!Array.isArray(input)) return input;
+  // Compaction asks the model for a handoff summary, not a tool turn. The raw
+  // function_call / function_call_output items are not useful to the summarizer
+  // and, once translated to chat completions for strict providers (e.g.
+  // MiniMax), can trip "tool call result does not follow tool call" because the
+  // summarization request carries no tools but the tool-bearing history still
+  // does. Drop tool-call and tool-result items before summarizing so the
+  // request is a clean narrative of user/assistant messages; message items
+  // (including assistant output_text) are preserved.
+  const TOOL_ITEM_TYPES = new Set([
+    "function_call",
+    "function_call_output",
+    "custom_tool_call",
+    "custom_tool_call_output",
+  ]);
+  return input.filter((item) => !TOOL_ITEM_TYPES.has(item?.type));
+}
+
 function normalizeNativeInput(input) {
   if (!Array.isArray(input)) return input;
   return input.map((item) => {
@@ -401,7 +420,7 @@ async function summarize(payload, route, signal) {
     tools: [],
     tool_choice: "none",
     input: [
-      ...normalizeRoutedInput(originalInput),
+      ...stripToolCallItems(normalizeRoutedInput(originalInput)),
       messageItem(COMPACT_PROMPT),
     ],
   };

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -645,6 +645,60 @@ test("router synthesizes routed compaction and safely replays it to native model
   }
 });
 
+test("router strips tool-call items from routed compaction input", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, {
+      id: "resp-summary",
+      object: "response",
+      output: [
+        { type: "message", content: [{ type: "output_text", text: "compact summary" }] },
+      ],
+    });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const headers = {
+    Authorization: "Bearer CODEX_CALLER_SECRET",
+    "Content-Type": "application/json",
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const input = [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "do work" }] },
+      { type: "function_call", id: "call_1", call_id: "call_1", name: "exec_command", arguments: "{}" },
+      { type: "function_call_output", call_id: "call_1", output: "done" },
+      { type: "message", role: "assistant", content: [{ type: "output_text", text: "all set" }] },
+    ];
+    const v2 = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "deepseek/deepseek-v4-pro",
+        stream: false,
+        input: [...input, { type: "compaction_trigger" }],
+      }),
+    });
+    assert.equal(v2.status, 200);
+    const summarizeRequest = gatewayRequests[0];
+    const sentTypes = summarizeRequest.body.input.map((item) => item?.type);
+    assert.ok(!sentTypes.includes("function_call"));
+    assert.ok(!sentTypes.includes("function_call_output"));
+    // Message items (user + assistant text) and the compact prompt are kept.
+    assert.ok(sentTypes.includes("message"));
+    assert.match(summarizeRequest.body.input.at(-1).content[0].text, /CONTEXT CHECKPOINT COMPACTION/);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 test("API forwarder replaces caller auth and enforces Kimi K3 API parameters", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
## What

Strip tool-call and tool-result items from the input before asking the routed model to summarize a conversation (routed compaction).

## Why

Routed compaction sends the conversation to the model with `tools: []` and `tool_choice: "none"` to ask for a handoff summary, but the input still contained the raw `function_call` / `function_call_output` items. When that history is translated to chat completions for a strict provider (e.g. MiniMax), the summarization request is rejected:

```
litellm.BadRequestError: OpenAIException - invalid params,
tool call result does not follow tool call (2013).
Received Model Group=minimax-token-plan-minimax-m3
```

because the tool-bearing history is forwarded with no tools for the results to follow. From the user's side this shows up as compaction failing on every switch into a strict provider (the switch triggers compaction when the accumulated conversation exceeds the new model's context window, and the compaction then routes to the strict model and fails).

Drop tool-call and tool-result items (`function_call`, `function_call_output`, `custom_tool_call`, `custom_tool_call_output`) before summarizing, leaving a clean narrative of user and assistant message items (including assistant `output_text`) plus the compact prompt. The summarizer does not need the raw tool I/O, and the request can no longer trip the strict-provider tool-ordering rule.

This complements #31 (coalescing consecutive assistant messages), which fixes the same tool-ordering issue for regular turns; this PR fixes the compaction path specifically and also reduces the summarization payload.

## Validation

- `node --check src/router.mjs`
- `node --test test/routing.test.mjs` (new test sends a compaction request with `function_call` + `function_call_output` items and asserts the gateway's summarize request contains no tool items while message items and the compact prompt are preserved; all existing tests still pass)
- Full suite: only the 7 pre-existing environmental failures (kimi-oauth, provider-account-usage, provider-usage, service-operation-lock, startup, vendor-quota-adapters) remain, unchanged from `main`.
