### PR TITLE
fix: a transient probe failure defers verification instead of condemning the model

### DIFF
--- a/src/subagent-verify.mjs
+++ b/src/subagent-verify.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import { MODEL_BY_SLUG } from "./model-registry.mjs";
 import {
+  clearSubagentProof,
   readSubagentProofs,
   recordProbeResult,
   recordProbeStarted,
@@ -53,6 +54,19 @@ export function subagentVerificationCandidates(slugs, { force = false, now = Dat
   return candidates;
 }
 
+// The probe measures capability, and a provider that is rate limited, out of
+// quota, or briefly down has not answered that question. "failed" is reserved
+// for evidence the model cannot hold the role; everything transient clears the
+// slot instead, so the next toggle or sweep simply researches again — the same
+// distinction the request-path observer draws between a 400 and a 429.
+const TRANSIENT_PROBE_STATUSES = new Set([402, 408, 429, 500, 502, 503, 504]);
+
+function probeWasTransient(outcome) {
+  const failing = (outcome.checks || []).filter((check) => !check.ok);
+  if (!failing.length) return false;
+  return failing.every((check) => TRANSIENT_PROBE_STATUSES.has(check.status));
+}
+
 export async function verifySubagentCandidates(slugs, { probe, force = false } = {}) {
   const runProbe =
     probe ||
@@ -69,6 +83,11 @@ export async function verifySubagentCandidates(slugs, { probe, force = false } =
         checks: [],
         detail: error instanceof Error ? error.message : String(error),
       };
+    }
+    if (!outcome.ok && probeWasTransient(outcome)) {
+      clearSubagentProof(slug);
+      results.push({ slug, status: "deferred", reason: outcome.detail });
+      continue;
     }
     results.push({
       slug,

--- a/test/subagent-proofs.test.mjs
+++ b/test/subagent-proofs.test.mjs
@@ -169,3 +169,35 @@ test("a wedged 'checking' becomes retryable once it goes stale", () => {
   assert.deepEqual(subagentVerificationCandidates([slug]), [slug]);
   clearSubagentProof(slug);
 });
+
+test("a probe that only hit quota or outage defers instead of condemning", async () => {
+  const slug = "deepseek/deepseek-v4-flash";
+  const deferred = await verifySubagentCandidates([slug], {
+    probe: async () => ({
+      ok: false,
+      checks: [
+        { name: "tool calling", ok: false, status: 429, detail: "1-week quota exhausted" },
+        { name: "streaming", ok: true, status: 200 },
+      ],
+      detail: "tool calling: 1-week quota exhausted",
+    }),
+  });
+  assert.equal(deferred[0].status, "deferred");
+  // Nothing recorded: the next toggle or sweep researches again.
+  assert.equal(subagentProofSnapshot()[slug], undefined);
+
+  // A structural rejection alongside a transient one is still a failure —
+  // the 400 answered the capability question even though the 503 did not.
+  const condemned = await verifySubagentCandidates([slug], {
+    probe: async () => ({
+      ok: false,
+      checks: [
+        { name: "tool calling", ok: false, status: 400, detail: "tool_choice rejected" },
+        { name: "streaming", ok: false, status: 503, detail: "upstream flap" },
+      ],
+      detail: "tool calling: tool_choice rejected",
+    }),
+  });
+  assert.equal(condemned[0].status, "failed");
+  clearSubagentProof(slug);
+});


### PR DESCRIPTION
First live sweep found this: `qwen-plan/qwen3.8-max` was recorded **failed** — permanently, with a reason — because the plan's weekly quota was exhausted (HTTP 429). That's a verdict about the account written down as a verdict about the model.

The probe now classifies all-transient failures (402/408/429/5xx across every failing check) as **deferred**: the proof slot is cleared, nothing is advertised, and the next toggle or sweep simply researches again. A structural rejection beside a transient one still condemns — the 400 answered the capability question even though the 503 didn't. This mirrors the transient/structural distinction the request-path observer already draws (429 never demotes, 400 does).

## Test plan
- [x] `npm run check` / `npm test` — 1224 pass, 0 fail
- [x] New tests: all-transient probe → deferred + slot cleared; mixed 400+503 → still failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113FjuH7bU6xRMsUf8Aytio