### PR TITLE
Let the readiness wait cover a LiteLLM cold start

### DIFF
--- a/src/service.mjs
+++ b/src/service.mjs
@@ -19,6 +19,12 @@ if (!script) {
 const command = process.argv[2] || "status";
 const mutatingCommands = new Set(["install", "uninstall", "start", "stop", "restart"]);
 const readinessCommands = new Set(["install", "start", "restart"]);
+// start.mjs allows the LiteLLM gateway 300s to cold start, so the readiness
+// wait has to cover at least that. A shorter wait reports failure while the
+// service is still booting, and the installer's rollback then uninstalls the
+// service and reverts the app config out from under a router that goes on to
+// come up healthy seconds later.
+const READINESS_TIMEOUT_MS = 300_000;
 
 async function runServiceCommand() {
   const result = spawnSync(
@@ -30,9 +36,11 @@ async function runServiceCommand() {
   if (result.status !== 0) return result.status ?? 1;
   if (!readinessCommands.has(command)) return 0;
 
-  const health = await waitForRouterHealth();
+  const health = await waitForRouterHealth({ timeoutMs: READINESS_TIMEOUT_MS });
   if (health.ok) return 0;
-  console.error(`Router did not become healthy within 30 seconds: ${health.error}`);
+  console.error(
+    `Router did not become healthy within ${READINESS_TIMEOUT_MS / 1_000} seconds: ${health.error}`,
+  );
   return 1;
 }
 

--- a/src/wait-health.mjs
+++ b/src/wait-health.mjs
@@ -2,7 +2,9 @@ import { PORTS, loopback } from "./paths.mjs";
 import { waitForRouterHealth } from "./router-health.mjs";
 
 const url = process.argv[2] || loopback(PORTS.router, "/health");
-const timeoutMs = Number(process.argv[3] || 30_000);
+// Matches the LiteLLM gateway cold-start allowance in start.mjs. install.ps1
+// calls this with no explicit timeout right after the service is installed.
+const timeoutMs = Number(process.argv[3] || 300_000);
 const health = await waitForRouterHealth({ url, timeoutMs });
 if (health.ok) {
   process.stdout.write(`${JSON.stringify(health.payload)}\n`);


### PR DESCRIPTION
## Summary

`start.mjs` allows the LiteLLM gateway up to 300s to become healthy:

https://github.com/duolahypercho/codex-router/blob/main/src/start.mjs#L177-L186

But the readiness check that gates installation waits only 30s:

- `src/service.mjs` calls `waitForRouterHealth()` with no argument, taking the 30s default from `router-health.mjs`
- `src/wait-health.mjs` defaults to 30s, and `install.ps1` invokes it with no explicit timeout

On Windows the gateway routinely needs more than 30s to import, so the readiness check reports failure while the service is still starting normally.

## Why this is worse than a slow start

`install.ps1` treats that timeout as a fatal install error and runs its rollback:

```powershell
} catch {
  if ($ServiceInstalled) { & node src/service.mjs uninstall 2>$null | Out-Null }
  if ($ConfigEnabled) { & node $ConfigManager disable 2>$null | Out-Null }
  throw
}
```

So the rollback uninstalls the background service and reverts the app routing config, while the router it just launched comes up healthy moments later. The end state is a running router the app is no longer pointed at, with the auto-start task deleted. `doctor` then reports the contradiction directly:

```
FAIL  Codex routing config: native
FAIL  Background service: stopped
OK    Router health: version 0.4.0-beta.1
```

From the user side this surfaces as the Codex app looping on `Reconnecting 5/5` with `stream disconnected before completion: error sending request for url (http://127.0.0.1:4102/...)`, because `config.toml` was reverted out from under a router that is actually alive. Re-running `enable` a second time appears to fix it, but only because the gateway is warm by then and fits inside 30s.

## Measurement

Windows 11, cold start with no router processes running and all ports free:

```
exit code: 0
elapsed: 102s
```

102s to a healthy router, 3.4x over the previous 30s limit. This is not an outlier on a loaded machine, it is the normal path.

## Fix

Raise both defaults to 300s so the readiness wait matches the allowance `start.mjs` already grants the gateway. No behavior change once the service is warm, since the check returns as soon as health passes.

## Test plan
- [x] Killed all router processes, confirmed ports 4100-4108 free, ran `enable` from cold: previously failed at 30s and rolled back, now exits 0 after 102s
- [x] `doctor` reports all checks OK afterward, including `Codex routing config: router` and `Background service: running`
- [x] Warm re-run still returns promptly, no added latency
- [ ] Maintainer to confirm the macOS/Linux service paths want the same allowance