### PR TITLE
Add DeepSeek V4 Flash Ollama Cloud model

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Linux installations support the Codex CLI.
 | Kimi K2.7 Code (Ollama Cloud) | `ollama-cloud/kimi-k2.7-code` | Ollama Cloud API key |
 | MiniMax M3 (Ollama Cloud) | `ollama-cloud/minimax-m3` | Ollama Cloud API key |
 | DeepSeek V4 Pro (Ollama Cloud) | `ollama-cloud/deepseek-v4-pro` | Ollama Cloud API key |
+| DeepSeek V4 Flash (Ollama Cloud) | `ollama-cloud/deepseek-v4-flash` | Ollama Cloud API key |
 | MiniMax M3 | `minimax-token-plan/minimax-m3` | MiniMax Token Plan API key |
 | Qwen3.8 Max (Plan) | `qwen-plan/qwen3.8-max` | Alibaba Model Studio plan API key |
 | Qwen3.8 Max Preview (Plan) | `qwen-plan/qwen3.8-max-preview` | Alibaba Model Studio plan API key |

--- a/config/ollama/cloud/deepseek-v4-flash.json
+++ b/config/ollama/cloud/deepseek-v4-flash.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "ollama-cloud/deepseek-v4-flash",
+      "gatewayModel": "ollama-cloud-deepseek-v4-flash",
+      "upstreamModel": "deepseek-v4-flash:cloud",
+      "provider": "ollama-cloud",
+      "listed": true,
+      "displayName": "DeepSeek V4 Flash (Ollama Cloud)",
+      "description": "DeepSeek V4 Flash hosted on Ollama Cloud, a 284B Mixture-of-Experts model with 13B activated parameters, tool support, reasoning, and a 1M-token context window.",
+      "priority": 26,
+      "defaultEffort": "max",
+      "reasoningLevels": [
+        {
+          "effort": "none",
+          "description": "No thinking for fast, intuitive answers"
+        },
+        {
+          "effort": "high",
+          "description": "Thinking for careful logical analysis"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning effort for the hardest problems"
+        }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 940000,
+      "inputModalities": [
+        "text"
+      ],
+      "requestProfile": "ollama-cloud",
+      "compHash": "ollama-cloud-deepseek-v4-flash-v1"
+    }
+  ]
+}

--- a/config/ollama/cloud/deepseek-v4-flash.json
+++ b/config/ollama/cloud/deepseek-v4-flash.json
@@ -13,7 +13,7 @@
       "defaultEffort": "max",
       "reasoningLevels": [
         {
-          "effort": "none",
+          "effort": "minimal",
           "description": "No thinking for fast, intuitive answers"
         },
         {

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -72,12 +72,13 @@ function kimiK3Effort(value) {
 
 // Ollama's OpenAI-compatible surface documents reasoning_effort as of v0.18.0
 // and validates it against high/medium/low/max/none, erroring on anything else
-// -- so Codex-only rungs must be mapped instead of forwarded verbatim. "none"
-// is never produced here: it disables thinking, which no advertised level asks
-// for. An unrecognized value falls back to the documented default rather than
-// failing the turn.
+// -- so Codex-only rungs must be mapped instead of forwarded verbatim. Codex
+// has no "none" rung, so "minimal" is the advertised no-thinking tier and is
+// translated here to Ollama's "none". An unrecognized value falls back to the
+// documented default rather than failing the turn.
 function ollamaCloudEffort(value) {
-  if (["low", "minimal"].includes(value)) return "low";
+  if (value === "minimal") return "none";
+  if (value === "low") return "low";
   if (value === "medium") return "medium";
   if (["xhigh", "max", "ultra"].includes(value)) return "max";
   return "high";

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -304,9 +304,11 @@ test("resellers of one upstream model share a default effort when their ladders 
 
 // Ollama validates reasoning_effort against high/medium/low/max/none and
 // rejects anything else outright, so a level the forwarder cannot map into that
-// set would 400 the moment a user picked it.
-test("Ollama Cloud models advertise only levels Ollama accepts", () => {
-  const accepted = new Set(["none", "low", "medium", "high", "max"]);
+// set would 400 the moment a user picked it. Codex does not expose none, so
+// the no-thinking rung is advertised as minimal and mapped to none in
+// src/api-forwarder.mjs.
+test("Ollama Cloud models advertise only levels the forwarder maps to Ollama", () => {
+  const accepted = new Set(["minimal", "low", "medium", "high", "max"]);
   for (const model of MODELS) {
     if (model.requestProfile !== "ollama-cloud") continue;
     for (const level of model.reasoningLevels || []) {

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -63,6 +63,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "meta/muse-spark-1.2-contributor",
       "meta/muse-spark-1.2",
       "minimax-token-plan/minimax-m3",
+      "ollama-cloud/deepseek-v4-flash",
       "ollama-cloud/deepseek-v4-pro",
       "ollama-cloud/glm-5.2",
       "ollama-cloud/kimi-k2.7-code",
@@ -305,7 +306,7 @@ test("resellers of one upstream model share a default effort when their ladders 
 // rejects anything else outright, so a level the forwarder cannot map into that
 // set would 400 the moment a user picked it.
 test("Ollama Cloud models advertise only levels Ollama accepts", () => {
-  const accepted = new Set(["low", "medium", "high", "max"]);
+  const accepted = new Set(["none", "low", "medium", "high", "max"]);
   for (const model of MODELS) {
     if (model.requestProfile !== "ollama-cloud") continue;
     for (const level of model.reasoningLevels || []) {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -2107,7 +2107,7 @@ test("API forwarder routes Ollama Cloud models without unsupported parameters", 
       ["ollama-cloud-glm-5-2", "glm-5.2", "high", "high"],
       ["ollama-cloud-glm-5-2", "glm-5.2", "max", "max"],
       ["ollama-cloud-glm-5-2", "glm-5.2", "xhigh", "max"],
-      ["ollama-cloud-glm-5-2", "glm-5.2", "minimal", "low"],
+      ["ollama-cloud-glm-5-2", "glm-5.2", "minimal", "none"],
       ["ollama-cloud-glm-5-2", "glm-5.2", "bogus", "high"],
       ["ollama-cloud-kimi-k2-7-code", "kimi-k2.7-code", "high", "high"],
     ]) {


### PR DESCRIPTION
Adds the DeepSeek V4 Flash Ollama Cloud model config under config/ollama/cloud, with README and registry test updates.