### PR TITLE
fix(router): omit tool_choice from compaction requests

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -878,8 +878,10 @@ async function summarize(payload, route, signal) {
     ...payload,
     model: route.gatewayModel,
     stream: false,
+    // An empty tool list already disables tool use on every forwarder, and
+    // xAI rejects tool_choice "none" paired with it, so the field is omitted
+    // rather than sent redundantly.
     tools: [],
-    tool_choice: "none",
     input: [...bridged, messageItem(COMPACT_PROMPT)],
   };
   delete body.previous_response_id;


### PR DESCRIPTION
Takes the compaction half of #105 on its own.

## The change

`summarize()` sent `tools: []` and `tool_choice: "none"` together. xAI rejects that combination, so compaction failed on Grok while the identical request succeeds with the field simply omitted.

The field was redundant on every path, not just Grok's:

- `src/grok-oauth-forwarder.mjs:190` only forwards `tool_choice` when `tools.length` is non-zero. With an empty tool list it was never sent upstream at all.
- No request profile in `src/api-forwarder.mjs` reads, requires, or defaults `tool_choice` — the sole branch that touches it is `qwen-plan`, which downgrades a *forced* choice.
- No other forwarder references it.

So an empty tool list already disables tool use everywhere, and `"none"` only ever added a value one provider refuses.

## What is not included

#105 also changed the compatibility probe in `src/compatibility-test.mjs` from `tool_choice: "required"` to `"auto"` globally. That half is left out deliberately — reasoning is in a comment on #105. Short version: `auto` lets a model decline the call, so the probe stops proving tool calling works and becomes nondeterministic for every provider, and the two models it accommodates are not in the shipped registry (`config/openrouter/openrouter.json` ships zero models; OpenRouter is catalog-only). The right shape is a per-profile downgrade like the existing `qwen-plan` guard.

## Tests

`npm run check` and `npm test` pass on current main: 490 tests, 485 passed, 0 failed.

Credit to @jepgambardella, who found this and wrote the fix in #105.
