### PR TITLE
fix(gemini-api): strip unsupported thinking/think params before forwarding

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -281,8 +281,18 @@ function normalizeBody(buffer, contentType, route) {
   }
 
   payload.model = model.upstreamModel;
-  // Gemini has no OpenAI-shaped web search parameter and 400s on the field.
-  if (isGeminiProvider(provider)) delete payload.web_search_options;
+  // Google's OpenAI-compatible endpoint (/v1beta/openai/chat/completions)
+  // rejects any field outside the OpenAI schema with a hard 400
+  // (INVALID_ARGUMENT: Unknown name "..."). Two such fields reach this hop for
+  // Gemini: web_search_options, and the thinking/think reasoning controls that
+  // upstream reasoning translation attaches for Gemini 3.x thinking models.
+  // Left in place the 400 surfaces as a misleading native-ChatGPT fallback
+  // error rather than a routing failure, so strip them before forwarding.
+  if (isGeminiProvider(provider)) {
+    delete payload.web_search_options;
+    delete payload.thinking;
+    delete payload.think;
+  }
   if (Array.isArray(payload.messages)) {
     payload.messages = sanitizeChatToolHistory(payload.messages, provider);
   }

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -1152,6 +1152,8 @@ test("API forwarder fills only missing Gemini thought signatures", async () => {
       body: JSON.stringify({
         model: curated.gatewayModel,
         web_search_options: { search_context_size: "medium" },
+        thinking: { type: "enabled" },
+        think: true,
         messages: [
           { role: "user", content: "test" },
           {
@@ -1174,8 +1176,11 @@ test("API forwarder fills only missing Gemini thought signatures", async () => {
     assert.equal(response.status, 200);
     const body = upstreamRequests[0];
     assert.equal(body.model, "gemini-3.5-flash");
-    // Gemini rejects the OpenAI-shaped web search parameter outright.
+    // Google's OpenAI-compatible endpoint 400s on any non-OpenAI field, so the
+    // web search and thinking/think reasoning controls are stripped outright.
     assert.equal(body.web_search_options, undefined);
+    assert.equal(body.thinking, undefined);
+    assert.equal(body.think, undefined);
     const [signed, bare] = body.messages.find((message) => message.role === "assistant").tool_calls;
     // A signature Gemini already returned must survive untouched.
     assert.equal(signed.thought_signature, "real-upstream-signature");


### PR DESCRIPTION
## Root cause

Curated Gemini models route through LiteLLM → the api-forwarder → Google's OpenAI-compatible endpoint (`/v1beta/openai/chat/completions`). That endpoint 400s on **any** field outside the OpenAI schema (`INVALID_ARGUMENT: Unknown name "thinking"`). Upstream reasoning translation attaches `thinking`/`think` for Gemini 3.x thinking models, so the call fails — and because a 400 triggers Codex's native-ChatGPT fallback, the user sees a misleading `The 'gemini-api/models/gemini-3.1-pro' model is not supported when using Codex with a ChatGPT account.` instead of the real routing failure.

## Fix

Strip `thinking`/`think` at the Gemini forwarding boundary, alongside the existing `web_search_options` strip in `normalizeBody` — the one place codex-router already sanitizes Google-incompatible fields.

Scope kept surgical: penalties/`seed`/`store`/`logit_bias` are **not** stripped (Google's OpenAI surface accepts them; removing them would change sampling behavior), and image content parts are **not** rewritten (handled by the in-progress vision-bridge work).

## Tests

Existing Gemini forwarder test extended to send `thinking`/`think` and assert both are stripped upstream. Full suite: 428 pass / 0 fail / 5 skipped.

Supersedes the `thinking`/`think` portion of #89.