### PR TITLE
fix: escape interpolated Windows paths in config-manager TOML fixtures

### DIFF
--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -593,7 +593,7 @@ test("config manager upgrades the earlier Kimi-only managed block", () => {
 
 # BEGIN kimi-codex-router-managed
 openai_base_url = "http://127.0.0.1:46192/v1"
-model_catalog_json = "${path.join(codexHome, "kimi-router", "merged-models.json")}"
+model_catalog_json = ${JSON.stringify(path.join(codexHome, "kimi-router", "merged-models.json"))}
 # END kimi-codex-router-managed
 
 [profiles.personal]
@@ -629,7 +629,7 @@ model_reasoning_effort = "high"
 
 # BEGIN kimi-codex-router-managed
 openai_base_url = "http://127.0.0.1:46192/v1"
-model_catalog_json = "${prototypeCatalog}"
+model_catalog_json = ${JSON.stringify(prototypeCatalog)}
 
 [projects."/important/project"]
 trust_level = "trusted"


### PR DESCRIPTION
## Summary
- `test/config-manager.test.mjs` interpolated `os.tmpdir()`-based paths raw into quoted TOML strings. On Windows the path contains backslashes (`C:\Users\...`), which are invalid basic-string escapes, so `toml-structure.mjs` correctly refused the document and the "upgrades the earlier Kimi-only managed block" test failed on windows-latest.
- Fix: wrap both interpolated paths in `JSON.stringify`, matching how the tests already assert on the written config. No product code change — the scanner's refusal was correct.

## Test plan
- [x] `node --test test/config-manager.test.mjs` passes locally (35/35)
- [ ] CI test (windows-latest) green