### PR TITLE
feat: announce newly routable models through Codex's native cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,11 @@ to ship tested support to every installer.
    effort in the picker); the deterministic `--models` form takes
    conservative defaults, `--efforts minimal,low,medium,high,xhigh` sets the
    effort ladder, and every stored value stays editable in
-   `user-models.json`. Curated models are not implicitly approved as native
-   v2 subagent model overrides.
+   `user-models.json`. An optional `availabilityNux` string on a model becomes
+   the Codex "Introducing {model}" announcement (shown a limited number of
+   times per slug, tracked by the Codex client itself); leave it unset unless
+   the model is genuinely news to the operator. Curated models are not
+   implicitly approved as native v2 subagent model overrides.
 6. Run `./bin/model-router codex doctor`. A live `bin/test-model` request uses
    provider quota, so run it only with the user's approval. Finally, tell the
    user to fully quit and reopen Codex before checking the picker.
@@ -116,7 +119,23 @@ installation. It is repository development and requires the process below.
    `gatewayModel`, and provider/upstream IDs; complete picker metadata;
    supported reasoning levels; input modalities; context/compaction limits;
    and the correct request profile. Use `listed: false` for compatibility-only
-   aliases.
+   aliases. An optional `availabilityNux` string ships announcement copy that
+   Codex renders as its "Introducing {model}" card the first few launches
+   after the model appears; reserve it for a genuinely new flagship, because
+   every installer will see it. Checked-in models that newly become routable
+   (added by an update, or unlocked when the operator credentials and enables
+   their provider) also announce automatically for seven days with copy
+   assembled from their verified picker metadata (context window, effort
+   ladder, image support) — tracked in the protected
+   `announced-models.json` state; the first catalog capture seeds that state
+   silently, curated `availabilityNux` copy wins over the generated text, and
+   locally curated user models never self-announce. In the CLI TUI this renders as a startup tip
+   line; the full-screen prompt is instead driven by an optional `upgradeTo`
+   object (`{ "model": "target/slug", "markdown": "..." }`) on the model the
+   operator currently runs: Codex renders the markdown as the entire
+   "Codex just got an upgrade" modal (with `{model_from}`/`{model_to}`
+   placeholders), and accepting switches the operator's default model to the
+   target, so ship one only for a genuine successor.
 3. A new provider also needs credential isolation, discovery metadata,
    selection/onboarding support, request translation, health behavior, and
    tests. Never place an API key or OAuth artifact in the registry. A new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **New models announce themselves in Codex.** Checked-in models that newly
+  become routable — shipped by a router update, or unlocked the moment their
+  provider is credentialed and enabled — now carry Codex's native
+  "Introducing {model}" announcement for seven days, with copy assembled from
+  their verified picker metadata (context window, effort ladder, image
+  input). The first catalog capture seeds the tracking state silently so an
+  install never announces the whole catalog, locally curated models never
+  self-announce, and Codex's own per-model show cap still applies. Curators
+  can override the generated copy with an `availabilityNux` string on the
+  registry entry, and a new `upgradeTo` field (`{ model, markdown }`) drives
+  Codex's full-screen migration prompt for a genuine successor model —
+  accepting it switches the operator's default model, so it is reserved for
+  deliberate hand-offs.
+
 - **Adapted the managed `[agents]` concurrency default to the installed Codex
   build.** Some Codex builds (observed on 0.141-0.145) parse `[agents]` as a
   pure role map and refuse to load any config containing the scalar, which

--- a/config/providers.json
+++ b/config/providers.json
@@ -1630,6 +1630,7 @@
       "listed": true,
       "displayName": "Muse Spark 1.2 (Meta)",
       "description": "Meta's coding-optimized agentic model with a 1M context window, through the Meta Model API using the Responses API.",
+      "availabilityNux": "Muse Spark 1.2 is now in your curated catalog: Meta's coding-optimized agentic model with a 1M-token context window, a minimal-to-xhigh effort ladder, and reasoning summaries.",
       "priority": 48,
       "defaultEffort": "high",
       "reasoningLevels": [

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -10,12 +10,14 @@ import { fileURLToPath } from "node:url";
 
 import { protectPrivateFile } from "./file-security.mjs";
 import {
+  ANNOUNCED_MODELS_PATH,
   CONFIG_PATH,
   MERGED_CATALOG_PATH,
   NATIVE_ALIAS_PATH,
   NATIVE_CATALOG_PATH,
 } from "./paths.mjs";
 import { codexAuthStatus, codexVersion, runCodex } from "./codex-binary.mjs";
+import { readUserModels } from "./user-models.mjs";
 import { syncRoutedCodexAgents } from "./codex-agent-catalog.mjs";
 import { MODEL_BY_SLUG } from "./model-registry.mjs";
 import { buildNativeAliasAssignments } from "./native-alias.mjs";
@@ -183,8 +185,22 @@ export function routedModel(template, model) {
     comp_hash: model.compHash,
     additional_speed_tiers: [],
     service_tiers: [],
-    availability_nux: null,
-    upgrade: null,
+    // Codex surfaces this once per slug (up to its own show cap) as the
+    // "Introducing {model}" announcement; absent copy must stay null so the
+    // client never renders an empty card.
+    availability_nux:
+      typeof model.availabilityNux === "string" && model.availabilityNux.trim()
+        ? { message: model.availabilityNux.trim() }
+        : null,
+    // Codex renders the markdown as the whole "Codex just got an upgrade"
+    // modal when this entry is the operator's current model and the target
+    // slug is listed; {model_from}/{model_to} are substituted by the client.
+    upgrade: model.upgradeTo
+      ? {
+          model: model.upgradeTo.model,
+          migration_markdown: model.upgradeTo.markdown.trim(),
+        }
+      : null,
     supports_reasoning_summaries: model.supportsReasoningSummaries === true,
     default_reasoning_summary:
       model.supportsReasoningSummaries === true
@@ -207,6 +223,88 @@ export function routedModel(template, model) {
     next.model_messages = rewriteModelMessages(next.model_messages, model);
   }
   return next;
+}
+
+export const AUTO_ANNOUNCE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function formatTokenCount(tokens) {
+  if (tokens >= 995_000) {
+    const millions = Math.round((tokens / 1_000_000) * 10) / 10;
+    return `${millions % 1 === 0 ? Math.round(millions) : millions}M`;
+  }
+  return `${Math.round(tokens / 1000)}K`;
+}
+
+function joinNaturally(parts) {
+  if (parts.length <= 1) return parts.join("");
+  if (parts.length === 2) return `${parts[0]} and ${parts[1]}`;
+  return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`;
+}
+
+// Announcement copy is assembled from verified registry capabilities only, so
+// it can never claim more than the picker metadata already does.
+function autoAnnouncementCopy(model) {
+  const details = [];
+  if (Number.isInteger(model.contextWindow)) {
+    details.push(`a ${formatTokenCount(model.contextWindow)}-token context window`);
+  }
+  const efforts = Array.isArray(model.reasoningLevels)
+    ? model.reasoningLevels.map((level) => level.effort)
+    : [];
+  if (efforts.length > 1) {
+    details.push(`reasoning efforts from ${efforts[0]} to ${efforts[efforts.length - 1]}`);
+  }
+  if ((model.inputModalities || []).includes("image")) {
+    details.push("image input");
+  }
+  const capabilities = details.length ? ` It comes with ${joinNaturally(details)}.` : "";
+  return `${model.displayName} just landed in your model picker.${capabilities}`;
+}
+
+// A new checked-in model announces itself for a window of rebuilds rather
+// than a single one, because catalogs rebuild on updates and provider toggles
+// and the operator may not launch Codex in between; Codex itself stops the
+// card after four showings per slug. The first capture seeds silently so an
+// install never announces the entire catalog, and locally curated models are
+// excluded because the operator added those deliberately. Only models whose
+// provider is selected and credentialed ever reach this list, so a model the
+// operator cannot use never announces.
+export function annotateNewModelAnnouncements(routedModelsList, announcedAt, userSlugs, now) {
+  const firstRun = announcedAt === null;
+  const nextAnnouncedAt = new Map(firstRun ? [] : announcedAt);
+  const models = routedModelsList.map((model) => {
+    if (!nextAnnouncedAt.has(model.slug)) {
+      nextAnnouncedAt.set(model.slug, firstRun ? 0 : now);
+    }
+    if (model.availabilityNux || userSlugs.has(model.slug)) return model;
+    const since = nextAnnouncedAt.get(model.slug);
+    if (since === 0 || now - since >= AUTO_ANNOUNCE_WINDOW_MS) return model;
+    return { ...model, availabilityNux: autoAnnouncementCopy(model) };
+  });
+  return { models, announcedAt: nextAnnouncedAt };
+}
+
+function readAnnouncedAt() {
+  if (!existsSync(ANNOUNCED_MODELS_PATH)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(ANNOUNCED_MODELS_PATH, "utf8"));
+    if (!parsed || typeof parsed.models !== "object" || Array.isArray(parsed.models)) {
+      return null;
+    }
+    return new Map(
+      Object.entries(parsed.models).filter(([, value]) => Number.isFinite(value)),
+    );
+  } catch {
+    // Corrupt state must reseed silently, not announce the whole catalog.
+    return null;
+  }
+}
+
+function writeAnnouncedAt(announcedAt) {
+  atomicJson(ANNOUNCED_MODELS_PATH, {
+    version: 1,
+    models: Object.fromEntries([...announcedAt.entries()].sort()),
+  });
 }
 
 function sortCatalogModels(models) {
@@ -264,7 +362,13 @@ function main() {
   // that does not own this state directory is how the picker ends up
   // advertising models the running gateway has no route for.
   assertStateOwnership("write the Codex model catalog");
-  const routedModels = selectedConfiguredListedModels();
+  const userSlugs = new Set(readUserModels().map((model) => String(model.slug)));
+  const { models: routedModels, announcedAt } = annotateNewModelAnnouncements(
+    selectedConfiguredListedModels(),
+    readAnnouncedAt(),
+    userSlugs,
+    Date.now(),
+  );
   const native = nativeCatalog();
   // Dropping every native model is destructive, so only do it when Codex
   // actually answered that the session is signed out. If the probe could not
@@ -290,6 +394,7 @@ function main() {
       };
   atomicJson(MERGED_CATALOG_PATH, { models: merged });
   atomicJson(NATIVE_ALIAS_PATH, { version: 1, aliases });
+  writeAnnouncedAt(announcedAt);
   const routedAgents = syncRoutedCodexAgents(routedModels);
   process.stdout.write(
     `${JSON.stringify({

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -136,6 +136,29 @@ function modelProblem(model, providers, slugs, gatewayModels) {
   ) {
     return `model ${model.slug} has an invalid defaultReasoningSummary`;
   }
+  if (
+    model.availabilityNux !== undefined &&
+    (typeof model.availabilityNux !== "string" || !model.availabilityNux.trim())
+  ) {
+    return `model ${model.slug} has an invalid availabilityNux`;
+  }
+  // The markdown is the entire migration modal body, so an empty one would
+  // render a blank prompt; a self-target would loop the prompt forever.
+  if (model.upgradeTo !== undefined) {
+    const upgrade = model.upgradeTo;
+    if (
+      !upgrade ||
+      typeof upgrade !== "object" ||
+      Array.isArray(upgrade) ||
+      typeof upgrade.model !== "string" ||
+      !upgrade.model ||
+      upgrade.model === model.slug ||
+      typeof upgrade.markdown !== "string" ||
+      !upgrade.markdown.trim()
+    ) {
+      return `model ${model.slug} has an invalid upgradeTo`;
+    }
+  }
   if (slugs.has(model.slug)) return `duplicate model slug ${model.slug}`;
   if (gatewayModels.has(model.gatewayModel)) {
     return `duplicate gateway model ${model.gatewayModel}`;

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -34,6 +34,7 @@ export const CODEX_AGENTS_DIR = path.join(CODEX_HOME, "agents");
 export const NATIVE_CATALOG_PATH = path.join(STATE_DIR, "native-models.json");
 export const MERGED_CATALOG_PATH = path.join(STATE_DIR, "merged-models.json");
 export const NATIVE_ALIAS_PATH = path.join(STATE_DIR, "native-aliases.json");
+export const ANNOUNCED_MODELS_PATH = path.join(STATE_DIR, "announced-models.json");
 export const LITELLM_CONFIG_PATH = path.join(STATE_DIR, "litellm.yaml");
 export const INTERNAL_SECRET_PATH = path.join(STATE_DIR, "internal-secret");
 export const CALLER_SECRET_PATH = path.join(STATE_DIR, "caller-secret");

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -27,6 +27,8 @@ const METADATA_FIELDS = new Set([
   "inputModalities",
   "reasoningLevels",
   "defaultEffort",
+  "availabilityNux",
+  "upgradeTo",
 ]);
 
 function gatewaySafe(value) {

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  AUTO_ANNOUNCE_WINDOW_MS,
+  annotateNewModelAnnouncements,
   buildMergedCatalog,
   buildLoginFreeCatalog,
   nativeCatalogIsReusable,
@@ -70,6 +72,78 @@ test("routed models advertise reasoning summaries only when the registry opts in
   });
   assert.equal(summarized.supports_reasoning_summaries, true);
   assert.equal(summarized.default_reasoning_summary, "auto");
+});
+
+test("routed models announce availability only when curated with NUX copy", () => {
+  // Default stays null: an empty announcement card must never render.
+  const plain = routedModel(template, grok);
+  assert.equal(plain.availability_nux, null);
+  const announced = routedModel(template, {
+    ...grok,
+    availabilityNux: "  Grok 4.5 now routes through your own X subscription.  ",
+  });
+  assert.deepEqual(announced.availability_nux, {
+    message: "Grok 4.5 now routes through your own X subscription.",
+  });
+});
+
+test("first capture seeds announcement state without announcing anything", () => {
+  const { models, announcedAt } = annotateNewModelAnnouncements([grok], null, new Set(), 1000);
+  assert.equal(models[0].availabilityNux, undefined);
+  assert.equal(announcedAt.get(grok.slug), 0);
+});
+
+test("models new since the last capture announce for a window, then go quiet", () => {
+  const seeded = new Map([["kimi-oauth/k3", 0]]);
+  const now = 5000;
+  const { models, announcedAt } = annotateNewModelAnnouncements([grok], seeded, new Set(), now);
+  assert.equal(
+    models[0].availabilityNux,
+    "Grok 4.5 (OAuth) just landed in your model picker. It comes with a 500K-token context window and image input.",
+  );
+  assert.equal(announcedAt.get(grok.slug), now);
+  // Within the window the copy persists across rebuilds; after it, silence.
+  const later = annotateNewModelAnnouncements([grok], announcedAt, new Set(), now + 1);
+  assert.ok(later.models[0].availabilityNux);
+  const expired = annotateNewModelAnnouncements(
+    [grok],
+    announcedAt,
+    new Set(),
+    now + AUTO_ANNOUNCE_WINDOW_MS,
+  );
+  assert.equal(expired.models[0].availabilityNux, undefined);
+  assert.equal(expired.announcedAt.get(grok.slug), now);
+});
+
+test("curated copy and locally curated models are left alone by auto-announce", () => {
+  const seeded = new Map();
+  const curated = { ...grok, availabilityNux: "Hand-written copy." };
+  const { models } = annotateNewModelAnnouncements([curated], seeded, new Set(), 1000);
+  assert.equal(models[0].availabilityNux, "Hand-written copy.");
+  const userModel = { ...grok, slug: "deepseek/user-added" };
+  const skipped = annotateNewModelAnnouncements(
+    [userModel],
+    seeded,
+    new Set(["deepseek/user-added"]),
+    1000,
+  );
+  assert.equal(skipped.models[0].availabilityNux, undefined);
+});
+
+test("routed models carry a migration prompt only when curated with upgradeTo", () => {
+  const plain = routedModel(template, grok);
+  assert.equal(plain.upgrade, null);
+  const upgraded = routedModel(template, {
+    ...grok,
+    upgradeTo: {
+      model: "kimi-oauth/k3",
+      markdown: "# Introducing Kimi K3\n\nSwitch from {model_from} to {model_to}.\n",
+    },
+  });
+  assert.deepEqual(upgraded.upgrade, {
+    model: "kimi-oauth/k3",
+    migration_markdown: "# Introducing Kimi K3\n\nSwitch from {model_from} to {model_to}.",
+  });
 });
 
 test("unverified routed models retain conservative v1 collaboration", () => {

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -105,11 +105,21 @@ test("readUserModels returns an empty list when the file is absent or invalid", 
 
 test("registry merges valid user models and skips collisions", async () => {
   const entries = [
-    userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-user-test", priority: 100 }),
+    userModelEntry({
+      providerId: "deepseek",
+      upstreamId: "deepseek-user-test",
+      priority: 100,
+      metadata: { availabilityNux: "Now available through your DeepSeek key." },
+    }),
     // Collides with a built-in slug and must be skipped, not fatal.
     { ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-v4-pro", priority: 101 }) },
     // Unknown provider must be skipped, not fatal.
     userModelEntry({ providerId: "no-such-provider", upstreamId: "x-model", priority: 102 }),
+    // Announcement copy must be a non-empty string; a blank one is skipped.
+    {
+      ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-blank-nux", priority: 103 }),
+      availabilityNux: "   ",
+    },
   ];
   writeUserModels(entries);
   const registry = await import("../src/model-registry.mjs");
@@ -117,8 +127,10 @@ test("registry merges valid user models and skips collisions", async () => {
   assert.ok(slugs.includes("deepseek/deepseek-user-test"));
   assert.equal(slugs.filter((slug) => slug === "deepseek/deepseek-v4-pro").length, 1);
   assert.ok(!slugs.includes("no-such-provider/x-model"));
+  assert.ok(!slugs.includes("deepseek/deepseek-blank-nux"));
   assert.ok(registry.MODEL_BY_GATEWAY_ID.has("deepseek-deepseek-user-test"));
-  assert.ok(registry.USER_MODEL_WARNINGS.length >= 2);
+  assert.ok(registry.USER_MODEL_WARNINGS.length >= 3);
   const merged = registry.MODEL_BY_SLUG.get("deepseek/deepseek-user-test");
   assert.equal(merged.listed, true);
+  assert.equal(merged.availabilityNux, "Now available through your DeepSeek key.");
 });


### PR DESCRIPTION
## Summary
- Checked-in models that newly become routable (shipped by a router update, or unlocked when their provider is credentialed and enabled) now carry Codex's native "Introducing {model}" announcement for seven days, with copy assembled from their verified picker metadata (context window, effort ladder, image input) — e.g. *"Kimi K3 (OAuth) just landed in your model picker. It comes with a 262K-token context window, reasoning efforts from low to xhigh, and image input."*
- The first catalog capture seeds the protected `announced-models.json` state silently so a fresh install never announces the whole catalog; locally curated user models never self-announce; Codex's own 4-showings-per-slug cap still applies; models without provider credentials never enter the catalog, so they can never announce.
- Curators can override generated copy with an explicit `availabilityNux` string on a registry entry (demo copy included for `meta/muse-spark-1.2`), and the new `upgradeTo` field (`{ model, markdown }`) drives Codex's full-screen "Codex just got an upgrade" migration prompt — accepting switches the operator's default model, so it is documented as reserved for genuine successors.
- Field shapes (`availability_nux: { message }`, `upgrade: { model, migration_markdown }` with `{model_from}`/`{model_to}` placeholders) verified against openai/codex source at tag rust-v0.141.0 and current main; identical across the range.

## Test plan
- `npm test` (241 passing) covers: registry validation for `availabilityNux`/`upgradeTo`, catalog emission for both fields, silent first-run seeding, the 7-day announce window, curated-copy precedence, and user-model exclusion.
- Verified live on macOS with codex-cli 0.141.0: simulated a new model arriving, confirmed the generated announcement in the merged catalog, and exercised the migration modal end to end (accept switches model; decline records the acknowledgment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)