### PR TITLE
fix: exclude unauthenticated providers from login-free slots

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -26,7 +26,7 @@ import {
 } from "./multi-agent-state.mjs";
 import { readHiddenModels } from "./model-picker-state.mjs";
 import { buildNativeAliasAssignments } from "./native-alias.mjs";
-import { selectedConfiguredListedModels } from "./provider-selection.mjs";
+import { selectedConfiguredListedModels, configuredProviderIds } from "./provider-selection.mjs";
 import { assertStateOwnership } from "./state-owner.mjs";
 import { applyVisionBridge, resolveVisionEngine } from "./vision-bridge.mjs";
 import { readVisionBridgeSettings } from "./vision-bridge-state.mjs";
@@ -450,8 +450,19 @@ export function buildMergedCatalog(native, routedModelsList, { includeNative = t
 // models are republished under those slugs with their own names and reasoning
 // levels. Each aliased model keeps a hidden entry under its canonical slug so
 // routing, doctor checks, and existing configs keep resolving it.
+//
+// Only providers with a live credential may take a whitelist slot: the slot is
+// what a signed-out desktop picker offers, and a model whose provider cannot
+// authenticate would occupy it with requests that fail on the first turn. The
+// merged-catalog path filters through `selectedConfiguredListedModels()`; this
+// function keeps the same rule for the login-free path instead of trusting its
+// caller to pre-filter, so no future call site can publish dead slots again.
 export function buildLoginFreeCatalog(native, routedModelsList) {
-  const assignments = buildNativeAliasAssignments(native.models, routedModelsList);
+  const configured = new Set(configuredProviderIds());
+  const usableModels = routedModelsList.filter(
+    (model) => !model.provider || configured.has(model.provider),
+  );
+  const assignments = buildNativeAliasAssignments(native.models, usableModels);
   const aliasedSlugs = new Set(assignments.map(({ model }) => model.slug));
   const aliases = Object.fromEntries(
     assignments.map(({ nativeModel, model }) => [nativeModel.slug, model.slug]),
@@ -462,7 +473,7 @@ export function buildLoginFreeCatalog(native, routedModelsList) {
       slug: nativeModel.slug,
       priority: nativeModel.priority,
     })),
-    ...buildMergedCatalog(native, routedModelsList, { includeNative: false }).map(
+    ...buildMergedCatalog(native, usableModels, { includeNative: false }).map(
       (model) =>
         aliasedSlugs.has(model.slug) ? { ...model, visibility: "hide" } : model,
     ),

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1,4 +1,12 @@
 import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -273,6 +281,88 @@ test("login-free catalog keeps overflow models visible under their own slugs", (
   const bySlug = new Map(models.map((model) => [model.slug, model]));
   assert.equal(bySlug.get("kimi-oauth/kimi-for-coding").visibility, "list");
   assert.equal(bySlug.get("grok-oauth/grok-4.5").visibility, "hide");
+});
+
+function withCredentialEnvironment(kimiHome, run) {
+  const previousKimi = process.env.KIMI_CODE_HOME;
+  const previousGrok = process.env.GROK_AUTH_PATH;
+  const dir = mkdtempSync(path.join(os.tmpdir(), "catalog-login-free-"));
+  if (kimiHome === "unconfigured") {
+    process.env.KIMI_CODE_HOME = path.join(dir, "kimi-home");
+  } else {
+    const credentialsDir = path.join(dir, "kimi-home", "credentials");
+    mkdirSync(credentialsDir, { recursive: true });
+    writeFileSync(
+      path.join(credentialsDir, "kimi-code.json"),
+      JSON.stringify({
+        access_token: "access-value",
+        refresh_token: "refresh-value",
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        scope: "kimi-code",
+      }),
+      { mode: 0o600 },
+    );
+    process.env.KIMI_CODE_HOME = path.join(dir, "kimi-home");
+  }
+  process.env.GROK_AUTH_PATH = path.join(dir, "grok", "auth.json");
+  try {
+    return run();
+  } finally {
+    if (previousKimi === undefined) delete process.env.KIMI_CODE_HOME;
+    else process.env.KIMI_CODE_HOME = previousKimi;
+    if (previousGrok === undefined) delete process.env.GROK_AUTH_PATH;
+    else process.env.GROK_AUTH_PATH = previousGrok;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("login-free catalog does not assign slots to unauthenticated providers", () => {
+  const kimi = {
+    ...grok,
+    slug: "kimi-oauth/k3",
+    provider: "kimi-oauth",
+    displayName: "Kimi K3 (OAuth)",
+    priority: 2,
+    compHash: "kimi-oauth-k3-v1",
+  };
+  withCredentialEnvironment("unconfigured", () => {
+    // The credential file does not exist under this KIMI_CODE_HOME, so
+    // kimi-oauth is not configured; its model must not take a slot.
+    const { models, aliases } = buildLoginFreeCatalog(
+      { models: [template] },
+      [kimi],
+    );
+    assert.deepEqual(aliases, {});
+    assert.deepEqual(models, []);
+  });
+});
+
+test("login-free catalog assigns slots to models of credentialed providers", () => {
+  const kimi = {
+    ...grok,
+    slug: "kimi-oauth/k3",
+    provider: "kimi-oauth",
+    displayName: "Kimi K3 (OAuth)",
+    priority: 2,
+    compHash: "kimi-oauth-k3-v1",
+  };
+  const unauthenticatedGrok = {
+    ...grok,
+    provider: "grok-oauth",
+  };
+  withCredentialEnvironment("configured", () => {
+    // kimi-oauth has a live credential, grok-oauth does not: only the kimi
+    // model may take the whitelist slot.
+    const { models, aliases } = buildLoginFreeCatalog(
+      { models: [template] },
+      [kimi, unauthenticatedGrok],
+    );
+    assert.deepEqual(aliases, { "gpt-5.5": "kimi-oauth/k3" });
+    const bySlug = new Map(models.map((model) => [model.slug, model]));
+    assert.equal(bySlug.get("gpt-5.5").display_name, "Kimi K3 (OAuth)");
+    assert.equal(bySlug.get("gpt-5.5").visibility, "list");
+    assert.equal(bySlug.get("kimi-oauth/k3").visibility, "hide");
+  });
 });
 
 test("effort vocabulary follows the installed codex build's enum history", () => {


### PR DESCRIPTION
## What

Login-free slot assignment could hand whitelist slots to models whose provider has no usable credential. The merged-catalog path filters through `selectedConfiguredListedModels()` (`provider-selection.mjs`), but `buildLoginFreeCatalog()` accepted `routedModelsList` as-is and trusted the caller to pre-filter — so an unauthenticated provider's models could occupy the signed-out picker's allowlisted slugs with requests that fail on the first turn.

Found while using login-free with a stale kimi credential file: the credential file existed with tokens but a long-past `expires_at`, so kimi-oauth was treated as configured; 3 of the 5 whitelist slots went to kimi models that 402'd on every request (usage-events.jsonl: kimi-oauth/* all 402, opencode-go/* all 200), while usable opencode-go models were pushed out.

## Fix

`src/catalog.mjs` — `buildLoginFreeCatalog()` now applies the same configured-provider rule the merged-catalog path uses, at the slot-assignment point itself:

- filters `routedModelsList` to models whose `provider` is in `configuredProviderIds()` before `buildNativeAliasAssignments()` runs
- models without a `provider` field pass through unchanged (keeps the pure-function contract for direct callers/tests)
- the canonical/hidden overflow entries are built from the same filtered list, so an unauthenticated model is neither aliased nor published

The function now owns the rule instead of trusting its caller to pre-filter, so no future call site can publish dead slots again. It composes idempotently with the existing `selectedConfiguredListedModels()` filtering in `main()`.

## Tests

`test/catalog.test.mjs`, 2 new cases following the existing `buildLoginFreeCatalog` style:

| scenario | expected |
|---|---|
| provider has no credential (empty `KIMI_CODE_HOME`) | no slot assigned, `aliases` empty, no models published |
| credentialed provider + unauthenticated provider in one list | only the credentialed model takes the whitelist slot, the other is absent |

Credential state is staged via `KIMI_CODE_HOME`/`GROK_AUTH_PATH` temp dirs so the tests are hermetic.

`npm test`: 655 tests, 644 pass, 10 skipped, 1 known environment failure (test/control.test.mjs:342 — pre-existing, fails on the untouched base too: a real Codex CLI on the machine makes `nativeCatalog()` re-capture 8 real whitelist slots instead of the test's single one). All 30 catalog tests pass, including the two new ones.