### PR TITLE
fix: make the missing-Codex test actually exercise the missing case

### DIFF
--- a/test/codex-account-usage.test.mjs
+++ b/test/codex-account-usage.test.mjs
@@ -93,5 +93,9 @@ test("the usage panel reaches an npm-installed Codex through cmd.exe", () => {
 });
 
 test("the usage panel names a missing Codex instead of blaming the app-server", async () => {
-  await assert.rejects(readCodexAccountUsage({ binary: undefined }), /no Codex binary was found/);
+  // `null`, not `undefined`: a default parameter fires for `undefined`, so
+  // passing that resolved a real binary and the rejection never happened on any
+  // machine with Codex installed. It only looked green because CI runners have
+  // none -- which is the one environment where this assertion cannot fail.
+  await assert.rejects(readCodexAccountUsage({ binary: null }), /no Codex binary was found/);
 });


### PR DESCRIPTION
Found while checking whether #186 broke anything on `main`. It didn't — but it exposed a test that could never have failed for the right reason.

## The bug

```js
await assert.rejects(readCodexAccountUsage({ binary: undefined }), /no Codex binary was found/);
```

A default parameter fires for `undefined`. So `binary: undefined` does not override `binary = codexBinary()` — it *invokes* it. On any machine with Codex installed the call resolves a real path, no rejection happens, and the assertion fails.

It looked green only where `codexBinary()` returns nothing: the CI runner, and nowhere else. Every developer machine with Codex installed failed it.

## Why now

#186 widened binary discovery. On this machine `findCodexBinary()` now returns `/Applications/ChatGPT.app/Contents/Resources/codex`, which the previous code did not find — so the default started resolving where it used to come back empty. That is #186 working as intended; it just moved this test from accidentally-green to reliably-red outside CI.

Confirmed by running the same file at `d533b9f` (the commit before #186): 2 pass. At `67e710e`: 1 fail.

## The production code was correct

Verified directly rather than assumed:

```
findCodexBinary() on this machine: /Applications/ChatGPT.app/Contents/Resources/codex
binary:null -> rejects: The Codex app-server could not be started: no Codex binary was found.
```

The guard in `readCodexAccountUsage` does the right thing. Only the test could not reach it.

## Fix

Pass `null`, which is not `undefined` and therefore reaches the guard.

## Test plan

- [x] `node --test test/codex-account-usage.test.mjs` — 4 pass (was 1 fail on this machine)
- [x] `npm test` on a clean worktree of `main` + this fix — **1072 pass, 0 fail**, up from 1071 pass / 1 fail
- [x] Verified the failure is caused by #186 by testing the commit immediately before it