### PR TITLE
refactor: share private JSON writes

### DIFF
--- a/src/dsh-web.mjs
+++ b/src/dsh-web.mjs
@@ -1,9 +1,9 @@
 import { spawn } from "node:child_process";
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { closeSync, existsSync, openSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import { harnessCliPath } from "./dsh-install.mjs";
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { spawnEnvironment } from "./npm-global-install.mjs";
 import { STATE_DIR } from "./paths.mjs";
 import { processStartIdentity, stateOwnsProcess } from "./process-identity.mjs";
@@ -45,15 +45,7 @@ function readState() {
 }
 
 function writeState(state) {
-  mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
-  const temporary = `${STATE_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify({ version: 1, ...state }, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, STATE_PATH);
-  protectPrivateFile(STATE_PATH);
+  writePrivateJson(STATE_PATH, { version: 1, ...state });
 }
 
 // Reachability, not identity. Whether the URL the button would open actually

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -1,5 +1,14 @@
 import { execFileSync } from "node:child_process";
-import { chmodSync, existsSync, statSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
 
 let windowsSid;
 
@@ -35,6 +44,30 @@ export function protectPrivateFile(target) {
     { stdio: "ignore" },
   );
   return target;
+}
+
+// All private JSON state uses the same temp-file, owner-only, atomic replace.
+// Keeping it here prevents one state writer from drifting away from the rest.
+export function writePrivateFile(target, contents, { directoryMode } = {}) {
+  const directory = path.dirname(target);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  if (directoryMode !== undefined) chmodSync(directory, directoryMode);
+  const temporary = `${target}.tmp.${process.pid}`;
+  try {
+    writeFileSync(temporary, contents, { encoding: "utf8", mode: 0o600 });
+    protectPrivateFile(temporary);
+    renameSync(temporary, target);
+    protectPrivateFile(target);
+  } catch (error) {
+    if (existsSync(temporary)) unlinkSync(temporary);
+    throw error;
+  }
+  return target;
+}
+
+export function writePrivateJson(target, value, { space = 2, directoryMode } = {}) {
+  writePrivateFile(target, `${JSON.stringify(value, null, space)}\n`, { directoryMode });
+  return value;
 }
 
 export function privateFileIsProtected(target) {

--- a/src/install-manifest.mjs
+++ b/src/install-manifest.mjs
@@ -1,20 +1,15 @@
 import { execFileSync } from "node:child_process";
 import {
-  chmodSync,
   existsSync,
-  mkdirSync,
   readFileSync,
-  renameSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import {
   INSTALL_MANIFEST_PATH,
   SOURCE_ROOT,
-  STATE_DIR,
   TARGET,
 } from "./paths.mjs";
 import { providerSelectionStatus } from "./provider-selection.mjs";
@@ -52,16 +47,7 @@ export function readInstallManifest() {
 }
 
 function atomicWrite(value) {
-  mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
-  chmodSync(STATE_DIR, 0o700);
-  const temporary = `${INSTALL_MANIFEST_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, INSTALL_MANIFEST_PATH);
-  protectPrivateFile(INSTALL_MANIFEST_PATH);
+  writePrivateJson(INSTALL_MANIFEST_PATH, value, { directoryMode: 0o700 });
 }
 
 export function recordInstall() {

--- a/src/local-benchmark.mjs
+++ b/src/local-benchmark.mjs
@@ -1,14 +1,10 @@
 import {
-  chmodSync,
   existsSync,
-  mkdirSync,
   readFileSync,
-  renameSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 import { normalizeLocalModelTag } from "./local-model-ref.mjs";
 import { ollamaRootUrl } from "./ollama-runtime.mjs";
@@ -26,17 +22,7 @@ export function readLocalBenchmarks() {
   }
 }
 export function writeLocalBenchmarks(results) {
-  const directory = path.dirname(LOCAL_BENCHMARKS_PATH);
-  mkdirSync(directory, { recursive: true, mode: 0o700 });
-  chmodSync(directory, 0o700);
-  const temporary = `${LOCAL_BENCHMARKS_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify({ version: 1, results }, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, LOCAL_BENCHMARKS_PATH);
-  protectPrivateFile(LOCAL_BENCHMARKS_PATH);
+  writePrivateJson(LOCAL_BENCHMARKS_PATH, { version: 1, results }, { directoryMode: 0o700 });
   return results;
 }
 

--- a/src/local-download.mjs
+++ b/src/local-download.mjs
@@ -1,15 +1,11 @@
 import {
-  chmodSync,
   existsSync,
-  mkdirSync,
   readFileSync,
-  renameSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 import { ensureOllamaHeadless } from "./ollama-runtime.mjs";
 import { normalizeLocalModelTag } from "./local-model-ref.mjs";
@@ -72,14 +68,7 @@ export function readLocalDownload(options) {
 }
 
 export function writeLocalDownload(state) {
-  const directory = path.dirname(LOCAL_DOWNLOAD_STATE_PATH);
-  mkdirSync(directory, { recursive: true, mode: 0o700 });
-  chmodSync(directory, 0o700);
-  const temporary = `${LOCAL_DOWNLOAD_STATE_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify(state)}\n`, { encoding: "utf8", mode: 0o600 });
-  protectPrivateFile(temporary);
-  renameSync(temporary, LOCAL_DOWNLOAD_STATE_PATH);
-  protectPrivateFile(LOCAL_DOWNLOAD_STATE_PATH);
+  writePrivateJson(LOCAL_DOWNLOAD_STATE_PATH, state, { space: 0, directoryMode: 0o700 });
   return state;
 }
 

--- a/src/multi-agent-state.mjs
+++ b/src/multi-agent-state.mjs
@@ -1,14 +1,10 @@
 import {
-  chmodSync,
   existsSync,
-  mkdirSync,
   readFileSync,
-  renameSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 
 export const MULTI_AGENT_STATE_PATH =
@@ -74,17 +70,7 @@ export function subagentSettingsSnapshot() {
 }
 
 function writeSettings(settings) {
-  const stateDir = path.dirname(MULTI_AGENT_STATE_PATH);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  chmodSync(stateDir, 0o700);
-  const temporary = `${MULTI_AGENT_STATE_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify(settings, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, MULTI_AGENT_STATE_PATH);
-  protectPrivateFile(MULTI_AGENT_STATE_PATH);
+  writePrivateJson(MULTI_AGENT_STATE_PATH, settings, { directoryMode: 0o700 });
 }
 
 export function setMultiAgentMode(mode) {

--- a/src/native-redirect.mjs
+++ b/src/native-redirect.mjs
@@ -1,15 +1,11 @@
 import {
-  chmodSync,
   existsSync,
-  mkdirSync,
   readFileSync,
-  renameSync,
   unlinkSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 
 export const NATIVE_REDIRECT_PATH =
@@ -45,17 +41,11 @@ export function setNativeRedirect(slug) {
   const value = String(slug || "").trim();
   if (!value) throw new Error("A routed model slug is required.");
 
-  const stateDir = path.dirname(NATIVE_REDIRECT_PATH);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  chmodSync(stateDir, 0o700);
-  const temporary = `${NATIVE_REDIRECT_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify({ version: 1, model: value }, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, NATIVE_REDIRECT_PATH);
-  protectPrivateFile(NATIVE_REDIRECT_PATH);
+  writePrivateJson(
+    NATIVE_REDIRECT_PATH,
+    { version: 1, model: value },
+    { directoryMode: 0o700 },
+  );
   return nativeRedirectSnapshot();
 }
 

--- a/src/ollama-runtime.mjs
+++ b/src/ollama-runtime.mjs
@@ -6,14 +6,12 @@ import {
   openSync,
   readFileSync,
   realpathSync,
-  renameSync,
   unlinkSync,
-  writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 import { processStartIdentity, stateOwnsProcess } from "./process-identity.mjs";
 
@@ -123,19 +121,6 @@ export async function probeOllama({
       error: error instanceof Error ? error.message : String(error),
     };
   }
-}
-
-function writePrivateJson(target, value) {
-  mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
-  const temporary = `${target}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, target);
-  protectPrivateFile(target);
-  return value;
 }
 
 export function readOllamaRuntimeState() {

--- a/src/presence-state.mjs
+++ b/src/presence-state.mjs
@@ -1,14 +1,10 @@
 import {
-  chmodSync,
   existsSync,
-  mkdirSync,
   readFileSync,
-  renameSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { DSH_CATALOG_PATH, STATE_DIR } from "./paths.mjs";
 import { commandOnPath } from "./spawnable-command.mjs";
 
@@ -96,16 +92,6 @@ export function setPresenceMode(mode) {
     throw new Error(`Presence mode must be one of: ${PRESENCE_MODES.join(", ")}.`);
   }
 
-  const stateDir = path.dirname(PRESENCE_STATE_PATH);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  chmodSync(stateDir, 0o700);
-  const temporary = `${PRESENCE_STATE_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify({ version: 1, mode: value }, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, PRESENCE_STATE_PATH);
-  protectPrivateFile(PRESENCE_STATE_PATH);
+  writePrivateJson(PRESENCE_STATE_PATH, { version: 1, mode: value }, { directoryMode: 0o700 });
   return presenceSnapshot();
 }

--- a/src/tool-result-aging-state.mjs
+++ b/src/tool-result-aging-state.mjs
@@ -1,14 +1,10 @@
 import {
-  chmodSync,
   existsSync,
-  mkdirSync,
   readFileSync,
-  renameSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 import { toolResultAgingTotals } from "./usage-events.mjs";
 
@@ -53,17 +49,7 @@ export function readToolResultAgingSettings() {
 }
 
 function writeSettings(settings) {
-  const stateDir = path.dirname(TOOL_RESULT_AGING_STATE_PATH);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  chmodSync(stateDir, 0o700);
-  const temporary = `${TOOL_RESULT_AGING_STATE_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify(settings, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, TOOL_RESULT_AGING_STATE_PATH);
-  protectPrivateFile(TOOL_RESULT_AGING_STATE_PATH);
+  writePrivateJson(TOOL_RESULT_AGING_STATE_PATH, settings, { directoryMode: 0o700 });
   return settings;
 }
 

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -1,7 +1,7 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 
 // User-curated models live outside the checked-in config/ registry tree so a checkout update
@@ -78,19 +78,6 @@ export function readUserModels() {
 }
 
 export function writeUserModels(models) {
-  mkdirSync(path.dirname(USER_MODELS_PATH), { recursive: true, mode: 0o700 });
-  const temporary = `${USER_MODELS_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify({ version: 1, models }, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  try {
-    protectPrivateFile(temporary);
-    renameSync(temporary, USER_MODELS_PATH);
-    protectPrivateFile(USER_MODELS_PATH);
-  } catch (error) {
-    if (existsSync(temporary)) unlinkSync(temporary);
-    throw error;
-  }
+  writePrivateJson(USER_MODELS_PATH, { version: 1, models });
   return USER_MODELS_PATH;
 }

--- a/src/vision-benchmark.mjs
+++ b/src/vision-benchmark.mjs
@@ -1,5 +1,7 @@
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
+
+import { writePrivateJson } from "./file-security.mjs";
 import { fileURLToPath } from "node:url";
 
 import { SOURCE_ROOT, STATE_DIR } from "./paths.mjs";
@@ -87,13 +89,7 @@ export function readBenchmarkResults() {
 
 export function saveBenchmarkResult(tag, result) {
   const results = { ...readBenchmarkResults(), [tag]: result };
-  mkdirSync(path.dirname(BENCHMARK_RESULTS_PATH), { recursive: true, mode: 0o700 });
-  const temporary = `${BENCHMARK_RESULTS_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify({ version: 1, results })}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  renameSync(temporary, BENCHMARK_RESULTS_PATH);
+  writePrivateJson(BENCHMARK_RESULTS_PATH, { version: 1, results });
   return results;
 }
 

--- a/src/vision-bridge-state.mjs
+++ b/src/vision-bridge-state.mjs
@@ -1,14 +1,10 @@
 import {
-  chmodSync,
   existsSync,
-  mkdirSync,
   readFileSync,
-  renameSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 
 export const VISION_BRIDGE_STATE_PATH =
@@ -130,17 +126,7 @@ export function readVisionBridgeSettings() {
 }
 
 function writeSettings(settings) {
-  const stateDir = path.dirname(VISION_BRIDGE_STATE_PATH);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  chmodSync(stateDir, 0o700);
-  const temporary = `${VISION_BRIDGE_STATE_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify(settings, null, 2)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, VISION_BRIDGE_STATE_PATH);
-  protectPrivateFile(VISION_BRIDGE_STATE_PATH);
+  writePrivateJson(VISION_BRIDGE_STATE_PATH, settings, { directoryMode: 0o700 });
   return settings;
 }
 

--- a/src/vision-download.mjs
+++ b/src/vision-download.mjs
@@ -1,15 +1,11 @@
 import {
-  chmodSync,
   existsSync,
-  mkdirSync,
   readFileSync,
-  renameSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { protectPrivateFile } from "./file-security.mjs";
+import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 import { DEFAULT_LOCAL_VISION_BASE_URL } from "./vision-bridge.mjs";
 
@@ -34,17 +30,7 @@ export function readVisionDownload() {
 }
 
 export function writeVisionDownload(state) {
-  const stateDir = path.dirname(VISION_DOWNLOAD_STATE_PATH);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  chmodSync(stateDir, 0o700);
-  const temporary = `${VISION_DOWNLOAD_STATE_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, `${JSON.stringify(state)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-  });
-  protectPrivateFile(temporary);
-  renameSync(temporary, VISION_DOWNLOAD_STATE_PATH);
-  protectPrivateFile(VISION_DOWNLOAD_STATE_PATH);
+  writePrivateJson(VISION_DOWNLOAD_STATE_PATH, state, { space: 0, directoryMode: 0o700 });
   return state;
 }
 

--- a/test/file-security.test.mjs
+++ b/test/file-security.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -8,8 +8,22 @@ import test from "node:test";
 import {
   privateFileIsProtected,
   protectPrivateFile,
+  writePrivateJson,
   windowsFullControlGrant,
 } from "../src/file-security.mjs";
+
+test("private JSON state uses one owner-only atomic writer", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-private-json-"));
+  const target = path.join(directory, "state.json");
+  const value = { version: 1, enabled: true };
+  try {
+    assert.deepEqual(writePrivateJson(target, value, { directoryMode: 0o700 }), value);
+    assert.deepEqual(JSON.parse(readFileSync(target, "utf8")), value);
+    if (process.platform !== "win32") assert.equal(statSync(target).mode & 0o777, 0o600);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
 
 test("Windows numeric SID grants use the icacls SID prefix", () => {
   assert.equal(


### PR DESCRIPTION
**Shared private JSON writer**

Adds one atomic owner-only writer for private JSON state.

This removes repeated temporary-file and permission code while keeping the same file format and cleanup behavior.

Validation:
- `npm run check`
- `npm test`
- State and security tests
