### PR TITLE
fix(win): repair the hidden API-key prompt on Windows

### DIFF
--- a/src/provider-key.mjs
+++ b/src/provider-key.mjs
@@ -25,14 +25,19 @@ if (!providerId || !new Set(["status", "set", "remove"]).has(command)) {
 
 const provider = apiProvider(providerId);
 
+// The try/finally pair must live in a single array element: joining elements
+// with "; " would otherwise produce "}; finally", which PowerShell rejects
+// with "MissingCatchOrFinally" — silently breaking every hidden key prompt
+// on Windows (the POSIX path reads /dev/tty directly and never hits this).
+export const WINDOWS_HIDDEN_PROMPT_SCRIPT = [
+  "$secret = Read-Host $env:CODEX_ROUTER_PROMPT_LABEL -AsSecureString",
+  "$pointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secret)",
+  "try { [Console]::Out.Write([Runtime.InteropServices.Marshal]::PtrToStringBSTR($pointer)) } finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($pointer) }",
+].join("; ");
+
 function hiddenPrompt(label) {
   if (process.platform === "win32") {
-    const script = [
-      "$secret = Read-Host $env:CODEX_ROUTER_PROMPT_LABEL -AsSecureString",
-      "$pointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secret)",
-      "try { [Console]::Out.Write([Runtime.InteropServices.Marshal]::PtrToStringBSTR($pointer)) }",
-      "finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($pointer) }",
-    ].join("; ");
+    const script = WINDOWS_HIDDEN_PROMPT_SCRIPT;
     let lastError;
     for (const executable of ["powershell.exe", "pwsh.exe"]) {
       try {

--- a/test/provider-key.test.mjs
+++ b/test/provider-key.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+// provider-key.mjs is a CLI entry that validates process.argv at module
+// evaluation time (and exits when the arguments are missing), so give it a
+// valid invocation before importing it.
+const savedArgv = [...process.argv];
+process.argv = [process.argv[0], "provider-key.mjs", "opencode-go", "status"];
+const { WINDOWS_HIDDEN_PROMPT_SCRIPT } = await import("../src/provider-key.mjs");
+process.argv = savedArgv;
+
+test("the Windows hidden-prompt script is structurally valid PowerShell", () => {
+  // Joining the script pieces with "; " must not split `try { }` from
+  // `finally { }`: PowerShell rejects "}; finally" with
+  // MissingCatchOrFinally, which made every hidden key prompt fail on
+  // Windows before the prompt was even shown.
+  assert.doesNotMatch(WINDOWS_HIDDEN_PROMPT_SCRIPT, /}\s*;\s*finally/i);
+  assert.match(WINDOWS_HIDDEN_PROMPT_SCRIPT, /}\s*finally\s*{/i);
+  assert.match(WINDOWS_HIDDEN_PROMPT_SCRIPT, /-AsSecureString/);
+
+  const opens = (WINDOWS_HIDDEN_PROMPT_SCRIPT.match(/\{/g) || []).length;
+  const closes = (WINDOWS_HIDDEN_PROMPT_SCRIPT.match(/\}/g) || []).length;
+  assert.equal(opens, closes);
+});
+
+test(
+  "the Windows hidden-prompt script parses under powershell.exe",
+  { skip: process.platform !== "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-prompt-"));
+    const scriptPath = path.join(testRoot, "hidden-prompt.ps1");
+    try {
+      writeFileSync(scriptPath, WINDOWS_HIDDEN_PROMPT_SCRIPT, "utf8");
+      const escaped = scriptPath.replaceAll("'", "''");
+      const check = [
+        "$tokens = $null; $errors = $null",
+        `[System.Management.Automation.Language.Parser]::ParseFile('${escaped}', [ref]$tokens, [ref]$errors) | Out-Null`,
+        "if ($errors.Count) { $errors | ForEach-Object { $_.Message }; exit 1 }",
+      ].join("; ");
+      execFileSync("powershell.exe", ["-NoLogo", "-NoProfile", "-Command", check], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "inherit"],
+      });
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
## Problem

`provider-key PROVIDER set` is completely broken on Windows: every hidden key prompt fails before it is even shown.

```powershell
$secret = Read-Host ... -AsSecureString; ...; try { ... }; finally { ... }
#                                                          ^
#                          ParserError: MissingCatchOrFinally
```

The PowerShell statements were joined with `"; "`, which split the `try`/`finally` pair into `}; finally`. PowerShell requires `finally` to follow the `try` block immediately, so the child `powershell.exe` exits with a parser error; the fallback `pwsh.exe` then fails with `ENOENT` on systems without PowerShell 7. The POSIX path reads `/dev/tty` directly and never exercises this code, which is why it went unnoticed.

## Fix

The `try`/`finally` pair now lives in a **single** array element (exported as `WINDOWS_HIDDEN_PROMPT_SCRIPT`), so the joined script is valid PowerShell:

```
try { ... } finally { ... }
```

## Verification

- New `test/provider-key.test.mjs`:
  - cross-platform structural test (no `}; finally`, balanced braces),
  - Windows-only test that parses the script with `System.Management.Automation.Language.Parser` under the real `powershell.exe`.
- Live on Windows PowerShell 5.1: the script parses, the prompt appears, and hidden input is captured (masked) as expected.
