### PR TITLE
fix(custom): the free Qwen3.8 endpoint refuses a system message that arrives late or twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **The free Qwen3.8 endpoint refused any conversation whose system message
+  arrived late or twice.** Its chat template answers those with a 400 reading
+  "System message must be at the beginning", and a real Codex session reaches
+  that shape routinely — a second system message, or one appended after the
+  conversation is already under way. Probing the live endpoint pinned the rule
+  to at most one `system` message sitting ahead of the first user, assistant, or
+  tool turn; the `developer` role is outside it entirely, so
+  `[developer, system, user]` is accepted and "the beginning" means before the
+  first turn rather than index 0. The request profile now coalesces the system
+  messages into one and places it ahead of the first turn, handling both plain
+  string content and content-parts arrays, and leaves developer messages exactly
+  where they are. A conversation the rule already allows is forwarded unchanged.
+  Hoisting is a compatibility repair with a real cost — instructions the caller
+  placed mid-conversation are read as opening context instead — accepted only
+  because the alternative from this endpoint is no answer at all.
+
 - **Every compaction against the free Qwen3.8 endpoint failed on an empty tool
   list.** Compaction disables tool use by sending `tools: []`, which every other
   forwarder reads as "no tools" — this endpoint's vLLM build answers it with a

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -320,6 +320,78 @@ function sanitizeChatToolHistory(messages, provider) {
     : repaired;
 }
 
+// The Qwen3.8 chat template counts a turn as one of these three roles. Probing
+// the live community endpoint with one-message-token requests measured the rule
+// exactly: `[system, user]` 200s, while `[user, system, user]`,
+// `[user, assistant, system]`, and `[system, system, user]` each 400 with
+// "System message must be at the beginning." So: at most one `system`, and it
+// must sit ahead of the first turn. `developer` is not a turn and is not
+// counted -- `[developer, system, user]`, `[user, developer, user]`, and
+// `[developer, developer, user]` all 200 -- which is why "the beginning" means
+// "before the first turn" rather than index 0, and why nothing here moves,
+// merges, or rewrites a developer message.
+const QWEN38_TURN_ROLES = new Set(["user", "assistant", "tool"]);
+
+function qwen38SystemOrderIsLegal(messages) {
+  let systems = 0;
+  let sawTurn = false;
+  for (const message of messages) {
+    const role = message?.role;
+    if (role === "system") {
+      systems += 1;
+      if (systems > 1 || sawTurn) return false;
+    } else if (QWEN38_TURN_ROLES.has(role)) {
+      sawTurn = true;
+    }
+  }
+  return true;
+}
+
+// Content arrives as a plain string or as OpenAI content parts, and Codex sends
+// both shapes on this route. Strings join with a blank line so the merged
+// instructions read as separate paragraphs; parts lists concatenate. A mixed
+// merge promotes the strings to text parts rather than stringifying the parts,
+// because flattening a parts list would drop everything that is not text.
+function combineQwen38SystemContent(contents) {
+  if (contents.every((content) => typeof content === "string")) return contents.join("\n\n");
+  return contents.flatMap((content) =>
+    typeof content === "string" ? [{ type: "text", text: content }] : content,
+  );
+}
+
+// A compatibility repair, and it is not free: instructions the caller placed
+// mid-conversation end up hoisted ahead of the first turn, so the model reads
+// them as opening context instead of as a later correction. That is a real
+// change in meaning, accepted only because this endpoint answers the original
+// ordering with a 400 and no answer at all. Every non-system message keeps its
+// position, and the merged text keeps the callers' relative order.
+function normalizeQwen38SystemMessages(messages) {
+  if (!Array.isArray(messages) || qwen38SystemOrderIsLegal(messages)) return messages;
+  const rest = [];
+  const contents = [];
+  let first;
+  let firstSystemSlot = -1;
+  for (const message of messages) {
+    if (message?.role !== "system") {
+      rest.push(message);
+      continue;
+    }
+    if (firstSystemSlot === -1) {
+      firstSystemSlot = rest.length;
+      first = message;
+    }
+    const content = message.content;
+    if (content === undefined || content === null || content === "") continue;
+    contents.push(content);
+  }
+  const firstTurn = rest.findIndex((message) => QWEN38_TURN_ROLES.has(message?.role));
+  // Ahead of the first turn, and no earlier than where the caller's own first
+  // system message sat -- so a leading `developer` message keeps its lead.
+  const insertAt = firstTurn === -1 ? firstSystemSlot : Math.min(firstSystemSlot, firstTurn);
+  const merged = { ...first, content: combineQwen38SystemContent(contents) };
+  return [...rest.slice(0, insertAt), merged, ...rest.slice(insertAt)];
+}
+
 function normalizeBody(buffer, contentType, route) {
   if (!buffer.length || !String(contentType || "").includes("application/json")) {
     const error = new Error("API-provider requests require a JSON body.");
@@ -541,6 +613,13 @@ function normalizeBody(buffer, contentType, route) {
     if (Array.isArray(payload.tools) && payload.tools.length === 0) delete payload.tools;
     if (!Array.isArray(payload.tools) || payload.tools.length === 0) {
       delete payload.tool_choice;
+    }
+    // Third measured refusal on the same endpoint: "System message must be at
+    // the beginning." A conversation that already satisfies the rule is left
+    // byte-identical -- see normalizeQwen38SystemMessages for the rule, the
+    // developer-role exemption, and what the repair costs.
+    if (Array.isArray(payload.messages)) {
+      payload.messages = normalizeQwen38SystemMessages(payload.messages);
     }
   } else if (model.requestProfile === "minimax-m3") {
     // MiniMax uses its own thinking control on the OpenAI-compatible

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -2983,6 +2983,214 @@ test("API forwarder omits the empty tool list the free Qwen3.8 endpoint rejects"
   }
 });
 
+// The third refusal measured on the same endpoint: "System message must be at
+// the beginning." Probing it with one-token requests pinned the rule to at most
+// one `system` message, sitting ahead of the first user/assistant/tool turn --
+// `[user, system, user]`, `[user, assistant, system]`, and
+// `[system, system, user]` all 400, `[system, user]` 200. The `developer` role
+// is outside the rule entirely (`[developer, system, user]`,
+// `[user, developer, user]`, `[developer, developer, user]` all 200), which is
+// why "the beginning" is measured as "before the first turn" and why the
+// profile never touches a developer message.
+test("API forwarder hoists and coalesces the system messages the free Qwen3.8 endpoint refuses", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const curated = curatedQwen38EffortModel();
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    MODEL_ROUTER_USER_MODELS: curated.file,
+    OPENROUTER_API_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OPENROUTER_API_KEY: "TEST_OPENROUTER_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const send = async (messages) => {
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: curated.gatewayModel, messages }),
+    });
+    assert.equal(response.status, 200);
+    return upstreamRequests.at(-1).body.messages;
+  };
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+
+    // Two leading system messages: one arrives, carrying both texts in the
+    // order the caller wrote them.
+    assert.deepEqual(
+      await send([
+        { role: "system", content: "You are Codex." },
+        { role: "system", content: "Answer in English." },
+        { role: "user", content: "hello" },
+      ]),
+      [
+        { role: "system", content: "You are Codex.\n\nAnswer in English." },
+        { role: "user", content: "hello" },
+      ],
+    );
+
+    // A late system message is hoisted ahead of the first turn; every other
+    // message keeps its place, including the assistant turn behind it.
+    assert.deepEqual(
+      await send([
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+        { role: "system", content: "Be brief." },
+        { role: "user", content: "and now?" },
+      ]),
+      [
+        { role: "system", content: "Be brief." },
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+        { role: "user", content: "and now?" },
+      ],
+    );
+
+    // Content parts are the other shape Codex sends. They concatenate instead
+    // of being flattened into a string, and a mixed merge promotes the plain
+    // string to a text part rather than stringifying the parts list.
+    assert.deepEqual(
+      await send([
+        { role: "system", content: [{ type: "text", text: "You are Codex." }] },
+        { role: "user", content: "hello" },
+        { role: "system", content: [{ type: "text", text: "Be brief." }] },
+      ]),
+      [
+        {
+          role: "system",
+          content: [
+            { type: "text", text: "You are Codex." },
+            { type: "text", text: "Be brief." },
+          ],
+        },
+        { role: "user", content: "hello" },
+      ],
+    );
+    assert.deepEqual(
+      await send([
+        { role: "system", content: "You are Codex." },
+        { role: "system", content: [{ type: "text", text: "Be brief." }] },
+        { role: "user", content: "hello" },
+      ]),
+      [
+        {
+          role: "system",
+          content: [
+            { type: "text", text: "You are Codex." },
+            { type: "text", text: "Be brief." },
+          ],
+        },
+        { role: "user", content: "hello" },
+      ],
+    );
+
+    // A leading developer message keeps its lead: the coalesced system message
+    // lands ahead of the first turn, not at index 0.
+    assert.deepEqual(
+      await send([
+        { role: "developer", content: "Repo rules." },
+        { role: "system", content: "You are Codex." },
+        { role: "user", content: "hello" },
+        { role: "system", content: "Be brief." },
+      ]),
+      [
+        { role: "developer", content: "Repo rules." },
+        { role: "system", content: "You are Codex.\n\nBe brief." },
+        { role: "user", content: "hello" },
+      ],
+    );
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+    rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
+// Hoisting moves instructions the caller placed mid-conversation, so it only
+// runs when the endpoint would otherwise refuse the request. A conversation the
+// measured rule already allows has to reach the upstream exactly as it was
+// sent -- including the developer-role orderings that are legal only because
+// developer is outside the rule.
+test("API forwarder leaves an already-legal Qwen3.8 message order untouched", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const curated = curatedQwen38EffortModel();
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    MODEL_ROUTER_USER_MODELS: curated.file,
+    OPENROUTER_API_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OPENROUTER_API_KEY: "TEST_OPENROUTER_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    for (const messages of [
+      // The shape the endpoint documents as correct.
+      [
+        { role: "system", content: "You are Codex." },
+        { role: "user", content: "hello" },
+      ],
+      // Legal because developer is not a turn: the lone system message still
+      // precedes the first user message.
+      [
+        { role: "developer", content: "Repo rules." },
+        { role: "system", content: "You are Codex." },
+        { role: "user", content: "hello" },
+      ],
+      // Two developer messages after a turn -- measured 200, and nothing here
+      // may merge or move them.
+      [
+        { role: "user", content: "hello" },
+        { role: "developer", content: "Repo rules." },
+        { role: "developer", content: "Answer in English." },
+        { role: "user", content: "and now?" },
+      ],
+      // No system message at all is legal by construction.
+      [{ role: "user", content: "hello" }],
+      // Content parts on an already-legal list are forwarded as written.
+      [
+        { role: "system", content: [{ type: "text", text: "You are Codex." }] },
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+      ],
+    ]) {
+      const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ model: curated.gatewayModel, messages }),
+      });
+      assert.equal(response.status, 200);
+      assert.equal(
+        JSON.stringify(upstreamRequests.at(-1).body.messages),
+        JSON.stringify(messages),
+      );
+    }
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+    rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
 test("API forwarder routes MiniMax M3 streaming tool calls with adaptive thinking", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
Follow-up to #258. That fix cleared the empty-tool-list 400; real Codex use then hit a second, unrelated constraint in the same Qwen3.8 chat template:

```
litellm.BadRequestError: OpenAIException - System message must be at the beginning.
  Received Model Group=custom-qwen3-8-27b
```

## The measured rule

Probed against the live endpoint:

| messages | result |
|---|---|
| `[system, user]` | 200 |
| `[user, system, user]` | **400** |
| `[user, assistant, system]` | **400** |
| `[system, system, user]` | **400** |
| `[developer, user]` | 200 |
| `[user, developer, user]` | 200 |
| `[system, developer, user]` | 200 |
| `[developer, system, user]` | 200 |
| `[developer, developer, user]` | 200 |

At most one `system` message, and it must precede the first `user`/`assistant`/`tool` turn. The `developer` role is unconstrained. Note `[developer, system, user]` passes, so "at the beginning" means "before the first conversational turn", not literally index 0.

## The fix

The `qwen38-community` profile coalesces every `system` message into one and inserts it at `min(first system's own slot, first turn)` — so a leading `developer` message keeps its place. String and content-parts content are both handled. An already-legal list is returned by identity and forwarded byte-identical. `developer` messages are never moved.

Coalescing a *late* system message does move those instructions to the front of the conversation. That is a real semantic shift, and it is noted in the code comment — the endpoint rejects the alternative outright.

## Test plan

- [x] `npm test` — 1336 tests, 1324 pass, 0 fail, 12 pre-existing skips
- [x] `node --test test/routing.test.mjs test/registry.test.mjs` — 85 pass, 0 fail
- [x] `node scripts-check.mjs` — syntax checks passed
- [x] RED check: reverting only `api-forwarder.mjs` fails the new hoist test
- [x] **Live end-to-end**, real forwarder against the real endpoint, no mocks:

| Payload | Before | After |
|---|---|---|
| two leading system messages | **400** | **200** |
| system after user/assistant | **400** | **200** |
| already-legal `[system, user]` | 200 | 200 |
| empty `tools` (#258 regression check) | 200 | 200 |
| normal turn with a real tool | 200 | 200 |

- [x] Ran on a real installed router driving real Codex sessions before merge; the reported failure is gone.

Caveat: the "leaves an already-legal order untouched" test asserts an absence, so it passes with and without the fix. It guards against over-eager normalization rather than acting as a RED test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXPWEJidiS8MxEtHTCZq5i
