### PR TITLE
refactor: build the namespace inventory once per routed request

### DIFF
--- a/packaging/homebrew/check-formula.mjs
+++ b/packaging/homebrew/check-formula.mjs
@@ -55,9 +55,13 @@ async function main() {
 
   const committedLines = committed.split("\n");
   const regeneratedLines = regenerated.split("\n");
-  const firstDifference = committedLines.findIndex(
+  // A committed file that is a prefix of the regenerated one has no differing
+  // line at all, and findIndex then reports -1 -- which would print line 0 and
+  // quote two identical lines. The first missing line is the difference there.
+  const differing = committedLines.findIndex(
     (line, index) => line !== regeneratedLines[index],
   );
+  const firstDifference = differing === -1 ? committedLines.length : differing;
   throw new Error(
     [
       `${FORMULA_PATH} no longer matches requirements/python.txt.`,

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1653,13 +1653,6 @@ async function handleResponses(request, response, requestUrl) {
       // `reasoning_content` on the tool-call message.
       carryReasoningThroughInput(input);
       const provider = providerForModel(route);
-      // Capture collaboration schema metadata for every routed provider. The
-      // response transform uses the exact spawn_agent model enum to remove an
-      // invented or stale optional override before Codex validates the call.
-      // Responses-native providers keep the namespace tools untouched; chat
-      // bridges additionally receive the flattened form below.
-      const namespaceInventory = flattenNamespaceTools(payload.tools);
-      flattenedNamespaces = namespaceInventory.namespaces;
       // LiteLLM's Responses -> Chat Completions bridge drops namespace tools,
       // which is how the client ships the collaboration runtime, the app
       // toolset (threads, automations, navigation), and every MCP server
@@ -1682,6 +1675,13 @@ async function handleResponses(request, response, requestUrl) {
           payload.tools = flattened.tools;
           flattenedNamespaces = flattened.namespaces;
         }
+      } else {
+        // Responses-native providers keep the namespace tools untouched, so
+        // nothing is flattened and the payload is left alone. The inventory is
+        // still built, because the response transform reads the exact
+        // spawn_agent model enum off it to drop an invented or stale optional
+        // override before Codex validates the call.
+        flattenedNamespaces = flattenNamespaceTools(payload.tools).namespaces;
       }
       let routedInput = input;
       // The stored call history must use the same tool names as the tool


### PR DESCRIPTION
Two follow-ups to #155 and #156, both merged.

## Namespace inventory (#155)

#155 added an unconditional `flattenNamespaceTools` call so the response
transform could read the collaboration `spawn_agent` model enum off the
request's exact tool schema. Chat-completions bridges then flattened the tool
list a second time, after merging the deferred `codex_app` definitions in, and
the first result was thrown away.

Move the inventory into the responses-native branch — the only path that was
not already building one. Semantics are unchanged: a request with no namespace
tools yields an empty map either way, and the chat-bridge path still overwrites
with the post-merge inventory it needs for `flattenNamespacedHistory`.

## Drift report (#156)

When the committed formula is a prefix of the regenerated one, no line differs,
`findIndex` returns `-1`, and the failure message pointed at line 0 while
quoting two identical lines. Report the first missing line instead. The check
already failed correctly; only the diagnostic was wrong.

## Test plan

- [x] `npm test` — 896 tests, 890 pass, 0 fail, 6 skipped
- [x] `npm run check`
- [x] `node packaging/homebrew/check-formula.mjs` — `{"checked":true,"drifted":false}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)