### PR TITLE
feat(retention): give retained tool results a lifetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,39 @@
   before: the forwarder is health-waited alongside the other three, an
   unbindable port still aborts startup naming the forwarder, and a forwarder
   that dies still ends the service so the OS supervisor rebuilds it.
+- **A retained tool result kept forever was an archive nobody chose.** The store
+  had a cap but no lifetime, so bytes retained today were still on disk a year
+  from now, and a store that reached 512 files or 512 MiB stopped retaining
+  anything new permanently — until somebody noticed and emptied it by hand.
+  Retained originals now expire after **7 days**.
+
+  The number is derived rather than round. Nothing ever reads those bytes back
+  into a turn: the receipt tells the model to repeat the tool call, so a
+  retained original's only reader is the operator, forensically, and only while
+  the session that produced it still matters. The caps say the same thing about
+  intent — 512 files and 512 MiB against a 32 KiB compaction floor is a working
+  set of a few long sessions, not a history. And a week is already this
+  repository's horizon for "recent enough to still act on", in the catalog's
+  announce window and the vision host's size cache alike.
+
+  Nothing sweeps on a timer and nothing is added to startup. Entries expire when
+  the store is next written to — the way the cooldown store is trimmed on its
+  next write, and the way a provider cooldown reads as gone long before anything
+  deletes it. `./bin/doctor` therefore reports what has already aged out rather
+  than what has been removed, and `./bin/control tool-result-aging purge
+  --expired` runs that sweep by hand for an install where compaction is off and
+  nothing is going to write again. It carries the same `--yes` consent, the same
+  `--dry-run`, and the same containment as a full purge, and it never removes
+  the key that binds the store's names to the install — expiring that would
+  orphan the entries the TTL just decided to keep.
+
+  `./bin/control tool-result-aging ttl <days|off|default>` sets the lifetime.
+  `off` is a real answer, kept verbatim: an operator who wants the archive keeps
+  it, and no later default overwrites that. A state file written before the TTL
+  existed never answered the question, so it reads as the default rather than as
+  "keep them forever". The `CODEX_ROUTER_TOOL_RESULT_AGING=0` kill switch does
+  not disable expiry — it stops the router rewriting request context, and expiry
+  is disk hygiene for bytes that are already written.
 
 - **The free Qwen3.8 endpoint refused any conversation whose system message
   arrived late or twice.** Its chat template answers those with a 400 reading

--- a/README.md
+++ b/README.md
@@ -688,13 +688,17 @@ environment-level override that disables both the routed and the native path.
 
 Where compaction parks the exact original bytes of a result it rewrote, they go
 to an owner-private store at `<state dir>/retained-tool-results` (override with
-`MODEL_ROUTER_TOOL_RESULT_RETENTION_DIR`). Nothing evicts that store and it has
-no TTL, so both a way to see it and a way to empty it are part of the feature:
+`MODEL_ROUTER_TOOL_RESULT_RETENTION_DIR`). Nothing evicts that store, so both a
+way to see it and a way to empty it are part of the feature:
 
 ```sh
-./bin/doctor                                   # reports count, size, oldest entry
-./bin/control tool-result-aging purge          # says what it would remove
-./bin/control tool-result-aging purge --yes    # removes it
+./bin/doctor                                     # count, size, oldest entry, TTL
+./bin/control tool-result-aging purge            # says what it would remove
+./bin/control tool-result-aging purge --yes      # removes it
+./bin/control tool-result-aging purge --expired  # only what the TTL outlived
+./bin/control tool-result-aging ttl 30           # keep retained results 30 days
+./bin/control tool-result-aging ttl off          # keep them until purged
+./bin/control tool-result-aging ttl default      # back to 7 days
 ```
 
 The doctor row appears whether or not the store exists, because an install that
@@ -705,6 +709,21 @@ default: without `--yes` it prints what it would remove and removes nothing, and
 files this store wrote, only inside that one directory, never recursing and
 never following a symlink out of it; anything else that ends up there is left in
 place and named.
+
+**Retained results expire after 7 days.** Nothing ever reads those bytes back
+into a turn — the receipt tells the model to repeat the tool call — so a
+retained original's only reader is you, and only while the session that produced
+it still matters. A week is also what keeps the store's caps from becoming
+permanent: at 512 files or 512 MiB retention stops accepting new results, and
+with a TTL that state drains by itself instead of waiting for somebody to notice
+it. Nothing sweeps on a timer: the store expires when it is next written to, and
+`purge --expired` runs the same sweep by hand, with the same `--yes` consent and
+the same containment as a full purge. The key that binds the store to this
+install is never expired, only purged. `ttl off` keeps everything until an
+explicit purge and is remembered verbatim, and the
+`CODEX_ROUTER_TOOL_RESULT_AGING=0` kill switch does not disable expiry — it
+stops the router rewriting context, while expiry is disk hygiene for bytes that
+are already written.
 
 To estimate the effect without spending provider quota, run:
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -455,11 +455,10 @@ are preserved.
 Tool-result compaction can park the exact original bytes of a result it rewrote
 in `<state dir>/retained-tool-results`. That store is owner-only, is excluded
 from support bundles, and is bounded rather than evicting — at its cap it stops
-accepting new results and eligible results pass through uncompacted — but
-nothing ever removes what is already in it.
+accepting new results and eligible results pass through uncompacted.
 
-`./bin/doctor` reports the store on every run: file count, total size, and the
-age of the oldest entry. To empty it:
+`./bin/doctor` reports the store on every run: file count, total size, the age
+of the oldest entry, and the TTL. To empty it:
 
 ```sh
 ./bin/control tool-result-aging purge          # what it would remove
@@ -471,6 +470,24 @@ itself wrote, only inside that one directory, and refuses to follow a symlink
 out of it; anything else that ends up there is reported and left alone. Deleting
 retained bytes is not reversible — a compacted result in an open session keeps
 its hash and head/tail evidence, but the original is gone.
+
+Retained results expire after 7 days by default, so most stores never need a
+purge at all. Nothing sweeps on a timer: entries expire when the store is next
+written to. On an install where compaction is off, or one that filled before the
+TTL existed, nothing is going to write again — run the sweep by hand:
+
+```sh
+./bin/control tool-result-aging purge --expired        # what has aged out
+./bin/control tool-result-aging purge --expired --yes  # remove it
+```
+
+`--expired` removes only entries past the TTL, under the same containment as a
+full purge, and never removes the store's key. Change the lifetime with
+`./bin/control tool-result-aging ttl <days>`, keep everything with `ttl off`, or
+return to the shipped default with `ttl default`. If doctor reports the store at
+its cap and the entries are recent, the TTL has nothing to drain yet: purge it
+or shorten the TTL. `CODEX_ROUTER_TOOL_RESULT_AGING=0` stops compaction but does
+not stop expiry.
 
 ## Uninstall retained files
 

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -955,36 +955,62 @@ async function handleSubagents(action, value, flag, rest = []) {
 }
 
 const TOOL_RESULT_AGING_USAGE =
-  "Usage: control tool-result-aging status|on|off|native <on|off>|purge [--yes] [--dry-run]";
+  "Usage: control tool-result-aging status|on|off|native <on|off>|ttl <days|off|default>|" +
+  "purge [--yes] [--dry-run] [--expired]";
 
 // Emptying the store deletes the only copy of bytes the model already saw, so
 // the default is the report and not the deletion: an invocation without --yes
 // says exactly what it would remove and removes nothing. --dry-run says the
 // same thing on purpose rather than by omission, and outranks --yes so a
 // wrapper that always passes consent can still preview.
+//
+// --expired removes only what the TTL has outlived. The store expires on the
+// next write to it, so this is the same sweep run by hand: it is what an
+// operator uses to reclaim a store that filled before the TTL existed, or one
+// on an install where compaction is off and nothing is going to write again.
 async function handleToolResultAgingPurge(flags) {
   const {
     describeRetentionAge,
+    describeRetentionTtl,
+    expireRetainedToolResults,
     formatRetentionBytes,
     purgeRetainedToolResults,
   } = await import("./tool-result-retention.mjs");
+  const { retentionTtlMs } = await import("./tool-result-aging-state.mjs");
   const requested = new Set(flags);
   const previewOnly = requested.has("--dry-run") || !(requested.has("--yes") || requested.has("-y"));
-  const result = purgeRetainedToolResults({ dryRun: previewOnly });
+  const expiredOnly = requested.has("--expired");
+  const ttlMs = retentionTtlMs();
+  if (expiredOnly && ttlMs === 0) {
+    throw new Error(
+      "Retained tool results have no TTL: this install was told to keep them. " +
+        "Set one with ./bin/control tool-result-aging ttl <days>, or purge without --expired.",
+    );
+  }
+  const result = expiredOnly
+    ? expireRetainedToolResults({ dryRun: previewOnly, ttlMs })
+    : purgeRetainedToolResults({ dryRun: previewOnly });
   const age =
     result.oldestAgeMs === undefined ? "" : `, oldest ${describeRetentionAge(result.oldestAgeMs)} old`;
+  const scope = expiredOnly ? ` older than ${describeRetentionTtl(ttlMs)}` : "";
   if (!result.exists || result.files === 0) {
     process.stderr.write(`No retained tool results in ${result.path}; nothing to purge.\n`);
+  } else if (expiredOnly && result.expired === 0) {
+    process.stderr.write(
+      `Nothing in ${result.path} is older than ${describeRetentionTtl(ttlMs)}` +
+        ` (${result.results} retained result(s)${age}); nothing to purge.\n`,
+    );
   } else if (previewOnly) {
     process.stderr.write(
-      `Would remove ${result.removed} file(s) (${result.results} retained result(s)${age}) ` +
+      `Would remove ${result.removed} file(s)${scope} ` +
+        `(${result.results} retained result(s)${age}) ` +
         `and reclaim ${formatRetentionBytes(result.reclaimedBytes)} from ${result.path}.\n` +
         `Nothing was deleted. Re-run with --yes to empty it: ` +
-        `./bin/control tool-result-aging purge --yes\n`,
+        `./bin/control tool-result-aging purge${expiredOnly ? " --expired" : ""} --yes\n`,
     );
   } else {
     process.stderr.write(
-      `Removed ${result.removed} file(s) and reclaimed ` +
+      `Removed ${result.removed} file(s)${scope} and reclaimed ` +
         `${formatRetentionBytes(result.reclaimedBytes)} from ${result.path}.\n`,
     );
   }
@@ -1001,6 +1027,7 @@ async function handleToolResultAgingPurge(flags) {
 async function handleToolResultAging(action, nativeAction, flags = []) {
   const {
     setNativeToolResultAgingEnabled,
+    setRetentionTtlDays,
     setToolResultAgingEnabled,
     toolResultAgingSnapshot,
   } = await import("./tool-result-aging-state.mjs");
@@ -1011,6 +1038,22 @@ async function handleToolResultAging(action, nativeAction, flags = []) {
   }
   if (desired === "purge") {
     await handleToolResultAgingPurge(flags);
+    return;
+  }
+  // How long a retained original lives. `off` is a real answer and is kept
+  // verbatim -- an operator who wants the archive keeps it -- while `default`
+  // clears the answer so a later release's number applies again.
+  if (desired === "ttl") {
+    const requested = String(nativeAction ?? "").trim();
+    if (!requested) throw new Error(TOOL_RESULT_AGING_USAGE);
+    if (requested === "default") {
+      setRetentionTtlDays(undefined);
+    } else if (requested === "off" || requested === "never") {
+      setRetentionTtlDays(0);
+    } else {
+      setRetentionTtlDays(requested.replace(/d$/u, ""));
+    }
+    process.stdout.write(`${JSON.stringify(toolResultAgingSnapshot())}\n`);
     return;
   }
   if (desired === "native") {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -70,9 +70,11 @@ import {
 } from "./dependency-repair.mjs";
 import {
   describeRetentionAge,
+  describeRetentionTtl,
   formatRetentionBytes,
   retainedToolResultsUsage,
 } from "./tool-result-retention.mjs";
+import { retentionTtlMs } from "./tool-result-aging-state.mjs";
 
 const checks = [];
 const add = (status, name, detail, fix) => checks.push({ status, name, detail, fix });
@@ -722,11 +724,24 @@ add(
 // most installs should see, and seeing it is how the directory becomes
 // discoverable at all.
 try {
-  const retention = retainedToolResultsUsage();
+  const ttlMs = retentionTtlMs();
+  const retention = retainedToolResultsUsage({ ttlMs });
+  // The TTL expires on the next write to the store, so a count here is what is
+  // already dead rather than what has been removed -- the same way a cooldown
+  // reads as gone before anything deletes it. Naming it is what tells an
+  // operator whose install stopped compacting that `purge --expired` is the
+  // sweep, not a wait.
+  const expiry =
+    !retention.exists || ttlMs === 0
+      ? ""
+      : retention.expired
+        ? `, ${retention.expired} past the ${describeRetentionTtl(ttlMs)} TTL`
+        : `, TTL ${describeRetentionTtl(ttlMs)}`;
   const retentionDetail = !retention.exists
     ? `nothing retained; no store at ${retention.path}`
     : `${retention.results} retained result(s), ${formatRetentionBytes(retention.bytes)}` +
       `${retention.oldestAgeMs === undefined ? "" : `, oldest ${describeRetentionAge(retention.oldestAgeMs)} old`}` +
+      `${expiry}` +
       ` in ${retention.path}`;
   add(
     retention.capacityReached || retention.foreign.length ? "warn" : "ok",

--- a/src/tool-result-aging-state.mjs
+++ b/src/tool-result-aging-state.mjs
@@ -6,6 +6,12 @@ import path from "node:path";
 
 import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
+import {
+  RETENTION_DEFAULT_TTL_DAYS,
+  RETENTION_MAX_TTL_DAYS,
+  RETENTION_MIN_TTL_DAYS,
+  retentionTtlMsFromDays,
+} from "./tool-result-retention.mjs";
 import { toolResultAgingTotals } from "./usage-events.mjs";
 
 export const TOOL_RESULT_AGING_STATE_PATH =
@@ -22,11 +28,35 @@ export const TOOL_RESULT_AGING_STATE_PATH =
 // operator's own answer and is kept verbatim, so turning this on survives any
 // later change of default.
 function defaultSettings() {
-  return { version: 1, enabled: false, nativeEnabled: false, defaulted: true };
+  return {
+    version: 1,
+    enabled: false,
+    nativeEnabled: false,
+    retentionTtlDays: RETENTION_DEFAULT_TTL_DAYS,
+    defaulted: true,
+  };
 }
 
 function disabledSettings() {
-  return { version: 1, enabled: false, nativeEnabled: false };
+  return {
+    version: 1,
+    enabled: false,
+    nativeEnabled: false,
+    retentionTtlDays: RETENTION_DEFAULT_TTL_DAYS,
+  };
+}
+
+// How long a retained original lives. Absent means nobody has answered, so the
+// default applies and a later release may change it; a stored number is the
+// operator's own answer and is kept verbatim, including `0`, which is "keep
+// them until I say otherwise" and is the one answer a default must never
+// overwrite -- expiry deletes bytes the model already saw.
+function readRetentionTtlDays(value) {
+  if (value === undefined || value === null) return RETENTION_DEFAULT_TTL_DAYS;
+  const days = Number(value);
+  if (!Number.isFinite(days) || days < 0) return RETENTION_DEFAULT_TTL_DAYS;
+  if (days === 0) return 0;
+  return Math.min(RETENTION_MAX_TTL_DAYS, Math.max(RETENTION_MIN_TTL_DAYS, days));
 }
 
 export function readToolResultAgingSettings() {
@@ -40,6 +70,10 @@ export function readToolResultAgingSettings() {
         // Absent on files written before the native flag existed; absence is
         // the off default, never an error.
         nativeEnabled: parsed.nativeEnabled === true,
+        // Absent on every file written before the TTL existed, which reads as
+        // the default rather than as "keep forever" -- those installs never
+        // had a choice to preserve.
+        retentionTtlDays: readRetentionTtlDays(parsed.retentionTtlDays),
       };
     }
   } catch {
@@ -59,6 +93,7 @@ export function setToolResultAgingEnabled(enabled) {
     version: 1,
     enabled: enabled === true,
     nativeEnabled: current.nativeEnabled === true,
+    retentionTtlDays: current.retentionTtlDays,
   });
 }
 
@@ -68,7 +103,52 @@ export function setNativeToolResultAgingEnabled(enabled) {
     version: 1,
     enabled: current.enabled === true,
     nativeEnabled: enabled === true,
+    retentionTtlDays: current.retentionTtlDays,
   });
+}
+
+/**
+ * Choose how long retained originals live. `0` keeps them until an explicit
+ * purge; `undefined` restores the default and lets a later release move it.
+ */
+export function setRetentionTtlDays(days) {
+  const current = readToolResultAgingSettings();
+  let requested;
+  if (days === undefined || days === null || days === "") {
+    requested = RETENTION_DEFAULT_TTL_DAYS;
+  } else {
+    const value = Number(days);
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error(
+        `Retention TTL must be a number of days, or 0 to keep retained results: ${days}`,
+      );
+    }
+    if (value > 0 && (value < RETENTION_MIN_TTL_DAYS || value > RETENTION_MAX_TTL_DAYS)) {
+      throw new Error(
+        `Retention TTL must be 0 (off) or between ${RETENTION_MIN_TTL_DAYS} and ` +
+          `${RETENTION_MAX_TTL_DAYS} days: ${days}`,
+      );
+    }
+    requested = value;
+  }
+  return writeSettings({
+    version: 1,
+    enabled: current.enabled === true,
+    nativeEnabled: current.nativeEnabled === true,
+    retentionTtlDays: requested,
+  });
+}
+
+export function retentionTtlDays() {
+  return readToolResultAgingSettings().retentionTtlDays;
+}
+
+// The lifetime every reader of the store resolves. The environment kill switch
+// is deliberately not consulted: it stops the router rewriting request context,
+// and expiry is disk hygiene for bytes that were already written -- silencing
+// compaction is no reason to keep an aging archive alive forever.
+export function retentionTtlMs() {
+  return retentionTtlMsFromDays(retentionTtlDays());
 }
 
 export function toolResultAgingEnabled() {

--- a/src/tool-result-retention.mjs
+++ b/src/tool-result-retention.mjs
@@ -6,10 +6,12 @@ import { STATE_DIR } from "./paths.mjs";
 // Where compaction parks the exact original bytes of a tool result it has
 // rewritten. The directory is owner-private, is excluded from support bundles,
 // and is the first place this router persists model-visible *content* to disk.
-// Nothing here writes to it -- this module only reads it and empties it -- so
-// the path is resolved exactly the way the retention writer resolves it,
-// including the environment override, or a purge would look in a directory the
-// writer never used.
+// Nothing here writes to it -- this module only reads it, empties it, and ages
+// entries out of it -- so the path is resolved exactly the way the retention
+// writer resolves it, including the environment override, or a purge would look
+// in a directory the writer never used. A writer belongs on the other side of
+// `expireRetainedToolResults`: it already scans this directory to check the caps
+// before every write, and that scan is where the TTL costs nothing extra.
 export const TOOL_RESULT_RETENTION_DIR =
   process.env.MODEL_ROUTER_TOOL_RESULT_RETENTION_DIR ||
   path.join(STATE_DIR, "retained-tool-results");
@@ -31,8 +33,58 @@ const RETENTION_KEY_NAME = ".retention-key";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+// How long a retained original is worth keeping, by default.
+//
+// Seven days, and the number is derived rather than round. Nothing ever reads
+// these bytes back into a turn: the receipt tells the model to repeat the tool
+// call, so a retained file's only reader is the operator, forensically, and
+// only while the session that produced it still matters. The caps say the same
+// thing about intent -- 512 files and 512 MiB against a 32 KiB compaction floor
+// is a working set of a few long sessions, not an archive. Seven days is also
+// the horizon this repository already treats as "recent enough to still act on"
+// in the two other places it keeps something around: the catalog's
+// AUTO_ANNOUNCE_WINDOW_MS and the vision host's SIZE_CACHE_TTL_MS are both
+// exactly a week. Anything shorter would delete a store mid-session; anything
+// longer keeps file contents and command output past every use they have.
+//
+// The cap failure the TTL actually fixes: a store parked at 512 files stops
+// accepting new results permanently. With a TTL it drains itself a week later
+// instead of waiting for somebody to notice.
+export const RETENTION_DEFAULT_TTL_DAYS = 7;
+export const RETENTION_DEFAULT_TTL_MS = RETENTION_DEFAULT_TTL_DAYS * DAY_MS;
+
+// A stored TTL is the operator's own answer, so it is bounded only where a
+// value stops meaning anything: below a day it would expire a store while the
+// session that filled it is still running, and ten years is past any disk this
+// would be measured on.
+export const RETENTION_MIN_TTL_DAYS = 1;
+export const RETENTION_MAX_TTL_DAYS = 3_650;
+
+export function retentionTtlDaysFromMs(ttlMs) {
+  return Number.isFinite(ttlMs) && ttlMs > 0 ? ttlMs / DAY_MS : 0;
+}
+
+export function retentionTtlMsFromDays(days) {
+  const value = Number(days);
+  return Number.isFinite(value) && value > 0 ? value * DAY_MS : 0;
+}
+
+export function describeRetentionTtl(ttlMs) {
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) return "off";
+  const days = retentionTtlDaysFromMs(ttlMs);
+  return Number.isInteger(days) ? `${days}d` : `${days.toFixed(1)}d`;
+}
+
 function isRetentionEntry(name) {
   if (name === RETENTION_KEY_NAME) return true;
+  return RESULT_FILE_PATTERN.test(name) || STAGE_FILE_PATTERN.test(name);
+}
+
+// The key is not a retained result and does not age out with one. It is what
+// binds the store's names to this install, so dropping it while retained
+// results are still live would orphan the entries the TTL just decided to
+// keep. Purge removes it because purge empties the store; expiry never does.
+function isExpirable(name) {
   return RESULT_FILE_PATTERN.test(name) || STAGE_FILE_PATTERN.test(name);
 }
 
@@ -78,12 +130,19 @@ export function describeRetentionAge(ageMs) {
  * wrote, including the key and any interrupted stage. `foreign` counts entries
  * this store did not write, which purge will refuse to touch and which are
  * worth naming rather than silently ignoring.
+ *
+ * With a `ttlMs`, it also reports how much of that is already past its
+ * lifetime. Reporting is all this does: expiry happens on the next write to
+ * the store or on an explicit sweep, the same way a provider cooldown is read
+ * as gone long before anything deletes it.
  */
 export function retainedToolResultsUsage({
   directory = TOOL_RESULT_RETENTION_DIR,
   now = Date.now(),
+  ttlMs = 0,
 } = {}) {
   const root = path.resolve(directory);
+  const lifetime = Number.isFinite(ttlMs) && ttlMs > 0 ? ttlMs : 0;
   const empty = {
     path: root,
     exists: false,
@@ -95,6 +154,10 @@ export function retainedToolResultsUsage({
     oldestAgeMs: undefined,
     entries: [],
     capacityReached: false,
+    ttlMs: lifetime,
+    expired: 0,
+    expiredResults: 0,
+    expiredBytes: 0,
   };
   let listing;
   try {
@@ -113,6 +176,9 @@ export function retainedToolResultsUsage({
   let results = 0;
   let bytes = 0;
   let oldestMs;
+  let expiredCount = 0;
+  let expiredResults = 0;
+  let expiredBytes = 0;
   for (const entry of listing) {
     const name = entry.name;
     let stat;
@@ -129,10 +195,19 @@ export function retainedToolResultsUsage({
       foreign.push(name);
       continue;
     }
-    entries.push({ name, bytes: stat.size, mtimeMs: stat.mtimeMs });
+    // A future mtime is a clock that moved, not an entry that has aged
+    // backwards, so age floors at zero and such an entry simply survives.
+    const ageMs = Math.max(0, now - stat.mtimeMs);
+    const expired = lifetime > 0 && isExpirable(name) && ageMs > lifetime;
+    entries.push({ name, bytes: stat.size, mtimeMs: stat.mtimeMs, ageMs, expired });
     bytes += stat.size;
+    if (expired) {
+      expiredCount += 1;
+      expiredBytes += stat.size;
+    }
     if (RESULT_FILE_PATTERN.test(name)) {
       results += 1;
+      if (expired) expiredResults += 1;
       if (oldestMs === undefined || stat.mtimeMs < oldestMs) oldestMs = stat.mtimeMs;
     }
   }
@@ -147,6 +222,10 @@ export function retainedToolResultsUsage({
     oldestAgeMs: oldestMs === undefined ? undefined : Math.max(0, now - oldestMs),
     entries,
     capacityReached: results >= RETENTION_MAX_FILES || bytes >= RETENTION_MAX_TOTAL_BYTES,
+    ttlMs: lifetime,
+    expired: expiredCount,
+    expiredResults,
+    expiredBytes,
   };
 }
 
@@ -177,8 +256,62 @@ export function purgeRetainedToolResults({
     failed: [],
   };
   if (!usage.exists || usage.files === 0) return summary;
-  for (const entry of usage.entries) {
-    const target = retentionEntryPath(usage.path, entry.name);
+  removeRetentionEntries(usage.path, usage.entries, summary);
+  return summary;
+}
+
+/**
+ * Drop retained results the TTL has outlived, or report which ones it would.
+ *
+ * Same containment as a purge, because it is the same removal: only names
+ * retention itself produces, only entries whose resolved parent is this one
+ * directory, `lstat` never `stat`, no recursion, and no symlink followed or
+ * removed. The key is never expired -- see `isExpirable`.
+ *
+ * Nothing sweeps on a timer. This runs when the store is next written to, the
+ * way `writeCooldownDocument` trims the cooldown store on its next write, and
+ * on an operator's explicit `purge --expired`. A TTL of zero means the operator
+ * asked to keep everything, and this removes nothing at all.
+ */
+export function expireRetainedToolResults({
+  directory = TOOL_RESULT_RETENTION_DIR,
+  ttlMs = RETENTION_DEFAULT_TTL_MS,
+  dryRun = false,
+  now = Date.now(),
+} = {}) {
+  const lifetime = Number.isFinite(ttlMs) && ttlMs > 0 ? ttlMs : 0;
+  const usage = retainedToolResultsUsage({ directory, now, ttlMs: lifetime });
+  const summary = {
+    path: usage.path,
+    exists: usage.exists,
+    dryRun: dryRun === true,
+    ttlMs: lifetime,
+    results: usage.results,
+    files: usage.files,
+    bytes: usage.bytes,
+    foreign: usage.foreign,
+    oldestAgeMs: usage.oldestAgeMs,
+    expired: usage.expired,
+    expiredResults: usage.expiredResults,
+    expiredBytes: usage.expiredBytes,
+    removed: 0,
+    reclaimedBytes: 0,
+    failed: [],
+  };
+  if (!usage.exists || lifetime === 0 || usage.expired === 0) return summary;
+  removeRetentionEntries(
+    usage.path,
+    usage.entries.filter((entry) => entry.expired),
+    summary,
+  );
+  return summary;
+}
+
+// One removal path for both commands: whatever a caller decided to remove, it
+// still leaves this module through the same containment check.
+function removeRetentionEntries(root, entries, summary) {
+  for (const entry of entries) {
+    const target = retentionEntryPath(root, entry.name);
     if (summary.dryRun) {
       summary.removed += 1;
       summary.reclaimedBytes += entry.bytes;

--- a/test/tool-result-aging-state.test.mjs
+++ b/test/tool-result-aging-state.test.mjs
@@ -11,11 +11,16 @@ const {
   TOOL_RESULT_AGING_STATE_PATH,
   nativeToolResultAgingEnabled,
   readToolResultAgingSettings,
+  retentionTtlMs,
   setNativeToolResultAgingEnabled,
+  setRetentionTtlDays,
   setToolResultAgingEnabled,
   toolResultAgingEnabled,
   toolResultAgingSnapshot,
 } = await import("../src/tool-result-aging-state.mjs");
+
+const { RETENTION_DEFAULT_TTL_DAYS } = await import("../src/tool-result-retention.mjs");
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 function forgetState() {
   rmSync(TOOL_RESULT_AGING_STATE_PATH, { force: true });
@@ -30,6 +35,7 @@ test("tool-result aging defaults off until it is configured", () => {
     version: 1,
     enabled: false,
     nativeEnabled: false,
+    retentionTtlDays: RETENTION_DEFAULT_TTL_DAYS,
     defaulted: true,
   });
   assert.equal(toolResultAgingSnapshot().configured, false);
@@ -43,6 +49,7 @@ test("tool-result aging toggle round-trips through protected state", () => {
     version: 1,
     enabled: false,
     nativeEnabled: false,
+    retentionTtlDays: RETENTION_DEFAULT_TTL_DAYS,
   });
   assert.equal(toolResultAgingEnabled(), false);
   assert.equal(toolResultAgingSnapshot().configured, true);
@@ -80,6 +87,9 @@ test("a pre-native state file reads as native off, not as corrupt", () => {
     version: 1,
     enabled: true,
     nativeEnabled: false,
+    // A file written before the TTL existed never answered the question, so it
+    // reads as the default rather than as "keep them forever".
+    retentionTtlDays: RETENTION_DEFAULT_TTL_DAYS,
   });
 });
 
@@ -120,7 +130,65 @@ test("corrupt explicit state fails closed", () => {
     version: 1,
     enabled: false,
     nativeEnabled: false,
+    retentionTtlDays: RETENTION_DEFAULT_TTL_DAYS,
   });
   assert.equal(toolResultAgingEnabled(), false);
   assert.equal(nativeToolResultAgingEnabled(), false);
+});
+
+// The TTL deletes bytes the model already saw, so an operator's answer is kept
+// verbatim in both directions: a shorter lifetime and "keep them" alike.
+test("the retention TTL defaults to a week and round-trips through protected state", () => {
+  forgetState();
+  assert.equal(readToolResultAgingSettings().retentionTtlDays, RETENTION_DEFAULT_TTL_DAYS);
+  assert.equal(retentionTtlMs(), RETENTION_DEFAULT_TTL_DAYS * DAY_MS);
+
+  setRetentionTtlDays(2);
+  assert.equal(readToolResultAgingSettings().retentionTtlDays, 2);
+  assert.equal(retentionTtlMs(), 2 * DAY_MS);
+  assert.equal(toolResultAgingSnapshot().retentionTtlDays, 2);
+
+  // Zero is an answer, not an absence: it means keep them until an explicit
+  // purge, and no default may overwrite it.
+  setRetentionTtlDays(0);
+  assert.equal(readToolResultAgingSettings().retentionTtlDays, 0);
+  assert.equal(retentionTtlMs(), 0);
+
+  setRetentionTtlDays(undefined);
+  assert.equal(readToolResultAgingSettings().retentionTtlDays, RETENTION_DEFAULT_TTL_DAYS);
+});
+
+test("the TTL survives the aging toggles, and they survive it", () => {
+  forgetState();
+  setRetentionTtlDays(3);
+  setToolResultAgingEnabled(true);
+  setNativeToolResultAgingEnabled(true);
+  assert.equal(readToolResultAgingSettings().retentionTtlDays, 3);
+
+  setRetentionTtlDays(0);
+  assert.equal(toolResultAgingEnabled(), true);
+  assert.equal(nativeToolResultAgingEnabled(), true);
+  forgetState();
+});
+
+test("a TTL that is not a number of days is refused rather than stored", () => {
+  forgetState();
+  assert.throws(() => setRetentionTtlDays("soon"), /number of days/u);
+  assert.throws(() => setRetentionTtlDays(-1), /number of days/u);
+  assert.throws(() => setRetentionTtlDays(0.5), /between 1 and 3650 days/u);
+  assert.throws(() => setRetentionTtlDays(4_000), /between 1 and 3650 days/u);
+  assert.equal(readToolResultAgingSettings().retentionTtlDays, RETENTION_DEFAULT_TTL_DAYS);
+});
+
+// The kill switch stops the router rewriting request context. Expiry is disk
+// hygiene for bytes already written, so silencing compaction must not strand an
+// aging archive on disk forever.
+test("the environment kill switch does not disable the retention TTL", () => {
+  forgetState();
+  setRetentionTtlDays(2);
+  process.env.CODEX_ROUTER_TOOL_RESULT_AGING = "0";
+  assert.equal(toolResultAgingEnabled(), false);
+  assert.equal(retentionTtlMs(), 2 * DAY_MS);
+  delete process.env.CODEX_ROUTER_TOOL_RESULT_AGING;
+  forgetState();
 });

--- a/test/tool-result-retention.test.mjs
+++ b/test/tool-result-retention.test.mjs
@@ -292,3 +292,262 @@ test("a store parked at its file cap is reported as a warning, not as healthy", 
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+// --- the TTL ---------------------------------------------------------------
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function ageEntry(store, name, days) {
+  const seconds = Math.floor(Date.now() / 1000) - Math.round(days * 24 * 60 * 60);
+  utimesSync(path.join(store, name), seconds, seconds);
+}
+
+function agingStatePath(stateDir, settings) {
+  const file = path.join(stateDir, "tool-result-aging.json");
+  if (settings) writeFileSync(file, `${JSON.stringify({ version: 1, ...settings })}\n`, "utf8");
+  return file;
+}
+
+test("the TTL expires what has outlived it and keeps everything younger", async () => {
+  const { expireRetainedToolResults } = await import("../src/tool-result-retention.mjs");
+  const { stateDir, store } = stageStore({
+    [`${handle("A")}.result`]: "a".repeat(4_000),
+    [`${handle("B")}.result`]: "b".repeat(1_000),
+    [`.${handle("C")}.stage.${"0".repeat(32)}`]: "interrupted",
+    ".retention-key": "key",
+  });
+  try {
+    ageEntry(store, `${handle("A")}.result`, 9);
+    ageEntry(store, `.${handle("C")}.stage.${"0".repeat(32)}`, 30);
+    ageEntry(store, ".retention-key", 400);
+    const result = expireRetainedToolResults({ directory: store, ttlMs: 7 * DAY_MS });
+    assert.equal(result.expired, 2);
+    assert.equal(result.expiredResults, 1);
+    assert.equal(result.removed, 2);
+    assert.equal(result.reclaimedBytes, 4_000 + 11);
+    assert.deepEqual(result.failed, []);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), false);
+    // Younger than the TTL, so it stays byte-for-byte.
+    assert.equal(readFileSync(path.join(store, `${handle("B")}.result`), "utf8"), "b".repeat(1_000));
+    // The key binds the store's names to this install. Expiring it would orphan
+    // the entries the TTL just decided to keep, so it never ages out.
+    assert.equal(existsSync(path.join(store, ".retention-key")), true);
+    assert.equal(existsSync(store), true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("a TTL of zero is an answer: nothing expires and nothing is removed", async () => {
+  const { expireRetainedToolResults } = await import("../src/tool-result-retention.mjs");
+  const { stateDir, store } = stageStore({ [`${handle("A")}.result`]: "a".repeat(64) });
+  try {
+    ageEntry(store, `${handle("A")}.result`, 900);
+    const result = expireRetainedToolResults({ directory: store, ttlMs: 0 });
+    assert.equal(result.ttlMs, 0);
+    assert.equal(result.expired, 0);
+    assert.equal(result.removed, 0);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("expiry previews without --yes, exactly as a purge does", async () => {
+  const { expireRetainedToolResults } = await import("../src/tool-result-retention.mjs");
+  const { stateDir, store } = stageStore({ [`${handle("A")}.result`]: "a".repeat(2_048) });
+  try {
+    ageEntry(store, `${handle("A")}.result`, 8);
+    const result = expireRetainedToolResults({
+      directory: store,
+      ttlMs: 7 * DAY_MS,
+      dryRun: true,
+    });
+    assert.equal(result.dryRun, true);
+    assert.equal(result.removed, 1);
+    assert.equal(result.reclaimedBytes, 2_048);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// The cap is the reason the TTL exists: a store parked at 512 files stops
+// retaining anything new, permanently, until somebody empties it. Aging it out
+// has to actually clear that state, or the TTL fixes nothing.
+test("expiry drains a store parked at its file cap, and the cap still binds", async () => {
+  const { RETENTION_MAX_FILES, expireRetainedToolResults, retainedToolResultsUsage } =
+    await import("../src/tool-result-retention.mjs");
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "retained-ttl-capacity-"));
+  const store = path.join(stateDir, "retained-tool-results");
+  mkdirSync(store, { recursive: true, mode: 0o700 });
+  try {
+    for (let index = 0; index < RETENTION_MAX_FILES; index += 1) {
+      const name = `${String(index).padStart(43, "0")}.result`;
+      writeFileSync(path.join(store, name), "x", { mode: 0o600 });
+      if (index < RETENTION_MAX_FILES - 1) ageEntry(store, name, 8);
+    }
+    const before = retainedToolResultsUsage({ directory: store, ttlMs: 7 * DAY_MS });
+    assert.equal(before.capacityReached, true);
+    assert.equal(before.expired, RETENTION_MAX_FILES - 1);
+
+    const result = expireRetainedToolResults({ directory: store, ttlMs: 7 * DAY_MS });
+    assert.equal(result.removed, RETENTION_MAX_FILES - 1);
+    const after = retainedToolResultsUsage({ directory: store, ttlMs: 7 * DAY_MS });
+    assert.equal(after.results, 1);
+    assert.equal(after.capacityReached, false);
+    assert.equal(after.expired, 0);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// Expiry deletes on an age rather than on an operator's explicit "empty it", so
+// it needs the containment purge has, not less of it.
+test("expiry deletes nothing it did not write and never follows a link out of the store", async () => {
+  const { expireRetainedToolResults } = await import("../src/tool-result-retention.mjs");
+  const { stateDir, store } = stageStore({
+    [`${handle("A")}.result`]: "a".repeat(512),
+    "notes.txt": "not ours",
+    "short.result": "wrong handle shape",
+  });
+  const outsider = path.join(stateDir, "outside-the-store.txt");
+  writeFileSync(outsider, "must survive", { mode: 0o600 });
+  mkdirSync(path.join(store, "nested"), { recursive: true, mode: 0o700 });
+  writeFileSync(path.join(store, "nested", `${handle("E")}.result`), "nested", { mode: 0o600 });
+  if (process.platform !== "win32") {
+    symlinkSync(outsider, path.join(store, `${handle("D")}.result`));
+  }
+  const ancient = Math.floor(Date.now() / 1000) - 900 * 24 * 60 * 60;
+  for (const name of ["notes.txt", "short.result", `${handle("A")}.result`]) {
+    utimesSync(path.join(store, name), ancient, ancient);
+  }
+  utimesSync(outsider, ancient, ancient);
+  utimesSync(path.join(store, "nested"), ancient, ancient);
+  try {
+    const result = expireRetainedToolResults({ directory: store, ttlMs: DAY_MS });
+    assert.equal(result.removed, 1);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), false);
+    assert.equal(readFileSync(outsider, "utf8"), "must survive");
+    assert.equal(existsSync(path.join(store, "notes.txt")), true);
+    assert.equal(existsSync(path.join(store, "short.result")), true);
+    // No recursion: a directory is foreign, and what is under it is not read.
+    assert.equal(existsSync(path.join(store, "nested", `${handle("E")}.result`)), true);
+    assert.ok(result.foreign.includes("notes.txt"));
+    assert.ok(result.foreign.includes("nested"));
+    if (process.platform !== "win32") {
+      // The link is neither followed nor removed; refusing it is what proves
+      // nothing resolved through it.
+      assert.equal(existsSync(path.join(store, `${handle("D")}.result`)), true);
+      assert.ok(result.foreign.includes(`${handle("D")}.result`));
+    }
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("purge --expired removes only what the TTL outlived, and previews first", () => {
+  const { stateDir, store } = stageStore({
+    [`${handle("A")}.result`]: "a".repeat(2_048),
+    [`${handle("B")}.result`]: "b".repeat(1_024),
+    ".retention-key": "key",
+  });
+  const agingState = agingStatePath(stateDir, { enabled: true, retentionTtlDays: 7 });
+  try {
+    ageEntry(store, `${handle("A")}.result`, 10);
+    const preview = purge(store, ["--expired"], {
+      MODEL_ROUTER_TOOL_RESULT_AGING_STATE: agingState,
+    });
+    assert.equal(preview.status, 0);
+    assert.equal(preview.json.dryRun, true);
+    assert.equal(preview.json.removed, 1);
+    assert.match(preview.stderr, /Would remove 1 file\(s\) older than 7d/);
+    assert.match(preview.stderr, /purge --expired --yes/);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), true);
+
+    const applied = purge(store, ["--expired", "--yes"], {
+      MODEL_ROUTER_TOOL_RESULT_AGING_STATE: agingState,
+    });
+    assert.equal(applied.status, 0);
+    assert.equal(applied.json.dryRun, false);
+    assert.equal(applied.json.removed, 1);
+    assert.equal(applied.json.reclaimedBytes, 2_048);
+    assert.match(applied.stderr, /Removed 1 file\(s\) older than 7d/);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), false);
+    assert.equal(existsSync(path.join(store, `${handle("B")}.result`)), true);
+    assert.equal(existsSync(path.join(store, ".retention-key")), true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("purge --expired says so when nothing has aged out yet", () => {
+  const { stateDir, store } = stageStore({ [`${handle("A")}.result`]: "a".repeat(64) });
+  const agingState = agingStatePath(stateDir, { enabled: true, retentionTtlDays: 7 });
+  try {
+    const result = purge(store, ["--expired", "--yes"], {
+      MODEL_ROUTER_TOOL_RESULT_AGING_STATE: agingState,
+    });
+    assert.equal(result.status, 0);
+    assert.equal(result.json.removed, 0);
+    assert.match(result.stderr, /Nothing in .* is older than 7d/);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// An install that asked to keep its retained results has no TTL to sweep. A
+// command that quietly emptied the store instead would be the worst possible
+// reading of "--expired".
+test("purge --expired refuses on an install whose TTL is off", () => {
+  const { stateDir, store } = stageStore({ [`${handle("A")}.result`]: "a".repeat(64) });
+  const agingState = agingStatePath(stateDir, { enabled: true, retentionTtlDays: 0 });
+  try {
+    ageEntry(store, `${handle("A")}.result`, 900);
+    const result = purge(store, ["--expired", "--yes"], {
+      MODEL_ROUTER_TOOL_RESULT_AGING_STATE: agingState,
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /no TTL/);
+    assert.equal(existsSync(path.join(store, `${handle("A")}.result`)), true);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("an unknown tool-result-aging action names the TTL in its usage", () => {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(root, "src", "control.mjs"), "tool-result-aging", "nonsense"],
+    { cwd: root, encoding: "utf8" },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /ttl <days\|off\|default>/);
+});
+
+test(
+  "doctor names the TTL, and counts what it has already outlived",
+  { timeout: 120_000 },
+  () => {
+    const codexHome = mkdtempSync(path.join(os.tmpdir(), "retained-doctor-ttl-"));
+    const stateDir = path.join(codexHome, "codex-router");
+    const store = path.join(stateDir, "retained-tool-results");
+    mkdirSync(store, { recursive: true, mode: 0o700 });
+    writeFileSync(path.join(store, `${handle("A")}.result`), "a".repeat(1_024), { mode: 0o600 });
+    writeFileSync(path.join(store, `${handle("B")}.result`), "b".repeat(1_024), { mode: 0o600 });
+    ageEntry(store, `${handle("A")}.result`, 12);
+    try {
+      const fresh = doctorCheck(stateDir, "Retained tool results");
+      assert.ok(fresh, "doctor reports a retained-tool-results row");
+      assert.match(fresh.detail, /1 past the 7d TTL/);
+      // A store with nothing past its lifetime still names the lifetime, so the
+      // TTL is discoverable before it has deleted anything.
+      agingStatePath(stateDir, { enabled: true, retentionTtlDays: 30 });
+      const relaxed = doctorCheck(stateDir, "Retained tool results");
+      assert.match(relaxed.detail, /, TTL 30d in /);
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
Implements the TTL from the third bullet of #251, so all three asks are now done. Builds on the purge and doctor row from #277.

## 7 days — derived, not round

Three independent lines point at a week:

1. **Nothing ever reads retained bytes back into a turn.** `src/tool-result-aging.mjs`'s `resultReceipt` tells the model to *repeat the tool call*, and #245's owner-retrieval UI was explicitly left out. So a retained original's only reader is the operator, forensically, and only while the session that produced it still matters.
2. **The caps say the same about intent.** 512 files / 512 MiB against the 32 KiB `TOOL_RESULT_AGING_MIN_BYTES` floor is a working set of a few long sessions (~1 MiB average), not a history.
3. **A week is already this repo's "recent enough to still act on" horizon** — the only two other places it keeps something around use it: `AUTO_ANNOUNCE_WINDOW_MS` (`src/catalog.mjs`) and `SIZE_CACHE_TTL_MS` (`src/vision-host.mjs`).

Anything shorter expires a store mid-session; anything longer is an archive.

## Configured the house way

`./bin/control tool-result-aging ttl <days|off|default>`, stored as `retentionTtlDays` in the same versioned private JSON the aging toggles already use (`tool-result-aging.json`, `writePrivateJson`).

This matches how `failover` and `tool-result-aging` already work: operator **policy** lives in a versioned state doc plus a `control` subcommand, while **limits** (`MAX_COOLDOWN_MS`, `RETENTION_MAX_FILES`) are named module constants. No new mechanism, no new env var.

`off` is a real answer, kept verbatim. A state file written before the TTL existed never answered the question, so it reads as the default. `CODEX_ROUTER_TOOL_RESULT_AGING=0` deliberately does **not** disable expiry — it stops the router rewriting request context; expiry is disk hygiene for bytes already written.

## Expiry runs on the next write, never on a timer

Precedent is explicit: `src/model-failover.mjs`'s `writeCooldownDocument` trims on its next write, and the comment on `providerCooldown` says "expiry needs no sweeper". So `expireRetainedToolResults` is the call the writer's pre-write cap scan makes — that scan already enumerates the directory, so the TTL costs nothing extra and adds zero startup cost.

`doctor` **reports** what has aged out and never deletes, the way `readProviderCooldowns` reads a cooldown as gone before anything unlinks it. Because nothing on main writes the store today, `purge --expired [--yes] [--dry-run]` runs the identical sweep by hand — same consent default, same containment as purge, and it refuses outright when the TTL is off rather than quietly emptying the store. `.retention-key` is never expired, only purged: dropping it would orphan the entries the TTL just decided to keep.

This also fixes the cap failure the issue names — a store parked at 512 files now drains itself.

## Why #245 is closed (investigated, not assumed)

**Withdrawn by its author, not rejected.** `HaileyStorm` closed it at 2026-08-15T23:51:28Z with no closing comment, and closed their fork mirror 9 seconds later. Six minutes earlier they had pushed a fix for the last red job (Windows 8.3 short paths, d57dffa) and said "Waiting for upstream Windows CI as the acceptance gate" — but that run was `action_required`, blocked on maintainer approval for an external branch.

So: abandoned mid-review over process friction, everything technical green except an unapproved CI run, with two judgement calls outstanding (default-on retention as product policy; the receipt's re-run wording). **No successor PR or issue exists.**

**#277's interface still fits the writer.** Path resolution, `MODEL_ROUTER_TOOL_RESULT_RETENTION_DIR`, the three name shapes and the 512/512 caps all mirror it. The reland edits the *same file* — #245's stack traces name `src/tool-result-retention.mjs:175 assertPlainOwnedDirectory` — so its hardening and the 64 MiB single-result cap come back into a file that now also holds read/purge/expire. A merge, not a conflict.

**What this TTL constrains for a reland**, so it is not a surprise later:
- `tool-result-aging.json` gained `retentionTtlDays`, and both existing setters now thread it. A reland that rewrites `tool-result-aging-state.mjs` must keep that threading or a toggle silently drops the operator's TTL.
- The writer should call `expireRetainedToolResults` from its cap scan — a two-line hook. If it never lands, `purge --expired` still works.
- Expiry ages by **mtime**. If a retrieval feature ever touches mtime on read, the TTL silently becomes "since last access" — a policy change to make deliberately, not to inherit.

## Tests

`test/tool-result-retention.test.mjs` +10, `test/tool-result-aging-state.test.mjs` +4 (and 4 existing `deepEqual`s updated for the new field). Covers expiry by age, survival within the TTL, caps still working, and expiry respecting the same containment as purge.

`npm run check` passes. `npm test`: 1604 pass, 0 fail, 12 skipped.
