### PR TITLE
fix(router): stop a stale selection file and a mid-stream failure from taking the router down

### DIFF
--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -216,6 +216,16 @@ try {
       : "none",
     "Run ./bin/setup --guided and choose at least one provider.",
   );
+  // The router no longer refuses to serve on a selection file it cannot fully
+  // resolve, so the damage has to be reported here instead of as a 502.
+  if (selection.degraded) {
+    add(
+      "warn",
+      "Provider selection file",
+      selection.degraded,
+      "Run ./bin/setup --guided, or ./bin/providers enable PROVIDER, to rewrite the selection with this build's provider ids.",
+    );
+  }
 } catch (error) {
   add(
     "fail",

--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -1,4 +1,5 @@
 import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 
 import { secretEqual } from "./caller-auth.mjs";
 import { TARGET } from "./paths.mjs";
@@ -63,6 +64,59 @@ export function copyResponseHeaders(upstream, response, denylist = HOP_BY_HOP_HE
   }
 }
 
+function isEventStream(response) {
+  return String(response.getHeader("content-type") || "")
+    .toLowerCase()
+    .includes("text/event-stream");
+}
+
+function finishResponse(response) {
+  return new Promise((resolve) => {
+    if (response.writableFinished || response.destroyed) {
+      resolve();
+      return;
+    }
+    response.once("finish", resolve);
+    // A client that hangs up before the last chunk drains emits "close"
+    // without "finish"; the request is over either way.
+    response.once("close", resolve);
+    if (!response.writableEnded) response.end();
+  });
+}
+
+// Terminate a response whose body is already streaming.
+//
+// `response.destroy()` resets the socket, so an in-flight chunked body loses
+// its terminating `0\r\n\r\n` and the client reports a transport failure
+// ("error decoding response body") with nothing to say about the cause. Ending
+// the body instead produces a well-formed, if short, HTTP message.
+//
+// A gracefully ended SSE stream, though, is indistinguishable from a completed
+// one: the turn would simply look short and successful. So on `text/event-stream`
+// we first emit a terminal `error` event, matching the event framing the router
+// already writes elsewhere and the Responses API's own `error` event. A parser
+// that understands it surfaces a real failure; one that does not ignores the
+// unknown event and lands on the plain graceful end, which is still strictly
+// better than a reset. The frame carries a fixed router-side message and never
+// upstream error text, so no response body can leak through it.
+export function endStreamedResponse(response) {
+  if (!response || response.writableEnded || response.destroyed) return;
+  if (isEventStream(response)) {
+    try {
+      const data = {
+        type: "error",
+        code: "local_router_stream_failed",
+        message: "The local router lost the upstream response stream.",
+        param: null,
+      };
+      response.write(`event: error\ndata: ${JSON.stringify(data)}\n\n`);
+    } catch {
+      // The socket may already be gone; ending below is still correct.
+    }
+  }
+  response.end();
+}
+
 export async function pipeResponse(upstream, response, denylist, transform) {
   const transforms = transform === undefined
     ? []
@@ -75,30 +129,23 @@ export async function pipeResponse(upstream, response, denylist, transform) {
     response.end();
     return;
   }
-  await new Promise((resolve, reject) => {
-    const stream = Readable.fromWeb(upstream.body);
-    let settled = false;
-    const settle = (error) => {
-      if (settled) return;
-      settled = true;
-      if (error) reject(error);
-      else resolve();
-    };
-    stream.once("error", settle);
-    for (const entry of transforms) entry.once("error", settle);
-    response.once("finish", () => settle());
-    response.once("error", settle);
-    // A client that disconnects mid-stream emits "close" without "finish" or
-    // "error". Without this the promise never settles, so the caller's finally
-    // block never runs and the request stays counted as in-flight forever.
-    response.once("close", () => {
-      if (!settled) stream.destroy();
-      settle();
-    });
-    let target = stream;
-    for (const entry of transforms) target = target.pipe(entry);
-    target.pipe(response);
-  });
+  const source = Readable.fromWeb(upstream.body);
+  try {
+    // `pipeline` forwards errors and destroys every stream in the chain, which
+    // `.pipe()` does not: a mid-stream upstream failure used to leave the
+    // response half-written and open forever. `end: false` keeps the response
+    // itself out of that teardown so the caller can end the body cleanly (see
+    // `endStreamedResponse`) instead of resetting the socket.
+    await pipeline(source, ...transforms, response, { end: false });
+  } catch (error) {
+    // A client that disconnects mid-stream destroys the response, which
+    // pipeline reports as a premature close. That is not a router failure, and
+    // pipeline has already torn the upstream read down, so the in-flight
+    // counter releases without inventing an error.
+    if (response.destroyed && !response.writableFinished) return;
+    throw error;
+  }
+  await finishResponse(response);
 }
 
 export function requireInternalAuth(request, response, secret) {

--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -99,6 +99,17 @@ function finishResponse(response) {
 // unknown event and lands on the plain graceful end, which is still strictly
 // better than a reset. The frame carries a fixed router-side message and never
 // upstream error text, so no response body can leak through it.
+//
+// The frame is prefixed with a blank line because the stream is being ended at
+// the point upstream died, which is very often mid-line: transforms forward
+// upstream's chunk boundaries verbatim, and a single `output_text.delta` can
+// carry a long span. Writing `event: error` straight onto an unterminated
+// `data:` line does not produce an error event at all -- a conforming parser
+// reads the field name as more of the previous event's data, so the failure
+// signal turns into garbage appended to the last delta, which is exactly the
+// silent corruption this function exists to avoid. Leading newlines are inert
+// when the stream did end cleanly: a blank line with no buffered fields
+// dispatches nothing.
 export function endStreamedResponse(response) {
   if (!response || response.writableEnded || response.destroyed) return;
   if (isEventStream(response)) {
@@ -109,7 +120,7 @@ export function endStreamedResponse(response) {
         message: "The local router lost the upstream response stream.",
         param: null,
       };
-      response.write(`event: error\ndata: ${JSON.stringify(data)}\n\n`);
+      response.write(`\n\nevent: error\ndata: ${JSON.stringify(data)}\n\n`);
     } catch {
       // The socket may already be gone; ending below is still correct.
     }

--- a/src/provider-selection.mjs
+++ b/src/provider-selection.mjs
@@ -41,15 +41,41 @@ function expandProviderIds(ids) {
   return [...selected];
 }
 
-export function validateProviderIds(values) {
-  const named = values
+// Trim, drop blanks, and rewrite retired ids to their successor. Shared by the
+// strict write path and the tolerant read path so both resolve aliases the
+// same way; only the handling of an id this build does not know differs.
+function resolveProviderIds(values) {
+  return values
     .map((value) => String(value).trim())
     .filter(Boolean)
     .map((value) => RETIRED_PROVIDER_ALIASES.get(value) || value);
+}
+
+// Write path: strict. Someone naming a provider -- on the CLI, in
+// `install --providers`, in the guided picker, or through the tray -- gets a
+// hard error for a typo instead of a silently narrower selection.
+export function validateProviderIds(values) {
+  const named = resolveProviderIds(values);
   for (const id of named) {
     if (!PROVIDERS.has(id)) throw new Error(`Unknown provider: ${id}`);
   }
   return [...new Set(named.map((id) => canonicalProviderId(id)))];
+}
+
+// Read path: tolerant. `PROVIDERS` is built from `config/` at module import, so
+// the set of known ids is frozen for the life of the process while the
+// selection file is rewritten by CLI runs that may come from another checkout.
+// One id this build does not recognize -- version skew after an update, a
+// renamed or removed provider -- must not take the whole router down, because
+// this runs on every routed turn and as the first statement of /health.
+function filterKnownProviderIds(values) {
+  const known = [];
+  const unknown = [];
+  for (const id of resolveProviderIds(values)) {
+    if (PROVIDERS.has(id)) known.push(canonicalProviderId(id));
+    else unknown.push(id);
+  }
+  return { known: [...new Set(known)], unknown: [...new Set(unknown)] };
 }
 
 export function configuredProviderIds() {
@@ -73,27 +99,68 @@ export function configuredProviderIds() {
   return configured;
 }
 
-export function readProviderSelection() {
+// Never throws. Returns the providers to expose plus what had to be ignored, so
+// doctor and the support bundle can report the damage while requests keep
+// flowing. Degrading here matches every other state reader in the hot path
+// (`readNativeAliases`, `readNativeRedirect`, the doctor's catalog read).
+export function readProviderSelectionDetail() {
   if (
     process.env.MODEL_ROUTER_SHOW_ALL_MODELS === "1" ||
     (TARGET === "codex" && process.env.CODEX_ROUTER_SHOW_ALL_MODELS === "1")
   ) {
-    return providerIds();
+    return { providers: providerIds(), ignored: [], degraded: undefined };
   }
-  if (!existsSync(PROVIDER_SELECTION_PATH)) return providerIds();
+  if (!existsSync(PROVIDER_SELECTION_PATH)) {
+    return { providers: providerIds(), ignored: [], degraded: undefined };
+  }
+  let parsed;
   try {
-    const parsed = JSON.parse(readFileSync(PROVIDER_SELECTION_PATH, "utf8"));
-    if (parsed?.version !== 1 || !Array.isArray(parsed.providers)) {
-      throw new Error("version/providers are invalid");
-    }
-    return expandProviderIds(validateProviderIds(parsed.providers));
+    parsed = JSON.parse(readFileSync(PROVIDER_SELECTION_PATH, "utf8"));
   } catch (error) {
-    throw new Error(
-      `Invalid provider selection ${PROVIDER_SELECTION_PATH}: ${
+    return {
+      providers: providerIds(),
+      ignored: [],
+      degraded: `Unreadable provider selection ${PROVIDER_SELECTION_PATH}: ${
         error instanceof Error ? error.message : String(error)
       }`,
-    );
+    };
   }
+  if (parsed?.version !== 1 || !Array.isArray(parsed.providers)) {
+    return {
+      providers: providerIds(),
+      ignored: [],
+      degraded: `Invalid provider selection ${PROVIDER_SELECTION_PATH}: version/providers are invalid`,
+    };
+  }
+  const { known, unknown } = filterKnownProviderIds(parsed.providers);
+  // An explicitly empty list is a real choice -- disabling the last provider
+  // writes `[]`, and hiding everything is supported -- so it stays empty.
+  // A non-empty list that filters down to nothing is different: this build
+  // recognizes none of the operator's choices, so their file says nothing
+  // about the providers it does have. Falling back to the no-file default
+  // leaves the install in the same coherent state as a fresh one instead of
+  // stranding it with zero routable models, and the credential-aware catalog
+  // still hides anything that cannot authenticate.
+  if (known.length === 0 && unknown.length > 0) {
+    return {
+      providers: providerIds(),
+      ignored: unknown,
+      degraded: `Provider selection ${PROVIDER_SELECTION_PATH} names no provider this build knows (${
+        unknown.join(", ")
+      }); showing all providers until it is rewritten.`,
+    };
+  }
+  return {
+    providers: expandProviderIds(known),
+    ignored: unknown,
+    degraded: unknown.length
+      ? `Provider selection ${PROVIDER_SELECTION_PATH} names unknown providers: ${unknown.join(", ")}`
+      : undefined,
+  };
+}
+
+export function readProviderSelection() {
+  return readProviderSelectionDetail().providers;
 }
 
 export function writeProviderSelection(values) {
@@ -145,10 +212,13 @@ export function selectedConfiguredListedModels() {
 }
 
 export function providerSelectionStatus() {
+  const detail = readProviderSelectionDetail();
   return {
     path: PROVIDER_SELECTION_PATH,
     explicit: existsSync(PROVIDER_SELECTION_PATH),
-    providers: readProviderSelection(),
+    providers: detail.providers,
+    ignored: detail.ignored,
+    ...(detail.degraded ? { degraded: detail.degraded } : {}),
   };
 }
 

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -15,6 +15,7 @@ import {
   authenticatedRoute,
 } from "./caller-auth.mjs";
 import {
+  endStreamedResponse,
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
   pipeResponse,
@@ -1375,7 +1376,14 @@ async function handleRequest(request, response) {
 const server = http.createServer((request, response) => {
   handleRequest(request, response).catch((error) => {
     const status = httpErrorStatus(error);
-    console.error("[codex-router] request failed");
+    // The bare string this used to log made every mid-stream failure
+    // indistinguishable in production. The cause belongs in the log; response
+    // bodies never do, so only the error's own message and code are recorded.
+    console.error(
+      `[codex-router] request failed: ${
+        error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+      }${error?.code ? ` (${error.code})` : ""}`,
+    );
     if (!response.headersSent) {
       writeJson(response, status, {
         error: {
@@ -1383,8 +1391,11 @@ const server = http.createServer((request, response) => {
           message: "The local router could not complete the request.",
         },
       });
-    } else if (!response.writableEnded) {
-      response.destroy();
+    } else {
+      // The body is already streaming, so there is no status left to change.
+      // Destroying here reset the socket and cost the chunked terminator,
+      // which the client reported only as a decode failure.
+      endStreamedResponse(response);
     }
   });
 });
@@ -1394,6 +1405,30 @@ server.on("upgrade", (_request, socket) => {
   socket.end(
     "HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
   );
+});
+// Without this an 'error' event is unhandled and the process exits silently.
+// Under a supervisor that reads as a crash loop with the port never bound and
+// nothing in the log saying why, so name the cause and use exit codes a
+// supervisor and a human can tell apart.
+server.on("error", (error) => {
+  if (error?.code === "EADDRINUSE") {
+    console.error(
+      `[codex-router] cannot listen: ${LISTEN_HOST}:${LISTEN_PORT} is already in use. Another router or an unrelated process holds it; stop that process, then start the service again.`,
+    );
+    process.exit(98);
+  }
+  if (error?.code === "EACCES") {
+    console.error(
+      `[codex-router] cannot listen: permission denied binding ${LISTEN_HOST}:${LISTEN_PORT}.`,
+    );
+    process.exit(97);
+  }
+  console.error(
+    `[codex-router] server error: ${
+      error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+    }${error?.code ? ` (${error.code})` : ""}`,
+  );
+  process.exit(96);
 });
 server.requestTimeout = 0;
 server.headersTimeout = 65_000;

--- a/test/pipe-response.test.mjs
+++ b/test/pipe-response.test.mjs
@@ -189,6 +189,71 @@ test("an upstream body that fails mid-stream ends the chunked body instead of re
   assert.equal(transform.destroyed, true, "the failure did not destroy the chain");
 });
 
+// The case above fails between two complete events, which is the lucky one. A
+// real reset lands wherever it lands, and transforms forward upstream's chunk
+// boundaries verbatim, so the client is often left holding an unterminated
+// `data:` line. Writing the terminal frame straight onto it produces no error
+// event at all: a conforming parser reads `event: error` as more of the
+// previous event's data, so the one signal saying the router lost the stream
+// becomes garbage glued to the last delta.
+test("a mid-line upstream failure still yields a parseable terminal error event", async () => {
+  const partial = 'data: {"type":"response.output_text.delta","delta":"unterminated';
+  const upstream = {
+    status: 200,
+    headers: new Map([["content-type", "text/event-stream"]]),
+    body: new ReadableStream({
+      start(controller) {
+        // No trailing newline: the stream dies mid-field.
+        controller.enqueue(new TextEncoder().encode(partial));
+        setTimeout(() => controller.error(new Error("reset mid-line")), 10);
+      },
+    }),
+  };
+
+  const server = http.createServer(async (request, response) => {
+    try {
+      await pipeResponse(upstream, response, new Set(), []);
+    } catch {
+      endStreamedResponse(response);
+    }
+  });
+
+  const port = await listen(server);
+  const result = await readRaw(port);
+  await close(server);
+
+  assert.equal(result.complete, true, "the chunked body never reached its terminator");
+
+  // The field name must begin a line of its own. Without the blank-line prefix
+  // this assertion fails: the body reads "...unterminatedevent: error".
+  assert.match(
+    result.body,
+    /\nevent: error\n/,
+    "the terminal frame was glued onto the unterminated data line",
+  );
+
+  // And the frame must survive an actual SSE parse rather than merely appearing
+  // in the bytes: split on the blank-line dispatch boundary and require an
+  // event whose own `event:` field is `error` and whose data parses.
+  const events = result.body.split(/\r?\n\r?\n/).filter((block) => block.trim());
+  const errorEvent = events.find((block) => /^event: error$/m.test(block));
+  assert.ok(errorEvent, "no dispatched event declared itself an error");
+  const dataLine = errorEvent.split(/\r?\n/).find((line) => line.startsWith("data: "));
+  assert.equal(
+    JSON.parse(dataLine.slice(6)).code,
+    "local_router_stream_failed",
+    "the terminal frame did not carry the router's failure code",
+  );
+
+  // The truncated delta is unavoidable -- upstream died there -- but it must
+  // not have absorbed the router's frame.
+  assert.equal(
+    /unterminatedevent/.test(result.body),
+    false,
+    "router protocol text leaked into the model's output span",
+  );
+});
+
 // Only SSE gets a terminal event. Injecting one into a JSON body would corrupt
 // it; a truncated JSON body already fails the client's parser, and a clean end
 // still beats a reset because the failure is a parse error rather than an

--- a/test/pipe-response.test.mjs
+++ b/test/pipe-response.test.mjs
@@ -1,8 +1,9 @@
 import assert from "node:assert/strict";
 import http from "node:http";
+import { Transform } from "node:stream";
 import test from "node:test";
 
-import { pipeResponse } from "../src/http-utils.mjs";
+import { endStreamedResponse, pipeResponse } from "../src/http-utils.mjs";
 
 function listen(server) {
   return new Promise((resolve) => {
@@ -87,4 +88,157 @@ test("pipeResponse resolves after a complete response", async () => {
   await close(server);
   assert.equal(body, "done");
   assert.equal(settled, true);
+});
+
+// Read a response with the raw client so a socket reset is distinguishable
+// from a complete message: a reset mid-chunked-body emits "aborted"/"error"
+// and never "end", which is exactly what a reqwest client reports as
+// "error decoding response body".
+function readRaw(port) {
+  return new Promise((resolve, reject) => {
+    const request = http.request({ host: "127.0.0.1", port, path: "/" }, (response) => {
+      let body = "";
+      let aborted = false;
+      response.setEncoding("utf8");
+      response.on("data", (chunk) => {
+        body += chunk;
+      });
+      response.once("aborted", () => {
+        aborted = true;
+      });
+      response.once("error", () => {
+        aborted = true;
+      });
+      response.once("end", () => resolve({ body, aborted, complete: response.complete }));
+      response.once("close", () => {
+        if (!response.complete) resolve({ body, aborted: true, complete: false });
+      });
+    });
+    request.once("error", reject);
+    request.end();
+  });
+}
+
+function failingSseUpstream(message) {
+  return {
+    status: 200,
+    headers: new Map([["content-type", "text/event-stream"]]),
+    body: new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: first\n\n"));
+        setTimeout(() => controller.error(new Error(message)), 10);
+      },
+    }),
+  };
+}
+
+// `.pipe()` forwards neither errors nor destroy, so an upstream body that
+// failed mid-stream left the response half-written and open; the router then
+// reset the socket, and the client saw only a transport decode failure with no
+// cause. `pipeline` must surface the error with its message so the router can
+// log it, and must leave the response endable so the chunked body terminates.
+test("an upstream body that fails mid-stream ends the chunked body instead of resetting", async () => {
+  let pipeError;
+  const logged = [];
+  const transform = new Transform({
+    transform(chunk, _encoding, callback) {
+      callback(null, chunk);
+    },
+  });
+
+  const server = http.createServer(async (request, response) => {
+    try {
+      await pipeResponse(
+        failingSseUpstream("upstream exploded"),
+        response,
+        new Set(),
+        [transform],
+      );
+    } catch (error) {
+      pipeError = error;
+      // The router's top-level handler: log the cause, then terminate the
+      // stream gracefully rather than destroying the socket.
+      logged.push(
+        `[codex-router] request failed: ${
+          error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+        }`,
+      );
+      endStreamedResponse(response);
+    }
+  });
+
+  const port = await listen(server);
+  const result = await readRaw(port);
+  await close(server);
+
+  assert.equal(pipeError instanceof Error, true, "the upstream failure must surface");
+  assert.equal(pipeError.message, "upstream exploded");
+  // The message is what made this diagnosable at all; the old handler logged a
+  // bare string with no error attached.
+  assert.deepEqual(logged, ["[codex-router] request failed: Error: upstream exploded"]);
+
+  assert.equal(result.aborted, false, "the socket was reset instead of ending the body");
+  assert.equal(result.complete, true, "the chunked body never reached its terminator");
+  assert.match(result.body, /data: first/);
+  // A silently truncated SSE stream reads to the client as a short successful
+  // turn, so the failure is stated as a terminal event before the clean end.
+  assert.match(result.body, /event: error/);
+  assert.match(result.body, /local_router_stream_failed/);
+
+  // `pipeline` tears the whole chain down; `.pipe()` left the transform alive.
+  assert.equal(transform.destroyed, true, "the failure did not destroy the chain");
+});
+
+// Only SSE gets a terminal event. Injecting one into a JSON body would corrupt
+// it; a truncated JSON body already fails the client's parser, and a clean end
+// still beats a reset because the failure is a parse error rather than an
+// unexplained transport reset.
+test("a non-SSE body is ended without an injected event frame", async () => {
+  let pipeError;
+
+  const server = http.createServer(async (request, response) => {
+    const upstream = {
+      status: 200,
+      headers: new Map([["content-type", "application/json"]]),
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"partial":'));
+          setTimeout(() => controller.error(new Error("upstream exploded")), 10);
+        },
+      }),
+    };
+    try {
+      await pipeResponse(upstream, response, new Set());
+    } catch (error) {
+      pipeError = error;
+      endStreamedResponse(response);
+    }
+  });
+
+  const port = await listen(server);
+  const result = await readRaw(port);
+  await close(server);
+
+  assert.equal(pipeError.message, "upstream exploded");
+  assert.equal(result.aborted, false);
+  assert.equal(result.complete, true);
+  assert.equal(result.body, '{"partial":');
+});
+
+// A response that already ended, or whose client is gone, must not be written
+// to again.
+test("endStreamedResponse is a no-op on a finished or destroyed response", async () => {
+  const server = http.createServer((request, response) => {
+    response.setHeader("content-type", "text/event-stream");
+    response.end("data: done\n\n");
+    endStreamedResponse(response);
+    response.destroy();
+    endStreamedResponse(response);
+  });
+
+  const port = await listen(server);
+  const result = await readRaw(port);
+  await close(server);
+
+  assert.equal(result.body, "data: done\n\n");
 });

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -28,13 +28,23 @@ const {
   configuredProviderIds,
   disableProvider,
   enableProvider,
+  providerSelectionStatus,
   readProviderSelection,
+  readProviderSelectionDetail,
   selectedConfiguredListedModels,
   selectedListedModels,
+  validateProviderIds,
   writeProviderSelection,
 } = await import("../src/provider-selection.mjs");
 const { PROVIDER_SELECTION_PATH } = await import("../src/paths.mjs");
 const { privateFileIsProtected } = await import("../src/file-security.mjs");
+
+// Write the selection file behind the API so a test can stage the exact state a
+// newer checkout, or a corrupt write, leaves behind for an older running build.
+function stageSelectionFile(contents) {
+  mkdirSync(path.dirname(PROVIDER_SELECTION_PATH), { recursive: true });
+  writeFileSync(PROVIDER_SELECTION_PATH, contents, { encoding: "utf8", mode: 0o600 });
+}
 
 test("provider selection keeps backward compatibility and can hide the final provider", () => {
   try {
@@ -140,6 +150,159 @@ test("Command Code protocol variants follow their parent as one family", () => {
         .map((model) => model.slug)
         .includes("commandcode-messages/claude-sonnet-5"),
     );
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+// `PROVIDERS` is frozen at module import, so a selection file naming an id this
+// build does not have -- version skew after an update, a CLI run from a newer
+// checkout, a provider that was renamed or removed -- used to throw out of the
+// first statement of `healthPayload()` and out of every `/responses` turn,
+// wedging the whole router until the service restarted.
+test("an unknown provider id in the selection file is filtered out, not fatal", () => {
+  try {
+    stageSelectionFile(
+      `${JSON.stringify({
+        version: 1,
+        providers: ["deepseek", "provider-from-a-newer-build"],
+      })}\n`,
+    );
+
+    assert.deepEqual(readProviderSelection(), ["deepseek"]);
+    const detail = readProviderSelectionDetail();
+    assert.deepEqual(detail.ignored, ["provider-from-a-newer-build"]);
+    assert.match(detail.degraded, /provider-from-a-newer-build/);
+    // The surviving provider still routes and still filters the catalog.
+    assert.deepEqual(
+      selectedListedModels().map((model) => model.slug),
+      ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"],
+    );
+    // Doctor and the support bundle read through this, so the damage is
+    // reportable instead of arriving as a 502 on every request.
+    const status = providerSelectionStatus();
+    assert.deepEqual(status.providers, ["deepseek"]);
+    assert.deepEqual(status.ignored, ["provider-from-a-newer-build"]);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("a retired provider alias still maps to its successor while unknown ids are dropped", () => {
+  try {
+    stageSelectionFile(
+      `${JSON.stringify({
+        version: 1,
+        providers: ["chatgpt-oauth", "provider-from-a-newer-build"],
+      })}\n`,
+    );
+
+    assert.deepEqual(readProviderSelection(), ["grok-oauth"]);
+    assert.deepEqual(readProviderSelectionDetail().ignored, ["provider-from-a-newer-build"]);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+// When nothing in the file exists in this build, the operator's stored intent
+// says nothing about the providers this build does have, so the read falls back
+// to the no-file default rather than stranding the install with no route at
+// all. The credential-aware catalog still hides anything that cannot
+// authenticate, so this is the same coherent state as a fresh install.
+test("a selection naming only unknown providers falls back to the no-file default", () => {
+  try {
+    stageSelectionFile(
+      `${JSON.stringify({
+        version: 1,
+        providers: ["provider-from-a-newer-build", "provider-that-was-removed"],
+      })}\n`,
+    );
+
+    assert.deepEqual(readProviderSelection(), [...PROVIDERS.keys()]);
+    const detail = readProviderSelectionDetail();
+    assert.deepEqual(detail.ignored, [
+      "provider-from-a-newer-build",
+      "provider-that-was-removed",
+    ]);
+    assert.match(detail.degraded, /no provider this build knows/);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+// An explicitly empty list is a deliberate choice -- disabling the last
+// provider writes `[]` -- so it must not be mistaken for the unknown-id
+// fallback above and silently reopen every provider.
+test("an explicitly empty selection still hides every provider", () => {
+  try {
+    stageSelectionFile(`${JSON.stringify({ version: 1, providers: [] })}\n`);
+
+    assert.deepEqual(readProviderSelection(), []);
+    assert.deepEqual(readProviderSelectionDetail().ignored, []);
+    assert.equal(readProviderSelectionDetail().degraded, undefined);
+    assert.deepEqual(selectedListedModels(), []);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("an unreadable or wrong-version selection file degrades instead of throwing", () => {
+  try {
+    stageSelectionFile("{ not json at all");
+    assert.deepEqual(readProviderSelection(), [...PROVIDERS.keys()]);
+    assert.match(readProviderSelectionDetail().degraded, /Unreadable provider selection/);
+
+    stageSelectionFile(`${JSON.stringify({ version: 99, providers: ["deepseek"] })}\n`);
+    assert.deepEqual(readProviderSelection(), [...PROVIDERS.keys()]);
+    assert.match(readProviderSelectionDetail().degraded, /version\/providers are invalid/);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+// The read path degrading must not soften the write path: a person naming a
+// provider on the CLI, in `install --providers`, or through the tray still gets
+// a hard error for a typo rather than a silently narrower selection.
+test("the write path still rejects an unknown provider id", () => {
+  try {
+    assert.throws(
+      () => validateProviderIds(["deepseek", "provider-from-a-newer-build"]),
+      /Unknown provider: provider-from-a-newer-build/,
+    );
+    assert.throws(
+      () => writeProviderSelection(["deepseek", "provider-from-a-newer-build"]),
+      /Unknown provider: provider-from-a-newer-build/,
+    );
+    assert.throws(
+      () => enableProvider("provider-from-a-newer-build"),
+      /Unknown provider: provider-from-a-newer-build/,
+    );
+
+    // A rejected write leaves the previous file exactly as it was.
+    writeProviderSelection(["deepseek"]);
+    assert.throws(
+      () => writeProviderSelection(["provider-from-a-newer-build"]),
+      /Unknown provider: provider-from-a-newer-build/,
+    );
+    assert.deepEqual(
+      JSON.parse(readFileSync(PROVIDER_SELECTION_PATH, "utf8")).providers,
+      ["deepseek"],
+    );
+
+    // A CLI run against a file a newer build left behind rewrites it without
+    // the unknown id, so the next read is clean again.
+    stageSelectionFile(
+      `${JSON.stringify({
+        version: 1,
+        providers: ["deepseek", "provider-from-a-newer-build"],
+      })}\n`,
+    );
+    assert.deepEqual(enableProvider("kimi-api"), ["deepseek", "kimi-api"]);
+    assert.deepEqual(
+      JSON.parse(readFileSync(PROVIDER_SELECTION_PATH, "utf8")).providers,
+      ["deepseek", "kimi-api"],
+    );
+    assert.deepEqual(readProviderSelectionDetail().ignored, []);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }

--- a/test/router-resilience.test.mjs
+++ b/test/router-resilience.test.mjs
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { callerBaseUrl } from "../src/caller-auth.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
+const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
+
+async function openPort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function mockServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return { server, port: server.address().port };
+}
+
+function run(env) {
+  const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MODEL_ROUTER_STATE_DIR: mkdtempSync(path.join(os.tmpdir(), "router-resilience-state-")),
+      CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
+      CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+      KIMI_INTERNAL_KEY: INTERNAL_KEY,
+      CODEX_ROUTER_SHOW_ALL_MODELS: "1",
+      CODEX_ROUTER_QUIET: "1",
+      ...env,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let errors = "";
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+  child.testErrors = () => errors;
+  return child;
+}
+
+async function waitFor(url, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Child exited early (${child.exitCode}): ${child.testErrors()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Not bound yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${url}: ${child.testErrors()}`);
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await new Promise((resolve) => child.once("exit", resolve));
+}
+
+async function closeServer(server) {
+  await new Promise((resolve) => server.close(resolve));
+}
+
+// Read the routed turn with the raw client so a socket reset stays
+// distinguishable from a complete message. A reset mid-chunked-body leaves
+// `response.complete` false, which is the transport failure a reqwest client
+// reports as "error decoding response body".
+function readRouted(port, body) {
+  const base = new URL(`${callerBaseUrl(port, CALLER_KEY)}/responses`);
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: base.pathname,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer codex-caller-auth",
+        },
+      },
+      (response) => {
+        let text = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          text += chunk;
+        });
+        const done = () =>
+          resolve({ status: response.statusCode, body: text, complete: response.complete });
+        response.once("end", done);
+        response.once("close", done);
+        response.once("error", done);
+      },
+    );
+    request.once("error", reject);
+    request.end(JSON.stringify(body));
+  });
+}
+
+// A gateway that dies partway through an SSE body used to reach the client as a
+// bare socket reset: `.pipe()` never forwarded the error, so the response stayed
+// half-written until the top-level handler destroyed it, and the log said only
+// "[codex-router] request failed".
+test("a gateway that dies mid-stream ends the routed body and logs the cause", async () => {
+  const gateway = await mockServer((request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      const payload = Buffer.from(JSON.stringify({ ok: true }), "utf8");
+      response.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    response.writeHead(200, {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache",
+    });
+    response.write('event: response.created\ndata: {"type":"response.created"}\n\n');
+    // Reset the upstream socket without the terminating chunk, exactly as an
+    // edge that drops a live stream does.
+    setTimeout(() => response.destroy(), 60);
+  });
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+  });
+
+  try {
+    await waitFor(`${callerBaseUrl(routerPort, CALLER_KEY)}/models`, router);
+
+    const result = await readRouted(routerPort, {
+      model: "deepseek/deepseek-v4-pro",
+      input: "hello",
+      stream: true,
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(
+      result.complete,
+      true,
+      "the chunked body was reset instead of reaching its terminator",
+    );
+    // What the upstream managed to send survives, and the failure is stated
+    // rather than passed off as a short successful turn.
+    assert.match(result.body, /event: response\.created/);
+    assert.match(result.body, /event: error/);
+    assert.match(result.body, /local_router_stream_failed/);
+
+    // The log has to name the cause; the bare string it used to write is why
+    // this was undiagnosable in production.
+    const deadline = Date.now() + 2_000;
+    while (!/request failed: /.test(router.testErrors()) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.match(router.testErrors(), /\[codex-router\] request failed: \w+: .+/);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
+// A bare `listen()` failure is an unhandled 'error' event: the process exits
+// silently, the supervisor restarts it, and the port is never bound with
+// nothing in the log to say why.
+test("a taken port exits with a named cause and a distinguishable code", async () => {
+  const holder = net.createServer();
+  await new Promise((resolve, reject) => {
+    holder.once("error", reject);
+    holder.listen(0, "127.0.0.1", resolve);
+  });
+  const takenPort = holder.address().port;
+  const router = run({ CODEX_ROUTER_PORT: String(takenPort) });
+
+  try {
+    const exitCode = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("router never exited")), 10_000);
+      router.once("exit", (code) => {
+        clearTimeout(timer);
+        resolve(code);
+      });
+    });
+    assert.equal(exitCode, 98);
+    assert.match(router.testErrors(), /cannot listen: 127\.0\.0\.1:\d+ is already in use/);
+  } finally {
+    await stopChild(router);
+    await new Promise((resolve) => holder.close(resolve));
+  }
+});
+
+// The router must keep answering /health and keep routing when the selection
+// file names a provider this build does not have; that read used to throw out
+// of the first statement of healthPayload().
+test("a selection file naming an unknown provider does not wedge the router", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "router-resilience-selection-"));
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    `${JSON.stringify({
+      version: 1,
+      providers: ["deepseek", "provider-from-a-newer-build"],
+    })}\n`,
+    { mode: 0o600 },
+  );
+  const gateway = await mockServer((request, response) => {
+    const payload = Buffer.from(JSON.stringify({ ok: true, route: "external" }), "utf8");
+    response.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_SHOW_ALL_MODELS: "0",
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, router);
+    const health = await fetch(`http://127.0.0.1:${routerPort}/health`);
+    assert.equal(health.status, 200);
+    assert.equal((await health.json()).ok, true);
+
+    // The known provider in the same file still routes.
+    const routed = await fetch(`${callerBaseUrl(routerPort, CALLER_KEY)}/responses`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer codex-caller-auth",
+      },
+      body: JSON.stringify({ model: "deepseek/deepseek-v4-pro", input: "hello" }),
+    });
+    assert.equal(routed.status, 200);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Three router-resilience defects found while root-causing #100. **None of them is the 503 in that issue's title** — that turned out to be OpenAI's edge relayed faithfully, with the local URL in the message being Codex naming the endpoint it dialed. Analysis is in [#100](https://github.com/duolahypercho/codex-router/issues/100#issuecomment-5228507232). These are what the investigation found underneath it.

## 1. One state file could wedge every route until restart

`readProviderSelection()` was the only hot-path state reader that threw instead of degrading — `readNativeAliases`, `readNativeRedirect`, and `catalogModels` all swallow. It throws `Unknown provider: X` for any id not in `PROVIDERS`, and that map is built from `config/` at module import, so it is frozen for the process lifetime while the selection file is rewritten by CLI runs that may come from another checkout.

It runs as the **first statement** of `healthPayload()` (before the gateway probe) and on **every** `/responses` turn. So one unknown id — version skew after an update, a renamed or removed provider — 502s everything and fails `/health`, while the process stays alive and bound, so the supervisor keeps reporting it healthy.

The read path now filters unknown ids and reports them; the **write path stays strict**, so a typo on the CLI is still a hard error rather than a silently narrower selection. `doctor` surfaces what was ignored, since the router no longer refuses to serve on it.

One judgment call worth flagging: an explicitly empty list stays empty, because disabling the last provider legitimately writes `[]`. But a non-empty list that filters down to nothing falls back to the no-file default — that file says nothing about the providers this build actually has, so falling back leaves the install coherent instead of stranded with zero routable models. The credential-aware catalog still hides anything that cannot authenticate.

## 2. A mid-stream failure reset the socket instead of ending the stream

`pipeResponse` used `.pipe()`, which does not forward errors or propagate `destroy()`. An upstream body error left the response half-written and never ended, and the top-level handler then called `response.destroy()` — resetting an in-flight chunked body without its terminating `0\r\n\r\n`. reqwest reports that as exactly `error decoding response body`, naming nothing.

Now `stream.pipeline` with `end: false`, so a failure destroys the whole chain while leaving the response for the caller to end cleanly.

**On `end()` vs a terminal error event — both, gated on content type.** A bare `end()` on SSE is worse than it looks: the Responses SSE protocol has no length, so "the stream stopped" and "the turn finished" are the same bytes, and Codex would render a truncated answer as a completed short turn. That trades a cosmetic failure for a silent correctness one. So `text/event-stream` gets an `event: error` frame first — in-protocol (the Responses API defines it), matching the framing `writeCompactionSse()` already emits, and safe under any parser: one that dispatches it surfaces a real failure, one that doesn't ignores the unknown event and lands on the graceful end anyway. `sequence_number` is deliberately omitted rather than guessed. Non-SSE bodies get a plain `end()`; a truncated JSON body already fails the client's parser loudly.

The frame carries a fixed router-side string and never upstream error text, so no response body leaks through it.

## 3. `EADDRINUSE` exited silently

`server` had no `'error'` handler, so a bind failure was an unhandled `'error'` event → silent process exit → a permanent supervisor restart loop with the port never bound and nothing in the log. Now named, with exit codes 98/97/96 a human and a supervisor can tell apart. `KeepAlive` is unconditional with a 10s throttle, so these change nothing about restart behavior — only legibility.

## Plus the reason this was undiagnosable

`src/router.mjs` logged the bare string `[codex-router] request failed` and never the error object. It now logs `name`, `message`, and `code` — and only those, never a body.

## Deliberately not changed

`response.destroy()` in the three forwarders (`api-forwarder.mjs:561`, `oauth-forwarder.mjs:239`, `grok-oauth-forwarder.mjs:495`) looks like the same bug and isn't. Their only client is the router itself over loopback; after this change the router's `pipeResponse` turns that reset into a source error and converts it into a properly terminated client body. Making them end gracefully would make a failed internal hop look like a clean short stream, which the router would relay as a successful truncated turn — the exact failure being removed at the edge. The reset is load-bearing signalling on an internal hop.

## Tests

503 tests, 498 pass, 0 fail, 5 skipped (baseline 491; +12 added). Regression value verified by stashing `src/` and re-running: all three new end-to-end tests fail against the pre-fix code.

`test/router-resilience.test.mjs` (new) spawns the real router: a gateway that resets mid-SSE yields a complete chunked body with the terminal error event and a stderr line matching `\[codex-router\] request failed: \w+: .+`; a taken port exits 98 with the cause named; a selection file with an unknown provider returns `/health` 200 and still routes the known provider in the same file.

`test/pipe-response.test.mjs` reads with the raw `http.request` client so `response.complete === false` catches a reset, and asserts `transform.destroyed === true` — the discriminator between `.pipe()` and `pipeline`.

`test/provider-selection.test.mjs` covers the filter, retired aliases, all-unknown fallback, explicit-empty preservation, corrupt JSON, and that `validateProviderIds`, `writeProviderSelection`, and `enableProvider` all still throw on an unknown id with the previous file left byte-identical.

## Unrelated flake seen while testing

`test/startup-cleanup.test.mjs:35` "startup failure terminates services that already became healthy" fails intermittently under parallel load. Reproduced on **clean main** (1 failure in 3 runs) with none of these changes present, and 4/4 green on this branch. Pre-existing timing sensitivity, not touched here.
