### PR TITLE
fix(macOS): preserve tray bundle path from build script

### DIFF
--- a/scripts/build-macos-tray-app.sh
+++ b/scripts/build-macos-tray-app.sh
@@ -7,7 +7,10 @@ bundle_dir=${1:-"$repo_dir/dist/Model Router.app"}
 configuration=${MODEL_ROUTER_TRAY_CONFIGURATION:-release}
 binary_dir="$tray_dir/.build/$configuration"
 
-swift build -c "$configuration" --package-path "$tray_dir"
+# Keep the bundle path as the only stdout value so callers such as
+# bin/model-router-tray can safely capture it. SwiftPM's build progress is
+# still shown to the user on stderr.
+swift build -c "$configuration" --package-path "$tray_dir" >&2
 mkdir -p "$bundle_dir/Contents/MacOS" "$bundle_dir/Contents/Resources"
 cp "$binary_dir/ModelRouterTray" "$bundle_dir/Contents/MacOS/ModelRouterTray"
 cp "$tray_dir/Resources/Info.plist" "$bundle_dir/Contents/Info.plist"


### PR DESCRIPTION
# Fix macOS tray bundle path capture

## What changed

- Send SwiftPM build progress to stderr so the build script emits only the bundle path on stdout.
- Keep `bin/model-router-tray` able to capture the path and open the generated app.

## Why

`bin/model-router-tray` captures the build script output in a shell variable. SwiftPM writes progress to stdout, so the captured value included build logs and `open` received an invalid path. The build completed successfully, but the launcher failed to open the app.

## Validation

- `npm run check`
- `npm test` (237 passed, 0 failed, 2 skipped)
- Built and launched the native macOS menu-bar app from the fixed launcher path.
