### PR TITLE
fix(doctor): repair foreign checkout state through the recorded owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **`doctor --fix` no longer breaks a running install from a second checkout.**
+  When the recorded state owner still exists, repair now runs from that
+  checkout and keeps ownership there. Deliberate ownership transfer still
+  requires an explicit override or a fresh install.
+
 - **The macOS tray stays linked to the apps that launch it.** If the tray
   bundle moves (for example from a checkout on a removable volume to the
   stable install), the next launch re-registers the login item against the

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -21,6 +21,35 @@ If a recognized older Kimi router is reported:
 
 Neither command prints credential values. Repair refuses unknown router owners.
 
+## State directory belongs to another checkout
+
+If `doctor` reports a state ownership failure, you are running from a clone
+that did not perform the install. The safe fix is to repair through the
+checkout that owns the installed state:
+
+```sh
+./bin/model-router codex doctor --fix
+```
+
+When the recorded owner still exists, this command runs the repair there and
+keeps the installed checkout unchanged. It deliberately transfers ownership to
+the current checkout only when the recorded owner is gone or you set
+`MODEL_ROUTER_ALLOW_FOREIGN_STATE=1`.
+
+To inspect the recorded owner:
+
+```sh
+# Find the owning checkout from the state manifest.
+STATE_DIR="${MODEL_ROUTER_STATE_DIR:-${CODEX_ROUTER_STATE_DIR:-${KIMI_CODEX_STATE_DIR:-${HOME}/.codex/codex-router}}}"
+cat "$STATE_DIR/install-manifest.json" | sed -n '1,80p'
+```
+
+To deliberately switch ownership to the checkout you are running from:
+
+```sh
+MODEL_ROUTER_ALLOW_FOREIGN_STATE=1 ./bin/model-router codex doctor --fix
+```
+
 ## External models are missing from the picker
 
 ```sh

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -52,6 +52,33 @@ function childJson(script, args = []) {
 }
 
 function repair() {
+  const ownership = stateOwnershipStatus();
+  if (
+    ownership.foreign &&
+    !ownership.overridden &&
+    ownership.owner &&
+    existsSync(path.join(ownership.owner, "src", "doctor.mjs")) &&
+    existsSync(path.join(ownership.owner, "bin", "install"))
+  ) {
+    // A foreign doctor run must not repoint the live installation by accident.
+    // The recorded owner still exists, so run the same repair from there; only
+    // an explicit override or a fresh install transfers ownership.
+    process.stderr.write(
+      `codex-router: repairing from the owning checkout ${ownership.owner}\n`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [path.join(ownership.owner, "src", "doctor.mjs"), ...process.argv.slice(2)],
+      { cwd: ownership.owner, env: process.env, stdio: "inherit" },
+    );
+    if (result.error) {
+      throw new Error(
+        `Could not run doctor from the owning checkout ${ownership.owner}: ${result.error.message}`,
+      );
+    }
+    process.exit(result.status ?? 1);
+  }
+
   const legacy = detectLegacyInstallations();
   if (legacy.unknownConflict) {
     throw new Error(

--- a/src/state-owner.mjs
+++ b/src/state-owner.mjs
@@ -45,9 +45,11 @@ export function stateOwnershipMessage(operation, status) {
     `Refusing to ${operation}: ${status.stateDir} is owned by another checkout.`,
     `  owner:   ${status.owner}`,
     `  current: ${status.current}`,
-    "Run this command from the owning checkout. Writing generated state from a",
-    "second checkout makes Codex advertise models the running gateway cannot",
-    `route. To deliberately take ownership, reinstall from here, or set ${OVERRIDE_ENV}=1.`,
+    "Writing generated state from a second checkout makes Codex advertise",
+    "models the running gateway cannot route. Run `./bin/model-router codex",
+    "doctor --fix` from this checkout; when the recorded owner is available,",
+    "repair runs there without changing ownership. To deliberately transfer",
+    `ownership to this checkout, reinstall from here or set ${OVERRIDE_ENV}=1.`,
   ].join("\n");
 }
 

--- a/test/state-owner.test.mjs
+++ b/test/state-owner.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -155,4 +155,35 @@ test("the installer is allowed to take ownership", () => {
     });
     assert.doesNotMatch(result.stderr || "", /owned by another checkout/);
   });
+});
+
+test("doctor --fix from a foreign checkout delegates to the recorded owner", () => {
+  const owner = mkdtempSync(path.join(os.tmpdir(), "state-owner-checkout-"));
+  const marker = path.join(owner, "delegated-doctor-ran");
+  mkdirSync(path.join(owner, "bin"), { recursive: true });
+  mkdirSync(path.join(owner, "src"), { recursive: true });
+  writeFileSync(path.join(owner, "bin", "install"), "#!/bin/sh\n");
+  writeFileSync(
+    path.join(owner, "src", "doctor.mjs"),
+    `import { writeFileSync } from "node:fs";\n` +
+      `writeFileSync(${JSON.stringify(marker)}, "ok");\n`,
+  );
+  try {
+    withState({ owner }, (stateDir) => {
+      const result = spawnSync(
+        process.execPath,
+        [path.join(root, "src", "doctor.mjs"), "--fix"],
+        {
+          cwd: root,
+          encoding: "utf8",
+          env: { ...process.env, MODEL_ROUTER_STATE_DIR: stateDir },
+        },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(existsSync(marker), true);
+      assert.match(result.stderr, /repairing from the owning checkout/);
+    });
+  } finally {
+    rmSync(owner, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Problem

Running doctor from a second checkout reports a foreign state owner. The current guidance told users to reinstall from that checkout, which would repoint the live installation even when the recorded owner still exists and is healthy.

## Change

When `doctor --fix` runs from a foreign checkout and the recorded owner still exists, it now delegates the repair to that owner and exits with its result. Ownership stays with the installed checkout unless the owner is gone or the user explicitly overrides ownership transfer.

## Verification

- `npm run check` passes.
- `node --test test/state-owner.test.mjs` passes, including a new test for delegated repair.
- Live repair from this checkout through the recorded owner completed with all core doctor checks OK.