### PR TITLE
fix: preserve wrapped Node launcher and PATH

### DIFF
--- a/bin/enable
+++ b/bin/enable
@@ -7,6 +7,8 @@ case "${MODEL_ROUTER_TARGET:-codex}" in
   codex) ;;
   *) echo "MODEL_ROUTER_TARGET must be codex." >&2; exit 2 ;;
 esac
+CODEX_ROUTER_NODE_BIN=${CODEX_ROUTER_NODE_BIN:-$(command -v node)}
+export CODEX_ROUTER_NODE_BIN
 adopt_native_catalog=false
 for argument in "$@"; do
   case "$argument" in

--- a/bin/install
+++ b/bin/install
@@ -60,6 +60,12 @@ done
 
 node -e 'const [a,b]=process.versions.node.split(".").map(Number); if (!(a>22 || (a===22 && b>=19))) { console.error("Node.js 22.19 or newer is required."); process.exit(1) }'
 
+# Preserve the launcher selected by the operator. A compatibility wrapper may
+# delegate to another runtime, so process.execPath is not necessarily the
+# executable that should be placed in the background service.
+CODEX_ROUTER_NODE_BIN=${CODEX_ROUTER_NODE_BIN:-$(command -v node)}
+export CODEX_ROUTER_NODE_BIN
+
 cd "$repo_dir"
 codex_home=${CODEX_HOME:-$HOME/.codex}
 mkdir -p "$codex_home"

--- a/src/service-linux.mjs
+++ b/src/service-linux.mjs
@@ -49,6 +49,7 @@ function systemdQuote(value) {
 function unit() {
   const start = path.join(SOURCE_ROOT, "src", "start.mjs");
   const environment = {
+    PATH: process.env.PATH || "/usr/local/bin:/usr/bin:/bin",
     MODEL_ROUTER_TARGET: TARGET,
     MODEL_ROUTER_STATE_DIR: STATE_DIR,
     MODEL_ROUTER_QUIET: "1",

--- a/src/service-macos.mjs
+++ b/src/service-macos.mjs
@@ -47,6 +47,7 @@ function xml(value) {
 
 function environmentEntries() {
   const values = {
+    PATH: process.env.PATH || "/usr/local/bin:/usr/bin:/bin",
     MODEL_ROUTER_TARGET: TARGET,
     MODEL_ROUTER_STATE_DIR: STATE_DIR,
     MODEL_ROUTER_QUIET: "1",

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -109,6 +115,62 @@ test("install.sh is valid POSIX shell", () => {
   });
   assert.equal(result.status, 0, result.stderr);
 });
+
+test(
+  "POSIX install and enable preserve the PATH-selected Node wrapper",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-node-wrapper-"));
+    const wrapperDir = path.join(testRoot, "runtime bin % wrapper");
+    const wrapper = path.join(wrapperDir, "node");
+    const callLog = path.join(testRoot, "wrapper calls.log");
+    const servicePath = `${wrapperDir}:${process.env.PATH || "/usr/local/bin:/usr/bin:/bin"}`;
+    const baseEnv = { ...process.env };
+    delete baseEnv.CODEX_ROUTER_NODE_BIN;
+    try {
+      mkdirSync(wrapperDir, { recursive: true });
+      writeFileSync(
+        wrapper,
+        `#!/bin/sh
+printf '%s\\t%s\\t' "$CODEX_ROUTER_NODE_BIN" "$PATH" >>"$CODEX_ROUTER_WRAPPER_LOG"
+printf '<%s>' "$@" >>"$CODEX_ROUTER_WRAPPER_LOG"
+printf '\\n' >>"$CODEX_ROUTER_WRAPPER_LOG"
+if [ "\${1:-}" = src/install-plan.mjs ] && [ "\${2:-}" = status ]; then
+  printf 'skip\\n'
+fi
+`,
+        { mode: 0o755 },
+      );
+      const env = {
+        ...baseEnv,
+        PATH: servicePath,
+        HOME: testRoot,
+        CODEX_HOME: path.join(testRoot, "codex home"),
+        CODEX_ROUTER_STATE_DIR: path.join(testRoot, "router state"),
+        MODEL_ROUTER_STATE_DIR: path.join(testRoot, "router state"),
+        CODEX_ROUTER_WRAPPER_LOG: callLog,
+      };
+
+      for (const [script, args, expectedCall] of [
+        [path.join(root, "bin", "install"), ["--prepare-only"], "<src/catalog.mjs>"],
+        [path.join(root, "bin", "enable"), [], "<src/service.mjs><install>"],
+      ]) {
+        writeFileSync(callLog, "", "utf8");
+        const result = spawnSync(script, args, { cwd: root, encoding: "utf8", env });
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+        const calls = readFileSync(callLog, "utf8").trim().split("\n");
+        assert.ok(calls.some((line) => line.includes(expectedCall)), calls.join("\n"));
+        const routedCalls = calls.filter((line) => line.includes("\t<src/"));
+        assert.ok(
+          routedCalls.every((line) => line.startsWith(`${wrapper}\t${servicePath}\t`)),
+          calls.join("\n"),
+        );
+      }
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
 
 test(
   "install.ps1 parses under powershell.exe",

--- a/test/provider-key.test.mjs
+++ b/test/provider-key.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "..");
 
 // provider-key.mjs is a CLI entry that validates process.argv at module
 // evaluation time (and exits when the arguments are missing), so give it a
@@ -90,6 +92,99 @@ test(
         encoding: "utf8",
         stdio: ["ignore", "pipe", "inherit"],
       });
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "the POSIX hidden prompt captures a key without echoing it",
+  {
+    skip:
+      process.platform === "win32" ||
+      spawnSync("python3", ["--version"], { stdio: "ignore" }).status !== 0,
+  },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-posix-prompt-"));
+    const secret = "test-value";
+    const helper = String.raw`
+import errno
+import os
+import select
+import sys
+import termios
+import time
+
+node, provider_key, home, state_dir, secret = sys.argv[1:]
+env = os.environ.copy()
+env.update({
+    "HOME": home,
+    "CODEX_HOME": home,
+    "CODEX_ROUTER_STATE_DIR": state_dir,
+    "MODEL_ROUTER_STATE_DIR": state_dir,
+})
+pid, master = os.forkpty()
+if pid == 0:
+    os.execve(node, [node, provider_key, "deepseek", "set"], env)
+
+output = bytearray()
+prompt = b"DeepSeek API key: "
+sent = False
+while True:
+    ready, _, _ = select.select([master], [], [], 10)
+    if not ready:
+        os.kill(pid, 9)
+        raise SystemExit("timed out waiting for provider-key")
+    try:
+        chunk = os.read(master, 4096)
+    except OSError as error:
+        if error.errno == errno.EIO:
+            break
+        raise
+    if not chunk:
+        break
+    output.extend(chunk)
+    if not sent and prompt in output:
+        deadline = time.monotonic() + 2
+        while termios.tcgetattr(master)[3] & termios.ECHO:
+            if time.monotonic() >= deadline:
+                os.kill(pid, 9)
+                raise SystemExit("provider-key did not disable terminal echo")
+            time.sleep(0.01)
+        os.write(master, secret.encode() + b"\n")
+        sent = True
+
+_, status = os.waitpid(pid, 0)
+os.close(master)
+sys.stdout.buffer.write(output)
+raise SystemExit(os.waitstatus_to_exitcode(status))
+`;
+    try {
+      const result = spawnSync(
+        "python3",
+        [
+          "-c",
+          helper,
+          process.execPath,
+          path.join(root, "src", "provider-key.mjs"),
+          testRoot,
+          path.join(testRoot, "router state"),
+          secret,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            DEEPSEEK_API_KEY: "",
+          },
+          timeout: 20_000,
+        },
+      );
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /Received \d+ characters\./);
+      assert.match(result.stdout, /DeepSeek API key saved to protected local storage/);
+      assert.doesNotMatch(result.stdout, new RegExp(secret));
     } finally {
       rmSync(testRoot, { recursive: true, force: true });
     }

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -70,16 +70,27 @@ function systemdQuoted(value) {
     .replaceAll('"', '\\"')}"`;
 }
 
+function launchdXml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
 test("background service definitions render for macOS, Linux, and Windows", () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-services-"));
   try {
     const launchd = render("service-macos.mjs", "darwin", testRoot);
     assert.match(launchd, /<string>io\.github\.codex-router<\/string>/);
+    assert.match(launchd, /<key>PATH<\/key>/);
     assert.match(launchd, /CODEX_ROUTER_STATE_DIR/);
 
     const systemd = render("service-linux.mjs", "linux", testRoot);
     assert.match(systemd, /\[Service\]/);
     assert.match(systemd, /ExecStart=/);
+    assert.match(systemd, /Environment="PATH=/);
     assert.match(systemd, /Environment="CODEX_ROUTER_STATE_DIR=/);
 
     const windows = render("service-windows.mjs", "win32", testRoot);
@@ -95,14 +106,16 @@ test("background service definitions render for macOS, Linux, and Windows", () =
   }
 });
 
-test("packaged services persist stable source and Node paths", () => {
+test("packaged services preserve wrapper and PATH values with service-safe quoting", () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-packaged-service-"));
-  const stableRoot = path.join(testRoot, "opt", "codex-router", "libexec");
-  const stableNode = path.join(testRoot, "opt", "node", "bin", "node");
+  const stableRoot = path.join(testRoot, "opt % router", "libexec");
+  const stableNode = path.join(testRoot, 'runtime "bin" %', "node wrapper");
+  const servicePath = `${path.dirname(stableNode)}:${path.join(testRoot, "support & tools")}`;
   const env = {
     CODEX_ROUTER_SOURCE_ROOT: stableRoot,
     CODEX_ROUTER_NODE_BIN: stableNode,
     CODEX_ROUTER_PACKAGE_MANAGER: "homebrew",
+    PATH: servicePath,
   };
   try {
     const launchd = serviceCommand(
@@ -114,7 +127,12 @@ test("packaged services persist stable source and Node paths", () => {
       root,
       env,
     );
-    assert.match(launchd, new RegExp(stableNode.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    assert.ok(launchd.includes(`<string>${launchdXml(stableNode)}</string>`));
+    assert.ok(
+      launchd.includes(
+        `<key>PATH</key>\n    <string>${launchdXml(servicePath)}</string>`,
+      ),
+    );
     assert.match(launchd, /<key>CODEX_ROUTER_SOURCE_ROOT<\/key>/);
     assert.match(launchd, /<key>CODEX_ROUTER_NODE_BIN<\/key>/);
     assert.match(launchd, /<string>homebrew<\/string>/);
@@ -130,6 +148,7 @@ test("packaged services persist stable source and Node paths", () => {
     );
     assert.ok(systemd.includes(`WorkingDirectory=${stableRoot.replaceAll("%", "%%")}`));
     assert.ok(systemd.includes(`ExecStart=${systemdQuoted(stableNode)}`));
+    assert.ok(systemd.includes(`Environment=${systemdQuoted(`PATH=${servicePath}`)}`));
     assert.ok(systemd.includes(`Environment="CODEX_ROUTER_PACKAGE_MANAGER=homebrew"`));
   } finally {
     rmSync(testRoot, { recursive: true, force: true });


### PR DESCRIPTION
Supersedes #149 without rewriting the contributor branch's history.

## What changed

- Preserve the PATH-selected Node compatibility wrapper through install/enable and into both systemd and launchd.
- Preserve the corresponding PATH with platform-safe systemd quoting and launchd XML escaping.
- Keep portable descriptor-based `stty` behavior for hidden API-key entry on POSIX systems.
- Add real controlling-PTY coverage plus service and wrapper regression tests.

## Why a replacement PR

The repaired contributor branch briefly contained a deliberately fake high-entropy PTY fixture. GitGuardian scans every commit in that PR and continues to fail after the fixture was removed. This branch reproduces the verified final diff from current `main` with clean history and no flagged fixture; no contributor history was rewritten or force-pushed.

## Verification

- `git diff --check origin/main...HEAD`
- `npm run check`
- focused provider-key/service/installer suites: 35 passed, 3 platform skips
- full `npm test`: 792 passed, 0 failed, 6 expected skips
- POSIX shell syntax checks
- launchd plist validation with `plutil`

