### PR TITLE
fix(config): avoid unsupported router websockets

### DIFF
--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -36,6 +36,7 @@ const endMarker = "# END codex-router-managed";
 const providerStartMarker = "# BEGIN codex-router-provider-managed";
 const providerEndMarker = "# END codex-router-provider-managed";
 const routerProviderId = "codex-router";
+const authenticatedRouterProviderId = "codex-router-openai";
 const defaultChatgptBaseUrl = "https://chatgpt.com/backend-api";
 const defaultRealtimeWebsocketBaseUrl = "https://api.openai.com/v1";
 const realtimeCallBaseUrlKey = "experimental_realtime_webrtc_call_base_url";
@@ -162,11 +163,12 @@ function readProviderModeState() {
   try {
     const parsed = JSON.parse(readFileSync(CODEX_PROVIDER_MODE_PATH, "utf8"));
     if (
-      parsed?.version !== 1 ||
+      ![1, 2].includes(parsed?.version) ||
       typeof parsed.previousPresent !== "boolean" ||
       (parsed.previousPresent && typeof parsed.previousModelProvider !== "string") ||
       typeof parsed.previousModelPresent !== "boolean" ||
-      (parsed.previousModelPresent && typeof parsed.previousModel !== "string")
+      (parsed.previousModelPresent && typeof parsed.previousModel !== "string") ||
+      (parsed.version === 2 && typeof parsed.restoreModel !== "boolean")
     ) {
       throw new Error("invalid state");
     }
@@ -200,7 +202,7 @@ function clearProviderModeState() {
 function hasUnmanagedRouterProvider(contents) {
   const withoutManagedBlock = removeMarkedBlock(contents);
   return new RegExp(
-    `^\\s*\\[model_providers\\.(?:${routerProviderId}|["']${routerProviderId}["'])\\]\\s*$`,
+    `^\\s*\\[model_providers\\.(?:${routerProviderId}|${authenticatedRouterProviderId}|["'](?:${routerProviderId}|${authenticatedRouterProviderId})["'])\\]\\s*$`,
     "m",
   ).test(withoutManagedBlock);
 }
@@ -237,8 +239,9 @@ function legacyManagedRouterProvider(contents) {
     isManagedRouterBaseUrl(rootBaseUrl) &&
     fields.get("wire_api") === "responses";
   const currentShape =
-    fields.size === 3 &&
-    fields.get("name") === "Codex Router (external models)";
+    fields.get("name") === "Codex Router (external models)" &&
+    (fields.size === 3 ||
+      (fields.size === 4 && fields.get("supports_websockets") === "false"));
   const prototypeShape =
     fields.size === 4 &&
     fields.get("name") === "Codex Router (extra providers)" &&
@@ -299,7 +302,7 @@ function snapshot(contents) {
   };
 }
 
-function enabledContents(contents) {
+function enabledContents(contents, providerId = authenticatedRouterProviderId) {
   const { rootLines: currentRoot } = splitRoot(contents);
   const currentProvider = rootValue(currentRoot, "model_provider");
   const legacyProvider = legacyManagedRouterProvider(contents);
@@ -308,7 +311,8 @@ function enabledContents(contents) {
     : contents;
   if (
     hasUnmanagedRouterProvider(contentsWithoutLegacyProvider) ||
-    (currentProvider === routerProviderId && !existsSync(CODEX_PROVIDER_MODE_PATH))
+    ([routerProviderId, authenticatedRouterProviderId].includes(currentProvider) &&
+      !existsSync(CODEX_PROVIDER_MODE_PATH))
   ) {
     throw new Error(
       `Refusing to replace user-owned model provider ${routerProviderId}.`,
@@ -316,7 +320,9 @@ function enabledContents(contents) {
   }
   const routerBaseUrl = configuredRouterBaseUrl();
   const cleaned = clean(contentsWithoutLegacyProvider);
-  const rootLines = trimBlankEdges(cleaned.rootLines);
+  const rootLines = trimBlankEdges(cleaned.rootLines).filter(
+    (line) => !/^\s*model_provider\s*=/.test(line),
+  );
   const existingBase = rootValue(rootLines, "openai_base_url");
   const existingCatalog = rootValue(rootLines, "model_catalog_json");
   if (existingBase && existingBase !== routerBaseUrl) {
@@ -343,6 +349,7 @@ function enabledContents(contents) {
   rootLines.push(
     "",
     startMarker,
+    `model_provider = ${JSON.stringify(providerId)}`,
     `openai_base_url = ${JSON.stringify(routerBaseUrl)}`,
     `model_catalog_json = ${JSON.stringify(MERGED_CATALOG_PATH)}`,
     ...managedRealtimeOverrides,
@@ -355,10 +362,18 @@ function enabledContents(contents) {
     ...tableLines,
     ...(tableLines.length ? [""] : []),
     providerStartMarker,
+    `[model_providers.${authenticatedRouterProviderId}]`,
+    'name = "Codex Router (OpenAI authenticated)"',
+    `base_url = ${JSON.stringify(routerBaseUrl)}`,
+    'wire_api = "responses"',
+    "requires_openai_auth = true",
+    "supports_websockets = false",
+    "",
     `[model_providers.${routerProviderId}]`,
     'name = "Codex Router (external models)"',
     `base_url = ${JSON.stringify(routerBaseUrl)}`,
     'wire_api = "responses"',
+    "supports_websockets = false",
     providerEndMarker,
   ];
   return `${next.join("\n").trimEnd()}\n`;
@@ -394,28 +409,48 @@ if (command === "status") {
 let next;
 let pendingProviderModeState;
 if (command === "enable") {
-  next = enabledContents(current);
-} else if (command === "login-free-enable") {
-  const enabled = enabledContents(current);
   const { rootLines } = splitRoot(current);
-  const loginFreeModel = String(process.argv[3] || "").trim();
-  const alreadyManaged =
-    rootValue(rootLines, "model_provider") === routerProviderId &&
-    existsSync(CODEX_PROVIDER_MODE_PATH);
-  if (!alreadyManaged) {
+  const currentProvider = rootValue(rootLines, "model_provider");
+  const state = readProviderModeState();
+  if (!state) {
     pendingProviderModeState = {
-      version: 1,
+      version: 2,
       previousPresent: rootHasValue(rootLines, "model_provider"),
       ...(rootHasValue(rootLines, "model_provider")
-        ? { previousModelProvider: rootValue(rootLines, "model_provider") }
+        ? { previousModelProvider: currentProvider }
         : {}),
+      restoreModel: false,
+      previousModelPresent: false,
+    };
+  }
+  next = enabledContents(
+    current,
+    currentProvider === routerProviderId
+      ? routerProviderId
+      : authenticatedRouterProviderId,
+  );
+} else if (command === "login-free-enable") {
+  const { rootLines } = splitRoot(current);
+  const loginFreeModel = String(process.argv[3] || "").trim();
+  const state = readProviderModeState();
+  if (!state || rootValue(rootLines, "model_provider") !== routerProviderId) {
+    pendingProviderModeState = {
+      version: 2,
+      previousPresent: state?.previousPresent ?? rootHasValue(rootLines, "model_provider"),
+      ...((state?.previousPresent ?? rootHasValue(rootLines, "model_provider"))
+        ? {
+            previousModelProvider:
+              state?.previousModelProvider || rootValue(rootLines, "model_provider"),
+          }
+        : {}),
+      restoreModel: true,
       previousModelPresent: rootHasValue(rootLines, "model"),
       ...(rootHasValue(rootLines, "model")
         ? { previousModel: rootValue(rootLines, "model") }
         : {}),
     };
   }
-  next = `${replaceRootValue(enabled, "model_provider", routerProviderId)}\n`;
+  next = enabledContents(current, routerProviderId);
   if (loginFreeModel) next = `${replaceRootValue(next, "model", loginFreeModel)}\n`;
 } else {
   const state = readProviderModeState();
@@ -423,7 +458,7 @@ if (command === "enable") {
   const currentProvider = rootValue(rootLines, "model_provider");
   let restored = current;
   if (state) {
-    if (currentProvider !== routerProviderId) {
+    if (![routerProviderId, authenticatedRouterProviderId].includes(currentProvider)) {
       throw new Error(
         `Refusing to replace user-owned model_provider: ${currentProvider || "unset"}.`,
       );
@@ -433,16 +468,27 @@ if (command === "enable") {
       "model_provider",
       state.previousPresent ? state.previousModelProvider : undefined,
     )}\n`;
-    restored = `${replaceRootValue(
-      restored,
-      "model",
-      state.previousModelPresent ? state.previousModel : undefined,
-    )}\n`;
+    if (state.version === 1 || state.restoreModel) {
+      restored = `${replaceRootValue(
+        restored,
+        "model",
+        state.previousModelPresent ? state.previousModel : undefined,
+      )}\n`;
+    }
   } else if (command === "login-free-disable" && currentProvider === routerProviderId) {
     throw new Error("Codex login-free mode is not managed by this router.");
   }
   if (command === "login-free-disable") {
-    next = restored;
+    next = enabledContents(restored, authenticatedRouterProviderId);
+    if (state) {
+      pendingProviderModeState = {
+        ...state,
+        version: 2,
+        restoreModel: false,
+        previousModelPresent: false,
+      };
+      delete pendingProviderModeState.previousModel;
+    }
   } else {
     const cleaned = clean(restored);
     next = `${[
@@ -463,5 +509,5 @@ try {
   if (pendingProviderModeState) clearProviderModeState();
   throw error;
 }
-if (command === "disable" || command === "login-free-disable") clearProviderModeState();
+if (command === "disable") clearProviderModeState();
 process.stdout.write(`${JSON.stringify(snapshot(next))}\n`);

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -284,18 +284,22 @@ function snapshot(contents) {
   const { rootLines } = splitRoot(contents);
   const baseUrl = rootValue(rootLines, "openai_base_url");
   const catalog = rootValue(rootLines, "model_catalog_json");
+  const modelProvider = rootValue(rootLines, "model_provider") || "openai";
+  const providerModeStatePresent = existsSync(CODEX_PROVIDER_MODE_PATH);
   return {
     mode:
       isManagedRouterBaseUrl(baseUrl) && catalog === MERGED_CATALOG_PATH
         ? "router"
         : "native",
     model: rootValue(rootLines, "model") || null,
-    model_provider: rootValue(rootLines, "model_provider") || "openai",
-    login_free: rootValue(rootLines, "model_provider") === routerProviderId,
+    model_provider: modelProvider,
+    provider_mode_managed:
+      [routerProviderId, authenticatedRouterProviderId].includes(modelProvider) &&
+      providerModeStatePresent,
+    login_free: modelProvider === routerProviderId,
     login_free_managed:
-      rootValue(rootLines, "model_provider") === routerProviderId &&
-      existsSync(CODEX_PROVIDER_MODE_PATH),
-    provider_mode_state_present: existsSync(CODEX_PROVIDER_MODE_PATH),
+      modelProvider === routerProviderId && providerModeStatePresent,
+    provider_mode_state_present: providerModeStatePresent,
     openai_base_url: baseUrl ? redactCallerUrl(baseUrl) : null,
     model_catalog_json: catalog || null,
     config_protected: privateFileIsProtected(CONFIG_PATH),

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -268,9 +268,9 @@ try {
     config.mode,
     "Run ./bin/enable or ./bin/doctor --fix.",
   );
-  const providerModeOk = config.login_free
-    ? config.login_free_managed
-    : !config.provider_mode_state_present;
+  const providerModeOk = config.provider_mode_state_present
+    ? config.provider_mode_managed
+    : !config.login_free;
   add(
     providerModeOk ? "ok" : "fail",
     "Codex login mode",
@@ -279,7 +279,9 @@ try {
         ? "external providers; OpenAI login not required"
         : "unmanaged custom provider"
       : config.provider_mode_state_present
-        ? "stale provider-mode restore state"
+        ? config.provider_mode_managed
+          ? "OpenAI login available through managed router"
+          : "stale provider-mode restore state"
         : "OpenAI login available",
     "Use the tray toggle to switch modes, or run ./bin/doctor --fix.",
   );

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -61,7 +61,7 @@ approval_policy = "never"
     const enabled = run("enable", codexHome);
     assert.equal(enabled.mode, "router");
     assert.equal(enabled.model, "gpt-5.6-sol");
-    assert.equal(enabled.model_provider, "openai");
+    assert.equal(enabled.model_provider, "codex-router-openai");
     assert.equal(enabled.config_protected, true);
     assert.equal(
       enabled.openai_base_url,
@@ -73,7 +73,10 @@ approval_policy = "never"
     assert.match(configured, /# BEGIN codex-router-managed/);
     assert.match(configured, /# BEGIN codex-router-provider-managed/);
     assert.match(configured, /\[model_providers\.codex-router\]/);
+    assert.match(configured, /\[model_providers\.codex-router-openai\]/);
     assert.match(configured, /wire_api = "responses"/);
+    assert.match(configured, /requires_openai_auth = true/);
+    assert.match(configured, /supports_websockets = false/);
     assert.ok(
       configured.includes(
         `openai_base_url = "http://127.0.0.1:46192/_codex-router/${CALLER_KEY}/v1"`,
@@ -108,6 +111,15 @@ approval_policy = "never"
       1,
     );
 
+    writeFileSync(
+      configPath,
+      readFileSync(configPath, "utf8").replace(
+        'model = "gpt-5.6-sol"',
+        'model = "gpt-5.6-terra"',
+      ),
+      { mode: 0o600 },
+    );
+
     const disabled = run("disable", codexHome);
     assert.equal(disabled.mode, "native");
     assert.equal(disabled.config_protected, true);
@@ -116,7 +128,7 @@ approval_policy = "never"
       restored,
       /codex-router-(?:provider-)?managed|openai_base_url|model_catalog_json|experimental_realtime_(?:webrtc_call|ws)_base_url/,
     );
-    assert.match(restored, /model = "gpt-5\.6-sol"/);
+    assert.match(restored, /model = "gpt-5\.6-terra"/);
     assert.match(restored, /model_provider = "openai"/);
     assert.match(restored, /model_reasoning_effort = "xhigh"/);
     assert.match(restored, /\[profiles\.work\]/);
@@ -224,12 +236,20 @@ approval_policy = "never"
 
     const restored = run("login-free-disable", codexHome, stateDir);
     assert.equal(restored.mode, "router");
-    assert.equal(restored.model_provider, "openai");
+    assert.equal(restored.model_provider, "codex-router-openai");
     assert.equal(restored.login_free, false);
     assert.equal(restored.model, "gpt-5.6-sol");
+    assert.equal(existsSync(providerModePath), true);
+    assert.match(
+      readFileSync(configPath, "utf8"),
+      /^model_provider = "codex-router-openai"$/m,
+    );
+    assert.match(readFileSync(configPath, "utf8"), /^model = "gpt-5.6-sol"$/m);
+
+    const disabled = run("disable", codexHome, stateDir);
+    assert.equal(disabled.model_provider, "openai");
     assert.equal(existsSync(providerModePath), false);
     assert.match(readFileSync(configPath, "utf8"), /^model_provider = "openai"$/m);
-    assert.match(readFileSync(configPath, "utf8"), /^model = "gpt-5.6-sol"$/m);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }
@@ -292,6 +312,11 @@ test("config manager adopts the exact legacy router-owned provider table", () =>
       .replace("# BEGIN codex-router-provider-managed\n", "")
       .replace("\n# END codex-router-provider-managed", "")
       .replace(
+        /\[model_providers\.codex-router-openai\][\s\S]*?(?=\n\[model_providers\.codex-router\])\n/,
+        "",
+      )
+      .replace("\nsupports_websockets = false", "")
+      .replace(
         'name = "Codex Router (external models)"',
         'name = "Codex Router (extra providers)"',
       )
@@ -304,9 +329,14 @@ test("config manager adopts the exact legacy router-owned provider table", () =>
     assert.equal(enabled.model, "kimi-oauth/kimi-k2.5");
     const migrated = readFileSync(configPath, "utf8");
     assert.equal((migrated.match(/\[model_providers\.codex-router\]/g) || []).length, 1);
+    assert.equal(
+      (migrated.match(/\[model_providers\.codex-router-openai\]/g) || []).length,
+      1,
+    );
     assert.match(migrated, /# BEGIN codex-router-provider-managed/);
     assert.match(migrated, /name = "Codex Router \(external models\)"/);
-    assert.doesNotMatch(migrated, /extra providers|requires_openai_auth/);
+    assert.doesNotMatch(migrated, /extra providers/);
+    assert.match(migrated, /requires_openai_auth = true/);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -62,6 +62,7 @@ approval_policy = "never"
     assert.equal(enabled.mode, "router");
     assert.equal(enabled.model, "gpt-5.6-sol");
     assert.equal(enabled.model_provider, "codex-router-openai");
+    assert.equal(enabled.provider_mode_managed, true);
     assert.equal(enabled.config_protected, true);
     assert.equal(
       enabled.openai_base_url,
@@ -237,6 +238,7 @@ approval_policy = "never"
     const restored = run("login-free-disable", codexHome, stateDir);
     assert.equal(restored.mode, "router");
     assert.equal(restored.model_provider, "codex-router-openai");
+    assert.equal(restored.provider_mode_managed, true);
     assert.equal(restored.login_free, false);
     assert.equal(restored.model, "gpt-5.6-sol");
     assert.equal(existsSync(providerModePath), true);

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -251,7 +251,7 @@ test("login-free control selects a ready external model and restores Codex defau
     const disabled = runMode("off");
     assert.equal(disabled.login_free, false);
     assert.equal(disabled.model, "gpt-5.6-sol");
-    assert.equal(disabled.model_provider, "openai");
+    assert.equal(disabled.model_provider, "codex-router-openai");
   } finally {
     rmSync(stateDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- select an authenticated managed router provider for normal Codex sessions
- declare WebSocket transport unsupported for both authenticated and login-free router providers
- preserve and restore the user's prior provider and model state across enable, disable, and login-free transitions

## Verification
- `npm test` (170 passed, 0 failed, 2 skipped)
- `npm run check`
- `git diff --check`
- live Codex transport probe against the local router