### PR TITLE
feat(doctor): flag context windows the provider has already disproved

### DIFF
--- a/src/context-window-drift.mjs
+++ b/src/context-window-drift.mjs
@@ -28,9 +28,18 @@ function positiveInteger(value) {
 // Estimated counts prove nothing either -- the router substitutes those when a
 // provider reports zero, and an estimate cannot disprove a provider's own
 // limit.
+// An empty-completion retry sends the same prompt twice and both attempts are
+// billed, so the meter deliberately sums them (mergeTokenUsage) and the turn
+// lands as a normal 200 carrying roughly double the prompt it actually sent.
+// Believed as capacity that is a ~2x window overstatement invented out of one
+// retry -- and the remediation this check prints is "raise the window", so the
+// bad sample would talk an operator into doubling a correct number.
+// provider-usage.mjs drops these same events from its throughput math for the
+// same reason: a merged pair is not one measurement.
 export function acceptedInputTokens(event) {
   if (event?.status !== 200) return undefined;
   if (event?.estimatedInputTokens !== undefined) return undefined;
+  if (event?.emptyCompletionRetried === true) return undefined;
   return positiveInteger(event?.inputTokens);
 }
 

--- a/src/context-window-drift.mjs
+++ b/src/context-window-drift.mjs
@@ -1,0 +1,88 @@
+// A declared context window is a claim, and every successful turn is evidence
+// against it. When a provider answered 200 to a prompt larger than the window
+// we advertise, the window is not "probably" wrong -- the provider itself
+// disproved it, and the only question is by how much.
+//
+// This matters because the failure is silent and asymmetric. Codex compacts at
+// the auto-compact limit derived from that window, so an understated window
+// makes a legitimate task open above its own compaction threshold, summarize,
+// lose the agent's working state, redo the same opening work, and compact
+// again without ever finishing. Nothing errors. The session simply never ends,
+// and the model takes the blame. An overstated window fails the honest way
+// instead: one upstream rejection that names the real limit.
+//
+// The evidence is already on disk. This reads it rather than probing, so the
+// check costs no quota and no network.
+
+// A provider reporting more input tokens than it could possibly have accepted
+// is a metering bug, not a window discovery. Anything beyond this multiple of
+// the declared window is treated as unusable rather than believed.
+const IMPLAUSIBLE_MULTIPLE = 64;
+
+function positiveInteger(value) {
+  return Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+// Only a turn the provider actually accepted proves capacity. A failed turn
+// proves nothing: the request may have been rejected for exactly this reason.
+// Estimated counts prove nothing either -- the router substitutes those when a
+// provider reports zero, and an estimate cannot disprove a provider's own
+// limit.
+export function acceptedInputTokens(event) {
+  if (event?.status !== 200) return undefined;
+  if (event?.estimatedInputTokens !== undefined) return undefined;
+  return positiveInteger(event?.inputTokens);
+}
+
+// Highest accepted prompt per model slug. Keyed on the routed slug rather than
+// the upstream model name on purpose: the same model reached through two
+// providers is two different ceilings, because resellers and subscription
+// endpoints enforce their own.
+export function observedCeilings(events) {
+  const highest = new Map();
+  for (const event of events ?? []) {
+    const accepted = acceptedInputTokens(event);
+    if (accepted === undefined) continue;
+    const slug = typeof event.model === "string" ? event.model : undefined;
+    if (!slug) continue;
+    if (accepted > (highest.get(slug) ?? 0)) highest.set(slug, accepted);
+  }
+  return highest;
+}
+
+// Models whose own traffic contradicts their declared window, worst first.
+// `models` is any list carrying { slug, contextWindow, autoCompact }; `ceilings`
+// is a slug -> highest-accepted-prompt Map, from observedCeilings() or from
+// usage-events' own streaming scan when the full ledger is too large to parse
+// into an array.
+export function contextWindowDrift(models, ceilings) {
+  const highest = ceilings instanceof Map ? ceilings : observedCeilings(ceilings);
+  const drift = [];
+  for (const model of models ?? []) {
+    const declared = positiveInteger(model?.contextWindow);
+    const observed = highest.get(model?.slug);
+    if (!declared || !observed || observed <= declared) continue;
+    if (observed > declared * IMPLAUSIBLE_MULTIPLE) continue;
+    drift.push({
+      slug: model.slug,
+      declared,
+      observed,
+      autoCompact: positiveInteger(model?.autoCompact),
+      // How much capacity the declaration is hiding. Reported as a ratio
+      // because that is what decides whether this is a rounding disagreement
+      // or a model being run at a quarter of its size.
+      ratio: Number((observed / declared).toFixed(2)),
+    });
+  }
+  return drift.sort((left, right) => right.ratio - left.ratio);
+}
+
+export function describeContextWindowDrift(drift) {
+  if (!drift?.length) return undefined;
+  const worst = drift
+    .slice(0, 3)
+    .map((entry) => `${entry.slug} declares ${entry.declared} but accepted ${entry.observed}`)
+    .join("; ");
+  const rest = drift.length > 3 ? `, and ${drift.length - 3} more` : "";
+  return `${worst}${rest}`;
+}

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -54,6 +54,8 @@ import {
   readVisionBridgeSettings,
   visionBridgeConfigured,
 } from "./vision-bridge-state.mjs";
+import { contextWindowDrift, describeContextWindowDrift } from "./context-window-drift.mjs";
+import { observedInputCeilings } from "./usage-events.mjs";
 import { venvRuntimeProblem } from "./venv-runtime.mjs";
 import {
   dependencyRepairHint,
@@ -459,6 +461,20 @@ add(
     ? `${unroutable.length} offered model(s) have no gateway route: ${unroutable.join(", ")}`
     : `${catalogRoutedModels.length} routed models`,
   "Run ./bin/doctor --fix from the owning checkout, then fully quit and reopen Codex.",
+);
+// Warn, not fail: an understated window still routes, and the operator may be
+// running a plan whose real ceiling is genuinely lower than the vendor's. What
+// they cannot do is notice it on their own -- the symptom is a session that
+// compacts and restarts its own work forever, which reads as a bad model
+// rather than a bad number.
+const windowDrift = contextWindowDrift(catalogRoutedModels, observedInputCeilings());
+add(
+  windowDrift.length ? "warn" : "ok",
+  "Context windows match observed traffic",
+  windowDrift.length
+    ? describeContextWindowDrift(windowDrift)
+    : `${catalogRoutedModels.length} routed models, no provider has exceeded its declared window`,
+  "The provider accepted more than the declared contextWindow, so the entry understates the model. Raise contextWindow (and autoCompact with it) in this model's config entry.",
 );
 // "Off" is a normal state and reports ok. Enabled with no resolvable engine is
 // the broken one: Codex would keep offering the paste while nothing could read

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -10,6 +10,7 @@ import path from "node:path";
 
 import { STATE_DIR } from "./paths.mjs";
 import { canonicalProviderId } from "./provider-selection.mjs";
+import { acceptedInputTokens } from "./context-window-drift.mjs";
 
 export const USAGE_EVENTS_PATH = path.join(STATE_DIR, "usage-events.jsonl");
 
@@ -399,4 +400,33 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
   } catch {
     return [];
   }
+}
+
+// Highest prompt each model has been observed to have accepted, scanned across
+// the whole ledger rather than a recent window: the turn that disproves a
+// declared context window may be months old and must not age out of the
+// evidence. Streamed line by line with a cheap pre-filter, because the ledger
+// only grows and parsing every row to find a maximum is wasteful.
+export function observedInputCeilings() {
+  const highest = new Map();
+  if (!existsSync(USAGE_EVENTS_PATH)) return highest;
+  try {
+    for (const line of usageEventLines()) {
+      if (!line.includes('"inputTokens"')) continue;
+      // A substituted estimate cannot disprove a provider's own limit.
+      if (line.includes('"estimatedInputTokens"')) continue;
+      let event;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const accepted = acceptedInputTokens(event);
+      if (accepted === undefined) continue;
+      if (accepted > (highest.get(event.model) ?? 0)) highest.set(event.model, accepted);
+    }
+  } catch {
+    // Telemetry must never break a status surface; report what was readable.
+  }
+  return highest;
 }

--- a/test/context-window-drift.test.mjs
+++ b/test/context-window-drift.test.mjs
@@ -57,6 +57,31 @@ test("only turns the provider accepted count as evidence", () => {
   assert.deepEqual(drift, []);
 });
 
+// An empty-completion retry bills both attempts, so the meter sums them and a
+// perfectly ordinary turn lands as a 200 carrying twice the prompt it sent.
+// Believing that would invent a ~2x window out of one retry -- and this check
+// tells the operator to raise the window, so the bad sample argues for
+// doubling a number that was right.
+test("a retried turn's doubled prompt count is not evidence of capacity", () => {
+  assert.equal(
+    acceptedInputTokens(event("m", 900_000, { emptyCompletionRetried: true })),
+    undefined,
+  );
+  assert.equal(acceptedInputTokens(event("m", 900_000)), 900_000);
+  const drift = contextWindowDrift(MODELS, [
+    event("qwen-plan/qwen3.8-max", 524_288, { emptyCompletionRetried: true }),
+  ]);
+  assert.deepEqual(drift, []);
+  // A real accepted turn still counts on a slug that also has retried traffic.
+  assert.deepEqual(
+    contextWindowDrift(MODELS, [
+      event("qwen-plan/qwen3.8-max", 524_288, { emptyCompletionRetried: true }),
+      event("qwen-plan/qwen3.8-max", 277_174),
+    ]).map((entry) => entry.observed),
+    [277_174],
+  );
+});
+
 // The router substitutes its own estimate when a provider reports zero input
 // tokens. An estimate cannot disprove that provider's own limit.
 test("estimated input counts never disprove a declared window", () => {

--- a/test/context-window-drift.test.mjs
+++ b/test/context-window-drift.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  acceptedInputTokens,
+  contextWindowDrift,
+  describeContextWindowDrift,
+  observedCeilings,
+} from "../src/context-window-drift.mjs";
+
+const MODELS = [
+  { slug: "qwen-plan/qwen3.8-max", contextWindow: 262_144, autoCompact: 235_000 },
+  { slug: "grok-oauth/grok-4.5", contextWindow: 500_000, autoCompact: 440_000 },
+  { slug: "openai/gpt-5.6-sol", contextWindow: 1_000_000, autoCompact: 900_000 },
+];
+
+function event(model, inputTokens, extra = {}) {
+  return { model, status: 200, inputTokens, ...extra };
+}
+
+test("a provider accepting more than the declared window is reported as drift", () => {
+  const drift = contextWindowDrift(MODELS, [
+    event("qwen-plan/qwen3.8-max", 277_174),
+    event("openai/gpt-5.6-sol", 214_784),
+  ]);
+  assert.equal(drift.length, 1);
+  assert.deepEqual(drift[0], {
+    slug: "qwen-plan/qwen3.8-max",
+    declared: 262_144,
+    observed: 277_174,
+    autoCompact: 235_000,
+    ratio: 1.06,
+  });
+});
+
+test("drift is ordered worst-first so the most understated entry leads", () => {
+  const drift = contextWindowDrift(MODELS, [
+    event("qwen-plan/qwen3.8-max", 277_174),
+    event("grok-oauth/grok-4.5", 2_033_426),
+  ]);
+  assert.deepEqual(drift.map((entry) => entry.slug), [
+    "grok-oauth/grok-4.5",
+    "qwen-plan/qwen3.8-max",
+  ]);
+  assert.equal(drift[0].ratio, 4.07);
+});
+
+// A rejected turn may have been rejected for exceeding the very limit under
+// test, so it is evidence of nothing.
+test("only turns the provider accepted count as evidence", () => {
+  assert.equal(acceptedInputTokens(event("m", 900_000, { status: 400 })), undefined);
+  assert.equal(acceptedInputTokens(event("m", 900_000, { status: 0 })), undefined);
+  assert.equal(acceptedInputTokens(event("m", 900_000)), 900_000);
+  const drift = contextWindowDrift(MODELS, [
+    event("qwen-plan/qwen3.8-max", 999_999, { status: 400 }),
+  ]);
+  assert.deepEqual(drift, []);
+});
+
+// The router substitutes its own estimate when a provider reports zero input
+// tokens. An estimate cannot disprove that provider's own limit.
+test("estimated input counts never disprove a declared window", () => {
+  const drift = contextWindowDrift(MODELS, [
+    event("qwen-plan/qwen3.8-max", 400_000, { estimatedInputTokens: 400_000 }),
+  ]);
+  assert.deepEqual(drift, []);
+});
+
+test("a provider reporting an impossible count is treated as a metering bug", () => {
+  const drift = contextWindowDrift(MODELS, [
+    event("qwen-plan/qwen3.8-max", 262_144 * 100),
+  ]);
+  assert.deepEqual(drift, [], "a 100x overshoot is not a discovery");
+});
+
+// Same upstream model, two providers, two ceilings: a reseller or subscription
+// endpoint enforces its own, so evidence must not cross between slugs.
+test("evidence is keyed per routed slug, not per upstream model", () => {
+  const ceilings = observedCeilings([
+    event("qwen-plan/qwen3.8-max", 277_174),
+    event("grok-oauth/grok-4.5", 120_000),
+  ]);
+  assert.equal(ceilings.get("qwen-plan/qwen3.8-max"), 277_174);
+  assert.equal(ceilings.get("grok-oauth/grok-4.5"), 120_000);
+  assert.equal(ceilings.size, 2);
+});
+
+test("a model whose traffic stays inside its window reports no drift", () => {
+  assert.deepEqual(contextWindowDrift(MODELS, [event("openai/gpt-5.6-sol", 999_999)]), []);
+  assert.equal(describeContextWindowDrift([]), undefined);
+});
+
+test("the summary names the worst offenders and counts the rest", () => {
+  const many = Array.from({ length: 5 }, (_, index) => ({
+    slug: `p/model-${index}`,
+    contextWindow: 1_000,
+    autoCompact: 900,
+  }));
+  const drift = contextWindowDrift(
+    many,
+    many.map((model, index) => event(model.slug, 1_100 + index * 100)),
+  );
+  const summary = describeContextWindowDrift(drift);
+  assert.match(summary, /p\/model-4 declares 1000 but accepted 1500/);
+  assert.match(summary, /and 2 more$/);
+});


### PR DESCRIPTION
## Why

Four wrong context windows were found by hand this week — qwen-plan's nine models (#240), GLM-5.3 twice (#246), and `grok-oauth/grok-4.5`. Each was invisible until a user hit it.

The failure is silent and asymmetric. Codex compacts at the auto-compact limit derived from the window we declare, so an **understated** window makes a legitimate task open *above* its own compaction threshold: it summarizes, the agent loses its working state, redoes its opening work, regrows, and compacts again without ever finishing. Nothing errors. The session just never ends and the model takes the blame. An **overstated** window fails honestly instead — one upstream rejection that names the real limit.

## What this does

The evidence was already on disk. Every successful turn records its input tokens, so a 200 on a prompt larger than the declared window is the provider disproving our entry. This scans the ledger for the highest accepted prompt per routed slug and warns when it exceeds what we declare.

Running it against my own install immediately reproduces the known bug:

```json
{
  "status": "warn",
  "name": "Context windows match observed traffic",
  "detail": "grok-oauth/grok-4.5 declares 500000 but accepted 2033426"
}
```

No probing, no quota, no network — it reads data we already keep.

## Evidence rules

- **Only accepted turns count.** A rejected turn may have been rejected for exceeding the very limit under test.
- **Estimated counts are excluded.** The router substitutes its own estimate when a provider reports zero; an estimate cannot disprove a provider's own limit.
- **Beyond 64× is a metering bug, not a discovery.**
- **Keyed per routed slug, not per upstream model** — the same model behind two providers has two real ceilings, as qwen-plan vs clinepass and zai-coding vs zai-api both showed.

Warn rather than fail: an understated window still routes, and an operator may genuinely be on a plan whose ceiling is lower than the vendor's. What they can't do is notice it themselves.

## Next in this direction

This is the passive half. The active half is learning ceilings from limit-bearing errors (`Range of input length should be [1, N]`) and caching them per provider+model+endpoint — that closes the loop from above, where this closes it from below.

## Test plan
- [x] `npm run check`
- [x] `npm test`: 1,310 pass / 0 fail (8 new)
- [x] `doctor --json` verified against the real registry and ledger — 107 models scanned, 42 with traffic, 1 flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zVk2R4t6CELtWk4MaX5WZ