### PR TITLE
fix(win): force UTF-8 output for the LiteLLM gateway

### DIFF
--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -47,6 +47,12 @@ function wrapper() {
     CODEX_ROUTER_OAUTH_PORT: String(PORTS.oauth),
     CODEX_ROUTER_PORT: String(PORTS.router),
     CODEX_ROUTER_API_PORT: String(PORTS.api),
+    // The LiteLLM gateway is a Python process. Force UTF-8 output so its
+    // startup banner and logs do not crash on Windows systems whose default
+    // ANSI/OEM code page is not UTF-8 (e.g. Russian cp1251), where Python
+    // would otherwise encode stdout as the legacy code page.
+    PYTHONIOENCODING: "utf-8",
+    PYTHONUTF8: "1",
     ...(process.env.KIMI_CODE_HOME ? { KIMI_CODE_HOME: process.env.KIMI_CODE_HOME } : {}),
   };
   return `@echo off\r\n${Object.entries(variables)

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -41,6 +41,10 @@ test("background service definitions render for macOS, Linux, and Windows", () =
     assert.match(windows, /@echo off\r?\n/);
     assert.match(windows, /set "CODEX_ROUTER_STATE_DIR=/);
     assert.match(windows, /litellm|start\.mjs/);
+    // The Python gateway must run with UTF-8 output even when the host
+    // console code page is not UTF-8 (see service-windows.mjs).
+    assert.match(windows, /set "PYTHONIOENCODING=utf-8"/);
+    assert.match(windows, /set "PYTHONUTF8=1"/);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem

On Windows systems whose console code page is not UTF-8 (e.g. Russian `cp1251`), the router background service fails to start:

```
File "...\encodings\cp1251.py", line 19, in encode
UnicodeEncodeError: 'charmap' codec can't encode characters in position 5-7
ERROR:    Application startup failed. Exiting.
[model-router] startup failed: LiteLLM gateway exited before becoming healthy.
```

The LiteLLM gateway is a Python process; Python on Windows defaults `stdout` to the legacy ANSI/OEM code page, and printing the startup banner (which contains non-Latin-1 characters) raises `UnicodeEncodeError`. On macOS/Linux Python defaults to UTF-8, so this path is never exercised there.

## Fix

The Windows service wrapper (`src/service-windows.mjs`) now sets `PYTHONIOENCODING=utf-8` and `PYTHONUTF8=1` for the spawned gateway.

## Verification

- Extended `test/service-render.test.mjs` to assert both variables appear in the rendered Windows wrapper.
- Reproduced the original crash on a Russian-locale Windows 10 machine (`cp1251`), then confirmed the service starts and reports healthy after the fix.

## Notes

- Applied locally via the router's own `protectPrivateFile` (config ACL unchanged).
- No behavior change on POSIX or on UTF-8 Windows consoles.
