### PR TITLE
fix(win): recover from detached HEAD instead of crashing

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -72,8 +72,25 @@ if (-not $CheckoutInstall) {
       if ($LASTEXITCODE -ne 0 -or $Dirty) {
         throw "$InstallDir has local changes; automatic update will not overwrite them."
       }
-      $Branch = (& git -C $InstallDir branch --show-current).Trim()
-      if ($Branch -ne "main") { throw "$InstallDir must be on its main branch to update." }
+      # A failed setup rolls the checkout back to a detached HEAD (see the
+      # rollback below), where `branch --show-current` prints nothing. A native
+      # command with no output yields $null, and in Windows PowerShell 5.1
+      # [string]$null stays $null, so guard explicitly before calling Trim().
+      $Branch = & git -C $InstallDir branch --show-current
+      if ($null -eq $Branch) { $Branch = "" }
+      $Branch = [string]$Branch.Trim()
+      if ($Branch -ne "main") {
+        if (-not $Branch) {
+          & git -C $InstallDir switch main 2>$null
+          if ($LASTEXITCODE -ne 0) {
+            throw "$InstallDir is in a detached HEAD state and could not be restored to main; run 'git switch main' there and retry."
+          }
+          $Branch = & git -C $InstallDir branch --show-current
+          if ($null -eq $Branch) { $Branch = "" }
+          $Branch = [string]$Branch.Trim()
+        }
+        if ($Branch -ne "main") { throw "$InstallDir must be on its main branch to update." }
+      }
       $PreviousRevision = (& git -C $InstallDir rev-parse HEAD).Trim()
       & git -C $InstallDir update-ref refs/codex-router/rollback $PreviousRevision
       & git -C $InstallDir pull --ff-only origin main


### PR DESCRIPTION
## Problem

When setup fails, `install.ps1` rolls the checkout back with `git switch --detach <rev>`. On the next run, the update path executes:

```powershell
$Branch = (& git -C $InstallDir branch --show-current).Trim()
```

In a detached HEAD, `git branch --show-current` prints nothing. A native command with no output yields `$null`, and **in Windows PowerShell 5.1 `[string]$null` stays `$null`** (unlike PowerShell 7), so `.Trim()` throws `InvokeMethodOnNull`. The installer crashes on every retry after a failed setup, with no actionable message:

```
cr-install.ps1 : Вызов метода невозможен, так как объект NULL. (method invocation failed because object is NULL)
```

## Fix

`install.ps1` now guards the value explicitly (`if ($null -eq $Branch) { $Branch = "" }`) and, when the checkout is detached, **automatically reattaches to `main`** before updating — a retry after a failed setup succeeds instead of crashing. A clear error is thrown only if reattaching fails.

## Verification

- Reproduced the crash on Windows PowerShell 5.1 with a detached scratch checkout.
- After the fix, the same scenario recovers to `main` (`before: []`, `after: [main]`), no exception.
- `install.ps1` parses cleanly under `System.Management.Automation.Language.Parser`.
