### PR TITLE
fix(desktop): disable WebKit DMA-BUF renderer only on proprietary NVIDIA driver

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -60,6 +60,16 @@ impl Default for DesktopSettings {
 }
 
 fn main() {
+    // WebKitGTK's accelerated compositor crashes inside the NVIDIA EGL driver
+    // (SIGSEGV in libnvidia-eglcore.so on the SkiaGPUWorker thread) when the
+    // tray webviews are shown. Force the software compositor on Linux so the
+    // panel renders reliably on NVIDIA and other GPU stacks.
+    #[cfg(target_os = "linux")]
+    {
+        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
+        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
             platform_info,
@@ -104,6 +114,13 @@ fn main() {
             });
 
             install_tray(app)?;
+
+            // Verification aid: open the panel on startup when requested. Lets a
+            // smoke test exercise the exact window-show path that historically
+            // crashed WebKitGTK's GPU worker on NVIDIA.
+            if std::env::var_os("CODEX_ROUTER_SHOW_PANEL").is_some() {
+                let _ = show_panel_window(app.handle());
+            }
 
             if should_show_island {
                 show_island_window(app.handle(), false)?;

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -59,16 +59,37 @@ impl Default for DesktopSettings {
     }
 }
 
-fn main() {
-    // WebKitGTK's accelerated compositor crashes inside the NVIDIA EGL driver
-    // (SIGSEGV in libnvidia-eglcore.so on the SkiaGPUWorker thread) when the
-    // tray webviews are shown. Force the software compositor on Linux so the
-    // panel renders reliably on NVIDIA and other GPU stacks.
-    #[cfg(target_os = "linux")]
-    {
-        std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
-        std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+/// Returns whether WebKitGTK's DMA-BUF renderer should be disabled.
+///
+/// The renderer shares GPU buffers with the Wayland compositor (Hyprland,
+/// GNOME, ...) through the graphics driver. With the proprietary NVIDIA kernel
+/// driver that handoff segfaults inside libnvidia-eglcore.so on the
+/// SkiaGPUWorker thread as soon as a webview is shown, taking the tray app
+/// down. Mesa drivers (AMD, Intel, NVK) do not crash, so only NVIDIA disables
+/// the renderer; WebKit then falls back to wl_shm and keeps accelerated
+/// compositing. CODEX_ROUTER_WEBKIT_DMABUF forces the renderer on ("1"/"true")
+/// or off ("0"/"false") regardless of the detected driver.
+#[cfg(target_os = "linux")]
+fn dmabuf_renderer_disabled(override_value: Option<&str>, nvidia_driver_present: bool) -> bool {
+    match override_value {
+        Some("1") | Some("true") => false,
+        Some("0") | Some("false") => true,
+        _ => nvidia_driver_present,
     }
+}
+
+#[cfg(target_os = "linux")]
+fn apply_webkit_workarounds() {
+    let nvidia_driver_present = Path::new("/proc/driver/nvidia/version").exists();
+    let override_value = env::var("CODEX_ROUTER_WEBKIT_DMABUF").ok();
+    if dmabuf_renderer_disabled(override_value.as_deref(), nvidia_driver_present) {
+        env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
+    }
+}
+
+fn main() {
+    #[cfg(target_os = "linux")]
+    apply_webkit_workarounds();
 
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
@@ -985,5 +1006,21 @@ mod tests {
     fn rejects_non_success_health_response() {
         let response = b"HTTP/1.1 503 Nope\r\n\r\n{}";
         assert!(parse_health_response(response).is_none());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn disables_dmabuf_renderer_only_with_nvidia() {
+        assert!(dmabuf_renderer_disabled(None, true));
+        assert!(!dmabuf_renderer_disabled(None, false));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn dmabuf_renderer_override_beats_detection() {
+        assert!(!dmabuf_renderer_disabled(Some("1"), true));
+        assert!(!dmabuf_renderer_disabled(Some("true"), true));
+        assert!(dmabuf_renderer_disabled(Some("0"), false));
+        assert!(dmabuf_renderer_disabled(Some("false"), false));
     }
 }

--- a/docs/DESKTOP-TRAY.md
+++ b/docs/DESKTOP-TRAY.md
@@ -101,3 +101,17 @@ provider selection is restored.
 Windows and Linux builds run in CI on every change. UI data shaping and chart
 behavior have platform-neutral Node tests, while the Rust tests cover provider
 validation, health parsing, and multi-monitor placement math.
+
+## Troubleshooting: WebKitGTK crashes on NVIDIA
+
+On some Linux systems with the NVIDIA proprietary driver, showing the tray
+panel crashed WebKitGTK's GPU worker (SIGSEGV in `libnvidia-eglcore.so` on the
+`SkiaGPUWorker` thread), which also took down the tray app. The companion now
+forces WebKit's software compositor on Linux by setting
+`WEBKIT_DISABLE_COMPOSITING_MODE=1` and `WEBKIT_DISABLE_DMABUF_RENDERER=1`
+before the webviews are created. The panel is small, so software rendering has
+no visible impact.
+
+To reproduce the exact window-show path in a smoke test, start the binary with
+`CODEX_ROUTER_SHOW_PANEL=1`; the panel opens on startup instead of waiting for
+a tray interaction.

--- a/docs/DESKTOP-TRAY.md
+++ b/docs/DESKTOP-TRAY.md
@@ -104,13 +104,19 @@ validation, health parsing, and multi-monitor placement math.
 
 ## Troubleshooting: WebKitGTK crashes on NVIDIA
 
-On some Linux systems with the NVIDIA proprietary driver, showing the tray
-panel crashed WebKitGTK's GPU worker (SIGSEGV in `libnvidia-eglcore.so` on the
-`SkiaGPUWorker` thread), which also took down the tray app. The companion now
-forces WebKit's software compositor on Linux by setting
-`WEBKIT_DISABLE_COMPOSITING_MODE=1` and `WEBKIT_DISABLE_DMABUF_RENDERER=1`
-before the webviews are created. The panel is small, so software rendering has
-no visible impact.
+WebKitGTK's DMA-BUF renderer shares GPU buffers with the Wayland compositor
+(Hyprland, GNOME, KDE, ...) through the graphics driver. With the proprietary
+NVIDIA kernel driver that handoff crashed (SIGSEGV in `libnvidia-eglcore.so`
+on the `SkiaGPUWorker` thread) as soon as the tray panel was shown, which also
+took down the tray app.
+
+The companion now detects the proprietary NVIDIA kernel driver via
+`/proc/driver/nvidia/version` and disables only the DMA-BUF renderer
+(`WEBKIT_DISABLE_DMABUF_RENDERER=1`) before the webviews are created, falling
+back to `wl_shm`. Accelerated compositing stays enabled, and non-NVIDIA
+systems keep the DMA-BUF fast path. Set `CODEX_ROUTER_WEBKIT_DMABUF=1` to
+force the renderer back on (for example after a driver update fixes the
+crash) or `CODEX_ROUTER_WEBKIT_DMABUF=0` to force it off on any system.
 
 To reproduce the exact window-show path in a smoke test, start the binary with
 `CODEX_ROUTER_SHOW_PANEL=1`; the panel opens on startup instead of waiting for


### PR DESCRIPTION
## Problem

On Linux with the proprietary NVIDIA driver, the desktop tray dies the moment a webview window is shown: `WebKitWebProcess` segfaults in `libnvidia-eglcore.so` on the `SkiaGPUWorker` thread, taking the tray app with it.

## Root cause

Confirmed by A/B testing: WebKitGTK's DMA-BUF renderer hands GPU buffers to the Wayland compositor (Hyprland / GNOME / KDE) through the NVIDIA driver, and that handoff segfaults inside the driver on first show.

## Fix

Minimal and gated — `apps/desktop/src-tauri/src/main.rs`:

- Set only `WEBKIT_DISABLE_DMABUF_RENDERER=1`, and only when the proprietary NVIDIA kernel driver is detected (`/proc/driver/nvidia/version`).
- Accelerated compositing stays on; WebKit falls back to `wl_shm`. Mesa (AMD / Intel / NVK) keeps the DMA-BUF fast path.
- `CODEX_ROUTER_WEBKIT_DMABUF=1/0` forces the renderer on/off regardless of detection (e.g. to reclaim DMA-BUF after a driver fix).
- Adds `CODEX_ROUTER_SHOW_PANEL=1` startup hook to exercise the exact window-show path in smoke tests.

Docs updated in `docs/DESKTOP-TRAY.md`.

## Tests

- 2 new unit tests for the gating logic — 7/7 pass; `npm run check` clean.

## Verification

Hyprland 0.56 + NVIDIA 610.43.03 (RTX 5090), driving `CODEX_ROUTER_SHOW_PANEL=1`:

| Scenario | Result |
| --- | --- |
| No workaround | Crash — `WebKitWebProcess` SIGSEGV coredump |
| Detection active (no env) | Alive, no coredump |
| `CODEX_ROUTER_WEBKIT_DMABUF=1` (force GPU) | Crash — proves the gate controls it |
| `CODEX_ROUTER_WEBKIT_DMABUF=0` | Alive, no coredump |
