### PR TITLE
feat(failover): continue a turn on another model when the provider is out of usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1033,6 +1033,87 @@ merely failing them.
    the status or the transport error's own name and code — never a response
    body, and never the caller capability path.
 
+## Moving a turn to another model is legal only before the first relayed byte
+
+`src/model-failover.mjs` decides when a turn whose provider reported it has no
+usage left is rebuilt for a different model, and `buildRoutedRequest` in
+`src/router.mjs` is what makes rebuilding it possible. The rules are narrow on
+purpose; several of them exist because the obvious wider version is wrong.
+
+1. The **same relayed-byte rule as upstream retries**, for the same reason. The
+   failover branch lives before `pipeResponse`, and `nothingRelayed(response)`
+   is re-checked before every hop. Never move it around `pipeResponse`: a
+   mid-stream swap grafts a second response onto a stream the client is reading,
+   and duplicates any tool call the client has already executed. That second
+   hazard is worse than the duplicated stream and has no equivalent in the retry
+   path.
+2. Only **"your usage is gone"** qualifies: `upstreamFailureKind` returning
+   `out_of_usage`, a 402, or a 429 whose `Retry-After` exceeds sixty seconds. Do
+   not add 401 or 403 — a swap would hide the rejected credential that is the
+   only thing worth telling the operator. Do not add 404 or 400, which are
+   deterministic. Do not add 5xx: `upstream-retry.mjs` already absorbs the
+   transient shapes, and masking a provider outage costs an incident somebody
+   would want to see. Do not lower the 429 threshold; trading a twenty-second
+   wait for a cold prompt cache is a bad deal for the rest of the session.
+   Entitlement failures are classified **before** quota ones and never swap,
+   because "upgrade your plan" appears in both vocabularies and no other
+   provider's quota makes a missing entitlement true.
+   Claude Code excludes billing errors from its own fallback on the reasoning
+   that they usually mean misconfiguration. That reasoning does not hold here:
+   with thirty providers configured, an exhausted plan is a daily event and
+   having somewhere else to go is the whole point of the install.
+3. **Never trade a quota error for a context error.** A candidate is eligible
+   only when its `contextWindow` can hold `estimateInputTokens` of the bytes the
+   turn was about to send. That estimate errs high by design, which is the safe
+   direction. Falling from a 1M-context model onto a 262K one mid-session is a
+   strictly worse turn than the one it replaced.
+4. **Never fail over inside the same provider family.** Compare
+   `canonicalProviderId`: protocol variants share one credential and therefore
+   one quota, so a sibling is guaranteed to fail the same way.
+5. **A cooldown is only ever a window the provider itself named.** Derived from
+   `Retry-After` and `cooldownUntil`, never invented, capped at six hours, and
+   cleared on that provider's next successful answer. A provider under cooldown
+   is skipped before dispatch, which is the entire saving — so a cooldown that
+   is wrong strands the operator's chosen model, and that is why nothing may
+   record one from a guess. `control failover reset` and the doctor's report
+   exist so a wrong one is visible and removable.
+6. **Bounded**: at most two hops, a thirty-second budget for the whole sequence,
+   abort-aware, stop on the first success. When nothing is eligible, return the
+   failure the operator's own model gave — it is the one they can act on.
+7. **Never silent, and never in the transcript.** The log line is not gated on
+   `CODEX_ROUTER_QUIET`, which a production LaunchAgent hard-sets. Both attempts
+   are metered and the serving row carries `failoverFrom`. Do not "helpfully"
+   inject a notice into the stream: Codex replays assistant output as input, so
+   a router-authored sentence comes back next turn as something the model
+   believes it said.
+8. **The rebuild must start from the pristine payload.** `buildRoutedRequest`
+   writes to neither `payload` nor the aged input, and this is load-bearing in
+   two places. `flattenNamespaceTools` only recognizes `type: "namespace"`
+   items, so a second pass over already-flattened tools returns an *empty*
+   namespace map — plausible tools with no way to map the model's calls back.
+   And `carryReasoningThroughInput` replaces reasoning items in place, so a
+   responses-native second pass would find them already gone. The input array is
+   copied before it is rewritten — and copied **only when it is an array**,
+   because `input` is equally legal as a bare string and spreading one produces
+   an array of single characters, which reaches the provider and still reads as
+   a 200. `test/router-timing-log.test.mjs` caught exactly that.
+9. `selectedConfiguredListedModels()` is **not** cheap: it probes every
+   provider's credential synchronously and spawns `/usr/bin/security` per
+   keychain service on macOS. Call it only once a failure or a cooldown is
+   already known, never on the happy path.
+10. Coverage lives in `test/model-failover.test.mjs` (classifier, ranking,
+    cooldown store) and `test/model-failover-router.test.mjs` (end to end,
+    including that the failed attempt's bytes never reach the client). A change
+    to the trigger set, the ranking, or the cooldown rules needs a test there.
+
+**Not implemented: the native ChatGPT tier.** Falling back to the signed-in
+ChatGPT plan is deliberately absent. It is not a body swap but the other branch
+entirely, and it crosses the routed/native boundary this file governs
+elsewhere — `encrypted_content` rewriting, the compatibility relay, the
+collaboration envelope. Those rules require live marker-return probes through
+every installed routed agent before a change ships, so the tier cannot be added
+from the test suite alone. Add it with those proofs or not at all.
+
 ## Substituting a prompt-token count a provider reported as zero
 
 Codex decides when to compact from the `input_tokens` each response reports, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,39 @@
   The entry is also renamed to **Qwen3.8-27-free-victor**, crediting `victor`,
   who publishes the endpoint, in the name the picker shows rather than only in
   the endpoint note.
+- **A turn whose provider has run out of usage now continues on another model.**
+  An install with thirty providers configured runs out of one of them most days:
+  a coding-plan window closes, a weekly quota lands, a balance empties. The
+  router named that failure clearly and then stopped — Codex has nothing to do
+  with a billing error, so a session mid-task simply ended, subagents included,
+  while every other model the operator could reach sat unused. The turn is now
+  rebuilt for the next eligible model and sent again, and the client sees one
+  clean answer.
+
+  What qualifies is deliberately narrow: an exhausted balance or plan limit, a
+  402, or a 429 whose `Retry-After` is longer than a minute. A rejected
+  credential, an unknown model, a malformed request, and every 5xx keep exactly
+  the error they returned before — swapping models to dodge a bad key would hide
+  the one fact that fixes it, and a short rate limit is cheaper to wait out than
+  a cold prompt cache is to pay for. Free models are tried before paid ones,
+  then the rest in the registry's own preference order; a model on your own
+  machine is never chosen automatically, because the runtime might not be
+  running. A candidate whose context window cannot hold the conversation is
+  skipped, so a quota failure is never traded for a context-window rejection.
+
+  When a provider says when it will be back, that window is believed: the next
+  turn skips it outright instead of buying the same rejection again, and it is
+  used again by itself once the window passes or the next time it answers. A
+  reset time is never invented, only ever read from the provider, and it is
+  capped at six hours so a malformed one cannot strand a model.
+
+  Nothing about the swap is silent, and nothing is injected into the transcript.
+  The router logs it (never gated on `CODEX_ROUTER_QUIET`), the tray Island names
+  the model actually answering, and the usage event carries `failoverFrom` so a
+  rescued turn stays distinguishable from one that never failed. Compaction gets
+  the same treatment, because a compaction that fails ends a session just as
+  hard. `./bin/control failover status|on|off|chain <slugs>|auto|reset`; the
+  doctor reports any provider currently being held off and when it clears.
 
 - **The GLM-5.3 1M entry routed to a model code Z.ai does not serve.** Shipping
   `glm-5.3[1m]` took the vendor's documented 1M suffix at its word, and the

--- a/README.md
+++ b/README.md
@@ -1135,6 +1135,71 @@ How the local path differs from a paid engine:
   a paid vision engine still reads better; the local option is about cost and
   privacy, not peak quality.
 
+### Keep working when a provider runs out of usage
+
+A coding-plan window closes, a weekly quota lands, a balance empties — and the
+turn you were in the middle of used to stop there. Codex can do nothing with a
+billing error, so the session ended, subagents included, while every other model
+you had configured sat unused.
+
+Now the turn is **rebuilt for the next eligible model and sent again**. You get
+one clean answer. It is **on by default**, and it only ever uses models you have
+already enabled and credentialed.
+
+```sh
+./bin/control failover status
+./bin/control failover off      # a provider running out ends the turn, as before
+```
+
+Turning it off is remembered permanently; an update never turns it back on.
+
+**What counts as running out** is deliberately narrow: an exhausted balance or
+plan limit, a `402`, or a `429` that asks you to wait more than a minute.
+Everything else keeps the error it always gave — a rejected key still says the
+key was rejected, an unknown model still says so, and a provider outage is still
+reported rather than hidden. Swapping models to dodge a bad credential would
+only bury the one fact that fixes it.
+
+**Which model answers instead**, in order:
+
+1. Free models — the anonymous gateways, if you have any enabled
+2. Everything else you have enabled, in the picker's own preference order
+
+A model served from your own machine is never chosen automatically, for the same
+reason the vision bridge does not choose one: your runtime might not be running.
+Name it in a chain and it is used. A model whose context window cannot hold the
+conversation is skipped, so a quota failure never turns into a "too many tokens"
+failure. Choose the order yourself, or hand the choice back:
+
+```sh
+./bin/control failover chain opencode-free/big-pickle,kimi-api/kimi-k3
+./bin/control failover auto
+```
+
+**When a provider tells you when it will be back, that is believed.** The next
+turn skips it outright instead of paying for the same rejection again, and it
+starts being used the moment the window passes — or the next time it answers
+successfully, whichever comes first. Reset times are never invented, only read
+from the provider, and capped at six hours. `doctor` shows anything currently
+being held off and when it clears:
+
+```sh
+./bin/control failover reset   # clear every hold now and ask again next turn
+```
+
+**You are never left guessing which model answered.** The tray Island names the
+model actually serving, `router.log` records every swap (even with the quiet
+flag the background service sets), and the usage graphs mark the turn with the
+model you originally asked for. Nothing is written into your transcript — Codex
+replays assistant output back as input, so a note from the router would come
+back next turn as a sentence the model thinks it wrote.
+
+Compaction gets the same treatment: a compaction that cannot run ends a long
+session just as surely as a turn that cannot run.
+
+Note: your signed-in ChatGPT plan is **not** currently used as a fallback tier.
+Routed models fall back to other routed models only.
+
 ## Make models appear in DeepSeek Harness
 
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`)
@@ -1335,6 +1400,7 @@ specific bytes. Browser and computer-use execution remains live-only.
 ./bin/model-router codex enable
 ./bin/model-router codex uninstall
 ./bin/control vision-bridge status
+./bin/control failover status
 ```
 
 Every command takes `dsh` in place of `codex` to act on the DeepSeek Harness

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -19,8 +19,9 @@ import {
   endpointForModel,
   resolveProviderBaseUrl,
 } from "./model-registry.mjs";
-import { parseRateLimitHeaders } from "./rate-limit-headers.mjs";
+import { cooldownUntil, parseRateLimitHeaders } from "./rate-limit-headers.mjs";
 import { recordRateLimitSnapshot } from "./rate-limit-state.mjs";
+import { recordProviderCooldown } from "./model-failover.mjs";
 import { canonicalProviderId, readProviderSelection } from "./provider-selection.mjs";
 import { stripImages, supportsImageInput } from "./vision-bridge.mjs";
 import {
@@ -863,6 +864,22 @@ async function handleRequest(request, response) {
   // Variant-routed responses meter the same upstream subscription, so quota
   // headers land under the family's canonical provider id.
   if (rateLimit) recordRateLimitSnapshot(canonicalProviderId(normalized.provider.id), rateLimit);
+  // This hop is the only place the provider's own status and headers are seen
+  // before LiteLLM restates them, so it is the only place a reset time the
+  // gateway does not relay can still be read. A failure that names when the
+  // caller may return is worth recording: the router reads it to skip a
+  // provider it already knows is empty instead of buying the same rejection
+  // once per turn. Only a failure, and only a window the provider itself
+  // named -- a healthy response is never a reason to stop using a provider.
+  if (!upstream.ok) {
+    const until = cooldownUntil(rateLimit);
+    if (until) {
+      recordProviderCooldown(canonicalProviderId(normalized.provider.id), {
+        until,
+        reason: upstream.status === 429 ? "rate_limited" : "out_of_usage",
+      });
+    }
+  }
   if (!QUIET) {
     console.error(
       `[api-forwarder] provider=${normalized.provider.id} model=${normalized.model.upstreamModel} status=${upstream.status} duration_ms=${Date.now() - startedAt}`,

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -970,6 +970,45 @@ async function handleToolResultAging(action, nativeAction) {
   process.stdout.write(`${JSON.stringify(toolResultAgingSnapshot())}\n`);
 }
 
+// Failover has one switch, one optional order, and one escape hatch. The
+// escape hatch matters most: a cooldown is the router refusing to send to a
+// provider, and an operator who believes it is wrong needs a way to say so
+// without waiting out a window somebody else's clock chose.
+async function handleFailover(action, ...rest) {
+  const {
+    clearAllProviderCooldowns,
+    readFailoverSettings,
+    readProviderCooldowns,
+    setFailoverChain,
+    setFailoverEnabled,
+  } = await import("./model-failover.mjs");
+  const snapshot = () => ({
+    ...readFailoverSettings(),
+    cooldowns: readProviderCooldowns(),
+  });
+  const desired = action || "status";
+  if (desired === "status") {
+    process.stdout.write(`${JSON.stringify(snapshot(), null, 2)}\n`);
+    return;
+  }
+  if (desired === "on" || desired === "off") {
+    setFailoverEnabled(desired === "on");
+  } else if (desired === "chain") {
+    setFailoverChain(rest);
+  } else if (desired === "auto") {
+    setFailoverChain([]);
+  } else if (desired === "reset") {
+    // Every recorded window at once. A provider is asked again on the very
+    // next turn, and answers for itself.
+    clearAllProviderCooldowns();
+  } else {
+    throw new Error(
+      "Usage: control failover status|on|off|chain <model-slug,...>|auto|reset",
+    );
+  }
+  process.stdout.write(`${JSON.stringify(snapshot(), null, 2)}\n`);
+}
+
 // The bridge changes what the picker advertises (image input on text-only
 // models), so every mutation rebuilds the catalog the way the subagent and
 // picker toggles do.
@@ -1995,6 +2034,8 @@ if (args.includes("--probe")) {
   await handleLocalModels(args[1], args[2], ...args.slice(3));
 } else if (args[0] === "vision-bridge") {
   await handleVisionBridge(args[1] || "status", args[2], args[3]);
+} else if (args[0] === "failover") {
+  await handleFailover(args[1], ...args.slice(2));
 } else if (args[0] === "picker") {
   await handlePicker(...pickerCommandArgs(args));
 } else if (args[0] === "service") {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -54,6 +54,7 @@ import {
   readVisionBridgeSettings,
   visionBridgeConfigured,
 } from "./vision-bridge-state.mjs";
+import { readFailoverSettings, readProviderCooldowns } from "./model-failover.mjs";
 import { contextWindowDrift, describeContextWindowDrift } from "./context-window-drift.mjs";
 import { observedInputCeilings } from "./usage-events.mjs";
 import { venvRuntimeProblem } from "./venv-runtime.mjs";
@@ -518,6 +519,39 @@ if (visionSettings.enabled && !visionEngine) {
     "Vision bridge",
     visionEngine ? `text-only models read images via ${visionEngine.slug}` : "off",
     "Run ./bin/model-router codex control vision-bridge on to let text-only models read pasted images.",
+  );
+}
+// A cooldown is the router declining to send to a provider, which looks
+// exactly like the provider being broken if nobody says so out loud. Report
+// every live one with its expiry, so "why is my model not being used" has an
+// answer here rather than in the log.
+const failoverSettings = readFailoverSettings();
+const activeCooldowns = Object.entries(readProviderCooldowns());
+if (!failoverSettings.enabled) {
+  add(
+    "ok",
+    "Model failover",
+    "off -- a provider that runs out of usage ends the turn",
+    "Run ./bin/model-router codex control failover on to let a turn continue on another enabled model.",
+  );
+} else if (activeCooldowns.length) {
+  add(
+    "warn",
+    "Model failover",
+    `holding off ${activeCooldowns
+      .map(([id, entry]) => `${id} until ${entry.until} (${entry.reason || "reported empty"})`)
+      .join(", ")}`,
+    "Each clears itself at that time, or on the provider's next successful answer. " +
+      "Run ./bin/model-router codex control failover reset to clear them now.",
+  );
+} else {
+  add(
+    "ok",
+    "Model failover",
+    failoverSettings.chain.length
+      ? `on, in the order you set: ${failoverSettings.chain.join(" -> ")}`
+      : "on, free models first then your other enabled providers",
+    "Run ./bin/model-router codex control failover chain <model-slug,...> to choose the order yourself.",
   );
 }
 // The same list the catalog writes definitions from, so a model switched off

--- a/src/error-translation.mjs
+++ b/src/error-translation.mjs
@@ -110,6 +110,27 @@ function isOutOfUsage(detail, errorType) {
   return QUOTA_PATTERNS.some((pattern) => pattern.test(detail));
 }
 
+// The same two questions `describeFailure` asks, in the same order, answered for
+// a caller that needs to *act* on the distinction rather than word it. Exported
+// as one function rather than as the two predicates, because the order is the
+// load-bearing part: "upgrade your plan" appears in both pattern sets, so a
+// caller that asked about quota first would read a permanent entitlement failure
+// as an exhausted balance. Keeping the ordering here means there is one place it
+// can be got right.
+//
+// Returns "entitlement" (a plan that never included this API -- nothing the
+// operator does with keys or top-ups changes it), "out_of_usage" (an exhausted
+// balance or plan limit, which time or a top-up fixes), or undefined for
+// everything else, including every 5xx: the origin ran, and what it said about
+// quota is not evidence about the caller's.
+export function upstreamFailureKind({ status, bodyText }) {
+  if (!(Number(status) < 500)) return undefined;
+  const detail = extractUpstreamDetail(bodyText);
+  if (isPlanEntitlement(detail)) return "entitlement";
+  if (isOutOfUsage(detail, parseUpstreamError(bodyText).type)) return "out_of_usage";
+  return undefined;
+}
+
 function describeFailure({
   status,
   detail,

--- a/src/model-failover.mjs
+++ b/src/model-failover.mjs
@@ -164,14 +164,31 @@ export function providerCooldown(providerId, { now } = {}) {
 // Only ever records a window the provider itself reported. A verdict with no
 // `until` records nothing: the turn fails over, and the next one asks the
 // operator's chosen provider again rather than guessing on its behalf.
+//
+// The one exception is naming, not timing. Two hops see the same failure and
+// know different amounts about it: `api-forwarder` sees the provider's real
+// headers -- including the `Retry-After` LiteLLM does not relay, which is the
+// only reason a window is ever known at all -- but it has already piped the
+// body away and can classify by status alone. The router sees the body and can
+// tell an exhausted plan from a burst rate limit. So a later caller with no
+// window of its own may sharpen the reason on a window that already exists.
+// It may never create one.
 export function recordProviderCooldown(providerId, { until, reason, now } = {}) {
   const id = canonicalProviderId(String(providerId || "").trim());
+  if (!id) return undefined;
   const at = nowMs(now);
+  const document = readCooldownDocument();
+  const existing = document[id];
+  const live = existing && Date.parse(existing.until) > at ? existing : undefined;
   const expiry = isoOrUndefined(until);
-  if (!id || !expiry) return undefined;
+  if (!expiry) {
+    if (!live || !reason || live.reason === reason) return undefined;
+    document[id] = { ...live, reason };
+    writeCooldownDocument(document);
+    return document[id];
+  }
   const capped = new Date(Math.min(Date.parse(expiry), at + MAX_COOLDOWN_MS)).toISOString();
   if (Date.parse(capped) <= at) return undefined;
-  const document = readCooldownDocument();
   document[id] = {
     until: capped,
     ...(reason ? { reason } : {}),

--- a/src/model-failover.mjs
+++ b/src/model-failover.mjs
@@ -1,0 +1,333 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { writePrivateJson } from "./file-security.mjs";
+import { STATE_DIR } from "./paths.mjs";
+import { upstreamFailureKind } from "./error-translation.mjs";
+import { PROVIDERS } from "./model-registry.mjs";
+import { canonicalProviderId } from "./provider-selection.mjs";
+
+// Keeping a turn alive when the provider it was routed to has no usage left.
+//
+// An install with thirty providers configured runs out of one of them most
+// days: a coding-plan window closes, a weekly quota lands, a balance empties.
+// Today that ends the conversation -- the router names the failure clearly and
+// Codex has nothing to do with a billing error, so a session mid-task simply
+// stops, subagents included. Every other model the operator can reach is
+// already known to this process; nothing ever tried one.
+//
+// The rules that make that safe are in AGENTS.md ("Failing a turn over to
+// another model is legal only before the first relayed byte"). This module owns
+// three of them: which failures qualify, which candidates are eligible, and how
+// long a provider that said it was empty is believed.
+
+export const PROVIDER_COOLDOWNS_PATH =
+  process.env.MODEL_ROUTER_PROVIDER_COOLDOWNS ||
+  path.join(STATE_DIR, "provider-cooldowns.json");
+
+export const FAILOVER_STATE_PATH =
+  process.env.MODEL_ROUTER_FAILOVER_STATE || path.join(STATE_DIR, "failover.json");
+
+// A rate limit short enough to wait out is not worth a model swap: the wait
+// costs seconds, and the swap costs a cold prompt cache for the rest of the
+// session. Sixty seconds is the line because it is roughly where Codex's own
+// retrying stops being invisible to the user.
+export const MIN_RATE_LIMIT_COOLDOWN_SECONDS = 60;
+
+// A provider's own reset time is believed, but not indefinitely. A malformed or
+// absurd `Retry-After` (some gateways send epoch seconds where seconds-from-now
+// belong) would otherwise strand the operator's chosen model for years.
+export const MAX_COOLDOWN_MS = 6 * 60 * 60 * 1_000;
+
+// Two hops, so a turn costs at most two extra round trips before it either
+// succeeds or returns the failure it was always going to return.
+export const MAX_FAILOVER_HOPS = 2;
+
+// The whole failover sequence, not each hop. A turn that has already spent this
+// long recovering is better off reporting the original failure than spending
+// more of the user's time on a third guess.
+export const FAILOVER_BUDGET_MS = 30_000;
+
+const MAX_COOLDOWN_ENTRIES = 64;
+
+// Free before paid, and the operator's signed-in ChatGPT plan between them.
+// A free model is a real downgrade in capability, so it is not the first choice
+// on merit -- it is first because it is the only tier that cannot surprise
+// someone with a bill they did not choose to incur. The native tier sits second
+// because a ChatGPT subscription is already paid for and flat-rate. Metered
+// providers rank last, and only ones the operator explicitly enabled.
+export const FAILOVER_TIER = Object.freeze({ free: 0, native: 1, subscription: 2 });
+
+function nowMs(now) {
+  return Number.isFinite(now) ? now : Date.now();
+}
+
+function isoOrUndefined(value) {
+  const ms = typeof value === "string" ? Date.parse(value) : Number(value);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : undefined;
+}
+
+// -- which failures qualify --------------------------------------------------
+
+// `{ swap: false }`, or `{ swap: true, reason, until }` where `until` is present
+// only when the provider itself said when it would be back.
+//
+// Deliberately narrow. A rejected credential, an unknown model, and a malformed
+// request all produce the same answer from every other provider too, so a swap
+// would spend two more round trips to reprint the same failure with a different
+// model's name on it -- and for a credential in particular it would hide the one
+// fact the operator needs. A 5xx is excluded because upstream-retry.mjs already
+// absorbs the transient shapes and because masking a provider outage costs the
+// operator an incident they would want to see.
+export function classifyRoutedFailure({ status, bodyText, retryAfterSeconds, now } = {}) {
+  const code = Number(status);
+  if (!Number.isFinite(code) || code < 400 || code >= 500) return { swap: false };
+  const at = nowMs(now);
+  const retryAfter = Number(retryAfterSeconds);
+  const kind = upstreamFailureKind({ status: code, bodyText });
+
+  // A plan that never included this API is not an exhausted balance, and no
+  // other model on another provider makes it true. Checked first because the
+  // two vocabularies overlap.
+  if (kind === "entitlement") return { swap: false };
+
+  if (kind === "out_of_usage" || code === 402) {
+    // Most providers say they are empty without saying when they refill. That
+    // is not a reason to invent a window: the turn still fails over, and the
+    // next turn tries the operator's chosen model again, which is the honest
+    // behaviour when nothing is known.
+    return {
+      swap: true,
+      reason: "out_of_usage",
+      ...(Number.isFinite(retryAfter) && retryAfter > 0
+        ? { until: cappedUntil(at, retryAfter * 1_000) }
+        : {}),
+    };
+  }
+
+  if (code === 429 && Number.isFinite(retryAfter) && retryAfter > MIN_RATE_LIMIT_COOLDOWN_SECONDS) {
+    return { swap: true, reason: "rate_limited", until: cappedUntil(at, retryAfter * 1_000) };
+  }
+
+  return { swap: false };
+}
+
+function cappedUntil(at, durationMs) {
+  return new Date(at + Math.min(durationMs, MAX_COOLDOWN_MS)).toISOString();
+}
+
+// -- how long an empty provider is believed ----------------------------------
+
+function readCooldownDocument() {
+  if (!existsSync(PROVIDER_COOLDOWNS_PATH)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(PROVIDER_COOLDOWNS_PATH, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    // A corrupt file must never take routing down. An unreadable cooldown
+    // document means "nothing is cooled down", which costs one wasted round
+    // trip at worst -- the failure mode a stale cooldown does not have.
+    return {};
+  }
+}
+
+function writeCooldownDocument(document) {
+  try {
+    const entries = Object.entries(document)
+      .sort((left, right) => String(right[1]?.until).localeCompare(String(left[1]?.until)))
+      .slice(0, MAX_COOLDOWN_ENTRIES);
+    writePrivateJson(PROVIDER_COOLDOWNS_PATH, Object.fromEntries(entries), {
+      directoryMode: 0o700,
+    });
+  } catch {
+    // Cooldown bookkeeping must never interrupt or fail a model request.
+  }
+}
+
+export function readProviderCooldowns({ now } = {}) {
+  const at = nowMs(now);
+  const live = {};
+  for (const [id, entry] of Object.entries(readCooldownDocument())) {
+    const until = isoOrUndefined(entry?.until);
+    if (until && Date.parse(until) > at) live[id] = { ...entry, until };
+  }
+  return live;
+}
+
+// `undefined` once the window the provider named has passed, so expiry needs no
+// sweeper and a provider comes back by itself.
+export function providerCooldown(providerId, { now } = {}) {
+  const id = canonicalProviderId(String(providerId || "").trim());
+  return id ? readProviderCooldowns({ now })[id] : undefined;
+}
+
+// Only ever records a window the provider itself reported. A verdict with no
+// `until` records nothing: the turn fails over, and the next one asks the
+// operator's chosen provider again rather than guessing on its behalf.
+export function recordProviderCooldown(providerId, { until, reason, now } = {}) {
+  const id = canonicalProviderId(String(providerId || "").trim());
+  const at = nowMs(now);
+  const expiry = isoOrUndefined(until);
+  if (!id || !expiry) return undefined;
+  const capped = new Date(Math.min(Date.parse(expiry), at + MAX_COOLDOWN_MS)).toISOString();
+  if (Date.parse(capped) <= at) return undefined;
+  const document = readCooldownDocument();
+  document[id] = {
+    until: capped,
+    ...(reason ? { reason } : {}),
+    observedAt: new Date(at).toISOString(),
+  };
+  writeCooldownDocument(document);
+  return document[id];
+}
+
+// Called on the first success from a provider. A quota that refilled early, a
+// limit the operator raised, a reset time the provider got wrong -- all three
+// end the same way, with a real answer, and that answer is better evidence than
+// anything this file recorded.
+export function clearProviderCooldown(providerId) {
+  const id = canonicalProviderId(String(providerId || "").trim());
+  if (!id) return false;
+  const document = readCooldownDocument();
+  if (!(id in document)) return false;
+  delete document[id];
+  writeCooldownDocument(document);
+  return true;
+}
+
+export function clearAllProviderCooldowns() {
+  writeCooldownDocument({});
+  return true;
+}
+
+// -- the operator's answer ---------------------------------------------------
+
+function defaultSettings() {
+  return { version: 1, enabled: true, chain: [], defaulted: true };
+}
+
+// A file exists, so somebody was here, but this build cannot tell what they
+// chose. Off is what every install had before failover shipped, and
+// `bin/control failover on` is one command away. Same reasoning as the vision
+// bridge's `disabledSettings()`.
+function unreadableSettings() {
+  return { version: 1, enabled: false, chain: [] };
+}
+
+export function readFailoverSettings() {
+  if (!existsSync(FAILOVER_STATE_PATH)) return defaultSettings();
+  try {
+    const parsed = JSON.parse(readFileSync(FAILOVER_STATE_PATH, "utf8"));
+    if (parsed?.version === 1 && typeof parsed.enabled === "boolean") {
+      return {
+        version: 1,
+        enabled: parsed.enabled,
+        chain: Array.isArray(parsed.chain)
+          ? parsed.chain.map((slug) => String(slug).trim()).filter(Boolean)
+          : [],
+      };
+    }
+  } catch {
+    // Falls through to the conservative reading below.
+  }
+  return unreadableSettings();
+}
+
+export function setFailoverEnabled(enabled) {
+  const current = readFailoverSettings();
+  const next = { version: 1, enabled: enabled === true, chain: current.chain };
+  writePrivateJson(FAILOVER_STATE_PATH, next, { directoryMode: 0o700 });
+  return next;
+}
+
+// An empty chain hands the choice back to the ranking. A named chain is the
+// operator's order and is used verbatim, minus any entry this build cannot
+// route to -- a pinned model that was removed must not disable failover.
+export function setFailoverChain(slugs) {
+  const current = readFailoverSettings();
+  const chain = (Array.isArray(slugs) ? slugs : [])
+    .flatMap((value) => String(value).split(","))
+    .map((value) => value.trim())
+    .filter(Boolean);
+  const next = { version: 1, enabled: current.enabled, chain };
+  writePrivateJson(FAILOVER_STATE_PATH, next, { directoryMode: 0o700 });
+  return next;
+}
+
+// -- which candidates are eligible -------------------------------------------
+
+export function failoverTier(model, providers = PROVIDERS) {
+  const provider = providers.get(model?.provider);
+  return provider?.keyless || provider?.authMode === "anonymous"
+    ? FAILOVER_TIER.free
+    : FAILOVER_TIER.subscription;
+}
+
+function supportsImageInput(model) {
+  return Array.isArray(model?.inputModalities) && model.inputModalities.includes("image");
+}
+
+// The candidate has to be able to hold the conversation that is already in
+// flight. `estimatedTokens` comes from the bytes the router was about to send
+// (estimateInputTokens), which errs high by design -- the safe direction here,
+// because trading a quota failure for a context-window rejection is a strictly
+// worse turn than the one it replaced.
+function eligible(model, { fromProvider, estimatedTokens, needsImage, needsMultiAgentV2, cooled }) {
+  if (!model?.slug) return false;
+  if (canonicalProviderId(model.provider) === fromProvider) return false;
+  if (cooled.has(canonicalProviderId(model.provider))) return false;
+  if (Number.isFinite(estimatedTokens) && Number(model.contextWindow) < estimatedTokens) {
+    return false;
+  }
+  // A text-only candidate can still serve an image turn -- the vision bridge
+  // stands in -- but only when the bridge is on for it. `visionBridge: false`
+  // is the registry saying this model must never be handed transcribed images.
+  if (needsImage && !supportsImageInput(model) && model.visionBridge === false) return false;
+  if (needsMultiAgentV2 && (model.multiAgentVersion || "v1") !== "v2") return false;
+  return true;
+}
+
+// Ordered candidates for a turn whose route just reported it had no usage left.
+// `models` is what the operator can actually reach right now -- the caller
+// passes `selectedConfiguredListedModels()` minus hidden slugs, which is the
+// same set the vision bridge picks its engine from.
+//
+// Shaped like `rankVisionEngines`: filter on declared capability, then order by
+// cost, then by the registry's own preference. The native ChatGPT candidate is
+// not a registry model and is spliced in at `FAILOVER_TIER.native` by the
+// caller, which is the only place that knows whether a session exists.
+export function rankFailoverCandidates(
+  models,
+  { from, estimatedTokens, needsImage = false, needsMultiAgentV2 = false, chain = [], now } = {},
+) {
+  const fromProvider = canonicalProviderId(from?.provider || "");
+  const cooled = new Set(Object.keys(readProviderCooldowns({ now })));
+  const available = (Array.isArray(models) ? models : []).filter(
+    (model) =>
+      model.slug !== from?.slug &&
+      eligible(model, { fromProvider, estimatedTokens, needsImage, needsMultiAgentV2, cooled }),
+  );
+
+  if (chain.length) {
+    const bySlug = new Map(available.map((model) => [model.slug, model]));
+    return chain
+      .map((slug) => bySlug.get(slug))
+      .filter(Boolean)
+      .map((model) => ({ tier: failoverTier(model), model }));
+  }
+
+  return available
+    // A model served from this machine is free and private, and it is still
+    // never chosen automatically: the runtime might not be running, and a
+    // failover that lands on a dead localhost has turned an honest quota error
+    // into a connection error. Same rule the vision bridge applies to its own
+    // local engine -- name one in the chain and it is used.
+    .filter((model) => !PROVIDERS.get(model.provider)?.keyless)
+    .map((model) => ({ tier: failoverTier(model), model }))
+    .sort(
+      (left, right) =>
+        left.tier - right.tier ||
+        Number(left.model.priority ?? 999) - Number(right.model.priority ?? 999) ||
+        String(left.model.slug).localeCompare(String(right.model.slug)),
+    );
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1581,6 +1581,8 @@ async function summarize(request, payload, route, signal) {
   // rather than asked, exactly as on the turn path. Nothing is sent while this
   // list is built.
   const attempts = compactionAttempts(route, aged);
+  // Attempts that were sent and rejected, kept so the caller can meter each one.
+  const failed = [];
   let last;
   for (let index = 0; index < attempts.length; index += 1) {
     const attemptRoute = attempts[index];
@@ -1609,9 +1611,15 @@ async function summarize(request, payload, route, signal) {
         usage,
         toolResultAging: aged.stats,
         route: attemptRoute,
+        failed,
         ...(attemptRoute === route ? {} : { failoverFrom: route.slug }),
       };
     }
+    // Each attempt that failed was still sent and still billed, so it is
+    // metered on its own row exactly as on the turn path -- otherwise a
+    // compaction the router rescued would leave no trace of the provider that
+    // could not serve it.
+    failed.push({ route: attemptRoute, status: sent.upstream.status, usage });
     // The first failure is the one reported if every attempt fails: it came
     // from the model the conversation is actually on, which is the one the
     // operator can do something about.
@@ -1628,13 +1636,13 @@ async function summarize(request, payload, route, signal) {
       bodyText: bytes.toString("utf8"),
       retryAfterSeconds: Number(sent.upstream.headers.get("retry-after")),
     });
-    if (!verdict.swap) return last;
+    if (!verdict.swap) return { ...last, failed };
     recordProviderCooldown(attemptRoute.provider, verdict);
     if (index + 1 < attempts.length) {
       logFailover(attemptRoute, attempts[index + 1], `compaction/${verdict.reason}`, sent.upstream.status);
     }
   }
-  return last;
+  return last && { ...last, failed };
 }
 
 function compactionSnapshot(model, item, status = "completed") {
@@ -1683,6 +1691,8 @@ async function handleRoutedCompaction(request, response, payload, route, signal,
   // actually produced the summary, the same as any other turn.
   const served = {
     route: result.route,
+    // Only the attempts that lost; the winner is metered by the caller.
+    failed: (result.failed || []).filter((entry) => entry.route !== result.route),
     ...(result.failoverFrom ? { failoverFrom: result.failoverFrom } : {}),
   };
   if (!result.ok) {
@@ -2171,6 +2181,18 @@ async function handleResponses(request, response, requestUrl) {
       // a successful nor a failed one appeared anywhere in the router's own
       // telemetry. Mirror the ordinary request path exactly.
       const compacted = compaction.route || route;
+      // A compaction the router moved was still charged by the provider that
+      // refused it, so each losing attempt gets its own row before the serving
+      // one -- the same shape the turn path records.
+      for (const attempt of compaction.failed || []) {
+        recordUsageEvent({
+          model: attempt.route.slug,
+          provider: canonicalProviderId(attempt.route.provider),
+          status: attempt.status,
+          durationMs: Date.now() - startedAt,
+          ...attempt.usage,
+        });
+      }
       recordUsageEvent({
         model: compacted.slug,
         provider: canonicalProviderId(compacted.provider),
@@ -2184,9 +2206,15 @@ async function handleResponses(request, response, requestUrl) {
       finalStatus = compaction.status;
       activityStatus = compaction.status;
       usageRecorded = true;
+      // The compaction chose its own model inside `summarize`, so the outer
+      // route still names the one the conversation is on. Adopt what actually
+      // served before returning, or the timing line emitted in `finally` would
+      // credit the exhausted provider with this turn's 200.
+      route = compacted;
+      failoverFrom ??= compaction.failoverFrom;
       if (!QUIET) {
         console.error(
-          `[codex-router] model=${requestedModel || "unknown"} provider=${compacted.provider} status=${compaction.status}${
+          `[codex-router] model=${compacted.slug} provider=${compacted.provider} status=${compaction.status}${
             compaction.failoverFrom ? ` failover-from=${compaction.failoverFrom}` : ""
           }`,
         );
@@ -2660,7 +2688,7 @@ async function handleResponses(request, response, requestUrl) {
       // The substitution is named in the log line as well as the usage event:
       // a router that quietly invents token counts is its own trap.
       console.error(
-        `[codex-router] model=${requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${finalStatus}${
+        `[codex-router] model=${route?.slug || requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${finalStatus}${
           upstreamRetries ? ` retries=${upstreamRetries}` : ""
         }${estimatedInputTokens ? ` estimated-input-tokens=${estimatedInputTokens}` : ""}${
           toolResultAging?.toolResultBytesSaved
@@ -2758,10 +2786,15 @@ async function handleResponses(request, response, requestUrl) {
     // QUIET: the production LaunchAgent hard-sets CODEX_ROUTER_QUIET=1. A
     // missing provider count is logged as unknown, not zero; an explicit zero
     // remains zero so a real cache miss is distinguishable from absent data.
+    // `model` and `provider` always name the pair that actually served the
+    // turn, so the two never disagree. On a turn the router moved, that is the
+    // fallback -- and `failover_from` carries what was asked for. Reading them
+    // the other way round (the asked-for model beside the serving provider)
+    // describes a combination that never ran.
     console.error(
-      `[codex-router] timing at=${new Date().toISOString()} model=${requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${status} total_ms=${Date.now() - startedAt} upstream_ms=${timingMetric(upstreamLatencyMs)} out_tokens=${timingMetric(usage?.outputTokens)} cached_tokens=${timingMetric(usage?.cachedInputTokens)}${
+      `[codex-router] timing at=${new Date().toISOString()} model=${route?.slug || requestedModel || "unknown"} provider=${route?.provider || "openai"} status=${status} total_ms=${Date.now() - startedAt} upstream_ms=${timingMetric(upstreamLatencyMs)} out_tokens=${timingMetric(usage?.outputTokens)} cached_tokens=${timingMetric(usage?.cachedInputTokens)}${
         estimatedInputTokens ? ` est_input=${estimatedInputTokens}` : ""
-      }`,
+      }${failoverFrom ? ` failover_from=${failoverFrom}` : ""}`,
     );
   }
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -58,7 +58,17 @@ import {
   flattenNamespaceTools,
   repairToolSchemaRoots,
 } from "./namespace-relay.mjs";
-import { pendingInterruptTargets } from "./subagent-completion.mjs";
+import { collaborationToolAvailable, pendingInterruptTargets } from "./subagent-completion.mjs";
+import {
+  FAILOVER_BUDGET_MS,
+  MAX_FAILOVER_HOPS,
+  classifyRoutedFailure,
+  clearProviderCooldown,
+  providerCooldown,
+  rankFailoverCandidates,
+  readFailoverSettings,
+  recordProviderCooldown,
+} from "./model-failover.mjs";
 import {
   awaitingSpawnProof,
   recordSpawnFailure,
@@ -1495,24 +1505,37 @@ function extractResponseText(payload) {
   return text.join("\n");
 }
 
-async function summarize(request, payload, route, signal) {
-  const originalInput = Array.isArray(payload.input) ? payload.input : [];
-  // Compaction replays the whole conversation, so any image still in it would
-  // reach the text-only model unbridged and fail the compaction rather than
-  // the turn. The evidence is already cached from the turn that pasted it.
-  //
-  // It replays the collaboration items too, so the agent-payload resolution a
-  // routed turn performs has to happen here as well -- otherwise a compaction
-  // inside a `/goal` or subagent session summarizes opaque payloads. The relay
-  // is cached by ciphertext, so a conversation whose turns already resolved
-  // costs nothing extra here.
-  const normalized = await normalizeRoutedAgentInput(request, originalInput, signal);
-  const aged = ageToolResults(normalized, { enabled: toolResultAgingEnabled() });
-  const bridged = await bridgeVisionInput(
-    aged.input,
-    route,
-    request,
-  );
+// The models a compaction may be tried on, best first, without sending
+// anything. The conversation's own model leads unless it has already said it
+// is empty, in which case asking it again only buys the same rejection.
+function compactionAttempts(route, aged) {
+  const settings = readFailoverSettings();
+  if (!settings.enabled) return [route];
+  const candidates = rankFailoverCandidates(
+    selectedConfiguredListedModels().filter((model) => !readHiddenModels().has(model.slug)),
+    {
+      from: route,
+      // The transcript being summarized is nearly all of the request, so its
+      // serialized size is the honest measure of what a candidate must hold.
+      estimatedTokens: estimateInputTokens(JSON.stringify(aged.input ?? [])),
+      needsImage: inputHasImage(aged.input),
+      // Compaction sends `tools: []`, so no candidate needs the collaboration
+      // proof to serve one.
+      chain: settings.chain,
+    },
+  )
+    .slice(0, MAX_FAILOVER_HOPS)
+    .map((entry) => entry.model);
+  if (!candidates.length) return [route];
+  return providerCooldown(route.provider) ? candidates : [route, ...candidates];
+}
+
+// One compaction attempt against one model. Everything route-dependent lives
+// here so a compaction can be moved to another model exactly like an ordinary
+// turn -- a compaction that fails ends the session just as hard, because the
+// conversation cannot get under its context limit without one.
+async function summarizeWith(request, payload, route, aged, signal) {
+  const bridged = await bridgeVisionInput(aged.input, route, request);
   const body = {
     ...payload,
     model: route.gatewayModel,
@@ -1529,43 +1552,89 @@ async function summarize(request, payload, route, signal) {
   // Compaction re-enters the same provider as the routed turn; Fireworks
   // rejects this OpenAI search parameter at that boundary too.
   if (providerForModel(route)?.id === "fireworks") delete body.web_search_options;
+  const serialized = JSON.stringify(body);
   const upstream = await fetch(`${GATEWAY_BASE}/responses`, {
     method: "POST",
     headers: routedHeaders(),
-    body: JSON.stringify(body),
+    body: serialized,
     signal,
   });
-  const bytes = Buffer.from(await upstream.arrayBuffer());
-  if (bytes.length > 32 * 1024 * 1024) {
-    return {
+  return { upstream, bridged, bytes: Buffer.byteLength(serialized, "utf8") };
+}
+
+async function summarize(request, payload, route, signal) {
+  const originalInput = Array.isArray(payload.input) ? payload.input : [];
+  // Compaction replays the whole conversation, so any image still in it would
+  // reach the text-only model unbridged and fail the compaction rather than
+  // the turn. The evidence is already cached from the turn that pasted it.
+  //
+  // It replays the collaboration items too, so the agent-payload resolution a
+  // routed turn performs has to happen here as well -- otherwise a compaction
+  // inside a `/goal` or subagent session summarizes opaque payloads. The relay
+  // is cached by ciphertext, so a conversation whose turns already resolved
+  // costs nothing extra here.
+  const normalized = await normalizeRoutedAgentInput(request, originalInput, signal);
+  const aged = ageToolResults(normalized, { enabled: toolResultAgingEnabled() });
+
+  // The models this compaction may be moved to, in order, starting with the one
+  // the conversation is on. A provider already known to be empty is dropped
+  // rather than asked, exactly as on the turn path. Nothing is sent while this
+  // list is built.
+  const attempts = compactionAttempts(route, aged);
+  let last;
+  for (let index = 0; index < attempts.length; index += 1) {
+    const attemptRoute = attempts[index];
+    const sent = await summarizeWith(request, payload, attemptRoute, aged, signal);
+    const bytes = Buffer.from(await sent.upstream.arrayBuffer());
+    if (bytes.length > 32 * 1024 * 1024) {
+      return {
+        ok: false,
+        status: 502,
+        payload: { error: { message: "Compact response is too large." } },
+        toolResultAging: aged.stats,
+      };
+    }
+    const parsed = JSON.parse(bytes.toString("utf8"));
+    // Compaction is a plain non-streaming call, so the usage block (when the
+    // provider sends one) is already in hand. `tokenUsageFromPayload` returns
+    // undefined when it is absent, and `recordUsageEvent` then omits the token
+    // fields entirely rather than metering an invented zero.
+    const usage = tokenUsageFromPayload(parsed);
+    if (sent.upstream.ok) {
+      clearProviderCooldown(attemptRoute.provider);
+      return {
+        ok: true,
+        summary: extractResponseText(parsed),
+        input: originalInput,
+        usage,
+        toolResultAging: aged.stats,
+        route: attemptRoute,
+        ...(attemptRoute === route ? {} : { failoverFrom: route.slug }),
+      };
+    }
+    // The first failure is the one reported if every attempt fails: it came
+    // from the model the conversation is actually on, which is the one the
+    // operator can do something about.
+    last ??= {
       ok: false,
-      status: 502,
-      payload: { error: { message: "Compact response is too large." } },
-      toolResultAging: aged.stats,
-    };
-  }
-  const parsed = JSON.parse(bytes.toString("utf8"));
-  // Compaction is a plain non-streaming call, so the usage block (when the
-  // provider sends one) is already in hand. `tokenUsageFromPayload` returns
-  // undefined when it is absent, and `recordUsageEvent` then omits the token
-  // fields entirely rather than metering an invented zero.
-  const usage = tokenUsageFromPayload(parsed);
-  if (!upstream.ok) {
-    return {
-      ok: false,
-      status: upstream.status,
+      status: sent.upstream.status,
       payload: parsed,
       usage,
       toolResultAging: aged.stats,
+      route: attemptRoute,
     };
+    const verdict = classifyRoutedFailure({
+      status: sent.upstream.status,
+      bodyText: bytes.toString("utf8"),
+      retryAfterSeconds: Number(sent.upstream.headers.get("retry-after")),
+    });
+    if (!verdict.swap) return last;
+    recordProviderCooldown(attemptRoute.provider, verdict);
+    if (index + 1 < attempts.length) {
+      logFailover(attemptRoute, attempts[index + 1], `compaction/${verdict.reason}`, sent.upstream.status);
+    }
   }
-  return {
-    ok: true,
-    summary: extractResponseText(parsed),
-    input: originalInput,
-    usage,
-    toolResultAging: aged.stats,
-  };
+  return last;
 }
 
 function compactionSnapshot(model, item, status = "completed") {
@@ -1610,12 +1679,19 @@ function writeCompactionSse(response, model, summary) {
 // routed compaction leaves the same telemetry trail as any other routed turn.
 async function handleRoutedCompaction(request, response, payload, route, signal, v2) {
   const result = await summarize(request, payload, route, signal);
+  // A compaction moved to another model is metered against the model that
+  // actually produced the summary, the same as any other turn.
+  const served = {
+    route: result.route,
+    ...(result.failoverFrom ? { failoverFrom: result.failoverFrom } : {}),
+  };
   if (!result.ok) {
     writeJson(response, result.status, result.payload);
     return {
       status: result.status,
       usage: result.usage,
       toolResultAging: result.toolResultAging,
+      ...served,
     };
   }
   if (v2) {
@@ -1633,6 +1709,7 @@ async function handleRoutedCompaction(request, response, payload, route, signal,
       status: 200,
       usage: result.usage,
       toolResultAging: result.toolResultAging,
+      ...served,
     };
   }
   writeJson(response, 200, { output: compactOutput(result.input, result.summary) });
@@ -1640,6 +1717,7 @@ async function handleRoutedCompaction(request, response, payload, route, signal,
     status: 200,
     usage: result.usage,
     toolResultAging: result.toolResultAging,
+    ...served,
   };
 }
 
@@ -1713,6 +1791,258 @@ function observeSubagentOutcome(request, route, status, { emptyCompletion = fals
   }
 }
 
+// Everything about a routed request that depends on which model is serving it.
+//
+// Extracted so it can run more than once for a single turn: a turn whose
+// provider reports it has no usage left is rebuilt for another model and sent
+// again, and that second build has to start from exactly what the first one
+// started from. Two things in here would quietly corrupt a second pass if it
+// did not.
+//
+//   - The tool list is rewritten for chat-completions providers (merged,
+//     flattened, schema-repaired). `flattenNamespaceTools` only recognizes
+//     items of `type: "namespace"`, so a second pass over already-flattened
+//     tools returns an *empty* namespace map -- shipping plausible tools with
+//     no way to map the model's calls back to the client's namespace shape.
+//   - `carryReasoningThroughInput` replaces `reasoning` items in place, so a
+//     responses-native second pass would find the reasoning already gone.
+//
+// Both are avoided the same way: nothing here writes to `payload` or to
+// `agedInput`. The tool list is a local, and the input array is copied before
+// anything rewrites it.
+async function buildRoutedRequest({ request, payload, route, agedInput }) {
+  let namespacesFlattened = false;
+  let flattenedNamespaces = new Map();
+  const bridged = await bridgeVisionInput(agedInput, route, request);
+  // `bridgeVisionInput` returns its argument unchanged when there is no image
+  // to read, and `carryReasoningThroughInput` writes into the array it is
+  // given -- so without this copy the first build would rewrite the shared
+  // aged input and a second build would start from the result.
+  //
+  // Copied only when it *is* an array. `input` is equally legal as a bare
+  // string, and spreading one of those produces an array of single characters
+  // -- a turn that still reaches the provider, and still reads as a 200,
+  // having quietly replaced the prompt with its own letters.
+  const input = Array.isArray(bridged) ? [...bridged] : bridged;
+  // DeepSeek thinking mode requires the assistant's reasoning to be replayed on
+  // tool-call turns, but LiteLLM's Responses->chat translation drops
+  // `reasoning` input items entirely. Merge each reasoning summary into the
+  // following assistant function_call message's content so the translation
+  // carries it; the forwarder then attaches it as `reasoning_content` on the
+  // tool-call message.
+  carryReasoningThroughInput(input);
+  const provider = providerForModel(route);
+  let tools = payload.tools;
+  // LiteLLM's Responses -> Chat Completions bridge drops namespace tools, which
+  // is how the client ships the collaboration runtime, the app toolset
+  // (threads, automations, navigation), and every MCP server (node_repl,
+  // peekaboo, github, ...). Chat-completions providers need every namespace
+  // flattened into ordinary functions; the response transform maps calls back
+  // to the client's native namespace shape.
+  if (provider?.protocol !== "openai-responses") {
+    // Relay the app's full native toolset (threads, automations, app
+    // navigation) to the provider. The client registers these tools with
+    // deferLoading and executes the calls natively, but only sends a reduced
+    // codex_app namespace on routed requests; merge the deferred definitions in
+    // so routed models see what native models see. The router never executes
+    // these calls -- the app owns thread, automation, and navigation state --
+    // it only relays definitions and results.
+    const merged = mergeCodexAppTools(tools);
+    if (merged.merged) tools = merged.tools;
+    const flattened = flattenNamespaceTools(tools);
+    namespacesFlattened = flattened.flattened;
+    if (namespacesFlattened) {
+      tools = flattened.tools;
+      flattenedNamespaces = flattened.namespaces;
+    }
+  } else {
+    // Responses-native providers keep the namespace tools untouched, so nothing
+    // is flattened and the list is left alone. The inventory is still built,
+    // because the response transform reads the exact spawn_agent model enum off
+    // it to drop an invented or stale optional override before Codex validates
+    // the call.
+    flattenedNamespaces = flattenNamespaceTools(tools).namespaces;
+    // Keeping the namespace shape is not the same as keeping a root the
+    // upstream rejects. `opencode-go-responses/gpt-5.6-luna` 400s a
+    // `type: ["object","null"]` parameter root while accepting the same request
+    // with a plain or union root -- so the strict-root repair has to run here
+    // too, on the tools alone, without flattening anything.
+    tools = repairToolSchemaRoots(tools);
+  }
+  let routedInput = input;
+  // The stored call history must use the same tool names as the tool list, or
+  // the model copies the bare names out of its own transcript.
+  if (namespacesFlattened) {
+    routedInput = flattenNamespacedHistory(routedInput, flattenedNamespaces);
+  }
+  const routed = {
+    ...payload,
+    tools,
+    model: route.gatewayModel,
+    input: routedInput,
+  };
+  // Codex chooses a child's model; this is where an operator gets to choose its
+  // depth. Applied only to turns Codex marked as a child, so a parent
+  // conversation on the same model is untouched -- running one model
+  // differently in the two roles is the whole point.
+  //
+  // The level is deliberately not validated against the model here. A provider
+  // that rejects an unsupported effort says so in a way the operator can read,
+  // whereas silently dropping the setting looks like the feature never worked.
+  const childEffort = request.headers["x-openai-subagent"]
+    ? subagentEffort(route.slug)
+    : undefined;
+  // This leaves on the Responses API, where the effort travels inside
+  // `reasoning`. A flat `reasoning_effort` is a Chat Completions field:
+  // LiteLLM's Responses bridge derives its own effort from `reasoning` whenever
+  // the client sent one -- and Codex always does -- then that derived value
+  // overwrites anything flat the router set, so a flat-only override never
+  // reaches the provider. Set both: `reasoning.effort` is what actually
+  // travels, and the flat field is what a bare chat-completions gateway reads.
+  if (childEffort) {
+    routed.reasoning_effort = childEffort;
+    routed.reasoning = { ...(routed.reasoning || {}), effort: childEffort };
+  }
+  normalizeAutoToolChoice(routed, route);
+  // Native OpenAI traffic keeps client_metadata; routed providers do not
+  // consume it and the strict ones reject the unknown field.
+  delete routed.client_metadata;
+  // Codex sends reasoning as an object. LiteLLM's Ollama path tests that value
+  // for membership of a string set, which raises on a dict and fails the whole
+  // turn -- 210 of them here before this was caught. Ollama has no
+  // reasoning-effort concept to map it onto anyway, so drop it rather than
+  // translate it into something the model never asked for.
+  if (provider?.keyless) {
+    delete routed.reasoning;
+    delete routed.reasoning_effort;
+  }
+  if (provider?.id === "fireworks") delete routed.web_search_options;
+  return {
+    body: Buffer.from(JSON.stringify(routed), "utf8"),
+    target: `${GATEWAY_BASE}/responses`,
+    headers: routedHeaders(),
+    namespacesFlattened,
+    flattenedNamespaces,
+    // Close finished children the parent left Working. Only when the
+    // collaboration toolset is actually available on this turn.
+    pendingInterrupts: pendingInterruptTargets(input, {
+      namespaces: flattenedNamespaces,
+    }),
+  };
+}
+
+// The models this turn could be moved to, best first. Deliberately computed
+// only after a failure is already known: `selectedConfiguredListedModels()`
+// probes every provider's credential synchronously and spawns
+// `/usr/bin/security` per keychain service on macOS, which would cost every
+// healthy turn about 250ms of blocked event loop for nothing.
+function failoverCandidates({ route, routedBody, agedInput, flattenedNamespaces, chain }) {
+  const hidden = readHiddenModels();
+  return rankFailoverCandidates(
+    selectedConfiguredListedModels().filter((model) => !hidden.has(model.slug)),
+    {
+      from: route,
+      // The bytes this turn was about to send. `estimateInputTokens` errs high
+      // by design, which is the safe direction here: a candidate that cannot
+      // hold the conversation would answer the quota failure with a
+      // context-window rejection, which is a strictly worse turn than the one
+      // it replaced.
+      estimatedTokens: estimateInputTokens(routedBody),
+      needsImage: inputHasImage(agedInput),
+      // Only a turn that can actually spawn children needs a model that has
+      // been through the collaboration proof. A child answering its own turn
+      // does not.
+      needsMultiAgentV2: collaborationToolAvailable(flattenedNamespaces),
+      chain,
+    },
+  );
+}
+
+function logFailover(from, to, reason, status) {
+  // Never gated on CODEX_ROUTER_QUIET, which a production LaunchAgent hard-sets.
+  // A silent swap makes an exhausted provider look healthy and leaves the
+  // operator wondering why the answers changed character.
+  console.error(
+    `[codex-router] failover model=${from.slug} reason=${reason} status=${status} -> ${
+      to ? to.slug : "none"
+    }`,
+  );
+}
+
+// Moves a turn whose provider reported it has no usage left onto another model.
+//
+// Legal only because nothing has been relayed: this runs before `pipeResponse`,
+// and `nothingRelayed` is re-checked before every hop. Returns the state the
+// caller should switch to, or undefined to keep the original failure -- which
+// is the honest answer whenever no candidate can serve this conversation.
+async function attemptModelFailover({
+  request,
+  response,
+  payload,
+  route,
+  agedInput,
+  routedBody,
+  flattenedNamespaces,
+  verdict,
+  status,
+  signal,
+}) {
+  const settings = readFailoverSettings();
+  if (!settings.enabled) return undefined;
+  const candidates = failoverCandidates({
+    route,
+    routedBody,
+    agedInput,
+    flattenedNamespaces,
+    chain: settings.chain,
+  }).slice(0, MAX_FAILOVER_HOPS);
+  if (!candidates.length) {
+    logFailover(route, undefined, verdict.reason, status);
+    return undefined;
+  }
+  const startedAt = Date.now();
+  for (const { model } of candidates) {
+    // The caller left, or something has been relayed since the last check.
+    // Either way this turn is over: a hop would be work for nobody, or a second
+    // response grafted onto a stream the client is already reading.
+    if (signal.aborted || !nothingRelayed(response)) return undefined;
+    // A turn that has already spent this long recovering is better off
+    // reporting the failure it started with than spending more of the user's
+    // time on another guess.
+    if (Date.now() - startedAt >= FAILOVER_BUDGET_MS) break;
+    let built;
+    let upstream;
+    try {
+      built = await buildRoutedRequest({ request, payload, route: model, agedInput });
+      upstream = await fetch(built.target, {
+        method: "POST",
+        headers: built.headers,
+        body: built.body,
+        signal,
+      });
+    } catch (error) {
+      if (signal.aborted) throw error;
+      logFailover(route, model, verdict.reason, `transport/${error?.name || "Error"}`);
+      continue;
+    }
+    if (upstream.ok) {
+      logFailover(route, model, verdict.reason, status);
+      return { route: model, built, upstream };
+    }
+    // The candidate failed too. If it failed the same way, believe it and take
+    // it out of the running for the next turn as well; anything else is that
+    // model's own problem and not evidence about the operator's chosen one.
+    const hopVerdict = classifyRoutedFailure({
+      status: upstream.status,
+      bodyText: await upstream.text().catch(() => ""),
+      retryAfterSeconds: Number(upstream.headers.get("retry-after")),
+    });
+    if (hopVerdict.swap) recordProviderCooldown(model.provider, hopVerdict);
+    logFailover(route, model, verdict.reason, upstream.status);
+  }
+  return undefined;
+}
+
 // The local answer an idle install gives instead of native forwarding. With
 // discovery disabled the native path is impossible by construction -- the
 // session fallback never reads auth.json -- so traffic that would leave for
@@ -1750,6 +2080,9 @@ async function handleResponses(request, response, requestUrl) {
   let pendingInterrupts = [];
   let emptyCompletion = false;
   let emptyCompletionRetried = false;
+  // The model the operator actually asked for, when this turn ended up being
+  // served by a different one. Present only on a turn the router rescued.
+  let failoverFrom;
   // An empty turn the router could not repair because the attempt was already
   // relayed. Distinct from `emptyCompletionRetried` in the meter: one is a
   // failure the router absorbed, the other a failure it had to hand to the
@@ -1837,13 +2170,15 @@ async function handleResponses(request, response, requestUrl) {
       // Compaction used to return here without metering or logging, so neither
       // a successful nor a failed one appeared anywhere in the router's own
       // telemetry. Mirror the ordinary request path exactly.
+      const compacted = compaction.route || route;
       recordUsageEvent({
-        model: route.slug,
-        provider: canonicalProviderId(route.provider),
+        model: compacted.slug,
+        provider: canonicalProviderId(compacted.provider),
         status: compaction.status,
         durationMs: Date.now() - startedAt,
         ...compaction.usage,
         ...compaction.toolResultAging,
+        ...(compaction.failoverFrom ? { failoverFrom: compaction.failoverFrom } : {}),
       });
       usage = compaction.usage;
       finalStatus = compaction.status;
@@ -1851,7 +2186,9 @@ async function handleResponses(request, response, requestUrl) {
       usageRecorded = true;
       if (!QUIET) {
         console.error(
-          `[codex-router] model=${requestedModel || "unknown"} provider=${route.provider} status=${compaction.status}`,
+          `[codex-router] model=${requestedModel || "unknown"} provider=${compacted.provider} status=${compaction.status}${
+            compaction.failoverFrom ? ` failover-from=${compaction.failoverFrom}` : ""
+          }`,
         );
       }
       return;
@@ -1862,6 +2199,32 @@ async function handleResponses(request, response, requestUrl) {
     let routedBody;
     let namespacesFlattened = false;
     let flattenedNamespaces = new Map();
+    // The route-independent half of the input, computed once. Failing the turn
+    // over to another model rebuilds only the route-dependent half against
+    // these exact items, so the encrypted-payload relay and the aging pass are
+    // paid for once however many models the turn ends up asking.
+    let agedInput;
+    // Adopts a rebuilt request for a different model. Everything downstream --
+    // the response transforms, the prompt-token estimate, the empty-completion
+    // retry -- reads these, so all of them have to move together or the turn
+    // would be relayed through one model's namespace map while another model
+    // answered it.
+    const adoptRoute = (nextRoute, built) => {
+      failoverFrom ??= route.slug;
+      route = nextRoute;
+      namespacesFlattened = built.namespacesFlattened;
+      flattenedNamespaces = built.flattenedNamespaces;
+      pendingInterrupts = built.pendingInterrupts;
+      target = built.target;
+      headers = built.headers;
+      routedBody = built.body;
+      // The tray Island has to name the model that is actually answering.
+      activity.setRoute({
+        provider: canonicalProviderId(route.provider),
+        model: route.slug,
+        ...activityMetadataFromHeaders(request.headers),
+      });
+    };
     if (route) {
       const normalized = await normalizeRoutedAgentInput(
         request,
@@ -1870,112 +2233,38 @@ async function handleResponses(request, response, requestUrl) {
       );
       const aged = ageToolResults(normalized, { enabled: toolResultAgingEnabled() });
       toolResultAging = aged.stats;
-      const input = await bridgeVisionInput(
-        aged.input,
-        route,
-        request,
-      );
-      // DeepSeek thinking mode requires the assistant's reasoning to be
-      // replayed on tool-call turns, but LiteLLM's Responses->chat translation
-      // drops `reasoning` input items entirely. Merge each reasoning summary
-      // into the following assistant function_call message's content so the
-      // translation carries it; the forwarder then attaches it as
-      // `reasoning_content` on the tool-call message.
-      carryReasoningThroughInput(input);
-      const provider = providerForModel(route);
-      // LiteLLM's Responses -> Chat Completions bridge drops namespace tools,
-      // which is how the client ships the collaboration runtime, the app
-      // toolset (threads, automations, navigation), and every MCP server
-      // (node_repl, peekaboo, github, ...). Chat-completions providers need
-      // every namespace flattened into ordinary functions; the response
-      // transform maps calls back to the client's native namespace shape.
-      if (provider?.protocol !== "openai-responses") {
-        // Relay the app's full native toolset (threads, automations, app
-        // navigation) to the provider. The client registers these tools with
-        // deferLoading and executes the calls natively, but only sends a
-        // reduced codex_app namespace on routed requests; merge the deferred
-        // definitions in so routed models see what native models see. The
-        // router never executes these calls -- the app owns thread, automation,
-        // and navigation state -- it only relays definitions and results.
-        const merged = mergeCodexAppTools(payload.tools);
-        if (merged.merged) payload.tools = merged.tools;
-        const flattened = flattenNamespaceTools(payload.tools);
-        namespacesFlattened = flattened.flattened;
-        if (namespacesFlattened) {
-          payload.tools = flattened.tools;
-          flattenedNamespaces = flattened.namespaces;
+      agedInput = aged.input;
+      const built = await buildRoutedRequest({ request, payload, route, agedInput });
+      namespacesFlattened = built.namespacesFlattened;
+      flattenedNamespaces = built.flattenedNamespaces;
+      pendingInterrupts = built.pendingInterrupts;
+      target = built.target;
+      headers = built.headers;
+      routedBody = built.body;
+      // This provider has already said it would be empty until a named time.
+      // Sending anyway buys one guaranteed rejection per turn for as long as
+      // the window lasts, so move now and skip the dead round trip. The body
+      // just built is thrown away, which costs one local serialization -- far
+      // less than the request it avoids. The cooldown expires by itself, so
+      // the operator's chosen model comes back without anyone doing anything.
+      const settings = readFailoverSettings();
+      const cooled = settings.enabled ? providerCooldown(route.provider) : undefined;
+      if (cooled) {
+        const [next] = failoverCandidates({
+          route,
+          routedBody,
+          agedInput,
+          flattenedNamespaces,
+          chain: settings.chain,
+        });
+        if (next) {
+          logFailover(route, next.model, `cooled_until_${cooled.until}`, "skipped");
+          adoptRoute(
+            next.model,
+            await buildRoutedRequest({ request, payload, route: next.model, agedInput }),
+          );
         }
-      } else {
-        // Responses-native providers keep the namespace tools untouched, so
-        // nothing is flattened and the payload is left alone. The inventory is
-        // still built, because the response transform reads the exact
-        // spawn_agent model enum off it to drop an invented or stale optional
-        // override before Codex validates the call.
-        flattenedNamespaces = flattenNamespaceTools(payload.tools).namespaces;
-        // Keeping the namespace shape is not the same as keeping a root the
-        // upstream rejects. `opencode-go-responses/gpt-5.6-luna` 400s a
-        // `type: ["object","null"]` parameter root while accepting the same
-        // request with a plain or union root -- so the strict-root repair has to
-        // run here too, on the tools alone, without flattening anything.
-        payload.tools = repairToolSchemaRoots(payload.tools);
       }
-      let routedInput = input;
-      // The stored call history must use the same tool names as the tool
-      // list, or the model copies the bare names out of its own transcript.
-      if (namespacesFlattened) {
-        routedInput = flattenNamespacedHistory(routedInput, flattenedNamespaces);
-      }
-      // Close finished children the parent left Working. Only when the
-      // collaboration toolset is actually available on this turn.
-      pendingInterrupts = pendingInterruptTargets(input, {
-        namespaces: flattenedNamespaces,
-      });
-      const routed = {
-        ...payload,
-        model: route.gatewayModel,
-        input: routedInput,
-      };
-      // Codex chooses a child's model; this is where an operator gets to
-      // choose its depth. Applied only to turns Codex marked as a child, so a
-      // parent conversation on the same model is untouched -- running one
-      // model differently in the two roles is the whole point.
-      //
-      // The level is deliberately not validated against the model here. A
-      // provider that rejects an unsupported effort says so in a way the
-      // operator can read, whereas silently dropping the setting looks like
-      // the feature never worked.
-      const childEffort = request.headers["x-openai-subagent"]
-        ? subagentEffort(route.slug)
-        : undefined;
-      // This leaves on the Responses API, where the effort travels inside
-      // `reasoning`. A flat `reasoning_effort` is a Chat Completions field:
-      // LiteLLM's Responses bridge derives its own effort from `reasoning`
-      // whenever the client sent one -- and Codex always does -- then that
-      // derived value overwrites anything flat the router set, so a flat-only
-      // override never reaches the provider. Set both: `reasoning.effort` is
-      // what actually travels, and the flat field is what a bare
-      // chat-completions gateway would read.
-      if (childEffort) {
-        routed.reasoning_effort = childEffort;
-        routed.reasoning = { ...(routed.reasoning || {}), effort: childEffort };
-      }
-      normalizeAutoToolChoice(routed, route);
-      // Native OpenAI traffic keeps client_metadata; routed providers do not
-      // consume it and the strict ones reject the unknown field.
-      delete routed.client_metadata;
-      // Codex sends reasoning as an object. LiteLLM's Ollama path tests that
-      // value for membership of a string set, which raises on a dict and fails
-      // the whole turn -- 210 of them here before this was caught. Ollama has
-      // no reasoning-effort concept to map it onto anyway, so drop it rather
-      // than translate it into something the model never asked for.
-      if (provider?.keyless) {
-        delete routed.reasoning;
-        delete routed.reasoning_effort;
-      }
-      if (provider?.id === "fireworks") delete routed.web_search_options;
-      target = `${GATEWAY_BASE}/responses`;
-      headers = routedHeaders();
-      routedBody = Buffer.from(JSON.stringify(routed), "utf8");
     } else {
       const native = { ...payload };
       if (Array.isArray(payload.input)) {
@@ -2018,7 +2307,7 @@ async function handleResponses(request, response, requestUrl) {
     // attempt replays the identical bytes under the identical encoding. Nothing
     // here consumes a stream, which is what makes the request replayable at
     // all.
-    const { response: upstream, retries } = await fetchWithRetry(
+    let { response: upstream, retries } = await fetchWithRetry(
       target,
       {
         method: "POST",
@@ -2042,6 +2331,57 @@ async function handleResponses(request, response, requestUrl) {
     // routed turn that means the full router -> litellm -> api-forwarder ->
     // provider path, so a stall here is the provider's, not the router's.
     upstreamLatencyMs = Date.now() - startedAt;
+    // The body of a failed routed attempt, read once: the failover classifier
+    // and the error translation below both need it, and it can only be read
+    // once. Nothing is relayed either way, so reading it is free.
+    let failedBodyText;
+    if (route && !upstream.ok) {
+      failedBodyText = await upstream.text().catch(() => "");
+      const verdict = classifyRoutedFailure({
+        status: upstream.status,
+        bodyText: failedBodyText,
+        retryAfterSeconds: Number(upstream.headers.get("retry-after")),
+      });
+      if (verdict.swap) {
+        // Believe the provider about when it will be back before trying anyone
+        // else, so the next turn skips it instead of paying for the same
+        // rejection again.
+        recordProviderCooldown(route.provider, verdict);
+        const moved = await attemptModelFailover({
+          request,
+          response,
+          payload,
+          route,
+          agedInput,
+          routedBody,
+          flattenedNamespaces,
+          verdict,
+          status: upstream.status,
+          signal: controller.signal,
+        });
+        if (moved) {
+          // The attempt that failed is still a turn that happened and still
+          // cost the provider something, so it is metered on its own row. The
+          // serving row below carries `failoverFrom`, which is what makes a
+          // rescued turn distinguishable from one that never failed.
+          recordUsageEvent({
+            model: route.slug,
+            provider: canonicalProviderId(route.provider),
+            status: upstream.status,
+            durationMs: Date.now() - startedAt,
+            responseStartMs: upstreamLatencyMs,
+          });
+          adoptRoute(moved.route, moved.built);
+          upstream = moved.upstream;
+          failedBodyText = undefined;
+        }
+      }
+    }
+    // A provider that just answered is not out of usage, whatever this router
+    // recorded earlier: a quota that refilled early, a limit the operator
+    // raised, or a reset time the provider got wrong all end the same way, and
+    // a real answer is better evidence than anything on disk.
+    if (route && upstream.ok) clearProviderCooldown(route.provider);
     // Gateway error bodies leak LiteLLM's internal exception chain, which
     // reads like a router bug. Rewrite them to name the provider that failed.
     // Native traffic passes through untouched: OpenAI errors are already clear.
@@ -2055,7 +2395,9 @@ async function handleResponses(request, response, requestUrl) {
         upstream.status,
         translateGatewayError({
           status: upstream.status,
-          bodyText: await upstream.text(),
+          // Already drained above so the failover classifier could read it; a
+          // second `.text()` on the same response yields "".
+          bodyText: failedBodyText ?? (await upstream.text().catch(() => "")),
           modelName: route.displayName || route.slug,
           providerName: provider?.ownedBy || provider?.displayName || route.provider,
           providerKind: provider?.kind,
@@ -2309,6 +2651,7 @@ async function handleResponses(request, response, requestUrl) {
       ...(emptyCompletionRetried ? { emptyCompletionRetried: true } : {}),
       ...(emptyCompletionUnrepairable ? { emptyCompletionUnrepairable: true } : {}),
       ...(guardReleasedForBudget ? { emptyCompletionGuardReleased: true } : {}),
+      ...(failoverFrom ? { failoverFrom } : {}),
     });
     observeSubagentOutcome(request, route, finalStatus, { emptyCompletion });
     usageRecorded = true;
@@ -2327,7 +2670,9 @@ async function handleResponses(request, response, requestUrl) {
           emptyCompletionRetried ? " empty-completion-retried=true" : ""
         }${
           emptyCompletionUnrepairable ? " empty-completion-unrepairable=true" : ""
-        }${emptyCompletion ? " empty-completion=true" : ""}`,
+        }${emptyCompletion ? " empty-completion=true" : ""}${
+          failoverFrom ? ` failover-from=${failoverFrom}` : ""
+        }`,
       );
     }
   } catch (error) {

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -131,6 +131,13 @@ export function recordUsageEvent({
   // two: compare it against the eligibility floor.
   toolResultsEvaluated,
   toolResultBytesLargest,
+  // Present only on a turn the router moved to another model because the one
+  // the operator asked for reported it had no usage left. `model` and
+  // `provider` above name what actually served the turn; this names what was
+  // asked for. Without it a rescued turn is indistinguishable from an operator
+  // who simply changed models, which is the difference between "your provider
+  // is empty" and "you switched".
+  failoverFrom,
   at = Date.now(),
 }) {
   const event = {
@@ -156,6 +163,9 @@ export function recordUsageEvent({
       ? { emptyCompletionGuardReleased: true }
       : {}),
     ...(safeRetryCount(retries) !== undefined ? { retries: safeRetryCount(retries) } : {}),
+    ...(typeof failoverFrom === "string" && failoverFrom.trim()
+      ? { failoverFrom: safeText(failoverFrom, "unknown") }
+      : {}),
     ...(safeTokenCount(inputTokens) !== undefined
       ? { inputTokens: safeTokenCount(inputTokens) }
       : {}),

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -1,0 +1,536 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { callerBaseUrl } from "../src/caller-auth.mjs";
+import { openPort } from "./port-pool.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
+const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
+
+// The model the turn asks for, and the one the router is told to move it to.
+// The fallback is named explicitly rather than left to the ranking so the
+// assertion does not depend on which providers the developer's own machine has
+// credentials for.
+const PRIMARY = { slug: "deepseek/deepseek-v4-pro", gatewayModel: "deepseek-v4-pro" };
+const FALLBACK = { slug: "zai-api/glm-5.2", gatewayModel: "zai-api-glm-5-2" };
+
+const TURN_BODY = { model: PRIMARY.slug, input: "hello", stream: true };
+
+// Marker text is what proves whose bytes reached the client.
+function contentSse(marker) {
+  return [
+    `data: ${JSON.stringify({ type: "response.created", response: { id: `r-${marker}` } })}`,
+    "",
+    `data: ${JSON.stringify({
+      type: "response.output_text.delta",
+      delta: `answered-by-${marker}`,
+    })}`,
+    "",
+    `data: ${JSON.stringify({
+      type: "response.completed",
+      response: {
+        id: `r-${marker}`,
+        output: [
+          { type: "message", role: "assistant", content: [{ type: "output_text", text: marker }] },
+        ],
+        usage: { input_tokens: 100, output_tokens: 5, total_tokens: 105 },
+      },
+    })}`,
+    "",
+    "data: [DONE]",
+    "",
+  ].join("\n");
+}
+
+const QUOTA_BODY = JSON.stringify({
+  error: {
+    message:
+      "litellm.RateLimitError: RateLimitError: OpenAIException - You have exceeded your current quota, please check your plan and billing details.",
+    type: "insufficient_quota",
+    code: "429",
+  },
+});
+
+const BAD_KEY_BODY = JSON.stringify({
+  error: { message: "Incorrect API key provided.", type: "invalid_request_error", code: "401" },
+});
+
+async function mockServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return { server, port: server.address().port };
+}
+
+function gateway(handler) {
+  return mockServer((request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      const payload = Buffer.from(JSON.stringify({ ok: true }), "utf8");
+      response.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    handler(request, response);
+  });
+}
+
+function bodyJson(request) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    request.on("data", (chunk) => chunks.push(chunk));
+    request.on("end", () => {
+      try {
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+function run(env, { chain = [FALLBACK.slug], enabled = true, cooldowns } = {}) {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-failover-router-state-"));
+  if (chain !== null) {
+    writeFileSync(
+      path.join(stateDir, "failover.json"),
+      JSON.stringify({ version: 1, enabled, chain }),
+      "utf8",
+    );
+  }
+  if (cooldowns) {
+    writeFileSync(
+      path.join(stateDir, "provider-cooldowns.json"),
+      JSON.stringify(cooldowns),
+      "utf8",
+    );
+  }
+  // A candidate has to be one the operator could actually reach, and
+  // `configuredProviderIds()` only counts a *persistent* credential -- an
+  // environment variable deliberately does not qualify. Write the file the
+  // provider's registry entry names, so the fallback is credentialed here and
+  // nowhere else on the machine.
+  writeFileSync(path.join(stateDir, "zai-api-key.secret"), "test-zai-platform-key\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MODEL_ROUTER_STATE_DIR: stateDir,
+      CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
+      CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+      KIMI_INTERNAL_KEY: INTERNAL_KEY,
+      CODEX_ROUTER_SHOW_ALL_MODELS: "1",
+      // The failover log line must survive the flag a production LaunchAgent
+      // hard-sets, so every test here runs with it on.
+      CODEX_ROUTER_QUIET: "1",
+      // Makes the fallback provider credentialed without touching a keychain.
+      ZAI_PLATFORM_API_KEY: "test-zai-platform-key",
+      ...env,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let errors = "";
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+  child.testErrors = () => errors;
+  child.stateDir = stateDir;
+  return child;
+}
+
+function routerEnv(gatewayPort, routerPort) {
+  return {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+  };
+}
+
+function usageEvents(stateDir) {
+  const file = path.join(stateDir, "usage-events.jsonl");
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line));
+}
+
+async function waitForUsageEvents(stateDir, count, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const events = usageEvents(stateDir);
+    if (events.length >= count) return events;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${count} usage events: ${child.testErrors()}`);
+}
+
+async function waitFor(url, child) {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Child exited early (${child.exitCode}): ${child.testErrors()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Not bound yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${url}: ${child.testErrors()}`);
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await new Promise((resolve) => child.once("exit", resolve));
+}
+
+async function closeServer(server) {
+  await new Promise((resolve) => server.close(resolve));
+}
+
+function readRouted(port, body) {
+  return new Promise((resolve, reject) => {
+    const base = new URL(`${callerBaseUrl(port, CALLER_KEY)}/responses`);
+    const request = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: base.pathname,
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: "Bearer codex-caller-auth" },
+      },
+      (response) => {
+        let text = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          text += chunk;
+        });
+        const done = () =>
+          resolve({
+            status: response.statusCode,
+            headers: response.headers,
+            body: text,
+            complete: response.complete,
+          });
+        response.once("end", done);
+        response.once("close", done);
+        response.once("error", done);
+      },
+    );
+    request.once("error", reject);
+    request.end(JSON.stringify(body));
+  });
+}
+
+function streamGateway() {
+  const seen = [];
+  return {
+    seen,
+    handler: async (request, response, decide) => {
+      const body = await bodyJson(request);
+      seen.push(body);
+      decide(body, response);
+    },
+  };
+}
+
+test("a turn whose provider is out of usage is served by the next model", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    if (body.model === PRIMARY.gatewayModel) {
+      const payload = Buffer.from(QUOTA_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("fallback"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort));
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, TURN_BODY);
+
+    // Exactly two upstream attempts: the exhausted model, then the fallback.
+    assert.equal(seen.length, 2);
+    assert.equal(seen[0].model, PRIMARY.gatewayModel);
+    assert.equal(seen[1].model, FALLBACK.gatewayModel);
+
+    // The client saw one clean 200 carrying only the fallback's bytes. The
+    // failed attempt must never appear in the stream.
+    assert.equal(result.status, 200);
+    assert.equal(result.complete, true);
+    assert.match(result.body, /answered-by-fallback/);
+    assert.doesNotMatch(result.body, /exceeded your current quota/);
+
+    // Both attempts are metered, and the serving row names what was asked for.
+    const events = await waitForUsageEvents(child.stateDir, 2, child);
+    const failed = events.find((event) => event.model === PRIMARY.slug);
+    const served = events.find((event) => event.model === FALLBACK.slug);
+    assert.equal(failed.status, 429);
+    assert.equal(failed.failoverFrom, undefined);
+    assert.equal(served.status, 200);
+    assert.equal(served.failoverFrom, PRIMARY.slug);
+
+    // The swap is never silent, even with the quiet flag a LaunchAgent sets.
+    assert.match(child.testErrors(), /failover model=deepseek\/deepseek-v4-pro/);
+    assert.match(child.testErrors(), /reason=out_of_usage/);
+    assert.match(child.testErrors(), /-> zai-api\/glm-5\.2/);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("the exhausted provider is skipped outright on the next turn", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    if (body.model === PRIMARY.gatewayModel) {
+      // Names when it will be back, which is what the router is allowed to
+      // believe. Without this header the next turn must ask again.
+      const payload = Buffer.from(QUOTA_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Retry-After": "1800",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("fallback"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort));
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    await readRouted(routerPort, TURN_BODY);
+    assert.equal(seen.length, 2);
+
+    const second = await readRouted(routerPort, TURN_BODY);
+    // One attempt this time: the cooled-down provider is never contacted.
+    assert.equal(seen.length, 3);
+    assert.equal(seen[2].model, FALLBACK.gatewayModel);
+    assert.equal(second.status, 200);
+    assert.match(second.body, /answered-by-fallback/);
+    assert.match(child.testErrors(), /reason=cooled_until_/);
+
+    const cooldowns = JSON.parse(
+      readFileSync(path.join(child.stateDir, "provider-cooldowns.json"), "utf8"),
+    );
+    assert.equal(cooldowns.deepseek.reason, "out_of_usage");
+    assert.ok(Date.parse(cooldowns.deepseek.until) > Date.now());
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a rejected credential keeps its own error and is never swapped away", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    const payload = Buffer.from(BAD_KEY_BODY, "utf8");
+    response.writeHead(401, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort));
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, TURN_BODY);
+    // Exactly one attempt, and the operator still reads the real cause.
+    assert.equal(seen.length, 1);
+    assert.equal(result.status, 401);
+    const payload = JSON.parse(result.body);
+    assert.equal(payload.error.type, "authentication_error");
+    assert.match(payload.error.message, /DeepSeek/i);
+    assert.doesNotMatch(child.testErrors(), /failover/);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("with nothing eligible the original failure is returned unchanged", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    const payload = Buffer.from(QUOTA_BODY, "utf8");
+    response.writeHead(429, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const routerPort = await openPort();
+  // A chain naming only a model this build cannot route to leaves no candidate.
+  const child = run(routerEnv(gw.port, routerPort), { chain: ["gone/removed-model"] });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, TURN_BODY);
+    assert.equal(seen.length, 1);
+    assert.equal(result.status, 429);
+    const payload = JSON.parse(result.body);
+    assert.equal(payload.error.type, "billing_error");
+    assert.match(payload.error.message, /run out of usage/i);
+    // The turn still says out loud that it looked and found nothing.
+    assert.match(child.testErrors(), /failover model=deepseek\/deepseek-v4-pro.*-> none/s);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("an operator who turned failover off keeps the plain error", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    const payload = Buffer.from(QUOTA_BODY, "utf8");
+    response.writeHead(429, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), { enabled: false, chain: [] });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, TURN_BODY);
+    assert.equal(seen.length, 1);
+    assert.equal(result.status, 429);
+    assert.doesNotMatch(child.testErrors(), /failover/);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a provider that answers again clears the cooldown this router recorded", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("primary"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), {
+    // A stale window recorded earlier, for a provider that is in fact fine.
+    // With nothing eligible to move to, the turn stays on the operator's own
+    // model -- and its success is what retires the window. (A cooldown with a
+    // candidate behind it is never probed; it expires on its own clock.)
+    chain: ["gone/removed-model"],
+    cooldowns: {
+      deepseek: {
+        until: new Date(Date.now() + 30 * 60_000).toISOString(),
+        reason: "out_of_usage",
+      },
+    },
+  });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, TURN_BODY);
+    assert.equal(result.status, 200);
+    assert.match(result.body, /answered-by-primary/);
+    await waitForUsageEvents(child.stateDir, 1, child);
+    const cooldowns = JSON.parse(
+      readFileSync(path.join(child.stateDir, "provider-cooldowns.json"), "utf8"),
+    );
+    assert.equal(cooldowns.deepseek, undefined);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a fallback rebuild carries the full request, not a model swap", async () => {
+  // The routed body is rebuilt for the fallback from the pristine payload.
+  // The regression this guards is a second build over already-flattened tools,
+  // which yields a plausible tool list with an empty namespace map.
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    if (body.model === PRIMARY.gatewayModel) {
+      const payload = Buffer.from(QUOTA_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("fallback"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort));
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    await readRouted(routerPort, {
+      ...TURN_BODY,
+      tools: [
+        {
+          type: "namespace",
+          name: "collaboration",
+          tools: [
+            {
+              type: "function",
+              name: "spawn_agent",
+              description: "Spawn a child agent.",
+              parameters: { type: "object", properties: {}, additionalProperties: false },
+            },
+          ],
+        },
+      ],
+    });
+    assert.equal(seen.length, 2);
+    const [first, second] = seen;
+    // Both attempts flattened the namespace the same way, from the same source.
+    const names = (body) => (body.tools || []).map((tool) => tool.name).sort();
+    assert.deepEqual(names(second), names(first));
+    assert.ok(names(second).includes("collaboration__spawn_agent"));
+    // A bare string is as legal an `input` as an array, and the rebuild must
+    // hand the fallback the same prompt -- not the same prompt spread into its
+    // own letters, which reaches the provider and still reads as a 200.
+    assert.equal(first.input, "hello");
+    assert.equal(second.input, "hello");
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -1,0 +1,361 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-failover-test-"));
+process.env.CODEX_ROUTER_STATE_DIR = stateDir;
+
+const {
+  FAILOVER_TIER,
+  MAX_COOLDOWN_MS,
+  MIN_RATE_LIMIT_COOLDOWN_SECONDS,
+  PROVIDER_COOLDOWNS_PATH,
+  classifyRoutedFailure,
+  clearAllProviderCooldowns,
+  clearProviderCooldown,
+  failoverTier,
+  providerCooldown,
+  rankFailoverCandidates,
+  readFailoverSettings,
+  readProviderCooldowns,
+  recordProviderCooldown,
+  setFailoverChain,
+  setFailoverEnabled,
+} = await import("../src/model-failover.mjs");
+
+const NOW = Date.parse("2026-08-15T12:00:00.000Z");
+
+function quotaBody(message) {
+  return JSON.stringify({ error: { message } });
+}
+
+// -- classification ----------------------------------------------------------
+
+test("classifyRoutedFailure swaps on exhausted usage across provider dialects", () => {
+  const bodies = [
+    // OpenAI-style insufficient_quota, DeepSeek/Anthropic balance wording, zai
+    // and Kimi plan limits, and the Chinese-market phrasing.
+    "You exceeded your current quota, please check your plan and billing details.",
+    "Your credit balance is too low to access the Anthropic API.",
+    "usage limit reached for your GLM Coding Plan",
+    "You have reached your monthly limit.",
+    "余额不足",
+  ];
+  for (const message of bodies) {
+    const verdict = classifyRoutedFailure({ status: 429, bodyText: quotaBody(message), now: NOW });
+    assert.equal(verdict.swap, true, message);
+    assert.equal(verdict.reason, "out_of_usage", message);
+  }
+});
+
+test("classifyRoutedFailure swaps on 402 whatever the body says", () => {
+  const verdict = classifyRoutedFailure({ status: 402, bodyText: "{}", now: NOW });
+  assert.deepEqual(verdict, { swap: true, reason: "out_of_usage" });
+});
+
+test("classifyRoutedFailure records no window when the provider named none", () => {
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaBody("insufficient_quota"),
+    now: NOW,
+  });
+  assert.equal(verdict.swap, true);
+  assert.equal(verdict.until, undefined);
+});
+
+test("classifyRoutedFailure carries the provider's own reset time", () => {
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaBody("insufficient_quota"),
+    retryAfterSeconds: 900,
+    now: NOW,
+  });
+  assert.equal(verdict.until, new Date(NOW + 900_000).toISOString());
+});
+
+test("classifyRoutedFailure swaps on a rate limit only when it is long", () => {
+  const short = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaBody("Too many requests"),
+    retryAfterSeconds: MIN_RATE_LIMIT_COOLDOWN_SECONDS,
+    now: NOW,
+  });
+  assert.equal(short.swap, false);
+
+  const long = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaBody("Too many requests"),
+    retryAfterSeconds: 600,
+    now: NOW,
+  });
+  assert.deepEqual(long, {
+    swap: true,
+    reason: "rate_limited",
+    until: new Date(NOW + 600_000).toISOString(),
+  });
+});
+
+test("classifyRoutedFailure never swaps an entitlement failure for a quota one", () => {
+  // "upgrade your plan" appears in both pattern sets; a plan that never
+  // included the API is not something another model's quota can fix, and the
+  // operator has to read the real message.
+  const verdict = classifyRoutedFailure({
+    status: 403,
+    bodyText: quotaBody("Your Go plan doesn't include API access. Upgrade to Provider or higher."),
+    now: NOW,
+  });
+  assert.equal(verdict.swap, false);
+});
+
+test("classifyRoutedFailure leaves every other failure exactly as it was", () => {
+  const cases = [
+    { status: 400, bodyText: quotaBody("Invalid request") },
+    { status: 401, bodyText: quotaBody("Incorrect API key provided") },
+    { status: 403, bodyText: quotaBody("Forbidden") },
+    { status: 404, bodyText: quotaBody("model not found") },
+    { status: 429, bodyText: quotaBody("Too many requests") },
+    { status: 500, bodyText: quotaBody("insufficient_quota") },
+    { status: 503, bodyText: quotaBody("insufficient_quota") },
+  ];
+  for (const one of cases) {
+    assert.equal(classifyRoutedFailure({ ...one, now: NOW }).swap, false, String(one.status));
+  }
+});
+
+// -- cooldowns ---------------------------------------------------------------
+
+test("recordProviderCooldown stores only a window the provider reported", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  assert.equal(recordProviderCooldown("zai-coding", { reason: "out_of_usage" }), undefined);
+  assert.deepEqual(readProviderCooldowns({ now: NOW }), {});
+});
+
+test("providerCooldown expires by itself and needs no sweeper", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  recordProviderCooldown("zai-coding", {
+    until: new Date(NOW + 60_000).toISOString(),
+    reason: "out_of_usage",
+    now: NOW,
+  });
+  assert.equal(providerCooldown("zai-coding", { now: NOW })?.reason, "out_of_usage");
+  assert.equal(providerCooldown("zai-coding", { now: NOW + 61_000 }), undefined);
+});
+
+test("a cooldown is capped so a malformed reset cannot strand a model", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  const entry = recordProviderCooldown("zai-coding", {
+    // Some gateways send epoch seconds where seconds-from-now belong.
+    until: new Date(NOW + 400 * 24 * 60 * 60 * 1_000).toISOString(),
+    now: NOW,
+  });
+  assert.equal(Date.parse(entry.until), NOW + MAX_COOLDOWN_MS);
+});
+
+test("a cooldown is recorded against the whole variant family", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  // Protocol variants share one credential and therefore one quota, so a
+  // variant that reported empty must cool its parent down too.
+  recordProviderCooldown("opencode-go-responses", {
+    until: new Date(NOW + 60_000).toISOString(),
+    now: NOW,
+  });
+  assert.ok(providerCooldown("opencode-go", { now: NOW }));
+});
+
+test("clearProviderCooldown lets a provider back in on its first success", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  recordProviderCooldown("zai-coding", { until: new Date(NOW + 60_000).toISOString(), now: NOW });
+  assert.equal(clearProviderCooldown("zai-coding"), true);
+  assert.equal(providerCooldown("zai-coding", { now: NOW }), undefined);
+});
+
+test("an unreadable cooldown document means nothing is cooled down", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  writeFileSync(PROVIDER_COOLDOWNS_PATH, "{not json", "utf8");
+  assert.deepEqual(readProviderCooldowns({ now: NOW }), {});
+});
+
+// -- ranking -----------------------------------------------------------------
+
+const FROM = { slug: "zai-coding/glm-5.3", provider: "zai-coding", contextWindow: 1_048_576 };
+
+function model(slug, provider, extra = {}) {
+  return {
+    slug,
+    provider,
+    priority: 50,
+    contextWindow: 262_144,
+    inputModalities: ["text"],
+    ...extra,
+  };
+}
+
+test("rankFailoverCandidates puts free models ahead of paid ones", () => {
+  const ranked = rankFailoverCandidates(
+    [
+      model("kimi/k3", "kimi", { priority: 10 }),
+      model("opencode-free/big-pickle", "opencode-free", { priority: 90 }),
+    ],
+    { from: FROM },
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.model.slug),
+    ["opencode-free/big-pickle", "kimi/k3"],
+  );
+  assert.equal(ranked[0].tier, FAILOVER_TIER.free);
+  assert.equal(ranked[1].tier, FAILOVER_TIER.subscription);
+});
+
+test("rankFailoverCandidates orders a tier by the registry's own preference", () => {
+  const ranked = rankFailoverCandidates(
+    [model("kimi/k3", "kimi", { priority: 60 }), model("deepseek/v4", "deepseek", { priority: 20 })],
+    { from: FROM },
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.model.slug),
+    ["deepseek/v4", "kimi/k3"],
+  );
+});
+
+test("rankFailoverCandidates never routes back into the same quota", () => {
+  const ranked = rankFailoverCandidates(
+    [
+      model("zai-coding/glm-5.2", "zai-coding"),
+      // A protocol variant of the exhausted provider shares its credential.
+      model("zai-coding/glm-5.1", "zai-coding"),
+      model("kimi/k3", "kimi"),
+    ],
+    { from: FROM },
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.model.slug),
+    ["kimi/k3"],
+  );
+});
+
+test("rankFailoverCandidates will not trade a quota error for a context error", () => {
+  const ranked = rankFailoverCandidates(
+    [model("kimi/k3", "kimi", { contextWindow: 262_144 }), model("gemini/g4", "gemini", { contextWindow: 1_048_576 })],
+    { from: FROM, estimatedTokens: 400_000 },
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.model.slug),
+    ["gemini/g4"],
+  );
+});
+
+test("rankFailoverCandidates skips a provider that is already cooled down", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  recordProviderCooldown("kimi", { until: new Date(NOW + 600_000).toISOString(), now: NOW });
+  const ranked = rankFailoverCandidates(
+    [model("kimi/k3", "kimi"), model("deepseek/v4", "deepseek")],
+    { from: FROM, now: NOW },
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.model.slug),
+    ["deepseek/v4"],
+  );
+});
+
+test("rankFailoverCandidates keeps a collaboration turn on a v2 model", () => {
+  const ranked = rankFailoverCandidates(
+    [
+      model("kimi/k3", "kimi", { multiAgentVersion: "v1" }),
+      model("deepseek/v4", "deepseek", { multiAgentVersion: "v2" }),
+    ],
+    { from: FROM, needsMultiAgentV2: true },
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.model.slug),
+    ["deepseek/v4"],
+  );
+});
+
+test("rankFailoverCandidates refuses a model the registry bars from the vision bridge", () => {
+  const ranked = rankFailoverCandidates(
+    [
+      model("kimi/k3", "kimi", { visionBridge: false }),
+      model("deepseek/v4", "deepseek"),
+      model("gemini/g4", "gemini", { inputModalities: ["text", "image"] }),
+    ],
+    { from: FROM, needsImage: true },
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.model.slug).sort(),
+    ["deepseek/v4", "gemini/g4"],
+  );
+});
+
+test("rankFailoverCandidates returns nothing rather than something unsuitable", () => {
+  assert.deepEqual(rankFailoverCandidates([model("zai-coding/glm-5.2", "zai-coding")], { from: FROM }), []);
+  assert.deepEqual(rankFailoverCandidates([], { from: FROM }), []);
+  assert.deepEqual(rankFailoverCandidates(undefined, { from: FROM }), []);
+});
+
+test("a named chain is used verbatim, minus entries this build cannot route to", () => {
+  const ranked = rankFailoverCandidates(
+    [
+      model("kimi/k3", "kimi", { priority: 90 }),
+      model("opencode-free/big-pickle", "opencode-free", { priority: 10 }),
+    ],
+    { from: FROM, chain: ["kimi/k3", "gone/removed-model", "opencode-free/big-pickle"] },
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.model.slug),
+    ["kimi/k3", "opencode-free/big-pickle"],
+  );
+});
+
+test("failoverTier reads free from the registry rather than a name", () => {
+  assert.equal(failoverTier(model("opencode-free/big-pickle", "opencode-free")), FAILOVER_TIER.free);
+  assert.equal(failoverTier(model("local/qwen3", "local")), FAILOVER_TIER.free);
+  assert.equal(failoverTier(model("kimi/k3", "kimi")), FAILOVER_TIER.subscription);
+  // A provider this build does not know is never assumed to be free.
+  assert.equal(failoverTier(model("gone/removed", "gone")), FAILOVER_TIER.subscription);
+});
+
+test("a model on this machine is never chosen automatically, but can be named", () => {
+  const auto = rankFailoverCandidates(
+    [model("local/qwen3", "local"), model("kimi/k3", "kimi")],
+    { from: FROM },
+  );
+  assert.deepEqual(
+    auto.map((entry) => entry.model.slug),
+    ["kimi/k3"],
+  );
+
+  const named = rankFailoverCandidates(
+    [model("local/qwen3", "local"), model("kimi/k3", "kimi")],
+    { from: FROM, chain: ["local/qwen3"] },
+  );
+  assert.deepEqual(
+    named.map((entry) => entry.model.slug),
+    ["local/qwen3"],
+  );
+});
+
+// -- settings ----------------------------------------------------------------
+
+test("failover is on for an install that has never answered the question", () => {
+  assert.equal(readFailoverSettings().enabled, true);
+  assert.equal(readFailoverSettings().defaulted, true);
+});
+
+test("an operator's off is remembered verbatim", () => {
+  setFailoverEnabled(false);
+  assert.equal(readFailoverSettings().enabled, false);
+  assert.equal(readFailoverSettings().defaulted, undefined);
+  setFailoverEnabled(true);
+  assert.equal(readFailoverSettings().enabled, true);
+});
+
+test("setFailoverChain accepts comma-separated slugs and auto clears it", () => {
+  assert.deepEqual(setFailoverChain(["a/one,b/two", " c/three "]).chain, [
+    "a/one",
+    "b/two",
+    "c/three",
+  ]);
+  assert.deepEqual(setFailoverChain([]).chain, []);
+});

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -164,6 +164,24 @@ test("a cooldown is recorded against the whole variant family", (t) => {
   assert.ok(providerCooldown("opencode-go", { now: NOW }));
 });
 
+test("a later hop may sharpen the reason but never invent the window", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  // api-forwarder sees the provider's Retry-After but not its body, so it can
+  // only say "429". The router reads the body and knows the plan is exhausted.
+  recordProviderCooldown("zai-coding", {
+    until: new Date(NOW + 1_800_000).toISOString(),
+    reason: "rate_limited",
+    now: NOW,
+  });
+  const refined = recordProviderCooldown("zai-coding", { reason: "out_of_usage", now: NOW });
+  assert.equal(refined.reason, "out_of_usage");
+  // The window itself is untouched by the refinement.
+  assert.equal(refined.until, new Date(NOW + 1_800_000).toISOString());
+  // And a reason alone still cannot cool a provider that is not already cooled.
+  assert.equal(recordProviderCooldown("kimi-api", { reason: "out_of_usage", now: NOW }), undefined);
+  assert.equal(providerCooldown("kimi-api", { now: NOW }), undefined);
+});
+
 test("clearProviderCooldown lets a provider back in on its first success", (t) => {
   t.after(() => clearAllProviderCooldowns());
   recordProviderCooldown("zai-coding", { until: new Date(NOW + 60_000).toISOString(), now: NOW });

--- a/test/vision-bridge.test.mjs
+++ b/test/vision-bridge.test.mjs
@@ -1445,15 +1445,31 @@ test("every surface asks the one shared helper for native vision candidates", as
   }
 });
 
+// Scopes a source guard to one top-level function.
+//
+// These guards assert on how a caller is *written*, so they have to see that
+// caller's body and nothing else. Slicing to the next `\n}\n` did that on a
+// checkout with LF endings and silently failed on one with CRLF: `indexOf`
+// returned -1, `slice(start, -1)` swallowed the rest of the file, and the guard
+// quietly widened to every function defined below it. That is how a negative
+// assertion turns into a Windows-only failure naming code it was never meant to
+// police. Normalize first, and refuse to guess when the end is not found.
+function routerFunctionBody(source, signature) {
+  const normalized = source.replace(/\r\n/g, "\n");
+  const start = normalized.indexOf(signature);
+  assert.notEqual(start, -1, `router.mjs must still define ${signature}`);
+  const end = normalized.indexOf("\n}\n", start);
+  assert.notEqual(end, -1, `${signature} must be a top-level function this guard can scope to`);
+  return normalized.slice(start, end);
+}
+
 test("the request path will not nominate a native engine without a live session", async () => {
   // The gate cannot be an on-disk artifact alone: `nativeCatalog()` reuses a
   // cached capture when a fresh probe fails, and the merged catalog is only
   // rewritten on an explicit rebuild, so after a sign-out both still name the
   // engine. The caller's own session is the evidence that cannot go stale.
   const source = await readFile(path.join(repoRoot, "src/router.mjs"), "utf8");
-  const start = source.indexOf("async function bridgeVisionInput");
-  assert.notEqual(start, -1, "router.mjs must still resolve the engine in bridgeVisionInput");
-  const body = source.slice(start, source.indexOf("\n}\n", start));
+  const body = routerFunctionBody(source, "async function bridgeVisionInput");
   assert.match(
     body,
     /hasNativeSession\(nativeHeaders\(request\)\)/,
@@ -1473,9 +1489,7 @@ test("the request path will not nominate a native engine without a live session"
 // how the caller is written, and nothing else observes it from outside.
 test("the request path hands the engine resolver a list it has not built yet", async () => {
   const source = await readFile(path.join(repoRoot, "src/router.mjs"), "utf8");
-  const start = source.indexOf("async function bridgeVisionInput");
-  assert.notEqual(start, -1, "router.mjs must still resolve the engine in bridgeVisionInput");
-  const body = source.slice(start, source.indexOf("\n}\n", start));
+  const body = routerFunctionBody(source, "async function bridgeVisionInput");
   assert.match(
     body,
     /resolveVisionEngines\(\s*\(\)\s*=>/,
@@ -1562,9 +1576,7 @@ test("a cached native transcript is not replayed for a different account", () =>
   // caller's live session, so a hit on another account's entry would skip the
   // call and with it any re-check that this session may spend that model.
   const source = readFileSync(path.join(repoRoot, "src/router.mjs"), "utf8");
-  const start = source.indexOf("async function visionEvidenceFor");
-  assert.notEqual(start, -1);
-  const body = source.slice(start, source.indexOf("\n}\n", start));
+  const body = routerFunctionBody(source, "async function visionEvidenceFor");
   assert.match(body, /engine\.native \? nativeAccountKey\(/);
   assert.match(body, /const key = .*\$\{account\}/);
 });


### PR DESCRIPTION
An install with thirty providers configured runs out of one of them most days: a
coding-plan window closes, a weekly quota lands, a balance empties. The router
named that failure clearly and then stopped — Codex has nothing to do with a
billing error, so a session mid-task simply ended, subagents included, while
every other model the operator could reach sat unused.

The turn is now rebuilt for the next eligible model and sent again. The client
sees one clean answer.

## What qualifies

Deliberately narrow: an exhausted balance or plan limit, a 402, or a 429 whose
`Retry-After` is longer than a minute. A rejected credential, an unknown model, a
malformed request, and every 5xx keep exactly the error they returned before —
swapping models to dodge a bad key would hide the one fact that fixes it, and a
short rate limit is cheaper to wait out than a cold prompt cache is to pay for.

Entitlement failures are classified *before* quota ones, because "upgrade your
plan" appears in both vocabularies and no other provider's quota makes a missing
entitlement true.

## Which model answers

Free first, then the rest in the registry's own preference order. A model on this
machine is never chosen automatically — the runtime might not be running — but it
is used when named in a chain. A candidate whose context window cannot hold the
conversation is skipped, so a quota failure is never traded for a context-window
rejection. Never a sibling of the exhausted provider: variants share a credential
and therefore a quota.

## Cooldowns

When a provider says when it will be back, that window is believed: the next turn
skips it outright rather than buying the same rejection again, and it is used
again once the window passes or the next time it answers. A reset time is never
invented, only read from the provider, and capped at six hours.

`api-forwarder` is where this is captured, and that placement is load-bearing:
**LiteLLM does not relay `Retry-After`** (verified against the live gateway), so
that hop is the only place the provider's own reset time still exists.

## Visibility

Nothing is silent and nothing is injected into the transcript. The router logs
every swap (never gated on `CODEX_ROUTER_QUIET`), the tray Island names the model
actually answering, and the usage event carries `failoverFrom`. `model` and
`provider` always name the pair that served; `failover_from` carries what was
asked for. Codex replays assistant output as input, so a router-authored note
would come back next turn as a sentence the model believes it wrote — hence no
transcript injection.

Compaction gets the same treatment: a compaction that cannot run ends a long
session just as surely as a turn that cannot run.

`./bin/control failover status|on|off|chain <slugs>|auto|reset`. The doctor
reports any provider currently held off and when it clears. On by default;
`off` is remembered permanently.

## Not included

The native ChatGPT tier. It is not a body swap but the other branch entirely, and
it crosses the routed/native boundary AGENTS.md governs — `encrypted_content`
rewriting, the compatibility relay, the collaboration envelope. Those rules
require live marker-return probes through every installed routed agent, so the
tier cannot be added from the test suite alone. Documented as such.

## Test plan

Unit and integration: **1359 pass, 0 fail** (`npm test`), `npm run check` clean.
New coverage in `test/model-failover.test.mjs` (classifier, tiered ranking,
cooldown store) and `test/model-failover-router.test.mjs` (end to end, including
that the failed attempt's bytes never reach the client).

Verified live against a **genuinely out-of-usage provider** (`kimi-oauth/k3`,
real 403 "You've reached your usage limit for this billing cycle"), running the
full stack — router, real LiteLLM, api-forwarder — from this branch after rebase:

- [x] turn on the exhausted model → answered by `grok-oauth/grok-4.6`
- [x] turn with namespace/collaboration tools → answered, tools rebuilt correctly
- [x] subagent turn (`x-openai-subagent`) → answered
- [x] compaction on the exhausted model → real compaction item produced
- [x] healthy model untouched, no failover triggered
- [x] real `commandcode` **entitlement** 403 → correctly not swapped, real message shown
- [x] real `commandcode` 500 → correctly not swapped
- [x] `failover off` → exact prior behaviour restored
- [x] stream integrity: exactly one `response.created` / `response.completed`, no error events
- [x] telemetry: log lines, timing lines, and usage events all name the serving pair

Defects found by that live testing and fixed here: log lines contradicting the
usage event, the compaction timing line crediting the exhausted provider with the
turn's 200, the failed compaction attempt missing from the meter, a mislabelled
cooldown reason, and a string `input` being spread into an array of characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9M4PfijioNMe3RsUQ999x