### PR TITLE
feat(commandcode): serve the coding plans through the route their own CLI uses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -559,7 +559,14 @@ surfaces.
    registry entry. `providers enable`, `doctor`, and the tray all print it, so
    the requirement is visible where someone connects instead of arriving as a
    403 inside Codex. Command Code is the case: any plan signs in, only the
-   Provider plan is served.
+   Provider plan may call the documented API, and the router answers that
+   refusal by moving the turn to the CLI's own route so the cheap plans are
+   served anyway — see "Command Code is reached by two routes, and the plan
+   picks which" below. The note stays because what survives the fallback is a
+   billing difference the operator still has to know about, not an outage.
+   Prefer a route that serves the plan over a note that explains why nothing
+   works: check whether the provider's own client reaches an ungated endpoint
+   before declaring a plan unsupported.
 4. **Usage, limits, and balance in the tray.** Wire the provider's account
    endpoint into `src/provider-account-usage.mjs` so `provider-usage --json`
    returns real metrics: `quota` metrics (used/limit/remaining with reset
@@ -1195,6 +1202,62 @@ elsewhere — `encrypted_content` rewriting, the compatibility relay, the
 collaboration envelope. Those rules require live marker-return probes through
 every installed routed agent before a change ships, so the tier cannot be added
 from the test suite alone. Add it with those proofs or not at all.
+
+## Command Code is reached by two routes, and the plan picks which
+
+Command Code sells one catalog behind two surfaces, and the documented one is
+an entitlement rather than a credential. `POST /provider/v1/chat/completions`
+and `/provider/v1/messages` are the published Provider API; an account below
+the Provider plan signs in, mints a real key, runs the official CLI all day,
+and is still answered
+`403 {"error":{"code":"upgrade_required","message":"Your Go plan doesn't
+include API access…"}}`. `POST /alpha/generate` is the route the `command-code`
+CLI itself uses for every turn it takes, and it is not plan-gated. Serving the
+cheap plans means speaking that route.
+
+1. **The fallback is a route change, never a provider split.** `commandcode`
+   and `commandcode-messages` stay one family with one credential and one
+   catalog, exactly as the provider checklist requires. What changes is where
+   the turn is sent, which is why this lives in `src/api-forwarder.mjs` beside
+   the Copilot replay rather than in a forwarder of its own.
+2. **Only the entitlement refusal may move a turn.** `isUpgradeRequired()` in
+   `src/commandcode-plan.mjs` demands a 403 *and* the `upgrade_required` code
+   (or its message). A timeout, a 500, or a rate limit says nothing about the
+   plan, and reading one as a refusal would quietly move a paying
+   Provider-plan account onto its coding-plan credits. Any other 403 is
+   relayed with the provider's own message.
+3. **It is legal because nothing has been relayed yet.** The refusal arrives
+   before the first response byte reaches the caller, which is the same
+   boundary the upstream-retry and model-failover rules draw. A fallback after
+   a relayed byte would not be legal and is not attempted.
+4. **The verdict is remembered per credential, not per process.**
+   `commandcode-plan.json` stores a SHA-256 fingerprint of the key — never the
+   key — so a new key after an upgrade re-probes, and a six-hour window
+   re-checks a plan that changed under the same key. A success is written only
+   when that window came due, so a healthy account does not rewrite state once
+   per turn.
+5. **The envelope is reverse-engineered, so re-derive it rather than guess.**
+   Command Code publishes no reference for `/alpha/generate`. The shapes in
+   `src/commandcode-generate.mjs` and `src/commandcode-stream.mjs` came from
+   the shipped bundle at `$(npm root -g)/command-code/dist/cli.mjs` (v1.14.1)
+   and were confirmed against the live gateway. Three traps are load-bearing:
+   `config` is schema-strict and every field is required, `memory` is a string
+   and not an object, and `params.messages` is the Vercel AI SDK
+   `ModelMessage[]` schema — not Anthropic blocks and not OpenAI tool
+   messages. The response is newline-delimited JSON despite the
+   `text/event-stream` content type, its blocks interleave, and the trailing
+   `tool-call` event keys on `toolCallId` where every incremental event keys
+   on `id`.
+6. **An empty `system` field is not "no system prompt".** It is a cue to
+   splice in the Command Code agent's own preamble. Measured against the live
+   gateway, the same one-line turn cost 92 prompt tokens with a system prompt
+   and 7,637 without, and the model spent them being told it was Command Code
+   with Command Code's tools. A turn carrying none gets a neutral one.
+7. **Billing differs even though the models do not.** The Provider plan pays
+   as it goes; a coding plan spends plan credits against 5-hour and weekly
+   window caps and per-model allowances. That is what the `planNote` is for,
+   and it is why the note stays on the registry entry now that the plan no
+   longer blocks access outright.
 
 ## Substituting a prompt-token count a provider reported as zero
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,48 @@
   The launcher now goes through the same `spawnableCommand` helper every other
   external command in the repository uses. The shipped installer produces
   `litellm.exe`, so a normal Windows install is unaffected.
+- **Command Code was unusable on every plan but one, which is not the plan most
+  of its customers buy.** The provider only ever spoke `/provider/v1`, and that
+  surface is an entitlement rather than a credential: a $1 Go account signs in,
+  mints a real key, runs the official CLI all day, and is still answered `403
+  upgrade_required` — "Your Go plan doesn't include API access". The router's
+  only response was a plan note explaining why nothing worked. The `command-code`
+  CLI itself does not use that surface; every turn it takes goes to
+  `/alpha/generate`, which is not plan-gated. The forwarder now answers the
+  entitlement refusal by moving the turn there, so Go, GOAT, Pro, and Max are
+  served with the same key, the same catalog, and no upgrade. Both protocols are
+  covered: the chat-completions catalog and the Messages variant that carries the
+  Claude models. The refusal is remembered against a fingerprint of the
+  credential — never the key — so it is bought once rather than once per turn,
+  re-probed when the key changes, and re-checked every six hours in case the plan
+  did. Only a real `upgrade_required` may move a turn; a timeout, a 500, or any
+  other 403 is relayed with the provider's own message, because reading one of
+  those as a refusal would quietly move a paying Provider-plan account onto its
+  coding-plan credits. The fallback happens before the first relayed byte, the
+  same boundary the upstream-retry and model-failover rules draw.
+
+  That route carries the CLI's own envelope, not an OpenAI or Anthropic body, so
+  both directions are translated: a schema-strict `config` block where every
+  field is required and `memory` is a string rather than an object, messages in
+  the Vercel AI SDK `ModelMessage` schema, snake_case `input_schema` tools, and a
+  newline-delimited JSON response — despite its `text/event-stream` content type
+  — whose blocks interleave and whose trailing `tool-call` event keys on
+  `toolCallId` where every incremental event keys on `id`. Command Code publishes
+  no reference for any of it; the shapes were derived from the shipped CLI bundle
+  (v1.14.1) and confirmed against the live gateway.
+
+  One measurement changed the design. An empty `system` field is not "no system
+  prompt" to that route — it is a cue to splice in the Command Code agent's own
+  preamble. The same one-line turn cost 92 prompt tokens with a system prompt and
+  7,637 without, spent telling the model it was a different product with
+  different tools. A turn carrying no system prompt of its own now gets a neutral
+  one instead of the agent's.
+
+- **The tray showed Command Code's spending windows but not what was left to
+  spend.** The billing route it already polls reports the credit pool beside the
+  5-hour and weekly caps, and a coding plan runs out of the first long before it
+  stops hitting the second. Plan, purchased, and free credits now surface as a
+  balance metric, and the plan's own low-credit threshold marks it unavailable.
 
 - **The free Qwen3.8 endpoint refused any conversation whose system message
   arrived late or twice.** Its chat template answers those with a 400 reading

--- a/README.md
+++ b/README.md
@@ -456,27 +456,42 @@ entry — the key or the address is already the boundary.
 > something to depend on: nothing in this repository can keep them working, and
 > a failure here is not a bug the project can fix.
 
-### Command Code Provider API
+### Command Code
 
 Command Code's official Provider API is an OpenAI-compatible chat completions
 surface plus an Anthropic Messages surface at `https://api.commandcode.ai/provider/v1`
 (`COMMAND_CODE_API_KEY` or `COMMANDCODE_API_KEY` in the environment, or store
-the key once, or reuse a `command-code login` session). It requires the
-Provider plan or higher and uses the same key that authenticates the Command
-Code CLI. Everything appears as one
+the key once, or reuse a `command-code login` session). It uses the same key
+that authenticates the Command Code CLI. Everything appears as one
 "Command Code" provider; internally the catalog is split between
 `commandcode` for Chat Completions models and `commandcode-messages` for
 models that require the Messages protocol (Claude).
 
-**The Provider plan is required, and signing in does not grant it.** A Go-plan
-account can run the Command Code CLI but is refused by `/provider/v1` with
-`Your Go plan doesn't include API access`. That is an entitlement, not a
-credential problem: no sign-in, key, or reinstall changes it. Check the plan
-at [commandcode.ai/billing](https://commandcode.ai/billing) before enabling
-this provider.
+**Every Command Code plan is served, but not on the same money.** The Provider
+API is an entitlement rather than a credential: a Go-plan account signs in
+fine, mints a real key, runs the CLI all day, and is still refused by
+`/provider/v1` with `Your Go plan doesn't include API access`. The router
+answers that refusal by moving the turn to `/alpha/generate` — the route the
+`command-code` CLI itself uses, which is not plan-gated — so a $1 Go plan, a
+$10 GOAT plan, Pro, and Max all route here without an upgrade. The refusal is
+remembered per credential, so it is bought once rather than once per turn, and
+re-checked every six hours in case the plan changed.
 
-Given the Provider plan, there are two ways to authenticate, and either one is
-enough.
+What differs is the billing, which is why the note appears at connect time and
+in `doctor`:
+
+| Plan | Route | Cost |
+| --- | --- | --- |
+| Provider | `/provider/v1` | Pay as you go at API rates, no window caps |
+| Go, GOAT, Pro, Max, Team | `/alpha/generate` | Plan credits, subject to the plan's 5-hour and weekly caps |
+
+A coding plan also carries per-model allowances — Go reaches the open models
+plus GPT-5.6 Luna, Grok 4.5, and Qwen Max/Plus, while Claude and the rest of
+the GPT line need Pro or above — so a model outside the plan is refused by
+Command Code with its own message rather than by the router. Check the plan at
+[commandcode.ai/billing](https://commandcode.ai/billing).
+
+There are two ways to authenticate, and either one is enough.
 
 **Sign in through the browser (OAuth).** `command-code login` opens the
 Command Code authorization page, receives the callback on a temporary local
@@ -537,9 +552,11 @@ enabling or disabling either toggles the whole family together. The live
 catalog is available without authentication from
 `https://api.commandcode.ai/provider/v1/models`, and additional models can be
 added per machine with `./bin/curate-models commandcode`. Point
-`COMMANDCODE_BASE_URL` elsewhere to override the endpoint. Command Code does
-not document an account-balance API, so the tray links to Command Code Studio
-for credits and usage.
+`COMMANDCODE_BASE_URL` elsewhere to override the endpoint — both routes follow
+it, so a redirected provider stays coherent. The tray reports the plan's
+remaining credits and its 5-hour and weekly windows from the same undocumented
+billing route the official CLI polls, and links to Command Code Studio when
+that route is unavailable.
 
 ### Meta Model API
 

--- a/config/commandcode/commandcode.json
+++ b/config/commandcode/commandcode.json
@@ -8,7 +8,7 @@
       "ownedBy": "commandcode",
       "baseUrl": "https://api.commandcode.ai/provider/v1",
       "baseUrlEnv": "COMMANDCODE_BASE_URL",
-      "planNote": "Needs the Command Code Provider plan.",
+      "planNote": "Any Command Code plan works. Provider-plan accounts use the documented API and pay as they go; Go, GOAT, Pro, and Max accounts are served through the CLI's own route and spend plan credits, including the 5-hour and weekly window caps.",
       "credential": {
         "environment": [
           "COMMAND_CODE_API_KEY",

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -33,6 +33,12 @@ import {
   ensureFreshGitHubCopilotSession,
   githubCopilotRequestHeaders,
 } from "./github-copilot-session.mjs";
+import {
+  commandCodeRoute,
+  isUpgradeRequired,
+  recordCommandCodeRoute,
+} from "./commandcode-plan.mjs";
+import { relayCommandCodeGenerate } from "./commandcode-relay.mjs";
 import { VERSION } from "./version.mjs";
 import { installStableFetchTransport } from "./fetch-transport.mjs";
 
@@ -249,6 +255,13 @@ const GEMINI_THOUGHT_SIGNATURE_SENTINEL = "skip_thought_signature_validator";
 
 function isGeminiProvider(provider) {
   return provider?.id === "gemini-api" || provider?.ownedBy === "google";
+}
+
+// Both Command Code entries -- the chat-completions catalog and the Messages
+// variant that carries the Claude models -- reach the same account, so both
+// answer to the same plan entitlement and the same fallback route.
+function isCommandCodeProvider(provider) {
+  return provider?.ownedBy === "commandcode";
 }
 
 // Gemini 3.x thinking models reject assistant tool calls whose reasoning
@@ -714,6 +727,32 @@ async function upstreamSession(provider, credential, payload, options = {}, endp
   };
 }
 
+// Harvest the provider's own quota report from the response it just sent.
+// Costs no extra request and works for any provider that emits the standard
+// headers, so a newly added provider reports limits without bespoke code.
+// Called after the body streams because persisting is synchronous I/O and must
+// never sit in time-to-first-byte.
+function recordUpstreamLimits(normalized, upstream) {
+  const rateLimit = parseRateLimitHeaders(upstream.headers);
+  // Variant-routed responses meter the same upstream subscription, so quota
+  // headers land under the family's canonical provider id.
+  if (rateLimit) recordRateLimitSnapshot(canonicalProviderId(normalized.provider.id), rateLimit);
+  // This hop is the only place the provider's own status and headers are seen
+  // before LiteLLM restates them, so it is the only place a reset time the
+  // gateway does not relay can still be read. A failure that names when the
+  // caller may return is worth recording: the router reads it to skip a
+  // provider it already knows is empty instead of buying the same rejection
+  // once per turn. Only a failure, and only a window the provider itself
+  // named -- a healthy response is never a reason to stop using a provider.
+  if (upstream.ok) return;
+  const until = cooldownUntil(rateLimit);
+  if (!until) return;
+  recordProviderCooldown(canonicalProviderId(normalized.provider.id), {
+    until,
+    reason: upstream.status === 429 ? "rate_limited" : "out_of_usage",
+  });
+}
+
 function healthPayload() {
   const providers = {};
   const enabled = new Set(readProviderSelection());
@@ -801,6 +840,43 @@ async function handleRequest(request, response) {
   response.once("close", () => {
     if (!response.writableEnded) controller.abort();
   });
+  // Command Code's documented API is an entitlement, not a credential: the
+  // same key that runs its CLI is refused by /provider/v1 on the plans most of
+  // its customers buy. The CLI's own route serves those plans, so an account
+  // already known to be refused goes straight there rather than paying a 403
+  // for the privilege of finding out again.
+  const commandCode = isCommandCodeProvider(normalized.provider)
+    ? (() => {
+        const id = canonicalProviderId(normalized.provider.id);
+        return { id, ...commandCodeRoute(id, credential.value) };
+      })()
+    : undefined;
+  const relayThroughPlan = async () => {
+    const outcome = await relayCommandCodeGenerate({
+      payload: normalized.payload,
+      model: normalized.model,
+      provider: normalized.provider,
+      apiKey: credential.value,
+      baseUrl: providerBaseUrl(normalized.endpoint),
+      response,
+      signal: controller.signal,
+    });
+    // The plan route meters the same subscription and answers the same quota
+    // headers, so it reports limits and cooldowns exactly as the documented
+    // one does. Skipping this would leave the router blind to an exhausted
+    // plan on the very accounts this route exists to serve.
+    recordUpstreamLimits(normalized, outcome);
+    if (!QUIET) {
+      console.error(
+        `[api-forwarder] provider=${normalized.provider.id} model=${normalized.model.upstreamModel} ` +
+          `route=alpha-generate status=${outcome.status} duration_ms=${Date.now() - startedAt}`,
+      );
+    }
+  };
+  if (commandCode?.route === "plan") {
+    await relayThroughPlan();
+    return;
+  }
   // Fetch may detach a Buffer's backing ArrayBuffer while sending it. Copilot
   // can replay once after refreshing account routing, so use one immutable
   // string for both attempts instead of trying to reuse detached bytes.
@@ -854,32 +930,44 @@ async function handleRequest(request, response) {
       signal: controller.signal,
     });
   }
-  await pipeResponse(upstream, response);
-  // Harvest the provider's own quota report from the response it just sent.
-  // Costs no extra request and works for any provider that emits the standard
-  // headers, so a newly added provider reports limits without bespoke code.
-  // Recorded after the body streams because persisting is synchronous I/O and
-  // must never sit in time-to-first-byte.
-  const rateLimit = parseRateLimitHeaders(upstream.headers);
-  // Variant-routed responses meter the same upstream subscription, so quota
-  // headers land under the family's canonical provider id.
-  if (rateLimit) recordRateLimitSnapshot(canonicalProviderId(normalized.provider.id), rateLimit);
-  // This hop is the only place the provider's own status and headers are seen
-  // before LiteLLM restates them, so it is the only place a reset time the
-  // gateway does not relay can still be read. A failure that names when the
-  // caller may return is worth recording: the router reads it to skip a
-  // provider it already knows is empty instead of buying the same rejection
-  // once per turn. Only a failure, and only a window the provider itself
-  // named -- a healthy response is never a reason to stop using a provider.
-  if (!upstream.ok) {
-    const until = cooldownUntil(rateLimit);
-    if (until) {
-      recordProviderCooldown(canonicalProviderId(normalized.provider.id), {
-        until,
-        reason: upstream.status === 429 ? "rate_limited" : "out_of_usage",
-      });
+  // Falling back here is legal for the same reason the Copilot replay above
+  // is: nothing has been relayed yet. The refusal is read rather than piped
+  // because only its body distinguishes "this plan has no API access" from
+  // every other 403 a gateway can send, and a plan refusal must not reach the
+  // caller as a failed turn when a working route exists.
+  if (commandCode && upstream.status === 403) {
+    const raw = await upstream.text().catch(() => "");
+    let refusal;
+    try {
+      refusal = JSON.parse(raw);
+    } catch {
+      refusal = undefined;
     }
+    if (isUpgradeRequired(upstream.status, refusal)) {
+      recordCommandCodeRoute(commandCode.id, credential.value, { providerApi: false });
+      await relayThroughPlan();
+      return;
+    }
+    writeJson(
+      response,
+      403,
+      refusal || {
+        error: {
+          type: "provider_error",
+          message: raw.slice(0, 400) || "Command Code refused the request.",
+        },
+      },
+    );
+    return;
   }
+  // Only written when the account was previously known to be refused and its
+  // re-check window came due, so a healthy Provider-plan account never rewrites
+  // this state once per turn to repeat what it already said.
+  if (commandCode?.recheck && upstream.ok) {
+    recordCommandCodeRoute(commandCode.id, credential.value, { providerApi: true });
+  }
+  await pipeResponse(upstream, response);
+  recordUpstreamLimits(normalized, upstream);
   if (!QUIET) {
     console.error(
       `[api-forwarder] provider=${normalized.provider.id} model=${normalized.model.upstreamModel} status=${upstream.status} duration_ms=${Date.now() - startedAt}`,

--- a/src/commandcode-generate.mjs
+++ b/src/commandcode-generate.mjs
@@ -1,0 +1,381 @@
+// Command Code sells two ways to reach the same 55-model catalog, and only one
+// of them is a documented API.
+//
+// `POST /provider/v1/{chat/completions,messages}` is the published Provider
+// API. It is an entitlement, not a credential: an account on the $1 Go plan
+// signs in fine, mints a real key, runs the official CLI all day, and still
+// gets `403 upgrade_required` from those two paths ("Your Go plan doesn't
+// include API access"). No key, sign-in, or reinstall changes that.
+//
+// `POST /alpha/generate` is the route the `command-code` CLI itself uses for
+// every turn it takes. It carries the CLI's own envelope rather than an
+// OpenAI or Anthropic body, and it is not plan-gated -- any account that can
+// run the CLI can call it, Go included. That is the entire reason this module
+// exists: it lets the router serve the cheap coding plans (Go, GOAT, Pro, Max)
+// through the same provider, the same key, and the same catalog, instead of
+// telling most of Command Code's customers that their subscription is not
+// welcome here.
+//
+// Command Code publishes no reference for `/alpha/generate`. Everything below
+// was derived from the shipped CLI bundle
+// (`$(npm root -g)/command-code/dist/cli.mjs`, v1.14.1) and confirmed against
+// the live gateway on a Go-plan account. Treat it as a snapshot: when it
+// breaks, re-derive it from the current bundle rather than guessing.
+
+import { randomUUID } from "node:crypto";
+
+// The envelope is schema-strict. Every `config` field below is required, and
+// omitting one answers 400 with the exact missing JSON paths. None of them are
+// load-bearing for routing -- the gateway splices them into a system-prompt
+// preamble -- so neutral values are honest here: the router is not the CLI and
+// has no working directory, git branch, or project structure to report.
+export const GENERATE_ROUTE = "/alpha/generate";
+
+// Sent as `x-command-code-version`. The gateway accepts what it is given; this
+// is the CLI build the envelope in this file was derived from, so it is also
+// the honest answer to "which client shape is this". Overridable for an
+// operator chasing a gateway that starts refusing an older client.
+export const GENERATE_CLIENT_VERSION =
+  process.env.COMMANDCODE_CLI_VERSION || "1.14.1";
+
+// The CLI's own ceiling for a turn. The gateway does not default this for us.
+const DEFAULT_MAX_OUTPUT_TOKENS = 64_000;
+
+// An empty `system` is not "no system prompt" to this route -- it is a cue to
+// splice in the Command Code CLI's own agent preamble. Measured against the
+// live gateway: the same one-line turn cost 92 prompt tokens with a system
+// prompt and 7,637 without, and the model spent them being told it was Command
+// Code, with Command Code's tools and rules. Neither the credits nor the
+// identity are the caller's to spend, so a turn that carries no system prompt
+// of its own gets a neutral one rather than the agent's.
+const NEUTRAL_SYSTEM_PROMPT = "You are a helpful assistant.";
+
+function isoDate(at) {
+  return new Date(at).toISOString().slice(0, 10);
+}
+
+function staticConfig(at) {
+  return {
+    workingDir: "",
+    date: isoDate(at),
+    environment: "production",
+    structure: [],
+    isGitRepo: false,
+    currentBranch: "",
+    mainBranch: "",
+    gitStatus: "",
+    recentCommits: [],
+  };
+}
+
+export function generateHeaders(apiKey, { sessionId = randomUUID(), zdr } = {}) {
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+    "Content-Type": "application/json",
+    "x-cli-environment": "production",
+    "x-command-code-version": GENERATE_CLIENT_VERSION,
+    "x-session-id": sessionId,
+  };
+  // Command Code's zero-data-retention switch is an environment variable on the
+  // CLI, so an operator who set it for the CLI expects it to hold here too.
+  if (zdr ?? process.env.CMD_ZDR === "1") headers["x-cmd-zdr"] = "1";
+  return headers;
+}
+
+// ---------------------------------------------------------------------------
+// Messages
+//
+// `params.messages` is the Vercel AI SDK `ModelMessage[]` schema, which is
+// neither Anthropic content blocks nor OpenAI tool messages. Sending either
+// verbatim answers "Invalid prompt: The messages do not match the
+// ModelMessage[] schema", so both protocols are translated rather than passed
+// through. Three shapes matter: text/image parts on `user`, `text` and
+// `tool-call` parts on `assistant`, and `tool-result` parts on their own
+// `tool` message -- never folded into a user turn.
+// ---------------------------------------------------------------------------
+
+function textPart(text) {
+  return { type: "text", text };
+}
+
+// A data: URL carries its own media type; a remote URL does not, and the
+// gateway wants one. Guessing from the extension beats sending nothing,
+// because an absent mediaType is what makes the part ambiguous upstream.
+function imagePart(url) {
+  const dataMatch = /^data:([^;,]+)[;,]/.exec(url || "");
+  if (dataMatch) return { type: "image", image: url, mediaType: dataMatch[1] };
+  const extension = /\.(png|jpe?g|gif|webp)(?:[?#]|$)/i.exec(url || "");
+  const mediaType = extension
+    ? `image/${extension[1].toLowerCase() === "jpg" ? "jpeg" : extension[1].toLowerCase()}`
+    : undefined;
+  return { type: "image", image: url, ...(mediaType ? { mediaType } : {}) };
+}
+
+function toolResultOutput(value, { error = false } = {}) {
+  // Not a raw string: the schema wants a tagged output object, and an
+  // error-text result is how a failed tool run is reported without the turn
+  // reading as if the tool had succeeded with that text.
+  return { type: error ? "error-text" : "text", value: stringifyToolResult(value) };
+}
+
+function stringifyToolResult(value) {
+  if (typeof value === "string") return value;
+  if (value === undefined || value === null) return "";
+  if (Array.isArray(value)) {
+    // Anthropic tool results arrive as content blocks; only text survives the
+    // trip, and dropping a block silently would lose the tool's answer.
+    return value
+      .map((block) => {
+        if (typeof block === "string") return block;
+        if (block?.type === "text") return String(block.text ?? "");
+        return JSON.stringify(block);
+      })
+      .join("\n");
+  }
+  return JSON.stringify(value);
+}
+
+function parseToolArguments(raw) {
+  if (raw === undefined || raw === null || raw === "") return {};
+  if (typeof raw === "object") return raw;
+  try {
+    const parsed = JSON.parse(raw);
+    // A bare string or array is legal JSON but not an argument object; the
+    // gateway wants an object, so wrap rather than fail the whole turn.
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : { value: parsed };
+  } catch {
+    return { value: String(raw) };
+  }
+}
+
+// Consecutive tool results belong to one `tool` message. Pushing each as its
+// own message is accepted by the schema but reads to the model as a series of
+// separate turns, which is not what happened.
+function pushToolResult(messages, part) {
+  const last = messages[messages.length - 1];
+  if (last?.role === "tool") {
+    last.content.push(part);
+    return;
+  }
+  messages.push({ role: "tool", content: [part] });
+}
+
+function openAiUserContent(content) {
+  if (typeof content === "string") return [textPart(content)];
+  if (!Array.isArray(content)) return [textPart(String(content ?? ""))];
+  const parts = [];
+  for (const part of content) {
+    if (typeof part === "string") {
+      parts.push(textPart(part));
+    } else if (part?.type === "text" || part?.type === "input_text") {
+      parts.push(textPart(String(part.text ?? "")));
+    } else if (part?.type === "image_url") {
+      parts.push(imagePart(part.image_url?.url ?? part.image_url));
+    } else if (part?.type === "input_image") {
+      parts.push(imagePart(part.image_url ?? part.image));
+    }
+  }
+  return parts.length ? parts : [textPart("")];
+}
+
+function fromOpenAiMessages(messages) {
+  const system = [];
+  const wire = [];
+  // `tool` messages name only the call id, but the schema wants the tool name
+  // on the result too, so remember what each id was called.
+  const toolNames = new Map();
+  for (const message of Array.isArray(messages) ? messages : []) {
+    const role = message?.role;
+    if (role === "system" || role === "developer") {
+      system.push(
+        typeof message.content === "string"
+          ? message.content
+          : openAiUserContent(message.content)
+              .filter((part) => part.type === "text")
+              .map((part) => part.text)
+              .join("\n"),
+      );
+      continue;
+    }
+    if (role === "tool" || role === "function") {
+      pushToolResult(wire, {
+        type: "tool-result",
+        toolCallId: String(message.tool_call_id ?? message.id ?? ""),
+        toolName: toolNames.get(String(message.tool_call_id ?? "")) || message.name || "tool",
+        output: toolResultOutput(message.content),
+      });
+      continue;
+    }
+    if (role === "assistant") {
+      const content = [];
+      const text = typeof message.content === "string" ? message.content : "";
+      if (text) content.push(textPart(text));
+      else if (Array.isArray(message.content)) {
+        for (const part of openAiUserContent(message.content)) {
+          if (part.type === "text" && part.text) content.push(part);
+        }
+      }
+      for (const call of Array.isArray(message.tool_calls) ? message.tool_calls : []) {
+        const id = String(call?.id ?? "");
+        const name = String(call?.function?.name ?? call?.name ?? "tool");
+        toolNames.set(id, name);
+        content.push({
+          type: "tool-call",
+          toolCallId: id,
+          toolName: name,
+          input: parseToolArguments(call?.function?.arguments ?? call?.arguments),
+        });
+      }
+      // An assistant turn with neither text nor a call says nothing; the
+      // schema rejects empty content, and the turn is no worse without it.
+      if (content.length) wire.push({ role: "assistant", content });
+      continue;
+    }
+    if (role === "user") wire.push({ role: "user", content: openAiUserContent(message.content) });
+  }
+  return { system: system.filter(Boolean).join("\n\n"), messages: wire };
+}
+
+function anthropicImagePart(source) {
+  if (source?.type === "base64") {
+    return {
+      type: "image",
+      image: `data:${source.media_type};base64,${source.data}`,
+      mediaType: source.media_type,
+    };
+  }
+  return imagePart(source?.url);
+}
+
+function fromAnthropicMessages(messages, systemField) {
+  const system = [];
+  if (typeof systemField === "string") system.push(systemField);
+  else if (Array.isArray(systemField)) {
+    for (const block of systemField) {
+      if (block?.type === "text") system.push(String(block.text ?? ""));
+      else if (typeof block === "string") system.push(block);
+    }
+  }
+  const wire = [];
+  const toolNames = new Map();
+  for (const message of Array.isArray(messages) ? messages : []) {
+    const blocks =
+      typeof message?.content === "string"
+        ? [{ type: "text", text: message.content }]
+        : Array.isArray(message?.content)
+          ? message.content
+          : [];
+    if (message?.role === "assistant") {
+      const content = [];
+      for (const block of blocks) {
+        if (block?.type === "text" && block.text) content.push(textPart(String(block.text)));
+        else if (block?.type === "tool_use") {
+          const id = String(block.id ?? "");
+          const name = String(block.name ?? "tool");
+          toolNames.set(id, name);
+          content.push({ type: "tool-call", toolCallId: id, toolName: name, input: block.input ?? {} });
+        }
+        // `thinking` blocks are Anthropic's own replay format for extended
+        // thinking and are meaningless to a gateway that never issued them.
+      }
+      if (content.length) wire.push({ role: "assistant", content });
+      continue;
+    }
+    // Anthropic puts tool results inside the *user* turn. The ModelMessage
+    // schema puts them in their own `tool` message, so one Anthropic turn can
+    // split into a tool message followed by a user message.
+    const userContent = [];
+    for (const block of blocks) {
+      if (block?.type === "tool_result") {
+        pushToolResult(wire, {
+          type: "tool-result",
+          toolCallId: String(block.tool_use_id ?? ""),
+          toolName: toolNames.get(String(block.tool_use_id ?? "")) || "tool",
+          output: toolResultOutput(block.content, { error: block.is_error === true }),
+        });
+      } else if (block?.type === "text") {
+        userContent.push(textPart(String(block.text ?? "")));
+      } else if (block?.type === "image") {
+        userContent.push(anthropicImagePart(block.source));
+      }
+    }
+    if (userContent.length) wire.push({ role: "user", content: userContent });
+  }
+  return { system: system.filter(Boolean).join("\n\n"), messages: wire };
+}
+
+// ---------------------------------------------------------------------------
+// Tools
+//
+// The wire form is snake_case `input_schema` carrying plain JSON Schema. The
+// gateway rewrites it into Vercel's `{ type:"function", name, description,
+// inputSchema }` itself -- confirmed by the `start-step` event, which echoes
+// the rewritten request back.
+// ---------------------------------------------------------------------------
+
+function toWireTools(tools, protocol) {
+  if (!Array.isArray(tools) || !tools.length) return [];
+  const wire = [];
+  for (const tool of tools) {
+    if (protocol === "anthropic") {
+      if (!tool?.name) continue;
+      wire.push({
+        name: tool.name,
+        description: tool.description || "",
+        input_schema: tool.input_schema || { type: "object", properties: {} },
+      });
+      continue;
+    }
+    const fn = tool?.type === "function" ? tool.function || tool : tool;
+    if (!fn?.name) continue;
+    wire.push({
+      name: fn.name,
+      description: fn.description || "",
+      input_schema: fn.parameters || { type: "object", properties: {} },
+    });
+  }
+  return wire;
+}
+
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate an OpenAI chat-completions or Anthropic Messages body into the
+ * `/alpha/generate` envelope.
+ *
+ * `stream` is always true on the wire: the route only streams, and a caller
+ * that asked for a whole response gets one assembled from the stream instead.
+ */
+export function toGenerateRequest(payload, { protocol = "openai", model, at = Date.now() } = {}) {
+  const anthropic = protocol === "anthropic";
+  const { system, messages } = anthropic
+    ? fromAnthropicMessages(payload?.messages, payload?.system)
+    : fromOpenAiMessages(payload?.messages);
+  const maxTokens = Number(
+    (anthropic ? payload?.max_tokens : payload?.max_completion_tokens ?? payload?.max_tokens) ||
+      DEFAULT_MAX_OUTPUT_TOKENS,
+  );
+  const params = {
+    model: String(model ?? payload?.model ?? ""),
+    system: system || NEUTRAL_SYSTEM_PROMPT,
+    messages,
+    tools: toWireTools(payload?.tools, protocol),
+    max_tokens: Number.isFinite(maxTokens) && maxTokens > 0 ? maxTokens : DEFAULT_MAX_OUTPUT_TOKENS,
+    stream: true,
+  };
+  // Only forwarded when the caller set it. The route accepts temperature but
+  // has no documented default, so inventing one would change every turn.
+  if (typeof payload?.temperature === "number") params.temperature = payload.temperature;
+  return {
+    config: staticConfig(at),
+    // A string, not an object -- an object here is a 400. The router has no
+    // Command Code memory or taste profile to contribute.
+    memory: "",
+    taste: null,
+    skills: null,
+    permissionMode: "standard",
+    params,
+  };
+}

--- a/src/commandcode-plan.mjs
+++ b/src/commandcode-plan.mjs
@@ -1,0 +1,125 @@
+// Which of Command Code's two routes this account is allowed to use.
+//
+// The answer is an entitlement the credential cannot reveal on its own: the
+// same key that runs the CLI is refused by `/provider/v1` unless the account
+// carries the Provider plan or a coding plan above Go. There is no documented
+// endpoint that names the plan, so the only honest source of truth is the
+// gateway's own answer -- a `403 upgrade_required` means this account routes
+// through `/alpha/generate` instead.
+//
+// Remembering it matters because the alternative is buying that 403 once per
+// turn, forever, on the very plan the router is trying to serve. Remembering
+// it *per credential* matters because an operator who upgrades and mints a new
+// key must not stay pinned to the fallback, and a re-check window covers the
+// case where the plan changes under the same key.
+
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+import { STATE_DIR } from "./paths.mjs";
+
+export const COMMANDCODE_PLAN_PATH = path.join(STATE_DIR, "commandcode-plan.json");
+
+// Long enough that a Go-plan account is not paying a wasted round-trip through
+// a working day, short enough that an upgrade is noticed the same afternoon.
+export const ROUTE_RECHECK_MS = 6 * 60 * 60 * 1000;
+
+// Never the key itself, and never enough of it to be one: this file is state,
+// not a credential store, and a fingerprint answers the only question asked of
+// it -- "is this still the same key".
+export function credentialFingerprint(value) {
+  return createHash("sha256").update(String(value ?? "")).digest("hex").slice(0, 16);
+}
+
+function readDocument() {
+  if (!existsSync(COMMANDCODE_PLAN_PATH)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(COMMANDCODE_PLAN_PATH, "utf8"));
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    // A corrupt file must never take routing down. Losing it costs one 403.
+    return {};
+  }
+}
+
+function writeDocument(document) {
+  try {
+    mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
+    const temporary = `${COMMANDCODE_PLAN_PATH}.tmp.${process.pid}`;
+    writeFileSync(temporary, `${JSON.stringify(document, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    renameSync(temporary, COMMANDCODE_PLAN_PATH);
+    chmodSync(COMMANDCODE_PLAN_PATH, 0o600);
+  } catch {
+    // Entitlement memory is an optimization; failing to persist it must never
+    // fail the turn it was learned from.
+  }
+}
+
+/**
+ * The route to try for this account right now.
+ *
+ * Unknown means "try the documented API first": it is the route the operator
+ * paid for if they have it, and one 403 is what teaches this module otherwise.
+ *
+ * `recheck` marks the one case where a success is worth writing down -- a
+ * known-refused account whose window has expired. Without it a healthy
+ * Provider-plan account would rewrite the same state file on every single
+ * turn to say what it already said.
+ */
+export function commandCodeRoute(providerId, credentialValue, { at = Date.now() } = {}) {
+  const entry = readDocument()[String(providerId || "")];
+  const known =
+    entry && entry.credential === credentialFingerprint(credentialValue) && entry.providerApi === false;
+  if (!known) return { route: "provider-api", recheck: false };
+  const observed = Date.parse(entry.observedAt || "");
+  if (Number.isFinite(observed) && at - observed > ROUTE_RECHECK_MS) {
+    return { route: "provider-api", recheck: true };
+  }
+  return { route: "plan", recheck: false };
+}
+
+/**
+ * Record what the gateway just said about this account.
+ *
+ * `providerApi: false` is only ever written from a real `upgrade_required`
+ * refusal -- never from a timeout, a 500, or a rate limit, because those say
+ * nothing about entitlement and pinning the fallback on one would quietly move
+ * a paying Provider-plan account onto its coding-plan credits.
+ */
+export function recordCommandCodeRoute(
+  providerId,
+  credentialValue,
+  { providerApi, at = Date.now() } = {},
+) {
+  const id = String(providerId || "").trim();
+  if (!id || typeof providerApi !== "boolean") return;
+  const document = readDocument();
+  document[id] = {
+    credential: credentialFingerprint(credentialValue),
+    providerApi,
+    observedAt: new Date(at).toISOString(),
+  };
+  writeDocument(document);
+}
+
+export function readCommandCodePlanState() {
+  return readDocument();
+}
+
+/**
+ * Is this refusal the entitlement one?
+ *
+ * Matched on the machine-readable code first; the message is a fallback for a
+ * gateway that stops sending the code, and both are required to be a 403 so a
+ * differently-shaped 401 can never be read as "downgrade this account".
+ */
+export function isUpgradeRequired(status, body) {
+  if (status !== 403) return false;
+  const error = body?.error || body;
+  if (error?.code === "upgrade_required") return true;
+  return /doesn't include API access|upgrade to/i.test(String(error?.message || ""));
+}

--- a/src/commandcode-relay.mjs
+++ b/src/commandcode-relay.mjs
@@ -1,0 +1,155 @@
+// Serving a Command Code turn over the CLI's own route.
+//
+// Kept out of the API forwarder because it is the only provider whose request
+// leaves in a shape no other provider uses: everything else there forwards an
+// OpenAI or Anthropic body more or less intact, while this one is rewritten
+// into the `/alpha/generate` envelope and rewritten back on the way home.
+
+import {
+  GENERATE_ROUTE,
+  generateHeaders,
+  toGenerateRequest,
+} from "./commandcode-generate.mjs";
+import { GenerateTranslator, readGenerateEvents } from "./commandcode-stream.mjs";
+import { VERSION } from "./version.mjs";
+
+// The registry points Command Code at `https://api.commandcode.ai/provider/v1`
+// because that is where the documented API lives. `/alpha/generate` hangs off
+// the origin instead, so the route is derived from whatever base URL is in
+// force -- an operator who redirected the provider with COMMANDCODE_BASE_URL
+// gets both routes redirected together, which is the only coherent answer.
+export function generateEndpoint(baseUrl) {
+  return `${new URL(baseUrl).origin}${GENERATE_ROUTE}`;
+}
+
+function errorBody(status, raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    parsed = undefined;
+  }
+  // Two error shapes reach this line: the Provider API's
+  // `{error:{message,type,code}}` and the alpha route's
+  // `{success:false,message,cause}`. Callers downstream read `error.message`,
+  // so both are normalized to that rather than relayed as-is.
+  const message =
+    parsed?.error?.message ||
+    parsed?.message ||
+    (raw ? String(raw).slice(0, 400) : `Command Code returned ${status}.`);
+  return {
+    error: {
+      type: parsed?.error?.type || "commandcode_generate_error",
+      ...(parsed?.error?.code ? { code: parsed.error.code } : {}),
+      message,
+    },
+  };
+}
+
+function writeHead(response, contentType) {
+  response.writeHead(200, {
+    "Content-Type": contentType,
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+}
+
+/**
+ * Run one turn through `/alpha/generate` and answer in the caller's protocol.
+ *
+ * Returns `{ status, ok, headers }`: the status for the forwarder's log line,
+ * and the upstream's own headers so this route's quota reporting and cooldowns
+ * work exactly as they do for a provider forwarded intact. Nothing here throws
+ * for an upstream refusal -- a refusal is a response, and the caller sees the
+ * gateway's own message rather than a generic proxy error.
+ */
+export async function relayCommandCodeGenerate({
+  payload,
+  model,
+  provider,
+  apiKey,
+  baseUrl,
+  response,
+  signal,
+  fetchImpl = fetch,
+  at = Date.now(),
+}) {
+  const protocol = provider.protocol === "anthropic" ? "anthropic" : "openai";
+  const streaming = payload?.stream === true;
+  const upstream = await fetchImpl(generateEndpoint(baseUrl), {
+    method: "POST",
+    headers: {
+      ...generateHeaders(apiKey),
+      "User-Agent": `codex-router/${VERSION}`,
+      "Accept-Encoding": "identity",
+    },
+    body: JSON.stringify(
+      toGenerateRequest(payload, { protocol, model: model.upstreamModel, at }),
+    ),
+    signal,
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    const raw = await upstream.text().catch(() => "");
+    const body = JSON.stringify(errorBody(upstream.status, raw));
+    response.writeHead(upstream.status, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(body),
+    });
+    response.end(body);
+    return { status: upstream.status, ok: false, headers: upstream.headers };
+  }
+
+  const outcome = (status) => ({ status, ok: upstream.ok, headers: upstream.headers });
+
+  const translator = new GenerateTranslator({
+    protocol,
+    model: model.gatewayModel,
+    created: Math.floor(at / 1000),
+  });
+
+  if (!streaming) {
+    // The route only streams. A caller that asked for a whole response gets
+    // one assembled here rather than a stream it never agreed to parse.
+    for await (const event of readGenerateEvents(upstream.body)) translator.push(event);
+    if (translator.error) {
+      const body = JSON.stringify(errorBody(502, JSON.stringify({ message: translator.error })));
+      response.writeHead(502, {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(body),
+      });
+      response.end(body);
+      return outcome(502);
+    }
+    const body = JSON.stringify(translator.body());
+    response.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(body),
+    });
+    response.end(body);
+    return outcome(200);
+  }
+
+  writeHead(response, "text/event-stream");
+  for await (const event of readGenerateEvents(upstream.body)) {
+    const chunk = translator.push(event);
+    if (chunk) response.write(chunk);
+  }
+  if (translator.error) {
+    // The head is long gone, so the only honest place left to report a
+    // mid-stream failure is inside the stream. Terminating cleanly afterwards
+    // matters more than the shape: a caller still waiting on a terminal event
+    // hangs until its own timeout otherwise.
+    response.write(
+      protocol === "anthropic"
+        ? `event: error\ndata: ${JSON.stringify({
+            type: "error",
+            error: { type: "api_error", message: translator.error },
+          })}\n\n`
+        : `data: ${JSON.stringify(errorBody(502, JSON.stringify({ message: translator.error })))}\n\n`,
+    );
+  }
+  response.write(translator.finish());
+  response.end();
+  return outcome(200);
+}

--- a/src/commandcode-stream.mjs
+++ b/src/commandcode-stream.mjs
@@ -1,0 +1,450 @@
+// The other half of the `/alpha/generate` bridge: turning what the route
+// answers back into what the caller asked for.
+//
+// The response is newline-delimited JSON, not SSE -- no `data:` prefix, no
+// `event:` lines, one JSON object per line. A logical block (reasoning, text,
+// or one tool call) is keyed by `id`, and blocks interleave: a live stream was
+// observed emitting `text-start` before the `reasoning-end` of the reasoning
+// block preceding it. OpenAI chunks tolerate that directly; Anthropic content
+// blocks do not, so the Anthropic side serializes blocks and closes the open
+// one before opening the next.
+//
+// One trap worth naming: the incremental tool events key on `id`, but the
+// final redundant `tool-call` event keys on `toolCallId`. Reading only `id`
+// silently drops it, and on a model that skips the incremental events that is
+// the whole tool call.
+
+const FINISH_REASONS = new Map([
+  ["stop", { openai: "stop", anthropic: "end_turn" }],
+  ["length", { openai: "length", anthropic: "max_tokens" }],
+  ["tool-calls", { openai: "tool_calls", anthropic: "tool_use" }],
+  ["content-filter", { openai: "content_filter", anthropic: "end_turn" }],
+  ["error", { openai: "stop", anthropic: "end_turn" }],
+]);
+
+function finishReason(raw, protocol) {
+  const mapped = FINISH_REASONS.get(String(raw || "stop"));
+  return mapped ? mapped[protocol] : protocol === "anthropic" ? "end_turn" : "stop";
+}
+
+// `inputTokens` follows the Vercel AI SDK convention and already *includes*
+// the cached tokens. OpenAI's shape wants the same total with cached reported
+// separately, so it maps straight across; Anthropic's `input_tokens` excludes
+// cache reads, so the cached count is subtracted there instead of being
+// double-counted into the caller's cost math.
+function openAiUsage(usage) {
+  if (!usage) return undefined;
+  const cached = Number(usage.cachedInputTokens || 0);
+  return {
+    prompt_tokens: Number(usage.inputTokens || 0),
+    completion_tokens: Number(usage.outputTokens || 0),
+    total_tokens: Number(usage.totalTokens || 0),
+    ...(cached ? { prompt_tokens_details: { cached_tokens: cached } } : {}),
+    ...(usage.reasoningTokens
+      ? { completion_tokens_details: { reasoning_tokens: Number(usage.reasoningTokens) } }
+      : {}),
+  };
+}
+
+function anthropicUsage(usage) {
+  if (!usage) return { input_tokens: 0, output_tokens: 0 };
+  const cached = Number(usage.cachedInputTokens || 0);
+  return {
+    input_tokens: Math.max(0, Number(usage.inputTokens || 0) - cached),
+    output_tokens: Number(usage.outputTokens || 0),
+    ...(cached ? { cache_read_input_tokens: cached } : {}),
+  };
+}
+
+function sse(data, event) {
+  return `${event ? `event: ${event}\n` : ""}data: ${JSON.stringify(data)}\n\n`;
+}
+
+/**
+ * Incremental translator from `/alpha/generate` events to one caller protocol.
+ *
+ * `push(event)` returns the SSE text to write for that event (possibly empty).
+ * `finish()` closes whatever the stream left open -- a stream that ends with
+ * neither `finish-step` nor `finish` still has to terminate cleanly, because a
+ * caller waiting on a terminal event would otherwise hang on a dead socket.
+ */
+export class GenerateTranslator {
+  constructor({ protocol = "openai", model = "", id, created = Math.floor(Date.now() / 1000) } = {}) {
+    this.protocol = protocol;
+    this.model = model;
+    this.id = id || `chatcmpl-${Math.random().toString(36).slice(2, 12)}`;
+    this.created = created;
+    this.started = false;
+    this.finished = false;
+    this.usage = undefined;
+    this.finishReasonRaw = "stop";
+    this.error = undefined;
+    // Anthropic serialization state.
+    this.blockIndex = -1;
+    this.openBlock = undefined;
+    // OpenAI tool-call slots, and the ids already emitted so the redundant
+    // trailing `tool-call` event cannot fire a second, duplicate call.
+    this.toolIndexes = new Map();
+    this.toolNames = new Map();
+    this.completedTools = new Set();
+    // Non-streaming assembly.
+    this.text = "";
+    this.reasoning = "";
+    this.toolCalls = [];
+  }
+
+  push(event) {
+    if (this.finished || !event || typeof event !== "object") return "";
+    switch (event.type) {
+      case "start":
+        return this.#start();
+      case "reasoning-start":
+        return this.#blockStart(event.id, "reasoning");
+      case "reasoning-delta":
+        this.reasoning += String(event.text ?? "");
+        return this.#delta(event.id, "reasoning", String(event.text ?? ""));
+      case "text-start":
+        return this.#blockStart(event.id, "text");
+      case "text-delta":
+        this.text += String(event.text ?? "");
+        return this.#delta(event.id, "text", String(event.text ?? ""));
+      case "reasoning-end":
+      case "text-end":
+        return this.#blockEnd(event.id);
+      case "tool-input-start":
+        return this.#toolStart(event.id, event.toolName);
+      case "tool-input-delta":
+        return this.#toolDelta(event.id, String(event.delta ?? ""));
+      case "tool-input-end":
+        return this.#toolEnd(event.id);
+      case "tool-call":
+        return this.#toolComplete(event);
+      case "finish-step":
+      case "finish":
+        if (event.usage) this.usage = event.usage;
+        if (event.totalUsage) this.usage = event.totalUsage;
+        if (event.finishReason) this.finishReasonRaw = event.finishReason;
+        return "";
+      case "error":
+        this.error = event.error?.message || event.message || "Command Code stream error";
+        return "";
+      default:
+        // `start-step` echoes the resolved upstream request and carries no
+        // content; unknown future events are ignored rather than fatal.
+        return "";
+    }
+  }
+
+  finish() {
+    if (this.finished) return "";
+    this.finished = true;
+    let out = this.started ? "" : this.#start();
+    out += this.#closeOpenBlock();
+    if (this.protocol === "anthropic") {
+      out += sse(
+        {
+          type: "message_delta",
+          delta: { stop_reason: finishReason(this.finishReasonRaw, "anthropic"), stop_sequence: null },
+          usage: anthropicUsage(this.usage),
+        },
+        "message_delta",
+      );
+      out += sse({ type: "message_stop" }, "message_stop");
+      return out;
+    }
+    const usage = openAiUsage(this.usage);
+    out += sse({
+      ...this.#chunkShell(),
+      choices: [{ index: 0, delta: {}, finish_reason: finishReason(this.finishReasonRaw, "openai") }],
+      ...(usage ? { usage } : {}),
+    });
+    out += "data: [DONE]\n\n";
+    return out;
+  }
+
+  /** The whole answer, for a caller that did not ask for a stream. */
+  body() {
+    if (this.protocol === "anthropic") {
+      const content = [];
+      if (this.reasoning) content.push({ type: "thinking", thinking: this.reasoning, signature: "" });
+      if (this.text) content.push({ type: "text", text: this.text });
+      for (const call of this.toolCalls) {
+        content.push({ type: "tool_use", id: call.id, name: call.name, input: safeJson(call.arguments) });
+      }
+      return {
+        id: this.id,
+        type: "message",
+        role: "assistant",
+        model: this.model,
+        content,
+        stop_reason: finishReason(this.finishReasonRaw, "anthropic"),
+        stop_sequence: null,
+        usage: anthropicUsage(this.usage),
+      };
+    }
+    const message = { role: "assistant", content: this.text || null };
+    if (this.reasoning) message.reasoning_content = this.reasoning;
+    if (this.toolCalls.length) {
+      message.tool_calls = this.toolCalls.map((call) => ({
+        id: call.id,
+        type: "function",
+        function: { name: call.name, arguments: call.arguments || "{}" },
+      }));
+    }
+    const usage = openAiUsage(this.usage);
+    return {
+      id: this.id,
+      object: "chat.completion",
+      created: this.created,
+      model: this.model,
+      choices: [
+        { index: 0, message, finish_reason: finishReason(this.finishReasonRaw, "openai") },
+      ],
+      ...(usage ? { usage } : {}),
+    };
+  }
+
+  #chunkShell() {
+    return { id: this.id, object: "chat.completion.chunk", created: this.created, model: this.model };
+  }
+
+  #start() {
+    if (this.started) return "";
+    this.started = true;
+    if (this.protocol === "anthropic") {
+      return sse(
+        {
+          type: "message_start",
+          message: {
+            id: this.id,
+            type: "message",
+            role: "assistant",
+            model: this.model,
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: 0, output_tokens: 0 },
+          },
+        },
+        "message_start",
+      );
+    }
+    return sse({
+      ...this.#chunkShell(),
+      choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }],
+    });
+  }
+
+  #closeOpenBlock() {
+    if (this.protocol !== "anthropic" || !this.openBlock) return "";
+    this.openBlock = undefined;
+    return sse({ type: "content_block_stop", index: this.blockIndex }, "content_block_stop");
+  }
+
+  #blockStart(id, kind) {
+    let out = this.started ? "" : this.#start();
+    if (this.protocol !== "anthropic") return out;
+    out += this.#closeOpenBlock();
+    this.blockIndex += 1;
+    this.openBlock = { id, kind };
+    const contentBlock =
+      kind === "reasoning" ? { type: "thinking", thinking: "" } : { type: "text", text: "" };
+    return (
+      out +
+      sse({ type: "content_block_start", index: this.blockIndex, content_block: contentBlock }, "content_block_start")
+    );
+  }
+
+  #blockEnd(id) {
+    // A late end for a block another start already displaced is not an error;
+    // the displacement already closed it.
+    if (this.protocol !== "anthropic" || this.openBlock?.id !== id) return "";
+    return this.#closeOpenBlock();
+  }
+
+  #delta(id, kind, text) {
+    if (!text) return this.started ? "" : this.#start();
+    let out = this.started ? "" : this.#start();
+    if (this.protocol !== "anthropic") {
+      return (
+        out +
+        sse({
+          ...this.#chunkShell(),
+          choices: [
+            {
+              index: 0,
+              delta: kind === "reasoning" ? { reasoning_content: text } : { content: text },
+              finish_reason: null,
+            },
+          ],
+        })
+      );
+    }
+    // A delta for a block that never opened (or that a later start displaced)
+    // still has content the caller must see, so open a block for it.
+    if (this.openBlock?.id !== id) out += this.#blockStart(id, kind);
+    return (
+      out +
+      sse(
+        {
+          type: "content_block_delta",
+          index: this.blockIndex,
+          delta:
+            kind === "reasoning" ? { type: "thinking_delta", thinking: text } : { type: "text_delta", text },
+        },
+        "content_block_delta",
+      )
+    );
+  }
+
+  #toolStart(id, toolName) {
+    if (!id || this.toolIndexes.has(id)) return "";
+    let out = this.started ? "" : this.#start();
+    const name = String(toolName || "tool");
+    this.toolNames.set(id, name);
+    this.toolCalls.push({ id, name, arguments: "" });
+    if (this.protocol === "anthropic") {
+      out += this.#closeOpenBlock();
+      this.blockIndex += 1;
+      this.openBlock = { id, kind: "tool" };
+      this.toolIndexes.set(id, this.blockIndex);
+      return (
+        out +
+        sse(
+          {
+            type: "content_block_start",
+            index: this.blockIndex,
+            content_block: { type: "tool_use", id, name, input: {} },
+          },
+          "content_block_start",
+        )
+      );
+    }
+    const index = this.toolIndexes.size;
+    this.toolIndexes.set(id, index);
+    return (
+      out +
+      sse({
+        ...this.#chunkShell(),
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [{ index, id, type: "function", function: { name, arguments: "" } }],
+            },
+            finish_reason: null,
+          },
+        ],
+      })
+    );
+  }
+
+  #toolDelta(id, delta) {
+    if (!delta) return "";
+    let out = "";
+    if (!this.toolIndexes.has(id)) out += this.#toolStart(id, this.toolNames.get(id));
+    const call = this.toolCalls.find((entry) => entry.id === id);
+    if (call) call.arguments += delta;
+    const index = this.toolIndexes.get(id);
+    if (this.protocol === "anthropic") {
+      return (
+        out +
+        sse(
+          {
+            type: "content_block_delta",
+            index,
+            delta: { type: "input_json_delta", partial_json: delta },
+          },
+          "content_block_delta",
+        )
+      );
+    }
+    return (
+      out +
+      sse({
+        ...this.#chunkShell(),
+        choices: [
+          {
+            index: 0,
+            delta: { tool_calls: [{ index, function: { arguments: delta } }] },
+            finish_reason: null,
+          },
+        ],
+      })
+    );
+  }
+
+  #toolEnd(id) {
+    this.completedTools.add(id);
+    if (this.protocol !== "anthropic" || this.openBlock?.id !== id) return "";
+    return this.#closeOpenBlock();
+  }
+
+  // The redundant trailing event. It is the only tool signal some models emit,
+  // so it must be honored -- and it must not double-fire when the incremental
+  // events already delivered the same call.
+  #toolComplete(event) {
+    const id = event.toolCallId || event.id;
+    if (!id || this.completedTools.has(id) || this.toolIndexes.has(id)) {
+      this.completedTools.add(id);
+      return "";
+    }
+    const args = JSON.stringify(event.input ?? {});
+    let out = this.#toolStart(id, event.toolName);
+    out += this.#toolDelta(id, args);
+    out += this.#toolEnd(id);
+    return out;
+  }
+}
+
+function safeJson(raw) {
+  try {
+    const parsed = JSON.parse(raw || "{}");
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Split a byte stream into `/alpha/generate` events.
+ *
+ * Kept separate from the translator so a partial line at a chunk boundary is
+ * handled in one place: the route splits JSON objects across TCP reads, and a
+ * parser that assumed whole lines would drop content at random under load.
+ */
+export async function* readGenerateEvents(stream) {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const chunk of stream) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let newline = buffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      if (line) {
+        const event = parseEvent(line);
+        if (event) yield event;
+      }
+      newline = buffer.indexOf("\n");
+    }
+  }
+  const tail = buffer.trim();
+  if (tail) {
+    const event = parseEvent(tail);
+    if (event) yield event;
+  }
+}
+
+function parseEvent(line) {
+  try {
+    // The gateway answers `text/event-stream` for this route but sends bare
+    // JSON lines. Should it ever start prefixing them, the prefix is stripped
+    // rather than turning every event into a parse failure.
+    const payload = line.startsWith("data:") ? line.slice(5).trim() : line;
+    if (!payload || payload === "[DONE]") return undefined;
+    return JSON.parse(payload);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/provider-account-usage.mjs
+++ b/src/provider-account-usage.mjs
@@ -303,7 +303,31 @@ export function commandCodeCreditsMetrics(payload) {
       "credits",
     );
   };
+  // The window caps say how fast the plan may be spent; the credit pool says
+  // how much is left to spend at all. A coding plan runs out of the second one
+  // long before it stops hitting the first, so reporting only the windows
+  // hides the number that actually ends someone's afternoon.
+  const credits = payload?.credits;
+  const monthly = numberValue(credits?.monthlyCredits);
+  const purchased = numberValue(credits?.purchasedCredits);
+  const free = numberValue(credits?.freeCredits);
+  const total = [monthly, purchased, free].filter(Number.isFinite).reduce((sum, part) => sum + part, 0);
+  const balance = Number.isFinite(monthly)
+    ? [{
+        kind: "balance",
+        label: "Plan credits",
+        value: total,
+        currency: "USD",
+        detail: [
+          Number.isFinite(monthly) ? `Plan ${monthly.toFixed(2)}` : undefined,
+          Number.isFinite(purchased) && purchased > 0 ? `Purchased ${purchased.toFixed(2)}` : undefined,
+          Number.isFinite(free) && free > 0 ? `Free ${free.toFixed(2)}` : undefined,
+        ].filter(Boolean).join(" · "),
+        available: credits?.belowThreshold !== true,
+      }]
+    : [];
   return [
+    ...balance,
     windowMetric("5-hour limit", windows.fiveHour),
     windowMetric("Weekly limit", windows.weekly),
   ].filter(Boolean);

--- a/test/cli-session-credential.test.mjs
+++ b/test/cli-session-credential.test.mjs
@@ -316,10 +316,13 @@ test("a CLI session descriptor may not escape its own home directory", () => {
   }
 });
 
-// Connecting succeeds and then every request 403s unless the account holds the
-// Provider plan. That gap is invisible at connect time, so the note has to
-// reach the surfaces where someone decides to connect.
-test("the Provider plan requirement is stated wherever Command Code is connected", () => {
+// Every Command Code plan is served, but not the same way and not on the same
+// money: a Provider-plan account pays as it goes through the documented API,
+// while a coding plan is served through the CLI's own route and spends the
+// plan's credits against its 5-hour and weekly window caps. Which one an
+// account gets is invisible at connect time, so the note has to reach the
+// surfaces where someone decides to connect.
+test("how a Command Code plan is billed is stated wherever it is connected", () => {
   const { testRoot, sessionDirectory } = sessionRoot(SESSION_KEY);
   const environmentValues = environment(testRoot, sessionDirectory);
   try {
@@ -329,7 +332,8 @@ test("the Provider plan requirement is stated wherever Command Code is connected
       { cwd: root, encoding: "utf8", env: environmentValues },
     );
     assert.equal(enabled.status, 0, enabled.stderr);
-    assert.match(enabled.stdout, /Provider plan/);
+    assert.match(enabled.stdout, /Any Command Code plan works/);
+    assert.match(enabled.stdout, /plan credits/);
 
     const doctor = spawnSync(process.execPath, [path.join(root, "src", "doctor.mjs"), "--json"], {
       cwd: root,
@@ -347,7 +351,7 @@ test("the Provider plan requirement is stated wherever Command Code is connected
       { cwd: root, encoding: "utf8", env: environmentValues },
     );
     const row = JSON.parse(snapshot.stdout).providers.find((p) => p.id === "commandcode");
-    assert.match(row.planNote, /Provider plan/);
+    assert.match(row.planNote, /Any Command Code plan works/);
     // Providers without the gate must stay silent about plans.
     const deepseek = JSON.parse(snapshot.stdout).providers.find((p) => p.id === "deepseek");
     assert.equal("planNote" in deepseek, false);

--- a/test/commandcode-forwarder.test.mjs
+++ b/test/commandcode-forwarder.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import http from "node:http";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { openPort } from "./port-pool.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const internalKey = "test-commandcode-internal-service-key-with-length";
+
+const TURN = [
+  { type: "start" },
+  { type: "text-start", id: "t" },
+  { type: "text-delta", id: "t", text: "OK" },
+  { type: "text-end", id: "t" },
+  { type: "finish-step", finishReason: "stop", usage: { inputTokens: 5, outputTokens: 1, totalTokens: 6 } },
+];
+
+// Stands in for api.commandcode.ai: the documented API refuses a Go-plan
+// account exactly the way the live gateway does, and the CLI's own route
+// answers the same turn.
+function mockCommandCode() {
+  const calls = { providerApi: 0, generate: 0, generateBodies: [] };
+  const server = http.createServer((request, response) => {
+    let raw = "";
+    request.on("data", (chunk) => {
+      raw += chunk;
+    });
+    request.on("end", () => {
+      if (request.url.startsWith("/provider/v1/")) {
+        calls.providerApi += 1;
+        const body = JSON.stringify({
+          error: {
+            message:
+              "Your Go plan doesn't include API access. Upgrade to Provider or higher at https://commandcode.ai/billing to use these endpoints.",
+            type: "permission_error",
+            code: "upgrade_required",
+          },
+        });
+        response.writeHead(403, { "Content-Type": "application/json" });
+        response.end(body);
+        return;
+      }
+      if (request.url === "/alpha/generate") {
+        calls.generate += 1;
+        calls.generateBodies.push(JSON.parse(raw));
+        response.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "x-ratelimit-limit-requests": "100",
+          "x-ratelimit-remaining-requests": "97",
+        });
+        for (const event of TURN) response.write(`${JSON.stringify(event)}\n`);
+        response.end();
+        return;
+      }
+      response.writeHead(404).end("{}");
+    });
+  });
+  return { server, calls };
+}
+
+async function listen(server, port) {
+  await new Promise((resolve) => server.listen(port, "127.0.0.1", resolve));
+}
+
+async function waitForHealth(base, headers, child, errors) {
+  const deadline = Date.now() + 8_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`forwarder exited: ${errors()}`);
+    try {
+      const health = await fetch(`${base}/health`, { headers });
+      if (health.ok) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  }
+  throw new Error(`forwarder never became healthy: ${errors()}`);
+}
+
+test("a plan-refused Command Code account is served through the CLI route", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "commandcode-forwarder-state-"));
+  const cliHome = mkdtempSync(path.join(os.tmpdir(), "commandcode-forwarder-home-"));
+  const upstreamPort = await openPort();
+  const forwarderPort = await openPort();
+  const { server, calls } = mockCommandCode();
+  await listen(server, upstreamPort);
+
+  const child = spawn(process.execPath, [path.join(root, "src", "api-forwarder.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MODEL_ROUTER_TARGET: "codex",
+      MODEL_ROUTER_INTERNAL_KEY: internalKey,
+      MODEL_ROUTER_API_PORT: String(forwarderPort),
+      MODEL_ROUTER_STATE_DIR: stateDir,
+      MODEL_ROUTER_QUIET: "1",
+      COMMANDCODE_BASE_URL: `http://127.0.0.1:${upstreamPort}/provider/v1`,
+      COMMAND_CODE_API_KEY: "user_test_key",
+      COMMANDCODE_CLI_HOME: cliHome,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const base = `http://127.0.0.1:${forwarderPort}`;
+  const headers = { Authorization: `Bearer ${internalKey}`, "Content-Type": "application/json" };
+  try {
+    await waitForHealth(base, headers, child, () => stderr);
+
+    const turn = () =>
+      fetch(`${base}/v1/chat/completions`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          model: "commandcode-deepseek-v4-flash",
+          stream: true,
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      });
+
+    const first = await turn();
+    assert.equal(first.status, 200);
+    const firstBody = await first.text();
+    assert.match(firstBody, /"content":"OK"/);
+    assert.ok(firstBody.endsWith("data: [DONE]\n\n"));
+    assert.equal(calls.providerApi, 1);
+    assert.equal(calls.generate, 1);
+    // The envelope that left carries the upstream model id and the schema-strict
+    // config the route validates.
+    assert.equal(calls.generateBodies[0].params.model, "deepseek/deepseek-v4-flash");
+    assert.equal(calls.generateBodies[0].memory, "");
+    assert.equal(calls.generateBodies[0].config.environment, "production");
+
+    // The refusal was written down, so the second turn never buys it again.
+    const planPath = path.join(stateDir, "commandcode-plan.json");
+    assert.ok(existsSync(planPath));
+    assert.equal(JSON.parse(readFileSync(planPath, "utf8")).commandcode.providerApi, false);
+
+    const second = await turn();
+    assert.equal(second.status, 200);
+    assert.match(await second.text(), /"content":"OK"/);
+    assert.equal(calls.providerApi, 1, "the documented API must not be asked twice");
+    assert.equal(calls.generate, 2);
+
+    // The plan route meters the same subscription, so its quota headers are
+    // harvested the same way a forwarded provider's are.
+    const limits = JSON.parse(readFileSync(path.join(stateDir, "rate-limits.json"), "utf8"));
+    assert.equal(limits.commandcode.requests.remaining, 97);
+    assert.equal(limits.commandcode.requests.limit, 100);
+  } finally {
+    if (child.exitCode === null) {
+      child.kill("SIGTERM");
+      await new Promise((resolve) => child.once("exit", resolve));
+    }
+    await new Promise((resolve) => server.close(resolve));
+    rmSync(stateDir, { recursive: true, force: true });
+    rmSync(cliHome, { recursive: true, force: true });
+  }
+});
+
+test("a 403 that is not the plan refusal is relayed, not routed around", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "commandcode-forwarder-state-"));
+  const cliHome = mkdtempSync(path.join(os.tmpdir(), "commandcode-forwarder-home-"));
+  const upstreamPort = await openPort();
+  const forwarderPort = await openPort();
+  let generateCalls = 0;
+  const server = http.createServer((request, response) => {
+    request.resume();
+    request.on("end", () => {
+      if (request.url === "/alpha/generate") generateCalls += 1;
+      response.writeHead(403, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "Region not supported", type: "permission_error" } }));
+    });
+  });
+  await listen(server, upstreamPort);
+
+  const child = spawn(process.execPath, [path.join(root, "src", "api-forwarder.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MODEL_ROUTER_TARGET: "codex",
+      MODEL_ROUTER_INTERNAL_KEY: internalKey,
+      MODEL_ROUTER_API_PORT: String(forwarderPort),
+      MODEL_ROUTER_STATE_DIR: stateDir,
+      MODEL_ROUTER_QUIET: "1",
+      COMMANDCODE_BASE_URL: `http://127.0.0.1:${upstreamPort}/provider/v1`,
+      COMMAND_CODE_API_KEY: "user_test_key",
+      COMMANDCODE_CLI_HOME: cliHome,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let stderr = "";
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const base = `http://127.0.0.1:${forwarderPort}`;
+  const headers = { Authorization: `Bearer ${internalKey}`, "Content-Type": "application/json" };
+  try {
+    await waitForHealth(base, headers, child, () => stderr);
+    const response = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "commandcode-deepseek-v4-flash",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    assert.equal(response.status, 403);
+    assert.match((await response.json()).error.message, /Region not supported/);
+    assert.equal(generateCalls, 0);
+    // Nothing was learned about the plan, so nothing was written down.
+    assert.equal(existsSync(path.join(stateDir, "commandcode-plan.json")), false);
+  } finally {
+    if (child.exitCode === null) {
+      child.kill("SIGTERM");
+      await new Promise((resolve) => child.once("exit", resolve));
+    }
+    await new Promise((resolve) => server.close(resolve));
+    rmSync(stateDir, { recursive: true, force: true });
+    rmSync(cliHome, { recursive: true, force: true });
+  }
+});

--- a/test/commandcode-generate.test.mjs
+++ b/test/commandcode-generate.test.mjs
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { generateHeaders, toGenerateRequest } = await import("../src/commandcode-generate.mjs");
+
+const AT = Date.parse("2026-08-16T09:00:00.000Z");
+
+// Every one of these is required. The gateway answers a 400 that lists the
+// exact missing JSON paths, so a dropped field is a dead provider rather than
+// a degraded one.
+test("the config envelope carries every field the route validates", () => {
+  const { config, memory, taste, skills, permissionMode } = toGenerateRequest(
+    { messages: [{ role: "user", content: "hi" }] },
+    { model: "deepseek/deepseek-v4-flash", at: AT },
+  );
+  assert.deepEqual(Object.keys(config).sort(), [
+    "currentBranch",
+    "date",
+    "environment",
+    "gitStatus",
+    "isGitRepo",
+    "mainBranch",
+    "recentCommits",
+    "structure",
+    "workingDir",
+  ]);
+  assert.equal(config.date, "2026-08-16");
+  assert.equal(config.isGitRepo, false);
+  // A string, not an object: an object here is a hard 400.
+  assert.equal(memory, "");
+  assert.equal(taste, null);
+  assert.equal(skills, null);
+  assert.equal(permissionMode, "standard");
+});
+
+test("openai system messages become the system field, not a message", () => {
+  const { params } = toGenerateRequest(
+    {
+      messages: [
+        { role: "system", content: "Be terse." },
+        { role: "developer", content: "Never guess." },
+        { role: "user", content: "Hello" },
+      ],
+    },
+    { model: "m", at: AT },
+  );
+  assert.equal(params.system, "Be terse.\n\nNever guess.");
+  assert.deepEqual(params.messages, [{ role: "user", content: [{ type: "text", text: "Hello" }] }]);
+});
+
+test("openai tool calls and results translate to ModelMessage shape", () => {
+  const { params } = toGenerateRequest(
+    {
+      messages: [
+        { role: "user", content: "weather?" },
+        {
+          role: "assistant",
+          content: "checking",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "get_weather", arguments: '{"location":"Paris"}' },
+            },
+          ],
+        },
+        { role: "tool", tool_call_id: "call_1", content: "18C" },
+        { role: "tool", tool_call_id: "call_1", content: "clear" },
+      ],
+    },
+    { model: "m", at: AT },
+  );
+  assert.deepEqual(params.messages[1], {
+    role: "assistant",
+    content: [
+      { type: "text", text: "checking" },
+      {
+        type: "tool-call",
+        toolCallId: "call_1",
+        toolName: "get_weather",
+        input: { location: "Paris" },
+      },
+    ],
+  });
+  // Results live in their own tool message, and consecutive results merge into
+  // one -- two tool messages would read to the model as two separate turns.
+  assert.equal(params.messages.length, 3);
+  assert.equal(params.messages[2].role, "tool");
+  assert.equal(params.messages[2].content.length, 2);
+  assert.deepEqual(params.messages[2].content[0], {
+    type: "tool-result",
+    toolCallId: "call_1",
+    toolName: "get_weather",
+    output: { type: "text", value: "18C" },
+  });
+});
+
+test("unparseable tool arguments still produce an object", () => {
+  const { params } = toGenerateRequest(
+    {
+      messages: [
+        {
+          role: "assistant",
+          tool_calls: [{ id: "c", type: "function", function: { name: "t", arguments: "not json" } }],
+        },
+      ],
+    },
+    { model: "m", at: AT },
+  );
+  assert.deepEqual(params.messages[0].content[0].input, { value: "not json" });
+});
+
+test("openai images become data-url image parts with a media type", () => {
+  const { params } = toGenerateRequest(
+    {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "what is this" },
+            { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+          ],
+        },
+      ],
+    },
+    { model: "m", at: AT },
+  );
+  assert.deepEqual(params.messages[0].content[1], {
+    type: "image",
+    image: "data:image/png;base64,AAAA",
+    mediaType: "image/png",
+  });
+});
+
+test("openai tools translate to snake_case input_schema", () => {
+  const { params } = toGenerateRequest(
+    {
+      messages: [],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "read_file",
+            description: "Read a file.",
+            parameters: { type: "object", properties: { path: { type: "string" } } },
+          },
+        },
+      ],
+    },
+    { model: "m", at: AT },
+  );
+  assert.deepEqual(params.tools, [
+    {
+      name: "read_file",
+      description: "Read a file.",
+      input_schema: { type: "object", properties: { path: { type: "string" } } },
+    },
+  ]);
+});
+
+test("anthropic turns split tool results out of the user message", () => {
+  const { params } = toGenerateRequest(
+    {
+      system: [{ type: "text", text: "Be exact." }],
+      max_tokens: 2048,
+      messages: [
+        { role: "user", content: [{ type: "text", text: "weather?" }] },
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "hmm" },
+            { type: "text", text: "checking" },
+            { type: "tool_use", id: "tu_1", name: "get_weather", input: { location: "Paris" } },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tu_1", content: [{ type: "text", text: "18C" }] },
+            { type: "text", text: "and tomorrow?" },
+          ],
+        },
+      ],
+    },
+    { protocol: "anthropic", model: "claude-sonnet-5", at: AT },
+  );
+  assert.equal(params.system, "Be exact.");
+  assert.equal(params.max_tokens, 2048);
+  // The thinking block is Anthropic's own replay format and means nothing to a
+  // gateway that never issued it, so it is dropped rather than forwarded.
+  assert.deepEqual(params.messages[1].content, [
+    { type: "text", text: "checking" },
+    { type: "tool-call", toolCallId: "tu_1", toolName: "get_weather", input: { location: "Paris" } },
+  ]);
+  assert.equal(params.messages[2].role, "tool");
+  assert.deepEqual(params.messages[2].content[0].output, { type: "text", value: "18C" });
+  assert.deepEqual(params.messages[3], {
+    role: "user",
+    content: [{ type: "text", text: "and tomorrow?" }],
+  });
+});
+
+test("anthropic error results keep their error tag", () => {
+  const { params } = toGenerateRequest(
+    {
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tu_1", is_error: true, content: "boom" },
+          ],
+        },
+      ],
+    },
+    { protocol: "anthropic", model: "m", at: AT },
+  );
+  assert.deepEqual(params.messages[0].content[0].output, { type: "error-text", value: "boom" });
+});
+
+test("anthropic base64 images become data urls", () => {
+  const { params } = toGenerateRequest(
+    {
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: { type: "base64", media_type: "image/jpeg", data: "QUJD" },
+            },
+          ],
+        },
+      ],
+    },
+    { protocol: "anthropic", model: "m", at: AT },
+  );
+  assert.deepEqual(params.messages[0].content[0], {
+    type: "image",
+    image: "data:image/jpeg;base64,QUJD",
+    mediaType: "image/jpeg",
+  });
+});
+
+// Measured live: the same one-line turn cost 92 prompt tokens with a system
+// prompt and 7,637 without, because an empty one makes the gateway splice in
+// the Command Code agent's own preamble -- on the caller's credits, and
+// telling the model it is a different product.
+test("a turn with no system prompt of its own does not inherit the agent's", () => {
+  const { params } = toGenerateRequest(
+    { messages: [{ role: "user", content: "hi" }] },
+    { model: "m", at: AT },
+  );
+  assert.equal(params.system, "You are a helpful assistant.");
+  assert.equal(
+    toGenerateRequest(
+      { messages: [{ role: "system", content: "Be terse." }] },
+      { model: "m", at: AT },
+    ).params.system,
+    "Be terse.",
+  );
+  assert.equal(
+    toGenerateRequest({ system: "Be exact.", messages: [] }, { protocol: "anthropic", model: "m", at: AT })
+      .params.system,
+    "Be exact.",
+  );
+});
+
+test("the turn always streams and defaults its own ceiling", () => {
+  const { params } = toGenerateRequest({ messages: [] }, { model: "m", at: AT });
+  assert.equal(params.stream, true);
+  assert.equal(params.max_tokens, 64_000);
+  assert.equal(params.temperature, undefined);
+  assert.equal(
+    toGenerateRequest({ messages: [], temperature: 0.2 }, { model: "m", at: AT }).params.temperature,
+    0.2,
+  );
+});
+
+test("headers identify the client the envelope was derived from", () => {
+  const headers = generateHeaders("user_secret", { sessionId: "s-1" });
+  assert.equal(headers.Authorization, "Bearer user_secret");
+  assert.equal(headers["x-cli-environment"], "production");
+  assert.equal(headers["x-session-id"], "s-1");
+  assert.match(headers["x-command-code-version"], /^\d+\.\d+\.\d+$/);
+  assert.equal(headers["x-cmd-zdr"], undefined);
+  assert.equal(generateHeaders("k", { zdr: true })["x-cmd-zdr"], "1");
+});

--- a/test/commandcode-plan.test.mjs
+++ b/test/commandcode-plan.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "commandcode-plan-test-"));
+process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+
+const {
+  COMMANDCODE_PLAN_PATH,
+  ROUTE_RECHECK_MS,
+  commandCodeRoute,
+  isUpgradeRequired,
+  readCommandCodePlanState,
+  recordCommandCodeRoute,
+} = await import("../src/commandcode-plan.mjs");
+
+const AT = Date.parse("2026-08-16T09:00:00.000Z");
+
+function forget() {
+  rmSync(COMMANDCODE_PLAN_PATH, { force: true });
+}
+
+// The documented API is what the operator paid for if they have it, so an
+// account nobody has heard a refusal from tries it first.
+test("an unknown account tries the documented API", () => {
+  forget();
+  assert.deepEqual(commandCodeRoute("commandcode", "key-a", { at: AT }), {
+    route: "provider-api",
+    recheck: false,
+  });
+});
+
+test("a refused account routes through the plan without asking again", () => {
+  forget();
+  recordCommandCodeRoute("commandcode", "key-a", { providerApi: false, at: AT });
+  assert.deepEqual(commandCodeRoute("commandcode", "key-a", { at: AT + 60_000 }), {
+    route: "plan",
+    recheck: false,
+  });
+});
+
+// An operator who upgrades mints a new key, and the old answer says nothing
+// about it.
+test("a different credential is a different question", () => {
+  forget();
+  recordCommandCodeRoute("commandcode", "key-a", { providerApi: false, at: AT });
+  assert.equal(commandCodeRoute("commandcode", "key-b", { at: AT }).route, "provider-api");
+});
+
+test("the refusal is re-checked once its window comes due", () => {
+  forget();
+  recordCommandCodeRoute("commandcode", "key-a", { providerApi: false, at: AT });
+  assert.deepEqual(commandCodeRoute("commandcode", "key-a", { at: AT + ROUTE_RECHECK_MS + 1 }), {
+    route: "provider-api",
+    recheck: true,
+  });
+  recordCommandCodeRoute("commandcode", "key-a", { providerApi: true, at: AT + ROUTE_RECHECK_MS + 2 });
+  assert.deepEqual(commandCodeRoute("commandcode", "key-a", { at: AT + ROUTE_RECHECK_MS + 3 }), {
+    route: "provider-api",
+    recheck: false,
+  });
+});
+
+test("the state file records a fingerprint and never the key", () => {
+  forget();
+  recordCommandCodeRoute("commandcode", "user_supersecret_value", { providerApi: false, at: AT });
+  const raw = readFileSync(COMMANDCODE_PLAN_PATH, "utf8");
+  assert.doesNotMatch(raw, /supersecret/);
+  const entry = readCommandCodePlanState().commandcode;
+  assert.match(entry.credential, /^[0-9a-f]{16}$/);
+  assert.equal(entry.providerApi, false);
+  assert.equal(entry.observedAt, new Date(AT).toISOString());
+});
+
+test("a corrupt state file costs one 403, not routing", () => {
+  forget();
+  recordCommandCodeRoute("commandcode", "key-a", { providerApi: false, at: AT });
+  rmSync(COMMANDCODE_PLAN_PATH, { force: true });
+  assert.equal(commandCodeRoute("commandcode", "key-a", { at: AT }).route, "provider-api");
+});
+
+// Only a real entitlement refusal may pin the fallback. Reading a timeout, a
+// 500, or a rate limit as one would quietly move a paying Provider-plan
+// account onto its coding-plan credits.
+test("only the entitlement refusal counts as one", () => {
+  assert.equal(
+    isUpgradeRequired(403, {
+      error: {
+        message: "Your Go plan doesn't include API access. Upgrade to Provider or higher.",
+        type: "permission_error",
+        code: "upgrade_required",
+      },
+    }),
+    true,
+  );
+  // The message alone still identifies it if the code ever stops being sent.
+  assert.equal(
+    isUpgradeRequired(403, { error: { message: "Your Go plan doesn't include API access." } }),
+    true,
+  );
+  assert.equal(isUpgradeRequired(403, { error: { message: "Forbidden" } }), false);
+  assert.equal(isUpgradeRequired(401, { error: { code: "upgrade_required" } }), false);
+  assert.equal(isUpgradeRequired(429, undefined), false);
+  assert.equal(isUpgradeRequired(403, undefined), false);
+});
+
+test("a non-boolean verdict is never written down", () => {
+  forget();
+  recordCommandCodeRoute("commandcode", "key-a", { at: AT });
+  assert.deepEqual(readCommandCodePlanState(), {});
+});

--- a/test/commandcode-relay.test.mjs
+++ b/test/commandcode-relay.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import test from "node:test";
+
+const { generateEndpoint, relayCommandCodeGenerate } = await import(
+  "../src/commandcode-relay.mjs"
+);
+
+const AT = Date.parse("2026-08-16T09:00:00.000Z");
+const MODEL = { gatewayModel: "commandcode-deepseek-v4-flash", upstreamModel: "deepseek/deepseek-v4-flash" };
+const OPENAI_PROVIDER = { id: "commandcode", ownedBy: "commandcode" };
+const ANTHROPIC_PROVIDER = { id: "commandcode-messages", ownedBy: "commandcode", protocol: "anthropic" };
+
+function fakeResponse() {
+  const captured = { status: undefined, headers: undefined, body: "", ended: false };
+  return {
+    captured,
+    writeHead(status, headers) {
+      captured.status = status;
+      captured.headers = headers;
+    },
+    write(chunk) {
+      captured.body += chunk;
+    },
+    end(chunk) {
+      if (chunk) captured.body += chunk;
+      captured.ended = true;
+    },
+  };
+}
+
+function ndjson(events) {
+  return Readable.from(
+    events.map((event) => Buffer.from(`${JSON.stringify(event)}\n`, "utf8")),
+  );
+}
+
+function upstreamOk(events) {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "x-ratelimit-remaining-requests": "41" }),
+    body: ndjson(events),
+  };
+}
+
+const TURN = [
+  { type: "start" },
+  { type: "text-start", id: "t" },
+  { type: "text-delta", id: "t", text: "OK" },
+  { type: "text-end", id: "t" },
+  { type: "finish-step", finishReason: "stop", usage: { inputTokens: 5, outputTokens: 1, totalTokens: 6 } },
+];
+
+// The registry points the provider at /provider/v1 because that is where the
+// documented API lives; the CLI route hangs off the origin instead.
+test("the route is derived from whatever base url is in force", () => {
+  assert.equal(
+    generateEndpoint("https://api.commandcode.ai/provider/v1"),
+    "https://api.commandcode.ai/alpha/generate",
+  );
+  assert.equal(
+    generateEndpoint("http://127.0.0.1:9090/provider/v1/"),
+    "http://127.0.0.1:9090/alpha/generate",
+  );
+});
+
+test("a streaming turn is translated to openai chunks", async () => {
+  const response = fakeResponse();
+  let seen;
+  const outcome = await relayCommandCodeGenerate({
+    payload: { model: "x", stream: true, messages: [{ role: "user", content: "hi" }] },
+    model: MODEL,
+    provider: OPENAI_PROVIDER,
+    apiKey: "user_key",
+    baseUrl: "https://api.commandcode.ai/provider/v1",
+    response,
+    at: AT,
+    fetchImpl: async (url, init) => {
+      seen = { url, init };
+      return upstreamOk(TURN);
+    },
+  });
+  assert.equal(outcome.status, 200);
+  // The upstream's own headers travel back so this route reports quota and
+  // cooldowns exactly as a provider forwarded intact does.
+  assert.equal(outcome.headers.get("x-ratelimit-remaining-requests"), "41");
+  assert.equal(seen.url, "https://api.commandcode.ai/alpha/generate");
+  assert.equal(seen.init.headers.Authorization, "Bearer user_key");
+  // The upstream model id travels, not the gateway id the caller used.
+  assert.equal(JSON.parse(seen.init.body).params.model, "deepseek/deepseek-v4-flash");
+  assert.equal(response.captured.headers["Content-Type"], "text/event-stream");
+  assert.match(response.captured.body, /"content":"OK"/);
+  assert.ok(response.captured.body.endsWith("data: [DONE]\n\n"));
+  assert.equal(response.captured.ended, true);
+});
+
+test("a non-streaming caller gets one assembled json body", async () => {
+  const response = fakeResponse();
+  const status = await relayCommandCodeGenerate({
+    payload: { model: "x", messages: [{ role: "user", content: "hi" }] },
+    model: MODEL,
+    provider: OPENAI_PROVIDER,
+    apiKey: "user_key",
+    baseUrl: "https://api.commandcode.ai/provider/v1",
+    response,
+    at: AT,
+    fetchImpl: async () => upstreamOk(TURN),
+  });
+  assert.equal(status.status, 200);
+  assert.equal(response.captured.headers["Content-Type"], "application/json");
+  const body = JSON.parse(response.captured.body);
+  assert.equal(body.object, "chat.completion");
+  assert.equal(body.choices[0].message.content, "OK");
+  assert.equal(body.model, MODEL.gatewayModel);
+});
+
+test("an anthropic caller gets anthropic events", async () => {
+  const response = fakeResponse();
+  await relayCommandCodeGenerate({
+    payload: { model: "x", stream: true, max_tokens: 128, messages: [{ role: "user", content: "hi" }] },
+    model: MODEL,
+    provider: ANTHROPIC_PROVIDER,
+    apiKey: "user_key",
+    baseUrl: "https://api.commandcode.ai/provider/v1",
+    response,
+    at: AT,
+    fetchImpl: async () => upstreamOk(TURN),
+  });
+  assert.match(response.captured.body, /^event: message_start\n/);
+  assert.match(response.captured.body, /event: message_stop/);
+  assert.doesNotMatch(response.captured.body, /\[DONE\]/);
+});
+
+// The gateway's own message is what tells the operator to top up or upgrade;
+// a generic proxy error would send them looking at the router instead.
+test("an upstream refusal is relayed with its own status and message", async () => {
+  const response = fakeResponse();
+  const status = await relayCommandCodeGenerate({
+    payload: { model: "x", stream: true, messages: [] },
+    model: MODEL,
+    provider: OPENAI_PROVIDER,
+    apiKey: "user_key",
+    baseUrl: "https://api.commandcode.ai/provider/v1",
+    response,
+    at: AT,
+    fetchImpl: async () => ({
+      ok: false,
+      status: 402,
+      headers: new Headers({ "retry-after": "60" }),
+      text: async () => JSON.stringify({ success: false, message: "insufficient credits" }),
+    }),
+  });
+  assert.equal(status.status, 402);
+  assert.equal(status.ok, false);
+  assert.equal(status.headers.get("retry-after"), "60");
+  assert.equal(response.captured.status, 402);
+  assert.equal(JSON.parse(response.captured.body).error.message, "insufficient credits");
+});
+
+test("a mid-stream failure is reported inside the stream and still terminates", async () => {
+  const response = fakeResponse();
+  const status = await relayCommandCodeGenerate({
+    payload: { model: "x", stream: true, messages: [] },
+    model: MODEL,
+    provider: OPENAI_PROVIDER,
+    apiKey: "user_key",
+    baseUrl: "https://api.commandcode.ai/provider/v1",
+    response,
+    at: AT,
+    fetchImpl: async () =>
+      upstreamOk([
+        { type: "start" },
+        { type: "text-start", id: "t" },
+        { type: "text-delta", id: "t", text: "par" },
+        { type: "error", error: { message: "premium_credits_exhausted" } },
+      ]),
+  });
+  assert.equal(status.status, 200);
+  assert.match(response.captured.body, /premium_credits_exhausted/);
+  assert.ok(response.captured.body.endsWith("data: [DONE]\n\n"));
+});

--- a/test/commandcode-stream.test.mjs
+++ b/test/commandcode-stream.test.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import test from "node:test";
+
+const { GenerateTranslator, readGenerateEvents } = await import("../src/commandcode-stream.mjs");
+
+const CREATED = 1_786_000_000;
+
+// Captured from a live Go-plan turn against api.commandcode.ai. The ordering is
+// the real one, including `text-start` arriving before the reasoning block it
+// follows has ended.
+const REASONING_TURN = [
+  { type: "start" },
+  { type: "start-step", request: { body: {} }, warnings: [] },
+  { type: "reasoning-start", id: "reasoning-0" },
+  { type: "reasoning-delta", id: "reasoning-0", text: "think" },
+  { type: "text-start", id: "txt-0" },
+  { type: "reasoning-end", id: "reasoning-0" },
+  { type: "text-delta", id: "txt-0", text: "OK" },
+  { type: "text-end", id: "txt-0" },
+  {
+    type: "finish-step",
+    finishReason: "stop",
+    usage: {
+      inputTokens: 94,
+      outputTokens: 18,
+      totalTokens: 112,
+      cachedInputTokens: 16,
+      reasoningTokens: 16,
+    },
+  },
+];
+
+const TOOL_TURN = [
+  { type: "start" },
+  { type: "tool-input-start", id: "call_1", toolName: "get_weather", dynamic: false },
+  { type: "tool-input-delta", id: "call_1", delta: '{"location"' },
+  { type: "tool-input-delta", id: "call_1", delta: ':"Paris"}' },
+  { type: "tool-input-end", id: "call_1" },
+  // The redundant trailing event, which keys on toolCallId rather than id.
+  { type: "tool-call", toolCallId: "call_1", toolName: "get_weather", input: { location: "Paris" } },
+  { type: "finish-step", finishReason: "tool-calls", usage: { inputTokens: 367, outputTokens: 64 } },
+];
+
+function run(events, options) {
+  const translator = new GenerateTranslator({ created: CREATED, model: "cc-model", ...options });
+  let out = "";
+  for (const event of events) out += translator.push(event);
+  out += translator.finish();
+  return { translator, sse: out };
+}
+
+function openAiChunks(sse) {
+  return sse
+    .split("\n\n")
+    .map((block) => block.replace(/^data: /, "").trim())
+    .filter((line) => line && line !== "[DONE]")
+    .map((line) => JSON.parse(line));
+}
+
+function anthropicEvents(sse) {
+  return sse
+    .split("\n\n")
+    .filter(Boolean)
+    .map((block) => {
+      const [eventLine, dataLine] = block.split("\n");
+      return { event: eventLine.replace(/^event: /, ""), data: JSON.parse(dataLine.replace(/^data: /, "")) };
+    });
+}
+
+test("openai chunks carry text, reasoning, finish reason, and usage", () => {
+  const { sse } = run(REASONING_TURN);
+  const chunks = openAiChunks(sse);
+  assert.deepEqual(chunks[0].choices[0].delta, { role: "assistant" });
+  assert.equal(chunks[0].object, "chat.completion.chunk");
+  assert.equal(chunks[0].created, CREATED);
+  assert.deepEqual(
+    chunks.map((chunk) => chunk.choices[0].delta).filter((delta) => delta.reasoning_content),
+    [{ reasoning_content: "think" }],
+  );
+  assert.deepEqual(
+    chunks.map((chunk) => chunk.choices[0].delta).filter((delta) => delta.content),
+    [{ content: "OK" }],
+  );
+  const final = chunks.at(-1);
+  assert.equal(final.choices[0].finish_reason, "stop");
+  // inputTokens already includes the cached reads, which is what OpenAI's
+  // shape reports too -- so it maps across rather than being adjusted.
+  assert.deepEqual(final.usage, {
+    prompt_tokens: 94,
+    completion_tokens: 18,
+    total_tokens: 112,
+    prompt_tokens_details: { cached_tokens: 16 },
+    completion_tokens_details: { reasoning_tokens: 16 },
+  });
+  assert.ok(sse.endsWith("data: [DONE]\n\n"));
+});
+
+test("anthropic blocks stay serialized even when the source interleaves them", () => {
+  const { sse } = run(REASONING_TURN, { protocol: "anthropic" });
+  const events = anthropicEvents(sse);
+  assert.deepEqual(
+    events.map((entry) => entry.event),
+    [
+      "message_start",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "content_block_start",
+      "content_block_delta",
+      "content_block_stop",
+      "message_delta",
+      "message_stop",
+    ],
+  );
+  assert.equal(events[1].data.content_block.type, "thinking");
+  assert.deepEqual(events[2].data.delta, { type: "thinking_delta", thinking: "think" });
+  assert.equal(events[4].data.index, 1);
+  assert.deepEqual(events[5].data.delta, { type: "text_delta", text: "OK" });
+  assert.equal(events[7].data.delta.stop_reason, "end_turn");
+  // Anthropic's input_tokens excludes cache reads, so the cached count is
+  // subtracted here rather than double-counted into the caller's cost math.
+  assert.deepEqual(events[7].data.usage, {
+    input_tokens: 78,
+    output_tokens: 18,
+    cache_read_input_tokens: 16,
+  });
+});
+
+test("a tool call fires once even though the route reports it twice", () => {
+  const { sse } = run(TOOL_TURN);
+  const chunks = openAiChunks(sse);
+  const toolDeltas = chunks
+    .map((chunk) => chunk.choices[0].delta.tool_calls)
+    .filter(Boolean)
+    .flat();
+  assert.deepEqual(toolDeltas[0], {
+    index: 0,
+    id: "call_1",
+    type: "function",
+    function: { name: "get_weather", arguments: "" },
+  });
+  assert.equal(
+    toolDeltas
+      .map((call) => call.function?.arguments || "")
+      .join(""),
+    '{"location":"Paris"}',
+  );
+  assert.equal(toolDeltas.filter((call) => call.id).length, 1);
+  assert.equal(chunks.at(-1).choices[0].finish_reason, "tool_calls");
+});
+
+test("a model that only sends the trailing tool-call still produces one", () => {
+  const { sse, translator } = run([
+    { type: "start" },
+    { type: "tool-call", toolCallId: "c9", toolName: "run", input: { cmd: "ls" } },
+    { type: "finish-step", finishReason: "tool-calls" },
+  ]);
+  const calls = openAiChunks(sse)
+    .map((chunk) => chunk.choices[0].delta.tool_calls)
+    .filter(Boolean)
+    .flat();
+  assert.equal(calls[0].id, "c9");
+  assert.equal(calls[0].function.name, "run");
+  assert.equal(calls.map((call) => call.function?.arguments || "").join(""), '{"cmd":"ls"}');
+  assert.deepEqual(translator.body().choices[0].message.tool_calls, [
+    { id: "c9", type: "function", function: { name: "run", arguments: '{"cmd":"ls"}' } },
+  ]);
+});
+
+test("anthropic tool calls become a tool_use block with json deltas", () => {
+  const { sse } = run(TOOL_TURN, { protocol: "anthropic" });
+  const events = anthropicEvents(sse);
+  const start = events.find((entry) => entry.event === "content_block_start");
+  assert.deepEqual(start.data.content_block, {
+    type: "tool_use",
+    id: "call_1",
+    name: "get_weather",
+    input: {},
+  });
+  assert.deepEqual(
+    events
+      .filter((entry) => entry.event === "content_block_delta")
+      .map((entry) => entry.data.delta.partial_json)
+      .join(""),
+    '{"location":"Paris"}',
+  );
+  assert.equal(events.find((entry) => entry.event === "message_delta").data.delta.stop_reason, "tool_use");
+});
+
+test("a stream that stops without a terminal event still terminates cleanly", () => {
+  const { sse } = run([
+    { type: "start" },
+    { type: "text-start", id: "t" },
+    { type: "text-delta", id: "t", text: "half" },
+  ]);
+  const chunks = openAiChunks(sse);
+  assert.equal(chunks.at(-1).choices[0].finish_reason, "stop");
+  assert.ok(sse.endsWith("data: [DONE]\n\n"));
+});
+
+test("the whole answer is assembled for a caller that did not ask to stream", () => {
+  const { translator } = run(REASONING_TURN);
+  const body = translator.body();
+  assert.equal(body.object, "chat.completion");
+  assert.equal(body.choices[0].message.content, "OK");
+  assert.equal(body.choices[0].message.reasoning_content, "think");
+  assert.equal(body.choices[0].finish_reason, "stop");
+  assert.equal(body.usage.prompt_tokens, 94);
+});
+
+test("the anthropic body assembles thinking, text, and tool blocks", () => {
+  const translator = new GenerateTranslator({ protocol: "anthropic", model: "m", created: CREATED });
+  for (const event of [...REASONING_TURN, ...TOOL_TURN.slice(1)]) translator.push(event);
+  const body = translator.body();
+  assert.deepEqual(
+    body.content.map((block) => block.type),
+    ["thinking", "text", "tool_use"],
+  );
+  assert.deepEqual(body.content[2].input, { location: "Paris" });
+  assert.equal(body.stop_reason, "tool_use");
+});
+
+test("a mid-stream error event is captured rather than swallowed", () => {
+  const { translator } = run([
+    { type: "start" },
+    { type: "error", error: { message: "insufficient credits" } },
+  ]);
+  assert.equal(translator.error, "insufficient credits");
+});
+
+test("events survive being split across read boundaries", async () => {
+  const wire = REASONING_TURN.map((event) => `${JSON.stringify(event)}\n`).join("");
+  // Deliberately ugly slicing: the route splits JSON objects across TCP reads,
+  // and a parser that assumed whole lines would drop content under load.
+  const pieces = [];
+  for (let index = 0; index < wire.length; index += 7) {
+    pieces.push(Buffer.from(wire.slice(index, index + 7), "utf8"));
+  }
+  const events = [];
+  for await (const event of readGenerateEvents(Readable.from(pieces))) events.push(event);
+  assert.deepEqual(events, REASONING_TURN);
+});
+
+test("a data-prefixed line and a [DONE] sentinel are tolerated", async () => {
+  const events = [];
+  const body = Readable.from([
+    Buffer.from('data: {"type":"start"}\n', "utf8"),
+    Buffer.from("not json\n", "utf8"),
+    Buffer.from("[DONE]\n", "utf8"),
+  ]);
+  for await (const event of readGenerateEvents(body)) events.push(event);
+  assert.deepEqual(events, [{ type: "start" }]);
+});

--- a/test/provider-account-usage.test.mjs
+++ b/test/provider-account-usage.test.mjs
@@ -256,6 +256,14 @@ test("Command Code usage reads plan windows from the billing credits API", async
     assert.equal(snapshot.commandcode.dashboardUrl, "https://commandcode.ai/studio");
     assert.deepEqual(snapshot.commandcode.metrics, [
       {
+        kind: "balance",
+        label: "Plan credits",
+        value: 10,
+        currency: "USD",
+        detail: "Plan 10.00",
+        available: true,
+      },
+      {
         kind: "quota",
         label: "5-hour limit",
         usedPercent: (1 / 3) * 100,
@@ -763,6 +771,16 @@ test("normalizes Command Code plan windows and skips a zero resetAt", () => {
       weekly: { used: 0, cap: 6, exceeded: false, resetAt: 1_786_579_200_000 },
     },
   }), [
+    // The credit pool leads: a coding plan runs out of credits long before it
+    // stops hitting the windows, so it is the number that ends the afternoon.
+    {
+      kind: "balance",
+      label: "Plan credits",
+      value: 10,
+      currency: "USD",
+      detail: "Plan 10.00",
+      available: true,
+    },
     {
       kind: "quota",
       label: "5-hour limit",
@@ -785,6 +803,31 @@ test("normalizes Command Code plan windows and skips a zero resetAt", () => {
       resetAt: 1_786_579_200,
     },
   ]);
+});
+
+test("Command Code top-ups and a low-credit warning reach the balance metric", () => {
+  const [balance] = commandCodeCreditsMetrics({
+    credits: {
+      belowThreshold: true,
+      creditThreshold: 2,
+      monthlyCredits: 1.5,
+      purchasedCredits: 20,
+      freeCredits: 0.25,
+    },
+    windowLimits: { fiveHour: { used: 0, cap: 3 } },
+  });
+  assert.equal(balance.value, 21.75);
+  assert.equal(balance.detail, "Plan 1.50 · Purchased 20.00 · Free 0.25");
+  assert.equal(balance.available, false);
+});
+
+// Nothing to report is reported as nothing. A zero-valued balance would read
+// as an empty account rather than as an answer the provider did not give.
+test("Command Code windows without a credit pool report only the windows", () => {
+  assert.deepEqual(
+    commandCodeCreditsMetrics({ windowLimits: { weekly: { used: 1, cap: 6 } } }).map((m) => m.kind),
+    ["quota"],
+  );
 });
 
 test("normalizes Grok prepaid credits and pay-as-you-go balance", () => {


### PR DESCRIPTION
## The problem

Command Code is reachable on one plan, and it is not the plan most of its customers buy.

The provider only ever spoke `/provider/v1`. That surface is an **entitlement, not a credential**: a \$1 Go account signs in, mints a real key, runs the official CLI all day, and is still answered

```
403 {"error":{"code":"upgrade_required",
     "message":"Your Go plan doesn't include API access. Upgrade to Provider or higher…"}}
```

No sign-in, key, or reinstall changes it. The router's entire response was a `planNote` explaining why nothing worked.

## The fix

The `command-code` CLI does not use that surface. Every turn it takes goes to `POST /alpha/generate`, which is **not plan-gated**. The forwarder now answers the entitlement refusal by moving the turn there, so Go, GOAT, Pro, and Max are served with the same key and the same catalog. Both protocols are covered — the chat-completions catalog and the Messages variant carrying the Claude models.

| Plan | Route | Cost |
| --- | --- | --- |
| Provider | `/provider/v1` | Pay as you go, no window caps |
| Go, GOAT, Pro, Max, Team | `/alpha/generate` | Plan credits, 5-hour and weekly caps |

## The rules around the fallback

Deliberately the narrow ones this repository already draws elsewhere:

- **Only a real `upgrade_required` moves a turn.** `isUpgradeRequired()` demands a 403 *and* the machine-readable code (or its message). A timeout, a 500, or a rate limit says nothing about entitlement, and reading one as a refusal would quietly move a paying Provider-plan account onto its coding-plan credits. Every other 403 is relayed with the provider's own message.
- **It happens before the first relayed byte** — the same boundary the upstream-retry and model-failover rules draw, and beside the Copilot replay that shares it.
- **It stays one provider.** `commandcode` and `commandcode-messages` keep one credential, one catalog, one family toggle. What changes is where the turn is sent, not what the operator selected.
- **The verdict is remembered against a SHA-256 fingerprint of the credential, never the key** — so the 403 is bought once rather than once per turn, re-probed when the key changes, and re-checked every six hours in case the plan did. A success is written only when that window came due, so a healthy Provider-plan account does not rewrite state once per turn.
- **Quota headers and cooldowns are harvested on the plan route too**, so the router is not blind to an exhausted plan on the accounts this route exists to serve.

## The envelope

Command Code publishes no reference for `/alpha/generate`. The shapes were derived from the shipped bundle (`$(npm root -g)/command-code/dist/cli.mjs`, v1.14.1) and confirmed against the live gateway on a Go-plan account. Four things are load-bearing, each worth a failed request to learn:

1. `config` is schema-strict — every field required, or a 400 listing the missing paths.
2. `memory` is a **string**, not an object.
3. `params.messages` is the Vercel AI SDK `ModelMessage[]` schema — not Anthropic content blocks, not OpenAI tool messages. Tool results get their own `role:"tool"` message.
4. The response is **newline-delimited JSON** despite its `text/event-stream` content type, its blocks interleave, and the trailing `tool-call` event keys on `toolCallId` where every incremental event keys on `id`.

**One measurement changed the design.** An empty `system` field is not "no system prompt" to that route — it is a cue to splice in the Command Code agent's own preamble. The same one-line turn cost **92 prompt tokens with a system prompt and 7,637 without**, and the model spent them being told it was a different product with different tools. A turn carrying none now gets a neutral one.

## Also

The tray reported Command Code's spending windows but not what was left to spend. The billing route it already polls reports the credit pool beside the caps, and a coding plan runs out of the first long before it stops hitting the second. Plan, purchased, and free credits now surface as a balance metric, and the plan's own low-credit threshold marks it unavailable.

## Test plan

- [x] `npm run check` — passes
- [x] `npm test` — 1409 pass, 0 fail
- [x] 39 new tests: request translation (both protocols), stream translation (both protocols), entitlement memory, the relay, and a forwarder integration test that stands a mock gateway up and proves the documented API is asked exactly once
- [x] Live against `api.commandcode.ai` on a real Go-plan account, through `src/api-forwarder.mjs`: DeepSeek V4 Flash, Qwen3.8 Max, GLM-5.2, Kimi K3, GPT-5.6 Luna, Grok 4.5, MiniMax M3 — all 200, all correct answers; tool calling returns `get_weather {"location": "Paris"}` with `finish_reason: tool_calls`; non-streaming assembles one body; the Anthropic path was validated with a full `tool_use`/`tool_result` history
- [x] Claude on a Go plan is refused by Command Code itself, verbatim: `MODEL_NOT_IN_PLAN: Claude Haiku 4.5 available in Pro and above plans` — a plan allowance, not a router failure
- [ ] Reinstall and a full Codex restart on a Go-plan machine
- [ ] Native subagent probe on a plan-routed model