### PR TITLE
feat(custom): a provider whose models each name their own endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,11 +60,14 @@ user.
    interactive terminal to choose models. If they did not specify and
    credentials already exist, use
    `configured` rather than showing providers that cannot authenticate.
-   The anonymous catalog-only providers `opencode-free` and `kilo-free` are
-   also selectable, but they need no credential only for their documented free
-   model subsets. They ship no preselected models and must be explicitly
-   selected before `bin/curate-models PROVIDER` is run; never select either one
-   on the user's behalf just because it can authenticate without a key.
+   The anonymous providers `opencode-free` and `kilo-free` are also selectable,
+   but they need no credential only for their documented free model subsets.
+   Both are catalog-only: they ship no preselected models and need
+   `bin/curate-models PROVIDER` after selection. `custom` is selectable on the
+   same terms and is a container whose models each name their own endpoint, so
+   enabling it asks for nothing and curating it is unnecessary. All three must
+   be selected explicitly; never select one on the user's behalf just because
+   it can authenticate without a key.
    `kimi-api` and `kimi-api-cn` are two different Moonshot platforms, not a
    fallback pair: the global console at platform.moonshot.ai and the mainland
    one at platform.moonshot.cn have separate accounts, separate billing, and
@@ -778,12 +781,64 @@ override, and the registry loader keeps its endpoint allowlisted.
 
 Anonymous providers are **configured but never defaulted**: the credential
 resolver may report them as ready, and an explicit `--providers` choice may
-route a curated free model, but `defaultProviderIds()`, the no-argument setup
-path, `--providers configured`, and `ensure-configured` must not add them when
-the operator did not ask. They are catalog-only, so discovery filters the
-provider's live `/models` response to its documented free IDs and the user
-must curate models locally. Never check in a paid model ID or silently turn on
-an anonymous endpoint during installation.
+route a free model, but `defaultProviderIds()`, the no-argument setup path,
+`--providers configured`, and `ensure-configured` must not add them when the
+operator did not ask. Never check in a paid model ID or silently turn on an
+anonymous endpoint during installation.
+
+Which free IDs a reseller gateway serves is decided by `anonymousModelAllowed`
+in `src/model-registry.mjs`, never by the registry fragment alone, and the
+`ANONYMOUS_ENDPOINTS` table beside it is the reason a fragment edit cannot
+point a credential-free provider at a model somebody would be billed for.
+`opencode-free` and `kilo-free` each expose a large free subset picked out by a
+naming rule that changes without notice, so both stay catalog-only: discovery
+filters the provider's live `/models` response and the user curates locally.
+
+## A provider whose models each name their own endpoint
+
+`custom` is a **container, not a destination**. It declares no `baseUrl`, no
+`credential`, and no `protocol`; each of its models carries all three in an
+`endpoint` block, and `endpointForModel()` is what every consumer asks instead
+of reading `provider.baseUrl`. The loader refuses a container that declares any
+of them, because two answers to "where does this go" have a silent winner.
+
+1. **The endpoint descriptor is provider-shaped on purpose.** `baseUrl`,
+   `authMode`, `keyless`, and `credential` mean exactly what they mean on a
+   provider, so `resolveProviderBaseUrl` and the whole credential chain accept
+   one unchanged. Do not grow a parallel resolver: the moment the two
+   implementations differ, one of them is the one nobody audited.
+2. **Identity is derived, never declared.** `id` is the model slug and `kind`
+   is fixed, both injected at load; a fragment that set either could point one
+   model's credential file and Keychain entry at another model's secret. The
+   loader refuses a fragment that spells them.
+3. **Exactly one auth story per endpoint** — anonymous, keyless, or a
+   credential. Two would leave a silent winner; none would send an
+   unauthenticated request to an address nobody vetted.
+4. **The allowlist follows the address down.** An `authMode: "anonymous"`
+   endpoint reaches a third party with no credential, so its address must
+   appear in `ANONYMOUS_MODEL_ENDPOINTS`, keyed by slug. Without that, adding a
+   JSON file under `config/custom/` would be enough to send an operator's
+   prompts to any HTTPS host on earth with nothing to authenticate them — which
+   is the exact hazard the provider-level allowlist exists to prevent, one level
+   down. A `keyless` endpoint stays loopback-only for the same reason, and
+   neither may declare a `baseUrlEnv`, because an environment override walks
+   around whichever of the two rules applied. An endpoint that carries a
+   credential needs no allowlist entry: the key is already the boundary.
+5. **Never defaulted.** `defaultProviderIds()` excludes `per-model` alongside
+   `anonymous`. What the container holds is whatever somebody put in it, and at
+   least one of those addresses is reached with no credential, so "enabling this
+   sends prompts off-box" stays a choice a person made.
+6. **Nothing offers a key at the container level.** `apiProvider()` refuses it,
+   the onboarding card is informational, and `resolveProviderCredential()`
+   returns a persistent marker so selection, health, and the catalog still work.
+   A key stored against `custom` would be read by nothing.
+7. **Discovery refuses it.** Discovery asks one endpoint what it serves, and a
+   container is not an endpoint. Picking one of its models' addresses and
+   reporting that as the provider's catalog would be worse than the refusal.
+8. **Check in metadata you measured.** A `custom` model ships with a verified
+   context window, modality set, and effort ladder rather than the conservative
+   defaults `curate-models` would guess. An anonymous endpoint answers without a
+   credential, so there is no excuse for inferring any of it.
 
 ## Local models as a provider
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,62 @@
   exists. A `config.toml` still naming the removed slug has nothing to route to
   and fails at the native target; reselect the plain GLM-5.3 entry.
 
+- **A `custom` provider whose models each name their own endpoint.** Every other
+  provider owns one address, which is why "route this one model from that one
+  host" has always meant inventing a whole provider for it. `custom` owns none:
+  each of its models carries its own `baseUrl`, its own auth, and its own
+  metadata, so one picker entry can hold a free community endpoint, a
+  self-hosted server, and a paid API with a key, at once. Enabling it asks for
+  nothing and it is never in the default set, because what it holds is whatever
+  somebody put in it.
+
+  Its first model is the free community Hugging Face Inference Endpoint for
+  `Qwen/Qwen3.8-27B`: no API key, 262K context, image input, tool calling, and a
+  thinking budget the effort picker dials. Every capability was measured against
+  the live endpoint rather than read off its model card — including the one
+  divergence, that its vLLM build validates `reasoning_effort` against a literal
+  set omitting the Codex ladder's `ultra`, so the request profile folds exactly
+  that rung onto `max` and leaves every other tier alone. It is shared, rate
+  limited per IP, and its owner says it will be retired once launch interest
+  fades: a model to try, not one to depend on.
+
+  The security rule follows the address down rather than staying at the provider.
+  A `custom` endpoint reached with no credential must have that address
+  allowlisted in code, exactly as an anonymous provider's is — otherwise adding a
+  JSON file under `config/custom/` would be enough to send prompts to any host on
+  the internet with nothing to authenticate them. A keyless endpoint stays
+  loopback-only, neither may declare an environment override that would walk
+  around those two rules, and an endpoint's identity is derived from its model so
+  one model's credential file can never be pointed at another model's secret.
+
+- **The GLM-5.3 1M entry routed to a model code Z.ai does not serve.** Shipping
+  `glm-5.3[1m]` took the vendor's documented 1M suffix at its word, and the
+  suffix answers `1214` on both the OpenAI-compatible and Anthropic endpoints --
+  every request through that entry failed, while plain `glm-5.3` on the same
+  endpoint and credential succeeded. The entry is gone rather than repaired,
+  because there is nothing behind it to repair. The window it was invented to
+  reach turned out to be served on the plain entry all along: a 990,020-token
+  prompt was accepted, so `zai-coding/glm-5.3` declares 1M and its picker
+  description says so instead of directing readers to an entry that no longer
+  exists. A `config.toml` still naming the removed slug has nothing to route to
+  and fails at the native target; reselect the plain GLM-5.3 entry.
+
+- **A free Qwen3.8-27B provider that needs no account.** `qwen38-free` routes
+  the community Hugging Face Inference Endpoint for `Qwen/Qwen3.8-27B`: no API
+  key, 262K context, image input, tool calling, and a thinking budget the
+  effort picker dials. It joins `opencode-free` and `kilo-free` as an anonymous
+  provider, so it is never selected on anyone's behalf and never defaulted --
+  `./bin/model-router codex providers enable qwen38-free` is the whole setup.
+  Unlike those two it is not catalog-only: a single-model endpoint has no
+  naming rule to filter by, so its one documented free ID lives in code beside
+  the endpoint allowlist and the model ships with metadata verified against the
+  live endpoint rather than guessed by `curate-models`. The endpoint validates
+  `reasoning_effort` against a literal set that omits the Codex ladder's
+  `ultra`, so its request profile folds exactly that rung onto `max` and leaves
+  every other tier -- and forced tool choices, which it answers correctly --
+  alone. It is shared, rate limited per IP, and its owner says it will be
+  retired once launch interest fades: a model to try, not one to depend on.
+
 - **The panel's local-model view surfaces LM Studio.** LM Studio arrived as a
   provider with exactly one door: `./bin/curate-models lmstudio` in an
   interactive terminal, while the panel's Local LLMs section read only

--- a/README.md
+++ b/README.md
@@ -371,17 +371,18 @@ endpoints.
 
 ### Anonymous free model gateways
 
-Two additional catalog-only entries use providers' documented free-model
-exceptions. They do not ask for an API key, and they deliberately ship no
-checked-in model metadata: the provider's live `/models` response is filtered
-to the free subset and then added locally with `./bin/curate-models`.
+Two additional entries use providers' documented free-model exceptions. Neither
+asks for an API key, neither is ever selected on your behalf, and each is pinned
+in code to its official endpoint.
 
 | Picker label | Provider ID | Endpoint | Free-model rule |
 | --- | --- | --- | --- |
 | OpenCode Free | `opencode-free` | `https://opencode.ai/zen/v1` | `big-pickle` and IDs ending in `-free` |
 | Kilo Free | `kilo-free` | `https://api.kilo.ai/api/gateway` | IDs ending in `:free` |
 
-Enable one and discover its current catalog:
+Both are catalog-only and deliberately ship no checked-in model metadata: the
+provider's live `/models` response is filtered to the free subset and then added
+locally with `./bin/curate-models`.
 
 ```sh
 ./bin/model-router codex providers enable opencode-free
@@ -400,11 +401,49 @@ has been observed. Kilo's general SDK setup guide still asks external SDK
 users for an API key; this entry intentionally covers only the gateway's
 documented anonymous `:free` path.
 
-> **Use these at your own risk.** They are the only providers here that reach an
+### Custom: one provider, many endpoints
+
+Every other provider owns one address. `custom` owns none — each of its models
+names its own endpoint, its own auth, and its own metadata, so a single picker
+entry can hold a free community endpoint, a friend's self-hosted server, and a
+paid API you have a key for, all at once.
+
+```sh
+./bin/model-router codex providers enable custom
+```
+
+Enabling it costs nothing and asks for nothing: a model that needs a key says so
+on its own row. It is never selected for you and never part of the default set,
+because what it holds is whatever somebody put in it.
+
+| Model | Endpoint | Auth |
+| --- | --- | --- |
+| Qwen3.8 27B (Free) | `https://g9hnto0u7lvbu837.us-east-2.aws.endpoints.huggingface.cloud/v1` | none |
+
+That first model is a free community [Hugging Face Inference
+Endpoint](https://huggingface.co/spaces/victor/Qwen3.8-27B-free-endpoint) for
+`Qwen/Qwen3.8-27B`, published by an individual rather than by Qwen or Hugging
+Face: BF16 on one H200 behind vLLM, 262,144-token context, image input, tool
+calling, and a thinking budget you dial with the normal effort picker. It is
+shared and rate limited to roughly 30 requests per minute per IP, and its owner
+says it will be retired once launch interest fades — so treat it as a model to
+try, not one to depend on.
+
+An endpoint reached with **no credential** is the one thing a registry fragment
+cannot introduce on its own. Its address has to be allowlisted in
+`src/model-registry.mjs`, exactly as an anonymous provider's is, because
+otherwise adding a JSON file under `config/custom/` would be enough to send your
+prompts to any host on the internet with nothing to authenticate them. An
+endpoint that carries a key, or one that stays on loopback, needs no allowlist
+entry — the key or the address is already the boundary.
+
+> **Use these at your own risk.** The two gateways above, and any `custom` model
+> whose endpoint carries no credential, are the only routes here that reach an
 > upstream with no account behind them, and that changes what "supported" can
 > mean. Nobody has agreed to serve you: access is a published exception, not an
 > entitlement, and it can be narrowed, rate-limited, or withdrawn without
-> notice. The naming rule is a heuristic rather than a promise — the catalogs
+> notice. On the two reseller gateways the naming rule is a heuristic rather
+> than a promise — their catalogs
 > carry no pricing field to check, so a model whose ID says `free` can still
 > answer `401 Paid inference requests require an Authorization bearer token`,
 > and the router cannot tell in advance. Anonymous traffic is identified by IP,

--- a/apps/macos/ModelRouterTray/Resources/PROVIDER-ICON-SOURCES.md
+++ b/apps/macos/ModelRouterTray/Resources/PROVIDER-ICON-SOURCES.md
@@ -26,6 +26,8 @@ blue accent and DeepSeek's original blue mark are preserved.
 
 The Z.AI, Qwen, Ollama, Cline, MiniMax, and Meta AI marks were fetched on
 2026-08-15. The opencode-go routes reuse the OpenCode Free mark rather than
-shipping a duplicate asset.
+shipping a duplicate asset. `custom` deliberately ships no mark at all: it is a
+container for whatever endpoints an operator puts in it, and its models come
+from different vendors, so any single logo would misattribute the rest.
 
 The marks remain trademarks of their respective owners.

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -1020,6 +1020,10 @@ struct ProviderIcon: View {
     if providerID == "chutes" { return "Chutes" }
     if providerID == "opencode-free" { return "OpenCode Free" }
     if providerID == "kilo-free" { return "Kilo Free" }
+    // Deliberately not a vendor name: this provider is a container for
+    // whatever endpoints the operator put in it, and its models come from
+    // different places.
+    if providerID == "custom" { return "Custom" }
     return routerLocalized("Model provider")
   }
 }

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -639,6 +639,7 @@ final class RouterStore: ObservableObject {
   private static let providerShortNames: [String: String] = [
     "opencode-free": "OpenCode Free",
     "kilo-free": "Kilo Free",
+    "custom": "Custom",
     "grok-oauth": "Grok",
     "kimi-oauth": "Kimi",
     "deepseek": "DeepSeek",

--- a/config/custom/custom.json
+++ b/config/custom/custom.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "custom",
+      "displayName": "Custom",
+      "kind": "openai-compatible",
+      "ownedBy": "custom",
+      "authMode": "per-model",
+      "perModelEndpoint": true,
+      "planNote": "Each model here names its own endpoint. Enabling the provider costs nothing; a model that needs a key says so on its own row."
+    }
+  ]
+}

--- a/config/custom/qwen3.8-27b.json
+++ b/config/custom/qwen3.8-27b.json
@@ -1,0 +1,55 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "custom/qwen3.8-27b",
+      "gatewayModel": "custom-qwen3-8-27b",
+      "upstreamModel": "Qwen/Qwen3.8-27B",
+      "provider": "custom",
+      "endpoint": {
+        "baseUrl": "https://g9hnto0u7lvbu837.us-east-2.aws.endpoints.huggingface.cloud/v1",
+        "authMode": "anonymous",
+        "note": "No API key is needed: this is a free community Hugging Face Inference Endpoint for Qwen3.8-27B, published by an individual rather than by Qwen or Hugging Face. Use at your own risk: it is shared, rate limited to roughly 30 requests per minute per IP, and its owner says it will be retired once launch interest fades."
+      },
+      "listed": true,
+      "displayName": "Qwen3.8 27B (Free)",
+      "description": "Qwen3.8-27B on a free, rate-limited community Hugging Face Inference Endpoint: 262K context, image input, tool calling, and a dialable thinking budget. Shared with everyone behind your IP, so expect 429s under load.",
+      "priority": 140,
+      "defaultEffort": "medium",
+      "reasoningLevels": [
+        {
+          "effort": "minimal",
+          "description": "Least thinking"
+        },
+        {
+          "effort": "low",
+          "description": "Brief reasoning"
+        },
+        {
+          "effort": "medium",
+          "description": "Balanced reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "xhigh",
+          "description": "Extended reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning depth"
+        }
+      ],
+      "contextWindow": 262144,
+      "autoCompact": 230000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "requestProfile": "qwen38-community",
+      "compHash": "custom-qwen3-8-27b-v1"
+    }
+  ]
+}

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -16,6 +16,7 @@ import {
   MODEL_BY_GATEWAY_ID,
   PROVIDERS,
   providerForModel,
+  endpointForModel,
   resolveProviderBaseUrl,
 } from "./model-registry.mjs";
 import { parseRateLimitHeaders } from "./rate-limit-headers.mjs";
@@ -516,6 +517,15 @@ function normalizeBody(buffer, contentType, route) {
     delete payload.reasoning_effort;
     payload.thinking = { type: "adaptive" };
     payload.output_config = { effort };
+  } else if (model.requestProfile === "qwen38-community") {
+    // The community endpoint's vLLM build validates reasoning_effort against a
+    // literal set -- none, minimal, low, medium, high, xhigh, max -- and
+    // answers anything else with a 400 naming the whole enum (measured against
+    // the live endpoint, not read off the model card). The Codex ladder is
+    // that set plus `ultra`, so `ultra` is the one value that has to be folded,
+    // and it folds onto `max` because that is the tier it is asking for.
+    // Everything else passes through as the literal the endpoint accepts.
+    if (payload.reasoning_effort === "ultra") payload.reasoning_effort = "max";
   } else if (model.requestProfile === "minimax-m3") {
     // MiniMax uses its own thinking control on the OpenAI-compatible
     // Chat Completions endpoint instead of reasoning_effort.
@@ -544,10 +554,14 @@ function normalizeBody(buffer, contentType, route) {
       payload.tool_choice = "auto";
     }
   }
-  return { body: Buffer.from(JSON.stringify(payload), "utf8"), model, provider, payload };
+  // The provider still answers protocol, auth profile, and identity; the
+  // endpoint answers where the request goes and what authenticates it. For
+  // every provider but a per-model-endpoint one they are the same object.
+  const endpoint = endpointForModel(model);
+  return { body: Buffer.from(JSON.stringify(payload), "utf8"), model, provider, endpoint, payload };
 }
 
-function upstreamHeaders(requestHeaders, body, apiKey, provider, extraHeaders = {}) {
+function upstreamHeaders(requestHeaders, body, apiKey, provider, extraHeaders = {}, endpoint = provider) {
   const headers = {};
   const providerIdentityHeaders = new Set([
     "copilot-integration-id",
@@ -571,9 +585,10 @@ function upstreamHeaders(requestHeaders, body, apiKey, provider, extraHeaders = 
     }
     if (value !== undefined) headers[name] = Array.isArray(value) ? value.join(", ") : value;
   }
-  if (provider.authMode === "anonymous") {
-    // The upstream explicitly permits anonymous access for the provider's
-    // free-model subset. Never forward the gateway's internal bearer token.
+  if (endpoint.authMode === "anonymous") {
+    // The upstream explicitly permits anonymous access -- for a reseller's
+    // free-model subset, or for a single allowlisted community endpoint.
+    // Never forward the gateway's internal bearer token to either.
   } else if (provider.protocol === "anthropic") {
     headers["x-api-key"] = apiKey;
     headers["anthropic-version"] ||= "2023-06-01";
@@ -589,9 +604,9 @@ function upstreamHeaders(requestHeaders, body, apiKey, provider, extraHeaders = 
   return headers;
 }
 
-async function upstreamSession(provider, credential, payload, options = {}) {
+async function upstreamSession(provider, credential, payload, options = {}, endpoint = provider) {
   if (provider.authProfile !== "github-copilot") {
-    return { apiKey: credential.value, baseUrl: providerBaseUrl(provider), headers: {} };
+    return { apiKey: credential.value, baseUrl: providerBaseUrl(endpoint), headers: {} };
   }
   const session = await ensureFreshGitHubCopilotSession(credential.value, options);
   return {
@@ -659,18 +674,27 @@ async function handleRequest(request, response) {
 
   const original = await readRequestBody(request);
   const normalized = normalizeBody(original, request.headers["content-type"], route);
-  const credential = resolveProviderCredential(normalized.provider);
+  // Resolved against the endpoint, not the provider: a per-model endpoint keeps
+  // its credential under its own slug, so two custom models on two hosts never
+  // share a key and one missing key never blocks the other model.
+  const credential = resolveProviderCredential(normalized.endpoint);
   if (!credential) {
-    const setup = credentialStatus(normalized.provider).setup;
-    const credentialType = credentialLabel(normalized.provider);
+    const setup = credentialStatus(normalized.endpoint).setup;
+    const credentialType = credentialLabel(normalized.endpoint);
     const label = credentialType === "API key" ? "key" : credentialType.toLowerCase();
+    // Name whichever of the two the operator would go and configure. For a
+    // per-model endpoint the provider is a container, so "Custom key is not
+    // configured" would not say which model to fix.
+    const subject = normalized.provider.perModelEndpoint
+      ? normalized.model.displayName || normalized.model.slug
+      : normalized.provider.displayName;
     writeJson(response, 503, {
       error: {
         type: credentialType === "API key"
           ? "provider_api_key_missing"
           : "provider_credential_missing",
         provider: normalized.provider.id,
-        message: `${normalized.provider.displayName} ${label} is not configured. ${setup}.`,
+        message: `${subject} ${label} is not configured. ${setup}.`,
       },
     });
     return;
@@ -687,7 +711,13 @@ async function handleRequest(request, response) {
   const upstreamBody = normalized.provider.authProfile === "github-copilot"
     ? normalized.body.toString("utf8")
     : normalized.body;
-  let session = await upstreamSession(normalized.provider, credential, normalized.payload);
+  let session = await upstreamSession(
+    normalized.provider,
+    credential,
+    normalized.payload,
+    {},
+    normalized.endpoint,
+  );
   let target = `${session.baseUrl}${route}${requestUrl.search}`;
   let upstream = await fetch(target, {
     method: request.method,
@@ -697,6 +727,7 @@ async function handleRequest(request, response) {
       session.apiKey,
       normalized.provider,
       session.headers,
+      normalized.endpoint,
     ),
     body: upstreamBody,
     signal: controller.signal,
@@ -710,6 +741,7 @@ async function handleRequest(request, response) {
       credential,
       normalized.payload,
       { force: true },
+      normalized.endpoint,
     );
     target = `${session.baseUrl}${route}${requestUrl.search}`;
     upstream = await fetch(target, {
@@ -720,6 +752,7 @@ async function handleRequest(request, response) {
         session.apiKey,
         normalized.provider,
         session.headers,
+        normalized.endpoint,
       ),
       body: upstreamBody,
       signal: controller.signal,

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -715,6 +715,8 @@ for (const provider of PROVIDERS.values()) {
       ? `${provider.displayName} endpoint`
       : provider.authMode === "anonymous"
         ? `${provider.displayName} anonymous endpoint`
+      : provider.authMode === "per-model"
+        ? `${provider.displayName} per-model endpoints`
       : `${provider.displayName} ${credentialNoun}`,
     status.configured ? status.source : "not configured",
     provider.keyless
@@ -723,6 +725,8 @@ for (const provider of PROVIDERS.values()) {
         : `Start ${provider.displayName}, then run ./bin/curate-models ${provider.id}.`
       : provider.authMode === "anonymous"
         ? provider.anonymousNote || "No key needed; only the provider's free models are available."
+      : provider.authMode === "per-model"
+        ? "Each model here names its own endpoint; a model that needs a key reports it on its own row."
       : session
         ? `Run ${session.loginCommand}, or ./bin/provider-key ${provider.id} set.`
         : `Run ./bin/provider-key ${provider.id} set.`,

--- a/src/model-discovery.mjs
+++ b/src/model-discovery.mjs
@@ -75,6 +75,16 @@ async function providerPayload(provider) {
 export async function discoverProviderModels(providerId) {
   const provider = PROVIDERS.get(providerId);
   if (!provider) throw new Error(`Unknown provider: ${providerId}`);
+  // Discovery asks one endpoint what it serves. A per-model-endpoint provider
+  // is not an endpoint, so there is no single host to ask and no answer that
+  // would mean anything for the models under it. Refusing beats picking one of
+  // its models' addresses and reporting that as the provider's catalog.
+  if (provider.perModelEndpoint) {
+    throw new Error(
+      `${provider.displayName} has no endpoint of its own; each of its models names one. ` +
+        "Discovery runs against a single endpoint, so there is nothing to list here.",
+    );
+  }
   if (provider.kind !== "openai-compatible") {
     throw new Error(`${provider.displayName} does not expose a supported model-list endpoint.`);
   }

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -22,6 +22,17 @@ const ANONYMOUS_ENDPOINTS = Object.freeze({
   "kilo-free": "https://api.kilo.ai/api/gateway",
 });
 
+// The same guarantee, one level down. A per-model endpoint moves the address
+// out of the provider and into the model, so the allowlist has to follow it or
+// it stops being an allowlist at all: without this, adding a JSON fragment
+// under `config/custom/` would be enough to make the router send an operator's
+// prompts to any HTTPS host on earth with no credential and no review. Keyed
+// on the slug, which is what a fragment cannot forge without colliding.
+const ANONYMOUS_MODEL_ENDPOINTS = Object.freeze({
+  "custom/qwen3.8-27b":
+    "https://g9hnto0u7lvbu837.us-east-2.aws.endpoints.huggingface.cloud/v1",
+});
+
 export function anonymousModelAllowed(provider, modelId) {
   const id = typeof modelId === "string" ? modelId.trim() : "";
   if (provider?.authMode !== "anonymous" || !id) return false;
@@ -30,6 +41,27 @@ export function anonymousModelAllowed(provider, modelId) {
   }
   if (provider.anonymousModelPolicy === "suffix-free") return id.endsWith(":free");
   return false;
+}
+
+// A provider that defers its address to its models has no endpoint of its own,
+// so every consumer that used to read `provider.baseUrl` has to ask this
+// instead. The descriptor is deliberately provider-shaped: `baseUrl`,
+// `authMode`, `keyless`, and `credential` mean exactly what they mean on a
+// provider, so `resolveProviderBaseUrl` and the whole credential resolution
+// chain accept one unchanged rather than growing a parallel implementation.
+// Its `id` is the model slug, which is what makes a per-model credential file
+// and Keychain entry distinct from every other endpoint's.
+export function endpointForModel(model, providers = PROVIDERS) {
+  const provider = providers.get(model?.provider);
+  return provider?.perModelEndpoint ? model.endpoint : provider;
+}
+
+// "Nothing for the operator to supply to *this provider*" — three different
+// reasons, one consequence, and every surface that offers to take a key has to
+// agree on it. Named once because the list grew a third member and the four
+// call sites that spelled it inline would each have had to be found.
+export function providerNeedsNoKey(provider) {
+  return Boolean(provider?.keyless) || ["anonymous", "per-model"].includes(provider?.authMode);
 }
 
 function normalizedBaseUrl(value) {
@@ -202,7 +234,25 @@ function loadRegistry() {
       fail(`OAuth provider ${provider.id} requires proxyBaseEnv`);
     }
     if (provider.kind === "openai-compatible") {
-      if (!/^https?:\/\//.test(provider.baseUrl || "")) {
+      // A per-model-endpoint provider is a container, not a destination: it
+      // has no address, no credential, and nothing to authenticate, because
+      // each of its models carries all three. Letting it also declare them
+      // would create two answers to "where does this go" and a silent winner.
+      if (provider.perModelEndpoint !== undefined) {
+        if (provider.perModelEndpoint !== true) {
+          fail(`provider ${provider.id} has an invalid perModelEndpoint flag`);
+        }
+        if (provider.authMode !== "per-model") {
+          fail(`provider ${provider.id} must declare authMode per-model`);
+        }
+        for (const field of ["baseUrl", "baseUrlEnv", "credential", "keyless", "protocol"]) {
+          if (provider[field] !== undefined) {
+            fail(`per-model-endpoint provider ${provider.id} must not declare ${field}`);
+          }
+        }
+      } else if (provider.authMode === "per-model") {
+        fail(`provider ${provider.id} declares authMode per-model without perModelEndpoint`);
+      } else if (!/^https?:\/\//.test(provider.baseUrl || "")) {
         fail(`provider ${provider.id} requires an HTTP(S) baseUrl`);
       }
       // A keyless provider serves from this machine (a local Ollama or
@@ -222,7 +272,7 @@ function loadRegistry() {
       }
       if (
         provider.authMode !== undefined &&
-        !["anonymous"].includes(provider.authMode)
+        !["anonymous", "per-model"].includes(provider.authMode)
       ) {
         fail(`provider ${provider.id} has an unsupported authMode`);
       }
@@ -237,7 +287,9 @@ function loadRegistry() {
         if (provider.keyless || provider.credential !== undefined) {
           fail(`anonymous provider ${provider.id} must not declare keyless or credential metadata`);
         }
-        if (!["opencode-console", "suffix-free"].includes(provider.anonymousModelPolicy)) {
+        if (
+          !["opencode-console", "suffix-free"].includes(provider.anonymousModelPolicy)
+        ) {
           fail(`anonymous provider ${provider.id} requires a supported anonymousModelPolicy`);
         }
         if (typeof provider.anonymousNote !== "string" || !provider.anonymousNote.trim()) {
@@ -248,7 +300,7 @@ function loadRegistry() {
       }
       if (
         !provider.keyless &&
-        provider.authMode !== "anonymous" &&
+        !["anonymous", "per-model"].includes(provider.authMode) &&
         (!provider.credential?.file || !Array.isArray(provider.credential.environment))
       ) {
         fail(`provider ${provider.id} requires credential metadata`);
@@ -325,7 +377,7 @@ function loadRegistry() {
     if (problem) fail(problem);
     slugs.add(model.slug);
     gatewayModels.add(model.gatewayModel);
-    return Object.freeze(model);
+    return normalizedModel(model, providers.get(model.provider));
   });
 
   const modelBySlug = new Map(models.map((model) => [model.slug, model]));
@@ -356,6 +408,93 @@ function upgradeTargetProblem(model, modelBySlug) {
   return undefined;
 }
 
+// A model's own endpoint answers the three questions a provider normally
+// answers -- where the request goes, whether it carries a credential, and
+// which one -- so it is validated to the same standard, in the same order, and
+// with the same refusals. Everything an operator can add to `config/custom/`
+// or to their user-model overlay lands here.
+function endpointProblem(model, provider) {
+  if (!provider.perModelEndpoint) {
+    return model.endpoint === undefined
+      ? undefined
+      : `model ${model.slug} declares an endpoint but ${provider.id} is not a per-model-endpoint provider`;
+  }
+  const endpoint = model.endpoint;
+  if (!endpoint || typeof endpoint !== "object" || Array.isArray(endpoint)) {
+    return `model ${model.slug} requires an endpoint under per-model-endpoint provider ${provider.id}`;
+  }
+  if (endpoint.id !== undefined || endpoint.kind !== undefined) {
+    // Both are derived from the model, and a fragment that set them could
+    // point one model's credential file at another model's secret.
+    return `model ${model.slug} endpoint must not declare id or kind`;
+  }
+  if (!/^https?:\/\//.test(endpoint.baseUrl || "")) {
+    return `model ${model.slug} endpoint requires an HTTP(S) baseUrl`;
+  }
+  if (endpoint.authMode !== undefined && endpoint.authMode !== "anonymous") {
+    return `model ${model.slug} endpoint has an unsupported authMode`;
+  }
+  if (endpoint.keyless !== undefined && typeof endpoint.keyless !== "boolean") {
+    return `model ${model.slug} endpoint has an invalid keyless flag`;
+  }
+  // Exactly one auth story per endpoint. Two would leave a silent winner, and
+  // none would send an unauthenticated request to an address nobody vetted.
+  const declared = [
+    endpoint.authMode === "anonymous",
+    Boolean(endpoint.keyless),
+    endpoint.credential !== undefined,
+  ].filter(Boolean).length;
+  if (declared !== 1) {
+    return `model ${model.slug} endpoint must declare exactly one of anonymous, keyless, or credential`;
+  }
+  // The keyless rule is about the address, not the flag: an endpoint that
+  // sends no credential may only talk to this machine.
+  if (endpoint.keyless && !loopbackBaseUrl(endpoint.baseUrl)) {
+    return `model ${model.slug} keyless endpoint must use a loopback baseUrl`;
+  }
+  // An anonymous endpoint reaches a third party with no credential at all, so
+  // the address itself is the security boundary and it lives in code.
+  if (endpoint.authMode === "anonymous") {
+    const expected = ANONYMOUS_MODEL_ENDPOINTS[model.slug];
+    if (!expected || normalizedBaseUrl(endpoint.baseUrl) !== expected) {
+      return `model ${model.slug} anonymous endpoint must use its allowlisted address`;
+    }
+    if (typeof endpoint.note !== "string" || !endpoint.note.trim()) {
+      return `model ${model.slug} anonymous endpoint requires a note`;
+    }
+  }
+  if (
+    endpoint.credential !== undefined &&
+    (!endpoint.credential.file || !Array.isArray(endpoint.credential.environment))
+  ) {
+    return `model ${model.slug} endpoint requires credential metadata`;
+  }
+  if (endpoint.baseUrlEnv !== undefined && typeof endpoint.baseUrlEnv !== "string") {
+    return `model ${model.slug} endpoint has an invalid baseUrlEnv`;
+  }
+  // An override on an endpoint that carries no key would walk straight around
+  // the allowlist the anonymous case just enforced.
+  if (endpoint.baseUrlEnv && (endpoint.authMode === "anonymous" || endpoint.keyless)) {
+    return `model ${model.slug} endpoint must not allow a baseUrl override without a credential`;
+  }
+  return undefined;
+}
+
+// The endpoint the registry declares is data; the endpoint the router resolves
+// has to be provider-shaped so the existing base-URL and credential chains
+// accept it. Identity is derived here rather than read from the fragment.
+function normalizedModel(model, provider) {
+  if (!provider?.perModelEndpoint) return Object.freeze(model);
+  return Object.freeze({
+    ...model,
+    endpoint: Object.freeze({
+      ...model.endpoint,
+      id: model.slug,
+      kind: "openai-compatible",
+    }),
+  });
+}
+
 // Returns a problem description instead of throwing so the strict registry
 // loader can fail hard while the user-model overlay skips with a warning.
 function modelProblem(model, providers, slugs, gatewayModels) {
@@ -377,6 +516,8 @@ function modelProblem(model, providers, slugs, gatewayModels) {
   if (provider.authMode === "anonymous" && !anonymousModelAllowed(provider, model.upstreamModel)) {
     return `anonymous provider ${provider.id} only accepts its documented free-model ids`;
   }
+  const endpoint = endpointProblem(model, provider);
+  if (endpoint) return endpoint;
   if (model.requestProfile !== undefined && typeof model.requestProfile !== "string") {
     return `model ${model.slug} has an invalid requestProfile`;
   }
@@ -571,7 +712,7 @@ function mergeUserModels(base) {
     }
     slugs.add(model.slug);
     gatewayModels.add(model.gatewayModel);
-    const frozen = Object.freeze(model);
+    const frozen = normalizedModel(model, base.providers.get(model.provider));
     userModels.add(frozen);
     models.push(frozen);
   }

--- a/src/provider-account-usage.mjs
+++ b/src/provider-account-usage.mjs
@@ -804,7 +804,10 @@ async function accountUsageFor(providerId, fetchImpl) {
     if (providerId === "commandcode") return await commandCodeAccount(fetchImpl);
     if (providerId === "minimax-token-plan") return await minimaxTokenPlanAccount(fetchImpl);
     if (providerId === "opencode-go") return await opencodeGoAccount(fetchImpl);
-    if (providerId === "opencode-free" || providerId === "kilo-free") {
+    // Keyed on the auth mode rather than on a list of ids: an anonymous
+    // provider has no account to query by construction, so a new one must not
+    // be able to fall through to a branch that would try.
+    if (["anonymous", "per-model"].includes(PROVIDERS.get(providerId)?.authMode)) {
       return withHeaderQuota(providerId, localOnly("Anonymous free-provider quota is not exposed; showing router traffic"));
     }
     if (providerId === "github-copilot") return await githubCopilotAccount(fetchImpl);

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -27,7 +27,11 @@ import {
 
 export function apiProvider(providerId) {
   const provider = PROVIDERS.get(providerId);
-  if (!provider || provider.kind !== "openai-compatible" || provider.authMode === "anonymous") {
+  if (
+    !provider ||
+    provider.kind !== "openai-compatible" ||
+    ["anonymous", "per-model"].includes(provider.authMode)
+  ) {
     throw new Error(`Unknown API-key provider: ${providerId}`);
   }
   return provider;
@@ -148,6 +152,14 @@ export function resolveProviderCredential(providerOrId, options = {}) {
   if (provider.authMode === "anonymous") {
     return { value: undefined, source: "official anonymous endpoint", persistent: true };
   }
+  // A per-model-endpoint provider holds no credential of its own: each of its
+  // models resolves through this same function with its own endpoint
+  // descriptor. Answering "configured" here is what lets the container take
+  // part in selection, health, and the catalog; a model whose own endpoint
+  // needs a key still reports that against the key it actually wants.
+  if (provider.authMode === "per-model") {
+    return { value: undefined, source: "per-model endpoints", persistent: true };
+  }
   // Nothing to resolve for a loopback provider: it authenticates no one. The
   // placeholder keeps the forwarder's header shape uniform, and the registry
   // guarantees keyless providers are loopback-only, so it never leaves the
@@ -201,6 +213,7 @@ export function resolveProviderCredential(providerOrId, options = {}) {
 // prints this sentence (doctor, discovery errors, the enable gate).
 export function credentialSetupHint(provider) {
   if (provider.authMode === "anonymous") return "No key needed; free models are rate limited by the provider.";
+  if (provider.authMode === "per-model") return "No key needed here; each model names its own endpoint.";
   if (provider.keyless) return "No key needed; it runs on this machine.";
   const keyCommand = targetCli(`provider-key ${provider.id} set`);
   const session = cliSessionDescriptor(provider);
@@ -211,6 +224,7 @@ export function credentialSetupHint(provider) {
 
 export function credentialLabel(provider) {
   if (provider.authMode === "anonymous") return "No API key";
+  if (provider.authMode === "per-model") return "Per-model endpoints";
   return provider.credential?.label || "API key";
 }
 

--- a/src/provider-onboarding.mjs
+++ b/src/provider-onboarding.mjs
@@ -11,7 +11,7 @@ import {
 import { cliSessionPath, cliSessionStatus } from "./cli-session-credential.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { KIMI_CLI_NPM_PACKAGE } from "./kimi-oauth-onboarding.mjs";
-import { MODELS, PROVIDERS } from "./model-registry.mjs";
+import { MODELS, PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { STATE_DIR } from "./paths.mjs";
 import {
@@ -126,7 +126,7 @@ export function providerOnboardingSnapshot() {
                 : "login",
         };
       }
-      const configured = provider.keyless || provider.authMode === "anonymous"
+      const configured = providerNeedsNoKey(provider)
         ? true
         : credentialStatus(provider, { persistent: true }).configured;
       const entry = {
@@ -140,6 +140,16 @@ export function providerOnboardingSnapshot() {
         // moment someone decides to connect, not after Codex 403s.
         ...(provider.planNote ? { planNote: provider.planNote } : {}),
       };
+      // A container has no key field of its own. Saying so is the whole card:
+      // an "Add Key" button here would store a secret nothing ever reads.
+      if (provider.authMode === "per-model") {
+        entry.kind = "per-model";
+        entry.action = "per-model";
+        entry.credentialLabel = "Per-model endpoints";
+        entry.perModelNote =
+          "Each model here names its own endpoint and its own auth. Enabling this provider costs nothing.";
+        return entry;
+      }
       if (provider.authMode === "anonymous") {
         entry.kind = "anonymous";
         // Guided setup pre-checks every `ready` row. An off-box endpoint must

--- a/src/provider-selection.mjs
+++ b/src/provider-selection.mjs
@@ -12,7 +12,7 @@ import { fileURLToPath } from "node:url";
 import { discoveryDisabled } from "./discovery-mode.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
 import { PROVIDER_SELECTION_PATH, STATE_DIR, TARGET } from "./paths.mjs";
-import { LISTED_MODELS, PROVIDERS } from "./model-registry.mjs";
+import { LISTED_MODELS, PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import { targetCli } from "./target-integration.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
@@ -93,7 +93,7 @@ export function configuredProviderIds() {
       } else if (provider.id === "grok-oauth" && grokOAuthStatus().configured) {
         configured.push(provider.id);
       }
-    } else if (provider.keyless || provider.authMode === "anonymous") {
+    } else if (providerNeedsNoKey(provider)) {
       // Nothing to configure: local providers run on this machine, while
       // anonymous providers authenticate by the provider's free-model policy.
       // Reachability and rate limits remain health questions, not reasons to
@@ -113,8 +113,12 @@ export function configuredProviderIds() {
 // third-party endpoint, so it must be an explicit choice. Loopback keyless
 // providers remain safe to include in the default.
 export function defaultProviderIds() {
+  // A per-model-endpoint container is excluded on the same reasoning: it holds
+  // whatever endpoints someone put in it, and at least one of them today is a
+  // third-party address reached with no credential. "Enabling this sends
+  // prompts off-box" has to stay a choice somebody made.
   return configuredProviderIds().filter(
-    (id) => PROVIDERS.get(id)?.authMode !== "anonymous",
+    (id) => !["anonymous", "per-model"].includes(PROVIDERS.get(id)?.authMode),
   );
 }
 

--- a/src/provider-usage.mjs
+++ b/src/provider-usage.mjs
@@ -56,7 +56,9 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
           ? "oauth"
           : provider.authMode === "anonymous"
             ? "anonymous"
-            : "api",
+            : provider.authMode === "per-model"
+              ? "per-model"
+              : "api",
         scope: "local-router",
         requests: 0,
         successfulRequests: 0,

--- a/src/providers.mjs
+++ b/src/providers.mjs
@@ -1,7 +1,7 @@
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-import { PROVIDERS } from "./model-registry.mjs";
+import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import { cliSessionDescriptor } from "./cli-session-credential.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
@@ -31,7 +31,7 @@ function configured(provider) {
   if (provider.kind === "oauth") {
     return Boolean(SIGN_IN_STATUS[provider.id]?.status().configured);
   }
-  return provider.keyless || provider.authMode === "anonymous"
+  return providerNeedsNoKey(provider)
     ? true
     : credentialStatus(provider, { persistent: true }).configured;
 }

--- a/src/setup-shared.mjs
+++ b/src/setup-shared.mjs
@@ -14,7 +14,7 @@ import {
   MAX_LOGIN_ATTEMPTS,
   kimiCliInstallGuidance,
 } from "./kimi-oauth-onboarding.mjs";
-import { PROVIDERS } from "./model-registry.mjs";
+import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
@@ -123,7 +123,7 @@ export function providerConfigured(provider) {
     if (provider.id === "grok-oauth") return grokOAuthStatus().configured;
     return false;
   }
-  return provider.keyless || provider.authMode === "anonymous"
+  return providerNeedsNoKey(provider)
     ? true
     : credentialStatus(provider, { persistent: true }).configured;
 }
@@ -289,7 +289,7 @@ export function configureProvider(provider, { guided, providerKeyCommand }) {
     if (provider.id === "grok-oauth") onboardGrokOauth();
     else onboardKimiOauth();
   } else {
-    if (provider.authMode === "anonymous") return;
+    if (["anonymous", "per-model"].includes(provider.authMode)) return;
     const prompt = provider.credential?.prompt || `${provider.displayName} API key`;
     if (!confirm(`Enter ${prompt} securely now?`)) {
       throw new Error(`${provider.displayName} setup was cancelled.`);

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import { cliSessionDescriptor } from "./cli-session-credential.mjs";
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
-import { PROVIDERS } from "./model-registry.mjs";
+import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT, TARGET } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
@@ -202,7 +202,7 @@ function providerConfigured(provider) {
     if (provider.id === "grok-oauth") return grokOAuthStatus().configured;
     return false;
   }
-  return provider.keyless || provider.authMode === "anonymous"
+  return providerNeedsNoKey(provider)
     ? true
     : credentialStatus(provider, { persistent: true }).configured;
 }
@@ -291,7 +291,7 @@ function configureProvider(provider) {
       throw incomplete(`${provider.displayName} sign-in did not produce a usable credential.`);
     }
   } else {
-    if (provider.authMode === "anonymous") return;
+    if (["anonymous", "per-model"].includes(provider.authMode)) return;
     // A provider whose CLI mints its key in the browser gets that offer first,
     // because most people have an account long before they have a key. Saying
     // no falls through to the key prompt rather than failing the install.

--- a/src/support-bundle.mjs
+++ b/src/support-bundle.mjs
@@ -15,7 +15,7 @@ import { redactCallerUrl } from "./caller-auth.mjs";
 import { readInstallManifest } from "./install-manifest.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
 import { detectLegacyInstallations } from "./legacy-migration.mjs";
-import { PROVIDERS } from "./model-registry.mjs";
+import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import {
   CALLER_SECRET_PATH,
   CONFIG_PATH,
@@ -89,7 +89,7 @@ function knownLocalSecrets() {
     if (provider.kind !== "openai-compatible") continue;
     // A keyless provider holds no secret, so there is nothing to collect and
     // nothing to redact for it.
-    if (provider.keyless || provider.authMode === "anonymous") continue;
+    if (providerNeedsNoKey(provider)) continue;
     files.push(...credentialPaths(provider));
     for (const name of provider.credential.environment) {
       const value = process.env[name]?.trim();

--- a/test/provider-account-usage.test.mjs
+++ b/test/provider-account-usage.test.mjs
@@ -221,15 +221,15 @@ test("does not poll account endpoints for disabled providers", async () => {
 
 test("anonymous free providers degrade to traffic-only usage without a balance API", async () => {
   const snapshot = await providerAccountUsageSnapshot({
-    providerIds: ["opencode-free", "kilo-free"],
+    providerIds: ["opencode-free", "kilo-free", "custom"],
     fetchImpl: async () => {
       throw new Error("anonymous providers must not poll a private account endpoint");
     },
   });
-  assert.equal(snapshot["opencode-free"].status, "local-only");
-  assert.equal(snapshot["kilo-free"].status, "local-only");
-  assert.match(snapshot["opencode-free"].message, /quota is not exposed/);
-  assert.match(snapshot["kilo-free"].message, /quota is not exposed/);
+  for (const id of ["opencode-free", "kilo-free", "custom"]) {
+    assert.equal(snapshot[id].status, "local-only");
+    assert.match(snapshot[id].message, /quota is not exposed/);
+  }
 });
 
 test("Command Code usage reads plan windows from the billing credits API", async () => {

--- a/test/provider-onboarding.test.mjs
+++ b/test/provider-onboarding.test.mjs
@@ -84,6 +84,13 @@ test("provider onboarding reports install, login, and API key actions without se
       assert.equal(byId[id].credentialLabel, "No API key");
       assert.match(byId[id].anonymousNote, /No API key/);
     }
+    // A per-model-endpoint container must never offer a key field: a secret
+    // stored against it would be read by nothing.
+    assert.equal(byId.custom.kind, "per-model");
+    assert.equal(byId.custom.configured, true);
+    assert.equal(byId.custom.action, "per-model");
+    assert.equal(byId.custom.credentialLabel, "Per-model endpoints");
+    assert.match(byId.custom.perModelNote, /own endpoint/);
     assert.equal("source" in byId["kimi-api"], false);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -56,11 +56,24 @@ test("provider selection keeps backward compatibility and can hide the final pro
     // Local backends are keyless: they serve from this machine, so there is no
     // credential to configure and they are always available. Everything else
     // has to authenticate before it counts.
-    assert.deepEqual(configuredProviderIds(), ["kilo-free", "lmstudio", "local", "opencode-free"]);
+    assert.deepEqual(configuredProviderIds(), [
+      "custom",
+      "kilo-free",
+      "lmstudio",
+      "local",
+      "opencode-free",
+    ]);
     assert.deepEqual(defaultProviderIds(), ["lmstudio", "local"]);
     delete process.env.KIMI_API_KEY;
     writeProviderCredential("deepseek", "TEST_DEEPSEEK_SELECTION_KEY");
-    assert.deepEqual(configuredProviderIds(), ["deepseek", "kilo-free", "lmstudio", "local", "opencode-free"]);
+    assert.deepEqual(configuredProviderIds(), [
+      "custom",
+      "deepseek",
+      "kilo-free",
+      "lmstudio",
+      "local",
+      "opencode-free",
+    ]);
     assert.deepEqual(defaultProviderIds(), ["deepseek", "lmstudio", "local"]);
 
     writeProviderSelection(["chatgpt-oauth"]);

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -17,10 +17,12 @@ const { renderLiteLlmConfig } = await import("../src/litellm-config.mjs");
 const {
   API_MODELS,
   anonymousModelAllowed,
+  endpointForModel,
   LISTED_MODELS,
   MODEL_BY_SLUG,
   MODELS,
   PROVIDERS,
+  providerNeedsNoKey,
   readRegistryDocument,
   resolveProviderBaseUrl,
 } = await import("../src/model-registry.mjs");
@@ -79,6 +81,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "commandcode/qwen3.7-plus",
       "commandcode/qwen3.8-max",
       "commandcode/step-3.7-flash",
+      "custom/qwen3.8-27b",
       "deepseek/deepseek-v4-flash",
       "deepseek/deepseek-v4-pro",
       "grok-api/grok-4.5",
@@ -268,6 +271,42 @@ test("provider registry exposes configured API and OAuth model families", () => 
   assert.equal(kiloFree.baseUrl, "https://api.kilo.ai/api/gateway");
   assert.equal(anonymousModelAllowed(kiloFree, "z-ai/glm-5:free"), true);
   assert.equal(anonymousModelAllowed(kiloFree, "z-ai/glm-5"), false);
+  // The `custom` provider is a container: it has no address, no credential, and
+  // nothing to authenticate, because each of its models carries all three.
+  const custom = PROVIDERS.get("custom");
+  assert.equal(custom.perModelEndpoint, true);
+  assert.equal(custom.authMode, "per-model");
+  assert.equal(custom.baseUrl, undefined);
+  assert.equal(custom.baseUrlEnv, undefined);
+  assert.equal(custom.credential, undefined);
+  assert.equal(providerNeedsNoKey(custom), true);
+  // Its first model names the free community endpoint and reaches it with no
+  // credential, so the address is the security boundary and lives in code.
+  const customModels = LISTED_MODELS.filter(({ provider }) => provider === "custom");
+  assert.deepEqual(
+    customModels.map(({ slug }) => slug),
+    ["custom/qwen3.8-27b"],
+  );
+  const [qwen38] = customModels;
+  assert.equal(
+    qwen38.endpoint.baseUrl,
+    "https://g9hnto0u7lvbu837.us-east-2.aws.endpoints.huggingface.cloud/v1",
+  );
+  assert.equal(qwen38.endpoint.authMode, "anonymous");
+  assert.equal(qwen38.endpoint.credential, undefined);
+  assert.equal(qwen38.endpoint.baseUrlEnv, undefined);
+  // Identity is derived from the model, never read from the fragment, so one
+  // model's credential file can never be pointed at another model's secret.
+  assert.equal(qwen38.endpoint.id, "custom/qwen3.8-27b");
+  assert.equal(qwen38.endpoint.kind, "openai-compatible");
+  assert.equal(endpointForModel(qwen38), qwen38.endpoint);
+  // Metadata verified against the live endpoint rather than guessed.
+  assert.equal(qwen38.contextWindow, 262144);
+  assert.deepEqual(qwen38.inputModalities, ["text", "image"]);
+  assert.equal(qwen38.requestProfile, "qwen38-community");
+  // Every other provider is its own endpoint, so the two answers coincide.
+  const deepseekModel = LISTED_MODELS.find(({ provider }) => provider === "deepseek");
+  assert.equal(endpointForModel(deepseekModel), PROVIDERS.get("deepseek"));
   const clinepass = PROVIDERS.get("clinepass");
   assert.equal(clinepass.baseUrl, "https://api.cline.bot/api/v1");
   assert.equal(clinepass.baseUrlEnv, "CLINE_API_BASE_URL");
@@ -773,7 +812,7 @@ test("a keyless provider must be loopback and must not carry a credential", asyn
   }
 });
 
-test("anonymous providers are fixed official endpoints without credentials", async () => {
+test("credential-free endpoints are allowlisted addresses, at the provider and at the model", async () => {
   const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
   const { tmpdir } = await import("node:os");
   const nodePath = (await import("node:path")).default;
@@ -810,6 +849,100 @@ test("anonymous providers are fixed official endpoints without credentials", asy
     });
     assert.equal(keyed.status, 1);
     assert.match(keyed.stderr, /anonymous provider kilo-free must not declare keyless or credential metadata/);
+
+    // Everything below is the same guarantee one level down. A per-model
+    // endpoint moves the address out of the provider and into the model, so a
+    // JSON fragment is the thing that must not be able to widen it.
+    const customModel = (mutate) => (registry) => {
+      registry.models = registry.models.map((model) =>
+        model.provider === "custom" ? mutate(model) : model,
+      );
+    };
+
+    // The address is the security boundary for a credential-free endpoint, so
+    // it is allowlisted in code and a fragment cannot repoint it.
+    const redirectedModel = load(customModel((model) => ({
+      ...model,
+      endpoint: { ...model.endpoint, baseUrl: "https://example.com/v1" },
+    })));
+    assert.equal(redirectedModel.status, 1);
+    assert.match(
+      redirectedModel.stderr,
+      /model custom\/qwen3\.8-27b anonymous endpoint must use its allowlisted address/,
+    );
+
+    // An environment override would walk straight around that allowlist.
+    const overridden = load(customModel((model) => ({
+      ...model,
+      endpoint: { ...model.endpoint, baseUrlEnv: "CUSTOM_BASE_URL" },
+    })));
+    assert.equal(overridden.status, 1);
+    assert.match(
+      overridden.stderr,
+      /must not allow a baseUrl override without a credential/,
+    );
+
+    // Exactly one auth story per endpoint: two would leave a silent winner.
+    const doubled = load(customModel((model) => ({
+      ...model,
+      endpoint: {
+        ...model.endpoint,
+        credential: { file: "custom.secret", environment: ["CUSTOM_API_KEY"] },
+      },
+    })));
+    assert.equal(doubled.status, 1);
+    assert.match(
+      doubled.stderr,
+      /must declare exactly one of anonymous, keyless, or credential/,
+    );
+
+    // The keyless rule is about the address, not the flag: an endpoint that
+    // sends no credential may only talk to this machine.
+    const offBox = load(customModel((model) => ({
+      ...model,
+      endpoint: { baseUrl: "https://example.com/v1", keyless: true },
+    })));
+    assert.equal(offBox.status, 1);
+    assert.match(offBox.stderr, /keyless endpoint must use a loopback baseUrl/);
+
+    // Identity is derived from the model. A fragment that set it could point
+    // one model's credential file at another model's secret.
+    const forged = load(customModel((model) => ({
+      ...model,
+      endpoint: { ...model.endpoint, id: "deepseek" },
+    })));
+    assert.equal(forged.status, 1);
+    assert.match(forged.stderr, /endpoint must not declare id or kind/);
+
+    // A container has no address of its own; two answers to "where does this
+    // go" would have a silent winner.
+    const addressedContainer = load((registry) => {
+      registry.providers = registry.providers.map((provider) =>
+        provider.id === "custom"
+          ? { ...provider, baseUrl: "https://example.com/v1" }
+          : provider,
+      );
+    });
+    assert.equal(addressedContainer.status, 1);
+    assert.match(
+      addressedContainer.stderr,
+      /per-model-endpoint provider custom must not declare baseUrl/,
+    );
+
+    // And the reverse: an endpoint on a provider that already is one would be
+    // silently ignored today and quietly obeyed after any future refactor.
+    const strayEndpoint = load((registry) => {
+      registry.models = registry.models.map((model) =>
+        model.provider === "deepseek"
+          ? { ...model, endpoint: { baseUrl: "https://example.com/v1" } }
+          : model,
+      );
+    });
+    assert.equal(strayEndpoint.status, 1);
+    assert.match(
+      strayEndpoint.stderr,
+      /declares an endpoint but deepseek is not a per-model-endpoint provider/,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -2779,6 +2779,118 @@ test("API forwarder downgrades forced tool choices only for models that declare 
 });
 
 
+// The free Qwen3.8 community endpoint validates reasoning_effort against a
+// literal set and 400s on anything outside it. `ultra` is the one rung of the
+// Codex ladder that set omits, so the profile folds exactly that value and
+// leaves the rest alone. The profile is a property of the model, not of the
+// provider, so this exercises it through a curated model on a provider whose
+// base URL can be pointed at a local mock -- an anonymous provider is pinned
+// to its official endpoint by construction and has none.
+function curatedQwen38EffortModel() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "routing-qwen38-community-models-"));
+  const file = path.join(dir, "user-models.json");
+  writeFileSync(
+    file,
+    JSON.stringify({
+      version: 1,
+      models: [
+        {
+          slug: "openrouter/qwen-3.8-27b-effort",
+          gatewayModel: "openrouter-qwen-3-8-27b-effort",
+          upstreamModel: "qwen/qwen3.8-27b",
+          provider: "openrouter",
+          listed: true,
+          displayName: "Qwen3.8 27B (effort fixture)",
+          description: "Test fixture.",
+          priority: 500,
+          defaultEffort: "medium",
+          reasoningLevels: [{ effort: "medium", description: "Balanced reasoning" }],
+          contextWindow: 262144,
+          autoCompact: 230000,
+          inputModalities: ["text"],
+          requestProfile: "qwen38-community",
+          compHash: "openrouter-qwen-3-8-27b-effort-user-v1",
+        },
+      ],
+    }),
+    "utf8",
+  );
+  return { dir, file, gatewayModel: "openrouter-qwen-3-8-27b-effort" };
+}
+
+test("API forwarder folds only the effort tier the free Qwen3.8 endpoint rejects", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const curated = curatedQwen38EffortModel();
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    MODEL_ROUTER_USER_MODELS: curated.file,
+    OPENROUTER_API_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OPENROUTER_API_KEY: "TEST_OPENROUTER_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    for (const [sentEffort, expectedEffort] of [
+      ["ultra", "max"],
+      ["max", "max"],
+      ["xhigh", "xhigh"],
+      ["high", "high"],
+      ["medium", "medium"],
+      ["low", "low"],
+      ["minimal", "minimal"],
+      ["none", "none"],
+    ]) {
+      const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: curated.gatewayModel,
+          reasoning_effort: sentEffort,
+          tool_choice: "required",
+          messages: [{ role: "user", content: "test" }],
+        }),
+      });
+      assert.equal(response.status, 200);
+      const request = upstreamRequests.at(-1);
+      assert.equal(request.body.reasoning_effort, expectedEffort);
+      // The endpoint answers a forced tool choice with a real tool call
+      // (verified live), so the profile must not downgrade it -- the
+      // compatibility probe and the subagent payload relay both depend on it.
+      assert.equal(request.body.tool_choice, "required");
+    }
+
+    // An absent effort stays absent so the endpoint applies its own default.
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: curated.gatewayModel,
+        messages: [{ role: "user", content: "test" }],
+      }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal("reasoning_effort" in upstreamRequests.at(-1).body, false);
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+    rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
 test("API forwarder routes MiniMax M3 streaming tool calls with adaptive thinking", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
Supersedes the first draft of this PR, which shipped the free Qwen3.8 endpoint as its own `qwen38-free` provider. Same endpoint, different shape.

## Why the shape changed

Every other provider owns one address. That is why "route this one model from that one host" has always meant inventing a whole provider for it — and why a second host means a second provider, with its own credential story, its own tray card, and its own row in every surface that enumerates providers.

`custom` owns no address at all. It declares no `baseUrl`, no `credential`, and no `protocol`; each of its models carries all three in an `endpoint` block, and `endpointForModel()` is what the forwarder asks instead of reading `provider.baseUrl`. One picker entry can hold a free community endpoint, a self-hosted server, and a paid API with a key, at the same time.

```
config/custom/custom.json        { id: "custom", perModelEndpoint: true }
config/custom/qwen3.8-27b.json   endpoint: { baseUrl: <hf endpoint>, authMode: "anonymous" }
config/custom/<next>.json        endpoint: { baseUrl: <other host>, credential: {...} }
```

The endpoint descriptor is deliberately **provider-shaped**: `baseUrl`, `authMode`, `keyless`, and `credential` mean exactly what they mean on a provider, so `resolveProviderBaseUrl` and the whole credential chain accept one unchanged — including a per-model credential file and Keychain entry, which fall out of giving the descriptor the model slug as its `id`. A parallel resolver would have been the larger change and the worse one: the moment two implementations differ, one of them is the copy nobody audited.

## The part worth reviewing

The rule that keeps a credential-free provider from becoming an arbitrary-endpoint egress path has to **follow the address down**, or it stops being a rule. Without it, adding a JSON file under `config/custom/` would be enough to send an operator's prompts to any HTTPS host on earth with nothing to authenticate them.

| Refusal | Why |
| --- | --- |
| An `anonymous` endpoint's address must be in `ANONYMOUS_MODEL_ENDPOINTS`, keyed by slug | The address *is* the boundary when nothing authenticates the request |
| A `keyless` endpoint must be loopback | Same rule as a keyless provider: no credential means no off-box traffic |
| Neither may declare a `baseUrlEnv` | An environment override walks around whichever of the two rules applied |
| `endpoint.id` / `endpoint.kind` are injected at load, and a fragment that spells them is refused | Otherwise one model's endpoint could name itself after another and collect that model's secret |
| Exactly one of anonymous / keyless / credential | Two would leave a silent winner; none would send an unauthenticated request to an unvetted address |
| A container declaring its own `baseUrl`, or a normal provider's model declaring an `endpoint` | Two answers to "where does this go" have a silent winner |

Every row has a test that fails without it (`test/registry.test.mjs`).

Selection treats the container like an anonymous provider: `defaultProviderIds()` excludes it, because what it holds is whatever somebody put in it. Nothing offers a key at the container level — `apiProvider()` refuses it, the onboarding card is informational — since a secret stored there would be read by nothing. Discovery refuses it outright, because it asks *one* endpoint what it serves and picking one of its models' addresses to report as the provider's catalog is worse than saying no.

Four call sites spelled `keyless || authMode === "anonymous"` inline. The list has grown a third member, so it is named once as `providerNeedsNoKey()`.

## The first model, measured not inferred

The endpoint answers anonymously, so there was no excuse for reading capabilities off its model card. Source: https://huggingface.co/spaces/victor/Qwen3.8-27B-free-endpoint

| Probe | Result |
| --- | --- |
| `GET /v1/models` | one model, `max_model_len` 262144 |
| `tool_choice: "required"` | real tool call — no `auto-tool-choice` downgrade warranted |
| vision (known image) | read correctly |
| streaming | SSE frames normally |
| `usage.prompt_tokens` | non-zero, so the zero-token substitution never engages |
| `reasoning_effort` | accepts `none/minimal/low/medium/high/xhigh/max`; **400s on `ultra`** |

The Codex ladder is that set plus `ultra`, so the `qwen38-community` profile folds exactly that rung onto `max` and leaves every other tier alone. The regression drives all eight values, because a profile that silently clamped more than one would look identical from the picker.

The endpoint is shared, rate limited to ~30 requests/minute per IP, and its owner says it will be retired once launch interest fades. A model to try, not one to depend on — the README says so where someone would enable it.

## Test plan

- [x] `npm run check`
- [x] `npm test` — 1333 tests, 0 fail, rebased on current `main` (includes #249)
- [x] `swift build` + `swift test` — 26 tests pass, artifacts cleaned
- [x] `./bin/discover-models custom` — refuses with the explanation, as designed
- [x] Live endpoint re-checked reachable (HTTP 200) after the restructure
- [ ] After merge: `bin/update`, `providers enable custom`, restart Codex, confirm **Qwen3.8 27B (Free)** answers
- [ ] Optional, spends no quota: `./bin/test-model 'custom/qwen3.8-27b' --live --yes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKT3Zabs9wpfa3UEWgmaVV