### PR TITLE
fix: resolve and spawn commands the way Windows requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## Unreleased
 
+- **Windows stops mistaking its own spawn failures for provider problems.** A
+  command resolved on Windows and a command Windows can spawn are two different
+  things: `where.exe` lists the extensionless npm shim first, and Node has
+  refused to run a `.cmd` shim without a shell since CVE-2024-27980. Four
+  copies of the same lookup helper took line one anyway, and the spawn errors
+  that followed were each read as something else. The official Grok CLI was the
+  worst of it — a healthy npm install failed to launch, raising the same
+  `spawn UNKNOWN` that Smart App Control raises, so the router announced that
+  Windows application control had blocked it and told the operator to give up
+  on OAuth and use an API key. Even had the preflight passed, the token refresh
+  behind it spawned the shim the same unusable way.
+
+  Resolution and launching now live in one module and are used everywhere:
+  the routed-subagent proof run (which hands Codex a whole sentence, so it
+  cannot go through a shell that joins arguments on spaces), the Codex account
+  usage panel, the doctor's Codex configuration probe, the `npm install -g` and
+  sign-in paths for provider CLIs, and the precedence probe. Arguments are
+  escaped for `cmd.exe` rather than concatenated, so a path under
+  `C:\Program Files` and a prompt containing spaces both survive.
+
+- **Three more Windows-only breakages in the same family.** The Codex account
+  usage panel kept a private two-line search for the CLI — an undocumented
+  environment variable, a macOS-only path, then the bare name — which finds
+  nothing on Windows, so the panel reported "the Codex app-server could not be
+  started" on every machine; it now uses the shared discovery and kills the
+  process tree rather than leaking a Codex process per poll. `control apply`
+  ran the POSIX `bin/enable` script, which Windows cannot execute, and now
+  takes the PowerShell installer that `doctor --fix` already uses. The
+  vision-model download worker was the one detached child without
+  `windowsHide`, so it opened a console window for the length of a
+  multi-gigabyte pull.
+
+- **A local Ollama the router could find is one it can also run.** The vision
+  host probed for Ollama through the runtime's known install locations but then
+  spawned the bare name, so a Windows install under `%LOCALAPPDATA%` reported
+  as available and failed at the next call. Both now use the same resolver.
+
 - **Routed models that emit integer tool arguments as JSON floats no longer
   get those calls rejected by Codex.** Grok 4.6 was sending
   `timeout_ms: 20000.0`; Codex's native `shell_command` schema wants a `u64`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Windows installs the tray companion, and keeps it.** Nothing on Windows
+  ever built or started it: `install.ps1` had no tray option at all, the
+  installer's own decision helper excluded the platform outright, and
+  `control tray enable` answered `{"supported":false}` and exited 0 — a silent
+  no-op that reads as success while no tray was ever going to appear. The only
+  route was knowing to run `scripts/build-desktop-tray.ps1` by hand, and even
+  then the companion vanished at the next reboot. `install.ps1 -WithTray` (and
+  `-NoTray`, matching `install.sh`) now builds it and registers a `Codex Router
+  Tray` logon task, kept separate from the router's own task so stopping one
+  never takes the other down. Quitting from the tray menu stays quit: the
+  restart setting covers a crash, not a clean exit. A platform with no
+  supervisor now says so on stderr rather than reporting success, and the
+  guidance names the `^` overflow that hides new tray icons on Windows 11.
+
 - **Windows stops mistaking its own spawn failures for provider problems.** A
   command resolved on Windows and a command Windows can spawn are two different
   things: `where.exe` lists the extensionless npm shim first, and Node has

--- a/README.md
+++ b/README.md
@@ -1020,10 +1020,16 @@ surface.
 ```
 
 ```powershell
-# Windows PowerShell
+# Windows PowerShell -- build, launch, and start at logon
+.\install.ps1 -CheckoutInstall -WithTray
+
+# or build and launch it by hand
 .\scripts\build-desktop-tray.ps1 -BinaryOnly
 Start-Process .\apps\desktop\src-tauri\target\release\codex-router-desktop.exe
 ```
+
+Windows 11 hides new tray icons in the `^` overflow next to the clock; drag the
+icon onto the taskbar to pin it.
 
 Windows and Linux on X11 receive the floating top-center activity pill. Linux
 on Wayland uses the tray panel without the pill because the compositor owns

--- a/docs/DESKTOP-TRAY.md
+++ b/docs/DESKTOP-TRAY.md
@@ -91,6 +91,28 @@ Start-Process .\apps\desktop\src-tauri\target\release\codex-router-desktop.exe
 Pass `-BinaryOnly` for an unbundled executable. Installer artifacts are written
 under `apps\desktop\src-tauri\target\release\bundle` by a full build.
 
+## Starting at logon
+
+`install.ps1 -WithTray` builds the companion and registers a `Codex Router
+Tray` scheduled task that runs it at logon, separately from the router's own
+`Codex Router` task so stopping one never takes the other down. The same task
+is managed directly with:
+
+```powershell
+node src\control.mjs tray enable    # build required first; also starts it now
+node src\control.mjs tray status
+node src\control.mjs tray disable
+```
+
+Quitting from the tray menu keeps it quit: the restart setting covers a crash,
+not a clean exit, so the tray returns at the next logon rather than reappearing
+immediately. Linux has no supervisor — launch it with `./bin/model-router-tray`
+— and the tray commands say so instead of reporting a silent success.
+
+Windows 11 hides new tray icons in the `^` overflow next to the clock. Drag the
+icon onto the taskbar to pin it; an unpinned icon is the most common reason the
+companion looks like it never started.
+
 The app discovers the router checkout from `MODEL_ROUTER_SOURCE_ROOT`, a saved
 bundle pointer, the source tree during development, or the standard install
 location (`%LOCALAPPDATA%\codex-router` on Windows and

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -70,12 +70,16 @@ Set-Location codex-router
 ./install.ps1 -Guided
 ```
 
-On macOS and Linux, guided setup also offers to build and launch the desktop
-companion (the macOS menu bar app or the Windows/Linux tray). `--with-tray`
-installs it without asking, `--no-tray` never offers it, and automatic mode
-skips it. On macOS the app bundle is placed in `~/Applications` and needs the
-Swift toolchain; a missing toolchain skips the step with guidance instead of
-failing setup. Windows still builds the tray manually with
+Guided setup also offers to build and launch the desktop companion (the macOS
+menu bar app, or the Windows/Linux tray). `--with-tray` installs it without
+asking, `--no-tray` never offers it, and automatic mode skips it. On Windows
+the same choice is `-WithTray` / `-NoTray`.
+
+On macOS the app bundle is placed in `~/Applications` and needs the Swift
+toolchain; a missing toolchain skips the step with guidance instead of failing
+setup. On Windows the Tauri companion is built with Rust and registered as a
+`Codex Router Tray` logon task so it returns after a reboot; a missing Rust
+toolchain skips the step the same way. You can still build it by hand with
 `scripts/build-desktop-tray.ps1`.
 Guided setup walks through numbered steps: a provider list you toggle by
 number (`a` selects all, `n` clears, Enter continues) with a live

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -117,8 +117,14 @@ On Windows, first confirm that the installed official CLI can launch:
 grok --version
 ```
 
-If that command reports `spawn UNKNOWN`, "An Application Control policy has
-blocked this file," or a Smart App Control notification, Grok OAuth cannot
+If `grok --version` works in a terminal but the doctor still reports the CLI as
+blocked, upgrade first: releases before this fix picked the extensionless npm
+shim out of `where.exe grok` and could not spawn it, and that failure raises the
+same `spawn UNKNOWN` Windows application control does. The router now selects
+the `grok.cmd` shim and launches it through `cmd.exe`.
+
+If the command itself reports `spawn UNKNOWN`, "An Application Control policy
+has blocked this file," or a Smart App Control notification, Grok OAuth cannot
 complete login or refresh its session. Keep Smart App Control enabled; it does
 not offer a safe per-app bypass for this failure. Until xAI publishes an
 official CLI build that Windows allows, use the API-key provider instead:

--- a/install.ps1
+++ b/install.ps1
@@ -11,6 +11,10 @@ param(
   [switch]$MigrateKnown,
   [switch]$AdoptNativeCatalog,
   [switch]$SmokeTest,
+  # Matches install.sh's --with-tray/--no-tray. Windows previously had no way
+  # to ask for the companion at all, so it was never built and never started.
+  [switch]$WithTray,
+  [switch]$NoTray,
   # Discards tracked edits in the managed checkout so the update can proceed.
   # Deliberately never touches untracked files -- see Reset-ManagedCheckout.
   [switch]$Force,
@@ -30,6 +34,9 @@ if ($PrepareOnly -and $AdoptNativeCatalog) {
 }
 if ($MigrateKnown -and $AdoptNativeCatalog) {
   throw "-AdoptNativeCatalog cannot be combined with -MigrateKnown."
+}
+if ($WithTray -and $NoTray) {
+  throw "-WithTray cannot be combined with -NoTray."
 }
 $PreviousRevision = $null
 $RepositoryUrl = if ($env:CODEX_ROUTER_REPOSITORY_URL) {
@@ -172,6 +179,8 @@ if (-not $CheckoutInstall) {
   if ($MigrateKnown) { $SetupArguments += "--migrate-known" }
   if ($AdoptNativeCatalog) { $SetupArguments += "--adopt-native-catalog" }
   if ($SmokeTest) { $SetupArguments += "--smoke-test" }
+  if ($WithTray) { $SetupArguments += "--with-tray" }
+  if ($NoTray) { $SetupArguments += "--no-tray" }
   & node @SetupArguments
   $SetupExitCode = $LASTEXITCODE
   # Exit 2 means setup left configuration unfinished (a declined prompt, a

--- a/scripts/provider-precedence-probe.mjs
+++ b/scripts/provider-precedence-probe.mjs
@@ -19,7 +19,7 @@ import { fileURLToPath } from "node:url";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
 import { buildMergedCatalog } from "../src/catalog.mjs";
-import { codexSpawnTarget, findCodexBinary } from "../src/codex-binary.mjs";
+import { findCodexBinary, spawnableCommand } from "../src/codex-binary.mjs";
 import { writeLiteLlmConfig } from "../src/litellm-config.mjs";
 import { MODEL_BY_SLUG, PROVIDERS } from "../src/model-registry.mjs";
 
@@ -134,10 +134,11 @@ function runCodex({ model, marker, routerBaseUrl, catalogPath }) {
       SOURCE_ROOT,
       `Reply with exactly ${marker}. Do not call tools.`,
     ];
-    const { command, options } = codexSpawnTarget(CODEX_BIN);
-    const child = spawn(command, args, {
-      ...options,
+    const target = spawnableCommand(CODEX_BIN, args);
+    const child = spawn(target.command, target.args, {
+      ...target.options,
       cwd: SOURCE_ROOT,
+      windowsHide: true,
       env: { ...process.env, CODEX_HOME, MODEL_ROUTER_TARGET: "codex" },
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/src/agent-check.mjs
+++ b/src/agent-check.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { findCodexBinary } from "./codex-binary.mjs";
+import { spawnableCommand } from "./spawnable-command.mjs";
 
 // Whether a local model can drive Codex is not predictable from its size, its
 // tool flag, or a hand-written probe. Every approximation tried here got it
@@ -74,7 +75,13 @@ export function checkAgentCapability(slug, options = {}) {
 
 function runAgentCheckOnce(
   slug,
-  { codex = findCodexBinary(), spawn = spawnSync, timeoutMs = 420_000, catalogSlugs } = {},
+  {
+    codex = findCodexBinary(),
+    spawn = spawnSync,
+    timeoutMs = 420_000,
+    catalogSlugs,
+    platform = process.platform,
+  } = {},
 ) {
   if (!codex) return { slug, ok: false, error: "No Codex binary found." };
   // A slug Codex cannot resolve does not fail loudly -- it quietly serves the
@@ -96,7 +103,10 @@ function runAgentCheckOnce(
   const startedAt = Date.now();
   try {
     writeFileSync(path.join(workspace, marker), "ok\n", "utf8");
-    const result = spawn(
+    // The prompt is a whole sentence, so this cannot go through a naive
+    // `shell: true` -- that joins arguments on spaces and would hand Codex
+    // eighteen arguments instead of one. spawnableCommand quotes for cmd.exe.
+    const target = spawnableCommand(
       codex,
       [
         "exec",
@@ -108,8 +118,15 @@ function runAgentCheckOnce(
         "--skip-git-repo-check",
         CHECK_PROMPT,
       ],
-      { cwd: workspace, encoding: "utf8", timeout: timeoutMs },
+      platform,
     );
+    const result = spawn(target.command, target.args, {
+      ...target.options,
+      cwd: workspace,
+      encoding: "utf8",
+      timeout: timeoutMs,
+      windowsHide: true,
+    });
     const graded = gradeCodexRun(
       { status: result.status, stdout: result.stdout, stderr: result.stderr },
       marker,

--- a/src/codex-account-usage.mjs
+++ b/src/codex-account-usage.mjs
@@ -1,14 +1,39 @@
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
 import readline from "node:readline";
 
-const DEFAULT_TIMEOUT_MS = 10_000;
-const APP_CODEX = "/Applications/ChatGPT.app/Contents/Resources/codex";
+import { findCodexBinary } from "./codex-binary.mjs";
+import { spawnableCommand } from "./spawnable-command.mjs";
 
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+// This used to keep its own two-line search -- an undocumented CODEX_BINARY
+// override, a hardcoded macOS app path, then the bare name "codex". None of
+// the three finds a Windows install: the bundled Desktop CLI lives under a
+// version-hashed %LOCALAPPDATA% directory, and a bare "codex" resolves to the
+// extensionless npm shim that Node cannot spawn. The panel reported "the Codex
+// app-server could not be started" on every Windows machine. Use the same
+// discovery the rest of the router uses, and keep CODEX_BINARY working for
+// anyone who set it.
 function codexBinary() {
-  if (process.env.CODEX_BINARY) return process.env.CODEX_BINARY;
-  if (existsSync(APP_CODEX)) return APP_CODEX;
-  return "codex";
+  return process.env.CODEX_BINARY || findCodexBinary();
+}
+
+// Killing a child that was reached through cmd.exe kills the shell, not the
+// app-server behind it. On a timeout that left a Codex process holding the
+// pipe for as long as the session lived, once per poll.
+function killProcessTree(child, viaShell) {
+  if (!viaShell || process.platform !== "win32" || !child.pid) {
+    child.kill();
+    return;
+  }
+  try {
+    execFileSync("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+  } catch {
+    child.kill();
+  }
 }
 
 function clampPercent(value) {
@@ -62,10 +87,22 @@ export function normalizeCodexAccountUsage(rateLimitResponse, usageResponse, now
   };
 }
 
-export function readCodexAccountUsage({ timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+export function readCodexAccountUsage({
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  binary = codexBinary(),
+  platform = process.platform,
+  spawnImpl = spawn,
+} = {}) {
   return new Promise((resolve, reject) => {
-    const processHandle = spawn(codexBinary(), ["app-server"], {
+    if (!binary) {
+      reject(new Error("The Codex app-server could not be started: no Codex binary was found."));
+      return;
+    }
+    const target = spawnableCommand(binary, ["app-server"], platform);
+    const processHandle = spawnImpl(target.command, target.args, {
+      ...target.options,
       stdio: ["pipe", "pipe", "ignore"],
+      windowsHide: true,
     });
     const lines = readline.createInterface({ input: processHandle.stdout });
     const responses = new Map();
@@ -76,7 +113,7 @@ export function readCodexAccountUsage({ timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
       settled = true;
       clearTimeout(timer);
       lines.close();
-      processHandle.kill();
+      killProcessTree(processHandle, Boolean(target.options.windowsVerbatimArguments));
       if (error) reject(error);
       else resolve(value);
     };

--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -99,8 +99,11 @@ export function codexVersion() {
 export function codexAuthStatus() {
   const binary = findCodexBinary();
   if (!binary) return { authenticated: false, reason: "codex-not-found" };
-  const target = spawnableCommand(binary, ["login", "status"]);
   try {
+    // Inside the try: a path this module refuses to hand to a shell is a probe
+    // that could not run, which is the "unknown" this function exists to
+    // report -- not an exception for every caller to learn to expect.
+    const target = spawnableCommand(binary, ["login", "status"]);
     execFileSync(target.command, target.args, {
       ...target.options,
       timeout: 10_000,

--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -3,6 +3,10 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { commandOnPath, preferSpawnablePath, spawnableCommand } from "./spawnable-command.mjs";
+
+export { preferSpawnablePath, spawnableCommand };
+
 // The ChatGPT/Codex desktop app bundles its CLI under a version-hashed
 // directory, e.g. %LOCALAPPDATA%\OpenAI\Codex\bin\<hash>\codex.exe. That hash
 // changes on every app update, so scan for the newest installed version
@@ -45,38 +49,12 @@ function candidates() {
   ].filter(Boolean);
 }
 
-// `where.exe codex` on an npm global install lists the extensionless shell shim
-// before the one Node can run:
-//   ...\npm\codex       <- POSIX-style shim, listed first, NOT spawnable
-//   ...\npm\codex.cmd   <- the batch shim that actually works
-// existsSync() reports true for the first because Windows resolves it through
-// PATHEXT, but execFileSync throws ENOENT on it without a shell. Choose an entry
-// Node can execute instead of trusting the listed order.
-const WINDOWS_SPAWNABLE_EXTENSIONS = [".exe", ".com", ".cmd", ".bat"];
-
-export function preferSpawnablePath(paths, platform = process.platform) {
-  const found = paths.map((value) => value.trim()).filter(Boolean);
-  if (platform !== "win32") return found[0];
-  for (const extension of WINDOWS_SPAWNABLE_EXTENSIONS) {
-    const match = found.find((value) => value.toLowerCase().endsWith(extension));
-    if (match) return match;
-  }
-  return found[0];
-}
-
 export function findCodexBinary() {
   const direct = candidates().find((candidate) => existsSync(candidate));
   if (direct) return direct;
-  const finder = process.platform === "win32" ? "where.exe" : "which";
-  try {
-    const output = execFileSync(finder, ["codex"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return preferSpawnablePath(output.split(/\r?\n/)) || undefined;
-  } catch {
-    return undefined;
-  }
+  // Never the raw first line of the finder: on Windows that is the
+  // extensionless npm shim, which Node cannot spawn. See spawnable-command.mjs.
+  return commandOnPath("codex");
 }
 
 export function requireCodexBinary() {
@@ -89,19 +67,13 @@ export function requireCodexBinary() {
   return binary;
 }
 
-// A .cmd/.bat shim is a batch script, so Windows needs a shell to run it. The
-// path is quoted because cmd.exe splits on spaces and Codex is routinely
-// installed under a profile directory that contains them.
-export function codexSpawnTarget(binary, platform = process.platform) {
-  if (platform === "win32" && /\.(cmd|bat)$/i.test(binary)) {
-    return { command: `"${binary}"`, options: { shell: true } };
-  }
-  return { command: binary, options: {} };
-}
-
 export function runCodex(args, options = {}) {
-  const { command, options: spawnOptions } = codexSpawnTarget(requireCodexBinary());
-  return execFileSync(command, args, { ...spawnOptions, ...options });
+  const target = spawnableCommand(requireCodexBinary(), args);
+  return execFileSync(target.command, target.args, {
+    windowsHide: true,
+    ...target.options,
+    ...options,
+  });
 }
 
 // The version tells catalog code whether a cached native capture came from
@@ -127,12 +99,13 @@ export function codexVersion() {
 export function codexAuthStatus() {
   const binary = findCodexBinary();
   if (!binary) return { authenticated: false, reason: "codex-not-found" };
-  const { command, options } = codexSpawnTarget(binary);
+  const target = spawnableCommand(binary, ["login", "status"]);
   try {
-    execFileSync(command, ["login", "status"], {
-      ...options,
+    execFileSync(target.command, target.args, {
+      ...target.options,
       timeout: 10_000,
       stdio: "ignore",
+      windowsHide: true,
     });
     return { authenticated: true, reason: "authenticated", binary };
   } catch (error) {

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -14,7 +14,7 @@ import {
 import os from "node:os";
 import path from "node:path";
 
-import { codexSpawnTarget, findCodexBinary } from "./codex-binary.mjs";
+import { findCodexBinary, spawnableCommand } from "./codex-binary.mjs";
 
 import {
   assertCallerSecret,
@@ -245,13 +245,14 @@ multi_agent_v2 = { enabled = true, max_concurrent_threads_per_session = ${manage
 `,
       { encoding: "utf8", mode: 0o600 },
     );
-    const { command: probeCommand, options } = codexSpawnTarget(binary);
+    const probe = spawnableCommand(binary, ["login", "status"]);
     // `login status` exits non-zero when signed out, so the exit code says
     // nothing about the config; only the load-error message does.
-    const result = spawnSync(probeCommand, ["login", "status"], {
-      ...options,
+    const result = spawnSync(probe.command, probe.args, {
+      ...probe.options,
       encoding: "utf8",
       timeout: 10_000,
+      windowsHide: true,
       env: { ...process.env, CODEX_HOME: probeHome },
     });
     if (result.error) return false;
@@ -321,13 +322,14 @@ function probeAgentConcurrencyScalar() {
       `max_concurrent_threads_per_session = ${managedAgentMaxConcurrency}\n`,
       { encoding: "utf8", mode: 0o600 },
     );
-    const { command: probeCommand, options } = codexSpawnTarget(binary);
+    const probe = spawnableCommand(binary, ["login", "status"]);
     // `login status` exits non-zero when signed out, so the exit code says
     // nothing about the config; only the load-error message does.
-    const result = spawnSync(probeCommand, ["login", "status"], {
-      ...options,
+    const result = spawnSync(probe.command, probe.args, {
+      ...probe.options,
       encoding: "utf8",
       timeout: 10_000,
+      windowsHide: true,
       env: { ...process.env, CODEX_HOME: probeHome },
     });
     if (result.error) return true;

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -321,10 +321,32 @@ function runApply() {
     if (targetIsActive(target)) {
       refreshActiveTarget(target);
     } else {
-      const result = spawnSync(path.join(REPO_ROOT, "bin", "enable"), [], {
-        env: { ...process.env, MODEL_ROUTER_TARGET: target },
-        stdio: "inherit",
-      });
+      // `bin/enable` is a POSIX shell script. Windows reaches the same enable
+      // path through the PowerShell installer, the way doctor --fix and
+      // curate-models already do; spawning the shell script there failed with
+      // ENOEXEC and reported it as a plain "apply failed".
+      const result = process.platform === "win32"
+        ? spawnSync(
+            "powershell.exe",
+            [
+              "-NoLogo",
+              "-NoProfile",
+              "-ExecutionPolicy",
+              "Bypass",
+              "-File",
+              path.join(REPO_ROOT, "install.ps1"),
+              "-CheckoutInstall",
+            ],
+            {
+              cwd: REPO_ROOT,
+              env: { ...process.env, MODEL_ROUTER_TARGET: target },
+              stdio: "inherit",
+            },
+          )
+        : spawnSync(path.join(REPO_ROOT, "bin", "enable"), [], {
+            env: { ...process.env, MODEL_ROUTER_TARGET: target },
+            stdio: "inherit",
+          });
       if (result.status !== 0) throw new Error(`${target}: apply failed`);
     }
     applied.push(target);
@@ -898,7 +920,10 @@ async function handleVisionBridge(action, value, extra) {
     const child = spawn(
       process.execPath,
       [path.join(REPO_ROOT, "src", "vision-download.mjs"), tag],
-      { detached: true, stdio: "ignore" },
+      // windowsHide matters more here than anywhere else: a detached child
+      // gets its own console on Windows, and this one lives for the length of
+      // a multi-gigabyte pull. The local-model worker below already hides.
+      { detached: true, stdio: "ignore", windowsHide: true },
     );
     child.unref();
     process.stdout.write(`${JSON.stringify({ started: true, tag })}\n`);

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import { validCallerSecret } from "./caller-auth.mjs";
 import { codexAuthStatus, findCodexBinary, runCodex } from "./codex-binary.mjs";
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
 import { routedCodexAgentStatus } from "./codex-agent-catalog.mjs";
 import { privateFileIsProtected } from "./file-security.mjs";
 import { grokCliPreflight } from "./grok-cli.mjs";
@@ -90,7 +91,16 @@ function bundledVenvProblem() {
 // says nothing here; only the load-error message does.
 function configLoadComplaint(binary, spawn) {
   try {
-    const result = spawn(binary, ["login", "status"], { encoding: "utf8", timeout: 10_000 });
+    // A .cmd shim needs the cmd.exe hop, or the probe dies before Codex is
+    // reached -- and a probe that never ran reports no complaint, which made
+    // this check silently pass on every npm-installed Windows Codex.
+    const target = spawnableCommand(binary, ["login", "status"]);
+    const result = spawn(target.command, target.args, {
+      ...target.options,
+      encoding: "utf8",
+      timeout: 10_000,
+      windowsHide: true,
+    });
     if (result.error) return undefined;
     return `${result.stdout || ""}\n${result.stderr || ""}`
       .split(/\r?\n/)
@@ -121,18 +131,6 @@ export function codexConfigLoadError({
   return undefined;
 }
 
-function commandOnPath(name) {
-  try {
-    return execFileSync(process.platform === "win32" ? "where.exe" : "which", [name], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-      .trim()
-      .split(/\r?\n/)[0];
-  } catch {
-    return undefined;
-  }
-}
 
 function readableSecret(target, validator) {
   if (!existsSync(target)) return false;

--- a/src/grok-cli.mjs
+++ b/src/grok-cli.mjs
@@ -1,7 +1,9 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
 
 const WINDOWS_BLOCK_CODES = new Set(["EACCES", "EPERM", "UNKNOWN"]);
 const WINDOWS_BLOCK_PATTERNS = [
@@ -17,26 +19,18 @@ export const GROK_CLI_BLOCKED_DETAIL =
 export const GROK_CLI_BLOCKED_FIX =
   "Keep Smart App Control enabled. Use the grok-api provider, or install a trusted official Grok CLI release that Windows allows.";
 
-function commandPath(name, platform = process.platform) {
-  const finder = platform === "win32" ? "where.exe" : "which";
-  try {
-    return execFileSync(finder, [name], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-      .trim()
-      .split(/\r?\n/)[0];
-  } catch {
-    return undefined;
-  }
-}
-
 export function grokCliPath({
   environment = process.env,
   platform = process.platform,
+  exec,
 } = {}) {
   if (environment.GROK_CLI) return environment.GROK_CLI;
-  const discovered = commandPath("grok", platform);
+  // The official CLI ships as an npm package, so on Windows `where.exe grok`
+  // leads with the extensionless shim Node cannot spawn. Taking that line made
+  // a perfectly healthy install fail with the same `spawn UNKNOWN` that Smart
+  // App Control raises, and the preflight below then blamed application
+  // control for it. Ask for a spawnable entry instead.
+  const discovered = commandOnPath("grok", { platform, ...(exec ? { exec } : {}) });
   if (discovered) return discovered;
 
   const directory = path.join(
@@ -44,7 +38,11 @@ export function grokCliPath({
     "bin",
   );
   const candidates = platform === "win32"
-    ? [path.join(directory, "grok.exe"), path.join(directory, "grok")]
+    ? [
+        path.join(directory, "grok.exe"),
+        path.join(directory, "grok.cmd"),
+        path.join(directory, "grok"),
+      ]
     : [
         path.join(os.homedir(), ".npm-global", "bin", "grok"),
         path.join(directory, "grok"),
@@ -93,7 +91,12 @@ export function grokCliPreflight({
   }
 
   const { XAI_API_KEY: _apiKey, ...sanitizedEnvironment } = environment;
-  const result = spawnSyncImpl(executable, ["--version"], {
+  // An npm-installed CLI resolves to a .cmd shim, which Node refuses to spawn
+  // without a shell; without this hop the launch fails before the CLI is even
+  // reached and the failure reads as an application-control block.
+  const target = spawnableCommand(executable, ["--version"], platform);
+  const result = spawnSyncImpl(target.command, target.args, {
+    ...target.options,
     encoding: "utf8",
     env: sanitizedEnvironment,
     timeout: 5_000,

--- a/src/grok-cli.mjs
+++ b/src/grok-cli.mjs
@@ -94,14 +94,28 @@ export function grokCliPreflight({
   // An npm-installed CLI resolves to a .cmd shim, which Node refuses to spawn
   // without a shell; without this hop the launch fails before the CLI is even
   // reached and the failure reads as an application-control block.
-  const target = spawnableCommand(executable, ["--version"], platform);
-  const result = spawnSyncImpl(target.command, target.args, {
-    ...target.options,
-    encoding: "utf8",
-    env: sanitizedEnvironment,
-    timeout: 5_000,
-    windowsHide: true,
-  });
+  let result;
+  try {
+    const target = spawnableCommand(executable, ["--version"], platform);
+    result = spawnSyncImpl(target.command, target.args, {
+      ...target.options,
+      encoding: "utf8",
+      env: sanitizedEnvironment,
+      timeout: 5_000,
+      windowsHide: true,
+    });
+  } catch (error) {
+    // A path this module will not hand to a shell is a CLI that cannot run,
+    // and saying so beats letting the throw escape into the doctor's report.
+    return {
+      state: "unavailable",
+      installed: true,
+      runnable: false,
+      executable,
+      detail: `installed, but the official Grok CLI could not run (${error.message})`,
+      fix: "Check GROK_CLI, then run `grok --version` in a terminal and rerun the doctor.",
+    };
+  }
   if (!result.error && result.status === 0) {
     return { state: "ready", installed: true, runnable: true, executable };
   }

--- a/src/grok-oauth-session.mjs
+++ b/src/grok-oauth-session.mjs
@@ -7,6 +7,7 @@ import {
   grokCliPreflight,
 } from "./grok-cli.mjs";
 import { grokAuthPath, grokSessionEntry } from "./grok-oauth-status.mjs";
+import { spawnableCommand } from "./spawnable-command.mjs";
 
 const REFRESH_THRESHOLD_MS = 5 * 60 * 1_000;
 const REFRESH_TIMEOUT_MS = 30_000;
@@ -54,18 +55,25 @@ function isHardExpired(session, now) {
 
 export function refreshWithOfficialCli({
   executable = grokCliPath() || "grok",
+  platform = process.platform,
   preflightOptions,
   spawnImpl = spawn,
 } = {}) {
-  const preflight = grokCliPreflight({ executable, ...preflightOptions });
+  const preflight = grokCliPreflight({ executable, platform, ...preflightOptions });
   if (!preflight.runnable) {
     return Promise.reject(oauthError(grokCliFailureMessage(preflight)));
   }
   return new Promise((resolve, reject) => {
     const { XAI_API_KEY: _apiKey, ...environment } = process.env;
-    const child = spawnImpl(executable, ["models"], {
+    // The same batch-shim hop the preflight takes: a refresh that skipped it
+    // failed on every npm-installed Windows CLI, expiring the session that the
+    // preflight had just reported as healthy.
+    const target = spawnableCommand(executable, ["models"], platform);
+    const child = spawnImpl(target.command, target.args, {
+      ...target.options,
       env: environment,
       stdio: ["ignore", "ignore", "ignore"],
+      windowsHide: true,
     });
     let timedOut = false;
     const timer = setTimeout(() => {

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -92,6 +92,9 @@ export const TRAY_APP_PATH =
   trayBundleDir("darwin", os.homedir()) ?? path.join(os.homedir(), "Applications", "Model Router.app");
 export const LEGACY_TRAY_APP_PATH = path.join(SOURCE_ROOT, "dist", "Model Router.app");
 export const TRAY_APP_BINARY = path.join(TRAY_APP_PATH, "Contents", "MacOS", "ModelRouterTray");
+// Task Scheduler names the tray separately from the router's own task so
+// stopping one never takes the other down.
+export const TRAY_TASK_NAME = "Codex Router Tray";
 
 function port(name, fallback) {
   const value = Number(process.env[name] || fallback);

--- a/src/provider-onboarding.mjs
+++ b/src/provider-onboarding.mjs
@@ -22,6 +22,7 @@ import {
   writeProviderCredential,
 } from "./provider-credentials.mjs";
 import { disableProvider } from "./provider-selection.mjs";
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
 
 const SIGN_IN_CLIS = Object.freeze({
   "kimi-oauth": {
@@ -68,11 +69,14 @@ function readNpmGlobalBinDir() {
   const npm = npmPath();
   if (!npm) return undefined;
   try {
-    const prefix = execFileSync(npm, ["prefix", "-g"], {
+    const npmPrefix = spawnableCommand(npm, ["prefix", "-g"]);
+    const prefix = execFileSync(npmPrefix.command, npmPrefix.args, {
+      ...npmPrefix.options,
       encoding: "utf8",
       env: spawnEnvironment(),
       timeout: 15_000,
       stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
     }).trim();
     if (!prefix) return undefined;
     // npm drops binaries straight into the prefix on Windows and into
@@ -84,17 +88,9 @@ function readNpmGlobalBinDir() {
 }
 
 function commandPath(name) {
-  const finder = process.platform === "win32" ? "where.exe" : "which";
-  try {
-    return execFileSync(finder, [name], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-      .trim()
-      .split(/\r?\n/)[0];
-  } catch {
-    return undefined;
-  }
+  // Not the finder's first line: on Windows that is the extensionless npm
+  // shim, and every caller here goes on to spawn what it gets back.
+  return commandOnPath(name);
 }
 
 // A registry entry can declare a CLI session before anyone teaches this module
@@ -241,7 +237,10 @@ export function installOauthCli(providerId) {
   }
   const npm = npmPath();
   if (!npm) throw new Error("Node.js and npm are required to install this provider CLI.");
-  const result = spawnSync(npm, ["install", "-g", cli.npmPackage], {
+  const install = spawnableCommand(npm, ["install", "-g", cli.npmPackage]);
+  const result = spawnSync(install.command, install.args, {
+    ...install.options,
+    windowsHide: true,
     encoding: "utf8",
     env: spawnEnvironment(),
   });
@@ -349,7 +348,9 @@ export function loginOauthProvider(providerId) {
   }
   // The CLI itself is another `#!/usr/bin/env node` script, so signing in needs
   // the same PATH repair the install did.
-  const result = spawnSync(executable, oauthLoginArgs(providerId), {
+  const login = spawnableCommand(executable, oauthLoginArgs(providerId));
+  const result = spawnSync(login.command, login.args, {
+    ...login.options,
     encoding: "utf8",
     env: spawnEnvironment(),
     timeout: LOGIN_TIMEOUT_MS,

--- a/src/setup-shared.mjs
+++ b/src/setup-shared.mjs
@@ -21,6 +21,7 @@ import { SOURCE_ROOT } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
 import { providerOnboardingSnapshot } from "./provider-onboarding.mjs";
 import { configuredProviderIds, validateProviderIds } from "./provider-selection.mjs";
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
 import { renderProviderChoices, toggleSelection } from "./setup-ui.mjs";
 
 // Target-agnostic setup helpers shared by every target's <target>-setup.mjs.
@@ -134,21 +135,15 @@ function oauthSetupHint(provider) {
 }
 
 function executable(name) {
-  const finder = process.platform === "win32" ? "where.exe" : "which";
-  try {
-    return execFileSync(finder, [name], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    })
-      .trim()
-      .split(/\r?\n/)[0];
-  } catch {
-    return undefined;
-  }
+  // Not the finder's first line: on Windows that is the extensionless npm
+  // shim, and every caller here goes on to spawn what it gets back.
+  return commandOnPath(name);
 }
 
 export function run(command, commandArgs) {
-  const result = spawnSync(command, commandArgs, {
+  const target = spawnableCommand(command, commandArgs);
+  const result = spawnSync(target.command, target.args, {
+    ...target.options,
     cwd: SOURCE_ROOT,
     env: process.env,
     stdio: "inherit",
@@ -162,7 +157,9 @@ export function run(command, commandArgs) {
 // Like run(), but reports success instead of throwing on a non-zero exit so the
 // caller can offer a retry (e.g. a cancelled `kimi login`).
 function tryRun(command, commandArgs) {
-  const result = spawnSync(command, commandArgs, {
+  const target = spawnableCommand(command, commandArgs);
+  const result = spawnSync(target.command, target.args, {
+    ...target.options,
     cwd: SOURCE_ROOT,
     env: process.env,
     stdio: "inherit",

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -297,6 +297,25 @@ function installTray() {
       run(path.join(SOURCE_ROOT, "scripts", "build-macos-tray-app.sh"), [bundleDir]);
       run("open", [bundleDir]);
       process.stdout.write(`Menu-bar companion installed at ${bundleDir} and opened.\n`);
+    } else if (process.platform === "win32") {
+      // Windows had no path through here at all: the tray was built by hand or
+      // not at all, and nothing brought it back after a reboot. Registering the
+      // logon task is what makes it stay, and it also starts the first
+      // instance, so there is no separate launch step.
+      run("powershell.exe", [
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        path.join(SOURCE_ROOT, "scripts", "build-desktop-tray.ps1"),
+        "-BinaryOnly",
+      ]);
+      run(process.execPath, [path.join(SOURCE_ROOT, "src", "tray-service.mjs"), "install"]);
+      process.stdout.write(
+        "Desktop companion built, launched, and set to start at logon.\n" +
+          "Windows 11 hides new tray icons: click the ^ chevron by the clock to find it, and drag it onto the taskbar to pin it.\n",
+      );
     } else {
       run(path.join(SOURCE_ROOT, "bin", "model-router-tray"), []);
       process.stdout.write("Desktop companion built and launched.\n");
@@ -307,7 +326,10 @@ function installTray() {
         (process.platform === "darwin"
           ? "Recent macOS SDKs need the full Xcode app (not only the Command Line Tools) to build the menu-bar companion's SwiftUI macros.\n"
           : "") +
-        "The router itself is installed; retry later with ./bin/model-router-tray.\n",
+        (process.platform === "win32"
+          ? "The Tauri companion needs Rust stable and Cargo on PATH.\n" +
+            "The router itself is installed; retry later with .\\scripts\\build-desktop-tray.ps1 -BinaryOnly.\n"
+          : "The router itself is installed; retry later with ./bin/model-router-tray.\n"),
     );
   }
 }

--- a/src/spawnable-command.mjs
+++ b/src/spawnable-command.mjs
@@ -104,8 +104,17 @@ export function escapeWindowsShellCommand(value) {
   return String(value).replace(CMD_META_CHARACTERS, "^$1");
 }
 
+// An argument holding nothing cmd.exe or the child's parser would act on is
+// passed through bare. Wrapping it in quotes anyway is invisible to a real
+// program -- argv parsing strips them -- but a batch file that compares `%1`
+// textually sees the quotes and stops matching, and shims that inspect their
+// own arguments are common enough that quoting everything breaks them. Bare is
+// also simply what a person typing the command would produce.
+const SAFE_BARE_ARGUMENT = /^[A-Za-z0-9_@+=:.\/\\-]+$/;
+
 export function escapeWindowsShellArgument(value, doubleEscape = false) {
   let escaped = String(value);
+  if (SAFE_BARE_ARGUMENT.test(escaped)) return escaped;
   // Backslashes are literal unless they precede a quote, where each one has to
   // be doubled so the quote it escapes survives as data.
   escaped = escaped.replace(/(\\*)"/g, '$1$1\\"');

--- a/src/spawnable-command.mjs
+++ b/src/spawnable-command.mjs
@@ -61,9 +61,44 @@ export function isWindowsBatchShim(binary, platform = process.platform) {
 // `shell: true` does, silently splitting any argument that contains one. The
 // escaping below is the form npm's own `cross-spawn` uses: quote the argument,
 // preserve backslash runs ahead of a quote, then neutralize every character
-// cmd.exe would otherwise act on. Batch files get a second round because
-// cmd.exe re-parses the line when it invokes one.
+// cmd.exe would otherwise act on.
+//
+// Exactly one shim shape needs a second round of `^` escaping: the cmd-shim
+// npm generates under `node_modules/.bin`, which re-enters cmd.exe to reach
+// the real program, so the first interpreter consumes one layer before the
+// second ever sees it. Applying that second layer to an ordinary batch file
+// instead corrupts the line -- Windows answers "The syntax of the command is
+// incorrect", which is how this was caught.
+const CMD_SHIM_PATTERN = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i;
+
+export function needsDoubleEscape(binary) {
+  return CMD_SHIM_PATTERN.test(String(binary || ""));
+}
 const CMD_META_CHARACTERS = /([()\][%!^"`<>&|;, *?])/g;
+
+// Escaping is the wrong last line of defence for a character that cannot occur
+// in a real path to begin with. Windows forbids " < > | ? * and every control
+// character in a file name, and those are exactly the ones that could end the
+// quoted span or start a second command if the escaping above were ever wrong.
+// (`&`, `^`, `%`, `!`, `(`, `)` and spaces are legal -- "C:\Program Files
+// (x86)" is an ordinary path -- so those are escaped, not rejected.)
+//
+// The binary path reaching here comes from CODEX_BIN, LOCALAPPDATA, or PATH.
+// Anyone who can set those already chooses which program runs, so this is not
+// the boundary that stops an attacker who has them; it is what keeps a
+// mistyped or hostile value from becoming a second command instead of a plain
+// "that is not a path" error.
+const PATH_ILLEGAL_ON_WINDOWS = /["<>|?*\u0000-\u001f]/;
+
+export function assertSpawnablePath(binary) {
+  if (PATH_ILLEGAL_ON_WINDOWS.test(String(binary))) {
+    throw new Error(
+      "Refusing to run a Windows path containing characters no file name may hold. " +
+        "Check CODEX_BIN, GROK_CLI, or whatever set this command path.",
+    );
+  }
+  return binary;
+}
 
 export function escapeWindowsShellCommand(value) {
   return String(value).replace(CMD_META_CHARACTERS, "^$1");
@@ -93,9 +128,11 @@ export function spawnableCommand(binary, args = [], platform = process.platform)
   if (!isWindowsBatchShim(binary, platform)) {
     return { command: binary, args: argumentList, options: {} };
   }
+  assertSpawnablePath(binary);
+  const doubleEscape = needsDoubleEscape(binary);
   const line = [
     escapeWindowsShellCommand(binary),
-    ...argumentList.map((argument) => escapeWindowsShellArgument(argument, true)),
+    ...argumentList.map((argument) => escapeWindowsShellArgument(argument, doubleEscape)),
   ].join(" ");
   return {
     command: process.env.ComSpec || "cmd.exe",

--- a/src/spawnable-command.mjs
+++ b/src/spawnable-command.mjs
@@ -1,0 +1,108 @@
+// Windows resolves a bare command name through PATHEXT, so the file a lookup
+// reports and the file Node can actually spawn are routinely different. Two
+// separate failures come out of that gap, and both used to be re-implemented
+// (or forgotten) at every call site:
+//
+//   1. `where.exe grok` on an npm global install lists the extensionless POSIX
+//      shim before the batch shim that works:
+//        ...\npm\grok       <- sh script, listed first, NOT spawnable
+//        ...\npm\grok.cmd   <- the batch shim Windows can run
+//      Taking the first line hands Node a file it cannot execute.
+//
+//   2. A .cmd/.bat shim is a batch script, so Windows needs cmd.exe to run it.
+//      Node has refused to spawn one without a shell since the CVE-2024-27980
+//      fix (18.20.2 / 20.12.2 / 21.7.3), and reports EINVAL when asked.
+//
+// Both failures surface as a spawn error the caller then misreads as something
+// else entirely -- "signed out", "blocked by Windows application control", or a
+// silently skipped check. Resolution and spawning therefore live together here,
+// so a caller that gets the path right also gets the launch right.
+import { execFileSync } from "node:child_process";
+
+export const WINDOWS_SPAWNABLE_EXTENSIONS = [".exe", ".com", ".cmd", ".bat"];
+
+// Ordered by preference: a real executable is spawned directly, and only a
+// batch shim has to pay for a cmd.exe hop.
+export function preferSpawnablePath(paths, platform = process.platform) {
+  const found = (paths || []).map((value) => String(value).trim()).filter(Boolean);
+  if (platform !== "win32") return found[0];
+  for (const extension of WINDOWS_SPAWNABLE_EXTENSIONS) {
+    const match = found.find((value) => value.toLowerCase().endsWith(extension));
+    if (match) return match;
+  }
+  return found[0];
+}
+
+// `which`/`where.exe` for a command name, returning an entry Node can spawn
+// rather than whichever one the finder happened to print first.
+export function commandOnPath(
+  name,
+  { platform = process.platform, exec = execFileSync } = {},
+) {
+  const finder = platform === "win32" ? "where.exe" : "which";
+  try {
+    const output = exec(finder, [name], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    return preferSpawnablePath(String(output || "").split(/\r?\n/), platform) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isWindowsBatchShim(binary, platform = process.platform) {
+  return platform === "win32" && /\.(cmd|bat)$/i.test(String(binary || ""));
+}
+
+// cmd.exe does not use the standard command-line parser, so an argument list
+// cannot simply be joined with spaces -- which is exactly what Node's
+// `shell: true` does, silently splitting any argument that contains one. The
+// escaping below is the form npm's own `cross-spawn` uses: quote the argument,
+// preserve backslash runs ahead of a quote, then neutralize every character
+// cmd.exe would otherwise act on. Batch files get a second round because
+// cmd.exe re-parses the line when it invokes one.
+const CMD_META_CHARACTERS = /([()\][%!^"`<>&|;, *?])/g;
+
+export function escapeWindowsShellCommand(value) {
+  return String(value).replace(CMD_META_CHARACTERS, "^$1");
+}
+
+export function escapeWindowsShellArgument(value, doubleEscape = false) {
+  let escaped = String(value);
+  // Backslashes are literal unless they precede a quote, where each one has to
+  // be doubled so the quote it escapes survives as data.
+  escaped = escaped.replace(/(\\*)"/g, '$1$1\\"');
+  escaped = escaped.replace(/(\\*)$/, "$1$1");
+  escaped = `"${escaped}"`;
+  escaped = escaped.replace(CMD_META_CHARACTERS, "^$1");
+  if (doubleEscape) escaped = escaped.replace(CMD_META_CHARACTERS, "^$1");
+  return escaped;
+}
+
+// Turns a resolved binary and its arguments into something Node can spawn on
+// this platform. Callers spread the result:
+//
+//   const { command, args, options } = spawnableCommand(binary, ["login"]);
+//   spawnSync(command, args, { ...options, encoding: "utf8" });
+//
+// Everything except a Windows batch shim passes through untouched.
+export function spawnableCommand(binary, args = [], platform = process.platform) {
+  const argumentList = [...args];
+  if (!isWindowsBatchShim(binary, platform)) {
+    return { command: binary, args: argumentList, options: {} };
+  }
+  const line = [
+    escapeWindowsShellCommand(binary),
+    ...argumentList.map((argument) => escapeWindowsShellArgument(argument, true)),
+  ].join(" ");
+  return {
+    command: process.env.ComSpec || "cmd.exe",
+    // `/d` skips AutoRun commands, `/s` makes cmd.exe strip only the outer
+    // quote pair and take the rest verbatim, and verbatim arguments stop Node
+    // from re-quoting a line that is already escaped for cmd.exe.
+    args: ["/d", "/s", "/c", `"${line}"`],
+    options: { windowsVerbatimArguments: true },
+  };
+}

--- a/src/tray-install.mjs
+++ b/src/tray-install.mjs
@@ -4,11 +4,31 @@ import path from "node:path";
 // guided setup. Kept free of process state so the flag/platform matrix is
 // unit-testable; setup.mjs owns the actual build and launch.
 
+const TRAY_PLATFORMS = new Set(["darwin", "linux", "win32"]);
+
 export function trayDecision({ platform, withTray, noTray, guided }) {
   if (noTray) return "skip";
-  if (platform !== "darwin" && platform !== "linux") return "skip";
+  // Windows was excluded here while it had no tray build, which left the
+  // installer silently skipping the one platform whose tray has to be built by
+  // hand -- so nothing ever appeared and nothing said why.
+  if (!TRAY_PLATFORMS.has(platform)) return "skip";
   if (withTray) return "install";
   return guided ? "ask" : "skip";
+}
+
+// The Tauri companion's release binary, which Windows and Linux share. macOS
+// builds a Swift app bundle instead and is served by TRAY_APP_BINARY.
+export function desktopTrayBinary(platform, sourceRoot) {
+  if (platform !== "win32" && platform !== "linux") return undefined;
+  return path.join(
+    sourceRoot,
+    "apps",
+    "desktop",
+    "src-tauri",
+    "target",
+    "release",
+    platform === "win32" ? "codex-router-desktop.exe" : "codex-router-desktop",
+  );
 }
 
 export function trayBundleDir(platform, home) {

--- a/src/tray-service-windows.mjs
+++ b/src/tray-service-windows.mjs
@@ -1,0 +1,153 @@
+// Windows autostart for the Tauri tray companion. Without it the tray is a
+// bare executable somebody has to remember to launch, so it disappears at
+// every reboot -- and `control tray enable` answered {"supported":false} and
+// exited 0, which reads as success while doing nothing at all.
+//
+// This is the router's own Task Scheduler pattern from service-windows.mjs,
+// with one deliberate difference: no windowless wrapper. That wrapper exists
+// to keep a console off the screen for a background Node process; the tray is
+// a GUI binary that owns no console, and routing it through wscript would only
+// put a script host between Task Scheduler and the window it has to show.
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+import { SOURCE_ROOT, TRAY_TASK_NAME } from "./paths.mjs";
+import { desktopTrayBinary } from "./tray-install.mjs";
+
+const effectivePlatform = process.env.CODEX_ROUTER_SERVICE_PLATFORM || process.platform;
+const command = process.argv[2] || "status";
+const renderCommands = new Set(["render", "render-task"]);
+// Resolved from the effective platform, not process.platform, so a render on
+// a POSIX machine shows the Windows path it would actually register.
+const TRAY_BINARY = desktopTrayBinary(effectivePlatform, SOURCE_ROOT);
+
+if (effectivePlatform !== "win32" && !renderCommands.has(command)) {
+  throw new Error("The Task Scheduler tray manager runs on Windows only.");
+}
+
+function schtasks(args, options = {}) {
+  return execFileSync("schtasks.exe", args, {
+    encoding: "utf8",
+    windowsHide: true,
+    stdio: options.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "pipe", "pipe"],
+  });
+}
+
+export function trayTaskAction(binary = TRAY_BINARY) {
+  return { execute: binary, argument: "" };
+}
+
+// RestartCount covers a crash, not a clean exit. That distinction is the whole
+// reason the tray's Quit menu item still works: Task Scheduler treats a zero
+// exit as the task finishing, so quitting stays quit until the next logon --
+// the same conditional-KeepAlive intent the macOS agent spells out.
+function installTask() {
+  const script = [
+    "$action = New-ScheduledTaskAction -Execute $env:CODEX_ROUTER_TRAY_EXECUTE",
+    "$trigger = New-ScheduledTaskTrigger -AtLogOn -User ([Security.Principal.WindowsIdentity]::GetCurrent().Name)",
+    "$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew",
+    "$principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited",
+    "Register-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_TASK -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Force | Out-Null",
+  ].join("; ");
+  execFileSync(
+    "powershell.exe",
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      env: {
+        ...process.env,
+        CODEX_ROUTER_TRAY_TASK: TRAY_TASK_NAME,
+        CODEX_ROUTER_TRAY_EXECUTE: trayTaskAction().execute,
+      },
+      stdio: ["ignore", "ignore", "ignore"],
+      windowsHide: true,
+    },
+  );
+}
+
+function taskExists() {
+  try {
+    schtasks(["/Query", "/TN", TRAY_TASK_NAME], { quiet: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function taskRunning() {
+  try {
+    return /\bRunning\b/i.test(schtasks(["/Query", "/TN", TRAY_TASK_NAME, "/FO", "LIST", "/V"]));
+  } catch {
+    return false;
+  }
+}
+
+function endTask() {
+  try {
+    schtasks(["/End", "/TN", TRAY_TASK_NAME], { quiet: true });
+  } catch {
+    // Missing or already idle: the state the caller asked for either way.
+  }
+}
+
+function requireBuiltTray() {
+  if (!TRAY_BINARY || !existsSync(TRAY_BINARY)) {
+    throw new Error(
+      `The tray app is not built at ${TRAY_BINARY}. ` +
+        "Run scripts\\build-desktop-tray.ps1 -BinaryOnly first.",
+    );
+  }
+}
+
+if (
+  !new Set(["install", "uninstall", "start", "stop", "restart", "status", "render", "render-task"]).has(
+    command,
+  )
+) {
+  console.error(
+    "Usage: tray-service-windows.mjs install|uninstall|start|stop|restart|status|render|render-task",
+  );
+  process.exit(2);
+}
+
+if (command === "render" || command === "render-task") {
+  process.stdout.write(`${JSON.stringify(trayTaskAction())}\n`);
+} else if (command === "status") {
+  const installed = taskExists();
+  process.stdout.write(
+    `${JSON.stringify({
+      installed,
+      supported: true,
+      loaded: installed && taskRunning(),
+      appPresent: Boolean(TRAY_BINARY) && existsSync(TRAY_BINARY),
+      state: installed && taskRunning() ? "running" : "stopped",
+      path: TRAY_BINARY,
+    })}\n`,
+  );
+} else if (command === "install") {
+  requireBuiltTray();
+  endTask();
+  installTask();
+  schtasks(["/Run", "/TN", TRAY_TASK_NAME], { quiet: true });
+  process.stdout.write(`${JSON.stringify({ installed: true, path: TRAY_BINARY })}\n`);
+} else if (command === "uninstall") {
+  endTask();
+  try {
+    schtasks(["/Delete", "/TN", TRAY_TASK_NAME, "/F"], { quiet: true });
+  } catch {
+    // The task may not exist.
+  }
+  process.stdout.write(`${JSON.stringify({ installed: false })}\n`);
+} else if (command === "stop") {
+  endTask();
+  process.stdout.write(`${JSON.stringify({ state: "stopped" })}\n`);
+} else {
+  // start and restart. A tray that was quit by hand is not running, so both
+  // reduce to asking Task Scheduler for a fresh instance.
+  requireBuiltTray();
+  if (!taskExists()) {
+    throw new Error(`The tray task is not installed. Run: control tray enable`);
+  }
+  if (command === "restart") endTask();
+  schtasks(["/Run", "/TN", TRAY_TASK_NAME], { quiet: true });
+  process.stdout.write(`${JSON.stringify({ state: "running" })}\n`);
+}

--- a/src/tray-service.mjs
+++ b/src/tray-service.mjs
@@ -3,21 +3,36 @@ import path from "node:path";
 
 import { SOURCE_ROOT } from "./paths.mjs";
 
-// Only macOS supervises the tray today. The Linux companion is launched
-// directly by bin/model-router-tray and Windows has no tray build, so the
-// commands succeed as no-ops there rather than failing an install.
+// macOS supervises the tray through launchd and Windows through Task
+// Scheduler. Linux is still launched directly by bin/model-router-tray, so its
+// commands succeed as no-ops rather than failing an install.
+const SUPERVISORS = {
+  darwin: "tray-service-macos.mjs",
+  win32: "tray-service-windows.mjs",
+};
+
 const platform = process.env.CODEX_ROUTER_SERVICE_PLATFORM || process.platform;
 
 const command = process.argv[2] || "status";
 
-if (platform !== "darwin") {
+const supervisor = SUPERVISORS[platform];
+if (!supervisor) {
+  // Still exit 0 -- an install must not fail over a companion this platform
+  // does not supervise -- but say so. A bare {"supported":false} on stdout was
+  // read as success by anyone running `control tray enable` and waiting for a
+  // tray that was never going to appear.
+  if (command !== "status") {
+    process.stderr.write(
+      `The tray is not supervised on ${platform}; launch it with ./bin/model-router-tray.\n`,
+    );
+  }
   process.stdout.write(`${JSON.stringify({ installed: false, supported: false })}\n`);
   process.exit(0);
 }
 
 const result = spawnSync(
   process.execPath,
-  [path.join(SOURCE_ROOT, "src", "tray-service-macos.mjs"), ...process.argv.slice(2)],
+  [path.join(SOURCE_ROOT, "src", supervisor), ...process.argv.slice(2)],
   { stdio: "inherit", env: process.env },
 );
 if (result.error) {

--- a/src/vision-host.mjs
+++ b/src/vision-host.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  ollamaCommand,
   ollamaAvailable as runtimeOllamaAvailable,
   ollamaInstallHint,
 } from "./ollama-runtime.mjs";
@@ -33,8 +34,16 @@ export function ollamaAvailable({ spawn = spawnSync } = {}) {
 
 // A model download is gigabytes, so it is never silent: the caller passes an
 // explicit consent flag (a --yes on the CLI, or a confirmed installer prompt).
+//
+// The runtime resolver, not the bare name: `ollamaAvailable()` above finds
+// Ollama through its known install locations, which on Windows is a
+// %LOCALAPPDATA% path the router's own PATH may never have seen. Probing with
+// one resolver and running with another reported an installed Ollama and then
+// failed to spawn it.
 export function pullOllamaModel(model, { spawn = spawnSync } = {}) {
-  const result = spawn("ollama", ["pull", model], { stdio: "inherit" });
+  const command = ollamaCommand({ spawn });
+  if (!command) throw new Error(`\`ollama pull ${model}\` failed: ${ollamaInstallMessage()}`);
+  const result = spawn(command, ["pull", model], { stdio: "inherit" });
   if (result.status !== 0) {
     throw new Error(`\`ollama pull ${model}\` failed (exit ${result.status ?? "unknown"}).`);
   }
@@ -46,7 +55,9 @@ export function pullOllamaModel(model, { spawn = spawnSync } = {}) {
 // as Ollama reports them (e.g. "qwen2.5vl:3b", "moondream:latest").
 export function ollamaInstalledModels({ spawn = spawnSync } = {}) {
   try {
-    const result = spawn("ollama", ["list"], { encoding: "utf8" });
+    const command = ollamaCommand({ spawn });
+    if (!command) return [];
+    const result = spawn(command, ["list"], { encoding: "utf8", windowsHide: true });
     if (result.status !== 0 || typeof result.stdout !== "string") return [];
     return result.stdout
       .split("\n")

--- a/test/agent-check.test.mjs
+++ b/test/agent-check.test.mjs
@@ -31,3 +31,35 @@ test("agent capability checks override user config with an ephemeral read-only s
   assert.equal(invocation.args[5], slug);
   assert.ok(invocation.args.includes("--skip-git-repo-check"));
 });
+
+// The proof run hands Codex a whole sentence as one argument. Node's
+// `shell: true` would join the list on spaces and split that sentence into
+// eighteen arguments; spawning the .cmd shim directly fails outright, which
+// graded every routed model on Windows as not agent-capable.
+test("the proof run reaches Codex through an npm batch shim on Windows", () => {
+  let invocation;
+  const slug = "local/test-model";
+  const spawn = (command, args, options) => {
+    invocation = { command, args, options };
+    const marker = readdirSync(options.cwd).find((entry) => entry.startsWith("agentcheck-"));
+    return { status: 0, stdout: `${marker}\n`, stderr: "" };
+  };
+
+  const result = checkAgentCapability(slug, {
+    attempts: 1,
+    codex: "C:\\Users\\ann\\AppData\\Roaming\\npm\\codex.cmd",
+    platform: "win32",
+    spawn,
+    catalogSlugs: new Set([slug]),
+  });
+
+  assert.equal(result.agentCapable, true);
+  assert.match(invocation.command, /cmd\.exe$/i);
+  assert.deepEqual(invocation.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.equal(invocation.options.windowsVerbatimArguments, true);
+  assert.equal(invocation.options.windowsHide, true);
+  const line = invocation.args[3];
+  assert.ok(line.includes("codex.cmd"), line);
+  // One argument, not one per word.
+  assert.ok(line.includes("list^^^ the^^^ files"), line);
+});

--- a/test/agent-check.test.mjs
+++ b/test/agent-check.test.mjs
@@ -61,5 +61,5 @@ test("the proof run reaches Codex through an npm batch shim on Windows", () => {
   const line = invocation.args[3];
   assert.ok(line.includes("codex.cmd"), line);
   // One argument, not one per word.
-  assert.ok(line.includes("list^^^ the^^^ files"), line);
+  assert.ok(line.includes("list^ the^ files"), line);
 });

--- a/test/codex-account-usage.test.mjs
+++ b/test/codex-account-usage.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { normalizeCodexAccountUsage } from "../src/codex-account-usage.mjs";
+import {
+  normalizeCodexAccountUsage,
+  readCodexAccountUsage,
+} from "../src/codex-account-usage.mjs";
 
 test("normalizes Codex limits and daily usage without account credentials", () => {
   const value = normalizeCodexAccountUsage(
@@ -59,4 +62,36 @@ test("clamps malformed percentages and tolerates missing usage", () => {
   assert.equal(value.primary.usedPercent, 100);
   assert.equal(value.primary.remainingPercent, 0);
   assert.deepEqual(value.dailyUsageBuckets, []);
+});
+
+// The panel used to run its own two-line search for Codex -- an undocumented
+// CODEX_BINARY, a macOS app path, then the bare name "codex". On Windows all
+// three miss, and the bare name resolves to the npm shim Node refuses to
+// spawn, so the usage panel reported "the Codex app-server could not be
+// started" on every Windows machine.
+test("the usage panel reaches an npm-installed Codex through cmd.exe", () => {
+  let invocation;
+  readCodexAccountUsage({
+    binary: "C:\\Users\\ann\\AppData\\Roaming\\npm\\codex.cmd",
+    platform: "win32",
+    spawnImpl: (command, args, options) => {
+      invocation = { command, args, options };
+      return {
+        stdout: { on() {}, once() {}, removeListener() {}, setEncoding() {} },
+        stdin: { write() {} },
+        once() {},
+        kill() {},
+      };
+    },
+  }).catch(() => {});
+
+  assert.match(invocation.command, /cmd\.exe$/i);
+  assert.deepEqual(invocation.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.ok(invocation.args[3].includes("codex.cmd"), invocation.args[3]);
+  assert.equal(invocation.options.windowsVerbatimArguments, true);
+  assert.equal(invocation.options.windowsHide, true);
+});
+
+test("the usage panel names a missing Codex instead of blaming the app-server", async () => {
+  await assert.rejects(readCodexAccountUsage({ binary: undefined }), /no Codex binary was found/);
 });

--- a/test/codex-binary.test.mjs
+++ b/test/codex-binary.test.mjs
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { codexSpawnTarget, findCodexBinary, preferSpawnablePath } from "../src/codex-binary.mjs";
+import { findCodexBinary, preferSpawnablePath, spawnableCommand } from "../src/codex-binary.mjs";
 
 // Reported in #46: `where.exe codex` on an npm global install lists the
 // extensionless POSIX shim before the batch shim. Node cannot spawn the former
@@ -54,23 +54,31 @@ test("returns undefined for empty finder output", () => {
   assert.equal(preferSpawnablePath(["", "   "], "darwin"), undefined);
 });
 
-test("a Windows batch shim runs through a shell with its path quoted", () => {
+test("a Windows batch shim runs through cmd.exe with its path escaped", () => {
   // cmd.exe splits on spaces and Codex is routinely installed under a profile
   // directory that contains them.
-  const target = codexSpawnTarget("C:\\Program Files\\npm\\codex.cmd", "win32");
-  assert.equal(target.command, '"C:\\Program Files\\npm\\codex.cmd"');
-  assert.equal(target.options.shell, true);
+  const target = spawnableCommand("C:\\Program Files\\npm\\codex.cmd", ["login"], "win32");
+  assert.match(target.command, /cmd\.exe$/i);
+  assert.equal(target.args[0], "/d");
+  assert.equal(target.args[2], "/c");
+  assert.match(target.args[3], /C:\\Program\^ Files\\npm\\codex\.cmd/);
+  assert.equal(target.options.windowsVerbatimArguments, true);
 });
 
 test("a Windows .exe is spawned directly, without a shell", () => {
-  const target = codexSpawnTarget("C:\\Programs\\Codex\\codex.exe", "win32");
+  const target = spawnableCommand("C:\\Programs\\Codex\\codex.exe", ["login"], "win32");
   assert.equal(target.command, "C:\\Programs\\Codex\\codex.exe");
-  assert.equal(target.options.shell, undefined);
+  assert.deepEqual(target.args, ["login"]);
+  assert.deepEqual(target.options, {});
 });
 
 test("a POSIX binary never gets a shell, even if it ends in .cmd", () => {
-  assert.equal(codexSpawnTarget("/opt/homebrew/bin/codex", "darwin").options.shell, undefined);
-  assert.equal(codexSpawnTarget("/weird/path/codex.cmd", "darwin").options.shell, undefined);
+  assert.deepEqual(spawnableCommand("/opt/homebrew/bin/codex", ["login"], "darwin"), {
+    command: "/opt/homebrew/bin/codex",
+    args: ["login"],
+    options: {},
+  });
+  assert.deepEqual(spawnableCommand("/weird/path/codex.cmd", [], "darwin").options, {});
 });
 
 test(

--- a/test/grok-cli.test.mjs
+++ b/test/grok-cli.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   grokCliFailureMessage,
+  grokCliPath,
   grokCliPreflight,
   windowsApplicationControlBlocked,
 } from "../src/grok-cli.mjs";
@@ -126,4 +127,60 @@ test("Grok OAuth refresh surfaces the Windows policy block before token expiry",
     },
   );
   assert.equal(refreshLaunches, 0);
+});
+
+// The official CLI is an npm package, so `where.exe grok` leads with the
+// extensionless shim. Spawning that raises `spawn UNKNOWN`, which is also what
+// Smart App Control raises -- so a healthy install was reported as blocked by
+// Windows application control and the operator was told to give up on OAuth.
+test("Grok CLI discovery skips the npm shim Windows cannot spawn", () => {
+  const resolved = grokCliPath({
+    environment: {},
+    platform: "win32",
+    exec: () =>
+      "C:\\Users\\ann\\AppData\\Roaming\\npm\\grok\r\n" +
+      "C:\\Users\\ann\\AppData\\Roaming\\npm\\grok.cmd\r\n",
+  });
+  assert.equal(resolved, "C:\\Users\\ann\\AppData\\Roaming\\npm\\grok.cmd");
+});
+
+test("Grok CLI preflight launches a batch shim through cmd.exe", () => {
+  let invocation;
+  const status = grokCliPreflight({
+    executable: "C:\\Users\\ann\\AppData\\Roaming\\npm\\grok.cmd",
+    environment: {},
+    platform: "win32",
+    spawnSyncImpl: (command, args, options) => {
+      invocation = { command, args, options };
+      return { status: 0, stdout: "0.2.112\n" };
+    },
+  });
+  assert.equal(status.state, "ready");
+  assert.match(invocation.command, /cmd\.exe$/i);
+  assert.deepEqual(invocation.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.ok(invocation.args[3].includes("grok.cmd"), invocation.args[3]);
+  assert.equal(invocation.options.windowsVerbatimArguments, true);
+  assert.equal(invocation.options.windowsHide, true);
+});
+
+test("Grok OAuth refresh runs the batch shim the preflight approved", async () => {
+  const launches = [];
+  await refreshWithOfficialCli({
+    executable: "C:\\npm\\grok.cmd",
+    platform: "win32",
+    preflightOptions: { spawnSyncImpl: () => ({ status: 0 }) },
+    spawnImpl: (command, args, options) => {
+      launches.push({ command, args, options });
+      return {
+        once(event, handler) {
+          if (event === "exit") handler(0);
+        },
+        kill() {},
+      };
+    },
+  });
+  assert.equal(launches.length, 1);
+  assert.match(launches[0].command, /cmd\.exe$/i);
+  assert.ok(launches[0].args[3].includes("grok.cmd"), launches[0].args[3]);
+  assert.equal(launches[0].options.windowsVerbatimArguments, true);
 });

--- a/test/live-probe-consent.test.mjs
+++ b/test/live-probe-consent.test.mjs
@@ -37,7 +37,7 @@ test("the precedence probe uses shared cross-platform Codex and venv paths", () 
     "utf8",
   );
   assert.match(source, /findCodexBinary\(\)/);
-  assert.match(source, /codexSpawnTarget\(CODEX_BIN\)/);
+  assert.match(source, /spawnableCommand\(CODEX_BIN, args\)/);
   assert.match(source, /process\.platform === "win32" \? "Scripts" : "bin"/);
   assert.match(source, /process\.platform === "win32" \? "litellm\.exe" : "litellm"/);
 });

--- a/test/spawnable-command.test.mjs
+++ b/test/spawnable-command.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -147,6 +147,20 @@ const TRICKY_ARGUMENTS = [
   "caret^value",
 ];
 
+// Deliberately awkward, and all of it legal on Windows: the runner's own temp
+// path has no spaces, so nothing here would otherwise exercise the escaping
+// that a real "C:\\Program Files (x86)" install depends on.
+const AWKWARD_DIRECTORY = "shim dir (x86) & co";
+
+function shimDirectory() {
+  const directory = path.join(
+    mkdtempSync(path.join(os.tmpdir(), "codex-router-shim-")),
+    AWKWARD_DIRECTORY,
+  );
+  mkdirSync(directory, { recursive: true });
+  return directory;
+}
+
 function argumentDumper(directory) {
   const dumper = path.join(directory, "dump-argv.mjs");
   writeFileSync(dumper, "console.log(JSON.stringify(process.argv.slice(2)));\n");
@@ -166,7 +180,7 @@ function runThroughShim(shimPath) {
 }
 
 test("a plain batch shim receives every argument intact", windowsOnly, () => {
-  const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-shim-"));
+  const directory = shimDirectory();
   try {
     const dumper = argumentDumper(directory);
     const shim = path.join(directory, "probe.cmd");
@@ -182,7 +196,7 @@ test("an npm global shim receives every argument intact", windowsOnly, () => {
   // the case this router hits most, and the one that decides whether the
   // double-escape branch applies here. It does not: this template reaches the
   // program without re-entering cmd.exe.
-  const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-npm-shim-"));
+  const directory = shimDirectory();
   try {
     const dumper = argumentDumper(directory);
     const shim = path.join(directory, "probe.cmd");
@@ -236,4 +250,20 @@ test("only an npm cmd-shim under node_modules/.bin takes the second escape layer
   assert.equal(needsDoubleEscape("C:\\p\\node_modules\\.bin\\codex.CMD"), true);
   assert.equal(needsDoubleEscape("C:\\Users\\ann\\AppData\\Roaming\\npm\\codex.cmd"), false);
   assert.equal(needsDoubleEscape("C:\\tools\\codex.cmd"), false);
+});
+
+test("an ordinary token is passed through bare, so a shim's %1 still matches", () => {
+  // Windows CI caught this: quoting every argument turned `debug` into
+  // `"debug"`, and a batch shim comparing %1 textually stopped matching. A
+  // real program never notices -- argv parsing strips the quotes -- but shims
+  // that read their own arguments do.
+  const line = spawnableCommand("C:\\npm\\codex.cmd", ["debug", "models"], "win32").args[3];
+  assert.ok(line.endsWith('codex.cmd debug models"'), line);
+
+  for (const bare of ["--version", "login", "app-server", "gpt-5.6-sol", "@xai-official/grok"]) {
+    assert.equal(escapeWindowsShellArgument(bare), bare);
+  }
+  for (const quoted of ["a b", 'say "hi"', "a&b", "100%", "a^b", "a(b)", "a,b", ""]) {
+    assert.notEqual(escapeWindowsShellArgument(quoted), quoted);
+  }
 });

--- a/test/spawnable-command.test.mjs
+++ b/test/spawnable-command.test.mjs
@@ -1,10 +1,15 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
   commandOnPath,
   escapeWindowsShellArgument,
   isWindowsBatchShim,
+  needsDoubleEscape,
   preferSpawnablePath,
   spawnableCommand,
 } from "../src/spawnable-command.mjs";
@@ -88,7 +93,7 @@ test("an argument containing spaces survives as one argument", () => {
   assert.equal(target.options.windowsVerbatimArguments, true);
   // Each argument is quoted as a unit, and the spaces inside it are escaped
   // rather than left as separators.
-  assert.ok(line.includes("list^^^ the^^^ files"), line);
+  assert.ok(line.includes("list^ the^ files"), line);
   assert.equal(line.split(" ").length > 1, true);
 });
 
@@ -123,4 +128,112 @@ test("the caller's argument array is never mutated", () => {
   const args = ["login", "status"];
   spawnableCommand("C:\\npm\\codex.cmd", args, "win32");
   assert.deepEqual(args, ["login", "status"]);
+});
+
+// Everything above asserts the shape of a command line without running it, and
+// that is precisely how a wrong second layer of `^` escaping reached CI: the
+// rendered string looked plausible and Windows answered "The syntax of the
+// command is incorrect". These run a real shim and read back what the child
+// actually received, which is the only assertion that can settle the question.
+const windowsOnly = { skip: process.platform !== "win32" ? "Windows only" : false };
+
+const TRICKY_ARGUMENTS = [
+  "debug",
+  "list the files, then say how many",
+  'model_reasoning_effort="high"',
+  "C:\\Program Files (x86)\\thing",
+  "a&b",
+  "100%",
+  "caret^value",
+];
+
+function argumentDumper(directory) {
+  const dumper = path.join(directory, "dump-argv.mjs");
+  writeFileSync(dumper, "console.log(JSON.stringify(process.argv.slice(2)));\n");
+  return dumper;
+}
+
+function runThroughShim(shimPath) {
+  const target = spawnableCommand(shimPath, TRICKY_ARGUMENTS);
+  const result = spawnSync(target.command, target.args, {
+    ...target.options,
+    encoding: "utf8",
+    windowsHide: true,
+  });
+  assert.equal(result.error, undefined, String(result.error));
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  return JSON.parse(result.stdout.trim().split(/\r?\n/).pop());
+}
+
+test("a plain batch shim receives every argument intact", windowsOnly, () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-shim-"));
+  try {
+    const dumper = argumentDumper(directory);
+    const shim = path.join(directory, "probe.cmd");
+    writeFileSync(shim, `@echo off\r\nnode "${dumper}" %*\r\n`);
+    assert.deepEqual(runThroughShim(shim), TRICKY_ARGUMENTS);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("an npm global shim receives every argument intact", windowsOnly, () => {
+  // The shape npm actually writes into %APPDATA%\npm for a global install --
+  // the case this router hits most, and the one that decides whether the
+  // double-escape branch applies here. It does not: this template reaches the
+  // program without re-entering cmd.exe.
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-npm-shim-"));
+  try {
+    const dumper = argumentDumper(directory);
+    const shim = path.join(directory, "probe.cmd");
+    writeFileSync(
+      shim,
+      [
+        "@ECHO off",
+        "GOTO start",
+        ":find_dp0",
+        "SET dp0=%~dp0",
+        "EXIT /b",
+        ":start",
+        "SETLOCAL",
+        "CALL :find_dp0",
+        'IF EXIST "%dp0%\\node.exe" (',
+        '  SET "_prog=%dp0%\\node.exe"',
+        ") ELSE (",
+        '  SET "_prog=node"',
+        "  SET PATHEXT=%PATHEXT:;.JS;=;%",
+        ")",
+        `endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" "${dumper}" %*`,
+        "",
+      ].join("\r\n"),
+    );
+    assert.deepEqual(runThroughShim(shim), TRICKY_ARGUMENTS);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("a path no file name could hold is refused rather than escaped", () => {
+  assert.throws(
+    () => spawnableCommand('C:\\npm\\co"dex.cmd', ["login"], "win32"),
+    /Refusing to run a Windows path/,
+  );
+  assert.throws(
+    () => spawnableCommand("C:\\npm\\codex\r\nshutdown.exe.cmd", [], "win32"),
+    /Refusing to run a Windows path/,
+  );
+  // A path that never reaches a shell needs no such guard: without cmd.exe in
+  // the middle there is no command line for a stray character to break out of.
+  assert.doesNotThrow(() =>
+    spawnableCommand('C:\\npm\\co"dex.exe', ["login"], "win32"),
+  );
+  // Characters that are legal in a Windows path stay escaped, not rejected.
+  assert.ok(spawnableCommand("C:\\Program Files (x86)\\a&b\\codex.cmd", [], "win32").args[3]);
+});
+
+test("only an npm cmd-shim under node_modules/.bin takes the second escape layer", () => {
+  assert.equal(needsDoubleEscape("C:\\p\\node_modules\\.bin\\codex.cmd"), true);
+  assert.equal(needsDoubleEscape("C:\\p\\node_modules\\.bin\\codex.CMD"), true);
+  assert.equal(needsDoubleEscape("C:\\Users\\ann\\AppData\\Roaming\\npm\\codex.cmd"), false);
+  assert.equal(needsDoubleEscape("C:\\tools\\codex.cmd"), false);
 });

--- a/test/spawnable-command.test.mjs
+++ b/test/spawnable-command.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  commandOnPath,
+  escapeWindowsShellArgument,
+  isWindowsBatchShim,
+  preferSpawnablePath,
+  spawnableCommand,
+} from "../src/spawnable-command.mjs";
+
+// `where.exe <name>` on an npm global install lists the extensionless POSIX
+// shim first. Node cannot spawn it, and every caller that took the first line
+// then blamed the resulting spawn error on something else entirely.
+const NPM_WHERE_OUTPUT = [
+  "C:\\Users\\ann\\AppData\\Roaming\\npm\\grok",
+  "C:\\Users\\ann\\AppData\\Roaming\\npm\\grok.cmd",
+  "",
+];
+
+function fakeFinder(lines) {
+  return (command, args) => {
+    assert.deepEqual(args.length, 1);
+    return `${lines.join("\r\n")}\r\n`;
+  };
+}
+
+test("a PATH lookup skips the shim Windows cannot spawn", () => {
+  assert.equal(
+    commandOnPath("grok", { platform: "win32", exec: fakeFinder(NPM_WHERE_OUTPUT) }),
+    "C:\\Users\\ann\\AppData\\Roaming\\npm\\grok.cmd",
+  );
+});
+
+test("a PATH lookup keeps the first hit on POSIX", () => {
+  assert.equal(
+    commandOnPath("grok", {
+      platform: "darwin",
+      exec: fakeFinder(["/opt/homebrew/bin/grok", "/usr/local/bin/grok"]),
+    }),
+    "/opt/homebrew/bin/grok",
+  );
+});
+
+test("a PATH lookup reports nothing when the finder fails", () => {
+  assert.equal(
+    commandOnPath("grok", {
+      platform: "win32",
+      exec: () => {
+        throw Object.assign(new Error("not found"), { status: 1 });
+      },
+    }),
+    undefined,
+  );
+  assert.equal(
+    commandOnPath("grok", { platform: "win32", exec: fakeFinder(["", "   "]) }),
+    undefined,
+  );
+});
+
+test("only a Windows batch shim is treated as one", () => {
+  assert.equal(isWindowsBatchShim("C:\\npm\\grok.cmd", "win32"), true);
+  assert.equal(isWindowsBatchShim("C:\\npm\\grok.BAT", "win32"), true);
+  assert.equal(isWindowsBatchShim("C:\\npm\\grok.exe", "win32"), false);
+  assert.equal(isWindowsBatchShim("/usr/bin/grok.cmd", "darwin"), false);
+  assert.equal(isWindowsBatchShim(undefined, "win32"), false);
+});
+
+test("preferSpawnablePath ranks a real executable above a batch shim", () => {
+  assert.equal(
+    preferSpawnablePath(["C:\\shim\\codex.cmd", "C:\\real\\codex.exe"], "win32"),
+    "C:\\real\\codex.exe",
+  );
+  assert.equal(preferSpawnablePath(["C:\\odd\\codex"], "win32"), "C:\\odd\\codex");
+  assert.equal(preferSpawnablePath([], "win32"), undefined);
+});
+
+// Node's own `shell: true` joins the argument list on spaces, so a single
+// argument containing one arrives at the child as several. Every prompt this
+// router hands Codex is a whole sentence, so that split is not theoretical.
+test("an argument containing spaces survives as one argument", () => {
+  const target = spawnableCommand(
+    "C:\\npm\\codex.cmd",
+    ["exec", "list the files, then say how many"],
+    "win32",
+  );
+  const line = target.args[3];
+  assert.equal(target.options.windowsVerbatimArguments, true);
+  // Each argument is quoted as a unit, and the spaces inside it are escaped
+  // rather than left as separators.
+  assert.ok(line.includes("list^^^ the^^^ files"), line);
+  assert.equal(line.split(" ").length > 1, true);
+});
+
+test("a quoted argument value keeps its quotes as data", () => {
+  const escaped = escapeWindowsShellArgument('model_reasoning_effort="high"', true);
+  // The inner quotes are backslash-escaped so the child's parser sees them,
+  // and every cmd.exe metacharacter is neutralized twice for a batch file.
+  assert.ok(escaped.includes('\\^^^"high'), escaped);
+});
+
+test("a command path containing spaces is escaped, not split", () => {
+  const target = spawnableCommand("C:\\Program Files\\npm\\codex.cmd", [], "win32");
+  assert.match(target.command, /cmd\.exe$/i);
+  assert.deepEqual(target.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.ok(target.args[3].startsWith('"C:\\Program^ Files\\npm\\codex.cmd'), target.args[3]);
+});
+
+test("everything that is not a Windows batch shim is spawned untouched", () => {
+  assert.deepEqual(spawnableCommand("/usr/bin/codex", ["a b"], "linux"), {
+    command: "/usr/bin/codex",
+    args: ["a b"],
+    options: {},
+  });
+  assert.deepEqual(spawnableCommand("C:\\Programs\\codex.exe", ["a b"], "win32"), {
+    command: "C:\\Programs\\codex.exe",
+    args: ["a b"],
+    options: {},
+  });
+});
+
+test("the caller's argument array is never mutated", () => {
+  const args = ["login", "status"];
+  spawnableCommand("C:\\npm\\codex.cmd", args, "win32");
+  assert.deepEqual(args, ["login", "status"]);
+});

--- a/test/tray-install.test.mjs
+++ b/test/tray-install.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import { test } from "node:test";
 
-import { trayBundleDir, trayDecision } from "../src/tray-install.mjs";
+import { desktopTrayBinary, trayBundleDir, trayDecision } from "../src/tray-install.mjs";
 
 test("trayDecision skips when --no-tray is passed", () => {
   assert.equal(
@@ -10,9 +11,27 @@ test("trayDecision skips when --no-tray is passed", () => {
   );
 });
 
-test("trayDecision skips on Windows where no launcher exists yet", () => {
+// Windows used to be excluded here because it had no launcher. It has one
+// now, and the exclusion was the reason the installer silently skipped the one
+// platform whose tray never got built by anything else.
+test("trayDecision offers the tray on Windows", () => {
   assert.equal(
     trayDecision({ platform: "win32", withTray: true, noTray: false, guided: true }),
+    "install",
+  );
+  assert.equal(
+    trayDecision({ platform: "win32", withTray: false, noTray: false, guided: true }),
+    "ask",
+  );
+  assert.equal(
+    trayDecision({ platform: "win32", withTray: false, noTray: true, guided: true }),
+    "skip",
+  );
+});
+
+test("trayDecision still skips a platform with no companion at all", () => {
+  assert.equal(
+    trayDecision({ platform: "aix", withTray: true, noTray: false, guided: true }),
     "skip",
   );
 });
@@ -58,4 +77,16 @@ test("trayBundleDir uses forward slashes regardless of the host OS", () => {
 
 test("trayBundleDir is undefined on other platforms", () => {
   assert.equal(trayBundleDir("linux", "/home/example"), undefined);
+});
+
+test("desktopTrayBinary names the Tauri release binary per platform", () => {
+  assert.equal(
+    desktopTrayBinary("win32", "C:\\repo"),
+    ["C:\\repo", "apps", "desktop", "src-tauri", "target", "release", "codex-router-desktop.exe"].join(
+      path.sep,
+    ),
+  );
+  assert.ok(desktopTrayBinary("linux", "/repo").endsWith("codex-router-desktop"));
+  // macOS builds a Swift app bundle instead, served by TRAY_APP_BINARY.
+  assert.equal(desktopTrayBinary("darwin", "/repo"), undefined);
 });

--- a/test/tray-service-windows.test.mjs
+++ b/test/tray-service-windows.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// The Windows tray manager can only be exercised off-Windows through its
+// render commands, the same contract service-windows.mjs uses: everything that
+// touches Task Scheduler refuses to run on the wrong platform, and everything
+// that only renders a definition works anywhere so CI can check it.
+function trayService(command, { platform = "win32", env = {} } = {}) {
+  return spawnSync(
+    process.execPath,
+    [path.join(root, "src", "tray-service-windows.mjs"), command],
+    {
+      encoding: "utf8",
+      env: { ...process.env, CODEX_ROUTER_SERVICE_PLATFORM: platform, ...env },
+    },
+  );
+}
+
+function trayDispatch(command, platform) {
+  return spawnSync(
+    process.execPath,
+    [path.join(root, "src", "tray-service.mjs"), command],
+    {
+      encoding: "utf8",
+      env: { ...process.env, CODEX_ROUTER_SERVICE_PLATFORM: platform },
+    },
+  );
+}
+
+test("the registered action points at the Tauri release binary", () => {
+  const result = trayService("render-task");
+  assert.equal(result.status, 0, result.stderr);
+  const action = JSON.parse(result.stdout);
+  assert.ok(action.execute.endsWith("codex-router-desktop.exe"), action.execute);
+  assert.ok(action.execute.includes(path.join("src-tauri", "target", "release")), action.execute);
+  // A GUI binary takes no arguments; the router's task needs them, this one
+  // must not inherit that shape.
+  assert.equal(action.argument, "");
+});
+
+test("a render resolves the path for the platform it is rendering for", () => {
+  // Not process.platform: a render on Linux still has to show the .exe that
+  // would actually be registered on Windows.
+  assert.match(JSON.parse(trayService("render-task").stdout).execute, /\.exe$/);
+});
+
+test("Task Scheduler commands refuse to run off Windows", () => {
+  for (const command of ["install", "uninstall", "start", "stop", "restart", "status"]) {
+    const result = trayService(command, { platform: "linux" });
+    assert.notEqual(result.status, 0, `${command} should have refused`);
+    assert.match(result.stderr, /runs on Windows only/);
+  }
+});
+
+test("an unknown subcommand exits 2 with usage", () => {
+  const result = trayService("frobnicate");
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Usage: tray-service-windows\.mjs/);
+});
+
+test("install refuses before the tray has been built", () => {
+  // The checkout under test has no compiled Tauri binary, so this exercises
+  // the real guard rather than a stub. A missing binary must name the build
+  // command instead of registering a task that points at nothing.
+  const result = trayService("install");
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /not built at/);
+  assert.match(result.stderr, /build-desktop-tray\.ps1/);
+});
+
+test("the dispatcher routes Windows to the Task Scheduler manager", () => {
+  // Windows reached the no-op branch before this existed, so `control tray
+  // enable` printed {"supported":false} and exited 0 -- success, with no tray.
+  const result = trayDispatch("status", "win32");
+  assert.doesNotMatch(result.stdout, /"supported":false/);
+});
+
+test("a platform with no supervisor says so instead of reporting success", () => {
+  const result = trayDispatch("install", "linux");
+  assert.equal(result.status, 0, "an install must not fail over an unsupervised companion");
+  assert.match(result.stdout, /"supported":false/);
+  assert.match(result.stderr, /not supervised on linux/);
+  // `status` is machine-readable and stays quiet.
+  assert.equal(trayDispatch("status", "linux").stderr, "");
+});

--- a/test/windows-parity.test.mjs
+++ b/test/windows-parity.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Three Windows defects in this repository were the same mistake made in
+// different files: resolve a command the way POSIX does, spawn it the way
+// POSIX does, or run a POSIX shell script outright. Each one surfaced as a
+// spawn error that the caller then misread as something else -- "signed out",
+// "blocked by Windows application control", a check that quietly passed. None
+// of them can be caught by the Linux and macOS legs of CI, and the Windows leg
+// cannot exercise an operator's npm install either, so the invariants are
+// asserted against the source instead.
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourceDir = path.join(root, "src");
+
+const sources = readdirSync(sourceDir)
+  .filter((name) => name.endsWith(".mjs"))
+  .map((name) => ({ name, text: readFileSync(path.join(sourceDir, name), "utf8") }));
+
+test("command lookup lives in one place, so no file takes the finder's first line", () => {
+  // `where.exe <name>` lists the extensionless npm shim before the .cmd shim
+  // that Windows can actually run. Four copies of the same helper each took
+  // line one; spawnable-command.mjs is now the only module allowed to ask.
+  const offenders = sources
+    .filter(({ name }) => name !== "spawnable-command.mjs")
+    .filter(({ text }) => /"where\.exe"/.test(text))
+    .map(({ name }) => name);
+  assert.deepEqual(offenders, [], `these must use commandOnPath(): ${offenders.join(", ")}`);
+});
+
+test("no POSIX bin/ script is spawned without a Windows counterpart", () => {
+  // bin/* are `#!/bin/sh` scripts. Windows reaches the same work through
+  // install.ps1, the way doctor --fix and curate-models already do.
+  const spawnsBinScript = /(?:spawnSync|spawn|execFileSync)\(\s*path\.join\([^)]*"bin",\s*"[a-z-]+"\s*\)/;
+  const offenders = sources
+    .filter(({ text }) => spawnsBinScript.test(text))
+    .filter(({ text }) => !text.includes("install.ps1"))
+    .map(({ name }) => name);
+  assert.deepEqual(
+    offenders,
+    [],
+    `these spawn a POSIX shell script with no win32 branch: ${offenders.join(", ")}`,
+  );
+});
+
+test("every detached worker is spawned without a console window", () => {
+  // A detached child gets its own console on Windows. The vision-model worker
+  // missed the flag and left a console open for the length of a multi-gigabyte
+  // pull, while its local-model twin two hundred lines away hid correctly.
+  for (const { name, text } of sources) {
+    let index = text.indexOf("detached: true");
+    while (index !== -1) {
+      const options = text.slice(index, index + 240);
+      assert.ok(
+        options.includes("windowsHide: true"),
+        `${name}: a detached spawn near "${options.split("\n")[0].trim()}" must set windowsHide`,
+      );
+      index = text.indexOf("detached: true", index + 1);
+    }
+  }
+});


### PR DESCRIPTION
On Windows, a command you can *find* and a command you can *spawn* are two different things. `where.exe` lists the extensionless npm shim before the `.cmd` shim, and Node has refused to spawn a `.cmd` without a shell since the CVE-2024-27980 fix. Four copies of the same lookup helper took the first line regardless, and every spawn failure that followed was attributed to something other than the spawn.

`src/codex-binary.mjs` already carried the fix for Codex (#46). It never propagated to the other four copies.

## The most visible symptom

A healthy npm-installed **Grok CLI could not be launched**, which raises `spawn UNKNOWN` — the same code Smart App Control raises. `UNKNOWN` is in `WINDOWS_BLOCK_CODES`, so the preflight concluded that Windows application control had blocked the CLI and told the operator to abandon OAuth for an API key. The token refresh behind that preflight spawned the shim the same unusable way, so passing the preflight would not have helped either.

`docs/TROUBLESHOOTING.md` documents this as a Windows policy problem. It was substantially self-inflicted; that section is updated.

## Same root cause, other call sites

| Where | Effect on Windows |
|---|---|
| `agent-check.mjs` | The routed-subagent proof from `c15e3a8` graded **every** routed model as not agent-capable |
| `doctor.mjs` config probe | Hit the error path and returned "no complaint" — a check that silently always passed |
| `grok-oauth-session.mjs` | Token refresh failed, expiring a session the preflight had just called healthy |
| `setup-shared.mjs` / `provider-onboarding.mjs` | `npm install -g` and CLI sign-in resolved `npm`/`kimi` to the shim and failed |

## Three standalone bugs

- **`codex-account-usage.mjs`** kept a private search for Codex — an undocumented `CODEX_BINARY`, a macOS-only path, then the bare name `"codex"`. None of the three exists on Windows, so the usage panel reported *"the Codex app-server could not be started"* on every Windows machine. It also killed only the shell on timeout, leaking a Codex process per poll.
- **`control.mjs` `apply`** ran the POSIX `bin/enable` shell script. `doctor --fix` and `curate-models` already branch to `install.ps1`; this now does too.
- **The vision-download worker** was the one detached child without `windowsHide`, opening a console window for the length of a multi-gigabyte pull.

Separately, `vision-host.mjs` probed for Ollama through the runtime's known install locations but then spawned the bare name — so a Windows install under `%LOCALAPPDATA%` reported as available and failed at the very next call.

## Approach

Resolution and launching now live together in `src/spawnable-command.mjs`, because a caller that gets the path right also needs to get the launch right. Arguments are escaped for `cmd.exe` (cross-spawn's algorithm) rather than joined on spaces — Node's `shell: true` would have split the agent-check prompt into eighteen arguments, and a path under `C:\Program Files` into two.

## Testing

Suite is green: **1038 pass, 0 fail** (1019 before; +19 new tests).

`test/windows-parity.test.mjs` guards all three classes from the source — no file but `spawnable-command.mjs` may call `where.exe`, no `bin/` script is spawned without a win32 branch, every detached spawn sets `windowsHide`. I verified each guard fails against the original code.

**What is still unverified:** I could not execute `cmd.exe`, so the escaping is checked by unit-testing the rendered command line against the reference implementation's output, not by running it. The Windows CI leg won't exercise a `.cmd` shim either. The outstanding check is a real npm-installed Codex or Grok CLI on Windows:

```powershell
npm install -g @xai-official/grok
./codex-router.ps1 doctor          # Grok CLI should read ready, not blocked
./model-router.ps1 codex control account-usage   # should return usage, not an app-server error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ay8brnrizV8xfbB322f1w8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ay8brnrizV8xfbB322f1w8)_