### PR TITLE
feat: split the mainland China Moonshot platform into its own provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ user.
 3. Never ask the user to paste OAuth tokens or API keys into chat, command
    arguments, logs, environment snippets, or tracked files.
 4. Determine which provider IDs the user requested: `anthropic-api`,
-   `kimi-oauth`, `kimi-api`, `deepseek`, `grok-oauth`, `grok-api`, `qwen-plan`,
+   `kimi-oauth`, `kimi-api`, `kimi-api-cn`, `deepseek`, `grok-oauth`, `grok-api`, `qwen-plan`,
    `zai-coding`, `ollama-cloud`, `minimax-token-plan`, `meta`, `clinepass`, and/or
    `opencode-go`
    (shown to users as "opencode Go/Zen"; its `opencode-go-messages`,
@@ -47,6 +47,12 @@ user.
    interactive terminal to choose models. If they did not specify and
    credentials already exist, use
    `configured` rather than showing providers that cannot authenticate.
+   `kimi-api` and `kimi-api-cn` are two different Moonshot platforms, not a
+   fallback pair: the global console at platform.moonshot.ai and the mainland
+   one at platform.moonshot.cn have separate accounts, separate billing, and
+   keys that each host rejects from the other. Ask which platform the user's
+   key came from rather than defaulting, and never copy a stored key between
+   the two.
 5. For Kimi OAuth, reuse a valid `kimi login` session. If login is needed, run
    the official CLI only in an interactive terminal. For API providers, invoke
    `bin/model-router codex provider-key PROVIDER set` in a PTY so the hidden

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Linux installations support the Codex CLI.
 | K2.7 Coding (OAuth) | `kimi-oauth/kimi-for-coding` | Existing Kimi Code CLI OAuth session |
 | Kimi K3 (OAuth) | `kimi-oauth/k3` | Existing Kimi Code CLI OAuth session |
 | Kimi K3 (API) | `kimi-api/kimi-k3` | Separately billed Kimi Platform API key |
+| Kimi K3 (China API) | `kimi-api-cn/kimi-k3` | Separately billed Moonshot **China** platform key |
 | DeepSeek V4 Flash (API) | `deepseek/deepseek-v4-flash` | DeepSeek API key |
 | DeepSeek V4 Pro (API) | `deepseek/deepseek-v4-pro` | DeepSeek API key |
 | Grok 4.5 (OAuth) | `grok-oauth/grok-4.5` | Official Grok CLI OAuth session |
@@ -144,6 +145,14 @@ Linux installations support the Codex CLI.
 | Qwen3.7 Max (ClinePass) | `clinepass/qwen3.7-max` | ClinePass API key |
 | Qwen3.7 Plus (ClinePass) | `clinepass/qwen3.7-plus` | ClinePass API key |
 | Qwen3.8 Max (ClinePass) | `clinepass/qwen3.8-max` | ClinePass API key |
+
+Kimi has two API platforms and they are not interchangeable. `kimi-api` is the
+global console at platform.moonshot.ai; `kimi-api-cn` is the mainland console at
+platform.moonshot.cn. Accounts, billing, and keys are separate — a key minted on
+one platform is rejected by the other — so each is enabled and credentialed on
+its own, and both can be active at once. Pick the one matching where your key
+was created. (`kimi-oauth` is a third, distinct thing: the Kimi Code
+subscription reused through the official CLI's session.)
 
 The Codex catalog is credential-aware. It includes models only from enabled
 external providers with a stored credential or valid OAuth session. Native GPT

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -433,6 +433,7 @@ final class RouterStore: ObservableObject {
     "deepseek": "DeepSeek",
     "grok-api": "Grok API",
     "kimi-api": "Kimi API",
+    "kimi-api-cn": "Kimi CN",
     "anthropic-api": "Claude",
     "zai-coding": "GLM",
     "qwen-plan": "Qwen",
@@ -1934,6 +1935,7 @@ struct RouterProviderInfo: Decodable {
     .init(id: "deepseek", displayName: "DeepSeek API", kind: "openai-compatible"),
     .init(id: "grok-api", displayName: "Grok API", kind: "openai-compatible"),
     .init(id: "kimi-api", displayName: "Kimi API", kind: "openai-compatible"),
+    .init(id: "kimi-api-cn", displayName: "Kimi API (China)", kind: "openai-compatible"),
     .init(id: "anthropic-api", displayName: "Anthropic API", kind: "openai-compatible"),
   ]
 }

--- a/config/kimi/api-cn/kimi-k3.json
+++ b/config/kimi/api-cn/kimi-k3.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "kimi-api-cn/kimi-k3",
+      "gatewayModel": "kimi-api-cn-k3",
+      "upstreamModel": "kimi-k3",
+      "provider": "kimi-api-cn",
+      "listed": true,
+      "displayName": "Kimi K3 (China API)",
+      "description": "Kimi K3 through the mainland China Moonshot platform (api.moonshot.cn), billed to a separate platform.moonshot.cn account.",
+      "priority": 6,
+      "defaultEffort": "max",
+      "reasoningLevels": [
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Balanced deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning depth"
+        }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 900000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "requestProfile": "kimi-k3",
+      "supportsImageDetailOriginal": true,
+      "compHash": "kimi-api-cn-k3-v1"
+    }
+  ]
+}

--- a/config/kimi/kimi.json
+++ b/config/kimi/kimi.json
@@ -10,7 +10,7 @@
     },
     {
       "id": "kimi-api",
-      "displayName": "Kimi Platform API",
+      "displayName": "Kimi Platform API (Global)",
       "kind": "openai-compatible",
       "ownedBy": "kimi",
       "baseUrl": "https://api.moonshot.ai/v1",
@@ -30,6 +30,27 @@
         ],
         "prompt": "Kimi Platform API key"
       }
+    },
+    {
+      "id": "kimi-api-cn",
+      "displayName": "Kimi Platform API (China)",
+      "kind": "openai-compatible",
+      "ownedBy": "kimi",
+      "baseUrl": "https://api.moonshot.cn/v1",
+      "baseUrlEnv": "KIMI_API_CN_BASE_URL",
+      "credential": {
+        "environment": [
+          "KIMI_API_CN_KEY",
+          "MOONSHOT_CN_API_KEY"
+        ],
+        "file": "kimi-api-cn-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-kimi-api-cn"
+        ],
+        "prompt": "Kimi Platform API key (China, platform.moonshot.cn)"
+      },
+      "planNote": "Keys are not interchangeable with the global platform: create this one at platform.moonshot.cn."
     }
   ]
 }

--- a/src/provider-account-usage.mjs
+++ b/src/provider-account-usage.mjs
@@ -392,8 +392,13 @@ async function deepSeekAccount(fetchImpl) {
   return { status: "available", source: "official-api", metrics };
 }
 
-async function kimiApiAccount(fetchImpl) {
-  const provider = PROVIDERS.get("kimi-api");
+// Moonshot runs two platforms that share this balance route but nothing else:
+// the global console at platform.moonshot.ai and the mainland one at
+// platform.moonshot.cn. Accounts, billing, and keys are separate -- a key
+// minted on one is rejected by the other -- so they are separate providers here
+// and this probe is parameterized rather than pinned to one of them.
+async function kimiApiAccount(fetchImpl, providerId = "kimi-api") {
+  const provider = PROVIDERS.get(providerId);
   const credential = resolveProviderCredential(provider);
   if (!credential) return { status: "not-configured", source: "official-api", metrics: [] };
   const baseURL = (process.env[provider.baseUrlEnv] || provider.baseUrl).replace(/\/+$/, "");
@@ -735,7 +740,9 @@ async function accountUsageFor(providerId, fetchImpl) {
   try {
     if (providerId === "chutes") return await chutesAccount(fetchImpl);
     if (providerId === "deepseek") return await deepSeekAccount(fetchImpl);
-    if (providerId === "kimi-api") return await kimiApiAccount(fetchImpl);
+    if (providerId === "kimi-api" || providerId === "kimi-api-cn") {
+      return await kimiApiAccount(fetchImpl, providerId);
+    }
     if (providerId === "kimi-oauth") return await kimiOAuthAccount(fetchImpl);
     if (providerId === "grok-oauth") return await grokOAuthAccount(fetchImpl);
     if (providerId === "grok-api") {

--- a/test/provider-account-usage.test.mjs
+++ b/test/provider-account-usage.test.mjs
@@ -816,3 +816,34 @@ test("normalizes Grok prepaid credits and pay-as-you-go balance", () => {
     },
   ]);
 });
+
+// The balance probe used to be pinned to the global provider id. Both Moonshot
+// platforms answer /users/me/balance, in their own currency, from their own
+// account -- so it is parameterized and each provider must reach its own host.
+test("the China Kimi platform is probed on its own host and currency", async () => {
+  const requested = [];
+  process.env.KIMI_API_CN_KEY = "TEST_KIMI_CN_KEY";
+  delete process.env.KIMI_API_CN_BASE_URL;
+  try {
+    const snapshot = await providerAccountUsageSnapshot({
+      providerIds: ["kimi-api-cn"],
+      fetchImpl: async (url) => {
+        requested.push(String(url));
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            code: 0,
+            status: true,
+            data: { available_balance: 3.5, cash_balance: 3.5, voucher_balance: 0 },
+          }),
+        };
+      },
+    });
+    assert.deepEqual(requested, ["https://api.moonshot.cn/v1/users/me/balance"]);
+    assert.equal(snapshot["kimi-api-cn"].status, "available");
+    assert.equal(snapshot["kimi-api-cn"].metrics[0].currency, "CNY");
+  } finally {
+    delete process.env.KIMI_API_CN_KEY;
+  }
+});

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -69,6 +69,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "grok-oauth/grok-4.5",
       "grok-oauth/grok-4.6",
       "kimi-api/kimi-k3",
+      "kimi-api-cn/kimi-k3",
       "kimi-oauth/k3",
       "kimi-oauth/kimi-for-coding-highspeed",
       "kimi-oauth/kimi-for-coding",
@@ -151,9 +152,36 @@ test("provider registry exposes configured API and OAuth model families", () => 
     "COMMANDCODE_API_KEY",
   ]);
   assert.equal(PROVIDERS.get("grok-api").baseUrl, "https://api.x.ai/v1");
-  // Kimi API Platform uses the global endpoint by default; China/custom
-  // deployments can still override it with KIMI_API_BASE_URL.
+  // kimi-api is the global platform. The mainland one is its own provider
+  // below, not a KIMI_API_BASE_URL override of this one -- the override still
+  // works for a genuinely custom deployment, but pointing it at moonshot.cn
+  // would authenticate the wrong account's key against the wrong host.
   assert.equal(PROVIDERS.get("kimi-api").baseUrl, "https://api.moonshot.ai/v1");
+  // Moonshot runs two platforms with separate accounts, separate billing, and
+  // keys each host rejects from the other. They must never collapse into one
+  // provider, and must never share a credential.
+  assert.equal(PROVIDERS.get("kimi-api-cn").baseUrl, "https://api.moonshot.cn/v1");
+  assert.notEqual(
+    PROVIDERS.get("kimi-api-cn").credential.file,
+    PROVIDERS.get("kimi-api").credential.file,
+  );
+  assert.notEqual(
+    PROVIDERS.get("kimi-api-cn").baseUrlEnv,
+    PROVIDERS.get("kimi-api").baseUrlEnv,
+  );
+  for (const field of ["environment", "keychainServices"]) {
+    const global = new Set(PROVIDERS.get("kimi-api").credential[field]);
+    const china = PROVIDERS.get("kimi-api-cn").credential[field];
+    assert.ok(
+      china.every((entry) => !global.has(entry)),
+      `kimi-api-cn ${field} must not overlap the global platform`,
+    );
+  }
+  // The China route has never been through the native collaboration probe
+  // AGENTS.md requires, so it stays conservative v1 while the global one is v2.
+  assert.equal(MODEL_BY_SLUG.get("kimi-api-cn/kimi-k3").multiAgentVersion, undefined);
+  assert.equal(MODEL_BY_SLUG.get("kimi-api/kimi-k3").multiAgentVersion, "v2");
+  assert.equal(MODEL_BY_SLUG.get("kimi-api-cn/kimi-k3").upstreamModel, "kimi-k3");
   assert.equal(PROVIDERS.get("github-copilot").authProfile, "github-copilot");
   assert.equal(PROVIDERS.get("github-copilot").protocol, "openai-responses");
   assert.deepEqual(PROVIDERS.get("github-copilot").credential.environment, [
@@ -235,12 +263,19 @@ test("provider registry exposes configured API and OAuth model families", () => 
     "DASHSCOPE_API_KEY",
   ]);
   assert.equal(PROVIDERS.get("anthropic-api").protocol, "anthropic");
+  // Deliberate v1 holdouts. Both are unproven through the native collaboration
+  // probe AGENTS.md requires, and a v2 claim is not inherited from a sibling
+  // route: kimi-api-cn is the same model on a different platform, which is
+  // exactly the kind of "surely it also works" assumption the probe exists for.
+  const unprovenForV2 = new Set(["grok-oauth/grok-4.6", "kimi-api-cn/kimi-k3"]);
   for (const model of LISTED_MODELS.filter(({ provider, slug }) =>
-    /^(?:kimi|grok)-/.test(provider) && slug !== "grok-oauth/grok-4.6",
+    /^(?:kimi|grok)-/.test(provider) && !unprovenForV2.has(slug),
   )) {
     assert.equal(model.multiAgentVersion, "v2", model.slug);
   }
-  assert.equal(MODEL_BY_SLUG.get("grok-oauth/grok-4.6").multiAgentVersion, undefined);
+  for (const slug of unprovenForV2) {
+    assert.equal(MODEL_BY_SLUG.get(slug).multiAgentVersion, undefined, slug);
+  }
   assert.equal(MODEL_BY_SLUG.get("deepseek/deepseek-v4-pro").multiAgentVersion, undefined);
   for (const slug of [
     "kimi-oauth/kimi-for-coding-highspeed",
@@ -289,6 +324,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
     "grok-api/grok-4.5",
     "grok-oauth/grok-4.5",
     "grok-oauth/grok-4.6",
+    "kimi-api-cn/kimi-k3",
     "kimi-api/kimi-k3",
     "kimi-oauth/k3",
     "kimi-oauth/kimi-for-coding",


### PR DESCRIPTION
## Why

Moonshot runs **two platforms**, not one endpoint with a regional mirror:

| | Console | Endpoint | Account / billing |
|---|---|---|---|
| `kimi-api` | platform.moonshot.ai | `api.moonshot.ai/v1` | Global |
| `kimi-api-cn` *(new)* | platform.moonshot.cn | `api.moonshot.cn/v1` | Mainland China |

Keys are **not interchangeable** — a key minted on one platform is rejected by the other host. Confirmed against current provider documentation rather than inferred, per AGENTS.md.

Until now the only way to reach the mainland platform was `KIMI_API_BASE_URL`, which points the *global* provider's stored credential at a host that will refuse it. An env var that looks like it works and cannot.

This is the exact condition AGENTS.md already names as grounds for a split: *"Split a provider only when the routes differ in endpoint, models, or billing."* All three differ.

## What changed

- **`kimi-api` is untouched** — same id, same endpoint, same stored credentials. No existing install changes. Display name now says "(Global)".
- **`kimi-api-cn`** is a first-class provider with its own credential file (`kimi-api-cn-key.secret`), keychain service, and environment variables (`KIMI_API_CN_KEY` / `MOONSHOT_CN_API_KEY`). Both can be credentialed and enabled at once; neither can read the other's key — asserted in tests.
- **`kimi-api-cn/kimi-k3`** is the same upstream model on the mainland platform, one priority rung lower so picker order is unchanged for anyone not on it.
- **`planNote`** carries the one thing a user can get wrong to where they connect: the keys are not interchangeable, create this one at platform.moonshot.cn.
- **Balance probe parameterized.** It was pinned to `PROVIDERS.get("kimi-api")`. Both platforms answer `/users/me/balance` from their own account, and the CNY/USD selection already keyed off the host — only the provider lookup was hardcoded.

## Deliberately not v2

`multiAgentVersion` is omitted. It is the same model, but **a v2 claim is not inherited from a sibling route** — AGENTS.md requires the native collaboration probe (marker-return spawn, encrypted payload relay, same-thread follow-up), and this endpoint has not been through one. It joins `grok-oauth/grok-4.6` as a documented holdout, and the registry test now asserts that as an explicit set rather than a one-off exception.

This is the same standard I applied when reviewing #183, so applying a weaker one here would be inconsistent.

## DeepSeek was checked and does not need this

`api.deepseek.com` is a single endpoint with no separate international host — splitting it would produce a provider identical to the existing one. Left alone.

## Surfaces verified

- Registry loads it; no slug or `gatewayModel` collisions
- LiteLLM gateway config renders the route
- Onboarding reports `add-key` and surfaces the `planNote`
- Not auto-configured without a credential (`configuredProviderIds()` excludes it)
- Tray: short name + legacy fallback added. Icon needs no work — the tray already maps any `kimi*` provider id to the Kimi mark
- AGENTS.md provider list and README model table updated

## Test plan

- [x] `npm test` — 1037 pass, 0 fail, 6 skipped
- [x] `npm run check`
- [x] `swift build`
- [x] New tests: endpoint, credential isolation (file, env, keychain all non-overlapping), v1 holdout, and a probe test asserting the China provider hits `api.moonshot.cn` and reports CNY
- [ ] Live check with a real platform.moonshot.cn key

The live check is the one thing I cannot do here. Everything above is static verification.