### PR TITLE
feat: add official Xiaomi MiMo API provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Linux installations support the Codex CLI.
 | DeepSeek V4 Pro (Ollama Cloud) | `ollama-cloud/deepseek-v4-pro` | Ollama Cloud API key |
 | DeepSeek V4 Flash (Ollama Cloud) | `ollama-cloud/deepseek-v4-flash` | Ollama Cloud API key |
 | MiniMax M3 | `minimax-token-plan/minimax-m3` | MiniMax Token Plan API key |
+| MiMo-V2.5 (Xiaomi API) | `xiaomi-mimo/mimo-v2.5` | Xiaomi MiMo API key |
+| MiMo-V2.5-Pro (Xiaomi API) | `xiaomi-mimo/mimo-v2.5-pro` | Xiaomi MiMo API key |
 | Qwen3.8 Max (Plan) | `qwen-plan/qwen3.8-max` | Alibaba Model Studio plan API key |
 | Qwen3.8 Max Preview (Plan) | `qwen-plan/qwen3.8-max-preview` | Alibaba Model Studio plan API key |
 | Qwen3.7 Max (Plan) | `qwen-plan/qwen3.7-max` | Alibaba Model Studio plan API key |
@@ -208,6 +210,14 @@ endpoint.
 npm install -g @xai-official/grok
 grok login --oauth
 ```
+
+MiMo (Xiaomi API) uses Xiaomi's official OpenAI-compatible endpoint at
+`https://api.xiaomimimo.com/v1`. Unlike MiMo reseller routes, the direct API
+serves `mimo-v2.5` and `mimo-v2.5-pro` through the standard
+`/chat/completions` surface, so requests never touch the Responses gateway.
+`mimo-v2.5` is verified for text/image input and Codex standalone web search;
+`mimo-v2.5-pro` is text-only. Store the key with
+`./bin/model-router codex provider-key xiaomi-mimo set`.
 
 Native GPT models continue to use Codex directly. There is no separate GPT or
 ChatGPT OAuth provider in the router.

--- a/config/xiaomi/api/mimo-v2.5-pro.json
+++ b/config/xiaomi/api/mimo-v2.5-pro.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "xiaomi-mimo/mimo-v2.5-pro",
+      "gatewayModel": "xiaomi-mimo-mimo-v2-5-pro",
+      "upstreamModel": "mimo-v2.5-pro",
+      "provider": "xiaomi-mimo",
+      "listed": true,
+      "displayName": "MiMo-V2.5-Pro (Xiaomi API)",
+      "description": "MiMo-V2.5-Pro through Xiaomi's official OpenAI-compatible API. Text input only.",
+      "priority": 70,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 996147,
+      "inputModalities": [
+        "text"
+      ],
+      "compHash": "xiaomi-mimo-v2-5-pro-v1",
+      "supportsReasoningSummaries": true,
+      "supportsParallelToolCalls": false,
+      "experimentalSupportedTools": [],
+      "supportsApplyPatchTool": false
+    }
+  ]
+}

--- a/config/xiaomi/api/mimo-v2.5-pro.json
+++ b/config/xiaomi/api/mimo-v2.5-pro.json
@@ -18,7 +18,7 @@
         }
       ],
       "contextWindow": 1048576,
-      "autoCompact": 996147,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],

--- a/config/xiaomi/api/mimo-v2.5.json
+++ b/config/xiaomi/api/mimo-v2.5.json
@@ -18,7 +18,7 @@
         }
       ],
       "contextWindow": 1048576,
-      "autoCompact": 996147,
+      "autoCompact": 900000,
       "inputModalities": [
         "text",
         "image"

--- a/config/xiaomi/api/mimo-v2.5.json
+++ b/config/xiaomi/api/mimo-v2.5.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "xiaomi-mimo/mimo-v2.5",
+      "gatewayModel": "xiaomi-mimo-mimo-v2-5",
+      "upstreamModel": "mimo-v2.5",
+      "provider": "xiaomi-mimo",
+      "listed": true,
+      "displayName": "MiMo-V2.5 (Xiaomi API)",
+      "description": "MiMo-V2.5 through Xiaomi's official OpenAI-compatible API with text and image input.",
+      "priority": 71,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 996147,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "compHash": "xiaomi-mimo-v2-5-v1",
+      "supportsReasoningSummaries": true,
+      "supportsImageDetailOriginal": true,
+      "searchTool": {
+        "mode": "standalone"
+      },
+      "supportsParallelToolCalls": false,
+      "experimentalSupportedTools": [],
+      "supportsApplyPatchTool": false
+    }
+  ]
+}

--- a/config/xiaomi/mimo.json
+++ b/config/xiaomi/mimo.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "xiaomi-mimo",
+      "displayName": "Xiaomi MiMo API",
+      "kind": "openai-compatible",
+      "ownedBy": "xiaomi",
+      "protocol": "openai",
+      "baseUrl": "https://api.xiaomimimo.com/v1",
+      "baseUrlEnv": "XIAOMI_MIMO_API_BASE_URL",
+      "credential": {
+        "environment": [
+          "MIMO_API_KEY"
+        ],
+        "file": "xiaomi-mimo-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-xiaomi-mimo-api"
+        ],
+        "prompt": "Xiaomi MiMo API key"
+      }
+    }
+  ]
+}

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -574,6 +574,15 @@ export function routedModel(template, model) {
     delete next.default_reasoning_level;
     delete next.supported_reasoning_levels;
   }
+  // A few OpenAI-compatible upstreams reject tool scheduling the native
+  // template advertises. Registry entries opt out explicitly so the picker
+  // never offers a custom or parallel tool the provider backend will 400.
+  if (typeof model.supportsParallelToolCalls === "boolean") {
+    next.supports_parallel_tool_calls = model.supportsParallelToolCalls;
+  }
+  if (Array.isArray(model.experimentalSupportedTools)) {
+    next.experimental_supported_tools = [...model.experimentalSupportedTools];
+  }
   if (typeof next.base_instructions === "string") {
     next.base_instructions = rewriteIdentity(next.base_instructions, model);
   }

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -399,6 +399,21 @@ function modelProblem(model, providers, slugs, gatewayModels) {
     return `model ${model.slug} has an invalid supportsApplyPatchTool`;
   }
   if (
+    model.supportsParallelToolCalls !== undefined &&
+    typeof model.supportsParallelToolCalls !== "boolean"
+  ) {
+    return `model ${model.slug} has an invalid supportsParallelToolCalls`;
+  }
+  if (
+    model.experimentalSupportedTools !== undefined &&
+    (!Array.isArray(model.experimentalSupportedTools) ||
+      model.experimentalSupportedTools.some(
+        (tool) => typeof tool !== "string" || !tool.trim(),
+      ))
+  ) {
+    return `model ${model.slug} has invalid experimentalSupportedTools`;
+  }
+  if (
     model.supportsImageDetailOriginal !== undefined &&
     typeof model.supportsImageDetailOriginal !== "boolean"
   ) {

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -202,6 +202,20 @@ test("routed models advertise search and image detail only when the registry opt
   assert.equal(standalone.supports_search_tool, true);
 });
 
+test("routed models can explicitly narrow inherited tool capabilities", () => {
+  const plain = routedModel(template, grok);
+  assert.equal("supports_parallel_tool_calls" in plain, false);
+  assert.equal("experimental_supported_tools" in plain, false);
+
+  const narrowed = routedModel(template, {
+    ...grok,
+    supportsParallelToolCalls: false,
+    experimentalSupportedTools: [],
+  });
+  assert.equal(narrowed.supports_parallel_tool_calls, false);
+  assert.deepEqual(narrowed.experimental_supported_tools, []);
+});
+
 test("routed service tiers are explicit and never inherit a paid default", () => {
   const plain = routedModel(template, grok);
   assert.deepEqual(plain.service_tiers, []);

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -126,6 +126,8 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "qwen-plan/qwen3.7-plus",
       "qwen-plan/qwen3.8-max-preview",
       "qwen-plan/qwen3.8-max",
+      "xiaomi-mimo/mimo-v2.5-pro",
+      "xiaomi-mimo/mimo-v2.5",
       "zai-api/glm-4.7",
       "zai-api/glm-5.2",
       "zai-api/glm-5.3",
@@ -182,6 +184,12 @@ test("provider registry exposes configured API and OAuth model families", () => 
   assert.equal(PROVIDERS.get("commandcode").baseUrl, "https://api.commandcode.ai/provider/v1");
   assert.equal(PROVIDERS.get("commandcode-messages").baseUrl, "https://api.commandcode.ai/provider/v1");
   assert.equal(PROVIDERS.get("commandcode-messages").protocol, "anthropic");
+  // Xiaomi's direct API is OpenAI-compatible chat, not the Responses gateway.
+  assert.equal(PROVIDERS.get("xiaomi-mimo").baseUrl, "https://api.xiaomimimo.com/v1");
+  assert.equal(PROVIDERS.get("xiaomi-mimo").baseUrlEnv, "XIAOMI_MIMO_API_BASE_URL");
+  assert.equal(PROVIDERS.get("xiaomi-mimo").protocol, "openai");
+  assert.deepEqual(PROVIDERS.get("xiaomi-mimo").credential.environment, ["MIMO_API_KEY"]);
+  assert.equal(PROVIDERS.get("xiaomi-mimo").credential.file, "xiaomi-mimo-api-key.secret");
   // The protocol variants are one selectable family: they declare the parent
   // whose credential and picker selection they follow.
   assert.equal(PROVIDERS.get("opencode-go").variantOf, undefined);
@@ -373,6 +381,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
   const standaloneSearchSlugs = new Set([
     "deepseek/deepseek-v4-flash",
     "opencode-go/deepseek-v4-flash",
+    "xiaomi-mimo/mimo-v2.5",
   ]);
   for (const model of MODELS) {
     if (["grok-oauth/grok-4.5", "grok-oauth/grok-4.6"].includes(model.slug) || standaloneSearchSlugs.has(model.slug)) continue;
@@ -399,6 +408,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
     "qwen-plan/qwen3.7-max",
     "qwen-plan/qwen3.8-max",
     "qwen-plan/qwen3.8-max-preview",
+    "xiaomi-mimo/mimo-v2.5",
   ]);
   for (const slug of originalDetailSlugs) {
     assert.ok(
@@ -476,6 +486,28 @@ test("Meta models opt out of the apply_patch custom tool", () => {
     assert.equal(MODEL_BY_SLUG.get(slug).supportsApplyPatchTool, false);
   }
   assert.equal(MODEL_BY_SLUG.get("grok-oauth/grok-4.5").supportsApplyPatchTool, undefined);
+});
+
+test("official Xiaomi MiMo routes advertise only verified capabilities", () => {
+  const vlm = MODEL_BY_SLUG.get("xiaomi-mimo/mimo-v2.5");
+  const pro = MODEL_BY_SLUG.get("xiaomi-mimo/mimo-v2.5-pro");
+  for (const model of [pro, vlm]) {
+    assert.equal(model.contextWindow, 1_048_576);
+    assert.equal(model.autoCompact, 996_147);
+    assert.equal(model.defaultEffort, "high");
+    assert.deepEqual(model.reasoningLevels, [
+      { effort: "high", description: "Deep reasoning" },
+    ]);
+    assert.equal(model.supportsReasoningSummaries, true);
+    assert.equal(model.supportsParallelToolCalls, false);
+    assert.deepEqual(model.experimentalSupportedTools, []);
+    assert.equal(model.supportsApplyPatchTool, false);
+  }
+  assert.deepEqual(pro.inputModalities, ["text"]);
+  assert.equal(pro.searchTool, undefined);
+  assert.deepEqual(vlm.inputModalities, ["text", "image"]);
+  assert.equal(vlm.supportsImageDetailOriginal, true);
+  assert.deepEqual(vlm.searchTool, { mode: "standalone" });
 });
 
 test("deprecated DeepSeek aliases remain routable but stay out of the picker", () => {

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -493,7 +493,12 @@ test("official Xiaomi MiMo routes advertise only verified capabilities", () => {
   const pro = MODEL_BY_SLUG.get("xiaomi-mimo/mimo-v2.5-pro");
   for (const model of [pro, vlm]) {
     assert.equal(model.contextWindow, 1_048_576);
-    assert.equal(model.autoCompact, 996_147);
+    // 900,000 is what every other million-token route in this registry
+    // compacts at, including the three other MiMo routes. The 95% this
+    // started at left ~52K of headroom on a window Codex is already told to
+    // treat as 95% effective, so a turn could grow past the limit before
+    // anything compacted it.
+    assert.equal(model.autoCompact, 900_000);
     assert.equal(model.defaultEffort, "high");
     assert.deepEqual(model.reasoningLevels, [
       { effort: "high", description: "Deep reasoning" },

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3494,6 +3494,52 @@ test("API forwarder strips web_search_options for Fireworks", async () => {
   }
 });
 
+test("API forwarder keeps Xiaomi MiMo web search options on chat completions", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push(await bodyJson(request));
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    XIAOMI_MIMO_API_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    MIMO_API_KEY: "TEST_MIMO_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "xiaomi-mimo-mimo-v2-5",
+          web_search_options: { search_context_size: "medium" },
+          client_metadata: { workspace: "caller-owned" },
+          messages: [{ role: "user", content: "test" }],
+        }),
+      },
+    );
+    assert.equal(response.status, 200, forwarder.testErrors());
+    assert.equal(upstreamRequests[0].model, "mimo-v2.5");
+    assert.deepEqual(upstreamRequests[0].web_search_options, {
+      search_context_size: "medium",
+    });
+    assert.equal(upstreamRequests[0].client_metadata, undefined);
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("router strips Fireworks web_search_options on routed and compaction requests", async () => {
   const gatewayRequests = [];
   const gateway = await mockServer(async (request, response) => {


### PR DESCRIPTION
# feat: add official Xiaomi MiMo API provider

## Problem

codex-router already routes MiMo through ClinePass, opencode Go, and Command Code, but there is no direct route for Xiaomi's official MiMo API (`https://api.xiaomimimo.com/v1`).

When a direct MiMo route was tried over the Responses gateway, Xiaomi rejected the standard Codex tool declarations:

```text
HTTP 400 responses_feature_not_supported
tool type 'web_search' is not supported by this gateway phase
tool type 'custom' is not supported by this gateway phase
```

Codex sends hosted-style tool declarations (`tools: [{type: "web_search"}]`, plus custom tools from the native template). Forwarding those untouched to `api.xiaomimimo.com/v1/responses` is rejected by Xiaomi's gateway. MiMo's official OpenAI-compatible API accepts chat completions with `web_search_options` instead.

## Changes

- Add `xiaomi-mimo` provider with `protocol: "openai"`, so LiteLLM generates `openai/<gatewayModel>` with `use_chat_completions_api: true` and requests never touch the Responses gateway.
- Add `xiaomi-mimo/mimo-v2.5` (text + image, Codex standalone web search, 1M context) and `xiaomi-mimo/mimo-v2.5-pro` (text only, 1M context).
- Allow routed model metadata to narrow tool capabilities inherited from the native template: `supports_parallel_tool_calls: false`, `experimental_supported_tools: []`, and `supports_apply_patch_tool: false` keep Codex from offering custom tools MiMo rejects.
- Validate the new `supportsParallelToolCalls` and `experimentalSupportedTools` registry fields.
- Add registry, catalog, and API-forwarder regression tests, including a chat-completions request that keeps `web_search_options` and strips `client_metadata`.
- Document the provider and credential setup in the README.

## Verification

- `npm run check` passes.
- `npm test`: 1294 passed, 0 failed, 13 skipped.
- Local end-to-end check: Xiaomi `/v1/chat/completions` accepts both a plain request and a request with `web_search_options` (HTTP 200); a router-gateway MiMo request carrying a `web_search` tool also returns 200 after the protocol change.

## Notes

- Credential environment variable: `MIMO_API_KEY`; protected key file: `xiaomi-mimo-api-key.secret`; keychain service: `codex-router-xiaomi-mimo-api`.
- Base URL override: `XIAOMI_MIMO_API_BASE_URL`.
- No API keys or credentials are included in this PR.
