### PR TITLE
feat(models): offer GPT-5.6 Sol at the 1M context window OpenAI documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -617,6 +617,43 @@ so the unit of evidence is always the slug, never the model name.
    `./bin/test-model 'provider/model' --live --yes`, reinstall, fully restart
    Codex, and perform the native subagent probe before claiming support.
 
+### Republish a native model at a different context window
+
+`src/native-context-variants.mjs` publishes a native GPT model under a second
+slug carrying a different context window — `gpt-5.6-sol-1m` is the first. It is
+not a new model and never becomes one: the entry is copied wholesale from the
+capture, the router translates the slug back to its base on the way out, and
+the only fields overridden are the slug, the display name, the description, and
+the window/compaction pair.
+
+1. The window is read from the provider's current official documentation, the
+   same rule as any other model. Never raise one because a request happened to
+   be accepted, and never guess from the family name. `bin/doctor` reports
+   windows a provider has already disproved; that check does not authorize the
+   opposite direction.
+2. A variant ships hidden. `seedModelsHidden` applies that default exactly once
+   per slug, so it can never re-apply itself over an operator's choice — which
+   is why `model-picker.json` records `seeded` alongside `hidden`, and why
+   every writer in `src/model-picker-state.mjs` must preserve it. A variant
+   that costs more per turn than the model it shadows must never arrive
+   switched on in an update.
+3. Derive only from a base the capture actually shipped as `visibility: "list"`,
+   and never in a login-free install: signed-out Codex surfaces display native
+   slugs from a server-supplied allowlist, so a synthesized slug would consume
+   an alias slot and then be invisible.
+4. Every surface that enumerates the OpenAI group goes through
+   `withNativeContextVariants` — the catalog build, the tray probe, and the
+   group's Show all / Hide all. A surface that reads `native-models.json`
+   directly will silently omit variants. Published clients
+   (`src/routed-client-models.mjs`, serving DeepSeek Harness and Gemini CLI)
+   are deliberately not among them: they read the capture and do not apply the
+   picker's hidden set to native models, so a variant would arrive switched on
+   in a surface that has no switch. Publishing one there means fixing that
+   first.
+5. Cover the derivation, the slug translation on a live native turn, the
+   hidden-by-default seeding, and the survival of an explicit choice across a
+   rebuild. `test/native-context-variants.test.mjs` is the existing shape.
+
 ### Ship a new provider to every installer
 
 A new provider is only complete when all of the following are true. Do not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+- **GPT-5.6 Sol can now run at the 1M context window OpenAI documents for it.**
+  The catalog Codex ships declares 272,000 tokens against a documented
+  1,050,000, and that figure has already moved twice
+  (openai/codex#31860, #32806). Editing `model_context_window` and
+  `model_auto_compact_token_limit` in `config.toml` answers this for a whole
+  machine; the picker now answers it per task. **GPT-5.6-Sol (1M context)**
+  (`gpt-5.6-sol-1m`) is the same upstream model published under a second slug
+  with a 1,000,000-token window and compaction starting at 900,000 —
+  instructions, reasoning ladder, image input, and subagent behavior are copied
+  from `gpt-5.6-sol`, and the router rewrites the slug back to its base before
+  the turn leaves, so OpenAI only ever sees the model it published. It ships
+  **switched off**, because a turn resends the whole conversation and a request
+  above 272,000 input tokens is billed at a higher rate in full: a model that
+  costs more than the one it shadows has to be chosen, not discovered after the
+  bill. Switch it on under OpenAI in the Settings model list, or with
+  `./bin/control picker set gpt-5.6-sol-1m show`. That answer is remembered —
+  later catalog rebuilds never re-apply the default to a model already decided,
+  in either direction — and a login-free install does not get the entry at all,
+  because its native slugs come from a server-supplied allowlist.
+
 - **Gemini CLI is a target.** It speaks only the Gemini API and Google ships no
   bring-your-own-provider setting, so pointing it at this router used to be
   impossible — the endpoint it wants does not exist anywhere in the codebase.

--- a/README.md
+++ b/README.md
@@ -747,6 +747,42 @@ supports_standalone_web_search = true
 The generated path is local caller authentication. Do not paste the complete
 managed URL into an issue.
 
+### Run GPT-5.6 Sol at its documented 1M context window
+
+OpenAI documents GPT-5.6 Sol at 1,050,000 tokens. The catalog Codex ships
+declares 272,000, and it has moved more than once
+([openai/codex#31860](https://github.com/openai/codex/issues/31860),
+[#32806](https://github.com/openai/codex/issues/32806)). The single-install
+answer is `model_context_window` and `model_auto_compact_token_limit` in
+`~/.codex/config.toml`; the router's answer is a second entry in the picker, so
+the choice is per task rather than per machine:
+
+| Picker label | Model ID | Context window | Auto-compaction |
+| --- | --- | --- | --- |
+| GPT-5.6-Sol (1M context) | `gpt-5.6-sol-1m` | 1,000,000 | 900,000 |
+
+It is the same upstream model. Everything else in the entry — instructions,
+reasoning ladder, image input, subagent behavior — is copied from
+`gpt-5.6-sol`, and the router rewrites the slug back before the turn leaves for
+chatgpt.com, so OpenAI only ever sees the model it published.
+
+**It ships switched off,** because it costs more than the model it shadows: a
+turn resends the whole conversation, and a request above 272,000 input tokens
+is billed at a higher rate *in full*. Switch it on under **OpenAI** in the
+router Settings model list, or:
+
+```sh
+./bin/control picker set gpt-5.6-sol-1m show    # and `hide` to put it back
+```
+
+Your answer is remembered. Later catalog rebuilds never re-apply the default to
+a model you have already decided, in either direction. Fully quit and reopen
+Codex afterwards — the picker is read at startup.
+
+A login-free install does not get this entry: signed-out Codex only displays
+native slugs from a server-supplied allowlist, and a slot spent on a
+synthesized slug is a slot a routed model does not get.
+
 ### Windows Codex Desktop running through WSL
 
 When Codex Desktop runs on Windows while commands are executed through WSL,

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -29,8 +29,12 @@ import {
   readMultiAgentSettings,
   subagentEligibleModels,
 } from "./multi-agent-state.mjs";
-import { readHiddenModels } from "./model-picker-state.mjs";
+import { readHiddenModels, seedModelsHidden } from "./model-picker-state.mjs";
 import { buildNativeAliasAssignments } from "./native-alias.mjs";
+import {
+  NATIVE_CONTEXT_VARIANT_SLUGS,
+  withNativeContextVariants,
+} from "./native-context-variants.mjs";
 import { selectedConfiguredListedModels, configuredProviderIds } from "./provider-selection.mjs";
 import { assertStateOwnership } from "./state-owner.mjs";
 import { scanTomlDocument, tomlStringValue } from "./toml-structure.mjs";
@@ -769,6 +773,11 @@ function main() {
   // advertising models the running gateway has no route for.
   assertStateOwnership("write the Codex model catalog");
   const userSlugs = new Set(readUserModels().map((model) => String(model.slug)));
+  // Before the hidden set is read, not after: an extended-window variant costs
+  // more per turn than the model it shadows, so it arrives switched off and
+  // stays off until the operator says otherwise. Only slugs with no recorded
+  // decision are touched, so this cannot undo a choice already made.
+  seedModelsHidden(NATIVE_CONTEXT_VARIANT_SLUGS);
   const hiddenModels = readHiddenModels();
   const selectedModels = selectedConfiguredListedModels();
   const multiAgentSettings = readMultiAgentSettings();
@@ -791,9 +800,18 @@ function main() {
     Date.now(),
   );
   const captured = nativeCatalog();
+  const loginFree = loginFreeConfigured();
   const native = {
     ...captured,
-    models: promoteNativeMultiAgent(captured.models, multiAgentSettings, hiddenModels),
+    // Variants join before the multi-agent pass so a switched-off one is
+    // demoted exactly like every other hidden model, and a switched-on one
+    // inherits its base model's verified backend version rather than a
+    // separate claim about the same upstream.
+    models: promoteNativeMultiAgent(
+      withNativeContextVariants(captured.models, { enabled: !loginFree }),
+      multiAgentSettings,
+      hiddenModels,
+    ),
   };
   // Dropping every native model is destructive, so only do it when Codex
   // actually answered that the session is signed out. If the probe could not
@@ -808,7 +826,6 @@ function main() {
     );
   }
   const openaiAuthenticated = auth.authenticated;
-  const loginFree = loginFreeConfigured();
   const routedCatalog = routedCatalogActive();
   // Advertised last, and only while an engine actually resolves: Codex gates
   // the paste on `input_modalities`, so a bridge that has gone away must take

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { pickerCommandArgs } from "./control-args.mjs";
 import { promoteNativeMultiAgent } from "./catalog.mjs";
+import { withNativeContextVariants } from "./native-context-variants.mjs";
 // The publish marker lives under the shared state directory, which does not
 // vary by target, so reading it here does not disturb the per-target probes
 // below that re-import paths with their own MODEL_ROUTER_TARGET.
@@ -92,12 +93,25 @@ async function shippedNativeVisionEngines(hidden) {
   return installedNativeVisionEngines({ hidden });
 }
 
-function nativeCodexModels(catalogPath, hiddenModels = new Set(), subagentSettings = {}) {
+function nativeCodexModels(
+  catalogPath,
+  hiddenModels = new Set(),
+  subagentSettings = {},
+  { contextVariants = true } = {},
+) {
   if (!existsSync(catalogPath)) return [];
   try {
     const parsed = JSON.parse(readFileSync(catalogPath, "utf8"));
     return promoteNativeMultiAgent(
-      Array.isArray(parsed.models) ? parsed.models : [],
+      // The capture holds what Codex published; the extended-window variants
+      // are the router's own additions to the same group, and the tray is
+      // where they are switched on, so they have to be drawn here too. The
+      // catalog build derives them from this same list, so the rows the
+      // operator sees and the entries Codex reads cannot drift apart.
+      withNativeContextVariants(
+        Array.isArray(parsed.models) ? parsed.models : [],
+        { enabled: contextVariants },
+      ),
       subagentSettings,
       hiddenModels,
     )
@@ -211,14 +225,20 @@ async function emitProbe() {
     // a ladder keeps the exact shape it always had.
     ...reasoningLevelField(model.reasoningLevels),
   }));
+  const selectedModel = TARGET === "codex" ? configuredDefaultModel(CONFIG_PATH) : undefined;
+  const codexConfig = TARGET === "codex" ? codexConfigSnapshot() : undefined;
   const models = TARGET === "codex"
     ? [
-        ...nativeCodexModels(NATIVE_CATALOG_PATH, hiddenModels, subagentSettings),
+        ...nativeCodexModels(NATIVE_CATALOG_PATH, hiddenModels, subagentSettings, {
+          // A login-free install republishes external models under the native
+          // slugs Codex allowlists, and a synthesized slug is not one of them.
+          // The catalog build drops the variants there for the same reason, so
+          // the tray must not offer a row the picker will never show.
+          contextVariants: !codexConfig?.login_free,
+        }),
         ...routedModels,
       ]
     : routedModels;
-  const selectedModel = TARGET === "codex" ? configuredDefaultModel(CONFIG_PATH) : undefined;
-  const codexConfig = TARGET === "codex" ? codexConfigSnapshot() : undefined;
 
   process.stdout.write(
     JSON.stringify({
@@ -1854,12 +1874,11 @@ async function handlePicker(action, value, flag) {
     let slugs;
     if (provider === "openai") {
       const { NATIVE_CATALOG_PATH } = await import("./paths.mjs");
-      const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
-      slugs = Array.isArray(parsed.models)
-        ? parsed.models
-            .filter((model) => model.visibility === "list")
-            .map((model) => String(model.slug))
-        : [];
+      // Through the same helper the tray draws its rows with, so the group's
+      // Show all / Hide all covers every row in the group. Reading the capture
+      // straight off disk skipped the extended-window variants, which left
+      // "Hide all" with one row still showing.
+      slugs = nativeCodexModels(NATIVE_CATALOG_PATH).map((model) => model.slug);
     } else {
       const { canonicalProviderId, readProviderSelection } = await import(
         "./provider-selection.mjs"

--- a/src/model-picker-state.mjs
+++ b/src/model-picker-state.mjs
@@ -17,15 +17,49 @@ export const MODEL_PICKER_STATE_PATH =
 
 // Per-model visibility overrides for the Codex picker. Hiding a model only
 // changes the merged catalog for this machine; the registry stays untouched.
-export function readHiddenModels() {
-  if (!existsSync(MODEL_PICKER_STATE_PATH)) return new Set();
+//
+// `hidden` answers "is this model off"; `seeded` answers the different question
+// "has this model ever been decided" -- by the operator, or by a default the
+// catalog build applied once. Absence from `hidden` cannot answer it, because
+// that is also what a model nobody has ever seen looks like, and a default
+// that cannot tell the two apart re-applies itself over the operator's choice
+// on the next rebuild (see `seedModelsHidden`).
+function readPickerState() {
+  const empty = { hidden: new Set(), seeded: new Set() };
+  if (!existsSync(MODEL_PICKER_STATE_PATH)) return empty;
   try {
     const parsed = JSON.parse(readFileSync(MODEL_PICKER_STATE_PATH, "utf8"));
-    if (parsed?.version !== 1 || !Array.isArray(parsed.hidden)) return new Set();
-    return new Set(parsed.hidden.map((slug) => String(slug)).filter(Boolean));
+    if (parsed?.version !== 1 || !Array.isArray(parsed.hidden)) return empty;
+    const slugs = (value) =>
+      new Set((Array.isArray(value) ? value : []).map((slug) => String(slug)).filter(Boolean));
+    return { hidden: slugs(parsed.hidden), seeded: slugs(parsed.seeded) };
   } catch {
-    return new Set();
+    return empty;
   }
+}
+
+export function readHiddenModels() {
+  return readPickerState().hidden;
+}
+
+function writePickerState({ hidden, seeded }) {
+  const stateDir = path.dirname(MODEL_PICKER_STATE_PATH);
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  chmodSync(stateDir, 0o700);
+  const temporary = `${MODEL_PICKER_STATE_PATH}.tmp.${process.pid}`;
+  writeFileSync(
+    temporary,
+    `${JSON.stringify(
+      { version: 1, hidden: [...hidden].sort(), seeded: [...seeded].sort() },
+      null,
+      2,
+    )}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  protectPrivateFile(temporary);
+  renameSync(temporary, MODEL_PICKER_STATE_PATH);
+  protectPrivateFile(MODEL_PICKER_STATE_PATH);
+  return modelPickerSnapshot();
 }
 
 export function modelPickerSnapshot() {
@@ -44,41 +78,44 @@ export function setModelVisible(slug, visible) {
 export function setModelsVisible(slugs, visible) {
   const values = [...new Set(slugs.map((slug) => String(slug || "").trim()).filter(Boolean))];
   if (values.length === 0) throw new Error("At least one model slug is required.");
-  const hidden = readHiddenModels();
+  const { hidden, seeded } = readPickerState();
   for (const value of values) {
     if (visible) hidden.delete(value);
     else hidden.add(value);
+    // The operator just decided this one. Recording it is what stops a
+    // shipped default from quietly undoing the decision later.
+    seeded.add(value);
   }
-
-  const stateDir = path.dirname(MODEL_PICKER_STATE_PATH);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  chmodSync(stateDir, 0o700);
-  const temporary = `${MODEL_PICKER_STATE_PATH}.tmp.${process.pid}`;
-  writeFileSync(
-    temporary,
-    `${JSON.stringify({ version: 1, hidden: [...hidden].sort() }, null, 2)}\n`,
-    { encoding: "utf8", mode: 0o600 },
-  );
-  protectPrivateFile(temporary);
-  renameSync(temporary, MODEL_PICKER_STATE_PATH);
-  protectPrivateFile(MODEL_PICKER_STATE_PATH);
-  return modelPickerSnapshot();
+  return writePickerState({ hidden, seeded });
 }
 
 export function setAllModelsVisible(slugs, visible) {
   const known = [...new Set(slugs.map((slug) => String(slug).trim()).filter(Boolean))];
-  const hidden = visible ? new Set() : new Set(known);
-  const stateDir = path.dirname(MODEL_PICKER_STATE_PATH);
-  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  chmodSync(stateDir, 0o700);
-  const temporary = `${MODEL_PICKER_STATE_PATH}.tmp.${process.pid}`;
-  writeFileSync(
-    temporary,
-    `${JSON.stringify({ version: 1, hidden: [...hidden].sort() }, null, 2)}\n`,
-    { encoding: "utf8", mode: 0o600 },
-  );
-  protectPrivateFile(temporary);
-  renameSync(temporary, MODEL_PICKER_STATE_PATH);
-  protectPrivateFile(MODEL_PICKER_STATE_PATH);
-  return modelPickerSnapshot();
+  const { seeded } = readPickerState();
+  return writePickerState({
+    hidden: visible ? new Set() : new Set(known),
+    seeded: new Set([...seeded, ...known]),
+  });
+}
+
+// Applies a shipped default to models the operator has never decided, and only
+// to those. Used by the catalog build for entries that must arrive switched off
+// (`src/native-context-variants.mjs`): they cost more per turn than the model
+// they shadow, so an update must never turn one on by itself.
+//
+// Idempotent, and silent when there is nothing to record -- this runs on every
+// catalog rebuild, and rewriting the operator's picker state to say nothing new
+// is how a protected file starts churning.
+export function seedModelsHidden(slugs) {
+  const values = [...new Set(
+    (Array.isArray(slugs) ? slugs : []).map((slug) => String(slug || "").trim()).filter(Boolean),
+  )];
+  const { hidden, seeded } = readPickerState();
+  const fresh = values.filter((value) => !seeded.has(value));
+  if (fresh.length === 0) return modelPickerSnapshot();
+  for (const value of fresh) {
+    hidden.add(value);
+    seeded.add(value);
+  }
+  return writePickerState({ hidden, seeded });
 }

--- a/src/native-context-variants.mjs
+++ b/src/native-context-variants.mjs
@@ -1,0 +1,96 @@
+// A second slug for a native GPT model, carrying the context window OpenAI
+// documents for it rather than the one Codex ships.
+//
+// Codex publishes one window per native model, and it is not always the
+// model's. OpenAI documents GPT-5.6 Sol at 1,050,000 tokens; the catalog Codex
+// captures on this machine declares 272,000 (openai/codex#31860, #32806). The
+// gap is a deliberate product decision -- every turn resends the whole
+// conversation, and a prompt above 272,000 input tokens is billed at a higher
+// rate for the *entire* request -- so it is not the router's to overturn for
+// everyone. What the router can offer is the choice, which is what the
+// documented `model_context_window` / `model_auto_compact_token_limit` pair in
+// `config.toml` does for a single install, and what these entries do for the
+// picker.
+//
+// Each variant republishes its base entry under a new slug with the documented
+// window and a compaction limit below it. Nothing about the upstream model
+// changes: chatgpt.com has never heard of `gpt-5.6-sol-1m`, so the router
+// rewrites the slug back to its base before the turn leaves
+// (`nativeContextVariantBase`). The only difference is how much history Codex
+// keeps before it compacts.
+//
+// They ship hidden. A model that costs more per turn than the one it shadows
+// must be switched on deliberately, in the tray under OpenAI, and never
+// arrive switched on in an update.
+
+export const NATIVE_CONTEXT_VARIANTS = Object.freeze([
+  Object.freeze({
+    slug: "gpt-5.6-sol-1m",
+    baseSlug: "gpt-5.6-sol",
+    displayName: "GPT-5.6-Sol (1M context)",
+    description:
+      "Latest frontier agentic coding model, running at its documented 1M-token " +
+      "context window. Turns above 272K input tokens bill at a higher rate.",
+    contextWindow: 1_000_000,
+    // Compaction starts here, leaving headroom below the window so a long turn
+    // has somewhere to land. Mirrors the documented
+    // `model_auto_compact_token_limit` guidance for this model.
+    autoCompact: 900_000,
+  }),
+]);
+
+export const NATIVE_CONTEXT_VARIANT_SLUGS = Object.freeze(
+  NATIVE_CONTEXT_VARIANTS.map((variant) => variant.slug),
+);
+
+const BASE_BY_VARIANT = new Map(
+  NATIVE_CONTEXT_VARIANTS.map((variant) => [variant.slug, variant.baseSlug]),
+);
+
+// The upstream model a variant slug stands for, or undefined for every slug
+// that is already its own model. The request path asks this on the way out, so
+// it must stay a pure lookup over the checked-in list: a variant that resolved
+// through disk state could send a turn to a model the operator never picked.
+export function nativeContextVariantBase(slug) {
+  return BASE_BY_VARIANT.get(String(slug ?? ""));
+}
+
+function variantEntry(base, variant) {
+  return {
+    ...base,
+    slug: variant.slug,
+    display_name: variant.displayName,
+    description: variant.description,
+    context_window: variant.contextWindow,
+    max_context_window: variant.contextWindow,
+    auto_compact_token_limit: variant.autoCompact,
+    // Announcement copy belongs to the model OpenAI shipped, not to a window
+    // the router republished. Both cards would otherwise fire for what the
+    // operator sees as one model.
+    availability_nux: null,
+    upgrade: null,
+  };
+}
+
+// Appends every variant whose base the capture actually shipped as a listed
+// model. A base that is missing, hidden, or unlisted (a signed-out capture, or
+// a model OpenAI withdrew) produces nothing: a picker row whose upstream the
+// account cannot pick is a row that fails on its first turn.
+//
+// `enabled: false` is how a login-free install opts out. There, Codex only
+// displays native slugs from a server-delivered allowlist, so a synthesized
+// slug would take an alias slot and then be invisible -- costing a routed
+// model its own slot for nothing.
+export function withNativeContextVariants(models, { enabled = true } = {}) {
+  const list = Array.isArray(models) ? models : [];
+  if (!enabled) return list;
+  const bySlug = new Map(list.map((model) => [String(model?.slug), model]));
+  const derived = [];
+  for (const variant of NATIVE_CONTEXT_VARIANTS) {
+    if (bySlug.has(variant.slug)) continue;
+    const base = bySlug.get(variant.baseSlug);
+    if (!base || base.visibility !== "list") continue;
+    derived.push(variantEntry(base, variant));
+  }
+  return derived.length ? [...list, ...derived] : list;
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -41,6 +41,7 @@ import { MODEL_BY_SLUG, PROVIDERS, providerForModel } from "./model-registry.mjs
 import { createHealthCache } from "./health-cache.mjs";
 import { discoveryDisabled } from "./discovery-mode.mjs";
 import { readNativeAliases } from "./native-alias.mjs";
+import { nativeContextVariantBase } from "./native-context-variants.mjs";
 import { readNativeRedirect } from "./native-redirect.mjs";
 import {
   canonicalProviderId,
@@ -2405,6 +2406,15 @@ async function handleResponses(request, response, requestUrl) {
       }
     } else {
       const native = { ...payload };
+      // An extended-window variant is the model it was derived from, published
+      // under a second slug so the picker can offer a different context
+      // window (`src/native-context-variants.mjs`). chatgpt.com has never
+      // heard of that slug, so it is translated back here -- the last point
+      // before the turn leaves. Everything the operator reads keeps the slug
+      // they picked: `requestedModel` is untouched, so activity, usage, and
+      // the log still name the model the picker showed.
+      const variantBase = nativeContextVariantBase(native.model);
+      if (variantBase) native.model = variantBase;
       if (Array.isArray(payload.input)) {
         native.input = normalizeNativeInput(payload.input);
         // Native turns leave here as stateless full conversations (the
@@ -2948,9 +2958,19 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
     });
 
     const headers = nativeHeaders(request);
+    // The same slug translation the turn path does, for the same reason: these
+    // endpoints normally carry their own model ("gpt-image-2", the search
+    // model), but nothing stops a client from naming the picked one, and an
+    // extended-window slug means nothing to chatgpt.com. The bytes are only
+    // re-encoded when a variant is actually present, so every other request on
+    // this path is forwarded exactly as it arrived.
+    const variantBase = nativeContextVariantBase(payload.model);
+    const outgoing = variantBase
+      ? Buffer.from(JSON.stringify({ ...payload, model: variantBase }), "utf8")
+      : body;
     // Same replayable-Buffer rule as the turn path: encode once, outside the
     // retry, so every attempt carries identical bytes under identical headers.
-    const imageBody = await compressedNativeBody(body, headers);
+    const imageBody = await compressedNativeBody(outgoing, headers);
     const { response: upstream, retries: upstreamRetries } = await fetchWithRetry(
       nativeTarget(requestUrl.pathname, nativeRequestSearch(requestUrl)),
       {

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -45,6 +45,17 @@ function probe(target, providers, usageEvents = [], options = {}) {
       { mode: 0o600 },
     );
   }
+  if (options.hiddenModels) {
+    writeFileSync(
+      path.join(stateDir, "model-picker.json"),
+      `${JSON.stringify({
+        version: 1,
+        hidden: options.hiddenModels,
+        seeded: options.hiddenModels,
+      })}\n`,
+      { mode: 0o600 },
+    );
+  }
   if (options.loginFree) {
     writeFileSync(
       path.join(stateDir, "config.toml"),
@@ -173,6 +184,40 @@ test("codex probe includes native GPT models and the configured default", () => 
   assert.equal(slice.modelSettings.localModels.lmstudio.provider, "lmstudio");
   assert.equal(typeof slice.modelSettings.localModels.lmstudio.reachable, "boolean");
   assert.ok(Array.isArray(slice.modelSettings.localModels.lmstudio.models));
+});
+
+// The row is the whole feature: an entry the operator cannot find is an entry
+// that ships off forever. It belongs in the OpenAI group, drawn unchecked.
+test("codex probe draws the extended-context variant under OpenAI, switched off", () => {
+  const slice = probe("codex", [], [], {
+    hiddenModels: ["gpt-5.6-sol-1m"],
+    nativeModels: [
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", visibility: "list" },
+    ],
+  });
+
+  const variant = slice.models.find((model) => model.slug === "gpt-5.6-sol-1m");
+  assert.equal(variant.provider, "openai");
+  assert.equal(variant.native, true);
+  assert.equal(variant.visible, false);
+  assert.equal(variant.displayName, "GPT-5.6-Sol (1M context)");
+  // And it has not displaced the model it was derived from.
+  assert.equal(slice.models.find((model) => model.slug === "gpt-5.6-sol").visible, true);
+});
+
+test("a login-free probe draws no extended-context variant", () => {
+  const slice = probe("codex", ["deepseek"], [], {
+    loginFree: true,
+    nativeModels: [
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", visibility: "list" },
+    ],
+  });
+
+  assert.equal(slice.loginFree, true);
+  // Signed-out Codex only displays allowlisted native slugs, so the row would
+  // offer a model the picker can never show.
+  assert.equal(slice.models.some((model) => model.slug === "gpt-5.6-sol-1m"), false);
+  assert.ok(slice.models.some((model) => model.slug === "gpt-5.6-sol"));
 });
 
 test("codex probe reports the effective v2 state of selected native GPT models", () => {

--- a/test/doctor-routing-mode.test.mjs
+++ b/test/doctor-routing-mode.test.mjs
@@ -113,7 +113,22 @@ wire_api = "responses"
       const merged = JSON.parse(
         readFileSync(path.join(stateDir, "merged-models.json"), "utf8"),
       );
-      assert.deepEqual(merged.models.map((model) => model.slug), ["gpt-5.6-sol"]);
+      // The captured native model, plus the extended-window variant the
+      // router derives from it. Nothing routed, which is what this test is
+      // about — and the variant ships switched off, so a build that publishes
+      // it has still changed nothing the operator did not ask for.
+      assert.deepEqual(merged.models.map((model) => model.slug), [
+        "gpt-5.6-sol",
+        "gpt-5.6-sol-1m",
+      ]);
+      assert.equal(
+        merged.models.find((model) => model.slug === "gpt-5.6-sol-1m").visibility,
+        "hide",
+      );
+      assert.equal(
+        merged.models.find((model) => model.slug === "gpt-5.6-sol").visibility,
+        "list",
+      );
       assert.equal(
         readdirSync(path.join(codexHome, "agents")).filter((name) =>
           name.startsWith("router-model-"),

--- a/test/native-context-variants.test.mjs
+++ b/test/native-context-variants.test.mjs
@@ -1,0 +1,387 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { zstdDecompressSync } from "node:zlib";
+
+import { callerBaseUrl } from "../src/caller-auth.mjs";
+import { buildLoginFreeCatalog, buildMergedCatalog } from "../src/catalog.mjs";
+import {
+  NATIVE_CONTEXT_VARIANTS,
+  NATIVE_CONTEXT_VARIANT_SLUGS,
+  nativeContextVariantBase,
+  withNativeContextVariants,
+} from "../src/native-context-variants.mjs";
+import { openPort } from "./port-pool.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
+const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
+
+const pickerStateDir = mkdtempSync(path.join(os.tmpdir(), "context-variant-picker-"));
+process.env.MODEL_ROUTER_MODEL_PICKER_STATE = path.join(pickerStateDir, "model-picker.json");
+const {
+  MODEL_PICKER_STATE_PATH,
+  readHiddenModels,
+  seedModelsHidden,
+  setAllModelsVisible,
+  setModelVisible,
+} = await import("../src/model-picker-state.mjs");
+
+// The shape the capture actually has, trimmed to the fields the derivation
+// reads or must carry through untouched.
+const sol = {
+  slug: "gpt-5.6-sol",
+  display_name: "GPT-5.6-Sol",
+  description: "Latest frontier agentic coding model.",
+  visibility: "list",
+  priority: 1,
+  context_window: 272_000,
+  max_context_window: 272_000,
+  effective_context_window_percent: 95,
+  comp_hash: "3000",
+  multi_agent_version: "v2",
+  input_modalities: ["text", "image"],
+  base_instructions: "You are Codex, a coding agent based on GPT-5.",
+  supported_reasoning_levels: [{ effort: "low", description: "Fast" }],
+  availability_nux: { message: "Introducing GPT-5.6-Sol" },
+};
+
+const spark = { ...sol, slug: "gpt-5.3-codex-spark", context_window: 128_000 };
+
+function variantOf(models, slug = "gpt-5.6-sol-1m") {
+  return models.find((model) => model.slug === slug);
+}
+
+test("the variant is its base model, published at the window OpenAI documents", () => {
+  const [variant] = NATIVE_CONTEXT_VARIANTS;
+  const models = withNativeContextVariants([sol, spark]);
+
+  assert.equal(models.length, 3, "the capture keeps every model it arrived with");
+  const derived = variantOf(models);
+  assert.equal(derived.context_window, 1_000_000);
+  assert.equal(derived.max_context_window, 1_000_000);
+  // Compaction has to start below the window, or the first turn that reaches
+  // the limit has nowhere to land.
+  assert.ok(derived.auto_compact_token_limit < derived.context_window);
+  assert.equal(derived.auto_compact_token_limit, variant.autoCompact);
+  assert.equal(derived.display_name, variant.displayName);
+  assert.notEqual(derived.display_name, sol.display_name);
+
+  // Everything else is the base model, unchanged: same instructions, same
+  // capabilities, same compaction prompt. A variant that drifted here would be
+  // a second model pretending to be the first.
+  assert.equal(derived.base_instructions, sol.base_instructions);
+  assert.equal(derived.comp_hash, sol.comp_hash);
+  assert.equal(derived.multi_agent_version, sol.multi_agent_version);
+  assert.deepEqual(derived.input_modalities, sol.input_modalities);
+  assert.deepEqual(derived.supported_reasoning_levels, sol.supported_reasoning_levels);
+
+  // The base model owns its announcement. Both cards firing would announce one
+  // model twice.
+  assert.equal(derived.availability_nux, null);
+  assert.equal(derived.upgrade, null);
+
+  // And the base is left exactly as captured.
+  assert.equal(variantOf(models, "gpt-5.6-sol").context_window, 272_000);
+});
+
+test("no base, no variant: a row whose upstream this account cannot pick never appears", () => {
+  assert.deepEqual(withNativeContextVariants([spark]), [spark]);
+  assert.deepEqual(withNativeContextVariants([]), []);
+  assert.deepEqual(withNativeContextVariants(undefined), []);
+  // A capture that withdrew the model to "hide" is the signed-out and
+  // deprecated case both: the base is present but unpickable.
+  assert.deepEqual(withNativeContextVariants([{ ...sol, visibility: "hide" }]), [
+    { ...sol, visibility: "hide" },
+  ]);
+});
+
+test("deriving twice adds one variant, not two", () => {
+  const once = withNativeContextVariants([sol]);
+  assert.deepEqual(withNativeContextVariants(once), once);
+});
+
+test("a login-free install gets no variants, because its native slugs are allowlisted", () => {
+  // Signed-out Codex surfaces only display native slugs from a server-supplied
+  // allowlist, and republish external models under them. A synthesized slug
+  // would take one of those slots and then never be displayed, costing a real
+  // model its own slot.
+  const models = withNativeContextVariants([sol], { enabled: false });
+  assert.deepEqual(models, [sol]);
+
+  const external = [
+    {
+      slug: "kimi-oauth/k3",
+      displayName: "Kimi K3",
+      priority: 1,
+      contextWindow: 256_000,
+      reasoningLevels: [{ effort: "high", description: "Deep" }],
+      inputModalities: ["text"],
+      provider: undefined,
+    },
+  ];
+  const { aliases } = buildLoginFreeCatalog({ models }, external);
+  assert.deepEqual(Object.keys(aliases), ["gpt-5.6-sol"]);
+});
+
+test("the router knows which upstream model a variant slug stands for", () => {
+  assert.equal(nativeContextVariantBase("gpt-5.6-sol-1m"), "gpt-5.6-sol");
+  // Every real model must answer undefined, or the rewrite would redirect a
+  // turn the operator did pick.
+  assert.equal(nativeContextVariantBase("gpt-5.6-sol"), undefined);
+  assert.equal(nativeContextVariantBase("kimi-oauth/k3"), undefined);
+  assert.equal(nativeContextVariantBase(undefined), undefined);
+  assert.equal(nativeContextVariantBase(""), undefined);
+  for (const variant of NATIVE_CONTEXT_VARIANTS) {
+    assert.equal(nativeContextVariantBase(variant.slug), variant.baseSlug);
+    assert.notEqual(variant.slug, variant.baseSlug);
+  }
+});
+
+test("the variant reaches the catalog Codex reads, alongside its base", () => {
+  const merged = buildMergedCatalog({ models: withNativeContextVariants([sol, spark]) }, []);
+  const slugs = merged.map((model) => model.slug);
+  assert.ok(slugs.includes("gpt-5.6-sol"));
+  assert.ok(slugs.includes("gpt-5.6-sol-1m"));
+  assert.equal(variantOf(merged).context_window, 1_000_000);
+});
+
+test("a variant arrives switched off, and stays off until the operator says otherwise", () => {
+  rmSync(MODEL_PICKER_STATE_PATH, { force: true });
+  seedModelsHidden(NATIVE_CONTEXT_VARIANT_SLUGS);
+  assert.deepEqual([...readHiddenModels()].sort(), [...NATIVE_CONTEXT_VARIANT_SLUGS].sort());
+
+  // Switched on in the tray, then a catalog rebuild reapplies the default:
+  // the choice has to survive, or an update quietly switches it back off.
+  setModelVisible("gpt-5.6-sol-1m", true);
+  seedModelsHidden(NATIVE_CONTEXT_VARIANT_SLUGS);
+  assert.equal(readHiddenModels().has("gpt-5.6-sol-1m"), false);
+
+  // Switched off again by hand: the same rule, in the other direction.
+  setModelVisible("gpt-5.6-sol-1m", false);
+  seedModelsHidden(NATIVE_CONTEXT_VARIANT_SLUGS);
+  assert.equal(readHiddenModels().has("gpt-5.6-sol-1m"), true);
+});
+
+test("seeding leaves every other picker choice alone", () => {
+  rmSync(MODEL_PICKER_STATE_PATH, { force: true });
+  setModelVisible("kimi-oauth/k3", false);
+  seedModelsHidden(NATIVE_CONTEXT_VARIANT_SLUGS);
+  assert.equal(readHiddenModels().has("kimi-oauth/k3"), true);
+
+  // "Show all" is an explicit decision about every listed model, this one
+  // included, so a later rebuild must not undo it.
+  setAllModelsVisible(["kimi-oauth/k3", "gpt-5.6-sol", "gpt-5.6-sol-1m"], true);
+  seedModelsHidden(NATIVE_CONTEXT_VARIANT_SLUGS);
+  assert.deepEqual([...readHiddenModels()], []);
+});
+
+test("state written by an older install keeps its hidden models when the default lands", () => {
+  rmSync(MODEL_PICKER_STATE_PATH, { force: true });
+  // Exactly what a pre-upgrade `model-picker.json` looks like: no record of
+  // which models have ever been decided.
+  setModelVisible("kimi-oauth/k3", false);
+  const legacy = JSON.parse(readFileSync(MODEL_PICKER_STATE_PATH, "utf8"));
+  delete legacy.seeded;
+  writeFileSync(MODEL_PICKER_STATE_PATH, `${JSON.stringify(legacy, null, 2)}\n`, "utf8");
+
+  seedModelsHidden(NATIVE_CONTEXT_VARIANT_SLUGS);
+  const hidden = readHiddenModels();
+  assert.equal(hidden.has("kimi-oauth/k3"), true);
+  assert.equal(hidden.has("gpt-5.6-sol-1m"), true);
+});
+
+// --- the request path -------------------------------------------------------
+
+function routerBase(port) {
+  return callerBaseUrl(port, CALLER_KEY);
+}
+
+async function mockServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return { server, port: server.address().port };
+}
+
+async function readBody(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  const raw = Buffer.concat(chunks);
+  const decoded =
+    request.headers["content-encoding"] === "zstd" ? zstdDecompressSync(raw) : raw;
+  return JSON.parse(decoded.toString("utf8"));
+}
+
+function runRouter(env) {
+  const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
+      CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+      KIMI_INTERNAL_KEY: INTERNAL_KEY,
+      CODEX_ROUTER_QUIET: "1",
+      ...env,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let errors = "";
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+  child.testErrors = () => errors;
+  return child;
+}
+
+async function waitFor(url, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Child exited early (${child.exitCode}): ${child.testErrors()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Not bound yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${url}: ${child.testErrors()}`);
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await new Promise((resolve) => child.once("exit", resolve));
+}
+
+async function closeServer(server) {
+  await new Promise((resolve) => server.close(resolve));
+}
+
+async function waitUntil(predicate, message, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(message);
+}
+
+// The whole point of the variant: chatgpt.com has never heard of the slug the
+// picker offered, so a turn that reached it unchanged would 400 on every
+// message. The operator still has to see the model they picked.
+test("a turn on the variant reaches chatgpt.com as the base model", async () => {
+  const seen = [];
+  const native = await mockServer(async (request, response) => {
+    seen.push({ path: request.url, body: await readBody(request) });
+    const payload = Buffer.from(JSON.stringify({ id: "resp-1m", output: [] }), "utf8");
+    response.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "context-variant-state-"));
+  const routerPort = await openPort();
+  const router = runRouter({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${native.port}/v1`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const result = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { Authorization: "Bearer caller", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.6-sol-1m",
+        input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      }),
+    });
+
+    const relayed = await result.text();
+    assert.equal(result.status, 200, relayed);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].body.model, "gpt-5.6-sol");
+
+    // Reported under the slug the operator picked, or the tray would credit
+    // the turn to a model that is not the one in their picker.
+    await waitUntil(
+      () => usageEvents(stateDir).some((event) => event.model === "gpt-5.6-sol-1m"),
+      `No usage event named the variant: ${JSON.stringify(usageEvents(stateDir))}`,
+    );
+    assert.equal(
+      usageEvents(stateDir).some((event) => event.model === "gpt-5.6-sol"),
+      false,
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("a turn on a real native model is forwarded untouched", async () => {
+  const seen = [];
+  const native = await mockServer(async (request, response) => {
+    seen.push(await readBody(request));
+    const payload = Buffer.from(JSON.stringify({ id: "resp-base", output: [] }), "utf8");
+    response.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "context-variant-state-"));
+  const routerPort = await openPort();
+  const router = runRouter({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${native.port}/v1`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const result = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { Authorization: "Bearer caller", "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "gpt-5.6-sol",
+        input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      }),
+    });
+    assert.equal(result.status, 200, await result.text());
+    assert.equal(seen[0].model, "gpt-5.6-sol");
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+function usageEvents(stateDir) {
+  const file = path.join(stateDir, "usage-events.jsonl");
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+test.after(() => {
+  rmSync(pickerStateDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## What

Adds **GPT-5.6-Sol (1M context)** (`gpt-5.6-sol-1m`) to the Codex picker, under OpenAI, **switched off**.

Codex ships GPT-5.6 Sol with a 272,000-token window against a documented 1,050,000, and that number has already moved twice (openai/codex#31860, #32806). Editing `model_context_window` / `model_auto_compact_token_limit` in `config.toml` settles it for a whole machine; this settles it per task.

| Picker label | Model ID | Context window | Auto-compaction |
| --- | --- | --- | --- |
| GPT-5.6-Sol (1M context) | `gpt-5.6-sol-1m` | 1,000,000 | 900,000 |

## How

- `src/native-context-variants.mjs` derives the entry from the captured `gpt-5.6-sol`: everything is copied, only slug, name, description and the window/compaction pair are overridden. Announcement fields are cleared so one model does not announce twice.
- `src/router.mjs` translates the slug back to `gpt-5.6-sol` on the way out (turn path and the image/search path), so chatgpt.com only ever sees the model it published. Usage, activity and the log keep the slug the operator picked.
- **Off by default.** A turn resends the whole conversation and a request above 272,000 input tokens bills at a higher rate *in full*, so a model that costs more than the one it shadows is chosen rather than discovered. `model-picker.json` now records `seeded` beside `hidden`, so the default is applied once per slug and a rebuild can never re-apply it over the operator's answer in either direction. An older state file keeps every choice it held.
- **No variant in a login-free install** — those native slugs come from a server-supplied allowlist, so a synthesized one would take an alias slot and then be invisible.
- Every surface that enumerates the OpenAI group goes through the same helper, including the group's Show all / Hide all, which read the capture directly and would otherwise have left the row behind.

Switch it on in Settings under OpenAI, or `./bin/control picker set gpt-5.6-sol-1m show`.

## Test plan

- `npm run check` and `npm test`: **1483 pass, 0 fail**, 12 pre-existing skips.
- New `test/native-context-variants.test.mjs`: derivation and field carry-through, no-base/hidden-base/idempotence, login-free opt-out (asserted through `buildLoginFreeCatalog` alias slots), slug translation on a **live native turn** through a spawned router, untouched forwarding for a real slug, hidden-by-default seeding, survival of an explicit choice across a rebuild, and an older `model-picker.json` keeping its hidden models.
- `test/control.test.mjs`: the tray probe draws the row under OpenAI unchecked; a login-free probe draws no row.
- `test/doctor-routing-mode.test.mjs`: a real catalog build publishes the variant with `visibility: "hide"` while the base stays `list`.
- Manual, against this machine's real native capture in an isolated state dir: builds hidden → tray row unchecked → `picker set … show` → rebuild publishes it `list` at 1,000,000/900,000 → group Show all / Hide all covers it.