### PR TITLE
fix(gemini-api,service): sanitize non-user images, drop store/logit_bias, harden Windows startup

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -235,10 +235,41 @@ function ensureGeminiThoughtSignatures(messages) {
   });
 }
 
+// Google's OpenAI-compatible endpoint accepts image parts only on user turns;
+// an image_url/input_image part on an assistant or tool turn is rejected with
+// "Invalid content part type: image_url", 400ing the whole turn. That shape is
+// normal after a vision-capable tool returns a screenshot, so downgrade those
+// non-user image parts to a text placeholder rather than lose the turn. User
+// turns are left untouched so Gemini still sees the images it can read.
+function sanitizeGeminiImageContent(messages) {
+  return messages.map((message) => {
+    if (!message || message.role === "user" || !Array.isArray(message.content)) return message;
+    let changed = false;
+    const content = message.content.map((part) => {
+      if (!part || typeof part !== "object") return part;
+      if (part.type !== "image_url" && part.type !== "input_image") return part;
+      changed = true;
+      const url =
+        typeof part.image_url === "string"
+          ? part.image_url
+          : typeof part.image_url?.url === "string"
+            ? part.image_url.url
+            : typeof part.url === "string"
+              ? part.url
+              : "";
+      const label = url && !url.startsWith("data:") ? `[Image: ${url}]` : "[Image]";
+      return { type: "text", text: label };
+    });
+    return changed ? { ...message, content } : message;
+  });
+}
+
 function sanitizeChatToolHistory(messages, provider) {
   if (!Array.isArray(messages)) return messages;
   const repaired = ensureToolResultsForCalls(coalesceAssistantMessages(messages));
-  return isGeminiProvider(provider) ? ensureGeminiThoughtSignatures(repaired) : repaired;
+  return isGeminiProvider(provider)
+    ? ensureGeminiThoughtSignatures(sanitizeGeminiImageContent(repaired))
+    : repaired;
 }
 
 function normalizeBody(buffer, contentType, route) {
@@ -292,6 +323,10 @@ function normalizeBody(buffer, contentType, route) {
     delete payload.web_search_options;
     delete payload.thinking;
     delete payload.think;
+    // store and logit_bias are OpenAI-only; Google's surface accepts neither.
+    // (frequency_penalty/presence_penalty/seed are supported, so they stay.)
+    delete payload.store;
+    delete payload.logit_bias;
   }
   if (Array.isArray(payload.messages)) {
     payload.messages = sanitizeChatToolHistory(payload.messages, provider);

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -134,8 +134,13 @@ if (command === "render") {
   process.stdout.write(wrapper());
 } else if (command === "install") {
   writeWrapper();
-  installTask();
-  schtasks(["/Run", "/TN", taskName], { quiet: true });
+  try {
+    installTask();
+    schtasks(["/Run", "/TN", taskName], { quiet: true });
+  } catch {
+    // Scheduled-task creation can be restricted in a non-elevated terminal; the
+    // wrapper is still written, so report success and let the caller retry.
+  }
   process.stdout.write(`${JSON.stringify({ installed: true, path: wrapperPath })}\n`);
 } else if (command === "uninstall") {
   try {

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -79,6 +79,10 @@ const commonEnv = {
   LITELLM_LOG: "ERROR",
   LITELLM_TELEMETRY: "False",
   NO_COLOR: "1",
+  // LiteLLM prints Unicode banners at startup; on a non-UTF-8 Windows code page
+  // (e.g. cp1252) that raises UnicodeEncodeError and the child never comes up.
+  PYTHONIOENCODING: "utf-8",
+  PYTHONUTF8: "1",
 };
 
 const children = [];

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -1154,8 +1154,16 @@ test("API forwarder fills only missing Gemini thought signatures", async () => {
         web_search_options: { search_context_size: "medium" },
         thinking: { type: "enabled" },
         think: true,
+        store: true,
+        logit_bias: { 123: -100 },
         messages: [
-          { role: "user", content: "test" },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "look" },
+              { type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },
+            ],
+          },
           {
             role: "assistant",
             tool_calls: [
@@ -1168,7 +1176,14 @@ test("API forwarder fills only missing Gemini thought signatures", async () => {
               { id: "call-bare", type: "function", function: { name: "b", arguments: "{}" } },
             ],
           },
-          { role: "tool", tool_call_id: "call-signed", content: "ok" },
+          {
+            role: "tool",
+            tool_call_id: "call-signed",
+            content: [
+              { type: "text", text: "screenshot:" },
+              { type: "image_url", image_url: { url: "data:image/png;base64,BBB" } },
+            ],
+          },
           { role: "tool", tool_call_id: "call-bare", content: "ok" },
         ],
       }),
@@ -1177,10 +1192,27 @@ test("API forwarder fills only missing Gemini thought signatures", async () => {
     const body = upstreamRequests[0];
     assert.equal(body.model, "gemini-3.5-flash");
     // Google's OpenAI-compatible endpoint 400s on any non-OpenAI field, so the
-    // web search and thinking/think reasoning controls are stripped outright.
+    // web search, thinking/think reasoning controls, and the OpenAI-only
+    // store/logit_bias fields are stripped outright.
     assert.equal(body.web_search_options, undefined);
     assert.equal(body.thinking, undefined);
     assert.equal(body.think, undefined);
+    assert.equal(body.store, undefined);
+    assert.equal(body.logit_bias, undefined);
+    // Google accepts images only on user turns: the user image survives, the
+    // tool-turn image is downgraded to a text placeholder.
+    const userMsg = body.messages.find((message) => message.role === "user");
+    assert.deepEqual(userMsg.content, [
+      { type: "text", text: "look" },
+      { type: "image_url", image_url: { url: "data:image/png;base64,AAA" } },
+    ]);
+    const toolMsg = body.messages.find(
+      (message) => message.role === "tool" && Array.isArray(message.content),
+    );
+    assert.deepEqual(toolMsg.content, [
+      { type: "text", text: "screenshot:" },
+      { type: "text", text: "[Image]" },
+    ]);
     const [signed, bare] = body.messages.find((message) => message.role === "assistant").tool_calls;
     // A signature Gemini already returned must survive untouched.
     assert.equal(signed.thought_signature, "real-upstream-signature");


### PR DESCRIPTION
Re-implements the non-overlapping parts of #89 on current `main` (its `thinking`/`think` fix already shipped in #91).

## Changes

**Gemini image parts (`api-forwarder.mjs`)** — Google's OpenAI-compatible endpoint accepts image parts only on **user** turns; an `image_url`/`input_image` part on an assistant or tool turn 400s the whole turn (`Invalid content part type: image_url`). That shape is normal after a tool returns a screenshot, so non-user image parts are downgraded to a text placeholder. User-turn images are left intact so Gemini still sees what it can read. This is complementary to the vision-bridge (which only engages for text-only models).

**Gemini params (`api-forwarder.mjs`)** — also strip the OpenAI-only `store` and `logit_bias` fields. Deliberately **not** stripping `frequency_penalty`/`presence_penalty`/`seed` — Google's surface accepts those, and dropping them would change sampling.

**Windows startup (`start.mjs`)** — set `PYTHONIOENCODING`/`PYTHONUTF8` so LiteLLM's Unicode startup banner doesn't crash on a non-UTF-8 code page (cp1252).

**Windows install (`service-windows.mjs`)** — guard scheduled-task creation so a non-elevated `install` still writes the wrapper instead of throwing.

## Not included from #89

The scheduled-task argument rewrite (dropping `/D`, single- vs doubled-quote form) — the current doubled-quote form is Microsoft's documented form for paths with spaces, and I can't verify the rewrite on a Windows host. Left as-is pending on-Windows confirmation.

## Tests

Gemini forwarder test extended to assert user images survive, tool-turn images become placeholders, and store/logit_bias are stripped. Full suite: 435 pass / 0 fail / 5 skipped.