### PR TITLE
fix: the tray's subagent rows honor machine-local proofs

### DIFF
--- a/src/control.mjs
+++ b/src/control.mjs
@@ -154,9 +154,25 @@ async function emitProbe() {
   const usageEvents = TARGET === "codex"
     ? (await import("./usage-events.mjs")).recentUsageEvents()
     : [];
+  // The same machine-local capability proofs the catalog honors: the tray's
+  // "Subagent models" section filters on v2, so a probe built from the raw
+  // registry hid every model this machine had just verified — the third
+  // consumer to need this overlay, after the catalog and the DSH preset.
+  //
+  // Deliberately unlike the catalog, `disabled` is not passed: the catalog
+  // demotes a switched-off model so Codex stops offering it, but this probe
+  // is what draws the rows the operator switches. A proven model whose
+  // toggle is off must keep its row — with the toggle shown off — or the
+  // section it was switched off in loses the way to switch it back on.
+  const { applySubagentProofs } = await import("./subagent-proofs.mjs");
+  const provenListedModels = applySubagentProofs(
+    LISTED_MODELS,
+    subagentSettingsSnapshot().proofs,
+    { hidden: hiddenModels },
+  );
   // The tray groups models by provider to build its rows, so protocol
   // variants report their canonical family id: one opencode Go row, not three.
-  const routedModels = LISTED_MODELS.map((model) => ({
+  const routedModels = provenListedModels.map((model) => ({
     slug: model.slug,
     displayName: model.displayName,
     provider: canonicalProviderId(model.provider),


### PR DESCRIPTION
Found live: after the #225 verifier promoted models on a real machine, Codex offered them but the tray's **Subagent models** section stayed empty — the probe feeding the tray built its model list from the raw registry, never applying the local proofs overlay. Third consumer to need it (catalog in #225, DSH preset in the #225 review fix, now the probe).

One deliberate divergence from the catalog: the probe does **not** pass the disabled list to the overlay. The catalog demotes switched-off models so Codex stops offering them; the probe draws the rows the operator uses to switch, so a proven-but-off model must keep its row (toggle shown off) or the section loses the way back. Picker-hidden models remain excluded, matching the existing rule that a hidden model cannot be a subagent.

Verified against the live state: probe now reports 12 v2 routed rows (registry 7 + this machine's 5 visible local proofs), and `npm run check` / `npm test` pass (1223/0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113FjuH7bU6xRMsUf8Aytio