### PR TITLE
fix: an unreachable probe defers verification instead of condemning the model

### DIFF
--- a/src/subagent-verify.mjs
+++ b/src/subagent-verify.mjs
@@ -82,13 +82,17 @@ export async function verifySubagentCandidates(slugs, { probe, force = false } =
     try {
       outcome = await runProbe(slug);
     } catch (error) {
+      // A probe that never got an answer — router restarting, DNS, socket
+      // refused — proved nothing about the model. Mark it unreachable so the
+      // classifier below defers it rather than condemning it.
       outcome = {
         ok: false,
+        unreachable: true,
         checks: [],
         detail: error instanceof Error ? error.message : String(error),
       };
     }
-    if (!outcome.ok && probeAnsweredAboutTheAccount(outcome)) {
+    if (!outcome.ok && (outcome.unreachable || probeAnsweredAboutTheAccount(outcome))) {
       clearSubagentProof(slug);
       results.push({ slug, status: "deferred", reason: outcome.detail });
       continue;

--- a/test/subagent-proofs.test.mjs
+++ b/test/subagent-proofs.test.mjs
@@ -133,14 +133,16 @@ test("verify records the probe's verdict, and a probe crash reads as a failure",
   assert.equal(subagentProofSnapshot()["deepseek/deepseek-v4-flash"].status, "experimental");
   clearSubagentProof("deepseek/deepseek-v4-flash");
 
+  // A probe that never reached the provider proved nothing: it defers and
+  // leaves no verdict, instead of writing "incapable" for a socket error.
   const crashed = await verifySubagentCandidates(["deepseek/deepseek-v4-flash"], {
     probe: async () => {
       throw new Error("router unreachable");
     },
   });
-  assert.equal(crashed[0].status, "failed");
+  assert.equal(crashed[0].status, "deferred");
   assert.match(crashed[0].reason, /router unreachable/);
-  clearSubagentProof("deepseek/deepseek-v4-flash");
+  assert.equal(subagentProofSnapshot()["deepseek/deepseek-v4-flash"], undefined);
 });
 
 test("the proofs path override is honoured", () => {


### PR DESCRIPTION
Live-found classification gap #3 (after quota #228 and entitlement #230): re-verifying five models seconds after a service restart recorded five permanent "failed" verdicts whose entire evidence was `fetch failed` — ECONNREFUSED against the router's own port while it booted. A probe that never reached the provider proves nothing; thrown transport errors now defer (slot cleared, transport's own wording kept as the reason) instead of condemning.

## Test plan
- [x] `npm run check` / `npm test` — full suite green
- [x] Updated test: thrown probe → deferred, no verdict recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113FjuH7bU6xRMsUf8Aytio