### PR TITLE
fix: five more opencode models never receive a forced tool_choice

### DIFF
--- a/config/opencode/go-messages/qwen3.6-plus.json
+++ b/config/opencode/go-messages/qwen3.6-plus.json
@@ -22,7 +22,8 @@
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-messages-qwen3-6-plus-v1"
+      "compHash": "opencode-go-messages-qwen3-6-plus-v2",
+      "requestProfile": "auto-tool-choice"
     }
   ]
 }

--- a/config/opencode/go-messages/qwen3.7-max.json
+++ b/config/opencode/go-messages/qwen3.7-max.json
@@ -23,7 +23,8 @@
         "text",
         "image"
       ],
-      "compHash": "opencode-go-messages-qwen3-7-max-v2"
+      "compHash": "opencode-go-messages-qwen3-7-max-v3",
+      "requestProfile": "auto-tool-choice"
     }
   ]
 }

--- a/config/opencode/go-messages/qwen3.7-plus.json
+++ b/config/opencode/go-messages/qwen3.7-plus.json
@@ -22,7 +22,8 @@
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-messages-qwen3-7-plus-v1"
+      "compHash": "opencode-go-messages-qwen3-7-plus-v2",
+      "requestProfile": "auto-tool-choice"
     }
   ]
 }

--- a/config/opencode/go-messages/qwen3.8-max.json
+++ b/config/opencode/go-messages/qwen3.8-max.json
@@ -23,7 +23,8 @@
         "text",
         "image"
       ],
-      "compHash": "opencode-go-messages-qwen3-8-max-v2"
+      "compHash": "opencode-go-messages-qwen3-8-max-v3",
+      "requestProfile": "auto-tool-choice"
     }
   ]
 }

--- a/config/opencode/go/kimi-k2.7-code.json
+++ b/config/opencode/go/kimi-k2.7-code.json
@@ -22,7 +22,8 @@
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-kimi-k2-7-code-v1"
+      "compHash": "opencode-go-kimi-k2-7-code-v2",
+      "requestProfile": "auto-tool-choice"
     }
   ]
 }

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -878,7 +878,18 @@ test("opencode's DeepSeek models never receive a forced tool_choice", () => {
   // 2026-08-15. Per AGENTS.md that is exactly the per-model auto-tool-choice
   // case: the restriction belongs to the upstream behind the reseller, so the
   // router downgrades the forced choice for these two slugs and no others.
-  for (const slug of ["opencode-go/deepseek-v4-flash", "opencode-go/deepseek-v4-pro"]) {
+  for (const slug of [
+    "opencode-go/deepseek-v4-flash",
+    "opencode-go/deepseek-v4-pro",
+    // Same class, observed 2026-08-15 in the full sweep: 400 on required
+    // (Kimi K2.7 Code on the chat route; the four Qwens on the messages
+    // route answer a bare {"model": ...} echo), clean probe calls under auto.
+    "opencode-go/kimi-k2.7-code",
+    "opencode-go-messages/qwen3.6-plus",
+    "opencode-go-messages/qwen3.7-max",
+    "opencode-go-messages/qwen3.7-plus",
+    "opencode-go-messages/qwen3.8-max",
+  ]) {
     assert.equal(MODEL_BY_SLUG.get(slug).requestProfile, "auto-tool-choice", slug);
   }
   // The sibling opencode routes keep their defaults: the probe proved nothing


### PR DESCRIPTION
Round two of #227, driven by the full-provider sweep: the four `opencode-go-messages` Qwens failed the forced-tool-call probe with a bare `{"model": ...}` HTTP 400 echo, and `opencode-go/kimi-k2.7-code` with a provider 400 of the same class. All five were then observed calling the probe tool cleanly with valid JSON args under `tool_choice: "auto"` (live, 2026-08-15). Both evidence halves per AGENTS.md → per-model `auto-tool-choice` on exactly these five slugs; siblings keep the strict probe.

## Test plan
- [x] `npm run check` / `npm test` — 1224 pass, 0 fail
- [x] Registry test extended: profile pinned to the seven opencode slugs that earned it, sibling controls still default
- [ ] Post-merge live: re-verify all five → experimental v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113FjuH7bU6xRMsUf8Aytio