### PR TITLE
test(failover): cover the untested paths, and stop promising a free tier that is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,8 +1162,21 @@ only bury the one fact that fixes it.
 
 **Which model answers instead**, in order:
 
-1. Free models — the anonymous gateways, if you have any enabled
+1. Free models — the anonymous gateways, if you have curated any
 2. Everything else you have enabled, in the picker's own preference order
+
+**A free first stop is not automatic, and that is deliberate.** The free
+catalogs at `opencode-free` and `kilo-free` are picked out by naming rules their
+vendors change without notice, so none are checked in, and an anonymous provider
+is never enabled for you — turning one on sends your prompts to a third-party
+endpoint with no credential, which has to be your choice. Until you make it,
+failover goes straight to your own providers. `doctor` says which of the two
+you are in. To give failover a free first stop:
+
+```sh
+./bin/providers enable opencode-free
+./bin/model-router codex curate-models opencode-free
+```
 
 A model served from your own machine is never chosen automatically, for the same
 reason the vision bridge does not choose one: your runtime might not be running.

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -54,7 +54,11 @@ import {
   readVisionBridgeSettings,
   visionBridgeConfigured,
 } from "./vision-bridge-state.mjs";
-import { readFailoverSettings, readProviderCooldowns } from "./model-failover.mjs";
+import {
+  failoverTierCounts,
+  readFailoverSettings,
+  readProviderCooldowns,
+} from "./model-failover.mjs";
 import { contextWindowDrift, describeContextWindowDrift } from "./context-window-drift.mjs";
 import { observedInputCeilings } from "./usage-events.mjs";
 import { venvRuntimeProblem } from "./venv-runtime.mjs";
@@ -544,14 +548,30 @@ if (!failoverSettings.enabled) {
     "Each clears itself at that time, or on the provider's next successful answer. " +
       "Run ./bin/model-router codex control failover reset to clear them now.",
   );
-} else {
+} else if (failoverSettings.chain.length) {
   add(
     "ok",
     "Model failover",
-    failoverSettings.chain.length
-      ? `on, in the order you set: ${failoverSettings.chain.join(" -> ")}`
-      : "on, free models first then your other enabled providers",
-    "Run ./bin/model-router codex control failover chain <model-slug,...> to choose the order yourself.",
+    `on, in the order you set: ${failoverSettings.chain.join(" -> ")}`,
+    "Run ./bin/model-router codex control failover auto to hand the order back to the ranking.",
+  );
+} else {
+  // Count what the ranking can actually reach rather than restating the tier
+  // order. "Free models first" is only true where a free model exists, and on
+  // a machine that has curated none it describes an order that cannot happen.
+  const failoverHidden = readHiddenModels();
+  const failoverCounts = failoverTierCounts(
+    requiredRoutedModels.filter((model) => !failoverHidden.has(model.slug)),
+  );
+  add(
+    "ok",
+    "Model failover",
+    failoverCounts.free
+      ? `on, ${failoverCounts.free} free model(s) first then ${failoverCounts.subscription} of your own`
+      : `on, ${failoverCounts.subscription} of your own providers -- no free model is curated, so nothing cheaper is tried first`,
+    failoverCounts.free
+      ? "Run ./bin/model-router codex control failover chain <model-slug,...> to choose the order yourself."
+      : "Free catalogs change without notice so none are checked in. Run ./bin/model-router codex curate-models opencode-free to give failover a free first stop.",
   );
 }
 // The same list the catalog writes definitions from, so a model switched off

--- a/src/model-failover.mjs
+++ b/src/model-failover.mjs
@@ -280,6 +280,30 @@ export function failoverTier(model, providers = PROVIDERS) {
     : FAILOVER_TIER.subscription;
 }
 
+// What the ranking will actually be able to do, counted rather than promised.
+//
+// The tier order is free-then-paid, but `opencode-free` and `kilo-free` are
+// catalog-only by design: their free subsets are picked out by a naming rule
+// their vendors change without notice, so nothing is checked in and the free
+// tier is empty until the operator curates a model locally. Reporting
+// "free models first" on an install that has curated none describes an order
+// that cannot happen. Every surface that talks about failover asks this
+// instead, and says only what is true here.
+//
+// A model served from this machine is counted apart: it is free, and it is
+// still never chosen automatically, so promising it would be the same mistake
+// in a different place.
+export function failoverTierCounts(models, providers = PROVIDERS) {
+  const counts = { free: 0, local: 0, subscription: 0 };
+  for (const model of Array.isArray(models) ? models : []) {
+    const provider = providers.get(model?.provider);
+    if (provider?.keyless) counts.local += 1;
+    else if (provider?.authMode === "anonymous") counts.free += 1;
+    else counts.subscription += 1;
+  }
+  return counts;
+}
+
 function supportsImageInput(model) {
   return Array.isArray(model?.inputModalities) && model.inputModalities.includes("image");
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1639,7 +1639,13 @@ async function summarize(request, payload, route, signal) {
     if (!verdict.swap) return { ...last, failed };
     recordProviderCooldown(attemptRoute.provider, verdict);
     if (index + 1 < attempts.length) {
-      logFailover(attemptRoute, attempts[index + 1], `compaction/${verdict.reason}`, sent.upstream.status);
+      logFailover(
+        attemptRoute,
+        attempts[index + 1],
+        `compaction/${verdict.reason}`,
+        sent.upstream.status,
+        "retrying",
+      );
     }
   }
   return last && { ...last, failed };
@@ -1968,14 +1974,21 @@ function failoverCandidates({ route, routedBody, agedInput, flattenedNamespaces,
   );
 }
 
-function logFailover(from, to, reason, status) {
-  // Never gated on CODEX_ROUTER_QUIET, which a production LaunchAgent hard-sets.
-  // A silent swap makes an exhausted provider look healthy and leaves the
-  // operator wondering why the answers changed character.
+// `status` is always what the *asked-for* model said; `outcome` is what the
+// candidate did about it. Reporting one number for both was actively
+// misleading: a hop rejected with its own 400 printed
+// `reason=out_of_usage status=400`, which reads as the exhausted provider
+// having answered 400 and sent a reader looking for a quota bug that was not
+// there. They are two different events and now say so.
+//
+// Never gated on CODEX_ROUTER_QUIET, which a production LaunchAgent hard-sets.
+// A silent swap makes an exhausted provider look healthy and leaves the
+// operator wondering why the answers changed character.
+function logFailover(from, to, reason, status, outcome) {
   console.error(
-    `[codex-router] failover model=${from.slug} reason=${reason} status=${status} -> ${
+    `[codex-router] failover model=${from.slug} status=${status} reason=${reason} -> ${
       to ? to.slug : "none"
-    }`,
+    } outcome=${outcome}`,
   );
 }
 
@@ -2007,7 +2020,7 @@ async function attemptModelFailover({
     chain: settings.chain,
   }).slice(0, MAX_FAILOVER_HOPS);
   if (!candidates.length) {
-    logFailover(route, undefined, verdict.reason, status);
+    logFailover(route, undefined, verdict.reason, status, "no-candidate");
     return undefined;
   }
   const startedAt = Date.now();
@@ -2032,11 +2045,11 @@ async function attemptModelFailover({
       });
     } catch (error) {
       if (signal.aborted) throw error;
-      logFailover(route, model, verdict.reason, `transport/${error?.name || "Error"}`);
+      logFailover(route, model, verdict.reason, status, `transport/${error?.name || "Error"}`);
       continue;
     }
     if (upstream.ok) {
-      logFailover(route, model, verdict.reason, status);
+      logFailover(route, model, verdict.reason, status, upstream.status);
       return { route: model, built, upstream };
     }
     // The candidate failed too. If it failed the same way, believe it and take
@@ -2048,7 +2061,7 @@ async function attemptModelFailover({
       retryAfterSeconds: Number(upstream.headers.get("retry-after")),
     });
     if (hopVerdict.swap) recordProviderCooldown(model.provider, hopVerdict);
-    logFailover(route, model, verdict.reason, upstream.status);
+    logFailover(route, model, verdict.reason, status, upstream.status);
   }
   return undefined;
 }
@@ -2286,7 +2299,7 @@ async function handleResponses(request, response, requestUrl) {
           chain: settings.chain,
         });
         if (next) {
-          logFailover(route, next.model, `cooled_until_${cooled.until}`, "skipped");
+          logFailover(route, next.model, `cooled_until_${cooled.until}`, "not-sent", "swapped");
           adoptRoute(
             next.model,
             await buildRoutedRequest({ request, payload, route: next.model, agedInput }),

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -125,6 +125,12 @@ function run(env, { chain = [FALLBACK.slug], enabled = true, cooldowns } = {}) {
     encoding: "utf8",
     mode: 0o600,
   });
+  // The responses-native provider used by the protocol-crossing cases. It is a
+  // variant of opencode-go, so it authenticates with that family's credential.
+  writeFileSync(path.join(stateDir, "opencode-go-api-key.secret"), "test-opencode-go-key\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
   const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
     cwd: root,
     env: {
@@ -299,7 +305,7 @@ test("a turn whose provider is out of usage is served by the next model", async 
     // The swap is never silent, even with the quiet flag a LaunchAgent sets.
     assert.match(child.testErrors(), /failover model=deepseek\/deepseek-v4-pro/);
     assert.match(child.testErrors(), /reason=out_of_usage/);
-    assert.match(child.testErrors(), /-> zai-api\/glm-5\.2/);
+    assert.match(child.testErrors(), /-> zai-api\/glm-5\.2 outcome=200/);
   } finally {
     await stopChild(child);
     await closeServer(gw.server);
@@ -406,7 +412,7 @@ test("with nothing eligible the original failure is returned unchanged", async (
     assert.equal(payload.error.type, "billing_error");
     assert.match(payload.error.message, /run out of usage/i);
     // The turn still says out loud that it looked and found nothing.
-    assert.match(child.testErrors(), /failover model=deepseek\/deepseek-v4-pro.*-> none/s);
+    assert.match(child.testErrors(), /failover model=deepseek\/deepseek-v4-pro.*-> none outcome=no-candidate/s);
   } finally {
     await stopChild(child);
     await closeServer(gw.server);
@@ -529,6 +535,384 @@ test("a fallback rebuild carries the full request, not a model swap", async () =
     // own letters, which reaches the provider and still reads as a 200.
     assert.equal(first.input, "hello");
     assert.equal(second.input, "hello");
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+// -- crossing the protocol line ----------------------------------------------
+//
+// The rebuild trap in AGENTS.md, exercised. A chat-completions provider needs
+// every namespace flattened into ordinary functions; a responses-native one
+// needs the namespace shape kept. A failover that crosses that line has to
+// rebuild for the *destination*, not reship the first build's tools -- and a
+// second pass over an already-flattened list would return an empty namespace
+// map, shipping plausible tools the response transform can no longer map back.
+
+const RESPONSES_MODEL = {
+  slug: "opencode-go-responses/gpt-5.6-luna",
+  gatewayModel: "opencode-go-responses-gpt-5-6-luna",
+};
+
+const NAMESPACE_TOOLS = [
+  {
+    type: "namespace",
+    name: "collaboration",
+    tools: [
+      {
+        type: "function",
+        name: "spawn_agent",
+        description: "Spawn a child agent.",
+        parameters: {
+          type: "object",
+          properties: { task: { type: "string" } },
+          required: ["task"],
+          additionalProperties: false,
+        },
+      },
+    ],
+  },
+];
+
+function toolNames(body) {
+  return (body.tools || []).map((tool) => `${tool.type}:${tool.name}`).sort();
+}
+
+test("a chat-completions turn failing over to a responses provider keeps the namespace", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    if (body.model === PRIMARY.gatewayModel) {
+      const payload = Buffer.from(QUOTA_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("responses-fallback"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), { chain: [RESPONSES_MODEL.slug] });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, { ...TURN_BODY, tools: NAMESPACE_TOOLS });
+    assert.equal(result.status, 200);
+    assert.equal(seen.length, 2);
+    const [first, second] = seen;
+    assert.equal(first.model, PRIMARY.gatewayModel);
+    assert.equal(second.model, RESPONSES_MODEL.gatewayModel);
+
+    // The chat-completions attempt flattened the namespace into plain functions
+    // (alongside the merged codex_app toolset, which only that branch adds).
+    assert.ok(toolNames(first).includes("function:collaboration__spawn_agent"));
+    assert.ok(!toolNames(first).some((name) => name.startsWith("namespace:")));
+    // The responses-native attempt must have been rebuilt from the pristine
+    // payload and kept the namespace intact. A flattened name here is the exact
+    // regression this guards: the second build reusing the first's rewritten
+    // tool list, which also yields an empty namespace map.
+    assert.deepEqual(toolNames(second), ["namespace:collaboration"]);
+    assert.equal(second.tools[0].tools[0].name, "spawn_agent");
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a responses turn failing over to a chat-completions provider flattens it", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    if (body.model === RESPONSES_MODEL.gatewayModel) {
+      const payload = Buffer.from(QUOTA_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("chat-fallback"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), { chain: [FALLBACK.slug] });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, {
+      model: RESPONSES_MODEL.slug,
+      input: "hello",
+      stream: true,
+      tools: NAMESPACE_TOOLS,
+    });
+    assert.equal(result.status, 200);
+    assert.equal(seen.length, 2);
+    const [first, second] = seen;
+    assert.deepEqual(toolNames(first), ["namespace:collaboration"]);
+    // Rebuilt for a chat-completions destination: the namespace is gone and the
+    // call is an ordinary function the provider can actually invoke.
+    assert.ok(toolNames(second).includes("function:collaboration__spawn_agent"));
+    assert.ok(!toolNames(second).some((name) => name.startsWith("namespace:")));
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+// A fallback that answers with a flattened tool call. The response transform has
+// to map it back to the client's namespace shape using the *fallback's* map and
+// slug -- the ones adopted during the swap, not the exhausted model's.
+function toolCallSse(name) {
+  const args = JSON.stringify({ task: "audit the map" });
+  const events = [
+    { type: "response.created", response: { id: "r-tool" } },
+    {
+      type: "response.output_item.added",
+      item: { type: "function_call", id: "fc_1", name, arguments: "" },
+    },
+    { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: args },
+    { type: "response.function_call_arguments.done", item_id: "fc_1", arguments: args },
+    {
+      type: "response.output_item.done",
+      item: { type: "function_call", id: "fc_1", name, arguments: args },
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "r-tool",
+        output: [{ type: "function_call", id: "fc_1", name, arguments: args }],
+        usage: { input_tokens: 10, output_tokens: 3, total_tokens: 13 },
+      },
+    },
+  ];
+  return `${events
+    .map((entry) => `event: ${entry.type}\ndata: ${JSON.stringify(entry)}\n\n`)
+    .join("")}data: [DONE]\n\n`;
+}
+
+test("a tool call from the fallback is mapped back to the client's namespace", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    if (body.model === PRIMARY.gatewayModel) {
+      const payload = Buffer.from(QUOTA_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(toolCallSse("collaboration__spawn_agent"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort));
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, { ...TURN_BODY, tools: NAMESPACE_TOOLS });
+    assert.equal(result.status, 200);
+    assert.equal(seen.length, 2);
+    // Restored to the namespaced shape Codex registered, not the flattened name
+    // the provider was given. Without the swap adopting the fallback's namespace
+    // map, the call would reach the client as `collaboration__spawn_agent` and
+    // Codex would reject a tool it never registered.
+    assert.match(result.body, /"namespace":"collaboration"/);
+    assert.match(result.body, /"name":"spawn_agent"/);
+    assert.doesNotMatch(result.body, /"name":"collaboration__spawn_agent"/);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("failover walks past a candidate that is also out of usage", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body.model);
+    if (body.model === RESPONSES_MODEL.gatewayModel) {
+      response.writeHead(200, { "Content-Type": "text/event-stream" });
+      response.end(contentSse("second-candidate"));
+      return;
+    }
+    // Both the asked-for model and the first candidate report empty.
+    const payload = Buffer.from(QUOTA_BODY, "utf8");
+    response.writeHead(429, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), {
+    chain: [FALLBACK.slug, RESPONSES_MODEL.slug],
+  });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, TURN_BODY);
+    assert.equal(result.status, 200);
+    assert.match(result.body, /answered-by-second-candidate/);
+    // Asked model, first candidate, second candidate -- and no further, because
+    // the hop bound stops there.
+    assert.deepEqual(seen, [
+      PRIMARY.gatewayModel,
+      FALLBACK.gatewayModel,
+      RESPONSES_MODEL.gatewayModel,
+    ]);
+    // The candidate that also reported empty is cooled down on its own account.
+    const events = await waitForUsageEvents(child.stateDir, 2, child);
+    assert.equal(events.at(-1).failoverFrom, PRIMARY.slug);
+    assert.equal(events.at(-1).model, RESPONSES_MODEL.slug);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("the hop bound stops after two candidates rather than walking the catalog", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body.model);
+    const payload = Buffer.from(QUOTA_BODY, "utf8");
+    response.writeHead(429, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), {
+    chain: [FALLBACK.slug, RESPONSES_MODEL.slug, "kimi-api/kimi-k3"],
+  });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, TURN_BODY);
+    // Everything failed, so the operator reads the failure their own model gave.
+    assert.equal(result.status, 429);
+    assert.equal(JSON.parse(result.body).error.type, "billing_error");
+    // One asked-for attempt plus at most MAX_FAILOVER_HOPS candidates.
+    assert.equal(seen.length, 3);
+    assert.equal(seen[0], PRIMARY.gatewayModel);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a non-streaming turn fails over the same way", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    if (body.model === PRIMARY.gatewayModel) {
+      const payload = Buffer.from(QUOTA_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    const payload = Buffer.from(
+      JSON.stringify({
+        id: "r-json",
+        object: "response",
+        model: body.model,
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "answered-by-json-fallback" }],
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 4, total_tokens: 14 },
+      }),
+      "utf8",
+    );
+    response.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort));
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, { ...TURN_BODY, stream: false });
+    assert.equal(result.status, 200);
+    assert.equal(seen.length, 2);
+    assert.equal(seen[1].model, FALLBACK.gatewayModel);
+    assert.match(result.body, /answered-by-json-fallback/);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a client that leaves mid-failover does not hang or crash the router", async () => {
+  let fallbackStarted = 0;
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    if (body.model === PRIMARY.gatewayModel) {
+      const payload = Buffer.from(QUOTA_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    // The fallback is slow, so the abort lands while the hop is in flight --
+    // the window the failover loop has to notice the caller is gone.
+    fallbackStarted += 1;
+    setTimeout(() => {
+      if (response.writableEnded) return;
+      response.writeHead(200, { "Content-Type": "text/event-stream" });
+      response.end(contentSse("late"));
+    }, 3_000);
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort));
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const base = new URL(`${callerBaseUrl(routerPort, CALLER_KEY)}/responses`);
+    const aborted = new Promise((resolve) => {
+      const outbound = http.request(
+        {
+          host: "127.0.0.1",
+          port: routerPort,
+          path: base.pathname,
+          method: "POST",
+          headers: { "Content-Type": "application/json", Authorization: "Bearer x" },
+        },
+        (response) => response.resume(),
+      );
+      outbound.on("error", () => resolve());
+      outbound.end(JSON.stringify(TURN_BODY));
+      setTimeout(() => {
+        outbound.destroy();
+        resolve();
+      }, 800);
+    });
+    await aborted;
+
+    // The router must still be serving, and a later turn must behave normally.
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    assert.equal(child.exitCode, null, `router exited: ${child.testErrors()}`);
+    assert.ok(fallbackStarted >= 1, "the failover hop should have been attempted");
+    // A departed caller meters as 0 rather than as a committed success.
+    const events = await waitForUsageEvents(child.stateDir, 1, child);
+    assert.ok(events.length >= 1);
+    assert.doesNotMatch(child.testErrors(), /UnhandledPromiseRejection|FATAL/);
   } finally {
     await stopChild(child);
     await closeServer(gw.server);

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -16,6 +16,7 @@ const {
   clearAllProviderCooldowns,
   clearProviderCooldown,
   failoverTier,
+  failoverTierCounts,
   providerCooldown,
   rankFailoverCandidates,
   readFailoverSettings,
@@ -324,6 +325,29 @@ test("a named chain is used verbatim, minus entries this build cannot route to",
     ranked.map((entry) => entry.model.slug),
     ["kimi/k3", "opencode-free/big-pickle"],
   );
+});
+
+test("failoverTierCounts separates free, local, and paid rather than promising an order", () => {
+  const counts = failoverTierCounts([
+    model("opencode-free/big-pickle", "opencode-free"),
+    model("kilo-free/x:free", "kilo-free"),
+    model("local/qwen3", "local"),
+    model("kimi-api/kimi-k3", "kimi-api"),
+    model("zai-api/glm-5.2", "zai-api"),
+  ]);
+  // Local is counted apart from free: it costs nothing and is still never
+  // chosen automatically, so folding it into `free` would let a surface promise
+  // a first stop that cannot happen.
+  assert.deepEqual(counts, { free: 2, local: 1, subscription: 2 });
+  // The case every install starts in: nothing curated, so nothing cheaper to
+  // try first, and no surface may claim otherwise.
+  assert.deepEqual(failoverTierCounts([model("kimi-api/kimi-k3", "kimi-api")]), {
+    free: 0,
+    local: 0,
+    subscription: 1,
+  });
+  assert.deepEqual(failoverTierCounts([]), { free: 0, local: 0, subscription: 0 });
+  assert.deepEqual(failoverTierCounts(undefined), { free: 0, local: 0, subscription: 0 });
 });
 
 test("failoverTier reads free from the registry rather than a name", () => {


### PR DESCRIPTION
Follow-up to #260, which merged with two problems.

## 1. Every failover was tested on the one shape that cannot break

All coverage went chat-completions → chat-completions. The rule the feature
ships with is about the *other* shapes, and none had a test. Added:

- **Crossing the protocol line, both directions.** A chat turn moving to a
  responses-native provider must keep its namespace tools intact; a responses
  turn moving to a chat provider must flatten them. The regression this guards
  is the second build reusing the first's rewritten tool list, which
  `flattenNamespaceTools` answers with an *empty* namespace map — plausible
  tools the response transform can no longer map back.
- **A tool call arriving from the fallback**, restored to the namespace shape
  Codex registered rather than the flattened name the provider was handed.
- **Walking past a candidate that is also out of usage**, and stopping at the
  hop bound rather than the end of the catalog.
- **A non-streaming turn.**
- **A client that leaves while a hop is in flight** — no hang, no crash.

Live testing then found the log line actively misleading: a hop rejected with
its own 400 printed `reason=out_of_usage status=400`, which reads as the
exhausted provider having answered 400. Those are two different events and the
line now says both:

```
failover model=kimi-oauth/k3 status=403 reason=out_of_usage -> opencode-go-responses/gpt-5.6-luna outcome=400
failover model=kimi-oauth/k3 status=403 reason=out_of_usage -> grok-oauth/grok-4.6 outcome=200
```

## 2. It promised a free first stop that could not happen

The ranking puts free models first and every surface said so. On a real install
that sentence is false: `doctor` reported "free models first then your other
enabled providers" while the free tier held nothing, so failover went straight
to a paid subscription having told the operator otherwise.

The ranking is fine. `opencode-free` and `kilo-free` stay catalog-only because
their free subsets are picked out by naming rules the vendors change without
notice, and an anonymous provider is never enabled for someone who did not ask —
both rules are deliberate and stay. The *claim* is what changes.
`failoverTierCounts` counts what the ranking can actually reach and `doctor`
reports that:

```
on, 1 free model(s) first then 27 of your own
on, 73 of your own providers -- no free model is curated, so nothing cheaper is tried first
```

Models on this machine are counted apart from free ones: they cost nothing and
are still never chosen automatically, so folding them together would recreate
the same false promise. The README now says the free stop is opt-in, and how to
take it.

## Test plan

`npm test` → **1376 pass, 0 fail**. `npm run check` clean.

Verified live against a genuinely out-of-usage provider (`kimi-oauth/k3`, real
403 "You've reached your usage limit for this billing cycle"), full stack —
router, real LiteLLM, api-forwarder:

- [x] a real chain walks past a candidate that genuinely fails, then answers
- [x] pre-dispatch cooldown skip: exhausted provider never contacted (4.0s vs ~10s, no usage event)
- [x] with `opencode-free` enabled and one model curated, the turn is served by
      `opencode-free/deepseek-v4-flash-free` — tier 0, ahead of 73 paid candidates, at no cost
- [x] without curation the same turn goes to a paid provider, and doctor says so

Worth recording because no mock could show it: `opencode-go-responses/gpt-5.6-luna`
answers 400 `invalid_prompt` to namespace tools whether or not a failover is
involved. The router handles it correctly by walking past — but that is a
property of the model, not of this feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9M4PfijioNMe3RsUQ999x