### PR TITLE
fix(start): supervise the gateway in place instead of tearing the service down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,7 +319,20 @@ and every client saw a bare "Connection error" naming nothing.
    lets doctor report "serving but reports gateway unreachable" instead of "not
    ready", which sent operators looking for a dead service when the gateway was
    the thing that died.
-7. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
+7. **The launcher is spawned through `spawnableCommand`, like every other
+   external command.** The installer produces `litellm.exe` on Windows, so the
+   shipped path is untouched pass-through — but `MODEL_ROUTER_LITELLM_BIN` and
+   `CODEX_ROUTER_LITELLM_BIN` are operator-set, and Node has refused to spawn a
+   `.cmd`/`.bat` without a shell since CVE-2024-27980. A batch launcher there
+   used to end the service before it spawned anything, with an EINVAL naming
+   neither the file nor the reason. Never reintroduce a bare
+   `spawn(command, args)` in `start.mjs`; `test/gateway-restart.test.mjs` guards
+   the shape, because the behaviour itself cannot be exercised on POSIX. Note
+   the one cost of the batch path: the service then holds the `cmd.exe` hop
+   rather than the gateway, so a signal reaches the hop and the real process is
+   orphaned. That is strictly better than not starting at all, and it is another
+   reason the installer produces an `.exe`.
+8. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
    security floor and a wheel-availability decision (see the lock section
    above), any change to it has to be proven by booting the proxy rather than by
    a successful resolve, and a router that survives its gateway is worth having

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,57 @@ dependency tree. That tree is pinned and hashed rather than re-resolved.
    meaningless. Do not add a resolver cache there; a cache hit can serve an
    already-unpacked wheel and skip the hash check the job exists to perform.
 
+## The gateway is restarted in place; the router is not taken down with it
+
+`src/gateway-supervisor.mjs` watches the LiteLLM child and replaces it when it
+dies. It exists because the gateway is the one child of the service that is not
+ours: a bug anywhere in that pinned Python tree can end the process rather than
+the request, and issue #261 is exactly that — mapping an upstream 429 raised out
+of LiteLLM's own request handler and the proxy exited 1. `start.mjs` raced every
+child's exit, so one failed request killed the router and all three forwarders
+and every client saw a bare "Connection error" naming nothing.
+
+1. **Only the gateway is supervised.** The forwarders and the router are ours;
+   when one of them dies the service still exits and the OS supervisor rebuilds
+   it. Do not extend the supervisor to them to "be consistent" — a crash in our
+   own code is a bug report, and papering over it costs the incident.
+2. **Supervision starts only after the gateway has been healthy once.** A
+   gateway that never came up is a dependency or configuration failure, and
+   retrying it buries the message the operator needs. Startup failure is
+   unchanged: it throws out of `main()` and takes the service down, which is
+   what `test/startup-cleanup.test.mjs` asserts.
+3. **Bounded, and bounded *in a window*.** At most five restarts inside ten
+   minutes, backing off 1s, 2s, 4s, 8s, 16s, capped at 30s. The window is
+   load-bearing in both directions: a lifetime budget would eventually stop
+   restarting an install that crashes once a month, and no bound at all turns a
+   gateway that dies on every request into a spawn loop. Past the bound the
+   supervisor returns and the service exits exactly as it used to, so launchd's
+   `KeepAlive`, systemd's `Restart=always`, and Task Scheduler get their clean
+   restart. `CODEX_ROUTER_GATEWAY_RESTARTS=0` disables it entirely and restores
+   the pre-#261 behaviour, which is what a crash investigation wants.
+4. **Never silent.** The production LaunchAgent hard-sets `CODEX_ROUTER_QUIET`,
+   and a router that quietly resurrects a crashing gateway is indistinguishable
+   from one that never failed. Every crash, every restart, and the decision to
+   stop restarting are logged unconditionally.
+5. **A replacement that never becomes healthy is stopped, not left parked.**
+   Otherwise the loop waits on an exit that only an external kill can produce,
+   and a hung gateway looks like a healthy one.
+6. **`/health` names the unreachable dependency.** The unauthenticated leaf
+   carries `degraded: ["gateway"]` — a closed set of three fixed local service
+   names, never a URL, a credential, or the per-service payloads the protected
+   leaf carries, and `test/routing.test.mjs` asserts that boundary. It is what
+   lets doctor report "serving but reports gateway unreachable" instead of "not
+   ready", which sent operators looking for a dead service when the gateway was
+   the thing that died.
+7. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
+   security floor and a wheel-availability decision (see the lock section
+   above), any change to it has to be proven by booting the proxy rather than by
+   a successful resolve, and a router that survives its gateway is worth having
+   at every version. Coverage lives in `test/gateway-supervisor.test.mjs` (the
+   loop, the bound, the window, the backoff) and `test/gateway-restart.test.mjs`
+   (end to end: a stand-in gateway exits 1 mid-request, the service does not,
+   and the router is still serving afterwards).
+
 ## Requests to install or expose more models
 
 First distinguish a local model addition from a repository-wide model change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,26 @@
   alongside this and is not involved — the aging pass only ever rewrites the
   `output` of a tool result, and now has a test proving the reasoning and
   assistant turns around it come through by reference.
+- **A single bad upstream response could take the whole router down.** LiteLLM
+  1.96.0 raises out of its own request handler while mapping an upstream 429 —
+  opencode Zen's exhausted free tier is one reliable way to reach it — and the
+  gateway process ends with exit code 1. The service raced every child's exit,
+  so that one failed request also killed the router and all three forwarders,
+  and from then on every client got a bare `Connection error` naming nothing
+  (#261). The gateway is now supervised: it is restarted in place, with a
+  doubling backoff and at most five restarts inside ten minutes, while the
+  router keeps listening — so a crash costs one stalled request instead of the
+  session, and the next one is answered by a live gateway. Every crash, every
+  restart, and the decision to stop restarting are logged unconditionally, and
+  when the bound is exhausted the service exits exactly as before so the OS
+  supervisor performs a clean restart. Supervision starts only once the gateway
+  has been healthy: a gateway that never came up is still a startup failure, not
+  a retry loop. `/health` now names which local service is unreachable, so
+  doctor reports "serving but reports gateway unreachable" instead of "not
+  ready", and `CODEX_ROUTER_GATEWAY_RESTARTS=0` restores the old behaviour for
+  an investigation that wants the process to die where it died. The pinned
+  litellm version is unchanged: a router that survives its gateway is worth
+  having whichever version is installed.
 
 - **The free Qwen3.8 endpoint refused any conversation whose system message
   arrived late or twice.** Its chat template answers those with a 400 reading

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@
   litellm version is unchanged: a router that survives its gateway is worth
   having whichever version is installed.
 
+  Startup also stopped refusing a Windows batch launcher. Node has declined to
+  spawn a `.cmd`/`.bat` without a shell since CVE-2024-27980, so pointing
+  `MODEL_ROUTER_LITELLM_BIN` at a batch wrapper ended the service before it
+  spawned anything, with an `EINVAL` naming neither the file nor the reason.
+  The launcher now goes through the same `spawnableCommand` helper every other
+  external command in the repository uses. The shipped installer produces
+  `litellm.exe`, so a normal Windows install is unaffected.
+
 - **The free Qwen3.8 endpoint refused any conversation whose system message
   arrived late or twice.** Its chat template answers those with a 400 reading
   "System message must be at the beginning", and a real Codex session reaches

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -963,6 +963,13 @@ try {
 }
 
 const health = await waitForRouterHealth({ timeoutMs: serviceLoaded ? 30_000 : 2_000 });
+// A router that answers while a dependency is down is not the same outcome as
+// a router that never answered, and saying "not ready" for both sent operators
+// looking for a dead service when the gateway was the thing that died. The
+// gateway is restarted in place, so this state is usually transient.
+const degradedDependencies = Array.isArray(health.degradedPayload?.degraded)
+  ? health.degradedPayload.degraded
+  : [];
 add(
   health.ok ? "ok" : serviceStoppedByDesign ? "warn" : "fail",
   "Router health",
@@ -970,7 +977,12 @@ add(
     ? `version ${health.payload.version}`
     : serviceStoppedByDesign
       ? "not serving; the background service is following Codex"
-      : `not ready on 127.0.0.1:${PORTS.router} after ${serviceLoaded ? 30 : 2} seconds; ${health.error}`,
+      : degradedDependencies.length
+        ? `serving on 127.0.0.1:${PORTS.router} but ${health.error}` +
+          (degradedDependencies.includes("gateway")
+            ? "; the service restarts a crashed gateway in place, so check the log for its restart lines"
+            : "")
+        : `not ready on 127.0.0.1:${PORTS.router} after ${serviceLoaded ? 30 : 2} seconds; ${health.error}`,
   "Run ./bin/doctor --fix. If it still fails, create a support bundle.",
 );
 

--- a/src/gateway-supervisor.mjs
+++ b/src/gateway-supervisor.mjs
@@ -1,0 +1,159 @@
+// The LiteLLM gateway is the one child of the service that is not ours. It is
+// a large Python process pinned by `requirements/python.txt`, and a bug
+// anywhere in that tree can end the process rather than the request -- issue
+// #261 is exactly that: mapping an upstream 429 raised out of the request
+// handler and the proxy exited 1.
+//
+// Before this module, `start.mjs` raced every child's exit and tore the whole
+// service down when any of them died, so a gateway crash took the router and
+// all three forwarders with it. The OS supervisor (launchd KeepAlive, systemd
+// Restart=always, Task Scheduler) does bring the service back, but it brings
+// back *everything*: the router's in-memory state is discarded and the gateway
+// pays a cold Python import that start.mjs itself allows up to five minutes
+// for. For that whole window clients get a refused connection -- "Connection
+// error", with nothing naming the gateway as the cause.
+//
+// Restarting only the gateway keeps the router listening, so a crash costs one
+// stalled request instead of the session: the router answers with a translated
+// upstream error, `/health` reports `gateway.reachable: false` and returns 503,
+// and doctor's "Router health" check sees it.
+//
+// Three rules keep the restart from being worse than the crash:
+//
+//   1. **Only after the gateway has been healthy once.** A gateway that never
+//      came up is a configuration or dependency failure, and retrying it hides
+//      the message the operator needs. Startup failure is unchanged: it still
+//      throws out of `main()` and takes the service down.
+//   2. **Bounded, in a window.** At most `maxRestarts` failures inside
+//      `windowMs`; past that the supervisor returns and the service exits so
+//      the OS supervisor performs a genuinely clean restart. Without the
+//      window, an install that crashes once a week would eventually exhaust a
+//      lifetime budget and stop being restarted at all; without the bound, a
+//      gateway that dies on every request becomes a spawn loop.
+//   3. **Never silent.** Every crash, every restart, and the decision to stop
+//      restarting are logged unconditionally -- the production LaunchAgent
+//      hard-sets `CODEX_ROUTER_QUIET`, and a router that quietly resurrects a
+//      crashing gateway is indistinguishable from one that never failed.
+
+export const DEFAULT_MAX_RESTARTS = 5;
+export const DEFAULT_RESTART_WINDOW_MS = 10 * 60_000;
+export const DEFAULT_RESTART_BACKOFF_MS = 1_000;
+export const MAX_RESTART_BACKOFF_MS = 30_000;
+
+// Doubling from the base, capped. The cap matters more than the curve: a
+// gateway that crashes on a poisoned request recovers on the first restart,
+// while one that dies on startup must not be respawned faster than it takes to
+// read the failure in the log.
+export function restartBackoffMs(attempt, base = DEFAULT_RESTART_BACKOFF_MS) {
+  const index = Number.isFinite(attempt) && attempt > 0 ? Math.floor(attempt) : 0;
+  const step = Math.max(0, base) * 2 ** Math.min(index, 16);
+  return Math.min(step, MAX_RESTART_BACKOFF_MS);
+}
+
+function positiveInteger(value, fallback, { allowZero = false } = {}) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  const floored = Math.floor(parsed);
+  if (floored < 0) return fallback;
+  if (floored === 0 && !allowZero) return fallback;
+  return floored;
+}
+
+// `CODEX_ROUTER_GATEWAY_RESTARTS=0` disables supervision entirely and restores
+// the pre-#261 behaviour, which is what a bisect or a crash investigation
+// wants: the process should die where it died.
+export function gatewaySupervisorLimits(env = process.env) {
+  return {
+    maxRestarts: positiveInteger(env.CODEX_ROUTER_GATEWAY_RESTARTS, DEFAULT_MAX_RESTARTS, {
+      allowZero: true,
+    }),
+    backoffMs: positiveInteger(
+      env.CODEX_ROUTER_GATEWAY_RESTART_BACKOFF_MS,
+      DEFAULT_RESTART_BACKOFF_MS,
+      { allowZero: true },
+    ),
+    windowMs: positiveInteger(
+      env.CODEX_ROUTER_GATEWAY_RESTART_WINDOW_MS,
+      DEFAULT_RESTART_WINDOW_MS,
+    ),
+  };
+}
+
+function isRunning(child) {
+  return Boolean(child) && child.exitCode === null && child.signalCode === null;
+}
+
+function reason(error) {
+  return (error instanceof Error && error.message) || String(error);
+}
+
+/**
+ * Watch an already-healthy gateway child and restart it in place when it dies.
+ *
+ * Resolves with the same shape `waitForExit` produces -- `{ label, code,
+ * signal }` -- so the caller can keep racing it against the other children.
+ * `restarts` counts the crashes seen, and `exhausted` is true when the loop
+ * gave up rather than the service shutting down.
+ */
+export async function superviseGateway({
+  label = "LiteLLM gateway",
+  child,
+  start,
+  waitForExit,
+  waitForHealth,
+  stop = (target) => target.kill("SIGTERM"),
+  isShuttingDown = () => false,
+  log = (message) => console.error(message),
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  now = Date.now,
+  maxRestarts = DEFAULT_MAX_RESTARTS,
+  windowMs = DEFAULT_RESTART_WINDOW_MS,
+  backoffMs = DEFAULT_RESTART_BACKOFF_MS,
+} = {}) {
+  let current = child;
+  let restarts = 0;
+  const failures = [];
+
+  for (;;) {
+    const exit = await waitForExit(current, label);
+    if (isShuttingDown()) return { ...exit, restarts };
+
+    const at = now();
+    failures.push(at);
+    while (failures.length > 0 && at - failures[0] > windowMs) failures.shift();
+
+    const describeExit = `code=${String(exit.code)}, signal=${String(exit.signal)}`;
+    if (maxRestarts <= 0 || failures.length > maxRestarts) {
+      log(
+        maxRestarts <= 0
+          ? `${label} exited (${describeExit}); restarts are disabled.`
+          : `${label} exited (${describeExit}) after ${failures.length - 1} restart(s) ` +
+            `within ${Math.round(windowMs / 1000)}s; not restarting it again.`,
+      );
+      return { ...exit, restarts, exhausted: true };
+    }
+
+    const wait = restartBackoffMs(failures.length - 1, backoffMs);
+    log(
+      `${label} exited (${describeExit}); restarting in ${wait} ms ` +
+        `(restart ${failures.length} of ${maxRestarts}). The router stays up; ` +
+        `requests fail with an upstream error until it answers again.`,
+    );
+    await sleep(wait);
+    if (isShuttingDown()) return { ...exit, restarts };
+
+    restarts += 1;
+    try {
+      current = start();
+      await waitForHealth(current);
+      log(`${label} is healthy again after ${restarts} restart(s).`);
+    } catch (error) {
+      log(`${label} did not come back: ${reason(error)}.`);
+      // A child that is alive but never became healthy would leave the loop
+      // parked on a `waitForExit` that resolves only when something else kills
+      // it, so end it here and let the next iteration count it.
+      if (isRunning(current)) stop(current);
+    }
+  }
+}

--- a/src/router-health.mjs
+++ b/src/router-health.mjs
@@ -23,6 +23,11 @@ export async function waitForRouterHealth({
 
   const deadline = Date.now() + Math.max(0, timeoutMs);
   let lastError = "service unavailable";
+  // A router that answers but reports a dependency down is a different failure
+  // from a router that is not listening, and only the first one is survivable
+  // (the gateway is restarted in place). Keep the last such payload so the
+  // caller can say which of the two happened instead of "not ready".
+  let lastPayload;
   do {
     try {
       const response = await fetchImpl(url, {
@@ -40,6 +45,12 @@ export async function waitForRouterHealth({
       }
       if (payload.service && payload.service !== expectedService) {
         lastError = `a different service (${payload.service}) is listening on the router port`;
+      } else if (payload.service === expectedService) {
+        lastPayload = payload;
+        const down = Array.isArray(payload.degraded) ? payload.degraded : [];
+        lastError = down.length
+          ? `it is listening but reports ${down.join(", ")} unreachable (HTTP ${response.status})`
+          : `it is listening but answered HTTP ${response.status}`;
       } else if (response.status) {
         lastError = `HTTP ${response.status}`;
       }
@@ -52,5 +63,5 @@ export async function waitForRouterHealth({
     await new Promise((resolve) => setTimeout(resolve, Math.min(intervalMs, remainingMs)));
   } while (Date.now() <= deadline);
 
-  return { ok: false, error: lastError };
+  return { ok: false, error: lastError, degradedPayload: lastPayload };
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -758,11 +758,24 @@ async function healthPayload() {
     apiEnabled ? serviceHealth(API_HEALTH) : { reachable: true, enabled: false },
     serviceHealth(GATEWAY_HEALTH),
   ]);
+  // Naming the unreachable dependency is the difference between "the router is
+  // broken" and "the gateway is restarting". It costs nothing to carry: these
+  // are three fixed local service names, so it is safe on the unauthenticated
+  // leaf too, which is the only one `waitForRouterHealth` and therefore doctor
+  // can read.
+  const degraded = [
+    ["oauth", oauth],
+    ["api", api],
+    ["gateway", gateway],
+  ]
+    .filter(([, service]) => !service.reachable)
+    .map(([name]) => name);
   return {
-    ok: oauth.reachable && api.reachable && gateway.reachable,
+    ok: degraded.length === 0,
     service: "codex-router",
     version: VERSION,
     router: "ready",
+    degraded,
     activity: activityPayload(),
     oauth,
     api,
@@ -2993,6 +3006,7 @@ async function handleRequest(request, response) {
       ok: health.ok,
       service: health.service,
       version: health.version,
+      degraded: health.degraded,
       activity: health.activity,
     });
     return;

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -18,6 +18,7 @@ import { waitForHealth as pollHealth } from "./health-probe.mjs";
 import { gatewaySupervisorLimits, superviseGateway } from "./gateway-supervisor.mjs";
 import { writeLiteLlmConfig } from "./litellm-config.mjs";
 import { readLocalModelSelection } from "./local-models.mjs";
+import { spawnableCommand } from "./spawnable-command.mjs";
 import { ensureOllamaHeadless } from "./ollama-runtime.mjs";
 import { venvRuntimeProblem } from "./venv-runtime.mjs";
 import { dependencyRepairHint } from "./dependency-repair.mjs";
@@ -142,11 +143,22 @@ const commonEnv = {
 const children = [];
 let shuttingDown = false;
 
+// Every child goes through `spawnableCommand` for the one case that needs it:
+// a Windows `.cmd`/`.bat` launcher, which Node has refused to spawn without a
+// shell since the CVE-2024-27980 fix and answers with a bare EINVAL. The
+// installer produces `litellm.exe`, so the shipped path is untouched
+// pass-through -- but `MODEL_ROUTER_LITELLM_BIN` and `CODEX_ROUTER_LITELLM_BIN`
+// are operator-set, and a batch wrapper there used to take the whole service
+// down before it spawned anything, with an error naming neither the file nor
+// the reason. Our own Node children resolve to `process.execPath`, so they are
+// pass-through on every platform.
 function run(command, args, extraEnv = {}) {
-  const child = spawn(command, args, {
+  const spawnable = spawnableCommand(command, args);
+  const child = spawn(spawnable.command, spawnable.args, {
     cwd: SOURCE_ROOT,
     env: { ...process.env, ...commonEnv, ...extraEnv },
     stdio: "inherit",
+    ...spawnable.options,
   });
   children.push(child);
   return child;

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -15,6 +15,7 @@ import {
   loopback,
 } from "./paths.mjs";
 import { waitForHealth as pollHealth } from "./health-probe.mjs";
+import { gatewaySupervisorLimits, superviseGateway } from "./gateway-supervisor.mjs";
 import { writeLiteLlmConfig } from "./litellm-config.mjs";
 import { readLocalModelSelection } from "./local-models.mjs";
 import { ensureOllamaHeadless } from "./ollama-runtime.mjs";
@@ -224,25 +225,29 @@ async function main() {
     ),
   ]);
 
-  const gateway = run(litellm, [
-    "--config",
-    LITELLM_CONFIG_PATH,
-    "--host",
-    "127.0.0.1",
-    "--port",
-    String(PORTS.gateway),
-  ]);
+  const startGateway = () =>
+    run(litellm, [
+      "--config",
+      LITELLM_CONFIG_PATH,
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(PORTS.gateway),
+    ]);
   // LiteLLM cold starts can take minutes when launchd starves the job under
   // system load; killing it mid-import restarts the import from scratch and
   // the service loops forever, so wait long enough for a starved import.
-  await waitForHealth(
-    "LiteLLM gateway",
-    loopback(PORTS.gateway, "/health/liveliness"),
-    { Authorization: `Bearer ${internalKey}` },
-    300_000,
-    undefined,
-    gateway,
-  );
+  const gatewayHealthy = (child) =>
+    waitForHealth(
+      "LiteLLM gateway",
+      loopback(PORTS.gateway, "/health/liveliness"),
+      { Authorization: `Bearer ${internalKey}` },
+      300_000,
+      undefined,
+      child,
+    );
+  const gateway = startGateway();
+  await gatewayHealthy(gateway);
 
   const frontend = FRONTEND;
   const frontendService = frontend.service;
@@ -257,11 +262,25 @@ async function main() {
   );
 
   console.error(`[${frontendService}] ready (authenticated loopback endpoint)`);
+  // Only the gateway is supervised. The forwarders and the router are ours and
+  // are restarted by rebuilding the whole service; the gateway is a third-party
+  // Python process that can end itself on a single bad upstream response
+  // (issue #261, a 429 raised out of LiteLLM's exception mapping), and taking
+  // the router down with it turned one failed request into a dead session.
   const result = await Promise.race([
     waitForExit(kimiForwarder, "OAuth forwarder"),
     waitForExit(api, "API forwarder"),
     waitForExit(grokForwarder, "Grok OAuth forwarder"),
-    waitForExit(gateway, "LiteLLM gateway"),
+    superviseGateway({
+      label: "LiteLLM gateway",
+      child: gateway,
+      start: startGateway,
+      waitForExit,
+      waitForHealth: gatewayHealthy,
+      isShuttingDown: () => shuttingDown,
+      log: (message) => console.error(`[${frontendService}] ${message}`),
+      ...gatewaySupervisorLimits(),
+    }),
     waitForExit(router, frontend.label),
   ]);
   if (!shuttingDown) {

--- a/test/gateway-restart.test.mjs
+++ b/test/gateway-restart.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { freePort } from "./port-pool.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Issue #261: LiteLLM's exception mapping raised out of the request handler on
+// an upstream 429 and the proxy exited 1. start.mjs raced every child's exit,
+// so that single bad response took the router and all three forwarders down and
+// every client saw a bare "Connection error" from then on.
+//
+// The gateway here is a stand-in that answers the liveliness probe and exits 1
+// when asked, which is the only part of LiteLLM's behaviour this has to
+// reproduce -- the defect was never in what killed the gateway, it was in what
+// the service did afterwards.
+function writeFakeGateway(directory, script) {
+  const windows = process.platform === "win32";
+  const target = path.join(directory, windows ? "fake-gateway.cmd" : "fake-gateway");
+  writeFileSync(
+    target,
+    windows
+      ? `@echo off\r\n"${process.execPath}" "${script}" %*\r\n`
+      : `#!/bin/sh\nexec '${process.execPath}' '${script}' "$@"\n`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    script,
+    `import { createServer } from "node:http";
+const args = process.argv.slice(2);
+const port = Number(args[args.indexOf("--port") + 1]);
+createServer((request, response) => {
+  if ((request.url || "").startsWith("/crash")) {
+    response.writeHead(200).end("crashing");
+    // Exactly what LiteLLM did: the process ends, mid-request, with code 1.
+    setTimeout(() => process.exit(1), 10);
+    return;
+  }
+  response.writeHead(200, { "content-type": "application/json" }).end('{"status":"healthy"}');
+}).listen(port, "127.0.0.1");
+`,
+    { mode: 0o600 },
+  );
+  return target;
+}
+
+async function get(url) {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(3_000) });
+    return { status: response.status, body: await response.text() };
+  } catch (error) {
+    return { status: 0, body: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function waitFor(readErrors, pattern, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve, reject) => {
+    const poll = setInterval(() => {
+      if (pattern.test(readErrors())) {
+        clearInterval(poll);
+        resolve();
+        return;
+      }
+      if (Date.now() >= deadline) {
+        clearInterval(poll);
+        reject(new Error(`never saw ${pattern}; stderr so far:\n${readErrors()}`));
+      }
+    }, 100);
+  });
+}
+
+test("a gateway that dies mid-request is restarted and the router keeps serving", { timeout: 180_000 }, async () => {
+  const ports = await Promise.all(Array.from({ length: 5 }, () => freePort()));
+  assert.equal(new Set(ports).size, ports.length);
+  const [routerPort, gatewayPort, oauthPort, apiPort, grokOauthPort] = ports;
+  const rootDir = mkdtempSync(path.join(os.tmpdir(), "model-router-gateway-restart-"));
+  const stateDir = path.join(rootDir, "state");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  const callerKey = "gateway-restart-caller-key-with-sufficient-length";
+  writeFileSync(path.join(stateDir, "internal-secret"), "gateway-restart-internal-key-with-sufficient-length\n", { mode: 0o600 });
+  writeFileSync(path.join(stateDir, "caller-secret"), `${callerKey}\n`, { mode: 0o600 });
+  const gatewayBin = writeFakeGateway(rootDir, path.join(rootDir, "fake-gateway.mjs"));
+
+  const child = spawn(process.execPath, [path.join(root, "src", "start.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MODEL_ROUTER_TARGET: "codex",
+      MODEL_ROUTER_STATE_DIR: stateDir,
+      MODEL_ROUTER_PORT: String(routerPort),
+      MODEL_ROUTER_GATEWAY_PORT: String(gatewayPort),
+      MODEL_ROUTER_OAUTH_PORT: String(oauthPort),
+      MODEL_ROUTER_API_PORT: String(apiPort),
+      MODEL_ROUTER_GROK_OAUTH_PORT: String(grokOauthPort),
+      MODEL_ROUTER_LITELLM_BIN: gatewayBin,
+      // Keep the backoff out of the run time; the sequencing is what matters.
+      CODEX_ROUTER_GATEWAY_RESTART_BACKOFF_MS: "50",
+      CODEX_ROUTER_HOME: rootDir,
+      CODEX_HOME: rootDir,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  let errors = "";
+  let exited;
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+  child.once("exit", (code, signal) => {
+    exited = { code, signal };
+  });
+
+  try {
+    await waitFor(() => errors, /\[codex-router\] ready \(authenticated loopback endpoint\)/);
+    assert.equal((await get(`http://127.0.0.1:${routerPort}/health`)).status, 200, errors);
+
+    // Kill the gateway the way a bad upstream response did.
+    await get(`http://127.0.0.1:${gatewayPort}/crash`);
+
+    await waitFor(
+      () => errors,
+      /\[codex-router\] LiteLLM gateway exited \(code=1, signal=null\); restarting in 50 ms \(restart 1 of 5\)/,
+    );
+    assert.match(errors, /The router stays up/);
+    await waitFor(() => errors, /\[codex-router\] LiteLLM gateway is healthy again after 1 restart\(s\)\./);
+
+    assert.equal(exited, undefined, `the service exited when the gateway crashed:\n${errors}`);
+    const health = await get(`http://127.0.0.1:${routerPort}/health`);
+    assert.equal(health.status, 200, `the router stopped serving:\n${errors}`);
+    assert.doesNotMatch(errors, /gateway-restart-internal-key-with-sufficient-length/);
+    assert.doesNotMatch(errors, /gateway-restart-caller-key-with-sufficient-length/);
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    rmSync(rootDir, { recursive: true, force: true });
+  }
+});

--- a/test/gateway-restart.test.mjs
+++ b/test/gateway-restart.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -18,6 +18,14 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 // when asked, which is the only part of LiteLLM's behaviour this has to
 // reproduce -- the defect was never in what killed the gateway, it was in what
 // the service did afterwards.
+//
+// It is reached through a launcher rather than directly because the real
+// `MODEL_ROUTER_LITELLM_BIN` is a launcher: `.venv/bin/litellm` on POSIX and
+// `.venv\Scripts\litellm.exe` on Windows. A `.cmd` is the closest a test can
+// get to the second without shipping a PE binary, and Node refuses to spawn one
+// without a shell (CVE-2024-27980) -- which is exactly the gap
+// `spawnableCommand` closes in `start.mjs`, so exercising it here is the point
+// rather than an accident.
 function writeFakeGateway(directory, script) {
   const windows = process.platform === "win32";
   const target = path.join(directory, windows ? "fake-gateway.cmd" : "fake-gateway");
@@ -34,10 +42,14 @@ function writeFakeGateway(directory, script) {
 const args = process.argv.slice(2);
 const port = Number(args[args.indexOf("--port") + 1]);
 createServer((request, response) => {
-  if ((request.url || "").startsWith("/crash")) {
-    response.writeHead(200).end("crashing");
+  const url = request.url || "";
+  if (url.startsWith("/crash") || url.startsWith("/quit")) {
+    response.writeHead(200).end("stopping");
     // Exactly what LiteLLM did: the process ends, mid-request, with code 1.
-    setTimeout(() => process.exit(1), 10);
+    // /quit is the teardown door -- on Windows the launcher is a batch shim, so
+    // the service holds the cmd.exe hop rather than this process, and a signal
+    // to the hop would leave this one alive holding the port.
+    setTimeout(() => process.exit(url.startsWith("/quit") ? 0 : 1), 10);
     return;
   }
   response.writeHead(200, { "content-type": "application/json" }).end('{"status":"healthy"}');
@@ -57,18 +69,40 @@ async function get(url) {
   }
 }
 
-function waitFor(readErrors, pattern, timeoutMs = 60_000) {
+// Fails as soon as the service exits rather than waiting out the budget: a
+// startup that died in the first second used to be reported sixty seconds later
+// as "never saw ..." with no exit status, which is a mystery rather than a
+// diagnosis. The exit status is what names the failure -- a Windows `spawn
+// EINVAL` on the batch launcher reads nothing like a health-probe timeout.
+function waitFor(readErrors, readExit, pattern, timeoutMs = 60_000) {
   const deadline = Date.now() + timeoutMs;
   return new Promise((resolve, reject) => {
     const poll = setInterval(() => {
-      if (pattern.test(readErrors())) {
+      const errors = readErrors();
+      if (pattern.test(errors)) {
         clearInterval(poll);
         resolve();
         return;
       }
+      const exit = readExit();
+      if (exit) {
+        clearInterval(poll);
+        reject(
+          new Error(
+            `the service exited (code=${String(exit.code)}, signal=${String(exit.signal)}) ` +
+              `before ${pattern}; stderr:\n${errors || "(the service produced no output at all)"}`,
+          ),
+        );
+        return;
+      }
       if (Date.now() >= deadline) {
         clearInterval(poll);
-        reject(new Error(`never saw ${pattern}; stderr so far:\n${readErrors()}`));
+        reject(
+          new Error(
+            `never saw ${pattern} in ${timeoutMs} ms; the service is still running; ` +
+              `stderr:\n${errors || "(the service produced no output at all)"}`,
+          ),
+        );
       }
     }, 100);
   });
@@ -115,8 +149,9 @@ test("a gateway that dies mid-request is restarted and the router keeps serving"
     exited = { code, signal };
   });
 
+  const readExit = () => exited;
   try {
-    await waitFor(() => errors, /\[codex-router\] ready \(authenticated loopback endpoint\)/);
+    await waitFor(() => errors, readExit, /\[codex-router\] ready \(authenticated loopback endpoint\)/);
     assert.equal((await get(`http://127.0.0.1:${routerPort}/health`)).status, 200, errors);
 
     // Kill the gateway the way a bad upstream response did.
@@ -124,10 +159,15 @@ test("a gateway that dies mid-request is restarted and the router keeps serving"
 
     await waitFor(
       () => errors,
+      readExit,
       /\[codex-router\] LiteLLM gateway exited \(code=1, signal=null\); restarting in 50 ms \(restart 1 of 5\)/,
     );
     assert.match(errors, /The router stays up/);
-    await waitFor(() => errors, /\[codex-router\] LiteLLM gateway is healthy again after 1 restart\(s\)\./);
+    await waitFor(
+      () => errors,
+      readExit,
+      /\[codex-router\] LiteLLM gateway is healthy again after 1 restart\(s\)\./,
+    );
 
     assert.equal(exited, undefined, `the service exited when the gateway crashed:\n${errors}`);
     const health = await get(`http://127.0.0.1:${routerPort}/health`);
@@ -138,6 +178,30 @@ test("a gateway that dies mid-request is restarted and the router keeps serving"
     if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
     await new Promise((resolve) => setTimeout(resolve, 500));
     if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
-    rmSync(rootDir, { recursive: true, force: true });
+    // On Windows the service holds the cmd.exe hop, not the gateway behind it,
+    // and killing the hop orphans the stand-in -- which would keep the port and
+    // a lock on the temp directory. Ask it to leave through its own door; by now
+    // nothing is left to restart it. Harmless and already-dead on POSIX.
+    await get(`http://127.0.0.1:${gatewayPort}/quit`);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    rmSync(rootDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   }
+});
+
+// The Windows half of the launch cannot be exercised on POSIX -- the batch shim
+// is pass-through here -- so the wiring is asserted directly. Without it, a
+// refactor that spawned the gateway straight from `spawn()` again would go green
+// on ubuntu and macos and fail only on the Windows job, which is how this was
+// found. `spawnableCommand`'s own conversion is covered by
+// test/spawnable-command.test.mjs.
+test("start.mjs launches every child through the Windows-safe spawn helper", () => {
+  const source = readFileSync(path.join(root, "src", "start.mjs"), "utf8");
+  assert.match(source, /import \{ spawnableCommand \} from "\.\/spawnable-command\.mjs";/);
+  const runBody = /function run\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
+  assert.match(runBody, /spawnableCommand\(command, args\)/);
+  assert.match(runBody, /spawn\(spawnable\.command, spawnable\.args,/);
+  assert.match(runBody, /\.\.\.spawnable\.options,/);
+  // A bare `spawn(command, args` in the launcher is the exact shape that
+  // answers a `.cmd` launcher with EINVAL and takes the service down.
+  assert.doesNotMatch(runBody, /spawn\(command, args/);
 });

--- a/test/gateway-supervisor.test.mjs
+++ b/test/gateway-supervisor.test.mjs
@@ -1,0 +1,244 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_MAX_RESTARTS,
+  MAX_RESTART_BACKOFF_MS,
+  gatewaySupervisorLimits,
+  restartBackoffMs,
+  superviseGateway,
+} from "../src/gateway-supervisor.mjs";
+
+// A stand-in for a spawned process that is only ever asked the two questions
+// start.mjs asks: has it exited, and when does it exit.
+function fakeChild(id) {
+  const child = { id, exitCode: null, signalCode: null, killed: [] };
+  child.resolvers = [];
+  child.kill = (signal) => {
+    child.killed.push(signal);
+    child.exit(0, signal);
+  };
+  child.exit = (code, signal = null) => {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    child.exitCode = signal ? null : code;
+    child.signalCode = signal;
+    for (const resolve of child.resolvers.splice(0)) resolve({ code, signal });
+  };
+  return child;
+}
+
+function harness({ health = () => Promise.resolve(), limits = {} } = {}) {
+  const spawned = [];
+  const logs = [];
+  let shuttingDown = false;
+  const slept = [];
+
+  const start = () => {
+    const child = fakeChild(spawned.length);
+    spawned.push(child);
+    return child;
+  };
+  const waitForExit = (child, label) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      return Promise.resolve({ label, code: child.exitCode, signal: child.signalCode });
+    }
+    return new Promise((resolve) => {
+      child.resolvers.push(({ code, signal }) => resolve({ label, code, signal }));
+    });
+  };
+
+  const first = start();
+  const done = superviseGateway({
+    child: first,
+    start,
+    waitForExit,
+    waitForHealth: (child) => health(child, spawned.indexOf(child)),
+    isShuttingDown: () => shuttingDown,
+    log: (message) => logs.push(message),
+    sleep: async (ms) => {
+      slept.push(ms);
+    },
+    ...limits,
+  });
+
+  return {
+    done,
+    spawned,
+    logs,
+    slept,
+    shutDown: () => {
+      shuttingDown = true;
+    },
+  };
+}
+
+// The whole point of #261: a gateway that dies mid-session must not take the
+// router with it. The supervisor's contract is that it keeps waiting -- it does
+// not resolve, so start.mjs's `Promise.race` never fires and nothing is torn
+// down -- and that a replacement is spawned.
+test("a gateway that exits 1 mid-session is replaced instead of ending the service", async () => {
+  const supervisor = harness();
+  let settled = false;
+  supervisor.done.then(() => {
+    settled = true;
+  });
+
+  supervisor.spawned[0].exit(1);
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(settled, false, "the service was torn down by a gateway crash");
+  assert.equal(supervisor.spawned.length, 2, "no replacement gateway was spawned");
+  assert.match(supervisor.logs[0], /exited \(code=1, signal=null\); restarting in 1000 ms/);
+  assert.match(supervisor.logs[0], /router stays up/);
+  assert.match(supervisor.logs[1], /healthy again after 1 restart/);
+
+  supervisor.shutDown();
+  supervisor.spawned[1].exit(0);
+  await supervisor.done;
+});
+
+test("restarts back off and stay inside the bound, then the service gives up", async () => {
+  const supervisor = harness({ limits: { maxRestarts: 3 } });
+  const settled = supervisor.done;
+
+  for (let index = 0; index < 4; index += 1) {
+    supervisor.spawned[index].exit(1);
+    // Let the loop observe the exit, sleep, respawn and re-probe health.
+    for (let tick = 0; tick < 6; tick += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  }
+
+  const result = await settled;
+  assert.equal(result.exhausted, true);
+  assert.equal(result.code, 1);
+  assert.equal(result.restarts, 3);
+  assert.equal(supervisor.spawned.length, 4, "the bound did not stop the spawn loop");
+  assert.deepEqual(supervisor.slept, [1_000, 2_000, 4_000]);
+  assert.match(
+    supervisor.logs.at(-1),
+    /exited \(code=1, signal=null\) after 3 restart\(s\) within \d+s; not restarting it again/,
+  );
+});
+
+test("a replacement that never becomes healthy is stopped and counted", async () => {
+  const supervisor = harness({
+    limits: { maxRestarts: 1 },
+    health: async (child, index) => {
+      if (index > 0) throw new Error("LiteLLM gateway exited before becoming healthy.");
+    },
+  });
+  const settled = supervisor.done;
+
+  supervisor.spawned[0].exit(1);
+  const result = await settled;
+
+  assert.equal(result.exhausted, true);
+  assert.deepEqual(supervisor.spawned[1].killed, ["SIGTERM"]);
+  assert.match(
+    supervisor.logs.find((line) => line.includes("did not come back")) ?? "",
+    /did not come back: LiteLLM gateway exited before becoming healthy/,
+  );
+});
+
+test("shutting down is not a crash and never respawns", async () => {
+  const supervisor = harness();
+  supervisor.shutDown();
+  supervisor.spawned[0].exit(null, "SIGTERM");
+
+  const result = await supervisor.done;
+  assert.equal(result.signal, "SIGTERM");
+  assert.equal(result.restarts, 0);
+  assert.equal(supervisor.spawned.length, 1);
+  assert.deepEqual(supervisor.logs, []);
+});
+
+test("supervision can be turned off entirely", async () => {
+  const supervisor = harness({ limits: { maxRestarts: 0 } });
+  supervisor.spawned[0].exit(1);
+
+  const result = await supervisor.done;
+  assert.equal(result.exhausted, true);
+  assert.equal(supervisor.spawned.length, 1);
+  assert.match(supervisor.logs[0], /restarts are disabled/);
+});
+
+test("the backoff doubles from the base and is capped", () => {
+  assert.equal(restartBackoffMs(0), 1_000);
+  assert.equal(restartBackoffMs(1), 2_000);
+  assert.equal(restartBackoffMs(4), 16_000);
+  assert.equal(restartBackoffMs(9), MAX_RESTART_BACKOFF_MS);
+  assert.equal(restartBackoffMs(0, 250), 250);
+});
+
+test("limits come from the environment and fall back on nonsense", () => {
+  assert.deepEqual(gatewaySupervisorLimits({}), {
+    maxRestarts: DEFAULT_MAX_RESTARTS,
+    backoffMs: 1_000,
+    windowMs: 600_000,
+  });
+  assert.equal(gatewaySupervisorLimits({ CODEX_ROUTER_GATEWAY_RESTARTS: "0" }).maxRestarts, 0);
+  assert.equal(
+    gatewaySupervisorLimits({ CODEX_ROUTER_GATEWAY_RESTARTS: "-3" }).maxRestarts,
+    DEFAULT_MAX_RESTARTS,
+  );
+  assert.equal(
+    gatewaySupervisorLimits({ CODEX_ROUTER_GATEWAY_RESTARTS: "not-a-number" }).maxRestarts,
+    DEFAULT_MAX_RESTARTS,
+  );
+  assert.equal(
+    gatewaySupervisorLimits({ CODEX_ROUTER_GATEWAY_RESTART_WINDOW_MS: "1000" }).windowMs,
+    1_000,
+  );
+});
+
+// The window is what keeps a long-lived install restartable: five crashes over
+// a year must not exhaust the same budget five crashes in a minute does.
+test("failures outside the window do not count against the bound", async () => {
+  let clock = 0;
+  const spawned = [];
+  const start = () => {
+    const child = fakeChild(spawned.length);
+    spawned.push(child);
+    return child;
+  };
+  const waitForExit = (child, label) =>
+    child.exitCode !== null || child.signalCode !== null
+      ? Promise.resolve({ label, code: child.exitCode, signal: child.signalCode })
+      : new Promise((resolve) => {
+          child.resolvers.push(({ code, signal }) => resolve({ label, code, signal }));
+        });
+
+  const first = start();
+  const done = superviseGateway({
+    child: first,
+    start,
+    waitForExit,
+    waitForHealth: async () => {},
+    log: () => {},
+    sleep: async () => {},
+    now: () => clock,
+    maxRestarts: 1,
+    windowMs: 60_000,
+  });
+
+  for (let index = 0; index < 5; index += 1) {
+    clock += 120_000;
+    spawned[index].exit(1);
+    for (let tick = 0; tick < 6; tick += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  }
+
+  assert.equal(spawned.length, 6, "an aged-out failure was still charged to the bound");
+
+  // Two crashes inside one window do exhaust it: this one lands a millisecond
+  // after the fifth, so both are still in the window and the bound of 1 is
+  // exceeded.
+  clock += 1;
+  spawned[5].exit(1);
+  const result = await done;
+  assert.equal(result.exhausted, true);
+  assert.equal(spawned.length, 6, "the bound did not stop the spawn loop");
+});

--- a/test/router-health.test.mjs
+++ b/test/router-health.test.mjs
@@ -23,6 +23,25 @@ test("router health waits through a transient startup failure", async () => {
   assert.equal(health.payload.version, "test");
 });
 
+// A router that answers while the gateway is being restarted is a different
+// failure from a router that is not listening, and doctor says so only if the
+// payload survives the non-ok response.
+test("router health names the unreachable dependency behind a 503", async () => {
+  const health = await waitForRouterHealth({
+    target: "codex",
+    timeoutMs: 0,
+    fetchImpl: async () =>
+      new Response(
+        JSON.stringify({ ok: false, service: "codex-router", version: "test", degraded: ["gateway"] }),
+        { status: 503 },
+      ),
+  });
+
+  assert.equal(health.ok, false);
+  assert.match(health.error, /listening but reports gateway unreachable \(HTTP 503\)/);
+  assert.deepEqual(health.degradedPayload.degraded, ["gateway"]);
+});
+
 test("router health rejects a different service on the configured port", async () => {
   const health = await waitForRouterHealth({
     target: "codex",

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -308,7 +308,18 @@ test("router requires the configured path capability before any model route", as
     const publicHealth = await fetch(`http://127.0.0.1:${routerPort}/health`);
     assert.equal(publicHealth.status, 200);
     const publicPayload = await publicHealth.json();
-    assert.deepEqual(Object.keys(publicPayload).sort(), ["activity", "ok", "service", "version"]);
+    assert.deepEqual(
+      Object.keys(publicPayload).sort(),
+      ["activity", "degraded", "ok", "service", "version"],
+    );
+    // `degraded` names which local service is unreachable so doctor can say the
+    // gateway died rather than "the router is not ready". It is a closed set of
+    // three fixed local service names -- never a URL, a credential, or the
+    // per-service payloads the protected leaf carries.
+    assert.ok(
+      publicPayload.degraded.every((name) => ["oauth", "api", "gateway"].includes(name)),
+      JSON.stringify(publicPayload.degraded),
+    );
     assert.equal(publicPayload.activity.state, "error");
 
     const protectedHealth = await fetch(`${routerBase(routerPort)}/health`);


### PR DESCRIPTION
Fixes the router-side half of #261.

## Root cause

`src/start.mjs:260-272` raced every child's exit as service death:

```js
Promise.race([...waitForExit(gateway, "LiteLLM gateway")...])
```

When LiteLLM 1.96.0's `exception_mapping_utils._map_openai_exception` raised a `RateLimitError` out of its request handler on an upstream 429 and the proxy exited 1, that race resolved, `main()` returned, and `stopChildren()` SIGTERM'd the router **and all three forwarders**. Nothing was left listening on the router port, so clients got a transport-level `Connection error` with nothing in it naming the gateway.

The OS supervisor does rebuild the service — but it rebuilds *everything*, including a LiteLLM cold start that `start.mjs` itself allows 300 s for.

## The fix

New `src/gateway-supervisor.mjs` restarts the gateway in place with doubling backoff (1/2/4/8/16 s, capped at 30 s), at most 5 restarts inside a 10-minute sliding window. Past that bound it returns and the service exits exactly as before, so launchd / systemd / Task Scheduler still get their clean restart. Supervision starts only after the gateway has been healthy once, so the startup-failure contract in `test/startup-cleanup.test.mjs` is unchanged. `CODEX_ROUTER_GATEWAY_RESTARTS=0` restores the old behaviour.

- `src/start.mjs`: gateway spawn and health wait extracted into `startGateway`/`gatewayHealthy`, handed to the supervisor inside the same race. Forwarders and the router are deliberately **not** supervised.
- `src/router.mjs`: `/health` now carries `degraded: ["gateway"]` on both leaves — a closed set of three fixed local service names, no URLs or credentials.
- `src/router-health.mjs` + `src/doctor.mjs`: doctor now reports "serving on 127.0.0.1:PORT but it is listening and reports gateway unreachable (HTTP 503); the service restarts a crashed gateway in place" instead of a flat "not ready".
- AGENTS.md gains a rules section beside the Python-lock section; CHANGELOG updated.

## Why the pin is not moved

`litellm==1.96.0` stays. No released version is known to fix an exception escaping the request handler — the closest upstream reports ([BerriAI/litellm#26015](https://github.com/BerriAI/litellm/issues/26015), [#24366](https://github.com/BerriAI/litellm/issues/24366)) are open 429-path bugs. The pin is also a security floor and a wheel-availability decision, and AGENTS.md requires any pin move be proven by booting the proxy rather than by a successful resolve.

A router that survives its gateway is the right fix at any version. Reporting the mapping bug upstream is worth doing separately.

## Tests

- `test/gateway-restart.test.mjs` is the real regression test: it spawns the actual `src/start.mjs` against a stand-in gateway binary that answers `/health/liveliness` and `process.exit(1)`s mid-request when hit on `/crash`. Asserts the restart log line, "healthy again after 1 restart(s)", that `start.mjs` did **not** exit, and that `GET /health` on the router still returns 200. Verified genuine — it fails against `HEAD:src/start.mjs` and passes with the fix, in about 2 s.
- `test/gateway-supervisor.test.mjs`: 8 tests covering the no-teardown contract, the bound and backoff sequence, an unhealthy replacement being SIGTERM'd, shutdown not counting as a crash, `maxRestarts=0`, env parsing, and window aging.
- One existing assertion updated on purpose: `test/routing.test.mjs:311` pins the exact key set of the unauthenticated `/health` payload. It now includes `degraded`, plus a new check that every entry is one of `oauth`/`api`/`gateway` so the leak guard stays meaningful.

`npm run check` passes. `npm test`: 1378 pass, 0 fail, 12 skipped.
