### PR TITLE
Show remaining plan usage for xAI OAuth, MiniMax, Command Code, and opencode Go

### DIFF
--- a/apps/desktop/ui/app.js
+++ b/apps/desktop/ui/app.js
@@ -428,14 +428,22 @@ function startPanel() {
         }));
     }
 
-    function providerGroupsMarkup(groups, rowMarkup, setting) {
+    // `groupSummary` counts what this section actually controls. The two
+    // sections list the same providers, so a click that lands in the wrong one
+    // has to be visible here rather than only in Codex's picker after a
+    // restart. Button labels name the setting for the same reason: two
+    // identical "Unselect all" buttons is how a subagent toggle gets mistaken
+    // for a picker toggle.
+    function providerGroupsMarkup(groups, rowMarkup, setting, groupSummary) {
+      const [onLabel, offLabel] =
+        setting === "picker" ? ["Show all", "Hide all"] : ["Subagents on", "Subagents off"];
       return groups
         .map(
           (group) => `<details class="model-provider-group" open>
-            <summary><span>${escapeHtml(providerLabel(group.provider))}</span><span class="model-provider-count">${group.items.length}</span></summary>
+            <summary><span>${escapeHtml(providerLabel(group.provider))}</span><span class="model-provider-count">${escapeHtml(groupSummary(group))}</span></summary>
             <div class="model-provider-toolbar">
-              <button class="text-button" type="button" data-provider-setting="${setting}" data-provider="${escapeHtml(group.provider)}" data-enabled="true">${setting === "picker" ? "Show all" : "Select all"}</button>
-              <button class="text-button" type="button" data-provider-setting="${setting}" data-provider="${escapeHtml(group.provider)}" data-enabled="false">Unselect all</button>
+              <button class="text-button" type="button" data-provider-setting="${setting}" data-provider="${escapeHtml(group.provider)}" data-enabled="true">${onLabel}</button>
+              <button class="text-button" type="button" data-provider-setting="${setting}" data-provider="${escapeHtml(group.provider)}" data-enabled="false">${offLabel}</button>
             </div>
             <div class="model-settings-list">${group.items.map(rowMarkup).join("")}</div>
           </details>`,
@@ -451,14 +459,26 @@ function startPanel() {
         ? "Only selected models are exposed as Codex subagents."
         : "Only registry-proven v2 models are exposed as Codex subagents.";
 
-    const subagentModels = enabledModels
-      .filter((model) => !model.native && model.visible !== false)
+    // Models hidden from the picker are forced off as subagents, so their
+    // rows here were permanently locked noise. They are filtered out; the
+    // note under the list keeps the count visible and points at the picker
+    // section, which is where unhiding brings a model back.
+    const subagentModels = enabledModels.filter(
+      (model) => !model.native && model.visible !== false,
+    );
+    const hiddenSubagentCount = enabledModels.filter(
+      (model) => !model.native && model.visible === false,
+    ).length;
     const subagentGroups = groupModels(subagentModels);
+    const isSubagentOn = (model) =>
+      model.visible === false
+        ? false
+        : subagent.mode === "all"
+        ? !disabledSubagents.has(model.slug)
+        : (model.multiAgentVersion === "v2" || enabledSubagents.has(model.slug)) &&
+          !disabledSubagents.has(model.slug);
     const subagentRow = (model) => {
-        const checked = subagent.mode === "all"
-          ? !disabledSubagents.has(model.slug)
-          : (model.multiAgentVersion === "v2" || enabledSubagents.has(model.slug)) &&
-            !disabledSubagents.has(model.slug);
+        const checked = isSubagentOn(model);
         const badge = model.multiAgentVersion === "v2" ? " · proven v2" : "";
         return `<label class="model-setting-row">
           <span><strong>${escapeHtml(model.displayName)}</strong><small>${escapeHtml(badge)}</small></span>
@@ -466,9 +486,23 @@ function startPanel() {
         </label>`;
       };
 
+    const hiddenSubagentNote = hiddenSubagentCount
+      ? `<div class="model-settings-note">${hiddenSubagentCount} model${
+          hiddenSubagentCount === 1 ? " is" : "s are"
+        } hidden from the picker and not listed here. Show ${
+          hiddenSubagentCount === 1 ? "it" : "them"
+        } in the picker section below to use ${
+          hiddenSubagentCount === 1 ? "it" : "them"
+        } as ${hiddenSubagentCount === 1 ? "a subagent" : "subagents"}.</div>`
+      : "";
     elements.subagentModelList.innerHTML = subagentGroups.length
-      ? providerGroupsMarkup(subagentGroups, subagentRow, "subagents")
-      : '<div class="empty-state">Enable a provider to choose subagent models here.</div>';
+      ? providerGroupsMarkup(
+          subagentGroups,
+          subagentRow,
+          "subagents",
+          (group) => `${group.items.filter(isSubagentOn).length} of ${group.items.length} on`,
+        ) + hiddenSubagentNote
+      : `<div class="empty-state">Enable a provider to choose subagent models here.</div>${hiddenSubagentNote}`;
     const subagentCount = subagent.mode === "all"
       ? enabledModels.filter(
           (model) => !model.native && model.visible !== false && !disabledSubagents.has(model.slug),
@@ -492,7 +526,15 @@ function startPanel() {
       };
 
     elements.pickerModelList.innerHTML = pickerGroups.length
-      ? providerGroupsMarkup(pickerGroups, pickerRow, "picker")
+      ? providerGroupsMarkup(
+          pickerGroups,
+          pickerRow,
+          "picker",
+          (group) =>
+            `${group.items.filter((model) => !hiddenModels.has(model.slug)).length} of ${
+              group.items.length
+            } visible`,
+        )
       : '<div class="empty-state">No enabled models to show.</div>';
     const pickerCount = pickerModels.filter((model) => !hiddenModels.has(model.slug)).length;
     elements.pickerSummary.textContent = `${pickerCount} visible · ${hiddenModels.size} hidden`;
@@ -716,7 +758,9 @@ function startPanel() {
           state.snapshot = await call("set_picker_provider", { provider, visible: enabled });
         }
         showToast(
-          `${provider} models ${enabled ? "selected" : "unselected"}. Restart Codex to refresh its picker.`,
+          setting === "subagents"
+            ? `${provider} models ${enabled ? "on" : "off"} as subagents. They stay in Codex's picker. Restart Codex to refresh its subagents.`
+            : `${provider} models ${enabled ? "shown in" : "hidden from"} the picker. Restart Codex to refresh it.`,
         );
         await refreshPanel({ quiet: true });
       } catch (error) {
@@ -738,13 +782,13 @@ function startPanel() {
         const selectAll = action === "select-all";
         state.snapshot = await call("set_subagent_selection", { selectAll });
         showToast(
-          `${selectAll ? "Every picker-visible model can now run as a subagent." : "Subagent selection cleared."} Restart Codex to refresh its picker.`,
+          `${selectAll ? "Every picker-visible model can now run as a subagent." : "Subagent selection cleared. Models stay in Codex's picker."} Restart Codex to refresh its subagents.`,
         );
       } else {
         const showAll = action === "show-all";
         state.snapshot = await call("set_picker_models", { showAll });
         showToast(
-          `${showAll ? "Every model is visible in the picker." : "All models hidden from the picker."} Restart Codex to refresh its picker.`,
+          `${showAll ? "Every model is visible in the picker." : "All models hidden from the picker."} Restart Codex to refresh it.`,
         );
       }
       await refreshPanel({ quiet: true });
@@ -768,7 +812,9 @@ function startPanel() {
           slug: subagent.dataset.subagent,
           enabled: subagent.checked,
         });
-        showToast("Subagent selection updated. Restart Codex to refresh its picker.");
+        showToast(
+          "Subagent selection updated. The model stays in Codex's picker. Restart Codex to refresh its subagents.",
+        );
       } else {
         state.snapshot = await call("set_picker_model", {
           slug: picker.dataset.picker,

--- a/apps/desktop/ui/index.html
+++ b/apps/desktop/ui/index.html
@@ -131,9 +131,10 @@
                 <span class="sr-only">Use all selected models as subagents</span>
               </label>
             </div>
+            <p class="accordion-note">Choices here decide what Codex can spawn as a subagent. They do not hide anything from Codex's model picker — use Model picker below for that.</p>
             <div class="accordion-toolbar">
-              <button class="text-button" type="button" data-model-action="subagents" data-action="select-all">Select all</button>
-              <button class="text-button" type="button" data-model-action="subagents" data-action="unselect-all">Unselect all</button>
+              <button class="text-button" type="button" data-model-action="subagents" data-action="select-all">Subagents on</button>
+              <button class="text-button" type="button" data-model-action="subagents" data-action="unselect-all">Subagents off</button>
             </div>
             <div id="subagent-model-list" class="model-settings-list"></div>
           </div>
@@ -151,7 +152,7 @@
             <p class="accordion-note">Models hidden here stay connected but are not offered by Codex.</p>
             <div class="accordion-toolbar">
               <button class="text-button" type="button" data-model-action="picker" data-action="show-all">Show all</button>
-              <button class="text-button" type="button" data-model-action="picker" data-action="hide-all">Unselect all</button>
+              <button class="text-button" type="button" data-model-action="picker" data-action="hide-all">Hide all</button>
             </div>
             <div id="picker-model-list" class="model-settings-list"></div>
           </div>

--- a/apps/desktop/ui/styles.css
+++ b/apps/desktop/ui/styles.css
@@ -799,6 +799,16 @@ h2 {
   padding: 0 8px 8px;
 }
 
+.model-settings-note {
+  margin-top: 6px;
+  padding: 7px 10px;
+  border: 1px dashed rgba(255, 255, 255, 0.095);
+  border-radius: 9px;
+  color: var(--muted);
+  font-size: 9.5px;
+  line-height: 1.45;
+}
+
 .model-provider-toolbar {
   display: flex;
   justify-content: flex-end;

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -2672,9 +2672,13 @@ private struct TrayView: View {
     private var settings: ModelSettingsSnapshot? { target.modelSettings }
     private var busy: Bool { store.providerOperation == "models" }
 
+    // Hidden models stay listed here. A model hidden from the picker cannot be
+    // a subagent either, but dropping its row made it look deleted and left no
+    // way back to it from this panel -- the tray must always show every model
+    // it can still change.
     private var enabledExternalModels: [RouterModel] {
       target.models
-        .filter { $0.enabled && $0.provider != "openai" && $0.visible != false }
+        .filter { $0.enabled && $0.provider != "openai" }
         .sorted {
           if $0.provider != $1.provider { return $0.provider < $1.provider }
           return $0.slug < $1.slug
@@ -2701,17 +2705,33 @@ private struct TrayView: View {
       return target.providers?.first(where: { $0.id == id })?.displayName ?? id
     }
 
-    private func providerBinding(_ provider: String) -> Binding<Bool> {
-      Binding(
-        get: { !collapsedProviders.contains(provider) },
+    // Keyed by section as well as provider: "Subagent models" and "Model
+    // picker" list the same providers for different settings, so a shared key
+    // made expanding one open the other and turned the two panels into
+    // look-alikes -- which is how a subagent toggle gets mistaken for a picker
+    // toggle.
+    private func providerBinding(_ section: String, _ provider: String) -> Binding<Bool> {
+      let key = "\(section):\(provider)"
+      return Binding(
+        get: { !collapsedProviders.contains(key) },
         set: { expanded in
           if expanded {
-            collapsedProviders.remove(provider)
+            collapsedProviders.remove(key)
           } else {
-            collapsedProviders.insert(provider)
+            collapsedProviders.insert(key)
           }
         }
       )
+    }
+
+    // Per-provider counts, so a click that lands on the wrong panel is visible
+    // in the header it did not change instead of only in Codex's picker.
+    private func subagentGroupSummary(_ group: ProviderModels) -> String {
+      "\(group.models.filter { isSubagent($0) }.count) of \(group.models.count) on"
+    }
+
+    private func pickerGroupSummary(_ group: ProviderModels) -> String {
+      "\(group.models.filter { !hiddenModels.contains($0.slug) }.count) of \(group.models.count) visible"
     }
 
     var body: some View {
@@ -2739,25 +2759,28 @@ private struct TrayView: View {
               ),
               disabled: busy
             )
+            Text("Subagent choices do not hide models from Codex's picker — use Model picker below for that.")
+              .font(.system(size: 9))
+              .foregroundStyle(routerMuted)
             toolbar(
               buttons: [
-                ("Select all", { Task { await store.selectAllSubagents() } }),
-                ("Unselect all", { Task { await store.unselectAllSubagents() } }),
+                ("Subagents on", { Task { await store.selectAllSubagents() } }),
+                ("Subagents off", { Task { await store.unselectAllSubagents() } }),
               ]
             )
             ForEach(providerGroups(enabledExternalModels)) { group in
               AccordionPanel(
                 title: providerName(group.provider),
-                summary: "\(group.models.count) models",
-                expanded: providerBinding(group.provider)
+                summary: subagentGroupSummary(group),
+                expanded: providerBinding("subagents", group.provider)
               ) {
                 VStack(alignment: .leading, spacing: 6) {
                   toolbar(
                     buttons: [
-                      ("Select all", {
+                      ("Subagents on", {
                         Task { await store.setSubagentProvider(group.provider, enabled: true) }
                       }),
-                      ("Unselect all", {
+                      ("Subagents off", {
                         Task { await store.setSubagentProvider(group.provider, enabled: false) }
                       }),
                     ]
@@ -2772,7 +2795,7 @@ private struct TrayView: View {
                           Task { await store.setSubagentModel(model.slug, enabled: enabled) }
                         }
                       ),
-                      disabled: busy
+                      disabled: busy || model.visible == false
                     )
                   }
                 }
@@ -2799,8 +2822,8 @@ private struct TrayView: View {
             ForEach(providerGroups(enabledModels)) { group in
               AccordionPanel(
                 title: providerName(group.provider),
-                summary: "\(group.models.count) models",
-                expanded: providerBinding(group.provider)
+                summary: pickerGroupSummary(group),
+                expanded: providerBinding("picker", group.provider)
               ) {
                 VStack(alignment: .leading, spacing: 6) {
                   toolbar(
@@ -2808,7 +2831,7 @@ private struct TrayView: View {
                       ("Show all", {
                         Task { await store.setPickerProvider(group.provider, visible: true) }
                       }),
-                      ("Unselect all", {
+                      ("Hide all", {
                         Task { await store.setPickerProvider(group.provider, visible: false) }
                       }),
                     ]
@@ -3960,7 +3983,11 @@ private struct TrayView: View {
       Set(settings?.subagents.disabled ?? [])
     }
 
+    // Matches the catalog rule (`applyMultiAgentSettings`): a model hidden from
+    // the picker is never promoted to a subagent, whatever the subagent mode
+    // says.
     private func isSubagent(_ model: RouterModel) -> Bool {
+      if model.visible == false { return false }
       if disabledSubagentSet.contains(model.slug) { return false }
       switch settings?.subagents.mode ?? "proven" {
       case "all":
@@ -3973,6 +4000,7 @@ private struct TrayView: View {
     }
 
     private func subagentDetail(for model: RouterModel) -> String {
+      if model.visible == false { return "Hidden from picker — show it below to use it here" }
       if isSubagent(model) {
         return model.multiAgentVersion == "v2" ? "Proven v2" : "Subagent"
       }

--- a/src/provider-account-usage.mjs
+++ b/src/provider-account-usage.mjs
@@ -139,7 +139,7 @@ export function grokCreditsMetrics(payload) {
   if (!config || typeof config !== "object") return [];
 
   const metrics = [];
-  const usagePct = numberValue(config.creditUsagePercent ?? config.credit_usage_percent);
+  const reportedPct = numberValue(config.creditUsagePercent ?? config.credit_usage_percent);
   const period = config.currentPeriod || config.current_period || {};
   const periodType = String(period.type || period.period_type || "");
   const periodEnd = period.end || config.billingPeriodEnd || config.billing_period_end;
@@ -148,6 +148,15 @@ export function grokCreditsMetrics(payload) {
     : periodType.includes("MONTHLY")
       ? "Monthly limit"
       : "Usage limit";
+
+  // The proxy serializes proto3 JSON, which drops zero-valued fields: a
+  // period with no recorded usage arrives without creditUsagePercent at all.
+  // The period itself proves the quota exists, so missing means 0% used.
+  const usagePct = Number.isFinite(reportedPct)
+    ? reportedPct
+    : periodType || periodEnd
+      ? 0
+      : undefined;
 
   if (Number.isFinite(usagePct)) {
     const usedPercent = Math.max(0, Math.min(100, usagePct));
@@ -201,6 +210,103 @@ export function grokCreditsMetrics(payload) {
   }
 
   return metrics;
+}
+
+// MiniMax reports coding-plan windows as remaining percentages per feature;
+// only the "general" entry covers the chat models this router forwards to
+// (other entries track video and image generation allowances).
+export function minimaxQuotaMetrics(payload) {
+  const entries = Array.isArray(payload?.model_remains) ? payload.model_remains : [];
+  const coding = entries.find((entry) => entry?.model_name === "general");
+  if (!coding) return [];
+  const windowMetric = (label, remainingValue, endMs) => {
+    const reported = numberValue(remainingValue);
+    if (!Number.isFinite(reported)) return undefined;
+    const remainingPercent = Math.max(0, Math.min(100, reported));
+    const usedPercent = 100 - remainingPercent;
+    const metric = {
+      kind: "quota",
+      label,
+      usedPercent,
+      remainingPercent,
+      used: usedPercent,
+      limit: 100,
+      remaining: remainingPercent,
+      unit: "percent",
+    };
+    const end = numberValue(endMs);
+    if (Number.isFinite(end) && end > 0) metric.resetAt = end / 1_000;
+    return metric;
+  };
+  const start = numberValue(coding.start_time);
+  const end = numberValue(coding.end_time);
+  const hours =
+    Number.isFinite(start) && Number.isFinite(end) && end > start
+      ? Math.round((end - start) / 3_600_000)
+      : undefined;
+  const intervalLabel = Number.isFinite(hours) && hours >= 1 ? `${hours}-hour limit` : "Current window";
+  return [
+    windowMetric(intervalLabel, coding.current_interval_remaining_percent, coding.end_time),
+    windowMetric("Weekly limit", coding.current_weekly_remaining_percent, coding.weekly_end_time),
+  ].filter(Boolean);
+}
+
+// opencode Zen reports Go-plan windows as used percentages. The rolling
+// window's duration is not part of the payload, so its label stays generic
+// instead of claiming a specific span.
+export function opencodeGoUsageMetrics(payload) {
+  const usage = payload?.usage;
+  if (!usage || typeof usage !== "object") return [];
+  const windowMetric = (label, detail) => {
+    const percent = numberValue(detail?.percent);
+    if (!Number.isFinite(percent)) return undefined;
+    const usedPercent = Math.max(0, Math.min(100, percent));
+    const metric = {
+      kind: "quota",
+      label,
+      usedPercent,
+      remainingPercent: 100 - usedPercent,
+      used: usedPercent,
+      limit: 100,
+      remaining: 100 - usedPercent,
+      unit: "percent",
+    };
+    const resetAt = resetTimestamp(detail?.resetsAt ?? detail?.reset_at);
+    if (resetAt !== undefined) metric.resetAt = resetAt;
+    return metric;
+  };
+  return [
+    windowMetric("Rolling limit", usage.rolling),
+    windowMetric("Weekly limit", usage.weekly),
+    windowMetric("Monthly limit", usage.monthly),
+  ].filter(Boolean);
+}
+
+// Command Code's billing API reports plan windows as used/cap credit
+// counters; resetAt is an epoch that stays 0 until the window first opens.
+export function commandCodeCreditsMetrics(payload) {
+  const windows = payload?.windowLimits;
+  if (!windows || typeof windows !== "object") return [];
+  const windowMetric = (label, detail) => {
+    if (!detail || typeof detail !== "object") return undefined;
+    const resetRaw = numberValue(detail.resetAt);
+    const resetMs = Number.isFinite(resetRaw) && resetRaw > 0
+      ? resetRaw > 1e12 ? resetRaw : resetRaw * 1_000
+      : undefined;
+    return quotaMetric(
+      label,
+      {
+        limit: detail.cap,
+        used: detail.used,
+        ...(resetMs !== undefined ? { resetTime: new Date(resetMs).toISOString() } : {}),
+      },
+      "credits",
+    );
+  };
+  return [
+    windowMetric("5-hour limit", windows.fiveHour),
+    windowMetric("Weekly limit", windows.weekly),
+  ].filter(Boolean);
 }
 
 export function githubCopilotQuotaMetrics(payload) {
@@ -336,6 +442,44 @@ async function chutesAccount(fetchImpl) {
     metrics,
     dashboardUrl: "https://chutes.ai/app",
   };
+}
+
+async function opencodeGoAccount(fetchImpl) {
+  const provider = PROVIDERS.get("opencode-go");
+  const credential = resolveProviderCredential(provider);
+  if (!credential) return { status: "not-configured", source: "official-api", metrics: [] };
+  const baseURL = (process.env[provider.baseUrlEnv] || provider.baseUrl).replace(/\/+$/, "");
+  if (new URL(baseURL).origin !== "https://opencode.ai") {
+    return localOnly("Plan usage is unavailable for a custom opencode endpoint");
+  }
+  const payload = await requestJson(`${baseURL}/usage`, credential.value, {}, fetchImpl);
+  const metrics = opencodeGoUsageMetrics(payload);
+  if (!metrics.length) throw new Error("opencode usage response was incomplete");
+  return { status: "available", source: "official-api", metrics };
+}
+
+const MINIMAX_ACCOUNT_HOSTS = new Set(["api.minimax.io", "api.minimaxi.com"]);
+
+async function minimaxTokenPlanAccount(fetchImpl) {
+  const provider = PROVIDERS.get("minimax-token-plan");
+  const credential = resolveProviderCredential(provider);
+  if (!credential) return { status: "not-configured", source: "official-api", metrics: [] };
+  const baseURL = (process.env[provider.baseUrlEnv] || provider.baseUrl).replace(/\/+$/, "");
+  if (!MINIMAX_ACCOUNT_HOSTS.has(new URL(baseURL).hostname)) {
+    return localOnly("Plan usage is unavailable for a custom MiniMax endpoint");
+  }
+  const payload = await requestJson(`${baseURL}/coding_plan/remains`, credential.value, {}, fetchImpl);
+  const status = payload?.base_resp?.status_code;
+  if (status !== undefined && status !== 0) {
+    throw new Error(
+      typeof payload?.base_resp?.status_msg === "string" && payload.base_resp.status_msg
+        ? payload.base_resp.status_msg
+        : `MiniMax coding plan API returned status ${status}`,
+    );
+  }
+  const metrics = minimaxQuotaMetrics(payload);
+  if (!metrics.length) throw new Error("MiniMax coding plan response was incomplete");
+  return { status: "available", source: "official-api", metrics };
 }
 
 async function kimiOAuthAccount(fetchImpl) {
@@ -524,6 +668,43 @@ async function zaiCodingAccount(fetchImpl) {
   return account;
 }
 
+// The credits route is the one the official Command Code CLI polls; it is
+// not in the public docs, so any failure degrades to the Studio link and
+// observed router traffic instead of an error state.
+async function commandCodeAccount(fetchImpl) {
+  const provider = PROVIDERS.get("commandcode");
+  const credential = resolveProviderCredential(provider);
+  if (!credential) return { status: "not-configured", source: "official-api", metrics: [] };
+  const fallback = (message) => ({
+    ...withHeaderQuota("commandcode", localOnly(message)),
+    dashboardUrl: COMMANDCODE_DASHBOARD_URL,
+  });
+  const baseURL = (process.env[provider.baseUrlEnv] || provider.baseUrl).replace(/\/+$/, "");
+  if (new URL(baseURL).origin !== "https://api.commandcode.ai") {
+    return fallback("Account usage is unavailable for a custom Command Code endpoint");
+  }
+  try {
+    const payload = await requestJson(
+      "https://api.commandcode.ai/alpha/billing/credits",
+      credential.value,
+      {},
+      fetchImpl,
+    );
+    const metrics = commandCodeCreditsMetrics(payload);
+    if (!metrics.length) {
+      return fallback("Command Code reported no plan windows; showing router traffic");
+    }
+    return {
+      status: "available",
+      source: "official-api",
+      metrics,
+      dashboardUrl: COMMANDCODE_DASHBOARD_URL,
+    };
+  } catch {
+    return fallback("Command Code account usage is unavailable; showing router traffic");
+  }
+}
+
 async function githubCopilotAccount(fetchImpl) {
   const credential = resolveProviderCredential("github-copilot");
   if (!credential) return { status: "not-configured", source: "official-api", metrics: [] };
@@ -598,17 +779,9 @@ async function accountUsageFor(providerId, fetchImpl) {
           }
         : { status: "not-configured", source: "official-api", metrics: [] };
     }
-    if (providerId === "commandcode") {
-      return resolveProviderCredential("commandcode")
-        ? {
-            ...withHeaderQuota(
-              providerId,
-              localOnly("Command Code shows credits and usage only in Studio; showing router traffic"),
-            ),
-            dashboardUrl: COMMANDCODE_DASHBOARD_URL,
-          }
-        : { status: "not-configured", source: "official-api", metrics: [] };
-    }
+    if (providerId === "commandcode") return await commandCodeAccount(fetchImpl);
+    if (providerId === "minimax-token-plan") return await minimaxTokenPlanAccount(fetchImpl);
+    if (providerId === "opencode-go") return await opencodeGoAccount(fetchImpl);
     if (providerId === "github-copilot") return await githubCopilotAccount(fetchImpl);
     // Every remaining provider — including the catalog-only ones — reports its
     // window through response headers or shows router traffic alone.

--- a/test/provider-account-usage.test.mjs
+++ b/test/provider-account-usage.test.mjs
@@ -4,11 +4,14 @@ import test from "node:test";
 import {
   chutesBalanceMetrics,
   chutesSubscriptionMetrics,
+  commandCodeCreditsMetrics,
   deepSeekBalanceMetrics,
   githubCopilotQuotaMetrics,
   grokCreditsMetrics,
   kimiApiBalanceMetrics,
   kimiQuotaMetrics,
+  minimaxQuotaMetrics,
+  opencodeGoUsageMetrics,
   providerAccountUsageSnapshot,
 } from "../src/provider-account-usage.mjs";
 
@@ -216,21 +219,299 @@ test("does not poll account endpoints for disabled providers", async () => {
   assert.ok(Object.values(snapshot).every((account) => account.status === "disabled"));
 });
 
-test("Command Code usage degrades to the Studio link without an account API", async () => {
+test("Command Code usage reads plan windows from the billing credits API", async () => {
   delete process.env.COMMAND_CODE_API_KEY;
   delete process.env.COMMANDCODE_API_KEY;
   process.env.COMMAND_CODE_API_KEY = "TEST_COMMANDCODE_USAGE_KEY";
   try {
     const snapshot = await providerAccountUsageSnapshot({
       providerIds: ["commandcode"],
-      fetchImpl: async () => {
-        throw new Error("Command Code usage should not reach an undocumented endpoint");
+      fetchImpl: async (url, options) => {
+        assert.equal(url, "https://api.commandcode.ai/alpha/billing/credits");
+        assert.equal(options.headers.Authorization, "Bearer TEST_COMMANDCODE_USAGE_KEY");
+        return new Response(JSON.stringify({
+          credits: { monthlyCredits: 10, purchasedCredits: 0, freeCredits: 0 },
+          windowLimits: {
+            limited: true,
+            fiveHour: { used: 1, cap: 3, exceeded: false, resetAt: 1_786_579_200 },
+            weekly: { used: 2, cap: 6, exceeded: false, resetAt: 0 },
+          },
+        }));
       },
+    });
+    assert.equal(snapshot.commandcode.status, "available");
+    assert.equal(snapshot.commandcode.dashboardUrl, "https://commandcode.ai/studio");
+    assert.deepEqual(snapshot.commandcode.metrics, [
+      {
+        kind: "quota",
+        label: "5-hour limit",
+        usedPercent: (1 / 3) * 100,
+        remainingPercent: 100 - (1 / 3) * 100,
+        used: 1,
+        limit: 3,
+        remaining: 2,
+        unit: "credits",
+        resetAt: 1_786_579_200,
+      },
+      {
+        kind: "quota",
+        label: "Weekly limit",
+        usedPercent: (2 / 6) * 100,
+        remainingPercent: 100 - (2 / 6) * 100,
+        used: 2,
+        limit: 6,
+        remaining: 4,
+        unit: "credits",
+      },
+    ]);
+    assert.doesNotMatch(JSON.stringify(snapshot), /TEST_COMMANDCODE_USAGE_KEY/);
+  } finally {
+    delete process.env.COMMAND_CODE_API_KEY;
+  }
+});
+
+test("Command Code usage degrades to the Studio link when the credits API fails", async () => {
+  delete process.env.COMMAND_CODE_API_KEY;
+  delete process.env.COMMANDCODE_API_KEY;
+  process.env.COMMAND_CODE_API_KEY = "TEST_COMMANDCODE_USAGE_KEY";
+  try {
+    const snapshot = await providerAccountUsageSnapshot({
+      providerIds: ["commandcode"],
+      fetchImpl: async () => new Response("nope", { status: 503 }),
     });
     assert.equal(snapshot.commandcode.status, "local-only");
     assert.equal(snapshot.commandcode.dashboardUrl, "https://commandcode.ai/studio");
   } finally {
     delete process.env.COMMAND_CODE_API_KEY;
+  }
+});
+
+test("Command Code usage avoids the billing API for a custom endpoint", async () => {
+  delete process.env.COMMAND_CODE_API_KEY;
+  delete process.env.COMMANDCODE_API_KEY;
+  process.env.COMMAND_CODE_API_KEY = "TEST_COMMANDCODE_CUSTOM_KEY";
+  process.env.COMMANDCODE_BASE_URL = "https://example.test/provider/v1";
+  try {
+    const snapshot = await providerAccountUsageSnapshot({
+      providerIds: ["commandcode"],
+      fetchImpl: async () => {
+        throw new Error("custom Command Code endpoints must not trigger billing API calls");
+      },
+    });
+    assert.equal(snapshot.commandcode.status, "local-only");
+    assert.match(snapshot.commandcode.message, /custom Command Code endpoint/);
+  } finally {
+    delete process.env.COMMAND_CODE_API_KEY;
+    delete process.env.COMMANDCODE_BASE_URL;
+  }
+});
+
+test("normalizes opencode Go rolling, weekly, and monthly windows", () => {
+  assert.deepEqual(opencodeGoUsageMetrics({
+    usage: {
+      rolling: { status: "ok", percent: 1, resetsAt: "2026-08-13T01:32:51.675Z" },
+      weekly: { status: "ok", percent: 67, resetsAt: "2026-08-17T00:00:00.675Z" },
+      monthly: { status: "ok", percent: 52, resetsAt: "2026-09-04T23:37:45.675Z" },
+    },
+  }), [
+    {
+      kind: "quota",
+      label: "Rolling limit",
+      usedPercent: 1,
+      remainingPercent: 99,
+      used: 1,
+      limit: 100,
+      remaining: 99,
+      unit: "percent",
+      resetAt: 1786584771.675,
+    },
+    {
+      kind: "quota",
+      label: "Weekly limit",
+      usedPercent: 67,
+      remainingPercent: 33,
+      used: 67,
+      limit: 100,
+      remaining: 33,
+      unit: "percent",
+      resetAt: 1786924800.675,
+    },
+    {
+      kind: "quota",
+      label: "Monthly limit",
+      usedPercent: 52,
+      remainingPercent: 48,
+      used: 52,
+      limit: 100,
+      remaining: 48,
+      unit: "percent",
+      resetAt: 1788565065.675,
+    },
+  ]);
+});
+
+test("opencode Go usage reads the Zen usage API", async () => {
+  const saved = process.env.OPENCODE_API_KEY;
+  process.env.OPENCODE_API_KEY = "TEST_OPENCODE_USAGE_KEY";
+  try {
+    const snapshot = await providerAccountUsageSnapshot({
+      providerIds: ["opencode-go"],
+      fetchImpl: async (url, options) => {
+        assert.equal(url, "https://opencode.ai/zen/go/v1/usage");
+        assert.equal(options.headers.Authorization, "Bearer TEST_OPENCODE_USAGE_KEY");
+        return new Response(JSON.stringify({
+          usage: {
+            rolling: { status: "ok", percent: 5, resetsAt: "2026-08-13T01:00:00Z" },
+            weekly: { status: "ok", percent: 60, resetsAt: "2026-08-17T00:00:00Z" },
+          },
+        }));
+      },
+    });
+    assert.equal(snapshot["opencode-go"].status, "available");
+    assert.equal(snapshot["opencode-go"].metrics.length, 2);
+    assert.equal(snapshot["opencode-go"].metrics[1].remainingPercent, 40);
+    assert.doesNotMatch(JSON.stringify(snapshot), /TEST_OPENCODE_USAGE_KEY/);
+  } finally {
+    if (saved === undefined) delete process.env.OPENCODE_API_KEY;
+    else process.env.OPENCODE_API_KEY = saved;
+  }
+});
+
+test("opencode Go usage avoids the Zen API for a custom endpoint", async () => {
+  const savedKey = process.env.OPENCODE_API_KEY;
+  const savedBase = process.env.OPENCODE_GO_BASE_URL;
+  process.env.OPENCODE_API_KEY = "TEST_OPENCODE_CUSTOM_KEY";
+  process.env.OPENCODE_GO_BASE_URL = "https://example.test/zen/go/v1";
+  try {
+    const snapshot = await providerAccountUsageSnapshot({
+      providerIds: ["opencode-go"],
+      fetchImpl: async () => {
+        throw new Error("custom opencode endpoints must not trigger usage API calls");
+      },
+    });
+    assert.equal(snapshot["opencode-go"].status, "local-only");
+    assert.match(snapshot["opencode-go"].message, /custom opencode endpoint/);
+  } finally {
+    if (savedKey === undefined) delete process.env.OPENCODE_API_KEY;
+    else process.env.OPENCODE_API_KEY = savedKey;
+    if (savedBase === undefined) delete process.env.OPENCODE_GO_BASE_URL;
+    else process.env.OPENCODE_GO_BASE_URL = savedBase;
+  }
+});
+
+test("normalizes MiniMax coding plan windows from the general entry only", () => {
+  assert.deepEqual(minimaxQuotaMetrics({
+    model_remains: [
+      {
+        model_name: "general",
+        start_time: 1_786_564_800_000,
+        end_time: 1_786_579_200_000,
+        current_interval_remaining_percent: 98,
+        current_weekly_remaining_percent: 82,
+        weekly_end_time: 1_786_924_800_000,
+      },
+      {
+        model_name: "video",
+        current_interval_remaining_percent: 10,
+        current_weekly_remaining_percent: 10,
+      },
+    ],
+    base_resp: { status_code: 0, status_msg: "success" },
+  }), [
+    {
+      kind: "quota",
+      label: "4-hour limit",
+      usedPercent: 2,
+      remainingPercent: 98,
+      used: 2,
+      limit: 100,
+      remaining: 98,
+      unit: "percent",
+      resetAt: 1_786_579_200,
+    },
+    {
+      kind: "quota",
+      label: "Weekly limit",
+      usedPercent: 18,
+      remainingPercent: 82,
+      used: 18,
+      limit: 100,
+      remaining: 82,
+      unit: "percent",
+      resetAt: 1_786_924_800,
+    },
+  ]);
+});
+
+test("MiniMax token plan usage reads the coding plan remains API", async () => {
+  const saved = process.env.MINIMAX_API_KEY;
+  process.env.MINIMAX_API_KEY = "TEST_MINIMAX_USAGE_KEY";
+  try {
+    const snapshot = await providerAccountUsageSnapshot({
+      providerIds: ["minimax-token-plan"],
+      fetchImpl: async (url, options) => {
+        assert.equal(url, "https://api.minimax.io/v1/coding_plan/remains");
+        assert.equal(options.headers.Authorization, "Bearer TEST_MINIMAX_USAGE_KEY");
+        return new Response(JSON.stringify({
+          model_remains: [{
+            model_name: "general",
+            start_time: 1_786_564_800_000,
+            end_time: 1_786_579_200_000,
+            current_interval_remaining_percent: 55,
+            current_weekly_remaining_percent: 40,
+            weekly_end_time: 1_786_924_800_000,
+          }],
+          base_resp: { status_code: 0, status_msg: "success" },
+        }));
+      },
+    });
+    assert.equal(snapshot["minimax-token-plan"].status, "available");
+    assert.equal(snapshot["minimax-token-plan"].metrics[0].remainingPercent, 55);
+    assert.equal(snapshot["minimax-token-plan"].metrics[1].label, "Weekly limit");
+    assert.doesNotMatch(JSON.stringify(snapshot), /TEST_MINIMAX_USAGE_KEY/);
+  } finally {
+    if (saved === undefined) delete process.env.MINIMAX_API_KEY;
+    else process.env.MINIMAX_API_KEY = saved;
+  }
+});
+
+test("MiniMax token plan usage surfaces an API error status", async () => {
+  const saved = process.env.MINIMAX_API_KEY;
+  process.env.MINIMAX_API_KEY = "TEST_MINIMAX_ERROR_KEY";
+  try {
+    const snapshot = await providerAccountUsageSnapshot({
+      providerIds: ["minimax-token-plan"],
+      fetchImpl: async () => new Response(JSON.stringify({
+        base_resp: { status_code: 1004, status_msg: "invalid api key" },
+      })),
+    });
+    assert.equal(snapshot["minimax-token-plan"].status, "unavailable");
+    assert.match(snapshot["minimax-token-plan"].message, /invalid api key/);
+  } finally {
+    if (saved === undefined) delete process.env.MINIMAX_API_KEY;
+    else process.env.MINIMAX_API_KEY = saved;
+  }
+});
+
+test("MiniMax token plan usage avoids the plan API for a custom endpoint", async () => {
+  const savedKey = process.env.MINIMAX_API_KEY;
+  const savedBase = process.env.MINIMAX_BASE_URL;
+  process.env.MINIMAX_API_KEY = "TEST_MINIMAX_CUSTOM_KEY";
+  process.env.MINIMAX_BASE_URL = "https://example.test/v1";
+  try {
+    const snapshot = await providerAccountUsageSnapshot({
+      providerIds: ["minimax-token-plan"],
+      fetchImpl: async () => {
+        throw new Error("custom MiniMax endpoints must not trigger plan API calls");
+      },
+    });
+    assert.equal(snapshot["minimax-token-plan"].status, "local-only");
+    assert.match(snapshot["minimax-token-plan"].message, /custom MiniMax endpoint/);
+  } finally {
+    if (savedKey === undefined) delete process.env.MINIMAX_API_KEY;
+    else process.env.MINIMAX_API_KEY = savedKey;
+    if (savedBase === undefined) delete process.env.MINIMAX_BASE_URL;
+    else process.env.MINIMAX_BASE_URL = savedBase;
   }
 });
 
@@ -426,6 +707,71 @@ test("normalizes Grok weekly credits usage from billing proxy", () => {
     unit: "percent",
     resetAt: 1784693470.883,
   }]);
+});
+
+test("treats a Grok period without creditUsagePercent as 0% used", () => {
+  // proto3 JSON omits zero-valued fields, so a fresh weekly window arrives
+  // with a currentPeriod but no creditUsagePercent at all.
+  assert.deepEqual(grokCreditsMetrics({
+    config: {
+      currentPeriod: {
+        type: "USAGE_PERIOD_TYPE_WEEKLY",
+        start: "2026-08-12T04:11:10.883403+00:00",
+        end: "2026-08-19T04:11:10.883403+00:00",
+      },
+      onDemandCap: { val: 0 },
+      onDemandUsed: { val: 0 },
+      prepaidBalance: { val: 0 },
+      isUnifiedBillingUser: true,
+    },
+  }), [{
+    kind: "quota",
+    label: "Weekly limit",
+    usedPercent: 0,
+    remainingPercent: 100,
+    used: 0,
+    limit: 100,
+    remaining: 100,
+    unit: "percent",
+    resetAt: 1787112670.883,
+  }]);
+});
+
+test("returns no Grok metrics for a config without any billing period", () => {
+  assert.deepEqual(grokCreditsMetrics({ config: { isUnifiedBillingUser: true } }), []);
+});
+
+test("normalizes Command Code plan windows and skips a zero resetAt", () => {
+  assert.deepEqual(commandCodeCreditsMetrics({
+    credits: { monthlyCredits: 10, purchasedCredits: 0, freeCredits: 0 },
+    windowLimits: {
+      limited: true,
+      fiveHour: { used: 0, cap: 3, exceeded: false, resetAt: 0 },
+      weekly: { used: 0, cap: 6, exceeded: false, resetAt: 1_786_579_200_000 },
+    },
+  }), [
+    {
+      kind: "quota",
+      label: "5-hour limit",
+      usedPercent: 0,
+      remainingPercent: 100,
+      used: 0,
+      limit: 3,
+      remaining: 3,
+      unit: "credits",
+    },
+    {
+      kind: "quota",
+      label: "Weekly limit",
+      usedPercent: 0,
+      remainingPercent: 100,
+      used: 0,
+      limit: 6,
+      remaining: 6,
+      unit: "credits",
+      resetAt: 1_786_579_200,
+    },
+  ]);
 });
 
 test("normalizes Grok prepaid credits and pay-as-you-go balance", () => {


### PR DESCRIPTION
## Summary

- **xAI Grok OAuth (bug fix)**: the billing proxy serializes proto3 JSON, which omits zero-valued fields — a fresh weekly window arrives without `creditUsagePercent` and the usage card showed "unavailable" instead of 100% left. A billing period with no percent now reads as 0% used.
- **MiniMax Token Plan**: new fetcher for `GET /v1/coding_plan/remains`, surfacing the interval (e.g. 4-hour) and weekly windows of the coding (`general`) entry; video/image allowances are ignored.
- **Command Code**: new fetcher for `GET /alpha/billing/credits` — the route the official `command-code` CLI polls — surfacing 5-hour and weekly credit windows. Any failure degrades to the previous Studio-link + router-traffic behavior.
- **opencode Go**: new fetcher for `GET /zen/go/v1/usage`, surfacing rolling, weekly, and monthly windows. Protocol variants (`opencode-go-messages`/`-responses`) share the account automatically.
- Every fetcher refuses to send the credential to a custom base URL (falls back to local-only), matching the existing DeepSeek/Kimi/Chutes guards.

## Subagent vs picker UX

- The desktop subagent list now shows only picker-visible models. Hidden models rendered as permanently locked rows; they are filtered out, with a note giving the hidden count and pointing at the picker section to bring them back.
- Toolbar labels name the setting they change ("Subagents on/off", "Show all"/"Hide all") and both surfaces note that subagent choices do not hide models from Codex's picker.
- The tray keys per-provider expansion by section so the two look-alike panels no longer expand in lockstep, and shows per-provider "N of M on / visible" counts.

## Test plan

- [x] 8 new unit tests for the Grok zero-usage regression, MiniMax, Command Code, and opencode Go metric parsers plus snapshot fetchers (URL, Bearer auth, custom-endpoint guard, error status, no key leakage)
- [x] Full suite on this branch: 976 pass, 0 fail
- [x] Verified live against real accounts: all four providers report `available` with correct remaining percentages and reset times
- [ ] Manual: open the desktop panel, confirm quota cards for the four providers and the filtered subagent list with hidden-count note