### PR TITLE
Make every local model installable, with or without Ollama

### DIFF
--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -287,23 +287,27 @@ async fn local_models(state: State<'_, RouterState>) -> Result<Value, String> {
     .await
 }
 
+// `--yes` is consent to install and start Ollama itself when it is missing, so
+// a single install action covers both the runtime and the model. `force` is a
+// separate decision -- the operator accepting a model this machine is rated too
+// small for -- and the two have to be expressible together.
 #[tauri::command]
 async fn install_local_model(
     state: State<'_, RouterState>,
     model: String,
+    force: Option<bool>,
 ) -> Result<Value, String> {
     validate_local_model_ref(&model)?;
-    run_json_command(
-        state.inner().clone(),
-        vec![
-            "local-models".into(),
-            "install".into(),
-            model,
-            "--yes".into(),
-        ],
-        None,
-    )
-    .await
+    let mut args: Vec<String> = vec![
+        "local-models".into(),
+        "install".into(),
+        model,
+        "--yes".into(),
+    ];
+    if force.unwrap_or(false) {
+        args.push("--force".into());
+    }
+    run_json_command(state.inner().clone(), args, None).await
 }
 
 #[tauri::command]

--- a/apps/desktop/ui/app.js
+++ b/apps/desktop/ui/app.js
@@ -623,7 +623,7 @@ function startPanel() {
     }
   }
 
-  async function startLocalInstall(model) {
+  async function startLocalInstall(model, { force = false } = {}) {
     state.localRemoveArmed = null;
     state.localModelBusy = { kind: "install", tag: model };
     state.localModels = {
@@ -632,15 +632,26 @@ function startPanel() {
     };
     renderLocalModels();
     try {
-      await call("install_local_model", { model });
+      // The router installs and starts Ollama headlessly as part of this call
+      // when it is missing, so one action covers the runtime and the model.
+      await call("install_local_model", { model, force });
       await pollLocalInstall(model);
     } catch (error) {
+      const detail = errorMessage(error);
       try {
         state.localModels = await call("local_models");
       } catch {}
-      showToast(errorMessage(error), true);
       state.localModelBusy = null;
       renderLocalModels();
+      // A model rated too large is refused once, not hidden. Ask, then retry
+      // with the override so every catalog entry stays installable.
+      if (!force && detail.includes("--force")) {
+        if (window.confirm(`${detail}\n\nDownload ${model} anyway?`)) {
+          await startLocalInstall(model, { force: true });
+        }
+        return;
+      }
+      showToast(detail, true);
     }
   }
 

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -1292,7 +1292,10 @@ final class RouterStore: ObservableObject {
   /// needed, and checks the model on for Codex after the pull completes. The
   /// control command returns immediately; the state file is polled so the
   /// tray remains responsive during multi-gigabyte downloads.
-  func downloadLocalModel(_ tag: String) async {
+  /// `force` carries the operator's deliberate override for a model this
+  /// machine is rated too small for. Every catalog entry is offered, so the
+  /// only way to attempt an oversized one is to say so explicitly here.
+  func downloadLocalModel(_ tag: String, force: Bool = false) async {
     guard localDownload?.isRunning != true else { return }
     let startedAt = Date().timeIntervalSince1970 * 1_000
     localDownload = VisionDownloadState(
@@ -1305,7 +1308,11 @@ final class RouterStore: ObservableObject {
       updatedAt: startedAt
     )
     do {
-      _ = try await runControl(arguments: ["local-models", "install", tag, "--yes"])
+      // `--yes` consents to installing and starting Ollama headlessly when it
+      // is missing, so one click covers both the runtime and the model.
+      var arguments = ["local-models", "install", tag, "--yes"]
+      if force { arguments.append("--force") }
+      _ = try await runControl(arguments: arguments)
     } catch {
       message = error.localizedDescription
       localDownload = VisionDownloadState(
@@ -2602,6 +2609,9 @@ private struct TrayView: View {
     @State private var localCatalogFilter = ""
     @State private var installTag = ""
     @State private var armedRemoval: String?
+    // Set to the tag awaiting an "it will not fit here" confirmation. Held as
+    // the tag rather than a Bool so the alert can name the model.
+    @State private var pendingOversizedInstall: String?
     @State private var quickPicksExpanded = false
     @State private var collapsedProviders = Set<String>()
 
@@ -2781,6 +2791,25 @@ private struct TrayView: View {
         ) {
           visionPanel
         }
+      }
+      .alert(
+        "Download anyway?",
+        isPresented: Binding(
+          get: { pendingOversizedInstall != nil },
+          set: { presented in if !presented { pendingOversizedInstall = nil } }
+        ),
+        presenting: pendingOversizedInstall
+      ) { tag in
+        Button("Download \(tag)", role: .destructive) {
+          pendingOversizedInstall = nil
+          Task { await store.downloadLocalModel(tag, force: true) }
+        }
+        Button("Cancel", role: .cancel) { pendingOversizedInstall = nil }
+      } message: { tag in
+        Text(
+          "\(tag) is rated too large for this machine's memory or free disk. "
+            + "It will download, but it may fail to load or run very slowly."
+        )
       }
     }
 
@@ -3170,11 +3199,23 @@ private struct TrayView: View {
           .font(.system(size: 8))
           .foregroundStyle(!downloadable ? routerMuted : (tooLarge ? routerRed : routerMutedStrong))
         if downloadable {
-          Button("Download") { Task { await store.downloadLocalModel(model.tag) } }
-            .buttonStyle(.borderless)
-            .font(.system(size: 8, weight: .medium))
-            .foregroundStyle(canDownloadLocalSuggestion && !tooLarge ? routerMint : routerMutedStrong)
-            .disabled(!canDownloadLocalSuggestion || tooLarge)
+          // A model rated too large is still offered, because refusing to show
+          // the button left those tags with no install path at all. The label
+          // changes to name the risk and the tap asks once before spending the
+          // gigabytes; confirming sends --force.
+          Button(tooLarge ? "Anyway" : "Download") {
+            if tooLarge {
+              pendingOversizedInstall = model.tag
+            } else {
+              Task { await store.downloadLocalModel(model.tag) }
+            }
+          }
+          .buttonStyle(.borderless)
+          .font(.system(size: 8, weight: .medium))
+          .foregroundStyle(
+            !canDownloadLocalSuggestion ? routerMutedStrong : (tooLarge ? routerRed : routerMint)
+          )
+          .disabled(!canDownloadLocalSuggestion)
         } else {
           Text("cloud only")
             .font(.system(size: 8, weight: .medium))

--- a/docs/LOCAL-MODELS.md
+++ b/docs/LOCAL-MODELS.md
@@ -30,10 +30,17 @@ published variants—not only the family aliases. Cloud aliases are shown for
 completeness but are labelled **cloud only** and cannot be downloaded as local
 weights. The manifest is a dated snapshot, so arbitrary Ollama tags and model
 URLs remain supported even when a newly published tag has not been added yet.
-The router checks model size against available memory and disk before
-downloading. An installed model's generation speed is measured on demand with
-the **Speed** button and reported as tokens/second; unmeasured models never
-receive a guessed number.
+An installed model's generation speed is measured on demand with the **Speed**
+button and reported as tokens/second; unmeasured models never receive a guessed
+number.
+
+Every model in the catalog is listed and installable, including ones this
+machine is rated too small for. The two shortlists above the catalog—the coding
+quick picks and the image readers—are recommendations and only show what fits,
+but nothing is ever removed from the catalog itself: a model that will not fit
+is labelled **won't fit**, and its button reads **Anyway** and asks for
+confirmation before spending the gigabytes. Hiding those entries previously left
+them with no install path at all on a small machine.
 
 Useful commands:
 
@@ -41,11 +48,19 @@ Useful commands:
 ./bin/control local-models list --json
 ./bin/control local-models inspect https://ollama.com/library/gemma4:12b
 ./bin/control local-models install gemma4:12b --yes
+./bin/control local-models install gpt-oss:20b --yes --force
 ./bin/control local-models benchmark gemma4:12b
 ./bin/control local-models runtime status
 ./bin/control local-models runtime start
 ./bin/control local-models runtime update --yes
 ```
+
+`install` takes two independent consent flags, and they combine:
+
+| Flag | Consents to |
+| --- | --- |
+| `--yes` | installing and starting Ollama itself, headlessly, when it is missing |
+| `--force` | downloading a model rated too large for this machine's memory or disk |
 
 Checking or unchecking a model refreshes the picker and gateway routes and
 restarts the router service, so the newly published `local/...` route is served
@@ -55,7 +70,13 @@ no service to restart; restart them by hand after toggling.
 Updating Ollama is explicit. A normal model install reuses the installed
 runtime and does not replace it behind the user's back.
 
-Downloads rated too large for the machine are stopped even when `--yes` is
-present. Use `--force` only when you intentionally want to attempt one anyway.
-If Ollama is not installed, first run `runtime start --yes`, then use
-`install <tag> --force` for that deliberate override.
+Downloads rated too large for the machine are stopped unless `--force` is
+present; `--yes` alone does not override the fit check, because consenting to
+install Ollama is not the same as consenting to a model that will not run. A
+single `install <tag> --yes --force` covers both, so a machine with no Ollama
+can still install an oversized model in one command.
+
+Checking a model uses one canonical tag. `devstral` and `devstral:latest` are
+the same weights, so checking or unchecking through either spelling affects the
+same entry, and selection files written by older versions are normalized on the
+next write.

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -709,7 +709,7 @@ async function handleSubagents(action, value, flag) {
 async function runVisionBridgeSetup({ consent }) {
   const { readVisionBridgeSettings, setVisionBridgeLocal, setVisionBridgeEnabled } =
     await import("./vision-bridge-state.mjs");
-  const { suggestLocalVisionSetup, ollamaAvailable, pullOllamaModel, OLLAMA_INSTALL_HINT } =
+  const { suggestLocalVisionSetup, ollamaAvailable, pullOllamaModel, ollamaInstallMessage } =
     await import("./vision-host.mjs");
 
   const suggestion = await suggestLocalVisionSetup(readVisionBridgeSettings());
@@ -731,7 +731,7 @@ async function runVisionBridgeSetup({ consent }) {
     process.stderr.write(
       `No local vision runtime is running.\n` +
         `Recommended for this machine (${profile.memGib} GB ${profile.arch}): ${chosen}.\n` +
-        `${OLLAMA_INSTALL_HINT}\n` +
+        `${ollamaInstallMessage()}\n` +
         `Prefer llama.cpp? Start it, then: ./bin/control vision-bridge local ${chosen} http://127.0.0.1:8080/v1\n`,
     );
     return;
@@ -838,9 +838,9 @@ async function handleVisionBridge(action, value, extra) {
     // pinned by the worker only after it lands.
     const tag = String(value || "").trim();
     if (!tag) throw new Error("Usage: control vision-bridge pull <model-tag>");
-    const { ollamaAvailable, OLLAMA_INSTALL_HINT } = await import("./vision-host.mjs");
+    const { ollamaAvailable, ollamaInstallMessage } = await import("./vision-host.mjs");
     if (!ollamaAvailable()) {
-      throw new Error(`Ollama is not installed. ${OLLAMA_INSTALL_HINT}`);
+      throw new Error(`Ollama is not installed. ${ollamaInstallMessage()}`);
     }
     const { readVisionDownload, writeVisionDownload } = await import(
       "./vision-download.mjs"
@@ -969,10 +969,17 @@ async function handleVisionBridge(action, value, extra) {
 // Local models are managed as their own thing, not as a vision detail: the
 // operator installs, checks, and removes them here, and the vision bridge is
 // only one of the consumers.
-async function handleLocalModels(action, value, flag) {
+async function handleLocalModels(action, value, ...rest) {
+  // Variadic because `--yes` and `--force` answer different questions and an
+  // install can need both: `--yes` consents to installing Ollama itself,
+  // `--force` consents to a model this machine may not fit. A single flag slot
+  // made that combination unexpressible.
+  const options = rest.filter((item) => typeof item === "string");
+  const flags = new Set(options.filter((item) => item.startsWith("--")));
+  const positional = options.find((item) => !item.startsWith("--"));
   const {
+    isLocalModelEnabled,
     localModelsSnapshot,
-    readLocalModelSelection,
     removeLocalModel,
     setLocalModelEnabled,
   } = await import("./local-models.mjs");
@@ -993,7 +1000,7 @@ async function handleLocalModels(action, value, flag) {
     // single unbroken line, which only got worse once the snapshot grew a
     // download list. Explicit `--json` keeps the machine contract, and a bare
     // invocation is readable.
-    if (value === "--json" || flag === "--json" || !process.stdout.isTTY) {
+    if (value === "--json" || flags.has("--json") || !process.stdout.isTTY) {
       process.stdout.write(`${JSON.stringify(current)}\n`);
       return;
     }
@@ -1020,9 +1027,10 @@ async function handleLocalModels(action, value, flag) {
   if (action === "inspect") {
     // Answers "can Codex drive this?" for a few kilobytes instead of a
     // multi-gigabyte download.
+    // normalizeLocalModelTag throws on an empty or malformed reference, so
+    // there is no separate emptiness check to make here.
     const { normalizeLocalModelTag } = await import("./local-model-ref.mjs");
     const tag = normalizeLocalModelTag(value);
-    if (!tag) throw new Error("Usage: control local-models inspect <model-tag>");
     const {
       fetchRegistryCapabilities,
       fetchRegistryContext,
@@ -1066,14 +1074,16 @@ async function handleLocalModels(action, value, flag) {
       return;
     }
     if (subcommand === "update") {
-      if (flag !== "--yes") throw new Error("Updating Ollama changes system software. Pass --yes to confirm.");
+      if (!flags.has("--yes")) {
+        throw new Error("Updating Ollama changes system software. Pass --yes to confirm.");
+      }
       const result = updateOllamaRuntime();
       const running = await ensureOllamaHeadless({ install: false });
       process.stdout.write(`${JSON.stringify({ ...result, running: running.running })}\n`);
       return;
     }
     if (subcommand === "start") {
-      const result = await ensureOllamaHeadless({ install: flag === "--yes" });
+      const result = await ensureOllamaHeadless({ install: flags.has("--yes") });
       process.stdout.write(`${JSON.stringify(result)}\n`);
       return;
     }
@@ -1136,17 +1146,26 @@ async function handleLocalModels(action, value, flag) {
       const capacity = detectMachine();
       const fit = advertised ? rateModelFit(advertised.sizeGb, capacity) : undefined;
       const diskFit = advertised ? rateDiskFit(advertised.sizeGb, capacity) : undefined;
-      if ((fit === "too-large" || diskFit === "too-large") && flag !== "--force") {
+      if ((fit === "too-large" || diskFit === "too-large") && !flags.has("--force")) {
         throw new Error(
           `${fitAdvisory(tag, advertised.sizeGb, capacity) || `${tag} may not fit on this machine's free disk.`} Pass --force to download it anyway.`,
         );
       }
       writePhase("Preparing headless Ollama");
-      const { ensureOllamaHeadless } = await import("./ollama-runtime.mjs");
-      // A missing runtime is installed only as part of an explicit install click
-      // (`--yes`). Existing runtimes are started with `ollama serve`, detached
-      // from the tray so no GUI window is involved.
-      await ensureOllamaHeadless({ install: flag === "--yes" });
+      const { ensureOllamaHeadless, ollamaCommand } = await import("./ollama-runtime.mjs");
+      // One action installs both. `--yes` is the operator's consent to touch
+      // system software: with it a missing Ollama is installed headlessly (the
+      // Homebrew formula when available, otherwise the official installer with
+      // OLLAMA_NO_START=1) and then started as a detached `ollama serve`. The
+      // Ollama desktop app is never launched. Without `--yes`, say so plainly
+      // rather than surfacing the runtime layer's generic "not installed".
+      const installRuntime = flags.has("--yes");
+      if (!installRuntime && !ollamaCommand()) {
+        throw new Error(
+          `Ollama is not installed. Re-run with --yes to install it headlessly and then download ${tag}.`,
+        );
+      }
+      await ensureOllamaHeadless({ install: installRuntime });
       writePhase("Starting model download");
       const child = spawn(process.execPath, [path.join(REPO_ROOT, "src", "local-download.mjs"), tag], {
         detached: true,
@@ -1207,22 +1226,29 @@ async function handleLocalModels(action, value, flag) {
   if (action === "uninstall") {
     const tag = String(value || "").trim();
     if (!tag) throw new Error("Usage: control local-models uninstall <model-tag> --yes");
-    removeLocalModel(tag, { confirmed: flag === "--yes" || value === "--yes" });
+    removeLocalModel(tag, { confirmed: flags.has("--yes") || value === "--yes" });
     refreshModelSettingsCatalog({ routes: true });
     await restartRouterForLocalRoutes();
   } else if (action === "set") {
-    if (!["on", "off"].includes(flag)) {
+    if (!["on", "off"].includes(positional)) {
       throw new Error("Usage: control local-models set <model-tag> <on|off>");
     }
-    const enabled = flag === "on";
-    const wasEnabled = readLocalModelSelection().enabled.includes(String(value).trim());
+    const enabled = positional === "on";
+    // Compared across spellings: the downloader stores `gemma3:latest` and a
+    // hand-typed `gemma3` is the same model, so a raw string match here would
+    // skip the router restart that publishes the route change.
+    const wasEnabled = isLocalModelEnabled(value);
     setLocalModelEnabled(value, enabled);
     refreshModelSettingsCatalog({ routes: true });
     if (wasEnabled !== enabled) await restartRouterForLocalRoutes();
   } else {
     throw new Error(
-      "Usage: control local-models list|inspect <tag-or-url>|install <tag-or-url> [--yes]|" +
-        "benchmark <tag>|runtime status|start|update --yes|uninstall <tag> --yes|set <tag> <on|off>",
+      "Usage: control local-models list [--json]|inspect <tag-or-url>|" +
+        "install <tag-or-url> [--yes] [--force]|benchmark <tag>|" +
+        "runtime status|runtime start [--yes]|runtime update --yes|" +
+        "uninstall <tag> --yes|set <tag> <on|off>\n" +
+        "  --yes    consent to installing/starting Ollama itself (headless)\n" +
+        "  --force  download a model rated too large for this machine anyway",
     );
   }
   process.stdout.write(`${JSON.stringify(snapshot())}\n`);
@@ -1386,7 +1412,7 @@ if (args.includes("--probe")) {
 } else if (args[0] === "subagents") {
   await handleSubagents(args[1], args[2], args[3]);
 } else if (args[0] === "local-models") {
-  await handleLocalModels(args[1], args[2], args[3]);
+  await handleLocalModels(args[1], args[2], ...args.slice(3));
 } else if (args[0] === "vision-bridge") {
   await handleVisionBridge(args[1] || "status", args[2], args[3]);
 } else if (args[0] === "picker") {

--- a/src/local-model-ref.mjs
+++ b/src/local-model-ref.mjs
@@ -22,7 +22,9 @@ export function normalizeLocalModelTag(input) {
       throw new Error("Use an Ollama model-page URL or enter the model tag directly.");
     }
     const parts = parsed.pathname.split("/").filter(Boolean).map((part) => decodeURIComponent(part));
-    if (parts.length < 2 || parts[0] === "search" || parts[0] === "library" && parts.length < 2) {
+    // `/library/<model>` and `/<namespace>/<model>` are the two model-page
+    // shapes; anything shorter is a family or search page with no tag in it.
+    if (parts.length < 2 || parts[0] === "search") {
       throw new Error("That URL does not contain an Ollama model tag.");
     }
     candidate = parts[0] === "library" ? parts.slice(1).join("/") : parts.join("/");
@@ -35,6 +37,20 @@ export function normalizeLocalModelTag(input) {
     throw new Error(`Invalid Ollama model tag: ${candidate}`);
   }
   return candidate;
+}
+
+// `gemma3` and `gemma3:latest` are the same model, but only the second is what
+// `ollama list` prints. State written from either spelling has to compare
+// equal, or `set gemma3 off` silently fails to clear an entry the downloader
+// stored as `gemma3:latest`. Unparseable input falls back to its trimmed self
+// instead of throwing: callers use this to match stored entries, and a corrupt
+// entry should be inert rather than fatal.
+export function canonicalLocalModelTag(input) {
+  try {
+    return normalizeLocalModelTag(input);
+  } catch {
+    return String(input || "").trim();
+  }
 }
 
 export function splitLocalModelTag(input) {

--- a/src/local-models.mjs
+++ b/src/local-models.mjs
@@ -20,6 +20,7 @@ import {
 import { STATE_DIR } from "./paths.mjs";
 import { readUserModels, userModelEntry, writeUserModels } from "./user-models.mjs";
 import {
+  canonicalLocalModelTag,
   localModelDisplayName,
   splitLocalModelTag,
 } from "./local-model-ref.mjs";
@@ -117,9 +118,15 @@ const LOCAL_AUTO_COMPACT = 28000;
 export function setLocalModelEnabled(tag, enabled, { capabilitiesFor } = {}) {
   const value = String(tag || "").trim();
   if (!value) throw new Error("A model tag is required.");
-  const current = new Set(readLocalModelSelection().enabled);
-  if (enabled) current.add(value);
-  else current.delete(value);
+  // Store one spelling per model. The downloader normalizes to `gemma3:latest`
+  // while the CLI used to store whatever was typed, so a set keyed on the raw
+  // string could hold both and `set gemma3 off` would clear neither. Dropping
+  // every spelling first also migrates those older entries on the next write.
+  const canonical = canonicalLocalModelTag(value);
+  const remaining = readLocalModelSelection().enabled.filter(
+    (entry) => canonicalLocalModelTag(entry) !== canonical,
+  );
+  const current = new Set(enabled ? [...remaining, canonical] : remaining);
   const selection = writeSelection({ version: 1, enabled: [...current].sort() });
   syncLocalUserModels({ enabled: selection.enabled, ...(capabilitiesFor ? { capabilitiesFor } : {}) });
   // Checking a model is the operator saying they want it available, so the
@@ -415,6 +422,13 @@ export function runningLocalModels({ spawn = spawnSync } = {}) {
   }
 }
 
+// Answers "is this model checked?" across spellings, so a caller holding
+// `gemma3` and a state file holding `gemma3:latest` agree.
+export function isLocalModelEnabled(tag, selection = readLocalModelSelection()) {
+  const canonical = canonicalLocalModelTag(tag);
+  return selection.enabled.some((entry) => canonicalLocalModelTag(entry) === canonical);
+}
+
 // Deleting reclaims gigabytes and cannot be undone without downloading again,
 // so the caller must pass explicit consent rather than this inferring it.
 export function removeLocalModel(tag, { spawn = spawnSync, confirmed = false, capabilitiesFor } = {}) {
@@ -444,7 +458,10 @@ export function localModelsSnapshot({
   capabilities,
   agentChecks = readAgentChecks(),
 } = {}) {
-  const enabled = new Set(selection.enabled);
+  // Compared canonically: `ollama list` always prints `gemma3:latest`, while an
+  // older state file may hold the bare `gemma3` the CLI once stored. Matching
+  // on the raw string showed such a model as unchecked even though it routed.
+  const enabled = new Set(selection.enabled.map((tag) => canonicalLocalModelTag(tag)));
   const runningSet = new Set(running);
   const cache = capabilities;
   const models = inventory.map((entry) => {
@@ -463,7 +480,7 @@ export function localModelsSnapshot({
       family: identity.family,
       variant: identity.variant,
       capabilities: caps,
-      enabled: enabled.has(entry.tag),
+      enabled: enabled.has(canonicalLocalModelTag(entry.tag)),
       running: runningSet.has(entry.tag),
       // Reported by Ollama, not guessed from the name.
       vision: caps.includes("vision"),
@@ -866,28 +883,51 @@ export function suggestedVisionModels({
     );
 }
 
+// Every model the router knows about, in one browsable list.
+//
+// The two shortlists above are recommendations, and they deliberately drop
+// anything this machine cannot run. That also made those entries unreachable:
+// on an 8 GB laptop `qwen2.5-coder:14b`, `gpt-oss:20b` and `devstral` appeared
+// in no list at all, so there was no way to install one even deliberately.
+// This list hides nothing. It carries the fit rating instead, so the caller can
+// warn about a model that will not fit rather than pretend it does not exist.
 export function suggestedExploreModels({
   capacity = detectMachine(),
   installed = [],
 } = {}) {
   const fresh = notInstalled(installed);
-  return EXPLORE_LOCAL_MODELS
-    .filter((entry) => fresh(entry.tag))
-    .map((entry) => {
-      const identity = splitLocalModelTag(entry.tag);
-      const research = LOCAL_FAMILY_RESEARCH[identity.family];
-      return {
-        ...entry,
-        family: identity.family,
-        variant: identity.variant,
-        displayName: entry.displayName || localModelDisplayName(entry.tag),
-        fit: entry.downloadable === false ? "cloud-only" : rateModelFit(entry.sizeGb, capacity),
-        diskFit: entry.downloadable === false ? "cloud-only" : rateDiskFit(entry.sizeGb, capacity),
-        researchStatus: research?.status || "Cataloged · compatibility unverified",
-        researchCapabilities: research?.capabilities || [],
-        researchNote: research?.note || "Verify capabilities after pull.",
-      };
+  const seen = new Set();
+  const entries = [];
+  for (const entry of [...EXPLORE_LOCAL_MODELS, ...SUGGESTED_LOCAL_MODELS, ...VISION_CATALOG]) {
+    // `devstral` and `devstral:latest` are one model; the shortlists spell the
+    // bare form and the explore catalog spells the tagged one.
+    const canonical = canonicalLocalModelTag(entry.tag);
+    if (seen.has(canonical) || !fresh(entry.tag)) continue;
+    seen.add(canonical);
+    let identity;
+    try {
+      identity = splitLocalModelTag(entry.tag);
+    } catch {
+      identity = { family: entry.tag, variant: "latest" };
+    }
+    const research = LOCAL_FAMILY_RESEARCH[identity.family];
+    const cloudOnly = entry.downloadable === false;
+    entries.push({
+      // Defaults first so a catalog that states either one still wins.
+      tools: false,
+      downloadable: true,
+      ...entry,
+      family: identity.family,
+      variant: identity.variant,
+      displayName: entry.displayName || localModelDisplayName(entry.tag),
+      fit: cloudOnly ? "cloud-only" : rateModelFit(entry.sizeGb, capacity),
+      diskFit: cloudOnly ? "cloud-only" : rateDiskFit(entry.sizeGb, capacity),
+      researchStatus: research?.status || "Cataloged · compatibility unverified",
+      researchCapabilities: research?.capabilities || [],
+      researchNote: research?.note || "Verify capabilities after pull.",
     });
+  }
+  return entries;
 }
 
 // Mirrors the vision catalog's own ranking: measured-accurate, then partial,

--- a/src/vision-host.mjs
+++ b/src/vision-host.mjs
@@ -13,7 +13,16 @@ import {
   DEFAULT_LOCAL_VISION_MODEL,
 } from "./vision-bridge.mjs";
 
-export const OLLAMA_INSTALL_HINT = `Install Ollama (${ollamaInstallHint()}), then retry.`;
+// Deliberately a function, not a top-level constant. Building the hint asks
+// `ollamaInstallPlan` which package manager is present, and that is a
+// synchronous `brew --version` (~200 ms here). As a constant it ran on every
+// import of this module -- including the static start.mjs -> local-models.mjs
+// chain -- so every router start paid for a string almost nobody reads.
+let cachedInstallHint;
+export function ollamaInstallMessage() {
+  cachedInstallHint ??= `Install Ollama (${ollamaInstallHint()}), then retry.`;
+  return cachedInstallHint;
+}
 
 // A runtime is the operator's own software. This helper only reports whether
 // the CLI is present; the local-model install flow may install it after the

--- a/test/local-llm.test.mjs
+++ b/test/local-llm.test.mjs
@@ -12,8 +12,12 @@ process.env.MODEL_ROUTER_LOCAL_BENCHMARKS = path.join(stateDir, "benchmarks.json
 process.env.MODEL_ROUTER_OLLAMA_RUNTIME_STATE = path.join(stateDir, "runtime.json");
 process.env.MODEL_ROUTER_OLLAMA_LOG = path.join(stateDir, "ollama.log");
 
-const { localModelDisplayName, normalizeLocalModelTag, splitLocalModelTag } =
-  await import("../src/local-model-ref.mjs");
+const {
+  canonicalLocalModelTag,
+  localModelDisplayName,
+  normalizeLocalModelTag,
+  splitLocalModelTag,
+} = await import("../src/local-model-ref.mjs");
 const {
   ensureOllamaHeadless,
   localOllamaRuntimeSnapshot,
@@ -52,6 +56,31 @@ test("Ollama model URLs normalize to explicit family and variant tags", () => {
   });
   assert.equal(localModelDisplayName("gemma4:12b"), "Gemma4 · 12b");
   assert.throws(() => normalizeLocalModelTag("https://example.com/model"), /Ollama model-page/);
+  // A family overview page carries no tag, so it must be rejected rather than
+  // guessed at. The namespace form is the only two-segment shape that is one.
+  assert.throws(
+    () => normalizeLocalModelTag("https://ollama.com/library"),
+    /does not contain an Ollama model tag/,
+  );
+  assert.throws(
+    () => normalizeLocalModelTag("https://ollama.com/search/gemma"),
+    /does not contain an Ollama model tag/,
+  );
+});
+
+test("tag spellings canonicalize so one model is never two entries", () => {
+  assert.equal(canonicalLocalModelTag("devstral"), "devstral:latest");
+  assert.equal(canonicalLocalModelTag("devstral:latest"), "devstral:latest");
+  assert.equal(canonicalLocalModelTag(" gemma4:12b "), "gemma4:12b");
+  assert.equal(
+    canonicalLocalModelTag("https://ollama.com/library/muse-glimmer"),
+    "muse-glimmer:latest",
+  );
+  // Unparseable input is inert rather than fatal: this runs over stored state,
+  // and one corrupt entry must not break reading the rest of the file.
+  assert.equal(canonicalLocalModelTag("--force"), "--force");
+  assert.equal(canonicalLocalModelTag(""), "");
+  assert.equal(canonicalLocalModelTag(undefined), "");
 });
 
 test("runtime helpers keep Ollama headless and expose safe install plans", () => {
@@ -92,6 +121,21 @@ test("runtime helpers keep Ollama headless and expose safe install plans", () =>
     ollamaInstallPlan({ platform: "darwin", spawn: noPackageManager, interactive: false }).command,
     "/usr/bin/osascript",
   );
+  // Every macOS path that runs the official installer must keep it headless.
+  // Without OLLAMA_NO_START the installer launches the Ollama desktop app, and
+  // the router would end up talking to a GUI process it does not own.
+  for (const interactive of [true, false]) {
+    const plan = ollamaInstallPlan({ platform: "darwin", spawn: noPackageManager, interactive });
+    assert.ok(
+      plan.args.some((argument) => argument.includes("OLLAMA_NO_START=1")),
+      `darwin interactive=${interactive} must not start the Ollama app`,
+    );
+  }
+  // Homebrew installs the headless CLI formula, never the desktop cask.
+  assert.deepEqual(ollamaInstallPlan({ platform: "darwin", spawn: fakeSpawn }).args, [
+    "install",
+    "ollama",
+  ]);
 });
 
 test("runtime updates use Homebrew only when it owns the Ollama formula", () => {
@@ -350,6 +394,60 @@ test("control persists a visible terminal error when install preflight fails", (
   assert.equal(state.status, "error");
   assert.equal(state.detail, "failed");
   assert.match(state.error, /not loopback/);
+});
+
+// Runs `control local-models ...` against a throwaway state directory whose
+// local endpoint is deliberately not loopback, so the command fails at a known
+// point after argument parsing.
+function runLocalModels(...args) {
+  const childState = mkdtempSync(path.join(os.tmpdir(), "local-llm-args-"));
+  const result = spawnSync(process.execPath, [path.resolve("src/control.mjs"), "local-models", ...args], {
+    cwd: path.resolve("."),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_ROUTER_STATE_DIR: childState,
+      MODEL_ROUTER_LOCAL_DOWNLOAD_STATE: path.join(childState, "download.json"),
+      MODEL_ROUTER_OLLAMA_RUNTIME_STATE: path.join(childState, "runtime.json"),
+      MODEL_ROUTER_OLLAMA_LOG: path.join(childState, "ollama.log"),
+      MODEL_ROUTER_LOCAL_BASE_URL: "https://example.com",
+      MODEL_ROUTER_OLLAMA_REGISTRY: "http://127.0.0.1:9",
+    },
+  });
+  return { ...result, childState, output: `${result.stdout || ""}${result.stderr || ""}` };
+}
+
+test("install accepts --yes and --force together, in either order", () => {
+  // A single flag slot made these mutually exclusive, yet they answer different
+  // questions: --yes consents to installing Ollama itself, --force to a model
+  // this machine is rated too small for. Installing an oversized model on a
+  // machine without Ollama needs both at once.
+  for (const flags of [["--yes", "--force"], ["--force", "--yes"]]) {
+    const result = runLocalModels("install", "flag-probe:latest", ...flags);
+    assert.notEqual(result.status, 0);
+    const state = JSON.parse(readFileSync(path.join(result.childState, "download.json"), "utf8"));
+    // Reaching the loopback check proves both were read as flags rather than
+    // mistaken for the tag, and that --yes was still honored beside --force.
+    assert.match(state.error, /not loopback/, flags.join(" "));
+  }
+});
+
+test("a missing Ollama is named as installable rather than reported as absent", () => {
+  // Without --yes the command must say what to do next, not just that Ollama is
+  // missing: one flag installs the runtime headlessly and then the model.
+  const result = runLocalModels("install", "flag-probe:latest");
+  assert.notEqual(result.status, 0);
+  // On a machine that already has Ollama this reaches the loopback guard
+  // instead; either way it must never claim the model started downloading.
+  assert.match(result.output, /Re-run with --yes|not loopback/);
+});
+
+test("the usage text names both consent flags", () => {
+  const result = runLocalModels("no-such-action");
+  assert.notEqual(result.status, 0);
+  assert.match(result.output, /--force/);
+  assert.match(result.output, /--yes/);
+  assert.match(result.output, /install <tag-or-url>/);
 });
 
 test("a configured-off vision bridge is never re-enabled by a local pull", async () => {

--- a/test/local-models.test.mjs
+++ b/test/local-models.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -14,8 +14,10 @@ process.env.CODEX_ROUTER_STATE_DIR = stateDir;
 const {
   CODEX_PROMPT_TOKENS,
   EXPLORE_LOCAL_MODELS,
+  LOCAL_MODELS_STATE_PATH,
   describeMachine,
   fitAdvisory,
+  isLocalModelEnabled,
   localModelsSnapshot,
   machineCapacity,
   parseGgufContextLength,
@@ -29,6 +31,13 @@ const {
   suggestedExploreModels,
   suggestedVisionModels,
 } = await import("../src/local-models.mjs");
+
+// Writes the selection file directly, which is the only way to reproduce state
+// left by an older build that stored whatever spelling was typed.
+function writeSelectionFile(selection) {
+  mkdirSync(path.dirname(LOCAL_MODELS_STATE_PATH), { recursive: true, mode: 0o700 });
+  writeFileSync(LOCAL_MODELS_STATE_PATH, `${JSON.stringify(selection)}\n`, "utf8");
+}
 
 const LIST = `NAME                ID              SIZE      MODIFIED
 gemma3:4b           a2af6cc3eb7f    3.3 GB    19 minutes ago
@@ -287,6 +296,110 @@ test("a machine too small for everything still gets an honest empty list", () =>
   assert.deepEqual(suggestedLocalModels({ capacity: tiny }), []);
   // Asking for the unusable ones is explicit, never the default.
   assert.ok(suggestedLocalModels({ capacity: tiny, includeUnusable: true }).length > 0);
+});
+
+test("every catalog model stays reachable on a machine that cannot run it", () => {
+  // The shortlists are recommendations and drop what will not fit. That must
+  // not make a model disappear entirely: an 8 GB laptop previously had no list
+  // containing qwen2.5-coder:14b, gpt-oss:20b or devstral, so there was no way
+  // to install one even on purpose.
+  const laptop = machineCapacity({ totalMemoryBytes: 8e9, platform: "linux" });
+  const shortlisted = suggestedLocalModels({ capacity: laptop, includeUnusable: true });
+  const recommended = new Set(suggestedLocalModels({ capacity: laptop }).map((e) => e.tag));
+  const dropped = shortlisted.filter((entry) => !recommended.has(entry.tag));
+  assert.ok(dropped.length > 0, "expected this machine to be too small for something");
+
+  const explore = suggestedExploreModels({ capacity: laptop });
+  const exploreTags = new Set(explore.map((entry) => entry.tag));
+  for (const entry of dropped) {
+    assert.ok(exploreTags.has(entry.tag), `${entry.tag} is unreachable`);
+  }
+  // Reachable, but still honestly labelled, so the caller can warn.
+  assert.equal(explore.find((entry) => entry.tag === "gpt-oss:20b").fit, "too-large");
+  // Image readers the vision shortlist hid are reachable for the same reason.
+  const visionShown = new Set(suggestedVisionModels({ capacity: laptop }).map((e) => e.tag));
+  assert.ok(!visionShown.has("qwen2.5vl:7b"));
+  assert.ok(exploreTags.has("qwen2.5vl:7b"));
+
+  // One row per model. `devstral` and `devstral:latest` are the same weights
+  // spelled two ways across the shortlist and the explore catalog.
+  assert.equal(explore.length, exploreTags.size);
+  assert.deepEqual(
+    explore.filter((entry) => entry.family === "devstral").map((entry) => entry.tag),
+    ["devstral"],
+  );
+  // An already-installed model is still never re-offered.
+  const withInstalled = suggestedExploreModels({
+    capacity: laptop,
+    installed: [{ tag: "gpt-oss:20b" }],
+  });
+  assert.ok(!withInstalled.some((entry) => entry.tag === "gpt-oss:20b"));
+});
+
+test("every catalog entry carries the fields the tray decoder requires", () => {
+  // `AvailableLocalModel` in the macOS tray declares these non-optional. Swift
+  // fails the whole array on one bad element, so a single catalog entry missing
+  // `note` would empty the catalog in the UI without any visible error. The
+  // explore list merges three catalogs with different shapes, which is exactly
+  // where such a gap would appear.
+  const required = { tag: "string", sizeGb: "number", tools: "boolean", note: "string", fit: "string" };
+  const machines = [
+    machineCapacity({ totalMemoryBytes: 8e9, platform: "linux" }),
+    machineCapacity({ totalMemoryBytes: 128e9, unifiedMemory: true, freeDiskBytes: 2e12 }),
+  ];
+  for (const capacity of machines) {
+    for (const entry of suggestedExploreModels({ capacity })) {
+      for (const [key, type] of Object.entries(required)) {
+        assert.equal(typeof entry[key], type, `${entry.tag} has no usable ${key}`);
+      }
+    }
+  }
+});
+
+test("one model checked under two spellings stays one entry", () => {
+  // The downloader stores the normalized `devstral:latest`; a hand-typed
+  // `devstral` is the same model. Keying the selection on the raw string let
+  // both land in the file, and `set devstral off` then cleared neither.
+  // The whole file shares one state directory, so put back what was there.
+  const restore = readLocalModelSelection();
+  try {
+    writeSelectionFile({ version: 1, enabled: [] });
+    setLocalModelEnabled("devstral:latest", true, NO_OLLAMA);
+    setLocalModelEnabled("devstral", true, NO_OLLAMA);
+    assert.deepEqual(readLocalModelSelection().enabled, ["devstral:latest"]);
+    assert.equal(isLocalModelEnabled("devstral"), true);
+    assert.equal(isLocalModelEnabled("devstral:latest"), true);
+
+    // Unchecking through the other spelling has to clear it.
+    setLocalModelEnabled("devstral", false, NO_OLLAMA);
+    assert.deepEqual(readLocalModelSelection().enabled, []);
+    assert.equal(isLocalModelEnabled("devstral:latest"), false);
+  } finally {
+    writeSelectionFile(restore);
+  }
+});
+
+test("a legacy bare tag in the selection file is matched and migrated", () => {
+  const restore = readLocalModelSelection();
+  try {
+    // State written before tags were canonicalized holds the bare spelling.
+    writeSelectionFile({ version: 1, enabled: ["mistral"] });
+    assert.equal(isLocalModelEnabled("mistral:latest"), true);
+    // `ollama list` reports the tagged spelling, so the row must read as checked.
+    const snapshot = localModelsSnapshot({
+      inventory: parseOllamaList(
+        "NAME  ID  SIZE  MODIFIED\nmistral:latest  aaa  4.4 GB  1 hour ago\n",
+      ),
+      running: [],
+      capabilities: { "mistral:latest": ["completion", "tools"] },
+    });
+    assert.equal(snapshot.models[0].enabled, true);
+    // The next write leaves one canonical entry behind, not two.
+    setLocalModelEnabled("mistral:latest", true, NO_OLLAMA);
+    assert.deepEqual(readLocalModelSelection().enabled, ["mistral:latest"]);
+  } finally {
+    writeSelectionFile(restore);
+  }
 });
 
 test("the listing renders for a person, not only for the tray", () => {

--- a/test/vision-host.test.mjs
+++ b/test/vision-host.test.mjs
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
+  ollamaInstallMessage,
   annotateLocalModels,
   detectLocalRuntimes,
   hostVisionProfile,
@@ -15,6 +17,27 @@ import {
 } from "../src/vision-host.mjs";
 
 const GIB = 1024 ** 3;
+
+test("the Ollama install hint is built on demand, not on import", () => {
+  // Building it asks which package manager is present, which is a synchronous
+  // `brew --version` (~200 ms). As a top-level constant that ran on every
+  // import of this module, and start.mjs reaches it through a chain of static
+  // imports -- so every router start paid for a string almost nobody reads.
+  const source = readFileSync(new URL("../src/vision-host.mjs", import.meta.url), "utf8");
+  const topLevel = source
+    .split("\n")
+    .filter((line) => /^(export\s+)?(const|let|var)\s/.test(line));
+  assert.equal(
+    topLevel.some((line) => line.includes("ollamaInstallHint(")),
+    false,
+    "install hint must not be computed at module scope",
+  );
+
+  const message = ollamaInstallMessage();
+  assert.match(message, /^Install Ollama \(/);
+  // Memoized: the plan lookup is the expensive part and cannot repeat per call.
+  assert.equal(ollamaInstallMessage(), message);
+});
 
 test("hardware recommendation scales with memory", () => {
   assert.equal(hostVisionProfile({ totalMemBytes: 4 * GIB }).recommended, "moondream");


### PR DESCRIPTION
## Summary

- surface every catalog model instead of hiding the ones this machine cannot run, and let an oversized one be installed after an explicit confirmation
- split `--yes` and `--force` into independent, combinable flags so one command can install Ollama *and* an oversized model
- fix five defects found while reviewing #163 line by line: a startup `brew --version`, an undocumented flag, duplicate tag spellings in the selection file, a skipped router restart, and two pieces of dead code

## Why

Two problems compounded. The catalog dropped any model rated too large for the machine, and the tray hard-disabled Download for whatever was left. On an 8 GB laptop that meant `qwen2.5-coder:14b`, `gpt-oss:20b` and `devstral` appeared in **no list at all** — not recommended, not browsable, not installable even deliberately. On a 17 GB machine, 133 of 202 catalog tags rendered with a dead button.

The escape hatch did not work either. `--force` overrides the fit check and `--yes` consents to installing Ollama, but they shared a single argument slot, so `install <tag> --yes --force` was unexpressible — exactly the combination an oversized model on a machine without Ollama requires. Both UI surfaces always send `--yes`, so neither could ever force.

## User impact

Every model in the catalog is now listed and installable. The coding and vision shortlists stay recommendations and still only show what fits, but nothing is removed from the catalog itself: a model that will not fit is labelled **won't fit**, its button reads **Anyway**, and confirming sends `--force`. Installing still takes one action when Ollama is absent — `--yes` installs and starts it headlessly (Homebrew CLI formula where available, otherwise the official installer with `OLLAMA_NO_START=1`), and a test now asserts every macOS path keeps that flag so the desktop app is never launched.

| | before | after |
| --- | --- | --- |
| Catalog entries | 189 | 202 |
| Too-large models installable | no | yes, after confirming |
| `install --yes --force` | rejected | supported |
| `brew --version` per router start | 1 (~200 ms) | 0 |

## Also fixed (from the #163 review)

- `OLLAMA_INSTALL_HINT` was a top-level constant whose initializer shells out to `brew --version` — measured at 208 ms here. `start.mjs` reaches it through a chain of static imports, so every router start paid for a string almost nobody reads. It is a memoized function now.
- `gemma3` and `gemma3:latest` could both sit in the selection file, and `set gemma3 off` cleared neither. Tags are canonicalized on write and compared canonically on read, which also migrates state written by older versions.
- `set` compared the raw string to decide whether to restart the router service, so a spelling mismatch silently skipped the restart that publishes the route change.
- Dropped an unreachable clause in the model-URL parser and a dead emptiness check after `normalizeLocalModelTag`, which already throws on empty input.

One finding was deliberately left alone: on macOS without Homebrew, installing Ollama escalates via `osascript` to run the official `install.sh` as root. It is vendor-official, HTTPS, Homebrew-preferred, and only fires on explicit consent — and removing it would break one-click install on those machines.

## Validation

- `npm test` — 934 tests, 0 failures (8 new)
- `npm run check`
- `swift build` from clean (macOS tray)
- `cargo check` and `cargo test` (6/6, Tauri desktop)
- `git diff --check origin/main...HEAD`

New tests cover: catalog completeness on a machine too small for part of it, canonical tag dedupe, legacy selection-file migration, `--yes`/`--force` in either order, the usage text naming both flags, headless `OLLAMA_NO_START=1` on every macOS installer path, and the install hint not being computed at module scope.

Also added a guard that would not have caught anything before this PR but will now: vision-catalog entries flow into the explore list, and Swift fails an entire array on one bad element, so a single entry missing `note` would have silently emptied the tray catalog with no visible error. A test asserts every entry satisfies the tray's decoder.