### PR TITLE
feat(subagents): let a proven slug be demoted, and stop a looping child

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -550,21 +550,61 @@ so the unit of evidence is always the slug, never the model name.
    turn for that slug completed cleanly, so the model can hold the child role;
    it does not say the child finished what it was delegated. The router
    observes HTTP turns, not agent lifecycles — a child makes one turn per
-   tool-call round trip, and the loop that strings them together is Codex's —
-   so a model that answers turn after turn without converging still reaches
-   `proven` and keeps it until `control subagents verify` re-researches it.
+   tool-call round trip, and the loop that strings them together is Codex's.
    Do not write copy anywhere (log lines, tray, docs) that reads `proven` as
-   "the delegated task succeeded"; demoting a looping child needs a
-   convergence signal the request path does not yet have (issue #257).
-4. Local settings still never manufacture a v2 claim. The only writers of
+   "the delegated task succeeded".
+4. **`proven` is revocable, and only downward automatically** (issue #257).
+   Promotion is a one-time event, but the window in which machine-local
+   evidence can be taken away stays open for as long as that evidence is what
+   the v2 advertisement rests on. A 400/422 on any child turn demotes the slug,
+   before or after promotion and without needing to repeat: it is the same
+   structural refusal the capability probe treats as disqualifying, the
+   transient statuses that prove nothing are already excluded, and the
+   alternative is letting the oldest observation beat the newest. A registry-v2
+   model is untouched — its claim is the shipped native collaboration proof,
+   not this machine's traffic. Re-promotion is never automatic: it costs live
+   requests, so it happens only through `control subagents verify` or switching
+   the model off and on.
+5. **A looping child is demoted against its own compaction budget**, because a
+   child that answers forever emits nothing but 200s and no status-shaped
+   branch can ever see it. `src/subagent-turns.mjs` accounts each spawn
+   separately, keyed on the `thread-id` header, and adds up the *new* input
+   tokens it produces (every child turn resends the whole conversation, so the
+   growth in the prompt count is what the child newly made; a compaction makes
+   the count fall and everything after the fall is work being done twice). The
+   ceiling is twice the larger of the model's declared `autoCompact` budget and
+   the largest prompt this spawn has actually had accepted. Nothing there is
+   invented: `autoCompact` is per model and comes from the provider's published
+   window, and the multiple comes from the pathology
+   `src/context-window-drift.mjs` already names — one budget is a large but
+   legitimate task, it is *compacting again without ever finishing* that is the
+   runaway. Measuring against the observed peak as well as the declaration is
+   what makes a false demotion impossible rather than merely unlikely: an
+   uncompacted spawn's total is exactly half its own ceiling however long its
+   task runs, which matters because the registry validator permits any
+   `1 <= autoCompact <= contextWindow` and one oversized tool result can carry a
+   single turn past the compaction limit in one step. A child thread reused for
+   a `FOLLOWUP_TASK` is deliberately one spawn here — its context really does
+   carry across — and an idle one expires rather than accumulating forever.
+   No positive "terminal turn" detector is needed or possible: the
+   turn that ended a spawn is only knowable by no further turn arriving, and a
+   ceiling can only ever be crossed by a spawn that is still producing turns.
+   Only a prompt count the provider actually reported may move the total —
+   substituted estimates and retry-doubled counts are refused here for exactly
+   the reasons `context-window-drift.mjs` refuses them as capacity evidence. A
+   model that declares no `autoCompact` has no derived ceiling and is counted
+   but never condemned; do not give it one by guessing. Both demotion paths log
+   unconditionally and record the turn and token counts in the proofs file, so
+   `control subagents status` and the tray can say what happened.
+6. Local settings still never manufacture a v2 claim. The only writers of
    promotion evidence are the probe worker and the router's observation of
    real traffic; an unreadable proofs file promotes nothing, and a hidden or
    switched-off slug stays v1 whatever evidence it carries.
-5. `control subagents verify [SLUG ...]` re-researches explicitly (foreground,
+7. `control subagents verify [SLUG ...]` re-researches explicitly (foreground,
    ~2 requests per candidate); with no slugs it sweeps the enabled list.
    Select-all and mode changes never trigger probes — a sweep across every
    provider is quota the operator must ask for.
-6. Machine-local proofs are exactly that. Shipping a default to every
+8. Machine-local proofs are exactly that. Shipping a default to every
    installer still requires the full native collaboration proof and a registry
    change (below); never edit the checked-in `config/` tree because one
    machine's probe passed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,46 @@
   session of its own now lives in `src/routed-client-models.mjs` instead of
   inside the harness manager. It was always a general rule; a second client
   wanting it verbatim is what made a second copy the wrong answer.
+- **A subagent that had been proven once could never be un-proven, however
+  badly it behaved afterwards.** The observer that settles a locally verified
+  subagent gated itself on `awaitingSpawnProof`, which is true only while a
+  slug sits in the experimental window — so the instant turn one promoted a
+  model, the router stopped watching it. A hard 400/422 on turn two was
+  discarded with everything else, and the only thing that could re-examine the
+  slug was a hand-run `control subagents verify` (#257). Two changes, both
+  about the gate rather than the thresholds. `proven` is now revocable: the
+  same structural rejection that would have blocked promotion takes it back
+  afterwards, without needing to repeat, because nothing makes a 400 weaker
+  after a 200 than before it and the transient statuses that prove nothing
+  (429, 5xx, disconnects) were already excluded. Registry-v2 models are
+  untouched — their claim is the shipped native collaboration proof, not one
+  machine's traffic — and re-promotion stays manual, since that is the
+  direction that spends quota. And a child that answers turn after turn
+  without converging is now demotable at all: it emits nothing but 200s, so no
+  status-shaped branch could ever see it, and the evidence instead is how much
+  of its own budget one spawn burns while still going. `src/subagent-turns.mjs`
+  accounts each spawn separately by `thread-id` and adds up the new input
+  tokens it produces — every child turn resends the whole conversation, so
+  growth in the prompt count is what the child newly made, and a compaction
+  makes the count fall so everything after it is work being done twice. The
+  ceiling is twice the larger of the model's declared `autoCompact` budget and
+  the largest prompt the spawn has actually had accepted: one budget is a large
+  but legitimate task, and it is compacting *again* without ever finishing that
+  names the runaway, which is the same pathology
+  `context-window-drift.mjs` and #266 already describe. No round number was
+  invented — `autoCompact` is per model and comes from the provider's own
+  published window, and a model that declares none is counted but never
+  condemned. Measuring against the spawn's own observed peak as well as the
+  declaration makes a false demotion impossible rather than merely unlikely: an
+  uncompacted spawn's total is exactly half its own ceiling however long its
+  task runs, so neither a model whose declared budget sits far below its window
+  nor a single oversized tool result can condemn anything. Only prompt counts
+  the provider actually reported move the total,
+  so substituted estimates and retry-doubled counts cannot manufacture a
+  demotion. Both paths log unconditionally and record the turn and token
+  counts in the proofs file, so `control subagents status` and the tray say
+  what happened rather than a picker entry quietly disappearing.
+
 - **Grok OAuth no longer loses late or custom tool calls.** The forwarder now
   accepts `function_call` and `custom_tool_call` items that first appear in
   `response.output_item.done`, restores final arguments when argument deltas

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -76,11 +76,16 @@ import {
   awaitingSpawnProof,
   recordSpawnFailure,
   recordSpawnObserved,
+  spawnProofRevocable,
   subagentProofSnapshot,
 } from "./subagent-proofs.mjs";
+import { forgetChildSpawn, observeChildTurn } from "./subagent-turns.mjs";
 import { subagentEffort } from "./multi-agent-state.mjs";
 import { mergeCodexAppTools } from "./codex-app-tools.mjs";
-import { activityMetadataFromHeaders } from "./codex-session-names.mjs";
+import {
+  activityMetadataFromHeaders,
+  threadIdFromHeaders,
+} from "./codex-session-names.mjs";
 import { translateGatewayError } from "./error-translation.mjs";
 import { recordUsageEvent } from "./usage-events.mjs";
 import {
@@ -1849,10 +1854,10 @@ function requireCodexTransport(request, response) {
 // A model in the experimental subagent window earns its durable proof — or
 // its demotion — from real traffic: Codex marks child turns with
 // x-openai-subagent, so the first clean completion of one settles "this model
-// can hold the child role" without a dedicated probe session. Only structural
+// can hold the child role" without a dedicated probe session. Structural
 // rejections demote (400/422, the shape a schema or encrypted-payload refusal
 // takes); transient failures — 429s, 5xx, disconnects — prove nothing either
-// way and leave the window open. Neither line is QUIET-gated: a promotion or
+// way and leave the window open. No line here is QUIET-gated: a promotion or
 // demotion that happens silently is how a picker entry becomes unexplainable.
 //
 // What the promotion claims is exactly one HTTP turn, and the log line has to
@@ -1861,34 +1866,77 @@ function requireCodexTransport(request, response) {
 // that strings them together, so "the child reached done" is not a fact
 // available here. An operator who read the old "subagent proven … completed a
 // live child turn" as *the delegated work finished* was reading a promise the
-// router cannot make (issue #257). A model that speaks the protocol turn after
-// turn without ever converging therefore still carries this proof: it returns
-// 200s, so nothing above demotes it, and only `control subagents verify` — run
-// by hand — re-examines it. Closing that needs a convergence signal this
-// function does not have; naming the claim honestly is the part that does not
-// require inventing one.
+// router cannot make (issue #257).
+//
+// The two halves of that issue meet here, and both are about the gate rather
+// than the thresholds. The gate used to be `awaitingSpawnProof`, true only for
+// `experimental` — so the instant turn one promoted a slug this function
+// stopped looking at it, and a hard 400/422 on turn two was discarded along
+// with everything else. That made the *oldest* observation win over the
+// newest, which no comment ever argued for. The gate is now revocability, so a
+// slug keeps being watched for as long as this machine's traffic is what the
+// v2 advertisement rests on; promotion alone stays scoped to the experimental
+// window, because a first clean turn is only news once.
+//
+// Watching a `proven` slug is also what makes the convergence signal usable. A
+// looping child emits 200s forever, so no status-shaped branch could ever fire
+// for it; the evidence is instead how much of its own budget one spawn burns
+// without stopping, accounted per child thread in subagent-turns.mjs against
+// the model's declared auto-compact limit.
 
-function observeSubagentOutcome(request, route, status, { emptyCompletion = false } = {}) {
+function observeSubagentOutcome(request, route, status, options = {}) {
   if (!route) return;
   try {
     if (!request.headers["x-openai-subagent"]) return;
-    if (!awaitingSpawnProof(route.slug, subagentProofSnapshot())) return;
-    if (status === 200 && !emptyCompletion) {
+    const proofs = subagentProofSnapshot();
+    if (!spawnProofRevocable(route.slug, proofs)) return;
+    const spawnId = threadIdFromHeaders(request.headers);
+    const settle = (reason, detail = { status }) => {
+      recordSpawnFailure(route.slug, { reason, ...detail });
+      forgetChildSpawn(spawnId);
+      console.error(
+        `[codex-router] subagent demoted: ${route.slug} ${reason}; ` +
+          "it stays v1 until 'control subagents verify' passes again",
+      );
+    };
+    if (status === 400 || status === 422) {
+      settle(
+        `child turn rejected with HTTP ${status}` +
+          (proofs[route.slug]?.status === "proven"
+            ? ", revoking the child role it had already served"
+            : ""),
+      );
+      return;
+    }
+    if (status !== 200 || options.emptyCompletion) return;
+    if (awaitingSpawnProof(route.slug, proofs)) {
       recordSpawnObserved(route.slug, { status });
       console.error(
         `[codex-router] subagent child role verified: ${route.slug} served a live child turn; ` +
           "the model holds the child role on the wire, which is not a claim the child finished its task",
       );
-    } else if (status === 400 || status === 422) {
-      recordSpawnFailure(route.slug, {
-        status,
-        reason: `child turn rejected with HTTP ${status}`,
-      });
-      console.error(
-        `[codex-router] subagent demoted: ${route.slug} child turn rejected with HTTP ${status}; ` +
-          "it stays v1 until 'control subagents verify' passes again",
-      );
     }
+    const spawn = observeChildTurn({
+      spawnId,
+      slug: route.slug,
+      autoCompact: route.autoCompact,
+      event: {
+        status,
+        inputTokens: options.usage?.inputTokens,
+        estimatedInputTokens: options.estimatedInputTokens,
+        emptyCompletionRetried: options.emptyCompletionRetried,
+      },
+    });
+    if (!spawn?.exceeded) return;
+    settle(
+      `one child spawn ran ${spawn.turns} turns and produced ${spawn.newInputTokens} new input ` +
+        `tokens without converging, past the ${spawn.budget}-token ceiling this model's own ` +
+        "auto-compact budget sets",
+      // Deliberately no `status`: every turn of this spawn answered 200, and
+      // recording one of them as the failure would read as a rejection that
+      // never happened. The counts are the evidence.
+      { turns: spawn.turns, newInputTokens: spawn.newInputTokens },
+    );
   } catch {
     // Observation is bookkeeping; it must never fail the turn it watched.
   }
@@ -2793,7 +2841,15 @@ async function handleResponses(request, response, requestUrl) {
       ...(guardReleasedForBudget ? { emptyCompletionGuardReleased: true } : {}),
       ...(failoverFrom ? { failoverFrom } : {}),
     });
-    observeSubagentOutcome(request, route, finalStatus, { emptyCompletion });
+    // The same usage this turn just metered, and the same two disqualifiers
+    // context-window-drift.mjs applies to it: a substituted estimate and a
+    // retry-doubled count are not measurements of what the child sent.
+    observeSubagentOutcome(request, route, finalStatus, {
+      emptyCompletion,
+      usage,
+      estimatedInputTokens,
+      emptyCompletionRetried,
+    });
     usageRecorded = true;
     activityStatus = finalStatus;
     if (!QUIET) {

--- a/src/subagent-proofs.mjs
+++ b/src/subagent-proofs.mjs
@@ -28,9 +28,23 @@ import { STATE_DIR } from "./paths.mjs";
 // role. The router observes HTTP turns, not agent lifecycles — a child makes
 // one turn per tool-call round trip and the loop that strings them together is
 // Codex's, not the router's — so nothing here can say the child reached done.
-// A model that keeps answering turns without ever converging still reaches
-// "proven" and stays there until `control subagents verify` re-researches it
-// (issue #257).
+//
+// "proven" is therefore revocable (issue #257). It was written as a terminal
+// state, which meant the newest evidence on the wire lost to the oldest: a
+// slug promoted by one clean turn kept the v2 advertisement through every
+// structural rejection that followed, because the observer stopped listening
+// the moment it promoted. Nothing about a 400/422 is weaker after promotion
+// than before it — it is the same structural refusal the probe treats as
+// disqualifying, and the transient statuses that prove nothing (429, 5xx) are
+// already excluded elsewhere. So the same evidence demotes at any point in the
+// lifecycle, and the router's per-spawn accounting (subagent-turns.mjs) can
+// condemn a child that runs past its model's own compaction budget without
+// converging.
+//
+// Demotion is automatic; re-promotion is not. A demoted slug only comes back
+// through `control subagents verify` or a switch off and on, both of which
+// spend live requests re-researching it — the direction that costs quota is
+// the direction that stays under the operator's hand.
 export const SUBAGENT_PROOFS_PATH =
   process.env.MODEL_ROUTER_SUBAGENT_PROOFS ||
   path.join(STATE_DIR, "multi-agent-proofs.json");
@@ -98,10 +112,25 @@ export function recordSpawnObserved(slug, { status, at = new Date().toISOString(
   return updateProof(slug, { status: "proven", spawn: { ok: true, status, at } });
 }
 
-export function recordSpawnFailure(slug, { status, reason, at = new Date().toISOString() } = {}) {
+// `turns` and `newInputTokens` are carried so the recorded evidence says how
+// much of a spawn it took, not just that one failed: the proofs snapshot is
+// what `control subagents verify`, `control subagents status` and the tray
+// render, so this is where a demotion becomes something an operator can read.
+export function recordSpawnFailure(
+  slug,
+  { status, reason, turns, newInputTokens, at = new Date().toISOString() } = {},
+) {
   return updateProof(slug, {
     status: "failed",
-    spawn: { ok: false, status, at },
+    spawn: {
+      ok: false,
+      status,
+      at,
+      ...(Number.isInteger(turns) && turns > 0 ? { turns } : {}),
+      ...(Number.isInteger(newInputTokens) && newInputTokens > 0
+        ? { newInputTokens }
+        : {}),
+    },
     reason: reason || `spawn failed with HTTP ${status}`,
   });
 }
@@ -143,8 +172,19 @@ export function applySubagentProofs(models, proofs, { hidden, disabled } = {}) {
   });
 }
 
-// Whether an observed child turn for this slug should settle a verdict:
-// only models sitting in the experimental window are listening.
+// Whether an observed child turn for this slug can *promote* it: only models
+// sitting in the experimental window are waiting on a first clean turn.
 export function awaitingSpawnProof(slug, proofs = subagentProofSnapshot()) {
   return proofs[String(slug)]?.status === "experimental";
+}
+
+// Whether an observed child turn for this slug can *demote* it. Everything the
+// v2 advertisement currently rests on is revocable — the experimental window
+// and the durable proof alike — because both are claims about the same wire
+// the failing turn just came off. A slug already `failed`, still `checking`,
+// or carrying no local proof at all (including a registry-v2 model, whose
+// claim is the shipped native collaboration proof and not this machine's
+// traffic) has nothing here to take away.
+export function spawnProofRevocable(slug, proofs = subagentProofSnapshot()) {
+  return PROMOTED_STATUSES.has(proofs[String(slug)]?.status);
 }

--- a/src/subagent-turns.mjs
+++ b/src/subagent-turns.mjs
@@ -1,0 +1,178 @@
+import { acceptedInputTokens } from "./context-window-drift.mjs";
+
+// Per-spawn accounting for child turns, and the only signal the router has
+// that a child is looping rather than working.
+//
+// The router sees HTTP turns, not agent lifecycles: a child makes one turn per
+// tool-call round trip and the loop stringing them together is Codex's. So
+// "the child reached done" is not observable here, and neither is a terminal
+// turn in any positive sense -- the turn that ended a spawn is only knowable
+// afterwards, by no further turn arriving on that thread. That is exactly why
+// no positive terminal-turn detector is needed: a ceiling can only ever be
+// crossed by a spawn that is *still producing turns*, which is the same
+// statement as "this spawn has not converged". A converged child stops, and a
+// spawn that stopped never reaches the ceiling.
+//
+// What has to be defensible is the ceiling, and the repository already names
+// both the pathology and its unit. `context-window-drift.mjs` describes the
+// runaway shape verbatim: a task that opens above its own compaction
+// threshold, summarizes, "lose[s] the agent's working state, redo[es] the same
+// opening work, and compact[s] again without ever finishing. Nothing errors.
+// The session simply never ends" -- the same failure the v0.4.0-beta.4
+// changelog records for understated windows (#266). The unit in that sentence
+// is the model's auto-compact budget, which every listed model already carries
+// (`autoCompact`, validated in model-registry.mjs and derived from the
+// provider's own declared window at AUTO_COMPACT_RATIO). It is per model, it
+// is published by the provider, and nobody here invented it.
+//
+// The multiple is read off the same sentence. One compaction budget of new
+// input is a large but legitimate task -- a child that reads a big file
+// reaches it honestly. It is *compacting again* that names the runaway, so the
+// ceiling is two budgets of new input with the child still going.
+//
+// That multiple is also what makes a false demotion structurally impossible
+// rather than merely unlikely, which matters because a false demotion silently
+// drops a working model from the picker and only a hand-run
+// `control subagents verify` restores it. A spawn that has never been
+// compacted cannot have produced more new input than its own largest prompt,
+// so the ceiling is taken against whichever is bigger, the model's declared
+// budget or the largest prompt this spawn has actually had accepted. An
+// uncompacted spawn's total is then exactly half its own ceiling, however long
+// its task runs and whatever the catalog declares -- the invariant holds even
+// for a model whose `autoCompact` sits far below its window, which the registry
+// validator permits (it requires only 1 <= autoCompact <= contextWindow), and
+// for the single oversized tool result that can carry one turn past the
+// compaction limit in one step. Crossing the ceiling therefore requires the
+// child to have filled its context, been summarized, and filled it again
+// without stopping. That is not a big task; it is the runaway, stated in the
+// only unit the router can see.
+//
+// One thing this cannot separate, and does not pretend to: Codex reuses a
+// child thread for a FOLLOWUP_TASK, so a thread that is delegated to twice is
+// one spawn here. That is the conservative reading -- the child's context does
+// carry across, so the tokens really are cumulative -- and a child left idle
+// between delegations is expired by IDLE_SPAWN_MS below rather than
+// accumulating forever.
+export const SPAWN_BUDGET_MULTIPLE = 2;
+
+// The counter is per spawn, so it grows with concurrent children rather than
+// with traffic; Codex is configured for six threads per session
+// (`max_concurrent_threads_per_session`, config-manager.mjs). 256 follows the
+// agent payload cache's bound, and eviction is LRU so a busy router drops the
+// coldest spawn rather than the newest.
+export const MAX_TRACKED_SPAWNS = 256;
+
+// A spawn nobody has sent a turn for in this long is over, whatever ended it.
+// The same 15 minutes the router uses to decide an in-flight request leaked:
+// no single Codex turn streams for that long, so a gap that size is not a
+// child still thinking.
+export const IDLE_SPAWN_MS = 15 * 60_000;
+
+// spawnId -> { slug, turns, newInputTokens, lastInputTokens, startedAt, updatedAt }
+// Insertion order is the LRU order: every touched spawn is re-inserted last.
+const spawns = new Map();
+
+function prune(now) {
+  for (const [id, state] of spawns) {
+    if (now - state.updatedAt > IDLE_SPAWN_MS) spawns.delete(id);
+  }
+  while (spawns.size > MAX_TRACKED_SPAWNS) {
+    const oldest = spawns.keys().next();
+    if (oldest.done) break;
+    spawns.delete(oldest.value);
+  }
+}
+
+function spawnKey(spawnId) {
+  return typeof spawnId === "string" && spawnId.trim()
+    ? spawnId.trim().toLowerCase()
+    : undefined;
+}
+
+// Record one observed child turn against its spawn.
+//
+// `event` is the shape context-window-drift.mjs already judges: only a turn
+// the provider answered 200 with a reported (not estimated, not
+// retry-doubled) prompt count is allowed to move the token total, because an
+// estimate the router invented cannot be evidence about how much the child
+// actually sent. A skipped sample still counts as a turn, and the next
+// believable sample folds its growth in, so a provider that meters badly slows
+// the accounting down rather than corrupting it. (The router's own caller
+// only reaches here for clean 200s; the non-200 case is reachable through
+// this module's own contract and is defined rather than left to chance.)
+//
+// Returns undefined when the turn cannot be attributed to a spawn -- no
+// thread id means no way to tell one child from the next, and guessing would
+// demote a model for someone else's traffic.
+export function observeChildTurn({
+  spawnId,
+  slug,
+  autoCompact,
+  event,
+  now = Date.now(),
+} = {}) {
+  const id = spawnKey(spawnId);
+  if (!id) return undefined;
+  const model = String(slug || "");
+  if (!model) return undefined;
+  const previous = spawns.get(id);
+  // A thread id that comes back on a different model is a different spawn.
+  // Codex cannot change a child's model mid-thread, so this only guards
+  // against merging two spawns that happened to collide.
+  const state =
+    previous && previous.slug === model
+      ? previous
+      : {
+          slug: model,
+          turns: 0,
+          newInputTokens: 0,
+          lastInputTokens: 0,
+          peakInputTokens: 0,
+          startedAt: now,
+        };
+  state.turns += 1;
+  state.updatedAt = now;
+  const accepted = acceptedInputTokens(event);
+  if (accepted !== undefined) {
+    // Every child turn resends the whole conversation, so the prompt count is
+    // the conversation so far and its growth is what the child newly produced.
+    // A compaction makes the count fall; everything after the fall is new work
+    // the child has to do again, which is precisely what is being counted.
+    state.newInputTokens += Math.max(0, accepted - state.lastInputTokens);
+    state.lastInputTokens = accepted;
+    state.peakInputTokens = Math.max(state.peakInputTokens, accepted);
+  }
+  spawns.delete(id);
+  spawns.set(id, state);
+  prune(now);
+  const declared = Number.isInteger(autoCompact) && autoCompact > 0 ? autoCompact : 0;
+  // Whichever is bigger: what the catalog says the child may hold, and what
+  // this provider has actually accepted from it. The second term is what keeps
+  // one very large legitimate prompt from being read as a loop.
+  const held = Math.max(declared, state.peakInputTokens);
+  const budget = declared > 0 ? held * SPAWN_BUDGET_MULTIPLE : undefined;
+  return {
+    turns: state.turns,
+    newInputTokens: state.newInputTokens,
+    budget,
+    // A model with no declared compaction budget has no derived ceiling, so it
+    // is counted and never demoted on this signal. Inventing one for it is the
+    // thing this module exists not to do.
+    exceeded: budget !== undefined && state.newInputTokens > budget,
+  };
+}
+
+// Drop a spawn the router has already settled a verdict on, so a child that
+// keeps answering after its slug was demoted does not keep re-firing.
+export function forgetChildSpawn(spawnId) {
+  const id = spawnKey(spawnId);
+  if (id) spawns.delete(id);
+}
+
+export function childSpawnSnapshot() {
+  return [...spawns.entries()].map(([spawnId, state]) => ({ spawnId, ...state }));
+}
+
+export function resetChildSpawns() {
+  spawns.clear();
+}

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5068,6 +5068,138 @@ test("a live child turn settles an experimental subagent's proof", async () => {
   }
 });
 
+// Issue #257(b). Two things a `proven` slug could not do before: be taken back
+// by a structural rejection on a later turn, and be taken back by a child that
+// answers forever. The first was unreachable because the observer's gate was
+// the experimental window, so promotion on turn one closed the demotion path
+// with it; the second had no signal at all, because a looping child emits
+// nothing but 200s.
+test("a proven subagent is demoted by a later rejection and by a child that never converges", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "subagent-demote-e2e-"));
+  const proofsPath = path.join(stateDir, "multi-agent-proofs.json");
+  // Both already carry the durable proof: this is the state the old observer
+  // stopped looking at.
+  writeFileSync(
+    proofsPath,
+    JSON.stringify({
+      version: 1,
+      proofs: {
+        "deepseek/deepseek-v4-pro": { status: "proven", spawn: { ok: true, status: 200 } },
+        "deepseek/deepseek-v4-flash": { status: "proven", spawn: { ok: true, status: 200 } },
+      },
+    }),
+    { mode: 0o600 },
+  );
+
+  // deepseek-v4-pro declares autoCompact 900000, so its derived ceiling is two
+  // budgets — 1,800,000 tokens of new input — with the child still going. This
+  // series is the runaway shape: grow, get compacted (the prompt count falls),
+  // redo the same opening work, compact again. It crosses on the sixth turn.
+  const promptCounts = [400_000, 900_000, 300_000, 900_000, 300_000, 900_000];
+  let served = 0;
+  const gateway = await mockServer(async (request, response) => {
+    if (request.url === "/health") {
+      json(response, 200, { ok: true });
+      return;
+    }
+    const body = await bodyJson(request);
+    if (String(body.model || "").includes("flash")) {
+      json(response, 400, { error: { message: "encrypted payload rejected" } });
+      return;
+    }
+    const inputTokens = promptCounts[Math.min(served, promptCounts.length - 1)];
+    served += 1;
+    json(response, 200, {
+      id: `resp_child_${served}`,
+      output: [{ type: "message", content: [{ type: "output_text", text: "still working" }] }],
+      usage: { input_tokens: inputTokens, output_tokens: 4 },
+    });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    MODEL_ROUTER_SUBAGENT_PROOFS: proofsPath,
+    // Thread identity resolves against rollout files; point it at empty state
+    // so the test never walks the developer's own ~/.codex/sessions.
+    CODEX_ROUTER_SESSIONS_PATH: path.join(stateDir, "sessions"),
+    CODEX_ROUTER_SESSION_INDEX: path.join(stateDir, "session_index.jsonl"),
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  const spawnThread = "11111111-2222-4333-8444-555555555555";
+  const childTurn = (model, headers = {}) =>
+    fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-openai-subagent": "review-child",
+        ...headers,
+      },
+      body: JSON.stringify({ model, input: "finish the task" }),
+    });
+
+  const proofFor = async (slug, predicate) => {
+    const deadline = Date.now() + 3_000;
+    let proof;
+    while (Date.now() < deadline) {
+      proof = JSON.parse(readFileSync(proofsPath, "utf8")).proofs[slug];
+      if (predicate(proof)) return proof;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    return proof;
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    // A structural rejection after promotion is the same evidence it was
+    // before it, so it takes the proof back.
+    const rejected = await childTurn("deepseek/deepseek-v4-flash", {
+      "thread-id": "99999999-8888-4777-8666-555555555555",
+    });
+    assert.equal(rejected.status, 400);
+    const flash = await proofFor(
+      "deepseek/deepseek-v4-flash",
+      (proof) => proof?.status === "failed",
+    );
+    assert.equal(flash.status, "failed");
+    assert.match(flash.reason, /400/);
+    assert.match(flash.reason, /revoking the child role it had already served/);
+
+    // The looping child. Every turn is a clean 200, so nothing status-shaped
+    // could ever fire; what condemns it is how much of its own budget one
+    // spawn burns while still going.
+    for (let index = 0; index < promptCounts.length; index += 1) {
+      const looping = await childTurn("deepseek/deepseek-v4-pro", {
+        "thread-id": spawnThread,
+      });
+      assert.equal(looping.status, 200, `child turn ${index + 1} failed`);
+    }
+    const pro = await proofFor("deepseek/deepseek-v4-pro", (proof) => proof?.status === "failed");
+    assert.equal(pro.status, "failed", "a child that never converged kept its proof");
+    assert.equal(pro.spawn.turns, promptCounts.length);
+    assert.equal(pro.spawn.newInputTokens, 2_100_000);
+    assert.match(pro.reason, /without converging/);
+    assert.match(pro.reason, /1800000-token ceiling/);
+
+    // Both demotions have to be readable in the log, even under the QUIET the
+    // production LaunchAgent hard-sets: a picker entry that vanishes with no
+    // line explaining it is unexplainable.
+    const errors = router.testErrors();
+    assert.match(errors, /subagent demoted: deepseek\/deepseek-v4-flash/);
+    assert.match(errors, /subagent demoted: deepseek\/deepseek-v4-pro/);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
 // The whole value of a per-model subagent effort is that it applies in one
 // role and not the other: the same model must keep its normal depth when it is
 // the parent. A setting that leaked into parent turns would quietly re-tune

--- a/test/subagent-proofs.test.mjs
+++ b/test/subagent-proofs.test.mjs
@@ -19,6 +19,7 @@ const {
   recordProbeStarted,
   recordSpawnFailure,
   recordSpawnObserved,
+  spawnProofRevocable,
   subagentProofSnapshot,
   SUBAGENT_PROOFS_PATH,
 } = await import("../src/subagent-proofs.mjs");
@@ -56,6 +57,44 @@ test("a proof walks checking -> experimental -> proven, and failures carry reaso
 
   clearSubagentProof("example/gamma");
   assert.equal(subagentProofSnapshot()["example/gamma"], undefined);
+});
+
+// Issue #257(b): `proven` was terminal, so the oldest observation on the wire
+// beat every later one. Promotion is still a one-time event, but the window in
+// which evidence can be *taken away* stays open for as long as this machine's
+// traffic is what the v2 advertisement rests on.
+test("a proven slug stays revocable while an unproven or settled one is untouchable", () => {
+  const slug = "example/revocable";
+  recordProbeResult(slug, { ok: true, checks: [] });
+  assert.equal(spawnProofRevocable(slug), true, "the experimental window is revocable");
+
+  recordSpawnObserved(slug, { status: 200 });
+  assert.equal(awaitingSpawnProof(slug), false, "a first clean turn is only news once");
+  assert.equal(spawnProofRevocable(slug), true, "promotion must not close the demotion path");
+
+  // The counts that condemned it travel with the record, so `control subagents
+  // status` and the tray can say how much of a spawn it took.
+  const demoted = recordSpawnFailure(slug, {
+    status: 200,
+    reason: "one child spawn ran 6 turns without converging",
+    turns: 6,
+    newInputTokens: 2_100,
+  });
+  assert.equal(demoted.status, "failed");
+  assert.equal(demoted.spawn.turns, 6);
+  assert.equal(demoted.spawn.newInputTokens, 2_100);
+  assert.equal(
+    spawnProofRevocable(slug),
+    false,
+    "a slug already demoted has nothing left for traffic to take",
+  );
+
+  // Nothing local to revoke: a checking slug is not advertised yet, and a
+  // registry-v2 model's claim is the shipped native proof, not this machine.
+  recordProbeStarted(slug);
+  assert.equal(spawnProofRevocable(slug), false);
+  assert.equal(spawnProofRevocable("kimi-oauth/k3"), false);
+  clearSubagentProof(slug);
 });
 
 test("a proofs file that cannot be read promotes nothing", () => {

--- a/test/subagent-turns.test.mjs
+++ b/test/subagent-turns.test.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import test, { beforeEach } from "node:test";
+
+import {
+  IDLE_SPAWN_MS,
+  MAX_TRACKED_SPAWNS,
+  SPAWN_BUDGET_MULTIPLE,
+  childSpawnSnapshot,
+  forgetChildSpawn,
+  observeChildTurn,
+  resetChildSpawns,
+} from "../src/subagent-turns.mjs";
+
+const AUTO_COMPACT = 1_000;
+const BUDGET = AUTO_COMPACT * SPAWN_BUDGET_MULTIPLE;
+
+function turn(spawnId, inputTokens) {
+  return observeChildTurn({
+    spawnId,
+    slug: "vendor/looper",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 200, inputTokens },
+  });
+}
+
+beforeEach(() => resetChildSpawns());
+
+// The reported gap: a child that answers turn after turn without ever
+// converging emits nothing but 200s, so no status-shaped branch can see it.
+// What it does emit is its own context, over and over.
+test("a looping spawn crosses the ceiling its model's compaction budget sets", () => {
+  // A converging child grows its context and stops. This one grows, gets
+  // compacted (the prompt count falls), redoes the same opening work, and
+  // compacts again -- the runaway context-window-drift.mjs describes.
+  assert.equal(turn("spawn-a", 400).newInputTokens, 400);
+  assert.equal(turn("spawn-a", 900).newInputTokens, 900);
+  // Compaction: the count falls, and everything after it is work done twice.
+  assert.equal(turn("spawn-a", 300).newInputTokens, 900);
+  const stillUnder = turn("spawn-a", 900);
+  assert.equal(stillUnder.newInputTokens, 1_500);
+  assert.equal(stillUnder.budget, BUDGET);
+  assert.equal(stillUnder.exceeded, false, "one budget of new input is a big task, not a loop");
+
+  turn("spawn-a", 300);
+  const over = turn("spawn-a", 900);
+  assert.equal(over.newInputTokens, 2_100);
+  assert.equal(over.turns, 6);
+  assert.equal(over.exceeded, true, "a second full budget with the child still going is the loop");
+});
+
+// The property that keeps this from condemning a working model: a spawn that
+// was never compacted cannot have produced more new input than its own latest
+// prompt, and Codex compacts at `autoCompact`. So however many turns a big
+// honest task takes, its total is capped at one budget and the two-budget
+// ceiling is out of reach. Only a child that filled its context, got
+// summarized, and filled it again can cross.
+test("a long task that never gets compacted cannot reach the ceiling", () => {
+  let last = 0;
+  for (let index = 1; index <= 50; index += 1) {
+    // Monotonic growth up to the compaction limit, the shape of a child that
+    // is genuinely working and simply has a lot to hold.
+    last = Math.min(AUTO_COMPACT, index * 40);
+    const seen = turn("spawn-honest", last);
+    assert.equal(seen.exceeded, false, `turn ${index} condemned a child that never compacted`);
+  }
+  const final = turn("spawn-honest", AUTO_COMPACT);
+  assert.equal(final.turns, 51);
+  assert.equal(final.newInputTokens, AUTO_COMPACT);
+  assert.equal(final.newInputTokens <= final.budget / SPAWN_BUDGET_MULTIPLE, true);
+});
+
+// The counter has to survive the demotion it triggers without re-firing, and
+// two children of the same parent are two spawns.
+test("spawns are accounted separately and a settled one is forgotten", () => {
+  turn("spawn-a", 1_500);
+  turn("spawn-b", 100);
+  assert.equal(childSpawnSnapshot().length, 2);
+  assert.equal(turn("spawn-b", 200).newInputTokens, 200);
+
+  forgetChildSpawn("SPAWN-A");
+  assert.deepEqual(
+    childSpawnSnapshot().map((entry) => entry.spawnId),
+    ["spawn-b"],
+    "the thread id is matched case-insensitively, the way every other UUID here is",
+  );
+  assert.equal(turn("spawn-a", 900).newInputTokens, 900, "a forgotten spawn starts over");
+});
+
+// A model with no declared compaction budget has no derived ceiling. Counting
+// it is free; condemning it would mean inventing the number this module exists
+// not to invent.
+test("a model with no auto-compact budget is counted and never condemned", () => {
+  const seen = observeChildTurn({
+    spawnId: "spawn-c",
+    slug: "vendor/unsized",
+    autoCompact: undefined,
+    event: { status: 200, inputTokens: 10_000_000 },
+  });
+  assert.equal(seen.turns, 1);
+  assert.equal(seen.newInputTokens, 10_000_000);
+  assert.equal(seen.budget, undefined);
+  assert.equal(seen.exceeded, false);
+});
+
+// Only a prompt count the provider actually reported may move the total. The
+// router substitutes an estimate when a provider reports zero, and an
+// empty-completion retry bills the same prompt twice and merges both counts --
+// context-window-drift.mjs refuses both as capacity evidence for exactly the
+// same reason they must not be counted as a child's work here.
+test("estimated, retry-doubled, and failed turns count as turns but not as tokens", () => {
+  const estimated = observeChildTurn({
+    spawnId: "spawn-d",
+    slug: "vendor/looper",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 200, inputTokens: 5_000, estimatedInputTokens: 5_000 },
+  });
+  assert.equal(estimated.turns, 1);
+  assert.equal(estimated.newInputTokens, 0);
+
+  const retried = observeChildTurn({
+    spawnId: "spawn-d",
+    slug: "vendor/looper",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 200, inputTokens: 5_000, emptyCompletionRetried: true },
+  });
+  assert.equal(retried.turns, 2);
+  assert.equal(retried.newInputTokens, 0);
+
+  const failed = observeChildTurn({
+    spawnId: "spawn-d",
+    slug: "vendor/looper",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 503, inputTokens: 5_000 },
+  });
+  assert.equal(failed.turns, 3);
+  assert.equal(failed.newInputTokens, 0);
+
+  // The next believable sample folds in the growth the skipped ones hid, so a
+  // badly metering provider slows the accounting rather than corrupting it.
+  const believable = observeChildTurn({
+    spawnId: "spawn-d",
+    slug: "vendor/looper",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 200, inputTokens: 5_000 },
+  });
+  assert.equal(believable.newInputTokens, 5_000);
+  // Still not a loop: one accepted prompt is one prompt, and the ceiling is
+  // measured against the largest this spawn has actually been allowed to send.
+  assert.equal(believable.budget, 10_000);
+  assert.equal(believable.exceeded, false);
+});
+
+// The registry validator permits any `1 <= autoCompact <= contextWindow`, and
+// one oversized tool result can carry a single turn well past the compaction
+// limit in one step. Neither may be enough to condemn a model, so the ceiling
+// is taken against the larger of the declared budget and what this spawn has
+// actually had accepted.
+test("a single oversized prompt cannot condemn a model whose declared budget is small", () => {
+  const tiny = 100;
+  const huge = observeChildTurn({
+    spawnId: "spawn-oversized",
+    slug: "vendor/understated",
+    autoCompact: tiny,
+    event: { status: 200, inputTokens: 500_000 },
+  });
+  assert.equal(huge.newInputTokens, 500_000);
+  assert.equal(huge.budget, 1_000_000, "the ceiling followed the prompt the provider accepted");
+  assert.equal(huge.exceeded, false);
+
+  // It still condemns the same spawn once it has been summarized and has
+  // filled that much again, twice over: the ceiling moved with the prompt, it
+  // did not go away.
+  let looping;
+  for (const inputTokens of [10_000, 500_000, 10_000, 500_000]) {
+    looping = observeChildTurn({
+      spawnId: "spawn-oversized",
+      slug: "vendor/understated",
+      autoCompact: tiny,
+      event: { status: 200, inputTokens },
+    });
+  }
+  assert.equal(looping.newInputTokens, 1_480_000);
+  assert.equal(looping.budget, 1_000_000);
+  assert.equal(looping.exceeded, true);
+});
+
+// Without a thread id there is no way to tell one child from the next, and
+// merging two children's turns would demote a model for someone else's
+// traffic.
+test("a turn that cannot be attributed to a spawn is not accounted at all", () => {
+  assert.equal(observeChildTurn({ spawnId: "", slug: "vendor/looper" }), undefined);
+  assert.equal(observeChildTurn({ spawnId: "spawn-e", slug: "" }), undefined);
+  assert.deepEqual(childSpawnSnapshot(), []);
+});
+
+// A thread id reused on a different model is a different spawn, not a
+// continuation: the totals must not merge.
+test("a spawn id seen on another model starts fresh", () => {
+  observeChildTurn({
+    spawnId: "spawn-f",
+    slug: "vendor/one",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 200, inputTokens: 1_900 },
+  });
+  const other = observeChildTurn({
+    spawnId: "spawn-f",
+    slug: "vendor/two",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 200, inputTokens: 1_900 },
+  });
+  assert.equal(other.turns, 1);
+  assert.equal(other.newInputTokens, 1_900);
+  assert.equal(other.exceeded, false);
+});
+
+// The map is per live spawn, not per turn, but a router runs for weeks: an
+// abandoned child must not hold a slot forever, and a busy one must not grow
+// the map without bound.
+test("idle spawns expire and the map stays bounded", () => {
+  const start = 1_000_000;
+  observeChildTurn({
+    spawnId: "spawn-old",
+    slug: "vendor/looper",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 200, inputTokens: 10 },
+    now: start,
+  });
+  observeChildTurn({
+    spawnId: "spawn-new",
+    slug: "vendor/looper",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 200, inputTokens: 10 },
+    now: start + IDLE_SPAWN_MS + 1,
+  });
+  assert.deepEqual(
+    childSpawnSnapshot().map((entry) => entry.spawnId),
+    ["spawn-new"],
+  );
+
+  resetChildSpawns();
+  for (let index = 0; index < MAX_TRACKED_SPAWNS + 10; index += 1) {
+    observeChildTurn({
+      spawnId: `spawn-${index}`,
+      slug: "vendor/looper",
+      autoCompact: AUTO_COMPACT,
+      event: { status: 200, inputTokens: 10 },
+    });
+  }
+  const snapshot = childSpawnSnapshot();
+  assert.equal(snapshot.length, MAX_TRACKED_SPAWNS);
+  // LRU: the coldest spawns went, the newest stayed.
+  assert.equal(snapshot.at(-1).spawnId, `spawn-${MAX_TRACKED_SPAWNS + 9}`);
+  assert.equal(snapshot.at(0).spawnId, "spawn-10");
+});


### PR DESCRIPTION
Implements half (b) of #257. Half (a) landed in #273.

## The gate was the defect, not the thresholds

`observeSubagentOutcome` gated on `awaitingSpawnProof`, which is true **only** for `experimental`. So promotion on turn one closed the 400/422 demotion path along with it — after turn one nothing could demote a slug at all, and the oldest observation on the wire beat every later one.

The gate is now revocability (`spawnProofRevocable`: experimental **or** proven). Promotion stays scoped to the experimental window, because a first clean turn is only news once.

## Decision 1 — a 400/422 demotes a `proven` slug, on one occurrence

The lifecycle comment at `src/subagent-proofs.mjs:22` already defines `failed` as "the probe failed, **or an observed spawn failed structurally**". Nothing in that definition was ever scoped to `experimental`; the scoping was an accident of `awaitingSpawnProof` being reused as the observer's gate.

`proven` is documented as a claim about the wire, not the work. A 400/422 on a later child turn is the *same kind* of evidence, freshly obtained. And 400/422 is explicitly the **structural** class — the statuses that answer about the account or the moment (401/402/403/408/429/5xx) are already excluded in both the probe and the observer, so the signal does not decay with time and is no weaker after a 200 than before one.

**One occurrence, not a repeat**, because promotion is one occurrence (pinned at `test/routing.test.mjs:4974`) and the experimental demotion already required only one — a slug that has just passed a two-request live probe is demoted by a single 400 today. A false demotion is bounded and reversible; a missed demotion is an advertised subagent that fails every spawn.

**Re-promotion needed no change.** `subagentVerificationCandidates` skips `experimental`/`proven` but not `failed`, so `control subagents verify` or a switch off-and-on re-researches a demoted slug with live requests. Demotion is automatic; the direction that spends quota stays under the operator's hand. Registry-`v2` models are untouched — their claim is the shipped native collaboration proof, not this machine's traffic.

## Decision 2 — the ceiling is in tokens, not turns

**A turn count would have been invented.** There is no turn-shaped number in the repo: `max_concurrent_threads_per_session = 6` is width not depth, `turnLimit` in `codex-app-tools.mjs:935` is pagination over thread summaries, `MAX_DEPTH = 8` is JSON-schema recursion. And no test or fixture has ever run a child for more than one turn.

**But `src/context-window-drift.mjs:6-12` already names this exact pathology** — a task that opens above its compaction threshold, summarizes, "lose[s] the agent's working state, redo[es] the same opening work, and compact[s] again without ever finishing. Nothing errors. The session simply never ends." That sentence supplies both the unit and the multiple: the unit is the model's own `autoCompact` budget, published by the provider and already validated in `model-registry.mjs`; one budget is a large but legitimate task, and it is compacting *again* that is the runaway.

New `src/subagent-turns.mjs` accounts each spawn separately by `thread-id` and sums the **new** input tokens it produces — every child turn resends the whole conversation, so growth in the prompt count is what the child newly made, and a compaction makes the count fall, so everything after it is work being done twice. The ceiling is twice the larger of the declared `autoCompact` and the largest prompt that spawn has actually had accepted.

**That second term is what makes a false demotion impossible rather than merely unlikely.** An uncompacted spawn's cumulative new input equals its own largest prompt, so measuring against `max(autoCompact, observed peak) × 2` puts its total at exactly half the ceiling however long the task runs. Neither a model whose declared budget sits far below its window (the validator only requires `1 ≤ autoCompact ≤ contextWindow`) nor a single oversized tool result can condemn anything. Crossing requires the child to fill its context, be summarized, and fill it again while still going.

Only counts the provider actually reported move the total — substituted estimates and retry-doubled counts are refused via the existing `acceptedInputTokens` predicate, for the same reasons `context-window-drift.mjs` refuses them as capacity evidence. A model declaring no `autoCompact` is counted and never condemned.

## On "terminal turn": no detector is needed

The turn that ended a spawn is only knowable retrospectively, by no further turn arriving. But a ceiling can only ever be crossed by a spawn that is **still producing turns** — which is the same statement as "this has not converged". A converged child stops, and a spawn that stopped never reaches the ceiling. The issue's worry about telling an intermediate no-tool-call turn from a final one therefore never has to be resolved.

A child thread reused for a `FOLLOWUP_TASK` is deliberately one spawn (its context genuinely carries across); an idle spawn expires at 15 minutes. Accounting is LRU-bounded at 256 spawns, with constants derived from `AGENT_PAYLOAD_CACHE_MAX_ENTRIES` and `STALE_ACTIVITY_MS`.

## Observability

Both demotions log unconditionally — not `QUIET`-gated, asserted in the e2e — and the reason plus turn/token counts land in the proofs file, which `subagentSettingsSnapshot()` feeds to `control subagents status`, the tray and the desktop catalog. That is the house pattern ("the reason kept where it was switched on"); no new surface invented. The ceiling record deliberately carries no `status`: every turn answered 200, and recording one as the failure would read as a rejection that never happened.

## Review findings acted on

- **Structural invariant not enforced** (medium): the "uncompacted spawn can't cross" argument originally depended on `autoCompact ≥ contextWindow/2`, which the validator does not require. Fixed by measuring against the observed peak as well, making the invariant hold by construction. Regression test added.
- **Header trust** (raised as high, assessed as weaker): `/responses` is behind the caller-capability secret in the URL path (`authenticatedRoute`, `src/router.mjs:3068`), so only a caller holding the install's key can send subagent-marked turns — the same trust the promotion path already rests on. The boundary is not widened, and the added direction is the conservative one.
- **Thread reuse across delegations** (medium, real): Codex reuses a child thread for `FOLLOWUP_TASK`. Documented rather than papered over — the context does carry across, so cumulative accounting is the correct reading, and idle expiry bounds it.

## Tests

9 unit tests in `test/subagent-turns.test.mjs`, 1 in `test/subagent-proofs.test.mjs`, and a router e2e covering both a post-promotion 400 and a 6-turn looping child. The e2e is non-vacuous: reverting only the gate to `awaitingSpawnProof` makes it fail.

The intentional promote-on-first-turn e2e at `test/routing.test.mjs:4974` is untouched and passing.

`npm run check` passes. `npm test`: 1601 pass, 0 fail, 12 skipped.
