### PR TITLE
Release 0.4.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,46 @@
 # Changelog
 
-## Unreleased
+## 0.4.0-beta.3
+
+- **The usage panel shows what is left of your plan for xAI OAuth, MiniMax,
+  Command Code, and opencode Go.** MiniMax reads its coding-plan remains
+  endpoint (interval and weekly windows), Command Code reads the same billing
+  credits route its official CLI polls (5-hour and weekly windows), and
+  opencode Go reads its usage endpoint (rolling, weekly, and monthly windows,
+  shared across the protocol variants). A fresh xAI weekly window arrives with
+  its zero usage omitted from the wire format, which used to read as
+  "unavailable" instead of everything left — a billing period with no percent
+  now reads as 0% used. Every fetcher refuses to send the credential anywhere
+  but the provider's own host, and any failure degrades to the previous
+  router-traffic view.
+
+- **The subagent list shows only models you can actually pick.** Hidden models
+  rendered as permanently locked rows; they are filtered out, with a note
+  giving the hidden count and pointing at the picker section that brings them
+  back. Toolbar labels name the setting they change, both surfaces note that
+  subagent choices never hide models from Codex's picker, and the tray's two
+  look-alike provider panels no longer expand in lockstep.
+
+- **A failed request names its cause all the way down.** The transport reports
+  every connection-level failure as a bare `TypeError: fetch failed` with the
+  code that says why buried on the cause chain, which left repeated native
+  failures unexplainable from the retained log. The router and every forwarder
+  now log the whole chain — names and codes only where a failure can wrap
+  upstream response text. Name-resolution and local-resource failures
+  (`ENOTFOUND`, `EADDRNOTAVAIL`, `ENOBUFS`) joined the retryable set, since
+  all three fail before a connection exists. Every native failure now records
+  a usage event, so a 502 without one can no longer hide inside the router,
+  and an uncaught crash exits with its own code (95/94) and full chain in the
+  log, so a supervisor's exit line alone distinguishes an in-process crash
+  from an external kill.
+
+- **One union-rooted tool schema no longer kills every xAI OAuth turn.** xAI
+  rejects the whole request when any tool's parameter schema roots in an
+  `anyOf`/`oneOf`/`allOf` union, and Codex's own automation tool ships one —
+  so a Grok session that never touched automations still died on its first
+  message. Union roots are flattened into a single object schema (branch
+  properties merged, `required` narrowed to what every branch demands) and
+  object-rooted schemas pass through untouched.
 
 - **GitHub Copilot is available as a catalog-only provider.** A
   fine-grained PAT with the Copilot Requests permission is validated through

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codex-router/desktop",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codex-router/desktop",
-      "version": "0.4.0-beta.2",
+      "version": "0.4.0-beta.3",
       "devDependencies": {
         "@tauri-apps/cli": "2.11.4"
       }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-router/desktop",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "codex-router-desktop"
-version = "0.4.0-beta.2"
+version = "0.4.0-beta.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-router-desktop"
-version = "0.4.0-beta.2"
+version = "0.4.0-beta.3"
 description = "Windows and Linux tray companion for Codex Model Router"
 authors = ["Codex Model Router contributors"]
 edition = "2021"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Codex Model Router",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "identifier": "com.codexrouter.desktop",
   "build": {
     "frontendDist": "../ui"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-model-router",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-model-router",
-      "version": "0.4.0-beta.2",
+      "version": "0.4.0-beta.3",
       "dependencies": {
         "proper-lockfile": "4.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-model-router",
-  "version": "0.4.0-beta.2",
+  "version": "0.4.0-beta.3",
   "private": true,
   "type": "module",
   "description": "Extensible local model router for Codex and Cursor",


### PR DESCRIPTION
Version bump + changelog for 0.4.0-beta.3.

Delivers to Homebrew/installer users the fixes for #162 (port 4101 BrlAPI conflict), #164 (brew-managed dependency reconciliation), #161 (minimax-m3 tool_choice downgrade), #159 (standalone web search), #171 (error-chain logging, retry codes, native failure metering, crash exit codes), the xAI union-root tool schema fix, and the plan-usage cards from #172.

After merge: tag `v0.4.0-beta.3` on main — the release workflow builds archives, publishes the GitHub release, and pushes the regenerated Homebrew formula.