### PR TITLE
fix(codex): keep native catalog and root concurrency compatibility

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -225,9 +225,13 @@ function rewriteModelMessages(messages, model) {
 }
 
 function normalizeNativeModel(model) {
-  return Object.hasOwn(model, "supports_reasoning_summaries")
-    ? model
-    : { ...model, supports_reasoning_summaries: false };
+  return {
+    ...model,
+    supports_reasoning_summaries:
+      typeof model.supports_reasoning_summaries === "boolean"
+        ? model.supports_reasoning_summaries
+        : false,
+  };
 }
 
 export function routedModel(template, model) {

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -157,13 +157,11 @@ function hasModernMultiAgentConfig(input) {
     .some((line) => /^\s*multi_agent_v2\s*=/.test(line));
 }
 
-// Some Codex builds parse `[agents]` as a pure role map and reject the
-// concurrency scalar outright, which blocks the whole config from loading
-// (observed on 0.141-0.145; earlier and later builds accept it). A version
-// table would need constant maintenance, so ask the installed binary instead:
-// have it load a config containing only the scalar and see whether it parses.
-// The probe config is minimal on purpose — the answer must not depend on
-// anything else in the user's config.
+// Some Codex builds reject a managed concurrency scalar and block the whole
+// config from loading. Ask the installed binary instead of maintaining a
+// version table: have it load a config containing only the root-level scalar
+// and see whether it parses. The probe config is minimal on purpose, so the
+// answer must not depend on anything else in the user's config.
 let codexAcceptsAgentConcurrencyScalar;
 function installedCodexAcceptsAgentConcurrencyScalar() {
   if (codexAcceptsAgentConcurrencyScalar !== undefined) {
@@ -181,7 +179,7 @@ function probeAgentConcurrencyScalar() {
   try {
     writeFileSync(
       path.join(probeHome, "config.toml"),
-      `[agents]\nmax_concurrent_threads_per_session = ${managedAgentMaxConcurrency}\n`,
+      `max_concurrent_threads_per_session = ${managedAgentMaxConcurrency}\n`,
       { encoding: "utf8", mode: 0o600 },
     );
     const { command: probeCommand, options } = codexSpawnTarget(binary);
@@ -210,9 +208,7 @@ function withManagedAgentConcurrency(input) {
   const { rootLines } = splitRoot(cleaned);
   if (
     rootLines.some((line) =>
-      /^\s*agents(?:\.(?:max_concurrent_threads_per_session|max_threads))?\s*=/.test(
-        line,
-      ),
+      /^\s*(?:max_concurrent_threads_per_session|max_threads)\s*=/.test(line),
     )
   ) {
     return cleaned;
@@ -238,12 +234,9 @@ function withManagedAgentConcurrency(input) {
     `max_concurrent_threads_per_session = ${managedAgentMaxConcurrency}`,
     agentConcurrencyEndMarker,
   ];
-  if (agentsHeader !== -1) {
-    lines.splice(agentsHeader + 1, 0, ...managedLines);
-  } else {
-    while (lines.length && !lines.at(-1).trim()) lines.pop();
-    lines.push("", createdAgentsTableMarker, "[agents]", ...managedLines);
-  }
+  const firstTable = lines.findIndex((line) => /^\s*\[/.test(line));
+  const insertionIndex = firstTable === -1 ? lines.length : firstTable;
+  lines.splice(insertionIndex, 0, ...managedLines, "");
   return `${lines.join("\n").trimEnd()}\n`;
 }
 

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -166,6 +166,15 @@ test("merged catalog preserves native GPT identity while rewriting routed models
   assert.doesNotMatch(bySlug.get("grok-oauth/grok-4.5").base_instructions, /GPT-5/);
 });
 
+test("merged catalog preserves an explicit native reasoning summary capability", () => {
+  const native = {
+    ...template,
+    supports_reasoning_summaries: true,
+  };
+  const merged = buildMergedCatalog({ models: [native] }, []);
+  assert.equal(merged[0].supports_reasoning_summaries, true);
+});
+
 test("login-free catalogs contain only authenticated external models", () => {
   const merged = buildMergedCatalog({ models: [template] }, [grok], {
     includeNative: false,

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -20,10 +20,10 @@ const manager = path.join(root, "src", "config-manager.mjs");
 const CALLER_KEY = "test-config-caller-capability-with-sufficient-length";
 
 // The config manager probes the installed Codex binary to learn whether its
-// schema accepts the managed [agents] concurrency scalar. Point it at stubs so
-// the tests do not depend on whichever Codex build this machine has. Windows
-// cannot execute shebang scripts, so the stubs are batch files there — the
-// same .cmd shape codexSpawnTarget already handles for npm-installed Codex.
+// schema accepts the managed root-level concurrency scalar. Point it at stubs
+// so the tests do not depend on whichever Codex build this machine has.
+// Windows cannot execute shebang scripts, so the stubs are batch files there —
+// the same .cmd shape codexSpawnTarget already handles for npm-installed Codex.
 const codexStubDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-codex-stub-"));
 function writeCodexStub(name, message) {
   const isWindows = process.platform === "win32";
@@ -97,8 +97,8 @@ approval_policy = "never"
     assert.match(configured, /# BEGIN codex-router-managed/);
     assert.match(configured, /# BEGIN codex-router-provider-managed/);
     assert.match(configured, /# BEGIN codex-router-agent-concurrency-managed/);
-    assert.match(configured, /\[agents\]/);
     assert.match(configured, /max_concurrent_threads_per_session = 6/);
+    assert.doesNotMatch(configured, /\[agents\]/);
     assert.match(configured, /\[model_providers\.codex-router\]/);
     assert.match(configured, /wire_api = "responses"/);
     assert.ok(
@@ -156,8 +156,9 @@ approval_policy = "never"
 test("config manager preserves a user-owned agent concurrency limit", () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-agent-limit-"));
   const configPath = path.join(codexHome, "config.toml");
-  const original = `[agents]
-max_concurrent_threads_per_session = 3
+  const original = `max_concurrent_threads_per_session = 3
+
+[agents]
 default_subagent_model = "gpt-5.6-terra"
 `;
   writeFileSync(configPath, original, { mode: 0o600 });
@@ -182,7 +183,7 @@ default_subagent_model = "gpt-5.6-terra"
   }
 });
 
-test("config manager adds concurrency inside an existing agents table and removes only its value", () => {
+test("config manager adds concurrency at root before an existing agents table", () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-agent-default-"));
   const configPath = path.join(codexHome, "config.toml");
   writeFileSync(
@@ -202,6 +203,10 @@ model_reasoning_effort = "high"
     assert.equal((enabled.match(/^\[agents\]$/gm) || []).length, 1);
     assert.match(enabled, /^max_concurrent_threads_per_session = 6$/m);
     assert.match(enabled, /^default_subagent_model = "gpt-5\.6-terra"$/m);
+    assert.ok(
+      enabled.indexOf("max_concurrent_threads_per_session = 6") <
+        enabled.indexOf("[agents]"),
+    );
 
     run("disable", codexHome);
     const restored = readFileSync(configPath, "utf8");


### PR DESCRIPTION
Preserve two local compatibility fixes on top of the upstream catalog/config refactor:

- Native models missing `supports_reasoning_summaries` now normalize to `false`, so older or incomplete native captures do not leak undefined capability values into the merged catalog.
- The managed concurrency scalar stays at the root of `config.toml` before any `[agents]` table, avoiding an `[agents]` block that breaks companion configs on the current Codex build.

Tests: `npm test` passes with 261 passed, 2 skipped, 0 failed. `./bin/install` also completes with this working tree.