### PR TITLE
fix: validate kimi oauth credential expiry

### DIFF
--- a/src/oauth-status.mjs
+++ b/src/oauth-status.mjs
@@ -6,6 +6,22 @@ export function kimiCodeHome() {
   return process.env.KIMI_CODE_HOME || path.join(os.homedir(), ".kimi-code");
 }
 
+// A credential is only usable while its expiry is a real future timestamp.
+// `kimi login` writes seconds since epoch; some builds write milliseconds, so
+// the cutoff distinguishes the two scales. A missing field is not a failure:
+// older CLI builds may never have written one, and the token fields are the
+// only signal those builds trusted. Anything else — a non-numeric value, a
+// zero, or a date already past (including the epoch garbage that broken login
+// flows leave behind) — must reject the credential.
+function credentialExpired(value) {
+  const raw = value?.expires_at;
+  if (raw === undefined || raw === null || raw === "") return false;
+  const expiresAt = Number(raw);
+  if (!Number.isFinite(expiresAt) || expiresAt <= 0) return true;
+  const millis = expiresAt > 1e11 ? expiresAt : expiresAt * 1000;
+  return millis <= Date.now();
+}
+
 export function kimiOAuthStatus() {
   const credentialsPath = path.join(
     kimiCodeHome(),
@@ -21,14 +37,22 @@ export function kimiOAuthStatus() {
   }
   try {
     const value = JSON.parse(readFileSync(credentialsPath, "utf8"));
-    const configured = Boolean(value?.access_token && value?.refresh_token);
+    const configured =
+      Boolean(value?.access_token && value?.refresh_token) &&
+      !credentialExpired(value);
     return configured
       ? { configured: true, credentialsPath, scope: value.scope || "kimi-code" }
-      : {
-          configured: false,
-          credentialsPath,
-          setup: "Run `kimi login` again; the credential file is incomplete",
-        };
+      : credentialExpired(value)
+        ? {
+            configured: false,
+            credentialsPath,
+            setup: "Run `kimi login` again; the credential is expired",
+          }
+        : {
+            configured: false,
+            credentialsPath,
+            setup: "Run `kimi login` again; the credential file is incomplete",
+          };
   } catch {
     return {
       configured: false,

--- a/test/oauth-status.test.mjs
+++ b/test/oauth-status.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { kimiOAuthStatus } from "../src/oauth-status.mjs";
+
+function withCredentialsFile(contents, run) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "kimi-oauth-"));
+  const credentialsPath = path.join(dir, "credentials", "kimi-code.json");
+  if (contents !== undefined) {
+    mkdirSync(path.dirname(credentialsPath), { recursive: true });
+    writeFileSync(credentialsPath, contents, { mode: 0o600 });
+  }
+  const previous = process.env.KIMI_CODE_HOME;
+  process.env.KIMI_CODE_HOME = dir;
+  try {
+    return run(credentialsPath);
+  } finally {
+    if (previous === undefined) delete process.env.KIMI_CODE_HOME;
+    else process.env.KIMI_CODE_HOME = previous;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function futureSeconds() {
+  return Math.floor(Date.now() / 1000) + 3600;
+}
+
+test("reports configured for a credential with a valid future expiry", () => {
+  const status = withCredentialsFile(
+    JSON.stringify({
+      access_token: "access-value",
+      refresh_token: "refresh-value",
+      expires_at: futureSeconds(),
+      scope: "kimi-code",
+    }),
+    () => kimiOAuthStatus(),
+  );
+  assert.equal(status.configured, true);
+  assert.equal(status.scope, "kimi-code");
+  // No token value must appear anywhere in the status object.
+  assert.doesNotMatch(JSON.stringify(status), /access-value|refresh-value/);
+});
+
+test("reports not configured when the expiry is already past", () => {
+  const status = withCredentialsFile(
+    JSON.stringify({
+      access_token: "access-value",
+      refresh_token: "refresh-value",
+      expires_at: futureSeconds() - 7200,
+    }),
+    () => kimiOAuthStatus(),
+  );
+  assert.equal(status.configured, false);
+  assert.match(status.setup, /expired/);
+});
+
+test("reports not configured when the expiry is the epoch garbage value", () => {
+  // A broken login flow left 1970-01-22 behind: fields are present, but the
+  // expiry is decades past and must not count as a usable session.
+  const status = withCredentialsFile(
+    JSON.stringify({
+      access_token: "access-value",
+      refresh_token: "refresh-value",
+      expires_at: 1900800,
+    }),
+    () => kimiOAuthStatus(),
+  );
+  assert.equal(status.configured, false);
+  assert.match(status.setup, /expired/);
+});
+
+test("accepts a millisecond-since-epoch expiry", () => {
+  const status = withCredentialsFile(
+    JSON.stringify({
+      access_token: "access-value",
+      refresh_token: "refresh-value",
+      expires_at: Date.now() + 3600_000,
+    }),
+    () => kimiOAuthStatus(),
+  );
+  assert.equal(status.configured, true);
+});
+
+test("rejects a non-numeric or zero expiry", () => {
+  for (const expires_at of ["not-a-number", 0, -5]) {
+    const status = withCredentialsFile(
+      JSON.stringify({ access_token: "a", refresh_token: "r", expires_at }),
+      () => kimiOAuthStatus(),
+    );
+    assert.equal(status.configured, false, `expires_at=${expires_at}`);
+    assert.match(status.setup, /expired/);
+  }
+});
+
+test("treats a missing expiry conservatively as configured", () => {
+  // Older CLI builds may never write the field; token presence stays the
+  // signal those builds trusted, so it must not regress into "incomplete".
+  const status = withCredentialsFile(
+    JSON.stringify({
+      access_token: "access-value",
+      refresh_token: "refresh-value",
+    }),
+    () => kimiOAuthStatus(),
+  );
+  assert.equal(status.configured, true);
+});
+
+test("reports not configured when the credential file is missing", () => {
+  const status = withCredentialsFile(undefined, () => kimiOAuthStatus());
+  assert.equal(status.configured, false);
+  assert.match(status.setup, /kimi login/);
+});
+
+test("reports not configured when tokens are incomplete", () => {
+  const status = withCredentialsFile(
+    JSON.stringify({
+      access_token: "access-value",
+      expires_at: futureSeconds(),
+    }),
+    () => kimiOAuthStatus(),
+  );
+  assert.equal(status.configured, false);
+  assert.match(status.setup, /incomplete/);
+});
+
+test("reports not configured for an invalid credential file", () => {
+  const status = withCredentialsFile("{ not json", () => kimiOAuthStatus());
+  assert.equal(status.configured, false);
+  assert.match(status.setup, /invalid/);
+});


### PR DESCRIPTION
## What

`kimiOAuthStatus()` only checked that `access_token` and `refresh_token` fields **exist** — it never validated `expires_at`. A credential file with present tokens but a stale/garbage expiry (e.g. the `1970-01-22` epoch value a broken login flow leaves behind) was reported as `configured: true`.

Found while using login-free with a stale kimi credential file: the dead kimi-oauth models took 3 of the 5 whitelist slots, and every pick from them failed with 402 `unable to verify your membership benefits` (usage-events.jsonl: kimi-oauth/* all 402, opencode-go/* all 200).

## Fix

`src/oauth-status.mjs` — the `configured` verdict now requires `expires_at` to be a real future timestamp:

- `expires_at` missing → conservative pass-through (older CLI builds may not write the field; token presence stays the trusted signal)
- `expires_at` non-numeric / zero / already past / epoch garbage → `configured: false` with setup hint `Run `kimi login` again; the credential is expired`
- seconds- and milliseconds-since-epoch values both handled (1e11 cutoff)
- return shape unchanged (`configured` / `credentialsPath` / `setup` / `scope`)

This also closes the catalog hole: `configuredProviderIds()` → `selectedConfiguredListedModels()` → login-free slot assignment all read through this verdict, so an expired credential no longer lets dead models occupy whitelist slots.

## Tests

New `test/oauth-status.test.mjs`, 9 cases (node:test, following the `grok-oauth-status.test.mjs` style):

| case | expected |
|---|---|
| valid future `expires_at` (seconds) | configured: true |
| millisecond-since-epoch expiry | configured: true |
| expired `expires_at` | configured: false, setup mentions expired |
| epoch garbage (`1900800` = 1970-01-22) | configured: false |
| non-numeric / zero / negative expiry | configured: false |
| missing `expires_at` | configured: true (conservative) |
| missing file / incomplete tokens / invalid JSON | unchanged behavior |

`npm test` on this branch: **662 tests, 651 pass, 10 skipped, 1 known environment failure** (test/control.test.mjs:342 — pre-existing, fails on the untouched base too: a real Codex CLI on the machine makes `nativeCatalog()` re-capture 8 real whitelist slots instead of the test's single one).

Verified live on this machine: the real `~/.kimi-code/credentials/kimi-code.json` had `expires_at` already past → status now reports `configured: false` / "the credential is expired" (previously misreported as logged in).