### PR TITLE
docs: say that native models publish, because they do now

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,14 +157,19 @@ beside ours, so everything else in them is somebody else's work.
    the same bound the harness itself holds them to, and status output reports
    the redacted URL exactly as the Codex manager does. Never print the complete
    managed base URL.
-4. **Only routed models are published**, and only the selected, credentialed,
-   listed, non-hidden ones. An unregistered slug on the router's
-   `/v1/responses` endpoint is treated as native GPT traffic needing the
-   caller's own ChatGPT session, which a harness request does not carry — so a
-   native model advertised here would offer a turn that cannot authenticate.
-   For the same reason the vision-bridge engine candidates exclude native
-   models: this call site's evidence is that there is no caller session to
-   check.
+4. **Routed models are always published; native ones only while a session backs
+   them.** Publish only the selected, credentialed, listed, non-hidden routed
+   models. An unregistered slug on the router's `/v1/responses` endpoint is
+   treated as native GPT traffic needing a ChatGPT session, which a harness
+   request does not carry — so a native model is advertised only while
+   `nativeSessionStatus().usable` reports the session this machine is signed in
+   with as spendable, and is withheld again the moment it is not. Publishing one
+   the router cannot authorize offers a turn that 401s, which is the failure
+   this gate exists to prevent; never widen it to presence alone, because an
+   expired session is present.
+   The vision-bridge engine candidates still exclude native models: that call
+   site admits an engine on evidence the *caller's* session can spend it, and a
+   substituted session is not the caller's.
 5. **The protocol is `openai-responses`**, because that is the only thing the
    router's caller endpoint serves, and every router capability — tool-result
    ageing, the vision bridge, prompt-token substitution, upstream retry, usage
@@ -926,9 +931,11 @@ user has to find in the docs, so `src/dsh-install.mjs` owns the other half.
   provider CLIs. One copy, because the details that took a debugging session to
   get right — the PATH a spawn inherits, where npm drops binaries per platform,
   which line of npm's output is worth showing — are exactly what drifts.
-- Native GPT models are not published, here or anywhere: they need the caller's
-  own ChatGPT session, which a harness request does not carry. The count the
-  button reports is the routable set, not the picker.
+- Native GPT models are published only while `codex-native-session.mjs` reports
+  a usable session: they need a ChatGPT session, a harness request carries none
+  of its own, and the fallback spends the one this machine is already signed in
+  with. They are withheld again the moment it is missing or expired. The count
+  the button reports is the routable set, not the picker.
 
 `src/dsh-web.mjs` starts and finds the browser UI, so the tray's button can be
 `Open site` once there is a site to open.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,9 @@
   with the provider-CLI installs rather than copied.
 
   It is never a side effect: no `apply`, `enable`, or repair path installs the
-  harness. Native GPT models stay unpublished for the reason they always were —
-  a harness request carries no ChatGPT session — so the model count the button
-  reports is the routable set.
+  harness. The model count the button reports is the routable set, not the
+  picker — native GPT models come and go with the Codex session described
+  above.
 
   The row then runs the harness's browser UI: **Install**, then **Connect**,
   then a play button, then **Open site**, each shown only in the state it

--- a/README.md
+++ b/README.md
@@ -1066,9 +1066,20 @@ comments, and your other stored keys are left exactly as they were —
 A settings file this build cannot read unambiguously is refused with the file
 untouched rather than rewritten on a guess.
 
-**Native GPT models are not published.** They need the caller's own ChatGPT
-session, which a harness request does not carry, so advertising them would
-offer a turn that cannot authenticate.
+**Native GPT models publish while this machine has a usable Codex session.**
+They are authorized by a ChatGPT session and a harness request carries none of
+its own, so the router falls back to the session Codex is already signed in with
+here — you are logged in on this machine, and a client running as the same user
+should not have to log in again. They are withheld the moment that session is
+missing or expired, so the picker never offers a turn that would 401. If they
+disappear, open Codex once to renew it; `./bin/model-router doctor` says so too.
+
+It is a fallback and never an override: a request that presents its own
+credential is relayed untouched, so nothing about a Codex turn changes. Worth
+knowing before leaving it on — it widens what the caller key reaches, from the
+API-key providers to your ChatGPT subscription as well. Set
+`CODEX_ROUTER_NATIVE_SESSION_FALLBACK=0` to turn it off, and the harness
+publishes routed models only.
 
 **Subagents.** A child spawned by `dsh-tool-subagent` with no model of its own
 inherits the default model selection, so it is already routed once this route

--- a/src/dsh-catalog.mjs
+++ b/src/dsh-catalog.mjs
@@ -6,10 +6,12 @@
 // settings write, not a plugin or composition change, and the harness picks it
 // up on its next request because `dsh-settings-file` hot-reloads the document.
 //
-// Only routed models are published. An unregistered slug on the router's
-// `/v1/responses` endpoint is treated as native GPT traffic, which needs the
-// caller's own ChatGPT session — the harness carries none, so advertising a
-// native model here would offer a turn that cannot authenticate.
+// Routed models are always published. An unregistered slug on the router's
+// `/v1/responses` endpoint is treated as native GPT traffic, which needs a
+// ChatGPT session the harness does not carry — so a native model is published
+// only while `codex-native-session.mjs` can substitute the one this machine is
+// signed in with, and is withheld again the moment it cannot. See
+// `dshNativeModels` below.
 
 import { applyVisionBridge } from "./vision-bridge.mjs";
 import { yamlScalar } from "./yaml-structure.mjs";

--- a/src/dsh-install.mjs
+++ b/src/dsh-install.mjs
@@ -154,9 +154,11 @@ export async function setupHarness({ force = false, setDefaultModel = false } = 
     installedNow: install.changed,
     published,
     web: await dshWebState(),
-    // Native GPT models are never published: they need the caller's own
-    // ChatGPT session, which a harness request does not carry. Saying so beats
-    // letting somebody count the picker and conclude the publish dropped them.
+    // `published` is the routed count. Native GPT models ride the Codex session
+    // this machine is signed in with, so they come and go with it -- reporting
+    // the routed set beats a number that changes when nobody published
+    // anything, and beats letting somebody count the picker and conclude the
+    // publish dropped them.
     launch: `${DSH_EXECUTABLE} web`,
   };
 }


### PR DESCRIPTION
## Summary

#198 made native GPT models publishable to the DeepSeek Harness whenever this machine has a usable Codex session. Six places still said they are never published — including two inside the same CHANGELOG entry as the feature that changed it, and two source comments a few lines above the code that contradicts them.

| Site | Was |
| --- | --- |
| `src/dsh-catalog.mjs:9` | "Only routed models are published" — with `dshNativeModels` exported at :143 of the same file |
| `src/dsh-install.mjs:157` | "Native GPT models are never published" |
| `AGENTS.md` rule 4 | "**Only routed models are published**" |
| `AGENTS.md` harness-install notes | "Native GPT models are not published, here or anywhere" |
| `CHANGELOG.md` | "Native GPT models stay unpublished" — contradicting the entry above it |
| `README.md` | "**Native GPT models are not published.**" |

## The rule, restated

`AGENTS.md` rule 4 now states the real invariant — native models are advertised exactly while `nativeSessionStatus().usable` is true — and says explicitly not to widen it to presence, because an expired session is present. That is the distinction the gate exists for.

The vision-bridge native exclusion is **kept**, and its reason sharpened: that call site admits an engine on evidence the *caller's* session can spend it, and a substituted session is not the caller's. Verified still enforced at `src/dsh-catalog.mjs:124`.

## The user-facing half was missing

`README.md` now says the models appear and vanish with the session, that opening Codex once is the fix when they vanish, and that a request presenting its own credential is relayed untouched.

It also documents `CODEX_ROUTER_NATIVE_SESSION_FALLBACK=0`, which appeared in CHANGELOG and AGENTS.md but **nowhere a user would look**. It is the off switch for a default-on setting that widens what the caller key reaches — from the API-key providers to the ChatGPT subscription — so it belongs where the feature is described.

## Checks

- `npm run check` — syntax checks passed
- `npm test` — **1158 passed, 0 failed, 8 skipped**
- No behavior change: comments and prose only, plus no code paths touched