### PR TITLE
fix(qwen): use the limits the provider itself reports, measured

### DIFF
--- a/config/qwen/plan/qwen3.6-flash.json
+++ b/config/qwen/plan/qwen3.6-flash.json
@@ -17,7 +17,7 @@
           "description": "Adaptive reasoning tuned for speed"
         }
       ],
-      "contextWindow": 1000000,
+      "contextWindow": 983616,
       "autoCompact": 900000,
       "inputModalities": [
         "text",

--- a/config/qwen/plan/qwen3.7-max.json
+++ b/config/qwen/plan/qwen3.7-max.json
@@ -17,7 +17,7 @@
           "description": "Adaptive deep reasoning"
         }
       ],
-      "contextWindow": 1000000,
+      "contextWindow": 983616,
       "autoCompact": 900000,
       "inputModalities": [
         "text",

--- a/config/qwen/plan/qwen3.7-plus.json
+++ b/config/qwen/plan/qwen3.7-plus.json
@@ -17,7 +17,7 @@
           "description": "Adaptive deep reasoning"
         }
       ],
-      "contextWindow": 1000000,
+      "contextWindow": 983616,
       "autoCompact": 900000,
       "inputModalities": [
         "text"

--- a/config/qwen/plan/qwen3.8-max-preview.json
+++ b/config/qwen/plan/qwen3.8-max-preview.json
@@ -17,8 +17,8 @@
           "description": "Adaptive deep reasoning"
         }
       ],
-      "contextWindow": 262144,
-      "autoCompact": 235000,
+      "contextWindow": 983616,
+      "autoCompact": 900000,
       "inputModalities": [
         "text",
         "image"

--- a/config/qwen/plan/qwen3.8-max.json
+++ b/config/qwen/plan/qwen3.8-max.json
@@ -17,7 +17,7 @@
           "description": "Adaptive deep reasoning"
         }
       ],
-      "contextWindow": 1000000,
+      "contextWindow": 983616,
       "autoCompact": 900000,
       "inputModalities": [
         "text",


### PR DESCRIPTION
Follow-up to #240, now that qwen-plan quota was restored and the endpoint could actually be probed.

## Method

DashScope names its own ceiling when you exceed it. Send an oversized prompt, read the number back out of the rejection:

```
Range of input length should be [1, 983616]
```

Nine models, nine measurements, against `token-plan.ap-southeast-1.maas.aliyuncs.com` — the host we actually route through, not the standard Model Studio endpoint the docs describe.

| Model | Measured | #240 declared |
|---|---|---|
| deepseek-v4-pro / -0813 / -flash-0731 | 1,000,000 | 1,000,000 ✅ exact |
| glm-5.2 | 1,048,576 | 1,048,576 ✅ exact |
| qwen3.8-max / 3.7-max / 3.7-plus / 3.6-flash | **983,616** | 1,000,000 |
| qwen3.8-max-preview | **983,616** | 262,144 |

## What this corrects

**The four Qwen entries were 1.7% optimistic.** 983,616 is the *thinking-mode* input ceiling, and thinking is on by default for this family — so 1,000,000 is a number the provider will refuse. Harmless in practice (autoCompact 900,000 compacts well below the wall), but a declared value the upstream rejects is the same imprecision that started this whole thread.

**`qwen3.8-max-preview` is not retired.** #240 left it at 262,144 because its doc page 404s and it looked dead at GA. The probe disproves that: it answered with a proper limit rather than an unknown-model error, and it returned 200 as recently as 2026-08-03. Same 983,616 as the GA entry.

## Worth noting

The documentation research and the empirical probe agreed **exactly** — 983,616 was the documented thinking-mode figure before it was ever measured. The docs were right; we had simply never read them for these entries.

This is also the strongest argument yet for learning limits at runtime: the provider hands you the exact number in the error, per model, per endpoint, for free. Nine correct values took one script and about a minute.

## Test plan
- [x] `npm run check`
- [x] `npm test`: 0 fail
- [x] Every value in the table measured live against the routed host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zVk2R4t6CELtWk4MaX5WZ