### PR TITLE
feat: mark empty-completion guard budget releases and indeterminate terminal parses

### DIFF
--- a/src/empty-completion-guard.mjs
+++ b/src/empty-completion-guard.mjs
@@ -130,6 +130,7 @@ export class EmptyCompletionGuard extends Transform {
   #sawTerminal = false;
   #empty = false;
   #released = false;
+  #releasedForBudget = false;
   #headerlessDetector;
   #maxPreludeBytes;
   #maxPreludeMs;
@@ -163,6 +164,17 @@ export class EmptyCompletionGuard extends Transform {
 
   hasContent() {
     return this.#sawContent;
+  }
+
+  // True when the stream was released by the hold budget (byte cap or timer)
+  // rather than by a content or terminal verdict. The turn is then relayed
+  // unchanged and never classified empty — the conservative choice — but the
+  // caller can tell "released because we could not afford to hold it" apart
+  // from "released because it produced something", which is the difference
+  // between "may have been an empty completion we chose not to retry" and a
+  // healthy turn in the meter.
+  releasedForBudget() {
+    return this.#releasedForBudget;
   }
 
   _transform(chunk, _encoding, callback) {
@@ -199,7 +211,9 @@ export class EmptyCompletionGuard extends Transform {
     this.#bufferedBytes += bytes.length;
     this.#parseBuffer += this.#decoder.write(bytes);
     this.#consumeBlocks();
-    if (!this.#released && this.#bufferedBytes > this.#maxPreludeBytes) this.#release();
+    if (!this.#released && this.#bufferedBytes > this.#maxPreludeBytes) {
+      this.#release({ budget: true });
+    }
   }
 
   _flush(callback) {
@@ -258,19 +272,29 @@ export class EmptyCompletionGuard extends Transform {
     // Content is decided before the terminal check: a gateway that puts the
     // whole turn in `response.completed` emits a terminal event that is also
     // the only content event in the stream.
-    if (this.#contentOf(eventType, dataText)) {
+    const content = this.#contentOf(eventType, dataText);
+    if (content === true) {
       this.#sawContent = true;
       this.#release();
       return;
     }
     if (isTerminalEvent(eventType, dataText)) {
+      // A terminal event whose payload cannot be parsed is not evidence of an
+      // empty completion — the very event that would carry the output is the
+      // one we could not read. Release the stream (indeterminate) rather than
+      // declaring the turn empty and forcing a retry of a possibly valid one.
+      if (content === undefined) {
+        this.#release();
+        return;
+      }
       this.#sawTerminal = true;
     }
   }
 
-  #release() {
+  #release({ budget = false } = {}) {
     if (this.#released) return;
     this.#released = true;
+    if (budget) this.#releasedForBudget = true;
     this.#clearTimer();
     for (const chunk of this.#chunks) this.push(chunk);
     this.#chunks = [];
@@ -287,7 +311,7 @@ export class EmptyCompletionGuard extends Transform {
 
   #startTimer() {
     if (this.#timer || this.#released) return;
-    this.#timer = setTimeout(() => this.#release(), this.#maxPreludeMs);
+    this.#timer = setTimeout(() => this.#release({ budget: true }), this.#maxPreludeMs);
     this.#timer.unref?.();
   }
 
@@ -316,7 +340,11 @@ export class EmptyCompletionGuard extends Transform {
       const data = JSON.parse(dataText);
       return isContentEvent(eventType ?? data?.type, data);
     } catch {
-      return false;
+      // Indeterminate, not "no content": the payload could not be parsed, so
+      // the absence of recognized content says nothing about whether the turn
+      // produced output. Callers must not treat this as evidence of an empty
+      // completion.
+      return undefined;
     }
   }
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1532,6 +1532,7 @@ async function handleResponses(request, response, requestUrl) {
   let upstreamRetries;
   let upstreamLatencyMs;
   let usageTransform;
+  let emptyCompletionGuard;
   let retryUsageTransform;
   let retryEmptyCompletionGuard;
   let retryUsage;
@@ -1821,7 +1822,7 @@ async function handleResponses(request, response, requestUrl) {
     };
     const firstPipeline = createResponsePipeline(upstreamContentType);
     usageTransform = firstPipeline.usageObserver;
-    const emptyCompletionGuard = firstPipeline.guard;
+    emptyCompletionGuard = firstPipeline.guard;
     const relayOpen = Boolean(emptyCompletionGuard);
     await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS, firstPipeline.transforms, {
       leaveOpen: relayOpen,
@@ -1925,6 +1926,10 @@ async function handleResponses(request, response, requestUrl) {
           );
           const retryClientWalkedAway =
             clientGone || (response.destroyed && !response.writableFinished);
+          guardReleasedForBudget =
+            guardReleasedForBudget ||
+            (retryEmptyCompletionGuard?.releasedForBudget() === true &&
+              !retryClientWalkedAway);
           if (retryClientWalkedAway) {
             finalStatus = 0;
             if (secondPipeline.guard.hasContent()) emptyCompletion = false;
@@ -1991,6 +1996,15 @@ async function handleResponses(request, response, requestUrl) {
   } catch (error) {
     upstreamLatencyMs ??= Date.now() - startedAt;
     if (retryEmptyCompletionGuard?.hasContent()) emptyCompletion = false;
+    if (!clientGone) {
+      // A pipeline can fail after either guard has released its held bytes but
+      // before the success path samples the accessor. Preserve that verdict in
+      // the failure event too.
+      guardReleasedForBudget =
+        guardReleasedForBudget ||
+        emptyCompletionGuard?.releasedForBudget() === true ||
+        retryEmptyCompletionGuard?.releasedForBudget() === true;
+    }
     if (usageTransform) {
       usage = mergeTokenUsage(
         usageTransform.tokenUsage(),

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1539,6 +1539,7 @@ async function handleResponses(request, response, requestUrl) {
   let estimatedInputTokens;
   let emptyCompletion = false;
   let emptyCompletionRetried = false;
+  let guardReleasedForBudget = false;
   let finalStatus;
   let activityStatus;
   let usageRecorded = false;
@@ -1835,6 +1836,13 @@ async function handleResponses(request, response, requestUrl) {
       clientGone || (response.destroyed && !response.writableFinished);
     finalStatus = clientWalkedAway ? 0 : upstream.status;
     emptyCompletion = emptyCompletionGuard?.isEmpty() === true && !clientWalkedAway;
+    // The guard releases long turns at its byte/time budget without a verdict.
+    // Those turns may have been empty completions the router chose not to
+    // retry, which must stay distinguishable from healthy long turns in the
+    // meter — otherwise a 40-second reasoning-only empty completion reads as a
+    // successful 40-second turn.
+    guardReleasedForBudget =
+      emptyCompletionGuard?.releasedForBudget() === true && !clientWalkedAway;
     if (emptyCompletion) {
       // The upstream answered 200 with nothing. Retry the identical request
       // once: same bytes, same headers, same signal. The guard discarded the
@@ -1965,6 +1973,7 @@ async function handleResponses(request, response, requestUrl) {
       estimatedInputTokens,
       ...(emptyCompletion ? { emptyCompletion: true } : {}),
       ...(emptyCompletionRetried ? { emptyCompletionRetried: true } : {}),
+      ...(guardReleasedForBudget ? { emptyCompletionGuardReleased: true } : {}),
     });
     usageRecorded = true;
     activityStatus = finalStatus;
@@ -2035,6 +2044,7 @@ async function handleResponses(request, response, requestUrl) {
         ...(response.headersSent ? { streamAborted: true } : {}),
         ...(emptyCompletion ? { emptyCompletion: true } : {}),
         ...(emptyCompletionRetried ? { emptyCompletionRetried: true } : {}),
+        ...(guardReleasedForBudget ? { emptyCompletionGuardReleased: true } : {}),
       });
       usageRecorded = true;
     }

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -49,6 +49,12 @@ export function recordUsageEvent({
   // cover both attempts, because both were sent and both were billed. This
   // marker is what says the reported spend belongs to two attempts at one turn.
   emptyCompletionRetried,
+  // True when the guard released the stream at its byte/time hold budget
+  // without a verdict, so this turn may have been an empty completion the
+  // router chose not to retry. Kept apart from `emptyCompletion` because the
+  // release is the conservative path: the turn is relayed as-is and cannot be
+  // proven empty, but it must not read as a guaranteed-healthy turn either.
+  emptyCompletionGuardReleased,
   // Present only when the router replaced an upstream `input_tokens: 0` with
   // its own estimate on the way to Codex (#95). The reported counts above stay
   // exactly as the provider sent them, so an estimated turn is never mistaken
@@ -67,6 +73,9 @@ export function recordUsageEvent({
     ...(streamAborted === true ? { streamAborted: true } : {}),
     ...(emptyCompletion === true ? { emptyCompletion: true } : {}),
     ...(emptyCompletionRetried === true ? { emptyCompletionRetried: true } : {}),
+    ...(emptyCompletionGuardReleased === true
+      ? { emptyCompletionGuardReleased: true }
+      : {}),
     ...(safeRetryCount(retries) !== undefined ? { retries: safeRetryCount(retries) } : {}),
     ...(safeTokenCount(inputTokens) !== undefined
       ? { inputTokens: safeTokenCount(inputTokens) }
@@ -142,6 +151,9 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
           ...(event.emptyCompletion === true ? { emptyCompletion: true } : {}),
           ...(event.emptyCompletionRetried === true
             ? { emptyCompletionRetried: true }
+            : {}),
+          ...(event.emptyCompletionGuardReleased === true
+            ? { emptyCompletionGuardReleased: true }
             : {}),
           ...(retries !== undefined ? { retries } : {}),
           ...(inputTokens !== undefined ? { inputTokens } : {}),

--- a/test/empty-completion-guard.test.mjs
+++ b/test/empty-completion-guard.test.mjs
@@ -359,3 +359,96 @@ test("non-SSE bodies pass through byte for byte and are never empty", async () =
   assert.equal(empty, false);
   assert.equal(body, json);
 });
+
+test("a byte-budget release reports releasedForBudget", async () => {
+  const guard = new EmptyCompletionGuard("text/event-stream", { maxPreludeBytes: 1 });
+  const chunks = [];
+  await pipeline(
+    Readable.from([Buffer.from(EMPTY_TURN)]),
+    guard,
+    new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    }),
+  );
+  assert.equal(guard.isEmpty(), false);
+  assert.equal(guard.releasedForBudget(), true);
+  assert.equal(Buffer.concat(chunks).toString("utf8"), EMPTY_TURN);
+});
+
+test("a time-budget release reports releasedForBudget and never classifies empty", async () => {
+  const split = EMPTY_TURN.indexOf("event: response.completed");
+  async function* delayedTurn() {
+    yield Buffer.from(EMPTY_TURN.slice(0, split));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    yield Buffer.from(EMPTY_TURN.slice(split));
+  }
+  const guard = new EmptyCompletionGuard("", { maxPreludeMs: 5 });
+  const chunks = [];
+  await pipeline(
+    Readable.from(delayedTurn()),
+    guard,
+    new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    }),
+  );
+  assert.equal(guard.isEmpty(), false);
+  assert.equal(guard.releasedForBudget(), true);
+  assert.equal(Buffer.concat(chunks).toString("utf8"), EMPTY_TURN);
+});
+
+test("a content release never reports releasedForBudget", async () => {
+  const { empty } = await runGuard(CONTENT_TURN);
+  assert.equal(empty, false);
+  // content release goes through the same runGuard pipeline, so re-run with a
+  // direct guard to assert the accessor stays false for a content verdict
+  const guard = new EmptyCompletionGuard("text/event-stream");
+  await pipeline(
+    Readable.from([Buffer.from(CONTENT_TURN)]),
+    guard,
+    new Writable({
+      write(_chunk, _encoding, callback) {
+        callback();
+      },
+    }),
+  );
+  assert.equal(guard.releasedForBudget(), false);
+  assert.equal(guard.hasContent(), true);
+});
+
+test("a terminal event whose data fails to parse is indeterminate, not empty", async () => {
+  const input = [
+    "event: response.created",
+    'data: {"type":"response.created","response":{"id":"r1"}}',
+    "",
+    "event: response.completed",
+    "data: {not valid json",
+    "",
+    "event: response.done",
+    'data: {"type":"response.done","response":{"id":"r1"}}',
+    "",
+  ].join("\n");
+  const guard = new EmptyCompletionGuard("text/event-stream");
+  const chunks = [];
+  await pipeline(
+    Readable.from([Buffer.from(input)]),
+    guard,
+    new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    }),
+  );
+  // A parse failure at the terminal event is not evidence of "nothing was
+  // produced": the guard must not declare the turn empty and force a retry.
+  assert.equal(guard.isEmpty(), false);
+  assert.equal(guard.hasContent(), false);
+  assert.equal(guard.releasedForBudget(), false);
+  assert.equal(Buffer.concat(chunks).toString("utf8"), input);
+});

--- a/test/empty-completion-router.test.mjs
+++ b/test/empty-completion-router.test.mjs
@@ -53,6 +53,30 @@ const CONTENT_SSE = [
   "",
 ].join("\n");
 
+// Large enough to force the guard past its 1 MiB pre-content hold budget
+// before any client-visible output arrives.
+const BUDGET_RELEASE_REASONING_SSE = [
+  "event: response.created",
+  'data: {"type":"response.created","response":{"id":"r-budget"}}',
+  "",
+  "event: response.reasoning_text.delta",
+  `data: ${JSON.stringify({
+    type: "response.reasoning_text.delta",
+    delta: "x".repeat(2 * 1024 * 1024),
+  })}`,
+  "",
+].join("\n");
+
+const BUDGET_RELEASE_EMPTY_SSE = [
+  BUDGET_RELEASE_REASONING_SSE,
+  "event: response.completed",
+  'data: {"type":"response.completed","response":{"id":"r-budget","output":[]}}',
+  "",
+  "event: response.done",
+  'data: {"type":"response.done","response":{"id":"r-budget"}}',
+  "",
+].join("\n");
+
 const CUSTOM_TOOL_CALL_SSE = [
   "event: response.created",
   'data: {"type":"response.created","sequence_number":0,"response":{"id":"r-custom-tool"}}',
@@ -540,6 +564,35 @@ test("a retried turn meters the tokens of both attempts", async () => {
     assert.equal(event.cachedInputTokens, 140);
     assert.equal(event.outputTokens, 5);
     assert.equal(event.totalTokens, 205);
+  } finally {
+    await stopChild(router);
+    await closeServer(gw.server);
+  }
+});
+
+test("a retry that crosses the guard byte budget records the release", async () => {
+  let posts = 0;
+  const gw = await gateway((_request, response) => {
+    posts += 1;
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(posts === 1 ? EMPTY_SSE : BUDGET_RELEASE_EMPTY_SSE);
+  });
+  const routerPort = await openPort();
+  const router = run(routerEnv(gw.port, routerPort));
+
+  try {
+    await waitFor(`${callerBaseUrl(routerPort, CALLER_KEY)}/models`, router);
+    const result = await readRouted(routerPort, TURN_BODY);
+
+    assert.equal(result.status, 200);
+    assert.equal(result.complete, true);
+    assert.match(result.body, /r-budget/);
+    assert.equal(posts, 2);
+
+    const [event] = await waitForUsageEvents(router.stateDir, 1, router);
+    assert.equal(event.status, 200);
+    assert.equal(event.emptyCompletionRetried, true);
+    assert.equal(event.emptyCompletionGuardReleased, true);
   } finally {
     await stopChild(router);
     await closeServer(gw.server);

--- a/test/usage-events.test.mjs
+++ b/test/usage-events.test.mjs
@@ -102,3 +102,40 @@ test("an aborted stream persists its marker and reads back", async () => {
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+test("a guard budget release persists its marker and reads back", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-router-usage-"));
+  const previousStateDir = process.env.MODEL_ROUTER_STATE_DIR;
+  process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+  try {
+    const usage = await import(`../src/usage-events.mjs?guard=1&ts=${Date.now()}`);
+    usage.recordUsageEvent({
+      model: "opencode-go/deepseek-v4-flash",
+      provider: "opencode-go",
+      status: 200,
+      durationMs: 40_100,
+      emptyCompletionGuardReleased: true,
+    });
+    const [event] = usage
+      .recentUsageEvents()
+      .filter((candidate) => candidate.emptyCompletionGuardReleased === true);
+    assert.equal(event.status, 200);
+    assert.equal(event.durationMs, 40_100);
+    // An ordinary turn never carries the marker, so the release path stays
+    // distinguishable from a healthy turn of the same duration.
+    usage.recordUsageEvent({
+      model: "opencode-go/deepseek-v4-flash",
+      provider: "opencode-go",
+      status: 200,
+      durationMs: 40_100,
+    });
+    const [ordinary] = usage
+      .recentUsageEvents()
+      .filter((candidate) => candidate.emptyCompletionGuardReleased !== true);
+    assert.equal("emptyCompletionGuardReleased" in ordinary, false);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.MODEL_ROUTER_STATE_DIR;
+    else process.env.MODEL_ROUTER_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

Two follow-ups from my review of #145 (empty-completion guard), which the merge did not carry. Both are classification/telemetry robustness gaps in `EmptyCompletionGuard`, not changes to the retry behaviour itself.

### 1. Budget-exhaustion turns lose all telemetry

The guard releases the stream at its byte/time hold budget (1 MiB / 30s) with no verdict — `isEmpty()` stays false. That is the right conservative choice ("we can't hold a real turn hostage"), but it makes the exact failure #145 fixes conditional on duration: a 40-second reasoning-only empty completion records as a healthy 200 in `usage-events.jsonl`, indistinguishable from a healthy 40-second turn.

Fix: `releasedForBudget()` on the guard (set only by the byte-cap and timer release paths, never by a content verdict), surfaced as an `emptyCompletionGuardReleased: true` marker on the usage event. Retry behaviour is unchanged; the operator just gains the telemetry that says "this turn may have been an empty completion we chose not to retry".

### 2. A terminal event whose payload fails to parse flips to empty

`#contentOf` returned `false` on `JSON.parse` failure. For a gateway that rides the whole turn on `response.completed`, an unparseable terminal payload then classified the turn as empty and forced a retry of a possibly valid one.

Fix: `#contentOf` now returns `undefined` (indeterminate) on parse failure, and `#classifyBlock` releases the stream instead of declaring it empty — a parse failure at the terminal event is not evidence that nothing was produced.

## Tests

- `test/empty-completion-guard.test.mjs` +4: byte-budget release reports `releasedForBudget`, time-budget release reports it, a content release never does, and a terminal event with unparseable data is indeterminate (not empty, stream relayed byte-for-byte).
- `test/usage-events.test.mjs` +1: `emptyCompletionGuardReleased` persists and reads back; an ordinary turn never carries it.

Verified: 53/53 in the guard/router/usage/resilience suites, full `npm test` 867 tests, 851 pass, 2 fail (both the pre-existing `doctor-kimi-oauth-health` Windows ENOTEMPTY environment issue that also fails on untouched `main`), 14 skipped. `npm run check` passes.

These are the items 2 and 3 from my review on #145 (https://github.com/duolahypercho/codex-router/pull/145#pullrequestreview-4901525309); item 1 (shared SSE sniff) was independently implemented by the author before merge.