### PR TITLE
fix(api-forwarder): let a curated model declare that it refuses a forced tool_choice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,17 @@ to ship tested support to every installer.
    times per slug, tracked by the Codex client itself); leave it unset unless
    the model is genuinely news to the operator. Curated models are not
    implicitly approved as native v2 subagent model overrides.
-6. Run `./bin/model-router codex doctor`. A live `bin/test-model` request uses
+6. A curated model inherits a request profile from the provider's registry
+   models. The catalog-only resellers ship none, so curation also asks whether
+   the model rejects a forced `tool_choice` (`--request-profile
+   auto-tool-choice` in the deterministic form). Answer yes only for a model
+   observed to answer HTTP 400 on `tool_choice: "required"` while still
+   calling tools under `"auto"` — the restriction belongs to the upstream
+   behind the reseller, not to the reseller, so it is set per model and never
+   as a provider-wide default. Never widen it by changing what
+   `src/compatibility-test.mjs` sends: the probe must keep sending `required`,
+   or it stops proving tool calling works for every other provider.
+7. Run `./bin/model-router codex doctor`. A live `bin/test-model` request uses
    provider quota, so run it only with the user's approval. Finally, tell the
    user to fully quit and reopen Codex before checking the picker.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **A curated model can say it refuses a forced tool choice.** A few upstreams
+  call tools happily when `tool_choice` is `"auto"` and answer HTTP 400 when
+  one is required, so the compatibility check reported no tool support and the
+  routed-subagent handoff failed on a model whose tool calling was fine. The
+  vendor profiles already covered DeepSeek and Qwen on their own endpoints;
+  reached through a reseller like OpenRouter the same model had nowhere to
+  declare it, because those providers ship no registry models to inherit a
+  profile from. Curation now asks, and stores `auto-tool-choice`
+  (`--request-profile auto-tool-choice` in the `--models` form), which
+  downgrades the forced choice for that model and touches no other parameter.
+  It stays per model on purpose: OpenRouter reports `tool_choice` support per
+  model in its own catalog, so downgrading for a whole reseller would let
+  models that honor a forced choice quietly decline both the probe and the
+  subagent relay's forced function call. The probe itself still sends
+  `required`. Thanks to @jepgambardella for the report.
+
 - **Windows no longer opens a console window at logon.** The scheduled task ran
   the CMD wrapper through `cmd.exe`, so a console window appeared at every logon
   and stayed for the router's lifetime, reappearing on each watchdog restart.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,13 @@ image support, and reasoning efforts — so curated models get the effort
 switcher in the picker — and everything defaults conservatively when
 unanswered (`--efforts minimal,low,medium,high,xhigh` sets the ladder in the
 non-interactive `--models` form; every value stays editable in
-`user-models.json`). The provider's own `/v1/models` endpoint always decides
+`user-models.json`). It also asks whether the model rejects a forced
+`tool_choice`: a few upstreams call tools happily when the choice is `auto`
+but answer HTTP 400 when one is required, which fails the compatibility check
+and the routed-subagent handoff even though tool calling works. Answering yes
+stores `"requestProfile": "auto-tool-choice"`, and the router downgrades the
+forced choice for that model only (`--request-profile auto-tool-choice` in the
+`--models` form). The provider's own `/v1/models` endpoint always decides
 which models exist. Curated models are local to your machine and are not
 vetted by the repository's compatibility tests.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -75,6 +75,17 @@ the deterministic `--models` form), and everything defaults conservatively
 when unanswered. The stored entries in `user-models.json` are plain local
 state — edit any value in place and re-run `./bin/install` to apply.
 
+A curated model inherits a request profile from the provider's registry
+models when it has any. The catalog-only resellers ship none, so curation
+also offers `auto-tool-choice` (`--request-profile` in the deterministic
+form) — the one profile meaningful to pick by hand, for a model whose
+upstream rejects `tool_choice: "required"` while still calling tools under
+`"auto"`. It normalizes the tool choice and nothing else, so it composes with
+no vendor's parameter surface and misreads none. Keep it per model: the
+restriction belongs to the upstream behind the reseller, and a provider-wide
+downgrade would let models that honor a forced choice decline both the
+compatibility probe and the subagent payload relay's forced function call.
+
 ## Tests
 
 ```sh

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -420,6 +420,28 @@ function normalizeBody(buffer, contentType, route) {
     // Chat Completions endpoint instead of reasoning_effort.
     delete payload.reasoning_effort;
     payload.thinking = { type: "adaptive" };
+  } else if (model.requestProfile === "auto-tool-choice") {
+    // Some models call tools happily under "auto" but reject being forced to,
+    // the way DeepSeek and Qwen do in thinking mode. Their vendor profiles
+    // above already handle it; this one exists for a model reached through a
+    // reseller (OpenRouter, Together, Fireworks, ...), where the restriction
+    // travels with the upstream model while the reseller's parameter surface
+    // is plain OpenAI. So it normalizes the tool choice and nothing else:
+    // borrowing qwen-plan for an OpenRouter-hosted Qwen would silently
+    // collapse the picked effort onto DashScope's two-tier ladder.
+    //
+    // Deliberately not applied provider-wide. OpenRouter reports tool_choice
+    // as a per-model entry in the `supported_parameters` of its own
+    // /api/v1/models listing (filterable with ?supported_parameters=tool_choice),
+    // and its default routing forwards a parameter an endpoint does not
+    // support rather than refusing the request, so a rejection is the
+    // upstream's and not the reseller's. Downgrading for every model behind
+    // one reseller would let models that honor "required" decline the
+    // compatibility probe and, worse, decline the forced function call the
+    // subagent payload relay depends on.
+    if (payload.tool_choice !== undefined && payload.tool_choice !== "none") {
+      payload.tool_choice = "auto";
+    }
   }
   return { body: Buffer.from(JSON.stringify(payload), "utf8"), model, provider };
 }

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -24,6 +24,10 @@ const effortsOption = (() => {
   const index = process.argv.indexOf("--efforts");
   return index === -1 ? undefined : process.argv[index + 1];
 })();
+const requestProfileOption = (() => {
+  const index = process.argv.indexOf("--request-profile");
+  return index === -1 ? undefined : process.argv[index + 1];
+})();
 
 // The Codex effort ladder. Registry models describe each level explicitly;
 // curated models reuse these standard descriptions. Only advertise levels the
@@ -38,12 +42,38 @@ const EFFORT_DESCRIPTIONS = {
   max: "Maximum reasoning",
 };
 
+// Request profiles a curated model may opt into. The vendor profiles in
+// `src/api-forwarder.mjs` translate one upstream's parameter surface and are
+// inherited from that provider's registry models, never chosen here; these
+// describe a restriction the user observed on a model the repository does not
+// ship, so they are the only ones worth offering by hand.
+const AUTO_TOOL_CHOICE = "auto-tool-choice";
+const REQUEST_PROFILE_DESCRIPTIONS = {
+  [AUTO_TOOL_CHOICE]:
+    'reject a forced tool_choice ("required") while still calling tools under "auto"',
+};
+
 function usage() {
   console.error(
     "Usage: curate-models.mjs PROVIDER [--models id1,id2 | interactive] " +
-      "[--apply|--no-apply] [--efforts minimal,low,medium,high,xhigh]",
+      "[--apply|--no-apply] [--efforts minimal,low,medium,high,xhigh] " +
+      `[--request-profile ${Object.keys(REQUEST_PROFILE_DESCRIPTIONS).join("|")}]`,
   );
   process.exit(2);
+}
+
+// Nothing downstream validates the stored value: the forwarder simply matches
+// no branch, so a typo would store a model that keeps failing exactly the way
+// it did before curation. Fail here instead, the way an unknown effort does.
+export function parseRequestProfile(raw) {
+  const profile = String(raw ?? "").trim().toLowerCase();
+  if (!profile) return undefined;
+  if (!REQUEST_PROFILE_DESCRIPTIONS[profile]) {
+    throw new Error(
+      `Unknown request profile "${profile}". Choose from: ${Object.keys(REQUEST_PROFILE_DESCRIPTIONS).join(", ")}.`,
+    );
+  }
+  return profile;
 }
 
 export function parseEfforts(raw) {
@@ -75,6 +105,14 @@ if (!provider) {
 const flagEfforts = (() => {
   try {
     return effortsOption ? parseEfforts(effortsOption) : undefined;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(2);
+  }
+})();
+const flagRequestProfile = (() => {
+  try {
+    return requestProfileOption ? parseRequestProfile(requestProfileOption) : undefined;
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(2);
@@ -199,15 +237,37 @@ async function main() {
     return Object.keys(metadata).length > 0 ? metadata : undefined;
   };
 
+  // A provider that ships registry models lends its vendor profile to anything
+  // curated beside them. The catalog-only providers ship none, so their first
+  // curated model would get nothing at all -- which is correct for almost
+  // every model and wrong for the ones whose upstream refuses a forced tool
+  // choice. That is a per-model fact (a reseller fronts many upstreams, and
+  // the restriction belongs to the model behind it), so it is asked per model
+  // rather than defaulted per provider.
+  const requestProfileFor = (id) => {
+    if (flagRequestProfile) return flagRequestProfile;
+    if (inheritedProfile) return inheritedProfile;
+    if (!interactive) return undefined;
+    // Defaults to no: this weakens a forced tool choice into a request the
+    // model may decline, so it must be answered rather than fallen into by
+    // pressing Enter through the prompts.
+    return confirm(`  Does ${id} ${REQUEST_PROFILE_DESCRIPTIONS[AUTO_TOOL_CHOICE]}?`, false)
+      ? AUTO_TOOL_CHOICE
+      : undefined;
+  };
+
   const nextMine = chosen.map((id, index) => {
     const existing = byUpstream.get(id);
     if (existing) return existing;
+    // Ask for the metadata before the profile so the interactive prompts stay
+    // under the one "Metadata for ID" heading in the order they are printed.
+    const metadata = metadataFor(id);
     return userModelEntry({
       providerId,
       upstreamId: id,
-      requestProfile: inheritedProfile,
+      requestProfile: requestProfileFor(id),
       priority: 100 + index,
-      metadata: metadataFor(id),
+      metadata,
     });
   });
   const target = writeUserModels([...others, ...nextMine]);

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -7,7 +7,9 @@ import test from "node:test";
 // coverage of any kind.
 const savedArgv = [...process.argv];
 process.argv = [process.argv[0], "curate-models.mjs", "gemini-api"];
-const { parseEfforts, renderRows } = await import("../src/curate-models.mjs");
+const { parseEfforts, parseRequestProfile, renderRows } = await import(
+  "../src/curate-models.mjs"
+);
 process.argv = savedArgv;
 process.exitCode = 0;
 
@@ -52,6 +54,29 @@ test("whitespace and casing are tolerated", () => {
 test("an empty efforts list leaves the model defaults alone", () => {
   assert.equal(parseEfforts(""), undefined);
   assert.equal(parseEfforts(" , , "), undefined);
+});
+
+test("a curated model can opt into the auto tool-choice profile", () => {
+  // A reseller-hosted model whose upstream rejects tool_choice "required" is
+  // otherwise unreachable: the catalog-only providers ship no registry model
+  // to inherit a profile from, so the first curated model gets none.
+  assert.equal(parseRequestProfile("auto-tool-choice"), "auto-tool-choice");
+});
+
+test("an unknown request profile is rejected by name", () => {
+  // Nothing validates requestProfile downstream — the forwarder just runs no
+  // branch — so a typo would store a model that silently keeps failing.
+  assert.throws(() => parseRequestProfile("qwen-plan"), /Unknown request profile "qwen-plan"/);
+  assert.throws(() => parseRequestProfile("auto_tool_choice"), /Unknown request profile/);
+});
+
+test("an empty request profile leaves the model without one", () => {
+  assert.equal(parseRequestProfile(""), undefined);
+  assert.equal(parseRequestProfile("  "), undefined);
+});
+
+test("request profile whitespace and casing are tolerated", () => {
+  assert.equal(parseRequestProfile(" Auto-Tool-Choice "), "auto-tool-choice");
 });
 
 test("the picker marks selection and existing curation separately", () => {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -2174,6 +2174,143 @@ test("API forwarder routes Qwen plan models without unsupported parameters", asy
   }
 });
 
+// The catalog-only resellers ship no models, so their entries reach the
+// registry only through `bin/curate-models`. The fixture registers two
+// OpenRouter models the same way curation does: one whose upstream refuses a
+// forced tool choice and therefore carries the opt-in profile, and one that
+// does not, because OpenRouter itself imposes no such restriction.
+function curatedOpenRouterModels() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "routing-openrouter-models-"));
+  const file = path.join(dir, "user-models.json");
+  const entry = (upstreamModel, gatewayModel, requestProfile) => ({
+    slug: `openrouter/${upstreamModel}`,
+    gatewayModel,
+    upstreamModel,
+    provider: "openrouter",
+    listed: true,
+    displayName: `${upstreamModel} (curated)`,
+    description: "Test fixture.",
+    priority: 500,
+    defaultEffort: "high",
+    reasoningLevels: [{ effort: "high", description: "Adaptive reasoning" }],
+    contextWindow: 131072,
+    autoCompact: 110000,
+    inputModalities: ["text"],
+    compHash: `${gatewayModel}-user-v1`,
+    ...(requestProfile ? { requestProfile } : {}),
+  });
+  writeFileSync(
+    file,
+    JSON.stringify({
+      version: 1,
+      models: [
+        entry("qwen/qwen3.8-max", "openrouter-qwen-qwen3-8-max", "auto-tool-choice"),
+        entry("openai/gpt-5.3", "openrouter-openai-gpt-5-3"),
+      ],
+    }),
+    "utf8",
+  );
+  return {
+    dir,
+    file,
+    restricted: "openrouter-qwen-qwen3-8-max",
+    unrestricted: "openrouter-openai-gpt-5-3",
+  };
+}
+
+test("API forwarder downgrades forced tool choices only for models that declare the restriction", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const curated = curatedOpenRouterModels();
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    MODEL_ROUTER_USER_MODELS: curated.file,
+    OPENROUTER_API_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OPENROUTER_API_KEY: "TEST_OPENROUTER_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  async function forward(gatewayModel, body) {
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: gatewayModel,
+        messages: [{ role: "user", content: "test" }],
+        ...body,
+      }),
+    });
+    assert.equal(response.status, 200);
+    return upstreamRequests.at(-1);
+  }
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    // Some upstreams answer a forced tool choice with a hard 400 while still
+    // calling tools under "auto". The compatibility probe sends the string
+    // form and the subagent payload relay sends the object form, so both must
+    // arrive as auto rather than failing the turn.
+    for (const toolChoice of [
+      "required",
+      { type: "function", function: { name: "relay_external_agent_payload" } },
+    ]) {
+      const request = await forward(curated.restricted, { tool_choice: toolChoice });
+      assert.equal(request.headers.authorization, "Bearer TEST_OPENROUTER_API_KEY");
+      assert.equal(request.body.model, "qwen/qwen3.8-max");
+      assert.equal(request.body.tool_choice, "auto");
+    }
+
+    // "none" is not a forced choice: it suppresses tool calls, which the
+    // compaction turn relies on, so it must survive untouched.
+    const suppressed = await forward(curated.restricted, { tool_choice: "none" });
+    assert.equal(suppressed.body.tool_choice, "none");
+
+    // An absent choice stays absent so the upstream applies its own default.
+    const absent = await forward(curated.restricted, {});
+    assert.equal(absent.body.tool_choice, undefined);
+    assert.equal("tool_choice" in absent.body, false);
+
+    // The profile normalizes the tool choice and nothing else. Reusing
+    // qwen-plan here would have collapsed the picked effort to DashScope's
+    // two-tier ladder, which is not OpenRouter's parameter surface.
+    const untouched = await forward(curated.restricted, {
+      reasoning_effort: "medium",
+      temperature: 0.4,
+      tool_choice: "required",
+    });
+    assert.equal(untouched.body.reasoning_effort, "medium");
+    assert.equal(untouched.body.temperature, 0.4);
+
+    // The restriction belongs to the upstream model, not to the reseller: a
+    // sibling curated on the same provider keeps its forced choice, so tool
+    // calling is not weakened for every OpenRouter model to serve two.
+    const sibling = await forward(curated.unrestricted, { tool_choice: "required" });
+    assert.equal(sibling.body.model, "openai/gpt-5.3");
+    assert.equal(sibling.body.tool_choice, "required");
+
+    const siblingObject = await forward(curated.unrestricted, {
+      tool_choice: { type: "function", function: { name: "relay_external_agent_payload" } },
+    });
+    assert.deepEqual(siblingObject.body.tool_choice, {
+      type: "function",
+      function: { name: "relay_external_agent_payload" },
+    });
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+    rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
 
 test("API forwarder routes MiniMax M3 streaming tool calls with adaptive thinking", async () => {
   const upstreamRequests = [];


### PR DESCRIPTION
Finishes what #105 set out to do. Its compaction half already landed as #108 with credit to @jepgambardella; this is the other half, built the way the codebase already handles this class of restriction.

## Why not the original approach

#105 changed the compatibility probe from `tool_choice: "required"` to `"auto"` globally. With `auto` a model may legitimately decline the call, so the probe stops proving tool calling works and becomes nondeterministic for every provider — to accommodate two models. `src/compatibility-test.mjs` is unchanged here and still sends `"required"`.

## Why not provider-wide either

I went in expecting an OpenRouter-wide downgrade. The evidence says model-specific:

- **OpenRouter's own data model treats `tool_choice` as per-model.** Its `/api/v1/models` listing carries `supported_parameters` in which `tool_choice` is a separate entry from `tools`, and is filterable on it. If forced tool choice were refused fleet-wide, that entry could never be true for anything.
- **OpenRouter does not reject unsupported parameters itself.** Its provider-routing docs say providers that don't support all specified parameters still receive the request and ignore unknown ones, unless `require_parameters: true`. So a hard 400 on `tool_choice: "required"` is the *upstream's* rejection travelling back through the proxy, not OpenRouter policy.
- **It is the same restriction already handled per-model twice here.** Both existing guards (`qwen-plan`, `deepseek-thinking`) are thinking-mode restrictions belonging to Alibaba's and DeepSeek's own models. An OpenRouter-hosted Qwen 3.8 Max is the same upstream model, so the restriction follows the model through whichever reseller fronts it.

**And a provider-wide downgrade would have been actively harmful.** The forwarder rewrites every request, so it would also downgrade the subagent payload relay's forced function object (`{type:"function", function:{name:"relay_external_agent_payload"}}`) for GPT, Claude, Gemini and Grok routed via OpenRouter — models that honor `required` — letting them answer in prose instead of returning the handoff. That is a routed-subagent regression, not a test-harness nuisance.

I also checked the provider-level-default idea: the registry has no provider-level `requestProfile` field, and adding one would be the wrong shape given the above. `src/curate-models.mjs:166` only inherits from an existing curated model on the same provider, so the fix is to make the profile **askable per model**, not defaultable per provider.

## What ships

- **`src/api-forwarder.mjs`** — a new `auto-tool-choice` branch: a forced `tool_choice` (string or function object) becomes `"auto"`; `"none"` and absent are untouched; no other parameter is modified.
- **`src/curate-models.mjs`** — a `--request-profile` flag with validation that throws on a typo by name (mirroring `parseEfforts`), plus an interactive per-model question defaulting to **no**. Precedence: explicit flag > inherited provider profile > interactive question. Inheriting suppresses the question, since `qwen-plan` and `deepseek-thinking` already downgrade.

**On the name:** deliberately not `openrouter-`. The restriction rides the upstream model, so someone curating the same model on Together needs identical behaviour and a vendor-prefixed name would read as inapplicable. It is `auto-tool-choice` — the only behaviour-named profile, justified inline because it normalizes a field rather than translating a vendor's parameter surface.

**Explicitly not `qwen-plan`,** which would have silently collapsed `reasoning_effort` to DashScope's `high`. A dedicated test asserts `reasoning_effort: "medium"` and `temperature` pass through untouched.

## Tests

`test/routing.test.mjs` registers two curated OpenRouter models — one with the profile, one without — via `MODEL_ROUTER_USER_MODELS`, mirroring the existing `curatedGeminiModel()` precedent for a catalog-only provider. The non-provider-wide claim is itself asserted: the sibling keeps `"required"` and keeps its forced function object byte-identical.

RED before the forwarder change: `AssertionError: 'required' !== 'auto'`. GREEN after. `test/curate-models.test.mjs` gains 4 tests, RED with `parseRequestProfile is not a function`.

561 tests, 555 pass, 0 fail, 6 skipped (+5 over baseline). No live or paid calls; the upstream is a local mock.

## What this does not do

It cannot ship the two named models. `config/openrouter/openrouter.json` remains provider-only and OpenRouter stays catalog-only by design. What ships is the mechanism plus the curation path to reach it — not dead code, since curation is the only route to any OpenRouter model and it now writes the field.

@jepgambardella, to fix your two models after this lands:

```sh
./bin/curate-models openrouter --models qwen/qwen3.8-max,<muse-spark-id> \
  --request-profile auto-tool-choice --apply
```

Curation never rewrites existing entries, so models curated before this need that re-run after deselecting them, or `"requestProfile": "auto-tool-choice"` added by hand in `user-models.json` followed by `./bin/install`.

## Unrelated, noticed while in there

`confirm()` defaults to yes, so the pre-existing `Does <id> accept image input?` prompt advertises image input on a bare Enter. I passed `false` explicitly for the new prompt but left that one alone as out of scope.
