### PR TITLE
fix(router): meter routed compaction and resolve its subagent payloads

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -37,7 +37,7 @@ import {
   readProviderSelection,
   selectedConfiguredListedModels,
 } from "./provider-selection.mjs";
-import { ResponseUsageTransform } from "./response-usage.mjs";
+import { ResponseUsageTransform, tokenUsageFromPayload } from "./response-usage.mjs";
 import {
   CollaborationToolCallTransform,
   flattenCollaborationHistory,
@@ -912,13 +912,19 @@ function extractResponseText(payload) {
   return text.join("\n");
 }
 
-async function summarize(payload, route, signal) {
+async function summarize(request, payload, route, signal) {
   const originalInput = Array.isArray(payload.input) ? payload.input : [];
   // Compaction replays the whole conversation, so any image still in it would
   // reach the text-only model unbridged and fail the compaction rather than
   // the turn. The evidence is already cached from the turn that pasted it.
+  //
+  // It replays the collaboration items too, so the agent-payload resolution a
+  // routed turn performs has to happen here as well -- otherwise a compaction
+  // inside a `/goal` or subagent session summarizes opaque payloads. The relay
+  // is cached by ciphertext, so a conversation whose turns already resolved
+  // costs nothing extra here.
   const bridged = await bridgeVisionInput(
-    normalizeRoutedInput(originalInput),
+    await normalizeRoutedAgentInput(request, originalInput, signal),
     route,
     signal,
   );
@@ -945,8 +951,15 @@ async function summarize(payload, route, signal) {
     return { ok: false, status: 502, payload: { error: { message: "Compact response is too large." } } };
   }
   const parsed = JSON.parse(bytes.toString("utf8"));
-  if (!upstream.ok) return { ok: false, status: upstream.status, payload: parsed };
-  return { ok: true, summary: extractResponseText(parsed), input: originalInput };
+  // Compaction is a plain non-streaming call, so the usage block (when the
+  // provider sends one) is already in hand. `tokenUsageFromPayload` returns
+  // undefined when it is absent, and `recordUsageEvent` then omits the token
+  // fields entirely rather than metering an invented zero.
+  const usage = tokenUsageFromPayload(parsed);
+  if (!upstream.ok) {
+    return { ok: false, status: upstream.status, payload: parsed, usage };
+  }
+  return { ok: true, summary: extractResponseText(parsed), input: originalInput, usage };
 }
 
 function compactionSnapshot(model, item, status = "completed") {
@@ -987,11 +1000,13 @@ function writeCompactionSse(response, model, summary) {
   response.end("data: [DONE]\n\n");
 }
 
-async function handleRoutedCompaction(response, payload, route, signal, v2) {
-  const result = await summarize(payload, route, signal);
+// Returns what the request path needs to meter and log the compaction, so a
+// routed compaction leaves the same telemetry trail as any other routed turn.
+async function handleRoutedCompaction(request, response, payload, route, signal, v2) {
+  const result = await summarize(request, payload, route, signal);
   if (!result.ok) {
     writeJson(response, result.status, result.payload);
-    return;
+    return { status: result.status, usage: result.usage };
   }
   if (v2) {
     if (payload.stream === false) {
@@ -1004,9 +1019,10 @@ async function handleRoutedCompaction(response, payload, route, signal, v2) {
     } else {
       writeCompactionSse(response, payload.model, result.summary);
     }
-    return;
+    return { status: 200, usage: result.usage };
   }
   writeJson(response, 200, { output: compactOutput(result.input, result.summary) });
+  return { status: 200, usage: result.usage };
 }
 
 async function handleModels(response) {
@@ -1110,7 +1126,29 @@ async function handleResponses(request, response, requestUrl) {
     });
 
     if (route && (compactV1 || compactV2)) {
-      await handleRoutedCompaction(response, payload, route, controller.signal, compactV2);
+      const compaction = await handleRoutedCompaction(
+        request,
+        response,
+        payload,
+        route,
+        controller.signal,
+        compactV2,
+      );
+      // Compaction used to return here without metering or logging, so neither
+      // a successful nor a failed one appeared anywhere in the router's own
+      // telemetry. Mirror the ordinary request path exactly.
+      recordUsageEvent({
+        model: route.slug,
+        provider: canonicalProviderId(route.provider),
+        status: compaction.status,
+        durationMs: Date.now() - startedAt,
+        ...compaction.usage,
+      });
+      if (!QUIET) {
+        console.error(
+          `[codex-router] model=${requestedModel || "unknown"} provider=${route.provider} status=${compaction.status}`,
+        );
+      }
       return;
     }
 

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -1,7 +1,14 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import http from "node:http";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -2817,5 +2824,237 @@ test("native redirect falls back to native when the target cannot route", async 
     await stopChild(router);
     await closeServer(native.server);
     rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+function usageEvents(stateDir) {
+  const file = path.join(stateDir, "usage-events.jsonl");
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+// The router meters after it has already answered the client, so the fetch can
+// resolve before the event reaches disk. Poll rather than sleep.
+async function waitForUsageEvents(stateDir, count, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const events = usageEvents(stateDir);
+    if (events.length >= count) return events;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${count} usage events: ${child.testErrors()}`);
+}
+
+async function waitForStderr(child, pattern) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (pattern.test(child.testErrors())) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${pattern}: ${child.testErrors()}`);
+}
+
+// A routed compaction that leaves no usage event and no log line is invisible:
+// nothing in the router's own telemetry can answer "was compaction even
+// attempted?", which is what made issue #95 slow to diagnose.
+test("routed compaction records usage and logs on success and on failure", async () => {
+  let failing = false;
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    if (failing) {
+      json(response, 502, { error: { message: "provider refused the compaction" } });
+      return;
+    }
+    json(response, 200, {
+      id: "resp-summary",
+      object: "response",
+      output: [
+        { type: "message", content: [{ type: "output_text", text: "compact summary" }] },
+      ],
+      usage: { input_tokens: 1234, output_tokens: 56, total_tokens: 1290 },
+    });
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "routing-compaction-usage-"));
+  const routerPort = await openPort();
+  // QUIET stays off here: the log line is half of what this test asserts.
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  });
+  const headers = {
+    Authorization: "Bearer CODEX_CALLER_SECRET",
+    "Content-Type": "application/json",
+  };
+  const body = JSON.stringify({
+    model: "deepseek/deepseek-v4-pro",
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "keep me" }] },
+    ],
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    const ok = await fetch(`${routerBase(routerPort)}/responses/compact`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    assert.equal(ok.status, 200, await ok.text());
+    const [success] = await waitForUsageEvents(stateDir, 1, router);
+    assert.equal(success.model, "deepseek/deepseek-v4-pro");
+    assert.equal(success.provider, "deepseek");
+    assert.equal(success.status, 200);
+    assert.equal(success.inputTokens, 1234);
+    assert.equal(success.outputTokens, 56);
+    assert.equal(success.totalTokens, 1290);
+    await waitForStderr(
+      router,
+      /\[codex-router\] model=deepseek\/deepseek-v4-pro provider=deepseek status=200/,
+    );
+
+    failing = true;
+    const failed = await fetch(`${routerBase(routerPort)}/responses/compact`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    assert.equal(failed.status, 502);
+    const events = await waitForUsageEvents(stateDir, 2, router);
+    const failure = events.at(-1);
+    assert.equal(failure.model, "deepseek/deepseek-v4-pro");
+    assert.equal(failure.provider, "deepseek");
+    assert.equal(failure.status, 502);
+    // A failed compaction reports no tokens at all rather than zeros, which
+    // would be indistinguishable from the zero-token accounting behind #95.
+    assert.equal("inputTokens" in failure, false);
+    assert.equal("outputTokens" in failure, false);
+    assert.equal("totalTokens" in failure, false);
+    await waitForStderr(
+      router,
+      /\[codex-router\] model=deepseek\/deepseek-v4-pro provider=deepseek status=502/,
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// AGENTS.md requires the same collaboration handling on `/responses` and
+// `/responses/compact` alike. Compaction replays the whole conversation, so a
+// `/goal` or subagent session compacting through a routed model would otherwise
+// summarize opaque payloads.
+test("routed compaction resolves subagent handoffs before summarizing", async () => {
+  const nativeRequests = [];
+  const native = await mockServer(async (request, response) => {
+    nativeRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    const relayArguments = JSON.stringify({ payload: "Review the routed diff." });
+    const events = [
+      {
+        type: "response.output_item.added",
+        item: {
+          type: "function_call",
+          id: "fc_relay",
+          name: "relay_external_agent_payload",
+          arguments: "",
+        },
+      },
+      {
+        type: "response.function_call_arguments.done",
+        item_id: "fc_relay",
+        arguments: relayArguments,
+      },
+    ];
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(
+      `${events
+        .map((entry) => `event: ${entry.type}\ndata: ${JSON.stringify(entry)}\n\n`)
+        .join("")}data: [DONE]\n\n`,
+    );
+  });
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, {
+      id: "resp-summary",
+      object: "response",
+      output: [
+        { type: "message", content: [{ type: "output_text", text: "compact summary" }] },
+      ],
+    });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses/compact`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CHATGPT_SESSION_TOKEN",
+        "ChatGPT-Account-Id": "account-id",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "kimi-oauth/k3",
+        input: [
+          {
+            type: "agent_message",
+            id: "amsg_routed",
+            author: "/root",
+            recipient: "/root/critic",
+            content: [
+              {
+                type: "input_text",
+                text: "Message Type: NEW_TASK\nTask name: /root/critic\nSender: /root\nPayload:\n",
+              },
+              {
+                type: "encrypted_content",
+                encrypted_content: "Summarize the routed subagent handoff.",
+              },
+            ],
+          },
+          {
+            type: "agent_message",
+            id: "amsg_native",
+            author: "/root",
+            recipient: "/root/critic",
+            content: [
+              { type: "input_text", text: "Message Type: MESSAGE\nSender: /root\nPayload:\n" },
+              { type: "encrypted_content", encrypted_content: "gAAAAA-test-payload=" },
+            ],
+          },
+        ],
+      }),
+    });
+    assert.equal(response.status, 200, await response.text());
+    assert.equal(gatewayRequests.length, 1);
+    const sent = gatewayRequests[0].input;
+
+    const routed = sent.find((item) => item?.id === "amsg_routed");
+    assert.equal(routed.content.some((part) => part.type === "encrypted_content"), false);
+    assert.equal(routed.content.at(-1).type, "input_text");
+    assert.equal(routed.content.at(-1).text, "Summarize the routed subagent handoff.");
+
+    // The Fernet-shaped payload proves the request itself is threaded through:
+    // resolving it needs the caller's native session for the relay.
+    const relayed = sent.find((item) => item?.id === "amsg_native");
+    assert.equal(relayed.content.some((part) => part.type === "encrypted_content"), false);
+    assert.equal(relayed.content.at(-1).text, "Review the routed diff.");
+    assert.equal(nativeRequests.length, 1);
+    assert.equal(nativeRequests[0].headers.authorization, "Bearer CHATGPT_SESSION_TOKEN");
+  } finally {
+    await stopChild(router);
+    await Promise.all([closeServer(native.server), closeServer(gateway.server)]);
   }
 });


### PR DESCRIPTION
Two router defects found while root-causing #95. Neither caused that issue — it turned out to be an upstream opencode token-accounting regression — but both are real, and the first is why it took so long to diagnose.

## 1. Routed compaction left no telemetry trail at all

`handleRoutedCompaction` returned before the metering and logging every other request path performs. A routed compaction — **success or failure** — produced no usage event and no log line. There was no way to answer "was compaction even attempted?" from the router's own telemetry, which is exactly the question #95 hinged on.

It now returns its status and the dispatch site meters and logs it, mirroring the ordinary path's field names and QUIET gating.

**On token counts, which is the interesting part.** `recordUsageEvent` omits each token key entirely when the value isn't a finite non-negative number, so the record distinguishes "no token data" from "zero tokens". Compaction is a plain non-streaming call, so its body is already parsed — this reuses `tokenUsageFromPayload`, the same normalizer the streaming `ResponseUsageTransform` uses, so compaction and ordinary turns derive tokens identically rather than through a second hand-rolled extraction.

When the response carries no `usage` — a failure body, the >32 MB bail-out, or a provider that simply doesn't send one — **no token keys are written**. Deliberately not falling back to `0`: an explicit `inputTokens: 0` is precisely what the upstream regression behind #95 looked like, so writing zeros would manufacture the false signal this change exists to make visible. A test locks that in with `"inputTokens" in failure === false`.

## 2. Compaction summarized opaque subagent payloads

Routed turns call `normalizeRoutedAgentInput`, which resolves `agent_message` `encrypted_content` into readable text. `summarize()` called only `normalizeRoutedInput`, so a compaction inside a `/goal` or subagent session summarized ciphertext — and wrote that garbage summary permanently into the conversation's replacement history.

AGENTS.md requires the same handling on `/responses` and `/responses/compact` alike. #109 just landed exactly this rule for the native path; this is the routed mirror image that was missed.

**Safety, since this adds a relay to the compaction path:** ordinary conversations are byte-for-byte unchanged — the rewrite only fires when the `Message Type: … Payload:` envelope matches alongside a non-empty `encrypted_content` part. Routed-authored (non-Fernet) payloads resolve **purely locally**, no network, which is the `/goal` case. Fernet payloads do relay to the native endpoint, but it is the identical call the routed turn already made for the identical items, cached by SHA-256 of the ciphertext with a 15-minute TTL, using `nativeHeaders(request)` — the caller's own session, no second credential path, no extra provider quota.

It can throw with `status = 502` on relay failure, surfacing as a generic `local_router_error` with no body leakage. That is the right trade: a bounded, visible 502 on conversations containing a native encrypted handoff beats today's behavior of silently succeeding while summarizing ciphertext.

`result.input` stays `originalInput` for the v1 `compactOutput` path — `extractUserMessages` only reads `type: "message"` items, so `agent_message` was never in that selection.

## Tests

Both verified RED against unfixed code:

- **Observability** — `Timed out waiting for 1 usage events`, with captured stderr containing only the startup line. No event and no log line existed.
- **Payloads** — the `encrypted_content` assertion failed: the opaque part reached the gateway.

GREEN after. The pre-existing routed-compaction test passed throughout, so these aren't re-testing covered ground. Note the existing dual-endpoint test at `test/routing.test.mjs:1356` uses the native slug `gpt-5.6-sol`, so it only ever exercised the native path — routed-path coverage here is genuinely new.

`npm run check` and `npm test` pass: 495 tests, 490 passed, 0 failed (baseline 493/488; exactly 2 added).

## Not included

The third idea from that investigation — substituting an estimated token count when the upstream reports zero — is deliberately left out. It papers over the provider's bug with a heuristic that risks compacting too early, and needs a live test first.
