### PR TITLE
meter: record mid-stream upstream aborts instead of 200

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1262,12 +1262,15 @@ async function handleResponses(request, response, requestUrl) {
   const startedAt = Date.now();
   const activity = beginRequestActivity();
   let clientGone = false;
+  let requestedModel = "";
+  let route;
+  let upstreamRetries;
   try {
     if (!requireCodexTransport(request, response)) return;
     const encoded = await readRequestBody(request);
     const body = decodeBody(encoded, request.headers["content-encoding"]);
     const payload = parseBody(body);
-    const requestedModel = typeof payload.model === "string" ? payload.model : "";
+    requestedModel = typeof payload.model === "string" ? payload.model : "";
     let registeredRoute =
       MODEL_BY_SLUG.get(requestedModel) ??
       MODEL_BY_SLUG.get(readNativeAliases()[requestedModel]);
@@ -1283,7 +1286,7 @@ async function handleResponses(request, response, requestUrl) {
         registeredRoute = redirect;
       }
     }
-    const route = registeredRoute && readProviderSelection().includes(registeredRoute.provider)
+    route = registeredRoute && readProviderSelection().includes(registeredRoute.provider)
       ? registeredRoute
       : undefined;
     if (registeredRoute && !route) {
@@ -1410,7 +1413,7 @@ async function handleResponses(request, response, requestUrl) {
     // attempt replays the identical bytes under the identical encoding. Nothing
     // here consumes a stream, which is what makes the request replayable at
     // all.
-    const { response: upstream, retries: upstreamRetries } = await fetchWithRetry(
+    const { response: upstream, retries } = await fetchWithRetry(
       target,
       {
         method: "POST",
@@ -1427,6 +1430,7 @@ async function handleResponses(request, response, requestUrl) {
         onRetry: (event) => logUpstreamRetry(event, requestedModel, requestUrl.pathname),
       },
     );
+    upstreamRetries = retries;
     // Gateway error bodies leak LiteLLM's internal exception chain, which
     // reads like a router bug. Rewrite them to name the provider that failed.
     // Native traffic passes through untouched: OpenAI errors are already clear.
@@ -1489,14 +1493,25 @@ async function handleResponses(request, response, requestUrl) {
     await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS, transforms);
     const usage = usageTransform?.tokenUsage();
     const estimatedInputTokens = usageTransform?.substitutedInputTokens();
+    // The `close` listener above sets `clientGone` when the client's socket
+    // goes away, but `pipeResponse` can resolve before that event fires: the
+    // response socket is already destroyed at that point. Read the state
+    // directly as well so a cancel that races the close event still meters 0.
+    const clientWalkedAway =
+      clientGone || (response.destroyed && !response.writableFinished);
     // `retries` separates "it never failed" from "it failed and the router
     // absorbed it", both of which otherwise record a plain 200;
     // `estimatedInputTokens` separates a count the provider sent from one the
     // router had to invent. Neither is inferable from the rest of the event.
+    // A stream that completed, or a client that walked away, both land here:
+    // `pipeResponse` resolves for a canceled generation (the response socket
+    // is already gone) and only rejects for an upstream that actually failed.
+    // A cancel is not a router failure, so it meters as 0 rather than the
+    // committed 200 that the client never finished reading.
     recordUsageEvent({
       model: route?.slug || requestedModel,
       provider: route ? canonicalProviderId(route.provider) : "openai",
-      status: upstream.status,
+      status: clientWalkedAway ? 0 : upstream.status,
       durationMs: Date.now() - startedAt,
       retries: upstreamRetries,
       ...usage,
@@ -1506,7 +1521,7 @@ async function handleResponses(request, response, requestUrl) {
       // The substitution is named in the log line as well as the usage event:
       // a router that quietly invents token counts is its own trap.
       console.error(
-        `[codex-router] model=${requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${upstream.status}${
+        `[codex-router] model=${requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${clientWalkedAway ? 0 : upstream.status}${
           upstreamRetries ? ` retries=${upstreamRetries}` : ""
         }${estimatedInputTokens ? ` estimated-input-tokens=${estimatedInputTokens}` : ""}`,
       );
@@ -1515,8 +1530,31 @@ async function handleResponses(request, response, requestUrl) {
     // A client that walked away (canceled generation, closed stream) is not
     // a router failure; only surface errors the router or upstream produced.
     if (clientGone) {
+      recordUsageEvent({
+        model: route?.slug || requestedModel,
+        provider: route ? canonicalProviderId(route.provider) : "openai",
+        status: 0,
+        durationMs: Date.now() - startedAt,
+        retries: upstreamRetries,
+      });
       activity.finish(0);
       return;
+    }
+    // The upstream stream died after its head was already committed: the
+    // client saw a 200 start and a truncated body, so the meter has to say so
+    // instead of a success the client never received. `streamAborted` is the
+    // additive marker; `status` is rewritten to 502 so dashboards that only
+    // read status still count the turn as a failure. Token counts are omitted
+    // because the truncated stream never reported a final usage.
+    if (response.headersSent) {
+      recordUsageEvent({
+        model: route?.slug || requestedModel,
+        provider: route ? canonicalProviderId(route.provider) : "openai",
+        status: 502,
+        durationMs: Date.now() - startedAt,
+        retries: upstreamRetries,
+        streamAborted: true,
+      });
     }
     activity.finish(500);
     throw error;

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -34,6 +34,11 @@ export function recordUsageEvent({
   outputTokens,
   totalTokens,
   retries,
+  // True when the upstream stream died after its 200 head was already
+  // committed, so `status` had to be rewritten (e.g. 502) and this marker is
+  // the only thing that says the turn was truncated rather than successful.
+  // Absent on ordinary events so old rows keep their exact shape.
+  streamAborted,
   // Present only when the router replaced an upstream `input_tokens: 0` with
   // its own estimate on the way to Codex (#95). The reported counts above stay
   // exactly as the provider sent them, so an estimated turn is never mistaken
@@ -49,6 +54,7 @@ export function recordUsageEvent({
     provider: safeText(provider, "unknown"),
     status: Number.isInteger(status) ? status : 0,
     durationMs: Number.isFinite(durationMs) ? Math.max(0, Math.round(durationMs)) : 0,
+    ...(streamAborted === true ? { streamAborted: true } : {}),
     ...(safeRetryCount(retries) !== undefined ? { retries: safeRetryCount(retries) } : {}),
     ...(safeTokenCount(inputTokens) !== undefined
       ? { inputTokens: safeTokenCount(inputTokens) }
@@ -116,6 +122,7 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
           durationMs: Number.isFinite(event.durationMs)
             ? Math.max(0, Math.round(event.durationMs))
             : 0,
+          ...(event.streamAborted === true ? { streamAborted: true } : {}),
           ...(retries !== undefined ? { retries } : {}),
           ...(inputTokens !== undefined ? { inputTokens } : {}),
           ...(outputTokens !== undefined ? { outputTokens } : {}),

--- a/test/pipe-response.test.mjs
+++ b/test/pipe-response.test.mjs
@@ -139,6 +139,7 @@ function failingSseUpstream(message) {
 // log it, and must leave the response endable so the chunked body terminates.
 test("an upstream body that fails mid-stream ends the chunked body instead of resetting", async () => {
   let pipeError;
+  let headersCommitted;
   const logged = [];
   const transform = new Transform({
     transform(chunk, _encoding, callback) {
@@ -156,6 +157,9 @@ test("an upstream body that fails mid-stream ends the chunked body instead of re
       );
     } catch (error) {
       pipeError = error;
+      // The router keys its meter off this: an upstream failure after the
+      // head was committed must record an abort, not the committed 200.
+      headersCommitted = response.headersSent;
       // The router's top-level handler: log the cause, then terminate the
       // stream gracefully rather than destroying the socket.
       logged.push(
@@ -173,6 +177,11 @@ test("an upstream body that fails mid-stream ends the chunked body instead of re
 
   assert.equal(pipeError instanceof Error, true, "the upstream failure must surface");
   assert.equal(pipeError.message, "upstream exploded");
+  assert.equal(
+    headersCommitted,
+    true,
+    "the failure surfaced after the 200 head was already committed",
+  );
   // The message is what made this diagnosable at all; the old handler logged a
   // bare string with no error attached.
   assert.deepEqual(logged, ["[codex-router] request failed: Error: upstream exploded"]);

--- a/test/router-resilience.test.mjs
+++ b/test/router-resilience.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import http from "node:http";
 import net from "node:net";
 import os from "node:os";
@@ -25,11 +32,12 @@ async function mockServer(handler) {
 }
 
 function run(env) {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "router-resilience-state-"));
   const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
     cwd: root,
     env: {
       ...process.env,
-      MODEL_ROUTER_STATE_DIR: mkdtempSync(path.join(os.tmpdir(), "router-resilience-state-")),
+      MODEL_ROUTER_STATE_DIR: stateDir,
       CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
       CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
       KIMI_INTERNAL_KEY: INTERNAL_KEY,
@@ -45,7 +53,29 @@ function run(env) {
     errors += chunk;
   });
   child.testErrors = () => errors;
+  child.stateDir = stateDir;
   return child;
+}
+
+function usageEvents(stateDir) {
+  const file = path.join(stateDir, "usage-events.jsonl");
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+// The router meters after it has already answered the client, so the request
+// can resolve before the event reaches disk. Poll rather than sleep.
+async function waitForUsageEvents(stateDir, count, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const events = usageEvents(stateDir);
+    if (events.length >= count) return events;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${count} usage events: ${child.testErrors()}`);
 }
 
 async function waitFor(url, child) {
@@ -172,6 +202,86 @@ test("a gateway that dies mid-stream ends the routed body and logs the cause", a
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
     assert.match(router.testErrors(), /\[codex-router\] request failed: \w+: .+/);
+
+    // The turn is truncated, not successful: the meter must record a failure
+    // carrying the abort marker instead of the committed 200 the client
+    // never finished reading.
+    const [event] = await waitForUsageEvents(router.stateDir, 1, router);
+    assert.equal(event.model, "deepseek/deepseek-v4-pro");
+    assert.equal(event.provider, "deepseek");
+    assert.equal(event.status, 502);
+    assert.equal(event.streamAborted, true);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
+// A client that cancels mid-stream is not an upstream failure: the router
+// meters the turn as 0 rather than the committed 200 or a fabricated 5xx.
+test("a client cancel mid-stream meters 0 and never claims an upstream failure", async () => {
+  const gateway = await mockServer((request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      const payload = Buffer.from(JSON.stringify({ ok: true }), "utf8");
+      response.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    // Hold the stream open; the client is the one leaving.
+    response.writeHead(200, { "Content-Type": "text/event-stream; charset=utf-8" });
+    response.write('event: response.created\ndata: {"type":"response.created"}\n\n');
+  });
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+  });
+
+  try {
+    await waitFor(`${callerBaseUrl(routerPort, CALLER_KEY)}/models`, router);
+
+    // Read with the raw client so the cancel is a real socket hangup, the
+    // same path Codex uses when the user stops a generation.
+    await new Promise((resolve) => {
+      const request = http.request(
+        {
+          host: "127.0.0.1",
+          port: routerPort,
+          path: `${callerBaseUrl(routerPort, CALLER_KEY)}/responses`,
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer codex-caller-auth",
+          },
+        },
+        (response) => {
+          response.once("data", () => {
+            request.destroy();
+            resolve();
+          });
+        },
+      );
+      request.once("error", resolve);
+      request.end(
+        JSON.stringify({ model: "deepseek/deepseek-v4-pro", input: "hello", stream: true }),
+      );
+    });
+
+    const [event] = await waitForUsageEvents(router.stateDir, 1, router);
+    assert.equal(event.model, "deepseek/deepseek-v4-pro");
+    assert.equal(event.status, 0);
+    assert.equal("streamAborted" in event, false);
+    // No 502 marker and no failure log: the cancel was never an upstream
+    // error, so it must not push the error state either.
+    assert.doesNotMatch(router.testErrors(), /request failed/);
+    const health = await fetch(`http://127.0.0.1:${routerPort}/health`).then((r) => r.json());
+    assert.equal(health.activity.state, "idle");
   } finally {
     await stopChild(router);
     await closeServer(gateway.server);

--- a/test/usage-events.test.mjs
+++ b/test/usage-events.test.mjs
@@ -63,3 +63,40 @@ test("reading usage events folds protocol variants into their canonical provider
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+test("an aborted stream persists its marker and reads back", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-router-usage-"));
+  const previousStateDir = process.env.MODEL_ROUTER_STATE_DIR;
+  process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+  try {
+    const usage = await import(`../src/usage-events.mjs?aborted=1&ts=${Date.now()}`);
+    usage.recordUsageEvent({
+      model: "opencode-go/deepseek-v4-flash",
+      provider: "opencode-go",
+      status: 502,
+      durationMs: 90,
+      streamAborted: true,
+    });
+    const [event] = usage
+      .recentUsageEvents()
+      .filter((candidate) => candidate.status === 502);
+    assert.equal(event.status, 502);
+    assert.equal(event.streamAborted, true);
+    // An ordinary turn never carries the marker, so historical rows keep
+    // their exact shape and old dashboards are unaffected.
+    usage.recordUsageEvent({
+      model: "opencode-go/deepseek-v4-flash",
+      provider: "opencode-go",
+      status: 200,
+      durationMs: 40,
+    });
+    const [ordinary] = usage
+      .recentUsageEvents()
+      .filter((candidate) => candidate.status === 200);
+    assert.equal("streamAborted" in ordinary, false);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.MODEL_ROUTER_STATE_DIR;
+    else process.env.MODEL_ROUTER_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

A turn whose upstream stream dies mid-flight was recorded in `usage-events.jsonl` as a plain `200` (the 200 head is committed before the stream finishes). This made every drop invisible in the meter and poisoned all downstream metrics. This change records the truth:

- Upstream stream aborted after the response head: `status: 502` plus an additive `streamAborted: true` marker, no token counts (the stream never reported final usage).
- Client walked away (cancel/close): `status: 0`, no marker, never counted as an upstream failure.

The distinction is guarded by the existing `clientGone` branch plus a direct destroyed-response check for the close-event race. The marker is additive, so existing dashboards keep working.

## Verification

- `npm test`: 676 tests, 669 pass, 0 fail, 7 skipped.
- `npm run check` passes.
- New e2e tests drive a real socket: upstream dies mid-SSE -> 502 + marker; raw client cancel -> 0, no marker.
- Reproduced the bug read-only on the live meter row `2026-08-09T20:49:39.265Z` (recorded 200 while router.log line 22538 logged a MidStream transfer error).

## Notes

Native `/v1/responses` traffic shares the same handler and gets the same treatment; image/web-search native paths are single-shot JSON and untouched. Pre-existing behavior: an upstream failure before headers are sent still records no row (not a regression from this change).