### PR TITLE
fix: stop one broken sample from carrying a model's speed, add per-model rates, default compaction off

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,15 @@ respectively when a deliberately larger local workload requires it.
 For routed external models, old textual tool results larger than 32 KiB are
 compacted after the model has acted on them. The four newest tool results stay
 intact, and each compacted result keeps a hash, head/tail evidence, and an exact
-rerun instruction. Toggle **Compact old tool results** in the router Settings;
+rerun instruction.
+
+This is **experimental and off by default.** It rewrites what the model sees
+mid-conversation, and its savings figures are still being validated against
+provider-billed tokens, so it is opted into rather than discovered after it has
+already altered a session. Turning it on is remembered: a stored answer is kept
+verbatim and is never re-defaulted by a later release.
+
+Toggle **Compact old tool results (experimental)** in the router Settings;
 the next external-model request sees the change without restarting Codex or the
 router. The equivalent CLI commands are `./bin/control tool-result-aging on`,
 `off`, and `status`.

--- a/apps/macos/ModelRouterTray/Sources/Localization.swift
+++ b/apps/macos/ModelRouterTray/Sources/Localization.swift
@@ -79,6 +79,8 @@ func routerFormat(_ english: String, _ arguments: CVarArg...) -> String {
 enum RouterChineseText {
   static let values: [String: String] = [
     "Uninstalling": "正在卸载",
+    "Compact old tool results (experimental)": "压缩旧工具结果（实验性）",
+    "Off by default · replaces consumed tool results on external models": "默认关闭 · 在外部模型上替换已使用的工具结果",
     "Fix Codex Router installation": "修复 Codex 路由安装",
     "Language": "语言",
     "System": "跟随系统",

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -675,6 +675,25 @@ final class RouterStore: ObservableObject {
       }
   }
 
+  // Issue #182. The headline card follows whatever is generating right now,
+  // which answers "how fast is this" but never "how do my models compare".
+  // `lastUsedAt` was already decoded and unread; this is what it was for.
+  // Only measured models appear -- an unmeasured one would need a placeholder
+  // row that says nothing, and the card above already covers "no samples yet".
+  var recentModelSpeeds: [ModelUsageRow] {
+    guard let snapshot = providerUsage else { return [] }
+    return snapshot.providers
+      .flatMap { provider in
+        (provider.models ?? []).map { model in
+          ModelUsageRow(providerID: provider.id, providerName: provider.displayName, model: model)
+        }
+      }
+      .filter { $0.model.observedTokensPerSecond != nil }
+      .sorted { ($0.model.lastUsedAt ?? "") > ($1.model.lastUsedAt ?? "") }
+      .prefix(4)
+      .map { $0 }
+  }
+
   var overallTokenTotal: Int64 {
     overallModelUsage.reduce(0) { $0 + $1.model.totalTokens }
   }
@@ -2599,6 +2618,37 @@ private struct TrayView: View {
       Color.primary.opacity(0.045),
       in: RoundedRectangle(cornerRadius: 9, style: .continuous)
     )
+    // Issue #182: the card above tracks the active model only, so a second
+    // model's speed was unknowable without switching to it and waiting.
+    if store.recentModelSpeeds.count > 1 {
+      VStack(spacing: 0) {
+        ForEach(store.recentModelSpeeds) { row in
+          HStack(spacing: 8) {
+            Text(row.model.displayName ?? row.model.slug)
+              .font(.system(size: 9))
+              .lineLimit(1)
+              .truncationMode(.middle)
+            Spacer(minLength: 8)
+            Text(row.providerName)
+              .font(.system(size: 8))
+              .foregroundStyle(routerMuted)
+              .lineLimit(1)
+            Text(row.model.observedTokensPerSecond.map { String(format: "%.1f", $0) } ?? "—")
+              .font(.system(size: 9, weight: .medium, design: .monospaced))
+              .foregroundStyle(routerMint)
+              .monospacedDigit()
+              .frame(width: 46, alignment: .trailing)
+          }
+          .padding(.vertical, 3)
+          .padding(.horizontal, 9)
+        }
+      }
+      .padding(.vertical, 2)
+      .background(
+        Color.primary.opacity(0.03),
+        in: RoundedRectangle(cornerRadius: 9, style: .continuous)
+      )
+    }
 
     if let agingStats = target?.modelSettings?.toolResultAging?.stats,
        let agedRequests = agingStats.requests, agedRequests > 0 {
@@ -2878,11 +2928,11 @@ private struct TrayView: View {
       isDisabled: store.providerOperation != nil || store.signedRouting
     )
     settingRow(
-      title: routerLocalized("Compact old tool results"),
+      title: routerLocalized("Compact old tool results (experimental)"),
       detail: target.modelSettings?.toolResultAging?.environmentOverride == true
         ? routerLocalized("Forced off by CODEX_ROUTER_TOOL_RESULT_AGING=0")
         : (target.modelSettings?.toolResultAging?.stats?.savingsSummary
-          ?? routerLocalized("External models · applies on the next request")),
+          ?? routerLocalized("Off by default · replaces consumed tool results on external models")),
       isOn: Binding(
         get: { target.modelSettings?.toolResultAging?.enabled ?? true },
         set: { enabled in Task { await store.setToolResultAgingEnabled(enabled) } }

--- a/src/provider-usage.mjs
+++ b/src/provider-usage.mjs
@@ -11,6 +11,10 @@ function dateKey(value) {
   return `${year}-${month}-${day}`;
 }
 
+// Fastest published serving rates are a few hundred tokens per second; this
+// is set well above them so a genuinely fast model is never discarded.
+const MAX_PLAUSIBLE_TOKENS_PER_SECOND = 500;
+
 function nonnegative(value) {
   const number = Number(value);
   return Number.isFinite(number) && number >= 0 ? Math.round(number) : 0;
@@ -134,14 +138,28 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
     // 426-token one at 69 on the same model.
     const firstTokenMs = optionalNonnegative(event.firstTokenMs);
     const generationDurationMs = durationMs - (firstTokenMs ?? durationMs);
+    // A long Codex turn can trip the empty-completion hold budget and still
+    // finish as a normal 200 with streamed tokens. That flag means "we
+    // stopped waiting to classify emptiness", not "this rate is unusable".
+    // Keep those replies; drop only empty/retried/canceled ones.
     const measurable =
       event.status >= 200 &&
       event.status < 400 &&
       !event.retries &&
       event.emptyCompletion !== true &&
-      event.emptyCompletionRetried !== true &&
-      event.emptyCompletionGuardReleased !== true;
-    if (measurable && outputTokens > 0 && firstTokenMs !== undefined && generationDurationMs > 0) {
+      event.emptyCompletionRetried !== true;
+    // Detection can fail on a converted stream -- the first token is noticed
+    // near the end, so thousands of tokens appear to arrive in milliseconds.
+    // No served model streams anywhere near this fast, so treat it as a broken
+    // sample rather than a record-breaking one.
+    const impossibleRate = (outputTokens * 1_000) / generationDurationMs > MAX_PLAUSIBLE_TOKENS_PER_SECOND;
+    if (
+      measurable &&
+      outputTokens > 0 &&
+      firstTokenMs !== undefined &&
+      generationDurationMs > 0 &&
+      !impossibleRate
+    ) {
       model.speedSamples.push({ outputTokens, generationDurationMs });
       // Keep the displayed rate current instead of averaging the model's
       // entire 90-day usage history. Twenty replies smooth one-off bursts
@@ -170,14 +188,17 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
       ),
       models: [...models.values()]
         .map(({ speedSamples, firstTokenSamples, ...model }) => {
-          const speedOutputTokens = speedSamples.reduce(
-            (total, sample) => total + sample.outputTokens,
-            0,
-          );
-          const speedDurationMs = speedSamples.reduce(
-            (total, sample) => total + sample.generationDurationMs,
-            0,
-          );
+          // Median of per-reply rates, not total tokens over total time. A
+          // pooled ratio lets one bad sample carry the answer: a stream whose
+          // first token is detected late reports thousands of tokens across a
+          // fraction of a second, and summing puts that straight into the
+          // numerator. Observed live -- one provider produced 11,656 tok/s
+          // this way and dragged a 20-sample window to 711 while every sane
+          // reply in it sat near 114. A median cannot be moved by a minority
+          // of impossible samples, and needs no threshold to tune.
+          const rates = speedSamples
+            .map((sample) => (sample.outputTokens * 1_000) / sample.generationDurationMs)
+            .sort((left, right) => left - right);
           return {
             ...model,
             speedSampleCount: speedSamples.length,
@@ -188,10 +209,9 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
                   Math.floor(firstTokenSamples.length / 2)
                 ]
               : null,
-            observedTokensPerSecond:
-              speedDurationMs > 0
-                ? Math.round((speedOutputTokens * 1_000 * 10) / speedDurationMs) / 10
-                : null,
+            observedTokensPerSecond: rates.length
+              ? Math.round(rates[Math.floor(rates.length / 2)] * 10) / 10
+              : null,
           };
         })
         .sort(

--- a/src/tool-result-aging-state.mjs
+++ b/src/tool-result-aging-state.mjs
@@ -16,11 +16,17 @@ export const TOOL_RESULT_AGING_STATE_PATH =
   process.env.MODEL_ROUTER_TOOL_RESULT_AGING_STATE ||
   path.join(STATE_DIR, "tool-result-aging.json");
 
-// Routed aging defaults on; native aging defaults off. The native path is
-// deliberately conservative (near-byte-identical forwarding to OpenAI), so
-// compacting it is an explicit operator opt-in rather than a default.
+// Both paths default off. Compaction rewrites tool results the model already
+// acted on: it saves real context, but it is a change to what the model sees
+// mid-conversation, and its savings figures are still being validated against
+// provider-billed tokens. That is an experiment to opt into, not a default to
+// discover after it has already altered a session. The structural rule from
+// the vision bridge applies here too -- an absent file means nobody has
+// answered and the current default applies, while a stored value is the
+// operator's own answer and is kept verbatim, so turning this on survives any
+// later change of default.
 function defaultSettings() {
-  return { version: 1, enabled: true, nativeEnabled: false, defaulted: true };
+  return { version: 1, enabled: false, nativeEnabled: false, defaulted: true };
 }
 
 function disabledSettings() {

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -158,7 +158,8 @@ test("codex probe includes native GPT models and the configured default", () => 
   assert.equal(slice.loginFreeManaged, false);
   assert.equal(slice.modelSettings.picker.hidden.length, 0);
   assert.ok(["all", "selected", "proven"].includes(slice.modelSettings.subagents.mode));
-  assert.equal(slice.modelSettings.toolResultAging.enabled, true);
+  // Compaction is opt-in, so an unconfigured probe reports it off.
+  assert.equal(slice.modelSettings.toolResultAging.enabled, false);
 });
 
 test("codex probe exposes managed login-free mode without credential details", () => {
@@ -217,10 +218,12 @@ test("control toggles tool-result aging without a router restart", () => {
       ),
     );
   try {
+    // Starts off, because compaction is opted into.
+    assert.equal(runControl("status").enabled, false);
+    assert.equal(runControl("on").enabled, true);
     assert.equal(runControl("status").enabled, true);
     assert.equal(runControl("off").enabled, false);
     assert.equal(runControl("status").enabled, false);
-    assert.equal(runControl("on").enabled, true);
   } finally {
     rmSync(stateDir, { recursive: true, force: true });
   }

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -4078,6 +4078,12 @@ test("router ages consumed large tool results but preserves the newest result fr
     json(response, 200, { output: [{ type: "message", role: "assistant", content: "ok" }] });
   });
   const stateDir = mkdtempSync(path.join(os.tmpdir(), "routing-tool-result-aging-"));
+  // Aging is opt-in, so this test states the setting it is exercising rather
+  // than relying on a default.
+  writeFileSync(
+    path.join(stateDir, "tool-result-aging.json"),
+    JSON.stringify({ version: 1, enabled: true, nativeEnabled: false }),
+  );
   const routerPort = await openPort();
   const router = run("router.mjs", {
     CODEX_ROUTER_PORT: String(routerPort),

--- a/test/tool-result-aging-state.test.mjs
+++ b/test/tool-result-aging-state.test.mjs
@@ -22,16 +22,18 @@ function forgetState() {
   delete process.env.CODEX_ROUTER_TOOL_RESULT_AGING;
 }
 
-test("tool-result aging defaults on before it is configured", () => {
+// Compaction rewrites what the model sees mid-conversation, so it is opted
+// into rather than discovered after the fact.
+test("tool-result aging defaults off until it is configured", () => {
   forgetState();
   assert.deepEqual(readToolResultAgingSettings(), {
     version: 1,
-    enabled: true,
+    enabled: false,
     nativeEnabled: false,
     defaulted: true,
   });
   assert.equal(toolResultAgingSnapshot().configured, false);
-  assert.equal(toolResultAgingEnabled(), true);
+  assert.equal(toolResultAgingEnabled(), false);
   assert.equal(nativeToolResultAgingEnabled(), false);
 });
 
@@ -54,8 +56,9 @@ test("native aging is a separate opt-in that survives the routed toggle", () => 
   forgetState();
   setNativeToolResultAgingEnabled(true);
   assert.equal(nativeToolResultAgingEnabled(), true);
-  // The routed default must not be disturbed by opting the native path in.
-  assert.equal(toolResultAgingEnabled(), true);
+  // The routed default must not be disturbed by opting the native path in --
+  // it stays at whatever it was, which on a fresh state is off.
+  assert.equal(toolResultAgingEnabled(), false);
 
   // Flipping the routed flag must not silently reset the native choice.
   setToolResultAgingEnabled(false);


### PR DESCRIPTION
Three related changes to the speed surface, all found by running the merged code against a live install.

## 1. One broken sample was deciding a model's speed

The tray showed `grok-oauth/grok-4.6` at **778 tok/s**. Individual samples in the same window:

| output | generation window | rate |
|---|---|---|
| 116–603 tokens | 1–6 s | 73–114 tok/s ✅ |
| 2326–6353 tokens | 0.2–5 s | 660–**11,656** tok/s ❌ |

6353 tokens in 723 ms is not physically possible. Those events carry a first-token time of **121 s against a 122 s request** — detection fires near the end of the stream, so the measured window is only its tail.

The aggregate was `sum(tokens) / sum(durations)`, which puts a broken sample straight into the numerator. Now it is the **median of per-reply rates**: it cannot be moved by a minority of impossible samples and needs no threshold to tune. Same window, same data → **105.6 tok/s**, matching the plausible population.

Samples claiming more than 500 tok/s are also rejected outright — set well above any published serving rate, so a genuinely fast model is never discarded, but a detection failure cannot be mistaken for a record.

**Still open:** the underlying detection failure on converted streams (grok-oauth) is real. This stops it deciding the displayed number; it does not fix the samples. Worth its own issue.

## 2. Per-model speeds — closes #182

The card followed whatever was generating, so it answered "how fast is this" and never "how do my models compare". `lastUsedAt` was already decoded in the tray and read by nothing — this is what it was for.

Up to four measured models, most recent first, under the existing headline card. Unmeasured models are omitted rather than shown as a row that says nothing; the card above already covers "no samples yet".

## 3. Tool-result compaction defaults off, and says it is experimental

It rewrites what the model sees mid-conversation, and its savings figures are still being validated against provider-billed tokens. That is something to opt into, not to discover after it has already altered a session.

The structural rule from the vision bridge carries over and is tested: an absent state file means nobody has answered and the current default applies; a stored value is the operator's own answer and is kept verbatim. **An install that already turned this on keeps it** through the default change — verified against a real install carrying `enabled: true`.

The tray row is now "Compact old tool results (experimental)", translated in both languages.

## Test plan

- [x] `npm test` — 1085 pass, 0 fail, 8 skipped
- [x] `npm run check`
- [x] `swift build` + `swift test` (13 tests)
- [x] Verified against the live install: 778 → 105.6 tok/s
- [x] Verified a stored `enabled: true` survives the default flip
- [x] Five tests updated to state the setting they exercise instead of relying on the old default