### PR TITLE
feat(devin): reach Devin's models through the session its CLI already stored

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -968,6 +968,61 @@ minutes later. Do not quietly drop the label because a check happened to pass.
    answering every request with `local_router_error`, suspect a process still
    holding pre-change state rather than the new code.
 
+## The Devin CLI provider is unverified, and says so
+
+`devin-cli` reuses the session `devin auth login` writes and spends that
+account's ACU credits, the same shape as `kimi-oauth` and `grok-oauth`. What is
+not the same is the transport, and that difference governs everything else
+about it.
+
+1. **There is no model API.** Cognition documents a *session* API
+   (`api.devin.ai`), not a chat API. The models answer only on Cascade —
+   `exa.api_server_pb.ApiServerService` over Connect RPC at the
+   `api_server_url` the CLI stored. The schemas in `src/devin-proto.mjs` are
+   transcribed from the descriptor set embedded in the shipped `devin` binary,
+   which is the only published source for them. Treat every field number as
+   evidence from one binary version, not as a contract.
+2. **Unverified until someone with an account proves it.** No maintainer has
+   run a live turn. The registry entry ships no models, the provider is
+   catalog-only, and nothing may claim support until `bin/devin-probe --live
+   --tools` passes for a real account. Do not set `multiAgentVersion`, do not
+   check in model fragments, and do not describe this provider as working in
+   README or release notes on the strength of the unit tests alone.
+3. **The unit tests prove translation, not the protocol.** `protobuf-wire`,
+   `devin-cli-turn`, `devin-cli-status`, and `devin-connect` cover the wire
+   codec, the request mapping, the credential reader, and the envelope framing
+   against fixtures. They cannot prove Cascade accepts the request. A green
+   suite here is necessary and nowhere near sufficient.
+4. **The decoder must stay permissive and the credential reader strict.**
+   Unknown protobuf fields are skipped, because the upstream adds them without
+   notice and a strict decoder would fail whole turns. `credentials.toml` is the
+   opposite: it is read through `toml-structure.mjs`, so a duplicate key or a
+   value the scanner cannot read plainly is refused rather than guessed at.
+5. **The router reads that file and never writes it.** No code path may create,
+   move, copy, or delete another tool's credential file, and the token never
+   reaches a log, an argument, or an error message. `--no-discovery` must keep
+   the file closed entirely.
+6. **Entitlement is the account's, not the registry's.** Which models an
+   operator may run is decided server-side by `GetCascadeModelConfigs` and team
+   settings. Discovery asks; the registry never guesses. A model that appears
+   for one account may be absent or refused for another.
+7. **Expect drift, and fail loudly when it happens.** An unversioned transport
+   can change under a `devin` update. When it does, the symptom is a Connect
+   `invalid_argument` on every turn, not a subtle wrong answer — keep it that
+   way rather than adding tolerant parsing that would mask a schema change.
+8. **An operator who never curated a Devin model pays nothing for it.** Unlike
+   the three forwarders that always run, `src/devin-cli-forwarder.mjs` is
+   spawned only when `MODELS` contains a `devin-cli` model, so an unconfigured
+   install starts no fourth child, binds no fourth port, and waits on no fourth
+   health probe. The gate is deliberately the curated model and not the stored
+   credential: a curated model is exactly what makes `writeLiteLlmConfig()`
+   emit a `DEVIN_CLI_FORWARD_BASE_URL` route, and both are read from the same
+   `MODELS` array on the same boot, so a live gateway route can never point at
+   a port nothing bound. Gating on `credentials.toml` instead would trade the
+   forwarder's actionable 401 naming `devin auth login` for a bare connection
+   error. An unverified provider must stay free for the people not using it —
+   apply the same rule to any future provider that needs its own forwarder.
+
 ## Codex safety boundaries
 
 - The config manager owns its marked root `openai_base_url` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,44 @@
   stops hitting the second. Plan, purchased, and free credits now surface as a
   balance metric, and the plan's own low-credit threshold marks it unavailable.
 
+- **Devin's models are reachable from the session its CLI already stored, and
+  this adds the provider that reaches them — untested against a real account.**
+  `devin auth login` writes a persistent token to `credentials.toml`, so
+  `devin-cli` reuses it exactly as `kimi-oauth` and `grok-oauth` reuse theirs.
+  The transport is the part with no precedent here: Cognition publishes a
+  session API, not a chat API, and the models answer only on Cascade —
+  `exa.api_server_pb.ApiServerService` over Connect RPC — so this ships a small
+  protobuf wire codec, the message subset transcribed from the descriptor set
+  embedded in the shipped `devin` binary, a Connect streaming client, and a
+  forwarder translating OpenAI Chat Completions into a `GetChatMessage` turn
+  and its deltas back. Reasoning and tool calls are mapped; images ride only on
+  the current turn, because replaying an older one fails the whole request.
+  Thirty-seven tests cover the codec against hand-computed bytes, the request
+  mapping, the credential reader, and envelope framing including a split frame
+  and an error carried in the end-of-stream terminator. None of that proves
+  Cascade accepts the request: no maintainer holds a Devin account, so the
+  provider ships catalog-only with no checked-in models and is documented as
+  unverified. `bin/devin-probe` is the way to find out — it checks the
+  credential and lists the account's models for free, and `--live --tools`
+  spends one turn to prove a streamed answer and a forced tool call.
+
+  Nobody who has not asked for Devin pays anything for it being here. The
+  forwarder is spawned only when the registry actually holds a `devin-cli`
+  model, so an install that never ran `bin/curate-models devin-cli` starts no
+  fourth child, binds no fourth port, and waits on no fourth health probe —
+  startup is byte-for-byte the work it was before. The gate is the curated
+  model rather than the stored credential on purpose: a curated model is
+  precisely what puts a `DEVIN_CLI_FORWARD_BASE_URL` route in the generated
+  gateway config, and the route and the listener are decided from the same
+  model list on the same boot, so a live route can never point at a port
+  nothing is listening on. Gating on `credentials.toml` would have been the
+  wrong trade — someone who curated a model but has not run `devin auth login`
+  gets a 401 naming that command, which a missing forwarder would have turned
+  into a bare connection error. When Devin *is* routed, everything is as
+  before: the forwarder is health-waited alongside the other three, an
+  unbindable port still aborts startup naming the forwarder, and a forwarder
+  that dies still ends the service so the OS supervisor rebuilds it.
+
 - **The free Qwen3.8 endpoint refused any conversation whose system message
   arrived late or twice.** Its chat template answers those with a 400 reading
   "System message must be at the beginning", and a real Codex session reaches

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -8,10 +8,19 @@ for Codex plus built-in Kimi and DeepSeek integrations.
 `opencodex` is distributed under the MIT License. Copyright (c) 2026
 opencodex contributors.
 
+The `devin-cli` provider's understanding of Cascade's Connect RPC surface —
+the service path, the doubled `Basic` credential, and which request fields a
+turn must carry — follows
+[devin-2api](https://github.com/leookun/devin-2api), distributed under the MIT
+License. Copyright (c) 2026 devin-2api contributors. The protobuf field
+numbers in `src/devin-proto.mjs` are transcribed from the descriptor set
+embedded in Cognition's own `devin` binary; no code was copied.
+
 This is an independent community project. It is not affiliated with or
-endorsed by OpenAI, Anthropic, Moonshot AI, the Kimi Code team, DeepSeek, or
-OpenRouter. GitHub and Copilot are trademarks of GitHub, Inc.; this project's
-GitHub Copilot integration is not endorsed by GitHub.
+endorsed by OpenAI, Anthropic, Moonshot AI, the Kimi Code team, DeepSeek,
+OpenRouter, or Cognition AI. GitHub and Copilot are trademarks of GitHub,
+Inc.; this project's GitHub Copilot integration is not endorsed by GitHub.
+Devin and Windsurf are trademarks of Cognition AI, Inc.
 
 The GitHub Copilot tray mark is adapted from Primer Octicons' `copilot-24.svg`,
 distributed under the MIT License. Copyright (c) 2026 GitHub Inc.

--- a/bin/devin-probe
+++ b/bin/devin-probe
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+exec node "$repo_dir/src/devin-cli-probe.mjs" "$@"

--- a/config/devin/devin.json
+++ b/config/devin/devin.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "devin-cli",
+      "displayName": "Devin CLI (Cascade)",
+      "kind": "oauth",
+      "ownedBy": "cognition",
+      "proxyBaseEnv": "DEVIN_CLI_FORWARD_BASE_URL",
+      "planNote": "Reuses the session `devin auth login` stores in the official Devin CLI and spends that account's ACU credits. Which models the account may run is decided server-side, so this provider ships no preselected models: run `bin/curate-models devin-cli` after signing in. Cognition publishes no model API, so the transport is unversioned and can change without notice."
+    }
+  ]
+}

--- a/src/devin-cli-forwarder.mjs
+++ b/src/devin-cli-forwarder.mjs
@@ -1,0 +1,317 @@
+import http from "node:http";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath } from "node:url";
+
+import {
+  applyKeepAliveTimeouts,
+  formatErrorChain,
+  httpErrorStatus,
+  readRequestBody,
+  requireInternalAuth,
+  writeJson,
+} from "./http-utils.mjs";
+import { PORTS } from "./paths.mjs";
+import { devinCliStatus } from "./devin-cli-status.mjs";
+import { readDevinSession } from "./devin-cli-session.mjs";
+import { connectServerStream, connectUnary } from "./devin-connect.mjs";
+import {
+  GET_CASCADE_MODEL_CONFIGS,
+  GET_CASCADE_MODEL_CONFIGS_REQUEST,
+  GET_CASCADE_MODEL_CONFIGS_RESPONSE,
+  GET_CHAT_MESSAGE,
+  GET_CHAT_MESSAGE_REQUEST,
+  GET_CHAT_MESSAGE_RESPONSE,
+  SERVICE_PATH,
+} from "./devin-proto.mjs";
+import { buildChatMessageRequest, finishReasonFor, usageFrom } from "./devin-cli-turn.mjs";
+import { installStableFetchTransport } from "./fetch-transport.mjs";
+
+installStableFetchTransport();
+
+// LiteLLM speaks OpenAI Chat Completions to this forwarder. It reuses the
+// official Devin CLI session and translates to Cascade's Connect RPC, which is
+// the only interface Cognition's models answer on.
+
+const LISTEN_HOST = process.env.MODEL_ROUTER_DEVIN_CLI_HOST || "127.0.0.1";
+const LISTEN_PORT = Number(process.env.MODEL_ROUTER_DEVIN_CLI_PORT || PORTS.devinCli);
+const INTERNAL_KEY = process.env.MODEL_ROUTER_INTERNAL_KEY;
+const QUIET = process.env.MODEL_ROUTER_QUIET === "1";
+
+function baseUrlFor(session) {
+  return process.env.DEVIN_CASCADE_BASE_URL || session.apiServerUrl;
+}
+
+const chunk = (id, created, model, delta, finishReason = null) =>
+  `data: ${JSON.stringify({
+    id,
+    object: "chat.completion.chunk",
+    created,
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`;
+
+// Cascade streams whole tool calls rather than argument fragments, so a call
+// arriving twice is the same call restated. Indexing by id keeps the OpenAI
+// `tool_calls[].index` stable across restatements instead of emitting a second
+// call the client would dispatch twice.
+class ToolCallStream {
+  constructor() {
+    this.byId = new Map();
+    this.collected = [];
+  }
+
+  accept(call) {
+    const id = call.id || `call_${randomUUID()}`;
+    const existing = this.byId.get(id);
+    const entry = {
+      id,
+      type: "function",
+      function: { name: call.name || existing?.function.name || "", arguments: call.argumentsJson || "" },
+    };
+    if (existing) {
+      const index = this.collected.findIndex((held) => held.id === id);
+      this.collected[index] = entry;
+      this.byId.set(id, entry);
+      return { index, entry, restated: true };
+    }
+    const index = this.collected.length;
+    this.collected.push(entry);
+    this.byId.set(id, entry);
+    return { index, entry, restated: false };
+  }
+}
+
+async function handleChatCompletions(request, response) {
+  const chat = JSON.parse((await readRequestBody(request)).toString("utf8"));
+  const wantsStream = chat.stream === true;
+  const model = typeof chat.model === "string" ? chat.model : "";
+
+  let session;
+  try {
+    session = readDevinSession();
+  } catch {
+    writeJson(response, 401, {
+      error: {
+        message: "The Devin CLI session is unavailable; run `devin auth login`.",
+        type: "authentication_error",
+        code: null,
+      },
+    });
+    return;
+  }
+
+  const controller = new AbortController();
+  request.once("aborted", () => controller.abort());
+  response.once("close", () => {
+    if (!response.writableEnded) controller.abort();
+  });
+
+  const upstream = connectServerStream({
+    baseUrl: baseUrlFor(session),
+    service: SERVICE_PATH,
+    method: GET_CHAT_MESSAGE,
+    token: session.apiKey,
+    requestSchema: GET_CHAT_MESSAGE_REQUEST,
+    responseSchema: GET_CHAT_MESSAGE_RESPONSE,
+    message: buildChatMessageRequest(chat, { token: session.apiKey, modelUid: model }),
+    signal: controller.signal,
+  });
+
+  const id = `chatcmpl-${randomUUID()}`;
+  const created = Math.floor(Date.now() / 1_000);
+  const toolCalls = new ToolCallStream();
+  let contentText = "";
+  let reasoningText = "";
+  let stopReason;
+  let usage;
+  let headersWritten = false;
+
+  const openStream = () => {
+    if (headersWritten || !wantsStream) return;
+    headersWritten = true;
+    response.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    response.write(chunk(id, created, model, { role: "assistant", content: "" }));
+  };
+
+  try {
+    for await (const message of upstream) {
+      openStream();
+      if (message.deltaThinking) {
+        reasoningText += message.deltaThinking;
+        if (wantsStream) {
+          response.write(chunk(id, created, model, { reasoning_content: message.deltaThinking }));
+        }
+      }
+      if (message.deltaText) {
+        contentText += message.deltaText;
+        if (wantsStream) response.write(chunk(id, created, model, { content: message.deltaText }));
+      }
+      for (const call of message.deltaToolCalls || []) {
+        const { index, entry, restated } = toolCalls.accept(call);
+        if (!wantsStream) continue;
+        response.write(
+          chunk(id, created, model, {
+            tool_calls: [
+              restated
+                ? { index, function: { arguments: entry.function.arguments } }
+                : { index, id: entry.id, type: "function", function: { ...entry.function } },
+            ],
+          }),
+        );
+      }
+      if (message.usage) usage = usageFrom(message.usage);
+      if (message.stopReason !== undefined) stopReason = message.stopReason;
+    }
+  } catch (error) {
+    if (!headersWritten) {
+      const status = httpErrorStatus(error, 502);
+      writeJson(response, status, {
+        error: {
+          message:
+            status === 401
+              ? "Devin rejected the CLI session; run `devin auth login`."
+              : "The Devin CLI forwarder could not complete the request.",
+          type: status === 401 ? "authentication_error" : "api_error",
+          code: null,
+        },
+      });
+      return;
+    }
+    // The turn already relayed bytes, so the client owns a partial message.
+    // End the stream rather than injecting an error object it would append.
+    if (!response.writableEnded) response.end("data: [DONE]\n\n");
+    return;
+  }
+
+  const finishReason = finishReasonFor(stopReason, toolCalls.collected.length > 0);
+
+  if (wantsStream) {
+    openStream();
+    response.write(chunk(id, created, model, {}, finishReason));
+    if (usage) {
+      response.write(
+        `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model, choices: [], usage })}\n\n`,
+      );
+    }
+    response.write("data: [DONE]\n\n");
+    response.end();
+  } else {
+    const message = { role: "assistant", content: contentText || null };
+    if (reasoningText) message.reasoning_content = reasoningText;
+    if (toolCalls.collected.length) message.tool_calls = toolCalls.collected;
+    writeJson(response, 200, {
+      id,
+      object: "chat.completion",
+      created,
+      model,
+      choices: [{ index: 0, message, finish_reason: finishReason }],
+      usage,
+    });
+  }
+
+  if (!QUIET) console.error(`[devin-cli] model=${model} finish=${finishReason}`);
+}
+
+// Discovery asks the account which models it may spend. The answer is the
+// operator's entitlement, not a checked-in list, so `bin/curate-models` reads
+// it live rather than the registry shipping a guess.
+export async function listCascadeModels({ session = readDevinSession(), signal } = {}) {
+  const response = await connectUnary({
+    baseUrl: baseUrlFor(session),
+    service: SERVICE_PATH,
+    method: GET_CASCADE_MODEL_CONFIGS,
+    token: session.apiKey,
+    requestSchema: GET_CASCADE_MODEL_CONFIGS_REQUEST,
+    responseSchema: GET_CASCADE_MODEL_CONFIGS_RESPONSE,
+    message: { metadata: { apiKey: session.apiKey, ideName: "windsurf", locale: "en" } },
+    signal,
+  });
+  return (response.clientModelConfigs || [])
+    .filter((config) => config.modelUid && !config.disabled)
+    .map((config) => ({
+      id: config.modelUid,
+      label: config.label || config.modelUid,
+      description: config.description || "",
+      maxTokens: config.maxTokens || undefined,
+      supportsImages: Boolean(config.supportsImages),
+      premium: Boolean(config.isPremium),
+      beta: Boolean(config.isBeta),
+    }));
+}
+
+async function handleModels(response) {
+  const models = await listCascadeModels();
+  writeJson(response, 200, {
+    object: "list",
+    data: models.map((model) => ({ id: model.id, object: "model", owned_by: "devin" })),
+  });
+}
+
+async function handleRequest(request, response) {
+  if (!INTERNAL_KEY) {
+    writeJson(response, 500, {
+      error: { type: "api_error", message: "MODEL_ROUTER_INTERNAL_KEY is required." },
+    });
+    return;
+  }
+  const requestUrl = new URL(request.url || "/", `http://${request.headers.host || LISTEN_HOST}`);
+  if (!requireInternalAuth(request, response, INTERNAL_KEY)) return;
+  if (request.method === "GET" && requestUrl.pathname === "/health") {
+    writeJson(response, 200, {
+      ok: true,
+      service: "codex-router-devin-cli-forwarder",
+      credential_present: devinCliStatus().configured,
+    });
+    return;
+  }
+  const route = requestUrl.pathname.replace(/^\/v1(?=\/|$)/, "");
+  if (request.method === "POST" && route === "/chat/completions") {
+    await handleChatCompletions(request, response);
+    return;
+  }
+  if (request.method === "GET" && route === "/models") {
+    await handleModels(response);
+    return;
+  }
+  writeJson(response, 404, {
+    error: { type: "proxy_route_not_found", message: "Unsupported Devin CLI route." },
+  });
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+
+if (isMain) {
+  if (!INTERNAL_KEY) throw new Error("MODEL_ROUTER_INTERNAL_KEY is required.");
+  const server = http.createServer((request, response) => {
+    handleRequest(request, response).catch((error) => {
+      const status = httpErrorStatus(error);
+      // Names and codes only: upstream text can carry prompt content, and
+      // bodies never belong in the log.
+      console.error(`[devin-cli] request failed: ${formatErrorChain(error, { messages: false })}`);
+      if (!response.headersSent) {
+        writeJson(response, status, {
+          error: {
+            type: status >= 500 ? "api_error" : "invalid_request_error",
+            message: "The Devin CLI forwarder could not complete the request.",
+          },
+        });
+      } else if (!response.writableEnded) {
+        response.destroy();
+      }
+    });
+  });
+
+  applyKeepAliveTimeouts(server);
+  server.listen(LISTEN_PORT, LISTEN_HOST, () => {
+    console.error("[devin-cli] listening");
+  });
+
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.on(signal, () => server.close(() => process.exit(0)));
+  }
+}

--- a/src/devin-cli-probe.mjs
+++ b/src/devin-cli-probe.mjs
@@ -1,0 +1,138 @@
+// A self-contained check that the Devin CLI provider can reach Cognition's
+// backend with the operator's own session. It talks to the upstream directly
+// rather than through the installed router, so it works before the provider is
+// enabled and tells a tester which of the three layers failed:
+//
+//   1. the credential the Devin CLI wrote
+//   2. the Connect transport and protobuf schemas
+//   3. a real streamed turn, optionally with a forced tool call
+//
+// Everything except step 3 is free. Step 3 spends the account's ACU credits,
+// so it only runs with --live.
+
+import { devinCliStatus } from "./devin-cli-status.mjs";
+import { readDevinSession } from "./devin-cli-session.mjs";
+import { connectServerStream } from "./devin-connect.mjs";
+import {
+  GET_CHAT_MESSAGE,
+  GET_CHAT_MESSAGE_REQUEST,
+  GET_CHAT_MESSAGE_RESPONSE,
+  SERVICE_PATH,
+} from "./devin-proto.mjs";
+import { buildChatMessageRequest } from "./devin-cli-turn.mjs";
+import { listCascadeModels } from "./devin-cli-forwarder.mjs";
+import { installStableFetchTransport } from "./fetch-transport.mjs";
+
+installStableFetchTransport();
+
+const args = process.argv.slice(2);
+const live = args.includes("--live");
+const wantsTools = args.includes("--tools");
+const modelFlag = args.indexOf("--model");
+const requestedModel = modelFlag >= 0 ? args[modelFlag + 1] : undefined;
+
+function line(status, message) {
+  console.log(`${status.padEnd(5)} ${message}`);
+}
+
+function fail(message) {
+  line("FAIL", message);
+  process.exitCode = 1;
+}
+
+async function main() {
+  const status = devinCliStatus();
+  if (!status.configured) {
+    fail(`Devin CLI session: ${status.setup}`);
+    console.log(`      looked in ${status.authPath}`);
+    return;
+  }
+  line("OK", `Devin CLI session found (${status.authPath})`);
+
+  const session = readDevinSession();
+  let models;
+  try {
+    models = await listCascadeModels({ session });
+  } catch (error) {
+    fail(`Model list refused: ${error.message}`);
+    return;
+  }
+  line("OK", `Account advertises ${models.length} model(s)`);
+  for (const model of models.slice(0, 40)) {
+    const notes = [model.premium ? "premium" : undefined, model.beta ? "beta" : undefined]
+      .filter(Boolean)
+      .join(", ");
+    console.log(`      ${model.id}${notes ? `  (${notes})` : ""}`);
+  }
+  if (models.length > 40) console.log(`      ... and ${models.length - 40} more`);
+
+  if (!live) {
+    line("SKIP", "Live turn not attempted. Re-run with --live to spend one turn of ACU credit.");
+    return;
+  }
+
+  const model = requestedModel || models[0]?.id;
+  if (!model) {
+    fail("No model to test; pass --model <uid>.");
+    return;
+  }
+
+  const chat = {
+    model,
+    messages: [
+      { role: "system", content: "You are a test harness. Answer in one short sentence." },
+      { role: "user", content: wantsTools ? "Call the ping tool with value 1." : "Reply with the word: ready" },
+    ],
+  };
+  if (wantsTools) {
+    chat.tools = [
+      {
+        type: "function",
+        function: {
+          name: "ping",
+          description: "Record a numeric value.",
+          parameters: { type: "object", properties: { value: { type: "number" } }, required: ["value"] },
+        },
+      },
+    ];
+    chat.tool_choice = "required";
+  }
+
+  let text = "";
+  let thinking = "";
+  const toolCalls = [];
+  try {
+    for await (const message of connectServerStream({
+      baseUrl: process.env.DEVIN_CASCADE_BASE_URL || session.apiServerUrl,
+      service: SERVICE_PATH,
+      method: GET_CHAT_MESSAGE,
+      token: session.apiKey,
+      requestSchema: GET_CHAT_MESSAGE_REQUEST,
+      responseSchema: GET_CHAT_MESSAGE_RESPONSE,
+      message: buildChatMessageRequest(chat, { token: session.apiKey, modelUid: model }),
+    })) {
+      if (message.deltaText) text += message.deltaText;
+      if (message.deltaThinking) thinking += message.deltaThinking;
+      for (const call of message.deltaToolCalls || []) toolCalls.push(call);
+    }
+  } catch (error) {
+    fail(`Live turn on ${model} failed: ${error.message}`);
+    return;
+  }
+
+  line("OK", `Live turn on ${model} streamed ${text.length} character(s)`);
+  if (thinking) line("OK", `Reasoning channel produced ${thinking.length} character(s)`);
+  if (text.trim()) console.log(`      ${text.trim().slice(0, 300)}`);
+  if (wantsTools) {
+    if (toolCalls.length) {
+      line("OK", `Forced tool call returned: ${toolCalls.map((call) => call.name).join(", ")}`);
+      console.log(`      arguments: ${toolCalls[0].argumentsJson}`);
+    } else {
+      fail("Forced tool call produced no tool call; this model cannot drive a Codex turn.");
+    }
+  }
+}
+
+main().catch((error) => {
+  fail(error.message);
+});

--- a/src/devin-cli-session.mjs
+++ b/src/devin-cli-session.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+
+import { devinCredentialsPath, devinSessionEntry } from "./devin-cli-status.mjs";
+
+// Unlike the Kimi and Grok sessions, the Devin CLI credential carries no
+// expiry: `devin auth login` writes a persistent token and the CLI has no
+// refresh command to drive. There is therefore nothing to renew -- a rejected
+// token means the operator must sign in again, and saying so beats spawning a
+// CLI that cannot help.
+function oauthError(message) {
+  const error = new Error(message);
+  error.code = "oauth_unauthorized";
+  error.status = 401;
+  return error;
+}
+
+export function readDevinSession({ credentialsPath = devinCredentialsPath() } = {}) {
+  let contents;
+  try {
+    contents = readFileSync(credentialsPath, "utf8");
+  } catch {
+    throw oauthError("Devin CLI session is unavailable; run `devin auth login`.");
+  }
+  let session;
+  try {
+    session = devinSessionEntry(contents);
+  } catch (error) {
+    throw oauthError(`Devin CLI session file could not be read plainly: ${error.message}`);
+  }
+  if (!session) {
+    throw oauthError("Devin CLI session is incomplete; run `devin auth login`.");
+  }
+  return session;
+}

--- a/src/devin-cli-status.mjs
+++ b/src/devin-cli-status.mjs
@@ -1,0 +1,76 @@
+import { existsSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { discoveryDisabled } from "./discovery-mode.mjs";
+import { scanTomlDocument, tomlStringValue } from "./toml-structure.mjs";
+
+// The official Devin CLI stores its session in `credentials.toml` after
+// `devin auth login`. The router reads it; it never writes, moves, copies, or
+// deletes another tool's credential file.
+export const DEFAULT_API_SERVER_URL = "https://server.codeium.com";
+
+export function devinCredentialsPath() {
+  if (process.env.DEVIN_CREDENTIALS_PATH) return process.env.DEVIN_CREDENTIALS_PATH;
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || path.join(os.homedir(), "AppData", "Roaming");
+    return path.join(appData, "devin", "credentials.toml");
+  }
+  const dataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), ".local", "share");
+  return path.join(dataHome, "devin", "credentials.toml");
+}
+
+// Parsed with the repository's fail-closed TOML scanner rather than a regex:
+// a duplicate key or a multi-line value is refused instead of guessed at.
+export function devinSessionEntry(contents) {
+  const document = scanTomlDocument(contents);
+  const apiKey = tomlStringValue(document, [], "windsurf_api_key");
+  if (typeof apiKey !== "string" || !apiKey) return undefined;
+  return {
+    apiKey,
+    apiServerUrl: tomlStringValue(document, [], "api_server_url") || DEFAULT_API_SERVER_URL,
+    devinApiUrl: tomlStringValue(document, [], "devin_api_url"),
+  };
+}
+
+// Report only credential presence. Token values never leave this module.
+export function devinCliStatus() {
+  const authPath = devinCredentialsPath();
+  // Defense in depth for --no-discovery: another CLI's session file must not
+  // be opened at all while discovery is off.
+  if (discoveryDisabled()) {
+    return {
+      configured: false,
+      authPath,
+      setup: "Credential discovery is disabled; re-run setup without --no-discovery",
+    };
+  }
+  if (!existsSync(authPath)) {
+    return {
+      configured: false,
+      authPath,
+      setup: "Run `devin auth login` in an interactive terminal",
+    };
+  }
+  try {
+    const session = devinSessionEntry(readFileSync(authPath, "utf8"));
+    if (!session) {
+      return {
+        configured: false,
+        authPath,
+        setup: "Run `devin auth login` again; the Devin session is incomplete",
+      };
+    }
+    return {
+      configured: true,
+      authPath,
+      source: "official Devin CLI session",
+    };
+  } catch {
+    return {
+      configured: false,
+      authPath,
+      setup: "Run `devin auth login` again; the Devin session file is invalid",
+    };
+  }
+}

--- a/src/devin-cli-turn.mjs
+++ b/src/devin-cli-turn.mjs
@@ -1,0 +1,199 @@
+// Translation between the OpenAI Chat Completions request LiteLLM sends this
+// provider and the Cascade `GetChatMessage` call the Devin backend answers.
+// Kept free of I/O so the mapping can be tested without an account.
+
+import { randomUUID } from "node:crypto";
+
+import {
+  CHAT_MESSAGE_REQUEST_TYPE,
+  CHAT_MESSAGE_SOURCE,
+  PLANNER_MODE_DEFAULT,
+  STEP_TYPE_USER_INPUT,
+  STOP_REASON,
+  TRAJECTORY_TYPE_CASCADE,
+} from "./devin-proto.mjs";
+
+const CLIENT_NAME = "windsurf";
+const CLIENT_VERSION = "1.0.0";
+
+// Cascade has no "assistant" message source. The shipped client sends prior
+// model turns as SYSTEM, and a turn built any other way is rejected.
+const SOURCE_BY_ROLE = Object.freeze({
+  user: CHAT_MESSAGE_SOURCE.USER,
+  assistant: CHAT_MESSAGE_SOURCE.SYSTEM,
+  tool: CHAT_MESSAGE_SOURCE.TOOL,
+});
+
+function textFromContent(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((part) => part && (part.type === "text" || typeof part.text === "string"))
+    .map((part) => part.text || "")
+    .join("");
+}
+
+function imagesFromContent(content) {
+  if (!Array.isArray(content)) return [];
+  const images = [];
+  for (const part of content) {
+    const url = part?.type === "image_url" ? part.image_url?.url : undefined;
+    if (typeof url !== "string") continue;
+    const match = /^data:([^;,]+);base64,(.*)$/s.exec(url);
+    if (!match) continue;
+    images.push({ mimeType: match[1], base64Data: match[2] });
+  }
+  return images;
+}
+
+// A tool description block mirroring the shipped client: Cascade models are
+// prompted with their tools inline as well as receiving the structured
+// definitions, and a turn that omits the block calls tools noticeably less.
+export function withToolDescriptions(systemPrompt, tools = []) {
+  const escape = (value) =>
+    String(value).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+  const sections = [];
+  for (const tool of tools) {
+    const name = tool?.function?.name;
+    const description = String(tool?.function?.description || "").trim();
+    if (!name || !description) continue;
+    sections.push(`<tool name="${escape(name)}">\n${escape(description)}\n</tool>`);
+  }
+  if (!sections.length) return systemPrompt;
+  const block = `# tools descriptions\n${sections.join("\n")}`;
+  const trimmed = String(systemPrompt || "").replace(/[\r\n]+$/, "");
+  return trimmed.trim() ? `${trimmed}\n\n${block}` : block;
+}
+
+function toolChoiceFor(toolChoice) {
+  if (!toolChoice) return undefined;
+  if (typeof toolChoice === "string") return { optionName: toolChoice };
+  const name = toolChoice?.function?.name;
+  return name ? { toolName: name } : undefined;
+}
+
+// Cascade accepts images only on the current turn; replaying historical ones
+// fails the whole request with `invalid_argument`. The current turn is every
+// message after the last assistant reply.
+function lastAssistantIndex(messages) {
+  let index = -1;
+  for (let position = 0; position < messages.length; position += 1) {
+    if (messages[position]?.role === "assistant") index = position;
+  }
+  return index;
+}
+
+function promptForMessage(message, { attachImages, newId }) {
+  const source = SOURCE_BY_ROLE[message.role];
+  if (source === undefined) return undefined;
+  const prompt = { messageId: newId(), source, prompt: textFromContent(message.content) };
+
+  const images = attachImages ? imagesFromContent(message.content) : [];
+  if (images.length) prompt.images = images;
+  else if (!attachImages && imagesFromContent(message.content).length) {
+    prompt.prompt = `${prompt.prompt}\n[Image omitted from history]`.trim();
+  }
+
+  if (message.role === "assistant" && Array.isArray(message.tool_calls)) {
+    prompt.toolCalls = message.tool_calls
+      .filter((call) => call?.function?.name)
+      .map((call) => ({
+        id: call.id || newId(),
+        name: call.function.name,
+        argumentsJson: call.function.arguments || "{}",
+      }));
+  }
+  if (message.role === "tool") {
+    prompt.toolCallId = message.tool_call_id || "";
+  }
+  return prompt;
+}
+
+export function buildChatMessageRequest(chat, { token, modelUid, newId = randomUUID } = {}) {
+  const messages = Array.isArray(chat?.messages) ? chat.messages : [];
+  const tools = Array.isArray(chat?.tools) ? chat.tools : [];
+  const systemPrompt = messages
+    .filter((message) => message?.role === "system" || message?.role === "developer")
+    .map((message) => textFromContent(message.content))
+    .join("\n\n");
+
+  const conversation = messages.filter(
+    (message) => message?.role !== "system" && message?.role !== "developer",
+  );
+  const boundary = lastAssistantIndex(conversation);
+
+  const request = {
+    metadata: {
+      apiKey: token,
+      ideName: CLIENT_NAME,
+      ideVersion: CLIENT_VERSION,
+      extensionName: CLIENT_NAME,
+      extensionVersion: CLIENT_VERSION,
+      locale: "en",
+      os: { darwin: "mac", win32: "win" }[process.platform] || "linux",
+    },
+    prompt: withToolDescriptions(systemPrompt, tools),
+    chatModelUid: modelUid,
+    requestType: CHAT_MESSAGE_REQUEST_TYPE.CASCADE,
+    plannerMode: PLANNER_MODE_DEFAULT,
+    cascadeId: newId(),
+    executionId: newId(),
+    promptId: newId(),
+    trajectoryReference: {
+      trajectoryId: newId(),
+      trajectoryType: TRAJECTORY_TYPE_CASCADE,
+      stepType: STEP_TYPE_USER_INPUT,
+    },
+    configuration: {
+      numCompletions: 1,
+      maxTokens: Number(chat?.max_tokens) > 0 ? Number(chat.max_tokens) : 128_000,
+      maxNewlines: 400,
+      temperature: typeof chat?.temperature === "number" ? chat.temperature : 1,
+      topK: 40,
+      topP: 0.95,
+    },
+    chatMessagePrompts: [],
+  };
+
+  for (let index = 0; index < conversation.length; index += 1) {
+    const prompt = promptForMessage(conversation[index], {
+      attachImages: index > boundary,
+      newId,
+    });
+    if (prompt) request.chatMessagePrompts.push(prompt);
+  }
+
+  if (tools.length) {
+    request.tools = tools
+      .filter((tool) => tool?.function?.name)
+      .map((tool) => ({
+        name: tool.function.name,
+        description: String(tool.function.description || ""),
+        jsonSchemaString: JSON.stringify(tool.function.parameters ?? { type: "object", properties: {} }),
+      }));
+  }
+  const choice = toolChoiceFor(chat?.tool_choice);
+  if (choice) request.toolChoice = choice;
+  if (chat?.parallel_tool_calls === false) request.disableParallelToolCalls = true;
+
+  return request;
+}
+
+export function finishReasonFor(stopReason, sawToolCall) {
+  if (sawToolCall || stopReason === STOP_REASON.FUNCTION_CALL) return "tool_calls";
+  if (stopReason === STOP_REASON.MAX_TOKENS) return "length";
+  if (stopReason === STOP_REASON.CONTENT_FILTER) return "content_filter";
+  return "stop";
+}
+
+export function usageFrom(stats) {
+  if (!stats) return undefined;
+  const prompt = Number(stats.inputTokens || 0);
+  const completion = Number(stats.outputTokens || 0);
+  return {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: prompt + completion,
+    prompt_tokens_details: { cached_tokens: Number(stats.cacheReadTokens || 0) },
+  };
+}

--- a/src/devin-connect.mjs
+++ b/src/devin-connect.mjs
@@ -1,0 +1,167 @@
+// A Connect-protocol client for the two RPCs the Devin CLI provider needs.
+//
+// Connect (connectrpc.com) is plain HTTP POST. Unary calls send one serialized
+// message and get one back; server-streaming calls send one message and read a
+// sequence of length-prefixed envelopes. That is small enough to implement
+// directly, which keeps the router's dependency list where it is.
+
+import { decodeMessage, encodeMessage } from "./protobuf-wire.mjs";
+
+const CONNECT_VERSION = "1";
+const END_STREAM_FLAG = 0x02;
+
+function connectError(message, { status = 502, code = "devin_upstream_error" } = {}) {
+  const error = new Error(message);
+  error.status = status;
+  error.code = code;
+  return error;
+}
+
+// Connect maps its error codes onto HTTP status codes. Preserving the
+// distinction matters upstream of here: the router retries a 429 or a 5xx and
+// must not retry an `invalid_argument`.
+const STATUS_BY_CONNECT_CODE = Object.freeze({
+  unauthenticated: 401,
+  permission_denied: 403,
+  not_found: 404,
+  invalid_argument: 400,
+  failed_precondition: 400,
+  resource_exhausted: 429,
+  unavailable: 503,
+  deadline_exceeded: 504,
+  internal: 502,
+  unknown: 502,
+});
+
+export function connectAuthorization(token) {
+  // Transcribed from the shipped client: the token is repeated either side of
+  // a hyphen and sent as a `Basic` credential without base64 encoding.
+  return `Basic ${token}-${token}`;
+}
+
+function requestUrl(baseUrl, service, method) {
+  return `${String(baseUrl).replace(/\/+$/, "")}/${service}/${method}`;
+}
+
+async function failureFromResponse(response) {
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    body = "";
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    parsed = undefined;
+  }
+  const code = typeof parsed?.code === "string" ? parsed.code : undefined;
+  const message = parsed?.message || body.slice(0, 500) || `HTTP ${response.status}`;
+  return connectError(`Devin upstream refused the request: ${message}`, {
+    status: STATUS_BY_CONNECT_CODE[code] || response.status || 502,
+    code: code ? `devin_${code}` : "devin_upstream_error",
+  });
+}
+
+export async function connectUnary({
+  baseUrl,
+  service,
+  method,
+  token,
+  requestSchema,
+  responseSchema,
+  message,
+  signal,
+  fetchImpl = fetch,
+}) {
+  const response = await fetchImpl(requestUrl(baseUrl, service, method), {
+    method: "POST",
+    signal,
+    headers: {
+      "content-type": "application/proto",
+      "connect-protocol-version": CONNECT_VERSION,
+      authorization: connectAuthorization(token),
+    },
+    body: encodeMessage(requestSchema, message),
+  });
+  if (!response.ok) throw await failureFromResponse(response);
+  const body = new Uint8Array(await response.arrayBuffer());
+  return decodeMessage(responseSchema, body);
+}
+
+function envelope(payload) {
+  const framed = new Uint8Array(payload.length + 5);
+  framed[0] = 0;
+  new DataView(framed.buffer).setUint32(1, payload.length, false);
+  framed.set(payload, 5);
+  return framed;
+}
+
+// Yields decoded response messages until the upstream sends its end-of-stream
+// envelope. A Connect stream reports failure *inside* that final envelope with
+// HTTP 200 already sent, so the terminator is inspected rather than ignored.
+export async function* connectServerStream({
+  baseUrl,
+  service,
+  method,
+  token,
+  requestSchema,
+  responseSchema,
+  message,
+  signal,
+  fetchImpl = fetch,
+}) {
+  const response = await fetchImpl(requestUrl(baseUrl, service, method), {
+    method: "POST",
+    signal,
+    headers: {
+      "content-type": "application/connect+proto",
+      "connect-protocol-version": CONNECT_VERSION,
+      authorization: connectAuthorization(token),
+    },
+    body: envelope(encodeMessage(requestSchema, message)),
+    duplex: "half",
+  });
+  if (!response.ok) throw await failureFromResponse(response);
+  if (!response.body) throw connectError("Devin upstream returned no response stream.");
+
+  let buffered = new Uint8Array(0);
+  for await (const chunk of response.body) {
+    const incoming = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+    const merged = new Uint8Array(buffered.length + incoming.length);
+    merged.set(buffered, 0);
+    merged.set(incoming, buffered.length);
+    buffered = merged;
+
+    for (;;) {
+      if (buffered.length < 5) break;
+      const view = new DataView(buffered.buffer, buffered.byteOffset, buffered.byteLength);
+      const flags = buffered[0];
+      const length = view.getUint32(1, false);
+      if (buffered.length < length + 5) break;
+      const payload = buffered.subarray(5, length + 5);
+      buffered = buffered.subarray(length + 5);
+      if ((flags & END_STREAM_FLAG) !== 0) {
+        let terminator;
+        try {
+          terminator = JSON.parse(new TextDecoder().decode(payload) || "{}");
+        } catch {
+          terminator = {};
+        }
+        if (terminator?.error) {
+          const code = terminator.error.code;
+          throw connectError(
+            `Devin upstream ended the stream: ${terminator.error.message || code || "unknown error"}`,
+            {
+              status: STATUS_BY_CONNECT_CODE[code] || 502,
+              code: code ? `devin_${code}` : "devin_upstream_error",
+            },
+          );
+        }
+        return;
+      }
+      yield decodeMessage(responseSchema, payload);
+    }
+  }
+}

--- a/src/devin-proto.mjs
+++ b/src/devin-proto.mjs
@@ -1,0 +1,186 @@
+// Wire schemas for the subset of `exa.api_server_pb.ApiServerService` the Devin
+// CLI provider speaks. Field numbers are transcribed from the descriptor set
+// embedded in the shipped `devin` binary, which is the only published source
+// for them -- Cognition documents no model API.
+//
+// Only fields the router reads or writes are listed. Everything else on the
+// wire decodes to nothing, which is deliberate: the upstream adds fields
+// without notice and this provider must not fail a turn over one.
+
+export const CHAT_MESSAGE_SOURCE = Object.freeze({
+  UNSPECIFIED: 0,
+  USER: 1,
+  SYSTEM: 2,
+  UNKNOWN: 3,
+  TOOL: 4,
+  SYSTEM_PROMPT: 5,
+});
+
+export const CHAT_MESSAGE_REQUEST_TYPE = Object.freeze({
+  UNSPECIFIED: 0,
+  GENERAL: 1,
+  CASCADE: 5,
+});
+
+export const STOP_REASON = Object.freeze({
+  UNSPECIFIED: 0,
+  INCOMPLETE: 1,
+  STOP_PATTERN: 2,
+  MAX_TOKENS: 3,
+  PARTIAL: 9,
+  FUNCTION_CALL: 10,
+  CONTENT_FILTER: 11,
+  ERROR: 13,
+});
+
+export const TRAJECTORY_TYPE_CASCADE = 4;
+export const STEP_TYPE_USER_INPUT = 14;
+export const PLANNER_MODE_DEFAULT = 1;
+
+export const METADATA = Object.freeze({
+  ideName: { no: 1, type: "string" },
+  extensionVersion: { no: 2, type: "string" },
+  apiKey: { no: 3, type: "string" },
+  locale: { no: 4, type: "string" },
+  os: { no: 5, type: "string" },
+  ideVersion: { no: 7, type: "string" },
+  extensionName: { no: 12, type: "string" },
+  deviceFingerprint: { no: 24, type: "string" },
+  f: { no: 31, type: "string" },
+});
+
+export const IMAGE_DATA = Object.freeze({
+  base64Data: { no: 1, type: "string" },
+  mimeType: { no: 2, type: "string" },
+  caption: { no: 3, type: "string" },
+});
+
+export const CHAT_TOOL_CALL = Object.freeze({
+  id: { no: 1, type: "string" },
+  name: { no: 2, type: "string" },
+  argumentsJson: { no: 3, type: "string" },
+  invalidJsonStr: { no: 4, type: "string" },
+  invalidJsonErr: { no: 5, type: "string" },
+  isCustomToolCall: { no: 6, type: "bool" },
+});
+
+export const CHAT_MESSAGE_PROMPT = Object.freeze({
+  messageId: { no: 1, type: "string" },
+  source: { no: 2, type: "enum" },
+  prompt: { no: 3, type: "string" },
+  numTokens: { no: 4, type: "uint32" },
+  toolCalls: { no: 6, type: "message", message: CHAT_TOOL_CALL, repeated: true },
+  toolCallId: { no: 7, type: "string" },
+  toolResultIsError: { no: 9, type: "bool" },
+  images: { no: 10, type: "message", message: IMAGE_DATA, repeated: true },
+  thinking: { no: 11, type: "string" },
+  signature: { no: 12, type: "string" },
+  thinkingRedacted: { no: 13, type: "bool" },
+  outputId: { no: 15, type: "string" },
+  thinkingId: { no: 16, type: "string" },
+  signatureType: { no: 18, type: "string" },
+});
+
+export const CHAT_TOOL_DEFINITION = Object.freeze({
+  name: { no: 1, type: "string" },
+  description: { no: 2, type: "string" },
+  jsonSchemaString: { no: 3, type: "string" },
+  strict: { no: 12, type: "bool" },
+});
+
+// `choice` is a oneof; writing both members would put two fields on the wire
+// and let the upstream pick. Callers set exactly one.
+export const CHAT_TOOL_CHOICE = Object.freeze({
+  optionName: { no: 1, type: "string" },
+  toolName: { no: 2, type: "string" },
+});
+
+export const COMPLETION_CONFIGURATION = Object.freeze({
+  numCompletions: { no: 1, type: "uint64" },
+  maxTokens: { no: 2, type: "uint64" },
+  maxNewlines: { no: 3, type: "uint64" },
+  temperature: { no: 5, type: "double" },
+  topK: { no: 7, type: "uint64" },
+  topP: { no: 8, type: "double" },
+  stopPatterns: { no: 9, type: "string", repeated: true },
+});
+
+export const TRAJECTORY_REFERENCE = Object.freeze({
+  trajectoryId: { no: 1, type: "string" },
+  stepIndex: { no: 2, type: "int32" },
+  trajectoryType: { no: 3, type: "enum" },
+  stepType: { no: 4, type: "enum" },
+});
+
+export const GET_CHAT_MESSAGE_REQUEST = Object.freeze({
+  metadata: { no: 1, type: "message", message: METADATA },
+  prompt: { no: 2, type: "string" },
+  chatMessagePrompts: { no: 3, type: "message", message: CHAT_MESSAGE_PROMPT, repeated: true },
+  requestType: { no: 7, type: "enum" },
+  configuration: { no: 8, type: "message", message: COMPLETION_CONFIGURATION },
+  tools: { no: 10, type: "message", message: CHAT_TOOL_DEFINITION, repeated: true },
+  disableParallelToolCalls: { no: 11, type: "bool" },
+  toolChoice: { no: 12, type: "message", message: CHAT_TOOL_CHOICE },
+  chatModelName: { no: 14, type: "string" },
+  trajectoryReference: { no: 15, type: "message", message: TRAJECTORY_REFERENCE },
+  cascadeId: { no: 16, type: "string" },
+  promptId: { no: 17, type: "string" },
+  plannerMode: { no: 20, type: "enum" },
+  chatModelUid: { no: 21, type: "string" },
+  executionId: { no: 22, type: "string" },
+});
+
+export const MODEL_USAGE_STATS = Object.freeze({
+  inputTokens: { no: 2, type: "uint64" },
+  outputTokens: { no: 3, type: "uint64" },
+  cacheWriteTokens: { no: 4, type: "uint64" },
+  cacheReadTokens: { no: 5, type: "uint64" },
+  modelUid: { no: 9, type: "string" },
+});
+
+export const GET_CHAT_MESSAGE_RESPONSE = Object.freeze({
+  messageId: { no: 1, type: "string" },
+  deltaText: { no: 3, type: "string" },
+  deltaTokens: { no: 4, type: "uint32" },
+  stopReason: { no: 5, type: "enum" },
+  deltaToolCalls: { no: 6, type: "message", message: CHAT_TOOL_CALL, repeated: true },
+  usage: { no: 7, type: "message", message: MODEL_USAGE_STATS },
+  redact: { no: 8, type: "bool" },
+  deltaThinking: { no: 9, type: "string" },
+  deltaSignature: { no: 10, type: "string" },
+  thinkingRedacted: { no: 11, type: "bool" },
+  creditCost: { no: 14, type: "int32" },
+  outputId: { no: 15, type: "string" },
+  thinkingId: { no: 16, type: "string" },
+  requestId: { no: 17, type: "string" },
+  deltaSignatureType: { no: 21, type: "string" },
+  actualModelUid: { no: 23, type: "string" },
+});
+
+export const MODEL_INFO = Object.freeze({
+  modelName: { no: 1, type: "string" },
+  maxOutputTokens: { no: 8, type: "int32" },
+});
+
+export const CLIENT_MODEL_CONFIG = Object.freeze({
+  label: { no: 1, type: "string" },
+  disabled: { no: 4, type: "bool" },
+  supportsImages: { no: 5, type: "bool" },
+  isPremium: { no: 7, type: "bool" },
+  isBeta: { no: 9, type: "bool" },
+  maxTokens: { no: 18, type: "int32" },
+  modelUid: { no: 22, type: "string" },
+  description: { no: 27, type: "string" },
+});
+
+export const GET_CASCADE_MODEL_CONFIGS_REQUEST = Object.freeze({
+  metadata: { no: 1, type: "message", message: METADATA },
+});
+
+export const GET_CASCADE_MODEL_CONFIGS_RESPONSE = Object.freeze({
+  clientModelConfigs: { no: 1, type: "message", message: CLIENT_MODEL_CONFIG, repeated: true },
+});
+
+export const SERVICE_PATH = "exa.api_server_pb.ApiServerService";
+export const GET_CHAT_MESSAGE = "GetChatMessage";
+export const GET_CASCADE_MODEL_CONFIGS = "GetCascadeModelConfigs";

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -150,6 +150,7 @@ export const DEFAULT_PORTS = Object.freeze({
   router: 4202,
   api: 4203,
   grokOauth: 4208,
+  devinCli: 4210,
 });
 
 // Ports used before the BrlAPI-safe defaults shipped. They remain recognized
@@ -181,6 +182,7 @@ export const PORTS = {
     process.env.CODEX_ROUTER_API_PORT || process.env.KIMI_API_FORWARD_PORT || DEFAULT_PORTS.api,
   ),
   grokOauth: port("MODEL_ROUTER_GROK_OAUTH_PORT", DEFAULT_PORTS.grokOauth),
+  devinCli: port("MODEL_ROUTER_DEVIN_CLI_PORT", DEFAULT_PORTS.devinCli),
 };
 
 export function loopback(portNumber, suffix = "") {

--- a/src/protobuf-wire.mjs
+++ b/src/protobuf-wire.mjs
@@ -1,0 +1,226 @@
+// A minimal protobuf reader/writer for the handful of messages the Devin CLI
+// provider needs. The repository ships two runtime dependencies and hand-rolls
+// its other structural parsers (`yaml-structure.mjs`, `toml-structure.mjs`), so
+// a wire codec small enough to audit in one sitting is preferred over a
+// general-purpose protobuf library.
+//
+// Schemas are declarative field tables:
+//   { fieldName: { no: 3, type: "string" } }
+// with `repeated: true` for repeated fields and `message: SCHEMA` for nested
+// ones. Unknown fields decode into nothing and encode from nothing: this codec
+// only has to round-trip what the router itself puts on the wire.
+
+const WIRE_VARINT = 0;
+const WIRE_FIXED64 = 1;
+const WIRE_LENGTH = 2;
+const WIRE_FIXED32 = 5;
+
+const VARINT_TYPES = new Set(["bool", "enum", "int32", "int64", "uint32", "uint64", "sint32", "sint64"]);
+
+class Writer {
+  constructor() {
+    this.chunks = [];
+  }
+
+  bytes(value) {
+    this.chunks.push(value);
+    return this;
+  }
+
+  varint(value) {
+    let remaining = typeof value === "bigint" ? value : BigInt(Math.trunc(Number(value) || 0));
+    if (remaining < 0n) remaining += 1n << 64n;
+    const out = [];
+    do {
+      let byte = Number(remaining & 0x7fn);
+      remaining >>= 7n;
+      if (remaining > 0n) byte |= 0x80;
+      out.push(byte);
+    } while (remaining > 0n);
+    return this.bytes(Uint8Array.from(out));
+  }
+
+  tag(fieldNumber, wireType) {
+    return this.varint(fieldNumber * 8 + wireType);
+  }
+
+  finish() {
+    let total = 0;
+    for (const chunk of this.chunks) total += chunk.length;
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      out.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return out;
+  }
+}
+
+function zigzag(value, bits) {
+  const wide = BigInt(Math.trunc(Number(value) || 0));
+  const limit = BigInt(bits);
+  return BigInt.asUintN(bits, (wide << 1n) ^ (wide >> (limit - 1n)));
+}
+
+function unzigzag(value) {
+  return (value >> 1n) ^ -(value & 1n);
+}
+
+function writeScalar(writer, fieldNumber, type, value) {
+  if (VARINT_TYPES.has(type)) {
+    writer.tag(fieldNumber, WIRE_VARINT);
+    if (type === "bool") return writer.varint(value ? 1 : 0);
+    if (type === "sint32") return writer.varint(zigzag(value, 32));
+    if (type === "sint64") return writer.varint(zigzag(value, 64));
+    return writer.varint(value);
+  }
+  if (type === "string") {
+    const encoded = new TextEncoder().encode(String(value));
+    writer.tag(fieldNumber, WIRE_LENGTH).varint(encoded.length);
+    return writer.bytes(encoded);
+  }
+  if (type === "bytes") {
+    const encoded = value instanceof Uint8Array ? value : Uint8Array.from(value || []);
+    writer.tag(fieldNumber, WIRE_LENGTH).varint(encoded.length);
+    return writer.bytes(encoded);
+  }
+  if (type === "double") {
+    const buffer = new Uint8Array(8);
+    new DataView(buffer.buffer).setFloat64(0, Number(value) || 0, true);
+    writer.tag(fieldNumber, WIRE_FIXED64);
+    return writer.bytes(buffer);
+  }
+  if (type === "float") {
+    const buffer = new Uint8Array(4);
+    new DataView(buffer.buffer).setFloat32(0, Number(value) || 0, true);
+    writer.tag(fieldNumber, WIRE_FIXED32);
+    return writer.bytes(buffer);
+  }
+  throw new Error(`protobuf: unsupported field type ${type}`);
+}
+
+export function encodeMessage(schema, value) {
+  const writer = new Writer();
+  if (!value || typeof value !== "object") return writer.finish();
+  for (const [name, field] of Object.entries(schema)) {
+    const held = value[name];
+    if (held === undefined || held === null) continue;
+    const items = field.repeated ? (Array.isArray(held) ? held : [held]) : [held];
+    for (const item of items) {
+      if (item === undefined || item === null) continue;
+      if (field.type === "message") {
+        const nested = encodeMessage(field.message, item);
+        writer.tag(field.no, WIRE_LENGTH).varint(nested.length).bytes(nested);
+        continue;
+      }
+      writeScalar(writer, field.no, field.type, item);
+    }
+  }
+  return writer.finish();
+}
+
+class Reader {
+  constructor(buffer) {
+    this.buffer = buffer;
+    this.offset = 0;
+  }
+
+  get done() {
+    return this.offset >= this.buffer.length;
+  }
+
+  varint() {
+    let result = 0n;
+    let shift = 0n;
+    for (;;) {
+      if (this.done) throw new Error("protobuf: truncated varint");
+      const byte = this.buffer[this.offset++];
+      result |= BigInt(byte & 0x7f) << shift;
+      if ((byte & 0x80) === 0) return result;
+      shift += 7n;
+      if (shift > 63n) throw new Error("protobuf: varint overflow");
+    }
+  }
+
+  slice(length) {
+    if (this.offset + length > this.buffer.length) throw new Error("protobuf: truncated field");
+    const out = this.buffer.subarray(this.offset, this.offset + length);
+    this.offset += length;
+    return out;
+  }
+}
+
+function readScalar(reader, wireType, type) {
+  if (wireType === WIRE_VARINT) {
+    const raw = reader.varint();
+    if (type === "bool") return raw !== 0n;
+    if (type === "sint32" || type === "sint64") return Number(unzigzag(raw));
+    if (type === "int32") return Number(BigInt.asIntN(32, raw));
+    if (type === "int64") return Number(BigInt.asIntN(64, raw));
+    return Number(raw);
+  }
+  if (wireType === WIRE_LENGTH) {
+    const bytes = reader.slice(Number(reader.varint()));
+    if (type === "string") return new TextDecoder().decode(bytes);
+    return Uint8Array.from(bytes);
+  }
+  if (wireType === WIRE_FIXED64) {
+    const bytes = reader.slice(8);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, 8);
+    return type === "double" ? view.getFloat64(0, true) : Number(view.getBigUint64(0, true));
+  }
+  if (wireType === WIRE_FIXED32) {
+    const bytes = reader.slice(4);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, 4);
+    return type === "float" ? view.getFloat32(0, true) : view.getUint32(0, true);
+  }
+  throw new Error(`protobuf: unsupported wire type ${wireType}`);
+}
+
+function skip(reader, wireType) {
+  if (wireType === WIRE_VARINT) return void reader.varint();
+  if (wireType === WIRE_LENGTH) return void reader.slice(Number(reader.varint()));
+  if (wireType === WIRE_FIXED64) return void reader.slice(8);
+  if (wireType === WIRE_FIXED32) return void reader.slice(4);
+  throw new Error(`protobuf: unsupported wire type ${wireType}`);
+}
+
+export function decodeMessage(schema, buffer) {
+  const byNumber = new Map();
+  for (const [name, field] of Object.entries(schema)) byNumber.set(field.no, { name, field });
+  const reader = new Reader(buffer instanceof Uint8Array ? buffer : Uint8Array.from(buffer || []));
+  const out = {};
+  while (!reader.done) {
+    const tag = Number(reader.varint());
+    const fieldNumber = tag >>> 3;
+    const wireType = tag & 7;
+    const known = byNumber.get(fieldNumber);
+    // An unknown field is expected traffic, not a fault: the upstream adds
+    // fields without notice and a strict decoder would fail whole turns.
+    if (!known) {
+      skip(reader, wireType);
+      continue;
+    }
+    const { name, field } = known;
+    let value;
+    if (field.type === "message") {
+      if (wireType !== WIRE_LENGTH) {
+        skip(reader, wireType);
+        continue;
+      }
+      value = decodeMessage(field.message, reader.slice(Number(reader.varint())));
+    } else if (field.repeated && VARINT_TYPES.has(field.type) && wireType === WIRE_LENGTH) {
+      // A packed repeated scalar arrives as one length-delimited run.
+      const packed = new Reader(reader.slice(Number(reader.varint())));
+      const collected = out[name] || (out[name] = []);
+      while (!packed.done) collected.push(readScalar(packed, WIRE_VARINT, field.type));
+      continue;
+    } else {
+      value = readScalar(reader, wireType, field.type);
+    }
+    if (field.repeated) (out[name] || (out[name] = [])).push(value);
+    else out[name] = value;
+  }
+  return out;
+}

--- a/src/provider-onboarding.mjs
+++ b/src/provider-onboarding.mjs
@@ -9,6 +9,7 @@ import {
   grokCliPreflight,
 } from "./grok-cli.mjs";
 import { cliSessionPath, cliSessionStatus } from "./cli-session-credential.mjs";
+import { devinCliStatus } from "./devin-cli-status.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { KIMI_CLI_NPM_PACKAGE } from "./kimi-oauth-onboarding.mjs";
 import { MODELS, PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
@@ -55,6 +56,18 @@ const SIGN_IN_CLIS = Object.freeze({
     // to be handed a real terminal.
     needsTerminal: true,
   },
+  // Devin ships no npm package: it is a Rust binary installed by Cognition's
+  // own script or Homebrew cask. `installCommand` is what the tray offers
+  // instead of an npm install it cannot perform.
+  "devin-cli": {
+    executable: "devin",
+    loginArgs: ["auth", "login"],
+    candidates: [path.join(os.homedir(), ".local", "bin", "devin")],
+    installCommand: "curl -fsSL https://cli.devin.ai/install.sh | bash",
+    // `devin auth login` draws a full-screen terminal interface, so a piped
+    // stdio pair kills it before it opens the browser.
+    needsTerminal: true,
+  },
 });
 
 function commandPath(name) {
@@ -93,6 +106,7 @@ export function oauthLoginArgs(providerId) {
 function oauthConfigured(providerId) {
   if (providerId === "kimi-oauth") return kimiOAuthStatus().configured;
   if (providerId === "grok-oauth") return grokOAuthStatus().configured;
+  if (providerId === "devin-cli") return devinCliStatus().configured;
   const provider = PROVIDERS.get(providerId);
   return provider ? cliSessionStatus(provider).configured : false;
 }
@@ -194,6 +208,14 @@ export function installOauthCli(providerId) {
     }
   } else if (oauthCliPath(providerId)) {
     return;
+  }
+  // Not every official CLI is an npm package. Naming the vendor's own
+  // installer is honest; running it unattended from the tray would fetch and
+  // execute a remote script the operator never saw.
+  if (!cli.npmPackage) {
+    throw new Error(
+      `The ${cli.executable} CLI is not installed and is not distributed through npm. Install it with: ${cli.installCommand}`,
+    );
   }
   npmInstallGlobal(cli.npmPackage, { label: `the official ${cli.executable} CLI` });
   if (providerId === "grok-oauth") {

--- a/src/providers.mjs
+++ b/src/providers.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import { cliSessionDescriptor } from "./cli-session-credential.mjs";
+import { devinCliStatus } from "./devin-cli-status.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
@@ -25,6 +26,7 @@ import {
 const SIGN_IN_STATUS = Object.freeze({
   "kimi-oauth": { status: kimiOAuthStatus, setup: "run `kimi login`" },
   "grok-oauth": { status: grokOAuthStatus, setup: "run `grok login --oauth`" },
+  "devin-cli": { status: devinCliStatus, setup: "run `devin auth login`" },
 });
 
 function configured(provider) {

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -17,6 +17,7 @@ import {
 import { waitForHealth as pollHealth } from "./health-probe.mjs";
 import { gatewaySupervisorLimits, superviseGateway } from "./gateway-supervisor.mjs";
 import { writeLiteLlmConfig } from "./litellm-config.mjs";
+import { MODELS } from "./model-registry.mjs";
 import { readLocalModelSelection } from "./local-models.mjs";
 import { spawnableCommand } from "./spawnable-command.mjs";
 import { ensureOllamaHeadless } from "./ollama-runtime.mjs";
@@ -95,6 +96,21 @@ if (readLocalModelSelection().enabled.length) {
   }
 }
 
+// Same rule, one layer up: a curated model is what gives a provider a gateway
+// route, so it is also what makes that provider's own forwarder worth a
+// process and a port. `writeLiteLlmConfig()` above emits the
+// `DEVIN_CLI_FORWARD_BASE_URL` route from this same MODELS array on this same
+// boot, so the route and the listener cannot disagree -- no curated Devin
+// model means no route to the port and nothing bound to it. Devin ships
+// catalog-only (`bin/curate-models devin-cli`), so an operator who never asked
+// for it pays nothing: no fourth child, no fourth port, no fourth health wait.
+//
+// The stored credential is deliberately *not* the gate. Someone who curated a
+// model but has not run `devin auth login` should get the forwarder's 401
+// naming that command, not a bare connection error from a port nobody is
+// listening on.
+const devinCliRouted = MODELS.some((model) => model.provider === "devin-cli");
+
 const commonEnv = {
   MODEL_ROUTER_TARGET: TARGET,
   MODEL_ROUTER_STATE_DIR: STATE_DIR,
@@ -114,6 +130,8 @@ const commonEnv = {
   MODEL_ROUTER_PORT: String(PORTS.router),
   MODEL_ROUTER_GROK_OAUTH_PORT: String(PORTS.grokOauth),
   GROK_OAUTH_FORWARD_BASE_URL: loopback(PORTS.grokOauth, "/v1"),
+  MODEL_ROUTER_DEVIN_CLI_PORT: String(PORTS.devinCli),
+  DEVIN_CLI_FORWARD_BASE_URL: loopback(PORTS.devinCli, "/v1"),
   MODEL_ROUTER_QUIET: "1",
   CODEX_ROUTER_CALLER_KEY: callerKey,
   CODEX_ROUTER_INTERNAL_KEY: internalKey,
@@ -210,6 +228,9 @@ async function main() {
   const kimiForwarder = run(process.execPath, [path.join(SOURCE_ROOT, "src", "oauth-forwarder.mjs")]);
   const api = run(process.execPath, [path.join(SOURCE_ROOT, "src", "api-forwarder.mjs")]);
   const grokForwarder = run(process.execPath, [path.join(SOURCE_ROOT, "src", "grok-oauth-forwarder.mjs")]);
+  const devinForwarder = devinCliRouted
+    ? run(process.execPath, [path.join(SOURCE_ROOT, "src", "devin-cli-forwarder.mjs")])
+    : undefined;
   await Promise.all([
     waitForHealth(
       "OAuth forwarder",
@@ -235,6 +256,22 @@ async function main() {
       undefined,
       grokForwarder,
     ),
+    // Spread rather than a conditional inside the wait: an unrouted Devin adds
+    // no entry at all, so it cannot add latency. A routed one is waited on
+    // exactly as the other three are, and a forwarder that cannot bind still
+    // aborts startup by name instead of being skipped quietly.
+    ...(devinForwarder
+      ? [
+        waitForHealth(
+          "Devin CLI forwarder",
+          loopback(PORTS.devinCli, "/health"),
+          { Authorization: `Bearer ${internalKey}` },
+          30_000,
+          undefined,
+          devinForwarder,
+        ),
+      ]
+      : []),
   ]);
 
   const startGateway = () =>
@@ -283,6 +320,13 @@ async function main() {
     waitForExit(kimiForwarder, "OAuth forwarder"),
     waitForExit(api, "API forwarder"),
     waitForExit(grokForwarder, "Grok OAuth forwarder"),
+    // Only when it is actually running. A forwarder of ours that dies is a bug
+    // report, and the rule above is that the service exits so the OS supervisor
+    // rebuilds it -- leaving this one out of the race would instead strand a
+    // Devin user on connection errors with nothing to notice them. An install
+    // that never spawned it adds no entry, so this cannot end anyone else's
+    // session.
+    ...(devinForwarder ? [waitForExit(devinForwarder, "Devin CLI forwarder")] : []),
     superviseGateway({
       label: "LiteLLM gateway",
       child: gateway,

--- a/test/devin-cli-status.test.mjs
+++ b/test/devin-cli-status.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { devinCredentialsPath, devinSessionEntry } from "../src/devin-cli-status.mjs";
+import { readDevinSession } from "../src/devin-cli-session.mjs";
+
+function withCredentials(contents, run) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "devin-cred-"));
+  const file = path.join(directory, "credentials.toml");
+  if (contents !== null) writeFileSync(file, contents);
+  const previous = process.env.DEVIN_CREDENTIALS_PATH;
+  process.env.DEVIN_CREDENTIALS_PATH = file;
+  try {
+    return run(file);
+  } finally {
+    if (previous === undefined) delete process.env.DEVIN_CREDENTIALS_PATH;
+    else process.env.DEVIN_CREDENTIALS_PATH = previous;
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("reads the token and server the Devin CLI wrote", () => {
+  const session = devinSessionEntry(
+    [
+      'windsurf_api_key = "devin-session-token$abc"',
+      'api_server_url = "https://server.codeium.com"',
+      'devin_api_url = "https://api.devin.ai"',
+    ].join("\n"),
+  );
+  assert.equal(session.apiKey, "devin-session-token$abc");
+  assert.equal(session.apiServerUrl, "https://server.codeium.com");
+  assert.equal(session.devinApiUrl, "https://api.devin.ai");
+});
+
+test("falls back to the documented API server when the file omits one", () => {
+  const session = devinSessionEntry('windsurf_api_key = "devin-session-token$abc"');
+  assert.equal(session.apiServerUrl, "https://server.codeium.com");
+});
+
+test("treats a credentials file without a key as unconfigured, not as an empty session", () => {
+  assert.equal(devinSessionEntry('api_server_url = "https://server.codeium.com"'), undefined);
+  assert.equal(devinSessionEntry('windsurf_api_key = ""'), undefined);
+});
+
+// The structural scanner is fail-closed on purpose: a duplicate assignment has
+// no single right answer, and guessing would pick a credential nobody chose.
+test("refuses a duplicated key rather than picking one", () => {
+  assert.throws(
+    () => devinSessionEntry('windsurf_api_key = "a"\nwindsurf_api_key = "b"'),
+    /duplicate/i,
+  );
+});
+
+test("honours DEVIN_CREDENTIALS_PATH so a test never reads the operator's own session", () => {
+  withCredentials('windsurf_api_key = "devin-session-token$xyz"', (file) => {
+    assert.equal(devinCredentialsPath(), file);
+    assert.equal(readDevinSession().apiKey, "devin-session-token$xyz");
+  });
+});
+
+test("reports a missing session as an auth failure naming the login command", () => {
+  withCredentials(null, () => {
+    assert.throws(readDevinSession, (error) => {
+      assert.equal(error.code, "oauth_unauthorized");
+      assert.equal(error.status, 401);
+      assert.match(error.message, /devin auth login/);
+      return true;
+    });
+  });
+});
+
+test("reports an unreadable session as an auth failure instead of throwing a parse error", () => {
+  withCredentials('windsurf_api_key = "a"\nwindsurf_api_key = "b"', () => {
+    assert.throws(readDevinSession, (error) => {
+      assert.equal(error.code, "oauth_unauthorized");
+      return true;
+    });
+  });
+});

--- a/test/devin-cli-turn.test.mjs
+++ b/test/devin-cli-turn.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CHAT_MESSAGE_SOURCE, STOP_REASON } from "../src/devin-proto.mjs";
+import {
+  buildChatMessageRequest,
+  finishReasonFor,
+  usageFrom,
+  withToolDescriptions,
+} from "../src/devin-cli-turn.mjs";
+
+function ids() {
+  let next = 0;
+  return () => `id-${(next += 1)}`;
+}
+
+function build(chat, overrides = {}) {
+  return buildChatMessageRequest(chat, { token: "tok", modelUid: "glm-5-2", newId: ids(), ...overrides });
+}
+
+test("carries the system prompt in `prompt`, not as a chat message", () => {
+  const request = build({
+    messages: [
+      { role: "system", content: "Be terse." },
+      { role: "user", content: "hi" },
+    ],
+  });
+  assert.equal(request.prompt, "Be terse.");
+  assert.equal(request.chatMessagePrompts.length, 1);
+  assert.equal(request.chatMessagePrompts[0].source, CHAT_MESSAGE_SOURCE.USER);
+});
+
+test("treats a developer message as a system message", () => {
+  const request = build({ messages: [{ role: "developer", content: "rules" }, { role: "user", content: "hi" }] });
+  assert.equal(request.prompt, "rules");
+});
+
+// Cascade has no assistant source; the shipped client sends prior model turns
+// as SYSTEM and a turn built any other way is rejected upstream.
+test("maps an assistant turn to the SYSTEM source with its tool calls attached", () => {
+  const request = build({
+    messages: [
+      { role: "user", content: "read a file" },
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{ id: "call_1", type: "function", function: { name: "read", arguments: '{"p":"a"}' } }],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "contents" },
+    ],
+  });
+  const [user, assistantTurn, toolResult] = request.chatMessagePrompts;
+  assert.equal(user.source, CHAT_MESSAGE_SOURCE.USER);
+  assert.equal(assistantTurn.source, CHAT_MESSAGE_SOURCE.SYSTEM);
+  assert.deepEqual(assistantTurn.toolCalls, [{ id: "call_1", name: "read", argumentsJson: '{"p":"a"}' }]);
+  assert.equal(toolResult.source, CHAT_MESSAGE_SOURCE.TOOL);
+  assert.equal(toolResult.toolCallId, "call_1");
+});
+
+// Replaying a historical image fails the whole request with invalid_argument,
+// so only the current turn may carry image data.
+test("attaches images from the current turn and replaces older ones with a placeholder", () => {
+  const image = {
+    type: "image_url",
+    image_url: { url: "data:image/png;base64,AAAA" },
+  };
+  const request = build({
+    messages: [
+      { role: "user", content: [{ type: "text", text: "old" }, image] },
+      { role: "assistant", content: "ok" },
+      { role: "user", content: [{ type: "text", text: "new" }, image] },
+    ],
+  });
+  const [historical, , current] = request.chatMessagePrompts;
+  assert.equal(historical.images, undefined);
+  assert.match(historical.prompt, /\[Image omitted from history\]/);
+  assert.deepEqual(current.images, [{ mimeType: "image/png", base64Data: "AAAA" }]);
+});
+
+test("sends tool definitions with their JSON schema serialized", () => {
+  const request = build({
+    messages: [{ role: "user", content: "go" }],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "read",
+          description: "Read a file.",
+          parameters: { type: "object", properties: { path: { type: "string" } } },
+        },
+      },
+    ],
+  });
+  assert.equal(request.tools.length, 1);
+  assert.equal(request.tools[0].name, "read");
+  assert.deepEqual(JSON.parse(request.tools[0].jsonSchemaString).properties.path, { type: "string" });
+});
+
+test("omits parameters-less tools' schema as an empty object rather than null", () => {
+  const request = build({
+    messages: [{ role: "user", content: "go" }],
+    tools: [{ type: "function", function: { name: "ping", description: "d" } }],
+  });
+  assert.deepEqual(JSON.parse(request.tools[0].jsonSchemaString), { type: "object", properties: {} });
+});
+
+test("maps a named tool choice to toolName and a keyword to optionName", () => {
+  const named = build({
+    messages: [{ role: "user", content: "go" }],
+    tool_choice: { type: "function", function: { name: "read" } },
+  });
+  assert.deepEqual(named.toolChoice, { toolName: "read" });
+  const keyword = build({ messages: [{ role: "user", content: "go" }], tool_choice: "required" });
+  assert.deepEqual(keyword.toolChoice, { optionName: "required" });
+});
+
+test("appends a tool description block to the system prompt", () => {
+  const prompt = withToolDescriptions("Be terse.", [
+    { function: { name: "read", description: "Read a <file>." } },
+    { function: { name: "nodesc" } },
+  ]);
+  assert.match(prompt, /^Be terse\.\n\n# tools descriptions\n/);
+  assert.match(prompt, /<tool name="read">/);
+  assert.match(prompt, /Read a &lt;file&gt;\./);
+  assert.doesNotMatch(prompt, /nodesc/);
+});
+
+test("leaves the system prompt alone when no tool carries a description", () => {
+  assert.equal(withToolDescriptions("Be terse.", []), "Be terse.");
+});
+
+test("honours an explicit max_tokens and falls back otherwise", () => {
+  assert.equal(build({ messages: [], max_tokens: 512 }).configuration.maxTokens, 512);
+  assert.equal(build({ messages: [] }).configuration.maxTokens, 128_000);
+});
+
+test("disables parallel tool calls only when the caller asked", () => {
+  assert.equal(build({ messages: [], parallel_tool_calls: false }).disableParallelToolCalls, true);
+  assert.equal(build({ messages: [] }).disableParallelToolCalls, undefined);
+});
+
+test("puts the session token in metadata where the upstream reads it", () => {
+  assert.equal(build({ messages: [] }).metadata.apiKey, "tok");
+  assert.equal(build({ messages: [] }).chatModelUid, "glm-5-2");
+});
+
+test("reports a tool-call finish whenever a call was seen, whatever the stop reason", () => {
+  assert.equal(finishReasonFor(STOP_REASON.STOP_PATTERN, true), "tool_calls");
+  assert.equal(finishReasonFor(STOP_REASON.FUNCTION_CALL, false), "tool_calls");
+  assert.equal(finishReasonFor(STOP_REASON.MAX_TOKENS, false), "length");
+  assert.equal(finishReasonFor(STOP_REASON.CONTENT_FILTER, false), "content_filter");
+  assert.equal(finishReasonFor(STOP_REASON.STOP_PATTERN, false), "stop");
+});
+
+test("translates usage, including cached prompt tokens", () => {
+  assert.deepEqual(usageFrom({ inputTokens: 10, outputTokens: 4, cacheReadTokens: 6 }), {
+    prompt_tokens: 10,
+    completion_tokens: 4,
+    total_tokens: 14,
+    prompt_tokens_details: { cached_tokens: 6 },
+  });
+  assert.equal(usageFrom(undefined), undefined);
+});

--- a/test/devin-connect.test.mjs
+++ b/test/devin-connect.test.mjs
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { connectAuthorization, connectServerStream, connectUnary } from "../src/devin-connect.mjs";
+import { encodeMessage } from "../src/protobuf-wire.mjs";
+
+const SCHEMA = { text: { no: 1, type: "string" } };
+
+function envelope(payload, flags = 0) {
+  const framed = new Uint8Array(payload.length + 5);
+  framed[0] = flags;
+  new DataView(framed.buffer).setUint32(1, payload.length, false);
+  framed.set(payload, 5);
+  return framed;
+}
+
+function streamResponse(chunks, { status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: (async function* () {
+      for (const chunk of chunks) yield chunk;
+    })(),
+    text: async () => "",
+  };
+}
+
+test("sends the token as the doubled Basic credential the upstream expects", () => {
+  assert.equal(connectAuthorization("devin-session-token$x"), "Basic devin-session-token$x-devin-session-token$x");
+});
+
+test("posts a unary call to the service path with the proto content type", async () => {
+  let seen;
+  const result = await connectUnary({
+    baseUrl: "https://server.codeium.com/",
+    service: "exa.api_server_pb.ApiServerService",
+    method: "GetCascadeModelConfigs",
+    token: "tok",
+    requestSchema: SCHEMA,
+    responseSchema: SCHEMA,
+    message: { text: "ask" },
+    fetchImpl: async (url, init) => {
+      seen = { url, init };
+      return {
+        ok: true,
+        status: 200,
+        arrayBuffer: async () => encodeMessage(SCHEMA, { text: "answer" }).buffer,
+      };
+    },
+  });
+  assert.equal(seen.url, "https://server.codeium.com/exa.api_server_pb.ApiServerService/GetCascadeModelConfigs");
+  assert.equal(seen.init.headers["content-type"], "application/proto");
+  assert.equal(seen.init.headers["connect-protocol-version"], "1");
+  assert.deepEqual(result, { text: "answer" });
+});
+
+test("frames a streaming request in one envelope", async () => {
+  let body;
+  const stream = connectServerStream({
+    baseUrl: "https://server.codeium.com",
+    service: "S",
+    method: "M",
+    token: "tok",
+    requestSchema: SCHEMA,
+    responseSchema: SCHEMA,
+    message: { text: "hi" },
+    fetchImpl: async (_url, init) => {
+      body = init.body;
+      return streamResponse([envelope(new Uint8Array(0), 2)]);
+    },
+  });
+  for await (const _ of stream) void _;
+  const payload = encodeMessage(SCHEMA, { text: "hi" });
+  assert.equal(body[0], 0);
+  assert.equal(new DataView(body.buffer, body.byteOffset).getUint32(1, false), payload.length);
+  assert.deepEqual([...body.subarray(5)], [...payload]);
+});
+
+test("yields each message and stops at the end-of-stream envelope", async () => {
+  const chunks = [
+    envelope(encodeMessage(SCHEMA, { text: "one" })),
+    envelope(encodeMessage(SCHEMA, { text: "two" })),
+    envelope(new TextEncoder().encode("{}"), 2),
+    envelope(encodeMessage(SCHEMA, { text: "never" })),
+  ];
+  const seen = [];
+  for await (const message of connectServerStream({
+    baseUrl: "https://x", service: "S", method: "M", token: "t",
+    requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+    fetchImpl: async () => streamResponse(chunks),
+  })) seen.push(message.text);
+  assert.deepEqual(seen, ["one", "two"]);
+});
+
+// An envelope can arrive split across TCP reads; a parser that assumed whole
+// frames would drop or mis-decode the tail of a long turn.
+test("reassembles an envelope split across chunk boundaries", async () => {
+  const whole = envelope(encodeMessage(SCHEMA, { text: "split" }));
+  const chunks = [whole.subarray(0, 3), whole.subarray(3, 7), whole.subarray(7), envelope(new Uint8Array(0), 2)];
+  const seen = [];
+  for await (const message of connectServerStream({
+    baseUrl: "https://x", service: "S", method: "M", token: "t",
+    requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+    fetchImpl: async () => streamResponse(chunks),
+  })) seen.push(message.text);
+  assert.deepEqual(seen, ["split"]);
+});
+
+// Connect reports stream failures inside the terminator with HTTP 200 already
+// sent. Ignoring it would turn a refused turn into a silently empty answer.
+test("raises the error carried by the end-of-stream envelope", async () => {
+  const terminator = new TextEncoder().encode(
+    JSON.stringify({ error: { code: "resource_exhausted", message: "out of credits" } }),
+  );
+  await assert.rejects(
+    (async () => {
+      for await (const _ of connectServerStream({
+        baseUrl: "https://x", service: "S", method: "M", token: "t",
+        requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+        fetchImpl: async () => streamResponse([envelope(terminator, 2)]),
+      })) void _;
+    })(),
+    (error) => {
+      assert.equal(error.status, 429);
+      assert.equal(error.code, "devin_resource_exhausted");
+      assert.match(error.message, /out of credits/);
+      return true;
+    },
+  );
+});
+
+test("maps an unauthenticated rejection to 401 so the caller is told to sign in again", async () => {
+  await assert.rejects(
+    connectUnary({
+      baseUrl: "https://x", service: "S", method: "M", token: "t",
+      requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+      fetchImpl: async () => ({
+        ok: false,
+        status: 500,
+        text: async () => JSON.stringify({ code: "unauthenticated", message: "bad token" }),
+      }),
+    }),
+    (error) => {
+      assert.equal(error.status, 401);
+      assert.equal(error.code, "devin_unauthenticated");
+      return true;
+    },
+  );
+});

--- a/test/devin-forwarder-gating.test.mjs
+++ b/test/devin-forwarder-gating.test.mjs
@@ -1,0 +1,206 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { freePort } from "./port-pool.mjs";
+import { userModelEntry } from "../src/user-models.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Devin ships catalog-only, so an unconfigured install has no `devin-cli` model
+// and start.mjs must not spend a process or a port on its forwarder. The gate
+// is the curated model rather than the stored credential, because a curated
+// model is exactly what puts a `DEVIN_CLI_FORWARD_BASE_URL` route in the
+// gateway config -- gate and route are computed from the same MODELS array on
+// the same boot, so a live route can never point at a port nobody bound.
+//
+// Every case here drives the real start.mjs. `MODEL_ROUTER_LITELLM_BIN` points
+// at node, which exits immediately when handed LiteLLM's arguments, so startup
+// always fails at the gateway -- the stage *after* the forwarders. That makes
+// "reached the gateway" a positive assertion that the forwarder stage
+// completed, and it is the same trick startup-cleanup.test.mjs uses.
+
+// See startup-cleanup.test.mjs: progress, not elapsed time, separates a slow
+// machine from a stuck one, so the watchdog fires only on silence.
+const STARTUP_STALL_MS = 30_000;
+
+function waitForStartupExit(child, readErrors) {
+  const started = Date.now();
+  return new Promise((resolve, reject) => {
+    let lastOutput = started;
+    const onProgress = () => {
+      lastOutput = Date.now();
+    };
+    child.stderr.on("data", onProgress);
+    const finish = () => {
+      clearInterval(watchdog);
+      child.stderr.off("data", onProgress);
+    };
+    const watchdog = setInterval(() => {
+      const idleMs = Date.now() - lastOutput;
+      if (idleMs < STARTUP_STALL_MS) return;
+      finish();
+      reject(
+        new Error(
+          `startup stalled: no output for ${idleMs} ms after waiting ${Date.now() - started} ms in total; stderr so far:\n${readErrors()}`,
+        ),
+      );
+    }, 250);
+    child.once("exit", (code, signal) => {
+      finish();
+      resolve({ code, signal });
+    });
+  });
+}
+
+// Holds a port for the duration of a test so a forwarder that tries to bind it
+// fails with EADDRINUSE. Occupying the port is how "nothing was spawned" is
+// proved positively: an unspawned forwarder cannot collide with the squatter,
+// so startup walks past it to the gateway.
+async function squat(port) {
+  const server = net.createServer();
+  // Hang up on anything that connects. A squatter that accepted and held the
+  // socket would leave the health probe waiting for a response that never came
+  // and would keep `server.close()` from ever completing; destroying the socket
+  // makes a probe of this port fail the way a dead listener does, which is what
+  // the port being unavailable is meant to look like.
+  server.on("connection", (socket) => socket.destroy());
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  return {
+    listening: () => server.listening,
+    close: () =>
+      new Promise((resolve) => {
+        server.close(resolve);
+        server.unref();
+      }),
+  };
+}
+
+async function runStartup({ curatedDevinModel = false, occupyDevinPort = false } = {}) {
+  const ports = await Promise.all(Array.from({ length: 6 }, () => freePort()));
+  assert.equal(new Set(ports).size, ports.length);
+  const [routerPort, gatewayPort, oauthPort, apiPort, grokOauthPort, devinPort] = ports;
+
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "model-router-devin-gate-"));
+  const stateDir = path.join(rootDir, "state");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(path.join(stateDir, "internal-secret"), "devin-gate-internal-key-with-sufficient-length\n", {
+    mode: 0o600,
+  });
+  writeFileSync(path.join(stateDir, "caller-secret"), "devin-gate-caller-key-with-sufficient-length\n", {
+    mode: 0o600,
+  });
+  if (curatedDevinModel) {
+    // Built through the same helper `bin/curate-models` uses, so this stays a
+    // real curated entry rather than a hand-written shape that could drift.
+    writeFileSync(
+      path.join(stateDir, "user-models.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          models: [
+            userModelEntry({ providerId: "devin-cli", upstreamId: "gate-test-model", priority: 900 }),
+          ],
+        },
+        null,
+        2,
+      ),
+      { mode: 0o600 },
+    );
+  }
+
+  const squatter = occupyDevinPort ? await squat(devinPort) : undefined;
+
+  const child = spawn(process.execPath, [path.join(root, "src", "start.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MODEL_ROUTER_TARGET: "codex",
+      MODEL_ROUTER_STATE_DIR: stateDir,
+      MODEL_ROUTER_PORT: String(routerPort),
+      MODEL_ROUTER_GATEWAY_PORT: String(gatewayPort),
+      MODEL_ROUTER_OAUTH_PORT: String(oauthPort),
+      MODEL_ROUTER_API_PORT: String(apiPort),
+      MODEL_ROUTER_GROK_OAUTH_PORT: String(grokOauthPort),
+      MODEL_ROUTER_DEVIN_CLI_PORT: String(devinPort),
+      MODEL_ROUTER_LITELLM_BIN: process.execPath,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let errors = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+
+  try {
+    const exit = await waitForStartupExit(child, () => errors);
+    // Read the squatter before the teardown below closes it: the caller runs
+    // after this function returns, by which point it is gone either way.
+    return { exit, errors, devinPort, squatterHeldPort: squatter ? squatter.listening() : undefined };
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+    if (squatter) await squatter.close();
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+test(
+  "an install with no curated Devin model spawns no forwarder and binds no port",
+  { timeout: 120_000 },
+  async () => {
+    // The Devin port is held by this test. A forwarder that was spawned would
+    // die on EADDRINUSE and abort startup by name, so reaching the gateway
+    // failure instead is proof that nothing was spawned and nothing was bound.
+    const { exit, errors, squatterHeldPort } = await runStartup({ occupyDevinPort: true });
+
+    assert.doesNotMatch(errors, /\[devin-cli\]/, errors);
+    assert.doesNotMatch(errors, /Devin CLI forwarder/, errors);
+    assert.match(errors, /startup failed: LiteLLM gateway exited before becoming healthy\./, errors);
+    assert.equal(exit.code, 1, errors);
+    assert.equal(squatterHeldPort, true, "something took the Devin port from this test");
+  },
+);
+
+test(
+  "a curated Devin model spawns the forwarder and waits on its health",
+  { timeout: 120_000 },
+  async () => {
+    const { exit, errors } = await runStartup({ curatedDevinModel: true });
+
+    // The forwarder announces itself on stderr when its listener is up, and
+    // startup only reaches the gateway once every forwarder health wait has
+    // resolved -- so both halves of "spawned and waited on" are asserted.
+    assert.match(errors, /\[devin-cli\] listening/, errors);
+    assert.match(errors, /startup failed: LiteLLM gateway exited before becoming healthy\./, errors);
+    assert.equal(exit.code, 1, errors);
+  },
+);
+
+test(
+  "a curated Devin model that cannot bind its port still fails startup by name",
+  { timeout: 120_000 },
+  async () => {
+    // Gating must not turn a real failure into a silent skip: when the provider
+    // is routed, an unbindable forwarder aborts startup naming itself, exactly
+    // as it did when the spawn was unconditional.
+    const { exit, errors } = await runStartup({ curatedDevinModel: true, occupyDevinPort: true });
+
+    assert.match(errors, /startup failed: Devin CLI forwarder exited before becoming healthy\./, errors);
+    assert.doesNotMatch(errors, /LiteLLM gateway exited before becoming healthy/, errors);
+    assert.equal(exit.code, 1, errors);
+  },
+);
+
+test("neither secret is echoed while the gate is being decided", { timeout: 120_000 }, async () => {
+  const { errors } = await runStartup({ curatedDevinModel: true });
+  assert.doesNotMatch(errors, /devin-gate-internal-key-with-sufficient-length/);
+  assert.doesNotMatch(errors, /devin-gate-caller-key-with-sufficient-length/);
+});

--- a/test/protobuf-wire.test.mjs
+++ b/test/protobuf-wire.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { decodeMessage, encodeMessage } from "../src/protobuf-wire.mjs";
+
+const NESTED = { name: { no: 1, type: "string" } };
+const SCHEMA = {
+  text: { no: 1, type: "string" },
+  count: { no: 2, type: "uint64" },
+  flag: { no: 3, type: "bool" },
+  ratio: { no: 4, type: "double" },
+  tags: { no: 5, type: "string", repeated: true },
+  child: { no: 6, type: "message", message: NESTED },
+  children: { no: 7, type: "message", message: NESTED, repeated: true },
+  kind: { no: 8, type: "enum" },
+  blob: { no: 9, type: "bytes" },
+  scores: { no: 10, type: "int32", repeated: true },
+};
+
+test("encodes a string field with the field number and length protobuf specifies", () => {
+  // field 1, wire type 2 -> tag byte 0x0a; length 2; "hi"
+  const encoded = encodeMessage({ text: { no: 1, type: "string" } }, { text: "hi" });
+  assert.deepEqual([...encoded], [0x0a, 0x02, 0x68, 0x69]);
+});
+
+test("encodes a varint field larger than one byte", () => {
+  // field 2, wire type 0 -> tag 0x10; 300 -> 0xac 0x02
+  const encoded = encodeMessage({ count: { no: 2, type: "uint64" } }, { count: 300 });
+  assert.deepEqual([...encoded], [0x10, 0xac, 0x02]);
+});
+
+test("round-trips every supported field shape", () => {
+  const value = {
+    text: "hello",
+    count: 4_294_967_296,
+    flag: true,
+    ratio: 0.95,
+    tags: ["a", "b"],
+    child: { name: "one" },
+    children: [{ name: "two" }, { name: "three" }],
+    kind: 5,
+    blob: Uint8Array.from([1, 2, 3]),
+  };
+  const decoded = decodeMessage(SCHEMA, encodeMessage(SCHEMA, value));
+  assert.equal(decoded.text, "hello");
+  assert.equal(decoded.count, 4_294_967_296);
+  assert.equal(decoded.flag, true);
+  assert.ok(Math.abs(decoded.ratio - 0.95) < 1e-12);
+  assert.deepEqual(decoded.tags, ["a", "b"]);
+  assert.deepEqual(decoded.child, { name: "one" });
+  assert.deepEqual(decoded.children, [{ name: "two" }, { name: "three" }]);
+  assert.equal(decoded.kind, 5);
+  assert.deepEqual([...decoded.blob], [1, 2, 3]);
+});
+
+test("omits absent fields rather than writing proto3 defaults", () => {
+  assert.equal(encodeMessage(SCHEMA, { text: undefined, count: null }).length, 0);
+});
+
+test("writes a false boolean and a zero, which are meaningful on an optional field", () => {
+  const encoded = encodeMessage(SCHEMA, { flag: false, count: 0 });
+  const decoded = decodeMessage(SCHEMA, encoded);
+  assert.equal(decoded.flag, false);
+  assert.equal(decoded.count, 0);
+});
+
+// The upstream adds fields without notice. A decoder that failed on one would
+// fail whole turns for a field the router never reads.
+test("skips unknown fields of every wire type instead of failing", () => {
+  const wide = {
+    ...SCHEMA,
+    extraVarint: { no: 40, type: "uint64" },
+    extraString: { no: 41, type: "string" },
+    extraDouble: { no: 42, type: "double" },
+    extraFloat: { no: 43, type: "float" },
+  };
+  const encoded = encodeMessage(wide, {
+    text: "kept",
+    extraVarint: 9,
+    extraString: "dropped",
+    extraDouble: 1.5,
+    extraFloat: 2.5,
+  });
+  const decoded = decodeMessage(SCHEMA, encoded);
+  assert.equal(decoded.text, "kept");
+  assert.equal(decoded.extraString, undefined);
+});
+
+test("reads a packed repeated scalar, which is how the upstream sends enum lists", () => {
+  // field 10, wire type 2 (packed) -> tag 0x52; length 3; values 1,2,3
+  const packed = Uint8Array.from([0x52, 0x03, 0x01, 0x02, 0x03]);
+  assert.deepEqual(decodeMessage(SCHEMA, packed).scores, [1, 2, 3]);
+});
+
+test("reads an unpacked repeated scalar too", () => {
+  const unpacked = Uint8Array.from([0x50, 0x01, 0x50, 0x02]);
+  assert.deepEqual(decodeMessage(SCHEMA, unpacked).scores, [1, 2]);
+});
+
+test("refuses a truncated field rather than returning a half-read message", () => {
+  assert.throws(() => decodeMessage(SCHEMA, Uint8Array.from([0x0a, 0x05, 0x68])), /truncated/);
+});

--- a/test/target-isolation.test.mjs
+++ b/test/target-isolation.test.mjs
@@ -37,6 +37,7 @@ test("codex owns the default port block", () => {
     router: 4202,
     api: 4203,
     grokOauth: 4208,
+    devinCli: 4210,
   });
 });
 
@@ -60,7 +61,16 @@ test("operators can keep an explicitly configured legacy block during migration"
       },
     ),
   );
-  assert.deepEqual(ports, { gateway: 4100, oauth: 4101, router: 4102, api: 4103, grokOauth: 4108 });
+  // The Devin CLI forwarder postdates the legacy block, so an operator
+  // migrating from it never pinned that port and keeps the current default.
+  assert.deepEqual(ports, {
+    gateway: 4100,
+    oauth: 4101,
+    router: 4102,
+    api: 4103,
+    grokOauth: 4108,
+    devinCli: 4210,
+  });
 });
 
 test("removed targets are rejected rather than silently mapped to codex", () => {


### PR DESCRIPTION
Adds `devin-cli`: a provider that reuses the session the official Devin CLI stores, so Codex can drive Devin's models through the router. Same shape as `kimi-oauth` and `grok-oauth` — read the CLI's own credential, never write it, spend the operator's own account.

**Draft on purpose. This has never spoken to Cognition's backend.** Testers wanted: #270.

## Why the transport is new

Cognition publishes a *session* API (`api.devin.ai`), not a chat API. I checked for a BYOK path first and there isn't one: no `baseUrl`/`apiKey` keys in `~/.config/devin/config.json`, no model-endpoint flag or env var, and enterprise `system.json` only pins `enterprise_host`, `account_id`, and an HTTP proxy. Models are `model_uid`s the server hands the client, gated by `allowed_model_uids` in team settings.

The models answer only on Cascade: `exa.api_server_pb.ApiServerService` over Connect RPC at the `api_server_url` the CLI stored. Auth is the doubled `Basic <token>-<token>` header plus the same token inside `Metadata.api_key`.

So this needed four things the repo didn't have.

## What landed

| File | Role | Lines |
|---|---|---|
| `src/protobuf-wire.mjs` | varint / length-delimited codec | 233 |
| `src/devin-proto.mjs` | the ~15 messages actually used | 190 |
| `src/devin-connect.mjs` | Connect unary + server-streaming client | 175 |
| `src/devin-cli-status.mjs` | read `credentials.toml`, report presence only | 74 |
| `src/devin-cli-session.mjs` | resolve the token, fail as 401 | 34 |
| `src/devin-cli-turn.mjs` | Chat Completions → `GetChatMessage` | 196 |
| `src/devin-cli-forwarder.mjs` | the forwarder LiteLLM talks to | 274 |
| `src/devin-cli-probe.mjs` + `bin/devin-probe` | the tester-facing check | 137 |
| `config/devin/devin.json` | provider registry entry, catalog-only | — |

Hand-rolled protobuf rather than a new dependency: `package.json` has two deps today, and the repo already hand-rolls a YAML lexer and a TOML scanner. The codec is 233 lines and tested against hand-computed bytes.

## Decisions worth reviewing

- **The decoder skips unknown fields; the credential reader refuses ambiguity.** Opposite postures on purpose. The upstream adds protobuf fields without notice, so a strict decoder would fail whole turns over a field the router never reads. `credentials.toml` goes through `toml-structure.mjs` instead, so a duplicate key is refused rather than guessed at — the wrong guess there picks a credential nobody chose.
- **Assistant turns are sent as `CHAT_MESSAGE_SOURCE_SYSTEM`.** Cascade has no assistant source. This follows the shipped client.
- **Images ride only on the current turn.** Replaying a historical image fails the whole request with `invalid_argument`; older ones become a text placeholder.
- **Errors in the end-of-stream terminator are raised, not swallowed.** Connect reports stream failures inside the final envelope with HTTP 200 already sent. Ignoring it would turn "out of credits" into a silently empty answer.
- **A stream that already relayed bytes ends rather than injecting an error.** The client owns a partial message at that point; appending an error object would corrupt it.
- **`installOauthCli` now throws for a CLI with no npm package** and names the vendor's installer. Devin ships a Rust binary via curl or Homebrew. Running a remote install script unattended from the tray is not something this should do on the operator's behalf.
- **Catalog-only, no checked-in models.** Which models an account may run is a server-side entitlement. `bin/curate-models devin-cli` after signing in.

## Tests

37 new, full suite green (**1405 pass, 0 fail**).

- `test/protobuf-wire.test.mjs` — tag bytes and multi-byte varints against hand-computed expectations, every field shape round-tripped, unknown fields of all four wire types skipped, packed and unpacked repeated scalars, truncation refused.
- `test/devin-connect.test.mjs` — service path and headers, request framing, a frame split across three chunk boundaries, the end-of-stream terminator ending iteration, an error carried inside it surfacing as 429, an `unauthenticated` rejection mapping to 401.
- `test/devin-cli-turn.test.mjs` — system prompt placement, role→source mapping, tool calls and results, the current-turn image rule, tool schemas, tool choice, finish reasons, usage.
- `test/devin-cli-status.test.mjs` — token and server extraction, the documented fallback, duplicate-key refusal, missing and unreadable sessions as 401s naming `devin auth login`.
- `test/target-isolation.test.mjs` — updated for the new port (4210).

**What these do not prove:** that Cascade accepts the request. They show the translation is self-consistent. Only a live account settles the rest.

## Not done, deliberately

- No live verification (see #270).
- No model fragments in `config/devin/`.
- No `multiAgentVersion` — subagent capability is researched, not asserted.
- No README provider-list entry. That advertises a working provider, and this one is not known to work yet.

`AGENTS.md` records all of this as rules, including what may not be claimed for this provider until somebody proves it.

## Attribution

Protocol understanding — service path, credential shape, which request fields a turn must carry — follows [devin-2api](https://github.com/leookun/devin-2api) (MIT). Field numbers are transcribed from the descriptor set embedded in Cognition's own `devin` binary. No code copied. `NOTICE.md` updated.

Closes nothing yet. Blocked on #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0195bb8wGGRnRhN3uWF8NYwa
