### PR TITLE
fix(codex): adapt the agents scalar and native catalog to the installed Codex build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Adapted the managed `[agents]` concurrency default to the installed Codex
+  build.** Some Codex builds (observed on 0.141-0.145) parse `[agents]` as a
+  pure role map and refuse to load any config containing the scalar, which
+  broke `codex login status` and `codex doctor` outright. The config manager
+  now probes the installed binary with a minimal config before writing the
+  scalar and skips it when the build rejects it, so builds that accept the
+  scalar keep the concurrency cap and strict builds keep a loadable config.
+- **Re-captured the native model catalog when the Codex build changes.** The
+  cached capture now records the Codex version that produced it and is
+  refreshed from `codex debug models` on mismatch, so a catalog captured by an
+  older build no longer feeds missing or stale capability fields (such as
+  `supports_reasoning_summaries`) into the merged catalog after an upgrade. If
+  the re-capture fails, the router keeps serving the previous capture and says
+  so instead of failing the rebuild.
+
 - **Removed the Cursor and opencode app targets.** The router now focuses on
   Codex only: `--target codex` is the sole installer target, the Cursor Chat
   Completions gateway and the opencode config manager/subagent generator are

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -15,7 +15,7 @@ import {
   NATIVE_ALIAS_PATH,
   NATIVE_CATALOG_PATH,
 } from "./paths.mjs";
-import { codexAuthStatus, runCodex } from "./codex-binary.mjs";
+import { codexAuthStatus, codexVersion, runCodex } from "./codex-binary.mjs";
 import { syncRoutedCodexAgents } from "./codex-agent-catalog.mjs";
 import { MODEL_BY_SLUG } from "./model-registry.mjs";
 import { buildNativeAliasAssignments } from "./native-alias.mjs";
@@ -64,17 +64,43 @@ function captureNative() {
       "Refusing to capture an already-merged catalog. Disable the router before refreshing native models.",
     );
   }
-  atomicJson(NATIVE_CATALOG_PATH, { models: parsed.models });
+  const capturedWith = codexVersion();
+  atomicJson(NATIVE_CATALOG_PATH, {
+    ...(capturedWith ? { captured_with: capturedWith } : {}),
+    models: parsed.models,
+  });
   return parsed;
+}
+
+// A native capture is only trustworthy for the Codex build that produced it:
+// newer builds can require catalog fields the older build never emitted, or
+// carry different capability values for the same slug. An unknown current
+// version keeps the cache — with no binary to re-ask, stale is the best we
+// have.
+export function nativeCatalogIsReusable(parsed, currentVersion) {
+  if (!parsed || !Array.isArray(parsed.models) || parsed.models.length === 0) {
+    return false;
+  }
+  return !currentVersion || parsed.captured_with === currentVersion;
 }
 
 function nativeCatalog() {
   if (!existsSync(NATIVE_CATALOG_PATH) || refresh) return captureNative();
   const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
-  if (!parsed || !Array.isArray(parsed.models) || parsed.models.length === 0) {
+  if (nativeCatalogIsReusable(parsed, codexVersion())) return parsed;
+  try {
     return captureNative();
+  } catch (error) {
+    // Version-mismatched is still better than empty: serve the stale capture
+    // when the re-capture fails, but say so instead of hiding it.
+    if (parsed && Array.isArray(parsed.models) && parsed.models.length > 0) {
+      console.error(
+        `Could not refresh the native model catalog (${error.message}); reusing the cached capture.`,
+      );
+      return parsed;
+    }
+    throw error;
   }
-  return parsed;
 }
 
 function selectedModel() {

--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -82,6 +82,22 @@ export function runCodex(args, options = {}) {
   return execFileSync(command, args, { ...spawnOptions, ...options });
 }
 
+// The version tells catalog code whether a cached native capture came from
+// the currently installed build. Undefined means "could not ask", which
+// callers must treat as unknown rather than as a mismatch.
+export function codexVersion() {
+  try {
+    const output = runCodex(["--version"], {
+      encoding: "utf8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return output.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // Failing to *run* Codex is not evidence that the user is signed out. The two
 // used to be indistinguishable, so one Windows spawn error silently stripped
 // every native model from the catalog. Report the reason so callers can refuse

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -1,13 +1,19 @@
+import { spawnSync } from "node:child_process";
 import {
   copyFileSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   renameSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
+import os from "node:os";
 import path from "node:path";
+
+import { codexSpawnTarget, findCodexBinary } from "./codex-binary.mjs";
 
 import {
   assertCallerSecret,
@@ -151,6 +157,53 @@ function hasModernMultiAgentConfig(input) {
     .some((line) => /^\s*multi_agent_v2\s*=/.test(line));
 }
 
+// Some Codex builds parse `[agents]` as a pure role map and reject the
+// concurrency scalar outright, which blocks the whole config from loading
+// (observed on 0.141-0.145; earlier and later builds accept it). A version
+// table would need constant maintenance, so ask the installed binary instead:
+// have it load a config containing only the scalar and see whether it parses.
+// The probe config is minimal on purpose — the answer must not depend on
+// anything else in the user's config.
+let codexAcceptsAgentConcurrencyScalar;
+function installedCodexAcceptsAgentConcurrencyScalar() {
+  if (codexAcceptsAgentConcurrencyScalar !== undefined) {
+    return codexAcceptsAgentConcurrencyScalar;
+  }
+  codexAcceptsAgentConcurrencyScalar = probeAgentConcurrencyScalar();
+  return codexAcceptsAgentConcurrencyScalar;
+}
+
+function probeAgentConcurrencyScalar() {
+  const binary = findCodexBinary();
+  // With no binary to ask, keep the historical behavior of writing the scalar.
+  if (!binary) return true;
+  const probeHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-schema-probe-"));
+  try {
+    writeFileSync(
+      path.join(probeHome, "config.toml"),
+      `[agents]\nmax_concurrent_threads_per_session = ${managedAgentMaxConcurrency}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    const { command: probeCommand, options } = codexSpawnTarget(binary);
+    // `login status` exits non-zero when signed out, so the exit code says
+    // nothing about the config; only the load-error message does.
+    const result = spawnSync(probeCommand, ["login", "status"], {
+      ...options,
+      encoding: "utf8",
+      timeout: 10_000,
+      env: { ...process.env, CODEX_HOME: probeHome },
+    });
+    if (result.error) return true;
+    return !/Error loading configuration/i.test(
+      `${result.stdout || ""}\n${result.stderr || ""}`,
+    );
+  } catch {
+    return true;
+  } finally {
+    rmSync(probeHome, { recursive: true, force: true });
+  }
+}
+
 function withManagedAgentConcurrency(input) {
   const cleaned = withoutManagedAgentConcurrency(input);
   if (hasModernMultiAgentConfig(cleaned)) return cleaned;
@@ -169,11 +222,6 @@ function withManagedAgentConcurrency(input) {
   const agentsHeader = lines.findIndex((line) =>
     /^\s*\[\s*agents\s*\]\s*(?:#.*)?$/.test(line),
   );
-  const managedLines = [
-    agentConcurrencyStartMarker,
-    `max_concurrent_threads_per_session = ${managedAgentMaxConcurrency}`,
-    agentConcurrencyEndMarker,
-  ];
   if (agentsHeader !== -1) {
     let tableEnd = agentsHeader + 1;
     while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd])) tableEnd += 1;
@@ -183,6 +231,14 @@ function withManagedAgentConcurrency(input) {
         /^\s*(?:max_concurrent_threads_per_session|max_threads)\s*=/.test(line),
       );
     if (userConfigured) return cleaned;
+  }
+  if (!installedCodexAcceptsAgentConcurrencyScalar()) return cleaned;
+  const managedLines = [
+    agentConcurrencyStartMarker,
+    `max_concurrent_threads_per_session = ${managedAgentMaxConcurrency}`,
+    agentConcurrencyEndMarker,
+  ];
+  if (agentsHeader !== -1) {
     lines.splice(agentsHeader + 1, 0, ...managedLines);
   } else {
     while (lines.length && !lines.at(-1).trim()) lines.pop();

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildMergedCatalog, buildLoginFreeCatalog, routedModel } from "../src/catalog.mjs";
+import {
+  buildMergedCatalog,
+  buildLoginFreeCatalog,
+  nativeCatalogIsReusable,
+  routedModel,
+} from "../src/catalog.mjs";
 
 const template = {
   slug: "gpt-5.5",
@@ -129,4 +134,19 @@ test("login-free catalog keeps overflow models visible under their own slugs", (
   const bySlug = new Map(models.map((model) => [model.slug, model]));
   assert.equal(bySlug.get("kimi-oauth/kimi-for-coding").visibility, "list");
   assert.equal(bySlug.get("grok-oauth/grok-4.5").visibility, "hide");
+});
+
+test("native catalog cache is reusable only for the codex build that captured it", () => {
+  const captured = { captured_with: "codex-cli 0.142.5", models: [template] };
+
+  assert.equal(nativeCatalogIsReusable(captured, "codex-cli 0.142.5"), true);
+  assert.equal(nativeCatalogIsReusable(captured, "codex-cli 0.146.1"), false);
+  // Unknown current version: no binary to re-ask, so keep what we have.
+  assert.equal(nativeCatalogIsReusable(captured, undefined), true);
+  // Un-stamped caches predate version tracking; re-capture when we can ask.
+  assert.equal(nativeCatalogIsReusable({ models: [template] }, "codex-cli 0.146.1"), false);
+  assert.equal(nativeCatalogIsReusable({ models: [template] }, undefined), true);
+  // Invalid or empty caches are never reusable.
+  assert.equal(nativeCatalogIsReusable(undefined, undefined), false);
+  assert.equal(nativeCatalogIsReusable({ models: [] }, "codex-cli 0.146.1"), false);
 });

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -19,11 +19,27 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const manager = path.join(root, "src", "config-manager.mjs");
 const CALLER_KEY = "test-config-caller-capability-with-sufficient-length";
 
+// The config manager probes the installed Codex binary to learn whether its
+// schema accepts the managed [agents] concurrency scalar. Point it at stubs so
+// the tests do not depend on whichever Codex build this machine has.
+const codexStubDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-codex-stub-"));
+const scalarAcceptingCodex = path.join(codexStubDir, "codex-accepts-scalar");
+writeFileSync(scalarAcceptingCodex, "#!/bin/sh\necho 'Not logged in' >&2\nexit 1\n", {
+  mode: 0o755,
+});
+const scalarRejectingCodex = path.join(codexStubDir, "codex-rejects-scalar");
+writeFileSync(
+  scalarRejectingCodex,
+  "#!/bin/sh\necho 'Error loading configuration: invalid type: integer, expected struct AgentRoleToml' >&2\nexit 1\n",
+  { mode: 0o755 },
+);
+
 function run(
   command,
   codexHome,
   stateDir = path.join(codexHome, "router-state"),
   commandArgs = [],
+  env = {},
 ) {
   mkdirSync(stateDir, { recursive: true, mode: 0o700 });
   const callerSecretPath = path.join(stateDir, "caller-secret");
@@ -36,9 +52,11 @@ function run(
       encoding: "utf8",
       env: {
         ...process.env,
+        CODEX_BIN: scalarAcceptingCodex,
         CODEX_HOME: codexHome,
         CODEX_ROUTER_STATE_DIR: stateDir,
         CODEX_ROUTER_PORT: "46192",
+        ...env,
       },
     }),
   );
@@ -208,6 +226,42 @@ config_file = "/tmp/example-agent.toml"
 
     run("disable", codexHome);
     assert.equal(readFileSync(configPath, "utf8").trimStart(), original);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager skips the agents scalar when the codex binary rejects it", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-strict-schema-"));
+  const configPath = path.join(codexHome, "config.toml");
+  const original = `model = "gpt-5.5"
+`;
+  writeFileSync(configPath, original, { mode: 0o600 });
+
+  try {
+    run("enable", codexHome, undefined, [], { CODEX_BIN: scalarRejectingCodex });
+    const enabled = readFileSync(configPath, "utf8");
+    assert.doesNotMatch(enabled, /codex-router-agent-concurrency-managed/);
+    assert.doesNotMatch(enabled, /^\[agents\]$/m);
+    assert.match(enabled, /# BEGIN codex-router-managed/);
+
+    run("disable", codexHome, undefined, [], { CODEX_BIN: scalarRejectingCodex });
+    assert.equal(readFileSync(configPath, "utf8").trimStart(), original);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager keeps writing the agents scalar when the codex binary accepts it", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-lenient-schema-"));
+  const configPath = path.join(codexHome, "config.toml");
+  writeFileSync(configPath, `model = "gpt-5.5"\n`, { mode: 0o600 });
+
+  try {
+    run("enable", codexHome, undefined, [], { CODEX_BIN: scalarAcceptingCodex });
+    const enabled = readFileSync(configPath, "utf8");
+    assert.match(enabled, /codex-router-agent-concurrency-managed/);
+    assert.match(enabled, /^max_concurrent_threads_per_session = 6$/m);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }


### PR DESCRIPTION
## What changed

- Probe the installed Codex binary before writing the managed `[agents]` concurrency scalar: ask it to load a minimal config containing only the scalar, and skip the managed default when the build rejects it.
- Stamp the cached native model catalog with the Codex version that captured it, and re-capture via `codex debug models` when the installed build changes. If the re-capture fails, keep serving the previous capture with a warning.

## Why

Follow-ups to #50, closing two gaps found while verifying it against real binaries:

- #50 skips the scalar only when the *config* looks modern (role tables or `features.multi_agent_v2`). But the failure is a property of the *binary*: Codex 0.141–0.145 reject the scalar even in legacy-shaped configs (verified: `codex login status` fails with `invalid type: integer '6', expected struct AgentRoleToml`), while 0.146+ accept it again alongside role tables. Probing the binary handles both directions: strict builds get a loadable config, lenient builds keep the concurrency cap.
- #50 stamps `supports_reasoning_summaries: false` onto native entries missing the field. Real catalogs advertise `true` for GPT models, so a stale capture from an older build would silently disable reasoning summaries after an upgrade. Refreshing the capture on version change keeps the field truthful; the `false` default remains as a last resort.

## Validation

- `npm run check`, `npm test` (227 passed, 0 failed, 2 skipped; 3 tests added)
- End-to-end against real binaries: `enable` skips the scalar under Codex 0.141.0 and 0.142.5 (config then loads cleanly) and injects it under 0.146.1
- Existing config-manager tests pinned to stub binaries so results no longer depend on the machine's Codex build

🤖 Generated with [Claude Code](https://claude.com/claude-code)