### PR TITLE
fix(curation): size a curated model by the window its provider advertises

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,7 +312,15 @@ to ship tested support to every installer.
    effort in the picker); the deterministic `--models` form takes
    conservative defaults, `--efforts minimal,low,medium,high,xhigh` sets the
    effort ladder, and every stored value stays editable in
-   `user-models.json`. An optional `availabilityNux` string on a model becomes
+   `user-models.json`. The context window is the exception to "conservative
+   default": both forms store the `context_length` the provider's own catalog
+   advertises for that model (`modelContextLengths` in
+   `src/model-discovery.mjs`), because `autoCompact` is derived from it and an
+   understated window makes Codex compact a session that had the room. Only a
+   model the catalog sizes in silence falls back to 131072. An entry curated
+   before this landed keeps its stored window — an additive run never rewrites
+   existing metadata — so repair it by editing `user-models.json` or by
+   `--remove`-ing and re-curating the model. An optional `availabilityNux` string on a model becomes
    the Codex "Introducing {model}" announcement (shown a limited number of
    times per slug, tracked by the Codex client itself); leave it unset unless
    the model is genuinely news to the operator. Curated models are not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- **Curated models were filed at 131072 tokens however big they actually
+  were, and the million-token ones compacted on every turn.** Curation stored
+  one conservative window for every model it added, so a model OpenRouter
+  advertises at 1,050,000 was told to auto-compact at 110,000 — eight times
+  below its real capacity. That is not a cosmetic understatement: when a
+  provider answers with `prompt_tokens: 0` the router substitutes an estimate
+  of the prompt it just sent, and that estimate errs high on purpose, so
+  against a threshold this low it landed above the compaction limit turn after
+  turn. The session summarized itself, lost its working state, redid the same
+  opening work, and summarized again without ever finishing (#266). The
+  provider's catalog already carries the answer, so discovery now reads it:
+  `context_length`, the figure the serving endpoint reports under
+  `top_provider`, `context_window`, or Copilot's
+  `capabilities.limits.max_context_window_tokens`, taking the smallest of the
+  ones present because those are limits at different scopes and only the
+  narrowest is the one the request path can rely on. Both curation forms store
+  it, and `autoCompact` follows from it; the interactive prompt offers it as
+  the default rather than making the user retype a number the provider already
+  published. A model the catalog sizes in silence still falls back to 131072,
+  and an entry curated earlier keeps what it was given — an additive run never
+  rewrites metadata a user may have tuned by hand, so repair it in
+  `user-models.json` or `--remove` and curate it again.
+
 - **The free Qwen3.8 endpoint refused any conversation whose system message
   arrived late or twice.** Its chat template answers those with a 400 reading
   "System message must be at the beginning", and a real Codex session reaches

--- a/README.md
+++ b/README.md
@@ -296,7 +296,11 @@ the ones you want, and stores them as user models in protected state
 command and deselecting). Curation asks for each new model's context window,
 image support, and reasoning efforts — so curated models get the effort
 switcher in the picker — and everything defaults conservatively when
-unanswered. The non-interactive `--models id1,id2` form is additive: it keeps
+unanswered. The context window is not guessed when the provider publishes one:
+the `context_length` its catalog advertises for the model is offered as the
+default and stored by both curation forms, so a million-token model is not
+filed as a 131K one and told to compact at 110K. The non-interactive
+`--models id1,id2` form is additive: it keeps
 existing curated entries and their metadata while adding the named models;
 `--efforts minimal,low,medium,high,xhigh` sets the new entries' ladder. Remove
 entries explicitly with `--remove id1,id2`. Every value stays editable in
@@ -584,8 +588,10 @@ Add a key, then pick the models you want from the provider's live catalog:
 ```
 
 Curated entries use the context window, image support, and reasoning efforts
-you provide during curation (conservative defaults otherwise) and are local
-to your machine. Verify a model before relying on it:
+you provide during curation — the context window falling back to the one the
+provider's catalog advertises, and to a conservative default only when it
+advertises none — and are local to your machine. Verify a model before relying
+on it:
 
 ```sh
 ./bin/test-model 'groq/MODEL_ID' --live --yes

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -197,9 +197,16 @@ release, curate it for your own machine:
 
 Curated entries live in the state directory's `user-models.json` with the
 context window, image support, and reasoning efforts you provide during
-curation (conservative defaults otherwise), are skipped automatically if a
-later registry update ships the same model, and are removed by re-running
-the command and deselecting them.
+curation — the context window taken from the provider's advertised
+`context_length` when you do not name one, and from a conservative default only
+when the provider advertises none — are skipped automatically if a later
+registry update ships the same model, and are removed by re-running the command
+and deselecting them.
+
+An entry curated before the router read that advertised size keeps whatever it
+was given: an additive `--models` run deliberately leaves existing metadata
+alone. Edit `contextWindow` and `autoCompact` in `user-models.json` directly, or
+`--remove` the model and curate it again, then regenerate with `./bin/install`.
 
 ## A session ran past the context window instead of compacting
 
@@ -227,6 +234,30 @@ grep -c estimatedInputTokens "$CODEX_HOME/codex-router/usage-events.jsonl"
 Report zero-token responses to the provider; only they can fix the source. To
 see the provider's own numbers in Codex again, set
 `CODEX_ROUTER_ZERO_INPUT_ESTIMATE=0` in the service environment.
+
+## A session compacts on every turn instead of getting work done
+
+The same substitution read against a window that is too small. Check what the
+model is declared as:
+
+```sh
+grep -A2 '"contextWindow"' "$CODEX_HOME/codex-router/user-models.json"
+```
+
+Curation now stores the `context_length` the provider's catalog advertises, but
+a model curated before that landed kept the conservative 131072 default — and a
+model that really carries a million tokens was then told to compact at 110,000,
+which a high-erring estimate clears on turn after turn. Compare it against what
+the provider says:
+
+```sh
+./bin/discover-models PROVIDER --json
+```
+
+Fix it by editing `contextWindow` and `autoCompact` (85% of the window) in
+`user-models.json`, or by `./bin/curate-models PROVIDER --remove MODEL_ID` and
+curating the model again. Either way run `./bin/install` and restart the
+service so the picker catalog and the gateway routes carry the new figures.
 
 ## Finished subagents stay Working
 

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -7,7 +7,12 @@ import { MODELS, PROVIDERS, USER_MODEL_WARNINGS } from "./model-registry.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import { confirm, promptLine } from "./setup-shared.mjs";
 import { toggleSelection } from "./setup-ui.mjs";
-import { readUserModels, userModelEntry, writeUserModels } from "./user-models.mjs";
+import {
+  DEFAULT_CONTEXT_WINDOW,
+  readUserModels,
+  userModelEntry,
+  writeUserModels,
+} from "./user-models.mjs";
 
 // Interactive curation: list the provider's live models that are not part of
 // the checked-in registry, let the user toggle the ones they want, and persist
@@ -56,6 +61,27 @@ const REQUEST_PROFILE_DESCRIPTIONS = {
   [AUTO_TOOL_CHOICE]:
     'reject a forced tool_choice ("required") while still calling tools under "auto"',
 };
+
+// Codex compacts at this fraction of the declared window.
+const AUTO_COMPACT_RATIO = 0.85;
+
+// The sizing to store for a context window, from the provider's catalog or from
+// the interactive prompt. Both have to derive `autoCompact` the same way: it is
+// the number Codex actually reads to decide when to summarize, and a window
+// stored without it keeps whatever the conservative default said.
+//
+// Guessing 131072 for a model the provider advertises at 1,050,000 does not
+// fail safe. The estimate the router substitutes when an upstream reports zero
+// prompt tokens errs high on purpose, so against an eight-times-too-small
+// threshold it lands above the compaction limit on turn after turn and the
+// session compacts forever without finishing anything (#266).
+export function curatedSizing(contextLength) {
+  if (!Number.isInteger(contextLength) || contextLength < 1) return undefined;
+  return {
+    contextWindow: contextLength,
+    autoCompact: Math.floor(contextLength * AUTO_COMPACT_RATIO),
+  };
+}
 
 function usage() {
   console.error(
@@ -263,16 +289,22 @@ async function main() {
 
   const metadataFor = (id) => {
     const metadata = { ...(flagEfforts || {}) };
-    if (!interactive) return flagEfforts ? metadata : undefined;
+    // The provider already published this model's size; asking the user to
+    // retype it, or defaulting past it, is how a million-token model ends up
+    // stored as a 131K one. A catalog that said nothing still falls back.
+    const advertised = curatedSizing(discovery.contextLengths?.[id]);
+    if (advertised) Object.assign(metadata, advertised);
+    if (!interactive) return Object.keys(metadata).length > 0 ? metadata : undefined;
     process.stdout.write(`\nMetadata for ${id} (Enter keeps the default):\n`);
-    const rawContext = promptLine("  Context window in tokens [131072]").trim();
+    const suggested = advertised?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+    const rawContext = promptLine(
+      `  Context window in tokens [${suggested}${advertised ? ", advertised" : ""}]`,
+    ).trim();
     if (rawContext) {
       const context = Number.parseInt(rawContext, 10);
-      if (!Number.isInteger(context) || context < 1) {
-        throw new Error(`Invalid context window: ${rawContext}`);
-      }
-      metadata.contextWindow = context;
-      metadata.autoCompact = Math.floor(context * 0.85);
+      const sizing = curatedSizing(context);
+      if (!sizing) throw new Error(`Invalid context window: ${rawContext}`);
+      Object.assign(metadata, sizing);
     }
     if (confirm(`  Does ${id} accept image input?`)) {
       metadata.inputModalities = ["text", "image"];

--- a/src/model-discovery.mjs
+++ b/src/model-discovery.mjs
@@ -40,6 +40,49 @@ export function modelIds(payload, provider) {
   return [...new Set(candidates.map((item) => String(item?.id || "").trim()).filter(Boolean))].sort();
 }
 
+// What a provider says one model's context window is, or undefined when it says
+// nothing usable. OpenAI-compatible catalogs disagree about the key: OpenRouter
+// and most resellers publish `context_length` and repeat the figure the chosen
+// endpoint actually serves under `top_provider`, Copilot puts it in
+// `capabilities.limits`, and a few spell it `context_window`.
+//
+// When more than one is present they are not alternatives, they are limits at
+// different scopes, and the smallest one is the only one the request path can
+// rely on: a model that can do 200K reached through an endpoint that serves
+// 131K is a 131K model here. Anything that is not a positive integer is treated
+// as silence -- a string, a float, or a zero is a catalog quirk, not a size.
+function advertisedContextLength(item) {
+  let smallest;
+  for (const value of [
+    item?.context_length,
+    item?.top_provider?.context_length,
+    item?.context_window,
+    item?.capabilities?.limits?.max_context_window_tokens,
+  ]) {
+    if (!Number.isInteger(value) || value < 1) continue;
+    if (smallest === undefined || value < smallest) smallest = value;
+  }
+  return smallest;
+}
+
+// Model id -> advertised context window, for the models `modelIds` kept. A
+// model the provider filtered out has no answer worth carrying, and a model
+// the provider sized in silence is absent rather than guessed: curation falls
+// back to its conservative default only when nothing was advertised.
+export function modelContextLengths(payload, provider) {
+  const data = Array.isArray(payload) ? payload : payload?.data;
+  if (!Array.isArray(data)) return {};
+  const kept = new Set(modelIds(payload, provider));
+  const lengths = {};
+  for (const item of data) {
+    const id = String(item?.id || "").trim();
+    if (!id || !kept.has(id) || id in lengths) continue;
+    const length = advertisedContextLength(item);
+    if (length !== undefined) lengths[id] = length;
+  }
+  return lengths;
+}
+
 async function providerPayload(provider) {
   const fixture = option("--fixture");
   if (fixture) return JSON.parse(readFileSync(path.resolve(fixture), "utf8"));
@@ -88,7 +131,8 @@ export async function discoverProviderModels(providerId) {
   if (provider.kind !== "openai-compatible") {
     throw new Error(`${provider.displayName} does not expose a supported model-list endpoint.`);
   }
-  const discovered = modelIds(await providerPayload(provider), provider);
+  const payload = await providerPayload(provider);
+  const discovered = modelIds(payload, provider);
   const registered = MODELS
     .filter((model) => model.provider === providerId)
     .map((model) => model.upstreamModel)
@@ -101,6 +145,9 @@ export async function discoverProviderModels(providerId) {
     registered,
     unregistered: discovered.filter((id) => !registeredSet.has(id)),
     unavailable: registered.filter((id) => !discoveredSet.has(id)),
+    // Sizing the provider published for itself. Curation stores it rather than
+    // guessing a window for a model whose catalog entry already names one.
+    contextLengths: modelContextLengths(payload, provider),
     note: "Discovery never edits the registry. New models must pass the live compatibility test before they are listed in Codex.",
   };
 }

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -14,7 +14,11 @@ import { STATE_DIR } from "./paths.mjs";
 export const USER_MODELS_PATH =
   process.env.MODEL_ROUTER_USER_MODELS || path.join(STATE_DIR, "user-models.json");
 
-const DEFAULT_CONTEXT_WINDOW = 131072;
+// Only reached when the provider's own catalog said nothing about the model's
+// size. Curation prefers the advertised context length precisely because this
+// number is a guess, and a guess eight times too small compacts a session that
+// had the room (#266).
+export const DEFAULT_CONTEXT_WINDOW = 131072;
 const DEFAULT_AUTO_COMPACT = 110000;
 
 // Curation may adjust presentation, sizing, and effort metadata only;

--- a/test/chutes-provider.test.mjs
+++ b/test/chutes-provider.test.mjs
@@ -139,7 +139,9 @@ test("Chutes public-catalog fixtures drive discovery, deterministic curation, an
     const fixture = path.join(testRoot, "models.json");
     writeFileSync(fixture, JSON.stringify({
       data: [
-        { id: "moonshotai/Kimi-K3-TEE", object: "model" },
+        { id: "moonshotai/Kimi-K3-TEE", object: "model", context_length: 262144 },
+        // A record the catalog sizes in silence: curation falls back rather
+        // than inventing a window for it.
         { id: "zai-org/GLM-5.2-TEE", object: "model" },
       ],
     }));
@@ -155,6 +157,7 @@ test("Chutes public-catalog fixtures drive discovery, deterministic curation, an
       registered: [],
       unregistered: ["moonshotai/Kimi-K3-TEE", "zai-org/GLM-5.2-TEE"],
       unavailable: [],
+      contextLengths: { "moonshotai/Kimi-K3-TEE": 262144 },
       note: "Discovery never edits the registry. New models must pass the live compatibility test before they are listed in Codex.",
     });
 
@@ -175,6 +178,11 @@ test("Chutes public-catalog fixtures drive discovery, deterministic curation, an
     assert.equal(stored.models[0].provider, "chutes");
     assert.equal(stored.models[0].upstreamModel, "moonshotai/Kimi-K3-TEE");
     assert.equal(stored.models[0].requestProfile, undefined);
+    // The catalog said how big this model is, so curation stores that rather
+    // than the conservative 131072 guess -- and the compaction threshold
+    // Codex reads follows from it (#266).
+    assert.equal(stored.models[0].contextWindow, 262144);
+    assert.equal(stored.models[0].autoCompact, 222822);
     assert.deepEqual(
       stored.models[0].reasoningLevels.map((level) => level.effort),
       ["high"],

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -14,9 +14,8 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 // coverage of any kind.
 const savedArgv = [...process.argv];
 process.argv = [process.argv[0], "curate-models.mjs", "gemini-api"];
-const { parseEfforts, parseRequestProfile, planCuration, renderRows } = await import(
-  "../src/curate-models.mjs"
-);
+const { curatedSizing, parseEfforts, parseRequestProfile, planCuration, renderRows } =
+  await import("../src/curate-models.mjs");
 process.argv = savedArgv;
 process.exitCode = 0;
 
@@ -189,4 +188,72 @@ test("the picker marks selection and existing curation separately", () => {
   const [first, second] = rows.split("\n");
   assert.match(first, /\[ \] 1\. gemini-3\.5-flash \(currently curated\)/);
   assert.match(second, /\[x\] 2\. gemini-3\.5-pro \(new\)/);
+});
+
+test("a curated model is sized from the context length its provider advertises", () => {
+  // #266: every scripted curation stored 131072 regardless of the model. Codex
+  // derives its compaction threshold from that number, so a 1,050,000-token
+  // model was told to summarize at 110,000 -- and did, on every turn.
+  assert.deepEqual(curatedSizing(1_050_000), {
+    contextWindow: 1_050_000,
+    autoCompact: 892_500,
+  });
+});
+
+test("a context length that is not a whole positive count sizes nothing", () => {
+  // Silence has to stay distinguishable from a number, or a catalog quirk
+  // becomes a stored window.
+  for (const value of [undefined, null, 0, -1, 1024.5, "200000", NaN, Infinity]) {
+    assert.equal(curatedSizing(value), undefined, `${String(value)} is not a size`);
+  }
+});
+
+test("scripted curation stores the advertised window, not the conservative guess", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "curate-models-context-"));
+  const file = path.join(dir, "user-models.json");
+  const fixture = path.join(dir, "models.json");
+  writeFileSync(
+    fixture,
+    JSON.stringify({
+      data: [
+        { id: "openai/gpt-5.6-luna", context_length: 1_050_000 },
+        // A model the catalog sizes in silence keeps the conservative default.
+        { id: "vendor/unsized" },
+      ],
+    }),
+  );
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(root, "src", "curate-models.mjs"),
+        "openrouter",
+        "--models",
+        "openai/gpt-5.6-luna,vendor/unsized",
+        "--fixture",
+        fixture,
+        "--no-apply",
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENROUTER_API_KEY: "",
+          MODEL_ROUTER_USER_MODELS: file,
+          MODEL_ROUTER_STATE_DIR: dir,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const stored = JSON.parse(readFileSync(file, "utf8"));
+    const luna = stored.models.find((model) => model.upstreamModel === "openai/gpt-5.6-luna");
+    assert.equal(luna.contextWindow, 1_050_000);
+    assert.equal(luna.autoCompact, 892_500);
+    const unsized = stored.models.find((model) => model.upstreamModel === "vendor/unsized");
+    assert.equal(unsized.contextWindow, 131072);
+    assert.ok(unsized.autoCompact <= unsized.contextWindow);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/test/model-discovery.test.mjs
+++ b/test/model-discovery.test.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const { PROVIDERS } = await import("../src/model-registry.mjs");
-const { modelIds } = await import("../src/model-discovery.mjs");
+const { modelContextLengths, modelIds } = await import("../src/model-discovery.mjs");
 
 test("model discovery compares fixtures without needing or exposing a key", () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-discovery-"));
@@ -144,5 +144,87 @@ test("anonymous discovery keeps only each provider's documented free models", ()
       { id: "z-ai/glm-5" },
     ] }, kilo),
     ["minimax/minimax-m2.1:free", "z-ai/glm-5:free"],
+  );
+});
+
+test("discovery reports the context length the provider advertises", () => {
+  // Curation used to store 131072 for every model it added, including the
+  // million-token ones, and Codex reads the auto-compact figure derived from
+  // that number to decide when to summarize (#266). The catalog already says
+  // how big each model is; the only reason it was guessed is that discovery
+  // threw the answer away.
+  const openrouter = PROVIDERS.get("openrouter");
+  assert.deepEqual(
+    modelContextLengths(
+      {
+        data: [
+          { id: "openai/gpt-5.6-luna", context_length: 1_050_000 },
+          { id: "deepseek/deepseek-v4-flash", context_length: 1_048_576 },
+          // Silence is a legitimate answer and must not become a guess.
+          { id: "vendor/unsized" },
+          { id: "vendor/nonsense", context_length: "lots" },
+          { id: "vendor/negative", context_length: -1 },
+          { id: "vendor/fractional", context_length: 1024.5 },
+        ],
+      },
+      openrouter,
+    ),
+    {
+      "openai/gpt-5.6-luna": 1_050_000,
+      "deepseek/deepseek-v4-flash": 1_048_576,
+    },
+  );
+});
+
+test("the served context length wins over the model's nominal one", () => {
+  // OpenRouter records carry both: `context_length` is what the model can do
+  // and `top_provider.context_length` is what the endpoint behind this id will
+  // actually accept. Storing the larger one would advertise capacity the
+  // request path cannot use.
+  assert.deepEqual(
+    modelContextLengths(
+      { data: [{ id: "z-ai/glm-5", context_length: 200_000, top_provider: { context_length: 131_072 } }] },
+      PROVIDERS.get("openrouter"),
+    ),
+    { "z-ai/glm-5": 131_072 },
+  );
+});
+
+test("context lengths are reported only for models discovery kept", () => {
+  // A filtered-out record's size is not this provider's answer about anything,
+  // and storing it would size a model the picker never offers.
+  assert.deepEqual(
+    modelContextLengths(
+      {
+        data: [
+          { id: "z-ai/glm-5:free", context_length: 200_000 },
+          { id: "z-ai/glm-5", context_length: 200_000 },
+        ],
+      },
+      PROVIDERS.get("kilo-free"),
+    ),
+    { "z-ai/glm-5:free": 200_000 },
+  );
+});
+
+test("Copilot advertises its window under the capability limits", () => {
+  assert.deepEqual(
+    modelContextLengths(
+      {
+        data: [
+          {
+            id: "gpt-responses",
+            policy: { state: "enabled" },
+            supported_endpoints: ["/responses"],
+            capabilities: {
+              supports: { tool_calls: true, streaming: true },
+              limits: { max_context_window_tokens: 128_000 },
+            },
+          },
+        ],
+      },
+      PROVIDERS.get("github-copilot"),
+    ),
+    { "gpt-responses": 128_000 },
   );
 });


### PR DESCRIPTION
Fixes the cause of the every-turn compaction loop in #266.

## The bug

`discover-models` was already fetching the provider catalog record that says `context_length: 1050000` — and throwing everything but the model ids away (`src/model-discovery.mjs:75`). Curation then filed every model it added under the hard-coded `contextWindow: 131072` / `autoCompact: 110000` from `src/user-models.mjs:17-18`, overridable only by an interactive prompt.

Codex derives its compaction threshold from that number, so a 1.05M-token OpenRouter model was told to summarize at 110,000 tokens. The router's high-erring estimate for a zero-reporting provider cleared that on every single turn, and the session compacted instead of working.

## The fix

- `src/model-discovery.mjs`: new exported `modelContextLengths(payload, provider)` reads each kept record's advertised size from `context_length`, `top_provider.context_length`, `context_window`, or Copilot's `capabilities.limits.max_context_window_tokens`. It takes the **smallest** present — these are limits at different scopes, and only the narrowest is what the request path can actually use. `discoverProviderModels` now returns `contextLengths`.
- `src/curate-models.mjs`: new exported `curatedSizing(contextLength)` derives `{contextWindow, autoCompact}` at the existing 0.85 ratio. Both the `--models` form and the interactive prompt use the advertised value; interactive offers it as the shown default. Falls back to 131072 only when the catalog is silent about a model.
- `src/user-models.mjs`: `DEFAULT_CONTEXT_WINDOW` exported so the prompt default and the stored default cannot drift apart.
- Docs: AGENTS.md, README, CHANGELOG, plus a new TROUBLESHOOTING section "A session compacts on every turn instead of getting work done" — an additive `--models` run deliberately does not rewrite existing metadata, so already-curated entries need a manual edit or `--remove` and re-curate.

## Deliberately not fixed

The reporter's ~3.9x estimate gap is real — roughly 382 KB of serialized body over ~29.5K real prompt tokens, so ~13 real bytes per token against the `ESTIMATE_BYTES_PER_TOKEN = 3.3` in `src/response-usage.mjs:26`. That constant is calibrated against model-visible text, while `estimateInputTokens` measures the whole routed body including re-sent tool schemas, JSON escaping, and `encrypted_content` reasoning blobs.

Recalibrating it without a captured Responses payload to measure would just be a different guess, and the two error directions are not symmetric: an estimate that lands low lets the provider reject the turn outright. Left open.

Same for the `Math.min(estimate, contextWindow)` clamp at `src/response-usage.mjs:110-112`, which puts any clamped estimate above the compaction threshold by construction. It is deliberate, documented, and pinned by `test/response-usage.test.mjs:157` — and it never fired in the reported session anyway (115,762 was already under the declared 131,072).

## Tests

7 new regression tests, all verified red before / green after by reverting the three `src/` files and re-running (`# fail 7` → `# fail 0`): advertised length reported; nonsense, negative, fractional and string values treated as silence; served `top_provider` length winning over nominal; filtered-out models excluded; Copilot's `capabilities.limits` key; `curatedSizing(1_050_000)` → `{1050000, 892500}`; and end-to-end curation storing the right pair for a sized and an unsized model.

`npm run check` passes. `npm test`: 1375 pass, 0 fail, 12 skipped.
