### PR TITLE
docs(issues): say the tracker is for the router, not the app it routes through

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,6 +6,12 @@ body:
   - type: markdown
     attributes:
       value: |
+        **This tracker is for codex-router itself** — installation, routing, providers, models, and the codex-router menu-bar panel.
+
+        It is not the right place for bugs in the apps you route *through*. If the Codex desktop app or Claude Desktop is misbehaving on its own — window rendering, animations, its sidebar or composer, crashes unrelated to routing — please file that with the app's own project. A quick way to tell: disable codex-router (`./bin/disable`) and see whether the problem persists. If it does, it is not ours.
+  - type: markdown
+    attributes:
+      value: |
         Never paste API keys, OAuth files, the full managed `openai_base_url`, full prompts, or unredacted logs. Run `./bin/support-bundle` and attach the generated JSON if you are comfortable sharing its metadata. Report security issues through [Private Vulnerability Reporting](https://github.com/duolahypercho/codex-router/security/advisories/new), not a public issue.
   - type: textarea
     id: problem
@@ -17,7 +23,8 @@ body:
   - type: dropdown
     id: target
     attributes:
-      label: App target
+      label: Which app do you route through?
+      description: The harness codex-router is installed into — not which app is showing the problem.
       options: [Codex, Claude Desktop experimental]
     validations:
       required: true


### PR DESCRIPTION
The "App target" dropdown asks which harness codex-router is installed into. Read cold, it looks like it is asking which app has the problem — so a bug in the Codex desktop app arrives here labelled `App target: Codex` and reads as ours.

#268 was filed exactly that way: a recording of the Codex desktop app's own window ghosting mid-animation, in a Turkish UI this project does not ship, against a menu-bar panel that never appeared in the clip. The reporter did nothing wrong; the form pointed them here.

## Changes

- Rename the field to **"Which app do you route through?"** with the description "The harness codex-router is installed into — not which app is showing the problem."
- Add a scope note above it stating that this tracker covers codex-router itself — installation, routing, providers, models, and the codex-router menu-bar panel — and that bugs in the apps you route *through* belong with those projects. It includes a test the reporter can run before filing: disable the router and see whether the problem survives.

No behaviour change; `.github/ISSUE_TEMPLATE/bug.yml` only. YAML validated — 6 body blocks parse.