### PR TITLE
fix(reasoning): replay the reasoning behind a prose turn, not only a tool call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,23 @@
   and an entry curated earlier keeps what it was given — an additive run never
   rewrites metadata a user may have tuned by hand, so repair it in
   `user-models.json` or `--remove` and curate it again.
+- **A subagent on a thinking model poisoned the conversation that spawned it.**
+  Every request after the child finished came back as a 400 reading "The
+  `reasoning_content` in the thinking mode must be passed back to the API",
+  seen on DeepSeek V4 Flash through the opencode Go subscription. LiteLLM's
+  Responses-to-chat translation drops `reasoning` input items outright, and the
+  carry that compensates for that only recognised a tool loop — reasoning
+  sitting immediately before a `function_call`. A subagent ends in prose, so
+  the reasoning behind its final answer was thrown away and the provider was
+  asked to continue a thinking turn it had never been shown. The carry now
+  covers every assistant turn: prose answers and custom tool calls as well as
+  function calls, and the whole run of reasoning items a turn emits rather than
+  only the last of them. It merges into the assistant message instead of
+  inserting a second one, because two assistant turns back to back are their
+  own rejection on the same providers. "Compact old tool results" was reported
+  alongside this and is not involved — the aging pass only ever rewrites the
+  `output` of a tool result, and now has a test proving the reasoning and
+  assistant turns around it come through by reference.
 
 - **The free Qwen3.8 endpoint refused any conversation whose system message
   arrived late or twice.** Its chat template answers those with a 400 reading

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1192,47 +1192,84 @@ async function readVisionEvidence({ url, engine, nativeCall, effort, question, k
   }
 }
 
-// DeepSeek thinking mode rejects a tool-call turn whose assistant message
-// carries no reasoning_content. LiteLLM's Responses->chat translation drops
-// `reasoning` input items entirely, so the reasoning text never reaches the
-// provider. Replace each reasoning item with a synthetic assistant message
-// carrying the reasoning text; LiteLLM merges it into the following
-// function_call's assistant message, and the forwarder's replay attaches it as
-// `reasoning_content` on the tool-call message. In-place, no-op when there is
-// nothing to carry.
+// DeepSeek thinking mode rejects a turn whose assistant message carries no
+// reasoning_content. LiteLLM's Responses->chat translation drops `reasoning`
+// input items entirely (`_transform_responses_api_input_item_to_chat_completion_message`
+// returns nothing for an item whose `content` is null, which is the shape
+// Codex stores), so the reasoning text never reaches the provider at all.
+// Carry each run of reasoning items onto the assistant turn it belongs to, and
+// the translation keeps it as that message's content. In-place, no-op when
+// there is nothing to carry.
+//
+// Every assistant turn needs covering, not only the ones that call a tool.
+// This used to carry the reasoning solely into a following `function_call` or
+// an empty assistant filler, which is the shape of a tool loop -- so a turn
+// that answers in prose lost its reasoning, and the provider refused the
+// *next* request for a reasoning_content it had never been given. A subagent
+// always ends that way, which is why spawning one failed every time and an
+// ordinary tool loop did not (#256).
 function carryReasoningThroughInput(input) {
   if (!Array.isArray(input) || input.length < 2) return;
-  for (let i = 0; i < input.length - 1; i += 1) {
-    const item = input[i];
-    if (item?.type !== "reasoning") continue;
-    const text = reasoningItemText(item);
-    if (!text) continue;
-    const next = input[i + 1];
-    // DeepSeek emits reasoning directly before a function_call, or before an
-    // empty assistant message that announces the call. Carry the reasoning in
-    // both cases; otherwise LiteLLM's Responses->chat translation drops it and
-    // the tool-call turn 400s for missing `reasoning_content`.
-    const nextIsCall = next?.type === "function_call";
-    const nextIsEmptyAssistant =
-      next?.type === "message" &&
-      next?.role === "assistant" &&
-      assistantMessageText(next) === "";
-    if (!nextIsCall && !nextIsEmptyAssistant) continue;
-    // Replace the reasoning item with an assistant message carrying its text.
-    input[i] = {
-      type: "message",
-      role: "assistant",
-      content: [{ type: "output_text", text }],
-    };
+  for (let index = 0; index < input.length - 1; index += 1) {
+    if (input[index]?.type !== "reasoning") continue;
+    // One assistant turn can emit several reasoning items in a row, and they
+    // all belong to the turn that follows. Carrying only the item nearest the
+    // turn dropped everything the model thought before it.
+    let end = index;
+    const texts = [];
+    while (end < input.length && input[end]?.type === "reasoning") {
+      const text = reasoningItemText(input[end]);
+      if (text) texts.push(text);
+      end += 1;
+    }
+    const text = texts.join("\n");
+    const next = input[end];
+    // Only the last item of the run is rewritten. The earlier ones stay
+    // `reasoning` items, which the translation drops -- their text is already
+    // in the joined value, and leaving them in place keeps the array the same
+    // length for every other pass over it.
+    if (text && next) {
+      if (next.type === "function_call" || next.type === "custom_tool_call") {
+        input[end - 1] = assistantTextItem(text);
+      } else if (next.type === "message" && next.role === "assistant") {
+        // Merged into the assistant message rather than inserted in front of
+        // it. A separate message would put two assistant turns back to back,
+        // which the same strict chat-completions providers reject outright --
+        // and the tool-call branch above ends up merged anyway, because
+        // LiteLLM folds a following function_call into the assistant message
+        // it already emitted.
+        input[end] = mergeAssistantText(next, text);
+      }
+    }
+    index = end - 1;
   }
 }
 
-// Text of an assistant message item, or "" when it has no readable text.
-function assistantMessageText(item) {
-  if (!Array.isArray(item?.content)) return "";
-  return item.content
-    .map((part) => (part && typeof part.text === "string" ? part.text : ""))
-    .join("");
+function assistantTextItem(text) {
+  return {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "output_text", text }],
+  };
+}
+
+// The reasoning goes in front of the answer it produced. `content` is an array
+// of parts on everything Codex stores, but a bare string is equally legal on
+// the Responses API, so both shapes are handled rather than assumed away.
+function mergeAssistantText(item, text) {
+  const part = { type: "output_text", text };
+  if (typeof item.content === "string") {
+    return {
+      ...item,
+      content: item.content
+        ? [part, { type: "output_text", text: item.content }]
+        : [part],
+    };
+  }
+  return {
+    ...item,
+    content: [part, ...(Array.isArray(item.content) ? item.content : [])],
+  };
 }
 
 function reasoningItemText(item) {
@@ -1856,12 +1893,10 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   // -- a turn that still reaches the provider, and still reads as a 200,
   // having quietly replaced the prompt with its own letters.
   const input = Array.isArray(bridged) ? [...bridged] : bridged;
-  // DeepSeek thinking mode requires the assistant's reasoning to be replayed on
-  // tool-call turns, but LiteLLM's Responses->chat translation drops
-  // `reasoning` input items entirely. Merge each reasoning summary into the
-  // following assistant function_call message's content so the translation
-  // carries it; the forwarder then attaches it as `reasoning_content` on the
-  // tool-call message.
+  // DeepSeek thinking mode requires the assistant's reasoning to be replayed,
+  // but LiteLLM's Responses->chat translation drops `reasoning` input items
+  // entirely. Merge each reasoning run into the assistant message of the turn
+  // it belongs to so the translation carries it there.
   carryReasoningThroughInput(input);
   const provider = providerForModel(route);
   const chatCompletionsProvider = provider?.protocol !== "openai-responses";

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5231,3 +5231,110 @@ test("a subagent effort overrides the effort Codex nested in the reasoning objec
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+// #256: spawning a subagent on opencode-go/deepseek-v4-flash made every
+// following parent request 400 with "The `reasoning_content` in the thinking
+// mode must be passed back to the API". LiteLLM's Responses->chat translation
+// drops `reasoning` input items outright, and the carry that compensates for
+// that only recognized a tool loop -- reasoning immediately before a
+// function_call. A subagent ends in prose, so its reasoning was thrown away
+// and the provider was asked to continue a thinking turn it had never been
+// shown. The second reporter saw the same 400 with "Compact old tool results"
+// on, so aging is switched on here as well: it must age the tool result and
+// still leave every reasoning run carried.
+test("reasoning survives the replay onto tool-call and prose assistant turns alike", async () => {
+  const gatewayBodies = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayBodies.push(await bodyJson(request));
+    json(response, 200, { output: [{ type: "message", role: "assistant", content: "ok" }] });
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "reasoning-replay-state-"));
+  writeFileSync(
+    path.join(stateDir, "tool-result-aging.json"),
+    `${JSON.stringify({ version: 1, enabled: true })}\n`,
+    "utf8",
+  );
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const reasoning = (id, text) => ({
+    type: "reasoning",
+    id,
+    summary: [{ type: "summary_text", text }],
+    content: null,
+  });
+  const input = [
+    { type: "message", role: "user", content: [{ type: "input_text", text: "check the log" }] },
+    // A single turn can emit several reasoning items before it acts.
+    reasoning("rs_1", "The log lives under /var/log."),
+    reasoning("rs_2", "Tail it rather than read the whole file."),
+    { type: "function_call", call_id: "old", name: "exec_command", arguments: "{}" },
+    { type: "function_call_output", call_id: "old", output: "x".repeat(40_000) },
+    ...[1, 2, 3, 4].map((n) => ({
+      type: "function_call_output",
+      call_id: `call-${n}`,
+      output: `small result ${n}`,
+    })),
+    // The shape a subagent always ends on, and the one that used to be lost.
+    reasoning("rs_3", "Nothing in the tail looks wrong, so I can say so."),
+    { type: "message", role: "assistant", content: [{ type: "output_text", text: "All clear." }] },
+    { type: "message", role: "user", content: [{ type: "input_text", text: "and now?" }] },
+  ];
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: "deepseek/deepseek-v4-pro", stream: false, input }),
+    });
+    assert.equal(response.status, 200, await response.text());
+    const forwarded = gatewayBodies[0].input;
+    const text = (item) =>
+      (Array.isArray(item?.content) ? item.content : [])
+        .map((part) => (typeof part?.text === "string" ? part.text : ""))
+        .join("\n");
+
+    // The aging pass really ran: without it this assertion passes for the
+    // wrong reason, and the compaction half of the report goes untested.
+    const older = forwarded.find(
+      (item) => item?.type === "function_call_output" && item.call_id === "old",
+    );
+    assert.match(older.output, /compacted by Codex Router/);
+
+    // The whole reasoning run reaches the assistant message LiteLLM will fold
+    // the tool call into, not just the item nearest the call.
+    const callIndex = forwarded.findIndex((item) => item?.type === "function_call");
+    const beforeCall = forwarded[callIndex - 1];
+    assert.equal(beforeCall.type, "message");
+    assert.equal(beforeCall.role, "assistant");
+    assert.match(text(beforeCall), /The log lives under \/var\/log\./);
+    assert.match(text(beforeCall), /Tail it rather than read the whole file\./);
+
+    // The prose answer carries its own reasoning and still says what it said.
+    const answer = forwarded.find(
+      (item) => item?.type === "message" && item.role === "assistant" && /All clear\./.test(text(item)),
+    );
+    assert.match(text(answer), /Nothing in the tail looks wrong/);
+
+    // One assistant message per turn: two in a row is what several strict
+    // chat-completions providers reject.
+    for (let index = 1; index < forwarded.length; index += 1) {
+      const previous = forwarded[index - 1];
+      const current = forwarded[index];
+      if (previous?.role !== "assistant" || current?.role !== "assistant") continue;
+      assert.fail("two assistant messages ended up back to back");
+    }
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/test/tool-result-aging.test.mjs
+++ b/test/tool-result-aging.test.mjs
@@ -129,3 +129,40 @@ test("a disabled pass stays distinguishable from one that ran and found nothing"
   const on = ageToolResults(input);
   assert.equal(on.stats.toolResultsEvaluated, 0, "every result here sits inside the frontier");
 });
+
+// Reported alongside #256: the 400 was seen with "Compact old tool results"
+// switched on, so the pass had to be cleared of rewriting the reasoning that
+// a thinking provider demands back. It only ever replaces the `output` of a
+// tool result; reasoning items and assistant messages come out by reference.
+test("a pass that ages a result leaves the reasoning and assistant turns around it untouched", () => {
+  const reasoning = {
+    type: "reasoning",
+    id: "rs_1",
+    summary: [{ type: "summary_text", text: "The user wants the log tail." }],
+    content: null,
+  };
+  const answer = {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "output_text", text: "Here is what the log says." }],
+  };
+  const input = [
+    reasoning,
+    call("old", "exec_command"),
+    output("old", `HEAD\n${"middle\n".repeat(8_000)}TAIL`),
+    answer,
+    ...Array.from({ length: 4 }, (_, index) => [
+      call(`new-${index}`),
+      output(`new-${index}`, "small"),
+    ]).flat(),
+  ];
+
+  const result = ageToolResults(input);
+  assert.equal(result.stats.toolResultsAged, 1, "the old result did qualify");
+  assert.equal(result.input[0], reasoning, "the reasoning item is passed through by reference");
+  assert.equal(result.input[3], answer, "the assistant turn is passed through by reference");
+  assert.deepEqual(
+    result.input.filter((item) => item.type === "reasoning"),
+    [reasoning],
+  );
+});


### PR DESCRIPTION
Fixes #256.

## Root cause

`carryReasoningThroughInput` (`src/router.mjs:1202`, called from `buildRoutedRequest` at `:1843`).

The wire path is Codex → router `/responses` → LiteLLM `/v1/responses` → router `src/api-forwarder.mjs` → provider. LiteLLM 1.96.0's `_transform_responses_api_input_item_to_chat_completion_message` returns `[]` for any input item whose `content` is `null` — which is exactly how Codex stores a `reasoning` item. Reasoning therefore never reaches the provider on its own.

The router already compensated for that by replacing a `reasoning` item with a synthetic assistant message — but **only when the next item was a `function_call` or an empty assistant filler**, i.e. only inside a tool loop. A turn that ends in prose had its reasoning silently discarded, and the next request asked the provider to continue a thinking turn it had never been shown → HTTP 400.

That is why an ordinary tool loop kept working and spawning a subagent failed every time: a subagent always ends in prose, as does the parent's reply once the child reports back.

Two further gaps in the same function: `custom_tool_call` was not recognised at all, and when a turn emitted several consecutive `reasoning` items only the last one was carried.

## The fix

The carry now covers `function_call`, `custom_tool_call`, **and** assistant messages; it carries the whole run of reasoning items a turn emits rather than only the last; and it *merges* into an existing assistant message instead of inserting a second one, since back-to-back assistant messages are their own rejection on the same strict providers. (The tool-call case ends up merged anyway, because LiteLLM folds a following call into the preceding assistant message.)

## The compaction lead is ruled out

`ageToolResults` (`src/tool-result-aging.mjs:87`) only ever rewrites the `output` field of `function_call_output`/`custom_tool_call_output`. Every other item — including `reasoning` and assistant messages — comes back by reference through `input.map(...)`. There is now a test holding it to that.

The reporter in the comments saw this while "Compact old tool results" was enabled and flagged the correlation as unconfirmed. It was: whether the 400 fires depends on whether the conversation contains a prose assistant turn, not on the aging toggle, which is what made it look intermittent.

## Incidental correction

The comments at `src/router.mjs:1199` and `:1841` claimed "the forwarder's replay attaches it as `reasoning_content`". Nothing in this repo has ever written `reasoning_content` outbound — `git log -S` confirms. Comment corrected rather than left to mislead the next reader.

## Tests

- New integration test in `test/routing.test.mjs`: replays a history through the routed path with tool-result aging **enabled**, asserts the old result really was compacted, then asserts both the tool-call turn and the prose answer carry their reasoning, and that no two assistant messages end up adjacent. Verified RED on the pre-fix `src/router.mjs`, GREEN after.
- New `test/tool-result-aging.test.mjs` test: reasoning items and assistant turns survive an aging pass by reference.

`npm run check` passes. `npm test`: 1370 pass, 0 fail, 12 skipped.
