### PR TITLE
fix: diagnose blocked Grok CLI on Windows

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -80,9 +80,9 @@ not offer a safe per-app bypass for this failure. Until xAI publishes an
 official CLI build that Windows allows, use the API-key provider instead:
 
 ```powershell
-./bin/model-router codex provider-key grok-api set
-./bin/model-router codex providers enable grok-api
-./bin/model-router codex doctor
+./model-router.ps1 codex provider-key grok-api set
+./model-router.ps1 codex providers enable grok-api
+./model-router.ps1 codex doctor
 ```
 
 An OAuth session created while the executable was allowed is not a durable

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -65,6 +65,30 @@ Codex Router reads the official Kimi CLI credential under `$KIMI_CODE_HOME` or
 `~/.kimi-code` and refreshes it under a cross-process lock. Do not copy the OAuth
 token into Codex config, an API-key file, or an environment variable.
 
+## Windows blocks the Grok OAuth CLI
+
+On Windows, first confirm that the installed official CLI can launch:
+
+```powershell
+grok --version
+```
+
+If that command reports `spawn UNKNOWN`, "An Application Control policy has
+blocked this file," or a Smart App Control notification, Grok OAuth cannot
+complete login or refresh its session. Keep Smart App Control enabled; it does
+not offer a safe per-app bypass for this failure. Until xAI publishes an
+official CLI build that Windows allows, use the API-key provider instead:
+
+```powershell
+./bin/model-router codex provider-key grok-api set
+./bin/model-router codex providers enable grok-api
+./bin/model-router codex doctor
+```
+
+An OAuth session created while the executable was allowed is not a durable
+workaround. The router invokes the official CLI again near token expiry, so the
+session eventually stops refreshing if Windows blocks the executable later.
+
 ## An API key is missing or invalid
 
 ```sh

--- a/src/cursor-doctor.mjs
+++ b/src/cursor-doctor.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { validCallerSecret } from "./caller-auth.mjs";
 import { privateFileIsProtected } from "./file-security.mjs";
+import { grokCliPreflight } from "./grok-cli.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
@@ -195,11 +196,17 @@ add(
   "Run kimi login, then rerun the doctor.",
 );
 const grokOauth = grokOAuthStatus();
+const grokCli = grokCliPreflight();
+const grokOauthReady = grokOauth.configured && grokCli.runnable;
 add(
-  grokOauth.configured ? "ok" : selection.providers.includes("grok-oauth") ? "fail" : "warn",
+  grokOauthReady ? "ok" : selection.providers.includes("grok-oauth") ? "fail" : "warn",
   "Grok OAuth",
-  grokOauth.configured ? grokOauth.source : `not configured; ${grokOauth.setup}`,
-  "Run grok login, then rerun the doctor.",
+  !grokCli.runnable
+    ? grokCli.detail
+    : grokOauth.configured
+      ? grokOauth.source
+      : `not configured; ${grokOauth.setup}`,
+  !grokCli.runnable ? grokCli.fix : "Run grok login, then rerun the doctor.",
 );
 for (const provider of PROVIDERS.values()) {
   if (provider.kind !== "openai-compatible") continue;

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { validCallerSecret } from "./caller-auth.mjs";
 import { findCodexBinary } from "./codex-binary.mjs";
 import { privateFileIsProtected } from "./file-security.mjs";
+import { grokCliPreflight } from "./grok-cli.mjs";
 import { detectLegacyInstallations } from "./legacy-migration.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
@@ -242,11 +243,17 @@ add(
   "Run kimi login, then rerun the doctor.",
 );
 const grokOauth = grokOAuthStatus();
+const grokCli = grokCliPreflight();
+const grokOauthReady = grokOauth.configured && grokCli.runnable;
 add(
-  grokOauth.configured ? "ok" : selection.providers.includes("grok-oauth") ? "fail" : "warn",
+  grokOauthReady ? "ok" : selection.providers.includes("grok-oauth") ? "fail" : "warn",
   "Grok OAuth",
-  grokOauth.configured ? grokOauth.source : `not configured; ${grokOauth.setup}`,
-  "Run grok login, then rerun the doctor.",
+  !grokCli.runnable
+    ? grokCli.detail
+    : grokOauth.configured
+      ? grokOauth.source
+      : `not configured; ${grokOauth.setup}`,
+  !grokCli.runnable ? grokCli.fix : "Run grok login, then rerun the doctor.",
 );
 
 for (const provider of PROVIDERS.values()) {

--- a/src/grok-cli.mjs
+++ b/src/grok-cli.mjs
@@ -1,0 +1,127 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const WINDOWS_BLOCK_CODES = new Set(["EACCES", "EPERM", "UNKNOWN"]);
+const WINDOWS_BLOCK_PATTERNS = [
+  /spawn UNKNOWN/i,
+  /application control/i,
+  /smart app control/i,
+  /blocked (?:part of )?this app/i,
+  /blocked this file/i,
+];
+
+export const GROK_CLI_BLOCKED_DETAIL =
+  "installed, but Windows application control appears to have blocked the official Grok CLI";
+export const GROK_CLI_BLOCKED_FIX =
+  "Keep Smart App Control enabled. Use the grok-api provider, or install a trusted official Grok CLI release that Windows allows.";
+
+function commandPath(name, platform = process.platform) {
+  const finder = platform === "win32" ? "where.exe" : "which";
+  try {
+    return execFileSync(finder, [name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .trim()
+      .split(/\r?\n/)[0];
+  } catch {
+    return undefined;
+  }
+}
+
+export function grokCliPath({
+  environment = process.env,
+  platform = process.platform,
+} = {}) {
+  if (environment.GROK_CLI) return environment.GROK_CLI;
+  const discovered = commandPath("grok", platform);
+  if (discovered) return discovered;
+
+  const directory = path.join(
+    environment.GROK_HOME || path.join(os.homedir(), ".grok"),
+    "bin",
+  );
+  const candidates = platform === "win32"
+    ? [path.join(directory, "grok.exe"), path.join(directory, "grok")]
+    : [
+        path.join(os.homedir(), ".npm-global", "bin", "grok"),
+        path.join(directory, "grok"),
+      ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function launchDiagnostic(result) {
+  return [
+    result?.error?.code,
+    result?.error?.message,
+    result?.stderr,
+    result?.stdout,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function windowsApplicationControlBlocked(result) {
+  if (WINDOWS_BLOCK_CODES.has(result?.error?.code)) return true;
+  const diagnostic = launchDiagnostic(result);
+  return WINDOWS_BLOCK_PATTERNS.some((pattern) => pattern.test(diagnostic));
+}
+
+export function grokCliPreflight({
+  executable = grokCliPath(),
+  environment = process.env,
+  platform = process.platform,
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  if (!executable) {
+    return {
+      state: "missing",
+      installed: false,
+      runnable: false,
+      detail: "official Grok CLI not found",
+      fix: "Install @xai-official/grok, then run `grok login --oauth`.",
+    };
+  }
+
+  // Smart App Control is Windows-specific. Preserve the existing lightweight
+  // path check on other platforms instead of launching the CLI during status
+  // and doctor commands.
+  if (platform !== "win32") {
+    return { state: "ready", installed: true, runnable: true, executable };
+  }
+
+  const { XAI_API_KEY: _apiKey, ...sanitizedEnvironment } = environment;
+  const result = spawnSyncImpl(executable, ["--version"], {
+    encoding: "utf8",
+    env: sanitizedEnvironment,
+    timeout: 5_000,
+    windowsHide: true,
+  });
+  if (!result.error && result.status === 0) {
+    return { state: "ready", installed: true, runnable: true, executable };
+  }
+  if (windowsApplicationControlBlocked(result)) {
+    return {
+      state: "blocked",
+      installed: true,
+      runnable: false,
+      executable,
+      detail: GROK_CLI_BLOCKED_DETAIL,
+      fix: GROK_CLI_BLOCKED_FIX,
+    };
+  }
+  return {
+    state: "unavailable",
+    installed: true,
+    runnable: false,
+    executable,
+    detail: "installed, but the official Grok CLI could not run",
+    fix: "Run `grok --version` in a terminal, fix the CLI error, then rerun the doctor.",
+  };
+}
+
+export function grokCliFailureMessage(status) {
+  return `${status.detail}. ${status.fix}`;
+}

--- a/src/grok-oauth-session.mjs
+++ b/src/grok-oauth-session.mjs
@@ -1,8 +1,11 @@
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import os from "node:os";
-import path from "node:path";
+import { readFileSync } from "node:fs";
 
+import {
+  grokCliFailureMessage,
+  grokCliPath,
+  grokCliPreflight,
+} from "./grok-cli.mjs";
 import { grokAuthPath, grokSessionEntry } from "./grok-oauth-status.mjs";
 
 const REFRESH_THRESHOLD_MS = 5 * 60 * 1_000;
@@ -49,16 +52,18 @@ function isHardExpired(session, now) {
   return Number.isFinite(session.expiresAt) && session.expiresAt <= now;
 }
 
-function grokExecutable() {
-  if (process.env.GROK_CLI) return process.env.GROK_CLI;
-  const managed = path.join(process.env.GROK_HOME || path.join(os.homedir(), ".grok"), "bin", "grok");
-  return existsSync(managed) ? managed : "grok";
-}
-
-function refreshWithOfficialCli() {
+export function refreshWithOfficialCli({
+  executable = grokCliPath() || "grok",
+  preflightOptions,
+  spawnImpl = spawn,
+} = {}) {
+  const preflight = grokCliPreflight({ executable, ...preflightOptions });
+  if (!preflight.runnable) {
+    return Promise.reject(oauthError(grokCliFailureMessage(preflight)));
+  }
   return new Promise((resolve, reject) => {
     const { XAI_API_KEY: _apiKey, ...environment } = process.env;
-    const child = spawn(grokExecutable(), ["models"], {
+    const child = spawnImpl(executable, ["models"], {
       env: environment,
       stdio: ["ignore", "ignore", "ignore"],
     });

--- a/src/provider-onboarding.mjs
+++ b/src/provider-onboarding.mjs
@@ -3,6 +3,11 @@ import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import {
+  grokCliFailureMessage,
+  grokCliPath,
+  grokCliPreflight,
+} from "./grok-cli.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { KIMI_CLI_NPM_PACKAGE } from "./kimi-oauth-onboarding.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
@@ -20,10 +25,6 @@ const OAUTH_CLIS = Object.freeze({
     executable: "grok",
     npmPackage: "@xai-official/grok",
     loginArgs: ["login", "--oauth"],
-    candidates: [
-      path.join(os.homedir(), ".npm-global", "bin", "grok"),
-      path.join(process.env.GROK_HOME || path.join(os.homedir(), ".grok"), "bin", "grok"),
-    ],
   },
 });
 
@@ -44,6 +45,7 @@ function commandPath(name) {
 export function oauthCliPath(providerId) {
   const cli = OAUTH_CLIS[providerId];
   if (!cli) throw new Error(`Unknown OAuth provider: ${providerId}`);
+  if (providerId === "grok-oauth") return grokCliPath();
   const discovered = commandPath(cli.executable);
   if (discovered) return discovered;
   return cli.candidates.find((candidate) => existsSync(candidate));
@@ -65,7 +67,11 @@ export function providerOnboardingSnapshot() {
   return {
     providers: [...PROVIDERS.values()].map((provider) => {
       if (provider.kind === "oauth") {
-        const cliInstalled = Boolean(oauthCliPath(provider.id));
+        const cliPath = oauthCliPath(provider.id);
+        const cli = provider.id === "grok-oauth"
+          ? grokCliPreflight({ executable: cliPath })
+          : { installed: Boolean(cliPath), runnable: Boolean(cliPath) };
+        const cliInstalled = cli.installed;
         const configured = oauthConfigured(provider.id);
         return {
           id: provider.id,
@@ -73,7 +79,14 @@ export function providerOnboardingSnapshot() {
           kind: "oauth",
           configured,
           cliInstalled,
-          action: !cliInstalled ? "install" : configured ? "ready" : "login",
+          cliRunnable: cli.runnable,
+          action: !cliInstalled
+            ? "install"
+            : !cli.runnable
+              ? "blocked"
+              : configured
+                ? "ready"
+                : "login",
         };
       }
       const configured = credentialStatus(provider, { persistent: true }).configured;
@@ -103,7 +116,15 @@ function npmPath() {
 export function installOauthCli(providerId) {
   const cli = OAUTH_CLIS[providerId];
   if (!cli) throw new Error(`Unknown OAuth provider: ${providerId}`);
-  if (oauthCliPath(providerId)) return;
+  if (providerId === "grok-oauth") {
+    const preflight = grokCliPreflight();
+    if (preflight.installed) {
+      if (!preflight.runnable) throw new Error(grokCliFailureMessage(preflight));
+      return;
+    }
+  } else if (oauthCliPath(providerId)) {
+    return;
+  }
   const npm = npmPath();
   if (!npm) throw new Error("Node.js and npm are required to install this provider CLI.");
   const result = spawnSync(npm, ["install", "-g", cli.npmPackage], {
@@ -113,7 +134,10 @@ export function installOauthCli(providerId) {
   if (result.error || result.status !== 0) {
     throw new Error(`Could not install the official ${cli.executable} CLI.`);
   }
-  if (!oauthCliPath(providerId)) {
+  if (providerId === "grok-oauth") {
+    const preflight = grokCliPreflight();
+    if (!preflight.runnable) throw new Error(grokCliFailureMessage(preflight));
+  } else if (!oauthCliPath(providerId)) {
     throw new Error(`The official ${cli.executable} CLI was installed but could not be located.`);
   }
 }
@@ -121,6 +145,10 @@ export function installOauthCli(providerId) {
 export function loginOauthProvider(providerId) {
   const executable = oauthCliPath(providerId);
   if (!executable) throw new Error("Install the provider CLI before signing in.");
+  if (providerId === "grok-oauth") {
+    const preflight = grokCliPreflight({ executable });
+    if (!preflight.runnable) throw new Error(grokCliFailureMessage(preflight));
+  }
   const result = spawnSync(executable, oauthLoginArgs(providerId), {
     encoding: "utf8",
     env: process.env,

--- a/src/setup-shared.mjs
+++ b/src/setup-shared.mjs
@@ -1,8 +1,12 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { closeSync, existsSync, openSync, readSync, writeSync } from "node:fs";
-import os from "node:os";
+import { closeSync, openSync, readSync, writeSync } from "node:fs";
 import path from "node:path";
 
+import {
+  grokCliFailureMessage,
+  grokCliPath,
+  grokCliPreflight,
+} from "./grok-cli.mjs";
 import {
   KIMI_CLI_INSTALL_URL,
   KIMI_CLI_NPM_PACKAGE,
@@ -246,13 +250,7 @@ function onboardKimiOauth() {
 }
 
 function onboardGrokOauth() {
-  let grok = executable("grok");
-  const installed = path.join(
-    process.env.GROK_HOME || path.join(os.homedir(), ".grok"),
-    "bin",
-    "grok",
-  );
-  if (!grok && existsSync(installed)) grok = installed;
+  let grok = grokCliPath();
   if (!grok) {
     const npm = executable("npm");
     if (!npm || !confirm("Install the official Grok CLI with `npm install -g @xai-official/grok`?")) {
@@ -261,10 +259,11 @@ function onboardGrokOauth() {
       );
     }
     tryRun(npm, ["install", "-g", "@xai-official/grok"]);
-    grok = executable("grok");
-    if (!grok && existsSync(installed)) grok = installed;
+    grok = grokCliPath();
   }
   if (!grok) throw new Error("The official Grok CLI was installed but could not be located.");
+  const preflight = grokCliPreflight({ executable: grok });
+  if (!preflight.runnable) throw new Error(grokCliFailureMessage(preflight));
   for (let attempt = 0; attempt < MAX_LOGIN_ATTEMPTS; attempt += 1) {
     if (!confirm("Run `grok login --oauth` now?")) {
       throw new Error("Grok OAuth setup was cancelled.");

--- a/src/setup-ui.mjs
+++ b/src/setup-ui.mjs
@@ -7,6 +7,7 @@ const ACTION_LABELS = Object.freeze({
   "add-key": "needs API key",
   login: "needs CLI sign-in",
   install: "needs CLI install",
+  blocked: "CLI blocked by Windows",
 });
 
 const COLOR_CODES = Object.freeze({
@@ -38,7 +39,11 @@ export function renderProviderChoices(snapshots, selected, colorEnabled = false)
       const label = providerStatusLabel(snapshot);
       const colored = colorize(
         label,
-        snapshot.action === "ready" ? "green" : "yellow",
+        snapshot.action === "ready"
+          ? "green"
+          : snapshot.action === "blocked"
+            ? "red"
+            : "yellow",
         colorEnabled,
       );
       return `  ${mark} ${position}. ${snapshot.displayName} — ${colored}`;

--- a/test/grok-cli.test.mjs
+++ b/test/grok-cli.test.mjs
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  grokCliFailureMessage,
+  grokCliPreflight,
+  windowsApplicationControlBlocked,
+} from "../src/grok-cli.mjs";
+import { refreshWithOfficialCli } from "../src/grok-oauth-session.mjs";
+
+test("Grok CLI preflight distinguishes a missing executable", () => {
+  const status = grokCliPreflight({ executable: null });
+  assert.equal(status.state, "missing");
+  assert.equal(status.installed, false);
+  assert.equal(status.runnable, false);
+});
+
+test("Grok CLI preflight preserves path-only checks outside Windows", () => {
+  let launches = 0;
+  const status = grokCliPreflight({
+    executable: "/usr/local/bin/grok",
+    platform: "darwin",
+    spawnSyncImpl: () => {
+      launches += 1;
+      return { status: 0 };
+    },
+  });
+  assert.equal(status.state, "ready");
+  assert.equal(status.runnable, true);
+  assert.equal(launches, 0);
+});
+
+test("Grok CLI preflight launches a harmless version check on Windows", () => {
+  let invocation;
+  const status = grokCliPreflight({
+    executable: "C:\\tools\\grok.exe",
+    environment: { XAI_API_KEY: "must-not-leak", SAFE_VALUE: "present" },
+    platform: "win32",
+    spawnSyncImpl: (command, args, options) => {
+      invocation = { command, args, options };
+      return { status: 0, stdout: "0.2.112\n" };
+    },
+  });
+  assert.equal(status.state, "ready");
+  assert.equal(status.runnable, true);
+  assert.equal(invocation.command, "C:\\tools\\grok.exe");
+  assert.deepEqual(invocation.args, ["--version"]);
+  assert.equal(invocation.options.env.SAFE_VALUE, "present");
+  assert.equal("XAI_API_KEY" in invocation.options.env, false);
+});
+
+test("Grok CLI preflight identifies the Windows spawn UNKNOWN policy failure", () => {
+  const status = grokCliPreflight({
+    executable: "grok.cmd",
+    platform: "win32",
+    spawnSyncImpl: () => ({
+      status: 1,
+      error: Object.assign(new Error("spawn UNKNOWN"), { code: "UNKNOWN" }),
+    }),
+  });
+  assert.equal(status.state, "blocked");
+  assert.equal(status.runnable, false);
+  assert.match(status.detail, /application control.*blocked/i);
+  assert.match(status.fix, /Smart App Control enabled/);
+  assert.match(status.fix, /grok-api/);
+  assert.doesNotMatch(grokCliFailureMessage(status), /disable Smart App Control/i);
+});
+
+test("Grok CLI preflight recognizes an Application Control stderr message", () => {
+  const result = {
+    status: 1,
+    stderr: "An Application Control policy has blocked this file",
+  };
+  assert.equal(windowsApplicationControlBlocked(result), true);
+  assert.equal(
+    grokCliPreflight({
+      executable: "grok.exe",
+      platform: "win32",
+      spawnSyncImpl: () => result,
+    }).state,
+    "blocked",
+  );
+});
+
+test("Grok CLI preflight recognizes spawn UNKNOWN from the npm launcher", () => {
+  const status = grokCliPreflight({
+    executable: "grok.cmd",
+    platform: "win32",
+    spawnSyncImpl: () => ({ status: 1, stderr: "Error: spawn UNKNOWN" }),
+  });
+  assert.equal(status.state, "blocked");
+});
+
+test("Grok CLI preflight keeps unrelated Windows failures generic", () => {
+  const status = grokCliPreflight({
+    executable: "grok.exe",
+    platform: "win32",
+    spawnSyncImpl: () => ({ status: 2, stderr: "invalid installation" }),
+  });
+  assert.equal(status.state, "unavailable");
+  assert.match(status.fix, /grok --version/);
+  assert.doesNotMatch(status.detail, /application control/i);
+});
+
+test("Grok OAuth refresh surfaces the Windows policy block before token expiry", async () => {
+  let refreshLaunches = 0;
+  await assert.rejects(
+    refreshWithOfficialCli({
+      executable: "grok.cmd",
+      preflightOptions: {
+        platform: "win32",
+        spawnSyncImpl: () => ({
+          status: 1,
+          error: Object.assign(new Error("spawn UNKNOWN"), { code: "UNKNOWN" }),
+        }),
+      },
+      spawnImpl: () => {
+        refreshLaunches += 1;
+      },
+    }),
+    (error) => {
+      assert.equal(error.code, "oauth_unauthorized");
+      assert.match(error.message, /application control.*blocked/i);
+      assert.match(error.message, /grok-api/);
+      return true;
+    },
+  );
+  assert.equal(refreshLaunches, 0);
+});

--- a/test/setup-ui.test.mjs
+++ b/test/setup-ui.test.mjs
@@ -24,6 +24,7 @@ test("providerStatusLabel maps onboarding actions to friendly text", () => {
   assert.equal(providerStatusLabel({ action: "add-key" }), "needs API key");
   assert.equal(providerStatusLabel({ action: "login" }), "needs CLI sign-in");
   assert.equal(providerStatusLabel({ action: "install" }), "needs CLI install");
+  assert.equal(providerStatusLabel({ action: "blocked" }), "CLI blocked by Windows");
   assert.equal(providerStatusLabel({ action: "mystery" }), "setup required");
 });
 


### PR DESCRIPTION
## Summary

- preflight the official Grok CLI on Windows before onboarding, doctor, and OAuth refresh paths
- distinguish missing, policy-blocked, and otherwise unrunnable CLI installations
- keep Smart App Control enabled and recommend `grok-api` when Windows blocks the OAuth executable
- show a blocked state in provider setup and document the durable refresh limitation

## Root cause

The router treated a discovered Grok CLI path as usable. On Windows, Smart App Control can allow the npm package to install while blocking the native executable, so login and later token refresh both degraded into generic failures.

## Verification

- `node --test test/grok-cli.test.mjs test/grok-oauth-session.test.mjs test/provider-onboarding.test.mjs test/setup-ui.test.mjs` — 29 passed
- `npm test` — 178 passed, 2 skipped
- `npm run check`
- `git diff --check`

Fixes #35