### PR TITLE
fix: use global endpoint for Kimi API Platform

### DIFF
--- a/config/kimi/kimi.json
+++ b/config/kimi/kimi.json
@@ -13,7 +13,7 @@
       "displayName": "Kimi Platform API",
       "kind": "openai-compatible",
       "ownedBy": "kimi",
-      "baseUrl": "https://api.moonshot.cn/v1",
+      "baseUrl": "https://api.moonshot.ai/v1",
       "baseUrlEnv": "KIMI_API_BASE_URL",
       "credential": {
         "environment": [

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -151,6 +151,9 @@ test("provider registry exposes configured API and OAuth model families", () => 
     "COMMANDCODE_API_KEY",
   ]);
   assert.equal(PROVIDERS.get("grok-api").baseUrl, "https://api.x.ai/v1");
+  // Kimi API Platform uses the global endpoint by default; China/custom
+  // deployments can still override it with KIMI_API_BASE_URL.
+  assert.equal(PROVIDERS.get("kimi-api").baseUrl, "https://api.moonshot.ai/v1");
   assert.equal(PROVIDERS.get("github-copilot").authProfile, "github-copilot");
   assert.equal(PROVIDERS.get("github-copilot").protocol, "openai-responses");
   assert.deepEqual(PROVIDERS.get("github-copilot").credential.environment, [


### PR DESCRIPTION
## Why

The Kimi API Platform provider defaulted to the China endpoint (`api.moonshot.cn`). International Kimi API keys are rejected there, while the same key works with Moonshot’s global endpoint.

## What changed

- Use `https://api.moonshot.ai/v1` as the default for Kimi API Platform.
- Keep `KIMI_API_BASE_URL` as an override for China or custom deployments.
- Add a registry regression test.

This is a default-only change; explicit endpoint overrides are unchanged.

## Validation

- `node --test test/registry.test.mjs`
- `npm test`