### PR TITLE
fix: coerce whole-number tool arguments for Codex integer schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+- **Routed models that emit integer tool arguments as JSON floats no longer
+  get those calls rejected by Codex.** Grok 4.6 was sending
+  `timeout_ms: 20000.0`; Codex's native `shell_command` schema wants a `u64`,
+  so every agentic turn died before the command ran. The response rewrite now
+  turns whole-number tokens into integers on the way back, including native
+  tools that are not namespaced. Genuine fractions are left alone.
+
 ## 0.4.0-beta.3
 
 - **The usage panel shows what is left of your plan for xAI OAuth, MiniMax,

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -2,6 +2,7 @@ import { Transform } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
 
 import { HeaderlessSseDetector } from "./sse-prefix.mjs";
+import { coerceFunctionCallArguments } from "./tool-arguments.mjs";
 
 // The Codex client ships most of its toolset as `type: "namespace"` entries:
 // the collaboration runtime, the app toolset (threads, automations,
@@ -231,6 +232,13 @@ function sanitizeSpawnAgentModel(item, lookups) {
 // name (some models emit the unqualified form) is restored only when it is
 // unambiguous across every flattened namespace; a collision stays untouched
 // rather than guessing which runtime owns it.
+function rewriteFunctionCallArguments(item) {
+  if (!item || typeof item !== "object") return item;
+  const argumentsText = coerceFunctionCallArguments(item.arguments);
+  if (argumentsText === item.arguments) return item;
+  return { ...item, arguments: argumentsText };
+}
+
 function rewriteNamespaceFunctionCallItem(item, lookups, sessionModel) {
   if (!item || item.type !== "function_call") return undefined;
   let rewritten = item;
@@ -253,6 +261,7 @@ function rewriteNamespaceFunctionCallItem(item, lookups, sessionModel) {
   }
   rewritten = sanitizeSpawnAgentModel(rewritten, lookups);
   rewritten = injectSessionModelForSpawnCalls(rewritten, sessionModel);
+  rewritten = rewriteFunctionCallArguments(rewritten);
   return rewritten === item ? undefined : rewritten;
 }
 
@@ -281,6 +290,14 @@ export function rewriteNamespaceResponsePayload(payload, lookups, sessionModel) 
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
   let rewritten = rewriteNamespaceFunctionCall(payload, lookups, sessionModel) || payload;
   let changed = rewritten !== payload;
+
+  if (payload.type === "response.function_call_arguments.done") {
+    const argumentsText = coerceFunctionCallArguments(rewritten.arguments);
+    if (argumentsText !== rewritten.arguments) {
+      rewritten = { ...rewritten, arguments: argumentsText };
+      changed = true;
+    }
+  }
 
   const output = rewriteOutputItems(rewritten.output, lookups, sessionModel);
   if (output) {

--- a/src/tool-arguments.mjs
+++ b/src/tool-arguments.mjs
@@ -1,0 +1,85 @@
+// Codex tool schemas use integer/u64 fields. Some routed models (Grok in
+// particular) emit whole numbers as JSON floats (`20000.0`). Serde then
+// rejects the call before the tool runs.
+//
+// JSON.parse cannot see the difference between 20000 and 20000.0, so this
+// rewrites number tokens in the raw argument string.
+
+const JSON_NUMBER = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/;
+const PLAIN_INTEGER = /^-?(?:0|[1-9]\d*)$/;
+
+function integerToken(token) {
+  const value = Number(token);
+  if (!Number.isSafeInteger(value)) return token;
+  if (PLAIN_INTEGER.test(token) && !Object.is(value, -0)) return token;
+  return Object.is(value, -0) ? "0" : String(value);
+}
+
+export function rewriteWholeNumberTokens(raw) {
+  if (typeof raw !== "string" || raw.length === 0) return raw;
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < raw.length; ) {
+    const ch = raw[i];
+    if (inString) {
+      out += ch;
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === "-" || (ch >= "0" && ch <= "9")) {
+      const match = raw.slice(i).match(JSON_NUMBER);
+      if (match) {
+        out += integerToken(match[0]);
+        i += match[0].length;
+        continue;
+      }
+    }
+    out += ch;
+    i += 1;
+  }
+  return out;
+}
+
+export function coerceWholeNumberJson(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => coerceWholeNumberJson(entry));
+  }
+  if (!value || typeof value !== "object") {
+    if (typeof value === "number" && Number.isSafeInteger(value)) {
+      return Object.is(value, -0) ? 0 : value;
+    }
+    return value;
+  }
+  const next = {};
+  for (const [key, entry] of Object.entries(value)) {
+    next[key] = coerceWholeNumberJson(entry);
+  }
+  return next;
+}
+
+export function coerceFunctionCallArguments(raw) {
+  if (typeof raw !== "string") return raw;
+  try {
+    JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  const rewritten = rewriteWholeNumberTokens(raw);
+  if (rewritten === raw) return raw;
+  try {
+    JSON.parse(rewritten);
+  } catch {
+    return raw;
+  }
+  return rewritten;
+}

--- a/src/tool-arguments.mjs
+++ b/src/tool-arguments.mjs
@@ -6,13 +6,37 @@
 // rewrites number tokens in the raw argument string.
 
 const JSON_NUMBER = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/;
+const JSON_NUMBER_PARTS = /^(-)?(0|[1-9]\d*)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/;
 const PLAIN_INTEGER = /^-?(?:0|[1-9]\d*)$/;
 
+// Decide integrality from the token spelling. JS Number rounds 1e-324 to 0
+// and cannot represent every u64, so it must not be the judge.
+function integerSpelling(token) {
+  const parts = token.match(JSON_NUMBER_PARTS);
+  if (!parts) return undefined;
+  const sign = parts[1] || "";
+  const intPart = parts[2];
+  const fracPart = parts[3] || "";
+  const exp = parts[4] === undefined ? 0 : Number.parseInt(parts[4], 10);
+  if (!Number.isSafeInteger(exp)) return undefined;
+  const digits = intPart + fracPart;
+  const point = intPart.length + exp;
+  if (point > 40) return undefined;
+  for (let i = Math.max(0, point); i < digits.length; i += 1) {
+    if (digits[i] !== "0") return undefined;
+  }
+  let integerDigits;
+  if (point <= 0) integerDigits = "0";
+  else if (point >= digits.length) integerDigits = digits + "0".repeat(point - digits.length);
+  else integerDigits = digits.slice(0, point);
+  integerDigits = integerDigits.replace(/^0+(?=\d)/, "") || "0";
+  if (integerDigits === "0") return "0";
+  return `${sign}${integerDigits}`;
+}
+
 function integerToken(token) {
-  const value = Number(token);
-  if (!Number.isSafeInteger(value)) return token;
-  if (PLAIN_INTEGER.test(token) && !Object.is(value, -0)) return token;
-  return Object.is(value, -0) ? "0" : String(value);
+  if (PLAIN_INTEGER.test(token) && token !== "-0") return token;
+  return integerSpelling(token) ?? token;
 }
 
 export function rewriteWholeNumberTokens(raw) {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -565,3 +565,55 @@ test("rewriteNamespaceFunctionCall rejects non-call events", () => {
   assert.equal(rewriteNamespaceFunctionCall({ item: { type: "message" } }, lookups), undefined);
   assert.equal(rewriteNamespaceFunctionCall(undefined, lookups), undefined);
 });
+
+test("response rewrite turns Grok whole-float tool arguments into integers", () => {
+  const lookups = buildNamespaceLookups(new Map());
+  const rewritten = rewriteNamespaceResponsePayload(
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        name: "shell_command",
+        call_id: "call_shell",
+        arguments: '{"command":"git status","timeout_ms":20000.0}',
+      },
+    },
+    lookups,
+  );
+  assert.equal(rewritten.item.arguments, '{"command":"git status","timeout_ms":20000}');
+  assert.equal(rewritten.item.name, "shell_command");
+
+  const done = rewriteNamespaceResponsePayload(
+    {
+      type: "response.function_call_arguments.done",
+      item_id: "item_1",
+      arguments: '{"timeout_ms":20000.0,"ratio":3.14}',
+    },
+    lookups,
+  );
+  assert.equal(done.arguments, '{"timeout_ms":20000,"ratio":3.14}');
+});
+
+test("response transform rewrites native shell_command integer floats in SSE", async () => {
+  const events = [
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        name: "shell_command",
+        call_id: "call_shell",
+        arguments: '{"timeout_ms":20000.0}',
+      },
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: "item_1",
+      arguments: '{"timeout_ms":15000.0}',
+    },
+  ].map((event) => `data: ${JSON.stringify(event)}\n\n`);
+  const transform = new NamespaceToolCallTransform(new Map());
+  const output = await collect(Readable.from(events).pipe(transform));
+  assert.match(output, /timeout_ms\\":20000/);
+  assert.match(output, /timeout_ms\\":15000/);
+  assert.doesNotMatch(output, /20000\.0|15000\.0/);
+});

--- a/test/tool-arguments.test.mjs
+++ b/test/tool-arguments.test.mjs
@@ -63,3 +63,28 @@ test("coerceFunctionCallArguments ignores non-strings", () => {
   assert.equal(coerceFunctionCallArguments(undefined), undefined);
   assert.deepEqual(coerceFunctionCallArguments({ timeout_ms: 1.0 }), { timeout_ms: 1.0 });
 });
+
+test("trailing .0 is dropped even past MAX_SAFE_INTEGER", () => {
+  assert.equal(
+    coerceFunctionCallArguments('{"n":9007199254740993.0}'),
+    '{"n":9007199254740993}',
+  );
+  assert.equal(
+    coerceFunctionCallArguments('{"n":9007199254740992.0}'),
+    '{"n":9007199254740992}',
+  );
+});
+
+test("fractions that JS Number would round are left alone", () => {
+  assert.equal(coerceFunctionCallArguments('{"n":1e-324}'), '{"n":1e-324}');
+  assert.equal(
+    coerceFunctionCallArguments('{"n":9007199254740991.4}'),
+    '{"n":9007199254740991.4}',
+  );
+});
+
+test("whole scientific and extra-zero decimals become plain integers", () => {
+  assert.equal(coerceFunctionCallArguments('{"n":20000.00}'), '{"n":20000}');
+  assert.equal(coerceFunctionCallArguments('{"n":2e4}'), '{"n":20000}');
+  assert.equal(coerceFunctionCallArguments('{"n":-0.0}'), '{"n":0}');
+});

--- a/test/tool-arguments.test.mjs
+++ b/test/tool-arguments.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  coerceFunctionCallArguments,
+  coerceWholeNumberJson,
+} from "../src/tool-arguments.mjs";
+
+test("coerceWholeNumberJson turns whole floats into integers", () => {
+  assert.deepEqual(coerceWholeNumberJson({ timeout_ms: 20000.0, workdir: "C:\\tmp" }), {
+    timeout_ms: 20000,
+    workdir: "C:\\tmp",
+  });
+  assert.equal(Object.is(coerceWholeNumberJson({ n: -0 }).n, 0), true);
+  assert.equal(Number.isInteger(coerceWholeNumberJson({ n: 20000.0 }).n), true);
+});
+
+test("coerceWholeNumberJson leaves genuine fractions and non-numbers alone", () => {
+  const input = {
+    ratio: 3.14,
+    label: "20000.0",
+    flag: true,
+    empty: null,
+    nested: [{ wait: 1.5 }, { wait: 2.0 }],
+  };
+  const out = coerceWholeNumberJson(input);
+  assert.equal(out.ratio, 3.14);
+  assert.equal(out.label, "20000.0");
+  assert.equal(out.flag, true);
+  assert.equal(out.empty, null);
+  assert.equal(out.nested[0].wait, 1.5);
+  assert.equal(out.nested[1].wait, 2);
+  assert.equal(Number.isInteger(out.nested[1].wait), true);
+});
+
+test("coerceWholeNumberJson does not invent integers past MAX_SAFE_INTEGER", () => {
+  const huge = Number.MAX_SAFE_INTEGER + 2;
+  assert.equal(coerceWholeNumberJson({ n: huge }).n, huge);
+});
+
+test("coerceFunctionCallArguments rewrites a complete JSON string only when needed", () => {
+  const original = '{"command":"git status","timeout_ms":20000.0}';
+  const rewritten = coerceFunctionCallArguments(original);
+  assert.equal(rewritten, '{"command":"git status","timeout_ms":20000}');
+  assert.ok(!rewritten.includes("20000.0"));
+  assert.deepEqual(JSON.parse(rewritten), { command: "git status", timeout_ms: 20000 });
+  assert.equal(Number.isInteger(JSON.parse(rewritten).timeout_ms), true);
+
+  const alreadyInt = '{"timeout_ms":20000}';
+  assert.equal(coerceFunctionCallArguments(alreadyInt), alreadyInt);
+
+  const invalid = "{not json";
+  assert.equal(coerceFunctionCallArguments(invalid), invalid);
+
+  const fraction = '{"x":3.14}';
+  assert.equal(coerceFunctionCallArguments(fraction), fraction);
+
+  const quoted = '{"label":"20000.0","timeout_ms":2.0e4}';
+  assert.equal(coerceFunctionCallArguments(quoted), '{"label":"20000.0","timeout_ms":20000}');
+});
+
+test("coerceFunctionCallArguments ignores non-strings", () => {
+  assert.equal(coerceFunctionCallArguments(undefined), undefined);
+  assert.deepEqual(coerceFunctionCallArguments({ timeout_ms: 1.0 }), { timeout_ms: 1.0 });
+});


### PR DESCRIPTION
## Summary

Grok 4.6 emits integer tool fields as JSON floats such as `timeout_ms: 20000.0`. Codex then rejects the call (`invalid type: floating point 20000.0, expected u64`), so native tools like `shell_command` never run.

`JSON.parse` cannot tell `20000` from `20000.0`, so this rewrites whole-number tokens in the raw argument string on the routed Responses path.

- New `src/tool-arguments.mjs` rewrites complete JSON argument strings: `20000.0` / `2.0e4` become `20000`; genuine fractions, quoted strings, and invalid JSON stay untouched.
- `NamespaceToolCallTransform` already sits on every routed response. It now also coerces `function_call.arguments` and `response.function_call_arguments.done`, including native tools that are not namespaced.

## Changes

- Added: `src/tool-arguments.mjs`, `test/tool-arguments.test.mjs`
- Modified: `src/namespace-relay.mjs`, `test/namespace-relay.test.mjs`, `CHANGELOG.md`

## Testing

- [x] `node --test test/tool-arguments.test.mjs test/namespace-relay.test.mjs` — 24/24 pass
- [x] Installed onto the local router and restarted; `/health` stayed on 0.4.0-beta.3
- [ ] GitHub CI

## Related Issues

None opened. Reproduced locally with `grok-oauth/grok-4.6` on Codex desktop (`shell_command` timeout fields).