### PR TITLE
feat: surface LM Studio models in the panel's local view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+- **The panel's local-model view surfaces LM Studio.** LM Studio arrived as a
+  provider with exactly one door: `./bin/curate-models lmstudio` in an
+  interactive terminal, while the panel's Local LLMs section read only
+  `ollama list` -- so models loaded in LM Studio were invisible there and
+  uncountable in its summary. The snapshot now carries an LM Studio section
+  read from the server's own `/v1/models` endpoint, the panel lists what it
+  serves with checkboxes, and checking one publishes it through the same
+  user-model overlay the terminal writes, so neither door can strand the
+  other's entries. A stopped server reads "not running" instead of the section
+  vanishing, and a curated model the server no longer serves stays visible as
+  such rather than lingering in the picker with no way to see why.
+
 ## 0.4.0-beta.4
 
 - **A command that opens the browser panel.** The panel shipped with no way to

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -566,7 +566,7 @@ async fn set_lmstudio_model_enabled(
     model: String,
     enabled: bool,
 ) -> Result<Value, String> {
-    validate_local_model_ref(&model)?;
+    validate_lmstudio_model_id(&model)?;
     run_json_command(
         state.inner().clone(),
         vec![
@@ -1432,6 +1432,25 @@ fn validate_local_model_ref(model: &str) -> Result<(), String> {
         Ok(())
     } else {
         Err("Enter a valid Ollama model tag or model-page URL.".into())
+    }
+}
+
+/// Same character discipline as the Node-side `requireTag` (an id reaches a
+/// command line either way), with an error that names LM Studio instead of
+/// telling an LM Studio user their id is not a valid Ollama tag.
+fn validate_lmstudio_model_id(model: &str) -> Result<(), String> {
+    let trimmed = model.trim();
+    let valid = !trimmed.is_empty()
+        && trimmed.len() <= 128
+        && trimmed.chars().next().is_some_and(|c| c.is_ascii_alphanumeric())
+        && trimmed
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '/' | ':' | '-'))
+        && !trimmed.starts_with('-');
+    if valid {
+        Ok(())
+    } else {
+        Err("Enter a valid LM Studio model id.".into())
     }
 }
 

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -1442,7 +1442,10 @@ fn validate_lmstudio_model_id(model: &str) -> Result<(), String> {
     let trimmed = model.trim();
     let valid = !trimmed.is_empty()
         && trimmed.len() <= 128
-        && trimmed.chars().next().is_some_and(|c| c.is_ascii_alphanumeric())
+        && trimmed
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
         && trimmed
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '/' | ':' | '-'))

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -120,6 +120,7 @@ fn main() {
             uninstall_local_model,
             cancel_local_model,
             set_local_model_enabled,
+            set_lmstudio_model_enabled,
             install_provider_cli,
             connect_oauth,
             save_api_key,
@@ -551,6 +552,26 @@ async fn set_local_model_enabled(
         vec![
             "local-models".into(),
             "set".into(),
+            model,
+            (if enabled { "on" } else { "off" }).into(),
+        ],
+        None,
+    )
+    .await
+}
+
+#[tauri::command]
+async fn set_lmstudio_model_enabled(
+    state: State<'_, RouterState>,
+    model: String,
+    enabled: bool,
+) -> Result<Value, String> {
+    validate_local_model_ref(&model)?;
+    run_json_command(
+        state.inner().clone(),
+        vec![
+            "local-models".into(),
+            "lmstudio-set".into(),
             model,
             (if enabled { "on" } else { "off" }).into(),
         ],

--- a/apps/desktop/ui/app.js
+++ b/apps/desktop/ui/app.js
@@ -40,6 +40,7 @@ function startPanel() {
     providerUsage: null,
     providerSetup: null,
     localModels: null,
+    lmstudioBusy: null,
     visionBridge: null,
     visionDownload: null,
     visionPollTimer: null,
@@ -140,6 +141,7 @@ function startPanel() {
     visionEffort: document.getElementById("vision-effort"),
     visionLocalModels: document.getElementById("vision-local-models"),
     localRuntimeActions: document.getElementById("local-runtime-actions"),
+    lmstudioSection: document.getElementById("lmstudio-section"),
     refresh: document.getElementById("refresh-data"),
     islandSwitch: document.getElementById("island-switch"),
     islandSwitchLabel: document.getElementById("island-switch-label"),
@@ -200,6 +202,7 @@ function startPanel() {
   elements.localModelList.addEventListener("click", handleLocalModelClick);
   elements.localModelList.addEventListener("change", handleLocalModelToggle);
   elements.localRuntimeActions.addEventListener("click", handleLocalRuntimeClick);
+  elements.lmstudioSection.addEventListener("change", handleLmstudioModelToggle);
   elements.localDownloadStatus.addEventListener("click", handleLocalModelClick);
   elements.localQuickPicks.addEventListener("click", handleLocalModelClick);
   elements.localCatalog.addEventListener("click", handleLocalModelClick);
@@ -912,11 +915,70 @@ function startPanel() {
           .join("")}${morePicks}`
       : "";
     renderLocalCatalog(local, installBusy);
+    renderLmstudioSection(local.lmstudio, installBusy);
     const runtime = local.runtime || {};
     const machine = local.machine ? `<small class="muted-line">${escapeHtml(local.machine)}</small>` : "";
     elements.localRuntimeActions.innerHTML = runtime.installed
       ? `<div><small>Ollama ${escapeHtml(runtime.version || "installed")} · headless server ${runtime.running ? "running" : "not started"}</small>${runtime.modelsPath ? `<small class="muted-line">Models: ${escapeHtml(runtime.modelsPath)}</small>` : ""}${machine}</div><button class="text-button" type="button" data-local-runtime-action="update"${state.maintenanceBusy || state.localModelBusy ? " disabled" : ""}>Update Ollama</button>`
       : `<small>Ollama is not installed. Installing a model can set it up with explicit consent.</small>`;
+  }
+
+  // LM Studio owns loading and unloading its models, so this section is a
+  // roster with checkboxes, not a lifecycle manager: checking publishes the
+  // model to the picker, and a stopped server reads "not running" instead of
+  // the section disappearing.
+  function renderLmstudioSection(lmstudio, busy = false) {
+    if (!elements.lmstudioSection) return;
+    if (!lmstudio) {
+      elements.lmstudioSection.innerHTML = "";
+      return;
+    }
+    const name = lmstudio.displayName || "LM Studio";
+    const header = `<div class="local-section-label"><span>${escapeHtml(name)}</span><small>${
+      lmstudio.reachable
+        ? "Local server running · models are managed in LM Studio"
+        : "Not running · start LM Studio's local server to list its models"
+    }</small></div>`;
+    const models = Array.isArray(lmstudio.models) ? lmstudio.models : [];
+    if (!models.length) {
+      elements.lmstudioSection.innerHTML = lmstudio.reachable
+        ? `${header}<div class="empty-state local-empty">No models are loaded in LM Studio yet.</div>`
+        : header;
+      return;
+    }
+    const rowBusy = busy || state.lmstudioBusy;
+    const rows = models
+      .map((model) => {
+        const isBusy = state.lmstudioBusy === model.id;
+        const detail = model.served
+          ? model.enabled ? "In the picker" : "Served · unchecked"
+          : "Checked but not currently served";
+        return `<article class="local-model-row${isBusy ? " is-busy" : ""}">
+          <label class="provider-check"><input type="checkbox" data-lmstudio-toggle="${escapeHtml(model.id)}" aria-label="Offer ${escapeHtml(model.id)} in the model picker"${model.enabled ? " checked" : ""}${rowBusy ? " disabled" : ""}></label>
+          <div><strong>${escapeHtml(model.id)}</strong><small>${escapeHtml(detail)}</small></div>
+        </article>`;
+      })
+      .join("");
+    elements.lmstudioSection.innerHTML = `${header}${rows}`;
+  }
+
+  async function handleLmstudioModelToggle(event) {
+    const checkbox = event.target.closest("input[data-lmstudio-toggle]");
+    if (!checkbox) return;
+    const model = checkbox.dataset.lmstudioToggle;
+    if (!model || state.lmstudioBusy) return;
+    const enabled = checkbox.checked;
+    state.lmstudioBusy = model;
+    renderLmstudioSection(state.localModels?.lmstudio);
+    try {
+      state.localModels = await call("set_lmstudio_model_enabled", { model, enabled });
+      await refreshPanel({ quiet: true });
+    } catch (error) {
+      showToast(errorMessage(error), true);
+    } finally {
+      state.lmstudioBusy = null;
+      renderLocalModels();
+    }
   }
 
   function handleLocalCatalogInput(event) {

--- a/apps/desktop/ui/index.html
+++ b/apps/desktop/ui/index.html
@@ -271,6 +271,7 @@
             <div id="local-quick-picks" class="local-quick-picks"></div>
             <div id="local-catalog" class="local-catalog"></div>
             <div id="local-runtime-actions" class="local-runtime-actions"></div>
+            <div id="lmstudio-section" class="lmstudio-section"></div>
           </div>
         </div>
       </section>

--- a/apps/desktop/ui/styles.css
+++ b/apps/desktop/ui/styles.css
@@ -844,6 +844,18 @@ h2 {
   font-size: 8px;
 }
 
+.lmstudio-section {
+  margin-top: 10px;
+}
+
+.lmstudio-section:empty {
+  display: none;
+}
+
+.lmstudio-section .local-model-row {
+  grid-template-columns: auto 1fr;
+}
+
 .maintenance-card {
   display: flex;
   align-items: center;

--- a/docs/LOCAL-MODELS.md
+++ b/docs/LOCAL-MODELS.md
@@ -95,6 +95,20 @@ The default endpoint is `http://127.0.0.1:1234/v1`. Override it with
 `MODEL_ROUTER_LMSTUDIO_BASE_URL`. LM Studio models use the generic Chat
 Completions path; Ollama continues using its native route and context handling.
 
+The desktop companion and browser panel list the models LM Studio is currently
+serving under Local LLMs, and checking one publishes it to the picker without
+the interactive terminal:
+
+```text
+./bin/control local-models list            # includes the LM Studio section
+./bin/control local-models lmstudio-set <model-id> on|off
+```
+
+Both doors write the same user-model overlay, so a model curated in the
+terminal can be unchecked in the panel and vice versa. Loading and unloading
+the weights stays in LM Studio; the checkbox only controls whether the model
+is offered in the picker.
+
 Downloads rated too large for the machine are stopped unless `--force` is
 present; `--yes` alone does not override the fit check, because consenting to
 install Ollama is not the same as consenting to a model that will not run. A

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -1188,11 +1188,17 @@ async function handleLocalModels(action, value, ...rest) {
     [...new Set([...Object.keys(visionBenchmarks), ...Object.keys(localBenchmarks)])]
       .map((tag) => [tag, { ...visionBenchmarks[tag], ...localBenchmarks[tag] }]),
   );
-  const snapshot = () => localModelsSnapshot({
-    benchmarks: localAndVisionBenchmarks,
+  // The LM Studio section rides along with every snapshot so the panel's one
+  // `local_models` read covers both local runtimes. Its probe is a loopback
+  // HTTP call with a short timeout, so an LM Studio that is simply off costs
+  // the snapshot a bounded wait, not an error.
+  const { lmstudioSnapshot } = await import("./lmstudio-models.mjs");
+  const snapshot = async () => ({
+    ...localModelsSnapshot({ benchmarks: localAndVisionBenchmarks }),
+    lmstudio: await lmstudioSnapshot(),
   });
   if (action === "list" || action === "status" || !action) {
-    const current = snapshot();
+    const current = await snapshot();
     // The tray and any script read JSON; a person at a terminal was handed a
     // single unbroken line, which only got worse once the snapshot grew a
     // download list. Explicit `--json` keeps the machine contract, and a bare
@@ -1609,17 +1615,33 @@ async function handleLocalModels(action, value, ...rest) {
     setLocalModelEnabled(value, enabled);
     refreshModelSettingsCatalog({ routes: true });
     if (wasEnabled !== enabled) await restartRouterForLocalRoutes();
+  } else if (action === "lmstudio-set") {
+    if (!["on", "off"].includes(positional)) {
+      throw new Error("Usage: control local-models lmstudio-set <model-id> <on|off>");
+    }
+    // The panel's checkbox for a model LM Studio serves. Publishing goes
+    // through the same user-model overlay `curate-models lmstudio` writes,
+    // and the same restart that makes an Ollama toggle live makes this one.
+    const { isLmstudioModelEnabled, setLmstudioModelEnabled } = await import(
+      "./lmstudio-models.mjs"
+    );
+    const enabled = positional === "on";
+    const wasEnabled = isLmstudioModelEnabled(value);
+    setLmstudioModelEnabled(value, enabled);
+    refreshModelSettingsCatalog({ routes: true });
+    if (wasEnabled !== enabled) await restartRouterForLocalRoutes();
   } else {
     throw new Error(
       "Usage: control local-models list [--json]|inspect <tag-or-url>|" +
         "install <tag-or-url> [--yes] [--force]|benchmark <tag>|" +
         "runtime status|runtime start [--yes]|runtime update --yes|" +
-        "uninstall <tag> --yes|cancel [<tag>]|set <tag> <on|off>\n" +
+        "uninstall <tag> --yes|cancel [<tag>]|set <tag> <on|off>|" +
+        "lmstudio-set <id> <on|off>\n" +
         "  --yes    consent to installing/starting Ollama itself (headless)\n" +
         "  --force  download a model rated too large for this machine anyway",
     );
   }
-  process.stdout.write(`${JSON.stringify(snapshot())}\n`);
+  process.stdout.write(`${JSON.stringify(await snapshot())}\n`);
 }
 
 async function handlePicker(action, value, flag) {

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -228,12 +228,18 @@ async function emitProbe() {
               subagents: subagentSettingsSnapshot(),
               picker: modelPickerSnapshot(),
               toolResultAging: toolResultAgingSnapshot(),
-              localModels: localModelsSnapshot({
-                inventory: localInventory,
-                running: localRunning,
-                runtime: localRuntime,
-                benchmarks: localAndVisionBenchmarks,
-              }),
+              localModels: {
+                ...localModelsSnapshot({
+                  inventory: localInventory,
+                  running: localRunning,
+                  runtime: localRuntime,
+                  benchmarks: localAndVisionBenchmarks,
+                }),
+                // The panel's periodic refresh reads this snapshot, not
+                // `local-models list`, so the LM Studio section must ride
+                // here too or it paints once and vanishes on the next poll.
+                lmstudio: await (await import("./lmstudio-models.mjs")).lmstudioSnapshot(),
+              },
               visionBridge: (() => {
                 const candidates = selectedConfiguredListedModels();
                 // Only the native models that actually shipped into the picker.

--- a/src/desktop-commands.mjs
+++ b/src/desktop-commands.mjs
@@ -71,6 +71,9 @@ export const COMMANDS = {
   set_local_model_enabled: ({ model, tag, enabled }) => ({
     args: ["local-models", "set", requireTag(model ?? tag), enabled ? "on" : "off"],
   }),
+  set_lmstudio_model_enabled: ({ model, id, enabled }) => ({
+    args: ["local-models", "lmstudio-set", requireTag(model ?? id), enabled ? "on" : "off"],
+  }),
   install_provider_cli: ({ provider }) => ({ args: ["install-cli", requireProvider(provider)] }),
   connect_oauth: ({ provider }) => ({
     args: ["login", requireProvider(provider)],

--- a/src/lmstudio-models.mjs
+++ b/src/lmstudio-models.mjs
@@ -1,0 +1,166 @@
+import { PROVIDERS, resolveProviderBaseUrl } from "./model-registry.mjs";
+import {
+  disableProvider,
+  enableProvider,
+  readProviderSelection,
+} from "./provider-selection.mjs";
+import { readUserModels, userModelEntry, writeUserModels } from "./user-models.mjs";
+
+// LM Studio is the operator's own software serving models it already manages,
+// so the router only ever reads and reports what the server offers -- the same
+// stance local-models.mjs takes toward Ollama. Loading and unloading weights
+// stays in LM Studio; checking a model here only publishes it to the picker.
+
+export const LMSTUDIO_PROVIDER_ID = "lmstudio";
+
+// After the Ollama local block (900): both are local, and LM Studio models are
+// curated with less verification, so they sort last.
+const LMSTUDIO_MODEL_PRIORITY = 950;
+
+// A loopback server either answers immediately or is not running; waiting the
+// full discovery timeout would hold the whole panel snapshot hostage to a
+// server that is simply off.
+const PROBE_TIMEOUT_MS = 3000;
+
+// Same reasoning as the Ollama constants in local-models.mjs: Codex sizes its
+// prompts to the advertised window, and a local model asked for a 128K prompt
+// spills its KV cache out of GPU memory. LM Studio sizes the real allocation
+// in its own settings; this only caps what Codex sends.
+const LMSTUDIO_CONTEXT_WINDOW = 32768;
+const LMSTUDIO_AUTO_COMPACT = 28000;
+
+function lmstudioProvider() {
+  return PROVIDERS.get(LMSTUDIO_PROVIDER_ID);
+}
+
+export function curatedLmstudioModels(models = readUserModels()) {
+  return models.filter((model) => model.provider === LMSTUDIO_PROVIDER_ID);
+}
+
+export function isLmstudioModelEnabled(id, models = readUserModels()) {
+  const value = String(id || "").trim();
+  return curatedLmstudioModels(models).some((model) => model.upstreamModel === value);
+}
+
+// What the server is serving right now, straight from its OpenAI-compatible
+// /models endpoint. Unreachable is a state, not an error: the panel shows
+// "not running" instead of losing the section.
+export async function lmstudioServedModels({
+  fetchImpl = fetch,
+  timeoutMs = PROBE_TIMEOUT_MS,
+} = {}) {
+  const provider = lmstudioProvider();
+  if (!provider) return { reachable: false, baseUrl: undefined, models: [] };
+  const { baseUrl } = resolveProviderBaseUrl(provider);
+  try {
+    const response = await fetchImpl(`${baseUrl}/models`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return { reachable: false, baseUrl, models: [] };
+    const payload = await response.json().catch(() => ({}));
+    const data = Array.isArray(payload) ? payload : payload?.data;
+    const ids = Array.isArray(data)
+      ? [...new Set(data.map((item) => String(item?.id || "").trim()).filter(Boolean))].sort()
+      : [];
+    return { reachable: true, baseUrl, models: ids };
+  } catch {
+    return { reachable: false, baseUrl, models: [] };
+  }
+}
+
+// The panel's view of LM Studio: everything the server serves, everything the
+// picker publishes, and the difference between them. A curated model the
+// server no longer serves stays visible as `served: false` -- hiding it would
+// leave a route in the picker with no way to see or clear it here.
+export async function lmstudioSnapshot({
+  fetchImpl,
+  timeoutMs,
+  userModels = readUserModels(),
+} = {}) {
+  const provider = lmstudioProvider();
+  const served = await lmstudioServedModels({
+    ...(fetchImpl ? { fetchImpl } : {}),
+    ...(timeoutMs ? { timeoutMs } : {}),
+  });
+  const curated = curatedLmstudioModels(userModels);
+  const curatedIds = new Set(curated.map((model) => model.upstreamModel));
+  const servedSet = new Set(served.models);
+  const models = [
+    ...served.models.map((id) => ({ id, enabled: curatedIds.has(id), served: true })),
+    ...curated
+      .filter((model) => !servedSet.has(model.upstreamModel))
+      .map((model) => ({ id: model.upstreamModel, enabled: true, served: false })),
+  ].sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
+  let providerEnabled;
+  try {
+    providerEnabled = readProviderSelection().includes(LMSTUDIO_PROVIDER_ID);
+  } catch {
+    providerEnabled = undefined;
+  }
+  return {
+    provider: LMSTUDIO_PROVIDER_ID,
+    displayName: provider?.displayName || "LM Studio",
+    reachable: served.reachable,
+    baseUrl: served.baseUrl,
+    enabled: models.filter((model) => model.enabled).length,
+    providerEnabled,
+    models,
+  };
+}
+
+// Deliberately failure-tolerant for the same reason as the Ollama twin: the
+// selection file is shared state, and a checkbox that publishes the model but
+// cannot flip the provider beats one that fails outright.
+export function syncLmstudioProviderSelection(shouldEnable) {
+  try {
+    const enabled = readProviderSelection().includes(LMSTUDIO_PROVIDER_ID);
+    if (shouldEnable && !enabled) enableProvider(LMSTUDIO_PROVIDER_ID);
+    if (!shouldEnable && enabled) disableProvider(LMSTUDIO_PROVIDER_ID);
+    return shouldEnable;
+  } catch {
+    return undefined;
+  }
+}
+
+// Checking a model publishes it through the same user-model overlay that
+// `curate-models lmstudio` writes, so the panel and the interactive CLI are
+// two doors to one state -- neither can strand the other's entries.
+export function setLmstudioModelEnabled(id, enabled) {
+  const value = String(id || "").trim();
+  if (!value) throw new Error("A model id is required.");
+  const existing = readUserModels();
+  const others = existing.filter((model) => model.provider !== LMSTUDIO_PROVIDER_ID);
+  const mine = existing.filter(
+    (model) => model.provider === LMSTUDIO_PROVIDER_ID && model.upstreamModel !== value,
+  );
+  const entries = enabled
+    ? [
+        ...mine,
+        {
+          ...userModelEntry({
+            providerId: LMSTUDIO_PROVIDER_ID,
+            upstreamId: value,
+            priority: LMSTUDIO_MODEL_PRIORITY + mine.length,
+            metadata: {
+              contextWindow: LMSTUDIO_CONTEXT_WINDOW,
+              autoCompact: LMSTUDIO_AUTO_COMPACT,
+              description: `${value} served by LM Studio on this machine.`,
+            },
+          }),
+          // "experimental" is a promise AGENTS.md forbids dropping: driving a
+          // Codex turn locally is unproven per-model, and nothing here has
+          // verified this one can dispatch tool calls at all.
+          displayName: `${value} (LM Studio, experimental)`,
+          // The same conservative choices the Ollama publish path makes, for
+          // the same reasons: apply_patch is a freeform custom tool with no
+          // clean representation in an OpenAI-compatible tool schema, and no
+          // local model has been shown here to drive subagents.
+          supportsApplyPatchTool: false,
+          multiAgentVersion: "v1",
+        },
+      ]
+    : mine;
+  writeUserModels([...others, ...entries]);
+  syncLmstudioProviderSelection(entries.length > 0);
+  return entries;
+}

--- a/src/lmstudio-models.mjs
+++ b/src/lmstudio-models.mjs
@@ -133,14 +133,14 @@ export function setLmstudioModelEnabled(id, enabled) {
   const mine = existing.filter(
     (model) => model.provider === LMSTUDIO_PROVIDER_ID && model.upstreamModel !== value,
   );
-  const entries = enabled
+  const next = enabled
     ? [
         ...mine,
         {
           ...userModelEntry({
             providerId: LMSTUDIO_PROVIDER_ID,
             upstreamId: value,
-            priority: LMSTUDIO_MODEL_PRIORITY + mine.length,
+            priority: LMSTUDIO_MODEL_PRIORITY,
             metadata: {
               contextWindow: LMSTUDIO_CONTEXT_WINDOW,
               autoCompact: LMSTUDIO_AUTO_COMPACT,
@@ -160,6 +160,14 @@ export function setLmstudioModelEnabled(id, enabled) {
         },
       ]
     : mine;
+  // Renumbered on every write rather than assigned once: a priority derived
+  // from the list length at toggle time collides after a disable/re-enable
+  // cycle (enable A,B,C; disable B; re-enable B lands on C's number). Kept as
+  // a renumber, not a rebuild, so metadata curate-models asked for survives.
+  const entries = next.map((entry, index) => ({
+    ...entry,
+    priority: LMSTUDIO_MODEL_PRIORITY + index,
+  }));
   writeUserModels([...others, ...entries]);
   syncLmstudioProviderSelection(entries.length > 0);
   return entries;

--- a/src/local-models.mjs
+++ b/src/local-models.mjs
@@ -1046,6 +1046,24 @@ export function renderLocalModels(snapshot) {
       "  Any valid Ollama tag or ollama.com model URL also works.",
     );
   }
+  // Present whenever the snapshot carries it, including the not-running case:
+  // an LM Studio user who stopped the server should read "not running", not
+  // watch the whole section vanish as if support had gone away.
+  const lmstudio = snapshot.lmstudio;
+  if (lmstudio) {
+    lines.push("", `${lmstudio.displayName || "LM Studio"}:`);
+    if (!lmstudio.reachable && lmstudio.models.length === 0) {
+      lines.push("  Not running. Start LM Studio's local server to list its models.");
+    } else {
+      for (const model of lmstudio.models) {
+        lines.push(
+          `  ${model.enabled ? "[x]" : "[ ]"} ${model.id}` +
+            `${model.served ? "" : "  · not currently served"}`,
+        );
+      }
+      lines.push("  Toggle one:  ./bin/control local-models lmstudio-set <id> on|off");
+    }
+  }
   return lines.join("\n");
 }
 

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -160,6 +160,12 @@ test("codex probe includes native GPT models and the configured default", () => 
   assert.ok(["all", "selected", "proven"].includes(slice.modelSettings.subagents.mode));
   // Compaction is opt-in, so an unconfigured probe reports it off.
   assert.equal(slice.modelSettings.toolResultAging.enabled, false);
+  // The panel's periodic refresh reads this snapshot, not `local-models
+  // list`, so the LM Studio section has to ride here or it paints once and
+  // vanishes on the next poll.
+  assert.equal(slice.modelSettings.localModels.lmstudio.provider, "lmstudio");
+  assert.equal(typeof slice.modelSettings.localModels.lmstudio.reachable, "boolean");
+  assert.ok(Array.isArray(slice.modelSettings.localModels.lmstudio.models));
 });
 
 test("codex probe exposes managed login-free mode without credential details", () => {

--- a/test/desktop-commands.test.mjs
+++ b/test/desktop-commands.test.mjs
@@ -19,6 +19,15 @@ test("desktop local-model commands use the shared model argument", () => {
   assert.deepEqual(COMMANDS.set_local_model_enabled({ model: "gemma4:12b", enabled: true }), {
     args: ["local-models", "set", "gemma4:12b", "on"],
   });
+  // LM Studio ids carry slashes ("qwen/qwen3-4b"), which requireTag permits.
+  assert.deepEqual(
+    COMMANDS.set_lmstudio_model_enabled({ model: "qwen/qwen3-4b", enabled: true }),
+    { args: ["local-models", "lmstudio-set", "qwen/qwen3-4b", "on"] },
+  );
+  assert.deepEqual(
+    COMMANDS.set_lmstudio_model_enabled({ id: "qwen/qwen3-4b", enabled: false }),
+    { args: ["local-models", "lmstudio-set", "qwen/qwen3-4b", "off"] },
+  );
   assert.deepEqual(COMMANDS.local_model_speed({ model: "gemma4:12b" }), {
     args: ["local-models", "benchmark", "gemma4:12b"],
   });

--- a/test/lmstudio-models.test.mjs
+++ b/test/lmstudio-models.test.mjs
@@ -107,6 +107,18 @@ test("checking a model publishes it through the same overlay curate-models write
   assert.ok(Array.isArray(raw.models));
 });
 
+test("a disable/re-enable cycle cannot land two models on one priority", () => {
+  writeUserModels([]);
+  setLmstudioModelEnabled("alpha", true);
+  setLmstudioModelEnabled("beta", true);
+  setLmstudioModelEnabled("gamma", true);
+  setLmstudioModelEnabled("beta", false);
+  setLmstudioModelEnabled("beta", true);
+  const mine = readUserModels().filter((model) => model.provider === "lmstudio");
+  const priorities = mine.map((model) => model.priority);
+  assert.equal(new Set(priorities).size, priorities.length, `collision in ${priorities}`);
+});
+
 test("toggling one model leaves the other curated LM Studio entries alone", () => {
   writeUserModels([]);
   setLmstudioModelEnabled("alpha", true);

--- a/test/lmstudio-models.test.mjs
+++ b/test/lmstudio-models.test.mjs
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+// Set before the imports below: user-models and provider-selection bind their
+// paths at module load, and these tests must never touch the real state.
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "lmstudio-panel-test-"));
+process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+process.env.MODEL_ROUTER_USER_MODELS = path.join(stateDir, "user-models.json");
+
+const {
+  isLmstudioModelEnabled,
+  lmstudioServedModels,
+  lmstudioSnapshot,
+  setLmstudioModelEnabled,
+} = await import("../src/lmstudio-models.mjs");
+const { readUserModels, writeUserModels, userModelEntry } = await import(
+  "../src/user-models.mjs"
+);
+const { readProviderSelection } = await import("../src/provider-selection.mjs");
+
+function fetchOk(ids) {
+  return async () => ({
+    ok: true,
+    json: async () => ({ data: ids.map((id) => ({ id })) }),
+  });
+}
+
+const fetchDown = async () => {
+  throw new Error("connection refused");
+};
+
+test("served models come from the /models endpoint, deduplicated and sorted", async () => {
+  const served = await lmstudioServedModels({
+    fetchImpl: fetchOk(["zeta", "alpha", "alpha", ""]),
+  });
+  assert.equal(served.reachable, true);
+  assert.match(String(served.baseUrl), /^http:\/\/127\.0\.0\.1:1234/);
+  assert.deepEqual(served.models, ["alpha", "zeta"]);
+});
+
+test("a server that is off reads as unreachable, not as an error", async () => {
+  const served = await lmstudioServedModels({ fetchImpl: fetchDown });
+  assert.equal(served.reachable, false);
+  assert.deepEqual(served.models, []);
+});
+
+test("the snapshot merges served models with curated ones, keeping stale entries visible", async () => {
+  const userModels = [
+    userModelEntry({ providerId: "lmstudio", upstreamId: "alpha", priority: 950 }),
+    userModelEntry({ providerId: "lmstudio", upstreamId: "gone-model", priority: 951 }),
+    userModelEntry({ providerId: "kimi-api", upstreamId: "other", priority: 100 }),
+  ];
+  const snapshot = await lmstudioSnapshot({
+    fetchImpl: fetchOk(["alpha", "beta"]),
+    userModels,
+  });
+  assert.equal(snapshot.reachable, true);
+  assert.equal(snapshot.enabled, 2);
+  assert.deepEqual(snapshot.models, [
+    { id: "alpha", enabled: true, served: true },
+    { id: "beta", enabled: false, served: true },
+    // Curated but no longer served: hiding it would strand a picker route
+    // with no way to see or clear it from the panel.
+    { id: "gone-model", enabled: true, served: false },
+  ]);
+});
+
+test("an unreachable server still reports curated models", async () => {
+  const userModels = [
+    userModelEntry({ providerId: "lmstudio", upstreamId: "alpha", priority: 950 }),
+  ];
+  const snapshot = await lmstudioSnapshot({ fetchImpl: fetchDown, userModels });
+  assert.equal(snapshot.reachable, false);
+  assert.deepEqual(snapshot.models, [{ id: "alpha", enabled: true, served: false }]);
+});
+
+test("checking a model publishes it through the same overlay curate-models writes", () => {
+  writeUserModels([
+    userModelEntry({ providerId: "kimi-api", upstreamId: "other", priority: 100 }),
+  ]);
+  setLmstudioModelEnabled("qwen/qwen3-4b", true);
+
+  const stored = readUserModels();
+  const mine = stored.filter((model) => model.provider === "lmstudio");
+  assert.equal(mine.length, 1);
+  assert.equal(mine[0].upstreamModel, "qwen/qwen3-4b");
+  assert.equal(mine[0].displayName, "qwen/qwen3-4b (LM Studio, experimental)");
+  assert.equal(mine[0].supportsApplyPatchTool, false);
+  assert.equal(mine[0].multiAgentVersion, "v1");
+  // The KV-cache reasoning from the Ollama path applies to any local model.
+  assert.equal(mine[0].contextWindow, 32768);
+  // Other providers' curated entries survive untouched.
+  assert.ok(stored.some((model) => model.provider === "kimi-api"));
+  assert.equal(isLmstudioModelEnabled("qwen/qwen3-4b"), true);
+  // The provider follows the models: first check turns it on.
+  assert.ok(readProviderSelection().includes("lmstudio"));
+
+  setLmstudioModelEnabled("qwen/qwen3-4b", false);
+  assert.equal(isLmstudioModelEnabled("qwen/qwen3-4b"), false);
+  assert.ok(readUserModels().some((model) => model.provider === "kimi-api"));
+  // ...and the last uncheck turns it back off.
+  assert.ok(!readProviderSelection().includes("lmstudio"));
+  const raw = JSON.parse(readFileSync(process.env.MODEL_ROUTER_USER_MODELS, "utf8"));
+  assert.ok(Array.isArray(raw.models));
+});
+
+test("toggling one model leaves the other curated LM Studio entries alone", () => {
+  writeUserModels([]);
+  setLmstudioModelEnabled("alpha", true);
+  setLmstudioModelEnabled("beta", true);
+  setLmstudioModelEnabled("alpha", false);
+  const mine = readUserModels().filter((model) => model.provider === "lmstudio");
+  assert.deepEqual(mine.map((model) => model.upstreamModel), ["beta"]);
+  assert.ok(readProviderSelection().includes("lmstudio"));
+});


### PR DESCRIPTION
Closes #241.

## What changed

- **`src/lmstudio-models.mjs`** — reads LM Studio's own `/v1/models` endpoint (loopback probe, 3 s timeout, so a stopped server costs a bounded wait, not an error) and merges it with the curated user-model overlay. A curated model the server no longer serves stays visible as `served: false` instead of lingering in the picker with no way to see why.
- **`control local-models list`** now carries an `lmstudio` section in both JSON and text output; **`control local-models lmstudio-set <id> on|off`** toggles a model with the same catalog-plus-routes rewrite and router restart an Ollama toggle gets.
- Checking a model publishes it through the **same user-model overlay** `curate-models lmstudio` writes — one state, two doors — with the experimental label AGENTS.md requires, `supportsApplyPatchTool: false`, and the 32K context cap the Ollama path uses for the same KV-cache reasons. The provider flips on with the first check and off with the last.
- **Panel UI** (shared across Tauri, Electron, and browser shells): an LM Studio roster under Local LLMs with checkboxes; a stopped server reads "not running" instead of the section vanishing. New `set_lmstudio_model_enabled` in the shared command table plus the Tauri-side command.
- Docs (`docs/LOCAL-MODELS.md`) and CHANGELOG updated.

## Validation

- `npm run check`
- `npm test`: 1291 passing, 0 failed, 12 platform-gated skips
- `cargo check` on `apps/desktop/src-tauri`
- Smoke: `control local-models list --json` against an isolated state dir returns the `lmstudio` section with `reachable: false` when no server is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9M4PfijioNMe3RsUQ999x