### PR TITLE
fix(win): start the background service without a console window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@
   which starts the wrapper hidden and waits for it, re-raising the wrapper's
   exit code so Task Scheduler's restart-on-failure settings still see a crash as
   a crash. Reinstalling replaces the old task in place, and uninstalling removes
-  both generated launchers.
+  both generated launchers. Reinstalling and restarting now wait for the running
+  instance to actually exit before starting the new one, an install that cannot
+  register the task starts the router again rather than leaving the machine with
+  none, and stopping a service that was never installed is no longer an error.
 
 - **Text-only models can answer about a pasted image.** A model with no image
   input — DeepSeek, GLM, Kimi — used to refuse the paste outright. When the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Windows no longer opens a console window at logon.** The scheduled task ran
+  the CMD wrapper through `cmd.exe`, so a console window appeared at every logon
+  and stayed for the router's lifetime, reappearing on each watchdog restart.
+  The task now runs a generated VBS launcher under `wscript.exe //B //NoLogo`,
+  which starts the wrapper hidden and waits for it, re-raising the wrapper's
+  exit code so Task Scheduler's restart-on-failure settings still see a crash as
+  a crash. Reinstalling replaces the old task in place, and uninstalling removes
+  both generated launchers.
+
 - **Text-only models can answer about a pasted image.** A model with no image
   input — DeepSeek, GLM, Kimi — used to refuse the paste outright. When the
   vision bridge is on, a vision model you already have reads the image and

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -247,6 +247,11 @@ Get-ScheduledTask -TaskName "Codex Router"
 ./codex-router.ps1 doctor --fix
 ```
 
+The task runs `start-codex-router-hidden.vbs` from the state directory under
+`wscript.exe`, which starts `start-codex-router.cmd` without a console window,
+so a missing window is not a sign that the router is down. Read `router.log` in
+the same directory for its output.
+
 Keep the repository at the absolute path used during installation. Rerun setup
 from the new path if it was moved.
 

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -182,11 +182,56 @@ function installTask() {
   }
 }
 
+// `schtasks /End` returns once Task Scheduler has accepted the request, not
+// once the instance is gone, and `MultipleInstances IgnoreNew` silently drops a
+// `/Run` issued while the old one is still winding down -- which leaves the
+// router stopped until the next logon, and turns the installer's readiness wait
+// into a five-minute stall followed by a rollback. Polling the real state beats
+// retrying `/Run`: it continues as soon as the instance has actually gone
+// instead of guessing how long that takes, and it gives up on a fixed deadline
+// instead of hoping one extra attempt is enough.
+const TASK_STOP_TIMEOUT_MS = 10_000;
+const TASK_STOP_POLL_MS = 250;
+// Every state query has to return for the deadline above to mean anything, so a
+// wedged PowerShell is capped rather than allowed to hang the install outright.
+const TASK_STATE_TIMEOUT_MS = 15_000;
+
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function waitForTaskToStop() {
+  const deadline = Date.now() + TASK_STOP_TIMEOUT_MS;
+  // An undefined state means no PowerShell could answer -- the same restricted
+  // shell that blocks registration -- so there is nothing to poll and waiting
+  // would only spend the deadline on a question that cannot be answered.
+  while (taskState() === "running") {
+    if (Date.now() >= deadline) return;
+    sleep(TASK_STOP_POLL_MS);
+  }
+}
+
 function endTask() {
   try {
     schtasks(["/End", "/TN", taskName], { quiet: true });
   } catch {
-    // The task may not exist, or may not be running.
+    // The task may not exist, or may not be running; either way there is no
+    // instance left to wait for.
+    return;
+  }
+  waitForTaskToStop();
+}
+
+// Only a task that still exists can be started. `Register-ScheduledTask -Force`
+// unregisters before it registers, so a failed registration leaves either the
+// previous definition or nothing at all, and `/Run` against a name that is gone
+// recovers nothing while reporting an error of its own.
+function taskExists() {
+  try {
+    schtasks(["/Query", "/TN", taskName], { quiet: true });
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -202,6 +247,7 @@ function taskState() {
           encoding: "utf8",
           env: { ...process.env, CODEX_ROUTER_TASK: taskName },
           stdio: ["ignore", "pipe", "ignore"],
+          timeout: TASK_STATE_TIMEOUT_MS,
         },
       ).trim().toLowerCase();
     } catch {
@@ -237,8 +283,11 @@ if (command === "render") {
 } else if (command === "render-task") {
   process.stdout.write(`${JSON.stringify(taskAction())}\n`);
 } else if (command === "install") {
-  writeLaunchers();
   try {
+    // Writing the launchers belongs inside the try: renameSync over the .vbs
+    // raises a sharing violation while a running wscript.exe still holds it
+    // open, and that used to throw out of install with nothing to catch it.
+    writeLaunchers();
     // An upgrade from the console-visible task may still have that instance
     // running. Register-ScheduledTask -Force replaces the definition under the
     // same task name, so no duplicate is left behind, but it does not stop the
@@ -248,8 +297,19 @@ if (command === "render") {
     installTask();
     schtasks(["/Run", "/TN", taskName], { quiet: true });
   } catch {
-    // Scheduled-task creation can be restricted in a non-elevated terminal; the
-    // launchers are still written, so report success and let the caller retry.
+    // Scheduled-task creation can be restricted in a non-elevated terminal. The
+    // launchers are still written, so the install is reported as success and
+    // the caller can retry -- but endTask() has already stopped whatever was
+    // running by this point, so simply returning would take a working router
+    // down in exchange for nothing. Start whichever definition survived the
+    // failed registration. When none did there is nothing to restore: no
+    // snapshot was taken, and re-creating the old console-visible action would
+    // reintroduce the very defect this launcher exists to fix.
+    try {
+      if (taskExists()) schtasks(["/Run", "/TN", taskName], { quiet: true });
+    } catch {
+      // Nothing left to start; the caller's readiness check reports the failure.
+    }
   }
   process.stdout.write(`${JSON.stringify({ installed: true, path: wrapperPath })}\n`);
 } else if (command === "uninstall") {
@@ -281,7 +341,9 @@ if (command === "render") {
     `${JSON.stringify({ installed, loaded: state === "running", state })}\n`,
   );
 } else if (command === "stop") {
-  schtasks(["/End", "/TN", taskName], { quiet: true });
+  // Stopping is idempotent, like uninstall and restart: a task that is missing
+  // or already idle is the state the caller asked for, not an error to raise.
+  endTask();
   process.stdout.write(`${JSON.stringify({ state: "stopped" })}\n`);
 } else {
   if (command === "restart") endTask();

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -19,15 +19,21 @@ import {
 
 const effectivePlatform = process.env.CODEX_ROUTER_SERVICE_PLATFORM || process.platform;
 const command = process.argv[2] || "status";
+const renderCommands = new Set(["render", "render-launcher", "render-task"]);
 const taskName = "Codex Router";
 const wrapperPath = path.join(STATE_DIR, "start-codex-router.cmd");
+const launcherPath = path.join(STATE_DIR, "start-codex-router-hidden.vbs");
 
-if (effectivePlatform !== "win32" && command !== "render") {
+if (effectivePlatform !== "win32" && !renderCommands.has(command)) {
   throw new Error("The Task Scheduler service manager runs on Windows only.");
 }
 
 function cmdEscape(value) {
   return String(value).replaceAll("%", "%%").replaceAll('"', '""');
+}
+
+function vbsEscape(value) {
+  return String(value).replaceAll('"', '""');
 }
 
 function wrapper() {
@@ -60,6 +66,38 @@ function wrapper() {
     .join("\r\n")}\r\n"${cmdEscape(process.execPath)}" "${cmdEscape(start)}" >> "${cmdEscape(LOG_PATH)}" 2>&1\r\n`;
 }
 
+// The scheduled task launches this script through `wscript.exe //B //NoLogo`,
+// which is a windowless host, and the script starts the CMD wrapper with a
+// window style of 0. Without it the wrapper owned a console window that stayed
+// on screen for the router's lifetime and reappeared on every watchdog restart.
+//
+// The `True` wait flag is what keeps Task Scheduler's restart settings alive:
+// Run then blocks until the wrapper exits and returns its exit code, which the
+// script re-raises through WScript.Quit. Quitting with a fixed 0 (or letting the
+// script fall off the end) would report every crash as a clean exit and silently
+// disable RestartCount/RestartInterval.
+function launcher() {
+  // A Windows path cannot contain a double quote, but escape it anyway so a
+  // hand-edited state directory can never break out of the string literal.
+  // Chr(34) supplies the quotes cmd.exe needs around the wrapper path, which
+  // keeps this generated source free of stacked quote-doubling.
+  return [
+    "Option Explicit",
+    "",
+    "Dim quote, shell, status",
+    "quote = Chr(34)",
+    'Set shell = CreateObject("WScript.Shell")',
+    "On Error Resume Next",
+    `status = shell.Run("cmd.exe /D /C " & quote & quote & "${vbsEscape(wrapperPath)}" & quote & quote, 0, True)`,
+    "If Err.Number <> 0 Then",
+    "  WScript.Quit 1",
+    "End If",
+    "On Error Goto 0",
+    "WScript.Quit status",
+    "",
+  ].join("\r\n");
+}
+
 function schtasks(args, options = {}) {
   return execFileSync("schtasks.exe", args, {
     encoding: "utf8",
@@ -67,16 +105,45 @@ function schtasks(args, options = {}) {
   });
 }
 
-function writeWrapper() {
+function writeAtomic(target, contents) {
+  const temporary = `${target}.tmp.${process.pid}`;
+  writeFileSync(temporary, contents);
+  // renameSync replaces an existing destination on Windows, so reinstalling
+  // over an older launcher pair is a plain overwrite rather than a conflict.
+  renameSync(temporary, target);
+}
+
+function writeLaunchers() {
   mkdirSync(STATE_DIR, { recursive: true });
-  const temporary = `${wrapperPath}.tmp.${process.pid}`;
-  writeFileSync(temporary, wrapper(), "utf8");
-  renameSync(temporary, wrapperPath);
+  writeAtomic(wrapperPath, Buffer.from(wrapper(), "utf8"));
+  // wscript.exe parses a script file with the system ANSI code page unless the
+  // file carries a UTF-16 byte order mark, so a state directory holding
+  // non-ASCII characters only round-trips when the launcher is UTF-16LE.
+  writeAtomic(
+    launcherPath,
+    Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(launcher(), "utf16le")]),
+  );
+}
+
+// `//B` suppresses script errors and prompts, `//NoLogo` suppresses the banner;
+// neither host allocates a console, so nothing is drawn at logon.
+function taskAction() {
+  return {
+    execute: "wscript.exe",
+    // Unlike cmd.exe, wscript.exe follows the standard command-line parser, so
+    // the launcher path takes a single quote pair. cmd.exe's doubled-quote form
+    // would parse as an empty argument followed by a split path.
+    argument: `//B //NoLogo "${launcherPath}"`,
+  };
 }
 
 function installTask() {
+  const { execute, argument } = taskAction();
   const script = [
-    "$action = New-ScheduledTaskAction -Execute 'cmd.exe' -Argument ('/D /C \"\"' + $env:CODEX_ROUTER_WRAPPER + '\"\"')",
+    // The action strings travel through the environment so that the quotes
+    // around the launcher path never pass through powershell.exe's -Command
+    // reparse or the schtasks argument escaper.
+    "$action = New-ScheduledTaskAction -Execute $env:CODEX_ROUTER_TASK_EXECUTE -Argument $env:CODEX_ROUTER_TASK_ARGUMENT",
     "$trigger = New-ScheduledTaskTrigger -AtLogOn -User ([Security.Principal.WindowsIdentity]::GetCurrent().Name)",
     "$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew",
     "$principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited",
@@ -90,17 +157,36 @@ function installTask() {
         env: {
           ...process.env,
           CODEX_ROUTER_TASK: taskName,
-          CODEX_ROUTER_WRAPPER: wrapperPath,
+          CODEX_ROUTER_TASK_EXECUTE: execute,
+          CODEX_ROUTER_TASK_ARGUMENT: argument,
         },
         stdio: ["ignore", "ignore", "ignore"],
       },
     );
   } catch {
-    const action = `cmd.exe /D /C ""${wrapperPath}""`;
     schtasks(
-      ["/Create", "/TN", taskName, "/SC", "ONLOGON", "/TR", action, "/RL", "LIMITED", "/F"],
+      [
+        "/Create",
+        "/TN",
+        taskName,
+        "/SC",
+        "ONLOGON",
+        "/TR",
+        `${execute} ${argument}`,
+        "/RL",
+        "LIMITED",
+        "/F",
+      ],
       { quiet: true },
     );
+  }
+}
+
+function endTask() {
+  try {
+    schtasks(["/End", "/TN", taskName], { quiet: true });
+  } catch {
+    // The task may not exist, or may not be running.
   }
 }
 
@@ -125,35 +211,61 @@ function taskState() {
   return undefined;
 }
 
-if (!new Set(["install", "uninstall", "start", "stop", "restart", "status", "render"]).has(command)) {
-  console.error("Usage: service-windows.mjs install|uninstall|start|stop|restart|status|render");
+if (
+  !new Set([
+    "install",
+    "uninstall",
+    "start",
+    "stop",
+    "restart",
+    "status",
+    "render",
+    "render-launcher",
+    "render-task",
+  ]).has(command)
+) {
+  console.error(
+    "Usage: service-windows.mjs install|uninstall|start|stop|restart|status|render|render-launcher|render-task",
+  );
   process.exit(2);
 }
 
 if (command === "render") {
   process.stdout.write(wrapper());
+} else if (command === "render-launcher") {
+  process.stdout.write(launcher());
+} else if (command === "render-task") {
+  process.stdout.write(`${JSON.stringify(taskAction())}\n`);
 } else if (command === "install") {
-  writeWrapper();
+  writeLaunchers();
   try {
+    // An upgrade from the console-visible task may still have that instance
+    // running. Register-ScheduledTask -Force replaces the definition under the
+    // same task name, so no duplicate is left behind, but it does not stop the
+    // running instance, and MultipleInstances IgnoreNew would then drop the new
+    // hidden run — the console window would survive until the next logon.
+    endTask();
     installTask();
     schtasks(["/Run", "/TN", taskName], { quiet: true });
   } catch {
     // Scheduled-task creation can be restricted in a non-elevated terminal; the
-    // wrapper is still written, so report success and let the caller retry.
+    // launchers are still written, so report success and let the caller retry.
   }
   process.stdout.write(`${JSON.stringify({ installed: true, path: wrapperPath })}\n`);
 } else if (command === "uninstall") {
-  try {
-    schtasks(["/End", "/TN", taskName], { quiet: true });
-  } catch {
-    // The task may not be running.
-  }
+  endTask();
   try {
     schtasks(["/Delete", "/TN", taskName, "/F"], { quiet: true });
   } catch {
     // The task may not exist.
   }
-  if (existsSync(wrapperPath)) unlinkSync(wrapperPath);
+  for (const target of [launcherPath, wrapperPath]) {
+    try {
+      if (existsSync(target)) unlinkSync(target);
+    } catch {
+      // The launcher may already be gone, or a concurrent uninstall removed it.
+    }
+  }
   process.stdout.write(`${JSON.stringify({ installed: false })}\n`);
 } else if (command === "status") {
   let installed = false;
@@ -172,13 +284,7 @@ if (command === "render") {
   schtasks(["/End", "/TN", taskName], { quiet: true });
   process.stdout.write(`${JSON.stringify({ state: "stopped" })}\n`);
 } else {
-  if (command === "restart") {
-    try {
-      schtasks(["/End", "/TN", taskName], { quiet: true });
-    } catch {
-      // The task may not be running.
-    }
-  }
+  if (command === "restart") endTask();
   schtasks(["/Run", "/TN", taskName], { quiet: true });
   process.stdout.write(`${JSON.stringify({ state: "running" })}\n`);
 }

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -15,6 +16,18 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function serviceEnv(platform, testRoot, target = "codex") {
+  return {
+    ...process.env,
+    CODEX_HOME: path.join(testRoot, "codex home"),
+    CODEX_ROUTER_STATE_DIR: path.join(testRoot, "router state"),
+    MODEL_ROUTER_STATE_DIR: path.join(testRoot, `${target} router state`),
+    MODEL_ROUTER_TARGET: target,
+    CODEX_ROUTER_SERVICE_PLATFORM: platform,
+    XDG_CONFIG_HOME: path.join(testRoot, "xdg config"),
+  };
+}
 
 function serviceCommand(
   script,
@@ -31,15 +44,7 @@ function serviceCommand(
     {
       cwd: sourceRoot,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        CODEX_HOME: path.join(testRoot, "codex home"),
-        CODEX_ROUTER_STATE_DIR: path.join(testRoot, "router state"),
-        MODEL_ROUTER_STATE_DIR: path.join(testRoot, `${target} router state`),
-        MODEL_ROUTER_TARGET: target,
-        CODEX_ROUTER_SERVICE_PLATFORM: platform,
-        XDG_CONFIG_HOME: path.join(testRoot, "xdg config"),
-      },
+      env: serviceEnv(platform, testRoot, target),
     },
   );
 }
@@ -295,6 +300,223 @@ test(
 
       // Uninstalling again must not fail on the already-removed launchers.
       assert.equal(run("uninstall").installed, false);
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+// Off Windows there is no schtasks.exe or powershell.exe, so every scheduler
+// call src/service-windows.mjs makes is a failure and the ordering between them
+// is invisible. Executable stubs of those names, first on PATH, make the whole
+// sequence observable and let one call be failed on demand -- which is the only
+// way to reach the recovery path without a Windows box and a restricted shell.
+// They can never shadow the real executables, because the tests that use them
+// are skipped on win32.
+function schedulerStubs(directory, options = {}) {
+  const { schtasksFail = "", powershellFail = "", runningQueries = 0 } = options;
+  mkdirSync(directory, { recursive: true });
+  const logPath = path.join(directory, "calls.log");
+  const counterPath = path.join(directory, "state-queries");
+  const preamble = (fail) =>
+    [
+      "#!/bin/sh",
+      `printf '%s\\n' "$*" >> "${logPath}"`,
+      `for pattern in ${fail}; do`,
+      '  case "$*" in *"$pattern"*) exit 1 ;; esac',
+      "done",
+    ].join("\n");
+
+  writeFileSync(path.join(directory, "schtasks.exe"), `${preamble(schtasksFail)}\nexit 0\n`);
+  // taskState() reads the task state off this process's stdout. The counter is
+  // what lets a test say "report Running for the first N queries", so the stop
+  // wait can be observed polling and then finishing.
+  writeFileSync(
+    path.join(directory, "powershell.exe"),
+    [
+      preamble(powershellFail),
+      'case "$*" in',
+      "  *Get-ScheduledTask*)",
+      "    count=0",
+      `    if [ -f "${counterPath}" ]; then count=$(cat "${counterPath}"); fi`,
+      "    count=$((count + 1))",
+      `    printf '%s' "$count" > "${counterPath}"`,
+      `    if [ "$count" -le ${runningQueries} ]; then printf 'Running'; else printf 'Ready'; fi`,
+      "    ;;",
+      "esac",
+      "exit 0",
+      "",
+    ].join("\n"),
+  );
+
+  for (const name of ["schtasks.exe", "powershell.exe"]) {
+    chmodSync(path.join(directory, name), 0o755);
+  }
+  return {
+    path: `${directory}${path.delimiter}${process.env.PATH}`,
+    calls: () =>
+      existsSync(logPath)
+        ? readFileSync(logPath, "utf8").split("\n").filter(Boolean)
+        : [],
+  };
+}
+
+function runWindowsService(testRoot, command, extraEnv = {}) {
+  return spawnSync(
+    process.execPath,
+    [path.join(root, "src", "service-windows.mjs"), command],
+    {
+      cwd: root,
+      encoding: "utf8",
+      timeout: 120_000,
+      env: { ...serviceEnv("win32", testRoot), ...extraEnv },
+    },
+  );
+}
+
+test(
+  "a blocked registration restarts whichever task definition survived",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-recover-"));
+    try {
+      // Registration is blocked through both routes, the way a restricted or
+      // non-elevated terminal blocks it. endTask() has already stopped the
+      // running router by then, so returning here would trade a working install
+      // for nothing at all -- the regression this guards.
+      const stubs = schedulerStubs(path.join(testRoot, "survivor"), {
+        schtasksFail: "/Create",
+        powershellFail: "Register-ScheduledTask",
+      });
+      const result = runWindowsService(testRoot, "install", { PATH: stubs.path });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(JSON.parse(result.stdout).installed, true);
+
+      const calls = stubs.calls();
+      const at = (needle) => calls.findIndex((line) => line.includes(needle));
+      assert.ok(at("/End") >= 0, `no /End in:\n${calls.join("\n")}`);
+      assert.ok(
+        at("/End") < at("Register-ScheduledTask"),
+        `the running instance must be ended before re-registering:\n${calls.join("\n")}`,
+      );
+      // The surviving definition is queried before it is started: /Run against
+      // a name that failed to register recovers nothing and reports its own
+      // error over the one that actually matters.
+      assert.ok(
+        at("/Create") < at("/Query") && at("/Query") < at("/Run"),
+        `the recovery must query before it runs:\n${calls.join("\n")}`,
+      );
+      assert.equal(calls.filter((line) => line.includes("/Run")).length, 1);
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "a registration failure that leaves no task does not start one",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-no-task-"));
+    try {
+      const stubs = schedulerStubs(path.join(testRoot, "gone"), {
+        schtasksFail: "/Create /Query",
+        powershellFail: "Register-ScheduledTask",
+      });
+      const result = runWindowsService(testRoot, "install", { PATH: stubs.path });
+      // Still best effort: the launchers are written and the caller retries.
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(JSON.parse(result.stdout).installed, true);
+
+      const calls = stubs.calls();
+      assert.ok(calls.some((line) => line.includes("/Query")));
+      assert.equal(
+        calls.some((line) => line.includes("/Run")),
+        false,
+        `nothing survived to start, so /Run must not be issued:\n${calls.join("\n")}`,
+      );
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "install waits for the ended instance before starting the new one",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-stop-wait-"));
+    try {
+      // schtasks /End returns before the instance is gone. Reporting Running
+      // for the first two state queries reproduces that window; a /Run issued
+      // inside it is dropped by MultipleInstances IgnoreNew.
+      const stubs = schedulerStubs(path.join(testRoot, "winding-down"), {
+        runningQueries: 2,
+      });
+      const result = runWindowsService(testRoot, "install", { PATH: stubs.path });
+      assert.equal(result.status, 0, result.stderr);
+
+      const calls = stubs.calls();
+      const states = calls.filter((line) => line.includes("Get-ScheduledTask"));
+      assert.equal(
+        states.length,
+        3,
+        `the wait must poll until the state leaves Running:\n${calls.join("\n")}`,
+      );
+      const lastState = calls.findLastIndex((line) => line.includes("Get-ScheduledTask"));
+      assert.ok(
+        lastState < calls.findIndex((line) => line.includes("/Run")),
+        `the new instance must start after the old one has gone:\n${calls.join("\n")}`,
+      );
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "an instance that never stops cannot hang the install",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-stuck-"));
+    try {
+      // The state never leaves Running, so only the deadline can end the wait.
+      // Without it install would block forever and take the installer with it.
+      const stubs = schedulerStubs(path.join(testRoot, "stuck"), {
+        runningQueries: 1_000_000,
+      });
+      const result = runWindowsService(testRoot, "install", { PATH: stubs.path });
+      assert.equal(result.status, 0, result.stderr);
+
+      const calls = stubs.calls();
+      const states = calls.filter((line) => line.includes("Get-ScheduledTask"));
+      assert.ok(states.length > 1, "the wait must have polled more than once");
+      assert.ok(
+        states.length < 500,
+        `the wait must be bounded, not merely slow: ${states.length} state queries`,
+      );
+      // Giving up is not giving in: the install still registers and starts the
+      // task, and the readiness check downstream is what reports a router that
+      // never came back.
+      assert.ok(calls.some((line) => line.includes("/Run")));
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "stopping a service that was never installed is not an error",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-stop-"));
+    try {
+      // No stubs on PATH, so schtasks.exe is missing exactly as it is when the
+      // task does not exist. stop used to throw that straight at the caller
+      // while uninstall and restart tolerated it.
+      const result = runWindowsService(testRoot, "stop");
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), { state: "stopped" });
     } finally {
       rmSync(testRoot, { recursive: true, force: true });
     }

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -127,6 +135,131 @@ test("the Windows scheduled task runs the VBS launcher through wscript.exe", () 
     rmSync(testRoot, { recursive: true, force: true });
   }
 });
+
+// The scheduled task's restart policy is the reason the exit code matters:
+// Task Scheduler only re-triggers RestartCount/RestartInterval when the action
+// reports a failure, so a launcher that swallowed the wrapper's exit code would
+// trade a console window for a router that stays dead after its first crash.
+// Nothing off Windows can execute a .vbs, so -- exactly like
+// `install.ps1 parses under powershell.exe` in test/installer-scripts.test.mjs --
+// this is the only place that link is executed rather than reasoned about.
+//
+// wscript.exe with //B //NoLogo is the host the scheduled task actually uses
+// (see taskAction in src/service-windows.mjs). cscript.exe is the console host
+// over the same script engine, and it runs without //B so that a broken
+// launcher reports the parse or runtime error on stderr instead of arriving as
+// an unexplained exit code.
+const WINDOWS_SCRIPT_HOSTS = [
+  { name: "cscript.exe", args: ["//NoLogo"] },
+  { name: "wscript.exe", args: ["//B", "//NoLogo"] },
+];
+
+// Resolved absolutely: these live in the system directory, and naming them
+// outright keeps the test independent of whatever PATH the runner supplies.
+function scriptHost(name) {
+  return path.join(process.env.SystemRoot || "C:\\Windows", "System32", name);
+}
+
+test(
+  "the generated Windows launcher returns the wrapper's exit code to its script host",
+  { skip: process.platform !== "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-vbs-exit-"));
+    try {
+      const stateDir = windowsStateDir(testRoot);
+      mkdirSync(stateDir, { recursive: true });
+      const wrapperPath = path.join(stateDir, "start-codex-router.cmd");
+      const launcherPath = path.join(stateDir, "start-codex-router-hidden.vbs");
+
+      // The shipped generator produces the source. Only the encoding is
+      // repeated here: `install` is the code path that writes the file, and
+      // running it would register a real scheduled task on this machine.
+      // `the Windows installer writes both launchers idempotently` asserts that
+      // the shipped writer emits exactly these bytes.
+      const source = serviceCommand(
+        "service-windows.mjs",
+        "win32",
+        testRoot,
+        "render-launcher",
+      );
+      const encoded = Buffer.concat([
+        Buffer.from([0xff, 0xfe]),
+        Buffer.from(source, "utf16le"),
+      ]);
+      writeFileSync(launcherPath, encoded);
+
+      const report = (host, result, expectation, note) =>
+        [
+          `host: ${host.name} ${host.args.join(" ")} "${launcherPath}"`,
+          `expected exit code: ${expectation}`,
+          `actual exit code: ${result.status}`,
+          `terminating signal: ${result.signal ?? "none"}`,
+          `spawn error: ${result.error ? result.error.message : "none"}`,
+          `stdout: ${(result.stdout || "").trim() || "(empty)"}`,
+          `stderr: ${(result.stderr || "").trim() || "(empty)"}`,
+          note,
+          "generated launcher source:",
+          source,
+        ].join("\n");
+
+      const runLauncher = (host) => {
+        const result = spawnSync(scriptHost(host.name), [...host.args, launcherPath], {
+          encoding: "utf8",
+          timeout: 60_000,
+          windowsHide: true,
+        });
+        // A spawn failure or a timeout leaves status null, which would satisfy
+        // the "not zero" assertion below without the launcher having run at all.
+        assert.equal(
+          typeof result.status,
+          "number",
+          report(host, result, "any number", "the script host did not run to completion"),
+        );
+        return result;
+      };
+
+      for (const host of WINDOWS_SCRIPT_HOSTS) {
+        // A crashed router has to reach Task Scheduler as a failed run. 42 is
+        // arbitrary and distinctive: it is neither the 1 a WSH script error
+        // produces nor the 0 a silent success would.
+        writeFileSync(wrapperPath, "@echo off\r\nexit /b 42\r\n");
+        let result = runLauncher(host);
+        assert.equal(
+          result.status,
+          42,
+          report(host, result, 42, "the wrapper's exit code must reach the host unchanged"),
+        );
+
+        // ...and the reverse: a clean stop must not be reported as a failure,
+        // or the task restarts a router that was deliberately shut down.
+        writeFileSync(wrapperPath, "@echo off\r\nexit /b 0\r\n");
+        result = runLauncher(host);
+        assert.equal(
+          result.status,
+          0,
+          report(host, result, 0, "a clean wrapper exit must not be reported as a failure"),
+        );
+
+        // A wrapper that cannot start at all must still fail. `On Error Resume
+        // Next` without the Err.Number guard leaves `status` unset, and
+        // `WScript.Quit` on an unset value exits 0 -- which is the shape that
+        // silently disables the restart policy. cmd.exe itself reports this
+        // particular failure; the Err.Number branch covers a cmd.exe that will
+        // not start, which no ordinary host can reproduce because CreateProcess
+        // resolves it from the system directory whatever PATH says.
+        rmSync(wrapperPath);
+        result = runLauncher(host);
+        assert.notEqual(
+          result.status,
+          0,
+          report(host, result, "anything but 0", "a wrapper that never ran must not report success"),
+        );
+      }
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
 
 test(
   "the Windows installer writes both launchers idempotently and uninstall removes both",

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -8,21 +8,42 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-function render(script, platform, testRoot, target = "codex", sourceRoot = root) {
+function serviceCommand(
+  script,
+  platform,
+  testRoot,
+  command = "render",
+  target = "codex",
+  sourceRoot = root,
+) {
   const nodeArgs = sourceRoot === root ? [] : ["--preserve-symlinks", "--preserve-symlinks-main"];
-  return execFileSync(process.execPath, [...nodeArgs, path.join(sourceRoot, "src", script), "render"], {
-    cwd: sourceRoot,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      CODEX_HOME: path.join(testRoot, "codex home"),
-      CODEX_ROUTER_STATE_DIR: path.join(testRoot, "router state"),
-      MODEL_ROUTER_STATE_DIR: path.join(testRoot, `${target} router state`),
-      MODEL_ROUTER_TARGET: target,
-      CODEX_ROUTER_SERVICE_PLATFORM: platform,
-      XDG_CONFIG_HOME: path.join(testRoot, "xdg config"),
+  return execFileSync(
+    process.execPath,
+    [...nodeArgs, path.join(sourceRoot, "src", script), command],
+    {
+      cwd: sourceRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CODEX_HOME: path.join(testRoot, "codex home"),
+        CODEX_ROUTER_STATE_DIR: path.join(testRoot, "router state"),
+        MODEL_ROUTER_STATE_DIR: path.join(testRoot, `${target} router state`),
+        MODEL_ROUTER_TARGET: target,
+        CODEX_ROUTER_SERVICE_PLATFORM: platform,
+        XDG_CONFIG_HOME: path.join(testRoot, "xdg config"),
+      },
     },
-  });
+  );
+}
+
+function render(script, platform, testRoot, target = "codex", sourceRoot = root) {
+  return serviceCommand(script, platform, testRoot, "render", target, sourceRoot);
+}
+
+// Mirrors src/service-windows.mjs: MODEL_ROUTER_STATE_DIR wins over every other
+// state-directory source, and the fixture name deliberately carries a space.
+function windowsStateDir(testRoot) {
+  return path.join(testRoot, "codex router state");
 }
 
 test("background service definitions render for macOS, Linux, and Windows", () => {
@@ -49,6 +70,103 @@ test("background service definitions render for macOS, Linux, and Windows", () =
     rmSync(testRoot, { recursive: true, force: true });
   }
 });
+
+test("the Windows launcher starts the wrapper hidden and propagates its exit code", () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-hidden-launcher-"));
+  try {
+    const stateDir = windowsStateDir(testRoot);
+    assert.ok(stateDir.includes(" "), "the fixture state directory must contain a space");
+    const wrapperPath = path.join(stateDir, "start-codex-router.cmd");
+    const script = serviceCommand("service-windows.mjs", "win32", testRoot, "render-launcher");
+
+    assert.match(script, /^Option Explicit\r\n/);
+    assert.match(script, /\r\nSet shell = CreateObject\("WScript\.Shell"\)\r\n/);
+    // Window style 0 hides the wrapper's console; True waits for it so that
+    // Run returns the wrapper's exit code instead of returning immediately.
+    assert.ok(
+      script.includes(
+        `status = shell.Run("cmd.exe /D /C " & quote & quote & "${wrapperPath}" & quote & quote, 0, True)\r\n`,
+      ),
+      `launcher did not embed the wrapper path correctly:\n${script}`,
+    );
+    // Without this line Task Scheduler reads every crash as a clean exit and
+    // the RestartCount/RestartInterval settings never fire again.
+    assert.match(script, /\r\nWScript\.Quit status\r\n$/);
+    // A failure to even start the wrapper must also surface as a failure.
+    assert.match(script, /\r\nIf Err\.Number <> 0 Then\r\n {2}WScript\.Quit 1\r\nEnd If\r\n/);
+
+    // Every generated line must be a valid VBScript statement: string literals
+    // escape a double quote by doubling it, so quotes always come in pairs.
+    for (const line of script.split("\r\n")) {
+      assert.equal(
+        (line.match(/"/g) || []).length % 2,
+        0,
+        `unbalanced quotes in generated line: ${line}`,
+      );
+    }
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("the Windows scheduled task runs the VBS launcher through wscript.exe", () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-task-action-"));
+  try {
+    const launcherPath = path.join(windowsStateDir(testRoot), "start-codex-router-hidden.vbs");
+    const action = JSON.parse(
+      serviceCommand("service-windows.mjs", "win32", testRoot, "render-task"),
+    );
+
+    assert.equal(action.execute, "wscript.exe");
+    // //B and //NoLogo keep the windowless host quiet; the launcher path takes a
+    // single quote pair because wscript.exe uses the standard argument parser.
+    assert.equal(action.argument, `//B //NoLogo "${launcherPath}"`);
+    // The console-visible cmd.exe action is what issue #98 reported.
+    assert.doesNotMatch(`${action.execute} ${action.argument}`, /cmd\.exe/);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test(
+  "the Windows installer writes both launchers idempotently and uninstall removes both",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-install-"));
+    try {
+      const stateDir = windowsStateDir(testRoot);
+      const wrapperPath = path.join(stateDir, "start-codex-router.cmd");
+      const launcherPath = path.join(stateDir, "start-codex-router-hidden.vbs");
+      const run = (command) =>
+        JSON.parse(serviceCommand("service-windows.mjs", "win32", testRoot, command));
+
+      // schtasks.exe and powershell.exe are absent off Windows, and every call
+      // to them is best effort, so only the generated files are exercised here.
+      assert.equal(run("install").installed, true);
+      assert.equal(existsSync(wrapperPath), true);
+      assert.equal(existsSync(launcherPath), true);
+
+      const bytes = readFileSync(launcherPath);
+      // wscript.exe falls back to the ANSI code page without this byte order
+      // mark, which corrupts a state directory holding non-ASCII characters.
+      assert.deepEqual([...bytes.subarray(0, 2)], [0xff, 0xfe]);
+      assert.match(bytes.toString("utf16le").slice(1), /^Option Explicit\r\n/);
+
+      // Reinstalling over an existing pair overwrites instead of failing.
+      assert.equal(run("install").installed, true);
+      assert.equal(readFileSync(launcherPath).equals(bytes), true);
+
+      assert.equal(run("uninstall").installed, false);
+      assert.equal(existsSync(wrapperPath), false);
+      assert.equal(existsSync(launcherPath), false);
+
+      // Uninstalling again must not fail on the already-removed launchers.
+      assert.equal(run("uninstall").installed, false);
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
 
 test(
   "systemd WorkingDirectory is unquoted and escapes literal specifiers",


### PR DESCRIPTION
Fixes #98.

> **Needs a Windows smoke test before merge.** This was developed on macOS. The generated-string logic is fully tested, but no `wscript.exe` or Task Scheduler was available to execute. The unverified list is at the bottom and item 2 is the one that matters.

## The problem

The background-service installer registers an InteractiveToken task running `cmd.exe /D /C "<state-dir>\start-codex-router.cmd"`, and the wrapper keeps `node src/start.mjs` in the foreground. A console window appears at logon and stays for the router's lifetime; watchdog restarts re-open it.

## The change

`src/service-windows.mjs` generates a second launcher beside the CMD wrapper and points the task at `wscript.exe //B //NoLogo "<state-dir>\start-codex-router-hidden.vbs"`.

Rendered here with a spaced, non-ASCII path:

```vbs
Option Explicit

Dim quote, shell, status
quote = Chr(34)
Set shell = CreateObject("WScript.Shell")
On Error Resume Next
status = shell.Run("cmd.exe /D /C " & quote & quote & "C:\Users\Ann Marie\AppData\Local\codex-роутер\start-codex-router.cmd" & quote & quote, 0, True)
If Err.Number <> 0 Then
  WScript.Quit 1
End If
On Error Goto 0
WScript.Quit status
```

**Exit-code propagation** is the part that must be right, since Task Scheduler's `RestartCount 999 / RestartInterval 1m` is what keeps the router alive. `Run(..., 0, True)` returns the child's code and it is re-raised via `WScript.Quit status`. A failure to launch at all (`Err.Number <> 0`) quits `1` — otherwise a WSH runtime error exits 0 and the restart behavior silently never fires again.

**The .vbs is written UTF-16LE with a BOM.** `wscript.exe` otherwise parses a script file using the system ANSI code page, which mangles a non-ASCII state dir. The .cmd wrapper's existing UTF-8 encoding is untouched — that is a separate latent issue and I did not widen scope for it.

**Path quoting** uses `Chr(34)` for the quotes cmd.exe needs rather than stacked `""""` sequences, so the only quoting in the generated source is the string literal around the path. A test asserts every generated line has an even quote count.

## Upgrade path

The task name is unchanged and `Register-ScheduledTask -Force` / `schtasks /F` replace the definition, so there is no duplicate task. But `-Force` does not stop a *running* instance, and `MultipleInstances IgnoreNew` would then drop the new hidden `/Run` — leaving the old console window alive until next logon. So `install` now calls `endTask()` first. That was extracted and reused in `uninstall` and `restart`.

## Quoting hardening

The action's `Execute`/`Argument` now travel through the environment (`CODEX_ROUTER_TASK_EXECUTE` / `CODEX_ROUTER_TASK_ARGUMENT`) instead of being embedded in the `-Command` string, so quotes around the launcher path never pass through `powershell.exe -Command` reparsing. The schtasks fallback uses a **single** quote pair — the doubled-quote form is a cmd.exe-specific quirk and would split a spaced path into two arguments under the standard parser wscript.exe uses.

## Tests

Three added to `test/service-render.test.mjs` via two new render-only commands (`render-launcher`, `render-task`) so the tests assert against real generated values rather than duplicated literals. Coverage: VBS content with a spaced state dir, the exit-code propagation lines, quote balance on every line, the task command shape, and install/reinstall/uninstall/double-uninstall file handling — the last skipped on `win32` so it can never create a real scheduled task.

`npm run check` and `npm test` pass on current main: 493 tests, 488 passed, 0 failed (up from 490/485).

## Not verified on macOS

1. That the console window is actually gone. Window-style-0 is reasoned from the API contract, not observed.
2. **That `WScript.Quit status` reaches Task Scheduler as a failure and re-triggers the restart policy.** Highest-value check: kill `node src/start.mjs`, confirm Last Run Result is non-zero and the task restarts within a minute.
3. That `wscript.exe` accepts the UTF-16LE-with-BOM file. WSH documents Unicode support and honors the BOM, but if this is wrong the router fails to start at all — worth one manual run.
4. The `schtasks /Create /TR` fallback string, which only runs when `Register-ScheduledTask` fails in restricted or non-elevated shells.
5. The `powershell.exe -Command` argv round-trip for the env-var action.
6. The upgrade sequence on a real prior install: old task running → `/End` → re-register → exactly one hidden instance.
7. A genuinely non-ASCII `%LOCALAPPDATA%` end to end.

Credit to @Haz4rdovisk for the report, which specified the VBS approach, the task registration, exit-code propagation, and the uninstall cleanup.
