### PR TITLE
fix: release the empty-completion hold when the upstream proves it is generating

### DIFF
--- a/src/empty-completion-guard.mjs
+++ b/src/empty-completion-guard.mjs
@@ -60,10 +60,53 @@ function chunkHasChatContent(data) {
   });
 }
 
+// Liveness is proof the upstream is generating without being output the client
+// can act on. Reasoning is the canonical case, and it is why liveness exists as
+// a separate verdict: on a reasoning model the gap between the first reasoning
+// delta and the first output token is seconds to minutes, and holding that gap
+// is what turns a healthy turn into a frozen screen. Measured against
+// deepseek-v4-pro, the hold moved the client's first byte from 517 ms to
+// 30,638 ms — the byte/time budget, not the model, decided when the caller saw
+// anything. Liveness ends the hold. It deliberately does not count as content,
+// so the emptiness verdict below is unchanged: a turn that streams only
+// reasoning and then completes with nothing is still classified empty, it just
+// can no longer be repaired invisibly.
+function isLivenessEvent(eventType, data) {
+  if (typeof eventType === "string") {
+    if (/reasoning/.test(eventType)) {
+      if (/\.delta$/.test(eventType)) {
+        return typeof data?.delta === "string" && data.delta.length > 0;
+      }
+      // `.added`/`.done` on a reasoning part carry no delta of their own but
+      // still only appear once the model has started producing.
+      if (/\.(?:added|done)$/.test(eventType)) return true;
+    }
+    // Responses streams without summaries announce reasoning as an output item
+    // rather than as a typed reasoning event.
+    if (
+      eventType === "response.output_item.added" &&
+      data?.item?.type === "reasoning"
+    ) {
+      return true;
+    }
+  }
+  const choices = data?.choices;
+  if (!Array.isArray(choices)) return false;
+  return choices.some((choice) => {
+    const delta = choice?.delta ?? choice?.message;
+    if (!delta || typeof delta !== "object") return false;
+    // `reasoning_content` is DeepSeek's field; `reasoning` is what several
+    // OpenAI-compatible resellers relay instead.
+    const reasoning = delta.reasoning_content ?? delta.reasoning;
+    return typeof reasoning === "string" && reasoning.length > 0;
+  });
+}
+
 // Content means something the client can act on: output text or a tool call.
 // Reasoning deltas are deliberately not content — a turn that streams only
 // reasoning and then completes with nothing is exactly the empty completion
-// this guard exists to catch.
+// this guard exists to catch. See `isLivenessEvent` for what reasoning does
+// instead: it ends the hold without settling the verdict.
 function isContentEvent(eventType, data) {
   if (typeof eventType === "string") {
     if (/(?:^|\.)output_text\.delta$/.test(eventType)) {
@@ -116,10 +159,17 @@ function isContentEvent(eventType, data) {
 // the upstream answers 200 and emits `response.completed` but never produced
 // output text or a tool call. The client has no code path for "the model said
 // nothing", so it silently marks the turn done — the "random stop" the app
-// cannot explain. The guard holds the entire pre-content attempt, not merely
-// its terminal events: an empty first attempt must contribute no response id,
-// sequence number, reasoning, or other prologue bytes to the retry the caller
-// ultimately sees.
+// cannot explain.
+//
+// The hold exists only to make the retry invisible: an empty first attempt must
+// contribute no response id, sequence number, or other prologue bytes to the
+// retry the caller ultimately sees. That is worth paying for when the upstream
+// is silent, because a silent upstream has no prologue worth waiting for. It is
+// not worth paying for when the upstream is visibly generating — so a liveness
+// event ends the hold and the guard keeps watching from behind the relay. The
+// turn can still be classified empty afterwards; what it loses is the ability
+// to be repaired without the client noticing, which `suppressedPrologue()`
+// reports so the caller can retry silently or state the failure instead.
 export class EmptyCompletionGuard extends Transform {
   #eventStream;
   #decoder = new StringDecoder("utf8");
@@ -131,6 +181,8 @@ export class EmptyCompletionGuard extends Transform {
   #empty = false;
   #released = false;
   #releasedForBudget = false;
+  #releasedForLiveness = false;
+  #suppressedPrologue = false;
   #headerlessDetector;
   #maxPreludeBytes;
   #maxPreludeMs;
@@ -177,6 +229,22 @@ export class EmptyCompletionGuard extends Transform {
     return this.#releasedForBudget;
   }
 
+  // True when the hold ended because the upstream proved it was generating
+  // rather than because it produced content. The stream was relayed in full and
+  // on time; the verdict, if any, arrives later.
+  releasedForLiveness() {
+    return this.#releasedForLiveness;
+  }
+
+  // True when the guard still held every byte at the moment it declared the
+  // turn empty. Only then can the caller retry invisibly: the client has seen
+  // no head, no response id, and no sequence numbers from the failed attempt.
+  // An empty turn without this is real and must be reported, not retried — a
+  // second attempt would graft a second head onto a stream already in flight.
+  suppressedPrologue() {
+    return this.#suppressedPrologue;
+  }
+
   _transform(chunk, _encoding, callback) {
     if (this.#headerlessDetector) {
       const detected = this.#headerlessDetector.write(chunk);
@@ -202,11 +270,18 @@ export class EmptyCompletionGuard extends Transform {
       this.push(chunk);
       return;
     }
+    const bytes = Buffer.from(chunk);
     if (this.#released) {
-      this.push(chunk);
+      this.push(bytes);
+      // A liveness release ends the hold, not the question. Keep parsing from
+      // behind the relay so a turn that streamed reasoning and then produced
+      // nothing is still recognized — it just gets reported instead of retried.
+      if (!this.#settled()) {
+        this.#parseBuffer += this.#decoder.write(bytes);
+        this.#consumeBlocks();
+      }
       return;
     }
-    const bytes = Buffer.from(chunk);
     this.#chunks.push(bytes);
     this.#bufferedBytes += bytes.length;
     this.#parseBuffer += this.#decoder.write(bytes);
@@ -214,6 +289,13 @@ export class EmptyCompletionGuard extends Transform {
     if (!this.#released && this.#bufferedBytes > this.#maxPreludeBytes) {
       this.#release({ budget: true });
     }
+  }
+
+  // No further parsing can change the outcome: either the turn produced content
+  // or the hold ended for a reason that also ended the verdict (a content
+  // release, an unparseable terminal, or the byte/time budget).
+  #settled() {
+    return this.#sawContent || (this.#released && !this.#releasedForLiveness);
   }
 
   _flush(callback) {
@@ -231,6 +313,18 @@ export class EmptyCompletionGuard extends Transform {
       return;
     }
     if (this.#released) {
+      // A stream released for liveness was relayed in full, so there is nothing
+      // left to push — but its verdict is still owed. Finish parsing and record
+      // it; the caller reads `suppressedPrologue()` to learn that this one
+      // cannot be retried behind the client's back.
+      if (!this.#settled()) {
+        this.#parseBuffer += this.#decoder.end();
+        if (this.#parseBuffer) {
+          this.#classifyBlock(this.#parseBuffer);
+          this.#parseBuffer = "";
+        }
+        if (!this.#sawContent && this.#sawTerminal) this.#empty = true;
+      }
       callback();
       return;
     }
@@ -243,6 +337,8 @@ export class EmptyCompletionGuard extends Transform {
     }
     if (!this.#sawContent && this.#sawTerminal) {
       this.#empty = true;
+      // Every byte is still held, so the retry can replace this attempt whole.
+      this.#suppressedPrologue = true;
       this.#chunks = [];
       this.#bufferedBytes = 0;
     } else {
@@ -263,7 +359,7 @@ export class EmptyCompletionGuard extends Transform {
     this.#parseBuffer = blocks.pop() || "";
     for (const block of blocks) {
       this.#classifyBlock(block);
-      if (this.#released) return;
+      if (this.#settled()) return;
     }
   }
 
@@ -288,18 +384,29 @@ export class EmptyCompletionGuard extends Transform {
         return;
       }
       this.#sawTerminal = true;
+      return;
+    }
+    // Neither content nor terminal. If it proves the upstream is generating,
+    // stop holding: the cost of the hold is paid by every reasoning turn, while
+    // the empty completions it repairs are a fraction of a percent of them.
+    if (!this.#released && this.#livenessOf(eventType, dataText) === true) {
+      this.#release({ liveness: true });
     }
   }
 
-  #release({ budget = false } = {}) {
+  #release({ budget = false, liveness = false } = {}) {
     if (this.#released) return;
     this.#released = true;
     if (budget) this.#releasedForBudget = true;
+    if (liveness) this.#releasedForLiveness = true;
     this.#clearTimer();
     for (const chunk of this.#chunks) this.push(chunk);
     this.#chunks = [];
     this.#bufferedBytes = 0;
-    this.#parseBuffer = "";
+    // A liveness release keeps parsing, and the buffer holds the partial block
+    // straddling the release. Dropping it would corrupt the very block the
+    // verdict may depend on. Every other release is done reading.
+    if (!liveness) this.#parseBuffer = "";
   }
 
   #clearTimer() {
@@ -332,6 +439,19 @@ export class EmptyCompletionGuard extends Transform {
       // a content event into a false empty completion.
       dataText: dataLines.length ? dataLines.join("\n") : undefined,
     };
+  }
+
+  // Liveness never decides the verdict, only the hold, so an unparseable block
+  // is simply "not yet proven alive" rather than the indeterminate that
+  // `#contentOf` has to preserve.
+  #livenessOf(eventType, dataText) {
+    if (!dataText || dataText === "[DONE]") return false;
+    try {
+      const data = JSON.parse(dataText);
+      return isLivenessEvent(eventType ?? data?.type, data);
+    } catch {
+      return false;
+    }
   }
 
   #contentOf(eventType, dataText) {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -25,6 +25,7 @@ import {
   pipeResponse,
   readRequestBody,
   writeJson,
+  writeStreamErrorEvent,
 } from "./http-utils.mjs";
 import { EmptyCompletionGuard } from "./empty-completion-guard.mjs";
 import {
@@ -1684,6 +1685,11 @@ async function handleResponses(request, response, requestUrl) {
   let toolResultAging;
   let emptyCompletion = false;
   let emptyCompletionRetried = false;
+  // An empty turn the router could not repair because the attempt was already
+  // relayed. Distinct from `emptyCompletionRetried` in the meter: one is a
+  // failure the router absorbed, the other a failure it had to hand to the
+  // client, and only the second is visible to the user.
+  let emptyCompletionUnrepairable = false;
   let guardReleasedForBudget = false;
   let finalStatus;
   let activityStatus;
@@ -2027,11 +2033,26 @@ async function handleResponses(request, response, requestUrl) {
     // successful 40-second turn.
     guardReleasedForBudget =
       emptyCompletionGuard?.releasedForBudget() === true && !clientWalkedAway;
-    if (emptyCompletion) {
-      // The upstream answered 200 with nothing. Retry the identical request
-      // once: same bytes, same headers, same signal. The guard discarded the
-      // whole first stream, so the retry supplies the only head, response id,
-      // sequence space, reasoning, and output the client ever receives.
+    // The turn produced nothing, but the guard had already released it: the
+    // upstream proved it was generating (reasoning), so the head, response id,
+    // and prologue are on the wire. A second attempt would graft a second
+    // response onto a stream the client is already reading. State the failure
+    // instead. This is the case the hold used to cover, priced honestly — the
+    // hold cost every reasoning turn up to its full budget of dead air, and
+    // bought a silent rescue on roughly one routed turn in a thousand.
+    if (emptyCompletion && emptyCompletionGuard?.suppressedPrologue() !== true) {
+      emptyCompletionUnrepairable = true;
+      writeStreamErrorEvent(response, {
+        code: "empty_completion",
+        message:
+          "The model streamed reasoning but produced no output. The router could not retry because the response had already started.",
+      });
+    } else if (emptyCompletion) {
+      // The upstream answered 200 with nothing and never proved otherwise, so
+      // the guard still holds every byte. Retry the identical request once:
+      // same bytes, same headers, same signal. The discarded first stream means
+      // the retry supplies the only head, response id, sequence space,
+      // reasoning, and output the client ever receives.
       emptyCompletionRetried = true;
       let upstream2;
       try {
@@ -2164,6 +2185,7 @@ async function handleResponses(request, response, requestUrl) {
       ...toolResultAging,
       ...(emptyCompletion ? { emptyCompletion: true } : {}),
       ...(emptyCompletionRetried ? { emptyCompletionRetried: true } : {}),
+      ...(emptyCompletionUnrepairable ? { emptyCompletionUnrepairable: true } : {}),
       ...(guardReleasedForBudget ? { emptyCompletionGuardReleased: true } : {}),
     });
     usageRecorded = true;
@@ -2180,6 +2202,8 @@ async function handleResponses(request, response, requestUrl) {
             : ""
         }${
           emptyCompletionRetried ? " empty-completion-retried=true" : ""
+        }${
+          emptyCompletionUnrepairable ? " empty-completion-unrepairable=true" : ""
         }${emptyCompletion ? " empty-completion=true" : ""}`,
       );
     }

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -97,6 +97,13 @@ export function recordUsageEvent({
   // cover both attempts, because both were sent and both were billed. This
   // marker is what says the reported spend belongs to two attempts at one turn.
   emptyCompletionRetried,
+  // True when the turn was empty and the router could not repair it, because
+  // the attempt had already been relayed: the upstream proved it was generating
+  // before it produced nothing, so the hold was over and a retry would have
+  // grafted a second response onto a stream the client was already reading.
+  // Kept apart from `emptyCompletionRetried` because this failure reaches the
+  // user and that one does not.
+  emptyCompletionUnrepairable,
   // True when the guard released the stream at its byte/time hold budget
   // without a verdict, so this turn may have been an empty completion the
   // router chose not to retry. Kept apart from `emptyCompletion` because the
@@ -134,6 +141,9 @@ export function recordUsageEvent({
     ...(streamAborted === true ? { streamAborted: true } : {}),
     ...(emptyCompletion === true ? { emptyCompletion: true } : {}),
     ...(emptyCompletionRetried === true ? { emptyCompletionRetried: true } : {}),
+    ...(emptyCompletionUnrepairable === true
+      ? { emptyCompletionUnrepairable: true }
+      : {}),
     ...(emptyCompletionGuardReleased === true
       ? { emptyCompletionGuardReleased: true }
       : {}),
@@ -336,6 +346,9 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
             : {}),
           ...(event.streamAborted === true ? { streamAborted: true } : {}),
           ...(event.emptyCompletion === true ? { emptyCompletion: true } : {}),
+          ...(event.emptyCompletionUnrepairable === true
+            ? { emptyCompletionUnrepairable: true }
+            : {}),
           ...(event.emptyCompletionRetried === true
             ? { emptyCompletionRetried: true }
             : {}),

--- a/test/empty-completion-guard.test.mjs
+++ b/test/empty-completion-guard.test.mjs
@@ -39,6 +39,8 @@ async function runGuard(
   return {
     body: Buffer.concat(chunks).toString("utf8"),
     empty: guard.isEmpty(),
+    suppressed: guard.suppressedPrologue(),
+    live: guard.releasedForLiveness(),
   };
 }
 
@@ -60,12 +62,33 @@ const CONTENT_TURN = [
   "",
 ].join("\n");
 
+// Empty after visibly generating. The reasoning delta is liveness: it ends the
+// hold, so the attempt reaches the client and can no longer be swapped out for
+// a retry behind its back. Still classified empty.
 const EMPTY_TURN = [
   'event: response.created',
   'data: {"type":"response.created","response":{"id":"r1"}}',
   "",
   'event: response.reasoning_text.delta',
   'data: {"type":"response.reasoning_text.delta","delta":"thinking..."}',
+  "",
+  'event: response.completed',
+  'data: {"type":"response.completed","response":{"id":"r1","output":[]}}',
+  "",
+  'event: response.done',
+  'data: {"type":"response.done","response":{"id":"r1"}}',
+  "",
+].join("\n");
+
+// Empty without ever proving it was generating: prologue, then a terminal. The
+// hold costs nothing here (a silent upstream has no prologue worth waiting for)
+// and buys everything, so this attempt is discarded whole and retried.
+const SILENT_TURN = [
+  'event: response.created',
+  'data: {"type":"response.created","response":{"id":"r1"}}',
+  "",
+  'event: response.in_progress',
+  'data: {"type":"response.in_progress","response":{"id":"r1"}}',
   "",
   'event: response.completed',
   'data: {"type":"response.completed","response":{"id":"r1","output":[]}}',
@@ -104,10 +127,70 @@ test("a turn with output text passes through untouched and is not empty", async 
   assert.match(body, /response\.done/);
 });
 
-test("a reasoning-only turn is flagged empty and the entire attempt is discarded", async () => {
-  const { body, empty } = await runGuard(EMPTY_TURN);
+test("a silent turn is flagged empty and the entire attempt is discarded", async () => {
+  const { body, empty, suppressed, live } = await runGuard(SILENT_TURN);
   assert.equal(empty, true);
+  assert.equal(suppressed, true);
+  assert.equal(live, false);
   assert.equal(body, "");
+});
+
+test("a reasoning-only turn is still empty but is relayed, not suppressed", async () => {
+  const { body, empty, suppressed, live } = await runGuard(EMPTY_TURN);
+  assert.equal(empty, true);
+  // The verdict survives the release: the caller learns the turn produced
+  // nothing, and learns it cannot fix that invisibly.
+  assert.equal(suppressed, false);
+  assert.equal(live, true);
+  assert.equal(body, EMPTY_TURN);
+});
+
+test("reasoning ends the hold before the terminal event arrives", async () => {
+  // The point of the release is latency, so prove the bytes leave the guard
+  // while the stream is still open rather than at flush.
+  const guard = new EmptyCompletionGuard("text/event-stream");
+  const seen = [];
+  guard.on("data", (chunk) => seen.push(Buffer.from(chunk).toString("utf8")));
+  const split = EMPTY_TURN.indexOf("event: response.completed");
+  guard.write(Buffer.from(EMPTY_TURN.slice(0, split)));
+  assert.match(seen.join(""), /reasoning_text\.delta/);
+  guard.end(Buffer.from(EMPTY_TURN.slice(split)));
+  await new Promise((resolve) => guard.on("end", resolve).resume());
+  assert.equal(guard.isEmpty(), true);
+  assert.equal(guard.suppressedPrologue(), false);
+});
+
+test("a reasoning turn that then produces content is not empty", async () => {
+  const input = [
+    "event: response.reasoning_text.delta",
+    'data: {"type":"response.reasoning_text.delta","delta":"thinking..."}',
+    "",
+    "event: response.output_text.delta",
+    'data: {"type":"response.output_text.delta","delta":"Hello"}',
+    "",
+    "event: response.completed",
+    'data: {"type":"response.completed","response":{"output":[]}}',
+    "",
+  ].join("\n");
+  const { body, empty, live } = await runGuard(input, { chunkSize: 13 });
+  assert.equal(empty, false);
+  assert.equal(live, true);
+  assert.equal(body, input);
+});
+
+test("a reasoning item announces liveness when no summary is streamed", async () => {
+  const input = [
+    "event: response.output_item.added",
+    'data: {"type":"response.output_item.added","item":{"type":"reasoning","id":"rs_1"}}',
+    "",
+    "event: response.completed",
+    'data: {"type":"response.completed","response":{"output":[]}}',
+    "",
+  ].join("\n");
+  const { body, empty, suppressed } = await runGuard(input);
+  assert.equal(empty, true);
+  assert.equal(suppressed, false);
+  assert.equal(body, input);
 });
 
 test("a content turn is released byte for byte after classification", async () => {
@@ -276,16 +359,31 @@ test("a chat-completions tool call counts as content", async () => {
   assert.equal((await runGuard(input)).empty, false);
 });
 
-test("a chat-completions turn with only reasoning is still empty", async () => {
+test("a chat-completions turn with only reasoning is empty but relayed", async () => {
   const input = [
     `data: ${JSON.stringify({ choices: [{ delta: { reasoning_content: "thinking..." } }] })}`,
     "",
     "data: [DONE]",
     "",
   ].join("\n");
-  const { body, empty } = await runGuard(input);
+  const { body, empty, suppressed, live } = await runGuard(input);
   assert.equal(empty, true);
-  assert.doesNotMatch(body, /\[DONE\]/);
+  assert.equal(suppressed, false);
+  assert.equal(live, true);
+  assert.equal(body, input);
+});
+
+test("a chat-completions `reasoning` field is liveness too", async () => {
+  // DeepSeek sends `reasoning_content`; several resellers relay `reasoning`.
+  const input = [
+    `data: ${JSON.stringify({ choices: [{ delta: { reasoning: "thinking..." } }] })}`,
+    "",
+    "data: [DONE]",
+    "",
+  ].join("\n");
+  const { empty, suppressed } = await runGuard(input);
+  assert.equal(empty, true);
+  assert.equal(suppressed, false);
 });
 
 test("multiple data fields are joined per the SSE dispatch algorithm", async () => {
@@ -303,17 +401,17 @@ test("multiple data fields are joined per the SSE dispatch algorithm", async () 
 });
 
 test("the pre-content byte bound fails open to one coherent original attempt", async () => {
-  const { body, empty } = await runGuard(EMPTY_TURN, { maxPreludeBytes: 1 });
+  const { body, empty } = await runGuard(SILENT_TURN, { maxPreludeBytes: 1 });
   assert.equal(empty, false);
-  assert.equal(body, EMPTY_TURN);
+  assert.equal(body, SILENT_TURN);
 });
 
 test("the pre-content time bound also covers a headerless SSE attempt", async () => {
-  const split = EMPTY_TURN.indexOf("event: response.completed");
+  const split = SILENT_TURN.indexOf("event: response.completed");
   async function* delayedTurn() {
-    yield Buffer.from(EMPTY_TURN.slice(0, split));
+    yield Buffer.from(SILENT_TURN.slice(0, split));
     await new Promise((resolve) => setTimeout(resolve, 20));
-    yield Buffer.from(EMPTY_TURN.slice(split));
+    yield Buffer.from(SILENT_TURN.slice(split));
   }
   const guard = new EmptyCompletionGuard("", { maxPreludeMs: 5 });
   const chunks = [];
@@ -328,7 +426,7 @@ test("the pre-content time bound also covers a headerless SSE attempt", async ()
     }),
   );
   assert.equal(guard.isEmpty(), false);
-  assert.equal(Buffer.concat(chunks).toString("utf8"), EMPTY_TURN);
+  assert.equal(Buffer.concat(chunks).toString("utf8"), SILENT_TURN);
 });
 
 test("headerless SSE detection spans a split BOM, comments, and blank lines", async () => {
@@ -364,7 +462,7 @@ test("a byte-budget release reports releasedForBudget", async () => {
   const guard = new EmptyCompletionGuard("text/event-stream", { maxPreludeBytes: 1 });
   const chunks = [];
   await pipeline(
-    Readable.from([Buffer.from(EMPTY_TURN)]),
+    Readable.from([Buffer.from(SILENT_TURN)]),
     guard,
     new Writable({
       write(chunk, _encoding, callback) {
@@ -375,15 +473,15 @@ test("a byte-budget release reports releasedForBudget", async () => {
   );
   assert.equal(guard.isEmpty(), false);
   assert.equal(guard.releasedForBudget(), true);
-  assert.equal(Buffer.concat(chunks).toString("utf8"), EMPTY_TURN);
+  assert.equal(Buffer.concat(chunks).toString("utf8"), SILENT_TURN);
 });
 
 test("a time-budget release reports releasedForBudget and never classifies empty", async () => {
-  const split = EMPTY_TURN.indexOf("event: response.completed");
+  const split = SILENT_TURN.indexOf("event: response.completed");
   async function* delayedTurn() {
-    yield Buffer.from(EMPTY_TURN.slice(0, split));
+    yield Buffer.from(SILENT_TURN.slice(0, split));
     await new Promise((resolve) => setTimeout(resolve, 20));
-    yield Buffer.from(EMPTY_TURN.slice(split));
+    yield Buffer.from(SILENT_TURN.slice(split));
   }
   const guard = new EmptyCompletionGuard("", { maxPreludeMs: 5 });
   const chunks = [];
@@ -399,7 +497,7 @@ test("a time-budget release reports releasedForBudget and never classifies empty
   );
   assert.equal(guard.isEmpty(), false);
   assert.equal(guard.releasedForBudget(), true);
-  assert.equal(Buffer.concat(chunks).toString("utf8"), EMPTY_TURN);
+  assert.equal(Buffer.concat(chunks).toString("utf8"), SILENT_TURN);
 });
 
 test("a content release never reports releasedForBudget", async () => {

--- a/test/empty-completion-router.test.mjs
+++ b/test/empty-completion-router.test.mjs
@@ -20,7 +20,27 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
 const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
 
+// An attempt that never proves it was generating. The guard holds all of it, so
+// the router can swap it for a retry the client never sees.
 const EMPTY_SSE = [
+  'event: response.created',
+  'data: {"type":"response.created","sequence_number":0,"response":{"id":"r-empty"}}',
+  "",
+  'event: response.in_progress',
+  'data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"r-empty"}}',
+  "",
+  'event: response.completed',
+  'data: {"type":"response.completed","sequence_number":2,"response":{"id":"r-empty","output":[]}}',
+  "",
+  'event: response.done',
+  'data: {"type":"response.done","sequence_number":3,"response":{"id":"r-empty"}}',
+  "",
+].join("\n");
+
+// The same failure after the upstream proved it was generating. The reasoning
+// delta releases the hold, so this attempt is already on the wire by the time
+// it turns out to be empty and cannot be retried invisibly.
+const REASONING_EMPTY_SSE = [
   'event: response.created',
   'data: {"type":"response.created","sequence_number":0,"response":{"id":"r-empty"}}',
   "",
@@ -54,15 +74,17 @@ const CONTENT_SSE = [
 ].join("\n");
 
 // Large enough to force the guard past its 1 MiB pre-content hold budget
-// before any client-visible output arrives.
+// before any client-visible output arrives. Deliberately not a reasoning event:
+// reasoning releases the hold on liveness long before the byte cap, so a
+// reasoning prelude would exercise the wrong release path.
 const BUDGET_RELEASE_REASONING_SSE = [
   "event: response.created",
   'data: {"type":"response.created","response":{"id":"r-budget"}}',
   "",
-  "event: response.reasoning_text.delta",
+  "event: response.in_progress",
   `data: ${JSON.stringify({
-    type: "response.reasoning_text.delta",
-    delta: "x".repeat(2 * 1024 * 1024),
+    type: "response.in_progress",
+    response: { id: "r-budget", status: "x".repeat(2 * 1024 * 1024) },
   })}`,
   "",
 ].join("\n");
@@ -455,6 +477,52 @@ test("an empty completion is retried once and the retry's content reaches the cl
     assert.equal(event.status, 200);
     assert.equal(event.emptyCompletionRetried, true);
     assert.equal(event.emptyCompletion, undefined);
+  } finally {
+    await stopChild(router);
+    await closeServer(gw.server);
+  }
+});
+
+// The counterpart to the test above. Once the upstream streams reasoning, the
+// hold is over and the attempt is on the wire, so the router cannot substitute
+// a retry for it. It states the failure into the open stream instead. Holding
+// the prologue for this case is what used to cost every reasoning turn seconds
+// of dead air, and the silent rescue it bought landed on roughly one routed
+// turn in a thousand.
+test("a reasoning turn that ends empty is relayed and stated, never retried", async () => {
+  let posts = 0;
+  const gw = await gateway((_request, response) => {
+    posts += 1;
+    response.writeHead(200, {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "X-Upstream-Attempt": posts === 1 ? "first" : "retry",
+    });
+    response.end(posts === 1 ? REASONING_EMPTY_SSE : CONTENT_SSE);
+  });
+  const routerPort = await openPort();
+  const router = run(routerEnv(gw.port, routerPort));
+
+  try {
+    await waitFor(`${callerBaseUrl(routerPort, CALLER_KEY)}/models`, router);
+
+    const result = await readRouted(routerPort, TURN_BODY);
+
+    assert.equal(result.status, 200);
+    // The reasoning the user watched arrive is still theirs...
+    assert.match(result.body, /thinking/);
+    assert.match(result.body, /r-empty/);
+    // ...followed by a stated failure rather than a silent stop.
+    assert.match(result.body, /event: error/);
+    assert.match(result.body, /empty_completion/);
+    // No second attempt: the response had already started.
+    assert.equal(posts, 1, "a relayed attempt must not be retried");
+    assert.doesNotMatch(result.body, /Recovered|r-content/);
+    assert.equal(result.headers["x-upstream-attempt"], "first");
+
+    const [event] = await waitForUsageEvents(router.stateDir, 1, router);
+    assert.equal(event.emptyCompletion, true);
+    assert.equal(event.emptyCompletionUnrepairable, true);
+    assert.equal(event.emptyCompletionRetried, undefined);
   } finally {
     await stopChild(router);
     await closeServer(gw.server);


### PR DESCRIPTION
> Re-landing of #200, which was auto-closed on 2026-08-14 when its base branch `feat/harness-lifecycle-and-native-session` was deleted by the squash-merge of #198. The work was never reviewed down — it lost its base. This is the same commit, cherry-picked onto current `main` (clean, no conflicts) and re-tested: **1166 passed, 0 failed, 8 skipped**.

---

## The problem

`EmptyCompletionGuard` buffers every routed streaming response until it sees content, and reasoning deltas deliberately do not count as content. On a reasoning model the gap between the first reasoning delta and the first output token is seconds to minutes, so the guard held that entire gap. The client saw nothing until the turn closed or the 30s budget expired.

Measured against `opencode-go/deepseek-v4-pro`, two router processes sharing the same gateway, forwarder and provider, with only this behaviour varying and arms alternating so provider drift cancels:

| Model | Held | Released on liveness |
|---|---|---|
| `deepseek-v4-pro` | 30,638 / 30,531 ms | **517 / 526 ms** |
| `deepseek-v4-flash` | 29,409 / 29,577 ms | **536 / 503 ms** |

Both held arms park at `MAX_PRECONTENT_MS` — the hold budget, not the model, decided when the caller saw anything. `gpt-5.6-luna` showed no difference, because that upstream emits nothing until it emits text, so there was never a gap to hold.

Throughput is unaffected, which is why this never read as a slow turn — only a frozen one. It could not read as anything in telemetry either: `responseStartMs` stops at the response headers and `firstTokenMs` fires on reasoning deltas, and the guard kept holding past both. There was no field for the hold.

## What it cost, from 77,566 recorded turns

| | Count |
|---|---|
| Routed turns (guard applies) | 19,043 |
| Empty-completion retries fired | 168 |
| Retries that succeeded | **17** |

Every reasoning turn paid up to 30 seconds of dead air for a silent rescue on roughly one routed turn in a thousand. In the other 90% of empty turns the user got an error anyway, just 30 seconds later and after a second billed request.

## The change

The hold exists only to make the retry invisible. That is worth paying for when the upstream is silent — a silent upstream has no prologue worth waiting for — and not worth paying for when it is visibly generating.

- **`isLivenessEvent()`** — reasoning deltas, reasoning `.added`/`.done`, `output_item.added` carrying a reasoning item, and chat-completions `reasoning_content` / `reasoning`.
- Liveness **ends the hold without settling the verdict**. The guard relays and keeps parsing from behind the relay, so a turn that streams reasoning and then produces nothing is still classified empty.
- **`suppressedPrologue()`** — true only when every byte was still held at the moment the turn was declared empty. That is the precondition for an invisible retry, and it is what the router now branches on.
- A silent turn still holds every byte and still retries silently. Unchanged.
- When the attempt was already relayed, the router states the failure into the open stream via `writeStreamErrorEvent` rather than grafting a second response onto it.
- New `emptyCompletionUnrepairable` usage-event field. `recordUsageEvent` has an explicit field allowlist, so this had to be added there too or it is silently dropped.

One subtlety worth review: `#release()` no longer clears `#parseBuffer` on a liveness release. That buffer holds the partial SSE block straddling the release, and dropping it would corrupt the block the verdict may depend on.

## Why the visible error is not a regression

Verified against `codex-cli 0.145.0` with a stub upstream and an isolated `CODEX_HOME`, 3/3 reproducible:

| Stub response | Upstream turns | Answered | Codex retried |
|---|---|---|---|
| reasoning + text (control) | 1 | yes | — |
| reasoning + empty completion | 1 | **no** | **no** |
| reasoning + `event: error` | 2 | yes | yes |

The silent arm reproduces the original bug exactly: Codex prints the reasoning, reports tokens used, exits 0, and shows no answer and no error. The error arm makes Codex reissue the turn on its own ladder (`Reconnecting... 1/5`), so recovery is stronger than the single silent retry it replaces — up to five attempts instead of one — and visible instead of hidden.

Cosmetic wart: the reasoning summary renders twice in the error arm, once from the failed attempt and once from the retry. That is the visible seam that buys the 25 seconds.

## Test plan

- [x] `test/empty-completion-guard.test.mjs` + `test/empty-completion-router.test.mjs` — 52/52
- [x] `npm test` — 1161 pass, 0 fail, 8 skipped
- [x] `npm run check` — syntax checks pass
- [x] Live A/B against `opencode-go/deepseek-v4-pro` through the real provider: first byte 30,638 ms -> 1,159 ms
- [x] Live telemetry confirms the verdict survives the release: patched runs record `emptyCompletion` + `emptyCompletionUnrepairable` where the unpatched run recorded only `emptyCompletionGuardReleased` with no verdict at all
- [x] Codex client behaviour verified with a stub upstream, 3 modes, 3 reps

Fixture split for review: `SILENT_TURN` (no liveness — suppressed and retried) vs `EMPTY_TURN` (reasoning — relayed and stated). The byte/time-budget fixtures were repointed off reasoning, since liveness now releases long before the byte cap and they were about to exercise the wrong path.

## Base branch

Stacked on `feat/harness-lifecycle-and-native-session` (#198) because that branch also modifies `src/router.mjs`. Retarget to `main` once #198 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBkowYuJbJihuKStRH3K9H
