### PR TITLE
fix(usage): stop billing sealed reasoning ciphertext to the prompt-token estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,37 @@
   and an entry curated earlier keeps what it was given — an additive run never
   rewrites metadata a user may have tuned by hand, so repair it in
   `user-models.json` or `--remove` and curate it again.
+
+- **The substituted prompt-token estimate charged the session for reasoning no
+  model ever reads.** When a provider answers with `prompt_tokens: 0` the
+  router substitutes an estimate of the prompt it just sent, dividing the
+  serialized request body by 3.3 bytes per token. That divisor is calibrated
+  against text a model reads, and the body is not: most of a Codex turn is
+  `encrypted_content`, the sealed chain of thought carried on every reasoning
+  item. The gateway's Responses-to-chat bridge drops reasoning items outright
+  and no routed provider can decrypt another vendor's token, so those bytes buy
+  zero prompt tokens — but they were counted, and there can be a lot of them.
+  The router already sheds some: a reasoning item that carries summary text and
+  sits immediately before the turn it belongs to is rewritten into assistant
+  text, ciphertext and all. An item with an empty summary, which is what a
+  provider returns when it has none to give, is forwarded whole. Measured
+  through the router itself on a twelve-turn tool loop: with summaries no
+  ciphertext reaches the gateway at all, and without them every blob does and
+  they are 64% of the body the router sends. Charging that 64% at 3.3 bytes per
+  token is where the field reports of 3.9x–4.7x come from, and an estimate that
+  high clears `autoCompact` on a window the session is nowhere near, so it
+  compacted on every turn the provider reported as zero (#266). The
+  estimate now discounts `encrypted_content` and counts everything else. The
+  subtraction is deliberately one-sided: an unrecognized field is still counted,
+  so a body shape nobody anticipated errs high rather than estimating near zero,
+  and JSON escaping, structural scaffolding, and base64 image data all stay on
+  the bill for the same reason. The clamp to the declared context window is
+  unchanged, but it now means something. It used to fire on conversations at a
+  quarter of the limit, and since `autoCompact` is 85% of the window a clamped
+  estimate compacts by construction. Counting only model-visible bytes puts a
+  floor under it: the estimate can only reach the window if the visible text
+  does, so a clamped estimate now means the conversation really is between 82.5%
+  and 100% of the limit, where compacting is the right answer.
 - **A subagent on a thinking model poisoned the conversation that spawned it.**
   Every request after the child finished came back as a 400 reading "The
   `reasoning_content` in the thinking mode must be passed back to the API",

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -246,9 +246,9 @@ grep -A2 '"contextWindow"' "$CODEX_HOME/codex-router/user-models.json"
 
 Curation now stores the `context_length` the provider's catalog advertises, but
 a model curated before that landed kept the conservative 131072 default — and a
-model that really carries a million tokens was then told to compact at 110,000,
-which a high-erring estimate clears on turn after turn. Compare it against what
-the provider says:
+model that really carries a million tokens is then told to compact at 110,000,
+which a real conversation reaches long before it needs to. Compare it against
+what the provider says:
 
 ```sh
 ./bin/discover-models PROVIDER --json

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -5,7 +5,7 @@ import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 
 const MAX_JSON_CAPTURE_BYTES = 8 * 1024 * 1024;
 
-// Bytes of forwarded request body per prompt token.
+// Bytes of *model-visible* request body per prompt token.
 //
 // The familiar rule is four characters per token, which is roughly where plain
 // English lands. Source code and tool output -- what a Codex session is mostly
@@ -23,6 +23,10 @@ const MAX_JSON_CAPTURE_BYTES = 8 * 1024 * 1024;
 // the session can be summarized out of. Against real text this lands between
 // about 1.0x (code-heavy) and 1.3x (prose-heavy) of the true count, so
 // compaction fires somewhere between 690,000 and 900,000 real tokens.
+//
+// That band only holds if the bytes handed to it are bytes the model reads.
+// See NON_VISIBLE_KEY below for the one class that is not, and issue #266 for
+// what happened when it was counted anyway.
 const ESTIMATE_BYTES_PER_TOKEN = 3.3;
 
 // Below this the substitution could not affect compaction anyway, and leaving
@@ -31,6 +35,104 @@ const ESTIMATE_BYTES_PER_TOKEN = 3.3;
 // safety property is that only an explicit zero is ever replaced, and no
 // tokenizer returns zero for a prompt that serializes to kilobytes.
 const MIN_ESTIMATED_INPUT_TOKENS = 1_000;
+
+// The one field of a routed body that is provably not prompt content.
+//
+// `encrypted_content` carries a reasoning item's ciphertext -- the hidden chain
+// of thought, sealed by whoever produced it. No routed provider reads it: the
+// gateway's Responses -> Chat Completions bridge drops reasoning items outright,
+// and a Responses-native routed provider cannot decrypt another vendor's token.
+// The router's own uses are already gone by the time a body is built --
+// `normalizeRoutedInput` turns compaction items into visible text, and
+// `normalizeRoutedAgentInput` inlines every collaboration payload as
+// `input_text` -- so what remains here is ciphertext and nothing else.
+//
+// It is also the largest thing left in the body when it survives at all.
+// `carryReasoningThroughInput` rewrites a reasoning item into assistant text
+// when it can, and the ciphertext goes with it -- but only for an item that
+// carries summary text and is immediately followed by the turn it belongs to.
+// A reasoning item with an empty summary, which is what a provider returns when
+// it has no summary to give, is forwarded whole. Measured through the router
+// itself on a twelve-turn tool loop: with summaries, no ciphertext reaches the
+// gateway at all; without them, every blob does and they are 64% of the body
+// the router sends. That is the regime issue #266 was reported from, and 64%
+// of the bytes charged at 3.3 each is where 3.9x-4.7x comes from.
+//
+// Everything else stays counted. JSON escaping (0.2%-3%) and structural
+// scaffolding (1%-5%) are small and keep the estimate erring high, which is the
+// direction that matters. Base64 image data is far larger than the tokens an
+// image really costs, but what it really costs is a per-provider tiling formula
+// the router has no business inventing, so it too stays counted at the byte
+// rate -- wrong, but wrong upward.
+//
+// Subtracting what is provably invisible rather than summing what is visible is
+// the point. An unrecognized field is counted by default, so a body shape
+// nobody anticipated errs high instead of estimating near zero.
+const NON_VISIBLE_KEY = Buffer.from('"encrypted_content"', "utf8");
+const QUOTE = 0x22;
+const BACKSLASH = 0x5c;
+const COLON = 0x3a;
+
+function isJsonSpace(byte) {
+  return byte === 0x20 || byte === 0x09 || byte === 0x0a || byte === 0x0d;
+}
+
+// Bytes occupied by `encrypted_content` string values in a serialized body.
+//
+// A scan rather than a parse: these bodies reach a megabyte and a half, and the
+// estimate runs on every routed turn, so building a second object graph to
+// throw away is a cost with no answer attached. The scan is exact, not
+// heuristic. Inside a JSON string every quote is escaped, so the unescaped byte
+// sequence `"encrypted_content"` followed by a colon can only be a key -- a
+// tool result that happens to quote this very JSON appears escaped and cannot
+// match. The colon check is what separates the key from the identically named
+// content-part `type` value that sits beside it.
+function nonVisibleBytes(buffer) {
+  let total = 0;
+  let index = 0;
+  while (index < buffer.length) {
+    const key = buffer.indexOf(NON_VISIBLE_KEY, index);
+    if (key === -1) break;
+    let cursor = key + NON_VISIBLE_KEY.length;
+    index = cursor;
+    while (cursor < buffer.length && isJsonSpace(buffer[cursor])) cursor += 1;
+    if (buffer[cursor] !== COLON) continue;
+    cursor += 1;
+    while (cursor < buffer.length && isJsonSpace(buffer[cursor])) cursor += 1;
+    // `null`, or any non-string value, carries no bytes worth discounting.
+    if (buffer[cursor] !== QUOTE) continue;
+    const start = cursor;
+    const end = endOfJsonString(buffer, start);
+    // A body with no closing quote is truncated or not JSON at all. Discount
+    // nothing rather than guess where the value stopped: over-counting is the
+    // safe error, and this one would be unbounded.
+    if (end === -1) break;
+    total += end - start;
+    index = end;
+  }
+  return total;
+}
+
+// The byte after the closing quote of the JSON string opening at `start`, or -1
+// if it never closes. Hops quote to quote natively -- a ciphertext blob is tens
+// of kilobytes with nothing to escape in it, and walking that a byte at a time
+// in JS costs more than parsing the whole document.
+function endOfJsonString(buffer, start) {
+  let cursor = start + 1;
+  while (cursor < buffer.length) {
+    const quote = buffer.indexOf(QUOTE, cursor);
+    if (quote === -1) return -1;
+    // A quote is part of the value when an odd number of backslashes precede
+    // it, and closes the value otherwise.
+    let slashes = 0;
+    while (quote - slashes - 1 > start && buffer[quote - slashes - 1] === BACKSLASH) {
+      slashes += 1;
+    }
+    if (slashes % 2 === 0) return quote + 1;
+    cursor = quote + 1;
+  }
+  return -1;
+}
 
 function tokenCount(value) {
   const number = Number(value);
@@ -99,14 +201,36 @@ export function tokenUsageFromPayload(payload) {
 // bytes that went upstream rather than against a model of the conversation.
 // Returns undefined when the request is too small for the estimate to matter,
 // which is also what keeps it away from genuinely small turns.
+//
+// The bytes counted are the body minus its `encrypted_content` ciphertext.
+// Anything that is not JSON -- a compressed frame, an opaque buffer, a plain
+// string -- simply finds no key to discount and is counted whole, exactly as
+// before.
 export function estimateInputTokens(body, { contextWindow } = {}) {
-  const bytes = Buffer.isBuffer(body)
-    ? body.byteLength
-    : Buffer.byteLength(String(body ?? ""), "utf8");
+  const buffer = Buffer.isBuffer(body) ? body : Buffer.from(String(body ?? ""), "utf8");
+  const bytes = buffer.byteLength - nonVisibleBytes(buffer);
   const estimate = Math.ceil(bytes / ESTIMATE_BYTES_PER_TOKEN);
   if (estimate < MIN_ESTIMATED_INPUT_TOKENS) return undefined;
   // A request the provider answered cannot have exceeded the window, so the
   // estimate is never allowed to claim it did.
+  //
+  // Clamping to the window is the same value it always was, but it no longer
+  // means the same thing. It used to fire on conversations nowhere near the
+  // limit -- a body three quarters ciphertext crossed the window at a quarter
+  // of its real size -- and because `autoCompact` is 85% of the window, a
+  // clamped estimate sits above the compaction threshold by construction, so
+  // every one of those turns compacted for nothing. That was the bug: not the
+  // clamp, but what was allowed to reach it.
+  //
+  // Counting only model-visible bytes puts a floor under it. For the estimate
+  // to exceed the window the visible text must exceed `contextWindow * 3.3`
+  // bytes, and real text tokenizes between 3.3 (code) and 4.0 (prose) bytes per
+  // token -- so a clamped estimate means the true count is between 82.5% and
+  // 100% of the window. `autoCompact` sits at 85%. Compacting there is correct:
+  // the conversation really is against the limit, and the alternative, reporting
+  // something below the threshold, would skip the compaction and hand the next
+  // turn to the provider to reject. Erring high costs a summary; erring low
+  // costs the turn.
   return Number.isInteger(contextWindow) && contextWindow > 0
     ? Math.min(estimate, contextWindow)
     : estimate;

--- a/test/response-usage.test.mjs
+++ b/test/response-usage.test.mjs
@@ -523,3 +523,170 @@ test("substitutes an estimated prompt count on a headerless stream", async () =>
   assert.match(output, /"input_tokens":1200/);
   assert.equal(transform.substitutedInputTokens(), 1200);
 });
+
+// Issue #266: on a curated OpenRouter model the substituted estimate came in
+// 3.9x-4.7x above the true prompt count, which pushed every zero-report turn
+// past the compaction threshold and compacted the session on every turn.
+// `estimateInputTokens` was measuring the whole serialized body, and the body a
+// Codex session sends is mostly `encrypted_content` -- reasoning ciphertext no
+// routed provider reads. The reporter's figures: ~382 KB of body over ~29,551
+// real prompt tokens, about 12.9 real bytes per token against a divisor of 3.3.
+
+// A reasoning item as Codex replays one: a short visible summary and a large
+// opaque ciphertext blob.
+function reasoningItem(summary, ciphertextBytes) {
+  return {
+    type: "reasoning",
+    id: "rs_1",
+    summary: [{ type: "summary_text", text: summary }],
+    encrypted_content: `gAAAAAB${"x".repeat(ciphertextBytes)}`,
+  };
+}
+
+test("reasoning ciphertext is not counted as prompt tokens", () => {
+  // Same conversation twice: once as the provider stores it, once with the
+  // ciphertext stripped. The model reads the same words either way, so the two
+  // must estimate the same.
+  const visible = { type: "message", role: "user", content: [{ type: "input_text", text: "x".repeat(40_000) }] };
+  const withCiphertext = Buffer.from(
+    JSON.stringify({ model: "m", input: [visible, reasoningItem("Thinking about it.", 300_000)] }),
+    "utf8",
+  );
+  const withoutCiphertext = Buffer.from(
+    JSON.stringify({
+      model: "m",
+      input: [visible, { type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "Thinking about it." }] }],
+    }),
+    "utf8",
+  );
+  // The ciphertext is nearly 90% of the stored body.
+  assert.ok(withCiphertext.byteLength > withoutCiphertext.byteLength * 8);
+  const stored = estimateInputTokens(withCiphertext);
+  const stripped = estimateInputTokens(withoutCiphertext);
+  // Before the fix `stored` was over 90,000 against `stripped` of about 12,000.
+  assert.ok(
+    Math.abs(stored - stripped) <= 40,
+    `ciphertext changed the estimate: ${stored} vs ${stripped}`,
+  );
+});
+
+test("a body that is mostly reasoning ciphertext does not force a compaction", () => {
+  // The reporter's shape: a conversation Codex is nowhere near needing to
+  // compact, inside a body three quarters ciphertext. autoCompact is 85% of the
+  // window, so the estimate has to stay under that or the session compacts on
+  // every turn that the provider reports as zero.
+  const contextWindow = 131_072;
+  const autoCompact = Math.floor(contextWindow * 0.85);
+  const input = [];
+  for (let turn = 0; turn < 24; turn += 1) {
+    input.push({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: `turn ${turn}: ${"word ".repeat(800)}` }],
+    });
+    input.push(reasoningItem(`Turn ${turn} reasoning summary.`, 12_000));
+  }
+  const body = Buffer.from(JSON.stringify({ model: "m", input }), "utf8");
+  // Roughly the reporter's proportions: a body whose real prompt content is a
+  // small fraction of its bytes.
+  assert.ok(body.byteLength > 380_000, `body was ${body.byteLength} bytes`);
+  const wholeBody = Math.ceil(body.byteLength / 3.3);
+  assert.ok(wholeBody > autoCompact, "the pre-fix estimate must clear the threshold");
+  const estimate = estimateInputTokens(body, { contextWindow });
+  assert.ok(
+    estimate < autoCompact,
+    `estimate ${estimate} still forces compaction at ${autoCompact}`,
+  );
+  // And it is not merely small: the visible half of the conversation is still
+  // counted in full.
+  assert.ok(estimate > 25_000, `estimate ${estimate} lost the visible text too`);
+});
+
+test("only the ciphertext is discounted, never the text beside it", () => {
+  // `encrypted_content` is also the name of a content-part type, and it appears
+  // as a value right next to the key. Discounting the value would silently drop
+  // real text; the scan keys on the colon that only follows the key.
+  const body = JSON.stringify({
+    input: [
+      {
+        type: "agent_message",
+        content: [
+          { type: "encrypted_content", encrypted_content: "gAAAA" + "z".repeat(50_000) },
+          { type: "input_text", text: "y".repeat(20_000) },
+        ],
+      },
+    ],
+  });
+  const estimate = estimateInputTokens(body);
+  const visibleOnly = estimateInputTokens(
+    JSON.stringify({
+      input: [
+        {
+          type: "agent_message",
+          content: [
+            { type: "encrypted_content", encrypted_content: "" },
+            { type: "input_text", text: "y".repeat(20_000) },
+          ],
+        },
+      ],
+    }),
+  );
+  assert.ok(Math.abs(estimate - visibleOnly) <= 4, `${estimate} vs ${visibleOnly}`);
+  // A tool result that quotes this very JSON is text, not a key, and every
+  // quote inside it is escaped -- so it must not be discounted.
+  const quoted = JSON.stringify({
+    input: [
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_text", text: `here is the payload: {"encrypted_content":"${"q".repeat(40_000)}"}` },
+        ],
+      },
+    ],
+  });
+  assert.ok(
+    estimateInputTokens(quoted) > 12_000,
+    "escaped text was mistaken for a key and discounted",
+  );
+});
+
+test("a non-JSON body is still counted whole", () => {
+  // A compressed frame or any other opaque payload finds no key to discount and
+  // is measured exactly as it always was. Erring high is the safe direction, so
+  // an unparseable body must never estimate low.
+  const opaque = Buffer.alloc(64_000, 0x9c);
+  assert.equal(estimateInputTokens(opaque), Math.ceil(64_000 / 3.3));
+});
+
+test("a ciphertext value carrying escapes ends where JSON says it ends", () => {
+  // Base64 has no quotes in it, but nothing stops a provider putting something
+  // else under the key. Stopping at an escaped quote would end the value early
+  // and discount the rest of the body as if it were ciphertext; running past
+  // the real closing quote would discount the visible text after it. Neither
+  // shows up as a wrong-looking number on its own, so the assertion is
+  // invariance: what the model reads is the same either way, so the estimate
+  // has to be too.
+  const visible = (awkward) =>
+    JSON.stringify({
+      input: [
+        { type: "reasoning", encrypted_content: awkward + "q".repeat(20_000) },
+        {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "z".repeat(30_000) }],
+        },
+      ],
+    });
+  const baseline = estimateInputTokens(visible(""));
+  // The trailing text dominates, so the estimate has to be near it rather than
+  // near the 15,000 tokens the ciphertext would have added.
+  assert.ok(baseline > 9_000 && baseline < 9_300, `baseline was ${baseline}`);
+  for (const awkward of ['a"b', "a\\", 'a\\"b', '\\\\"', "line\nbreak", '"']) {
+    assert.equal(
+      estimateInputTokens(visible(awkward)),
+      baseline,
+      `escape ${JSON.stringify(awkward)} moved the estimate`,
+    );
+  }
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -4545,6 +4545,113 @@ test("router substitutes a prompt-token estimate a provider reported as zero", a
   }
 });
 
+// Issue #266: the estimate above is calibrated against text a model reads, but
+// it was measuring the whole serialized body -- and most of a Codex body is
+// `encrypted_content`, the sealed chain of thought on every reasoning item that
+// no routed provider can read. The estimate came out 3.9x-4.7x high and cleared
+// the compaction threshold on every zero-report turn, so the session summarized
+// itself instead of working. End to end because the premise is about the body
+// the router actually builds: reasoning items survive into it, so the bytes are
+// really there to be discounted.
+test("reasoning ciphertext is not billed to the prompt-token estimate", async () => {
+  const gatewayBodies = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayBodies.push(await bodyJson(request));
+    const completed = {
+      type: "response.completed",
+      response: {
+        id: "resp_routed",
+        usage: { input_tokens: 0, output_tokens: 12, total_tokens: 12 },
+      },
+    };
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(
+      `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", delta: "ok" })}\n\n` +
+        `event: response.completed\ndata: ${JSON.stringify(completed)}\n\ndata: [DONE]\n\n`,
+    );
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "routing-ciphertext-"));
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  });
+  const headers = {
+    Authorization: "Bearer CODEX_CALLER_SECRET",
+    "Content-Type": "application/json",
+  };
+  // One conversation, sent twice: once as the provider stores it, and once with
+  // the ciphertext removed. The model reads the same words either way.
+  const conversation = "the quick brown fox jumps over the lazy dog. ".repeat(400);
+  const transcript = (ciphertext) => {
+    const input = [];
+    for (let turn = 0; turn < 6; turn += 1) {
+      input.push({
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: `${turn}: ${conversation}` }],
+      });
+      // No summary, which is what a provider returns when it has none to give.
+      // `carryReasoningThroughInput` rewrites a summarized reasoning item into
+      // assistant text and the ciphertext leaves with it -- these are the items
+      // that survive into the body, and the only ones the estimate can get
+      // wrong. The premise assertion below proves they really did survive.
+      input.push({
+        type: "reasoning",
+        id: `rs_${turn}`,
+        summary: [],
+        ...(ciphertext ? { encrypted_content: `gAAAAAB${"x".repeat(40_000)}` } : {}),
+      });
+    }
+    return JSON.stringify({ model: "opencode-go/deepseek-v4-flash", input });
+  };
+  const estimateFor = async (body) => {
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    assert.equal(response.status, 200, router.testErrors());
+    const completed = JSON.parse(
+      (await response.text())
+        .split("\n")
+        .find((line) => line.startsWith("data:") && line.includes("response.completed"))
+        .slice(5),
+    );
+    return completed.response.usage.input_tokens;
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const sealed = await estimateFor(transcript(true));
+    const plain = await estimateFor(transcript(false));
+
+    // The premise: the router really does forward the ciphertext, so it really
+    // was on the bill. Without this the test would pass on a body that never
+    // carried the bytes in the first place.
+    const forwarded = JSON.stringify(gatewayBodies[0]);
+    assert.ok(
+      forwarded.length > JSON.stringify(gatewayBodies[1]).length * 2,
+      "the routed body did not carry the reasoning ciphertext",
+    );
+
+    // Before the fix the sealed body estimated over 80,000 against the plain
+    // body's ~34,000. The words are identical, so the estimates must be too.
+    assert.ok(
+      Math.abs(sealed - plain) <= 100,
+      `ciphertext moved the estimate: ${sealed} vs ${plain}`,
+    );
+    // And the visible conversation is still counted in full, not discarded
+    // along with the ciphertext.
+    assert.ok(sealed >= Math.ceil((conversation.length * 6) / 4), `estimate ${sealed} too low`);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
 // Inventing token counts is a heuristic, however tightly gated, so an operator
 // has to be able to see the provider's own numbers again without downgrading.
 test("the prompt-token estimate can be switched off", async () => {


### PR DESCRIPTION
Fixes point 2 of #266, and resolves point 1 by making the clamp safe rather than removing it.

## The constant was right. Its input was not.

`estimateInputTokens` divided `buffer.byteLength` of the **entire serialized routed body** by `ESTIMATE_BYTES_PER_TOKEN = 3.3`. That constant is calibrated against model-visible text. The body is not model-visible text — most of it, on the turns that matter, is `encrypted_content`: the sealed chain of thought on each reasoning item.

Those bytes buy **zero** prompt tokens on the routed path. The gateway's Responses→Chat bridge drops reasoning items outright, and a Responses-native routed provider cannot decrypt another vendor's Fernet token. They were being charged at 3.3 bytes each anyway.

## Measured, not inferred

Through the real router — `src/router.mjs` spawned against a mock gateway, inspecting the bytes actually forwarded on a 12-turn tool loop:

| reasoning items | client body | routed body | blobs forwarded | `encrypted_content` share |
|---|---|---|---|---|
| with summary text | 112,849 B | 40,535 B | 0/12 | 0% |
| empty summary | 112,177 B | 112,177 B | 12/12 | **64.3%** |

There is a sharp condition on it. `carryReasoningThroughInput` already rewrites a reasoning item into assistant text when it carries summary text, and the ciphertext leaves with it. An item with an **empty** summary — what a provider returns when it has none to give — is forwarded whole. That is why this bites some sessions and not others.

Synthetic sweep over hidden reasoning per turn, 30 turns, aging on:

| reasoning/turn | body | visible | tools | encrypted | escaping | scaffolding | est/real |
|---|---|---|---|---|---|---|---|
| 500 | 239K | 51.3% | 12.8% | 29.8% | 1.0% | 5.1% | 1.56x |
| 1,500 | 376K | 32.6% | 8.1% | 55.3% | 0.6% | 3.3% | 2.45x |
| 4,000 | 717K | 17.1% | 4.3% | 76.6% | 0.3% | 1.7% | **4.68x** |

The reporter's own figures pin it independently: 382 KB over 29,551 tokens is 12.9 real bytes per token, and visible text cannot exceed ~4 B/tok — so ≥69% of that body was provably not model-visible.

**The other two candidates are ruled out by measurement.** JSON escaping is 0.2–3%; structural scaffolding 1–5%. Tool schemas are 4–13%, appear **once** (not multiplied), and are genuine prompt tokens — so they stay counted.

## The fix

`estimateInputTokens` now counts `byteLength − nonVisibleBytes(buffer)`.

The mechanism is **subtract what is provably invisible, never sum what is visible**. An unrecognized field is counted by default, so an unanticipated body shape errs high instead of estimating near zero. That inversion is what makes this principled rather than a retuned guess — no constant moved.

Implemented as a byte scan, not a parse: exact, because quotes inside JSON strings are escaped, so an unescaped `"encrypted_content":` can only be a key. 0.046 ms on a 1.27 MB body against 0.55 ms for `JSON.parse`.

The estimator only runs on routed turns (`ZERO_INPUT_ESTIMATE && route`), so native replay — where OpenAI genuinely does bill replayed reasoning — is never touched.

## The clamp stays, and now it is safe

`Math.min(estimate, contextWindow)` was not wrong because it clamped. It was wrong because of what reached it: a body three-quarters ciphertext crossed the window at a quarter of its real size, and since `autoCompact` is 85%, a clamped value compacted **by construction**.

Counting only visible bytes puts a floor under it. The estimate can now only reach the window if the visible text does, so a clamped estimate means the true count is between 82.5% (prose at 4.0 B/tok) and 100% of the window — where compacting is the correct answer. Clamping lower would skip a compaction that is genuinely due and hand the next turn to the provider to reject, which is the failure this mechanism exists to prevent.

`test/response-usage.test.mjs:157` stands unchanged. The new tests pin the *reason* — a ciphertext-heavy body must land below the threshold — rather than re-pinning the value.

## Erring high is preserved

- One field discounted, on a code-path proof that it buys zero prompt tokens where the estimate is used.
- Every ambiguous case biases upward: non-JSON body, compressed frame, non-string value, unterminated string, unknown field → counted whole.
- Escaping and scaffolding stay on the bill.
- Base64 image data stays counted at the byte rate. That is far above what an image really costs, but the real cost is a per-provider tiling formula with no captured data to calibrate — so it stays wrong *upward*. Worth a separate follow-up; it is the remaining source of spurious clamping.

## Tests

Regression tests verified fail-before/pass-after by reverting `src/response-usage.mjs`:

- `test/routing.test.mjs` — "reasoning ciphertext is not billed to the prompt-token estimate", end-to-end through a real router process. Before: `ciphertext moved the estimate: 105754 vs 32972`. Includes a premise assertion that the routed body really carried the blobs, so it cannot pass vacuously.
- `test/response-usage.test.mjs` — ciphertext-invariance, the #266 compaction-threshold scenario, and a key-vs-`type`-value collision. Two more guard the safe direction.

`npm run check` passes. `npm test`: 1596 pass, 0 fail, 12 skipped.
