### PR TITLE
feat(tray): tie the router and the tray to the Codex desktop apps, and supervise the tray with launchd

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -283,6 +283,11 @@ final class RouterStore: ObservableObject {
   // The process itself stays resident as the watcher — quitting on app exit
   // would leave nothing around to notice the next launch.
   func startHostAppObservation() {
+    // The mode lives in two places: UserDefaults for the tray and presence.json
+    // for doctor. Only a toggle used to write the second one, so a reinstall or
+    // a cleared state directory left doctor believing the router should always
+    // be up while the tray was quietly stopping it. Republish on every launch.
+    persistPresenceMode(presenceMode)
     let center = NSWorkspace.shared.notificationCenter
     for name in [
       NSWorkspace.didLaunchApplicationNotification,

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -83,6 +83,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     Task { await store.startAccountUsagePolling() }
     Task { await store.startProviderPolling() }
   }
+
+  func applicationWillTerminate(_ notification: Notification) {
+    store.restoreServiceOnQuit()
+  }
 }
 
 @MainActor
@@ -127,6 +131,15 @@ final class RouterStore: ObservableObject {
   // as "Codex is open" for the follow mode.
   private let hostAppBundleIDs = ["com.openai.codex", "com.openai.chat"]
   private var workspaceObservers: [NSObjectProtocol] = []
+  private var pendingServiceStop: Task<Void, Never>?
+  private var serviceWork: Task<Void, Never>?
+  private var serviceIntent: ServiceIntent = .unknown
+  // Codex relaunches itself to apply updates, so a momentary disappearance must
+  // not bounce the router. Wait the absence out and re-check before stopping.
+  private let hostAppAbsenceGrace = Duration.seconds(30)
+  // A request in flight outlives the window that started it; retry rather than
+  // cutting a generation off mid-stream.
+  private let activeRequestRecheck = Duration.seconds(15)
   private var accountUsageResolved = false
   private var hasResolvedInitialUsageProvider = false
   private var hasObservedActiveProvider = false
@@ -268,6 +281,11 @@ final class RouterStore: ObservableObject {
     presenceMode = mode
     defaults.set(mode.rawValue, forKey: presenceModeKey)
     refreshSurfacesVisible()
+    // doctor reads the mode from the router's own state directory: without it a
+    // service the tray stopped on purpose reads as a crash and drives the Fix
+    // button into a full repair.
+    persistPresenceMode(mode)
+    reconcileService()
   }
 
   private func refreshHostAppRunning() {
@@ -276,10 +294,103 @@ final class RouterStore: ObservableObject {
         .contains { !$0.isTerminated }
     }
     refreshSurfacesVisible()
+    reconcileService()
   }
 
   private func refreshSurfacesVisible() {
     surfacesVisible = presenceMode == .always || hostAppRunning
+  }
+
+  private func persistPresenceMode(_ mode: TrayPresenceMode) {
+    enqueueServiceWork { [weak self] in
+      _ = try? await self?.runControl(arguments: ["presence", "set", mode.controlValue])
+    }
+  }
+
+  // In follow mode the router runs only while Codex or ChatGPT is open. Starts
+  // are immediate so the gateway is warming while the user walks to the prompt.
+  // Stops are deferred: Codex restarts itself, and a request can outlive the
+  // window that issued it.
+  private func reconcileService() {
+    pendingServiceStop?.cancel()
+    pendingServiceStop = nil
+    guard presenceMode == .followCodex else {
+      // Leaving follow mode hands the router back to launchd's always-on
+      // contract, so anything the tray stopped has to come back up.
+      if serviceIntent == .stopped { startService() }
+      serviceIntent = .unknown
+      return
+    }
+    if hostAppRunning {
+      startService()
+      return
+    }
+    pendingServiceStop = Task { [weak self] in
+      guard let self else { return }
+      try? await Task.sleep(for: self.hostAppAbsenceGrace)
+      guard !Task.isCancelled else { return }
+      await self.stopServiceWhenIdle()
+    }
+  }
+
+  private func stopServiceWhenIdle() async {
+    while !Task.isCancelled {
+      guard presenceMode == .followCodex, !hostAppRunning else { return }
+      if activityState == .idle { break }
+      try? await Task.sleep(for: activeRequestRecheck)
+    }
+    guard !Task.isCancelled, presenceMode == .followCodex, !hostAppRunning else { return }
+    guard serviceIntent != .stopped else { return }
+    serviceIntent = .stopped
+    enqueueServiceWork { [weak self] in
+      await self?.runServiceCommand("stop")
+    }
+  }
+
+  private func startService() {
+    guard serviceIntent != .running else { return }
+    serviceIntent = .running
+    enqueueServiceWork { [weak self] in
+      await self?.runServiceCommand("start")
+    }
+  }
+
+  // launchctl rejects overlapping bootstrap/bootout for the same label, so every
+  // service call queues behind the previous one.
+  private func enqueueServiceWork(_ work: @escaping @Sendable () async -> Void) {
+    let previous = serviceWork
+    serviceWork = Task { [weak self] in
+      _ = await previous?.value
+      guard self != nil else { return }
+      await work()
+    }
+  }
+
+  private func runServiceCommand(_ action: String) async {
+    do {
+      _ = try await runControl(arguments: ["service", action])
+    } catch {
+      // A failed stop is harmless; a failed start is not, so surface it and let
+      // the next Codex launch retry from a known-unknown intent.
+      serviceIntent = .unknown
+      message = "Router \(action): \(error.localizedDescription)"
+    }
+    await refresh()
+  }
+
+  // The tray is the only watcher in follow mode. If it goes away with the router
+  // stopped, nothing is left to notice the next Codex launch, so hand the router
+  // back to launchd on the way out. Detached so quitting never blocks on the
+  // gateway's health wait.
+  func restoreServiceOnQuit() {
+    pendingServiceStop?.cancel()
+    guard presenceMode == .followCodex, serviceIntent == .stopped else { return }
+    guard let root = try? sourceRoot() else { return }
+    let task = Process()
+    task.executableURL = root.appendingPathComponent("bin/control")
+    task.arguments = ["service", "start"]
+    task.currentDirectoryURL = root
+    try? task.run()
   }
 
   func setLaunchAtLogin(_ enabled: Bool) {
@@ -1527,6 +1638,22 @@ enum TrayPresenceMode: String, CaseIterable, Identifiable {
     case .followCodex: return "With Codex"
     }
   }
+
+  // `control presence` spells the modes in the router's kebab-case vocabulary.
+  var controlValue: String {
+    switch self {
+    case .always: return "always"
+    case .followCodex: return "follow-codex"
+    }
+  }
+}
+
+// What the tray last asked the background service to do, so a burst of
+// workspace notifications does not re-issue a start the router already honored.
+enum ServiceIntent {
+  case unknown
+  case running
+  case stopped
 }
 
 enum IslandMode: String, CaseIterable, Identifiable {

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -226,10 +226,30 @@ final class RouterStore: ObservableObject {
     Bundle.main.bundleIdentifier != nil
   }
 
+  // The launchd agent supersedes the login item: it starts the tray at login
+  // *and* restarts it when it exits abnormally, which a login item never did.
+  // Both mechanisms at once would open two trays every login, so the login item
+  // is retired the moment the agent exists.
+  var supervisedByAgent: Bool {
+    FileManager.default.fileExists(atPath: trayAgentPath)
+  }
+
+  private var trayAgentPath: String {
+    FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent("Library/LaunchAgents/io.github.codex-router.tray.plist")
+      .path
+  }
+
   func bootstrapLaunchAtLogin() {
     guard launchAtLoginAvailable else { return }
     let service = SMAppService.mainApp
     let bundlePath = Bundle.main.bundlePath
+    if supervisedByAgent {
+      if service.status == .enabled { try? service.unregister() }
+      defaults.set(bundlePath, forKey: loginItemBundlePathKey)
+      launchAtLogin = true
+      return
+    }
     launchAtLogin = service.status == .enabled
     let registeredPath = defaults.string(forKey: loginItemBundlePathKey)
     // Migrate the first-run registration if the tray moved (for example from
@@ -395,6 +415,16 @@ final class RouterStore: ObservableObject {
 
   func setLaunchAtLogin(_ enabled: Bool) {
     guard launchAtLoginAvailable else { return }
+    if supervisedByAgent {
+      // launchd owns startup now. Turning this off would mean booting the agent
+      // out, which kills the running tray -- the switch would quit the app
+      // instead of changing a preference. Removing the agent is an explicit
+      // `./bin/control tray disable`.
+      launchAtLogin = true
+      message = "launchd starts the tray and restarts it if it stops. "
+        + "Run ./bin/control tray disable to hand startup back to a login item."
+      return
+    }
     let service = SMAppService.mainApp
     do {
       if enabled {

--- a/bin/install
+++ b/bin/install
@@ -134,6 +134,10 @@ service_installed=true
 node src/service.mjs install
 node src/wait-health.mjs
 node src/install-manifest.mjs record >/dev/null
+# Adopt an already-built companion into launchd's care. Installs that never
+# added the tray skip this; the point is that anyone who has one ends up
+# supervised without having to know the agent exists.
+node src/tray-service.mjs install >/dev/null 2>&1 || true
 config_enabled=false
 service_installed=false
 trap - EXIT HUP INT TERM

--- a/bin/model-router-tray
+++ b/bin/model-router-tray
@@ -6,14 +6,20 @@ repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 case $(uname -s) in
   Darwin)
     bundle_dir=$("$repo_dir/scripts/build-macos-tray-app.sh")
-    # A running tray keeps executing its old binary; replace it before opening
-    # the rebuilt bundle so updates take effect immediately.
+    # A running tray keeps executing its old binary; replace it before starting
+    # the rebuilt bundle so updates take effect immediately. A tray that was
+    # opened by hand is outside launchd's reach, so ask it to quit as well.
     if pgrep -x ModelRouterTray >/dev/null 2>&1; then
       osascript -e 'tell application id "io.github.codex-router.tray" to quit' >/dev/null 2>&1 \
         || killall -QUIT ModelRouterTray >/dev/null 2>&1 || true
       sleep 1
     fi
-    open "$bundle_dir"
+    # launchd owns the companion from here. Installing the agent starts it now,
+    # starts it at every login, and restarts it if it ever exits abnormally --
+    # a login item alone only covers the login case, which left a crashed tray
+    # gone until the next one.
+    node "$repo_dir/src/tray-service.mjs" install >/dev/null
+    printf 'Tray installed and supervised by launchd: %s\n' "$bundle_dir"
     ;;
   Linux)
     binary_path=$("$repo_dir/scripts/build-desktop-tray.sh" --binary-only | tail -n 1)

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -546,6 +546,43 @@ async function handlePicker(action, value, flag) {
   process.stdout.write(`${JSON.stringify(modelPickerSnapshot())}\n`);
 }
 
+// The tray drives these two when it follows the Codex/ChatGPT desktop apps:
+// `presence` records the mode so doctor can tell a deliberate shutdown from a
+// crash, and `service` starts or stops the background service. Installing and
+// uninstalling stay out of reach; the tray must not be able to unregister the
+// LaunchAgent that owns the router.
+const SERVICE_COMMANDS = ["status", "start", "stop", "restart"];
+
+function handleService(action) {
+  const value = action || "status";
+  if (!SERVICE_COMMANDS.includes(value)) {
+    throw new Error(`Usage: control service ${SERVICE_COMMANDS.join("|")}`);
+  }
+  const result = spawnSync(
+    process.execPath,
+    [path.join(REPO_ROOT, "src", "service.mjs"), value],
+    { stdio: "inherit", env: process.env },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`Background service ${value} failed with exit code ${result.status}.`);
+  }
+}
+
+async function handlePresence(action, value) {
+  const { PRESENCE_MODES, presenceSnapshot, setPresenceMode } = await import(
+    "./presence-state.mjs"
+  );
+  if (!action || action === "status") {
+    process.stdout.write(`${JSON.stringify(presenceSnapshot())}\n`);
+    return;
+  }
+  if (action !== "set") {
+    throw new Error(`Usage: control presence status|set <${PRESENCE_MODES.join("|")}>`);
+  }
+  process.stdout.write(`${JSON.stringify(setPresenceMode(value))}\n`);
+}
+
 // --- dispatch ---------------------------------------------------------------
 
 if (args.includes("--probe")) {
@@ -584,6 +621,10 @@ if (args.includes("--probe")) {
   await handleSubagents(args[1], args[2], args[3]);
 } else if (args[0] === "picker") {
   await handlePicker(args[1], args[2], args[3]);
+} else if (args[0] === "service") {
+  handleService(args[1]);
+} else if (args[0] === "presence") {
+  await handlePresence(args[1], args[2]);
 } else if (args[0] === "maintenance") {
   await updateAndVerifyCodex();
 } else if (args[0] === "doctor") {

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -569,6 +569,28 @@ function handleService(action) {
   }
 }
 
+// Supervision for the tray companion. `disable` boots the agent out, which
+// stops the running tray too -- that is why the Settings toggle does not call
+// it and this stays an explicit command.
+const TRAY_COMMANDS = { enable: "install", disable: "uninstall", status: "status", restart: "restart" };
+
+function handleTray(action) {
+  const value = action || "status";
+  const subcommand = TRAY_COMMANDS[value];
+  if (!subcommand) {
+    throw new Error(`Usage: control tray ${Object.keys(TRAY_COMMANDS).join("|")}`);
+  }
+  const result = spawnSync(
+    process.execPath,
+    [path.join(REPO_ROOT, "src", "tray-service.mjs"), subcommand],
+    { stdio: "inherit", env: process.env },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`Tray ${value} failed with exit code ${result.status}.`);
+  }
+}
+
 async function handlePresence(action, value) {
   const { PRESENCE_MODES, presenceSnapshot, setPresenceMode } = await import(
     "./presence-state.mjs"
@@ -623,6 +645,8 @@ if (args.includes("--probe")) {
   await handlePicker(args[1], args[2], args[3]);
 } else if (args[0] === "service") {
   handleService(args[1]);
+} else if (args[0] === "tray") {
+  handleTray(args[1]);
 } else if (args[0] === "presence") {
   await handlePresence(args[1], args[2]);
 } else if (args[0] === "maintenance") {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -13,6 +13,7 @@ import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { readMultiAgentSettings } from "./multi-agent-state.mjs";
 import { readHiddenModels } from "./model-picker-state.mjs";
+import { serviceFollowsHostApps } from "./presence-state.mjs";
 import { waitForRouterHealth } from "./router-health.mjs";
 import {
   CALLER_SECRET_PATH,
@@ -425,14 +426,24 @@ add(
     : "Disable the other router manually; Codex Router will not overwrite it.",
 );
 
+// When the tray follows the desktop apps it stops the service as soon as Codex
+// and ChatGPT are both closed. That is the resting state, not a fault, so it
+// must not read as a failure: a `fail` here sets the exit code and sends the
+// tray's Fix button down the full repair path for a router that is off on
+// purpose.
+const followsHostApps = serviceFollowsHostApps();
 let serviceLoaded = false;
+let serviceStoppedByDesign = false;
 try {
   const service = childJson("service.mjs", ["status"]);
   serviceLoaded = Boolean(service.loaded);
+  serviceStoppedByDesign = !serviceLoaded && followsHostApps;
   add(
-    service.loaded ? "ok" : "fail",
+    serviceLoaded ? "ok" : serviceStoppedByDesign ? "warn" : "fail",
     "Background service",
-    service.state || "stopped",
+    serviceStoppedByDesign
+      ? "stopped; following Codex (open Codex or ChatGPT to start it)"
+      : service.state || "stopped",
     "Run ./bin/enable or ./bin/doctor --fix.",
   );
 } catch (error) {
@@ -446,11 +457,13 @@ try {
 
 const health = await waitForRouterHealth({ timeoutMs: serviceLoaded ? 30_000 : 2_000 });
 add(
-  health.ok ? "ok" : "fail",
+  health.ok ? "ok" : serviceStoppedByDesign ? "warn" : "fail",
   "Router health",
   health.ok
     ? `version ${health.payload.version}`
-    : `not ready on 127.0.0.1:${PORTS.router} after ${serviceLoaded ? 30 : 2} seconds; ${health.error}`,
+    : serviceStoppedByDesign
+      ? "not serving; the background service is following Codex"
+      : `not ready on 127.0.0.1:${PORTS.router} after ${serviceLoaded ? 30 : 2} seconds; ${health.error}`,
   "Run ./bin/doctor --fix. If it still fails, create a support bundle.",
 );
 

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -57,6 +57,17 @@ export const LAUNCH_AGENTS_DIR =
   process.env.CODEX_ROUTER_LAUNCH_AGENTS_DIR ||
   path.join(os.homedir(), "Library", "LaunchAgents");
 export const LAUNCH_AGENT_PATH = path.join(LAUNCH_AGENTS_DIR, `${SERVICE_LABEL}.plist`);
+// The tray runs under its own agent rather than a login item: launchd is the
+// only thing that brings it back when it exits, and a login item only fires at
+// login. Both are registered by the installer so the companion is supervised
+// from the moment it is set up.
+export const TRAY_SERVICE_LABEL = `${SERVICE_LABEL}.tray`;
+export const TRAY_LAUNCH_AGENT_PATH = path.join(
+  LAUNCH_AGENTS_DIR,
+  `${TRAY_SERVICE_LABEL}.plist`,
+);
+export const TRAY_APP_PATH = path.join(SOURCE_ROOT, "dist", "Model Router.app");
+export const TRAY_APP_BINARY = path.join(TRAY_APP_PATH, "Contents", "MacOS", "ModelRouterTray");
 
 function port(name, fallback) {
   const value = Number(process.env[name] || fallback);

--- a/src/presence-state.mjs
+++ b/src/presence-state.mjs
@@ -1,0 +1,63 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import { protectPrivateFile } from "./file-security.mjs";
+import { STATE_DIR } from "./paths.mjs";
+
+export const PRESENCE_ALWAYS = "always";
+export const PRESENCE_FOLLOW_CODEX = "follow-codex";
+export const PRESENCE_MODES = [PRESENCE_ALWAYS, PRESENCE_FOLLOW_CODEX];
+
+export const PRESENCE_STATE_PATH =
+  process.env.MODEL_ROUTER_PRESENCE_STATE || path.join(STATE_DIR, "presence.json");
+
+// How the tray ties the router to the Codex/ChatGPT desktop apps. The tray owns
+// the setting, but the Node side has to read it too: in follow mode a stopped
+// service is the expected resting state, and doctor must not report that as a
+// failure the way it reports a service that died on its own.
+export function readPresenceMode() {
+  if (!existsSync(PRESENCE_STATE_PATH)) return PRESENCE_ALWAYS;
+  try {
+    const parsed = JSON.parse(readFileSync(PRESENCE_STATE_PATH, "utf8"));
+    if (parsed?.version !== 1) return PRESENCE_ALWAYS;
+    return PRESENCE_MODES.includes(parsed.mode) ? parsed.mode : PRESENCE_ALWAYS;
+  } catch {
+    return PRESENCE_ALWAYS;
+  }
+}
+
+// True when the router is allowed to be down because the desktop apps are shut.
+export function serviceFollowsHostApps() {
+  return readPresenceMode() === PRESENCE_FOLLOW_CODEX;
+}
+
+export function presenceSnapshot() {
+  return { mode: readPresenceMode(), path: PRESENCE_STATE_PATH };
+}
+
+export function setPresenceMode(mode) {
+  const value = String(mode || "").trim();
+  if (!PRESENCE_MODES.includes(value)) {
+    throw new Error(`Presence mode must be one of: ${PRESENCE_MODES.join(", ")}.`);
+  }
+
+  const stateDir = path.dirname(PRESENCE_STATE_PATH);
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  chmodSync(stateDir, 0o700);
+  const temporary = `${PRESENCE_STATE_PATH}.tmp.${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify({ version: 1, mode: value }, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  protectPrivateFile(temporary);
+  renameSync(temporary, PRESENCE_STATE_PATH);
+  protectPrivateFile(PRESENCE_STATE_PATH);
+  return presenceSnapshot();
+}

--- a/src/tray-service-macos.mjs
+++ b/src/tray-service-macos.mjs
@@ -1,0 +1,161 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  LAUNCH_AGENTS_DIR,
+  TRAY_APP_BINARY,
+  TRAY_APP_PATH,
+  TRAY_LAUNCH_AGENT_PATH,
+  TRAY_SERVICE_LABEL,
+} from "./paths.mjs";
+
+const launchctl = "/bin/launchctl";
+const domain = `gui/${process.getuid()}`;
+const service = `${domain}/${TRAY_SERVICE_LABEL}`;
+const retryWait = new Int32Array(new SharedArrayBuffer(4));
+
+function xml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+// KeepAlive is conditional on purpose. `SuccessfulExit: false` restarts the tray
+// when it crashes or is killed, but leaves it down after the Quit menu item
+// exits cleanly — an unconditional KeepAlive would make Quit impossible.
+function plist() {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${xml(TRAY_SERVICE_LABEL)}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xml(TRAY_APP_BINARY)}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>LimitLoadToSessionType</key>
+  <string>Aqua</string>
+</dict>
+</plist>
+`;
+}
+
+function run(args, options = {}) {
+  return execFileSync(launchctl, args, {
+    encoding: "utf8",
+    timeout: 15_000,
+    stdio: options.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "pipe", "pipe"],
+  });
+}
+
+function loaded() {
+  try {
+    const description = run(["print", service]);
+    return /(?:state|path|type) =/.test(description) ? description : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function bootout() {
+  if (!loaded()) return;
+  try {
+    run(["bootout", service], { quiet: true });
+  } catch (error) {
+    if (loaded()) throw error;
+    return;
+  }
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (!loaded()) return;
+    Atomics.wait(retryWait, 0, 0, 100);
+  }
+  throw new Error(`Timed out waiting for ${TRAY_SERVICE_LABEL} to stop.`);
+}
+
+function writeAgent() {
+  mkdirSync(LAUNCH_AGENTS_DIR, { recursive: true });
+  const temporary = `${TRAY_LAUNCH_AGENT_PATH}.tmp.${process.pid}`;
+  writeFileSync(temporary, plist(), { encoding: "utf8", mode: 0o644 });
+  chmodSync(temporary, 0o644);
+  renameSync(temporary, TRAY_LAUNCH_AGENT_PATH);
+}
+
+function bootstrap() {
+  run(["enable", service], { quiet: true });
+  try {
+    run(["bootstrap", domain, TRAY_LAUNCH_AGENT_PATH], { quiet: true });
+  } catch (error) {
+    // Already bootstrapped is not a failure; anything else is.
+    if (!loaded()) throw error;
+  }
+}
+
+const command = process.argv[2] || "status";
+if (!new Set(["install", "uninstall", "start", "stop", "restart", "status", "render"]).has(command)) {
+  console.error("Usage: tray-service-macos.mjs install|uninstall|start|stop|restart|status|render");
+  process.exit(2);
+}
+
+if (command === "render") {
+  process.stdout.write(plist());
+} else if (command === "status") {
+  const description = loaded();
+  const installed = existsSync(TRAY_LAUNCH_AGENT_PATH);
+  process.stdout.write(
+    `${JSON.stringify({
+      installed,
+      loaded: Boolean(description) && installed,
+      appPresent: existsSync(TRAY_APP_BINARY),
+      state: description ? description.match(/state = ([^\n]+)/)?.[1]?.trim() || "loaded" : "stopped",
+      path: TRAY_LAUNCH_AGENT_PATH,
+    })}\n`,
+  );
+} else if (command === "install") {
+  if (!existsSync(TRAY_APP_BINARY)) {
+    throw new Error(
+      `The tray app is not built at ${TRAY_APP_PATH}. Run ./bin/model-router-tray first.`,
+    );
+  }
+  bootout();
+  writeAgent();
+  bootstrap();
+  process.stdout.write(`${JSON.stringify({ installed: true, path: TRAY_LAUNCH_AGENT_PATH })}\n`);
+} else if (command === "uninstall") {
+  bootout();
+  try {
+    run(["disable", service], { quiet: true });
+  } catch {
+    // Best effort.
+  }
+  if (existsSync(TRAY_LAUNCH_AGENT_PATH)) unlinkSync(TRAY_LAUNCH_AGENT_PATH);
+  process.stdout.write(`${JSON.stringify({ installed: false })}\n`);
+} else if (command === "stop") {
+  bootout();
+  process.stdout.write(`${JSON.stringify({ state: "stopped" })}\n`);
+} else if (command === "start") {
+  if (!existsSync(TRAY_LAUNCH_AGENT_PATH)) {
+    throw new Error(`The tray agent is not installed at ${TRAY_LAUNCH_AGENT_PATH}.`);
+  }
+  if (!loaded()) bootstrap();
+  process.stdout.write(`${JSON.stringify({ state: "running" })}\n`);
+} else if (command === "restart") {
+  if (loaded()) run(["kickstart", "-k", service], { quiet: true });
+  else bootstrap();
+  process.stdout.write(`${JSON.stringify({ state: "running" })}\n`);
+}

--- a/src/tray-service.mjs
+++ b/src/tray-service.mjs
@@ -1,0 +1,27 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+import { SOURCE_ROOT } from "./paths.mjs";
+
+// Only macOS supervises the tray today. The Linux companion is launched
+// directly by bin/model-router-tray and Windows has no tray build, so the
+// commands succeed as no-ops there rather than failing an install.
+const platform = process.env.CODEX_ROUTER_SERVICE_PLATFORM || process.platform;
+
+const command = process.argv[2] || "status";
+
+if (platform !== "darwin") {
+  process.stdout.write(`${JSON.stringify({ installed: false, supported: false })}\n`);
+  process.exit(0);
+}
+
+const result = spawnSync(
+  process.execPath,
+  [path.join(SOURCE_ROOT, "src", "tray-service-macos.mjs"), ...process.argv.slice(2)],
+  { stdio: "inherit", env: process.env },
+);
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);

--- a/test/presence-state.test.mjs
+++ b/test/presence-state.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "presence-state-test-"));
+process.env.CODEX_ROUTER_STATE_DIR = stateDir;
+
+const {
+  PRESENCE_ALWAYS,
+  PRESENCE_FOLLOW_CODEX,
+  PRESENCE_STATE_PATH,
+  presenceSnapshot,
+  readPresenceMode,
+  serviceFollowsHostApps,
+  setPresenceMode,
+} = await import("../src/presence-state.mjs");
+
+test("presence defaults to always when no state has been written", () => {
+  assert.equal(readPresenceMode(), PRESENCE_ALWAYS);
+  assert.equal(serviceFollowsHostApps(), false);
+  assert.ok(PRESENCE_STATE_PATH.startsWith(stateDir));
+});
+
+test("presence round-trips through protected state", () => {
+  assert.deepEqual(setPresenceMode(PRESENCE_FOLLOW_CODEX), {
+    mode: PRESENCE_FOLLOW_CODEX,
+    path: PRESENCE_STATE_PATH,
+  });
+  assert.equal(readPresenceMode(), PRESENCE_FOLLOW_CODEX);
+  assert.equal(serviceFollowsHostApps(), true);
+  assert.equal(statSync(PRESENCE_STATE_PATH).mode & 0o777, 0o600);
+
+  setPresenceMode(PRESENCE_ALWAYS);
+  assert.equal(serviceFollowsHostApps(), false);
+  assert.equal(presenceSnapshot().mode, PRESENCE_ALWAYS);
+});
+
+test("presence rejects modes the tray does not offer", () => {
+  assert.throws(() => setPresenceMode("sometimes"), /Presence mode must be one of/);
+  assert.throws(() => setPresenceMode(""), /Presence mode must be one of/);
+});
+
+test("presence falls back to always when the state file is unusable", () => {
+  writeFileSync(PRESENCE_STATE_PATH, "{ not json", "utf8");
+  assert.equal(readPresenceMode(), PRESENCE_ALWAYS);
+
+  writeFileSync(PRESENCE_STATE_PATH, JSON.stringify({ version: 2, mode: "follow-codex" }), "utf8");
+  assert.equal(readPresenceMode(), PRESENCE_ALWAYS);
+
+  writeFileSync(PRESENCE_STATE_PATH, JSON.stringify({ version: 1, mode: "nonsense" }), "utf8");
+  assert.equal(readPresenceMode(), PRESENCE_ALWAYS);
+});


### PR DESCRIPTION
## Why

Two failure modes hit this install today, both of the same shape: a component went down and nothing could bring it back.

1. **The tray had no watchdog.** The router runs under a `KeepAlive` LaunchAgent that launchd revives. The tray was only an `SMAppService` login item — it started at login and nothing watched it afterwards. When it exited mid-session the menu bar was simply empty until the next login, with no signal that anything had happened.
2. **Follow mode was half a feature.** "With Codex" hid the tray surfaces but left the background service running from login regardless, so the setting did not mean what it said.

## What changed

### Tray supervision (`3a95aa8`)

The tray gets its own LaunchAgent. `KeepAlive` is conditional on `SuccessfulExit` so a crash or a kill comes back within a second, while the Quit menu item still sticks — an unconditional `KeepAlive` would make Quit impossible.

Registration happens wherever the companion is set up: `bin/model-router-tray` installs the agent after building, which covers `setup.mjs` and the updater, and `bin/install` adopts an already-built bundle so existing installs gain supervision without knowing the agent exists.

Both mechanisms at once would open two trays every login, so the app unregisters the login item as soon as it sees the agent. The Settings toggle reports that launchd owns startup rather than booting the agent out — that would kill the running tray, making the switch quit the app instead of setting a preference.

### Follow mode drives the service (`287edb0`)

Starts are immediate so the gateway warms while the user reaches the prompt. Stops wait out a 30s grace period because Codex relaunches itself to update, then hold off further while a request is in flight. `launchctl` rejects overlapping bootstrap/bootout for one label, so the calls queue.

`doctor` learns the mode from a new presence state file. Without it, a service the tray stopped on purpose reads as a crash, sets a non-zero exit, and sends the tray's Fix button into a full repair of a router that is off by design. It now reports `warn` with the reason instead of `fail`.

The tray hands the router back to launchd when it quits, so follow mode can never leave a stopped service with no watcher around to restart it.

### Presence sync (`557d0eb`)

The mode lived in two places — `UserDefaults` for the tray, `presence.json` for doctor — and only the Settings toggle wrote the second. Any install that did not pass through a toggle left them disagreeing. The tray now republishes at startup.

### New commands

- `control tray enable|disable|status|restart`
- `control presence status|set <always|follow-codex>`
- `control service status|start|stop|restart`

`install` and `uninstall` are deliberately out of the tray's reach: it must never be able to unregister the LaunchAgent that owns the router.

## Test plan

Verified on a live install, not just compiled.

- [x] `SIGKILL` the tray → back in **1s** (repeated three times, including on the final deployed build)
- [x] Quit menu item → stays quit through a 12s watch
- [x] Exactly one tray process after install; login-item registration gone
- [x] Codex closed, follow mode on → service survives the grace period, `stopped` at t+40s
- [x] Tray process stays resident as the watcher while the service is down
- [x] Open ChatGPT → service starts in **~2s**, healthy **~4s** later
- [x] `presence.json` republished to `follow-codex` on app launch
- [x] doctor reports `warn` (not `fail`) for a deliberately stopped service; overall exit unaffected
- [x] `control service uninstall` and `control tray <bad verb>` rejected
- [x] 292 tests pass (4 new in `test/presence-state.test.mjs`); `swift build` clean under Swift 6 strict concurrency

### Not covered

- Linux and Windows tray supervision — `tray-service.mjs` no-ops off darwin.
- The window between a Codex launch and the gateway becoming healthy. Cold start measured at **12s** from truly cold, ~6s warm. A prompt fired inside that window reaches a router that is not listening yet; the client-side behaviour there is unverified.
- `doctor --fix` still starts the service unconditionally, so running it while Codex is closed produces a router that follow mode stops again 30s later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)