### PR TITLE
Say what is blocking an update, and offer a way past it

### DIFF
--- a/src/update.mjs
+++ b/src/update.mjs
@@ -21,9 +21,6 @@ function requireManagedCheckout() {
       "This release is not a Git checkout. Re-run the installation command to upgrade it.",
     );
   }
-  if (git(["status", "--porcelain"])) {
-    throw new Error("The checkout has local changes; refusing to replace them during update.");
-  }
   const origin = git(["remote", "get-url", "origin"]);
   const configured = process.env.CODEX_ROUTER_REPOSITORY_URL;
   const allowed = new Set([
@@ -35,6 +32,48 @@ function requireManagedCheckout() {
   if (!allowed.has(origin)) {
     throw new Error(`The origin remote is not a recognized Codex Router repository: ${origin}`);
   }
+}
+
+const DIRTY_PREVIEW_LIMIT = 10;
+
+// Only tracked edits are at stake. A fast-forward merge never replaces an
+// untracked file, and git refuses the rare collision on its own with a precise
+// message, so counting untracked files as "local changes" only ever stranded
+// people: one stray file in the checkout and every future update was refused,
+// with nothing in the error to say which file or how to get past it.
+export function localModifications() {
+  return git(["status", "--porcelain", "--untracked-files=no"])
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export function localModificationsMessage(changes, sourceRoot = SOURCE_ROOT) {
+  const preview = changes
+    .slice(0, DIRTY_PREVIEW_LIMIT)
+    .map((line) => `  ${line}`)
+    .join("\n");
+  const remainder = changes.length - DIRTY_PREVIEW_LIMIT;
+  return [
+    `The checkout has local changes to ${changes.length} tracked file${
+      changes.length === 1 ? "" : "s"
+    }; refusing to replace them during update:`,
+    preview,
+    ...(remainder > 0 ? [`  ...and ${remainder} more`] : []),
+    "",
+    `Keep them:    git -C ${sourceRoot} stash`,
+    "Discard them: re-run the same command with --force",
+  ].join("\n");
+}
+
+// Called only where the checkout is actually about to be rewritten, so a
+// checkout with edits still answers "is an update available?" and still
+// reinstalls at the same commit.
+function requireReplaceableCheckout(force) {
+  const changes = localModifications();
+  if (changes.length === 0) return;
+  if (!force) throw new Error(localModificationsMessage(changes));
+  git(["reset", "--hard", "HEAD"], { inherit: true });
 }
 
 export function currentCheckoutInstaller(platform = process.platform, target = TARGET) {
@@ -144,7 +183,7 @@ export function installationNeedsRefresh(manifest, revision) {
   return manifest?.current?.commit !== revision;
 }
 
-export function updateCheckout() {
+export function updateCheckout({ force = false } = {}) {
   const status = checkForUpdate();
   if (!status.updateAvailable) {
     if (!installationNeedsRefresh(readInstallManifest(), status.current)) {
@@ -154,6 +193,7 @@ export function updateCheckout() {
     refreshTrayCompanion();
     return { ...status, updated: false, reinstalled: true };
   }
+  requireReplaceableCheckout(force);
   let branch = git(["branch", "--show-current"]);
   if (!branch) {
     git(["switch", "main"], { inherit: true });
@@ -184,8 +224,11 @@ export function updateCheckout() {
   return { ...status, updated: true, reinstalled: true };
 }
 
-export function rollbackCheckout() {
+export function rollbackCheckout({ force = false } = {}) {
   requireManagedCheckout();
+  // A rollback checks out a different revision, so it overwrites tracked edits
+  // exactly the way an update does.
+  requireReplaceableCheckout(force);
   const current = git(["rev-parse", "HEAD"]);
   let target;
   try {
@@ -223,16 +266,22 @@ const COMMANDS = {
 // `check` must stay read-only: the tray and the CLI both use it to answer "is
 // an update available?" without touching the installation.
 export function resolveCommand(args) {
-  return COMMANDS[args[0] || "update"];
+  return COMMANDS[args.find((argument) => !argument.startsWith("--")) || "update"];
+}
+
+// A bare `update --force` has to keep working, so the flag is stripped before
+// the subcommand is read rather than being taken for one.
+export function parseArguments(args) {
+  return { command: resolveCommand(args), force: args.includes("--force") };
 }
 
 async function main() {
-  const command = resolveCommand(process.argv.slice(2));
+  const { command, force } = parseArguments(process.argv.slice(2));
   if (!command) {
-    console.error("Usage: update.mjs check|update|rollback");
+    console.error("Usage: update.mjs check|update|rollback [--force]");
     process.exit(2);
   }
-  process.stdout.write(`${JSON.stringify(command(), null, 2)}\n`);
+  process.stdout.write(`${JSON.stringify(command({ force }), null, 2)}\n`);
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/test/update-target.test.mjs
+++ b/test/update-target.test.mjs
@@ -8,6 +8,8 @@ import {
   checkForUpdate,
   currentCheckoutInstaller,
   installationNeedsRefresh,
+  localModificationsMessage,
+  parseArguments,
   resolveCommand,
   trayRefreshRequired,
 } from "../src/update.mjs";
@@ -125,4 +127,44 @@ test("tray refresh is skipped on non-macOS platforms", () => {
     }),
     false,
   );
+});
+
+test("--force is a flag on a command, never mistaken for one", () => {
+  assert.equal(resolveCommand(["--force"]), resolveCommand(["update"]));
+  assert.equal(resolveCommand(["check", "--force"]), checkForUpdate);
+
+  assert.deepEqual(parseArguments([]), { command: resolveCommand(["update"]), force: false });
+  assert.deepEqual(parseArguments(["--force"]), {
+    command: resolveCommand(["update"]),
+    force: true,
+  });
+  assert.deepEqual(parseArguments(["rollback", "--force"]), {
+    command: resolveCommand(["rollback"]),
+    force: true,
+  });
+  assert.equal(parseArguments(["nonsense"]).command, undefined);
+});
+
+test("a refused update names the files in the way and both ways forward", () => {
+  const message = localModificationsMessage([" M src/router.mjs", " M bin/install"], "/tmp/checkout");
+  assert.match(message, /2 tracked files/);
+  // Whoever hits this has to be able to see what is holding the update, or
+  // they are stuck on an old version with no way to work out why.
+  assert.match(message, /src\/router\.mjs/);
+  assert.match(message, /bin\/install/);
+  assert.match(message, /git -C \/tmp\/checkout stash/);
+  assert.match(message, /--force/);
+});
+
+test("a long list of local changes is previewed, not dumped", () => {
+  const changes = Array.from({ length: 14 }, (_, index) => ` M src/file-${index}.mjs`);
+  const message = localModificationsMessage(changes, "/tmp/checkout");
+  assert.match(message, /14 tracked files/);
+  assert.match(message, /src\/file-9\.mjs/);
+  assert.equal(message.includes("src/file-10.mjs"), false);
+  assert.match(message, /\.\.\.and 4 more/);
+});
+
+test("a single local change reads as one file, not one files", () => {
+  assert.match(localModificationsMessage([" M src/router.mjs"]), /1 tracked file;/);
 });


### PR DESCRIPTION
# Say what is blocking an update, and offer a way past it

Closes the update failure reported in #101.

## The problem

`requireManagedCheckout()` treated any output from `git status --porcelain` as
local changes, and that includes untracked files. One stray file in the
checkout, from an editor, an antivirus scan, or a half-finished experiment, and
every future update was refused:

```
The checkout has local changes; refusing to replace them during update.
```

The message does not say which file is in the way, and there is no flag to get
past it, so the installation is stuck on an old commit for good. The reporter
of #101 is in exactly this state: the image fix they came for is already on
main, and they cannot reach it.

The same guard also sat on the read-only path, so `update check`, which the
tray calls on a timer, failed for the same reason.

## The change

Only tracked edits hold an update now. A fast-forward merge never replaces an
untracked file, and git refuses the rare collision itself with a precise
message, so counting untracked files only ever stranded people.

When there are tracked edits, the error names them:

```
The checkout has local changes to 2 tracked files; refusing to replace them during update:
   M src/router.mjs
   M bin/install

Keep them:    git -C /path/to/checkout stash
Discard them: re-run the same command with --force
```

Long lists are previewed at ten entries with a count of the rest. `--force`
discards tracked edits with `git reset --hard HEAD` and never touches untracked
files. The flag is parsed as a flag, so `update --force` is still an update
rather than an unknown command, and it reaches `src/update.mjs` unchanged
through `bin/update` and `codex-router.ps1`. `rollback` takes the same guard,
since it checks out a different revision and overwrites tracked edits the same
way.

The guard moved out of `requireManagedCheckout()` into the two places that
actually rewrite the checkout, so asking whether an update is available works
again on a checkout with edits, and so does reinstalling at the same commit.
The origin allowlist and the "not a git checkout" check are untouched.

## Tests

`test/update-target.test.mjs` covers flag parsing against every subcommand, the
message naming the files and both ways forward, the preview truncating with a
remainder count, and singular against plural.

Verified by hand in a throwaway clone: a stray untracked file no longer blocks
`update check`, a modified tracked file produces the message above, and the
origin allowlist still rejects an unrecognized remote.

`npm run check` and `npm test` pass: 488 tests, 482 passed, 0 failed.

---

Sent as three independent branches so you can take them separately. They touch different code and merge cleanly in any order.
