### PR TITLE
docs: add missing article 'a' before 'separate quota' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ aliases remain hidden compatibility routes and are not advertised to new users.
 
 
 The Ollama Cloud entries bill through an ollama.com account and can host the
-same model families as other providers under separate quota. Matching entries
+same model families as other providers under a separate quota. Matching entries
 (for example DeepSeek V4 Pro) intentionally coexist with the vendor-direct
 providers because credentials and billing differ.
 The Qwen entries default to the Alibaba Model Studio Token Plan endpoint in


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `README.md` (line 118).

## Problem

Missing article before 'separate quota'. 'Quota' is typically countable, so the phrase reads awkwardly without an article or pluralization.

The problematic text:

```markdown
can host the same model families as other providers under separate quota
```

## Fix

Replaced with:

```markdown
can host the same model families as other providers under a separate quota
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text