### PR TITLE
fix(router): estimate prompt tokens when a provider reports an impossible zero

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,6 +481,44 @@ merely failing them.
    the status or the transport error's own name and code — never a response
    body, and never the caller capability path.
 
+## Substituting a prompt-token count a provider reported as zero
+
+Codex decides when to compact from the `input_tokens` each response reports, so
+a provider that answers a large prompt with an explicit zero disables
+compaction entirely and the session runs until the provider rejects the turn.
+The router replaces that number on the way to Codex. The rules are narrow on
+purpose.
+
+1. Only an **explicit zero** is replaced, and only on a **routed** response
+   whose request the router measured as large. A missing usage block, a missing
+   prompt field, and any positive count are all forwarded untouched, so a
+   provider that reports correctly never sees this path and the substitution
+   stops by itself the moment the upstream recovers. Do not widen the predicate
+   into "the number looks wrong".
+2. The estimate errs **high**. Compaction sits below the provider's hard limit
+   (900,000 of 1,048,576 for the affected models, a 14% margin), so an estimate
+   that lands low still lets the turn die, while a high one only compacts
+   sooner. Do not "improve" the ratio toward accuracy without re-checking that
+   margin, and do not add a tokenizer dependency or download for it.
+3. Telemetry keeps what the **provider** said. The usage event records the
+   reported counts verbatim and adds `estimatedInputTokens` beside them; the
+   log line names the substitution. Never fold the estimate into `inputTokens`
+   — a run of estimated turns is the evidence that the provider is still
+   broken, and an overwritten field would read as a recovery.
+4. The response body is otherwise byte-identical, including bytes that are not
+   valid UTF-8: the rewrite path forwards the original buffers and re-encodes
+   only the one `data:` line it replaces, preserving framing and terminators.
+   Do not reintroduce a decoded-text passthrough, which silently rewrites a
+   malformed byte to U+FFFD.
+5. If a provider is ever added that reports prompt tokens *excluding* cache
+   hits, a fully cached turn could report a truthful zero. Substituting there
+   is still right for compaction — cached tokens occupy the context window —
+   but say so in that provider's registry work rather than discovering it from
+   a surprised user.
+6. Regression coverage lives in `test/response-usage.test.mjs` and the
+   `prompt-token estimate` cases in `test/routing.test.mjs`. A change to the
+   predicate, the ratio, or the telemetry needs a test there.
+
 ## Routed subagent regression prevention
 
 - A normal `/responses` smoke test does not cover Codex collaboration. Current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,25 @@
   on the usage event, so an upstream that is being papered over still looks
   flaky in the telemetry instead of healthy.
 
+- **A provider that reports no prompt tokens no longer disables compaction.**
+  Codex decides when to auto-compact from the `input_tokens` each response
+  reports. opencode's Go endpoint stopped reporting them for its DeepSeek V4
+  models, so the context counter never climbed, compaction never fired, and
+  sessions ran until the provider itself refused the turn — one captured turn
+  carried 1,050,034 tokens against a 1,048,576-token limit, with the context
+  bar still showing nearly empty. When a routed response now explicitly claims
+  zero prompt tokens for a request the router just measured as large, the
+  router substitutes an estimate of the prompt it sent, so Codex compacts on
+  time. The estimate errs high on purpose: compaction sits 14% below the hard
+  limit, so an estimate that lands low would let the turn die anyway, while a
+  high one only compacts sooner. Nothing else is touched — a provider that
+  reports correctly, a response with no usage block, and native traffic all
+  pass through byte for byte, and the substitution stops by itself once the
+  upstream starts reporting again. It is never silent: the usage event keeps
+  the provider's own counts and adds `estimatedInputTokens` beside them, and
+  the turn logs `estimated-input-tokens=<count>`, so estimated turns can never
+  be mistaken for the provider having recovered.
+
 - **Windows no longer opens a console window at logon.** The scheduled task ran
   the CMD wrapper through `cmd.exe`, so a console window appeared at every logon
   and stayed for the router's lifetime, reappearing on each watchdog restart.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -192,6 +192,33 @@ curation (conservative defaults otherwise), are skipped automatically if a
 later registry update ships the same model, and are removed by re-running
 the command and deselecting them.
 
+## A session ran past the context window instead of compacting
+
+Codex decides when to auto-compact from the `input_tokens` each response
+reports. A provider that answers a large prompt with `input_tokens: 0` leaves
+that counter flat: the context bar looks nearly empty right up to the point the
+provider itself rejects the turn for exceeding its context length.
+
+The router substitutes an estimate of the prompt it just sent when — and only
+when — a routed response explicitly reports zero prompt tokens for a request
+that plainly carried a large one. The estimate errs high, because compaction
+sits below the provider's hard limit and an estimate that lands too low would
+let the turn die anyway.
+
+Substitutions are recorded rather than hidden. The usage event keeps the
+provider's own numbers and adds `estimatedInputTokens`, and the router logs
+`estimated-input-tokens=<count>` on that turn, so a run of them means the
+provider is still not reporting. Count them in the state directory's
+`usage-events.jsonl`:
+
+```sh
+grep -c estimatedInputTokens "$CODEX_HOME/codex-router/usage-events.jsonl"
+```
+
+Report zero-token responses to the provider; only they can fix the source. To
+see the provider's own numbers in Codex again, set
+`CODEX_ROUTER_ZERO_INPUT_ESTIMATE=0` in the service environment.
+
 ## Native GPT models stopped working
 
 Temporarily return Codex to its native base URL:

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -3,6 +3,33 @@ import { StringDecoder } from "node:string_decoder";
 
 const MAX_JSON_CAPTURE_BYTES = 8 * 1024 * 1024;
 
+// Bytes of forwarded request body per prompt token.
+//
+// The familiar rule is four characters per token, which is roughly where plain
+// English lands. Source code and tool output -- what a Codex session is mostly
+// made of -- tokenize denser, near 3.3, and JSON serialization adds only about
+// 4% on top of the text it carries (measured on a request built from this
+// repository's own files: 369,460 body bytes over 354,429 model-visible
+// characters). Taking the dense figure as the divisor assumes the whole
+// conversation tokenizes like code, which is the assumption that errs high on
+// everything else.
+//
+// The direction is arithmetic, not taste. Compaction fires at 900,000 tokens
+// of a 1,048,576-token window, a margin of 14%, so an estimate more than 14%
+// low still lets the provider reject the turn -- the failure this exists to
+// prevent -- while a high estimate only compacts sooner, which costs context
+// the session can be summarized out of. Against real text this lands between
+// about 1.0x (code-heavy) and 1.3x (prose-heavy) of the true count, so
+// compaction fires somewhere between 690,000 and 900,000 real tokens.
+const ESTIMATE_BYTES_PER_TOKEN = 3.3;
+
+// Below this the substitution could not affect compaction anyway, and leaving
+// small turns alone keeps the router out of responses whose reported numbers
+// barely matter. It is a "do not bother" floor, not the safety property: the
+// safety property is that only an explicit zero is ever replaced, and no
+// tokenizer returns zero for a prompt that serializes to kilobytes.
+const MIN_ESTIMATED_INPUT_TOKENS = 1_000;
+
 function tokenCount(value) {
   const number = Number(value);
   return Number.isFinite(number) && number >= 0 ? Math.round(number) : undefined;
@@ -34,45 +61,161 @@ export function tokenUsageFromPayload(payload) {
   return undefined;
 }
 
+// Estimates the prompt tokens in a request the router has already serialized.
+//
+// Character-count-over-a-ratio is crude, but it is predictable, needs no
+// dependency and no tokenizer download, and it is measured against the exact
+// bytes that went upstream rather than against a model of the conversation.
+// Returns undefined when the request is too small for the estimate to matter,
+// which is also what keeps it away from genuinely small turns.
+export function estimateInputTokens(body, { contextWindow } = {}) {
+  const bytes = Buffer.isBuffer(body)
+    ? body.byteLength
+    : Buffer.byteLength(String(body ?? ""), "utf8");
+  const estimate = Math.ceil(bytes / ESTIMATE_BYTES_PER_TOKEN);
+  if (estimate < MIN_ESTIMATED_INPUT_TOKENS) return undefined;
+  // A request the provider answered cannot have exceeded the window, so the
+  // estimate is never allowed to claim it did.
+  return Number.isInteger(contextWindow) && contextWindow > 0
+    ? Math.min(estimate, contextWindow)
+    : estimate;
+}
+
+// True only when the upstream explicitly said the prompt was empty. A missing
+// key, a null, a string, or any positive count is left alone: the router
+// replaces a value it knows to be false, never one it merely dislikes. `null`
+// in particular means "no count yet", not "no tokens", and `Number(null)` is 0,
+// so the type is checked rather than coerced.
+function reportsZeroPromptTokens(usage) {
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return false;
+  for (const key of ["input_tokens", "prompt_tokens"]) {
+    if (typeof usage[key] === "number" && usage[key] === 0) return true;
+  }
+  return false;
+}
+
+function withEstimatedPromptTokens(usage, estimate) {
+  const outputTokens = tokenCount(usage.output_tokens ?? usage.completion_tokens) || 0;
+  const next = { ...usage, total_tokens: estimate + outputTokens };
+  if ("input_tokens" in usage) next.input_tokens = estimate;
+  if ("prompt_tokens" in usage) next.prompt_tokens = estimate;
+  return next;
+}
+
+// Returns a copy of a payload whose zero prompt count has been replaced by the
+// estimate, or undefined when the payload does not qualify.
+export function substituteZeroInputUsage(payload, estimate) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+  if (!Number.isInteger(estimate) || estimate <= 0) return undefined;
+  if (reportsZeroPromptTokens(payload.usage)) {
+    return { ...payload, usage: withEstimatedPromptTokens(payload.usage, estimate) };
+  }
+  const nested = payload.response;
+  if (
+    nested &&
+    typeof nested === "object" &&
+    !Array.isArray(nested) &&
+    reportsZeroPromptTokens(nested.usage)
+  ) {
+    return {
+      ...payload,
+      response: { ...nested, usage: withEstimatedPromptTokens(nested.usage, estimate) },
+    };
+  }
+  return undefined;
+}
+
+const LINE_FEED = 0x0a;
+
 export class ResponseUsageTransform extends Transform {
   #eventStream;
   #decoder = new StringDecoder("utf8");
   #buffer = "";
   #capturedBytes = 0;
   #usage;
+  #estimate;
+  #substituted;
+  // Rewrite mode holds the raw bytes rather than decoded text: everything the
+  // router is not rewriting has to leave as the exact buffer that arrived, so
+  // a malformed or non-UTF-8 byte can never be replaced on its way through.
+  #pending = Buffer.alloc(0);
+  #released = false;
 
-  constructor(contentType = "") {
+  // `estimatedInputTokens` arrives only on routed requests large enough that a
+  // reported zero cannot be true. Without it this transform observes and
+  // forwards the response byte for byte, exactly as it always did.
+  constructor(contentType = "", { estimatedInputTokens } = {}) {
     super();
     this.#eventStream = String(contentType).toLowerCase().includes("text/event-stream");
+    this.#estimate =
+      Number.isInteger(estimatedInputTokens) && estimatedInputTokens > 0
+        ? estimatedInputTokens
+        : undefined;
   }
 
   _transform(chunk, _encoding, callback) {
-    this.push(chunk);
-    if (this.#eventStream) {
-      this.#buffer += this.#decoder.write(chunk);
-      this.#consumeEventLines();
-    } else if (this.#capturedBytes <= MAX_JSON_CAPTURE_BYTES) {
-      this.#capturedBytes += chunk.length;
-      if (this.#capturedBytes <= MAX_JSON_CAPTURE_BYTES) {
-        this.#buffer += this.#decoder.write(chunk);
-      } else {
-        this.#buffer = "";
-      }
+    if (this.#estimate === undefined) {
+      this.#observeOnly(chunk);
+      callback();
+      return;
     }
+    if (this.#released) {
+      this.push(chunk);
+      callback();
+      return;
+    }
+    this.#pending = this.#pending.length ? Buffer.concat([this.#pending, chunk]) : chunk;
+    if (this.#eventStream) {
+      this.#consumeRewrittenLines();
+      callback();
+      return;
+    }
+    // A non-streaming body has to be held to be rewritten. Oversized ones are
+    // released and forwarded from then on, the way the observer stops
+    // capturing past the same limit.
+    if (this.#pending.length > MAX_JSON_CAPTURE_BYTES) this.#release();
     callback();
   }
 
   _flush(callback) {
-    this.#buffer += this.#decoder.end();
-    if (this.#eventStream) {
-      this.#consumeEventLines(true);
-    } else if (this.#buffer) {
-      try {
-        this.#observe(JSON.parse(this.#buffer));
-      } catch {
-        // The response remains untouched when optional usage parsing fails.
+    if (this.#estimate === undefined) {
+      this.#buffer += this.#decoder.end();
+      if (this.#eventStream) {
+        this.#consumeEventLines(true);
+      } else if (this.#buffer) {
+        try {
+          this.#observe(JSON.parse(this.#buffer));
+        } catch {
+          // The response remains untouched when optional usage parsing fails.
+        }
       }
+      callback();
+      return;
     }
+    if (this.#eventStream) {
+      this.#consumeRewrittenLines(true);
+      callback();
+      return;
+    }
+    const body = this.#pending;
+    this.#pending = Buffer.alloc(0);
+    if (this.#released || !body.length) {
+      if (body.length) this.push(body);
+      callback();
+      return;
+    }
+    let payload;
+    try {
+      payload = JSON.parse(body.toString("utf8"));
+    } catch {
+      this.push(body);
+      callback();
+      return;
+    }
+    this.#observe(payload);
+    const substituted = substituteZeroInputUsage(payload, this.#estimate);
+    this.#substituted = substituted ? this.#estimate : undefined;
+    this.push(substituted ? Buffer.from(JSON.stringify(substituted), "utf8") : body);
     callback();
   }
 
@@ -80,18 +223,90 @@ export class ResponseUsageTransform extends Transform {
     return this.#usage;
   }
 
+  // The estimate written into the response, or undefined when the upstream
+  // reported its own prompt count. Never folded into `tokenUsage()`: what the
+  // provider said and what the router substituted stay separate all the way
+  // into the usage event.
+  substitutedInputTokens() {
+    return this.#substituted;
+  }
+
+  #observeOnly(chunk) {
+    this.push(chunk);
+    if (this.#eventStream) {
+      this.#buffer += this.#decoder.write(chunk);
+      this.#consumeEventLines();
+      return;
+    }
+    if (this.#capturedBytes > MAX_JSON_CAPTURE_BYTES) return;
+    this.#capturedBytes += chunk.length;
+    if (this.#capturedBytes <= MAX_JSON_CAPTURE_BYTES) {
+      this.#buffer += this.#decoder.write(chunk);
+    } else {
+      this.#buffer = "";
+    }
+  }
+
+  #release() {
+    this.#released = true;
+    if (this.#pending.length) this.push(this.#pending);
+    this.#pending = Buffer.alloc(0);
+  }
+
   #consumeEventLines(flush = false) {
     const lines = this.#buffer.split(/\r?\n/);
     this.#buffer = flush ? "" : lines.pop() || "";
-    for (const line of lines) {
-      if (!line.startsWith("data:")) continue;
-      const data = line.slice(5).trim();
-      if (!data || data === "[DONE]") continue;
-      try {
-        this.#observe(JSON.parse(data));
-      } catch {
-        // Ignore non-JSON SSE fields while preserving the original stream.
-      }
+    for (const line of lines) this.#observeEventLine(line);
+  }
+
+  // Each complete line is forwarded as soon as it is whole, carrying its own
+  // terminator, so framing survives byte for byte and nothing is buffered
+  // beyond the line currently being written.
+  #consumeRewrittenLines(flush = false) {
+    while (true) {
+      const index = this.#pending.indexOf(LINE_FEED);
+      if (index === -1) break;
+      const line = this.#pending.subarray(0, index + 1);
+      this.#pending = this.#pending.subarray(index + 1);
+      this.push(this.#rewriteEventLine(line) || line);
+    }
+    if (flush && this.#pending.length) {
+      const line = this.#pending;
+      this.#pending = Buffer.alloc(0);
+      this.push(this.#rewriteEventLine(line) || line);
+    }
+  }
+
+  // Returns the replacement line, or undefined to forward the original bytes.
+  #rewriteEventLine(line) {
+    const text = line.toString("utf8");
+    const terminator = text.endsWith("\r\n") ? "\r\n" : text.endsWith("\n") ? "\n" : "";
+    const content = terminator ? text.slice(0, -terminator.length) : text;
+    const payload = this.#observeEventLine(content);
+    if (payload === undefined) return undefined;
+    const substituted = substituteZeroInputUsage(payload, this.#estimate);
+    if (substituted) {
+      this.#substituted = this.#estimate;
+      return Buffer.from(`data: ${JSON.stringify(substituted)}${terminator}`, "utf8");
+    }
+    // Codex reads the last usage it is given, so a later event that reports its
+    // own prompt count supersedes an earlier substituted one -- in telemetry as
+    // well as in the stream.
+    if (tokenUsageFromPayload(payload)) this.#substituted = undefined;
+    return undefined;
+  }
+
+  #observeEventLine(line) {
+    if (!line.startsWith("data:")) return undefined;
+    const data = line.slice(5).trim();
+    if (!data || data === "[DONE]") return undefined;
+    try {
+      const payload = JSON.parse(data);
+      this.#observe(payload);
+      return payload;
+    } catch {
+      // Ignore non-JSON SSE fields while preserving the original stream.
+      return undefined;
     }
   }
 

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -37,7 +37,11 @@ import {
   readProviderSelection,
   selectedConfiguredListedModels,
 } from "./provider-selection.mjs";
-import { ResponseUsageTransform, tokenUsageFromPayload } from "./response-usage.mjs";
+import {
+  estimateInputTokens,
+  ResponseUsageTransform,
+  tokenUsageFromPayload,
+} from "./response-usage.mjs";
 import { fetchWithRetry } from "./upstream-retry.mjs";
 import {
   CollaborationToolCallTransform,
@@ -91,6 +95,11 @@ const INTERNAL_KEY =
 const CALLER_KEY = process.env.CODEX_ROUTER_CALLER_KEY;
 const QUIET =
   process.env.CODEX_ROUTER_QUIET === "1" || process.env.KIMI_PROXY_QUIET === "1";
+// Kill switch for the zero-prompt-token substitution (#95). It is on because a
+// provider that reports no prompt tokens breaks compaction outright, but an
+// operator who would rather see the provider's own numbers can turn it off
+// without downgrading the router.
+const ZERO_INPUT_ESTIMATE = process.env.CODEX_ROUTER_ZERO_INPUT_ESTIMATE !== "0";
 const ERROR_STATUS_DURATION_MS = 8_000;
 const configuredDecodedBodyBytes = Number(
   process.env.MODEL_ROUTER_MAX_DECODED_BODY_BYTES ||
@@ -1303,8 +1312,23 @@ async function handleResponses(request, response, requestUrl) {
     }
     // Native OpenAI responses carry the same `usage` shape as routed ones, so
     // meter both paths; without this, native traffic reports zero tokens.
+    //
+    // A routed provider that answers a large prompt with `input_tokens: 0` is
+    // reporting something that cannot be true, and Codex reads exactly that
+    // number to decide when to compact -- opencode's Go endpoint did it for a
+    // whole model family and sessions ran past the context window and died
+    // (#95). The estimate below is offered only for those responses; the
+    // predicate is structural (this request, these bytes, an explicit zero),
+    // so it cannot fire on a provider that reports correctly and it disables
+    // itself the moment the upstream starts reporting again.
     const usageTransform = new ResponseUsageTransform(
       upstream.headers.get("content-type") || "",
+      {
+        estimatedInputTokens:
+          ZERO_INPUT_ESTIMATE && route
+            ? estimateInputTokens(routedBody, { contextWindow: route.contextWindow })
+            : undefined,
+      },
     );
     const transforms = [usageTransform];
     if (collaborationFlattened) {
@@ -1312,8 +1336,11 @@ async function handleResponses(request, response, requestUrl) {
     }
     await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS, transforms);
     const usage = usageTransform?.tokenUsage();
-    // `retries` is what separates "it never failed" from "it failed and the
-    // router absorbed it", both of which otherwise record a plain 200.
+    const estimatedInputTokens = usageTransform?.substitutedInputTokens();
+    // `retries` separates "it never failed" from "it failed and the router
+    // absorbed it", both of which otherwise record a plain 200;
+    // `estimatedInputTokens` separates a count the provider sent from one the
+    // router had to invent. Neither is inferable from the rest of the event.
     recordUsageEvent({
       model: route?.slug || requestedModel,
       provider: route ? canonicalProviderId(route.provider) : "openai",
@@ -1321,10 +1348,15 @@ async function handleResponses(request, response, requestUrl) {
       durationMs: Date.now() - startedAt,
       retries: upstreamRetries,
       ...usage,
+      estimatedInputTokens,
     });
     if (!QUIET) {
+      // The substitution is named in the log line as well as the usage event:
+      // a router that quietly invents token counts is its own trap.
       console.error(
-        `[codex-router] model=${requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${upstream.status}${upstreamRetries ? ` retries=${upstreamRetries}` : ""}`,
+        `[codex-router] model=${requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${upstream.status}${
+          upstreamRetries ? ` retries=${upstreamRetries}` : ""
+        }${estimatedInputTokens ? ` estimated-input-tokens=${estimatedInputTokens}` : ""}`,
       );
     }
   } catch (error) {

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -34,6 +34,12 @@ export function recordUsageEvent({
   outputTokens,
   totalTokens,
   retries,
+  // Present only when the router replaced an upstream `input_tokens: 0` with
+  // its own estimate on the way to Codex (#95). The reported counts above stay
+  // exactly as the provider sent them, so an estimated turn is never mistaken
+  // for the provider having recovered -- and a run of these events is the
+  // signal that it has not.
+  estimatedInputTokens,
   at = Date.now(),
 }) {
   const event = {
@@ -52,6 +58,9 @@ export function recordUsageEvent({
       : {}),
     ...(safeTokenCount(totalTokens) !== undefined
       ? { totalTokens: safeTokenCount(totalTokens) }
+      : {}),
+    ...(safeTokenCount(estimatedInputTokens) !== undefined
+      ? { estimatedInputTokens: safeTokenCount(estimatedInputTokens) }
       : {}),
   };
   try {
@@ -94,6 +103,7 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
         const outputTokens = safeTokenCount(event.outputTokens);
         const totalTokens = safeTokenCount(event.totalTokens);
         const retries = safeRetryCount(event.retries);
+        const estimatedInputTokens = safeTokenCount(event.estimatedInputTokens);
         return {
           ...(event.meteringVersion === 1 ? { meteringVersion: 1 } : {}),
           at: event.at,
@@ -110,6 +120,7 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
           ...(inputTokens !== undefined ? { inputTokens } : {}),
           ...(outputTokens !== undefined ? { outputTokens } : {}),
           ...(totalTokens !== undefined ? { totalTokens } : {}),
+          ...(estimatedInputTokens !== undefined ? { estimatedInputTokens } : {}),
         };
       });
   } catch {

--- a/test/response-usage.test.mjs
+++ b/test/response-usage.test.mjs
@@ -2,8 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  estimateInputTokens,
   normalizeTokenUsage,
   ResponseUsageTransform,
+  substituteZeroInputUsage,
   tokenUsageFromPayload,
 } from "../src/response-usage.mjs";
 
@@ -74,4 +76,212 @@ test("parses usage when UTF-8 text is split across response chunks", async () =>
     outputTokens: 3,
     totalTokens: 10,
   });
+});
+
+// Issue #95: opencode's Go endpoint stopped reporting prompt tokens for its
+// DeepSeek V4 models, so Codex's context counter never climbed, auto-compaction
+// never fired, and the turn died at the provider's real 1,048,576-token limit.
+// The router substitutes an estimate only where the upstream is plainly wrong.
+const DEEPSEEK_CONTEXT_WINDOW = 1_048_576;
+const DEEPSEEK_AUTO_COMPACT = 900_000;
+
+function completedEvent(usage) {
+  return `event: response.completed\ndata: ${JSON.stringify({
+    type: "response.completed",
+    response: { id: "resp_test", usage },
+  })}\n\n`;
+}
+
+test("the prompt-token estimate errs high rather than low", () => {
+  // The two errors are not symmetric. Compaction fires at 900,000 of a
+  // 1,048,576-token window, so an estimate more than ~14% low still lets the
+  // provider reject the turn -- the exact failure this exists to prevent --
+  // while a high estimate only compacts sooner. Four bytes per token is the
+  // most generous density real conversation text reaches, so an estimate at
+  // least that large never lands under the true count.
+  const body = Buffer.alloc(64_000, "a");
+  assert.ok(estimateInputTokens(body) >= Math.ceil(body.byteLength / 4));
+
+  // A conversation sitting at the hard limit serializes to at least four bytes
+  // per token; the estimate has to cross the compaction threshold there.
+  const atTheLimit = Buffer.alloc(DEEPSEEK_CONTEXT_WINDOW * 4, "a");
+  const estimate = estimateInputTokens(atTheLimit, {
+    contextWindow: DEEPSEEK_CONTEXT_WINDOW,
+  });
+  assert.ok(estimate > DEEPSEEK_AUTO_COMPACT);
+  // A request the provider accepted cannot have exceeded the window, so the
+  // estimate is never allowed to claim it did.
+  assert.equal(estimate, DEEPSEEK_CONTEXT_WINDOW);
+});
+
+test("a request too small to matter produces no estimate at all", () => {
+  assert.equal(estimateInputTokens(Buffer.alloc(200, "a")), undefined);
+  assert.equal(estimateInputTokens(Buffer.alloc(3_000, "a")), undefined);
+  assert.ok(estimateInputTokens(Buffer.alloc(40_000, "a")) > 0);
+});
+
+test("only an explicit zero prompt count is substituted", () => {
+  const estimate = 4_242;
+  const zero = substituteZeroInputUsage(
+    { response: { usage: { input_tokens: 0, output_tokens: 8, total_tokens: 8 } } },
+    estimate,
+  );
+  assert.deepEqual(zero.response.usage, {
+    input_tokens: estimate,
+    output_tokens: 8,
+    total_tokens: estimate + 8,
+  });
+  assert.deepEqual(
+    substituteZeroInputUsage({ usage: { prompt_tokens: 0, completion_tokens: 3 } }, estimate)
+      .usage,
+    { prompt_tokens: estimate, completion_tokens: 3, total_tokens: estimate + 3 },
+  );
+
+  // A correctly reported count, a response carrying no usage at all, and a
+  // usage block that never mentions the prompt are all left alone: the router
+  // replaces a value it knows to be false, never one it merely dislikes.
+  assert.equal(
+    substituteZeroInputUsage(
+      { response: { usage: { input_tokens: 17, output_tokens: 8 } } },
+      estimate,
+    ),
+    undefined,
+  );
+  assert.equal(substituteZeroInputUsage({ response: { id: "resp" } }, estimate), undefined);
+  assert.equal(substituteZeroInputUsage({ usage: { output_tokens: 8 } }, estimate), undefined);
+  // `null` means "no count yet", not "no tokens" -- and `Number(null)` is 0, so
+  // a coercing predicate would have fabricated a number here.
+  assert.equal(
+    substituteZeroInputUsage({ usage: { input_tokens: null, output_tokens: 8 } }, estimate),
+    undefined,
+  );
+  assert.equal(
+    substituteZeroInputUsage({ usage: { input_tokens: 0, output_tokens: 8 } }, undefined),
+    undefined,
+  );
+});
+
+test("a zero-prompt SSE response is rewritten with the estimate", async () => {
+  const estimate = 512_000;
+  const body = [
+    "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+    completedEvent({ input_tokens: 0, output_tokens: 12, total_tokens: 12 }),
+    "data: [DONE]\n\n",
+  ];
+  const transform = new ResponseUsageTransform("text/event-stream; charset=utf-8", {
+    estimatedInputTokens: estimate,
+  });
+  const streamed = await passThrough(transform, body);
+  const completed = JSON.parse(
+    streamed
+      .split("\n")
+      .find((line) => line.includes("response.completed") && line.startsWith("data:"))
+      .slice(5),
+  );
+  assert.equal(completed.response.usage.input_tokens, estimate);
+  assert.equal(completed.response.usage.total_tokens, estimate + 12);
+  // Every byte outside the rewritten event -- the delta, the framing, the
+  // terminator -- is forwarded exactly as the provider wrote it.
+  assert.ok(streamed.startsWith(body[0]));
+  assert.ok(streamed.endsWith(`\n\n${body[2]}`));
+  assert.equal(transform.substitutedInputTokens(), estimate);
+  // Telemetry keeps what the provider actually said, so a substitution can
+  // never be mistaken for the provider having recovered.
+  assert.deepEqual(transform.tokenUsage(), {
+    inputTokens: 0,
+    outputTokens: 12,
+    totalTokens: 12,
+  });
+});
+
+test("a correctly reported response is never rewritten", async () => {
+  const body = [
+    completedEvent({ input_tokens: 21, output_tokens: 8, total_tokens: 29 }),
+    "data: [DONE]\n\n",
+  ];
+  const transform = new ResponseUsageTransform("text/event-stream", {
+    estimatedInputTokens: 512_000,
+  });
+  assert.equal(await passThrough(transform, body), body.join(""));
+  assert.equal(transform.substitutedInputTokens(), undefined);
+  assert.deepEqual(transform.tokenUsage(), {
+    inputTokens: 21,
+    outputTokens: 8,
+    totalTokens: 29,
+  });
+});
+
+test("a response with no estimate behind it is forwarded untouched", async () => {
+  const body = [
+    completedEvent({ input_tokens: 0, output_tokens: 12, total_tokens: 12 }),
+    "data: [DONE]\n\n",
+  ];
+  const transform = new ResponseUsageTransform("text/event-stream");
+  assert.equal(await passThrough(transform, body), body.join(""));
+  assert.equal(transform.substitutedInputTokens(), undefined);
+});
+
+test("bytes the router is not rewriting survive rewrite mode exactly", async () => {
+  // Only the one substituted line is re-encoded. Everything else -- including a
+  // byte sequence that is not valid UTF-8 at all -- has to leave as it arrived,
+  // or a decoder would quietly replace it with U+FFFD.
+  const malformed = Buffer.from([0x64, 0x61, 0x74, 0x61, 0x3a, 0x20, 0xff, 0xfe, 0x0a, 0x0a]);
+  const chunks = [
+    malformed,
+    Buffer.from(completedEvent({ input_tokens: 0, output_tokens: 4, total_tokens: 4 }), "utf8"),
+    Buffer.from("data: [DONE]\n\n", "utf8"),
+  ];
+  const transform = new ResponseUsageTransform("text/event-stream", {
+    estimatedInputTokens: 7_000,
+  });
+  const output = [];
+  transform.on("data", (chunk) => output.push(chunk));
+  for (const chunk of chunks) transform.write(chunk);
+  transform.end();
+  await new Promise((resolve, reject) => {
+    transform.once("finish", resolve);
+    transform.once("error", reject);
+  });
+  const streamed = Buffer.concat(output);
+  assert.deepEqual(streamed.subarray(0, malformed.length), malformed);
+  assert.deepEqual(streamed.subarray(streamed.length - 14), chunks[2]);
+  assert.equal(transform.substitutedInputTokens(), 7_000);
+});
+
+test("a later reported count supersedes an earlier substituted one", async () => {
+  // Codex reads the last usage it is given, so telemetry must not keep claiming
+  // a substitution the client never ended up using.
+  const body = [
+    completedEvent({ input_tokens: 0, output_tokens: 4, total_tokens: 4 }),
+    completedEvent({ input_tokens: 5_000, output_tokens: 9, total_tokens: 5_009 }),
+    "data: [DONE]\n\n",
+  ];
+  const transform = new ResponseUsageTransform("text/event-stream", {
+    estimatedInputTokens: 7_000,
+  });
+  await passThrough(transform, body);
+  assert.equal(transform.substitutedInputTokens(), undefined);
+  assert.deepEqual(transform.tokenUsage(), {
+    inputTokens: 5_000,
+    outputTokens: 9,
+    totalTokens: 5_009,
+  });
+});
+
+test("a zero-prompt JSON response is rewritten with the estimate", async () => {
+  const body = JSON.stringify({
+    id: "response-test",
+    usage: { input_tokens: 0, output_tokens: 11, total_tokens: 11 },
+  });
+  const transform = new ResponseUsageTransform("application/json", {
+    estimatedInputTokens: 99_000,
+  });
+  const rewritten = JSON.parse(await passThrough(transform, [body]));
+  assert.deepEqual(rewritten.usage, {
+    input_tokens: 99_000,
+    output_tokens: 11,
+    total_tokens: 99_011,
+  });
+  assert.equal(rewritten.id, "response-test");
+  assert.equal(transform.substitutedInputTokens(), 99_000);
 });

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3195,3 +3195,164 @@ test("routed compaction resolves subagent handoffs before summarizing", async ()
     await Promise.all([closeServer(native.server), closeServer(gateway.server)]);
   }
 });
+
+// Issue #95: opencode's Go endpoint reports `input_tokens: 0` for its DeepSeek
+// V4 models, so Codex's context counter never climbs, auto-compaction never
+// fires, and the provider eventually rejects the turn at its real limit. Codex
+// reads that number out of `response.completed`, so a router that only logged
+// the problem would not fix it -- the substituted count has to reach the client.
+test("router substitutes a prompt-token estimate a provider reported as zero", async () => {
+  let reportedInputTokens = 0;
+  const gatewayBodies = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayBodies.push(await bodyJson(request));
+    const completed = {
+      type: "response.completed",
+      response: {
+        id: "resp_routed",
+        usage: {
+          input_tokens: reportedInputTokens,
+          output_tokens: 12,
+          total_tokens: reportedInputTokens + 12,
+        },
+      },
+    };
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(
+      `event: response.completed\ndata: ${JSON.stringify(completed)}\n\ndata: [DONE]\n\n`,
+    );
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "routing-zero-input-"));
+  const routerPort = await openPort();
+  // QUIET stays off: the log line is part of what makes a substitution visible.
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  });
+  const headers = {
+    Authorization: "Bearer CODEX_CALLER_SECRET",
+    "Content-Type": "application/json",
+  };
+  const conversation = "the quick brown fox jumps over the lazy dog. ".repeat(1_000);
+  const body = JSON.stringify({
+    model: "opencode-go/deepseek-v4-flash",
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: conversation }] },
+    ],
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    const zero = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    assert.equal(zero.status, 200);
+    const streamed = await zero.text();
+    const completed = JSON.parse(
+      streamed
+        .split("\n")
+        .find((line) => line.startsWith("data:") && line.includes("response.completed"))
+        .slice(5),
+    );
+    // What Codex now reads is an estimate of the prompt it actually sent,
+    // erring high: never below the familiar four-bytes-per-token figure, and
+    // never above the densest plausible three.
+    const estimate = completed.response.usage.input_tokens;
+    assert.ok(estimate >= Math.ceil(conversation.length / 4), `estimate ${estimate} too low`);
+    assert.ok(estimate <= Math.ceil((conversation.length + 2_000) / 3), `estimate ${estimate} too high`);
+    assert.equal(completed.response.usage.total_tokens, estimate + 12);
+
+    const [substituted] = await waitForUsageEvents(stateDir, 1, router);
+    assert.equal(substituted.model, "opencode-go/deepseek-v4-flash");
+    // The telemetry keeps the provider's own zero and records the estimate
+    // beside it, so nothing here can be mistaken for the provider recovering.
+    assert.equal(substituted.inputTokens, 0);
+    assert.equal(substituted.outputTokens, 12);
+    assert.equal(substituted.estimatedInputTokens, estimate);
+    await waitForStderr(router, new RegExp(`estimated-input-tokens=${estimate}\\b`));
+
+    // A provider that reports correctly is left alone on the very same route.
+    reportedInputTokens = 4_321;
+    const reported = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    assert.equal(reported.status, 200);
+    assert.match(await reported.text(), /"input_tokens":4321/);
+    const events = await waitForUsageEvents(stateDir, 2, router);
+    const honest = events.at(-1);
+    assert.equal(honest.inputTokens, 4_321);
+    assert.equal("estimatedInputTokens" in honest, false);
+    assert.equal(router.testErrors().match(/estimated-input-tokens=/g).length, 1);
+    assert.equal(gatewayBodies.length, 2);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// Inventing token counts is a heuristic, however tightly gated, so an operator
+// has to be able to see the provider's own numbers again without downgrading.
+test("the prompt-token estimate can be switched off", async () => {
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    const completed = {
+      type: "response.completed",
+      response: {
+        id: "resp_routed",
+        usage: { input_tokens: 0, output_tokens: 12, total_tokens: 12 },
+      },
+    };
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(
+      `event: response.completed\ndata: ${JSON.stringify(completed)}\n\ndata: [DONE]\n\n`,
+    );
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "routing-zero-input-off-"));
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_ZERO_INPUT_ESTIMATE: "0",
+    CODEX_ROUTER_QUIET: "1",
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "opencode-go/deepseek-v4-flash",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [
+              { type: "input_text", text: "the quick brown fox. ".repeat(2_000) },
+            ],
+          },
+        ],
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.match(await response.text(), /"input_tokens":0/);
+    const [event] = await waitForUsageEvents(stateDir, 1, router);
+    assert.equal(event.inputTokens, 0);
+    assert.equal("estimatedInputTokens" in event, false);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Stops the sessions in #95 from dying, without pretending to fix opencode's endpoint.

## Why I deferred this, and why that was wrong

I originally called this "too heuristic" and left it, on the reasoning that under-estimating is the safe direction because it degrades to today's behaviour. **That reasoning does not survive the arithmetic.**

Compaction fires at 900,000 of a 1,048,576-token window — a margin of **14%**. With `r = estimate / true`, compaction triggers at `900,000 / r` true tokens, so any `r < 0.858` fires it when the true prompt is *already past the provider's hard limit*. The session still dies. Erring low is not a safe fallback; it is the failure mode.

So the real choice is bounded, recoverable premature compaction versus an unrecoverable failure. That asymmetry is what justifies shipping.

## Why this is not papering over a provider bug

The router is not overriding a number it dislikes. It replaces one that is **provably false**: an explicit `input_tokens: 0` for a request the router itself just serialized and measured at tens or hundreds of kilobytes. No tokenizer returns zero for that.

## The predicate — three conditions, all necessary

Substitution happens only when:

1. The turn is **routed** — native OpenAI traffic never gets an estimate.
2. The router measured the body it forwarded and the estimate clears a floor.
3. The response carries a usage object whose `input_tokens`/`prompt_tokens` is an **explicit numeric zero**.

A missing usage block, a missing key, a `null`, or any positive count is forwarded untouched.

**The `null` case is the subtle one.** `Number(null) === 0`, so a coercing check would have fabricated counts for a provider signalling "no count yet". The predicate checks the type. That was one of two HIGH defects a review pass found in the first implementation.

On a genuinely zero-input request the predicate cannot fire: a Codex `/responses` turn always carries instructions, a tool list, and at least one input item. The floor is a "don't bother" threshold, not the safety property.

## Scope, and why not a provider allowlist

Every routed model, gated on what was actually sent. A per-provider flag would need a registry change each time another endpoint regresses, and would linger after opencode fixes theirs. The structural predicate cannot fire on a provider reporting correctly, and it **self-disables the moment the upstream starts reporting again** — asserted end to end, where the same route stops substituting as soon as the mock reports a real count.

One caveat is documented in AGENTS.md: a provider that reports prompt tokens *excluding* cache hits could truthfully report zero on a fully cached turn. Substituting is still correct there (cached tokens occupy the window), but it needs calling out in that provider's registry work.

## Visibility — the estimate never overwrites what the provider said

`inputTokens`/`outputTokens`/`totalTokens` stay verbatim as reported (still `0`); a separate `estimatedInputTokens` field is added, and the turn logs `estimated-input-tokens=<n>`.

So the diagnostic in my #95 comment still tells the truth about the provider, and a run of `estimatedInputTokens` events becomes a *better* "is opencode still broken?" signal than counting zeros. `CODEX_ROUTER_ZERO_INPUT_ESTIMATE=0` disables it.

## Estimation

Forwarded body bytes ÷ 3.3, floored at 1,000 tokens, clamped to the model's context window. No dependency, no tokenizer download, and it measures the exact bytes that went upstream.

JSON-serialization overhead was measured on a realistic request built from this repo's own files: 369,460 body bytes over 354,429 model-visible characters — **1.042×**, well below the ~1.15 assumed. Picking 3.3 (the density of code and tool output, which is what these sessions mostly are) puts the estimate at ~1.0× on code-heavy content and 1.25–1.35× on prose, so compaction fires between ~690k and ~900k real tokens — always above the 0.858 danger boundary, with margin even for pathological base64-dense content (~0.91).

Errors do not accumulate: Codex resends the whole conversation each turn, so every substitution is an independent absolute estimate, not a running sum.

Not measured against a real BPE tokenizer — that needs a download — and the source comment states the ranges it assumes.

## Review pass

A reviewer subagent found two HIGH defects in the first implementation, both fixed with tests:

- **Byte corruption.** The rewrite path decoded chunks through `StringDecoder` and re-encoded them, so any non-UTF-8 byte anywhere in a routed response became U+FFFD — contradicting the byte-identical claim. It now holds raw Buffers and re-encodes only the single `data:` line it replaces.
- **`null` coerced to zero**, as above.

It also flagged that a sticky substitution flag could survive a later correctly-reported event; the flag is now superseded by any later usage-carrying event.

## Tests

567 tests, 561 pass, 0 fail (+11).

RED end-to-end with the source stashed: `error: 'estimate 0 too low'` — which *is* the bug; Codex received `input_tokens: 0`. RED unit: the export does not exist. GREEN after.

Coverage: direction of error, the floor, the predicate across explicit-zero / correct-count / absent-usage / absent-key / `null` / no-estimate, SSE and JSON substitution, byte preservation including non-UTF-8, superseding, and the kill switch.

## Out of scope

The routed compaction path does not substitute — it builds its own short prompt and writes an SSE snapshot with `usage: null`, so an estimate there would only add telemetry noise.

The underlying bug is still opencode's. `docs/TROUBLESHOOTING.md` gains a section telling affected users to report the zero-token responses upstream.
