### PR TITLE
fix: an entitlement refusal defers verification instead of condemning the model

### DIFF
--- a/src/subagent-verify.mjs
+++ b/src/subagent-verify.mjs
@@ -54,17 +54,21 @@ export function subagentVerificationCandidates(slugs, { force = false, now = Dat
   return candidates;
 }
 
-// The probe measures capability, and a provider that is rate limited, out of
-// quota, or briefly down has not answered that question. "failed" is reserved
-// for evidence the model cannot hold the role; everything transient clears the
-// slot instead, so the next toggle or sweep simply researches again — the same
-// distinction the request-path observer draws between a 400 and a 429.
-const TRANSIENT_PROBE_STATUSES = new Set([402, 408, 429, 500, 502, 503, 504]);
+// The probe measures capability, and these statuses answer about the account
+// or the moment, never about the model: rate limits, exhausted quota, and
+// outages (402/408/429/5xx) clear on their own; missing credentials and plan
+// entitlements (401/403) clear when the operator upgrades — a Command Code Go
+// plan probing 30 models recorded 30 "incapable" verdicts when the truth was
+// one un-entitled account. "failed" is reserved for evidence the model cannot
+// hold the role; everything here clears the slot instead, so the next toggle
+// or sweep simply researches again — the same distinction the request-path
+// observer draws between a 400 and a 429.
+const PROBE_STATUSES_ABOUT_THE_ACCOUNT = new Set([401, 402, 403, 408, 429, 500, 502, 503, 504]);
 
-function probeWasTransient(outcome) {
+function probeAnsweredAboutTheAccount(outcome) {
   const failing = (outcome.checks || []).filter((check) => !check.ok);
   if (!failing.length) return false;
-  return failing.every((check) => TRANSIENT_PROBE_STATUSES.has(check.status));
+  return failing.every((check) => PROBE_STATUSES_ABOUT_THE_ACCOUNT.has(check.status));
 }
 
 export async function verifySubagentCandidates(slugs, { probe, force = false } = {}) {
@@ -84,7 +88,7 @@ export async function verifySubagentCandidates(slugs, { probe, force = false } =
         detail: error instanceof Error ? error.message : String(error),
       };
     }
-    if (!outcome.ok && probeWasTransient(outcome)) {
+    if (!outcome.ok && probeAnsweredAboutTheAccount(outcome)) {
       clearSubagentProof(slug);
       results.push({ slug, status: "deferred", reason: outcome.detail });
       continue;

--- a/test/subagent-proofs.test.mjs
+++ b/test/subagent-proofs.test.mjs
@@ -201,3 +201,22 @@ test("a probe that only hit quota or outage defers instead of condemning", async
   assert.equal(condemned[0].status, "failed");
   clearSubagentProof(slug);
 });
+
+test("a plan-entitlement refusal defers every model it gated, condemning none", async () => {
+  const slug = "deepseek/deepseek-v4-flash";
+  // The Command Code case: the credential authenticates, the plan cannot call
+  // the API, and every model behind it answers 403. Thirty models probed on
+  // an un-entitled account must not become thirty "incapable" verdicts.
+  const gated = await verifySubagentCandidates([slug], {
+    probe: async () => ({
+      ok: false,
+      checks: [
+        { name: "tool calling", ok: false, status: 403, detail: "plan does not include the API" },
+        { name: "streaming", ok: false, status: 403, detail: "plan does not include the API" },
+      ],
+      detail: "tool calling: plan does not include the API",
+    }),
+  });
+  assert.equal(gated[0].status, "deferred");
+  assert.equal(subagentProofSnapshot()[slug], undefined);
+});


### PR DESCRIPTION
The first full-provider sweep probed 30 Command Code models on a Go plan that cannot call the Provider API (the `planNote` case) and recorded 30 permanent "failed" verdicts for what was one un-entitled account. Same category error #228 fixed for quota: 401/403 answer about the **account**, never about the model. They now join the about-the-account statuses that clear the slot ("deferred"), so the models research normally the day the plan can call them. A structural 400 beside one still condemns.

## Test plan
- [x] `npm run check` / `npm test` — 1224 pass, 0 fail
- [x] New test: all-403 probe → deferred, nothing recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113FjuH7bU6xRMsUf8Aytio