### PR TITLE
Stop offering a subagent that was switched off

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -23,6 +23,7 @@ import { MODEL_BY_SLUG } from "./model-registry.mjs";
 import {
   applyMultiAgentSettings,
   readMultiAgentSettings,
+  subagentEligibleModels,
 } from "./multi-agent-state.mjs";
 import { readHiddenModels } from "./model-picker-state.mjs";
 import { buildNativeAliasAssignments } from "./native-alias.mjs";
@@ -478,9 +479,10 @@ function main() {
   const userSlugs = new Set(readUserModels().map((model) => String(model.slug)));
   const hiddenModels = readHiddenModels();
   const selectedModels = selectedConfiguredListedModels();
+  const multiAgentSettings = readMultiAgentSettings();
   const allMultiAgentModels = applyMultiAgentSettings(
     selectedModels,
-    readMultiAgentSettings(),
+    multiAgentSettings,
     hiddenModels,
   );
   // Clamp before announcements and agent sync so every surface Codex reads —
@@ -495,11 +497,7 @@ function main() {
   const captured = nativeCatalog();
   const native = {
     ...captured,
-    models: promoteNativeMultiAgent(
-      captured.models,
-      readMultiAgentSettings(),
-      hiddenModels,
-    ),
+    models: promoteNativeMultiAgent(captured.models, multiAgentSettings, hiddenModels),
   };
   // Dropping every native model is destructive, so only do it when Codex
   // actually answered that the session is signed out. If the probe could not
@@ -556,13 +554,20 @@ function main() {
   });
   atomicJson(NATIVE_ALIAS_PATH, { version: 1, aliases });
   writeAnnouncedAt(announcedAt);
-  const routedAgents = syncRoutedCodexAgents(routedModels);
+  // Codex offers every file in the agents directory by name, so a model
+  // switched off as a subagent needs its definition gone as well. Without
+  // this, switching it off changes multi_agent_version and nothing else, and
+  // the model still answers when it is spawned by name.
+  const routedAgents = syncRoutedCodexAgents(
+    subagentEligibleModels(routedModels, multiAgentSettings),
+  );
   process.stdout.write(
     `${JSON.stringify({
       path: MERGED_CATALOG_PATH,
       models: merged.length,
       routed_models: routedModels.length,
-      routed_agents: routedAgents.length,
+      routed_agents: routedAgents.written.length,
+      removed_agents: routedAgents.removed.length,
       vision_bridge_engine: visionEngine?.slug || null,
       vision_bridged_models: catalogModels.filter(
         (model) => model.visionBridgeEngine !== undefined,

--- a/src/codex-agent-catalog.mjs
+++ b/src/codex-agent-catalog.mjs
@@ -1,8 +1,10 @@
 import {
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
@@ -22,6 +24,18 @@ export function safeIdentifier(value, separator) {
 
 function tomlString(value) {
   return JSON.stringify(String(value));
+}
+
+// Only files matching this belong to the sync. Everything else in the agents
+// directory is the user's own and is never read or removed here.
+const MANAGED_AGENT_FILE = /^router-model-[a-z0-9-]+\.toml$/;
+
+function managedAgentFiles(agentsDir) {
+  try {
+    return readdirSync(agentsDir).filter((entry) => MANAGED_AGENT_FILE.test(entry));
+  } catch {
+    return [];
+  }
 }
 
 export function routedAgentDefinition(model) {
@@ -49,9 +63,14 @@ export function routedAgentDefinition(model) {
   return { agentName, fileName: `${fileStem}.toml`, contents };
 }
 
+// Writes one definition per model, and removes the definitions of models that
+// are no longer passed in. Codex offers every file in the agents directory by
+// name, so a definition left behind keeps a model spawnable through
+// `agent_type` after the settings stopped allowing it.
 export function syncRoutedCodexAgents(models, agentsDir = CODEX_AGENTS_DIR) {
   mkdirSync(agentsDir, { recursive: true, mode: 0o700 });
   const written = [];
+  const keep = new Set();
   for (const model of models) {
     const definition = routedAgentDefinition(model);
     const target = path.join(agentsDir, definition.fileName);
@@ -60,9 +79,21 @@ export function syncRoutedCodexAgents(models, agentsDir = CODEX_AGENTS_DIR) {
     protectPrivateFile(temporary);
     renameSync(temporary, target);
     protectPrivateFile(target);
+    keep.add(definition.fileName);
     written.push({ model: model.slug, agent: definition.agentName, path: target });
   }
-  return written;
+  const removed = [];
+  for (const entry of managedAgentFiles(agentsDir)) {
+    if (keep.has(entry)) continue;
+    try {
+      unlinkSync(path.join(agentsDir, entry));
+      removed.push(entry);
+    } catch {
+      // A definition that cannot be removed is reported by the doctor check
+      // rather than failing the catalog write.
+    }
+  }
+  return { written, removed };
 }
 
 export function routedCodexAgentStatus(models, agentsDir = CODEX_AGENTS_DIR) {
@@ -72,10 +103,13 @@ export function routedCodexAgentStatus(models, agentsDir = CODEX_AGENTS_DIR) {
     missing: [],
     stale: [],
     unprotected: [],
+    extra: [],
   };
+  const expectedFiles = new Set();
   for (const model of models) {
     const definition = routedAgentDefinition(model);
     const target = path.join(agentsDir, definition.fileName);
+    expectedFiles.add(definition.fileName);
     if (!existsSync(target)) {
       status.missing.push(model.slug);
       continue;
@@ -97,8 +131,16 @@ export function routedCodexAgentStatus(models, agentsDir = CODEX_AGENTS_DIR) {
     }
     status.current += 1;
   }
+  status.extra = managedAgentFiles(agentsDir).filter((entry) => !expectedFiles.has(entry));
   return {
     ...status,
-    ok: status.expected > 0 && status.current === status.expected,
+    // A leftover definition is as much a drift as a missing one: it keeps a
+    // model spawnable that the settings no longer allow. An install with every
+    // model switched off is a valid state, so an empty set stays ok.
+    ok:
+      status.current === status.expected &&
+      status.stale.length === 0 &&
+      status.unprotected.length === 0 &&
+      status.extra.length === 0,
   };
 }

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -11,7 +11,10 @@ import { detectLegacyInstallations } from "./legacy-migration.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
-import { readMultiAgentSettings } from "./multi-agent-state.mjs";
+import {
+  readMultiAgentSettings,
+  subagentEligibleModels,
+} from "./multi-agent-state.mjs";
 import { readHiddenModels } from "./model-picker-state.mjs";
 import { serviceFollowsHostApps } from "./presence-state.mjs";
 import { waitForRouterHealth } from "./router-health.mjs";
@@ -390,13 +393,19 @@ if (visionSettings.enabled && !visionEngine) {
     "Run ./bin/model-router codex control vision-bridge on to let text-only models read pasted images.",
   );
 }
-const agentStatus = routedCodexAgentStatus(requiredRoutedModels);
+// The same list the catalog writes definitions from, so a model switched off
+// as a subagent is expected to have no definition rather than a missing one.
+const agentStatus = routedCodexAgentStatus(
+  subagentEligibleModels(requiredRoutedModels, readMultiAgentSettings()),
+);
 add(
   agentStatus.ok ? "ok" : "fail",
   "Routed model agents",
   agentStatus.ok
     ? `${agentStatus.current} current definitions in ${CODEX_AGENTS_DIR}`
-    : `${agentStatus.current} of ${agentStatus.expected} current definitions in ${CODEX_AGENTS_DIR}`,
+    : agentStatus.extra.length && agentStatus.current === agentStatus.expected
+      ? `${agentStatus.extra.length} definitions in ${CODEX_AGENTS_DIR} for models that are switched off as subagents`
+      : `${agentStatus.current} of ${agentStatus.expected} current definitions in ${CODEX_AGENTS_DIR}`,
   "Run ./bin/doctor --fix, then fully quit Codex, reopen it, and create a new task.",
 );
 add(

--- a/src/multi-agent-state.mjs
+++ b/src/multi-agent-state.mjs
@@ -160,6 +160,16 @@ export function applyMultiAgentSettings(models, settings, hidden = new Set()) {
   });
 }
 
+// Models the user has not switched off as a subagent.
+//
+// Only the explicit "off" is honoured here. A model the settings never mention
+// keeps the definition it has always had, so an install that has chosen
+// nothing keeps every model callable by name the way it does today.
+export function subagentEligibleModels(models, settings) {
+  const disabled = new Set(settings?.disabled || []);
+  return models.filter((model) => !disabled.has(String(model.slug)));
+}
+
 // Compatibility helper for the original all-models switch.
 export function applyAllMultiAgent(models, enabled) {
   return applyMultiAgentSettings(models, {

--- a/test/codex-agent-catalog.test.mjs
+++ b/test/codex-agent-catalog.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -9,6 +9,7 @@ import {
   routedCodexAgentStatus,
   syncRoutedCodexAgents,
 } from "../src/codex-agent-catalog.mjs";
+import { subagentEligibleModels } from "../src/multi-agent-state.mjs";
 
 const kimi = {
   slug: "kimi-oauth/k3",
@@ -26,11 +27,10 @@ test("routed agent definitions select the router provider and exact model slug",
 
 test("agent sync writes one private definition for every routed model", () => {
   const agentsDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-agents-"));
-  const written = syncRoutedCodexAgents(
-    [kimi, { slug: "grok-oauth/grok-4.5", displayName: "Grok 4.5 (OAuth)" }],
-    agentsDir,
-  );
+  const grok = { slug: "grok-oauth/grok-4.5", displayName: "Grok 4.5 (OAuth)" };
+  const { written, removed } = syncRoutedCodexAgents([kimi, grok], agentsDir);
 
+  assert.deepEqual(removed, []);
   assert.deepEqual(
     written.map(({ model, agent }) => ({ model, agent })),
     [
@@ -40,12 +40,13 @@ test("agent sync writes one private definition for every routed model", () => {
   );
   const kimiFile = path.join(agentsDir, "router-model-kimi-oauth-k3.toml");
   assert.match(readFileSync(kimiFile, "utf8"), /name = "router_kimi_oauth_k3"/);
-  assert.deepEqual(routedCodexAgentStatus([kimi], agentsDir), {
-    expected: 1,
-    current: 1,
+  assert.deepEqual(routedCodexAgentStatus([kimi, grok], agentsDir), {
+    expected: 2,
+    current: 2,
     missing: [],
     stale: [],
     unprotected: [],
+    extra: [],
     ok: true,
   });
 });
@@ -58,10 +59,75 @@ test("agent status reports definitions that have not been installed", () => {
     missing: ["kimi-oauth/k3"],
     stale: [],
     unprotected: [],
+    extra: [],
     ok: false,
   });
 });
 
 test("agent definitions reject non-routed model slugs", () => {
   assert.throws(() => routedAgentDefinition({ slug: "gpt-5.6-sol" }), /invalid model slug/);
+});
+
+test("a model switched off as a subagent loses its definition", () => {
+  const agentsDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-agents-"));
+  const grok = { slug: "grok-oauth/grok-4.5", displayName: "Grok 4.5 (OAuth)" };
+  syncRoutedCodexAgents([kimi, grok], agentsDir);
+
+  const { written, removed } = syncRoutedCodexAgents([kimi], agentsDir);
+  assert.deepEqual(
+    written.map(({ model }) => model),
+    ["kimi-oauth/k3"],
+  );
+  assert.deepEqual(removed, ["router-model-grok-oauth-grok-4-5.toml"]);
+  assert.deepEqual(readdirSync(agentsDir), ["router-model-kimi-oauth-k3.toml"]);
+});
+
+test("agent sync leaves definitions it does not manage alone", () => {
+  const agentsDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-agents-"));
+  writeFileSync(path.join(agentsDir, "reviewer.toml"), 'name = "reviewer"\n');
+  syncRoutedCodexAgents([kimi], agentsDir);
+
+  const { removed } = syncRoutedCodexAgents([], agentsDir);
+  assert.deepEqual(removed, ["router-model-kimi-oauth-k3.toml"]);
+  assert.deepEqual(readdirSync(agentsDir), ["reviewer.toml"]);
+});
+
+test("agent status reports a definition left behind by an older install", () => {
+  const agentsDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-agents-"));
+  syncRoutedCodexAgents([kimi], agentsDir);
+
+  const status = routedCodexAgentStatus([], agentsDir);
+  assert.deepEqual(status.extra, ["router-model-kimi-oauth-k3.toml"]);
+  assert.equal(status.ok, false);
+});
+
+test("an install with every model switched off is a clean state", () => {
+  const agentsDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-agents-"));
+  const status = routedCodexAgentStatus([], agentsDir);
+  assert.deepEqual(status.extra, []);
+  assert.equal(status.ok, true);
+});
+
+test("only an explicit switch off withholds a definition", () => {
+  const models = [
+    { slug: "kimi-oauth/k3" },
+    { slug: "grok-oauth/grok-4.5" },
+    { slug: "deepseek/deepseek-v4-flash" },
+  ];
+  // Settings that name nothing leave every model eligible, which is what an
+  // install that has never opened the subagent settings looks like.
+  assert.deepEqual(
+    subagentEligibleModels(models, { mode: "proven", enabled: [], disabled: [] }).map(
+      ({ slug }) => slug,
+    ),
+    ["kimi-oauth/k3", "grok-oauth/grok-4.5", "deepseek/deepseek-v4-flash"],
+  );
+  assert.deepEqual(
+    subagentEligibleModels(models, {
+      mode: "all",
+      enabled: [],
+      disabled: ["deepseek/deepseek-v4-flash"],
+    }).map(({ slug }) => slug),
+    ["kimi-oauth/k3", "grok-oauth/grok-4.5"],
+  );
 });


### PR DESCRIPTION
A model switched off in Subagent models still runs as a subagent. Switching it off changes `multi_agent_version` in the catalog, which closes `spawn_agent(model=...)`, but the agent definition stays on disk and Codex offers it by name. The second path is never checked against the settings.

## Reproduction

A clean install on a second machine, `main` at 7027271, no local changes, one provider enabled:

```
settings          opencode-go/deepseek-v4-pro is in "disabled"
merged catalog    opencode-go/deepseek-v4-pro -> v1
agents directory  router-model-opencode-go-deepseek-v4-pro.toml is present
```

```
codex exec 'Spawn one subagent with agent_type="router_opencode_go_deepseek_v4_pro"
            and fork_turns="none". Task: write a two-line poem about rain.'
```

It answered, and the usage log recorded the spend:

```
14:26:11  opencode-go/deepseek-v4-pro  status 200  tokens 47  8615 ms
```

## The change

`syncRoutedCodexAgents` now receives the models that are not switched off, and removes the definitions of the ones that are.

Only the explicit switch off is honoured. A model the settings never mention keeps the definition it has always had, so an install that has never opened the subagent settings writes exactly the same files it writes today:

```
default settings, 20 routed models        20 definitions, unchanged
11 models switched off                     9 definitions
```

Removal is limited to `router-model-*.toml`, the files this sync writes. A hand-written agent in the same directory is never read or removed, which a test covers.

`doctor` reports a leftover definition the way it already reports a missing one, so an install that predates this keeps working until the next catalog write and says what is wrong in the meantime.

## Tests

Six cases: a switched-off model loses its definition, unmanaged files are left alone, the status call reports a leftover, an install with every model switched off is a clean state rather than a failure, and settings that name nothing leave every model eligible.
