### PR TITLE
Prepare Homebrew core submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,25 +107,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24"
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@b35a29a0f83ee8b8ca07b219fc8db3d7bb88ab49 # 2026.08.10.2
-      - name: Generate formula for this commit
-        shell: bash
-        run: |
-          set -euo pipefail
-          version=$(node -p 'require("./package.json").version')
-          archive="$RUNNER_TEMP/codex-router-$version.tar.gz"
-          git archive --format=tar.gz --prefix="codex-router-$version/" -o "$archive" HEAD
-          sha=$(shasum -a 256 "$archive" | awk '{ print $1 }')
-          node packaging/homebrew/generate-formula.mjs \
-            --version "$version" \
-            --source-url "file://$archive" \
-            --source-sha256 "$sha" \
-            --allow-local-source \
-            --output Formula/codex-router.rb
       - name: Build and test the formula from source
         run: packaging/homebrew/check-core-readiness.sh --install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - run: npm audit --omit=dev --audit-level=high
       - name: Check shell syntax
         if: runner.os != 'Windows'
-        run: for file in install.sh bin/* scripts/build-desktop-tray.sh; do [ "$(head -n 1 "$file")" != '#!/bin/sh' ] || sh -n "$file"; done
+        run: for file in install.sh bin/* scripts/build-desktop-tray.sh packaging/homebrew/check-core-readiness.sh; do [ "$(head -n 1 "$file")" != '#!/bin/sh' ] || sh -n "$file"; done
       - name: Check installer help
         if: runner.os != 'Windows'
         run: ./install.sh --help
@@ -76,6 +76,58 @@ jobs:
       - name: Verify the formula matches the Python lock
         if: steps.changed.outputs.run == 'true'
         run: node packaging/homebrew/check-formula.mjs
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        if: steps.changed.outputs.run == 'true'
+        uses: Homebrew/actions/setup-homebrew@b35a29a0f83ee8b8ca07b219fc8db3d7bb88ab49 # 2026.08.10.2
+      - name: Cache Homebrew Bundler RubyGems
+        id: cache-homebrew-gems
+        if: steps.changed.outputs.run == 'true'
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+      - name: Install Homebrew Bundler RubyGems
+        if: steps.changed.outputs.run == 'true' && steps.cache-homebrew-gems.outputs.cache-hit != 'true'
+        run: brew install-bundler-gems
+      - name: Audit the generated formula for Homebrew core
+        if: steps.changed.outputs.run == 'true'
+        run: packaging/homebrew/check-core-readiness.sh
+
+  # A complete source build is intentionally manual because LiteLLM's locked
+  # Python dependency tree is large. Run this on the candidate stable commit
+  # before opening the homebrew/core pull request.
+  homebrew-install:
+    if: github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@b35a29a0f83ee8b8ca07b219fc8db3d7bb88ab49 # 2026.08.10.2
+      - name: Generate formula for this commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(node -p 'require("./package.json").version')
+          archive="$RUNNER_TEMP/codex-router-$version.tar.gz"
+          git archive --format=tar.gz --prefix="codex-router-$version/" -o "$archive" HEAD
+          sha=$(shasum -a 256 "$archive" | awk '{ print $1 }')
+          node packaging/homebrew/generate-formula.mjs \
+            --version "$version" \
+            --source-url "file://$archive" \
+            --source-sha256 "$sha" \
+            --allow-local-source \
+            --output Formula/codex-router.rb
+      - name: Build and test the formula from source
+        run: packaging/homebrew/check-core-readiness.sh --install
 
   desktop:
     strategy:

--- a/Formula/codex-router.rb
+++ b/Formula/codex-router.rb
@@ -593,8 +593,14 @@ class CodexRouter < Formula
       ) do
         venv.pip_install relaxed
       end
-      system formula_opt_bin("node")/"node", "src/install-plan.mjs", "record", "node-deps"
-      system formula_opt_bin("node")/"node", "src/install-plan.mjs", "record", "python-deps"
+      # Older release archives predate the dependency fingerprint helper. The
+      # dependencies are already installed at this point, so those archives
+      # remain usable; newer releases record fingerprints for faster updates.
+      install_plan = libexec/"src/install-plan.mjs"
+      if install_plan.exist?
+        system formula_opt_bin("node")/"node", install_plan, "record", "node-deps"
+        system formula_opt_bin("node")/"node", install_plan, "record", "python-deps"
+      end
     end
 
     (bin/"codex-router").write <<~SH

--- a/Formula/codex-router.rb
+++ b/Formula/codex-router.rb
@@ -633,7 +633,9 @@ class CodexRouter < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/codex-router --version")
+    output = shell_output("#{bin}/codex-router providers list --json")
+    assert_match '"providers":', output
+    assert_match '"anthropic-api"', output
     system formula_opt_bin("node")/"node", "--input-type=module", "--eval",
            "import('#{libexec}/node_modules/proper-lockfile/index.js')"
     system libexec/".venv/bin/python", "-c", "import fastapi, litellm"

--- a/Formula/codex-router.rb
+++ b/Formula/codex-router.rb
@@ -605,11 +605,12 @@ class CodexRouter < Formula
 
     (bin/"codex-router").write <<~SH
       #!/bin/sh
+      source_root=$(CDPATH= cd -- "#{opt_libexec}" && pwd -P)
       export PATH="#{formula_opt_bin("node")}:$PATH"
-      export CODEX_ROUTER_SOURCE_ROOT="#{opt_libexec}"
+      export CODEX_ROUTER_SOURCE_ROOT="$source_root"
       export CODEX_ROUTER_NODE_BIN="#{formula_opt_bin("node")}/node"
       export CODEX_ROUTER_PACKAGE_MANAGER=homebrew
-      exec "#{opt_libexec}/bin/model-router" codex "$@"
+      exec "$source_root/bin/model-router" codex "$@"
     SH
   end
 

--- a/Formula/codex-router.rb
+++ b/Formula/codex-router.rb
@@ -4,12 +4,9 @@ class CodexRouter < Formula
   desc "Use external coding models inside the Codex App and CLI"
   homepage "https://github.com/duolahypercho/codex-router"
   url "https://github.com/duolahypercho/codex-router/releases/download/v0.4.0-beta.2/codex-router-0.4.0-beta.2.tar.gz"
-  version "0.4.0-beta.2"
   sha256 "665511833fe4681c6e2c9e930f4561710ad3d265622ed1fb4fa1df8d24307482"
   license "MIT"
 
-  depends_on "node"
-  depends_on "python@3.14"
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "libsndfile"
@@ -17,6 +14,9 @@ class CodexRouter < Formula
   # skips the libsodium it vendors and expects one to already be present. Without
   # this its _sodium.c cannot find sodium.h. See Homebrew's extend/ENV/super.rb.
   depends_on "libsodium"
+  depends_on "libyaml"
+  depends_on "node"
+  depends_on "python@3.14"
 
   # Optional LiteLLM resources omitted because PyPI publishes no portable source:
   # - hf-xet==1.6.0
@@ -560,50 +560,48 @@ class CodexRouter < Formula
       # resolved by the interpreter at load time, so linking one on macOS needs
       # -undefined dynamic_lookup. maturin supplies that itself for some projects
       # and not others -- polars gets it, tokenizers does not, and tokenizers
-      # fails with hundreds of undefined _Py* symbols. Setting RUSTFLAGS covers
-      # the gap without fighting maturin: CARGO_ENCODED_RUSTFLAGS wins wherever
-      # maturin does set it, and non-Rust resources ignore this entirely.
-      with_env(RUSTFLAGS: "-C link-arg=-undefined -C link-arg=dynamic_lookup") do
-        venv.pip_install standard
-        # Homebrew's superenv shim strips every -O flag the caller passes and
-        # substitutes HOMEBREW_OPTIMIZATION_LEVEL. That breaks a Rust resource
-        # built through cc-rs whose vendored C insists on its own level:
-        # litellm's python-bridge pulls aws-lc-sys, whose jitterentropy refuses
-        # to compile unless optimization is off, and its deliberate -O0 never
-        # survives. Dropping "O" from HOMEBREW_CCCFG turns that rewriting off;
-        # cargo already picks correct release flags on its own.
-        #
-        # polars-runtime-32 turns on foldhash's "nightly" cargo feature, whose
-        # #![feature(hasher_prefixfree_extras)] stable rustc rejects outright
-        # (E0554). Polars publishes wheels built on a nightly toolchain and
-        # Homebrew ships only stable, so the escape hatch upstream relies on is
-        # the only way through. polars is not optional here: litellm declares it
-        # under the "proxy" extra, and the proxy is what this router runs.
-        #
-        # polars also asks for thin LTO plus debug line tables, and linking it
-        # that way needs far more scratch space than the crate itself: a machine
-        # without tens of spare gigabytes fails as an LLVM write error,
-        # surfacing only as a rustc SIGSEGV. Neither setting changes what the
-        # router does with polars, so drop both rather than require headroom.
-        with_env(
-          HOMEBREW_CCCFG: ENV.fetch("HOMEBREW_CCCFG", "").delete("O"),
-          RUSTC_BOOTSTRAP: "1",
-          CARGO_PROFILE_RELEASE_LTO: "false",
-          CARGO_PROFILE_RELEASE_DEBUG: "false",
-          CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: "off",
-        ) do
-          venv.pip_install relaxed
-        end
+      # fails with hundreds of undefined _Py* symbols. Non-Rust resources ignore
+      # the flag, and Linux must not receive this macOS linker option.
+      ENV.append_to_rustflags "-C link-arg=-Wl,-undefined,dynamic_lookup" if OS.mac?
+      venv.pip_install standard
+      # Homebrew's superenv shim strips every -O flag the caller passes and
+      # substitutes HOMEBREW_OPTIMIZATION_LEVEL. That breaks a Rust resource
+      # built through cc-rs whose vendored C insists on its own level:
+      # litellm's python-bridge pulls aws-lc-sys, whose jitterentropy refuses
+      # to compile unless optimization is off, and its deliberate -O0 never
+      # survives. Dropping "O" from HOMEBREW_CCCFG turns that rewriting off;
+      # cargo already picks correct release flags on its own.
+      #
+      # polars-runtime-32 turns on foldhash's "nightly" cargo feature, whose
+      # #![feature(hasher_prefixfree_extras)] stable rustc rejects outright
+      # (E0554). Polars publishes wheels built on a nightly toolchain and
+      # Homebrew ships only stable, so the escape hatch upstream relies on is
+      # the only way through. polars is not optional here: litellm declares it
+      # under the "proxy" extra, and the proxy is what this router runs.
+      #
+      # polars also asks for thin LTO plus debug line tables, and linking it
+      # that way needs far more scratch space than the crate itself: a machine
+      # without tens of spare gigabytes fails as an LLVM write error,
+      # surfacing only as a rustc SIGSEGV. Neither setting changes what the
+      # router does with polars, so drop both rather than require headroom.
+      with_env(
+        HOMEBREW_CCCFG:                        ENV.fetch("HOMEBREW_CCCFG", "").delete("O"),
+        RUSTC_BOOTSTRAP:                       "1",
+        CARGO_PROFILE_RELEASE_LTO:             "false",
+        CARGO_PROFILE_RELEASE_DEBUG:           "false",
+        CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: "off",
+      ) do
+        venv.pip_install relaxed
       end
-      system Formula["node"].opt_bin/"node", "src/install-plan.mjs", "record", "node-deps"
-      system Formula["node"].opt_bin/"node", "src/install-plan.mjs", "record", "python-deps"
+      system formula_opt_bin("node")/"node", "src/install-plan.mjs", "record", "node-deps"
+      system formula_opt_bin("node")/"node", "src/install-plan.mjs", "record", "python-deps"
     end
 
     (bin/"codex-router").write <<~SH
       #!/bin/sh
-      export PATH="#{Formula['node'].opt_bin}:$PATH"
+      export PATH="#{formula_opt_bin("node")}:$PATH"
       export CODEX_ROUTER_SOURCE_ROOT="#{opt_libexec}"
-      export CODEX_ROUTER_NODE_BIN="#{Formula['node'].opt_bin}/node"
+      export CODEX_ROUTER_NODE_BIN="#{formula_opt_bin("node")}/node"
       export CODEX_ROUTER_PACKAGE_MANAGER=homebrew
       exec "#{opt_libexec}/bin/model-router" codex "$@"
     SH
@@ -611,12 +609,12 @@ class CodexRouter < Formula
 
   def post_install
     state_root = ENV["MODEL_ROUTER_STATE_DIR"] || ENV["CODEX_ROUTER_STATE_DIR"] ||
-                 ENV["KIMI_CODEX_STATE_DIR"] || Pathname(Dir.home)/".codex/codex-router"
+                 ENV["KIMI_CODEX_STATE_DIR"] || (Pathname(Dir.home)/".codex/codex-router")
     manifest_path = Pathname(state_root)/"install-manifest.json"
     return unless manifest_path.exist?
 
     manifest = JSON.parse(manifest_path.read)
-    return unless manifest.dig("current", "packageManager") == "homebrew"
+    return if manifest.dig("current", "packageManager") != "homebrew"
 
     system bin/"codex-router", "install"
   rescue JSON::ParserError
@@ -635,8 +633,8 @@ class CodexRouter < Formula
   end
 
   test do
-    assert_match "Usage: model-router", shell_output("#{bin}/codex-router 2>&1", 2)
-    system Formula["node"].opt_bin/"node", "--input-type=module", "--eval",
+    assert_match version.to_s, shell_output("#{bin}/codex-router --version")
+    system formula_opt_bin("node")/"node", "--input-type=module", "--eval",
            "import('#{libexec}/node_modules/proper-lockfile/index.js')"
     system libexec/".venv/bin/python", "-c", "import fastapi, litellm"
   end

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ installer below because the formula builds the locked Python dependencies from
 source. The release workflow generates `Formula/codex-router.rb` from
 `requirements/python.txt` and refreshes it for each release.
 
+Maintainers preparing the eventual `homebrew/core` submission should follow
+[`docs/HOMEBREW_CORE.md`](docs/HOMEBREW_CORE.md).
+
 ### Guided installer
 
 macOS or Linux:

--- a/bin/model-router
+++ b/bin/model-router
@@ -17,6 +17,20 @@ Examples:
 EOF
 }
 
+version() {
+  node -p 'require(process.argv[1]).version' "$repo_dir/package.json"
+}
+
+if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then
+  version
+  exit 0
+fi
+
+if [ "$#" -eq 2 ] && [ "$1" = "codex" ] && [ "$2" = "--version" ]; then
+  version
+  exit 0
+fi
+
 if [ "$#" -lt 2 ]; then
   usage >&2
   exit 2

--- a/docs/HOMEBREW_CORE.md
+++ b/docs/HOMEBREW_CORE.md
@@ -22,8 +22,9 @@ application form: the submission is a pull request adding
   packaging/homebrew/check-core-readiness.sh
   ```
 
-- Run a clean source installation on both macOS and Linux. The CI workflow's
-  manual `workflow_dispatch` path packages the selected commit and runs:
+- After the release workflow regenerates the checked-in formula, run a clean
+  source installation on both macOS and Linux. The CI workflow's manual
+  `workflow_dispatch` path runs:
 
   ```sh
   packaging/homebrew/check-core-readiness.sh --install

--- a/docs/HOMEBREW_CORE.md
+++ b/docs/HOMEBREW_CORE.md
@@ -1,0 +1,76 @@
+# Homebrew core submission
+
+Codex Router can be proposed to `Homebrew/homebrew-core` after the upstream
+project and its formula meet Homebrew's acceptance requirements. There is no
+application form: the submission is a pull request adding
+`Formula/c/codex-router.rb` to `homebrew-core`.
+
+## Before submitting
+
+- Wait until the upstream repository is at least 30 days old. The repository
+  was created on July 19, 2026, so submit no earlier than August 19, 2026.
+- Publish a release that upstream explicitly identifies as stable. A beta or
+  release candidate is not eligible. The tag, `package.json` version, source
+  archive name, formula version, and release URL must agree.
+- Confirm the repository still meets Homebrew's self-submission notability
+  threshold: 90 forks, 90 watchers, or 225 stars.
+- Confirm the release archive is immutable and that the formula contains its
+  SHA-256 checksum.
+- Run the formula audit on the generated formula:
+
+  ```sh
+  packaging/homebrew/check-core-readiness.sh
+  ```
+
+- Run a clean source installation on both macOS and Linux. The CI workflow's
+  manual `workflow_dispatch` path packages the selected commit and runs:
+
+  ```sh
+  packaging/homebrew/check-core-readiness.sh --install
+  ```
+
+  The install check intentionally refuses to replace an existing
+  `codex-router` formula.
+- Verify the stable release through the normal release workflow. It must
+  regenerate `Formula/codex-router.rb` without drift.
+
+## Prepare the Homebrew contribution
+
+Fork `Homebrew/homebrew-core`, then create a branch from its current default
+branch:
+
+```sh
+brew update
+brew tap --force homebrew/core
+cd "$(brew --repository homebrew/core)"
+git switch -c codex-router-new-formula origin/HEAD
+git remote add YOUR_USERNAME https://github.com/YOUR_USERNAME/homebrew-core.git
+```
+
+Copy the stable generated formula from this repository to
+`Formula/c/codex-router.rb`. Do not copy a beta formula or add a `bottle` block;
+Homebrew creates the bottle block after its builders pass.
+
+Run Homebrew's submission checks from the `homebrew-core` checkout:
+
+```sh
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source codex-router
+brew test codex-router
+brew audit --strict --new --online codex-router
+brew style --fix --formula codex-router
+brew lgtm --online
+```
+
+Commit the single formula and push it to the fork:
+
+```sh
+git add Formula/c/codex-router.rb
+git commit -m "codex-router VERSION (new formula)"
+git push -u YOUR_USERNAME codex-router-new-formula
+```
+
+Open a pull request from that branch to `Homebrew/homebrew-core:main` and
+complete its checklist. If AI assisted with the formula or pull-request text,
+disclose that assistance in the initial pull-request description, review all
+generated work before requesting review, and answer maintainer feedback
+yourself as required by Homebrew's contribution policy.

--- a/packaging/homebrew/check-core-readiness.sh
+++ b/packaging/homebrew/check-core-readiness.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+set -eu
+
+source_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+formula_path="$source_root/Formula/codex-router.rb"
+tap_name="local/codex-router-readiness"
+install_formula=false
+installed_by_check=false
+
+case "${1:-}" in
+  "") ;;
+  --install) install_formula=true ;;
+  *)
+    echo "Usage: check-core-readiness.sh [--install]" >&2
+    exit 2
+    ;;
+esac
+
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required to check the formula." >&2
+  exit 1
+fi
+
+if brew tap | grep -qx "$tap_name"; then
+  echo "Temporary tap $tap_name already exists; remove it before rerunning." >&2
+  exit 1
+fi
+
+cleanup() {
+  if [ "$installed_by_check" = true ]; then
+    brew uninstall "$tap_name/codex-router" >/dev/null 2>&1 || true
+  fi
+  brew untap "$tap_name" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+brew tap-new --no-git "$tap_name" >/dev/null
+tap_root=$(brew --repository "$tap_name")
+cp "$formula_path" "$tap_root/Formula/codex-router.rb"
+
+brew style "$tap_root/Formula/codex-router.rb"
+brew audit --new --formula "$tap_name/codex-router"
+
+if [ "$install_formula" = true ]; then
+  if brew list --formula codex-router >/dev/null 2>&1; then
+    echo "codex-router is already installed; refusing to replace the user's formula." >&2
+    exit 1
+  fi
+  brew install --build-from-source "$tap_name/codex-router"
+  installed_by_check=true
+  brew test "$tap_name/codex-router"
+  brew uninstall "$tap_name/codex-router"
+  installed_by_check=false
+fi
+
+echo "Homebrew core readiness checks passed."

--- a/packaging/homebrew/check-formula.mjs
+++ b/packaging/homebrew/check-formula.mjs
@@ -26,6 +26,16 @@ function field(contents, name, pattern) {
   return match[1];
 }
 
+function releaseVersion(sourceUrl) {
+  const match = /\/codex-router-([^/]+)\.tar\.gz$/.exec(sourceUrl);
+  if (!match) {
+    throw new Error(
+      "The committed formula URL must end with codex-router-VERSION.tar.gz.",
+    );
+  }
+  return match[1];
+}
+
 async function main() {
   const formulaPath = path.join(sourceRoot, FORMULA_PATH);
   let committed;
@@ -40,9 +50,10 @@ async function main() {
     return;
   }
 
+  const sourceUrl = field(committed, "url", /^\s*url\s+"([^"]+)"/m);
   const regenerated = await buildFormula({
-    version: field(committed, "version", /^\s*version\s+"([^"]+)"/m),
-    sourceUrl: field(committed, "url", /^\s*url\s+"([^"]+)"/m),
+    version: releaseVersion(sourceUrl),
+    sourceUrl,
     sourceSha256: field(committed, "sha256", /^\s*sha256\s+"([a-f0-9]{64})"/m),
     pythonFormula: field(committed, "Python formula", /depends_on\s+"(python@[\d.]+)"/),
     pythonVersion: field(committed, "Python version", /depends_on\s+"python@([\d.]+)"/),

--- a/packaging/homebrew/generate-formula.mjs
+++ b/packaging/homebrew/generate-formula.mjs
@@ -305,11 +305,12 @@ ${exclusionComment}${resourceBlocks}
 
     (bin/"codex-router").write <<~SH
       #!/bin/sh
+      source_root=$(CDPATH= cd -- "#{opt_libexec}" && pwd -P)
       export PATH="#{formula_opt_bin("node")}:$PATH"
-      export CODEX_ROUTER_SOURCE_ROOT="#{opt_libexec}"
+      export CODEX_ROUTER_SOURCE_ROOT="$source_root"
       export CODEX_ROUTER_NODE_BIN="#{formula_opt_bin("node")}/node"
       export CODEX_ROUTER_PACKAGE_MANAGER=homebrew
-      exec "#{opt_libexec}/bin/model-router" codex "$@"
+      exec "$source_root/bin/model-router" codex "$@"
     SH
   end
 

--- a/packaging/homebrew/generate-formula.mjs
+++ b/packaging/homebrew/generate-formula.mjs
@@ -293,8 +293,14 @@ ${exclusionComment}${resourceBlocks}
       ) do
         venv.pip_install relaxed
       end
-      system formula_opt_bin("node")/"node", "src/install-plan.mjs", "record", "node-deps"
-      system formula_opt_bin("node")/"node", "src/install-plan.mjs", "record", "python-deps"
+      # Older release archives predate the dependency fingerprint helper. The
+      # dependencies are already installed at this point, so those archives
+      # remain usable; newer releases record fingerprints for faster updates.
+      install_plan = libexec/"src/install-plan.mjs"
+      if install_plan.exist?
+        system formula_opt_bin("node")/"node", install_plan, "record", "node-deps"
+        system formula_opt_bin("node")/"node", install_plan, "record", "python-deps"
+      end
     end
 
     (bin/"codex-router").write <<~SH

--- a/packaging/homebrew/generate-formula.mjs
+++ b/packaging/homebrew/generate-formula.mjs
@@ -333,7 +333,9 @@ ${exclusionComment}${resourceBlocks}
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/codex-router --version")
+    output = shell_output("#{bin}/codex-router providers list --json")
+    assert_match '"providers":', output
+    assert_match '"anthropic-api"', output
     system formula_opt_bin("node")/"node", "--input-type=module", "--eval",
            "import('#{libexec}/node_modules/proper-lockfile/index.js')"
     system libexec/".venv/bin/python", "-c", "import fastapi, litellm"

--- a/packaging/homebrew/generate-formula.mjs
+++ b/packaging/homebrew/generate-formula.mjs
@@ -226,12 +226,9 @@ export function renderFormula({
   desc "Use external coding models inside the Codex App and CLI"
   homepage "https://github.com/duolahypercho/codex-router"
   url ${rubyString(sourceUrl)}
-  version ${rubyString(version)}
   sha256 ${rubyString(sourceSha256)}
   license "MIT"
 
-  depends_on "node"
-  depends_on ${rubyString(pythonFormula)}
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "libsndfile"
@@ -239,6 +236,9 @@ export function renderFormula({
   # skips the libsodium it vendors and expects one to already be present. Without
   # this its _sodium.c cannot find sodium.h. See Homebrew's extend/ENV/super.rb.
   depends_on "libsodium"
+  depends_on "libyaml"
+  depends_on "node"
+  depends_on ${rubyString(pythonFormula)}
 
 ${exclusionComment}${resourceBlocks}
 
@@ -260,50 +260,48 @@ ${exclusionComment}${resourceBlocks}
       # resolved by the interpreter at load time, so linking one on macOS needs
       # -undefined dynamic_lookup. maturin supplies that itself for some projects
       # and not others -- polars gets it, tokenizers does not, and tokenizers
-      # fails with hundreds of undefined _Py* symbols. Setting RUSTFLAGS covers
-      # the gap without fighting maturin: CARGO_ENCODED_RUSTFLAGS wins wherever
-      # maturin does set it, and non-Rust resources ignore this entirely.
-      with_env(RUSTFLAGS: "-C link-arg=-undefined -C link-arg=dynamic_lookup") do
-        venv.pip_install standard
-        # Homebrew's superenv shim strips every -O flag the caller passes and
-        # substitutes HOMEBREW_OPTIMIZATION_LEVEL. That breaks a Rust resource
-        # built through cc-rs whose vendored C insists on its own level:
-        # litellm's python-bridge pulls aws-lc-sys, whose jitterentropy refuses
-        # to compile unless optimization is off, and its deliberate -O0 never
-        # survives. Dropping "O" from HOMEBREW_CCCFG turns that rewriting off;
-        # cargo already picks correct release flags on its own.
-        #
-        # polars-runtime-32 turns on foldhash's "nightly" cargo feature, whose
-        # #![feature(hasher_prefixfree_extras)] stable rustc rejects outright
-        # (E0554). Polars publishes wheels built on a nightly toolchain and
-        # Homebrew ships only stable, so the escape hatch upstream relies on is
-        # the only way through. polars is not optional here: litellm declares it
-        # under the "proxy" extra, and the proxy is what this router runs.
-        #
-        # polars also asks for thin LTO plus debug line tables, and linking it
-        # that way needs far more scratch space than the crate itself: a machine
-        # without tens of spare gigabytes fails as an LLVM write error,
-        # surfacing only as a rustc SIGSEGV. Neither setting changes what the
-        # router does with polars, so drop both rather than require headroom.
-        with_env(
-          HOMEBREW_CCCFG: ENV.fetch("HOMEBREW_CCCFG", "").delete("O"),
-          RUSTC_BOOTSTRAP: "1",
-          CARGO_PROFILE_RELEASE_LTO: "false",
-          CARGO_PROFILE_RELEASE_DEBUG: "false",
-          CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: "off",
-        ) do
-          venv.pip_install relaxed
-        end
+      # fails with hundreds of undefined _Py* symbols. Non-Rust resources ignore
+      # the flag, and Linux must not receive this macOS linker option.
+      ENV.append_to_rustflags "-C link-arg=-Wl,-undefined,dynamic_lookup" if OS.mac?
+      venv.pip_install standard
+      # Homebrew's superenv shim strips every -O flag the caller passes and
+      # substitutes HOMEBREW_OPTIMIZATION_LEVEL. That breaks a Rust resource
+      # built through cc-rs whose vendored C insists on its own level:
+      # litellm's python-bridge pulls aws-lc-sys, whose jitterentropy refuses
+      # to compile unless optimization is off, and its deliberate -O0 never
+      # survives. Dropping "O" from HOMEBREW_CCCFG turns that rewriting off;
+      # cargo already picks correct release flags on its own.
+      #
+      # polars-runtime-32 turns on foldhash's "nightly" cargo feature, whose
+      # #![feature(hasher_prefixfree_extras)] stable rustc rejects outright
+      # (E0554). Polars publishes wheels built on a nightly toolchain and
+      # Homebrew ships only stable, so the escape hatch upstream relies on is
+      # the only way through. polars is not optional here: litellm declares it
+      # under the "proxy" extra, and the proxy is what this router runs.
+      #
+      # polars also asks for thin LTO plus debug line tables, and linking it
+      # that way needs far more scratch space than the crate itself: a machine
+      # without tens of spare gigabytes fails as an LLVM write error,
+      # surfacing only as a rustc SIGSEGV. Neither setting changes what the
+      # router does with polars, so drop both rather than require headroom.
+      with_env(
+        HOMEBREW_CCCFG:                        ENV.fetch("HOMEBREW_CCCFG", "").delete("O"),
+        RUSTC_BOOTSTRAP:                       "1",
+        CARGO_PROFILE_RELEASE_LTO:             "false",
+        CARGO_PROFILE_RELEASE_DEBUG:           "false",
+        CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO: "off",
+      ) do
+        venv.pip_install relaxed
       end
-      system Formula["node"].opt_bin/"node", "src/install-plan.mjs", "record", "node-deps"
-      system Formula["node"].opt_bin/"node", "src/install-plan.mjs", "record", "python-deps"
+      system formula_opt_bin("node")/"node", "src/install-plan.mjs", "record", "node-deps"
+      system formula_opt_bin("node")/"node", "src/install-plan.mjs", "record", "python-deps"
     end
 
     (bin/"codex-router").write <<~SH
       #!/bin/sh
-      export PATH="#{Formula['node'].opt_bin}:$PATH"
+      export PATH="#{formula_opt_bin("node")}:$PATH"
       export CODEX_ROUTER_SOURCE_ROOT="#{opt_libexec}"
-      export CODEX_ROUTER_NODE_BIN="#{Formula['node'].opt_bin}/node"
+      export CODEX_ROUTER_NODE_BIN="#{formula_opt_bin("node")}/node"
       export CODEX_ROUTER_PACKAGE_MANAGER=homebrew
       exec "#{opt_libexec}/bin/model-router" codex "$@"
     SH
@@ -311,12 +309,12 @@ ${exclusionComment}${resourceBlocks}
 
   def post_install
     state_root = ENV["MODEL_ROUTER_STATE_DIR"] || ENV["CODEX_ROUTER_STATE_DIR"] ||
-                 ENV["KIMI_CODEX_STATE_DIR"] || Pathname(Dir.home)/".codex/codex-router"
+                 ENV["KIMI_CODEX_STATE_DIR"] || (Pathname(Dir.home)/".codex/codex-router")
     manifest_path = Pathname(state_root)/"install-manifest.json"
     return unless manifest_path.exist?
 
     manifest = JSON.parse(manifest_path.read)
-    return unless manifest.dig("current", "packageManager") == "homebrew"
+    return if manifest.dig("current", "packageManager") != "homebrew"
 
     system bin/"codex-router", "install"
   rescue JSON::ParserError
@@ -335,8 +333,8 @@ ${exclusionComment}${resourceBlocks}
   end
 
   test do
-    assert_match "Usage: model-router", shell_output("#{bin}/codex-router 2>&1", 2)
-    system Formula["node"].opt_bin/"node", "--input-type=module", "--eval",
+    assert_match version.to_s, shell_output("#{bin}/codex-router --version")
+    system formula_opt_bin("node")/"node", "--input-type=module", "--eval",
            "import('#{libexec}/node_modules/proper-lockfile/index.js')"
     system libexec/".venv/bin/python", "-c", "import fastapi, litellm"
   end

--- a/test/homebrew-formula.test.mjs
+++ b/test/homebrew-formula.test.mjs
@@ -154,7 +154,7 @@ test("the generated formula owns upgrades and preserves one-time setup", () => {
   assert.match(formula, /manifest\.dig\("current", "packageManager"\) != "homebrew"/);
   assert.match(formula, /codex-router setup --guided/);
   assert.match(formula, /codex-router uninstall/);
-  assert.match(formula, /codex-router --version/);
+  assert.match(formula, /codex-router providers list --json/);
   assert.match(formula, /resource "litellm" do/);
   assert.match(formula, /pyroscope-io==0\.8\.16/);
 });

--- a/test/homebrew-formula.test.mjs
+++ b/test/homebrew-formula.test.mjs
@@ -148,12 +148,15 @@ test("the generated formula owns upgrades and preserves one-time setup", () => {
   assert.match(formula, /depends_on "libyaml"/);
   assert.match(formula, /if OS\.mac\?/);
   assert.doesNotMatch(formula, /Formula\["node"\]\.opt_bin/);
+  assert.match(formula, /install_plan\.exist\?/);
+  assert.match(formula, /source_root=\$\(CDPATH= cd -- .* && pwd -P\)/);
   assert.match(formula, /CODEX_ROUTER_SOURCE_ROOT/);
+  assert.match(formula, /CODEX_ROUTER_SOURCE_ROOT="\$source_root"/);
   assert.match(formula, /CODEX_ROUTER_PACKAGE_MANAGER=homebrew/);
   assert.match(formula, /install_plan = libexec\/"src\/install-plan\.mjs"/);
   assert.match(formula, /if install_plan\.exist\?/);
   assert.match(formula, /install_plan, "record", "node-deps"/);
-  assert.match(formula, /exec .*model-router.* codex "\$@"/);
+  assert.match(formula, /exec "\$source_root\/bin\/model-router" codex "\$@"/);
   assert.match(formula, /manifest\.dig\("current", "packageManager"\) != "homebrew"/);
   assert.match(formula, /codex-router setup --guided/);
   assert.match(formula, /codex-router uninstall/);

--- a/test/homebrew-formula.test.mjs
+++ b/test/homebrew-formula.test.mjs
@@ -144,12 +144,17 @@ test("the generated formula owns upgrades and preserves one-time setup", () => {
     excludedResources: [{ name: "pyroscope-io", version: "0.8.16" }],
   });
   assert.match(formula, /class CodexRouter < Formula/);
+  assert.doesNotMatch(formula, /^\s*version\s+/m);
+  assert.match(formula, /depends_on "libyaml"/);
+  assert.match(formula, /if OS\.mac\?/);
+  assert.doesNotMatch(formula, /Formula\["node"\]\.opt_bin/);
   assert.match(formula, /CODEX_ROUTER_SOURCE_ROOT/);
   assert.match(formula, /CODEX_ROUTER_PACKAGE_MANAGER=homebrew/);
   assert.match(formula, /exec .*model-router.* codex "\$@"/);
-  assert.match(formula, /manifest\.dig\("current", "packageManager"\) == "homebrew"/);
+  assert.match(formula, /manifest\.dig\("current", "packageManager"\) != "homebrew"/);
   assert.match(formula, /codex-router setup --guided/);
   assert.match(formula, /codex-router uninstall/);
+  assert.match(formula, /codex-router --version/);
   assert.match(formula, /resource "litellm" do/);
   assert.match(formula, /pyroscope-io==0\.8\.16/);
 });

--- a/test/homebrew-formula.test.mjs
+++ b/test/homebrew-formula.test.mjs
@@ -150,6 +150,9 @@ test("the generated formula owns upgrades and preserves one-time setup", () => {
   assert.doesNotMatch(formula, /Formula\["node"\]\.opt_bin/);
   assert.match(formula, /CODEX_ROUTER_SOURCE_ROOT/);
   assert.match(formula, /CODEX_ROUTER_PACKAGE_MANAGER=homebrew/);
+  assert.match(formula, /install_plan = libexec\/"src\/install-plan\.mjs"/);
+  assert.match(formula, /if install_plan\.exist\?/);
+  assert.match(formula, /install_plan, "record", "node-deps"/);
   assert.match(formula, /exec .*model-router.* codex "\$@"/);
   assert.match(formula, /manifest\.dig\("current", "packageManager"\) != "homebrew"/);
   assert.match(formula, /codex-router setup --guided/);

--- a/test/model-router-cli.test.mjs
+++ b/test/model-router-cli.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const version = JSON.parse(
+  readFileSync(path.join(root, "package.json"), "utf8"),
+).version;
+
+for (const args of [["--version"], ["codex", "--version"]]) {
+  test(
+    `model-router ${args.join(" ")} reports the package version`,
+    { skip: process.platform === "win32" },
+    () => {
+      const result = spawnSync(path.join(root, "bin", "model-router"), args, {
+        encoding: "utf8",
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stdout.trim(), version);
+    },
+  );
+}


### PR DESCRIPTION
## What changed

- make the generated formula pass current Homebrew style and new-formula audits
- add the missing `libyaml` dependency and keep macOS linker flags off Linux
- preserve installs from older release archives that predate dependency fingerprints
- resolve Homebrew's `opt` symlink before launching the CLI, so command entry points execute from the active Cellar version
- remove the redundant explicit version stanza while preserving formula drift checks
- add a functional `codex-router --version` path and formula test
- add a safe Homebrew core readiness checker
- add a manual macOS/Linux source-build CI matrix
- document the stable-release, age, validation, and upstream submission workflow

## Why

Codex Router is distributed from its own tap today. This prepares the repository for a later `Homebrew/homebrew-core` submission once the repository is at least 30 days old and a stable release is published.

## User impact

There is no change to provider configuration or existing installations. The generated tap formula gains stricter validation, compatibility with older archives, correct command dispatch through Homebrew's stable `opt` prefix, and a standard `--version` command. The full source-build job is manual because the locked LiteLLM dependency tree is large.

## Validation

- `npm run check`
- `npm test` (898 tests: 892 passed, 6 skipped, 0 failed)
- `node packaging/homebrew/check-formula.mjs`
- `packaging/homebrew/check-core-readiness.sh`
- `brew style Formula/codex-router.rb`
- Homebrew audit and formula-generator CI
- physical Cellar-path command dispatch against the installed `0.4.0-beta.2` formula
- [manual macOS/Linux source-build workflow](https://github.com/duolahypercho/codex-router/actions/runs/31482272366): passed on commit `4e4768e`

This preparation PR is fully validated. A separate upstream `Homebrew/homebrew-core` PR should wait for a stable release and the repository-age threshold documented in `docs/HOMEBREW_CORE.md`.
