### PR TITLE
Fix OpenRouter tool calling and compaction

### DIFF
--- a/src/compatibility-test.mjs
+++ b/src/compatibility-test.mjs
@@ -50,7 +50,9 @@ async function toolCall(model) {
         strict: true,
       },
     ],
-    tool_choice: "required",
+    // OpenRouter providers for Qwen 3.8 Max and Muse Spark 1.2 reject
+    // `required` while still supporting function calls through `auto`.
+    tool_choice: "auto",
   });
   const call = (payload?.output || []).find(
     (item) => item?.type === "function_call" && item?.name === "codex_router_probe",

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -851,7 +851,6 @@ async function summarize(payload, route, signal) {
     model: route.gatewayModel,
     stream: false,
     tools: [],
-    tool_choice: "none",
     input: [...bridged, messageItem(COMPACT_PROMPT)],
   };
   delete body.previous_response_id;


### PR DESCRIPTION
OpenRouter's Qwen 3.8 Max and Muse Spark 1.2 support function calling, but their providers reject `tool_choice: required` and only accept `auto`. The models still return the requested function call with `auto`, so the compatibility check now matches the provider behavior.

This also removes `tool_choice: none` from compaction requests with no tools. xAI/Grok rejects that invalid combination, while the same request succeeds when the field is omitted.

Tested with OpenRouter: Qwen 3.8 Max, Muse Spark 1.2, and Grok 4.5.