### PR TITLE
feat(vision): read a pasted image with no configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,14 +310,36 @@ request path sends each image part to a vision-capable model the operator has
 already enabled and credentialed, and substitutes the returned transcript into
 the turn as text. Treat it as a router capability, never as a model capability.
 
-1. It is opt-in per install (`bin/control vision-bridge on`, protected state in
-   `vision-bridge.json`). The installer auto-enables it once, and only when it
-   is still unconfigured and the operator already enabled a vision-capable
-   provider — that reuses a model they already pay for, so no download and no
-   surprise. When no such provider exists it stays off and the summary points
-   at `vision-bridge setup`. `visionBridgeConfigured()` gates this so
-   re-running the installer never overrides an explicit off. Never auto-enable
-   in any other path; a routed image spends the engine provider's quota.
+1. It is **on by default** and off only when the operator says so
+   (`bin/control vision-bridge off`, protected state in `vision-bridge.json`).
+   Reading a pasted screenshot is the one thing people expect to work without
+   finding a toggle, and everything it needs is already installed: an install
+   with nothing to read images with resolves no engine and degrades exactly as
+   it did before the bridge existed, so the default costs an unequipped machine
+   nothing.
+   - The line between "never configured" and "configured off" is **structural,
+     not a sentinel**: no state file means nobody has answered and the current
+     default applies; a readable file's `enabled` is the operator's own answer
+     and is taken verbatim forever. A stored `false` must never be re-enabled by
+     a change of default. A file that exists but this build cannot parse falls
+     back to **off**, not to the default — somebody was here and we cannot tell
+     what they chose, so it must not start spending quota.
+   - `version` stays `1` on purpose. A bump would have to guess what an older
+     `false` meant, and there is nothing to guess with; file presence already
+     answers it, and `visionBridgeConfigured()` has gated exactly that
+     distinction since the bridge shipped. Do not add a migration that replaces
+     that fact with an inference.
+   - The installer writes no bridge state at all. It used to auto-enable once
+     when a vision-capable provider happened to be selected, which made the
+     file's presence mean "the installer ran" and left every other install
+     needing a command nobody knew about. It now only reports. Never write
+     bridge state from an install or update path; a routed image spends the
+     engine provider's quota, so the only writers are the operator's own
+     commands.
+   - Because it is on by default, a surface that would nag an unconfigured
+     install checks `visionBridgeConfigured()` first. `doctor` warns about "no
+     resolvable engine" only for an operator who actually asked; for a
+     default-on install it reports `ok`, since nothing was lost.
 2. The registry keeps declaring what each model itself reads. `inputModalities`
    is never edited to add `image` for a bridge, and `visionBridge` accepts only
    `false`, as a per-model opt-out. The registry loader rejects `true` so the
@@ -345,7 +367,15 @@ the turn as text. Treat it as a router capability, never as a model capability.
    lives outside the registry, so the request path calls its
    `/v1/chat/completions` endpoint directly with no credential, and it is used
    only when explicitly pinned — auto mode never routes images to `localhost`,
-   since an unreachable server would fail every paste. This is what lets a
+   since an unreachable server would fail every paste. The rule is about the
+   address, not about that one engine: a **keyless registry provider** (`local`,
+   and the loader guarantees keyless means a loopback `baseUrl`) is the same
+   hazard wearing a registry slug, so `resolveVisionEngine` excludes every
+   loopback-served candidate from auto and admits it only by explicit pin. It
+   stays listed in the picker, because choosing it carries the knowledge that
+   the server has to be up. Auto mode is the only default an unattended machine
+   gets, so it may only nominate an engine that is reachable without the
+   operator having started something. This is what lets a
    text-only-only install enable the bridge with no paid vision model. The
    `vision-bridge setup` command and probe target Ollama for auto-download
    because it is a managed daemon with a stable model registry — the only
@@ -394,12 +424,18 @@ the turn as text. Treat it as a router capability, never as a model capability.
      vision key, or an external dependency goes through the gateway or does not
      ship.
 
-   Known gap: plan quota spent this way is **not** surfaced in usage or limits,
-   so a transcribed screenshot bills the operator's ChatGPT plan invisibly. That
-   is the one thing "Ship a new provider to every installer" requires of
-   everyone else that this path does not yet do. It is being closed separately.
-   Do not read it as settled, do not weaken this section to accommodate it, and
-   do not extend the exception to another engine while it is still open.
+   Known gap: **plan quota and limits** spent this way are still not surfaced.
+   Every bridged read now records a usage event through the shared pipeline
+   (model, provider, status, duration — no token counts, because the request
+   path receives the transcript rather than the envelope) and logs one
+   never-quieted line, so the operator can tell a vision call happened and
+   against what. What is still missing is the other half of what "Ship a new
+   provider to every installer" requires of everyone else: the ChatGPT plan's
+   remaining quota does not move in the tray when a screenshot is transcribed,
+   and no surface renders routed usage events at all. It is being closed
+   separately. Do not read it as settled, do not weaken this section to
+   accommodate it, and do not extend the exception to another engine while it is
+   still open.
 6. Substituted transcripts are untrusted user data. Keep them fenced and
    labelled as quoted image content, never log a transcript or a gateway error
    body, and keep the per-image failure path degrading to a stated failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+- **A text-only model reads a pasted image with no configuration.** The vision
+  bridge is now on by default: paste a screenshot into DeepSeek, GLM, or Kimi
+  and it is transcribed by the cheapest vision-capable model you have already
+  enabled — or by your signed-in ChatGPT plan — instead of silently doing
+  nothing until you discovered a toggle. An install with nothing to read images
+  with behaves exactly as it did before: no engine resolves, the picker keeps
+  saying text-only, and Codex keeps refusing the paste.
+
+  Turning it off is permanent. The state file's *presence* is what separates
+  "never configured" from "configured off", so a stored `enabled: false` is
+  never re-enabled by this change or any future one, and a state file this
+  build cannot parse falls back to off rather than to the new default. The
+  installer no longer writes bridge state at all; it only reports what will
+  happen.
+
+  Two things it will not do on its own. It never picks an engine served from
+  your own machine — the pinned `local` engine, or a model from the keyless
+  `local` provider — because your runtime may not be running and that would
+  fail every paste; pin one and it is used gladly. And it no longer spends
+  quota invisibly: every read that misses the transcript cache records a usage
+  event naming the engine it was billed to, and the per-turn log line is no
+  longer suppressed on an unattended service. A ChatGPT-plan engine's quota is
+  still not reflected in the tray's limits.
+
 - **A curated model can say it refuses a forced tool choice.** A few upstreams
   call tools happily when `tool_choice` is `"auto"` and answer HTTP 400 when
   one is required, so the compatibility check reported no tool support and the

--- a/README.md
+++ b/README.md
@@ -574,17 +574,23 @@ The vision bridge fixes that at the router: it sends the pasted image to a
 vision-capable model you have **already enabled**, and substitutes the reply
 into the turn as text before the text-only model ever sees it.
 
+It is **on by default** — paste a screenshot and it is read, with nothing to
+configure. If nothing on your machine can read images, nothing changes: the
+picker keeps saying text-only, exactly as before.
+
 ```sh
-./bin/control vision-bridge on
 ./bin/control vision-bridge status
+./bin/control vision-bridge off     # never spend an engine's quota on a paste
 ```
 
-Then fully quit Codex and reopen it, so the picker picks up the rebuilt catalog.
+Turning it off is remembered permanently; an update never turns it back on.
 
-The engine is chosen automatically from your enabled, credentialed models,
-cheapest tier first (a Flash or Haiku class model beats a flagship for reading a
-screenshot, at a fraction of the cost). Pin a specific one, or hand the choice
-back:
+The engine is chosen automatically from your enabled, credentialed models and
+your signed-in ChatGPT plan, cheapest tier first (a Flash or Haiku class model
+beats a flagship for reading a screenshot, at a fraction of the cost). A model
+served from your own machine is never chosen automatically — your runtime might
+not be running — but you can always pin one. Pin a specific engine, or hand the
+choice back:
 
 ```sh
 ./bin/control vision-bridge engine qwen-plan/qwen3.6-flash
@@ -613,6 +619,10 @@ Notes worth knowing:
 - **It advertises only what it can deliver.** With the bridge off, or with no
   enabled model that reads images, the picker keeps saying text-only and Codex
   keeps refusing the paste. `doctor` reports the engine in use.
+- **You can see what it spent.** Every read that is not served from the cache
+  is written to `usage-events.jsonl` with the engine it was billed to, and the
+  router logs one line per bridged turn. Plan quota for a ChatGPT-plan engine
+  is still not reflected in the tray's limits — see `AGENTS.md`.
 
 The evidence contract is modelled on
 [ModLens](https://github.com/liustack/modlens), which solves the same problem

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -34,7 +34,10 @@ import {
   selectedConfiguredListedModels,
 } from "./provider-selection.mjs";
 import { resolveVisionEngine } from "./vision-bridge.mjs";
-import { readVisionBridgeSettings } from "./vision-bridge-state.mjs";
+import {
+  readVisionBridgeSettings,
+  visionBridgeConfigured,
+} from "./vision-bridge-state.mjs";
 
 const checks = [];
 const add = (status, name, detail, fix) => checks.push({ status, name, detail, fix });
@@ -281,20 +284,33 @@ add(
     : `${requiredRoutedModels.length} routed models`,
   "Run ./bin/doctor --fix from the owning checkout, then fully quit and reopen Codex.",
 );
-// The bridge is opt-in, so "off" is a normal state and reports ok. Enabled
-// with no resolvable engine is the broken one: Codex would keep offering the
-// paste while nothing could read it, so the catalog drops the advertisement
-// and this says why.
+// "Off" is a normal state and reports ok. Enabled with no resolvable engine is
+// the broken one: Codex would keep offering the paste while nothing could read
+// it, so the catalog drops the advertisement and this says why.
+//
+// Only for an operator who actually asked, though. The bridge is now on by
+// default, so a plain text-only install reaches this branch having configured
+// nothing and having lost nothing -- images degrade exactly as they did before
+// the bridge existed. Warning there would put a yellow line on every fresh
+// DeepSeek-only install for a feature nobody switched on. It still reports what
+// is true, just at the severity the situation has.
+//
+// This check sees routed models only, so a native (ChatGPT-plan) engine is
+// invisible to it and a signed-in install may well read images fine while this
+// says nothing resolves.
 const visionSettings = readVisionBridgeSettings();
 const visionEngine = resolveVisionEngine(() => requiredRoutedModels, visionSettings);
 if (visionSettings.enabled && !visionEngine) {
+  const asked = visionBridgeConfigured();
   add(
-    "warn",
+    asked ? "warn" : "ok",
     "Vision bridge",
     visionSettings.engine
       ? `pinned engine ${visionSettings.engine} is not an enabled model that reads images`
-      : "enabled, but no enabled provider offers a model that reads images",
-    "Enable a provider with a vision model, or run ./bin/model-router codex control vision-bridge engine auto.",
+      : asked
+        ? "enabled, but no enabled provider offers a model that reads images"
+        : "on by default, but no enabled provider offers a model that reads images yet",
+    "Enable a provider with a vision model, sign in to ChatGPT, or run ./bin/model-router codex control vision-bridge setup for a local reader.",
   );
 } else if (visionEngine?.local) {
   add(

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -760,6 +760,15 @@ async function normalizeRoutedAgentInput(request, input, signal) {
   return output;
 }
 
+// Which bill a bridged read lands on. A registry engine names its own provider;
+// a native engine spends the signed-in ChatGPT plan, which the tray already
+// calls `openai`; a local engine spends nothing but electricity.
+function visionEngineProvider(engine) {
+  if (engine.native) return "openai";
+  if (engine.local) return "local";
+  return engine.provider || "unknown";
+}
+
 // Codex resends the whole conversation every turn, so the same screenshot
 // arrives again on every follow-up. Without the hash cache a five-turn
 // conversation about one image would buy the same transcript five times.
@@ -782,17 +791,39 @@ async function visionEvidenceFor(url, engine, signal, request, effort) {
   // the same screenshot again must re-read it, not replay the cheaper pass.
   const key = `${engine.slug}\u0000${effort || "default"}\u0000${account}\u0000${url}`;
   const cached = evidenceCache.get(key);
+  // A cache hit buys nothing, so it records nothing: the events file is a
+  // record of spend, not of calls the router avoided.
   if (cached !== undefined) return cached;
-  const text = await describeImage({
-    engine,
-    imageUrl: url,
-    gatewayBase: GATEWAY_BASE,
-    headers: routedHeaders(),
-    nativeCall,
-    effort,
-    signal,
-  });
-  return evidenceCache.set(key, text);
+  // A bridged read is a request the operator never asked for by name, billed to
+  // whichever engine won the ranking. It rides the same usage-events pipeline
+  // every routed turn uses, so `usage-events.jsonl` and `control probe` show
+  // that a vision call happened, against which model, and whether it worked --
+  // otherwise the very first read on an install that enabled nothing would
+  // leave no trace at all. Token counts are not available here (`describeImage`
+  // returns the transcript, not the envelope), so the event carries what it
+  // honestly has.
+  const startedAt = Date.now();
+  let status = 0;
+  try {
+    const text = await describeImage({
+      engine,
+      imageUrl: url,
+      gatewayBase: GATEWAY_BASE,
+      headers: routedHeaders(),
+      nativeCall,
+      effort,
+      signal,
+    });
+    status = 200;
+    return evidenceCache.set(key, text);
+  } finally {
+    recordUsageEvent({
+      model: engine.slug,
+      provider: visionEngineProvider(engine),
+      status,
+      durationMs: Date.now() - startedAt,
+    });
+  }
 }
 
 // Text-only models get their images read by a vision-capable model the
@@ -848,12 +879,15 @@ async function bridgeVisionInput(input, route, signal, request) {
     text: await visionEvidenceFor(url, engine, signal, request, effort),
     engineName,
   }));
-  if (!QUIET) {
-    console.error(
-      `[codex-router] vision-bridge model=${route.slug} engine=${engine.slug} ` +
-        `images=${result.images} described=${result.described} failed=${result.failed}`,
-    );
-  }
+  // Never gated on QUIET, for the same reason the retry line is not: a
+  // production LaunchAgent hard-sets `CODEX_ROUTER_QUIET=1`, and this is the
+  // one line that says the router spent an engine's quota on a paste nobody
+  // named. Silent automatic spending is the failure mode; the log carries a
+  // model, an engine, and counts -- never a transcript.
+  console.error(
+    `[codex-router] vision-bridge model=${route.slug} engine=${engine.slug} ` +
+      `images=${result.images} described=${result.described} failed=${result.failed}`,
+  );
   return result.input;
 }
 

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -27,7 +27,7 @@ import {
 import { trayBundleDir, trayDecision } from "./tray-install.mjs";
 import { resolveVisionEngine } from "./vision-bridge.mjs";
 import {
-  setVisionBridgeEnabled,
+  readVisionBridgeSettings,
   visionBridgeConfigured,
 } from "./vision-bridge-state.mjs";
 
@@ -358,26 +358,24 @@ async function main() {
   }
   writeProviderSelection(providers);
 
-  // Make pasted images just work for text-only models on a fresh install. When
-  // the operator already enabled a vision-capable provider, turn the bridge on
-  // before the catalog is built (so the picker advertises image input from the
-  // first launch) using that model -- no download, no extra step. This only
-  // fires when the bridge was never configured, so re-running the installer
-  // never overrides someone who turned it off on purpose. With no vision
-  // provider, it stays off and the summary points at the local-model setup.
-  let visionBridge;
-  if (!visionBridgeConfigured()) {
-    const engine = resolveVisionEngine(() => selectedConfiguredListedModels(), {
-      enabled: true,
-      engine: null,
-    });
-    if (engine) {
-      setVisionBridgeEnabled(true);
-      visionBridge = { enabled: true, engine: engine.slug };
-    } else {
-      visionBridge = { enabled: false, engine: null };
-    }
-  }
+  // Pasted images just work for text-only models: the bridge is on by default,
+  // so the installer no longer writes anything here. It used to auto-enable
+  // once when a vision-capable provider happened to be selected, which both
+  // left the state file's mere presence meaning "the installer ran" and left
+  // every other install needing a command nobody knew about. Reporting is all
+  // that is left to do -- and only for an install that has not answered the
+  // question itself, so a re-run never claims credit for a machine the operator
+  // already configured.
+  const visionBridge = visionBridgeConfigured()
+    ? undefined
+    : {
+        enabled: readVisionBridgeSettings().enabled,
+        engine:
+          resolveVisionEngine(
+            () => selectedConfiguredListedModels(),
+            readVisionBridgeSettings(),
+          )?.slug || null,
+      };
 
   let migration;
   if (legacy.installations.length) {
@@ -442,14 +440,16 @@ async function main() {
   process.stdout.write(
     `\nCodex Router is ready with: ${providers.join(", ")}\nFully quit Codex, reopen it, and start a new task.\n`,
   );
-  if (visionBridge?.enabled) {
+  if (visionBridge?.enabled && visionBridge.engine) {
     process.stdout.write(
-      `\nVision: text-only models can now read pasted images, via ${visionBridge.engine}.\n`,
+      `\nVision: text-only models can now read pasted images, via ${visionBridge.engine}.\n` +
+        `  It spends that provider's quota. Turn it off with: ./bin/control vision-bridge off\n`,
     );
-  } else if (visionBridge && !visionBridge.enabled) {
+  } else if (visionBridge?.enabled) {
     process.stdout.write(
-      `\nVision: no image-capable provider is enabled, so text-only models cannot read images yet.\n` +
-        `  Free local option: ./bin/control vision-bridge setup   (uses a small local model)\n`,
+      `\nVision: no enabled provider offers a model that reads images.\n` +
+        `  Signed in to ChatGPT? Codex's own vision model will read them, on the plan you already pay for.\n` +
+        `  Otherwise, free local option: ./bin/control vision-bridge setup   (uses a small local model)\n`,
     );
   }
   if (pendingCredentials.length) {

--- a/src/vision-bridge-state.mjs
+++ b/src/vision-bridge-state.mjs
@@ -15,7 +15,25 @@ export const VISION_BRIDGE_STATE_PATH =
   process.env.MODEL_ROUTER_VISION_BRIDGE_STATE ||
   path.join(STATE_DIR, "vision-bridge.json");
 
+// What a machine that has never answered the question gets. Pasting a
+// screenshot to a text-only model is the single thing operators expect to work
+// without reading documentation, and everything the bridge needs to serve it is
+// already installed: the ranking prefers the cheapest engine, and an install
+// with nothing to read images with resolves no engine and degrades exactly as
+// it always did. So the honest default is on.
+//
+// This is deliberately *not* the fallback for a state file that exists and
+// cannot be read -- see `disabledSettings()`.
 function defaultSettings() {
+  return { version: 1, enabled: true, engine: null, effort: null, local: null };
+}
+
+// The conservative reading, used only when a state file is present but this
+// build cannot make sense of it. A file on disk means the operator has been
+// here; it is not evidence of consent, so it must not inherit a default that
+// starts spending an engine's quota. Off is what every install had before the
+// bridge existed, and `bin/control vision-bridge on` is one command away.
+function disabledSettings() {
   return { version: 1, enabled: false, engine: null, effort: null, local: null };
 }
 
@@ -53,10 +71,25 @@ function normalizeLocal(value) {
   return local;
 }
 
-// Local opt-in that lets text-only models receive pasted images as described
-// text. The checked-in registry keeps declaring what each model itself can
-// read; this state only records that the operator wants the router to stand in
-// for the missing capability on this machine.
+// The checked-in registry keeps declaring what each model itself can read; this
+// state only records how the operator wants the router to stand in for the
+// missing capability on this machine.
+//
+// Three cases, and the distinction between them is structural rather than a
+// sentinel value:
+//
+//   no file      -- nobody has ever answered. Takes the current default.
+//   readable     -- `enabled` is the operator's own answer and is taken
+//                   verbatim, forever. A stored `false` is never re-enabled by
+//                   a change of default; that is the whole point of writing it.
+//   unreadable   -- a file exists, so somebody was here, but this build cannot
+//                   tell what they chose. Falls back to off, not to the default.
+//
+// That is why the version stays 1. A bumped version would have to guess what a
+// v1 `false` meant, and there is nothing to guess with: file presence already
+// separates "never configured" from "configured off", and `visionBridgeConfigured()`
+// has been the installer's gate on exactly that distinction since the bridge
+// shipped. A migration could only replace a fact with an inference.
 export function readVisionBridgeSettings() {
   if (!existsSync(VISION_BRIDGE_STATE_PATH)) return defaultSettings();
   try {
@@ -71,10 +104,9 @@ export function readVisionBridgeSettings() {
       };
     }
   } catch {
-    // Corrupt state falls back to off, which is the behavior every install had
-    // before the bridge existed.
+    // Falls through to the conservative reading below.
   }
-  return defaultSettings();
+  return disabledSettings();
 }
 
 function writeSettings(settings) {
@@ -123,9 +155,11 @@ export function setVisionBridgeEffort(effort) {
   return writeSettings({ ...current, version: 1, effort: normalizeEffort(effort) });
 }
 
-// True once the operator has made any explicit choice. Install-time auto-enable
-// checks this so re-running the installer never overrides someone who turned
-// the bridge off on purpose.
+// True once the operator has made any explicit choice. This is the structural
+// line between "never configured", which takes the current default, and
+// "configured", whose stored `enabled` is authoritative and outlives any change
+// of default. Surfaces that would otherwise nag about an unconfigured install
+// check this rather than inferring intent from the value.
 export function visionBridgeConfigured() {
   return existsSync(VISION_BRIDGE_STATE_PATH);
 }

--- a/src/vision-bridge.mjs
+++ b/src/vision-bridge.mjs
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
 
+import { PROVIDERS } from "./model-registry.mjs";
+
 // A text-only model cannot read a pasted screenshot, so the router reads it on
 // the model's behalf: every image part is sent to a vision-capable model the
 // operator has already enabled, and the reply is substituted into the turn as
@@ -182,6 +184,22 @@ export function nativeVisionCandidates(models, hidden = new Set()) {
     .filter(supportsImageInput);
 }
 
+// Auto must never nominate an engine served from this machine. The pinned
+// `local` engine has always been pin-only for this reason -- an unreachable
+// localhost would fail every paste -- and a keyless registry provider is the
+// identical hazard wearing a registry slug: the loader guarantees `keyless`
+// means a loopback `baseUrl`, so those models are somebody's own Ollama or LM
+// Studio, up only while they have it running. That was survivable while the
+// bridge was opt-in; with the bridge on by default it would silently make a
+// stopped runtime the default reader on every machine that ever checked a local
+// vision model. Pinning one stays fully supported, and the picker still lists
+// them, because a deliberate choice carries the knowledge that the server has
+// to be up.
+export function isLoopbackEngine(model) {
+  if (model?.local === true) return true;
+  return Boolean(PROVIDERS.get(String(model?.provider || ""))?.keyless);
+}
+
 // `listCandidates` must return the selected and credentialed set: an engine the
 // operator cannot actually call would make the catalog promise image input that
 // every turn then fails to deliver. The local engine is the one exception --
@@ -218,7 +236,7 @@ export function resolveVisionEngine(listCandidates, settings) {
     // reason to silently describe images with a different model.
     return ranked.find((model) => model.slug === settings.engine);
   }
-  return ranked[0];
+  return ranked.find((model) => !isLoopbackEngine(model));
 }
 
 // The bridge stands in for the model, so a model that already reads images is

--- a/test/vision-bridge-state.test.mjs
+++ b/test/vision-bridge-state.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -14,12 +14,42 @@ const {
   setVisionBridgeEnabled,
   setVisionBridgeEngine,
   setVisionBridgeLocal,
+  visionBridgeConfigured,
   visionBridgeSnapshot,
 } = await import("../src/vision-bridge-state.mjs");
+const { resolveVisionEngine } = await import("../src/vision-bridge.mjs");
 
-test("the bridge is off until the operator turns it on", () => {
-  assert.deepEqual(readVisionBridgeSettings(), { version: 1, enabled: false, engine: null, effort: null, local: null });
+function forgetState() {
+  rmSync(VISION_BRIDGE_STATE_PATH, { force: true });
+}
+
+test("a machine that never configured the bridge gets it on", () => {
+  forgetState();
+  assert.equal(visionBridgeConfigured(), false);
+  assert.deepEqual(readVisionBridgeSettings(), {
+    version: 1,
+    enabled: true,
+    engine: null,
+    effort: null,
+    local: null,
+  });
   assert.ok(VISION_BRIDGE_STATE_PATH.startsWith(stateDir));
+});
+
+test("the default reaches the resolver, so a pasted image is read with no configuration", () => {
+  forgetState();
+  const flash = {
+    slug: "qwen-plan/qwen3.6-flash",
+    provider: "qwen-plan",
+    inputModalities: ["text", "image"],
+  };
+  assert.equal(
+    resolveVisionEngine(() => [flash], readVisionBridgeSettings())?.slug,
+    "qwen-plan/qwen3.6-flash",
+  );
+  // ...and with nothing to read it with, the answer is still "no engine", which
+  // is byte-for-byte the behaviour a switched-off bridge always had.
+  assert.equal(resolveVisionEngine(() => [], readVisionBridgeSettings()), undefined);
 });
 
 test("enabling and pinning round-trip through protected state", () => {
@@ -61,6 +91,48 @@ test("pinning a local model stores it and selects the local engine", () => {
 test("corrupt state reads as off rather than throwing", () => {
   writeFileSync(VISION_BRIDGE_STATE_PATH, "{not json", "utf8");
   assert.deepEqual(readVisionBridgeSettings(), { version: 1, enabled: false, engine: null, effort: null, local: null });
+});
+
+// The migration rule, stated as a test. "Never configured" is the absence of
+// the file; anything on disk is the operator's own answer and the new default
+// must not reach past it. An unreadable file is not consent either way, so it
+// keeps the conservative reading it always had.
+test("a stored off is never re-enabled by the new default", () => {
+  writeFileSync(
+    VISION_BRIDGE_STATE_PATH,
+    `${JSON.stringify({ version: 1, enabled: false, engine: null, effort: null, local: null })}\n`,
+    "utf8",
+  );
+  assert.equal(visionBridgeConfigured(), true);
+  assert.equal(readVisionBridgeSettings().enabled, false);
+  // And it keeps surviving reads, writes of unrelated fields, and re-reads.
+  setVisionBridgeEffort("high");
+  assert.equal(readVisionBridgeSettings().enabled, false);
+  setVisionBridgeEngine("qwen-plan/qwen3.6-flash");
+  assert.equal(readVisionBridgeSettings().enabled, false);
+  // A stored off resolves no engine, exactly as before.
+  assert.equal(
+    resolveVisionEngine(
+      () => [
+        { slug: "qwen-plan/qwen3.6-flash", provider: "qwen-plan", inputModalities: ["text", "image"] },
+      ],
+      readVisionBridgeSettings(),
+    ),
+    undefined,
+  );
+  setVisionBridgeEffort(null);
+  setVisionBridgeEngine(null);
+});
+
+test("a state file this build cannot read stays off rather than adopting the new default", () => {
+  writeFileSync(
+    VISION_BRIDGE_STATE_PATH,
+    `${JSON.stringify({ version: 99, enabled: true })}\n`,
+    "utf8",
+  );
+  assert.equal(readVisionBridgeSettings().enabled, false);
+  writeFileSync(VISION_BRIDGE_STATE_PATH, `${JSON.stringify({ version: 1 })}\n`, "utf8");
+  assert.equal(readVisionBridgeSettings().enabled, false);
 });
 
 test("a reasoning effort is pinned and cleared on its own, without touching the engine", () => {

--- a/test/vision-bridge.test.mjs
+++ b/test/vision-bridge.test.mjs
@@ -175,6 +175,52 @@ test("a pinned local engine resolves even with no paid vision model enabled", ()
   assert.equal(engine.baseUrl, "http://127.0.0.1:11434/v1");
 });
 
+// The bridge is on by default now, so "auto" runs on machines nobody set up.
+// A model served from this machine is only there while the operator's own
+// runtime is running, so nominating one automatically would fail every paste
+// on a machine where Ollama happens to be closed -- the same reasoning that
+// keeps the pinned `local` engine pin-only. The registry enforces that a
+// keyless provider is loopback-only, so that flag is the whole rule.
+const LOOPBACK_VISION = {
+  slug: "local/qwen2.5vl:3b",
+  displayName: "Qwen2.5-VL 3B (local)",
+  provider: "local",
+  gatewayModel: "qwen2.5vl:3b",
+  inputModalities: ["text", "image"],
+  priority: 1,
+};
+
+test("auto never nominates an engine served from this machine", () => {
+  assert.equal(resolveVisionEngine(() => [LOOPBACK_VISION], { enabled: true }), undefined);
+  assert.equal(
+    resolveVisionEngine(() => [LOOPBACK_VISION, FLASH_VISION], { enabled: true })?.slug,
+    FLASH_VISION.slug,
+  );
+  // The exclusion is about auto only: an operator who names it still gets it.
+  assert.equal(
+    resolveVisionEngine(() => [LOOPBACK_VISION], { enabled: true, engine: LOOPBACK_VISION.slug })?.slug,
+    LOOPBACK_VISION.slug,
+  );
+  // ...and it stays offerable in the picker, which lists what can be pinned.
+  assert.deepEqual(
+    rankVisionEngines([LOOPBACK_VISION, FLASH_VISION]).map((model) => model.slug),
+    [FLASH_VISION.slug, LOOPBACK_VISION.slug],
+  );
+});
+
+test("with nothing to read an image with, a paste degrades exactly as it did before", () => {
+  // The switched-off bridge and the on-by-default bridge with no engine reach
+  // the identical code path: no engine, so the router states the failure
+  // instead of sending a part the provider would reject.
+  assert.equal(resolveVisionEngine(() => [TEXT_ONLY], { enabled: true }), undefined);
+  assert.equal(resolveVisionEngine(() => [], { enabled: true }), undefined);
+  assert.deepEqual(applyVisionBridge([TEXT_ONLY], undefined), [TEXT_ONLY]);
+  const off = stripImages(imageInput(), "reason");
+  assert.equal(off.images, 1);
+  assert.equal(off.input[0].content[1].type, "input_text");
+  assert.match(off.input[0].content[1].text, /could not be read/);
+});
+
 test("the local engine falls back to sensible defaults", () => {
   const engine = localVisionEngine({});
   assert.equal(engine.gatewayModel, DEFAULT_LOCAL_VISION_MODEL);
@@ -877,6 +923,42 @@ test("the request path hands the engine resolver a list it has not built yet", a
     eager,
     [],
     "bridgeVisionInput must only reach the credential scan from inside the deferred candidate list",
+  );
+});
+
+// The bridge now spends an engine's quota on machines that configured nothing,
+// so a read that leaves no trace is the failure mode. Two records, for the two
+// questions an operator asks afterwards: did a vision call happen, and against
+// what.
+test("a bridged read is recorded rather than spent silently", async () => {
+  const source = await readFile(path.join(repoRoot, "src/router.mjs"), "utf8");
+  const evidence = source.slice(
+    source.indexOf("async function visionEvidenceFor"),
+    source.indexOf("async function bridgeVisionInput"),
+  );
+  assert.match(
+    evidence,
+    /recordUsageEvent\(\{[\s\S]*model: engine\.slug/,
+    "a bridged read must record a usage event naming the engine that was billed",
+  );
+  // A cache hit skipped the call, so it must not appear as spend.
+  assert.ok(
+    evidence.indexOf("if (cached !== undefined) return cached;") <
+      evidence.indexOf("recordUsageEvent("),
+    "a cache hit must return before anything is recorded",
+  );
+  const bridge = source.slice(
+    source.indexOf("async function bridgeVisionInput"),
+    source.indexOf("function isOpaqueEncryptedContent"),
+  );
+  // A production LaunchAgent hard-sets CODEX_ROUTER_QUIET=1, so gating this
+  // line on it would hide automatic spending on exactly the installs that run
+  // unattended.
+  assert.match(bridge, /console\.error\(\s*`\[codex-router\] vision-bridge /);
+  assert.doesNotMatch(
+    bridge,
+    /if \(!QUIET\)/,
+    "the vision-bridge line must not be gated on QUIET",
   );
 });
 


### PR DESCRIPTION
Makes a text-only model read a pasted image with **zero configuration**. Today `defaultSettings()` returns `enabled: false`, so pasting a screenshot at DeepSeek, GLM, or Kimi does nothing until the operator discovers a toggle.

The machinery was already there: `resolveVisionEngine` with no pin returns `ranked[0]`, and `rankVisionEngines` sorts by `engineCostRank` **first**, so auto already prefers the cheapest engine. The product change is one default. The care is everywhere else.

## "Never configured" vs "explicitly off"

Split by file state, not by a sentinel — and deliberately **without** a version bump:

- **no file** → default (on). Absence is the only honest evidence nobody has answered.
- **readable `version: 1` file** → `parsed.enabled` verbatim, forever. A stored `false` is never re-enabled.
- **file present but unparseable or from a future version** → new `disabledSettings()` (off). This previously fell through to the default, which would have flipped a corrupt file to *on*. A file on disk means somebody was here; that is not consent, so it must not start spending quota.

A `version: 2` migration was considered and rejected: it would have to *guess* what a v1 `false` meant, and there is nothing to guess with. File presence answers it exactly, and `visionBridgeConfigured()` — literally `existsSync(path)` — has been the installer's gate on that same distinction since the bridge shipped. A bump would replace a fact with an inference.

**The installer stopped writing bridge state.** It used to auto-enable once when a vision-capable provider happened to be selected, which made the file's mere presence mean "the installer ran" — converting an implicit default into an explicit choice for a subset of users. It now only reports.

## A hazard this surfaced

The `local` registry provider is **keyless**, and `configuredProviderIds()` treats every keyless provider as always-configured. So a checked local Ollama vision model was already a full auto candidate through `selectedConfiguredListedModels()`.

Opt-in made that survivable. **On by default it would silently make a stopped Ollama the default reader on every machine that ever checked one**, failing every paste.

New `isLoopbackEngine()` excludes `model.local === true` and any model whose provider is keyless — derived, not a hardcoded id, since the registry loader guarantees keyless ⇒ loopback `baseUrl`. It applies **only to the auto branch**: pins still resolve, and ranking still lists them so the picker can offer them.

That is the real line for a default, and it is reachability rather than billing: auto is the only default an unattended machine gets, so it may only nominate an engine reachable without the operator having started something.

## Visibility — it was worse than assumed

A first-time bridged read left **no trace at all**. `recordUsageEvent` is only called from the four response paths; the bridge called `describeImage` directly and recorded nothing. Its one log line was gated on `!QUIET`, and a production LaunchAgent hard-sets `CODEX_ROUTER_QUIET=1`.

Now: the log line is ungated (same precedent and reasoning as the retry line in #119), and each read that **misses** the transcript cache records a usage event. Cache hits record nothing — the file is a record of spend, not of avoided calls.

**Still invisible, reported rather than fixed:** the macOS tray does not render routed usage events *at all* — `usageEvents` is emitted by `control probe` and consumed by nothing in `ModelRouterTrayApp.swift`. A native engine's ChatGPT-plan quota still doesn't move in the tray's limits. AGENTS.md's "Known gap" now says exactly which half is closed and which is not.

## Why not narrower — native-only

Restricting default-on to the operator's signed-in plan was seriously considered and rejected on the repo's own reasoning: AGENTS.md item 1 already sanctioned auto-enabling on a metered provider at install time, justified as reusing a model they already pay for. An enabled *and credentialed* provider is a bill already opened. Native-only would also fail the actual goal — a signed-out Kimi-only install is exactly the user in question, and would get nothing.

## Residual risk, flagged rather than guessed

`engineCostRank` is a **name** heuristic (`flash|haiku|mini|lite|small|turbo`). An install whose only vision model matches none of those gets a flagship as `ranked[0]`. Building a price table would mean inventing numbers the registry does not carry. One screenshot on a flagship is cents, capped by the one-hour transcript cache, and now logged and recorded.

## Tests

612 tests, 606 pass, 0 fail (+6).

RED against the current default: the fresh-install default, the default reaching the resolver, and auto never nominating a loopback engine all fail. The two "must not change" cases — a stored `false` surviving, and a paste with nothing to read it degrading exactly as before — are guards that pass both sides by design. Visibility RED was proven against `git show HEAD:src/router.mjs`: `records usage event: false`, `gates log on QUIET: true`.

`doctor` now warns only when `visionBridgeConfigured()` — an operator actually asked — so a plain DeepSeek-only install does not gain a new WARN.

## What a user notices that they did not ask for

1. **The picker changes.** Text-only models advertise `image` input when an engine resolves, so Codex stops refusing the paste. Needs a full Codex quit and reopen.
2. **Money moves without an explicit toggle.** That is the point, but it is real: an enabled Gemini/Qwen/Grok key can be billed for a screenshot pasted at DeepSeek. Mitigated by cheapest-first ranking, the one-hour cache, the usage event, and the log line.
3. **A new log line on quiet installs.**
4. **New rows in `usage-events.jsonl`** under the engine's slug, including `provider: "openai"` for native engines — an id no registry provider owns. Harmless today; worth knowing before something renders these.
5. **Anyone who had a local vision model auto-selected loses it.** They must have turned the bridge on themselves and left the engine on auto; they now get a cloud engine or nothing until they pin the local model. `doctor` and `vision-bridge status` both name the resolved engine.
