### PR TITLE
chore: remove dead catalog helper

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -523,10 +523,6 @@ export function routedModel(template, model) {
   return next;
 }
 
-export function applyAllMultiAgent(models, enabled) {
-  return models;
-}
-
 export const AUTO_ANNOUNCE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 function formatTokenCount(tokens) {

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -12,7 +12,6 @@ import test from "node:test";
 import {
   AUTO_ANNOUNCE_WINDOW_MS,
   annotateNewModelAnnouncements,
-  applyAllMultiAgent,
   buildMergedCatalog,
   buildLoginFreeCatalog,
   clampModelEfforts,
@@ -308,19 +307,6 @@ test("unverified routed models retain conservative v1 collaboration", () => {
     multiAgentVersion: undefined,
   });
   assert.equal(model.multi_agent_version, "v1");
-});
-
-test("all-models multi-agent mode cannot manufacture v2 capability", () => {
-  const models = [
-    { slug: "opencode-go/deepseek-v4-flash" },
-    { slug: "qwen-plan/qwen3.8-max", multiAgentVersion: "v1" },
-  ];
-  const promoted = applyAllMultiAgent(models, true);
-  assert.deepEqual(
-    promoted.map((model) => model.multiAgentVersion),
-    [undefined, "v1"],
-  );
-  assert.equal(applyAllMultiAgent(models, false), models);
 });
 
 test("merged catalog preserves native GPT identity while rewriting routed models", () => {


### PR DESCRIPTION
**Remove dead catalog helper**

Removes an unused no-op multi-agent helper from the catalog.

The real multi-agent implementation remains in the shared state module.

Validation:
- `npm run check`
- `node --test test/catalog.test.mjs`
