### PR TITLE
feat(retention): purge retained tool results, and report them in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,33 @@
   5-hour and weekly caps, and a coding plan runs out of the first long before it
   stops hitting the second. Plan, purchased, and free credits now surface as a
   balance metric, and the plan's own low-credit threshold marks it unavailable.
+- **Retained tool results had no way to be seen and no way to be cleared.**
+  Tool-result compaction parks the exact original bytes of a result it rewrote
+  in `<state dir>/retained-tool-results`. That store is bounded and fails safe —
+  at its cap it stops accepting new results and eligible results pass through
+  uncompacted — but it has no eviction and no TTL, so the only way to empty it
+  was `rm -rf`, and the first time most operators would learn it existed was
+  while hunting disk usage. It also matters more than its byte count: tool
+  results carry file contents, command output, and API responses, and this is
+  the one place the router keeps model-visible *content* on disk rather than the
+  counts and bytes its telemetry is limited to.
+
+  `./bin/doctor` now reports the store on every run — file count, total size,
+  and the age of the oldest entry — and reports it whether or not the directory
+  exists, because "nothing retained" is the answer most installs should see and
+  seeing it is what makes the directory discoverable at all. A store parked at
+  its cap is reported as a warning rather than as healthy, since that state is
+  permanent until somebody empties it.
+
+  `./bin/control tool-result-aging purge` empties it. It is a report by default:
+  without `--yes` it prints what it would remove and removes nothing, and
+  `--dry-run` says the same thing explicitly and outranks `--yes` so a wrapper
+  that always consents can still preview. Deletion is confined to the store by
+  construction rather than by intent — only names retention itself produces,
+  only entries whose parent resolves to that one directory, no recursion, and no
+  symlink is followed or removed. Anything else that ends up in there is left in
+  place and named. The directory itself is kept: emptying it is the whole job,
+  and removing it under a concurrent write buys nothing.
 
 - **The free Qwen3.8 endpoint refused any conversation whose system message
   arrived late or twice.** Its chat template answers those with a 400 reading

--- a/README.md
+++ b/README.md
@@ -684,6 +684,26 @@ to OpenAI's own endpoint, and an install that has never run it keeps the
 pre-existing behavior. Set `CODEX_ROUTER_TOOL_RESULT_AGING=0` for a hard
 environment-level override that disables both the routed and the native path.
 
+Where compaction parks the exact original bytes of a result it rewrote, they go
+to an owner-private store at `<state dir>/retained-tool-results` (override with
+`MODEL_ROUTER_TOOL_RESULT_RETENTION_DIR`). Nothing evicts that store and it has
+no TTL, so both a way to see it and a way to empty it are part of the feature:
+
+```sh
+./bin/doctor                                   # reports count, size, oldest entry
+./bin/control tool-result-aging purge          # says what it would remove
+./bin/control tool-result-aging purge --yes    # removes it
+```
+
+The doctor row appears whether or not the store exists, because an install that
+has never retained anything is the answer most people should see and seeing it
+is how the directory becomes discoverable at all. The purge is a report by
+default: without `--yes` it prints what it would remove and removes nothing, and
+`--dry-run` says the same thing explicitly and outranks `--yes`. It removes only
+files this store wrote, only inside that one directory, never recursing and
+never following a symlink out of it; anything else that ends up there is left in
+place and named.
+
 To estimate the effect without spending provider quota, run:
 
 ```bash

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -450,6 +450,28 @@ Run `./bin/enable` again after updating, fully quit Codex, and reopen it so the
 managed realtime overrides take effect. User-owned realtime endpoint overrides
 are preserved.
 
+## Retained tool results are using disk
+
+Tool-result compaction can park the exact original bytes of a result it rewrote
+in `<state dir>/retained-tool-results`. That store is owner-only, is excluded
+from support bundles, and is bounded rather than evicting — at its cap it stops
+accepting new results and eligible results pass through uncompacted — but
+nothing ever removes what is already in it.
+
+`./bin/doctor` reports the store on every run: file count, total size, and the
+age of the oldest entry. To empty it:
+
+```sh
+./bin/control tool-result-aging purge          # what it would remove
+./bin/control tool-result-aging purge --yes    # remove it
+```
+
+Without `--yes` nothing is deleted. The purge removes only files the store
+itself wrote, only inside that one directory, and refuses to follow a symlink
+out of it; anything else that ends up there is reported and left alone. Deleting
+retained bytes is not reversible — a compacted result in an open session keeps
+its hash and head/tail evidence, but the original is gone.
+
 ## Uninstall retained files
 
 This is intentional. `./bin/uninstall` removes only the active integration and

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -944,7 +944,51 @@ async function handleSubagents(action, value, flag, rest = []) {
   process.stdout.write(`${JSON.stringify(subagentSettingsSnapshot())}\n`);
 }
 
-async function handleToolResultAging(action, nativeAction) {
+const TOOL_RESULT_AGING_USAGE =
+  "Usage: control tool-result-aging status|on|off|native <on|off>|purge [--yes] [--dry-run]";
+
+// Emptying the store deletes the only copy of bytes the model already saw, so
+// the default is the report and not the deletion: an invocation without --yes
+// says exactly what it would remove and removes nothing. --dry-run says the
+// same thing on purpose rather than by omission, and outranks --yes so a
+// wrapper that always passes consent can still preview.
+async function handleToolResultAgingPurge(flags) {
+  const {
+    describeRetentionAge,
+    formatRetentionBytes,
+    purgeRetainedToolResults,
+  } = await import("./tool-result-retention.mjs");
+  const requested = new Set(flags);
+  const previewOnly = requested.has("--dry-run") || !(requested.has("--yes") || requested.has("-y"));
+  const result = purgeRetainedToolResults({ dryRun: previewOnly });
+  const age =
+    result.oldestAgeMs === undefined ? "" : `, oldest ${describeRetentionAge(result.oldestAgeMs)} old`;
+  if (!result.exists || result.files === 0) {
+    process.stderr.write(`No retained tool results in ${result.path}; nothing to purge.\n`);
+  } else if (previewOnly) {
+    process.stderr.write(
+      `Would remove ${result.removed} file(s) (${result.results} retained result(s)${age}) ` +
+        `and reclaim ${formatRetentionBytes(result.reclaimedBytes)} from ${result.path}.\n` +
+        `Nothing was deleted. Re-run with --yes to empty it: ` +
+        `./bin/control tool-result-aging purge --yes\n`,
+    );
+  } else {
+    process.stderr.write(
+      `Removed ${result.removed} file(s) and reclaimed ` +
+        `${formatRetentionBytes(result.reclaimedBytes)} from ${result.path}.\n`,
+    );
+  }
+  if (result.foreign.length) {
+    process.stderr.write(
+      `Left ${result.foreign.length} entry/entries this store did not write in place: ` +
+        `${result.foreign.slice(0, 5).join(", ")}\n`,
+    );
+  }
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  if (result.failed.length) process.exitCode = 1;
+}
+
+async function handleToolResultAging(action, nativeAction, flags = []) {
   const {
     setNativeToolResultAgingEnabled,
     setToolResultAgingEnabled,
@@ -955,16 +999,20 @@ async function handleToolResultAging(action, nativeAction) {
     process.stdout.write(`${JSON.stringify(toolResultAgingSnapshot())}\n`);
     return;
   }
+  if (desired === "purge") {
+    await handleToolResultAgingPurge(flags);
+    return;
+  }
   if (desired === "native") {
     if (nativeAction !== "on" && nativeAction !== "off") {
-      throw new Error("Usage: control tool-result-aging status|on|off|native <on|off>");
+      throw new Error(TOOL_RESULT_AGING_USAGE);
     }
     setNativeToolResultAgingEnabled(nativeAction === "on");
     process.stdout.write(`${JSON.stringify(toolResultAgingSnapshot())}\n`);
     return;
   }
   if (desired !== "on" && desired !== "off") {
-    throw new Error("Usage: control tool-result-aging status|on|off|native <on|off>");
+    throw new Error(TOOL_RESULT_AGING_USAGE);
   }
   setToolResultAgingEnabled(desired === "on");
   process.stdout.write(`${JSON.stringify(toolResultAgingSnapshot())}\n`);
@@ -2029,7 +2077,7 @@ if (args.includes("--probe")) {
 } else if (args[0] === "subagents") {
   await handleSubagents(args[1], args[2], args[3], args.slice(2));
 } else if (args[0] === "tool-result-aging") {
-  await handleToolResultAging(args[1], args[2]);
+  await handleToolResultAging(args[1], args[2], args.slice(2));
 } else if (args[0] === "local-models") {
   await handleLocalModels(args[1], args[2], ...args.slice(3));
 } else if (args[0] === "vision-bridge") {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -66,6 +66,11 @@ import {
   dependencyRepairHint,
   isHomebrewManaged,
 } from "./dependency-repair.mjs";
+import {
+  describeRetentionAge,
+  formatRetentionBytes,
+  retainedToolResultsUsage,
+} from "./tool-result-retention.mjs";
 
 const checks = [];
 const add = (status, name, detail, fix) => checks.push({ status, name, detail, fix });
@@ -696,6 +701,39 @@ add(
         : `mode ${callerSecretMode.toString(8)}`,
   "Run ./bin/doctor --fix; this capability is generated locally and is not a provider key.",
 );
+
+// Tool-result retention is the one place this router keeps model-visible
+// *content* on disk rather than counts and bytes, and it has no eviction and no
+// TTL. Reporting it here is the difference between an operator learning about
+// the store from this line and learning about it while hunting disk usage. The
+// row exists whether or not the store does: "nothing retained" is the answer
+// most installs should see, and seeing it is how the directory becomes
+// discoverable at all.
+try {
+  const retention = retainedToolResultsUsage();
+  const retentionDetail = !retention.exists
+    ? `nothing retained; no store at ${retention.path}`
+    : `${retention.results} retained result(s), ${formatRetentionBytes(retention.bytes)}` +
+      `${retention.oldestAgeMs === undefined ? "" : `, oldest ${describeRetentionAge(retention.oldestAgeMs)} old`}` +
+      ` in ${retention.path}`;
+  add(
+    retention.capacityReached || retention.foreign.length ? "warn" : "ok",
+    "Retained tool results",
+    retention.capacityReached
+      ? `${retentionDetail} -- at capacity, so new eligible results now pass through uncompacted`
+      : retention.foreign.length
+        ? `${retentionDetail}; ${retention.foreign.length} entry/entries this store did not write`
+        : retentionDetail,
+    "Run ./bin/control tool-result-aging purge to see what would be removed, then --yes to empty it.",
+  );
+} catch (error) {
+  add(
+    "warn",
+    "Retained tool results",
+    error instanceof Error ? error.message : String(error),
+    "Run ./bin/control tool-result-aging purge to inspect the store.",
+  );
+}
 
 // Per-provider credential rows are themselves discovery: each one resolves the
 // provider's credential. Under --no-discovery the resolvers answer nothing by

--- a/src/tool-result-retention.mjs
+++ b/src/tool-result-retention.mjs
@@ -1,0 +1,202 @@
+import { lstatSync, readdirSync, unlinkSync } from "node:fs";
+import path from "node:path";
+
+import { STATE_DIR } from "./paths.mjs";
+
+// Where compaction parks the exact original bytes of a tool result it has
+// rewritten. The directory is owner-private, is excluded from support bundles,
+// and is the first place this router persists model-visible *content* to disk.
+// Nothing here writes to it -- this module only reads it and empties it -- so
+// the path is resolved exactly the way the retention writer resolves it,
+// including the environment override, or a purge would look in a directory the
+// writer never used.
+export const TOOL_RESULT_RETENTION_DIR =
+  process.env.MODEL_ROUTER_TOOL_RESULT_RETENTION_DIR ||
+  path.join(STATE_DIR, "retained-tool-results");
+
+// Retention is bounded rather than evicting: at either cap the store stops
+// accepting new results and eligible results pass through uncompacted. That is
+// a safe failure, but it is also permanent until somebody empties the store,
+// so it is the one state worth reporting louder than "here is a directory".
+export const RETENTION_MAX_FILES = 512;
+export const RETENTION_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
+
+// The three name shapes retention itself produces. Purge removes nothing else:
+// a name the writer could not have produced is somebody else's file that
+// happens to sit in this directory, and deleting it is not this command's
+// business. These mirror the writer's own validation.
+const RESULT_FILE_PATTERN = /^[A-Za-z0-9_-]{43}\.result$/u;
+const STAGE_FILE_PATTERN = /^\.[^/\\]+\.stage\.[0-9a-f]{32}$/u;
+const RETENTION_KEY_NAME = ".retention-key";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function isRetentionEntry(name) {
+  if (name === RETENTION_KEY_NAME) return true;
+  return RESULT_FILE_PATTERN.test(name) || STAGE_FILE_PATTERN.test(name);
+}
+
+// A directory entry name is not a path. Joining one that is `..`, or that
+// carries a separator on a filesystem that allowed it, would let a purge reach
+// outside the store, so the join is checked rather than trusted: the parent of
+// the resolved target must be the retention directory itself.
+function retentionEntryPath(root, name) {
+  if (
+    name === "." ||
+    name === ".." ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    name.includes("\0")
+  ) {
+    throw new Error(`Retained-result storage contains an unusable entry name: ${name}`);
+  }
+  const target = path.resolve(root, name);
+  if (path.dirname(target) !== root || path.basename(target) !== name) {
+    throw new Error("Retained-result purge refused a path outside the retention directory.");
+  }
+  return target;
+}
+
+export function formatRetentionBytes(bytes) {
+  if (bytes < 1024) return `${bytes} bytes`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KiB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GiB`;
+}
+
+export function describeRetentionAge(ageMs) {
+  if (!Number.isFinite(ageMs) || ageMs < 0) return "unknown";
+  if (ageMs < 60 * 60 * 1000) return `${Math.max(1, Math.round(ageMs / 60_000))}m`;
+  if (ageMs < DAY_MS) return `${Math.round(ageMs / (60 * 60 * 1000))}h`;
+  return `${Math.round(ageMs / DAY_MS)}d`;
+}
+
+/**
+ * What is on disk right now, without changing any of it.
+ *
+ * `results` counts retained originals; `files` counts everything retention
+ * wrote, including the key and any interrupted stage. `foreign` counts entries
+ * this store did not write, which purge will refuse to touch and which are
+ * worth naming rather than silently ignoring.
+ */
+export function retainedToolResultsUsage({
+  directory = TOOL_RESULT_RETENTION_DIR,
+  now = Date.now(),
+} = {}) {
+  const root = path.resolve(directory);
+  const empty = {
+    path: root,
+    exists: false,
+    results: 0,
+    files: 0,
+    bytes: 0,
+    foreign: [],
+    oldestMs: undefined,
+    oldestAgeMs: undefined,
+    entries: [],
+    capacityReached: false,
+  };
+  let listing;
+  try {
+    listing = readdirSync(root, { withFileTypes: true });
+  } catch (error) {
+    // A store that was never created is the normal state on an install that
+    // has never compacted a result, not a fault to report.
+    if (error?.code === "ENOENT") return empty;
+    if (error?.code === "ENOTDIR") {
+      return { ...empty, exists: true, foreign: [path.basename(root)] };
+    }
+    throw error;
+  }
+  const entries = [];
+  const foreign = [];
+  let results = 0;
+  let bytes = 0;
+  let oldestMs;
+  for (const entry of listing) {
+    const name = entry.name;
+    let stat;
+    try {
+      // lstat, never stat: a symlink parked in this directory is not a
+      // retained result, and following one is how a purge ends up reading or
+      // reporting a file that lives somewhere else entirely.
+      stat = lstatSync(path.join(root, name));
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      throw error;
+    }
+    if (!stat.isFile() || stat.isSymbolicLink() || !isRetentionEntry(name)) {
+      foreign.push(name);
+      continue;
+    }
+    entries.push({ name, bytes: stat.size, mtimeMs: stat.mtimeMs });
+    bytes += stat.size;
+    if (RESULT_FILE_PATTERN.test(name)) {
+      results += 1;
+      if (oldestMs === undefined || stat.mtimeMs < oldestMs) oldestMs = stat.mtimeMs;
+    }
+  }
+  return {
+    path: root,
+    exists: true,
+    results,
+    files: entries.length,
+    bytes,
+    foreign,
+    oldestMs,
+    oldestAgeMs: oldestMs === undefined ? undefined : Math.max(0, now - oldestMs),
+    entries,
+    capacityReached: results >= RETENTION_MAX_FILES || bytes >= RETENTION_MAX_TOTAL_BYTES,
+  };
+}
+
+/**
+ * Empty the store, or report what emptying it would remove.
+ *
+ * The directory itself is left in place: it is created and permission-hardened
+ * by the writer, and removing it under a concurrent write buys nothing that
+ * removing its contents does not.
+ */
+export function purgeRetainedToolResults({
+  directory = TOOL_RESULT_RETENTION_DIR,
+  dryRun = false,
+  now = Date.now(),
+} = {}) {
+  const usage = retainedToolResultsUsage({ directory, now });
+  const summary = {
+    path: usage.path,
+    exists: usage.exists,
+    dryRun: dryRun === true,
+    results: usage.results,
+    files: usage.files,
+    bytes: usage.bytes,
+    foreign: usage.foreign,
+    oldestAgeMs: usage.oldestAgeMs,
+    removed: 0,
+    reclaimedBytes: 0,
+    failed: [],
+  };
+  if (!usage.exists || usage.files === 0) return summary;
+  for (const entry of usage.entries) {
+    const target = retentionEntryPath(usage.path, entry.name);
+    if (summary.dryRun) {
+      summary.removed += 1;
+      summary.reclaimedBytes += entry.bytes;
+      continue;
+    }
+    try {
+      unlinkSync(target);
+      summary.removed += 1;
+      summary.reclaimedBytes += entry.bytes;
+    } catch (error) {
+      // Something removed it between the scan and the unlink; that is the
+      // outcome this command wanted anyway.
+      if (error?.code === "ENOENT") continue;
+      summary.failed.push({
+        name: entry.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return summary;
+}

--- a/test/tool-result-retention.test.mjs
+++ b/test/tool-result-retention.test.mjs
@@ -1,0 +1,294 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function handle(letter) {
+  return letter.repeat(43);
+}
+
+function stageStore(files = {}) {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "retained-tool-results-"));
+  const store = path.join(stateDir, "retained-tool-results");
+  mkdirSync(store, { recursive: true, mode: 0o700 });
+  for (const [name, contents] of Object.entries(files)) {
+    writeFileSync(path.join(store, name), contents, { mode: 0o600 });
+  }
+  return { stateDir, store };
+}
+
+function purge(store, args, extraEnv = {}) {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(root, "src", "control.mjs"), "tool-result-aging", "purge", ...args],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        MODEL_ROUTER_TOOL_RESULT_RETENTION_DIR: store,
+        ...extraEnv,
+      },
+    },
+  );
+  return { ...result, json: result.stdout.trim() ? JSON.parse(result.stdout) : undefined };
+}
+
+function doctorCheck(stateDir, name) {
+  const result = spawnSync(process.execPath, [path.join(root, "src", "doctor.mjs"), "--json"], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CODEX_HOME: path.dirname(stateDir),
+      CODEX_ROUTER_PORT: "46281",
+      CODEX_ROUTER_STATE_DIR: stateDir,
+      MODEL_ROUTER_STATE_DIR: stateDir,
+      MODEL_ROUTER_TARGET: "codex",
+    },
+    timeout: 90_000,
+  });
+  const report = JSON.parse(result.stdout);
+  return report.checks.find((check) => check.name === name);
+}
+
+test("usage reports an absent store as nothing retained rather than as a fault", async () => {
+  const { retainedToolResultsUsage } = await import("../src/tool-result-retention.mjs");
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "retained-absent-"));
+  try {
+    const usage = retainedToolResultsUsage({
+      directory: path.join(stateDir, "retained-tool-results"),
+    });
+    assert.equal(usage.exists, false);
+    assert.equal(usage.results, 0);
+    assert.equal(usage.bytes, 0);
+    assert.equal(usage.oldestAgeMs, undefined);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("usage counts retained results, bytes, and the age of the oldest one", async () => {
+  const { retainedToolResultsUsage } = await import("../src/tool-result-retention.mjs");
+  const { stateDir, store } = stageStore({
+    [`${handle("A")}.result`]: "a".repeat(4_000),
+    [`${handle("B")}.result`]: "b".repeat(1_000),
+    ".retention-key": "key",
+  });
+  try {
+    const oldSeconds = Math.floor(Date.now() / 1000) - 3 * 24 * 60 * 60;
+    utimesSync(path.join(store, `${handle("A")}.result`), oldSeconds, oldSeconds);
+    const usage = retainedToolResultsUsage({ directory: store });
+    assert.equal(usage.exists, true);
+    assert.equal(usage.results, 2);
+    // The key is part of the store's footprint even though it is not a result.
+    assert.equal(usage.files, 3);
+    assert.equal(usage.bytes, 5_003);
+    assert.ok(usage.oldestAgeMs > 2.5 * 24 * 60 * 60 * 1000);
+    assert.deepEqual(usage.foreign, []);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("a purge without --yes reports what it would remove and removes nothing", () => {
+  const { stateDir, store } = stageStore({
+    [`${handle("A")}.result`]: "a".repeat(2_048),
+    ".retention-key": "key",
+  });
+  try {
+    const result = purge(store, []);
+    assert.equal(result.status, 0);
+    assert.equal(result.json.dryRun, true);
+    assert.equal(result.json.removed, 2);
+    assert.equal(result.json.reclaimedBytes, 2_051);
+    assert.match(result.stderr, /Would remove 2 file\(s\)/);
+    assert.match(result.stderr, /Re-run with --yes/);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("--yes empties the store, reports the bytes reclaimed, and keeps the directory", () => {
+  const { stateDir, store } = stageStore({
+    [`${handle("A")}.result`]: "a".repeat(2_048),
+    [`${handle("B")}.result`]: "b".repeat(1_024),
+    ".retention-key": "key",
+    [`.${handle("C")}.stage.${"0".repeat(32)}`]: "staged",
+  });
+  try {
+    const result = purge(store, ["--yes"]);
+    assert.equal(result.status, 0);
+    assert.equal(result.json.dryRun, false);
+    assert.equal(result.json.removed, 4);
+    assert.equal(result.json.results, 2);
+    assert.equal(result.json.reclaimedBytes, 2_048 + 1_024 + 3 + 6);
+    assert.deepEqual(result.json.failed, []);
+    assert.match(result.stderr, /Removed 4 file\(s\)/);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), false);
+    assert.equal(existsSync(path.join(store, ".retention-key")), false);
+    // The writer creates and hardens this directory; emptying it is the whole
+    // job, and removing it under a concurrent write buys nothing.
+    assert.equal(existsSync(store), true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("--dry-run outranks --yes so a wrapper that always consents can still preview", () => {
+  const { stateDir, store } = stageStore({ [`${handle("A")}.result`]: "a".repeat(64) });
+  try {
+    const result = purge(store, ["--yes", "--dry-run"]);
+    assert.equal(result.json.dryRun, true);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// The store holds file contents and command output. A purge that reached one
+// directory further than its own would be deleting the operator's data on the
+// strength of a filename, so the refusal is proved rather than assumed.
+test("purge deletes nothing it did not write and never follows a link out of the store", () => {
+  const { stateDir, store } = stageStore({
+    [`${handle("A")}.result`]: "a".repeat(512),
+    "notes.txt": "not ours",
+    "short.result": "wrong handle shape",
+  });
+  const outsider = path.join(stateDir, "outside-the-store.txt");
+  writeFileSync(outsider, "must survive", { mode: 0o600 });
+  mkdirSync(path.join(store, "nested"), { recursive: true, mode: 0o700 });
+  if (process.platform !== "win32") {
+    symlinkSync(outsider, path.join(store, `${handle("D")}.result`));
+  }
+  try {
+    const result = purge(store, ["--yes"]);
+    assert.equal(result.status, 0);
+    assert.equal(result.json.removed, 1);
+    assert.equal(existsSync(outsider), true);
+    assert.equal(readFileSync(outsider, "utf8"), "must survive");
+    assert.equal(existsSync(path.join(store, "notes.txt")), true);
+    assert.equal(existsSync(path.join(store, "short.result")), true);
+    assert.equal(existsSync(path.join(store, "nested")), true);
+    assert.ok(result.json.foreign.includes("notes.txt"));
+    assert.ok(result.json.foreign.includes("nested"));
+    if (process.platform !== "win32") {
+      // The link itself is left alone too: refusing it is what proves nothing
+      // resolved through it.
+      assert.equal(existsSync(path.join(store, `${handle("D")}.result`)), true);
+      assert.ok(result.json.foreign.includes(`${handle("D")}.result`));
+    }
+    assert.match(result.stderr, /did not write in place/);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("purging an absent store says so and exits cleanly", () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "retained-none-"));
+  try {
+    const result = purge(path.join(stateDir, "retained-tool-results"), ["--yes"]);
+    assert.equal(result.status, 0);
+    assert.equal(result.json.exists, false);
+    assert.equal(result.json.removed, 0);
+    assert.match(result.stderr, /nothing to purge/);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("an unknown tool-result-aging action names purge in its usage", () => {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(root, "src", "control.mjs"), "tool-result-aging", "nonsense"],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /purge \[--yes\] \[--dry-run\]/);
+});
+
+test(
+  "doctor reports the retained-result store's count, size, and oldest entry",
+  { timeout: 120_000 },
+  () => {
+    const codexHome = mkdtempSync(path.join(os.tmpdir(), "retained-doctor-"));
+    const stateDir = path.join(codexHome, "codex-router");
+    const store = path.join(stateDir, "retained-tool-results");
+    mkdirSync(store, { recursive: true, mode: 0o700 });
+    writeFileSync(path.join(store, `${handle("A")}.result`), "a".repeat(3 * 1024 * 1024), {
+      mode: 0o600,
+    });
+    writeFileSync(path.join(store, ".retention-key"), "key", { mode: 0o600 });
+    const oldSeconds = Math.floor(Date.now() / 1000) - 5 * 24 * 60 * 60;
+    utimesSync(path.join(store, `${handle("A")}.result`), oldSeconds, oldSeconds);
+    try {
+      const check = doctorCheck(stateDir, "Retained tool results");
+      assert.ok(check, "doctor reports a retained-tool-results row");
+      assert.equal(check.status, "ok");
+      assert.match(check.detail, /1 retained result\(s\)/);
+      assert.match(check.detail, /3\.0 MiB/);
+      assert.match(check.detail, /oldest 5d old/);
+      assert.ok(check.detail.includes(store));
+      assert.match(check.fix, /tool-result-aging purge/);
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "doctor says nothing is retained on an install that has never compacted a result",
+  { timeout: 120_000 },
+  () => {
+    const codexHome = mkdtempSync(path.join(os.tmpdir(), "retained-doctor-empty-"));
+    const stateDir = path.join(codexHome, "codex-router");
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    try {
+      const check = doctorCheck(stateDir, "Retained tool results");
+      assert.ok(check, "the row exists even with no store, or the store stays undiscoverable");
+      assert.equal(check.status, "ok");
+      assert.match(check.detail, /nothing retained/);
+      assert.ok(check.detail.includes(path.join(stateDir, "retained-tool-results")));
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  },
+);
+
+test("a store parked at its file cap is reported as a warning, not as healthy", async () => {
+  const { RETENTION_MAX_FILES, retainedToolResultsUsage } = await import(
+    "../src/tool-result-retention.mjs"
+  );
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "retained-capacity-"));
+  const store = path.join(stateDir, "retained-tool-results");
+  mkdirSync(store, { recursive: true, mode: 0o700 });
+  try {
+    for (let index = 0; index < RETENTION_MAX_FILES; index += 1) {
+      // Digits are inside the handle alphabet, so a zero-padded counter is a
+      // unique name of exactly the shape the writer produces.
+      writeFileSync(path.join(store, `${String(index).padStart(43, "0")}.result`), "x", {
+        mode: 0o600,
+      });
+    }
+    const usage = retainedToolResultsUsage({ directory: store });
+    assert.equal(usage.results, RETENTION_MAX_FILES);
+    assert.equal(usage.capacityReached, true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Implements both halves of #251.

## Read this first — one decision for the maintainer

**#245, which introduces `retained-tool-results/`, is closed, not merged.** Nothing on `main` writes to that directory today; `ageToolResults` compacts in memory only.

So this ships visibility and cleanup for a store main does not yet fill. It is still correct and useful now — it empties leftovers for anyone who ran the #245 branch, and it reports "nothing retained" on a clean install — and it resolves the directory exactly the way #245's writer does (`MODEL_ROUTER_TOOL_RESULT_RETENTION_DIR` || `STATE_DIR/retained-tool-results`), with the same name shapes and caps, so it lines up if #245 relands.

If you would rather this waited for the writer, it is a one-commit revert.

## The purge command

`./bin/control tool-result-aging purge [--yes] [--dry-run]` — a new action on the existing `tool-result-aging` subcommand, alongside `status|on|off|native`, which is what the issue proposed. `bin/control` already routes it, so no new `bin/` entry.

Report by default. Without `--yes` it prints exactly what it would remove and removes nothing; `--dry-run` says so explicitly and outranks `--yes`. Human line on stderr, JSON summary on stdout, exit 1 only if an unlink actually fails.

```
$ ./bin/control tool-result-aging purge
Would remove 3 file(s) (2 retained result(s), oldest 6d old) and reclaim 6.8 KiB from …/retained-tool-results.
Nothing was deleted. Re-run with --yes to empty it: ./bin/control tool-result-aging purge --yes
```

Deletion is confined to the store **by construction, not by intent**: only names retention itself produces (`<43-char handle>.result`, `.retention-key`, `.<n>.stage.<hex32>`), only entries whose resolved parent *is* that directory, `lstat` never `stat`, no recursion, and no symlink followed or removed. Anything else found in there is left in place and named in the output. The directory itself is kept.

## Doctor visibility

New `Retained tool results` row in `src/doctor.mjs`, present on every run whether or not the directory exists:

```
OK    Retained tool results: 1 retained result(s), 3.0 MiB, oldest 5d old in …/retained-tool-results
OK    Retained tool results: nothing retained; no store at …/retained-tool-results
WARN  Retained tool results: 512 retained result(s), 512.0 MiB, oldest 41d old in … -- at capacity, so new eligible results now pass through uncompacted
```

It warns — never fails — when the store is parked at its 512-file / 512-MiB cap, since that state is permanent until someone empties it, and when foreign entries are present.

## Not included

No desktop/tray purge button: the panel is read-only as of e71c890, and a destructive control for a store nothing currently writes is a separate design call.

No TTL (the third bullet of the issue). That changes retention *policy* rather than adding an operator escape hatch, and belongs with the writer.

## Tests

New `test/tool-result-retention.test.mjs`, 11 tests: absent store; count/bytes/oldest-age; no-consent preview deletes nothing; `--yes` empties and reports reclaimed bytes; `--dry-run` outranks `--yes`; the containment proof — a foreign file, a wrong-shape name, a subdirectory and a `*.result` **symlink pointing outside the store** all survive, and the outside target is byte-identical afterwards; usage string names `purge`; both doctor rows end-to-end via `doctor --json`; the capacity threshold.

`npm run check` passes. `npm test`: 1405 pass, 0 fail, 12 skipped.
