### PR TITLE
fix: opencode's DeepSeek models never receive a forced tool_choice

### DIFF
--- a/config/opencode/go/deepseek-v4-flash.json
+++ b/config/opencode/go/deepseek-v4-flash.json
@@ -33,7 +33,8 @@
       "searchTool": {
         "mode": "standalone"
       },
-      "compHash": "opencode-go-deepseek-v4-flash-v2"
+      "requestProfile": "auto-tool-choice",
+      "compHash": "opencode-go-deepseek-v4-flash-v3"
     }
   ]
 }

--- a/config/opencode/go/deepseek-v4-pro.json
+++ b/config/opencode/go/deepseek-v4-pro.json
@@ -26,7 +26,8 @@
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-deepseek-v4-pro-v1"
+      "requestProfile": "auto-tool-choice",
+      "compHash": "opencode-go-deepseek-v4-pro-v2"
     }
   ]
 }

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -870,3 +870,21 @@ test("a keyless provider's baseUrl override must stay on loopback", () => {
   assert.equal(overridden.baseUrl, "https://proxy.example/v1");
   assert.equal(overridden.refusedOverride, undefined);
 });
+
+test("opencode's DeepSeek models never receive a forced tool_choice", () => {
+  // Console Go serves DeepSeek V4 in thinking mode, which answers HTTP 400 to
+  // tool_choice "required" ("Thinking mode does not support this tool_choice")
+  // while calling tools correctly under "auto" — both halves observed live on
+  // 2026-08-15. Per AGENTS.md that is exactly the per-model auto-tool-choice
+  // case: the restriction belongs to the upstream behind the reseller, so the
+  // router downgrades the forced choice for these two slugs and no others.
+  for (const slug of ["opencode-go/deepseek-v4-flash", "opencode-go/deepseek-v4-pro"]) {
+    assert.equal(MODEL_BY_SLUG.get(slug).requestProfile, "auto-tool-choice", slug);
+  }
+  // The sibling opencode routes keep their defaults: the probe proved nothing
+  // about them, and a provider-wide default is what the rule forbids. (kimi-k3
+  // carries its own effort profile, so it is not a clean control here.)
+  for (const slug of ["opencode-go/glm-5.3", "opencode-go/grok-4.5", "opencode-go/mimo-v2.5"]) {
+    assert.equal(MODEL_BY_SLUG.get(slug).requestProfile, undefined, slug);
+  }
+});


### PR DESCRIPTION
The subagent capability sweep (#225's verifier, first live run) found both `opencode-go/deepseek-v4-*` models failing the forced-tool-call probe: Console Go serves DeepSeek V4 in thinking mode, which rejects `tool_choice: "required"` with HTTP 400 ("Thinking mode does not support this tool_choice") while calling tools correctly under `"auto"` — both halves observed live on 2026-08-15 (the 400 in the sweep, the clean `{"value": "ok"}` tool call under auto in a follow-up probe).

Per AGENTS.md this is exactly the per-model `auto-tool-choice` case: the restriction belongs to the upstream behind the reseller, so the profile is declared on the two observed slugs and nowhere else. The probe itself keeps sending `required` — the router now downgrades it for these models the same way it will for every real turn.

New registry test pins the profile to exactly these two slugs and asserts the sibling opencode routes keep their defaults.

## Test plan
- [x] `npm run check`
- [x] `npm test` — 1222 pass / 0 fail
- [ ] Post-merge on a live install: `control subagents verify` on both slugs → experimental v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113FjuH7bU6xRMsUf8Aytio