### PR TITLE
docs(subagents): say that a subagent proof is about the wire, not the work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,15 +356,25 @@ so the unit of evidence is always the slug, never the model name.
    (`proven`) or a structural rejection — HTTP 400/422 — as a demotion back to
    v1 with the reason kept where it was switched on. Transient failures (429,
    5xx, disconnects) prove nothing and leave the window open.
-3. Local settings still never manufacture a v2 claim. The only writers of
+3. `proven` is a claim about the wire, not about the work. It says one child
+   turn for that slug completed cleanly, so the model can hold the child role;
+   it does not say the child finished what it was delegated. The router
+   observes HTTP turns, not agent lifecycles — a child makes one turn per
+   tool-call round trip, and the loop that strings them together is Codex's —
+   so a model that answers turn after turn without converging still reaches
+   `proven` and keeps it until `control subagents verify` re-researches it.
+   Do not write copy anywhere (log lines, tray, docs) that reads `proven` as
+   "the delegated task succeeded"; demoting a looping child needs a
+   convergence signal the request path does not yet have (issue #257).
+4. Local settings still never manufacture a v2 claim. The only writers of
    promotion evidence are the probe worker and the router's observation of
    real traffic; an unreadable proofs file promotes nothing, and a hidden or
    switched-off slug stays v1 whatever evidence it carries.
-4. `control subagents verify [SLUG ...]` re-researches explicitly (foreground,
+5. `control subagents verify [SLUG ...]` re-researches explicitly (foreground,
    ~2 requests per candidate); with no slugs it sweeps the enabled list.
    Select-all and mode changes never trigger probes — a sweep across every
    provider is quota the operator must ask for.
-5. Machine-local proofs are exactly that. Shipping a default to every
+6. Machine-local proofs are exactly that. Shipping a default to every
    installer still requires the full native collaboration proof and a registry
    change (below); never edit the checked-in `config/` tree because one
    machine's probe passed.

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1776,6 +1776,20 @@ function requireCodexTransport(request, response) {
 // takes); transient failures — 429s, 5xx, disconnects — prove nothing either
 // way and leave the window open. Neither line is QUIET-gated: a promotion or
 // demotion that happens silently is how a picker entry becomes unexplainable.
+//
+// What the promotion claims is exactly one HTTP turn, and the log line has to
+// say so. A child agent makes many turns — one per tool-call round trip — and
+// this observer sees each of them separately; it never sees the agent loop
+// that strings them together, so "the child reached done" is not a fact
+// available here. An operator who read the old "subagent proven … completed a
+// live child turn" as *the delegated work finished* was reading a promise the
+// router cannot make (issue #257). A model that speaks the protocol turn after
+// turn without ever converging therefore still carries this proof: it returns
+// 200s, so nothing above demotes it, and only `control subagents verify` — run
+// by hand — re-examines it. Closing that needs a convergence signal this
+// function does not have; naming the claim honestly is the part that does not
+// require inventing one.
+
 function observeSubagentOutcome(request, route, status, { emptyCompletion = false } = {}) {
   if (!route) return;
   try {
@@ -1784,7 +1798,8 @@ function observeSubagentOutcome(request, route, status, { emptyCompletion = fals
     if (status === 200 && !emptyCompletion) {
       recordSpawnObserved(route.slug, { status });
       console.error(
-        `[codex-router] subagent proven: ${route.slug} completed a live child turn`,
+        `[codex-router] subagent child role verified: ${route.slug} served a live child turn; ` +
+          "the model holds the child role on the wire, which is not a claim the child finished its task",
       );
     } else if (status === 400 || status === 422) {
       recordSpawnFailure(route.slug, {

--- a/src/subagent-proofs.mjs
+++ b/src/subagent-proofs.mjs
@@ -22,6 +22,15 @@ import { STATE_DIR } from "./paths.mjs";
 //   failed        the probe failed, or an observed spawn failed structurally;
 //                 the model stays v1 and the reason is shown where it was
 //                 switched on
+//
+// "proven" is a claim about the wire, not about the work: it means one child
+// turn for this slug completed cleanly, so the model can hold the v2 child
+// role. The router observes HTTP turns, not agent lifecycles — a child makes
+// one turn per tool-call round trip and the loop that strings them together is
+// Codex's, not the router's — so nothing here can say the child reached done.
+// A model that keeps answering turns without ever converging still reaches
+// "proven" and stays there until `control subagents verify` re-researches it
+// (issue #257).
 export const SUBAGENT_PROOFS_PATH =
   process.env.MODEL_ROUTER_SUBAGENT_PROOFS ||
   path.join(STATE_DIR, "multi-agent-proofs.json");

--- a/test/subagent-proofs.test.mjs
+++ b/test/subagent-proofs.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -221,4 +221,26 @@ test("a plan-entitlement refusal defers every model it gated, condemning none", 
   });
   assert.equal(gated[0].status, "deferred");
   assert.equal(subagentProofSnapshot()[slug], undefined);
+});
+
+// Issue #257: an operator watched "subagent proven: <slug> completed a live
+// child turn" and read it as the child finishing the work it was delegated.
+// The observer sees one HTTP turn — a child makes one per tool-call round trip
+// and the loop stringing them together is Codex's — so the promotion cannot
+// mean that, and the line it prints has to scope its own claim. Guarded at the
+// source because the wording *is* the fix: nothing else in the process states
+// what `proven` promises to the person reading the router log.
+test("the subagent promotion log line claims the wire role, not a finished task", () => {
+  const source = readFileSync(new URL("../src/router.mjs", import.meta.url), "utf8");
+  const start = source.indexOf("function observeSubagentOutcome");
+  assert.ok(start > 0, "observeSubagentOutcome moved; re-point this guard at the promotion path");
+  // Scoped to the one function, so an unrelated router line cannot satisfy it.
+  const body = source.slice(start).split(/\r?\n\}/)[0];
+  assert.match(body, /child role verified/);
+  assert.match(body, /not a claim the child finished its task/);
+  assert.doesNotMatch(
+    body,
+    /subagent proven/,
+    "the promotion line claims more than one observed turn proves",
+  );
 });


### PR DESCRIPTION
Addresses the first half of #257 — the label, not the threshold. Behaviour is unchanged.

## What the investigation found

Splitting the issue in two:

**(a) Promotion on the first successful child turn is deliberate.** `observeSubagentOutcome` (`src/router.mjs:1784`) promotes on one HTTP 200 that is non-empty and carries `x-openai-subagent`. AGENTS.md already says "the first real child turn settles it", and `test/routing.test.mjs:5021` pins it on purpose. The threshold is not the defect; the word `proven` is, because it reads as a claim about the work when it is only a claim about the wire.

**(b) The demotion gap is sharper than filed.** Demotion fires only on 400/422 (`src/router.mjs:1789`), and a looping child emits 200s forever — but the compounding problem is the observer's own gate at `src/router.mjs:1783`. `awaitingSpawnProof` (`src/subagent-proofs.mjs:139`) is true **only** for `experimental`. So the moment turn one promotes a slug, the observer stops looking at it entirely, and even a hard 400/422 on turn two is ignored. After promotion, nothing can demote a slug at all; the only re-examination is a manual `control subagents verify`.

## What this PR changes

Option 1 from the issue, which the issue author leaned toward:

- The promotion log line becomes `subagent child role verified: <slug> served a live child turn; the model holds the child role on the wire, which is not a claim the child finished its task`, plus a comment explaining why a loop is invisible at this point.
- The lifecycle comment in `src/subagent-proofs.mjs` and AGENTS.md record that `proven` is a wire claim and that a looping model keeps it.
- A source guard in `test/subagent-proofs.test.mjs`, scoped to `observeSubagentOutcome` and CRLF-safe.

Options 2 and 3 were deliberately not implemented. Option 2 needs an invented N, does not fix the reported gap, and would break the intentional e2e. Option 3 needs a turn ceiling that the issue itself calls undefensible without a decision from you.

## If you later want option 3

Per-spawn turn counting keyed on the `thread-id` header needs no new plumbing — the router already forwards it (`src/router.mjs:258`) and `src/codex-session-names.mjs` already resolves child/parent thread identity. It needs a ceiling constant and a definition of a terminal turn, nothing else. Worth deciding alongside a related question: should a 400/422 be able to demote a slug that is already `proven`? Today it cannot. That is a two-line change, but it makes `proven` revocable, which is the same promise question.

## Tests

`npm run check` passes. `npm test`: 1369 pass, 0 fail, 12 skipped. The existing promotion/demotion e2e passes unmodified.
