### PR TITLE
fix(tray): prevent stale chat names in Dynamic Island

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -131,6 +131,7 @@ final class RouterStore: ObservableObject {
   private var hasObservedActiveProvider = false
   private var manuallySelectedUsageProvider = false
   private var latestObservedActivityRequestID: String?
+  private var lastObservedSessionID: String?
   private var activityHealthFailureStartedAt: Date?
   private var dailyUsageCache: [DailyUsageCacheKey: [DailyUsagePoint]] = [:]
   private var localUsageTotalsCache: [LocalUsageTotalsCacheKey: UsageTotals] = [:]
@@ -988,7 +989,21 @@ final class RouterStore: ObservableObject {
         activeRequestCount = nextActiveRequestCount
       }
       if activeModel != health.activity.model { activeModel = health.activity.model }
-      if let sessionName = health.activity.sessionName, !sessionName.isEmpty {
+      let latestActiveRequest = nextActiveRequests.last
+      let activeSessionID = latestActiveRequest?.sessionId ?? latestActiveRequest?.threadId
+      if let activeSessionID, activeSessionID != lastObservedSessionID {
+        lastObservedSessionID = activeSessionID
+        activitySessionName = nil
+      }
+      let activeSessionName = latestActiveRequest?.sessionName?.trimmingCharacters(in: .whitespacesAndNewlines)
+      if let activeSessionID, activeSessionID == lastObservedSessionID,
+         let activeSessionName, !activeSessionName.isEmpty,
+         activitySessionName != activeSessionName {
+        activitySessionName = activeSessionName
+      } else if activeSessionID == nil,
+                let sessionName = health.activity.sessionName?.trimmingCharacters(in: .whitespacesAndNewlines),
+                !sessionName.isEmpty,
+                lastObservedSessionID == nil {
         if activitySessionName != sessionName { activitySessionName = sessionName }
       }
       if health.activity.state == .generating,


### PR DESCRIPTION
## Summary

  - Track the active Codex session/thread ID alongside the displayed chat name.
  - Keep the name stable across multiple messages in the same chat.
  - Clear stale names when a different chat session becomes active.
  - Preserve the last known name while the current session is idle.

## Problem

The tray retained the last activity name without tracking which session it belonged to. After a chat was deleted, the Dynamic Island could continue displaying that old chat name indefinitely.

## Validation

- npm test: 260 passed, 0 failed, 2 skipped
- npm run check: passed
- Shell syntax checks for `install.sh` and `bin/*`: passed