### PR TITLE
fix(api-forwarder): downgrade forced tool_choice for DeepSeek thinking models

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -344,6 +344,14 @@ function normalizeBody(buffer, contentType, route) {
     delete payload.top_p;
     delete payload.presence_penalty;
     delete payload.frequency_penalty;
+    // DeepSeek rejects forced tool choices while thinking is enabled
+    // ("Thinking mode does not support this tool_choice"); downgrade to auto so
+    // tool calls stay available. Codex sends "required" for the compatibility
+    // probe and a function object for the subagent payload relay, so without
+    // this both tool calling and routed subagents fail on every thinking model.
+    if (payload.tool_choice !== undefined && payload.tool_choice !== "none") {
+      payload.tool_choice = "auto";
+    }
   } else if (model.requestProfile === "deepseek-nonthinking") {
     payload.thinking = { type: "disabled" };
     delete payload.reasoning_effort;

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -1602,6 +1602,86 @@ test("API forwarder supports all DeepSeek V4 models and normalizes thinking", as
   }
 });
 
+test("API forwarder downgrades forced tool choices for DeepSeek thinking models", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    DEEPSEEK_API_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    DEEPSEEK_API_KEY: "TEST_DEEPSEEK_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  async function forward(gatewayModel, body) {
+    const response = await fetch(
+      `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: gatewayModel,
+          messages: [{ role: "user", content: "test" }],
+          ...body,
+        }),
+      },
+    );
+    assert.equal(response.status, 200);
+    return upstreamRequests.at(-1);
+  }
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    // DeepSeek answers a forced tool choice under thinking with HTTP 400
+    // ("Thinking mode does not support this tool_choice"). The compatibility
+    // probe sends the string form and the subagent payload relay sends the
+    // object form, so both must arrive as auto rather than failing the turn.
+    for (const gatewayModel of [
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+      "deepseek-legacy-reasoner",
+    ]) {
+      for (const toolChoice of [
+        "required",
+        { type: "function", function: { name: "relay_external_agent_payload" } },
+      ]) {
+        const request = await forward(gatewayModel, { tool_choice: toolChoice });
+        assert.deepEqual(request.body.thinking, { type: "enabled" });
+        assert.equal(request.body.tool_choice, "auto");
+      }
+
+      // "none" is not a forced choice: it suppresses tool calls, which the
+      // compaction turn relies on, so it must survive untouched.
+      const suppressed = await forward(gatewayModel, { tool_choice: "none" });
+      assert.equal(suppressed.body.tool_choice, "none");
+
+      // An absent choice stays absent so DeepSeek applies its own default.
+      const absent = await forward(gatewayModel, {});
+      assert.equal(absent.body.tool_choice, undefined);
+      assert.equal("tool_choice" in absent.body, false);
+    }
+
+    // Thinking is disabled on the non-thinking profile, so the restriction does
+    // not apply and a forced choice must pass through unchanged.
+    const nonThinking = await forward("deepseek-legacy-chat", {
+      tool_choice: "required",
+    });
+    assert.deepEqual(nonThinking.body.thinking, { type: "disabled" });
+    assert.equal(nonThinking.body.tool_choice, "required");
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder coalesces consecutive assistant messages so tool results follow tool calls", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
Fixes #106.

## The bug

The `deepseek-thinking` branch in `src/api-forwarder.mjs` enables thinking but leaves `tool_choice` untouched. DeepSeek then rejects the request:

```
HTTP 400: Thinking mode does not support this tool_choice
```

This is not limited to the compatibility probe. `src/router.mjs` sends `tool_choice` as a **function object** for the subagent payload relay, so routed subagents fail on every DeepSeek thinking model in normal use.

The identical guard already existed ~30 lines below in the `qwen-plan` branch — DashScope resells DeepSeek, which is where the restriction was first hit, and the fix landed on that path only.

## The fix

Mirror the existing `qwen-plan` guard into `deepseek-thinking`, with a comment quoting DeepSeek's own error text.

## Why this stays per-profile

All nine request profiles were audited rather than blanket-applying the guard. Two findings worth recording:

- **`anthropic-reasoning` must not get this guard.** It sets `"protocol": "anthropic"`, so the route is `/messages`, where `tool_choice` is an object (`{"type":"auto"|"any"|"tool"}`) and the bare string `"auto"` is schema-invalid. Applying the guard there would turn working requests into 400s. If Anthropic ever restricts forced tool use under adaptive thinking, the correct value is `{ type: "auto" }`.
- **`deepseek-nonthinking` is correctly exempt.** The upstream restriction is scoped to thinking mode by its own wording; adding the guard would strip working functionality from `deepseek-chat`. This is now asserted by a test so a later blanket-apply gets caught.

## Still open

`glm-thinking` is structurally identical to the bug fixed here and is the highest-risk unverified profile. The only corroborating datapoint is the `qwen-plan` guard, whose error text is DashScope's own wording and which covers Qwen, resold DeepSeek, and resold GLM indistinguishably — it does not isolate whether the restriction belongs to GLM or to DashScope. Z.ai direct has no reported 400. Confirming needs a live paid run (`bin/test-model 'zai-coding/glm-5.2' --live`), which was deliberately not performed here. Flagged rather than speculatively patched.

## Tests

New case in `test/routing.test.mjs` covering `deepseek-v4-flash`, `deepseek-v4-pro`, and `deepseek-legacy-reasoner`: `"required"` and a function-object `tool_choice` both become `"auto"`, `"none"` is preserved, absent stays absent. Closes with a `deepseek-legacy-chat` case asserting non-thinking passes `"required"` through unchanged.

`npm run check` and `npm test` pass on top of current main: 491 tests, 486 passed, 0 failed. No live or paid API calls.

Credit to @KirillAkimkin for the report, the root cause, and the proposed diff.
