### PR TITLE
fix: measure output speed after the first token, not after the headers

### DIFF
--- a/src/provider-usage.mjs
+++ b/src/provider-usage.mjs
@@ -108,6 +108,7 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
       outputTokens: 0,
       totalTokens: 0,
       speedSamples: [],
+      firstTokenSamples: [],
       lastUsedAt: new Date(at).toISOString(),
     };
     model.requests += 1;
@@ -124,23 +125,36 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
     model.totalTokens += totalTokens;
     const durationMs = nonnegative(event.durationMs);
     const responseStartMs = optionalNonnegative(event.responseStartMs);
-    const generationDurationMs = durationMs - (responseStartMs ?? durationMs);
-    if (
+    // Output tokens per second is defined as the rate *after* the first token,
+    // with the wait before it reported separately as time-to-first-token --
+    // that is how every published benchmark states it, and it is the only
+    // split that does not change with reply length. Dividing by the time since
+    // the response headers instead buries a reasoning model's silent thinking
+    // in the denominator, which made a 31-token reply read at 12 tok/s and a
+    // 426-token one at 69 on the same model.
+    const firstTokenMs = optionalNonnegative(event.firstTokenMs);
+    const generationDurationMs = durationMs - (firstTokenMs ?? durationMs);
+    const measurable =
       event.status >= 200 &&
       event.status < 400 &&
-      outputTokens > 0 &&
-      responseStartMs !== undefined &&
-      generationDurationMs > 0 &&
       !event.retries &&
       event.emptyCompletion !== true &&
       event.emptyCompletionRetried !== true &&
-      event.emptyCompletionGuardReleased !== true
-    ) {
+      event.emptyCompletionGuardReleased !== true;
+    if (measurable && outputTokens > 0 && firstTokenMs !== undefined && generationDurationMs > 0) {
       model.speedSamples.push({ outputTokens, generationDurationMs });
       // Keep the displayed rate current instead of averaging the model's
       // entire 90-day usage history. Twenty replies smooth one-off bursts
       // without letting old sessions dominate the result.
       if (model.speedSamples.length > 20) model.speedSamples.shift();
+    }
+    // Time-to-first-token stands on its own: it is the pause the operator
+    // actually feels before anything appears, and on a reasoning model it is
+    // roughly half the request. Sampled from the same events, so a turn that
+    // is unfit for a rate is unfit for this too.
+    if (measurable && firstTokenMs !== undefined && firstTokenMs > 0 && firstTokenMs <= durationMs) {
+      model.firstTokenSamples.push(firstTokenMs);
+      if (model.firstTokenSamples.length > 20) model.firstTokenSamples.shift();
     }
     if (at >= Date.parse(model.lastUsedAt)) model.lastUsedAt = new Date(at).toISOString();
     provider.models.set(slug, model);
@@ -155,7 +169,7 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
         left.startDate.localeCompare(right.startDate),
       ),
       models: [...models.values()]
-        .map(({ speedSamples, ...model }) => {
+        .map(({ speedSamples, firstTokenSamples, ...model }) => {
           const speedOutputTokens = speedSamples.reduce(
             (total, sample) => total + sample.outputTokens,
             0,
@@ -167,6 +181,13 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
           return {
             ...model,
             speedSampleCount: speedSamples.length,
+            // Median, not mean: one cold start or one queued request would
+            // drag an average far more than it reflects a typical turn.
+            observedFirstTokenMs: firstTokenSamples.length
+              ? [...firstTokenSamples].sort((left, right) => left - right)[
+                  Math.floor(firstTokenSamples.length / 2)
+                ]
+              : null,
             observedTokensPerSecond:
               speedDurationMs > 0
                 ? Math.round((speedOutputTokens * 1_000 * 10) / speedDurationMs) / 10

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -172,6 +172,12 @@ export class ResponseUsageTransform extends Transform {
   #pending = Buffer.alloc(0);
   #released = false;
   #headerlessDetector;
+  // When the first token of visible output arrived, relative to whenever the
+  // caller says the request started. Headers are not this: a reasoning model
+  // answers with headers and then thinks in silence for seconds before the
+  // first token appears, and counting that silence as generation is what makes
+  // a fast model read as slow. See #192.
+  #firstTokenAt;
 
   // `estimatedInputTokens` arrives only on routed requests large enough that a
   // reported zero cannot be true. Without it this transform observes and
@@ -371,7 +377,33 @@ export class ResponseUsageTransform extends Transform {
   }
 
   #observe(payload) {
+    this.#noteFirstToken(payload);
     const usage = tokenUsageFromPayload(payload);
     if (usage) this.#usage = usage;
+  }
+
+  // The first event that carries visible generated text. Reasoning summaries
+  // and tool-call argument deltas are output the model is producing, so they
+  // count too -- what must not count is the wait before any of it starts.
+  #noteFirstToken(payload) {
+    if (this.#firstTokenAt !== undefined) return;
+    const type = payload?.type;
+    if (typeof type !== "string") return;
+    const producesOutput =
+      type === "response.output_text.delta" ||
+      type === "response.reasoning_summary_text.delta" ||
+      type === "response.function_call_arguments.delta" ||
+      type === "response.audio_transcript.delta";
+    // Chat-completions bridges stream choices[].delta instead of typed events.
+    const chatDelta = payload?.choices?.[0]?.delta;
+    const chatProducesOutput =
+      typeof chatDelta?.content === "string" && chatDelta.content.length > 0;
+    if (producesOutput || chatProducesOutput) this.#firstTokenAt = Date.now();
+  }
+
+  // Epoch milliseconds of the first generated token, or undefined when the
+  // response never streamed one (a non-streaming reply, or an error).
+  firstTokenAt() {
+    return this.#firstTokenAt;
   }
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1584,6 +1584,7 @@ async function handleResponses(request, response, requestUrl) {
   let route;
   let upstreamRetries;
   let upstreamLatencyMs;
+  let firstTokenMs;
   let usageTransform;
   let emptyCompletionGuard;
   let retryUsageTransform;
@@ -1857,6 +1858,7 @@ async function handleResponses(request, response, requestUrl) {
         status: upstream.status,
         durationMs: Date.now() - startedAt,
         responseStartMs: upstreamLatencyMs,
+        firstTokenMs,
       });
       finalStatus = upstream.status;
       activityStatus = upstream.status;
@@ -1911,6 +1913,12 @@ async function handleResponses(request, response, requestUrl) {
       leaveOpen: relayOpen,
     });
     usage = usageTransform?.tokenUsage();
+    // Time to the first generated token, which is what an output-tokens-per-
+    // second figure has to divide by. `upstreamLatencyMs` stops at the response
+    // headers, and on a reasoning model the gap between the two is seconds of
+    // silent thinking that would otherwise be charged to the generation rate.
+    const firstTokenAt = usageTransform?.firstTokenAt?.();
+    if (firstTokenAt !== undefined) firstTokenMs = firstTokenAt - startedAt;
     estimatedInputTokens = usageTransform?.substitutedInputTokens();
     // The `close` listener above sets `clientGone` when the client's socket
     // goes away, but `pipeResponse` can resolve before that event fires: the
@@ -2057,6 +2065,7 @@ async function handleResponses(request, response, requestUrl) {
       status: finalStatus,
       durationMs: Date.now() - startedAt,
       responseStartMs: upstreamLatencyMs,
+      firstTokenMs,
       retries: upstreamRetries,
       ...usage,
       estimatedInputTokens,
@@ -2120,6 +2129,7 @@ async function handleResponses(request, response, requestUrl) {
           status: 0,
           durationMs: Date.now() - startedAt,
           responseStartMs: upstreamLatencyMs,
+        firstTokenMs,
           retries: upstreamRetries,
           ...usage,
           estimatedInputTokens,
@@ -2144,6 +2154,7 @@ async function handleResponses(request, response, requestUrl) {
         status: finalStatus,
         durationMs: Date.now() - startedAt,
         responseStartMs: upstreamLatencyMs,
+        firstTokenMs,
         retries: upstreamRetries,
         ...usage,
         estimatedInputTokens,

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -72,6 +72,12 @@ export function recordUsageEvent({
   // generation phase from prompt processing, queueing, and router setup.
   // Historical rows omit it and must not be used for generation-rate math.
   responseStartMs,
+  // Milliseconds from receiving the request until the first generated token
+  // reached the client. This -- not responseStartMs -- is the split an
+  // output-tokens-per-second figure divides by, matching how the industry
+  // reports it: tokens after the first token, with the wait before it counted
+  // separately as time-to-first-token.
+  firstTokenMs,
   inputTokens,
   cachedInputTokens,
   outputTokens,
@@ -121,6 +127,9 @@ export function recordUsageEvent({
     durationMs: Number.isFinite(durationMs) ? Math.max(0, Math.round(durationMs)) : 0,
     ...(safeTokenCount(responseStartMs) !== undefined
       ? { responseStartMs: safeTokenCount(responseStartMs) }
+      : {}),
+    ...(safeTokenCount(firstTokenMs) !== undefined
+      ? { firstTokenMs: safeTokenCount(firstTokenMs) }
       : {}),
     ...(streamAborted === true ? { streamAborted: true } : {}),
     ...(emptyCompletion === true ? { emptyCompletion: true } : {}),
@@ -321,6 +330,9 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
             : 0,
           ...(safeTokenCount(event.responseStartMs) !== undefined
             ? { responseStartMs: safeTokenCount(event.responseStartMs) }
+            : {}),
+          ...(safeTokenCount(event.firstTokenMs) !== undefined
+            ? { firstTokenMs: safeTokenCount(event.firstTokenMs) }
             : {}),
           ...(event.streamAborted === true ? { streamAborted: true } : {}),
           ...(event.emptyCompletion === true ? { emptyCompletion: true } : {}),

--- a/test/provider-usage.test.mjs
+++ b/test/provider-usage.test.mjs
@@ -77,7 +77,7 @@ test("breaks provider usage down by model, heaviest first", () => {
         model: "deepseek/deepseek-v4-flash",
         status: 200,
         durationMs: 2_000,
-        responseStartMs: 500,
+        firstTokenMs: 500,
         inputTokens: 100,
         outputTokens: 40,
         totalTokens: 140,
@@ -89,7 +89,7 @@ test("breaks provider usage down by model, heaviest first", () => {
         model: "deepseek/deepseek-v4-pro",
         status: 200,
         durationMs: 4_000,
-        responseStartMs: 1_500,
+        firstTokenMs: 1_500,
         inputTokens: 900,
         outputTokens: 100,
         totalTokens: 1_000,
@@ -164,7 +164,7 @@ test("uses only the latest 20 clean generation timings for observed speed", () =
     model: "deepseek/deepseek-v4-flash",
     status: 200,
     durationMs: index < 2 ? 11_000 : 3_000,
-    responseStartMs: 1_000,
+    firstTokenMs: 1_000,
     outputTokens: 100,
     totalTokens: 100,
   }));
@@ -173,12 +173,12 @@ test("uses only the latest 20 clean generation timings for observed speed", () =
   events.push({
     ...events.at(-1),
     at: new Date(now - 500).toISOString(),
-    responseStartMs: undefined,
+    firstTokenMs: undefined,
   });
   events.push({
     ...events.at(-1),
     at: new Date(now).toISOString(),
-    responseStartMs: 1_000,
+    firstTokenMs: 1_000,
     retries: 1,
   });
 
@@ -201,7 +201,7 @@ test("accepts a response that starts within the first measured millisecond", () 
         model: "deepseek/deepseek-v4-flash",
         status: 200,
         durationMs: 2_000,
-        responseStartMs: 0,
+        firstTokenMs: 0,
         outputTokens: 100,
       },
     ],
@@ -232,4 +232,85 @@ test("keeps unlabeled model traffic visible instead of dropping it", () => {
 
   assert.deepEqual(grok.models.map((model) => model.slug), ["unknown"]);
   assert.equal(grok.models[0].totalTokens, 25);
+});
+
+// Output tokens per second is the rate after the first token, with the wait
+// before it reported separately -- the definition every published benchmark
+// uses. Dividing by time-since-headers instead put a reasoning model's silent
+// thinking in the denominator, so the same model read at 12 tok/s on a short
+// reply and 69 on a long one.
+test("the observed rate does not move with reply length", () => {
+  const at = new Date().toISOString();
+  const reply = (outputTokens) => ({
+    meteringVersion: 1,
+    at,
+    model: "gpt-x",
+    provider: "openai",
+    status: 200,
+    inputTokens: 10,
+    outputTokens,
+    totalTokens: 10 + outputTokens,
+    responseStartMs: 700,
+    firstTokenMs: 2900,
+    // 2.9s of thinking, then a steady 80 tokens/second.
+    durationMs: 2900 + Math.round(outputTokens * 12.5),
+  });
+
+  const short = aggregateProviderUsage([reply(31)]).providers[0].models[0];
+  const long = aggregateProviderUsage([reply(426)]).providers[0].models[0];
+  assert.equal(Math.round(short.observedTokensPerSecond), 80);
+  assert.equal(Math.round(long.observedTokensPerSecond), 80);
+});
+
+test("time to first token is reported on its own", () => {
+  const at = new Date().toISOString();
+  const events = [1200, 2900, 5000].map((firstTokenMs) => ({
+    meteringVersion: 1,
+    at,
+    model: "gpt-x",
+    provider: "openai",
+    status: 200,
+    inputTokens: 10,
+    outputTokens: 100,
+    totalTokens: 110,
+    firstTokenMs,
+    durationMs: firstTokenMs + 1000,
+  }));
+  const model = aggregateProviderUsage(events).providers[0].models[0];
+  // Median, so one cold start cannot drag it.
+  assert.equal(model.observedFirstTokenMs, 2900);
+});
+
+test("a first token that outlives its own request is not sampled", () => {
+  const model = aggregateProviderUsage([{
+    meteringVersion: 1,
+    at: new Date().toISOString(),
+    model: "gpt-x",
+    provider: "openai",
+    status: 200,
+    inputTokens: 10,
+    outputTokens: 100,
+    totalTokens: 110,
+    firstTokenMs: 5000,
+    durationMs: 1000,
+  }]).providers[0].models[0];
+  assert.equal(model.observedTokensPerSecond, null);
+  assert.equal(model.observedFirstTokenMs, null);
+});
+
+test("rows recorded before first-token timing are unmeasured, not wrong", () => {
+  const model = aggregateProviderUsage([{
+    meteringVersion: 1,
+    at: new Date().toISOString(),
+    model: "gpt-x",
+    provider: "openai",
+    status: 200,
+    inputTokens: 10,
+    outputTokens: 100,
+    totalTokens: 110,
+    responseStartMs: 200,
+    durationMs: 1000,
+  }]).providers[0].models[0];
+  assert.equal(model.observedTokensPerSecond, null);
+  assert.equal(model.observedFirstTokenMs, null);
 });


### PR DESCRIPTION
Follow-up to #192. Its arithmetic was correct; it divided by the wrong interval.

## The problem

Output tokens per second is defined as the rate **after the first token**, with the wait before it reported separately as time-to-first-token. That is how [Artificial Analysis](https://artificialanalysis.ai/methodology/performance-benchmarking) and every published benchmark state it, and it is the only split that does not move with reply length.

#192 divided by time since the **response headers**. On a reasoning model the headers arrive seconds before the first token, so that silent thinking landed in the denominator.

Measured on 60 real `gpt-5.6-sol` requests from a live install:

| output tokens | reported rate |
|---|---|
| 31 | 11.7 tok/s |
| 54 | 29.8 |
| 204 | 49.3 |
| 324 | 58.0 |
| 426 | **69.4** |

Same model, same traffic — a 6× spread driven entirely by reply length. Regressing all 60:

```
generation_ms = 2176ms  +  12.47ms per token
                  ↑              ↑
       fixed overhead    true rate ≈ 80 tok/s
```

2.2 seconds of non-generation sat inside every measurement. On a short reply that *is* the measurement.

## The fix

- **`ResponseUsageTransform` timestamps the first event carrying generated output** — `output_text.delta`, reasoning summary, tool-call arguments, audio transcript, or a chat-completions content delta. It already parsed every SSE line, so this observes what was passing through rather than adding a hook.
- **The router resolves that to `firstTokenMs`** and records it beside `responseStartMs` at all four exits.
- **`provider-usage` divides by it.** `responseStartMs` stays: headers-to-first-token is the reasoning time, which is worth having.
- **A first token timestamped after its own request ended is rejected** for both figures rather than reported as a slow start.

`observedFirstTokenMs` (median) is computed and exposed on the snapshot but deliberately **not** surfaced in any UI — the tray keeps one number, not two.

## Result

On a fixture built from the real distribution (2.9s TTFT, 80 tok/s streaming):

| reply | before | after |
|---|---|---|
| 31 tokens | 11.7 tok/s | **80.1** |
| 426 tokens | 69.4 tok/s | **80.2** |

And live, on the four real replies since deploying this locally: 44.4 / 38.1 / 66.6 / 52.0 → pooled **58.4 tok/s**, where the tray had been showing 20.4.

## Known transition

Rows without `firstTokenMs` read as unmeasured rather than being reinterpreted, so 47 of 49 models show no rate until their next streamed reply. Same shape as #192's transition, and the same reasoning: better a blank than a number computed under a different definition. Each model repopulates on first use.

Aborted streams (`status: 0`) take an early exit that never resolves `firstTokenMs`, so they record `responseStartMs` without it. No effect on either figure — the `status >= 200 && status < 400` guard already excludes them — but the asymmetry is worth tidying separately.

## Test plan

- [x] `npm test` — 1083 pass, 0 fail, 8 skipped
- [x] `npm run check`
- [x] 4 new tests: rate is stable across reply length, TTFT is median-sampled, an out-of-range first token is rejected, historical rows are unmeasured rather than wrong
- [x] #192's three rate fixtures updated to the new definition
- [x] Deployed to a live router and verified against real streamed traffic