### PR TITLE
feat(skills): add a codex-subagents skill for spawning routed subagents

### DIFF
--- a/.claude/skills/codex-subagents/SKILL.md
+++ b/.claude/skills/codex-subagents/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: codex-subagents
+description: Set up, verify, and troubleshoot spawning subagents on non-OpenAI models through codex-router. Use when the user wants Codex to delegate work to subagents, asks which models can act as subagents, says spawning a subagent fails or picks the wrong model, or wants to orchestrate parallel agents across routed providers.
+---
+
+# Spawning subagents through codex-router
+
+Codex can delegate a task to a subagent running on a different model. codex-router
+decides which models Codex is allowed to pick. This skill covers getting the right
+models offered, proving they actually work, and fixing it when they don't.
+
+Run every command from the codex-router checkout.
+
+## Start here, always
+
+```bash
+node .claude/skills/codex-subagents/subagent-report.mjs
+```
+
+This answers the only question that matters — *if I ask Codex to spawn a subagent
+right now, what can it pick?* — and it is the one question `control subagents status`
+does not answer. That command reports your **intent**. The merged catalog is what
+Codex actually **reads**. They drift apart silently, and the report catches the drift.
+
+If the report says a model is spawnable, it is offered to Codex. If it doesn't
+appear there, nothing else you do in Codex will surface it.
+
+## How a model becomes spawnable
+
+A model carries `multiAgentVersion: "v2"` in the catalog. Three modes decide who gets it:
+
+| Mode | Effect |
+|---|---|
+| `proven` | Only models the registry ships as verified. Conservative default. |
+| `selected` | Proven models plus ones you explicitly turn on. **Use this.** |
+| `all` | Every non-hidden model, regardless of whether it works. |
+
+```bash
+./bin/control subagents status                    # current mode, enabled, disabled
+./bin/control subagents mode selected
+./bin/control subagents set opencode-go/glm-5.2 on
+./bin/control subagents set qwen-plan/qwen3.6-flash off
+./bin/control subagents select-all                # turn every model on
+./bin/control subagents unselect-all              # clear the list, back to a clean slate
+```
+
+An explicit `off` beats every mode, including `all`. That is how you keep a model
+out without leaving `all` — verified: under `mode: all`, a model in `disabled`
+still resolves to `v1`.
+
+`unselect-all` is the fastest way out of a crowded list when the models you want
+have been pushed past what Codex advertises.
+
+**After any change:**
+
+```bash
+node src/catalog.mjs
+```
+
+then **fully quit and reopen Codex**. Not a new window — the whole app. Codex reads
+the catalog at startup and caches it. Skipping this is the single most common reason
+a change appears to do nothing, and the report flags it as `STALE`.
+
+## Two traps that waste the most time
+
+**Codex advertises only a small priority-ordered subset.** Turning on twelve models
+does not give you twelve choices — it buries the ones you wanted behind ones you
+didn't. The report prints models in Codex's ranking order and marks where the cut
+probably falls. If a model you want sits far down that list, turn off the ones above
+it rather than adding more.
+
+**`mode all` is not "make everything work".** It advertises every model as capable,
+including models that cannot drive Codex at all. A model that emits tool calls as
+prose will be offered, accepted, and then fail mid-task with nothing useful in the
+log. Prefer `selected` plus a real check.
+
+## Proving a model actually works
+
+Capability is not predictable from size, a tool-support flag, or a hand-written probe.
+A 3B model that emits perfect tool calls on a short prompt answers *about* its
+instructions when Codex's real ~24K-token prompt is in front of it. The only honest
+test runs the real client:
+
+```bash
+./bin/control local-models agent-check <model-tag>     # local models
+```
+
+For a routed (non-local) model, call the same checker directly:
+
+```bash
+node --input-type=module -e '
+import { checkAgentCapability } from "./src/agent-check.mjs";
+console.log(JSON.stringify(checkAgentCapability(process.argv[1]), null, 2));
+' "opencode-go/glm-5.2"
+```
+
+This runs `codex exec` through the router with the real prompt and tools, twice —
+one run is luck, not a verdict. Verdicts:
+
+| Verdict | Meaning |
+|---|---|
+| `agent` | Ran a tool, read real output. Safe to enable. |
+| `text-tool-calls` | Emitted a tool call as prose. No client can dispatch it. |
+| `invents-tools` | Called a tool that was never offered. |
+| `no-tool-use` | Answered without using a tool. |
+| `flaky` | Mixed across runs. Do not rely on it. |
+
+**This spends provider quota** — it is a real turn against a real model. Get the
+user's approval before running it, and say which provider it will bill.
+
+## Spawning, once a model is offered
+
+Ask Codex in plain language: *"spawn a subagent on glm-5.2 to audit src/router.mjs
+for unhandled promise rejections."* Codex picks from the models the report listed.
+There is no router-side command that spawns an agent — the router only controls
+what Codex is allowed to choose.
+
+For parallel work, ask for several in one message so they run concurrently rather
+than in sequence.
+
+## When it goes wrong
+
+**Model not offered in Codex.** Run the report. Not listed → `subagents set <slug> on`,
+rebuild, restart. Listed but far down → crowded out; turn off higher-priority models.
+
+**Subagent starts, then fails or stalls.** Run the agent check. A `text-tool-calls`
+or `invents-tools` verdict means the model cannot do this job; turn it off rather
+than retrying.
+
+**Change had no effect.** Almost always a missed `node src/catalog.mjs` or a Codex
+that was never fully quit. The report's `STALE` line catches the first.
+
+**Everything fails at once, on every model.** Not a subagent problem. Check the
+router itself:
+
+```bash
+./bin/model-router codex doctor
+```
+
+A provider named in `enabled-providers.json` that this build doesn't know used to
+502 every request while the process stayed alive and looked healthy. `doctor` now
+reports it as a warning naming the ignored ids.
+
+## Rules worth keeping
+
+- Never set `multiAgentVersion: "v2"` in the checked-in registry to make something
+  work locally. That claims support for every user. Local opt-in is
+  `./bin/control subagents set`, which only changes this machine's catalog.
+- The registry uses camelCase (`multiAgentVersion`); the merged catalog is Codex's
+  wire format and uses snake_case (`multi_agent_version`). Reading the wrong key
+  reports zero capable models on a healthy install.
+- Curated models from `bin/curate-models` are **not** implicitly approved as
+  subagents. They need an explicit `subagents set <slug> on`.

--- a/.claude/skills/codex-subagents/subagent-report.mjs
+++ b/.claude/skills/codex-subagents/subagent-report.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Readiness report for Codex subagent spawning.
+//
+// Answers the question the CLI cannot: "if I ask Codex to spawn a subagent
+// right now, which models can it actually pick?" That is not what
+// `control subagents status` reports. Settings name an intent; the merged
+// catalog is what Codex reads. The two drift apart whenever the catalog is not
+// rebuilt after a settings change, and the drift is silent.
+
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const STATE_DIR =
+  process.env.MODEL_ROUTER_STATE_DIR ||
+  path.join(process.env.HOME || "", ".codex", "codex-router");
+
+const CATALOG_PATH = path.join(STATE_DIR, "merged-models.json");
+const SETTINGS_PATH = path.join(STATE_DIR, "multi-agent-settings.json");
+
+// Codex advertises only a small priority-ordered subset of spawn-model
+// overrides. The exact cut is the client's, not ours, so this is a reporting
+// threshold for "you are probably past what Codex will show", not a promise.
+const LIKELY_VISIBLE = 8;
+
+const json = (file) => JSON.parse(readFileSync(file, "utf8"));
+const bad = (message) => {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+};
+
+if (!existsSync(CATALOG_PATH)) {
+  bad(
+    `No merged catalog at ${CATALOG_PATH}.\n` +
+      "Run ./bin/model-router codex doctor first, or reinstall — the router has not built a catalog yet.",
+  );
+}
+
+const catalog = json(CATALOG_PATH);
+const models = Array.isArray(catalog) ? catalog : catalog.models || [];
+
+// The registry uses camelCase; the merged catalog is Codex's wire format and
+// uses snake_case. Reading the wrong one reports zero capable models on a
+// perfectly healthy install, which looks exactly like a real fault.
+const capable = models
+  .filter((model) => model.multi_agent_version === "v2")
+  .sort((a, b) => (a.priority ?? Infinity) - (b.priority ?? Infinity));
+
+const settings = existsSync(SETTINGS_PATH)
+  ? json(SETTINGS_PATH)
+  : { mode: "proven", enabled: [], disabled: [] };
+
+const out = [];
+out.push(`Mode:     ${settings.mode}`);
+out.push(`Catalog:  ${models.length} models, ${capable.length} spawnable as subagents`);
+if (settings.disabled?.length) {
+  out.push(`Disabled: ${settings.disabled.length} model(s) held back by an explicit off`);
+}
+out.push("");
+
+if (capable.length === 0) {
+  out.push("No model can be spawned as a subagent right now.");
+  out.push("");
+  out.push("  Most likely: the catalog predates your settings. Rebuild it:");
+  out.push("    node src/catalog.mjs");
+  out.push("  Then fully quit and reopen Codex.");
+} else {
+  out.push("Spawnable, in the order Codex ranks them:");
+  out.push("");
+  capable.forEach((model, index) => {
+    const rank = String(index + 1).padStart(2);
+    const priority = String(model.priority ?? "-").padStart(4);
+    const hidden = model.visibility === "hide" ? "  [hidden in picker]" : "";
+    const marker = index === LIKELY_VISIBLE ? "  <- Codex likely stops advertising here" : "";
+    out.push(`  ${rank}. prio ${priority}  ${model.slug}${hidden}${marker}`);
+  });
+  if (capable.length > LIKELY_VISIBLE) {
+    out.push("");
+    out.push(
+      `  ${capable.length} models carry v2, but Codex advertises only a small priority-ordered`,
+    );
+    out.push(
+      "  subset. Models far down this list may never appear. Turn off the ones you do not",
+    );
+    out.push("  want so the ones you do want are not crowded out:");
+    out.push("    ./bin/control subagents set <slug> off");
+  }
+}
+
+// A catalog older than the settings that shape it is the single most common
+// reason a subagent change appears to do nothing.
+if (existsSync(SETTINGS_PATH)) {
+  const settingsAge = statSync(SETTINGS_PATH).mtimeMs;
+  const catalogAge = statSync(CATALOG_PATH).mtimeMs;
+  if (settingsAge > catalogAge) {
+    out.push("");
+    out.push("STALE: subagent settings changed after the catalog was built.");
+    out.push("  Codex is reading an older list than the one you configured. Rebuild:");
+    out.push("    node src/catalog.mjs");
+    out.push("  Then fully quit and reopen Codex.");
+  }
+}
+
+process.stdout.write(`${out.join("\n")}\n`);


### PR DESCRIPTION
Adds `.claude/skills/codex-subagents/` — a skill for getting non-OpenAI models offered to Codex as subagents, proving they work, and fixing it when they don't.

## Why

The flow has four steps that each fail silently: pick a mode, enable the model, rebuild the catalog, fully restart Codex. Miss the rebuild or the restart and nothing changes, with no error anywhere. There is also no single command that answers the actual question — *which models can Codex pick right now?*

## What ships

**`SKILL.md`** — the three modes, the CLI surface, the agent-capability check, and troubleshooting.

**`subagent-report.mjs`** — reads the merged catalog Codex actually consumes and reports what is spawnable, in Codex's own priority order. `control subagents status` reports **intent**; the merged catalog is **truth**. They drift apart whenever the catalog is not rebuilt after a settings change, so the report compares mtimes and prints a `STALE` warning naming the fix.

Against a real install:

```
Mode:     all
Catalog:  41 models, 16 spawnable as subagents
Disabled: 19 model(s) held back by an explicit off

Spawnable, in the order Codex ranks them:

   1. prio    1  gpt-5.6-sol
   2. prio    1  gpt-5.6-sol-wm  [hidden in picker]
   3. prio    1  grok-oauth/grok-4.5
   ...
   9. prio   31  opencode-go/glm-5.2  <- Codex likely stops advertising here
```

## Two traps found while verifying, now documented

**Codex advertises only a small priority-ordered subset** of spawn overrides — AGENTS.md says so, and it means enabling more models *buries* the ones you wanted rather than adding choices. The report prints Codex's ranking and marks where the cut probably falls, so the fix (turn off what is above) is visible instead of guessed.

**The registry is camelCase (`multiAgentVersion`); the merged catalog is Codex's snake_case wire format (`multi_agent_version`).** Reading the wrong key reports zero capable models on a perfectly healthy install, which looks exactly like a real fault. I hit this while building the report and left a comment at the filter so the next reader doesn't.

## Verified

Everything in the skill was executed, not assumed:

- Report against the live install (41 models, 16 spawnable) and against three synthetic states: missing catalog (exit 1 with the doctor hint), zero capable, and settings newer than catalog (`STALE` fires).
- `control subagents` usage string checked against the real CLI — `mode <all|selected|proven>` and `set <model-slug> <on|off>` match; `select-all`/`unselect-all` were missing from my first draft and are now included.
- `checkAgentCapability` imports and resolves as a function. **Not executed** — it is a real `codex exec` turn that spends provider quota. The skill says so and tells the caller to get approval first.
- The skill's claim that an explicit `off` beats `mode: all` — confirmed against `applyMultiAgentSettings`: under `all`, a disabled model resolves to `v1`.
- Full loop end to end in an isolated state dir: `mode selected` + `set opencode-go/glm-5.2 on` → applied to the camelCase registry → rendered to snake_case → report lists exactly that one model, with the non-enabled sibling correctly absent.

All mutation tests ran against a temporary `MODEL_ROUTER_MULTI_AGENT_STATE`, never the real config.

`npm run check` and `npm test` pass: 493 tests, 488 passed, 0 failed.

## Note

Docs and a helper only — no `src/` changes, so nothing about routing behavior moves.
