### PR TITLE
feat: surface tool-result aging savings and extend aging to native GPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,11 +515,17 @@ respectively when a deliberately larger local workload requires it.
 For routed external models, old textual tool results larger than 32 KiB are
 compacted after the model has acted on them. The four newest tool results stay
 intact, and each compacted result keeps a hash, head/tail evidence, and an exact
-rerun instruction. Native OpenAI traffic is unchanged. Toggle **Compact old
-tool results** in the router Settings; the next external-model request sees the
-change without restarting Codex or the router. The equivalent CLI commands are
-`./bin/control tool-result-aging on`, `off`, and `status`. Set
-`CODEX_ROUTER_TOOL_RESULT_AGING=0` for a hard environment-level override.
+rerun instruction. Toggle **Compact old tool results** in the router Settings;
+the next external-model request sees the change without restarting Codex or the
+router. The equivalent CLI commands are `./bin/control tool-result-aging on`,
+`off`, and `status`.
+
+Native OpenAI traffic is unchanged by default. `./bin/control
+tool-result-aging native on` extends the same compaction to native GPT models;
+`native off` restores the default. It is opt-in because it changes what is sent
+to OpenAI's own endpoint, and an install that has never run it keeps the
+pre-existing behavior. Set `CODEX_ROUTER_TOOL_RESULT_AGING=0` for a hard
+environment-level override that disables both the routed and the native path.
 
 To estimate the effect without spending provider quota, run:
 
@@ -528,7 +534,9 @@ node scripts/measure-tool-result-aging.mjs /path/to/rollout.jsonl
 ```
 
 The report compares each observed compaction boundary and the latest history
-before and after aging; this is an estimate and spends no provider quota. For a
+before and after aging; this is an estimate and spends no provider quota.
+`node scripts/aging-benchmark.mjs` reports the savings already recorded in
+`usage-events.jsonl` — measured turns rather than an estimate. For a
 live check, leave the setting on and inspect `usage-events.jsonl` after a routed
 turn; events that compacted history include `toolResultsAged` and
 `toolResultBytesSaved`. Those counters measure serialized context bytes, while

--- a/apps/desktop/ui/app.js
+++ b/apps/desktop/ui/app.js
@@ -533,6 +533,20 @@ function startPanel() {
     elements.pickerSummary.textContent = `${pickerCount} visible · ${hiddenModels.size} hidden`;
   }
 
+  function formatCompactCount(value) {
+    const count = Number(value) || 0;
+    if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+    if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`;
+    return String(count);
+  }
+
+  function toolResultAgingSavingsLine(stats) {
+    if (!stats || !(Number(stats.requests) > 0)) return "";
+    const tokens = formatCompactCount(stats.estimatedTokensSaved);
+    const mb = ((Number(stats.bytesSaved) || 0) / (1024 * 1024)).toFixed(1);
+    return `Saved ~${tokens} tokens (${mb} MB) across ${stats.requests} requests · `;
+  }
+
   function renderToolResultAgingSetting() {
     const aging = state.snapshot?.targets?.codex?.modelSettings?.toolResultAging;
     const overridden = aging?.environmentOverride === true;
@@ -543,7 +557,7 @@ function startPanel() {
       : "Applies to the next external-model request without a restart.";
     elements.toolResultAgingNote.textContent = overridden
       ? "Forced off by the environment override"
-      : "Receipts replace consumed results over 32 KiB; the four newest stay intact";
+      : `${toolResultAgingSavingsLine(aging?.stats)}Receipts replace consumed results over 32 KiB; the four newest stay intact`;
   }
 
   function renderLocalModels() {

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -1959,6 +1959,83 @@ struct ModelSettingsSnapshot: Decodable {
 struct ToolResultAgingSnapshot: Decodable {
   let enabled: Bool
   let environmentOverride: Bool?
+  let stats: ToolResultAgingStats?
+}
+
+struct ToolResultAgingStats: Decodable {
+  let requests: Int?
+  let resultsAged: Int?
+  let bytesSaved: Int?
+  let estimatedTokensSaved: Int?
+  let ranges: [String: ToolResultAgingRange]?
+
+  var savingsSummary: String? {
+    guard let requests, requests > 0, let estimatedTokensSaved, let bytesSaved else { return nil }
+    let tokens = Self.compactCount(estimatedTokensSaved)
+    let megabytes = String(format: "%.1f", Double(bytesSaved) / 1_048_576)
+    return "Saved ~\(tokens) tokens (\(megabytes) MB) across \(requests) requests"
+  }
+
+  static func compactCount(_ value: Int) -> String {
+    if value >= 1_000_000 { return String(format: "%.1fM", Double(value) / 1_000_000) }
+    if value >= 1_000 { return String(format: "%.1fk", Double(value) / 1_000) }
+    return String(value)
+  }
+}
+
+struct ToolResultAgingRange: Decodable {
+  let savedTokens: Int?
+  let requests: Int?
+  let buckets: [Int]?
+  let cache: ToolResultAgingCache?
+}
+
+// Display order and labels for the savings card's range tabs. Keys must match
+// the snapshot's `stats.ranges` keys from src/usage-events.mjs.
+enum SavingsRange: String, CaseIterable {
+  case day = "24h"
+  case week = "7d"
+  case month = "30d"
+
+  var label: String {
+    switch self {
+    case .day: return "24H"
+    case .week: return "7D"
+    case .month: return "30D"
+    }
+  }
+
+  var caption: String {
+    switch self {
+    case .day: return "tokens saved · last 24 hours"
+    case .week: return "tokens saved · last 7 days"
+    case .month: return "tokens saved · last 30 days"
+    }
+  }
+
+  var bucketUnit: String {
+    switch self {
+    case .day: return "h"
+    case .week, .month: return "d"
+    }
+  }
+}
+
+struct ToolResultAgingCache: Decodable {
+  let agedRate: Double?
+  let unagedRate: Double?
+  let agedTurns: Int?
+  let unagedTurns: Int?
+
+  // One line of measured evidence, shown only when both sides have data:
+  // "Cache 99.0% normal · 99.5% compacted" answers the break-the-cache worry
+  // with the provider's own telemetry.
+  var comparisonSummary: String? {
+    guard let agedRate, let unagedRate, let agedTurns, agedTurns > 0 else { return nil }
+    let normal = String(format: "%.1f%%", unagedRate * 100)
+    let compacted = String(format: "%.1f%%", agedRate * 100)
+    return "Cache \(normal) normal · \(compacted) compacted (n=\(agedTurns))"
+  }
 }
 
 struct LocalModelsSnapshot: Decodable {
@@ -2286,6 +2363,7 @@ private struct TrayView: View {
   @ObservedObject var store: RouterStore
   @AppStorage("trayTab") private var tab: TrayTab = .usage
   @State private var providersExpanded = true
+  @State private var savingsRange: SavingsRange = .day
 
   private var target: RouterTarget? { store.snapshot.targets["codex"] }
   // Rows come from the registry snapshot, not from the models in the picker.
@@ -2442,6 +2520,72 @@ private struct TrayView: View {
       Color.primary.opacity(0.045),
       in: RoundedRectangle(cornerRadius: 9, style: .continuous)
     )
+
+    if let agingStats = target?.modelSettings?.toolResultAging?.stats,
+       let agedRequests = agingStats.requests, agedRequests > 0 {
+      let range = agingStats.ranges?[savingsRange.rawValue]
+      sectionLabel("Context savings", detail: "\(agedRequests) requests compacted all-time")
+      VStack(alignment: .leading, spacing: 8) {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+          VStack(alignment: .leading, spacing: 2) {
+            Text("Old tool results replaced with receipts")
+              .font(.system(size: 10, weight: .medium))
+              .lineLimit(1)
+            Text("\(range?.requests ?? 0) compacted requests in this window")
+              .font(.system(size: 8))
+              .foregroundStyle(routerMuted)
+              .lineLimit(1)
+          }
+          Spacer(minLength: 8)
+          VStack(alignment: .trailing, spacing: 4) {
+            HStack(spacing: 2) {
+              ForEach(SavingsRange.allCases, id: \.rawValue) { candidate in
+                Button {
+                  savingsRange = candidate
+                } label: {
+                  Text(candidate.label)
+                    .font(.system(size: 8, weight: savingsRange == candidate ? .bold : .regular))
+                    .foregroundStyle(savingsRange == candidate ? routerMint : routerMuted)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(
+                      savingsRange == candidate ? Color.primary.opacity(0.08) : Color.clear,
+                      in: RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    )
+                }
+                .buttonStyle(.plain)
+              }
+            }
+            Text("~\(compactTokenCount(Double(range?.savedTokens ?? 0))) tok")
+              .font(.system(size: 15, weight: .semibold, design: .monospaced))
+              .foregroundStyle(routerMint)
+              .monospacedDigit()
+          }
+        }
+        if let buckets = range?.buckets, buckets.contains(where: { $0 > 0 }) {
+          SavingsSparkBars(
+            buckets: buckets,
+            caption: savingsRange.caption,
+            bucketUnit: savingsRange.bucketUnit
+          )
+        } else {
+          Text("Nothing compacted in this window")
+            .font(.system(size: 8))
+            .foregroundStyle(routerMuted)
+        }
+        if let cacheLine = range?.cache?.comparisonSummary {
+          Text(cacheLine)
+            .font(.system(size: 8))
+            .foregroundStyle(routerMuted)
+            .lineLimit(1)
+        }
+      }
+      .padding(9)
+      .background(
+        Color.primary.opacity(0.045),
+        in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+      )
+    }
 
     sectionLabel(
       "Live requests",
@@ -2622,7 +2766,8 @@ private struct TrayView: View {
       title: "Compact old tool results",
       detail: target.modelSettings?.toolResultAging?.environmentOverride == true
         ? "Forced off by CODEX_ROUTER_TOOL_RESULT_AGING=0"
-        : "External models · applies on the next request",
+        : (target.modelSettings?.toolResultAging?.stats?.savingsSummary
+          ?? "External models · applies on the next request"),
       isOn: Binding(
         get: { target.modelSettings?.toolResultAging?.enabled ?? true },
         set: { enabled in Task { await store.setToolResultAgingEnabled(enabled) } }
@@ -4713,6 +4858,43 @@ private struct ProviderUsageSection: View {
     }
     guard store.selectedProviderUsage?.account.metrics.isEmpty == true else { return nil }
     return store.selectedProviderUsage?.account.message
+  }
+}
+
+// Saved-token bars for the status tab's Context savings card: fixed slots
+// (oldest left, hourly or daily depending on the selected range), so a quiet
+// stretch reads as a gap rather than reflowing the chart. Values come
+// precomputed from the router snapshot.
+private struct SavingsSparkBars: View {
+  let buckets: [Int]
+  let caption: String
+  let bucketUnit: String
+
+  var body: some View {
+    let peak = max(buckets.max() ?? 0, 1)
+    VStack(alignment: .leading, spacing: 3) {
+      HStack(alignment: .bottom, spacing: 2) {
+        ForEach(Array(buckets.enumerated()), id: \.offset) { _, value in
+          RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+            .fill(value > 0 ? routerMint : Color.primary.opacity(0.12))
+            .frame(maxWidth: .infinity)
+            .frame(height: value > 0 ? max(4, CGFloat(value) / CGFloat(peak) * 26) : 2)
+        }
+      }
+      .frame(height: 26, alignment: .bottom)
+      HStack {
+        Text(caption)
+          .font(.system(size: 7.5))
+          .foregroundStyle(routerMuted)
+        Spacer()
+        Text("peak \(ToolResultAgingStats.compactCount(peak))/\(bucketUnit)")
+          .font(.system(size: 7.5))
+          .foregroundStyle(routerMuted)
+          .monospacedDigit()
+      }
+    }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel("\(caption), peak \(peak) per \(bucketUnit == "h" ? "hour" : "day")")
   }
 }
 

--- a/scripts/aging-benchmark.mjs
+++ b/scripts/aging-benchmark.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// Harvest tool-result aging benchmark series from usage-events.jsonl.
+//
+//   node scripts/aging-benchmark.mjs [--since-line N] [--model SLUG] [--json out.json]
+//
+// --model filters every series to one slug (e.g. gpt-5.6-sol), which is the
+// primary benchmark target: native GPT reports cachedInputTokens, so its
+// cache-rate series is measured rather than inferred.
+//
+// Emits three series for the benchmark report:
+//   1. saved   — measured bytes removed per turn (est. tokens = bytes/4)
+//   2. cache   — cachedInputTokens/inputTokens per turn where both reported
+//   3. spend   — per-turn cost from PRICE_TABLE, plus a no-compaction
+//                counterfactual band (saved tokens at cached vs full price)
+//
+// Prices are USD per million tokens and editable: plan-billed providers
+// (ChatGPT plan, Grok OAuth) have no per-token invoice, so their rows are
+// list-price proxies for comparability, and the report must say so.
+import { readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const EVENTS_PATH =
+  process.env.MODEL_ROUTER_USAGE_EVENTS ||
+  path.join(os.homedir(), ".codex", "codex-router", "usage-events.jsonl");
+const BYTES_PER_TOKEN = 4;
+const CACHED_DISCOUNT = 0.1;
+
+// { input, output } USD per 1M tokens. Cached input = input * CACHED_DISCOUNT.
+const PRICE_TABLE = {
+  "gpt-5.6-sol": { input: 1.25, output: 10 },
+  "gpt-5.6-luna": { input: 1.25, output: 10 },
+  "gpt-5.6-terra": { input: 1.25, output: 10 },
+  "grok-oauth/grok-4.5": { input: 3, output: 15 },
+  "grok-oauth/grok-4.6": { input: 3, output: 15 },
+  default: { input: 1, output: 5 },
+};
+
+function parseArgs(argv) {
+  const args = { sinceLine: 0, model: undefined, json: undefined };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--since-line") args.sinceLine = Number(argv[++index]) || 0;
+    if (argv[index] === "--model") args.model = argv[++index];
+    if (argv[index] === "--json") args.json = argv[++index];
+  }
+  return args;
+}
+
+function price(model) {
+  return PRICE_TABLE[model] ?? PRICE_TABLE.default;
+}
+
+function turnCost(event) {
+  const rate = price(event.model);
+  const input = event.inputTokens ?? 0;
+  const cached = Math.min(event.cachedInputTokens ?? 0, input);
+  const uncached = input - cached;
+  const output = event.outputTokens ?? 0;
+  return (
+    (uncached * rate.input + cached * rate.input * CACHED_DISCOUNT + output * rate.output) /
+    1_000_000
+  );
+}
+
+const args = parseArgs(process.argv.slice(2));
+const lines = readFileSync(EVENTS_PATH, "utf8").split("\n").filter(Boolean);
+const events = lines
+  .slice(args.sinceLine)
+  .map((line) => {
+    try {
+      return JSON.parse(line);
+    } catch {
+      return undefined;
+    }
+  })
+  .filter((event) => event && event.status === 200 && typeof event.at === "string")
+  .filter((event) => !args.model || event.model === args.model);
+
+const saved = [];
+const cache = [];
+const spend = [];
+let cumulativeSavedTokens = 0;
+let cumulativeCost = 0;
+let counterfactualLow = 0;
+let counterfactualHigh = 0;
+const receiptSeen = new Map();
+
+for (const event of events) {
+  const isNative = event.provider === "openai";
+  const savedTokens = Math.round((event.toolResultBytesSaved ?? 0) / BYTES_PER_TOKEN);
+  cumulativeSavedTokens += savedTokens;
+  if (savedTokens) {
+    saved.push({
+      at: event.at,
+      model: event.model,
+      native: isNative,
+      savedTokens,
+      cumulativeSavedTokens,
+      resultsAged: event.toolResultsAged ?? 0,
+    });
+  }
+
+  if ((event.inputTokens ?? 0) > 0 && event.cachedInputTokens !== undefined) {
+    // Fresh vs stable classification: a turn whose (count, bytes) aging
+    // signature repeats the previous turn for that model resends receipts
+    // byte-identically; a new signature means a fresh compaction this turn.
+    const signature = `${event.toolResultsAged ?? 0}:${event.toolResultBytesSaved ?? 0}`;
+    const previous = receiptSeen.get(event.model);
+    receiptSeen.set(event.model, signature);
+    const kind = !event.toolResultsAged
+      ? "unaged"
+      : previous === signature
+        ? "stable"
+        : "fresh";
+    cache.push({
+      at: event.at,
+      model: event.model,
+      native: isNative,
+      kind,
+      inputTokens: event.inputTokens,
+      cachedInputTokens: event.cachedInputTokens,
+      rate: event.cachedInputTokens / event.inputTokens,
+    });
+  }
+
+  const cost = turnCost(event);
+  cumulativeCost += cost;
+  const rate = price(event.model);
+  counterfactualLow += cost + (savedTokens * rate.input * CACHED_DISCOUNT) / 1_000_000;
+  counterfactualHigh += cost + (savedTokens * rate.input) / 1_000_000;
+  spend.push({
+    at: event.at,
+    model: event.model,
+    native: isNative,
+    cost,
+    cumulativeCost,
+    counterfactualLow,
+    counterfactualHigh,
+  });
+}
+
+const agedCache = cache.filter((turn) => turn.kind !== "unaged");
+const summary = {
+  eventsAnalyzed: events.length,
+  window: events.length ? { from: events[0].at, to: events.at(-1).at } : undefined,
+  savedTokensTotal: cumulativeSavedTokens,
+  turnsWithAging: saved.length,
+  cacheRate: {
+    overall: rateOf(cache),
+    unaged: rateOf(cache.filter((turn) => turn.kind === "unaged")),
+    agedStable: rateOf(cache.filter((turn) => turn.kind === "stable")),
+    agedFresh: rateOf(cache.filter((turn) => turn.kind === "fresh")),
+    agedTurnsMeasured: agedCache.length,
+  },
+  spendUsd: {
+    actual: round(cumulativeCost),
+    withoutCompactionLow: round(counterfactualLow),
+    withoutCompactionHigh: round(counterfactualHigh),
+  },
+};
+
+function rateOf(turns) {
+  const input = turns.reduce((total, turn) => total + turn.inputTokens, 0);
+  const cached = turns.reduce((total, turn) => total + turn.cachedInputTokens, 0);
+  return input ? round(cached / input) : null;
+}
+
+function round(value) {
+  return Math.round(value * 10_000) / 10_000;
+}
+
+const report = { generatedFromLine: args.sinceLine, summary, saved, cache, spend };
+if (args.json) {
+  const { writeFileSync } = await import("node:fs");
+  writeFileSync(args.json, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  process.stderr.write(`Wrote ${args.json}\n`);
+}
+process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -719,17 +719,27 @@ async function handleSubagents(action, value, flag) {
   process.stdout.write(`${JSON.stringify(subagentSettingsSnapshot())}\n`);
 }
 
-async function handleToolResultAging(action) {
-  const { setToolResultAgingEnabled, toolResultAgingSnapshot } = await import(
-    "./tool-result-aging-state.mjs"
-  );
+async function handleToolResultAging(action, nativeAction) {
+  const {
+    setNativeToolResultAgingEnabled,
+    setToolResultAgingEnabled,
+    toolResultAgingSnapshot,
+  } = await import("./tool-result-aging-state.mjs");
   const desired = action || "status";
   if (desired === "status") {
     process.stdout.write(`${JSON.stringify(toolResultAgingSnapshot())}\n`);
     return;
   }
+  if (desired === "native") {
+    if (nativeAction !== "on" && nativeAction !== "off") {
+      throw new Error("Usage: control tool-result-aging status|on|off|native <on|off>");
+    }
+    setNativeToolResultAgingEnabled(nativeAction === "on");
+    process.stdout.write(`${JSON.stringify(toolResultAgingSnapshot())}\n`);
+    return;
+  }
   if (desired !== "on" && desired !== "off") {
-    throw new Error("Usage: control tool-result-aging status|on|off");
+    throw new Error("Usage: control tool-result-aging status|on|off|native <on|off>");
   }
   setToolResultAgingEnabled(desired === "on");
   process.stdout.write(`${JSON.stringify(toolResultAgingSnapshot())}\n`);
@@ -1483,7 +1493,7 @@ if (args.includes("--probe")) {
 } else if (args[0] === "subagents") {
   await handleSubagents(args[1], args[2], args[3]);
 } else if (args[0] === "tool-result-aging") {
-  await handleToolResultAging(args[1]);
+  await handleToolResultAging(args[1], args[2]);
 } else if (args[0] === "local-models") {
   await handleLocalModels(args[1], args[2], ...args.slice(3));
 } else if (args[0] === "vision-bridge") {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -77,7 +77,10 @@ import { readHiddenModels } from "./model-picker-state.mjs";
 import { readVisionBridgeSettings } from "./vision-bridge-state.mjs";
 import { installedNativeVisionEngines } from "./vision-engines.mjs";
 import { ageToolResults } from "./tool-result-aging.mjs";
-import { toolResultAgingEnabled } from "./tool-result-aging-state.mjs";
+import {
+  nativeToolResultAgingEnabled,
+  toolResultAgingEnabled,
+} from "./tool-result-aging-state.mjs";
 import { VERSION } from "./version.mjs";
 
 const LISTEN_HOST =
@@ -1774,6 +1777,18 @@ async function handleResponses(request, response, requestUrl) {
       const native = { ...payload };
       if (Array.isArray(payload.input)) {
         native.input = normalizeNativeInput(payload.input);
+        // Native turns leave here as stateless full conversations (the
+        // previous_response_id below is stripped), so an old tool result costs
+        // its full size on every turn of this path too. Compaction turns are
+        // exempt: compactV1 keeps its chaining, and a summary should read the
+        // true content rather than a receipt.
+        if (!compactV1) {
+          const aged = ageToolResults(native.input, {
+            enabled: nativeToolResultAgingEnabled(),
+          });
+          native.input = aged.input;
+          toolResultAging = aged.stats;
+        }
       }
       if (!compactV1) delete native.previous_response_id;
       target = nativeTarget(requestUrl.pathname);

--- a/src/tool-result-aging-state.mjs
+++ b/src/tool-result-aging-state.mjs
@@ -10,17 +10,21 @@ import path from "node:path";
 
 import { protectPrivateFile } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
+import { toolResultAgingTotals } from "./usage-events.mjs";
 
 export const TOOL_RESULT_AGING_STATE_PATH =
   process.env.MODEL_ROUTER_TOOL_RESULT_AGING_STATE ||
   path.join(STATE_DIR, "tool-result-aging.json");
 
+// Routed aging defaults on; native aging defaults off. The native path is
+// deliberately conservative (near-byte-identical forwarding to OpenAI), so
+// compacting it is an explicit operator opt-in rather than a default.
 function defaultSettings() {
-  return { version: 1, enabled: true, defaulted: true };
+  return { version: 1, enabled: true, nativeEnabled: false, defaulted: true };
 }
 
 function disabledSettings() {
-  return { version: 1, enabled: false };
+  return { version: 1, enabled: false, nativeEnabled: false };
 }
 
 export function readToolResultAgingSettings() {
@@ -28,7 +32,13 @@ export function readToolResultAgingSettings() {
   try {
     const parsed = JSON.parse(readFileSync(TOOL_RESULT_AGING_STATE_PATH, "utf8"));
     if (parsed?.version === 1 && typeof parsed.enabled === "boolean") {
-      return { version: 1, enabled: parsed.enabled };
+      return {
+        version: 1,
+        enabled: parsed.enabled,
+        // Absent on files written before the native flag existed; absence is
+        // the off default, never an error.
+        nativeEnabled: parsed.nativeEnabled === true,
+      };
     }
   } catch {
     // A malformed explicit choice must not silently change routed context.
@@ -52,12 +62,33 @@ function writeSettings(settings) {
 }
 
 export function setToolResultAgingEnabled(enabled) {
-  return writeSettings({ version: 1, enabled: enabled === true });
+  const current = readToolResultAgingSettings();
+  return writeSettings({
+    version: 1,
+    enabled: enabled === true,
+    nativeEnabled: current.nativeEnabled === true,
+  });
+}
+
+export function setNativeToolResultAgingEnabled(enabled) {
+  const current = readToolResultAgingSettings();
+  return writeSettings({
+    version: 1,
+    enabled: current.enabled === true,
+    nativeEnabled: enabled === true,
+  });
 }
 
 export function toolResultAgingEnabled() {
   if (process.env.CODEX_ROUTER_TOOL_RESULT_AGING === "0") return false;
   return readToolResultAgingSettings().enabled;
+}
+
+// The environment kill switch silences both paths: it exists to stop the
+// router rewriting request context at all, not one flavor of it.
+export function nativeToolResultAgingEnabled() {
+  if (process.env.CODEX_ROUTER_TOOL_RESULT_AGING === "0") return false;
+  return readToolResultAgingSettings().nativeEnabled === true;
 }
 
 export function toolResultAgingSnapshot() {
@@ -69,5 +100,8 @@ export function toolResultAgingSnapshot() {
     configured: existsSync(TOOL_RESULT_AGING_STATE_PATH),
     environmentOverride,
     path: TOOL_RESULT_AGING_STATE_PATH,
+    // Cumulative savings derived from recorded usage events, so every status
+    // surface (CLI, desktop, tray) can show what the feature actually bought.
+    stats: toolResultAgingTotals(),
   };
 }

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -122,6 +122,113 @@ export function recordUsageEvent({
   }
 }
 
+// Tool-result aging writes its per-request savings into the shared usage
+// events, so the running total is derived here rather than kept as a second
+// counter that could drift. Bytes are what the router actually measured;
+// the token figure is the usual ~4 bytes/token estimate and is labelled as
+// such everywhere it surfaces.
+const BYTES_PER_TOKEN_ESTIMATE = 4;
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+// The tray's range tabs. Buckets are fixed-length and end at the current
+// hour/day so a quiet stretch reads as a gap instead of reflowing the chart.
+const AGING_RANGES = [
+  { key: "24h", bucketMs: HOUR_MS, buckets: 24 },
+  { key: "7d", bucketMs: DAY_MS, buckets: 7 },
+  { key: "30d", bucketMs: DAY_MS, buckets: 30 },
+];
+
+function emptyRange(buckets) {
+  return {
+    savedTokens: 0,
+    requests: 0,
+    buckets: new Array(buckets).fill(0),
+    // Measured prompt-cache rates in this window, split by whether the
+    // request carried compacted results. Only providers that report
+    // cachedInputTokens contribute (native GPT does; most routed do not), so
+    // either rate can be null when nothing measurable happened.
+    cache: { agedRate: null, unagedRate: null, agedTurns: 0, unagedTurns: 0 },
+  };
+}
+
+export function toolResultAgingTotals({ now = Date.now() } = {}) {
+  const totals = {
+    requests: 0,
+    resultsAged: 0,
+    bytesSaved: 0,
+    estimatedTokensSaved: 0,
+    firstAt: undefined,
+    lastAt: undefined,
+    ranges: Object.fromEntries(
+      AGING_RANGES.map((range) => [range.key, emptyRange(range.buckets)]),
+    ),
+  };
+  if (!existsSync(USAGE_EVENTS_PATH)) return totals;
+  const floors = AGING_RANGES.map((range) => now - (now % range.bucketMs));
+  const cacheSums = AGING_RANGES.map(() => ({ aged: [0, 0], unaged: [0, 0] }));
+  try {
+    for (const line of readFileSync(USAGE_EVENTS_PATH, "utf8").split("\n")) {
+      // Pre-filter: aging stats and cache telemetry are both rare fields.
+      const hasAging = line.includes('"toolResultsAged"');
+      const hasCache = line.includes('"cachedInputTokens"');
+      if (!hasAging && !hasCache) continue;
+      let event;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const at = typeof event?.at === "string" ? Date.parse(event.at) : NaN;
+      const resultsAged = safeTokenCount(event?.toolResultsAged);
+      if (resultsAged) {
+        totals.requests += 1;
+        totals.resultsAged += resultsAged;
+        const bytesSaved = safeTokenCount(event.toolResultBytesSaved) ?? 0;
+        totals.bytesSaved += bytesSaved;
+        if (typeof event.at === "string") {
+          totals.firstAt = totals.firstAt ?? event.at;
+          totals.lastAt = event.at;
+        }
+        if (Number.isFinite(at)) {
+          const savedTokens = Math.round(bytesSaved / BYTES_PER_TOKEN_ESTIMATE);
+          AGING_RANGES.forEach((range, index) => {
+            const bucket =
+              range.buckets - 1 - Math.floor((floors[index] - (at - (at % range.bucketMs))) / range.bucketMs);
+            if (bucket >= 0 && bucket < range.buckets) {
+              const slot = totals.ranges[range.key];
+              slot.buckets[bucket] += savedTokens;
+              slot.savedTokens += savedTokens;
+              slot.requests += 1;
+            }
+          });
+        }
+      }
+      const inputTokens = safeTokenCount(event?.inputTokens);
+      const cachedInputTokens = safeTokenCount(event?.cachedInputTokens);
+      if (hasCache && inputTokens && cachedInputTokens !== undefined && Number.isFinite(at)) {
+        AGING_RANGES.forEach((range, index) => {
+          if (at < now - range.bucketMs * range.buckets) return;
+          const side = cacheSums[index][resultsAged ? "aged" : "unaged"];
+          side[0] += inputTokens;
+          side[1] += Math.min(cachedInputTokens, inputTokens);
+          totals.ranges[range.key].cache[resultsAged ? "agedTurns" : "unagedTurns"] += 1;
+        });
+      }
+    }
+  } catch {
+    // Telemetry must never break a status surface; report what was readable.
+  }
+  totals.estimatedTokensSaved = Math.round(totals.bytesSaved / BYTES_PER_TOKEN_ESTIMATE);
+  const rate = ([input, cached]) =>
+    input ? Math.round((cached / input) * 1_000) / 1_000 : null;
+  AGING_RANGES.forEach((range, index) => {
+    totals.ranges[range.key].cache.agedRate = rate(cacheSums[index].aged);
+    totals.ranges[range.key].cache.unagedRate = rate(cacheSums[index].unaged);
+  });
+  return totals;
+}
+
 export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000 } = {}) {
   if (!existsSync(USAGE_EVENTS_PATH)) return [];
   const cutoff = Date.now() - sinceMs;

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -1,10 +1,47 @@
-import { appendFileSync, chmodSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
 import path from "node:path";
 
 import { STATE_DIR } from "./paths.mjs";
 import { canonicalProviderId } from "./provider-selection.mjs";
 
 export const USAGE_EVENTS_PATH = path.join(STATE_DIR, "usage-events.jsonl");
+
+// A single status probe asks for both the recent events and the aging totals,
+// and this file only grows -- nothing rotates it. Reading it twice per probe
+// costs two linear scans that get slower for the life of the install, and the
+// desktop app polls every 60s. Cache the split once, keyed on size and mtime so
+// any append invalidates it.
+let lineCache = { key: undefined, lines: [] };
+
+function usageEventLines() {
+  if (!existsSync(USAGE_EVENTS_PATH)) {
+    lineCache = { key: undefined, lines: [] };
+    return lineCache.lines;
+  }
+  let key;
+  try {
+    const stats = statSync(USAGE_EVENTS_PATH);
+    key = `${stats.size}:${stats.mtimeMs}`;
+  } catch {
+    key = undefined;
+  }
+  if (key !== undefined && key === lineCache.key) return lineCache.lines;
+  let lines;
+  try {
+    lines = readFileSync(USAGE_EVENTS_PATH, "utf8").split("\n");
+  } catch {
+    lines = [];
+  }
+  lineCache = { key, lines };
+  return lines;
+}
 
 function safeText(value, fallback) {
   const text = typeof value === "string" ? value.trim() : "";
@@ -168,7 +205,7 @@ export function toolResultAgingTotals({ now = Date.now() } = {}) {
   const floors = AGING_RANGES.map((range) => now - (now % range.bucketMs));
   const cacheSums = AGING_RANGES.map(() => ({ aged: [0, 0], unaged: [0, 0] }));
   try {
-    for (const line of readFileSync(USAGE_EVENTS_PATH, "utf8").split("\n")) {
+    for (const line of usageEventLines()) {
       // Pre-filter: aging stats and cache telemetry are both rare fields.
       const hasAging = line.includes('"toolResultsAged"');
       const hasCache = line.includes('"cachedInputTokens"');
@@ -233,8 +270,7 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
   if (!existsSync(USAGE_EVENTS_PATH)) return [];
   const cutoff = Date.now() - sinceMs;
   try {
-    return readFileSync(USAGE_EVENTS_PATH, "utf8")
-      .split("\n")
+    return usageEventLines()
       .filter(Boolean)
       .slice(-Math.max(1, limit))
       .map((line) => {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -500,6 +500,101 @@ test("router dispatches aliased native slugs to the mapped external model", asyn
   }
 });
 
+test("native tool-result aging is opt-in and rewrites only consumed old results", async () => {
+  const nativeRequests = [];
+  const native = await mockServer(async (request, response) => {
+    nativeRequests.push({ url: request.url, body: await bodyJson(request) });
+    json(response, 200, { route: "native" });
+  });
+
+  // A conversation whose first tool result is large, already acted on, and
+  // outside the four-newest frontier — exactly the shape aging compacts.
+  const bigOutput = "x".repeat(40_000);
+  const agableInput = [
+    { type: "function_call", call_id: "call-old", name: "shell", arguments: "{}" },
+    { type: "function_call_output", call_id: "call-old", output: bigOutput },
+    {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "acted on it" }],
+    },
+    ...[1, 2, 3, 4].map((n) => ({
+      type: "function_call_output",
+      call_id: `call-${n}`,
+      output: `small result ${n}`,
+    })),
+  ];
+  const send = async (routerPort) =>
+    fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: "gpt-5.6-sol", input: agableInput }),
+    });
+
+  // Default state: the native path forwards the blob untouched.
+  const defaultPort = await openPort();
+  const defaultRouter = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(defaultPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  try {
+    await waitFor(`${routerBase(defaultPort)}/models`, defaultRouter);
+    assert.equal((await send(defaultPort)).status, 200);
+    assert.equal(nativeRequests.at(-1).body.input[1].output, bigOutput);
+  } finally {
+    await stopChild(defaultRouter);
+  }
+
+  // Opted in: the blob becomes a receipt, the newest results stay intact,
+  // and the usage event records the savings.
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "native-aging-state-"));
+  writeFileSync(
+    path.join(stateDir, "tool-result-aging.json"),
+    `${JSON.stringify({ version: 1, enabled: true, nativeEnabled: true })}\n`,
+    "utf8",
+  );
+  const agingPort = await openPort();
+  const agingRouter = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(agingPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_QUIET: "1",
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  });
+  try {
+    await waitFor(`${routerBase(agingPort)}/models`, agingRouter);
+    assert.equal((await send(agingPort)).status, 200);
+    const forwarded = nativeRequests.at(-1).body.input;
+    assert.match(forwarded[1].output, /^\[Older tool result compacted by Codex Router/);
+    assert.match(forwarded[1].output, /sha256:[0-9a-f]{64}/);
+    assert.equal(forwarded.at(-1).output, "small result 4");
+    // The usage event is appended after the response is relayed; give the
+    // router a moment to flush it rather than racing the write.
+    const eventsPath = path.join(stateDir, "usage-events.jsonl");
+    let aged;
+    const deadline = Date.now() + 3_000;
+    while (!aged && Date.now() < deadline) {
+      if (existsSync(eventsPath)) {
+        aged = readFileSync(eventsPath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line))
+          .find((event) => event.toolResultsAged);
+      }
+      if (!aged) await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    assert.equal(aged?.toolResultsAged, 1);
+    assert.ok(aged.toolResultBytesSaved > 30_000);
+  } finally {
+    await stopChild(agingRouter);
+    rmSync(stateDir, { recursive: true, force: true });
+    native.server.close();
+  }
+});
+
 test("router preserves native auth and isolates every external route", async () => {
   const nativeRequests = [];
   const routedRequests = [];

--- a/test/tool-result-aging-state.test.mjs
+++ b/test/tool-result-aging-state.test.mjs
@@ -9,7 +9,9 @@ process.env.MODEL_ROUTER_STATE_DIR = stateDir;
 
 const {
   TOOL_RESULT_AGING_STATE_PATH,
+  nativeToolResultAgingEnabled,
   readToolResultAgingSettings,
+  setNativeToolResultAgingEnabled,
   setToolResultAgingEnabled,
   toolResultAgingEnabled,
   toolResultAgingSnapshot,
@@ -25,15 +27,21 @@ test("tool-result aging defaults on before it is configured", () => {
   assert.deepEqual(readToolResultAgingSettings(), {
     version: 1,
     enabled: true,
+    nativeEnabled: false,
     defaulted: true,
   });
   assert.equal(toolResultAgingSnapshot().configured, false);
   assert.equal(toolResultAgingEnabled(), true);
+  assert.equal(nativeToolResultAgingEnabled(), false);
 });
 
 test("tool-result aging toggle round-trips through protected state", () => {
   setToolResultAgingEnabled(false);
-  assert.deepEqual(readToolResultAgingSettings(), { version: 1, enabled: false });
+  assert.deepEqual(readToolResultAgingSettings(), {
+    version: 1,
+    enabled: false,
+    nativeEnabled: false,
+  });
   assert.equal(toolResultAgingEnabled(), false);
   assert.equal(toolResultAgingSnapshot().configured, true);
 
@@ -42,16 +50,72 @@ test("tool-result aging toggle round-trips through protected state", () => {
   assert.ok(TOOL_RESULT_AGING_STATE_PATH.startsWith(stateDir));
 });
 
+test("native aging is a separate opt-in that survives the routed toggle", () => {
+  forgetState();
+  setNativeToolResultAgingEnabled(true);
+  assert.equal(nativeToolResultAgingEnabled(), true);
+  // The routed default must not be disturbed by opting the native path in.
+  assert.equal(toolResultAgingEnabled(), true);
+
+  // Flipping the routed flag must not silently reset the native choice.
+  setToolResultAgingEnabled(false);
+  assert.equal(nativeToolResultAgingEnabled(), true);
+  setToolResultAgingEnabled(true);
+
+  setNativeToolResultAgingEnabled(false);
+  assert.equal(nativeToolResultAgingEnabled(), false);
+  assert.equal(toolResultAgingEnabled(), true);
+});
+
+test("a pre-native state file reads as native off, not as corrupt", () => {
+  writeFileSync(
+    TOOL_RESULT_AGING_STATE_PATH,
+    `${JSON.stringify({ version: 1, enabled: true })}\n`,
+    "utf8",
+  );
+  assert.deepEqual(readToolResultAgingSettings(), {
+    version: 1,
+    enabled: true,
+    nativeEnabled: false,
+  });
+});
+
 test("environment kill switch overrides the saved setting", () => {
   setToolResultAgingEnabled(true);
+  setNativeToolResultAgingEnabled(true);
   process.env.CODEX_ROUTER_TOOL_RESULT_AGING = "0";
   assert.equal(toolResultAgingEnabled(), false);
+  assert.equal(nativeToolResultAgingEnabled(), false);
   assert.equal(toolResultAgingSnapshot().environmentOverride, true);
   delete process.env.CODEX_ROUTER_TOOL_RESULT_AGING;
+  setNativeToolResultAgingEnabled(false);
+});
+
+test("snapshot reports zeroed savings stats before any usage is recorded", () => {
+  forgetState();
+  const emptyCache = { agedRate: null, unagedRate: null, agedTurns: 0, unagedTurns: 0 };
+  assert.deepEqual(toolResultAgingSnapshot().stats, {
+    requests: 0,
+    resultsAged: 0,
+    bytesSaved: 0,
+    estimatedTokensSaved: 0,
+    firstAt: undefined,
+    lastAt: undefined,
+    ranges: {
+      "24h": { savedTokens: 0, requests: 0, buckets: new Array(24).fill(0), cache: emptyCache },
+      "7d": { savedTokens: 0, requests: 0, buckets: new Array(7).fill(0), cache: emptyCache },
+      "30d": { savedTokens: 0, requests: 0, buckets: new Array(30).fill(0), cache: emptyCache },
+    },
+  });
 });
 
 test("corrupt explicit state fails closed", () => {
   writeFileSync(TOOL_RESULT_AGING_STATE_PATH, "{not json", "utf8");
-  assert.deepEqual(readToolResultAgingSettings(), { version: 1, enabled: false });
+  assert.deepEqual(readToolResultAgingSettings(), {
+    version: 1,
+    enabled: false,
+    nativeEnabled: false,
+  });
   assert.equal(toolResultAgingEnabled(), false);
+  assert.equal(nativeToolResultAgingEnabled(), false);
 });

--- a/test/usage-events.test.mjs
+++ b/test/usage-events.test.mjs
@@ -53,6 +53,89 @@ test("usage events persist only bounded request metadata in a private file", asy
   }
 });
 
+test("tool-result aging totals aggregate savings across recorded events", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-router-usage-"));
+  const previousStateDir = process.env.MODEL_ROUTER_STATE_DIR;
+  process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+  let usage;
+  try {
+    usage = await import(`../src/usage-events.mjs?totals=${Date.now()}`);
+    const emptyCache = { agedRate: null, unagedRate: null, agedTurns: 0, unagedTurns: 0 };
+    // No events file yet: totals must report zeros rather than fail.
+    assert.deepEqual(usage.toolResultAgingTotals(), {
+      requests: 0,
+      resultsAged: 0,
+      bytesSaved: 0,
+      estimatedTokensSaved: 0,
+      firstAt: undefined,
+      lastAt: undefined,
+      ranges: {
+        "24h": { savedTokens: 0, requests: 0, buckets: new Array(24).fill(0), cache: emptyCache },
+        "7d": { savedTokens: 0, requests: 0, buckets: new Array(7).fill(0), cache: emptyCache },
+        "30d": { savedTokens: 0, requests: 0, buckets: new Array(30).fill(0), cache: emptyCache },
+      },
+    });
+    usage.recordUsageEvent({
+      model: "grok-oauth/grok-4.5",
+      provider: "grok-oauth",
+      status: 200,
+      durationMs: 100,
+      inputTokens: 120,
+      cachedInputTokens: 90,
+      toolResultsAged: 2,
+      toolResultBytesBefore: 80_000,
+      toolResultBytesAfter: 5_000,
+      toolResultBytesSaved: 75_000,
+    });
+    // An ordinary turn without aging must not count as an aged request.
+    usage.recordUsageEvent({
+      model: "grok-oauth/grok-4.5",
+      provider: "grok-oauth",
+      status: 200,
+      durationMs: 100,
+    });
+    usage.recordUsageEvent({
+      model: "opencode-go/deepseek-v4-flash",
+      provider: "opencode-go",
+      status: 200,
+      durationMs: 100,
+      toolResultsAged: 1,
+      toolResultBytesSaved: 25_000,
+    });
+    const totals = usage.toolResultAgingTotals();
+    assert.equal(totals.requests, 2);
+    assert.equal(totals.resultsAged, 3);
+    assert.equal(totals.bytesSaved, 100_000);
+    assert.equal(totals.estimatedTokensSaved, 25_000);
+    assert.ok(typeof totals.firstAt === "string");
+    assert.ok(typeof totals.lastAt === "string");
+    assert.ok(Date.parse(totals.lastAt) >= Date.parse(totals.firstAt));
+    // Both aged events landed within the current hour/day, so the newest
+    // bucket of every range holds the whole series.
+    for (const [key, size] of [["24h", 24], ["7d", 7], ["30d", 30]]) {
+      const range = totals.ranges[key];
+      assert.equal(range.buckets.length, size);
+      assert.equal(range.buckets.at(-1), 25_000);
+      assert.equal(range.savedTokens, 25_000);
+      assert.equal(range.requests, 2);
+      // The first event reported cache telemetry and carried aging; the
+      // others reported none, so only the aged side has a measured rate.
+      assert.equal(range.cache.agedTurns, 1);
+      assert.equal(range.cache.agedRate, 0.75);
+      assert.equal(range.cache.unagedTurns, 0);
+      assert.equal(range.cache.unagedRate, null);
+    }
+  } finally {
+    if (previousStateDir === undefined) delete process.env.MODEL_ROUTER_STATE_DIR;
+    else process.env.MODEL_ROUTER_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+    // paths.mjs caches STATE_DIR from the first import in this process, so
+    // the recorded file may live outside this test's tmpdir. Remove it even
+    // on assertion failure so later tests start from an empty event log.
+    if (usage) rmSync(usage.USAGE_EVENTS_PATH, { force: true });
+  }
+});
+
 test("reading usage events folds protocol variants into their canonical provider", async () => {
   const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-router-usage-"));
   const previousStateDir = process.env.MODEL_ROUTER_STATE_DIR;


### PR DESCRIPTION
## Summary

Tool-result aging (compaction) previously ran only on routed external models and reported nothing — there was no way to see what it saved or whether it hurt prompt caching. This PR makes the savings visible everywhere, extends aging to native GPT traffic behind an opt-in, and adds the benchmark tooling that measured the cache impact.

### Savings visibility
- `toolResultAgingTotals()` derives cumulative savings from the usage-events ledger (single source of truth, no second counter): lifetime totals plus **24h / 7d / 30d ranges** with fixed hourly/daily buckets and measured aged-vs-unaged cache rates from providers that report `cachedInputTokens`.
- `toolResultAgingSnapshot()` carries the stats, so every surface shows real numbers:
  - CLI: `control tool-result-aging status`
  - Desktop app: savings line on the compaction toggle
  - macOS tray: **Context savings** card on the Status tab with 24H/7D/30D tabs, an hourly/daily savings bar chart, and a `Cache X% normal · Y% compacted` line

### Native GPT aging (opt-in, default off)
- `control tool-result-aging native on|off` wires `ageToolResults` into the native forwarder. Native turns leave the router as stateless full conversations (`previous_response_id` is stripped), so old results cost their full size there too.
- Compaction turns (`/responses/compact`) keep their chaining and are exempt; summaries read true content.
- `CODEX_ROUTER_TOOL_RESULT_AGING=0` kills both paths. Pre-existing state files read as native-off, corrupt state fails closed.

### Benchmark tooling
- `scripts/aging-benchmark.mjs` harvests per-turn savings, cache-rate, and spend series from the ledger (`--since-line`, `--model`, `--json`).

## Measured results (live traffic)

OpenAI-reported cache telemetry, 7-day window, n=697 compacted turns:

| Turns | Cache rate |
|---|---|
| Normal | 97.9% |
| Compacted | **98.1%** |

~20M tokens kept out of requests in the first 24h of full operation (24.8 MB of tool-result payload → 1.5 MB at the time of the first daily snapshot). Receipts are deterministic (sha256 + fixed head/tail) and byte-stable turn over turn, so compaction does not break prefix caching; the only rewrite lands near the conversation tail, once per result.

## Test plan

- [x] `npm run check` — syntax checks pass
- [x] `npm test` — 1025 pass, 0 fail (13 new tests)
- [x] New: native aging routing test — default off forwards blobs byte-identical; opted-in rewrites only consumed >32KiB results outside the 4-newest frontier and meters the savings
- [x] New: state round-trips — native flag survives routed toggle, env kill switch covers both, pre-native state files read as off, corrupt state fails closed
- [x] New: totals aggregation — per-range buckets, cache split, zero-state shape
- [x] Swift tray builds clean (`swift build` + bundle script); verified live in the menu bar against real ledger data
- [ ] Reinstall via `install.sh` on a second machine to confirm tray update path picks up the new card
