### PR TITLE
feat: publish agent integrations and provider quota telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,12 @@ user.
    arguments, logs, environment snippets, or tracked files.
 4. Determine which provider IDs the user requested: `anthropic-api`,
    `kimi-oauth`, `kimi-api`, `deepseek`, `grok-api`, `qwen-plan`,
-   `zai-coding`, and/or `ollama-cloud`. If they did not specify and
+   `zai-coding`, `ollama-cloud`, and/or `minimax-token-plan`. The
+   catalog-only providers `groq`, `openrouter`, `together`, `fireworks`,
+   `cerebras`, `mistral`, `nvidia-nim`, `siliconflow`, `huggingface`, and
+   `gemini-api` are also selectable, but they ship no preselected models: after
+   the key is stored, the user must run `bin/curate-models PROVIDER` in an
+   interactive terminal to choose models. If they did not specify and
    credentials already exist, use
    `configured` rather than showing providers that cannot authenticate.
 5. For Kimi OAuth, reuse a valid `kimi login` session. If login is needed, run

--- a/README.md
+++ b/README.md
@@ -136,6 +136,54 @@ removable by re-running the command and deselecting). Curated models are
 local to your machine and are not vetted by the repository's compatibility
 tests.
 
+### Catalog-only providers
+
+These OpenAI-compatible providers are registered for routing and credential
+isolation but ship no preselected models, because their catalogs change too
+often for the repository to pin and live-verify individual entries:
+
+| Provider | Provider ID | Base URL |
+| --- | --- | --- |
+| Groq | `groq` | `https://api.groq.com/openai/v1` |
+| OpenRouter | `openrouter` | `https://openrouter.ai/api/v1` |
+| Together AI | `together` | `https://api.together.xyz/v1` |
+| Fireworks AI | `fireworks` | `https://api.fireworks.ai/inference/v1` |
+| Cerebras | `cerebras` | `https://api.cerebras.ai/v1` |
+| Mistral AI | `mistral` | `https://api.mistral.ai/v1` |
+| NVIDIA NIM | `nvidia-nim` | `https://integrate.api.nvidia.com/v1` |
+| SiliconFlow | `siliconflow` | `https://api.siliconflow.cn/v1` |
+| Hugging Face Router | `huggingface` | `https://router.huggingface.co/v1` |
+| Google Gemini API | `gemini-api` | `https://generativelanguage.googleapis.com/v1beta/openai` |
+
+Add a key, then pick the models you want from the provider's live catalog:
+
+```sh
+./bin/model-router codex provider-key groq set
+./bin/curate-models groq
+```
+
+Curated entries carry conservative default metadata and are local to your
+machine. Verify a model before relying on it:
+
+```sh
+./bin/test-model 'groq/MODEL_ID' --live --yes
+```
+
+Each base URL is overridable through the provider's `baseUrlEnv` variable, so a
+regional endpoint or a self-hosted gateway can reuse the same provider entry.
+
+Quota cards work for these providers without any extra configuration. Most
+OpenAI-compatible services report the caller's remaining window on every
+response through `x-ratelimit-*` headers, and Anthropic reports the same facts
+under an `anthropic-ratelimit-*` prefix. The router reads those headers as
+traffic passes through, so a provider starts showing real request and token
+limits after its first request — no balance endpoint, no extra API call, and no
+separate credential. Providers that publish no such headers, including Google
+Gemini, keep showing router traffic only.
+Gemini is routed through Google's OpenAI-compatible surface rather than the
+native Gemini protocol, so it shares the existing forwarder and needs no
+separate adapter.
+
 Only enabled providers appear in an app's picker. Each target has its own
 selection and API-key files:
 

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -3,6 +3,23 @@ import SwiftUI
 
 private let islandBezel = Color(red: 0.004, green: 0.005, blue: 0.007)
 
+private struct IslandActivitySession: Identifiable {
+  let id: String
+  let name: String
+  let requests: [RouterActiveRequest]
+
+  var agents: [RouterActiveRequest] {
+    var seen = Set<String>()
+    return requests.filter { request in
+      seen.insert(request.threadId ?? request.id).inserted
+    }
+  }
+
+  var latestStartedAt: Double {
+    requests.map(\.startedAt).max() ?? 0
+  }
+}
+
 @MainActor
 final class IslandDisplayModel: ObservableObject {
   enum State: Equatable {
@@ -158,6 +175,7 @@ private struct IslandOverlayView: View {
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
   @ObservedObject var store: RouterStore
   @ObservedObject var display: IslandDisplayModel
+  @State private var selectedSessionID: String?
 
   var body: some View {
     VStack(spacing: 0) {
@@ -190,9 +208,10 @@ private struct IslandOverlayView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .foregroundStyle(.white)
-    .onAppear { display.setActiveRequestCount(store.activeRequests.count) }
+    .onAppear { display.setActiveRequestCount(activeSessions.count) }
     .onChange(of: store.activeRequests.count) { count in
-      display.setActiveRequestCount(count)
+      display.setActiveRequestCount(activeSessions.count)
+      if count == 0 { selectedSessionID = nil }
     }
   }
 
@@ -225,11 +244,12 @@ private struct IslandOverlayView: View {
       BouncingSessionName(text: compactSessionName, fontSize: 10.5, weight: .medium)
         .frame(maxWidth: .infinity)
         .layoutPriority(1)
-      if hiddenActiveCount > 0 {
-        Text("+\(hiddenActiveCount)")
+      if !store.activeRequests.isEmpty {
+        Label("\(activeAgentCount)", systemImage: "person.2.fill")
           .font(.system(size: 9.5, weight: .semibold, design: .rounded))
-          .foregroundStyle(.white.opacity(0.56))
+          .foregroundStyle(.white.opacity(0.72))
           .fixedSize()
+          .help("\(activeAgentCount) active \(activeAgentCount == 1 ? "agent" : "agents")")
       }
       if store.activeRequests.isEmpty {
         Text(compactUsageSummary)
@@ -238,9 +258,9 @@ private struct IslandOverlayView: View {
           .lineLimit(1)
           .minimumScaleFactor(0.75)
       }
-      if let weeklyUsedPercent {
+      if let weeklyRemainingPercent {
         VStack(alignment: .trailing, spacing: 0) {
-          Text("\(Int((100 - weeklyUsedPercent).rounded()))%")
+          Text("\(Int(weeklyRemainingPercent.rounded()))%")
             .font(.system(size: 10, weight: .semibold, design: .monospaced))
             .foregroundStyle(.white.opacity(0.9))
             .monospacedDigit()
@@ -302,7 +322,7 @@ private struct IslandOverlayView: View {
           Text(store.activityState.label)
             .font(.system(size: 12, weight: .semibold, design: .rounded))
             .foregroundStyle(store.activityState.tint)
-          Text("\(store.activeRequestCount) ACTIVE \(store.activeRequestCount == 1 ? "SESSION" : "SESSIONS")")
+          Text("\(activeSessions.count) \(activeSessions.count == 1 ? "SESSION" : "SESSIONS") • \(activeAgentCount) \(activeAgentCount == 1 ? "AGENT" : "AGENTS")")
             .font(.system(size: 8, weight: .semibold, design: .monospaced))
             .foregroundStyle(routerMuted)
         }
@@ -315,10 +335,10 @@ private struct IslandOverlayView: View {
         }
       }
       ScrollView(.vertical) {
-        ActiveRequestList(store: store, limit: store.activeRequests.count, compact: true)
+        IslandSessionList(sessions: activeSessions, compact: true)
       }
       .scrollIndicators(.hidden)
-      .frame(maxHeight: CGFloat(store.activeRequestCount) * 40)
+      .frame(maxHeight: CGFloat(max(1, activeSessions.count)) * 40)
 
       HStack {
         Text("DAILY USAGE")
@@ -340,6 +360,16 @@ private struct IslandOverlayView: View {
   }
 
   private var expandedContent: some View {
+    Group {
+      if activeSessions.isEmpty {
+        usageExpandedContent
+      } else {
+        sessionExpandedContent
+      }
+    }
+  }
+
+  private var usageExpandedContent: some View {
     VStack(spacing: 13) {
       HStack(spacing: 10) {
         LiveOrb(state: store.activityState, count: store.activeRequestCount)
@@ -427,6 +457,67 @@ private struct IslandOverlayView: View {
     .padding(.bottom, 12)
   }
 
+  private var sessionExpandedContent: some View {
+    VStack(spacing: 12) {
+      HStack(spacing: 10) {
+        if selectedSession != nil {
+          Button {
+            selectedSessionID = nil
+          } label: {
+            Image(systemName: "chevron.left")
+          }
+          .buttonStyle(.plain)
+          .foregroundStyle(routerMuted)
+        }
+        LiveOrb(state: store.activityState, count: activeAgentCount)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(selectedSession?.name ?? "Active sessions")
+            .font(.system(size: 15, weight: .semibold, design: .rounded))
+            .lineLimit(1)
+          Text(selectedSession == nil
+            ? "\(activeSessions.count) running • \(activeAgentCount) active agents"
+            : "\(selectedSession?.agents.count ?? 0) assigned agents")
+            .font(.system(size: 9, weight: .medium, design: .rounded))
+            .foregroundStyle(store.activityState.tint)
+        }
+        Spacer()
+        if let weeklyRemainingPercent {
+          IslandHeaderMetric(
+            value: "\(Int(weeklyRemainingPercent.rounded()))%",
+            label: "WEEKLY LEFT"
+          )
+        }
+        Button("Collapse") { display.setState(.peek) }
+          .buttonStyle(.plain)
+          .font(.system(size: 9, weight: .medium, design: .rounded))
+          .foregroundStyle(routerMuted)
+      }
+
+      Divider().overlay(Color.white.opacity(0.08))
+
+      if let session = selectedSession {
+        ScrollView(.vertical) {
+          IslandAgentList(store: store, session: session)
+        }
+        .scrollIndicators(.hidden)
+      } else {
+        ScrollView(.vertical) {
+          IslandSessionList(
+            sessions: activeSessions,
+            compact: false,
+            onSelect: { selectedSessionID = $0 }
+          )
+        }
+        .scrollIndicators(.hidden)
+      }
+
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 17)
+    .padding(.top, 13)
+    .padding(.bottom, 12)
+  }
+
   private var glow: some View {
     StatusGlow(state: store.activityState)
       .id("\(store.activityState.rawValue)-\(store.activeRequestCount)")
@@ -448,8 +539,27 @@ private struct IslandOverlayView: View {
       ?? "Ready"
   }
 
-  private var hiddenActiveCount: Int {
-    max(0, store.activeRequestCount - 1)
+  private var activeSessions: [IslandActivitySession] {
+    let grouped = Dictionary(grouping: store.activeRequests) { request in
+      request.sessionId ?? request.sessionName ?? "request-\(request.id)"
+    }
+    return grouped.map { id, requests in
+      let fallback = requests.first.map(store.sessionName(for:)) ?? "Active session"
+      let name = requests.compactMap(\.sessionName).first
+        ?? (grouped.count == 1 ? store.activitySessionName : nil)
+        ?? fallback
+      return IslandActivitySession(id: id, name: name, requests: requests)
+    }
+    .sorted { $0.latestStartedAt > $1.latestStartedAt }
+  }
+
+  private var activeAgentCount: Int {
+    activeSessions.reduce(0) { $0 + $1.agents.count }
+  }
+
+  private var selectedSession: IslandActivitySession? {
+    guard let selectedSessionID else { return nil }
+    return activeSessions.first(where: { $0.id == selectedSessionID })
   }
 
   private var sourceLabel: String {
@@ -488,20 +598,20 @@ private struct IslandOverlayView: View {
     return max(0, min(100, used))
   }
 
-  private var weeklyUsedPercent: Double? {
+  private var weeklyRemainingPercent: Double? {
     if store.selectedUsageUsesChatGPT {
       let windows = [store.accountUsage?.primary, store.accountUsage?.secondary].compactMap { $0 }
       guard let weekly = windows.first(where: { $0.durationLabel == "Weekly limit" }) else {
         return nil
       }
-      return Double(max(0, min(100, weekly.usedPercent)))
+      return Double(max(0, min(100, weekly.remainingPercent)))
     }
     guard let weekly = store.selectedProviderUsage?.account.metrics.first(where: {
       $0.kind == "quota" && standardizedLimitLabel($0.label) == "Weekly limit"
-    }), let used = weekly.usedPercent else {
+    }), let remaining = weekly.remainingPercent else {
       return nil
     }
-    return max(0, min(100, used))
+    return max(0, min(100, remaining))
   }
 
   private var accountUsageLabel: String {
@@ -515,12 +625,14 @@ private struct IslandOverlayView: View {
   }
 
   private var accountHeaderValue: String? {
+    if let weeklyRemainingPercent { return "\(Int(weeklyRemainingPercent.rounded()))%" }
     if let quotaUsedPercent { return "\(Int(quotaUsedPercent.rounded()))%" }
     guard let metric = store.selectedAccountMetric, metric.kind == "balance" else { return nil }
     return formattedAccountMetric(metric)
   }
 
   private var accountHeaderLabel: String {
+    if weeklyRemainingPercent != nil { return "WEEKLY LEFT" }
     if quotaUsedPercent != nil {
       let window = accountUsageLabel.replacingOccurrences(
         of: " limit",
@@ -890,6 +1002,132 @@ private struct BouncingSessionName: View {
         try? await Task.sleep(nanoseconds: UInt64((travelDuration + 0.7) * 1_000_000_000))
       }
     }
+  }
+}
+
+private struct IslandSessionList: View {
+  let sessions: [IslandActivitySession]
+  let compact: Bool
+  var onSelect: ((String) -> Void)?
+
+  init(
+    sessions: [IslandActivitySession],
+    compact: Bool,
+    onSelect: ((String) -> Void)? = nil
+  ) {
+    self.sessions = sessions
+    self.compact = compact
+    self.onSelect = onSelect
+  }
+
+  var body: some View {
+    VStack(spacing: compact ? 5 : 7) {
+      ForEach(sessions) { session in
+        Group {
+          if let onSelect {
+            Button { onSelect(session.id) } label: { row(session) }
+              .buttonStyle(.plain)
+          } else {
+            row(session)
+          }
+        }
+      }
+    }
+  }
+
+  private func row(_ session: IslandActivitySession) -> some View {
+    HStack(spacing: 9) {
+      ProviderIcon(providerID: session.requests.first?.provider ?? "openai", size: compact ? 22 : 26)
+      VStack(alignment: .leading, spacing: 2) {
+        Text(session.name)
+          .font(.system(size: compact ? 10.5 : 11.5, weight: .semibold, design: .rounded))
+          .foregroundStyle(.white.opacity(0.94))
+          .lineLimit(1)
+        Text("\(session.agents.count) \(session.agents.count == 1 ? "agent" : "agents")")
+          .font(.system(size: 8.5, weight: .medium, design: .monospaced))
+          .foregroundStyle(routerMuted)
+      }
+      Spacer()
+      if !compact {
+        Text(shortModelSummary(session))
+          .font(.system(size: 8.5, weight: .medium, design: .rounded))
+          .foregroundStyle(routerYellow.opacity(0.9))
+          .lineLimit(1)
+        Image(systemName: "chevron.right")
+          .font(.system(size: 8, weight: .bold))
+          .foregroundStyle(routerMuted)
+      }
+    }
+    .padding(.horizontal, compact ? 8 : 11)
+    .padding(.vertical, compact ? 5 : 9)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .contentShape(Rectangle())
+    .background(Color.white.opacity(0.038), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 8, style: .continuous)
+        .stroke(Color.white.opacity(0.055), lineWidth: 0.5)
+    }
+  }
+
+  private func shortModelSummary(_ session: IslandActivitySession) -> String {
+    let models = Array(Set(session.agents.compactMap(\.model))).sorted()
+    guard let first = models.first else { return "Active" }
+    let short = first.split(separator: "/").last.map(String.init) ?? first
+    return models.count == 1 ? short : "\(short) +\(models.count - 1)"
+  }
+}
+
+private struct IslandAgentList: View {
+  @ObservedObject var store: RouterStore
+  let session: IslandActivitySession
+
+  var body: some View {
+    VStack(spacing: 7) {
+      ForEach(session.agents) { request in
+        HStack(spacing: 10) {
+          ProviderIcon(providerID: request.provider, size: 24)
+          VStack(alignment: .leading, spacing: 2) {
+            Text(agentLabel(request))
+              .font(.system(size: 11, weight: .semibold, design: .rounded))
+              .foregroundStyle(.white.opacity(0.94))
+              .lineLimit(1)
+            Text(store.modelLabel(for: request))
+              .font(.system(size: 8.5, weight: .medium, design: .monospaced))
+              .foregroundStyle(routerMuted)
+              .lineLimit(1)
+          }
+          Spacer()
+          TimelineView(.periodic(from: .now, by: 1)) { context in
+            Text(elapsedLabel(for: request, now: context.date))
+              .font(.system(size: 9, weight: .medium, design: .rounded))
+              .foregroundStyle(routerYellow.opacity(0.95))
+              .monospacedDigit()
+          }
+        }
+        .padding(.horizontal, 11)
+        .padding(.vertical, 9)
+        .background(Color.white.opacity(0.038), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .stroke(Color.white.opacity(0.055), lineWidth: 0.5)
+        }
+      }
+    }
+  }
+
+  private func agentLabel(_ request: RouterActiveRequest) -> String {
+    if let name = request.agentName, !name.isEmpty {
+      return name.replacingOccurrences(of: "_", with: " ")
+    }
+    if let nickname = request.agentNickname, !nickname.isEmpty { return nickname }
+    return request.isSubagent == true ? "Agent" : "Primary"
+  }
+
+  private func elapsedLabel(for request: RouterActiveRequest, now: Date) -> String {
+    let started = Date(timeIntervalSince1970: request.startedAt / 1000)
+    let seconds = max(0, Int(now.timeIntervalSince(started)))
+    if seconds < 60 { return "\(seconds)s" }
+    return "\(seconds / 60)m \(seconds % 60)s"
   }
 }
 

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -904,6 +904,12 @@ struct RouterActiveRequest: Decodable, Identifiable, Equatable {
   let provider: String
   let model: String?
   let sessionName: String?
+  let sessionId: String?
+  let threadId: String?
+  let parentThreadId: String?
+  let agentName: String?
+  let agentNickname: String?
+  let isSubagent: Bool?
   let startedAt: Double
 }
 

--- a/config/providers.json
+++ b/config/providers.json
@@ -176,6 +176,199 @@
         ],
         "prompt": "MiniMax Token Plan API key"
       }
+    },
+    {
+      "id": "groq",
+      "displayName": "Groq",
+      "kind": "openai-compatible",
+      "ownedBy": "groq",
+      "baseUrl": "https://api.groq.com/openai/v1",
+      "baseUrlEnv": "GROQ_API_BASE_URL",
+      "credential": {
+        "environment": [
+          "GROQ_API_KEY"
+        ],
+        "file": "groq-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-groq"
+        ],
+        "prompt": "Groq API key"
+      }
+    },
+    {
+      "id": "openrouter",
+      "displayName": "OpenRouter",
+      "kind": "openai-compatible",
+      "ownedBy": "openrouter",
+      "baseUrl": "https://openrouter.ai/api/v1",
+      "baseUrlEnv": "OPENROUTER_API_BASE_URL",
+      "credential": {
+        "environment": [
+          "OPENROUTER_API_KEY"
+        ],
+        "file": "openrouter-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-openrouter"
+        ],
+        "prompt": "OpenRouter API key"
+      }
+    },
+    {
+      "id": "together",
+      "displayName": "Together AI",
+      "kind": "openai-compatible",
+      "ownedBy": "together",
+      "baseUrl": "https://api.together.xyz/v1",
+      "baseUrlEnv": "TOGETHER_API_BASE_URL",
+      "credential": {
+        "environment": [
+          "TOGETHER_API_KEY"
+        ],
+        "file": "together-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-together"
+        ],
+        "prompt": "Together AI API key"
+      }
+    },
+    {
+      "id": "fireworks",
+      "displayName": "Fireworks AI",
+      "kind": "openai-compatible",
+      "ownedBy": "fireworks",
+      "baseUrl": "https://api.fireworks.ai/inference/v1",
+      "baseUrlEnv": "FIREWORKS_API_BASE_URL",
+      "credential": {
+        "environment": [
+          "FIREWORKS_API_KEY"
+        ],
+        "file": "fireworks-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-fireworks"
+        ],
+        "prompt": "Fireworks AI API key"
+      }
+    },
+    {
+      "id": "cerebras",
+      "displayName": "Cerebras",
+      "kind": "openai-compatible",
+      "ownedBy": "cerebras",
+      "baseUrl": "https://api.cerebras.ai/v1",
+      "baseUrlEnv": "CEREBRAS_API_BASE_URL",
+      "credential": {
+        "environment": [
+          "CEREBRAS_API_KEY"
+        ],
+        "file": "cerebras-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-cerebras"
+        ],
+        "prompt": "Cerebras API key"
+      }
+    },
+    {
+      "id": "mistral",
+      "displayName": "Mistral AI",
+      "kind": "openai-compatible",
+      "ownedBy": "mistral",
+      "baseUrl": "https://api.mistral.ai/v1",
+      "baseUrlEnv": "MISTRAL_API_BASE_URL",
+      "credential": {
+        "environment": [
+          "MISTRAL_API_KEY"
+        ],
+        "file": "mistral-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-mistral"
+        ],
+        "prompt": "Mistral AI API key"
+      }
+    },
+    {
+      "id": "nvidia-nim",
+      "displayName": "NVIDIA NIM",
+      "kind": "openai-compatible",
+      "ownedBy": "nvidia",
+      "baseUrl": "https://integrate.api.nvidia.com/v1",
+      "baseUrlEnv": "NVIDIA_NIM_BASE_URL",
+      "credential": {
+        "environment": [
+          "NVIDIA_API_KEY",
+          "NVIDIA_NIM_API_KEY"
+        ],
+        "file": "nvidia-nim-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-nvidia-nim"
+        ],
+        "prompt": "NVIDIA NIM API key"
+      }
+    },
+    {
+      "id": "siliconflow",
+      "displayName": "SiliconFlow",
+      "kind": "openai-compatible",
+      "ownedBy": "siliconflow",
+      "baseUrl": "https://api.siliconflow.cn/v1",
+      "baseUrlEnv": "SILICONFLOW_BASE_URL",
+      "credential": {
+        "environment": [
+          "SILICONFLOW_API_KEY"
+        ],
+        "file": "siliconflow-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-siliconflow"
+        ],
+        "prompt": "SiliconFlow API key"
+      }
+    },
+    {
+      "id": "huggingface",
+      "displayName": "Hugging Face Router",
+      "kind": "openai-compatible",
+      "ownedBy": "huggingface",
+      "baseUrl": "https://router.huggingface.co/v1",
+      "baseUrlEnv": "HUGGINGFACE_BASE_URL",
+      "credential": {
+        "environment": [
+          "HF_TOKEN",
+          "HUGGINGFACE_API_KEY"
+        ],
+        "file": "huggingface-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-huggingface"
+        ],
+        "prompt": "Hugging Face access token"
+      }
+    },
+    {
+      "id": "gemini-api",
+      "displayName": "Google Gemini API",
+      "kind": "openai-compatible",
+      "ownedBy": "google",
+      "baseUrl": "https://generativelanguage.googleapis.com/v1beta/openai",
+      "baseUrlEnv": "GEMINI_API_BASE_URL",
+      "credential": {
+        "environment": [
+          "GEMINI_API_KEY",
+          "GOOGLE_API_KEY"
+        ],
+        "file": "gemini-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-gemini-api"
+        ],
+        "prompt": "Google Gemini API key"
+      }
     }
   ],
   "models": [

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -11,6 +11,8 @@
 - `src/grok-oauth-forwarder.mjs` adapts Grok CLI OAuth to OpenAI-compatible chat.
 - `src/api-forwarder.mjs` is shared by all API-key providers.
 - `src/provider-credentials.mjs` isolates environment, file, and Keychain lookup.
+- `src/rate-limit-headers.mjs` parses provider rate-limit headers into snapshots.
+- `src/rate-limit-state.mjs` stores the latest observed window per provider.
 - `src/provider-selection.mjs` controls which tested models enter the picker.
 - `src/start.mjs` supervises the loopback processes.
 - `src/service-*.mjs` install per-user services for macOS, Linux, and Windows.

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -15,6 +15,8 @@ import {
   PROVIDERS,
   providerForModel,
 } from "./model-registry.mjs";
+import { parseRateLimitHeaders } from "./rate-limit-headers.mjs";
+import { recordRateLimitSnapshot } from "./rate-limit-state.mjs";
 import { readProviderSelection } from "./provider-selection.mjs";
 import {
   credentialStatus,
@@ -298,6 +300,13 @@ async function handleRequest(request, response) {
     signal: controller.signal,
   });
   await pipeResponse(upstream, response);
+  // Harvest the provider's own quota report from the response it just sent.
+  // Costs no extra request and works for any provider that emits the standard
+  // headers, so a newly added provider reports limits without bespoke code.
+  // Recorded after the body streams because persisting is synchronous I/O and
+  // must never sit in time-to-first-byte.
+  const rateLimit = parseRateLimitHeaders(upstream.headers);
+  if (rateLimit) recordRateLimitSnapshot(normalized.provider.id, rateLimit);
   if (!QUIET) {
     console.error(
       `[api-forwarder] provider=${normalized.provider.id} model=${normalized.model.upstreamModel} status=${upstream.status} duration_ms=${Date.now() - startedAt}`,

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -17,6 +17,7 @@ import {
   NATIVE_CATALOG_PATH,
 } from "./paths.mjs";
 import { codexIsAuthenticated, requireCodexBinary } from "./codex-binary.mjs";
+import { syncRoutedCodexAgents } from "./codex-agent-catalog.mjs";
 import { MODEL_BY_SLUG } from "./model-registry.mjs";
 import { buildNativeAliasAssignments } from "./native-alias.mjs";
 import { selectedConfiguredListedModels } from "./provider-selection.mjs";
@@ -233,11 +234,13 @@ function main() {
       };
   atomicJson(MERGED_CATALOG_PATH, { models: merged });
   atomicJson(NATIVE_ALIAS_PATH, { version: 1, aliases });
+  const routedAgents = syncRoutedCodexAgents(routedModels);
   process.stdout.write(
     `${JSON.stringify({
       path: MERGED_CATALOG_PATH,
       models: merged.length,
       routed_models: routedModels.length,
+      routed_agents: routedAgents.length,
       native_models: !loginFree && openaiAuthenticated
         ? merged.filter((model) => !MODEL_BY_SLUG.has(String(model.slug))).length
         : 0,

--- a/src/codex-agent-catalog.mjs
+++ b/src/codex-agent-catalog.mjs
@@ -1,0 +1,57 @@
+import { mkdirSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { protectPrivateFile } from "./file-security.mjs";
+import { CODEX_AGENTS_DIR } from "./paths.mjs";
+
+function safeIdentifier(value, separator) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, separator)
+    .replace(new RegExp(`^\\${separator}+|\\${separator}+$`, "g"), "");
+}
+
+function tomlString(value) {
+  return JSON.stringify(String(value));
+}
+
+export function routedAgentDefinition(model) {
+  const slug = String(model?.slug || "").trim();
+  if (!slug || !slug.includes("/")) {
+    throw new Error(`Cannot create a routed agent for invalid model slug: ${slug || "<empty>"}`);
+  }
+  const fileStem = `router-model-${safeIdentifier(slug, "-")}`;
+  const agentName = `router_${safeIdentifier(slug, "_")}`;
+  const displayName = String(model.displayName || model.display_name || slug).trim();
+  const contents = [
+    "# Managed by Codex Router. Refresh the model catalog to update this file.",
+    `name = ${tomlString(agentName)}`,
+    `description = ${tomlString(`${displayName} agent routed through an authenticated Codex Router provider.`)}`,
+    'model_provider = "codex-router"',
+    `model = ${tomlString(slug)}`,
+    "",
+    'developer_instructions = """',
+    "Complete the bounded task assigned by the parent agent.",
+    "Respect repository instructions, keep changes surgical, and run relevant verification.",
+    "Return a concise summary of work completed, checks run, and remaining risks.",
+    '"""',
+    "",
+  ].join("\n");
+  return { agentName, fileName: `${fileStem}.toml`, contents };
+}
+
+export function syncRoutedCodexAgents(models, agentsDir = CODEX_AGENTS_DIR) {
+  mkdirSync(agentsDir, { recursive: true, mode: 0o700 });
+  const written = [];
+  for (const model of models) {
+    const definition = routedAgentDefinition(model);
+    const target = path.join(agentsDir, definition.fileName);
+    const temporary = `${target}.tmp.${process.pid}`;
+    writeFileSync(temporary, definition.contents, { encoding: "utf8", mode: 0o600 });
+    protectPrivateFile(temporary);
+    renameSync(temporary, target);
+    protectPrivateFile(target);
+    written.push({ model: model.slug, agent: definition.agentName, path: target });
+  }
+  return written;
+}

--- a/src/codex-session-names.mjs
+++ b/src/codex-session-names.mjs
@@ -1,4 +1,11 @@
-import { readFileSync, statSync } from "node:fs";
+import {
+  closeSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -15,10 +22,14 @@ const METADATA_ID_KEYS = new Set([
 export const SESSION_INDEX_PATH =
   process.env.CODEX_ROUTER_SESSION_INDEX ||
   path.join(process.env.CODEX_HOME || path.join(os.homedir(), ".codex"), "session_index.jsonl");
+export const SESSIONS_PATH =
+  process.env.CODEX_ROUTER_SESSIONS_PATH ||
+  path.join(process.env.CODEX_HOME || path.join(os.homedir(), ".codex"), "sessions");
 
 let cachedPath;
 let cachedModifiedAt = -1;
 let cachedNames = new Map();
+const cachedRolloutMetadata = new Map();
 
 function headerText(headers, name) {
   const value = headers?.[name];
@@ -46,7 +57,7 @@ function metadataThreadId(value) {
 }
 
 export function threadIdFromHeaders(headers = {}) {
-  for (const name of ["thread-id", "session-id", "session_id", "x-codex-parent-thread-id"]) {
+  for (const name of ["thread-id", "session-id", "session_id"]) {
     const id = uuidIn(headerText(headers, name));
     if (id) return id;
   }
@@ -58,6 +69,80 @@ export function threadIdFromHeaders(headers = {}) {
   } catch {
     return undefined;
   }
+}
+
+export function parentThreadIdFromHeaders(headers = {}) {
+  return uuidIn(headerText(headers, "x-codex-parent-thread-id"));
+}
+
+function findRollout(root, threadId) {
+  let entries;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+  for (const entry of entries) {
+    const target = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      const nested = findRollout(target, threadId);
+      if (nested) return nested;
+    } else if (entry.isFile() && entry.name.endsWith(`-${threadId}.jsonl`)) {
+      return target;
+    }
+  }
+  return undefined;
+}
+
+function firstJsonLine(filePath) {
+  let descriptor;
+  try {
+    descriptor = openSync(filePath, "r");
+    const buffer = Buffer.alloc(64 * 1024);
+    const length = readSync(descriptor, buffer, 0, buffer.length, 0);
+    const line = buffer.subarray(0, length).toString("utf8").split("\n", 1)[0];
+    return JSON.parse(line);
+  } catch {
+    return undefined;
+  } finally {
+    if (descriptor !== undefined) closeSync(descriptor);
+  }
+}
+
+function rolloutMetadata(threadId, sessionsPath) {
+  if (!threadId) return undefined;
+  const key = `${sessionsPath}:${threadId.toLowerCase()}`;
+  if (cachedRolloutMetadata.has(key)) return cachedRolloutMetadata.get(key);
+  const rolloutPath = findRollout(sessionsPath, threadId);
+  const payload = rolloutPath ? firstJsonLine(rolloutPath)?.payload : undefined;
+  const spawn = payload?.source?.subagent?.thread_spawn;
+  const metadata = {
+    threadId,
+    parentThreadId: uuidIn(spawn?.parent_thread_id),
+    agentPath: typeof spawn?.agent_path === "string" ? spawn.agent_path : undefined,
+    agentNickname:
+      typeof spawn?.agent_nickname === "string" ? spawn.agent_nickname : undefined,
+    isSubagent: Boolean(spawn),
+  };
+  cachedRolloutMetadata.set(key, metadata);
+  return metadata;
+}
+
+function rootThreadId(threadId, sessionsPath) {
+  let current = threadId;
+  const visited = new Set();
+  while (current && !visited.has(current.toLowerCase())) {
+    visited.add(current.toLowerCase());
+    const parent = rolloutMetadata(current, sessionsPath)?.parentThreadId;
+    if (!parent) return current;
+    current = parent;
+  }
+  return threadId;
+}
+
+function shortAgentName(agentPath) {
+  if (typeof agentPath !== "string") return undefined;
+  return agentPath.split("/").filter(Boolean).at(-1);
 }
 
 function sessionNames(indexPath) {
@@ -91,4 +176,32 @@ export function sessionNameFromHeaders(headers, { indexPath = SESSION_INDEX_PATH
   const id = threadIdFromHeaders(headers);
   if (!id) return undefined;
   return sessionNames(indexPath).get(id.toLowerCase());
+}
+
+export function activityMetadataFromHeaders(
+  headers,
+  { indexPath = SESSION_INDEX_PATH, sessionsPath = SESSIONS_PATH } = {},
+) {
+  const threadId = threadIdFromHeaders(headers);
+  const rollout = rolloutMetadata(threadId, sessionsPath);
+  const headerParent = parentThreadIdFromHeaders(headers);
+  const parentThreadId = rollout?.parentThreadId || headerParent;
+  const sessionId = rootThreadId(parentThreadId || threadId, sessionsPath);
+  const sessionName = sessionId
+    ? sessionNames(indexPath).get(sessionId.toLowerCase())
+    : undefined;
+  const headerAgent = headerText(headers, "x-openai-subagent")?.trim();
+  const agentName = shortAgentName(rollout?.agentPath) ||
+    (headerAgent && !["1", "true"].includes(headerAgent.toLowerCase())
+      ? headerAgent
+      : undefined);
+  return {
+    ...(threadId ? { threadId } : {}),
+    ...(parentThreadId ? { parentThreadId } : {}),
+    ...(sessionId ? { sessionId } : {}),
+    ...(sessionName ? { sessionName } : {}),
+    ...(agentName ? { agentName } : {}),
+    ...(rollout?.agentNickname ? { agentNickname: rollout.agentNickname } : {}),
+    isSubagent: Boolean(rollout?.isSubagent || parentThreadId || headerAgent),
+  };
 }

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -51,6 +51,7 @@ function managedStateDir() {
 export const STATE_DIR = process.env.MODEL_ROUTER_STATE_DIR || managedStateDir();
 export const LEGACY_STATE_DIR = path.join(CODEX_HOME, "kimi-router");
 export const CONFIG_PATH = path.join(CODEX_HOME, "config.toml");
+export const CODEX_AGENTS_DIR = path.join(CODEX_HOME, "agents");
 export const NATIVE_CATALOG_PATH = path.join(STATE_DIR, "native-models.json");
 export const MERGED_CATALOG_PATH = path.join(STATE_DIR, "merged-models.json");
 export const NATIVE_ALIAS_PATH = path.join(STATE_DIR, "native-aliases.json");

--- a/src/provider-account-usage.mjs
+++ b/src/provider-account-usage.mjs
@@ -6,6 +6,8 @@ import { ensureFreshKimiOAuthToken, kimiIdentityHeaders } from "./kimi-oauth-ses
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { resolveProviderCredential } from "./provider-credentials.mjs";
+import { cooldownUntil } from "./rate-limit-headers.mjs";
+import { rateLimitSnapshotFor } from "./rate-limit-state.mjs";
 import { VERSION } from "./version.mjs";
 
 const REQUEST_TIMEOUT_MS = 8_000;
@@ -20,7 +22,7 @@ function resetTimestamp(value) {
   return Number.isFinite(milliseconds) ? milliseconds / 1_000 : undefined;
 }
 
-function quotaMetric(label, detail) {
+function quotaMetric(label, detail, unit = "requests") {
   const limit = numberValue(detail?.limit);
   const used = numberValue(detail?.used);
   const remaining = numberValue(detail?.remaining);
@@ -40,7 +42,7 @@ function quotaMetric(label, detail) {
     used: resolvedUsed,
     limit,
     remaining: Number.isFinite(remaining) ? remaining : Math.max(0, limit - resolvedUsed),
-    unit: "requests",
+    unit,
     ...(resetTimestamp(detail?.resetTime ?? detail?.reset_time ?? detail?.resetAt) !== undefined
       ? { resetAt: resetTimestamp(detail?.resetTime ?? detail?.reset_time ?? detail?.resetAt) }
       : {}),
@@ -283,6 +285,36 @@ function localOnly(message) {
   return { status: "local-only", source: "local-router", metrics: [], message };
 }
 
+// Providers without a documented balance endpoint still report the caller's
+// current window on every response header. Those observations are recorded by
+// the forwarder, so a provider shows real quota cards once it has served one
+// request — no extra API call and no per-provider integration.
+function headerQuota(providerId) {
+  const snapshot = rateLimitSnapshotFor(providerId);
+  if (!snapshot) return undefined;
+  const metrics = [
+    quotaMetric("Request limit", snapshot.requests, "requests"),
+    quotaMetric("Token limit", snapshot.tokens, "tokens"),
+  ].filter(Boolean);
+  if (!metrics.length) return undefined;
+  return {
+    status: "available",
+    source: "response-headers",
+    metrics,
+    observedAt: resetTimestamp(snapshot.observedAt),
+    ...(cooldownUntil(snapshot) !== undefined
+      ? { cooldownUntil: resetTimestamp(cooldownUntil(snapshot)) }
+      : {}),
+    message: "Reported by the provider on its most recent response",
+  };
+}
+
+// Prefer a real account balance; fall back to the observed response headers
+// before degrading to router-traffic-only.
+function withHeaderQuota(providerId, fallback) {
+  return headerQuota(providerId) || fallback;
+}
+
 const ZAI_QUOTA_URL =
   process.env.ZAI_QUOTA_URL || "https://api.z.ai/api/monitor/usage/quota/limit";
 const ZAI_PLAN_DASHBOARD_URL = "https://z.ai/manage-apikey/coding-plan/personal/my-plan";
@@ -382,12 +414,18 @@ async function accountUsageFor(providerId, fetchImpl) {
     if (providerId === "grok-oauth") return await grokOAuthAccount(fetchImpl);
     if (providerId === "grok-api") {
       return resolveProviderCredential("grok-api")
-        ? localOnly("xAI API account balance is unavailable; showing router traffic")
+        ? withHeaderQuota(
+            providerId,
+            localOnly("xAI API account balance is unavailable; showing router traffic"),
+          )
         : { status: "not-configured", source: "official-api", metrics: [] };
     }
     if (providerId === "anthropic-api") {
       return resolveProviderCredential("anthropic-api")
-        ? localOnly("Anthropic API account balance is unavailable; showing router traffic")
+        ? withHeaderQuota(
+            providerId,
+            localOnly("Anthropic API account balance is unavailable; showing router traffic"),
+          )
         : { status: "not-configured", source: "official-api", metrics: [] };
     }
     if (providerId === "zai-coding") return await zaiCodingAccount(fetchImpl);
@@ -396,7 +434,10 @@ async function accountUsageFor(providerId, fetchImpl) {
       // import browser cookies. Link to the console instead.
       return resolveProviderCredential("qwen-plan")
         ? {
-            ...localOnly("Alibaba shows plan quotas only in its console; showing router traffic"),
+            ...withHeaderQuota(
+              providerId,
+              localOnly("Alibaba shows plan quotas only in its console; showing router traffic"),
+            ),
             dashboardUrl: QWEN_PLAN_DASHBOARD_URL,
           }
         : { status: "not-configured", source: "official-api", metrics: [] };
@@ -404,12 +445,17 @@ async function accountUsageFor(providerId, fetchImpl) {
     if (providerId === "ollama-cloud") {
       return resolveProviderCredential("ollama-cloud")
         ? {
-            ...localOnly("Ollama shows account usage only on ollama.com; showing router traffic"),
+            ...withHeaderQuota(
+              providerId,
+              localOnly("Ollama shows account usage only on ollama.com; showing router traffic"),
+            ),
             dashboardUrl: OLLAMA_DASHBOARD_URL,
           }
         : { status: "not-configured", source: "official-api", metrics: [] };
     }
-    return localOnly("Showing router traffic");
+    // Every remaining provider — including the catalog-only ones — reports its
+    // window through response headers or shows router traffic alone.
+    return withHeaderQuota(providerId, localOnly("Showing router traffic"));
   } catch (error) {
     return {
       status: "unavailable",

--- a/src/rate-limit-headers.mjs
+++ b/src/rate-limit-headers.mjs
@@ -1,0 +1,113 @@
+// Passive rate-limit discovery.
+//
+// Most OpenAI-compatible providers report the caller's remaining quota on every
+// response through `x-ratelimit-*` headers, and Anthropic reports the same facts
+// under an `anthropic-ratelimit-*` prefix. Reading them costs no extra request
+// and needs no provider-specific balance endpoint, so a provider reports its own
+// limits as soon as the user makes a real call.
+//
+// This module is pure parsing. Persistence lives in rate-limit-state.mjs.
+
+const DURATION_PATTERN = /^(?:(\d+(?:\.\d+)?)h)?(?:(\d+(?:\.\d+)?)m(?!s))?(?:(\d+(?:\.\d+)?)m?s)?$/;
+
+function finiteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function count(value) {
+  const number = finiteNumber(value);
+  return number !== undefined && number >= 0 ? Math.round(number) : undefined;
+}
+
+// Providers express resets three different ways: a Go-style duration
+// ("2m59.56s", "7.66s"), bare seconds ("60"), or an absolute timestamp. All three
+// normalize to an absolute epoch milliseconds value so consumers never re-parse.
+export function resetAt(value, now = Date.now()) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) return undefined;
+
+  const bare = finiteNumber(text);
+  if (bare !== undefined) {
+    // A plain number is seconds-from-now when small, and an epoch when it is
+    // large enough to be a real timestamp (some gateways send epoch seconds).
+    if (bare >= 1_000_000_000) return Math.round(bare * (bare >= 1e12 ? 1 : 1000));
+    return bare >= 0 ? now + Math.round(bare * 1000) : undefined;
+  }
+
+  const duration = DURATION_PATTERN.exec(text.toLowerCase());
+  if (duration && duration.slice(1).some(Boolean)) {
+    const hours = finiteNumber(duration[1]) || 0;
+    const minutes = finiteNumber(duration[2]) || 0;
+    const seconds = finiteNumber(duration[3]) || 0;
+    const ms = text.toLowerCase().endsWith("ms") ? seconds : seconds * 1000;
+    return now + Math.round(hours * 3_600_000 + minutes * 60_000 + ms);
+  }
+
+  const absolute = Date.parse(text);
+  return Number.isFinite(absolute) ? absolute : undefined;
+}
+
+function window(headers, limitKeys, remainingKeys, resetKeys, now) {
+  const read = (keys) => {
+    for (const key of keys) {
+      const value = headers.get(key);
+      if (value !== null && value !== undefined && String(value).trim() !== "") return value;
+    }
+    return undefined;
+  };
+  const limit = count(read(limitKeys));
+  const remaining = count(read(remainingKeys));
+  const reset = resetAt(read(resetKeys), now);
+  if (limit === undefined && remaining === undefined && reset === undefined) return undefined;
+  return {
+    ...(limit !== undefined ? { limit } : {}),
+    ...(remaining !== undefined ? { remaining } : {}),
+    ...(reset !== undefined ? { resetAt: new Date(reset).toISOString() } : {}),
+  };
+}
+
+// `headers` is a fetch Headers instance (case-insensitive lookup).
+export function parseRateLimitHeaders(headers, { now = Date.now() } = {}) {
+  if (!headers || typeof headers.get !== "function") return undefined;
+
+  const requests = window(
+    headers,
+    ["x-ratelimit-limit-requests", "anthropic-ratelimit-requests-limit", "x-ratelimit-limit"],
+    [
+      "x-ratelimit-remaining-requests",
+      "anthropic-ratelimit-requests-remaining",
+      "x-ratelimit-remaining",
+    ],
+    ["x-ratelimit-reset-requests", "anthropic-ratelimit-requests-reset", "x-ratelimit-reset"],
+    now,
+  );
+  const tokens = window(
+    headers,
+    ["x-ratelimit-limit-tokens", "anthropic-ratelimit-tokens-limit"],
+    ["x-ratelimit-remaining-tokens", "anthropic-ratelimit-tokens-remaining"],
+    ["x-ratelimit-reset-tokens", "anthropic-ratelimit-tokens-reset"],
+    now,
+  );
+  const retryAt = resetAt(headers.get("retry-after"), now);
+
+  if (!requests && !tokens && retryAt === undefined) return undefined;
+  return {
+    ...(requests ? { requests } : {}),
+    ...(tokens ? { tokens } : {}),
+    ...(retryAt !== undefined ? { retryAt: new Date(retryAt).toISOString() } : {}),
+  };
+}
+
+// The soonest moment a provider is worth retrying, or undefined when nothing in
+// the response says the caller is currently limited. A cooldown map reads this.
+export function cooldownUntil(snapshot) {
+  if (!snapshot) return undefined;
+  const candidates = [
+    snapshot.retryAt,
+    snapshot.requests?.remaining === 0 ? snapshot.requests.resetAt : undefined,
+    snapshot.tokens?.remaining === 0 ? snapshot.tokens.resetAt : undefined,
+  ].filter(Boolean);
+  if (!candidates.length) return undefined;
+  return candidates.sort()[candidates.length - 1];
+}

--- a/src/rate-limit-state.mjs
+++ b/src/rate-limit-state.mjs
@@ -1,0 +1,54 @@
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { STATE_DIR } from "./paths.mjs";
+
+// Latest observed rate-limit snapshot per provider, refreshed from response
+// headers as traffic flows. Unlike usage-events.jsonl this is a small
+// last-write-wins document, because only the current window matters.
+
+export const RATE_LIMITS_PATH = path.join(STATE_DIR, "rate-limits.json");
+
+const MAX_PROVIDERS = 64;
+
+function readDocument() {
+  if (!existsSync(RATE_LIMITS_PATH)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(RATE_LIMITS_PATH, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    // A corrupt file must never take routing down; it is rebuilt from the next
+    // response that carries headers.
+    return {};
+  }
+}
+
+export function recordRateLimitSnapshot(providerId, snapshot, { at = Date.now() } = {}) {
+  const id = typeof providerId === "string" ? providerId.trim() : "";
+  if (!id || !snapshot) return;
+  try {
+    const document = readDocument();
+    document[id] = { ...snapshot, observedAt: new Date(at).toISOString() };
+    const entries = Object.entries(document)
+      .sort((left, right) => String(right[1]?.observedAt).localeCompare(String(left[1]?.observedAt)))
+      .slice(0, MAX_PROVIDERS);
+    mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
+    const temporary = `${RATE_LIMITS_PATH}.tmp.${process.pid}`;
+    writeFileSync(temporary, `${JSON.stringify(Object.fromEntries(entries), null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    renameSync(temporary, RATE_LIMITS_PATH);
+    chmodSync(RATE_LIMITS_PATH, 0o600);
+  } catch {
+    // Rate-limit telemetry must never interrupt or fail a model request.
+  }
+}
+
+export function readRateLimitSnapshots() {
+  return readDocument();
+}
+
+export function rateLimitSnapshotFor(providerId) {
+  return readDocument()[String(providerId || "").trim()];
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -25,7 +25,7 @@ import { MODEL_BY_SLUG, PROVIDERS, providerForModel } from "./model-registry.mjs
 import { readNativeAliases } from "./native-alias.mjs";
 import { readProviderSelection } from "./provider-selection.mjs";
 import { ResponseUsageTransform } from "./response-usage.mjs";
-import { sessionNameFromHeaders } from "./codex-session-names.mjs";
+import { activityMetadataFromHeaders } from "./codex-session-names.mjs";
 import { recordUsageEvent } from "./usage-events.mjs";
 import { VERSION } from "./version.mjs";
 
@@ -107,13 +107,14 @@ function beginRequestActivity() {
   activeRequests.set(requestId, null);
   let finished = false;
   return {
-    setRoute({ provider, model, sessionName } = {}) {
+    setRoute({ provider, model, sessionName, ...metadata } = {}) {
       if (!provider) return;
       const entry = {
         id: String(requestId),
         provider,
         ...(model ? { model } : {}),
         ...(sessionName ? { sessionName } : {}),
+        ...metadata,
         startedAt: Date.now(),
       };
       activeRequests.set(requestId, entry);
@@ -573,7 +574,7 @@ async function handleResponses(request, response, requestUrl) {
     activity.setRoute({
       provider: route?.provider || "openai",
       model: route?.slug || requestedModel || undefined,
-      sessionName: sessionNameFromHeaders(request.headers),
+      ...activityMetadataFromHeaders(request.headers),
     });
     const compactV1 = /\/responses\/compact$/.test(requestUrl.pathname);
     const compactV2 =
@@ -672,7 +673,7 @@ async function handleNativeImage(request, response, requestUrl) {
     activity.setRoute({
       provider: "openai",
       model: requestedModel,
-      sessionName: sessionNameFromHeaders(request.headers),
+      ...activityMetadataFromHeaders(request.headers),
     });
 
     const controller = new AbortController();

--- a/test/codex-agent-catalog.test.mjs
+++ b/test/codex-agent-catalog.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  routedAgentDefinition,
+  syncRoutedCodexAgents,
+} from "../src/codex-agent-catalog.mjs";
+
+const kimi = {
+  slug: "kimi-oauth/k3",
+  displayName: "Kimi K3 (OAuth)",
+};
+
+test("routed agent definitions select the router provider and exact model slug", () => {
+  const definition = routedAgentDefinition(kimi);
+  assert.equal(definition.agentName, "router_kimi_oauth_k3");
+  assert.equal(definition.fileName, "router-model-kimi-oauth-k3.toml");
+  assert.match(definition.contents, /^# Managed by Codex Router\./);
+  assert.match(definition.contents, /model_provider = "codex-router"/);
+  assert.match(definition.contents, /model = "kimi-oauth\/k3"/);
+});
+
+test("agent sync writes one private definition for every routed model", () => {
+  const agentsDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-agents-"));
+  const written = syncRoutedCodexAgents(
+    [kimi, { slug: "grok-oauth/grok-4.5", displayName: "Grok 4.5 (OAuth)" }],
+    agentsDir,
+  );
+
+  assert.deepEqual(
+    written.map(({ model, agent }) => ({ model, agent })),
+    [
+      { model: "kimi-oauth/k3", agent: "router_kimi_oauth_k3" },
+      { model: "grok-oauth/grok-4.5", agent: "router_grok_oauth_grok_4_5" },
+    ],
+  );
+  const kimiFile = path.join(agentsDir, "router-model-kimi-oauth-k3.toml");
+  assert.match(readFileSync(kimiFile, "utf8"), /name = "router_kimi_oauth_k3"/);
+});
+
+test("agent definitions reject non-routed model slugs", () => {
+  assert.throws(() => routedAgentDefinition({ slug: "gpt-5.6-sol" }), /invalid model slug/);
+});

--- a/test/codex-session-names.test.mjs
+++ b/test/codex-session-names.test.mjs
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import {
+  activityMetadataFromHeaders,
   sessionNameFromHeaders,
   threadIdFromHeaders,
 } from "../src/codex-session-names.mjs";
@@ -33,4 +34,48 @@ test("finds nested thread metadata without exposing unrelated metadata", () => {
     THREAD_ID,
   );
   assert.equal(threadIdFromHeaders({ "x-codex-turn-metadata": "not-json" }), undefined);
+});
+
+test("groups subagent activity under its root session with a short agent name", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codex-agent-session-"));
+  const sessionsPath = path.join(directory, "sessions");
+  const indexPath = path.join(directory, "session_index.jsonl");
+  const childId = "019fa7d4-e478-7640-be48-1b2698b4a975";
+  const day = path.join(sessionsPath, "2026", "07", "28");
+  mkdirSync(day, { recursive: true });
+  writeFileSync(indexPath, `${JSON.stringify({ id: THREAD_ID, thread_name: "Build arena" })}\n`);
+  writeFileSync(
+    path.join(day, `rollout-2026-07-28T00-00-00-${childId}.jsonl`),
+    `${JSON.stringify({
+      type: "session_meta",
+      payload: {
+        id: childId,
+        source: {
+          subagent: {
+            thread_spawn: {
+              parent_thread_id: THREAD_ID,
+              agent_path: "/root/harsh_critic",
+              agent_nickname: "Heisenberg",
+            },
+          },
+        },
+      },
+    })}\n`,
+  );
+
+  assert.deepEqual(
+    activityMetadataFromHeaders(
+      { "thread-id": childId, "x-codex-parent-thread-id": THREAD_ID },
+      { indexPath, sessionsPath },
+    ),
+    {
+      threadId: childId,
+      parentThreadId: THREAD_ID,
+      sessionId: THREAD_ID,
+      sessionName: "Build arena",
+      agentName: "harsh_critic",
+      agentNickname: "Heisenberg",
+      isSubagent: true,
+    },
+  );
 });

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -9,8 +9,12 @@ process.env.CODEX_HOME = path.join(testRoot, "codex");
 process.env.CODEX_ROUTER_STATE_DIR = path.join(testRoot, "state");
 process.env.KIMI_CODE_HOME = path.join(testRoot, "kimi-code");
 process.env.GROK_AUTH_PATH = path.join(testRoot, "grok", "auth.json");
-for (const name of ["ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY", "KIMI_API_KEY", "MINIMAX_API_KEY", "MINIMAX_TOKEN_PLAN_API_KEY", "MOONSHOT_API_KEY", "XAI_API_KEY", "GROK_API_KEY"]) {
-  delete process.env[name];
+const { PROVIDERS } = await import("../src/model-registry.mjs");
+// Clearing every registry-declared credential variable keeps the "no provider
+// is configured yet" assertions deterministic on a developer machine that has
+// real keys exported, and stays correct as providers are added.
+for (const provider of PROVIDERS.values()) {
+  for (const name of provider.credential?.environment || []) delete process.env[name];
 }
 
 const { writeProviderCredential } = await import("../src/provider-credentials.mjs");
@@ -28,18 +32,9 @@ const { privateFileIsProtected } = await import("../src/file-security.mjs");
 
 test("provider selection keeps backward compatibility and can hide the final provider", () => {
   try {
-    assert.deepEqual(readProviderSelection(), [
-      "kimi-oauth",
-      "kimi-api",
-      "deepseek",
-      "grok-oauth",
-      "grok-api",
-      "anthropic-api",
-      "zai-coding",
-      "qwen-plan",
-      "ollama-cloud",
-      "minimax-token-plan",
-    ]);
+    // No selection file means every registry provider stays visible; the
+    // credential-aware catalog is what hides providers that cannot authenticate.
+    assert.deepEqual(readProviderSelection(), [...PROVIDERS.keys()]);
     process.env.KIMI_API_KEY = "TEST_ENVIRONMENT_ONLY_KEY";
     assert.deepEqual(configuredProviderIds(), []);
     delete process.env.KIMI_API_KEY;

--- a/test/rate-limit-headers.test.mjs
+++ b/test/rate-limit-headers.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { cooldownUntil, parseRateLimitHeaders, resetAt } = await import(
+  "../src/rate-limit-headers.mjs"
+);
+
+const NOW = Date.parse("2026-07-25T12:00:00.000Z");
+
+test("reset values normalize from every documented shape", () => {
+  // Go-style durations (Groq, OpenAI).
+  assert.equal(resetAt("7.66s", NOW), NOW + 7660);
+  assert.equal(resetAt("2m59.56s", NOW), NOW + 179_560);
+  assert.equal(resetAt("6m0s", NOW), NOW + 360_000);
+  assert.equal(resetAt("1h2m3s", NOW), NOW + 3_723_000);
+  // Bare seconds (retry-after).
+  assert.equal(resetAt("60", NOW), NOW + 60_000);
+  // Absolute timestamps (Anthropic).
+  assert.equal(resetAt("2026-07-25T12:05:00Z", NOW), Date.parse("2026-07-25T12:05:00Z"));
+  // Junk never produces a bogus window.
+  assert.equal(resetAt("", NOW), undefined);
+  assert.equal(resetAt("soon", NOW), undefined);
+  assert.equal(resetAt(undefined, NOW), undefined);
+});
+
+test("openai-compatible headers become a normalized snapshot", () => {
+  const snapshot = parseRateLimitHeaders(
+    new Headers({
+      "x-ratelimit-limit-requests": "14400",
+      "x-ratelimit-remaining-requests": "14370",
+      "x-ratelimit-reset-requests": "2m59.56s",
+      "x-ratelimit-limit-tokens": "18000",
+      "x-ratelimit-remaining-tokens": "17997",
+      "x-ratelimit-reset-tokens": "7.66s",
+    }),
+    { now: NOW },
+  );
+  assert.deepEqual(snapshot, {
+    requests: {
+      limit: 14400,
+      remaining: 14370,
+      resetAt: new Date(NOW + 179_560).toISOString(),
+    },
+    tokens: {
+      limit: 18000,
+      remaining: 17997,
+      resetAt: new Date(NOW + 7660).toISOString(),
+    },
+  });
+});
+
+test("anthropic's prefixed headers parse through the same path", () => {
+  const snapshot = parseRateLimitHeaders(
+    new Headers({
+      "anthropic-ratelimit-requests-limit": "50",
+      "anthropic-ratelimit-requests-remaining": "0",
+      "anthropic-ratelimit-requests-reset": "2026-07-25T12:01:00Z",
+    }),
+    { now: NOW },
+  );
+  assert.deepEqual(snapshot.requests, {
+    limit: 50,
+    remaining: 0,
+    resetAt: "2026-07-25T12:01:00.000Z",
+  });
+  assert.equal(snapshot.tokens, undefined);
+});
+
+test("a provider that reports nothing yields no snapshot", () => {
+  assert.equal(parseRateLimitHeaders(new Headers({ "content-type": "application/json" })), undefined);
+  assert.equal(parseRateLimitHeaders(undefined), undefined);
+  assert.equal(parseRateLimitHeaders({}), undefined);
+});
+
+test("cooldown only triggers on real exhaustion", () => {
+  // Headroom left on both windows is not a cooldown.
+  assert.equal(
+    cooldownUntil({
+      requests: { remaining: 12, resetAt: "2026-07-25T12:01:00.000Z" },
+      tokens: { remaining: 900, resetAt: "2026-07-25T12:02:00.000Z" },
+    }),
+    undefined,
+  );
+  // An exhausted window is, and the latest reset wins so a retry never fires early.
+  assert.equal(
+    cooldownUntil({
+      requests: { remaining: 0, resetAt: "2026-07-25T12:01:00.000Z" },
+      tokens: { remaining: 0, resetAt: "2026-07-25T12:03:00.000Z" },
+    }),
+    "2026-07-25T12:03:00.000Z",
+  );
+  // An explicit retry-after is honored on its own.
+  assert.equal(cooldownUntil({ retryAt: "2026-07-25T12:09:00.000Z" }), "2026-07-25T12:09:00.000Z");
+  assert.equal(cooldownUntil(undefined), undefined);
+});

--- a/test/rate-limit-quota.test.mjs
+++ b/test/rate-limit-quota.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+// State paths bind at import time, so the isolated root must be set first.
+const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-rate-limit-"));
+process.env.CODEX_HOME = path.join(testRoot, "codex");
+process.env.CODEX_ROUTER_STATE_DIR = path.join(testRoot, "state");
+
+const { parseRateLimitHeaders } = await import("../src/rate-limit-headers.mjs");
+const { recordRateLimitSnapshot, readRateLimitSnapshots } = await import(
+  "../src/rate-limit-state.mjs"
+);
+const { providerAccountUsageSnapshot } = await import("../src/provider-account-usage.mjs");
+
+const NEVER_CALLED = async () => {
+  throw new Error("header-derived quota must not reach the network");
+};
+
+test("observed response headers become quota cards for a catalog-only provider", async () => {
+  try {
+    recordRateLimitSnapshot(
+      "groq",
+      parseRateLimitHeaders(
+        new Headers({
+          "x-ratelimit-limit-requests": "14400",
+          "x-ratelimit-remaining-requests": "14370",
+          "x-ratelimit-reset-requests": "2m59.56s",
+          "x-ratelimit-limit-tokens": "18000",
+          "x-ratelimit-remaining-tokens": "9000",
+          "x-ratelimit-reset-tokens": "7.66s",
+        }),
+      ),
+    );
+
+    const snapshot = await providerAccountUsageSnapshot({
+      providerIds: ["groq", "mistral"],
+      fetchImpl: NEVER_CALLED,
+    });
+
+    const groq = snapshot.groq;
+    assert.equal(groq.status, "available");
+    assert.equal(groq.source, "response-headers");
+    assert.deepEqual(
+      groq.metrics.map((metric) => [metric.label, metric.unit, metric.remaining]),
+      [
+        ["Request limit", "requests", 14370],
+        ["Token limit", "tokens", 9000],
+      ],
+    );
+    // Percentages are derived, not echoed, so a half-spent token window reads 50.
+    assert.equal(groq.metrics[1].usedPercent, 50);
+
+    // A provider that has served no traffic yet must not invent a card.
+    assert.equal(snapshot.mistral.status, "local-only");
+    assert.deepEqual(snapshot.mistral.metrics, []);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("an exhausted window is retained as a cooldown hint", async () => {
+  try {
+    recordRateLimitSnapshot(
+      "cerebras",
+      parseRateLimitHeaders(new Headers({ "retry-after": "30" })),
+    );
+    const stored = readRateLimitSnapshots().cerebras;
+    assert.ok(stored.retryAt, "retry-after should persist as an absolute instant");
+    assert.ok(stored.observedAt, "every snapshot records when it was observed");
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- sync routed models into Codex custom-agent definitions
- surface active root and subagent sessions in the Dynamic Island overlay
- expand the provider catalog and make provider-selection tests registry-driven
- capture OpenAI-compatible and Anthropic rate-limit headers, persist bounded private snapshots, and expose observed request/token quota cards
- include the current repository guidance and related documentation updates

## Verification

- `npm ci`
- `npm run check`
- `npm test` — 189 passed, 2 intentionally skipped, 0 failed
- `npm ci` in `apps/desktop`
- `npm run check` in `apps/desktop` — UI tests, Cargo formatting/check, and 5 Rust tests passed
- `git diff --check origin/main...HEAD`

This draft preserves all previously local commits and working-tree changes while integrating the current `main` without rebasing or force-pushing.