### PR TITLE
fix: outlast the client's connection pool on idle keep-alive

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -1,6 +1,7 @@
 import http from "node:http";
 
 import {
+  applyKeepAliveTimeouts,
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
   pipeResponse,
@@ -702,6 +703,7 @@ const server = http.createServer((request, response) => {
   });
 });
 
+applyKeepAliveTimeouts(server);
 server.listen(LISTEN_PORT, LISTEN_HOST, () => {
   console.error("[api-forwarder] listening");
 });

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
 import {
+  applyKeepAliveTimeouts,
   httpErrorStatus,
   readRequestBody,
   requireInternalAuth,
@@ -497,6 +498,7 @@ if (isMain) {
     });
   });
 
+  applyKeepAliveTimeouts(server);
   server.listen(LISTEN_PORT, LISTEN_HOST, () => {
     console.error("[grok-oauth] listening");
   });

--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -27,6 +27,29 @@ export const HOP_BY_HOP_HEADERS = new Set([
   "upgrade",
 ]);
 
+// Node closes an idle keep-alive connection after 5 seconds and advertises
+// that as `Keep-Alive: timeout=5`. Codex's HTTP client (hyper) never reads
+// that header and pools idle sockets for 90 seconds, so every gap longer than
+// five seconds — a tool call, a turn boundary, roughly a third of this
+// router's traffic — leaves the client holding a socket the server has
+// already closed. A request written into that window is answered with a FIN
+// instead of a response, which surfaces to the user as
+// `stream disconnected before completion: error sending request for url`.
+// The server has to be the side that outlasts the pool, so hold idle
+// connections past any plausible client idle timeout instead.
+export const KEEPALIVE_TIMEOUT_MS = 120_000;
+
+// Node runs the headers timer over keep-alive idle time as well, so a
+// `headersTimeout` below `keepAliveTimeout` destroys connections the server
+// otherwise intends to keep. Derive it rather than letting the two drift.
+export const HEADERS_TIMEOUT_MS = KEEPALIVE_TIMEOUT_MS + 5_000;
+
+export function applyKeepAliveTimeouts(server) {
+  server.keepAliveTimeout = KEEPALIVE_TIMEOUT_MS;
+  server.headersTimeout = HEADERS_TIMEOUT_MS;
+  return server;
+}
+
 export async function readRequestBody(request) {
   const chunks = [];
   let total = 0;

--- a/src/oauth-forwarder.mjs
+++ b/src/oauth-forwarder.mjs
@@ -1,6 +1,7 @@
 import http from "node:http";
 
 import {
+  applyKeepAliveTimeouts,
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
   pipeResponse,
@@ -241,6 +242,7 @@ const server = http.createServer((request, response) => {
   });
 });
 
+applyKeepAliveTimeouts(server);
 server.listen(LISTEN_PORT, LISTEN_HOST, () => {
   console.error("[kimi-oauth] listening");
 });

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -15,6 +15,7 @@ import {
   authenticatedRoute,
 } from "./caller-auth.mjs";
 import {
+  applyKeepAliveTimeouts,
   endStreamedResponse,
   finishResponse,
   HOP_BY_HOP_HEADERS,
@@ -2290,7 +2291,7 @@ server.on("error", (error) => {
   process.exit(96);
 });
 server.requestTimeout = 0;
-server.headersTimeout = 65_000;
+applyKeepAliveTimeouts(server);
 server.listen(LISTEN_PORT, LISTEN_HOST, () => {
   console.error("[codex-router] listening");
 });

--- a/test/router-resilience.test.mjs
+++ b/test/router-resilience.test.mjs
@@ -375,3 +375,90 @@ test("a selection file naming an unknown provider does not wedge the router", as
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+// Codex's HTTP client pools idle connections for 90 seconds and ignores the
+// `Keep-Alive: timeout=` header the router advertises, so Node's 5-second
+// default made the server close sockets the client still believed were live.
+// Reusing one of those answered the next turn with a FIN instead of a
+// response, which reqwest reports as "error sending request for url" and
+// Codex surfaces as "stream disconnected before completion". The idle gap
+// here is longer than that old default and shorter than the pool it has to
+// outlast.
+test("an idle keep-alive connection survives past Node's default timeout", async () => {
+  const gateway = await mockServer((request, response) => {
+    const payload = Buffer.from(JSON.stringify({ ok: true }), "utf8");
+    response.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+  });
+  const IDLE_MS = 6_500;
+
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, router);
+
+    const socket = net.connect(routerPort, "127.0.0.1");
+    try {
+      const request =
+        "GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: keep-alive\r\n\r\n";
+      // A raw socket is the only way to hold one connection across the idle
+      // gap; an agent would be free to open a second one and hide the bug.
+      const exchange = () =>
+        new Promise((resolve, reject) => {
+          let text = "";
+          const onData = (chunk) => {
+            text += chunk.toString("utf8");
+            if (text.includes("\r\n\r\n") && text.trimEnd().endsWith("}")) done(resolve, text);
+          };
+          const onEnd = () =>
+            done(reject, undefined, new Error("server closed the idle connection"));
+          const onError = (error) => done(reject, undefined, error);
+          function done(settle, value, error) {
+            socket.off("data", onData);
+            socket.off("end", onEnd);
+            socket.off("error", onError);
+            clearTimeout(timer);
+            error ? settle(error) : settle(value);
+          }
+          const timer = setTimeout(
+            () => done(reject, undefined, new Error("no response on the reused connection")),
+            5_000,
+          );
+          socket.on("data", onData);
+          socket.once("end", onEnd);
+          socket.once("error", onError);
+          socket.write(request);
+        });
+
+      const first = await exchange();
+      assert.match(first, /^HTTP\/1\.1 200/);
+      // The advertised timeout is what a client that does read the header
+      // (undici, curl) paces itself by, so it has to move with the setting.
+      assert.match(first, /Keep-Alive: timeout=120/);
+
+      await new Promise((resolve) => setTimeout(resolve, IDLE_MS));
+      assert.equal(
+        socket.destroyed,
+        false,
+        `the router closed an idle connection within ${IDLE_MS}ms`,
+      );
+
+      const second = await exchange();
+      assert.match(second, /^HTTP\/1\.1 200/);
+    } finally {
+      socket.destroy();
+    }
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});


### PR DESCRIPTION
## The bug

Codex reported this 84 times across three weeks:

```
stream disconnected before completion: error sending request for url
(http://127.0.0.1:4102/_codex-router/<caller>/v1/responses)
```

At every one of those timestamps the router was healthy — serving other turns, no restart, no upstream failure, `streamAborted` set on 3 of 69,000 requests. The failure is entirely in connection reuse.

`src/router.mjs` set `requestTimeout` and `headersTimeout` but never `keepAliveTimeout`, so it fell back to Node's 5-second default. Codex's HTTP client is hyper, which pools idle connections for 90 seconds and does not read the `Keep-Alive: timeout=` header the router advertises. The server therefore closes sockets the client still believes are live, and a request written into that window gets a FIN instead of a response — which reqwest reports as `error sending request for url`.

## Evidence

Measured against the running service:

```
closed by server after 6007 ms; Keep-Alive: timeout=5

5900ms -> ok          6100ms -> EOF-mid-reuse
6000ms -> ok          6200ms -> EOF-mid-reuse
```

Exposure, from 5,999 consecutive request gaps in `router.log`:

| gap | share |
|---|---|
| < 1 s | 25.2% |
| 1–5 s | 43.8% |
| **5–90 s** | **30.8%** |

That middle band is the danger window, and an agent loop — think, tool call, think — generates it by construction.

## The change

The invariant is that the server must outlast any client's pool. `applyKeepAliveTimeouts` holds idle connections for 120 s and derives `headersTimeout` from it, because Node runs the headers timer over keep-alive idle time and a lower value destroys connections the server means to keep. `headersTimeout` stops being an independent 65 s constant.

The three forwarders share the defect against LiteLLM's pool and get the same call. **No log evidence blames them yet** — drop that part if you'd rather keep the diff to the one hop with a reproduction. The router's own upstream leg is already safe, but only because undici *does* read the advertised timeout and evicts at 4 s, which is luck rather than design.

## Test plan

- `test/router-resilience.test.mjs` holds one raw socket across a 6.5 s idle gap and asserts the second request is still answered, plus that the advertised `Keep-Alive: timeout=120` tracks the setting. A raw socket is used because an agent would be free to open a second connection and hide the bug.
- Verified non-vacuous: with `headersTimeout = 65_000` restored and the keep-alive call removed, the test fails with `the router closed an idle connection within 6500ms`.
- `npm test` — 891 pass, 0 fail, 6 skipped.
- `npm run check` — passes.

Not yet verified against a restarted live service; the running router still has the old 5 s timeout.

## Separately

`usage-events.jsonl` carries 8,195 `status=0` events (2.49M output tokens, 24.9 wall-hours). Most is legitimate cancellation, but the meter cannot distinguish a user pressing Esc from a stale socket, so transport noise is permanently mixed into the usage view. Worth a follow-up if the numbers matter.