### PR TITLE
docs: fix comma splice in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,7 +77,7 @@ The router, LiteLLM gateway, OAuth forwarder, and API forwarder bind only to
 it in the managed URL and Cursor sends it as the configured gateway credential.
 Internal gateway and forwarder routes require a separate random service key,
 and credential-detail health responses are authenticated.
-Model requests must use JSON, requests with browser-origin headers are rejected,
+Model requests must use JSON; requests with browser-origin headers are rejected,
 and the router sends no CORS permission headers. This remains compatible with
 Codex API-key sessions that do not attach a bearer header to the loopback hop.
 


### PR DESCRIPTION
## Summary

This PR fixes a grammar issue in `SECURITY.md` (line 80).

## Problem

Comma splice: three independent clauses joined by commas with 'and' only before the final clause. The first two clauses are joined by a comma without a coordinating conjunction.

The problematic text:

```markdown
Model requests must use JSON, requests with browser-origin headers are rejected, and the router sends no CORS permission headers.
```

## Fix

Replaced with:

```markdown
Model requests must use JSON; requests with browser-origin headers are rejected, and the router sends no CORS permission headers.
```

## Type of Change

- [x] Documentation fix (grammar, spelling, logical error)
- [ ] Code change
- [ ] Breaking change

## Checklist

- [x] Documentation files only
- [x] No code changes
- [x] Fix verified against original text