### PR TITLE
Bridge native tool_search for routed chat-completions models

### DIFF
--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -42,6 +42,47 @@ export const NAMESPACE_DELIMITER = "__";
 // Map in a WeakMap preserves the Map's public shape for existing callers while
 // letting the response path validate model-generated overrides.
 const SPAWN_AGENT_MODELS = new WeakMap();
+const TOOL_SEARCH_RELAYS = new WeakMap();
+
+const TOOL_SEARCH_FUNCTION_NAME = "tool_search";
+
+function providerFunctionName(tool) {
+  return tool?.name ?? tool?.function?.name;
+}
+
+function providerVisibleToolNames(tools) {
+  const names = new Set();
+  if (!Array.isArray(tools)) return names;
+  for (const tool of tools) {
+    if (tool?.type === "namespace" && Array.isArray(tool.tools)) {
+      for (const fn of tool.tools) {
+        if (fn?.name) names.add(`${tool.name}${NAMESPACE_DELIMITER}${fn.name}`);
+      }
+      continue;
+    }
+    const name = providerFunctionName(tool);
+    if (typeof name === "string" && name) names.add(name);
+  }
+  return names;
+}
+
+function availableToolSearchName(tools) {
+  const names = providerVisibleToolNames(tools);
+  if (!names.has(TOOL_SEARCH_FUNCTION_NAME)) return TOOL_SEARCH_FUNCTION_NAME;
+  let suffix = 1;
+  while (names.has(`codex_tool_search_${suffix}`)) suffix += 1;
+  return `codex_tool_search_${suffix}`;
+}
+
+function providerToolSearchDescription(description, providerName) {
+  if (typeof description !== "string") return undefined;
+  if (providerName === TOOL_SEARCH_FUNCTION_NAME) return description;
+  const rewritten = description.replaceAll(
+    `\`${TOOL_SEARCH_FUNCTION_NAME}\``,
+    `\`${providerName}\``,
+  );
+  return `${rewritten}\n\nFor this routed request, call \`${providerName}\` for deferred tool discovery; \`${TOOL_SEARCH_FUNCTION_NAME}\` is a separate ordinary function.`;
+}
 
 function schemaStringValues(schema, values = new Set()) {
   if (!schema || typeof schema !== "object") return values;
@@ -128,23 +169,51 @@ export function repairToolSchemaRoots(tools) {
   return changed ? repaired : tools;
 }
 
+function flattenNamespaceChild(namespace, fn) {
+  const clientSchema = fn.parameters ?? fn.inputSchema;
+  const parameters =
+    clientSchema === undefined ? undefined : providerToolSchema(clientSchema);
+  return {
+    ...fn,
+    name: `${namespace}${NAMESPACE_DELIMITER}${fn.name}`,
+    ...(parameters === undefined ? {} : { parameters }),
+  };
+}
+
 // Flatten every namespace entry into plain functions named
 // `<namespace>__<tool>`. Returns the set of namespaces that were flattened
 // (name -> tool names) so callers can rename history and restore calls.
-export function flattenNamespaceTools(tools) {
+export function flattenNamespaceTools(tools, { bridgeToolSearch = true } = {}) {
   if (!Array.isArray(tools)) return { tools, flattened: false, namespaces: new Map() };
   const flattened = [];
   const namespaces = new Map();
   const spawnAgentModels = new Set();
+  const toolSearchName = bridgeToolSearch ? availableToolSearchName(tools) : undefined;
+  let toolSearchRelay;
   let changed = false;
   for (const tool of tools) {
-    // Codex adds this control tool when one or more namespace tools use
-    // deferred loading. By this boundary every namespace is expanded below,
-    // so the search control is redundant; chat-completions providers accept
-    // only ordinary function tools and reject `type: "tool_search"` before
-    // the model can call any MCP function.
+    // Codex registers deferred tools client-side and exposes this native
+    // control so the model can search them on demand. Chat-completions
+    // providers reject the native type, so present the same request-local
+    // capability as an ordinary function and restore its calls on the
+    // response path. Only the native client-executed shape enables the relay;
+    // an unrelated function named `tool_search` never does. When such a plain
+    // function already exists, use a deterministic alias so neither call can
+    // hijack the other.
     if (tool?.type === "tool_search") {
       changed = true;
+      if (bridgeToolSearch && tool.execution === "client" && !toolSearchRelay) {
+        const parameters =
+          tool.parameters === undefined ? undefined : providerToolSchema(tool.parameters);
+        const description = providerToolSearchDescription(tool.description, toolSearchName);
+        flattened.push({
+          type: "function",
+          name: toolSearchName,
+          ...(description === undefined ? {} : { description }),
+          ...(parameters === undefined ? {} : { parameters }),
+        });
+        toolSearchRelay = { providerName: toolSearchName };
+      }
       continue;
     }
     if (tool?.type === "namespace" && Array.isArray(tool.tools)) {
@@ -166,14 +235,7 @@ export function flattenNamespaceTools(tools) {
         // never touches automations still dies on its first message. Normalize
         // only the provider-facing copy; `inputSchema` stays exactly as the
         // client sent it.
-        const clientSchema = fn.parameters ?? fn.inputSchema;
-        const parameters =
-          clientSchema === undefined ? undefined : providerToolSchema(clientSchema);
-        flattened.push({
-          ...fn,
-          name: `${tool.name}${NAMESPACE_DELIMITER}${fn.name}`,
-          ...(parameters === undefined ? {} : { parameters }),
-        });
+        flattened.push(flattenNamespaceChild(tool.name, fn));
         names.add(fn.name);
         if (tool.name === "collaboration" && fn.name === "spawn_agent") {
           schemaStringValues(fn.inputSchema?.properties?.model, spawnAgentModels);
@@ -198,7 +260,198 @@ export function flattenNamespaceTools(tools) {
     flattened.push(repaired);
   }
   if (spawnAgentModels.size > 0) SPAWN_AGENT_MODELS.set(namespaces, spawnAgentModels);
+  if (toolSearchRelay) TOOL_SEARCH_RELAYS.set(namespaces, toolSearchRelay);
   return { tools: flattened, flattened: changed, namespaces };
+}
+
+function plainObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : undefined;
+}
+
+function validToolSearchHistoryArguments(value) {
+  const argumentsObject = plainObject(value);
+  if (!argumentsObject || typeof argumentsObject.query !== "string") return false;
+  if (!argumentsObject.query.trim()) return false;
+  const { limit } = argumentsObject;
+  return limit === undefined || (Number.isInteger(limit) && limit > 0);
+}
+
+function discoveredProviderTools(toolSpecs) {
+  if (!Array.isArray(toolSpecs)) return [];
+  const discovered = [];
+  for (const tool of toolSpecs) {
+    if (tool?.type === "namespace" && typeof tool.name === "string" && Array.isArray(tool.tools)) {
+      for (const fn of tool.tools) {
+        if (fn?.type !== "function" || !fn.name) continue;
+        discovered.push({
+          tool: flattenNamespaceChild(tool.name, fn),
+          native: { namespace: tool.name, name: fn.name },
+        });
+      }
+      continue;
+    }
+    if (tool?.type !== "function" || !providerFunctionName(tool)) continue;
+    discovered.push({ tool: repairToolSchemaRoot(tool) });
+  }
+  return discovered;
+}
+
+function addDiscoveredNamespace(namespaces, native) {
+  if (!native) return;
+  let names = namespaces.get(native.namespace);
+  if (!names) {
+    names = new Set();
+    namespaces.set(native.namespace, names);
+  }
+  names.add(native.name);
+}
+
+// A native tool_search output changes what the model may call on the next
+// turn. The Responses API understands that special history item directly;
+// LiteLLM's chat-completions bridge does not. Translate matched call/output
+// pairs into ordinary function history and add the returned definitions to
+// this request's provider-facing tool list. Live top-level schemas win on a
+// name collision. Native items that do not form one unique, ordered,
+// well-formed pair are dropped: a chat-completions provider cannot consume
+// them, and forwarding one would make the transcript promise unavailable
+// tools.
+export function flattenToolSearchHistory(input, tools, namespaces) {
+  const relay = TOOL_SEARCH_RELAYS.get(namespaces);
+  if (!Array.isArray(input)) {
+    return { input, tools, flattened: false };
+  }
+  if (!Array.isArray(tools)) {
+    const routedInput = input.filter(
+      (item) => item?.type !== "tool_search_call" && item?.type !== "tool_search_output",
+    );
+    return {
+      input: routedInput.length === input.length ? input : routedInput,
+      tools,
+      flattened: routedInput.length !== input.length,
+    };
+  }
+
+  const callsById = new Map();
+  const invalidIds = new Set();
+  let nativeItems = 0;
+  // Pair in one forward walk. Outputs may follow several parallel calls, but
+  // they may never reach backwards past an orphan, duplicate, or malformed
+  // item with the same id. Records are materialized only after the walk, so a
+  // duplicate discovered late invalidates the entire id before any tool can be
+  // added to the provider request.
+  for (let index = 0; index < input.length; index += 1) {
+    const item = input[index];
+    const isCall = item?.type === "tool_search_call";
+    const isOutput = item?.type === "tool_search_output";
+    if (!isCall && !isOutput) continue;
+    nativeItems += 1;
+
+    const id = typeof item.call_id === "string" && item.call_id ? item.call_id : undefined;
+    if (!id) continue;
+    if (invalidIds.has(id)) continue;
+
+    if (isCall) {
+      const valid =
+        item.execution === "client" && validToolSearchHistoryArguments(item.arguments);
+      if (!valid || callsById.has(id)) {
+        callsById.delete(id);
+        invalidIds.add(id);
+        continue;
+      }
+      callsById.set(id, { call: item, callIndex: index });
+      continue;
+    }
+
+    const call = callsById.get(id);
+    const valid =
+      item.execution === "client" &&
+      item.status === "completed" &&
+      Array.isArray(item.tools);
+    if (!valid || !call || call.output) {
+      callsById.delete(id);
+      invalidIds.add(id);
+      continue;
+    }
+    call.output = item;
+    call.outputIndex = index;
+  }
+
+  if (nativeItems === 0) return { input, tools, flattened: false };
+
+  const callsByIndex = new Map();
+  const outputsByIndex = new Map();
+  if (relay) {
+    for (const [id, record] of callsById) {
+      if (!record.output || invalidIds.has(id)) continue;
+      callsByIndex.set(record.callIndex, record);
+      outputsByIndex.set(record.outputIndex, record);
+    }
+  }
+
+  const visibleNames = providerVisibleToolNames(tools);
+  let routedTools = tools;
+  const routedInput = [];
+  for (let index = 0; index < input.length; index += 1) {
+    const item = input[index];
+    if (item?.type === "tool_search_call") {
+      if (!callsByIndex.has(index)) continue;
+      const {
+        type: _type,
+        execution: _execution,
+        status: _status,
+        arguments: searchArguments,
+        ...rest
+      } = item;
+      routedInput.push({
+        ...rest,
+        type: "function_call",
+        name: relay.providerName,
+        arguments: JSON.stringify(searchArguments),
+      });
+      continue;
+    }
+
+    if (item?.type !== "tool_search_output") {
+      routedInput.push(item);
+      continue;
+    }
+    if (!outputsByIndex.has(index)) continue;
+
+    const accepted = [];
+    for (const candidate of discoveredProviderTools(item.tools)) {
+      const name = providerFunctionName(candidate.tool);
+      if (!name || visibleNames.has(name)) continue;
+      visibleNames.add(name);
+      accepted.push(candidate.tool);
+      addDiscoveredNamespace(namespaces, candidate.native);
+    }
+    // Keep the live-name set across outputs. The first valid discovery wins;
+    // later outputs omit a duplicate from both their result and the request's
+    // tool list instead of advertising a schema that cannot take precedence.
+    if (accepted.length) {
+      if (routedTools === tools) routedTools = [...tools];
+      routedTools.push(...accepted);
+    }
+
+    const {
+      type: _type,
+      execution: _execution,
+      status: _status,
+      tools: _tools,
+      ...rest
+    } = item;
+    routedInput.push({
+      ...rest,
+      type: "function_call_output",
+      output: JSON.stringify({ tools: accepted }),
+    });
+  }
+
+  return {
+    input: routedInput,
+    tools: routedTools,
+    flattened: true,
+  };
 }
 
 // Flattening only the tool list leaves the model reading two names for one
@@ -264,6 +517,7 @@ export function buildNamespaceLookups(namespaces) {
     flatToNative,
     bareToNamespaces,
     spawnAgentModels: SPAWN_AGENT_MODELS.get(namespaces),
+    toolSearch: TOOL_SEARCH_RELAYS.get(namespaces),
   };
 }
 
@@ -297,8 +551,60 @@ function rewriteFunctionCallArguments(item) {
   return { ...item, arguments: argumentsText };
 }
 
-function rewriteNamespaceFunctionCallItem(item, lookups, sessionModel) {
+function toolSearchArguments(value, allowPlaceholder) {
+  if (plainObject(value)) return value;
+  if (typeof value !== "string") return undefined;
+  if (allowPlaceholder && value.trim() === "") return {};
+  try {
+    return plainObject(JSON.parse(value));
+  } catch {
+    return undefined;
+  }
+}
+
+function rewriteToolSearchFunctionCallItem(item, lookups, allowPlaceholder) {
+  const relay = lookups.toolSearch;
+  if (
+    !relay ||
+    item?.type !== "function_call" ||
+    item.name !== relay.providerName ||
+    item.namespace !== undefined ||
+    typeof item.call_id !== "string" ||
+    !item.call_id
+  ) {
+    return undefined;
+  }
+  const argumentsObject = toolSearchArguments(item.arguments, allowPlaceholder);
+  if (!argumentsObject) return undefined;
+  const {
+    type: _type,
+    name: _name,
+    namespace: _namespace,
+    arguments: _arguments,
+    encrypted_function_args: _encryptedFunctionArgs,
+    ...rest
+  } = item;
+  return {
+    ...rest,
+    type: "tool_search_call",
+    execution: "client",
+    arguments: argumentsObject,
+  };
+}
+
+function rewriteNamespaceFunctionCallItem(
+  item,
+  lookups,
+  sessionModel,
+  { allowIncompleteToolSearch = false } = {},
+) {
   if (!item || item.type !== "function_call") return undefined;
+  const toolSearch = rewriteToolSearchFunctionCallItem(
+    item,
+    lookups,
+    allowIncompleteToolSearch,
+  );
+  if (toolSearch) return toolSearch;
   let rewritten = item;
   const resolved = lookups.flatToNative.get(item.name);
   if (resolved) {
@@ -324,7 +630,9 @@ function rewriteNamespaceFunctionCallItem(item, lookups, sessionModel) {
 }
 
 export function rewriteNamespaceFunctionCall(event, lookups, sessionModel) {
-  const item = rewriteNamespaceFunctionCallItem(event?.item, lookups, sessionModel);
+  const item = rewriteNamespaceFunctionCallItem(event?.item, lookups, sessionModel, {
+    allowIncompleteToolSearch: event?.type === "response.output_item.added",
+  });
   return item ? { ...event, item } : undefined;
 }
 

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -56,6 +56,7 @@ import {
   NamespaceToolCallTransform,
   flattenNamespacedHistory,
   flattenNamespaceTools,
+  flattenToolSearchHistory,
   repairToolSchemaRoots,
 } from "./namespace-relay.mjs";
 import { collaborationToolAvailable, pendingInterruptTargets } from "./subagent-completion.mjs";
@@ -1842,6 +1843,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   // tool-call message.
   carryReasoningThroughInput(input);
   const provider = providerForModel(route);
+  const chatCompletionsProvider = provider?.protocol !== "openai-responses";
   let tools = payload.tools;
   // LiteLLM's Responses -> Chat Completions bridge drops namespace tools, which
   // is how the client ships the collaboration runtime, the app toolset
@@ -1849,7 +1851,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   // peekaboo, github, ...). Chat-completions providers need every namespace
   // flattened into ordinary functions; the response transform maps calls back
   // to the client's native namespace shape.
-  if (provider?.protocol !== "openai-responses") {
+  if (chatCompletionsProvider) {
     // Relay the app's full native toolset (threads, automations, app
     // navigation) to the provider. The client registers these tools with
     // deferLoading and executes the calls natively, but only sends a reduced
@@ -1861,9 +1863,9 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     if (merged.merged) tools = merged.tools;
     const flattened = flattenNamespaceTools(tools);
     namespacesFlattened = flattened.flattened;
+    flattenedNamespaces = flattened.namespaces;
     if (namespacesFlattened) {
       tools = flattened.tools;
-      flattenedNamespaces = flattened.namespaces;
     }
   } else {
     // Responses-native providers keep the namespace tools untouched, so nothing
@@ -1871,7 +1873,9 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     // because the response transform reads the exact spawn_agent model enum off
     // it to drop an invented or stale optional override before Codex validates
     // the call.
-    flattenedNamespaces = flattenNamespaceTools(tools).namespaces;
+    flattenedNamespaces = flattenNamespaceTools(tools, {
+      bridgeToolSearch: false,
+    }).namespaces;
     // Keeping the namespace shape is not the same as keeping a root the
     // upstream rejects. `opencode-go-responses/gpt-5.6-luna` 400s a
     // `type: ["object","null"]` parameter root while accepting the same request
@@ -1880,6 +1884,15 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     tools = repairToolSchemaRoots(tools);
   }
   let routedInput = input;
+  if (chatCompletionsProvider) {
+    const searchHistory = flattenToolSearchHistory(
+      routedInput,
+      tools,
+      flattenedNamespaces,
+    );
+    routedInput = searchHistory.input;
+    tools = searchHistory.tools;
+  }
   // The stored call history must use the same tool names as the tool list, or
   // the model copies the bare names out of its own transcript.
   if (namespacesFlattened) {
@@ -2313,7 +2326,9 @@ async function handleResponses(request, response, requestUrl) {
       // SF and other native multi-agent parents hit this path (model_provider
       // openai). They have the same Working-badge bug, so inventory the tools
       // and queue missing interrupt_agent closes the same way as routed turns.
-      flattenedNamespaces = flattenNamespaceTools(payload.tools).namespaces;
+      flattenedNamespaces = flattenNamespaceTools(payload.tools, {
+        bridgeToolSearch: false,
+      }).namespaces;
       pendingInterrupts = pendingInterruptTargets(native.input ?? payload.input, {
         namespaces: flattenedNamespaces,
       });

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -139,7 +139,20 @@ function routedRequestPayload(stream = true, model = "opencode-go/deepseek-v4-fl
       { type: "function_call_output", call_id: "call_hist", output: "{}" },
     ],
     tools: [
-      { type: "tool_search" },
+      {
+        type: "tool_search",
+        execution: "client",
+        description: "Search deferred tools.",
+        parameters: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+            limit: { type: "number" },
+          },
+          required: ["query"],
+          additionalProperties: false,
+        },
+      },
       { type: "function", name: "exec_command" },
       { type: "function", name: "view_image" },
       {
@@ -189,6 +202,86 @@ function routedRequestPayload(stream = true, model = "opencode-go/deepseek-v4-fl
       },
     ],
   };
+}
+
+function routedToolSearchHistoryPayload(
+  stream = true,
+  model = "opencode-go/deepseek-v4-flash",
+) {
+  const payload = routedRequestPayload(stream, model);
+  payload.tools.push({
+    type: "function",
+    name: "mcp__calendar__create_event",
+    description: "Current live schema.",
+    parameters: {
+      type: "object",
+      properties: { live: { type: "boolean" } },
+    },
+  });
+  payload.input.push(
+    {
+      type: "tool_search_call",
+      call_id: "search-history-1",
+      execution: "client",
+      arguments: { query: "calendar", limit: 2 },
+    },
+    {
+      type: "tool_search_call",
+      call_id: "search-history-2",
+      execution: "client",
+      arguments: { query: "mail", limit: 1 },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "search-history-1",
+      status: "completed",
+      execution: "client",
+      tools: [
+        {
+          type: "namespace",
+          name: "mcp__calendar",
+          description: "Calendar tools.",
+          tools: [
+            {
+              type: "function",
+              name: "create_event",
+              parameters: {
+                type: "object",
+                properties: { stale: { type: "string" } },
+              },
+            },
+            {
+              type: "function",
+              name: "delete_event",
+              parameters: {
+                type: "object",
+                properties: { id: { type: "string" } },
+                required: ["id"],
+                additionalProperties: false,
+              },
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "tool_search_output",
+      call_id: "search-history-2",
+      status: "completed",
+      execution: "client",
+      tools: [
+        {
+          type: "function",
+          name: "list_messages",
+          parameters: {
+            type: "object",
+            properties: { query: { type: "string" } },
+          },
+        },
+      ],
+    },
+  );
+  return payload;
 }
 
 function sseEvent(event) {
@@ -274,6 +367,15 @@ function gatewaySseBody() {
         arguments: "{}",
       },
     }),
+    sseEvent({
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        name: "tool_search",
+        call_id: "call_search",
+        arguments: JSON.stringify({ query: "calendar", limit: 2 }),
+      },
+    }),
     sseEvent({ type: "response.completed" }),
     "data: [DONE]\n\n",
   ].join("");
@@ -322,6 +424,12 @@ function gatewayJsonBody() {
         call_id: "call_exec",
         arguments: "{}",
       },
+      {
+        type: "function_call",
+        name: "tool_search",
+        call_id: "call_search",
+        arguments: JSON.stringify({ query: "calendar", limit: 2 }),
+      },
     ],
   };
 }
@@ -358,8 +466,8 @@ function responsesProviderJsonBody() {
   };
 }
 
-function functionCallsFromSse(body) {
-  const calls = new Map();
+function responseItemsFromSse(body) {
+  const items = [];
   for (const line of body.split(/\r?\n/)) {
     if (!line.startsWith("data:")) continue;
     const data = line.slice(5).trimStart();
@@ -370,7 +478,14 @@ function functionCallsFromSse(body) {
     } catch {
       continue;
     }
-    const item = event?.item;
+    if (event?.item) items.push(event.item);
+  }
+  return items;
+}
+
+function functionCallsFromSse(body) {
+  const calls = new Map();
+  for (const item of responseItemsFromSse(body)) {
     if (item?.type === "function_call") calls.set(item.call_id, item);
   }
   return calls;
@@ -382,6 +497,7 @@ async function scenario(
     model = "opencode-go/deepseek-v4-flash",
     sseBody = gatewaySseBody,
     jsonBody = gatewayJsonBody,
+    requestPayload = routedRequestPayload,
   } = {},
 ) {
   const gatewayBodies = [];
@@ -417,7 +533,7 @@ async function scenario(
         Authorization: "Bearer CODEX_CALLER_SECRET",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(routedRequestPayload(stream, model)),
+      body: JSON.stringify(requestPayload(stream, model)),
     });
     assert.equal(response.status, 200, `router status ${response.status}`);
     const clientBody = await response.text();
@@ -448,6 +564,7 @@ test("routed request flattens every namespace to the gateway and restores calls 
   assert.ok(names.includes("codex_app__create_thread"), "merged codex_app tool flattened");
   assert.ok(names.includes("mcp__node_repl__js"), "node_repl js flattened");
   assert.ok(names.includes("mcp__node_repl__js_reset"), "node_repl js_reset flattened");
+  assert.ok(names.includes("tool_search"), "native tool_search exposed as a function");
   assert.ok(
     names.includes("mcp__codex_apps__github__fetch_issue"),
     "nested-namespace MCP tool flattened",
@@ -459,8 +576,11 @@ test("routed request flattens every namespace to the gateway and restores calls 
   );
   assert.ok(
     outgoing.tools.every((tool) => tool?.type !== "tool_search"),
-    "deferred tool search does not reach a function-only provider",
+    "native deferred-search controls do not reach a function-only provider",
   );
+  const toolSearch = outgoing.tools.find((tool) => tool.name === "tool_search");
+  assert.equal(toolSearch.type, "function");
+  assert.deepEqual(toolSearch.parameters.required, ["query"]);
   // The merged codex_app tool definitions keep their schema.
   const createThread = outgoing.tools.find((tool) => tool.name === "codex_app__create_thread");
   assert.ok(createThread?.inputSchema, "create_thread schema survives the relay");
@@ -520,6 +640,15 @@ test("routed request flattens every namespace to the gateway and restores calls 
   // Ordinary calls pass through untouched -- no namespace invented.
   assert.equal(calls.get("call_exec").name, "exec_command");
   assert.equal(calls.get("call_exec").namespace, undefined);
+  const searchCall = responseItemsFromSse(first.clientBody).find(
+    (item) => item.call_id === "call_search",
+  );
+  assert.deepEqual(searchCall, {
+    type: "tool_search_call",
+    call_id: "call_search",
+    execution: "client",
+    arguments: { query: "calendar", limit: 2 },
+  });
   // The router never executed any app tool: the gateway saw exactly one
   // request and the client saw exactly the relayed calls.
   assert.equal(first.gatewayBodies.length, 1);
@@ -567,6 +696,103 @@ test("non-streaming routed responses restore namespace calls before client dispa
   );
   assert.equal(client.output[5].name, "exec_command");
   assert.equal(client.output[5].namespace, undefined);
+  assert.deepEqual(client.output[6], {
+    type: "tool_search_call",
+    call_id: "call_search",
+    execution: "client",
+    arguments: { query: "calendar", limit: 2 },
+  });
+});
+
+test("routed tool_search history declares discovered tools and restores their calls", async () => {
+  const searchedCall = {
+    type: "function_call",
+    name: "mcp__calendar__delete_event",
+    call_id: "delete-1",
+    arguments: JSON.stringify({ id: "evt-1" }),
+  };
+  const options = {
+    requestPayload: routedToolSearchHistoryPayload,
+    sseBody: () =>
+      [
+        sseEvent({ type: "response.output_item.done", item: searchedCall }),
+        sseEvent({
+          type: "response.completed",
+          response: { id: "resp-search", output: [searchedCall] },
+        }),
+        "data: [DONE]\n\n",
+      ].join(""),
+    jsonBody: () => ({ id: "resp-search-json", output: [searchedCall] }),
+  };
+
+  for (const stream of [true, false]) {
+    const result = await scenario(stream, options);
+    const outgoing = result.gatewayBodies[0];
+    const historyCall = outgoing.input.find(
+      (item) => item.call_id === "search-history-1" && item.type === "function_call",
+    );
+    assert.deepEqual(historyCall, {
+      type: "function_call",
+      name: "tool_search",
+      call_id: "search-history-1",
+      arguments: '{"query":"calendar","limit":2}',
+    });
+    assert.deepEqual(
+      outgoing.input.find(
+        (item) => item.call_id === "search-history-2" && item.type === "function_call",
+      ),
+      {
+        type: "function_call",
+        name: "tool_search",
+        call_id: "search-history-2",
+        arguments: '{"query":"mail","limit":1}',
+      },
+    );
+    const historyOutput = outgoing.input.find(
+      (item) =>
+        item.call_id === "search-history-1" && item.type === "function_call_output",
+    );
+    assert.deepEqual(
+      JSON.parse(historyOutput.output).tools.map((tool) => tool.name),
+      ["mcp__calendar__delete_event"],
+    );
+    const secondHistoryOutput = outgoing.input.find(
+      (item) =>
+        item.call_id === "search-history-2" && item.type === "function_call_output",
+    );
+    assert.deepEqual(
+      JSON.parse(secondHistoryOutput.output).tools.map((tool) => tool.name),
+      ["list_messages"],
+    );
+    assert.equal(
+      outgoing.input.some(
+        (item) => item.type === "tool_search_call" || item.type === "tool_search_output",
+      ),
+      false,
+      "batched native search history never leaks to a chat-completions provider",
+    );
+    assert.equal(
+      outgoing.tools.filter((tool) => tool.name === "mcp__calendar__create_event").length,
+      1,
+      "live top-level schemas take precedence over searched history",
+    );
+    assert.ok(
+      outgoing.tools.some((tool) => tool.name === "mcp__calendar__delete_event"),
+      "the searched tool is declared to the chat-completions provider",
+    );
+    assert.ok(outgoing.tools.some((tool) => tool.name === "list_messages"));
+
+    const clientCall = stream
+      ? responseItemsFromSse(result.clientBody).find((item) => item.call_id === "delete-1")
+      : JSON.parse(result.clientBody).output[0];
+    assert.deepEqual(clientCall, {
+      type: "function_call",
+      name: "delete_event",
+      namespace: "mcp__calendar",
+      call_id: "delete-1",
+      arguments: '{"id":"evt-1"}',
+    });
+  }
 });
 
 test("Responses-native routed providers inherit the model on fresh local thread calls", async () => {
@@ -574,12 +800,26 @@ test("Responses-native routed providers inherit the model on fresh local thread 
     model: "opencode-go-responses/gpt-5.6-luna",
     sseBody: responsesProviderSseBody,
     jsonBody: responsesProviderJsonBody,
+    requestPayload: routedToolSearchHistoryPayload,
   };
   const streamed = await scenario(true, options);
   assert.equal(streamed.gatewayBodies[0].model, "opencode-go-responses-gpt-5-6-luna");
   assert.ok(
     streamed.gatewayBodies[0].tools.some((tool) => tool?.type === "namespace"),
     "Responses-native tools stay namespaced",
+  );
+  assert.ok(
+    streamed.gatewayBodies[0].tools.some((tool) => tool?.type === "tool_search"),
+    "Responses-native tool_search stays native",
+  );
+  assert.ok(
+    streamed.gatewayBodies[0].input.some((item) => item?.type === "tool_search_call"),
+    "Responses-native search history is not translated",
+  );
+  assert.equal(
+    streamed.gatewayBodies[0].tools.some((tool) => tool?.name === "list_messages"),
+    false,
+    "native tool_search_output history remains authoritative without top-level injection",
   );
   const streamedCall = functionCallsFromSse(streamed.clientBody).get("call_native_thread");
   assert.deepEqual(JSON.parse(streamedCall.arguments), {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -7,6 +7,7 @@ import {
   buildNamespaceLookups,
   flattenNamespacedHistory,
   flattenNamespaceTools,
+  flattenToolSearchHistory,
   rewriteNamespaceFunctionCall,
   rewriteNamespaceResponsePayload,
   repairToolSchemaRoots,
@@ -79,6 +80,23 @@ function clientRoutedTools() {
   ];
 }
 
+function clientToolSearchControl() {
+  return {
+    type: "tool_search",
+    execution: "client",
+    description: "Search deferred tools.",
+    parameters: {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        limit: { type: "number" },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  };
+}
+
 test("flattenNamespaceTools flattens every namespace, including MCP ones", () => {
   const { tools, flattened, namespaces } = flattenNamespaceTools(clientRoutedTools());
   assert.equal(flattened, true);
@@ -145,9 +163,9 @@ test("flattenNamespaceTools preserves a supplied provider parameter schema", () 
   assert.deepEqual(tools[0].inputSchema, inputSchema);
 });
 
-test("flattenNamespaceTools drops the deferred-loading control after expanding namespaces", () => {
+test("flattenNamespaceTools exposes client tool_search as an ordinary provider function", () => {
   const { tools, flattened } = flattenNamespaceTools([
-    { type: "tool_search" },
+    clientToolSearchControl(),
     {
       type: "namespace",
       name: "mcp__example",
@@ -155,7 +173,66 @@ test("flattenNamespaceTools drops the deferred-loading control after expanding n
     },
   ]);
   assert.equal(flattened, true);
-  assert.deepEqual(tools, [{ type: "function", name: "mcp__example__read" }]);
+  assert.deepEqual(tools, [
+    {
+      type: "function",
+      name: "tool_search",
+      description: "Search deferred tools.",
+      parameters: clientToolSearchControl().parameters,
+    },
+    { type: "function", name: "mcp__example__read" },
+  ]);
+});
+
+test("tool_search bridge uses a collision-safe request-local name", () => {
+  const { tools, namespaces } = flattenNamespaceTools([
+    {
+      type: "function",
+      name: "tool_search",
+      description: "An unrelated application function.",
+      parameters: { type: "object" },
+    },
+    clientToolSearchControl(),
+  ]);
+  assert.deepEqual(
+    tools.map((tool) => tool.name),
+    ["tool_search", "codex_tool_search_1"],
+  );
+  assert.match(tools[1].description, /call `codex_tool_search_1`/);
+  assert.match(tools[1].description, /`tool_search` is a separate ordinary function/);
+
+  const lookups = buildNamespaceLookups(namespaces);
+  const bridged = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        {
+          type: "function_call",
+          name: "codex_tool_search_1",
+          call_id: "search-1",
+          arguments: '{"query":"calendar"}',
+        },
+        {
+          type: "function_call",
+          name: "tool_search",
+          call_id: "ordinary-1",
+          arguments: "{}",
+        },
+      ],
+    },
+    lookups,
+  );
+  assert.deepEqual(bridged.output[0], {
+    type: "tool_search_call",
+    call_id: "search-1",
+    execution: "client",
+    arguments: { query: "calendar" },
+  });
+  assert.deepEqual(bridged.output[1], {
+    type: "function_call",
+    name: "tool_search",
+    call_id: "ordinary-1",
+    arguments: "{}",
+  });
 });
 
 test("flattenNamespaceTools handles non-array and empty input", () => {
@@ -250,6 +327,316 @@ test("stored namespaced calls are renamed to match the flattened tools", () => {
   assert.deepEqual(input[5], { type: "function_call_output", call_id: "call_1", output: "{}" });
 });
 
+test("matched tool_search history declares discovered tools and expands namespace lookup", () => {
+  const flattened = flattenNamespaceTools([
+    clientToolSearchControl(),
+    {
+      type: "function",
+      name: "mcp__calendar__create_event",
+      description: "Live schema wins.",
+      parameters: { type: "object", properties: { live: { type: "boolean" } } },
+    },
+  ]);
+  const history = [
+    {
+      type: "tool_search_call",
+      call_id: "search-1",
+      execution: "client",
+      arguments: { query: "calendar", limit: 2 },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "search-1",
+      status: "completed",
+      execution: "client",
+      tools: [
+        {
+          type: "namespace",
+          name: "mcp__calendar",
+          tools: [
+            {
+              type: "function",
+              name: "create_event",
+              parameters: { type: "object", properties: { stale: { type: "string" } } },
+            },
+            {
+              type: "function",
+              name: "delete_event",
+              parameters: {
+                type: "object",
+                properties: { id: { type: "string" } },
+                required: ["id"],
+              },
+            },
+            { type: "custom", name: "freeform_is_not_a_function" },
+          ],
+        },
+        {
+          type: "function",
+          name: "weather",
+          parameters: { type: "object", properties: { city: { type: "string" } } },
+        },
+      ],
+    },
+    {
+      type: "tool_search_output",
+      call_id: "orphan",
+      status: "completed",
+      execution: "client",
+      tools: [{ type: "function", name: "must_not_be_injected" }],
+    },
+  ];
+
+  const routed = flattenToolSearchHistory(history, flattened.tools, flattened.namespaces);
+  assert.deepEqual(routed.input[0], {
+    type: "function_call",
+    name: "tool_search",
+    call_id: "search-1",
+    arguments: '{"query":"calendar","limit":2}',
+  });
+  const output = JSON.parse(routed.input[1].output);
+  assert.equal(routed.input[1].type, "function_call_output");
+  assert.deepEqual(
+    output.tools.map((tool) => tool.name),
+    ["mcp__calendar__delete_event", "weather"],
+  );
+  assert.equal(routed.input.length, 2, "orphan native history is dropped, not forwarded");
+  assert.deepEqual(
+    routed.tools.map((tool) => tool.name),
+    [
+      "tool_search",
+      "mcp__calendar__create_event",
+      "mcp__calendar__delete_event",
+      "weather",
+    ],
+  );
+  assert.equal(
+    routed.tools.filter((tool) => tool.name === "mcp__calendar__create_event").length,
+    1,
+    "the current live schema wins over searched history",
+  );
+  assert.equal(
+    routed.tools.some((tool) => tool.name === "freeform_is_not_a_function"),
+    false,
+  );
+  assert.equal(routed.tools.some((tool) => tool.name === "must_not_be_injected"), false);
+
+  const restored = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        {
+          type: "function_call",
+          name: "mcp__calendar__delete_event",
+          call_id: "delete-1",
+          arguments: '{"id":"evt-1"}',
+        },
+      ],
+    },
+    buildNamespaceLookups(flattened.namespaces),
+  );
+  assert.deepEqual(restored.output[0], {
+    type: "function_call",
+    name: "delete_event",
+    namespace: "mcp__calendar",
+    call_id: "delete-1",
+    arguments: '{"id":"evt-1"}',
+  });
+});
+
+test("parallel tool_search calls pair by call_id when all outputs follow the calls", () => {
+  const flattened = flattenNamespaceTools([clientToolSearchControl()]);
+  const history = [
+    {
+      type: "tool_search_call",
+      call_id: "search-mail",
+      execution: "client",
+      arguments: { query: "mail" },
+    },
+    {
+      type: "tool_search_call",
+      call_id: "search-calendar",
+      execution: "client",
+      arguments: { query: "calendar" },
+    },
+    { type: "message", role: "assistant", content: [] },
+    {
+      type: "tool_search_output",
+      call_id: "search-mail",
+      status: "completed",
+      execution: "client",
+      tools: [{ type: "function", name: "list_messages" }],
+    },
+    {
+      type: "tool_search_output",
+      call_id: "search-calendar",
+      status: "completed",
+      execution: "client",
+      tools: [{ type: "function", name: "list_events" }],
+    },
+  ];
+  const routed = flattenToolSearchHistory(history, flattened.tools, flattened.namespaces);
+  assert.deepEqual(
+    routed.input.map((item) => [item.type, item.call_id]),
+    [
+      ["function_call", "search-mail"],
+      ["function_call", "search-calendar"],
+      ["message", undefined],
+      ["function_call_output", "search-mail"],
+      ["function_call_output", "search-calendar"],
+    ],
+  );
+  assert.deepEqual(
+    routed.tools.map((tool) => tool.name),
+    ["tool_search", "list_messages", "list_events"],
+  );
+  assert.equal(
+    routed.input.some(
+      (item) => item.type === "tool_search_call" || item.type === "tool_search_output",
+    ),
+    false,
+  );
+  assert.equal(routed.flattened, true);
+});
+
+test("orphaned, malformed, and no-control native tool_search history is dropped", () => {
+  const flattened = flattenNamespaceTools([clientToolSearchControl()]);
+  const marker = { type: "message", role: "assistant", content: [] };
+  const history = [
+    marker,
+    {
+      type: "tool_search_call",
+      call_id: "call-only",
+      execution: "client",
+      arguments: { query: "lost output" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "output-only",
+      status: "completed",
+      execution: "client",
+      tools: [{ type: "function", name: "orphan_injection" }],
+    },
+    {
+      type: "tool_search_call",
+      call_id: "malformed",
+      execution: "client",
+      arguments: "not-an-object",
+    },
+    {
+      type: "tool_search_output",
+      call_id: "malformed",
+      status: "completed",
+      execution: "client",
+      tools: [{ type: "function", name: "malformed_injection" }],
+    },
+  ];
+  const routed = flattenToolSearchHistory(history, flattened.tools, flattened.namespaces);
+  assert.deepEqual(routed.input, [marker]);
+  assert.equal(routed.tools, flattened.tools);
+  assert.equal(routed.flattened, true);
+
+  const withoutControl = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "mcp__example",
+      tools: [{ type: "function", name: "read" }],
+    },
+  ]);
+  const noControl = flattenToolSearchHistory(
+    [
+      history[1],
+      {
+        type: "tool_search_output",
+        call_id: "call-only",
+        status: "completed",
+        execution: "client",
+        tools: [{ type: "function", name: "no_control_injection" }],
+      },
+      marker,
+    ],
+    withoutControl.tools,
+    withoutControl.namespaces,
+  );
+  assert.deepEqual(noControl.input, [marker]);
+  assert.equal(noControl.tools, withoutControl.tools);
+});
+
+test("compacted tool_search history keeps an ordered pair without reviving tool schemas", () => {
+  const flattened = flattenNamespaceTools([clientToolSearchControl()]);
+  const history = [
+    {
+      type: "tool_search_call",
+      call_id: "compacted-search",
+      execution: "client",
+      arguments: { query: "calendar" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "compacted-search",
+      status: "completed",
+      execution: "client",
+      tools: [],
+    },
+  ];
+
+  const routed = flattenToolSearchHistory(history, flattened.tools, flattened.namespaces);
+  assert.deepEqual(
+    routed.input.map((item) => item.type),
+    ["function_call", "function_call_output"],
+  );
+  assert.deepEqual(JSON.parse(routed.input[1].output), { tools: [] });
+  assert.equal(routed.tools, flattened.tools);
+});
+
+test("duplicate ids, reversed order, and malicious outputs invalidate the whole id", () => {
+  const call = (call_id) => ({
+    type: "tool_search_call",
+    call_id,
+    execution: "client",
+    arguments: { query: call_id },
+  });
+  const output = (call_id, name, overrides = {}) => ({
+    type: "tool_search_output",
+    call_id,
+    status: "completed",
+    execution: "client",
+    tools: [{ type: "function", name }],
+    ...overrides,
+  });
+  const cases = [
+    [call("duplicate-call"), call("duplicate-call"), output("duplicate-call", "attack_a")],
+    [
+      call("duplicate-output"),
+      output("duplicate-output", "attack_b"),
+      output("duplicate-output", "attack_c"),
+    ],
+    [
+      output("reversed", "attack_d"),
+      call("reversed"),
+      output("reversed", "attack_e"),
+    ],
+    [call("bad-tools"), output("bad-tools", "attack_f", { tools: { name: "attack_f" } })],
+    [call("server-output"), output("server-output", "attack_g", { execution: "server" })],
+    [
+      { ...call("empty-query"), arguments: { query: "   " } },
+      output("empty-query", "attack_h"),
+    ],
+    [
+      { ...call("bad-limit"), arguments: { query: "mail", limit: 0 } },
+      output("bad-limit", "attack_i"),
+    ],
+    [call("missing-status"), output("missing-status", "attack_j", { status: undefined })],
+  ];
+
+  for (const history of cases) {
+    const flattened = flattenNamespaceTools([clientToolSearchControl()]);
+    const routed = flattenToolSearchHistory(history, flattened.tools, flattened.namespaces);
+    assert.deepEqual(routed.input, []);
+    assert.equal(routed.tools, flattened.tools);
+    assert.equal(routed.flattened, true);
+  }
+});
+
 test("history rename is idempotent and leaves other namespaces alone", () => {
   const { namespaces } = flattenNamespaceTools(clientRoutedTools());
   const alreadyFlat = {
@@ -337,6 +724,131 @@ test("response transform restores flattened calls to the native namespace shape"
   assert.match(output, /"name":"fetch_issue"/);
   assert.match(output, /"namespace":"mcp__codex_apps__github"/);
   assert.doesNotMatch(output, /collaboration__spawn_agent|codex_app__create_thread|mcp__node_repl__js/);
+});
+
+test("tool_search response bridge covers SSE added, delta, done, and completed", async () => {
+  const { namespaces } = flattenNamespaceTools([clientToolSearchControl()]);
+  const events = [
+    {
+      type: "response.output_item.added",
+      item: {
+        type: "function_call",
+        name: "tool_search",
+        call_id: "search-1",
+        arguments: "",
+      },
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: "fc_search_1",
+      call_id: "search-1",
+      delta: '{"query":"cal',
+    },
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        name: "tool_search",
+        call_id: "search-1",
+        arguments: '{"query":"calendar","limit":2.0}',
+      },
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp-1",
+        output: [
+          {
+            type: "function_call",
+            name: "tool_search",
+            call_id: "search-1",
+            arguments: '{"query":"calendar","limit":2}',
+          },
+        ],
+      },
+    },
+  ].map((event) => `data: ${JSON.stringify(event)}\n\n`);
+  const output = await collect(
+    Readable.from(events).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+    ),
+  );
+  const parsed = output
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => JSON.parse(line.slice(5).trimStart()));
+
+  assert.deepEqual(parsed[0].item, {
+    type: "tool_search_call",
+    call_id: "search-1",
+    execution: "client",
+    arguments: {},
+  });
+  assert.deepEqual(parsed[1], {
+    type: "response.function_call_arguments.delta",
+    item_id: "fc_search_1",
+    call_id: "search-1",
+    delta: '{"query":"cal',
+  });
+  assert.deepEqual(parsed[2].item, {
+    type: "tool_search_call",
+    call_id: "search-1",
+    execution: "client",
+    arguments: { query: "calendar", limit: 2 },
+  });
+  assert.deepEqual(parsed[3].response.output[0], {
+    type: "tool_search_call",
+    call_id: "search-1",
+    execution: "client",
+    arguments: { query: "calendar", limit: 2 },
+  });
+});
+
+test("tool_search response bridge fails closed without native control or valid arguments", () => {
+  const ordinary = flattenNamespaceTools([
+    { type: "function", name: "tool_search", parameters: { type: "object" } },
+  ]);
+  const ordinaryPayload = {
+    output: [
+      {
+        type: "function_call",
+        name: "tool_search",
+        call_id: "ordinary-1",
+        arguments: '{"query":"calendar"}',
+      },
+    ],
+  };
+  assert.equal(
+    rewriteNamespaceResponsePayload(
+      ordinaryPayload,
+      buildNamespaceLookups(ordinary.namespaces),
+    ),
+    undefined,
+  );
+
+  const bridged = flattenNamespaceTools([clientToolSearchControl()]);
+  const malformed = {
+    output: [
+      {
+        type: "function_call",
+        name: "tool_search",
+        call_id: "bad-1",
+        arguments: "{not-json",
+      },
+      {
+        type: "function_call",
+        name: "tool_search",
+        arguments: '{"query":"missing call id"}',
+      },
+    ],
+  };
+  assert.equal(
+    rewriteNamespaceResponsePayload(
+      malformed,
+      buildNamespaceLookups(bridged.namespaces),
+    ),
+    undefined,
+  );
 });
 
 test("response transform restores namespace on unambiguous unprefixed calls", async () => {


### PR DESCRIPTION
## Summary

- Lower Codex client-executed native tool_search into a collision-safe ordinary function for routed chat-completions providers.
- Restore streamed and non-streamed provider calls to native tool_search_call items so the Codex client performs discovery and registration.
- Replay only adjacent, matching client call/output history; expose accepted discovered function schemas on the following routed request and extend the exact request-local namespace lookup.
- Keep Responses-native routes unchanged and fail closed on malformed history, server execution, custom/freeform tools, and discovered-name collisions.

## Why

Codex 0.146 registers deferred connector tools only after its native tool_search flow. Copying cached definitions into the request can make a model see a tool that the client still rejects as unsupported. This change preserves the client-owned discovery and execution boundary while adapting only the provider-facing wire shape.

Stable Codex contract references:

- Native tool declaration: https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/tools/src/tool_spec.rs#L18-L29
- Client tool_search handler: https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/core/src/tools/handlers/tool_search_spec.rs#L18-L76
- Native dispatch path: https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/core/src/tools/router.rs#L144-L162
- Follow-up history contract: https://github.com/openai/codex/blob/rust-v0.146.0/codex-rs/core/tests/suite/search_tool.rs#L745-L815

## Verification

- npm ci --ignore-scripts: 0 vulnerabilities
- node --test test/namespace-relay.test.mjs test/namespace-relay-routing.test.mjs: 35/35 passed
- npm run check: passed
- npm test on current main: 1,338 total; 1,326 passed; 12 skipped; 0 failed
- Independent read-only review: PASS after tightening replay to adjacent call/output pairs

The repository-gated real LiteLLM adapter integration and a quota-consuming live provider probe were not run. Mock-gateway coverage exercises routed SSE, non-streaming JSON, next-turn replay, discovered namespace dispatch, collision handling, and the Responses-native control path.

Disclosure: I maintain dsh-mcp-lens and am contributing here because the same deferred tool-discovery boundary affects routed DeepSeek Harness and Codex workflows. This patch does not add or depend on MCP Lens.

Fixes #252.