### PR TITLE
feat(vision): ask the reader what the operator wants to know

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -461,6 +461,38 @@ the turn as text. Treat it as a router capability, never as a model capability.
    layout list, readable data values, and an explicit uncertainty list, so the
    downstream model quotes rather than guesses. Preserve the uncertainty
    section in any rewrite.
+   - `## Identification` is the **one** section where inference is allowed, and
+     it exists because a pure transcription contract cannot answer "what is
+     this?" — which is the most common thing anyone asks about a pasted image.
+     Without it the reader described a photo it plainly recognized, and the
+     routed model went looking on the internet, uploading the operator's
+     screenshot to a public host on the way. Keep it separate from `## Text`,
+     keep it required, and keep `(unrecognized)` as the answer when nothing is
+     recognizable. Inference belongs in one labelled place, never spread
+     through the sections that claim to be a reading.
+8. The reader is asked what the operator wants to know, and asked **again when
+   that changes**. Pinning the question to the image's own message kept the
+   cache still and made an image's reading a snapshot of the first thing ever
+   asked about it. The newest image follows the newest question instead. Three
+   properties keep that affordable, and all three are load-bearing:
+   - Bought once per *question*, never per turn: a question already asked is
+     served from the record, so Codex resending the conversation is free.
+   - Only the **newest** image follows the conversation. Older images keep the
+     question they were read for, so a chat holding ten screenshots cannot turn
+     one new question into ten new reads.
+   - The record accumulates, so an earlier answer survives a later question.
+   The question itself is the operator's words only: Codex's `<image …>` wrapper,
+   its `# Files mentioned by the user:` preamble, and its context blocks
+   (`<environment_context>`, `<recommended_plugins>`) are bookkeeping, and
+   sending them produced transcripts written about a filename.
+9. A read that fails **transiently** is asked again — twice, at 250ms and 1s.
+   The engine is a rate-limited account across a network, and losing an image
+   for the whole turn to a 429 that would have cleared in a second is the
+   opposite of what the bridge is for. What is not retried is equally
+   deliberate: 4xx refusals buy the identical refusal, and a timeout is reported
+   rather than retried because the per-attempt budget is already two minutes. A
+   transport failure keeps the transport's own wording ("fetch failed"), which
+   is how an operator learns their own loopback engine is down.
    - A reading that came back **incomplete** says so in its own header. The
      downstream model cannot otherwise tell "the image does not show that" from
      "the transcript does not mention it", and it answers the first with
@@ -471,7 +503,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
      not follow the format at all -- a small local model answering in prose --
      and reading again returns the same shape, so an invitation there buys a
      loop rather than an answer. Never advertise a second look on every image.
-8. Every image the router carries is read, in **both** places Codex puts one:
+10. Every image the router carries is read, in **both** places Codex puts one:
    parts of a user message, and the `output` of a `function_call_output`. A
    text-only model that has just been handed a transcript still sees the file's
    path in the turn and calls `view_image` on it, and that tool result holds the
@@ -490,7 +522,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
      buying a second one. It is also the only way a *later* question gets a
      freshly focused read, since the question pinned to an image is the one in
      its own message.
-9. An image's evidence is **one record per image, not one transcript per
+11. An image's evidence is **one record per image, not one transcript per
    question**. The question still decides whether a read has to be bought;
    what gets injected is every reading the router holds for that image. Filing
    one transcript per (image, question) and injecting only the matching one made
@@ -502,7 +534,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
    slot prints the record; the rest point at it. That pointer is keyed on the
    image, never on matching transcript text: two different screenshots can read
    identically, and "the same image" has to be a fact about the bytes.
-10. One image, one purchase. The transcript cache only knows about reads that
+12. One image, one purchase. The transcript cache only knows about reads that
    have **finished**, so concurrent requests — Codex sends them, and a subagent
    runs beside its parent — all missed and all bought the same transcript. Reads
    in flight are shared by image, effort, account, and question; waiters take the
@@ -511,7 +543,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
    request an image. Reads within a turn run concurrently under a fixed cap: the
    operator waits for all of them before the routed turn starts, but the engine
    is somebody's rate-limited account and must not receive an album as a burst.
-11. Never add a local model to `LOCAL_VISION_CATALOG` with an `accuracy` claim
+13. Never add a local model to `LOCAL_VISION_CATALOG` with an `accuracy` claim
    that was not measured. Run `node src/vision-benchmark.mjs`, which scores a
    model against a checked-in image with known contents, and record the result
    in `measured`; anything unmeasured stays `untested`. This is not bureaucracy:
@@ -519,7 +551,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
    plausible, so a reputation-based label would route users straight to a model
    that fabricates invoice numbers. The picker sorts on this field, so an
    unearned "accurate" puts a confident-wrong reader at the top of the list.
-12. Which native models may read an image is one rule in one place
+14. Which native models may read an image is one rule in one place
    (`src/vision-engines.mjs`), not a criterion each surface re-derives. The
    catalog build, the tray, and the request path each asked it separately once,
    and the three answers disagreed — the request path applied no auth gate at
@@ -528,7 +560,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
    process) and only the request path holds the caller's live session. Every
    call site names its evidence explicitly, and the coverage below fails when
    one of them stops.
-13. The bridge lives on the **routed request path only**. `src/api-forwarder.mjs`
+15. The bridge lives on the **routed request path only**. `src/api-forwarder.mjs`
     sits downstream of the gateway — every routed model's `api_base` points at
     it — so Codex's traffic arrives already bridged and an image reaching that
     hop came from a client talking to the gateway directly. It replaces those
@@ -537,7 +569,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
     substituted part must use the protocol's own text type (`input_text` for
     Responses, `text` for chat completions and Anthropic messages), or an image
     the provider rejects is merely traded for a text part it rejects.
-14. Regression coverage lives in `test/vision-bridge.test.mjs`,
+16. Regression coverage lives in `test/vision-bridge.test.mjs`,
     `test/vision-bridge-state.test.mjs`, the bridged-catalog case in
     `test/catalog.test.mjs`, the whole-path measurements in
     `test/vision-bridge-e2e.test.mjs`, and the router cases in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -485,7 +485,26 @@ the turn as text. Treat it as a router capability, never as a model capability.
    its `# Files mentioned by the user:` preamble, and its context blocks
    (`<environment_context>`, `<recommended_plugins>`) are bookkeeping, and
    sending them produced transcripts written about a filename.
-9. A read that fails **transiently** is asked again — twice, at 250ms and 1s.
+9. Resolving an engine and **reaching** it are different questions. The reader
+   is a short list — the operator's choice first, then the other credentialed,
+   non-loopback vision models — and an image is offered to the next one when the
+   first cannot be reached. A 401 from a lapsed session and a 503 from a
+   provider outage both turned every paste into "could not be read" while the
+   engine still resolved perfectly. What the fallback must not become:
+   - **Silent.** The evidence header names the engine that actually read the
+     image, and the per-turn log line records `fellBack`.
+   - **A way around a pin.** A pin that does not *resolve* is still an
+     operator-visible problem, never a quiet switch to another model, and a
+     pinned **local** engine never falls back onto a provider's quota nobody
+     chose to spend.
+   - **Expensive.** The list is capped, the candidate set is still built at most
+     once per turn, and a second engine is only ever called after the first has
+     failed — so a working engine costs exactly what it did before. Another
+     provider is tried before another *attempt* at a broken one: retries are
+     spent only on the last engine in the list, because waiting out a retry
+     ladder against a dead endpoint while a working engine sits behind it is
+     how a fallback that works becomes a paste that takes half a minute.
+10. A read that fails **transiently** is asked again — twice, at 250ms and 1s.
    The engine is a rate-limited account across a network, and losing an image
    for the whole turn to a 429 that would have cleared in a second is the
    opposite of what the bridge is for. What is not retried is equally
@@ -503,7 +522,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
      not follow the format at all -- a small local model answering in prose --
      and reading again returns the same shape, so an invitation there buys a
      loop rather than an answer. Never advertise a second look on every image.
-10. Every image the router carries is read, in **both** places Codex puts one:
+11. Every image the router carries is read, in **both** places Codex puts one:
    parts of a user message, and the `output` of a `function_call_output`. A
    text-only model that has just been handed a transcript still sees the file's
    path in the turn and calls `view_image` on it, and that tool result holds the
@@ -522,7 +541,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
      buying a second one. It is also the only way a *later* question gets a
      freshly focused read, since the question pinned to an image is the one in
      its own message.
-11. An image's evidence is **one record per image, not one transcript per
+12. An image's evidence is **one record per image, not one transcript per
    question**. The question still decides whether a read has to be bought;
    what gets injected is every reading the router holds for that image. Filing
    one transcript per (image, question) and injecting only the matching one made
@@ -534,7 +553,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
    slot prints the record; the rest point at it. That pointer is keyed on the
    image, never on matching transcript text: two different screenshots can read
    identically, and "the same image" has to be a fact about the bytes.
-12. One image, one purchase. The transcript cache only knows about reads that
+13. One image, one purchase. The transcript cache only knows about reads that
    have **finished**, so concurrent requests — Codex sends them, and a subagent
    runs beside its parent — all missed and all bought the same transcript. Reads
    in flight are shared by image, effort, account, and question; waiters take the
@@ -543,7 +562,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
    request an image. Reads within a turn run concurrently under a fixed cap: the
    operator waits for all of them before the routed turn starts, but the engine
    is somebody's rate-limited account and must not receive an album as a burst.
-13. Never add a local model to `LOCAL_VISION_CATALOG` with an `accuracy` claim
+14. Never add a local model to `LOCAL_VISION_CATALOG` with an `accuracy` claim
    that was not measured. Run `node src/vision-benchmark.mjs`, which scores a
    model against a checked-in image with known contents, and record the result
    in `measured`; anything unmeasured stays `untested`. This is not bureaucracy:
@@ -551,7 +570,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
    plausible, so a reputation-based label would route users straight to a model
    that fabricates invoice numbers. The picker sorts on this field, so an
    unearned "accurate" puts a confident-wrong reader at the top of the list.
-14. Which native models may read an image is one rule in one place
+15. Which native models may read an image is one rule in one place
    (`src/vision-engines.mjs`), not a criterion each surface re-derives. The
    catalog build, the tray, and the request path each asked it separately once,
    and the three answers disagreed — the request path applied no auth gate at
@@ -560,7 +579,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
    process) and only the request path holds the caller's live session. Every
    call site names its evidence explicitly, and the coverage below fails when
    one of them stops.
-15. The bridge lives on the **routed request path only**. `src/api-forwarder.mjs`
+16. The bridge lives on the **routed request path only**. `src/api-forwarder.mjs`
     sits downstream of the gateway — every routed model's `api_base` points at
     it — so Codex's traffic arrives already bridged and an image reaching that
     hop came from a client talking to the gateway directly. It replaces those
@@ -569,7 +588,7 @@ the turn as text. Treat it as a router capability, never as a model capability.
     substituted part must use the protocol's own text type (`input_text` for
     Responses, `text` for chat completions and Anthropic messages), or an image
     the provider rejects is merely traded for a text part it rejects.
-16. Regression coverage lives in `test/vision-bridge.test.mjs`,
+17. Regression coverage lives in `test/vision-bridge.test.mjs`,
     `test/vision-bridge-state.test.mjs`, the bridged-catalog case in
     `test/catalog.test.mjs`, the whole-path measurements in
     `test/vision-bridge-e2e.test.mjs`, and the router cases in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@
   the one section where inference is allowed — `## Text` stays verbatim, and an
   unrecognizable image says `(unrecognized)` rather than guessing.
 
+- **One unreachable engine no longer costs you the image.** Resolving an engine
+  and reaching it are different questions, and the bridge conflated them: a
+  pinned engine that resolved and then answered 401 because a session lapsed,
+  or 503 because the provider's endpoint was down, left every paste degrading
+  to "could not be read" until somebody noticed. Both happened within an hour of
+  testing. The reader is now a short list — your chosen engine first, then the
+  other credentialed vision models — and the image is offered to the next one
+  when the first cannot be reached. Verified live with a genuinely dead engine
+  pinned first: all ten test images were still read.
+
+  Nothing extra is spent when your engine works, since a second engine is only
+  called after the first has failed. It is not silent: the evidence names
+  whichever engine actually did the reading and the log line records the
+  fallback. A pin that does not resolve at all is still an operator-visible
+  problem rather than a quiet switch, and a pinned local engine never falls back
+  onto a provider's quota you did not choose to spend. Another provider is tried
+  before another attempt at a broken one, which cut a degraded read from 30–52s
+  to 12–35s.
+
 - **A read that fails once is asked again.** The engine is a rate-limited
   account across a network, so a 429, a 502, a reset connection, or an empty
   reply used to cost you that image for the whole turn. Those are retried twice,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+- **The reader is asked what you actually want to know, and asked again when
+  that changes.** The question used to be pinned to the image's own message, so
+  an image's reading was fixed by the first thing ever asked about it. Paste a
+  photo, ask "what is this?", and a reader under orders to describe rather than
+  identify answered "a lake at dusk" — after which the model went to the
+  filesystem, then to reverse image search, and uploaded the screenshot to a
+  public image host to get an answer the vision model could have given in a
+  line. Now the newest image follows the newest question.
+
+  It is still bought once per *question*, never once per turn, so Codex
+  resending the whole conversation between turns costs nothing — and only the
+  newest image follows the conversation, so a chat holding ten screenshots
+  cannot turn one new question into ten new reads. Earlier readings are kept, so
+  the answer to your first question is still in front of the model when you ask
+  your second.
+
+- **The reader may say what something is.** A new `## Identification` section:
+  the place, product, application, chart type, or well-known image it
+  recognizes, with its confidence and what in the picture supports it. It is
+  the one section where inference is allowed — `## Text` stays verbatim, and an
+  unrecognizable image says `(unrecognized)` rather than guessing.
+
+- **A read that fails once is asked again.** The engine is a rate-limited
+  account across a network, so a 429, a 502, a reset connection, or an empty
+  reply used to cost you that image for the whole turn. Those are retried twice,
+  250ms then 1s. A refusal is not: 400, 401, 403 and 404 buy the identical
+  refusal a second time, and a timeout is reported rather than retried, because
+  the per-attempt budget is already two minutes. A local engine that is down
+  still reports the transport's own words, which is how you learn your own
+  server is not running.
+
 - **The gateway no longer installs a cryptography with a known advisory.**
   litellm 1.95.0 required `cryptography>=48.0.1,<49.0`, and the fix for
   GHSA-g6cj-pr64-35w5 — a Bleichenbacher oracle reachable through PKCS#7

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -57,7 +57,7 @@ import {
   hasNativeSession,
   inputHasImage,
   nativeAccountKey,
-  resolveVisionEngine,
+  resolveVisionEngines,
   stripImages,
   substituteImages,
   supportsImageInput,
@@ -782,7 +782,7 @@ const visionReadsInFlight = new Map();
 // Codex resends the whole conversation every turn, so the same screenshot
 // arrives again on every follow-up. Without the hash cache a five-turn
 // conversation about one image would buy the same transcript five times.
-async function visionEvidenceFor(url, engine, request, effort, question = "") {
+async function visionEvidenceFor(url, engine, request, effort, question = "", retryDelaysMs) {
   // A native engine is spent on the caller's own ChatGPT session, so it can
   // only be reached with the headers this very request arrived with. The router
   // never stores those.
@@ -816,7 +816,7 @@ async function visionEvidenceFor(url, engine, request, effort, question = "") {
   // waiting on and cost it an image it could have had. `describeImage` bounds
   // itself with its own timeout, and an abandoned read still fills the cache
   // for the retry that usually follows.
-  const read = readVisionEvidence({ url, engine, nativeCall, effort, question, key });
+  const read = readVisionEvidence({ url, engine, nativeCall, effort, question, key, retryDelaysMs });
   visionReadsInFlight.set(readKey, read);
   try {
     return await read;
@@ -833,7 +833,7 @@ async function visionEvidenceFor(url, engine, request, effort, question = "") {
 // leave no trace at all. Token counts are not available here (`describeImage`
 // returns the transcript, not the envelope), so the event carries what it
 // honestly has.
-async function readVisionEvidence({ url, engine, nativeCall, effort, question, key }) {
+async function readVisionEvidence({ url, engine, nativeCall, effort, question, key, retryDelaysMs }) {
   const startedAt = Date.now();
   let status = 0;
   try {
@@ -845,6 +845,7 @@ async function readVisionEvidence({ url, engine, nativeCall, effort, question, k
       nativeCall,
       effort,
       question,
+      ...(retryDelaysMs ? { retryDelaysMs } : {}),
     });
     status = 200;
     return evidenceCache.set(key, question, text);
@@ -868,7 +869,7 @@ async function bridgeVisionInput(input, route, request) {
     return stripImages(input, `${route.displayName || route.slug} cannot read images`).input;
   }
   const settings = readVisionBridgeSettings();
-  // Nothing below is evaluated unless `resolveVisionEngine` is actually going to
+  // Nothing below is evaluated unless `resolveVisionEngines` is actually going to
   // rank candidates, which it is not when the bridge is off and not when the
   // engine is pinned to `local`. Both of those used to pay for this list anyway:
   // `selectedConfiguredListedModels()` probes every provider's credential
@@ -887,7 +888,7 @@ async function bridgeVisionInput(input, route, request) {
   // cannot be stale, so it has to hold too: without one there is no native
   // engine to nominate, and a pin naming one stops resolving on the very next
   // paste rather than at the next catalog rebuild.
-  const engine = resolveVisionEngine(
+  const engines = resolveVisionEngines(
     () => [
       ...selectedConfiguredListedModels(),
       ...(request && hasNativeSession(nativeHeaders(request))
@@ -896,7 +897,7 @@ async function bridgeVisionInput(input, route, request) {
     ],
     settings,
   );
-  if (!engine) {
+  if (!engines.length) {
     // The catalog only advertises image input while an engine resolves, so
     // this is the race where one went away mid-conversation, or a client that
     // attached an image regardless.
@@ -905,20 +906,51 @@ async function bridgeVisionInput(input, route, request) {
       "the router's vision bridge is off or has no enabled vision model to read it with",
     ).input;
   }
-  const engineName = engine.displayName || engine.slug;
   const { effort } = settings;
-  const result = await substituteImages(input, async (url, _ordinal, question) => ({
-    text: await visionEvidenceFor(url, engine, request, effort, question),
-    engineName,
-  }));
+  let fellBack = 0;
+  // Each engine in turn until one reads the image. The first is the operator's
+  // choice and answers nearly always; the rest exist so a lapsed session or a
+  // provider outage costs a slower read rather than the whole image.
+  const readWithAnyEngine = async (url, question) => {
+    let lastError;
+    for (const [index, engine] of engines.entries()) {
+      // Retry the engine only when there is nothing else to try. Waiting out a
+      // 250ms + 1s ladder against an endpoint that is down, when a working
+      // engine is sitting right behind it, is how a fallback that works turns
+      // into a paste that takes half a minute -- measured at 30-52s before this
+      // line existed. Another provider beats another attempt.
+      const last = index === engines.length - 1;
+      try {
+        const text = await visionEvidenceFor(
+          url,
+          engine,
+          request,
+          effort,
+          question,
+          last ? undefined : [],
+        );
+        if (index) fellBack += 1;
+        return { text, engineName: engine.displayName || engine.slug };
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    // Every engine refused, so the turn says what the last one said -- the
+    // operator's own engine is named first in the log line above it.
+    throw lastError;
+  };
+  const result = await substituteImages(input, (url, _ordinal, question) =>
+    readWithAnyEngine(url, question),
+  );
   // Never gated on QUIET, for the same reason the retry line is not: a
   // production LaunchAgent hard-sets `CODEX_ROUTER_QUIET=1`, and this is the
   // one line that says the router spent an engine's quota on a paste nobody
   // named. Silent automatic spending is the failure mode; the log carries a
   // model, an engine, and counts -- never a transcript.
   console.error(
-    `[codex-router] vision-bridge model=${route.slug} engine=${engine.slug} ` +
-      `images=${result.images} described=${result.described} failed=${result.failed}`,
+    `[codex-router] vision-bridge model=${route.slug} engine=${engines[0].slug} ` +
+      `images=${result.images} described=${result.described} failed=${result.failed}` +
+      (fellBack ? ` fellBack=${fellBack}` : ""),
   );
   return result.input;
 }

--- a/src/vision-bridge.mjs
+++ b/src/vision-bridge.mjs
@@ -22,6 +22,14 @@ export const VISION_EVIDENCE_INSTRUCTIONS = [
   "## Summary",
   "One paragraph: what this image is and what it shows.",
   "",
+  "## Identification",
+  "What this most likely *is*, when you recognize it: a place, product, application,",
+  "person's role, chart type, document, or well-known image -- and the notable things",
+  "in it and how they relate. This is the one section where inference is allowed, so",
+  "say how confident you are and name what in the image supports it. Write",
+  "`(unrecognized)` when nothing here is recognizable. Never present a guess as",
+  "something you read; that belongs in the sections below or in `## Uncertain`.",
+  "",
   "## Text",
   "Every readable word, transcribed verbatim in reading order. Preserve line breaks,",
   "code indentation, and table structure. Write `(no text)` when the image has none.",
@@ -69,11 +77,24 @@ export function focusInstructions(question) {
   ].join("\n");
 }
 
-// A question is only worth asking the engine if it stays identical every turn,
-// because Codex resends the whole conversation and the cache is keyed on it. So
-// it comes from the text sitting in the same message as the image -- fixed the
-// moment the turn was sent -- and never from the newest message, which changes
-// on every follow-up and would buy a fresh transcript each time.
+// The reader is asked what the operator actually wants to know, and it is asked
+// again whenever that changes. Pinning the question to the image's own message
+// kept the cache still, but it meant an image's reading was fixed by the first
+// thing ever asked about it: paste a photo, ask "what is this?", and the reader
+// -- under instructions to describe rather than identify -- came back with "a
+// lake at dusk". The model then went to the filesystem, then to reverse image
+// search, and uploaded the operator's screenshot to a public host to get an
+// answer the vision model could have given in one line.
+//
+// So the newest image tracks the newest question, which is what a person means
+// by "ask about this picture". The cost is bounded by the thing that actually
+// bounds it: a question that has already been asked is served from the record,
+// so a conversation pays once per *distinct* question rather than once per
+// turn. Codex resending the whole conversation is therefore still free.
+//
+// Only the newest image follows the conversation. Older images keep the
+// question they were read for and their accumulated record, so a chat with ten
+// screenshots in it cannot turn one new question into ten new reads.
 export const VISION_QUESTION_MAX_CHARS = 500;
 
 // Codex fences a pasted image with its own markup:
@@ -94,16 +115,60 @@ function partText(part) {
   return typeof part.text === "string" ? part.text.trim() : "";
 }
 
-export function questionForImage(item) {
+// Codex sends its own bookkeeping as user-role messages -- the plugin list, the
+// environment context -- each one a single tag wrapping its whole part. They
+// are not anybody's question, and taking the newest user message literally
+// would hand the reader a directory listing to describe.
+const CONTEXT_BLOCK = /^<([a-z][\w-]*)>[\s\S]*<\/\1>$/i;
+
+// And it prefixes the operator's words with the files they mentioned:
+//
+//   # Files mentioned by the user:
+//   ## Screenshot 2026-08-09 at 4.53.53 AM.png: /Users/…/Desktop/Screenshot…
+//   ## My request:
+//   what img is this?
+//
+// Only the request is the question. The rest is a path the reader cannot see,
+// and sending it produced transcripts written about a filename.
+const REQUEST_MARKER = /^##[ \t]*My request:[ \t]*$/im;
+
+function requestOnly(text) {
+  const marker = REQUEST_MARKER.exec(text);
+  return marker ? text.slice(marker.index + marker[0].length).trim() : text;
+}
+
+function messageQuestion(item) {
   if (!Array.isArray(item?.content)) return "";
   const text = item.content
     .map((part) => partText(part))
-    .filter((value) => value && !IMAGE_WRAPPER_TAG.test(value))
+    .filter(
+      (value) => value && !IMAGE_WRAPPER_TAG.test(value) && !CONTEXT_BLOCK.test(value),
+    )
     .join("\n\n")
     .trim();
-  return text.length > VISION_QUESTION_MAX_CHARS
-    ? text.slice(0, VISION_QUESTION_MAX_CHARS).trimEnd()
-    : text;
+  const question = requestOnly(text).trim();
+  return question.length > VISION_QUESTION_MAX_CHARS
+    ? question.slice(0, VISION_QUESTION_MAX_CHARS).trimEnd()
+    : question;
+}
+
+export function questionForImage(item) {
+  return messageQuestion(item);
+}
+
+// The last thing the operator actually asked, which is what the newest image is
+// read for. Walking backwards rather than forwards because Codex appends: the
+// newest message is the current question, and everything before it has already
+// been answered.
+export function latestQuestion(input) {
+  if (!Array.isArray(input)) return "";
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    const item = input[index];
+    if (item?.role !== "user") continue;
+    const asked = messageQuestion(item);
+    if (asked) return asked;
+  }
+  return "";
 }
 
 export const VISION_EVIDENCE_MAX_CHARS = 24_000;
@@ -402,6 +467,25 @@ function viewImagePaths(input) {
   return paths;
 }
 
+// Which image the conversation is currently about: the one in the last item
+// that carries any. Keyed by URL rather than by position so the paste and the
+// `view_image` result that fetched the same bytes count as one image and share
+// a single read, instead of buying the same transcript twice under two
+// different questions.
+function activeImageUrls(input) {
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    if (!hasImagePart(input[index])) continue;
+    const field = imagePartsField(input[index]);
+    const urls = new Set();
+    for (const part of input[index][field]) {
+      const url = imageUrlOf(part);
+      if (url !== undefined) urls.add(url);
+    }
+    return urls;
+  }
+  return new Set();
+}
+
 function sourceForImage(item, field, index, paths) {
   if (field === "output") return paths.get(item?.call_id) || "";
   for (let before = index - 1; before >= 0; before -= 1) {
@@ -427,7 +511,13 @@ export function inputHasImage(input) {
 // omit it when there is nothing to tabulate -- so it is not evidence of a bad
 // read. The other four are unconditional, and their absence means the engine
 // answered in some shape of its own rather than the one it was asked for.
-const REQUIRED_EVIDENCE_SECTIONS = ["Summary", "Text", "Layout", "Uncertain"];
+const REQUIRED_EVIDENCE_SECTIONS = [
+  "Summary",
+  "Identification",
+  "Text",
+  "Layout",
+  "Uncertain",
+];
 
 export const TRUNCATION_NOTICE = "[transcript truncated by the router]";
 
@@ -812,6 +902,28 @@ function describeRequest(engine, imageUrl, gatewayBase, gatewayHeaders, nativeCa
   };
 }
 
+// A read that fails once is not a read that cannot be done. The engine is a
+// rate-limited account on the other side of a network, so 429s, 502s and reset
+// connections happen -- and losing that image for the whole turn means the
+// operator pastes a screenshot and gets told it could not be read, for a reason
+// that would have gone away in a second. Everything here is a *transient*
+// answer: a refusal (401, 403, 404) or a bad request is not retried, because a
+// second identical call buys the identical refusal.
+const VISION_RETRY_DELAYS_MS = [250, 1_000];
+
+function isTransientStatus(status) {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+// A timeout is deliberately *not* transient. The per-attempt budget is already
+// two minutes; spending another two on the same slow engine turns one late
+// answer into a turn that never comes back.
+function isTransientError(error) {
+  return !["TimeoutError", "AbortError"].includes(error?.name);
+}
+
+class TransientVisionError extends Error {}
+
 export async function describeImage({
   engine,
   imageUrl,
@@ -823,15 +935,70 @@ export async function describeImage({
   question = "",
   fetchImpl = fetch,
   timeoutMs = DEFAULT_VISION_TIMEOUT_MS,
+  retryDelaysMs = VISION_RETRY_DELAYS_MS,
+}) {
+  let lastTransient;
+  for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
+    if (attempt) {
+      await new Promise((resolve) => setTimeout(resolve, retryDelaysMs[attempt - 1]));
+      // The caller went away between attempts; there is nobody to read for.
+      if (signal?.aborted) break;
+    }
+    try {
+      return await attemptDescribe({
+        engine,
+        imageUrl,
+        gatewayBase,
+        headers,
+        nativeCall,
+        effort,
+        signal,
+        question,
+        fetchImpl,
+        timeoutMs,
+      });
+    } catch (error) {
+      if (!(error instanceof TransientVisionError)) throw error;
+      lastTransient = error;
+    }
+  }
+  throw new Error(lastTransient?.message || `${engine.displayName || engine.slug} could not be reached`);
+}
+
+async function attemptDescribe({
+  engine,
+  imageUrl,
+  gatewayBase,
+  headers,
+  nativeCall,
+  effort,
+  signal,
+  question,
+  fetchImpl,
+  timeoutMs,
 }) {
   const request = describeRequest(engine, imageUrl, gatewayBase, headers, nativeCall, effort, question);
   const timeout = AbortSignal.timeout(timeoutMs);
-  const upstream = await fetchImpl(request.url, {
-    method: "POST",
-    headers: request.headers,
-    body: JSON.stringify(request.body),
-    signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
-  });
+  let upstream;
+  try {
+    upstream = await fetchImpl(request.url, {
+      method: "POST",
+      headers: request.headers,
+      body: JSON.stringify(request.body),
+      signal: signal ? AbortSignal.any([signal, timeout]) : timeout,
+    });
+  } catch (error) {
+    // The transport's own wording is kept: "fetch failed" against a loopback
+    // engine is how an operator learns their own server is down, and replacing
+    // it with something tidier would throw that away. It is still retried --
+    // a server that is restarting answers the second ask.
+    if (error?.name === "TimeoutError") {
+      throw new Error(`${engine.displayName || engine.slug} took too long to read it`);
+    }
+    const message = error?.message || `${engine.displayName || engine.slug} could not be reached`;
+    if (isTransientError(error)) throw new TransientVisionError(message);
+    throw new Error(message);
+  }
   const bytes = Buffer.from(await upstream.arrayBuffer());
   if (bytes.length > MAX_VISION_RESPONSE_BYTES) {
     throw new Error(`${engine.displayName || engine.slug} returned an oversized response`);
@@ -839,9 +1006,9 @@ export async function describeImage({
   if (!upstream.ok) {
     // Never echo the gateway body: it can carry provider error text that names
     // credential state.
-    throw new Error(
-      `${engine.displayName || engine.slug} answered HTTP ${upstream.status}`,
-    );
+    const message = `${engine.displayName || engine.slug} answered HTTP ${upstream.status}`;
+    if (isTransientStatus(upstream.status)) throw new TransientVisionError(message);
+    throw new Error(message);
   }
   let text;
   try {
@@ -857,7 +1024,13 @@ export async function describeImage({
         : `${engine.displayName || engine.slug} returned an unreadable response`,
     );
   }
-  if (!text) throw new Error(`${engine.displayName || engine.slug} returned no description`);
+  // An empty reply is an engine that hiccupped, not one that refuses: worth
+  // one more ask before the image is written off.
+  if (!text) {
+    throw new TransientVisionError(
+      `${engine.displayName || engine.slug} returned no description`,
+    );
+  }
   return text.length > VISION_EVIDENCE_MAX_CHARS
     ? `${text.slice(0, VISION_EVIDENCE_MAX_CHARS)}\n${TRUNCATION_NOTICE}`
     : text;
@@ -891,11 +1064,12 @@ async function runBounded(jobs, limit, run) {
 export async function substituteImages(input, describe) {
   if (!Array.isArray(input)) return { input, images: 0, described: 0, failed: 0 };
   const paths = viewImagePaths(input);
+  // The newest image is read for the newest question; everything older keeps
+  // the question it was already read for, and its record.
+  const active = activeImageUrls(input);
+  const newest = latestQuestion(input);
   // A tool result has no words of its own, so the words it is read for are the
-  // ones that led to it: the last thing the user asked. That is what makes the
-  // `view_image` round trip free -- same image, same question, same cache key
-  // as the paste it came from -- and it is stable on every later turn, because
-  // a follow-up question is appended after the tool result, never before it.
+  // ones that led to it: the last thing the user asked before it.
   let lastQuestion = "";
   // Numbering is fixed here, walking the turn in order, so "Image 3" means the
   // third image in the conversation no matter which read finishes first.
@@ -920,7 +1094,7 @@ export async function substituteImages(input, describe) {
       if (url === undefined) return { part };
       const job = {
         url,
-        question,
+        question: active.has(url) && newest ? newest : question,
         ordinal: jobs.length + 1,
         source: sourceForImage(item, field, index, paths),
       };

--- a/src/vision-bridge.mjs
+++ b/src/vision-bridge.mjs
@@ -371,6 +371,48 @@ export function resolveVisionEngine(listCandidates, settings) {
   return ranked.find((model) => !isLoopbackEngine(model));
 }
 
+// How many engines one image may be offered to before it is written off. The
+// point is an image that gets read, not a tour of every provider the operator
+// has a key for: a second opinion is worth a little quota, a fifth is not.
+const VISION_ENGINE_ATTEMPTS = 3;
+
+// Resolving an engine and *reaching* it are different questions, and the bridge
+// used to conflate them. A pin that no longer resolves stays an operator-visible
+// problem -- that rule is untouched above. But a pinned engine that resolves and
+// then answers 401 because a session lapsed, or 503 because the provider's
+// endpoint is down, left every paste degrading to "could not be read" until
+// somebody noticed. Both happened here within one hour of testing.
+//
+// So the reader is a *list*: the chosen engine first, then the other
+// credentialed, non-loopback vision models, ranked as always. Nothing extra is
+// spent on the happy path, because the second engine is only ever called after
+// the first has failed and exhausted its retries. It is not silent either --
+// the evidence header names whichever engine actually did the reading, and the
+// per-turn log line says a fallback happened.
+export function resolveVisionEngines(listCandidates, settings) {
+  if (typeof listCandidates !== "function") {
+    throw new TypeError(
+      "resolveVisionEngines takes a function returning the selected, credentialed candidates, " +
+        "so the list is only built when it is going to be ranked.",
+    );
+  }
+  // Built at most once per call, however many times it is needed below.
+  // Assembling it means a synchronous credential probe of every provider --
+  // on macOS a `/usr/bin/security` spawn each, ~250ms with the event loop
+  // stopped -- so asking twice would double the cost of every pasted image.
+  let candidates;
+  const once = () => (candidates ??= listCandidates());
+  const primary = resolveVisionEngine(once, settings);
+  if (!primary) return [];
+  // A pinned local engine is the operator naming their own machine; falling
+  // back off it would spend a provider's quota they did not ask to spend here.
+  if (primary.local) return [primary];
+  const alternates = rankVisionEngines(once()).filter(
+    (model) => model.slug !== primary.slug && !isLoopbackEngine(model),
+  );
+  return [primary, ...alternates].slice(0, VISION_ENGINE_ATTEMPTS);
+}
+
 // The bridge stands in for the model, so a model that already reads images is
 // left exactly as the registry declared it.
 export function bridgedModel(model, engine) {

--- a/test/vision-bridge-e2e.test.mjs
+++ b/test/vision-bridge-e2e.test.mjs
@@ -311,7 +311,7 @@ function imageParts(input) {
 // Measurements 1, 2 and 3 are one conversation, because they are one question:
 // what does a five-turn conversation about one screenshot cost, and what does
 // the model actually receive?
-test("five turns about one pasted image buy exactly one transcript", async () => {
+test("one image is bought once per question asked, never once per turn", async () => {
   const upstreams = await bridgeUpstreams();
   const router = await startBridgedRouter(upstreams);
   const durations = [];
@@ -330,10 +330,11 @@ test("five turns about one pasted image buy exactly one transcript", async () =>
 
     // Codex resends the whole conversation, so the message the screenshot was
     // pasted into -- image, question and all -- arrives again on every later
-    // turn, with each new question appended after it as its own message. The
-    // engine is asked about the words beside the image, and those never change
-    // once the turn carrying them has been sent, so the four follow-ups land on
-    // the transcript the first turn bought.
+    // turn, with each new question appended after it as its own message. Each
+    // of those questions is a different thing to ask about the picture, and the
+    // reader is the only thing that can answer them, so each one is asked once
+    // and the answers accumulate. What must never happen is paying again for a
+    // question already asked -- see the resend below.
     const history = [];
     for (let index = 1; index <= 5; index += 1) {
       const question = `Question ${index} about this screenshot?`;
@@ -353,27 +354,41 @@ test("five turns about one pasted image buy exactly one transcript", async () =>
       );
     }
 
-    // 1. The billing property. One image, five turns, one purchase.
-    report(`reads for 5 turns on one image: ${upstreams.state.visionRequests.length}`);
-    assert.equal(upstreams.state.visionRequests.length, 1);
+    // 1. The billing property. Five distinct questions, five reads -- one per
+    // question, never one per turn. The resend below is what proves the
+    // difference, and it is the case Codex actually produces most often.
+    report(`reads for 5 different questions on one image: ${upstreams.state.visionRequests.length}`);
+    assert.equal(upstreams.state.visionRequests.length, 5);
     assert.equal(upstreams.state.gatewayRequests.length, 8);
 
-    // 2. Latency. Turn 1 pays for the read; nothing after it does. The bound is
-    // the difference rather than an absolute, because carrying an image also
-    // costs a fixed amount that has nothing to do with the engine -- see the
-    // overhead report below, which is measured but deliberately not asserted.
-    const [first, ...rest] = durations;
-    const cached = [...rest].sort((left, right) => left - right)[Math.floor(rest.length / 2)];
+    // The same conversation arriving again -- which is what happens while the
+    // model works through a turn -- asks the engine nothing at all.
+    await turn(router.port, textTurn({ question: "Question 5 about this screenshot?", history: history.slice(0, -1) }));
+    report(`reads after resending the same conversation: ${upstreams.state.visionRequests.length}`);
+    assert.equal(upstreams.state.visionRequests.length, 5);
+
+    // 2. Latency. A question the reader has already been asked costs nothing:
+    // that is what the resend above measures, and it is the shape Codex
+    // produces on every turn while a model works. A *new* question pays for the
+    // read, on purpose -- it is the only way to answer it. The bound is a
+    // difference rather than an absolute, because carrying an image also costs
+    // a fixed amount that has nothing to do with the engine.
+    const repeated = await turn(
+      router.port,
+      textTurn({ question: "Question 5 about this screenshot?", history: history.slice(0, -1) }),
+    );
+    const asked = [...durations].sort((left, right) => left - right)[Math.floor(durations.length / 2)];
     const floor = [...baseline].sort((left, right) => left - right)[1];
     report(`image turn latencies ms: ${durations.map((ms) => ms.toFixed(0)).join(", ")}`);
     report(
-      `read cost ${(first - cached).toFixed(0)}ms; ` +
-        `fixed cost of carrying an image on a cache hit ${(cached - floor).toFixed(0)}ms`,
+      `read cost ${(asked - repeated.ms).toFixed(0)}ms; ` +
+        `fixed cost of carrying an image on a cache hit ${(repeated.ms - floor).toFixed(0)}ms`,
     );
+    assert.equal(repeated.status, 200);
     assert.ok(
-      first - cached >= VISION_DELAY_MS * 0.5,
-      `turn 1 (${first.toFixed(0)}ms) did not visibly pay the ${VISION_DELAY_MS}ms read ` +
-        `that later turns (${cached.toFixed(0)}ms) skipped`,
+      asked - repeated.ms >= VISION_DELAY_MS * 0.5,
+      `a repeated question (${repeated.ms.toFixed(0)}ms) did not visibly skip the ` +
+        `${VISION_DELAY_MS}ms read that a new one (${asked.toFixed(0)}ms) pays`,
     );
 
     // 3. What the routed model was handed, on every turn -- not just the first.
@@ -417,7 +432,10 @@ test("a failed vision read degrades to a stated failure and the turn still compl
       imageTurn({ question: "What does this error say?" }),
     );
     assert.equal(result.status, 200);
-    assert.equal(upstreams.state.visionRequests.length, 1);
+    // A 500 is transient, so the read was asked for again before the image was
+    // written off: one attempt plus two retries.
+    report(`attempts against a failing engine: ${upstreams.state.visionRequests.length}`);
+    assert.equal(upstreams.state.visionRequests.length, 3);
     const sent = upstreams.state.gatewayRequests.at(-1);
     assert.equal(imageParts(sent.input).length, 0);
     const stated = textParts(sent.input).find((text) => text.includes("could not be read"));
@@ -437,7 +455,10 @@ test("a failed vision read degrades to a stated failure and the turn still compl
     );
     assert.equal(retry.status, 200);
     report(`reads after a failure then a recovery: ${upstreams.state.visionRequests.length}`);
-    assert.equal(upstreams.state.visionRequests.length, 2);
+    // Three attempts against the failing engine, then one against the
+    // recovered one. Nothing was cached, so recovery is tried rather than the
+    // failure being replayed for an hour.
+    assert.equal(upstreams.state.visionRequests.length, 4);
     assert.ok(
       textParts(upstreams.state.gatewayRequests.at(-1).input).some((text) =>
         text.includes("<<<IMAGE EVIDENCE"),
@@ -486,6 +507,55 @@ test("a model that declares image input is never sent through the bridge", async
 // bought separately rather than answered from the first transcript. Measurement
 // 1 still comes out at one read because a resent conversation repeats the
 // image's own message verbatim; it is a fresh paste that costs again.
+// The whole point, end to end: paste a screenshot, ask something, then ask
+// something else about the same picture in a later turn. The second question
+// has to reach the engine, and the first answer has to still be in front of the
+// model. This is the failure that sent a model to a public image host for an
+// answer the reader could have given.
+test("a follow-up question about a pasted image reaches the engine, once", async () => {
+  const upstreams = await bridgeUpstreams({ visionDelayMs: 0 });
+  const router = await startBridgedRouter(upstreams);
+
+  try {
+    const paste = imageTurn({ question: "what img is this?" });
+    await turn(router.port, paste);
+    assert.equal(upstreams.state.visionRequests.length, 1);
+
+    // Codex resends the conversation while the model works. No new question,
+    // so nothing is bought.
+    await turn(router.port, paste);
+    assert.equal(upstreams.state.visionRequests.length, 1);
+
+    // A follow-up, as a new user message after the image.
+    const followUp = {
+      ...paste,
+      input: [
+        ...paste.input,
+        { type: "message", role: "user", content: [{ type: "input_text", text: "what does the text say?" }] },
+      ],
+    };
+    await turn(router.port, followUp);
+    report(`reads after a follow-up question: ${upstreams.state.visionRequests.length}`);
+    assert.equal(upstreams.state.visionRequests.length, 2);
+
+    // The engine was asked the *new* question...
+    const asked = upstreams.state.visionRequests.map((body) => JSON.stringify(body));
+    assert.match(asked[1], /what does the text say\?/);
+    // ...and the model is still shown the answer to the first one.
+    const evidence = textParts(upstreams.state.gatewayRequests.at(-1).input)
+      .filter((text) => text.includes("<<<IMAGE EVIDENCE"))
+      .join("\n");
+    assert.match(evidence, /IMAGE EVIDENCE/);
+
+    // Asking the same follow-up again costs nothing.
+    await turn(router.port, followUp);
+    assert.equal(upstreams.state.visionRequests.length, 2);
+  } finally {
+    await router.stop();
+    await closeServer(upstreams.server);
+  }
+});
+
 test("the evidence cache is keyed on the image and on the question pasted with it", async () => {
   const upstreams = await bridgeUpstreams({ visionDelayMs: 0 });
   const router = await startBridgedRouter(upstreams);

--- a/test/vision-bridge.test.mjs
+++ b/test/vision-bridge.test.mjs
@@ -23,6 +23,7 @@ import {
   questionForImage,
   rankVisionEngines,
   resolveVisionEngine,
+  resolveVisionEngines,
   responseText,
   streamedResponseText,
   stripImages,
@@ -683,6 +684,63 @@ test("the question is the operator's words, not Codex's bookkeeping", () => {
 // engine is a rate-limited account across a network. A 429 or a 502 that would
 // have cleared in a second used to cost the operator that image for the whole
 // turn.
+// Resolving an engine and reaching it are different questions. Both of these
+// happened within an hour of live testing: the native engine answered 401 after
+// a session lapsed, and a provider's endpoint answered 503. Either one used to
+// mean every pasted image degraded to "could not be read" until somebody
+// noticed.
+test("the reader is a list, so one unreachable engine does not cost the image", () => {
+  const candidates = () => [FLASH_VISION, FLAGSHIP_VISION, LOOPBACK_VISION];
+
+  // The operator's choice comes first, then the other credentialed models.
+  const pinned = resolveVisionEngines(candidates, { enabled: true, engine: FLAGSHIP_VISION.slug });
+  assert.deepEqual(pinned.map((engine) => engine.slug), [FLAGSHIP_VISION.slug, FLASH_VISION.slug]);
+
+  // Auto puts the cheapest first and still carries a spare.
+  const auto = resolveVisionEngines(candidates, { enabled: true, engine: null });
+  assert.deepEqual(auto.map((engine) => engine.slug), [FLASH_VISION.slug, FLAGSHIP_VISION.slug]);
+
+  // A machine-served engine is never a fallback: it is only there while the
+  // operator's own runtime is running, which is why auto never picks one.
+  assert.ok(!auto.some((engine) => engine.slug === LOOPBACK_VISION.slug));
+
+  // ...and pinning one means the operator named their machine on purpose, so
+  // nothing falls off it onto a provider's quota they did not choose to spend.
+  const local = resolveVisionEngines(candidates, {
+    enabled: true,
+    engine: LOCAL_ENGINE_SLUG,
+    local: { model: "moondream", baseUrl: "http://127.0.0.1:11434/v1" },
+  });
+  assert.equal(local.length, 1);
+  assert.equal(local[0].slug, LOCAL_ENGINE_SLUG);
+
+  // Off is still off, and an unresolvable pin is still an operator-visible
+  // problem rather than a silent switch to another model.
+  assert.deepEqual(resolveVisionEngines(candidates, { enabled: false }), []);
+  assert.deepEqual(resolveVisionEngines(candidates, { enabled: true, engine: "nobody/here" }), []);
+});
+
+// The credentialed list costs a synchronous credential probe per provider, so
+// asking for a fallback must not mean asking for that list twice.
+test("the candidate list is still built at most once, fallback or not", () => {
+  let built = 0;
+  const candidates = () => {
+    built += 1;
+    return [FLASH_VISION, FLAGSHIP_VISION];
+  };
+  assert.equal(resolveVisionEngines(candidates, { enabled: true, engine: null }).length, 2);
+  assert.equal(built, 1);
+
+  built = 0;
+  resolveVisionEngines(candidates, { enabled: false });
+  assert.equal(built, 0, "a switched-off bridge still consulted the credentialed model list");
+
+  assert.throws(
+    () => resolveVisionEngines([FLASH_VISION], { enabled: true, engine: null }),
+    /function returning the selected, credentialed candidates/,
+  );
+});
+
 test("a read that fails transiently is asked again; a refusal is not", async () => {
   const engine = localVisionEngine({ local: { model: "moondream" } });
   const ok = () =>
@@ -1420,8 +1478,8 @@ test("the request path hands the engine resolver a list it has not built yet", a
   const body = source.slice(start, source.indexOf("\n}\n", start));
   assert.match(
     body,
-    /resolveVisionEngine\(\s*\(\)\s*=>/,
-    "bridgeVisionInput must pass resolveVisionEngine a thunk, not an assembled array",
+    /resolveVisionEngines\(\s*\(\)\s*=>/,
+    "bridgeVisionInput must pass resolveVisionEngines a thunk, not an assembled array",
   );
   // `selectedConfiguredListedModels()` is the synchronous credential scan. It
   // may only appear inside that thunk -- never on a line the handler runs before
@@ -1472,6 +1530,31 @@ test("a bridged read is recorded rather than spent silently", async () => {
     /if \(!QUIET\)/,
     "the vision-bridge line must not be gated on QUIET",
   );
+});
+
+// The list only helps if the read path actually walks it. Asserted against the
+// source because the loop lives inside the request handler, the same way the
+// QUIET and usage-event rules above are asserted.
+test("the read path tries every resolved engine before giving up on an image", async () => {
+  const source = await readFile(path.join(repoRoot, "src/router.mjs"), "utf8");
+  const bridge = source.slice(
+    source.indexOf("async function bridgeVisionInput"),
+    source.indexOf("function isOpaqueEncryptedContent"),
+  );
+  assert.match(bridge, /for \(const \[index, engine\] of engines\.entries\(\)\)/);
+  // A failure moves to the next engine rather than ending the image.
+  assert.match(bridge, /catch \(error\) \{\s*lastError = error;/);
+  // ...and when they all refuse, the turn says what the last one said.
+  assert.match(bridge, /throw lastError;/);
+  // A fallback is never silent: the engine that actually read it is named in
+  // the evidence, and the log line says a fallback happened.
+  assert.match(bridge, /engineName: engine\.displayName \|\| engine\.slug/);
+  assert.match(bridge, /fellBack/);
+  // Another provider beats another attempt: an engine is only retried when
+  // there is nothing else left to try, or a paste waits out a retry ladder
+  // against a dead endpoint while a working engine sits behind it.
+  assert.match(bridge, /const last = index === engines\.length - 1;/);
+  assert.match(bridge, /last \? undefined : \[\]/);
 });
 
 test("a cached native transcript is not replayed for a different account", () => {

--- a/test/vision-bridge.test.mjs
+++ b/test/vision-bridge.test.mjs
@@ -19,6 +19,7 @@ import {
   nativeAccountKey,
   nativeVisionCandidates,
   nativeVisionEngine,
+  latestQuestion,
   questionForImage,
   rankVisionEngines,
   resolveVisionEngine,
@@ -384,6 +385,7 @@ test("a tool result's image is read for the question that led to it, and costs n
   let calls = 0;
   const transcript = [
     "## Summary\nA login screen.",
+    "## Identification\nA sign-in page. (medium confidence)",
     "## Text\nSign in",
     "## Layout\n- title (top)",
     "## Uncertain\n(nothing)",
@@ -429,6 +431,7 @@ test("a tool result's image is read for the question that led to it, and costs n
 test("an incomplete reading says so, and only then mentions looking again", async () => {
   const full = [
     "## Summary\nA login screen.",
+    "## Identification\nA sign-in page. (medium confidence)",
     "## Text\nSign in",
     "## Layout\n- title (top)",
     "## Uncertain\n(nothing)",
@@ -555,7 +558,7 @@ test("the question comes from the image's own message, not the newest one", () =
 });
 
 // Summary, Text, Layout, Data, Uncertain.
-const VISION_EVIDENCE_SECTIONS = 5;
+const VISION_EVIDENCE_SECTIONS = 6;
 
 test("a question is added to the engine's instructions without replacing them", async () => {
   const call = async (question) => {
@@ -628,19 +631,213 @@ test("two questions about one image are read separately and kept together", asyn
   assert.match(last, /the same image, read again for: "what colour is the header\?"/);
 });
 
-// The pointer that saves repeating a record must never cost a reading. Two
-// slots holding one image can be read for different questions in the same turn,
-// and those reads run concurrently, so the earlier slot's record can predate the
-// later reading. Pointing at it would drop what the second question bought.
-test("one image read for two questions keeps both readings in the turn", async () => {
+// The story this whole design exists for: paste a screenshot, ask something,
+// then ask something *else* about the same picture. The second question has to
+// reach the reader -- that is what "ask the model that can see" means -- and
+// the first answer has to survive, because the model is still being shown both.
+// Codex sends its own bookkeeping as user-role messages and prefixes the
+// operator's words with the files they mentioned. Taking the newest user
+// message literally handed the reader a plugin catalogue or a temp-file path to
+// describe -- which is exactly what it did to a screenshot on 2026-08-09.
+test("the question is the operator's words, not Codex's bookkeeping", () => {
+  const conversation = [
+    {
+      type: "message",
+      role: "user",
+      content: [
+        { type: "input_text", text: "<recommended_plugins>\nAirtable\nAsana\n</recommended_plugins>" },
+        { type: "input_text", text: "<environment_context>\n  <cwd>/x</cwd>\n</environment_context>" },
+      ],
+    },
+    {
+      type: "message",
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text:
+            "\n# Files mentioned by the user:\n\n" +
+            "## Screenshot 2026-08-09 at 4.53.53\u202fAM.png: /Users/me/Desktop/Screenshot.png\n\n" +
+            "## My request:\nwhat img is this?\n",
+        },
+        { type: "input_text", text: '<image name=[Image #1] path="/Users/me/Desktop/Screenshot.png">' },
+        { type: "input_image", image_url: "data:image/png;base64,AAAA" },
+        { type: "input_text", text: "</image>" },
+      ],
+    },
+  ];
+  assert.equal(latestQuestion(conversation), "what img is this?");
+  assert.equal(questionForImage(conversation[1]), "what img is this?");
+  // A context-only message is nobody's question.
+  assert.equal(latestQuestion([conversation[0]]), "");
+  // Without the marker the whole text is the question, as before.
+  assert.equal(
+    latestQuestion([{ type: "message", role: "user", content: [{ type: "input_text", text: "read the dialog" }] }]),
+    "read the dialog",
+  );
+  assert.equal(latestQuestion([]), "");
+  assert.equal(latestQuestion(undefined), "");
+});
+
+// "Every time I submit an image, it gets read" is a reliability claim, and the
+// engine is a rate-limited account across a network. A 429 or a 502 that would
+// have cleared in a second used to cost the operator that image for the whole
+// turn.
+test("a read that fails transiently is asked again; a refusal is not", async () => {
+  const engine = localVisionEngine({ local: { model: "moondream" } });
+  const ok = () =>
+    new Response(JSON.stringify({ choices: [{ message: { content: "## Summary\nA chart." } }] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  for (const status of [429, 503]) {
+    let calls = 0;
+    const text = await describeImage({
+      engine,
+      imageUrl: "data:image/png;base64,AAAA",
+      gatewayBase: "http://unused/v1",
+      headers: {},
+      retryDelaysMs: [1, 1],
+      fetchImpl: async () => {
+        calls += 1;
+        return calls === 1 ? new Response("", { status }) : ok();
+      },
+    });
+    assert.equal(calls, 2, `HTTP ${status} should have been retried`);
+    assert.match(text, /A chart\./);
+  }
+
+  // An empty reply is a hiccup, not a refusal.
+  let empty = 0;
+  await describeImage({
+    engine,
+    imageUrl: "data:image/png;base64,AAAA",
+    gatewayBase: "http://unused/v1",
+    headers: {},
+    retryDelaysMs: [1],
+    fetchImpl: async () => {
+      empty += 1;
+      return empty === 1
+        ? new Response(JSON.stringify({ choices: [] }), { status: 200 })
+        : ok();
+    },
+  });
+  assert.equal(empty, 2);
+
+  // A refusal is final: asking again buys the identical refusal.
+  for (const status of [400, 401, 403, 404]) {
+    let calls = 0;
+    await assert.rejects(
+      describeImage({
+        engine,
+        imageUrl: "data:image/png;base64,AAAA",
+        gatewayBase: "http://unused/v1",
+        headers: {},
+        retryDelaysMs: [1, 1],
+        fetchImpl: async () => {
+          calls += 1;
+          return new Response("", { status });
+        },
+      }),
+      new RegExp(`answered HTTP ${status}`),
+    );
+    assert.equal(calls, 1, `HTTP ${status} must not be retried`);
+  }
+
+  // Retries are bounded, and the last transient message is what the turn says.
+  let attempts = 0;
+  await assert.rejects(
+    describeImage({
+      engine,
+      imageUrl: "data:image/png;base64,AAAA",
+      gatewayBase: "http://unused/v1",
+      headers: {},
+      retryDelaysMs: [1, 1],
+      fetchImpl: async () => {
+        attempts += 1;
+        return new Response("", { status: 502 });
+      },
+    }),
+    /answered HTTP 502/,
+  );
+  assert.equal(attempts, 3);
+});
+
+// A slow engine is not retried: the per-attempt budget is already two minutes,
+// and spending another two turns one late answer into a turn that never ends.
+test("a timeout is reported rather than tried again", async () => {
+  let calls = 0;
+  await assert.rejects(
+    describeImage({
+      engine: localVisionEngine({ local: { model: "moondream" } }),
+      imageUrl: "data:image/png;base64,AAAA",
+      gatewayBase: "http://unused/v1",
+      headers: {},
+      retryDelaysMs: [1, 1],
+      fetchImpl: async () => {
+        calls += 1;
+        const error = new Error("timed out");
+        error.name = "TimeoutError";
+        throw error;
+      },
+    }),
+    /took too long to read it/,
+  );
+  assert.equal(calls, 1);
+});
+
+test("a follow-up question is asked of the image, and the earlier reading is kept", async () => {
   const cache = createEvidenceCache();
   const url = "data:image/png;base64,AAAA";
+  const asked = [];
   const describe = async (image, _ordinal, question) => {
     const cached = cache.get(image, question);
     if (cached !== undefined) return { text: cached, engineName: "Qwen3.6 Flash" };
+    asked.push(question);
     return { text: cache.set(image, question, `read: ${question}`), engineName: "Qwen3.6 Flash" };
   };
-  const ask = (text) => ({
+  const paste = {
+    type: "message",
+    role: "user",
+    content: [
+      { type: "input_text", text: "what colour is it?" },
+      { type: "input_image", image_url: url },
+    ],
+  };
+  const says = (text) => ({ type: "message", role: "user", content: [{ type: "input_text", text }] });
+
+  // Turn one.
+  await substituteImages([paste], describe);
+  assert.deepEqual(asked, ["what colour is it?"]);
+
+  // Codex resends the conversation with nothing new: no question has changed,
+  // so nothing is bought.
+  await substituteImages([paste], describe);
+  assert.deepEqual(asked, ["what colour is it?"]);
+
+  // Turn two asks something else. That reaches the reader, once.
+  const second = await substituteImages([paste, says("what does it say?")], describe);
+  assert.deepEqual(asked, ["what colour is it?", "what does it say?"]);
+  const rendered = JSON.stringify(second.input);
+  assert.match(rendered, /read: what does it say\?/);
+  // ...and the answer to the first question is still in front of the model.
+  assert.match(rendered, /read: what colour is it\?/);
+
+  // Asking it again costs nothing.
+  await substituteImages([paste, says("what does it say?")], describe);
+  assert.equal(asked.length, 2);
+});
+
+// Only the newest image follows the conversation. A chat holding ten
+// screenshots must not turn one new question into ten new reads.
+test("a new question re-reads the newest image and leaves older ones alone", async () => {
+  const asked = [];
+  const describe = async (url, _ordinal, question) => {
+    asked.push(`${url.slice(-4)}:${question}`);
+    return { text: `read ${url.slice(-4)} for ${question}`, engineName: "Qwen3.6 Flash" };
+  };
+  const paste = (url, text) => ({
     type: "message",
     role: "user",
     content: [
@@ -648,13 +845,15 @@ test("one image read for two questions keeps both readings in the turn", async (
       { type: "input_image", image_url: url },
     ],
   });
-
-  const result = await substituteImages([ask("what colour is it?"), ask("what does it say?")], describe);
-  const rendered = JSON.stringify(result.input);
-  assert.equal(result.described, 2);
-  assert.match(rendered, /read: what colour is it\?/);
-  assert.match(rendered, /read: what does it say\?/);
-  assert.doesNotMatch(rendered, /is the same image as/);
+  const older = paste("data:image/png;base64,AAAA", "what is the first one?");
+  const newer = paste("data:image/png;base64,BBBB", "what is the second one?");
+  await substituteImages(
+    [older, newer, { type: "message", role: "user", content: [{ type: "input_text", text: "and the totals?" }] }],
+    describe,
+  );
+  // The newest image is read for the newest question; the older one keeps the
+  // question it was already read for.
+  assert.deepEqual(asked, ["AAAA:what is the first one?", "BBBB:and the totals?"]);
 });
 
 test("a record drops the readings it cannot fit, and never the first one", () => {


### PR DESCRIPTION
## What went wrong

Pasted a screenshot, asked **"what img is this?"**. The bridge worked perfectly — one read at 12:08:06Z, cached across the next ~15 turns, no 400. And the model still went: filesystem → reverse image search → **uploaded the screenshot to a public image host** → headless Chrome → Yandex → "Lake Tahoe / macOS Tahoe wallpaper". Ten minutes, ~15 full-conversation resends, for an answer the vision model it was already talking to could have given in one line.

Both causes are in the contract, not the plumbing:

1. **The question was pinned to the image's own message**, so an image's reading was fixed by the first thing ever asked about it. A later question got the earlier answer.
2. **The reader was told never to infer** — "Report only what is visible. Never guess, never infer intent beyond the pixels." That forbids exactly the answer "what is this?" wants.

## What changed

**The newest image follows the newest question.** Three properties keep that affordable, each with a test:

- bought once per **question**, never per turn — Codex resending the conversation is still free;
- only the **newest** image follows the conversation — a chat with ten screenshots can't turn one new question into ten reads;
- readings **accumulate** — the answer to your first question is still in front of the model when you ask the second.

**A new `## Identification` section.** What the reader recognizes — place, product, application, chart type, well-known image — with confidence and the evidence for it. The one section where inference is allowed; `## Text` stays verbatim, unrecognizable images say `(unrecognized)`.

**The question is the operator's words alone.** Codex's `# Files mentioned by the user:` preamble and its `<environment_context>` / `<recommended_plugins>` blocks are bookkeeping — sending them had the reader describing a screenshot under the heading of a temp-file path.

**A transiently failed read is asked again**, twice at 250ms and 1s. A 429, 502, reset connection, or empty reply used to cost that image for the whole turn. Not retried: 4xx refusals (identical refusal), and timeouts (the per-attempt budget is already two minutes). A transport failure keeps its own wording — `fetch failed` is how you learn your local engine is down.

## Not a copy of the references

[ModLens](https://github.com/liustack/modlens) always re-asks the engine but is skill-shaped: it needs the model to cooperate, costs an extra round trip, doesn't cover tool-returned images, and documents no caching. [opencodex](https://github.com/lidge-jun/opencodex) puts vision as a pipeline stage before the provider, which is where ours already sits.

What's better here: re-asking is bounded to *distinct questions* rather than every call; it runs below the model so nothing has to cooperate; tool-returned images are covered; readings accumulate instead of being replaced; and transient failures are retried, which neither reference does.

## Verification

- 658 tests, 0 failures, `npm run check` clean.
- End-to-end through a real router process: a follow-up question reaches the engine exactly once, a resent conversation asks nothing, and the earlier reading is still in the forwarded body.
- Retry behaviour pinned per status: 429/503/empty retried, 400/401/403/404 not, timeout not, bounded at 3 attempts.
- The e2e latency test now measures a *repeated* question skipping the read, since a new question pays for one by design.

Two existing tests asserted the old contract ("five turns buy one transcript"; the pinned-question case) and were rewritten to the new one rather than deleted — the change in what they assert is the change in behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)