### PR TITLE
feat: offer the Qwen3.8 family in the local Ollama catalog

### DIFF
--- a/src/local-ollama-catalog.mjs
+++ b/src/local-ollama-catalog.mjs
@@ -3,7 +3,7 @@
 // non-downloadable: they route through Ollama cloud and have no local weights.
 // Refresh this manifest when the upstream tag pages change; arbitrary tags
 // and model-page URLs remain supported by the install field.
-// Captured from the official pages on 2026-08-11.
+// Captured from the official pages on 2026-08-11; qwen3.8 captured 2026-08-15.
 
 // The tag list is intentionally exhaustive, but the tray should not make a
 // first-time user choose between every quantization and accelerator build.
@@ -24,6 +24,11 @@ export const LOCAL_FAMILY_RESEARCH = Object.freeze({
     status: "Official Ollama · 30 tags",
     capabilities: Object.freeze(["vision", "tools", "thinking"]),
     note: "Qwen's newer agentic-coding and thinking-focused family.",
+  }),
+  "qwen3.8": Object.freeze({
+    status: "Official Ollama · 12 tags",
+    capabilities: Object.freeze(["vision", "tools", "thinking"]),
+    note: "27B Qwen family with substantial gains on coding and long-horizon agentic tasks.",
   }),
   "nemotron-3-super": Object.freeze({
     status: "Official Ollama · 7 tags",
@@ -197,6 +202,18 @@ export const EXPLORE_LOCAL_MODELS = Object.freeze(
     {"tag": "qwen3.6:35b-a3b-mtp-bf16", "sizeGb": 72, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.6 · 35b a3b mtp bf16", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
     {"tag": "qwen3.6:35b-a3b-mxfp8", "sizeGb": 38, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.6 · 35b a3b mxfp8", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
     {"tag": "qwen3.6:35b-mlx", "sizeGb": 22, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.6 · 35b mlx", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:latest", "sizeGb": 18, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · latest", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b", "sizeGb": 18, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-mlx", "sizeGb": 18, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b mlx", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-mlx-bf16", "sizeGb": 56, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b mlx bf16", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-mtp-q4_K_M", "sizeGb": 18, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b mtp q4_K_M", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-mtp-q8_0", "sizeGb": 30, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b mtp q8_0", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-mtp-bf16", "sizeGb": 56, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b mtp bf16", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-mxfp8", "sizeGb": 32, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b mxfp8", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-nvfp4", "sizeGb": 18, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b nvfp4", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-q4_K_M", "sizeGb": 18, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b q4_K_M", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-q8_0", "sizeGb": 30, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b q8_0", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "qwen3.8:27b-bf16", "sizeGb": 56, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Qwen3.8 · 27b bf16", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
     {"tag": "nemotron-3-super:latest", "sizeGb": 87, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Nemotron 3 Super · latest", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
     {"tag": "nemotron-3-super:cloud", "sizeGb": 0, "tools": false, "context": 262144, "codex": "cloud-only", "displayName": "Nemotron 3 Super · cloud", "note": "Cloud-only Ollama alias; no local weights to download.", "downloadable": false},
     {"tag": "nemotron-3-super:120b", "sizeGb": 87, "tools": false, "context": 262144, "codex": "unverified", "displayName": "Nemotron 3 Super · 120b", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},

--- a/test/local-models.test.mjs
+++ b/test/local-models.test.mjs
@@ -474,6 +474,8 @@ test("the explore catalog groups the requested Ollama families and keeps fit vis
     "qwen3.5:35b-a3b-coding-nvfp4",
     "qwen3.6:27b",
     "qwen3.6:35b-a3b-mtp-q4_K_M",
+    "qwen3.8:27b",
+    "qwen3.8:27b-q4_K_M",
     "nemotron-3-super:120b",
     "nemotron-3-super:120b-a12b-q8_0",
     "nemotron-3.5-lightning:latest",
@@ -496,8 +498,14 @@ test("the explore catalog groups the requested Ollama families and keeps fit vis
   ]) assert.ok(tags.has(tag), tag);
   assert.equal(entries.find((entry) => entry.tag === "nemotron-3-super:120b").fit, "too-large");
   assert.equal(entries.find((entry) => entry.tag === "gemma4:12b").tools, false);
-  assert.equal(EXPLORE_LOCAL_MODELS.length, 189);
-  assert.equal(new Set(EXPLORE_LOCAL_MODELS.map((entry) => entry.tag)).size, 189);
+  assert.equal(EXPLORE_LOCAL_MODELS.length, 201);
+  assert.equal(new Set(EXPLORE_LOCAL_MODELS.map((entry) => entry.tag)).size, 201);
+  // The qwen3.8 capture (2026-08-15): 12 official 27B tags, 256K context.
+  assert.equal(
+    entries.find((entry) => entry.tag === "qwen3.8:27b").researchStatus,
+    "Official Ollama · 12 tags",
+  );
+  assert.equal(entries.find((entry) => entry.tag === "qwen3.8:27b").context, 262144);
   const cloud = entries.find((entry) => entry.tag === "qwen3.5:cloud");
   assert.equal(cloud.downloadable, false);
   assert.equal(cloud.fit, "cloud-only");


### PR DESCRIPTION
Adds the `qwen3.8` family to the local-model manifest, captured from the official Ollama tag page on 2026-08-15: **12 tags** (all 27B — `latest`, plain, `mlx`/`mlx-bf16`, `mtp-q4_K_M`/`mtp-q8_0`/`mtp-bf16`, `mxfp8`, `nvfp4`, `q4_K_M`, `q8_0`, `bf16`), 256K context, vision/tools/thinking badges upstream.

Conventions preserved: `tools: false` until the post-pull capability check proves it (the qwen2.5-coder lesson), `codex: "unverified"` until `local-models agent-check` runs, sizes exactly as the tag page lists them. The catalog is read by both the macOS tray and the Windows desktop app, so the family shows up in the download picker on both platforms — nothing platform-specific to add.

## Test plan
- [x] `npm run check` / `npm test` — 1244 pass, 0 fail
- [x] Catalog count pins updated (189 → 201), research-status and context assertions for the new family

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113FjuH7bU6xRMsUf8Aytio