### PR TITLE
tooling: verify skill injection and document relay operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,17 +969,20 @@ node src/skills-install.mjs uninstall
 against the checkout, free of name collisions, and matching the app
 toolset snapshot the router relays.
 
-To verify the pack actually reaches a session, run the probe against a
-rollout after using a custom model in the app:
+To inspect rollout evidence for the pack, run the read-only check after using
+a custom model in the app:
 
 ```sh
 node scripts/verify-skill-injection.mjs ~/.codex/sessions/2026/08/09/rollout-*.jsonl
+node scripts/verify-skill-injection.mjs --latest --expect routed
 ```
 
-It asserts the session listed a pack skill, that the model read it, that
-`create_thread` calls carried the required fields, and (with
-`--expect native`) that native sessions never read the pack. The browser
-and computer-use bootstrap one-liners are live-only and flagged as such.
+It accepts only a standalone app-injected developer block with a turn ID, then
+correlates a same-turn tool call referencing the skill path with its output and
+checks same-turn `create_thread` arguments. With `--expect native`, that
+completed pack-path call is an error. Because arbitrary exec code is opaque,
+the rollout proves a completed path-referencing call, not that the command read
+specific bytes. Browser and computer-use execution remains live-only.
 
 ## Common commands
 

--- a/README.md
+++ b/README.md
@@ -965,6 +965,22 @@ node src/skills-install.mjs install
 node src/skills-install.mjs uninstall
 ```
 
+`./bin/model-router codex doctor` checks the pack: installed, current
+against the checkout, free of name collisions, and matching the app
+toolset snapshot the router relays.
+
+To verify the pack actually reaches a session, run the probe against a
+rollout after using a custom model in the app:
+
+```sh
+node scripts/verify-skill-injection.mjs ~/.codex/sessions/2026/08/09/rollout-*.jsonl
+```
+
+It asserts the session listed a pack skill, that the model read it, that
+`create_thread` calls carried the required fields, and (with
+`--expect native`) that native sessions never read the pack. The browser
+and computer-use bootstrap one-liners are live-only and flagged as such.
+
 ## Common commands
 
 ```sh

--- a/scripts/verify-skill-injection.mjs
+++ b/scripts/verify-skill-injection.mjs
@@ -1,22 +1,8 @@
 #!/usr/bin/env node
-// Verify that the codex-router skill pack actually reaches routed sessions.
-//
-// Given a Codex session rollout (jsonl), assert:
-//   (a) the app's <skills_instructions> block lists a pack skill under an
-//       r0 root (the user ~/.codex/skills directory);
-//   (b) the model read that SKILL.md before acting;
-//   (c) every create_thread call carries prompt and target (the two required
-//       fields the pack teaches);
-//   (d) on a native GPT session the pack skill is never read (guards the
-//       description scoping);
-//   (e) reported separately: the browser and computer-use bootstrap one-liners
-//       must be exercised against the live app runtime -- a rollout cannot
-//       prove they execute, so the script flags them as live-only.
-//
-// Read-only and deterministic. Exit code is non-zero when any assertion fails.
-//
-// Usage:
-//   node scripts/verify-skill-injection.mjs <rollout.jsonl> [--expect routed|native]
+// Inspect a Codex rollout for turn-scoped evidence that the managed skill pack
+// was injected by the app and then referenced by a completed model tool call.
+// This is deliberately an evidence check, not a live execution probe: an
+// arbitrary exec call cannot prove from the rollout alone that bytes were read.
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -29,9 +15,6 @@ export const PACK_SKILLS = [
   "codex-computer-use",
 ];
 
-// The newest session rollout under a Codex sessions root (recursive; the app
-// stores rollouts in per-day directories). Used by --latest so the probe can
-// be run without naming a file.
 export function latestRollout(sessionsRoot) {
   let best;
   let bestMtime = -1;
@@ -54,7 +37,7 @@ export function latestRollout(sessionsRoot) {
             bestMtime = mtime;
           }
         } catch {
-          // unreadable file; skip
+          // Unreadable rollout; keep looking.
         }
       }
     }
@@ -69,72 +52,129 @@ function defaultSessionsRoot() {
 
 function parseRollout(lines) {
   const events = [];
-  for (const line of lines) {
+  for (const [index, line] of lines.entries()) {
     if (!line.trim()) continue;
     try {
-      events.push(JSON.parse(line));
+      events.push({ index, event: JSON.parse(line) });
     } catch {
-      // tolerate a non-JSON line (never in real rollouts)
+      // A damaged unrelated line does not become trusted evidence.
     }
   }
   return events;
 }
 
-// Find every injected text block (user and developer message content) so the
-// skills_instructions listing can be located. The app lands the block in a
-// user message on some sessions and a developer message on others.
-function injectedTexts(events) {
-  const texts = [];
-  for (const event of events) {
-    const payload = event?.payload || {};
-    if (!["user", "developer"].includes(payload.role)) continue;
-    if (typeof payload.content === "string") {
-      texts.push(payload.content);
-    }
-    if (Array.isArray(payload.content)) {
-      for (const part of payload.content) {
-        if (part?.type === "input_text" && typeof part.text === "string") {
-          texts.push(part.text);
-        }
-      }
-    }
-  }
-  return texts;
+function eventTurnId(event) {
+  const payload = event?.payload;
+  const candidates = [
+    payload?.internal_chat_message_metadata_passthrough?.turn_id,
+    payload?.item?.internal_chat_message_metadata_passthrough?.turn_id,
+    event?.internal_chat_message_metadata_passthrough?.turn_id,
+  ];
+  return candidates.find((value) => typeof value === "string" && value.trim())?.trim();
 }
 
-function skillsInstructions(texts) {
-  const block = texts.find((text) => text.includes("<skills_instructions>"));
-  return block || undefined;
+function eventItem(event) {
+  return event?.payload?.item || event?.payload || {};
+}
+
+function completeSkillsBlock(text) {
+  if (typeof text !== "string") return false;
+  const trimmed = text.trim();
+  return /^<skills_instructions>[\s\S]*<\/skills_instructions>$/.test(trimmed);
 }
 
 function listedPackSkills(block) {
-  const listed = new Set();
-  for (const skill of PACK_SKILLS) {
-    if (block.includes(`(file: r0/${skill}/SKILL.md)`)) listed.add(skill);
-  }
-  return [...listed];
+  return PACK_SKILLS.filter((skill) => block.includes(`(file: r0/${skill}/SKILL.md)`));
 }
 
-function modelReadsPackSkill(events) {
-  const reads = new Set();
-  for (const event of events) {
-    const item = event?.payload?.item || event?.payload || {};
-    if (item.type !== "function_call" || item.name !== "exec_command") continue;
-    const args = typeof item.arguments === "string" ? item.arguments : JSON.stringify(item.arguments || {});
-    for (const skill of PACK_SKILLS) {
-      if (args.includes(`${skill}/SKILL.md`) && reads.size < PACK_SKILLS.length) {
-        reads.add(skill);
-      }
+function r0Root(block) {
+  const match = block.match(/^r0\s*=\s*(.+?)\s*$/m);
+  return match?.[1]?.replace(/^['"]|['"]$/g, "");
+}
+
+function trustedInjections(events) {
+  const candidates = [];
+  for (const { index, event } of events) {
+    const payload = event?.payload;
+    if (event?.type !== "response_item") continue;
+    if (payload?.type !== "message" || payload.role !== "developer") continue;
+    if (!Array.isArray(payload.content)) continue;
+    const turnId = eventTurnId(event);
+    if (!turnId) continue;
+    for (const part of payload.content) {
+      if (part?.type !== "input_text" || !completeSkillsBlock(part.text)) continue;
+      candidates.push({
+        index,
+        turnId,
+        block: part.text.trim(),
+        listed: listedPackSkills(part.text),
+      });
     }
   }
-  return [...reads];
+  return candidates;
 }
 
-function createThreadCalls(events) {
+function sourceForToolCall(item) {
+  if (item?.type === "custom_tool_call" && item.name === "exec") {
+    return typeof item.input === "string" ? item.input : JSON.stringify(item.input || {});
+  }
+  if (item?.type === "function_call" && item.name === "exec_command") {
+    return typeof item.arguments === "string"
+      ? item.arguments
+      : JSON.stringify(item.arguments || {});
+  }
+  return undefined;
+}
+
+function exactSkillForSource(source, block) {
+  if (!source) return undefined;
+  const root = r0Root(block);
+  return PACK_SKILLS.find((skill) => {
+    const aliases = [`r0/${skill}/SKILL.md`];
+    if (root) aliases.push(path.join(root, skill, "SKILL.md"));
+    return aliases.some((candidate) => source.includes(candidate));
+  });
+}
+
+function matchingOutput(events, call, turnId) {
+  if (typeof call.callId !== "string" || !call.callId) return false;
+  return events.some(({ index, event }) => {
+    if (index <= call.index || eventTurnId(event) !== turnId) return false;
+    const item = eventItem(event);
+    return (
+      ["custom_tool_call_output", "function_call_output"].includes(item?.type) &&
+      item.call_id === call.callId
+    );
+  });
+}
+
+function modelPackReads(events, injection) {
+  if (!injection) return { issued: [], completed: [], issuedWithoutOutput: [] };
+  const issued = [];
+  for (const { index, event } of events) {
+    if (index <= injection.index || eventTurnId(event) !== injection.turnId) continue;
+    const item = eventItem(event);
+    const skill = exactSkillForSource(sourceForToolCall(item), injection.block);
+    if (!skill) continue;
+    issued.push({ skill, callId: item.call_id, index });
+  }
+  const completedCalls = issued.filter((call) => matchingOutput(events, call, injection.turnId));
+  return {
+    issued,
+    completed: [...new Set(completedCalls.map((call) => call.skill))],
+    issuedWithoutOutput: issued.filter(
+      (call) => !completedCalls.some((completed) => completed === call),
+    ),
+  };
+}
+
+function createThreadCalls(events, injection) {
+  if (!injection) return [];
   const calls = [];
-  for (const event of events) {
-    const item = event?.payload?.item || event?.payload || {};
-    if (item.type !== "function_call") continue;
+  for (const { index, event } of events) {
+    if (index <= injection.index || eventTurnId(event) !== injection.turnId) continue;
+    const item = eventItem(event);
+    if (item?.type !== "function_call") continue;
     const flat = item.name === "codex_app__create_thread";
     const native = item.name === "create_thread" && item.namespace === "codex_app";
     if (!flat && !native) continue;
@@ -144,107 +184,164 @@ function createThreadCalls(events) {
     } catch {
       args = {};
     }
-    calls.push({ flat, native, hasPrompt: Object.hasOwn(args, "prompt"), hasTarget: Object.hasOwn(args, "target"), args });
+    calls.push({
+      flat,
+      native,
+      hasPrompt: Object.hasOwn(args, "prompt"),
+      hasTarget: Object.hasOwn(args, "target"),
+      args,
+    });
   }
   return calls;
 }
 
 function sessionModel(events) {
-  const meta = events.find((event) => event?.type === "session_meta");
-  const settings = events
+  const parsed = events.map(({ event }) => event);
+  const meta = parsed.find((event) => event?.type === "session_meta");
+  const settings = parsed
     .map((event) => event?.payload?.thread_settings || event?.payload)
     .find((payload) => payload?.model);
   return meta?.payload?.model || settings?.model || undefined;
 }
 
 export function analyzeRollout(lines, { expect = "routed" } = {}) {
+  if (!["routed", "native"].includes(expect)) {
+    throw new Error(`invalid expectation: ${expect}`);
+  }
   const events = parseRollout(lines);
-  const texts = injectedTexts(events);
-  const block = skillsInstructions(texts);
-  const listed = block ? listedPackSkills(block) : [];
-  const reads = modelReadsPackSkill(events);
-  const calls = createThreadCalls(events);
+  const injection = trustedInjections(events).at(-1);
+  const listed = injection?.listed || [];
+  const readEvidence = modelPackReads(events, injection);
+  const reads = readEvidence.completed;
+  const calls = createThreadCalls(events, injection);
   const model = sessionModel(events);
   const malformed = calls.filter((call) => !call.hasPrompt || !call.hasTarget);
+  const packComplete = listed.length === PACK_SKILLS.length;
 
   const assertions = [
     {
-      name: "(a) skills_instructions lists a pack skill under r0",
-      pass: listed.length > 0,
-      detail: block
-        ? listed.length > 0
-          ? `listed: ${listed.join(", ")}`
-          : "no pack skill listed in the skills_instructions block"
-        : "no <skills_instructions> block found",
+      name: "(a) app developer injection lists the managed pack under r0",
+      pass: Boolean(injection) && packComplete,
+      detail: !injection
+        ? "no standalone developer <skills_instructions> block with a turn_id"
+        : packComplete
+          ? `turn ${injection.turnId}; listed: ${listed.join(", ")}`
+          : `turn ${injection.turnId}; missing: ${PACK_SKILLS.filter((skill) => !listed.includes(skill)).join(", ")}`,
     },
     {
-      name: "(b) the model read a pack SKILL.md before acting",
-      pass: reads.length > 0,
-      detail: reads.length > 0 ? `read: ${reads.join(", ")}` : "no pack SKILL.md read found",
-    },
-    {
-      name: "(c) every create_thread call carries prompt and target",
-      pass: calls.length > 0 && malformed.length === 0,
+      name: "(b) routed model completed a same-turn tool call referencing pack SKILL.md",
+      pass: expect === "native" ? true : reads.length > 0,
       detail:
-        calls.length === 0
-          ? "no create_thread calls in this rollout"
-          : `${calls.length} call(s), ${malformed.length} missing prompt and/or target`,
+        expect === "native"
+          ? "skipped for native expectation"
+          : reads.length > 0
+            ? `referenced: ${reads.join(", ")}`
+            : readEvidence.issuedWithoutOutput.length > 0
+              ? "skill read issued, output not observed"
+              : "no same-turn completed tool call referenced pack SKILL.md after injection",
     },
     {
-      name: "(d) native sessions never read a pack skill",
+      name: "(c) same-turn create_thread calls carry prompt and target",
+      pass: expect === "native" ? true : calls.length > 0 && malformed.length === 0,
+      detail:
+        expect === "native"
+          ? "skipped for native expectation"
+          : calls.length === 0
+            ? "no same-turn create_thread calls after injection"
+            : `${calls.length} call(s), ${malformed.length} missing prompt and/or target`,
+    },
+    {
+      name: "(d) native sessions do not complete a same-turn pack-path tool call",
       pass: expect === "native" ? reads.length === 0 : true,
       detail:
         expect === "native"
           ? reads.length === 0
-            ? "no pack skill read (scoping holds)"
-            : `pack skill(s) read on a native session: ${reads.join(", ")}`
-          : `skipped (expect=${expect})`,
+            ? "no completed pack-path tool call after the trusted injection"
+            : `pack skill path(s) referenced on a native session: ${reads.join(", ")}`
+          : "skipped for routed expectation",
     },
     {
       name: "(e) browser and computer-use bootstraps execute (live-only)",
       pass: undefined,
-      detail:
-        "not provable from a rollout; exercise the bootstrap one-liners in a live routed session",
+      detail: "not provable from a rollout; exercise them in a live routed session",
     },
   ];
 
   const failed = assertions.filter((assertion) => assertion.pass === false);
-  return { model, listed, reads, calls, assertions, failed, ok: failed.length === 0 };
+  return {
+    model,
+    turnId: injection?.turnId,
+    listed,
+    reads,
+    readCalls: readEvidence.issued,
+    issuedWithoutOutput: readEvidence.issuedWithoutOutput,
+    calls,
+    assertions,
+    failed,
+    ok: failed.length === 0,
+  };
+}
+
+export function parseCliArgs(args) {
+  let expect = "routed";
+  let latest = false;
+  let source;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--expect") {
+      const value = args[index + 1];
+      if (!value || value.startsWith("--")) throw new Error("--expect requires routed or native");
+      if (!["routed", "native"].includes(value)) throw new Error(`invalid --expect value: ${value}`);
+      expect = value;
+      index += 1;
+    } else if (arg === "--latest") {
+      if (latest) throw new Error("--latest may be supplied only once");
+      latest = true;
+    } else if (arg.startsWith("--")) {
+      throw new Error(`unknown option: ${arg}`);
+    } else if (source) {
+      throw new Error("only one rollout path may be supplied");
+    } else {
+      source = arg;
+    }
+  }
+  if (latest && source) throw new Error("choose either a rollout path or --latest");
+  if (!latest && !source) throw new Error("a rollout path or --latest is required");
+  return { expect, latest, source };
 }
 
 function report(result, source) {
   console.log(`verify-skill-injection: ${path.basename(source)} (model ${result.model || "unknown"})`);
   for (const assertion of result.assertions) {
-    const verdict =
-      assertion.pass === undefined ? "LIVE" : assertion.pass ? "PASS" : "FAIL";
+    const verdict = assertion.pass === undefined ? "LIVE" : assertion.pass ? "PASS" : "FAIL";
     console.log(`  ${verdict.padEnd(5)} ${assertion.name}: ${assertion.detail}`);
   }
-  if (result.failed.length > 0) {
-    console.log(`FAILED: ${result.failed.length} assertion(s)`);
-  } else {
-    console.log("OK: all rollout-checkable assertions passed");
-  }
+  console.log(
+    result.failed.length > 0
+      ? `FAILED: ${result.failed.length} assertion(s)`
+      : "OK: all rollout-checkable assertions passed",
+  );
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const args = process.argv.slice(2);
-  const expectFlag = args.indexOf("--expect");
-  const expect = expectFlag !== -1 ? args[expectFlag + 1] : "routed";
-  let source = args.find((arg) => !arg.startsWith("--"));
-  if (!source && args.includes("--latest")) {
-    source = latestRollout(defaultSessionsRoot());
-    if (!source) {
-      console.error("verify-skill-injection: no session rollout found under ~/.codex/sessions");
-      process.exit(2);
-    }
-  }
-  if (!source) {
+  let parsed;
+  try {
+    parsed = parseCliArgs(process.argv.slice(2));
+  } catch (error) {
+    console.error(`verify-skill-injection: ${error.message}`);
     console.error(
       "Usage: verify-skill-injection.mjs <rollout.jsonl> [--expect routed|native] | --latest [--expect routed|native]",
     );
     process.exit(2);
   }
-  const result = analyzeRollout(readFileSync(source, "utf8").split("\n"), { expect });
+  const source = parsed.latest ? latestRollout(defaultSessionsRoot()) : parsed.source;
+  if (!source) {
+    console.error("verify-skill-injection: no session rollout found under ~/.codex/sessions");
+    process.exit(2);
+  }
+  const result = analyzeRollout(readFileSync(source, "utf8").split("\n"), {
+    expect: parsed.expect,
+  });
   report(result, source);
   process.exit(result.ok ? 0 : 1);
 }

--- a/scripts/verify-skill-injection.mjs
+++ b/scripts/verify-skill-injection.mjs
@@ -17,7 +17,8 @@
 //
 // Usage:
 //   node scripts/verify-skill-injection.mjs <rollout.jsonl> [--expect routed|native]
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -27,6 +28,44 @@ export const PACK_SKILLS = [
   "codex-in-app-browser",
   "codex-computer-use",
 ];
+
+// The newest session rollout under a Codex sessions root (recursive; the app
+// stores rollouts in per-day directories). Used by --latest so the probe can
+// be run without naming a file.
+export function latestRollout(sessionsRoot) {
+  let best;
+  let bestMtime = -1;
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const candidate = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(candidate);
+      } else if (entry.name.endsWith(".jsonl")) {
+        try {
+          const mtime = statSync(candidate).mtimeMs;
+          if (mtime > bestMtime) {
+            best = candidate;
+            bestMtime = mtime;
+          }
+        } catch {
+          // unreadable file; skip
+        }
+      }
+    }
+  };
+  walk(sessionsRoot);
+  return best;
+}
+
+function defaultSessionsRoot() {
+  return path.join(process.env.CODEX_HOME || path.join(os.homedir(), ".codex"), "sessions");
+}
 
 function parseRollout(lines) {
   const events = [];
@@ -188,11 +227,21 @@ function report(result, source) {
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-  const source = process.argv[2];
-  const expectFlag = process.argv.indexOf("--expect");
-  const expect = expectFlag !== -1 ? process.argv[expectFlag + 1] : "routed";
+  const args = process.argv.slice(2);
+  const expectFlag = args.indexOf("--expect");
+  const expect = expectFlag !== -1 ? args[expectFlag + 1] : "routed";
+  let source = args.find((arg) => !arg.startsWith("--"));
+  if (!source && args.includes("--latest")) {
+    source = latestRollout(defaultSessionsRoot());
+    if (!source) {
+      console.error("verify-skill-injection: no session rollout found under ~/.codex/sessions");
+      process.exit(2);
+    }
+  }
   if (!source) {
-    console.error("Usage: verify-skill-injection.mjs <rollout.jsonl> [--expect routed|native]");
+    console.error(
+      "Usage: verify-skill-injection.mjs <rollout.jsonl> [--expect routed|native] | --latest [--expect routed|native]",
+    );
     process.exit(2);
   }
   const result = analyzeRollout(readFileSync(source, "utf8").split("\n"), { expect });

--- a/scripts/verify-skill-injection.mjs
+++ b/scripts/verify-skill-injection.mjs
@@ -131,7 +131,10 @@ function exactSkillForSource(source, block) {
   const root = r0Root(block);
   return PACK_SKILLS.find((skill) => {
     const aliases = [`r0/${skill}/SKILL.md`];
-    if (root) aliases.push(path.join(root, skill, "SKILL.md"));
+    if (root) {
+      const base = root.replace(/[\\/]+$/, "");
+      aliases.push(`${base}/${skill}/SKILL.md`, `${base}\\${skill}\\SKILL.md`);
+    }
     return aliases.some((candidate) => source.includes(candidate));
   });
 }

--- a/scripts/verify-skill-injection.mjs
+++ b/scripts/verify-skill-injection.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+// Verify that the codex-router skill pack actually reaches routed sessions.
+//
+// Given a Codex session rollout (jsonl), assert:
+//   (a) the app's <skills_instructions> block lists a pack skill under an
+//       r0 root (the user ~/.codex/skills directory);
+//   (b) the model read that SKILL.md before acting;
+//   (c) every create_thread call carries prompt and target (the two required
+//       fields the pack teaches);
+//   (d) on a native GPT session the pack skill is never read (guards the
+//       description scoping);
+//   (e) reported separately: the browser and computer-use bootstrap one-liners
+//       must be exercised against the live app runtime -- a rollout cannot
+//       prove they execute, so the script flags them as live-only.
+//
+// Read-only and deterministic. Exit code is non-zero when any assertion fails.
+//
+// Usage:
+//   node scripts/verify-skill-injection.mjs <rollout.jsonl> [--expect routed|native]
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const PACK_SKILLS = [
+  "codex-router",
+  "codex-app-threads",
+  "codex-in-app-browser",
+  "codex-computer-use",
+];
+
+function parseRollout(lines) {
+  const events = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // tolerate a non-JSON line (never in real rollouts)
+    }
+  }
+  return events;
+}
+
+// Find every injected text block (user and developer message content) so the
+// skills_instructions listing can be located. The app lands the block in a
+// user message on some sessions and a developer message on others.
+function injectedTexts(events) {
+  const texts = [];
+  for (const event of events) {
+    const payload = event?.payload || {};
+    if (!["user", "developer"].includes(payload.role)) continue;
+    if (typeof payload.content === "string") {
+      texts.push(payload.content);
+    }
+    if (Array.isArray(payload.content)) {
+      for (const part of payload.content) {
+        if (part?.type === "input_text" && typeof part.text === "string") {
+          texts.push(part.text);
+        }
+      }
+    }
+  }
+  return texts;
+}
+
+function skillsInstructions(texts) {
+  const block = texts.find((text) => text.includes("<skills_instructions>"));
+  return block || undefined;
+}
+
+function listedPackSkills(block) {
+  const listed = new Set();
+  for (const skill of PACK_SKILLS) {
+    if (block.includes(`(file: r0/${skill}/SKILL.md)`)) listed.add(skill);
+  }
+  return [...listed];
+}
+
+function modelReadsPackSkill(events) {
+  const reads = new Set();
+  for (const event of events) {
+    const item = event?.payload?.item || event?.payload || {};
+    if (item.type !== "function_call" || item.name !== "exec_command") continue;
+    const args = typeof item.arguments === "string" ? item.arguments : JSON.stringify(item.arguments || {});
+    for (const skill of PACK_SKILLS) {
+      if (args.includes(`${skill}/SKILL.md`) && reads.size < PACK_SKILLS.length) {
+        reads.add(skill);
+      }
+    }
+  }
+  return [...reads];
+}
+
+function createThreadCalls(events) {
+  const calls = [];
+  for (const event of events) {
+    const item = event?.payload?.item || event?.payload || {};
+    if (item.type !== "function_call") continue;
+    const flat = item.name === "codex_app__create_thread";
+    const native = item.name === "create_thread" && item.namespace === "codex_app";
+    if (!flat && !native) continue;
+    let args = {};
+    try {
+      args = typeof item.arguments === "string" ? JSON.parse(item.arguments) : item.arguments || {};
+    } catch {
+      args = {};
+    }
+    calls.push({ flat, native, hasPrompt: Object.hasOwn(args, "prompt"), hasTarget: Object.hasOwn(args, "target"), args });
+  }
+  return calls;
+}
+
+function sessionModel(events) {
+  const meta = events.find((event) => event?.type === "session_meta");
+  const settings = events
+    .map((event) => event?.payload?.thread_settings || event?.payload)
+    .find((payload) => payload?.model);
+  return meta?.payload?.model || settings?.model || undefined;
+}
+
+export function analyzeRollout(lines, { expect = "routed" } = {}) {
+  const events = parseRollout(lines);
+  const texts = injectedTexts(events);
+  const block = skillsInstructions(texts);
+  const listed = block ? listedPackSkills(block) : [];
+  const reads = modelReadsPackSkill(events);
+  const calls = createThreadCalls(events);
+  const model = sessionModel(events);
+  const malformed = calls.filter((call) => !call.hasPrompt || !call.hasTarget);
+
+  const assertions = [
+    {
+      name: "(a) skills_instructions lists a pack skill under r0",
+      pass: listed.length > 0,
+      detail: block
+        ? listed.length > 0
+          ? `listed: ${listed.join(", ")}`
+          : "no pack skill listed in the skills_instructions block"
+        : "no <skills_instructions> block found",
+    },
+    {
+      name: "(b) the model read a pack SKILL.md before acting",
+      pass: reads.length > 0,
+      detail: reads.length > 0 ? `read: ${reads.join(", ")}` : "no pack SKILL.md read found",
+    },
+    {
+      name: "(c) every create_thread call carries prompt and target",
+      pass: calls.length > 0 && malformed.length === 0,
+      detail:
+        calls.length === 0
+          ? "no create_thread calls in this rollout"
+          : `${calls.length} call(s), ${malformed.length} missing prompt and/or target`,
+    },
+    {
+      name: "(d) native sessions never read a pack skill",
+      pass: expect === "native" ? reads.length === 0 : true,
+      detail:
+        expect === "native"
+          ? reads.length === 0
+            ? "no pack skill read (scoping holds)"
+            : `pack skill(s) read on a native session: ${reads.join(", ")}`
+          : `skipped (expect=${expect})`,
+    },
+    {
+      name: "(e) browser and computer-use bootstraps execute (live-only)",
+      pass: undefined,
+      detail:
+        "not provable from a rollout; exercise the bootstrap one-liners in a live routed session",
+    },
+  ];
+
+  const failed = assertions.filter((assertion) => assertion.pass === false);
+  return { model, listed, reads, calls, assertions, failed, ok: failed.length === 0 };
+}
+
+function report(result, source) {
+  console.log(`verify-skill-injection: ${path.basename(source)} (model ${result.model || "unknown"})`);
+  for (const assertion of result.assertions) {
+    const verdict =
+      assertion.pass === undefined ? "LIVE" : assertion.pass ? "PASS" : "FAIL";
+    console.log(`  ${verdict.padEnd(5)} ${assertion.name}: ${assertion.detail}`);
+  }
+  if (result.failed.length > 0) {
+    console.log(`FAILED: ${result.failed.length} assertion(s)`);
+  } else {
+    console.log("OK: all rollout-checkable assertions passed");
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const source = process.argv[2];
+  const expectFlag = process.argv.indexOf("--expect");
+  const expect = expectFlag !== -1 ? process.argv[expectFlag + 1] : "routed";
+  if (!source) {
+    console.error("Usage: verify-skill-injection.mjs <rollout.jsonl> [--expect routed|native]");
+    process.exit(2);
+  }
+  const result = analyzeRollout(readFileSync(source, "utf8").split("\n"), { expect });
+  report(result, source);
+  process.exit(result.ok ? 0 : 1);
+}

--- a/skills/codex-app-threads/SKILL.md
+++ b/skills/codex-app-threads/SKILL.md
@@ -8,6 +8,10 @@ description: Create, list, read, message, wait on, fork, rename, archive, and pi
 The tools are `codex_app__*` (for example `codex_app__create_thread`). Call
 them with these exact shapes.
 
+Do NOT prefix them with `mcp__codex_apps__` — that is a different set of MCP
+servers (github, linear, notion) that exist in your tool list; the thread
+tools are `codex_app__` only.
+
 ## Create a thread
 
 `create_thread` requires TWO fields: `prompt` (string) and `target`

--- a/skills/codex-app-threads/SKILL.md
+++ b/skills/codex-app-threads/SKILL.md
@@ -7,8 +7,7 @@ description: Create, list, read, message, wait on, fork, rename, archive, and pi
 
 # Codex App Threads
 
-The tools are `codex_app__*` (for example `codex_app__create_thread`). Call
-them with these exact shapes.
+The tools are `codex_app__*` (for example `codex_app__create_thread`). Use these exact shapes.
 
 Do NOT prefix them with `mcp__codex_apps__` — that is a different set of MCP
 servers (github, linear, notion) that exist in your tool list; the thread
@@ -93,8 +92,6 @@ or needs attention wins. Use `timeoutMs: 0` for an immediate snapshot.
 
 ## Automations
 
-`automation_update` creates, updates, views, or deletes recurring
-automations. Use it when the user asks for a scheduled task, reminder,
-recurring run, follow-up, or to watch or monitor something. Pass a `mode`
-(`create`, `update`, `view`, or `delete`), a `name`, a `prompt`, and an
-`rrule` recurrence rule.
+`automation_update` creates, updates, views, or deletes recurring automations.
+Use it for a scheduled task, reminder, follow-up, or monitor. Pass a `mode`
+(`create`, `update`, `view`, or `delete`), `name`, `prompt`, and `rrule`.

--- a/skills/codex-router/SKILL.md
+++ b/skills/codex-router/SKILL.md
@@ -40,3 +40,42 @@ turns.
 1. Use the tools you were given. Do not build workarounds.
 2. Read the companion skill before the relevant work.
 3. When a call fails, fix the arguments from the skill, then retry.
+
+## Spawned threads and model inheritance
+
+When you create or continue a thread with `create_thread` or
+`send_message_to_thread`, omit the `model` field unless the user explicitly
+asked for a specific model. The router injects the session's own model into
+the call, so the new thread uses the same custom provider as you. An
+explicit model you send is never overridden.
+
+Never override a spawned agent's model to a native OpenAI model such as
+`gpt-5.6-luna` unless the user explicitly requires it. Native models can be
+quota-blocked on the account (the error reads "You've hit your usage
+limit"); a blocked spawn dies in seconds while the parent keeps waiting,
+which looks like a stopped session. Inherit your own model instead.
+
+## What the token and usage numbers mean
+
+- The router meter records provider-reported counts verbatim. When the
+  provider reports `input_tokens: 0`, the router substitutes a byte-based
+  estimate and stores it in a separate `estimatedInputTokens` field; the
+  provider's zero is preserved in the row. Treat `estimatedInputTokens` as
+  an approximation, never as a real provider count.
+- A turn whose upstream stream dies mid-flight is recorded with status 502
+  and a `streamAborted` marker. A client cancel records status 0. If you see
+  many `streamAborted` rows, the upstream connection is flaky; do not treat
+  them as model behavior.
+- The app's displayed context window is 95% of the model's advertised
+  window. The per-turn input number you see in the app can include the
+  estimate; the running total can therefore exceed the real context usage.
+
+## If the session seems to stop mid-task
+
+Check the meter at `~/.codex/codex-router/usage-events.jsonl` for the
+session's model first. Causes, in order of likelihood: a spawned thread died
+on a native usage limit while the parent waited; an upstream stream dropped
+mid-flight; the app compacted early on inflated estimated totals; the router
+restarted. The router service restarts are normally supervised by launchd
+and are not a production crash loop unless the log shows repeated exits
+without an external trigger.

--- a/skills/codex-router/SKILL.md
+++ b/skills/codex-router/SKILL.md
@@ -43,17 +43,10 @@ turns.
 
 ## Spawned threads and model inheritance
 
-When you create or continue a thread with `create_thread` or
-`send_message_to_thread`, omit the `model` field unless the user explicitly
-asked for a specific model. The router injects the session's own model into
-the call, so the new thread uses the same custom provider as you. An
-explicit model you send is never overridden.
-
-Never override a spawned agent's model to a native OpenAI model such as
-`gpt-5.6-luna` unless the user explicitly requires it. Native models can be
-quota-blocked on the account (the error reads "You've hit your usage
-limit"); a blocked spawn dies in seconds while the parent keeps waiting,
-which looks like a stopped session. Inherit your own model instead.
+For a new local Codex thread, omit the `model` field unless the user
+explicitly requested one. The router selects the parent routed model. An
+explicit model is never overridden. Follow-up messages retain the target
+thread's settings, and cloud tasks choose their model outside this relay.
 
 ## What the token and usage numbers mean
 

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -28,13 +28,10 @@ import { StringDecoder } from "node:string_decoder";
 
 export const NAMESPACE_DELIMITER = "__";
 
-// The tools that create or continue a thread with a model: `create_thread`
-// takes the model only when the user explicitly asked for one, and
-// `send_message_to_thread` describes its model field the same way. A routed
-// session that omits the field would otherwise leave the child on the app's
-// default model. The relay instead injects the current route slug so children
-// stay on the parent's selected provider. An explicit model always wins.
-export const SPAWN_MODEL_TOOLS = new Set(["create_thread", "send_message_to_thread"]);
+// A fresh local thread inherits the routed session model when the caller did
+// not choose one. Follow-up messages intentionally keep the target thread's
+// settings, and cloud tasks require model omission, so neither is rewritten.
+export const SPAWN_MODEL_TOOLS = new Set(["create_thread"]);
 const SPAWN_TOOL_PREFIX = `codex_app${NAMESPACE_DELIMITER}`;
 
 function isSpawnModelCall(item) {
@@ -50,7 +47,7 @@ function isSpawnModelCall(item) {
   return false;
 }
 
-// Inject the session model into spawn/continue tool calls that omitted it.
+// Inject the session model into local create_thread calls that omitted it.
 // `model` is the routed session's model (route.slug). Returns a rewritten
 // item when the call is one of SPAWN_MODEL_TOOLS, carries no explicit model,
 // and a session model is available; otherwise returns the item untouched.
@@ -66,6 +63,7 @@ export function injectSessionModelForSpawnCalls(item, model) {
   }
   if (typeof args !== "object" || args === null || Array.isArray(args)) return item;
   if (args.model !== undefined) return item;
+  if (args.target?.type === "chatgptWorkCloud") return item;
   return { ...item, arguments: JSON.stringify({ ...args, model }) };
 }
 

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -47,7 +47,6 @@ import {
   NamespaceToolCallTransform,
   flattenNamespacedHistory,
   flattenNamespaceTools,
-  injectSessionModelForSpawnCalls,
 } from "./namespace-relay.mjs";
 import { mergeCodexAppTools } from "./codex-app-tools.mjs";
 import { activityMetadataFromHeaders } from "./codex-session-names.mjs";
@@ -1470,17 +1469,6 @@ async function handleResponses(request, response, requestUrl) {
       if (namespacesFlattened) {
         routedInput = flattenNamespacedHistory(routedInput, flattenedNamespaces);
       }
-      // A routed session that spawns a thread without an explicit model would
-      // leave the child on the app's native default (gpt-5.6-luna, quota
-      // blocked until Sep 8), killing the child and stalling the parent. Answer
-      // for the model instead: inherit the session's routed model so the child
-      // bills the same custom provider as the parent. Explicit models pass
-      // through untouched -- the model always wins.
-      if (Array.isArray(routedInput)) {
-        routedInput = routedInput.map((item) =>
-          injectSessionModelForSpawnCalls(item, route.slug),
-        );
-      }
       const routed = {
         ...payload,
         model: route.gatewayModel,
@@ -1597,7 +1585,11 @@ async function handleResponses(request, response, requestUrl) {
       },
     );
     const transforms = [usageTransform];
-    if (namespacesFlattened) {
+    // Every routed response may contain a fresh app-native create_thread call
+    // that needs parent-model inheritance. Chat-completions routes also need
+    // flattened namespaces restored; Responses-native routes use an empty
+    // lookup and retain their already-namespaced call shape.
+    if (route) {
       transforms.push(
         new NamespaceToolCallTransform(flattenedNamespaces, upstreamContentType, route.slug),
       );

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -123,9 +123,9 @@ async function closeServer(server) {
 // (captured live): plain tools, collaboration, a reduced codex_app, and MCP
 // namespaces -- including mcp__node_repl, the in-app browser / computer-use
 // runtime, and a server whose namespace name contains the delimiter.
-function routedRequestPayload(stream = true) {
+function routedRequestPayload(stream = true, model = "opencode-go/deepseek-v4-flash") {
   return {
-    model: "opencode-go/deepseek-v4-flash",
+    model,
     stream,
     input: [
       { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
@@ -223,6 +223,27 @@ function gatewaySseBody() {
       type: "response.output_item.done",
       item: {
         type: "function_call",
+        name: "codex_app__send_message_to_thread",
+        call_id: "call_followup",
+        arguments: JSON.stringify({ threadId: "thread_1", prompt: "continue" }),
+      },
+    }),
+    sseEvent({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        name: "codex_app__create_thread",
+        call_id: "call_cloud_thread",
+        arguments: JSON.stringify({
+          prompt: "cloud",
+          target: { type: "chatgptWorkCloud" },
+        }),
+      },
+    }),
+    sseEvent({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
         name: "collaboration__spawn_agent",
         call_id: "call_agent",
         arguments: "{}",
@@ -266,9 +287,56 @@ function gatewayJsonBody() {
       },
       {
         type: "function_call",
+        name: "codex_app__send_message_to_thread",
+        call_id: "call_followup",
+        arguments: JSON.stringify({ threadId: "thread_1", prompt: "continue" }),
+      },
+      {
+        type: "function_call",
+        name: "codex_app__create_thread",
+        call_id: "call_cloud_thread",
+        arguments: JSON.stringify({
+          prompt: "cloud",
+          target: { type: "chatgptWorkCloud" },
+        }),
+      },
+      {
+        type: "function_call",
         name: "exec_command",
         call_id: "call_exec",
         arguments: "{}",
+      },
+    ],
+  };
+}
+
+function responsesProviderSseBody() {
+  return [
+    sseEvent({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        name: "create_thread",
+        namespace: "codex_app",
+        call_id: "call_native_thread",
+        arguments: JSON.stringify({ prompt: "hi", target: { type: "projectless" } }),
+      },
+    }),
+    sseEvent({ type: "response.completed" }),
+    "data: [DONE]\n\n",
+  ].join("");
+}
+
+function responsesProviderJsonBody() {
+  return {
+    id: "resp_native_json",
+    output: [
+      {
+        type: "function_call",
+        name: "create_thread",
+        namespace: "codex_app",
+        call_id: "call_native_thread",
+        arguments: JSON.stringify({ prompt: "hi", target: { type: "projectless" } }),
       },
     ],
   };
@@ -292,17 +360,24 @@ function functionCallsFromSse(body) {
   return calls;
 }
 
-async function scenario(stream = true) {
+async function scenario(
+  stream = true,
+  {
+    model = "opencode-go/deepseek-v4-flash",
+    sseBody = gatewaySseBody,
+    jsonBody = gatewayJsonBody,
+  } = {},
+) {
   const gatewayBodies = [];
   const gateway = await mockServer(async (request, response) => {
     if (request.url === "/v1/responses") {
       const gatewayBody = await bodyJson(request);
       gatewayBodies.push(gatewayBody);
       if (gatewayBody.stream === false) {
-        json(response, 200, gatewayJsonBody());
+        json(response, 200, jsonBody());
         return;
       }
-      const body = Buffer.from(gatewaySseBody(), "utf8");
+      const body = Buffer.from(sseBody(), "utf8");
       response.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Content-Length": String(body.length),
@@ -326,7 +401,7 @@ async function scenario(stream = true) {
         Authorization: "Bearer CODEX_CALLER_SECRET",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(routedRequestPayload(stream)),
+      body: JSON.stringify(routedRequestPayload(stream, model)),
     });
     assert.equal(response.status, 200, `router status ${response.status}`);
     const clientBody = await response.text();
@@ -376,12 +451,9 @@ test("routed request flattens every namespace to the gateway and restores calls 
   const historyCall = outgoing.input.find((item) => item?.type === "function_call");
   assert.equal(historyCall.name, "codex_app__create_thread");
   assert.equal(historyCall.namespace, undefined);
-  // A routed session that spawns a thread without an explicit model inherits
-  // the session's model, so the child bills the same custom provider instead
-  // of dying on the quota-blocked native default.
-  assert.deepEqual(JSON.parse(historyCall.arguments), {
-    model: "opencode-go/deepseek-v4-flash",
-  });
+  // Historical calls are evidence, not fresh outbound actions. Rewriting
+  // their model would change the transcript the provider is meant to see.
+  assert.deepEqual(JSON.parse(historyCall.arguments), {});
 
   // Function calls streaming back are restored to the client's native
   // namespace shape so the app dispatches them itself.
@@ -399,6 +471,14 @@ test("routed request flattens every namespace to the gateway and restores calls 
   });
   assert.deepEqual(JSON.parse(calls.get("call_explicit_thread").arguments), {
     model: "gpt-5.6-terra",
+  });
+  assert.deepEqual(JSON.parse(calls.get("call_followup").arguments), {
+    threadId: "thread_1",
+    prompt: "continue",
+  });
+  assert.deepEqual(JSON.parse(calls.get("call_cloud_thread").arguments), {
+    prompt: "cloud",
+    target: { type: "chatgptWorkCloud" },
   });
   assert.deepEqual(
     { name: calls.get("call_agent").name, namespace: calls.get("call_agent").namespace },
@@ -436,6 +516,50 @@ test("non-streaming routed responses restore namespace calls before client dispa
     { name: client.output[2].name, namespace: client.output[2].namespace },
     { name: "create_thread", namespace: "codex_app" },
   );
-  assert.equal(client.output[3].name, "exec_command");
-  assert.equal(client.output[3].namespace, undefined);
+  assert.deepEqual(JSON.parse(client.output[3].arguments), {
+    threadId: "thread_1",
+    prompt: "continue",
+  });
+  assert.deepEqual(
+    { name: client.output[3].name, namespace: client.output[3].namespace },
+    { name: "send_message_to_thread", namespace: "codex_app" },
+  );
+  assert.deepEqual(JSON.parse(client.output[4].arguments), {
+    prompt: "cloud",
+    target: { type: "chatgptWorkCloud" },
+  });
+  assert.deepEqual(
+    { name: client.output[4].name, namespace: client.output[4].namespace },
+    { name: "create_thread", namespace: "codex_app" },
+  );
+  assert.equal(client.output[5].name, "exec_command");
+  assert.equal(client.output[5].namespace, undefined);
+});
+
+test("Responses-native routed providers inherit the model on fresh local thread calls", async () => {
+  const options = {
+    model: "opencode-go-responses/gpt-5.6-luna",
+    sseBody: responsesProviderSseBody,
+    jsonBody: responsesProviderJsonBody,
+  };
+  const streamed = await scenario(true, options);
+  assert.equal(streamed.gatewayBodies[0].model, "opencode-go-responses-gpt-5-6-luna");
+  assert.ok(
+    streamed.gatewayBodies[0].tools.some((tool) => tool?.type === "namespace"),
+    "Responses-native tools stay namespaced",
+  );
+  const streamedCall = functionCallsFromSse(streamed.clientBody).get("call_native_thread");
+  assert.deepEqual(JSON.parse(streamedCall.arguments), {
+    prompt: "hi",
+    target: { type: "projectless" },
+    model: "opencode-go-responses/gpt-5.6-luna",
+  });
+
+  const nonStreaming = await scenario(false, options);
+  const nonStreamingCall = JSON.parse(nonStreaming.clientBody).output[0];
+  assert.deepEqual(JSON.parse(nonStreamingCall.arguments), {
+    prompt: "hi",
+    target: { type: "projectless" },
+    model: "opencode-go-responses/gpt-5.6-luna",
+  });
 });

--- a/test/subagent-model-inherit.test.mjs
+++ b/test/subagent-model-inherit.test.mjs
@@ -19,11 +19,8 @@ function spawnCall(name, namespace, argumentsText) {
   return item;
 }
 
-test("spawn tools are exactly create_thread and send_message_to_thread", () => {
-  assert.deepEqual([...SPAWN_MODEL_TOOLS].sort(), [
-    "create_thread",
-    "send_message_to_thread",
-  ]);
+test("only create_thread is eligible for routed model inheritance", () => {
+  assert.deepEqual([...SPAWN_MODEL_TOOLS], ["create_thread"]);
 });
 
 test("routed session + omitted model injects the session model (flattened form)", () => {
@@ -37,18 +34,14 @@ test("routed session + omitted model injects the session model (flattened form)"
   });
 });
 
-test("routed session + omitted model injects the session model (namespaced form)", () => {
+test("send_message_to_thread keeps the target thread model settings", () => {
   const item = spawnCall(
     "send_message_to_thread",
     "codex_app",
     JSON.stringify({ threadId: "t1", prompt: "continue" }),
   );
   const next = injectSessionModelForSpawnCalls(item, SESSION_MODEL);
-  assert.deepEqual(JSON.parse(next.arguments), {
-    threadId: "t1",
-    prompt: "continue",
-    model: SESSION_MODEL,
-  });
+  assert.equal(next, item);
 });
 
 test("explicit model always wins and stays untouched", () => {
@@ -67,6 +60,15 @@ test("explicit model always wins and stays untouched", () => {
     JSON.stringify({ threadId: "t1", prompt: "continue", model: "gpt-5.5" }),
   );
   assert.equal(injectSessionModelForSpawnCalls(namespaced, SESSION_MODEL), namespaced);
+});
+
+test("chatgptWorkCloud create_thread calls omit model", () => {
+  const item = spawnCall(
+    "codex_app__create_thread",
+    undefined,
+    JSON.stringify({ prompt: "cloud", target: { type: "chatgptWorkCloud" } }),
+  );
+  assert.equal(injectSessionModelForSpawnCalls(item, SESSION_MODEL), item);
 });
 
 test("non-routed session + omitted model stays untouched", () => {

--- a/test/verify-skill-injection.test.mjs
+++ b/test/verify-skill-injection.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { analyzeRollout, PACK_SKILLS } from "../scripts/verify-skill-injection.mjs";
+
+function skillsBlock(packSkills = []) {
+  const roots = [
+    "r0 = /Users/user/.codex/skills",
+    "r1 = /Users/user/.agents/skills",
+  ];
+  const entries = packSkills.map((skill) => `(file: r0/${skill}/SKILL.md)`);
+  return `<skills_instructions>\n${roots.join("\n")}\n${entries.join("\n")}\n</skills_instructions>`;
+}
+
+function meta(model) {
+  return {
+    type: "session_meta",
+    payload: { model, cli_version: "0.147.0-alpha.6.5", originator: "Codex Desktop" },
+  };
+}
+
+function userBlock(text) {
+  return {
+    type: "response_item",
+    payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+  };
+}
+
+function execRead(skill) {
+  return {
+    type: "response_item",
+    payload: {
+      type: "function_call",
+      item: {
+        type: "function_call",
+        name: "exec_command",
+        call_id: "call_read",
+        arguments: JSON.stringify({
+          cmd: `cat /Users/user/.codex/skills/${skill}/SKILL.md`,
+        }),
+      },
+    },
+  };
+}
+
+function createThread(args) {
+  return {
+    type: "response_item",
+    payload: {
+      type: "function_call",
+      item: {
+        type: "function_call",
+        name: "create_thread",
+        namespace: "codex_app",
+        call_id: "call_thread",
+        arguments: JSON.stringify(args),
+      },
+    },
+  };
+}
+
+function lines(...events) {
+  return events.map((event) => JSON.stringify(event));
+}
+
+test("a routed session that lists, reads, and calls correctly passes", () => {
+  const result = analyzeRollout(
+    lines(
+      meta("opencode-go/deepseek-v4-flash"),
+      userBlock(skillsBlock(["codex-app-threads", "codex-router"])),
+      execRead("codex-app-threads"),
+      createThread({ prompt: "hi", target: { type: "projectless" }, title: "X" }),
+    ),
+    { expect: "routed" },
+  );
+  assert.equal(result.ok, true, JSON.stringify(result.assertions));
+  assert.deepEqual(result.listed, ["codex-router", "codex-app-threads"]);
+  assert.ok(result.reads.includes("codex-app-threads"));
+  assert.equal(result.calls.length, 1);
+  assert.ok(result.calls[0].hasPrompt && result.calls[0].hasTarget);
+});
+
+test("create_thread without prompt fails assertion (c)", () => {
+  const result = analyzeRollout(
+    lines(
+      meta("opencode-go/deepseek-v4-flash"),
+      userBlock(skillsBlock(["codex-app-threads"])),
+      execRead("codex-app-threads"),
+      createThread({ target: { type: "projectless" } }),
+    ),
+  );
+  const assertion = result.assertions.find((a) => a.name.startsWith("(c)"));
+  assert.equal(assertion.pass, false);
+  assert.match(assertion.detail, /missing prompt and\/or target/);
+});
+
+test("a session that never lists the pack fails assertion (a)", () => {
+  const result = analyzeRollout(
+    lines(
+      meta("opencode-go/deepseek-v4-flash"),
+      userBlock("<skills_instructions>\nr0 = /Users/user/.codex/skills\n</skills_instructions>"),
+      createThread({ prompt: "hi", target: { type: "projectless" } }),
+    ),
+  );
+  const assertion = result.assertions.find((a) => a.name.startsWith("(a)"));
+  assert.equal(assertion.pass, false);
+});
+
+test("a native session that reads a pack skill fails assertion (d)", () => {
+  const result = analyzeRollout(
+    lines(
+      meta("gpt-5.6-luna"),
+      userBlock(skillsBlock(["codex-app-threads"])),
+      execRead("codex-app-threads"),
+    ),
+    { expect: "native" },
+  );
+  const assertion = result.assertions.find((a) => a.name.startsWith("(d)"));
+  assert.equal(assertion.pass, false);
+});
+
+test("a native session that never reads a pack skill passes assertion (d)", () => {
+  const result = analyzeRollout(
+    lines(meta("gpt-5.6-luna"), userBlock(skillsBlock(["codex-app-threads"]))),
+    { expect: "native" },
+  );
+  const assertion = result.assertions.find((a) => a.name.startsWith("(d)"));
+  assert.equal(assertion.pass, true);
+});
+
+test("the pack list is the four shipped skills", () => {
+  assert.deepEqual([...PACK_SKILLS].sort(), [
+    "codex-app-threads",
+    "codex-computer-use",
+    "codex-in-app-browser",
+    "codex-router",
+  ]);
+});

--- a/test/verify-skill-injection.test.mjs
+++ b/test/verify-skill-injection.test.mjs
@@ -1,64 +1,118 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { analyzeRollout, latestRollout, PACK_SKILLS } from "../scripts/verify-skill-injection.mjs";
+import {
+  analyzeRollout,
+  latestRollout,
+  PACK_SKILLS,
+  parseCliArgs,
+} from "../scripts/verify-skill-injection.mjs";
 
-function skillsBlock(packSkills = []) {
-  const roots = [
-    "r0 = /Users/user/.codex/skills",
-    "r1 = /Users/user/.agents/skills",
-  ];
+const SKILLS_ROOT = "/Users/user/.codex/skills";
+
+function skillsBlock(packSkills = PACK_SKILLS) {
   const entries = packSkills.map((skill) => `(file: r0/${skill}/SKILL.md)`);
-  return `<skills_instructions>\n${roots.join("\n")}\n${entries.join("\n")}\n</skills_instructions>`;
+  return [
+    "<skills_instructions>",
+    `r0 = ${SKILLS_ROOT}`,
+    "r1 = /Users/user/.agents/skills",
+    ...entries,
+    "</skills_instructions>",
+  ].join("\n");
+}
+
+function withTurn(payload, turnId = "turn-1") {
+  return {
+    ...payload,
+    internal_chat_message_metadata_passthrough: { turn_id: turnId },
+  };
 }
 
 function meta(model) {
+  return { type: "session_meta", payload: { model, originator: "Codex Desktop" } };
+}
+
+function developerBlock(text = skillsBlock(), turnId = "turn-1") {
   return {
-    type: "session_meta",
-    payload: { model, cli_version: "0.147.0-alpha.6.5", originator: "Codex Desktop" },
+    type: "response_item",
+    payload: withTurn(
+      { type: "message", role: "developer", content: [{ type: "input_text", text }] },
+      turnId,
+    ),
   };
 }
 
-function userBlock(text) {
+function userBlock(text = skillsBlock(), turnId = "turn-1") {
   return {
     type: "response_item",
-    payload: { type: "message", role: "user", content: [{ type: "input_text", text }] },
+    payload: withTurn(
+      { type: "message", role: "user", content: [{ type: "input_text", text }] },
+      turnId,
+    ),
   };
 }
 
-function execRead(skill) {
+function customExecRead(skill = "codex-app-threads", turnId = "turn-1", callId = "read-1") {
   return {
     type: "response_item",
-    payload: {
-      type: "function_call",
-      item: {
+    payload: withTurn(
+      {
+        type: "custom_tool_call",
+        name: "exec",
+        call_id: callId,
+        input: `sed -n '1,200p' ${SKILLS_ROOT}/${skill}/SKILL.md`,
+      },
+      turnId,
+    ),
+  };
+}
+
+function legacyExecRead(skill = "codex-app-threads", turnId = "turn-1", callId = "read-1") {
+  return {
+    type: "response_item",
+    payload: withTurn(
+      {
         type: "function_call",
         name: "exec_command",
-        call_id: "call_read",
-        arguments: JSON.stringify({
-          cmd: `cat /Users/user/.codex/skills/${skill}/SKILL.md`,
-        }),
+        call_id: callId,
+        arguments: JSON.stringify({ cmd: `cat ${SKILLS_ROOT}/${skill}/SKILL.md` }),
       },
-    },
+      turnId,
+    ),
   };
 }
 
-function createThread(args) {
+function toolOutput(callId = "read-1", turnId = "turn-1", legacy = false) {
   return {
     type: "response_item",
-    payload: {
-      type: "function_call",
-      item: {
+    payload: withTurn(
+      {
+        type: legacy ? "function_call_output" : "custom_tool_call_output",
+        call_id: callId,
+        output: "skill contents",
+      },
+      turnId,
+    ),
+  };
+}
+
+function createThread(args, turnId = "turn-1") {
+  return {
+    type: "response_item",
+    payload: withTurn(
+      {
         type: "function_call",
         name: "create_thread",
         namespace: "codex_app",
-        call_id: "call_thread",
+        call_id: "thread-1",
         arguments: JSON.stringify(args),
       },
-    },
+      turnId,
+    ),
   };
 }
 
@@ -66,69 +120,131 @@ function lines(...events) {
   return events.map((event) => JSON.stringify(event));
 }
 
-test("a routed session that lists, reads, and calls correctly passes", () => {
+function routedEvents(read = customExecRead(), output = toolOutput()) {
+  return [
+    meta("opencode-go/deepseek-v4-flash"),
+    developerBlock(),
+    read,
+    output,
+    createThread({ prompt: "hi", target: { type: "projectless" } }),
+  ];
+}
+
+test("trusted developer injection plus current exec call and output passes", () => {
+  const result = analyzeRollout(lines(...routedEvents()), { expect: "routed" });
+  assert.equal(result.ok, true, JSON.stringify(result.assertions));
+  assert.equal(result.turnId, "turn-1");
+  assert.deepEqual(result.listed, PACK_SKILLS);
+  assert.deepEqual(result.reads, ["codex-app-threads"]);
+  assert.equal(result.calls.length, 1);
+});
+
+test("legacy exec_command read remains compatible when its output is observed", () => {
   const result = analyzeRollout(
-    lines(
-      meta("opencode-go/deepseek-v4-flash"),
-      userBlock(skillsBlock(["codex-app-threads", "codex-router"])),
-      execRead("codex-app-threads"),
-      createThread({ prompt: "hi", target: { type: "projectless" }, title: "X" }),
-    ),
-    { expect: "routed" },
+    lines(...routedEvents(legacyExecRead(), toolOutput("read-1", "turn-1", true))),
   );
   assert.equal(result.ok, true, JSON.stringify(result.assertions));
-  assert.deepEqual(result.listed, ["codex-router", "codex-app-threads"]);
-  assert.ok(result.reads.includes("codex-app-threads"));
-  assert.equal(result.calls.length, 1);
-  assert.ok(result.calls[0].hasPrompt && result.calls[0].hasTarget);
 });
 
-test("create_thread without prompt fails assertion (c)", () => {
+test("user-pasted and embedded developer blocks cannot become trusted injection", () => {
+  for (const event of [
+    userBlock(),
+    developerBlock(`preface\n${skillsBlock()}\npostscript`),
+    {
+      type: "response_item",
+      payload: withTurn({
+        type: "agent_message",
+        role: "developer",
+        content: [{ type: "input_text", text: skillsBlock() }],
+      }),
+    },
+  ]) {
+    const result = analyzeRollout(lines(meta("routed"), event, customExecRead(), toolOutput(), createThread({ prompt: "x", target: {} })));
+    assert.equal(result.assertions[0].pass, false);
+  }
+});
+
+test("malformed wrapper, partial pack, and missing turn id fail injection", () => {
+  const missingTurn = developerBlock();
+  delete missingTurn.payload.internal_chat_message_metadata_passthrough;
+  for (const event of [
+    developerBlock(skillsBlock().replace("</skills_instructions>", "")),
+    developerBlock(skillsBlock(["codex-router"])),
+    missingTurn,
+  ]) {
+    const result = analyzeRollout(lines(meta("routed"), event));
+    assert.equal(result.assertions[0].pass, false);
+  }
+});
+
+test("read before injection or in another turn is not same-turn evidence", () => {
+  for (const events of [
+    [customExecRead(), toolOutput(), developerBlock(), createThread({ prompt: "x", target: {} })],
+    [developerBlock(), customExecRead("codex-app-threads", "turn-2"), toolOutput("read-1", "turn-2"), createThread({ prompt: "x", target: {} })],
+  ]) {
+    const result = analyzeRollout(lines(meta("routed"), ...events));
+    assert.equal(result.assertions[1].pass, false);
+  }
+});
+
+test("a read call without correlated output is reported but not claimed complete", () => {
   const result = analyzeRollout(
-    lines(
-      meta("opencode-go/deepseek-v4-flash"),
-      userBlock(skillsBlock(["codex-app-threads"])),
-      execRead("codex-app-threads"),
-      createThread({ target: { type: "projectless" } }),
-    ),
+    lines(meta("routed"), developerBlock(), customExecRead(), createThread({ prompt: "x", target: {} })),
   );
-  const assertion = result.assertions.find((a) => a.name.startsWith("(c)"));
-  assert.equal(assertion.pass, false);
-  assert.match(assertion.detail, /missing prompt and\/or target/);
+  assert.equal(result.assertions[1].pass, false);
+  assert.match(result.assertions[1].detail, /issued, output not observed/);
+  assert.equal(result.issuedWithoutOutput.length, 1);
 });
 
-test("a session that never lists the pack fails assertion (a)", () => {
-  const result = analyzeRollout(
-    lines(
-      meta("opencode-go/deepseek-v4-flash"),
-      userBlock("<skills_instructions>\nr0 = /Users/user/.codex/skills\n</skills_instructions>"),
-      createThread({ prompt: "hi", target: { type: "projectless" } }),
-    ),
+test("same-turn malformed create_thread fails but historical malformed calls do not", () => {
+  const historical = createThread({ target: {} }, "turn-old");
+  const passing = analyzeRollout(lines(historical, ...routedEvents()));
+  assert.equal(passing.assertions[2].pass, true);
+
+  const failing = analyzeRollout(
+    lines(meta("routed"), developerBlock(), customExecRead(), toolOutput(), createThread({ target: {} })),
   );
-  const assertion = result.assertions.find((a) => a.name.startsWith("(a)"));
-  assert.equal(assertion.pass, false);
+  assert.equal(failing.assertions[2].pass, false);
 });
 
-test("a native session that reads a pack skill fails assertion (d)", () => {
-  const result = analyzeRollout(
-    lines(
-      meta("gpt-5.6-luna"),
-      userBlock(skillsBlock(["codex-app-threads"])),
-      execRead("codex-app-threads"),
-    ),
+test("native mode fails only for a completed post-injection pack-path call", () => {
+  const noRead = analyzeRollout(lines(meta("gpt-5.6-luna"), developerBlock()), {
+    expect: "native",
+  });
+  assert.equal(noRead.ok, true, JSON.stringify(noRead.assertions));
+
+  const issuedOnly = analyzeRollout(
+    lines(meta("gpt-5.6-luna"), developerBlock(), customExecRead()),
     { expect: "native" },
   );
-  const assertion = result.assertions.find((a) => a.name.startsWith("(d)"));
-  assert.equal(assertion.pass, false);
-});
+  assert.equal(issuedOnly.ok, true, JSON.stringify(issuedOnly.assertions));
 
-test("a native session that never reads a pack skill passes assertion (d)", () => {
-  const result = analyzeRollout(
-    lines(meta("gpt-5.6-luna"), userBlock(skillsBlock(["codex-app-threads"]))),
+  const completed = analyzeRollout(
+    lines(meta("gpt-5.6-luna"), developerBlock(), customExecRead(), toolOutput()),
     { expect: "native" },
   );
-  const assertion = result.assertions.find((a) => a.name.startsWith("(d)"));
-  assert.equal(assertion.pass, true);
+  assert.equal(completed.assertions[3].pass, false);
+});
+
+test("a path-only exec is reported as reference evidence, not proof of file bytes read", () => {
+  const pathOnly = customExecRead();
+  pathOnly.payload.input = `console.log("${SKILLS_ROOT}/codex-app-threads/SKILL.md")`;
+  const result = analyzeRollout(
+    lines(
+      meta("routed"),
+      developerBlock(),
+      pathOnly,
+      toolOutput(),
+      createThread({ prompt: "x", target: {} }),
+    ),
+  );
+  assert.equal(result.ok, true, JSON.stringify(result.assertions));
+  assert.match(result.assertions[1].name, /referencing/);
+  assert.doesNotMatch(result.assertions[1].detail, /\bread\b/);
+});
+
+test("invalid analysis expectation is rejected", () => {
+  assert.throws(() => analyzeRollout([], { expect: "anything" }), /invalid expectation/);
 });
 
 test("the pack list is the four shipped skills", () => {
@@ -140,6 +256,25 @@ test("the pack list is the four shipped skills", () => {
   ]);
 });
 
+test("CLI parser accepts options in either order and rejects ambiguous input", () => {
+  assert.deepEqual(parseCliArgs(["--latest", "--expect", "native"]), {
+    expect: "native",
+    latest: true,
+    source: undefined,
+  });
+  assert.deepEqual(parseCliArgs(["rollout.jsonl", "--expect", "routed"]), {
+    expect: "routed",
+    latest: false,
+    source: "rollout.jsonl",
+  });
+  assert.throws(() => parseCliArgs(["--expect"]), /requires/);
+  assert.throws(() => parseCliArgs(["--expect", "maybe", "x"]), /invalid/);
+  assert.throws(() => parseCliArgs(["--wat"]), /unknown/);
+  assert.throws(() => parseCliArgs(["a", "b"]), /only one/);
+  assert.throws(() => parseCliArgs(["a", "--latest"]), /either/);
+  assert.throws(() => parseCliArgs([]), /required/);
+});
+
 test("latestRollout picks the newest jsonl recursively", () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "sessions-probe-"));
   try {
@@ -149,12 +284,35 @@ test("latestRollout picks the newest jsonl recursively", () => {
     const newer = path.join(day, "rollout-new.jsonl");
     writeFileSync(older, "{}");
     writeFileSync(newer, "{}");
-    // Bump the newer file's mtime past the older one's (same-second writes
-    // can tie); the walk keeps the last strictly-greater candidate.
     const future = new Date(Date.now() + 5_000);
     utimesSync(newer, future, future);
     assert.equal(latestRollout(root), newer);
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("CLI --latest --expect routed resolves the rollout instead of treating routed as a path", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "verify-skills-cli-"));
+  try {
+    const sessions = path.join(codexHome, "sessions");
+    mkdirSync(sessions, { recursive: true });
+    writeFileSync(
+      path.join(sessions, "rollout.jsonl"),
+      `${lines(...routedEvents()).join("\n")}\n`,
+    );
+    const result = spawnSync(
+      process.execPath,
+      [path.resolve("scripts/verify-skill-injection.mjs"), "--latest", "--expect", "routed"],
+      {
+        cwd: path.resolve("."),
+        env: { ...process.env, CODEX_HOME: codexHome },
+        encoding: "utf8",
+      },
+    );
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout, /OK: all rollout-checkable assertions passed/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
   }
 });

--- a/test/verify-skill-injection.test.mjs
+++ b/test/verify-skill-injection.test.mjs
@@ -146,6 +146,23 @@ test("legacy exec_command read remains compatible when its output is observed", 
   assert.equal(result.ok, true, JSON.stringify(result.assertions));
 });
 
+test("skill-path evidence accepts Windows roots without depending on the verifier host", () => {
+  const windowsRoot = "C:\\Users\\user\\.codex\\skills";
+  const injection = developerBlock(skillsBlock().replace(SKILLS_ROOT, windowsRoot));
+  const call = customExecRead();
+  call.payload.input = `Get-Content ${windowsRoot}\\codex-app-threads\\SKILL.md`;
+  const result = analyzeRollout(
+    lines(
+      meta("routed"),
+      injection,
+      call,
+      toolOutput(),
+      createThread({ prompt: "x", target: {} }),
+    ),
+  );
+  assert.equal(result.ok, true, JSON.stringify(result.assertions));
+});
+
 test("user-pasted and embedded developer blocks cannot become trusted injection", () => {
   for (const event of [
     userBlock(),

--- a/test/verify-skill-injection.test.mjs
+++ b/test/verify-skill-injection.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
-import { analyzeRollout, PACK_SKILLS } from "../scripts/verify-skill-injection.mjs";
+import { analyzeRollout, latestRollout, PACK_SKILLS } from "../scripts/verify-skill-injection.mjs";
 
 function skillsBlock(packSkills = []) {
   const roots = [
@@ -135,4 +138,23 @@ test("the pack list is the four shipped skills", () => {
     "codex-in-app-browser",
     "codex-router",
   ]);
+});
+
+test("latestRollout picks the newest jsonl recursively", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "sessions-probe-"));
+  try {
+    const day = path.join(root, "2026", "08", "10");
+    mkdirSync(day, { recursive: true });
+    const older = path.join(day, "rollout-old.jsonl");
+    const newer = path.join(day, "rollout-new.jsonl");
+    writeFileSync(older, "{}");
+    writeFileSync(newer, "{}");
+    // Bump the newer file's mtime past the older one's (same-second writes
+    // can tie); the walk keeps the last strictly-greater candidate.
+    const future = new Date(Date.now() + 5_000);
+    utimesSync(newer, future, future);
+    assert.equal(latestRollout(root), newer);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## What

Tooling around the skill pack and relay:

- `verify-skill-injection.mjs`: probes the newest routed session and asserts (a) the pack is listed, (b) the model reads the skill, (c) `create_thread` shape, (d) native non-read; `--latest` auto-finds the newest session.
- `codex-app-threads` skill: warns against the `mcp__codex_apps__` prefix.
- Skill documentation for model inheritance, meter semantics, and session-stop diagnosis (added during review).

Commits: `e571550`, `226f877`, `d817843` + `758a79e` (skill doc commit added at review, content otherwise identical to originals).

## Verification

- `npm test`: 716 tests, 709 pass, 0 fail, 7 skipped (before the doc commit; the doc commit adds no code).
- `npm run check` passes.
- Injection probe passes against the newest routed session (thread created first try, browser + computer-use tool paths relay).

## Stack

Merges last, after `pr/relay-namespaces` and `pr/skill-pack`.