### PR TITLE
fix(custom): the free Qwen3.8 endpoint refuses the empty tool list compaction sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **Every compaction against the free Qwen3.8 endpoint failed on an empty tool
+  list.** Compaction disables tool use by sending `tools: []`, which every other
+  forwarder reads as "no tools" — this endpoint's vLLM build answers it with a
+  400 saying the array must not be empty and the field should be omitted
+  instead, and answers the tool choice sent alongside it with a second 400
+  saying `tools` must be set. The model carries a 262K window that auto-compacts
+  at 230K, so the failure was not an edge case: it was every long session. The
+  request profile now omits an empty list and then drops the tool choice that
+  strip leaves with nothing to choose from. The repair sits at the last hop
+  before this one endpoint, because an empty tool list stays the correct way to
+  disable tools everywhere else, and a real tool list still forwards untouched.
+
+  The entry is also renamed to **Qwen3.8-27-free-victor**, crediting `victor`,
+  who publishes the endpoint, in the name the picker shows rather than only in
+  the endpoint note.
+
 - **The GLM-5.3 1M entry routed to a model code Z.ai does not serve.** Shipping
   `glm-5.3[1m]` took the vendor's documented 1M suffix at its word, and the
   suffix answers `1214` on both the OpenAI-compatible and Anthropic endpoints --

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ because what it holds is whatever somebody put in it.
 
 | Model | Endpoint | Auth |
 | --- | --- | --- |
-| Qwen3.8 27B (Free) | `https://g9hnto0u7lvbu837.us-east-2.aws.endpoints.huggingface.cloud/v1` | none |
+| Qwen3.8-27-free-victor | `https://g9hnto0u7lvbu837.us-east-2.aws.endpoints.huggingface.cloud/v1` | none |
 
 That first model is a free community [Hugging Face Inference
 Endpoint](https://huggingface.co/spaces/victor/Qwen3.8-27B-free-endpoint) for

--- a/config/custom/qwen3.8-27b.json
+++ b/config/custom/qwen3.8-27b.json
@@ -12,8 +12,8 @@
         "note": "No API key is needed: this is a free community Hugging Face Inference Endpoint for Qwen3.8-27B, published by an individual rather than by Qwen or Hugging Face. Use at your own risk: it is shared, rate limited to roughly 30 requests per minute per IP, and its owner says it will be retired once launch interest fades."
       },
       "listed": true,
-      "displayName": "Qwen3.8 27B (Free)",
-      "description": "Qwen3.8-27B on a free, rate-limited community Hugging Face Inference Endpoint: 262K context, image input, tool calling, and a dialable thinking budget. Shared with everyone behind your IP, so expect 429s under load.",
+      "displayName": "Qwen3.8-27-free-victor",
+      "description": "Qwen3.8-27B on the free, rate-limited community Hugging Face Inference Endpoint published by victor: 262K context, image input, tool calling, and a dialable thinking budget. Shared with everyone behind your IP, so expect 429s under load.",
       "priority": 140,
       "defaultEffort": "medium",
       "reasoningLevels": [

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -526,6 +526,22 @@ function normalizeBody(buffer, contentType, route) {
     // and it folds onto `max` because that is the tier it is asking for.
     // Everything else passes through as the literal the endpoint accepts.
     if (payload.reasoning_effort === "ultra") payload.reasoning_effort = "max";
+    // The same build refuses two tool shapes Codex sends routinely, both
+    // measured live: an empty list answers "`tools` must not be an empty
+    // array. Either provide at least one tool or omit the field entirely",
+    // and a choice with nothing to choose from answers "When using
+    // `tool_choice`, `tools` must be set". `summarize()` in the router sends
+    // `tools: []` on every compaction, and this model auto-compacts at 230K of
+    // its 262K window, so left alone every compaction against it 400s. Strip
+    // the empty list first, then drop the tool choice that strip leaves
+    // dangling -- the order is what keeps the second rejection from replacing
+    // the first. The repair belongs at this last hop rather than in the
+    // compaction path because an empty tool list is legal on every other
+    // forwarder, and it is exactly how compaction disables tool use there.
+    if (Array.isArray(payload.tools) && payload.tools.length === 0) delete payload.tools;
+    if (!Array.isArray(payload.tools) || payload.tools.length === 0) {
+      delete payload.tool_choice;
+    }
   } else if (model.requestProfile === "minimax-m3") {
     // MiniMax uses its own thinking control on the OpenAI-compatible
     // Chat Completions endpoint instead of reasoning_effort.

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -2818,6 +2818,24 @@ function curatedQwen38EffortModel() {
   return { dir, file, gatewayModel: "openrouter-qwen-3-8-27b-effort" };
 }
 
+// One real tool, so a forced choice has something to choose from. The endpoint
+// rejects `tool_choice` sent on its own, so every request here that names a
+// choice names this list too.
+const QWEN38_TOOLS = [
+  {
+    type: "function",
+    function: {
+      name: "shell",
+      description: "Run a command.",
+      parameters: {
+        type: "object",
+        properties: { command: { type: "string" } },
+        required: ["command"],
+      },
+    },
+  },
+];
+
 test("API forwarder folds only the effort tier the free Qwen3.8 endpoint rejects", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {
@@ -2857,6 +2875,7 @@ test("API forwarder folds only the effort tier the free Qwen3.8 endpoint rejects
         body: JSON.stringify({
           model: curated.gatewayModel,
           reasoning_effort: sentEffort,
+          tools: QWEN38_TOOLS,
           tool_choice: "required",
           messages: [{ role: "user", content: "test" }],
         }),
@@ -2867,6 +2886,8 @@ test("API forwarder folds only the effort tier the free Qwen3.8 endpoint rejects
       // The endpoint answers a forced tool choice with a real tool call
       // (verified live), so the profile must not downgrade it -- the
       // compatibility probe and the subagent payload relay both depend on it.
+      // The choice travels with the tool it is forcing, because the endpoint
+      // rejects a tool_choice that has nothing to choose from.
       assert.equal(request.body.tool_choice, "required");
     }
 
@@ -2884,6 +2905,77 @@ test("API forwarder folds only the effort tier the free Qwen3.8 endpoint rejects
     });
     assert.equal(response.status, 200);
     assert.equal("reasoning_effort" in upstreamRequests.at(-1).body, false);
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+    rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
+// The same endpoint rejects an empty tool list ("`tools` must not be an empty
+// array ... or omit the field entirely") and a tool choice with no tools
+// ("When using `tool_choice`, `tools` must be set"), both measured live.
+// `summarize()` sends `tools: []` on every compaction and this model
+// auto-compacts well inside its window, so the pair arrives together and the
+// profile has to omit both fields rather than forward either.
+test("API forwarder omits the empty tool list the free Qwen3.8 endpoint rejects", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const curated = curatedQwen38EffortModel();
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    MODEL_ROUTER_USER_MODELS: curated.file,
+    OPENROUTER_API_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OPENROUTER_API_KEY: "TEST_OPENROUTER_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    // The compaction shape: an empty list plus the choice that goes with it.
+    // Both fields have to be gone, not one of them.
+    const compaction = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: curated.gatewayModel,
+        tools: [],
+        tool_choice: "none",
+        messages: [{ role: "user", content: "summarize" }],
+      }),
+    });
+    assert.equal(compaction.status, 200);
+    const compacted = upstreamRequests.at(-1).body;
+    assert.equal("tools" in compacted, false);
+    assert.equal("tool_choice" in compacted, false);
+
+    // A real tool list is the normal turn, and the strip must not touch it.
+    const turn = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: curated.gatewayModel,
+        tools: QWEN38_TOOLS,
+        tool_choice: "auto",
+        messages: [{ role: "user", content: "test" }],
+      }),
+    });
+    assert.equal(turn.status, 200);
+    const forwarded = upstreamRequests.at(-1).body;
+    assert.deepEqual(forwarded.tools, QWEN38_TOOLS);
+    assert.equal(forwarded.tool_choice, "auto");
   } finally {
     await stopChild(forwarder);
     await closeServer(upstream.server);


### PR DESCRIPTION
## The bug

`summarize()` disables tool use during compaction by sending `tools: []`, which every other forwarder reads as "no tools". The free Qwen3.8 community endpoint's vLLM build refuses it:

```
`tools` must not be an empty array. Either provide at least one tool or omit the field entirely. (parameter=tools)
```

and refuses the `tool_choice` sent beside it with a second 400:

```
When using `tool_choice`, `tools` must be set. (parameter=tool_choice)
```

`custom/qwen3.8-27b` auto-compacts at 230K of its 262K window, so **every long session against it failed** at the compaction.

## The fix

The `qwen38-community` request profile now omits an empty tool list, then drops the tool choice that strip leaves dangling. Order matters — otherwise the second rejection replaces the first.

It stays at the last hop before this one endpoint rather than in the compaction path, because an empty tool list is legal everywhere else and is exactly how compaction disables tool use there. A non-empty list forwards untouched.

The existing `ultra` → `max` effort fold is unchanged and still correct: `none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max` all return 200, `ultra` is the one rung the endpoint's enum omits.

## Also: credit the publisher

The endpoint is published by an individual, not by Qwen or Hugging Face. Renamed the entry to `Qwen3.8-27-free-victor` and credited victor in the description and the README table.

## Test plan

- [x] `node --test test/routing.test.mjs test/registry.test.mjs` — 83 pass, 0 fail
- [x] `npm test` — 1334 tests, 1322 pass, 0 fail, 12 pre-existing skips
- [x] `node scripts-check.mjs` — syntax checks passed
- [x] RED check: reverting only the `api-forwarder.mjs` change makes the new test fail
- [x] **Live end-to-end**, real forwarder against the real endpoint, no mocks:

| Payload | Before | After |
|---|---|---|
| compaction shape (`tools: []` + `tool_choice`) | **400** empty-array | **200** |
| normal turn (one real tool + `tool_choice: auto`) | 200 | 200 |

One pre-existing test was amended: the effort test drove `tool_choice: "required"` with no `tools` — a payload the live endpoint 400s — so it now carries a one-function tool fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXPWEJidiS8MxEtHTCZq5i
