### PR TITLE
fix(native-alias): read alias state fresh instead of caching on mtime

### DIFF
--- a/src/native-alias.mjs
+++ b/src/native-alias.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 import { NATIVE_ALIAS_PATH } from "./paths.mjs";
 
@@ -19,29 +19,29 @@ export function buildNativeAliasAssignments(nativeModels, externalModels) {
     .map((model, index) => ({ nativeModel: slots[index], model }));
 }
 
-let cache;
-
+// The alias file is a few hundred bytes and is rewritten whenever the user
+// switches models, so it is read fresh on every lookup. An mtime-keyed cache
+// used to guard the read, but file timestamps advance on a coarse tick (~15ms
+// on Windows), so a rewrite in the same tick kept serving the previous map and
+// routed the switched-to model to its old target.
 export function readNativeAliases() {
   if (!existsSync(NATIVE_ALIAS_PATH)) return {};
   try {
-    const mtimeMs = statSync(NATIVE_ALIAS_PATH).mtimeMs;
-    if (!cache || cache.mtimeMs !== mtimeMs) {
-      const parsed = JSON.parse(readFileSync(NATIVE_ALIAS_PATH, "utf8"));
-      const aliases =
-        parsed?.version === 1 &&
-        parsed.aliases &&
-        typeof parsed.aliases === "object" &&
-        !Array.isArray(parsed.aliases)
-          ? Object.fromEntries(
-              Object.entries(parsed.aliases).filter(
-                ([nativeSlug, target]) =>
-                  typeof nativeSlug === "string" && typeof target === "string",
-              ),
-            )
-          : {};
-      cache = { mtimeMs, aliases };
+    const parsed = JSON.parse(readFileSync(NATIVE_ALIAS_PATH, "utf8"));
+    if (
+      parsed?.version !== 1 ||
+      !parsed.aliases ||
+      typeof parsed.aliases !== "object" ||
+      Array.isArray(parsed.aliases)
+    ) {
+      return {};
     }
-    return cache.aliases;
+    return Object.fromEntries(
+      Object.entries(parsed.aliases).filter(
+        ([nativeSlug, target]) =>
+          typeof nativeSlug === "string" && typeof target === "string",
+      ),
+    );
   } catch {
     return {};
   }

--- a/test/native-alias.test.mjs
+++ b/test/native-alias.test.mjs
@@ -51,3 +51,18 @@ test("alias reads pick up rewritten state and reverse lookups resolve", () => {
   assert.equal(nativeAliasFor("kimi-oauth/k3"), "gpt-5.5");
   assert.equal(nativeAliasFor("grok-oauth/grok-4.5"), undefined);
 });
+
+test("alias reads see a same-size rewrite made within one clock tick", () => {
+  const write = (target) =>
+    writeFileSync(
+      NATIVE_ALIAS_PATH,
+      `${JSON.stringify({ version: 1, aliases: { "gpt-5.5": target } })}\n`,
+      { mode: 0o600 },
+    );
+  write("kimi-oauth/k3");
+  assert.deepEqual(readNativeAliases(), { "gpt-5.5": "kimi-oauth/k3" });
+  // Same byte length as the first write, so only a sub-millisecond mtime
+  // difference distinguishes the two revisions.
+  write("kimi-oauth/k9");
+  assert.deepEqual(readNativeAliases(), { "gpt-5.5": "kimi-oauth/k9" });
+});


### PR DESCRIPTION
## What

Drop the mtime-keyed cache in `readNativeAliases` and read the alias file fresh on every lookup.

## Why

File timestamps advance on a coarse tick (~15ms on Windows), so two rewrites inside one tick share an mtime and the cache keeps serving the previous alias map. Two consequences:

- **Product:** a model switch that rewrites the alias file shortly after a previous rewrite keeps routing the native slug to its old target until the next timestamp tick.
- **CI:** `test/native-alias.test.mjs:44` fails intermittently on `windows-latest` (`readNativeAliases()` returns `{}` after the version-1 file is written). It failed twice in a row on #31 and #32, which are unrelated to alias state.

The file is a few hundred bytes and is read once per routing decision, so the cache saved a `readFileSync` on a path already dominated by an upstream HTTP call.

## Validation

- `node --check src/native-alias.mjs`
- `node --test test/native-alias.test.mjs` — 4/4, including a new regression test that rewrites the file to a **same-size** payload within one clock tick (the case no timestamp-based stamp can catch)
- `node --test test/routing.test.mjs` — 17/17