### PR TITLE
test: make the startup-cleanup watchdog wait on progress, not a fixed deadline

### DIFF
--- a/test/startup-cleanup.test.mjs
+++ b/test/startup-cleanup.test.mjs
@@ -32,7 +32,68 @@ async function portIsClosed(port) {
   });
 }
 
-test("startup failure terminates services that already became healthy", { timeout: 20_000 }, async () => {
+// Startup is a pipeline of five sequential child spawns, each gated on an HTTP
+// health probe that backs off from 200 ms to a 2 s cap and aborts any single
+// probe after 1 s. That makes the run time depend on how fast this machine can
+// fork and schedule processes, not on the behaviour under test: measured
+// end-to-end at ~1.2 s idle, ~1.5 s under 2x CPU oversubscription, and ~18.6 s
+// when a concurrent fork storm makes spawns slow enough that live-but-starved
+// servers keep blowing the 1 s probe abort and the loop retries behind the
+// backoff. A single fixed budget for the whole pipeline therefore races machine
+// speed, which is why 10 s failed on a busy machine while startup was working
+// perfectly.
+//
+// Progress, not elapsed time, separates "slow" from "stuck": every stage
+// announces itself on the child's stderr ("[kimi-oauth] listening", the
+// gateway's spawn error, "startup failed"). Waiting on that observable signal
+// and failing only once it stops arriving keeps the guard against a hang while
+// letting a loaded machine take as long as it needs, and the budget no longer
+// accumulates across stages.
+//
+// 30 s is ~2x the worst single-stage silence observed in a run that still
+// produced the correct result (16.3 s, under the fork storm above). It stays
+// meaningful because start.mjs self-limits every wait -- 30 s per forwarder,
+// 300 s for the gateway -- so the only silence this can catch is the gateway's,
+// and it reports it 270 s sooner than start.mjs would.
+const STARTUP_STALL_MS = 30_000;
+
+// Fails only if the child produces no output at all for STARTUP_STALL_MS and
+// has not exited. Resolves as soon as it exits, however long that takes.
+function waitForStartupExit(child, readErrors) {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    let lastOutput = started;
+    const onProgress = () => {
+      lastOutput = Date.now();
+    };
+    child.stderr.on("data", onProgress);
+    const finish = () => {
+      clearInterval(watchdog);
+      child.stderr.off("data", onProgress);
+    };
+    const watchdog = setInterval(() => {
+      const idleMs = Date.now() - lastOutput;
+      if (idleMs < STARTUP_STALL_MS) return;
+      finish();
+      reject(
+        new Error(
+          `startup stalled: no output for ${idleMs} ms after waiting ${Date.now() - started} ms in total; stderr so far:\n${readErrors()}`,
+        ),
+      );
+    }, 250);
+    child.once("exit", (code, signal) => {
+      finish();
+      resolve({ code, signal });
+    });
+  });
+}
+
+// The stall watchdog is the real guard and gives a diagnosable message; this
+// outer timeout only backstops a child that hangs while still chattering. It
+// has to clear a loaded run (~19 s) plus one full stall window (30 s), so 20 s
+// was actually below the floor for reporting a stall at all. A passing run is
+// unaffected -- this bound is only reached when something is already broken.
+test("startup failure terminates services that already became healthy", { timeout: 120_000 }, async () => {
   const ports = await Promise.all(Array.from({ length: 5 }, () => freePort()));
   assert.equal(new Set(ports).size, ports.length);
   const [routerPort, gatewayPort, oauthPort, apiPort, grokOauthPort] = ports;
@@ -64,13 +125,7 @@ test("startup failure terminates services that already became healthy", { timeou
   });
 
   try {
-    const exit = await new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error(`startup did not fail promptly: ${errors}`)), 10_000);
-      child.once("exit", (code, signal) => {
-        clearTimeout(timeout);
-        resolve({ code, signal });
-      });
-    });
+    const exit = await waitForStartupExit(child, () => errors);
     assert.equal(exit.signal, null);
     assert.equal(exit.code, 1, errors);
     assert.match(errors, /\[model-router\] startup failed/);


### PR DESCRIPTION
Fixes the intermittent failure in `test/startup-cleanup.test.mjs:35` ("startup failure terminates services that already became healthy"), which fails on clean main roughly 1 run in 3 on a loaded machine.

## Root cause

The test gave the **entire startup pipeline** one fixed 10-second deadline. That pipeline is five sequential spawns — `oauth-forwarder` → `api-forwarder` → `grok-oauth-forwarder` → gateway → router — each gated on `waitForHealth` (`src/start.mjs:114`), which backs off 200 ms → 2 s and aborts each probe after 1 s.

So the test's duration tracked **how fast the machine can fork and schedule processes**, not the behaviour it asserts.

**The obvious theory was wrong, which is worth recording.** Pure CPU load barely moves it: 2× core-count busy loops took it from 1.2 s to 1.5 s. What actually breaks it is **fork/exec contention** — which is what "other work running concurrently" means when that work is a build or a test suite. Under that, a live-but-starved forwarder answers slower than the 1 s probe abort, every probe aborts, and the loop retries behind the backoff. Measured up to 18.6 s end to end.

The reported failure was reproduced byte-for-byte, including the `[kimi-oauth] listening` / `[api-forwarder] listening` output and line 68.

## Fix

Wait on the observable terminal signal — child exit — and fail only when *progress* stops, since every stage announces itself on stderr. The budget no longer accumulates across stages, so load stretches the run instead of consuming a shared allowance. The failure message now reports idle time and total wait, so a future flake is diagnosable instead of just "did not fail promptly".

**No assertion was changed.** The test still verifies that a startup failure terminates services that already became healthy.

Deliberately not done: no test-only backoff env var and no change to `src/start.mjs`. The watchdog fully addresses the flake, and retuning production probe timing for test convenience adds risk without need.

## Verification

| Condition | Result |
|---|---|
| Quiet, 12 runs | 12/12 pass (~1.24 s each) |
| 2× core-count CPU spinners, 8 runs | 8/8 pass (~1.5 s) |
| 8× fork storm + 2× CPU, 8 runs | 8/8 pass (3.5–5.6 s) |
| **Head-to-head, 11× fork storm, alternating** | **old 3/6 · new 6/6** |

The head-to-head is the bar that matters: identical alternating conditions, the old test reproducing the exact reported error at 10025 ms while the new one passes in up to 14.8 s — genuinely past the old budget, with every assertion still verified. The stall path was also confirmed to fire with a diagnosable message (`no output for 30002 ms after waiting 31273 ms`, naming the stage reached).

`npm run check` passes; `npm test`: 508 tests, 503 pass, 0 fail, 5 skipped.

## A production bug found on the way, not fixed here

Past roughly 16× fork-storm contention, **`src/start.mjs` fails on its own**: it reports `Timed out waiting for API forwarder to become healthy` after 30 s even though the forwarder printed `listening` at 1.4 s and is perfectly fine.

The 1-second per-probe abort means a starved-but-healthy service can *never* pass the health check, so startup declares a working service dead. That is a real robustness bug in `waitForHealth`, independent of this test, and it would hit a user booting the router on a busy machine — which is exactly when logging in and starting a build tend to coincide.

Above that threshold no test-side change can make this test pass, and it now correctly reports the stall rather than papering over a genuine product failure.

Two smaller things noticed and left alone: `waitForHealth` only checks `child.exitCode` at the top of its loop, so a crashed child goes unnoticed for up to a 2-second backoff sleep; and `portIsClosed` has no socket timeout, so a socket that neither connects nor errors hangs to the outer timeout.

## Not verified

All measurements come from one machine (10 cores, macOS, repo on an external SSD, Node v22.23.1), where module loading is more I/O-heavy than a typical CI checkout. Behaviour on the project's own runners is unmeasured.
