### PR TITLE
feat(win): discover the Codex Desktop App bundled CLI

### DIFF
--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -1,7 +1,28 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+// The ChatGPT/Codex desktop app bundles its CLI under a version-hashed
+// directory, e.g. %LOCALAPPDATA%\OpenAI\Codex\bin\<hash>\codex.exe. That hash
+// changes on every app update, so scan for the newest installed version
+// instead of pinning a single path.
+function desktopAppBundledCodex() {
+  if (process.platform !== "win32") return undefined;
+  const localAppData = process.env.LOCALAPPDATA;
+  if (!localAppData) return undefined;
+  const binDir = path.join(localAppData, "OpenAI", "Codex", "bin");
+  if (!existsSync(binDir)) return undefined;
+  try {
+    return readdirSync(binDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(binDir, entry.name, "codex.exe"))
+      .filter((candidate) => existsSync(candidate))
+      .sort((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)[0];
+  } catch {
+    return undefined;
+  }
+}
 
 function candidates() {
   const localAppData = process.env.LOCALAPPDATA;
@@ -19,6 +40,7 @@ function candidates() {
     localAppData && path.join(localAppData, "Programs", "OpenAI", "Codex", "bin", "codex.exe"),
     localAppData && path.join(localAppData, "Programs", "Codex", "resources", "codex.exe"),
     localAppData && path.join(localAppData, "Programs", "Codex", "resources", "app", "bin", "codex.exe"),
+    desktopAppBundledCodex(),
     path.join(os.homedir(), ".local", "bin", process.platform === "win32" ? "codex.exe" : "codex"),
   ].filter(Boolean);
 }

--- a/test/codex-binary.test.mjs
+++ b/test/codex-binary.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
-import { codexSpawnTarget, preferSpawnablePath } from "../src/codex-binary.mjs";
+import { codexSpawnTarget, findCodexBinary, preferSpawnablePath } from "../src/codex-binary.mjs";
 
 // Reported in #46: `where.exe codex` on an npm global install lists the
 // extensionless POSIX shim before the batch shim. Node cannot spawn the former
@@ -69,3 +72,39 @@ test("a POSIX binary never gets a shell, even if it ends in .cmd", () => {
   assert.equal(codexSpawnTarget("/opt/homebrew/bin/codex", "darwin").options.shell, undefined);
   assert.equal(codexSpawnTarget("/weird/path/codex.cmd", "darwin").options.shell, undefined);
 });
+
+test(
+  "finds the newest Codex Desktop App bundled CLI on Windows",
+  { skip: process.platform !== "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-desktop-cli-"));
+    const binDir = path.join(testRoot, "OpenAI", "Codex", "bin");
+    const oldVersion = path.join(binDir, "aaa111", "codex.exe");
+    const newVersion = path.join(binDir, "bbb222", "codex.exe");
+    mkdirSync(path.dirname(oldVersion), { recursive: true });
+    mkdirSync(path.dirname(newVersion), { recursive: true });
+    writeFileSync(oldVersion, "");
+    writeFileSync(newVersion, "");
+    const past = new Date(Date.now() - 60_000);
+    utimesSync(oldVersion, past, past);
+    utimesSync(newVersion, new Date(), new Date());
+
+    const saved = {
+      CODEX_BIN: process.env.CODEX_BIN,
+      CODEX_INSTALL_DIR: process.env.CODEX_INSTALL_DIR,
+      LOCALAPPDATA: process.env.LOCALAPPDATA,
+    };
+    try {
+      delete process.env.CODEX_BIN;
+      delete process.env.CODEX_INSTALL_DIR;
+      process.env.LOCALAPPDATA = testRoot;
+      assert.equal(findCodexBinary(), newVersion);
+    } finally {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
## Problem

The ChatGPT/Codex **desktop app** on Windows bundles its CLI under a version-hashed directory:

```
%LOCALAPPDATA%\OpenAI\Codex\bin\<hash>\codex.exe
```

The hash changes on every app update. `codex-binary.mjs` only knows the standalone-install locations (`...\Programs\OpenAI\Codex\bin\codex.exe`, etc.), so desktop-app users who never install the standalone CLI get:

```
Error: The Codex binary was not found. Install Codex or set CODEX_BIN to its CLI binary.
```

…and the router setup aborts during native-catalog generation.

## Fix

`codex-binary.mjs` now scans `%LOCALAPPDATA%\OpenAI\Codex\bin\*\codex.exe` on Windows and prefers the **newest installed version** (by mtime), keeping the existing candidate order intact.

## Verification

- New test in `test/codex-binary.test.mjs` (Windows-only): creates two fake version dirs with different mtimes and asserts `findCodexBinary()` returns the newer one.
- Live check on a machine with the desktop app installed: `findCodexBinary()` now finds `C:\Users\<user>\AppData\Local\OpenAI\Codex\bin\d7e8094cfb76a267\codex.exe` with `CODEX_BIN` unset.
