### PR TITLE
Relay deferred codex_apps connector tools to routed models

### DIFF
--- a/bin/connector-tools
+++ b/bin/connector-tools
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+exec node "$repo_dir/src/connector-tools.mjs" "$@"

--- a/src/codex-apps-connectors.mjs
+++ b/src/codex-apps-connectors.mjs
@@ -1,0 +1,215 @@
+// Codex connects app connectors (Outlook, GitHub, Notion, ...) through its
+// `codex_apps` MCP server and presents each one to the model as its own
+// namespace: `mcp__codex_apps__github`, holding `fetch_issue`, `list_issues`,
+// and the rest.
+//
+// Those namespaces use deferred loading. On a routed request the client ships
+// only a handful of the tools inline and leaves `type: "tool_search"` as the
+// way to reach the others. `flattenNamespaceTools` drops the search control --
+// it has to, chat-completions providers reject the type outright -- so on a
+// routed model the deferred remainder is simply unreachable. A live capture
+// here sent one GitHub tool out of the 89 the connector actually exposes.
+//
+// `mergeCodexAppTools` already solves the same problem for `codex_app`, the
+// app's own runtime, by merging a captured snapshot back in. Connectors cannot
+// use a snapshot: which ones exist is per-account and changes whenever the
+// operator connects one. They do not need it either, because Codex maintains
+// the full set on disk at `$CODEX_HOME/cache/codex_apps_tools/<hash>.json` and
+// refreshes it as connectors change. This module reads that cache and fills
+// the deferred remainder back into the request.
+//
+// Merging is opt-in per connector because the schemas are big -- 649 KB, about
+// 166k tokens, for all 171 tools on the capture machine. That size is why
+// Codex defers them in the first place, so the operator names the connectors
+// worth the context and the rest stay deferred exactly as they are today.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import { CODEX_HOME } from "./paths.mjs";
+
+export const CONNECTOR_TOOL_CACHE_DIR =
+  process.env.MODEL_ROUTER_CODEX_APPS_CACHE_DIR ||
+  path.join(CODEX_HOME, "cache", "codex_apps_tools");
+
+// The client prefixes every MCP server namespace with `mcp__`, so the cache's
+// `codex_apps__github` is `mcp__codex_apps__github` in a request.
+const CLIENT_NAMESPACE_PREFIX = "mcp__";
+export const CONNECTOR_SERVER = "codex_apps";
+
+// `<connector>.<method>` is the MCP tool name; the namespace child is the
+// method alone. Splitting on the first dot keeps a method containing one from
+// losing its tail.
+function methodName(toolName, connector) {
+  if (typeof toolName !== "string") return undefined;
+  const prefix = `${connector}.`;
+  if (toolName.startsWith(prefix)) return toolName.slice(prefix.length) || undefined;
+  const dot = toolName.indexOf(".");
+  return dot === -1 ? toolName : toolName.slice(dot + 1) || undefined;
+}
+
+// Codex writes one cache file per connector set and leaves older ones behind
+// when the set changes, so the newest file is the live one.
+function newestCacheFile(dir) {
+  let entries;
+  try {
+    entries = readdirSync(dir).filter((name) => name.endsWith(".json"));
+  } catch {
+    return undefined;
+  }
+  let newest;
+  for (const name of entries) {
+    const full = path.join(dir, name);
+    let mtime;
+    try {
+      mtime = statSync(full).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (!newest || mtime > newest.mtime) newest = { path: full, mtime };
+  }
+  return newest?.path;
+}
+
+// Reads the cache into `namespace -> { name, description, tools: Map }`, keyed
+// by the namespace name a request carries. Returns an empty Map when the cache
+// is absent or unreadable: no connectors merged is exactly today's behavior,
+// which is the right thing to fall back to.
+export function readConnectorToolCatalog(dir = CONNECTOR_TOOL_CACHE_DIR) {
+  const catalog = new Map();
+  if (!dir || !existsSync(dir)) return catalog;
+  const file = newestCacheFile(dir);
+  if (!file) return catalog;
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(file, "utf8"));
+  } catch {
+    return catalog;
+  }
+  const entries = Array.isArray(parsed?.tools) ? parsed.tools : [];
+  for (const entry of entries) {
+    if (entry?.server_name && entry.server_name !== CONNECTOR_SERVER) continue;
+    const toolNamespace = entry?.tool_namespace;
+    const tool = entry?.tool;
+    if (typeof toolNamespace !== "string" || !tool?.name) continue;
+    const connector = toolNamespace.slice(toolNamespace.lastIndexOf("__") + 2);
+    const name = methodName(tool.name, connector);
+    if (!connector || !name) continue;
+    const namespace = `${CLIENT_NAMESPACE_PREFIX}${toolNamespace}`;
+    if (!catalog.has(namespace)) {
+      catalog.set(namespace, {
+        name: namespace,
+        connector,
+        connectorName: entry.connector_name || connector,
+        description: entry.namespace_description || "",
+        tools: new Map(),
+      });
+    }
+    const bucket = catalog.get(namespace);
+    if (bucket.tools.has(name)) continue;
+    bucket.tools.set(name, {
+      type: "function",
+      name,
+      ...(tool.description ? { description: tool.description } : {}),
+      ...(tool.inputSchema ? { inputSchema: tool.inputSchema } : {}),
+    });
+  }
+  return catalog;
+}
+
+// The cache is ~1.4 MB where every connector is connected, so it is parsed
+// once and re-read only when Codex rewrites it (a connector added or removed).
+let cached;
+
+export function connectorToolCatalog(dir = CONNECTOR_TOOL_CACHE_DIR) {
+  const file = existsSync(dir) ? newestCacheFile(dir) : undefined;
+  let mtime;
+  if (file) {
+    try {
+      mtime = statSync(file).mtimeMs;
+    } catch {
+      mtime = undefined;
+    }
+  }
+  if (cached && cached.dir === dir && cached.file === file && cached.mtime === mtime) {
+    return cached.catalog;
+  }
+  const catalog = readConnectorToolCatalog(dir);
+  cached = { dir, file, mtime, catalog };
+  return catalog;
+}
+
+export function resetConnectorToolCatalogCache() {
+  cached = undefined;
+}
+
+// Accepts either the namespace name (`mcp__codex_apps__github`) or the bare
+// connector (`github`), because the second is what an operator types.
+function selectedNamespaces(catalog, enabled) {
+  const wanted = new Set();
+  if (!enabled) return wanted;
+  const names = enabled instanceof Set ? [...enabled] : enabled;
+  if (!Array.isArray(names)) return wanted;
+  for (const raw of names) {
+    if (typeof raw !== "string" || !raw) continue;
+    if (catalog.has(raw)) {
+      wanted.add(raw);
+      continue;
+    }
+    for (const [namespace, bucket] of catalog) {
+      if (bucket.connector === raw) wanted.add(namespace);
+    }
+  }
+  return wanted;
+}
+
+// Fill the deferred remainder of each selected connector back into `tools`.
+// Client-provided definitions win, so a tool the client did ship keeps the
+// client's exact schema; the cache only supplies what deferred loading held
+// back. A selected connector the client omitted entirely is appended whole --
+// the client still dispatches those calls natively, the same reasoning
+// `mergeCodexAppTools` relies on.
+export function mergeConnectorTools(tools, { catalog, enabled } = {}) {
+  if (!Array.isArray(tools) || !(catalog instanceof Map) || catalog.size === 0) {
+    return { tools, merged: false };
+  }
+  const wanted = selectedNamespaces(catalog, enabled);
+  if (wanted.size === 0) return { tools, merged: false };
+  const merged = [];
+  const seen = new Set();
+  let changed = false;
+  for (const tool of tools) {
+    if (tool?.type !== "namespace" || !wanted.has(tool.name)) {
+      merged.push(tool);
+      continue;
+    }
+    const bucket = catalog.get(tool.name);
+    const clientTools = [];
+    const present = new Set();
+    for (const fn of Array.isArray(tool.tools) ? tool.tools : []) {
+      if (!fn?.name) continue;
+      clientTools.push(fn);
+      present.add(fn.name);
+    }
+    const missing = [...bucket.tools.values()].filter((fn) => !present.has(fn.name));
+    if (missing.length) {
+      clientTools.push(...missing);
+      changed = true;
+    }
+    merged.push({ ...tool, tools: clientTools });
+    seen.add(tool.name);
+  }
+  for (const namespace of wanted) {
+    if (seen.has(namespace)) continue;
+    const bucket = catalog.get(namespace);
+    if (!bucket || bucket.tools.size === 0) continue;
+    merged.push({
+      type: "namespace",
+      name: namespace,
+      description: bucket.description || `Tools provided by ${bucket.connectorName}.`,
+      tools: [...bucket.tools.values()],
+    });
+    changed = true;
+  }
+  return changed ? { tools: merged, merged: true } : { tools, merged: false };
+}

--- a/src/connector-tools-state.mjs
+++ b/src/connector-tools-state.mjs
@@ -1,0 +1,45 @@
+// Which app connectors the operator wants relayed in full to routed models.
+//
+// Empty by default. Merging a connector costs real context -- Outlook's 46
+// tools serialize to about 66k tokens -- so nothing is merged until someone
+// asks for it by name, and an install that never opts in behaves exactly as it
+// does today.
+
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { writePrivateJson } from "./file-security.mjs";
+import { STATE_DIR } from "./paths.mjs";
+
+export const CONNECTOR_TOOLS_STATE_PATH =
+  process.env.MODEL_ROUTER_CONNECTOR_TOOLS_STATE ||
+  path.join(STATE_DIR, "connector-tools.json");
+
+export function readConnectorSelection(statePath = CONNECTOR_TOOLS_STATE_PATH) {
+  if (!existsSync(statePath)) return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(statePath, "utf8"));
+  } catch {
+    return [];
+  }
+  const connectors = parsed?.connectors;
+  if (!Array.isArray(connectors)) return [];
+  const unique = [];
+  for (const entry of connectors) {
+    if (typeof entry !== "string" || !entry) continue;
+    if (!unique.includes(entry)) unique.push(entry);
+  }
+  return unique;
+}
+
+export function writeConnectorSelection(connectors, statePath = CONNECTOR_TOOLS_STATE_PATH) {
+  const unique = [];
+  for (const entry of Array.isArray(connectors) ? connectors : []) {
+    if (typeof entry !== "string" || !entry) continue;
+    if (!unique.includes(entry)) unique.push(entry);
+  }
+  unique.sort();
+  writePrivateJson(statePath, { version: 1, connectors: unique });
+  return unique;
+}

--- a/src/connector-tools.mjs
+++ b/src/connector-tools.mjs
@@ -1,0 +1,117 @@
+// `connector-tools list|enable <connector>|disable <connector>`
+//
+// Lists the app connectors Codex has cached locally, with the context each one
+// costs, and records which of them the router should relay in full to routed
+// models.
+
+import {
+  CONNECTOR_TOOL_CACHE_DIR,
+  connectorToolCatalog,
+} from "./codex-apps-connectors.mjs";
+import {
+  CONNECTOR_TOOLS_STATE_PATH,
+  readConnectorSelection,
+  writeConnectorSelection,
+} from "./connector-tools-state.mjs";
+
+// Rough, and labelled rough in the output: what the operator needs is the
+// order of magnitude that tells them whether a connector fits their context.
+function approximateTokens(bucket) {
+  let chars = 0;
+  for (const tool of bucket.tools.values()) chars += JSON.stringify(tool).length;
+  return Math.round(chars / 4);
+}
+
+function connectorRows(catalog, selected) {
+  return [...catalog.values()]
+    .map((bucket) => ({
+      connector: bucket.connector,
+      label: bucket.connectorName,
+      tools: bucket.tools.size,
+      tokens: approximateTokens(bucket),
+      enabled: selected.includes(bucket.connector) || selected.includes(bucket.name),
+    }))
+    .sort((a, b) => b.tokens - a.tokens);
+}
+
+function printList(rows) {
+  if (rows.length === 0) {
+    console.log(`No connector tools cached under ${CONNECTOR_TOOL_CACHE_DIR}.`);
+    console.log("Connect an app in Codex, then run this again.");
+    return;
+  }
+  const width = Math.max(...rows.map((row) => row.connector.length));
+  console.log("  relayed  connector".padEnd(width + 13) + "tools   ~tokens");
+  for (const row of rows) {
+    const mark = row.enabled ? "yes" : " no";
+    console.log(
+      `      ${mark}  ${row.connector.padEnd(width)}  ${String(row.tools).padStart(5)}   ${String(
+        row.tokens,
+      ).padStart(7)}  ${row.label}`,
+    );
+  }
+  const on = rows.filter((row) => row.enabled);
+  const total = on.reduce((sum, row) => sum + row.tokens, 0);
+  console.log("");
+  console.log(
+    on.length
+      ? `Relaying ${on.length} connector(s), roughly ${total} tokens of tool schema per request.`
+      : "Relaying none. Routed models see only the subset Codex sends inline.",
+  );
+  console.log(`Selection: ${CONNECTOR_TOOLS_STATE_PATH}`);
+}
+
+function resolve(catalog, name) {
+  for (const bucket of catalog.values()) {
+    if (bucket.connector === name || bucket.name === name) return bucket.connector;
+  }
+  return undefined;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const [command, target] = argv;
+  const catalog = connectorToolCatalog();
+  const selected = readConnectorSelection();
+
+  if (!command || command === "list") {
+    printList(connectorRows(catalog, selected));
+    return 0;
+  }
+
+  if (command !== "enable" && command !== "disable") {
+    console.error("usage: connector-tools [list | enable <connector> | disable <connector>]");
+    return 2;
+  }
+  if (!target) {
+    console.error(`usage: connector-tools ${command} <connector>`);
+    return 2;
+  }
+
+  if (command === "enable") {
+    const connector = resolve(catalog, target);
+    if (!connector) {
+      console.error(`No cached connector named "${target}". Run \`connector-tools list\`.`);
+      return 1;
+    }
+    const next = writeConnectorSelection([...selected, connector]);
+    console.log(`Relaying ${connector}. Restart the router for it to take effect.`);
+    printList(connectorRows(catalog, next));
+    return 0;
+  }
+
+  // Disable resolves against the recorded selection too, so a connector that
+  // has since left the cache can still be turned off.
+  const connector = resolve(catalog, target) || target;
+  if (!selected.includes(connector)) {
+    console.log(`${connector} was not being relayed.`);
+    return 0;
+  }
+  const next = writeConnectorSelection(selected.filter((entry) => entry !== connector));
+  console.log(`Stopped relaying ${connector}. Restart the router for it to take effect.`);
+  printList(connectorRows(catalog, next));
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -66,6 +66,8 @@ import {
   subagentProofSnapshot,
 } from "./subagent-proofs.mjs";
 import { mergeCodexAppTools } from "./codex-app-tools.mjs";
+import { connectorToolCatalog, mergeConnectorTools } from "./codex-apps-connectors.mjs";
+import { readConnectorSelection } from "./connector-tools-state.mjs";
 import { activityMetadataFromHeaders } from "./codex-session-names.mjs";
 import { translateGatewayError } from "./error-translation.mjs";
 import { recordUsageEvent } from "./usage-events.mjs";
@@ -1898,6 +1900,15 @@ async function handleResponses(request, response, requestUrl) {
         // and navigation state -- it only relays definitions and results.
         const merged = mergeCodexAppTools(payload.tools);
         if (merged.merged) payload.tools = merged.tools;
+        // App connectors (Outlook, GitHub, Notion, ...) are deferred the same
+        // way, but through `tool_search`, which flattening drops. Fill the
+        // remainder back in for the connectors the operator opted into; with
+        // no selection this is a no-op and the request is untouched.
+        const connectors = mergeConnectorTools(payload.tools, {
+          catalog: connectorToolCatalog(),
+          enabled: readConnectorSelection(),
+        });
+        if (connectors.merged) payload.tools = connectors.tools;
         const flattened = flattenNamespaceTools(payload.tools);
         namespacesFlattened = flattened.flattened;
         if (namespacesFlattened) {

--- a/test/codex-apps-connectors.test.mjs
+++ b/test/codex-apps-connectors.test.mjs
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  mergeConnectorTools,
+  readConnectorToolCatalog,
+} from "../src/codex-apps-connectors.mjs";
+import { flattenNamespaceTools } from "../src/namespace-relay.mjs";
+
+// One entry in the shape Codex writes to
+// `$CODEX_HOME/cache/codex_apps_tools/<hash>.json`.
+function cacheEntry(connector, method, extra = {}) {
+  return {
+    server_name: "codex_apps",
+    tool_namespace: `codex_apps__${connector}`,
+    namespace_description: `Search and reference your ${connector}.`,
+    connector_name: connector,
+    tool: {
+      name: `${connector}.${method}`,
+      description: `${method} on ${connector}`,
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+      },
+    },
+    ...extra,
+  };
+}
+
+function cacheDir(tools) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "codex-apps-cache-"));
+  writeFileSync(
+    path.join(dir, "17b5aa79.json"),
+    JSON.stringify({ schema_version: 4, tools }),
+    "utf8",
+  );
+  return dir;
+}
+
+// The subset Codex actually sends on a routed request: one tool of the
+// connector's many, plus the search control that would have loaded the rest.
+function clientRoutedTools() {
+  return [
+    { type: "tool_search" },
+    { type: "function", name: "exec_command" },
+    {
+      type: "namespace",
+      name: "mcp__codex_apps__github",
+      tools: [{ type: "function", name: "fetch_issue" }],
+    },
+  ];
+}
+
+test("readConnectorToolCatalog keys namespaces the way a request names them", () => {
+  const dir = cacheDir([
+    cacheEntry("github", "fetch_issue"),
+    cacheEntry("microsoft_outlook_email", "list_messages"),
+  ]);
+  try {
+    const catalog = readConnectorToolCatalog(dir);
+    assert.deepEqual(
+      [...catalog.keys()].sort(),
+      ["mcp__codex_apps__github", "mcp__codex_apps__microsoft_outlook_email"],
+    );
+    // `<connector>.<method>` is the MCP tool name; the namespace child is the
+    // method alone, which is what Codex dispatches.
+    const outlook = catalog.get("mcp__codex_apps__microsoft_outlook_email");
+    assert.deepEqual([...outlook.tools.keys()], ["list_messages"]);
+    assert.equal(outlook.tools.get("list_messages").inputSchema.type, "object");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("readConnectorToolCatalog survives a missing or unreadable cache", () => {
+  assert.equal(readConnectorToolCatalog("/nonexistent/codex_apps_tools").size, 0);
+  const dir = mkdtempSync(path.join(os.tmpdir(), "codex-apps-cache-"));
+  try {
+    writeFileSync(path.join(dir, "broken.json"), "{not json", "utf8");
+    assert.equal(readConnectorToolCatalog(dir).size, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an unselected connector leaves the request untouched", () => {
+  const dir = cacheDir([cacheEntry("github", "fetch_issue"), cacheEntry("github", "list_issues")]);
+  try {
+    const tools = clientRoutedTools();
+    const result = mergeConnectorTools(tools, {
+      catalog: readConnectorToolCatalog(dir),
+      enabled: [],
+    });
+    assert.equal(result.merged, false);
+    assert.equal(result.tools, tools);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a selected connector regains the tools deferred loading held back", () => {
+  const dir = cacheDir([
+    cacheEntry("github", "fetch_issue"),
+    cacheEntry("github", "list_issues"),
+    cacheEntry("github", "create_pull_request"),
+    cacheEntry("notion", "search"),
+  ]);
+  try {
+    const result = mergeConnectorTools(clientRoutedTools(), {
+      catalog: readConnectorToolCatalog(dir),
+      enabled: ["github"],
+    });
+    assert.equal(result.merged, true);
+    const github = result.tools.find((tool) => tool.name === "mcp__codex_apps__github");
+    assert.deepEqual(
+      github.tools.map((fn) => fn.name).sort(),
+      ["create_pull_request", "fetch_issue", "list_issues"],
+    );
+    // An unselected connector is not merged in, and nothing else moves.
+    assert.equal(
+      result.tools.some((tool) => tool.name === "mcp__codex_apps__notion"),
+      false,
+    );
+    assert.equal(result.tools.some((tool) => tool.name === "exec_command"), true);
+    assert.equal(result.tools.some((tool) => tool?.type === "tool_search"), true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the client's own definition wins over the cached one", () => {
+  const dir = cacheDir([cacheEntry("github", "fetch_issue")]);
+  try {
+    const clientSchema = { type: "object", properties: { issue: { type: "integer" } } };
+    const tools = [
+      {
+        type: "namespace",
+        name: "mcp__codex_apps__github",
+        tools: [{ type: "function", name: "fetch_issue", inputSchema: clientSchema }],
+      },
+    ];
+    const result = mergeConnectorTools(tools, {
+      catalog: readConnectorToolCatalog(dir),
+      enabled: ["github"],
+    });
+    // Nothing was missing, so the request is returned unchanged rather than
+    // rebuilt around the cache's copy.
+    assert.equal(result.merged, false);
+    assert.equal(result.tools, tools);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a selected connector the client omitted entirely is appended whole", () => {
+  const dir = cacheDir([cacheEntry("notion", "search"), cacheEntry("notion", "fetch_page")]);
+  try {
+    const result = mergeConnectorTools(clientRoutedTools(), {
+      catalog: readConnectorToolCatalog(dir),
+      enabled: ["mcp__codex_apps__notion"],
+    });
+    assert.equal(result.merged, true);
+    const notion = result.tools.find((tool) => tool.name === "mcp__codex_apps__notion");
+    assert.deepEqual(notion.tools.map((fn) => fn.name).sort(), ["fetch_page", "search"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("merged connector tools flatten and restore through the existing relay", () => {
+  const dir = cacheDir([cacheEntry("microsoft_outlook_email", "list_messages")]);
+  try {
+    const merged = mergeConnectorTools(clientRoutedTools(), {
+      catalog: readConnectorToolCatalog(dir),
+      enabled: ["microsoft_outlook_email"],
+    });
+    const { tools, namespaces } = flattenNamespaceTools(merged.tools);
+    const flat = tools.find(
+      (tool) => tool.name === "mcp__codex_apps__microsoft_outlook_email__list_messages",
+    );
+    // Flattening carries the schema across as `parameters`, which is what the
+    // chat-completions bridge reads.
+    assert.ok(flat, "the merged tool is flattened for the provider");
+    assert.equal(flat.parameters.type, "object");
+    // And the namespace inventory records it, so the response transform maps
+    // the call back to what Codex dispatches.
+    assert.deepEqual(
+      [...namespaces.get("mcp__codex_apps__microsoft_outlook_email")],
+      ["list_messages"],
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #252.

## The gap

Codex presents each connected app connector as its own namespace — `mcp__codex_apps__github`, `mcp__codex_apps__microsoft_outlook_email` — and loads them lazily. On a routed request the client ships a handful of the tools inline and leaves `type: "tool_search"` as the way to reach the rest. `flattenNamespaceTools` drops that control, correctly: chat-completions providers reject the type outright. But the comment above the drop —

```js
// By this boundary every namespace is expanded below,
// so the search control is redundant;
```

— only holds for namespaces whose tools the client actually shipped. Connector namespaces arrive deliberately incomplete. The fixture in `test/namespace-relay-routing.test.mjs` captures it exactly: one `fetch_issue` under `mcp__codex_apps__github`, where the connector really exposes 89 tools. The remainder is unreachable on every routed model.

What that looks like in practice: a Grok 4.6 session spent about thirty turns trying to read Outlook mail, reporting each time that the connector was present but its tools were not mounted, then gave up and shelled out to a local IMAP binary. The same account calls those tools without trouble on the native route.

## The fix

`mergeCodexAppTools` already solves this for `codex_app`, the app's own runtime, by merging a captured snapshot back in. Connectors can't use a snapshot — which ones exist is per-account and changes whenever someone connects one — and don't need to: Codex maintains the full set at `$CODEX_HOME/cache/codex_apps_tools/<hash>.json` and refreshes it as connectors change. This reads that cache and fills the deferred remainder back into the request.

Nothing changes on the response path. The merged tools flatten to `mcp__codex_apps__<connector>__<method>` and restore through the existing relay to `{ namespace, name }`, which is the shape Codex dispatches:

```
restored -> {"type":"function_call","name":"list_messages",
             "namespace":"mcp__codex_apps__microsoft_outlook_email", ...}
```

## Opt-in, because schemas are big

Merging every connector would send ~166 KB of schema (the whole cache is 649 KB including output schemas and metadata this strips). That size is why Codex defers them at all, so the operator names the ones worth the context:

```
$ codex-router connector-tools list
  relayed  connector                tools   ~tokens
       no  github                      89     20892  GitHub
       no  microsoft_outlook_email     46     18916  Microsoft Outlook Email
       no  notion                      18     17664  Notion
       ...
$ codex-router connector-tools enable microsoft_outlook_email
```

With no selection recorded, `mergeConnectorTools` returns the original array by identity and the request is untouched — an install that never opts in behaves exactly as it does today. A missing or corrupt cache falls back the same way.

The client's own definition always wins; the cache only supplies what deferred loading held back. A selected connector the client omitted entirely is appended whole, on the same reasoning `mergeCodexAppTools` relies on — the client dispatches those calls natively whether or not the definition was in the request.

## Notes for review

- Applied in the non-responses branch next to `mergeCodexAppTools`, since that is where the observed failure is (Grok and DeepSeek both route as chat completions). Responses-native providers keep `tool_search` today, so they are left alone.
- The cache is parsed once and re-read only when its mtime changes, so the 1.4 MB file is not touched per request.
- `MODEL_ROUTER_CODEX_APPS_CACHE_DIR` and `MODEL_ROUTER_CONNECTOR_TOOLS_STATE` override the paths for tests.

## Tests

`test/codex-apps-connectors.test.mjs` covers cache parsing and the namespace/method naming, a missing and a corrupt cache, the untouched-by-default path, the merge, client-definition precedence, an entirely omitted connector, and the round trip through `flattenNamespaceTools` + `rewriteNamespaceFunctionCall`.
