### PR TITLE
fix(macOS): keep tray popover anchor stable during activity updates

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -1478,6 +1478,7 @@ struct ProviderSetupState: Decodable, Identifiable, Equatable {
 
 private struct StatusItemLabel: View {
   @ObservedObject var store: RouterStore
+  private static let reservedWidth: CGFloat = 180
 
   var body: some View {
     HStack(spacing: 5) {
@@ -1486,16 +1487,25 @@ private struct StatusItemLabel: View {
         .frame(width: 6, height: 6)
       Text(store.hasConcurrentActivity ? store.activitySummaryLabel : store.selectedUsageProvider.shortName)
         .font(.system(size: 11, weight: .medium, design: .rounded))
+        .lineLimit(1)
+        .truncationMode(.tail)
       if store.hasConcurrentActivity {
         Text(store.compactActivityProvidersLabel)
           .font(.system(size: 10, weight: .medium, design: .rounded))
           .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.tail)
       } else if let usage = store.selectedUsageText {
         Text(usage)
           .font(.system(size: 10, weight: .medium, design: .monospaced))
           .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .truncationMode(.tail)
       }
     }
+    // Keep the NSStatusItem anchor stable while activity text changes.
+    .frame(width: Self.reservedWidth, alignment: .leading)
+    .clipped()
   }
 }
 


### PR DESCRIPTION
## Summary

- Reserve a fixed width for the dynamic macOS menu-bar status label.
- Keep live activity and usage details while constraining them to one line with safe truncation.

## Root cause

`MenuBarExtra(.window)` anchors its popover to the SwiftUI status item. Activity polling runs every 350 ms and changes `StatusItemLabel` between provider, usage, and concurrent-activity text. Those strings have different intrinsic widths, so macOS repeatedly recalculates the anchor and the popover visibly jumps.

The Dynamic Island and desktop panel use separate fixed-position windows and are not involved.

## Validation

- `swift build -c release --package-path apps/macos/ModelRouterTray --scratch-path /tmp/codex-router-pr-swift-build`
- `./scripts/build-macos-tray-app.sh "/tmp/codex-router-pr-Model Router.app"`
- `sh -n scripts/build-macos-tray-app.sh`
- `node scripts-check.mjs`
- `npm test` (260 passed, 0 failed, 2 skipped)
- Targeted rerun of the two initially flaky tests (27 passed, 0 failed)

## Manual smoke test

1. Launch the tray and open the menu-bar popover.
2. Keep it open while activity transitions between idle, one active request, concurrent requests, and idle.
3. Confirm the popover remains anchored in place while the status text updates or truncates.

## Screenshot replicating the issue

<img width="796" height="1212" alt="CleanShot 2026-08-06 at 16 55 51@2x" src="https://github.com/user-attachments/assets/9a5ad800-8aaf-43b5-8d21-36a48fce1780" />

## Video recording of the issue

<img width="485" height="800" alt="CleanShot 2026-08-06 at 16 39 49" src="https://github.com/user-attachments/assets/409aa598-c321-456c-86a3-d72290d73221" />
