### PR TITLE
fix: the account catalog is an account read, and a flaked config read is not an uninstall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -873,6 +873,18 @@ runs against the real `CODEX_HOME`, and traffic gets a local
 3. Never select a provider, re-enable discovery, or clear the marker on the
    user's behalf. Re-running setup without the flags is the only exit path,
    and it is the operator's to take.
+4. The account-aware `codex debug models` (and `models_cache.json`, which is
+   that same catalog written to disk) counts as an account read: the catalog
+   capture and the doctor's staleness probe use only `debug models --bundled`
+   while the switch is set. `test/doctor-idle.test.mjs` proves the bare form
+   never spawns.
+5. A corrupt `discovery-mode.json` deliberately reads as discovery **on** —
+   the opposite direction of the vision-bridge precedent, which fails toward
+   off. There the risk is spending quota nobody approved; here the marker
+   only ever exists on a machine that installed with `--no-provider`, where
+   resuming reads finds no credentials to spend, while failing toward "off"
+   on a credentialed install would silently blind every provider over one
+   damaged file. `test/discovery-mode.test.mjs` pins the choice.
 
 ## The `codex` shim is opt-in and must never break `codex`
 

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -42,6 +42,7 @@ import {
   readNativeCatalogFile,
   readNativeCatalogSource,
 } from "./native-catalog-source.mjs";
+import { discoveryDisabled } from "./discovery-mode.mjs";
 
 const refresh = process.argv.includes("--refresh-native");
 
@@ -159,15 +160,23 @@ function restoreFileSnapshot(target, snapshot) {
   }
 }
 
-function captureNative(cache = readModelsCache()) {
+function captureNative(cache) {
+  // A discovery-disabled install promised that nothing account-derived is
+  // read: `debug models` without --bundled reflects the signed-in account's
+  // catalog, and `models_cache.json` is that same catalog written to disk, so
+  // both stay untouched and the bundled static list is the whole capture.
+  // This is the gate SECURITY.md's "the one Codex spawn that remains is
+  // `codex debug models --bundled`" claim rests on.
+  const idle = discoveryDisabled();
+  const resolved = cache ?? (idle ? {} : readModelsCache());
   // This is the account-aware catalog Codex itself cached after signing in.
   // Reading it directly also avoids asking `codex debug models` while the
   // router catalog is active, which would merely return our own merged output.
-  let account = cache.catalog;
+  let account = resolved.catalog;
   let fallback;
   let accountError;
   let fallbackError;
-  if (!account) {
+  if (!account && !idle) {
     try {
       account = JSON.parse(runCodex(["debug", "models"], {
         encoding: "utf8",
@@ -246,7 +255,10 @@ function nativeCatalog() {
     }
     return catalog;
   }
-  const cache = readModelsCache();
+  // `models_cache.json` is the signed-in account's catalog written to disk,
+  // so a discovery-disabled install leaves it unread like every other
+  // account-derived artifact.
+  const cache = discoveryDisabled() ? {} : readModelsCache();
   if (!existsSync(NATIVE_CATALOG_PATH) || refresh) return captureNative(cache);
   const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
   if (nativeCatalogIsReusable(parsed, codexVersion(), cache.fingerprint)) {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -964,7 +964,18 @@ if (codexTarget) {
   );
 }
 
-if (codex && catalogOk && routedTransportActive) {
+if (codex && catalogOk && routedTransportActive && credentialDiscoveryOff) {
+  // `debug models` without --bundled answers with the signed-in account's
+  // catalog, which a discovery-disabled install promised never to consult.
+  // The on-disk catalog was already verified above; the only thing skipped
+  // is the is-Codex-restarted staleness probe.
+  add(
+    "ok",
+    "Codex model catalog",
+    "on-disk catalog verified; the account-aware staleness probe is skipped while discovery is off",
+    "Re-enable discovery to restore the startup staleness check.",
+  );
+} else if (codex && catalogOk && routedTransportActive) {
   try {
     const parsed = JSON.parse(
       runCodex(["debug", "models"], {

--- a/src/target-integration.mjs
+++ b/src/target-integration.mjs
@@ -81,7 +81,12 @@ function codexIntegrationInstalled() {
   try {
     return managedMarkerPattern.test(readFileSync(CONFIG_PATH, "utf8"));
   } catch {
-    return false;
+    // The file exists and cannot be read — Codex mid-write, an AV lock, a
+    // permission hiccup. This answer feeds retire-the-service-if-unused, so
+    // "cannot tell" must count as installed: tearing down the shared service
+    // because a read flaked is the unrecoverable direction, while keeping it
+    // alive one cycle longer costs nothing.
+    return true;
   }
 }
 

--- a/test/doctor-idle.test.mjs
+++ b/test/doctor-idle.test.mjs
@@ -14,7 +14,7 @@ const callerSecret = "doctor-idle-caller-capability-with-sufficient-length";
 // session file must be skipped, so the tombstone staying absent is part of
 // what this file proves. Schema probes that point CODEX_HOME at a scratch
 // directory read no credentials and are allowed through.
-function writeCodexStub(directory, loginSentinel, realHome) {
+function writeCodexStub(directory, loginSentinel, realHome, accountSentinel) {
   const windows = process.platform === "win32";
   const target = path.join(directory, windows ? "codex-idle.cmd" : "codex-idle");
   const models = JSON.stringify({
@@ -22,15 +22,19 @@ function writeCodexStub(directory, loginSentinel, realHome) {
       { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", visibility: "list", priority: 10 },
     ],
   });
+  // `debug models` and `debug models --bundled` are different promises: the
+  // bare form answers with the signed-in account's catalog, the --bundled
+  // form with the binary's static list. The stub records every bare call so
+  // the no-discovery tests can prove only the bundled form ever ran.
   writeFileSync(
     target,
     windows
-      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" (if "%CODEX_HOME%"=="${realHome}" echo probed> "${loginSentinel}"\r\nexit /b 0)\r\nif "%1"=="debug" (echo ${models}& exit /b 0)\r\nexit /b 1\r\n`
+      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" (if "%CODEX_HOME%"=="${realHome}" echo probed> "${loginSentinel}"\r\nexit /b 0)\r\nif "%1"=="debug" if not "%3"=="--bundled" echo probed>> "${accountSentinel}"\r\nif "%1"=="debug" (echo ${models}& exit /b 0)\r\nexit /b 1\r\n`
       : `#!/bin/sh
 case "$1" in
   --version) echo 'codex-cli 99.0.0' ;;
   login) [ "\${CODEX_HOME:-}" = '${realHome}' ] && echo probed > '${loginSentinel}'; exit 0 ;;
-  debug) printf '%s\\n' '${models}' ;;
+  debug) [ "\${3:-}" = '--bundled' ] || echo probed >> '${accountSentinel}'; printf '%s\\n' '${models}' ;;
   *) exit 1 ;;
 esac
 `,
@@ -66,27 +70,33 @@ function stageIdleHome() {
     { mode: 0o600 },
   );
   const loginSentinel = path.join(codexHome, "login-probed");
+  const accountSentinel = path.join(codexHome, "account-catalog-probed");
   const env = {
     ...process.env,
-    CODEX_BIN: writeCodexStub(codexHome, loginSentinel, codexHome),
+    CODEX_BIN: writeCodexStub(codexHome, loginSentinel, codexHome, accountSentinel),
     CODEX_HOME: codexHome,
     CODEX_ROUTER_PORT: "46193",
     CODEX_ROUTER_STATE_DIR: stateDir,
     MODEL_ROUTER_STATE_DIR: stateDir,
     MODEL_ROUTER_TARGET: "codex",
   };
-  return { codexHome, stateDir, env, loginSentinel };
+  return { codexHome, stateDir, env, loginSentinel, accountSentinel };
 }
 
 test(
   "an idle --no-provider --no-discovery install passes the doctor at warn",
   { timeout: 60_000 },
   () => {
-    const { codexHome, env, loginSentinel } = stageIdleHome();
+    const { codexHome, env, loginSentinel, accountSentinel } = stageIdleHome();
     env.CODEX_ROUTER_NO_DISCOVERY = "1";
     try {
       const catalog = child("catalog.mjs", ["--refresh-native"], env);
       assert.equal(catalog.status, 0, catalog.stderr);
+      assert.equal(
+        existsSync(accountSentinel),
+        false,
+        "the catalog capture spawned the account-aware `codex debug models`",
+      );
       const gateway = child("litellm-config.mjs", [], env);
       assert.equal(gateway.status, 0, gateway.stderr);
       const enabled = child("config-manager.mjs", ["enable"], env);
@@ -120,6 +130,11 @@ test(
       assert.equal(byName.get("Codex sign-in probe").status, "ok");
       assert.equal(byName.get("Codex sign-in probe").detail, "discovery-disabled");
       assert.equal(existsSync(loginSentinel), false, "the sign-in probe still spawned codex login");
+      assert.equal(
+        existsSync(accountSentinel),
+        false,
+        "something spawned the account-aware `codex debug models` under --no-discovery",
+      );
 
       // The idle state fails nothing that touches providers; anything failed
       // must be environmental -- no running service, no installed skill pack,

--- a/test/target-integration.test.mjs
+++ b/test/target-integration.test.mjs
@@ -86,3 +86,19 @@ test("the harness catalog snapshot still marks the dsh integration", () => {
 test.after(() => {
   rmSync(testRoot, { recursive: true, force: true });
 });
+
+test("a config that exists but cannot be read still counts as installed", () => {
+  try {
+    // This answer feeds retire-the-service-if-unused. Codex mid-write, an AV
+    // lock, or a permission hiccup makes the read throw while the integration
+    // is plainly still there; "cannot tell" must keep the shared service
+    // alive rather than tear it down over a flaked read. A directory at the
+    // config path throws EISDIR on every platform, root included, which makes
+    // the unreadable case portable to test.
+    mkdirSync(CONFIG_PATH, { recursive: true });
+    assert.deepEqual(installedTargets(), ["codex"]);
+  } finally {
+    rmSync(CONFIG_PATH, { recursive: true, force: true });
+    clearStagedFiles();
+  }
+});


### PR DESCRIPTION
Follow-up to #233, which merged with two review findings still open (the review comment there has the full detail):

**The `--no-discovery` promise was broken on the very first install.** The catalog capture (`src/catalog.mjs` `captureNative`) and the doctor's staleness probe both spawned the account-aware `codex debug models` — and the capture read `models_cache.json`, that same account catalog on disk — on exactly the install the kill-switch covers, reproduced with a logging stub. SECURITY.md's "the one Codex spawn that remains is `codex debug models --bundled`" claim was false. Both sites are now gated on `discoveryDisabled()`: an idle capture is bundled-only, and the doctor keeps its on-disk catalog verification while naming what it skipped. The idle test's stub now records every bare `debug models` call, so the suite proves only the `--bundled` form runs.

**A flaked config read could tear the service down under a live install.** `codexIntegrationInstalled()` answered "not installed" when `config.toml` exists but the read throws (Codex mid-write, AV lock) — and that answer feeds retire-the-service-if-unused. Cannot-tell now counts as installed, with a portable EISDIR regression test.

Also pins the corrupt-marker default (discovery **on**) in AGENTS.md as a deliberate divergence from the vision-bridge fail-closed precedent, with the reasoning, so the next reader files it as a choice rather than a bug.

## Test plan
- [x] `npm run check` / `npm test` — 1245 pass, 0 fail
- [x] Idle-install test now asserts the account-aware spawn count is zero under `--no-discovery`
- [x] Unreadable-config regression test for `installedTargets()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113FjuH7bU6xRMsUf8Aytio