### PR TITLE
fix(test): give each test file its own ports instead of racing for them

### DIFF
--- a/test/anthropic-api-integration.test.mjs
+++ b/test/anthropic-api-integration.test.mjs
@@ -2,13 +2,13 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import http from "node:http";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
+import { freePort } from "./port-pool.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const litellm = path.join(
@@ -21,18 +21,6 @@ const enabled = process.env.MODEL_ROUTER_LITELLM_INTEGRATION === "1";
 const INTERNAL_KEY = "anthropic-e2e-internal-service-key-with-sufficient-length";
 const CALLER_KEY = "anthropic-e2e-caller-capability-with-sufficient-length";
 const PROVIDER_KEY = "anthropic-e2e-provider-key";
-
-async function freePort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  assert.ok(address && typeof address === "object");
-  await new Promise((resolve) => server.close(resolve));
-  return address.port;
-}
 
 async function freePorts(count) {
   const ports = new Set();

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -2,11 +2,11 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import http from "node:http";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { openPort } from "./port-pool.mjs";
 
 import {
   hostedSearchEnabledFor,
@@ -19,17 +19,6 @@ const INTERNAL_KEY = "test-grok-internal-service-key-with-sufficient-length";
 
 function sse(events) {
   return `${events.map((e) => `event: ${e.type}\ndata: ${JSON.stringify(e)}`).join("\n\n")}\n\n`;
-}
-
-async function openPort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const { port } = server.address();
-  await new Promise((resolve) => server.close(resolve));
-  return port;
 }
 
 async function mockBackend(handler) {

--- a/test/kimi-oauth-forwarder.test.mjs
+++ b/test/kimi-oauth-forwarder.test.mjs
@@ -1,25 +1,14 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { mkdtempSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { openPort } from "./port-pool.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const internalKey = "test-kimi-internal-service-key-with-sufficient-length";
-
-async function openPort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const { port } = server.address();
-  await new Promise((resolve) => server.close(resolve));
-  return port;
-}
 
 async function stop(child) {
   if (child.exitCode !== null) return;

--- a/test/native-retry.test.mjs
+++ b/test/native-retry.test.mjs
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import http from "node:http";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -11,6 +10,7 @@ import { zstdDecompressSync } from "node:zlib";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
 import { fetchWithRetry } from "../src/upstream-retry.mjs";
+import { openPort } from "./port-pool.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
@@ -24,17 +24,6 @@ const EDGE_503_BODY =
 
 function routerBase(port) {
   return callerBaseUrl(port, CALLER_KEY);
-}
-
-async function openPort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const { port } = server.address();
-  await new Promise((resolve) => server.close(resolve));
-  return port;
 }
 
 async function mockServer(handler) {

--- a/test/port-pool.mjs
+++ b/test/port-pool.mjs
@@ -1,0 +1,110 @@
+import { readdirSync } from "node:fs";
+import { createServer } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Reserving a port by binding :0, reading the number, and closing the socket
+// hands that number straight back to the ephemeral pool -- and whatever is
+// meant to use it does not bind for another few milliseconds. `node --test`
+// runs every test file in its own process, in parallel, so a second file's
+// bind(0) could be handed the same number inside that window and whichever
+// bound second died:
+//
+//     Error: listen EADDRINUSE: address already in use 127.0.0.1:35011
+//
+// It failed CI at random, most often in startup-cleanup.test.mjs, which
+// reserves five ports before it spawns anything and so holds five of those
+// windows open at once. Eight test files had their own copy of the same helper.
+//
+// The fix is to stop drawing from the pool everything else draws from. Each
+// test file gets a block of ports of its own, and the blocks sit *below* every
+// platform's ephemeral range (Linux from 32768, macOS and Windows from 49152),
+// so no other process's bind(0) can be handed one of ours and no other test
+// file shares a block. What remains is a leftover from an earlier run of the
+// same file, which the bind check catches by moving up the block.
+//
+// Nothing here serializes: the blocks are disjoint by construction, so no test
+// file ever waits on another.
+const FIRST_PORT = 20_000;
+// One below Linux's default ephemeral floor of 32768.
+const LAST_PORT = 32_767;
+const MAX_BLOCK = 256;
+const MIN_BLOCK = 32;
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+// The same listing in every process, so every file agrees on who owns what
+// without any shared state to coordinate. Adding a test file reshuffles the
+// blocks, which is harmless: one run sees one listing.
+function blockFor(entry) {
+  const files = readdirSync(TEST_DIR)
+    .filter((file) => file.endsWith(".test.mjs"))
+    .sort();
+  const index = files.indexOf(path.basename(entry));
+  if (index === -1) return undefined;
+  const size = Math.max(
+    MIN_BLOCK,
+    Math.min(MAX_BLOCK, Math.floor((LAST_PORT - FIRST_PORT) / Math.max(files.length, 1))),
+  );
+  const start = FIRST_PORT + index * size;
+  // More test files than the range can seat. Falling back keeps the suite
+  // working; it just stops being race-proof, which is what it was before.
+  if (start + size > LAST_PORT) return undefined;
+  return { start, size };
+}
+
+async function isFree(port) {
+  const server = createServer();
+  const listening = await new Promise((resolve) => {
+    server.once("error", () => resolve(false));
+    server.listen(port, "127.0.0.1", () => resolve(true));
+  });
+  if (!listening) return false;
+  await new Promise((resolve) => server.close(resolve));
+  return true;
+}
+
+// The old behaviour, kept for anything running outside `node --test` -- a file
+// executed directly, or imported by a tool that is not the test runner. It
+// carries the race, which is why it is the fallback rather than the path.
+async function ephemeralPort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+let block;
+const issued = new Set();
+
+/**
+ * A port nothing else in this test run will take.
+ *
+ * Still verified by binding it, because the only competitor left is this same
+ * file's own leftovers from an earlier run. Ports are never handed out twice
+ * within a file, since the caller binds later and a second check would find
+ * the port still free.
+ */
+export async function freePort() {
+  if (block === undefined) block = blockFor(process.argv[1] || "") ?? null;
+  if (!block) return ephemeralPort();
+  for (let offset = 0; offset < block.size; offset += 1) {
+    const port = block.start + offset;
+    if (issued.has(port)) continue;
+    // eslint-disable-next-line no-await-in-loop -- probing in order is the point
+    if (!(await isFree(port))) continue;
+    issued.add(port);
+    return port;
+  }
+  throw new Error(
+    `${path.basename(process.argv[1] || "this file")} exhausted its ${block.size}-port ` +
+      `block at ${block.start}; raise MAX_BLOCK in test/port-pool.mjs or free the leftovers`,
+  );
+}
+
+// Both names were in use across the suite for the identical function.
+export { freePort as openPort };

--- a/test/router-resilience.test.mjs
+++ b/test/router-resilience.test.mjs
@@ -9,21 +9,11 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
+import { openPort } from "./port-pool.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
 const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
-
-async function openPort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const { port } = server.address();
-  await new Promise((resolve) => server.close(resolve));
-  return port;
-}
 
 async function mockServer(handler) {
   const server = http.createServer(handler);

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -9,7 +9,6 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -17,6 +16,7 @@ import { fileURLToPath } from "node:url";
 import { zstdCompressSync, zstdDecompressSync } from "node:zlib";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
+import { openPort } from "./port-pool.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
@@ -43,19 +43,6 @@ async function bodyJson(request) {
   // way Codex itself does on the way in, so a mock backend has to decode one.
   const body = request.headers["content-encoding"] === "zstd" ? zstdDecompressSync(raw) : raw;
   return JSON.parse(body.toString("utf8"));
-}
-
-async function openPort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  assert.ok(typeof address === "object" && address);
-  const port = address.port;
-  await new Promise((resolve) => server.close(resolve));
-  return port;
 }
 
 async function mockServer(handler) {

--- a/test/startup-cleanup.test.mjs
+++ b/test/startup-cleanup.test.mjs
@@ -6,20 +6,9 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { freePort } from "./port-pool.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-
-async function freePort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  assert.ok(address && typeof address === "object");
-  await new Promise((resolve) => server.close(resolve));
-  return address.port;
-}
 
 // On loopback this settles either way in microseconds: a live listener accepts,
 // and a closed port refuses. A socket that does neither is not a third answer

--- a/test/vision-bridge-e2e.test.mjs
+++ b/test/vision-bridge-e2e.test.mjs
@@ -2,13 +2,13 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import http from "node:http";
-import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
+import { openPort } from "./port-pool.mjs";
 
 // `test/vision-bridge.test.mjs` proves the bridge's parts in isolation. This
 // file measures the whole path: a real router process, a real routed turn, and
@@ -84,17 +84,6 @@ async function bodyJson(request) {
   const chunks = [];
   for await (const chunk of request) chunks.push(chunk);
   return JSON.parse(Buffer.concat(chunks).toString("utf8"));
-}
-
-async function openPort() {
-  const server = net.createServer();
-  await new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const { port } = server.address();
-  await new Promise((resolve) => server.close(resolve));
-  return port;
 }
 
 async function mockServer(handler) {


### PR DESCRIPTION
## The failure

CI failed at random, most recently on `ubuntu-latest` in run [31311152425](https://github.com/duolahypercho/codex-router/actions/runs/31311152425), in `startup-cleanup.test.mjs`:

```
Error: listen EADDRINUSE: address already in use 127.0.0.1:35011
```

It passed on `macos-latest` and `windows-latest` in that same run, and passes locally — a race, not a defect in the code under test. Re-running the job turned it green with no code change.

## Root cause

Eight test files each had their own copy of one helper:

```js
server.listen(0, "127.0.0.1");   // ask the OS for a free port
const { port } = server.address();
await server.close();            // ...and give it straight back
return port;                     // something binds it ~hundreds of ms later
```

Closing returns the port to the ephemeral pool, and `node --test` runs every test **file in its own process, in parallel** — so a second file's `bind(0)` can be handed the same number inside that window, and whichever binds second dies.

`startup-cleanup.test.mjs` is the likeliest victim because it reserves **five** ports before it spawns anything, holding five of those windows open simultaneously.

## The fix

One shared helper, `test/port-pool.mjs`, replacing all eight copies (−98 lines). Each test file gets a block of ports of its own, derived from its position in the sorted listing of test files — deterministic, unique, and needing no shared state between processes.

The blocks live at **20000–32767**, below every platform's ephemeral floor (Linux 32768, macOS and Windows 49152). So:

- no other process's `bind(0)` can be handed one of our ports, and
- no two test files share a block.

Each port is still bind-checked before being handed out, because one competitor remains — the same file's own leftovers from an earlier run. That check moves up the block instead of failing.

## Verification

- **Blocks are disjoint**, and the highest ends at 32750, under the ephemeral floor. Block size divides the fixed range by the file count (170 today at 75 files), so adding test files narrows blocks rather than overflowing; the fallback only engages past ~398 files.
- **`bind(0)` cannot reach the pool**: sampled 1500 times on macOS → range 60469–61969, never once inside 20000–32767.
- **Allocation probe**, 8 parallel processes × 40 allocations: old helper put 320/320 ports in the ephemeral range, new helper 0/320.
- **Three consecutive full runs**: 653 tests, 0 failures, 21.78s each against a 21.8s baseline — nothing serialized.
- Single-file runs (`node --test test/routing.test.mjs`) still pass, and use outside the test runner falls back to the old ephemeral behaviour — which is why it is the fallback and not the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)