### PR TITLE
fix: normalize tool schemas for strict upstreams and stop reporting 401s as rate limits

### DIFF
--- a/src/error-translation.mjs
+++ b/src/error-translation.mjs
@@ -181,6 +181,22 @@ function describeFailure({
   };
 }
 
+// LiteLLM answers with its own 429 when it has taken the only deployment for a
+// model out of rotation, and its body carries the status that caused it. A
+// cooled-down 401 is a rejected credential, not a rate limit, and "wait a bit
+// and retry" loops the user forever. Read the raw body: the cooldown list sits
+// past extractUpstreamDetail's truncation limit.
+const COOLDOWN_MARKER = /No deployments available/i;
+const COOLDOWN_STATUS = /['"]?status_code['"]?\s*[:=]\s*['"]?(\d{3})/i;
+
+function cooledDownStatus(status, bodyText) {
+  if (status !== 429 || typeof bodyText !== "string" || !COOLDOWN_MARKER.test(bodyText)) {
+    return undefined;
+  }
+  const original = Number(COOLDOWN_STATUS.exec(bodyText)?.[1]);
+  return Number.isFinite(original) && original !== 429 ? original : undefined;
+}
+
 export function translateGatewayError({
   status,
   bodyText,
@@ -190,8 +206,11 @@ export function translateGatewayError({
   retryAfterSeconds,
 }) {
   const detail = extractUpstreamDetail(bodyText);
+  // Keep the HTTP status on the wire as-is; only the human-facing
+  // classification changes, so the transport stays truthful.
+  const effectiveStatus = cooledDownStatus(status, bodyText) ?? status;
   const failure = describeFailure({
-    status,
+    status: effectiveStatus,
     detail,
     errorType: parseUpstreamError(bodyText).type,
     modelName,

--- a/src/error-translation.mjs
+++ b/src/error-translation.mjs
@@ -181,22 +181,6 @@ function describeFailure({
   };
 }
 
-// LiteLLM answers with its own 429 when it has taken the only deployment for a
-// model out of rotation, and its body carries the status that caused it. A
-// cooled-down 401 is a rejected credential, not a rate limit, and "wait a bit
-// and retry" loops the user forever. Read the raw body: the cooldown list sits
-// past extractUpstreamDetail's truncation limit.
-const COOLDOWN_MARKER = /No deployments available/i;
-const COOLDOWN_STATUS = /['"]?status_code['"]?\s*[:=]\s*['"]?(\d{3})/i;
-
-function cooledDownStatus(status, bodyText) {
-  if (status !== 429 || typeof bodyText !== "string" || !COOLDOWN_MARKER.test(bodyText)) {
-    return undefined;
-  }
-  const original = Number(COOLDOWN_STATUS.exec(bodyText)?.[1]);
-  return Number.isFinite(original) && original !== 429 ? original : undefined;
-}
-
 export function translateGatewayError({
   status,
   bodyText,
@@ -206,11 +190,8 @@ export function translateGatewayError({
   retryAfterSeconds,
 }) {
   const detail = extractUpstreamDetail(bodyText);
-  // Keep the HTTP status on the wire as-is; only the human-facing
-  // classification changes, so the transport stays truthful.
-  const effectiveStatus = cooledDownStatus(status, bodyText) ?? status;
   const failure = describeFailure({
-    status: effectiveStatus,
+    status,
     detail,
     errorType: parseUpstreamError(bodyText).type,
     modelName,

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -17,7 +17,7 @@ import { PORTS } from "./paths.mjs";
 import { MODELS } from "./model-registry.mjs";
 import { ensureFreshGrokOAuthToken } from "./grok-oauth-session.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
-import { providerToolSchema } from "./tool-schema-root.mjs";
+import { normalizeSchemaLiterals, objectRootToolSchema } from "./tool-schema-root.mjs";
 import { VERSION } from "./version.mjs";
 
 // LiteLLM speaks OpenAI Chat Completions to this forwarder. It reuses the
@@ -188,9 +188,15 @@ export function toResponsesRequest(chat, options = {}) {
           name: tool.function.name,
           description: tool.function.description,
           // xAI 400s the whole request over a union-rooted parameter schema,
-          // which Codex's own `automation_update` app tool ships.
-          parameters: providerToolSchema(
-            tool.function.parameters || { type: "object", properties: {} },
+          // which Codex's own `automation_update` app tool ships. It rejects
+          // every non-object root, so this keeps objectRootToolSchema's full
+          // collapse rather than the narrower providerToolSchema the shared
+          // relay uses -- and additionally drops literals that contradict their
+          // declared type, which the relay now does for every provider.
+          parameters: objectRootToolSchema(
+            normalizeSchemaLiterals(
+              tool.function.parameters || { type: "object", properties: {} },
+            ),
           ),
           strict: false,
         }))

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -17,7 +17,7 @@ import { PORTS } from "./paths.mjs";
 import { MODELS } from "./model-registry.mjs";
 import { ensureFreshGrokOAuthToken } from "./grok-oauth-session.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
-import { objectRootToolSchema } from "./tool-schema-root.mjs";
+import { providerToolSchema } from "./tool-schema-root.mjs";
 import { VERSION } from "./version.mjs";
 
 // LiteLLM speaks OpenAI Chat Completions to this forwarder. It reuses the
@@ -189,7 +189,7 @@ export function toResponsesRequest(chat, options = {}) {
           description: tool.function.description,
           // xAI 400s the whole request over a union-rooted parameter schema,
           // which Codex's own `automation_update` app tool ships.
-          parameters: objectRootToolSchema(
+          parameters: providerToolSchema(
             tool.function.parameters || { type: "object", properties: {} },
           ),
           strict: false,

--- a/src/litellm-config.mjs
+++ b/src/litellm-config.mjs
@@ -63,6 +63,15 @@ export function renderLiteLlmConfig() {
     "  drop_params: true",
     "  request_timeout: 600",
     "",
+    // Every model_name above has exactly one deployment, so a cooldown can
+    // never route around a failure -- it can only hide it. LiteLLM cools a
+    // deployment down on a 401 and then answers with its own 429 "No
+    // deployments available", which the router translates into "provider is
+    // rate-limiting, wait a bit and retry": the one piece of advice that cannot
+    // fix a rejected credential. Relay the provider's real status instead.
+    "router_settings:",
+    "  disable_cooldowns: true",
+    "",
     "general_settings:",
     "  disable_spend_logs: true",
     "",

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -3,6 +3,7 @@ import { StringDecoder } from "node:string_decoder";
 
 import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 import { coerceFunctionCallArguments } from "./tool-arguments.mjs";
+import { providerToolSchema } from "./tool-schema-root.mjs";
 
 // The Codex client ships most of its toolset as `type: "namespace"` entries:
 // the collaboration runtime, the app toolset (threads, automations,
@@ -120,7 +121,17 @@ export function flattenNamespaceTools(tools) {
         // arguments their server requires. Keep inputSchema too: it is the
         // client's native representation and responses-native routes retain
         // it untouched.
-        const parameters = fn.parameters ?? fn.inputSchema;
+        //
+        // Strict upstreams (Moonshot/Kimi, the xAI CLI proxy) reject the whole
+        // request -- not the one tool -- over a union-rooted parameter schema or
+        // an enum literal that contradicts its declared type. Codex's own
+        // `codex_app__automation_update` ships a `oneOf` root, so a session that
+        // never touches automations still dies on its first message. Normalize
+        // only the provider-facing copy; `inputSchema` stays exactly as the
+        // client sent it.
+        const clientSchema = fn.parameters ?? fn.inputSchema;
+        const parameters =
+          clientSchema === undefined ? undefined : providerToolSchema(clientSchema);
         flattened.push({
           ...fn,
           name: `${tool.name}${NAMESPACE_DELIMITER}${fn.name}`,

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -114,3 +114,117 @@ export function objectRootToolSchema(schema) {
     additionalProperties: true,
   };
 }
+
+// Moonshot validates every enum/const literal against the type its own node
+// declares, and rejects the whole request -- not the one tool -- on a mismatch:
+//
+//   tools.function.parameters is not a valid moonshot flavored json schema,
+//   details: <At path 'properties.appTaskLane.properties.enabled.enum':
+//            enum value (true) does not match any type in [string]>
+//
+// The contradiction is the client's: mergeCodexAppTools lets client-provided
+// definitions win, so it cannot be repaired in the bundled snapshot. Drop the
+// offending literal rather than coercing it. A literal that contradicts its own
+// declared type could never validate, so dropping it cannot change a well-formed
+// schema; coercing `true` to `"true"` would instead tell the model to send a
+// value the app never asked for.
+
+const MAX_LITERAL_DEPTH = 32;
+const SCHEMA_MAP_KEYWORDS = ["properties", "patternProperties", "$defs", "definitions"];
+const SCHEMA_LIST_KEYWORDS = ["anyOf", "oneOf", "allOf", "prefixItems"];
+const SCHEMA_CHILD_KEYWORDS = [
+  "items",
+  "additionalProperties",
+  "contains",
+  "not",
+  "if",
+  "then",
+  "else",
+  "propertyNames",
+];
+
+function jsonTypeOf(value) {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (typeof value === "boolean") return "boolean";
+  if (typeof value === "string") return "string";
+  if (typeof value === "number") return Number.isInteger(value) ? "integer" : "number";
+  if (typeof value === "object") return "object";
+  return undefined;
+}
+
+function declaredTypes(schema) {
+  if (typeof schema.type === "string") return [schema.type];
+  if (Array.isArray(schema.type)) return schema.type.filter((entry) => typeof entry === "string");
+  return [];
+}
+
+function matchesDeclaredType(value, types) {
+  const actual = jsonTypeOf(value);
+  if (actual === undefined) return false;
+  if (types.includes(actual)) return true;
+  // JSON Schema counts every integer as a number.
+  return actual === "integer" && types.includes("number");
+}
+
+// Returns `schema` by identity when nothing contradicts, so a clean toolset
+// costs one walk and no copy, and the client's object is never mutated.
+export function normalizeSchemaLiterals(schema, depth = 0) {
+  if (!isPlainObject(schema) || depth > MAX_LITERAL_DEPTH) return schema;
+  let next = schema;
+  const replace = (key, value) => {
+    if (next === schema) next = { ...schema };
+    if (value === undefined) delete next[key];
+    else next[key] = value;
+  };
+
+  const types = declaredTypes(schema);
+  if (types.length) {
+    if (Array.isArray(schema.enum)) {
+      const kept = schema.enum.filter((value) => matchesDeclaredType(value, types));
+      if (kept.length !== schema.enum.length) replace("enum", kept.length ? kept : undefined);
+    }
+    if ("const" in schema && !matchesDeclaredType(schema.const, types)) {
+      replace("const", undefined);
+    }
+  }
+
+  for (const keyword of SCHEMA_MAP_KEYWORDS) {
+    const node = schema[keyword];
+    if (!isPlainObject(node)) continue;
+    let changed = false;
+    const rewritten = {};
+    for (const [name, child] of Object.entries(node)) {
+      const sanitized = normalizeSchemaLiterals(child, depth + 1);
+      if (sanitized !== child) changed = true;
+      rewritten[name] = sanitized;
+    }
+    if (changed) replace(keyword, rewritten);
+  }
+
+  for (const keyword of [...SCHEMA_LIST_KEYWORDS, ...SCHEMA_CHILD_KEYWORDS]) {
+    const node = schema[keyword];
+    if (Array.isArray(node)) {
+      let changed = false;
+      const rewritten = node.map((child) => {
+        const sanitized = normalizeSchemaLiterals(child, depth + 1);
+        if (sanitized !== child) changed = true;
+        return sanitized;
+      });
+      if (changed) replace(keyword, rewritten);
+      continue;
+    }
+    if (!isPlainObject(node)) continue;
+    const sanitized = normalizeSchemaLiterals(node, depth + 1);
+    if (sanitized !== node) replace(keyword, sanitized);
+  }
+
+  return next;
+}
+
+// The one provider-facing normalization: literals aligned with the type their
+// own node declares, then the root forced to a plain object. Returns `schema`
+// unchanged when neither applies.
+export function providerToolSchema(schema) {
+  return objectRootToolSchema(normalizeSchemaLiterals(schema));
+}

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -223,8 +223,19 @@ export function normalizeSchemaLiterals(schema, depth = 0) {
 }
 
 // The one provider-facing normalization: literals aligned with the type their
-// own node declares, then the root forced to a plain object. Returns `schema`
-// unchanged when neither applies.
+// own node declares, and a union root merged into a plain object. Returns
+// `schema` unchanged when neither applies.
+//
+// Deliberately narrower than objectRootToolSchema alone. That function collapses
+// *any* root it cannot recognize -- an array root, a bare `type: "string"`, an
+// empty object -- into `{type:"object", properties:{}}`, discarding the real
+// schema. That is the right trade for xAI, which rejects every non-object root
+// outright. It is the wrong trade here: this runs on every namespace and MCP
+// tool, where a server-defined schema that merely looks unusual would be
+// silently replaced with one accepting anything. Only a union root is the
+// documented strict-upstream rejection, so only a union root is rewritten.
 export function providerToolSchema(schema) {
-  return objectRootToolSchema(normalizeSchemaLiterals(schema));
+  const normalized = normalizeSchemaLiterals(schema);
+  if (!isPlainObject(normalized) || !hasRootUnion(normalized)) return normalized;
+  return objectRootToolSchema(normalized);
 }

--- a/test/error-translation.test.mjs
+++ b/test/error-translation.test.mjs
@@ -414,29 +414,31 @@ test("a genuine 403 credential rejection still says so", () => {
   assert.match(translated.error.message, /rejected the stored credentials/);
 });
 
-// Regression for #179: LiteLLM cools a deployment down on a 401 and then
-// answers with its own 429 "No deployments available". Telling the user to wait
-// out a rejected credential loops them forever.
-const COOLED_DOWN_401 = `{"error":{"message":"No deployments available for selected model, Try again in 51 seconds. ${"x".repeat(400)} cooldown_list=[('abc', {'exception_received': 'AuthenticationError', 'status_code': '401'})]"}}`;
-
-test("a cooled-down 401 is reported as an auth failure, not a rate limit", () => {
+// Regression for #179. LiteLLM used to cool a deployment down on a 401 and
+// then answer with its own 429, so the user was told to wait out a rejected
+// credential. router_settings.disable_cooldowns (see litellm-config) stops that
+// at the source; this locks in that a real upstream 401 still classifies
+// correctly once it reaches the translator, and that a real 429 still does too.
+//
+// Deliberately no test for parsing a status out of LiteLLM's cooldown body:
+// _get_cooldown_deployments returns bare deployment ids (cooldown_handlers.py),
+// so the client-facing message carries no originating status to read.
+test("an upstream 401 is an auth failure, not a rate limit", () => {
   const translated = translateGatewayError({
-    status: 429,
-    bodyText: COOLED_DOWN_401,
+    status: 401,
+    bodyText: JSON.stringify({ error: { message: "invalid api key" } }),
     modelName: "kimi-k3",
     providerName: "Kimi",
     providerKind: "api",
   });
   assert.equal(translated.error.type, "authentication_error");
   assert.match(translated.error.message, /Re-run codex-router setup/);
-  // The status on the wire stays truthful; only the classification changes.
-  assert.equal(translated.error.code, "429");
 });
 
-test("a cooled-down 401 on an OAuth provider advises signing in again", () => {
+test("an upstream 401 on an OAuth provider advises signing in again", () => {
   const translated = translateGatewayError({
-    status: 429,
-    bodyText: COOLED_DOWN_401,
+    status: 401,
+    bodyText: JSON.stringify({ error: { message: "invalid session" } }),
     modelName: "kimi-k3",
     providerName: "Kimi",
     providerKind: "oauth",
@@ -453,17 +455,6 @@ test("a genuine rate limit is still a rate limit", () => {
     providerName: "Kimi",
     providerKind: "api",
     retryAfterSeconds: 30,
-  });
-  assert.equal(translated.error.type, "rate_limit_error");
-});
-
-test("a cooldown caused by a 429 is not reclassified", () => {
-  const translated = translateGatewayError({
-    status: 429,
-    bodyText: COOLED_DOWN_401.replace("'401'", "'429'"),
-    modelName: "kimi-k3",
-    providerName: "Kimi",
-    providerKind: "api",
   });
   assert.equal(translated.error.type, "rate_limit_error");
 });

--- a/test/error-translation.test.mjs
+++ b/test/error-translation.test.mjs
@@ -413,3 +413,57 @@ test("a genuine 403 credential rejection still says so", () => {
   assert.equal(translated.error.type, "authentication_error");
   assert.match(translated.error.message, /rejected the stored credentials/);
 });
+
+// Regression for #179: LiteLLM cools a deployment down on a 401 and then
+// answers with its own 429 "No deployments available". Telling the user to wait
+// out a rejected credential loops them forever.
+const COOLED_DOWN_401 = `{"error":{"message":"No deployments available for selected model, Try again in 51 seconds. ${"x".repeat(400)} cooldown_list=[('abc', {'exception_received': 'AuthenticationError', 'status_code': '401'})]"}}`;
+
+test("a cooled-down 401 is reported as an auth failure, not a rate limit", () => {
+  const translated = translateGatewayError({
+    status: 429,
+    bodyText: COOLED_DOWN_401,
+    modelName: "kimi-k3",
+    providerName: "Kimi",
+    providerKind: "api",
+  });
+  assert.equal(translated.error.type, "authentication_error");
+  assert.match(translated.error.message, /Re-run codex-router setup/);
+  // The status on the wire stays truthful; only the classification changes.
+  assert.equal(translated.error.code, "429");
+});
+
+test("a cooled-down 401 on an OAuth provider advises signing in again", () => {
+  const translated = translateGatewayError({
+    status: 429,
+    bodyText: COOLED_DOWN_401,
+    modelName: "kimi-k3",
+    providerName: "Kimi",
+    providerKind: "oauth",
+  });
+  assert.equal(translated.error.type, "authentication_error");
+  assert.match(translated.error.message, /Sign in to Kimi again/);
+});
+
+test("a genuine rate limit is still a rate limit", () => {
+  const translated = translateGatewayError({
+    status: 429,
+    bodyText: JSON.stringify({ error: { message: "rate limit exceeded" } }),
+    modelName: "kimi-k3",
+    providerName: "Kimi",
+    providerKind: "api",
+    retryAfterSeconds: 30,
+  });
+  assert.equal(translated.error.type, "rate_limit_error");
+});
+
+test("a cooldown caused by a 429 is not reclassified", () => {
+  const translated = translateGatewayError({
+    status: 429,
+    bodyText: COOLED_DOWN_401.replace("'401'", "'429'"),
+    modelName: "kimi-k3",
+    providerName: "Kimi",
+    providerKind: "api",
+  });
+  assert.equal(translated.error.type, "rate_limit_error");
+});

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -617,3 +617,48 @@ test("response transform rewrites native shell_command integer floats in SSE", a
   assert.match(output, /timeout_ms\\":15000/);
   assert.doesNotMatch(output, /20000\.0|15000\.0/);
 });
+
+// Regression for #175: strict upstreams (the xAI CLI proxy, Moonshot/Kimi)
+// reject the whole request over a union-rooted parameter schema. Codex's own
+// `automation_update` ships a `oneOf` root, so every routed provider saw it.
+test("every flattened app tool reaches the provider with an object root", async () => {
+  const { mergeCodexAppTools } = await import("../src/codex-app-tools.mjs");
+  const { hasObjectRoot } = await import("../src/tool-schema-root.mjs");
+
+  const merged = mergeCodexAppTools([{ type: "namespace", name: "codex_app", tools: [] }]);
+  const { tools } = flattenNamespaceTools(merged.tools);
+
+  const unionRooted = tools
+    .filter((tool) => tool.parameters && !hasObjectRoot(tool.parameters))
+    .map((tool) => tool.name);
+  assert.deepEqual(unionRooted, [], "a union root fails the whole request, not the one tool");
+
+  const automationUpdate = tools.find((tool) => tool.name === "codex_app__automation_update");
+  assert.ok(automationUpdate, "automation_update is still relayed");
+  assert.equal(automationUpdate.parameters.type, "object");
+  assert.ok(
+    Array.isArray(automationUpdate.inputSchema.oneOf),
+    "inputSchema keeps the client's native union for responses-native routes",
+  );
+});
+
+test("flattened parameters drop literals that contradict their declared type", () => {
+  const { tools } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "codex_app",
+      tools: [
+        {
+          name: "automation_update",
+          inputSchema: {
+            type: "object",
+            properties: { enabled: { type: "string", enum: [true] } },
+          },
+        },
+      ],
+    },
+  ]);
+
+  const flattened = tools.find((tool) => tool.name === "codex_app__automation_update");
+  assert.equal("enum" in flattened.parameters.properties.enabled, false);
+});

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -426,6 +426,15 @@ test("Ollama Cloud models advertise only levels the forwarder maps to Ollama", (
   }
 });
 
+// Every model_name has exactly one deployment, so a cooldown can only hide a
+// failure -- it turns a 401 into LiteLLM's own 429. See #179.
+test("the gateway config disables deployment cooldowns", () => {
+  const rendered = renderLiteLlmConfig();
+  assert.match(rendered, /router_settings:\n\s+disable_cooldowns: true/);
+  const names = [...rendered.matchAll(/^  - model_name: (.+)$/gm)].map((m) => m[1]);
+  assert.equal(new Set(names).size, names.length, "one deployment per model_name");
+});
+
 test("LiteLLM configuration is generated from every registry route", () => {
   const rendered = renderLiteLlmConfig();
   for (const model of MODELS) {

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -200,3 +200,37 @@ test("providerToolSchema fixes a union root and its literals together", () => {
   assert.equal(normalized.type, "object");
   assert.deepEqual(normalized.properties.mode.enum, ["view"]);
 });
+
+// providerToolSchema runs on every namespace and MCP tool, where schemas are
+// server-defined. objectRootToolSchema collapses any root it cannot recognize
+// into an empty object -- correct for xAI, which rejects every non-object root,
+// but it would silently replace a real MCP schema with one accepting anything.
+test("a non-object root that is not a union is left alone", () => {
+  for (const schema of [
+    { type: "array", items: { type: "string" } },
+    { type: "string" },
+    {},
+  ]) {
+    assert.equal(providerToolSchema(schema), schema, JSON.stringify(schema));
+  }
+});
+
+test("a union root is still merged into an object", () => {
+  const merged = providerToolSchema({
+    oneOf: [
+      { type: "object", properties: { mode: { type: "string" } } },
+      { type: "object", properties: { id: { type: "string" } } },
+    ],
+  });
+  assert.equal(merged.type, "object");
+  assert.deepEqual(Object.keys(merged.properties).sort(), ["id", "mode"]);
+});
+
+test("literals are still normalized inside a schema that keeps its root", () => {
+  const normalized = providerToolSchema({
+    type: "array",
+    items: { type: "string", enum: [true, "ok"] },
+  });
+  assert.equal(normalized.type, "array");
+  assert.deepEqual(normalized.items.enum, ["ok"]);
+});

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -3,7 +3,12 @@ import test from "node:test";
 
 import { CODEX_APP_TOOLS } from "../src/codex-app-tools.mjs";
 import { toResponsesRequest } from "../src/grok-oauth-forwarder.mjs";
-import { hasObjectRoot, objectRootToolSchema } from "../src/tool-schema-root.mjs";
+import {
+  hasObjectRoot,
+  normalizeSchemaLiterals,
+  objectRootToolSchema,
+  providerToolSchema,
+} from "../src/tool-schema-root.mjs";
 
 test("object-rooted schemas are returned untouched", () => {
   const schema = { type: "object", properties: { path: { type: "string" } }, required: ["path"] };
@@ -125,4 +130,73 @@ test("automation_update keeps its branch fields after flattening", () => {
     Object.keys(flattened.properties).includes("mode"),
     "the discriminating field survives the merge",
   );
+});
+
+// Regression for #179: Moonshot rejects the whole request when an enum literal
+// contradicts the type its own node declares. The reported path was
+// `properties.appTaskLane.properties.enabled.enum`, from a client-supplied
+// schema, so it cannot be repaired in the bundled snapshot.
+test("literals that contradict their declared type are dropped", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      appTaskLane: {
+        type: "object",
+        properties: {
+          enabled: { type: "string", enum: [true] },
+          mode: { type: "string", enum: ["auto", "manual"] },
+        },
+      },
+    },
+  };
+
+  const normalized = normalizeSchemaLiterals(schema);
+  assert.deepEqual(normalized.properties.appTaskLane.properties.enabled, { type: "string" });
+  assert.deepEqual(normalized.properties.appTaskLane.properties.mode.enum, ["auto", "manual"]);
+  assert.deepEqual(
+    schema.properties.appTaskLane.properties.enabled.enum,
+    [true],
+    "the client's schema object is never mutated",
+  );
+});
+
+test("a clean schema is returned by identity, with no copy", () => {
+  const schema = { type: "object", properties: { mode: { type: "string", enum: ["a"] } } };
+  assert.equal(normalizeSchemaLiterals(schema), schema);
+  assert.equal(providerToolSchema(schema), schema);
+});
+
+test("integers satisfy a declared number type", () => {
+  assert.deepEqual(normalizeSchemaLiterals({ type: "number", enum: [1, 2.5] }).enum, [1, 2.5]);
+});
+
+test("a const contradicting its declared type is dropped", () => {
+  assert.deepEqual(normalizeSchemaLiterals({ type: "string", const: 5 }), { type: "string" });
+});
+
+test("an untyped enum is left alone", () => {
+  const schema = { enum: [true, "a"] };
+  assert.equal(normalizeSchemaLiterals(schema), schema);
+});
+
+test("contradicting literals are dropped through $defs and unions", () => {
+  const schema = {
+    $defs: { lane: { type: "string", enum: [1] } },
+    oneOf: [{ type: "object", properties: { flag: { type: "boolean", enum: ["yes"] } } }],
+  };
+  const normalized = normalizeSchemaLiterals(schema);
+  assert.equal("enum" in normalized.$defs.lane, false, "an emptied enum is removed, not left empty");
+  assert.equal("enum" in normalized.oneOf[0].properties.flag, false);
+});
+
+test("providerToolSchema fixes a union root and its literals together", () => {
+  const schema = {
+    oneOf: [
+      { type: "object", properties: { mode: { type: "string", enum: [true, "view"] } } },
+      { type: "object", properties: { id: { type: "string" } } },
+    ],
+  };
+  const normalized = providerToolSchema(schema);
+  assert.equal(normalized.type, "object");
+  assert.deepEqual(normalized.properties.mode.enum, ["view"]);
 });


### PR DESCRIPTION
Fixes two independent, user-reported failures.

**Correction to an earlier revision of this description:** it claimed both failures were "reproduced against the live registry". That was true for the tool-schema half and **not** for the 401 half, which was tested against a hand-written fixture. Adversarial review caught it. See "What review changed" below.

## 1. Strict upstreams reject the whole request over one tool schema (#175, #179)

`namespace-relay.mjs` copied the client's tool schema to the provider verbatim. Two shapes are rejected by Moonshot/Kimi and the xAI CLI proxy, and both fail the **entire request**, not the one tool:

- a parameter schema rooted in an `anyOf`/`oneOf` union
- an `enum`/`const` literal that contradicts the type its own node declares

Codex's own `codex_app__automation_update` ships a `oneOf` root, so a session that never touched automations still died on its first message. Reproduced against the live registry — 1 of 18 flattened app tools reached every non-responses provider with a `$schema,oneOf,$defs` root.

`objectRootToolSchema` already solved the union half, but it had exactly one call site (`grok-oauth-forwarder.mjs`), so Kimi and Moonshot never reached it.

**Fix:** `normalizeSchemaLiterals` drops literals that contradict their declared type; `providerToolSchema` composes it with union-root flattening. Applied in the relay to the **provider-facing copy only** — `inputSchema` keeps the client's native union for responses-native routes.

Dropping rather than coercing is deliberate: a literal contradicting its own type could never validate. Note this *is* a widening — `enum: [true]` under `type: "string"` becomes "any string" rather than "must be `true`" — but the schema was malformed to begin with, and coercing to `"true"` would tell the model to send a value the app never asked for.

`appTaskLane` from #179 appears nowhere in this repo. It is client-supplied, and `mergeCodexAppTools` lets client definitions win, so it can only be fixed at relay time.

## 2. A rejected credential was reported as a rate limit (#179)

LiteLLM cools a deployment down on a 401, then answers subsequent calls with its own 429 `No deployments available`. The router passed that through, so the user was told to wait out a permanent auth failure. The correct 401 branch already existed; it was never reached.

Every `model_name` has exactly one deployment (83 models, 83 unique `gatewayModel`), so a cooldown can never route around a failure — only hide one.

**Fix:** `router_settings.disable_cooldowns`. LiteLLM then never synthesizes the 429 and the real 401 reaches the existing authentication branch. Verified `disable_cooldowns` is a real `Router.__init__` kwarg in the pinned `litellm==1.96.0` (`router.py:369`) and is accepted by the proxy's `router_settings` validator; unknown keys there are warned-and-ignored, never fatal, so this cannot break gateway boot.

## What review changed

An adversarial review pass (commit `0a00f6a`) found two defects in this PR:

1. **The reclassification code was unreachable.** It parsed a `status_code` out of LiteLLM's cooldown body. That field is never there: `cooldown_handlers.py:376` and `handle_error.py:90` both reduce the cooldown list to bare deployment ids, discarding the debug tuple that carries the status. The three tests covering it asserted a hand-written fixture, not a captured response. **Removed** — `disable_cooldowns` alone fixes #179. Replacement tests assert the real behavior and document why no cooldown-body test exists.

2. **`providerToolSchema` was too blunt.** It called `objectRootToolSchema` unconditionally, which collapses any unrecognized root (array, bare string, empty object) into `{type:"object", properties:{}}`. Correct for xAI; wrong for the relay, which now runs on every namespace and MCP tool, where it would silently replace a server-defined schema with one accepting anything. **Narrowed** to rewrite only a union root. `grok-oauth-forwarder` keeps its full collapse unchanged.

Review also confirmed, and I re-verified: no mutation of the caller's schema, identity return on clean input, and no `$ref` cycle risk (`normalizeSchemaLiterals` never dereferences `$ref`).

## Known trade-off, not fixed here

`disable_cooldowns` also removes LiteLLM's fast-fail circuit breaker for genuine outages, not just 401s. During a real provider outage each request now pays a full round trip instead of a cheap synthetic 429. Accepted deliberately: with one deployment per model the cooldown only ever hid the cause, and a misdiagnosed permanent auth failure costs more than a slow failure during an outage. Worth revisiting if latency during outages becomes a complaint.

## Not addressed

#179's Kimi coding-endpoint balance probe. `sk-kimi-xk…` keys belong to the Kimi Platform coding subscription, not the Moonshot Open Platform. The issue's suggested fix — adding `api.kimi.com` to the allowed hosts — would probe `/users/me/balance` on an endpoint with no such route, turning a graceful "unavailable" into a thrown error. Needs a live check of `kimi-k3` vs `k3` model ids first.

#179's baseUrl half is already fixed on main (`config/kimi/kimi.json:16` is `api.moonshot.ai`, changed ~7.5 hours before the issue was filed).

## Test plan

- [x] `npm test` — 1036 pass, 0 fail, 6 skipped
- [x] `npm run check`
- [x] 15 regression tests, named after the live errors
- [x] Union-rooted tool reproduced against the live registry, then confirmed resolved
- [x] Non-object non-union roots confirmed to pass through untouched
- [x] `disable_cooldowns` verified against the pinned litellm 1.96.0 source
- [ ] Live check against Moonshot/Kimi with a real credential