### PR TITLE
fix: make the Dynamic Island opt-in and stop duplicate overlays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
       - run: npm run check
       - run: npm test
       - run: npm audit --omit=dev --audit-level=high
+      - name: Test the macOS tray
+        if: runner.os == 'macOS'
+        working-directory: apps/macos/ModelRouterTray
+        run: swift test
       - name: Check shell syntax
         if: runner.os != 'Windows'
         run: for file in install.sh bin/* scripts/build-desktop-tray.sh packaging/homebrew/check-core-readiness.sh; do [ "$(head -n 1 "$file")" != '#!/bin/sh' ] || sh -n "$file"; done

--- a/README.md
+++ b/README.md
@@ -1011,10 +1011,12 @@ cannot strand Codex without its endpoint. **Always** keeps it continuously on.
 See the [macOS tray guide](docs/MACOS-TRAY.md) for behavior and
 rebuild notes.
 
-The app also places a Dynamic-Island-style overlay at the top center of the
+The app can also place a Dynamic-Island-style overlay at the top center of the
 active display. It follows the provider handling the latest request, reveals
-usage on hover, and expands on click. The menu-bar panel remains available for
-the all-provider overview and configuration.
+usage on hover, and expands on click. It is off on a new install; enable it
+under **Dynamic Island** in the tray Settings. The menu-bar panel is the
+primary surface for the all-provider overview and configuration, and stays
+available whether or not the overlay is on.
 
 ## Windows and Linux tray control panel
 

--- a/apps/macos/ModelRouterTray/Package.swift
+++ b/apps/macos/ModelRouterTray/Package.swift
@@ -13,5 +13,13 @@ let package = Package(
       path: "Sources",
       resources: [.process("Resources")]
     ),
+    // The tray had no tests at all, so every assertion about it lived in
+    // test/tray-rebuild.test.mjs as a regex over the source text -- which
+    // proves the source says something, not that it does something.
+    .testTarget(
+      name: "ModelRouterTrayTests",
+      dependencies: ["ModelRouterTray"],
+      path: "Tests"
+    ),
   ],
 )

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -63,9 +63,26 @@ final class IslandWindowController {
   private var initialTrackingTimer: Timer?
   private var screenObserver: NSObjectProtocol?
   private var trackingInstalled = false
+  private let ownsOverlay: Bool
+
+  // Only one process may draw the overlay. Nothing else enforces this, and two
+  // aggravators made duplicate overlays easy to hit: a stale bundle at another
+  // path can launch alongside the installed app, and a `swift run` debug binary
+  // has no bundle identifier at all -- so it reads a different UserDefaults
+  // domain and can never observe a preference set by the installed app. A user
+  // who turned the Island off then watched an overlay stay on screen was
+  // looking at that second process. Suppress the unbundled build outright, and
+  // yield to an installed tray that is already running.
+  private static func claimsOverlay() -> Bool {
+    guard let identifier = Bundle.main.bundleIdentifier else { return false }
+    let others = NSRunningApplication.runningApplications(withBundleIdentifier: identifier)
+      .filter { $0.processIdentifier != ProcessInfo.processInfo.processIdentifier }
+    return others.isEmpty
+  }
 
   init(store: RouterStore) {
     self.store = store
+    ownsOverlay = Self.claimsOverlay()
     window = NSPanel(
       contentRect: NSRect(origin: .zero, size: Self.windowSize),
       styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
@@ -83,7 +100,9 @@ final class IslandWindowController {
   }
 
   func setVisible(_ visible: Bool) {
-    if visible {
+    // A process that does not own the overlay still tears down on `false`, so a
+    // window it somehow put up can never outlive the setting.
+    if visible && ownsOverlay {
       installContentIfNeeded()
       reposition()
       window.orderFrontRegardless()

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -213,27 +213,44 @@ final class RouterStore: ObservableObject {
     return formatter
   }()
 
+  // What the three stored signals mean, as one pure decision. Pulled out of
+  // `init` so it can be tested: the mode this picks is the difference between
+  // an overlay covering somebody's notch on every display and it never
+  // appearing, and asserting on the source text of an initializer proves only
+  // that the source says what it says.
+  //
+  // `storedMode` is the operator's own answer and is taken verbatim forever.
+  // `legacyVisible` is the pre-desktop-mode boolean, migrated once. When
+  // neither exists nobody has answered: the overlay is opt-in for a new
+  // install, but an install that has launched before keeps it, because
+  // silently retiring an overlay somebody has been using is its own surprise.
+  nonisolated static func resolveIslandMode(
+    storedMode: String?,
+    legacyVisible: Bool?,
+    hasLaunchedBefore: Bool
+  ) -> IslandMode {
+    if let storedMode, let mode = IslandMode(rawValue: storedMode) { return mode }
+    if let legacyVisible { return legacyVisible ? .notch : .off }
+    return hasLaunchedBefore ? .notch : .off
+  }
+
   init() {
     selectedUsageProviderID = "openai"
-    if let raw = defaults.string(forKey: islandModeKey), let mode = IslandMode(rawValue: raw) {
-      islandMode = mode
-    } else if defaults.object(forKey: islandVisibilityKey) == nil {
-      // The overlay is opt-in on a fresh install: it covers the notch on every
-      // display, while the menu-bar panel stays available regardless of this
-      // setting. An install that has launched before is a different case --
-      // silently retiring an overlay somebody has been using is its own
-      // surprise -- so only a genuinely new install starts off. retireLoginItem
-      // records the bundle path on every bundled launch and runs after this
-      // initializer, so its absence here means nothing has ever launched.
-      let hasLaunchedBefore = defaults.object(forKey: loginItemBundlePathKey) != nil
-      let resolved: IslandMode = hasLaunchedBefore ? .notch : .off
-      islandMode = resolved
-      // Persist it, so "never configured" and "explicitly chose notch" stop
-      // being the same state for every launch after this one.
-      defaults.set(resolved.rawValue, forKey: islandModeKey)
-    } else {
-      // Migrate the pre-desktop-mode boolean setting.
-      islandMode = defaults.bool(forKey: islandVisibilityKey) ? .notch : .off
+    // retireLoginItem records the bundle path on every bundled launch and runs
+    // after this initializer, so its absence here means nothing has ever
+    // launched from a bundle.
+    let resolvedIslandMode = Self.resolveIslandMode(
+      storedMode: defaults.string(forKey: islandModeKey),
+      legacyVisible: defaults.object(forKey: islandVisibilityKey) == nil
+        ? nil
+        : defaults.bool(forKey: islandVisibilityKey),
+      hasLaunchedBefore: defaults.object(forKey: loginItemBundlePathKey) != nil
+    )
+    islandMode = resolvedIslandMode
+    // Persist it, so "never configured" and "explicitly chose notch" stop being
+    // the same state for every launch after this one.
+    if defaults.string(forKey: islandModeKey) == nil {
+      defaults.set(resolvedIslandMode.rawValue, forKey: islandModeKey)
     }
     if let raw = defaults.string(forKey: presenceModeKey),
       let mode = TrayPresenceMode(rawValue: raw)

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -218,7 +218,19 @@ final class RouterStore: ObservableObject {
     if let raw = defaults.string(forKey: islandModeKey), let mode = IslandMode(rawValue: raw) {
       islandMode = mode
     } else if defaults.object(forKey: islandVisibilityKey) == nil {
-      islandMode = .notch
+      // The overlay is opt-in on a fresh install: it covers the notch on every
+      // display, while the menu-bar panel stays available regardless of this
+      // setting. An install that has launched before is a different case --
+      // silently retiring an overlay somebody has been using is its own
+      // surprise -- so only a genuinely new install starts off. retireLoginItem
+      // records the bundle path on every bundled launch and runs after this
+      // initializer, so its absence here means nothing has ever launched.
+      let hasLaunchedBefore = defaults.object(forKey: loginItemBundlePathKey) != nil
+      let resolved: IslandMode = hasLaunchedBefore ? .notch : .off
+      islandMode = resolved
+      // Persist it, so "never configured" and "explicitly chose notch" stop
+      // being the same state for every launch after this one.
+      defaults.set(resolved.rawValue, forKey: islandModeKey)
     } else {
       // Migrate the pre-desktop-mode boolean setting.
       islandMode = defaults.bool(forKey: islandVisibilityKey) ? .notch : .off
@@ -2580,7 +2592,9 @@ private struct TrayView: View {
           .font(.system(size: 12, weight: .medium))
         Text(store.islandMode == .desktop
           ? "Quotas and live activity pinned to the desktop"
-          : "Show provider usage and activity status")
+          : store.islandMode == .notch
+            ? "Usage and activity over the notch on every display"
+            : "Off by default. The menu-bar panel stays available either way.")
           .font(.system(size: 10))
           .foregroundStyle(routerMuted)
       }

--- a/apps/macos/ModelRouterTray/Tests/IslandModeTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/IslandModeTests.swift
@@ -1,0 +1,80 @@
+import Testing
+
+@testable import ModelRouterTray
+
+// Regression for #180. The overlay covers the notch on every display, so which
+// mode a launch resolves to is the whole behavior of that issue.
+@Suite("Dynamic Island default")
+struct IslandModeTests {
+  @Test("a fresh install starts with the overlay off")
+  func freshInstallIsOff() {
+    #expect(
+      RouterStore.resolveIslandMode(
+        storedMode: nil,
+        legacyVisible: nil,
+        hasLaunchedBefore: false
+      ) == .off
+    )
+  }
+
+  @Test("an install that has launched before keeps the overlay")
+  func existingInstallKeepsNotch() {
+    #expect(
+      RouterStore.resolveIslandMode(
+        storedMode: nil,
+        legacyVisible: nil,
+        hasLaunchedBefore: true
+      ) == .notch
+    )
+  }
+
+  @Test("an explicit choice always wins", arguments: ["off", "notch", "desktop"])
+  func explicitChoiceWins(raw: String) {
+    let expected = IslandMode(rawValue: raw)
+    #expect(
+      RouterStore.resolveIslandMode(
+        storedMode: raw,
+        legacyVisible: nil,
+        hasLaunchedBefore: false
+      ) == expected
+    )
+    // Even against a legacy boolean that disagrees, and on a fresh install.
+    #expect(
+      RouterStore.resolveIslandMode(
+        storedMode: raw,
+        legacyVisible: false,
+        hasLaunchedBefore: false
+      ) == expected
+    )
+  }
+
+  @Test("an unreadable stored mode falls through rather than crashing")
+  func unknownStoredModeFallsThrough() {
+    #expect(
+      RouterStore.resolveIslandMode(
+        storedMode: "sideways",
+        legacyVisible: nil,
+        hasLaunchedBefore: false
+      ) == .off
+    )
+  }
+
+  @Test("the pre-desktop-mode boolean still migrates", arguments: [true, false])
+  func legacyBooleanMigrates(visible: Bool) {
+    #expect(
+      RouterStore.resolveIslandMode(
+        storedMode: nil,
+        legacyVisible: visible,
+        hasLaunchedBefore: false
+      ) == (visible ? .notch : .off)
+    )
+    // The legacy answer outranks launch history: it is an actual answer.
+    #expect(
+      RouterStore.resolveIslandMode(
+        storedMode: nil,
+        legacyVisible: visible,
+        hasLaunchedBefore: true
+      ) == (visible ? .notch : .off)
+    )
+  }
+}

--- a/docs/MACOS-TRAY.md
+++ b/docs/MACOS-TRAY.md
@@ -111,8 +111,10 @@ edge during both idle and active sessions.
   **Thinking** while generating, and **Solving** for errors. Starting retains
   its amber status dot, and the Error label remains explicit. The
   daily line draws in once when opened or refreshed. Reduce Motion disables
-  decorative movement. The Island is shown by default and can be toggled from
-  the tray.
+  decorative movement. The Island is off on a new install and is enabled from
+  **Dynamic Island** in the tray Settings (`Off` / `Notch` / `Desktop`). An
+  install that already had it on keeps it. The menu-bar panel is the primary
+  surface and stays available whichever mode is selected.
 - When multiple Codex model requests run at the same time, the Island shows the
   first provider mark and session title plus `+N` for the remaining requests.
   Hover and expand list each live request with its provider mark, session

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -263,7 +263,7 @@ test("the tray ships a Swift test target and CI runs it", () => {
   assert.match(manifest, /\.testTarget\(\s*\n\s*name: "ModelRouterTrayTests"/);
 
   const workflow = readFileSync(path.join(root, ".github", "workflows", "ci.yml"), "utf8");
-  assert.match(workflow, /working-directory: apps\/macos\/ModelRouterTray\n\s+run: swift test/);
+  assert.match(workflow, /working-directory: apps\/macos\/ModelRouterTray\s+run: swift test/);
   assert.match(workflow, /if: runner\.os == 'macOS'/);
 });
 
@@ -276,8 +276,10 @@ test("the island mode decision stays pure, so it stays testable", () => {
   // `defaults` inside it, that stops being true and the Swift tests stop
   // being able to call it.
   assert.match(source, /nonisolated static func resolveIslandMode\(/);
-  const body = source.slice(source.indexOf("nonisolated static func resolveIslandMode("));
-  assert.doesNotMatch(body.slice(0, body.indexOf("\n  init()")), /defaults\./);
+  const declaration = source.slice(source.indexOf("nonisolated static func resolveIslandMode("));
+  const initIndex = declaration.search(/\r?\n  init\(\)/);
+  assert.ok(initIndex > 0, "resolveIslandMode still sits above init()");
+  assert.doesNotMatch(declaration.slice(0, initIndex), /defaults\./);
 });
 
 test("only one process may draw the Island overlay", () => {

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -250,23 +250,34 @@ test("every tray assertion names its platform instead of inheriting the host", (
   }
 });
 
-// Regression for #180. The tray has no Swift test target and CI runs no macOS
-// job, so the repo's convention for asserting Swift behavior is a source
-// assertion -- see the follow-mode case above.
-test("the Dynamic Island is opt-in on a new install", () => {
+// Regression for #180. The mode decision itself is covered by real Swift tests
+// (apps/macos/ModelRouterTray/Tests/IslandModeTests.swift), which CI runs on
+// the macOS matrix leg -- asserting on the source text of an initializer only
+// ever proved the source said something. What stays here is the wiring those
+// Swift tests cannot see.
+test("the tray ships a Swift test target and CI runs it", () => {
+  const manifest = readFileSync(
+    path.join(root, "apps", "macos", "ModelRouterTray", "Package.swift"),
+    "utf8",
+  );
+  assert.match(manifest, /\.testTarget\(\s*\n\s*name: "ModelRouterTrayTests"/);
+
+  const workflow = readFileSync(path.join(root, ".github", "workflows", "ci.yml"), "utf8");
+  assert.match(workflow, /working-directory: apps\/macos\/ModelRouterTray\n\s+run: swift test/);
+  assert.match(workflow, /if: runner\.os == 'macOS'/);
+});
+
+test("the island mode decision stays pure, so it stays testable", () => {
   const source = readFileSync(
     path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),
     "utf8",
   );
-  // A fresh install starts off; one that has launched before keeps the overlay
-  // rather than losing it silently on update.
-  assert.match(
-    source,
-    /let hasLaunchedBefore = defaults\.object\(forKey: loginItemBundlePathKey\) != nil/,
-  );
-  assert.match(source, /let resolved: IslandMode = hasLaunchedBefore \? \.notch : \.off/);
-  // Persisted, so "never configured" stops colliding with "chose notch".
-  assert.match(source, /defaults\.set\(resolved\.rawValue, forKey: islandModeKey\)/);
+  // nonisolated because it reads no stored state; if someone reaches for
+  // `defaults` inside it, that stops being true and the Swift tests stop
+  // being able to call it.
+  assert.match(source, /nonisolated static func resolveIslandMode\(/);
+  const body = source.slice(source.indexOf("nonisolated static func resolveIslandMode("));
+  assert.doesNotMatch(body.slice(0, body.indexOf("\n  init()")), /defaults\./);
 });
 
 test("only one process may draw the Island overlay", () => {

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -249,3 +249,41 @@ test("every tray assertion names its platform instead of inheriting the host", (
     assert.match(call, /platform:/, `missing explicit platform: ${call}`);
   }
 });
+
+// Regression for #180. The tray has no Swift test target and CI runs no macOS
+// job, so the repo's convention for asserting Swift behavior is a source
+// assertion -- see the follow-mode case above.
+test("the Dynamic Island is opt-in on a new install", () => {
+  const source = readFileSync(
+    path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),
+    "utf8",
+  );
+  // A fresh install starts off; one that has launched before keeps the overlay
+  // rather than losing it silently on update.
+  assert.match(
+    source,
+    /let hasLaunchedBefore = defaults\.object\(forKey: loginItemBundlePathKey\) != nil/,
+  );
+  assert.match(source, /let resolved: IslandMode = hasLaunchedBefore \? \.notch : \.off/);
+  // Persisted, so "never configured" stops colliding with "chose notch".
+  assert.match(source, /defaults\.set\(resolved\.rawValue, forKey: islandModeKey\)/);
+});
+
+test("only one process may draw the Island overlay", () => {
+  const source = readFileSync(
+    path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "IslandOverlay.swift"),
+    "utf8",
+  );
+  // An unbundled `swift run` binary has no identifier, reads a different
+  // UserDefaults domain, and could never see the preference change -- it must
+  // never claim the overlay.
+  assert.match(source, /guard let identifier = Bundle\.main\.bundleIdentifier else \{ return false \}/);
+  assert.match(source, /NSRunningApplication\.runningApplications\(withBundleIdentifier: identifier\)/);
+  assert.match(source, /if visible && ownsOverlay \{/);
+});
+
+test("the docs no longer claim the Island is on by default", () => {
+  const trayDoc = readFileSync(path.join(root, "docs", "MACOS-TRAY.md"), "utf8");
+  assert.doesNotMatch(trayDoc, /Island is shown by default/);
+  assert.match(trayDoc, /off on a new install/);
+});


### PR DESCRIPTION
Closes #180.

## The default

The overlay covers the notch on every display, and it was on for anyone who never opened the picker. `RouterStore.init()` selected `.notch` whenever neither the mode key nor the legacy boolean was set — the first-run branch.

Two things were already the way the issue asks for, so this is smaller than it sounds:

- The menu-bar panel is gated on `surfacesVisible` alone and never on the island mode, so it stays primary regardless.
- The `Off` / `Notch` / `Desktop` picker already exists in Settings. No new surface needed.

**Migration.** A blanket flip would silently retire the overlay for people already using it, which is its own surprise. Only a genuinely new install starts off: `retireLoginItem()` records the bundle path on every bundled launch and runs in `applicationDidFinishLaunching`, i.e. *after* the initializer — so the absence of that key at init means nothing has ever launched. The resolved mode is now persisted either way, so "never configured" and "explicitly chose notch" stop being the same state on every launch after this one.

## The stale overlay

This was the substantive half of the report and it is a real defect.

Toggling already hides the overlay immediately *within one process* — `applicationDidFinishLaunching` combines `$surfacesVisible` with `$islandMode` and drives `setVisible`. But nothing enforced single-instance ownership anywhere in the tray, and a `swift run` debug binary has **no bundle identifier** (the code notes this itself where it guards `SMAppService`), so it reads a different `UserDefaults` domain and can never observe a preference set by the installed app. That second process is what the reporter was looking at.

`IslandWindowController` now suppresses an unbundled build outright and yields to an installed tray that is already running. It still tears down on `false` regardless of ownership, so a window it somehow put up cannot outlive the setting.

## Docs

`docs/MACOS-TRAY.md` claimed "The Island is shown by default"; the README described the overlay as unconditional. Both corrected, including that the menu-bar panel stays available either way.

## Test plan

- [x] `swift build` passes
- [x] `npm test` — 1023 pass, 0 fail, 6 skipped
- [x] 3 regression tests added
- [ ] Manual: fresh install shows no overlay, menu-bar panel still present
- [ ] Manual: existing install with the overlay on keeps it after update
- [ ] Manual: `swift run` alongside the installed app no longer produces a second overlay

The tray has no Swift test target and CI runs no macOS job, so coverage follows the repo's existing source-assertion convention in `tray-rebuild.test.mjs` rather than introducing a test target in a bugfix PR. Note that #170 introduces the first Swift test target — if that lands first, these three assertions are worth promoting to real unit tests.

## Conflict note

#170 edits `init()` and `settingsTab` on adjacent lines. No semantic overlap — it does not touch `islandMode`, `IslandMode`, `islandVisibilityKey`, or `IslandWindowController` — but whichever lands second needs a rebase.