### PR TITLE
perf(update): skip dependency work an update does not change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,13 @@ user.
    catalog, caller capability, internal key, service, router health, and
    selected credentials must be `OK`. Unselected credentials may be `WARN`.
 9. If a managed layer fails, use `model-router codex doctor --fix`; add
-   `--migrate-known` only for a recognized older installation. If repair still
-   fails, create `bin/support-bundle` and report its path without uploading it.
+   `--migrate-known` only for a recognized older installation. Repair rebuilds
+   the Node and Python dependencies unconditionally, unlike a normal install or
+   update, which skips whichever dependency step already matches its
+   fingerprint. Force that rebuild by hand with `bin/install --force-deps`
+   (`./install.ps1 -CheckoutInstall -ForceDeps`) when an environment looks
+   corrupted rather than merely out of date. If repair still fails, create
+   `bin/support-bundle` and report its path without uploading it.
 10. Do not terminate Codex. Tell the user to fully quit it, reopen it, create a
     new task, and choose the new model.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## 0.4.0-beta.2
 
+- **Updates stop reinstalling dependencies that never changed.** Every update
+  re-ran the whole installer, so a commit that touched one `.mjs` file still
+  wiped `node_modules` for a fresh `npm ci` and re-resolved the entire
+  `litellm[proxy]` tree against PyPI — which pulled unpinned transitive
+  upgrades and, on a cold uv cache or a slow link, dominated the run. Both
+  installers now fingerprint each dependency step (the lockfile for Node, the
+  pinned requirement set plus the installed distribution versions for Python)
+  and skip it when the artifacts already match, recording the stamp next to
+  `node_modules/` and `.venv/` so deleting either one reinstalls. Repair still
+  rebuilds everything: `doctor --fix` passes `--force-deps` (`-ForceDeps` on
+  Windows), which fingerprints cannot know about a corrupted tree. The
+  LiteLLM and FastAPI pins now live in `src/install-plan.mjs`, and a test
+  fails if either installer's copy drifts.
+
+- **`update check` no longer performs the update.** The `bin/update` wrapper
+  hardcoded the `update` subcommand, so the read-only availability check was
+  unreachable from the CLI and asking "is there a new version?" reinstalled
+  the router instead. Both `bin/update` and `codex-router.ps1 update` now
+  forward the subcommand, and a bare invocation still updates.
+
 - **Reasoning efforts now match what the installed Codex build can display.**
   Codex's picker parses effort levels into a fixed enum and silently drops
   values it does not recognize; `max` and `ultra` only joined that enum in

--- a/bin/install
+++ b/bin/install
@@ -4,6 +4,7 @@ set -eu
 repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 prepare_only=false
 migrate_known=false
+force_deps=false
 target=${MODEL_ROUTER_TARGET:-codex}
 
 # Installing is the sanctioned way for a checkout to take over a state
@@ -21,7 +22,8 @@ for argument in "$@"; do
   case "$argument" in
     --prepare-only) prepare_only=true ;;
     --migrate-known) migrate_known=true ;;
-    *) echo "Usage: $0 [--prepare-only] [--migrate-known]" >&2; exit 2 ;;
+    --force-deps) force_deps=true ;;
+    *) echo "Usage: $0 [--prepare-only] [--migrate-known] [--force-deps]" >&2; exit 2 ;;
   esac
 done
 
@@ -59,15 +61,34 @@ fi
 if [ "$prepare_only" != true ]; then
   node src/provider-selection.mjs ensure-configured >/dev/null
 fi
-npm ci --omit=dev
+# Every update re-runs this installer, so the dependency steps are skipped when
+# their inputs are unchanged; --force-deps (used by doctor --fix) rebuilds them.
+install_step() {
+  if [ "$force_deps" = true ]; then
+    echo run
+  else
+    node src/install-plan.mjs status "$1" 2>/dev/null || echo run
+  fi
+}
 
-if command -v uv >/dev/null 2>&1; then
+if [ "$(install_step node-deps)" = skip ]; then
+  echo "Node dependencies already match package-lock.json; skipping npm ci."
+else
+  npm ci --omit=dev
+  node src/install-plan.mjs record node-deps
+fi
+
+if [ "$(install_step python-deps)" = skip ]; then
+  echo "LiteLLM already matches the pinned versions; skipping the Python install."
+elif command -v uv >/dev/null 2>&1; then
   if [ ! -x .venv/bin/python ]; then
     uv venv --python 3.12 .venv
   fi
   # litellm 1.95.0 needs fastapi<0.140 (get_flat_dependant was removed);
-  # re-test before lifting either pin.
+  # re-test before lifting either pin. src/install-plan.mjs holds the same pins
+  # and its test fails when only one copy moves.
   uv pip install --python .venv/bin/python 'litellm[proxy]==1.95.0' 'fastapi==0.139.2'
+  node src/install-plan.mjs record python-deps
 else
   if ! command -v python3 >/dev/null 2>&1; then
     echo "Python 3.10+ or uv is required to install LiteLLM." >&2
@@ -77,6 +98,7 @@ else
   python3 -m venv .venv
   .venv/bin/python -m pip install --upgrade pip
   .venv/bin/python -m pip install 'litellm[proxy]==1.95.0' 'fastapi==0.139.2'
+  node src/install-plan.mjs record python-deps
 fi
 
 node src/secret.mjs ensure

--- a/bin/update
+++ b/bin/update
@@ -2,4 +2,9 @@
 set -eu
 
 repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-exec node "$repo_dir/src/update.mjs" update "$@"
+# Forward the subcommand so `update check` stays a read-only comparison instead
+# of silently performing a full update.
+if [ "$#" -eq 0 ]; then
+  exec node "$repo_dir/src/update.mjs" update
+fi
+exec node "$repo_dir/src/update.mjs" "$@"

--- a/codex-router.ps1
+++ b/codex-router.ps1
@@ -43,7 +43,11 @@ switch ($Command) {
     Invoke-RouterNode "src\config-manager.mjs" @("disable")
     Invoke-RouterNode "src\service.mjs" @("uninstall")
   }
-  "update" { Invoke-RouterNode "src\update.mjs" @("update") }
+  "update" {
+    # `update check` stays a read-only comparison; a bare `update` installs.
+    $UpdateArguments = if ($Arguments.Count) { $Arguments } else { @("update") }
+    Invoke-RouterNode "src\update.mjs" $UpdateArguments
+  }
   "rollback" { Invoke-RouterNode "src\update.mjs" @("rollback") }
   "support-bundle" { Invoke-RouterNode "src\support-bundle.mjs" $Arguments }
   "smoke-test" {

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -249,6 +249,7 @@ Live quota-consuming verification is separate:
 ## Update and rollback
 
 ```sh
+./bin/update check
 ./bin/update
 ./bin/rollback
 ```
@@ -256,6 +257,7 @@ Live quota-consuming verification is separate:
 Windows:
 
 ```powershell
+./codex-router.ps1 update check
 ./codex-router.ps1 update
 ./codex-router.ps1 rollback
 ```
@@ -263,7 +265,14 @@ Windows:
 The updater requires a clean checkout on the recognized GitHub origin. It
 fetches `origin/main`, retains the current revision under
 `refs/codex-router/rollback`, fast-forwards, and reinstalls. A failed install
-automatically checks out and reinstalls the previous revision.
+automatically checks out and reinstalls the previous revision. `update check`
+only compares the revisions and changes nothing.
+
+The reinstall skips dependency work whose inputs are unchanged, so an update
+that carries no `package-lock.json` or LiteLLM pin change costs a service
+restart rather than a full `npm ci` and PyPI resolution. `./bin/doctor --fix`
+rebuilds them regardless, as does `./bin/install --force-deps`
+(`./install.ps1 -CheckoutInstall -ForceDeps` on Windows).
 
 When upgrading from a release without caller capabilities, the installer
 generates one, replaces only the marked managed URL, tightens config permissions,

--- a/install.ps1
+++ b/install.ps1
@@ -2,6 +2,7 @@
 param(
   [switch]$CheckoutInstall,
   [switch]$PrepareOnly,
+  [switch]$ForceDeps,
   [ValidateSet("codex")]
   [string]$Target = "codex",
   [switch]$Guided,
@@ -133,18 +134,44 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "Configure at least one provider before installing." }
   }
 
-  & npm ci --omit=dev
-  if ($LASTEXITCODE -ne 0) { throw "npm dependency installation failed." }
+  # Every update re-runs this installer, so the dependency steps are skipped
+  # when their inputs are unchanged; -ForceDeps (used by doctor --fix) rebuilds
+  # them.
+  function Get-InstallStep([string]$Step) {
+    if ($ForceDeps) { return "run" }
+    try {
+      $Status = (& node src/install-plan.mjs status $Step 2>$null | Select-Object -Last 1)
+      if ($LASTEXITCODE -ne 0) { return "run" }
+      return "$Status".Trim()
+    } catch {
+      return "run"
+    }
+  }
+
+  if ((Get-InstallStep "node-deps") -eq "skip") {
+    Write-Host "Node dependencies already match package-lock.json; skipping npm ci."
+  } else {
+    & npm ci --omit=dev
+    if ($LASTEXITCODE -ne 0) { throw "npm dependency installation failed." }
+    & node src/install-plan.mjs record node-deps
+    if ($LASTEXITCODE -ne 0) { throw "Recording the Node dependency state failed." }
+  }
 
   $Python = Join-Path $ScriptDirectory ".venv\Scripts\python.exe"
-  if (Get-Command "uv" -ErrorAction SilentlyContinue) {
+  if ((Get-InstallStep "python-deps") -eq "skip") {
+    Write-Host "LiteLLM already matches the pinned versions; skipping the Python install."
+  } elseif (Get-Command "uv" -ErrorAction SilentlyContinue) {
     if (-not (Test-Path $Python)) {
       & uv venv --python 3.12 .venv
       if ($LASTEXITCODE -ne 0) { throw "uv could not create the Python environment." }
     }
     # litellm 1.95.0 needs fastapi<0.140 (get_flat_dependant was removed);
-    # re-test before lifting either pin.
+    # re-test before lifting either pin. src/install-plan.mjs holds the same
+    # pins and its test fails when only one copy moves.
     & uv pip install --python $Python "litellm[proxy]==1.95.0" "fastapi==0.139.2"
+    if ($LASTEXITCODE -ne 0) { throw "LiteLLM installation failed." }
+    & node src/install-plan.mjs record python-deps
+    if ($LASTEXITCODE -ne 0) { throw "Recording the Python dependency state failed." }
   } else {
     if (Get-Command "py" -ErrorAction SilentlyContinue) {
       & py -3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"
@@ -161,8 +188,10 @@ try {
     & $Python -m pip install --upgrade pip
     if ($LASTEXITCODE -ne 0) { throw "pip upgrade failed." }
     & $Python -m pip install "litellm[proxy]==1.95.0" "fastapi==0.139.2"
+    if ($LASTEXITCODE -ne 0) { throw "LiteLLM installation failed." }
+    & node src/install-plan.mjs record python-deps
+    if ($LASTEXITCODE -ne 0) { throw "Recording the Python dependency state failed." }
   }
-  if ($LASTEXITCODE -ne 0) { throw "LiteLLM installation failed." }
 
   & node src/secret.mjs ensure
   if ($LASTEXITCODE -ne 0) { throw "Local router-key setup failed." }

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -67,6 +67,8 @@ function repair() {
     childJson("legacy-migration.mjs", ["apply", "--yes"]);
   }
   const repairStdio = jsonOutput ? ["inherit", "ignore", "inherit"] : "inherit";
+  // Repair rebuilds dependencies unconditionally: the fingerprints an ordinary
+  // install trusts cannot see a corrupted node_modules or virtual environment.
   const result = process.platform === "win32"
     ? spawnSync(
         "powershell.exe",
@@ -78,10 +80,11 @@ function repair() {
           "-File",
           path.join(SOURCE_ROOT, "install.ps1"),
           "-CheckoutInstall",
+          "-ForceDeps",
         ],
         { cwd: SOURCE_ROOT, env: process.env, stdio: repairStdio },
       )
-    : spawnSync(path.join(SOURCE_ROOT, "bin", "install"), [], {
+    : spawnSync(path.join(SOURCE_ROOT, "bin", "install"), ["--force-deps"], {
         cwd: SOURCE_ROOT,
         env: process.env,
         stdio: repairStdio,

--- a/src/install-plan.mjs
+++ b/src/install-plan.mjs
@@ -1,0 +1,187 @@
+// Every update runs the whole installer, so the expensive dependency steps are
+// gated on a fingerprint of the inputs they consume. A code-only update then
+// costs a service restart instead of a full `npm ci` plus a fresh PyPI
+// resolution of the LiteLLM proxy tree.
+//
+// Each stamp lives next to the artifact it describes (`node_modules/`,
+// `.venv/`), so deleting the artifact invalidates the stamp automatically and
+// no state directory has to stay in sync with the checkout.
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const SOURCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// litellm 1.95.0 needs fastapi<0.140 (get_flat_dependant was removed); re-test
+// before lifting either pin. bin/install and install.ps1 repeat these literals
+// so both scripts stay readable; `installerRequirementDrift` fails the test
+// suite if a copy is edited alone.
+export const PYTHON_REQUIREMENTS = ["litellm[proxy]==1.95.0", "fastapi==0.139.2"];
+
+const STAMP_NAME = ".codex-router-install.json";
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function readFile(target) {
+  try {
+    return readFileSync(target, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+export function requirementParts(requirement) {
+  const [specifier, version] = String(requirement).split("==");
+  return { name: specifier.replace(/\[[^\]]*\]$/, "").trim(), version: (version || "").trim() };
+}
+
+function sitePackages(root, platform) {
+  if (platform === "win32") return [path.join(root, ".venv", "Lib", "site-packages")];
+  const libraries = path.join(root, ".venv", "lib");
+  try {
+    return readdirSync(libraries)
+      .filter((entry) => entry.startsWith("python"))
+      .map((entry) => path.join(libraries, entry, "site-packages"));
+  } catch {
+    return [];
+  }
+}
+
+// Distribution directories normalize the project name, so `litellm[proxy]`
+// installs as `litellm-1.95.0.dist-info`.
+export function installedDistributionVersion(name, { root = SOURCE_ROOT, platform = process.platform } = {}) {
+  const normalized = name.toLowerCase().replace(/[-_.]+/g, "_");
+  for (const directory of sitePackages(root, platform)) {
+    let entries;
+    try {
+      entries = readdirSync(directory);
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.endsWith(".dist-info")) continue;
+      const base = entry.slice(0, -".dist-info".length);
+      const separator = base.lastIndexOf("-");
+      if (separator <= 0) continue;
+      if (base.slice(0, separator).toLowerCase().replace(/[-_.]+/g, "_") === normalized) {
+        return base.slice(separator + 1);
+      }
+    }
+  }
+  return undefined;
+}
+
+function venvPython(root, platform) {
+  return platform === "win32"
+    ? path.join(root, ".venv", "Scripts", "python.exe")
+    : path.join(root, ".venv", "bin", "python");
+}
+
+// uv writes `version_info`, the stdlib venv module writes `version`.
+function venvPythonVersion(root) {
+  const config = readFile(path.join(root, ".venv", "pyvenv.cfg")) || "";
+  const match = config.match(/^\s*version(?:_info)?\s*=\s*(\d+\.\d+)/m);
+  return match ? match[1] : "unknown";
+}
+
+export const STEPS = {
+  "node-deps": {
+    stamp: (root) => path.join(root, "node_modules", STAMP_NAME),
+    fingerprint: (root) =>
+      sha256(
+        [
+          `node:${process.versions.node.split(".")[0]}`,
+          readFile(path.join(root, "package-lock.json")) ?? "",
+        ].join("\0"),
+      ),
+    // npm writes this tree summary on every successful install; a partially
+    // deleted `node_modules` therefore reads as "not installed".
+    installed: (root) => existsSync(path.join(root, "node_modules", ".package-lock.json")),
+    skipMessage: "Node dependencies already match package-lock.json; skipping npm ci.",
+  },
+  "python-deps": {
+    stamp: (root) => path.join(root, ".venv", STAMP_NAME),
+    fingerprint: (root) =>
+      sha256([`python:${venvPythonVersion(root)}`, ...PYTHON_REQUIREMENTS].join("\0")),
+    installed: (root, platform) => {
+      if (!existsSync(venvPython(root, platform))) return false;
+      return PYTHON_REQUIREMENTS.every((requirement) => {
+        const { name, version } = requirementParts(requirement);
+        return installedDistributionVersion(name, { root, platform }) === version;
+      });
+    },
+    skipMessage: "LiteLLM already matches the pinned versions; skipping the Python install.",
+  },
+};
+
+export function stepStatus(step, { root = SOURCE_ROOT, platform = process.platform } = {}) {
+  const definition = STEPS[step];
+  if (!definition) throw new Error(`Unknown install step: ${step}`);
+  if (!definition.installed(root, platform)) return "run";
+  const stamp = readFile(definition.stamp(root));
+  if (!stamp) return "run";
+  try {
+    const parsed = JSON.parse(stamp);
+    return parsed?.fingerprint === definition.fingerprint(root) ? "skip" : "run";
+  } catch {
+    return "run";
+  }
+}
+
+export function recordStep(step, { root = SOURCE_ROOT } = {}) {
+  const definition = STEPS[step];
+  if (!definition) throw new Error(`Unknown install step: ${step}`);
+  const target = definition.stamp(root);
+  writeFileSync(
+    target,
+    `${JSON.stringify({ version: 1, step, fingerprint: definition.fingerprint(root) }, null, 2)}\n`,
+    { encoding: "utf8" },
+  );
+  return target;
+}
+
+// The installers hold the pins as literals so the shell stays readable; this
+// check keeps those copies identical to PYTHON_REQUIREMENTS.
+export function installerRequirementDrift(root = SOURCE_ROOT) {
+  return [path.join("bin", "install"), "install.ps1"].filter((script) => {
+    const contents = readFile(path.join(root, script)) ?? "";
+    return !PYTHON_REQUIREMENTS.every((requirement) => contents.includes(requirement));
+  });
+}
+
+function main(argv) {
+  const [command, step] = argv;
+  if (command === "status") {
+    // Fail open: an unexpected error must run the step, never skip it.
+    let status = "run";
+    try {
+      status = stepStatus(step);
+    } catch {
+      status = "run";
+    }
+    process.stdout.write(`${status}\n`);
+    return 0;
+  }
+  if (command === "record") {
+    recordStep(step);
+    return 0;
+  }
+  if (command === "requirements") {
+    process.stdout.write(`${PYTHON_REQUIREMENTS.join("\n")}\n`);
+    return 0;
+  }
+  console.error("Usage: install-plan.mjs status|record <node-deps|python-deps> | requirements");
+  return 2;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exit(main(process.argv.slice(2)));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/update.mjs
+++ b/src/update.mjs
@@ -162,20 +162,25 @@ export function rollbackCheckout() {
   return { rolledBack: true, from: current, to: target };
 }
 
+const COMMANDS = {
+  check: checkForUpdate,
+  update: updateCheckout,
+  rollback: rollbackCheckout,
+};
+
+// `check` must stay read-only: the tray and the CLI both use it to answer "is
+// an update available?" without touching the installation.
+export function resolveCommand(args) {
+  return COMMANDS[args[0] || "update"];
+}
+
 async function main() {
-  const command = process.argv[2] || "update";
-  const result = command === "check"
-    ? checkForUpdate()
-    : command === "update"
-      ? updateCheckout()
-      : command === "rollback"
-        ? rollbackCheckout()
-        : undefined;
-  if (!result) {
+  const command = resolveCommand(process.argv.slice(2));
+  if (!command) {
     console.error("Usage: update.mjs check|update|rollback");
     process.exit(2);
   }
-  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(command(), null, 2)}\n`);
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/test/install-plan.test.mjs
+++ b/test/install-plan.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  PYTHON_REQUIREMENTS,
+  installedDistributionVersion,
+  installerRequirementDrift,
+  recordStep,
+  requirementParts,
+  stepStatus,
+} from "../src/install-plan.mjs";
+
+function checkout() {
+  const root = mkdtempSync(path.join(tmpdir(), "install-plan-"));
+  writeFileSync(path.join(root, "package-lock.json"), '{"lockfileVersion":3}\n');
+  return root;
+}
+
+function installNodeModules(root) {
+  mkdirSync(path.join(root, "node_modules"), { recursive: true });
+  writeFileSync(path.join(root, "node_modules", ".package-lock.json"), "{}\n");
+}
+
+function installVenv(root, versions = { litellm: "1.95.0", fastapi: "0.139.2" }) {
+  const site = path.join(root, ".venv", "lib", "python3.12", "site-packages");
+  mkdirSync(site, { recursive: true });
+  mkdirSync(path.join(root, ".venv", "bin"), { recursive: true });
+  writeFileSync(path.join(root, ".venv", "bin", "python"), "");
+  writeFileSync(path.join(root, ".venv", "pyvenv.cfg"), "version_info = 3.12\n");
+  for (const [name, version] of Object.entries(versions)) {
+    mkdirSync(path.join(site, `${name}-${version}.dist-info`), { recursive: true });
+  }
+}
+
+test("a missing installation always runs its step", () => {
+  const root = checkout();
+  try {
+    assert.equal(stepStatus("node-deps", { root, platform: "darwin" }), "run");
+    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("recorded steps are skipped until their inputs change", () => {
+  const root = checkout();
+  try {
+    installNodeModules(root);
+    installVenv(root);
+    recordStep("node-deps", { root });
+    recordStep("python-deps", { root });
+
+    assert.equal(stepStatus("node-deps", { root, platform: "darwin" }), "skip");
+    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "skip");
+
+    writeFileSync(path.join(root, "package-lock.json"), '{"lockfileVersion":3,"x":1}\n');
+    assert.equal(stepStatus("node-deps", { root, platform: "darwin" }), "run");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a stamp cannot vouch for dependencies that are no longer installed", () => {
+  const root = checkout();
+  try {
+    installNodeModules(root);
+    installVenv(root);
+    recordStep("node-deps", { root });
+    recordStep("python-deps", { root });
+
+    // A drifted transitive upgrade that downgraded a pinned distribution must
+    // reinstall even though the stamp still matches the pins.
+    rmSync(path.join(root, ".venv", "lib", "python3.12", "site-packages", "litellm-1.95.0.dist-info"), {
+      recursive: true,
+      force: true,
+    });
+    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+
+    rmSync(path.join(root, "node_modules", ".package-lock.json"), { force: true });
+    assert.equal(stepStatus("node-deps", { root, platform: "darwin" }), "run");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a rebuilt virtual environment on another Python reinstalls", () => {
+  const root = checkout();
+  try {
+    installVenv(root);
+    recordStep("python-deps", { root });
+    writeFileSync(path.join(root, ".venv", "pyvenv.cfg"), "version = 3.13.1\n");
+    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("distribution lookup normalizes names and ignores extras", () => {
+  const root = checkout();
+  try {
+    installVenv(root, { litellm: "1.95.0", "litellm_proxy_extras": "0.4.81" });
+    assert.equal(requirementParts("litellm[proxy]==1.95.0").name, "litellm");
+    assert.equal(
+      installedDistributionVersion("litellm-proxy-extras", { root, platform: "darwin" }),
+      "0.4.81",
+    );
+    assert.equal(installedDistributionVersion("absent", { root, platform: "darwin" }), undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("both installers pin the same LiteLLM and FastAPI versions", () => {
+  assert.equal(PYTHON_REQUIREMENTS.length, 2);
+  assert.deepEqual(installerRequirementDrift(), []);
+});

--- a/test/update-target.test.mjs
+++ b/test/update-target.test.mjs
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  checkForUpdate,
   currentCheckoutInstaller,
   installationNeedsRefresh,
+  resolveCommand,
 } from "../src/update.mjs";
 
 test("checkout updates preserve the codex target on every platform", () => {
@@ -14,6 +16,13 @@ test("checkout updates preserve the codex target on every platform", () => {
   const posixCodex = currentCheckoutInstaller("darwin", "codex");
   assert.match(posixCodex.command, /bin[\\/]install$/);
   assert.deepEqual(posixCodex.args, []);
+});
+
+test("a bare invocation updates and an explicit check stays read-only", () => {
+  assert.equal(resolveCommand([]), resolveCommand(["update"]));
+  assert.equal(resolveCommand(["check"]), checkForUpdate);
+  assert.notEqual(resolveCommand(["check"]), resolveCommand(["update"]));
+  assert.equal(resolveCommand(["nonsense"]), undefined);
 });
 
 test("an update reinstalls a revision pulled outside the updater", () => {


### PR DESCRIPTION
## Why

`Update & Verify` (tray) and `bin/update` both run `src/update.mjs update`, which re-runs the **entire** installer no matter how small the change. A commit touching one `.mjs` file still wiped `node_modules` for a fresh `npm ci` and re-resolved the whole `litellm[proxy]` tree against PyPI. The pins are exact but their transitive dependencies are not, so every update churned the virtual environment — one run here replaced 7 packages (litellm 1.93→1.95, litellm-enterprise, proxy-extras, +inquirerpy/prompt-toolkit). On a cold uv cache or a slow link that step dominates the run.

Measured warm on macOS: doctor 0.6s, `git fetch` 0.3s, catalog 0.4s. The dependency step is the one that explodes; the residual ~7s is the launchd restart plus LiteLLM's cold start, which is inherent — the service runs code straight from the checkout, so new code means a restart.

## What changed

- **`src/install-plan.mjs`** (new) fingerprints each dependency step: `package-lock.json` + Node major for npm, the pinned requirement set + venv Python version for LiteLLM. It also verifies the pinned distributions are genuinely installed before trusting a stamp, so a drifted or partially removed environment reinstalls. Stamps live inside `node_modules/` and `.venv/`, so deleting either invalidates them automatically. The status probe **fails open** — any error runs the step.
- **`bin/install` / `install.ps1`** gate `npm ci` and the Python install on that status, with `--force-deps` / `-ForceDeps` to override.
- **`doctor --fix`** passes the force flag: a fingerprint cannot see a corrupted tree, so repair still rebuilds everything.
- The LiteLLM/FastAPI pins now have **one source of truth** in `install-plan.mjs`; a test fails if either installer's literal drifts.
- **`bin/update` bug fix**: the wrapper hardcoded the `update` subcommand, so `bin/update check` performed a full reinstall instead of the read-only revision comparison it advertises. `bin/update` and `codex-router.ps1 update` now forward the subcommand; a bare invocation still updates.

## Verification

- `npm run check` and `npm test` — 252 pass, 0 fail, 2 pre-existing skips.
- CI's shell check locally: `sh -n` over `install.sh bin/* scripts/build-desktop-tray.sh` clean. The PowerShell parse check runs on the Windows CI leg (no `pwsh` on the dev machine).
- Real installer, repeat run: both steps report `skip`, no npm or PyPI traffic; `bin/install --force-deps` still rebuilds.
- `bin/doctor` after the change: 45 checks, 0 failures, service healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)