### PR TITLE
fix(codex): support modern config and catalog schemas

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -132,6 +132,12 @@ function rewriteModelMessages(messages, model) {
   return next;
 }
 
+function normalizeNativeModel(model) {
+  return Object.hasOwn(model, "supports_reasoning_summaries")
+    ? model
+    : { ...model, supports_reasoning_summaries: false };
+}
+
 export function routedModel(template, model) {
   const next = {
     ...template,
@@ -190,7 +196,9 @@ export function buildMergedCatalog(native, routedModelsList, { includeNative = t
     throw new Error("Native model catalog is empty.");
   }
   const models = new Map(
-    includeNative ? native.models.map((model) => [model.slug, model]) : [],
+    includeNative
+      ? native.models.map((model) => [model.slug, normalizeNativeModel(model)])
+      : [],
   );
   for (const model of routedModelsList) {
     models.set(model.slug, routedModel(template, model));

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -136,8 +136,24 @@ function withoutManagedAgentConcurrency(input) {
   );
 }
 
+function hasModernMultiAgentConfig(input) {
+  const lines = input.split("\n");
+  if (lines.some((line) => /^\s*features\.multi_agent_v2\s*=/.test(line))) return true;
+  if (lines.some((line) => /^\s*\[agents\.[^\]]+\]\s*(?:#.*)?$/.test(line))) return true;
+  const featuresHeader = lines.findIndex((line) =>
+    /^\s*\[features\]\s*(?:#.*)?$/.test(line),
+  );
+  if (featuresHeader === -1) return false;
+  let tableEnd = featuresHeader + 1;
+  while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd])) tableEnd += 1;
+  return lines
+    .slice(featuresHeader + 1, tableEnd)
+    .some((line) => /^\s*multi_agent_v2\s*=/.test(line));
+}
+
 function withManagedAgentConcurrency(input) {
   const cleaned = withoutManagedAgentConcurrency(input);
+  if (hasModernMultiAgentConfig(cleaned)) return cleaned;
   const { rootLines } = splitRoot(cleaned);
   if (
     rootLines.some((line) =>

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -66,6 +66,7 @@ test("merged catalog preserves native GPT identity while rewriting routed models
   const merged = buildMergedCatalog({ models: [template] }, [grok]);
   const bySlug = new Map(merged.map((model) => [model.slug, model]));
   assert.match(bySlug.get("gpt-5.5").base_instructions, /based on GPT-5/);
+  assert.equal(bySlug.get("gpt-5.5").supports_reasoning_summaries, false);
   assert.match(bySlug.get("grok-oauth/grok-4.5").base_instructions, /based on Grok 4\.5/);
   assert.doesNotMatch(bySlug.get("grok-oauth/grok-4.5").base_instructions, /GPT-5/);
 });

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -190,6 +190,29 @@ model_reasoning_effort = "high"
   }
 });
 
+test("config manager does not add the legacy agents scalar to modern agent configs", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-modern-agents-"));
+  const configPath = path.join(codexHome, "config.toml");
+  const original = `[agents.gsd-example]
+description = "Example agent"
+config_file = "/tmp/example-agent.toml"
+`;
+  writeFileSync(configPath, original, { mode: 0o600 });
+
+  try {
+    run("enable", codexHome);
+    const enabled = readFileSync(configPath, "utf8");
+    assert.doesNotMatch(enabled, /codex-router-agent-concurrency-managed/);
+    assert.doesNotMatch(enabled, /^\[agents\]$/m);
+    assert.match(enabled, /^\[agents\.gsd-example\]$/m);
+
+    run("disable", codexHome);
+    assert.equal(readFileSync(configPath, "utf8").trimStart(), original);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
 test("config manager preserves user-owned realtime endpoints", () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-realtime-"));
   const configPath = path.join(codexHome, "config.toml");


### PR DESCRIPTION
## What changed

- Avoid injecting the legacy `[agents]` concurrency scalar when Codex uses modern `[agents.<role>]`/`features.multi_agent_v2` configuration.
- Normalize native model catalog entries with `supports_reasoning_summaries: false` when older Codex app catalogs omit the field.
- Add regression coverage for both compatibility paths.

## Why

Codex 0.142.5 rejected the router-generated `[agents] max_concurrent_threads_per_session = 6` because `agents` is a role map in modern configs. It also rejected the merged catalog because older app-bundled native entries omitted `supports_reasoning_summaries`.

These failures prevented `codex login status`, `codex debug models`, and `codex doctor` from loading the user configuration. The changes preserve modern user-owned agent tables and keep older native catalogs usable across Codex binaries.

## Validation

- `npm run check`
- `npm test` (237 passed, 0 failed, 2 skipped)
- Native app-bundled and standalone Codex model catalogs parse successfully
- `codex doctor` reports 0 failures