### PR TITLE
Fix macOS tray and router lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -970,7 +970,11 @@ the Settings tab's **Start at login** toggle or System Settings › Login Items
 turns that off, and the choice is never re-applied behind your back. A
 **Show tray** setting can additionally tie every tray surface to the Codex
 and ChatGPT desktop apps, appearing when they launch and hiding when they
-quit. See the [macOS tray guide](docs/MACOS-TRAY.md) for behavior and
+quit. In **With Codex** mode the endpoint starts with either app and stops only
+after both remain closed for 30 seconds and active requests have drained. A
+periodic process recheck backs up workspace notifications so a missed launch
+cannot strand Codex without its endpoint. **Always** keeps it continuously on.
+See the [macOS tray guide](docs/MACOS-TRAY.md) for behavior and
 rebuild notes.
 
 The app also places a Dynamic-Island-style overlay at the top center of the

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -927,11 +927,17 @@ private struct ProviderIcon: View {
 
   private var providerImage: NSImage? {
     guard let assetName else { return nil }
-    let url = Bundle.module.url(
+    // Installed apps keep SwiftPM resources in the standard sealed resources
+    // directory. Bundle.module remains the development fallback for swift run.
+    let installedBundle = Bundle.main.resourceURL
+      .map { $0.appendingPathComponent("ModelRouterTray_ModelRouterTray.bundle") }
+      .flatMap(Bundle.init(url:))
+    let resources = installedBundle ?? Bundle.module
+    let url = resources.url(
       forResource: assetName,
       withExtension: assetExtension,
       subdirectory: "ProviderIcons"
-    ) ?? Bundle.module.url(forResource: assetName, withExtension: assetExtension)
+    ) ?? resources.url(forResource: assetName, withExtension: assetExtension)
     return url.flatMap(NSImage.init(contentsOf:))
   }
 

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -154,11 +154,14 @@ final class RouterStore: ObservableObject {
   private let hostAppBundleIDs = ["com.openai.codex", "com.openai.chat"]
   private var workspaceObservers: [NSObjectProtocol] = []
   private var pendingServiceStop: Task<Void, Never>?
+  private var hostAppRecheck: Task<Void, Never>?
   private var serviceWork: Task<Void, Never>?
   private var serviceIntent: ServiceIntent = .unknown
   // Codex relaunches itself to apply updates, so a momentary disappearance must
-  // not bounce the router. Wait the absence out and re-check before stopping.
+  // not bounce the router. Wait the absence out and re-check the process list
+  // directly before stopping; workspace notifications are only hints.
   private let hostAppAbsenceGrace = Duration.seconds(30)
+  private let hostAppRecheckInterval = Duration.seconds(5)
   // A request in flight outlives the window that started it; retry rather than
   // cutting a generation off mid-stream.
   private let activeRequestRecheck = Duration.seconds(15)
@@ -262,9 +265,11 @@ final class RouterStore: ObservableObject {
     try? service.unregister()
   }
 
-  // In follow mode every tray surface tracks the Codex/ChatGPT desktop apps.
-  // The process itself stays resident as the watcher — quitting on app exit
-  // would leave nothing around to notice the next launch.
+  // In follow mode every tray surface and the endpoint track the Codex/ChatGPT
+  // desktop apps. The process itself stays resident as the watcher — quitting
+  // on app exit would leave nothing around to notice the next launch. Workspace
+  // notifications are backed by polling because missing one must never strand
+  // Codex without its endpoint.
   func startHostAppObservation() {
     // The mode lives in two places: UserDefaults for the tray and presence.json
     // for doctor. Only a toggle used to write the second one, so a reinstall or
@@ -283,6 +288,14 @@ final class RouterStore: ObservableObject {
       )
     }
     refreshHostAppRunning()
+    hostAppRecheck?.cancel()
+    hostAppRecheck = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: self?.hostAppRecheckInterval ?? .seconds(5))
+        guard !Task.isCancelled else { return }
+        self?.refreshHostAppRunning()
+      }
+    }
   }
 
   func setPresenceMode(_ mode: TrayPresenceMode) {
@@ -297,10 +310,11 @@ final class RouterStore: ObservableObject {
   }
 
   private func refreshHostAppRunning() {
-    hostAppRunning = hostAppBundleIDs.contains { identifier in
+    let detected = hostAppBundleIDs.contains { identifier in
       NSRunningApplication.runningApplications(withBundleIdentifier: identifier)
         .contains { !$0.isTerminated }
     }
+    if hostAppRunning != detected { hostAppRunning = detected }
     refreshSurfacesVisible()
     reconcileService()
   }
@@ -320,9 +334,9 @@ final class RouterStore: ObservableObject {
   // Stops are deferred: Codex restarts itself, and a request can outlive the
   // window that issued it.
   private func reconcileService() {
-    pendingServiceStop?.cancel()
-    pendingServiceStop = nil
     guard presenceMode == .followCodex else {
+      pendingServiceStop?.cancel()
+      pendingServiceStop = nil
       // Leaving follow mode hands the router back to launchd's always-on
       // contract, so anything the tray stopped has to come back up.
       if serviceIntent == .stopped { startService() }
@@ -330,13 +344,21 @@ final class RouterStore: ObservableObject {
       return
     }
     if hostAppRunning {
+      pendingServiceStop?.cancel()
+      pendingServiceStop = nil
       startService()
       return
     }
+    // Periodic process rechecks must not restart this grace period forever.
+    guard pendingServiceStop == nil else { return }
     pendingServiceStop = Task { [weak self] in
       guard let self else { return }
       try? await Task.sleep(for: self.hostAppAbsenceGrace)
       guard !Task.isCancelled else { return }
+      // Do not trust a possibly missed launch notification. Query the process
+      // list again at the decision point before unloading the endpoint.
+      self.refreshHostAppRunning()
+      guard !Task.isCancelled, !self.hostAppRunning else { return }
       await self.stopServiceWhenIdle()
     }
   }
@@ -344,14 +366,16 @@ final class RouterStore: ObservableObject {
   private func stopServiceWhenIdle() async {
     while !Task.isCancelled {
       guard presenceMode == .followCodex, !hostAppRunning else { return }
-      if activityState == .idle { break }
+      if activeRequestCount == 0 && activityState == .idle { break }
       try? await Task.sleep(for: activeRequestRecheck)
+      refreshHostAppRunning()
     }
     guard !Task.isCancelled, presenceMode == .followCodex, !hostAppRunning else { return }
     guard serviceIntent != .stopped else { return }
     serviceIntent = .stopped
     enqueueServiceWork { [weak self] in
-      await self?.runServiceCommand("stop")
+      guard let self, self.presenceMode == .followCodex, !self.hostAppRunning else { return }
+      await self.runServiceCommand("stop")
     }
   }
 
@@ -365,7 +389,7 @@ final class RouterStore: ObservableObject {
 
   // launchctl rejects overlapping bootstrap/bootout for the same label, so every
   // service call queues behind the previous one.
-  private func enqueueServiceWork(_ work: @escaping @Sendable () async -> Void) {
+  private func enqueueServiceWork(_ work: @escaping @MainActor @Sendable () async -> Void) {
     let previous = serviceWork
     serviceWork = Task { [weak self] in
       _ = await previous?.value
@@ -381,6 +405,7 @@ final class RouterStore: ObservableObject {
       // A failed stop is harmless; a failed start is not, so surface it and let
       // the next Codex launch retry from a known-unknown intent.
       serviceIntent = .unknown
+      if action == "stop" { pendingServiceStop = nil }
       message = "Router \(action): \(error.localizedDescription)"
     }
     await refresh()
@@ -392,6 +417,7 @@ final class RouterStore: ObservableObject {
   // gateway's health wait.
   func restoreServiceOnQuit() {
     pendingServiceStop?.cancel()
+    hostAppRecheck?.cancel()
     guard presenceMode == .followCodex, serviceIntent == .stopped else { return }
     guard let root = try? sourceRoot() else { return }
     let task = Process()
@@ -1643,12 +1669,12 @@ final class RouterStore: ObservableObject {
   }
 
   private func sourceRoot() throws -> URL {
-    guard let resourceURL = Bundle.main.resourceURL else {
+    guard let configured = Bundle.main.object(forInfoDictionaryKey: "ModelRouterSourceRoot") as? String,
+      !configured.isEmpty
+    else {
       throw RouterError("Cannot find this Model Router checkout. Rebuild the tray app from the router repository.")
     }
-    return try validatedSourceRoot(
-      resourceURL.appendingPathComponent("router-root", isDirectory: true)
-    )
+    return try validatedSourceRoot(URL(fileURLWithPath: configured, isDirectory: true))
   }
 
   private func validatedSourceRoot(_ root: URL) throws -> URL {

--- a/bin/model-router-tray
+++ b/bin/model-router-tray
@@ -5,15 +5,41 @@ repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 
 case $(uname -s) in
   Darwin)
-    bundle_dir=$("$repo_dir/scripts/build-macos-tray-app.sh")
-    # A running tray keeps executing its old binary; replace it before starting
-    # the rebuilt bundle so updates take effect immediately. A tray that was
-    # opened by hand is outside launchd's reach, so ask it to quit as well.
+    bundle_dir="$HOME/Applications/Model Router.app"
+    bundle_parent="$HOME/Applications"
+    mkdir -p "$bundle_parent"
+    staging_dir=$(mktemp -d "$bundle_parent/.model-router-tray.XXXXXX")
+    staged_bundle="$staging_dir/Model Router.app"
+    cleanup_staging() {
+      rm -rf "$staging_dir"
+    }
+    trap cleanup_staging EXIT HUP INT TERM
+
+    # Assemble and verify the replacement away from the live app. A failed
+    # build leaves the running tray intact; overwriting its mapped signed pages
+    # in place is what made macOS kill it as an invalid-signature process.
+    "$repo_dir/scripts/build-macos-tray-app.sh" "$staged_bundle" >/dev/null
+
+    # A tray opened by hand is outside launchd's reach, so ask it to quit too.
+    # This happens only after the staged replacement passes codesign verification.
     if pgrep -x ModelRouterTray >/dev/null 2>&1; then
       osascript -e 'tell application id "io.github.codex-router.tray" to quit' >/dev/null 2>&1 \
         || killall -QUIT ModelRouterTray >/dev/null 2>&1 || true
       sleep 1
     fi
+
+    previous_bundle="$staging_dir/Previous Model Router.app"
+    if [ -d "$bundle_dir" ]; then
+      mv "$bundle_dir" "$previous_bundle"
+    fi
+    if ! mv "$staged_bundle" "$bundle_dir"; then
+      if [ -d "$previous_bundle" ]; then
+        mv "$previous_bundle" "$bundle_dir"
+      fi
+      printf 'codex-router: could not install the rebuilt tray bundle.\n' >&2
+      exit 1
+    fi
+    rm -rf "$previous_bundle"
     # launchd owns the companion from here. Installing the agent starts it now,
     # starts it at every login, and restarts it if it ever exits abnormally --
     # a login item alone only covers the login case, which left a crashed tray
@@ -32,6 +58,8 @@ case $(uname -s) in
       rm -rf "$legacy_bundle"
       printf 'Removed the superseded in-checkout companion: %s\n' "$legacy_bundle"
     fi
+    trap - EXIT HUP INT TERM
+    cleanup_staging
     printf 'Tray installed and supervised by launchd: %s\n' "$bundle_dir"
     ;;
   Linux)

--- a/docs/MACOS-TRAY.md
+++ b/docs/MACOS-TRAY.md
@@ -49,8 +49,12 @@ nothing around to notice the next launch. Combined with **Start at login**,
 this makes the tray fully automatic: it waits invisibly after a reboot and
 shows up exactly while Codex is open. While hidden, reopen Codex (or run
 `defaults write io.github.codex-router.tray ModelRouterTray.presenceMode
-always` and relaunch) to reach the toggle again. The router's background
-service is unaffected by visibility.
+always` and relaunch) to reach the toggle again. In **With Codex** mode the
+router endpoint starts as soon as Codex or ChatGPT appears and stops only after
+both remain absent for 30 seconds and active requests have drained. The watcher
+also polls the process list every five seconds so a missed workspace
+notification cannot strand the next launch. **Always** leaves the endpoint
+under launchd continuously.
 
 ## Provider usage
 

--- a/scripts/build-macos-tray-app.sh
+++ b/scripts/build-macos-tray-app.sh
@@ -22,15 +22,18 @@ if [ -d "$binary_dir/ModelRouterTray_ModelRouterTray.bundle" ]; then
   rm -rf "$bundle_dir/Contents/Resources/ModelRouterTray_ModelRouterTray.bundle" \
     "$bundle_dir/ModelRouterTray_ModelRouterTray.bundle"
   cp -R "$binary_dir/ModelRouterTray_ModelRouterTray.bundle" "$bundle_dir/Contents/Resources/"
-  # SwiftPM's generated accessor resolves resources from Bundle.main.bundleURL
-  # (the .app itself) and falls back to the build directory — it never looks in
-  # Contents/Resources. Without this copy the app runs only while .build
-  # survives, and dies with a fatalError once that is cleaned.
-  cp -R "$binary_dir/ModelRouterTray_ModelRouterTray.bundle" "$bundle_dir/"
 fi
-# Keep the checkout relationship as a bundle-owned filesystem link. The tray
-# resolves this link directly instead of parsing a path from file contents and
-# then treating that text as an executable location.
-ln -sfn "$repo_dir" "$bundle_dir/Contents/Resources/router-root"
+# Seal the checkout relationship into Info.plist itself. An external symlink is
+# invalid inside a strict macOS code-signed bundle; a loose text resource would
+# be executable-path input. This value is covered by the final signature, so
+# changing the selected checkout also invalidates verification.
+/usr/libexec/PlistBuddy -c "Add :ModelRouterSourceRoot string $repo_dir" \
+  "$bundle_dir/Contents/Info.plist"
+
+# The copied SwiftPM executable carries an ad-hoc signature. Sign only after
+# every executable, resource, and link is in its final location; mutating the
+# live signed bundle is what produced taskgated "Invalid Page" terminations.
+/usr/bin/codesign --force --deep --sign - "$bundle_dir"
+/usr/bin/codesign --verify --deep --strict "$bundle_dir"
 
 printf '%s\n' "$bundle_dir"

--- a/src/install-plan.mjs
+++ b/src/install-plan.mjs
@@ -7,7 +7,7 @@
 // `.venv/`), so deleting the artifact invalidates the stamp automatically and
 // no state directory has to stay in sync with the checkout.
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -168,7 +168,9 @@ const TRAY_PLATFORMS = {
     },
     artifact: (root, home) =>
       path.join(trayBundleDir("darwin", home), "Contents", "MacOS", "ModelRouterTray"),
-    stamp: (root, home) => path.join(trayBundleDir("darwin", home), "Contents", STAMP_NAME),
+    // The source fingerprint is mutable router state, not an app resource.
+    // Keeping it inside Contents would invalidate the completed bundle seal.
+    stamp: (root, home) => path.join(home, ".codex", "codex-router", "tray-build.json"),
     // Companions built before the per-user move live inside the checkout.
     legacy: (root) =>
       path.join(root, "dist", "Model Router.app", "Contents", "MacOS", "ModelRouterTray"),
@@ -288,10 +290,11 @@ export function recordTrayBuild({
   const definition = TRAY_PLATFORMS[platform];
   if (!definition) throw new Error(`The desktop companion is not built on ${platform}.`);
   const target = definition.stamp(root, home);
+  mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
   writeFileSync(
     target,
     `${JSON.stringify({ version: 1, step: "tray", fingerprint: traySourceFingerprint(root, platform) }, null, 2)}\n`,
-    { encoding: "utf8" },
+    { encoding: "utf8", mode: 0o600 },
   );
   return target;
 }

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -144,20 +144,71 @@ test("one companion location: the Node and shell sides name the same directory",
   assert.doesNotMatch(script, /\$repo_dir\/dist\/Model Router\.app"\}/);
 });
 
-test("the macOS tray never executes control from a text-selected checkout", () => {
+test("the macOS tray is signed only after its resources are assembled", () => {
+  const script = readFileSync(path.join(root, "scripts", "build-macos-tray-app.sh"), "utf8");
+  const resource = script.indexOf('Add :ModelRouterSourceRoot string $repo_dir');
+  const sign = script.indexOf('/usr/bin/codesign --force --deep --sign - "$bundle_dir"');
+  const verify = script.indexOf('/usr/bin/codesign --verify --deep --strict "$bundle_dir"');
+  assert.ok(resource >= 0, "the checkout link must be placed in the bundle");
+  assert.ok(sign > resource, "signing must happen after the final resource write");
+  assert.ok(verify > sign, "the completed signature must be verified");
+  assert.doesNotMatch(
+    script,
+    /cp -R .*ModelRouterTray_ModelRouterTray\.bundle" "\$bundle_dir\/"/,
+    "the SwiftPM resource bundle belongs only under Contents/Resources",
+  );
+});
+
+test("the macOS tray fingerprint stays outside the signed app bundle", () => {
+  const home = scratch();
+  try {
+    installTrayAt(home);
+    const stamp = recordTrayBuild({ root, platform: "darwin", home });
+    assert.equal(stamp, path.join(home, ".codex", "codex-router", "tray-build.json"));
+    assert.doesNotMatch(stamp, /Model Router\.app/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("tray updates stage a signed bundle before stopping and replacing the live app", () => {
+  const script = readFileSync(path.join(root, "bin", "model-router-tray"), "utf8");
+  const build = script.indexOf('build-macos-tray-app.sh" "$staged_bundle"');
+  const stop = script.indexOf("pgrep -x ModelRouterTray");
+  const replace = script.indexOf('mv "$staged_bundle" "$bundle_dir"');
+  assert.match(script, /mktemp -d "\$bundle_parent\/\.model-router-tray\.XXXXXX"/);
+  assert.ok(build >= 0, "the replacement must be built in staging");
+  assert.ok(stop > build, "the old tray stays alive until staging succeeds");
+  assert.ok(replace > stop, "the live bundle is replaced only after its process stops");
+});
+
+test("the macOS tray executes control only from the checkout sealed into Info.plist", () => {
   const source = readFileSync(
     path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),
     "utf8",
   );
   assert.doesNotMatch(source, /MODEL_ROUTER_SOURCE_ROOT/);
-  assert.match(source, /appendingPathComponent\("router-root"/);
+  assert.match(source, /object\(forInfoDictionaryKey: "ModelRouterSourceRoot"\)/);
   assert.doesNotMatch(source, /String\(contentsOf:/);
   assert.doesNotMatch(source, /currentDirectoryPath/);
   assert.match(source, /isExecutableFile\(atPath: control\.path\)/);
 
   const script = readFileSync(path.join(root, "scripts", "build-macos-tray-app.sh"), "utf8");
-  assert.match(script, /ln -sfn "\$repo_dir" "\$bundle_dir\/Contents\/Resources\/router-root"/);
-  assert.doesNotMatch(script, /> "\$bundle_dir\/Contents\/Resources\/router-root"/);
+  assert.match(script, /Add :ModelRouterSourceRoot string \$repo_dir/);
+  assert.doesNotMatch(script, /Contents\/Resources\/router-root/);
+});
+
+test("follow mode rechecks host presence and drains requests before stopping", () => {
+  const source = readFileSync(
+    path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),
+    "utf8",
+  );
+  assert.match(source, /hostAppAbsenceGrace = Duration\.seconds\(30\)/);
+  assert.match(source, /hostAppRecheckInterval = Duration\.seconds\(5\)/);
+  assert.match(source, /guard pendingServiceStop == nil else \{ return \}/);
+  assert.match(source, /activeRequestCount == 0 && activityState == \.idle/);
+  assert.match(source, /self\.refreshHostAppRunning\(\)/);
+  assert.match(source, /runServiceCommand\("stop"\)/);
 });
 
 // Every case names its platform explicitly. Letting it default to


### PR DESCRIPTION
## What changed

- Build and strict-verify the completed macOS tray bundle before installation.
- Stage tray updates outside the live app, then swap atomically only after the replacement verifies.
- Keep SwiftPM resources under `Contents/Resources` and seal the checkout root in `Info.plist`.
- Store the mutable tray fingerprint outside the signed app bundle.
- Make **With Codex** lifecycle detection resilient with a five-second process recheck, a stable 30-second absence debounce, and an active-request drain before stopping the router.
- Recheck host presence immediately before the stop command so a missed launch notification cannot unload an endpoint Codex is using.

## Root cause

The updater overwrote the executable and resources of the running ad-hoc-signed app bundle. macOS subsequently killed the tray with `Code Signature Invalid` / `Invalid Page`. Separately, repeated workspace observations reset or raced the follow-mode shutdown decision, so tray disappearance and endpoint shutdown could strand Codex.

## Impact

The tray can be rebuilt safely without exposing a partially assembled or invalidly signed live bundle. If the tray crashes, launchd restarts it without affecting the router. In **With Codex** mode, the router still shuts down when Codex and ChatGPT are genuinely gone, but transient or missed workspace notifications no longer stop an endpoint that is in use.

## Verification

- `npm run check`
- `npm test`: 953 passed, 0 failed, 7 skipped
- `swift build --package-path apps/macos/ModelRouterTray`
- Focused tray/service tests: 45 passed, 0 failed, 1 skipped
- `codesign --verify --deep --strict ~/Applications/Model\ Router.app`
- Live forced-tray-crash probe: tray PID changed `81995 -> 82298`; router PID remained `53181`; 80/80 health probes returned HTTP 200; final `/health` returned 200.
