### PR TITLE
feat: credential-free install mode via --no-provider and --no-discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -852,6 +852,28 @@ minutes later. Do not quietly drop the label because a check happened to pass.
   directories.
 - Do not restart or quit the Codex App from the installation task.
 
+## Discovery-disabled means no credential reader touches anything
+
+An install made with `--no-provider --no-discovery` persists a discovery
+kill-switch (`discovery-mode.json`, read through
+`src/discovery-mode.mjs` `discoveryDisabled()`, overridable with
+`CODEX_ROUTER_NO_DISCOVERY=1|0`). While it is set, the promise is absolute:
+no provider credential file, macOS Keychain item, other CLI's OAuth or
+session file, or Codex `auth.json` is read, no `codex login status` probe
+runs against the real `CODEX_HOME`, and traffic gets a local
+`503 router_idle_no_provider` instead of provider or native forwarding.
+
+1. Every new credential reader, sign-in probe, or session consumer must
+   consult `discoveryDisabled()` before its first read or spawn and report
+   "nothing found" rather than throwing. The guard belongs at the reader, not
+   only at its current callers — call graphs move.
+2. An explicitly written empty provider selection is a deliberate state, not
+   an error: `ensure-configured` reports it as idle, the doctor warns instead
+   of failing, and installing or updating on top of it must keep working.
+3. Never select a provider, re-enable discovery, or clear the marker on the
+   user's behalf. Re-running setup without the flags is the only exit path,
+   and it is the operator's to take.
+
 ## The `codex` shim is opt-in and must never break `codex`
 
 `src/codex-shim.mjs` can put a wrapper named `codex` on the user's PATH so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **A credential-free install mode for lifecycle validation.** (#224)
+  `install.sh --no-provider --no-discovery` (PowerShell: `-NoProvider
+  -NoDiscovery`) installs the router idle: an explicit empty provider
+  selection, no credential prompts, and a persisted discovery kill-switch
+  honored by every credential reader — provider key files, the macOS
+  Keychain, other CLIs' OAuth and session files, Codex's `auth.json`, and the
+  `codex login status` probe all stay untouched. Codex traffic gets a local
+  `503 router_idle_no_provider` instead of provider or native forwarding, the
+  doctor reports the idle state at warn and exits 0, and a new `stop`
+  subcommand completes the install → start → status → doctor → stop →
+  uninstall loop. Re-running setup without the flags leaves idle mode. As
+  part of this, an explicitly empty provider selection now passes
+  `ensure-configured` as idle, which also un-breaks `bin/update` for anyone
+  who had hidden their last provider by hand.
 - **Uninstalling the last client integration now removes the background
   service.** Whether Codex still counted as installed was keyed on the cached
   native catalog, a file uninstall deliberately retains — so the service, its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Uninstalling the last client integration now removes the background
+  service.** Whether Codex still counted as installed was keyed on the cached
+  native catalog, a file uninstall deliberately retains — so the service, its
+  LaunchAgent, and its listening ports survived every codex uninstall. The
+  installed-state witness is now the managed block in `config.toml`, which
+  enable writes and disable removes; `bin/disable` of the last client retires
+  the service too, matching what the Windows wrapper always did, and
+  `bin/enable` reinstalls it on the way back.
+
 - **Switching a model on as a subagent now researches it instead of ignoring
   it.** Only six registry-proven models could ever be spawned as native v2
   children; everything else the operator enabled was a silent no-show, and

--- a/README.md
+++ b/README.md
@@ -1270,6 +1270,8 @@ specific bytes. Browser and computer-use execution remains live-only.
 ./bin/model-router codex setup --guided
 ./bin/model-router codex doctor
 ./bin/model-router codex status
+./bin/model-router codex start
+./bin/model-router codex stop
 ./bin/model-router codex disable
 ./bin/model-router codex enable
 ./bin/model-router codex uninstall

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ official `kimi login`, prompts invisibly for provider credentials, installs a pe
 background service, and verifies every local layer. It never makes a paid test
 request unless `--smoke-test` is explicitly selected.
 
+To validate the install and uninstall lifecycle before trusting the router
+with any credential, pass `--no-provider --no-discovery`: the router installs
+idle, reads no credential from anywhere, and answers Codex traffic with a
+local error. See [docs/INSTALL.md](docs/INSTALL.md#credential-free-idle-install).
+
 Requirements:
 
 - The Codex App or CLI.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,6 +103,17 @@ trusted-user configuration and receives the same token, so it must be protected
 like every other provider override. Validated account routing is cached briefly
 in process memory and refreshed once after an upstream 401.
 
+An install made with `--no-provider --no-discovery` (see
+[docs/INSTALL.md](docs/INSTALL.md)) is verifiable in this frame: zero provider
+credential reads or writes, zero Keychain lookups, zero reads of other CLIs'
+OAuth or session files, zero reads of Codex's `auth.json`, no `codex login
+status` spawn against the real `CODEX_HOME`, and no outbound provider or
+native connection — traffic gets a local `503 router_idle_no_provider`. Every
+credential reader funnels through the persisted `discovery-mode.json`
+kill-switch. The one Codex spawn that remains during install is `codex debug
+models --bundled`, which reads the binary's static model list, not
+credentials.
+
 ## Configuration safety
 
 The config manager:

--- a/bin/model-router
+++ b/bin/model-router
@@ -17,8 +17,8 @@ command writes, not which router it talks to.
 
 Commands:
   setup, install, doctor, status, provider-key, providers, enable, disable,
-  multi-agent, media, uninstall, smoke-test, start, update, rollback, shim
-  subagent-preset (dsh only)
+  multi-agent, media, uninstall, smoke-test, start, stop, update, rollback,
+  shim, subagent-preset (dsh only)
 
 Examples:
   ./bin/model-router codex doctor
@@ -57,7 +57,7 @@ case "$target" in
 esac
 
 case "$command" in
-  setup|install|doctor|status|provider-key|providers|enable|disable|multi-agent|media|uninstall|smoke-test|start|update|rollback|subagent-preset|shim) ;;
+  setup|install|doctor|status|provider-key|providers|enable|disable|multi-agent|media|uninstall|smoke-test|start|stop|update|rollback|subagent-preset|shim) ;;
   *) echo "Unknown command: $command" >&2; usage >&2; exit 2 ;;
 esac
 

--- a/bin/stop
+++ b/bin/stop
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$repo_dir"
+node src/service.mjs stop

--- a/codex-router.ps1
+++ b/codex-router.ps1
@@ -9,8 +9,8 @@ $Arguments = if ($args.Count -gt 1) { @($args[1..($args.Count - 1)]) } else { @(
 $Commands = @(
   "setup", "install", "doctor", "status", "providers", "provider-key", "enable",
   "disable", "uninstall", "update", "rollback", "support-bundle",
-  "smoke-test", "start", "test-model", "discover-models", "signed-routing",
-  "refresh-catalog", "media"
+  "smoke-test", "start", "stop", "test-model", "discover-models",
+  "signed-routing", "refresh-catalog", "media"
 )
 if ($Command -notin $Commands) {
   throw "Unknown command '$Command'. Choose: $($Commands -join ', ')."
@@ -69,6 +69,7 @@ switch ($Command) {
     Invoke-RouterNode "src\smoke-test.mjs" $Arguments
   }
   "start" { Invoke-RouterNode "src\start.mjs" $Arguments }
+  "stop" { Invoke-RouterNode "src\service.mjs" @("stop") }
   "test-model" { Invoke-RouterNode "src\compatibility-test.mjs" $Arguments }
   "discover-models" { Invoke-RouterNode "src\model-discovery.mjs" $Arguments }
   "media" { Invoke-RouterNode "src\minimax-media.mjs" $Arguments }

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -208,6 +208,63 @@ replace an unmarked user-owned `openai_base_url`, `model_catalog_json`, or agent
 concurrency value. Disabling the router removes only its marked concurrency
 default; a user-owned value remains intact.
 
+## Credential-free (idle) install
+
+For validating the router's install, lifecycle, network, and uninstall
+behavior before trusting it with any credential, both installers accept an
+explicit idle mode:
+
+```sh
+./install.sh --target codex --no-provider --no-discovery --no-tray
+```
+
+```powershell
+./install.ps1 -Target codex -NoProvider -NoDiscovery -NoTray
+```
+
+`--no-provider` installs with an explicit empty provider selection: no
+provider is selected, no credential is prompted for or written, and the
+default-provider discovery scan is skipped. It conflicts with `--guided`,
+`--providers`, and the key-prompt flags. On its own it does not disable
+credential discovery — the doctor and tray may still look at what exists, and
+Codex's native passthrough keeps working exactly as it does for an operator
+who hides every provider by hand.
+
+`--no-discovery` (requires `--no-provider`) additionally persists a discovery
+kill-switch in the state directory (`discovery-mode.json`). While it is set:
+
+- Provider credential files, the macOS Keychain, other CLIs' OAuth and
+  session files, and Codex's own `auth.json` are never read.
+- The `codex login status` sign-in probe is never spawned against the real
+  `CODEX_HOME`. (The catalog build still runs `codex debug models --bundled`,
+  which reads a static model list, not credentials.)
+- The merged catalog publishes no models, so Codex's picker is empty by
+  design while pointed at the router.
+- Codex traffic reaching the router gets a local
+  `503 router_idle_no_provider` error instead of native or provider
+  forwarding. Nothing leaves the machine; every listener stays on
+  `127.0.0.1` as always.
+
+The full lifecycle works in this state:
+
+```sh
+./bin/model-router codex status
+./bin/model-router codex doctor    # exits 0; idle state reports as warnings
+./bin/model-router codex stop
+./bin/model-router codex start     # foreground; the service restarts it otherwise
+./bin/model-router codex uninstall
+```
+
+Uninstall is the undo path: it removes the managed config block and, once no
+client integration remains, the background service and its LaunchAgent.
+`rollback` is not — it reverts the managed *source checkout* to the previous
+revision, not the installation.
+
+To leave idle mode, re-run setup or the installer without the flags (for
+example `./bin/setup --guided`); every setup run rewrites the discovery
+marker, so a normal install re-enables discovery. `CODEX_ROUTER_NO_DISCOVERY=1`
+(or `=0`) overrides the marker either way for one process.
+
 ## Recognized older installations
 
 Read-only detection:

--- a/install.ps1
+++ b/install.ps1
@@ -15,6 +15,10 @@ param(
   # to ask for the companion at all, so it was never built and never started.
   [switch]$WithTray,
   [switch]$NoTray,
+  # Matches install.sh's --no-provider/--no-discovery: install idle with an
+  # explicit empty selection, optionally with credential discovery disabled.
+  [switch]$NoProvider,
+  [switch]$NoDiscovery,
   # Discards tracked edits in the managed checkout so the update can proceed.
   # Deliberately never touches untracked files -- see Reset-ManagedCheckout.
   [switch]$Force,
@@ -43,6 +47,15 @@ if ($MigrateKnown -and $AdoptNativeCatalog) {
 }
 if ($WithTray -and $NoTray) {
   throw "-WithTray cannot be combined with -NoTray."
+}
+# An idle install is exactly "no providers", so naming providers alongside it
+# is a contradiction; and -NoDiscovery alone would select providers that can
+# never authenticate.
+if ($NoProvider -and ($Guided -or $Providers)) {
+  throw "-NoProvider cannot be combined with -Guided or -Providers."
+}
+if ($NoDiscovery -and -not $NoProvider) {
+  throw "-NoDiscovery requires -NoProvider."
 }
 $PreviousRevision = $null
 $RepositoryUrl = if ($env:CODEX_ROUTER_REPOSITORY_URL) {
@@ -179,7 +192,7 @@ if (-not $CheckoutInstall) {
 
   $SetupScript = "src\setup.mjs"
   $SetupArguments = @((Join-Path $Repository $SetupScript))
-  $UseGuided = $Guided -or (-not $Auto -and [Environment]::UserInteractive)
+  $UseGuided = $Guided -or (-not $Auto -and -not $NoProvider -and [Environment]::UserInteractive)
   if ($UseGuided) { $SetupArguments += "--guided" }
   if ($Providers) { $SetupArguments += @("--providers", $Providers) }
   if ($MigrateKnown) { $SetupArguments += "--migrate-known" }
@@ -187,6 +200,8 @@ if (-not $CheckoutInstall) {
   if ($SmokeTest) { $SetupArguments += "--smoke-test" }
   if ($WithTray) { $SetupArguments += "--with-tray" }
   if ($NoTray) { $SetupArguments += "--no-tray" }
+  if ($NoProvider) { $SetupArguments += "--no-provider" }
+  if ($NoDiscovery) { $SetupArguments += "--no-discovery" }
   & node @SetupArguments
   $SetupExitCode = $LASTEXITCODE
   # Exit 2 means setup left configuration unfinished (a declined prompt, a

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,8 @@ migrate_known=false
 smoke_test=false
 with_tray=false
 no_tray=false
+no_provider=false
+no_discovery=false
 previous_revision=
 force=false
 target=codex
@@ -38,6 +40,9 @@ Options:
   --smoke-test       Make one small billed request per enabled provider
   --with-tray        Also build and launch the desktop companion app
   --no-tray          Never offer the desktop companion app
+  --no-provider      Install idle: no provider is selected or configured
+  --no-discovery     With --no-provider: never read credentials, the Keychain,
+                     or other CLIs' sessions; Codex traffic gets a local error
   --force            Discard edits to tracked files in the managed checkout
                      before updating it. Untracked files are never touched.
   -h, --help          Show this help
@@ -149,6 +154,14 @@ while [ "$#" -gt 0 ]; do
       no_tray=true
       shift
       ;;
+    --no-provider)
+      no_provider=true
+      shift
+      ;;
+    --no-discovery)
+      no_discovery=true
+      shift
+      ;;
     --migrate-known)
       migrate_known=true
       shift
@@ -180,6 +193,15 @@ esac
 # counterpart in the harness, whose integration is one settings section.
 if [ "$target" != codex ] && [ "$migrate_known" = true ]; then
   die "--migrate-known applies only to the Codex target"
+fi
+# An idle install is exactly "no providers", so naming providers or pasting
+# keys alongside it is a contradiction; and --no-discovery alone would select
+# providers that can never authenticate.
+if [ "$no_provider" = true ] && { [ -n "$providers" ] || [ -n "$configure_provider_keys" ] || [ "$guided" = true ]; }; then
+  die "--no-provider cannot be combined with --guided, --providers, or key flags"
+fi
+if [ "$no_discovery" = true ] && [ "$no_provider" != true ]; then
+  die "--no-discovery requires --no-provider"
 fi
 MODEL_ROUTER_TARGET=$target
 export MODEL_ROUTER_TARGET
@@ -256,7 +278,9 @@ for provider_id in $configure_provider_keys; do
 done
 
 if [ "$guided" = auto ]; then
-  if [ -t 1 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
+  if [ "$no_provider" = true ]; then
+    guided=false
+  elif [ -t 1 ] && [ -r /dev/tty ] && [ -w /dev/tty ]; then
     guided=true
   else
     guided=false
@@ -270,6 +294,8 @@ if [ "$migrate_known" = true ]; then set -- "$@" --migrate-known; fi
 if [ "$smoke_test" = true ]; then set -- "$@" --smoke-test; fi
 if [ "$with_tray" = true ]; then set -- "$@" --with-tray; fi
 if [ "$no_tray" = true ]; then set -- "$@" --no-tray; fi
+if [ "$no_provider" = true ]; then set -- "$@" --no-provider; fi
+if [ "$no_discovery" = true ]; then set -- "$@" --no-discovery; fi
 setup_status=0
 "$repo_dir/bin/setup" "$@" || setup_status=$?
 # Exit 2 means setup left configuration unfinished (a declined prompt, a

--- a/src/cli-session-credential.mjs
+++ b/src/cli-session-credential.mjs
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { discoveryDisabled } from "./discovery-mode.mjs";
+
 // Some providers finish a browser OAuth flow in their own CLI and then mint a
 // long-lived API key into that CLI's home directory instead of handing back a
 // refreshable token pair. Command Code works this way: `command-code login`
@@ -39,6 +41,9 @@ export function cliSessionPath(provider) {
 export function readCliSessionCredential(provider) {
   const descriptor = cliSessionDescriptor(provider);
   if (!descriptor) return undefined;
+  // Defense in depth for --no-discovery: another CLI's session file must not
+  // be opened at all while discovery is off.
+  if (discoveryDisabled()) return undefined;
   const file = cliSessionPath(provider);
   if (!file || !existsSync(file)) return undefined;
   let parsed;

--- a/src/codex-account-usage.mjs
+++ b/src/codex-account-usage.mjs
@@ -2,6 +2,7 @@ import { execFileSync, spawn } from "node:child_process";
 import readline from "node:readline";
 
 import { findCodexBinary } from "./codex-binary.mjs";
+import { discoveryDisabled } from "./discovery-mode.mjs";
 import { spawnableCommand } from "./spawnable-command.mjs";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -94,6 +95,15 @@ export function readCodexAccountUsage({
   spawnImpl = spawn,
 } = {}) {
   return new Promise((resolve, reject) => {
+    // The app-server answers with the signed-in ChatGPT account's usage, which
+    // makes this a live credential probe against the real CODEX_HOME -- the
+    // same class of read codexAuthStatus() refuses. The tray polls this every
+    // 30 seconds, so an unguarded spawn here would quietly break the
+    // --no-discovery promise in the background.
+    if (discoveryDisabled()) {
+      reject(new Error("Credential discovery is disabled (--no-discovery); the Codex account is not read."));
+      return;
+    }
     if (!binary) {
       reject(new Error("The Codex app-server could not be started: no Codex binary was found."));
       return;

--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { isShimFile, resolveRealCodex } from "./codex-shim.mjs";
+import { discoveryDisabled } from "./discovery-mode.mjs";
 import { commandOnPath, preferSpawnablePath, spawnableCommand } from "./spawnable-command.mjs";
 
 export { preferSpawnablePath, spawnableCommand };
@@ -116,6 +117,13 @@ export function codexVersion() {
 // every native model from the catalog. Report the reason so callers can refuse
 // to act on an unknown instead of treating it as a definite "logged out".
 export function codexAuthStatus() {
+  // `codex login status` is a credential probe, so --no-discovery skips the
+  // spawn entirely. The distinct reason keeps this apart from "probe-failed":
+  // the catalog treats it like a deliberate signed-out answer (publish no
+  // native models) instead of refusing to rebuild.
+  if (discoveryDisabled()) {
+    return { authenticated: false, reason: "discovery-disabled" };
+  }
   const binary = findCodexBinary();
   if (!binary) return { authenticated: false, reason: "codex-not-found" };
   try {

--- a/src/codex-native-session.mjs
+++ b/src/codex-native-session.mjs
@@ -163,6 +163,21 @@ export function nativeSessionAvailable() {
  * from "not signed in".
  */
 export function nativeSessionStatus() {
+  // Whether auth.json exists, and how old it is, is metadata about a
+  // credential this process promised not to look at. Reporting it absent is
+  // the same answer every other guarded reader gives under --no-discovery.
+  if (discoveryDisabled()) {
+    return {
+      path: CODEX_AUTH_PATH,
+      present: false,
+      usable: false,
+      hasAccountId: false,
+      expired: false,
+      expiresInHours: undefined,
+      ageHours: undefined,
+      fallbackEnabled: false,
+    };
+  }
   const present = existsSync(CODEX_AUTH_PATH);
   const session = present ? readSession() : undefined;
   let ageHours;

--- a/src/codex-native-session.mjs
+++ b/src/codex-native-session.mjs
@@ -97,6 +97,10 @@ const REFRESH_RETRY_INTERVAL_MS = 5 * 60_000;
 const REFRESH_TIMEOUT_MS = 30_000;
 
 export async function refreshViaCodex({ now = Date.now() } = {}) {
+  // `codex login status` makes Codex read (and possibly rewrite) its session
+  // file; unreachable while readSession() is guarded, but the promise should
+  // not depend on that call graph staying put.
+  if (discoveryDisabled()) return false;
   if (refreshInFlight) return refreshInFlight;
   if (now - lastRefreshAttemptMs < REFRESH_RETRY_INTERVAL_MS) return false;
   lastRefreshAttemptMs = now;

--- a/src/codex-native-session.mjs
+++ b/src/codex-native-session.mjs
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
+import { discoveryDisabled } from "./discovery-mode.mjs";
 import { CODEX_HOME } from "./paths.mjs";
 
 // The ChatGPT session the local Codex install already holds.
@@ -26,6 +27,10 @@ export const CODEX_AUTH_PATH =
 // local process holding that key can spend the ChatGPT subscription and not
 // only the API-key providers -- so there has to be a way to say no.
 export function nativeSessionFallbackEnabled() {
+  // --no-discovery composes with the dedicated env switch: the Codex session
+  // is a credential this process did not receive from its caller, so an idle
+  // install must never spend it.
+  if (discoveryDisabled()) return false;
   return process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK !== "0";
 }
 
@@ -49,6 +54,9 @@ export function tokenExpiryMs(accessToken) {
 const EXPIRY_SKEW_MS = 120_000;
 
 function readSession() {
+  // Under --no-discovery the Codex auth file is never opened; status readers
+  // above report it absent rather than pretending to know what is inside.
+  if (discoveryDisabled()) return undefined;
   if (!existsSync(CODEX_AUTH_PATH)) return undefined;
   try {
     const parsed = JSON.parse(readFileSync(CODEX_AUTH_PATH, "utf8"));

--- a/src/discovery-mode.mjs
+++ b/src/discovery-mode.mjs
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { writePrivateJson } from "./file-security.mjs";
+import { DISCOVERY_MODE_PATH } from "./paths.mjs";
+
+// Credential discovery is every read of a secret the operator did not hand to
+// this process directly: provider credential files, the macOS Keychain, other
+// CLIs' session files, OAuth credential files, the Codex session, and the
+// `codex login status` probe. An install made with `--no-discovery` promises
+// none of those happen, and the promise has to survive the installer process:
+// the router, the doctor, and the tray all consult this switch, so the marker
+// is persisted in the state directory rather than carried in an environment
+// variable that dies with the setup run.
+//
+// `CODEX_ROUTER_NO_DISCOVERY` overrides the file in both directions ("1"
+// disables, "0" forces enabled). The installer uses it to make every child
+// process honor the choice before the state directory exists, and tests use
+// it to pin either mode.
+
+let cached;
+
+export function discoveryDisabled() {
+  const override = process.env.CODEX_ROUTER_NO_DISCOVERY;
+  if (override === "1") return true;
+  if (override === "0") return false;
+  if (cached === undefined) cached = readDiscoveryModeFile();
+  return cached;
+}
+
+function readDiscoveryModeFile() {
+  if (!existsSync(DISCOVERY_MODE_PATH)) return false;
+  try {
+    const parsed = JSON.parse(readFileSync(DISCOVERY_MODE_PATH, "utf8"));
+    // An unreadable or unrecognized file means the operator's intent cannot be
+    // proven, and the conservative reading of "cannot prove --no-discovery"
+    // is to keep discovery on: that is the state every install without the
+    // flag has always had.
+    return parsed?.version === 1 && parsed.discovery === "disabled";
+  } catch {
+    return false;
+  }
+}
+
+export function writeDiscoveryMode(disabled) {
+  writePrivateJson(
+    DISCOVERY_MODE_PATH,
+    { version: 1, discovery: disabled ? "disabled" : "enabled" },
+    { directoryMode: 0o700 },
+  );
+  cached = undefined;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const command = process.argv[2] || "status";
+  if (command === "status") {
+    process.stdout.write(
+      `${JSON.stringify({ discovery: discoveryDisabled() ? "disabled" : "enabled" })}\n`,
+    );
+  } else if (command === "set" && ["enabled", "disabled"].includes(process.argv[3])) {
+    writeDiscoveryMode(process.argv[3] === "disabled");
+    process.stdout.write(`${JSON.stringify({ discovery: process.argv[3] })}\n`);
+  } else {
+    console.error("Usage: discovery-mode.mjs status|set enabled|disabled");
+    process.exit(2);
+  }
+}

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -40,6 +40,7 @@ import {
   skillRequiredFields,
 } from "./skills-install.mjs";
 import { cliSessionDescriptor } from "./cli-session-credential.mjs";
+import { discoveryDisabled } from "./discovery-mode.mjs";
 import { credentialLabel, credentialStatus } from "./provider-credentials.mjs";
 import { providerNeedsCuration } from "./provider-onboarding.mjs";
 import { stateOwnershipStatus } from "./state-owner.mjs";
@@ -123,6 +124,10 @@ export function codexConfigLoadError({
   spawn = spawnSync,
   binaries = [findCodexBinary(), commandOnPath("codex")],
 } = {}) {
+  // The probe is `codex login status` against the user's real CODEX_HOME, and
+  // Codex reads its session file to answer it. --no-discovery promises that
+  // read never happens, so the config-load check goes unanswered in idle mode.
+  if (discoveryDisabled()) return undefined;
   const seen = new Set();
   for (const binary of binaries) {
     if (!binary || seen.has(binary)) continue;
@@ -347,18 +352,29 @@ let requiredModels = new Set();
 const routedTransportActive = codexTarget
   ? routedCatalogConfigured(existsSync(CONFIG_PATH) ? readFileSync(CONFIG_PATH, "utf8") : "")
   : existsSync(DSH_CATALOG_PATH);
+// An install made with --no-provider --no-discovery is idle on purpose: the
+// selection is an explicit empty list and the discovery marker is set. That
+// state is what the operator asked for, so the empty selection and the empty
+// catalog report at warn/ok -- the precedent is serviceStoppedByDesign below.
+let idleInstall = false;
 try {
   selection = providerSelectionStatus();
+  idleInstall =
+    selection.explicit && selection.providers.length === 0 && discoveryDisabled();
   requiredRoutedModels = selectedConfiguredListedModels();
   catalogRoutedModels = routedTransportActive ? requiredRoutedModels : [];
   requiredModels = new Set(catalogRoutedModels.map((model) => model.slug));
   add(
-    selection.providers.length ? "ok" : "fail",
+    selection.providers.length ? "ok" : idleInstall ? "warn" : "fail",
     "Enabled providers",
     selection.providers.length
       ? `${selection.providers.join(", ")}${selection.explicit ? "" : " (legacy show-all mode)"}`
-      : "none",
-    "Run ./bin/setup --guided and choose at least one provider.",
+      : idleInstall
+        ? "none (idle install: --no-provider)"
+        : "none",
+    idleInstall
+      ? "Run ./bin/setup without --no-provider to enable a provider."
+      : "Run ./bin/setup --guided and choose at least one provider.",
   );
   // The router no longer refuses to serve on a selection file it cannot fully
   // resolve, so the damage has to be reported here instead of as a 502.
@@ -392,20 +408,24 @@ try {
 }
 const catalogOk =
   catalogReadable &&
-  (routedTransportActive
+  (routedTransportActive && !idleInstall
     ? requiredModels.size > 0 &&
       [...requiredModels].every((slug) => catalogModels.some((model) => model.slug === slug))
     : !catalogModels.some((model) => MODEL_BY_SLUG.has(String(model.slug))));
 // The merged catalog is the file Codex reads. A harness install has no
 // equivalent: its offer is the settings route, checked by "Harness routing
-// config" below.
+// config" below. An idle install deliberately publishes no routed models, so
+// its catalog is held to the same standard as inactive transport: nothing
+// routable may be offered.
 if (codexTarget) add(
   catalogOk ? "ok" : "fail",
   "Merged catalog",
   catalogOk
-    ? routedTransportActive
-      ? `${requiredModels.size} routed models`
-      : "native-only; routed transport is inactive"
+    ? idleInstall
+      ? "idle install; no routed models"
+      : routedTransportActive
+        ? `${requiredModels.size} routed models`
+        : "native-only; routed transport is inactive"
     : MERGED_CATALOG_PATH,
   "Run ./bin/refresh-catalog, or ./bin/doctor --fix if files are missing.",
 );
@@ -603,40 +623,65 @@ add(
   "Run ./bin/doctor --fix; this capability is generated locally and is not a provider key.",
 );
 
-const kimiHealth = kimiOAuthHealth();
-const kimiSelected = selection.providers.includes("kimi-oauth");
-// An expired access token is a normal, recoverable state: the request path
-// refreshes it with the still-valid refresh token before forwarding, so it
-// must not read as a failure here. Every unusable state fails when Kimi OAuth
-// is selected; an unselected provider is advisory regardless of credential
-// health.
-const kimiStatus = !kimiSelected
-  ? "warn"
-  : kimiHealth.status === "ok" || kimiHealth.status === "stale"
-    ? "ok"
-    : "fail";
-add(
-  kimiStatus,
-  "Kimi OAuth",
-  kimiHealth.detail,
-  kimiHealth.fix,
-);
-const grokOauth = grokOAuthStatus();
-const grokCli = grokCliPreflight();
-const grokOauthReady = grokOauth.configured && grokCli.runnable;
-add(
-  grokOauthReady ? "ok" : selection.providers.includes("grok-oauth") ? "fail" : "warn",
-  "Grok OAuth",
-  !grokCli.runnable
-    ? grokCli.detail
-    : grokOauth.configured
-      ? grokOauth.source
-      : `not configured; ${grokOauth.setup}`,
-  !grokCli.runnable ? grokCli.fix : "Run grok login, then rerun the doctor.",
-);
+// Per-provider credential rows are themselves discovery: each one resolves the
+// provider's credential. Under --no-discovery the resolvers answer nothing by
+// design, so 26 rows of "not configured" would report the guard's output as
+// though it were the machine's state. One row says what is actually true.
+const credentialDiscoveryOff = discoveryDisabled();
+if (credentialDiscoveryOff) {
+  add(
+    "warn",
+    "Credential discovery",
+    "disabled (--no-discovery); provider credentials, the Keychain, and other CLIs' sessions are not read",
+    "Re-run ./bin/setup without --no-discovery to re-enable it.",
+  );
+  const listenHost = process.env.CODEX_ROUTER_HOST || process.env.KIMI_ROUTER_HOST;
+  if (listenHost && !["127.0.0.1", "localhost", "::1"].includes(listenHost)) {
+    add(
+      "warn",
+      "Router listen host",
+      `${listenHost} (an idle install is expected to stay loopback-only)`,
+      "Unset CODEX_ROUTER_HOST / KIMI_ROUTER_HOST to bind 127.0.0.1.",
+    );
+  }
+}
+if (!credentialDiscoveryOff) {
+  const kimiHealth = kimiOAuthHealth();
+  const kimiSelected = selection.providers.includes("kimi-oauth");
+  // An expired access token is a normal, recoverable state: the request path
+  // refreshes it with the still-valid refresh token before forwarding, so it
+  // must not read as a failure here. Every unusable state fails when Kimi OAuth
+  // is selected; an unselected provider is advisory regardless of credential
+  // health.
+  const kimiStatus = !kimiSelected
+    ? "warn"
+    : kimiHealth.status === "ok" || kimiHealth.status === "stale"
+      ? "ok"
+      : "fail";
+  add(
+    kimiStatus,
+    "Kimi OAuth",
+    kimiHealth.detail,
+    kimiHealth.fix,
+  );
+  const grokOauth = grokOAuthStatus();
+  const grokCli = grokCliPreflight();
+  const grokOauthReady = grokOauth.configured && grokCli.runnable;
+  add(
+    grokOauthReady ? "ok" : selection.providers.includes("grok-oauth") ? "fail" : "warn",
+    "Grok OAuth",
+    !grokCli.runnable
+      ? grokCli.detail
+      : grokOauth.configured
+        ? grokOauth.source
+        : `not configured; ${grokOauth.setup}`,
+    !grokCli.runnable ? grokCli.fix : "Run grok login, then rerun the doctor.",
+  );
+}
 
 for (const provider of PROVIDERS.values()) {
   if (provider.kind !== "openai-compatible") continue;
+  if (credentialDiscoveryOff) continue;
   const status = credentialStatus(provider, { persistent: true });
   const session = cliSessionDescriptor(provider);
   const credentialType = credentialLabel(provider);

--- a/src/grok-oauth-status.mjs
+++ b/src/grok-oauth-status.mjs
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { discoveryDisabled } from "./discovery-mode.mjs";
+
 export function grokSessionEntry(auth) {
   if (!auth || typeof auth !== "object" || Array.isArray(auth)) return undefined;
   return Object.entries(auth).find(
@@ -27,6 +29,15 @@ export function grokAuthPath() {
 // Report only credential presence. Token values never leave this module.
 export function grokOAuthStatus() {
   const authPath = grokAuthPath();
+  // Defense in depth for --no-discovery: another CLI's session file must not
+  // be opened at all while discovery is off.
+  if (discoveryDisabled()) {
+    return {
+      configured: false,
+      authPath,
+      setup: "Credential discovery is disabled; re-run setup without --no-discovery",
+    };
+  }
   if (!existsSync(authPath)) {
     return {
       configured: false,

--- a/src/oauth-status.mjs
+++ b/src/oauth-status.mjs
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { discoveryDisabled } from "./discovery-mode.mjs";
+
 export function kimiCodeHome() {
   return process.env.KIMI_CODE_HOME || path.join(os.homedir(), ".kimi-code");
 }
@@ -12,6 +14,16 @@ function kimiCredentialsPath() {
 
 export function kimiOAuthStatus() {
   const credentialsPath = kimiCredentialsPath();
+  // Defense in depth for --no-discovery: the caller-facing scans are already
+  // guarded, but this file is another CLI's credential store and must not be
+  // opened at all while discovery is off.
+  if (discoveryDisabled()) {
+    return {
+      configured: false,
+      credentialsPath,
+      setup: "Credential discovery is disabled; re-run setup without --no-discovery",
+    };
+  }
   if (!existsSync(credentialsPath)) {
     return {
       configured: false,
@@ -54,6 +66,13 @@ export function kimiOAuthStatus() {
 // - `incomplete` / `invalid` / `missing`: no usable session on disk
 export function kimiOAuthHealth() {
   const credentialsPath = kimiCredentialsPath();
+  if (discoveryDisabled()) {
+    return {
+      status: "missing",
+      detail: "credential discovery is disabled",
+      fix: "Re-run setup without --no-discovery",
+    };
+  }
   if (!existsSync(credentialsPath)) {
     return {
       status: "missing",

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -90,6 +90,7 @@ export const CALLER_SECRET_PATH = path.join(STATE_DIR, "caller-secret");
 export const CODEX_PROVIDER_MODE_PATH = path.join(STATE_DIR, "codex-provider-mode.json");
 export const SIGNED_PROVIDER_MODE_PATH = path.join(STATE_DIR, "signed-provider-mode.json");
 export const PROVIDER_SELECTION_PATH = path.join(STATE_DIR, "enabled-providers.json");
+export const DISCOVERY_MODE_PATH = path.join(STATE_DIR, "discovery-mode.json");
 export const INSTALL_MANIFEST_PATH = path.join(STATE_DIR, "install-manifest.json");
 export const SKILL_OWNERSHIP_PATH = path.join(STATE_DIR, "managed-skills.json");
 export const MIGRATIONS_DIR = path.join(STATE_DIR, "migrations");

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -15,6 +15,7 @@ import {
   cliSessionDescriptor,
   readCliSessionCredential,
 } from "./cli-session-credential.mjs";
+import { discoveryDisabled } from "./discovery-mode.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
 import { LEGACY_STATE_DIRS, STATE_DIR, TARGET } from "./paths.mjs";
 import { targetCli } from "./target-integration.mjs";
@@ -154,6 +155,11 @@ export function resolveProviderCredential(providerOrId, options = {}) {
   if (provider.keyless) {
     return { value: "local", source: "local endpoint (no key required)", persistent: true };
   }
+  // The --no-discovery promise: no environment sniffing, no credential files,
+  // no Keychain spawn, no other CLI's session file. The guard sits here, after
+  // the anonymous and keyless returns, because those two read nothing -- and
+  // before everything that does.
+  if (discoveryDisabled()) return undefined;
   if (!options.persistent) {
     for (const name of provider.credential.environment) {
       const value = process.env[name]?.trim();

--- a/src/provider-selection.mjs
+++ b/src/provider-selection.mjs
@@ -252,9 +252,19 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
         `${JSON.stringify({ providers: writeProviderSelection(values) }, null, 2)}\n`,
       );
     } else if (command === "ensure-configured") {
-      const providers = existsSync(PROVIDER_SELECTION_PATH)
+      const explicit = existsSync(PROVIDER_SELECTION_PATH);
+      const providers = explicit
         ? readProviderSelection()
         : writeProviderSelection(defaultProviderIds());
+      // An explicitly written empty selection is a deliberate state -- an
+      // idle --no-provider install, or an operator who hid the last provider
+      // -- and installing on top of it must keep working, or `bin/update`
+      // would strand exactly those installs. Only a *discovered* empty set
+      // still means "nothing can authenticate yet".
+      if (providers.length === 0 && explicit) {
+        process.stdout.write(`${JSON.stringify({ providers: [], idle: true }, null, 2)}\n`);
+        process.exit(0);
+      }
       if (providers.length === 0) {
         throw new Error(
           `No provider credential is configured. Run ${

--- a/src/provider-selection.mjs
+++ b/src/provider-selection.mjs
@@ -9,6 +9,7 @@ import {
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { discoveryDisabled } from "./discovery-mode.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
 import { PROVIDER_SELECTION_PATH, STATE_DIR, TARGET } from "./paths.mjs";
 import { LISTED_MODELS, PROVIDERS } from "./model-registry.mjs";
@@ -79,6 +80,11 @@ function filterKnownProviderIds(values) {
 }
 
 export function configuredProviderIds() {
+  // Under --no-discovery nothing counts as configured, not even keyless local
+  // backends that read no credential: "configured" feeds the default
+  // selection, the catalog, and the enable gate, and an idle install promises
+  // all of those stay empty until the operator re-runs setup.
+  if (discoveryDisabled()) return [];
   const configured = [];
   for (const provider of PROVIDERS.values()) {
     if (provider.kind === "oauth") {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -36,6 +36,7 @@ import {
 } from "./paths.mjs";
 import { MODEL_BY_SLUG, PROVIDERS, providerForModel } from "./model-registry.mjs";
 import { createHealthCache } from "./health-cache.mjs";
+import { discoveryDisabled } from "./discovery-mode.mjs";
 import { readNativeAliases } from "./native-alias.mjs";
 import { readNativeRedirect } from "./native-redirect.mjs";
 import {
@@ -1710,6 +1711,23 @@ function observeSubagentOutcome(request, route, status, { emptyCompletion = fals
   }
 }
 
+// The local answer an idle install gives instead of native forwarding. With
+// discovery disabled the native path is impossible by construction -- the
+// session fallback never reads auth.json -- so traffic that would leave for
+// chatgpt.com is refused before any upstream fetch, keeping the --no-discovery
+// promise that nothing leaves this machine.
+function writeIdleNoProviderError(response) {
+  writeJson(response, 503, {
+    error: {
+      type: "router_idle_no_provider",
+      message:
+        "This router was installed without providers and with credential discovery disabled " +
+        "(--no-provider --no-discovery), so no traffic leaves this machine. " +
+        "Re-run setup without those flags to enable a provider.",
+    },
+  });
+}
+
 async function handleResponses(request, response, requestUrl) {
   const startedAt = Date.now();
   const activity = beginRequestActivity();
@@ -1771,6 +1789,13 @@ async function handleResponses(request, response, requestUrl) {
           message: `Provider ${registeredRoute.provider} is hidden. Run ./bin/providers enable ${registeredRoute.provider}.`,
         },
       });
+      return;
+    }
+    // Anything without a route from here on is native GPT traffic. An install
+    // that merely hid every provider keeps its native passthrough -- that has
+    // always worked -- but an idle --no-discovery install answers locally.
+    if (!route && discoveryDisabled()) {
+      writeIdleNoProviderError(response);
       return;
     }
     // Activity and usage attribute protocol variants to their canonical
@@ -2377,6 +2402,12 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
   let requestedModel = defaultModel;
   try {
     if (!requireCodexTransport(request, response)) return;
+    // Image and web-search turns are native-only; an idle install refuses
+    // them locally rather than forwarding to chatgpt.com.
+    if (discoveryDisabled()) {
+      writeIdleNoProviderError(response);
+      return;
+    }
     const encoded = await readRequestBody(request);
     const body = decodeBody(encoded, request.headers["content-encoding"]);
     const payload = parseBody(body);

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -24,6 +24,7 @@ import {
   validateProviderIds,
   writeProviderSelection,
 } from "./provider-selection.mjs";
+import { writeDiscoveryMode } from "./discovery-mode.mjs";
 import { trayBundleDir, trayDecision } from "./tray-install.mjs";
 import { resolveVisionEngine } from "./vision-bridge.mjs";
 import {
@@ -39,6 +40,8 @@ const runSmoke = args.includes("--smoke-test");
 const selectionOnly = args.includes("--selection-only");
 const withTray = args.includes("--with-tray");
 const noTray = args.includes("--no-tray");
+const noProvider = args.includes("--no-provider");
+const noDiscovery = args.includes("--no-discovery");
 
 const flagOptions = new Set([
   "--guided",
@@ -49,6 +52,8 @@ const flagOptions = new Set([
   "--selection-only",
   "--with-tray",
   "--no-tray",
+  "--no-provider",
+  "--no-discovery",
   "--help",
 ]);
 let setupArgumentError;
@@ -69,6 +74,23 @@ if (!setupArgumentError && migrateKnown && adoptNativeCatalog) {
   setupArgumentError =
     "--adopt-native-catalog cannot be combined with --migrate-known.";
 }
+// An idle install is exactly "no providers": naming providers, answering the
+// guided picker, or pasting keys alongside it is a contradiction to report,
+// not to guess about. And --no-discovery without --no-provider would select
+// providers that can never authenticate, so the narrower flag requires the
+// wider one.
+if (!setupArgumentError && noProvider && (guided || args.includes("--providers"))) {
+  setupArgumentError = `--no-provider cannot be combined with ${
+    guided ? "--guided" : "--providers"
+  }.`;
+}
+if (!setupArgumentError && noDiscovery && !noProvider) {
+  setupArgumentError = "--no-discovery requires --no-provider.";
+}
+// Children (bin/install, the catalog build, the doctor) must honor the choice
+// before the marker file exists -- and a re-run without the flag must clear a
+// stale environment value just as writeDiscoveryMode clears the marker.
+process.env.CODEX_ROUTER_NO_DISCOVERY = noDiscovery ? "1" : "0";
 // Both act on Codex's own configuration: one replaces an older router's
 // managed block, the other adopts the ChatGPT-plan catalog Codex reads. The
 // harness integration is one settings section and has neither.
@@ -114,6 +136,9 @@ Options:
   --selection-only     Save provider selection without installing (development)
   --with-tray          Also build and launch the desktop companion app
   --no-tray            Never offer the desktop companion app
+  --no-provider        Install idle, with no provider selected or configured
+  --no-discovery       With --no-provider: never read credentials, the
+                       Keychain, or other CLIs' sessions; refuse traffic locally
   --help               Show this help
 
 Providers: ${[...PROVIDERS.values()].filter((provider) => !provider.variantOf).map((provider) => provider.id).join(", ")}
@@ -210,6 +235,9 @@ function guidedSelection() {
 }
 
 function requestedSelection() {
+  // The idle install asks for nothing, so nothing is scanned to find it: the
+  // defaultProviderIds() fallback below is itself a full credential sweep.
+  if (noProvider) return [];
   const requested = option("--providers");
   if (requested) {
     if (requested === "configured") return defaultProviderIds();
@@ -376,7 +404,7 @@ async function main() {
       ? error
       : incomplete(error instanceof Error ? error.message : String(error));
   }
-  if (providers.length === 0) {
+  if (providers.length === 0 && !noProvider) {
     throw incomplete(
       "No configured provider was found. Run `./bin/setup --guided` or pass `--providers` after configuring credentials.",
     );
@@ -401,6 +429,10 @@ async function main() {
     }
   }
   writeProviderSelection(providers);
+  // Written on every run, not only idle ones: re-running setup without
+  // --no-discovery is the exit path from idle mode, so a normal install must
+  // clear the marker just as an idle install sets it.
+  writeDiscoveryMode(noDiscovery);
 
   // Pasted images just work for text-only models: the bridge is on by default,
   // so the installer no longer writes anything here. It used to auto-enable
@@ -443,7 +475,7 @@ async function main() {
   if (guided) {
     process.stdout.write(
       `\nReady to install:\n` +
-        `  Providers: ${providers.join(", ")}\n` +
+        `  Providers: ${providers.length ? providers.join(", ") : "none (idle install)"}\n` +
         `  Migration: ${migration ? "recognized older router (rollback snapshot kept)" : "none needed"}\n` +
         (dshTarget
           ? `  Changes: per-user background service and one provider route in the harness settings document\n`
@@ -489,11 +521,14 @@ async function main() {
     run(process.execPath, [path.join(SOURCE_ROOT, "src", "smoke-test.mjs"), "--yes"]);
   }
   run(process.execPath, [path.join(SOURCE_ROOT, "src", "doctor.mjs")]);
+  const providerSummary = providers.length
+    ? providers.join(", ")
+    : "no providers (idle install; traffic gets a local error until one is enabled)";
   process.stdout.write(
     dshTarget
-      ? `\nDeepSeek Harness is ready with: ${providers.join(", ")}\n` +
+      ? `\nDeepSeek Harness is ready with: ${providerSummary}\n` +
         `It reloads its settings document on the next request, so there is nothing to restart.\n`
-      : `\nCodex Router is ready with: ${providers.join(", ")}\nFully quit Codex, reopen it, and start a new task.\n`,
+      : `\nCodex Router is ready with: ${providerSummary}\nFully quit Codex, reopen it, and start a new task.\n`,
   );
   if (visionBridge?.enabled && visionBridge.engine) {
     process.stdout.write(

--- a/src/target-integration.mjs
+++ b/src/target-integration.mjs
@@ -1,9 +1,22 @@
 import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { DSH_CATALOG_PATH, NATIVE_CATALOG_PATH, SOURCE_ROOT, TARGET } from "./paths.mjs";
+import {
+  CONFIG_PATH,
+  DSH_CATALOG_PATH,
+  NATIVE_CATALOG_PATH,
+  SOURCE_ROOT,
+  TARGET,
+} from "./paths.mjs";
+
+// The begin markers config-manager.mjs writes around every block it owns,
+// including the legacy kimi-era pairs it still recognizes. config-manager.mjs
+// is a command-line script, so the prefix is restated here rather than
+// imported; the markers are a compatibility surface that lives in users'
+// config files and cannot change without a migration anyway.
+const managedMarkerPattern = /^# BEGIN (?:kimi-)?codex-(?:router|proxy)-/m;
 
 function run(script, args = []) {
   execFileSync(process.execPath, [path.join(SOURCE_ROOT, "src", script), ...args], {
@@ -53,9 +66,23 @@ export function targetRestartHint() {
  */
 export function installedTargets() {
   const installed = [];
-  if (existsSync(NATIVE_CATALOG_PATH)) installed.push("codex");
+  // Codex counts as installed while its config still carries a managed block.
+  // The cached native catalog is deliberately retained across uninstalls, so
+  // its presence says a catalog was once published, not that Codex is still
+  // pointed at the plane -- keying on it left the service and its LaunchAgent
+  // behind after the last integration was removed.
+  if (codexIntegrationInstalled()) installed.push("codex");
   if (existsSync(DSH_CATALOG_PATH)) installed.push("dsh");
   return installed;
+}
+
+function codexIntegrationInstalled() {
+  if (!existsSync(CONFIG_PATH)) return false;
+  try {
+    return managedMarkerPattern.test(readFileSync(CONFIG_PATH, "utf8"));
+  } catch {
+    return false;
+  }
 }
 
 export function refreshTargetPickerIfInstalled() {

--- a/test/discovery-mode.test.mjs
+++ b/test/discovery-mode.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, statSync, writeFileSync, mkdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-discovery-"));
+process.env.CODEX_HOME = path.join(testRoot, "codex");
+process.env.CODEX_ROUTER_STATE_DIR = path.join(testRoot, "state");
+process.env.KIMI_CODE_HOME = path.join(testRoot, "kimi-code");
+process.env.GROK_AUTH_PATH = path.join(testRoot, "grok", "auth.json");
+delete process.env.CODEX_ROUTER_NO_DISCOVERY;
+
+const { discoveryDisabled, writeDiscoveryMode } = await import("../src/discovery-mode.mjs");
+const { DISCOVERY_MODE_PATH } = await import("../src/paths.mjs");
+
+test("discovery is enabled by default and the marker survives a process's choice", () => {
+  // No marker file is the state every install before the flag existed had.
+  assert.equal(discoveryDisabled(), false);
+
+  writeDiscoveryMode(true);
+  assert.equal(discoveryDisabled(), true);
+  if (process.platform !== "win32") {
+    assert.equal(statSync(DISCOVERY_MODE_PATH).mode & 0o777, 0o600);
+  }
+
+  writeDiscoveryMode(false);
+  assert.equal(discoveryDisabled(), false);
+});
+
+test("the environment override wins over the marker in both directions", () => {
+  try {
+    writeDiscoveryMode(false);
+    process.env.CODEX_ROUTER_NO_DISCOVERY = "1";
+    assert.equal(discoveryDisabled(), true);
+
+    writeDiscoveryMode(true);
+    process.env.CODEX_ROUTER_NO_DISCOVERY = "0";
+    assert.equal(discoveryDisabled(), false);
+  } finally {
+    delete process.env.CODEX_ROUTER_NO_DISCOVERY;
+    writeDiscoveryMode(false);
+  }
+});
+
+test("an unrecognized marker file keeps discovery on", () => {
+  try {
+    // "Cannot prove --no-discovery" must read as the state every install
+    // without the flag has always had, not as a surprise lockout.
+    mkdirSync(path.dirname(DISCOVERY_MODE_PATH), { recursive: true });
+    writeDiscoveryMode(false); // drop the module's cached reading via the API
+    writeFileSync(DISCOVERY_MODE_PATH, "not json", "utf8");
+    assert.equal(discoveryDisabled(), false);
+
+    writeDiscoveryMode(false);
+    writeFileSync(DISCOVERY_MODE_PATH, '{"version":99,"discovery":"disabled"}\n', "utf8");
+    assert.equal(discoveryDisabled(), false);
+  } finally {
+    delete process.env.CODEX_ROUTER_NO_DISCOVERY;
+    writeDiscoveryMode(false);
+  }
+});
+
+test("disabling discovery empties the configured set and blinds every reader", async () => {
+  const { configuredProviderIds } = await import("../src/provider-selection.mjs");
+  const { kimiOAuthStatus } = await import("../src/oauth-status.mjs");
+  const { grokOAuthStatus } = await import("../src/grok-oauth-status.mjs");
+  const { codexAuthStatus } = await import("../src/codex-binary.mjs");
+  const { nativeSessionFallbackEnabled } = await import("../src/codex-native-session.mjs");
+  try {
+    process.env.CODEX_ROUTER_NO_DISCOVERY = "1";
+    // Even keyless local backends drop out: "configured" feeds the default
+    // selection and the enable gate, and an idle install keeps both empty.
+    assert.deepEqual(configuredProviderIds(), []);
+    assert.equal(kimiOAuthStatus().configured, false);
+    assert.match(kimiOAuthStatus().setup, /discovery is disabled/i);
+    assert.equal(grokOAuthStatus().configured, false);
+    assert.deepEqual(codexAuthStatus(), {
+      authenticated: false,
+      reason: "discovery-disabled",
+    });
+    assert.equal(nativeSessionFallbackEnabled(), false);
+  } finally {
+    delete process.env.CODEX_ROUTER_NO_DISCOVERY;
+  }
+});
+
+test.after(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});

--- a/test/discovery-mode.test.mjs
+++ b/test/discovery-mode.test.mjs
@@ -66,7 +66,10 @@ test("disabling discovery empties the configured set and blinds every reader", a
   const { kimiOAuthStatus } = await import("../src/oauth-status.mjs");
   const { grokOAuthStatus } = await import("../src/grok-oauth-status.mjs");
   const { codexAuthStatus } = await import("../src/codex-binary.mjs");
-  const { nativeSessionFallbackEnabled } = await import("../src/codex-native-session.mjs");
+  const { nativeSessionFallbackEnabled, nativeSessionStatus } = await import(
+    "../src/codex-native-session.mjs"
+  );
+  const { readCodexAccountUsage } = await import("../src/codex-account-usage.mjs");
   try {
     process.env.CODEX_ROUTER_NO_DISCOVERY = "1";
     // Even keyless local backends drop out: "configured" feeds the default
@@ -80,6 +83,29 @@ test("disabling discovery empties the configured set and blinds every reader", a
       reason: "discovery-disabled",
     });
     assert.equal(nativeSessionFallbackEnabled(), false);
+
+    // Even the metadata is withheld: whether auth.json exists, and how old it
+    // is, is knowledge about a credential this process promised not to read.
+    const session = nativeSessionStatus();
+    assert.equal(session.present, false);
+    assert.equal(session.usable, false);
+    assert.equal(session.ageHours, undefined);
+    assert.equal(session.fallbackEnabled, false);
+
+    // The account-usage probe spawns `codex app-server` and reads the
+    // signed-in ChatGPT account; it must refuse before any spawn.
+    let spawned = false;
+    await assert.rejects(
+      readCodexAccountUsage({
+        binary: "codex",
+        spawnImpl: () => {
+          spawned = true;
+          throw new Error("must not spawn");
+        },
+      }),
+      /discovery is disabled/i,
+    );
+    assert.equal(spawned, false, "the account probe spawned despite the kill-switch");
   } finally {
     delete process.env.CODEX_ROUTER_NO_DISCOVERY;
   }

--- a/test/doctor-idle.test.mjs
+++ b/test/doctor-idle.test.mjs
@@ -122,10 +122,20 @@ test(
       assert.equal(existsSync(loginSentinel), false, "the sign-in probe still spawned codex login");
 
       // The idle state fails nothing that touches providers; anything failed
-      // must be environmental (no running service and no installed skill pack
-      // in this sandbox).
+      // must be environmental -- no running service, no installed skill pack,
+      // and on CI no LiteLLM virtual environment either.
       const failed = report.checks.filter((check) => check.status === "fail");
-      const allowed = new Set(["Background service", "Router health", "Codex skill pack"]);
+      const allowed = new Set([
+        "Background service",
+        "Router health",
+        "Codex skill pack",
+        "LiteLLM venv runtime",
+        // The staged secrets get POSIX modes, not the Windows ACL the real
+        // writers apply, so these two rows are staging noise on win32 only.
+        ...(process.platform === "win32"
+          ? ["Internal service key", "Router caller key"]
+          : []),
+      ]);
       assert.deepEqual(
         failed.map((check) => check.name).filter((name) => !allowed.has(name)),
         [],

--- a/test/doctor-idle.test.mjs
+++ b/test/doctor-idle.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const callerSecret = "doctor-idle-caller-capability-with-sufficient-length";
+
+// The stub leaves a tombstone when `codex login` runs against the user's real
+// CODEX_HOME: under --no-discovery every probe that would make Codex read its
+// session file must be skipped, so the tombstone staying absent is part of
+// what this file proves. Schema probes that point CODEX_HOME at a scratch
+// directory read no credentials and are allowed through.
+function writeCodexStub(directory, loginSentinel, realHome) {
+  const windows = process.platform === "win32";
+  const target = path.join(directory, windows ? "codex-idle.cmd" : "codex-idle");
+  const models = JSON.stringify({
+    models: [
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", visibility: "list", priority: 10 },
+    ],
+  });
+  writeFileSync(
+    target,
+    windows
+      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" (if "%CODEX_HOME%"=="${realHome}" echo probed> "${loginSentinel}"\r\nexit /b 0)\r\nif "%1"=="debug" (echo ${models}& exit /b 0)\r\nexit /b 1\r\n`
+      : `#!/bin/sh
+case "$1" in
+  --version) echo 'codex-cli 99.0.0' ;;
+  login) [ "\${CODEX_HOME:-}" = '${realHome}' ] && echo probed > '${loginSentinel}'; exit 0 ;;
+  debug) printf '%s\\n' '${models}' ;;
+  *) exit 1 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  return target;
+}
+
+function child(script, args, env) {
+  return spawnSync(process.execPath, [path.join(root, "src", script), ...args], {
+    cwd: root,
+    env,
+    encoding: "utf8",
+  });
+}
+
+function stageIdleHome() {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-doctor-idle-"));
+  const stateDir = path.join(codexHome, "router-state");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(path.join(codexHome, "config.toml"), 'model = "gpt-5.6-sol"\n', {
+    mode: 0o600,
+  });
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    `${JSON.stringify({ version: 1, providers: [] })}\n`,
+    { mode: 0o600 },
+  );
+  writeFileSync(path.join(stateDir, "caller-secret"), `${callerSecret}\n`, { mode: 0o600 });
+  writeFileSync(
+    path.join(stateDir, "internal-secret"),
+    "doctor-idle-internal-service-key-with-sufficient-length\n",
+    { mode: 0o600 },
+  );
+  const loginSentinel = path.join(codexHome, "login-probed");
+  const env = {
+    ...process.env,
+    CODEX_BIN: writeCodexStub(codexHome, loginSentinel, codexHome),
+    CODEX_HOME: codexHome,
+    CODEX_ROUTER_PORT: "46193",
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_TARGET: "codex",
+  };
+  return { codexHome, stateDir, env, loginSentinel };
+}
+
+test(
+  "an idle --no-provider --no-discovery install passes the doctor at warn",
+  { timeout: 60_000 },
+  () => {
+    const { codexHome, env, loginSentinel } = stageIdleHome();
+    env.CODEX_ROUTER_NO_DISCOVERY = "1";
+    try {
+      const catalog = child("catalog.mjs", ["--refresh-native"], env);
+      assert.equal(catalog.status, 0, catalog.stderr);
+      const gateway = child("litellm-config.mjs", [], env);
+      assert.equal(gateway.status, 0, gateway.stderr);
+      const enabled = child("config-manager.mjs", ["enable"], env);
+      assert.equal(enabled.status, 0, enabled.stderr);
+
+      const doctor = child("doctor.mjs", ["--json"], env);
+      const report = JSON.parse(doctor.stdout);
+      const byName = new Map(report.checks.map((check) => [check.name, check]));
+
+      const providers = byName.get("Enabled providers");
+      assert.equal(providers.status, "warn");
+      assert.equal(providers.detail, "none (idle install: --no-provider)");
+
+      const catalogCheck = byName.get("Merged catalog");
+      assert.equal(catalogCheck.status, "ok");
+      assert.equal(catalogCheck.detail, "idle install; no routed models");
+
+      const discovery = byName.get("Credential discovery");
+      assert.equal(discovery.status, "warn");
+      assert.match(discovery.detail, /--no-discovery/);
+
+      // The per-provider credential sweep is itself discovery; under the
+      // kill-switch it is replaced by the single row above.
+      assert.equal(byName.get("Kimi OAuth"), undefined);
+      assert.equal(byName.get("Grok OAuth"), undefined);
+      assert.ok(
+        !report.checks.some((check) => /API key|anonymous endpoint|endpoint$/.test(check.name)),
+        "a per-provider credential row leaked past --no-discovery",
+      );
+
+      assert.equal(byName.get("Codex sign-in probe").status, "ok");
+      assert.equal(byName.get("Codex sign-in probe").detail, "discovery-disabled");
+      assert.equal(existsSync(loginSentinel), false, "the sign-in probe still spawned codex login");
+
+      // The idle state fails nothing that touches providers; anything failed
+      // must be environmental (no running service and no installed skill pack
+      // in this sandbox).
+      const failed = report.checks.filter((check) => check.status === "fail");
+      const allowed = new Set(["Background service", "Router health", "Codex skill pack"]);
+      assert.deepEqual(
+        failed.map((check) => check.name).filter((name) => !allowed.has(name)),
+        [],
+        `unexpected failures: ${JSON.stringify(failed)}`,
+      );
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "an empty selection without --no-discovery still fails the doctor",
+  { timeout: 60_000 },
+  () => {
+    const { codexHome, env } = stageIdleHome();
+    try {
+      const doctor = child("doctor.mjs", ["--json"], env);
+      const report = JSON.parse(doctor.stdout);
+      const byName = new Map(report.checks.map((check) => [check.name, check]));
+      // Hiding every provider by hand is a state worth flagging loudly; only
+      // the flagged idle install downgrades it.
+      assert.equal(byName.get("Enabled providers").status, "fail");
+      assert.equal(byName.get("Enabled providers").detail, "none");
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -475,6 +475,27 @@ test("the documented rollback behaviour matches the exit-2 contract", () => {
 // Two structural properties guard that: --prepare-only must exit before the
 // skills step touches ~/.codex/skills, and the skills step must run after the
 // rollback trap is disarmed, so a skills failure cannot undo config/service.
+test("both installers declare, validate, and forward the idle-install flags", () => {
+  // The flags exist so issue #224's credential-free lifecycle validation can
+  // run identically on every platform; a flag that lands in only one
+  // installer silently narrows that promise to one OS.
+  const posix = readFileSync(path.join(root, "install.sh"), "utf8");
+  assert.match(posix, /--no-provider\)/);
+  assert.match(posix, /--no-discovery\)/);
+  assert.match(posix, /--no-discovery requires --no-provider/);
+  assert.match(posix, /--no-provider cannot be combined with/);
+  assert.match(posix, /set -- "\$@" --no-provider/);
+  assert.match(posix, /set -- "\$@" --no-discovery/);
+
+  const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
+  assert.match(windows, /\[switch\]\$NoProvider/);
+  assert.match(windows, /\[switch\]\$NoDiscovery/);
+  assert.match(windows, /-NoDiscovery requires -NoProvider/);
+  assert.match(windows, /-NoProvider cannot be combined with/);
+  assert.match(windows, /\$SetupArguments \+= "--no-provider"/);
+  assert.match(windows, /\$SetupArguments \+= "--no-discovery"/);
+});
+
 test("prepare-only exits before the skills step", () => {
   const source = readScript("bin", "install");
   const prepareExit = source.indexOf("Dependencies and local Codex router files are prepared");

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -268,9 +268,9 @@ test("the Windows wrapper hands every command its own arguments", () => {
   );
   assert.ok(branches.size >= 16, `only found ${branches.size} branches`);
 
-  // bin/disable and bin/uninstall accept no arguments, so their
+  // bin/disable, bin/uninstall, and bin/stop accept no arguments, so their
   // branches pass fixed node subcommand names rather than user input.
-  const takesNoArguments = new Set(["disable", "uninstall"]);
+  const takesNoArguments = new Set(["disable", "uninstall", "stop"]);
   for (const [command, body] of branches) {
     if (takesNoArguments.has(command)) {
       assert.equal(

--- a/test/model-router-cli.test.mjs
+++ b/test/model-router-cli.test.mjs
@@ -10,6 +10,18 @@ const version = JSON.parse(
   readFileSync(path.join(root, "package.json"), "utf8"),
 ).version;
 
+test("both dispatchers accept the stop command", () => {
+  // Issue #224's lifecycle validation flow needs install/start/stop/uninstall
+  // to be reachable from one CLI; stop existed only as `node src/service.mjs
+  // stop` before. The dispatchers are asserted as text so this holds on every
+  // platform without spawning the service.
+  const posix = readFileSync(path.join(root, "bin", "model-router"), "utf8");
+  assert.match(posix, /\|start\|stop\|/);
+  const windows = readFileSync(path.join(root, "codex-router.ps1"), "utf8");
+  assert.match(windows, /"stop"/);
+  assert.match(windows, /"stop"\s*\{\s*Invoke-RouterNode "src\\service\.mjs" @\("stop"\)/);
+});
+
 for (const args of [["--version"], ["codex", "--version"]]) {
   test(
     `model-router ${args.join(" ")} reports the package version`,

--- a/test/provider-credentials.test.mjs
+++ b/test/provider-credentials.test.mjs
@@ -114,6 +114,36 @@ test("provider credentials use protected files and remove legacy managed keys", 
   }
 });
 
+test("--no-discovery blinds the resolver to stored keys without a single keychain spawn", () => {
+  try {
+    // A credential really is on disk; the kill-switch must refuse to see it.
+    writeProviderCredential("deepseek", "TEST_DEEPSEEK_HIDDEN_KEY");
+    process.env.DEEPSEEK_API_KEY = "TEST_DEEPSEEK_ENVIRONMENT_KEY";
+    process.env.CODEX_ROUTER_NO_DISCOVERY = "1";
+    resetKeychainCache();
+
+    const before = keychainProbeCount();
+    assert.equal(resolveProviderCredential("deepseek"), undefined);
+    assert.equal(resolveProviderCredential("openrouter", { persistent: true }), undefined);
+    assert.equal(keychainProbeCount(), before, "the kill-switch still spawned /usr/bin/security");
+
+    // Sources that read nothing keep answering: anonymous and keyless
+    // providers carry no secret, so they are not discovery.
+    assert.equal(resolveProviderCredential("opencode-free")?.persistent, true);
+
+    delete process.env.CODEX_ROUTER_NO_DISCOVERY;
+    assert.equal(
+      resolveProviderCredential("deepseek", { persistent: true })?.value,
+      "TEST_DEEPSEEK_HIDDEN_KEY",
+      "lifting the switch must reveal the stored key again",
+    );
+  } finally {
+    delete process.env.CODEX_ROUTER_NO_DISCOVERY;
+    delete process.env.DEEPSEEK_API_KEY;
+    removeProviderCredential("deepseek");
+  }
+});
+
 // The keychain lookup is the only part of resolving a credential that spawns a
 // process, and `configuredProviderIds()` runs it once per provider per service
 // on the routed request path -- synchronously, so the whole event loop waits.

--- a/test/router-idle.test.mjs
+++ b/test/router-idle.test.mjs
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { callerBaseUrl } from "../src/caller-auth.mjs";
+import { openPort } from "./port-pool.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
+const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
+
+async function mockServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return { server, port: server.address().port };
+}
+
+// A stand-in for chatgpt.com that only counts. An idle router must answer
+// locally, so the count staying at zero is the whole point of this file.
+async function nativeRecorder() {
+  const hits = [];
+  const { server, port } = await mockServer((request, response) => {
+    hits.push(request.url);
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end('{"id":"native-response"}');
+  });
+  return { server, port, hits };
+}
+
+function run(env) {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-idle-"));
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  // The state an idle install leaves behind: an explicit empty selection.
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    '{"version":1,"providers":[]}\n',
+    { encoding: "utf8", mode: 0o600 },
+  );
+  const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      CODEX_HOME: path.join(testRoot, "codex"),
+      MODEL_ROUTER_STATE_DIR: stateDir,
+      MODEL_ROUTER_CODEX_AUTH: path.join(testRoot, "codex", "auth.json"),
+      CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
+      CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+      KIMI_INTERNAL_KEY: INTERNAL_KEY,
+      CODEX_ROUTER_QUIET: "1",
+      ...env,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let errors = "";
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+  child.testErrors = () => errors;
+  child.testRoot = testRoot;
+  return child;
+}
+
+async function waitFor(url, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Child exited early (${child.exitCode}): ${child.testErrors()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Not bound yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${url}: ${child.testErrors()}`);
+}
+
+async function stopChild(child) {
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGTERM");
+    await new Promise((resolve) => child.once("exit", resolve));
+  }
+  rmSync(child.testRoot, { recursive: true, force: true });
+}
+
+function post(port, pathname, body) {
+  const base = new URL(callerBaseUrl(port, CALLER_KEY));
+  return fetch(`http://127.0.0.1:${port}${base.pathname}${pathname}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function routerEnv(gatewayPort, routerPort, nativePort) {
+  return {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${nativePort}`,
+  };
+}
+
+test("an idle --no-discovery router answers locally and never calls the native base", async () => {
+  const gateway = await mockServer((request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end('{"ok":true}');
+  });
+  const native = await nativeRecorder();
+  const routerPort = await openPort();
+  const child = run({
+    ...routerEnv(gateway.port, routerPort, native.port),
+    CODEX_ROUTER_NO_DISCOVERY: "1",
+  });
+  try {
+    // Zero providers keeps /health ok: only the gateway is probed.
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+
+    const turn = await post(routerPort, "/responses", { model: "gpt-5", input: "hello" });
+    assert.equal(turn.status, 503);
+    const payload = await turn.json();
+    assert.equal(payload.error.type, "router_idle_no_provider");
+    assert.match(payload.error.message, /no traffic leaves this machine/i);
+
+    const image = await post(routerPort, "/images/generations", { prompt: "a test" });
+    assert.equal(image.status, 503);
+    assert.equal((await image.json()).error.type, "router_idle_no_provider");
+
+    assert.deepEqual(native.hits, [], "an idle router reached for the native base");
+  } finally {
+    await stopChild(child);
+    gateway.server.close();
+    native.server.close();
+  }
+});
+
+test("hiding every provider without --no-discovery keeps native passthrough working", async () => {
+  const gateway = await mockServer((request, response) => {
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end('{"ok":true}');
+  });
+  const native = await nativeRecorder();
+  const routerPort = await openPort();
+  // Same empty selection, discovery untouched: this is the pre-existing "hide
+  // everything" state, and its native fallthrough must not regress.
+  const child = run(routerEnv(gateway.port, routerPort, native.port));
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const turn = await post(routerPort, "/responses", { model: "gpt-5", input: "hello" });
+    assert.equal(turn.status, 200, await turn.text());
+    assert.equal(native.hits.length, 1, "the native turn never reached the native base");
+  } finally {
+    await stopChild(child);
+    gateway.server.close();
+    native.server.close();
+  }
+});

--- a/test/setup-exit-codes.test.mjs
+++ b/test/setup-exit-codes.test.mjs
@@ -50,6 +50,24 @@ test("an unknown provider id leaves the checkout update in place", () => {
   assert.equal(result.status, SETUP_INCOMPLETE_EXIT);
 });
 
+test("--no-provider contradicts naming or picking providers", () => {
+  const withProviders = runSetup(["--no-provider", "--providers", "deepseek"]);
+  assert.equal(withProviders.status, SETUP_INCOMPLETE_EXIT);
+  assert.match(withProviders.stderr, /--no-provider cannot be combined with --providers/);
+
+  const withGuided = runSetup(["--no-provider", "--guided"]);
+  assert.equal(withGuided.status, SETUP_INCOMPLETE_EXIT);
+  assert.match(withGuided.stderr, /--no-provider cannot be combined with --guided/);
+});
+
+test("--no-discovery alone leaves the checkout update in place", () => {
+  // Discovery off with providers still selected would manufacture an install
+  // where nothing can ever authenticate; the flag pair is the contract.
+  const result = runSetup(["--no-discovery"]);
+  assert.equal(result.status, SETUP_INCOMPLETE_EXIT);
+  assert.match(result.stderr, /--no-discovery requires --no-provider/);
+});
+
 // Deliberately absent: a "no configured provider" case driven through
 // `--providers configured`. Credentials for OAuth providers are discovered
 // from each CLI's own state, not from MODEL_ROUTER_STATE_DIR, so on a machine

--- a/test/setup.test.mjs
+++ b/test/setup.test.mjs
@@ -55,6 +55,94 @@ test("automatic selection-only setup exposes only configured providers", () => {
   }
 });
 
+test("--no-provider --no-discovery writes an empty selection and the discovery marker", () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-setup-idle-"));
+  const codexHome = path.join(testRoot, "codex");
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  // A configured credential really is on disk; the idle install must ignore
+  // it rather than auto-selecting its provider.
+  writeFileSync(path.join(stateDir, "deepseek-api-key.secret"), "TEST_SETUP_KEY\n", {
+    mode: 0o600,
+  });
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      ["src/setup.mjs", "--selection-only", "--no-provider", "--no-discovery"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_HOME: codexHome,
+          CODEX_ROUTER_STATE_DIR: stateDir,
+          KIMI_CODE_HOME: path.join(testRoot, "kimi-code"),
+          GROK_AUTH_PATH: path.join(testRoot, "grok", "auth.json"),
+          COMMANDCODE_CLI_HOME: path.join(testRoot, "commandcode"),
+          CODEX_ROUTER_LAUNCH_AGENTS_DIR: path.join(testRoot, "LaunchAgents"),
+          CODEX_ROUTER_SKIP_LAUNCHCTL: "1",
+        },
+      },
+    );
+    assert.deepEqual(JSON.parse(output).providers, []);
+    const selection = JSON.parse(readFileSync(path.join(stateDir, "enabled-providers.json"), "utf8"));
+    assert.deepEqual(selection.providers, []);
+    const discovery = JSON.parse(readFileSync(path.join(stateDir, "discovery-mode.json"), "utf8"));
+    assert.deepEqual(discovery, { version: 1, discovery: "disabled" });
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("re-running setup without the idle flags clears the discovery marker", () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-setup-exit-idle-"));
+  const codexHome = path.join(testRoot, "codex");
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(path.join(stateDir, "deepseek-api-key.secret"), "TEST_SETUP_KEY\n", {
+    mode: 0o600,
+  });
+  writeFileSync(
+    path.join(stateDir, "discovery-mode.json"),
+    '{"version":1,"discovery":"disabled"}\n',
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    '{"version":1,"providers":[]}\n',
+    { mode: 0o600 },
+  );
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      ["src/setup.mjs", "--selection-only", "--providers", "deepseek"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_HOME: codexHome,
+          CODEX_ROUTER_STATE_DIR: stateDir,
+          KIMI_CODE_HOME: path.join(testRoot, "kimi-code"),
+          GROK_AUTH_PATH: path.join(testRoot, "grok", "auth.json"),
+          COMMANDCODE_CLI_HOME: path.join(testRoot, "commandcode"),
+          CODEX_ROUTER_LAUNCH_AGENTS_DIR: path.join(testRoot, "LaunchAgents"),
+          CODEX_ROUTER_SKIP_LAUNCHCTL: "1",
+        },
+      },
+    );
+    // The re-run is the exit path from idle mode: the marker flips back to
+    // enabled and the stored key is discoverable again.
+    assert.deepEqual(JSON.parse(output).providers, ["deepseek"]);
+    const discovery = JSON.parse(readFileSync(path.join(stateDir, "discovery-mode.json"), "utf8"));
+    assert.deepEqual(discovery, { version: 1, discovery: "enabled" });
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("ensure-configured does not auto-select anonymous providers", () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-ensure-configured-"));
   const stateDir = path.join(testRoot, "state");
@@ -89,6 +177,41 @@ test("ensure-configured does not auto-select anonymous providers", () => {
     assert.deepEqual(JSON.parse(output).providers, ["deepseek", "lmstudio", "local"]);
     const selection = JSON.parse(readFileSync(path.join(stateDir, "enabled-providers.json"), "utf8"));
     assert.deepEqual(selection.providers, ["deepseek", "lmstudio", "local"]);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("ensure-configured accepts an explicitly empty selection as idle", () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-ensure-idle-"));
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  // The state an idle --no-provider install (or an operator who hid the last
+  // provider) leaves behind. Installing on top of it must keep working, or
+  // bin/update would strand exactly those installs.
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    '{"version":1,"providers":[]}\n',
+    { mode: 0o600 },
+  );
+  try {
+    const output = execFileSync(
+      process.execPath,
+      ["src/provider-selection.mjs", "ensure-configured"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_HOME: path.join(testRoot, "codex"),
+          CODEX_ROUTER_STATE_DIR: stateDir,
+          KIMI_CODE_HOME: path.join(testRoot, "kimi-code"),
+          GROK_AUTH_PATH: path.join(testRoot, "grok", "auth.json"),
+          COMMANDCODE_CLI_HOME: path.join(testRoot, "commandcode"),
+        },
+      },
+    );
+    assert.deepEqual(JSON.parse(output), { providers: [], idle: true });
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }

--- a/test/target-integration.test.mjs
+++ b/test/target-integration.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-targets-"));
+process.env.CODEX_HOME = path.join(testRoot, "codex");
+process.env.CODEX_ROUTER_STATE_DIR = path.join(testRoot, "state");
+
+const { installedTargets } = await import("../src/target-integration.mjs");
+const { CONFIG_PATH, DSH_CATALOG_PATH, NATIVE_CATALOG_PATH } = await import("../src/paths.mjs");
+
+function stageFile(filePath, contents) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents, "utf8");
+}
+
+function clearStagedFiles() {
+  for (const filePath of [CONFIG_PATH, DSH_CATALOG_PATH, NATIVE_CATALOG_PATH]) {
+    rmSync(filePath, { force: true });
+  }
+}
+
+test("a retained native catalog alone does not keep the codex integration installed", () => {
+  try {
+    // Uninstall retains the cached catalog on purpose, so its presence must
+    // not read as "Codex is still pointed at the plane" -- that is what left
+    // the service and its LaunchAgent behind after the last uninstall.
+    stageFile(NATIVE_CATALOG_PATH, "{}");
+    assert.deepEqual(installedTargets(), []);
+
+    stageFile(CONFIG_PATH, 'model = "gpt-5"\n');
+    assert.deepEqual(installedTargets(), []);
+  } finally {
+    clearStagedFiles();
+  }
+});
+
+test("a managed config block marks the codex integration as installed", () => {
+  try {
+    stageFile(
+      CONFIG_PATH,
+      [
+        'model = "gpt-5"',
+        "# BEGIN codex-router-managed",
+        'openai_base_url = "http://127.0.0.1:4202/caller"',
+        "# END codex-router-managed",
+        "",
+      ].join("\n"),
+    );
+    assert.deepEqual(installedTargets(), ["codex"]);
+  } finally {
+    clearStagedFiles();
+  }
+});
+
+test("legacy managed markers still count as an installed codex integration", () => {
+  try {
+    // A config written by the kimi-era router must keep the shared service
+    // alive until that block is migrated or removed.
+    stageFile(
+      CONFIG_PATH,
+      "# BEGIN kimi-codex-proxy-managed\n# END kimi-codex-proxy-managed\n",
+    );
+    assert.deepEqual(installedTargets(), ["codex"]);
+  } finally {
+    clearStagedFiles();
+  }
+});
+
+test("the harness catalog snapshot still marks the dsh integration", () => {
+  try {
+    // dsh-config-manager.mjs removes this snapshot on uninstall, so unlike the
+    // codex catalog it is a faithful installed-state marker.
+    stageFile(DSH_CATALOG_PATH, "{}");
+    assert.deepEqual(installedTargets(), ["dsh"]);
+
+    stageFile(CONFIG_PATH, "# BEGIN codex-router-managed\n# END codex-router-managed\n");
+    assert.deepEqual(installedTargets(), ["codex", "dsh"]);
+  } finally {
+    clearStagedFiles();
+  }
+});
+
+test.after(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});


### PR DESCRIPTION
Closes #224.

Adds an explicit, deterministic, credential-free install mode so the router's install, lifecycle, network, and uninstall behavior can be validated before it is trusted with API keys, OAuth sessions, Keychain credentials, or production Codex traffic.

## What's in here (7 commits, in dependency order)

1. **`fix:` retire the background service when the last managed config block is gone** — `installedTargets()` keyed "codex is installed" on the cached native catalog, a file uninstall deliberately retains, so the service, LaunchAgent, and listening ports survived every codex uninstall. The witness is now the managed block in `config.toml`. `bin/disable` of the last client retires the service too (matching the Windows wrapper), and `bin/enable` reinstalls it on the way back.
2. **`feat:` a `stop` subcommand** — `bin/stop`, `bin/model-router … stop`, and the Windows dispatcher, completing the install → start → status → doctor → stop → uninstall loop.
3. **`feat:` a persisted discovery kill-switch** — `src/discovery-mode.mjs` (`discovery-mode.json`, overridable with `CODEX_ROUTER_NO_DISCOVERY=1|0`), consulted by every credential reader: the credential resolver (env/file/Keychain/CLI-session), `configuredProviderIds()`, the Kimi/Grok OAuth status readers, the CLI-session reader, Codex's `auth.json` reader, and the `codex login status` probe (skipped with a distinct reason the catalog treats as deliberate signed-out).
4. **`feat:` local idle error instead of native forwarding** — with discovery disabled, `/responses` turns without a route and the native image/web-search endpoints return `503 router_idle_no_provider` before any upstream fetch. Hiding every provider *without* the flag keeps native passthrough exactly as today (regression-tested).
5. **`feat:` doctor idle mode** — an explicit empty selection plus the marker reports at warn, the merged catalog is held to the nothing-routable standard, the per-provider credential sweep (itself discovery) collapses to one row, and the config-load probe / session-refresh nudge — which make Codex read its real session file — are skipped. Doctor exits 0 on a healthy idle install; an empty selection without the marker still fails loudly.
6. **`feat:` the install flags** — `--no-provider` (empty explicit selection, no credential steps; conflicts with `--guided`/`--providers`/key flags) and `--no-discovery` (requires `--no-provider`), plumbed through `install.sh`, `install.ps1`, and `src/setup.mjs`. Setup writes the discovery marker on **every** run, so re-running without the flags is the exit path. `ensure-configured` now accepts an explicitly empty selection as idle — which also un-breaks `bin/update` for anyone who hid their last provider by hand.
7. **`docs:`** INSTALL.md section (flags, guarantees, lifecycle, uninstall-vs-rollback), SECURITY.md network-boundary claims (including the one remaining `codex debug models --bundled` static-list spawn), AGENTS.md invariant, README pointer, CHANGELOG.

## Acceptance criteria mapping

- Keychain / CLI-OAuth-session / credential reads & writes: **0** — kill-switch at every reader; `test/provider-credentials.test.mjs` asserts `keychainProbeCount()` stays flat with a real credential file on disk.
- Provider discovery / external connections: **0** — `configuredProviderIds()` returns `[]`; `test/router-idle.test.mjs` points `CODEX_NATIVE_BASE_URL` at a recording server and asserts zero hits.
- Listener loopback-only: already the default everywhere; doctor now warns if `CODEX_ROUTER_HOST` is non-loopback while discovery is off.
- Codex config/auth unchanged: only the standard managed block is written; `auth.json` is never opened (reader guarded).
- Background retry/discovery: none exists (no timers in any server process); subagent verification has zero candidates with zero providers.
- Lifecycle: `status`/`start`/`stop`/`doctor`/`uninstall` all work idle; uninstall now actually removes the LaunchAgent/service (commit 1). `rollback` reverts the source checkout, not the install — documented.

## Test plan

- [x] `npm run check`, `sh -n install.sh`, `npm audit --omit=dev` (0 vulnerabilities)
- [x] `npm test`: 1244 pass / 0 fail (8 pre-existing skips)
- [x] New suites: `discovery-mode`, `router-idle` (mocked native base, zero hits), `doctor-idle` (spawn sentinel proves no `codex login` against the real home), `target-integration`; extensions to `setup`, `setup-exit-codes`, `provider-credentials`, `installer-scripts`, `model-router-cli`
- [ ] Live install → … → uninstall loop on a scratch machine (not run here: this machine has a production router install on the real service label and ports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcQxQuxyLnPhr4ARF5mfb3