### PR TITLE
fix(qwen): correct qwen-plan context windows to the documented limits

### DIFF
--- a/config/qwen/plan/deepseek-v4-flash-0731.json
+++ b/config/qwen/plan/deepseek-v4-flash-0731.json
@@ -21,8 +21,8 @@
           "description": "Maximum reasoning depth"
         }
       ],
-      "contextWindow": 262144,
-      "autoCompact": 235000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],

--- a/config/qwen/plan/deepseek-v4-pro-0813.json
+++ b/config/qwen/plan/deepseek-v4-pro-0813.json
@@ -21,8 +21,8 @@
           "description": "Maximum reasoning depth"
         }
       ],
-      "contextWindow": 262144,
-      "autoCompact": 235000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],

--- a/config/qwen/plan/deepseek-v4-pro.json
+++ b/config/qwen/plan/deepseek-v4-pro.json
@@ -21,8 +21,8 @@
           "description": "Maximum reasoning depth"
         }
       ],
-      "contextWindow": 262144,
-      "autoCompact": 235000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],

--- a/config/qwen/plan/glm-5.2.json
+++ b/config/qwen/plan/glm-5.2.json
@@ -21,8 +21,8 @@
           "description": "Maximum reasoning depth"
         }
       ],
-      "contextWindow": 262144,
-      "autoCompact": 235000,
+      "contextWindow": 1048576,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],

--- a/config/qwen/plan/qwen3.6-flash.json
+++ b/config/qwen/plan/qwen3.6-flash.json
@@ -17,8 +17,8 @@
           "description": "Adaptive reasoning tuned for speed"
         }
       ],
-      "contextWindow": 262144,
-      "autoCompact": 235000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text",
         "image"

--- a/config/qwen/plan/qwen3.7-max.json
+++ b/config/qwen/plan/qwen3.7-max.json
@@ -17,8 +17,8 @@
           "description": "Adaptive deep reasoning"
         }
       ],
-      "contextWindow": 262144,
-      "autoCompact": 235000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text",
         "image"

--- a/config/qwen/plan/qwen3.7-plus.json
+++ b/config/qwen/plan/qwen3.7-plus.json
@@ -17,8 +17,8 @@
           "description": "Adaptive deep reasoning"
         }
       ],
-      "contextWindow": 262144,
-      "autoCompact": 235000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],

--- a/config/qwen/plan/qwen3.8-max.json
+++ b/config/qwen/plan/qwen3.8-max.json
@@ -17,8 +17,8 @@
           "description": "Adaptive deep reasoning"
         }
       ],
-      "contextWindow": 262144,
-      "autoCompact": 235000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text",
         "image"


### PR DESCRIPTION
## What was wrong

All nine `qwen-plan` entries carried an identical **262,144 / 235,000** — across Qwen, DeepSeek, *and* GLM models from three different vendors. That uniformity is the tell: a placeholder, not nine researched values. Our own repo already declares the same underlying models at 1,000,000–1,048,576 through clinepass, commandcode, deepseek, opencode-go, ollama-cloud, and zai-api. qwen-plan was the lone outlier on every one.

## What the documentation actually says

Verified against Alibaba's Chinese model-studio reference pages (the English pages are stale — the `deepseek-v4-pro` EN page predates the 0813 release entirely):

| Model | Context | Max input | Was |
|---|---|---|---|
| qwen3.8-max | 1,000,000 | 991,808 | 262,144 |
| qwen3.7-max / 3.7-plus / 3.6-flash | 1,000,000 | 991,808 | 262,144 |
| deepseek-v4-pro / -0813 / -flash-0731 | 1,000,000 | 1,000,000 | 262,144 |
| glm-5.2 | 1,048,576 | 1,048,576 | 262,144 |

**No reseller cap is involved.** DeepSeek's output ceiling on DashScope is 393,216 = exactly 384×1024, and GLM's is 131,072 = exactly 128×1024 — both match the original vendors precisely, so Alibaba is passing these through at full size.

## Why it mattered

Codex compacts at the `auto_compact_token_limit` we advertise. A field report shows a legitimate repo-audit task opening at **246,688 input tokens** — already past the old 235,000 threshold on turn one. It compacted immediately, lost its working state, restarted its git preflight, regrew, and compacted again, never finishing. The same trace shows a **277,174-token request accepted with HTTP 200**, which the old 262,144 window says should have been impossible.

`autoCompact` moves to 900,000, the value every other million-token model in this repo already uses (the old 235,000 was also 89.6% of its window, against this repo's 85% convention).

## Known risk

These are standard Model Studio figures; we route through `token-plan.ap-southeast-1.maas.aliyuncs.com`. Subscription endpoints can enforce below published limits — a field report on Alibaba's *Coding Plan* endpoint measured 169,984 enforced for a model its own FAQ publishes at 1,000,000. Direct evidence for token-plan is "at least 277,174" (observed accepted). **Recommend confirming with an oversized-request probe before merge** — DashScope returns `400 InvalidParameter: "Range of input length should be [1, N]"` with the true N embedded. My own quota resets 2026-08-18.

## Follow-ups not in this PR

- **Delist `qwen3.8-max-preview`** — its upstream doc page 404s and it appears retired at GA. Left untouched here rather than given an invented number.
- **Learn limits at runtime** — parse `Range of input length should be [1, N]` from 400s and cache per model+endpoint. There is no metadata API on any DashScope host, so every tool in this ecosystem hardcodes and drifts; this bug will otherwise recur.

## Test plan
- [x] `npm run check`
- [x] `npm test`: 1,285 pass / 0 fail
- [x] Diffs limited to the two fields; no reformatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zVk2R4t6CELtWk4MaX5WZ