### PR TITLE
fix: preserve Grok OAuth tool calls across Responses SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Grok OAuth no longer loses late or custom tool calls.** The forwarder now
+  accepts `function_call` and `custom_tool_call` items that first appear in
+  `response.output_item.done`, restores final arguments when argument deltas
+  are absent, joins repeated SSE `data:` fields, and consumes the final event
+  even when the upstream omits its trailing blank line. Streaming remains live
+  while the upstream turn is running.
+
 - **Curated models were filed at 131072 tokens however big they actually
   were, and the million-token ones compacted on every turn.** Curation stored
   one conservative window for every model it added, so a model OpenRouter

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -296,6 +296,13 @@ empty response as a completed turn and the agent appears to stop for no reason.
 Reasoning-only turns count — a model that thinks and then says nothing produces
 exactly this.
 
+Grok OAuth previously had a nearby parser failure with the same visible shape:
+the upstream could put a `function_call` only in `response.output_item.done`,
+emit a `custom_tool_call`, or end the final SSE block without a trailing blank
+line. The forwarder now accepts all three shapes and restores final tool
+arguments without holding the full turn, so Codex sees the tool call instead of
+mistaking the preceding status text for the completed task.
+
 The router holds the entire response until it knows the turn produced something.
 When nothing arrives it discards that attempt and retries the identical request
 once, so the client sees only one response head, response ID, and sequence space.

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -18,6 +18,12 @@ import { MODELS } from "./model-registry.mjs";
 import { ensureFreshGrokOAuthToken } from "./grok-oauth-session.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { normalizeSchemaLiterals, objectRootToolSchema } from "./tool-schema-root.mjs";
+import {
+  applyResponsesEvent,
+  createTurnState,
+  finalizeTurn,
+  sseDataFromBlock,
+} from "./grok-oauth-turn.mjs";
 import { VERSION } from "./version.mjs";
 import { installStableFetchTransport } from "./fetch-transport.mjs";
 
@@ -271,6 +277,25 @@ function upstreamHeaders(accessToken, model, messages) {
 }
 
 // Parse the upstream Responses SSE and invoke callbacks per normalized event.
+function nextSseBoundary(buffer) {
+  const crlf = buffer.indexOf("\r\n\r\n");
+  const lf = buffer.indexOf("\n\n");
+  if (crlf === -1 && lf === -1) return null;
+  if (crlf === -1) return { at: lf, size: 2 };
+  if (lf === -1) return { at: crlf, size: 4 };
+  return crlf < lf ? { at: crlf, size: 4 } : { at: lf, size: 2 };
+}
+
+function dispatchSseBlock(rawEvent, handlers) {
+  const data = sseDataFromBlock(rawEvent);
+  if (!data || data === "[DONE]") return;
+  try {
+    handlers(JSON.parse(data));
+  } catch {
+    // Ignore malformed upstream events while preserving the rest of the stream.
+  }
+}
+
 async function consumeResponsesStream(upstreamBody, handlers) {
   const reader = upstreamBody.getReader();
   const decoder = new TextDecoder();
@@ -280,24 +305,14 @@ async function consumeResponsesStream(upstreamBody, handlers) {
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
     let boundary;
-    while ((boundary = buffer.indexOf("\n\n")) !== -1) {
-      const rawEvent = buffer.slice(0, boundary);
-      buffer = buffer.slice(boundary + 2);
-      const dataLine = rawEvent
-        .split("\n")
-        .find((line) => line.startsWith("data:"));
-      if (!dataLine) continue;
-      const data = dataLine.slice(5).trim();
-      if (!data || data === "[DONE]") continue;
-      let event;
-      try {
-        event = JSON.parse(data);
-      } catch {
-        continue;
-      }
-      handlers(event);
+    while ((boundary = nextSseBoundary(buffer))) {
+      const rawEvent = buffer.slice(0, boundary.at);
+      buffer = buffer.slice(boundary.at + boundary.size);
+      dispatchSseBlock(rawEvent, handlers);
     }
   }
+  buffer += decoder.decode();
+  if (buffer.trim()) dispatchSseBlock(buffer, handlers);
 }
 
 const OPENAI_ROLE_CHUNK = (id, created, model, delta, finishReason = null) =>
@@ -378,10 +393,8 @@ async function handleChatCompletions(request, response) {
 
   const id = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1_000);
-  const toolIndex = new Map();
-  let contentText = "";
-  let finishReason = "stop";
-  let usage;
+  const turnState = createTurnState();
+  let emittedDeltaCount = 0;
 
   if (wantsStream) {
     response.writeHead(200, {
@@ -392,116 +405,44 @@ async function handleChatCompletions(request, response) {
     response.write(OPENAI_ROLE_CHUNK(id, created, model, { role: "assistant", content: "" }));
   }
 
+  const emitPendingDeltas = () => {
+    if (!wantsStream) return;
+    while (emittedDeltaCount < turnState.deltas.length) {
+      response.write(
+        OPENAI_ROLE_CHUNK(id, created, model, turnState.deltas[emittedDeltaCount]),
+      );
+      emittedDeltaCount += 1;
+    }
+  };
+
   const onEvent = (event) => {
-    switch (event.type) {
-      case "response.output_text.delta": {
-        contentText += event.delta || "";
-        if (wantsStream && event.delta) {
-          response.write(OPENAI_ROLE_CHUNK(id, created, model, { content: event.delta }));
-        }
-        break;
-      }
-      case "response.output_item.added": {
-        const item = event.item;
-        if (item?.type === "function_call") {
-          const index = toolIndex.size;
-          toolIndex.set(item.id, index);
-          finishReason = "tool_calls";
-          if (wantsStream) {
-            response.write(
-              OPENAI_ROLE_CHUNK(id, created, model, {
-                tool_calls: [
-                  {
-                    index,
-                    id: item.call_id || item.id,
-                    type: "function",
-                    function: { name: item.name || "", arguments: "" },
-                  },
-                ],
-              }),
-            );
-          }
-        }
-        break;
-      }
-      case "response.function_call_arguments.delta": {
-        const index = toolIndex.get(event.item_id) ?? 0;
-        if (wantsStream && event.delta) {
-          response.write(
-            OPENAI_ROLE_CHUNK(id, created, model, {
-              tool_calls: [{ index, function: { arguments: event.delta } }],
-            }),
-          );
-        }
-        break;
-      }
-      case "response.completed": {
-        const u = event.response?.usage;
-        if (u) {
-          usage = {
-            prompt_tokens: u.input_tokens ?? 0,
-            completion_tokens: u.output_tokens ?? 0,
-            total_tokens: (u.input_tokens ?? 0) + (u.output_tokens ?? 0),
-          };
-          // xAI caches prompts automatically and reports the hit under
-          // `input_tokens_details`. Dropping it here is what makes every routed
-          // Grok turn log `cached_tokens=unknown`, so the one number that says
-          // whether the cache is working is invisible -- and `response-usage.mjs`
-          // is already looking for it under both spellings.
-          const cached = u.input_tokens_details?.cached_tokens;
-          if (typeof cached === "number") {
-            usage.prompt_tokens_details = { cached_tokens: cached };
-          }
-          const reasoning = u.output_tokens_details?.reasoning_tokens;
-          if (typeof reasoning === "number") {
-            usage.completion_tokens_details = { reasoning_tokens: reasoning };
-          }
-        }
-        break;
-      }
-      default:
-        break;
-    }
+    applyResponsesEvent(turnState, event);
+    emitPendingDeltas();
   };
 
-  // For a non-streaming client we still need the tool-call structure, so collect
-  // the full output items from the completed event.
-  const collectedToolCalls = [];
-  const onEventCollecting = (event) => {
-    onEvent(event);
-    if (event.type === "response.output_item.done" && event.item?.type === "function_call") {
-      collectedToolCalls.push({
-        id: event.item.call_id || event.item.id,
-        type: "function",
-        function: { name: event.item.name, arguments: event.item.arguments || "" },
-      });
-    }
-  };
-
-  await consumeResponsesStream(upstream.body, wantsStream ? onEvent : onEventCollecting);
+  await consumeResponsesStream(upstream.body, onEvent);
+  const turn = finalizeTurn(turnState);
+  emitPendingDeltas();
 
   if (wantsStream) {
-    response.write(OPENAI_ROLE_CHUNK(id, created, model, {}, finishReason));
-    if (usage) {
+    response.write(OPENAI_ROLE_CHUNK(id, created, model, {}, turn.finishReason));
+    if (turn.usage) {
       response.write(
-        `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model, choices: [], usage })}\n\n`,
+        `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model, choices: [], usage: turn.usage })}\n\n`,
       );
     }
     response.write("data: [DONE]\n\n");
     response.end();
   } else {
-    const message = { role: "assistant", content: contentText || null };
-    if (collectedToolCalls.length) {
-      message.tool_calls = collectedToolCalls;
-      finishReason = "tool_calls";
-    }
+    const message = { role: "assistant", content: turn.contentText || null };
+    if (turn.toolCalls.length) message.tool_calls = turn.toolCalls;
     writeJson(response, 200, {
       id,
       object: "chat.completion",
       created,
       model,
-      choices: [{ index: 0, message, finish_reason: finishReason }],
-      usage: usage || { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+      choices: [{ index: 0, message, finish_reason: turn.finishReason }],
+      usage: turn.usage || { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
     });
   }
 

--- a/src/grok-oauth-turn.mjs
+++ b/src/grok-oauth-turn.mjs
@@ -1,0 +1,184 @@
+// SSE joins repeated `data:` fields with a line feed before dispatch.
+// Reading only the first field truncates multiline JSON.
+export function sseDataFromBlock(rawEvent) {
+  if (typeof rawEvent !== "string" || !rawEvent) return undefined;
+  const dataLines = [];
+  for (const line of rawEvent.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const value = line.slice(5);
+    dataLines.push(value.startsWith(" ") ? value.slice(1) : value);
+  }
+  return dataLines.length ? dataLines.join("\n") : undefined;
+}
+
+const TOOL_ITEM_TYPES = new Set(["function_call", "custom_tool_call"]);
+
+export function createTurnState() {
+  return {
+    contentText: "",
+    toolCalls: [],
+    toolByItemId: new Map(),
+    usage: undefined,
+    deltas: [],
+  };
+}
+
+export function mapUpstreamUsage(usage) {
+  if (!usage || typeof usage !== "object") return undefined;
+  const prompt = Number(usage.input_tokens ?? usage.prompt_tokens ?? 0);
+  const completion = Number(usage.output_tokens ?? usage.completion_tokens ?? 0);
+  const mapped = {
+    prompt_tokens: Number.isFinite(prompt) ? prompt : 0,
+    completion_tokens: Number.isFinite(completion) ? completion : 0,
+    total_tokens:
+      (Number.isFinite(prompt) ? prompt : 0) + (Number.isFinite(completion) ? completion : 0),
+  };
+  const cached = Number(usage.input_tokens_details?.cached_tokens);
+  if (Number.isFinite(cached)) {
+    mapped.prompt_tokens_details = { cached_tokens: cached };
+  }
+  const reasoning = Number(
+    usage.output_tokens_details?.reasoning_tokens ?? usage.reasoning_tokens,
+  );
+  if (Number.isFinite(reasoning)) {
+    mapped.completion_tokens_details = { reasoning_tokens: reasoning };
+  }
+  return mapped;
+}
+
+function toolArguments(item) {
+  if (typeof item?.arguments === "string") return item.arguments;
+  if (typeof item?.input === "string") return item.input;
+  return "";
+}
+
+function streamedToolArguments(state, index) {
+  return state.deltas
+    .flatMap((delta) => delta.tool_calls || [])
+    .filter((call) => call.index === index)
+    .map((call) => call.function?.arguments || "")
+    .join("");
+}
+
+function pushToolArgumentDelta(state, entry, delta) {
+  if (!entry || !delta) return;
+  const index = state.toolCalls.indexOf(entry);
+  state.deltas.push({
+    tool_calls: [{ index, function: { arguments: delta } }],
+  });
+}
+
+function appendToolArgumentDelta(state, itemId, delta) {
+  const entry = itemId ? state.toolByItemId.get(itemId) : undefined;
+  if (!entry || !delta) return;
+  entry.function.arguments += delta;
+  pushToolArgumentDelta(state, entry, delta);
+}
+
+function backfillToolArgumentDeltas(state) {
+  state.toolCalls.forEach((entry, index) => {
+    const finalArgs = entry.function.arguments || "";
+    const streamed = streamedToolArguments(state, index);
+    if (!finalArgs || streamed === finalArgs) return;
+    const extra = finalArgs.startsWith(streamed) ? finalArgs.slice(streamed.length) : finalArgs;
+    pushToolArgumentDelta(state, entry, extra);
+  });
+}
+
+function ensureToolCall(state, item, itemId, { complete = false } = {}) {
+  if (!item || !TOOL_ITEM_TYPES.has(item.type)) return undefined;
+  const key = itemId || item.id || item.call_id;
+  let entry = key ? state.toolByItemId.get(key) : undefined;
+  if (!entry) {
+    const args = toolArguments(item);
+    entry = {
+      id: item.call_id || item.id || key,
+      type: "function",
+      function: { name: item.name || "", arguments: args },
+    };
+    state.toolCalls.push(entry);
+    if (key) state.toolByItemId.set(key, entry);
+    state.deltas.push({
+      tool_calls: [
+        {
+          index: state.toolCalls.length - 1,
+          id: entry.id,
+          type: "function",
+          function: { name: entry.function.name, arguments: complete ? args : "" },
+        },
+      ],
+    });
+  } else {
+    if (item.name) entry.function.name = item.name;
+    const args = toolArguments(item);
+    if (args) entry.function.arguments = args;
+  }
+  return entry;
+}
+
+export function applyResponsesEvent(state, event) {
+  if (!event || typeof event !== "object") return state;
+  switch (event.type) {
+    case "response.output_text.delta": {
+      if (event.delta) {
+        state.contentText += event.delta;
+        state.deltas.push({ content: event.delta });
+      }
+      break;
+    }
+    case "response.output_item.added":
+    case "response.output_item.done": {
+      const item = event.item;
+      if (TOOL_ITEM_TYPES.has(item?.type)) {
+        ensureToolCall(state, item, item.id, {
+          complete: event.type === "response.output_item.done",
+        });
+      }
+      break;
+    }
+    case "response.function_call_arguments.delta":
+    case "response.custom_tool_call_input.delta": {
+      appendToolArgumentDelta(state, event.item_id, event.delta);
+      break;
+    }
+    case "response.function_call_arguments.done":
+    case "response.custom_tool_call_input.done": {
+      const complete = event.arguments ?? event.input ?? event.text;
+      if (typeof complete === "string") {
+        const entry = event.item_id ? state.toolByItemId.get(event.item_id) : undefined;
+        if (entry) {
+          const extra = complete.startsWith(entry.function.arguments)
+            ? complete.slice(entry.function.arguments.length)
+            : complete;
+          entry.function.arguments = complete;
+          pushToolArgumentDelta(state, entry, extra);
+        }
+      }
+      break;
+    }
+    case "response.completed": {
+      state.usage = mapUpstreamUsage(event.response?.usage);
+      break;
+    }
+    default:
+      break;
+  }
+  return state;
+}
+
+export function finalizeTurn(state) {
+  backfillToolArgumentDeltas(state);
+  return {
+    contentText: state.contentText,
+    toolCalls: state.toolCalls,
+    usage: state.usage,
+    deltas: state.deltas,
+    finishReason: state.toolCalls.length ? "tool_calls" : "stop",
+  };
+}
+
+export function collectResponsesEvents(events) {
+  const state = createTurnState();
+  for (const event of events || []) applyResponsesEvent(state, event);
+  return finalizeTurn(state);
+}

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -446,3 +446,161 @@ test("upstream headers keep one conversation on one conv-id", async () => {
     turnOne,
   );
 });
+
+test("streams visible output before the upstream turn completes", async () => {
+  let releaseCompletion;
+  const completionGate = new Promise((resolve) => {
+    releaseCompletion = resolve;
+  });
+  const backend = await mockBackend(async (_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.write(sse([{ type: "response.output_text.delta", delta: "working" }]));
+    await completionGate;
+    res.end(
+      sse([
+        { type: "response.completed", response: { usage: { input_tokens: 10, output_tokens: 2 } } },
+      ]),
+    );
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-live-stream-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "continue" }],
+        stream: true,
+      }),
+    });
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let body = "";
+    let timeout;
+    await Promise.race([
+      (async () => {
+        while (!body.includes('"content":"working"')) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          body += decoder.decode(value, { stream: true });
+        }
+      })(),
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("visible output was buffered until completion")),
+          2_000,
+        );
+      }),
+    ]);
+    clearTimeout(timeout);
+    assert.match(body, /"content":"working"/);
+    releaseCompletion();
+    for (;;) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+  } finally {
+    releaseCompletion?.();
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("streams a function call that appears only in a final unterminated SSE block", async () => {
+  let inbound = 0;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    const event = {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "fc_done",
+        call_id: "call_done",
+        name: "exec_command",
+        arguments: '{"cmd":"dir"}',
+      },
+    };
+    res.end(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n`);
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-final-block-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "run it" }],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: true,
+      }),
+    });
+    const body = await resp.text();
+    assert.match(body, /"finish_reason":"tool_calls"/);
+    assert.match(body, /exec_command/);
+    assert.match(body, /\\"cmd\\":\\"dir\\"/);
+    assert.equal(inbound, 1);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("forwards a short reasoning-heavy answer once without retrying", async () => {
+  let inbound = 0;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(
+      sse([
+        { type: "response.output_text.delta", delta: "Next I will update the deck." },
+        {
+          type: "response.completed",
+          response: {
+            usage: {
+              input_tokens: 105_882,
+              output_tokens: 1_660,
+              output_tokens_details: { reasoning_tokens: 1_620 },
+            },
+          },
+        },
+      ]),
+    );
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-short-answer-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "update the deck" }],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: false,
+      }),
+    });
+    const json = await resp.json();
+    assert.equal(json.choices[0].message.content, "Next I will update the deck.");
+    assert.equal(json.choices[0].finish_reason, "stop");
+    assert.equal(json.usage.completion_tokens_details.reasoning_tokens, 1_620);
+    assert.equal(inbound, 1);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/grok-oauth-turn.test.mjs
+++ b/test/grok-oauth-turn.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyResponsesEvent,
+  collectResponsesEvents,
+  createTurnState,
+  sseDataFromBlock,
+} from "../src/grok-oauth-turn.mjs";
+
+test("collectResponsesEvents keeps a function_call that only appears in output_item.done", () => {
+  const turn = collectResponsesEvents([
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "fc_1",
+        call_id: "call_1",
+        name: "exec_command",
+        arguments: '{"cmd":"dir"}',
+      },
+    },
+    { type: "response.completed", response: { usage: { input_tokens: 10, output_tokens: 8 } } },
+  ]);
+  assert.equal(turn.finishReason, "tool_calls");
+  assert.equal(turn.toolCalls.length, 1);
+  assert.equal(turn.toolCalls[0].function.name, "exec_command");
+  assert.equal(turn.toolCalls[0].function.arguments, '{"cmd":"dir"}');
+  assert.equal(turn.deltas[0].tool_calls[0].function.arguments, '{"cmd":"dir"}');
+});
+
+test("finalizeTurn backfills streamed arguments when added is followed by done without deltas", () => {
+  const turn = collectResponsesEvents([
+    {
+      type: "response.output_item.added",
+      item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "exec_command" },
+    },
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "fc_1",
+        call_id: "call_1",
+        name: "exec_command",
+        arguments: '{"cmd":"dir"}',
+      },
+    },
+  ]);
+  const streamedArgs = turn.deltas
+    .flatMap((delta) => delta.tool_calls || [])
+    .map((call) => call.function?.arguments || "")
+    .join("");
+  assert.equal(turn.toolCalls[0].function.arguments, '{"cmd":"dir"}');
+  assert.equal(streamedArgs, '{"cmd":"dir"}');
+});
+
+test("collectResponsesEvents maps custom_tool_call onto a function tool call", () => {
+  const turn = collectResponsesEvents([
+    {
+      type: "response.output_item.added",
+      item: { type: "custom_tool_call", id: "ctc_1", call_id: "call_9", name: "exec" },
+    },
+    { type: "response.custom_tool_call_input.delta", item_id: "ctc_1", delta: '{"x":1}' },
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "custom_tool_call",
+        id: "ctc_1",
+        call_id: "call_9",
+        name: "exec",
+        input: '{"x":1}',
+      },
+    },
+  ]);
+  assert.equal(turn.toolCalls[0].id, "call_9");
+  assert.equal(turn.toolCalls[0].function.name, "exec");
+  assert.equal(turn.toolCalls[0].function.arguments, '{"x":1}');
+});
+
+test("collectResponsesEvents copies reasoning tokens into usage details", () => {
+  const turn = collectResponsesEvents([
+    { type: "response.output_text.delta", delta: "ok" },
+    {
+      type: "response.completed",
+      response: {
+        usage: {
+          input_tokens: 100,
+          output_tokens: 1660,
+          output_tokens_details: { reasoning_tokens: 1600 },
+        },
+      },
+    },
+  ]);
+  assert.equal(turn.contentText, "ok");
+  assert.equal(turn.usage.completion_tokens, 1660);
+  assert.equal(turn.usage.completion_tokens_details.reasoning_tokens, 1600);
+});
+
+test("collectResponsesEvents preserves cached input tokens from the upstream usage", () => {
+  const turn = collectResponsesEvents([
+    {
+      type: "response.completed",
+      response: {
+        usage: {
+          input_tokens: 100,
+          output_tokens: 20,
+          input_tokens_details: { cached_tokens: 80 },
+        },
+      },
+    },
+  ]);
+  assert.equal(turn.usage.prompt_tokens_details.cached_tokens, 80);
+});
+
+test("applyResponsesEvent accumulates output text", () => {
+  const state = createTurnState();
+  applyResponsesEvent(state, { type: "response.output_text.delta", delta: "先" });
+  applyResponsesEvent(state, { type: "response.output_text.delta", delta: "看" });
+  assert.equal(state.contentText, "先看");
+});
+
+test("sseDataFromBlock joins repeated data fields the way SSE requires", () => {
+  const payload = { type: "response.output_text.delta", delta: "hi" };
+  const pretty = JSON.stringify(payload, null, 2);
+  const block = pretty
+    .split("\n")
+    .map((line) => `data: ${line}`)
+    .join("\n");
+  const joined = sseDataFromBlock(`event: response.output_text.delta\n${block}`);
+  assert.equal(joined, pretty);
+  assert.deepEqual(JSON.parse(joined), payload);
+});
+
+test("sseDataFromBlock keeps a single data field", () => {
+  assert.equal(sseDataFromBlock("data: [DONE]"), "[DONE]");
+  assert.equal(sseDataFromBlock("event: ping"), undefined);
+});


### PR DESCRIPTION
## Summary

Narrowed after maintainer review to the low-risk Grok OAuth Responses parser/mapping fix only. This PR no longer classifies or retries progress-only replies.

- Preserve `function_call` and `custom_tool_call` items that first appear in `response.output_item.done`.
- Backfill final tool arguments when the upstream omits argument deltas, including the streamed Chat Completions replay LiteLLM consumes.
- Join repeated SSE `data:` fields and dispatch a final block without a trailing blank line.
- Keep output streaming live while the upstream turn is still running.
- Preserve #265's conversation-ID routing plus `cached_tokens` and reasoning-token usage details.

A genuine short, tool-less answer is now forwarded unchanged. Any retry policy can be evaluated separately with its own liveness, accounting, logging, and kill-switch contract.

## Review changes

The progress-only classifier, hard-coded thresholds, developer nudge, second upstream request, and full-turn buffering were removed. That also removes the false retry, first-answer replacement, unmetered usage, missing kill switch, and unread retry-body concerns from this PR.

## Testing

- [x] `node --test test/grok-oauth-turn.test.mjs test/grok-oauth-forwarder.test.mjs` - 23/23 pass
- [x] `npm run check` - pass
- [x] Full `npm test` comparison: 1399 tests; the five local Windows failures reproduce unchanged on a clean `origin/main` worktree (three desktop i18n expectations under the zh-CN host locale and two pre-existing `ENOTEMPTY` Kimi doctor cleanup flakes)
- [x] GitHub CI

