### PR TITLE
fix(desktop): avoid environment-selected executable

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -714,11 +714,6 @@ fn standard_source_roots() -> Vec<PathBuf> {
 }
 
 fn resolve_node() -> Option<OsString> {
-    if let Some(configured) = env::var_os("MODEL_ROUTER_NODE") {
-        if !configured.is_empty() {
-            return Some(configured);
-        }
-    }
     let executable = if cfg!(target_os = "windows") {
         "node.exe"
     } else {


### PR DESCRIPTION
Removes the undocumented `MODEL_ROUTER_NODE` environment override before constructing the desktop companion's child process. Node discovery continues to use the existing PATH search.

Verification: reviewed the one-file diff. Local Rust checks could not run because this workspace's shell is unavailable.