### PR TITLE
perf: speed up desktop snapshot

### DIFF
--- a/apps/desktop/ui/app.js
+++ b/apps/desktop/ui/app.js
@@ -204,7 +204,6 @@ function startPanel() {
       ["account", "account_usage"],
       ["providerUsage", "provider_usage"],
       ["providerSetup", "provider_setup"],
-      ["localModels", "local_models"],
       ["health", "router_health"],
       ["platform", "platform_info"],
       ["settings", "desktop_settings"],
@@ -223,6 +222,10 @@ function startPanel() {
       if ("value" in result) state[result.key] = result.value;
       else errors.push(result.error);
     }
+    // The control snapshot already contains the local-model view. Reusing it
+    // avoids starting a second Node process for the same Ollama inventory.
+    const localModels = state.snapshot?.targets?.codex?.modelSettings?.localModels;
+    if (localModels) state.localModels = localModels;
     renderPanel();
     elements.refresh.disabled = false;
     if (!quiet && errors.length && !state.snapshot) showToast(errorMessage(errors[0]), true);

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -122,7 +122,8 @@ async function emitProbe() {
     "./vision-bridge.mjs"
   );
   const { installedNativeVisionEngines } = await import("./vision-engines.mjs");
-  const { annotateLocalModels, hostVisionProfile } = await import("./vision-host.mjs");
+  const { annotateLocalModels, hostVisionProfile, refreshVisionModelSizesIfStale } =
+    await import("./vision-host.mjs");
   const { readVisionDownload } = await import("./vision-download.mjs");
   const { readBenchmarkResults } = await import("./vision-benchmark.mjs");
   const { readLocalBenchmarks } = await import("./local-benchmark.mjs");
@@ -137,6 +138,9 @@ async function emitProbe() {
   );
   const { localOllamaRuntimeSnapshot } = await import("./ollama-runtime.mjs");
   const { selectedConfiguredListedModels } = await import("./provider-selection.mjs");
+  // Bounded and weekly: the tray reads this snapshot constantly, so a fresh
+  // cache costs nothing and a stale one costs one short, failure-tolerant pass.
+  if (TARGET === "codex") await refreshVisionModelSizesIfStale();
   // One probe serves several tray sections. Reuse the local reads so the same
   // snapshot does not run `ollama list` and the hardware checks once per view.
   const localInventory = TARGET === "codex" ? localModelInventory() : [];

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -122,8 +122,7 @@ async function emitProbe() {
     "./vision-bridge.mjs"
   );
   const { installedNativeVisionEngines } = await import("./vision-engines.mjs");
-  const { annotateLocalModels, hostVisionProfile, refreshVisionModelSizesIfStale } =
-    await import("./vision-host.mjs");
+  const { annotateLocalModels, hostVisionProfile } = await import("./vision-host.mjs");
   const { readVisionDownload } = await import("./vision-download.mjs");
   const { readBenchmarkResults } = await import("./vision-benchmark.mjs");
   const { readLocalBenchmarks } = await import("./local-benchmark.mjs");
@@ -133,11 +132,18 @@ async function emitProbe() {
     [...new Set([...Object.keys(visionBenchmarks), ...Object.keys(localBenchmarks)])]
       .map((tag) => [tag, { ...visionBenchmarks[tag], ...localBenchmarks[tag] }]),
   );
-  const { localModelsSnapshot } = await import("./local-models.mjs");
+  const { localModelInventory, localModelsSnapshot, runningLocalModels } = await import(
+    "./local-models.mjs",
+  );
+  const { localOllamaRuntimeSnapshot } = await import("./ollama-runtime.mjs");
   const { selectedConfiguredListedModels } = await import("./provider-selection.mjs");
-  // Bounded and weekly: the tray reads this snapshot constantly, so a fresh
-  // cache costs nothing and a stale one costs one short, failure-tolerant pass.
-  if (TARGET === "codex") await refreshVisionModelSizesIfStale();
+  // One probe serves several tray sections. Reuse the local reads so the same
+  // snapshot does not run `ollama list` and the hardware checks once per view.
+  const localInventory = TARGET === "codex" ? localModelInventory() : [];
+  const localRunning = TARGET === "codex" ? runningLocalModels() : [];
+  const localProfile = TARGET === "codex" ? hostVisionProfile() : undefined;
+  const localRuntime = TARGET === "codex" ? localOllamaRuntimeSnapshot() : undefined;
+  const localInstalled = localInventory.map((model) => model.tag);
 
   const enabledProviders = readProviderSelection();
   const hiddenModels = new Set(modelPickerSnapshot().hidden);
@@ -192,7 +198,12 @@ async function emitProbe() {
               subagents: subagentSettingsSnapshot(),
               picker: modelPickerSnapshot(),
               toolResultAging: toolResultAgingSnapshot(),
-              localModels: localModelsSnapshot({ benchmarks: localAndVisionBenchmarks }),
+              localModels: localModelsSnapshot({
+                inventory: localInventory,
+                running: localRunning,
+                runtime: localRuntime,
+                benchmarks: localAndVisionBenchmarks,
+              }),
               visionBridge: (() => {
                 const candidates = selectedConfiguredListedModels();
                 // Only the native models that actually shipped into the picker.
@@ -210,7 +221,7 @@ async function emitProbe() {
                   ...visionBridgeSnapshot(),
                   resolvedEngine: resolved?.slug || null,
                   resolvedEngineName: resolved?.displayName || null,
-                  hostMemGib: hostVisionProfile().memGib,
+                  hostMemGib: localProfile.memGib,
                   // Cloud vision models the operator already pays for -- the
                   // default engines. Auto picks the cheapest of these.
                   paidEngines: rankVisionEngines(candidates).map((model) => ({
@@ -228,7 +239,11 @@ async function emitProbe() {
                     efforts: visionEngineEfforts(model),
                   })),
                   // The downloadable local picker, each with size + fit + state.
-                  localModels: annotateLocalModels({ benchmarks: readBenchmarkResults() }),
+                  localModels: annotateLocalModels({
+                    profile: localProfile,
+                    installed: localInstalled,
+                    benchmarks: localAndVisionBenchmarks,
+                  }),
                   download: readVisionDownload(),
                 };
               })(),

--- a/src/local-models.mjs
+++ b/src/local-models.mjs
@@ -457,6 +457,7 @@ export function localModelsSnapshot({
   benchmarks = {},
   capabilities,
   agentChecks = readAgentChecks(),
+  runtime = localOllamaRuntimeSnapshot(),
 } = {}) {
   // Compared canonically: `ollama list` always prints `gemma3:latest`, while an
   // older state file may hold the bare `gemma3` the CLI once stored. Matching
@@ -545,7 +546,7 @@ export function localModelsSnapshot({
       mode: "ollama-tags",
       note: "Any valid Ollama tag is supported. Paste an ollama.com model URL or enter a tag to inspect and install it.",
     },
-    runtime: localOllamaRuntimeSnapshot(),
+    runtime,
     download: readLocalDownload(),
     machine: describeMachine(capacity),
   };

--- a/test/local-models.test.mjs
+++ b/test/local-models.test.mjs
@@ -71,6 +71,7 @@ test("the snapshot joins installed, checked, loaded, and vision state", () => {
     running: ["qwen2.5vl:3b"],
     selection: { version: 1, enabled: ["gemma3:4b"] },
     benchmarks: { "gemma3:4b": { tier: "accurate", textPercent: 100 } },
+    runtime: { installed: true, running: true, version: "0.1.0" },
     // Supplied so the test never shells out to the machine's real Ollama.
     capabilities: {
       "gemma3:4b": ["completion", "vision"],
@@ -91,6 +92,7 @@ test("the snapshot joins installed, checked, loaded, and vision state", () => {
   assert.equal(byTag["gemma3:4b"].vision, true);
   // None of these can call tools, so none can be a Codex chat model.
   assert.equal(snapshot.usableAsChat, 0);
+  assert.deepEqual(snapshot.runtime, { installed: true, running: true, version: "0.1.0" });
 });
 
 test("removing a model needs explicit consent and unchecks it", () => {


### PR DESCRIPTION
**Faster desktop snapshot**

The desktop panel no longer starts a second local-model process for the same data.

The control probe reuses local reads, and the optional registry size refresh no longer blocks the probe.

Validation:
- `npm test`
- `npm run check`
- `npm --prefix apps/desktop run check:js`
