### PR TITLE
fix(commandcode): shorten the plan hint to the requirement

### DIFF
--- a/config/commandcode/commandcode.json
+++ b/config/commandcode/commandcode.json
@@ -8,7 +8,7 @@
       "ownedBy": "commandcode",
       "baseUrl": "https://api.commandcode.ai/provider/v1",
       "baseUrlEnv": "COMMANDCODE_BASE_URL",
-      "planNote": "Needs the Command Code Provider plan. A Go, GOAT, Pro, or Max plan signs in successfully and is then refused with \"your plan doesn't include API access\" on every request.",
+      "planNote": "Needs the Command Code Provider plan.",
       "credential": {
         "environment": [
           "COMMAND_CODE_API_KEY",


### PR DESCRIPTION
## What

The Command Code plan note is inline UI — it prints under `providers enable`, in a `doctor` warning, and on the tray's setup card.

**Before:**
> Needs the Command Code Provider plan. A Go, GOAT, Pro, or Max plan signs in successfully and is then refused with "your plan doesn't include API access" on every request.

**After:**
> Needs the Command Code Provider plan.

Carrying the full failure story in three cramped UI surfaces buried the one thing the reader has to act on. The reasoning and the exact upstream error stay in [README.md](README.md) and [AGENTS.md](AGENTS.md), where there is room for them.

One line in `config/commandcode/commandcode.json`; all three surfaces read the same field.

## Test plan

- [x] `npm run check` and `npm test` — 399 pass / 0 fail
- [x] `the Provider plan requirement is stated wherever Command Code is connected` still passes — it asserts on "Provider plan", which the short form keeps