### PR TITLE
feat(tray): add custom model orchestrator mode control

### DIFF
--- a/apps/macos/ModelRouterTray/Package.swift
+++ b/apps/macos/ModelRouterTray/Package.swift
@@ -13,5 +13,10 @@ let package = Package(
       path: "Sources",
       resources: [.process("Resources")]
     ),
+    .testTarget(
+      name: "ModelRouterTrayTests",
+      dependencies: ["ModelRouterTray"],
+      path: "Tests"
+    ),
   ],
 )

--- a/apps/macos/ModelRouterTray/Resources/Info.plist
+++ b/apps/macos/ModelRouterTray/Resources/Info.plist
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
   <key>CFBundleDisplayName</key>
-  <string>Model Router</string>
+  <string>Open Router Model Router</string>
   <key>CFBundleExecutable</key>
   <string>ModelRouterTray</string>
   <key>CFBundleIdentifier</key>
   <string>io.github.codex-router.tray</string>
   <key>CFBundleName</key>
-  <string>Model Router</string>
+  <string>Open Router Model Router</string>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleShortVersionString</key>

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -56,6 +56,152 @@ enum RouterActivityState: String, Decodable {
   }
 }
 
+
+enum CodexMode: String {
+  case customModel
+  case chatGPT
+}
+
+struct CodexModeController {
+  private static let routerProviderLine = "model_provider = \"codex-router\""
+  private static let managedBlockBegin = "# BEGIN codex-router-managed"
+  private static let managedBlockEnd = "# END codex-router-managed"
+  private static let flashSubagentLine = "default_subagent_model = \"opencode-go/deepseek-v4-flash\""
+
+  enum ConfigurationError: LocalizedError {
+    case duplicateManagedBlock
+    case missingModel
+    case incompleteRouterConfiguration
+    case missingManagedBlockSource
+
+    var errorDescription: String? {
+      switch self {
+      case .duplicateManagedBlock:
+        return "Codex configuration contains duplicate router-managed blocks."
+      case .missingModel:
+        return "Codex configuration must include a model setting."
+      case .incompleteRouterConfiguration:
+        return "The codex-router provider requires its managed configuration block."
+      case .missingManagedBlockSource:
+        return "Could not find the local router-managed configuration block."
+      }
+    }
+  }
+
+  static func mode(from config: String) -> CodexMode {
+    config.contains(routerProviderLine) ? .customModel : .chatGPT
+  }
+
+  static func replacingRouterBlock(in config: String, enabled: Bool) throws -> String {
+    try validated(config)
+
+    var result = removeManagedBlock(from: config)
+    result = removeRouterProvider(from: result)
+
+    guard enabled else { return normalize(result) }
+
+    result = replaceSubagentModel(in: result)
+    let managedBlock = try managedBlockFromLocalConfiguration()
+    result = normalize(result)
+    if !result.isEmpty { result += "\n" }
+    result += routerProviderLine + "\n" + managedBlock
+    try validated(result)
+    return normalize(result)
+  }
+
+  static func validated(_ config: String) throws {
+    let begins = config.components(separatedBy: managedBlockBegin).count - 1
+    let ends = config.components(separatedBy: managedBlockEnd).count - 1
+    guard begins <= 1, ends <= 1, begins == ends else {
+      throw ConfigurationError.duplicateManagedBlock
+    }
+    guard containsSetting(named: "model", in: config) else {
+      throw ConfigurationError.missingModel
+    }
+    if mode(from: config) == .customModel && begins != 1 {
+      throw ConfigurationError.incompleteRouterConfiguration
+    }
+  }
+
+  private static func removeManagedBlock(from config: String) -> String {
+    guard let begin = config.range(of: managedBlockBegin),
+          let end = config.range(of: managedBlockEnd, range: begin.upperBound..<config.endIndex)
+    else { return config }
+
+    var lowerBound = begin.lowerBound
+    if lowerBound > config.startIndex,
+       config[config.index(before: lowerBound)] == "\n" {
+      lowerBound = config.index(before: lowerBound)
+    }
+    var upperBound = end.upperBound
+    if upperBound < config.endIndex, config[upperBound] == "\n" {
+      upperBound = config.index(after: upperBound)
+    }
+    var result = config
+    result.removeSubrange(lowerBound..<upperBound)
+    return result
+  }
+
+  private static func removeRouterProvider(from config: String) -> String {
+    config
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .filter { line in line.trimmingCharacters(in: .whitespaces) != routerProviderLine }
+      .joined(separator: "\n")
+  }
+
+  private static func replaceSubagentModel(in config: String) -> String {
+    let lines = config.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    var replaced = false
+    let result = lines.map { line -> String in
+      guard line.trimmingCharacters(in: .whitespaces).hasPrefix("default_subagent_model =") else {
+        return line
+      }
+      replaced = true
+      return flashSubagentLine
+    }
+    return replaced ? result.joined(separator: "\n") : config + (config.hasSuffix("\n") ? "" : "\n") + flashSubagentLine
+  }
+
+  private static func containsSetting(named name: String, in config: String) -> Bool {
+    config.split(separator: "\n", omittingEmptySubsequences: false).contains { line in
+      line.trimmingCharacters(in: .whitespaces).hasPrefix("\(name) =")
+    }
+  }
+
+  private static func managedBlockFromLocalConfiguration() throws -> String {
+    let fileManager = FileManager.default
+    let codexDirectory = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
+    let filenames = (try? fileManager.contentsOfDirectory(atPath: codexDirectory.path)) ?? []
+    let candidates = filenames
+      .filter { $0 == "config.toml" || $0.hasPrefix("config.toml.router-disabled-backup-") }
+      .sorted(by: >)
+      .map { codexDirectory.appendingPathComponent($0) }
+
+    for candidate in candidates {
+      guard let configuration = try? String(contentsOf: candidate, encoding: .utf8),
+            let block = extractManagedBlock(from: configuration)
+      else { continue }
+      return block
+    }
+    throw ConfigurationError.missingManagedBlockSource
+  }
+
+  private static func extractManagedBlock(from config: String) -> String? {
+    guard let begin = config.range(of: managedBlockBegin),
+          let end = config.range(of: managedBlockEnd, range: begin.upperBound..<config.endIndex)
+    else { return nil }
+    return String(config[begin.lowerBound...end.upperBound])
+  }
+
+  private static func normalize(_ config: String) -> String {
+    config
+      .split(separator: "\n", omittingEmptySubsequences: false)
+      .drop { $0.isEmpty }
+      .joined(separator: "\n")
+      .trimmingCharacters(in: .newlines) + "\n"
+  }
+}
+
 @main
 struct ModelRouterTrayApp: App {
   @NSApplicationDelegateAdaptor private var appDelegate: AppDelegate

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -1757,7 +1757,7 @@ final class RouterStore: ObservableObject {
   }
 
   private func refreshActivity() async {
-    let configuredPort = ProcessInfo.processInfo.environment["MODEL_ROUTER_PORT"] ?? "4202"
+    let configuredPort = ProcessInfo.processInfo.environment["MODEL_ROUTER_PORT"] ?? "4102"
     guard let url = URL(string: "http://127.0.0.1:\(configuredPort)/health") else {
       recordActivityHealthFailure()
       return

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -78,6 +78,8 @@ struct CodexModeController {
     case missingModel
     case incompleteRouterConfiguration
     case missingManagedBlockSource
+    case unavailableRouterTarget
+    case routerModeMismatch
 
     var errorDescription: String? {
       switch self {
@@ -89,12 +91,28 @@ struct CodexModeController {
         return "The codex-router provider requires its managed configuration block."
       case .missingManagedBlockSource:
         return "Could not find the local router-managed configuration block."
+      case .unavailableRouterTarget:
+        return "Router status did not include the Codex target."
+      case .routerModeMismatch:
+        return "Router status did not confirm the selected Codex mode."
       }
     }
   }
 
   static func mode(from config: String) -> CodexMode {
     config.contains(routerProviderLine) ? .customModel : .chatGPT
+  }
+
+
+  static func verifyRouterStatus(_ status: RouterSnapshot, expected mode: CodexMode) throws {
+    guard let target = status.targets["codex"] else {
+      throw ConfigurationError.unavailableRouterTarget
+    }
+    // Custom mode is only ready after the Codex target is live; ChatGPT mode
+    // must have released that target. A zero-exit stale status is not success.
+    guard target.active == (mode == .customModel) else {
+      throw ConfigurationError.routerModeMismatch
+    }
   }
 
   static func replacingRouterBlock(in config: String, enabled: Bool) throws -> String {
@@ -535,7 +553,9 @@ final class RouterStore: ObservableObject {
       guard CodexModeController.mode(from: written) == mode else {
         throw RouterError("Codex configuration did not retain the selected mode.")
       }
-      _ = try await runControl(arguments: ["--json"])
+      let statusOutput = try await runControl(arguments: ["--json"])
+      let routerStatus = try JSONDecoder().decode(RouterSnapshot.self, from: statusOutput)
+      try CodexModeController.verifyRouterStatus(routerStatus, expected: mode)
       codexMode = mode
       await refresh()
       message = mode == .customModel

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -104,13 +104,20 @@ struct CodexModeController {
   }
 
 
-  static func verifyRouterStatus(_ status: RouterSnapshot, expected mode: CodexMode) throws {
-    guard let target = status.targets["codex"] else {
+  static func verifyRouterStatus(
+    _ status: RouterSnapshot,
+    serviceStatus: RouterServiceStatus,
+    expected mode: CodexMode
+  ) throws {
+    guard let target = status.targets["codex"], target.target == "codex" else {
       throw ConfigurationError.unavailableRouterTarget
     }
-    // Custom mode is only ready after the Codex target is live; ChatGPT mode
-    // must have released that target. A zero-exit stale status is not success.
-    guard target.active == (mode == .customModel) else {
+    // `active` means the LaunchAgent is installed or loaded, so an intentionally
+    // stopped service still reports active. Check the service state separately.
+    let serviceIsRunning = serviceStatus.state != "stopped"
+    guard serviceIsRunning == (mode == .customModel),
+          mode != .customModel || target.active
+    else {
       throw ConfigurationError.routerModeMismatch
     }
   }
@@ -539,13 +546,15 @@ final class RouterStore: ObservableObject {
       failedAction = "write Codex configuration"
       try atomicallyReplaceCodexConfig(at: configURL, with: Data(replacement.utf8))
 
-      failedAction = mode == .customModel ? "start the router service" : "disable router mode"
+      failedAction = mode == .customModel ? "start the router service" : "stop router mode"
       if mode == .customModel {
         _ = try await runControl(arguments: ["service", "start"])
         failedAction = "apply router mode to Codex"
         _ = try await runControl(arguments: ["apply", "--targets", "codex", "--activate"])
       } else {
-        _ = try await runControl(arguments: ["disable"])
+        // Keep the launch agent installed so the tray remains available; stop
+        // the router process with the supported service command instead.
+        _ = try await runControl(arguments: ["service", "stop"])
       }
 
       failedAction = "verify the selected mode"
@@ -555,7 +564,10 @@ final class RouterStore: ObservableObject {
       }
       let statusOutput = try await runControl(arguments: ["--json"])
       let routerStatus = try JSONDecoder().decode(RouterSnapshot.self, from: statusOutput)
-      try CodexModeController.verifyRouterStatus(routerStatus, expected: mode)
+      let serviceOutput = try await runControl(arguments: ["service", "status"])
+      let serviceStatus = try JSONDecoder().decode(RouterServiceStatus.self, from: serviceOutput)
+      try CodexModeController.verifyRouterStatus(
+        routerStatus, serviceStatus: serviceStatus, expected: mode)
       codexMode = mode
       await refresh()
       message = mode == .customModel
@@ -2021,6 +2033,13 @@ private struct RouterError: LocalizedError {
 struct RouterSnapshot: Decodable {
   let targets: [String: RouterTarget]
   static let empty = RouterSnapshot(targets: [:])
+}
+
+
+struct RouterServiceStatus: Decodable {
+  let installed: Bool
+  let loaded: Bool
+  let state: String
 }
 
 enum UsageRange: Int, CaseIterable, Identifiable {

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -306,6 +306,8 @@ final class RouterStore: ObservableObject {
   @Published private(set) var presenceMode: TrayPresenceMode
   @Published private(set) var hostAppRunning = false
   @Published private(set) var surfacesVisible = true
+  @Published private(set) var codexMode: CodexMode
+  @Published private(set) var modeOperation: String?
 
   private var polling = false
   private var activityPolling = false
@@ -384,6 +386,15 @@ final class RouterStore: ObservableObject {
 
   init() {
     selectedUsageProviderID = "openai"
+    // Keep the switch read-only until a mode change is explicitly requested.
+    // A missing or unreadable config is treated as native ChatGPT mode.
+    let configURL = FileManager.default.homeDirectoryForCurrentUser
+      .appendingPathComponent(".codex/config.toml")
+    if let config = try? String(contentsOf: configURL, encoding: .utf8) {
+      codexMode = CodexModeController.mode(from: config)
+    } else {
+      codexMode = .chatGPT
+    }
     if let raw = defaults.string(forKey: islandModeKey), let mode = IslandMode(rawValue: raw) {
       islandMode = mode
     } else if defaults.object(forKey: islandVisibilityKey) == nil {
@@ -476,6 +487,104 @@ final class RouterStore: ObservableObject {
     // button into a full repair.
     persistPresenceMode(mode)
     reconcileService()
+  }
+
+
+  /// Switches only the router-owned portion of Codex configuration. The original
+  /// file is copied before any mutation so native ChatGPT credentials remain
+  /// untouched and every failed transition can be restored atomically.
+  func setCodexMode(_ mode: CodexMode) async {
+    guard modeOperation == nil, mode != codexMode else { return }
+    modeOperation = mode == .customModel ? "Enabling custom model mode" : "Restoring ChatGPT mode"
+    defer { modeOperation = nil }
+
+    let fileManager = FileManager.default
+    let codexDirectory = fileManager.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
+    let configURL = codexDirectory.appendingPathComponent("config.toml")
+    var snapshot: Data?
+    var failedAction = "read Codex configuration"
+
+    do {
+      let original = try String(contentsOf: configURL, encoding: .utf8)
+      snapshot = Data(original.utf8)
+      let backupDirectory = codexDirectory.appendingPathComponent("router-mode-backups", isDirectory: true)
+      try fileManager.createDirectory(at: backupDirectory, withIntermediateDirectories: true)
+      let timestamp = Self.modeBackupTimestamp.string(from: .now)
+      let backupURL = backupDirectory.appendingPathComponent("config.toml.\(timestamp)-\(UUID().uuidString).toml")
+      try snapshot!.write(to: backupURL, options: .atomic)
+      try fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: backupURL.path)
+
+      failedAction = "prepare the selected configuration"
+      let replacement = try CodexModeController.replacingRouterBlock(in: original, enabled: mode == .customModel)
+      try CodexModeController.validated(replacement)
+
+      failedAction = "write Codex configuration"
+      try atomicallyReplaceCodexConfig(at: configURL, with: Data(replacement.utf8))
+
+      failedAction = mode == .customModel ? "start the router service" : "disable router mode"
+      if mode == .customModel {
+        _ = try await runControl(arguments: ["service", "start"])
+        failedAction = "apply router mode to Codex"
+        _ = try await runControl(arguments: ["apply", "--targets", "codex", "--activate"])
+      } else {
+        _ = try await runControl(arguments: ["disable"])
+      }
+
+      failedAction = "verify the selected mode"
+      let written = try String(contentsOf: configURL, encoding: .utf8)
+      guard CodexModeController.mode(from: written) == mode else {
+        throw RouterError("Codex configuration did not retain the selected mode.")
+      }
+      _ = try await runControl(arguments: ["--json"])
+      codexMode = mode
+      await refresh()
+      message = mode == .customModel
+        ? "Custom model mode enabled. Fully quit and reopen Codex when ready."
+        : "ChatGPT mode restored. Fully quit and reopen Codex when ready."
+    } catch {
+      let transitionError = error
+      if let snapshot {
+        do {
+          try atomicallyReplaceCodexConfig(at: configURL, with: snapshot)
+          if let restored = try? String(contentsOf: configURL, encoding: .utf8) {
+            codexMode = CodexModeController.mode(from: restored)
+          }
+          if codexMode == .customModel {
+            _ = try? await runControl(arguments: ["service", "start"])
+          }
+        } catch {
+          message = "Failed to \(failedAction): \(transitionError.localizedDescription). Could not restore the original Codex configuration: \(error.localizedDescription)"
+          await refresh()
+          return
+        }
+      }
+      await refresh()
+      message = snapshot == nil
+        ? "Failed to \(failedAction): \(transitionError.localizedDescription). No Codex configuration was changed."
+        : "Failed to \(failedAction): \(transitionError.localizedDescription). Original Codex configuration was restored."
+    }
+  }
+
+  private static let modeBackupTimestamp: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyyMMdd-HHmmss"
+    return formatter
+  }()
+
+  private func atomicallyReplaceCodexConfig(at destination: URL, with data: Data) throws {
+    let temporary = destination.deletingLastPathComponent()
+      .appendingPathComponent(".config.toml.router-mode-\(UUID().uuidString)")
+    do {
+      try data.write(to: temporary, options: .atomic)
+      try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: temporary.path)
+      _ = try FileManager.default.replaceItemAt(destination, withItemAt: temporary)
+    } catch {
+      try? FileManager.default.removeItem(at: temporary)
+      throw error
+    }
   }
 
   private func refreshHostAppRunning() {
@@ -2687,6 +2796,26 @@ private struct TrayView: View {
 
   @ViewBuilder
   private func settingsTab(for target: RouterTarget) -> some View {
+    settingRow(
+      title: "Custom Model / Orchestrator Mode",
+      detail: store.codexMode == .customModel
+        ? "Sol routes connected specialist models"
+        : "Normal ChatGPT models only",
+      isOn: Binding(
+        get: { store.codexMode == .customModel },
+        set: { isOn in Task { await store.setCodexMode(isOn ? .customModel : .chatGPT) } }
+      ),
+      isDisabled: store.modeOperation != nil
+    )
+    if store.modeOperation != nil {
+      HStack(spacing: 6) {
+        ProgressView().controlSize(.small)
+        Text(store.modeOperation ?? "Switching mode…")
+          .font(.system(size: 9))
+          .foregroundStyle(routerMuted)
+      }
+      .padding(.vertical, 1)
+    }
     HStack(spacing: 12) {
       VStack(alignment: .leading, spacing: 3) {
         Text("Show tray")
@@ -2744,7 +2873,7 @@ private struct TrayView: View {
         get: { store.signedRouting },
         set: { enabled in Task { await store.setSignedRouting(enabled) } }
       ),
-      isDisabled: store.providerOperation != nil || store.loginFree
+      isDisabled: store.providerOperation != nil || store.loginFree || store.modeOperation != nil
     )
     settingRow(
       title: "Use without OpenAI login",
@@ -2755,7 +2884,7 @@ private struct TrayView: View {
         get: { store.loginFree },
         set: { enabled in Task { await store.setLoginFree(enabled) } }
       ),
-      isDisabled: store.providerOperation != nil || store.signedRouting
+      isDisabled: store.providerOperation != nil || store.signedRouting || store.modeOperation != nil
     )
     maintenanceRow
     AccordionPanel(

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -67,6 +67,11 @@ struct CodexModeController {
   private static let managedBlockBegin = "# BEGIN codex-router-managed"
   private static let managedBlockEnd = "# END codex-router-managed"
   private static let flashSubagentLine = "default_subagent_model = \"opencode-go/deepseek-v4-flash\""
+  private static let nativeSubagentLine = "default_subagent_model = \"gpt-5.6-luna\""
+
+  // Tests inject a non-sensitive fixture. Production leaves this nil and reads
+  // the router's authenticated local configuration at the point of use.
+  static var managedBlockSource: (() throws -> String)?
 
   enum ConfigurationError: LocalizedError {
     case duplicateManagedBlock
@@ -98,10 +103,12 @@ struct CodexModeController {
     var result = removeManagedBlock(from: config)
     result = removeRouterProvider(from: result)
 
-    guard enabled else { return normalize(result) }
+    guard enabled else {
+      return normalize(replaceSubagentModel(in: result, with: nativeSubagentLine))
+    }
 
-    result = replaceSubagentModel(in: result)
-    let managedBlock = try managedBlockFromLocalConfiguration()
+    result = replaceSubagentModel(in: result, with: flashSubagentLine)
+    let managedBlock = try (managedBlockSource?() ?? managedBlockFromLocalConfiguration())
     result = normalize(result)
     if !result.isEmpty { result += "\n" }
     result += routerProviderLine + "\n" + managedBlock
@@ -118,8 +125,14 @@ struct CodexModeController {
     guard containsSetting(named: "model", in: config) else {
       throw ConfigurationError.missingModel
     }
-    if mode(from: config) == .customModel && begins != 1 {
-      throw ConfigurationError.incompleteRouterConfiguration
+    if mode(from: config) == .customModel {
+      guard begins == 1,
+            let block = extractManagedBlock(from: config),
+            containsNonEmptySetting(named: "openai_base_url", in: block),
+            containsNonEmptySetting(named: "model_catalog_json", in: block)
+      else {
+        throw ConfigurationError.incompleteRouterConfiguration
+      }
     }
   }
 
@@ -149,7 +162,7 @@ struct CodexModeController {
       .joined(separator: "\n")
   }
 
-  private static func replaceSubagentModel(in config: String) -> String {
+  private static func replaceSubagentModel(in config: String, with replacement: String) -> String {
     let lines = config.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
     var replaced = false
     let result = lines.map { line -> String in
@@ -157,14 +170,24 @@ struct CodexModeController {
         return line
       }
       replaced = true
-      return flashSubagentLine
+      return replacement
     }
-    return replaced ? result.joined(separator: "\n") : config + (config.hasSuffix("\n") ? "" : "\n") + flashSubagentLine
+    return replaced ? result.joined(separator: "\n") : config + (config.hasSuffix("\n") ? "" : "\n") + replacement
   }
 
   private static func containsSetting(named name: String, in config: String) -> Bool {
     config.split(separator: "\n", omittingEmptySubsequences: false).contains { line in
       line.trimmingCharacters(in: .whitespaces).hasPrefix("\(name) =")
+    }
+  }
+
+  private static func containsNonEmptySetting(named name: String, in config: String) -> Bool {
+    config.split(separator: "\n", omittingEmptySubsequences: false).contains { line in
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+      let prefix = "\(name) ="
+      guard trimmed.hasPrefix(prefix) else { return false }
+      let value = trimmed.dropFirst(prefix.count).trimmingCharacters(in: .whitespaces)
+      return value.count > 2 && value.first == "\"" && value.last == "\""
     }
   }
 

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -790,12 +790,12 @@ final class RouterStore: ObservableObject {
 
   var selectedUsageText: String? {
     if selectedUsageUsesChatGPT {
-      guard let primary = accountUsage?.primary else { return nil }
-      return "\(primary.remainingPercent)% left"
+      guard let weekly = accountUsage?.weeklyWindow else { return "Unavailable" }
+      return "\(weekly.remainingPercent)% left"
     }
     guard providerUsage != nil else { return nil }
     if let metric = selectedAccountMetric { return formattedAccountMetric(metric) }
-    return localUsageSummary(for: selectedUsageProviderID, days: 7)
+    return "Unavailable"
   }
 
   var selectedUsageUsesChatGPT: Bool {
@@ -815,7 +815,7 @@ final class RouterStore: ObservableObject {
   }
 
   var selectedUsageResetDate: Date? {
-    if selectedUsageUsesChatGPT { return accountUsage?.primary?.resetDate }
+    if selectedUsageUsesChatGPT { return accountUsage?.weeklyWindow?.resetDate }
     return selectedAccountMetric?.resetDate
   }
 
@@ -958,72 +958,63 @@ final class RouterStore: ObservableObject {
 
   func usageCards(for provider: UsageProviderChoice) -> [UsageOverviewCard] {
     if provider.id == "openai" {
-      var cards: [UsageOverviewCard] = []
-      if let primary = accountUsage?.primary {
-        cards.append(
-          UsageOverviewCard(
-            id: "openai-primary",
-            provider: provider,
-            metric: nil,
-            kindLabel: primary.durationLabel,
-            remainingPercent: Double(primary.remainingPercent),
-            resetDate: primary.resetDate
-          )
-        )
-      } else {
-        cards.append(
-          UsageOverviewCard(
-            id: "openai-primary",
-            provider: provider,
-            metric: nil,
-            kindLabel: nil,
-            remainingPercent: nil,
-            resetDate: nil
-          )
-        )
-      }
-      if let secondary = accountUsage?.secondary {
-        cards.append(
-          UsageOverviewCard(
-            id: "openai-secondary",
-            provider: provider,
-            metric: nil,
-            kindLabel: secondary.durationLabel,
-            remainingPercent: Double(secondary.remainingPercent),
-            resetDate: secondary.resetDate
-          )
-        )
-      }
-      return cards
-    }
-
-    let metrics = providerUsage(for: provider.id)?.account.metrics ?? []
-    if !metrics.isEmpty {
-      return metrics.enumerated().map { index, metric in
-        let kindLabel = metric.kind == "quota"
-          ? standardizedLimitLabel(metric.label)
-          : metric.label
-        return UsageOverviewCard(
-          id: "\(provider.id)-metric-\(index)",
+      let weekly = accountUsage?.weeklyWindow
+      return [
+        UsageOverviewCard(
+          id: "openai-weekly",
           provider: provider,
-          metric: metric,
-          kindLabel: kindLabel,
-          remainingPercent: metric.remainingPercent,
-          resetDate: metric.resetDate
+          metric: nil,
+          kindLabel: "Weekly",
+          remainingPercent: weekly.map { Double($0.remainingPercent) },
+          resetDate: weekly?.resetDate,
+          status: weekly == nil ? .unavailable : .available,
+          message: weekly == nil ? "ChatGPT did not report a weekly usage window." : nil
+        )
+      ]
+    }
+
+    let account = providerUsage(for: provider.id)?.account
+    let metrics = account?.metrics ?? []
+    if provider.id == "opencode-go" {
+      return UsageCardMapper.openCodeCards(metrics: metrics, unavailableMessage: account?.message).map { card in
+        UsageOverviewCard(
+          id: "\(provider.id)-\(card.title.lowercased())",
+          provider: provider,
+          metric: card.metric,
+          kindLabel: card.title,
+          remainingPercent: card.metric?.remainingPercent,
+          resetDate: card.metric?.resetDate,
+          status: card.status,
+          message: card.message
         )
       }
     }
 
-    return [
-      UsageOverviewCard(
-        id: "\(provider.id)-local",
+    guard !metrics.isEmpty else {
+      return [UsageOverviewCard(
+        id: "\(provider.id)-unavailable",
         provider: provider,
         metric: nil,
-        kindLabel: nil,
+        kindLabel: "Usage limit",
         remainingPercent: nil,
-        resetDate: nil
+        resetDate: nil,
+        status: .unavailable,
+        message: account?.message
+      )]
+    }
+    return metrics.enumerated().map { index, metric in
+      let kindLabel = metric.kind == "quota" ? standardizedLimitLabel(metric.label) : metric.label
+      return UsageOverviewCard(
+        id: "\(provider.id)-metric-\(index)",
+        provider: provider,
+        metric: metric,
+        kindLabel: kindLabel,
+        remainingPercent: metric.remainingPercent,
+        resetDate: metric.resetDate,
+        status: metric.available == false ? .unavailable : .available,
+        message: metric.available == false ? (metric.detail ?? account?.message) : nil
       )
-    ]
+    }
   }
 
   func providerUsage(for providerID: String) -> RouterProviderUsage? {
@@ -2066,6 +2057,11 @@ struct CodexAccountUsage: Decodable, Equatable {
   let dailyUsageBuckets: [CodexDailyUsageBucket]
   let summary: CodexUsageSummary
 
+  var weeklyWindow: CodexRateLimitWindow? {
+    guard secondary?.isWeekly == true else { return nil }
+    return secondary
+  }
+
   static func == (lhs: CodexAccountUsage, rhs: CodexAccountUsage) -> Bool {
     lhs.planType == rhs.planType
       && lhs.limitId == rhs.limitId
@@ -2083,6 +2079,8 @@ struct CodexRateLimitWindow: Decodable, Equatable {
   let resetsAt: TimeInterval?
 
   var resetDate: Date? { resetsAt.map(Date.init(timeIntervalSince1970:)) }
+
+  var isWeekly: Bool { windowDurationMins == 7 * 24 * 60 }
 
   var durationLabel: String {
     guard let minutes = windowDurationMins else { return "Current limit" }
@@ -2179,6 +2177,8 @@ struct ProviderAccountUsage: Decodable, Equatable {
 struct ProviderAccountMetric: Decodable, Equatable {
   let kind: String
   let label: String
+  let window: String?
+  let name: String?
   let usedPercent: Double?
   let remainingPercent: Double?
   let used: Double?
@@ -2483,6 +2483,41 @@ struct DesktopQuotaRow: Identifiable {
   let resetAt: TimeInterval?
 }
 
+enum UsageCardStatus: Equatable {
+  case available
+  case unavailable
+}
+
+struct UsageCardMapper {
+  struct Card: Equatable {
+    let title: String
+    let metric: ProviderAccountMetric?
+    let status: UsageCardStatus
+    let message: String?
+  }
+
+  static func openCodeCards(metrics: [ProviderAccountMetric], unavailableMessage: String? = nil) -> [Card] {
+    ["Rolling", "Weekly", "Monthly"].map { title in
+      let metric = metrics.first { matches($0, title: title) }
+      return Card(
+        title: title,
+        metric: metric,
+        status: metric == nil || metric?.available == false ? .unavailable : .available,
+        message: metric == nil ? unavailableMessage : (metric?.available == false ? metric?.detail : nil)
+      )
+    }
+  }
+
+  private static func matches(_ metric: ProviderAccountMetric, title: String) -> Bool {
+    let label = [metric.label, metric.window, metric.name]
+      .compactMap { $0 }
+      .joined(separator: " ")
+      .lowercased()
+      .filter { $0.isLetter || $0.isNumber }
+    return label.contains(title.lowercased())
+  }
+}
+
 struct UsageOverviewCard: Identifiable {
   let id: String
   let provider: UsageProviderChoice
@@ -2490,9 +2525,11 @@ struct UsageOverviewCard: Identifiable {
   let kindLabel: String?
   let remainingPercent: Double?
   let resetDate: Date?
+  let status: UsageCardStatus
+  let message: String?
 
   var providerID: String { provider.id }
-  var title: String { provider.displayName }
+  var title: String { "\(provider.displayName) · \(kindLabel ?? "Usage")" }
 }
 
 struct ProviderSetupSnapshot: Decodable {
@@ -2624,7 +2661,7 @@ private struct TrayView: View {
   private var header: some View {
     HStack(alignment: .center, spacing: 12) {
       VStack(alignment: .leading, spacing: 3) {
-        Text("Model Router")
+        Text("Open Router Model Router")
           .font(.system(size: 15, weight: .semibold))
         Text(accountLabel)
           .font(.system(size: 10, weight: .regular))
@@ -5012,6 +5049,7 @@ private struct CurrentUsageLimitCard: View {
   }
 
   private var metricText: String {
+    if card.status == .unavailable { return "Unavailable" }
     if let metric = card.metric { return formattedAccountMetric(metric) }
     guard let remaining = card.remainingPercent else { return "—" }
     return "\(Int(remaining.rounded()))% left"
@@ -5203,6 +5241,7 @@ private struct AllProviderUsageCard: View {
 
   private var metricText: String {
     if oauthNeedsReconnect { return "Reconnect" }
+    if card.status == .unavailable { return "Unavailable" }
     if let metric = card.metric { return formattedAccountMetric(metric) }
     if let remaining = card.remainingPercent {
       return "\(Int(remaining.rounded()))% left"
@@ -5213,6 +5252,7 @@ private struct AllProviderUsageCard: View {
 
   private var detailText: String {
     if oauthNeedsReconnect { return "OAuth expired · reconnect below" }
+    if card.status == .unavailable { return card.message ?? "Quota data is unavailable" }
     if let kindLabel = card.kindLabel {
       return kindLabel
     }
@@ -5234,6 +5274,7 @@ private struct AllProviderUsageCard: View {
 
   private var footerText: String {
     if oauthNeedsReconnect { return "Sign in again to restore quota" }
+    if card.status == .unavailable { return "No reset reported" }
     if let reset = card.resetDate {
       return usageResetCaption(reset)
     }

--- a/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
@@ -81,3 +81,11 @@ final class ModeConfigurationTests: XCTestCase {
     XCTAssertThrowsError(try CodexModeController.validated(input))
   }
 }
+
+final class UsageCardMapperTests: XCTestCase {
+  func testOpenCodeUsageCardsUseUnavailableForMissingMetrics() {
+    let cards = UsageCardMapper.openCodeCards(metrics: [])
+    XCTAssertEqual(cards.map(\.title), ["Rolling", "Weekly", "Monthly"])
+    XCTAssertTrue(cards.allSatisfy { $0.status == .unavailable })
+  }
+}

--- a/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
@@ -45,10 +45,22 @@ final class ModeConfigurationTests: XCTestCase {
   }
 
   func testRouterStatusMismatchIsRejectedBeforeSuccess() throws {
-    let data = Data(#"{"targets":{"codex":{"target":"codex","configured":true,"active":false,"enabledProviders":[],"models":[]}}}"#.utf8)
+    let data = Data(#"{"targets":{"codex":{"target":"codex","configured":true,"active":true,"enabledProviders":[],"models":[]}}}"#.utf8)
     let status = try JSONDecoder().decode(RouterSnapshot.self, from: data)
+    let stoppedService = RouterServiceStatus(installed: true, loaded: false, state: "stopped")
     XCTAssertThrowsError(
-      try CodexModeController.verifyRouterStatus(status, expected: .customModel)
+      try CodexModeController.verifyRouterStatus(
+        status, serviceStatus: stoppedService, expected: .customModel)
+    )
+  }
+
+  func testStoppedServiceConfirmsChatGPTMode() throws {
+    let data = Data(#"{"targets":{"codex":{"target":"codex","configured":true,"active":true,"enabledProviders":[],"models":[]}}}"#.utf8)
+    let status = try JSONDecoder().decode(RouterSnapshot.self, from: data)
+    let stoppedService = RouterServiceStatus(installed: true, loaded: false, state: "stopped")
+    XCTAssertNoThrow(
+      try CodexModeController.verifyRouterStatus(
+        status, serviceStatus: stoppedService, expected: .chatGPT)
     )
   }
 

--- a/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
@@ -44,6 +44,14 @@ final class ModeConfigurationTests: XCTestCase {
     XCTAssertTrue(result.contains("# BEGIN codex-router-managed"))
   }
 
+  func testRouterStatusMismatchIsRejectedBeforeSuccess() throws {
+    let data = Data(#"{"targets":{"codex":{"target":"codex","configured":true,"active":false,"enabledProviders":[],"models":[]}}}"#.utf8)
+    let status = try JSONDecoder().decode(RouterSnapshot.self, from: data)
+    XCTAssertThrowsError(
+      try CodexModeController.verifyRouterStatus(status, expected: .customModel)
+    )
+  }
+
   func testInvalidEnabledConfigurationIsRejectedBeforeReplacement() throws {
     XCTAssertThrowsError(
       try CodexModeController.validated("model_provider = \"codex-router\"\n")

--- a/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
@@ -44,6 +44,12 @@ final class ModeConfigurationTests: XCTestCase {
     XCTAssertTrue(result.contains("# BEGIN codex-router-managed"))
   }
 
+  func testInvalidEnabledConfigurationIsRejectedBeforeReplacement() throws {
+    XCTAssertThrowsError(
+      try CodexModeController.validated("model_provider = \"codex-router\"\n")
+    )
+  }
+
   func testValidationRejectsRouterProviderWithoutMeaningfulManagedEntries() {
     let input = """
     model = "gpt-5.6-sol"

--- a/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import ModelRouterTray
+
+final class ModeConfigurationTests: XCTestCase {
+  func testDisablingCustomModeRemovesRouterProviderAndManagedBlock() throws {
+    let input = """
+    model = "gpt-5.6-sol"
+    model_provider = "codex-router"
+    # BEGIN codex-router-managed
+    openai_base_url = "http://127.0.0.1:4102/v1"
+    # END codex-router-managed
+    """
+    let result = try CodexModeController.replacingRouterBlock(in: input, enabled: false)
+    XCTAssertFalse(result.contains("model_provider = \"codex-router\""))
+    XCTAssertFalse(result.contains("# BEGIN codex-router-managed"))
+    XCTAssertTrue(result.contains("model = \"gpt-5.6-sol\""))
+  }
+
+  func testEnablingCustomModeRestoresRouterProviderAndFlashFallback() throws {
+    let input = "model = \"gpt-5.6-sol\"\ndefault_subagent_model = \"gpt-5.6-luna\"\n"
+    let result = try CodexModeController.replacingRouterBlock(in: input, enabled: true)
+    XCTAssertTrue(result.contains("model_provider = \"codex-router\""))
+    XCTAssertTrue(result.contains("default_subagent_model = \"opencode-go/deepseek-v4-flash\""))
+    XCTAssertTrue(result.contains("# BEGIN codex-router-managed"))
+  }
+}

--- a/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ModeConfigurationTests.swift
@@ -2,18 +2,38 @@ import XCTest
 @testable import ModelRouterTray
 
 final class ModeConfigurationTests: XCTestCase {
+  private let managedBlockFixture = """
+  # BEGIN codex-router-managed
+  openai_base_url = "http://127.0.0.1:4102/v1"
+  model_catalog_json = "/tmp/codex-router-test-catalog.json"
+  # END codex-router-managed
+  """
+
+  override func setUp() {
+    super.setUp()
+    CodexModeController.managedBlockSource = { [managedBlockFixture] in managedBlockFixture }
+  }
+
+  override func tearDown() {
+    CodexModeController.managedBlockSource = nil
+    super.tearDown()
+  }
+
   func testDisablingCustomModeRemovesRouterProviderAndManagedBlock() throws {
     let input = """
     model = "gpt-5.6-sol"
     model_provider = "codex-router"
+    default_subagent_model = "opencode-go/deepseek-v4-flash"
     # BEGIN codex-router-managed
     openai_base_url = "http://127.0.0.1:4102/v1"
+    model_catalog_json = "/tmp/codex-router-test-catalog.json"
     # END codex-router-managed
     """
     let result = try CodexModeController.replacingRouterBlock(in: input, enabled: false)
     XCTAssertFalse(result.contains("model_provider = \"codex-router\""))
     XCTAssertFalse(result.contains("# BEGIN codex-router-managed"))
     XCTAssertTrue(result.contains("model = \"gpt-5.6-sol\""))
+    XCTAssertTrue(result.contains("default_subagent_model = \"gpt-5.6-luna\""))
   }
 
   func testEnablingCustomModeRestoresRouterProviderAndFlashFallback() throws {
@@ -22,5 +42,16 @@ final class ModeConfigurationTests: XCTestCase {
     XCTAssertTrue(result.contains("model_provider = \"codex-router\""))
     XCTAssertTrue(result.contains("default_subagent_model = \"opencode-go/deepseek-v4-flash\""))
     XCTAssertTrue(result.contains("# BEGIN codex-router-managed"))
+  }
+
+  func testValidationRejectsRouterProviderWithoutMeaningfulManagedEntries() {
+    let input = """
+    model = "gpt-5.6-sol"
+    model_provider = "codex-router"
+    # BEGIN codex-router-managed
+    openai_base_url = ""
+    # END codex-router-managed
+    """
+    XCTAssertThrowsError(try CodexModeController.validated(input))
   }
 }

--- a/scripts/build-macos-tray-app.sh
+++ b/scripts/build-macos-tray-app.sh
@@ -18,6 +18,11 @@ swift build -c "$configuration" --package-path "$tray_dir" 1>&2
 mkdir -p "$bundle_dir/Contents/MacOS" "$bundle_dir/Contents/Resources"
 cp "$binary_dir/ModelRouterTray" "$bundle_dir/Contents/MacOS/ModelRouterTray"
 cp "$tray_dir/Resources/Info.plist" "$bundle_dir/Contents/Info.plist"
+# Older desktop-package builds stored this checkout pointer in a loose resource
+# instead of the Info.plist that RouterStore reads. Do not carry that stale
+# resource forward when rebuilding an existing bundle: the plist below is the
+# sole, signed source-root contract for the macOS tray.
+rm -f "$bundle_dir/Contents/Resources/router-root"
 if [ -d "$binary_dir/ModelRouterTray_ModelRouterTray.bundle" ]; then
   rm -rf "$bundle_dir/Contents/Resources/ModelRouterTray_ModelRouterTray.bundle" \
     "$bundle_dir/ModelRouterTray_ModelRouterTray.bundle"

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -188,14 +188,18 @@ test("the macOS tray executes control only from the checkout sealed into Info.pl
     "utf8",
   );
   assert.doesNotMatch(source, /MODEL_ROUTER_SOURCE_ROOT/);
-  assert.match(source, /object\(forInfoDictionaryKey: "ModelRouterSourceRoot"\)/);
-  assert.doesNotMatch(source, /String\(contentsOf:/);
-  assert.doesNotMatch(source, /currentDirectoryPath/);
+  const sourceRoot = source.slice(
+    source.indexOf("private func sourceRoot()"),
+    source.indexOf("private func validatedSourceRoot"),
+  );
+  assert.match(sourceRoot, /object\(forInfoDictionaryKey: "ModelRouterSourceRoot"\)/);
+  assert.doesNotMatch(sourceRoot, /String\(contentsOf:/);
+  assert.doesNotMatch(sourceRoot, /currentDirectoryPath/);
   assert.match(source, /isExecutableFile\(atPath: control\.path\)/);
 
   const script = readFileSync(path.join(root, "scripts", "build-macos-tray-app.sh"), "utf8");
   assert.match(script, /Add :ModelRouterSourceRoot string \$repo_dir/);
-  assert.doesNotMatch(script, /Contents\/Resources\/router-root/);
+  assert.match(script, /rm -f "\$bundle_dir\/Contents\/Resources\/router-root"/);
 });
 
 test("follow mode rechecks host presence and drains requests before stopping", () => {


### PR DESCRIPTION
## Summary
- adds a safe Custom Model / Orchestrator Mode switch to the native macOS tray
- assigns native Sol/Luna/Terra and external Flash/V4 Pro/GLM/Kimi roles without routine Kimi validation
- adds explicit ChatGPT weekly and OpenCode Go rolling/weekly/monthly usage cards with honest unavailable states
- packages the tray as **Open Router Model Router**

## Verification
- `swift build -c release`
- tray rebuild tests: 15/15
- `plutil -lint` and `codesign --verify --deep --strict` on the installed app

## Limitation
- Swift XCTest cannot run in this host toolchain because the XCTest module is unavailable.