### PR TITLE
fix: make Codex history replay compatible with strict providers (empty text, tool-call pairing)

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -322,6 +322,33 @@ function normalizeRoutedInput(input) {
           ? `${SUMMARY_PREFIX}\n\n${summary}`
           : "[Earlier conversation history was compacted in an unreadable format.]",
       );
+    })
+    .map((item) => {
+      // LiteLLM rejects messages whose text content is empty; Codex emits
+      // such filler assistant messages around tool calls. Strip empty text
+      // parts, and drop messages that carry nothing at all.
+      if (item?.type !== "message" || !Array.isArray(item.content)) return item;
+      const content = item.content.filter((part) => {
+        if (!part || typeof part !== "object") return true;
+        if (
+          (part.type === "input_text" ||
+            part.type === "output_text" ||
+            part.type === "text") &&
+          typeof part.text === "string" &&
+          part.text.trim() === ""
+        ) {
+          return false;
+        }
+        return true;
+      });
+      return { ...item, content };
+    })
+    .filter((item) => {
+      if (item?.type !== "message") return true;
+      if (Array.isArray(item.tool_calls) && item.tool_calls.length > 0) return true;
+      if (typeof item.content === "string") return item.content.trim() !== "";
+      if (Array.isArray(item.content)) return item.content.length > 0;
+      return true;
     });
 }
 


### PR DESCRIPTION
## Problem

Codex emits filler assistant messages with empty `output_text` around tool calls (visible in session rollouts; hundreds of them accumulate in long threads). When such history is replayed through the router, LiteLLM raises:

```
litellm.BadRequestError: OpenAIException - text content is empty
```

which surfaces to the user as `local_router_error` and a failed turn — repeatedly, on every request containing such items. Long-lived, tool-heavy threads eventually become unusable.

## Root cause

`normalizeRoutedInput` already transforms compaction items, but passes message items through untouched — including content parts with empty text that LiteLLM's OpenAI translation rejects.

## Fix

Sanitize in `normalizeRoutedInput` (the single choke point for all routed traffic, including the `/responses/compact` path):

1. Strip empty text parts (`input_text` / `output_text` / `text` with whitespace-only `text`) from message items.
2. Drop message items left with no content at all (and no `tool_calls` — those are legal on their own).

Tool-call/tool-output pairing is untouched: those are separate item types and are never modified.

## Verification

- Before: `POST /v1/responses` with assistant messages containing `{"type":"output_text","text":""}` → LiteLLM 400 (`text content is empty`).
- After: same payload → 200 with a valid completion.
- End-to-end: previously failing long threads resume and complete turns through the patched router.

## Note

This fixes the symptom centrally. Codex emitting these empty filler items at all is arguably an upstream Codex issue; sanitizing here is the pragmatic layer since the router is the translation boundary.