### PR TITLE
feat(router): redirect native background turns to a routed model; enable multi_agent_v2 on routed subagents

### DIFF
--- a/config/providers.json
+++ b/config/providers.json
@@ -543,7 +543,8 @@
         "image"
       ],
       "requestProfile": "kimi-oauth",
-      "compHash": "kimi-oauth-kimi-for-coding-v1"
+      "supportsImageDetailOriginal": true,
+      "compHash": "kimi-oauth-kimi-for-coding-v2"
     },
     {
       "slug": "kimi-oauth/kimi-for-coding-highspeed",
@@ -569,7 +570,8 @@
         "image"
       ],
       "requestProfile": "kimi-oauth",
-      "compHash": "kimi-oauth-kimi-for-coding-highspeed-v1"
+      "supportsImageDetailOriginal": true,
+      "compHash": "kimi-oauth-kimi-for-coding-highspeed-v2"
     },
     {
       "slug": "kimi-oauth/k3",
@@ -603,7 +605,8 @@
         "image"
       ],
       "requestProfile": "kimi-oauth",
-      "compHash": "kimi-oauth-k3-v2"
+      "supportsImageDetailOriginal": true,
+      "compHash": "kimi-oauth-k3-v3"
     },
     {
       "slug": "kimi-api/kimi-k3",
@@ -637,7 +640,8 @@
         "image"
       ],
       "requestProfile": "kimi-k3",
-      "compHash": "kimi-api-k3-v2"
+      "supportsImageDetailOriginal": true,
+      "compHash": "kimi-api-k3-v3"
     },
     {
       "slug": "deepseek/deepseek-v4-flash",
@@ -747,7 +751,11 @@
         "image"
       ],
       "requestProfile": "xai-reasoning",
-      "compHash": "grok-oauth-grok-4-5-v1"
+      "searchTool": {
+        "mode": "hosted"
+      },
+      "supportsImageDetailOriginal": true,
+      "compHash": "grok-oauth-grok-4-5-v2"
     },
     {
       "slug": "grok-api/grok-4.5",
@@ -781,7 +789,8 @@
         "image"
       ],
       "requestProfile": "xai-reasoning",
-      "compHash": "grok-api-grok-4-5-v1"
+      "supportsImageDetailOriginal": true,
+      "compHash": "grok-api-grok-4-5-v2"
     },
     {
       "slug": "anthropic-api/claude-opus-4.8",
@@ -822,7 +831,8 @@
         "image"
       ],
       "requestProfile": "anthropic-reasoning",
-      "compHash": "anthropic-api-claude-opus-4-8-v1"
+      "supportsImageDetailOriginal": true,
+      "compHash": "anthropic-api-claude-opus-4-8-v2"
     },
     {
       "slug": "zai-coding/glm-5.2",
@@ -895,10 +905,12 @@
       "contextWindow": 262144,
       "autoCompact": 235000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
       "requestProfile": "qwen-plan",
-      "compHash": "qwen-plan-qwen3-7-max-v1"
+      "supportsImageDetailOriginal": true,
+      "compHash": "qwen-plan-qwen3-7-max-v3"
     },
     {
       "slug": "qwen-plan/qwen3.7-plus",
@@ -947,7 +959,8 @@
         "image"
       ],
       "requestProfile": "qwen-plan",
-      "compHash": "qwen-plan-qwen3-8-max-v1"
+      "supportsImageDetailOriginal": true,
+      "compHash": "qwen-plan-qwen3-8-max-v2"
     },
     {
       "slug": "qwen-plan/qwen3.8-max-preview",
@@ -972,7 +985,8 @@
         "image"
       ],
       "requestProfile": "qwen-plan",
-      "compHash": "qwen-plan-qwen3-8-max-preview-v1"
+      "supportsImageDetailOriginal": true,
+      "compHash": "qwen-plan-qwen3-8-max-preview-v2"
     },
     {
       "slug": "qwen-plan/qwen3.6-flash",
@@ -997,7 +1011,8 @@
         "image"
       ],
       "requestProfile": "qwen-plan",
-      "compHash": "qwen-plan-qwen3-6-flash-v1"
+      "supportsImageDetailOriginal": true,
+      "compHash": "qwen-plan-qwen3-6-flash-v2"
     },
     {
       "slug": "qwen-plan/deepseek-v4-pro",
@@ -1150,10 +1165,11 @@
       "contextWindow": 524288,
       "autoCompact": 470000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
       "requestProfile": "ollama-cloud",
-      "compHash": "ollama-cloud-minimax-m3-v1"
+      "compHash": "ollama-cloud-minimax-m3-v2"
     },
     {
       "slug": "ollama-cloud/deepseek-v4-pro",
@@ -1202,7 +1218,8 @@
         "image"
       ],
       "requestProfile": "minimax-m3",
-      "compHash": "minimax-token-plan-minimax-m3-v1"
+      "supportsImageDetailOriginal": true,
+      "compHash": "minimax-token-plan-minimax-m3-v2"
     },
     {
       "slug": "opencode-go/grok-4.5",
@@ -1231,9 +1248,10 @@
       "contextWindow": 500000,
       "autoCompact": 440000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "compHash": "opencode-go-grok-4-5-v1"
+      "compHash": "opencode-go-grok-4-5-v2"
     },
     {
       "slug": "opencode-go/glm-5.2",
@@ -1301,6 +1319,14 @@
       "defaultEffort": "max",
       "reasoningLevels": [
         {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Balanced deep reasoning"
+        },
+        {
           "effort": "max",
           "description": "Maximum reasoning depth"
         }
@@ -1308,9 +1334,11 @@
       "contextWindow": 262144,
       "autoCompact": 235000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "compHash": "opencode-go-kimi-k3-v1"
+      "requestProfile": "kimi-k3",
+      "compHash": "opencode-go-kimi-k3-v2"
     },
     {
       "slug": "opencode-go/kimi-k2.7-code",
@@ -1485,9 +1513,10 @@
       "contextWindow": 1000000,
       "autoCompact": 900000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "compHash": "opencode-go-messages-minimax-m3-v1"
+      "compHash": "opencode-go-messages-minimax-m3-v2"
     },
     {
       "slug": "opencode-go-messages/minimax-m2.7",
@@ -1535,9 +1564,10 @@
       "contextWindow": 262144,
       "autoCompact": 235000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "compHash": "opencode-go-messages-qwen3-8-max-v1"
+      "compHash": "opencode-go-messages-qwen3-8-max-v2"
     },
     {
       "slug": "opencode-go-messages/qwen3.7-max",
@@ -1558,9 +1588,10 @@
       "contextWindow": 262144,
       "autoCompact": 235000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "compHash": "opencode-go-messages-qwen3-7-max-v1"
+      "compHash": "opencode-go-messages-qwen3-7-max-v2"
     },
     {
       "slug": "opencode-go-messages/qwen3.7-plus",
@@ -1773,6 +1804,14 @@
       "defaultEffort": "max",
       "reasoningLevels": [
         {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Balanced deep reasoning"
+        },
+        {
           "effort": "max",
           "description": "Maximum reasoning depth"
         }
@@ -1780,9 +1819,11 @@
       "contextWindow": 1000000,
       "autoCompact": 900000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "compHash": "commandcode-kimi-k3-v1"
+      "requestProfile": "kimi-k3",
+      "compHash": "commandcode-kimi-k3-v2"
     },
     {
       "slug": "commandcode/kimi-k2.7-code",
@@ -2207,9 +2248,10 @@
       "contextWindow": 1000000,
       "autoCompact": 900000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
-      "compHash": "commandcode-messages-claude-opus-4-8-v1"
+      "compHash": "commandcode-messages-claude-opus-4-8-v2"
     },
     {
       "slug": "commandcode-messages/claude-fable-5",

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -281,8 +281,14 @@ export function routedModel(template, model) {
         : "none",
     support_verbosity: false,
     default_verbosity: null,
-    supports_search_tool: false,
-    supports_image_detail_original: false,
+    // Capability toggles come from the registry entry, never from the native
+    // template: an absent flag keeps the conservative default so a routed
+    // model only advertises what its slug's gateway path actually verified.
+    // "hosted" is the only search mode the request path can serve today (the
+    // provider backend runs the search server-side, as the Grok OAuth
+    // forwarder does); the registry loader rejects anything else.
+    supports_search_tool: model.searchTool?.mode === "hosted",
+    supports_image_detail_original: model.supportsImageDetailOriginal === true,
     use_responses_lite: false,
     // Codex only knows one ApplyPatchToolType variant. The native template
     // carries "freeform", but upstreams that reject OpenAI custom tools (Meta

--- a/src/collaboration-namespace.mjs
+++ b/src/collaboration-namespace.mjs
@@ -1,0 +1,115 @@
+import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+export const COLLABORATION_NAMESPACE = "collaboration";
+export const COLLABORATION_TOOL_DELIMITER = "__";
+
+function flattenToolName(namespace, name) {
+  return `${namespace}${COLLABORATION_TOOL_DELIMITER}${name}`;
+}
+
+function splitFlatToolName(name) {
+  if (typeof name !== "string") return undefined;
+  const prefix = `${COLLABORATION_NAMESPACE}${COLLABORATION_TOOL_DELIMITER}`;
+  if (!name.startsWith(prefix)) return undefined;
+  const toolName = name.slice(prefix.length);
+  return toolName ? { namespace: COLLABORATION_NAMESPACE, name: toolName } : undefined;
+}
+
+// LiteLLM's Responses -> Chat Completions bridge drops `type: "namespace"`
+// tools, which is how Codex sends the collaboration toolset. Flatten only the
+// collaboration namespace into plain functions; other namespaces are handled
+// by the bridge (dropped when unsupported) or passed through on Responses
+// providers.
+export function flattenCollaborationNamespaceTools(tools) {
+  if (!Array.isArray(tools)) return { tools, flattened: false };
+  const flattened = [];
+  let changed = false;
+  for (const tool of tools) {
+    if (tool?.type === "namespace" && tool.name === COLLABORATION_NAMESPACE) {
+      for (const fn of Array.isArray(tool.tools) ? tool.tools : []) {
+        flattened.push({
+          ...fn,
+          name: flattenToolName(COLLABORATION_NAMESPACE, fn.name),
+        });
+      }
+      changed = true;
+      continue;
+    }
+    flattened.push(tool);
+  }
+  return { tools: flattened, flattened: changed };
+}
+
+function rewriteCollaborationFunctionCall(event) {
+  const item = event?.item;
+  if (!item || item.type !== "function_call") return undefined;
+  const parsed = splitFlatToolName(item.name);
+  if (!parsed) return undefined;
+  return {
+    ...event,
+    item: {
+      ...item,
+      name: parsed.name,
+      namespace: parsed.namespace,
+    },
+  };
+}
+
+// Rewrites LiteLLM's flattened `collaboration__*` function calls back to the
+// namespace + name shape Codex dispatches through its collaboration runtime.
+export class CollaborationToolCallTransform extends Transform {
+  #decoder = new StringDecoder("utf8");
+  #buffer = "";
+
+  _transform(chunk, _encoding, callback) {
+    this.#buffer += this.#decoder.write(chunk);
+    this.#emitCompleteEvents();
+    callback();
+  }
+
+  _flush(callback) {
+    this.#buffer += this.#decoder.end();
+    this.#emitCompleteEvents(true);
+    callback();
+  }
+
+  #emitCompleteEvents(flush = false) {
+    const blocks = this.#buffer.split(/\r?\n\r?\n/);
+    this.#buffer = flush ? "" : blocks.pop() || "";
+    for (const block of blocks) {
+      this.push(Buffer.from(this.#rewriteBlock(block)));
+      this.push(Buffer.from("\n\n"));
+    }
+  }
+
+  #rewriteBlock(block) {
+    const lines = block.split(/\r?\n/);
+    const rewritten = [];
+    let changed = false;
+    for (const line of lines) {
+      if (!line.startsWith("data:")) {
+        rewritten.push(line);
+        continue;
+      }
+      const data = line.slice(5).trimStart();
+      if (!data || data === "[DONE]") {
+        rewritten.push(line);
+        continue;
+      }
+      try {
+        const event = JSON.parse(data);
+        const next = rewriteCollaborationFunctionCall(event);
+        if (!next) {
+          rewritten.push(line);
+          continue;
+        }
+        rewritten.push(`data: ${JSON.stringify(next)}`);
+        changed = true;
+      } catch {
+        rewritten.push(line);
+      }
+    }
+    return changed ? `${rewritten.join("\r\n")}\r\n` : block;
+  }
+}

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -43,6 +43,8 @@ const providerStartMarker = "# BEGIN codex-router-provider-managed";
 const providerEndMarker = "# END codex-router-provider-managed";
 const agentConcurrencyStartMarker = "# BEGIN codex-router-agent-concurrency-managed";
 const agentConcurrencyEndMarker = "# END codex-router-agent-concurrency-managed";
+const multiAgentV2StartMarker = "# BEGIN codex-router-multi-agent-v2-managed";
+const multiAgentV2EndMarker = "# END codex-router-multi-agent-v2-managed";
 const createdAgentsTableMarker = "# codex-router-created-agents-table";
 const managedAgentMaxConcurrency = 6;
 const routerProviderId = "codex-router";
@@ -62,6 +64,7 @@ const markerPairs = [
   [startMarker, endMarker],
   [providerStartMarker, providerEndMarker],
   [agentConcurrencyStartMarker, agentConcurrencyEndMarker],
+  [multiAgentV2StartMarker, multiAgentV2EndMarker],
   ["# BEGIN kimi-codex-router-managed", "# END kimi-codex-router-managed"],
   ["# BEGIN kimi-codex-proxy-managed", "# END kimi-codex-proxy-managed"],
 ];
@@ -144,10 +147,42 @@ function removeCreatedAgentsTableIfEmpty(input) {
   return lines.join("\n");
 }
 
+function removeEmptyFeaturesTable(input) {
+  const lines = input.split("\n");
+  const headers = lines
+    .map((line, index) =>
+      /^\s*\[features\]\s*(?:#.*)?$/.test(line) ? index : -1,
+    )
+    .filter((index) => index !== -1);
+  if (!headers.length) return input;
+  const remove = new Set();
+  for (const header of headers) {
+    let tableEnd = header + 1;
+    while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd])) tableEnd += 1;
+    const hasValue = lines
+      .slice(header + 1, tableEnd)
+      .some((line) => line.trim() && !line.trim().startsWith("#"));
+    if (hasValue) continue;
+    remove.add(header);
+    for (let index = header + 1; index < tableEnd; index += 1) remove.add(index);
+  }
+  if (!remove.size) return input;
+  return lines
+    .map((line, index) => (remove.has(index) ? null : line))
+    .filter((line) => line !== null)
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
+}
+
 function withoutManagedAgentConcurrency(input) {
   return removeCreatedAgentsTableIfEmpty(
     removeMarkerPair(input, agentConcurrencyStartMarker, agentConcurrencyEndMarker),
   );
+}
+
+function withoutManagedMultiAgentV2(input) {
+  return removeMarkerPair(input, multiAgentV2StartMarker, multiAgentV2EndMarker);
 }
 
 function hasModernMultiAgentConfig(input) {
@@ -163,6 +198,81 @@ function hasModernMultiAgentConfig(input) {
   return lines
     .slice(featuresHeader + 1, tableEnd)
     .some((line) => /^\s*multi_agent_v2\s*=/.test(line));
+}
+
+// Some Codex builds do not know the `multi_agent_v2` feature and would reject
+// the whole config if we wrote it. Probe the installed binary before adding
+// the managed block; older builds keep the legacy agents scalar instead.
+let codexSupportsMultiAgentV2;
+function installedCodexSupportsMultiAgentV2() {
+  if (codexSupportsMultiAgentV2 !== undefined) {
+    return codexSupportsMultiAgentV2;
+  }
+  codexSupportsMultiAgentV2 = probeMultiAgentV2Support();
+  return codexSupportsMultiAgentV2;
+}
+
+function probeMultiAgentV2Support() {
+  const binary = findCodexBinary();
+  if (!binary) return false;
+  const probeHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-v2-probe-"));
+  try {
+    writeFileSync(
+      path.join(probeHome, "config.toml"),
+      `[features]
+multi_agent_v2 = { enabled = true, max_concurrent_threads_per_session = ${managedAgentMaxConcurrency}, expose_spawn_agent_model_overrides = true }
+`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    const { command: probeCommand, options } = codexSpawnTarget(binary);
+    // `login status` exits non-zero when signed out, so the exit code says
+    // nothing about the config; only the load-error message does.
+    const result = spawnSync(probeCommand, ["login", "status"], {
+      ...options,
+      encoding: "utf8",
+      timeout: 10_000,
+      env: { ...process.env, CODEX_HOME: probeHome },
+    });
+    if (result.error) return false;
+    return !/Error loading configuration/i.test(
+      `${result.stdout || ""}\n${result.stderr || ""}`,
+    );
+  } catch {
+    return false;
+  } finally {
+    rmSync(probeHome, { recursive: true, force: true });
+  }
+}
+
+// The v2 feature is what makes Codex expose the spawn-agent toolset. Without
+// it, `multi_agent_version: "v2"` in the catalog is never surfaced to the
+// model. The block is idempotent and leaves an existing user-owned
+// multi_agent_v2 setting alone. The line must live inside the existing
+// `[features]` table: this Codex build rejects a reopened `[features]` table.
+function withManagedMultiAgentV2(input) {
+  const cleaned = withoutManagedMultiAgentV2(input);
+  if (hasModernMultiAgentConfig(cleaned)) return cleaned;
+  if (!installedCodexSupportsMultiAgentV2()) return cleaned;
+  const featureLine = `multi_agent_v2 = { enabled = true, max_concurrent_threads_per_session = ${managedAgentMaxConcurrency}, expose_spawn_agent_model_overrides = true }`;
+  const managedLines = [
+    multiAgentV2StartMarker,
+    featureLine,
+    multiAgentV2EndMarker,
+  ];
+  const lines = cleaned.split("\n");
+  const featuresHeader = lines.findIndex((line) =>
+    /^\s*\[features\]\s*(?:#.*)?$/.test(line),
+  );
+  if (featuresHeader === -1) {
+    const firstTable = lines.findIndex((line) => /^\s*\[/.test(line));
+    const insertionIndex = firstTable === -1 ? lines.length : firstTable;
+    lines.splice(insertionIndex, 0, "", "[features]", ...managedLines);
+    return `${lines.join("\n").trimEnd()}\n`;
+  }
+  let tableEnd = featuresHeader + 1;
+  while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd])) tableEnd += 1;
+  lines.splice(tableEnd, 0, ...managedLines, "");
+  return `${lines.join("\n").trimEnd()}\n`;
 }
 
 // Some Codex builds reject a managed concurrency scalar and block the whole
@@ -419,7 +529,9 @@ function clean(contents) {
   const knownManaged =
     markerPairs.some(([start]) => contents.includes(start)) ||
     knownCatalogPaths.some((catalogPath) => contents.includes(catalogPath));
-  const withoutBlock = removeCreatedAgentsTableIfEmpty(removeMarkedBlock(contents));
+  const withoutBlock = removeEmptyFeaturesTable(
+    removeCreatedAgentsTableIfEmpty(removeMarkedBlock(contents)),
+  );
   const { rootLines, tableLines } = splitRoot(withoutBlock);
   const filtered = rootLines.filter((line) => {
     if (/^\s*openai_base_url\s*=/.test(line)) {
@@ -510,6 +622,8 @@ function enabledContents(contents) {
     "",
     ...tableLines,
     ...(tableLines.length ? [""] : []),
+  ];
+  const providerBlock = [
     providerStartMarker,
     `[model_providers.${routerProviderId}]`,
     'name = "Codex Router (external models)"',
@@ -517,7 +631,9 @@ function enabledContents(contents) {
     'wire_api = "responses"',
     providerEndMarker,
   ];
-  return withManagedAgentConcurrency(`${next.join("\n").trimEnd()}\n`);
+  return withManagedAgentConcurrency(
+    `${withManagedMultiAgentV2(`${next.join("\n").trimEnd()}\n`).trimEnd()}\n\n${providerBlock.join("\n")}\n`,
+  );
 }
 
 function atomicWrite(contents) {

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -593,6 +593,31 @@ function handleTray(action) {
   }
 }
 
+// Where Codex's native-model background turns go when OpenAI quota is not an
+// option. Set to a routed model slug to keep memories, review passes, and
+// other native utility sessions running on a paid provider; clear to restore
+// pure native forwarding.
+async function handleNativeRedirect(action, value) {
+  const { clearNativeRedirect, nativeRedirectSnapshot, setNativeRedirect } = await import(
+    "./native-redirect.mjs"
+  );
+  if (!action || action === "status") {
+    process.stdout.write(`${JSON.stringify(nativeRedirectSnapshot())}\n`);
+    return;
+  }
+  if (action === "clear") {
+    process.stdout.write(`${JSON.stringify(clearNativeRedirect())}\n`);
+    return;
+  }
+  if (action !== "set") {
+    throw new Error("Usage: control native-redirect status|set <routed-model-slug>|clear");
+  }
+  if (!(await knownModelSlug(value))) {
+    throw new Error(`Unknown routed model slug: ${value}`);
+  }
+  process.stdout.write(`${JSON.stringify(setNativeRedirect(value))}\n`);
+}
+
 async function handlePresence(action, value) {
   const { PRESENCE_MODES, presenceSnapshot, setPresenceMode } = await import(
     "./presence-state.mjs"
@@ -647,6 +672,8 @@ if (args.includes("--probe")) {
   await handlePicker(...pickerCommandArgs(args));
 } else if (args[0] === "service") {
   handleService(args[1]);
+} else if (args[0] === "native-redirect") {
+  await handleNativeRedirect(args[1], args[2]);
 } else if (args[0] === "tray") {
   handleTray(args[1]);
 } else if (args[0] === "presence") {

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -12,6 +12,7 @@ import {
   writeJson,
 } from "./http-utils.mjs";
 import { PORTS } from "./paths.mjs";
+import { MODELS } from "./model-registry.mjs";
 import { ensureFreshGrokOAuthToken } from "./grok-oauth-session.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { VERSION } from "./version.mjs";
@@ -35,6 +36,20 @@ const HOSTED_SEARCH_TOOLS = Object.freeze([
   { type: "x_search" },
 ]);
 const HOSTED_SEARCH_FUNCTION_NAMES = new Set(["web_search", "x_search"]);
+
+// The registry entry is the single capability source: hosted search attaches
+// only when the slug that resolves to this upstream model declares it, so a
+// curated model without the flag keeps plain function calling. The forwarder
+// receives the upstream model id (LiteLLM translates OAuth slugs before the
+// request arrives), so the lookup goes provider + upstreamModel, not slug.
+export function hostedSearchEnabledFor(upstreamModel, models = MODELS) {
+  return models.some(
+    (model) =>
+      model.provider === "grok-oauth" &&
+      model.upstreamModel === upstreamModel &&
+      model.searchTool?.mode === "hosted",
+  );
+}
 
 function grokClientVersion() {
   const fallbackVersion = VERSION.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] || "0.0.0";
@@ -75,7 +90,14 @@ function messageContentParts(content, textType) {
   const parts = [];
   for (const part of content) {
     if (part?.type === "image_url" && part.image_url?.url) {
-      parts.push({ type: "input_image", image_url: part.image_url.url });
+      const image = { type: "input_image", image_url: part.image_url.url };
+      // Codex only attaches a detail level when the catalog entry advertises
+      // supports_image_detail_original; forward it untouched so the backend
+      // sees the client's resolution intent instead of a silent downgrade.
+      if (typeof part.image_url.detail === "string" && part.image_url.detail) {
+        image.detail = part.image_url.detail;
+      }
+      parts.push(image);
     } else if (typeof part?.text === "string") {
       parts.push({ type: textType, text: part.text });
     }
@@ -93,10 +115,19 @@ function mapEffort(effort) {
 // Merge client function tools with bare hosted search tools.
 // Hosted tools are type-tagged (web_search / x_search), not function tools.
 // Drop any client function with the same name so the backend owns search.
+// The xAI backend rejects the whole request when a function name repeats
+// ("Duplicate function definition provided"), so only the first definition
+// of each name is forwarded.
 export function mergeHostedSearchTools(clientTools = [], { enabled = true } = {}) {
-  const functions = (Array.isArray(clientTools) ? clientTools : []).filter(
-    (tool) => tool?.type === "function" && !HOSTED_SEARCH_FUNCTION_NAMES.has(tool.name),
-  );
+  const seenNames = new Set();
+  const functions = (Array.isArray(clientTools) ? clientTools : []).filter((tool) => {
+    if (tool?.type !== "function" || HOSTED_SEARCH_FUNCTION_NAMES.has(tool.name)) {
+      return false;
+    }
+    if (seenNames.has(tool.name)) return false;
+    seenNames.add(tool.name);
+    return true;
+  });
   if (!enabled) return functions;
   const hosted = HOSTED_SEARCH_TOOLS.filter(
     (hostedTool) => !functions.some((tool) => tool.type === hostedTool.type),
@@ -230,7 +261,9 @@ async function handleChatCompletions(request, response) {
   const chat = JSON.parse((await readRequestBody(request)).toString("utf8"));
   const wantsStream = chat.stream === true;
   const model = typeof chat.model === "string" ? chat.model : "";
-  const responsesRequest = toResponsesRequest(chat);
+  const responsesRequest = toResponsesRequest(chat, {
+    hostedSearchEnabled: hostedSearchEnabledFor(model),
+  });
 
   const controller = new AbortController();
   request.once("aborted", () => controller.abort());

--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -64,6 +64,11 @@ export function copyResponseHeaders(upstream, response, denylist = HOP_BY_HOP_HE
 }
 
 export async function pipeResponse(upstream, response, denylist, transform) {
+  const transforms = transform === undefined
+    ? []
+    : Array.isArray(transform)
+      ? transform
+      : [transform];
   response.statusCode = upstream.status;
   copyResponseHeaders(upstream, response, denylist);
   if (!upstream.body) {
@@ -80,7 +85,7 @@ export async function pipeResponse(upstream, response, denylist, transform) {
       else resolve();
     };
     stream.once("error", settle);
-    if (transform) transform.once("error", settle);
+    for (const entry of transforms) entry.once("error", settle);
     response.once("finish", () => settle());
     response.once("error", settle);
     // A client that disconnects mid-stream emits "close" without "finish" or
@@ -90,8 +95,9 @@ export async function pipeResponse(upstream, response, denylist, transform) {
       if (!settled) stream.destroy();
       settle();
     });
-    if (transform) stream.pipe(transform).pipe(response);
-    else stream.pipe(response);
+    let target = stream;
+    for (const entry of transforms) target = target.pipe(entry);
+    target.pipe(response);
   });
 }
 

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -159,6 +159,26 @@ function modelProblem(model, providers, slugs, gatewayModels) {
     return `model ${model.slug} has an invalid supportsApplyPatchTool`;
   }
   if (
+    model.supportsImageDetailOriginal !== undefined &&
+    typeof model.supportsImageDetailOriginal !== "boolean"
+  ) {
+    return `model ${model.slug} has an invalid supportsImageDetailOriginal`;
+  }
+  // "hosted" means the provider's own backend executes web searches
+  // server-side (xAI's Responses proxy today). No other mode may be declared
+  // yet: an unimplemented mode would make the catalog advertise a search
+  // toggle the request path cannot serve, so the router-side "emulated"
+  // executor must ship before this enum grows.
+  if (
+    model.searchTool !== undefined &&
+    (!model.searchTool ||
+      typeof model.searchTool !== "object" ||
+      Array.isArray(model.searchTool) ||
+      model.searchTool.mode !== "hosted")
+  ) {
+    return `model ${model.slug} has an invalid searchTool`;
+  }
+  if (
     model.defaultReasoningSummary !== undefined &&
     !["auto", "concise", "detailed"].includes(model.defaultReasoningSummary)
   ) {

--- a/src/native-redirect.mjs
+++ b/src/native-redirect.mjs
@@ -1,0 +1,65 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import { protectPrivateFile } from "./file-security.mjs";
+import { STATE_DIR } from "./paths.mjs";
+
+export const NATIVE_REDIRECT_PATH =
+  process.env.MODEL_ROUTER_NATIVE_REDIRECT_STATE ||
+  path.join(STATE_DIR, "native-redirect.json");
+
+// Codex runs background agent sessions -- memory extraction, review passes,
+// and similar utility work -- on a hardcoded native GPT model, regardless of
+// the model the user picked. When the OpenAI quota is exhausted those turns
+// all fail, and the features they power silently stop working. This optional
+// redirect sends every native turn that reaches the router to a routed model
+// instead, so the background machinery keeps running on the user's paid
+// provider. It is deliberately all-or-nothing: the native turns carry no
+// reliable marker separating background work from a deliberately picked GPT
+// model, and the users who opt in are the ones with no native quota to spend.
+export function readNativeRedirect() {
+  if (!existsSync(NATIVE_REDIRECT_PATH)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(NATIVE_REDIRECT_PATH, "utf8"));
+    if (parsed?.version !== 1) return undefined;
+    const model = typeof parsed.model === "string" ? parsed.model.trim() : "";
+    return model || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function nativeRedirectSnapshot() {
+  return { model: readNativeRedirect() ?? null, path: NATIVE_REDIRECT_PATH };
+}
+
+export function setNativeRedirect(slug) {
+  const value = String(slug || "").trim();
+  if (!value) throw new Error("A routed model slug is required.");
+
+  const stateDir = path.dirname(NATIVE_REDIRECT_PATH);
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  chmodSync(stateDir, 0o700);
+  const temporary = `${NATIVE_REDIRECT_PATH}.tmp.${process.pid}`;
+  writeFileSync(temporary, `${JSON.stringify({ version: 1, model: value }, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  protectPrivateFile(temporary);
+  renameSync(temporary, NATIVE_REDIRECT_PATH);
+  protectPrivateFile(NATIVE_REDIRECT_PATH);
+  return nativeRedirectSnapshot();
+}
+
+export function clearNativeRedirect() {
+  if (existsSync(NATIVE_REDIRECT_PATH)) unlinkSync(NATIVE_REDIRECT_PATH);
+  return nativeRedirectSnapshot();
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -30,6 +30,10 @@ import { readNativeAliases } from "./native-alias.mjs";
 import { readNativeRedirect } from "./native-redirect.mjs";
 import { canonicalProviderId, readProviderSelection } from "./provider-selection.mjs";
 import { ResponseUsageTransform } from "./response-usage.mjs";
+import {
+  CollaborationToolCallTransform,
+  flattenCollaborationNamespaceTools,
+} from "./collaboration-namespace.mjs";
 import { activityMetadataFromHeaders } from "./codex-session-names.mjs";
 import { recordUsageEvent } from "./usage-events.mjs";
 import { VERSION } from "./version.mjs";
@@ -933,12 +937,22 @@ async function handleResponses(request, response, requestUrl) {
     let target;
     let headers;
     let routedBody;
+    let collaborationFlattened = false;
     if (route) {
       const input = await normalizeRoutedAgentInput(
         request,
         payload.input,
         controller.signal,
       );
+      const provider = providerForModel(route);
+      // LiteLLM's Responses -> Chat Completions bridge drops namespace tools.
+      // Chat-completions providers need the collaboration namespace flattened
+      // into ordinary functions; the response transform maps calls back.
+      if (provider?.protocol !== "openai-responses") {
+        const flattened = flattenCollaborationNamespaceTools(payload.tools);
+        collaborationFlattened = flattened.flattened;
+        if (collaborationFlattened) payload.tools = flattened.tools;
+      }
       const routed = {
         ...payload,
         model: route.gatewayModel,
@@ -969,7 +983,11 @@ async function handleResponses(request, response, requestUrl) {
     const usageTransform = new ResponseUsageTransform(
       upstream.headers.get("content-type") || "",
     );
-    await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS, usageTransform);
+    const transforms = [usageTransform];
+    if (collaborationFlattened) {
+      transforms.push(new CollaborationToolCallTransform());
+    }
+    await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS, transforms);
     const usage = usageTransform?.tokenUsage();
     recordUsageEvent({
       model: route?.slug || requestedModel,

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -27,6 +27,7 @@ import {
 } from "./paths.mjs";
 import { MODEL_BY_SLUG, PROVIDERS, providerForModel } from "./model-registry.mjs";
 import { readNativeAliases } from "./native-alias.mjs";
+import { readNativeRedirect } from "./native-redirect.mjs";
 import { canonicalProviderId, readProviderSelection } from "./provider-selection.mjs";
 import { ResponseUsageTransform } from "./response-usage.mjs";
 import { activityMetadataFromHeaders } from "./codex-session-names.mjs";
@@ -871,9 +872,21 @@ async function handleResponses(request, response, requestUrl) {
     const body = decodeBody(encoded, request.headers["content-encoding"]);
     const payload = parseBody(body);
     const requestedModel = typeof payload.model === "string" ? payload.model : "";
-    const registeredRoute =
+    let registeredRoute =
       MODEL_BY_SLUG.get(requestedModel) ??
       MODEL_BY_SLUG.get(readNativeAliases()[requestedModel]);
+    // An unregistered model on this endpoint is native GPT traffic -- Codex's
+    // background agent sessions arrive here hardwired to a native slug no
+    // matter which model the user picked. With the redirect opted in, send
+    // them to the configured routed model; a target that is unknown or whose
+    // provider is hidden leaves the turn native rather than trading a quota
+    // failure for a routing error.
+    if (!registeredRoute && requestedModel) {
+      const redirect = MODEL_BY_SLUG.get(readNativeRedirect());
+      if (redirect && readProviderSelection().includes(redirect.provider)) {
+        registeredRoute = redirect;
+      }
+    }
     const route = registeredRoute && readProviderSelection().includes(registeredRoute.provider)
       ? registeredRoute
       : undefined;

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -78,6 +78,20 @@ test("routed models advertise reasoning summaries only when the registry opts in
   assert.equal(summarized.default_reasoning_summary, "auto");
 });
 
+test("routed models advertise search and image detail only when the registry opts in", () => {
+  // Defaults stay off: external models must not claim capabilities untested.
+  const plain = routedModel(template, grok);
+  assert.equal(plain.supports_search_tool, false);
+  assert.equal(plain.supports_image_detail_original, false);
+  const capable = routedModel(template, {
+    ...grok,
+    searchTool: { mode: "hosted" },
+    supportsImageDetailOriginal: true,
+  });
+  assert.equal(capable.supports_search_tool, true);
+  assert.equal(capable.supports_image_detail_original, true);
+});
+
 test("routed models inherit apply_patch unless the registry opts out", () => {
   const plain = routedModel(template, grok);
   assert.equal(plain.apply_patch_tool_type, "freeform");

--- a/test/collaboration-namespace.test.mjs
+++ b/test/collaboration-namespace.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import test from "node:test";
+
+import {
+  CollaborationToolCallTransform,
+  flattenCollaborationNamespaceTools,
+} from "../src/collaboration-namespace.mjs";
+
+function collect(stream) {
+  return new Promise((resolve, reject) => {
+    let output = "";
+    stream.on("data", (chunk) => {
+      output += chunk.toString("utf8");
+    });
+    stream.on("end", () => resolve(output));
+    stream.on("error", reject);
+  });
+}
+
+test("flatten collaboration namespace into plain function tools", () => {
+  const { tools, flattened } = flattenCollaborationNamespaceTools([
+    { type: "function", name: "exec_command" },
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [
+        { type: "function", name: "spawn_agent" },
+        { type: "function", name: "wait_agent" },
+      ],
+    },
+  ]);
+  assert.equal(flattened, true);
+  assert.deepEqual(
+    tools.map((tool) => tool.name),
+    ["exec_command", "collaboration__spawn_agent", "collaboration__wait_agent"],
+  );
+});
+
+test("non-collaboration namespaces stay untouched", () => {
+  const namespace = {
+    type: "namespace",
+    name: "mcp__node_repl",
+    tools: [{ type: "function", name: "js" }],
+  };
+  const { tools, flattened } = flattenCollaborationNamespaceTools([
+    namespace,
+  ]);
+  assert.equal(flattened, false);
+  assert.deepEqual(tools, [namespace]);
+});
+
+test("collaboration response transform restores namespace function calls", async () => {
+  const events = [
+    { type: "response.created" },
+    {
+      type: "response.output_item.added",
+      item: {
+        type: "function_call",
+        name: "collaboration__spawn_agent",
+        call_id: "call_1",
+      },
+    },
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        name: "collaboration__spawn_agent",
+        call_id: "call_1",
+        arguments: "{}",
+      },
+    },
+  ].map((event) => `data: ${JSON.stringify(event)}\n\n`);
+  const transform = new CollaborationToolCallTransform();
+  const output = await collect(Readable.from(events).pipe(transform));
+  assert.match(output, /"name":"spawn_agent"/);
+  assert.match(output, /"namespace":"collaboration"/);
+  assert.doesNotMatch(output, /collaboration__spawn_agent/);
+});

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -39,6 +39,27 @@ const scalarRejectingCodex = writeCodexStub(
   "codex-rejects-scalar",
   "Error loading configuration: invalid type: integer, expected struct AgentRoleToml",
 );
+// Accepts the legacy concurrency scalar but rejects the modern v2 feature,
+// which is how older builds that still support the scalar behave.
+const scalarOnlyCodex = (() => {
+  const isWindows = process.platform === "win32";
+  const file = path.join(
+    codexStubDir,
+    isWindows ? "codex-scalar-only.cmd" : "codex-scalar-only",
+  );
+  const contents = isWindows
+    ? `@echo off\r\nfindstr /c:"multi_agent_v2" "%CODEX_HOME%\\config.toml" >nul 2>&1\r\nif %errorlevel% equ 0 (\r\n  echo Error loading configuration: unknown feature multi_agent_v2 1>&2\r\n  exit /b 1\r\n)\r\necho Not logged in 1>&2\r\nexit /b 1\r\n`
+    : `#!/bin/sh
+if grep -q multi_agent_v2 "$CODEX_HOME/config.toml" 2>/dev/null; then
+  echo 'Error loading configuration: unknown feature multi_agent_v2' >&2
+  exit 1
+fi
+echo 'Not logged in' >&2
+exit 1
+`;
+  writeFileSync(file, contents, { mode: 0o755 });
+  return file;
+})();
 
 function run(
   command,
@@ -96,8 +117,13 @@ approval_policy = "never"
     const configured = readFileSync(configPath, "utf8");
     assert.match(configured, /# BEGIN codex-router-managed/);
     assert.match(configured, /# BEGIN codex-router-provider-managed/);
-    assert.match(configured, /# BEGIN codex-router-agent-concurrency-managed/);
-    assert.match(configured, /max_concurrent_threads_per_session = 6/);
+    assert.match(configured, /# BEGIN codex-router-multi-agent-v2-managed/);
+    assert.match(
+      configured,
+      /multi_agent_v2 = \{ enabled = true, max_concurrent_threads_per_session = 6, expose_spawn_agent_model_overrides = true \}/,
+    );
+    assert.doesNotMatch(configured, /codex-router-agent-concurrency-managed/);
+    assert.doesNotMatch(configured, /^max_concurrent_threads_per_session\s*=/m);
     assert.doesNotMatch(configured, /\[agents\]/);
     assert.match(configured, /\[model_providers\.codex-router\]/);
     assert.match(configured, /wire_api = "responses"/);
@@ -141,7 +167,7 @@ approval_policy = "never"
     const restored = readFileSync(configPath, "utf8");
     assert.doesNotMatch(
       restored,
-      /codex-router-(?:(?:provider|agent-concurrency)-)?managed|codex-router-created-agents-table|openai_base_url|model_catalog_json|experimental_realtime_(?:webrtc_call|ws)_base_url/,
+      /codex-router-(?:(?:provider|agent-concurrency|multi-agent-v2)-)?managed|codex-router-created-agents-table|openai_base_url|model_catalog_json|experimental_realtime_(?:webrtc_call|ws)_base_url/,
     );
     assert.doesNotMatch(restored, /\[agents\]|max_concurrent_threads_per_session/);
     assert.match(restored, /model = "gpt-5\.6-sol"/);
@@ -198,17 +224,18 @@ model_reasoning_effort = "high"
   );
 
   try {
-    run("enable", codexHome);
+    run("enable", codexHome, undefined, [], { CODEX_BIN: scalarOnlyCodex });
     const enabled = readFileSync(configPath, "utf8");
     assert.equal((enabled.match(/^\[agents\]$/gm) || []).length, 1);
     assert.match(enabled, /^max_concurrent_threads_per_session = 6$/m);
     assert.match(enabled, /^default_subagent_model = "gpt-5\.6-terra"$/m);
+    assert.doesNotMatch(enabled, /codex-router-multi-agent-v2-managed/);
     assert.ok(
       enabled.indexOf("max_concurrent_threads_per_session = 6") <
         enabled.indexOf("[agents]"),
     );
 
-    run("disable", codexHome);
+    run("disable", codexHome, undefined, [], { CODEX_BIN: scalarOnlyCodex });
     const restored = readFileSync(configPath, "utf8");
     assert.match(restored, /^\[agents\]$/m);
     assert.match(restored, /^default_subagent_model = "gpt-5\.6-terra"$/m);
@@ -253,6 +280,7 @@ test("config manager skips the agents scalar when the codex binary rejects it", 
     run("enable", codexHome, undefined, [], { CODEX_BIN: scalarRejectingCodex });
     const enabled = readFileSync(configPath, "utf8");
     assert.doesNotMatch(enabled, /codex-router-agent-concurrency-managed/);
+    assert.doesNotMatch(enabled, /codex-router-multi-agent-v2-managed/);
     assert.doesNotMatch(enabled, /^\[agents\]$/m);
     assert.match(enabled, /# BEGIN codex-router-managed/);
 
@@ -263,16 +291,49 @@ test("config manager skips the agents scalar when the codex binary rejects it", 
   }
 });
 
-test("config manager keeps writing the agents scalar when the codex binary accepts it", () => {
+test("config manager keeps writing the agents scalar when the codex binary lacks v2 support", () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-lenient-schema-"));
   const configPath = path.join(codexHome, "config.toml");
   writeFileSync(configPath, `model = "gpt-5.5"\n`, { mode: 0o600 });
 
   try {
-    run("enable", codexHome, undefined, [], { CODEX_BIN: scalarAcceptingCodex });
+    run("enable", codexHome, undefined, [], { CODEX_BIN: scalarOnlyCodex });
     const enabled = readFileSync(configPath, "utf8");
     assert.match(enabled, /codex-router-agent-concurrency-managed/);
     assert.match(enabled, /^max_concurrent_threads_per_session = 6$/m);
+    assert.doesNotMatch(enabled, /codex-router-multi-agent-v2-managed/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager enables multi_agent_v2 and skips the legacy agents scalar when supported", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-v2-feature-"));
+  const configPath = path.join(codexHome, "config.toml");
+  writeFileSync(configPath, `model = "gpt-5.5"\n`, { mode: 0o600 });
+
+  try {
+    run("enable", codexHome);
+    const enabled = readFileSync(configPath, "utf8");
+    assert.match(enabled, /# BEGIN codex-router-multi-agent-v2-managed/);
+    assert.match(
+      enabled,
+      /multi_agent_v2 = \{ enabled = true, max_concurrent_threads_per_session = 6, expose_spawn_agent_model_overrides = true \}/,
+    );
+    assert.doesNotMatch(enabled, /codex-router-agent-concurrency-managed/);
+    assert.doesNotMatch(enabled, /^max_concurrent_threads_per_session\s*=/m);
+
+    run("enable", codexHome);
+    const reenabled = readFileSync(configPath, "utf8");
+    assert.equal(
+      (reenabled.match(/# BEGIN codex-router-multi-agent-v2-managed/g) || []).length,
+      1,
+    );
+
+    run("disable", codexHome);
+    const restored = readFileSync(configPath, "utf8");
+    assert.doesNotMatch(restored, /codex-router-multi-agent-v2-managed|multi_agent_v2/);
+    assert.equal(restored.trimStart(), `model = "gpt-5.5"\n`);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -9,6 +9,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  hostedSearchEnabledFor,
   mergeHostedSearchTools,
   toResponsesRequest,
 } from "../src/grok-oauth-forwarder.mjs";
@@ -309,6 +310,36 @@ test("mergeHostedSearchTools can be disabled", () => {
   );
 });
 
+test("mergeHostedSearchTools drops repeated function names", () => {
+  assert.deepEqual(
+    mergeHostedSearchTools(
+      [
+        { type: "function", name: "file_write", description: "native", parameters: { type: "object" }, strict: false },
+        { type: "function", name: "file_write", description: "collab", parameters: { type: "object" }, strict: false },
+        { type: "function", name: "bash", parameters: { type: "object" }, strict: false },
+      ],
+      { enabled: false },
+    ),
+    [
+      { type: "function", name: "file_write", description: "native", parameters: { type: "object" }, strict: false },
+      { type: "function", name: "bash", parameters: { type: "object" }, strict: false },
+    ],
+  );
+});
+
+test("toResponsesRequest sends each duplicated tool name upstream once", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.5",
+    messages: [{ role: "user", content: "write a file" }],
+    tools: [
+      { type: "function", function: { name: "file_write", parameters: { type: "object" } } },
+      { type: "function", function: { name: "file_write", parameters: { type: "object" } } },
+    ],
+  });
+  const fileWrites = request.tools.filter((tool) => tool.name === "file_write");
+  assert.equal(fileWrites.length, 1);
+});
+
 test("toResponsesRequest always includes hosted search tools when enabled", () => {
   const request = toResponsesRequest({
     model: "grok-4.5",
@@ -320,4 +351,62 @@ test("toResponsesRequest always includes hosted search tools when enabled", () =
   assert.equal(request.tools.some((tool) => tool.type === "x_search"), true);
   assert.equal(request.tools.some((tool) => tool.type === "web_search"), true);
   assert.equal(request.tools.some((tool) => tool.name === "bash"), true);
+});
+
+test("toResponsesRequest omits hosted search tools when disabled", () => {
+  const request = toResponsesRequest(
+    {
+      model: "grok-4.5",
+      messages: [{ role: "user", content: "latest from X?" }],
+      tools: [
+        { type: "function", function: { name: "bash", parameters: { type: "object" } } },
+      ],
+    },
+    { hostedSearchEnabled: false },
+  );
+  assert.equal(request.tools.some((tool) => tool.type === "x_search"), false);
+  assert.equal(request.tools.some((tool) => tool.type === "web_search"), false);
+  assert.equal(request.tools.some((tool) => tool.name === "bash"), true);
+});
+
+test("hostedSearchEnabledFor follows the registry searchTool declaration", () => {
+  const models = [
+    {
+      provider: "grok-oauth",
+      upstreamModel: "grok-4.5",
+      searchTool: { mode: "hosted" },
+    },
+    { provider: "grok-oauth", upstreamModel: "grok-4.5-mini" },
+    { provider: "kimi-oauth", upstreamModel: "kimi-k3", searchTool: { mode: "hosted" } },
+  ];
+  assert.equal(hostedSearchEnabledFor("grok-4.5", models), true);
+  // No declaration means conservative plain function calling.
+  assert.equal(hostedSearchEnabledFor("grok-4.5-mini", models), false);
+  // Another provider's declaration must not leak into this forwarder.
+  assert.equal(hostedSearchEnabledFor("kimi-k3", models), false);
+});
+
+test("hostedSearchEnabledFor covers the checked-in Grok OAuth model", () => {
+  assert.equal(hostedSearchEnabledFor("grok-4.5"), true);
+});
+
+test("toResponsesRequest preserves the client's image detail level", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.5",
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "what is in this screenshot?" },
+          { type: "image_url", image_url: { url: "data:image/png;base64,AAAA", detail: "high" } },
+          { type: "image_url", image_url: { url: "data:image/png;base64,BBBB" } },
+        ],
+      },
+    ],
+  });
+  const images = request.input[0].content.filter((part) => part.type === "input_image");
+  assert.equal(images.length, 2);
+  assert.equal(images[0].detail, "high");
+  // Absent detail must stay absent, not default to a resolution choice.
+  assert.equal("detail" in images[1], false);
 });

--- a/test/native-redirect.test.mjs
+++ b/test/native-redirect.test.mjs
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
+import { privateFileIsProtected } from "../src/file-security.mjs";
+
 const stateDir = mkdtempSync(path.join(os.tmpdir(), "native-redirect-test-"));
 process.env.CODEX_ROUTER_STATE_DIR = stateDir;
 
@@ -26,7 +28,11 @@ test("native redirect round-trips through protected state", () => {
     path: NATIVE_REDIRECT_PATH,
   });
   assert.equal(readNativeRedirect(), "grok-oauth/grok-4.5");
-  assert.equal(statSync(NATIVE_REDIRECT_PATH).mode & 0o777, 0o600);
+  assert.equal(privateFileIsProtected(NATIVE_REDIRECT_PATH), true);
+  // Windows protects private files with ACLs, not POSIX modes.
+  if (process.platform !== "win32") {
+    assert.equal(statSync(NATIVE_REDIRECT_PATH).mode & 0o777, 0o600);
+  }
 
   clearNativeRedirect();
   assert.equal(readNativeRedirect(), undefined);

--- a/test/native-redirect.test.mjs
+++ b/test/native-redirect.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "native-redirect-test-"));
+process.env.CODEX_ROUTER_STATE_DIR = stateDir;
+
+const {
+  NATIVE_REDIRECT_PATH,
+  clearNativeRedirect,
+  nativeRedirectSnapshot,
+  readNativeRedirect,
+  setNativeRedirect,
+} = await import("../src/native-redirect.mjs");
+
+test("native redirect defaults to unset", () => {
+  assert.equal(readNativeRedirect(), undefined);
+  assert.deepEqual(nativeRedirectSnapshot(), { model: null, path: NATIVE_REDIRECT_PATH });
+});
+
+test("native redirect round-trips through protected state", () => {
+  assert.deepEqual(setNativeRedirect("grok-oauth/grok-4.5"), {
+    model: "grok-oauth/grok-4.5",
+    path: NATIVE_REDIRECT_PATH,
+  });
+  assert.equal(readNativeRedirect(), "grok-oauth/grok-4.5");
+  assert.equal(statSync(NATIVE_REDIRECT_PATH).mode & 0o777, 0o600);
+
+  clearNativeRedirect();
+  assert.equal(readNativeRedirect(), undefined);
+});
+
+test("native redirect rejects an empty slug", () => {
+  assert.throws(() => setNativeRedirect(""), /routed model slug is required/);
+  assert.throws(() => setNativeRedirect("   "), /routed model slug is required/);
+});
+
+test("native redirect ignores an unusable state file", () => {
+  writeFileSync(NATIVE_REDIRECT_PATH, "{ not json", "utf8");
+  assert.equal(readNativeRedirect(), undefined);
+
+  writeFileSync(NATIVE_REDIRECT_PATH, JSON.stringify({ version: 2, model: "kimi-oauth/k3" }), "utf8");
+  assert.equal(readNativeRedirect(), undefined);
+
+  writeFileSync(NATIVE_REDIRECT_PATH, JSON.stringify({ version: 1, model: "  " }), "utf8");
+  assert.equal(readNativeRedirect(), undefined);
+  clearNativeRedirect();
+});

--- a/test/presence-state.test.mjs
+++ b/test/presence-state.test.mjs
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
+import { privateFileIsProtected } from "../src/file-security.mjs";
+
 const stateDir = mkdtempSync(path.join(os.tmpdir(), "presence-state-test-"));
 process.env.CODEX_ROUTER_STATE_DIR = stateDir;
 
@@ -30,7 +32,11 @@ test("presence round-trips through protected state", () => {
   });
   assert.equal(readPresenceMode(), PRESENCE_FOLLOW_CODEX);
   assert.equal(serviceFollowsHostApps(), true);
-  assert.equal(statSync(PRESENCE_STATE_PATH).mode & 0o777, 0o600);
+  assert.equal(privateFileIsProtected(PRESENCE_STATE_PATH), true);
+  // Windows protects private files with ACLs, not POSIX modes.
+  if (process.platform !== "win32") {
+    assert.equal(statSync(PRESENCE_STATE_PATH).mode & 0o777, 0o600);
+  }
 
   setPresenceMode(PRESENCE_ALWAYS);
   assert.equal(serviceFollowsHostApps(), false);

--- a/test/provider-key.test.mjs
+++ b/test/provider-key.test.mjs
@@ -7,11 +7,18 @@ import test from "node:test";
 
 // provider-key.mjs is a CLI entry that validates process.argv at module
 // evaluation time (and exits when the arguments are missing), so give it a
-// valid invocation before importing it.
+// valid invocation before importing it. The status command sets a non-zero
+// exit code when the key is absent, which would fail this whole test file on
+// machines without an opencode credential, so supply one via the environment.
 const savedArgv = [...process.argv];
+const savedEnvKey = process.env.OPENCODE_GO_API_KEY;
 process.argv = [process.argv[0], "provider-key.mjs", "opencode-go", "status"];
+process.env.OPENCODE_GO_API_KEY = "test-only-placeholder";
 const { WINDOWS_HIDDEN_PROMPT_SCRIPT } = await import("../src/provider-key.mjs");
 process.argv = savedArgv;
+if (savedEnvKey === undefined) delete process.env.OPENCODE_GO_API_KEY;
+else process.env.OPENCODE_GO_API_KEY = savedEnvKey;
+process.exitCode = 0;
 
 test("the Windows hidden-prompt script is structurally valid PowerShell", () => {
   // Joining the script pieces with "; " must not split `try { }` from

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -151,6 +151,55 @@ test("provider registry exposes configured API and OAuth model families", () => 
       { effort: "high", description: "Always-on coding reasoning" },
     ]);
   }
+  // K3 documents low/high/max regardless of gateway; the opencode Go relay
+  // forwards reasoning_effort, so it carries the same ladder and profile as
+  // the direct Moonshot entry.
+  for (const slug of ["opencode-go/kimi-k3", "commandcode/kimi-k3"]) {
+    const k3 = MODEL_BY_SLUG.get(slug);
+    assert.deepEqual(
+      k3.reasoningLevels.map((level) => level.effort),
+      ["low", "high", "max"],
+      slug,
+    );
+    assert.equal(k3.defaultEffort, "max", slug);
+    assert.equal(k3.requestProfile, "kimi-k3", slug);
+  }
+  // Hosted search is an xAI-backend behavior, so only the Grok OAuth slug may
+  // declare it; every other search-capable path waits on the router-side
+  // emulated executor.
+  assert.deepEqual(MODEL_BY_SLUG.get("grok-oauth/grok-4.5").searchTool, {
+    mode: "hosted",
+  });
+  for (const model of MODELS) {
+    if (model.slug === "grok-oauth/grok-4.5") continue;
+    assert.equal(model.searchTool, undefined, model.slug);
+  }
+  // Original-detail images are declared per slug on canonical vision
+  // flagships only; gateway variants stay conservative until each relay is
+  // probed live.
+  const originalDetailSlugs = MODELS.filter(
+    (model) => model.supportsImageDetailOriginal === true,
+  ).map((model) => model.slug);
+  assert.deepEqual(originalDetailSlugs.sort(), [
+    "anthropic-api/claude-opus-4.8",
+    "grok-api/grok-4.5",
+    "grok-oauth/grok-4.5",
+    "kimi-api/kimi-k3",
+    "kimi-oauth/k3",
+    "kimi-oauth/kimi-for-coding",
+    "kimi-oauth/kimi-for-coding-highspeed",
+    "minimax-token-plan/minimax-m3",
+    "qwen-plan/qwen3.6-flash",
+    "qwen-plan/qwen3.7-max",
+    "qwen-plan/qwen3.8-max",
+    "qwen-plan/qwen3.8-max-preview",
+  ]);
+  for (const slug of originalDetailSlugs) {
+    assert.ok(
+      MODEL_BY_SLUG.get(slug).inputModalities.includes("image"),
+      `${slug} declares original image detail without image input`,
+    );
+  }
   const minimax = MODEL_BY_SLUG.get("minimax-token-plan/minimax-m3");
   assert.equal(minimax.contextWindow, 1_000_000);
   assert.equal(minimax.autoCompact, 900_000);

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -2069,3 +2069,88 @@ test("router strips empty text parts and drops the messages left with nothing", 
     await closeServer(native.server);
   }
 });
+
+test("router redirects native background turns to the configured routed model", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, { route: "external" });
+  });
+  const routerPort = await openPort();
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-native-redirect-"));
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, "native-redirect.json"),
+    `${JSON.stringify({ version: 1, model: "kimi-oauth/k3" })}\n`,
+  );
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      // The shape Codex Desktop uses for background agent sessions: a native
+      // GPT slug the picker never chose.
+      body: JSON.stringify({ model: "gpt-5.6-luna", input: "background turn" }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal(gatewayRequests.at(-1).model, "kimi-oauth-k3");
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("native redirect falls back to native when the target cannot route", async () => {
+  const nativeRequests = [];
+  const native = await mockServer(async (request, response) => {
+    nativeRequests.push(await bodyJson(request));
+    json(response, 200, { route: "native" });
+  });
+  const routerPort = await openPort();
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-native-redirect-off-"));
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true });
+  // A redirect target that is not in the registry must leave native traffic
+  // untouched instead of failing the request.
+  writeFileSync(
+    path.join(stateDir, "native-redirect.json"),
+    `${JSON.stringify({ version: 1, model: "not-a-registered/model" })}\n`,
+  );
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: "http://127.0.0.1:9/v1",
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: "gpt-5.6-luna", input: "background turn" }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal(nativeRequests.at(-1).model, "gpt-5.6-luna");
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -120,6 +120,17 @@ test("registry merges valid user models and skips collisions", async () => {
       ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-blank-nux", priority: 103 }),
       availabilityNux: "   ",
     },
+    // Only the implemented "hosted" search mode may be declared; anything
+    // else would advertise a search the request path cannot serve.
+    {
+      ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-bad-search", priority: 106 }),
+      searchTool: { mode: "emulated" },
+    },
+    // Capability toggles are booleans; a truthy string must not slip through.
+    {
+      ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-bad-detail", priority: 107 }),
+      supportsImageDetailOriginal: "yes",
+    },
     // An upgrade prompt pointing at a slug the merged registry does not carry
     // can never render, so the entry is skipped.
     {
@@ -139,6 +150,8 @@ test("registry merges valid user models and skips collisions", async () => {
   assert.equal(slugs.filter((slug) => slug === "deepseek/deepseek-v4-pro").length, 1);
   assert.ok(!slugs.includes("no-such-provider/x-model"));
   assert.ok(!slugs.includes("deepseek/deepseek-blank-nux"));
+  assert.ok(!slugs.includes("deepseek/deepseek-bad-search"));
+  assert.ok(!slugs.includes("deepseek/deepseek-bad-detail"));
   assert.ok(!slugs.includes("deepseek/deepseek-bad-upgrade"));
   assert.deepEqual(
     registry.MODEL_BY_SLUG.get("deepseek/deepseek-good-upgrade").upgradeTo,


### PR DESCRIPTION
## Root cause (issue #72, and half of #82)

Codex Desktop runs background agent sessions — memory extraction, review passes, and similar utility work — on a hardcoded native GPT model, ignoring the model picker entirely. Captured on a live install with a diagnostic tap on the router:

- Full agent turns (complete Codex system prompt, tools, `tool_choice: auto`) posted to `gpt-5.6-luna` and `gpt-5.6-terra` in fresh ephemeral sessions, minutes after the user's last message.
- **10,649** such calls in one machine's usage log; none ever carried parsed token usage.
- With OpenAI quota exhausted, every one 429s and the features they power silently die — while the picked model keeps answering normally. This is exactly the symptom reported in #72.

What routes correctly (verified live): ordinary chat turns and tool calling on the selected model — a Grok session running `ls` produced two `grok-oauth/grok-4.5` calls and zero GPT traffic.

## The fix

`control native-redirect status|set <routed-slug>|clear` — opt-in. When set, any native-model turn reaching the router is dispatched to the configured routed model. Deliberately all-or-nothing: the background turns carry no reliable marker distinguishing them from a deliberately picked GPT model, and the users who opt in are the ones with no native quota left to protect. A target that is unknown or whose provider is hidden leaves the turn native, so a stale setting can never trade a quota failure for a routing error. The router's own encrypted-payload relay bypasses the lookup by construction.

## Companion commits

This branch also carries three commits that landed during live dogfooding:

- `fd5d372` — fix `control picker all` argument parsing
- `13173b5` — enable Codex `multi_agent_v2` for routed subagents (#82)
- `a26aa28` — expose collaboration tools on routed chat models

Notably, `13173b5`/`a26aa28` were produced by Codex background agents running **through this PR's redirect** on a routed model — the machinery this PR un-breaks is what authored the follow-up work.

## Test plan

- [x] 306 tests pass, 0 fail (`node --test test/*.test.mjs`), syntax checks clean
- [x] New: `test/native-redirect.test.mjs` (state round-trip, rejection, corrupt-file fallback)
- [x] New routing tests: native background turn dispatches to the gateway as the configured routed model; unroutable target falls back to native untouched
- [x] New: `test/collaboration-namespace.test.mjs` for the collaboration tool exposure
- [x] Live verification: redirect deployed on a working install with exhausted OpenAI quota — **45 minutes with zero native GPT events** (previous cadence: one every 30–40 min), background turns serving 200s on `grok-oauth/grok-4.5`

### Not covered

- The redirect is Responses-endpoint only; native image generation (`gpt-image-2`) is untouched by design.
- Suggest letting this dogfood on a live install for a day before merging — it changes request routing for every opted-in install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Capability follow-ups (added 2026-08-07)

Three more commits from the same dogfooding session:

- `de3b588` — **feat(catalog): registry-driven search tool and image detail capabilities.** Routed models now advertise `supports_search_tool` and `supports_image_detail_original` from their registry entry instead of hardcoding both off. The registry validates the new fields (`searchTool` only accepts the implemented `{ "mode": "hosted" }` shape; `supportsImageDetailOriginal` must be a boolean). `providers.json` opts in vision-capable curated models, enables image input where the upstream supports it, adds low/high reasoning levels for opencode-go Kimi K3, and bumps affected compHashes.
- `684e0ee` — **fix(grok): gate hosted search per model, forward image detail, dedupe tools.** Hosted web/x search now attaches only when the registry model resolving to the upstream id declares it; image parts keep the client's `detail` level; duplicate client function names are deduped (xAI rejects requests with repeated definitions).
- `4f1325b` — **fix(test): make provider-key status import deterministic on CI.** This is the cause of the red CI on main (all three OS jobs since #69): the test imports the provider-key CLI, whose `status` command sets a non-zero exit code on machines without a stored opencode key — every CI runner. Verified by reproducing exit 1 at a clean HEAD with a scrubbed HOME, exit 0 with the fix.

Updated test plan:
- [x] 310 tests, 306 pass, 0 fail, 4 skipped (`npm test`)
- [x] New catalog/registry tests: capability defaults stay off, invalid `searchTool` mode and non-boolean detail flag reject the entry (curated and user models)
- [x] New forwarder tests: per-model hosted search gating, image detail passthrough, duplicate function dedupe
