### PR TITLE
fix(router): retry a native upstream failure that happened before anything was relayed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -438,6 +438,49 @@ minutes later. Do not quietly drop the label because a check happened to pass.
   directories.
 - Do not restart or quit the Codex App from the installation task.
 
+## Upstream retries are legal only before the first relayed byte
+
+`src/upstream-retry.mjs` retries a native upstream request a bounded number of
+times. One rule governs it, and breaking it corrupts responses rather than
+merely failing them.
+
+1. A retry is legal only while **nothing has been relayed**. The loop lives
+   entirely before its callers touch their `ServerResponse`, and the `canRetry`
+   predicate (`response.headersSent`, checked again before every retry) is the
+   backstop. `copyResponseHeaders` only stages values with `setHeader`, so
+   `headersSent` flips when Node flushes the head — on the first body write, or
+   on `end()` for a bodyless upstream. Never move a retry around
+   `pipeResponse`: an upstream that dies mid-stream has already delivered
+   bytes, and replaying it appends a second response to a stream the client is
+   reading. `test/native-retry.test.mjs` asserts the caller received the partial
+   stream exactly once.
+2. Only failures where an intermediary never obtained a response qualify: 502,
+   503, 504, Cloudflare's 520-524, and connect-level socket errors. Do not add
+   429 — it is rate limiting, its `Retry-After` is relayed, and sleeping for the
+   upstream's suggested delay is the hang the bound exists to prevent. Do not
+   add 4xx, and do not add 500, where the origin ran and a repeat risks a second
+   execution.
+3. Keep the bound small. Codex retries roughly five times on its own and the
+   two loops multiply, so the router's share (2 retries, 250ms then 750ms) has
+   to keep the product a fast failure. A retry is also only *started* while the
+   request has been cheap so far — a five-second budget, because a 504 the edge
+   spent half a minute producing, or a connect timeout, must not be tripled.
+   `CODEX_ROUTER_NATIVE_RETRIES`, `CODEX_ROUTER_NATIVE_RETRY_BACKOFF_MS`, and
+   `CODEX_ROUTER_NATIVE_RETRY_BUDGET_MS` tune it; `0` disables it.
+4. The request body must stay replayable: encode it into a Buffer once, above
+   the retry, so every attempt sends identical bytes under the identical
+   `Content-Encoding`. Never hand the loop a stream, and never re-run
+   `compressedNativeBody` per attempt — headers and body would be free to
+   disagree.
+5. An abort stops everything at once, backoff included. Pass the caller's signal
+   through to both the fetch and the wait.
+6. A silent retry is worse than no retry: it makes a flaky upstream look
+   healthy. The retry log line is never gated on `CODEX_ROUTER_QUIET`, which a
+   production LaunchAgent hard-sets, and the usage event carries `retries` so a
+   turn the router rescued is distinguishable from one that never failed. Log
+   the status or the transport error's own name and code — never a response
+   body, and never the caller capability path.
+
 ## Routed subagent regression prevention
 
 - A normal `/responses` smoke test does not cover Codex collaboration. Current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,27 @@
   subagent relay's forced function call. The probe itself still sends
   `required`. Thanks to @jepgambardella for the report.
 
+- **An upstream failure that happens before any response byte is retried once
+  or twice instead of being relayed.** ChatGPT's edge intermittently answers a
+  native turn with a 503 whose body is "upstream connect error or
+  disconnect/reset before headers"; a live usage log recorded Cloudflare 520s
+  in the same window. The 503 is upstream and still is — but "before headers"
+  means nothing was ever served, so the router now sends the request again
+  rather than handing Codex a 5xx and spending one of its five reconnects on a
+  failure a quarter of a second would have absorbed. Two retries at 250ms and
+  750ms, so a genuinely dead upstream still fails in about a second rather than
+  hanging. Only the statuses that mean an intermediary never got a response
+  (502, 503, 504, and Cloudflare's 520-524) and connect-level socket failures
+  qualify: a 429 is relayed with its `Retry-After` intact, every 4xx is
+  relayed, and a 500 is left alone because the origin ran. A retry only starts
+  while the request has been cheap so far, so a 504 the edge spent half a
+  minute producing is relayed rather than tried twice more. Nothing is ever
+  retried once a byte has reached the caller, which would duplicate the stream.
+  A caller that disconnects stops the retries immediately, including during the
+  backoff. Retries are logged whether or not the service is quiet, and recorded
+  on the usage event, so an upstream that is being papered over still looks
+  flaky in the telemetry instead of healthy.
+
 - **Windows no longer opens a console window at logon.** The scheduled task ran
   the CMD wrapper through `cmd.exe`, so a console window appeared at every logon
   and stayed for the router's lifetime, reappearing on each watchdog restart.

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1383,6 +1383,15 @@ async function handleNativeImage(request, response, requestUrl) {
         signal: controller.signal,
       },
       {
+        // Images do not retry. The retryable statuses were chosen to mean "no
+        // response was obtained", but that is reasoning rather than something
+        // observable from here, and Cloudflare can emit 520 after reaching the
+        // origin. On a turn a wrong guess costs a duplicated request; on an
+        // image generation it costs the operator a second billed image. The
+        // failure this exists to absorb was reported on /v1/responses, so the
+        // turn path keeps the benefit and the billed path keeps the old
+        // behaviour until a captured 5xx proves it is safe.
+        retries: 0,
         canRetry: () => nothingRelayed(response),
         onRetry: (event) => logUpstreamRetry(event, requestedModel, requestUrl.pathname),
       },

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -38,6 +38,7 @@ import {
   selectedConfiguredListedModels,
 } from "./provider-selection.mjs";
 import { ResponseUsageTransform, tokenUsageFromPayload } from "./response-usage.mjs";
+import { fetchWithRetry } from "./upstream-retry.mjs";
 import {
   CollaborationToolCallTransform,
   flattenCollaborationHistory,
@@ -331,6 +332,41 @@ function routedHeaders() {
 function nativeTarget(pathname, search) {
   const withoutV1 = pathname.replace(/^\/v1(?=\/|$)/, "");
   return `${NATIVE_BASE}${withoutV1}${search}`;
+}
+
+// The safety line for an upstream retry: has the caller seen anything yet?
+//
+// `pipeResponse` assigns `response.statusCode` and calls `copyResponseHeaders`,
+// which only stages values with `setHeader` -- neither touches the socket.
+// Node flushes the head on the first body write, or on `end()` for a bodyless
+// upstream, and that is exactly when `headersSent` flips. So `headersSent` is
+// "at least the status line has been committed", which is the condition that
+// makes a retry unsafe: replaying then would append a second response to a
+// stream the client is already reading.
+//
+// `writableEnded`/`destroyed` cover the answers that never set headers through
+// this path (an early `writeJson`, a client that hung up). The structural
+// guarantee is stronger than the predicate: every retry happens inside
+// `fetchWithRetry`, which returns before any of this function's callers touch
+// `response` at all. This is the check that would notice if that ever stopped
+// being true.
+function nothingRelayed(response) {
+  return !response.headersSent && !response.writableEnded && !response.destroyed;
+}
+
+// Never gated on QUIET. A production LaunchAgent hard-sets `CODEX_ROUTER_QUIET=1`,
+// which suppresses the per-request status line, and a silent retry is worse
+// than no retry: a flaky upstream would look like an upstream that got better.
+// Response bodies are never logged, so a retry records the status or the
+// transport error's own name and code and nothing else.
+function logUpstreamRetry({ attempt, retries, status, error, delayMs }, model, routePath) {
+  const cause = status
+    ? `status=${status}`
+    : `error=${error?.name || "Error"}${error?.cause?.code ? `/${error.cause.code}` : ""}`;
+  console.error(
+    `[codex-router] native upstream retry ${attempt}/${retries} ${cause} ` +
+      `model=${model || "unknown"} path=${routePath} delayMs=${delayMs}`,
+  );
 }
 
 function catalogModels() {
@@ -1207,12 +1243,29 @@ async function handleResponses(request, response, requestUrl) {
       );
     }
 
-    const upstream = await fetch(target, {
-      method: "POST",
-      headers,
-      body: routedBody,
-      signal: controller.signal,
-    });
+    // `routedBody` is a fully materialized Buffer -- plain JSON, or the zstd
+    // frame `compressedNativeBody` produced together with the matching
+    // `Content-Encoding` header. Both are computed once, above, so every
+    // attempt replays the identical bytes under the identical encoding. Nothing
+    // here consumes a stream, which is what makes the request replayable at
+    // all.
+    const { response: upstream, retries: upstreamRetries } = await fetchWithRetry(
+      target,
+      {
+        method: "POST",
+        headers,
+        body: routedBody,
+        signal: controller.signal,
+      },
+      {
+        // Routed traffic terminates at the local gateway, which has its own
+        // error translation and Retry-After handling below; leave it exactly
+        // as it was.
+        retries: route ? 0 : undefined,
+        canRetry: () => nothingRelayed(response),
+        onRetry: (event) => logUpstreamRetry(event, requestedModel, requestUrl.pathname),
+      },
+    );
     // Gateway error bodies leak LiteLLM's internal exception chain, which
     // reads like a router bug. Rewrite them to name the provider that failed.
     // Native traffic passes through untouched: OpenAI errors are already clear.
@@ -1259,16 +1312,19 @@ async function handleResponses(request, response, requestUrl) {
     }
     await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS, transforms);
     const usage = usageTransform?.tokenUsage();
+    // `retries` is what separates "it never failed" from "it failed and the
+    // router absorbed it", both of which otherwise record a plain 200.
     recordUsageEvent({
       model: route?.slug || requestedModel,
       provider: route ? canonicalProviderId(route.provider) : "openai",
       status: upstream.status,
       durationMs: Date.now() - startedAt,
+      retries: upstreamRetries,
       ...usage,
     });
     if (!QUIET) {
       console.error(
-        `[codex-router] model=${requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${upstream.status}`,
+        `[codex-router] model=${requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${upstream.status}${upstreamRetries ? ` retries=${upstreamRetries}` : ""}`,
       );
     }
   } catch (error) {
@@ -1315,13 +1371,20 @@ async function handleNativeImage(request, response, requestUrl) {
     });
 
     const headers = nativeHeaders(request);
-    const upstream = await fetch(
+    // Same replayable-Buffer rule as the turn path: encode once, outside the
+    // retry, so every attempt carries identical bytes under identical headers.
+    const imageBody = await compressedNativeBody(body, headers);
+    const { response: upstream, retries: upstreamRetries } = await fetchWithRetry(
       nativeTarget(requestUrl.pathname, requestUrl.search),
       {
         method: "POST",
         headers,
-        body: await compressedNativeBody(body, headers),
+        body: imageBody,
         signal: controller.signal,
+      },
+      {
+        canRetry: () => nothingRelayed(response),
+        onRetry: (event) => logUpstreamRetry(event, requestedModel, requestUrl.pathname),
       },
     );
     await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS);
@@ -1330,10 +1393,11 @@ async function handleNativeImage(request, response, requestUrl) {
       provider: "openai",
       status: upstream.status,
       durationMs: Date.now() - startedAt,
+      retries: upstreamRetries,
     });
     if (!QUIET) {
       console.error(
-        `[codex-router] model=${requestedModel} provider=openai status=${upstream.status}`,
+        `[codex-router] model=${requestedModel} provider=openai status=${upstream.status}${upstreamRetries ? ` retries=${upstreamRetries}` : ""}`,
       );
     }
   } catch (error) {

--- a/src/upstream-retry.mjs
+++ b/src/upstream-retry.mjs
@@ -1,0 +1,203 @@
+// Bounded retry for an upstream request that failed before any byte of the
+// response reached the caller.
+//
+// ChatGPT's edge intermittently answers a native turn with
+// "upstream connect error or disconnect/reset before headers", and the router
+// relayed that 503 straight through. "Before headers" is the whole point: no
+// response bytes ever existed, so the request can be sent again and the caller
+// never learns it happened. Codex reacts to the relayed 5xx by spending one of
+// its own five reconnects on a failure that one short retry absorbs.
+//
+// The safety rule this module exists to enforce: a retry is only ever legal
+// while nothing has been relayed. That is guaranteed structurally -- the loop
+// runs entirely before the caller touches its own `ServerResponse` -- and the
+// `canRetry` predicate is the second line of defence, re-checked before every
+// single retry. Retrying after partial output would duplicate the stream.
+
+const DEFAULT_RETRIES = 2;
+const DEFAULT_BACKOFF_MS = 250;
+// Backoff grows 250ms -> 750ms, so two retries add at most one second of
+// waiting to a request that was going to fail anyway. Codex retries roughly
+// five times on its own and the two loops multiply, so the router's share has
+// to stay small enough that the product is still a fast failure.
+const BACKOFF_FACTOR = 3;
+// Retry only while the request has been cheap so far. Most of the retryable
+// failures below arrive in milliseconds, but two do not: a 504 the edge spent
+// half a minute producing, and a connect timeout. Tripling either turns a slow
+// failure into a hang, which is worse than the 503 this exists to absorb.
+const DEFAULT_BUDGET_MS = 5_000;
+const MAX_RETRIES = 5;
+const MAX_BACKOFF_MS = 5_000;
+const MAX_BUDGET_MS = 60_000;
+const MAX_CAUSE_DEPTH = 8;
+
+function clampedInteger(raw, fallback, min, max) {
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.floor(value)));
+}
+
+export const NATIVE_RETRY_LIMIT = clampedInteger(
+  process.env.CODEX_ROUTER_NATIVE_RETRIES,
+  DEFAULT_RETRIES,
+  0,
+  MAX_RETRIES,
+);
+export const NATIVE_RETRY_BACKOFF_MS = clampedInteger(
+  process.env.CODEX_ROUTER_NATIVE_RETRY_BACKOFF_MS,
+  DEFAULT_BACKOFF_MS,
+  0,
+  MAX_BACKOFF_MS,
+);
+export const NATIVE_RETRY_BUDGET_MS = clampedInteger(
+  process.env.CODEX_ROUTER_NATIVE_RETRY_BUDGET_MS,
+  DEFAULT_BUDGET_MS,
+  0,
+  MAX_BUDGET_MS,
+);
+
+// Statuses that mean an intermediary never obtained a usable response from the
+// origin, so the request itself was not served and sending it again is not a
+// second execution:
+//
+//   502/503/504  gateway/edge failure, the reported case
+//   520-524      Cloudflare-only edge failures; a live usage log recorded 520
+//                alongside the 503s, which is what proves the failure is
+//                happening at chatgpt.com's edge
+//
+// Deliberately absent:
+//
+//   429  quota and rate limiting. Retrying it blindly makes the condition
+//        worse, and honouring `Retry-After` would mean sleeping for as long as
+//        the upstream asks -- exactly the multi-second hang this bound exists
+//        to avoid. It is relayed so the caller and the user see it.
+//   4xx  deterministic. The same request produces the same answer.
+//   500  the origin ran and failed. Unlike the edge statuses above, a repeat
+//        risks a second execution of work that already happened.
+export const RETRYABLE_STATUSES = new Set([502, 503, 504, 520, 521, 522, 523, 524]);
+
+// Transport failures where no response ever started. `fetch` reports these as
+// a generic TypeError whose cause carries the socket-level code.
+const RETRYABLE_ERROR_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+export function isRetryableStatus(status) {
+  return RETRYABLE_STATUSES.has(Number(status));
+}
+
+export function isRetryableTransportError(error) {
+  if (!error) return false;
+  // An abort is the caller leaving, and a router-side error (a body that is too
+  // large, an unsupported encoding) carries its own HTTP status and would fail
+  // identically every time.
+  if (error.name === "AbortError" || error.name === "TimeoutError") return false;
+  if (error.status) return false;
+  let cause = error;
+  for (let depth = 0; cause && depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (typeof cause.code === "string" && RETRYABLE_ERROR_CODES.has(cause.code)) return true;
+    cause = cause.cause;
+  }
+  return false;
+}
+
+// A backoff that a departing caller does not have to sit through: an abort
+// resolves the wait immediately so the loop can stop on its next check.
+export function sleep(ms, signal) {
+  if (!(ms > 0)) return Promise.resolve();
+  return new Promise((resolve) => {
+    const finish = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener?.("abort", finish);
+      resolve();
+    };
+    const timer = setTimeout(finish, ms);
+    signal?.addEventListener?.("abort", finish, { once: true });
+  });
+}
+
+function abortError(signal) {
+  if (signal?.reason instanceof Error) return signal.reason;
+  const error = new Error("The upstream request was aborted by the caller.");
+  error.name = "AbortError";
+  return error;
+}
+
+// A failed attempt still owns a socket until its body is drained or cancelled.
+async function discardBody(response) {
+  try {
+    await response?.body?.cancel();
+  } catch {
+    // The connection is already gone, which is the state we wanted anyway.
+  }
+}
+
+function settle(response, failure, retries) {
+  if (failure) throw failure;
+  return { response, retries };
+}
+
+// Returns `{ response, retries }` where `retries` counts the attempts beyond
+// the first, so a caller can tell "succeeded immediately" from "succeeded on
+// the second try" and record the difference.
+export async function fetchWithRetry(target, init = {}, options = {}) {
+  const {
+    retries = NATIVE_RETRY_LIMIT,
+    backoffMs = NATIVE_RETRY_BACKOFF_MS,
+    budgetMs = NATIVE_RETRY_BUDGET_MS,
+    signal = init.signal,
+    canRetry,
+    onRetry,
+    fetchImpl = fetch,
+    sleepImpl = sleep,
+    now = Date.now,
+  } = options;
+  const startedAt = now();
+  let attempt = 0;
+  for (;;) {
+    let response;
+    let failure;
+    try {
+      response = await fetchImpl(target, init);
+    } catch (error) {
+      failure = error;
+    }
+    if (attempt >= retries) return settle(response, failure, attempt);
+    const retryable = failure
+      ? isRetryableTransportError(failure)
+      : isRetryableStatus(response?.status);
+    if (!retryable) return settle(response, failure, attempt);
+    // The caller is gone, or has already relayed something. Either way this
+    // request is over: a retry would be work for nobody, or a duplicated
+    // stream.
+    if (signal?.aborted || canRetry?.() === false) {
+      return settle(response, failure, attempt);
+    }
+    // This attempt was not cheap, so the failure was not the fast one a retry
+    // absorbs. Relay it rather than spending the same time again.
+    if (now() - startedAt >= budgetMs) return settle(response, failure, attempt);
+    await discardBody(response);
+    const delayMs = backoffMs * BACKOFF_FACTOR ** attempt;
+    attempt += 1;
+    onRetry?.({
+      attempt,
+      retries,
+      status: response?.status,
+      error: failure,
+      delayMs,
+    });
+    await sleepImpl(delayMs, signal);
+    if (signal?.aborted) throw abortError(signal);
+  }
+}

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -16,6 +16,15 @@ function safeTokenCount(value) {
   return Number.isFinite(number) && number >= 0 ? Math.round(number) : undefined;
 }
 
+// Retries are recorded only when there were any, so an ordinary event keeps the
+// exact shape it always had. A transparently absorbed upstream failure records
+// a 200 like any other turn, and this field is the only thing that says the
+// upstream is flaky rather than healthy.
+function safeRetryCount(value) {
+  const count = safeTokenCount(value);
+  return count ? count : undefined;
+}
+
 export function recordUsageEvent({
   model,
   provider,
@@ -24,6 +33,7 @@ export function recordUsageEvent({
   inputTokens,
   outputTokens,
   totalTokens,
+  retries,
   at = Date.now(),
 }) {
   const event = {
@@ -33,6 +43,7 @@ export function recordUsageEvent({
     provider: safeText(provider, "unknown"),
     status: Number.isInteger(status) ? status : 0,
     durationMs: Number.isFinite(durationMs) ? Math.max(0, Math.round(durationMs)) : 0,
+    ...(safeRetryCount(retries) !== undefined ? { retries: safeRetryCount(retries) } : {}),
     ...(safeTokenCount(inputTokens) !== undefined
       ? { inputTokens: safeTokenCount(inputTokens) }
       : {}),
@@ -82,6 +93,7 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
         const inputTokens = safeTokenCount(event.inputTokens);
         const outputTokens = safeTokenCount(event.outputTokens);
         const totalTokens = safeTokenCount(event.totalTokens);
+        const retries = safeRetryCount(event.retries);
         return {
           ...(event.meteringVersion === 1 ? { meteringVersion: 1 } : {}),
           at: event.at,
@@ -94,6 +106,7 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
           durationMs: Number.isFinite(event.durationMs)
             ? Math.max(0, Math.round(event.durationMs))
             : 0,
+          ...(retries !== undefined ? { retries } : {}),
           ...(inputTokens !== undefined ? { inputTokens } : {}),
           ...(outputTokens !== undefined ? { outputTokens } : {}),
           ...(totalTokens !== undefined ? { totalTokens } : {}),

--- a/test/native-retry.test.mjs
+++ b/test/native-retry.test.mjs
@@ -1,0 +1,530 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { zstdDecompressSync } from "node:zlib";
+
+import { callerBaseUrl } from "../src/caller-auth.mjs";
+import { fetchWithRetry } from "../src/upstream-retry.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
+const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
+
+// The body ChatGPT's edge actually returns. "before headers" is the property
+// that makes the request replayable: no response bytes ever existed.
+const EDGE_503_BODY =
+  "upstream connect error or disconnect/reset before headers. " +
+  "reset reason: remote connection failure";
+
+function routerBase(port) {
+  return callerBaseUrl(port, CALLER_KEY);
+}
+
+async function openPort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function mockServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return { server, port: server.address().port };
+}
+
+async function readBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  const raw = Buffer.concat(chunks);
+  return {
+    encoding: request.headers["content-encoding"],
+    raw,
+    // A retried turn must arrive as a valid body, not a half-consumed stream
+    // or a zstd frame whose header says one thing and whose bytes say another.
+    text: (request.headers["content-encoding"] === "zstd"
+      ? zstdDecompressSync(raw)
+      : raw
+    ).toString("utf8"),
+  };
+}
+
+function run(env) {
+  const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
+      CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+      KIMI_INTERNAL_KEY: INTERNAL_KEY,
+      CODEX_ROUTER_SHOW_ALL_MODELS: "1",
+      CODEX_ROUTER_QUIET: "1",
+      ...env,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let errors = "";
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+  child.testErrors = () => errors;
+  return child;
+}
+
+async function waitFor(url, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Child exited early (${child.exitCode}): ${child.testErrors()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Not bound yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${url}: ${child.testErrors()}`);
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await new Promise((resolve) => child.once("exit", resolve));
+}
+
+async function closeServer(server) {
+  await new Promise((resolve) => server.close(resolve));
+}
+
+function usageEvents(stateDir) {
+  const file = path.join(stateDir, "usage-events.jsonl");
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+async function waitUntil(predicate, message, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(message);
+}
+
+// A turn large enough that the router compresses it, so a retry has to replay
+// a zstd frame rather than plain JSON.
+function largeNativeTurn() {
+  const text = Array.from(
+    { length: 4_000 },
+    (_, index) => `line ${index}: the quick brown fox jumps over the lazy dog`,
+  ).join("\n");
+  return {
+    model: "gpt-5.6-sol",
+    input: [{ type: "message", role: "user", content: [{ type: "input_text", text }] }],
+  };
+}
+
+function startRouter({ nativePort, routerPort, stateDir, backoffMs = 20, retries }) {
+  return run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${nativePort}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${nativePort}/v1`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_NATIVE_RETRY_BACKOFF_MS: String(backoffMs),
+    ...(retries === undefined ? {} : { CODEX_ROUTER_NATIVE_RETRIES: String(retries) }),
+  });
+}
+
+function stateDirectory() {
+  return mkdtempSync(path.join(os.tmpdir(), "native-retry-state-"));
+}
+
+// The reported failure: ChatGPT's edge answers a native turn with a 503 whose
+// body says the connection reset *before headers*. Nothing was relayed, so the
+// router can send it again and the caller never learns it happened.
+test("a native 503 before headers is retried and the caller sees only the success", async () => {
+  const attempts = [];
+  const native = await mockServer(async (request, response) => {
+    attempts.push(await readBody(request));
+    if (attempts.length === 1) {
+      response.writeHead(503, { "Content-Type": "text/plain" });
+      response.end(EDGE_503_BODY);
+      return;
+    }
+    const payload = Buffer.from(JSON.stringify({ id: "resp-retried", output: [] }), "utf8");
+    response.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  const router = startRouter({ nativePort: native.port, routerPort, stateDir });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const turn = largeNativeTurn();
+    const result = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { Authorization: "Bearer caller", "Content-Type": "application/json" },
+      body: JSON.stringify(turn),
+    });
+
+    const relayed = await result.text();
+    assert.equal(result.status, 200, relayed);
+    assert.equal(JSON.parse(relayed).id, "resp-retried");
+    assert.equal(attempts.length, 2, "the 503 was relayed instead of retried");
+
+    // Idempotency: the replayed request is the same bytes under the same
+    // encoding, and it still decodes.
+    assert.equal(attempts[0].encoding, "zstd");
+    assert.equal(attempts[1].encoding, "zstd");
+    assert.deepEqual(
+      JSON.parse(attempts[1].text).input[0].content[0].text,
+      turn.input[0].content[0].text,
+    );
+    assert.ok(
+      attempts[0].raw.equals(attempts[1].raw),
+      "the retry did not replay the first attempt's bytes",
+    );
+
+    // A silent retry would let a flaky upstream read as a healthy one.
+    await waitUntil(
+      () => /native upstream retry /.test(router.testErrors()),
+      `no retry was logged: ${router.testErrors()}`,
+    );
+    assert.match(
+      router.testErrors(),
+      /\[codex-router\] native upstream retry 1\/2 status=503 model=gpt-5\.6-sol path=\/v1\/responses delayMs=\d+/,
+    );
+    // The logged path is the authenticated route the router already resolved,
+    // never the caller capability in the URL it was dialed with.
+    assert.equal(router.testErrors().includes(CALLER_KEY), false);
+
+    await waitUntil(
+      () => usageEvents(stateDir).length > 0,
+      "no usage event was recorded",
+    );
+    const event = usageEvents(stateDir).at(-1);
+    assert.equal(event.status, 200);
+    assert.equal(event.provider, "openai");
+    // Distinguishable from a first-attempt success, which records no field.
+    assert.equal(event.retries, 1);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// The bound has to be a bound. Once it is spent the upstream's own answer
+// reaches the caller untouched, exactly as it does today.
+test("a native 503 that outlives the retry bound is relayed unchanged", async () => {
+  const attempts = [];
+  const native = await mockServer(async (request, response) => {
+    attempts.push(await readBody(request));
+    response.writeHead(503, { "Content-Type": "text/plain", "X-Edge": "envoy" });
+    response.end(EDGE_503_BODY);
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  const router = startRouter({ nativePort: native.port, routerPort, stateDir });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const result = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { Authorization: "Bearer caller", "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5.6-sol", input: "native turn" }),
+    });
+
+    assert.equal(result.status, 503);
+    assert.equal(await result.text(), EDGE_503_BODY);
+    assert.equal(result.headers.get("x-edge"), "envoy");
+    // One first attempt plus the two the bound allows, and no more.
+    assert.equal(attempts.length, 3);
+
+    await waitUntil(
+      () => usageEvents(stateDir).length > 0,
+      "no usage event was recorded",
+    );
+    const event = usageEvents(stateDir).at(-1);
+    assert.equal(event.status, 503);
+    assert.equal(event.retries, 2);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// The constraint that must never break. Once any byte is on the wire the
+// request is no longer replayable: a retry would append a second response to a
+// stream the client is already reading.
+test("an upstream failure after headers is never retried", async () => {
+  const attempts = [];
+  const native = await mockServer(async (request, response) => {
+    attempts.push(await readBody(request));
+    response.writeHead(200, {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache",
+    });
+    response.write('event: response.created\ndata: {"type":"response.created"}\n\n');
+    // The edge drops a live stream: headers and one event already relayed.
+    setTimeout(() => response.destroy(), 60);
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  const router = startRouter({ nativePort: native.port, routerPort, stateDir });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const result = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { Authorization: "Bearer caller", "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5.6-sol", input: "native turn", stream: true }),
+    });
+    assert.equal(result.status, 200);
+    const body = await result.text();
+
+    // Give a would-be retry every chance to arrive before counting.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    assert.equal(attempts.length, 1, "a request that had already streamed was retried");
+
+    // The decisive assertion: the caller received the partial stream exactly
+    // once. A retry here would have duplicated it.
+    assert.equal(body.match(/event: response\.created/g)?.length, 1, body);
+    assert.match(body, /event: error/);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// 4xx is deterministic, and 429 is the one 5xx-adjacent status a retry makes
+// actively worse: it is rate limiting, and the caller has to see it.
+test("native 4xx and 429 responses are relayed without a retry", async () => {
+  const attempts = [];
+  const native = await mockServer(async (request, response) => {
+    await readBody(request);
+    attempts.push(request.url);
+    const status = attempts.length === 1 ? 400 : 429;
+    const payload = Buffer.from(JSON.stringify({ error: { code: status } }), "utf8");
+    response.writeHead(status, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+      ...(status === 429 ? { "Retry-After": "30" } : {}),
+    });
+    response.end(payload);
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  const router = startRouter({ nativePort: native.port, routerPort, stateDir });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const headers = {
+      Authorization: "Bearer caller",
+      "Content-Type": "application/json",
+    };
+    const body = JSON.stringify({ model: "gpt-5.6-sol", input: "native turn" });
+
+    const badRequest = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    assert.equal(badRequest.status, 400);
+    assert.equal((await badRequest.json()).error.code, 400);
+
+    const rateLimited = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    assert.equal(rateLimited.status, 429);
+    // The upstream's own pacing instruction survives, which a retry loop that
+    // swallowed 429 would have replaced with a burst of extra requests.
+    assert.equal(rateLimited.headers.get("retry-after"), "30");
+
+    assert.equal(attempts.length, 2, "a 4xx or 429 was retried");
+    assert.equal(/native upstream retry /.test(router.testErrors()), false);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// A caller that walked away must not keep the router working on its behalf,
+// least of all sleeping through a backoff for it.
+test("a caller that disconnects mid-backoff stops the retries", async () => {
+  let attempts = 0;
+  let sawFirst;
+  const firstAttempt = new Promise((resolve) => {
+    sawFirst = resolve;
+  });
+  const native = await mockServer(async (request, response) => {
+    attempts += 1;
+    for await (const _chunk of request) {
+      // Drain.
+    }
+    response.writeHead(503, { "Content-Type": "text/plain" });
+    response.end(EDGE_503_BODY);
+    sawFirst();
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  // A backoff long enough that the abort lands squarely inside it.
+  const router = startRouter({
+    nativePort: native.port,
+    routerPort,
+    stateDir,
+    backoffMs: 1_500,
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const controller = new AbortController();
+    const pending = fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { Authorization: "Bearer caller", "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5.6-sol", input: "native turn" }),
+      signal: controller.signal,
+    }).catch((error) => error);
+
+    await firstAttempt;
+    controller.abort();
+    const settled = await pending;
+    assert.equal(settled?.name, "AbortError");
+
+    // Well past the backoff the second attempt would have fired at.
+    await new Promise((resolve) => setTimeout(resolve, 2_500));
+    assert.equal(attempts, 1, "the router kept retrying for a caller that was gone");
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// The reported reset reason is "remote connection failure": the edge could not
+// reach the origin. Some of those arrive as a socket error rather than a 503,
+// and they are the same class of failure -- nothing was served.
+test("a connect failure is retried and an abort never is", async () => {
+  const connectFailure = () => {
+    const error = new TypeError("fetch failed");
+    error.cause = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    return error;
+  };
+  let calls = 0;
+  const retried = await fetchWithRetry(
+    "http://upstream.invalid/responses",
+    {},
+    {
+      retries: 2,
+      backoffMs: 0,
+      fetchImpl: async () => {
+        calls += 1;
+        if (calls < 3) throw connectFailure();
+        return new Response("ok", { status: 200 });
+      },
+    },
+  );
+  assert.equal(calls, 3);
+  assert.equal(retried.retries, 2);
+  assert.equal(retried.response.status, 200);
+
+  // An abort is the caller leaving, not an upstream failure.
+  let abortCalls = 0;
+  await assert.rejects(
+    fetchWithRetry(
+      "http://upstream.invalid/responses",
+      {},
+      {
+        retries: 2,
+        backoffMs: 0,
+        fetchImpl: async () => {
+          abortCalls += 1;
+          const error = new Error("aborted");
+          error.name = "AbortError";
+          throw error;
+        },
+      },
+    ),
+    /aborted/,
+  );
+  assert.equal(abortCalls, 1);
+});
+
+// A 504 the edge spent half a minute producing is still a 504, but retrying it
+// twice would turn a slow failure into a hang.
+test("a retryable failure that was slow to arrive is not retried", async () => {
+  let calls = 0;
+  let clock = 0;
+  const result = await fetchWithRetry(
+    "http://upstream.invalid/responses",
+    {},
+    {
+      retries: 2,
+      backoffMs: 0,
+      budgetMs: 5_000,
+      now: () => clock,
+      fetchImpl: async () => {
+        calls += 1;
+        clock += 30_000;
+        return new Response("gateway timeout", { status: 504 });
+      },
+    },
+  );
+  assert.equal(calls, 1);
+  assert.equal(result.retries, 0);
+  assert.equal(result.response.status, 504);
+});
+
+// The predicate the router binds to `response.headersSent`. Even a retryable
+// status must not be retried once the caller has been sent anything.
+test("a retryable status is not retried once something has been relayed", async () => {
+  let calls = 0;
+  let relayed = false;
+  const result = await fetchWithRetry(
+    "http://upstream.invalid/responses",
+    {},
+    {
+      retries: 3,
+      backoffMs: 0,
+      canRetry: () => !relayed,
+      fetchImpl: async () => {
+        calls += 1;
+        relayed = true;
+        return new Response("upstream connect error", { status: 503 });
+      },
+    },
+  );
+  assert.equal(calls, 1);
+  assert.equal(result.retries, 0);
+  assert.equal(result.response.status, 503);
+});

--- a/test/native-retry.test.mjs
+++ b/test/native-retry.test.mjs
@@ -528,3 +528,41 @@ test("a retryable status is not retried once something has been relayed", async 
   assert.equal(result.retries, 0);
   assert.equal(result.response.status, 503);
 });
+
+// A retried turn costs a duplicated request; a retried image generation costs
+// the operator a second billed image. The retryable statuses were chosen to
+// mean "no response was obtained", but that is reasoning rather than anything
+// observable from here, and Cloudflare can emit 520 after reaching the origin.
+// So the billed path keeps the pre-retry behaviour, and this test is what stops
+// it being switched on again by someone generalizing the turn path.
+test("an image generation is never retried, however retryable the failure looks", async () => {
+  const attempts = [];
+  const native = await mockServer(async (request, response) => {
+    attempts.push(await readBody(request));
+    response.writeHead(503, { "Content-Type": "text/plain" });
+    response.end(EDGE_503_BODY);
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  const router = startRouter({ nativePort: native.port, routerPort, stateDir });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const result = await fetch(`${routerBase(routerPort)}/images/generations`, {
+      method: "POST",
+      headers: { Authorization: "Bearer caller", "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-image-1", prompt: "a billed image" }),
+    });
+
+    assert.equal(result.status, 503, "the upstream failure must reach the caller");
+    assert.equal(
+      attempts.length,
+      1,
+      `a billed image generation was sent ${attempts.length} times`,
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Absorbs the transient upstream failure reported in #100, without pretending to fix ChatGPT's edge.

## The insight this rests on

The upstream error reads:

```
upstream connect error or disconnect/reset before headers. reset reason: remote connection failure
```

**Before headers** — no response byte ever reached the caller. That makes the request replayable and the retry invisible. Today the router doesn't retry at all, so it relays the 503 and Codex spends one of its own ~5 reconnects on a failure a single 250ms retry absorbs.

This does not fix the 503. #100's analysis established it originates at ChatGPT's edge (a live usage log recorded Cloudflare-only `520`s alongside the 503s). This stops it costing the user their turn.

## The safety line

`headersSent` is the guard, and it was verified against the code rather than assumed: `pipeResponse` assigns `statusCode` and calls `copyResponseHeaders`, which only stages values with `setHeader` — neither touches the socket. Node flushes the head on the first body write, and that is exactly when `headersSent` flips. So it means "the status line is committed", which is precisely when a replay would append a second response to a stream the client is already reading.

**The structural guarantee is stronger than the predicate:** the retry loop lives entirely inside `fetchWithRetry`, which returns before any caller touches its `ServerResponse`. `canRetry` is re-evaluated before every retry as the backstop if that ever stops being true.

That test was proven to have teeth by running it against a deliberately broken variant with the retry placed *around* `pipeResponse` — the classic mistake:

```
not ok — a request that had already streamed was retried: 2 !== 1
```

## What retries, and what deliberately doesn't

**Retried:** 502/503/504 and Cloudflare's 520–524, plus connect-level socket codes. All mean an intermediary never obtained a response, so a replay is not a second execution.

**Not retried, each for a reason:**

- **429** — `src/router.mjs:1221` already relays `Retry-After`. Retrying blind makes rate limiting worse, and honouring `Retry-After` would mean sleeping however long the upstream asks, which is the hang the bound exists to prevent.
- **500** — the origin ran and failed; a repeat risks a second execution.
- **All 4xx** — deterministic.
- **Image generations and edits.** This one I added on review. The retryable statuses were chosen to mean "no response obtained", but that is reasoning, not something observable from here, and Cloudflare can emit 520 after reaching the origin. On a turn a wrong guess costs a duplicated request; on `/images/*` it costs a second **billed image**. #100 was reported on `/v1/responses`, so the turn path keeps the benefit and the billed path keeps its old behaviour. A test asserts one upstream attempt — with retries re-enabled it reports the image being sent **three times**.

## Latency, bounded deliberately

2 retries, 250ms then 750ms. But a naive version had a hole: a 504 the edge spent 30s producing, or a connect timeout, would be tripled into a minute-plus hang. So a retry only *starts* while the request has been cheap — a 5s elapsed budget. A slow retryable failure is relayed rather than repeated.

- Reported case (edge 503 in tens of ms): ~1.1s added before the caller sees the same 503; ~5.5s across Codex's whole reconnect loop in the case where nothing helps.
- Ceiling: a slow-failing upstream is retried **zero** times. No path turns a fast failure into a 30s hang.
- A retry that succeeds costs 250ms instead of a failed turn.

## Idempotency

`routedBody` is a materialized Buffer, and `compressedNativeBody` (#103) is called **once, above** the loop — critical, since it mutates the headers object to set `Content-Encoding: zstd` and falls back to the plain body on failure; re-running per attempt could leave headers and body disagreeing. A test uses a >16KB turn so compression actually triggers and asserts both attempts arrived as zstd, decoded to the same turn, and were byte-identical.

## Observability

A silent retry would make a flaky upstream look like one that got better — the same trap as a check that never fails.

- `[codex-router] native upstream retry 1/2 status=503 model=… delayMs=250`, **not gated on QUIET**, because the LaunchAgent hard-sets `CODEX_ROUTER_QUIET=1`. Never logs a body; a test asserts the caller capability never appears.
- `retries` on the usage event, written only when non-zero so ordinary events keep their exact shape. The diagnostic one-liner from #100 now shows it.

## Tests

565 tests, 559 pass, 0 fail (+9). RED against unfixed code: `503 !== 200` and `1 !== 3`. The three guard tests necessarily pass before the change, so two were separately verified against broken variants — the post-headers one above, and the abort one against a retry that drops the caller's signal (`the router kept retrying for a caller that was gone`).

## What a live reproduction would still settle

- **The premise.** Mocks prove the mechanism, not that the edge succeeds ~250ms later. If the 503s arrive in correlated bursts, retries absorb fewer than hoped. The `retries` field in `usage-events.jsonl` answers this from a real install: a rising retry count with a flat 503 count means it is working.
- **Whether 520–524 share the before-headers property.** Included on reasoning; no captured 520 body was available. If one ever turns out to follow a partially-served origin request, it should come out of the set.
- `CODEX_ROUTER_NATIVE_RETRIES=0` disables the whole thing.

`relayEncryptedAgentPayload` is untouched — AGENTS.md requires it to fail closed, so it stays out of scope.
