### PR TITLE
Enable DeepSeek V4 Flash as a v2 subagent model

### DIFF
--- a/config/deepseek/deepseek-v4-flash.json
+++ b/config/deepseek/deepseek-v4-flash.json
@@ -7,6 +7,7 @@
       "upstreamModel": "deepseek-v4-flash",
       "provider": "deepseek",
       "listed": true,
+      "multiAgentVersion": "v2",
       "displayName": "DeepSeek V4 Flash (API)",
       "description": "DeepSeek V4 Flash via the DeepSeek API; fast reasoning, tool calls, and a 1M context window.",
       "priority": 6,

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -241,6 +241,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
     assert.equal(model.multiAgentVersion, "v2", model.slug);
   }
   assert.equal(MODEL_BY_SLUG.get("grok-oauth/grok-4.6").multiAgentVersion, undefined);
+  assert.equal(MODEL_BY_SLUG.get("deepseek/deepseek-v4-flash").multiAgentVersion, "v2");
   assert.equal(MODEL_BY_SLUG.get("deepseek/deepseek-v4-pro").multiAgentVersion, undefined);
   for (const slug of [
     "kimi-oauth/kimi-for-coding-highspeed",


### PR DESCRIPTION
## Summary

- mark `deepseek/deepseek-v4-flash` as a proven native v2 subagent model
- add a registry regression assertion so the marker cannot silently disappear

## Compatibility evidence

Authorized live probe through the installed router (`./bin/test-model 'deepseek/deepseek-v4-flash' --live --yes --json`):\n\n- basic response: HTTP 200, marker received\n- streaming: stream text and completion event verified\n- tool calling: function call and JSON arguments verified\n- compaction: compaction response verified\n\nThe PR registry generated `router-model-deepseek-deepseek-v4-flash.toml` with `model = "deepseek/deepseek-v4-flash"`; a direct Codex CLI request using that temporary catalog returned `DEEPSEEK_NATIVE_CHILD_OK`. The existing routed payload relay and follow-up regression coverage is green.\n\n## Checks\n\n- `git diff --check`\n- `npm run check`\n- focused registry/catalog/routing suite: 117 passed\n- full suite: 967 passed, 8 environment failures because this shallow checkout lacks `proper-lockfile` (the failures are in existing Kimi OAuth/account/lock/quota/startup tests)\n\nThe full native desktop spawn/follow-up probe remains to be confirmed in a Codex build that exposes the receiver thread to the CLI; no model behavior failure was observed.