### PR TITLE
docs: check bin scripts by language

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -121,7 +121,12 @@ npm ci
 npm run check
 npm test
 sh -n install.sh
-for file in bin/*; do sh -n "$file"; done
+for file in bin/*; do
+  case "$file" in
+    *.mjs) node --check "$file" ;;
+    *) sh -n "$file" ;;
+  esac
+done
 npm audit --omit=dev
 ```
 


### PR DESCRIPTION
**Fix script checks in development docs**

The test instructions now use `node --check` for Node scripts in `bin/` and `sh -n` for shell scripts.

This keeps the documented checks aligned with the repository.

Validation:
- The documented `bin/` check loop
- `sh -n install.sh`
- `npm run check`
