### PR TITLE
feat: add LM Studio local provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,20 @@ command directly, restart Codex yourself.
 
 ### Use a local model in Codex (experimental)
 
+LM Studio can run as a second local backend alongside Ollama. Its models use
+the stable `lmstudio/<model-id>` namespace, so identical model IDs loaded in
+the two backends never collide:
+
+```sh
+./bin/model-router codex providers enable lmstudio
+./bin/curate-models lmstudio
+```
+
+The default endpoint is `http://127.0.0.1:1234/v1`. Set
+`MODEL_ROUTER_LMSTUDIO_BASE_URL` when LM Studio listens elsewhere. Curation
+reads `/v1/models` and publishes only models explicitly chosen by the user.
+Ollama keeps its existing native route and local model controls.
+
 Models running on this machine can appear in Codex's picker like any other
 provider. They are labelled **experimental** there, and the label is earned:
 using a local model as the *vision reader* is reliable, but using one as a

--- a/config/lmstudio/lmstudio.json
+++ b/config/lmstudio/lmstudio.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "lmstudio",
+      "displayName": "LM Studio (Local)",
+      "kind": "openai-compatible",
+      "ownedBy": "lmstudio",
+      "protocol": "openai",
+      "baseUrl": "http://127.0.0.1:1234/v1",
+      "baseUrlEnv": "MODEL_ROUTER_LMSTUDIO_BASE_URL",
+      "keyless": true,
+      "planNote": "Runs on this machine. Start the LM Studio local server before using these models."
+    }
+  ]
+}

--- a/config/local/local.json
+++ b/config/local/local.json
@@ -6,6 +6,7 @@
       "displayName": "Local (Ollama)",
       "kind": "openai-compatible",
       "ownedBy": "local",
+      "transport": "ollama",
       "baseUrl": "http://127.0.0.1:11434/v1",
       "baseUrlEnv": "MODEL_ROUTER_LOCAL_BASE_URL",
       "keyless": true,

--- a/docs/LOCAL-MODELS.md
+++ b/docs/LOCAL-MODELS.md
@@ -70,6 +70,24 @@ no service to restart; restart them by hand after toggling.
 Updating Ollama is explicit. A normal model install reuses the installed
 runtime and does not replace it behind the user's back.
 
+## LM Studio
+
+LM Studio is supported as a separate local OpenAI-compatible backend. It can
+run alongside Ollama; models use the stable `lmstudio/<model-id>` namespace so
+identical model IDs from the two backends remain distinct.
+
+Start LM Studio's local server, enable the provider, and curate the models
+reported by its `/v1/models` endpoint:
+
+```text
+./bin/model-router codex providers enable lmstudio
+./bin/curate-models lmstudio
+```
+
+The default endpoint is `http://127.0.0.1:1234/v1`. Override it with
+`MODEL_ROUTER_LMSTUDIO_BASE_URL`. LM Studio models use the generic Chat
+Completions path; Ollama continues using its native route and context handling.
+
 Downloads rated too large for the machine are stopped unless `--force` is
 present; `--yes` alone does not override the fit check, because consenting to
 install Ollama is not the same as consenting to a model that will not run. A

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -653,7 +653,9 @@ for (const provider of PROVIDERS.values()) {
       : `${provider.displayName} ${credentialNoun}`,
     status.configured ? status.source : "not configured",
     provider.keyless
-      ? "Start Ollama, then run ./bin/control local-models list."
+      ? provider.id === "local"
+        ? "Start Ollama, then run ./bin/control local-models list."
+        : `Start ${provider.displayName}, then run ./bin/curate-models ${provider.id}.`
       : provider.authMode === "anonymous"
         ? provider.anonymousNote || "No key needed; only the provider's free models are available."
       : session
@@ -678,10 +680,12 @@ for (const provider of PROVIDERS.values()) {
         : provider.authMode === "anonymous"
           ? `${provider.displayName} is ready; discover and curate its current free models`
         : `${credentialNoun} stored but no models curated; the picker stays empty`,
-      // Local models are downloaded and checked, never curated from a remote
-      // catalog, so naming `curate-models` here points at the wrong command.
+      // Ollama models are downloaded and checked locally; other keyless local
+      // providers use the generic live catalog curation path.
       provider.keyless
-        ? `Install one with ./bin/control local-models install <tag-or-url> --yes; tool-capable models are checked automatically.`
+        ? provider.id === "local"
+          ? `Install one with ./bin/control local-models install <tag-or-url> --yes; tool-capable models are checked automatically.`
+          : `Run ./bin/curate-models ${provider.id} in an interactive terminal.`
         : `Run ./bin/curate-models ${provider.id} in an interactive terminal.`,
     );
   }

--- a/src/litellm-config.mjs
+++ b/src/litellm-config.mjs
@@ -26,7 +26,7 @@ export function renderLiteLlmConfig() {
     // a 16 GB machine and pushes inference onto the CPU. Measured here, the
     // same model went from 17 GB and 43% CPU to 3.1 GB entirely on the GPU,
     // and from ~35 s to under 10 s for the same reply.
-    if (provider.keyless) {
+    if (provider.keyless && provider.transport === "ollama") {
       lines.push(
         `  - model_name: ${yamlString(model.gatewayModel)}`,
         "    litellm_params:",

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -259,6 +259,12 @@ function loadRegistry() {
       ) {
         fail(`provider ${provider.id} has an unsupported API protocol`);
       }
+      if (provider.transport !== undefined && provider.transport !== "ollama") {
+        fail(`provider ${provider.id} has an unsupported transport`);
+      }
+      if (provider.transport === "ollama" && !provider.keyless) {
+        fail(`provider ${provider.id} Ollama transport must be keyless`);
+      }
     }
     providers.set(provider.id, Object.freeze(provider));
   }

--- a/test/lmstudio-provider.test.mjs
+++ b/test/lmstudio-provider.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const userModelsPath = path.join(mkdtempSync(path.join(os.tmpdir(), "lmstudio-test-")), "user-models.json");
+process.env.MODEL_ROUTER_USER_MODELS = userModelsPath;
+writeFileSync(
+  userModelsPath,
+  JSON.stringify({
+    version: 1,
+    models: [
+      {
+        slug: "lmstudio/qwen2.5-coder",
+        gatewayModel: "lmstudio-qwen2-5-coder",
+        upstreamModel: "qwen2.5-coder",
+        provider: "lmstudio",
+        listed: true,
+        displayName: "qwen2.5-coder (LM Studio)",
+        description: "Test model served by LM Studio.",
+        priority: 900,
+        defaultEffort: "high",
+        reasoningLevels: [{ effort: "high", description: "Adaptive reasoning" }],
+        contextWindow: 32768,
+        autoCompact: 28000,
+        inputModalities: ["text"],
+        compHash: "lmstudio-qwen2-5-coder-test-v1",
+      },
+    ],
+  }),
+);
+
+const { MODELS, PROVIDERS } = await import("../src/model-registry.mjs");
+const { renderLiteLlmConfig } = await import("../src/litellm-config.mjs");
+
+test("LM Studio models use the generic OpenAI-compatible local route", () => {
+  const model = MODELS.find((entry) => entry.slug === "lmstudio/qwen2.5-coder");
+  assert.ok(model);
+  assert.equal(PROVIDERS.get("lmstudio").protocol, "openai");
+
+  const rendered = renderLiteLlmConfig();
+  assert.match(rendered, /model_name: "lmstudio-qwen2-5-coder"/);
+  assert.match(rendered, /model: "openai\/lmstudio-qwen2-5-coder"/);
+  assert.doesNotMatch(rendered, /ollama_chat\/qwen2\.5-coder/);
+  assert.match(rendered, /os\.environ\/CODEX_ROUTER_API_FORWARD_BASE_URL/);
+});

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -53,15 +53,15 @@ test("provider selection keeps backward compatibility and can hide the final pro
     // credential-aware catalog is what hides providers that cannot authenticate.
     assert.deepEqual(readProviderSelection(), [...PROVIDERS.keys()]);
     process.env.KIMI_API_KEY = "TEST_ENVIRONMENT_ONLY_KEY";
-    // `local` is keyless: it serves from this machine, so there is no
-    // credential to configure and it is always available. Everything else has
-    // to authenticate before it counts.
-    assert.deepEqual(configuredProviderIds(), ["kilo-free", "local", "opencode-free"]);
-    assert.deepEqual(defaultProviderIds(), ["local"]);
+    // Local backends are keyless: they serve from this machine, so there is no
+    // credential to configure and they are always available. Everything else
+    // has to authenticate before it counts.
+    assert.deepEqual(configuredProviderIds(), ["kilo-free", "lmstudio", "local", "opencode-free"]);
+    assert.deepEqual(defaultProviderIds(), ["lmstudio", "local"]);
     delete process.env.KIMI_API_KEY;
     writeProviderCredential("deepseek", "TEST_DEEPSEEK_SELECTION_KEY");
-    assert.deepEqual(configuredProviderIds(), ["deepseek", "kilo-free", "local", "opencode-free"]);
-    assert.deepEqual(defaultProviderIds(), ["deepseek", "local"]);
+    assert.deepEqual(configuredProviderIds(), ["deepseek", "kilo-free", "lmstudio", "local", "opencode-free"]);
+    assert.deepEqual(defaultProviderIds(), ["deepseek", "lmstudio", "local"]);
 
     writeProviderSelection(["chatgpt-oauth"]);
     assert.deepEqual(readProviderSelection(), ["grok-oauth"]);

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -200,6 +200,9 @@ test("provider registry exposes configured API and OAuth model families", () => 
     "COMMANDCODE_API_KEY",
   ]);
   assert.equal(PROVIDERS.get("grok-api").baseUrl, "https://api.x.ai/v1");
+  assert.equal(PROVIDERS.get("local").transport, "ollama");
+  assert.equal(PROVIDERS.get("lmstudio").baseUrl, "http://127.0.0.1:1234/v1");
+  assert.equal(PROVIDERS.get("lmstudio").baseUrlEnv, "MODEL_ROUTER_LMSTUDIO_BASE_URL");
   // kimi-api is the global platform. The mainland one is its own provider
   // below, not a KIMI_API_BASE_URL override of this one -- the override still
   // works for a genuinely custom deployment, but pointing it at moonshot.cn

--- a/test/setup.test.mjs
+++ b/test/setup.test.mjs
@@ -45,12 +45,11 @@ test("automatic selection-only setup exposes only configured providers", () => {
         },
       },
     );
-    // `local` needs no credential -- it serves from this machine -- so the
-    // no-flag default includes it alongside keyed providers, but anonymous
-    // off-box endpoints require an explicit --providers choice.
-    assert.deepEqual(JSON.parse(output).providers, ["deepseek", "local"]);
+    // Local backends need no credential and are included by default, while
+    // anonymous off-box endpoints require an explicit --providers choice.
+    assert.deepEqual(JSON.parse(output).providers, ["deepseek", "lmstudio", "local"]);
     const selection = JSON.parse(readFileSync(path.join(stateDir, "enabled-providers.json"), "utf8"));
-    assert.deepEqual(selection.providers, ["deepseek", "local"]);
+    assert.deepEqual(selection.providers, ["deepseek", "lmstudio", "local"]);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }
@@ -87,9 +86,9 @@ test("ensure-configured does not auto-select anonymous providers", () => {
         },
       },
     );
-    assert.deepEqual(JSON.parse(output).providers, ["deepseek", "local"]);
+    assert.deepEqual(JSON.parse(output).providers, ["deepseek", "lmstudio", "local"]);
     const selection = JSON.parse(readFileSync(path.join(stateDir, "enabled-providers.json"), "utf8"));
-    assert.deepEqual(selection.providers, ["deepseek", "local"]);
+    assert.deepEqual(selection.providers, ["deepseek", "lmstudio", "local"]);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }
@@ -128,7 +127,7 @@ test("configured setup mode also excludes anonymous providers by default", () =>
         },
       },
     );
-    assert.deepEqual(JSON.parse(output).providers, ["deepseek", "local"]);
+    assert.deepEqual(JSON.parse(output).providers, ["deepseek", "lmstudio", "local"]);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
**LM Studio local provider**

Adds support for models served by LM Studio through its OpenAI-compatible API.

The provider uses the existing local model flow and supports a configurable base URL.

Validation:
- `npm run check`
- `npm test`
- Desktop checks
