### PR TITLE
feat: migration prompts for legacy opencode Go models, release 0.4.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
-## Unreleased
+## 0.4.0-beta.2
+
+- **Reasoning efforts now match what the installed Codex build can display.**
+  Codex's picker parses effort levels into a fixed enum and silently drops
+  values it does not recognize; `max` and `ultra` only joined that enum in
+  Codex 0.143.0, so on older builds the `max` tiers curated for several
+  models simply vanished from the effort menu (GLM-5.2 lost its second tier,
+  DeepSeek V4 Flash showed two levels instead of three). The catalog now
+  derives the supported vocabulary from the installed Codex version and
+  republishes out-of-range efforts at the nearest supported tier (`max` →
+  `xhigh`), keeping defaults and announcement copy in range. Routing is
+  unchanged — the forwarder already folds `xhigh` back to each vendor's
+  documented maximum.
+
+- **Legacy opencode Go models now offer Codex's native migration prompt.**
+  GLM-5.1, Kimi K2.6, and MiniMax M2.7 carry an `upgradeTo` entry pointing at
+  their generational successor on the same subscription (GLM-5.2, Kimi K3,
+  MiniMax M3), so operators still running the older model get the
+  full-screen "upgrade" modal and can switch their default with one accept —
+  the older models stay in the picker. Upgrade targets are now validated at
+  registry load: a checked-in prompt pointing at a missing or unlisted slug
+  fails the build, and a user-curated one is skipped with a warning instead
+  of shipping a modal that can never render.
 
 - **New models announce themselves in Codex.** Checked-in models that newly
   become routable — shipped by a router update, or unlocked the moment their

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codex-router/desktop",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codex-router/desktop",
-      "version": "0.4.0-beta.1",
+      "version": "0.4.0-beta.2",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-router/desktop",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "codex-router-desktop"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-router-desktop"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 description = "Windows and Linux tray companion for Codex Model Router"
 authors = ["Codex Model Router contributors"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Model Router",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "identifier": "com.codexrouter.desktop",
   "build": {
     "frontendDist": "../ui"

--- a/config/providers.json
+++ b/config/providers.json
@@ -1229,6 +1229,10 @@
       "displayName": "GLM-5.1 (opencode Go)",
       "description": "GLM-5.1 through the opencode Go subscription.",
       "priority": 32,
+      "upgradeTo": {
+        "model": "opencode-go/glm-5.2",
+        "markdown": "GLM-5.2 is available on your opencode Go subscription\n\n{model_to} is the next GLM generation after {model_from}, with the same 1M-token context window plus a Max reasoning tier for harder agent work. Accept to switch your default model; GLM-5.1 stays available in the picker."
+      },
       "defaultEffort": "high",
       "reasoningLevels": [
         {
@@ -1298,6 +1302,10 @@
       "displayName": "Kimi K2.6 (opencode Go)",
       "description": "Kimi K2.6 through the opencode Go subscription.",
       "priority": 35,
+      "upgradeTo": {
+        "model": "opencode-go/kimi-k3",
+        "markdown": "Kimi K3 is available on your opencode Go subscription\n\n{model_to} is Moonshot's successor to {model_from}, running at maximum reasoning effort with the same 256K-token context window. Accept to switch your default model; Kimi K2.6 stays available in the picker."
+      },
       "defaultEffort": "high",
       "reasoningLevels": [
         {
@@ -1448,6 +1456,10 @@
       "displayName": "MiniMax M2.7 (opencode Go)",
       "description": "MiniMax M2.7 through the opencode Go subscription using the Messages API.",
       "priority": 41,
+      "upgradeTo": {
+        "model": "opencode-go-messages/minimax-m3",
+        "markdown": "MiniMax M3 is available on your opencode Go subscription\n\n{model_to} succeeds {model_from} and grows the context window from 128K to 1M tokens. Accept to switch your default model; MiniMax M2.7 stays available in the picker."
+      },
       "defaultEffort": "high",
       "reasoningLevels": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-model-router",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-model-router",
-      "version": "0.4.0-beta.1",
+      "version": "0.4.0-beta.2",
       "dependencies": {
         "proper-lockfile": "4.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-model-router",
-  "version": "0.4.0-beta.1",
+  "version": "0.4.0-beta.2",
   "private": true,
   "type": "module",
   "description": "Extensible local model router for Codex and Cursor",

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -92,10 +92,32 @@ function loadRegistry() {
     return Object.freeze(model);
   });
 
+  const modelBySlug = new Map(models.map((model) => [model.slug, model]));
+  for (const model of models) {
+    const problem = upgradeTargetProblem(model, modelBySlug);
+    if (problem) fail(problem);
+  }
+
   return {
     providers,
     models: Object.freeze(models),
   };
+}
+
+// Codex only renders the upgrade modal when the target slug is in the picker,
+// so a prompt pointing at a missing or unlisted model can never fire. Catch
+// that at load time instead of shipping a silent no-op. Targets may be
+// declared later in the file, so this runs after the whole set is known.
+function upgradeTargetProblem(model, modelBySlug) {
+  if (model.upgradeTo === undefined) return undefined;
+  const target = modelBySlug.get(model.upgradeTo.model);
+  if (!target) {
+    return `model ${model.slug} upgrades to unknown model ${model.upgradeTo.model}`;
+  }
+  if (!target.listed) {
+    return `model ${model.slug} upgrades to unlisted model ${model.upgradeTo.model}`;
+  }
+  return undefined;
 }
 
 // Returns a problem description instead of throwing so the strict registry
@@ -217,6 +239,7 @@ function mergeUserModels(base) {
   const models = [...base.models];
   const slugs = new Set(models.map((model) => model.slug));
   const gatewayModels = new Set(models.map((model) => model.gatewayModel));
+  const userModels = new Set();
   for (const model of readUserModels()) {
     const problem = modelProblem(model, base.providers, slugs, gatewayModels);
     if (problem) {
@@ -225,9 +248,23 @@ function mergeUserModels(base) {
     }
     slugs.add(model.slug);
     gatewayModels.add(model.gatewayModel);
-    models.push(Object.freeze(model));
+    const frozen = Object.freeze(model);
+    userModels.add(frozen);
+    models.push(frozen);
   }
-  return { models: Object.freeze(models), warnings: Object.freeze(warnings) };
+  // Upgrade targets may point at models merged later in the overlay, so they
+  // resolve only after the whole set settles.
+  const modelBySlug = new Map(models.map((model) => [model.slug, model]));
+  const kept = models.filter((model) => {
+    if (!userModels.has(model)) return true;
+    const problem = upgradeTargetProblem(model, modelBySlug);
+    if (problem) {
+      warnings.push(`Skipped user model: ${problem}`);
+      return false;
+    }
+    return true;
+  });
+  return { models: Object.freeze(kept), warnings: Object.freeze(warnings) };
 }
 
 const registry = loadRegistry();

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -180,3 +180,62 @@ test("LiteLLM configuration is generated from every registry route", () => {
   assert.doesNotMatch(lunaBlock, /use_chat_completions_api/);
   assert.doesNotMatch(rendered, /ANTHROPIC_API_KEY|DEEPSEEK_API_KEY|KIMI_API_KEY/);
 });
+
+test("curated upgrade prompts point at listed generational successors", () => {
+  // The modal only renders when the target slug is in the picker, so every
+  // upgradeTo must resolve to a listed model (also enforced at load time).
+  for (const model of MODELS) {
+    if (model.upgradeTo === undefined) continue;
+    const target = MODEL_BY_SLUG.get(model.upgradeTo.model);
+    assert.ok(target, `${model.slug} upgrade target exists`);
+    assert.equal(target.listed, true, `${model.slug} upgrade target is listed`);
+    // Accepting the modal switches the default model, so the target must ride
+    // the same credential: same provider, or a variant of the same parent.
+    const family = (id) => PROVIDERS.get(id).variantOf || id;
+    assert.equal(
+      family(target.provider),
+      family(model.provider),
+      `${model.slug} upgrade target stays on the same credential`,
+    );
+  }
+  assert.equal(
+    MODEL_BY_SLUG.get("opencode-go/glm-5.1").upgradeTo.model,
+    "opencode-go/glm-5.2",
+  );
+  assert.equal(
+    MODEL_BY_SLUG.get("opencode-go/kimi-k2.6").upgradeTo.model,
+    "opencode-go/kimi-k3",
+  );
+  assert.equal(
+    MODEL_BY_SLUG.get("opencode-go-messages/minimax-m2.7").upgradeTo.model,
+    "opencode-go-messages/minimax-m3",
+  );
+});
+
+test("a checked-in upgrade prompt with an unresolvable target fails the registry load", async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const path = (await import("node:path")).default;
+  const { spawnSync } = await import("node:child_process");
+  const dir = mkdtempSync(path.join(tmpdir(), "registry-upgrade-test-"));
+  try {
+    const registry = JSON.parse(
+      (await import("node:fs")).readFileSync("config/providers.json", "utf8"),
+    );
+    registry.models[0] = {
+      ...registry.models[0],
+      upgradeTo: { model: "no-such/model", markdown: "Upgrade now" },
+    };
+    const registryPath = path.join(dir, "providers.json");
+    writeFileSync(registryPath, JSON.stringify(registry));
+    const result = spawnSync(
+      process.execPath,
+      ["-e", "import('./src/model-registry.mjs').catch((e)=>{console.error(e.message);process.exit(1);})"],
+      { encoding: "utf8", env: { ...process.env, MODEL_ROUTER_REGISTRY: registryPath } },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /upgrades to unknown model no-such\/model/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -120,6 +120,17 @@ test("registry merges valid user models and skips collisions", async () => {
       ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-blank-nux", priority: 103 }),
       availabilityNux: "   ",
     },
+    // An upgrade prompt pointing at a slug the merged registry does not carry
+    // can never render, so the entry is skipped.
+    {
+      ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-bad-upgrade", priority: 104 }),
+      upgradeTo: { model: "no-such/model", markdown: "Switch now" },
+    },
+    // A prompt targeting a listed checked-in model is kept.
+    {
+      ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-good-upgrade", priority: 105 }),
+      upgradeTo: { model: "deepseek/deepseek-v4-pro", markdown: "V4 Pro supersedes this preview." },
+    },
   ];
   writeUserModels(entries);
   const registry = await import("../src/model-registry.mjs");
@@ -128,8 +139,13 @@ test("registry merges valid user models and skips collisions", async () => {
   assert.equal(slugs.filter((slug) => slug === "deepseek/deepseek-v4-pro").length, 1);
   assert.ok(!slugs.includes("no-such-provider/x-model"));
   assert.ok(!slugs.includes("deepseek/deepseek-blank-nux"));
+  assert.ok(!slugs.includes("deepseek/deepseek-bad-upgrade"));
+  assert.deepEqual(
+    registry.MODEL_BY_SLUG.get("deepseek/deepseek-good-upgrade").upgradeTo,
+    { model: "deepseek/deepseek-v4-pro", markdown: "V4 Pro supersedes this preview." },
+  );
   assert.ok(registry.MODEL_BY_GATEWAY_ID.has("deepseek-deepseek-user-test"));
-  assert.ok(registry.USER_MODEL_WARNINGS.length >= 3);
+  assert.ok(registry.USER_MODEL_WARNINGS.length >= 4);
   const merged = registry.MODEL_BY_SLUG.get("deepseek/deepseek-user-test");
   assert.equal(merged.listed, true);
   assert.equal(merged.availabilityNux, "Now available through your DeepSeek key.");


### PR DESCRIPTION
## Summary

Wires the `upgradeTo` curation field (mechanism shipped in #59, previously unused) to real registry entries and cuts the first tagged release.

### Migration prompts

Three legacy models now point at their generational successor on the same opencode Go subscription, driving Codex's native full-screen "upgrade" modal:

| Current model | Successor | Verified delta in copy |
|---|---|---|
| GLM-5.1 | GLM-5.2 | adds a Max reasoning tier (same 1M context) |
| Kimi K2.6 | Kimi K3 | max-effort reasoning (same 256K context) |
| MiniMax M2.7 | MiniMax M3 | context grows 128K → 1M tokens |

All three stay listed in the picker; accepting the modal only switches the operator's default. Copy claims nothing beyond registry-verified metadata, per the AGENTS.md announcement discipline.

### Load-time validation

Codex only renders the modal when the target slug is in the picker, so an unresolvable target is a silent no-op. The registry now catches that: a checked-in `upgradeTo` pointing at a missing or unlisted slug **fails the load**, and a user-curated one is **skipped with a warning**. Targets resolve after the whole model set is known, so forward references and the user overlay both work.

### Release 0.4.0-beta.2

Version bumped in the router and desktop app (package.json, lockfiles, tauri.conf.json, Cargo.toml/lock), and the changelog's Unreleased section becomes `0.4.0-beta.2`, folding in the effort-clamp fix from #60. Tagging `v0.4.0-beta.2` after merge triggers the release workflow.

## Testing

- `npm test` — 245 pass (new: curated-upgrade invariants incl. same-credential-family check, fail-hard subprocess test for an unresolvable checked-in target, user-overlay skip/keep cases)
- `npm run check` — passes
- Live catalog rebuild emits the three routed upgrades alongside Codex's own native ones (gpt-5.4 → gpt-5.6-terra)
- The merged catalog parses cleanly through `codex debug models` on both **0.141.0** and **0.147.0-alpha** builds
- `model-router codex doctor` — healthy, 24 routed entries visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)