### PR TITLE
fix(panel): say the browser panel is read-only, and stop claiming ageing is on

### DIFF
--- a/apps/desktop/ui/app.js
+++ b/apps/desktop/ui/app.js
@@ -1,14 +1,17 @@
 import {
   buildQuotaCards,
   chartGeometry,
+  commandRefused,
   compactTokens,
   dailySeries,
   exactTokens,
   formatReset,
   observedModelSpeed,
+  readOnlyCapabilities,
   sevenDayTokens,
   sourceOptions,
   todayTokens,
+  toolResultAgingChecked,
   visibleLocalDownload,
 } from "./model.mjs";
 import { createThinkingOrb } from "./thinking-orb.mjs";
@@ -22,6 +25,12 @@ import {
 
 const invoke = window.__TAURI__?.core?.invoke;
 const view = new URLSearchParams(window.location.search).get("view") || "panel";
+
+// What the surface hosting this UI is willing to run, as the surface itself
+// reported it. Null until platform_info answers, and null forever in the tray
+// and the Electron window, which advertise no limit and carry the full command
+// table: every check below is a no-op for them.
+let capabilities = null;
 
 applyTranslations(document);
 
@@ -70,12 +79,15 @@ function startPanel() {
     localBenchmarkBusy: null,
     maintenanceResult: null,
     toolResultAgingBusy: false,
+    readOnlyWatched: false,
     keyProvider: null,
     removeProvider: null,
     toastTimer: null,
   };
 
   const elements = {
+    panel: document.getElementById("panel"),
+    readOnlyNote: document.getElementById("read-only-note"),
     tabs: [...document.querySelectorAll(".tab")],
     usageView: document.getElementById("usage-view"),
     statusView: document.getElementById("status-view"),
@@ -294,6 +306,7 @@ function startPanel() {
       state.visionDownload = codexSettings.visionBridge.download || null;
     }
     if (state.snapshot?.presence) state.presence = state.snapshot.presence;
+    adoptCapabilities();
     renderPanel();
     elements.refresh.disabled = false;
     if (!quiet && errors.length && !state.snapshot) showToast(errorMessage(errors[0]), true);
@@ -319,7 +332,27 @@ function startPanel() {
     state.lastActivityState = nextActivityState;
   }
 
+  // The surface reports what it will run in platform_info; a surface that says
+  // nothing keeps the full table. Watching starts once, because the restriction
+  // is a property of where this page is served from and cannot change while it
+  // is open.
+  function adoptCapabilities() {
+    capabilities = readOnlyCapabilities(state.platform);
+    if (!capabilities || state.readOnlyWatched) return;
+    state.readOnlyWatched = true;
+    watchReadOnly(elements.panel);
+  }
+
+  function renderReadOnlyNote() {
+    if (!elements.readOnlyNote) return;
+    elements.readOnlyNote.hidden = !capabilities;
+    // Re-read on every render rather than once: switching language re-renders,
+    // and a note left in the previous language is worse than no note.
+    if (capabilities) elements.readOnlyNote.textContent = t("general.readOnlySurface");
+  }
+
   function renderPanel() {
+    renderReadOnlyNote();
     renderStatus();
     renderSourcePicker();
     renderUsage();
@@ -336,6 +369,11 @@ function startPanel() {
     renderToolResultAgingSetting();
     renderVisionBridge();
     renderLocalModels();
+    // Last, because every render above re-derives `disabled` from its own busy
+    // state and would otherwise hand a refused control back to the user. The
+    // observer covers later section rebuilds; this covers the static controls,
+    // whose tooltips also have to follow a language change.
+    if (capabilities) applyReadOnly(elements.panel);
   }
 
   function renderStatus() {
@@ -570,8 +608,8 @@ function startPanel() {
       ? `<div class="local-section-label"><span>Local image readers</span><small>${models.length} available</small></div>${models.map((model) => {
           const installed = model.installed === true;
           const active = operation?.tag === model.tag && operation?.status === "downloading";
-          const action = active ? `<button class="mini-button" type="button" disabled>${Number(operation.percent || 0)}%</button>` : installed ? `<button class="mini-button" type="button" data-vision-action="use" data-model="${escapeHtml(model.tag)}">${vision.engine === "local" && vision.local?.model === model.tag ? "Using" : "Use"}</button>` : `<button class="mini-button" type="button" data-vision-action="download" data-model="${escapeHtml(model.tag)}"${state.visionBusy ? " disabled" : ""}>Download</button>`;
-          const tests = installed ? `<button class="text-button" type="button" data-vision-action="benchmark" data-model="${escapeHtml(model.tag)}"${state.localBenchmarkBusy ? " disabled" : ""}>Test</button>` : "";
+          const action = active ? `<button class="mini-button" type="button" disabled>${Number(operation.percent || 0)}%</button>` : installed ? `<button class="mini-button" type="button" data-command="use_local_vision_model" data-vision-action="use" data-model="${escapeHtml(model.tag)}">${vision.engine === "local" && vision.local?.model === model.tag ? "Using" : "Use"}</button>` : `<button class="mini-button" type="button" data-command="pull_vision_model" data-vision-action="download" data-model="${escapeHtml(model.tag)}"${state.visionBusy ? " disabled" : ""}>Download</button>`;
+          const tests = installed ? `<button class="text-button" type="button" data-command="benchmark_vision_model" data-vision-action="benchmark" data-model="${escapeHtml(model.tag)}"${state.localBenchmarkBusy ? " disabled" : ""}>Test</button>` : "";
           return `<div class="vision-model-row"><span><strong>${escapeHtml(model.label || model.tag)}</strong><small>${escapeHtml(model.tag)} · ${escapeHtml(model.accuracy || "unmeasured")}</small></span><span>${tests}${action}</span></div>`;
         }).join("")}`
       : "";
@@ -612,19 +650,19 @@ function startPanel() {
     const canRemove = provider.kind === "api" && provider.configured;
     const actionButton = isAnonymous
       ? `<button class="mini-button" type="button" disabled title="${escapeHtml(provider.anonymousNote || t("connections.noApiKey"))}">${escapeHtml(actionLabel)}</button>`
-      : `<button class="mini-button" type="button" data-action="${action}" data-provider="${escapeHtml(provider.id)}"${isBusy ? " disabled" : ""}>${escapeHtml(actionLabel)}</button>`;
+      : `<button class="mini-button" type="button" data-command="${action === "connect" ? "connect_oauth" : "save_api_key"}" data-action="${action}" data-provider="${escapeHtml(provider.id)}"${isBusy ? " disabled" : ""}>${escapeHtml(actionLabel)}</button>`;
     return `<article class="provider-row">
       <div><strong>${escapeHtml(provider.displayName)}</strong><small>${escapeHtml(detail)}</small>${provider.planNote ? `<small>${escapeHtml(localizeProviderPlan(provider.planNote))}</small>` : ""}${provider.anonymousNote ? `<small>${escapeHtml(provider.anonymousNote)}</small>` : ""}</div>
       <div class="provider-actions">
         ${actionButton}
         ${
           canRemove
-            ? `<button class="mini-button danger" type="button" data-action="remove-key" data-provider="${escapeHtml(provider.id)}" aria-label="${escapeHtml(t("connections.removeCredentialAria", { provider: provider.displayName }))}"${isBusy ? " disabled" : ""}>${escapeHtml(t("actions.remove"))}</button>`
+            ? `<button class="mini-button danger" type="button" data-command="remove_api_key" data-action="remove-key" data-provider="${escapeHtml(provider.id)}" aria-label="${escapeHtml(t("connections.removeCredentialAria", { provider: provider.displayName }))}"${isBusy ? " disabled" : ""}>${escapeHtml(t("actions.remove"))}</button>`
             : ""
         }
         ${
           provider.configured
-            ? `<label class="provider-check"><input type="checkbox" data-provider="${escapeHtml(provider.id)}" aria-label="${escapeHtml(t("connections.enableProviderAria", { provider: provider.displayName }))}"${enabled ? " checked" : ""}${isBusy ? " disabled" : ""}></label>`
+            ? `<label class="provider-check"><input type="checkbox" data-command="set_provider_enabled" data-provider="${escapeHtml(provider.id)}" aria-label="${escapeHtml(t("connections.enableProviderAria", { provider: provider.displayName }))}"${enabled ? " checked" : ""}${isBusy ? " disabled" : ""}></label>`
             : ""
         }
       </div>
@@ -696,13 +734,14 @@ function startPanel() {
         setting === "picker"
           ? [t("actions.showAll"), t("actions.hideAll")]
           : [t("actions.subagentsOn"), t("actions.subagentsOff")];
+      const groupCommand = setting === "picker" ? "set_picker_provider" : "set_subagent_provider";
       return groups
         .map(
           (group) => `<details class="model-provider-group" open>
             <summary><span>${escapeHtml(providerLabel(group.provider))}</span><span class="model-provider-count">${escapeHtml(groupSummary(group))}</span></summary>
             <div class="model-provider-toolbar">
-              <button class="text-button" type="button" data-provider-setting="${setting}" data-provider="${escapeHtml(group.provider)}" data-enabled="true">${onLabel}</button>
-              <button class="text-button" type="button" data-provider-setting="${setting}" data-provider="${escapeHtml(group.provider)}" data-enabled="false">${offLabel}</button>
+              <button class="text-button" type="button" data-command="${groupCommand}" data-provider-setting="${setting}" data-provider="${escapeHtml(group.provider)}" data-enabled="true">${onLabel}</button>
+              <button class="text-button" type="button" data-command="${groupCommand}" data-provider-setting="${setting}" data-provider="${escapeHtml(group.provider)}" data-enabled="false">${offLabel}</button>
             </div>
             <div class="model-settings-list">${group.items.map(rowMarkup).join("")}</div>
           </details>`,
@@ -740,7 +779,7 @@ function startPanel() {
                 : t("models.untested");
         return `<label class="model-setting-row">
           <span><strong>${escapeHtml(model.displayName)}</strong><small>${escapeHtml(badge)}</small></span>
-          <span class="provider-check"><input type="checkbox" data-subagent="${escapeHtml(model.slug)}" aria-label="${escapeHtml(t("models.useModelAria", { model: model.displayName }))}"${checked ? " checked" : ""}${state.modelSettingsBusy || model.visible === false ? " disabled" : ""}></span>
+          <span class="provider-check"><input type="checkbox" data-command="set_subagent_model" data-subagent="${escapeHtml(model.slug)}" aria-label="${escapeHtml(t("models.useModelAria", { model: model.displayName }))}"${checked ? " checked" : ""}${state.modelSettingsBusy || model.visible === false ? " disabled" : ""}></span>
         </label>`;
       };
 
@@ -767,7 +806,7 @@ function startPanel() {
         const visible = !hiddenModels.has(model.slug);
         return `<label class="model-setting-row">
           <span><strong>${escapeHtml(model.displayName)}</strong><small>${escapeHtml(model.slug)}</small></span>
-          <span class="provider-check"><input type="checkbox" data-picker="${escapeHtml(model.slug)}" aria-label="${escapeHtml(t("models.showModelAria", { model: model.displayName }))}"${visible ? " checked" : ""}${state.modelSettingsBusy ? " disabled" : ""}></span>
+          <span class="provider-check"><input type="checkbox" data-command="set_picker_model" data-picker="${escapeHtml(model.slug)}" aria-label="${escapeHtml(t("models.showModelAria", { model: model.displayName }))}"${visible ? " checked" : ""}${state.modelSettingsBusy ? " disabled" : ""}></span>
         </label>`;
       };
 
@@ -804,7 +843,7 @@ function startPanel() {
   function renderToolResultAgingSetting() {
     const aging = state.snapshot?.targets?.codex?.modelSettings?.toolResultAging;
     const overridden = aging?.environmentOverride === true;
-    elements.toolResultAgingSwitch.checked = aging?.enabled !== false;
+    elements.toolResultAgingSwitch.checked = toolResultAgingChecked(aging);
     elements.toolResultAgingSwitch.disabled = state.toolResultAgingBusy || overridden;
     elements.toolResultAgingSwitchLabel.title = overridden
       ? t("models.toolAgingForcedOff")
@@ -868,14 +907,14 @@ function startPanel() {
               ? " is-running"
               : " is-ready";
       const cancelButton = running && download.tag
-        ? `<button class="mini-button danger" type="button" data-local-action="cancel-operation" data-model="${escapeHtml(download.tag)}"${state.localCancelBusy ? " disabled" : ""}>Cancel</button>`
+        ? `<button class="mini-button danger" type="button" data-command="cancel_local_model" data-local-action="cancel-operation" data-model="${escapeHtml(download.tag)}"${state.localCancelBusy ? " disabled" : ""}>Cancel</button>`
         : "";
       // A terminal download failure/cancellation must be recoverable from the
       // status card itself.  The install form is still available, but a
       // one-click retry makes an interrupted pull obvious and avoids making
       // the operator retype a long Ollama tag or URL.
       const retryButton = !running && !removal && (failed || cancelled) && download.tag
-        ? `<button class="mini-button" type="button" data-local-action="retry-operation" data-model="${escapeHtml(download.tag)}"${state.localModelBusy || state.localCancelBusy ? " disabled" : ""}>Retry</button>`
+        ? `<button class="mini-button" type="button" data-command="install_local_model" data-local-action="retry-operation" data-model="${escapeHtml(download.tag)}"${state.localModelBusy || state.localCancelBusy ? " disabled" : ""}>Retry</button>`
         : "";
       elements.localDownloadStatus.innerHTML = `<div class="download-status${statusClass}">
         <div class="download-status-head"><span class="operation-pulse" aria-hidden="true"></span><strong>${title}</strong><span>${failed || cancelled || removal ? "" : `${percent}%`}</span>${cancelButton}${retryButton}</div>
@@ -902,7 +941,7 @@ function startPanel() {
     elements.localQuickPicks.innerHTML = picks.length
       ? `<div class="local-section-label"><span>${escapeHtml(t("models.quickPicks"))}</span><small>${escapeHtml(t("models.recommendedForMachine"))}</small></div>${picks
           .map(
-            (model) => `<button type="button" class="quick-pick" data-local-action="install" data-model="${escapeHtml(model.tag)}"${installBusy ? " disabled" : ""}>
+            (model) => `<button type="button" class="quick-pick" data-command="install_local_model" data-local-action="install" data-model="${escapeHtml(model.tag)}"${installBusy ? " disabled" : ""}>
               <span><strong>${escapeHtml(model.tag)}</strong><small>${escapeHtml(model.codex === "verified" ? t("models.verifiedInCodex") : model.fit || t("models.untested"))}</small></span>
               <span>${Number(model.sizeGb || 0).toFixed(1)} GB</span>
             </button>`,
@@ -914,7 +953,7 @@ function startPanel() {
     const runtime = local.runtime || {};
     const machine = local.machine ? `<small class="muted-line">${escapeHtml(local.machine)}</small>` : "";
     elements.localRuntimeActions.innerHTML = runtime.installed
-      ? `<div><small>Ollama ${escapeHtml(runtime.version || "installed")} · headless server ${runtime.running ? "running" : "not started"}</small>${runtime.modelsPath ? `<small class="muted-line">Models: ${escapeHtml(runtime.modelsPath)}</small>` : ""}${machine}</div><button class="text-button" type="button" data-local-runtime-action="update"${state.maintenanceBusy || state.localModelBusy ? " disabled" : ""}>Update Ollama</button>`
+      ? `<div><small>Ollama ${escapeHtml(runtime.version || "installed")} · headless server ${runtime.running ? "running" : "not started"}</small>${runtime.modelsPath ? `<small class="muted-line">Models: ${escapeHtml(runtime.modelsPath)}</small>` : ""}${machine}</div><button class="text-button" type="button" data-command="update_local_ollama" data-local-runtime-action="update"${state.maintenanceBusy || state.localModelBusy ? " disabled" : ""}>Update Ollama</button>`
       : `<small>Ollama is not installed. Installing a model can set it up with explicit consent.</small>`;
   }
 
@@ -949,7 +988,7 @@ function startPanel() {
           ? model.enabled ? "In the picker" : "Served · unchecked"
           : "Checked but not currently served";
         return `<article class="local-model-row${isBusy ? " is-busy" : ""}">
-          <label class="provider-check"><input type="checkbox" data-lmstudio-toggle="${escapeHtml(model.id)}" aria-label="Offer ${escapeHtml(model.id)} in the model picker"${model.enabled ? " checked" : ""}${rowBusy ? " disabled" : ""}></label>
+          <label class="provider-check"><input type="checkbox" data-command="set_lmstudio_model_enabled" data-lmstudio-toggle="${escapeHtml(model.id)}" aria-label="Offer ${escapeHtml(model.id)} in the model picker"${model.enabled ? " checked" : ""}${rowBusy ? " disabled" : ""}></label>
           <div><strong>${escapeHtml(model.id)}</strong><small>${escapeHtml(detail)}</small></div>
         </article>`;
       })
@@ -1089,7 +1128,7 @@ function startPanel() {
     } else if (installed.has(tag)) {
       action = '<span class="local-catalog-installed">Installed</span>';
     } else {
-      action = `<button class="mini-button${tooLarge ? " danger" : ""}" type="button" data-local-action="install" data-model="${escapeHtml(tag)}"${installBusy ? " disabled" : ""}>${tooLarge ? "Anyway" : "Download"}</button>`;
+      action = `<button class="mini-button${tooLarge ? " danger" : ""}" type="button" data-command="install_local_model" data-local-action="install" data-model="${escapeHtml(tag)}"${installBusy ? " disabled" : ""}>${tooLarge ? "Anyway" : "Download"}</button>`;
     }
     return `<article class="local-catalog-row${tooLarge ? " is-too-large" : ""}">
       <div class="local-catalog-copy"><strong>${escapeHtml(title)}</strong><small>${escapeHtml(tag)}${escapeHtml(capabilities)}</small></div>
@@ -1130,15 +1169,15 @@ function startPanel() {
       model.agent === "agent" ? t("models.worksInCodex") : model.tools ? t("models.chatUntested") : t("models.noToolCalling"),
       Number.isFinite(speed) ? `${speed.toFixed(1)} tok/s` : t("models.speedUnmeasured"),
     ].join(" · ");
-    const speedAction = `<button class="text-button" type="button" data-local-action="measure-speed" data-model="${escapeHtml(model.tag)}"${state.localBenchmarkBusy ? " disabled" : ""}>Speed</button>`;
+    const speedAction = `<button class="text-button" type="button" data-command="local_model_speed" data-local-action="measure-speed" data-model="${escapeHtml(model.tag)}"${state.localBenchmarkBusy ? " disabled" : ""}>Speed</button>`;
     const visionActions = model.vision
-      ? `<button class="text-button" type="button" data-local-action="test-image" data-model="${escapeHtml(model.tag)}"${state.localBenchmarkBusy ? " disabled" : ""}>Test image</button><button class="text-button" type="button" data-local-action="use-image" data-model="${escapeHtml(model.tag)}"${state.visionBusy ? " disabled" : ""}>${state.visionBridge?.engine === "local" && state.visionBridge?.local?.model === model.tag ? "Using image" : "Use image"}</button>`
+      ? `<button class="text-button" type="button" data-command="benchmark_vision_model" data-local-action="test-image" data-model="${escapeHtml(model.tag)}"${state.localBenchmarkBusy ? " disabled" : ""}>Test image</button><button class="text-button" type="button" data-command="use_local_vision_model" data-local-action="use-image" data-model="${escapeHtml(model.tag)}"${state.visionBusy ? " disabled" : ""}>${state.visionBridge?.engine === "local" && state.visionBridge?.local?.model === model.tag ? "Using image" : "Use image"}</button>`
       : "";
     return `<article class="local-model-row${isBusy ? " is-busy" : ""}">
-      <label class="provider-check"><input type="checkbox" data-local-toggle="${escapeHtml(model.tag)}" aria-label="${escapeHtml(t("models.enableLocalAria", { model: model.tag }))}"${model.enabled ? " checked" : ""}${busy || model.tools !== true ? " disabled" : ""}></label>
+      <label class="provider-check"><input type="checkbox" data-command="set_local_model_enabled" data-local-toggle="${escapeHtml(model.tag)}" aria-label="${escapeHtml(t("models.enableLocalAria", { model: model.tag }))}"${model.enabled ? " checked" : ""}${busy || model.tools !== true ? " disabled" : ""}></label>
       <div><strong>${escapeHtml(model.tag)}</strong><small>${escapeHtml(detail)}</small></div>
       <span class="local-size">${Number(model.sizeGb || 0).toFixed(1)} GB</span>
-      <div class="local-model-actions">${speedAction}${visionActions}<button class="mini-button danger" type="button" data-local-action="${armed ? "confirm-remove" : "remove"}" data-model="${escapeHtml(model.tag)}"${busy ? " disabled" : ""}>${armed ? escapeHtml(t("actions.confirm")) : escapeHtml(t("actions.remove"))}</button></div>
+      <div class="local-model-actions">${speedAction}${visionActions}<button class="mini-button danger" type="button" data-command="uninstall_local_model" data-local-action="${armed ? "confirm-remove" : "remove"}" data-model="${escapeHtml(model.tag)}"${busy ? " disabled" : ""}>${armed ? escapeHtml(t("actions.confirm")) : escapeHtml(t("actions.remove"))}</button></div>
     </article>`;
   }
 
@@ -2124,7 +2163,42 @@ function svgElement(name, attributes) {
 
 function call(command, args) {
   if (!invoke) return Promise.reject(new Error(t("status.desktopBridgeUnavailable")));
+  // A refused command comes back as a bare 403 the bridge reports as "the
+  // router command failed", which names nothing anyone can act on. Refusing it
+  // here says which surface refused and where the setting does live.
+  if (commandRefused(capabilities, command)) {
+    return Promise.reject(new Error(t("general.readOnlyControl")));
+  }
   return invoke(command, args);
+}
+
+// Every control that drives a command carries data-command, so the set to
+// disable is the surface's own allowlist rather than a second list here that
+// would drift the moment a command moves. The panel rebuilds whole sections
+// from innerHTML in a dozen places; an observer means a new section cannot
+// forget to ask, and it is installed only on a surface that is actually
+// restricted, so the other two shells never run it.
+function applyReadOnly(root) {
+  const message = t("general.readOnlyControl");
+  for (const element of root.querySelectorAll("[data-command]")) {
+    if (!commandRefused(capabilities, element.dataset.command)) continue;
+    element.disabled = true;
+    element.title = message;
+    // The switches hide their input behind a styled span, which is what a
+    // pointer actually rests on, so the tooltip has to live on the label too.
+    const label = element.closest("label");
+    if (label) label.title = message;
+  }
+}
+
+function watchReadOnly(root) {
+  applyReadOnly(root);
+  // childList only: setting `disabled` and `title` writes attributes, and
+  // observing those would have this re-enter itself on every pass.
+  new MutationObserver(() => applyReadOnly(root)).observe(root, {
+    childList: true,
+    subtree: true,
+  });
 }
 
 // A key can also come from the macOS Keychain or the environment, which the

--- a/apps/desktop/ui/i18n.mjs
+++ b/apps/desktop/ui/i18n.mjs
@@ -214,6 +214,8 @@ const MESSAGES = {
     "general.keyRemoved": "{provider} key removed.",
     "general.anotherSource": "another source",
     "general.provider": "The provider",
+    "general.readOnlySurface": "This browser panel can show the router's state but not change it. Open the Model Router tray or desktop app to change a setting.",
+    "general.readOnlyControl": "Read-only in the browser panel · change this from the Model Router tray or desktop app",
   },
   "zh-CN": {
     "app.title": "Codex 模型路由",
@@ -419,6 +421,8 @@ const MESSAGES = {
     "general.keyRemoved": "{provider} 密钥已移除。",
     "general.anotherSource": "其他来源",
     "general.provider": "该提供商",
+    "general.readOnlySurface": "此浏览器面板只能查看路由状态，无法进行更改。请打开模型路由托盘或桌面应用来修改设置。",
+    "general.readOnlyControl": "浏览器面板为只读 · 请在模型路由托盘或桌面应用中更改",
   },
   ar: {
     "app.title": "موجّه نماذج Codex",
@@ -624,6 +628,8 @@ const MESSAGES = {
     "general.keyRemoved": "تمت إزالة مفتاح {provider}.",
     "general.anotherSource": "مصدر آخر",
     "general.provider": "هذا المزوّد",
+    "general.readOnlySurface": "تعرض لوحة المتصفح هذه حالة الموجّه دون أن تتمكن من تغييرها. افتح شريط موجّه النماذج أو تطبيق سطح المكتب لتغيير أي إعداد.",
+    "general.readOnlyControl": "لوحة المتصفح للقراءة فقط · غيّر هذا من شريط موجّه النماذج أو تطبيق سطح المكتب",
   },
   hi: {
     "app.title": "Codex मॉडल राउटर",
@@ -829,6 +835,8 @@ const MESSAGES = {
     "general.keyRemoved": "{provider} कुंजी हटा दी गई।",
     "general.anotherSource": "अन्य स्रोत",
     "general.provider": "यह प्रदाता",
+    "general.readOnlySurface": "यह ब्राउज़र पैनल राउटर की स्थिति दिखा सकता है, बदल नहीं सकता। कोई सेटिंग बदलने के लिए मॉडल राउटर ट्रे या डेस्कटॉप ऐप खोलें।",
+    "general.readOnlyControl": "ब्राउज़र पैनल केवल पढ़ने के लिए · इसे मॉडल राउटर ट्रे या डेस्कटॉप ऐप से बदलें",
   },
   ja: {
     "app.title": "Codex モデルルーター",
@@ -1034,6 +1042,8 @@ const MESSAGES = {
     "general.keyRemoved": "{provider} のキーを削除しました。",
     "general.anotherSource": "別のソース",
     "general.provider": "このプロバイダー",
+    "general.readOnlySurface": "このブラウザーパネルはルーターの状態を表示できますが、変更はできません。設定を変更するにはモデルルーターのトレイまたはデスクトップアプリを開いてください。",
+    "general.readOnlyControl": "ブラウザーパネルは読み取り専用です · モデルルーターのトレイまたはデスクトップアプリから変更してください",
   },
   ko: {
     "app.title": "Codex 모델 라우터",
@@ -1239,6 +1249,8 @@ const MESSAGES = {
     "general.keyRemoved": "{provider} 키가 제거되었습니다.",
     "general.anotherSource": "다른 소스",
     "general.provider": "해당 제공업체",
+    "general.readOnlySurface": "이 브라우저 패널은 라우터 상태를 보여줄 수는 있지만 변경할 수는 없습니다. 설정을 바꾸려면 모델 라우터 트레이나 데스크톱 앱을 여세요.",
+    "general.readOnlyControl": "브라우저 패널은 읽기 전용입니다 · 모델 라우터 트레이나 데스크톱 앱에서 변경하세요",
   },
 };
 

--- a/apps/desktop/ui/index.html
+++ b/apps/desktop/ui/index.html
@@ -28,6 +28,8 @@
         <button class="tab" type="button" data-tab="models" data-i18n="nav.models">Models</button>
       </nav>
 
+      <p id="read-only-note" class="read-only-note" role="status" hidden></p>
+
       <section id="usage-view" class="view">
         <div class="usage-heading">
           <div>
@@ -122,7 +124,7 @@
             <small id="login-free-note" data-i18n="connections.useConnectedModels">Use connected external models in new Codex sessions</small>
           </div>
           <label class="switch" id="login-free-switch-label">
-            <input id="login-free-switch" type="checkbox" />
+            <input id="login-free-switch" type="checkbox" data-command="set_login_free" />
             <span aria-hidden="true"></span>
             <span class="sr-only" data-i18n="connections.useWithoutOpenAILoginAria">Use Codex without OpenAI login</span>
           </label>
@@ -133,7 +135,7 @@
             <small id="signed-routing-note">Keep native ChatGPT transport and task history</small>
           </div>
           <label class="switch" id="signed-routing-switch-label">
-            <input id="signed-routing-switch" type="checkbox" />
+            <input id="signed-routing-switch" type="checkbox" data-command="set_signed_routing" />
             <span aria-hidden="true"></span>
             <span class="sr-only">Use Router with ChatGPT</span>
           </label>
@@ -143,7 +145,7 @@
             <strong>Show tray</strong>
             <small id="presence-note">Keep the Windows tray visible</small>
           </div>
-          <select id="presence-mode" aria-label="Show tray mode">
+          <select id="presence-mode" aria-label="Show tray mode" data-command="set_presence_mode">
             <option value="always">Always</option>
             <option value="follow-codex">With Codex</option>
           </select>
@@ -155,8 +157,8 @@
             <small id="maintenance-note">Update the checkout and verify its installation.</small>
           </div>
           <div class="maintenance-actions">
-            <button id="maintenance-update" class="text-button" type="button">Update</button>
-            <button id="maintenance-fix" class="text-button" type="button">Fix</button>
+            <button id="maintenance-update" class="text-button" type="button" data-command="maintenance">Update</button>
+            <button id="maintenance-fix" class="text-button" type="button" data-command="doctor_fix">Fix</button>
           </div>
         </div>
       </section>
@@ -168,7 +170,7 @@
             <small id="tool-result-aging-note" data-i18n="models.reduceRepeatedContext">Reduce repeated context on external models</small>
           </div>
           <label class="switch" id="tool-result-aging-switch-label">
-            <input id="tool-result-aging-switch" type="checkbox" />
+            <input id="tool-result-aging-switch" type="checkbox" data-command="set_tool_result_aging" />
             <span aria-hidden="true"></span>
             <span class="sr-only" data-i18n="models.compactOldToolResultsAria">Compact old tool results for external models</span>
           </label>
@@ -188,14 +190,14 @@
                 <small id="vision-note">A vision engine reads pasted images and returns quoted text.</small>
               </div>
               <label class="switch" id="vision-switch-label">
-                <input id="vision-switch" type="checkbox" />
+                <input id="vision-switch" type="checkbox" data-command="set_vision_bridge" />
                 <span aria-hidden="true"></span>
                 <span class="sr-only">Read images for text-only models</span>
               </label>
             </div>
             <div class="vision-controls">
-              <label>Engine<select id="vision-engine" aria-label="Vision engine"></select></label>
-              <label>Effort<select id="vision-effort" aria-label="Vision effort"></select></label>
+              <label>Engine<select id="vision-engine" aria-label="Vision engine" data-command="set_vision_engine"></select></label>
+              <label>Effort<select id="vision-effort" aria-label="Vision effort" data-command="set_vision_effort"></select></label>
             </div>
             <div id="vision-local-models" class="vision-local-models"></div>
           </div>
@@ -215,15 +217,15 @@
                 <small data-i18n="models.exposeVerifiedModels">Expose every verified v2 model as a Codex subagent</small>
               </div>
               <label class="switch" id="subagent-all-switch-label">
-                <input id="subagent-all-switch" type="checkbox" />
+                <input id="subagent-all-switch" type="checkbox" data-command="set_subagent_mode" />
                 <span aria-hidden="true"></span>
                 <span class="sr-only" data-i18n="models.useAllProvenModelsAria">Use all proven v2 models as subagents</span>
               </label>
             </div>
             <p class="accordion-note" data-i18n="models.subagentExplanation">Choices here decide what Codex can spawn as a subagent. They do not hide anything from Codex's model picker — use Model picker below for that.</p>
             <div class="accordion-toolbar">
-              <button class="text-button" type="button" data-model-action="subagents" data-action="select-all" data-i18n="actions.subagentsOn">Subagents on</button>
-              <button class="text-button" type="button" data-model-action="subagents" data-action="unselect-all" data-i18n="actions.subagentsOff">Subagents off</button>
+              <button class="text-button" type="button" data-model-action="subagents" data-action="select-all" data-command="set_subagent_selection" data-i18n="actions.subagentsOn">Subagents on</button>
+              <button class="text-button" type="button" data-model-action="subagents" data-action="unselect-all" data-command="set_subagent_selection" data-i18n="actions.subagentsOff">Subagents off</button>
             </div>
             <div id="subagent-model-list" class="model-settings-list"></div>
           </div>
@@ -240,8 +242,8 @@
           <div class="accordion-body is-open" data-accordion-body="picker">
             <p class="accordion-note" data-i18n="models.pickerHiddenExplanation">Models hidden here stay connected but are not offered by Codex.</p>
             <div class="accordion-toolbar">
-              <button class="text-button" type="button" data-model-action="picker" data-action="show-all" data-i18n="actions.showAll">Show all</button>
-              <button class="text-button" type="button" data-model-action="picker" data-action="hide-all" data-i18n="actions.hideAll">Hide all</button>
+              <button class="text-button" type="button" data-model-action="picker" data-action="show-all" data-command="set_picker_models" data-i18n="actions.showAll">Show all</button>
+              <button class="text-button" type="button" data-model-action="picker" data-action="hide-all" data-command="set_picker_models" data-i18n="actions.hideAll">Hide all</button>
             </div>
             <div id="picker-model-list" class="model-settings-list"></div>
           </div>
@@ -263,8 +265,8 @@
             <form id="local-model-form" class="local-install-form">
               <label for="local-model-input" data-i18n="models.installModel">Install a model</label>
               <div>
-                <input id="local-model-input" type="text" autocomplete="off" spellcheck="false" data-i18n-placeholder="models.ollamaPlaceholder" placeholder="gemma4:12b or ollama.com/library/gemma4:12b" />
-                <button class="mini-button" type="submit" data-i18n="actions.install">Install</button>
+                <input id="local-model-input" type="text" data-command="install_local_model" autocomplete="off" spellcheck="false" data-i18n-placeholder="models.ollamaPlaceholder" placeholder="gemma4:12b or ollama.com/library/gemma4:12b" />
+                <button class="mini-button" type="submit" data-command="install_local_model" data-i18n="actions.install">Install</button>
               </div>
               <small data-i18n="models.ollamaTagOrUrl">Enter an Ollama tag or model-page URL.</small>
             </form>
@@ -287,7 +289,7 @@
             <select id="language-select" data-i18n-aria-label="footer.languageAria"></select>
           </label>
           <label class="switch" id="island-switch-label">
-            <input id="island-switch" type="checkbox" />
+            <input id="island-switch" type="checkbox" data-command="set_island_enabled" />
             <span aria-hidden="true"></span>
             <span class="sr-only" data-i18n="footer.showActivityPill">Show activity pill</span>
           </label>
@@ -309,7 +311,7 @@
           <input id="api-key" type="password" autocomplete="off" spellcheck="false" data-i18n-placeholder="connections.pasteCredential" placeholder="Paste credential" required />
           <div class="dialog-actions">
             <button id="cancel-key" class="button secondary" type="button" data-i18n="actions.cancel">Cancel</button>
-            <button class="button primary" type="submit" data-i18n="actions.saveCredential">Save credential</button>
+            <button class="button primary" type="submit" data-command="save_api_key" data-i18n="actions.saveCredential">Save credential</button>
           </div>
         </form>
       </dialog>
@@ -329,7 +331,7 @@
           </p>
           <div class="dialog-actions">
             <button id="cancel-remove" class="button secondary" type="button" data-i18n="actions.cancel">Cancel</button>
-            <button class="button danger" type="submit" data-i18n="actions.removeKey">Remove key</button>
+            <button class="button danger" type="submit" data-command="remove_api_key" data-i18n="actions.removeKey">Remove key</button>
           </div>
         </form>
       </dialog>

--- a/apps/desktop/ui/model.mjs
+++ b/apps/desktop/ui/model.mjs
@@ -230,6 +230,33 @@ export function observedModelSpeed(providerUsage, providerId, modelSlug) {
     : null;
 }
 
+// The router's own browser panel serves this same UI but answers only the
+// reading half of the command table, and says so in platform_info. A surface
+// that advertises nothing -- the Tauri tray, the Electron window -- carries the
+// full table, so nothing is refused there and nothing about it changes.
+export function readOnlyCapabilities(platform) {
+  const capabilities = platform?.capabilities;
+  return capabilities?.readOnly === true ? capabilities : null;
+}
+
+// Answered from the lists the surface sent, never from a copy of the allowlist
+// kept here: a second copy is the drift this exists to prevent. The commands a
+// read-only surface answers from its own process (show/hide, island state) are
+// permitted too, because it does answer them.
+export function commandRefused(capabilities, command) {
+  if (!capabilities || !command) return false;
+  const allowed = capabilities.allowedCommands || [];
+  const local = capabilities.localCommands || [];
+  return !allowed.includes(command) && !local.includes(command);
+}
+
+// Absent is not "on". src/tool-result-aging-state.mjs defaults the feature off
+// when nobody has answered, so a snapshot the panel could not read has to
+// render off rather than promise ageing that is not happening.
+export function toolResultAgingChecked(aging) {
+  return aging?.enabled === true;
+}
+
 function smoothPath(points) {
   if (!points.length) return "";
   if (points.length === 1) return `M ${points[0].x.toFixed(2)} ${points[0].y.toFixed(2)}`;

--- a/apps/desktop/ui/styles.css
+++ b/apps/desktop/ui/styles.css
@@ -220,6 +220,20 @@ button {
   color: var(--ink);
 }
 
+/* Sits under the tabs so the whole surface is qualified before a tab is
+   chosen. Muted rather than alarming: a read-only panel is working correctly,
+   it just is not where settings are changed. */
+.read-only-note {
+  margin: 10px 16px 0;
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.075);
+  border-radius: 9px;
+  background: rgba(1, 4, 8, 0.26);
+  color: var(--muted-strong);
+  font-size: 10px;
+  line-height: 1.45;
+}
+
 .view {
   min-height: 0;
   padding: 18px 16px 12px;

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -3517,7 +3517,11 @@ private struct TrayView: View {
         : (target.modelSettings?.toolResultAging?.stats?.savingsSummary
           ?? routerLocalized("Off by default · replaces consumed tool results on external models")),
       isOn: Binding(
-        get: { target.modelSettings?.toolResultAging?.enabled ?? true },
+        // Off when the snapshot has not arrived, because that is what the
+        // router does with no state file (tool-result-aging-state.mjs). The row
+        // says "Off by default" a line above; showing the switch on while
+        // nothing is being aged contradicted it on every fresh install.
+        get: { target.modelSettings?.toolResultAging?.enabled ?? false },
         set: { enabled in Task { await store.setToolResultAgingEnabled(enabled) } }
       ),
       isDisabled: store.providerOperation != nil

--- a/src/desktop-panel.mjs
+++ b/src/desktop-panel.mjs
@@ -90,7 +90,23 @@ export function panelCommandAllowed(command, { readOnly = true } = {}) {
 // failing: the UI asks for them on load and would otherwise paint an error
 // over a panel that is working.
 const LOCAL = {
-  platform_info: () => ({ platform: process.platform, island: false, shell: "web" }),
+  platform_info: () => ({
+    platform: process.platform,
+    island: false,
+    shell: "web",
+    // What this surface will and will not run, said out loud. The UI could
+    // infer it from `shell`, but then two places would encode the same policy
+    // and only one of them is the gate. Both lists are the real ones -- a
+    // command in neither is precisely what /panel/invoke answers 403 for -- so
+    // a control the UI leaves live cannot disagree with what the panel permits.
+    // The tray and the Electron shell advertise nothing here and keep the full
+    // table, which is why this field is additive rather than a mode switch.
+    capabilities: {
+      readOnly: true,
+      allowedCommands: [...READ_ONLY],
+      localCommands: Object.keys(LOCAL),
+    },
+  }),
   desktop_settings: () => ({ islandEnabled: false, islandExpanded: false }),
   // The router is answering this request, so it is by definition reachable.
   router_health: () => ({ ok: true, service: "codex-router", status: "ok" }),

--- a/test/desktop-panel.test.mjs
+++ b/test/desktop-panel.test.mjs
@@ -1,14 +1,17 @@
 import assert from "node:assert/strict";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import http from "node:http";
 import test from "node:test";
 
+import { COMMANDS } from "../src/desktop-commands.mjs";
 import { writeJson } from "../src/http-utils.mjs";
 import {
   handlePanelRequest,
   isPanelRoute,
   panelCommandAllowed,
+  panelLocalCommand,
 } from "../src/desktop-panel.mjs";
+import { commandRefused, readOnlyCapabilities } from "../apps/desktop/ui/model.mjs";
 
 // The panel is served by the router, so these drive the real handler over a
 // real socket rather than calling it in-process: the routing, the headers and
@@ -84,7 +87,15 @@ test("the panel serves each asset the UI loads", async () => {
 test("the panel refuses the commands that change credentials or state", async () => {
   const { url, close } = await serve();
   try {
-    for (const command of ["save_api_key", "remove_api_key", "set_provider_enabled", "connect_oauth"]) {
+    for (const command of [
+      "save_api_key",
+      "remove_api_key",
+      "set_provider_enabled",
+      "connect_oauth",
+      // The toggle the UI used to render live: the panel refused it silently
+      // and the click came back as a generic failure.
+      "set_tool_result_aging",
+    ]) {
       const response = await fetch(url("/panel/invoke"), {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -101,6 +112,88 @@ test("the panel refuses the commands that change credentials or state", async ()
   } finally {
     await close();
   }
+});
+
+// The refusal is correct; the UI not knowing about it is what turned a
+// deliberate posture into a broken-looking switch. platform_info is the one
+// call the UI already makes on load, so the panel says so there.
+test("the panel tells the UI it is read-only over the same command bridge", async () => {
+  const { url, close } = await serve();
+  try {
+    const response = await fetch(url("/panel/invoke"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ command: "platform_info", args: {} }),
+    });
+    assert.equal(response.status, 200);
+    const { value } = await response.json();
+    assert.equal(value.capabilities.readOnly, true);
+    assert.equal(readOnlyCapabilities(value)?.readOnly, true);
+    // What a shell that carries the full table sends: no capabilities block,
+    // so nothing is refused and the tray and Electron window are unaffected.
+    assert.equal(readOnlyCapabilities({ os: "darwin", islandSupported: true }), null);
+  } finally {
+    await close();
+  }
+});
+
+// Two lists that describe one policy drift. This asserts they cannot: what the
+// panel advertises has to agree with what the gate actually permits, for every
+// command in the shared table.
+test("the advertised allowed commands are exactly the ones the panel permits", () => {
+  const { capabilities } = panelLocalCommand("platform_info")();
+  assert.deepEqual(
+    [...capabilities.allowedCommands].sort(),
+    Object.keys(COMMANDS).filter((command) => panelCommandAllowed(command)).sort(),
+  );
+  for (const command of Object.keys(COMMANDS)) {
+    assert.equal(
+      commandRefused(capabilities, command),
+      !panelCommandAllowed(command),
+      `${command} is advertised differently from how it is gated`,
+    );
+  }
+  // Commands the panel answers from its own process are not refusals: the UI
+  // must keep offering Close and the activity pill, which do work here.
+  for (const command of capabilities.localCommands) {
+    assert.equal(commandRefused(capabilities, command), false, command);
+  }
+  assert.equal(commandRefused(capabilities, "set_tool_result_aging"), true);
+  assert.equal(commandRefused(capabilities, "control_snapshot"), false);
+});
+
+// The two halves joined: the commands the shipped markup declares, answered by
+// the capabilities the panel actually sends. Asserting each side separately
+// would still pass if a control named a command nobody gates.
+test("the panel's own answer marks the settings in the shipped markup dead", () => {
+  const { capabilities } = panelLocalCommand("platform_info")();
+  const markup = readFileSync(new URL("../apps/desktop/ui/index.html", import.meta.url), "utf8");
+  const declared = new Set([...markup.matchAll(/data-command="([a-z_]+)"/g)].map(([, name]) => name));
+  assert.ok(declared.size >= 15, `only ${declared.size} controls declare a command`);
+  for (const command of declared) {
+    assert.ok(
+      Object.hasOwn(COMMANDS, command) || capabilities.localCommands.includes(command),
+      `${command} is not a command any surface answers`,
+    );
+  }
+  // The switch this whole change is about, plus the two the panel does answer.
+  assert.equal(declared.has("set_tool_result_aging"), true);
+  assert.equal(commandRefused(capabilities, "set_tool_result_aging"), true);
+  assert.equal(commandRefused(capabilities, "set_island_enabled"), false);
+});
+
+// Reaching the tray or the Electron window means already running code on this
+// machine, so neither is narrowed by any of the above.
+test("a shell that is not the browser panel still carries the full table", () => {
+  for (const command of Object.keys(COMMANDS)) {
+    assert.equal(panelCommandAllowed(command, { readOnly: false }), true, command);
+  }
+  assert.equal(panelCommandAllowed("rm_minus_rf", { readOnly: false }), false);
+  // The Electron shell runs the table directly rather than through the panel's
+  // gate, which is what keeps the read-only posture local to the browser.
+  const electron = readFileSync(new URL("../apps/electron/main.js", import.meta.url), "utf8");
+  assert.doesNotMatch(electron, /panelCommandAllowed/);
+  assert.match(electron, /runDesktopCommand\(command, args \?\? \{\}, \{ root \}\)/);
 });
 
 test("an unknown command is refused rather than shelled out", async () => {

--- a/test/desktop-ui.test.mjs
+++ b/test/desktop-ui.test.mjs
@@ -1,16 +1,24 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   buildQuotaCards,
   chartGeometry,
+  commandRefused,
   compactTokens,
   dailySeries,
   metricRemainingPercent,
   observedModelSpeed,
   quotaWindow,
+  readOnlyCapabilities,
+  toolResultAgingChecked,
   visibleLocalDownload,
 } from "../apps/desktop/ui/model.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 import { availableLanguages, getLanguage, setLanguage, t, translationKeys } from "../apps/desktop/ui/i18n.mjs";
 
 test("desktop usage series fills missing local calendar days", () => {
@@ -172,6 +180,77 @@ test("active model speed prefers its provider and matches qualified slugs", () =
   assert.equal(observedModelSpeed(usage, "deepseek", "missing/model"), null);
 });
 
+// src/tool-result-aging-state.mjs defaults the feature off when no state file
+// exists, so an absent snapshot has to render off. Rendering on told every
+// fresh install that ageing was happening when nothing was.
+test("the tool-result-aging switch renders off when the snapshot is absent", () => {
+  assert.equal(toolResultAgingChecked(undefined), false);
+  assert.equal(toolResultAgingChecked(null), false);
+  assert.equal(toolResultAgingChecked({}), false);
+});
+
+test("the tool-result-aging switch follows the snapshot when it is present", () => {
+  assert.equal(toolResultAgingChecked({ enabled: true }), true);
+  assert.equal(toolResultAgingChecked({ enabled: false }), false);
+  assert.equal(toolResultAgingChecked({ enabled: true, environmentOverride: false }), true);
+});
+
+// A control the surface will refuse must be dead before it is clicked, and the
+// UI decides that from the surface's own lists rather than a copy of them.
+test("a read-only surface refuses only what it did not advertise", () => {
+  const capabilities = {
+    readOnly: true,
+    allowedCommands: ["control_snapshot"],
+    localCommands: ["hide_panel"],
+  };
+  assert.equal(commandRefused(capabilities, "set_tool_result_aging"), true);
+  assert.equal(commandRefused(capabilities, "control_snapshot"), false);
+  assert.equal(commandRefused(capabilities, "hide_panel"), false);
+  // A shell that advertises no limit carries the full table and refuses
+  // nothing, which is how the tray and the Electron window stay unaffected.
+  assert.equal(commandRefused(null, "set_tool_result_aging"), false);
+  assert.equal(readOnlyCapabilities({ os: "darwin" }), null);
+  assert.equal(readOnlyCapabilities({ capabilities: { readOnly: false } }), null);
+});
+
+test("the macOS tray tool-result-aging switch mirrors the same off default", () => {
+  const source = readFileSync(
+    path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),
+    "utf8",
+  );
+  assert.match(source, /toolResultAging\?\.enabled \?\? false/);
+  assert.doesNotMatch(source, /toolResultAging\?\.enabled \?\? true/);
+});
+
+// The disabled set is derived from data-command, so a control that drives a
+// command without carrying one would stay live on a surface that refuses it.
+test("every mutating control in the desktop UI names the command it drives", () => {
+  const markup = [
+    readFileSync(path.join(root, "apps", "desktop", "ui", "index.html"), "utf8"),
+    readFileSync(path.join(root, "apps", "desktop", "ui", "app.js"), "utf8"),
+  ].join("\n");
+  for (const command of [
+    "set_tool_result_aging",
+    "set_login_free",
+    "set_signed_routing",
+    "set_presence_mode",
+    "set_vision_bridge",
+    "set_subagent_mode",
+    "set_subagent_model",
+    "set_picker_model",
+    "set_provider_enabled",
+    "save_api_key",
+    "remove_api_key",
+    "install_local_model",
+    "set_local_model_enabled",
+  ]) {
+    assert.ok(
+      markup.includes(`data-command="${command}"`),
+      `no control declares data-command="${command}"`,
+    );
+  }
+});
+
 test("desktop UI exposes translations with matching keys for every language", () => {
   assert.deepEqual(
     availableLanguages().map(({ id }) => id),
@@ -181,6 +260,13 @@ test("desktop UI exposes translations with matching keys for every language", ()
   const englishKeys = [...keys.en].sort();
   for (const language of Object.keys(keys)) {
     assert.deepEqual([...keys[language]].sort(), englishKeys, `translation keys diverge for ${language}`);
+  }
+  // Stated separately from the parity check above, which would also pass if a
+  // new string were left out of all six.
+  for (const language of Object.keys(keys)) {
+    for (const key of ["general.readOnlySurface", "general.readOnlyControl"]) {
+      assert.ok([...keys[language]].includes(key), `${key} is missing from ${language}`);
+    }
   }
   const samples = [
     ["zh-CN", "用量"],


### PR DESCRIPTION
Reported as "the compact old tool-result toggle is only frontend and doesn't trigger the actual backend code." The backend is fine — `control tool-result-aging on|off` writes state correctly and `toolResultAgingEnabled()` re-reads the file per request with no caching. There were two separate frontend defects.

## Defect A — the browser panel is read-only and the UI did not know it

`panelCommandAllowed(command, { readOnly = true })` has one call site that passes no options, so the browser panel is always read-only and permits only five read commands. `apps/desktop/ui/app.js` had **zero** read-only awareness, so it rendered every mutating control as live; clicking one fired the command, the fetch 4xx'd, and the user got a generic failure on a control that was never operable in that surface.

The read-only posture is deliberate — a browser tab is reachable by any page that learns the capability — so **no command was added to the allowlist**. The UI now tells the truth instead.

`platform_info` (a `LOCAL` command, so it never touches the CLI) carries a capabilities block:

```json
{"readOnly": true,
 "allowedCommands": ["control_snapshot","account_usage","provider_usage","provider_setup","local_models"],
 "localCommands": ["platform_info","desktop_settings","router_health", "..."]}
```

`allowedCommands` is spread from `READ_ONLY` itself and `localCommands` from `Object.keys(LOCAL)`, so there is no second list to drift. Every control that drives a command now carries `data-command`, and a `MutationObserver` — installed only on a read-only surface — disables refused ones with a localized tooltip, plus a banner. `call()` rejects a refused command before the fetch.

The block is additive: the tray and Electron shells send no `capabilities`, so the helper returns null and the gate is a no-op there. They keep the full table.

## Defect B — the switch defaulted ON while the backend defaults OFF

`defaultSettings()` in `src/tool-result-aging-state.mjs` is `enabled: false` when no state file exists, but both UIs showed the switch on in that case:

- `apps/desktop/ui/app.js` — `aging?.enabled !== false` → `toolResultAgingChecked(aging)` (`aging?.enabled === true`)
- `ModelRouterTrayApp.swift` — `?? true` → `?? false`

A fresh install claimed ageing was on while nothing was being aged. Behavior when the snapshot is present is unchanged.

## Test plan

- [x] `npm test` — 1345 tests, 1333 pass, 0 fail, 12 pre-existing skips
- [x] `node scripts-check.mjs` — syntax checks passed
- [x] `swift build` — Build complete; `swift test` — 26 tests in 5 suites passed
- [x] RED checks on both defects: removing the capabilities block fails 2 panel tests; restoring the old default expressions fails 2 UI tests
- [x] New test asserts `commandRefused(caps, c) === !panelCommandAllowed(c)` for **every** key in `COMMANDS`, so the advertised set cannot drift from the enforced one
- [x] New test joins index.html's `data-command` set to the live capabilities
- [x] Refusal test extended with `set_tool_result_aging` — the security posture is verified unchanged

## Known gaps

- **No real-browser run.** The Playwright test skips (no preinstalled chromium in this environment). The server half was verified for real over HTTP; the DOM sweep (`applyReadOnly`/`watchReadOnly`) is reviewed, not executed — `app.js` self-executes against `window`, so it is not importable under `node:test` without a refactor. What is covered is the decision it makes and the inputs it reads.
- **Related defect deliberately left out:** the panel's `platform_info` omits `islandSupported`, so the activity-pill switch renders as supported in a browser tab that has no pill. One line would fix it, but it is a different defect.
- **Opposite-direction mismatch found, not changed:** the vision bridge backend defaults **on** while both UIs render an absent snapshot as off. Showing a quota-spending feature as on because the snapshot could not be read seemed like the wrong correction to make unilaterally. Worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PXPWEJidiS8MxEtHTCZq5i
