### PR TITLE
fix(router): normalize readable routed-agent handoffs for native replay and compaction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,6 +395,19 @@ minutes later. Do not quietly drop the label because a check happened to pass.
   native request with `stream: true`, accept SSE by body framing as well as
   content type, recognize padded `gAAAA...=` ciphertext, and treat non-Fernet
   `encrypted_content` from an external parent as plaintext.
+- The same rule applies in reverse, and it is not conditional on the envelope.
+  A routed subagent cannot mint an OpenAI token, so Codex stores its readable
+  handoff under `agent_message.content[].encrypted_content` whatever the
+  surrounding `Message Type:` rendering looks like. Before forwarding to a
+  native Responses endpoint — `/responses` and `/responses/compact` alike —
+  rewrite every non-Fernet `encrypted_content` part of an `agent_message` to
+  `input_text`; that schema accepts only `input_text`, `input_image`, and
+  `encrypted_content`, so `output_text` is not a fallback. Classify on the
+  ciphertext format (the `gAAAAA` Fernet prefix over base64url with no
+  whitespace), never on whether the plaintext looks readable, and forward a
+  value that passes byte-identical. Do not gate this on a router-written
+  sentinel: the router never authors these items, and a marker would strand
+  the already-broken conversations this recovers.
 - Never log relay response bodies, decrypted task text, or exception messages
   that can echo either. Regressions require fragmented/mislabeled SSE tests and
   real marker-return probes through every installed routed agent plus a

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -467,6 +467,17 @@ function nativeAgentRelayModel() {
   }
 }
 
+// Every `encrypted_content` value OpenAI issues is a Fernet token: the version
+// byte 0x80 followed by a big-endian timestamp whose leading bytes stay zero
+// for the rest of the century, which base64url-encodes to the fixed `gAAAAA`
+// prefix over the base64url alphabet with no whitespace. This is the whole
+// detection predicate -- the plaintext is never inspected.
+const NATIVE_ENCRYPTED_TOKEN = /^gAAAAA[A-Za-z0-9_-]+={0,2}$/;
+
+function isNativeEncryptedToken(value) {
+  return typeof value === "string" && NATIVE_ENCRYPTED_TOKEN.test(value);
+}
+
 function encryptedAgentPayload(item) {
   if (!Array.isArray(item?.content)) return undefined;
   const visibleText = item.content
@@ -488,7 +499,7 @@ function encryptedAgentPayload(item) {
   if (!encrypted) return undefined;
   return {
     content: encrypted.encrypted_content,
-    native: /^gAAAAA[A-Za-z0-9_-]+={0,2}$/.test(encrypted.encrypted_content),
+    native: isNativeEncryptedToken(encrypted.encrypted_content),
   };
 }
 
@@ -777,7 +788,43 @@ function sanitizeReasoningForNative(item) {
 // rejects the whole request with "Encrypted function output content could not
 // be decrypted or decoded" and the subagent dies before returning an answer.
 // Inline the payload as ordinary text so the native child can read it.
+//
+// Codex renders every handoff between agents as an `agent_message`, whose
+// content schema accepts only `input_text`, `input_image`, and
+// `encrypted_content` -- so `output_text` is not an option, and the readable
+// handoff has nowhere else to live. Matching the collaboration envelope covers
+// only the four `Message Type:` headers whose visible text ends at `Payload:`;
+// any other rendering reached OpenAI unchanged and failed replay and
+// `/responses/compact` alike, so the conversation could neither continue nor
+// compact. Normalize at the schema level instead.
+//
+// Classify on the ciphertext format alone (`isNativeEncryptedToken`), never on
+// what the plaintext looks like. A value that fails that shape is one the
+// native backend would reject anyway, so rewriting it replaces a certain
+// failure; a value that passes is forwarded byte-identical. Keying off the
+// stored value rather than a router-written sentinel is deliberate: the router
+// never authors these items -- Codex does, from the routed model's
+// collaboration tool call -- so there is no write site to mark, and a marker
+// would in any case abandon the already-broken conversations this recovers.
+function normalizeAgentMessageForNative(item) {
+  if (item?.type !== "agent_message" || !Array.isArray(item.content)) return item;
+  let changed = false;
+  const content = item.content.map((part) => {
+    if (part?.type !== "encrypted_content") return part;
+    const value = part.encrypted_content;
+    if (typeof value !== "string" || value.length === 0) return part;
+    if (isNativeEncryptedToken(value)) return part;
+    changed = true;
+    return { type: "input_text", text: value };
+  });
+  return changed ? { ...item, content } : item;
+}
+
 function sanitizeCollaborationForNative(item) {
+  const normalized = normalizeAgentMessageForNative(item);
+  if (normalized !== item) return normalized;
+  // Anything outside an `agent_message` is only rewritten when it carries a
+  // recognizable collaboration envelope, which is where the payload belongs.
   const payload = encryptedAgentPayload(item);
   if (!payload || payload.native) return item;
   return {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -1257,6 +1257,159 @@ test("router inlines an external parent's plaintext task before replaying to nat
   }
 });
 
+// A routed subagent cannot mint an OpenAI Fernet token, so Codex stores its
+// readable handoff under `agent_message.content[].encrypted_content` regardless
+// of how the surrounding envelope is rendered. The envelope-matching path only
+// covers the four `Message Type:` headers that end at `Payload:`; everything
+// else reached OpenAI unchanged and failed the whole request with "Encrypted
+// function output content could not be decrypted or decoded", so the
+// conversation could neither continue nor compact.
+const readableHandoffCases = [
+  {
+    label: "no envelope at all",
+    id: "amsg_bare",
+    content: [{ type: "encrypted_content", encrypted_content: "Summarize the diff." }],
+    expected: [{ type: "input_text", text: "Summarize the diff." }],
+  },
+  {
+    label: "text after the payload",
+    id: "amsg_trailing",
+    content: [
+      {
+        type: "input_text",
+        text: "Message Type: FINAL_ANSWER\nSender: /root/reviewer\nPayload:\n",
+      },
+      { type: "encrypted_content", encrypted_content: "The review is done." },
+      { type: "input_text", text: "\n(truncated)" },
+    ],
+    expected: [
+      {
+        type: "input_text",
+        text: "Message Type: FINAL_ANSWER\nSender: /root/reviewer\nPayload:\n",
+      },
+      { type: "input_text", text: "The review is done." },
+      { type: "input_text", text: "\n(truncated)" },
+    ],
+  },
+  {
+    label: "unrecognized message type",
+    id: "amsg_unknown_type",
+    content: [
+      { type: "input_text", text: "Message Type: TASK_ABORTED\nSender: /root\nPayload:\n" },
+      { type: "encrypted_content", encrypted_content: "The user interrupted the task." },
+    ],
+    expected: [
+      { type: "input_text", text: "Message Type: TASK_ABORTED\nSender: /root\nPayload:\n" },
+      { type: "input_text", text: "The user interrupted the task." },
+    ],
+  },
+  {
+    label: "readable and opaque parts in one message",
+    id: "amsg_mixed",
+    content: [
+      { type: "input_text", text: "Message Type: MESSAGE\nSender: /root\nPayload:\n" },
+      { type: "encrypted_content", encrypted_content: "Readable routed handoff." },
+      {
+        type: "encrypted_content",
+        encrypted_content: "gAAAAABkZmtM7cT9w_XY_zThisIsAnOpaqueBlobWithNoWhitespace==",
+      },
+    ],
+    expected: [
+      { type: "input_text", text: "Message Type: MESSAGE\nSender: /root\nPayload:\n" },
+      { type: "input_text", text: "Readable routed handoff." },
+      {
+        type: "encrypted_content",
+        encrypted_content: "gAAAAABkZmtM7cT9w_XY_zThisIsAnOpaqueBlobWithNoWhitespace==",
+      },
+    ],
+  },
+];
+
+// Nothing here may be rewritten: an opaque OpenAI blob has to arrive
+// byte-identical, and `input_text` / `input_image` are already legal.
+const untouchedHandoffItems = [
+  {
+    type: "agent_message",
+    id: "amsg_opaque",
+    author: "/root",
+    recipient: "/root/other",
+    content: [
+      { type: "input_text", text: "Message Type: NEW_TASK\nSender: /root\nPayload:\n" },
+      {
+        type: "encrypted_content",
+        encrypted_content: "gAAAAABmXk9wQ1J2c3RfT3BhcXVlQmxvYl9Ob1doaXRlc3BhY2U=",
+      },
+    ],
+  },
+  {
+    type: "agent_message",
+    id: "amsg_plain_parts",
+    author: "/root/reviewer",
+    recipient: "/root",
+    content: [
+      { type: "input_text", text: "Already ordinary text." },
+      { type: "input_image", image_url: "https://example.invalid/shot.png" },
+    ],
+  },
+];
+
+for (const endpoint of ["/responses", "/responses/compact"]) {
+  test(`router converts readable routed-agent handoffs to input_text on ${endpoint}`, async () => {
+    const nativeRequests = [];
+    const native = await mockServer(async (request, response) => {
+      nativeRequests.push({ url: request.url, body: await bodyJson(request) });
+      json(response, 200, { route: "native" });
+    });
+    const routerPort = await openPort();
+    const router = run("router.mjs", {
+      CODEX_ROUTER_PORT: String(routerPort),
+      CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+      CODEX_ROUTER_QUIET: "1",
+    });
+    const headers = {
+      Authorization: "Bearer CODEX_CALLER_SECRET",
+      "Content-Type": "application/json",
+    };
+
+    try {
+      await waitFor(`${routerBase(routerPort)}/models`, router);
+      const input = [
+        ...readableHandoffCases.map((entry) => ({
+          type: "agent_message",
+          id: entry.id,
+          author: "/root",
+          recipient: "/root/reviewer",
+          content: entry.content,
+        })),
+        ...untouchedHandoffItems,
+      ];
+      const replay = await fetch(`${routerBase(routerPort)}${endpoint}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ model: "gpt-5.6-sol", input }),
+      });
+      assert.equal(replay.status, 200);
+      assert.match(nativeRequests[0].url, new RegExp(`${endpoint}$`));
+      const sent = nativeRequests[0].body.input;
+      for (const entry of readableHandoffCases) {
+        const item = sent.find((candidate) => candidate?.id === entry.id);
+        assert.deepEqual(item.content, entry.expected, entry.label);
+        assert.equal(item.type, "agent_message", entry.label);
+        assert.equal(item.recipient, "/root/reviewer", entry.label);
+      }
+      for (const untouched of untouchedHandoffItems) {
+        assert.deepEqual(
+          sent.find((candidate) => candidate?.id === untouched.id),
+          untouched,
+        );
+      }
+    } finally {
+      await stopChild(router);
+      await closeServer(native.server);
+    }
+  });
+}
+
 // Gemini models reach the registry only through `bin/curate-models gemini-api`,
 // so the fixture registers one the same way curation does.
 function curatedGeminiModel() {


### PR DESCRIPTION
Fixes #99.

## The problem

A routed subagent cannot mint an OpenAI encrypted-content token, so Codex stores its readable handoff under `agent_message.content[].encrypted_content` as ordinary plaintext. Forwarded unchanged to a native Responses endpoint, replay and compaction fail:

```
Encrypted function output content could not be decrypted or decoded.
```

Converting to `output_text` is not a fallback — `agent_message.content` accepts only `input_text`, `input_image`, and `encrypted_content`.

A partial fix already existed (`sanitizeCollaborationForNative`, from 5c2ba39). Its gap was the predicate: `encryptedAgentPayload` only fired when the visible text matched a `Message Type: (NEW_TASK|MESSAGE|FOLLOWUP_TASK|FINAL_ANSWER) … \nPayload:` envelope. Any other rendering fell straight through to OpenAI.

## The predicate

A part is a **genuine opaque blob** iff it matches `/^gAAAAA[A-Za-z0-9_-]+={0,2}$/`. Everything else in an `agent_message` `encrypted_content` part becomes `input_text`.

This classifies on the ciphertext *format*, not the plaintext — no UTF-8 test, no base64 sniffing, no entropy heuristic. Every token OpenAI issues is a Fernet token: version byte `0x80` plus an 8-byte big-endian timestamp whose high bytes stay zero for the rest of the century, which base64url-encodes to the fixed `gAAAAA` prefix with no whitespace. That is a structural invariant of the format.

This is the predicate AGENTS.md already sanctions in the other direction — "recognize padded `gAAAA...=` ciphertext, and treat non-Fernet `encrypted_content` from an external parent as plaintext." This applies the same rule in reverse.

**No sentinel, deliberately.** The router never authors `agent_message` items — `grep -rn "agent_message" src/ apps/ bin/ scripts/` returns nothing; Codex builds them locally from the routed model's `collaboration.*` tool call. There is no write site to stamp. A marker would also have to live inside payload text the subagent reads and Codex renders, and would strand exactly the already-broken conversations this recovers.

**Failure modes, stated plainly:**

- *False positive* (real blob sent as plaintext) requires OpenAI to issue an `encrypted_content` value that is not `gAAAAA`-prefixed base64url. The test was deliberately left broad — no length or `(n−57)%16` structural decode, which would shrink the opaque class and *increase* this risk. The failure is also bounded: a value failing this shape is one the native backend rejects anyway, so rewriting it replaces a certain 400 rather than breaking a working request.
- *False negative* (readable handoff left as `encrypted_content`) requires plaintext that is pure base64url, whitespace-free, and starts with exactly `gAAAAA`. Behavior is unchanged from today.
- *Migration*: no marker means a conversation recorded before this change normalizes on its next replay. That is the reporter's case.

## Also fixed

The old envelope path filtered out **all** `encrypted_content` parts once it rewrote one, so a genuine blob sitting alongside a readable handoff was silently dropped. Covered by the `amsg_mixed` test.

## Tests

`test/routing.test.mjs`, parameterized over `/responses` and `/responses/compact` and asserting the forwarded URL so the compact path is genuinely exercised: no envelope at all, text after the payload, an unrecognized `Message Type:`, readable and opaque parts in one message, byte-identical opaque passthrough, and `input_text`/`input_image` items left alone. Verified RED before the fix (both endpoints failed the "no envelope" case) and GREEN after.

`npm run check` and `npm test` pass on current main: 492 tests, 487 passed, 0 failed. No live or paid API calls.

Credit to @Haz4rdovisk for the report and the diagnosis.
