### PR TITLE
fix: repair a nullable object root on every tool, not just namespaced ones

### DIFF
--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -97,6 +97,37 @@ export function injectSessionModelForSpawnCalls(item, model) {
 
 const MAX_JSON_CAPTURE_BYTES = 64 * 1024 * 1024;
 
+// Repair one tool's parameter root, or return it untouched. Providers reject a
+// union or nullable-object root by name -- xAI, DeepSeek V4, and the
+// opencode-go Responses surface all do -- and none of them care whether the
+// tool arrived inside a namespace. `providerToolSchema` returns anything it
+// does not recognize by identity, so an ordinary root costs one call and no
+// copy.
+export function repairToolSchemaRoot(tool) {
+  const parameters = tool?.function?.parameters ?? tool?.parameters;
+  if (parameters === undefined) return tool;
+  const repaired = providerToolSchema(parameters);
+  if (repaired === parameters) return tool;
+  return tool.function
+    ? { ...tool, function: { ...tool.function, parameters: repaired } }
+    : { ...tool, parameters: repaired };
+}
+
+// Array form for callers that relay tools without flattening them --
+// Responses-native providers keep the namespace shape but still need a root
+// their upstream accepts. Returns the original array when nothing needed
+// repair, so the common request is not copied.
+export function repairToolSchemaRoots(tools) {
+  if (!Array.isArray(tools)) return tools;
+  let changed = false;
+  const repaired = tools.map((tool) => {
+    const next = repairToolSchemaRoot(tool);
+    if (next !== tool) changed = true;
+    return next;
+  });
+  return changed ? repaired : tools;
+}
+
 // Flatten every namespace entry into plain functions named
 // `<namespace>__<tool>`. Returns the set of namespaces that were flattened
 // (name -> tool names) so callers can rename history and restore calls.
@@ -162,22 +193,9 @@ export function flattenNamespaceTools(tools) {
     // the flattened children left every client-declared tool to fail on the
     // provider that objects. `providerToolSchema` returns anything it does not
     // recognize unchanged, so a tool with an ordinary root is not copied.
-    const parameters = tool?.function?.parameters ?? tool?.parameters;
-    if (parameters === undefined) {
-      flattened.push(tool);
-      continue;
-    }
-    const repaired = providerToolSchema(parameters);
-    if (repaired === parameters) {
-      flattened.push(tool);
-      continue;
-    }
-    changed = true;
-    flattened.push(
-      tool.function
-        ? { ...tool, function: { ...tool.function, parameters: repaired } }
-        : { ...tool, parameters: repaired },
-    );
+    const repaired = repairToolSchemaRoot(tool);
+    if (repaired !== tool) changed = true;
+    flattened.push(repaired);
   }
   if (spawnAgentModels.size > 0) SPAWN_AGENT_MODELS.set(namespaces, spawnAgentModels);
   return { tools: flattened, flattened: changed, namespaces };

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -154,7 +154,30 @@ export function flattenNamespaceTools(tools) {
       }
       continue;
     }
-    flattened.push(tool);
+    // A plain function tool needs the same repair as a namespaced one. The
+    // rejections are the provider's, not the namespace's: DeepSeek V4 Flash and
+    // Pro both 400 a `type: ["object","null"]` root with "schema must be a JSON
+    // Schema of 'type: \"object\"'", and xAI rejects a union root the same way,
+    // whether the tool arrived inside a namespace or on its own. Repairing only
+    // the flattened children left every client-declared tool to fail on the
+    // provider that objects. `providerToolSchema` returns anything it does not
+    // recognize unchanged, so a tool with an ordinary root is not copied.
+    const parameters = tool?.function?.parameters ?? tool?.parameters;
+    if (parameters === undefined) {
+      flattened.push(tool);
+      continue;
+    }
+    const repaired = providerToolSchema(parameters);
+    if (repaired === parameters) {
+      flattened.push(tool);
+      continue;
+    }
+    changed = true;
+    flattened.push(
+      tool.function
+        ? { ...tool, function: { ...tool.function, parameters: repaired } }
+        : { ...tool, parameters: repaired },
+    );
   }
   if (spawnAgentModels.size > 0) SPAWN_AGENT_MODELS.set(namespaces, spawnAgentModels);
   return { tools: flattened, flattened: changed, namespaces };

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -54,6 +54,7 @@ import {
   NamespaceToolCallTransform,
   flattenNamespacedHistory,
   flattenNamespaceTools,
+  repairToolSchemaRoots,
 } from "./namespace-relay.mjs";
 import { pendingInterruptTargets } from "./subagent-completion.mjs";
 import { mergeCodexAppTools } from "./codex-app-tools.mjs";
@@ -1845,6 +1846,12 @@ async function handleResponses(request, response, requestUrl) {
         // spawn_agent model enum off it to drop an invented or stale optional
         // override before Codex validates the call.
         flattenedNamespaces = flattenNamespaceTools(payload.tools).namespaces;
+        // Keeping the namespace shape is not the same as keeping a root the
+        // upstream rejects. `opencode-go-responses/gpt-5.6-luna` 400s a
+        // `type: ["object","null"]` parameter root while accepting the same
+        // request with a plain or union root -- so the strict-root repair has to
+        // run here too, on the tools alone, without flattening anything.
+        payload.tools = repairToolSchemaRoots(payload.tools);
       }
       let routedInput = input;
       // The stored call history must use the same tool names as the tool

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -65,10 +65,19 @@ function hasRootUnion(schema) {
 // say `type: "object"` and still be rejected for carrying a `oneOf` beside it.
 // Checking only `type`/`properties` here is what let the live client's
 // `automation_update` -- which sends both -- through untouched.
+//
+// A declared type is read literally, which is why a nullable root is not an
+// object root. `type: ["object", "null"]` is a legal JSON Schema object that
+// also permits null, and xAI rejects it with the same
+// `tool parameter root must be an object type` as a union -- verified against
+// the live backend. Only the exact string passes; a declared type that is
+// anything else sends the schema down the rewrite path, and the `properties`
+// fallback is left for schemas that declare no type at all.
 export function hasObjectRoot(schema) {
   if (!isPlainObject(schema)) return false;
   if (hasRootUnion(schema)) return false;
-  return schema.type === "object" || isPlainObject(schema.properties);
+  if (schema.type !== undefined) return schema.type === "object";
+  return isPlainObject(schema.properties);
 }
 
 // Returns `schema` unchanged when its root is already a plain object, so the
@@ -110,8 +119,13 @@ export function objectRootToolSchema(schema) {
     properties,
     ...(required.length ? { required } : {}),
     // The merged object cannot describe which branch a call belongs to, so it
-    // must not reject fields that only one branch declares.
-    additionalProperties: true,
+    // must not reject fields that only one branch declares. A root that was
+    // rewritten without merging anything -- a nullable `type: ["object","null"]`
+    // becoming plain `"object"` -- has no such ambiguity, so it keeps whatever
+    // it declared rather than being quietly opened up.
+    ...(unionBranches.length || schema.additionalProperties === undefined
+      ? { additionalProperties: true }
+      : { additionalProperties: schema.additionalProperties }),
   };
 }
 
@@ -234,8 +248,28 @@ export function normalizeSchemaLiterals(schema, depth = 0) {
 // tool, where a server-defined schema that merely looks unusual would be
 // silently replaced with one accepting anything. Only a union root is the
 // documented strict-upstream rejection, so only a union root is rewritten.
+// A root `type` array that offers "object" among others -- the nullable object
+// root. Narrow on purpose: an array that cannot be an object at all is left
+// alone, because collapsing it would replace a real schema with one accepting
+// anything, which is the trade this function exists to avoid.
+function hasNullableObjectRoot(schema) {
+  return Array.isArray(schema.type) && schema.type.includes("object");
+}
+
 export function providerToolSchema(schema) {
   const normalized = normalizeSchemaLiterals(schema);
-  if (!isPlainObject(normalized) || !hasRootUnion(normalized)) return normalized;
+  if (!isPlainObject(normalized)) return normalized;
+  // Two independent upstreams reject a nullable object root by name, which is
+  // what promotes it from "unusual" to documented alongside the union:
+  //
+  //   xAI:      tool parameter root must be an object type
+  //   DeepSeek: schema must be a JSON Schema of 'type: "object"',
+  //             got 'type: ["object","null"]'
+  //
+  // Both were reproduced live. The repair is lossless here -- properties,
+  // required and additionalProperties all survive -- because only the root's
+  // own `null` alternative is dropped, and a tool call whose entire argument
+  // object is null is not a call any of these providers can dispatch.
+  if (!hasRootUnion(normalized) && !hasNullableObjectRoot(normalized)) return normalized;
   return objectRootToolSchema(normalized);
 }

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -662,3 +662,50 @@ test("flattened parameters drop literals that contradict their declared type", (
   const flattened = tools.find((tool) => tool.name === "codex_app__automation_update");
   assert.equal("enum" in flattened.parameters.properties.enabled, false);
 });
+
+// A plain function tool reaches the provider with the same root a namespaced
+// one does, and the providers that object do not care which it was. DeepSeek V4
+// (Flash and Pro) both 400 a `type: ["object","null"]` root -- "schema must be a
+// JSON Schema of 'type: \"object\"'" -- and xAI rejects a union root, both
+// reproduced live. Repairing only the flattened children left every
+// client-declared tool to fail on those providers.
+test("a plain function tool's union root is repaired too", () => {
+  const { tools, flattened } = flattenNamespaceTools([
+    {
+      type: "function",
+      function: {
+        name: "plain",
+        parameters: {
+          oneOf: [
+            { type: "object", properties: { a: { type: "string" } }, required: ["a"] },
+            { type: "object", properties: { b: { type: "string" } }, required: ["a"] },
+          ],
+        },
+      },
+    },
+  ]);
+  assert.equal(flattened, true);
+  assert.equal(tools[0].function.parameters.type, "object");
+  assert.equal(tools[0].function.parameters.oneOf, undefined);
+  assert.deepEqual(Object.keys(tools[0].function.parameters.properties), ["a", "b"]);
+});
+
+test("a plain function tool's nullable root is repaired too", () => {
+  const { tools, flattened } = flattenNamespaceTools([
+    { type: "function", name: "plain", parameters: { type: ["object", "null"], properties: { a: {} } } },
+  ]);
+  assert.equal(flattened, true);
+  assert.equal(tools[0].parameters.type, "object");
+});
+
+// The repair must not copy a tool it had nothing to fix: an ordinary root is
+// the overwhelming majority, and a needless rewrite is a needless risk.
+test("an ordinary function tool is passed through by identity", () => {
+  const tool = {
+    type: "function",
+    function: { name: "plain", parameters: { type: "object", properties: { a: {} } } },
+  };
+  const { tools, flattened } = flattenNamespaceTools([tool]);
+  assert.equal(tools[0], tool);
+  assert.equal(flattened, false);
+});

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -9,6 +9,7 @@ import {
   flattenNamespaceTools,
   rewriteNamespaceFunctionCall,
   rewriteNamespaceResponsePayload,
+  repairToolSchemaRoots,
 } from "../src/namespace-relay.mjs";
 import { mergeCodexAppTools } from "../src/codex-app-tools.mjs";
 
@@ -708,4 +709,25 @@ test("an ordinary function tool is passed through by identity", () => {
   const { tools, flattened } = flattenNamespaceTools([tool]);
   assert.equal(tools[0], tool);
   assert.equal(flattened, false);
+});
+
+// Responses-native providers keep the namespace shape, so their tools never go
+// through the flattening path -- but they still reach an upstream with a root
+// it may reject. `opencode-go-responses/gpt-5.6-luna` 400s a
+// `type: ["object","null"]` root while accepting the same request with a plain
+// or union root, so the repair has to be available without flattening.
+test("repairToolSchemaRoots fixes roots without flattening", () => {
+  const tools = [
+    { type: "function", name: "nullable", parameters: { type: ["object", "null"], properties: { a: {} } } },
+    { type: "namespace", name: "codex_app", tools: [{ name: "child", inputSchema: { type: "object" } }] },
+  ];
+  const repaired = repairToolSchemaRoots(tools);
+  assert.equal(repaired[0].parameters.type, "object");
+  // The namespace entry keeps its native shape; only roots are touched.
+  assert.equal(repaired[1], tools[1]);
+});
+
+test("repairToolSchemaRoots returns the original array when nothing needs repair", () => {
+  const tools = [{ type: "function", name: "fine", parameters: { type: "object", properties: { a: {} } } }];
+  assert.equal(repairToolSchemaRoots(tools), tools);
 });

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -234,3 +234,74 @@ test("literals are still normalized inside a schema that keeps its root", () => 
   assert.equal(normalized.type, "array");
   assert.deepEqual(normalized.items.enum, ["ok"]);
 });
+
+// xAI reads the root `type` literally. A nullable object root is legal JSON
+// Schema and is rejected with the same `tool parameter root must be an object
+// type` as a union -- confirmed against the live backend, where
+// `type: ["object", "null"]` 400s and plain `"object"` does not.
+test("a nullable object root is rewritten to a plain object root", () => {
+  const rewritten = objectRootToolSchema({
+    type: ["object", "null"],
+    properties: { id: { type: "string" } },
+    required: ["id"],
+  });
+  assert.equal(rewritten.type, "object");
+  assert.deepEqual(Object.keys(rewritten.properties), ["id"]);
+  assert.deepEqual(rewritten.required, ["id"]);
+});
+
+test("hasObjectRoot rejects a declared type that is not exactly object", () => {
+  assert.equal(hasObjectRoot({ type: ["object", "null"], properties: { id: {} } }), false);
+  assert.equal(hasObjectRoot({ type: "object", properties: { id: {} } }), true);
+  // No declared type at all still falls back to `properties`, which xAI accepts.
+  assert.equal(hasObjectRoot({ properties: { id: {} } }), true);
+});
+
+// Rewriting a root that merged nothing has no branch ambiguity to paper over,
+// so it must not quietly widen a schema that closed itself.
+test("a rewrite that merged no union keeps its own additionalProperties", () => {
+  const closed = objectRootToolSchema({
+    type: ["object", "null"],
+    properties: { id: {} },
+    additionalProperties: false,
+  });
+  assert.equal(closed.additionalProperties, false);
+  const merged = objectRootToolSchema({
+    oneOf: [
+      { type: "object", properties: { a: {} } },
+      { type: "object", properties: { b: {} } },
+    ],
+  });
+  assert.equal(merged.additionalProperties, true);
+});
+
+// A nullable object root is rejected by name by two independent upstreams --
+// xAI ("tool parameter root must be an object type") and DeepSeek ("schema must
+// be a JSON Schema of 'type: \"object\"', got 'type: [\"object\",\"null\"]'") --
+// both reproduced live, so the shared relay repairs it for every provider.
+test("the shared relay repairs a nullable object root", () => {
+  const repaired = providerToolSchema({
+    type: ["object", "null"],
+    properties: { id: { type: "string" } },
+    required: ["id"],
+    additionalProperties: false,
+  });
+  assert.equal(repaired.type, "object");
+  assert.deepEqual(Object.keys(repaired.properties), ["id"]);
+  assert.deepEqual(repaired.required, ["id"]);
+  // Nothing was merged, so the schema keeps the door it closed.
+  assert.equal(repaired.additionalProperties, false);
+});
+
+// Still narrow: the relay runs on every namespace and MCP tool, so a root it
+// merely finds unusual must survive untouched rather than be replaced with one
+// that accepts anything.
+test("the shared relay leaves other roots alone", () => {
+  const plain = { type: "object", properties: { id: {} } };
+  assert.equal(providerToolSchema(plain), plain);
+  const typeless = { properties: { id: {} } };
+  assert.equal(providerToolSchema(typeless), typeless);
+  // No "object" member means collapsing it would destroy the schema, not fix it.
+  const notObject = { type: ["string", "null"] };
+  assert.equal(providerToolSchema(notObject), notObject);
+});


### PR DESCRIPTION
Found while verifying #219. **That issue is already fixed on `main`** — confirmed live by deleting the sanitizer and reproducing the reporter's exact error — but probing the sanitizer with adversarial roots turned up one it lets through.

## The bug

A tool whose parameter root is `type: ["object", "null"]` is legal JSON Schema and is rejected **by name** by two independent upstreams. Both reproduced against the real backends:

| Upstream | Message |
|---|---|
| xAI | `tool parameter root must be an object type` |
| DeepSeek | `schema must be a JSON Schema of 'type: "object"', got 'type: ["object","null"]'` |

`hasObjectRoot` let it through because the root carried `properties`, so the declared type was never consulted.

## What changed

1. **`hasObjectRoot` reads a declared type literally** — only the exact string `"object"` passes. The `properties` fallback stays for schemas declaring no type at all, which xAI accepts (verified live).
2. **The shared relay repairs it too.** `providerToolSchema` is deliberately narrow because it runs on every namespace and MCP tool, and a schema that merely looks unusual must not be replaced with one accepting anything. A second upstream rejecting a nullable root *by name* is what promotes it from unusual to documented, alongside the union root already handled. A `type: ["string","null"]` root — no `"object"` member — is still left alone, since collapsing it would destroy the schema rather than fix it.
3. **Both repairs now reach plain function tools**, not only namespaced children. The rejections are the provider's, not the namespace's, so a client-declared tool with a union or nullable root failed on exactly the providers that object while the namespaced copy beside it was repaired. A tool needing nothing is passed through by identity, uncopied.
4. **A rewrite that merged no union keeps its own `additionalProperties`.** That `true` default exists because a merged object cannot say which branch a call belongs to; a nullable root becoming a plain object has no such ambiguity and should not be quietly widened.

The repair is lossless: properties, required and additionalProperties all survive, and only the root's own `null` alternative is dropped — a tool call whose entire argument object is null is not one any of these providers can dispatch.

## Measured live, before and after

|  | plain | nullable | union |
|---|---|---|---|
| `deepseek-v4-flash` | pass | **400 → pass** | pass |
| `deepseek-v4-pro` | pass | **400 → pass** | pass |
| `grok-4.6` | pass | **400 → pass** | pass |
| `glm-5.2` | pass | pass | pass |
| `minimax-m3` | pass | pass | pass |

Qwen could not be tested — the plan is out of quota. Kimi likewise (HTTP 403).

## Test plan

- [x] `npm test` — 1209 passed, 0 failed
- [x] `npm run check` — syntax checks pass
- [x] 8 new tests across `tool-schema-root` and `namespace-relay`: the nullable root, the literal-type rule, `additionalProperties` preservation, the narrowness guard (`type: ["string","null"]` untouched), plain-tool repair for both union and nullable roots, and identity pass-through
- [x] Live re-sweep through the running router after the change: all five reachable providers pass all three shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBkowYuJbJihuKStRH3K9H