### PR TITLE
fix(grok): keep one conversation on one conv-id so the prompt cache is read

### DIFF
--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 
 import {
@@ -214,8 +214,43 @@ export function toResponsesRequest(chat, options = {}) {
   return request;
 }
 
-function upstreamHeaders(accessToken, model) {
-  const sessionId = randomUUID();
+// xAI routes by `x-grok-conv-id` so that every turn of one conversation lands
+// on the server holding its KV cache; their docs name a wrong or changing
+// conversation id as the first thing to check when `cached_tokens` stays at
+// zero. A fresh UUID per request sends each turn somewhere else, and the cache
+// is never read: measured over a four-turn append-only session, 128 / 4608 /
+// 128 / 0 cached tokens against a 31k prompt that was identical up to the
+// appended tail every time.
+//
+// The conversation's own opening messages are the stable key. Codex appends and
+// never rewrites them, so hashing the first two pins every turn of a session to
+// one server while keeping separate sessions apart. Formatted as a UUID because
+// that is what the header carries everywhere else.
+export function conversationIdForTest(messages) {
+  return conversationId(messages);
+}
+
+function conversationId(messages) {
+  const anchor = [];
+  for (const message of Array.isArray(messages) ? messages : []) {
+    const content =
+      typeof message?.content === "string" ? message.content : JSON.stringify(message?.content);
+    anchor.push(`${message?.role}:${content}`);
+    if (anchor.length === 2) break;
+  }
+  if (anchor.length === 0) return randomUUID();
+  const digest = createHash("sha256").update(anchor.join("\n")).digest("hex");
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    digest.slice(12, 16),
+    digest.slice(16, 20),
+    digest.slice(20, 32),
+  ].join("-");
+}
+
+function upstreamHeaders(accessToken, model, messages) {
+  const sessionId = conversationId(messages);
   return {
     Authorization: `Bearer ${accessToken}`,
     "Content-Type": "application/json",
@@ -290,7 +325,7 @@ async function handleChatCompletions(request, response) {
 
   const requestUpstream = (accessToken) => fetch(`${GROK_BASE}/responses`, {
     method: "POST",
-    headers: upstreamHeaders(accessToken, model),
+    headers: upstreamHeaders(accessToken, model, chat?.messages),
     body: JSON.stringify(responsesRequest),
     signal: controller.signal,
   });
@@ -408,6 +443,19 @@ async function handleChatCompletions(request, response) {
             completion_tokens: u.output_tokens ?? 0,
             total_tokens: (u.input_tokens ?? 0) + (u.output_tokens ?? 0),
           };
+          // xAI caches prompts automatically and reports the hit under
+          // `input_tokens_details`. Dropping it here is what makes every routed
+          // Grok turn log `cached_tokens=unknown`, so the one number that says
+          // whether the cache is working is invisible -- and `response-usage.mjs`
+          // is already looking for it under both spellings.
+          const cached = u.input_tokens_details?.cached_tokens;
+          if (typeof cached === "number") {
+            usage.prompt_tokens_details = { cached_tokens: cached };
+          }
+          const reasoning = u.output_tokens_details?.reasoning_tokens;
+          if (typeof reasoning === "number") {
+            usage.completion_tokens_details = { reasoning_tokens: reasoning };
+          }
         }
         break;
       }

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -419,3 +419,30 @@ test("toResponsesRequest preserves the client's image detail level", () => {
   // Absent detail must stay absent, not default to a resolution choice.
   assert.equal("detail" in images[1], false);
 });
+
+// xAI routes by `x-grok-conv-id` so a conversation stays on the server holding
+// its KV cache. A fresh id per request scatters the turns and the cache is
+// never read: measured at 3.9% cached across an append-only session, against
+// 78.4% once the id was derived from the conversation.
+test("upstream headers keep one conversation on one conv-id", async () => {
+  const { conversationIdForTest } = await import("../src/grok-oauth-forwarder.mjs");
+  const opening = [
+    { role: "system", content: "You are Codex." },
+    { role: "user", content: "run the thing" },
+  ];
+  const turnOne = conversationIdForTest(opening);
+  // The next turn appends a tool call and its result; the opening is untouched.
+  const turnTwo = conversationIdForTest([
+    ...opening,
+    { role: "assistant", content: "", tool_calls: [{ id: "c1", function: { name: "sh" } }] },
+    { role: "tool", tool_call_id: "c1", content: "ok" },
+    { role: "user", content: "and again" },
+  ]);
+  assert.equal(turnTwo, turnOne);
+  assert.match(turnOne, /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  // A different conversation must not share the cache slot.
+  assert.notEqual(
+    conversationIdForTest([{ role: "system", content: "You are Codex." }, { role: "user", content: "other" }]),
+    turnOne,
+  );
+});


### PR DESCRIPTION
Routed Grok turns were re-reading the whole prompt every time. Two lines caused it, and a third hid it.

## What happens

`upstreamHeaders` mints a fresh UUID per request and sends it as the conversation id:

```js
function upstreamHeaders(accessToken, model) {
  const sessionId = randomUUID();
  return {
    ...
    "x-grok-conv-id": sessionId,
    "x-grok-session-id": sessionId,
```

xAI caches prompts automatically and routes by `x-grok-conv-id` so that every turn of a conversation reaches the server holding its KV cache. Their [docs](https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits) name a wrong or changing conversation id as the first thing to check when `cached_tokens` stays near zero. A new id per request scatters the turns of one Codex session across servers, so each turn prefills the whole prompt from scratch.

## Measurement

A four-turn append-only session (three shell commands, one per turn) against a ~31k prompt, with tool-result aging off so the history was strictly appended:

| turn | before: cached | after: cached |
|---|---:|---:|
| 1 | 128 (0.4%) | 4,608 (14.7%) |
| 2 | 4,608 (14.7%) | 31,360 (**99.6%**) |
| 3 | 128 (0.4%) | 31,360 (**99.4%**) |
| 4 | 0 (0.0%) | 31,488 (**99.6%**) |
| total | 4,864 / 125,194 = **3.9%** | 98,816 / 126,045 = **78.4%** |

Turn 1 has nothing to hit yet; turns 2-4 are the ones that matter and they go to ~99.5%.

Latency on those follow-up turns went from 2762 / 13532 / 2489 ms to 1810 / 1812 / 1853 ms. The steadiness is the more convincing half — a prompt that no longer needs prefilling stops varying.

## The fix

Derive the id from the conversation's opening messages. Codex appends to them and never rewrites them, so hashing the first two pins every turn of a session to one server while keeping separate sessions apart. Formatted as a UUID because that is what the header carries everywhere else.

Two sessions that genuinely share an opening will share a cache slot, which is correct — their prefix really is identical.

## Why this was invisible

The `response.completed` mapping dropped the usage detail:

```js
usage = {
  prompt_tokens: u.input_tokens ?? 0,
  completion_tokens: u.output_tokens ?? 0,
  total_tokens: ...,
};
```

`input_tokens_details.cached_tokens` never made it across, so every routed Grok turn logged `cached_tokens=unknown` — even though `response-usage.mjs:56` already reads it under both spellings and the timing log has a column for it. This forwards it, plus the reasoning-token detail beside it, so the number that says whether caching works can be read off the usage events instead of inferred.

That passthrough is what produced the table above; without it there was nothing to measure.

## Tests

`test/grok-oauth-forwarder.test.mjs` covers the id staying put when a turn appends a tool call and its result, the UUID shape, and two different conversations not colliding. Full suite green (1311 passing, 13 skipped).

## Note

Found while investigating why Grok 4.6 feels much slower in Codex than in other clients. Worth mentioning separately: 42 of 322 routed Grok requests here released the empty-completion guard (13%), each one re-sending the whole prompt. That is upstream behaviour rather than a router bug, but the rate seems high enough to be worth knowing.
