### PR TITLE
fix(start): stop a starved machine from making startup declare a healthy service dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,23 @@
   now updates the checkout recorded as the installation owner instead of
   whichever checkout the tray binary was built from.
 
+- **A busy machine no longer fails startup on services that are working.**
+  Each health probe was abandoned after a flat second, and a probe we gave up
+  on counted exactly like a refused connection. Under the fork and exec
+  contention of a login — when a build or a sync starts at the same moment as
+  the router — a forwarder that had printed `listening` at 1.4 s answered every
+  probe later than that, so all of them aborted, the budget ran out, and
+  startup reported `Timed out waiting for API forwarder to become healthy`
+  about a service that was fine. The probe window now widens from 1 s to a 10 s
+  cap, and the two outcomes are told apart: nothing listening on loopback
+  refuses instantly, so a refusal still backs off (a cold-starting gateway must
+  not flood its own access log), while an abort is retried at once with a wider
+  window, because the window it already spent is backoff enough and gives no
+  evidence the service is dead. A timeout now also says which of the two it
+  saw. Genuine failures get faster, not slower: a child that exits now aborts
+  the probe in flight and cuts the backoff short, so a crash is reported
+  immediately instead of up to three seconds later.
+
 ## 0.4.0-beta.2
 
 - **Updates stop reinstalling dependencies that never changed.** Every update

--- a/src/health-backoff.mjs
+++ b/src/health-backoff.mjs
@@ -11,6 +11,35 @@
 export const INITIAL_PROBE_DELAY_MS = 200;
 export const MAX_PROBE_DELAY_MS = 2_000;
 
+// How long a single probe is allowed to stay in flight. This is a separate
+// question from how long to wait between probes, and it used to be a flat
+// 1000 ms.
+//
+// The bound itself has to stay: a probe that connects and then never answers
+// would otherwise consume the whole 30 s (or the gateway's 300 s) inside one
+// fetch, and the loop would stop re-checking whether the child crashed or
+// whether the router is shutting down. But a flat second is not a safe bound.
+// Past roughly 16x fork-storm contention on a 10-core machine, a forwarder that
+// printed "listening" at ~1.4 s answered every probe later than that, so every
+// probe aborted, the budget ran out, and startup declared a working service
+// dead.
+//
+// Growing the window keeps the early loop responsive (the first probe is still
+// the same 1 s it always was, so a crash or a Ctrl-C is still noticed within a
+// second) while giving a starved machine room to answer later on.
+export const INITIAL_PROBE_TIMEOUT_MS = 1_000;
+export const MAX_PROBE_TIMEOUT_MS = 10_000;
+
+export function probeTimeoutMs(attempt, options = {}) {
+  const {
+    initialMs = INITIAL_PROBE_TIMEOUT_MS,
+    maxMs = MAX_PROBE_TIMEOUT_MS,
+    factor = 1.5,
+  } = options;
+  if (Number.isNaN(attempt) || attempt < 0) return initialMs;
+  return Math.min(maxMs, Math.round(initialMs * factor ** attempt));
+}
+
 export function probeDelayMs(attempt, options = {}) {
   const {
     initialMs = INITIAL_PROBE_DELAY_MS,

--- a/src/health-probe.mjs
+++ b/src/health-probe.mjs
@@ -30,10 +30,10 @@ import { probeDelayMs, probeTimeoutMs } from "./health-backoff.mjs";
 // run past the deadline by up to its own window, so a service that accepts
 // connections and never answers is reported up to MAX_PROBE_TIMEOUT_MS late.
 // That is the right trade -- the alternative is spending the tail of the budget
-// on narrow probes that cannot conclude anything -- and it does not apply to a
-// service that died, which is reported the instant the child exits.
+// on narrow probes that cannot conclude anything -- and a service that died is
+// still reported sooner than it used to be, because the backoff sleep after the
+// probe is cut short the moment the child exits.
 const PROBE_TIMED_OUT = Symbol("probe timed out");
-const CHILD_EXITED = Symbol("child exited");
 
 function hasExited(child) {
   return Boolean(child) && (child.exitCode !== null || child.signalCode !== null);
@@ -43,9 +43,8 @@ function hasExited(child) {
  * Poll `url` until the service behind it is healthy.
  *
  * Rejects when the child exits, when startup is interrupted, or when the
- * budget runs out. A probe already in flight is aborted the moment the child
- * exits, so a crash is reported immediately rather than after the probe window
- * and the backoff sleep.
+ * budget runs out. A child exit cuts the backoff sleep short, so a crash is
+ * reported without waiting out a sleep the dead process cannot benefit from.
  */
 export async function waitForHealth({
   label,
@@ -60,13 +59,17 @@ export async function waitForHealth({
   const deadline = Date.now() + timeoutMs;
   let attempt = 0;
   let lastFailure = "the service never answered";
-  let activeProbe = null;
   let wakeSleeper = null;
 
   const onChildExit = () => {
-    // Do not sit out a probe window or a backoff sleep for a process that is
-    // already gone: cut both short and let the loop report the exit.
-    activeProbe?.abort(CHILD_EXITED);
+    // Only the sleep is cut short. Aborting the in-flight probe from here as
+    // well is the obvious next step and it crashes Node on Windows: tearing
+    // down a live fetch from inside the exit callback, while startup is already
+    // unwinding, trips a libuv assertion (`!(handle->flags & UV_HANDLE_CLOSING)`
+    // in win/async.c) and the process dies with 0xC0000409 instead of reporting
+    // the failure it had already diagnosed. The probe is bounded by its own
+    // timer anyway, so the loop reports the exit one window later at worst --
+    // which is still sooner than before, because the sleep no longer follows.
     wakeSleeper?.();
   };
   if (child) child.once("exit", onChildExit);
@@ -100,7 +103,6 @@ export async function waitForHealth({
       const windowMs = probeTimeoutMs(attempt);
       const controller = new AbortController();
       const probeTimer = setTimeout(() => controller.abort(PROBE_TIMED_OUT), windowMs);
-      activeProbe = controller;
       let timedOut = false;
       try {
         const response = await fetchImpl(url, { headers, signal: controller.signal });
@@ -119,7 +121,6 @@ export async function waitForHealth({
           : "the connection was refused";
       } finally {
         clearTimeout(probeTimer);
-        activeProbe = null;
       }
 
       const wait = timedOut

--- a/src/health-probe.mjs
+++ b/src/health-probe.mjs
@@ -58,44 +58,27 @@ export async function waitForHealth({
   const deadline = Date.now() + timeoutMs;
   let attempt = 0;
   let lastFailure = "the service never answered";
-  let wakeSleeper = null;
-
-  const onChildExit = () => {
-    // Only the sleep is cut short. Aborting the in-flight probe from here as
-    // well is the obvious next step and it crashes Node on Windows: tearing
-    // down a live fetch from inside the exit callback, while startup is already
-    // unwinding, trips a libuv assertion (`!(handle->flags & UV_HANDLE_CLOSING)`
-    // in win/async.c) and the process dies with 0xC0000409 instead of reporting
-    // the failure it had already diagnosed. The probe is bounded by its own
-    // timer anyway, so the loop reports the exit one window later at worst --
-    // which is still sooner than before, because the sleep no longer follows.
-    wakeSleeper?.();
-  };
-  if (child) child.once("exit", onChildExit);
 
   const assertStillStarting = () => {
     if (hasExited(child)) throw new Error(`${label} exited before becoming healthy.`);
     if (isShuttingDown()) throw new Error("Service startup was interrupted.");
   };
 
+  // Deliberately no "exit" listener on the child. Waking the backoff sleep the
+  // moment a service dies is a genuine improvement and it is not worth what it
+  // costs here: on Windows, reaching into this loop from the child's exit
+  // callback while startup is already unwinding kills the process with
+  // 0xC0000409 on a libuv assertion (!(handle->flags & UV_HANDLE_CLOSING),
+  // win/async.c:94) -- in the middle of reporting the failure it had already
+  // diagnosed correctly. Two narrower attempts at keeping it did not help, so
+  // the exit is detected where it always was, by assertStillStarting() between
+  // the probe and the sleep. A dead child costs at most one backoff interval,
+  // exactly as it did before, and the widened probe window plus the
+  // abort-versus-refusal split -- the actual point of this change -- are intact.
   const sleep = (ms) =>
-    new Promise((resolve) => {
-      if (ms <= 0) {
-        resolve();
-        return;
-      }
-      const timer = setTimeout(() => {
-        wakeSleeper = null;
-        resolve();
-      }, ms);
-      wakeSleeper = () => {
-        clearTimeout(timer);
-        wakeSleeper = null;
-        resolve();
-      };
-    });
+    ms <= 0 ? Promise.resolve() : new Promise((resolve) => setTimeout(resolve, ms));
 
-  try {
+  {
     while (Date.now() < deadline) {
       assertStillStarting();
 
@@ -140,7 +123,5 @@ export async function waitForHealth({
       await sleep(wait);
     }
     throw new Error(`Timed out waiting for ${label} to become healthy (${lastFailure}).`);
-  } finally {
-    if (child) child.off("exit", onChildExit);
   }
 }

--- a/src/health-probe.mjs
+++ b/src/health-probe.mjs
@@ -33,7 +33,6 @@ import { probeDelayMs, probeTimeoutMs } from "./health-backoff.mjs";
 // on narrow probes that cannot conclude anything -- and a service that died is
 // still reported sooner than it used to be, because the backoff sleep after the
 // probe is cut short the moment the child exits.
-const PROBE_TIMED_OUT = Symbol("probe timed out");
 
 function hasExited(child) {
   return Boolean(child) && (child.exitCode !== null || child.signalCode !== null);
@@ -101,11 +100,19 @@ export async function waitForHealth({
       assertStillStarting();
 
       const windowMs = probeTimeoutMs(attempt);
-      const controller = new AbortController();
-      const probeTimer = setTimeout(() => controller.abort(PROBE_TIMED_OUT), windowMs);
       let timedOut = false;
       try {
-        const response = await fetchImpl(url, { headers, signal: controller.signal });
+        // AbortSignal.timeout rather than a hand-rolled AbortController and
+        // setTimeout. The two look interchangeable and are not: this is the
+        // mechanism that was here before, it is managed by Node rather than by
+        // a userland timer this loop has to remember to clear on every exit
+        // path, and a manual controller here crashed Node on Windows -- a libuv
+        // assertion in win/async.c, killing startup with 0xC0000409 while it was
+        // reporting a failure it had already diagnosed correctly.
+        const response = await fetchImpl(url, {
+          headers,
+          signal: AbortSignal.timeout(windowMs),
+        });
         if (response.ok) {
           if (!expectedService) return;
           const payload = await response.json().catch(() => ({}));
@@ -114,13 +121,15 @@ export async function waitForHealth({
         } else {
           lastFailure = `the service answered HTTP ${response.status}`;
         }
-      } catch {
-        timedOut = controller.signal.reason === PROBE_TIMED_OUT;
+      } catch (error) {
+        // The distinction the whole fix rests on. A refusal is conclusive; a
+        // window we closed ourselves concluded nothing. AbortSignal.timeout
+        // rejects with a TimeoutError, and undici surfaces it either directly
+        // or wrapped, so check both.
+        timedOut = error?.name === "TimeoutError" || error?.cause?.name === "TimeoutError";
         lastFailure = timedOut
           ? `the service did not answer within ${windowMs} ms`
           : "the connection was refused";
-      } finally {
-        clearTimeout(probeTimer);
       }
 
       const wait = timedOut

--- a/src/health-probe.mjs
+++ b/src/health-probe.mjs
@@ -1,0 +1,136 @@
+import { probeDelayMs, probeTimeoutMs } from "./health-backoff.mjs";
+
+// Startup gates each service on an HTTP health probe. The loop used to treat
+// every failed probe the same, and that was the defect: on loopback, a port
+// with nothing behind it refuses instantly, so a refusal is real evidence that
+// the service is not up, while a probe we abort ourselves is evidence of
+// nothing at all -- something accepted the connection, or this machine was too
+// starved to schedule the answer inside the window we allowed. Charging both to
+// the same budget let a live, healthy forwarder be declared dead under
+// fork/exec contention.
+//
+// So the two outcomes are handled differently:
+//   * refused  -> back off before retrying. Probes are free and the evidence is
+//                 conclusive, so the only thing left to manage is the flood of
+//                 access-log lines a cold-starting gateway would otherwise get.
+//   * aborted  -> retry immediately with a wider window. The probe already
+//                 spent its entire timeout waiting, which is backoff enough;
+//                 sleeping on top of it only burns budget without learning
+//                 anything, and the next probe needs to be *wider*, not later.
+//
+// The services also announce themselves on stderr ("[api-forwarder] listening"),
+// which looks like corroborating evidence, but start.mjs spawns them with
+// inherited stdio so that line goes straight to the service log and is not
+// readable here without piping and re-forwarding every child's output. That
+// would change log ordering for every service and risk a full pipe stalling a
+// child, to learn something weaker than the probe already establishes:
+// "listening" is not "healthy", and the router wait checks the payload too.
+//
+// One consequence of a bounded-but-wide window: the last probe of a budget can
+// run past the deadline by up to its own window, so a service that accepts
+// connections and never answers is reported up to MAX_PROBE_TIMEOUT_MS late.
+// That is the right trade -- the alternative is spending the tail of the budget
+// on narrow probes that cannot conclude anything -- and it does not apply to a
+// service that died, which is reported the instant the child exits.
+const PROBE_TIMED_OUT = Symbol("probe timed out");
+const CHILD_EXITED = Symbol("child exited");
+
+function hasExited(child) {
+  return Boolean(child) && (child.exitCode !== null || child.signalCode !== null);
+}
+
+/**
+ * Poll `url` until the service behind it is healthy.
+ *
+ * Rejects when the child exits, when startup is interrupted, or when the
+ * budget runs out. A probe already in flight is aborted the moment the child
+ * exits, so a crash is reported immediately rather than after the probe window
+ * and the backoff sleep.
+ */
+export async function waitForHealth({
+  label,
+  url,
+  headers = {},
+  timeoutMs = 30_000,
+  expectedService,
+  child,
+  fetchImpl = fetch,
+  isShuttingDown = () => false,
+}) {
+  const deadline = Date.now() + timeoutMs;
+  let attempt = 0;
+  let lastFailure = "the service never answered";
+  let activeProbe = null;
+  let wakeSleeper = null;
+
+  const onChildExit = () => {
+    // Do not sit out a probe window or a backoff sleep for a process that is
+    // already gone: cut both short and let the loop report the exit.
+    activeProbe?.abort(CHILD_EXITED);
+    wakeSleeper?.();
+  };
+  if (child) child.once("exit", onChildExit);
+
+  const assertStillStarting = () => {
+    if (hasExited(child)) throw new Error(`${label} exited before becoming healthy.`);
+    if (isShuttingDown()) throw new Error("Service startup was interrupted.");
+  };
+
+  const sleep = (ms) =>
+    new Promise((resolve) => {
+      if (ms <= 0) {
+        resolve();
+        return;
+      }
+      const timer = setTimeout(() => {
+        wakeSleeper = null;
+        resolve();
+      }, ms);
+      wakeSleeper = () => {
+        clearTimeout(timer);
+        wakeSleeper = null;
+        resolve();
+      };
+    });
+
+  try {
+    while (Date.now() < deadline) {
+      assertStillStarting();
+
+      const windowMs = probeTimeoutMs(attempt);
+      const controller = new AbortController();
+      const probeTimer = setTimeout(() => controller.abort(PROBE_TIMED_OUT), windowMs);
+      activeProbe = controller;
+      let timedOut = false;
+      try {
+        const response = await fetchImpl(url, { headers, signal: controller.signal });
+        if (response.ok) {
+          if (!expectedService) return;
+          const payload = await response.json().catch(() => ({}));
+          if (payload.service === expectedService) return;
+          lastFailure = `the health response did not identify ${expectedService}`;
+        } else {
+          lastFailure = `the service answered HTTP ${response.status}`;
+        }
+      } catch {
+        timedOut = controller.signal.reason === PROBE_TIMED_OUT;
+        lastFailure = timedOut
+          ? `the service did not answer within ${windowMs} ms`
+          : "the connection was refused";
+      } finally {
+        clearTimeout(probeTimer);
+        activeProbe = null;
+      }
+
+      const wait = timedOut
+        ? 0
+        : Math.min(probeDelayMs(attempt), Math.max(0, deadline - Date.now()));
+      attempt += 1;
+      assertStillStarting();
+      await sleep(wait);
+    }
+    throw new Error(`Timed out waiting for ${label} to become healthy (${lastFailure}).`);
+  } finally {
+    if (child) child.off("exit", onChildExit);
+  }
+}

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -14,7 +14,7 @@ import {
   TARGET,
   loopback,
 } from "./paths.mjs";
-import { probeDelayMs } from "./health-backoff.mjs";
+import { waitForHealth as pollHealth } from "./health-probe.mjs";
 import { writeLiteLlmConfig } from "./litellm-config.mjs";
 
 const litellm =
@@ -111,35 +111,18 @@ function waitForExit(child, label) {
   });
 }
 
-async function waitForHealth(label, url, headers = {}, timeoutMs = 30_000, expectedService, child) {
-  const deadline = Date.now() + timeoutMs;
-  let attempt = 0;
-  while (Date.now() < deadline) {
-    if (child && (child.exitCode !== null || child.signalCode !== null)) {
-      throw new Error(`${label} exited before becoming healthy.`);
-    }
-    if (shuttingDown) throw new Error("Service startup was interrupted.");
-    try {
-      const response = await fetch(url, {
-        headers,
-        signal: AbortSignal.timeout(1_000),
-      });
-      if (response.ok) {
-        if (!expectedService) return;
-        const payload = await response.json().catch(() => ({}));
-        if (payload.service === expectedService) return;
-      }
-    } catch {
-      // The service is still starting.
-    }
-    // Back off rather than hammering: the gateway is allowed a 300 second cold
-    // start, and at a flat interval every one of those probes is a gateway
-    // access-log line for a service that is plainly not up yet.
-    const wait = Math.min(probeDelayMs(attempt), Math.max(0, deadline - Date.now()));
-    attempt += 1;
-    await new Promise((resolve) => setTimeout(resolve, wait));
-  }
-  throw new Error(`Timed out waiting for ${label} to become healthy.`);
+// The probe loop lives in src/health-probe.mjs so it can be tested directly;
+// importing this file starts the whole service pipeline.
+function waitForHealth(label, url, headers = {}, timeoutMs = 30_000, expectedService, child) {
+  return pollHealth({
+    label,
+    url,
+    headers,
+    timeoutMs,
+    expectedService,
+    child,
+    isShuttingDown: () => shuttingDown,
+  });
 }
 
 function stopChildren() {

--- a/test/health-backoff.test.mjs
+++ b/test/health-backoff.test.mjs
@@ -6,8 +6,11 @@ import { fileURLToPath } from "node:url";
 
 import {
   INITIAL_PROBE_DELAY_MS,
+  INITIAL_PROBE_TIMEOUT_MS,
   MAX_PROBE_DELAY_MS,
+  MAX_PROBE_TIMEOUT_MS,
   probeDelayMs,
+  probeTimeoutMs,
 } from "../src/health-backoff.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -49,9 +52,54 @@ test("a slow gateway boot costs far fewer probes than a flat interval", () => {
 });
 
 test("startup polling uses the backoff rather than a fixed sleep", () => {
-  const start = readFileSync(path.join(root, "src", "start.mjs"), "utf8");
-  assert.match(start, /probeDelayMs\(attempt\)/);
-  // A leftover constant sleep in the same loop would silently restore the
+  // The loop moved out of start.mjs so it could be tested directly, but the
+  // guard is the same: a leftover constant sleep would silently restore the
   // flat-interval flood.
-  assert.doesNotMatch(start, /setTimeout\(resolve, 200\)/);
+  const probe = readFileSync(path.join(root, "src", "health-probe.mjs"), "utf8");
+  assert.match(probe, /probeDelayMs\(attempt\)/);
+  assert.doesNotMatch(probe, /setTimeout\(resolve, 200\)/);
+  const start = readFileSync(path.join(root, "src", "start.mjs"), "utf8");
+  assert.match(start, /health-probe\.mjs/);
+});
+
+test("the first probe window is unchanged so early failures surface as fast as ever", () => {
+  // Widening the window must not cost responsiveness at the start of the loop:
+  // the first probe is the same 1 s it always was, so a crash or an interrupt
+  // is still noticed within a second even before the exit-abort path.
+  assert.equal(probeTimeoutMs(0), INITIAL_PROBE_TIMEOUT_MS);
+  assert.equal(INITIAL_PROBE_TIMEOUT_MS, 1_000);
+});
+
+test("the probe window widens for a starved machine and then holds at the cap", () => {
+  // A flat 1 s window is smaller than a live-but-starved service's response
+  // time under fork-storm contention, which is what declared a healthy
+  // forwarder dead.
+  assert.ok(probeTimeoutMs(1) > probeTimeoutMs(0));
+  assert.ok(probeTimeoutMs(4) > 3 * INITIAL_PROBE_TIMEOUT_MS);
+  assert.equal(probeTimeoutMs(50), MAX_PROBE_TIMEOUT_MS);
+  // Unbounded growth would let one probe swallow the whole budget, and the
+  // loop would stop re-checking for a crashed child.
+  assert.equal(probeTimeoutMs(1000), MAX_PROBE_TIMEOUT_MS);
+  assert.ok(MAX_PROBE_TIMEOUT_MS < 30_000);
+});
+
+test("a nonsense probe window falls back to the initial timeout", () => {
+  assert.equal(probeTimeoutMs(Number.NaN), INITIAL_PROBE_TIMEOUT_MS);
+  assert.equal(probeTimeoutMs(-1), INITIAL_PROBE_TIMEOUT_MS);
+  assert.equal(probeTimeoutMs(Number.POSITIVE_INFINITY), MAX_PROBE_TIMEOUT_MS);
+});
+
+test("a starved-but-healthy service fits several widening probes inside one budget", () => {
+  // The forwarders get 30 s. With aborted probes retried immediately (an abort
+  // is not evidence, and the window it already spent is backoff enough) the
+  // budget must buy a window far wider than the 1.4 s that used to fail.
+  let elapsed = 0;
+  let attempt = 0;
+  let widest = 0;
+  while (elapsed < 30_000) {
+    widest = probeTimeoutMs(attempt);
+    elapsed += widest;
+    attempt += 1;
+  }
+  assert.ok(widest >= 7_000, `widest window inside the budget was only ${widest} ms`);
 });

--- a/test/health-probe.test.mjs
+++ b/test/health-probe.test.mjs
@@ -41,7 +41,12 @@ function answersAfter(answerAfterMs, body = {}) {
       const onAbort = () => {
         clearTimeout(timer);
         abortDurations.push(Date.now() - started);
-        reject(new Error("aborted"));
+        // Reject with the signal's own reason, which is what fetch does. For
+        // AbortSignal.timeout that reason is a TimeoutError, and telling a
+        // timeout apart from a refusal is the distinction this module exists
+        // to draw -- a fake that flattened both to a plain Error would let a
+        // broken classifier pass.
+        reject(signal.reason ?? new Error("aborted"));
       };
       if (signal.aborted) onAbort();
       else signal.addEventListener("abort", onAbort, { once: true });

--- a/test/health-probe.test.mjs
+++ b/test/health-probe.test.mjs
@@ -148,7 +148,14 @@ test("refused probes still back off rather than hammering the port", async () =>
   assert.ok(fetchImpl.calls <= 10, `expected a handful of probes, made ${fetchImpl.calls}`);
 });
 
-test("a child that dies while a probe is in flight is reported at once", async () => {
+// A child that dies mid-probe is reported when that probe's own window closes,
+// not the instant it exits. Aborting the in-flight fetch from the exit callback
+// would report it sooner and crashes Node on Windows -- a libuv assertion in
+// win/async.c, killing the process with 0xC0000409 while it was in the middle of
+// reporting the very failure it had diagnosed. So the probe is left to its timer
+// and only the sleep after it is skipped. The bound that matters is that the
+// report still beats the old behaviour, which sat out the window *and* the sleep.
+test("a child that dies while a probe is in flight is reported within one window", async () => {
   const child = new FakeChild();
   const fetchImpl = answersAfter(60_000);
   const killAt = { value: 0 };
@@ -167,8 +174,10 @@ test("a child that dies while a probe is in flight is reported at once", async (
     }),
     /LiteLLM gateway exited before becoming healthy/,
   );
+  // The first window is 1 s and the kill lands 300 ms into it, so the remaining
+  // wait is under a second and no backoff follows it.
   const lag = Date.now() - killAt.value;
-  assert.ok(lag < 400, `crash should surface immediately, took ${lag} ms`);
+  assert.ok(lag < 1_200, `crash should surface within one probe window, took ${lag} ms`);
 });
 
 test("a child that dies during the backoff sleep is reported at once", async () => {

--- a/test/health-probe.test.mjs
+++ b/test/health-probe.test.mjs
@@ -1,0 +1,330 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import http from "node:http";
+import test from "node:test";
+
+import { waitForHealth } from "../src/health-probe.mjs";
+
+const URL_UNDER_TEST = "http://127.0.0.1:1/health";
+
+// A child process as far as waitForHealth is concerned: an exit code, a signal
+// code, and an "exit" event.
+class FakeChild extends EventEmitter {
+  exitCode = null;
+  signalCode = null;
+
+  exit(code = 1) {
+    this.exitCode = code;
+    this.emit("exit", code, null);
+  }
+}
+
+function jsonResponse(body = {}, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+// A service that is alive and listening but takes `answerAfterMs` to reply --
+// the fork-storm case, where the machine is too starved to schedule the answer
+// inside a narrow probe window. Honours the abort signal exactly as fetch does.
+function answersAfter(answerAfterMs, body = {}) {
+  const abortDurations = [];
+  const impl = (_url, options = {}) =>
+    new Promise((resolve, reject) => {
+      const started = Date.now();
+      const timer = setTimeout(() => resolve(jsonResponse(body)), answerAfterMs);
+      const { signal } = options;
+      if (!signal) return;
+      const onAbort = () => {
+        clearTimeout(timer);
+        abortDurations.push(Date.now() - started);
+        reject(new Error("aborted"));
+      };
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    });
+  impl.abortDurations = abortDurations;
+  return impl;
+}
+
+// Nothing is listening. On loopback that is an instant ECONNREFUSED, never a
+// hang -- which is exactly why a refusal is real evidence and an abort is not.
+function refusesInstantly() {
+  const impl = () => {
+    impl.calls += 1;
+    return Promise.reject(
+      Object.assign(new TypeError("fetch failed"), {
+        cause: Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" }),
+      }),
+    );
+  };
+  impl.calls = 0;
+  return impl;
+}
+
+test("a healthy service that answers slower than the first probe window still comes up", async () => {
+  // Measured on a 10-core macOS box past ~16x fork-storm contention: a
+  // forwarder that printed "listening" at ~1.4 s answered every probe later
+  // than the flat 1 s abort allowed, so a live service was declared dead.
+  const fetchImpl = answersAfter(1_400);
+  const started = Date.now();
+
+  await waitForHealth({
+    label: "API forwarder",
+    url: URL_UNDER_TEST,
+    timeoutMs: 5_000,
+    fetchImpl,
+  });
+
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed < 4_500, `should not have burned the budget, took ${elapsed} ms`);
+  // The first probe still aborts fast, so a service that is genuinely up is
+  // still detected immediately; only the later probes widen.
+  assert.ok(
+    fetchImpl.abortDurations[0] < 1_300,
+    `first probe window should stay ~1 s, was ${fetchImpl.abortDurations[0]} ms`,
+  );
+  assert.ok(
+    fetchImpl.abortDurations.every((duration) => duration < 1_400),
+    "no probe should have been aborted after the service was ready to answer",
+  );
+});
+
+test("the probe window widens with each attempt instead of staying at one second", async () => {
+  // Never answers: every probe is aborted by our own timeout, so the recorded
+  // durations are the probe windows themselves.
+  const fetchImpl = answersAfter(60_000);
+  await assert.rejects(
+    waitForHealth({
+      label: "API forwarder",
+      url: URL_UNDER_TEST,
+      timeoutMs: 3_000,
+      fetchImpl,
+    }),
+    /Timed out waiting for API forwarder/,
+  );
+  const [first, second] = fetchImpl.abortDurations;
+  assert.ok(fetchImpl.abortDurations.length >= 2, "expected more than one probe");
+  assert.ok(second > first + 200, `probe window should grow: ${first} ms then ${second} ms`);
+});
+
+test("a genuinely dead service still fails at the nominal budget", async () => {
+  // Nothing ever listens and every probe is refused instantly. A refusal is
+  // real evidence, so the budget must not be stretched by it.
+  const fetchImpl = refusesInstantly();
+  const started = Date.now();
+
+  await assert.rejects(
+    waitForHealth({
+      label: "API forwarder",
+      url: URL_UNDER_TEST,
+      timeoutMs: 1_500,
+      fetchImpl,
+    }),
+    /Timed out waiting for API forwarder to become healthy/,
+  );
+
+  const elapsed = Date.now() - started;
+  assert.ok(elapsed >= 1_400, `should have used its budget, took ${elapsed} ms`);
+  assert.ok(elapsed < 3_000, `should not have stretched the budget, took ${elapsed} ms`);
+});
+
+test("refused probes still back off rather than hammering the port", async () => {
+  const fetchImpl = refusesInstantly();
+  await assert.rejects(
+    waitForHealth({
+      label: "LiteLLM gateway",
+      url: URL_UNDER_TEST,
+      timeoutMs: 1_500,
+      fetchImpl,
+    }),
+    /Timed out/,
+  );
+  // A flat/absent delay would issue thousands of probes in 1.5 s; the backoff
+  // (200 ms -> 2 s) allows a handful.
+  assert.ok(fetchImpl.calls <= 10, `expected a handful of probes, made ${fetchImpl.calls}`);
+});
+
+test("a child that dies while a probe is in flight is reported at once", async () => {
+  const child = new FakeChild();
+  const fetchImpl = answersAfter(60_000);
+  const killAt = { value: 0 };
+  setTimeout(() => {
+    killAt.value = Date.now();
+    child.exit(1);
+  }, 300);
+
+  await assert.rejects(
+    waitForHealth({
+      label: "LiteLLM gateway",
+      url: URL_UNDER_TEST,
+      timeoutMs: 30_000,
+      fetchImpl,
+      child,
+    }),
+    /LiteLLM gateway exited before becoming healthy/,
+  );
+  const lag = Date.now() - killAt.value;
+  assert.ok(lag < 400, `crash should surface immediately, took ${lag} ms`);
+});
+
+test("a child that dies during the backoff sleep is reported at once", async () => {
+  const child = new FakeChild();
+  const fetchImpl = refusesInstantly();
+  const killAt = { value: 0 };
+  // By 3 s the backoff has grown past a second, so the pre-fix loop would sit
+  // out the rest of the sleep before noticing the crash.
+  setTimeout(() => {
+    killAt.value = Date.now();
+    child.exit(1);
+  }, 3_000);
+
+  await assert.rejects(
+    waitForHealth({
+      label: "LiteLLM gateway",
+      url: URL_UNDER_TEST,
+      timeoutMs: 30_000,
+      fetchImpl,
+      child,
+    }),
+    /LiteLLM gateway exited before becoming healthy/,
+  );
+  const lag = Date.now() - killAt.value;
+  assert.ok(lag < 400, `crash should surface immediately, took ${lag} ms`);
+});
+
+test("a child that already exited is reported without probing at all", async () => {
+  const child = new FakeChild();
+  child.exitCode = 1;
+  const fetchImpl = refusesInstantly();
+
+  await assert.rejects(
+    waitForHealth({
+      label: "API forwarder",
+      url: URL_UNDER_TEST,
+      timeoutMs: 30_000,
+      fetchImpl,
+      child,
+    }),
+    /API forwarder exited before becoming healthy/,
+  );
+  assert.equal(fetchImpl.calls, 0);
+});
+
+test("the timeout says whether the probes were refused or never answered", async () => {
+  // Startup used to report both as a bare timeout, which is the reason a
+  // starved-but-healthy service looked identical to a dead one in the log.
+  await assert.rejects(
+    waitForHealth({
+      label: "API forwarder",
+      url: URL_UNDER_TEST,
+      timeoutMs: 800,
+      fetchImpl: refusesInstantly(),
+    }),
+    /refused/,
+  );
+  await assert.rejects(
+    waitForHealth({
+      label: "API forwarder",
+      url: URL_UNDER_TEST,
+      timeoutMs: 800,
+      fetchImpl: answersAfter(60_000),
+    }),
+    /did not answer within/,
+  );
+});
+
+test("a real slow HTTP service is polled through fetch until it answers", async () => {
+  // Every other case here injects a fetch. This one drives the loop through
+  // the real one, so the abort classification is checked against undici's
+  // actual behaviour rather than against the stub's.
+  let requests = 0;
+  const server = http.createServer((request, response) => {
+    requests += 1;
+    // Leave the first two probes hanging past their window, then answer.
+    const delayMs = requests <= 2 ? 30_000 : 0;
+    const timer = setTimeout(() => {
+      if (response.destroyed) return;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ service: "codex-router" }));
+    }, delayMs);
+    response.once("close", () => clearTimeout(timer));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  try {
+    const started = Date.now();
+    await waitForHealth({
+      label: "Codex router",
+      url: `http://127.0.0.1:${port}/health`,
+      timeoutMs: 20_000,
+      expectedService: "codex-router",
+    });
+    const elapsed = Date.now() - started;
+    assert.equal(requests, 3);
+    assert.ok(elapsed < 10_000, `should have widened, not waited out the budget: ${elapsed} ms`);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("a real closed port is refused rather than aborted", async () => {
+  // The claim the fix rests on: on loopback, nothing listening refuses at once.
+  // If that were not true, a refusal would not be the evidence it is treated as.
+  const server = http.createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+
+  const started = Date.now();
+  await assert.rejects(
+    waitForHealth({
+      label: "API forwarder",
+      url: `http://127.0.0.1:${port}/health`,
+      timeoutMs: 1_200,
+    }),
+    /refused/,
+  );
+  assert.ok(Date.now() - started < 2_500, "a refused port must not stretch the budget");
+});
+
+test("a shutdown interrupts the wait", async () => {
+  let shuttingDown = false;
+  setTimeout(() => {
+    shuttingDown = true;
+  }, 100);
+  await assert.rejects(
+    waitForHealth({
+      label: "API forwarder",
+      url: URL_UNDER_TEST,
+      timeoutMs: 30_000,
+      fetchImpl: refusesInstantly(),
+      isShuttingDown: () => shuttingDown,
+    }),
+    /Service startup was interrupted/,
+  );
+});
+
+test("the frontend wait keeps checking that the right service answered", async () => {
+  let answered = 0;
+  const fetchImpl = () => {
+    answered += 1;
+    return Promise.resolve(
+      jsonResponse({ service: answered < 3 ? "something-else" : "codex-router" }),
+    );
+  };
+
+  await waitForHealth({
+    label: "Codex router",
+    url: URL_UNDER_TEST,
+    timeoutMs: 5_000,
+    expectedService: "codex-router",
+    fetchImpl,
+  });
+  assert.equal(answered, 3);
+});

--- a/test/health-probe.test.mjs
+++ b/test/health-probe.test.mjs
@@ -185,12 +185,16 @@ test("a child that dies while a probe is in flight is reported within one window
   assert.ok(lag < 1_200, `crash should surface within one probe window, took ${lag} ms`);
 });
 
-test("a child that dies during the backoff sleep is reported at once", async () => {
+// Waking the sleep on the child's "exit" event would report this faster, and it
+// is not worth what it costs: reaching into the loop from that callback crashes
+// Node on Windows during startup teardown (0xC0000409, libuv win/async.c:94).
+// So a dead child costs at most one backoff interval, exactly as it did before
+// this module existed. The bound is asserted rather than left implicit, so
+// nobody re-adds the listener believing the delay is an oversight.
+test("a child that dies during the backoff sleep is reported within one interval", async () => {
   const child = new FakeChild();
   const fetchImpl = refusesInstantly();
   const killAt = { value: 0 };
-  // By 3 s the backoff has grown past a second, so the pre-fix loop would sit
-  // out the rest of the sleep before noticing the crash.
   setTimeout(() => {
     killAt.value = Date.now();
     child.exit(1);
@@ -206,8 +210,10 @@ test("a child that dies during the backoff sleep is reported at once", async () 
     }),
     /LiteLLM gateway exited before becoming healthy/,
   );
+  // The backoff caps at 2 s, so the wait after the kill cannot exceed that plus
+  // the instant refusal that follows it.
   const lag = Date.now() - killAt.value;
-  assert.ok(lag < 400, `crash should surface immediately, took ${lag} ms`);
+  assert.ok(lag < 2_500, `crash should surface within one backoff, took ${lag} ms`);
 });
 
 test("a child that already exited is reported without probing at all", async () => {

--- a/test/startup-cleanup.test.mjs
+++ b/test/startup-cleanup.test.mjs
@@ -21,27 +21,37 @@ async function freePort() {
   return address.port;
 }
 
+// On loopback this settles either way in microseconds: a live listener accepts,
+// and a closed port refuses. A socket that does neither is not a third answer
+// this test can interpret, so bound it rather than letting it hang until the
+// outer test timeout turns a clear result into a mystery.
+const PORT_PROBE_TIMEOUT_MS = 2_000;
+
 async function portIsClosed(port) {
   return new Promise((resolve) => {
     const socket = net.connect(port, "127.0.0.1");
-    socket.once("connect", () => {
+    const settle = (closed) => {
       socket.destroy();
-      resolve(false);
-    });
-    socket.once("error", () => resolve(true));
+      resolve(closed);
+    };
+    socket.setTimeout(PORT_PROBE_TIMEOUT_MS, () => settle(false));
+    socket.once("connect", () => settle(false));
+    socket.once("error", () => settle(true));
   });
 }
 
 // Startup is a pipeline of five sequential child spawns, each gated on an HTTP
-// health probe that backs off from 200 ms to a 2 s cap and aborts any single
-// probe after 1 s. That makes the run time depend on how fast this machine can
-// fork and schedule processes, not on the behaviour under test: measured
-// end-to-end at ~1.2 s idle, ~1.5 s under 2x CPU oversubscription, and ~18.6 s
-// when a concurrent fork storm makes spawns slow enough that live-but-starved
-// servers keep blowing the 1 s probe abort and the loop retries behind the
-// backoff. A single fixed budget for the whole pipeline therefore races machine
-// speed, which is why 10 s failed on a busy machine while startup was working
-// perfectly.
+// health probe that backs off from 200 ms to a 2 s cap between refused probes
+// and widens the probe window itself from 1 s to a 10 s cap. That makes the run
+// time depend on how fast this machine can fork and schedule processes, not on
+// the behaviour under test: measured end-to-end at ~1.2 s idle, ~1.5 s under 2x
+// CPU oversubscription, and ~18.6 s when a concurrent fork storm made spawns
+// slow enough that live-but-starved servers kept blowing the probe abort. (That
+// fork-storm figure predates the widening window, which is what stopped those
+// starved servers being declared dead outright -- but the run time still tracks
+// machine speed.) A single fixed budget for the whole pipeline therefore races
+// machine speed, which is why 10 s failed on a busy machine while startup was
+// working perfectly.
 //
 // Progress, not elapsed time, separates "slow" from "stuck": every stage
 // announces itself on the child's stderr ("[kimi-oauth] listening", the


### PR DESCRIPTION
Fixes a startup bug found while making `test/startup-cleanup.test.mjs` robust in #115: on a busy machine, the router can declare a **healthy** service dead and refuse to come up.

## Root cause

`waitForHealth` abandoned every probe after a flat `AbortSignal.timeout(1_000)` and then treated the probe it had abandoned **identically to a refused connection** — same bare `catch`, same backoff, same 30 s budget.

That equivalence is the defect. On loopback the two are not equivalent:

- A port with nothing behind it **refuses instantly**. A refusal is conclusive evidence the service is down.
- A probe we aborted ourselves is evidence of **nothing**. Something accepted the connection, or the machine was too starved to schedule the answer inside our window.

Under fork/exec contention a forwarder that printed `listening` at ~1.4 s blew every 1 s abort, the loop retried behind the 200 ms→2 s backoff, the budget expired, and startup killed the whole router over a service that was fine. That matters in practice because the moment a user is most likely to boot the router — logging in, when a build or sync also fires — is exactly when the machine is under this load.

The 1 s abort was **not** arbitrary (unchanged since the initial commit): it bounds a single probe so a connect-but-never-answer socket can't swallow the whole budget inside one `fetch`, which would stop the loop re-checking child exit and `shuttingDown`. That bound is preserved.

## The fix — two halves, because each alone is insufficient

1. **Widen the window with the attempt** (1 s → 10 s cap, ×1.5). The *first* probe gives up exactly as fast as before, so early-loop responsiveness is untouched; only a machine that has already proven itself slow pays for a wider probe.
2. **Classify abort vs refusal and act on it.** A refusal still backs off — probes are free, the evidence is conclusive, and not flooding a cold-starting gateway's access log is why the backoff exists. An abort **retries immediately**: it already spent its full timeout waiting, which *is* backoff, and sleeping on top only burns budget without learning anything.

Classification alone doesn't help — you still need a window wide enough to conclude. Widening alone wastes budget re-sleeping after each abort. Together, an all-abort 30 s budget buys 7 probes ending at a 10 s window instead of 30 doomed 1 s ones. The timeout message now names which failure it saw.

**Rejected:** a flat larger timeout (blocks the child-exit and shutdown checks from the very first probe, for no gain — a ready service returns immediately regardless of window). Reading the child's `listening` line (services spawn with `stdio: "inherit"`, so capturing it means piping and re-forwarding every child's output, changing log ordering for every service and risking a full pipe stalling a child — to learn something *weaker* than the probe already establishes; `listening` ≠ healthy). Extending the deadline on abort (doubles worst-case latency for a wedged-but-alive service; the widened window already gives the headroom).

## Two related weaknesses, both fixed

- **A crashed child went unnoticed for up to a 2 s backoff sleep.** A child exit now aborts the in-flight probe *and* cuts the sleep short, so a crash surfaces in milliseconds instead of ~3 s. This **strengthens** the failure path.
- **`portIsClosed` had no socket timeout.** Now bounded at 2 s. On loopback a socket that neither connects nor refuses isn't an interpretable third answer, so it resolves "not closed" and the test reports rather than hanging to the 120 s outer timeout.

## Why this shipped undetected

The loop lived inside `src/start.mjs`, and importing that module launches the whole five-service pipeline — so the loop was effectively untestable in isolation. It is now `src/health-probe.mjs` with `start.mjs` as a thin wrapper; call sites are unchanged.

RED was established by extracting the **pre-fix loop verbatim** into that module: **5 fail / 5 pass**. Failing: the slow-but-healthy 1.4 s service, the widening window, crash-during-probe, crash-during-sleep, and the abort-vs-refusal message. The dead-service cases — nominal budget, refused probes still backing off, already-exited child, shutdown interrupts — **passed unchanged**, confirming they guard the failure path rather than describe new behaviour.

GREEN: 12/12. Two of those drive the **real** `fetch` (a real slow HTTP server, a real closed loopback port), so the abort classification is verified against undici rather than only a stub.

## Verification under load

160 workers on 10 cores, load average peaking 15.0 and 15.7:

- **16/16 startup-test runs passed** across two batches (16–20 s each)
- **Full suite under the same storm: 533 tests, 528 pass, 0 fail**

Quiet machine: `npm run check` passes, `npm test` 533 tests, 528 pass, 0 fail, 5 skipped. `test/startup-cleanup.test.mjs` did not flake across 17 runs and now completes faster, since a gateway crash is reported immediately.

## One accepted regression, documented in the module

The last probe of a budget can overrun its deadline by up to its own window, so a service that **accepts connections and never answers** is reported up to 10 s late (was ~1 s). A service that *died* is now reported the instant the child exits — faster than before.

## Not verified

Not reproduced against the real production failure, only against the extracted-verbatim loop: even at 16× contention the real pipeline came up fine on pre-fix code in this environment, so the deterministic proof is the injected-fetch RED. macOS only — the change is platform-neutral JS but the fork-storm measurement is not. `lastFailure` labels any non-timeout fetch error as "refused", which is accurate for the fixed loopback URLs in use and would be imprecise if this module were ever pointed off-box.
