### PR TITLE
Meter native turns the backend streams without a content-type

### DIFF
--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -3,6 +3,11 @@ import { StringDecoder } from "node:string_decoder";
 
 const MAX_JSON_CAPTURE_BYTES = 8 * 1024 * 1024;
 
+// An SSE field line, matched against the opening bytes of a body whose
+// content-type header never arrived.
+const SSE_FIELD_LINE = /^(?:event|data):/m;
+const SSE_SNIFF_BYTES = 512;
+
 // Bytes of forwarded request body per prompt token.
 //
 // The familiar rule is four characters per token, which is roughly where plain
@@ -140,13 +145,20 @@ export class ResponseUsageTransform extends Transform {
   // a malformed or non-UTF-8 byte can never be replaced on its way through.
   #pending = Buffer.alloc(0);
   #released = false;
+  #undeclared = false;
 
   // `estimatedInputTokens` arrives only on routed requests large enough that a
   // reported zero cannot be true. Without it this transform observes and
   // forwards the response byte for byte, exactly as it always did.
   constructor(contentType = "", { estimatedInputTokens } = {}) {
     super();
-    this.#eventStream = String(contentType).toLowerCase().includes("text/event-stream");
+    const declared = String(contentType).toLowerCase();
+    this.#eventStream = declared.includes("text/event-stream");
+    // The ChatGPT backend answers /responses with an SSE body and no
+    // content-type header at all, so deciding on the header alone reads every
+    // native turn as a JSON document, fails to parse it, and meters the turn
+    // as zero tokens. When the header says nothing, the first bytes decide.
+    this.#undeclared = !this.#eventStream && !declared.includes("json");
     this.#estimate =
       Number.isInteger(estimatedInputTokens) && estimatedInputTokens > 0
         ? estimatedInputTokens
@@ -154,6 +166,12 @@ export class ResponseUsageTransform extends Transform {
   }
 
   _transform(chunk, _encoding, callback) {
+    if (this.#undeclared && chunk.length) {
+      this.#undeclared = false;
+      this.#eventStream = SSE_FIELD_LINE.test(
+        chunk.subarray(0, SSE_SNIFF_BYTES).toString("utf8"),
+      );
+    }
     if (this.#estimate === undefined) {
       this.#observeOnly(chunk);
       callback();

--- a/test/response-usage.test.mjs
+++ b/test/response-usage.test.mjs
@@ -285,3 +285,72 @@ test("a zero-prompt JSON response is rewritten with the estimate", async () => {
   assert.equal(rewritten.id, "response-test");
   assert.equal(transform.substitutedInputTokens(), 99_000);
 });
+
+test("meters a stream the backend sent without a content-type header", async () => {
+  // The ChatGPT backend answers /responses this way: an SSE body, every
+  // x-codex-* header present, and no content-type at all.
+  const body = [
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hi"}\n\n',
+    'event: response.completed\ndata: {"type":"response.completed","response":{"usage":{"input_tokens":153642,"output_tokens":661,"total_tokens":154303}}}\n\n',
+    "data: [DONE]\n\n",
+  ];
+  const transform = new ResponseUsageTransform("");
+  const output = await passThrough(transform, body.map((part) => Buffer.from(part, "utf8")));
+  assert.equal(output, body.join(""));
+  assert.deepEqual(transform.tokenUsage(), {
+    inputTokens: 153642,
+    outputTokens: 661,
+    totalTokens: 154303,
+  });
+});
+
+test("meters a headerless stream whose first event spans two chunks", async () => {
+  const terminal =
+    'event: response.completed\ndata: {"type":"response.completed","response":{"usage":{"input_tokens":4,"output_tokens":2}}}\n\n';
+  const transform = new ResponseUsageTransform("");
+  const output = await passThrough(transform, [
+    Buffer.from(terminal.slice(0, 40), "utf8"),
+    Buffer.from(terminal.slice(40), "utf8"),
+  ]);
+  assert.equal(output, terminal);
+  assert.deepEqual(transform.tokenUsage(), {
+    inputTokens: 4,
+    outputTokens: 2,
+    totalTokens: 6,
+  });
+});
+
+test("still reads a headerless body as JSON when it is not an event stream", async () => {
+  const body = JSON.stringify({ usage: { input_tokens: 7, output_tokens: 3 } });
+  const transform = new ResponseUsageTransform("");
+  const output = await passThrough(transform, [Buffer.from(body, "utf8")]);
+  assert.equal(output, body);
+  assert.deepEqual(transform.tokenUsage(), {
+    inputTokens: 7,
+    outputTokens: 3,
+    totalTokens: 10,
+  });
+});
+
+test("a declared JSON content-type is never re-read as an event stream", async () => {
+  // A JSON body that happens to open with the word data must not be sniffed
+  // into the streaming branch when the header already settled the question.
+  const body = '{"data": "one", "usage": {"input_tokens": 5, "output_tokens": 1}}';
+  const transform = new ResponseUsageTransform("application/json");
+  const output = await passThrough(transform, [Buffer.from(body, "utf8")]);
+  assert.equal(output, body);
+  assert.deepEqual(transform.tokenUsage(), {
+    inputTokens: 5,
+    outputTokens: 1,
+    totalTokens: 6,
+  });
+});
+
+test("substitutes an estimated prompt count on a headerless stream", async () => {
+  const body =
+    'event: response.completed\ndata: {"type":"response.completed","response":{"usage":{"input_tokens":0,"output_tokens":9,"total_tokens":9}}}\n\n';
+  const transform = new ResponseUsageTransform("", { estimatedInputTokens: 1200 });
+  const output = await passThrough(transform, [Buffer.from(body, "utf8")]);
+  assert.match(output, /"input_tokens":1200/);
+  assert.equal(transform.substitutedInputTokens(), 1200);
+});


### PR DESCRIPTION
Native turns are recorded with no tokens at all. On this machine that is 6,424 successful ChatGPT turns metered as zero, for as long as the events file goes back, while routed turns metered correctly throughout.

The ChatGPT backend answers `/responses` with an SSE body and **no `content-type` header**. `ResponseUsageTransform` decides how to read a body from that header alone, so every native turn takes the JSON branch, buffers the whole stream, fails to parse it at flush, and reports no usage. Codex itself is unaffected: it parses the stream without consulting the header, which is why this stayed invisible.

The header is genuinely absent rather than unexpected. Out of the router responses Codex logged over two days:

| responses | with `content-type` |
| --- | --- |
| native (`gpt-5.6-*`) | 0 of 491 |
| routed (gateway) | 991 of 1009 |

A native response carries `cf-ray`, `date`, `server` and about thirty `x-codex-*` headers, and no `content-type`.

The same turn, seen from both sides:

```
client SSE  gpt-5.6-luna  response.completed  total_tokens 154303
usage event gpt-5.6-luna  status 200  14801 ms  (no tokens)
```

A routed turn two seconds later in the same session recorded its tokens.

## The change

When the header says nothing, the first bytes decide: an SSE field line in the opening 512 bytes selects the streaming branch. A declared content-type stays authoritative in both directions, so a JSON body that happens to begin with the word `data` is never re-read as a stream.

## Verification

Spawning the router against a mock backend and changing only that one header:

```
before   with content-type: text/event-stream   total=154303
         no content-type                        (no tokens)

after    with content-type: text/event-stream   total=154303
         no content-type                        total=154303
```

Installed here, the next native turns recorded 77,222, 77,348 and 77,602 tokens where the previous 6,424 recorded nothing.

Five regression tests cover the headerless stream, an event split across two chunks, a headerless JSON body, a declared JSON body that opens with `data`, and the estimate substitution path on a headerless stream.
