### PR TITLE
fix(catalog): preserve native GPT speed tiers

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -109,7 +109,7 @@ state_dir=${MODEL_ROUTER_STATE_DIR:-${CODEX_ROUTER_STATE_DIR:-${KIMI_CODEX_STATE
 if [ -s "$state_dir/native-models.json" ]; then
   node src/catalog.mjs
 else
-  node src/catalog.mjs --refresh-native
+  node src/catalog.mjs --refresh-native --bundled-native
 fi
 node src/litellm-config.mjs
 

--- a/bin/refresh-catalog
+++ b/bin/refresh-catalog
@@ -13,7 +13,7 @@ restore_config() {
   if [ "$restore" = true ]; then node src/config-manager.mjs enable >/dev/null 2>&1 || true; fi
 }
 trap restore_config EXIT HUP INT TERM
-node src/catalog.mjs --refresh-native
+node src/catalog.mjs --refresh-native --bundled-native
 restore_config
 restore=false
 trap - EXIT HUP INT TERM


### PR DESCRIPTION
Codex Router can refresh the native catalog through a reduced catalog path, which drops the native GPT service-tier metadata. As a result, Codex no longer shows the Normal/Fast selector.

Use Codex's bundled native catalog for initial capture and refresh.

External providers are unchanged and do not receive OpenAI speed tiers.

Validation:
- npm run check