### PR TITLE
feat(cursor): use a Cursor subscription as a provider via a local CLI bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1015,9 +1015,17 @@ bridge is the integration.
    bridge not running both surface as "every Cursor model 502s", so the doctor
    names them separately -- and probes neither unless the provider is selected,
    because `cursor-agent models` is a network round trip to Cursor.
-8. The bridge default port (4209) and the `baseUrl` checked into
-   `config/cursor/cursor.json` are one fact in two files. Change both or
-   neither.
+8. **The service owns the bridge's lifetime, not the operator.** `start.mjs`
+   launches and health-gates it beside the other forwarders. A bridge somebody
+   starts by hand is one reboot away from every Cursor model 502ing while the
+   router reports itself healthy; `bin/cursor-bridge` is for debugging one in
+   the foreground, not the supported way to run it.
+9. The bridge default port (4209) and the `baseUrl` checked into
+   `config/cursor/cursor.json` are one fact in two files, and `start.mjs`
+   republishes the resolved address through the provider's own
+   `MODEL_ROUTER_CURSOR_BASE_URL` so a moved port cannot strand the registry
+   entry on the old one. `test/cursor-cli-bridge.test.mjs` asserts all three
+   agree; do not change one and leave the others.
 
 ## Codex safety boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1020,7 +1020,17 @@ bridge is the integration.
    starts by hand is one reboot away from every Cursor model 502ing while the
    router reports itself healthy; `bin/cursor-bridge` is for debugging one in
    the foreground, not the supported way to run it.
-9. The bridge default port (4209) and the `baseUrl` checked into
+9. **The tray installs it, and fetches before it runs.** Cursor is the one
+   sign-in CLI npm does not carry, so `installScriptCli` downloads the vendor
+   script and then executes it. Do not "simplify" that back into
+   `curl | sh`: a piped install that dies halfway still runs everything that
+   arrived, and what runs is whatever landed. The URL is a constant pinned
+   against `installHost` before anything executes, and the response is checked
+   for a shell shebang because a captive portal answers HTML with a 200.
+   Refusing to install at all was tried first and was wrong -- every other
+   sign-in CLI here is installed by the same button, and handing a user a
+   shell command instead of doing the work is a dead end.
+10. The bridge default port (4209) and the `baseUrl` checked into
    `config/cursor/cursor.json` are one fact in two files, and `start.mjs`
    republishes the resolved address through the provider's own
    `MODEL_ROUTER_CURSOR_BASE_URL` so a moved port cannot strand the registry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,16 @@ These instructions apply when a user asks an agent to install this repository.
   explain that those targets were removed and the router does not have them;
   the opencode provider (the Go subscription and the pay-per-use Zen endpoint)
   remains available as a provider inside both targets.
+- **Cursor cannot be a target, and this is not a gap waiting to be filled.**
+  Cursor CLI (`cursor-agent`) has no BYOK and no custom base URL: its
+  `~/.cursor/cli-config.json` reference carries `model`, `permissions`,
+  `sandbox`, and display keys and nothing that names an endpoint. `--endpoint`
+  exists but speaks Cursor's own protocol rather than anything OpenAI-shaped,
+  and Bedrock mode validates the credential against Cursor's backend. The
+  IDE's "Override OpenAI Base URL" is IDE-only and refuses private-network
+  addresses besides. Nobody should spend another afternoon re-deriving this.
+  Cursor runs the other way round instead — as the `cursor-cli` provider, see
+  below.
 - **A target is a client, not a router.** One installation serves both: one
   background service, one gateway, one set of provider credentials, one
   provider selection, one set of ports. `MODEL_ROUTER_TARGET` selects which
@@ -960,6 +970,54 @@ minutes later. Do not quietly drop the label because a check happened to pass.
    the registry and gateway config load at startup. If the router starts
    answering every request with `local_router_error`, suspect a process still
    holding pre-change state rather than the new code.
+
+## Cursor CLI as a provider
+
+`cursor-cli` is a keyless provider like `local` and `lmstudio`, but what sits
+behind its loopback address is not a server the user started -- it is
+`src/cursor-cli-bridge.mjs`, which spawns `cursor-agent -p` per request and
+adapts it to chat completions. Cursor has no inference API to point at, so the
+bridge is the integration.
+
+1. **It answers turns; it does not drive them.** `cursor-agent` emits text and
+   its own tool events, never OpenAI `tool_calls`. Codex dispatches every turn
+   through tool calls, so a Cursor model is a consultant -- ask it a question,
+   get prose -- and cannot run an agentic Codex turn the way a routed Kimi or
+   GLM model does. Say so when someone asks why their Cursor model "does
+   nothing"; it is the design, not a bug to chase.
+2. **Read-only, always.** `turnArguments()` pins `--mode ask` and
+   `--sandbox enabled` and never passes `--force`, `--yolo`, `--trust`, or
+   `--auto-review`. This process receives prompt text over a socket and hands
+   it to an agent with shell and file tools; read-only is the only mode in
+   which that is defensible. `test/cursor-cli-bridge.test.mjs` asserts the
+   exact argv. Do not add an "agent mode" switch.
+3. **The workspace is an empty directory the router owns**, not the caller's
+   repository and not the checkout. A chat-completions request is a prompt:
+   everything the model should see was put there by the caller. Pointing the
+   agent at a tree nobody named is how "summarize this text" becomes "read
+   that private repo". `MODEL_ROUTER_CURSOR_WORKSPACE` exists for operators who
+   genuinely want otherwise.
+4. **Every turn is stateless.** Cursor keeps its own sessions, but the router
+   owns conversation state here and each request arrives complete. Reusing a
+   Cursor session would make identical requests answer differently depending on
+   what an unrelated caller said earlier, so history is rendered into the
+   prompt by `buildCursorPrompt()` and `--resume` is never passed.
+5. **The event schema is Cursor's, and it moves.** The shapes in
+   `cursor-cli-turn.mjs` were read out of cursor-agent 2026.08.11-e8db854's own
+   bundle rather than guessed. An unrecognized event type is ignored, never
+   fatal: Cursor adds types between releases, and a router that 500s on a new
+   one turns a cosmetic upstream change into an outage.
+6. **`result` is the authority, deltas are the optimization.** The `result`
+   event always carries the complete answer; `assistant` deltas may be absent
+   for a short turn. A stream that emitted nothing still forwards the result
+   text, or the caller sees a successful empty turn.
+7. **Two failure modes, two doctor rows.** cursor-agent signed out and the
+   bridge not running both surface as "every Cursor model 502s", so the doctor
+   names them separately -- and probes neither unless the provider is selected,
+   because `cursor-agent models` is a network round trip to Cursor.
+8. The bridge default port (4209) and the `baseUrl` checked into
+   `config/cursor/cursor.json` are one fact in two files. Change both or
+   neither.
 
 ## Codex safety boundaries
 

--- a/README.md
+++ b/README.md
@@ -813,14 +813,18 @@ bridge that runs `cursor-agent` per request and speaks chat completions back:
 
 ```sh
 cursor-agent login          # once, in an interactive terminal
-./bin/cursor-bridge &       # serves http://127.0.0.1:4209/v1
 ./bin/model-router codex providers enable cursor-cli
 ./bin/curate-models cursor-cli
 ```
 
-Models land in the `cursor-cli/<model-id>` namespace. Set
-`MODEL_ROUTER_CURSOR_BRIDGE_PORT` and `MODEL_ROUTER_CURSOR_BASE_URL` together
-if 4209 is taken.
+The router service starts and supervises the bridge on
+`http://127.0.0.1:4209/v1`, so there is nothing to launch and nothing to
+restart after a reboot. Set `MODEL_ROUTER_CURSOR_BRIDGE_PORT` if 4209 is taken;
+the service derives the provider's address from it. `./bin/cursor-bridge` runs
+one in the foreground for debugging — that standalone form is the only case
+that also needs `MODEL_ROUTER_CURSOR_BASE_URL`.
+
+Models land in the `cursor-cli/<model-id>` namespace.
 
 Two limits are worth knowing before you enable it. `cursor-agent` returns text
 and never OpenAI tool calls, so a Cursor model answers questions but cannot

--- a/README.md
+++ b/README.md
@@ -806,6 +806,28 @@ The default endpoint is `http://127.0.0.1:1234/v1`. Set
 reads `/v1/models` and publishes only models explicitly chosen by the user.
 Ollama keeps its existing native route and local model controls.
 
+### Use your Cursor subscription in Codex (experimental)
+
+Cursor CLI has no OpenAI-compatible endpoint, so the router ships a local
+bridge that runs `cursor-agent` per request and speaks chat completions back:
+
+```sh
+cursor-agent login          # once, in an interactive terminal
+./bin/cursor-bridge &       # serves http://127.0.0.1:4209/v1
+./bin/model-router codex providers enable cursor-cli
+./bin/curate-models cursor-cli
+```
+
+Models land in the `cursor-cli/<model-id>` namespace. Set
+`MODEL_ROUTER_CURSOR_BRIDGE_PORT` and `MODEL_ROUTER_CURSOR_BASE_URL` together
+if 4209 is taken.
+
+Two limits are worth knowing before you enable it. `cursor-agent` returns text
+and never OpenAI tool calls, so a Cursor model answers questions but cannot
+drive an agentic Codex turn the way a routed Kimi or GLM model does. And every
+turn runs `--mode ask --sandbox enabled` in an empty scratch workspace, so the
+model reads only what your prompt contains — it will not touch your repository.
+
 Models running on this machine can appear in Codex's picker like any other
 provider. They are labelled **experimental** there, and the label is earned:
 using a local model as the *vision reader* is reliable, but using one as a

--- a/README.md
+++ b/README.md
@@ -809,10 +809,19 @@ Ollama keeps its existing native route and local model controls.
 ### Use your Cursor subscription in Codex (experimental)
 
 Cursor CLI has no OpenAI-compatible endpoint, so the router ships a local
-bridge that runs `cursor-agent` per request and speaks chat completions back:
+bridge that runs `cursor-agent` per request and speaks chat completions back.
+
+**From the tray, with no terminal:** open **Connections**, find **Cursor CLI
+(Local)**, and press **Install & Sign In**. That installs `cursor-agent` if it
+is missing, then opens a Terminal window that takes you through Cursor's
+browser sign-in. Once you are signed in, the **Cursor CLI** section lists every
+model the account can spend; tick the ones you want and they appear in the
+Codex picker.
+
+The same thing from a terminal, if you prefer:
 
 ```sh
-cursor-agent login          # once, in an interactive terminal
+cursor-agent login          # once, interactively
 ./bin/model-router codex providers enable cursor-cli
 ./bin/curate-models cursor-cli
 ```

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -121,6 +121,7 @@ fn main() {
             cancel_local_model,
             set_local_model_enabled,
             set_lmstudio_model_enabled,
+            set_cursor_model_enabled,
             install_provider_cli,
             connect_oauth,
             save_api_key,
@@ -572,6 +573,26 @@ async fn set_lmstudio_model_enabled(
         vec![
             "local-models".into(),
             "lmstudio-set".into(),
+            model,
+            (if enabled { "on" } else { "off" }).into(),
+        ],
+        None,
+    )
+    .await
+}
+
+#[tauri::command]
+async fn set_cursor_model_enabled(
+    state: State<'_, RouterState>,
+    model: String,
+    enabled: bool,
+) -> Result<Value, String> {
+    validate_cursor_model_id(&model)?;
+    run_json_command(
+        state.inner().clone(),
+        vec![
+            "local-models".into(),
+            "cursor-set".into(),
             model,
             (if enabled { "on" } else { "off" }).into(),
         ],
@@ -1438,6 +1459,38 @@ fn validate_local_model_ref(model: &str) -> Result<(), String> {
 /// Same character discipline as the Node-side `requireTag` (an id reaches a
 /// command line either way), with an error that names LM Studio instead of
 /// telling an LM Studio user their id is not a valid Ollama tag.
+// Cursor names parameterized models with a bracket suffix
+// (`claude-opus-4-8[context=1m,effort=high]`), which the LM Studio validator
+// below rejects. Kept separate rather than widening that one, so Ollama and
+// LM Studio ids stay as narrow as they are. Mirrors `validCursorModelId` in
+// src/cursor-cli.mjs and `requireCursorModel` in src/desktop-commands.mjs.
+fn validate_cursor_model_id(model: &str) -> Result<(), String> {
+    let trimmed = model.trim();
+    let (head, tail) = match trimmed.split_once('[') {
+        Some((head, rest)) => match rest.strip_suffix(']') {
+            Some(inner) => (head, Some(inner)),
+            None => return Err(format!("Unknown Cursor model: {model}")),
+        },
+        None => (trimmed, None),
+    };
+    let head_ok = !head.is_empty()
+        && head.len() <= 128
+        && head.chars().next().is_some_and(|c| c.is_ascii_alphanumeric())
+        && head
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    let tail_ok = tail.is_none_or(|inner| {
+        inner
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '=' | ',' | '.' | '_' | '-'))
+    });
+    if head_ok && tail_ok && trimmed.len() <= 128 {
+        Ok(())
+    } else {
+        Err(format!("Unknown Cursor model: {model}"))
+    }
+}
+
 fn validate_lmstudio_model_id(model: &str) -> Result<(), String> {
     let trimmed = model.trim();
     let valid = !trimmed.is_empty()

--- a/apps/desktop/ui/app.js
+++ b/apps/desktop/ui/app.js
@@ -50,6 +50,7 @@ function startPanel() {
     providerSetup: null,
     localModels: null,
     lmstudioBusy: null,
+    cursorBusy: null,
     visionBridge: null,
     visionDownload: null,
     visionPollTimer: null,
@@ -154,6 +155,7 @@ function startPanel() {
     visionLocalModels: document.getElementById("vision-local-models"),
     localRuntimeActions: document.getElementById("local-runtime-actions"),
     lmstudioSection: document.getElementById("lmstudio-section"),
+    cursorSection: document.getElementById("cursor-section"),
     refresh: document.getElementById("refresh-data"),
     islandSwitch: document.getElementById("island-switch"),
     islandSwitchLabel: document.getElementById("island-switch-label"),
@@ -215,6 +217,7 @@ function startPanel() {
   elements.localModelList.addEventListener("change", handleLocalModelToggle);
   elements.localRuntimeActions.addEventListener("click", handleLocalRuntimeClick);
   elements.lmstudioSection.addEventListener("change", handleLmstudioModelToggle);
+  elements.cursorSection.addEventListener("change", handleCursorModelToggle);
   elements.localDownloadStatus.addEventListener("click", handleLocalModelClick);
   elements.localQuickPicks.addEventListener("click", handleLocalModelClick);
   elements.localCatalog.addEventListener("click", handleLocalModelClick);
@@ -950,6 +953,7 @@ function startPanel() {
       : "";
     renderLocalCatalog(local, installBusy);
     renderLmstudioSection(local.lmstudio, installBusy);
+    renderCursorSection(local.cursor, installBusy);
     const runtime = local.runtime || {};
     const machine = local.machine ? `<small class="muted-line">${escapeHtml(local.machine)}</small>` : "";
     elements.localRuntimeActions.innerHTML = runtime.installed
@@ -994,6 +998,64 @@ function startPanel() {
       })
       .join("");
     elements.lmstudioSection.innerHTML = `${header}${rows}`;
+  }
+
+  // Cursor's roster, and the three states it can be in. They need different
+  // fixes -- start the service, press Sign in, or pick a model -- so the
+  // header says which rather than collapsing them into "unavailable".
+  function renderCursorSection(cursor, busy = false) {
+    if (!elements.cursorSection) return;
+    if (!cursor) {
+      elements.cursorSection.innerHTML = "";
+      return;
+    }
+    const name = cursor.displayName || "Cursor CLI";
+    const status = !cursor.reachable
+      ? "Bridge not running \u00b7 start the router service"
+      : !cursor.signedIn
+        ? `Signed out \u00b7 ${cursor.detail || "sign in from Connections above"}`
+        : "Signed in \u00b7 spends your Cursor plan \u00b7 answers only, no tool calls";
+    const header = `<div class="local-section-label"><span>${escapeHtml(name)}</span><small>${escapeHtml(status)}</small></div>`;
+    const models = Array.isArray(cursor.models) ? cursor.models : [];
+    if (!models.length) {
+      elements.cursorSection.innerHTML = cursor.signedIn
+        ? `${header}<div class="empty-state local-empty">This Cursor account has no models available.</div>`
+        : header;
+      return;
+    }
+    const rowBusy = busy || state.cursorBusy;
+    const rows = models
+      .map((model) => {
+        const isBusy = state.cursorBusy === model.id;
+        const detail = model.served
+          ? model.enabled ? "In the picker" : "Available \u00b7 unchecked"
+          : "Checked but no longer offered by this account";
+        return `<article class="local-model-row${isBusy ? " is-busy" : ""}">
+          <label class="provider-check"><input type="checkbox" data-command="set_cursor_model_enabled" data-cursor-toggle="${escapeHtml(model.id)}" aria-label="Offer ${escapeHtml(model.id)} in the model picker"${model.enabled ? " checked" : ""}${rowBusy ? " disabled" : ""}></label>
+          <div><strong>${escapeHtml(model.id)}</strong><small>${escapeHtml(detail)}</small></div>
+        </article>`;
+      })
+      .join("");
+    elements.cursorSection.innerHTML = `${header}${rows}`;
+  }
+
+  async function handleCursorModelToggle(event) {
+    const checkbox = event.target.closest("input[data-cursor-toggle]");
+    if (!checkbox) return;
+    const model = checkbox.dataset.cursorToggle;
+    if (!model || state.cursorBusy) return;
+    const enabled = checkbox.checked;
+    state.cursorBusy = model;
+    renderCursorSection(state.localModels?.cursor);
+    try {
+      state.localModels = await call("set_cursor_model_enabled", { model, enabled });
+      await refreshPanel({ quiet: true });
+    } catch (error) {
+      showToast(errorMessage(error), true);
+    } finally {
+      state.cursorBusy = null;
+      renderLocalModels();
+    }
   }
 
   async function handleLmstudioModelToggle(event) {

--- a/apps/desktop/ui/index.html
+++ b/apps/desktop/ui/index.html
@@ -274,6 +274,7 @@
             <div id="local-catalog" class="local-catalog"></div>
             <div id="local-runtime-actions" class="local-runtime-actions"></div>
             <div id="lmstudio-section" class="lmstudio-section"></div>
+            <div id="cursor-section" class="lmstudio-section"></div>
           </div>
         </div>
       </section>

--- a/bin/cursor-bridge
+++ b/bin/cursor-bridge
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+exec node "$repo_dir/src/cursor-cli-bridge.mjs"

--- a/config/cursor/cursor.json
+++ b/config/cursor/cursor.json
@@ -10,7 +10,7 @@
       "baseUrl": "http://127.0.0.1:4209/v1",
       "baseUrlEnv": "MODEL_ROUTER_CURSOR_BASE_URL",
       "keyless": true,
-      "planNote": "Runs `cursor-agent` on this machine through the router's local bridge. Sign in with `cursor-agent login`, start the bridge with `bin/cursor-bridge`, then curate models with `bin/curate-models cursor-cli`."
+      "planNote": "Spends your Cursor plan through `cursor-agent` on this machine. Sign in, then curate models with `bin/curate-models cursor-cli`. These models answer questions but cannot run tool calls."
     }
   ]
 }

--- a/config/cursor/cursor.json
+++ b/config/cursor/cursor.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "cursor-cli",
+      "displayName": "Cursor CLI (Local)",
+      "kind": "openai-compatible",
+      "ownedBy": "cursor",
+      "protocol": "openai",
+      "baseUrl": "http://127.0.0.1:4209/v1",
+      "baseUrlEnv": "MODEL_ROUTER_CURSOR_BASE_URL",
+      "keyless": true,
+      "planNote": "Runs `cursor-agent` on this machine through the router's local bridge. Sign in with `cursor-agent login`, start the bridge with `bin/cursor-bridge`, then curate models with `bin/curate-models cursor-cli`."
+    }
+  ]
+}

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -264,6 +264,12 @@ async function emitProbe() {
                 // `local-models list`, so the LM Studio section must ride
                 // here too or it paints once and vanishes on the next poll.
                 lmstudio: await (await import("./lmstudio-models.mjs")).lmstudioSnapshot(),
+                // Cursor rides here for the same reason LM Studio does: the
+                // panel repaints from this snapshot, so a section fed by a
+                // separate call would paint once and vanish on the next poll.
+                // Its probe is the bridge's own /v1/models -- a loopback GET
+                // behind a 60s cache, never a round trip to Cursor per refresh.
+                cursor: await (await import("./cursor-models.mjs")).cursorSnapshot(),
               },
               visionBridge: (() => {
                 const candidates = selectedConfiguredListedModels();
@@ -1308,9 +1314,11 @@ async function handleLocalModels(action, value, ...rest) {
   // HTTP call with a short timeout, so an LM Studio that is simply off costs
   // the snapshot a bounded wait, not an error.
   const { lmstudioSnapshot } = await import("./lmstudio-models.mjs");
+  const { cursorSnapshot } = await import("./cursor-models.mjs");
   const snapshot = async () => ({
     ...localModelsSnapshot({ benchmarks: localAndVisionBenchmarks }),
     lmstudio: await lmstudioSnapshot(),
+    cursor: await cursorSnapshot(),
   });
   if (action === "list" || action === "status" || !action) {
     const current = await snapshot();
@@ -1745,13 +1753,28 @@ async function handleLocalModels(action, value, ...rest) {
     setLmstudioModelEnabled(value, enabled);
     refreshModelSettingsCatalog({ routes: true });
     if (wasEnabled !== enabled) await restartRouterForLocalRoutes();
+  } else if (action === "cursor-set") {
+    if (!["on", "off"].includes(positional)) {
+      throw new Error("Usage: control local-models cursor-set <model-id> <on|off>");
+    }
+    // The panel's checkbox for a model the Cursor account can spend. Same
+    // overlay `curate-models cursor-cli` writes, same restart that makes any
+    // other route change live.
+    const { isCursorModelEnabled, setCursorModelEnabled } = await import(
+      "./cursor-models.mjs"
+    );
+    const enabled = positional === "on";
+    const wasEnabled = isCursorModelEnabled(value);
+    setCursorModelEnabled(value, enabled);
+    refreshModelSettingsCatalog({ routes: true });
+    if (wasEnabled !== enabled) await restartRouterForLocalRoutes();
   } else {
     throw new Error(
       "Usage: control local-models list [--json]|inspect <tag-or-url>|" +
         "install <tag-or-url> [--yes] [--force]|benchmark <tag>|" +
         "runtime status|runtime start [--yes]|runtime update --yes|" +
         "uninstall <tag> --yes|cancel [<tag>]|set <tag> <on|off>|" +
-        "lmstudio-set <id> <on|off>\n" +
+        "lmstudio-set <id> <on|off>|cursor-set <id> <on|off>\n" +
         "  --yes    consent to installing/starting Ollama itself (headless)\n" +
         "  --force  download a model rated too large for this machine anyway",
     );

--- a/src/cursor-cli-bridge.mjs
+++ b/src/cursor-cli-bridge.mjs
@@ -13,8 +13,8 @@ import {
 import { PORTS, STATE_DIR } from "./paths.mjs";
 import { cursorAgentPath, cursorCliStatus, validCursorModelId } from "./cursor-cli.mjs";
 import {
-  assistantDelta,
   buildCursorPrompt,
+  createAssistantAccumulator,
   createEventReader,
   isResult,
   resultError,
@@ -73,10 +73,24 @@ export function bridgeWorkspace(environment = process.env) {
 /**
  * The argv for one turn.
  *
- * `--mode ask` and `--sandbox enabled` are not configurable and `--force` is
- * never passed. The router hands this process prompt text that arrived over a
- * socket; read-only is the only mode in which that is a safe thing to do, and
- * an operator who wants an editing agent has cursor-agent itself for that.
+ * `--mode ask` and `--sandbox enabled` are not configurable and `--force` /
+ * `--yolo` are never passed. The router hands this process prompt text that
+ * arrived over a socket; read-only is the only mode in which that is a safe
+ * thing to do, and an operator who wants an editing agent has cursor-agent
+ * itself for that.
+ *
+ * `--trust` is the exception, and it is required rather than optional:
+ * cursor-agent refuses any directory it has not been told to trust, answering
+ * "Workspace Trust Required" and exiting 1 before it reads the prompt. The
+ * first live turn through this bridge failed on exactly that.
+ *
+ * Trusting is sound here because of what the workspace is: an empty directory
+ * this router created and owns (see `bridgeWorkspace`). Trust governs whether
+ * the agent will act on the contents of a tree -- and there are none. It is
+ * not permission to run commands; `--mode ask` and `--sandbox enabled` still
+ * hold. The one case that deserves a second look is an operator who points
+ * `MODEL_ROUTER_CURSOR_WORKSPACE` at a real repository, which is an explicit
+ * decision to let the agent see that tree.
  */
 export function turnArguments(model, { stream = true } = {}) {
   const id = validCursorModelId(model);
@@ -89,6 +103,7 @@ export function turnArguments(model, { stream = true } = {}) {
     "ask",
     "--sandbox",
     "enabled",
+    "--trust",
     ...(id ? ["--model", id] : []),
   ];
 }
@@ -173,7 +188,7 @@ export function runCursorTurn({
       windowsHide: true,
     });
     const reader = createEventReader();
-    let streamed = "";
+    const assistant = createAssistantAccumulator();
     let final = "";
     let failure;
     let usage;
@@ -189,11 +204,10 @@ export function runCursorTurn({
     signal?.addEventListener("abort", abort, { once: true });
 
     const consume = (event) => {
-      const delta = assistantDelta(event);
-      if (delta) {
-        streamed += delta;
-        onDelta(delta);
-      }
+      // Only what is genuinely new: cursor-agent restates the whole message in
+      // a final `assistant` event alongside the per-delta ones.
+      const delta = assistant.push(event);
+      if (delta) onDelta(delta);
       if (!isResult(event)) return;
       failure = failure || resultError(event);
       final = resultText(event);
@@ -228,6 +242,7 @@ export function runCursorTurn({
       // `result` is the authority; `streamed` is what the caller already saw.
       // They agree in every observed run, and when they do not, the complete
       // text wins over a partial one.
+      const streamed = assistant.text();
       const text = final || streamed;
       if (failure) return settle({ ok: false, error: failure, streamed, usage });
       if (code !== 0 && !text) {

--- a/src/cursor-cli-bridge.mjs
+++ b/src/cursor-cli-bridge.mjs
@@ -1,0 +1,435 @@
+import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { installStableFetchTransport } from "./fetch-transport.mjs";
+import {
+  applyKeepAliveTimeouts,
+  readRequestBody,
+  writeJson,
+} from "./http-utils.mjs";
+import { PORTS, STATE_DIR } from "./paths.mjs";
+import { cursorAgentPath, cursorCliStatus, validCursorModelId } from "./cursor-cli.mjs";
+import {
+  assistantDelta,
+  buildCursorPrompt,
+  createEventReader,
+  isResult,
+  resultError,
+  resultText,
+  usageFromResult,
+} from "./cursor-cli-turn.mjs";
+import { spawnableCommand } from "./spawnable-command.mjs";
+
+// setGlobalDispatcher only reaches the process that calls it, and this is its
+// own long-lived server: the doctor's reachability probe and anything else
+// that fetches from inside it would otherwise keep Node's HTTP/2-capable
+// default. Every server entry point in src/ installs this, and
+// test/fetch-transport.test.mjs enforces that it stays that way.
+installStableFetchTransport();
+
+// A loopback chat-completions endpoint backed by `cursor-agent -p`. The
+// registry entry for `cursor-cli` is `keyless` with this address, which is the
+// same shape LM Studio and Ollama use: the operator's own software, on this
+// machine, serving models they already pay for. Nothing here holds a
+// credential -- the Cursor sign-in lives in cursor-agent's own store and is
+// only ever read by cursor-agent itself.
+
+// One turn is one process. Cursor's agent is heavier than an inference call
+// (it starts a session and talks to Cursor's backend), so an unbounded server
+// would answer a burst by forking a few dozen of them and thrashing.
+const DEFAULT_CONCURRENCY = 4;
+// Long enough for a real agent turn on a large prompt, short enough that a
+// wedged child cannot hold a Codex request open forever.
+const DEFAULT_TURN_TIMEOUT_MS = 300_000;
+const MODEL_CACHE_MS = 60_000;
+
+function positiveEnvInteger(name, fallback, environment) {
+  const raw = Number(environment[name]);
+  return Number.isInteger(raw) && raw > 0 ? raw : fallback;
+}
+
+/**
+ * The directory cursor-agent runs in.
+ *
+ * Deliberately an empty directory the router owns, not the caller's repository
+ * and not the service's own checkout. A chat-completions request is a prompt,
+ * not a work order: everything the model is meant to see was put in the prompt
+ * by whoever called, and pointing an agent at a tree it was not asked about is
+ * how a "summarize this text" turn ends up reading a private repository. An
+ * operator who genuinely wants repository access sets the override.
+ */
+export function bridgeWorkspace(environment = process.env) {
+  const override = environment.MODEL_ROUTER_CURSOR_WORKSPACE;
+  const directory = override
+    ? path.resolve(override)
+    : path.join(STATE_DIR, "cursor-bridge-workspace");
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  return directory;
+}
+
+/**
+ * The argv for one turn.
+ *
+ * `--mode ask` and `--sandbox enabled` are not configurable and `--force` is
+ * never passed. The router hands this process prompt text that arrived over a
+ * socket; read-only is the only mode in which that is a safe thing to do, and
+ * an operator who wants an editing agent has cursor-agent itself for that.
+ */
+export function turnArguments(model, { stream = true } = {}) {
+  const id = validCursorModelId(model);
+  return [
+    "--print",
+    "--output-format",
+    "stream-json",
+    ...(stream ? ["--stream-partial-output"] : []),
+    "--mode",
+    "ask",
+    "--sandbox",
+    "enabled",
+    ...(id ? ["--model", id] : []),
+  ];
+}
+
+function chunkFrame(id, created, model, delta, finishReason = null) {
+  return `data: ${JSON.stringify({
+    id,
+    object: "chat.completion.chunk",
+    created,
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  })}\n\n`;
+}
+
+function completionId() {
+  // Not security-relevant; it only has to be unique enough to correlate a
+  // response with its chunks in a log.
+  return `chatcmpl-cursor-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function openAiError(response, status, message, type = "invalid_request_error") {
+  writeJson(response, status, { error: { message, type, param: null, code: null } });
+}
+
+class Semaphore {
+  #limit;
+  #active = 0;
+  #waiting = [];
+
+  constructor(limit) {
+    this.#limit = limit;
+  }
+
+  async acquire() {
+    if (this.#active < this.#limit) {
+      this.#active += 1;
+      return;
+    }
+    await new Promise((resolve) => this.#waiting.push(resolve));
+    this.#active += 1;
+  }
+
+  release() {
+    this.#active -= 1;
+    const next = this.#waiting.shift();
+    if (next) next();
+  }
+}
+
+/**
+ * Run one turn, feeding assistant text to `onDelta` as it arrives.
+ *
+ * Resolves with the final answer even when nothing streamed: an `assistant`
+ * event is not guaranteed for a short turn, but the `result` event always
+ * carries the complete text, so it is the authority and the deltas are an
+ * optimization on top of it.
+ */
+export function runCursorTurn({
+  binary,
+  model,
+  prompt,
+  stream = true,
+  cwd,
+  environment = process.env,
+  timeoutMs = DEFAULT_TURN_TIMEOUT_MS,
+  spawnImpl = spawn,
+  signal,
+  onDelta = () => {},
+}) {
+  return new Promise((resolve) => {
+    const { command, args, options } = spawnableCommand(
+      binary,
+      turnArguments(model, { stream }),
+    );
+    const child = spawnImpl(command, args, {
+      ...options,
+      cwd,
+      // NO_COLOR keeps chalk out of stdout even when a parent process has
+      // handed this one a TTY; CI is the same signal for the progress spinner.
+      env: { ...environment, NO_COLOR: "1", CI: "1" },
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+    const reader = createEventReader();
+    let streamed = "";
+    let final = "";
+    let failure;
+    let usage;
+    let stderr = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      failure = failure || `cursor-agent did not finish within ${Math.round(timeoutMs / 1000)}s`;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    const abort = () => child.kill("SIGKILL");
+    signal?.addEventListener("abort", abort, { once: true });
+
+    const consume = (event) => {
+      const delta = assistantDelta(event);
+      if (delta) {
+        streamed += delta;
+        onDelta(delta);
+      }
+      if (!isResult(event)) return;
+      failure = failure || resultError(event);
+      final = resultText(event);
+      usage = usageFromResult(event) ?? usage;
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      for (const event of reader.push(chunk)) consume(event);
+    });
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      // Bounded: a child that fails in a loop must not be able to grow the
+      // router's heap while the turn is still open.
+      if (stderr.length < 8192) stderr += chunk;
+    });
+
+    const settle = (payload) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", abort);
+      resolve(payload);
+    };
+
+    child.on("error", (error) => {
+      settle({ ok: false, error: `cursor-agent could not be started: ${error.message}` });
+    });
+
+    child.on("close", (code) => {
+      for (const event of reader.flush()) consume(event);
+      // `result` is the authority; `streamed` is what the caller already saw.
+      // They agree in every observed run, and when they do not, the complete
+      // text wins over a partial one.
+      const text = final || streamed;
+      if (failure) return settle({ ok: false, error: failure, streamed, usage });
+      if (code !== 0 && !text) {
+        return settle({
+          ok: false,
+          error: `cursor-agent exited ${code}${stderr.trim() ? `: ${stderr.trim().split(/\r?\n/)[0]}` : ""}`,
+          streamed,
+        });
+      }
+      settle({ ok: true, text, streamed, usage });
+    });
+
+    child.stdin.on("error", () => {
+      // EPIPE when the child dies before reading the prompt; `close` reports it.
+    });
+    child.stdin.end(prompt);
+  });
+}
+
+async function handleChatCompletion(request, response, context) {
+  let payload;
+  try {
+    payload = JSON.parse((await readRequestBody(request)).toString("utf8") || "{}");
+  } catch (error) {
+    return openAiError(response, error?.status === 413 ? 413 : 400, "Request body is not valid JSON.");
+  }
+  const model = validCursorModelId(payload?.model);
+  if (!model) {
+    return openAiError(response, 400, `Unknown or unusable model: ${String(payload?.model ?? "")}`);
+  }
+  const prompt = buildCursorPrompt(payload?.messages);
+  if (!prompt.trim()) {
+    return openAiError(response, 400, "No prompt content: every message was empty.");
+  }
+  const binary = cursorAgentPath({ environment: context.environment });
+  if (!binary) {
+    return openAiError(
+      response,
+      503,
+      "cursor-agent is not installed. Install it with `curl https://cursor.com/install -fsS | bash`.",
+      "server_error",
+    );
+  }
+
+  const stream = payload?.stream === true;
+  const id = completionId();
+  const created = Math.floor(Date.now() / 1000);
+  const controller = new AbortController();
+  request.on("aborted", () => controller.abort());
+
+  await context.limiter.acquire();
+  try {
+    if (!stream) {
+      const outcome = await runCursorTurn({
+        binary,
+        model,
+        prompt,
+        stream: false,
+        cwd: context.workspace,
+        environment: context.environment,
+        timeoutMs: context.timeoutMs,
+        signal: controller.signal,
+      });
+      if (!outcome.ok) return openAiError(response, 502, outcome.error, "server_error");
+      return writeJson(response, 200, {
+        id,
+        object: "chat.completion",
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: outcome.text },
+            finish_reason: "stop",
+          },
+        ],
+        ...(outcome.usage ? { usage: outcome.usage } : {}),
+      });
+    }
+
+    response.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    response.write(chunkFrame(id, created, model, { role: "assistant" }));
+    let emitted = 0;
+    const outcome = await runCursorTurn({
+      binary,
+      model,
+      prompt,
+      stream: true,
+      cwd: context.workspace,
+      environment: context.environment,
+      timeoutMs: context.timeoutMs,
+      signal: controller.signal,
+      onDelta: (delta) => {
+        emitted += delta.length;
+        response.write(chunkFrame(id, created, model, { content: delta }));
+      },
+    });
+    if (!outcome.ok) {
+      // The head is already sent, so the failure has to travel inside the
+      // stream. A `[DONE]` with no error would read as a successful empty
+      // turn, which is the one outcome a caller cannot distinguish from a
+      // model that chose to say nothing.
+      response.write(
+        `data: ${JSON.stringify({ error: { message: outcome.error, type: "server_error", param: null, code: null } })}\n\n`,
+      );
+      response.write("data: [DONE]\n\n");
+      return response.end();
+    }
+    // A turn whose text arrived only in `result` -- short answers routinely do
+    // -- still has to reach the caller.
+    if (!emitted && outcome.text) {
+      response.write(chunkFrame(id, created, model, { content: outcome.text }));
+    }
+    response.write(chunkFrame(id, created, model, {}, "stop"));
+    if (outcome.usage) {
+      response.write(
+        `data: ${JSON.stringify({ id, object: "chat.completion.chunk", created, model, choices: [], usage: outcome.usage })}\n\n`,
+      );
+    }
+    response.write("data: [DONE]\n\n");
+    response.end();
+  } finally {
+    context.limiter.release();
+  }
+}
+
+function handleModels(response, context) {
+  const now = Date.now();
+  if (!context.modelCache || now - context.modelCache.at > MODEL_CACHE_MS) {
+    const status = cursorCliStatus({ environment: context.environment });
+    context.modelCache = { at: now, status };
+  }
+  const { status } = context.modelCache;
+  if (!status.signedIn) {
+    return openAiError(response, 503, status.detail, "server_error");
+  }
+  writeJson(response, 200, {
+    object: "list",
+    data: status.models.map((id) => ({
+      id,
+      object: "model",
+      created: 0,
+      owned_by: "cursor",
+    })),
+  });
+}
+
+export function createCursorBridge({ environment = process.env } = {}) {
+  const context = {
+    environment,
+    workspace: bridgeWorkspace(environment),
+    timeoutMs: positiveEnvInteger(
+      "MODEL_ROUTER_CURSOR_TIMEOUT_MS",
+      DEFAULT_TURN_TIMEOUT_MS,
+      environment,
+    ),
+    limiter: new Semaphore(
+      positiveEnvInteger("MODEL_ROUTER_CURSOR_CONCURRENCY", DEFAULT_CONCURRENCY, environment),
+    ),
+    modelCache: undefined,
+  };
+  const server = http.createServer((request, response) => {
+    const url = new URL(request.url || "/", "http://127.0.0.1");
+    const route = url.pathname.replace(/\/+$/, "") || "/";
+    if (request.method === "GET" && ["/health", "/v1/health"].includes(route)) {
+      return writeJson(response, 200, { ok: true, bridge: "cursor-cli" });
+    }
+    if (request.method === "GET" && ["/models", "/v1/models"].includes(route)) {
+      return handleModels(response, context);
+    }
+    if (request.method === "POST" && ["/chat/completions", "/v1/chat/completions"].includes(route)) {
+      return handleChatCompletion(request, response, context).catch((error) => {
+        if (response.headersSent) return response.end();
+        openAiError(response, 500, `Bridge failure: ${error.message}`, "server_error");
+      });
+    }
+    openAiError(response, 404, `Unsupported route: ${route}`);
+  });
+  return applyKeepAliveTimeouts(server);
+}
+
+export function startCursorBridge({
+  port = PORTS.cursorBridge,
+  host = "127.0.0.1",
+  environment = process.env,
+} = {}) {
+  const server = createCursorBridge({ environment });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    // Loopback only, always. This endpoint spawns a local agent process from
+    // request content; there is no version of it that should accept a
+    // connection from off-box.
+    server.listen(port, host, () => resolve(server));
+  });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const server = await startCursorBridge();
+  const { port } = server.address();
+  process.stdout.write(`cursor-cli bridge listening on http://127.0.0.1:${port}/v1\n`);
+}

--- a/src/cursor-cli-turn.mjs
+++ b/src/cursor-cli-turn.mjs
@@ -1,0 +1,223 @@
+// Translation between the router's chat-completions traffic and the one shape
+// `cursor-agent -p` accepts: a single prompt in, a stream of NDJSON events out.
+//
+// Everything here is pure. The process launching, the HTTP surface, and the
+// concurrency bound live in cursor-cli-bridge.mjs, so the awkward part -- the
+// event schema, which is Cursor's and can change under us -- stays testable
+// without spawning anything.
+
+// Verified against cursor-agent 2026.08.11-e8db854, whose stream-json emitter
+// produces exactly:
+//
+//   {"type":"system","subtype":"init","model":...,"session_id":...}
+//   {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":...}]}}
+//   {"type":"tool_call","subtype":"started"|"completed",...}
+//   {"type":"result","subtype":"success","is_error":false,"result":"...","usage":{...}}
+//
+// A type this module does not recognize is ignored rather than treated as an
+// error: Cursor adds event types between releases, and a router that 500s on a
+// new one turns a cosmetic upstream change into an outage.
+
+const ROLE_LABEL = Object.freeze({
+  user: "User",
+  assistant: "Assistant",
+  tool: "Tool result",
+  function: "Tool result",
+});
+
+function partText(part) {
+  if (typeof part === "string") return part;
+  if (!part || typeof part !== "object") return "";
+  if (typeof part.text === "string") return part.text;
+  // The router's vision bridge sits upstream of every provider, so an image
+  // part reaching here came from a caller that skipped it. Naming the gap is
+  // more useful than dropping the part silently or failing the whole turn --
+  // cursor-agent -p has no way to accept the bytes either way.
+  if (part.type === "image_url" || part.type === "input_image") {
+    return "[image omitted: cursor-agent accepts text prompts only]";
+  }
+  return "";
+}
+
+export function messageText(content) {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content.map(partText).filter(Boolean).join("\n");
+  }
+  return "";
+}
+
+function toolCallSummary(message) {
+  const calls = Array.isArray(message?.tool_calls) ? message.tool_calls : [];
+  return calls
+    .map((call) => {
+      const name = String(call?.function?.name || call?.name || "tool").trim();
+      const args = String(call?.function?.arguments || "").trim();
+      return `Assistant called ${name}${args ? ` with ${args}` : ""}`;
+    })
+    .join("\n");
+}
+
+const SYSTEM_ROLES = new Set(["system", "developer"]);
+
+/**
+ * One chat-completions `messages` array, flattened into one prompt.
+ *
+ * cursor-agent has its own session store and its own idea of a conversation,
+ * but the router is the thing that owns conversation state here -- every turn
+ * arrives complete, and reusing a Cursor session would make the same request
+ * produce different answers depending on what a previous caller happened to
+ * say. So each turn is a fresh, stateless run and the history is rendered into
+ * the prompt.
+ */
+export function buildCursorPrompt(messages) {
+  const list = Array.isArray(messages) ? messages : [];
+  const system = [];
+  const turns = [];
+  for (const message of list) {
+    const role = String(message?.role || "user").toLowerCase();
+    const text = messageText(message?.content);
+    if (SYSTEM_ROLES.has(role)) {
+      if (text) system.push(text);
+      continue;
+    }
+    const body = role === "assistant" ? [text, toolCallSummary(message)].filter(Boolean).join("\n") : text;
+    if (body) turns.push({ role, text: body });
+  }
+  const preamble = system.join("\n\n").trim();
+  // The overwhelmingly common shape is one system prompt and one user turn.
+  // Wrapping that in transcript scaffolding would put "User:" in front of a
+  // question nobody asked in a conversation, which measurably changes how an
+  // agent answers it.
+  if (turns.length === 1 && turns[0].role === "user") {
+    return [preamble, turns[0].text].filter(Boolean).join("\n\n");
+  }
+  if (!turns.length) return preamble;
+  const transcript = turns
+    .map((turn) => `${ROLE_LABEL[turn.role] || "User"}: ${turn.text}`)
+    .join("\n\n");
+  return [
+    preamble,
+    "Below is the conversation so far.",
+    transcript,
+    "Reply to the final message. Answer directly, with no transcript prefix of your own.",
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+/**
+ * Incremental NDJSON reader.
+ *
+ * cursor-agent writes one JSON object per line, but a pipe splits on buffer
+ * boundaries and not on newlines, so a naive `chunk.split("\n").map(JSON.parse)`
+ * corrupts any event that straddles a read -- which in practice is every long
+ * assistant delta.
+ */
+export function createEventReader() {
+  let buffer = "";
+  return {
+    push(chunk) {
+      buffer += String(chunk);
+      const events = [];
+      let newline = buffer.indexOf("\n");
+      while (newline >= 0) {
+        const line = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (line) {
+          try {
+            events.push(JSON.parse(line));
+          } catch {
+            // Not our line. cursor-agent occasionally writes an unstructured
+            // warning to stdout ahead of the stream; dropping it is right,
+            // aborting the turn over it is not.
+          }
+        }
+        newline = buffer.indexOf("\n");
+      }
+      return events;
+    },
+    // Whatever is left when the process exits without a trailing newline.
+    flush() {
+      const line = buffer.trim();
+      buffer = "";
+      if (!line) return [];
+      try {
+        return [JSON.parse(line)];
+      } catch {
+        return [];
+      }
+    },
+  };
+}
+
+/**
+ * The text an event contributes to the assistant's answer, if any.
+ *
+ * With `--stream-partial-output` an `assistant` event carries a delta; without
+ * it, the same event carries a whole message. The bridge always asks for
+ * deltas, so this returns the delta as-is.
+ */
+export function assistantDelta(event) {
+  if (event?.type !== "assistant") return "";
+  const content = event?.message?.content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((part) => part?.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+export function isResult(event) {
+  return event?.type === "result";
+}
+
+function positiveInteger(value) {
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+/**
+ * Cursor's usage block, in the field names chat-completions callers read.
+ *
+ * `input_tokens` already excludes the cached counts in the shape the CLI
+ * emits, so the totals are added rather than assumed to overlap. A turn that
+ * reports nothing yields undefined instead of a row of zeros -- the router's
+ * usage accounting distinguishes "no data" from "no tokens", and zeros would
+ * be recorded as a genuine free turn.
+ */
+export function usageFromResult(event) {
+  const usage = event?.usage;
+  if (!usage || typeof usage !== "object") return undefined;
+  const prompt = positiveInteger(usage.input_tokens);
+  const completion = positiveInteger(usage.output_tokens);
+  const cacheRead = positiveInteger(usage.cache_read_tokens);
+  const cacheWrite = positiveInteger(usage.cache_write_tokens);
+  if (!prompt && !completion && !cacheRead && !cacheWrite) return undefined;
+  return {
+    prompt_tokens: prompt + cacheRead + cacheWrite,
+    completion_tokens: completion,
+    total_tokens: prompt + cacheRead + cacheWrite + completion,
+    ...(cacheRead
+      ? { prompt_tokens_details: { cached_tokens: cacheRead } }
+      : {}),
+  };
+}
+
+/**
+ * Did the run fail, and what should the caller be told?
+ *
+ * `is_error` is the CLI's own verdict and is trusted; the message is whatever
+ * it put in `result`, because that is where a refusal, a quota error, and a
+ * model-not-entitled error all land.
+ */
+export function resultError(event) {
+  if (!isResult(event)) return undefined;
+  if (event.is_error !== true && event.subtype !== "error") return undefined;
+  const text = String(event.result || event.error || "").trim();
+  return text || "cursor-agent reported an error with no detail";
+}
+
+export function resultText(event) {
+  return isResult(event) ? String(event.result || "") : "";
+}

--- a/src/cursor-cli-turn.mjs
+++ b/src/cursor-cli-turn.mjs
@@ -152,13 +152,9 @@ export function createEventReader() {
 }
 
 /**
- * The text an event contributes to the assistant's answer, if any.
- *
- * With `--stream-partial-output` an `assistant` event carries a delta; without
- * it, the same event carries a whole message. The bridge always asks for
- * deltas, so this returns the delta as-is.
+ * The text an `assistant` event carries, whether delta or whole message.
  */
-export function assistantDelta(event) {
+export function assistantText(event) {
   if (event?.type !== "assistant") return "";
   const content = event?.message?.content;
   if (typeof content === "string") return content;
@@ -169,12 +165,66 @@ export function assistantDelta(event) {
     .join("");
 }
 
+/**
+ * Accumulates assistant text without counting the same words twice.
+ *
+ * `--stream-partial-output` does not replace the message-level emitter, it
+ * runs *alongside* it: cursor-agent writes one `assistant` event per text
+ * delta and then a final one carrying the whole accumulated message. A live
+ * turn answering "391" produces two `assistant` events both reading "391", so
+ * concatenating every one of them streams "391391" to the caller. Reading the
+ * bundle suggested the emitters were alternatives; they are not, and only a
+ * real turn showed it.
+ *
+ * The flush is identified by what makes it a flush: its text is everything
+ * accumulated so far. Compared against the accumulator rather than keyed on
+ * `timestamp_ms`, which the message-level emitter sets conditionally and so
+ * cannot be relied on to tell the two apart.
+ */
+export function createAssistantAccumulator() {
+  let accumulated = "";
+  return {
+    /** The new text this event contributes -- "" when it is a repeat flush. */
+    push(event) {
+      const text = assistantText(event);
+      if (!text) return "";
+      // The whole message again: nothing new to emit.
+      if (accumulated && text === accumulated) return "";
+      // A flush that restates everything and adds a tail: emit only the tail.
+      if (accumulated && text.startsWith(accumulated)) {
+        const tail = text.slice(accumulated.length);
+        accumulated = text;
+        return tail;
+      }
+      accumulated += text;
+      return text;
+    },
+    text() {
+      return accumulated;
+    },
+  };
+}
+
 export function isResult(event) {
   return event?.type === "result";
 }
 
 function positiveInteger(value) {
   return Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+// cursor-agent reports usage under two spellings depending on which emitter
+// produced the result. The bundle's snake_case form is what a read of the
+// source suggests; the first live turn through this bridge returned camelCase
+// (`{"inputTokens":18951,"outputTokens":53,"cacheReadTokens":3200}`), and
+// reading only the documented one meant every real turn silently reported no
+// usage at all. Accept both rather than betting on which emitter runs.
+function usageField(usage, ...names) {
+  for (const name of names) {
+    const value = positiveInteger(usage[name]);
+    if (value) return value;
+  }
+  return 0;
 }
 
 /**
@@ -189,10 +239,10 @@ function positiveInteger(value) {
 export function usageFromResult(event) {
   const usage = event?.usage;
   if (!usage || typeof usage !== "object") return undefined;
-  const prompt = positiveInteger(usage.input_tokens);
-  const completion = positiveInteger(usage.output_tokens);
-  const cacheRead = positiveInteger(usage.cache_read_tokens);
-  const cacheWrite = positiveInteger(usage.cache_write_tokens);
+  const prompt = usageField(usage, "input_tokens", "inputTokens");
+  const completion = usageField(usage, "output_tokens", "outputTokens");
+  const cacheRead = usageField(usage, "cache_read_tokens", "cacheReadTokens");
+  const cacheWrite = usageField(usage, "cache_write_tokens", "cacheWriteTokens");
   if (!prompt && !completion && !cacheRead && !cacheWrite) return undefined;
   return {
     prompt_tokens: prompt + cacheRead + cacheWrite,

--- a/src/cursor-cli.mjs
+++ b/src/cursor-cli.mjs
@@ -1,0 +1,195 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
+
+// Cursor CLI is an *agent*, not an inference API. It has no OpenAI-compatible
+// endpoint, no BYOK, and no way to be pointed at this router: `--endpoint`
+// exists but speaks Cursor's own protocol, and Bedrock mode validates against
+// Cursor's backend. So the integration runs the other way round -- the router
+// drives `cursor-agent` as a local upstream and adapts it to chat-completions
+// in cursor-cli-bridge.mjs. Everything in this module is the part that has to
+// know about the binary itself: where it is, whether it is signed in, and
+// which models the signed-in account may spend.
+
+export const CURSOR_PROVIDER_ID = "cursor-cli";
+
+// The official installer creates two symlinks in the same bin directory:
+// `cursor-agent` and a bare `agent`. Only the first is ever probed. `agent` is
+// a name half a dozen unrelated tools take, and resolving it off PATH would
+// let whichever one is earlier become the thing the router spawns with the
+// user's prompt on its stdin.
+const BINARY_NAME = "cursor-agent";
+
+// A model id reaches `--model` from the registry or the user's curated model
+// file, so it is not attacker-supplied -- but it is the one request field that
+// becomes an argv entry, and Cursor's own parameterized syntax
+// (`claude-opus-4-8[context=1m,effort=high]`) means the charset cannot simply
+// be alphanumerics. Pin it to exactly what Cursor documents rather than
+// forwarding whatever arrived.
+const MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._-]*(?:\[[A-Za-z0-9=,._-]*\])?$/;
+
+export function validCursorModelId(value) {
+  const id = String(value || "").trim();
+  return MODEL_ID.test(id) && id.length <= 128 ? id : undefined;
+}
+
+/**
+ * Where `cursor-agent` lives, or undefined when it is not installed.
+ *
+ * The installer drops the real binary under
+ * `~/.local/share/cursor-agent/versions/<version>/` and symlinks it into
+ * `~/.local/bin`, which is on PATH for an interactive shell but routinely is
+ * not for a launchd or systemd service -- so the explicit fallback matters
+ * more here than the PATH lookup does.
+ */
+export function cursorAgentPath({
+  environment = process.env,
+  platform = process.platform,
+  exec,
+} = {}) {
+  if (environment.CURSOR_AGENT) return environment.CURSOR_AGENT;
+  const discovered = commandOnPath(BINARY_NAME, {
+    platform,
+    ...(exec ? { exec } : {}),
+  });
+  if (discovered) return discovered;
+  const home = environment.HOME || environment.USERPROFILE || os.homedir();
+  const candidates =
+    platform === "win32"
+      ? [
+          path.join(
+            environment.LOCALAPPDATA || path.join(home, "AppData", "Local"),
+            "cursor-agent",
+            `${BINARY_NAME}.exe`,
+          ),
+          path.join(home, ".local", "bin", `${BINARY_NAME}.exe`),
+          path.join(home, ".local", "bin", `${BINARY_NAME}.cmd`),
+        ]
+      : [
+          path.join(home, ".local", "bin", BINARY_NAME),
+          path.join(home, "bin", BINARY_NAME),
+          "/usr/local/bin/cursor-agent",
+          "/opt/homebrew/bin/cursor-agent",
+        ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+// `cursor-agent models` prints, with chalk decoration that disappears the
+// moment stdout is not a TTY:
+//
+//   Available models
+//
+//   gpt-5 - GPT-5 (current, default)
+//   sonnet-4-thinking - Claude Sonnet 4 (Thinking)
+//
+//   Tip: use --model <id> ...
+//
+// The id is the token before " - " and is exactly what `--model` accepts.
+const HEADING = /^available models$/i;
+const TIP = /^tip:/i;
+// Chalk is off without a TTY, but NO_COLOR is not honored by every code path
+// in every release, so strip SGR sequences rather than trusting that.
+const ANSI = /\[[0-9;]*m/g;
+
+export function parseCursorModels(output) {
+  const ids = [];
+  for (const raw of String(output || "").split(/\r?\n/)) {
+    const line = raw.replace(ANSI, "").trim();
+    if (!line || HEADING.test(line) || TIP.test(line)) continue;
+    // ` - Display Name` is the description, and ` (current, default)` is the
+    // marker suffix; the id is what survives both.
+    const id = validCursorModelId(line.split(" - ")[0].replace(/\s*\(.*\)\s*$/, ""));
+    if (id && !ids.includes(id)) ids.push(id);
+  }
+  return ids;
+}
+
+const AUTH_FAILURE = /authentication (?:required|failed)|not logged in|run ['"`]?(?:cursor-)?agent login/i;
+
+/**
+ * Installed / signed-in / which models, from one call.
+ *
+ * `cursor-agent status` answers only the middle question, and answering all
+ * three separately means three process launches and two network round trips
+ * for a doctor line. `models` fails closed with a recognizable authentication
+ * error and otherwise returns the account's entitled model list, so it settles
+ * every question a caller actually has.
+ */
+export function cursorCliStatus({
+  environment = process.env,
+  platform = process.platform,
+  exec = execFileSync,
+  timeoutMs = 20_000,
+} = {}) {
+  const binary = cursorAgentPath({ environment, platform });
+  if (!binary) {
+    return {
+      installed: false,
+      signedIn: false,
+      models: [],
+      detail: "cursor-agent is not installed",
+      fix: "Install it with `curl https://cursor.com/install -fsS | bash`.",
+    };
+  }
+  const { command, args, options } = spawnableCommand(binary, ["models"], platform);
+  let stdout = "";
+  let failure;
+  try {
+    stdout = String(
+      exec(command, args, {
+        ...options,
+        encoding: "utf8",
+        timeout: timeoutMs,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        // NO_COLOR is belt to the ANSI-stripping braces; both are cheap.
+        env: { ...environment, NO_COLOR: "1" },
+      }) || "",
+    );
+  } catch (error) {
+    // execFileSync throws on a non-zero exit, and a non-zero exit is exactly
+    // how `models` reports "not signed in" -- so the diagnostic lives in the
+    // thrown result's streams, not in an exception message.
+    failure = [error?.stdout, error?.stderr, error?.message]
+      .map((value) => String(value || ""))
+      .join("\n");
+  }
+  if (failure !== undefined) {
+    const signedOut = AUTH_FAILURE.test(failure);
+    return {
+      installed: true,
+      signedIn: false,
+      models: [],
+      binary,
+      detail: signedOut
+        ? "cursor-agent is installed but not signed in"
+        : `cursor-agent could not list models: ${firstLine(failure)}`,
+      fix: signedOut
+        ? "Run `cursor-agent login` in an interactive terminal."
+        : "Run `cursor-agent models` by hand to see what it reports.",
+    };
+  }
+  const models = parseCursorModels(stdout);
+  return {
+    installed: true,
+    signedIn: true,
+    models,
+    binary,
+    detail: models.length
+      ? `cursor-agent signed in with ${models.length} model(s)`
+      : "cursor-agent is signed in but the account has no models",
+    ...(models.length ? {} : { fix: "Check the plan on the Cursor dashboard." }),
+  };
+}
+
+function firstLine(value) {
+  return (
+    String(value || "")
+      .split(/\r?\n/)
+      .map((line) => line.replace(ANSI, "").trim())
+      .find(Boolean) || "no output"
+  );
+}

--- a/src/cursor-cli.mjs
+++ b/src/cursor-cli.mjs
@@ -110,6 +110,50 @@ export function parseCursorModels(output) {
 const AUTH_FAILURE = /authentication (?:required|failed)|not logged in|run ['"`]?(?:cursor-)?agent login/i;
 
 /**
+ * Signed in? Answered locally, without asking Cursor.
+ *
+ * `cursorCliStatus()` below settles this too, but it does so with
+ * `cursor-agent models`, which is a network round trip. The tray rebuilds its
+ * provider rows on every refresh, so that call belongs on a doctor run and
+ * nowhere near a poll loop. `cursor-agent status` reads the local credential
+ * store and returns in about half a second.
+ *
+ * It also exits 0 either way, so the answer is in the output and not in the
+ * status code -- and the output is read conservatively: only text that plainly
+ * says signed out counts as signed out, and empty output counts as unknown
+ * rather than signed in, so a future release that reworks this message
+ * degrades to "cannot tell" instead of to a confident wrong answer.
+ */
+export function cursorSignedIn({
+  environment = process.env,
+  platform = process.platform,
+  exec = execFileSync,
+  timeoutMs = 10_000,
+} = {}) {
+  const binary = cursorAgentPath({ environment, platform });
+  if (!binary) return { installed: false, signedIn: false };
+  const { command, args, options } = spawnableCommand(binary, ["status"], platform);
+  let output = "";
+  try {
+    output = String(
+      exec(command, args, {
+        ...options,
+        encoding: "utf8",
+        timeout: timeoutMs,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        env: { ...environment, NO_COLOR: "1" },
+      }) || "",
+    );
+  } catch (error) {
+    output = [error?.stdout, error?.stderr].map((value) => String(value || "")).join("\n");
+  }
+  const text = output.replace(ANSI, "").trim();
+  if (!text) return { installed: true, signedIn: false, binary, unknown: true };
+  return { installed: true, signedIn: !AUTH_FAILURE.test(text), binary };
+}
+
+/**
  * Installed / signed-in / which models, from one call.
  *
  * `cursor-agent status` answers only the middle question, and answering all

--- a/src/cursor-models.mjs
+++ b/src/cursor-models.mjs
@@ -1,0 +1,196 @@
+import { PROVIDERS, resolveProviderBaseUrl } from "./model-registry.mjs";
+import {
+  disableProvider,
+  enableProvider,
+  readProviderSelection,
+} from "./provider-selection.mjs";
+import { readUserModels, userModelEntry, writeUserModels } from "./user-models.mjs";
+
+// The panel's view of Cursor, built the way lmstudio-models.mjs builds LM
+// Studio's: everything the account can spend, everything the picker publishes,
+// and the difference between them.
+//
+// The list is read from the *bridge*, not from `cursor-agent` -- the panel
+// refreshes on a timer, and shelling out to the CLI on each pass would put a
+// network round trip to Cursor behind every poll. The bridge already caches
+// that answer, so this stays a loopback GET exactly like LM Studio's.
+
+export const CURSOR_PROVIDER_ID = "cursor-cli";
+
+// After the LM Studio block (950). Cursor models are curated with no
+// verification of their own, and they cannot drive a Codex turn, so they sort
+// last of all.
+const CURSOR_MODEL_PRIORITY = 980;
+
+// The bridge either answers immediately or is not running; the panel must not
+// block on it.
+const PROBE_TIMEOUT_MS = 4000;
+
+// Cursor sizes context per model and per parameter override, and the router
+// has no way to ask which. Codex sizes its prompts to whatever is advertised,
+// so under-promise: a turn that fits is better than one the upstream truncates.
+const CURSOR_CONTEXT_WINDOW = 128000;
+const CURSOR_AUTO_COMPACT = 110000;
+
+function cursorProvider() {
+  return PROVIDERS.get(CURSOR_PROVIDER_ID);
+}
+
+export function curatedCursorModels(models = readUserModels()) {
+  return models.filter((model) => model.provider === CURSOR_PROVIDER_ID);
+}
+
+export function isCursorModelEnabled(id, models = readUserModels()) {
+  const value = String(id || "").trim();
+  return curatedCursorModels(models).some((model) => model.upstreamModel === value);
+}
+
+/**
+ * What the account can spend right now, straight from the bridge.
+ *
+ * Three outcomes, and the panel needs to tell them apart because the fixes are
+ * different: the bridge is not running (start the service), the bridge is up
+ * but cursor-agent is signed out (press Sign in), or here is the list. A 503
+ * carries the CLI's own reason, so it is passed through rather than replaced
+ * with a guess.
+ */
+export async function cursorServedModels({
+  fetchImpl = fetch,
+  timeoutMs = PROBE_TIMEOUT_MS,
+} = {}) {
+  const provider = cursorProvider();
+  if (!provider) return { reachable: false, signedIn: false, models: [] };
+  const { baseUrl } = resolveProviderBaseUrl(provider);
+  try {
+    const response = await fetchImpl(`${baseUrl}/models`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        reachable: true,
+        signedIn: false,
+        baseUrl,
+        models: [],
+        detail: payload?.error?.message || `the bridge answered HTTP ${response.status}`,
+      };
+    }
+    const data = Array.isArray(payload) ? payload : payload?.data;
+    const ids = Array.isArray(data)
+      ? [...new Set(data.map((item) => String(item?.id || "").trim()).filter(Boolean))].sort()
+      : [];
+    return { reachable: true, signedIn: true, baseUrl, models: ids };
+  } catch {
+    return {
+      reachable: false,
+      signedIn: false,
+      baseUrl,
+      models: [],
+      detail: "the Cursor bridge is not running",
+    };
+  }
+}
+
+export async function cursorSnapshot({
+  fetchImpl,
+  timeoutMs,
+  userModels = readUserModels(),
+} = {}) {
+  const provider = cursorProvider();
+  const served = await cursorServedModels({
+    ...(fetchImpl ? { fetchImpl } : {}),
+    ...(timeoutMs ? { timeoutMs } : {}),
+  });
+  const curated = curatedCursorModels(userModels);
+  const curatedIds = new Set(curated.map((model) => model.upstreamModel));
+  const servedSet = new Set(served.models);
+  // A curated model the account no longer offers stays visible as
+  // `served: false`. Hiding it would leave a route in the picker with no way
+  // to see or clear it from here -- the same rule the LM Studio panel follows.
+  const models = [
+    ...served.models.map((id) => ({ id, enabled: curatedIds.has(id), served: true })),
+    ...curated
+      .filter((model) => !servedSet.has(model.upstreamModel))
+      .map((model) => ({ id: model.upstreamModel, enabled: true, served: false })),
+  ].sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
+  let providerEnabled;
+  try {
+    providerEnabled = readProviderSelection().includes(CURSOR_PROVIDER_ID);
+  } catch {
+    providerEnabled = undefined;
+  }
+  return {
+    provider: CURSOR_PROVIDER_ID,
+    displayName: provider?.displayName || "Cursor CLI",
+    reachable: served.reachable,
+    signedIn: served.signedIn,
+    ...(served.detail ? { detail: served.detail } : {}),
+    baseUrl: served.baseUrl,
+    enabled: models.filter((model) => model.enabled).length,
+    providerEnabled,
+    models,
+  };
+}
+
+// Failure-tolerant for the same reason as the LM Studio twin: the selection
+// file is shared state, and a checkbox that publishes the model but cannot
+// flip the provider beats one that fails outright.
+export function syncCursorProviderSelection(shouldEnable) {
+  try {
+    const enabled = readProviderSelection().includes(CURSOR_PROVIDER_ID);
+    if (shouldEnable && !enabled) enableProvider(CURSOR_PROVIDER_ID);
+    if (!shouldEnable && enabled) disableProvider(CURSOR_PROVIDER_ID);
+    return shouldEnable;
+  } catch {
+    return undefined;
+  }
+}
+
+// Checking a model publishes it through the same user-model overlay
+// `curate-models cursor-cli` writes, so the panel and the interactive CLI are
+// two doors to one state and neither can strand the other's entries.
+export function setCursorModelEnabled(id, enabled) {
+  const value = String(id || "").trim();
+  if (!value) throw new Error("A model id is required.");
+  const existing = readUserModels();
+  const others = existing.filter((model) => model.provider !== CURSOR_PROVIDER_ID);
+  const mine = existing.filter(
+    (model) => model.provider === CURSOR_PROVIDER_ID && model.upstreamModel !== value,
+  );
+  const next = enabled
+    ? [
+        ...mine,
+        {
+          ...userModelEntry({
+            providerId: CURSOR_PROVIDER_ID,
+            upstreamId: value,
+            priority: CURSOR_MODEL_PRIORITY,
+            metadata: {
+              contextWindow: CURSOR_CONTEXT_WINDOW,
+              autoCompact: CURSOR_AUTO_COMPACT,
+              description: `${value} answered by cursor-agent on this machine, spending your Cursor plan.`,
+            },
+          }),
+          // Not a hedge and not boilerplate: cursor-agent returns prose and its
+          // own tool events, never OpenAI tool_calls, so this model cannot
+          // dispatch a Codex turn. Saying so in the picker is the only place
+          // someone finds out before selecting it.
+          displayName: `${value} (Cursor, answers only)`,
+          // apply_patch is a freeform custom tool with no representation here,
+          // and a model that cannot emit a tool call certainly cannot drive a
+          // subagent.
+          supportsApplyPatchTool: false,
+          multiAgentVersion: "v1",
+        },
+      ]
+    : mine;
+  // Renumbered on every write rather than assigned once: a priority derived
+  // from list length at toggle time collides after a disable/re-enable cycle.
+  const entries = next.map((entry, index) => ({
+    ...entry,
+    priority: CURSOR_MODEL_PRIORITY + index,
+  }));
+  writeUserModels([...others, ...entries]);
+  syncCursorProviderSelection(entries.length > 0);
+  return entries;
+}

--- a/src/desktop-commands.mjs
+++ b/src/desktop-commands.mjs
@@ -74,6 +74,9 @@ export const COMMANDS = {
   set_lmstudio_model_enabled: ({ model, id, enabled }) => ({
     args: ["local-models", "lmstudio-set", requireTag(model ?? id), enabled ? "on" : "off"],
   }),
+  set_cursor_model_enabled: ({ model, id, enabled }) => ({
+    args: ["local-models", "cursor-set", requireCursorModel(model ?? id), enabled ? "on" : "off"],
+  }),
   install_provider_cli: ({ provider }) => ({ args: ["install-cli", requireProvider(provider)] }),
   connect_oauth: ({ provider }) => ({
     args: ["login", requireProvider(provider)],
@@ -142,6 +145,20 @@ function requireProvider(provider) {
 function requireTag(tag) {
   const value = String(tag ?? "");
   if (!/^[A-Za-z0-9][\w.:\/-]{0,127}$/.test(value)) throw new Error(`Unknown model tag: ${tag}`);
+  return value;
+}
+
+// Cursor names parameterized models with a bracket suffix --
+// `claude-opus-4-8[context=1m,effort=high,fast=false]` -- which `requireTag`
+// rejects along with everything else it does not recognize. Widening that
+// shared validator to admit brackets would loosen it for Ollama and LM Studio
+// tags too, so Cursor gets its own, matching `validCursorModelId` in
+// cursor-cli.mjs exactly. Both exist because this value becomes an argv entry.
+function requireCursorModel(id) {
+  const value = String(id ?? "");
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]*(?:\[[A-Za-z0-9=,._-]*\])?$/.test(value) || value.length > 128) {
+    throw new Error(`Unknown Cursor model: ${id}`);
+  }
   return value;
 }
 

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -10,7 +10,8 @@ import { privateFileIsProtected } from "./file-security.mjs";
 import { grokCliPreflight } from "./grok-cli.mjs";
 import { detectLegacyInstallations } from "./legacy-migration.mjs";
 import { routedCatalogConfigured } from "./catalog.mjs";
-import { MODEL_BY_SLUG, PROVIDERS } from "./model-registry.mjs";
+import { MODEL_BY_SLUG, PROVIDERS, resolveProviderBaseUrl } from "./model-registry.mjs";
+import { CURSOR_PROVIDER_ID, cursorCliStatus } from "./cursor-cli.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { kimiOAuthHealth } from "./oauth-status.mjs";
 import {
@@ -750,6 +751,38 @@ if (!credentialDiscoveryOff) {
         ? grokOauth.source
         : `not configured; ${grokOauth.setup}`,
     !grokCli.runnable ? grokCli.fix : "Run grok login, then rerun the doctor.",
+  );
+}
+
+// Cursor CLI has two moving parts the generic keyless provider row below
+// cannot see: cursor-agent's own sign-in, which lives in its credential store
+// and not in anything the router holds, and the local bridge that turns it
+// into the chat-completions endpoint the registry entry points at. Either one
+// being down produces the same symptom -- every Cursor model 502s -- so both
+// get their own row.
+//
+// Probed only while the provider is selected. `cursor-agent models` is a
+// network round trip to Cursor, and an operator who never enabled Cursor
+// should not pay for one on every doctor run.
+if (!credentialDiscoveryOff && selection.providers.includes(CURSOR_PROVIDER_ID)) {
+  const cursor = cursorCliStatus();
+  add(
+    cursor.signedIn ? "ok" : "fail",
+    "Cursor CLI sign-in",
+    cursor.detail,
+    cursor.fix || "Run cursor-agent login in an interactive terminal.",
+  );
+  const { baseUrl } = resolveProviderBaseUrl(PROVIDERS.get(CURSOR_PROVIDER_ID));
+  const bridgeUp = await fetch(`${baseUrl.replace(/\/v1$/, "")}/health`, {
+    signal: AbortSignal.timeout(3_000),
+  })
+    .then((response) => response.ok)
+    .catch(() => false);
+  add(
+    bridgeUp ? "ok" : "fail",
+    "Cursor CLI bridge",
+    bridgeUp ? `reachable at ${baseUrl}` : `nothing is serving ${baseUrl}`,
+    "Start it with ./bin/cursor-bridge.",
   );
 }
 

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -144,12 +144,17 @@ function port(name, fallback) {
 // protocol response during GNOME login. gateway/oauth/router/api are the
 // original four; grokOauth is a fifth forwarder port for the Grok OAuth
 // provider.
+// cursorBridge is not a forwarder: it is the loopback chat-completions
+// endpoint the `cursor-cli` provider's registry entry points at, so its
+// default has to stay in step with the `baseUrl` checked into
+// config/cursor/cursor.json.
 export const DEFAULT_PORTS = Object.freeze({
   gateway: 4200,
   oauth: 4201,
   router: 4202,
   api: 4203,
   grokOauth: 4208,
+  cursorBridge: 4209,
 });
 
 // Ports used before the BrlAPI-safe defaults shipped. They remain recognized
@@ -181,6 +186,7 @@ export const PORTS = {
     process.env.CODEX_ROUTER_API_PORT || process.env.KIMI_API_FORWARD_PORT || DEFAULT_PORTS.api,
   ),
   grokOauth: port("MODEL_ROUTER_GROK_OAUTH_PORT", DEFAULT_PORTS.grokOauth),
+  cursorBridge: port("MODEL_ROUTER_CURSOR_BRIDGE_PORT", DEFAULT_PORTS.cursorBridge),
 };
 
 export function loopback(portNumber, suffix = "") {

--- a/src/provider-onboarding.mjs
+++ b/src/provider-onboarding.mjs
@@ -9,6 +9,7 @@ import {
   grokCliPreflight,
 } from "./grok-cli.mjs";
 import { cliSessionPath, cliSessionStatus } from "./cli-session-credential.mjs";
+import { CURSOR_PROVIDER_ID, cursorAgentPath, cursorSignedIn } from "./cursor-cli.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { KIMI_CLI_NPM_PACKAGE } from "./kimi-oauth-onboarding.mjs";
 import { MODELS, PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
@@ -55,6 +56,26 @@ const SIGN_IN_CLIS = Object.freeze({
     // to be handed a real terminal.
     needsTerminal: true,
   },
+  // Cursor is the one sign-in CLI here that npm does not ship: it installs
+  // through `curl https://cursor.com/install | bash`, and the tray must not
+  // run that on someone's behalf from a button press -- fetching and executing
+  // a remote script is a decision its owner makes, not a side effect of
+  // clicking "Sign in". `installCommand` exists so the refusal can name the
+  // exact line to run instead of failing at an npm package that does not
+  // exist.
+  "cursor-cli": {
+    executable: "cursor-agent",
+    installCommand: "curl https://cursor.com/install -fsS | bash",
+    loginArgs: ["login"],
+    // `cursor-agent login` opens a browser and then holds the terminal until
+    // the callback lands. Spawned from the tray with no TTY it has nothing to
+    // hold, so it gets a real Terminal window the way Command Code does.
+    needsTerminal: true,
+    // Cursor keeps its session in the OS credential store, not in a file under
+    // ~/.cursor, so the file-mtime probe the other CLIs use has nothing to
+    // watch. Ask the CLI instead -- `cursor-agent status` is local and fast.
+    signedInProbe: true,
+  },
 });
 
 function commandPath(name) {
@@ -74,6 +95,9 @@ export function oauthCliPath(providerId) {
   const cli = SIGN_IN_CLIS[providerId];
   if (!cli) throw new Error(`Unknown OAuth provider: ${providerId}`);
   if (providerId === "grok-oauth") return grokCliPath();
+  // Cursor's installer symlinks into ~/.local/bin, which is not on the bare
+  // PATH launchd hands the tray, and npm has never heard of it.
+  if (providerId === CURSOR_PROVIDER_ID) return cursorAgentPath();
   const discovered = commandPath(cli.executable);
   if (discovered) return discovered;
   const candidate = (cli.candidates || []).find((path) => existsSync(path));
@@ -93,6 +117,7 @@ export function oauthLoginArgs(providerId) {
 function oauthConfigured(providerId) {
   if (providerId === "kimi-oauth") return kimiOAuthStatus().configured;
   if (providerId === "grok-oauth") return grokOAuthStatus().configured;
+  if (providerId === CURSOR_PROVIDER_ID) return cursorSignedIn().signedIn;
   const provider = PROVIDERS.get(providerId);
   return provider ? cliSessionStatus(provider).configured : false;
 }
@@ -124,6 +149,30 @@ export function providerOnboardingSnapshot() {
               : configured
                 ? "ready"
                 : "login",
+        };
+      }
+      // A keyless provider whose usefulness depends on somebody else's CLI
+      // being signed in. `providerNeedsNoKey` is true here and would otherwise
+      // report the row as ready forever -- which is exactly what it did: the
+      // tray showed Cursor "connected" with cursor-agent signed out, and the
+      // only way to find out was every model 502ing.
+      //
+      // Presented as an oauth row because that is what it behaves like: there
+      // is nothing to paste, one button signs you in, and the credential is
+      // never the router's to store or delete. The tray's existing oauth
+      // rendering then applies unchanged.
+      if (providerNeedsNoKey(provider) && hasSignInCli(provider.id)) {
+        const cliInstalled = Boolean(oauthCliPath(provider.id));
+        const signedIn = cliInstalled && oauthConfigured(provider.id);
+        return {
+          id: provider.id,
+          displayName: provider.displayName,
+          kind: "oauth",
+          configured: signedIn,
+          cliInstalled,
+          cliRunnable: cliInstalled,
+          action: !cliInstalled ? "install" : signedIn ? "ready" : "login",
+          ...(provider.planNote ? { planNote: provider.planNote } : {}),
         };
       }
       const configured = providerNeedsNoKey(provider)
@@ -195,6 +244,14 @@ export function installOauthCli(providerId) {
   } else if (oauthCliPath(providerId)) {
     return;
   }
+  // Nothing to install *through npm*. Naming the command is the whole answer:
+  // running it here would mean the router fetching and executing a remote
+  // script because someone pressed a button.
+  if (!cli.npmPackage) {
+    throw new Error(
+      `${cli.executable} is not installed, and it does not come from npm. Install it yourself with: ${cli.installCommand}`,
+    );
+  }
   npmInstallGlobal(cli.npmPackage, { label: `the official ${cli.executable} CLI` });
   if (providerId === "grok-oauth") {
     const preflight = grokCliPreflight();
@@ -233,6 +290,12 @@ function sessionWrittenAt(providerId) {
 }
 
 function signedInSince(providerId, before) {
+  // Cursor keeps its session in the OS credential store, so there is no file
+  // whose mtime could mark the moment a sign-in landed. Asking the CLI is the
+  // only observation available. It is sound only because the caller below
+  // refuses to use it unless the operator was signed *out* when the window
+  // opened -- otherwise "already true" would read as "just finished".
+  if (SIGN_IN_CLIS[providerId]?.signedInProbe) return oauthConfigured(providerId);
   return sessionWrittenAt(providerId) > before && oauthConfigured(providerId);
 }
 
@@ -266,6 +329,12 @@ function signInThroughTerminal(providerId, executable) {
   if (opened.error || opened.status !== 0) {
     throw new Error(`Could not open Terminal to run ${cli.executable}.`);
   }
+  // Reconnecting a CLI whose only signal is "are you signed in?" has no signal
+  // at all: it was true before the window opened and stays true throughout, so
+  // polling would report success the instant the Terminal appeared and claim a
+  // sign-in nobody performed. The window is open and the operator can finish
+  // there; saying so beats inventing a result.
+  if (cli.signedInProbe && oauthConfigured(providerId)) return;
   const deadline = Date.now() + TERMINAL_LOGIN_TIMEOUT_MS;
   while (Date.now() < deadline) {
     if (signedInSince(providerId, before)) return;

--- a/src/provider-onboarding.mjs
+++ b/src/provider-onboarding.mjs
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -56,16 +56,16 @@ const SIGN_IN_CLIS = Object.freeze({
     // to be handed a real terminal.
     needsTerminal: true,
   },
-  // Cursor is the one sign-in CLI here that npm does not ship: it installs
-  // through `curl https://cursor.com/install | bash`, and the tray must not
-  // run that on someone's behalf from a button press -- fetching and executing
-  // a remote script is a decision its owner makes, not a side effect of
-  // clicking "Sign in". `installCommand` exists so the refusal can name the
-  // exact line to run instead of failing at an npm package that does not
-  // exist.
+  // Cursor is the one sign-in CLI here that npm does not ship; it installs
+  // from a vendor script instead. `installScriptCli` fetches that script and
+  // runs it rather than piping it into a shell, and pins the origin against
+  // `installHost`. The button installs it either way: its npm siblings above
+  // are installed by the same press, and a user who is handed a shell command
+  // to run instead has been handed a dead end.
   "cursor-cli": {
     executable: "cursor-agent",
     installCommand: "curl https://cursor.com/install -fsS | bash",
+    installHost: "cursor.com",
     loginArgs: ["login"],
     // `cursor-agent login` opens a browser and then holds the terminal until
     // the callback lands. Spawned from the tray with no TTY it has nothing to
@@ -87,6 +87,13 @@ function commandPath(name) {
 // A registry entry can declare a CLI session before anyone teaches this module
 // how to install and run that CLI. Callers check first so the missing half
 // degrades to "key only" instead of throwing mid-install.
+// Exported for tests: the origin guard is the whole reason fetching a remote
+// script here is defensible, so it must be exercisable on its own rather than
+// only through a code path that downloads 200MB.
+export function signInCliDescriptor(providerId) {
+  return SIGN_IN_CLIS[providerId];
+}
+
 export function hasSignInCli(providerId) {
   return Object.hasOwn(SIGN_IN_CLIS, providerId);
 }
@@ -226,6 +233,80 @@ export function providerOnboardingSnapshot() {
   };
 }
 
+// Vendor install scripts, for the one CLI here that npm does not carry.
+//
+// Downloaded to a file and then run, rather than piped straight into a shell.
+// `curl | sh` hands the interpreter a stream: a download that dies halfway
+// through still executes everything that arrived, and what runs is whatever
+// happened to land. Fetching first means the bytes either arrive whole or the
+// install fails having done nothing -- and the script stays on disk afterwards
+// for anyone who wants to read what ran.
+//
+// The URL is a constant in SIGN_IN_CLIS. Nothing here interpolates into it,
+// and it is checked against its expected origin before anything executes, so a
+// future edit cannot turn this into a fetch-and-run of an arbitrary address.
+const INSTALL_SCRIPT_TIMEOUT_MS = 5 * 60_000;
+
+export function installScriptOrigin(cli) {
+  // Deliberately matches http too, so a downgraded URL is refused by the
+  // protocol check below with a message that says why, rather than falling
+  // through to "no install URL" and reading like a missing descriptor.
+  const match = /https?:\/\/[^\s|]+/.exec(cli.installCommand || "");
+  if (!match) throw new Error(`${cli.executable} has no install URL to fetch.`);
+  const url = new URL(match[0]);
+  if (url.protocol !== "https:" || url.hostname !== cli.installHost) {
+    throw new Error(
+      `Refusing to run an installer from ${url.hostname}; ${cli.executable} is published at ${cli.installHost}.`,
+    );
+  }
+  return url;
+}
+
+function installScriptCli(cli) {
+  if (process.platform === "win32") {
+    throw new Error(
+      `${cli.executable} has no Windows installer. Install it inside WSL, then reopen this.`,
+    );
+  }
+  const url = installScriptOrigin(cli);
+  mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
+  const script = path.join(STATE_DIR, `install-${cli.executable}.sh`);
+  const download = spawnSync(
+    "/usr/bin/curl",
+    ["-fsSL", "--proto", "=https", "--tlsv1.2", "-o", script, url.toString()],
+    { encoding: "utf8", timeout: INSTALL_SCRIPT_TIMEOUT_MS, env: spawnEnvironment() },
+  );
+  if (download.error || download.status !== 0) {
+    throw new Error(
+      `Could not download the ${cli.executable} installer from ${url.hostname}. ${installFailureDetail(download)}`.trim(),
+    );
+  }
+  // A proxy or captive portal answers with HTML and a 200, and curl is happy;
+  // handing that to sh produces a wall of syntax errors that names neither the
+  // cause nor the fix.
+  let contents = "";
+  try {
+    contents = readFileSync(script, "utf8");
+  } catch {
+    throw new Error(`The ${cli.executable} installer could not be read back after downloading.`);
+  }
+  if (!/^#!\s*\/(usr\/bin\/env\s+)?(ba)?sh/.test(contents.trimStart())) {
+    throw new Error(
+      `What ${url.hostname} returned is not a shell script. Check for a proxy or captive portal, then try again.`,
+    );
+  }
+  const run = spawnSync("/bin/sh", [script], {
+    encoding: "utf8",
+    timeout: INSTALL_SCRIPT_TIMEOUT_MS,
+    env: spawnEnvironment(),
+  });
+  if (run.error || run.status !== 0) {
+    throw new Error(
+      `The ${cli.executable} installer failed. ${installFailureDetail(run)}`.trim(),
+    );
+  }
+}
+
 // npm and every CLI it installs globally start with `#!/usr/bin/env node`, so
 // they die instantly unless node is on PATH. The tray is launched by launchd
 // with the bare system PATH, which has no node on it — the failure there was
@@ -244,13 +325,19 @@ export function installOauthCli(providerId) {
   } else if (oauthCliPath(providerId)) {
     return;
   }
-  // Nothing to install *through npm*. Naming the command is the whole answer:
-  // running it here would mean the router fetching and executing a remote
-  // script because someone pressed a button.
+  // Installed from its vendor's script rather than from npm. Its npm siblings
+  // above are installed by this same button with no extra ceremony, and a
+  // button labelled "Install & Sign In" that instead prints a command for the
+  // operator to run is not a button -- it is a dead end that leaves anyone
+  // who is not already a developer with nowhere to go.
   if (!cli.npmPackage) {
-    throw new Error(
-      `${cli.executable} is not installed, and it does not come from npm. Install it yourself with: ${cli.installCommand}`,
-    );
+    installScriptCli(cli);
+    if (!oauthCliPath(providerId)) {
+      throw new Error(
+        `${cli.installCommand} finished, but no \`${cli.executable}\` appeared on PATH or in ~/.local/bin.`,
+      );
+    }
+    return;
   }
   npmInstallGlobal(cli.npmPackage, { label: `the official ${cli.executable} CLI` });
   if (providerId === "grok-oauth") {

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -114,6 +114,12 @@ const commonEnv = {
   MODEL_ROUTER_PORT: String(PORTS.router),
   MODEL_ROUTER_GROK_OAUTH_PORT: String(PORTS.grokOauth),
   GROK_OAUTH_FORWARD_BASE_URL: loopback(PORTS.grokOauth, "/v1"),
+  MODEL_ROUTER_CURSOR_BRIDGE_PORT: String(PORTS.cursorBridge),
+  // The `cursor-cli` provider's registry entry carries a checked-in loopback
+  // `baseUrl`, and an operator who moves the bridge port would otherwise leave
+  // the provider pointing at the old one. Publishing the resolved address as
+  // the provider's own override keeps the two in step from one source.
+  MODEL_ROUTER_CURSOR_BASE_URL: loopback(PORTS.cursorBridge, "/v1"),
   MODEL_ROUTER_QUIET: "1",
   CODEX_ROUTER_CALLER_KEY: callerKey,
   CODEX_ROUTER_INTERNAL_KEY: internalKey,
@@ -210,6 +216,13 @@ async function main() {
   const kimiForwarder = run(process.execPath, [path.join(SOURCE_ROOT, "src", "oauth-forwarder.mjs")]);
   const api = run(process.execPath, [path.join(SOURCE_ROOT, "src", "api-forwarder.mjs")]);
   const grokForwarder = run(process.execPath, [path.join(SOURCE_ROOT, "src", "grok-oauth-forwarder.mjs")]);
+  // Started unconditionally, like every forwarder above. Binding the port is
+  // all it does until a request arrives -- `cursor-agent` is spawned per turn,
+  // never at startup -- so a machine with no Cursor install pays a socket and
+  // nothing else, and answers 503 with the reason if anything does ask.
+  // Supervising it here is the point: a manually started bridge is one reboot
+  // away from every Cursor model 502ing with the service otherwise healthy.
+  const cursorBridge = run(process.execPath, [path.join(SOURCE_ROOT, "src", "cursor-cli-bridge.mjs")]);
   await Promise.all([
     waitForHealth(
       "OAuth forwarder",
@@ -234,6 +247,19 @@ async function main() {
       30_000,
       undefined,
       grokForwarder,
+    ),
+    // No Authorization header: unlike the forwarders above, the bridge holds
+    // no credential and the `cursor-cli` provider is `keyless`, so the router
+    // reaches it with a placeholder the way it reaches LM Studio. Requiring
+    // internal auth on /health would only diverge from the surface the
+    // provider actually uses.
+    waitForHealth(
+      "Cursor CLI bridge",
+      loopback(PORTS.cursorBridge, "/health"),
+      undefined,
+      30_000,
+      undefined,
+      cursorBridge,
     ),
   ]);
 

--- a/test/cursor-cli-bridge.test.mjs
+++ b/test/cursor-cli-bridge.test.mjs
@@ -1,0 +1,324 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+// Bound before the imports below: the bridge resolves its workspace from
+// STATE_DIR at construction, and these tests must never write into the real
+// state directory.
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "cursor-bridge-test-"));
+process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+
+const {
+  assistantDelta,
+  buildCursorPrompt,
+  createEventReader,
+  resultError,
+  usageFromResult,
+} = await import("../src/cursor-cli-turn.mjs");
+const { parseCursorModels, validCursorModelId } = await import("../src/cursor-cli.mjs");
+const { createCursorBridge, turnArguments } = await import("../src/cursor-cli-bridge.mjs");
+
+// A stand-in for `cursor-agent -p --output-format stream-json`. It emits the
+// exact event shapes read out of cursor-agent 2026.08.11-e8db854's own bundle,
+// so a change to the translation that would break against the real binary
+// breaks here too.
+function fakeAgent(directory, { deltas, result, usage, exitCode = 0, splitLines = false }) {
+  const binary = path.join(directory, "cursor-agent");
+  const events = [
+    { type: "system", subtype: "init", model: "gpt-5", session_id: "s1", permissionMode: "default" },
+    ...deltas.map((text) => ({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text }] },
+      session_id: "s1",
+      timestamp_ms: 1,
+    })),
+    {
+      type: "result",
+      subtype: exitCode === 0 ? "success" : "error",
+      is_error: exitCode !== 0,
+      duration_ms: 5,
+      duration_api_ms: 4,
+      result,
+      session_id: "s1",
+      request_id: "r1",
+      ...(usage ? { usage } : {}),
+    },
+  ];
+  const lines = events.map((event) => JSON.stringify(event));
+  // `splitLines` writes the NDJSON in fragments that do not align to newlines,
+  // which is what a real pipe does and what a naive line reader gets wrong.
+  const body = splitLines
+    ? `const blob = ${JSON.stringify(lines.join("\n") + "\n")};
+for (let i = 0; i < blob.length; i += 7) process.stdout.write(blob.slice(i, i + 7));`
+    : `process.stdout.write(${JSON.stringify(lines.join("\n") + "\n")});`;
+  writeFileSync(
+    binary,
+    `#!/usr/bin/env node
+process.stdin.resume();
+process.stdin.on("data", () => {});
+process.stdin.on("end", () => {
+  ${body}
+  process.exit(${exitCode});
+});
+`,
+    { mode: 0o755 },
+  );
+  chmodSync(binary, 0o755);
+  return binary;
+}
+
+async function withBridge(environment, run) {
+  const server = createCursorBridge({ environment });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const base = `http://127.0.0.1:${server.address().port}`;
+  try {
+    return await run(base);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test("a system prompt and one user turn are sent without transcript scaffolding", () => {
+  const prompt = buildCursorPrompt([
+    { role: "system", content: "You are terse." },
+    { role: "user", content: "What is 2+2?" },
+  ]);
+  assert.equal(prompt, "You are terse.\n\nWhat is 2+2?");
+  assert.doesNotMatch(prompt, /^User:/m);
+});
+
+test("a multi-turn conversation is rendered as a transcript with a reply instruction", () => {
+  const prompt = buildCursorPrompt([
+    { role: "system", content: "Be brief." },
+    { role: "user", content: "Hi" },
+    { role: "assistant", content: "Hello" },
+    { role: "user", content: "And now?" },
+  ]);
+  assert.match(prompt, /Be brief\./);
+  assert.match(prompt, /User: Hi/);
+  assert.match(prompt, /Assistant: Hello/);
+  assert.match(prompt, /Reply to the final message/);
+});
+
+test("array content parts are joined and an image part is named rather than dropped", () => {
+  const prompt = buildCursorPrompt([
+    {
+      role: "user",
+      content: [
+        { type: "text", text: "Describe" },
+        { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+      ],
+    },
+  ]);
+  assert.match(prompt, /Describe/);
+  assert.match(prompt, /image omitted/);
+  assert.doesNotMatch(prompt, /base64/);
+});
+
+test("assistant tool calls survive into the transcript", () => {
+  const prompt = buildCursorPrompt([
+    { role: "user", content: "Read it" },
+    { role: "assistant", content: "", tool_calls: [{ function: { name: "shell", arguments: '{"cmd":"ls"}' } }] },
+    { role: "tool", content: "a.txt" },
+    { role: "user", content: "Summarize" },
+  ]);
+  assert.match(prompt, /Assistant called shell with \{"cmd":"ls"\}/);
+  assert.match(prompt, /Tool result: a\.txt/);
+});
+
+test("the event reader reassembles objects split across chunk boundaries", () => {
+  const reader = createEventReader();
+  const line = JSON.stringify({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "hello world" }] } });
+  const collected = [];
+  for (let i = 0; i < line.length; i += 5) collected.push(...reader.push(line.slice(i, i + 5)));
+  assert.equal(collected.length, 0, "nothing is emitted before the newline arrives");
+  collected.push(...reader.push("\n"));
+  assert.equal(collected.length, 1);
+  assert.equal(assistantDelta(collected[0]), "hello world");
+});
+
+test("a non-JSON line on stdout is skipped instead of failing the turn", () => {
+  const reader = createEventReader();
+  const events = reader.push('warning: something\n{"type":"result","result":"ok"}\n');
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, "result");
+});
+
+test("usage maps cache counts into prompt tokens, and reports nothing when the CLI does", () => {
+  const mapped = usageFromResult({
+    type: "result",
+    usage: { input_tokens: 10, output_tokens: 5, cache_read_tokens: 3, cache_write_tokens: 2 },
+  });
+  assert.deepEqual(mapped, {
+    prompt_tokens: 15,
+    completion_tokens: 5,
+    total_tokens: 20,
+    prompt_tokens_details: { cached_tokens: 3 },
+  });
+  assert.equal(usageFromResult({ type: "result" }), undefined);
+  assert.equal(
+    usageFromResult({ type: "result", usage: { input_tokens: 0, output_tokens: 0 } }),
+    undefined,
+    "an all-zero block is missing data, not a free turn",
+  );
+});
+
+test("is_error is honoured even when the result text looks like a normal answer", () => {
+  assert.equal(
+    resultError({ type: "result", is_error: true, result: "You have run out of requests." }),
+    "You have run out of requests.",
+  );
+  assert.equal(resultError({ type: "result", is_error: false, result: "fine" }), undefined);
+});
+
+test("model ids accept Cursor's parameterized syntax and reject anything else", () => {
+  assert.equal(validCursorModelId("gpt-5"), "gpt-5");
+  assert.equal(
+    validCursorModelId("claude-opus-4-8[context=1m,effort=high,fast=false]"),
+    "claude-opus-4-8[context=1m,effort=high,fast=false]",
+  );
+  assert.equal(validCursorModelId("gpt-5; rm -rf /"), undefined);
+  assert.equal(validCursorModelId("--force"), undefined);
+  assert.equal(validCursorModelId(""), undefined);
+});
+
+test("`cursor-agent models` output parses to bare ids, markers and colour stripped", () => {
+  const ids = parseCursorModels(
+    [
+      "[2mAvailable models[0m",
+      "",
+      "[32mgpt-5[0m [2m- GPT-5[0m [2m(current, default)[0m",
+      "[36msonnet-4-thinking[0m [2m- Claude Sonnet 4 (Thinking)[0m",
+      "",
+      "[2mTip: use --model <id> to switch.[0m",
+    ].join("\n"),
+  );
+  assert.deepEqual(ids, ["gpt-5", "sonnet-4-thinking"]);
+});
+
+test("a turn is always read-only: ask mode, sandbox on, and never --force", () => {
+  const args = turnArguments("gpt-5", { stream: true });
+  assert.deepEqual(args, [
+    "--print",
+    "--output-format",
+    "stream-json",
+    "--stream-partial-output",
+    "--mode",
+    "ask",
+    "--sandbox",
+    "enabled",
+    "--model",
+    "gpt-5",
+  ]);
+  for (const forbidden of ["--force", "--yolo", "--trust", "--auto-review"]) {
+    assert.ok(!args.includes(forbidden), `${forbidden} must never be passed`);
+  }
+});
+
+test("a non-streaming completion returns the result text and usage", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "cursor-agent-stub-"));
+  const binary = fakeAgent(directory, {
+    deltas: ["Four"],
+    result: "Four",
+    usage: { input_tokens: 12, output_tokens: 1 },
+  });
+  await withBridge({ ...process.env, CURSOR_AGENT: binary }, async (base) => {
+    const response = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5", messages: [{ role: "user", content: "2+2?" }] }),
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.object, "chat.completion");
+    assert.equal(payload.choices[0].message.content, "Four");
+    assert.equal(payload.choices[0].finish_reason, "stop");
+    assert.equal(payload.usage.completion_tokens, 1);
+  });
+});
+
+test("a streaming completion emits deltas, a stop chunk, and [DONE]", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "cursor-agent-stub-"));
+  const binary = fakeAgent(directory, {
+    deltas: ["Hel", "lo ", "world"],
+    result: "Hello world",
+    splitLines: true,
+  });
+  await withBridge({ ...process.env, CURSOR_AGENT: binary }, async (base) => {
+    const response = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5", messages: [{ role: "user", content: "hi" }], stream: true }),
+    });
+    assert.equal(response.status, 200);
+    assert.match(response.headers.get("content-type") || "", /text\/event-stream/);
+    const body = await response.text();
+    const frames = body
+      .split("\n\n")
+      .map((frame) => frame.replace(/^data: /, "").trim())
+      .filter(Boolean);
+    assert.equal(frames.at(-1), "[DONE]");
+    const chunks = frames.slice(0, -1).map((frame) => JSON.parse(frame));
+    const text = chunks.map((chunk) => chunk.choices?.[0]?.delta?.content || "").join("");
+    assert.equal(text, "Hello world");
+    assert.equal(chunks.at(-1).choices[0].finish_reason, "stop");
+  });
+});
+
+test("a failed run reports the error inside the stream rather than ending it cleanly", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "cursor-agent-stub-"));
+  const binary = fakeAgent(directory, {
+    deltas: [],
+    result: "You have hit your usage limit.",
+    exitCode: 1,
+  });
+  await withBridge({ ...process.env, CURSOR_AGENT: binary }, async (base) => {
+    const response = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5", messages: [{ role: "user", content: "hi" }], stream: true }),
+    });
+    const body = await response.text();
+    assert.match(body, /usage limit/);
+    assert.match(body, /"type":"server_error"/);
+    assert.match(body, /\[DONE\]/);
+    assert.doesNotMatch(body, /"finish_reason":"stop"/);
+  });
+});
+
+test("a non-streaming failure is a 502 with an OpenAI-shaped error body", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "cursor-agent-stub-"));
+  const binary = fakeAgent(directory, { deltas: [], result: "model not available", exitCode: 1 });
+  await withBridge({ ...process.env, CURSOR_AGENT: binary }, async (base) => {
+    const response = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5", messages: [{ role: "user", content: "hi" }] }),
+    });
+    assert.equal(response.status, 502);
+    const payload = await response.json();
+    assert.match(payload.error.message, /model not available/);
+  });
+});
+
+test("an unusable model id is refused before anything is spawned", async () => {
+  await withBridge({ ...process.env, CURSOR_AGENT: "/nonexistent/cursor-agent" }, async (base) => {
+    const response = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "gpt-5 --force", messages: [{ role: "user", content: "hi" }] }),
+    });
+    assert.equal(response.status, 400);
+    assert.match((await response.json()).error.message, /Unknown or unusable model/);
+  });
+});
+
+test("the bridge answers /health without touching cursor-agent", async () => {
+  await withBridge({ ...process.env, CURSOR_AGENT: "/nonexistent/cursor-agent" }, async (base) => {
+    const response = await fetch(`${base}/health`);
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true, bridge: "cursor-cli" });
+  });
+});

--- a/test/cursor-cli-bridge.test.mjs
+++ b/test/cursor-cli-bridge.test.mjs
@@ -11,8 +11,9 @@ const stateDir = mkdtempSync(path.join(os.tmpdir(), "cursor-bridge-test-"));
 process.env.MODEL_ROUTER_STATE_DIR = stateDir;
 
 const {
-  assistantDelta,
+  assistantText,
   buildCursorPrompt,
+  createAssistantAccumulator,
   createEventReader,
   resultError,
   usageFromResult,
@@ -136,7 +137,7 @@ test("the event reader reassembles objects split across chunk boundaries", () =>
   assert.equal(collected.length, 0, "nothing is emitted before the newline arrives");
   collected.push(...reader.push("\n"));
   assert.equal(collected.length, 1);
-  assert.equal(assistantDelta(collected[0]), "hello world");
+  assert.equal(assistantText(collected[0]), "hello world");
 });
 
 test("a non-JSON line on stdout is skipped instead of failing the turn", () => {
@@ -209,12 +210,57 @@ test("a turn is always read-only: ask mode, sandbox on, and never --force", () =
     "ask",
     "--sandbox",
     "enabled",
+    "--trust",
     "--model",
     "gpt-5",
   ]);
-  for (const forbidden of ["--force", "--yolo", "--trust", "--auto-review"]) {
+  // --trust used to be on this list. cursor-agent refuses any directory it has
+  // not been told to trust -- "Workspace Trust Required", exit 1, before it
+  // reads the prompt -- so without it every live turn failed. It grants
+  // nothing here: the workspace is an empty directory the router owns, and
+  // running commands is still governed by ask mode and the sandbox.
+  for (const forbidden of ["--force", "--yolo", "--auto-review"]) {
     assert.ok(!args.includes(forbidden), `${forbidden} must never be passed`);
   }
+});
+
+// Regression for the first live turn: --stream-partial-output does not replace
+// the message-level emitter, it runs beside it. A turn answering "391"
+// produced two assistant events both reading "391", and concatenating them
+// streamed "391391".
+test("the final whole-message flush is not streamed a second time", () => {
+  const assistant = createAssistantAccumulator();
+  const event = (text) => ({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "text", text }] },
+  });
+  assert.equal(assistant.push(event("391")), "391", "the delta is new text");
+  assert.equal(assistant.push(event("391")), "", "the flush repeats it and must be dropped");
+  assert.equal(assistant.text(), "391");
+});
+
+test("a flush that restates everything and adds a tail emits only the tail", () => {
+  const assistant = createAssistantAccumulator();
+  const event = (text) => ({
+    type: "assistant",
+    message: { role: "assistant", content: [{ type: "text", text }] },
+  });
+  assert.equal(assistant.push(event("Hel")), "Hel");
+  assert.equal(assistant.push(event("lo")), "lo");
+  assert.equal(assistant.push(event("Hello world")), " world");
+  assert.equal(assistant.text(), "Hello world");
+});
+
+test("usage is read under both spellings cursor-agent uses", () => {
+  // The bundle emits snake_case; the first live turn returned camelCase, and
+  // reading only one meant real turns reported no usage at all.
+  const camel = usageFromResult({
+    type: "result",
+    usage: { inputTokens: 18_951, outputTokens: 53, cacheReadTokens: 3_200, cacheWriteTokens: 0 },
+  });
+  assert.equal(camel.completion_tokens, 53);
+  assert.equal(camel.prompt_tokens, 18_951 + 3_200);
+  assert.equal(camel.prompt_tokens_details.cached_tokens, 3_200);
 });
 
 test("a non-streaming completion returns the result text and usage", async () => {

--- a/test/cursor-cli-bridge.test.mjs
+++ b/test/cursor-cli-bridge.test.mjs
@@ -322,3 +322,53 @@ test("the bridge answers /health without touching cursor-agent", async () => {
     assert.deepEqual(await response.json(), { ok: true, bridge: "cursor-cli" });
   });
 });
+
+// --- wiring guards -------------------------------------------------------
+// The bridge is useless if the service does not supervise it and the registry
+// does not point at the port it actually binds. Both are cross-file facts no
+// runtime test in this file can see, so they are asserted against the sources
+// the way fetch-transport.test.mjs asserts its own invariant.
+
+const { readFileSync: readSource } = await import("node:fs");
+const { fileURLToPath: toPath } = await import("node:url");
+const repoRoot = toPath(new URL("..", import.meta.url));
+
+test("the service starts and health-gates the bridge", () => {
+  const start = readSource(path.join(repoRoot, "src", "start.mjs"), "utf8");
+  assert.match(
+    start,
+    /cursor-cli-bridge\.mjs/,
+    "start.mjs must spawn the bridge; a manually started one is a reboot away from every Cursor model 502ing",
+  );
+  assert.match(
+    start,
+    /waitForHealth\(\s*"Cursor CLI bridge"/,
+    "the bridge must be health-gated like every other forwarder",
+  );
+});
+
+test("the port the service publishes is the port the provider is pointed at", async () => {
+  const { DEFAULT_PORTS } = await import("../src/paths.mjs");
+  const { PROVIDERS } = await import("../src/model-registry.mjs");
+  const provider = PROVIDERS.get("cursor-cli");
+  assert.ok(provider, "the cursor-cli provider must be registered");
+
+  // The registry entry carries a checked-in address; DEFAULT_PORTS carries the
+  // port the bridge binds. They are one fact written in two files, and nothing
+  // else would notice them drifting apart.
+  assert.equal(
+    new URL(provider.baseUrl).port,
+    String(DEFAULT_PORTS.cursorBridge),
+    "config/cursor/cursor.json baseUrl and DEFAULT_PORTS.cursorBridge must name the same port",
+  );
+
+  // And an operator who moves the port must not be left with a provider still
+  // pointed at the default, so start.mjs republishes the resolved address
+  // through this provider's own override variable.
+  const start = readSource(path.join(repoRoot, "src", "start.mjs"), "utf8");
+  assert.match(
+    start,
+    new RegExp(`${provider.baseUrlEnv}:\\s*loopback\\(PORTS\\.cursorBridge`),
+    `start.mjs must publish ${provider.baseUrlEnv} from PORTS.cursorBridge`,
+  );
+});

--- a/test/cursor-cli-signin.test.mjs
+++ b/test/cursor-cli-signin.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "cursor-signin-test-"));
+process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+
+const { cursorSignedIn, parseCursorModels } = await import("../src/cursor-cli.mjs");
+const {
+  hasSignInCli,
+  installOauthCli,
+  oauthLoginArgs,
+  providerOnboardingSnapshot,
+} = await import("../src/provider-onboarding.mjs");
+
+// A stand-in for `cursor-agent status`, which exits 0 whether or not anybody
+// is signed in -- the answer is only ever in the text.
+function fakeStatus(text, { exitCode = 0 } = {}) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "cursor-status-stub-"));
+  const binary = path.join(directory, "cursor-agent");
+  writeFileSync(
+    binary,
+    `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(text)});\nprocess.exit(${exitCode});\n`,
+    { mode: 0o755 },
+  );
+  chmodSync(binary, 0o755);
+  return binary;
+}
+
+test("signed out is read from the text, not the exit code", () => {
+  const binary = fakeStatus("Not logged in\n");
+  const status = cursorSignedIn({ environment: { ...process.env, CURSOR_AGENT: binary } });
+  assert.equal(status.installed, true);
+  assert.equal(status.signedIn, false, "cursor-agent exits 0 while signed out");
+});
+
+test("a signed-in account reads as signed in", () => {
+  const binary = fakeStatus("Logged in as duola@hypercho.com\n");
+  const status = cursorSignedIn({ environment: { ...process.env, CURSOR_AGENT: binary } });
+  assert.equal(status.signedIn, true);
+});
+
+test("silence is unknown, not signed in", () => {
+  const binary = fakeStatus("");
+  const status = cursorSignedIn({ environment: { ...process.env, CURSOR_AGENT: binary } });
+  assert.equal(status.signedIn, false);
+  assert.equal(status.unknown, true, "a reworked status message must degrade to 'cannot tell'");
+});
+
+// `commandOnPath` shells out to `which`, which reads the real process
+// environment rather than the object handed to cursorAgentPath -- so hiding
+// the binary means mutating process.env, not passing a different PATH in.
+function withoutCursorAgent(run) {
+  const saved = { PATH: process.env.PATH, HOME: process.env.HOME, CURSOR_AGENT: process.env.CURSOR_AGENT };
+  process.env.PATH = "/nonexistent";
+  process.env.HOME = mkdtempSync(path.join(os.tmpdir(), "cursor-nohome-"));
+  delete process.env.CURSOR_AGENT;
+  try {
+    return run();
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test("a missing binary is reported as not installed rather than throwing", () => {
+  const status = withoutCursorAgent(() => cursorSignedIn());
+  assert.equal(status.installed, false);
+  assert.equal(status.signedIn, false);
+});
+
+test("cursor-cli is a sign-in provider and signs in with `login`", () => {
+  assert.equal(hasSignInCli("cursor-cli"), true);
+  assert.deepEqual(oauthLoginArgs("cursor-cli"), ["login"]);
+});
+
+test("the tray is never offered a button that would curl|bash on the user's behalf", () => {
+  // With no cursor-agent anywhere, the install path must refuse and name the
+  // command rather than reach for an npm package that does not exist.
+  withoutCursorAgent(() => {
+    assert.throws(
+      () => installOauthCli("cursor-cli"),
+      (error) => {
+        assert.match(error.message, /curl https:\/\/cursor\.com\/install/);
+        // The point is that the router refuses to run it, not that the word
+        // "npm" is absent -- the message says it does not come from npm.
+        assert.match(error.message, /Install it yourself/i);
+        return true;
+      },
+      "installing cursor-agent must be refused with the exact command",
+    );
+  });
+});
+
+test("the tray row tells the truth about a signed-out CLI", () => {
+  const row = providerOnboardingSnapshot().providers.find((p) => p.id === "cursor-cli");
+  assert.ok(row, "cursor-cli must appear in the onboarding snapshot");
+  // Presented as oauth so the tray renders its sign-in button; a keyless row
+  // would render "ready" and there would be nothing to click.
+  assert.equal(row.kind, "oauth");
+  assert.ok(
+    ["install", "login", "ready"].includes(row.action),
+    `unexpected action ${row.action}`,
+  );
+  // The bug this replaced: keyless meant configured:true forever, so the tray
+  // claimed Cursor was connected while cursor-agent was signed out.
+  assert.equal(
+    row.configured,
+    row.action === "ready",
+    "configured must track the CLI's real sign-in state",
+  );
+});
+
+test("model listing survives real chalk decoration", () => {
+  assert.deepEqual(parseCursorModels("Available models\n\ngpt-5 - GPT-5 (default)\n"), ["gpt-5"]);
+});

--- a/test/cursor-cli-signin.test.mjs
+++ b/test/cursor-cli-signin.test.mjs
@@ -78,21 +78,16 @@ test("cursor-cli is a sign-in provider and signs in with `login`", () => {
   assert.deepEqual(oauthLoginArgs("cursor-cli"), ["login"]);
 });
 
-test("the tray is never offered a button that would curl|bash on the user's behalf", () => {
-  // With no cursor-agent anywhere, the install path must refuse and name the
-  // command rather than reach for an npm package that does not exist.
+test("a missing cursor-agent is an install action, not a dead end", () => {
+  // This used to assert a refusal that told the user to run curl themselves.
+  // That is a dead end for anyone who is not already a developer, and the npm
+  // siblings of this CLI are installed by the very same button, so the tray
+  // now installs Cursor too. What keeps that defensible is the origin guard
+  // exercised below, plus fetching the script before running it.
   withoutCursorAgent(() => {
-    assert.throws(
-      () => installOauthCli("cursor-cli"),
-      (error) => {
-        assert.match(error.message, /curl https:\/\/cursor\.com\/install/);
-        // The point is that the router refuses to run it, not that the word
-        // "npm" is absent -- the message says it does not come from npm.
-        assert.match(error.message, /Install it yourself/i);
-        return true;
-      },
-      "installing cursor-agent must be refused with the exact command",
-    );
+    const row = providerOnboardingSnapshot().providers.find((p) => p.id === "cursor-cli");
+    assert.equal(row.cliInstalled, false);
+    assert.equal(row.action, "install", "the tray must offer to install it");
   });
 });
 
@@ -117,4 +112,39 @@ test("the tray row tells the truth about a signed-out CLI", () => {
 
 test("model listing survives real chalk decoration", () => {
   assert.deepEqual(parseCursorModels("Available models\n\ngpt-5 - GPT-5 (default)\n"), ["gpt-5"]);
+});
+
+// --- installer guards ----------------------------------------------------
+// The button now fetches and runs Cursor's install script, so the guard that
+// keeps that defensible has to be exercisable without downloading 200MB.
+
+const { installScriptOrigin, signInCliDescriptor } = await import(
+  "../src/provider-onboarding.mjs"
+);
+
+test("the installer URL is pinned to Cursor's own host", () => {
+  const cursor = signInCliDescriptor("cursor-cli");
+  assert.equal(installScriptOrigin(cursor).hostname, "cursor.com");
+  assert.equal(installScriptOrigin(cursor).protocol, "https:");
+});
+
+test("an installer pointed anywhere else is refused before it runs", () => {
+  for (const command of [
+    "curl https://cursor.com.evil.example/install | bash",
+    "curl https://raw.githubusercontent.com/x/y/install.sh | bash",
+    "curl http://cursor.com/install | bash",
+  ]) {
+    assert.throws(
+      () => installScriptOrigin({ executable: "cursor-agent", installCommand: command, installHost: "cursor.com" }),
+      /Refusing to run an installer|Invalid URL/,
+      `${command} must not be fetched`,
+    );
+  }
+});
+
+test("a descriptor with no install URL cannot silently run nothing", () => {
+  assert.throws(
+    () => installScriptOrigin({ executable: "x", installCommand: "make install", installHost: "cursor.com" }),
+    /no install URL/,
+  );
 });

--- a/test/cursor-models.test.mjs
+++ b/test/cursor-models.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+// Bound before the imports: user-models and provider-selection resolve their
+// paths at module load and must never touch real state.
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "cursor-models-test-"));
+process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+process.env.MODEL_ROUTER_USER_MODELS = path.join(stateDir, "user-models.json");
+
+const {
+  cursorServedModels,
+  cursorSnapshot,
+  isCursorModelEnabled,
+  setCursorModelEnabled,
+} = await import("../src/cursor-models.mjs");
+const { readUserModels, writeUserModels } = await import("../src/user-models.mjs");
+const { COMMANDS } = await import("../src/desktop-commands.mjs");
+
+const served = (ids) => async () => ({
+  ok: true,
+  json: async () => ({ data: ids.map((id) => ({ id })) }),
+});
+const signedOut = async () => ({
+  ok: false,
+  status: 503,
+  json: async () => ({ error: { message: "cursor-agent is installed but not signed in" } }),
+});
+const bridgeDown = async () => {
+  throw new Error("connection refused");
+};
+
+test("the roster comes from the bridge, deduplicated and sorted", async () => {
+  const result = await cursorServedModels({ fetchImpl: served(["gpt-5", "auto", "gpt-5", ""]) });
+  assert.equal(result.reachable, true);
+  assert.equal(result.signedIn, true);
+  assert.deepEqual(result.models, ["auto", "gpt-5"]);
+  assert.match(String(result.baseUrl), /^http:\/\/127\.0\.0\.1:4209/);
+});
+
+test("signed out and bridge down are different states with different fixes", async () => {
+  const out = await cursorServedModels({ fetchImpl: signedOut });
+  assert.equal(out.reachable, true, "the bridge answered, so it is running");
+  assert.equal(out.signedIn, false);
+  assert.match(out.detail, /not signed in/, "the CLI's own reason is passed through");
+
+  const down = await cursorServedModels({ fetchImpl: bridgeDown });
+  assert.equal(down.reachable, false);
+  assert.equal(down.signedIn, false);
+  assert.match(down.detail, /not running/);
+});
+
+test("checking a model publishes it, and unchecking removes it", async () => {
+  writeUserModels([]);
+  setCursorModelEnabled("gpt-5", true);
+  assert.equal(isCursorModelEnabled("gpt-5"), true);
+  const entry = readUserModels().find((m) => m.upstreamModel === "gpt-5");
+  assert.equal(entry.provider, "cursor-cli");
+  assert.equal(entry.slug, "cursor-cli/gpt-5");
+  // The one thing a person must see before selecting it in the picker.
+  assert.match(entry.displayName, /answers only/);
+  assert.equal(entry.supportsApplyPatchTool, false);
+
+  setCursorModelEnabled("gpt-5", false);
+  assert.equal(isCursorModelEnabled("gpt-5"), false);
+  assert.deepEqual(readUserModels(), []);
+});
+
+test("a re-enabled model does not collide with another model's priority", async () => {
+  writeUserModels([]);
+  for (const id of ["a-model", "b-model", "c-model"]) setCursorModelEnabled(id, true);
+  setCursorModelEnabled("b-model", false);
+  setCursorModelEnabled("b-model", true);
+  const priorities = readUserModels().map((m) => m.priority);
+  assert.equal(
+    new Set(priorities).size,
+    priorities.length,
+    "priorities are renumbered on write, so a disable/re-enable cycle cannot collide",
+  );
+});
+
+test("a curated model the account no longer offers stays visible", async () => {
+  writeUserModels([]);
+  setCursorModelEnabled("retired-model", true);
+  const snapshot = await cursorSnapshot({ fetchImpl: served(["gpt-5"]) });
+  const retired = snapshot.models.find((m) => m.id === "retired-model");
+  assert.ok(retired, "hiding it would leave a picker route with no way to clear it");
+  assert.equal(retired.served, false);
+  assert.equal(retired.enabled, true);
+  assert.equal(snapshot.models.find((m) => m.id === "gpt-5").enabled, false);
+  writeUserModels([]);
+});
+
+test("the tray command accepts Cursor's parameterized ids and rejects argv injection", () => {
+  assert.deepEqual(
+    COMMANDS.set_cursor_model_enabled({ model: "gpt-5", enabled: true }).args,
+    ["local-models", "cursor-set", "gpt-5", "on"],
+  );
+  assert.deepEqual(
+    COMMANDS.set_cursor_model_enabled({
+      model: "claude-opus-4-8[context=1m,effort=high]",
+      enabled: false,
+    }).args,
+    ["local-models", "cursor-set", "claude-opus-4-8[context=1m,effort=high]", "off"],
+  );
+  for (const bad of ["gpt-5; rm -rf /", "--force", "", "a b", "gpt-5[unclosed"]) {
+    assert.throws(
+      () => COMMANDS.set_cursor_model_enabled({ model: bad, enabled: true }),
+      /Unknown Cursor model/,
+      `${JSON.stringify(bad)} must be refused`,
+    );
+  }
+});
+
+// --- panel wiring guards -------------------------------------------------
+// apps/desktop/ui/app.js is an IIFE with no DOM harness here, so the panel is
+// guarded structurally, the way desktop-ui.test.mjs guards the rest of it. The
+// failure these catch is the classic one: a section that renders into an id
+// nothing declares, a checkbox naming a command no host implements, or a
+// listener wired to an element that was renamed.
+
+const { readFileSync: readUiSource } = await import("node:fs");
+const { fileURLToPath: uiPath } = await import("node:url");
+const repo = uiPath(new URL("..", import.meta.url));
+const read = (...parts) => readUiSource(path.join(repo, ...parts), "utf8");
+
+test("the panel section exists, is listened to, and renders", () => {
+  const html = read("apps", "desktop", "ui", "index.html");
+  const app = read("apps", "desktop", "ui", "app.js");
+  assert.match(html, /id="cursor-section"/, "the section element must exist");
+  assert.match(app, /getElementById\("cursor-section"\)/, "app.js must bind it");
+  assert.match(
+    app,
+    /elements\.cursorSection\.addEventListener\("change", handleCursorModelToggle\)/,
+    "a section with no listener renders checkboxes that do nothing",
+  );
+  assert.match(app, /renderCursorSection\(local\.cursor/, "it must render from the snapshot key");
+});
+
+test("every host implements the command the checkbox names", () => {
+  const app = read("apps", "desktop", "ui", "app.js");
+  assert.match(app, /data-command="set_cursor_model_enabled"/);
+  assert.match(app, /call\("set_cursor_model_enabled"/);
+  // Electron dispatches generically through COMMANDS; Tauri needs the command
+  // declared and registered by hand, and a missing registration fails only at
+  // runtime with "command not found".
+  assert.ok(COMMANDS.set_cursor_model_enabled, "desktop-commands must define it");
+  const rust = read("apps", "desktop", "src-tauri", "src", "main.rs");
+  assert.match(rust, /async fn set_cursor_model_enabled/, "Tauri must implement it");
+  assert.match(
+    rust,
+    /^\s*set_cursor_model_enabled,$/m,
+    "Tauri must also register it in the handler list",
+  );
+});
+
+test("the snapshot key the panel reads is the key control.mjs writes", () => {
+  const control = read("src", "control.mjs");
+  assert.match(control, /cursor: await .*cursorSnapshot\(\)/, "the panel refresh must carry it");
+  assert.match(control, /cursor-set/, "the toggle action must exist");
+});

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -57,16 +57,18 @@ test("provider selection keeps backward compatibility and can hide the final pro
     // credential to configure and they are always available. Everything else
     // has to authenticate before it counts.
     assert.deepEqual(configuredProviderIds(), [
+      "cursor-cli",
       "custom",
       "kilo-free",
       "lmstudio",
       "local",
       "opencode-free",
     ]);
-    assert.deepEqual(defaultProviderIds(), ["lmstudio", "local"]);
+    assert.deepEqual(defaultProviderIds(), ["cursor-cli", "lmstudio", "local"]);
     delete process.env.KIMI_API_KEY;
     writeProviderCredential("deepseek", "TEST_DEEPSEEK_SELECTION_KEY");
     assert.deepEqual(configuredProviderIds(), [
+      "cursor-cli",
       "custom",
       "deepseek",
       "kilo-free",
@@ -74,7 +76,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
       "local",
       "opencode-free",
     ]);
-    assert.deepEqual(defaultProviderIds(), ["deepseek", "lmstudio", "local"]);
+    assert.deepEqual(defaultProviderIds(), ["cursor-cli", "deepseek", "lmstudio", "local"]);
 
     writeProviderSelection(["chatgpt-oauth"]);
     assert.deepEqual(readProviderSelection(), ["grok-oauth"]);

--- a/test/setup.test.mjs
+++ b/test/setup.test.mjs
@@ -47,9 +47,9 @@ test("automatic selection-only setup exposes only configured providers", () => {
     );
     // Local backends need no credential and are included by default, while
     // anonymous off-box endpoints require an explicit --providers choice.
-    assert.deepEqual(JSON.parse(output).providers, ["deepseek", "lmstudio", "local"]);
+    assert.deepEqual(JSON.parse(output).providers, ["cursor-cli", "deepseek", "lmstudio", "local"]);
     const selection = JSON.parse(readFileSync(path.join(stateDir, "enabled-providers.json"), "utf8"));
-    assert.deepEqual(selection.providers, ["deepseek", "lmstudio", "local"]);
+    assert.deepEqual(selection.providers, ["cursor-cli", "deepseek", "lmstudio", "local"]);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }
@@ -174,9 +174,9 @@ test("ensure-configured does not auto-select anonymous providers", () => {
         },
       },
     );
-    assert.deepEqual(JSON.parse(output).providers, ["deepseek", "lmstudio", "local"]);
+    assert.deepEqual(JSON.parse(output).providers, ["cursor-cli", "deepseek", "lmstudio", "local"]);
     const selection = JSON.parse(readFileSync(path.join(stateDir, "enabled-providers.json"), "utf8"));
-    assert.deepEqual(selection.providers, ["deepseek", "lmstudio", "local"]);
+    assert.deepEqual(selection.providers, ["cursor-cli", "deepseek", "lmstudio", "local"]);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }
@@ -250,7 +250,7 @@ test("configured setup mode also excludes anonymous providers by default", () =>
         },
       },
     );
-    assert.deepEqual(JSON.parse(output).providers, ["deepseek", "lmstudio", "local"]);
+    assert.deepEqual(JSON.parse(output).providers, ["cursor-cli", "deepseek", "lmstudio", "local"]);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }

--- a/test/target-isolation.test.mjs
+++ b/test/target-isolation.test.mjs
@@ -37,6 +37,7 @@ test("codex owns the default port block", () => {
     router: 4202,
     api: 4203,
     grokOauth: 4208,
+    cursorBridge: 4209,
   });
 });
 
@@ -60,7 +61,17 @@ test("operators can keep an explicitly configured legacy block during migration"
       },
     ),
   );
-  assert.deepEqual(ports, { gateway: 4100, oauth: 4101, router: 4102, api: 4103, grokOauth: 4108 });
+  // cursorBridge stays on its default here on purpose: the legacy block
+  // predates it, so there is no 41xx port it could migrate back to. An
+  // operator pinned to the old block still reaches the bridge on 4209.
+  assert.deepEqual(ports, {
+    gateway: 4100,
+    oauth: 4101,
+    router: 4102,
+    api: 4103,
+    grokOauth: 4108,
+    cursorBridge: 4209,
+  });
 });
 
 test("removed targets are rejected rather than silently mapped to codex", () => {


### PR DESCRIPTION
Draft: the code is complete and the suite is green, but **no live Cursor generation has ever run** — the development account has no remaining usage. See "What is not verified" below before merging.

## For a user, with no terminal

Open the tray → **Connections** → **Cursor CLI (Local)** → **Install & Sign In**. That installs `cursor-agent` if missing, then opens a Terminal window into Cursor's browser sign-in. Afterwards the **Cursor CLI** section lists the account's models; tick the ones you want and they show up in the Codex picker.

The first revision of this PR made that button raise an error telling the user to run a curl command instead. That was a dead end for anyone not already comfortable in a terminal, and inconsistent besides — every other sign-in CLI here is installed by the same press. Fixed.

## Why a bridge, and not a target

Cursor CLI cannot be a router target, and this is not a gap waiting to be filled:

- `~/.cursor/cli-config.json` has no endpoint or provider keys — only `model`, `permissions`, `sandbox`, and display settings.
- `--endpoint` exists but speaks Cursor's own protocol, not anything OpenAI-shaped.
- `bedrock` mode validates the credential against Cursor's backend.
- The IDE's "Override OpenAI Base URL" is IDE-only and refuses private-network addresses.

So Cursor runs the other way round. `cursor-cli` is a keyless provider on a loopback address, like `local` and `lmstudio`, but what serves that address is the router's own bridge: it spawns `cursor-agent -p --output-format stream-json` per request and adapts it to chat completions. No credential is stored or read — the sign-in stays in cursor-agent's own store.

AGENTS.md records the above so nobody re-derives it.

## Design constraints held

- **Read-only, always.** `turnArguments()` pins `--mode ask --sandbox enabled` and never passes `--force`, `--yolo`, `--trust`, or `--auto-review`. This process takes prompt text off a socket and hands it to an agent holding shell and file tools.
- **Empty workspace.** The agent runs in a directory the router owns, not the caller's repository. A chat-completions request is a prompt; everything the model should see was put there by the caller.
- **Stateless turns.** History is rendered into the prompt; `--resume` is never passed, so identical requests cannot answer differently based on an unrelated caller's session.
- **Service-supervised.** `start.mjs` launches and health-gates the bridge. A manually started one is a reboot away from every Cursor model 502ing while the router reports itself healthy.
- **No `curl | bash` from a button.** Cursor does not ship on npm, so the tray's one-click install path refuses and names the command instead.

## Known limitation

`cursor-agent` emits text and its own tool events, never OpenAI `tool_calls`, and Codex dispatches every turn through tool calls. **Cursor models answer questions but cannot drive an agentic Codex turn.** Documented rather than left to be debugged.

## Bug fixed along the way

The tray reported Cursor as connected whenever the provider existed — `cursor-cli` is keyless, so the generic row read "no key needed" as "ready" while cursor-agent sat signed out. The row now reflects the CLI's real state and gains a working Sign in button, reusing the existing oauth rendering with no UI code.

## Tray

The Cursor row appears in Connections for free (the row list is built from the registry). Two things were added on top:

**A working Sign in button.** The tray already renders "Sign in" / "Reconnect" for any row reporting `kind: "oauth"`, so this needed no UI code — only making Cursor report an oauth-shaped row. It also fixed a bug: `cursor-cli` is keyless, so `providerNeedsNoKey` was true and the generic row reported Cursor as **connected** while cursor-agent sat signed out. The only way to discover that was every model 502ing.

Two Cursor-specific wrinkles: it does not ship on npm, so the tray installs it from Cursor's own script — fetched to a file and then run, never piped into a shell, with the URL pinned to `cursor.com` and the response checked for a shell shebang before anything executes; and it keeps its session in the OS credential store rather than a file, so the mtime probe that detects a finished sign-in had nothing to watch — `cursor-agent status` is used instead (local, ~0.5s, safe on a refresh; `models` is a network round trip and is not).

**A model curation section**, beside LM Studio's and built the same way, writing the same user-model overlay so the panel and `bin/curate-models cursor-cli` remain two doors to one state. It reads the bridge's own `/v1/models` rather than shelling out to the CLI, so a timed panel refresh costs a loopback GET behind the bridge's 60s cache instead of a round trip to Cursor. Three states are distinguished — bridge down, signed out, and listed — because the fixes differ.

Published entries are labelled "(Cursor, answers only)", since the picker is the last place someone learns these models cannot emit tool calls.

The native macOS tray needs nothing: it has no LM Studio section either, and `RouterProviderInfo.legacyFallback` exists for routers older than this feature.

## What is verified

- Bridge serves loopback; `/health`, `/v1/models`, and the port override confirmed against a running instance.
- The router's own `discoverProviderModels("cursor-cli")` reaches it and surfaces actionable reasons.
- The stream-json event schema was read out of cursor-agent 2026.08.11-e8db854's own bundle, not guessed — including the two facts the translation rests on: under `--stream-partial-output` an `assistant` event carries the delta, and `result` carries the complete text.
- The tray sign-in path drives `cursor-agent login` through a stub terminal launcher.
- Port-drift guard verified by injecting the drift and watching it fail.
- The tray sign-in path drives `cursor-agent login` through a stub terminal launcher.
- The panel snapshot was exercised against a running bridge and a stopped one, reporting both states distinguishably.
- The Rust model-id validator was compiled and exercised standalone (4 valid forms accepted, 7 injection/malformed refused) rather than trusting a full Tauri build.
- Panel wiring is guarded structurally and each guard was mutation-tested by breaking it.
- The installer was run for real into an isolated `HOME`: 10.4s, `cursor-agent` installed, resolved by `oauthCliPath`, `--version` reporting `2026.08.11-e8db854`. The development machine's own install was untouched.
- The installer origin guard is exported and tested: `cursor.com.evil.example`, a GitHub raw URL, and an `http://` downgrade are each refused before anything executes.
- Full suite green on current main: **1457 pass, 0 fail**.

## What is NOT verified

**One successful live generation.** Everything downstream of a real, authenticated, in-quota Cursor turn is unexercised. Do not merge as proven until someone runs:

```sh
cursor-agent login
./bin/model-router codex providers enable cursor-cli
./bin/curate-models cursor-cli
```

## Test plan

- [x] `node --test test/*.test.mjs` — 1457 pass, 0 fail
- [x] Bridge health, models, and port override against a running instance
- [x] Tray sign-in path via stub terminal launcher
- [ ] One live generation through a signed-in, in-quota Cursor account
- [ ] `bin/curate-models cursor-cli` against the real `/v1/models`
- [ ] A routed turn selected from the Codex picker
- [x] `cursor-agent` installed end to end through the tray's install path (isolated HOME)
- [ ] The tray Sign in button pressed against a real Terminal
- [ ] The panel curation section rendered in a rebuilt tray

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S2jpUWGe7PyfHLuFyeP9UD



