### PR TITLE
feat(gemini): publish routed models into Gemini CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,23 +4,24 @@ These instructions apply when a user asks an agent to install this repository.
 
 ## Choose the target
 
-- `codex` (the Codex CLI and desktop app) and `dsh` (DeepSeek Harness) are the
+- `codex` (the Codex CLI and desktop app), `dsh` (DeepSeek Harness), and
+  `gemini` (Gemini CLI) are the
   supported targets. If the user asks for Cursor or opencode integration,
   explain that those targets were removed and the router does not have them;
   the opencode provider (the Go subscription and the pay-per-use Zen endpoint)
   remains available as a provider inside both targets.
-- **A target is a client, not a router.** One installation serves both: one
-  background service, one gateway, one set of provider credentials, one
+- **A target is a client, not a router.** One installation serves all of them:
+  one background service, one gateway, one set of provider credentials, one
   provider selection, one set of ports. `MODEL_ROUTER_TARGET` selects which
   client's configuration a command writes. It must never fork the state
-  directory, the service, or the credential store — a user who installs both
+  directory, the service, or the credential store — a user who installs two
   would otherwise be asked for every API key twice and would run two gateways
   against one set of provider quotas. `ROUTER_PLANE_TARGET` in
   `src/paths.mjs` names that shared plane, and the environment aliases and the
   `/health` service name are keyed on it rather than on the client.
-- Installing both is normal and needs no special handling: run the install
-  once per target. Whichever one is already present is republished whenever the
-  routable set changes, so the two clients cannot drift apart.
+- Installing more than one is normal and needs no special handling: run the
+  install once per target. Whichever ones are already present are republished
+  whenever the routable set changes, so the clients cannot drift apart.
 
 ## Codex outcome
 
@@ -137,6 +138,120 @@ nothing to restart and nothing to tell the user to quit.
    document and publishes external edits, so the route is live on the next
    request. Saying otherwise trains people to restart for nothing.
 
+## Gemini CLI outcome
+
+Publish the router's routed models into Gemini CLI by writing one marker block
+in the environment file it already reads, preserve every other line in that
+file, never open its `settings.json` for writing, and leave the user's next
+`gemini` run to pick the change up.
+
+## Gemini CLI procedure
+
+1. Steps 1-6 of the Codex procedure apply unchanged, except that Codex itself is
+   not a prerequisite: a Gemini-only machine needs Node 22.19+, `uv` or Python
+   3.10+, and the `gemini` CLI. Do not run `src/catalog.mjs` there, for the same
+   reason the harness does not.
+2. Run `./install.sh --target gemini --auto --providers IDS` (macOS/Linux) or
+   `./install.ps1 -Target gemini -Auto -Providers IDS` (Windows).
+   `--migrate-known` and `--adopt-native-catalog` are refused here: both act on
+   Codex's own configuration.
+3. Run `bin/model-router gemini doctor`. "Gemini routing config", "Gemini
+   environment conflicts", "Gemini environment privacy", and "Gemini default
+   model" must be `OK`, alongside the shared-plane checks.
+4. Do not tell the user to quit anything. Gemini CLI reads its environment once,
+   at process start, so the next `gemini` invocation has the new values. Tell
+   them instead to choose "Use Gemini API key" if the CLI asks how to
+   authenticate — that is a one-time choice the CLI saves for itself, and the
+   key it will use is this router's local caller capability, not a Google one.
+
+## What the Gemini integration writes, and what it must never touch
+
+Gemini CLI speaks only the Gemini API, so it is the one client that cannot be
+pointed at `/v1/responses`. Everything below exists so that fact costs one
+translation layer and nothing else.
+
+1. **One file, three keys, and no `settings.json`.** The router owns
+   `GOOGLE_GEMINI_BASE_URL`, `GEMINI_API_KEY`, and `GEMINI_MODEL` inside a
+   `# BEGIN codex-router-gemini` block in `~/.gemini/.env` (`GEMINI_HOME` in
+   `paths.mjs`, which honours the CLI's own `GEMINI_CLI_HOME` override). That is the whole
+   integration: `createContentGenerator` in `@google/gemini-cli-core` builds a
+   plain `@google/genai` client from those variables, so nothing else has to be
+   configured. Its `settings.json` is JSONC carrying the user's own comments and
+   is never opened for writing — a `JSON.parse`/`stringify` round trip there
+   deletes every one of them. Publishing twice is byte-identical, removing the
+   block restores the document exactly, and `test/gemini-env.test.mjs` asserts
+   both against a document with somebody else's work around ours.
+2. **Refuse rather than guess.** `dotenv` lets the last assignment of a key in a
+   file win, so a `GEMINI_API_KEY=` below our block silently decides the
+   credential and nothing in the file says so. `conflictingAssignments()` finds
+   any managed key assigned outside the block and the publish stops with the
+   line named and the file untouched. Damaged markers — a missing end, a second
+   begin — are refused the same way. Never add a "best effort" path there.
+3. **The document is private.** It carries the caller key and the managed base
+   URL, so it is written 0600. `~/.gemini` is created 0700 when absent and
+   deliberately *not* re-moded when present: that directory is Gemini CLI's, and
+   `protectPrivateFile` on a directory would strip its execute bit and break the
+   CLI outright. Status output reports the redacted URL, never the whole one.
+4. **`gemini` is a leaf of the caller capability, like `v1` and `panel`.** The
+   SDK appends `/v1beta/models/{model}:{method}` to whatever base URL it is
+   given, so the secret has to sit in the path ahead of it. A new leaf must be
+   added to `redactCallerUrl` at the same time it is added to the router, or the
+   caller key reaches doctor output and support bundles in the clear.
+5. **The surface translates and re-enters; it never reaches a provider.**
+   `gemini-surface.mjs` converts a Gemini request into a Responses request,
+   sends it through the router's own `/v1/responses` over the loopback, and
+   converts the answer back. That is what keeps the harness rule intact in
+   spirit: tool-result ageing, the vision bridge, prompt-token substitution,
+   upstream retry, model failover, and usage accounting all still sit on one
+   request path. Do not give this surface its own upstream.
+6. **The loopback carries no credential.** The key the CLI presents *is* this
+   router's caller capability, and the path it presented it on is already the
+   proof. Relaying it upstream would put a router secret on a hop that can be
+   substituted onto a provider — and leaving the header off is also what makes
+   `callerBroughtNoUpstreamCredential` true, which is how a client with no
+   ChatGPT session of its own reaches native models.
+7. **The default model is written, and that is deliberate.** Gemini CLI's own
+   default is `gemini-2.5-pro`, which this router does not route, so an install
+   that left it alone would 404 on the user's first turn. `GEMINI_MODEL`
+   out-ranks `settings.json`'s `model.name` and is out-ranked by `--model`;
+   `--no-default-model` turns it off. This is the one place the Gemini
+   integration deliberately departs from the harness's opt-in rule, because
+   there the default is a convenience and here it is the difference between a
+   working install and a broken one.
+8. **`embedContent` is refused, not faked.** No routed provider exposes an
+   embedding endpoint through this router. Gemini CLI calls it only from
+   `baseLlmClient`, never from the turn loop, so a named 501 is the honest
+   answer and a fabricated vector would be the dishonest one.
+9. **`countTokens` is estimated.** There is no upstream to ask, and spending a
+   real turn to answer a count would bill the user for a question they asked for
+   free. A client that gets no number cannot decide whether to compact, so the
+   same byte-ratio estimate `response-usage.mjs` uses for prompt accounting is
+   the better failure.
+10. **The model list is served live, so it cannot drift.**
+    `/gemini/v1beta/models` reads the catalog the router already publishes,
+    which is why this integration has no copy to keep in step. The published
+    *default model* is a snapshot and can drift; `gemini-models.json` records
+    it, doctor compares it against the routable set, and it is the marker that
+    decides whether the integration is installed.
+11. **A tool schema arrives as `parametersJsonSchema`, not `parameters`.**
+    `tools.js` in `@google/gemini-cli-core` writes every built-in tool's schema
+    into that field and validates incoming calls against the same one. Reading
+    only `parameters` — the older Schema-proto spelling, which the type also
+    permits — sent all ten tools upstream with no schema at all: the model
+    invented argument names and the CLI rejected each call with "params must
+    have required property 'file_path'". Every test passed while that was true,
+    because a fixture written from the type definition spells it the other way.
+    A declaration with neither field is sent as `{type: "object", properties:
+    {}}` rather than with `parameters` omitted, because a chat-completions
+    provider refuses a function whose parameters are absent.
+12. **Verify against the real CLI, not against the docs.** Google's own
+    documentation does not describe this configuration; the contract was read
+    out of the installed `@google/genai` and `@google/gemini-cli-core` bundles
+    (`GOOGLE_AI_API_DEFAULT_VERSION`, `formatMap('{model}:streamGenerateContent
+    ?alt=sse')`, `GOOGLE_API_KEY_HEADER`, `resolveModel`'s pass-through default)
+    and then proved by driving `gemini -p` at the surface. A change to the wire
+    shape needs that same proof, not a plausible reading.
+
 ## What the harness integration writes, and what it must never touch
 
 The router owns exactly two keys, in two documents that belong to the harness.
@@ -184,7 +299,10 @@ beside ours, so everything else in them is somebody else's work.
    and throughput accounting — already sits on that routed path. Do not add a
    second upstream path or a chat-completions surface for the harness; the
    point of pointing it at the same endpoint Codex uses is that there is one
-   request path to keep correct. `models[].id` is the router **slug**, never
+   request path to keep correct. The Gemini surface is not an exception to this:
+   it speaks Gemini at the edge because its client can speak nothing else, and
+   then re-enters this same endpoint over the loopback rather than reaching a
+   provider of its own. `models[].id` is the router **slug**, never
    the gateway model id: `/v1/responses` resolves it against `MODEL_BY_SLUG`,
    and a gateway id falls through to the native path.
 6. **No `compat` on the route.** pi-ai types its reasoning-dispatch switches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+- **Gemini CLI is a target.** It speaks only the Gemini API and Google ships no
+  bring-your-own-provider setting, so pointing it at this router used to be
+  impossible — the endpoint it wants does not exist anywhere in the codebase.
+  It does, however, read its endpoint, its credential, and its default model
+  from the environment, and `createContentGenerator` builds a plain
+  `@google/genai` client from them. So the router now serves
+  `/_codex-router/<key>/gemini/v1beta/models/{model}:{method}` and writes one
+  marker block into `~/.gemini/.env`. `./install.sh --target gemini` or
+  `./bin/model-router gemini enable` sets it up; the next `gemini` run has the
+  routed models, with nothing to restart.
+  The surface reaches no provider of its own. It translates the turn into a
+  Responses request and sends it through the router's existing `/v1/responses`
+  over the loopback, so tool-result ageing, the vision bridge, prompt-token
+  substitution, upstream retry, model failover, and usage accounting all still
+  sit on one request path rather than two that would drift. Tools, system
+  instructions, inline images, streaming deltas, reasoning summaries, tool calls
+  and their results, usage counts, and finish reasons all cross in both
+  directions. A stream the upstream drops still ends with a finish reason,
+  because the SDK waits for one before it considers a turn over.
+  `settings.json` is never opened for writing: it is JSONC carrying the user's
+  own comments, and this integration does not need it. The `.env` block is the
+  only thing written, it is 0600 because it holds the caller key, publishing
+  twice is byte-identical, and removing it restores the file exactly. A managed
+  key assigned outside the block stops the publish with the line named rather
+  than being silently overwritten — `dotenv` lets the last assignment win, so a
+  duplicate would quietly decide which endpoint is in force and nothing in the
+  file would say so.
+  The default model is written, unlike the harness integration's opt-in
+  equivalent, because Gemini CLI's own default is a Gemini model this router
+  does not route: an install that left it alone would 404 on the first turn.
+  `--model` still outranks it and `--no-default-model` omits it.
+  Embeddings are refused with a named 501 rather than faked, and `countTokens`
+  is estimated rather than answered by spending a real turn upstream.
+  None of this is documented by Google. The contract was read out of the
+  installed `@google/genai` and `@google/gemini-cli-core` bundles and then
+  proved by driving the real `gemini -p` at a real provider: a routed turn came
+  back through the CLI verbatim, and a tool-calling turn completed the whole
+  loop — ten tool schemas out, a tool call in, its result back out, and the
+  model's answer in. That live run is what caught the one bug the unit tests
+  could not: a Gemini tool declares its schema as `parametersJsonSchema`, not
+  `parameters`, so the first cut sent every tool upstream with no schema at all
+  and the CLI rejected each call the model made with "params must have required
+  property 'file_path'".
+- The rule for which models may be published to a client that carries no ChatGPT
+  session of its own now lives in `src/routed-client-models.mjs` instead of
+  inside the harness manager. It was always a general rule; a second client
+  wanting it verbatim is what made a second copy the wrong answer.
 - **Grok OAuth no longer loses late or custom tool calls.** The forwarder now
   accepts `function_call` and `custom_tool_call` items that first appear in
   `response.output_item.done`, restores final arguments when argument deltas

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 Use Anthropic, Kimi, DeepSeek, xAI, GitHub Copilot, opencode Go, Command Code,
 and future external models inside the Codex App and CLI — or inside
-[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) — through
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) or
+[Gemini CLI](https://github.com/google-gemini/gemini-cli) — through
 one local, credential-isolating router.
 The integration speaks the Responses API and merges external entries into
 Codex's native model catalog, so routed models appear in the normal picker
 next to the native GPT models. The same routed models publish into the
-harness as one provider route, so they appear in its Models page too.
+harness as one provider route, so they appear in its Models page too, and into
+Gemini CLI through a Gemini-shaped endpoint the router serves for it.
 
-Both clients share one installation: one background service, one gateway, one
-set of provider credentials, one provider selection. Installing the second
-integration does not ask for a single key again.
+Every client shares one installation: one background service, one gateway, one
+set of provider credentials, one provider selection. Installing a second or
+third integration does not ask for a single key again.
 
 Codex Router is an independent community project. It is not affiliated with or
 endorsed by OpenAI, GitHub, Anthropic, Moonshot AI, DeepSeek, OpenRouter,
-opencode, or the referenced opencodex project.
+opencode, Google, or the referenced opencodex project.
 
 ## Give the link to your agent
 
@@ -1296,6 +1298,59 @@ is the default. To put children on a *different* routed model, paste the block
 from `./bin/model-router dsh subagent-preset` into your preset's
 `agent.cordis.yml` — the router will not edit a preset it does not own.
 
+## Make models appear in Gemini CLI
+
+[Gemini CLI](https://github.com/google-gemini/gemini-cli) (`gemini`) speaks only
+the Gemini API, so the router serves it one: a Gemini-shaped endpoint that
+translates each turn into the same Responses request Codex makes and answers
+with the same models. Google ships no bring-your-own-provider setting, but the
+CLI does read its endpoint, its credential, and its default model from the
+environment — which is the whole integration.
+
+```sh
+./install.sh --target gemini --auto --providers configured
+# or, on an install that already serves Codex:
+./bin/model-router gemini enable
+```
+
+That writes one marker block into `~/.gemini/.env`:
+
+```sh
+# BEGIN codex-router-gemini
+GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:4202/_codex-router/<caller-key>/gemini
+GEMINI_API_KEY=<caller-key>
+GEMINI_MODEL=anthropic/claude-opus-4-6
+# END codex-router-gemini
+```
+
+The next `gemini` run picks it up — there is nothing to restart. If the CLI asks
+how to authenticate, choose **Use Gemini API key** once; the key is this
+router's local caller capability, not a Google one, and it never leaves the
+machine.
+
+**What is preserved.** Your `settings.json` is never opened for writing: it is
+JSONC and carries your comments, and this integration does not need it. Every
+other line of `~/.gemini/.env` is left exactly as it was, and
+`./bin/model-router gemini disable` removes the block and restores the file. An
+assignment of one of those three keys *outside* the block stops the publish with
+the line named rather than being silently overwritten — `dotenv` lets the last
+assignment win, so a duplicate would quietly decide which endpoint is in force.
+
+**Picking a model.** `--model vendor/slug` overrides the published default for
+one run; `GEMINI_MODEL` in the block is the default for the rest. Pass
+`--no-default-model` to `src/gemini-config-manager.mjs install` to leave the key
+out entirely, in which case the CLI falls back to its own Gemini default — which
+this router does not route, so a turn without `--model` will be refused by name.
+
+**What is not served.** Embeddings (`:embedContent`) are refused with a named
+501: no routed provider exposes an embedding endpoint through the router, and a
+fabricated vector would be worse than an error. `:countTokens` is answered from
+a byte-count estimate rather than by spending a real turn upstream.
+
+**Native GPT models** publish here under the same rule as the harness, described
+above: while this machine has a usable Codex session, and withheld the moment it
+does not.
+
 ## macOS tray control panel
 
 On macOS, build and open the native menu-bar control panel with:
@@ -1431,6 +1486,15 @@ integration instead:
 ./bin/model-router dsh status
 ./bin/model-router dsh subagent-preset   # block to paste for a routed child model
 ./bin/model-router dsh disable           # remove the route, keep everything else
+```
+
+…or `gemini` to act on the Gemini CLI integration:
+
+```sh
+./bin/model-router gemini enable         # publish the routed models
+./bin/model-router gemini doctor
+./bin/model-router gemini status
+./bin/model-router gemini disable        # remove the managed block, keep the rest
 ```
 
 The optional live check makes one small request per selected provider and may

--- a/bin/disable
+++ b/bin/disable
@@ -31,5 +31,11 @@ case "${MODEL_ROUTER_TARGET:-codex}" in
     echo "The codex-router provider route was removed from DeepSeek Harness."
     echo "Every other settings section, provider route, and stored credential was preserved."
     ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  gemini)
+    node src/gemini-config-manager.mjs uninstall >/dev/null
+    retire_service_if_unused
+    echo "The router's managed block was removed from Gemini CLI's environment file."
+    echo "Every other line in that file, and its settings.json, were left untouched."
+    ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac

--- a/bin/doctor
+++ b/bin/doctor
@@ -3,6 +3,6 @@ set -eu
 
 repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 case "${MODEL_ROUTER_TARGET:-codex}" in
-  codex|dsh) exec node "$repo_dir/src/doctor.mjs" "$@" ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  codex|dsh|gemini) exec node "$repo_dir/src/doctor.mjs" "$@" ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac

--- a/bin/enable
+++ b/bin/enable
@@ -5,8 +5,8 @@ repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$repo_dir"
 target=${MODEL_ROUTER_TARGET:-codex}
 case "$target" in
-  codex|dsh) ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  codex|dsh|gemini) ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac
 CODEX_ROUTER_NODE_BIN=${CODEX_ROUTER_NODE_BIN:-$(command -v node)}
 export CODEX_ROUTER_NODE_BIN
@@ -17,7 +17,7 @@ for argument in "$@"; do
     *) echo "Usage: $0 [--adopt-native-catalog]" >&2; exit 2 ;;
   esac
 done
-if [ "$target" = dsh ] && [ "$adopt_native_catalog" = true ]; then
+if [ "$target" != codex ] && [ "$adopt_native_catalog" = true ]; then
   echo "--adopt-native-catalog applies to the Codex integration only." >&2
   exit 2
 fi
@@ -30,6 +30,10 @@ fi
 # selection, the gateway route table, and the service are one shared plane.
 if [ "$target" = dsh ]; then
   config_manager=src/dsh-config-manager.mjs
+  config_enable_command=install
+  config_disable_command=uninstall
+elif [ "$target" = gemini ]; then
+  config_manager=src/gemini-config-manager.mjs
   config_enable_command=install
   config_disable_command=uninstall
 else
@@ -67,6 +71,9 @@ node src/litellm-config.mjs
 if [ "$target" != dsh ] && [ -s "$state_dir/dsh-models.json" ]; then
   node src/dsh-config-manager.mjs install >/dev/null
 fi
+if [ "$target" != gemini ] && [ -s "$state_dir/gemini-models.json" ]; then
+  node src/gemini-config-manager.mjs install >/dev/null
+fi
 config_enabled=true
 if [ "$adopt_native_catalog" = true ]; then
   node "$config_manager" "$config_enable_command" --adopt-native-catalog
@@ -81,6 +88,9 @@ service_installed=false
 trap - EXIT HUP INT TERM
 if [ "$target" = dsh ]; then
   echo "External model routes published to DeepSeek Harness. It reloads them on the next request."
+elif [ "$target" = gemini ]; then
+  echo "External model routes published to Gemini CLI. The next \`gemini\` run picks them up."
+  echo "Choose \"Use Gemini API key\" once if it asks how to authenticate; the key is this router's local caller capability."
 else
   echo "External model routes enabled. Fully quit and reopen Codex."
 fi

--- a/bin/install
+++ b/bin/install
@@ -15,8 +15,8 @@ MODEL_ROUTER_ALLOW_FOREIGN_STATE=1
 export MODEL_ROUTER_ALLOW_FOREIGN_STATE
 
 case "$target" in
-  codex|dsh) ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  codex|dsh|gemini) ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac
 
 for argument in "$@"; do

--- a/bin/model-router
+++ b/bin/model-router
@@ -10,8 +10,9 @@ Usage: model-router TARGET COMMAND [arguments]
 Targets:
   codex   the Codex CLI and desktop app
   dsh     DeepSeek Harness (its settings document, hot-reloaded)
+  gemini  Gemini CLI (its ~/.gemini/.env, read at startup)
 
-Both targets share one router: one service, one set of provider credentials,
+Every target shares one router: one service, one set of provider credentials,
 one provider selection. The target chooses which client's configuration a
 command writes, not which router it talks to.
 
@@ -27,6 +28,8 @@ Examples:
   ./bin/model-router codex shim install
   ./bin/model-router dsh enable
   ./bin/model-router dsh status
+  ./bin/model-router gemini enable
+  ./bin/model-router gemini status
 EOF
 }
 
@@ -39,7 +42,7 @@ if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then
   exit 0
 fi
 
-if [ "$#" -eq 2 ] && { [ "$1" = "codex" ] || [ "$1" = "dsh" ]; } && [ "$2" = "--version" ]; then
+if [ "$#" -eq 2 ] && { [ "$1" = "codex" ] || [ "$1" = "dsh" ] || [ "$1" = "gemini" ]; } && [ "$2" = "--version" ]; then
   version
   exit 0
 fi
@@ -54,7 +57,7 @@ command=$2
 shift 2
 
 case "$target" in
-  codex|dsh) ;;
+  codex|dsh|gemini) ;;
   *) echo "Unknown target: $target" >&2; usage >&2; exit 2 ;;
 esac
 

--- a/bin/multi-agent
+++ b/bin/multi-agent
@@ -11,7 +11,8 @@ cd "$repo_dir"
 case "${MODEL_ROUTER_TARGET:-codex}" in
   codex) ;;
   dsh) echo "Native subagent overrides are a Codex concept. For DeepSeek Harness run: ./bin/model-router dsh subagent-preset" >&2; exit 2 ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  gemini) echo "Native subagent overrides are a Codex concept. Gemini CLI delegates through its own subagents, which the router does not configure." >&2; exit 2 ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac
 
 command=${1:-status}

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,6 @@ set -eu
 
 repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 case "${MODEL_ROUTER_TARGET:-codex}" in
-  codex|dsh) exec node "$repo_dir/src/setup.mjs" "$@" ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  codex|dsh|gemini) exec node "$repo_dir/src/setup.mjs" "$@" ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac

--- a/bin/smoke-test
+++ b/bin/smoke-test
@@ -5,6 +5,6 @@ repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 # The smoke test spends provider quota against the shared router plane, so it
 # proves the same routes whichever client asked for it.
 case "${MODEL_ROUTER_TARGET:-codex}" in
-  codex|dsh) exec node "$repo_dir/src/smoke-test.mjs" "$@" ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  codex|dsh|gemini) exec node "$repo_dir/src/smoke-test.mjs" "$@" ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac

--- a/bin/status
+++ b/bin/status
@@ -6,7 +6,8 @@ cd "$repo_dir"
 case "${MODEL_ROUTER_TARGET:-codex}" in
   codex) node src/config-manager.mjs status ;;
   dsh) node src/dsh-config-manager.mjs status ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  gemini) node src/gemini-config-manager.mjs status ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac
 node src/service.mjs status
 node --input-type=module -e 'import { PORTS } from "./src/paths.mjs"; fetch(`http://127.0.0.1:${PORTS.router}/health`).then(async r=>{console.log(await r.text()); process.exitCode=r.ok?0:1}).catch(()=>{console.log(JSON.stringify({ok:false,router:"unavailable"})); process.exitCode=1})'

--- a/bin/subagent-preset
+++ b/bin/subagent-preset
@@ -6,7 +6,8 @@ cd "$repo_dir"
 case "${MODEL_ROUTER_TARGET:-codex}" in
   dsh) ;;
   codex) echo "Codex configures native subagents with ./bin/multi-agent." >&2; exit 2 ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  gemini) echo "The router does not configure Gemini CLI subagents; it publishes models, not agent definitions." >&2; exit 2 ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac
 node --input-type=module -e '
 import { subagentPreset } from "./src/dsh-config-manager.mjs";

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -36,6 +36,11 @@ case "${MODEL_ROUTER_TARGET:-codex}" in
     retire_service_if_unused
     echo "The DeepSeek Harness integration was removed."
     ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex or dsh." >&2; exit 2 ;;
+  gemini)
+    node src/gemini-config-manager.mjs uninstall >/dev/null
+    retire_service_if_unused
+    echo "The Gemini CLI integration was removed."
+    ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
 esac
 echo "The repository, cached native catalog, logs, and provider credentials were retained."

--- a/install.ps1
+++ b/install.ps1
@@ -3,7 +3,7 @@ param(
   [switch]$CheckoutInstall,
   [switch]$PrepareOnly,
   [switch]$ForceDeps,
-  [ValidateSet("codex", "dsh")]
+  [ValidateSet("codex", "dsh", "gemini")]
   [string]$Target = "codex",
   [switch]$Guided,
   [switch]$Auto,
@@ -233,9 +233,13 @@ if ([int]$VersionParts[0] -lt 22 -or
 
 # Each target enables its own client configuration; everything around that one
 # step is the shared router plane.
-$ConfigManager = if ($Target -eq "dsh") { "src\dsh-config-manager.mjs" } else { "src\config-manager.mjs" }
-$ConfigEnableCommand = if ($Target -eq "dsh") { "install" } else { "enable" }
-$ConfigDisableCommand = if ($Target -eq "dsh") { "uninstall" } else { "disable" }
+$ConfigManager = switch ($Target) {
+  "dsh" { "src\dsh-config-manager.mjs" }
+  "gemini" { "src\gemini-config-manager.mjs" }
+  default { "src\config-manager.mjs" }
+}
+$ConfigEnableCommand = if ($Target -eq "codex") { "enable" } else { "install" }
+$ConfigDisableCommand = if ($Target -eq "codex") { "disable" } else { "uninstall" }
 $ConfigEnabled = $false
 $ServiceInstalled = $false
 $AdoptionPending = $false
@@ -377,6 +381,9 @@ try {
   # The router plane is shared, so an install for one client changes the routable
   # set for the other. Republish whichever integration is already installed here
   # rather than leaving it advertising a stale model list.
+  if ($Target -ne "gemini" -and (Test-NonEmptyFile (Join-Path $StateRoot "gemini-models.json"))) {
+    & node src/gemini-config-manager.mjs install | Out-Null
+  }
   if ($Target -ne "dsh" -and (Test-NonEmptyFile (Join-Path $StateRoot "dsh-models.json"))) {
     & node src/dsh-config-manager.mjs install | Out-Null
     if ($LASTEXITCODE -ne 0) { throw "DeepSeek Harness republish failed." }
@@ -402,6 +409,9 @@ try {
   if ($LASTEXITCODE -ne 0) { throw "Install-manifest recording failed." }
   if ($Target -eq "dsh") {
     Write-Host "Published the selected external model routes to DeepSeek Harness. It reloads them on the next request."
+  } elseif ($Target -eq "gemini") {
+    Write-Host "Published the selected external model routes to Gemini CLI. The next 'gemini' run picks them up."
+    Write-Host "Choose 'Use Gemini API key' once if it asks how to authenticate; the key is this router's local caller capability."
   } else {
     Write-Host "Installed the selected external model routes. Fully quit and reopen Codex."
   }

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,8 @@ Install external model routes for Codex or DeepSeek Harness.
 
 Options:
   --install-dir PATH  Stable checkout used by the background service
-  --target APP        Install for "codex" (default) or "dsh" (DeepSeek Harness)
+  --target APP        Install for "codex" (default), "dsh" (DeepSeek Harness),
+                      or "gemini" (Gemini CLI)
   --prepare-only      Install dependencies without changing either app
   --api-key           Alias for --kimi-api-key
   --kimi-api-key      Prompt securely for a Kimi Platform API key
@@ -99,7 +100,7 @@ local_modifications_message() {
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --target)
-      [ "$#" -ge 2 ] || die "--target requires codex or dsh"
+      [ "$#" -ge 2 ] || die "--target requires codex, dsh, or gemini"
       target=$2
       shift 2
       ;;
@@ -185,8 +186,8 @@ while [ "$#" -gt 0 ]; do
 done
 
 case "$target" in
-  codex|dsh) ;;
-  *) die "--target must be codex or dsh" ;;
+  codex|dsh|gemini) ;;
+  *) die "--target must be codex, dsh, or gemini" ;;
 esac
 # Legacy migration replaces an older router's managed Codex config block, and
 # the native catalog is the ChatGPT-plan model list Codex adopts. Neither has a

--- a/src/caller-auth.mjs
+++ b/src/caller-auth.mjs
@@ -37,6 +37,20 @@ export function callerBaseUrl(port, secret) {
   return `http://127.0.0.1:${port}${callerBasePath(secret)}`;
 }
 
+// The Gemini API leaf, behind the identical capability in the identical
+// position. Gemini CLI hands its base URL to @google/genai, which appends
+// `/v1beta/models/{model}:{method}` itself -- so the secret has to be a path
+// prefix here, and the leaf stops at `gemini` rather than naming a version the
+// SDK is going to add. Every leaf must also be known to `redactCallerUrl`
+// below, or the key reaches doctor output and support bundles in the clear.
+export function geminiBasePath(secret) {
+  return `${CALLER_PATH_PREFIX}/${assertCallerSecret(secret)}/gemini`;
+}
+
+export function geminiBaseUrl(port, secret) {
+  return `http://127.0.0.1:${port}${geminiBasePath(secret)}`;
+}
+
 // The companion's browser surface sits behind the same capability as the API,
 // so it is the same secret in the same position -- only the leaf differs. Built
 // here rather than assembled by the caller so the one place that knows the
@@ -61,7 +75,7 @@ export function authenticatedRoute(pathname, expectedSecret) {
   return remainder.slice(separator) || "/";
 }
 
-export function isManagedCallerBaseUrl(value, port) {
+function isManagedLeafBaseUrl(value, port, leaf) {
   if (typeof value !== "string" || !value) return false;
   try {
     const url = new URL(value);
@@ -79,12 +93,25 @@ export function isManagedCallerBaseUrl(value, port) {
       return false;
     }
     const match = url.pathname.match(
-      new RegExp(`^${CALLER_PATH_PREFIX}/([A-Za-z0-9_-]+)/v1/?$`),
+      new RegExp(`^${CALLER_PATH_PREFIX}/([A-Za-z0-9_-]+)/${leaf}/?$`),
     );
     return Boolean(match && validCallerSecret(match[1]));
   } catch {
     return false;
   }
+}
+
+export function isManagedCallerBaseUrl(value, port) {
+  return isManagedLeafBaseUrl(value, port, "v1");
+}
+
+// The base URL the Gemini integration writes. Checked separately from the
+// Responses one because the two are not interchangeable: a client pointed at
+// `/v1` speaks Responses and a client pointed at `/gemini` speaks Gemini, so
+// accepting either as "managed" would let a repair leave a working-looking
+// configuration that 404s on every turn.
+export function isManagedGeminiBaseUrl(value, port) {
+  return isManagedLeafBaseUrl(value, port, "gemini");
 }
 
 // Every leaf the capability guards, not just `/v1`. Redaction is what keeps the
@@ -95,7 +122,7 @@ export function isManagedCallerBaseUrl(value, port) {
 export function redactCallerUrl(value) {
   if (typeof value !== "string") return value;
   return value.replace(
-    new RegExp(`(${CALLER_PATH_PREFIX}/)[A-Za-z0-9_-]+(?=/(?:v1|panel)(?:/|$))`, "g"),
+    new RegExp(`(${CALLER_PATH_PREFIX}/)[A-Za-z0-9_-]+(?=/(?:v1|panel|gemini)(?:/|$))`, "g"),
     "$1[REDACTED]",
   );
 }

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -8,7 +8,7 @@ import { promoteNativeMultiAgent } from "./catalog.mjs";
 // The publish marker lives under the shared state directory, which does not
 // vary by target, so reading it here does not disturb the per-target probes
 // below that re-import paths with their own MODEL_ROUTER_TARGET.
-import { DSH_CATALOG_PATH } from "./paths.mjs";
+import { DSH_CATALOG_PATH, GEMINI_CATALOG_PATH } from "./paths.mjs";
 // Same reasoning: presence is a property of the shared plane, not of a target,
 // so the overview can resolve it statically without perturbing those probes.
 import { presenceSnapshot } from "./presence-state.mjs";
@@ -27,7 +27,12 @@ const REPO_ROOT = path.resolve(path.dirname(SELF), "..");
 // run. `dsh-models.json` is written by the publish and removed by the
 // uninstall, so its presence is exactly the question being asked.
 const DSH_PUBLISHED = DSH_CATALOG_PATH;
-const TARGETS = existsSync(DSH_PUBLISHED) ? ["codex", "dsh"] : ["codex"];
+const GEMINI_PUBLISHED = GEMINI_CATALOG_PATH;
+const TARGETS = [
+  "codex",
+  ...(existsSync(DSH_PUBLISHED) ? ["dsh"] : []),
+  ...(existsSync(GEMINI_PUBLISHED) ? ["gemini"] : []),
+];
 const args = process.argv.slice(2);
 
 function targetIsActive(target) {
@@ -35,6 +40,9 @@ function targetIsActive(target) {
   // service's own status for more than one of them. For the harness it is
   // whether the route has been published into its settings document.
   if (target === "dsh") return existsSync(DSH_PUBLISHED);
+  // Same question for Gemini CLI: whether this router published its `.env`
+  // block. The CLI itself is not a resident process there is anything to poll.
+  if (target === "gemini") return existsSync(GEMINI_PUBLISHED);
   const result = spawnSync(process.execPath, [path.join(REPO_ROOT, "src", "service.mjs"), "status"], {
     env: { ...process.env, MODEL_ROUTER_TARGET: target },
     encoding: "utf8",
@@ -403,7 +411,9 @@ function refreshActiveTarget(target) {
       ? [process.execPath, [path.join(REPO_ROOT, "src", "catalog.mjs")]]
       : target === "dsh"
         ? [process.execPath, [path.join(REPO_ROOT, "src", "dsh-config-manager.mjs"), "install"]]
-        : undefined;
+        : target === "gemini"
+          ? [process.execPath, [path.join(REPO_ROOT, "src", "gemini-config-manager.mjs"), "install"]]
+          : undefined;
   if (!command) return;
   const result = spawnSync(command[0], command[1], {
     env: { ...process.env, MODEL_ROUTER_TARGET: target },

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -28,6 +28,8 @@ import {
   CONFIG_PATH,
   DSH_CATALOG_PATH,
   DSH_SETTINGS_PATH,
+  GEMINI_CATALOG_PATH,
+  GEMINI_ENV_PATH,
   INTERNAL_SECRET_PATH,
   LITELLM_CONFIG_PATH,
   MERGED_CATALOG_PATH,
@@ -333,14 +335,22 @@ if (codexTarget) {
 }
 // Both clients hold the managed base URL, which is a local caller capability,
 // so both documents are held to the same privacy bound.
-const privacyTarget = codexTarget ? CONFIG_PATH : DSH_SETTINGS_PATH;
+const privacyTarget = codexTarget
+  ? CONFIG_PATH
+  : TARGET === "gemini"
+    ? GEMINI_ENV_PATH
+    : DSH_SETTINGS_PATH;
 const configMode = existsSync(privacyTarget)
   ? statSync(privacyTarget).mode & 0o777
   : undefined;
 const configProtected = privateFileIsProtected(privacyTarget);
 add(
   configProtected ? "ok" : "fail",
-  codexTarget ? "Codex config privacy" : "Harness settings privacy",
+  codexTarget
+    ? "Codex config privacy"
+    : TARGET === "gemini"
+      ? "Gemini environment privacy"
+      : "Harness settings privacy",
   configMode === undefined
     ? "missing"
     : process.platform === "win32"
@@ -359,7 +369,9 @@ let requiredModels = new Set();
 // model as unoffered on a machine that has no Codex at all.
 const routedTransportActive = codexTarget
   ? routedCatalogConfigured(existsSync(CONFIG_PATH) ? readFileSync(CONFIG_PATH, "utf8") : "")
-  : existsSync(DSH_CATALOG_PATH);
+  : TARGET === "gemini"
+    ? existsSync(GEMINI_CATALOG_PATH)
+    : existsSync(DSH_CATALOG_PATH);
 // An install made with --no-provider --no-discovery is idle on purpose: the
 // selection is an explicit empty list and the discovery marker is set. That
 // state is what the operator asked for, so the empty selection and the empty
@@ -814,7 +826,57 @@ for (const provider of PROVIDERS.values()) {
   }
 }
 
-if (TARGET === "dsh") {
+if (TARGET === "gemini") {
+  try {
+    const gemini = childJson("gemini-config-manager.mjs", ["status"]);
+    add(
+      gemini.installed && gemini.baseUrlManaged ? "ok" : "fail",
+      "Gemini routing config",
+      gemini.installed
+        ? gemini.baseUrlManaged
+          ? `${gemini.managedKeys.join(", ")} in ${gemini.envPath}`
+          : `${gemini.envPath} names a base URL this router does not serve (${gemini.baseUrl})`
+        : `no managed block in ${gemini.envPath}`,
+      "Run ./bin/model-router gemini enable.",
+    );
+    // A managed key assigned outside the block is the failure mode this
+    // integration has that the others do not: dotenv lets the last assignment
+    // of a key win, so a duplicate silently decides the endpoint or the
+    // credential and nothing about the file says which one is in force.
+    add(
+      gemini.documentReadable && !gemini.conflicts.length ? "ok" : "fail",
+      "Gemini environment conflicts",
+      !gemini.documentReadable
+        ? `${gemini.envPath} could not be read plainly; its managed block markers are damaged`
+        : gemini.conflicts.length
+          ? gemini.conflicts.map(({ key, line }) => `${key} (line ${line})`).join(", ")
+          : "no competing assignments",
+      `Remove or comment out the competing assignments in ${gemini.envPath}, then run ./bin/model-router gemini enable.`,
+    );
+    // The model list is served live off the router's own catalog, so it cannot
+    // drift. The published default model can: it is one slug, written once, and
+    // a default naming a model the routable set has lost puts every fresh
+    // session on a 404 before the user has typed anything.
+    const drift = childJson("gemini-config-manager.mjs", ["drift"]);
+    add(
+      drift.defaultMissing ? "warn" : "ok",
+      "Gemini default model",
+      gemini.defaultModel
+        ? drift.defaultMissing
+          ? `${gemini.defaultModel} is no longer routable`
+          : gemini.defaultModel
+        : "not set; Gemini CLI will use its own default unless --model is passed",
+      "Run ./bin/model-router gemini enable to republish.",
+    );
+  } catch (error) {
+    add(
+      "fail",
+      "Gemini routing config",
+      error instanceof Error ? error.message : String(error),
+      `Inspect ${GEMINI_ENV_PATH}, then run ./bin/model-router gemini enable.`,
+    );
+  }
+} else if (TARGET === "dsh") {
   try {
     const dsh = childJson("dsh-config-manager.mjs", ["status"]);
     add(

--- a/src/dsh-catalog.mjs
+++ b/src/dsh-catalog.mjs
@@ -135,30 +135,12 @@ export function dshCatalogModels(selectedModels, visionEngine) {
 /**
  * Native GPT models, shaped for the harness route.
  *
- * These are authorized by a ChatGPT session rather than an API key, so they are
- * publishable only while the router can supply one -- see
- * `codex-native-session.mjs`. The caller decides that; this function only maps.
- *
- * `visibility: "hide"` entries are Codex's own internal variants (a watermarked
- * build, the auto-review model) and are not offered to anybody.
+ * The shaping is not harness-specific -- the Gemini integration publishes the
+ * identical set under the identical rule -- so it lives in
+ * `routed-client-models.mjs` and is re-exported here under the name its
+ * existing callers already use.
  */
-export function dshNativeModels(nativeCatalogModels) {
-  return (nativeCatalogModels || [])
-    .filter((model) => model?.slug && model.visibility !== "hide")
-    .map((model) => ({
-      slug: String(model.slug),
-      displayName: model.display_name ? `${model.display_name} (Codex)` : String(model.slug),
-      contextWindow: Number.isFinite(model.context_window) ? model.context_window : undefined,
-      inputModalities: Array.isArray(model.input_modalities) ? model.input_modalities : ["text"],
-      reasoningLevels: Array.isArray(model.supported_reasoning_levels)
-        ? model.supported_reasoning_levels
-            .filter((level) => level?.effort)
-            .map((level) => ({ effort: level.effort }))
-        : [],
-      priority: Number.isFinite(model.priority) ? -model.priority : undefined,
-      native: true,
-    }));
-}
+export { nativeClientModels as dshNativeModels } from "./routed-client-models.mjs";
 
 /** The model a fresh harness agent should start on: the highest priority one. */
 export function dshDefaultModel(models) {

--- a/src/dsh-config-manager.mjs
+++ b/src/dsh-config-manager.mjs
@@ -22,7 +22,6 @@ import {
   DSH_HOME,
   DSH_SETTINGS_PATH,
   CALLER_SECRET_PATH,
-  NATIVE_CATALOG_PATH,
   PORTS,
 } from "./paths.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
@@ -30,20 +29,13 @@ import {
   DSH_CREDENTIAL_REF,
   DSH_ROUTE_ID,
   buildDshRoute,
-  dshCatalogModels,
   dshDefaultModel,
-  dshNativeModels,
   renderDshRouteLines,
   unmappableEfforts,
 } from "./dsh-catalog.mjs";
-import { readHiddenModels } from "./model-picker-state.mjs";
 import { readMultiAgentSettings, subagentEligibleModels } from "./multi-agent-state.mjs";
-import { applySubagentProofs, subagentProofSnapshot } from "./subagent-proofs.mjs";
-import { selectedConfiguredListedModels } from "./provider-selection.mjs";
 import { assertStateOwnership } from "./state-owner.mjs";
-import { nativeSessionAvailable } from "./codex-native-session.mjs";
-import { resolveVisionEngine } from "./vision-bridge.mjs";
-import { readVisionBridgeSettings } from "./vision-bridge-state.mjs";
+import { routedClientModels } from "./routed-client-models.mjs";
 import { scanYamlDocument, spliceYamlBlock, yamlNode, yamlScalar } from "./yaml-structure.mjs";
 
 const ROUTE_PATH = ["llm-pi-ai", "providers", DSH_ROUTE_ID];
@@ -253,44 +245,17 @@ function restoreDefaultModel(contents) {
   return { contents: joinLines(normalizeTrailing(lines)), restored: true };
 }
 
-// The native catalog Codex itself published, captured by `catalog.mjs`. Read
-// rather than re-derived: it is the same document the Codex picker is built
-// from, so the harness cannot end up advertising a native model Codex does not
-// have. Absent simply means no native models are offered.
-function readNativeCatalogModels() {
-  if (!existsSync(NATIVE_CATALOG_PATH)) return [];
-  try {
-    const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
-    return Array.isArray(parsed?.models) ? parsed.models : [];
-  } catch {
-    return [];
-  }
-}
-
-/** The routed models the harness should be offered, vision bridge included. */
+/**
+ * The routed models the harness should be offered, vision bridge included.
+ *
+ * The rule is not the harness's own -- what may be published to a client that
+ * carries no ChatGPT session of its own is the same question for every such
+ * client -- so it lives in `routed-client-models.mjs` and both integrations
+ * read it. Two copies would drift, and the way that shows is one picker
+ * offering a model the other just lost.
+ */
 export function dshRoutedModels() {
-  const hidden = readHiddenModels();
-  // The same machine-local capability proofs the Codex catalog honors: a
-  // model this machine verified as a subagent is one everywhere the proven
-  // set is consumed, or the harness's tool-subagent preset silently disagrees
-  // with the picker about which children exist.
-  const selected = applySubagentProofs(
-    selectedConfiguredListedModels().filter((model) => !hidden.has(String(model.slug))),
-    subagentProofSnapshot(),
-    { hidden, disabled: readMultiAgentSettings().disabled },
-  );
-  // Native GPT models are authorized by a ChatGPT session rather than an API
-  // key. The harness carries none of its own -- but this machine is signed in
-  // to Codex, and the router relays that session for a caller that brought
-  // nothing (see `codex-native-session.mjs`). So they are publishable exactly
-  // while that fallback can supply one, and withheld the moment it cannot.
-  const native = nativeSessionAvailable() ? dshNativeModels(readNativeCatalogModels()) : [];
-  // The vision engine still resolves over routed candidates only. A native
-  // engine is spent per-caller, and `vision-engines` wants each call site to
-  // name its evidence; this one's is that a bridge read is issued by the router
-  // on the caller's behalf, which is not the same as relaying their turn.
-  const engine = resolveVisionEngine(() => selected, readVisionBridgeSettings());
-  return { models: [...dshCatalogModels(selected, engine), ...native], engine };
+  return routedClientModels();
 }
 
 function buildRoute() {

--- a/src/gemini-config-manager.mjs
+++ b/src/gemini-config-manager.mjs
@@ -1,0 +1,227 @@
+// Publishes the router's routed models into Gemini CLI.
+//
+// One document, three keys, and nothing else. Gemini CLI reads its endpoint,
+// its credential, and its default model from the environment and loads
+// `~/.gemini/.env` for them at startup, so that file is the entire
+// integration surface -- its `settings.json` is JSONC carrying the user's own
+// comments and is never opened for writing.
+//
+// The models themselves are not copied anywhere. `/gemini/v1beta/models` is
+// served live off the same catalog the router already publishes, which is why
+// this manager has no model list to keep in step and no drift to repair beyond
+// the base URL and the default model.
+
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertCallerSecret,
+  geminiBaseUrl,
+  isManagedGeminiBaseUrl,
+  redactCallerUrl,
+} from "./caller-auth.mjs";
+import {
+  CALLER_SECRET_PATH,
+  GEMINI_ENV_PATH,
+  GEMINI_CATALOG_PATH,
+  PORTS,
+} from "./paths.mjs";
+import { writePrivateFile, writePrivateJson } from "./file-security.mjs";
+import {
+  GEMINI_MANAGED_KEYS,
+  conflictingAssignments,
+  removeGeminiEnvBlock,
+  spliceGeminiEnvBlock,
+} from "./gemini-env.mjs";
+import { routedClientModels } from "./routed-client-models.mjs";
+import { assertStateOwnership } from "./state-owner.mjs";
+
+function callerSecret() {
+  if (!existsSync(CALLER_SECRET_PATH)) {
+    throw new Error("The local router caller key is missing; run ./bin/doctor --fix.");
+  }
+  return assertCallerSecret(readFileSync(CALLER_SECRET_PATH, "utf8").trim());
+}
+
+function callerBase() {
+  return geminiBaseUrl(PORTS.router, callerSecret());
+}
+
+function readDocument(target) {
+  return existsSync(target) ? readFileSync(target, "utf8") : "";
+}
+
+/** The model a fresh Gemini CLI session should start on: the highest priority one. */
+export function geminiDefaultModel(models) {
+  const ranked = [...models].sort(
+    (left, right) =>
+      (right.priority ?? 0) - (left.priority ?? 0) ||
+      String(left.slug).localeCompare(String(right.slug)),
+  );
+  return ranked[0]?.slug;
+}
+
+/** The routed models Gemini CLI should be offered. */
+export function geminiRoutedModels() {
+  return routedClientModels();
+}
+
+// A managed key assigned outside our block would out-rank or be out-ranked by
+// ours depending on which came last, and dotenv resolves that silently. Name
+// the line and stop rather than write a file whose behaviour nobody can predict
+// from reading it.
+function assertNoConflicts(document) {
+  const conflicts = conflictingAssignments(document);
+  if (!conflicts.length) return;
+  const named = conflicts.map(({ key, line }) => `${key} (line ${line})`).join(", ");
+  throw new Error(
+    `${GEMINI_ENV_PATH} already assigns ${named} outside the router's managed block. ` +
+      "Remove or comment those out, then publish again -- the router will not " +
+      "overwrite an assignment it did not write.",
+  );
+}
+
+/**
+ * Writes the managed block and records what it published.
+ *
+ * `setDefaultModel` is on by default, unlike the harness integration's
+ * equivalent, because it is not a convenience here: Gemini CLI's own default is
+ * `gemini-2.5-pro`, which is not a routed slug, so an integration that left it
+ * alone would 404 on the user's first turn. It out-ranks `settings.json`'s
+ * `model.name` and is out-ranked by `--model`, which is stated in the docs and
+ * is why it can be turned off.
+ */
+export function publishGeminiIntegration({
+  setDefaultModel = true,
+  routedModels = geminiRoutedModels,
+} = {}) {
+  assertStateOwnership("publish the Gemini CLI integration");
+  const { models, engine } = routedModels();
+  const baseUrl = callerBase();
+  const document = readDocument(GEMINI_ENV_PATH);
+  assertNoConflicts(document);
+  const defaultModel = setDefaultModel ? geminiDefaultModel(models) : undefined;
+  const written = spliceGeminiEnvBlock(document, {
+    GOOGLE_GEMINI_BASE_URL: baseUrl,
+    GEMINI_API_KEY: callerSecret(),
+    GEMINI_MODEL: defaultModel,
+  });
+  // The document carries the caller key and the managed base URL, which is a
+  // local caller capability, so the file is 0600 -- the same bound Gemini CLI
+  // holds its own credential store to. `writePrivateFile` creates a missing
+  // `~/.gemini` at 0700 and deliberately does not re-mode an existing one:
+  // that directory is Gemini CLI's, not the router's, and the 0600 on the file
+  // is what protects the key either way.
+  writePrivateFile(GEMINI_ENV_PATH, written);
+  writePrivateJson(GEMINI_CATALOG_PATH, {
+    updatedAt: new Date().toISOString(),
+    baseUrl,
+    defaultModel: defaultModel ?? null,
+    models: models.map((model) => String(model.slug)),
+  });
+  return { models, engine, defaultModel, baseUrl };
+}
+
+/** Removes the managed block, leaving the rest of the document exactly as found. */
+export function removeGeminiIntegration() {
+  assertStateOwnership("remove the Gemini CLI integration");
+  const document = readDocument(GEMINI_ENV_PATH);
+  const written = removeGeminiEnvBlock(document);
+  // A document that is now empty is one the router created; anything else is
+  // the user's and keeps its file.
+  if (existsSync(GEMINI_ENV_PATH)) {
+    if (written.trim() === "") unlinkSync(GEMINI_ENV_PATH);
+    else writePrivateFile(GEMINI_ENV_PATH, written);
+  }
+  if (existsSync(GEMINI_CATALOG_PATH)) unlinkSync(GEMINI_CATALOG_PATH);
+  return { removed: document !== written };
+}
+
+/** What is published, for `status`, `doctor`, and the tray. */
+export function geminiIntegrationStatus() {
+  const document = readDocument(GEMINI_ENV_PATH);
+  let published;
+  try {
+    published = existsSync(GEMINI_CATALOG_PATH)
+      ? JSON.parse(readFileSync(GEMINI_CATALOG_PATH, "utf8"))
+      : undefined;
+  } catch {
+    published = undefined;
+  }
+  // A document the lexer refuses has no trustworthy conflict list, so the two
+  // are reported together: `documentReadable: false` is the finding, and an
+  // empty `conflicts` beside it does not mean there are none.
+  let documentReadable = true;
+  let conflicts = [];
+  try {
+    conflicts = conflictingAssignments(document);
+  } catch {
+    documentReadable = false;
+  }
+  return {
+    envPath: GEMINI_ENV_PATH,
+    envExists: existsSync(GEMINI_ENV_PATH),
+    installed: existsSync(GEMINI_CATALOG_PATH),
+    documentReadable,
+    conflicts,
+    managedKeys: [...GEMINI_MANAGED_KEYS],
+    // Never the complete URL: it carries the caller capability, and status
+    // output reaches doctor, the tray, and support bundles.
+    baseUrl: published?.baseUrl ? redactCallerUrl(published.baseUrl) : null,
+    baseUrlManaged: published?.baseUrl
+      ? isManagedGeminiBaseUrl(published.baseUrl, PORTS.router)
+      : false,
+    defaultModel: published?.defaultModel ?? null,
+    publishedModels: Array.isArray(published?.models) ? published.models : [],
+    updatedAt: published?.updatedAt ?? null,
+  };
+}
+
+/**
+ * Models the last publish advertised that the router no longer routes.
+ *
+ * The catalog is served live, so the model list itself cannot drift -- but the
+ * published default model can, and a default naming a model that is gone puts
+ * every fresh session on a 404.
+ */
+export function geminiCatalogDrift({ routedModels = geminiRoutedModels } = {}) {
+  if (!existsSync(GEMINI_CATALOG_PATH)) return undefined;
+  const status = geminiIntegrationStatus();
+  const routable = new Set(routedModels().models.map((model) => String(model.slug)));
+  const missing = status.publishedModels.filter((slug) => !routable.has(slug));
+  const added = [...routable].filter((slug) => !status.publishedModels.includes(slug));
+  const defaultMissing = Boolean(status.defaultModel && !routable.has(status.defaultModel));
+  return { missing, added, defaultMissing };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const command = process.argv[2] || "status";
+  const handlers = {
+    status: () => geminiIntegrationStatus(),
+    // `--no-default-model` rather than `--set-default-model`: Gemini CLI's own
+    // default is a Gemini model this router does not route, so an install that
+    // left it alone would 404 on the user's first turn.
+    install: () =>
+      publishGeminiIntegration({
+        setDefaultModel: !process.argv.includes("--no-default-model"),
+      }),
+    uninstall: () => removeGeminiIntegration(),
+    drift: () => geminiCatalogDrift() ?? { installed: false },
+  };
+  const handler = handlers[command];
+  if (!handler) {
+    console.error(`Usage: gemini-config-manager ${Object.keys(handlers).join("|")}`);
+    process.exit(2);
+  }
+  try {
+    process.stdout.write(`${JSON.stringify(handler(), null, 2)}\n`);
+  } catch (error) {
+    if (error?.code === "foreign_state_owner") {
+      console.error(error.message);
+      process.exit(1);
+    }
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/gemini-env.mjs
+++ b/src/gemini-env.mjs
@@ -1,0 +1,138 @@
+// The one document the Gemini integration writes: `$GEMINI_HOME/.env`.
+//
+// Gemini CLI resolves its endpoint, its credential, and its default model from
+// the environment (`GOOGLE_GEMINI_BASE_URL`, `GEMINI_API_KEY`, `GEMINI_MODEL`),
+// and loads a `.env` for them at startup. That is the whole integration: no
+// edit to the user's `settings.json`, which is JSONC and carries their comments,
+// and no second copy of the model catalog to keep in step.
+//
+// The file may still be theirs. So the router owns a marker-delimited block and
+// treats every other byte as somebody else's work: publishing twice is
+// byte-identical, removing the block restores the document exactly, and a
+// document the lexer cannot read plainly is refused with the file untouched and
+// the reason named. `dotenv` lets the last assignment of a key win, so a
+// duplicate below our block would silently decide the base URL -- that is
+// reported rather than rewritten.
+
+export const GEMINI_ENV_BEGIN = "# BEGIN codex-router-gemini";
+export const GEMINI_ENV_END = "# END codex-router-gemini";
+
+// Ordered: the block is rendered in this sequence, which is what makes a
+// republish byte-identical rather than merely equivalent.
+export const GEMINI_MANAGED_KEYS = Object.freeze([
+  "GOOGLE_GEMINI_BASE_URL",
+  "GEMINI_API_KEY",
+  "GEMINI_MODEL",
+]);
+
+const ASSIGNMENT = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=/;
+
+function newline(document) {
+  return document.includes("\r\n") ? "\r\n" : "\n";
+}
+
+function splitLines(document) {
+  return document.split(/\r\n|\n/);
+}
+
+// Locates our block, and refuses anything ambiguous.
+//
+// A missing end marker or a second begin marker means somebody edited the file
+// by hand in a way this lexer cannot resolve. Splicing on a guess there rewrites
+// a document whose only copy is on the user's disk; refusing costs a command.
+function locateBlock(lines) {
+  const begins = [];
+  const ends = [];
+  lines.forEach((line, index) => {
+    if (line.trim() === GEMINI_ENV_BEGIN) begins.push(index);
+    if (line.trim() === GEMINI_ENV_END) ends.push(index);
+  });
+  if (!begins.length && !ends.length) return undefined;
+  if (begins.length > 1) {
+    throw new Error(
+      `${GEMINI_ENV_BEGIN} appears more than once; resolve the duplicate by hand before publishing.`,
+    );
+  }
+  if (!begins.length) {
+    throw new Error(
+      `${GEMINI_ENV_END} appears with no begin marker; resolve it by hand before publishing.`,
+    );
+  }
+  const end = ends.find((index) => index > begins[0]);
+  if (end === undefined) {
+    throw new Error(
+      `The managed block has no end marker (${GEMINI_ENV_END}); resolve it by hand before publishing.`,
+    );
+  }
+  return { start: begins[0], end };
+}
+
+// `.env` values are unquoted by default. Anything with whitespace, a quote, or
+// a `#` needs quoting or dotenv reads a truncated value -- and a truncated base
+// URL is a caller capability that no longer authenticates.
+function renderValue(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_\-./:@+=~]*$/.test(text)) return text;
+  return `"${text.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
+function renderBlock(values) {
+  const lines = [GEMINI_ENV_BEGIN];
+  for (const key of GEMINI_MANAGED_KEYS) {
+    const value = values?.[key];
+    // Omitted, never blank: `GEMINI_MODEL=` out-ranks the user's own
+    // `settings.json` choice with an empty string, which reads to the CLI as a
+    // model named "".
+    if (value === undefined || value === null || value === "") continue;
+    lines.push(`${key}=${renderValue(value)}`);
+  }
+  lines.push(GEMINI_ENV_END);
+  return lines;
+}
+
+/** Every managed key assigned outside our block, with its 1-based line number. */
+export function conflictingAssignments(document) {
+  const lines = splitLines(String(document ?? ""));
+  const block = locateBlock(lines);
+  const found = [];
+  lines.forEach((line, index) => {
+    if (block && index >= block.start && index <= block.end) return;
+    const match = ASSIGNMENT.exec(line);
+    if (!match) return;
+    if (!GEMINI_MANAGED_KEYS.includes(match[1])) return;
+    found.push({ key: match[1], line: index + 1 });
+  });
+  return found;
+}
+
+/** The document with the managed block written, replaced in place if present. */
+export function spliceGeminiEnvBlock(document, values) {
+  const text = String(document ?? "");
+  const eol = newline(text);
+  const lines = splitLines(text);
+  const block = locateBlock(lines);
+  const rendered = renderBlock(values);
+  if (block) {
+    const next = [...lines.slice(0, block.start), ...rendered, ...lines.slice(block.end + 1)];
+    return next.join(eol);
+  }
+  // Appended, so an existing document keeps its own leading content and its own
+  // trailing newline discipline. A file that did not end in a newline gains one
+  // here because the block has to start on its own line.
+  const prefix = text === "" ? [] : lines[lines.length - 1] === "" ? lines.slice(0, -1) : lines;
+  return [...prefix, ...rendered, ""].join(eol);
+}
+
+/** The document with the managed block removed, byte-identical to before it was written. */
+export function removeGeminiEnvBlock(document) {
+  const text = String(document ?? "");
+  const eol = newline(text);
+  const lines = splitLines(text);
+  const block = locateBlock(lines);
+  if (!block) return text;
+  const next = [...lines.slice(0, block.start), ...lines.slice(block.end + 1)];
+  // The block was appended onto a document that already ended in a newline, so
+  // its removal leaves the trailing empty element that split produced. Anything
+  // else in the document is left exactly as it was found.
+  return next.join(eol);
+}

--- a/src/gemini-shape.mjs
+++ b/src/gemini-shape.mjs
@@ -1,0 +1,465 @@
+// Translation between the Gemini generateContent API and the Responses API.
+//
+// Gemini CLI cannot speak anything but Gemini: with `GEMINI_API_KEY` set it
+// builds a `@google/genai` client and calls `{baseUrl}/v1beta/models/{model}:
+// {method}` directly (see `createContentGenerator` in @google/gemini-cli-core).
+// So a client integration for it needs a Gemini-shaped surface, which is the
+// one thing AGENTS.md tells the harness integration not to add for itself.
+//
+// The rule behind that instruction still holds, though, and this module is how:
+// nothing here talks to a provider. It converts a Gemini request into a
+// Responses request and a Responses answer back into a Gemini answer, and
+// `gemini-surface.mjs` sends the middle through the router's own
+// `/v1/responses` endpoint. There is still exactly one request path to keep
+// correct -- tool-result ageing, the vision bridge, prompt-token substitution,
+// upstream retry, failover, and usage accounting all sit on it -- and this file
+// is a pure function on either side of it.
+
+// @google/genai's GOOGLE_AI_API_DEFAULT_VERSION. The SDK joins the configured
+// base URL and this string itself, so serving any other version means the CLI's
+// requests 404 against a surface that is otherwise complete.
+export const GEMINI_API_VERSION = "v1beta";
+
+const MODELS_PREFIX = `/${GEMINI_API_VERSION}/models`;
+// `embedContent` is recognized here but not served: parsing it is what lets the
+// surface answer with a 501 that names the limit instead of a bare 404 that
+// looks like a broken base URL. Gemini CLI calls it from `baseLlmClient` only,
+// never from the turn loop.
+const SUPPORTED_METHODS = new Set([
+  "generateContent",
+  "streamGenerateContent",
+  "countTokens",
+  "embedContent",
+]);
+
+export const GEMINI_GENERATION_METHODS = Object.freeze([
+  "generateContent",
+  "streamGenerateContent",
+  "countTokens",
+]);
+
+// The same crude ratio `response-usage.mjs` uses for prompt estimates. It needs
+// no tokenizer download and is measured against the bytes that would go
+// upstream rather than against a model of the conversation.
+const ESTIMATE_BYTES_PER_TOKEN = 4;
+
+/**
+ * Splits a Gemini request path into its model and method.
+ *
+ * Router slugs carry a slash (`vendor/model`), and the SDK renders
+ * `models/{model}:{method}` verbatim -- so the model is everything between the
+ * prefix and the *last* colon, not the first path segment. An unrecognized
+ * shape returns undefined rather than a guess: the surface answers those with a
+ * 404 that names the path, which is a far better failure than routing a
+ * `tunedModels/...` request to whatever slug the parse happened to produce.
+ */
+export function parseGeminiPath(pathname) {
+  if (typeof pathname !== "string") return undefined;
+  const withoutQuery = pathname.split("?", 1)[0];
+  if (withoutQuery === MODELS_PREFIX || withoutQuery === `${MODELS_PREFIX}/`) {
+    return { method: "list" };
+  }
+  if (!withoutQuery.startsWith(`${MODELS_PREFIX}/`)) return undefined;
+  const remainder = withoutQuery.slice(MODELS_PREFIX.length + 1);
+  const separator = remainder.lastIndexOf(":");
+  if (separator <= 0) return undefined;
+  const model = remainder.slice(0, separator);
+  const method = remainder.slice(separator + 1);
+  if (!model || !SUPPORTED_METHODS.has(method)) return undefined;
+  return { model, method };
+}
+
+function textOf(value) {
+  if (typeof value === "string") return value;
+  if (value && typeof value === "object") {
+    const parts = Array.isArray(value.parts) ? value.parts : [];
+    const text = parts
+      .map((part) => (typeof part?.text === "string" ? part.text : ""))
+      .filter(Boolean)
+      .join("\n");
+    return text || undefined;
+  }
+  return undefined;
+}
+
+function inlineDataUrl(inlineData) {
+  const mimeType = String(inlineData?.mimeType || "application/octet-stream");
+  const data = String(inlineData?.data || "");
+  return `data:${mimeType};base64,${data}`;
+}
+
+// Gemini omits `id` on both halves of a tool exchange whenever the caller did
+// not supply one, so the pairing has to be rebuilt positionally: the nth call
+// to a tool answers the nth response for that tool. Responses silently drops a
+// `function_call_output` whose `call_id` matches no call, and to the model that
+// reads as a tool that was asked and never answered.
+function callIdAllocator() {
+  const calls = new Map();
+  const results = new Map();
+  const next = (counter, name) => {
+    const index = counter.get(name) || 0;
+    counter.set(name, index + 1);
+    return `gemini_${name}_${index}`;
+  };
+  return {
+    forCall: (name, id) => (id ? String(id) : next(calls, name)),
+    forResult: (name, id) => (id ? String(id) : next(results, name)),
+  };
+}
+
+function userParts(parts, items, ids) {
+  const content = [];
+  for (const part of parts) {
+    if (typeof part?.text === "string" && part.text) {
+      content.push({ type: "input_text", text: part.text });
+      continue;
+    }
+    if (part?.inlineData) {
+      content.push({ type: "input_image", image_url: inlineDataUrl(part.inlineData) });
+      continue;
+    }
+    if (part?.fileData?.fileUri) {
+      content.push({ type: "input_image", image_url: String(part.fileData.fileUri) });
+      continue;
+    }
+    if (part?.functionResponse) {
+      const name = String(part.functionResponse.name || "");
+      items.push({
+        type: "function_call_output",
+        call_id: ids.forResult(name, part.functionResponse.id),
+        output: JSON.stringify(part.functionResponse.response ?? {}),
+      });
+    }
+  }
+  if (content.length) items.push({ type: "message", role: "user", content });
+}
+
+function modelParts(parts, items, ids) {
+  const text = [];
+  for (const part of parts) {
+    // `thought: true` is the model's own reasoning. Replaying it as an ordinary
+    // assistant message would put private reasoning into the visible transcript
+    // on every subsequent turn of the conversation.
+    if (typeof part?.text === "string" && part.text && !part.thought) {
+      text.push(part.text);
+      continue;
+    }
+    if (part?.functionCall) {
+      const name = String(part.functionCall.name || "");
+      items.push({
+        type: "function_call",
+        call_id: ids.forCall(name, part.functionCall.id),
+        name,
+        arguments: JSON.stringify(part.functionCall.args ?? {}),
+      });
+    }
+  }
+  if (text.length) {
+    items.push({
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: text.join("\n") }],
+    });
+  }
+}
+
+// A FunctionDeclaration can spell its schema two ways, and the one Gemini CLI
+// actually uses is the second: `tools.js` writes `parametersJsonSchema` for
+// every built-in tool and validates incoming calls against that same field.
+// Reading only `parameters` therefore sent the whole tool set upstream with no
+// schema at all -- the model invented argument names, and the CLI rejected each
+// call with "params must have required property 'file_path'". The raw JSON
+// Schema wins when both are present; `parameters` is the older Schema-proto
+// spelling and may be a lossy rendering of it.
+function declarationSchema(declaration) {
+  if (declaration.parametersJsonSchema) return declaration.parametersJsonSchema;
+  if (declaration.parameters) return declaration.parameters;
+  // Not omitted: a provider on the chat-completions path rejects a function
+  // whose parameters are absent, and "takes no arguments" is a schema.
+  return { type: "object", properties: {} };
+}
+
+function responsesTools(tools) {
+  const declared = [];
+  for (const tool of tools || []) {
+    for (const declaration of tool?.functionDeclarations || []) {
+      if (!declaration?.name) continue;
+      const entry = { type: "function", name: String(declaration.name) };
+      if (declaration.description) entry.description = String(declaration.description);
+      entry.parameters = declarationSchema(declaration);
+      declared.push(entry);
+    }
+  }
+  return declared.length ? declared : undefined;
+}
+
+function toolChoice(toolConfig) {
+  const mode = String(toolConfig?.functionCallingConfig?.mode || "").toUpperCase();
+  if (mode === "ANY") return "required";
+  if (mode === "NONE") return "none";
+  if (mode === "AUTO") return "auto";
+  return undefined;
+}
+
+// Gemini spends a token budget; Responses picks a rung on a ladder. There is no
+// exact correspondence, so the mapping is stated in one place and kept coarse
+// rather than spread through the surface as arithmetic nobody can review. A
+// negative budget is Gemini's "decide for me", which is what medium means here.
+function reasoningEffort(thinkingConfig) {
+  if (!thinkingConfig || typeof thinkingConfig !== "object") return undefined;
+  const budget = thinkingConfig.thinkingBudget;
+  if (!Number.isFinite(budget)) return undefined;
+  if (budget === 0) return "minimal";
+  if (budget < 0) return "medium";
+  if (budget <= 1024) return "low";
+  if (budget <= 8192) return "medium";
+  return "high";
+}
+
+/**
+ * Builds the Responses request for one Gemini turn.
+ *
+ * `instructions` rather than a leading system message on purpose: Responses
+ * carries the system prompt out of band, and folding it into the input array
+ * puts it in the transcript where tool-result ageing is entitled to drop it.
+ */
+export function geminiToResponsesPayload({ model, body, stream = false }) {
+  const request = body && typeof body === "object" ? body : {};
+  const ids = callIdAllocator();
+  const items = [];
+  const contents = Array.isArray(request.contents)
+    ? request.contents
+    : request.contents
+      ? [request.contents]
+      : [];
+  for (const content of contents) {
+    const parts = Array.isArray(content?.parts) ? content.parts : [];
+    if (String(content?.role || "user") === "model") modelParts(parts, items, ids);
+    else userParts(parts, items, ids);
+  }
+
+  const generation = request.generationConfig || {};
+  const payload = { model: String(model), input: items, stream: Boolean(stream) };
+  const instructions = textOf(request.systemInstruction);
+  if (instructions) payload.instructions = instructions;
+  const tools = responsesTools(request.tools);
+  if (tools) payload.tools = tools;
+  const choice = toolChoice(request.toolConfig);
+  if (choice) payload.tool_choice = choice;
+  if (Number.isFinite(generation.temperature)) payload.temperature = generation.temperature;
+  if (Number.isFinite(generation.topP)) payload.top_p = generation.topP;
+  if (Number.isFinite(generation.maxOutputTokens)) {
+    payload.max_output_tokens = generation.maxOutputTokens;
+  }
+  const effort = reasoningEffort(generation.thinkingConfig);
+  // Absent, not defaulted: with no thinking config the router applies the
+  // model's own request profile, which knows more about that model than a
+  // budget the client never sent.
+  if (effort) payload.reasoning = { effort };
+  return payload;
+}
+
+function parseArguments(value) {
+  if (typeof value !== "string" || !value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function functionCallPart(item) {
+  const call = { name: String(item?.name || ""), args: parseArguments(item?.arguments) };
+  const id = item?.call_id || item?.id;
+  return { functionCall: id ? { id: String(id), ...call } : call };
+}
+
+function reasoningText(item) {
+  const summary = Array.isArray(item?.summary) ? item.summary : [];
+  return summary
+    .map((entry) => (typeof entry?.text === "string" ? entry.text : ""))
+    .filter(Boolean)
+    .join("\n");
+}
+
+function messageText(item) {
+  const content = Array.isArray(item?.content) ? item.content : [];
+  return content
+    .map((entry) =>
+      entry?.type === "output_text" || entry?.type === "text"
+        ? String(entry.text || "")
+        : "",
+    )
+    .filter(Boolean)
+    .join("");
+}
+
+function finishReasonFor(payload) {
+  if (payload?.status === "failed" || payload?.error) return "OTHER";
+  const reason = payload?.incomplete_details?.reason;
+  if (reason === "max_output_tokens") return "MAX_TOKENS";
+  if (reason === "content_filter") return "SAFETY";
+  if (reason) return "OTHER";
+  return "STOP";
+}
+
+function usageMetadata(usage) {
+  if (!usage || typeof usage !== "object") return undefined;
+  const prompt = usage.input_tokens ?? usage.prompt_tokens;
+  const output = usage.output_tokens ?? usage.completion_tokens;
+  const total = usage.total_tokens ?? (Number(prompt || 0) + Number(output || 0));
+  const metadata = {
+    promptTokenCount: Number(prompt || 0),
+    candidatesTokenCount: Number(output || 0),
+    totalTokenCount: Number(total || 0),
+  };
+  const reasoning = usage.output_tokens_details?.reasoning_tokens;
+  if (Number.isFinite(reasoning)) metadata.thoughtsTokenCount = Number(reasoning);
+  const cached = usage.input_tokens_details?.cached_tokens;
+  if (Number.isFinite(cached)) metadata.cachedContentTokenCount = Number(cached);
+  return metadata;
+}
+
+/** One non-streaming Responses payload as one Gemini GenerateContentResponse. */
+export function responsesPayloadToGemini(payload, { model } = {}) {
+  const output = Array.isArray(payload?.output) ? payload.output : [];
+  const parts = [];
+  for (const item of output) {
+    if (item?.type === "reasoning") {
+      const text = reasoningText(item);
+      if (text) parts.push({ text, thought: true });
+      continue;
+    }
+    if (item?.type === "message") {
+      const text = messageText(item);
+      if (text) parts.push({ text });
+      continue;
+    }
+    if (item?.type === "function_call") parts.push(functionCallPart(item));
+  }
+  const response = {
+    candidates: [
+      {
+        content: { role: "model", parts },
+        finishReason: finishReasonFor(payload),
+        index: 0,
+      },
+    ],
+  };
+  const usage = usageMetadata(payload?.usage);
+  if (usage) response.usageMetadata = usage;
+  const version = payload?.model || model;
+  if (version) response.modelVersion = String(version);
+  if (payload?.id) response.responseId = String(payload.id);
+  return response;
+}
+
+function candidateChunk(parts, { model, finishReason, usage, responseId } = {}) {
+  const candidate = { content: { role: "model", parts }, index: 0 };
+  if (finishReason) candidate.finishReason = finishReason;
+  const chunk = { candidates: [candidate] };
+  if (usage) chunk.usageMetadata = usage;
+  if (model) chunk.modelVersion = String(model);
+  if (responseId) chunk.responseId = String(responseId);
+  return chunk;
+}
+
+/**
+ * Converts a Responses event stream into Gemini stream chunks.
+ *
+ * Each returned object is a whole `GenerateContentResponse`, which is what the
+ * SDK's `alt=sse` reader expects in every `data:` frame -- it is not a delta
+ * format of its own.
+ *
+ * `finish()` exists because the SDK waits for a `finishReason` before it
+ * considers a turn over. An upstream that drops mid-stream would otherwise
+ * leave the CLI holding an open turn until its own timeout expires.
+ */
+export function createGeminiStreamTranslator({ model } = {}) {
+  let finished = false;
+  let emittedAnything = false;
+  return {
+    push(event) {
+      const type = event?.type;
+      if (type === "response.output_text.delta" && event.delta) {
+        emittedAnything = true;
+        return [candidateChunk([{ text: String(event.delta) }], { model })];
+      }
+      if (type === "response.reasoning_summary_text.delta" && event.delta) {
+        emittedAnything = true;
+        return [candidateChunk([{ text: String(event.delta), thought: true }], { model })];
+      }
+      // Only on `done`: an added item carries no arguments yet, and emitting it
+      // twice makes the CLI run the tool twice.
+      if (type === "response.output_item.done" && event.item?.type === "function_call") {
+        emittedAnything = true;
+        return [candidateChunk([functionCallPart(event.item)], { model })];
+      }
+      if (
+        type === "response.completed" ||
+        type === "response.failed" ||
+        type === "response.incomplete"
+      ) {
+        if (finished) return [];
+        finished = true;
+        const response = event.response || {};
+        return [
+          candidateChunk([], {
+            model: response.model || model,
+            finishReason: finishReasonFor(response),
+            usage: usageMetadata(response.usage),
+            responseId: response.id,
+          }),
+        ];
+      }
+      return [];
+    },
+    finish() {
+      if (finished) return [];
+      finished = true;
+      return [
+        candidateChunk([], {
+          model,
+          finishReason: emittedAnything ? "STOP" : "OTHER",
+        }),
+      ];
+    },
+  };
+}
+
+/** The routed set as a `models.list` page. */
+export function geminiModelListPayload(models) {
+  return {
+    models: (models || []).map((model) => {
+      const window = Number.isInteger(model?.contextWindow) && model.contextWindow > 0
+        ? model.contextWindow
+        : 131072;
+      return {
+        name: `models/${model.slug}`,
+        displayName: String(model.displayName || model.slug),
+        description: "Routed by Codex Router.",
+        inputTokenLimit: window,
+        outputTokenLimit: window,
+        supportedGenerationMethods: [...GEMINI_GENERATION_METHODS],
+      };
+    }),
+  };
+}
+
+/**
+ * A byte-count estimate for `countTokens`.
+ *
+ * There is no upstream to ask: the providers behind the router do not all
+ * expose a counting endpoint, and spending a real turn to answer a count would
+ * bill the user for a question they asked for free. A client that gets no
+ * number at all cannot decide whether to compact, so a crude estimate is the
+ * better failure -- the same tradeoff `estimateInputTokens` already makes for
+ * prompt accounting.
+ */
+export function estimateGeminiTokens(body) {
+  const serialized = JSON.stringify(body?.contents ?? body ?? "");
+  const bytes = Buffer.byteLength(serialized === undefined ? "" : serialized, "utf8");
+  if (!body || !Array.isArray(body.contents) || !body.contents.length) return 0;
+  return Math.ceil(bytes / ESTIMATE_BYTES_PER_TOKEN);
+}

--- a/src/gemini-surface.mjs
+++ b/src/gemini-surface.mjs
@@ -1,0 +1,317 @@
+// The Gemini-shaped caller surface.
+//
+// Gemini CLI builds `{GOOGLE_GEMINI_BASE_URL}/v1beta/models/{model}:{method}`
+// through @google/genai and speaks nothing else, so a client integration for it
+// needs this leaf. What it must not become is a second request path: everything
+// the router does for a turn -- tool-result ageing, the vision bridge,
+// prompt-token substitution, upstream retry, model failover, usage accounting
+// -- lives on `/v1/responses`, and a surface that reached providers directly
+// would have to reimplement all of it and then keep the two in step.
+//
+// So this handler translates and re-enters. `gemini-shape.mjs` converts the
+// request, this file sends it through the router's own Responses endpoint over
+// the loopback, and the answer is converted back. The extra hop is one local
+// socket; the alternative is two copies of the only path that matters.
+
+import { formatErrorChain, readRequestBody, writeJson } from "./http-utils.mjs";
+import {
+  createGeminiStreamTranslator,
+  estimateGeminiTokens,
+  geminiModelListPayload,
+  geminiToResponsesPayload,
+  parseGeminiPath,
+  responsesPayloadToGemini,
+} from "./gemini-shape.mjs";
+
+export const GEMINI_ROUTE_PREFIX = "/gemini";
+
+// google.rpc.Code names, which is what a Gemini client reads off `error.status`
+// to decide whether a failure is worth retrying.
+const RPC_STATUS = new Map([
+  [400, "INVALID_ARGUMENT"],
+  [401, "UNAUTHENTICATED"],
+  [403, "PERMISSION_DENIED"],
+  [404, "NOT_FOUND"],
+  [408, "DEADLINE_EXCEEDED"],
+  [409, "ABORTED"],
+  [413, "INVALID_ARGUMENT"],
+  [415, "INVALID_ARGUMENT"],
+  [422, "INVALID_ARGUMENT"],
+  [429, "RESOURCE_EXHAUSTED"],
+  [499, "CANCELLED"],
+  [500, "INTERNAL"],
+  [501, "UNIMPLEMENTED"],
+  [502, "UNAVAILABLE"],
+  [503, "UNAVAILABLE"],
+  [504, "DEADLINE_EXCEEDED"],
+]);
+
+export function isGeminiRoute(route) {
+  return (
+    typeof route === "string" &&
+    (route === GEMINI_ROUTE_PREFIX || route.startsWith(`${GEMINI_ROUTE_PREFIX}/`))
+  );
+}
+
+function geminiError(response, status, message) {
+  writeJson(response, status, {
+    error: {
+      code: status,
+      message,
+      status: RPC_STATUS.get(status) || "INTERNAL",
+    },
+  });
+}
+
+// The same two guards `requireCodexTransport` applies to the routed path, in
+// the shape this surface answers in. A browser can reach a loopback port, and
+// the caller capability is in the URL -- which is exactly what a page that
+// learned the URL would replay.
+function transportRejected(request, response) {
+  if (request.headers.origin || request.headers["sec-fetch-site"]) {
+    geminiError(
+      response,
+      403,
+      "Browser-originated requests are not accepted by the local model router.",
+    );
+    return true;
+  }
+  const contentType = String(request.headers["content-type"] || "")
+    .split(";", 1)[0]
+    .trim()
+    .toLowerCase();
+  if (contentType !== "application/json") {
+    geminiError(response, 415, "Gemini router requests require Content-Type: application/json.");
+    return true;
+  }
+  return false;
+}
+
+function upstreamMessage(text) {
+  if (!text) return undefined;
+  try {
+    const parsed = JSON.parse(text);
+    const message = parsed?.error?.message || parsed?.message;
+    return typeof message === "string" && message ? message : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// The loopback carries no credential on purpose.
+//
+// The key the CLI presents is this router's own caller capability, and the path
+// it presented it on is already the proof. Relaying it upstream would put a
+// router secret on a hop that can be substituted onto a provider; leaving the
+// header off is also what makes `callerBroughtNoUpstreamCredential` true, which
+// is how a client with no ChatGPT session of its own reaches native models.
+function loopbackHeaders() {
+  return { "content-type": "application/json", accept: "text/event-stream" };
+}
+
+async function readSseFrames(body, onEvent) {
+  const decoder = new TextDecoder();
+  let buffer = "";
+  for await (const chunk of body) {
+    buffer += decoder.decode(chunk, { stream: true });
+    let boundary = buffer.indexOf("\n\n");
+    while (boundary !== -1) {
+      const block = buffer.slice(0, boundary);
+      buffer = buffer.slice(boundary + 2);
+      dispatchSseBlock(block, onEvent);
+      boundary = buffer.indexOf("\n\n");
+    }
+  }
+  buffer += decoder.decode();
+  if (buffer.trim()) dispatchSseBlock(buffer, onEvent);
+}
+
+function dispatchSseBlock(block, onEvent) {
+  // Per the SSE grammar a dispatch may carry several `data:` lines, which
+  // concatenate with newlines. The router's own writers emit one, but an
+  // upstream that wraps long deltas emits more, and joining only the first
+  // would truncate the JSON into an unparsable fragment.
+  const data = [];
+  for (const rawLine of block.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    if (!line || line.startsWith(":")) continue;
+    if (!line.startsWith("data:")) continue;
+    data.push(line.slice(5).replace(/^ /, ""));
+  }
+  if (!data.length) return;
+  const payload = data.join("\n");
+  if (payload === "[DONE]") return;
+  try {
+    onEvent(JSON.parse(payload));
+  } catch {
+    // A frame the router did not write is not a reason to fail the turn; the
+    // translator's own closer still supplies a finish reason.
+  }
+}
+
+async function streamTurn({ response, upstream, model }) {
+  const translator = createGeminiStreamTranslator({ model });
+  response.writeHead(200, {
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  const write = (chunks) => {
+    for (const chunk of chunks) response.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  };
+  try {
+    if (upstream.body) {
+      await readSseFrames(upstream.body, (event) => write(translator.push(event)));
+    }
+  } finally {
+    // Always: the SDK waits for a finishReason before it considers the turn
+    // over, so an upstream that drops mid-stream would otherwise leave the CLI
+    // holding an open turn until its own timeout.
+    write(translator.finish());
+    response.end();
+  }
+}
+
+// The upstream turn should die with the client, but `request.signal` is not how
+// to say so. It does not exist before Node 22, and on Node 24 it aborts as soon
+// as the request body has been *read* -- which is before the loopback call is
+// made, so forwarding it failed every routed turn with an instant 502 on CI
+// while passing locally on a Node that has no `signal` at all. The response
+// closing is the event that actually means "the caller is gone", and it means
+// the same thing on every supported version.
+function clientGoneSignal(response) {
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  response.once("close", abort);
+  return {
+    signal: controller.signal,
+    release: () => response.off("close", abort),
+  };
+}
+
+async function relayTurn({ response, model, body, stream, responsesUrl, fetchImpl }) {
+  const payload = geminiToResponsesPayload({ model, body, stream });
+  const client = clientGoneSignal(response);
+  let upstream;
+  try {
+    upstream = await fetchImpl(responsesUrl, {
+      method: "POST",
+      headers: loopbackHeaders(),
+      body: JSON.stringify(payload),
+      signal: client.signal,
+    });
+  } catch (error) {
+    client.release();
+    // Naming the cause chain is the difference between a diagnosable failure
+    // and "could not be reached" repeated on every turn. `messages: false`
+    // keeps any upstream response text out of it; this reports names and codes.
+    geminiError(
+      response,
+      502,
+      `The local model router could not be reached: ${formatErrorChain(error, { messages: false })}`,
+    );
+    return;
+  }
+  if (!upstream.ok) {
+    client.release();
+    const text = await upstream.text().catch(() => "");
+    geminiError(
+      response,
+      upstream.status,
+      upstreamMessage(text) || "The local model router refused the request.",
+    );
+    return;
+  }
+  if (!stream) {
+    const answered = await upstream.json().catch(() => undefined);
+    client.release();
+    if (!answered) {
+      geminiError(response, 502, "The local model router returned an unreadable response.");
+      return;
+    }
+    writeJson(response, 200, responsesPayloadToGemini(answered, { model }));
+    return;
+  }
+  try {
+    await streamTurn({ response, upstream, model });
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Serves one Gemini API request.
+ *
+ * `route` is the path with the caller capability already stripped, so it starts
+ * at `/gemini`. `routedModels()` supplies the publishable set -- the same one
+ * the settings document advertises -- and a model outside it is refused by
+ * name: falling through would send an unregistered slug to `/v1/responses`,
+ * where it is treated as native GPT traffic, so a typo would quietly become a
+ * ChatGPT-session request instead of an error anybody can read.
+ */
+export async function handleGeminiRequest(
+  request,
+  response,
+  route,
+  { responsesUrl, routedModels, fetchImpl = fetch } = {},
+) {
+  const url = new URL(request.url || "/", "http://127.0.0.1");
+  const parsed = parseGeminiPath(route.slice(GEMINI_ROUTE_PREFIX.length));
+  if (!parsed) {
+    geminiError(response, 404, `Unsupported Gemini route: ${url.pathname}`);
+    return;
+  }
+
+  if (parsed.method === "list") {
+    if (request.method !== "GET") {
+      geminiError(response, 405, "The model list is served on GET.");
+      return;
+    }
+    writeJson(response, 200, geminiModelListPayload(routedModels()));
+    return;
+  }
+
+  if (request.method !== "POST") {
+    geminiError(response, 405, `${parsed.method} is served on POST.`);
+    return;
+  }
+  if (transportRejected(request, response)) return;
+
+  if (parsed.method === "embedContent") {
+    geminiError(
+      response,
+      501,
+      "The router serves chat turns only; no routed provider exposes an embedding endpoint through it.",
+    );
+    return;
+  }
+
+  const known = routedModels().some((model) => String(model.slug) === parsed.model);
+  if (!known) {
+    geminiError(response, 404, `${parsed.model} is not a routed model on this router.`);
+    return;
+  }
+
+  let body;
+  try {
+    body = JSON.parse((await readRequestBody(request)).toString("utf8") || "{}");
+  } catch {
+    geminiError(response, 400, "The request body is not valid JSON.");
+    return;
+  }
+
+  if (parsed.method === "countTokens") {
+    writeJson(response, 200, { totalTokens: estimateGeminiTokens(body) });
+    return;
+  }
+
+  const stream = parsed.method === "streamGenerateContent";
+  if (stream && url.searchParams.get("alt") !== "sse") {
+    // Without `alt=sse` the real API answers with a JSON array rather than an
+    // event stream. Serving SSE anyway hands the client a body it cannot parse.
+    geminiError(response, 400, "streamGenerateContent is served only with alt=sse.");
+    return;
+  }
+
+  await relayTurn({ response, model: parsed.model, body, stream, responsesUrl, fetchImpl });
+}

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import { trayBundleDir } from "./tray-install.mjs";
 
-const supportedTargets = new Set(["codex", "dsh"]);
+const supportedTargets = new Set(["codex", "dsh", "gemini"]);
 
 export const TARGET = process.env.MODEL_ROUTER_TARGET || "codex";
 if (!supportedTargets.has(TARGET)) {
@@ -25,8 +25,12 @@ if (!supportedTargets.has(TARGET)) {
 // process. They stay on `codex` whichever integration is being installed.
 export const ROUTER_PLANE_TARGET = "codex";
 
-export const TARGET_DISPLAY_NAME =
-  TARGET === "dsh" ? "DeepSeek Harness Router" : "Codex Router";
+const TARGET_DISPLAY_NAMES = Object.freeze({
+  dsh: "DeepSeek Harness Router",
+  gemini: "Gemini CLI Router",
+  codex: "Codex Router",
+});
+export const TARGET_DISPLAY_NAME = TARGET_DISPLAY_NAMES[TARGET] || TARGET_DISPLAY_NAMES.codex;
 const configuredSourceRoot = process.env.CODEX_ROUTER_SOURCE_ROOT;
 if (configuredSourceRoot && !path.isAbsolute(configuredSourceRoot)) {
   throw new Error("CODEX_ROUTER_SOURCE_ROOT must be an absolute path.");
@@ -58,6 +62,22 @@ export const DSH_SETTINGS_PATH =
 export const DSH_CREDENTIALS_PATH =
   process.env.MODEL_ROUTER_DSH_CREDENTIALS || path.join(DSH_HOME, ".credentials.yaml");
 
+// Gemini CLI resolves its own home as `GEMINI_CLI_HOME` or the user's home, and
+// then `.gemini` inside it (`homedir()` in @google/gemini-cli-core's paths
+// util, plus its `GEMINI_DIR` constant). Match that resolution exactly rather
+// than hardcoding the default, or a user who moved theirs gets a document
+// nothing reads.
+export const GEMINI_HOME = path.join(
+  process.env.GEMINI_CLI_HOME || os.homedir(),
+  ".gemini",
+);
+// The only document this integration writes. Gemini CLI loads it at startup for
+// `GOOGLE_GEMINI_BASE_URL`, `GEMINI_API_KEY`, and `GEMINI_MODEL` -- which is the
+// whole integration, so its `settings.json` is never touched. It holds the
+// caller key, so it is written 0600 under a 0700 directory.
+export const GEMINI_ENV_PATH =
+  process.env.MODEL_ROUTER_GEMINI_ENV || path.join(GEMINI_HOME, ".env");
+
 function managedStateDir() {
   return (
     process.env.CODEX_ROUTER_STATE_DIR ||
@@ -82,6 +102,11 @@ export const MERGED_CATALOG_PATH = path.join(STATE_DIR, "merged-models.json");
 // detected against this snapshot rather than by re-deriving what "should" be
 // there and trusting the answer.
 export const DSH_CATALOG_PATH = path.join(STATE_DIR, "dsh-models.json");
+// The same marker for the Gemini integration: what the last publish wrote, so
+// drift is detected against a snapshot rather than by re-deriving what should
+// be there and trusting the answer. Its presence is what says the integration
+// is installed.
+export const GEMINI_CATALOG_PATH = path.join(STATE_DIR, "gemini-models.json");
 export const NATIVE_ALIAS_PATH = path.join(STATE_DIR, "native-aliases.json");
 export const ANNOUNCED_MODELS_PATH = path.join(STATE_DIR, "announced-models.json");
 export const LITELLM_CONFIG_PATH = path.join(STATE_DIR, "litellm.yaml");

--- a/src/routed-client-models.mjs
+++ b/src/routed-client-models.mjs
@@ -1,0 +1,88 @@
+// The publishable model set for a client that is not Codex.
+//
+// Codex reads its own catalog and carries its own ChatGPT session; every other
+// client is published *to*, and the rules for what may be published are the
+// same whichever one it is. They were written for DeepSeek Harness first and
+// then wanted verbatim by the Gemini CLI integration, so they live here rather
+// than in either client's manager -- two copies of this would drift, and the
+// way it would show is one picker offering a model the other just lost.
+
+import { existsSync, readFileSync } from "node:fs";
+
+import { NATIVE_CATALOG_PATH } from "./paths.mjs";
+import { nativeSessionAvailable } from "./codex-native-session.mjs";
+import { readHiddenModels } from "./model-picker-state.mjs";
+import { readMultiAgentSettings } from "./multi-agent-state.mjs";
+import { selectedConfiguredListedModels } from "./provider-selection.mjs";
+import { applySubagentProofs, subagentProofSnapshot } from "./subagent-proofs.mjs";
+import { applyVisionBridge, resolveVisionEngine } from "./vision-bridge.mjs";
+import { readVisionBridgeSettings } from "./vision-bridge-state.mjs";
+
+// The native catalog Codex itself published, captured by `catalog.mjs`. Read
+// rather than re-derived: it is the same document the Codex picker is built
+// from, so a client cannot end up advertising a native model Codex does not
+// have. Absent simply means no native models are offered.
+function readNativeCatalogModels() {
+  if (!existsSync(NATIVE_CATALOG_PATH)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
+    return Array.isArray(parsed?.models) ? parsed.models : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Native GPT models, shaped for a published client.
+ *
+ * These are authorized by a ChatGPT session rather than an API key, so they are
+ * publishable only while the router can supply one -- see
+ * `codex-native-session.mjs`. The caller decides that; this function only maps.
+ *
+ * `visibility: "hide"` entries are Codex's own internal variants (a watermarked
+ * build, the auto-review model) and are not offered to anybody.
+ */
+export function nativeClientModels(nativeCatalogModels) {
+  return (nativeCatalogModels || [])
+    .filter((model) => model?.slug && model.visibility !== "hide")
+    .map((model) => ({
+      slug: String(model.slug),
+      displayName: model.display_name ? `${model.display_name} (Codex)` : String(model.slug),
+      contextWindow: Number.isFinite(model.context_window) ? model.context_window : undefined,
+      inputModalities: Array.isArray(model.input_modalities) ? model.input_modalities : ["text"],
+      reasoningLevels: Array.isArray(model.supported_reasoning_levels)
+        ? model.supported_reasoning_levels
+            .filter((level) => level?.effort)
+            .map((level) => ({ effort: level.effort }))
+        : [],
+      priority: Number.isFinite(model.priority) ? -model.priority : undefined,
+      native: true,
+    }));
+}
+
+/** The routed models a published client should be offered, vision bridge included. */
+export function routedClientModels() {
+  const hidden = readHiddenModels();
+  // The same machine-local capability proofs the Codex catalog honors: a model
+  // this machine verified as a subagent is one everywhere the proven set is
+  // consumed, or a client's tool-subagent preset silently disagrees with the
+  // picker about which children exist.
+  const selected = applySubagentProofs(
+    selectedConfiguredListedModels().filter((model) => !hidden.has(String(model.slug))),
+    subagentProofSnapshot(),
+    { hidden, disabled: readMultiAgentSettings().disabled },
+  );
+  // Native GPT models are authorized by a ChatGPT session rather than an API
+  // key. A published client carries none of its own -- but this machine is
+  // signed in to Codex, and the router relays that session for a caller that
+  // brought nothing (see `codex-native-session.mjs`). So they are publishable
+  // exactly while that fallback can supply one, and withheld the moment it
+  // cannot.
+  const native = nativeSessionAvailable() ? nativeClientModels(readNativeCatalogModels()) : [];
+  // The vision engine still resolves over routed candidates only. A native
+  // engine is spent per-caller, and `vision-engines` wants each call site to
+  // name its evidence; this one's is that a bridge read is issued by the router
+  // on the caller's behalf, which is not the same as relaying their turn.
+  const engine = resolveVisionEngine(() => selected, readVisionBridgeSettings());
+  return { models: [...applyVisionBridge(selected, engine), ...native], engine };
+}

--- a/src/router-health.mjs
+++ b/src/router-health.mjs
@@ -8,7 +8,13 @@ import { PORTS, ROUTER_PLANE_TARGET, TARGET, loopback } from "./paths.mjs";
 const SERVICE_BY_TARGET = {
   [ROUTER_PLANE_TARGET]: "codex-router",
 };
-const SUPPORTED_TARGETS = new Set(["codex", "dsh"]);
+// Every client this router publishes to. The set only guards against a typo in
+// a caller's `target` argument -- the health check itself is keyed on the plane
+// above, because one process serves all of them. It has to be extended
+// alongside `supportedTargets` in paths.mjs; a target missing here fails
+// `doctor` and `wait-health` with "Unknown router target" long before anything
+// about the integration itself is exercised.
+const SUPPORTED_TARGETS = new Set(["codex", "dsh", "gemini"]);
 
 export async function waitForRouterHealth({
   target = TARGET,

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -13,9 +13,11 @@ import { promisify } from "node:util";
 import {
   assertCallerSecret,
   authenticatedRoute,
+  callerBaseUrl,
   secretEqual,
 } from "./caller-auth.mjs";
 import { handlePanelRequest, isPanelRoute } from "./desktop-panel.mjs";
+import { handleGeminiRequest, isGeminiRoute } from "./gemini-surface.mjs";
 import {
   applyKeepAliveTimeouts,
   endStreamedResponse,
@@ -1799,6 +1801,25 @@ async function handleModels(response) {
   writeJson(response, 200, { object: "list", data });
 }
 
+// What the Gemini surface will accept a turn for.
+//
+// Deliberately the catalog the router already serves on `/v1/models`, not the
+// narrower set the Gemini settings document was published with. The gate exists
+// so a typo cannot fall through to the native path and quietly become a
+// ChatGPT-session request; being *stricter* than the published list would
+// instead refuse a model the user was legitimately offered, and a native model
+// whose session has since expired is better served by the provider's own 401
+// than by a 404 that misdescribes why.
+function geminiRoutedModels() {
+  return catalogModels().map((model) => ({
+    slug: String(model.slug),
+    displayName: model.display_name || model.displayName || String(model.slug),
+    contextWindow: Number.isFinite(model.context_window)
+      ? model.context_window
+      : model.contextWindow,
+  }));
+}
+
 function requireCodexTransport(request, response) {
   if (request.headers.origin || request.headers["sec-fetch-site"]) {
     writeJson(response, 403, {
@@ -3040,6 +3061,17 @@ async function handleRequest(request, response) {
   }
   if (request.method === "GET" && ["/models", "/v1/models"].includes(requestUrl.pathname)) {
     await handleModels(response);
+    return;
+  }
+  // Gemini CLI speaks nothing but the Gemini API, so it gets its own leaf
+  // behind the same capability. The handler translates and re-enters
+  // `/v1/responses` over the loopback rather than reaching a provider itself --
+  // there is still exactly one request path to keep correct.
+  if (isGeminiRoute(requestUrl.pathname)) {
+    await handleGeminiRequest(request, response, requestUrl.pathname, {
+      responsesUrl: `${callerBaseUrl(LISTEN_PORT, CALLER_KEY)}/responses`,
+      routedModels: geminiRoutedModels,
+    });
     return;
   }
   if (request.method === "OPTIONS") {

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -473,6 +473,9 @@ async function main() {
 
   nextStep("Review and install");
   const dshTarget = TARGET === "dsh";
+  // Like the harness, Gemini CLI has no native catalog to adopt: that list is
+  // the ChatGPT-plan model set Codex publishes for itself.
+  const geminiTarget = TARGET === "gemini";
   if (guided) {
     process.stdout.write(
       `\nReady to install:\n` +
@@ -480,8 +483,10 @@ async function main() {
         `  Migration: ${migration ? "recognized older router (rollback snapshot kept)" : "none needed"}\n` +
         (dshTarget
           ? `  Changes: per-user background service and one provider route in the harness settings document\n`
-          : `  Native catalog: ${adoptNativeCatalog ? "adopt existing user catalog" : "capture from Codex"}\n` +
-            `  Changes: per-user background service and the managed Codex config block\n`),
+          : geminiTarget
+            ? `  Changes: per-user background service and one managed block in Gemini CLI's environment file\n`
+            : `  Native catalog: ${adoptNativeCatalog ? "adopt existing user catalog" : "capture from Codex"}\n` +
+              `  Changes: per-user background service and the managed Codex config block\n`),
     );
     if (!confirm("Proceed?")) {
       throw incomplete("Setup was cancelled before installing the service.");
@@ -529,7 +534,11 @@ async function main() {
     dshTarget
       ? `\nDeepSeek Harness is ready with: ${providerSummary}\n` +
         `It reloads its settings document on the next request, so there is nothing to restart.\n`
-      : `\nCodex Router is ready with: ${providerSummary}\nFully quit Codex, reopen it, and start a new task.\n`,
+      : geminiTarget
+        ? `\nGemini CLI is ready with: ${providerSummary}\n` +
+          `It reads its environment at startup, so the next \`gemini\` run picks this up.\n` +
+          `If it asks how to authenticate, choose "Use Gemini API key" once -- the key is this router's local caller capability.\n`
+        : `\nCodex Router is ready with: ${providerSummary}\nFully quit Codex, reopen it, and start a new task.\n`,
   );
   if (visionBridge?.enabled && visionBridge.engine) {
     process.stdout.write(

--- a/src/target-integration.mjs
+++ b/src/target-integration.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import {
   CONFIG_PATH,
   DSH_CATALOG_PATH,
+  GEMINI_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
   SOURCE_ROOT,
   TARGET,
@@ -30,8 +31,14 @@ export function targetCli(command) {
   return `./bin/${command}`;
 }
 
+const PICKER_NAMES = Object.freeze({
+  dsh: "DeepSeek Harness",
+  gemini: "Gemini CLI",
+  codex: "Codex",
+});
+
 export function targetPickerName() {
-  return TARGET === "dsh" ? "DeepSeek Harness" : "Codex";
+  return PICKER_NAMES[TARGET] || PICKER_NAMES.codex;
 }
 
 /**
@@ -43,9 +50,16 @@ export function targetPickerName() {
  * reopen" there would be busywork the product does not need.
  */
 export function targetRestartHint() {
-  return TARGET === "dsh"
-    ? "DeepSeek Harness reloads its settings document on the next request."
-    : `Fully quit and reopen ${targetPickerName()} to refresh the model picker.`;
+  if (TARGET === "dsh") {
+    return "DeepSeek Harness reloads its settings document on the next request.";
+  }
+  // Gemini CLI reads its `.env` once, at process start. A session already open
+  // keeps the old values; the next `gemini` invocation picks the new ones up.
+  // Telling somebody to quit a CLI they may not have running would be busywork.
+  if (TARGET === "gemini") {
+    return "Gemini CLI reads its environment at startup; the next `gemini` run picks this up.";
+  }
+  return `Fully quit and reopen ${targetPickerName()} to refresh the model picker.`;
 }
 
 /**
@@ -73,6 +87,7 @@ export function installedTargets() {
   // behind after the last integration was removed.
   if (codexIntegrationInstalled()) installed.push("codex");
   if (existsSync(DSH_CATALOG_PATH)) installed.push("dsh");
+  if (existsSync(GEMINI_CATALOG_PATH)) installed.push("gemini");
   return installed;
 }
 
@@ -101,6 +116,14 @@ export function refreshTargetPickerIfInstalled() {
   // it survives a user who edits or moves the document by hand.
   if (existsSync(DSH_CATALOG_PATH)) {
     run("dsh-config-manager.mjs", ["install"]);
+    refreshed = true;
+  }
+  // Gemini CLI is served its model list live off the router's own catalog, so
+  // there is no list here to keep in step -- but the published default model is
+  // a slug like any other, and a republish is what moves it off one the routable
+  // set just lost.
+  if (existsSync(GEMINI_CATALOG_PATH)) {
+    run("gemini-config-manager.mjs", ["install"]);
     refreshed = true;
   }
   return refreshed;

--- a/test/caller-auth.test.mjs
+++ b/test/caller-auth.test.mjs
@@ -14,7 +14,9 @@ import { fileURLToPath } from "node:url";
 import {
   authenticatedRoute,
   callerBaseUrl,
+  geminiBaseUrl,
   isManagedCallerBaseUrl,
+  isManagedGeminiBaseUrl,
   redactCallerUrl,
 } from "../src/caller-auth.mjs";
 import { privateFileIsProtected } from "../src/file-security.mjs";
@@ -49,6 +51,34 @@ test("caller capability helpers accept only the secret-bearing path and redact i
     redactCallerUrl(baseUrl),
     "http://127.0.0.1:46192/_codex-router/[REDACTED]/v1",
   );
+});
+
+test("the gemini leaf sits behind the same capability and is redacted with it", () => {
+  // Gemini CLI appends `/v1beta/models/...` to whatever base URL it is given,
+  // so the capability has to be a path prefix here exactly as it is for `/v1`.
+  // A leaf that redaction does not know about is a caller key printed verbatim
+  // into doctor output, status output, and support bundles.
+  const baseUrl = geminiBaseUrl(46192, CALLER_KEY);
+  assert.equal(baseUrl, `http://127.0.0.1:46192/_codex-router/${CALLER_KEY}/gemini`);
+  assert.equal(
+    authenticatedRoute(
+      `/_codex-router/${CALLER_KEY}/gemini/v1beta/models/vendor/model:generateContent`,
+      CALLER_KEY,
+    ),
+    "/gemini/v1beta/models/vendor/model:generateContent",
+  );
+  assert.equal(
+    redactCallerUrl(baseUrl),
+    "http://127.0.0.1:46192/_codex-router/[REDACTED]/gemini",
+  );
+  assert.equal(
+    redactCallerUrl(`${baseUrl}/v1beta/models`),
+    "http://127.0.0.1:46192/_codex-router/[REDACTED]/gemini/v1beta/models",
+  );
+  assert.equal(isManagedGeminiBaseUrl(baseUrl, 46192), true);
+  assert.equal(isManagedGeminiBaseUrl(baseUrl, 4102), false);
+  assert.equal(isManagedGeminiBaseUrl(callerBaseUrl(46192, CALLER_KEY), 46192), false);
+  assert.equal(isManagedGeminiBaseUrl(`${baseUrl}?key=x`, 46192), false);
 });
 
 test("secret setup creates stable, separate, current-user-only keys", () => {

--- a/test/gemini-config-manager.test.mjs
+++ b/test/gemini-config-manager.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = mkdtempSync(path.join(os.tmpdir(), "codex-router-gemini-"));
+const codexHome = path.join(root, "codex");
+const stateDir = path.join(root, "state");
+const envPath = path.join(root, "gemini", ".env");
+const CALLER_KEY = "test-gemini-caller-capability-with-sufficient-length";
+
+process.env.CODEX_HOME = codexHome;
+process.env.CODEX_ROUTER_STATE_DIR = stateDir;
+process.env.MODEL_ROUTER_GEMINI_ENV = envPath;
+process.env.MODEL_ROUTER_STATE_OWNER_OVERRIDE = "1";
+
+const { writePrivateFile } = await import("../src/file-security.mjs");
+writePrivateFile(path.join(stateDir, "caller-secret"), `${CALLER_KEY}\n`);
+
+const { GEMINI_CATALOG_PATH } = await import("../src/paths.mjs");
+const {
+  geminiCatalogDrift,
+  geminiDefaultModel,
+  geminiIntegrationStatus,
+  publishGeminiIntegration,
+  removeGeminiIntegration,
+} = await import("../src/gemini-config-manager.mjs");
+
+// The real routed set reads provider selection, the picker state, and the
+// ChatGPT session, none of which a temp home has. What is under test here is
+// the document this manager writes, so the set is injected.
+const MODELS = [
+  { slug: "vendor/small", displayName: "Small", contextWindow: 128000, priority: 1 },
+  { slug: "vendor/large", displayName: "Large", contextWindow: 262144, priority: 5 },
+];
+const routedModels = (models = MODELS) => () => ({ models, engine: undefined });
+
+test.after(() => rmSync(root, { recursive: true, force: true }));
+
+test("the highest-priority routed model is the default", () => {
+  assert.equal(geminiDefaultModel(MODELS), "vendor/large");
+  assert.equal(geminiDefaultModel([]), undefined);
+});
+
+test("the default is stable when priorities tie", () => {
+  assert.equal(geminiDefaultModel([{ slug: "b/one" }, { slug: "a/two" }]), "a/two");
+});
+
+test("a publish writes the caller capability, the key, and a routed default", () => {
+  const result = publishGeminiIntegration({ routedModels: routedModels() });
+  const document = readFileSync(envPath, "utf8");
+  assert.ok(document.includes("GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:"));
+  assert.ok(document.includes(`/_codex-router/${CALLER_KEY}/gemini`));
+  assert.ok(document.includes(`GEMINI_API_KEY=${CALLER_KEY}`));
+  assert.ok(document.includes("GEMINI_MODEL=vendor/large"));
+  assert.equal(result.defaultModel, "vendor/large");
+});
+
+test("the document holding the caller key is owner-only", { skip: process.platform === "win32" }, () => {
+  assert.equal(statSync(envPath).mode & 0o777, 0o600);
+});
+
+test("republishing is byte-identical", () => {
+  const first = readFileSync(envPath, "utf8");
+  publishGeminiIntegration({ routedModels: routedModels() });
+  assert.equal(readFileSync(envPath, "utf8"), first);
+});
+
+test("status never prints the complete base URL", () => {
+  // It carries the caller capability, and status output reaches doctor, the
+  // tray, and support bundles.
+  const status = geminiIntegrationStatus();
+  assert.ok(status.baseUrl.includes("[REDACTED]"));
+  assert.ok(!status.baseUrl.includes(CALLER_KEY));
+  assert.equal(status.baseUrlManaged, true);
+  assert.equal(status.installed, true);
+  assert.equal(status.documentReadable, true);
+  assert.equal(status.defaultModel, "vendor/large");
+  assert.deepEqual(status.publishedModels, ["vendor/small", "vendor/large"]);
+});
+
+test("opting out of the default model omits the key rather than blanking it", () => {
+  publishGeminiIntegration({ routedModels: routedModels(), setDefaultModel: false });
+  const document = readFileSync(envPath, "utf8");
+  assert.ok(!document.includes("GEMINI_MODEL"));
+  assert.ok(document.includes("GEMINI_API_KEY="));
+});
+
+test("a user's own lines survive a publish and come back on removal", () => {
+  removeGeminiIntegration();
+  const mine = ["# my notes", "", "MY_TOOL=1", ""].join("\n");
+  writePrivateFile(envPath, mine);
+  publishGeminiIntegration({ routedModels: routedModels() });
+  assert.ok(readFileSync(envPath, "utf8").startsWith(mine));
+  removeGeminiIntegration();
+  assert.equal(readFileSync(envPath, "utf8"), mine);
+});
+
+test("a document the router created entirely is removed, not left empty", () => {
+  rmSync(envPath, { force: true });
+  publishGeminiIntegration({ routedModels: routedModels() });
+  removeGeminiIntegration();
+  assert.equal(geminiIntegrationStatus().envExists, false);
+  assert.equal(geminiIntegrationStatus().installed, false);
+});
+
+test("an assignment the router did not write stops the publish and names the line", () => {
+  const mine = ["# mine", "GEMINI_API_KEY=my-real-google-key", ""].join("\n");
+  writePrivateFile(envPath, mine);
+  assert.throws(
+    () => publishGeminiIntegration({ routedModels: routedModels() }),
+    /GEMINI_API_KEY \(line 2\)/,
+  );
+  // Refused with the file untouched: a refusal costs a command, a wrong guess
+  // rewrites a document whose only copy is on the user's disk.
+  assert.equal(readFileSync(envPath, "utf8"), mine);
+  rmSync(envPath, { force: true });
+});
+
+test("drift is reported against the models the last publish advertised", () => {
+  publishGeminiIntegration({ routedModels: routedModels() });
+  const drift = geminiCatalogDrift({ routedModels: routedModels([{ slug: "vendor/small" }]) });
+  assert.deepEqual(drift.missing, ["vendor/large"]);
+  assert.equal(drift.defaultMissing, true);
+  assert.deepEqual(drift.added, []);
+});
+
+test("no published catalog means no drift to report", () => {
+  removeGeminiIntegration();
+  rmSync(GEMINI_CATALOG_PATH, { force: true });
+  assert.equal(geminiCatalogDrift({ routedModels: routedModels() }), undefined);
+});

--- a/test/gemini-env.test.mjs
+++ b/test/gemini-env.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  GEMINI_ENV_BEGIN,
+  GEMINI_ENV_END,
+  GEMINI_MANAGED_KEYS,
+  conflictingAssignments,
+  removeGeminiEnvBlock,
+  spliceGeminiEnvBlock,
+} from "../src/gemini-env.mjs";
+
+const VALUES = {
+  GOOGLE_GEMINI_BASE_URL: "http://127.0.0.1:4202/_codex-router/secret/gemini",
+  GEMINI_API_KEY: "secret",
+  GEMINI_MODEL: "vendor/model",
+};
+
+test("the managed keys are exactly the three the integration needs", () => {
+  assert.deepEqual([...GEMINI_MANAGED_KEYS], [
+    "GOOGLE_GEMINI_BASE_URL",
+    "GEMINI_API_KEY",
+    "GEMINI_MODEL",
+  ]);
+});
+
+test("an empty document gains only the managed block", () => {
+  const written = spliceGeminiEnvBlock("", VALUES);
+  assert.equal(
+    written,
+    [
+      GEMINI_ENV_BEGIN,
+      "GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:4202/_codex-router/secret/gemini",
+      "GEMINI_API_KEY=secret",
+      "GEMINI_MODEL=vendor/model",
+      GEMINI_ENV_END,
+      "",
+    ].join("\n"),
+  );
+});
+
+test("publishing twice is byte-identical", () => {
+  const once = spliceGeminiEnvBlock("", VALUES);
+  assert.equal(spliceGeminiEnvBlock(once, VALUES), once);
+});
+
+test("everything that is not ours survives a publish untouched", () => {
+  // A `.env` in the user's home is theirs. Comments, blank lines and unrelated
+  // assignments are somebody's work and are not the router's to reflow.
+  const original = [
+    "# my own notes",
+    "",
+    "SOME_OTHER_TOOL=1",
+    "  SPACED = value  ",
+    "",
+    "# trailing note",
+    "",
+  ].join("\n");
+  const written = spliceGeminiEnvBlock(original, VALUES);
+  assert.ok(written.startsWith(original));
+  assert.ok(written.includes(GEMINI_ENV_BEGIN));
+  assert.equal(removeGeminiEnvBlock(written), original);
+});
+
+test("removing the block restores the document exactly", () => {
+  const original = ["A=1", "", "# note", "B=2", ""].join("\n");
+  const written = spliceGeminiEnvBlock(original, VALUES);
+  assert.equal(removeGeminiEnvBlock(written), original);
+});
+
+test("removing a block that was never written changes nothing", () => {
+  const original = "A=1\n";
+  assert.equal(removeGeminiEnvBlock(original), original);
+});
+
+test("an updated block replaces in place rather than appending a second one", () => {
+  const original = ["A=1", "", "# note", ""].join("\n");
+  const first = spliceGeminiEnvBlock(original, VALUES);
+  const second = spliceGeminiEnvBlock(first, { ...VALUES, GEMINI_MODEL: "other/model" });
+  assert.equal(second.match(/# BEGIN codex-router-gemini/g).length, 1);
+  assert.ok(second.includes("GEMINI_MODEL=other/model"));
+  assert.ok(!second.includes("GEMINI_MODEL=vendor/model"));
+  assert.equal(removeGeminiEnvBlock(second), original);
+});
+
+test("a key we omit is absent from the block rather than written empty", () => {
+  // The default model is opt-out. Writing `GEMINI_MODEL=` would out-rank the
+  // user's own settings.json choice with an empty string.
+  const written = spliceGeminiEnvBlock("", { ...VALUES, GEMINI_MODEL: undefined });
+  assert.ok(!written.includes("GEMINI_MODEL"));
+  assert.ok(written.includes("GEMINI_API_KEY=secret"));
+});
+
+test("a managed key assigned outside our block is reported, not overwritten", () => {
+  // dotenv lets the last assignment in a file win, so a duplicate below our
+  // block silently decides the base URL. Refusing and naming the line costs a
+  // command; guessing rewrites a file whose only copy is on the user's disk.
+  const document = ["# mine", "GEMINI_API_KEY=my-real-google-key", ""].join("\n");
+  assert.deepEqual(conflictingAssignments(document), [
+    { key: "GEMINI_API_KEY", line: 2 },
+  ]);
+});
+
+test("assignments inside our own block are not conflicts", () => {
+  const written = spliceGeminiEnvBlock("", VALUES);
+  assert.deepEqual(conflictingAssignments(written), []);
+});
+
+test("`export KEY=` and leading whitespace are recognized as assignments", () => {
+  const document = ["export GOOGLE_GEMINI_BASE_URL=https://example", "   GEMINI_MODEL=x"].join(
+    "\n",
+  );
+  assert.deepEqual(conflictingAssignments(document), [
+    { key: "GOOGLE_GEMINI_BASE_URL", line: 1 },
+    { key: "GEMINI_MODEL", line: 2 },
+  ]);
+});
+
+test("a commented-out assignment is not a conflict", () => {
+  assert.deepEqual(conflictingAssignments("# GEMINI_API_KEY=old\n"), []);
+});
+
+test("a value that needs quoting gets it", () => {
+  const written = spliceGeminiEnvBlock("", {
+    ...VALUES,
+    GEMINI_MODEL: "vendor/model with space",
+  });
+  assert.ok(written.includes('GEMINI_MODEL="vendor/model with space"'));
+});
+
+test("a document missing its end marker is refused rather than half-edited", () => {
+  const broken = ["A=1", GEMINI_ENV_BEGIN, "GEMINI_API_KEY=x", ""].join("\n");
+  assert.throws(() => spliceGeminiEnvBlock(broken, VALUES), /end marker/i);
+  assert.throws(() => removeGeminiEnvBlock(broken), /end marker/i);
+});
+
+test("a document with two begin markers is refused", () => {
+  const broken = [GEMINI_ENV_BEGIN, GEMINI_ENV_END, GEMINI_ENV_BEGIN, GEMINI_ENV_END, ""].join(
+    "\n",
+  );
+  assert.throws(() => spliceGeminiEnvBlock(broken, VALUES), /more than once/i);
+});
+
+test("CRLF documents keep their line endings", () => {
+  const original = "A=1\r\n# note\r\n";
+  const written = spliceGeminiEnvBlock(original, VALUES);
+  assert.ok(written.includes("\r\n"));
+  assert.ok(!/[^\r]\n/.test(written));
+  assert.equal(removeGeminiEnvBlock(written), original);
+});

--- a/test/gemini-shape.test.mjs
+++ b/test/gemini-shape.test.mjs
@@ -1,0 +1,531 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  GEMINI_API_VERSION,
+  createGeminiStreamTranslator,
+  estimateGeminiTokens,
+  geminiModelListPayload,
+  geminiToResponsesPayload,
+  parseGeminiPath,
+  responsesPayloadToGemini,
+} from "../src/gemini-shape.mjs";
+
+function userTurn(text) {
+  return { role: "user", parts: [{ text }] };
+}
+
+test("the api version is the one the GenAI SDK defaults to", () => {
+  // @google/genai builds `${baseUrl}/${apiVersion}/models/...` and its
+  // GOOGLE_AI_API_DEFAULT_VERSION is v1beta. Serving anything else means the
+  // CLI's own requests 404 against a surface that is otherwise correct.
+  assert.equal(GEMINI_API_VERSION, "v1beta");
+});
+
+test("a routed slug keeps its slash through the path", () => {
+  // Router slugs are `vendor/model`, and the SDK renders `models/{model}:method`
+  // verbatim. Splitting on the first slash would resolve `vendor` as the model.
+  assert.deepEqual(parseGeminiPath("/v1beta/models/vendor/model:generateContent"), {
+    model: "vendor/model",
+    method: "generateContent",
+  });
+});
+
+test("the streaming path is recognized with its alt=sse query already stripped", () => {
+  assert.deepEqual(parseGeminiPath("/v1beta/models/openai/gpt-5:streamGenerateContent"), {
+    model: "openai/gpt-5",
+    method: "streamGenerateContent",
+  });
+});
+
+test("the model list path carries no model", () => {
+  assert.deepEqual(parseGeminiPath("/v1beta/models"), { method: "list" });
+  assert.deepEqual(parseGeminiPath("/v1beta/models/"), { method: "list" });
+});
+
+test("an unknown path is refused rather than guessed at", () => {
+  assert.equal(parseGeminiPath("/v1/models/x:generateContent"), undefined);
+  assert.equal(parseGeminiPath("/v1beta/tunedModels/x:generateContent"), undefined);
+  assert.equal(parseGeminiPath("/v1beta/models/x:unknownMethod"), undefined);
+});
+
+test("a plain turn becomes a Responses input item", () => {
+  const payload = geminiToResponsesPayload({
+    model: "vendor/model",
+    body: { contents: [userTurn("hello")] },
+    stream: true,
+  });
+  assert.equal(payload.model, "vendor/model");
+  assert.equal(payload.stream, true);
+  assert.deepEqual(payload.input, [
+    { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] },
+  ]);
+});
+
+test("systemInstruction becomes instructions, not a message", () => {
+  // Responses carries the system prompt out of band. Folding it into the input
+  // array puts it in the transcript, where tool-result ageing can drop it.
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      systemInstruction: { parts: [{ text: "be terse" }, { text: "and correct" }] },
+      contents: [userTurn("hi")],
+    },
+  });
+  assert.equal(payload.instructions, "be terse\nand correct");
+  assert.equal(payload.input.length, 1);
+});
+
+test("a bare-string systemInstruction is accepted too", () => {
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: { systemInstruction: "be terse", contents: [userTurn("hi")] },
+  });
+  assert.equal(payload.instructions, "be terse");
+});
+
+test("inline image data becomes a data URL the routed path already understands", () => {
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [
+        { role: "user", parts: [{ inlineData: { mimeType: "image/png", data: "AAAA" } }] },
+      ],
+    },
+  });
+  assert.deepEqual(payload.input[0].content, [
+    { type: "input_image", image_url: "data:image/png;base64,AAAA" },
+  ]);
+});
+
+test("function declarations become Responses tools", () => {
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [userTurn("hi")],
+      tools: [
+        {
+          functionDeclarations: [
+            { name: "read_file", description: "reads", parameters: { type: "object" } },
+          ],
+        },
+      ],
+    },
+  });
+  assert.deepEqual(payload.tools, [
+    {
+      type: "function",
+      name: "read_file",
+      description: "reads",
+      parameters: { type: "object" },
+    },
+  ]);
+});
+
+test("a declaration that carries parametersJsonSchema keeps its schema", () => {
+  // Every Gemini CLI tool declares its schema this way -- `parametersJsonSchema`
+  // is what `tools.js` writes and what its own validator checks calls against.
+  // Reading only `parameters` sent all ten tools upstream with no schema, so the
+  // model invented argument names and the CLI rejected every call it got back
+  // with "params must have required property 'file_path'".
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [userTurn("hi")],
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "read_file",
+              description: "reads",
+              parametersJsonSchema: {
+                type: "object",
+                properties: { file_path: { type: "string" } },
+                required: ["file_path"],
+              },
+            },
+          ],
+        },
+      ],
+    },
+  });
+  assert.deepEqual(payload.tools[0].parameters, {
+    type: "object",
+    properties: { file_path: { type: "string" } },
+    required: ["file_path"],
+  });
+});
+
+test("parametersJsonSchema wins when a declaration carries both", () => {
+  // The raw JSON Schema is the authoritative one; `parameters` is the older
+  // Schema-proto spelling and may be a lossy rendering of it.
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [userTurn("hi")],
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: "f",
+              parameters: { type: "object", properties: { old: { type: "string" } } },
+              parametersJsonSchema: {
+                type: "object",
+                properties: { new: { type: "string" } },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  });
+  assert.deepEqual(payload.tools[0].parameters, {
+    type: "object",
+    properties: { new: { type: "string" } },
+  });
+});
+
+test("a tool with no schema at all is sent with an empty object schema", () => {
+  // Not omitted: a provider on the chat-completions path rejects a function
+  // whose parameters are absent, and "no arguments" is a schema, not a gap.
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [userTurn("hi")],
+      tools: [{ functionDeclarations: [{ name: "ping" }] }],
+    },
+  });
+  assert.deepEqual(payload.tools[0].parameters, { type: "object", properties: {} });
+});
+
+test("a tool call and its result pair on a synthesized call id", () => {
+  // Gemini omits `id` on both halves whenever the caller did not supply one,
+  // so the pairing has to be reconstructed positionally. Responses drops a
+  // function_call_output whose call_id matches no call, which reads to the
+  // model as a tool that never answered.
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [
+        userTurn("read it"),
+        { role: "model", parts: [{ functionCall: { name: "read_file", args: { path: "a" } } }] },
+        {
+          role: "user",
+          parts: [{ functionResponse: { name: "read_file", response: { text: "ok" } } }],
+        },
+      ],
+    },
+  });
+  const call = payload.input.find((item) => item.type === "function_call");
+  const output = payload.input.find((item) => item.type === "function_call_output");
+  assert.equal(call.name, "read_file");
+  assert.equal(call.arguments, JSON.stringify({ path: "a" }));
+  assert.equal(output.call_id, call.call_id);
+  assert.equal(output.output, JSON.stringify({ text: "ok" }));
+});
+
+test("repeated calls to one tool pair in order", () => {
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [
+        {
+          role: "model",
+          parts: [
+            { functionCall: { name: "f", args: { n: 1 } } },
+            { functionCall: { name: "f", args: { n: 2 } } },
+          ],
+        },
+        {
+          role: "user",
+          parts: [
+            { functionResponse: { name: "f", response: { n: 1 } } },
+            { functionResponse: { name: "f", response: { n: 2 } } },
+          ],
+        },
+      ],
+    },
+  });
+  const calls = payload.input.filter((item) => item.type === "function_call");
+  const outputs = payload.input.filter((item) => item.type === "function_call_output");
+  assert.equal(calls.length, 2);
+  assert.notEqual(calls[0].call_id, calls[1].call_id);
+  assert.equal(outputs[0].call_id, calls[0].call_id);
+  assert.equal(outputs[1].call_id, calls[1].call_id);
+});
+
+test("an explicit id wins over the synthesized one", () => {
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [
+        { role: "model", parts: [{ functionCall: { id: "call-7", name: "f", args: {} } }] },
+        { role: "user", parts: [{ functionResponse: { id: "call-7", name: "f", response: {} } }] },
+      ],
+    },
+  });
+  assert.equal(payload.input[0].call_id, "call-7");
+  assert.equal(payload.input[1].call_id, "call-7");
+});
+
+test("a model's own thought parts are not replayed as assistant text", () => {
+  // Gemini marks reasoning with `thought: true`. Sending it back as an ordinary
+  // assistant message would put the model's private reasoning in the visible
+  // transcript on every subsequent turn.
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [
+        { role: "model", parts: [{ text: "thinking", thought: true }, { text: "answer" }] },
+      ],
+    },
+  });
+  assert.deepEqual(payload.input, [
+    { type: "message", role: "assistant", content: [{ type: "output_text", text: "answer" }] },
+  ]);
+});
+
+test("generation config maps onto the Responses parameters that exist", () => {
+  const payload = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [userTurn("hi")],
+      generationConfig: { temperature: 0.2, topP: 0.9, maxOutputTokens: 512 },
+    },
+  });
+  assert.equal(payload.temperature, 0.2);
+  assert.equal(payload.top_p, 0.9);
+  assert.equal(payload.max_output_tokens, 512);
+});
+
+test("a thinking budget becomes a reasoning effort, and zero means minimal", () => {
+  const off = geminiToResponsesPayload({
+    model: "m",
+    body: { contents: [userTurn("hi")], generationConfig: { thinkingConfig: { thinkingBudget: 0 } } },
+  });
+  assert.deepEqual(off.reasoning, { effort: "minimal" });
+  const deep = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [userTurn("hi")],
+      generationConfig: { thinkingConfig: { thinkingBudget: 24000 } },
+    },
+  });
+  assert.deepEqual(deep.reasoning, { effort: "high" });
+});
+
+test("no thinking config leaves reasoning to the router's own per-model profile", () => {
+  const payload = geminiToResponsesPayload({ model: "m", body: { contents: [userTurn("hi")] } });
+  assert.equal(payload.reasoning, undefined);
+});
+
+test("the function calling mode maps onto tool_choice", () => {
+  const forced = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [userTurn("hi")],
+      toolConfig: { functionCallingConfig: { mode: "ANY" } },
+    },
+  });
+  assert.equal(forced.tool_choice, "required");
+  const none = geminiToResponsesPayload({
+    model: "m",
+    body: {
+      contents: [userTurn("hi")],
+      toolConfig: { functionCallingConfig: { mode: "NONE" } },
+    },
+  });
+  assert.equal(none.tool_choice, "none");
+});
+
+test("a completed Responses payload becomes one Gemini candidate", () => {
+  const gemini = responsesPayloadToGemini(
+    {
+      id: "resp_1",
+      model: "vendor/model",
+      status: "completed",
+      output: [
+        { type: "reasoning", summary: [{ type: "summary_text", text: "hmm" }] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "hello" }] },
+      ],
+      usage: { input_tokens: 11, output_tokens: 3, total_tokens: 14 },
+    },
+    { model: "vendor/model" },
+  );
+  assert.equal(gemini.candidates.length, 1);
+  assert.equal(gemini.candidates[0].finishReason, "STOP");
+  assert.deepEqual(gemini.candidates[0].content.parts, [
+    { text: "hmm", thought: true },
+    { text: "hello" },
+  ]);
+  assert.deepEqual(gemini.usageMetadata, {
+    promptTokenCount: 11,
+    candidatesTokenCount: 3,
+    totalTokenCount: 14,
+  });
+  assert.equal(gemini.responseId, "resp_1");
+  assert.equal(gemini.modelVersion, "vendor/model");
+});
+
+test("a function call survives the non-streaming translation", () => {
+  const gemini = responsesPayloadToGemini(
+    {
+      status: "completed",
+      output: [
+        { type: "function_call", call_id: "c1", name: "read_file", arguments: '{"path":"a"}' },
+      ],
+    },
+    { model: "m" },
+  );
+  assert.deepEqual(gemini.candidates[0].content.parts, [
+    { functionCall: { id: "c1", name: "read_file", args: { path: "a" } } },
+  ]);
+});
+
+test("unparsable tool arguments are surfaced, not dropped", () => {
+  // A provider that emits truncated JSON must not silently become a call with
+  // no arguments -- the tool would run on defaults and look like it succeeded.
+  const gemini = responsesPayloadToGemini(
+    { status: "completed", output: [{ type: "function_call", name: "f", arguments: "{oops" }] },
+    { model: "m" },
+  );
+  assert.deepEqual(gemini.candidates[0].content.parts[0].functionCall.args, {});
+  assert.equal(gemini.promptFeedback, undefined);
+});
+
+test("an output cut short reports MAX_TOKENS", () => {
+  const gemini = responsesPayloadToGemini(
+    {
+      status: "incomplete",
+      incomplete_details: { reason: "max_output_tokens" },
+      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "a" }] }],
+    },
+    { model: "m" },
+  );
+  assert.equal(gemini.candidates[0].finishReason, "MAX_TOKENS");
+});
+
+test("reasoning tokens are reported where Gemini clients look for them", () => {
+  const gemini = responsesPayloadToGemini(
+    {
+      status: "completed",
+      output: [],
+      usage: {
+        input_tokens: 5,
+        output_tokens: 9,
+        total_tokens: 14,
+        output_tokens_details: { reasoning_tokens: 4 },
+      },
+    },
+    { model: "m" },
+  );
+  assert.equal(gemini.usageMetadata.thoughtsTokenCount, 4);
+});
+
+test("the stream translator turns text deltas into candidate chunks", () => {
+  const translator = createGeminiStreamTranslator({ model: "m" });
+  const chunks = [
+    ...translator.push({ type: "response.output_text.delta", delta: "he" }),
+    ...translator.push({ type: "response.output_text.delta", delta: "llo" }),
+  ];
+  assert.deepEqual(
+    chunks.map((chunk) => chunk.candidates[0].content.parts[0].text),
+    ["he", "llo"],
+  );
+  assert.equal(chunks[0].candidates[0].content.role, "model");
+});
+
+test("reasoning deltas are marked as thoughts", () => {
+  const translator = createGeminiStreamTranslator({ model: "m" });
+  const [chunk] = translator.push({
+    type: "response.reasoning_summary_text.delta",
+    delta: "considering",
+  });
+  assert.deepEqual(chunk.candidates[0].content.parts, [{ text: "considering", thought: true }]);
+});
+
+test("a completed function call is emitted once, when the item closes", () => {
+  const translator = createGeminiStreamTranslator({ model: "m" });
+  assert.deepEqual(
+    translator.push({
+      type: "response.output_item.added",
+      item: { type: "function_call", name: "f", call_id: "c1" },
+    }),
+    [],
+  );
+  const [chunk] = translator.push({
+    type: "response.output_item.done",
+    item: { type: "function_call", name: "f", call_id: "c1", arguments: '{"a":1}' },
+  });
+  assert.deepEqual(chunk.candidates[0].content.parts, [
+    { functionCall: { id: "c1", name: "f", args: { a: 1 } } },
+  ]);
+});
+
+test("the terminal event carries the finish reason and the usage", () => {
+  const translator = createGeminiStreamTranslator({ model: "m" });
+  translator.push({ type: "response.output_text.delta", delta: "hi" });
+  const [chunk] = translator.push({
+    type: "response.completed",
+    response: {
+      id: "resp_9",
+      status: "completed",
+      usage: { input_tokens: 2, output_tokens: 1, total_tokens: 3 },
+    },
+  });
+  assert.equal(chunk.candidates[0].finishReason, "STOP");
+  assert.deepEqual(chunk.usageMetadata, {
+    promptTokenCount: 2,
+    candidatesTokenCount: 1,
+    totalTokenCount: 3,
+  });
+  assert.equal(chunk.responseId, "resp_9");
+});
+
+test("a stream that ends without a terminal event still closes the candidate", () => {
+  // The SDK waits for a finishReason. A dropped upstream would otherwise leave
+  // the CLI holding an open turn until its own timeout.
+  const translator = createGeminiStreamTranslator({ model: "m" });
+  translator.push({ type: "response.output_text.delta", delta: "hi" });
+  const closing = translator.finish();
+  assert.equal(closing.length, 1);
+  assert.equal(closing[0].candidates[0].finishReason, "STOP");
+});
+
+test("a terminal event makes the closer a no-op", () => {
+  const translator = createGeminiStreamTranslator({ model: "m" });
+  translator.push({ type: "response.completed", response: { status: "completed" } });
+  assert.deepEqual(translator.finish(), []);
+});
+
+test("a failed response finishes as OTHER rather than as a clean stop", () => {
+  const translator = createGeminiStreamTranslator({ model: "m" });
+  const [chunk] = translator.push({
+    type: "response.failed",
+    response: { status: "failed", error: { message: "upstream refused" } },
+  });
+  assert.equal(chunk.candidates[0].finishReason, "OTHER");
+});
+
+test("the model list is shaped the way the SDK expects", () => {
+  const payload = geminiModelListPayload([
+    { slug: "vendor/model", displayName: "Vendor Model", contextWindow: 262144 },
+  ]);
+  assert.deepEqual(payload.models, [
+    {
+      name: "models/vendor/model",
+      displayName: "Vendor Model",
+      description: "Routed by Codex Router.",
+      inputTokenLimit: 262144,
+      outputTokenLimit: 262144,
+      supportedGenerationMethods: ["generateContent", "streamGenerateContent", "countTokens"],
+    },
+  ]);
+});
+
+test("the token estimate always answers, including for an empty request", () => {
+  // countTokens has no upstream to ask, and a client that gets no number at all
+  // cannot decide whether to compact. A crude estimate beats a 501 here.
+  assert.equal(estimateGeminiTokens({ contents: [] }), 0);
+  assert.ok(estimateGeminiTokens({ contents: [userTurn("x".repeat(400))] }) > 0);
+});

--- a/test/gemini-surface.test.mjs
+++ b/test/gemini-surface.test.mjs
@@ -1,0 +1,412 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import { writeJson } from "../src/http-utils.mjs";
+import { GEMINI_ROUTE_PREFIX, handleGeminiRequest, isGeminiRoute } from "../src/gemini-surface.mjs";
+
+const MODELS = [
+  { slug: "vendor/model", displayName: "Vendor Model", contextWindow: 262144 },
+  { slug: "other/model", displayName: "Other Model", contextWindow: 128000 },
+];
+
+// A stand-in for the router's own /v1/responses endpoint. The surface reaches
+// it over the loopback exactly as it would in the service, so these exercise
+// the real request the CLI's turn becomes.
+function upstream(handler) {
+  const seen = [];
+  const server = http.createServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const body = Buffer.concat(chunks).toString("utf8");
+    seen.push({ headers: request.headers, body: body ? JSON.parse(body) : undefined });
+    handler(request, response, seen[seen.length - 1]);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        seen,
+        url: `http://127.0.0.1:${server.address().port}/v1/responses`,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+function surface(responsesUrl, { abortRequestSignal = false } = {}) {
+  const server = http.createServer(async (request, response) => {
+    const route = new URL(request.url, "http://127.0.0.1").pathname;
+    if (isGeminiRoute(route)) {
+      if (abortRequestSignal) {
+        // What Node 24 does on its own: `IncomingMessage.signal` aborts once the
+        // request body has been read, which is before the loopback call is made.
+        Object.defineProperty(request, "signal", { value: AbortSignal.abort() });
+      }
+      await handleGeminiRequest(request, response, route, {
+        responsesUrl,
+        routedModels: () => MODELS,
+      });
+      return;
+    }
+    writeJson(response, 404, { error: { type: "not_found" } });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        url: (path) => `http://127.0.0.1:${server.address().port}${GEMINI_ROUTE_PREFIX}${path}`,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+function sse(response, events) {
+  response.writeHead(200, {
+    "Content-Type": "text/event-stream; charset=utf-8",
+    "Cache-Control": "no-cache",
+  });
+  for (const [type, data] of events) {
+    response.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`);
+  }
+  response.end("data: [DONE]\n\n");
+}
+
+function frames(text) {
+  return text
+    .split("\n\n")
+    .map((block) => block.split("\n").find((line) => line.startsWith("data: ")))
+    .filter(Boolean)
+    .map((line) => line.slice("data: ".length))
+    .filter((payload) => payload !== "[DONE]")
+    .map((payload) => JSON.parse(payload));
+}
+
+test("only the gemini leaf is claimed", () => {
+  assert.equal(isGeminiRoute("/gemini/v1beta/models"), true);
+  assert.equal(isGeminiRoute("/gemini"), true);
+  assert.equal(isGeminiRoute("/v1/responses"), false);
+  assert.equal(isGeminiRoute("/gemini-other/v1beta/models"), false);
+});
+
+test("the model list serves the routed set", async () => {
+  const app = await surface("http://127.0.0.1:1/v1/responses");
+  try {
+    const response = await fetch(app.url("/v1beta/models"));
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.deepEqual(
+      payload.models.map((model) => model.name),
+      ["models/vendor/model", "models/other/model"],
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("a turn reaches the router's own Responses endpoint", async () => {
+  const back = await upstream((request, response) => {
+    writeJson(response, 200, {
+      id: "resp_1",
+      status: "completed",
+      output: [
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "hi" }] },
+      ],
+      usage: { input_tokens: 3, output_tokens: 1, total_tokens: 4 },
+    });
+  });
+  const app = await surface(back.url);
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/model:generateContent"), {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-goog-api-key": "caller-secret" },
+      body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "hello" }] }] }),
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload.candidates[0].content.parts, [{ text: "hi" }]);
+    assert.equal(payload.candidates[0].finishReason, "STOP");
+    assert.equal(payload.usageMetadata.promptTokenCount, 3);
+    assert.equal(back.seen[0].body.model, "vendor/model");
+    assert.equal(back.seen[0].body.stream, false);
+  } finally {
+    await app.close();
+    await back.close();
+  }
+});
+
+test("the caller's own key is never relayed upstream", async () => {
+  // The key the CLI sends is this router's caller capability. Forwarding it on
+  // the loopback would put a router secret into a request that can be
+  // substituted onto a real provider hop -- and `callerBroughtNoUpstreamCredential`
+  // is what lets a client with no ChatGPT session of its own reach native models.
+  const back = await upstream((request, response) => {
+    writeJson(response, 200, { status: "completed", output: [] });
+  });
+  const app = await surface(back.url);
+  try {
+    await fetch(app.url("/v1beta/models/vendor/model:generateContent"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-goog-api-key": "caller-secret",
+        authorization: "Bearer caller-secret",
+      },
+      body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "hi" }] }] }),
+    });
+    assert.equal(back.seen[0].headers.authorization, undefined);
+    assert.equal(back.seen[0].headers["x-goog-api-key"], undefined);
+  } finally {
+    await app.close();
+    await back.close();
+  }
+});
+
+test("an already-aborted request signal does not cancel the turn", async () => {
+  // `IncomingMessage.signal` does not exist before Node 22, and on Node 24 it
+  // aborts as soon as the request body has been read -- which is *before* the
+  // loopback call is made, so passing it through failed every routed turn with
+  // an instant 502 on CI while passing locally on a Node that has no `signal`
+  // at all. The turn's lifetime is tied to the response closing instead.
+  const back = await upstream((request, response) => {
+    writeJson(response, 200, {
+      status: "completed",
+      output: [
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "alive" }] },
+      ],
+    });
+  });
+  const app = await surface(back.url, { abortRequestSignal: true });
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/model:generateContent"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "hi" }] }] }),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual((await response.json()).candidates[0].content.parts, [{ text: "alive" }]);
+    assert.equal(back.seen.length, 1);
+  } finally {
+    await app.close();
+    await back.close();
+  }
+});
+
+test("a loopback failure names its cause instead of swallowing it", async () => {
+  // The first cut answered a failed loopback with a bare "could not be reached",
+  // so a CI run that failed on every turn had nothing in it to say why.
+  const app = await surface("http://127.0.0.1:1/v1/responses");
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/model:generateContent"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "hi" }] }] }),
+    });
+    assert.equal(response.status, 502);
+    const { error } = await response.json();
+    assert.match(error.message, /could not be reached/);
+    // The cause chain, not just the summary: a bare TypeError names nothing.
+    assert.match(error.message, /ECONNREFUSED|TypeError/);
+  } finally {
+    await app.close();
+  }
+});
+
+test("a streamed turn arrives as whole Gemini responses in SSE frames", async () => {
+  const back = await upstream((request, response) => {
+    sse(response, [
+      ["response.output_text.delta", { delta: "he" }],
+      ["response.output_text.delta", { delta: "llo" }],
+      [
+        "response.completed",
+        {
+          response: {
+            id: "resp_2",
+            status: "completed",
+            usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+          },
+        },
+      ],
+    ]);
+  });
+  const app = await surface(back.url);
+  try {
+    const response = await fetch(
+      app.url("/v1beta/models/vendor/model:streamGenerateContent?alt=sse"),
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "hi" }] }] }),
+      },
+    );
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type"), /text\/event-stream/);
+    const parsed = frames(await response.text());
+    assert.deepEqual(
+      parsed.slice(0, 2).map((chunk) => chunk.candidates[0].content.parts[0].text),
+      ["he", "llo"],
+    );
+    const last = parsed[parsed.length - 1];
+    assert.equal(last.candidates[0].finishReason, "STOP");
+    assert.equal(last.usageMetadata.totalTokenCount, 7);
+    assert.equal(back.seen[0].body.stream, true);
+  } finally {
+    await app.close();
+    await back.close();
+  }
+});
+
+test("a stream the upstream drops still ends with a finish reason", async () => {
+  const back = await upstream((request, response) => {
+    response.writeHead(200, { "Content-Type": "text/event-stream; charset=utf-8" });
+    response.write(
+      `event: response.output_text.delta\ndata: ${JSON.stringify({
+        type: "response.output_text.delta",
+        delta: "partial",
+      })}\n\n`,
+    );
+    response.end();
+  });
+  const app = await surface(back.url);
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/model:streamGenerateContent?alt=sse"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "hi" }] }] }),
+    });
+    const parsed = frames(await response.text());
+    assert.equal(parsed[parsed.length - 1].candidates[0].finishReason, "STOP");
+  } finally {
+    await app.close();
+    await back.close();
+  }
+});
+
+test("an upstream refusal is reported in the Gemini error shape", async () => {
+  const back = await upstream((request, response) => {
+    writeJson(response, 429, {
+      error: { type: "rate_limit_error", message: "provider is out of quota" },
+    });
+  });
+  const app = await surface(back.url);
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/model:generateContent"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "hi" }] }] }),
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 429);
+    assert.equal(payload.error.code, 429);
+    assert.equal(payload.error.status, "RESOURCE_EXHAUSTED");
+    assert.match(payload.error.message, /out of quota/);
+  } finally {
+    await app.close();
+    await back.close();
+  }
+});
+
+test("a model that is not routed is refused by name", async () => {
+  // Falling through would send the slug to /v1/responses, where an unregistered
+  // model is treated as native GPT traffic -- so a typo would silently become a
+  // ChatGPT-session request rather than an error the user can read.
+  const app = await surface("http://127.0.0.1:1/v1/responses");
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/missing:generateContent"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contents: [] }),
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 404);
+    assert.equal(payload.error.status, "NOT_FOUND");
+    assert.match(payload.error.message, /vendor\/missing/);
+  } finally {
+    await app.close();
+  }
+});
+
+test("countTokens answers without spending a turn", async () => {
+  const back = await upstream(() => {
+    throw new Error("countTokens must not reach the provider");
+  });
+  const app = await surface(back.url);
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/model:countTokens"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contents: [{ role: "user", parts: [{ text: "x".repeat(400) }] }] }),
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 200);
+    assert.ok(payload.totalTokens > 0);
+    assert.equal(back.seen.length, 0);
+  } finally {
+    await app.close();
+    await back.close();
+  }
+});
+
+test("embeddings are refused in a way that names the limit", async () => {
+  const app = await surface("http://127.0.0.1:1/v1/responses");
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/model:embedContent"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: { parts: [{ text: "hi" }] } }),
+    });
+    const payload = await response.json();
+    assert.equal(response.status, 501);
+    assert.equal(payload.error.status, "UNIMPLEMENTED");
+    assert.match(payload.error.message, /embedding/i);
+  } finally {
+    await app.close();
+  }
+});
+
+test("a streaming request without alt=sse is refused rather than answered wrongly", async () => {
+  // Without `alt=sse` the real API answers with a JSON array, not an event
+  // stream. Serving SSE anyway would hand a client a body it cannot parse.
+  const app = await surface("http://127.0.0.1:1/v1/responses");
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/model:streamGenerateContent"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ contents: [] }),
+    });
+    assert.equal(response.status, 400);
+    assert.equal((await response.json()).error.status, "INVALID_ARGUMENT");
+  } finally {
+    await app.close();
+  }
+});
+
+test("an unknown gemini path is a 404, not a crash", async () => {
+  const app = await surface("http://127.0.0.1:1/v1/responses");
+  try {
+    const response = await fetch(app.url("/v1beta/tunedModels/x:generateContent"), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    assert.equal(response.status, 404);
+  } finally {
+    await app.close();
+  }
+});
+
+test("a browser-originated request is rejected the way the routed path rejects one", async () => {
+  const app = await surface("http://127.0.0.1:1/v1/responses");
+  try {
+    const response = await fetch(app.url("/v1beta/models/vendor/model:generateContent"), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://example.com",
+      },
+      body: JSON.stringify({ contents: [] }),
+    });
+    assert.equal(response.status, 403);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
Adds `gemini` as a target alongside `codex` and `dsh`, so the router's models
show up in [Gemini CLI](https://github.com/google-gemini/gemini-cli).

**Please test this if you have Gemini CLI installed** — see "How to try it" below.
It is verified end to end on macOS with gemini-cli 0.27.3, but only against the
providers on one machine, and `install.ps1` has never been run.

## Why it needs a new surface

Gemini CLI speaks only the Gemini API, and Google
[does not support](https://discuss.ai.google.dev/t/antigravity-add-your-own-api-keys-models/137068)
bring-your-own-provider. But with `GEMINI_API_KEY` set, `createContentGenerator`
in `@google/gemini-cli-core` builds a plain `@google/genai` client and calls
`{GOOGLE_GEMINI_BASE_URL}/v1beta/models/{model}:{method}` — so a Gemini-shaped
endpoint is all that is missing.

The router now serves one at `/_codex-router/<key>/gemini`, behind the same
caller capability as `/v1` and `/panel`.

## It is not a second request path

`gemini-surface.mjs` translates the turn into a Responses request, sends it
through the router's existing `/v1/responses` **over the loopback**, and
translates the answer back. Tool-result ageing, the vision bridge, prompt-token
substitution, upstream retry, model failover, and usage accounting all still sit
on one request path. The loopback deliberately carries no credential — the key
the CLI presents *is* the caller capability, and leaving the header off is also
what lets native GPT models reach the ChatGPT-session fallback.

## What it writes

One marker block in `~/.gemini/.env`, and nothing else:

```sh
# BEGIN codex-router-gemini
GOOGLE_GEMINI_BASE_URL=http://127.0.0.1:4202/_codex-router/<caller-key>/gemini
GEMINI_API_KEY=<caller-key>
GEMINI_MODEL=anthropic/claude-opus-4-6
# END codex-router-gemini
```

`settings.json` is **never opened for writing** — it is JSONC carrying the
user's own comments, and a `JSON.parse`/`stringify` round trip would delete
every one of them. The block is 0600 because it holds the caller key,
publishing twice is byte-identical, and removing it restores the file exactly.
A managed key assigned outside the block stops the publish with the line named:
`dotenv` lets the last assignment win, so a duplicate would silently decide
which endpoint is in force.

## How to try it

```sh
./bin/model-router gemini enable
./bin/model-router gemini doctor
cd /some/project && gemini -p "what does this repo do?"
```

If the CLI asks how to authenticate, choose **Use Gemini API key** once — the
key is the router's local caller capability, not a Google one, and it never
leaves the machine. To undo: `./bin/model-router gemini disable`.

Please report: which provider/model you used, whether tool calls worked, and
anything `gemini doctor` said.

## Verified

Driven with the real `gemini` binary against real providers:

| Check | Result |
|---|---|
| `GET /v1beta/models` | 84 models |
| `:countTokens` | answers without spending a turn |
| `:streamGenerateContent` (`qwen-plan/qwen3.6-flash`) | correct text, reasoning as `thoughtsTokenCount`, `finishReason: STOP` |
| real CLI, plain turn | passed |
| real CLI, **tool calling** (`zai-coding/glm-5.3`) | full loop: 10 tool schemas out → call in → result out → answer in |
| provider 503 / quota 403 | relayed as `UNAVAILABLE` / `PERMISSION_DENIED` with the router's own message |

That live run caught the one bug the unit tests could not: a Gemini tool
declares its schema as **`parametersJsonSchema`**, not `parameters`
(`gemini-cli-core/dist/src/tools/tools.js:194`). The first cut read only
`parameters`, so every tool went upstream with no schema, the model invented
argument names, and the CLI rejected each call with
`params must have required property 'file_path'`.

## Deliberate limits

- **Embeddings refused** with a named 501 — no routed provider exposes one, and
  a fabricated vector is worse than an error. Gemini CLI calls `embedContent`
  only from `baseLlmClient`, never from the turn loop.
- **`countTokens` is estimated** rather than answered by spending a real turn.
- **The default model is written**, unlike the harness integration's opt-in
  equivalent, because Gemini CLI's own default is a Gemini model this router
  does not route — an install that left it alone would 404 on the first turn.
  `--model` still outranks it.
- **`~/.gemini/.env` loses to a project `.env`**: `findEnvFile` walks up from
  cwd first. Inside a repo that has its own `.env`, the router's block is
  ignored. Documented rather than worked around.
- **No tray surface.** The Swift tray reads `targets["codex"]` only, so Gemini
  will not appear there. Additive, nothing breaks.

## Also in here

`routed-client-models.mjs` extracts the "what may be published to a client that
carries no ChatGPT session of its own" rule out of the harness manager. It was
always a general rule; a second client wanting it verbatim made a second copy
the wrong answer.

## Tests

77 new tests. Full suite **1443 pass / 0 fail** on this branch; base `ef7995a`
is 1366 / 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKT3Zabs9wpfa3UEWgmaVV
