### PR TITLE
docs: explain Windows Codex Desktop configuration from WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,52 @@ wire_api = "responses"
 The generated path is local caller authentication. Do not paste the complete
 managed URL into an issue.
 
+### Windows Codex Desktop running through WSL
+
+When Codex Desktop runs on Windows while commands are executed through WSL,
+there may be two different Codex home directories:
+
+```text
+C:\Users\<WindowsUser>\.codex
+```
+
+and:
+
+```text
+/home/<LinuxUser>/.codex
+```
+
+Router commands use the Codex home selected by `CODEX_HOME`. Running them inside
+WSL without overriding that variable may update the Linux CLI configuration
+instead of the configuration used by Windows Codex Desktop.
+
+To target the Windows Desktop configuration from WSL:
+
+```sh
+export CODEX_HOME=/mnt/c/Users/<WindowsUser>/.codex
+export CODEX_ROUTER_STATE_DIR="$CODEX_HOME/codex-router"
+```
+
+Then run the router command normally. For example, to return to authenticated
+mode with native GPT models and enabled external providers in the merged
+catalog:
+
+```sh
+./bin/control auth-mode off
+```
+
+Verify that the Windows `config.toml` uses a path that the WSL runtime can read:
+
+```toml
+model_catalog_json = "/mnt/c/Users/<WindowsUser>/.codex/codex-router/merged-models.json"
+```
+
+A Windows-style path such as `C:\Users\...` may not resolve correctly when Codex
+is running through WSL.
+
+If setup appears successful but the Desktop model picker does not change, check
+which Codex home was modified before rerunning setup.
+
 ### Use Codex without an OpenAI login
 
 The tray's **Use without OpenAI login** switch selects the managed custom

--- a/README.md
+++ b/README.md
@@ -227,8 +227,9 @@ Verify that the Windows `config.toml` uses a path that the WSL runtime can read:
 model_catalog_json = "/mnt/c/Users/<WindowsUser>/.codex/codex-router/merged-models.json"
 ```
 
-A Windows-style path such as `C:\Users\...` may not resolve correctly when Codex
-is running through WSL.
+When the Codex runtime is executing inside WSL, a Windows-style path such as
+`C:\Users\...` is not readable as a Linux filesystem path. Use the corresponding
+`/mnt/c/...` path instead.
 
 If setup appears successful but the Desktop model picker does not change, check
 which Codex home was modified before rerunning setup.


### PR DESCRIPTION
## Summary

Adds a short subsection to `README.md` under **Make models appear in Codex**, explaining how to configure codex-router when **Codex Desktop runs on Windows but its app-server / commands execute inside WSL**.

This hybrid has two Codex home directories (`C:\Users\<user>\.codex` and `/home/<user>/.codex`), and router commands act on whichever `CODEX_HOME` selects. Running setup inside WSL without overriding `CODEX_HOME` silently edits the Linux CLI config instead of the Windows Desktop config, and the Windows `model_catalog_json` path (`C:\...`) is unreadable from the WSL runtime — chat creation fails with `failed to resolve feature override precedence: No such file or directory (os error 2)`.

## What the note covers

- The two Codex homes and how `CODEX_HOME` / `CODEX_ROUTER_STATE_DIR` pick the target.
- Pointing `model_catalog_json` at the `/mnt/c/...` path so the WSL runtime can read it.
- Returning to authenticated merged mode (`auth-mode off`) so native GPT models and external models appear together under their own slugs.
- A symptom check: if the Desktop model picker doesn't change after setup, verify which Codex home was actually modified.

## Why here

The README's platform model is macOS / Linux / Windows. This WSL-hosted Windows Desktop case fits none of the three cleanly and currently has no documentation. Placement follows the existing model-visibility discussion, immediately before **Use Codex without an OpenAI login**, since the two modes interact (the allowlist / aliasing behavior only applies when signed out).

Docs-only change; no code touched.

