### PR TITLE
fix(windows): detect ChatGPT auth through npm codex.cmd shim

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -16,7 +15,7 @@ import {
   NATIVE_ALIAS_PATH,
   NATIVE_CATALOG_PATH,
 } from "./paths.mjs";
-import { codexIsAuthenticated, requireCodexBinary } from "./codex-binary.mjs";
+import { codexIsAuthenticated, runCodex } from "./codex-binary.mjs";
 import { syncRoutedCodexAgents } from "./codex-agent-catalog.mjs";
 import { MODEL_BY_SLUG } from "./model-registry.mjs";
 import { buildNativeAliasAssignments } from "./native-alias.mjs";
@@ -40,20 +39,17 @@ function atomicJson(target, value) {
 function captureNative() {
   const args = ["debug", "models"];
   if (bundled) args.push("--bundled");
+  const options = {
+    encoding: "utf8",
+    timeout: 30_000,
+    maxBuffer: 32 * 1024 * 1024,
+  };
   let output;
   try {
-    output = execFileSync(requireCodexBinary(), args, {
-      encoding: "utf8",
-      timeout: 30_000,
-      maxBuffer: 32 * 1024 * 1024,
-    });
+    output = runCodex(args, options);
   } catch (error) {
     if (bundled) throw error;
-    output = execFileSync(requireCodexBinary(), ["debug", "models", "--bundled"], {
-      encoding: "utf8",
-      timeout: 30_000,
-      maxBuffer: 32 * 1024 * 1024,
-    });
+    output = runCodex(["debug", "models", "--bundled"], options);
   }
   const parsed = JSON.parse(output);
   if (!parsed || !Array.isArray(parsed.models) || parsed.models.length === 0) {

--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -35,10 +35,10 @@ export function findCodexBinary() {
     if (process.platform === "win32") {
       // `where codex` lists the extensionless npm shim first (e.g.
       // `...\npm\codex`), which Node cannot spawn directly. Prefer the
-      // explicit `.cmd`/`.exe` entries it also returns so callers get a
-      // directly executable path.
+      // explicit `.cmd`/`.bat`/`.exe` entries it also returns so callers get
+      // a directly executable path.
       return (
-        found.find((candidate) => candidate.toLowerCase().endsWith(".cmd")) ||
+        found.find((candidate) => /\.(cmd|bat)$/i.test(candidate)) ||
         found.find((candidate) => candidate.toLowerCase().endsWith(".exe")) ||
         found[0]
       );
@@ -59,22 +59,24 @@ export function requireCodexBinary() {
   return binary;
 }
 
-// On Windows, npm-installed CLIs resolve to a `.cmd` shim, which Node cannot
-// spawn without a shell (throws ENOENT/EINVAL). Centralize that handling here so
-// every codex invocation goes through one path. `findCodexBinary()` already
-// prefers the explicit `.cmd`, so callers can pass the resolved binary through
-// without re-checking the extension.
+// On Windows, npm-installed CLIs resolve to a `.cmd`/`.bat` shim, which Node
+// cannot spawn without a shell (throws ENOENT/EINVAL). Centralize that handling
+// here so every codex invocation goes through one path. `findCodexBinary()`
+// already prefers the explicit shim, so callers can pass the resolved binary
+// through without re-checking the extension.
 export function runCodex(args, options = {}) {
   const binary = requireCodexBinary();
   const merged = { ...options };
-  if (
-    process.platform === "win32" &&
-    binary.toLowerCase().endsWith(".cmd") &&
-    merged.shell === undefined
-  ) {
+  const needsShell =
+    process.platform === "win32" && /\.(cmd|bat)$/i.test(binary);
+  if (needsShell && merged.shell === undefined) {
     merged.shell = true;
   }
-  return execFileSync(binary, args, merged);
+  // With shell:true, Node concatenates file+args without quoting, so a path
+  // containing spaces (e.g. C:\Users\John Smith\...) would split into two
+  // tokens and fail. Quote the command; cmd.exe /d /s /c strips the outer
+  // quotes correctly, and this branch is Windows-only.
+  return execFileSync(merged.shell ? `"${binary}"` : binary, args, merged);
 }
 
 export function codexIsAuthenticated() {

--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -59,21 +59,29 @@ export function requireCodexBinary() {
   return binary;
 }
 
+// On Windows, npm-installed CLIs resolve to a `.cmd` shim, which Node cannot
+// spawn without a shell (throws ENOENT/EINVAL). Centralize that handling here so
+// every codex invocation goes through one path. `findCodexBinary()` already
+// prefers the explicit `.cmd`, so callers can pass the resolved binary through
+// without re-checking the extension.
+export function runCodex(args, options = {}) {
+  const binary = requireCodexBinary();
+  const merged = { ...options };
+  if (
+    process.platform === "win32" &&
+    binary.toLowerCase().endsWith(".cmd") &&
+    merged.shell === undefined
+  ) {
+    merged.shell = true;
+  }
+  return execFileSync(binary, args, merged);
+}
+
 export function codexIsAuthenticated() {
   const binary = findCodexBinary();
   if (!binary) return false;
-  const options = { timeout: 10_000, stdio: "ignore" };
   try {
-    // On Windows, npm-installed CLIs resolve to a `.cmd` shim, which Node
-    // cannot spawn without a shell (throws ENOENT/EINVAL, silently
-    // misreporting the user as logged out and dropping native OpenAI models
-    // from the merged catalog). Mirror the shell:true handling already used
-    // by catalog.execCodex().
-    if (process.platform === "win32" && binary.toLowerCase().endsWith(".cmd")) {
-      execFileSync(binary, ["login", "status"], { ...options, shell: true });
-    } else {
-      execFileSync(binary, ["login", "status"], options);
-    }
+    runCodex(["login", "status"], { timeout: 10_000, stdio: "ignore" });
     return true;
   } catch {
     return false;

--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -28,10 +28,22 @@ export function findCodexBinary() {
   if (direct) return direct;
   const finder = process.platform === "win32" ? "where.exe" : "which";
   try {
-    return execFileSync(finder, ["codex"], {
+    const found = execFileSync(finder, ["codex"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
-    }).trim().split(/\r?\n/)[0] || undefined;
+    }).trim().split(/\r?\n/).filter(Boolean);
+    if (process.platform === "win32") {
+      // `where codex` lists the extensionless npm shim first (e.g.
+      // `...\npm\codex`), which Node cannot spawn directly. Prefer the
+      // explicit `.cmd`/`.exe` entries it also returns so callers get a
+      // directly executable path.
+      return (
+        found.find((candidate) => candidate.toLowerCase().endsWith(".cmd")) ||
+        found.find((candidate) => candidate.toLowerCase().endsWith(".exe")) ||
+        found[0]
+      );
+    }
+    return found[0];
   } catch {
     return undefined;
   }
@@ -50,11 +62,18 @@ export function requireCodexBinary() {
 export function codexIsAuthenticated() {
   const binary = findCodexBinary();
   if (!binary) return false;
+  const options = { timeout: 10_000, stdio: "ignore" };
   try {
-    execFileSync(binary, ["login", "status"], {
-      timeout: 10_000,
-      stdio: "ignore",
-    });
+    // On Windows, npm-installed CLIs resolve to a `.cmd` shim, which Node
+    // cannot spawn without a shell (throws ENOENT/EINVAL, silently
+    // misreporting the user as logged out and dropping native OpenAI models
+    // from the merged catalog). Mirror the shell:true handling already used
+    // by catalog.execCodex().
+    if (process.platform === "win32" && binary.toLowerCase().endsWith(".cmd")) {
+      execFileSync(binary, ["login", "status"], { ...options, shell: true });
+    } else {
+      execFileSync(binary, ["login", "status"], options);
+    }
     return true;
   } catch {
     return false;

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -3,7 +3,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
 import { validCallerSecret } from "./caller-auth.mjs";
-import { findCodexBinary } from "./codex-binary.mjs";
+import { findCodexBinary, runCodex } from "./codex-binary.mjs";
 import { routedCodexAgentStatus } from "./codex-agent-catalog.mjs";
 import { privateFileIsProtected } from "./file-security.mjs";
 import { grokCliPreflight } from "./grok-cli.mjs";
@@ -358,7 +358,7 @@ add(
 if (codex && catalogOk) {
   try {
     const parsed = JSON.parse(
-      execFileSync(codex, ["debug", "models"], {
+      runCodex(["debug", "models"], {
         encoding: "utf8",
         timeout: 30_000,
         maxBuffer: 32 * 1024 * 1024,


### PR DESCRIPTION
Fixes #46.

## Problem

On Windows with an npm-installed Codex CLI, `where codex` lists the **extensionless** shim (`…\npm\codex`) before `…\npm\codex.cmd`. Node's `child_process` cannot spawn that extensionless entry directly — `execFileSync` throws **ENOENT**, which `codexIsAuthenticated()` swallows in its `catch {}` and returns `false`.

The catalog then runs with `includeNative: false`, so every native OpenAI model (`gpt-5.x`) is stripped from `merged-models.json` and the model picker shows only the external providers (e.g. DeepSeek) — despite the user being genuinely signed in via ChatGPT.

`catalog.execCodex()` already handles `.cmd` correctly with `shell: true`; this was just missed in the auth check.

## Changes (`src/codex-binary.mjs`)

- **`findCodexBinary()`** — prefer an explicit `.cmd`/`.exe` entry from the `where`/`which` output over the extensionless first entry, so callers get a directly spawnable path.
- **`codexIsAuthenticated()`** — spawn `.cmd` shims with `shell: true`, mirroring `catalog.execCodex()`.

No new dependencies; behaviour unchanged on macOS/Linux (the `.cmd`/`.exe` preference is guarded by `process.platform === "win32"`).

## Verification

Reproduced the bug on upstream `main` (commit `f2bbe96`) and confirmed the fix against a live Windows + npm Codex + ChatGPT auth setup:

```text
# before
resolved binary:  "C:\Users\krist\AppData\Roaming\npm\codex"   # extensionless
codexIsAuthenticated() -> false   (ENOENT swallowed)
catalog: { native_models: 0, openai_authenticated: false }

# after
resolved binary:  "C:\Users\krist\AppData\Roaming\npm\codex.cmd"
codexIsAuthenticated() -> true
catalog: { native_models: 7, openai_authenticated: true, models: 9 }
```

- `npm test` → **193 pass, 0 fail, 2 skipped** (unchanged from baseline)
- `npm run check` → **syntax checks passed**

## Notes

I did not add a unit test for `codexIsAuthenticated()` because mocking `node:child_process` is not viable from ESM here (the `node:child_process` namespace is non-configurable, so `node:test`'s `mock.method` cannot patch the `execFileSync` binding the module imports). Happy to add one if the maintainer prefers an injectable exec surface, but that's a larger change than fits this bugfix.