### PR TITLE
perf: start forwarders in parallel

### DIFF
--- a/src/start.mjs
+++ b/src/start.mjs
@@ -191,20 +191,38 @@ const FRONTEND = { script: "router.mjs", service: "codex-router", label: "Codex 
 for (const signal of ["SIGINT", "SIGTERM"]) process.on(signal, stopChildren);
 
 async function main() {
+  // These forwarders use separate ports and do not depend on one another.
+  // Start all of them before waiting so a cold service does not pay their
+  // startup times one after another.
   const kimiForwarder = run(process.execPath, [path.join(SOURCE_ROOT, "src", "oauth-forwarder.mjs")]);
-  await waitForHealth("OAuth forwarder", loopback(PORTS.oauth, "/health"), {
-    Authorization: `Bearer ${internalKey}`,
-  }, 30_000, undefined, kimiForwarder);
-
   const api = run(process.execPath, [path.join(SOURCE_ROOT, "src", "api-forwarder.mjs")]);
-  await waitForHealth("API forwarder", loopback(PORTS.api, "/health"), {
-    Authorization: `Bearer ${internalKey}`,
-  }, 30_000, undefined, api);
-
   const grokForwarder = run(process.execPath, [path.join(SOURCE_ROOT, "src", "grok-oauth-forwarder.mjs")]);
-  await waitForHealth("Grok OAuth forwarder", loopback(PORTS.grokOauth, "/health"), {
-    Authorization: `Bearer ${internalKey}`,
-  }, 30_000, undefined, grokForwarder);
+  await Promise.all([
+    waitForHealth(
+      "OAuth forwarder",
+      loopback(PORTS.oauth, "/health"),
+      { Authorization: `Bearer ${internalKey}` },
+      30_000,
+      undefined,
+      kimiForwarder,
+    ),
+    waitForHealth(
+      "API forwarder",
+      loopback(PORTS.api, "/health"),
+      { Authorization: `Bearer ${internalKey}` },
+      30_000,
+      undefined,
+      api,
+    ),
+    waitForHealth(
+      "Grok OAuth forwarder",
+      loopback(PORTS.grokOauth, "/health"),
+      { Authorization: `Bearer ${internalKey}` },
+      30_000,
+      undefined,
+      grokForwarder,
+    ),
+  ]);
 
   const gateway = run(litellm, [
     "--config",


### PR DESCRIPTION
**Faster forwarder startup**

Starts the OAuth, API, and Grok forwarders together before waiting for health checks.

This removes sequential startup delay while keeping the same health checks and cleanup.

Validation:
- `npm run check`
- `node --test test/health-probe.test.mjs test/python-lock.test.mjs`
