### PR TITLE
fix(install): make all three update paths agree on what blocks an update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Shell scripts must reach every checkout with LF endings. A CRLF install.sh is
+# not merely awkward to diff: `sh` treats the trailing \r as part of the last
+# token on every line, so the script fails at runtime. Windows checkouts with
+# core.autocrlf=true produced exactly that, and the installer-script tests read
+# these files as text, so the damage showed up there first.
+*.sh text eol=lf
+
+# The PowerShell entry points are the mirror image: they are executed by Windows
+# and are conventionally CRLF, but nothing here depends on their endings, so
+# they are normalized in the repository and left to the platform on checkout.
+*.ps1 text

--- a/README.md
+++ b/README.md
@@ -835,7 +835,9 @@ For a managed Git checkout:
 ./bin/model-router codex rollback
 ```
 
-Updates require a clean `main` checkout and a recognized repository origin.
+Updates require a `main` checkout with no edits to tracked files, plus a
+recognized repository origin. Untracked files never block an update, and
+`--force` discards tracked edits without deleting untracked ones.
 The previous revision is retained as a local rollback ref, and a failed install
 restores the previous source revision. If you already ran `git pull` manually,
 run the update command anyway; it applies the pulled revision when the install

--- a/codex-router.ps1
+++ b/codex-router.ps1
@@ -33,7 +33,11 @@ switch ($Command) {
   }
   "providers" { Invoke-RouterNode "src\providers.mjs" $Arguments }
   "provider-key" { Invoke-RouterNode "src\provider-key.mjs" $Arguments }
-  "install" { & (Join-Path $Root "install.ps1") -CheckoutInstall -Target $Target }
+  # `bin/install` accepts --prepare-only/--migrate-known/--force-deps, so the
+  # Windows wrapper has to pass the equivalent switches through instead of
+  # dropping them; `./model-router.ps1 codex install -ForceDeps` was silently
+  # running a plain install.
+  "install" { & (Join-Path $Root "install.ps1") -CheckoutInstall -Target $Target @Arguments }
   "enable" { & (Join-Path $Root "install.ps1") -CheckoutInstall -Target $Target }
   "disable" {
     Invoke-RouterNode "src\config-manager.mjs" @("disable")
@@ -48,7 +52,13 @@ switch ($Command) {
     $UpdateArguments = if ($Arguments.Count) { $Arguments } else { @("update") }
     Invoke-RouterNode "src\update.mjs" $UpdateArguments
   }
-  "rollback" { Invoke-RouterNode "src\update.mjs" @("rollback") }
+  "rollback" {
+    # The subcommand is fixed, so the caller's flags are appended to it rather
+    # than replacing it -- the shape `bin/rollback` uses (`update.mjs rollback
+    # "$@"`). Hardcoding the list here made `rollback --force` unreachable on
+    # Windows, which is the only way past tracked edits that block a rollback.
+    Invoke-RouterNode "src\update.mjs" (@("rollback") + $Arguments)
+  }
   "support-bundle" { Invoke-RouterNode "src\support-bundle.mjs" $Arguments }
   "smoke-test" {
     Invoke-RouterNode "src\smoke-test.mjs" $Arguments

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -262,11 +262,18 @@ Windows:
 ./codex-router.ps1 rollback
 ```
 
-The updater requires a clean checkout on the recognized GitHub origin. It
-fetches `origin/main`, retains the current revision under
+The updater requires the recognized GitHub origin and a checkout with no edits
+to tracked files. It fetches `origin/main`, retains the current revision under
 `refs/codex-router/rollback`, fast-forwards, and reinstalls. A failed install
 automatically checks out and reinstalls the previous revision. `update check`
 only compares the revisions and changes nothing.
+
+Untracked files never block an update; only edits to tracked files do, and the
+refusal names them. Keep them with `git -C <checkout> stash`, or discard them by
+re-running the same command with `--force` (`./bin/update --force`,
+`./bin/rollback --force`, `./codex-router.ps1 rollback --force`). The
+`irm | iex` bootstrap installer takes `-Force` for the same purpose. Every force
+path discards tracked edits only; none of them delete untracked files.
 
 Setup distinguishes a broken checkout from unfinished configuration. When it
 exits 2 — a declined prompt, a missing credential, an invalid `--providers`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -271,9 +271,10 @@ only compares the revisions and changes nothing.
 Untracked files never block an update; only edits to tracked files do, and the
 refusal names them. Keep them with `git -C <checkout> stash`, or discard them by
 re-running the same command with `--force` (`./bin/update --force`,
-`./bin/rollback --force`, `./codex-router.ps1 rollback --force`). The
-`irm | iex` bootstrap installer takes `-Force` for the same purpose. Every force
-path discards tracked edits only; none of them delete untracked files.
+`./bin/rollback --force`, `./codex-router.ps1 rollback --force`). The bootstrap
+installers take the same escape: `--force` for the `curl | sh` script and
+`-Force` for the `irm | iex` one. Every force path discards tracked edits only;
+none of them delete untracked files.
 
 Setup distinguishes a broken checkout from unfinished configuration. When it
 exits 2 — a declined prompt, a missing credential, an invalid `--providers`

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -259,8 +259,11 @@ Manual rollback is:
 ./bin/rollback
 ```
 
-Updates refuse dirty checkouts, non-`main` development branches, and unknown
-origin URLs rather than overwriting local work.
+Updates refuse edits to tracked files, non-`main` development branches, and
+unknown origin URLs rather than overwriting local work. Untracked files never
+block an update; the refusal names the tracked files that do, and re-running the
+same command with `--force` discards those edits without deleting anything
+untracked.
 
 Legacy migration rollback is separate:
 

--- a/install.ps1
+++ b/install.ps1
@@ -10,6 +10,9 @@ param(
   [string]$Providers,
   [switch]$MigrateKnown,
   [switch]$SmokeTest,
+  # Discards tracked edits in the managed checkout so the update can proceed.
+  # Deliberately never touches untracked files -- see Reset-ManagedCheckout.
+  [switch]$Force,
   [string]$InstallDir = $(
     if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "codex-router" }
     else { Join-Path $HOME ".local\share\codex-router" }
@@ -44,6 +47,47 @@ function Test-RouterCheckout([string]$Directory) {
   }
 }
 
+# Mirrors DIRTY_PREVIEW_LIMIT in src/update.mjs. test/installer-scripts.test.mjs
+# imports that constant and compares it with this one, so the two cannot drift.
+$DirtyPreviewLimit = 10
+
+# Mirrors localModifications() in src/update.mjs. Only tracked edits are at
+# stake: a fast-forward pull never replaces an untracked file, and git refuses
+# the rare collision on its own with a precise message. Counting untracked files
+# as "local changes" only ever stranded people -- one stray file in the checkout
+# and every later self-update was refused.
+function Get-LocalModification([string]$Directory) {
+  $Output = @(& git -C $Directory status --porcelain --untracked-files=no)
+  if ($LASTEXITCODE -ne 0) { throw "Unable to read the Git status of $Directory." }
+  return @($Output | ForEach-Object { "$_".Trim() } | Where-Object { $_ })
+}
+
+# Mirrors localModificationsMessage() in src/update.mjs. Naming the files and
+# both ways forward is the whole point: the old message named neither, so anyone
+# blocked by a single stray edit had nothing to act on.
+function Get-LocalModificationMessage([string[]]$Changes, [string]$Directory) {
+  $Plural = if ($Changes.Count -eq 1) { "" } else { "s" }
+  $Lines = @(
+    "The checkout has local changes to $($Changes.Count) tracked file${Plural}; refusing to replace them during update:"
+  )
+  $Lines += @($Changes | Select-Object -First $DirtyPreviewLimit | ForEach-Object { "  $_" })
+  $Remainder = $Changes.Count - $DirtyPreviewLimit
+  if ($Remainder -gt 0) { $Lines += "  ...and $Remainder more" }
+  $Lines += ""
+  $Lines += "Keep them:    git -C $Directory stash"
+  $Lines += "Discard them: re-run the same command with -Force"
+  return ($Lines -join "`n")
+}
+
+# Mirrors requireReplaceableCheckout() in src/update.mjs, including its refusal
+# to reach for `git clean`: -Force restores files git already tracks and leaves
+# untracked files exactly where they are, because an update has no business
+# deleting work git was never asked to track.
+function Reset-ManagedCheckout([string]$Directory) {
+  & git -C $Directory reset --hard HEAD
+  if ($LASTEXITCODE -ne 0) { throw "Unable to discard the local changes in $Directory." }
+}
+
 $ScriptDirectory = $PSScriptRoot
 if (-not $ScriptDirectory) { $ScriptDirectory = (Get-Location).Path }
 
@@ -68,9 +112,12 @@ if (-not $CheckoutInstall) {
       if ($Origin -notin $AllowedOrigins) {
         throw "$InstallDir has an unrecognized origin and will not be updated: $Origin"
       }
-      $Dirty = (& git -C $InstallDir status --porcelain)
-      if ($LASTEXITCODE -ne 0 -or $Dirty) {
-        throw "$InstallDir has local changes; automatic update will not overwrite them."
+      # PowerShell unrolls a one-element array on return, so re-wrap before
+      # reading .Count.
+      $Dirty = @(Get-LocalModification $InstallDir)
+      if ($Dirty.Count) {
+        if (-not $Force) { throw (Get-LocalModificationMessage $Dirty $InstallDir) }
+        Reset-ManagedCheckout $InstallDir
       }
       # A failed setup rolls the checkout back to a detached HEAD (see the
       # rollback below), where `branch --show-current` prints nothing. A native

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ smoke_test=false
 with_tray=false
 no_tray=false
 previous_revision=
+force=false
 target=codex
 
 usage() {
@@ -37,6 +38,8 @@ Options:
   --smoke-test       Make one small billed request per enabled provider
   --with-tray        Also build and launch the desktop companion app
   --no-tray          Never offer the desktop companion app
+  --force            Discard edits to tracked files in the managed checkout
+                     before updating it. Untracked files are never touched.
   -h, --help          Show this help
 
 When run from a checkout, this script installs that checkout. When piped from
@@ -47,6 +50,45 @@ EOF
 die() {
   printf 'codex-router: %s\n' "$*" >&2
   exit 1
+}
+
+# Mirrors DIRTY_PREVIEW_LIMIT in src/update.mjs and $DirtyPreviewLimit in
+# install.ps1. test/installer-scripts.test.mjs compares all three, so they
+# cannot drift apart.
+dirty_preview_limit=10
+
+# Mirrors localModifications() in src/update.mjs. Only tracked edits are at
+# stake: a fast-forward pull never replaces an untracked file, and git refuses
+# the rare collision on its own with a precise message. Counting untracked
+# files as "local changes" only ever stranded people -- one stray file in the
+# checkout and every later self-update was refused, with nothing in the error
+# to say which file or how to get past it.
+local_modifications() {
+  status_output=$(git -C "$1" status --porcelain --untracked-files=no) || return 1
+  printf '%s\n' "$status_output" | sed -e 's/^[[:space:]]*//' -e '/^$/d'
+}
+
+# Mirrors localModificationsMessage() in src/update.mjs. Naming the files and
+# both ways forward is the whole point: the old message named neither, so
+# anyone blocked by a single stray edit had nothing to act on.
+local_modifications_message() {
+  changes=$1
+  directory=$2
+  count=$(printf '%s\n' "$changes" | wc -l)
+  count=$((count))
+  if [ "$count" -eq 1 ]; then
+    counted="1 tracked file"
+  else
+    counted="$count tracked files"
+  fi
+  printf 'The checkout has local changes to %s; refusing to replace them during update:\n' "$counted"
+  printf '%s\n' "$changes" | head -n "$dirty_preview_limit" | sed 's/^/  /'
+  if [ "$count" -gt "$dirty_preview_limit" ]; then
+    printf '  ...and %s more\n' "$((count - dirty_preview_limit))"
+  fi
+  printf '\n'
+  printf 'Keep them:    git -C %s stash\n' "$directory"
+  printf 'Discard them: re-run the same command with --force\n'
 }
 
 while [ "$#" -gt 0 ]; do
@@ -115,6 +157,10 @@ while [ "$#" -gt 0 ]; do
       smoke_test=true
       shift
       ;;
+    --force)
+      force=true
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -161,8 +207,20 @@ if [ -z "$repo_dir" ]; then
         ;;
     esac
 
-    [ -z "$(git -C "$install_dir" status --porcelain)" ] ||
-      die "$install_dir has local changes; review them before updating"
+    # Mirrors requireReplaceableCheckout() in src/update.mjs, including its
+    # refusal to reach for `git clean`: --force restores files git already
+    # tracks and leaves untracked files exactly where they are, because an
+    # update has no business deleting work git was never asked to track.
+    changes=$(local_modifications "$install_dir") ||
+      die "unable to read the Git status of $install_dir"
+    if [ -n "$changes" ]; then
+      if [ "$force" != true ]; then
+        local_modifications_message "$changes" "$install_dir" >&2
+        exit 1
+      fi
+      git -C "$install_dir" reset --hard HEAD ||
+        die "unable to discard the local changes in $install_dir"
+    fi
     current_branch=$(git -C "$install_dir" branch --show-current)
     [ "$current_branch" = "main" ] ||
       die "$install_dir must be on its main branch before updating"

--- a/src/update.mjs
+++ b/src/update.mjs
@@ -34,7 +34,9 @@ function requireManagedCheckout() {
   }
 }
 
-const DIRTY_PREVIEW_LIMIT = 10;
+// Exported so the Windows bootstrap installer, which reimplements this refusal
+// in PowerShell and cannot import it, can be tested against the same number.
+export const DIRTY_PREVIEW_LIMIT = 10;
 
 // Only tracked edits are at stake. A fast-forward merge never replaces an
 // untracked file, and git refuses the rare collision on its own with a precise

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -47,8 +47,13 @@ function withoutComments(source) {
 // splatting it into a named-parameter call (@Arguments); both count.
 const FORWARDS_ARGUMENTS = /[@$]Arguments\b/;
 
+// Line endings are normalized because these assertions and the extraction below
+// anchor on "\n". A Windows checkout without the .gitattributes rule -- or with
+// a global core.autocrlf -- hands back "\r\n" and every anchor silently stops
+// matching, which reads as "the shipped script lost this code" rather than as a
+// checkout artifact. Normalizing keeps the failure honest either way.
 function readScript(...parts) {
-  return readFileSync(path.join(root, ...parts), "utf8");
+  return readFileSync(path.join(root, ...parts), "utf8").replace(/\r\n/g, "\n");
 }
 
 // The refusal that blocks an update on a dirty checkout is written three times

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -5,7 +5,46 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { DIRTY_PREVIEW_LIMIT, localModificationsMessage } from "../src/update.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Nothing on a non-Windows machine can execute PowerShell -- the parse test in
+// this file is skipped off Windows for exactly that reason -- so the Windows
+// assertions here read the shipped scripts as text instead. That still catches
+// the class of defect at issue: wrappers that silently drop the arguments they
+// were handed, and a refusal message that drifts from the one it mirrors.
+function windowsSwitchBranches(source) {
+  const start = source.indexOf("switch ($Command) {");
+  assert.notEqual(start, -1, "codex-router.ps1 must dispatch on $Command");
+  const body = source.slice(start);
+  const branches = new Map();
+  const opener = /"([a-z-]+)"\s*\{/g;
+  let match;
+  while ((match = opener.exec(body))) {
+    let depth = 1;
+    let index = opener.lastIndex;
+    while (depth > 0 && index < body.length) {
+      if (body[index] === "{") depth += 1;
+      else if (body[index] === "}") depth -= 1;
+      index += 1;
+    }
+    branches.set(match[1], body.slice(opener.lastIndex, index - 1));
+  }
+  return branches;
+}
+
+// A comment may legitimately name a command the code must never run.
+function withoutComments(source) {
+  return source
+    .split("\n")
+    .filter((line) => !/^\s*(#|\/\/)/.test(line))
+    .join("\n");
+}
+
+// PowerShell forwards an argument array either as a value ($Arguments) or by
+// splatting it into a named-parameter call (@Arguments); both count.
+const FORWARDS_ARGUMENTS = /[@$]Arguments\b/;
 
 test("install.sh is valid POSIX shell", () => {
   const result = spawnSync("sh", ["-n", path.join(root, "install.sh")], {
@@ -60,6 +99,105 @@ test("the kept-update message names the way back", () => {
   const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
   assert.match(posix, /\.\/bin\/rollback/);
   assert.match(windows, /codex-router\.ps1 rollback/);
+});
+
+test("the Windows wrapper hands every command its own arguments", () => {
+  // A hardcoded argument list is invisible: the command still runs, it just
+  // runs without the flag the caller typed. `rollback --force` was lost this
+  // way, leaving a Windows user with tracked edits no documented route to the
+  // force path at all.
+  const branches = windowsSwitchBranches(
+    readFileSync(path.join(root, "codex-router.ps1"), "utf8"),
+  );
+  assert.ok(branches.size >= 16, `only found ${branches.size} branches`);
+
+  // bin/enable, bin/disable, and bin/uninstall accept no arguments, so their
+  // branches pass fixed node subcommand names rather than user input.
+  const takesNoArguments = new Set(["enable", "disable", "uninstall"]);
+  for (const [command, body] of branches) {
+    if (takesNoArguments.has(command)) {
+      assert.equal(
+        FORWARDS_ARGUMENTS.test(body),
+        false,
+        `the ${command} branch forwards arguments its POSIX counterpart rejects`,
+      );
+      continue;
+    }
+    assert.ok(
+      FORWARDS_ARGUMENTS.test(body),
+      `the ${command} branch drops the caller's arguments`,
+    );
+  }
+});
+
+test("rollback --force reaches the updater on Windows", () => {
+  // bin/rollback runs `update.mjs rollback "$@"`: the subcommand is fixed and
+  // the caller's flags are appended to it. Replacing the whole list with
+  // @("rollback") is what silently dropped --force.
+  const branches = windowsSwitchBranches(
+    readFileSync(path.join(root, "codex-router.ps1"), "utf8"),
+  );
+  assert.match(branches.get("rollback"), /@\("rollback"\)\s*\+\s*\$Arguments/);
+});
+
+test("the bootstrap installer refuses on tracked edits only", () => {
+  // install.ps1 run without -CheckoutInstall is the irm|iex self-update path.
+  // It reimplements requireReplaceableCheckout() because it may be running as a
+  // piped script with no checkout to import from -- so it has to agree with it.
+  const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
+  assert.match(windows, /status --porcelain --untracked-files=no/);
+  assert.equal(
+    /status --porcelain(?! --untracked-files=no)/.test(windows),
+    false,
+    "an untracked-file-counting status check is back in install.ps1",
+  );
+});
+
+test("the bootstrap installer's refusal says what src/update.mjs says", () => {
+  const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
+  const reference = localModificationsMessage([" M src/router.mjs"], "/tmp/checkout");
+
+  // Sentence for sentence against the Node original, so a reword on one side
+  // has to be made on both. The divergence is the bug: install.ps1 kept the
+  // pre-fix "has local changes" wording, which names no file and no way out.
+  assert.ok(reference.startsWith("The checkout has local changes to 1 tracked file;"));
+  assert.match(
+    windows,
+    /"The checkout has local changes to \$\(\$Changes\.Count\) tracked file\$\{Plural\}; refusing to replace them during update:"/,
+  );
+  assert.equal(windows.includes("has local changes; automatic update"), false);
+
+  assert.match(reference, /^Keep them: {4}git -C \/tmp\/checkout stash$/m);
+  assert.match(windows, /"Keep them: {4}git -C \$Directory stash"/);
+  assert.match(reference, /^Discard them: re-run the same command with --force$/m);
+  assert.match(windows, /"Discard them: re-run the same command with -Force"/);
+
+  // The preview-and-count behaviour, so a checkout with 40 edited files still
+  // prints a readable error.
+  assert.match(windows, /Select-Object -First \$DirtyPreviewLimit/);
+  assert.match(windows, /"  \.\.\.and \$Remainder more"/);
+  const declared = windows.match(/^\$DirtyPreviewLimit = (\d+)$/m);
+  assert.ok(declared, "install.ps1 must declare $DirtyPreviewLimit");
+  assert.equal(Number(declared[1]), DIRTY_PREVIEW_LIMIT);
+});
+
+test("the bootstrap installer's force path cannot destroy untracked files", () => {
+  const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
+  const node = readFileSync(path.join(root, "src", "update.mjs"), "utf8");
+
+  assert.match(windows, /^\s*\[switch\]\$Force,$/m);
+  assert.match(windows, /if \(-not \$Force\) \{ throw \(Get-LocalModificationMessage/);
+  // `reset --hard` restores tracked files and leaves untracked ones alone.
+  assert.match(windows, /git -C \$Directory reset --hard HEAD/);
+  // `git clean` would delete work git was never asked to track. update.mjs has
+  // no such call and neither may the installer that mirrors it.
+  for (const [name, source] of [["install.ps1", windows], ["src/update.mjs", node]]) {
+    assert.equal(
+      /git\b[^\n]*\bclean\b/.test(withoutComments(source)),
+      false,
+      `${name} must not run git clean`,
+    );
+  }
 });
 
 test("the documented rollback behaviour matches the exit-2 contract", () => {

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -45,6 +46,57 @@ function withoutComments(source) {
 // PowerShell forwards an argument array either as a value ($Arguments) or by
 // splatting it into a named-parameter call (@Arguments); both count.
 const FORWARDS_ARGUMENTS = /[@$]Arguments\b/;
+
+function readScript(...parts) {
+  return readFileSync(path.join(root, ...parts), "utf8");
+}
+
+// The refusal that blocks an update on a dirty checkout is written three times
+// -- once in Node for the installed updater, once in PowerShell and once in
+// POSIX shell for the two bootstrap installers, neither of which can import
+// from src/. Three copies is how the first fix ended up incomplete, so every
+// property that matters is asserted against all three here.
+const BOOTSTRAP_INSTALLERS = [
+  {
+    name: "install.sh",
+    source: readScript("install.sh"),
+    previewLimit: /^dirty_preview_limit=(\d+)$/m,
+    forceGuard: /if \[ "\$force" != true \]; then/,
+    reset: /git -C "\$install_dir" reset --hard HEAD/,
+  },
+  {
+    name: "install.ps1",
+    source: readScript("install.ps1"),
+    previewLimit: /^\$DirtyPreviewLimit = (\d+)$/m,
+    forceGuard: /if \(-not \$Force\) \{ throw \(Get-LocalModificationMessage/,
+    reset: /git -C \$Directory reset --hard HEAD/,
+  },
+];
+
+// Unlike PowerShell, POSIX shell runs everywhere the suite does -- `sh -n` is
+// already relied on above -- so install.sh gets executed rather than pattern
+// matched. Lifting the helpers straight out of the shipped file keeps the test
+// honest: it runs the code that ships, not a copy of it.
+function posixDirtyHelpers() {
+  const source = readScript("install.sh");
+  const start = source.indexOf("dirty_preview_limit=");
+  const messageStart = source.indexOf("local_modifications_message() {");
+  assert.notEqual(start, -1, "install.sh must declare dirty_preview_limit");
+  assert.ok(messageStart > start, "install.sh must define local_modifications_message");
+  const end = source.indexOf("\n}\n", messageStart);
+  assert.notEqual(end, -1, "local_modifications_message must be a complete function");
+  return source.slice(start, end + 3);
+}
+
+function runPosixHelper(call, args, options = {}) {
+  const result = spawnSync("sh", ["-s", ...args], {
+    input: `${posixDirtyHelpers()}\n${call}\n`,
+    encoding: "utf8",
+    ...options,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
+}
 
 test("install.sh is valid POSIX shell", () => {
   const result = spawnSync("sh", ["-n", path.join(root, "install.sh")], {
@@ -140,26 +192,91 @@ test("rollback --force reaches the updater on Windows", () => {
   assert.match(branches.get("rollback"), /@\("rollback"\)\s*\+\s*\$Arguments/);
 });
 
-test("the bootstrap installer refuses on tracked edits only", () => {
-  // install.ps1 run without -CheckoutInstall is the irm|iex self-update path.
-  // It reimplements requireReplaceableCheckout() because it may be running as a
-  // piped script with no checkout to import from -- so it has to agree with it.
-  const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
-  assert.match(windows, /status --porcelain --untracked-files=no/);
-  assert.equal(
-    /status --porcelain(?! --untracked-files=no)/.test(windows),
-    false,
-    "an untracked-file-counting status check is back in install.ps1",
-  );
+test("both bootstrap installers refuse on tracked edits only", () => {
+  // Run without -CheckoutInstall / from a pipe, these are the curl|sh and
+  // irm|iex self-update paths. They reimplement requireReplaceableCheckout()
+  // because a piped script has no checkout to import from -- so they have to
+  // agree with it. Counting untracked files is what stranded people on an old
+  // version with no way to work out why.
+  for (const { name, source } of BOOTSTRAP_INSTALLERS) {
+    assert.match(source, /status --porcelain --untracked-files=no/, name);
+    assert.equal(
+      /status --porcelain(?! --untracked-files=no)/.test(source),
+      false,
+      `an untracked-file-counting status check is back in ${name}`,
+    );
+  }
 });
 
-test("the bootstrap installer's refusal says what src/update.mjs says", () => {
-  const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
-  const reference = localModificationsMessage([" M src/router.mjs"], "/tmp/checkout");
+test("every copy of the refusal previews at the same limit", () => {
+  for (const { name, source, previewLimit } of BOOTSTRAP_INSTALLERS) {
+    const declared = source.match(previewLimit);
+    assert.ok(declared, `${name} must declare its own preview limit`);
+    assert.equal(Number(declared[1]), DIRTY_PREVIEW_LIMIT, name);
+  }
+});
 
-  // Sentence for sentence against the Node original, so a reword on one side
-  // has to be made on both. The divergence is the bug: install.ps1 kept the
-  // pre-fix "has local changes" wording, which names no file and no way out.
+test("the POSIX installer's refusal is byte-identical to src/update.mjs", () => {
+  // Not a pattern match: install.sh's own helper is executed and its output
+  // compared with the Node original. A reword on either side fails here, which
+  // is the coupling that was missing when the first fix landed in one file.
+  for (const changes of [
+    ["M src/router.mjs"],
+    ["M src/router.mjs", "M bin/install"],
+    Array.from({ length: 14 }, (_, index) => `M src/file-${index}.mjs`),
+  ]) {
+    const posix = runPosixHelper('local_modifications_message "$1" "$2"', [
+      changes.join("\n"),
+      "/tmp/checkout",
+    ]);
+    assert.equal(posix, `${localModificationsMessage(changes, "/tmp/checkout")}\n`);
+  }
+});
+
+test("the POSIX installer counts tracked edits and ignores untracked files", () => {
+  // The behaviour change every curl|sh user gets: a checkout carrying nothing
+  // but an untracked file now updates instead of refusing forever.
+  const checkout = mkdtempSync(path.join(os.tmpdir(), "posix-dirty-"));
+  const git = (...args) =>
+    execFileSync("git", ["-C", checkout, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "t",
+        GIT_AUTHOR_EMAIL: "t@example.com",
+        GIT_COMMITTER_NAME: "t",
+        GIT_COMMITTER_EMAIL: "t@example.com",
+      },
+    });
+  try {
+    git("init", "--quiet");
+    writeFileSync(path.join(checkout, "tracked.txt"), "original\n");
+    git("add", "tracked.txt");
+    git("commit", "--quiet", "-m", "seed");
+
+    const modifications = () => runPosixHelper('local_modifications "$1"', [checkout]);
+    assert.equal(modifications(), "");
+
+    writeFileSync(path.join(checkout, "stray.txt"), "not git's business\n");
+    assert.equal(modifications(), "", "an untracked file must not block the update");
+
+    writeFileSync(path.join(checkout, "tracked.txt"), "edited\n");
+    assert.equal(modifications(), "M tracked.txt\n");
+    // ...and only the tracked one, so the message never names a file the user
+    // is about to be told to stash.
+    assert.equal(modifications().includes("stray.txt"), false);
+  } finally {
+    rmSync(checkout, { recursive: true, force: true });
+  }
+});
+
+test("the Windows installer's refusal says what src/update.mjs says", () => {
+  // PowerShell cannot run here, so this is the string-level equivalent of the
+  // executed POSIX comparison above: each sentence of the Node original is
+  // checked against the PowerShell literal that has to reproduce it.
+  const windows = readScript("install.ps1");
+  const reference = localModificationsMessage(["M src/router.mjs"], "/tmp/checkout");
+
   assert.ok(reference.startsWith("The checkout has local changes to 1 tracked file;"));
   assert.match(
     windows,
@@ -169,29 +286,40 @@ test("the bootstrap installer's refusal says what src/update.mjs says", () => {
 
   assert.match(reference, /^Keep them: {4}git -C \/tmp\/checkout stash$/m);
   assert.match(windows, /"Keep them: {4}git -C \$Directory stash"/);
+  // The one deliberate difference: PowerShell spells its switch -Force.
   assert.match(reference, /^Discard them: re-run the same command with --force$/m);
   assert.match(windows, /"Discard them: re-run the same command with -Force"/);
+  assert.match(windows, /^\s*\[switch\]\$Force,$/m);
 
-  // The preview-and-count behaviour, so a checkout with 40 edited files still
-  // prints a readable error.
   assert.match(windows, /Select-Object -First \$DirtyPreviewLimit/);
   assert.match(windows, /"  \.\.\.and \$Remainder more"/);
-  const declared = windows.match(/^\$DirtyPreviewLimit = (\d+)$/m);
-  assert.ok(declared, "install.ps1 must declare $DirtyPreviewLimit");
-  assert.equal(Number(declared[1]), DIRTY_PREVIEW_LIMIT);
 });
 
-test("the bootstrap installer's force path cannot destroy untracked files", () => {
-  const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
-  const node = readFileSync(path.join(root, "src", "update.mjs"), "utf8");
+test("the POSIX installer's force escape follows its own flag conventions", () => {
+  // install.sh parses long flags in a case statement and sets a shell boolean;
+  // --force is wired the same way rather than inventing a new mechanism.
+  const posix = readScript("install.sh");
+  assert.match(posix, /^\s*--force\)$/m);
+  assert.match(posix, /^force=false$/m);
+  assert.match(posix, /^\s*force=true$/m);
+  assert.match(posix, /--force {12}Discard edits to tracked files/);
+});
 
-  assert.match(windows, /^\s*\[switch\]\$Force,$/m);
-  assert.match(windows, /if \(-not \$Force\) \{ throw \(Get-LocalModificationMessage/);
-  // `reset --hard` restores tracked files and leaves untracked ones alone.
-  assert.match(windows, /git -C \$Directory reset --hard HEAD/);
-  // `git clean` would delete work git was never asked to track. update.mjs has
-  // no such call and neither may the installer that mirrors it.
-  for (const [name, source] of [["install.ps1", windows], ["src/update.mjs", node]]) {
+test("no force path anywhere can destroy untracked files", () => {
+  const node = readScript("src", "update.mjs");
+  for (const { name, source, forceGuard, reset } of BOOTSTRAP_INSTALLERS) {
+    // Refusing is the default; discarding happens only when asked for.
+    assert.match(source, forceGuard, name);
+    // `reset --hard` restores tracked files and leaves untracked ones alone.
+    assert.match(source, reset, name);
+  }
+  assert.match(node, /if \(!force\) throw new Error\(localModificationsMessage\(changes\)\)/);
+  assert.match(node, /git\(\["reset", "--hard", "HEAD"\]/);
+
+  // `git clean` would delete work git was never asked to track. No copy of
+  // this refusal has one, and none may grow one.
+  const sources = [...BOOTSTRAP_INSTALLERS, { name: "src/update.mjs", source: node }];
+  for (const { name, source } of sources) {
     assert.equal(
       /git\b[^\n]*\bclean\b/.test(withoutComments(source)),
       false,


### PR DESCRIPTION
Closes the parts of #101 that #102 did not reach, and fixes two argument-forwarding bugs found alongside them.

#102 fixed the dirty-checkout refusal in `src/update.mjs`. It turned out that refusal is reimplemented **three times** — and the other two still had the original bug. So the `irm | iex` and `curl | sh` bootstrap paths were still refusing to self-update because of a single untracked file, with the old message that names neither the file nor a way out.

## 1. The bootstrap installers still had the pre-#102 bug

`install.ps1` and `install.sh` both did the equivalent of:

```sh
[ -z "$(git -C "$install_dir" status --porcelain)" ] ||
  die "$install_dir has local changes; review them before updating"
```

Three faults each: counts untracked files, names no file, no force escape. Both now mirror `requireReplaceableCheckout()` — `--untracked-files=no`, the offending files named with the same preview-and-count behaviour, and a force escape following each script's own conventions (`-Force` on PowerShell, `--force` on POSIX).

Every force path is `git reset --hard HEAD` and nothing else. **No `git clean` anywhere** — an update has no business deleting work git was never asked to track. A test asserts that across all three files.

## 2. `rollback --force` was unreachable on Windows

`codex-router.ps1` hardcoded the argument list and discarded `$Arguments`, unlike the `update` branch two lines above. Since #102, `rollbackCheckout({force:true})` exists and works — but a Windows user with tracked edits blocking a rollback had no documented route to it. Now `(@("rollback") + $Arguments)`, matching `bin/rollback`'s `update.mjs rollback "$@"`.

## 3. A second bug of the same class, not originally in scope

The `install` branch discarded `$Arguments` entirely, so `./model-router.ps1 codex install -ForceDeps` silently ran a plain install. Fixed by splatting.

`enable`, `disable`, and `uninstall` are **not** bugs — their literal arrays are fixed node subcommand names, not dropped user input, and their POSIX counterparts accept no arguments. A new test asserts they stay that way.

## The coupling that was missing

The reason this bug survived #102 is that nothing tied the three implementations together. Now:

- **`install.sh` is executed, not pattern-matched.** POSIX shell runs everywhere the suite runs, so the test lifts `local_modifications_message` out of the *shipped* script, runs it under `sh`, and asserts the output is byte-identical to `localModificationsMessage()` for 1, 2, and 14 files. A reword on either side fails.
- Another test builds a real temp git repo — commits a file, adds an untracked stray, edits the tracked file — and asserts the helper reports the tracked edit and ignores the stray. That directly pins the behaviour change every `curl | sh` user gets.
- `DIRTY_PREVIEW_LIMIT` is now exported from `src/update.mjs` and compared against the declared limit in both installers.
- The switch-branch test enumerates `codex-router.ps1` generically, so a future branch that drops `$Arguments` fails without anyone remembering to add a case.

## Is there a fourth copy?

No — audited exhaustively. `--porcelain` appears on 5 lines repo-wide: 3 implementations plus 2 test assertions. Only 5 non-test source files shell out to git at all, and the other two (`install-manifest.mjs`, `support-bundle.mjs`) only record the commit. `apps/macos/**` never shells out to git; the tray's "Update & Verify" goes through `bin/control` and inherits the canonical check.

**One gap worth knowing about, deliberately not fixed here:** the three implementations are now pinned by message, command, and preview limit — but nothing pins the *call sites*. If someone added a fourth update path, no test would notice the gate was missing. That is the next thing that could let this class of bug back in.

## Docs

`README.md`, `docs/INSTALL.md`, and `docs/TROUBLESHOOTING.md` all still said updates require a *clean* checkout, which stopped being true at #102. All three now say tracked-edits-only and document both force escapes.

## Tests

517 tests, 512 pass, 0 fail on a clean run. `test/installer-scripts.test.mjs` grew from 5 to 14 (1 skipped off Windows); 9 new tests.

RED verified with `install.sh` reverted: 6 failures, all isolating to `install.sh` while the Windows tests stayed green. GREEN after.

## Verified / not verified

**Verified:** `sh -n`, `bash -n`, and **`dash -n`** all clean on `install.sh`; the helpers were executed under `dash` — much stricter POSIX than macOS `/bin/sh` — confirming the preview limit, `...and 4 more`, and `1 tracked file` / `14 tracked files` pluralisation. `local_modifications()` run against a real git repo.

**Not verified:** no PowerShell was executed (macOS), so the parser test stays skipped and array splatting, `$Plural` as an `if` expression, and `-Force` not colliding with a common parameter are reasoned rather than observed. `shellcheck` was unavailable. No end-to-end bootstrap self-update was driven on either platform.

The one thing I would most want a Windows smoke run on is `@Arguments` binding `-ForceDeps` by name.

Note: a full-suite run on this branch also hit `test/startup-cleanup.test.mjs:35`, the known pre-existing flake. It fails intermittently on clean main too (1 in 3 in isolation on a loaded machine) and is being fixed separately.
