### PR TITLE
fix: detect and rebuild venvs whose interpreter home was cleared

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -101,16 +101,15 @@ fi
 if [ "$(install_step python-deps)" = skip ]; then
   echo "LiteLLM already matches the pinned versions; skipping the Python install."
 elif command -v uv >/dev/null 2>&1; then
-  if [ ! -x .venv/bin/python ] || ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
+  if [ ! -x .venv/bin/python ]; then
+    uv venv --python 3.12 .venv
+  elif ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
     # A venv whose interpreter home was cleared (macOS wipes /private/tmp, and
     # installers that recorded a temporary Python as the venv home end up with
     # a dangling interpreter) must be recreated, not pip-installed into: the
     # launcher may still exist while pyvenv.cfg points at a vanished home.
-    if [ -e .venv ]; then
-      echo "The virtual environment's interpreter home is missing; recreating the venv."
-      rm -rf .venv
-    fi
-    uv venv --python 3.12 .venv
+    echo "The virtual environment's interpreter home is missing; recreating the venv."
+    uv venv --clear --python 3.12 .venv
   fi
   # requirements/python.txt is the hash-verified transitive closure of the pins
   # in src/install-plan.mjs. Hash checking makes every wheel and sdist in that
@@ -127,13 +126,12 @@ else
   python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else "Python 3.10 or newer is required.")'
   # Same clearing logic as the uv branch: a venv with a vanished interpreter
   # home must be recreated from scratch instead of installed over.
-  if ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
-    if [ -e .venv ]; then
-      echo "The virtual environment's interpreter home is missing; recreating the venv."
-      rm -rf .venv
-    fi
+  if node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
+    python3 -m venv .venv
+  else
+    echo "The virtual environment's interpreter home is missing; recreating the venv."
+    python3 -m venv --clear .venv
   fi
-  python3 -m venv .venv
   .venv/bin/python -m pip install --upgrade pip
   # Same hash-verified lock as the uv branch above; both branches stay checked.
   .venv/bin/python -m pip install --require-hashes -r requirements/python.txt

--- a/bin/install
+++ b/bin/install
@@ -101,7 +101,15 @@ fi
 if [ "$(install_step python-deps)" = skip ]; then
   echo "LiteLLM already matches the pinned versions; skipping the Python install."
 elif command -v uv >/dev/null 2>&1; then
-  if [ ! -x .venv/bin/python ]; then
+  if [ ! -x .venv/bin/python ] || ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
+    # A venv whose interpreter home was cleared (macOS wipes /private/tmp, and
+    # installers that recorded a temporary Python as the venv home end up with
+    # a dangling interpreter) must be recreated, not pip-installed into: the
+    # launcher may still exist while pyvenv.cfg points at a vanished home.
+    if [ -e .venv ]; then
+      echo "The virtual environment's interpreter home is missing; recreating the venv."
+      rm -rf .venv
+    fi
     uv venv --python 3.12 .venv
   fi
   # requirements/python.txt is the hash-verified transitive closure of the pins
@@ -117,6 +125,14 @@ else
     exit 1
   fi
   python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else "Python 3.10 or newer is required.")'
+  # Same clearing logic as the uv branch: a venv with a vanished interpreter
+  # home must be recreated from scratch instead of installed over.
+  if ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
+    if [ -e .venv ]; then
+      echo "The virtual environment's interpreter home is missing; recreating the venv."
+      rm -rf .venv
+    fi
+  fi
   python3 -m venv .venv
   .venv/bin/python -m pip install --upgrade pip
   # Same hash-verified lock as the uv branch above; both branches stay checked.

--- a/install.ps1
+++ b/install.ps1
@@ -248,17 +248,17 @@ try {
     Write-Host "LiteLLM already matches the pinned versions; skipping the Python install."
   } elseif (Get-Command "uv" -ErrorAction SilentlyContinue) {
     $VenvHomeOk = (& node src/install-plan.mjs venv-home-ok 2>$null | Select-Object -Last 1) -eq "ok"
-    if (-not (Test-Path $Python) -or -not $VenvHomeOk) {
+    if (-not (Test-Path $Python)) {
+      & uv venv --python 3.12 .venv
+      if ($LASTEXITCODE -ne 0) { throw "uv could not create the Python environment." }
+    } elseif (-not $VenvHomeOk) {
       # A venv whose interpreter home was cleared (macOS wipes /private/tmp,
       # and installers that recorded a temporary Python as the venv home end
       # up with a dangling interpreter) must be recreated, not pip-installed
       # into: the launcher may still exist while pyvenv.cfg points at a
       # vanished home.
-      if (Test-Path ".venv") {
-        Write-Host "The virtual environment's interpreter home is missing; recreating the venv."
-        Remove-Item -Recurse -Force ".venv"
-      }
-      & uv venv --python 3.12 .venv
+      Write-Host "The virtual environment's interpreter home is missing; recreating the venv."
+      & uv venv --clear --python 3.12 .venv
       if ($LASTEXITCODE -ne 0) { throw "uv could not create the Python environment." }
     }
     # requirements/python.txt is the hash-verified transitive closure of the
@@ -272,23 +272,25 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "Recording the Python dependency state failed." }
   } else {
     $VenvHomeOk = (& node src/install-plan.mjs venv-home-ok 2>$null | Select-Object -Last 1) -eq "ok"
-    if (-not $VenvHomeOk) {
-      # Same clearing logic as the uv branch: a venv with a vanished
-      # interpreter home must be recreated from scratch instead of installed
-      # over.
-      if (Test-Path ".venv") {
-        Write-Host "The virtual environment's interpreter home is missing; recreating the venv."
-        Remove-Item -Recurse -Force ".venv"
-      }
-    }
+    $RecreateVenv = -not $VenvHomeOk
     if (Get-Command "py" -ErrorAction SilentlyContinue) {
       & py -3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"
       if ($LASTEXITCODE -ne 0) { throw "Python 3.10 or newer is required." }
-      if (-not (Test-Path $Python)) { & py -3 -m venv .venv }
+      if (-not (Test-Path $Python)) {
+        & py -3 -m venv .venv
+      } elseif ($RecreateVenv) {
+        Write-Host "The virtual environment's interpreter home is missing; recreating the venv."
+        & py -3 -m venv --clear .venv
+      }
     } elseif (Get-Command "python" -ErrorAction SilentlyContinue) {
       & python -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"
       if ($LASTEXITCODE -ne 0) { throw "Python 3.10 or newer is required." }
-      if (-not (Test-Path $Python)) { & python -m venv .venv }
+      if (-not (Test-Path $Python)) {
+        & python -m venv .venv
+      } elseif ($RecreateVenv) {
+        Write-Host "The virtual environment's interpreter home is missing; recreating the venv."
+        & python -m venv --clear .venv
+      }
     } else {
       throw "Python 3.10+ or uv is required. Install uv from https://docs.astral.sh/uv/."
     }

--- a/install.ps1
+++ b/install.ps1
@@ -247,7 +247,17 @@ try {
   if ((Get-InstallStep "python-deps") -eq "skip") {
     Write-Host "LiteLLM already matches the pinned versions; skipping the Python install."
   } elseif (Get-Command "uv" -ErrorAction SilentlyContinue) {
-    if (-not (Test-Path $Python)) {
+    $VenvHomeOk = (& node src/install-plan.mjs venv-home-ok 2>$null | Select-Object -Last 1) -eq "ok"
+    if (-not (Test-Path $Python) -or -not $VenvHomeOk) {
+      # A venv whose interpreter home was cleared (macOS wipes /private/tmp,
+      # and installers that recorded a temporary Python as the venv home end
+      # up with a dangling interpreter) must be recreated, not pip-installed
+      # into: the launcher may still exist while pyvenv.cfg points at a
+      # vanished home.
+      if (Test-Path ".venv") {
+        Write-Host "The virtual environment's interpreter home is missing; recreating the venv."
+        Remove-Item -Recurse -Force ".venv"
+      }
       & uv venv --python 3.12 .venv
       if ($LASTEXITCODE -ne 0) { throw "uv could not create the Python environment." }
     }
@@ -261,6 +271,16 @@ try {
     & node src/install-plan.mjs record python-deps
     if ($LASTEXITCODE -ne 0) { throw "Recording the Python dependency state failed." }
   } else {
+    $VenvHomeOk = (& node src/install-plan.mjs venv-home-ok 2>$null | Select-Object -Last 1) -eq "ok"
+    if (-not $VenvHomeOk) {
+      # Same clearing logic as the uv branch: a venv with a vanished
+      # interpreter home must be recreated from scratch instead of installed
+      # over.
+      if (Test-Path ".venv") {
+        Write-Host "The virtual environment's interpreter home is missing; recreating the venv."
+        Remove-Item -Recurse -Force ".venv"
+      }
+    }
     if (Get-Command "py" -ErrorAction SilentlyContinue) {
       & py -3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"
       if ($LASTEXITCODE -ne 0) { throw "Python 3.10 or newer is required." }

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -48,6 +48,7 @@ import {
   readVisionBridgeSettings,
   visionBridgeConfigured,
 } from "./vision-bridge-state.mjs";
+import { venvRuntimeProblem } from "./venv-runtime.mjs";
 
 const checks = [];
 const add = (status, name, detail, fix) => checks.push({ status, name, detail, fix });
@@ -460,6 +461,28 @@ add(
   "Generated gateway config",
   LITELLM_CONFIG_PATH,
   "Run ./bin/doctor --fix.",
+);
+
+// The venv that runs LiteLLM can be broken while every file it needs still
+// exists: an interpreter home pointing at a cleared temporary directory
+// (macOS wipes /private/tmp, and an installer that recorded a temporary
+// Python as the venv home leaves `.venv/bin/python` dangling) keeps the
+// launcher on disk but makes every spawn fail with a bare ENOENT. Probing
+// the interpreter turns that silent restart loop into an actionable check.
+const venvPython = path.join(
+  SOURCE_ROOT,
+  ".venv",
+  process.platform === "win32" ? "Scripts" : "bin",
+  process.platform === "win32" ? "python.exe" : "python",
+);
+const venvProblem = venvRuntimeProblem(venvPython);
+add(
+  venvProblem ? "fail" : "ok",
+  "LiteLLM venv runtime",
+  venvProblem
+    ? `${venvPython} cannot run (${venvProblem})`
+    : `${venvPython} runs`,
+  "Run ./bin/doctor --fix; it rebuilds the virtual environment from the pinned lock.",
 );
 
 const secretMode = existsSync(INTERNAL_SECRET_PATH)

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -29,6 +29,7 @@ import {
   MERGED_CATALOG_PATH,
   PORTS,
   SOURCE_ROOT,
+  TARGET,
 } from "./paths.mjs";
 import { CODEX_APP_TOOLS } from "./codex-app-tools.mjs";
 import {
@@ -469,19 +470,38 @@ add(
 // Python as the venv home leaves `.venv/bin/python` dangling) keeps the
 // launcher on disk but makes every spawn fail with a bare ENOENT. Probing
 // the interpreter turns that silent restart loop into an actionable check.
-const venvPython = path.join(
-  SOURCE_ROOT,
-  ".venv",
-  process.platform === "win32" ? "Scripts" : "bin",
-  process.platform === "win32" ? "python.exe" : "python",
-);
-const venvProblem = venvRuntimeProblem(venvPython);
+// The probe applies only to the bundled venv: a custom launcher
+// (MODEL_ROUTER_LITELLM_BIN or a codex-target alias) may deliberately ship
+// without the bundled `.venv`, and a fresh checkout has no venv until the
+// installer runs.
+const usesBundledVenv = !process.env.MODEL_ROUTER_LITELLM_BIN &&
+  !(TARGET === "codex" &&
+    (process.env.CODEX_ROUTER_LITELLM_BIN || process.env.KIMI_LITELLM_BIN));
+let venvCheck;
+if (usesBundledVenv) {
+  const venvPython = path.join(
+    SOURCE_ROOT,
+    ".venv",
+    process.platform === "win32" ? "Scripts" : "bin",
+    process.platform === "win32" ? "python.exe" : "python",
+  );
+  const venvProblem = venvRuntimeProblem(venvPython);
+  venvCheck = venvProblem
+    ? {
+        status: "fail",
+        detail: `${venvPython} cannot run (${venvProblem})`,
+      }
+    : { status: "ok", detail: `${venvPython} runs` };
+} else {
+  venvCheck = {
+    status: "ok",
+    detail: "custom LiteLLM launcher configured; bundled venv not required",
+  };
+}
 add(
-  venvProblem ? "fail" : "ok",
+  venvCheck.status,
   "LiteLLM venv runtime",
-  venvProblem
-    ? `${venvPython} cannot run (${venvProblem})`
-    : `${venvPython} runs`,
+  venvCheck.detail,
   "Run ./bin/doctor --fix; it rebuilds the virtual environment from the pinned lock.",
 );
 

--- a/src/install-plan.mjs
+++ b/src/install-plan.mjs
@@ -123,6 +123,20 @@ function venvPythonVersion(root) {
   return match ? match[1] : "unknown";
 }
 
+// The venv records the base interpreter it was created from. If that
+// directory was cleared -- macOS periodically wipes /private/tmp, and an
+// installer that recorded a temporary Python as the venv home leaves the
+// interpreter dangling after reboot -- the venv is unusable even when
+// `.venv/bin/python` still resolves through a copied binary. Treat an
+// unresolvable home as "not installed" so every install/update rebuilds it.
+function venvPythonHomeUsable(root) {
+  const config = readFile(path.join(root, ".venv", "pyvenv.cfg")) || "";
+  const match = config.match(/^\s*home\s*=\s*(.+)$/m);
+  if (!match) return true; // unknown; the interpreter probe decides
+  const home = match[1].trim();
+  return existsSync(home);
+}
+
 // The companion is one bundle per user, not one per checkout: a `dist/` target
 // inside the repository produces a separate tray for every clone and leaves
 // launchd pointing at whichever one installed last.
@@ -220,6 +234,11 @@ export const STEPS = {
         ].join("\0"),
       ),
     installed: (root, platform) => {
+      // A venv whose interpreter home was cleared (macOS wipes /private/tmp,
+      // and installers that recorded a temporary Python as the venv home end
+      // up with a dangling interpreter) must read as "not installed" so the
+      // next install/update rebuilds it instead of skipping a broken venv.
+      if (!venvPythonHomeUsable(root)) return false;
       if (!existsSync(venvPython(root, platform))) return false;
       return PYTHON_REQUIREMENTS.every((requirement) => {
         const { name, version } = requirementParts(requirement);

--- a/src/install-plan.mjs
+++ b/src/install-plan.mjs
@@ -129,7 +129,7 @@ function venvPythonVersion(root) {
 // interpreter dangling after reboot -- the venv is unusable even when
 // `.venv/bin/python` still resolves through a copied binary. Treat an
 // unresolvable home as "not installed" so every install/update rebuilds it.
-function venvPythonHomeUsable(root) {
+export function venvPythonHomeUsable(root = SOURCE_ROOT) {
   const config = readFile(path.join(root, ".venv", "pyvenv.cfg")) || "";
   const match = config.match(/^\s*home\s*=\s*(.+)$/m);
   if (!match) return true; // unknown; the interpreter probe decides
@@ -516,6 +516,16 @@ function main(argv) {
     process.stdout.write(`${PYTHON_REQUIREMENTS.join("\n")}\n`);
     return 0;
   }
+  // `venv-home-ok` — 0/1 whether the recorded venv interpreter home still
+  // exists. The installers use this to decide whether a *present* venv must
+  // be cleared and recreated: `status python-deps` already returns "run" for
+  // a broken home, but the uv branch only recreates the venv when the python
+  // launcher itself is absent, so an existing-but-broken venv would otherwise
+  // be pip-installed into without ever rewriting pyvenv.cfg.
+  if (command === "venv-home-ok") {
+    process.stdout.write(venvPythonHomeUsable() ? "ok\n" : "damaged\n");
+    return venvPythonHomeUsable() ? 0 : 1;
+  }
   // `python-install-command <uv|pip> [posix|windows]` — what CI runs so that it
   // exercises the shipped installer's command rather than a copy of it.
   if (command === "python-install-command") {
@@ -524,7 +534,7 @@ function main(argv) {
   }
   console.error(
     "Usage: install-plan.mjs status|record <node-deps|python-deps> | tray-plan | record-tray | " +
-      "requirements | python-install-command <uv|pip> [posix|windows]",
+      "requirements | venv-home-ok | python-install-command <uv|pip> [posix|windows]",
   );
   return 2;
 }

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -40,21 +40,29 @@ if (!existsSync(litellm)) {
 // while the launcher itself is still present. Probe the interpreter
 // explicitly so a broken venv fails here with a readable message and a fix
 // path instead of feeding launchd's restart loop an unreadable crash.
-const venvPython =
-  process.env.MODEL_ROUTER_VENV_PYTHON ||
-  path.join(
+// The probe applies only to the bundled venv: a custom launcher
+// (MODEL_ROUTER_LITELLM_BIN or a codex-target alias) may deliberately ship
+// without the bundled `.venv`, and CI exercises startup with
+// MODEL_ROUTER_LITELLM_BIN=process.execPath on a fresh checkout that has no
+// venv at all.
+const usesBundledVenv = !process.env.MODEL_ROUTER_LITELLM_BIN &&
+  !(TARGET === "codex" &&
+    (process.env.CODEX_ROUTER_LITELLM_BIN || process.env.KIMI_LITELLM_BIN));
+if (usesBundledVenv) {
+  const venvPython = path.join(
     SOURCE_ROOT,
     ".venv",
     process.platform === "win32" ? "Scripts" : "bin",
     process.platform === "win32" ? "python.exe" : "python",
   );
-const venvProblem = venvRuntimeProblem(venvPython);
-if (venvProblem) {
-  throw new Error(
-    `The LiteLLM virtual environment is broken at ${venvPython} (${venvProblem}). ` +
-      `Run ./bin/doctor --fix to rebuild the virtual environment, ` +
-      `or ./bin/install --force-deps.`,
-  );
+  const venvProblem = venvRuntimeProblem(venvPython);
+  if (venvProblem) {
+    throw new Error(
+      `The LiteLLM virtual environment is broken at ${venvPython} (${venvProblem}). ` +
+        `Run ./bin/doctor --fix to rebuild the virtual environment, ` +
+        `or ./bin/install --force-deps.`,
+    );
+  }
 }
 if (!existsSync(INTERNAL_SECRET_PATH)) {
   throw new Error(`Internal service key is missing; run ./bin/install.`);

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -16,6 +16,7 @@ import {
 } from "./paths.mjs";
 import { waitForHealth as pollHealth } from "./health-probe.mjs";
 import { writeLiteLlmConfig } from "./litellm-config.mjs";
+import { venvRuntimeProblem } from "./venv-runtime.mjs";
 
 const litellm =
   process.env.MODEL_ROUTER_LITELLM_BIN ||
@@ -30,6 +31,30 @@ const litellm =
   );
 if (!existsSync(litellm)) {
   throw new Error(`LiteLLM is not installed at ${litellm}; run ./bin/install.`);
+}
+
+// A launcher file that exists on disk is not proof the venv works: an
+// interpreter home pointing at a cleared temporary directory (macOS wipes
+// /private/tmp, and an installer that recorded a temporary Python as the venv
+// home leaves `.venv/bin/python` dangling) makes every spawn fail with ENOENT
+// while the launcher itself is still present. Probe the interpreter
+// explicitly so a broken venv fails here with a readable message and a fix
+// path instead of feeding launchd's restart loop an unreadable crash.
+const venvPython =
+  process.env.MODEL_ROUTER_VENV_PYTHON ||
+  path.join(
+    SOURCE_ROOT,
+    ".venv",
+    process.platform === "win32" ? "Scripts" : "bin",
+    process.platform === "win32" ? "python.exe" : "python",
+  );
+const venvProblem = venvRuntimeProblem(venvPython);
+if (venvProblem) {
+  throw new Error(
+    `The LiteLLM virtual environment is broken at ${venvPython} (${venvProblem}). ` +
+      `Run ./bin/doctor --fix to rebuild the virtual environment, ` +
+      `or ./bin/install --force-deps.`,
+  );
 }
 if (!existsSync(INTERNAL_SECRET_PATH)) {
   throw new Error(`Internal service key is missing; run ./bin/install.`);

--- a/src/venv-runtime.mjs
+++ b/src/venv-runtime.mjs
@@ -1,0 +1,23 @@
+// The LiteLLM virtual environment can be broken while every file it needs
+// still exists: an interpreter home pointing at a cleared temporary directory
+// (macOS wipes /private/tmp, and an installer that recorded a temporary
+// Python as the venv home leaves `.venv/bin/python` dangling) keeps the
+// launcher on disk but makes every spawn fail with a bare ENOENT. Probing the
+// interpreter turns that silent failure into a checkable, fixable state.
+import { spawnSync } from "node:child_process";
+
+// Returns undefined when the interpreter runs, or a human-readable reason it
+// cannot. `spawn` is injectable so tests can stub it without forking.
+export function venvRuntimeProblem(python, { spawn = spawnSync, timeoutMs = 15_000 } = {}) {
+  const probe = spawn(python, ["--version"], {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (probe.error) return probe.error.message;
+  if (probe.status !== 0) {
+    const detail = (probe.stderr || "").trim() || "no stderr";
+    return `exited with code ${probe.status}: ${detail}`;
+  }
+  return undefined;
+}

--- a/test/install-plan.test.mjs
+++ b/test/install-plan.test.mjs
@@ -117,6 +117,24 @@ test("a rebuilt virtual environment on another Python reinstalls", () => {
   }
 });
 
+test("a virtual environment whose interpreter home was cleared reinstalls", () => {
+  const root = checkout();
+  try {
+    installVenv(root);
+    recordStep("python-deps", { root });
+    // macOS wipes /private/tmp; an installer that recorded a temporary Python
+    // as the venv home leaves the interpreter dangling after reboot. The stamp
+    // must not vouch for a venv that cannot run.
+    writeFileSync(
+      path.join(root, ".venv", "pyvenv.cfg"),
+      "home = /private/tmp/codex-router-python-bin\nversion = 3.12.12\n",
+    );
+    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("distribution lookup normalizes names and ignores extras", () => {
   const root = checkout();
   try {

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -210,6 +210,18 @@ test("both installers keep the update when setup reports exit 2", () => {
   assert.match(windows, /switch --detach \$PreviousRevision/);
 });
 
+test("broken virtual environments use the venv tools' exact-target clear mode", () => {
+  const posix = readFileSync(path.join(root, "bin", "install"), "utf8");
+  const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
+
+  assert.doesNotMatch(posix, /rm\s+-rf\s+\.venv/);
+  assert.match(posix, /uv venv --clear --python 3\.12 \.venv/);
+  assert.match(posix, /python3 -m venv --clear \.venv/);
+  assert.doesNotMatch(windows, /Remove-Item\s+-Recurse.*\.venv/);
+  assert.match(windows, /uv venv --clear --python 3\.12 \.venv/);
+  assert.match(windows, /-m venv --clear \.venv/);
+});
+
 test("the kept-update message names the way back", () => {
   // Keeping the update on exit 2 is the right default, but a user who wanted
   // the old revision needs to be told the escape hatch exists; the retained

--- a/test/venv-runtime.test.mjs
+++ b/test/venv-runtime.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { venvRuntimeProblem } from "../src/venv-runtime.mjs";
+
+test("a working interpreter has no runtime problem", () => {
+  assert.equal(venvRuntimeProblem("/usr/bin/true", { timeoutMs: 5_000 }), undefined);
+});
+
+test("a missing interpreter reports the spawn failure", () => {
+  const problem = venvRuntimeProblem("/nonexistent/python3.99");
+  assert.match(problem, /ENOENT|no such file/i);
+});
+
+test("an interpreter that exits non-zero reports its status", () => {
+  const problem = venvRuntimeProblem("/usr/bin/false");
+  assert.match(problem, /exited with code 1/);
+});
+
+test("the spawn is injectable for hermetic tests", () => {
+  let called = 0;
+  const spawn = () => {
+    called += 1;
+    return { error: undefined, status: 0, stderr: "", stdout: "Python 3.12.12\n" };
+  };
+  assert.equal(venvRuntimeProblem("python", { spawn }), undefined);
+  assert.equal(called, 1);
+});

--- a/test/venv-runtime.test.mjs
+++ b/test/venv-runtime.test.mjs
@@ -3,8 +3,11 @@ import test from "node:test";
 
 import { venvRuntimeProblem } from "../src/venv-runtime.mjs";
 
+// process.execPath is the current Node binary: present on every platform
+// (Windows runners have no /usr/bin/true), and `--version` exits 0 with
+// stdout, so it is a portable "working interpreter".
 test("a working interpreter has no runtime problem", () => {
-  assert.equal(venvRuntimeProblem("/usr/bin/true", { timeoutMs: 5_000 }), undefined);
+  assert.equal(venvRuntimeProblem(process.execPath, { timeoutMs: 5_000 }), undefined);
 });
 
 test("a missing interpreter reports the spawn failure", () => {
@@ -13,8 +16,12 @@ test("a missing interpreter reports the spawn failure", () => {
 });
 
 test("an interpreter that exits non-zero reports its status", () => {
-  const problem = venvRuntimeProblem("/usr/bin/false");
-  assert.match(problem, /exited with code 1/);
+  // A probe that deliberately fails: the injected spawn returns status 1, so
+  // the assertion does not depend on any platform-specific failing binary.
+  const problem = venvRuntimeProblem("interpreter", {
+    spawn: () => ({ error: undefined, status: 1, stderr: "boom\n", stdout: "" }),
+  });
+  assert.match(problem, /exited with code 1: boom/);
 });
 
 test("the spawn is injectable for hermetic tests", () => {


### PR DESCRIPTION
## Problem

After a macOS reboot (or any `/private/tmp` cleanup), the codex-router service silently stops working: **DeepSeek and other routed models disappear from the Codex model picker and every request returns 502**.

### Root cause

`bin/install` creates the venv with whatever Python is first on `PATH`. When that interpreter lives under `/private/tmp` (e.g. an installer that stages a temporary Python there), macOS wipes `/private/tmp` on reboot and the chain breaks:

```
.venv/bin/python -> python3 -> /private/tmp/codex-router-python-bin/python3  (dangling)
```

The crash loop is *silent* for three reasons, each addressed by this PR:

1. **`src/start.mjs`** only checked `existsSync(litellm)`. The launcher file is a regular script that is still present, so the check passed — then `spawn(litellm)` failed with a bare `ENOENT`, feeding launchd an unreadable restart-loop crash.
2. **`src/install-plan.mjs`** gated the Python install on a fingerprint. A broken venv still has `pyvenv.cfg` and `*.dist-info` directories, so `installed()` returned true and every subsequent `install`/`update` **skipped rebuilding the broken venv**.
3. **`src/doctor.mjs`** had no check that surfaced the broken interpreter, so `doctor` reported everything healthy.

## Fix

- **`start.mjs`**: probe the venv interpreter (`python --version`) before starting the gateway. A broken venv now fails with an actionable message: *"Run ./bin/doctor --fix to rebuild the virtual environment, or ./bin/install --force-deps."*
- **`install-plan.mjs`**: treat a venv whose `pyvenv.cfg` `home` directory is gone as "not installed", so the next `install`/`update` rebuilds it instead of skipping a broken venv.
- **`doctor.mjs`**: new **`LiteLLM venv runtime`** check that probes the interpreter and reports `FAIL` with a fix path, so `doctor` names the problem instead of the crash log being the only witness.
- New `src/venv-runtime.mjs` (probe, spawn-injectable for hermetic tests) + tests.

## Verification

- Full suite: 901 tests, 0 failures.
- Simulated the exact failure (dangling `python -> /private/tmp/...`):
  - `doctor` → `FAIL LiteLLM venv runtime: .../python cannot run (ENOENT)`
  - `install-plan status python-deps` → `run` (rebuild triggered)
  - `start.mjs` → readable error naming the fix command
- After restore: `doctor` → `OK`, service healthy.

Closes the "router breaks after update/reboot" class of issues on macOS.