### PR TITLE
docs: fix comma splice in HOW-IT-WORKS.md

### DIFF
--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -74,7 +74,7 @@ appear there. Aliased entries reuse the allowlisted slugs while carrying the
 external model's display name, description, and reasoning levels; each aliased
 model also keeps a hidden entry under its canonical slug so routing, doctor
 checks, and saved configs continue to resolve. `native-aliases.json` records
-the slug mapping, the router consults it when dispatching `/responses`, and
+the slug mapping; the router consults it when dispatching `/responses`, and
 `control model-set`/`auth-mode` write the alias slug into the Codex config so
 pickers highlight the active model. Signed-in catalog builds clear the alias
 map, which restores native GPT routing.


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `docs/HOW-IT-WORKS.md` (line 77).

## Problem

Comma splice: three independent clauses joined by commas with 'and' only before the final clause. The first two clauses are joined by a comma without a coordinating conjunction.

The problematic text:

```markdown
the slug mapping, the router consults it when dispatching `/responses`, and
```

## Fix

Replaced with:

```markdown
the slug mapping; the router consults it when dispatching `/responses`, and
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text