### PR TITLE
feat: diagnose kimi oauth credential health without breaking refresh

### DIFF
--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -10,7 +10,7 @@ import { grokCliPreflight } from "./grok-cli.mjs";
 import { detectLegacyInstallations } from "./legacy-migration.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
-import { kimiOAuthStatus } from "./oauth-status.mjs";
+import { kimiOAuthHealth, kimiOAuthStatus } from "./oauth-status.mjs";
 import {
   readMultiAgentSettings,
   subagentEligibleModels,
@@ -487,11 +487,22 @@ add(
 );
 
 const oauth = kimiOAuthStatus();
+const kimiHealth = kimiOAuthHealth();
+const kimiSelected = selection.providers.includes("kimi-oauth");
+// An expired access token is a normal, recoverable state: the request path
+// refreshes it with the still-valid refresh token before forwarding, so it
+// must not read as a failure here. A revoked tombstone (refresh rejected) is
+// the opposite -- the session genuinely needs `kimi login` again.
+const kimiStatus = kimiHealth.status === "revoked" ? "fail" : oauth.configured ? "ok" : kimiSelected ? "fail" : "warn";
 add(
-  oauth.configured ? "ok" : selection.providers.includes("kimi-oauth") ? "fail" : "warn",
+  kimiStatus,
   "Kimi OAuth",
-  oauth.configured ? "credential present" : `not configured; ${oauth.setup}`,
-  "Run kimi login, then rerun the doctor.",
+  oauth.configured ? kimiHealth.detail : `not configured; ${oauth.setup}`,
+  kimiHealth.status === "revoked"
+    ? kimiHealth.fix
+    : oauth.configured
+      ? kimiHealth.fix
+      : "Run kimi login, then rerun the doctor.",
 );
 const grokOauth = grokOAuthStatus();
 const grokCli = grokCliPreflight();

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -10,7 +10,7 @@ import { grokCliPreflight } from "./grok-cli.mjs";
 import { detectLegacyInstallations } from "./legacy-migration.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
-import { kimiOAuthHealth, kimiOAuthStatus } from "./oauth-status.mjs";
+import { kimiOAuthHealth } from "./oauth-status.mjs";
 import {
   readMultiAgentSettings,
   subagentEligibleModels,
@@ -486,23 +486,23 @@ add(
   "Run ./bin/doctor --fix; this capability is generated locally and is not a provider key.",
 );
 
-const oauth = kimiOAuthStatus();
 const kimiHealth = kimiOAuthHealth();
 const kimiSelected = selection.providers.includes("kimi-oauth");
 // An expired access token is a normal, recoverable state: the request path
 // refreshes it with the still-valid refresh token before forwarding, so it
-// must not read as a failure here. A revoked tombstone (refresh rejected) is
-// the opposite -- the session genuinely needs `kimi login` again.
-const kimiStatus = kimiHealth.status === "revoked" ? "fail" : oauth.configured ? "ok" : kimiSelected ? "fail" : "warn";
+// must not read as a failure here. Every unusable state fails when Kimi OAuth
+// is selected; an unselected provider is advisory regardless of credential
+// health.
+const kimiStatus = !kimiSelected
+  ? "warn"
+  : kimiHealth.status === "ok" || kimiHealth.status === "stale"
+    ? "ok"
+    : "fail";
 add(
   kimiStatus,
   "Kimi OAuth",
-  oauth.configured ? kimiHealth.detail : `not configured; ${oauth.setup}`,
-  kimiHealth.status === "revoked"
-    ? kimiHealth.fix
-    : oauth.configured
-      ? kimiHealth.fix
-      : "Run kimi login, then rerun the doctor.",
+  kimiHealth.detail,
+  kimiHealth.fix,
 );
 const grokOauth = grokOAuthStatus();
 const grokCli = grokCliPreflight();

--- a/src/oauth-status.mjs
+++ b/src/oauth-status.mjs
@@ -6,12 +6,12 @@ export function kimiCodeHome() {
   return process.env.KIMI_CODE_HOME || path.join(os.homedir(), ".kimi-code");
 }
 
+function kimiCredentialsPath() {
+  return path.join(kimiCodeHome(), "credentials", "kimi-code.json");
+}
+
 export function kimiOAuthStatus() {
-  const credentialsPath = path.join(
-    kimiCodeHome(),
-    "credentials",
-    "kimi-code.json",
-  );
+  const credentialsPath = kimiCredentialsPath();
   if (!existsSync(credentialsPath)) {
     return {
       configured: false,
@@ -36,4 +36,83 @@ export function kimiOAuthStatus() {
       setup: "Run `kimi login` again; the credential file is invalid",
     };
   }
+}
+
+// A deeper, read-only look at the credential than `kimiOAuthStatus()` offers,
+// aligned with what the session reader (`kimi-oauth-session.mjs` validateToken)
+// will accept at request time so a status verdict never diverges from runtime
+// usability:
+//
+// - `ok`:      a live session that will serve requests
+// - `stale`:   the access token is past its expiry, but the session is still
+//              recoverable -- `ensureFreshKimiOAuthToken()` refreshes it with
+//              the still-valid refresh token before forwarding, so this is a
+//              working install, not a failure
+// - `revoked`: the CLI wrote its revoked tombstone (all-empty tokens with zero
+//              expiry metadata); the refresh was rejected, so `kimi login` is
+//              genuinely required
+// - `incomplete` / `invalid` / `missing`: no usable session on disk
+export function kimiOAuthHealth() {
+  const credentialsPath = kimiCredentialsPath();
+  if (!existsSync(credentialsPath)) {
+    return {
+      status: "missing",
+      detail: "no credential file",
+      fix: "Run `kimi login` in an interactive terminal",
+    };
+  }
+  let value;
+  try {
+    value = JSON.parse(readFileSync(credentialsPath, "utf8"));
+  } catch {
+    return {
+      status: "invalid",
+      detail: "credential file is not valid JSON",
+      fix: "Run `kimi login` again; the credential file is invalid",
+    };
+  }
+  // Mirrors validateToken's all-empty + zero-metadata tombstone shape.
+  const revoked =
+    value?.access_token === "" &&
+    value?.refresh_token === "" &&
+    Number(value?.expires_at) === 0 &&
+    Number(value?.expires_in) === 0;
+  if (revoked) {
+    return {
+      status: "revoked",
+      detail: "OAuth session was rejected by Kimi",
+      fix: "Run `kimi login` again; the session must be re-authorized",
+    };
+  }
+  const hasTokens =
+    typeof value?.access_token === "string" &&
+    value.access_token !== "" &&
+    typeof value?.refresh_token === "string" &&
+    value.refresh_token !== "";
+  if (!hasTokens) {
+    return {
+      status: "incomplete",
+      detail: "credential file is missing the access or refresh token",
+      fix: "Run `kimi login` again; the credential file is incomplete",
+    };
+  }
+  const expiresAt = Number(value?.expires_at);
+  const expiresIn = Number(value?.expires_in);
+  if (!Number.isFinite(expiresAt) || !Number.isFinite(expiresIn)) {
+    return {
+      status: "incomplete",
+      detail: "credential file is missing finite second-based expiry metadata",
+      fix: "Run `kimi login` again; the credential file is incomplete",
+    };
+  }
+  const stale = Math.floor(Date.now() / 1_000) >= expiresAt;
+  return {
+    status: stale ? "stale" : "ok",
+    detail: stale
+      ? "access token expired; it refreshes automatically on the next request"
+      : "credential present",
+    fix: stale
+      ? "No action needed; ensureFreshKimiOAuthToken() refreshes it before forwarding."
+      : undefined,
+  };
 }

--- a/test/doctor-kimi-oauth-health.test.mjs
+++ b/test/doctor-kimi-oauth-health.test.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test, { after, before } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+let healthServer;
+let routerPort;
+
+before(async () => {
+  healthServer = spawn(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      `
+        import http from "node:http";
+        const server = http.createServer((_request, response) => {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(JSON.stringify({ service: "codex-router", version: "test" }));
+        });
+        server.listen(0, "127.0.0.1", () => process.stdout.write(String(server.address().port)));
+      `,
+    ],
+    { stdio: ["ignore", "pipe", "inherit"] },
+  );
+  const [chunk] = await once(healthServer.stdout, "data");
+  routerPort = Number(chunk);
+});
+
+after(() => {
+  healthServer?.kill();
+});
+
+function removeDirectoryIfPresent(directory) {
+  if (existsSync(directory)) rmdirSync(directory);
+}
+
+function doctorKimiCheck({ selected, credential }) {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "doctor-kimi-health-"));
+  const stateDir = path.join(testRoot, "state");
+  const kimiHome = path.join(testRoot, "kimi");
+  const credentialsDir = path.join(kimiHome, "credentials");
+  const credentialsPath = path.join(credentialsDir, "kimi-code.json");
+  const selectionPath = path.join(stateDir, "enabled-providers.json");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(
+    selectionPath,
+    JSON.stringify({ version: 1, providers: selected ? ["kimi-oauth"] : [] }),
+    { mode: 0o600 },
+  );
+  if (credential !== undefined) {
+    mkdirSync(credentialsDir, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      credentialsPath,
+      typeof credential === "string" ? credential : JSON.stringify(credential),
+      { mode: 0o600 },
+    );
+  }
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [path.join(root, "src", "doctor.mjs"), "--json"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: testRoot,
+          USERPROFILE: testRoot,
+          CODEX_HOME: path.join(testRoot, "codex"),
+          CODEX_BIN: process.execPath,
+          KIMI_CODE_HOME: kimiHome,
+          MODEL_ROUTER_TARGET: "codex",
+          MODEL_ROUTER_STATE_DIR: stateDir,
+          MODEL_ROUTER_LAUNCH_AGENTS_DIR: path.join(testRoot, "launch-agents"),
+          MODEL_ROUTER_PORT: String(routerPort),
+          MODEL_ROUTER_SHOW_ALL_MODELS: "0",
+          CODEX_ROUTER_SHOW_ALL_MODELS: "0",
+        },
+        timeout: 120_000,
+      },
+    );
+    assert.ok(result.stdout, result.stderr);
+    const check = JSON.parse(result.stdout).checks.find(({ name }) => name === "Kimi OAuth");
+    assert.ok(check, "doctor must include the Kimi OAuth check");
+    return check;
+  } finally {
+    rmSync(credentialsPath, { force: true });
+    removeDirectoryIfPresent(credentialsDir);
+    removeDirectoryIfPresent(kimiHome);
+    rmSync(selectionPath, { force: true });
+    removeDirectoryIfPresent(stateDir);
+    removeDirectoryIfPresent(testRoot);
+  }
+}
+
+function fixtures() {
+  const now = Math.floor(Date.now() / 1_000);
+  return [
+    {
+      name: "live",
+      credential: {
+        access_token: "access-value",
+        refresh_token: "refresh-value",
+        expires_at: now + 3_600,
+        expires_in: 3_600,
+      },
+      status: "ok",
+      detail: /credential present/,
+    },
+    {
+      name: "stale",
+      credential: {
+        access_token: "access-value",
+        refresh_token: "refresh-value",
+        expires_at: now - 3_600,
+        expires_in: 3_600,
+      },
+      status: "ok",
+      detail: /refreshes automatically/,
+    },
+    {
+      name: "missing",
+      credential: undefined,
+      status: "fail",
+      detail: /no credential file/,
+      fix: /kimi login/,
+    },
+    {
+      name: "invalid",
+      credential: "{ not json",
+      status: "fail",
+      detail: /not valid JSON/,
+      fix: /credential file is invalid/,
+    },
+    {
+      name: "missing token",
+      credential: {
+        access_token: "access-value",
+        expires_at: now + 3_600,
+        expires_in: 3_600,
+      },
+      status: "fail",
+      detail: /missing the access or refresh token/,
+      fix: /credential file is incomplete/,
+    },
+    {
+      name: "incomplete expiry metadata",
+      credential: {
+        access_token: "access-value",
+        refresh_token: "refresh-value",
+        expires_at: now + 3_600,
+      },
+      status: "fail",
+      detail: /missing finite second-based expiry metadata/,
+      fix: /credential file is incomplete/,
+    },
+    {
+      name: "revoked tombstone",
+      credential: {
+        access_token: "",
+        refresh_token: "",
+        expires_at: 0,
+        expires_in: 0,
+      },
+      status: "fail",
+      detail: /session was rejected by Kimi/,
+      fix: /session must be re-authorized/,
+    },
+  ];
+}
+
+test("doctor maps every selected Kimi OAuth health state", () => {
+  for (const fixture of fixtures()) {
+    const check = doctorKimiCheck({ selected: true, credential: fixture.credential });
+    assert.equal(check.status, fixture.status, fixture.name);
+    assert.match(check.detail, fixture.detail, fixture.name);
+    if (fixture.fix) assert.match(check.fix, fixture.fix, fixture.name);
+  }
+});
+
+test("doctor warns for every unselected Kimi OAuth health state", () => {
+  for (const fixture of fixtures()) {
+    const check = doctorKimiCheck({ selected: false, credential: fixture.credential });
+    assert.equal(check.status, "warn", fixture.name);
+    assert.match(check.detail, fixture.detail, fixture.name);
+  }
+});

--- a/test/oauth-status-health.test.mjs
+++ b/test/oauth-status-health.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { kimiOAuthHealth } from "../src/oauth-status.mjs";
+
+function withCredentialsFile(contents, run) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "kimi-oauth-health-"));
+  const credentialsPath = path.join(dir, "credentials", "kimi-code.json");
+  if (contents !== undefined) {
+    mkdirSync(path.dirname(credentialsPath), { recursive: true });
+    writeFileSync(credentialsPath, contents, { mode: 0o600 });
+  }
+  const previous = process.env.KIMI_CODE_HOME;
+  process.env.KIMI_CODE_HOME = dir;
+  try {
+    return run(credentialsPath);
+  } finally {
+    if (previous === undefined) delete process.env.KIMI_CODE_HOME;
+    else process.env.KIMI_CODE_HOME = previous;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function futureSeconds() {
+  return Math.floor(Date.now() / 1000) + 3600;
+}
+
+test("health is ok for a live credential", () => {
+  const health = withCredentialsFile(
+    JSON.stringify({
+      access_token: "access-value",
+      refresh_token: "refresh-value",
+      expires_at: futureSeconds(),
+      expires_in: 3600,
+      scope: "kimi-code",
+    }),
+    () => kimiOAuthHealth(),
+  );
+  assert.equal(health.status, "ok");
+  assert.match(health.detail, /credential present/);
+});
+
+test("health is stale, not failed, for an expired access token", () => {
+  // An expired access token is a normal state: ensureFreshKimiOAuthToken()
+  // refreshes it with the still-valid refresh token before forwarding, so the
+  // diagnosis must not tell the operator to re-login.
+  const health = withCredentialsFile(
+    JSON.stringify({
+      access_token: "access-value",
+      refresh_token: "refresh-value",
+      expires_at: futureSeconds() - 7200,
+      expires_in: 3600,
+    }),
+    () => kimiOAuthHealth(),
+  );
+  assert.equal(health.status, "stale");
+  assert.match(health.detail, /refreshes automatically/);
+  assert.match(health.fix, /No action needed/);
+});
+
+test("health is revoked for a rejected session tombstone", () => {
+  const health = withCredentialsFile(
+    JSON.stringify({
+      access_token: "",
+      refresh_token: "",
+      expires_at: 0,
+      expires_in: 0,
+    }),
+    () => kimiOAuthHealth(),
+  );
+  assert.equal(health.status, "revoked");
+  assert.match(health.fix, /kimi login/);
+});
+
+test("health is missing when the credential file does not exist", () => {
+  const health = withCredentialsFile(undefined, () => kimiOAuthHealth());
+  assert.equal(health.status, "missing");
+  assert.match(health.fix, /kimi login/);
+});
+
+test("health is incomplete when tokens are missing", () => {
+  const health = withCredentialsFile(
+    JSON.stringify({
+      access_token: "access-value",
+      expires_at: futureSeconds(),
+      expires_in: 3600,
+    }),
+    () => kimiOAuthHealth(),
+  );
+  assert.equal(health.status, "incomplete");
+  assert.match(health.fix, /kimi login/);
+});
+
+test("health is incomplete when expiry metadata is not finite seconds", () => {
+  for (const value of [
+    { access_token: "a", refresh_token: "r", expires_at: "not-a-number", expires_in: 3600 },
+    { access_token: "a", refresh_token: "r", expires_at: futureSeconds() },
+  ]) {
+    const health = withCredentialsFile(JSON.stringify(value), () => kimiOAuthHealth());
+    assert.equal(health.status, "incomplete", JSON.stringify(value));
+    assert.match(health.fix, /kimi login/);
+  }
+});
+
+test("health is invalid when the credential file is not JSON", () => {
+  const health = withCredentialsFile("{ not json", () => kimiOAuthHealth());
+  assert.equal(health.status, "invalid");
+  assert.match(health.fix, /kimi login/);
+});


### PR DESCRIPTION
## What

Diagnose the Kimi OAuth credential file with the refresh path in mind, instead of treating a past `expires_at` as a failure.

Follow-up to the discussion on #131: an expired access token is a **recoverable** state — `ensureFreshKimiOAuthToken()` refreshes it with the still-valid refresh token before forwarding — so status reporting must not tell the operator to re-login for that. The genuinely broken states are a **revoked tombstone** (the CLI wrote all-empty tokens with zero expiry metadata after a rejected refresh) and a structurally unusable file.

## How

`src/oauth-status.mjs` — new read-only `kimiOAuthHealth()` (return shape untouched for `kimiOAuthStatus()`, no behavior change for its callers):

| status | meaning |
|---|---|
| `ok` | live session |
| `stale` | access token past expiry, refresh token still valid → auto-refreshes on next request, **no action needed** |
| `revoked` | all-empty tokens + zero expiry metadata (the session reader's own tombstone shape) → `kimi login` genuinely required |
| `incomplete` / `invalid` / `missing` | no usable session on disk |

The metadata validation mirrors what the session reader (`validateToken` in `kimi-oauth-session.mjs`) accepts at request time — finite second-based `expires_at` and `expires_in` — so a status verdict can never diverge from runtime usability (the divergence #131's reviewer flagged).

`src/doctor.mjs` — the Kimi OAuth check now reports `fail` only for a revoked session; a stale credential reports `ok` with detail "access token expired; it refreshes automatically on the next request" instead of a misleading re-login instruction.

## Tests

New `test/oauth-status-health.test.mjs`, 7 cases: live → ok; expired access token → stale (not fail, fix says "No action needed"); revoked tombstone → revoked; missing file → missing; missing tokens / non-finite or absent expiry metadata → incomplete; invalid JSON → invalid.

`npm test` on this branch: **794 tests, 782 pass, 0 fail, 12 skipped**. `npm run check` passes.