### PR TITLE
fix(aging): prove the compaction pass ran even when it changes nothing

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -2440,13 +2440,26 @@ struct ToolResultAgingStats: Decodable {
       // operator hunting for a hook that was loaded the whole time. Report the
       // largest result seen so the gap to the floor is visible.
       guard let evaluatedRequests, evaluatedRequests > 0 else { return nil }
-      let largest = Self.compactBytes(largestResultBytes ?? 0)
+      let largestBytes = largestResultBytes ?? 0
+      let largest = Self.compactBytes(largestBytes)
+      // Size is only one of the two reasons nothing ages. A result the model
+      // has not acted on yet is skipped whatever its size, so a result over
+      // the floor can still be counted here -- and saying "no result over
+      // 32 KB (largest 40 KB)" would contradict itself in the same sentence.
+      if largestBytes > Self.agingMinBytes {
+        return "Nothing aged yet in \(evaluatedRequests) requests (largest \(largest))"
+      }
       return "No result over 32 KB in \(evaluatedRequests) requests (largest \(largest))"
     }
     let tokens = Self.compactCount(estimatedTokensSaved)
     let megabytes = String(format: "%.1f", Double(bytesSaved) / 1_048_576)
     return "Saved ~\(tokens) tokens (\(megabytes) MB) across \(requests) requests"
   }
+
+  // Mirrors TOOL_RESULT_AGING_MIN_BYTES in src/tool-result-aging.mjs. Only the
+  // wording above depends on it, so a drifted copy misworks a label rather
+  // than the pass itself.
+  static let agingMinBytes = 32 * 1024
 
   static func compactBytes(_ value: Int) -> String {
     if value >= 1_048_576 { return String(format: "%.1f MB", Double(value) / 1_048_576) }

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -2426,16 +2426,32 @@ struct ToolResultAgingSnapshot: Decodable {
 
 struct ToolResultAgingStats: Decodable {
   let requests: Int?
+  let evaluatedRequests: Int?
+  let largestResultBytes: Int?
   let resultsAged: Int?
   let bytesSaved: Int?
   let estimatedTokensSaved: Int?
   let ranges: [String: ToolResultAgingRange]?
 
   var savingsSummary: String? {
-    guard let requests, requests > 0, let estimatedTokensSaved, let bytesSaved else { return nil }
+    guard let requests, requests > 0, let estimatedTokensSaved, let bytesSaved else {
+      // Enabled and running, but nothing qualified. Saying nothing here reads
+      // as "the toggle did nothing" -- the exact ambiguity that sent an
+      // operator hunting for a hook that was loaded the whole time. Report the
+      // largest result seen so the gap to the floor is visible.
+      guard let evaluatedRequests, evaluatedRequests > 0 else { return nil }
+      let largest = Self.compactBytes(largestResultBytes ?? 0)
+      return "No result over 32 KB in \(evaluatedRequests) requests (largest \(largest))"
+    }
     let tokens = Self.compactCount(estimatedTokensSaved)
     let megabytes = String(format: "%.1f", Double(bytesSaved) / 1_048_576)
     return "Saved ~\(tokens) tokens (\(megabytes) MB) across \(requests) requests"
+  }
+
+  static func compactBytes(_ value: Int) -> String {
+    if value >= 1_048_576 { return String(format: "%.1f MB", Double(value) / 1_048_576) }
+    if value >= 1_024 { return String(format: "%.0f KB", Double(value) / 1_024) }
+    return "\(value) B"
   }
 
   static func compactCount(_ value: Int) -> String {

--- a/apps/macos/ModelRouterTray/Tests/AgingSummaryTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/AgingSummaryTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+@testable import ModelRouterTray
+
+// The savings card has to explain an idle pass without contradicting itself.
+// Size is only one of the two reasons a result is skipped -- a result the
+// model has not acted on yet is passed over whatever its size -- so the copy
+// has to agree with the number printed beside it.
+@Suite("Tool-result aging summary")
+struct AgingSummaryTests {
+  private func stats(
+    requests: Int? = nil,
+    evaluated: Int? = nil,
+    largest: Int? = nil,
+    bytesSaved: Int? = nil,
+    tokensSaved: Int? = nil,
+  ) -> ToolResultAgingStats {
+    let payload: [String: Any] = [
+      "requests": requests as Any,
+      "evaluatedRequests": evaluated as Any,
+      "largestResultBytes": largest as Any,
+      "bytesSaved": bytesSaved as Any,
+      "estimatedTokensSaved": tokensSaved as Any,
+    ].compactMapValues { $0 is NSNull ? nil : $0 }
+    let data = try! JSONSerialization.data(withJSONObject: payload)
+    return try! JSONDecoder().decode(ToolResultAgingStats.self, from: data)
+  }
+
+  @Test("a pass that never ran stays silent")
+  func neverRan() {
+    #expect(stats().savingsSummary == nil)
+    #expect(stats(evaluated: 0).savingsSummary == nil)
+  }
+
+  @Test("an idle pass under the floor names the floor")
+  func idleUnderFloor() {
+    let summary = stats(evaluated: 8, largest: 12_000).savingsSummary
+    #expect(summary == "No result over 32 KB in 8 requests (largest 12 KB)")
+  }
+
+  @Test("an idle pass over the floor does not claim nothing was big enough")
+  func idleOverFloor() {
+    // 40 KB cleared the floor and still aged nothing, so the blocker was the
+    // acted-after gate. Saying "no result over 32 KB (largest 40 KB)" would
+    // contradict itself in one sentence.
+    let summary = stats(evaluated: 5, largest: 40 * 1024).savingsSummary
+    #expect(summary?.contains("No result over 32 KB") == false)
+    #expect(summary == "Nothing aged yet in 5 requests (largest 40 KB)")
+  }
+
+  @Test("a pass that saved something reports the savings instead")
+  func reportsSavings() {
+    let summary = stats(
+      requests: 3,
+      evaluated: 9,
+      largest: 90_000,
+      bytesSaved: 2 * 1024 * 1024,
+      tokensSaved: 4_000,
+    ).savingsSummary
+    #expect(summary?.hasPrefix("Saved ~") == true)
+    #expect(summary?.contains("across 3 requests") == true)
+  }
+}

--- a/src/tool-result-aging.mjs
+++ b/src/tool-result-aging.mjs
@@ -98,6 +98,9 @@ export function ageToolResults(
     toolResultBytesAfter: 0,
     toolResultBytesSaved: 0,
   };
+  // A disabled pass reports nothing beyond the zeroed counters, so "off" stays
+  // distinguishable from "on and nothing qualified" -- two states this used to
+  // report identically, leaving no way to prove the pass had run at all.
   if (!enabled || !Array.isArray(input)) return { input, stats: empty };
 
   const outputIndexes = [];
@@ -116,12 +119,23 @@ export function ageToolResults(
   let toolResultsAged = 0;
   let toolResultBytesBefore = 0;
   let toolResultBytesAfter = 0;
+  // What the pass looked at, recorded whether or not anything qualified. A
+  // session can spend its whole context on results that each sit under the
+  // floor, and without these the outcome is indistinguishable from the pass
+  // never running. The largest result seen says which it was: compare it
+  // against minBytes.
+  let toolResultsEvaluated = 0;
+  let toolResultBytesLargest = 0;
   const replacements = new Map();
   for (let index = 0; index < input.length; index += 1) {
     const item = input[index];
     if (protectedIndexes.has(index)) continue;
     const value = textualOutput(item);
-    if (value === undefined || Buffer.byteLength(value, "utf8") <= minBytes) continue;
+    if (value === undefined) continue;
+    const size = Buffer.byteLength(value, "utf8");
+    toolResultsEvaluated += 1;
+    if (size > toolResultBytesLargest) toolResultBytesLargest = size;
+    if (size <= minBytes) continue;
     // A later result alone does not prove the model saw this one. A later
     // model-authored message, reasoning item, or tool call does.
     if (!actedAfter[index]) continue;
@@ -130,7 +144,7 @@ export function ageToolResults(
     // Count model-visible text rather than serializing the whole item again.
     // The request path will serialize once later; avoiding a second copy here
     // matters when the result itself is hundreds of megabytes.
-    const before = Buffer.byteLength(value, "utf8");
+    const before = size;
     const after = Buffer.byteLength(receipt, "utf8");
     if (after >= before) continue;
     changed = true;
@@ -150,6 +164,8 @@ export function ageToolResults(
       toolResultBytesBefore,
       toolResultBytesAfter,
       toolResultBytesSaved,
+      toolResultsEvaluated,
+      toolResultBytesLargest,
     },
   };
 }

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -123,6 +123,13 @@ export function recordUsageEvent({
   toolResultBytesBefore,
   toolResultBytesAfter,
   toolResultBytesSaved,
+  // Present whenever the aging pass ran, even when it changed nothing. Every
+  // count above is omitted when zero, so without these an operator who enables
+  // aging and sees an empty ledger cannot tell whether the pass never ran or
+  // ran and found every result under the floor. `BytesLargest` separates the
+  // two: compare it against the eligibility floor.
+  toolResultsEvaluated,
+  toolResultBytesLargest,
   at = Date.now(),
 }) {
   const event = {
@@ -173,6 +180,14 @@ export function recordUsageEvent({
     ...(safeTokenCount(toolResultBytesSaved)
       ? { toolResultBytesSaved: safeTokenCount(toolResultBytesSaved) }
       : {}),
+    // Zero is meaningful here -- it says the pass ran and saw no tool results
+    // at all -- so these are written whenever defined rather than when truthy.
+    ...(safeTokenCount(toolResultsEvaluated) !== undefined
+      ? { toolResultsEvaluated: safeTokenCount(toolResultsEvaluated) }
+      : {}),
+    ...(safeTokenCount(toolResultBytesLargest) !== undefined
+      ? { toolResultBytesLargest: safeTokenCount(toolResultBytesLargest) }
+      : {}),
   };
   try {
     mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
@@ -219,6 +234,13 @@ function emptyRange(buckets) {
 export function toolResultAgingTotals({ now = Date.now() } = {}) {
   const totals = {
     requests: 0,
+    // Requests where the pass ran, whether or not it changed anything, plus the
+    // largest single result any of them saw. `evaluatedRequests` above zero
+    // with `requests` at zero is the signature of a workload whose results all
+    // sit under the eligibility floor: proof the pass is wired in, and the
+    // number that says by how much it missed.
+    evaluatedRequests: 0,
+    largestResultBytes: 0,
     resultsAged: 0,
     bytesSaved: 0,
     estimatedTokensSaved: 0,
@@ -234,7 +256,8 @@ export function toolResultAgingTotals({ now = Date.now() } = {}) {
   try {
     for (const line of usageEventLines()) {
       // Pre-filter: aging stats and cache telemetry are both rare fields.
-      const hasAging = line.includes('"toolResultsAged"');
+      const hasAging =
+        line.includes('"toolResultsAged"') || line.includes('"toolResultsEvaluated"');
       const hasCache = line.includes('"cachedInputTokens"');
       if (!hasAging && !hasCache) continue;
       let event;
@@ -244,6 +267,12 @@ export function toolResultAgingTotals({ now = Date.now() } = {}) {
         continue;
       }
       const at = typeof event?.at === "string" ? Date.parse(event.at) : NaN;
+      const evaluated = safeTokenCount(event?.toolResultsEvaluated);
+      if (evaluated !== undefined) {
+        totals.evaluatedRequests += 1;
+        const largest = safeTokenCount(event?.toolResultBytesLargest) ?? 0;
+        if (largest > totals.largestResultBytes) totals.largestResultBytes = largest;
+      }
       const resultsAged = safeTokenCount(event?.toolResultsAged);
       if (resultsAged) {
         totals.requests += 1;

--- a/test/tool-result-aging-state.test.mjs
+++ b/test/tool-result-aging-state.test.mjs
@@ -99,6 +99,8 @@ test("snapshot reports zeroed savings stats before any usage is recorded", () =>
   const emptyCache = { agedRate: null, unagedRate: null, agedTurns: 0, unagedTurns: 0 };
   assert.deepEqual(toolResultAgingSnapshot().stats, {
     requests: 0,
+    evaluatedRequests: 0,
+    largestResultBytes: 0,
     resultsAged: 0,
     bytesSaved: 0,
     estimatedTokensSaved: 0,

--- a/test/tool-result-aging.test.mjs
+++ b/test/tool-result-aging.test.mjs
@@ -101,3 +101,31 @@ test("does not split surrogate pairs at either preview boundary", () => {
   assert.doesNotMatch(result.input[1].output, /�/);
   assert.equal((result.input[1].output.match(/😀/gu) || []).length, 2);
 });
+
+// The failure this instrumentation exists for: a session that spends its whole
+// context on results which each sit under the floor reported the same empty
+// stats as a pass that never ran, so an operator could not tell an ineffective
+// feature from an unloaded one.
+test("a pass that ages nothing still reports what it evaluated and the largest result it saw", () => {
+  const input = [
+    ...Array.from({ length: 12 }, (_, index) => [
+      call(`mid-${index}`),
+      output(`mid-${index}`, "x".repeat(12_000)),
+      { type: "message", role: "assistant", content: `read ${index}` },
+    ]).flat(),
+  ];
+  const { stats, input: unchanged } = ageToolResults(input);
+  assert.equal(stats.toolResultsAged, 0);
+  assert.equal(stats.toolResultsEvaluated, 8, "the four newest results stay protected");
+  assert.equal(stats.toolResultBytesLargest, 12_000);
+  assert.equal(unchanged, input, "nothing qualified, so the input is passed through by reference");
+});
+
+test("a disabled pass stays distinguishable from one that ran and found nothing", () => {
+  const input = [call("a"), output("a", "x".repeat(12_000))];
+  const off = ageToolResults(input, { enabled: false });
+  assert.equal(off.stats.toolResultsEvaluated, undefined);
+  assert.equal(off.stats.toolResultBytesLargest, undefined);
+  const on = ageToolResults(input);
+  assert.equal(on.stats.toolResultsEvaluated, 0, "every result here sits inside the frontier");
+});

--- a/test/usage-events.test.mjs
+++ b/test/usage-events.test.mjs
@@ -66,6 +66,8 @@ test("tool-result aging totals aggregate savings across recorded events", async 
     // No events file yet: totals must report zeros rather than fail.
     assert.deepEqual(usage.toolResultAgingTotals(), {
       requests: 0,
+      evaluatedRequests: 0,
+      largestResultBytes: 0,
       resultsAged: 0,
       bytesSaved: 0,
       estimatedTokensSaved: 0,
@@ -226,6 +228,46 @@ test("a guard budget release persists its marker and reads back", async () => {
       .recentUsageEvents()
       .filter((candidate) => candidate.emptyCompletionGuardReleased !== true);
     assert.equal("emptyCompletionGuardReleased" in ordinary, false);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.MODEL_ROUTER_STATE_DIR;
+    else process.env.MODEL_ROUTER_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// An operator who enables aging on a workload of medium-sized results saw an
+// all-zero ledger and reasonably concluded the hook had never loaded. The
+// evaluated counter is what separates "ran and nothing qualified" from "never
+// ran", and the largest-result byte count says how far under the floor it was.
+test("totals separate a pass that ran and aged nothing from one that never ran", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-router-usage-"));
+  const previousStateDir = process.env.MODEL_ROUTER_STATE_DIR;
+  process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+  try {
+    const usage = await import(`../src/usage-events.mjs?evaluated=${Date.now()}`);
+    // Aging enabled, ran over eleven results, none of them past the floor.
+    usage.recordUsageEvent({
+      model: "qwen-plan/qwen3.8-max",
+      provider: "qwen-plan",
+      status: 200,
+      durationMs: 100,
+      inputTokens: 275_000,
+      toolResultsEvaluated: 11,
+      toolResultBytesLargest: 12_400,
+    });
+    // Aging off: the pass reports nothing, so this row must not be counted.
+    usage.recordUsageEvent({
+      model: "qwen-plan/qwen3.8-max",
+      provider: "qwen-plan",
+      status: 200,
+      durationMs: 100,
+      inputTokens: 275_000,
+    });
+    const totals = usage.toolResultAgingTotals();
+    assert.equal(totals.evaluatedRequests, 1, "only the row from an enabled pass counts");
+    assert.equal(totals.largestResultBytes, 12_400);
+    assert.equal(totals.requests, 0, "nothing was aged, so no request saved anything");
+    assert.equal(totals.bytesSaved, 0);
   } finally {
     if (previousStateDir === undefined) delete process.env.MODEL_ROUTER_STATE_DIR;
     else process.env.MODEL_ROUTER_STATE_DIR = previousStateDir;


### PR DESCRIPTION
## The bug

Reported from the field: an operator enabled `tool-result-aging`, ran a large repo-audit task on Qwen 3.8 Max, and afterwards saw `requests=0, resultsAged=0, bytesSaved=0` with `toolResultsAged=null` on every usage row. They reasonably asked whether the hook had loaded at all, or whether that task path bypassed it.

It had loaded. Every aging counter is written only when non-zero (`usage-events.mjs`, truthiness spreads), and `toolResultAgingTotals` only counts a request when `resultsAged` is truthy. So **a pass that ran and found nothing eligible was byte-identical to a pass that never ran** — there was no signal anywhere that could distinguish them.

The likely reason nothing qualified: only individual results over 32 KiB are eligible, and a repo audit produces many medium reads rather than a few huge ones. A session can reach 275K tokens without a single result crossing the floor.

## The fix

Record what the pass looked at, whether or not it changed anything:

- `toolResultsEvaluated` — tool results examined
- `toolResultBytesLargest` — largest one seen

Totalled as `evaluatedRequests` / `largestResultBytes`. A **disabled** pass still reports neither, so off stays distinguishable from on-and-idle. Observed on a synthetic session where nothing qualifies:

```
enabled:  {"toolResultsAged":0, ..., "toolResultsEvaluated":8, "toolResultBytesLargest":12000}
disabled: {"toolResultsAged":0, ...}
```

`12000` against the 32,768-byte floor is the answer to "why did nothing age". The tray shows that case as **"No result over 32 KB in N requests (largest 12 KB)"** instead of falling back to the "Off by default…" text, which read as though the toggle had done nothing.

## Deliberately not included

- **Lowering the 32 KiB floor.** Likely too high for repo-audit workloads, but these counters are what will tell us by how much, across real sessions rather than one report.
- **Lowering `autoCompact`.** Cannot help the reported case: that task opened at 246,688 input tokens on turn one, already past the 235,000 threshold, so it could never get back under it. Why a fresh task starts near 250K is the open question.

## Test plan
- [x] `npm run check`
- [x] `npm test`: 1,252 pass / 0 fail — includes a test reproducing the reported scenario and one asserting off stays distinguishable from on-and-idle
- [x] `swift build` + `swift test`: 20 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zVk2R4t6CELtWk4MaX5WZ