### PR TITLE
fix: route standalone search and deferred MCP tools safely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -656,8 +656,9 @@ minutes later. Do not quietly drop the label because a check happened to pass.
 - A user-initiated macOS tray login-mode change may gracefully restart only the
   registered Codex desktop app. This does not authorize an installation task to
   quit Codex, and the tray must never force-terminate it.
-- Do not kill unknown processes on ports 4100-4103, or on the Grok OAuth
-  forwarder port 4108.
+- Do not kill unknown processes on ports 4200-4203, or on the Grok OAuth
+  forwarder port 4208. The previous 4100-4103/4108 defaults remain valid only
+  when explicitly supplied through the port environment variables.
 - Do not print or read credential-file contents. Status commands report presence
   and source only.
 - Treat the generated `/_codex-router/.../v1` config path as sensitive local

--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ model_catalog_json = "/absolute/path/to/.codex/codex-router/merged-models.json"
 name = "Codex Router (external models)"
 base_url = "http://127.0.0.1:4202/_codex-router/<generated-capability>/v1"
 wire_api = "responses"
+supports_standalone_web_search = true
 # END codex-router-provider-managed
 ```
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ surface Grok Build uses. xAI's backend chooses when to search and how to filter
 results; the router does not take search env knobs or request-side filter
 config. Install the official CLI and authenticate before enabling the route:
 
+Other routed providers can use Codex's client-side (standalone) web search when
+the selected model has been verified for it. DeepSeek V4 Flash is enabled on
+its direct API and opencode Go routes. A compatible model declares
+`"searchTool": { "mode": "standalone" }` in its registry or user-model
+metadata, and the managed Codex provider table advertises
+`supports_standalone_web_search = true`. This is intentionally opt-in per
+model; the router does not infer search compatibility from an OpenAI-compatible
+endpoint.
+
 ```sh
 npm install -g @xai-official/grok
 grok login --oauth
@@ -510,14 +519,14 @@ Codex config:
 
 ```toml
 # BEGIN codex-router-managed
-openai_base_url = "http://127.0.0.1:4102/_codex-router/<generated-capability>/v1"
+openai_base_url = "http://127.0.0.1:4202/_codex-router/<generated-capability>/v1"
 model_catalog_json = "/absolute/path/to/.codex/codex-router/merged-models.json"
 # END codex-router-managed
 
 # BEGIN codex-router-provider-managed
 [model_providers.codex-router]
 name = "Codex Router (external models)"
-base_url = "http://127.0.0.1:4102/_codex-router/<generated-capability>/v1"
+base_url = "http://127.0.0.1:4202/_codex-router/<generated-capability>/v1"
 wire_api = "responses"
 # END codex-router-provider-managed
 ```
@@ -1087,9 +1096,9 @@ and GitHub build-provenance attestations.
 
 ```mermaid
 flowchart LR
-  C["Codex Responses :4102"] --> L1["LiteLLM :4100"]
-  L1 --> K1["Kimi OAuth :4101"]
-  L1 --> A1["API keys :4103"]
+  C["Codex Responses :4202"] --> L1["LiteLLM :4200"]
+  L1 --> K1["Kimi OAuth :4201"]
+  L1 --> A1["API keys :4203"]
   K1 --> P["External providers"]
   A1 --> P
 ```

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -685,7 +685,7 @@ fn read_router_health() -> Value {
     let port = env::var("MODEL_ROUTER_PORT")
         .ok()
         .and_then(|value| value.parse::<u16>().ok())
-        .unwrap_or(4102);
+        .unwrap_or(4202);
     let address = SocketAddr::from(([127, 0, 0, 1], port));
     let mut stream = match TcpStream::connect_timeout(&address, Duration::from_millis(500)) {
         Ok(stream) => stream,

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -1423,7 +1423,7 @@ final class RouterStore: ObservableObject {
   }
 
   private func refreshActivity() async {
-    let configuredPort = ProcessInfo.processInfo.environment["MODEL_ROUTER_PORT"] ?? "4102"
+    let configuredPort = ProcessInfo.processInfo.environment["MODEL_ROUTER_PORT"] ?? "4202"
     guard let url = URL(string: "http://127.0.0.1:\(configuredPort)/health") else {
       recordActivityHealthFailure()
       return

--- a/bin/install
+++ b/bin/install
@@ -41,6 +41,10 @@ if [ "$migrate_known" = true ] && [ "$adopt_native_catalog" = true ]; then
   echo "--adopt-native-catalog cannot be combined with --migrate-known." >&2
   exit 2
 fi
+if [ "${CODEX_ROUTER_PACKAGE_MANAGER:-}" = homebrew ] && [ "$force_deps" = true ]; then
+  echo "--force-deps cannot rebuild Homebrew-managed dependencies; run brew reinstall codex-router instead." >&2
+  exit 2
+fi
 platform=$(uname -s)
 case "$platform" in
   Darwin|Linux) ;;
@@ -81,14 +85,15 @@ fi
 if [ "$prepare_only" != true ]; then
   node src/provider-selection.mjs ensure-configured >/dev/null
 fi
-# Every update re-runs this installer, so the dependency steps are skipped when
-# their inputs are unchanged; --force-deps (used by doctor --fix) rebuilds them.
+# Every update re-runs this installer, so checkout-owned dependency steps are
+# skipped when their inputs are unchanged; --force-deps (used by doctor --fix)
+# rebuilds them. Homebrew assembles its dependency tree before this script runs.
 install_step() {
   # A package-manager checkout already contains the dependency tree assembled
   # by that package manager. Re-running npm/pip here would mutate its managed
   # prefix and can fail when packages intentionally have no pip RECORD (as
-  # Homebrew-installed Python resources do). Even --force-deps must leave that
-  # tree to the package manager; repair it with brew reinstall instead.
+  # Homebrew-installed Python resources do). The explicit --force-deps case is
+  # rejected above with its package-manager repair command.
   if [ "${CODEX_ROUTER_PACKAGE_MANAGER:-}" = homebrew ]; then
     echo managed
   elif [ "$force_deps" = true ]; then

--- a/bin/install
+++ b/bin/install
@@ -84,59 +84,74 @@ fi
 # Every update re-runs this installer, so the dependency steps are skipped when
 # their inputs are unchanged; --force-deps (used by doctor --fix) rebuilds them.
 install_step() {
-  if [ "$force_deps" = true ]; then
+  # A package-manager checkout already contains the dependency tree assembled
+  # by that package manager. Re-running npm/pip here would mutate its managed
+  # prefix and can fail when packages intentionally have no pip RECORD (as
+  # Homebrew-installed Python resources do). Even --force-deps must leave that
+  # tree to the package manager; repair it with brew reinstall instead.
+  if [ "${CODEX_ROUTER_PACKAGE_MANAGER:-}" = homebrew ]; then
+    echo managed
+  elif [ "$force_deps" = true ]; then
     echo run
   else
     node src/install-plan.mjs status "$1" 2>/dev/null || echo run
   fi
 }
 
-if [ "$(install_step node-deps)" = skip ]; then
-  echo "Node dependencies already match package-lock.json; skipping npm ci."
-else
-  npm ci --omit=dev
-  node src/install-plan.mjs record node-deps
-fi
+case "$(install_step node-deps)" in
+  managed) echo "Homebrew manages Node dependencies; skipping npm ci." ;;
+  skip) echo "Node dependencies already match package-lock.json; skipping npm ci." ;;
+  *)
+    npm ci --omit=dev
+    node src/install-plan.mjs record node-deps
+    ;;
+esac
 
-if [ "$(install_step python-deps)" = skip ]; then
-  echo "LiteLLM already matches the pinned versions; skipping the Python install."
-elif command -v uv >/dev/null 2>&1; then
-  if [ ! -x .venv/bin/python ]; then
-    uv venv --python 3.12 .venv
-  elif ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
-    # A venv whose interpreter home was cleared (macOS wipes /private/tmp, and
-    # installers that recorded a temporary Python as the venv home end up with
-    # a dangling interpreter) must be recreated, not pip-installed into: the
-    # launcher may still exist while pyvenv.cfg points at a vanished home.
-    echo "The virtual environment's interpreter home is missing; recreating the venv."
-    uv venv --clear --python 3.12 .venv
-  fi
-  # requirements/python.txt is the hash-verified transitive closure of the pins
-  # in src/install-plan.mjs. Hash checking makes every wheel and sdist in that
-  # tree verify against the lock before it is executed; without it only the two
-  # top-level packages were pinned and the rest was whatever PyPI resolved that
-  # day. Regenerate the lock with bin/lock-python, never by hand.
-  uv pip install --python .venv/bin/python --require-hashes -r requirements/python.txt
-  node src/install-plan.mjs record python-deps
-else
-  if ! command -v python3 >/dev/null 2>&1; then
-    echo "Python 3.10+ or uv is required to install LiteLLM." >&2
-    exit 1
-  fi
-  python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else "Python 3.10 or newer is required.")'
-  # Same clearing logic as the uv branch: a venv with a vanished interpreter
-  # home must be recreated from scratch instead of installed over.
-  if node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
-    python3 -m venv .venv
-  else
-    echo "The virtual environment's interpreter home is missing; recreating the venv."
-    python3 -m venv --clear .venv
-  fi
-  .venv/bin/python -m pip install --upgrade pip
-  # Same hash-verified lock as the uv branch above; both branches stay checked.
-  .venv/bin/python -m pip install --require-hashes -r requirements/python.txt
-  node src/install-plan.mjs record python-deps
-fi
+case "$(install_step python-deps)" in
+  managed) echo "Homebrew manages LiteLLM; skipping Python dependency installation." ;;
+  skip) echo "LiteLLM already matches the pinned versions; skipping the Python install." ;;
+  *)
+    if command -v uv >/dev/null 2>&1; then
+      if [ ! -x .venv/bin/python ]; then
+        uv venv --python 3.12 .venv
+      elif ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
+        # A venv whose interpreter home was cleared (macOS wipes /private/tmp,
+        # and installers that recorded a temporary Python as the venv home end
+        # up with a dangling interpreter) must be recreated, not pip-installed
+        # into: the launcher may still exist while pyvenv.cfg points at a
+        # vanished home.
+        echo "The virtual environment's interpreter home is missing; recreating the venv."
+        uv venv --clear --python 3.12 .venv
+      fi
+      # requirements/python.txt is the hash-verified transitive closure of the
+      # pins in src/install-plan.mjs. Hash checking makes every wheel and sdist
+      # in that tree verify against the lock before it is executed; without it
+      # only the two top-level packages were pinned and the rest was whatever
+      # PyPI resolved that day. Regenerate the lock with bin/lock-python, never
+      # by hand.
+      uv pip install --python .venv/bin/python --require-hashes -r requirements/python.txt
+      node src/install-plan.mjs record python-deps
+    else
+      if ! command -v python3 >/dev/null 2>&1; then
+        echo "Python 3.10+ or uv is required to install LiteLLM." >&2
+        exit 1
+      fi
+      python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else "Python 3.10 or newer is required.")'
+      # Same clearing logic as the uv branch: a venv with a vanished interpreter
+      # home must be recreated from scratch instead of installed over.
+      if node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
+        python3 -m venv .venv
+      else
+        echo "The virtual environment's interpreter home is missing; recreating the venv."
+        python3 -m venv --clear .venv
+      fi
+      .venv/bin/python -m pip install --upgrade pip
+      # Same hash-verified lock as the uv branch above; both branches stay checked.
+      .venv/bin/python -m pip install --require-hashes -r requirements/python.txt
+      node src/install-plan.mjs record python-deps
+    fi
+    ;;
+esac
 
 node src/secret.mjs ensure
 config_enabled=false

--- a/config/deepseek/deepseek-v4-flash.json
+++ b/config/deepseek/deepseek-v4-flash.json
@@ -30,8 +30,11 @@
       "inputModalities": [
         "text"
       ],
+      "searchTool": {
+        "mode": "standalone"
+      },
       "requestProfile": "deepseek-thinking",
-      "compHash": "deepseek-v4-flash-v1"
+      "compHash": "deepseek-v4-flash-v2"
     }
   ]
 }

--- a/config/ollama/cloud/minimax-m3.json
+++ b/config/ollama/cloud/minimax-m3.json
@@ -23,8 +23,8 @@
         "text",
         "image"
       ],
-      "requestProfile": "ollama-cloud",
-      "compHash": "ollama-cloud-minimax-m3-v2"
+      "requestProfile": "ollama-cloud-auto-tool-choice",
+      "compHash": "ollama-cloud-minimax-m3-v3"
     }
   ]
 }

--- a/config/opencode/go/deepseek-v4-flash.json
+++ b/config/opencode/go/deepseek-v4-flash.json
@@ -30,7 +30,10 @@
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-deepseek-v4-flash-v1"
+      "searchTool": {
+        "mode": "standalone"
+      },
+      "compHash": "opencode-go-deepseek-v4-flash-v2"
     }
   ]
 }

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -22,10 +22,10 @@ Four pieces make the integration work:
 ```mermaid
 sequenceDiagram
   participant C as Codex
-  participant R as Router :4102
-  participant L as LiteLLM :4100
-  participant O as Kimi OAuth :4101
-  participant A as API forwarder :4103
+  participant R as Router :4202
+  participant L as LiteLLM :4200
+  participant O as Kimi OAuth :4201
+  participant A as API forwarder :4203
   participant G as ChatGPT Codex
   participant P as External provider
 
@@ -165,6 +165,24 @@ removed. Both current V4 models use the same shared forwarder and credential.
 The retired DeepSeek alias routes remain hidden registry entries. This keeps
 old CLI commands working only as long as DeepSeek continues serving those
 upstream aliases without advertising them to new users.
+
+### Standalone web search
+
+Codex 0.146 and newer can execute web search itself for a custom model
+provider. A routed model may opt in with `"searchTool": { "mode":
+"standalone" }`; the merged catalog then advertises the search capability and
+Codex sends the search result back through the normal routed Responses turn.
+This is a per-model compatibility declaration, not a claim that the upstream
+provider hosts search. Only enable it after verifying that the provider's
+model accepts Codex's web-search result items and preserves tool/function-call
+history. The managed Codex provider table must also set
+`supports_standalone_web_search = true` (on Codex versions that support that
+field); older clients ignore the field and continue without standalone search.
+
+The checked-in registry currently enables this mode for DeepSeek V4 Flash on
+its direct API and opencode Go routes. Other provider/model pairs stay off
+until verified. User-model curation can opt in locally without changing the
+shared registry.
 
 ## Transport and compaction
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -313,11 +313,15 @@ Any other non-zero exit still restores the previous revision. Re-run setup to
 continue, or `./bin/rollback` (`./codex-router.ps1 rollback` on Windows) to
 return to the retained revision deliberately.
 
-The reinstall skips dependency work whose inputs are unchanged, so an update
-that carries no `package-lock.json` or LiteLLM pin change costs a service
-restart rather than a full `npm ci` and PyPI resolution. `./bin/doctor --fix`
-rebuilds them regardless, as does `./bin/install --force-deps`
-(`./install.ps1 -CheckoutInstall -ForceDeps` on Windows).
+For checkout installs, the reinstall skips dependency work whose inputs are
+unchanged, so an update that carries no `package-lock.json` or LiteLLM pin
+change costs a service restart rather than a full `npm ci` and PyPI resolution.
+`./bin/doctor --fix` rebuilds checkout-owned dependencies regardless, as does
+`./bin/install --force-deps` (`./install.ps1 -CheckoutInstall -ForceDeps` on
+Windows). Homebrew owns the dependency tree in its formula prefix: its normal
+doctor repair regenerates config and services without mutating that tree, and a
+missing or broken package file must be repaired with `brew reinstall
+codex-router`.
 
 When upgrading from a release without caller capabilities, the installer
 generates one, replaces only the marked managed URL, tightens config permissions,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -198,7 +198,7 @@ If config or service installation fails, the new service and marked config block
 are removed. If a legacy migration was part of the transaction, its exact config
 and service definition are restored as well.
 
-The installer does not kill an unknown process on ports 4100–4103 and does not
+The installer does not kill an unknown process on ports 4200–4203 and does not
 replace an unmarked user-owned `openai_base_url`, `model_catalog_json`, or agent
 concurrency value. Disabling the router removes only its marked concurrency
 default; a user-owned value remains intact.
@@ -350,3 +350,10 @@ Uninstall removes the marked integration config and current background service.
 It intentionally retains the checkout, native catalog cache, logs, backups,
 migration snapshots, internal key, and provider credentials. This prevents a
 routine uninstall from silently destroying authentication or recovery data.
+Existing Codex Router installs that used the former 4100–4103/4108 defaults are
+migrated on the next install or update: the managed Codex URL and generated
+systemd/launchd/task service are rewritten as one install transaction, and the
+old service is stopped before the new unit is started. Explicit
+`MODEL_ROUTER_*_PORT` (or legacy `CODEX_ROUTER_*_PORT`) environment settings
+remain authoritative for operators who intentionally keep a custom or legacy
+block.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -91,7 +91,7 @@ agent definitions are stored under `$CODEX_HOME/agents/` (normally
 `~/.codex/agents/`).
 
 The config root should contain exactly one `codex-router-managed` block with the
-loopback base URL on port 4102, a generated `/_codex-router/.../v1` path, and a catalog under
+loopback base URL on port 4202, a generated `/_codex-router/.../v1` path, and a catalog under
 `$CODEX_HOME/codex-router/merged-models.json`.
 
 The generated path is a local caller capability. Use `./bin/status`, which
@@ -266,18 +266,18 @@ This removes only the marked block and current service; it preserves the
 selected model, profiles, provider credentials, and ChatGPT login. If native
 models work again, inspect router health and create a support bundle.
 
-## Another process owns ports 4100–4103
+## Another process owns ports 4200–4203
 
 macOS/Linux:
 
 ```sh
-lsof -nP -iTCP:4100 -iTCP:4101 -iTCP:4102 -iTCP:4103 -sTCP:LISTEN
+lsof -nP -iTCP:4200 -iTCP:4201 -iTCP:4202 -iTCP:4203 -sTCP:LISTEN
 ```
 
 Windows PowerShell:
 
 ```powershell
-Get-NetTCPConnection -LocalPort 4100,4101,4102,4103 -State Listen |
+Get-NetTCPConnection -LocalPort 4200,4201,4202,4203 -State Listen |
   Select-Object LocalAddress,LocalPort,OwningProcess
 ```
 

--- a/docs/research/ccswitch-preserved-provider-integration.md
+++ b/docs/research/ccswitch-preserved-provider-integration.md
@@ -173,7 +173,7 @@ model_catalog_json = "/Users/rohitsabu/.codex/codex-router/merged-models.json"
 
 [model_providers.custom]
 name = "OpenAI"
-base_url = "http://127.0.0.1:4102/_codex-router/<local-capability>/v1"
+base_url = "http://127.0.0.1:4202/_codex-router/<local-capability>/v1"
 wire_api = "responses"
 requires_openai_auth = true
 supports_websockets = false

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -404,7 +404,9 @@ function normalizeBody(buffer, contentType, route) {
   } else if (model.requestProfile === "deepseek-nonthinking") {
     payload.thinking = { type: "disabled" };
     delete payload.reasoning_effort;
-  } else if (model.requestProfile === "ollama-cloud") {
+  } else if (
+    ["ollama-cloud", "ollama-cloud-auto-tool-choice"].includes(model.requestProfile)
+  ) {
     // Absent means the model's own default; Ollama enables thinking on capable
     // models when the parameter is omitted.
     if (payload.reasoning_effort !== undefined) {
@@ -412,6 +414,16 @@ function normalizeBody(buffer, contentType, route) {
     }
     // The native think parameter is ignored on this endpoint.
     delete payload.think;
+    // MiniMax M3 on Ollama Cloud accepts tool calls under auto but can emit
+    // malformed arguments when Codex forces a particular tool. Preserve the
+    // model-scoped exception on direct Chat Completions traffic too.
+    if (
+      model.requestProfile === "ollama-cloud-auto-tool-choice" &&
+      payload.tool_choice !== undefined &&
+      payload.tool_choice !== "none"
+    ) {
+      payload.tool_choice = "auto";
+    }
   } else if (model.requestProfile === "qwen-plan") {
     // DashScope documents reasoning_effort only for the cross-vendor
     // DeepSeek/GLM models it resells (high/max; low/medium collapse to high,

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -375,10 +375,11 @@ export function routedModel(template, model) {
     // Capability toggles come from the registry entry, never from the native
     // template: an absent flag keeps the conservative default so a routed
     // model only advertises what its slug's gateway path actually verified.
-    // "hosted" is the only search mode the request path can serve today (the
-    // provider backend runs the search server-side, as the Grok OAuth
-    // forwarder does); the registry loader rejects anything else.
-    supports_search_tool: model.searchTool?.mode === "hosted",
+    // Both search paths are explicit registry capabilities. Hosted search is
+    // executed by the provider backend; standalone search is executed by
+    // Codex and its result is replayed through the routed conversation. An
+    // absent declaration remains the conservative default.
+    supports_search_tool: ["hosted", "standalone"].includes(model.searchTool?.mode),
     supports_image_detail_original: model.supportsImageDetailOriginal === true,
     use_responses_lite: false,
     // Codex only knows one ApplyPatchToolType variant. The native template

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -38,6 +38,7 @@ import {
   CODEX_PROVIDER_MODE_PATH,
   CONFIG_PATH,
   LEGACY_STATE_DIRS,
+  LEGACY_PORTS,
   MERGED_CATALOG_PATH,
   PORTS,
   SIGNED_PROVIDER_MODE_PATH,
@@ -45,7 +46,10 @@ import {
 } from "./paths.mjs";
 import { scanTomlDocument } from "./toml-structure.mjs";
 
-const legacyRouterBaseUrl = loopback(PORTS.router, "/v1");
+const managedRouterBaseUrls = new Set([
+  loopback(PORTS.router, "/v1"),
+  loopback(LEGACY_PORTS.router, "/v1"),
+]);
 const startMarker = "# BEGIN codex-router-managed";
 const endMarker = "# END codex-router-managed";
 const providerStartMarker = "# BEGIN codex-router-provider-managed";
@@ -96,8 +100,9 @@ function configuredRouterBaseUrl() {
 
 function isManagedRouterBaseUrl(value) {
   return (
-    value === legacyRouterBaseUrl ||
-    isManagedCallerBaseUrl(value, PORTS.router)
+    managedRouterBaseUrls.has(value) ||
+    isManagedCallerBaseUrl(value, PORTS.router) ||
+    isManagedCallerBaseUrl(value, LEGACY_PORTS.router)
   );
 }
 
@@ -474,9 +479,40 @@ function managedSignedProviderBlock(providerId, baseUrl) {
     `base_url = ${JSON.stringify(baseUrl)}`,
     'wire_api = "responses"',
     "requires_openai_auth = true",
+    // Codex 0.146+ performs standalone web search on the client and sends
+    // the resulting items back through the selected custom provider. Keep
+    // this opt-in on the managed provider table; older Codex versions ignore
+    // the unknown field and retain their existing behavior.
+    "supports_standalone_web_search = true",
     "supports_websockets = false",
     signedProviderEndMarker,
   ].join("\n");
+}
+
+// Keep accepting the pre-standalone-search managed block while upgrading it
+// in place. Existing signed state must not become "user-owned" merely because
+// this optional Codex capability was added.
+function managedSignedProviderBlockLegacy(providerId, baseUrl) {
+  const headerId = /^[A-Za-z0-9_-]+$/.test(providerId)
+    ? providerId
+    : JSON.stringify(providerId);
+  return [
+    signedProviderStartMarker,
+    `[model_providers.${headerId}]`,
+    'name = "Codex Router (with ChatGPT)"',
+    `base_url = ${JSON.stringify(baseUrl)}`,
+    'wire_api = "responses"',
+    "requires_openai_auth = true",
+    "supports_websockets = false",
+    signedProviderEndMarker,
+  ].join("\n");
+}
+
+function managedSignedProviderBlockMatches(actual, providerId, baseUrl) {
+  return [
+    managedSignedProviderBlock(providerId, baseUrl),
+    managedSignedProviderBlockLegacy(providerId, baseUrl),
+  ].includes(actual);
 }
 
 function signedProviderSlot(state, index) {
@@ -546,7 +582,7 @@ function signedProviderBlockIsOwned(contents, state) {
     const range = signedManagedRange(contents);
     if (!range) return false;
     const actual = range.lines.slice(range.start, range.end).join("\n");
-    return actual === managedSignedProviderBlock(state.managedProvider, state.managedBaseUrl);
+    return managedSignedProviderBlockMatches(actual, state.managedProvider, state.managedBaseUrl);
   }
   if (state.version !== 3) return false;
   const sections = state.previousProviderSections;
@@ -567,7 +603,7 @@ function signedProviderBlockIsOwned(contents, state) {
   const actual = range.lines.slice(range.start, range.end).join("\n");
   const slotIndex = lines.indexOf(signedProviderSlot(state, 0));
   return (
-    actual === managedSignedProviderBlock(state.managedProvider, state.managedBaseUrl) &&
+    managedSignedProviderBlockMatches(actual, state.managedProvider, state.managedBaseUrl) &&
     slotIndex + 1 === range.start &&
     providerRanges.length === 1 &&
     providerRanges[0].start === range.start + 1
@@ -790,10 +826,12 @@ function legacyManagedRouterProvider(contents) {
     isManagedRouterBaseUrl(rootBaseUrl) &&
     fields.get("wire_api") === "responses";
   const currentShape =
-    fields.size === 3 &&
+    (fields.size === 3 ||
+      (fields.size === 4 && fields.get("supports_standalone_web_search") === "true")) &&
     fields.get("name") === "Codex Router (external models)";
   const prototypeShape =
-    fields.size === 4 &&
+    (fields.size === 4 ||
+      (fields.size === 5 && fields.get("supports_standalone_web_search") === "true")) &&
     fields.get("name") === "Codex Router (extra providers)" &&
     fields.get("requires_openai_auth") === "true";
   return commonFieldsMatch && (currentShape || prototypeShape)
@@ -948,6 +986,7 @@ function enabledContents(contents) {
     'name = "Codex Router (external models)"',
     `base_url = ${JSON.stringify(routerBaseUrl)}`,
     'wire_api = "responses"',
+    "supports_standalone_web_search = true",
     providerEndMarker,
   ];
   return withManagedAgentConcurrency(

--- a/src/dependency-repair.mjs
+++ b/src/dependency-repair.mjs
@@ -1,0 +1,18 @@
+export function isHomebrewManaged(
+  packageManager = process.env.CODEX_ROUTER_PACKAGE_MANAGER,
+) {
+  return packageManager === "homebrew";
+}
+
+export function dependencyRepairHint({
+  packageManager = process.env.CODEX_ROUTER_PACKAGE_MANAGER,
+  platform = process.platform,
+} = {}) {
+  if (isHomebrewManaged(packageManager)) {
+    return "Run `brew reinstall codex-router` to rebuild the package-managed dependencies";
+  }
+  if (platform === "win32") {
+    return "Run `./codex-router.ps1 doctor --fix` or `./install.ps1 -CheckoutInstall -ForceDeps`";
+  }
+  return "Run `./bin/doctor --fix` or `./bin/install --force-deps`";
+}

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -50,10 +50,40 @@ import {
   visionBridgeConfigured,
 } from "./vision-bridge-state.mjs";
 import { venvRuntimeProblem } from "./venv-runtime.mjs";
+import {
+  dependencyRepairHint,
+  isHomebrewManaged,
+} from "./dependency-repair.mjs";
 
 const checks = [];
 const add = (status, name, detail, fix) => checks.push({ status, name, detail, fix });
 const jsonOutput = process.argv.includes("--json");
+const homebrewManaged = isHomebrewManaged();
+const usesBundledVenv = !process.env.MODEL_ROUTER_LITELLM_BIN &&
+  !(TARGET === "codex" &&
+    (process.env.CODEX_ROUTER_LITELLM_BIN || process.env.KIMI_LITELLM_BIN));
+const bundledVenvBin = path.join(
+  SOURCE_ROOT,
+  ".venv",
+  process.platform === "win32" ? "Scripts" : "bin",
+);
+const bundledVenvPython = path.join(
+  bundledVenvBin,
+  process.platform === "win32" ? "python.exe" : "python",
+);
+const bundledLiteLlm = path.join(
+  bundledVenvBin,
+  process.platform === "win32" ? "litellm.exe" : "litellm",
+);
+const dependencyFix = dependencyRepairHint();
+
+function bundledVenvProblem() {
+  if (!existsSync(bundledLiteLlm)) return `${bundledLiteLlm} is missing`;
+  const pythonProblem = venvRuntimeProblem(bundledVenvPython);
+  return pythonProblem
+    ? `${bundledVenvPython} cannot run (${pythonProblem})`
+    : undefined;
+}
 
 // Asks Codex to load its own configuration and returns its complaint, if any.
 // `login status` exits non-zero merely for being signed out, so the exit code
@@ -150,6 +180,18 @@ function repair() {
     process.exit(result.status ?? 1);
   }
 
+  // Homebrew owns every file under the formula prefix. Re-running npm or pip
+  // from here would mutate that prefix and fails for resources intentionally
+  // installed without pip RECORD metadata. A healthy package can still use
+  // doctor --fix to regenerate config and services, but damaged package files
+  // must be rebuilt by Homebrew itself before the service transaction starts.
+  if (homebrewManaged && usesBundledVenv) {
+    const problem = bundledVenvProblem();
+    if (problem) {
+      throw new Error(`Homebrew-managed LiteLLM is damaged (${problem}). ${dependencyFix}.`);
+    }
+  }
+
   const legacy = detectLegacyInstallations();
   if (legacy.unknownConflict) {
     throw new Error(
@@ -165,8 +207,11 @@ function repair() {
     childJson("legacy-migration.mjs", ["apply", "--yes"]);
   }
   const repairStdio = jsonOutput ? ["inherit", "ignore", "inherit"] : "inherit";
-  // Repair rebuilds dependencies unconditionally: the fingerprints an ordinary
-  // install trusts cannot see a corrupted node_modules or virtual environment.
+  // Checkout repair rebuilds dependencies unconditionally: the fingerprints
+  // an ordinary install trusts cannot see a corrupted node_modules or virtual
+  // environment. Homebrew has already validated its package-owned tree above,
+  // so its repair only regenerates configuration and services.
+  const posixArguments = homebrewManaged ? [] : ["--force-deps"];
   const result = process.platform === "win32"
     ? spawnSync(
         "powershell.exe",
@@ -182,7 +227,7 @@ function repair() {
         ],
         { cwd: SOURCE_ROOT, env: process.env, stdio: repairStdio },
       )
-    : spawnSync(path.join(SOURCE_ROOT, "bin", "install"), ["--force-deps"], {
+    : spawnSync(path.join(SOURCE_ROOT, "bin", "install"), posixArguments, {
         cwd: SOURCE_ROOT,
         env: process.env,
         stdio: repairStdio,
@@ -474,24 +519,15 @@ add(
 // (MODEL_ROUTER_LITELLM_BIN or a codex-target alias) may deliberately ship
 // without the bundled `.venv`, and a fresh checkout has no venv until the
 // installer runs.
-const usesBundledVenv = !process.env.MODEL_ROUTER_LITELLM_BIN &&
-  !(TARGET === "codex" &&
-    (process.env.CODEX_ROUTER_LITELLM_BIN || process.env.KIMI_LITELLM_BIN));
 let venvCheck;
 if (usesBundledVenv) {
-  const venvPython = path.join(
-    SOURCE_ROOT,
-    ".venv",
-    process.platform === "win32" ? "Scripts" : "bin",
-    process.platform === "win32" ? "python.exe" : "python",
-  );
-  const venvProblem = venvRuntimeProblem(venvPython);
+  const venvProblem = bundledVenvProblem();
   venvCheck = venvProblem
     ? {
         status: "fail",
-        detail: `${venvPython} cannot run (${venvProblem})`,
+        detail: venvProblem,
       }
-    : { status: "ok", detail: `${venvPython} runs` };
+    : { status: "ok", detail: `${bundledVenvPython} runs and ${bundledLiteLlm} exists` };
 } else {
   venvCheck = {
     status: "ok",
@@ -502,7 +538,7 @@ add(
   venvCheck.status,
   "LiteLLM venv runtime",
   venvCheck.detail,
-  "Run ./bin/doctor --fix; it rebuilds the virtual environment from the pinned lock.",
+  `${dependencyFix}.`,
 );
 
 const secretMode = existsSync(INTERNAL_SECRET_PATH)

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -326,16 +326,18 @@ function modelProblem(model, providers, slugs, gatewayModels) {
     return `model ${model.slug} may only set visionBridge to false`;
   }
   // "hosted" means the provider's own backend executes web searches
-  // server-side (xAI's Responses proxy today). No other mode may be declared
-  // yet: an unimplemented mode would make the catalog advertise a search
-  // toggle the request path cannot serve, so the router-side "emulated"
-  // executor must ship before this enum grows.
+  // server-side (xAI's Responses proxy today). "standalone" means Codex
+  // executes the search client-side and returns the result in the routed
+  // conversation; it is still opt-in per model because not every upstream
+  // accepts the resulting web-search items. Keep the enum closed so an
+  // unimplemented mode cannot make the catalog advertise an unsupported
+  // search path.
   if (
     model.searchTool !== undefined &&
     (!model.searchTool ||
       typeof model.searchTool !== "object" ||
       Array.isArray(model.searchTool) ||
-      model.searchTool.mode !== "hosted")
+      !["hosted", "standalone"].includes(model.searchTool.mode))
   ) {
     return `model ${model.slug} has an invalid searchTool`;
   }

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -103,9 +103,18 @@ export function flattenNamespaceTools(tools) {
       const names = new Set();
       for (const fn of tool.tools) {
         if (!fn?.name) continue;
+        // Codex names function schemas `inputSchema`, while LiteLLM's
+        // Responses -> Chat Completions adapter reads only `parameters`.
+        // Without this alias every flattened namespace child reaches the
+        // provider as an empty object schema, so MCP calls cannot receive the
+        // arguments their server requires. Keep inputSchema too: it is the
+        // client's native representation and responses-native routes retain
+        // it untouched.
+        const parameters = fn.parameters ?? fn.inputSchema;
         flattened.push({
           ...fn,
           name: `${tool.name}${NAMESPACE_DELIMITER}${fn.name}`,
+          ...(parameters === undefined ? {} : { parameters }),
         });
         names.add(fn.name);
         if (tool.name === "collaboration" && fn.name === "spawn_agent") {

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -99,6 +99,15 @@ export function flattenNamespaceTools(tools) {
   const spawnAgentModels = new Set();
   let changed = false;
   for (const tool of tools) {
+    // Codex adds this control tool when one or more namespace tools use
+    // deferred loading. By this boundary every namespace is expanded below,
+    // so the search control is redundant; chat-completions providers accept
+    // only ordinary function tools and reject `type: "tool_search"` before
+    // the model can call any MCP function.
+    if (tool?.type === "tool_search") {
+      changed = true;
+      continue;
+    }
     if (tool?.type === "namespace" && Array.isArray(tool.tools)) {
       const names = new Set();
       for (const fn of tool.tools) {

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -100,26 +100,48 @@ function port(name, fallback) {
   return value;
 }
 
-// gateway/oauth/router/api are the original four; grokOauth is a fifth
-// forwarder port for the Grok OAuth provider.
+// Keep the defaults in an unassigned IANA range. 4101-4104 are the registered
+// BrlAPI ports on Linux; binding an HTTP service there makes xbrlapi wait for a
+// protocol response during GNOME login. gateway/oauth/router/api are the
+// original four; grokOauth is a fifth forwarder port for the Grok OAuth
+// provider.
+export const DEFAULT_PORTS = Object.freeze({
+  gateway: 4200,
+  oauth: 4201,
+  router: 4202,
+  api: 4203,
+  grokOauth: 4208,
+});
+
+// Ports used before the BrlAPI-safe defaults shipped. They remain recognized
+// by config migration, but are never selected unless an operator explicitly
+// sets one of the environment variables below.
+export const LEGACY_PORTS = Object.freeze({
+  gateway: 4100,
+  oauth: 4101,
+  router: 4102,
+  api: 4103,
+  grokOauth: 4108,
+});
+
 export const PORTS = {
   gateway: port(
     "MODEL_ROUTER_GATEWAY_PORT",
-    process.env.CODEX_ROUTER_GATEWAY_PORT || process.env.KIMI_GATEWAY_PORT || 4100,
+    process.env.CODEX_ROUTER_GATEWAY_PORT || process.env.KIMI_GATEWAY_PORT || DEFAULT_PORTS.gateway,
   ),
   oauth: port(
     "MODEL_ROUTER_OAUTH_PORT",
-    process.env.CODEX_ROUTER_OAUTH_PORT || process.env.KIMI_OAUTH_FORWARD_PORT || 4101,
+    process.env.CODEX_ROUTER_OAUTH_PORT || process.env.KIMI_OAUTH_FORWARD_PORT || DEFAULT_PORTS.oauth,
   ),
   router: port(
     "MODEL_ROUTER_PORT",
-    process.env.CODEX_ROUTER_PORT || process.env.KIMI_ROUTER_PORT || 4102,
+    process.env.CODEX_ROUTER_PORT || process.env.KIMI_ROUTER_PORT || DEFAULT_PORTS.router,
   ),
   api: port(
     "MODEL_ROUTER_API_PORT",
-    process.env.CODEX_ROUTER_API_PORT || process.env.KIMI_API_FORWARD_PORT || 4103,
+    process.env.CODEX_ROUTER_API_PORT || process.env.KIMI_API_FORWARD_PORT || DEFAULT_PORTS.api,
   ),
-  grokOauth: port("MODEL_ROUTER_GROK_OAUTH_PORT", 4108),
+  grokOauth: port("MODEL_ROUTER_GROK_OAUTH_PORT", DEFAULT_PORTS.grokOauth),
 };
 
 export function loopback(portNumber, suffix = "") {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -359,6 +359,20 @@ function routedHeaders() {
   };
 }
 
+// LiteLLM translates Codex Responses requests into Chat Completions only after
+// this router hands the turn to the gateway. A profile that rejects forced
+// tool choices therefore has to be normalized here, before that translation
+// can cause the upstream model to emit an invalid forced call.
+function normalizeAutoToolChoice(payload, route) {
+  if (
+    ["auto-tool-choice", "ollama-cloud-auto-tool-choice"].includes(route.requestProfile) &&
+    payload.tool_choice !== undefined &&
+    payload.tool_choice !== "none"
+  ) {
+    payload.tool_choice = "auto";
+  }
+}
+
 function nativeTarget(pathname, search = "") {
   const withoutV1 = pathname.replace(/^\/v1(?=\/|$)/, "");
   return `${NATIVE_BASE}${withoutV1}${search}`;
@@ -1396,6 +1410,7 @@ async function summarize(request, payload, route, signal) {
     tools: [],
     input: [...bridged, messageItem(COMPACT_PROMPT)],
   };
+  normalizeAutoToolChoice(body, route);
   delete body.previous_response_id;
   delete body.client_metadata;
   // Compaction re-enters the same provider as the routed turn; Fireworks
@@ -1694,6 +1709,7 @@ async function handleResponses(request, response, requestUrl) {
         model: route.gatewayModel,
         input: routedInput,
       };
+      normalizeAutoToolChoice(routed, route);
       // Native OpenAI traffic keeps client_metadata; routed providers do not
       // consume it and the strict ones reject the unknown field.
       delete routed.client_metadata;

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -19,6 +19,9 @@ import { writeLiteLlmConfig } from "./litellm-config.mjs";
 import { readLocalModelSelection } from "./local-models.mjs";
 import { ensureOllamaHeadless } from "./ollama-runtime.mjs";
 import { venvRuntimeProblem } from "./venv-runtime.mjs";
+import { dependencyRepairHint } from "./dependency-repair.mjs";
+
+const dependencyFix = dependencyRepairHint();
 
 const litellm =
   process.env.MODEL_ROUTER_LITELLM_BIN ||
@@ -32,7 +35,7 @@ const litellm =
     process.platform === "win32" ? "litellm.exe" : "litellm",
   );
 if (!existsSync(litellm)) {
-  throw new Error(`LiteLLM is not installed at ${litellm}; run ./bin/install.`);
+  throw new Error(`LiteLLM is not installed at ${litellm}. ${dependencyFix}.`);
 }
 
 // A launcher file that exists on disk is not proof the venv works: an
@@ -61,8 +64,7 @@ if (usesBundledVenv) {
   if (venvProblem) {
     throw new Error(
       `The LiteLLM virtual environment is broken at ${venvPython} (${venvProblem}). ` +
-        `Run ./bin/doctor --fix to rebuild the virtual environment, ` +
-        `or ./bin/install --force-deps.`,
+        `${dependencyFix}.`,
     );
   }
 }

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -193,6 +193,11 @@ test("routed models advertise search and image detail only when the registry opt
   });
   assert.equal(capable.supports_search_tool, true);
   assert.equal(capable.supports_image_detail_original, true);
+  const standalone = routedModel(template, {
+    ...grok,
+    searchTool: { mode: "standalone" },
+  });
+  assert.equal(standalone.supports_search_tool, true);
 });
 
 test("routed service tiers are explicit and never inherit a paid default", () => {

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -127,6 +127,7 @@ approval_policy = "never"
     assert.doesNotMatch(configured, /\[agents\]/);
     assert.match(configured, /\[model_providers\.codex-router\]/);
     assert.match(configured, /wire_api = "responses"/);
+    assert.match(configured, /supports_standalone_web_search = true/);
     assert.ok(
       configured.includes(
         `openai_base_url = "http://127.0.0.1:46192/_codex-router/${CALLER_KEY}/v1"`,
@@ -700,6 +701,26 @@ model = "gpt-5.6-terra"
   }
 });
 
+test("config manager recognizes the pre-BrlAPI-safe default and rewrites it", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-legacy-port-"));
+  const stateDir = path.join(codexHome, "router-state");
+  const configPath = path.join(codexHome, "config.toml");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(path.join(stateDir, "caller-secret"), `${CALLER_KEY}\n`, { mode: 0o600 });
+  writeFileSync(
+    configPath,
+    `# BEGIN codex-router-managed\nopenai_base_url = "http://127.0.0.1:4102/_codex-router/${CALLER_KEY}/v1"\nmodel_catalog_json = ${JSON.stringify(path.join(stateDir, "merged-models.json"))}\n`,
+    { mode: 0o600 },
+  );
+  try {
+    assert.equal(run("enable", codexHome, stateDir).mode, "router");
+    assert.match(readFileSync(configPath, "utf8"), /127\.0\.0\.1:46192/);
+    assert.doesNotMatch(readFileSync(configPath, "utf8"), /127\.0\.0\.1:4102/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
 test("model_catalog_json round-trips through TOML escaping", () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-config-catalog-"));
   const configPath = path.join(codexHome, "config.toml");
@@ -834,6 +855,7 @@ Authorization = "Bearer PROVIDER_HEADER_SECRET"
     assert.match(configured, new RegExp(`base_url = "http://127\\.0\\.0\\.1:46192/_codex-router/${CALLER_KEY}/v1"`));
     assert.match(configured, /requires_openai_auth = true/);
     assert.match(configured, /supports_websockets = false/);
+    assert.match(configured, /supports_standalone_web_search = true/);
     assert.doesNotMatch(configured, /PROVIDER_(?:QUERY|AUTH|HEADER)_SECRET/);
     assert.doesNotMatch(
       configured,

--- a/test/dependency-repair.test.mjs
+++ b/test/dependency-repair.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  dependencyRepairHint,
+  isHomebrewManaged,
+} from "../src/dependency-repair.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function homebrewDoctorEnv(testRoot) {
+  return {
+    ...process.env,
+    CODEX_HOME: path.join(testRoot, "codex-home"),
+    CODEX_ROUTER_PACKAGE_MANAGER: "homebrew",
+    CODEX_ROUTER_SOURCE_ROOT: testRoot,
+    MODEL_ROUTER_STATE_DIR: path.join(testRoot, "state"),
+  };
+}
+
+function linkRegistry(testRoot) {
+  symlinkSync(path.join(root, "config"), path.join(testRoot, "config"), "dir");
+}
+
+test("Homebrew repair stays with the package manager", () => {
+  assert.equal(isHomebrewManaged("homebrew"), true);
+  assert.match(
+    dependencyRepairHint({ packageManager: "homebrew", platform: "darwin" }),
+    /^Run `brew reinstall codex-router`/,
+  );
+});
+
+test("checkout repair names the platform-native force path", () => {
+  assert.equal(isHomebrewManaged(undefined), false);
+  assert.match(
+    dependencyRepairHint({ packageManager: undefined, platform: "linux" }),
+    /\.\/bin\/doctor --fix.*\.\/bin\/install --force-deps/,
+  );
+  assert.match(
+    dependencyRepairHint({ packageManager: undefined, platform: "win32" }),
+    /codex-router\.ps1 doctor --fix.*install\.ps1 -CheckoutInstall -ForceDeps/,
+  );
+});
+
+test(
+  "Homebrew doctor refuses damaged package files before running the installer",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-homebrew-doctor-broken-"));
+    const installLog = path.join(testRoot, "install-args.log");
+    try {
+      linkRegistry(testRoot);
+      const result = spawnSync(process.execPath, [path.join(root, "src", "doctor.mjs"), "--fix"], {
+        encoding: "utf8",
+        env: { ...homebrewDoctorEnv(testRoot), CODEX_ROUTER_TEST_INSTALL_ARGS: installLog },
+      });
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /Homebrew-managed LiteLLM is damaged/);
+      assert.match(result.stderr, /brew reinstall codex-router/);
+      assert.equal(existsSync(installLog), false, "repair must fail before the installer runs");
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "Homebrew doctor reapplies managed state without force-deps when the package is healthy",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-homebrew-doctor-healthy-"));
+    const binDir = path.join(testRoot, "bin");
+    const venvBin = path.join(testRoot, ".venv", "bin");
+    const installLog = path.join(testRoot, "install-args.log");
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(venvBin, { recursive: true });
+    try {
+      linkRegistry(testRoot);
+      writeFileSync(
+        path.join(binDir, "install"),
+        '#!/bin/sh\nprintf "%s\\n" "$*" > "$CODEX_ROUTER_TEST_INSTALL_ARGS"\nexit 23\n',
+      );
+      writeFileSync(path.join(venvBin, "python"), "#!/bin/sh\nexit 0\n");
+      writeFileSync(path.join(venvBin, "litellm"), "#!/bin/sh\nexit 0\n");
+      for (const executable of [
+        path.join(binDir, "install"),
+        path.join(venvBin, "python"),
+        path.join(venvBin, "litellm"),
+      ]) {
+        chmodSync(executable, 0o755);
+      }
+
+      const result = spawnSync(process.execPath, [path.join(root, "src", "doctor.mjs"), "--fix"], {
+        encoding: "utf8",
+        env: { ...homebrewDoctorEnv(testRoot), CODEX_ROUTER_TEST_INSTALL_ARGS: installLog },
+      });
+      assert.equal(result.status, 1);
+      assert.match(result.stderr, /Repair installer exited with 23/);
+      assert.equal(readFileSync(installLog, "utf8").trim(), "");
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -132,6 +132,16 @@ test("Homebrew setup never reconciles package-manager-owned dependencies", () =>
   );
 });
 
+test("Homebrew force-deps fails early with the package-manager repair command", () => {
+  const result = spawnSync("sh", [path.join(root, "bin", "install"), "--force-deps"], {
+    encoding: "utf8",
+    env: { ...process.env, CODEX_ROUTER_PACKAGE_MANAGER: "homebrew" },
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /brew reinstall codex-router/);
+  assert.doesNotMatch(result.stdout, /npm ci|LiteLLM|service|catalog/i);
+});
+
 test(
   "POSIX install and enable preserve the PATH-selected Node wrapper",
   { skip: process.platform === "win32" },

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -116,6 +116,22 @@ test("install.sh is valid POSIX shell", () => {
   assert.equal(result.status, 0, result.stderr);
 });
 
+test("Homebrew setup never reconciles package-manager-owned dependencies", () => {
+  const installer = readScript("bin", "install");
+  const policy = installer.slice(
+    installer.indexOf("install_step() {"),
+    installer.indexOf("node src/secret.mjs ensure"),
+  );
+  assert.match(policy, /CODEX_ROUTER_PACKAGE_MANAGER:-.*= homebrew/);
+  assert.match(policy, /echo managed/);
+  assert.match(policy, /case "\$\(install_step node-deps\)" in\n\s*managed\)/);
+  assert.match(policy, /case "\$\(install_step python-deps\)" in\n\s*managed\)/);
+  assert.ok(
+    policy.indexOf("CODEX_ROUTER_PACKAGE_MANAGER") < policy.indexOf('"$force_deps" = true'),
+    "--force-deps must not mutate Homebrew's managed dependency tree",
+  );
+});
+
 test(
   "POSIX install and enable preserve the PATH-selected Node wrapper",
   { skip: process.platform === "win32" },

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -139,6 +139,7 @@ function routedRequestPayload(stream = true, model = "opencode-go/deepseek-v4-fl
       { type: "function_call_output", call_id: "call_hist", output: "{}" },
     ],
     tools: [
+      { type: "tool_search" },
       { type: "function", name: "exec_command" },
       { type: "function", name: "view_image" },
       {
@@ -455,6 +456,10 @@ test("routed request flattens every namespace to the gateway and restores calls 
   assert.ok(
     outgoing.tools.every((tool) => tool?.type !== "namespace"),
     "no namespace entries reach the gateway",
+  );
+  assert.ok(
+    outgoing.tools.every((tool) => tool?.type !== "tool_search"),
+    "deferred tool search does not reach a function-only provider",
   );
   // The merged codex_app tool definitions keep their schema.
   const createThread = outgoing.tools.find((tool) => tool.name === "codex_app__create_thread");

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -169,7 +169,22 @@ function routedRequestPayload(stream = true, model = "opencode-go/deepseek-v4-fl
       {
         type: "namespace",
         name: "mcp__codex_apps__github",
-        tools: [{ type: "function", name: "fetch_issue" }],
+        tools: [
+          {
+            type: "function",
+            name: "fetch_issue",
+            inputSchema: {
+              type: "object",
+              properties: {
+                owner: { type: "string" },
+                repo: { type: "string" },
+                issue_number: { type: "integer", minimum: 1 },
+              },
+              required: ["owner", "repo", "issue_number"],
+              additionalProperties: false,
+            },
+          },
+        ],
       },
     ],
   };
@@ -445,6 +460,19 @@ test("routed request flattens every namespace to the gateway and restores calls 
   const createThread = outgoing.tools.find((tool) => tool.name === "codex_app__create_thread");
   assert.ok(createThread?.inputSchema, "create_thread schema survives the relay");
   assert.equal(createThread.inputSchema.type, "object");
+  const fetchIssue = outgoing.tools.find(
+    (tool) => tool.name === "mcp__codex_apps__github__fetch_issue",
+  );
+  assert.deepEqual(fetchIssue?.parameters, {
+    type: "object",
+    properties: {
+      owner: { type: "string" },
+      repo: { type: "string" },
+      issue_number: { type: "integer", minimum: 1 },
+    },
+    required: ["owner", "repo", "issue_number"],
+    additionalProperties: false,
+  });
 
   // Stored namespaced calls in the input history are renamed to match the
   // flattened tool list the model sees.

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -126,7 +126,22 @@ test("flattenNamespaceTools keeps the full tool schema on flattened entries", ()
   assert.equal(flat.name, "codex_app__create_thread");
   assert.equal(flat.description, "Create a thread");
   assert.deepEqual(flat.inputSchema, schema);
+  assert.deepEqual(flat.parameters, schema);
   assert.equal(flat.strict, true);
+});
+
+test("flattenNamespaceTools preserves a supplied provider parameter schema", () => {
+  const inputSchema = { type: "object", properties: { stale: { type: "string" } } };
+  const parameters = { type: "object", properties: { current: { type: "integer" } } };
+  const { tools } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "mcp__example",
+      tools: [{ type: "function", name: "read", inputSchema, parameters }],
+    },
+  ]);
+  assert.deepEqual(tools[0].parameters, parameters);
+  assert.deepEqual(tools[0].inputSchema, inputSchema);
 });
 
 test("flattenNamespaceTools handles non-array and empty input", () => {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -144,6 +144,19 @@ test("flattenNamespaceTools preserves a supplied provider parameter schema", () 
   assert.deepEqual(tools[0].inputSchema, inputSchema);
 });
 
+test("flattenNamespaceTools drops the deferred-loading control after expanding namespaces", () => {
+  const { tools, flattened } = flattenNamespaceTools([
+    { type: "tool_search" },
+    {
+      type: "namespace",
+      name: "mcp__example",
+      tools: [{ type: "function", name: "read" }],
+    },
+  ]);
+  assert.equal(flattened, true);
+  assert.deepEqual(tools, [{ type: "function", name: "mcp__example__read" }]);
+});
+
 test("flattenNamespaceTools handles non-array and empty input", () => {
   assert.deepEqual(flattenNamespaceTools(undefined), {
     tools: undefined,

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -260,14 +260,17 @@ test("provider registry exposes configured API and OAuth model families", () => 
     assert.equal(k3.defaultEffort, "max", slug);
     assert.equal(k3.requestProfile, "kimi-k3", slug);
   }
-  // Hosted search is an xAI-backend behavior, so only the Grok OAuth slug may
-  // declare it; every other search-capable path waits on the router-side
-  // emulated executor.
+  // Hosted search is an xAI-backend behavior. Standalone search is limited to
+  // provider/model pairs verified against Codex's client-side replay path.
   assert.deepEqual(MODEL_BY_SLUG.get("grok-oauth/grok-4.5").searchTool, {
     mode: "hosted",
   });
+  const standaloneSearchSlugs = new Set([
+    "deepseek/deepseek-v4-flash",
+    "opencode-go/deepseek-v4-flash",
+  ]);
   for (const model of MODELS) {
-    if (model.slug === "grok-oauth/grok-4.5") continue;
+    if (model.slug === "grok-oauth/grok-4.5" || standaloneSearchSlugs.has(model.slug)) continue;
     assert.equal(model.searchTool, undefined, model.slug);
   }
   // Original-detail images are declared per slug on canonical vision
@@ -330,6 +333,15 @@ test("provider registry exposes configured API and OAuth model families", () => 
     assert.equal(model.contextWindow, 1_048_576);
     assert.match(model.description, /DeepSeek V4/);
     assert.deepEqual(model.inputModalities, ["text"]);
+  }
+});
+
+test("DeepSeek V4 Flash routes opt in to Codex standalone web search", () => {
+  for (const slug of [
+    "deepseek/deepseek-v4-flash",
+    "opencode-go/deepseek-v4-flash",
+  ]) {
+    assert.deepEqual(MODEL_BY_SLUG.get(slug)?.searchTool, { mode: "standalone" }, slug);
   }
 });
 

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -2418,6 +2418,46 @@ test("API forwarder routes Ollama Cloud models without unsupported parameters", 
       }),
     });
     assert.equal(upstreamRequests.at(-1).body.reasoning_effort, undefined);
+
+    async function forwardMiniMax(toolChoice) {
+      const response = await fetch(
+        `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${INTERNAL_KEY}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "ollama-cloud-minimax-m3",
+            reasoning_effort: "high",
+            messages: [{ role: "user", content: "test" }],
+            ...(toolChoice === undefined ? {} : { tool_choice: toolChoice }),
+          }),
+        },
+      );
+      assert.equal(response.status, 200);
+      return upstreamRequests.at(-1).body;
+    }
+
+    // The combined profile keeps Ollama's effort normalization while applying
+    // the MiniMax-specific compatibility exception on direct traffic.
+    const required = await forwardMiniMax("required");
+    assert.equal(required.model, "minimax-m3");
+    assert.equal(required.reasoning_effort, "high");
+    assert.equal(required.tool_choice, "auto");
+
+    const forcedFunction = await forwardMiniMax({
+      type: "function",
+      function: { name: "relay_external_agent_payload" },
+    });
+    assert.equal(forcedFunction.tool_choice, "auto");
+
+    const suppressed = await forwardMiniMax("none");
+    assert.equal(suppressed.tool_choice, "none");
+
+    const absentToolChoice = await forwardMiniMax();
+    assert.equal("tool_choice" in absentToolChoice, false);
   } finally {
     await stopChild(forwarder);
     await closeServer(upstream.server);
@@ -3361,6 +3401,68 @@ test("router strips Fireworks web_search_options on routed and compaction reques
     await stopChild(router);
     await closeServer(gateway.server);
     rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
+test("router normalizes forced tool choices before LiteLLM for auto-tool-choice models", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, { id: "resp_test", object: "response", output: [] });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const headers = {
+    Authorization: `Bearer ${CALLER_KEY}`,
+    "Content-Type": "application/json",
+  };
+
+  async function route(model, toolChoice) {
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ model, input: "test", tool_choice: toolChoice }),
+    });
+    assert.equal(response.status, 200, router.testErrors());
+    return gatewayRequests.at(-1);
+  }
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    // LiteLLM does its Responses -> Chat Completions translation after the
+    // router, so this must already be auto when it reaches the gateway.
+    const required = await route("ollama-cloud/minimax-m3", "required");
+    assert.equal(required.model, "ollama-cloud-minimax-m3");
+    assert.equal(required.tool_choice, "auto");
+
+    // The collaboration relay uses an object form; it has the same upstream
+    // restriction and therefore must not survive the Responses hop either.
+    const forcedFunction = await route("ollama-cloud/minimax-m3", {
+      type: "function",
+      name: "relay_external_agent_payload",
+    });
+    assert.equal(forcedFunction.tool_choice, "auto");
+
+    // Suppressing tools is not forcing one, and remains necessary for turns
+    // such as compaction that deliberately disable tools.
+    const suppressed = await route("ollama-cloud/minimax-m3", "none");
+    assert.equal(suppressed.tool_choice, "none");
+
+    const absent = await route("ollama-cloud/minimax-m3");
+    assert.equal("tool_choice" in absent, false);
+
+    // The profile remains model-scoped: other Ollama Cloud models preserve a
+    // forced choice so their capability probe and collaboration relay work.
+    const sibling = await route("ollama-cloud/glm-5.2", "required");
+    assert.equal(sibling.tool_choice, "required");
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
   }
 });
 

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -92,6 +92,10 @@ test("background service definitions render for macOS, Linux, and Windows", () =
     assert.match(systemd, /ExecStart=/);
     assert.match(systemd, /Environment="PATH=/);
     assert.match(systemd, /Environment="CODEX_ROUTER_STATE_DIR=/);
+    assert.match(systemd, /MODEL_ROUTER_GATEWAY_PORT=4200/);
+    assert.match(systemd, /MODEL_ROUTER_OAUTH_PORT=4201/);
+    assert.match(systemd, /MODEL_ROUTER_PORT=4202/);
+    assert.match(systemd, /MODEL_ROUTER_API_PORT=4203/);
 
     const windows = render("service-windows.mjs", "win32", testRoot);
     assert.match(windows, /@echo off\r?\n/);

--- a/test/target-isolation.test.mjs
+++ b/test/target-isolation.test.mjs
@@ -32,12 +32,35 @@ function pathsForTarget(target) {
 
 test("codex owns the default port block", () => {
   assert.deepEqual(JSON.parse(pathsForTarget("codex")), {
-    gateway: 4100,
-    oauth: 4101,
-    router: 4102,
-    api: 4103,
-    grokOauth: 4108,
+    gateway: 4200,
+    oauth: 4201,
+    router: 4202,
+    api: 4203,
+    grokOauth: 4208,
   });
+});
+
+test("operators can keep an explicitly configured legacy block during migration", () => {
+  const ports = JSON.parse(
+    execFileSync(
+      process.execPath,
+      ["--input-type=module", "--eval", 'import { PORTS } from "./src/paths.mjs"; process.stdout.write(JSON.stringify(PORTS));'],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          MODEL_ROUTER_TARGET: "codex",
+          MODEL_ROUTER_GATEWAY_PORT: "4100",
+          MODEL_ROUTER_OAUTH_PORT: "4101",
+          MODEL_ROUTER_PORT: "4102",
+          MODEL_ROUTER_API_PORT: "4103",
+          MODEL_ROUTER_GROK_OAUTH_PORT: "4108",
+        },
+      },
+    ),
+  );
+  assert.deepEqual(ports, { gateway: 4100, oauth: 4101, router: 4102, api: 4103, grokOauth: 4108 });
 });
 
 test("removed targets are rejected rather than silently mapped to codex", () => {

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -136,11 +136,17 @@ test("registry merges valid user models and skips collisions", async () => {
       ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-blank-nux", priority: 103 }),
       availabilityNux: "   ",
     },
-    // Only the implemented "hosted" search mode may be declared; anything
-    // else would advertise a search the request path cannot serve.
+    // Search modes are a closed set. Unknown modes must not advertise a
+    // search path the request path cannot serve.
     {
       ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-bad-search", priority: 106 }),
       searchTool: { mode: "emulated" },
+    },
+    // Standalone search is Codex-side execution; it remains an explicit
+    // per-model opt-in rather than a provider-wide default.
+    {
+      ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-standalone-search", priority: 110 }),
+      searchTool: { mode: "standalone" },
     },
     // Capability toggles are booleans; a truthy string must not slip through.
     {
@@ -179,6 +185,7 @@ test("registry merges valid user models and skips collisions", async () => {
   assert.ok(!slugs.includes("no-such-provider/x-model"));
   assert.ok(!slugs.includes("deepseek/deepseek-blank-nux"));
   assert.ok(!slugs.includes("deepseek/deepseek-bad-search"));
+  assert.ok(slugs.includes("deepseek/deepseek-standalone-search"));
   assert.ok(!slugs.includes("deepseek/deepseek-bad-detail"));
   assert.ok(!slugs.includes("deepseek/deepseek-summary-without-support"));
   assert.ok(!slugs.includes("deepseek/deepseek-invalid-summary-support"));
@@ -192,4 +199,8 @@ test("registry merges valid user models and skips collisions", async () => {
   const merged = registry.MODEL_BY_SLUG.get("deepseek/deepseek-user-test");
   assert.equal(merged.listed, true);
   assert.equal(merged.availabilityNux, "Now available through your DeepSeek key.");
+  assert.deepEqual(
+    registry.MODEL_BY_SLUG.get("deepseek/deepseek-standalone-search").searchTool,
+    { mode: "standalone" },
+  );
 });


### PR DESCRIPTION
## Summary

- enable Codex standalone web search for explicitly verified routed models
- preserve deferred MCP tool schemas while flattening namespace tools for Chat Completions providers
- downgrade forced tool choice for Ollama Cloud MiniMax M3 on both routed Responses and direct forwarding paths
- move the default listener block from the BrlAPI-reserved 4101–4104 range to 4200–4203, while recognizing explicitly configured legacy ports
- keep Homebrew-owned Node and Python dependencies under Homebrew control, with package-aware repair guidance and fail-early protection
- document the standalone-search provider flag and the checkout-versus-Homebrew repair contract
- update registry, catalog, config migration, service, documentation, and regression coverage

## Why

Routed models could not receive Codex standalone search, deferred MCP namespace children lost their argument schemas through the LiteLLM bridge, MiniMax M3 intermittently rejected forced tool calls, and the Linux OAuth listener could block GNOME login by occupying a registered BrlAPI port.

The MCP relay now aliases Codex `inputSchema` definitions to the `parameters` field consumed by the Chat Completions adapter and removes the redundant deferred `tool_search` control after expanding namespaces.

Homebrew repairs now reapply managed config and services without pretending to rebuild package-owned dependencies. A damaged package fails before mutation with the correct `brew reinstall codex-router` recovery path; checkout repairs continue to force a dependency rebuild.

Addresses #159, #161, and #162.

## Validation

- `npm run check`
- `npm test` — 937 tests, 931 passed, 0 failed, 6 skipped
- `MODEL_ROUTER_LITELLM_INTEGRATION=1 node --test test/anthropic-api-integration.test.mjs` — passed through the real local LiteLLM adapter
- `swift build` in `apps/macos/ModelRouterTray` — passed
- `cargo check` in `apps/desktop/src-tauri` — passed
- `cargo test` in `apps/desktop/src-tauri` — 6 passed, 0 failed
- `sh -n bin/install`
- `git diff --check`
- local merge simulations against PRs #165 and #166 completed without conflicts

## Not run

- quota-consuming live provider calls for standalone search and repeated MiniMax tool calls; these require explicit quota approval and are not part of the deterministic test suite
