### PR TITLE
fix: make gpt-5.6-luna usable as a v2 subagent without a mode switch

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -503,9 +503,14 @@ function sortCatalogModels(models) {
 // still ships gpt-5.6-luna as "v1" even though it runs correctly on the v2
 // backend (openai/codex#35097, #36294). spawn_agent filters candidate child
 // models on that static value, so a v1 entry can never be delegated to by a v2
-// parent. applyMultiAgentSettings only reaches routed models, which is why
-// "all" mode never promoted the native slugs; apply the same opt-in here so the
-// subagent modes mean what the Settings tab says they mean.
+// parent.
+//
+// These upstream-verified slugs run fine on the v2 backend, so they are
+// promoted unconditionally — no mode switch, no Settings dance. The subagent
+// opt-in below only reaches the *remaining* native models, which stay
+// conservative because their v2 relay paths have not been verified.
+const NATIVE_V2_BACKEND_SLUGS = new Set(["gpt-5.6-luna"]);
+
 export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
   const enabled = new Set(settings.enabled || []);
   const disabled = new Set(settings.disabled || []);
@@ -513,6 +518,9 @@ export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
     const slug = String(model.slug);
     if (model.visibility !== "list") return model;
     if (hidden.has(slug) || disabled.has(slug)) return model;
+    if (NATIVE_V2_BACKEND_SLUGS.has(slug)) {
+      return { ...model, multi_agent_version: "v2" };
+    }
     if (settings.mode === "all" || (settings.mode === "selected" && enabled.has(slug))) {
       return { ...model, multi_agent_version: "v2" };
     }

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -613,14 +613,36 @@ test("selected subagent mode only promotes the chosen native models", () => {
   assert.equal(promoted[1].multi_agent_version, "v1");
 });
 
-test("proven subagent mode leaves the native catalog untouched", () => {
-  const native = [{ slug: "gpt-5.6-luna", visibility: "list", multi_agent_version: "v1" }];
+test("proven subagent mode still promotes upstream-verified v2-backend slugs", () => {
+  // gpt-5.6-luna is shipped as v1 by upstream but runs on the v2 backend, so
+  // it must be promoted even in the conservative proven mode; an unverified
+  // native slug keeps its upstream value.
+  const native = [
+    { slug: "gpt-5.6-luna", visibility: "list", multi_agent_version: "v1" },
+    { slug: "gpt-5.4", visibility: "list", multi_agent_version: "v1" },
+  ];
   const promoted = promoteNativeMultiAgent(native, {
     mode: "proven",
     enabled: [],
     disabled: [],
   });
-  assert.deepEqual(promoted, native);
+  assert.equal(promoted[0].multi_agent_version, "v2");
+  assert.equal(promoted[1].multi_agent_version, "v1");
+});
+
+test("an upstream-verified slug still honours disabled and picker-hidden", () => {
+  const native = [{ slug: "gpt-5.6-luna", visibility: "list", multi_agent_version: "v1" }];
+  const promoted = promoteNativeMultiAgent(
+    native,
+    { mode: "proven", enabled: [], disabled: ["gpt-5.6-luna"] },
+  );
+  assert.equal(promoted[0].multi_agent_version, "v1");
+  const hidden = promoteNativeMultiAgent(
+    native,
+    { mode: "proven", enabled: [], disabled: [] },
+    new Set(["gpt-5.6-luna"]),
+  );
+  assert.equal(hidden[0].multi_agent_version, "v1");
 });
 
 test("a ChatGPT-plan model drives the same advertisement as a routed engine", async () => {


### PR DESCRIPTION
## Problem

`gpt-5.6-luna` is a cheap native model, but it can never be spawned as a child agent (subagent) from a v2 parent.

### Why this matters

The v1/v2 split exists to **separate model capability tiers** and stop a parent from accidentally delegating to a legacy model that would drag down the result. That intent is correct — but Luna was placed in the wrong tier:

- Luna runs correctly on the v2 backend (openai/codex#35097, #36294), so tagging it `v1` is not protecting anything; it is just hiding a capable model.
- With DeepSeek prices rising, **Luna is now the more cost-effective choice** versus `deepseek-v4-flash` for subagent work, so it should be front and center, not buried behind a settings toggle.

### Root cause

Codex `spawn_agent` only offers models whose catalog entry carries `multi_agent_version: "v2"` as child candidates. Upstream ships `gpt-5.6-luna` as `"v1"`, and `promoteNativeMultiAgent` only promoted a native slug to `v2` when the subagent mode was `all` or `selected` — so in the default `proven` mode Luna stayed `v1` and remained un-spawnable unless the user went into Settings and flipped modes. That is the "works but I have to fiddle with it" trap, and it is the kind of indirect behavior that is invisible to the parent agent and to the user.

## Fix

Promote the upstream-verified v2-backend slug (`gpt-5.6-luna`) **unconditionally** in `promoteNativeMultiAgent`:

- `hidden` and `disabled` still win (a user can still turn Luna off, or the picker can hide it).
- The subagent mode opt-in now only reaches the *remaining* native models, whose v2 relay paths are not yet verified.

No mode switch, no Settings dance. Luna shows up as a spawnable child out of the box.

## Verification

- Full suite: 926 tests, 0 failures.
- Rebuilt the merged catalog on the affected machine: `gpt-5.6-luna` now advertises `multi_agent_version: "v2"`, matching `gpt-5.6-sol` / `gpt-5.6-terra`.
- Added tests: proven mode still promotes Luna; disabled/hidden still suppress it.