### PR TITLE
fix: preserve account native model catalog

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -15,6 +16,7 @@ import {
   ANNOUNCED_MODELS_PATH,
   CONFIG_PATH,
   MERGED_CATALOG_PATH,
+  MODELS_CACHE_PATH,
   NATIVE_ALIAS_PATH,
   NATIVE_CATALOG_PATH,
 } from "./paths.mjs";
@@ -41,7 +43,69 @@ import {
 } from "./native-catalog-source.mjs";
 
 const refresh = process.argv.includes("--refresh-native");
-const bundled = process.argv.includes("--bundled-native");
+
+function validNativeCatalog(parsed) {
+  return parsed && Array.isArray(parsed.models) && parsed.models.length > 0;
+}
+
+// Codex has two native catalogs: the account-aware catalog (`debug models`)
+// and the static catalog shipped in the binary (`--bundled`). Neither is a
+// safe source by itself. The account catalog can add models or change their
+// visibility without a client update, while the bundled catalog can contain a
+// newer schema or models absent from a stale account cache. Preserve the
+// account entry for every shared slug, then append bundled-only entries.
+export function mergeNativeCatalogs(accountCatalog, bundledCatalog) {
+  const account = validNativeCatalog(accountCatalog) ? accountCatalog.models : [];
+  const fallback = validNativeCatalog(bundledCatalog) ? bundledCatalog.models : [];
+  const fallbackBySlug = new Map(
+    fallback.map((model) => [String(model?.slug || ""), model]),
+  );
+  const normalizedAccount = account.map((model) => {
+    const base = fallbackBySlug.get(String(model?.slug || ""));
+    const merged = base ? { ...base, ...model } : { ...model };
+    // The remote cache may omit `base_instructions` because Codex can derive
+    // it internally. A custom model_catalog_json is parsed more strictly and
+    // requires the field, so preserve the same instructions template under
+    // the required spelling for account-only models such as Codex Spark.
+    if (
+      typeof merged.base_instructions !== "string" &&
+      typeof merged.model_messages?.instructions_template === "string"
+    ) {
+      merged.base_instructions = merged.model_messages.instructions_template;
+    }
+    return merged;
+  });
+  const seen = new Set(normalizedAccount.map((model) => String(model?.slug || "")));
+  return {
+    models: [
+      ...normalizedAccount,
+      ...fallback.filter((model) => !seen.has(String(model?.slug || ""))),
+    ],
+  };
+}
+
+function modelsCacheFingerprint() {
+  if (!existsSync(MODELS_CACHE_PATH)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(MODELS_CACHE_PATH, "utf8"));
+    if (!validNativeCatalog(parsed)) return undefined;
+    return createHash("sha256")
+      .update(JSON.stringify(parsed.models))
+      .digest("hex");
+  } catch {
+    return undefined;
+  }
+}
+
+function accountNativeCatalog() {
+  if (!existsSync(MODELS_CACHE_PATH)) return undefined;
+  try {
+    const parsed = JSON.parse(readFileSync(MODELS_CACHE_PATH, "utf8"));
+    return validNativeCatalog(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 function atomicContents(target, contents) {
   mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
@@ -74,26 +138,42 @@ function restoreFileSnapshot(target, snapshot) {
 }
 
 function captureNative() {
-  const args = ["debug", "models"];
-  if (bundled) args.push("--bundled");
-  let output;
-  try {
-    output = runCodex(args, {
-      encoding: "utf8",
-      timeout: 30_000,
-      maxBuffer: 32 * 1024 * 1024,
-    });
-  } catch (error) {
-    if (bundled) throw error;
-    output = runCodex(["debug", "models", "--bundled"], {
-      encoding: "utf8",
-      timeout: 30_000,
-      maxBuffer: 32 * 1024 * 1024,
-    });
+  // This is the account-aware catalog Codex itself cached after signing in.
+  // Reading it directly also avoids asking `codex debug models` while the
+  // router catalog is active, which would merely return our own merged output.
+  let account = accountNativeCatalog();
+  let fallback;
+  let accountError;
+  let fallbackError;
+  if (!account) {
+    try {
+      account = JSON.parse(runCodex(["debug", "models"], {
+        encoding: "utf8",
+        timeout: 30_000,
+        maxBuffer: 32 * 1024 * 1024,
+      }));
+    } catch (error) {
+      accountError = error;
+    }
   }
-  const parsed = JSON.parse(output);
-  if (!parsed || !Array.isArray(parsed.models) || parsed.models.length === 0) {
-    throw new Error("Codex returned an empty or invalid model catalog.");
+  // The bundled source supplies schema fields that the remote cache is allowed
+  // to omit, so use both when available. If it fails, account-only entries are
+  // still normalized above and remain preferable to an empty picker.
+  try {
+    fallback = JSON.parse(runCodex(["debug", "models", "--bundled"], {
+      encoding: "utf8",
+      timeout: 30_000,
+      maxBuffer: 32 * 1024 * 1024,
+    }));
+  } catch (error) {
+    fallbackError = error;
+  }
+  const parsed = mergeNativeCatalogs(account, fallback);
+  if (!validNativeCatalog(parsed)) {
+    const detail = accountError?.message || fallbackError?.message;
+    throw new Error(
+      `Codex returned no valid native model catalog${detail ? ` (${detail})` : ""}.`,
+    );
   }
   if (parsed.models.some((model) => MODEL_BY_SLUG.has(String(model.slug)))) {
     throw new Error(
@@ -101,8 +181,10 @@ function captureNative() {
     );
   }
   const capturedWith = codexVersion();
+  const sourceFingerprint = modelsCacheFingerprint();
   atomicJson(NATIVE_CATALOG_PATH, {
     ...(capturedWith ? { captured_with: capturedWith } : {}),
+    ...(sourceFingerprint ? { native_source_fingerprint: sourceFingerprint } : {}),
     models: parsed.models,
   });
   return parsed;
@@ -113,11 +195,22 @@ function captureNative() {
 // carry different capability values for the same slug. An unknown current
 // version keeps the cache — with no binary to re-ask, stale is the best we
 // have.
-export function nativeCatalogIsReusable(parsed, currentVersion) {
+export function nativeCatalogIsReusable(
+  parsed,
+  currentVersion,
+  currentSourceFingerprint = undefined,
+) {
   if (!parsed || !Array.isArray(parsed.models) || parsed.models.length === 0) {
     return false;
   }
-  return !currentVersion || parsed.captured_with === currentVersion;
+  if (currentVersion && parsed.captured_with !== currentVersion) return false;
+  if (
+    currentSourceFingerprint &&
+    parsed.native_source_fingerprint !== currentSourceFingerprint
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function nativeCatalog() {
@@ -133,7 +226,11 @@ function nativeCatalog() {
   }
   if (!existsSync(NATIVE_CATALOG_PATH) || refresh) return captureNative();
   const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
-  if (nativeCatalogIsReusable(parsed, codexVersion())) return parsed;
+  if (
+    nativeCatalogIsReusable(parsed, codexVersion(), modelsCacheFingerprint())
+  ) {
+    return parsed;
+  }
   try {
     return captureNative();
   } catch (error) {

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -48,34 +48,59 @@ function validNativeCatalog(parsed) {
   return parsed && Array.isArray(parsed.models) && parsed.models.length > 0;
 }
 
+// The account cache stores the raw instruction template while the bundled
+// catalog ships `base_instructions` with the template variables already
+// substituted: for every shared slug that carries variables, the bundled
+// `base_instructions` equals the account template with `{{ personality }}`
+// replaced by `instructions_variables.personality_default`. Mirror that
+// substitution — and strip any placeholder without a default — so a literal
+// `{{ ... }}` token can never reach a model's system prompt.
+const INSTRUCTION_PLACEHOLDER = /\{\{\s*([\w.-]+)\s*\}\}/g;
+
+export function deriveBaseInstructions(modelMessages) {
+  const template = modelMessages?.instructions_template;
+  if (typeof template !== "string") return undefined;
+  const variables = modelMessages?.instructions_variables;
+  const substituted = template.replace(INSTRUCTION_PLACEHOLDER, (_token, name) => {
+    const fallback = variables?.[`${name}_default`];
+    return typeof fallback === "string" ? fallback : "";
+  });
+  // A default could itself contain a placeholder; the guarantee is that none
+  // survive, not that substitution is recursive.
+  return substituted.replace(INSTRUCTION_PLACEHOLDER, "");
+}
+
 // Codex has two native catalogs: the account-aware catalog (`debug models`)
 // and the static catalog shipped in the binary (`--bundled`). Neither is a
 // safe source by itself. The account catalog can add models or change their
 // visibility without a client update, while the bundled catalog can contain a
 // newer schema or models absent from a stale account cache. Preserve the
-// account entry for every shared slug, then append bundled-only entries.
+// account entry for every slug it lists (first occurrence wins on a
+// duplicate), then append bundled-only entries.
 export function mergeNativeCatalogs(accountCatalog, bundledCatalog) {
   const account = validNativeCatalog(accountCatalog) ? accountCatalog.models : [];
   const fallback = validNativeCatalog(bundledCatalog) ? bundledCatalog.models : [];
   const fallbackBySlug = new Map(
     fallback.map((model) => [String(model?.slug || ""), model]),
   );
-  const normalizedAccount = account.map((model) => {
-    const base = fallbackBySlug.get(String(model?.slug || ""));
+  const normalizedAccount = [];
+  const seen = new Set();
+  for (const model of account) {
+    const slug = String(model?.slug || "");
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    const base = fallbackBySlug.get(slug);
     const merged = base ? { ...base, ...model } : { ...model };
     // The remote cache may omit `base_instructions` because Codex can derive
     // it internally. A custom model_catalog_json is parsed more strictly and
-    // requires the field, so preserve the same instructions template under
-    // the required spelling for account-only models such as Codex Spark.
-    if (
-      typeof merged.base_instructions !== "string" &&
-      typeof merged.model_messages?.instructions_template === "string"
-    ) {
-      merged.base_instructions = merged.model_messages.instructions_template;
+    // requires the field, so derive it the same way for account-only models
+    // such as Codex Spark.
+    if (typeof merged.base_instructions !== "string") {
+      const derived = deriveBaseInstructions(merged.model_messages);
+      if (typeof derived === "string") merged.base_instructions = derived;
     }
-    return merged;
-  });
-  const seen = new Set(normalizedAccount.map((model) => String(model?.slug || "")));
+    normalizedAccount.push(merged);
+  }
   return {
     models: [
       ...normalizedAccount,
@@ -84,26 +109,22 @@ export function mergeNativeCatalogs(accountCatalog, bundledCatalog) {
   };
 }
 
-function modelsCacheFingerprint() {
-  if (!existsSync(MODELS_CACHE_PATH)) return undefined;
+// One read serves both the catalog contents and the fingerprint; reading the
+// file twice would hash a possibly different snapshot than the one merged.
+function readModelsCache() {
+  const missing = { catalog: undefined, fingerprint: undefined };
+  if (!existsSync(MODELS_CACHE_PATH)) return missing;
   try {
     const parsed = JSON.parse(readFileSync(MODELS_CACHE_PATH, "utf8"));
-    if (!validNativeCatalog(parsed)) return undefined;
-    return createHash("sha256")
-      .update(JSON.stringify(parsed.models))
-      .digest("hex");
+    if (!validNativeCatalog(parsed)) return missing;
+    return {
+      catalog: parsed,
+      fingerprint: createHash("sha256")
+        .update(JSON.stringify(parsed.models))
+        .digest("hex"),
+    };
   } catch {
-    return undefined;
-  }
-}
-
-function accountNativeCatalog() {
-  if (!existsSync(MODELS_CACHE_PATH)) return undefined;
-  try {
-    const parsed = JSON.parse(readFileSync(MODELS_CACHE_PATH, "utf8"));
-    return validNativeCatalog(parsed) ? parsed : undefined;
-  } catch {
-    return undefined;
+    return missing;
   }
 }
 
@@ -137,11 +158,11 @@ function restoreFileSnapshot(target, snapshot) {
   }
 }
 
-function captureNative() {
+function captureNative(cache = readModelsCache()) {
   // This is the account-aware catalog Codex itself cached after signing in.
   // Reading it directly also avoids asking `codex debug models` while the
   // router catalog is active, which would merely return our own merged output.
-  let account = accountNativeCatalog();
+  let account = cache.catalog;
   let fallback;
   let accountError;
   let fallbackError;
@@ -181,7 +202,7 @@ function captureNative() {
     );
   }
   const capturedWith = codexVersion();
-  const sourceFingerprint = modelsCacheFingerprint();
+  const sourceFingerprint = cache.fingerprint;
   atomicJson(NATIVE_CATALOG_PATH, {
     ...(capturedWith ? { captured_with: capturedWith } : {}),
     ...(sourceFingerprint ? { native_source_fingerprint: sourceFingerprint } : {}),
@@ -224,15 +245,14 @@ function nativeCatalog() {
     }
     return catalog;
   }
-  if (!existsSync(NATIVE_CATALOG_PATH) || refresh) return captureNative();
+  const cache = readModelsCache();
+  if (!existsSync(NATIVE_CATALOG_PATH) || refresh) return captureNative(cache);
   const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
-  if (
-    nativeCatalogIsReusable(parsed, codexVersion(), modelsCacheFingerprint())
-  ) {
+  if (nativeCatalogIsReusable(parsed, codexVersion(), cache.fingerprint)) {
     return parsed;
   }
   try {
-    return captureNative();
+    return captureNative(cache);
   } catch (error) {
     // Version-mismatched is still better than empty: serve the stale capture
     // when the re-capture fails, but say so instead of hiding it.

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -40,6 +40,7 @@ function managedStateDir() {
 export const STATE_DIR = process.env.MODEL_ROUTER_STATE_DIR || managedStateDir();
 export const LEGACY_STATE_DIR = path.join(CODEX_HOME, "kimi-router");
 export const CONFIG_PATH = path.join(CODEX_HOME, "config.toml");
+export const MODELS_CACHE_PATH = path.join(CODEX_HOME, "models_cache.json");
 export const CODEX_AGENTS_DIR = path.join(CODEX_HOME, "agents");
 export const NATIVE_CATALOG_PATH = path.join(STATE_DIR, "native-models.json");
 export const NATIVE_CATALOG_SOURCE_PATH = path.join(

--- a/src/refresh-catalog.mjs
+++ b/src/refresh-catalog.mjs
@@ -47,7 +47,7 @@ export function refreshCatalog({ run = nodeRunner } = {}) {
       checked(run, "config-manager.mjs", ["disable"]);
       restoreNeeded = true;
     }
-    catalogResult = checked(run, "catalog.mjs", ["--refresh-native", "--bundled-native"]);
+    catalogResult = checked(run, "catalog.mjs", ["--refresh-native"]);
     if (restoreNeeded) {
       restoreTransport(run, signed);
       restoreNeeded = false;

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -18,6 +18,7 @@ import {
   clampModelEfforts,
   codexEffortVocabulary,
   nativeCatalogIsReusable,
+  mergeNativeCatalogs,
   promoteNativeMultiAgent,
   routedCatalogConfigured,
   routedModel,
@@ -553,10 +554,23 @@ test("models stay untouched when the installed build understands their efforts",
 });
 
 test("native catalog cache is reusable only for the codex build that captured it", () => {
-  const captured = { captured_with: "codex-cli 0.142.5", models: [template] };
+  const captured = {
+    captured_with: "codex-cli 0.142.5",
+    native_source_fingerprint: "account-a",
+    models: [template],
+  };
 
   assert.equal(nativeCatalogIsReusable(captured, "codex-cli 0.142.5"), true);
   assert.equal(nativeCatalogIsReusable(captured, "codex-cli 0.146.1"), false);
+  // Account catalogs change independently of the binary version.
+  assert.equal(
+    nativeCatalogIsReusable(captured, "codex-cli 0.142.5", "account-b"),
+    false,
+  );
+  assert.equal(
+    nativeCatalogIsReusable(captured, "codex-cli 0.142.5", "account-a"),
+    true,
+  );
   // Unknown current version: no binary to re-ask, so keep what we have.
   assert.equal(nativeCatalogIsReusable(captured, undefined), true);
   // Un-stamped caches predate version tracking; re-capture when we can ask.
@@ -565,6 +579,67 @@ test("native catalog cache is reusable only for the codex build that captured it
   // Invalid or empty caches are never reusable.
   assert.equal(nativeCatalogIsReusable(undefined, undefined), false);
   assert.equal(nativeCatalogIsReusable({ models: [] }, "codex-cli 0.146.1"), false);
+});
+
+test("native catalog merge preserves account visibility and bundled-only models", () => {
+  const accountMini = {
+    slug: "gpt-mini",
+    visibility: "list",
+    source: "account",
+    model_messages: { instructions_template: "account instructions" },
+  };
+  const merged = mergeNativeCatalogs(
+    {
+      models: [
+        accountMini,
+        {
+          slug: "gpt-spark",
+          visibility: "list",
+          model_messages: { instructions_template: "spark instructions" },
+        },
+      ],
+    },
+    {
+      models: [
+        {
+          slug: "gpt-mini",
+          visibility: "hide",
+          source: "bundled",
+          base_instructions: "bundled instructions",
+        },
+        { slug: "gpt-bundled-only", visibility: "list" },
+      ],
+    },
+  );
+  assert.deepEqual(merged.models, [
+    {
+      ...accountMini,
+      base_instructions: "bundled instructions",
+    },
+    {
+      slug: "gpt-spark",
+      visibility: "list",
+      model_messages: { instructions_template: "spark instructions" },
+      base_instructions: "spark instructions",
+    },
+    { slug: "gpt-bundled-only", visibility: "list" },
+  ]);
+});
+
+test("account-only models satisfy the strict custom-catalog instruction schema", () => {
+  const [spark] = mergeNativeCatalogs(
+    {
+      models: [
+        {
+          slug: "gpt-spark",
+          visibility: "list",
+          model_messages: { instructions_template: "spark instructions" },
+        },
+      ],
+    },
+    { models: [{ slug: "other", base_instructions: "other instructions" }] },
+  ).models;
+  assert.equal(spark.base_instructions, "spark instructions");
 });
 
 test("native listed models follow the local subagent opt-in", () => {

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -18,6 +18,7 @@ import {
   clampModelEfforts,
   codexEffortVocabulary,
   nativeCatalogIsReusable,
+  deriveBaseInstructions,
   mergeNativeCatalogs,
   promoteNativeMultiAgent,
   routedCatalogConfigured,
@@ -640,6 +641,85 @@ test("account-only models satisfy the strict custom-catalog instruction schema",
     { models: [{ slug: "other", base_instructions: "other instructions" }] },
   ).models;
   assert.equal(spark.base_instructions, "spark instructions");
+});
+
+// The bundled catalog's base_instructions equals the account template with
+// `{{ personality }}` replaced by `instructions_variables.personality_default`
+// (verified against codex-cli for gpt-5.4, gpt-5.4-mini, and gpt-5.5).
+// Account-only models must get the same treatment: the literal placeholder
+// must never reach a system prompt.
+test("derived base_instructions substitutes template variable defaults", () => {
+  assert.equal(
+    deriveBaseInstructions({
+      instructions_template: "You are Codex.\n{{ personality }}\nBe fast.",
+      instructions_variables: {
+        personality_default: "# Personality\nStay neutral.",
+        personality_friendly: "# Personality\nBe warm.",
+      },
+    }),
+    "You are Codex.\n# Personality\nStay neutral.\nBe fast.",
+  );
+  // No default for the placeholder: strip it rather than leaking the token.
+  assert.equal(
+    deriveBaseInstructions({
+      instructions_template: "Intro {{ tone }} outro.",
+      instructions_variables: {},
+    }),
+    "Intro  outro.",
+  );
+  assert.equal(
+    deriveBaseInstructions({ instructions_template: "plain" }),
+    "plain",
+  );
+  assert.equal(deriveBaseInstructions(undefined), undefined);
+});
+
+test("no template placeholder survives into any merged base_instructions", () => {
+  const merged = mergeNativeCatalogs(
+    {
+      models: [
+        {
+          slug: "gpt-spark",
+          model_messages: {
+            instructions_template: "Spark. {{ personality }} End.",
+            instructions_variables: { personality_default: "Calm." },
+          },
+        },
+        {
+          slug: "gpt-undefaulted",
+          model_messages: {
+            instructions_template: "Head {{ mystery }} tail.",
+            instructions_variables: {
+              // A default may itself carry a placeholder; it must be stripped,
+              // not substituted recursively.
+              mystery_default: "nested {{ personality }} token",
+            },
+          },
+        },
+      ],
+    },
+    undefined,
+  );
+  for (const model of merged.models) {
+    assert.equal(typeof model.base_instructions, "string");
+    assert.doesNotMatch(model.base_instructions, /\{\{[\s\S]*?\}\}/);
+  }
+  assert.equal(merged.models[0].base_instructions, "Spark. Calm. End.");
+});
+
+test("duplicate account slugs collapse to the first occurrence", () => {
+  const merged = mergeNativeCatalogs(
+    {
+      models: [
+        { slug: "gpt-dupe", visibility: "list", base_instructions: "first" },
+        { slug: "gpt-dupe", visibility: "hide", base_instructions: "second" },
+      ],
+    },
+    { models: [{ slug: "gpt-dupe", base_instructions: "bundled" }] },
+  );
+  assert.equal(merged.models.length, 1);
+  assert.equal(merged.models[0].base_instructions, "first");
+  assert.equal(merged.models[0].visibility, "list");
 });
 
 test("native listed models follow the local subagent opt-in", () => {

--- a/test/doctor-routing-mode.test.mjs
+++ b/test/doctor-routing-mode.test.mjs
@@ -100,7 +100,7 @@ wire_api = "responses"
     };
 
     try {
-      const catalog = child("catalog.mjs", ["--refresh-native", "--bundled-native"], env);
+      const catalog = child("catalog.mjs", ["--refresh-native"], env);
       assert.equal(catalog.status, 0, catalog.stderr);
       assert.equal(JSON.parse(catalog.stdout).routed_catalog_active, false);
 

--- a/test/refresh-catalog.test.mjs
+++ b/test/refresh-catalog.test.mjs
@@ -35,7 +35,7 @@ test("refresh orchestration restores signed routing and republishes the routed c
   assert.deepEqual(runner.calls, [
     ["config-manager.mjs", ["status"]],
     ["config-manager.mjs", ["disable"]],
-    ["catalog.mjs", ["--refresh-native", "--bundled-native"]],
+    ["catalog.mjs", ["--refresh-native"]],
     ["config-manager.mjs", ["enable"]],
     ["config-manager.mjs", ["signed-enable"]],
     ["catalog.mjs", []],
@@ -52,7 +52,7 @@ test("refresh orchestration restores the active transport after catalog failure"
   assert.deepEqual(runner.calls, [
     ["config-manager.mjs", ["status"]],
     ["config-manager.mjs", ["disable"]],
-    ["catalog.mjs", ["--refresh-native", "--bundled-native"]],
+    ["catalog.mjs", ["--refresh-native"]],
     ["config-manager.mjs", ["enable"]],
     ["config-manager.mjs", ["signed-enable"]],
     ["catalog.mjs", []],
@@ -65,7 +65,7 @@ test("ordinary routed refresh also republishes external models after restore", (
   assert.deepEqual(runner.calls, [
     ["config-manager.mjs", ["status"]],
     ["config-manager.mjs", ["disable"]],
-    ["catalog.mjs", ["--refresh-native", "--bundled-native"]],
+    ["catalog.mjs", ["--refresh-native"]],
     ["config-manager.mjs", ["enable"]],
     ["catalog.mjs", []],
   ]);


### PR DESCRIPTION
## What changed

- capture the account-aware native model catalog from Codex's local `models_cache.json`
- merge it with the bundled catalog so account visibility and account-only models win while bundled schema fields and bundled-only models remain available
- derive `base_instructions` from the account catalog's instruction template when the strict custom-catalog schema requires it
- fingerprint the account model list so server-side catalog changes invalidate the saved native snapshot even when the Codex binary version is unchanged
- cover account visibility, bundled fallback, account-only models, and cache invalidation with tests

## Why

The install and refresh paths currently request `--bundled-native`. The bundled catalog can lag the signed-in account catalog: in practice it marked `gpt-5.4-mini` hidden and omitted `gpt-5.3-codex-spark`, so enabling the router made native models disappear from the picker.

This is not picker-slot competition. `model_catalog_json` replaces the catalog Codex reads, so the router must preserve the signed-in account's native model list and use the bundled catalog only as a schema and availability fallback.

## Impact

Native account models remain visible alongside routed external models. Existing provider routing, native GPT authentication, vision bridging, and provider credential isolation are unchanged.

## Validation

- `npm run check`
- `node --test test/catalog.test.mjs test/refresh-catalog.test.mjs` — 38 passed
- live catalog refresh and `doctor` on macOS — all core checks passed
- verified the resulting picker catalog lists `gpt-5.4-mini`, `gpt-5.3-codex-spark`, and routed models together

The complete `npm test` run reported 897 passed, 2 failed, and 6 skipped. The two failures are unrelated/environmental: a Kimi OAuth temporary-directory cleanup race that passes in isolation, and a POSIX hidden-prompt test that requires a real interactive TTY and also fails on an untouched checkout.
