### PR TITLE
feat: research any enabled model for the v2 subagent role automatically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,7 +342,10 @@ so the unit of evidence is always the slug, never the model name.
 1. Enabling a non-registry-v2 model hands it to a detached capability probe
    (`src/subagent-verify.mjs`): two live requests through the installed router
    proving streaming and a forced tool call. The proofs snapshot shows
-   `checking` until the verdict lands and the catalog republishes.
+   `checking` until the verdict lands and the catalog republishes. A worker
+   that dies without a verdict marks its slugs `failed` on the way out, and a
+   `checking` older than the probe ceiling is treated as abandoned — so
+   switching a wedged model off and on always re-researches it.
 2. A passing model is advertised to Codex as an **experimental** v2 subagent,
    recorded in the protected `multi-agent-proofs.json`. The first real child
    turn settles it: Codex marks child turns with `x-openai-subagent`, and the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,38 @@ to ship tested support to every installer.
 If the provider itself is unknown to the registry, stop treating the request as
 installation. It is repository development and requires the process below.
 
+### Subagent capability is researched, not asserted
+
+Switching a model on as a subagent (tray toggle, `control subagents set`) is
+the operator's whole job; deciding whether that model **under that provider**
+can hold the v2 child role is the router's. The same model answers differently
+per provider — tool support, request profiles, and payload handling all vary —
+so the unit of evidence is always the slug, never the model name.
+
+1. Enabling a non-registry-v2 model hands it to a detached capability probe
+   (`src/subagent-verify.mjs`): two live requests through the installed router
+   proving streaming and a forced tool call. The proofs snapshot shows
+   `checking` until the verdict lands and the catalog republishes.
+2. A passing model is advertised to Codex as an **experimental** v2 subagent,
+   recorded in the protected `multi-agent-proofs.json`. The first real child
+   turn settles it: Codex marks child turns with `x-openai-subagent`, and the
+   router's own request path records a clean completion as the durable proof
+   (`proven`) or a structural rejection — HTTP 400/422 — as a demotion back to
+   v1 with the reason kept where it was switched on. Transient failures (429,
+   5xx, disconnects) prove nothing and leave the window open.
+3. Local settings still never manufacture a v2 claim. The only writers of
+   promotion evidence are the probe worker and the router's observation of
+   real traffic; an unreadable proofs file promotes nothing, and a hidden or
+   switched-off slug stays v1 whatever evidence it carries.
+4. `control subagents verify [SLUG ...]` re-researches explicitly (foreground,
+   ~2 requests per candidate); with no slugs it sweeps the enabled list.
+   Select-all and mode changes never trigger probes — a sweep across every
+   provider is quota the operator must ask for.
+5. Machine-local proofs are exactly that. Shipping a default to every
+   installer still requires the full native collaboration proof and a registry
+   change (below); never edit the checked-in `config/` tree because one
+   machine's probe passed.
+
 ### Ship a model to every installer
 
 1. Run `./bin/discover-models PROVIDER`; discovery is read-only. Confirm the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **Switching a model on as a subagent now researches it instead of ignoring
+  it.** Only six registry-proven models could ever be spawned as native v2
+  children; everything else the operator enabled was a silent no-show, and
+  promoting one more meant a repository change per model per provider. Now the
+  toggle is the assignment: enabling a model hands it to a detached capability
+  probe (two live requests proving streaming and a forced tool call through
+  the installed router), a passing model is advertised to Codex as an
+  experimental subagent, and the first real child turn settles the verdict —
+  the router watches its own request path for `x-openai-subagent` turns, and a
+  clean completion records a durable machine-local proof while a structural
+  rejection demotes the model back to v1 with the reason kept in the subagent
+  snapshot. Evidence lives in the protected `multi-agent-proofs.json`; local
+  settings still cannot manufacture a v2 claim, hidden or switched-off models
+  stay v1 whatever evidence they carry, and `control subagents verify` re-runs
+  the research explicitly.
+
 - **A reasoning model no longer answers into thirty seconds of silence.** The
   empty-completion guard buffered every routed streaming response until it saw
   content, and reasoning deltas deliberately did not count as content. On a

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -29,6 +29,7 @@ import {
   readMultiAgentSettings,
   subagentEligibleModels,
 } from "./multi-agent-state.mjs";
+import { applySubagentProofs, subagentProofSnapshot } from "./subagent-proofs.mjs";
 import { readHiddenModels } from "./model-picker-state.mjs";
 import { buildNativeAliasAssignments } from "./native-alias.mjs";
 import { selectedConfiguredListedModels, configuredProviderIds } from "./provider-selection.mjs";
@@ -704,10 +705,14 @@ function main() {
   const hiddenModels = readHiddenModels();
   const selectedModels = selectedConfiguredListedModels();
   const multiAgentSettings = readMultiAgentSettings();
-  const allMultiAgentModels = applyMultiAgentSettings(
-    selectedModels,
-    multiAgentSettings,
-    hiddenModels,
+  // Demotions first, then this machine's own recorded proofs. Settings still
+  // never manufacture a v2 claim — a promotion here traces to a live probe
+  // or an observed spawn in `multi-agent-proofs.json` — and a slug the
+  // operator hid or switched off stays v1 whatever evidence it carries.
+  const allMultiAgentModels = applySubagentProofs(
+    applyMultiAgentSettings(selectedModels, multiAgentSettings, hiddenModels),
+    subagentProofSnapshot(),
+    { hidden: hiddenModels, disabled: multiAgentSettings.disabled },
   );
   // Clamp before announcements and agent sync so every surface Codex reads —
   // picker levels, defaults, and announcement copy — stays inside the effort

--- a/src/compatibility-test.mjs
+++ b/src/compatibility-test.mjs
@@ -125,6 +125,28 @@ async function compaction(model) {
   };
 }
 
+// The two capabilities a Codex spawn actually exercises, and nothing else:
+// a child turn is a streamed conversation driven by tool calls, so a model
+// that streams and answers a forced tool call can hold the child role. Basic
+// text and compaction stay out — this probe runs automatically when a model
+// is switched on as a subagent, and two requests is its whole quota budget.
+export async function subagentCapabilityProbe(model) {
+  if (!MODEL_BY_SLUG.has(model)) throw new Error(`Unknown registry model: ${model}`);
+  const checks = [
+    { name: "tool calling", ...(await toolCall(model)) },
+    { name: "streaming", ...(await streaming(model)) },
+  ];
+  return {
+    model,
+    ok: checks.every((check) => check.ok),
+    checks,
+    detail: checks
+      .filter((check) => !check.ok)
+      .map((check) => `${check.name}: ${check.detail}`)
+      .join("; "),
+  };
+}
+
 export async function compatibilityTest(model, options = {}) {
   if (!MODEL_BY_SLUG.has(model)) throw new Error(`Unknown registry model: ${model}`);
   const results = [];

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -741,7 +741,7 @@ async function knownModelSlug(slug) {
   return MODEL_BY_SLUG.has(slug);
 }
 
-async function handleSubagents(action, value, flag) {
+async function handleSubagents(action, value, flag, rest = []) {
   const {
     replaceMultiAgentState,
     setMultiAgentMode,
@@ -769,6 +769,19 @@ async function handleSubagents(action, value, flag) {
     });
   } else if (action === "mode") {
     setMultiAgentMode(value);
+  } else if (action === "verify") {
+    // Explicit re-research: probe the named slugs (or every enabled one) in
+    // the foreground and print the verdicts. Spends ~2 live requests per
+    // candidate on that model's own provider.
+    const { verifySubagentCandidates } = await import("./subagent-verify.mjs");
+    const targets = rest.filter(Boolean);
+    const sweep = targets.length
+      ? targets
+      : subagentSettingsSnapshot().enabled;
+    const verified = await verifySubagentCandidates(sweep, { force: targets.length > 0 });
+    refreshModelSettingsCatalog();
+    process.stdout.write(`${JSON.stringify({ verified })}\n`);
+    return;
   } else if (action === "set") {
     if (!["on", "off"].includes(flag)) {
       throw new Error("Usage: control subagents set <model-slug> <on|off>");
@@ -777,6 +790,14 @@ async function handleSubagents(action, value, flag) {
       throw new Error(`Unknown model slug: ${value}`);
     }
     setMultiAgentModel(value, flag === "on");
+    // Selection is the assignment: switching a model on hands it to the
+    // capability probe. Detached, because this command answers a tray toggle
+    // and cannot sit on a live network round-trip; the proofs snapshot shows
+    // "checking" until the worker records a verdict and republishes.
+    if (flag === "on") {
+      const { spawnDetachedVerification } = await import("./subagent-verify.mjs");
+      spawnDetachedVerification([value]);
+    }
   } else if (action === "provider") {
     if (!["on", "off"].includes(flag)) {
       throw new Error("Usage: control subagents provider <provider-id> <on|off>");
@@ -792,10 +813,14 @@ async function handleSubagents(action, value, flag) {
       throw new Error(`No enabled models found for provider: ${value}`);
     }
     setMultiAgentModels(slugs, flag === "on");
+    if (flag === "on") {
+      const { spawnDetachedVerification } = await import("./subagent-verify.mjs");
+      spawnDetachedVerification(slugs);
+    }
   } else {
     throw new Error(
       "Usage: control subagents status|select-all|unselect-all|mode <all|selected|proven>|" +
-        "set <model-slug> <on|off>|provider <provider-id> <on|off>",
+        "set <model-slug> <on|off>|provider <provider-id> <on|off>|verify [model-slug ...]",
     );
   }
   refreshModelSettingsCatalog();
@@ -1614,7 +1639,7 @@ if (args.includes("--probe")) {
 } else if (args[0] === "model-set") {
   await setLoginFreeModel(args[1]);
 } else if (args[0] === "subagents") {
-  await handleSubagents(args[1], args[2], args[3]);
+  await handleSubagents(args[1], args[2], args[3], args.slice(2));
 } else if (args[0] === "tool-result-aging") {
   await handleToolResultAging(args[1], args[2]);
 } else if (args[0] === "local-models") {

--- a/src/dsh-config-manager.mjs
+++ b/src/dsh-config-manager.mjs
@@ -38,6 +38,7 @@ import {
 } from "./dsh-catalog.mjs";
 import { readHiddenModels } from "./model-picker-state.mjs";
 import { readMultiAgentSettings, subagentEligibleModels } from "./multi-agent-state.mjs";
+import { applySubagentProofs, subagentProofSnapshot } from "./subagent-proofs.mjs";
 import { selectedConfiguredListedModels } from "./provider-selection.mjs";
 import { assertStateOwnership } from "./state-owner.mjs";
 import { nativeSessionAvailable } from "./codex-native-session.mjs";
@@ -269,8 +270,14 @@ function readNativeCatalogModels() {
 /** The routed models the harness should be offered, vision bridge included. */
 export function dshRoutedModels() {
   const hidden = readHiddenModels();
-  const selected = selectedConfiguredListedModels().filter(
-    (model) => !hidden.has(String(model.slug)),
+  // The same machine-local capability proofs the Codex catalog honors: a
+  // model this machine verified as a subagent is one everywhere the proven
+  // set is consumed, or the harness's tool-subagent preset silently disagrees
+  // with the picker about which children exist.
+  const selected = applySubagentProofs(
+    selectedConfiguredListedModels().filter((model) => !hidden.has(String(model.slug))),
+    subagentProofSnapshot(),
+    { hidden, disabled: readMultiAgentSettings().disabled },
   );
   // Native GPT models are authorized by a ChatGPT session rather than an API
   // key. The harness carries none of its own -- but this machine is signed in

--- a/src/multi-agent-state.mjs
+++ b/src/multi-agent-state.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
+import { subagentProofSnapshot } from "./subagent-proofs.mjs";
 
 export const MULTI_AGENT_STATE_PATH =
   process.env.MODEL_ROUTER_MULTI_AGENT_STATE ||
@@ -66,6 +67,11 @@ export function subagentSettingsSnapshot() {
     ...settings,
     all: settings.mode === "all",
     path: MULTI_AGENT_STATE_PATH,
+    // Machine-local capability verdicts, keyed by slug: checking /
+    // experimental / proven / failed (with the failure reason). This is what
+    // lets a surface explain *why* an enabled model is or is not offered as
+    // a subagent instead of leaving it a silent no-show.
+    proofs: subagentProofSnapshot(),
   };
 }
 

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -56,6 +56,12 @@ import {
   flattenNamespaceTools,
 } from "./namespace-relay.mjs";
 import { pendingInterruptTargets } from "./subagent-completion.mjs";
+import {
+  awaitingSpawnProof,
+  recordSpawnFailure,
+  recordSpawnObserved,
+  subagentProofSnapshot,
+} from "./subagent-proofs.mjs";
 import { mergeCodexAppTools } from "./codex-app-tools.mjs";
 import { activityMetadataFromHeaders } from "./codex-session-names.mjs";
 import { translateGatewayError } from "./error-translation.mjs";
@@ -1670,6 +1676,39 @@ function requireCodexTransport(request, response) {
   return true;
 }
 
+// A model in the experimental subagent window earns its durable proof — or
+// its demotion — from real traffic: Codex marks child turns with
+// x-openai-subagent, so the first clean completion of one settles "this model
+// can hold the child role" without a dedicated probe session. Only structural
+// rejections demote (400/422, the shape a schema or encrypted-payload refusal
+// takes); transient failures — 429s, 5xx, disconnects — prove nothing either
+// way and leave the window open. Neither line is QUIET-gated: a promotion or
+// demotion that happens silently is how a picker entry becomes unexplainable.
+function observeSubagentOutcome(request, route, status, { emptyCompletion = false } = {}) {
+  if (!route) return;
+  try {
+    if (!request.headers["x-openai-subagent"]) return;
+    if (!awaitingSpawnProof(route.slug, subagentProofSnapshot())) return;
+    if (status === 200 && !emptyCompletion) {
+      recordSpawnObserved(route.slug, { status });
+      console.error(
+        `[codex-router] subagent proven: ${route.slug} completed a live child turn`,
+      );
+    } else if (status === 400 || status === 422) {
+      recordSpawnFailure(route.slug, {
+        status,
+        reason: `child turn rejected with HTTP ${status}`,
+      });
+      console.error(
+        `[codex-router] subagent demoted: ${route.slug} child turn rejected with HTTP ${status}; ` +
+          "it stays v1 until 'control subagents verify' passes again",
+      );
+    }
+  } catch {
+    // Observation is bookkeeping; it must never fail the turn it watched.
+  }
+}
+
 async function handleResponses(request, response, requestUrl) {
   const startedAt = Date.now();
   const activity = beginRequestActivity();
@@ -1975,6 +2014,7 @@ async function handleResponses(request, response, requestUrl) {
         responseStartMs: upstreamLatencyMs,
         firstTokenMs,
       });
+      observeSubagentOutcome(request, route, upstream.status);
       finalStatus = upstream.status;
       activityStatus = upstream.status;
       usageRecorded = true;
@@ -2212,6 +2252,7 @@ async function handleResponses(request, response, requestUrl) {
       ...(emptyCompletionUnrepairable ? { emptyCompletionUnrepairable: true } : {}),
       ...(guardReleasedForBudget ? { emptyCompletionGuardReleased: true } : {}),
     });
+    observeSubagentOutcome(request, route, finalStatus, { emptyCompletion });
     usageRecorded = true;
     activityStatus = finalStatus;
     if (!QUIET) {

--- a/src/subagent-proofs.mjs
+++ b/src/subagent-proofs.mjs
@@ -1,0 +1,141 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { writePrivateJson } from "./file-security.mjs";
+import { STATE_DIR } from "./paths.mjs";
+
+// Machine-local subagent capability proofs.
+//
+// The registry's `multiAgentVersion: "v2"` marks models proven through the
+// full native collaboration probe and shipped to every installer. This file
+// holds the other kind of evidence: proofs collected on *this* machine, for
+// models the operator enabled as subagents that the registry has not promoted.
+// Local settings still never manufacture a v2 claim — the only writers here
+// are the verifier (a live tool/stream probe) and the router's own
+// observation of a real spawn succeeding or failing on the request path.
+//
+// Lifecycle per slug:
+//   checking      the probe worker is running; nothing is advertised yet
+//   experimental  the probe passed; the model is advertised to Codex as a v2
+//                 subagent, and the first observed spawn settles the verdict
+//   proven        the router watched a real child turn complete cleanly
+//   failed        the probe failed, or an observed spawn failed structurally;
+//                 the model stays v1 and the reason is shown where it was
+//                 switched on
+export const SUBAGENT_PROOFS_PATH =
+  process.env.MODEL_ROUTER_SUBAGENT_PROOFS ||
+  path.join(STATE_DIR, "multi-agent-proofs.json");
+
+const PROMOTED_STATUSES = new Set(["experimental", "proven"]);
+const KNOWN_STATUSES = new Set(["checking", "experimental", "proven", "failed"]);
+
+// A file that exists but cannot be parsed promotes nothing: somebody's
+// evidence was here and we can no longer read it, so the conservative v1
+// default applies until the operator re-verifies.
+export function readSubagentProofs(filePath = SUBAGENT_PROOFS_PATH) {
+  if (!existsSync(filePath)) return { version: 1, proofs: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+    if (parsed?.version === 1 && parsed.proofs && typeof parsed.proofs === "object") {
+      const proofs = {};
+      for (const [slug, proof] of Object.entries(parsed.proofs)) {
+        if (proof && typeof proof === "object" && KNOWN_STATUSES.has(proof.status)) {
+          proofs[slug] = proof;
+        }
+      }
+      return { version: 1, proofs };
+    }
+  } catch {
+    // Fall through to the empty (promote-nothing) state.
+  }
+  return { version: 1, proofs: {} };
+}
+
+function writeProofs(state, filePath = SUBAGENT_PROOFS_PATH) {
+  writePrivateJson(filePath, state, { directoryMode: 0o700 });
+}
+
+function updateProof(slug, update, filePath = SUBAGENT_PROOFS_PATH) {
+  const state = readSubagentProofs(filePath);
+  const key = String(slug);
+  const next = {
+    version: 1,
+    proofs: { ...state.proofs, [key]: { ...state.proofs[key], ...update } },
+  };
+  writeProofs(next, filePath);
+  return next.proofs[key];
+}
+
+export function recordProbeStarted(slug, { at = new Date().toISOString() } = {}) {
+  return updateProof(slug, { status: "checking", startedAt: at });
+}
+
+export function recordProbeResult(slug, { ok, checks, detail, at = new Date().toISOString() }) {
+  if (ok) {
+    return updateProof(slug, {
+      status: "experimental",
+      toolProbe: { ok: true, checks, at },
+      reason: undefined,
+    });
+  }
+  return updateProof(slug, {
+    status: "failed",
+    toolProbe: { ok: false, checks, at },
+    reason: detail || "capability probe failed",
+  });
+}
+
+export function recordSpawnObserved(slug, { status, at = new Date().toISOString() } = {}) {
+  return updateProof(slug, { status: "proven", spawn: { ok: true, status, at } });
+}
+
+export function recordSpawnFailure(slug, { status, reason, at = new Date().toISOString() } = {}) {
+  return updateProof(slug, {
+    status: "failed",
+    spawn: { ok: false, status, at },
+    reason: reason || `spawn failed with HTTP ${status}`,
+  });
+}
+
+export function clearSubagentProof(slug, filePath = SUBAGENT_PROOFS_PATH) {
+  const state = readSubagentProofs(filePath);
+  if (!(String(slug) in state.proofs)) return;
+  const proofs = { ...state.proofs };
+  delete proofs[String(slug)];
+  writeProofs({ version: 1, proofs }, filePath);
+}
+
+export function subagentProofSnapshot(filePath = SUBAGENT_PROOFS_PATH) {
+  return readSubagentProofs(filePath).proofs;
+}
+
+function promotedSlugs(proofs) {
+  return new Set(
+    Object.entries(proofs)
+      .filter(([, proof]) => PROMOTED_STATUSES.has(proof.status))
+      .map(([slug]) => slug),
+  );
+}
+
+// Promote routed models this machine has verified. Runs after
+// applyMultiAgentSettings, whose demotions must win: a slug the operator
+// hid or switched off stays v1 whatever evidence exists for it.
+export function applySubagentProofs(models, proofs, { hidden, disabled } = {}) {
+  const promoted = promotedSlugs(proofs || {});
+  if (promoted.size === 0) return models;
+  const hiddenSet = hidden instanceof Set ? hidden : new Set(hidden || []);
+  const disabledSet = disabled instanceof Set ? disabled : new Set(disabled || []);
+  return models.map((model) => {
+    const slug = String(model.slug);
+    if (model.multiAgentVersion === "v2") return model;
+    if (!promoted.has(slug)) return model;
+    if (hiddenSet.has(slug) || disabledSet.has(slug)) return model;
+    return { ...model, multiAgentVersion: "v2" };
+  });
+}
+
+// Whether an observed child turn for this slug should settle a verdict:
+// only models sitting in the experimental window are listening.
+export function awaitingSpawnProof(slug, proofs = subagentProofSnapshot()) {
+  return proofs[String(slug)]?.status === "experimental";
+}

--- a/src/subagent-verify.mjs
+++ b/src/subagent-verify.mjs
@@ -1,0 +1,119 @@
+import { spawn, spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { MODEL_BY_SLUG } from "./model-registry.mjs";
+import {
+  readSubagentProofs,
+  recordProbeResult,
+  recordProbeStarted,
+} from "./subagent-proofs.mjs";
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Enabling a model as a subagent is the assignment; this module answers
+// whether the assignment can hold. Verification is capability research, not
+// trust: the probe spends two live requests proving the model streams and
+// answers a forced tool call through the installed router, and only that
+// evidence — never the toggle itself — advertises the model to Codex as a
+// v2 subagent (as "experimental", until a real spawn settles it).
+
+// Which of these slugs need a probe at all. Registry-v2 models shipped with
+// the full native proof; slugs already carrying local evidence keep it.
+export function subagentVerificationCandidates(slugs, { force = false } = {}) {
+  const proofs = readSubagentProofs().proofs;
+  const seen = new Set();
+  const candidates = [];
+  for (const raw of slugs || []) {
+    const slug = String(raw || "").trim();
+    if (!slug || seen.has(slug)) continue;
+    seen.add(slug);
+    const model = MODEL_BY_SLUG.get(slug);
+    if (!model) continue;
+    if (model.multiAgentVersion === "v2") continue;
+    const status = proofs[slug]?.status;
+    if (!force && (status === "experimental" || status === "proven" || status === "checking")) {
+      continue;
+    }
+    candidates.push(slug);
+  }
+  return candidates;
+}
+
+export async function verifySubagentCandidates(slugs, { probe, force = false } = {}) {
+  const runProbe =
+    probe ||
+    (await import("./compatibility-test.mjs")).subagentCapabilityProbe;
+  const results = [];
+  for (const slug of subagentVerificationCandidates(slugs, { force })) {
+    recordProbeStarted(slug);
+    let outcome;
+    try {
+      outcome = await runProbe(slug);
+    } catch (error) {
+      outcome = {
+        ok: false,
+        checks: [],
+        detail: error instanceof Error ? error.message : String(error),
+      };
+    }
+    results.push({
+      slug,
+      ...recordProbeResult(slug, {
+        ok: outcome.ok,
+        checks: outcome.checks,
+        detail: outcome.detail,
+      }),
+    });
+  }
+  return results;
+}
+
+// The tray's toggle cannot wait on a live network probe, so control hands the
+// candidate list to a detached worker (the same shape as the vision-model
+// download worker): state moves to "checking" immediately, the worker records
+// the verdict and republishes the catalog when it lands.
+export function spawnDetachedVerification(slugs, { execPath = process.execPath } = {}) {
+  const candidates = subagentVerificationCandidates(slugs);
+  if (candidates.length === 0) return { spawned: false, candidates: [] };
+  for (const slug of candidates) recordProbeStarted(slug);
+  const child = spawn(
+    execPath,
+    [path.join(REPO_ROOT, "src", "subagent-verify.mjs"), "--worker", ...candidates],
+    {
+      cwd: REPO_ROOT,
+      env: { ...process.env, MODEL_ROUTER_TARGET: "codex" },
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    },
+  );
+  child.unref();
+  return { spawned: true, candidates };
+}
+
+function refreshCatalog() {
+  const result = spawnSync(process.execPath, [path.join(REPO_ROOT, "src", "catalog.mjs")], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, MODEL_ROUTER_TARGET: "codex" },
+    stdio: "ignore",
+  });
+  return result.status === 0;
+}
+
+async function workerMain(slugs) {
+  // The parent already marked these "checking"; force re-runs them past that.
+  await verifySubagentCandidates(slugs, { force: true });
+  // Publish whatever the verdicts imply. A failed refresh leaves the proofs
+  // recorded; the next control mutation republishes them.
+  refreshCatalog();
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const args = process.argv.slice(2);
+  if (args[0] === "--worker") {
+    workerMain(args.slice(1)).catch(() => {
+      process.exit(1);
+    });
+  }
+}

--- a/src/subagent-verify.mjs
+++ b/src/subagent-verify.mjs
@@ -18,9 +18,21 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 // evidence — never the toggle itself — advertises the model to Codex as a
 // v2 subagent (as "experimental", until a real spawn settles it).
 
+// A probe is two 180-second-capped requests, so any "checking" older than
+// this ceiling was left behind by a worker that died — machine sleep, OOM, a
+// kill — not one still working. Stale checking is retryable without force,
+// which is what makes toggling a wedged model off and on recover it.
+export const STALE_CHECKING_MS = 10 * 60_000;
+
+function checkingIsStale(proof, now = Date.now()) {
+  const startedAt = Date.parse(proof?.startedAt || "");
+  if (!Number.isFinite(startedAt)) return true;
+  return now - startedAt > STALE_CHECKING_MS;
+}
+
 // Which of these slugs need a probe at all. Registry-v2 models shipped with
 // the full native proof; slugs already carrying local evidence keep it.
-export function subagentVerificationCandidates(slugs, { force = false } = {}) {
+export function subagentVerificationCandidates(slugs, { force = false, now = Date.now() } = {}) {
   const proofs = readSubagentProofs().proofs;
   const seen = new Set();
   const candidates = [];
@@ -32,8 +44,9 @@ export function subagentVerificationCandidates(slugs, { force = false } = {}) {
     if (!model) continue;
     if (model.multiAgentVersion === "v2") continue;
     const status = proofs[slug]?.status;
-    if (!force && (status === "experimental" || status === "proven" || status === "checking")) {
-      continue;
+    if (!force) {
+      if (status === "experimental" || status === "proven") continue;
+      if (status === "checking" && !checkingIsStale(proofs[slug], now)) continue;
     }
     candidates.push(slug);
   }
@@ -102,11 +115,28 @@ function refreshCatalog() {
 }
 
 async function workerMain(slugs) {
-  // The parent already marked these "checking"; force re-runs them past that.
-  await verifySubagentCandidates(slugs, { force: true });
-  // Publish whatever the verdicts imply. A failed refresh leaves the proofs
-  // recorded; the next control mutation republishes them.
-  refreshCatalog();
+  try {
+    // The parent already marked these "checking"; force re-runs them past that.
+    await verifySubagentCandidates(slugs, { force: true });
+  } finally {
+    // A worker that dies before a verdict must not strand its slugs: anything
+    // still "checking" here failed to get an answer, and "failed" with a
+    // reason is recoverable where a silent wedge is not. (A hard kill writes
+    // nothing — the staleness ceiling above is that case's backstop.)
+    const proofs = readSubagentProofs().proofs;
+    for (const slug of slugs) {
+      if (proofs[String(slug)]?.status === "checking") {
+        recordProbeResult(slug, {
+          ok: false,
+          checks: [],
+          detail: "the probe worker exited before a verdict; switch the model off and on to retry",
+        });
+      }
+    }
+    // Publish whatever the verdicts imply. A failed refresh leaves the proofs
+    // recorded; the next control mutation republishes them.
+    refreshCatalog();
+  }
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -4501,3 +4501,100 @@ test("a turn with no image reaches a text-only model untouched", async () => {
     await closeServer(native.server);
   }
 });
+
+test("a live child turn settles an experimental subagent's proof", async () => {
+  const proofsPath = path.join(
+    mkdtempSync(path.join(os.tmpdir(), "subagent-proofs-e2e-")),
+    "multi-agent-proofs.json",
+  );
+  // Three models in the experimental window: one will prove itself, one will
+  // be rejected structurally, one completes a turn that carries no subagent
+  // marker and must stay untouched.
+  writeFileSync(
+    proofsPath,
+    JSON.stringify({
+      version: 1,
+      proofs: {
+        "deepseek/deepseek-v4-pro": { status: "experimental" },
+        "deepseek/deepseek-v4-flash": { status: "experimental" },
+        "deepseek/deepseek-chat": { status: "experimental" },
+      },
+    }),
+    { mode: 0o600 },
+  );
+  const gateway = await mockServer(async (request, response) => {
+    if (request.url === "/health") {
+      json(response, 200, { ok: true });
+      return;
+    }
+    const body = await bodyJson(request);
+    if (String(body.model || "").includes("flash")) {
+      json(response, 400, { error: { message: "encrypted payload rejected" } });
+      return;
+    }
+    json(response, 200, {
+      id: "resp_child",
+      output: [
+        { type: "message", content: [{ type: "output_text", text: "child done" }] },
+      ],
+      usage: { input_tokens: 12, output_tokens: 3 },
+    });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    MODEL_ROUTER_SUBAGENT_PROOFS: proofsPath,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  const childTurn = (model, headers = {}) =>
+    fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({ model, input: "finish the task" }),
+    });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    // A clean completion of a marked child turn is the durable proof.
+    const proven = await childTurn("deepseek/deepseek-v4-pro", {
+      "x-openai-subagent": "review-child",
+    });
+    assert.equal(proven.status, 200);
+
+    // A structural rejection of a marked child turn is the demotion.
+    const rejected = await childTurn("deepseek/deepseek-v4-flash", {
+      "x-openai-subagent": "review-child",
+    });
+    assert.equal(rejected.status, 400);
+
+    // The same success without the subagent marker proves nothing.
+    const unmarked = await childTurn("deepseek/deepseek-chat");
+    assert.equal(unmarked.status, 200);
+
+    const deadline = Date.now() + 3_000;
+    let proofs;
+    while (Date.now() < deadline) {
+      proofs = JSON.parse(readFileSync(proofsPath, "utf8")).proofs;
+      if (
+        proofs["deepseek/deepseek-v4-pro"].status === "proven" &&
+        proofs["deepseek/deepseek-v4-flash"].status === "failed"
+      ) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    assert.equal(proofs["deepseek/deepseek-v4-pro"].status, "proven");
+    assert.equal(proofs["deepseek/deepseek-v4-flash"].status, "failed");
+    assert.match(proofs["deepseek/deepseek-v4-flash"].reason, /400/);
+    assert.equal(proofs["deepseek/deepseek-chat"].status, "experimental");
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});

--- a/test/subagent-proofs.test.mjs
+++ b/test/subagent-proofs.test.mjs
@@ -146,3 +146,26 @@ test("verify records the probe's verdict, and a probe crash reads as a failure",
 test("the proofs path override is honoured", () => {
   assert.equal(SUBAGENT_PROOFS_PATH, process.env.MODEL_ROUTER_SUBAGENT_PROOFS);
 });
+
+test("a wedged 'checking' becomes retryable once it goes stale", () => {
+  const slug = "deepseek/deepseek-v4-flash";
+  recordProbeStarted(slug);
+  const started = Date.parse(subagentProofSnapshot()[slug].startedAt);
+
+  // Fresh checking means a worker is (plausibly) still running: don't stack a
+  // second probe on it.
+  assert.deepEqual(subagentVerificationCandidates([slug], { now: started + 1_000 }), []);
+
+  // Past the probe ceiling the worker is dead, and the ordinary toggle path
+  // must be able to re-probe without knowing about force.
+  assert.deepEqual(
+    subagentVerificationCandidates([slug], { now: started + 11 * 60_000 }),
+    [slug],
+  );
+
+  // A checking record with no readable start time is treated as stale, not
+  // trusted forever.
+  recordProbeStarted(slug, { at: "not-a-timestamp" });
+  assert.deepEqual(subagentVerificationCandidates([slug]), [slug]);
+  clearSubagentProof(slug);
+});

--- a/test/subagent-proofs.test.mjs
+++ b/test/subagent-proofs.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+// Point the proofs file and the user-model overlay at empty temp state before
+// the modules read their paths, the same isolation the registry tests use.
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "subagent-proofs-test-"));
+process.env.MODEL_ROUTER_SUBAGENT_PROOFS = path.join(stateDir, "multi-agent-proofs.json");
+process.env.MODEL_ROUTER_USER_MODELS = path.join(stateDir, "user-models.json");
+
+const {
+  applySubagentProofs,
+  awaitingSpawnProof,
+  clearSubagentProof,
+  readSubagentProofs,
+  recordProbeResult,
+  recordProbeStarted,
+  recordSpawnFailure,
+  recordSpawnObserved,
+  subagentProofSnapshot,
+  SUBAGENT_PROOFS_PATH,
+} = await import("../src/subagent-proofs.mjs");
+const { subagentVerificationCandidates, verifySubagentCandidates } = await import(
+  "../src/subagent-verify.mjs"
+);
+
+test("a proof walks checking -> experimental -> proven, and failures carry reasons", () => {
+  const slug = "example/alpha";
+  assert.equal(recordProbeStarted(slug).status, "checking");
+  assert.equal(awaitingSpawnProof(slug), false);
+
+  const experimental = recordProbeResult(slug, {
+    ok: true,
+    checks: [{ name: "tool calling", ok: true }],
+  });
+  assert.equal(experimental.status, "experimental");
+  assert.equal(awaitingSpawnProof(slug), true);
+
+  const proven = recordSpawnObserved(slug, { status: 200 });
+  assert.equal(proven.status, "proven");
+  assert.equal(awaitingSpawnProof(slug), false);
+
+  const failed = recordSpawnFailure("example/beta", { status: 400 });
+  assert.equal(failed.status, "failed");
+  assert.match(failed.reason, /400/);
+
+  const probeFailed = recordProbeResult("example/gamma", {
+    ok: false,
+    checks: [],
+    detail: "tool calling: function call missing",
+  });
+  assert.equal(probeFailed.status, "failed");
+  assert.match(probeFailed.reason, /function call missing/);
+
+  clearSubagentProof("example/gamma");
+  assert.equal(subagentProofSnapshot()["example/gamma"], undefined);
+});
+
+test("a proofs file that cannot be read promotes nothing", () => {
+  const corrupt = path.join(stateDir, "corrupt.json");
+  writeFileSync(corrupt, "{not json", { mode: 0o600 });
+  assert.deepEqual(readSubagentProofs(corrupt), { version: 1, proofs: {} });
+  // Unknown statuses are dropped rather than trusted.
+  const invented = path.join(stateDir, "invented.json");
+  writeFileSync(
+    invented,
+    JSON.stringify({ version: 1, proofs: { "x/y": { status: "definitely-v2" } } }),
+    { mode: 0o600 },
+  );
+  assert.deepEqual(readSubagentProofs(invented).proofs, {});
+});
+
+test("proof promotion respects demotions and never touches registry claims", () => {
+  const models = [
+    { slug: "vendor/experimental" },
+    { slug: "vendor/proven" },
+    { slug: "vendor/failed" },
+    { slug: "vendor/checking" },
+    { slug: "vendor/hidden" },
+    { slug: "vendor/disabled" },
+    { slug: "vendor/registry", multiAgentVersion: "v2" },
+  ];
+  const proofs = {
+    "vendor/experimental": { status: "experimental" },
+    "vendor/proven": { status: "proven" },
+    "vendor/failed": { status: "failed" },
+    "vendor/checking": { status: "checking" },
+    "vendor/hidden": { status: "proven" },
+    "vendor/disabled": { status: "proven" },
+  };
+  const promoted = applySubagentProofs(models, proofs, {
+    hidden: new Set(["vendor/hidden"]),
+    disabled: ["vendor/disabled"],
+  });
+  const bySlug = new Map(promoted.map((model) => [model.slug, model.multiAgentVersion]));
+  assert.equal(bySlug.get("vendor/experimental"), "v2");
+  assert.equal(bySlug.get("vendor/proven"), "v2");
+  assert.equal(bySlug.get("vendor/failed"), undefined);
+  assert.equal(bySlug.get("vendor/checking"), undefined);
+  assert.equal(bySlug.get("vendor/hidden"), undefined);
+  assert.equal(bySlug.get("vendor/disabled"), undefined);
+  assert.equal(bySlug.get("vendor/registry"), "v2");
+  // No proofs at all is a pass-through, not a rewrite.
+  assert.equal(applySubagentProofs(models, {}), models);
+});
+
+test("verification skips registry-v2 models, unknown slugs, and settled proofs", () => {
+  recordProbeResult("deepseek/deepseek-v4-pro", { ok: true, checks: [] });
+  const candidates = subagentVerificationCandidates([
+    "kimi-oauth/k3", // registry v2: shipped with the full native proof
+    "deepseek/deepseek-v4-pro", // already experimental locally
+    "deepseek/deepseek-v4-flash", // real, unproven: the one that needs research
+    "not-a/model", // unknown slugs cannot be probed
+    "deepseek/deepseek-v4-flash", // duplicates collapse
+  ]);
+  assert.deepEqual(candidates, ["deepseek/deepseek-v4-flash"]);
+  // force re-researches a settled slug.
+  assert.ok(
+    subagentVerificationCandidates(["deepseek/deepseek-v4-pro"], { force: true }).includes(
+      "deepseek/deepseek-v4-pro",
+    ),
+  );
+  clearSubagentProof("deepseek/deepseek-v4-pro");
+});
+
+test("verify records the probe's verdict, and a probe crash reads as a failure", async () => {
+  const passed = await verifySubagentCandidates(["deepseek/deepseek-v4-flash"], {
+    probe: async (slug) => ({ ok: true, checks: [{ name: "tool calling", ok: true, slug }] }),
+  });
+  assert.equal(passed[0].status, "experimental");
+  assert.equal(subagentProofSnapshot()["deepseek/deepseek-v4-flash"].status, "experimental");
+  clearSubagentProof("deepseek/deepseek-v4-flash");
+
+  const crashed = await verifySubagentCandidates(["deepseek/deepseek-v4-flash"], {
+    probe: async () => {
+      throw new Error("router unreachable");
+    },
+  });
+  assert.equal(crashed[0].status, "failed");
+  assert.match(crashed[0].reason, /router unreachable/);
+  clearSubagentProof("deepseek/deepseek-v4-flash");
+});
+
+test("the proofs path override is honoured", () => {
+  assert.equal(SUBAGENT_PROOFS_PATH, process.env.MODEL_ROUTER_SUBAGENT_PROOFS);
+});


### PR DESCRIPTION
Closes the gap #183 kept hitting: people want arbitrary models — DeepSeek, Kimi, GLM, whatever their provider serves — as native v2 subagents, but the only promotion path was a per-model registry change gated on a manual four-part probe. Six models ever made it through.

**Selection is now the assignment.** The operator toggles a model on as a subagent (tray or `control subagents set`); the router's job is answering whether that model *under that provider* can hold the child role:

1. **Auto probe on enable** — a detached worker (same shape as the vision-download worker, so the tray toggle never blocks) spends 2 live requests proving streaming + a forced tool call through the installed router. Snapshot shows `checking` → verdict → catalog republish.
2. **Experimental advertisement** — a passing model is offered to Codex as a v2 subagent, recorded in protected `multi-agent-proofs.json`.
3. **Proof by observation** — Codex marks child turns with `x-openai-subagent`; the router's request path records the first clean completion as the durable proof (`proven`), and a structural rejection (400/422) demotes back to v1 with the reason kept in the subagent snapshot. Transient failures (429/5xx/disconnects) prove nothing and leave the window open.
4. `control subagents verify [slug ...]` re-researches explicitly; no-arg sweeps the enabled list. Select-all and mode changes never probe — a sweep across every provider is quota the operator must ask for.

The AGENTS.md invariant survives intact: local settings still never manufacture a v2 claim. The only writers of promotion evidence are the probe worker and the router's own observation of real traffic; unreadable proofs promote nothing; hidden/disabled slugs stay v1 whatever evidence they carry. Registry v2 remains the path for repo-shipped defaults.

## Test plan
- [x] `npm run check`
- [x] `npm test` — 1210 pass / 0 fail
- [x] New unit suite `test/subagent-proofs.test.mjs` (lifecycle, corrupt-state fail-closed, promotion overlay vs demotions/registry, candidate filtering, probe-crash handling)
- [x] New e2e in `test/routing.test.mjs`: marked child turn 200 → `proven`; marked child turn 400 → `failed` with reason; unmarked 200 → untouched
- [ ] Live acceptance on a real install: enable a non-v2 model, watch `checking → experimental`, spawn it once in Codex, confirm `proven`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113FjuH7bU6xRMsUf8Aytio