### PR TITLE
fix(update): refresh tray bundles installed outside the checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Codex updates now refresh the tray for every supported install location.**
+  Guided setup installs the companion at `~/Applications/Model Router.app`,
+  but updates only refreshed the tray when the checkout's own `dist/Model
+  Router.app` existed. The update path now also detects the home-Applications
+  bundle and the registered login-item bundle, then rebuilds and relaunches
+  the tray from the updated checkout.
+
 - **The macOS tray stays linked to the apps that launch it.** If the tray
   bundle moves (for example from a checkout on a removable volume to the
   stable install), the next launch re-registers the login item against the

--- a/docs/MACOS-TRAY.md
+++ b/docs/MACOS-TRAY.md
@@ -144,8 +144,9 @@ repository.
 
 `bin/model-router-tray` replaces an already-running tray with the rebuilt
 bundle before opening it, and `codex update` rebuilds and relaunches an
-installed tray from the updated checkout, so the companion stays current
-without a manual rerun.
+installed tray from the updated checkout whether it lives in the checkout's
+`dist` directory, `~/Applications`, or the registered login-item bundle, so
+the companion stays current without a manual rerun.
 
 Provider changes apply automatically. Enabling, disabling, signing in, or
 adding an API key updates Codex immediately; the provider row shows progress

--- a/src/update.mjs
+++ b/src/update.mjs
@@ -90,16 +90,17 @@ export function trayRefreshRequired({
   platform = process.platform,
   home = os.homedir(),
   sourceRoot = SOURCE_ROOT,
-  registeredPath = registeredTrayBundlePath(),
+  registeredPath,
 } = {}) {
   if (platform !== "darwin") return false;
+  const registered = registeredPath ?? registeredTrayBundlePath();
   const candidates = [
     path.join(sourceRoot, "dist", "Model Router.app"),
     path.join(home, "Applications", "Model Router.app"),
   ];
   return (
     candidates.some((candidate) => existsSync(candidate)) ||
-    Boolean(registeredPath && existsSync(registeredPath))
+    Boolean(registered && existsSync(registered))
   );
 }
 
@@ -108,15 +109,6 @@ export function trayRefreshRequired({
 // update itself succeeded, and a failed tray refresh must not roll it back.
 function refreshTrayCompanion() {
   if (!trayRefreshRequired()) return;
-  const trayBinary = path.join(
-    SOURCE_ROOT,
-    "dist",
-    "Model Router.app",
-    "Contents",
-    "MacOS",
-    "ModelRouterTray",
-  );
-  if (!existsSync(trayBinary)) return;
   const launcher = path.join(SOURCE_ROOT, "bin", "model-router-tray");
   const result = spawnSync(launcher, [], { cwd: SOURCE_ROOT, stdio: "inherit" });
   if (result.error) {

--- a/src/update.mjs
+++ b/src/update.mjs
@@ -1,5 +1,6 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -68,11 +69,45 @@ function installCurrentCheckout() {
   }
 }
 
+function registeredTrayBundlePath() {
+  try {
+    const value = execFileSync(
+      "defaults",
+      [
+        "read",
+        "io.github.codex-router.tray",
+        "ModelRouterTray.loginItemBundlePath",
+      ],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+    ).trim();
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function trayRefreshRequired({
+  platform = process.platform,
+  home = os.homedir(),
+  sourceRoot = SOURCE_ROOT,
+  registeredPath = registeredTrayBundlePath(),
+} = {}) {
+  if (platform !== "darwin") return false;
+  const candidates = [
+    path.join(sourceRoot, "dist", "Model Router.app"),
+    path.join(home, "Applications", "Model Router.app"),
+  ];
+  return (
+    candidates.some((candidate) => existsSync(candidate)) ||
+    Boolean(registeredPath && existsSync(registeredPath))
+  );
+}
+
 // The tray is rebuilt from the same checkout that owns the router, so an
 // update never leaves a stale companion binary behind. Best-effort: the router
 // update itself succeeded, and a failed tray refresh must not roll it back.
 function refreshTrayCompanion() {
-  if (process.platform !== "darwin") return;
+  if (!trayRefreshRequired()) return;
   const trayBinary = path.join(
     SOURCE_ROOT,
     "dist",

--- a/test/update-target.test.mjs
+++ b/test/update-target.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -6,6 +9,7 @@ import {
   currentCheckoutInstaller,
   installationNeedsRefresh,
   resolveCommand,
+  trayRefreshRequired,
 } from "../src/update.mjs";
 
 test("checkout updates preserve the codex target on every platform", () => {
@@ -33,6 +37,92 @@ test("an update reinstalls a revision pulled outside the updater", () => {
   );
   assert.equal(
     installationNeedsRefresh({ current: { commit: "new-revision" } }, "new-revision"),
+    false,
+  );
+});
+
+test("tray refresh is required when the checkout dist bundle exists", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tray-refresh-dist-"));
+  try {
+    mkdirSync(path.join(root, "dist", "Model Router.app"), { recursive: true });
+    assert.equal(
+      trayRefreshRequired({
+        platform: "darwin",
+        home: path.join(root, "home"),
+        sourceRoot: root,
+        registeredPath: "",
+      }),
+      true,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("tray refresh is required when setup installed the home app bundle", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tray-refresh-home-"));
+  try {
+    mkdirSync(path.join(root, "home", "Applications", "Model Router.app"), {
+      recursive: true,
+    });
+    assert.equal(
+      trayRefreshRequired({
+        platform: "darwin",
+        home: path.join(root, "home"),
+        sourceRoot: path.join(root, "router"),
+        registeredPath: "",
+      }),
+      true,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("tray refresh is required when only a registered bundle path exists", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tray-refresh-registered-"));
+  try {
+    const registered = path.join(root, "Model Router.app");
+    mkdirSync(registered, { recursive: true });
+    assert.equal(
+      trayRefreshRequired({
+        platform: "darwin",
+        home: path.join(root, "home"),
+        sourceRoot: path.join(root, "router"),
+        registeredPath: registered,
+      }),
+      true,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("tray refresh is skipped when no tray bundle exists", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "tray-refresh-none-"));
+  try {
+    assert.equal(
+      trayRefreshRequired({
+        platform: "darwin",
+        home: path.join(root, "home"),
+        sourceRoot: path.join(root, "router"),
+        registeredPath: "",
+      }),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("tray refresh is skipped on non-macOS platforms", () => {
+  assert.equal(
+    trayRefreshRequired({
+      platform: "linux",
+      home: os.homedir(),
+      sourceRoot: path.resolve("."),
+      registeredPath: path.resolve("."),
+    }),
     false,
   );
 });


### PR DESCRIPTION
## Problem

Guided setup installs the macOS tray at `~/Applications/Model Router.app`, but `codex update` only refreshed the tray when `dist/Model Router.app` existed in the owning checkout. Users who installed through setup could update the router while the running tray kept executing the old binary.

## Change

The update path now detects three tray install locations before refreshing:

- `<checkout>/dist/Model Router.app`
- `~/Applications/Model Router.app`
- the bundle path recorded in `ModelRouterTray.loginItemBundlePath`

When any exists, update rebuilds the tray from the updated owning checkout and relaunches it, matching the behavior already documented for `codex update`.

## Verification

- `npm run check` passes.
- `node --test test/update-target.test.mjs` passes with 8/8 tests, including new coverage for all three install locations and the no-tray case.