### PR TITLE
Fix standalone web search routing

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,8 @@ intentional exception: the router reuses the official Kimi CLI session under
 
 Codex Router handles four credential classes and keeps them on distinct paths:
 
-- ChatGPT/Codex authentication is allow-listed only for native GPT requests.
+- ChatGPT/Codex authentication is allow-listed only for native GPT, image, and
+  standalone web-search requests.
 - Kimi Code OAuth is read from the official Kimi CLI directory and sent only to
   the Kimi Code managed endpoint.
 - Kimi Platform API keys are sent only to the configured Kimi Platform endpoint.

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -133,7 +133,7 @@ and never grants CORS access.
 
 | Route | Incoming Codex credential | Upstream credential |
 | --- | --- | --- |
-| Native GPT | Allow-listed and forwarded | Existing ChatGPT/Codex authentication |
+| Native GPT, image generation, and web search | Allow-listed and forwarded | Existing ChatGPT/Codex authentication |
 | Kimi OAuth | Discarded | Kimi CLI OAuth bearer from `~/.kimi-code` |
 | Kimi API | Discarded | Kimi Platform API key |
 | DeepSeek | Discarded | DeepSeek API key |

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -85,6 +85,7 @@ const NATIVE_IMAGE_PATHS = new Set([
   "/v1/images/edits",
   "/v1/images/generations",
 ]);
+const NATIVE_SEARCH_PATHS = new Set(["/alpha/search", "/v1/alpha/search"]);
 const AGENT_PAYLOAD_RELAY_TOOL = "relay_external_agent_payload";
 const AGENT_PAYLOAD_CACHE_TTL_MS = 15 * 60 * 1_000;
 const AGENT_PAYLOAD_CACHE_MAX_BYTES = 8 * 1024 * 1024;
@@ -984,7 +985,7 @@ async function handleResponses(request, response, requestUrl) {
   }
 }
 
-async function handleNativeImage(request, response, requestUrl) {
+async function handleNativeRequest(request, response, requestUrl, defaultModel) {
   const startedAt = Date.now();
   const activity = beginRequestActivity();
   let clientGone = false;
@@ -993,8 +994,7 @@ async function handleNativeImage(request, response, requestUrl) {
     const encoded = await readRequestBody(request);
     const body = decodeBody(encoded, request.headers["content-encoding"]);
     const payload = parseBody(body);
-    const requestedModel =
-      typeof payload.model === "string" ? payload.model : "gpt-image-2";
+    const requestedModel = typeof payload.model === "string" ? payload.model : defaultModel;
     activity.setRoute({
       provider: "openai",
       model: requestedModel,
@@ -1101,7 +1101,11 @@ async function handleRequest(request, response) {
     return;
   }
   if (request.method === "POST" && NATIVE_IMAGE_PATHS.has(requestUrl.pathname)) {
-    await handleNativeImage(request, response, requestUrl);
+    await handleNativeRequest(request, response, requestUrl, "gpt-image-2");
+    return;
+  }
+  if (request.method === "POST" && NATIVE_SEARCH_PATHS.has(requestUrl.pathname)) {
+    await handleNativeRequest(request, response, requestUrl, "web-search");
     return;
   }
   writeJson(response, 404, {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -880,6 +880,82 @@ test("router sends standalone image requests only to the native OpenAI backend",
   }
 });
 
+test("router sends standalone web search only to the native OpenAI backend", async () => {
+  const nativeRequests = [];
+  const native = await mockServer(async (request, response) => {
+    nativeRequests.push({
+      url: request.url,
+      headers: request.headers,
+      body: await bodyJson(request),
+    });
+    json(response, 200, {
+      output: "search result",
+      results: [{ type: "text_result", ref_id: "turn0search0" }],
+    });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const headers = {
+    Authorization: "Bearer CODEX_CALLER_SECRET",
+    "ChatGPT-Account-Id": "account-secret",
+    "X-Codex-Installation-Id": "installation-secret",
+    "X-Codex-Turn-Metadata": "turn-metadata",
+    "X-Private-Header": "must-not-forward",
+    "Content-Type": "application/json",
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const searchBody = zstdCompressSync(
+      Buffer.from(
+        JSON.stringify({
+          id: "search-session",
+          model: "gpt-5.6-sol",
+          commands: { search_query: [{ q: "OpenAI news" }] },
+          settings: { external_web_access: true },
+        }),
+      ),
+    );
+    const search = await fetch(`${routerBase(routerPort)}/alpha/search?source=codex`, {
+      method: "POST",
+      headers: { ...headers, "Content-Encoding": "zstd" },
+      body: searchBody,
+    });
+    const searchPayload = await search.json();
+    assert.equal(search.status, 200, JSON.stringify(searchPayload));
+    assert.deepEqual(searchPayload, {
+      output: "search result",
+      results: [{ type: "text_result", ref_id: "turn0search0" }],
+    });
+
+    assert.equal(nativeRequests.length, 1);
+    assert.equal(nativeRequests[0].url, "/backend-api/codex/alpha/search?source=codex");
+    assert.equal(nativeRequests[0].headers.authorization, "Bearer CODEX_CALLER_SECRET");
+    assert.equal(nativeRequests[0].headers["chatgpt-account-id"], "account-secret");
+    assert.equal(nativeRequests[0].headers["x-codex-installation-id"], "installation-secret");
+    assert.equal(nativeRequests[0].headers["x-codex-turn-metadata"], "turn-metadata");
+    assert.equal(nativeRequests[0].headers["x-private-header"], undefined);
+    assert.equal(nativeRequests[0].headers["content-encoding"], undefined);
+    assert.equal(nativeRequests[0].body.model, "gpt-5.6-sol");
+    assert.deepEqual(nativeRequests[0].body.commands.search_query, [{ q: "OpenAI news" }]);
+
+    const unsupported = await fetch(`${routerBase(routerPort)}/alpha/embeddings`, {
+      method: "POST",
+      headers,
+      body: "{}",
+    });
+    assert.equal(unsupported.status, 404);
+    assert.equal(nativeRequests.length, 1);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+  }
+});
+
 test("router synthesizes routed compaction and safely replays it to native models", async () => {
   const gatewayRequests = [];
   const gateway = await mockServer(async (request, response) => {


### PR DESCRIPTION
## Summary

- allow-list Codex's standalone `alpha/search` endpoint and forward it only to the native OpenAI backend
- reuse the existing guarded native request path for authentication, JSON validation, decompression, header filtering, cancellation, and response streaming
- add a regression test covering compressed search requests, query forwarding, credential boundaries, private-header removal, and fail-closed behavior for unrelated `alpha/*` routes
- document the native web-search credential boundary

## Root cause

Codex Router points the built-in OpenAI provider at its loopback `openai_base_url`. Codex's standalone `web.run` tool therefore sent `POST /v1/alpha/search` through the router, but the router only allow-listed Responses and image routes. The request fell through to `proxy_route_not_found` with HTTP 404.

## User impact

Codex web search works while Codex Router remains enabled. The change does not expose a general native proxy: only `/alpha/search` and `/v1/alpha/search` are added to the explicit allow-list.

## Validation

- `npm run check` — passed
- `node --check src/router.mjs` — passed
- targeted standalone web-search regression — passed
- live `web.run` request through the restarted local router — passed
- full local Windows suite after `npm ci`: 260 passed, 1 failed, 2 skipped; the remaining unrelated test hard-codes `/usr/bin/true` (`login-free aliasing applies even when a ChatGPT credential is still stored`)
