### PR TITLE
Surface upstream error cause chains, meter native failures, flatten union-rooted tool schemas for xAI

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -2,6 +2,7 @@ import http from "node:http";
 
 import {
   applyKeepAliveTimeouts,
+  formatErrorChain,
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
   pipeResponse,
@@ -701,7 +702,12 @@ async function handleRequest(request, response) {
 const server = http.createServer((request, response) => {
   handleRequest(request, response).catch((error) => {
     const status = httpErrorStatus(error);
-    console.error("[api-forwarder] request failed");
+    // Names and codes only: a forwarder failure can wrap upstream response
+    // text in its message, and bodies never belong in the log. The code chain
+    // is what distinguishes a dead socket from a refused connect (#171).
+    console.error(
+      `[api-forwarder] request failed: ${formatErrorChain(error, { messages: false })}`,
+    );
     if (!response.headersSent) {
       writeJson(response, status, {
         error: {

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -17,6 +17,7 @@ import { PORTS } from "./paths.mjs";
 import { MODELS } from "./model-registry.mjs";
 import { ensureFreshGrokOAuthToken } from "./grok-oauth-session.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
+import { objectRootToolSchema } from "./tool-schema-root.mjs";
 import { VERSION } from "./version.mjs";
 
 // LiteLLM speaks OpenAI Chat Completions to this forwarder. It reuses the
@@ -186,7 +187,11 @@ export function toResponsesRequest(chat, options = {}) {
           type: "function",
           name: tool.function.name,
           description: tool.function.description,
-          parameters: tool.function.parameters || { type: "object", properties: {} },
+          // xAI 400s the whole request over a union-rooted parameter schema,
+          // which Codex's own `automation_update` app tool ships.
+          parameters: objectRootToolSchema(
+            tool.function.parameters || { type: "object", properties: {} },
+          ),
           strict: false,
         }))
     : [];

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   applyKeepAliveTimeouts,
+  formatErrorChain,
   httpErrorStatus,
   readRequestBody,
   requireInternalAuth,
@@ -485,7 +486,11 @@ if (isMain) {
   const server = http.createServer((request, response) => {
     handleRequest(request, response).catch((error) => {
       const status = httpErrorStatus(error);
-      console.error("[grok-oauth] request failed");
+      // Names and codes only: a refresh failure can wrap upstream response
+      // text in its message, and bodies never belong in the log (#171).
+      console.error(
+        `[grok-oauth] request failed: ${formatErrorChain(error, { messages: false })}`,
+      );
       if (!response.headersSent) {
         writeJson(response, status, {
           error: {

--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -74,6 +74,41 @@ export function writeJson(response, status, payload) {
   response.end(body);
 }
 
+// The transport reports every connection-level failure as a bare
+// `TypeError: fetch failed`; the code that says why (ECONNREFUSED,
+// UND_ERR_CONNECT_TIMEOUT, ENOTFOUND, ...) lives on the `cause` chain, and a
+// log line that stops at the top error is what left #171's repeated native
+// failures unexplainable from the retained log. Walk the chain and name every
+// link. Services whose failures can wrap upstream response text pass
+// `messages: false` and record names and codes only, which never carry a body.
+const MAX_ERROR_CHAIN_DEPTH = 8;
+
+export function formatErrorChain(error, { messages = true } = {}) {
+  const parts = [];
+  let current = error;
+  for (
+    let depth = 0;
+    current !== undefined && current !== null && depth < MAX_ERROR_CHAIN_DEPTH;
+    depth += 1
+  ) {
+    if (typeof current !== "object") {
+      parts.push(String(current));
+      break;
+    }
+    const name = typeof current.name === "string" && current.name ? current.name : "Error";
+    const message =
+      messages && typeof current.message === "string" && current.message
+        ? `: ${current.message}`
+        : "";
+    const code = current.code !== undefined ? ` (${current.code})` : "";
+    parts.push(`${name}${message}${code}`);
+    // AggregateError (a dual-stack connect failure) links its members through
+    // `errors` rather than `cause`; the first member names the socket failure.
+    current = current.cause ?? (Array.isArray(current.errors) ? current.errors[0] : undefined);
+  }
+  return parts.length ? parts.join(" <- ") : String(error);
+}
+
 export function httpErrorStatus(error, fallback = 502) {
   const status = Number(error?.status);
   return Number.isInteger(status) && status >= 400 && status <= 599

--- a/src/oauth-forwarder.mjs
+++ b/src/oauth-forwarder.mjs
@@ -2,6 +2,7 @@ import http from "node:http";
 
 import {
   applyKeepAliveTimeouts,
+  formatErrorChain,
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
   pipeResponse,
@@ -226,7 +227,11 @@ const server = http.createServer((request, response) => {
   handleRequest(request, response).catch((error) => {
     const status = httpErrorStatus(error);
     const authenticationFailure = status === 401;
-    console.error("[kimi-oauth] request failed");
+    // Names and codes only: a refresh failure can wrap upstream response text
+    // in its message, and bodies never belong in the log (#171).
+    console.error(
+      `[kimi-oauth] request failed: ${formatErrorChain(error, { messages: false })}`,
+    );
     if (!response.headersSent) {
       writeJson(response, status, {
         error: {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -18,6 +18,7 @@ import {
   applyKeepAliveTimeouts,
   endStreamedResponse,
   finishResponse,
+  formatErrorChain,
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
   pipeResponse,
@@ -2159,12 +2160,13 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
   const startedAt = Date.now();
   const activity = beginRequestActivity();
   let clientGone = false;
+  let requestedModel = defaultModel;
   try {
     if (!requireCodexTransport(request, response)) return;
     const encoded = await readRequestBody(request);
     const body = decodeBody(encoded, request.headers["content-encoding"]);
     const payload = parseBody(body);
-    const requestedModel =
+    requestedModel =
       typeof payload.model === "string" ? payload.model : defaultModel;
     activity.setRoute({
       provider: "openai",
@@ -2224,11 +2226,29 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
       );
     }
   } catch (error) {
+    // A failure with no usage event is invisible to the diagnostic that
+    // separates "the upstream failed" from "the request died inside the
+    // router" — the distinction #171 turned on. Meter this path the way the
+    // turn path does: a departed client as 0, everything else by its status.
     if (clientGone) {
+      recordUsageEvent({
+        model: requestedModel,
+        provider: "openai",
+        status: 0,
+        durationMs: Date.now() - startedAt,
+      });
       activity.finish(0);
       return;
     }
-    activity.finish(500);
+    const status = response.headersSent ? 502 : httpErrorStatus(error);
+    recordUsageEvent({
+      model: requestedModel,
+      provider: "openai",
+      status,
+      durationMs: Date.now() - startedAt,
+      ...(response.headersSent ? { streamAborted: true } : {}),
+    });
+    activity.finish(status);
     throw error;
   } finally {
     activity.finish(response.statusCode);
@@ -2306,13 +2326,11 @@ const server = http.createServer((request, response) => {
   handleRequest(request, response).catch((error) => {
     const status = httpErrorStatus(error);
     // The bare string this used to log made every mid-stream failure
-    // indistinguishable in production. The cause belongs in the log; response
-    // bodies never do, so only the error's own message and code are recorded.
-    console.error(
-      `[codex-router] request failed: ${
-        error instanceof Error ? `${error.name}: ${error.message}` : String(error)
-      }${error?.code ? ` (${error.code})` : ""}`,
-    );
+    // indistinguishable in production, and stopping at the top error was the
+    // second half of the same problem: a native connect failure logs
+    // `TypeError: fetch failed` with the socket-level code buried on its cause
+    // (#171). The whole chain belongs in the log; response bodies never do.
+    console.error(`[codex-router] request failed: ${formatErrorChain(error)}`);
     if (!response.headersSent) {
       writeJson(response, status, {
         error: {
@@ -2358,6 +2376,24 @@ server.on("error", (error) => {
     }${error?.code ? ` (${error.code})` : ""}`,
   );
   process.exit(96);
+});
+// One escaped error here takes native and routed traffic down together, and
+// the default crash leaves nothing in the service log but the supervisor's
+// exit line — #171 recorded `exited (code=4294967295)` on Windows with no way
+// to tell an in-process crash from an external kill. Name the failure and its
+// whole cause chain before exiting, and use exit codes distinct from the
+// listen-failure ones above so the supervisor's line alone classifies the
+// death. The exit itself stays: after an uncaught throw the process state is
+// unknowable, and the service manager owns the restart.
+process.on("uncaughtException", (error) => {
+  console.error(`[codex-router] uncaught exception: ${formatErrorChain(error)}`);
+  if (error?.stack) console.error(error.stack);
+  process.exit(95);
+});
+process.on("unhandledRejection", (reason) => {
+  console.error(`[codex-router] unhandled rejection: ${formatErrorChain(reason)}`);
+  if (reason?.stack) console.error(reason.stack);
+  process.exit(94);
 });
 server.requestTimeout = 0;
 applyKeepAliveTimeouts(server);

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -1,0 +1,116 @@
+// xAI rejects any tool whose parameter schema does not have an object at the
+// root: "tool parameter root must be an object type (root schema is an
+// anyOf/oneOf union with a non-object branch)". The rejection fails the whole
+// request, not the one tool, so a single union-rooted definition makes every
+// turn on that provider a 400.
+//
+// Codex ships exactly such a tool: `codex_app__automation_update` roots its
+// schema in a `oneOf` over the view/create/update/delete shapes. The router
+// relays the app toolset to routed providers verbatim, which is how a Grok
+// session that never touches automations still dies on its first message.
+//
+// Flattening keeps the tool callable: the branches are merged into one object
+// so the model still sees every field it may send, with `required` narrowed to
+// the fields every branch demands (usually none, because the branches are
+// alternatives). Validation of which combination is legal stays where it
+// already was -- the Codex app executes these calls and checks its own
+// arguments.
+
+const MAX_DEPTH = 8;
+
+function isPlainObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Resolves the local `#/$defs/...` and `#/definitions/...` pointers Codex
+// emits. Anything else (remote refs, unusual pointers) resolves to undefined
+// and the branch is skipped rather than guessed at.
+function resolveRef(ref, root) {
+  if (typeof ref !== "string" || !ref.startsWith("#/")) return undefined;
+  let node = root;
+  for (const rawSegment of ref.slice(2).split("/")) {
+    if (!isPlainObject(node)) return undefined;
+    node = node[rawSegment.replace(/~1/g, "/").replace(/~0/g, "~")];
+  }
+  return isPlainObject(node) ? node : undefined;
+}
+
+// Every object-typed leaf reachable from `schema` through unions and local
+// refs. `seen` guards the self-referential `$defs` Codex generates.
+function objectBranches(schema, root, seen, depth = 0) {
+  if (!isPlainObject(schema) || depth > MAX_DEPTH) return [];
+  if (typeof schema.$ref === "string") {
+    if (seen.has(schema.$ref)) return [];
+    seen.add(schema.$ref);
+    return objectBranches(resolveRef(schema.$ref, root), root, seen, depth + 1);
+  }
+  const branches = [];
+  for (const keyword of ["anyOf", "oneOf", "allOf"]) {
+    if (!Array.isArray(schema[keyword])) continue;
+    for (const branch of schema[keyword]) {
+      branches.push(...objectBranches(branch, root, seen, depth + 1));
+    }
+  }
+  if (schema.type === "object" || isPlainObject(schema.properties)) branches.push(schema);
+  return branches;
+}
+
+const UNION_KEYWORDS = ["anyOf", "oneOf", "allOf"];
+
+function hasRootUnion(schema) {
+  return UNION_KEYWORDS.some((keyword) => Array.isArray(schema[keyword]));
+}
+
+// xAI's rule is about the root *keywords*, not the declared type: a schema may
+// say `type: "object"` and still be rejected for carrying a `oneOf` beside it.
+// Checking only `type`/`properties` here is what let the live client's
+// `automation_update` -- which sends both -- through untouched.
+export function hasObjectRoot(schema) {
+  if (!isPlainObject(schema)) return false;
+  if (hasRootUnion(schema)) return false;
+  return schema.type === "object" || isPlainObject(schema.properties);
+}
+
+// Returns `schema` unchanged when its root is already a plain object, so the
+// common case costs one type check and no copy.
+export function objectRootToolSchema(schema) {
+  if (!isPlainObject(schema)) return { type: "object", properties: {} };
+  if (hasObjectRoot(schema)) return schema;
+
+  const branches = objectBranches(schema, schema, new Set());
+  const properties = {};
+  // Root-level properties apply to every branch, so they win over branch
+  // definitions of the same name.
+  if (isPlainObject(schema.properties)) Object.assign(properties, schema.properties);
+  for (const branch of branches) {
+    if (!isPlainObject(branch.properties)) continue;
+    for (const [name, property] of Object.entries(branch.properties)) {
+      if (!(name in properties)) properties[name] = property;
+    }
+  }
+  // Required only where every branch requires it: a field the view branch
+  // demands is optional for the delete branch, and marking it required would
+  // reject calls the app accepts. Root-level requirements are separate -- they
+  // bind every branch, so they survive whatever the branches disagree about.
+  const rootRequired = Array.isArray(schema.required) ? schema.required : [];
+  const unionBranches = branches.filter((branch) => branch !== schema);
+  const shared = unionBranches.length
+    ? unionBranches
+        .map((branch) => (Array.isArray(branch.required) ? branch.required : []))
+        .reduce((left, right) => left.filter((name) => right.includes(name)))
+    : [];
+  const required = [...new Set([...rootRequired, ...shared])];
+
+  return {
+    ...(schema.$schema ? { $schema: schema.$schema } : {}),
+    ...(schema.$defs ? { $defs: schema.$defs } : {}),
+    ...(schema.definitions ? { definitions: schema.definitions } : {}),
+    ...(typeof schema.description === "string" ? { description: schema.description } : {}),
+    type: "object",
+    properties,
+    ...(required.length ? { required } : {}),
+    // The merged object cannot describe which branch a call belongs to, so it
+    // must not reject fields that only one branch declares.
+    additionalProperties: true,
+  };
+}

--- a/src/upstream-retry.mjs
+++ b/src/upstream-retry.mjs
@@ -78,7 +78,15 @@ export const RETRYABLE_STATUSES = new Set([502, 503, 504, 520, 521, 522, 523, 52
 
 // Transport failures where no response ever started. `fetch` reports these as
 // a generic TypeError whose cause carries the socket-level code.
+//
+// ENOTFOUND, EADDRNOTAVAIL, and ENOBUFS joined after #171: a Windows machine
+// under loopback churn failed native connects repeatedly while the same
+// origin answered other requests in the same window, which is the transient
+// shape this bound exists to absorb. All three fail before a connection
+// exists — a name that did not resolve, no ephemeral port to bind, no kernel
+// buffer for the socket — so a retry can never be a second execution.
 const RETRYABLE_ERROR_CODES = new Set([
+  "EADDRNOTAVAIL",
   "ECONNABORTED",
   "ECONNREFUSED",
   "ECONNRESET",
@@ -86,6 +94,8 @@ const RETRYABLE_ERROR_CODES = new Set([
   "EHOSTUNREACH",
   "ENETDOWN",
   "ENETUNREACH",
+  "ENOBUFS",
+  "ENOTFOUND",
   "EPIPE",
   "ETIMEDOUT",
   "UND_ERR_CONNECT_TIMEOUT",

--- a/test/error-chain.test.mjs
+++ b/test/error-chain.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatErrorChain } from "../src/http-utils.mjs";
+
+// The failure #171 could not explain from its logs: undici reports a connect
+// failure as a bare `TypeError: fetch failed` and hides the socket-level code
+// on the cause. The chain has to surface every link, or the log answers
+// "something failed" and nothing else.
+test("a fetch failure names the socket-level cause behind it", () => {
+  const error = new TypeError("fetch failed");
+  error.cause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:443"), {
+    code: "ECONNREFUSED",
+  });
+  assert.equal(
+    formatErrorChain(error),
+    "TypeError: fetch failed <- Error: connect ECONNREFUSED 127.0.0.1:443 (ECONNREFUSED)",
+  );
+});
+
+// A dual-stack connect failure arrives as an AggregateError whose members,
+// not whose cause, carry the socket codes.
+test("an AggregateError is followed through its first member", () => {
+  const error = new TypeError("fetch failed");
+  const aggregate = new AggregateError(
+    [
+      Object.assign(new Error("connect ETIMEDOUT 1.2.3.4:443"), { code: "ETIMEDOUT" }),
+      Object.assign(new Error("connect ENETUNREACH ::1:443"), { code: "ENETUNREACH" }),
+    ],
+    "",
+  );
+  error.cause = aggregate;
+  assert.match(formatErrorChain(error), /AggregateError/);
+  assert.match(formatErrorChain(error), /ETIMEDOUT/);
+});
+
+// The forwarders sit behind providers whose failures can wrap upstream
+// response text into a message. Names and codes never carry a body, so that
+// is all they may log.
+test("messages can be suppressed while names and codes survive", () => {
+  const error = new Error('upstream said {"secret":"leaky body text"}');
+  error.code = "UND_ERR_SOCKET";
+  error.cause = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+  const formatted = formatErrorChain(error, { messages: false });
+  assert.equal(formatted, "Error (UND_ERR_SOCKET) <- Error (ECONNRESET)");
+  assert.equal(/leaky/.test(formatted), false);
+});
+
+test("a thrown non-error is stringified rather than dropped", () => {
+  assert.equal(formatErrorChain("boom"), "boom");
+  assert.equal(formatErrorChain(42), "42");
+});
+
+// A cyclic cause chain must terminate rather than loop; depth is the bound.
+test("a cyclic cause chain terminates at the depth bound", () => {
+  const first = new Error("first");
+  const second = new Error("second");
+  first.cause = second;
+  second.cause = first;
+  const formatted = formatErrorChain(first);
+  assert.match(formatted, /^Error: first <- Error: second/);
+  assert.equal(formatted.split(" <- ").length, 8);
+});

--- a/test/native-retry.test.mjs
+++ b/test/native-retry.test.mjs
@@ -469,6 +469,35 @@ test("a connect failure is retried and an abort never is", async () => {
   assert.equal(abortCalls, 1);
 });
 
+// #171: a Windows machine under loopback churn failed native connects with
+// codes outside the original set while the same origin answered other
+// requests in the same window. Each of these fails before a connection
+// exists, so a retry can never re-execute work.
+test("pre-connection failures added after #171 are retried", async () => {
+  for (const code of ["ENOTFOUND", "EADDRNOTAVAIL", "ENOBUFS"]) {
+    let calls = 0;
+    const retried = await fetchWithRetry(
+      "http://upstream.invalid/responses",
+      {},
+      {
+        retries: 1,
+        backoffMs: 0,
+        fetchImpl: async () => {
+          calls += 1;
+          if (calls < 2) {
+            const error = new TypeError("fetch failed");
+            error.cause = Object.assign(new Error(`socket ${code}`), { code });
+            throw error;
+          }
+          return new Response("ok", { status: 200 });
+        },
+      },
+    );
+    assert.equal(calls, 2, `${code} was not retried`);
+    assert.equal(retried.response.status, 200);
+  }
+});
+
 // A 504 the edge spent half a minute producing is still a 504, but retrying it
 // twice would turn a slow failure into a hang.
 test("a retryable failure that was slow to arrive is not retried", async () => {

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CODEX_APP_TOOLS } from "../src/codex-app-tools.mjs";
+import { toResponsesRequest } from "../src/grok-oauth-forwarder.mjs";
+import { hasObjectRoot, objectRootToolSchema } from "../src/tool-schema-root.mjs";
+
+test("object-rooted schemas are returned untouched", () => {
+  const schema = { type: "object", properties: { path: { type: "string" } }, required: ["path"] };
+  assert.equal(objectRootToolSchema(schema), schema);
+});
+
+test("a schema with properties but no type counts as object-rooted", () => {
+  const schema = { properties: { path: { type: "string" } } };
+  assert.equal(objectRootToolSchema(schema), schema);
+});
+
+// The shape the live Codex client actually sends: an object root that also
+// carries a root-level union. xAI rejects it on the union alone, so declaring
+// `type: "object"` must not buy a pass.
+test("an object root carrying a root union is still rewritten", () => {
+  const flattened = objectRootToolSchema({
+    type: "object",
+    properties: { mode: { type: "string" } },
+    required: ["mode"],
+    oneOf: [
+      { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+      { type: "object", properties: { name: { type: "string" } }, required: ["name"] },
+    ],
+  });
+  assert.equal(flattened.oneOf, undefined, "the root union is gone");
+  assert.deepEqual(Object.keys(flattened.properties).sort(), ["id", "mode", "name"]);
+  // "mode" binds every branch; "id" and "name" are alternatives.
+  assert.deepEqual(flattened.required, ["mode"]);
+  assert.equal(hasObjectRoot(flattened), true);
+});
+
+test("union roots flatten into one object with every branch property", () => {
+  const flattened = objectRootToolSchema({
+    oneOf: [
+      { type: "object", properties: { mode: { const: "view" }, id: { type: "string" } }, required: ["mode", "id"] },
+      { type: "object", properties: { mode: { const: "delete" }, force: { type: "boolean" } }, required: ["mode"] },
+    ],
+  });
+  assert.equal(flattened.type, "object");
+  assert.deepEqual(Object.keys(flattened.properties).sort(), ["force", "id", "mode"]);
+  // "mode" is required by both branches, "id" only by the first.
+  assert.deepEqual(flattened.required, ["mode"]);
+  assert.equal(flattened.additionalProperties, true);
+});
+
+test("branches behind local $refs are resolved", () => {
+  const flattened = objectRootToolSchema({
+    $defs: {
+      create: { type: "object", properties: { name: { type: "string" } }, required: ["name"] },
+    },
+    anyOf: [{ $ref: "#/$defs/create" }, { type: "null" }],
+  });
+  assert.deepEqual(Object.keys(flattened.properties), ["name"]);
+  // The null branch is unreachable once the root must be an object, so the
+  // surviving branch's own requirement stands.
+  assert.deepEqual(flattened.required, ["name"]);
+  assert.ok(flattened.$defs, "keeps $defs so nested refs still resolve");
+});
+
+test("self-referential $refs terminate", () => {
+  const flattened = objectRootToolSchema({
+    $defs: { loop: { anyOf: [{ $ref: "#/$defs/loop" }] } },
+    oneOf: [{ $ref: "#/$defs/loop" }],
+  });
+  assert.equal(flattened.type, "object");
+  assert.deepEqual(flattened.properties, {});
+});
+
+test("a union with no object branch still yields a permissive object", () => {
+  const flattened = objectRootToolSchema({ anyOf: [{ type: "string" }, { type: "number" }] });
+  assert.equal(flattened.type, "object");
+  assert.equal(flattened.additionalProperties, true);
+});
+
+test("non-schema input yields an empty object schema", () => {
+  assert.deepEqual(objectRootToolSchema(undefined), { type: "object", properties: {} });
+  assert.deepEqual(objectRootToolSchema("nonsense"), { type: "object", properties: {} });
+});
+
+// The regression this exists for: xAI answers
+// "[invalid_client_tool_schema] codex_app__automation_update: tool parameter
+// root must be an object type" and fails the entire request, so a Grok session
+// could not complete a single turn while the Codex app toolset was attached.
+test("every Codex app tool reaches xAI with an object root", () => {
+  const appTools = CODEX_APP_TOOLS.flatMap((entry) =>
+    entry.type === "namespace" ? entry.tools : [entry],
+  );
+  const unionRooted = appTools.filter((tool) => !hasObjectRoot(tool.inputSchema));
+  assert.ok(
+    unionRooted.length > 0,
+    "expected at least one union-rooted app tool, or this test proves nothing",
+  );
+
+  const request = toResponsesRequest({
+    model: "grok-4.6",
+    messages: [{ role: "user", content: "hi" }],
+    tools: appTools.map((tool) => ({
+      type: "function",
+      function: { name: `codex_app__${tool.name}`, parameters: tool.inputSchema },
+    })),
+  });
+  for (const tool of request.tools.filter((entry) => entry.type === "function")) {
+    assert.ok(
+      hasObjectRoot(tool.parameters),
+      `${tool.name} would be rejected by xAI: root is not an object`,
+    );
+  }
+});
+
+test("automation_update keeps its branch fields after flattening", () => {
+  const automationUpdate = CODEX_APP_TOOLS.flatMap((entry) =>
+    entry.type === "namespace" ? entry.tools : [entry],
+  ).find((tool) => tool.name === "automation_update");
+  assert.ok(automationUpdate, "automation_update is still part of the app toolset");
+
+  const flattened = objectRootToolSchema(automationUpdate.inputSchema);
+  assert.equal(flattened.type, "object");
+  assert.ok(
+    Object.keys(flattened.properties).includes("mode"),
+    "the discriminating field survives the merge",
+  );
+});


### PR DESCRIPTION
## Summary

Two fixes, one commit each:

**`fix: surface upstream error cause chains and meter native failures`** — closes #171

- New `formatErrorChain()` in `src/http-utils.mjs` walks up to 8 links of `error.cause` (and `AggregateError.errors[0]`), so a native connect failure now logs the socket-level code instead of a bare `TypeError: fetch failed`. Wired into the router plus all three forwarders; the forwarders log names and codes only (`messages: false`) because their failures can wrap upstream response text.
- `ENOTFOUND`, `EADDRNOTAVAIL`, and `ENOBUFS` join the retryable transport codes — all three fail before a connection exists, so a retry can never re-execute work.
- Every native failure path now records a usage event (client-gone as status 0, everything else by its status), closing the "502 with no usage event" blind spot that made #171 hard to diagnose.
- `uncaughtException` / `unhandledRejection` handlers log the full chain and exit 95/94, so the supervisor's exit line alone distinguishes an in-process crash from an external kill (`code=4294967295`).

**`fix: flatten union-rooted tool parameter schemas for xAI OAuth`**

- xAI rejects any tool whose parameter schema roots in an `anyOf`/`oneOf`/`allOf` union, and the rejection 400s the whole request. Codex's own `codex_app__automation_update` ships a `oneOf` root, so a Grok OAuth session died on its first message whenever the app toolset was relayed.
- New `src/tool-schema-root.mjs` flattens union roots into a single object schema: branch properties merged, `required` narrowed to the intersection across branches, `additionalProperties: true`, local `$defs`/`definitions` refs resolved, object-rooted schemas passed through untouched.

## Test plan

- [x] New `test/error-chain.test.mjs` covers the chain formatter (depth cap, AggregateError, messages-off mode)
- [x] New `test/tool-schema-root.test.mjs` covers the schema flattener
- [x] New retry cases in `test/native-retry.test.mjs` for the three added codes
- [x] Full suite on this branch: 992 pass, 0 fail, 6 skipped