### PR TITLE
feat(devin-probe): make one tester's run settle each transport assumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,28 @@
   demotion. Both paths log unconditionally and record the turn and token
   counts in the proofs file, so `control subagents status` and the tray say
   what happened rather than a picker entry quietly disappearing.
+- **A passing Devin CLI probe now means something.** The provider's Cascade
+  transport was transcribed from a shipped binary and has never met Cognition's
+  backend, so #270 asks a volunteer with an account to settle it. The probe that
+  ask points at printed one line per stage, and every one of those lines could
+  pass while the thing it was meant to prove had failed: an empty model list
+  read as `OK: account advertises 0 model(s)`, a stream that decoded to nothing
+  read as `OK: streamed 0 character(s)`, and a tool call that arrived under a
+  field number this build does not know was skipped in silence and reported as a
+  model that chose not to call a tool — the one failure that decides whether
+  Codex can drive the provider at all. The probe now audits the raw bytes
+  alongside the schema and prints a PASS/FAIL line per assumption with the
+  observed value on each failure, so a run that reports success has confirmed
+  each one separately: request encoding, model list decoding, envelope framing,
+  the compression flag, the end-of-stream terminator, stop reason, usage,
+  tool-call ids and arguments, and a replay of the captured bytes through the
+  client a routed turn actually runs. Where a tool call goes missing, three
+  distinct lines separate a renumbered field from a model that declined. The
+  live turn is now capped at 64 output tokens and 90 seconds, `--live` remains
+  the only flag that spends anything, a mistyped flag fails the run instead of
+  quietly downgrading it, and the output folds `$HOME` to `~` and carries no
+  token, because it is written to be pasted into a public issue.
+  `docs/DEVIN-CLI-PROBE.md` is the tester's copy of all of it.
 
 - **Grok OAuth no longer loses late or custom tool calls.** The forwarder now
   accepts `function_call` and `custom_tool_call` items that first appear in

--- a/README.md
+++ b/README.md
@@ -1676,6 +1676,7 @@ streaming, image-input, tool-call, and context behavior are verified. See
 - [Architecture and request flow](docs/HOW-IT-WORKS.md)
 - [Security and credential handling](SECURITY.md)
 - [Provider development and tests](docs/DEVELOPMENT.md)
+- [Verifying the Devin CLI provider](docs/DEVIN-CLI-PROBE.md)
 - [Changelog](CHANGELOG.md)
 
 References: [Kimi Code CLI OAuth](https://www.kimi.com/help/kimi-code/cli-getting-started),

--- a/docs/DEVIN-CLI-PROBE.md
+++ b/docs/DEVIN-CLI-PROBE.md
@@ -1,0 +1,182 @@
+# Verifying the Devin CLI provider (`bin/devin-probe`)
+
+This page is for someone who has a Devin account and is willing to spend about
+five minutes and a few cents of ACU credit settling a question no maintainer of
+this repository can answer.
+
+You do not need to know this codebase. You will not install the router, start a
+service, change any configuration, or hand over a credential. The probe reads
+the session file the official Devin CLI already wrote, talks to Cognition
+directly, prints a checklist, and exits.
+
+## Why this needs you
+
+The Devin CLI provider drives Cognition's models over **Cascade**, a Connect RPC
+surface Cognition has not documented. Everything the provider knows about that
+surface — the protobuf field numbers, the service path, the authorization
+header, the stream framing — was transcribed out of the shipped `devin` binary.
+It has never spoken to Cognition's backend.
+
+The unit tests prove the translation is self-consistent. They cannot prove the
+upstream agrees with it. One run of this probe against a real account does.
+
+## What it costs
+
+| Command | Cost |
+| --- | --- |
+| `./bin/devin-probe` | Nothing. Reads your session file, re-reads the request the router would send, and asks your account which models it may run. |
+| `./bin/devin-probe --live` | One short turn. Output is capped at 64 tokens. |
+| `./bin/devin-probe --live --tools` | The same one short turn, with a tool call forced. |
+
+`--live` is the only flag that spends anything, and the turn it runs is capped
+by `--max-tokens` (default 64) and abandoned after `--timeout` seconds
+(default 90). Nothing else in the probe reaches a billable endpoint.
+
+## Before you start
+
+You need the official CLI installed and signed in:
+
+```sh
+curl -fsSL https://cli.devin.ai/install.sh | bash   # or: brew install --cask devin-cli
+devin auth login
+```
+
+You also need Node.js 22.19 or newer (`node --version`).
+
+## Run it
+
+```sh
+git clone https://github.com/duolahypercho/codex-router
+cd codex-router
+git fetch origin feat/devin-cli-provider feat/issue-270-devin-probe-hardening
+git checkout feat/devin-cli-provider
+git merge --no-edit origin/feat/issue-270-devin-probe-hardening
+npm install
+
+./bin/devin-probe                  # free
+./bin/devin-probe --live --tools   # one short turn of ACU credit
+```
+
+If the merge reports a conflict in `src/devin-cli-probe.mjs`, take this
+branch's version and continue — it is the newer probe:
+
+```sh
+git checkout --theirs src/devin-cli-probe.mjs && git add src/devin-cli-probe.mjs && git commit --no-edit
+```
+
+Once both branches have landed on `main`, the two `git fetch`/`git merge` lines
+above are unnecessary; a plain checkout of `main` is enough.
+
+Add `--model <uid>` to test a specific model from the list the free run printed.
+`--json` prints the same checklist as machine-readable JSON.
+
+## Reading the output
+
+Every assumption gets its own line. `PASS` and `FAIL` are the ones that matter;
+`INFO` lines are context, and `SKIP` means a check was not attempted.
+
+A healthy `--live --tools` run looks like this:
+
+```text
+PASS  devin cli session: read from ~/.local/share/devin/credentials.toml
+INFO  cascade host: server.codeium.com
+PASS  request encoding: 11 field(s) written, 321 bytes, all on their declared wire types
+PASS  model list: 6 enabled model(s) decoded, each with a model_uid
+INFO  entitlement flags: 4 premium, 1 beta, 1 standard
+INFO  model: swe-1  (premium)
+INFO  live response: http=200 content-type=application/connect+proto
+PASS  stream framing: 4 message frame(s) read from the response body
+PASS  frame compression: no frame carried the compressed flag
+PASS  end-of-stream terminator: clean terminator, no error carried
+PASS  turn produced output: 13 content char(s), 11 reasoning char(s), 1 tool call(s)
+INFO  stop reason: upstream stop reason 10
+PASS  usage accounting: prompt 120, completion 9
+PASS  served model: upstream confirmed swe-1
+PASS  tool calls decoded: 1 tool call(s): ping
+PASS  tool call ids: every tool call carried an id the forwarder can key on
+PASS  tool call arguments: every tool call carried parseable JSON arguments
+PASS  transport replay: the shipped transport reproduced all 4 message(s) from the captured bytes
+
+VERDICT PASS — 13 pass, 0 fail, 0 warn, 0 skipped
+```
+
+The last line is the summary. `PASS` means every assumption held.
+`PARTIAL` means everything attempted held but something was skipped — a free run
+always ends `PARTIAL`, because it never tried a turn. `FAIL` means at least one
+assumption is wrong, and `INCONCLUSIVE` means the run never reached anything
+worth reporting.
+
+## What each failure means
+
+Failures carry an `observed:` line with the value that actually came back, and
+usually a `fix:` line. Those two lines are the useful part — please include them.
+
+| Line | What it means |
+| --- | --- |
+| `FAIL devin cli session` | The probe could not read `credentials.toml`. Run `devin auth login` again. Nothing was sent. |
+| `FAIL request encoding` | A defect in this repository's own encoder, found before anything was sent. Nothing to do with your account. |
+| `FAIL model list … connect-code=unauthenticated` | Either your session expired, or the `Basic <token>-<token>` authorization scheme this build sends is wrong. Both are worth knowing. |
+| `FAIL model list … connect-code=unimplemented` | The service path or method name is wrong. Not your account's fault. |
+| `FAIL model list: the account advertised no usable model` | The response arrived but nothing in it decoded to a model. If the `observed:` line names `UNKNOWN` fields, the field numbers have moved. If it says the response decoded to nothing, your plan may entitle no Cascade model. |
+| `FAIL live turn … connect-code=invalid_argument` | The request shape is wrong. The upstream's message usually names the offending field — paste it verbatim, it is the single most useful thing in this document. |
+| `FAIL live turn … connect-code=permission_denied` or `failed_precondition` | Often a team setting (`disable_cascade`, `allowed_model_uids`) rather than a bug. Please say which plan you are on. |
+| `FAIL stream framing` | The upstream accepted the request and then sent no message frame. |
+| `FAIL frame compression` | The upstream compressed the stream. This transport cannot decompress and would decode every turn to nothing. |
+| `FAIL stream completeness` | The connection died part-way through a frame. |
+| `FAIL end-of-stream terminator` | A Connect stream reports failure *inside* its last frame, after HTTP 200 has already been sent. This line is that failure. |
+| `FAIL turn produced output` | Frames arrived and decoded to no text, no reasoning and no tool call. Check the `field census` line for `UNKNOWN` entries. |
+| **`FAIL tool calls decoded: … dropped on the wire, not declined by the model`** | The most important failure here. The upstream said it made a function call and this build decoded none, which means tool calls are being lost in translation. Codex drives every turn through tool calls, so this decides whether the provider is usable at all. |
+| `FAIL tool calls decoded: … the model declined a forced tool choice` | The transport is fine; this model would not call a tool when told to. Worth trying another `--model` before concluding anything. |
+| `FAIL tool call ids` | Tool calls arrived without ids. The forwarder keys restatements by id, so without them a restated call would be dispatched twice. |
+| `FAIL transport replay` | The bytes the upstream sent are read differently by the client the router actually runs than by the probe's own reader. A bug in this repository. |
+
+## What to paste back
+
+At the end of a text run the probe prints a fenced block beginning
+` ```text `. **Copy that whole block, fences included, into
+[issue #270](https://github.com/duolahypercho/codex-router/issues/270).** It
+carries the checklist plus your Node version, platform and `devin` CLI version,
+which is what makes the result reproducible.
+
+Also worth adding in your own words:
+
+1. **Your plan type** — Core, Team, or Enterprise. `allowed_model_uids` and
+   `disable_cascade` are team settings that can refuse the whole thing.
+2. **Whether the model list looks right** to you, compared with what the Devin
+   CLI or IDE offers you.
+3. Anything the probe printed that surprised you.
+
+A failure is as useful as a success. The `observed:` lines are what tell us
+which assumption was wrong.
+
+## What the probe does and does not print
+
+Its output is written to be pasted in public, so:
+
+- It never prints your API token.
+- It folds your home directory back to `~`.
+- It prints the Cascade **host** only, never a full URL with a path.
+- It records protobuf field numbers and byte counts, never field contents —
+  the exception is `model said:`, which echoes the first 200 characters of the
+  fixed test prompt's answer, and the tool-call arguments, which are `{"value":1}`
+  from the probe's own tool.
+
+It reads `credentials.toml` and never writes, moves, copies or deletes it.
+
+## For maintainers
+
+The probe is deliberately split so that most of it is testable without an
+account:
+
+| File | Role |
+| --- | --- |
+| `src/protobuf-audit.mjs` | Reads protobuf bytes without a schema and classifies every field against one. This is what makes a renumbered field loud instead of silent. |
+| `src/connect-stream-audit.mjs` | Connect envelope framing, the compression flag, the end-of-stream terminator, and the full Connect code → HTTP status table. |
+| `src/probe-report.mjs` | The PASS/FAIL checklist, the verdict, and the paste block. |
+| `src/devin-probe-checks.mjs` | Every judgement the probe makes, as pure functions over plain observations. |
+| `src/devin-cli-probe.mjs` | The I/O: reads the session, fetches, frames, and hands observations to the above. |
+
+`test/devin-cli-probe.test.mjs` runs the whole probe against a fabricated
+provider and a fabricated upstream, including the dropped-tool-call case, so the
+wiring is exercised in CI on machines with no Devin account and no provider
+sources.

--- a/src/connect-stream-audit.mjs
+++ b/src/connect-stream-audit.mjs
@@ -1,0 +1,181 @@
+// Connect-protocol stream inspection, kept separate from any Connect client.
+//
+// A transport reads frames in order to yield messages, and drops everything it
+// does not need: the compression bit, the frames it never completed, the shape
+// of the end-of-stream terminator. Those are exactly the things a probe has to
+// report, because each one has a quiet failure mode:
+//
+//   * A frame flagged compressed and handed straight to a protobuf decoder
+//     decodes to an empty message. No error is raised anywhere; the turn simply
+//     produces no text and no tool calls.
+//   * A stream that ends mid-frame yields every complete message before it and
+//     then stops, which reads as a short answer.
+//   * A Connect stream reports failure inside the terminator with HTTP 200
+//     already sent, so a client that ignores the terminator reports success.
+//
+// The status table below is the full set of Connect error codes. An incomplete
+// table is not a cosmetic gap: a code that falls through to 502 is treated as a
+// transient upstream fault and retried, and `unimplemented` -- the code an
+// upstream returns when the service path or method name is wrong -- must never
+// be retried, because it will never succeed.
+
+export const COMPRESSED_FLAG = 0x01;
+export const END_STREAM_FLAG = 0x02;
+export const ENVELOPE_HEADER_BYTES = 5;
+
+export const CONNECT_CODE_STATUS = Object.freeze({
+  canceled: 499,
+  unknown: 502,
+  invalid_argument: 400,
+  deadline_exceeded: 504,
+  not_found: 404,
+  already_exists: 409,
+  permission_denied: 403,
+  resource_exhausted: 429,
+  failed_precondition: 400,
+  aborted: 409,
+  out_of_range: 400,
+  unimplemented: 501,
+  internal: 502,
+  unavailable: 503,
+  data_loss: 500,
+  unauthenticated: 401,
+});
+
+// Only these are worth another attempt. Everything else describes a request the
+// upstream will refuse identically next time.
+const RETRIABLE_CODES = new Set(["unavailable", "resource_exhausted", "deadline_exceeded", "aborted"]);
+
+export function connectStatusFor(code, fallback = 502) {
+  if (typeof code !== "string") return fallback;
+  const status = CONNECT_CODE_STATUS[code.toLowerCase()];
+  return status === undefined ? fallback : status;
+}
+
+export function isRetriableConnectCode(code) {
+  return typeof code === "string" && RETRIABLE_CODES.has(code.toLowerCase());
+}
+
+export function isKnownConnectCode(code) {
+  return typeof code === "string" && Object.hasOwn(CONNECT_CODE_STATUS, code.toLowerCase());
+}
+
+function toBytes(input) {
+  if (input instanceof Uint8Array) return input;
+  if (ArrayBuffer.isView(input)) return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+  if (input instanceof ArrayBuffer) return new Uint8Array(input);
+  return Uint8Array.from(input || []);
+}
+
+function concat(left, right) {
+  if (!left.length) return right;
+  if (!right.length) return left;
+  const merged = new Uint8Array(left.length + right.length);
+  merged.set(left, 0);
+  merged.set(right, left.length);
+  return merged;
+}
+
+function readUint32BigEndian(bytes, offset) {
+  return (
+    ((bytes[offset] << 24) | (bytes[offset + 1] << 16) | (bytes[offset + 2] << 8) | bytes[offset + 3]) >>> 0
+  );
+}
+
+// Incremental so a caller can feed it the chunks a response body actually
+// produces. A frame header split across two chunks, or a payload split across
+// five, must not be observable to the caller.
+export function createEnvelopeScanner() {
+  let buffered = new Uint8Array(0);
+  let index = 0;
+  let ended = false;
+
+  return {
+    push(chunk) {
+      buffered = concat(buffered, toBytes(chunk));
+      const frames = [];
+      for (;;) {
+        if (buffered.length < ENVELOPE_HEADER_BYTES) break;
+        const flags = buffered[0];
+        const length = readUint32BigEndian(buffered, 1);
+        if (buffered.length < ENVELOPE_HEADER_BYTES + length) break;
+        const payload = buffered.slice(ENVELOPE_HEADER_BYTES, ENVELOPE_HEADER_BYTES + length);
+        buffered = buffered.subarray(ENVELOPE_HEADER_BYTES + length);
+        const frame = {
+          index,
+          flags,
+          length,
+          payload,
+          compressed: (flags & COMPRESSED_FLAG) !== 0,
+          endOfStream: (flags & END_STREAM_FLAG) !== 0,
+        };
+        index += 1;
+        if (frame.endOfStream) ended = true;
+        frames.push(frame);
+      }
+      return frames;
+    },
+    // Bytes the upstream sent that never became a frame. Non-empty at the end
+    // of a stream means the connection died mid-frame.
+    get pending() {
+      return buffered.length;
+    },
+    get sawEndOfStream() {
+      return ended;
+    },
+  };
+}
+
+export function scanEnvelopes(input) {
+  const scanner = createEnvelopeScanner();
+  const frames = scanner.push(input);
+  return { frames, pending: scanner.pending, sawEndOfStream: scanner.sawEndOfStream };
+}
+
+export function encodeEnvelope(payload, { flags = 0 } = {}) {
+  const bytes = toBytes(payload);
+  const framed = new Uint8Array(ENVELOPE_HEADER_BYTES + bytes.length);
+  framed[0] = flags;
+  framed[1] = (bytes.length >>> 24) & 0xff;
+  framed[2] = (bytes.length >>> 16) & 0xff;
+  framed[3] = (bytes.length >>> 8) & 0xff;
+  framed[4] = bytes.length & 0xff;
+  framed.set(bytes, ENVELOPE_HEADER_BYTES);
+  return framed;
+}
+
+// The terminator is JSON, `{}` on success and `{"error":{"code","message"}}` on
+// failure. A terminator that is neither is reported as malformed rather than
+// silently treated as success, because "we could not read the terminator" and
+// "the upstream said the turn succeeded" are different claims.
+export function parseEndStreamPayload(payload) {
+  const text = new TextDecoder().decode(toBytes(payload));
+  const trimmed = text.trim();
+  if (!trimmed) return { text: "", json: {}, malformed: false, error: undefined };
+  let json;
+  try {
+    json = JSON.parse(trimmed);
+  } catch {
+    return { text: trimmed.slice(0, 500), json: undefined, malformed: true, error: undefined };
+  }
+  if (!json || typeof json !== "object") {
+    return { text: trimmed.slice(0, 500), json, malformed: true, error: undefined };
+  }
+  const failure = json.error;
+  if (!failure || typeof failure !== "object") {
+    return { text: trimmed.slice(0, 500), json, malformed: false, error: undefined };
+  }
+  const code = typeof failure.code === "string" ? failure.code : undefined;
+  return {
+    text: trimmed.slice(0, 500),
+    json,
+    malformed: false,
+    error: {
+      code,
+      message: typeof failure.message === "string" ? failure.message : undefined,
+      status: connectStatusFor(code),
+      retriable: isRetriableConnectCode(code),
+      known: isKnownConnectCode(code),
+    },
+  };
+}

--- a/src/devin-cli-probe.mjs
+++ b/src/devin-cli-probe.mjs
@@ -1,90 +1,276 @@
-// A self-contained check that the Devin CLI provider can reach Cognition's
-// backend with the operator's own session. It talks to the upstream directly
-// rather than through the installed router, so it works before the provider is
-// enabled and tells a tester which of the three layers failed:
+// A conclusive check that the Devin CLI provider's Cascade transport is right.
 //
-//   1. the credential the Devin CLI wrote
-//   2. the Connect transport and protobuf schemas
-//   3. a real streamed turn, optionally with a forced tool call
+// Every network-facing constant this provider uses -- field numbers, wire
+// types, the service path, the authorization scheme, the framing -- was read
+// out of a shipped binary rather than a published interface. None of it has
+// ever met Cognition's backend. The point of this file is that one run by one
+// person with an account settles each of those assumptions separately, and
+// prints a line naming the one that broke, rather than a single boolean that
+// says "something responded".
 //
-// Everything except step 3 is free. Step 3 spends the account's ACU credits,
-// so it only runs with --live.
+// It talks to the upstream directly instead of through the installed router,
+// so it works before the provider is enabled, and it reads the raw bytes off
+// the wire rather than trusting the transport it is supposed to be testing.
+//
+// Everything except the `--live` stage is free. `--live` spends one short turn
+// of the account's ACU credits and is capped to a few dozen output tokens.
 
-import { devinCliStatus } from "./devin-cli-status.mjs";
-import { readDevinSession } from "./devin-cli-session.mjs";
-import { connectServerStream } from "./devin-connect.mjs";
-import {
-  GET_CHAT_MESSAGE,
-  GET_CHAT_MESSAGE_REQUEST,
-  GET_CHAT_MESSAGE_RESPONSE,
-  SERVICE_PATH,
-} from "./devin-proto.mjs";
-import { buildChatMessageRequest } from "./devin-cli-turn.mjs";
-import { listCascadeModels } from "./devin-cli-forwarder.mjs";
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
 import { installStableFetchTransport } from "./fetch-transport.mjs";
+import { ProbeReport, truncateForReport } from "./probe-report.mjs";
+import { auditMessage, fieldCensus } from "./protobuf-audit.mjs";
+import {
+  connectStatusFor,
+  createEnvelopeScanner,
+  encodeEnvelope,
+  isKnownConnectCode,
+  isRetriableConnectCode,
+  parseEndStreamPayload,
+} from "./connect-stream-audit.mjs";
+import {
+  liveTurnChecks,
+  modelListChecks,
+  parseProbeArgs,
+  requestShapeChecks,
+  streamFrameChecks,
+  toolCallChecks,
+} from "./devin-probe-checks.mjs";
 
 installStableFetchTransport();
 
-const args = process.argv.slice(2);
-const live = args.includes("--live");
-const wantsTools = args.includes("--tools");
-const modelFlag = args.indexOf("--model");
-const requestedModel = modelFlag >= 0 ? args[modelFlag + 1] : undefined;
+const USAGE = `Usage: bin/devin-probe [--live] [--tools] [--model <uid>] [--max-tokens <n>] [--timeout <seconds>] [--json]
 
-function line(status, message) {
-  console.log(`${status.padEnd(5)} ${message}`);
-}
+Checks the Devin CLI provider's Cascade transport against your own account and
+prints one PASS/FAIL line per assumption.
 
-function fail(message) {
-  line("FAIL", message);
-  process.exitCode = 1;
-}
+Without --live nothing is spent: the probe reads the session the official Devin
+CLI wrote, re-reads the request it would send, and asks the account which models
+it may run.
 
-async function main() {
-  const status = devinCliStatus();
-  if (!status.configured) {
-    fail(`Devin CLI session: ${status.setup}`);
-    console.log(`      looked in ${status.authPath}`);
-    return;
+--live       Run one short turn. This spends ACU credit on your account.
+--tools      With --live, force a tool call. This is the check that decides
+             whether Codex can drive the provider at all.
+--model      Pick a model uid from the free run's list. Defaults to the first.
+--max-tokens Cap the live turn's output. Default 64.
+--timeout    Give up on the live stream after this many seconds. Default 90.
+--json       Print the checklist as JSON instead of text.
+`;
+
+// The provider's own sources land with #271. Everything above is generic and
+// ships without them, so say plainly which branch is missing rather than dying
+// on a module resolution error a tester cannot act on.
+const PROVIDER_MODULES = Object.freeze([
+  "./devin-cli-status.mjs",
+  "./devin-cli-session.mjs",
+  "./devin-proto.mjs",
+  "./devin-cli-turn.mjs",
+  "./devin-connect.mjs",
+  "./protobuf-wire.mjs",
+]);
+
+async function loadProvider() {
+  const loaded = {};
+  for (const specifier of PROVIDER_MODULES) {
+    try {
+      loaded[specifier] = await import(specifier);
+    } catch (error) {
+      return { missing: specifier, reason: error?.message || String(error) };
+    }
   }
-  line("OK", `Devin CLI session found (${status.authPath})`);
+  return {
+    status: loaded["./devin-cli-status.mjs"],
+    session: loaded["./devin-cli-session.mjs"],
+    proto: loaded["./devin-proto.mjs"],
+    turn: loaded["./devin-cli-turn.mjs"],
+    connect: loaded["./devin-connect.mjs"],
+    wire: loaded["./protobuf-wire.mjs"],
+  };
+}
 
-  const session = readDevinSession();
-  let models;
+function devinCliVersion() {
+  const binary = commandOnPath("devin");
+  if (!binary) return "not on PATH";
   try {
-    models = await listCascadeModels({ session });
+    const { command, args } = spawnableCommand(binary, ["--version"]);
+    const result = spawnSync(command, args, { encoding: "utf8", timeout: 15_000, windowsHide: true });
+    const text = `${result.stdout || ""}${result.stderr || ""}`.trim();
+    return text.split("\n")[0]?.slice(0, 120) || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+// The output of this probe is written to be pasted into a public issue, so a
+// home directory -- which usually carries the operator's name -- is folded back
+// to `~` before it is ever printed.
+function homeRelative(target) {
+  const home = os.homedir();
+  return home && String(target).startsWith(home) ? `~${String(target).slice(home.length)}` : String(target);
+}
+
+// Only the host. The stored URL is not itself a secret, but a probe's output is
+// written to be pasted in public and an enterprise host names the employer.
+function hostOf(url) {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "(unparseable)";
+  }
+}
+
+function requestUrl(baseUrl, service, method) {
+  return `${String(baseUrl).replace(/\/+$/, "")}/${service}/${method}`;
+}
+
+async function describeHttpFailure(response) {
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    body = "";
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    parsed = undefined;
+  }
+  const code = typeof parsed?.code === "string" ? parsed.code : undefined;
+  return {
+    httpStatus: response.status,
+    code,
+    known: isKnownConnectCode(code),
+    retriable: isRetriableConnectCode(code),
+    mappedStatus: connectStatusFor(code, response.status),
+    message: parsed?.message || body.slice(0, 300) || `HTTP ${response.status}`,
+    contentType: response.headers?.get?.("content-type") || "(none)",
+  };
+}
+
+function failureCheck(name, failure, fix) {
+  return {
+    status: "fail",
+    name,
+    detail: `the upstream refused the request: ${truncateForReport(failure.message, 240)}`,
+    observed: `http=${failure.httpStatus} connect-code=${failure.code || "(none)"} known=${failure.known} retriable=${failure.retriable} content-type=${failure.contentType}`,
+    fix,
+  };
+}
+
+async function runFreeStage(report, provider, args, fetchImpl) {
+  const { proto, wire, turn, connect } = provider;
+  const status = provider.status.devinCliStatus();
+  if (!status.configured) {
+    report.fail("devin cli session", status.setup, { observed: homeRelative(status.authPath) });
+    return undefined;
+  }
+  report.pass("devin cli session", `read from ${homeRelative(status.authPath)}`);
+
+  let session;
+  try {
+    session = provider.session.readDevinSession();
   } catch (error) {
-    fail(`Model list refused: ${error.message}`);
-    return;
+    report.fail("devin cli session", error.message, { observed: homeRelative(status.authPath) });
+    return undefined;
   }
-  line("OK", `Account advertises ${models.length} model(s)`);
+  const baseUrl = process.env.DEVIN_CASCADE_BASE_URL || session.apiServerUrl;
+  report.info("cascade host", hostOf(baseUrl));
+
+  // Free and decisive about our own writer: build the exact turn request and
+  // read it back through an independent auditor.
+  const sampleRequest = turn.buildChatMessageRequest(
+    {
+      model: args.model || "probe-model",
+      messages: [{ role: "user", content: "probe" }],
+      max_tokens: args.maxTokens,
+    },
+    { token: session.apiKey, modelUid: args.model || "probe-model" },
+  );
+  report.addAll(
+    requestShapeChecks({
+      audit: auditMessage(wire.encodeMessage(proto.GET_CHAT_MESSAGE_REQUEST, sampleRequest), proto.GET_CHAT_MESSAGE_REQUEST),
+      requiredFields: ["metadata", "prompt", "requestType", "chatModelUid", "chatMessagePrompts", "configuration"],
+    }),
+  );
+
+  let response;
+  try {
+    response = await fetchImpl(requestUrl(baseUrl, proto.SERVICE_PATH, proto.GET_CASCADE_MODEL_CONFIGS), {
+      method: "POST",
+      headers: {
+        "content-type": "application/proto",
+        "connect-protocol-version": "1",
+        "connect-accept-encoding": "identity",
+        authorization: connect.connectAuthorization(session.apiKey),
+      },
+      body: wire.encodeMessage(proto.GET_CASCADE_MODEL_CONFIGS_REQUEST, {
+        metadata: { apiKey: session.apiKey, ideName: "windsurf", locale: "en" },
+      }),
+    });
+  } catch (error) {
+    report.fail("model list", `the request never reached the upstream: ${error.message}`, {
+      observed: hostOf(baseUrl),
+      fix: "A DNS or TLS failure here is a network problem, not a schema problem.",
+    });
+    return undefined;
+  }
+
+  if (!response.ok) {
+    const failure = await describeHttpFailure(response);
+    report.add(
+      failureCheck(
+        "model list",
+        failure,
+        failure.httpStatus === 401
+          ? "Run `devin auth login` again, or the Basic `<token>-<token>` authorization scheme this build sends is wrong."
+          : failure.code === "unimplemented"
+            ? "`unimplemented` means the service path or method name is wrong, not that the account is at fault."
+            : "Paste the observed line; the connect-code names which assumption broke.",
+      ),
+    );
+    return undefined;
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const audit = auditMessage(bytes, proto.GET_CASCADE_MODEL_CONFIGS_RESPONSE);
+  const decoded = wire.decodeMessage(proto.GET_CASCADE_MODEL_CONFIGS_RESPONSE, bytes);
+  const models = (decoded.clientModelConfigs || [])
+    .filter((config) => !config.disabled)
+    .map((config) => ({
+      id: config.modelUid,
+      label: config.label || config.modelUid,
+      premium: Boolean(config.isPremium),
+      beta: Boolean(config.isBeta),
+    }))
+    .filter((model) => model.id);
+
+  report.addAll(modelListChecks({ models, census: fieldCensus(audit), httpStatus: response.status }));
   for (const model of models.slice(0, 40)) {
-    const notes = [model.premium ? "premium" : undefined, model.beta ? "beta" : undefined]
-      .filter(Boolean)
-      .join(", ");
-    console.log(`      ${model.id}${notes ? `  (${notes})` : ""}`);
+    const notes = [model.premium ? "premium" : undefined, model.beta ? "beta" : undefined].filter(Boolean).join(", ");
+    report.info("model", `${model.id}${notes ? `  (${notes})` : ""}`);
   }
-  if (models.length > 40) console.log(`      ... and ${models.length - 40} more`);
+  if (models.length > 40) report.info("model", `…and ${models.length - 40} more`);
+  return { session, baseUrl, models };
+}
 
-  if (!live) {
-    line("SKIP", "Live turn not attempted. Re-run with --live to spend one turn of ACU credit.");
-    return;
-  }
-
-  const model = requestedModel || models[0]?.id;
-  if (!model) {
-    fail("No model to test; pass --model <uid>.");
-    return;
-  }
-
+function liveChatRequest(args, model) {
   const chat = {
     model,
+    max_tokens: args.maxTokens,
     messages: [
       { role: "system", content: "You are a test harness. Answer in one short sentence." },
-      { role: "user", content: wantsTools ? "Call the ping tool with value 1." : "Reply with the word: ready" },
+      {
+        role: "user",
+        content: args.tools ? "Call the ping tool with value 1." : "Reply with the word: ready",
+      },
     ],
   };
-  if (wantsTools) {
+  if (args.tools) {
     chat.tools = [
       {
         type: "function",
@@ -97,42 +283,284 @@ async function main() {
     ];
     chat.tool_choice = "required";
   }
+  return chat;
+}
 
-  let text = "";
-  let thinking = "";
-  const toolCalls = [];
+async function runLiveStage(report, provider, args, context, fetchImpl) {
+  const { proto, wire, turn, connect } = provider;
+  const model = args.model || context.models[0]?.id;
+  if (!model) {
+    report.fail("live turn", "no model to test", { fix: "Pass --model <uid> with a uid from the free run." });
+    return;
+  }
+  if (args.model && context.models.length && !context.models.some((entry) => entry.id === args.model)) {
+    report.warn("live turn", "the requested model is not in the list this account advertises", { observed: args.model });
+  }
+
+  const chat = liveChatRequest(args, model);
+  const message = turn.buildChatMessageRequest(chat, { token: context.session.apiKey, modelUid: model });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), args.timeoutMs);
+
+  let response;
   try {
-    for await (const message of connectServerStream({
-      baseUrl: process.env.DEVIN_CASCADE_BASE_URL || session.apiServerUrl,
-      service: SERVICE_PATH,
-      method: GET_CHAT_MESSAGE,
-      token: session.apiKey,
-      requestSchema: GET_CHAT_MESSAGE_REQUEST,
-      responseSchema: GET_CHAT_MESSAGE_RESPONSE,
-      message: buildChatMessageRequest(chat, { token: session.apiKey, modelUid: model }),
-    })) {
-      if (message.deltaText) text += message.deltaText;
-      if (message.deltaThinking) thinking += message.deltaThinking;
-      for (const call of message.deltaToolCalls || []) toolCalls.push(call);
-    }
+    response = await fetchImpl(requestUrl(context.baseUrl, proto.SERVICE_PATH, proto.GET_CHAT_MESSAGE), {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        "content-type": "application/connect+proto",
+        "connect-protocol-version": "1",
+        "connect-accept-encoding": "identity",
+        authorization: connect.connectAuthorization(context.session.apiKey),
+      },
+      body: encodeEnvelope(wire.encodeMessage(proto.GET_CHAT_MESSAGE_REQUEST, message)),
+      duplex: "half",
+    });
   } catch (error) {
-    fail(`Live turn on ${model} failed: ${error.message}`);
+    clearTimeout(timer);
+    report.fail("live turn", `the request never reached the upstream: ${error.message}`, { observed: hostOf(context.baseUrl) });
     return;
   }
 
-  line("OK", `Live turn on ${model} streamed ${text.length} character(s)`);
-  if (thinking) line("OK", `Reasoning channel produced ${thinking.length} character(s)`);
-  if (text.trim()) console.log(`      ${text.trim().slice(0, 300)}`);
-  if (wantsTools) {
-    if (toolCalls.length) {
-      line("OK", `Forced tool call returned: ${toolCalls.map((call) => call.name).join(", ")}`);
-      console.log(`      arguments: ${toolCalls[0].argumentsJson}`);
-    } else {
-      fail("Forced tool call produced no tool call; this model cannot drive a Codex turn.");
-    }
+  if (!response.ok) {
+    clearTimeout(timer);
+    const failure = await describeHttpFailure(response);
+    report.add(
+      failureCheck(
+        "live turn",
+        failure,
+        failure.code === "invalid_argument"
+          ? "`invalid_argument` is the request shape being wrong. The message text usually names the field; paste it verbatim."
+          : failure.code === "permission_denied" || failure.code === "failed_precondition"
+            ? "This is often a team setting: `disable_cascade` or an `allowed_model_uids` list. Say which plan you are on."
+            : "Paste the observed line.",
+      ),
+    );
+    return;
   }
+  report.info("live response", `http=${response.status} content-type=${response.headers?.get?.("content-type") || "(none)"}`);
+
+  const scanner = createEnvelopeScanner();
+  const rawChunks = [];
+  const frames = [];
+  const audits = [];
+  let terminator;
+  let text = "";
+  let thinking = "";
+  const toolCalls = [];
+  let stopReason;
+  let usage;
+  let actualModelUid;
+  let requestId;
+
+  try {
+    for await (const chunk of response.body) {
+      const bytes = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+      rawChunks.push(bytes);
+      for (const frame of scanner.push(bytes)) {
+        frames.push(frame);
+        if (frame.endOfStream) {
+          terminator = parseEndStreamPayload(frame.payload);
+          continue;
+        }
+        if (frame.compressed) continue;
+        audits.push(auditMessage(frame.payload, proto.GET_CHAT_MESSAGE_RESPONSE));
+        const decoded = wire.decodeMessage(proto.GET_CHAT_MESSAGE_RESPONSE, frame.payload);
+        if (decoded.deltaText) text += decoded.deltaText;
+        if (decoded.deltaThinking) thinking += decoded.deltaThinking;
+        for (const call of decoded.deltaToolCalls || []) toolCalls.push(call);
+        if (decoded.stopReason !== undefined) stopReason = decoded.stopReason;
+        if (decoded.usage) usage = provider.turn.usageFrom(decoded.usage);
+        if (decoded.actualModelUid) actualModelUid = decoded.actualModelUid;
+        if (decoded.requestId) requestId = decoded.requestId;
+      }
+    }
+  } catch (error) {
+    report.fail("live turn", `the stream ended early: ${error.message}`, {
+      observed: `${frames.length} frame(s) read, ${scanner.pending} byte(s) unframed`,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  const census = fieldCensus(audits);
+  report.addAll(
+    streamFrameChecks({ frames, pending: scanner.pending, sawEndOfStream: scanner.sawEndOfStream, terminator }),
+  );
+  report.addAll(
+    liveTurnChecks({
+      model,
+      text,
+      thinking,
+      toolCalls,
+      stopReason,
+      usage,
+      actualModelUid,
+      requestId,
+      census,
+      wantsTools: args.tools,
+    }),
+  );
+  report.addAll(
+    toolCallChecks({
+      wantsTools: args.tools,
+      toolCalls,
+      stopReason,
+      functionCallStopReason: proto.STOP_REASON?.FUNCTION_CALL,
+      census,
+      text,
+    }),
+  );
+  if (census.length) {
+    report.info(
+      "field census",
+      census.map((row) => `${row.path.length ? `${row.path.join(".")}.` : ""}${row.no}:${row.name ?? "UNKNOWN"}`).join(" "),
+    );
+  }
+  if (text.trim()) report.info("model said", truncateForReport(text.trim(), 200));
+
+  await replayThroughTransport(report, provider, rawChunks, {
+    messages: frames.filter((frame) => !frame.endOfStream).length,
+    text,
+    // A stream that ended in an error must make the transport throw. Replaying
+    // it and calling that throw a transport fault would send a tester chasing a
+    // defect that is not there.
+    expectThrow: Boolean(terminator?.error),
+  });
 }
 
-main().catch((error) => {
-  fail(error.message);
-});
+// The stages above read the wire directly, on purpose: a probe must not test a
+// transport with the transport. Replaying the captured bytes through the
+// shipped client afterwards is free, spends nothing, and is the only way to
+// show that the code a routed turn will actually run agrees with what arrived.
+async function replayThroughTransport(report, provider, rawChunks, expected) {
+  if (!rawChunks.length) {
+    report.skip("transport replay", "no bytes were captured to replay");
+    return;
+  }
+  const { proto, connect } = provider;
+  const fakeFetch = async () => ({
+    ok: true,
+    status: 200,
+    headers: new Map(),
+    body: (async function* body() {
+      for (const chunk of rawChunks) yield chunk;
+    })(),
+  });
+  let replayed = 0;
+  let replayedText = "";
+  try {
+    for await (const message of connect.connectServerStream({
+      baseUrl: "https://replay.invalid",
+      service: proto.SERVICE_PATH,
+      method: proto.GET_CHAT_MESSAGE,
+      token: "replay",
+      requestSchema: proto.GET_CHAT_MESSAGE_REQUEST,
+      responseSchema: proto.GET_CHAT_MESSAGE_RESPONSE,
+      message: {},
+      fetchImpl: fakeFetch,
+    })) {
+      replayed += 1;
+      if (message.deltaText) replayedText += message.deltaText;
+    }
+  } catch (error) {
+    report.add(
+      expected.expectThrow
+        ? {
+            status: "pass",
+            name: "transport replay",
+            detail: "the shipped transport raised the error the stream terminator carried, as it must",
+            observed: truncateForReport(error.message, 160),
+          }
+        : {
+            status: "fail",
+            name: "transport replay",
+            detail: `the shipped transport rejected bytes the upstream actually sent: ${error.message}`,
+            observed: `${replayed} of ${expected.messages} message(s) before the failure`,
+          },
+    );
+    return;
+  }
+  if (expected.expectThrow) {
+    report.fail("transport replay", "the stream carried an error the shipped transport did not raise", {
+      expected: "the terminator's error to surface as a thrown failure",
+      observed: `${replayed} message(s) yielded, no error`,
+    });
+    return;
+  }
+  report.add(
+    replayed === expected.messages && replayedText === expected.text
+      ? { status: "pass", name: "transport replay", detail: `the shipped transport reproduced all ${replayed} message(s) from the captured bytes` }
+      : {
+          status: "fail",
+          name: "transport replay",
+          detail: "the shipped transport read the captured bytes differently than a direct read of the same bytes",
+          expected: `${expected.messages} message(s), ${expected.text.length} char(s)`,
+          observed: `${replayed} message(s), ${replayedText.length} char(s)`,
+        },
+  );
+}
+
+// Every outside edge is injectable so the probe's own wiring -- which stage
+// runs, which check fires on which observation -- is exercised in CI against a
+// fabricated upstream, on a machine with neither an account nor the provider.
+export async function runProbe(argv = [], { provider: injected, fetchImpl = fetch, stdout = process.stdout, cliVersion = devinCliVersion } = {}) {
+  const args = parseProbeArgs(argv);
+  if (args.help) {
+    stdout.write(USAGE);
+    return { code: 0, report: undefined };
+  }
+  const report = new ProbeReport({
+    title: "codex-router devin-cli probe",
+    environment: {
+      node: process.version,
+      platform: `${process.platform}/${process.arch}`,
+      os: `${os.type()} ${os.release()}`,
+      "devin cli": cliVersion(),
+      mode: args.live ? (args.tools ? "--live --tools" : "--live") : "free",
+    },
+  });
+
+  for (const problem of args.errors) report.fail("arguments", problem);
+  if (args.unknown.length) {
+    report.fail("arguments", "unrecognised argument; the run below is not the one you asked for", {
+      observed: args.unknown.join(" "),
+      fix: `Did you mean --tools? ${USAGE.split("\n")[0]}`,
+    });
+  }
+
+  const provider = injected || (await loadProvider());
+  if (provider.missing) {
+    report.fail("devin provider sources", `${provider.missing} is not present in this checkout`, {
+      observed: truncateForReport(provider.reason, 160),
+      fix: "The provider lands with PR #271: `git fetch origin feat/devin-cli-provider && git checkout feat/devin-cli-provider`, then merge this branch on top. See docs/DEVIN-CLI-PROBE.md.",
+    });
+  } else if (!report.failed) {
+    const context = await runFreeStage(report, provider, args, fetchImpl);
+    if (context && args.live) await runLiveStage(report, provider, args, context, fetchImpl);
+    else if (context) {
+      report.skip("live turn", "not attempted; re-run with --live to spend one short turn of ACU credit");
+    }
+  }
+
+  if (args.json) {
+    stdout.write(`${JSON.stringify(report.toJson(), null, 2)}\n`);
+  } else {
+    stdout.write(report.render());
+    stdout.write("\nPaste everything between the fences into the issue:\n\n");
+    stdout.write(report.pasteBlock());
+  }
+  return { code: report.exitCode(), report };
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === path.resolve(fileURLToPath(import.meta.url));
+if (isMain) {
+  runProbe(process.argv.slice(2))
+    .then(({ code }) => {
+      process.exitCode = code;
+    })
+    .catch((error) => {
+      process.stderr.write(`FAIL  probe crashed: ${error?.stack || error}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/src/devin-probe-checks.mjs
+++ b/src/devin-probe-checks.mjs
@@ -1,0 +1,460 @@
+// The judgements the Devin CLI probe makes, with no I/O and no dependency on
+// the provider's schemas, so every one of them is exercised in CI on a machine
+// that has no Devin account.
+//
+// The probe itself only fetches bytes and hands the observations here. Keeping
+// the reasoning separate is what lets the interesting cases -- an upstream that
+// says it called a function while the decoder produced none, a model list that
+// decoded to nothing, a tool call with no id -- be tested against fabricated
+// observations instead of waiting on a volunteer.
+
+import { describeCensusRow } from "./protobuf-audit.mjs";
+import { truncateForReport } from "./probe-report.mjs";
+
+export const DEFAULT_MAX_TOKENS = 64;
+export const DEFAULT_TIMEOUT_MS = 90_000;
+
+const KNOWN_FLAGS = new Set(["--live", "--tools", "--json", "--help", "-h", "--model", "--max-tokens", "--timeout"]);
+
+// Unknown flags are reported rather than ignored. The published instructions
+// ask for `--live --tools`; a tester who types `--tool` must not get a run that
+// silently skips the only check that matters and then prints a pass.
+export function parseProbeArgs(argv = []) {
+  const args = [...argv];
+  const parsed = {
+    live: false,
+    tools: false,
+    json: false,
+    help: false,
+    model: undefined,
+    maxTokens: DEFAULT_MAX_TOKENS,
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    unknown: [],
+    errors: [],
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--live") parsed.live = true;
+    else if (arg === "--tools") parsed.tools = true;
+    else if (arg === "--json") parsed.json = true;
+    else if (arg === "--help" || arg === "-h") parsed.help = true;
+    else if (arg === "--model" || arg === "--max-tokens" || arg === "--timeout") {
+      const value = args[index + 1];
+      index += 1;
+      if (value === undefined || KNOWN_FLAGS.has(value)) {
+        parsed.errors.push(`${arg} needs a value`);
+        continue;
+      }
+      if (arg === "--model") parsed.model = value;
+      else if (arg === "--max-tokens") {
+        const tokens = Number(value);
+        if (!Number.isFinite(tokens) || tokens <= 0) parsed.errors.push(`--max-tokens needs a positive number, got ${value}`);
+        else parsed.maxTokens = Math.floor(tokens);
+      } else {
+        const seconds = Number(value);
+        if (!Number.isFinite(seconds) || seconds <= 0) parsed.errors.push(`--timeout needs a positive number of seconds, got ${value}`);
+        else parsed.timeoutMs = Math.floor(seconds * 1_000);
+      }
+    } else parsed.unknown.push(arg);
+  }
+  return parsed;
+}
+
+function censusList(rows, limit = 8) {
+  if (!rows.length) return "none";
+  const described = rows.slice(0, limit).map(describeCensusRow);
+  return rows.length > limit ? `${described.join("; ")}; …and ${rows.length - limit} more` : described.join("; ");
+}
+
+// The encoded request is auditable before anything is sent, which turns the
+// free run into a real check of the writer rather than a credential test.
+export function requestShapeChecks({ audit, requiredFields = [] }) {
+  const checks = [];
+  if (!audit) {
+    checks.push({ status: "skip", name: "request encoding", detail: "no request was built" });
+    return checks;
+  }
+  if (audit.truncated) {
+    checks.push({
+      status: "fail",
+      name: "request encoding",
+      detail: "the request this build produced does not re-read as valid protobuf",
+      observed: audit.error || "truncated",
+      fix: "This is a defect in the router's own encoder, not in the account. Paste this line into the issue.",
+    });
+    return checks;
+  }
+  const present = new Set(audit.matched.map((entry) => entry.name));
+  const missing = requiredFields.filter((name) => !present.has(name));
+  checks.push(
+    missing.length
+      ? {
+          status: "fail",
+          name: "request encoding",
+          detail: "the request omits fields the upstream is expected to require",
+          expected: requiredFields.join(", "),
+          observed: `missing ${missing.join(", ")}`,
+        }
+      : {
+          status: "pass",
+          name: "request encoding",
+          detail: `${audit.matched.length} field(s) written, ${audit.size} bytes, all on their declared wire types`,
+        },
+  );
+  if (audit.mismatched.length) {
+    checks.push({
+      status: "fail",
+      name: "request wire types",
+      detail: "a field was written on a wire type its own schema does not declare",
+      observed: censusList(audit.mismatched),
+    });
+  }
+  return checks;
+}
+
+export function modelListChecks({ models = [], census = [], httpStatus } = {}) {
+  const checks = [];
+  const unknown = census.filter((row) => row.status === "unknown");
+  const mismatched = census.filter((row) => row.status === "mismatched");
+
+  if (!models.length) {
+    // The old probe printed "OK: account advertises 0 model(s)" here. Zero is
+    // the exact symptom of a renumbered `modelUid`, an entitlement of nothing,
+    // or a response this build cannot read -- never a success.
+    checks.push({
+      status: "fail",
+      name: "model list",
+      detail: "the account advertised no usable model",
+      expected: "at least one enabled model with a model_uid",
+      observed: census.length
+        ? `response carried ${census.length} field group(s): ${censusList(census)}`
+        : `response decoded to nothing (HTTP ${httpStatus ?? "?"})`,
+      fix: "If the response carried fields this build calls UNKNOWN, the ClientModelConfig field numbers have moved. If it carried nothing, the account or plan entitles no Cascade model.",
+    });
+  } else {
+    checks.push({
+      status: "pass",
+      name: "model list",
+      detail: `${models.length} enabled model(s) decoded, each with a model_uid`,
+    });
+  }
+
+  const unnamed = models.filter((model) => !model.id);
+  if (unnamed.length) {
+    checks.push({
+      status: "fail",
+      name: "model uid field",
+      detail: "an advertised model decoded without a uid, so nothing can be routed to it",
+      observed: `${unnamed.length} of ${models.length} entries`,
+    });
+  }
+
+  if (models.length) {
+    const premium = models.filter((model) => model.premium).length;
+    const beta = models.filter((model) => model.beta).length;
+    checks.push({
+      status: "info",
+      name: "entitlement flags",
+      detail: `${premium} premium, ${beta} beta, ${models.length - premium - beta} standard`,
+    });
+  }
+
+  if (mismatched.length) {
+    checks.push({
+      status: "fail",
+      name: "model list wire types",
+      detail: "a field arrived on a wire type this build does not expect for it",
+      observed: censusList(mismatched),
+    });
+  }
+  if (unknown.length) {
+    checks.push({
+      status: "warn",
+      name: "model list unknown fields",
+      detail: "the upstream sent fields this build does not know; harmless unless something is missing above",
+      observed: censusList(unknown),
+    });
+  }
+  return checks;
+}
+
+export function streamFrameChecks({ frames = [], pending = 0, sawEndOfStream = false, terminator } = {}) {
+  const checks = [];
+  const dataFrames = frames.filter((frame) => !frame.endOfStream);
+
+  checks.push(
+    dataFrames.length
+      ? { status: "pass", name: "stream framing", detail: `${dataFrames.length} message frame(s) read from the response body` }
+      : {
+          status: "fail",
+          name: "stream framing",
+          detail: "the upstream accepted the request but sent no message frame",
+          observed: `${frames.length} frame(s) total, ${pending} byte(s) left unframed`,
+        },
+  );
+
+  const compressed = frames.filter((frame) => frame.compressed);
+  checks.push(
+    compressed.length
+      ? {
+          // The shipped client sends no `connect-accept-encoding`, so this
+          // should never fire. If it does, the transport hands compressed bytes
+          // to the protobuf decoder and every turn silently produces nothing.
+          status: "fail",
+          name: "frame compression",
+          detail: "the upstream compressed frames; this transport cannot decompress and would decode them to empty messages",
+          observed: `${compressed.length} of ${frames.length} frames carry the compressed flag`,
+          fix: "Report this. The transport must send connect-accept-encoding: identity or learn to decompress.",
+        }
+      : { status: "pass", name: "frame compression", detail: "no frame carried the compressed flag" },
+  );
+
+  if (pending > 0) {
+    checks.push({
+      status: "fail",
+      name: "stream completeness",
+      detail: "the response body ended part-way through a frame",
+      observed: `${pending} trailing byte(s) that never formed a frame`,
+    });
+  }
+
+  if (!sawEndOfStream) {
+    checks.push({
+      status: "fail",
+      name: "end-of-stream terminator",
+      detail: "the stream stopped without the terminator Connect requires",
+      fix: "A turn that ends this way is indistinguishable from a truncated answer.",
+    });
+  } else if (terminator?.malformed) {
+    checks.push({
+      status: "fail",
+      name: "end-of-stream terminator",
+      detail: "the terminator was not the JSON object Connect specifies",
+      observed: truncateForReport(terminator.text),
+    });
+  } else if (terminator?.error) {
+    checks.push({
+      status: "fail",
+      name: "end-of-stream terminator",
+      detail: `the upstream ended the stream with an error after sending HTTP 200: ${terminator.error.message || "(no message)"}`,
+      observed: `code=${terminator.error.code || "(none)"} known=${terminator.error.known} retriable=${terminator.error.retriable} mapped-status=${terminator.error.status}`,
+    });
+  } else {
+    checks.push({ status: "pass", name: "end-of-stream terminator", detail: "clean terminator, no error carried" });
+  }
+  return checks;
+}
+
+export function liveTurnChecks({
+  model,
+  text = "",
+  thinking = "",
+  toolCalls = [],
+  stopReason,
+  usage,
+  actualModelUid,
+  requestId,
+  census = [],
+  wantsTools = false,
+} = {}) {
+  const checks = [];
+  const produced = text.length + thinking.length + toolCalls.length;
+
+  checks.push(
+    produced
+      ? {
+          status: "pass",
+          name: "turn produced output",
+          detail: `${text.length} content char(s), ${thinking.length} reasoning char(s), ${toolCalls.length} tool call(s)`,
+        }
+      : {
+          // The old probe printed "OK: streamed 0 character(s)" for this.
+          status: "fail",
+          name: "turn produced output",
+          detail: "frames arrived but decoded to no content, no reasoning and no tool call",
+          expected: "at least one of deltaText, deltaThinking or deltaToolCalls",
+          observed: census.length ? `fields seen: ${censusList(census)}` : "the frames carried no readable field at all",
+          fix: "Any UNKNOWN field above is the likely renumbering. Paste the whole census line.",
+        },
+  );
+
+  if (stopReason === undefined) {
+    checks.push({
+      status: "warn",
+      name: "stop reason",
+      detail: "no stop reason arrived, so the finish_reason the router reports is a guess",
+    });
+  } else {
+    checks.push({
+      status: "info",
+      name: "stop reason",
+      detail: `upstream stop reason ${stopReason}`,
+      observed: String(stopReason),
+    });
+  }
+
+  const promptTokens = Number(usage?.prompt_tokens || 0);
+  const completionTokens = Number(usage?.completion_tokens || 0);
+  checks.push(
+    promptTokens || completionTokens
+      ? {
+          status: "pass",
+          name: "usage accounting",
+          detail: `prompt ${promptTokens}, completion ${completionTokens}`,
+        }
+      : {
+          status: "warn",
+          name: "usage accounting",
+          detail: "no token counts decoded; the router will report a turn with no usage",
+          observed: usage ? truncateForReport(usage) : "no usage message on the stream",
+        },
+  );
+
+  if (actualModelUid && model && actualModelUid !== model) {
+    checks.push({
+      status: "warn",
+      name: "served model",
+      detail: "the upstream served a different model than the one requested",
+      expected: model,
+      observed: actualModelUid,
+    });
+  } else if (actualModelUid) {
+    checks.push({ status: "pass", name: "served model", detail: `upstream confirmed ${actualModelUid}` });
+  } else {
+    checks.push({
+      status: "warn",
+      name: "served model",
+      detail: "the upstream did not name the model that served the turn",
+    });
+  }
+
+  if (requestId) checks.push({ status: "info", name: "upstream request id", detail: requestId });
+  if (!wantsTools) {
+    checks.push({
+      status: "skip",
+      name: "tool calls",
+      detail: "not attempted; re-run with --live --tools, which is the check that decides whether Codex can use this provider",
+    });
+  }
+  return checks;
+}
+
+// The failure this exists for: a tool call that never decodes looks exactly
+// like a model that declined to call one, and the old probe reported both the
+// same way. Three signals separate them, and each gets its own line.
+export function toolCallChecks({
+  wantsTools = false,
+  toolCalls = [],
+  stopReason,
+  functionCallStopReason,
+  census = [],
+  text = "",
+} = {}) {
+  if (!wantsTools) return [];
+  const checks = [];
+  const unknown = census.filter((row) => row.status === "unknown");
+  const claimedFunctionCall =
+    functionCallStopReason !== undefined && stopReason !== undefined && stopReason === functionCallStopReason;
+
+  if (!toolCalls.length) {
+    if (claimedFunctionCall) {
+      checks.push({
+        status: "fail",
+        name: "tool calls decoded",
+        detail:
+          "the upstream reported a function-call stop reason and this build decoded no tool call — calls are being dropped on the wire, not declined by the model",
+        expected: "at least one deltaToolCalls entry",
+        observed: `stopReason=${stopReason}; undecoded fields: ${censusList(unknown)}`,
+        fix: "This is the decisive failure. Paste this line: it means deltaToolCalls has moved off field 6 or ChatToolCall has been renumbered.",
+      });
+    } else if (unknown.length) {
+      checks.push({
+        status: "fail",
+        name: "tool calls decoded",
+        detail:
+          "no tool call decoded, and the stream carried fields this build does not know — the call may have arrived under a field number that was skipped",
+        expected: "at least one deltaToolCalls entry",
+        observed: censusList(unknown),
+        fix: "Paste the observed line. An UNKNOWN length-delimited field on a tool-forced turn is a renumbered deltaToolCalls until proven otherwise.",
+      });
+    } else {
+      checks.push({
+        status: "fail",
+        name: "tool calls decoded",
+        detail:
+          "no tool call decoded, and every field on the stream was one this build knows — the model declined a forced tool choice",
+        expected: "at least one deltaToolCalls entry",
+        observed: text ? `the model answered in prose instead: ${truncateForReport(text, 160)}` : "the turn produced nothing",
+        fix: "Either the tool_choice option name this build sends is not the one Cascade accepts, or this model cannot be forced. Try another --model before concluding the transport is wrong.",
+      });
+    }
+    return checks;
+  }
+
+  checks.push({
+    status: "pass",
+    name: "tool calls decoded",
+    detail: `${toolCalls.length} tool call(s): ${toolCalls.map((call) => call.name || "(unnamed)").join(", ")}`,
+  });
+
+  const unnamed = toolCalls.filter((call) => !call.name);
+  if (unnamed.length) {
+    checks.push({
+      status: "fail",
+      name: "tool call names",
+      detail: "a decoded tool call carried no name, so nothing can be dispatched for it",
+      observed: `${unnamed.length} of ${toolCalls.length}`,
+    });
+  }
+
+  // Without ids the forwarder mints a fresh one per delta, so a restated call
+  // becomes a second call and the client dispatches the same tool twice.
+  const unkeyed = toolCalls.filter((call) => !call.id);
+  checks.push(
+    unkeyed.length
+      ? {
+          status: "fail",
+          name: "tool call ids",
+          detail: "tool calls arrived without ids; every restatement would be dispatched as an additional call",
+          observed: `${unkeyed.length} of ${toolCalls.length} unkeyed`,
+          fix: "Paste this. The forwarder keys restatements by id and has nothing to key on.",
+        }
+      : { status: "pass", name: "tool call ids", detail: "every tool call carried an id the forwarder can key on" },
+  );
+
+  const invalid = toolCalls.filter((call) => {
+    if (typeof call.argumentsJson !== "string" || !call.argumentsJson.trim()) return true;
+    try {
+      JSON.parse(call.argumentsJson);
+      return false;
+    } catch {
+      return true;
+    }
+  });
+  checks.push(
+    invalid.length
+      ? {
+          status: "fail",
+          name: "tool call arguments",
+          detail: "a tool call's arguments are not JSON the client could parse",
+          observed: truncateForReport(invalid[0].argumentsJson ?? "(empty)"),
+        }
+      : { status: "pass", name: "tool call arguments", detail: "every tool call carried parseable JSON arguments" },
+  );
+
+  const seen = new Map();
+  let restated = 0;
+  for (const call of toolCalls) {
+    if (!call.id) continue;
+    if (seen.has(call.id)) restated += 1;
+    seen.set(call.id, call);
+  }
+  if (restated) {
+    checks.push({
+      status: "info",
+      name: "tool call restatement",
+      detail: `the upstream restated ${restated} call(s); keying by id is required and is what this build does`,
+    });
+  }
+  return checks;
+}

--- a/src/probe-report.mjs
+++ b/src/probe-report.mjs
@@ -1,0 +1,131 @@
+// A checklist for probes whose output a stranger has to paste into an issue.
+//
+// A probe that prints one boolean answers "did anything happen". A probe whose
+// findings are worth a maintainer's time answers "which of the things we assumed
+// held, and what came back instead for the ones that did not". This renders the
+// second, in the same `STATUS name: detail` shape `bin/doctor` already uses, and
+// adds two things a remote tester needs: the observed value on every failure,
+// and a single fenced block that is safe and sufficient to paste back.
+
+const STATUS_ORDER = Object.freeze(["fail", "warn", "pass", "info", "skip"]);
+const FAILING = new Set(["fail"]);
+
+export class ProbeReport {
+  constructor({ title = "probe", environment = {} } = {}) {
+    this.title = title;
+    this.environment = environment;
+    this.checks = [];
+  }
+
+  add(check) {
+    const status = String(check?.status || "info").toLowerCase();
+    if (!STATUS_ORDER.includes(status)) throw new Error(`probe-report: unknown status ${status}`);
+    const entry = {
+      status,
+      name: String(check?.name || ""),
+      detail: String(check?.detail || ""),
+    };
+    if (check?.expected !== undefined) entry.expected = String(check.expected);
+    if (check?.observed !== undefined) entry.observed = String(check.observed);
+    if (check?.fix) entry.fix = String(check.fix);
+    this.checks.push(entry);
+    return entry;
+  }
+
+  addAll(checks = []) {
+    for (const check of checks) this.add(check);
+    return this;
+  }
+
+  pass(name, detail, extra) {
+    return this.add({ ...extra, status: "pass", name, detail });
+  }
+
+  fail(name, detail, extra) {
+    return this.add({ ...extra, status: "fail", name, detail });
+  }
+
+  warn(name, detail, extra) {
+    return this.add({ ...extra, status: "warn", name, detail });
+  }
+
+  info(name, detail, extra) {
+    return this.add({ ...extra, status: "info", name, detail });
+  }
+
+  skip(name, detail, extra) {
+    return this.add({ ...extra, status: "skip", name, detail });
+  }
+
+  get failed() {
+    return this.checks.some((check) => FAILING.has(check.status));
+  }
+
+  counts() {
+    const totals = Object.fromEntries(STATUS_ORDER.map((status) => [status, 0]));
+    for (const check of this.checks) totals[check.status] += 1;
+    return totals;
+  }
+
+  // Three outcomes, not two. A run that never reached the thing it was meant to
+  // test is not a pass, and calling it one is how "seems to work" gets reported.
+  verdict() {
+    if (this.failed) return "FAIL";
+    if (!this.checks.some((check) => check.status === "pass")) return "INCONCLUSIVE";
+    if (this.checks.some((check) => check.status === "skip" || check.status === "warn")) return "PARTIAL";
+    return "PASS";
+  }
+
+  render() {
+    const lines = [];
+    for (const check of this.checks) {
+      lines.push(`${check.status.toUpperCase().padEnd(5)} ${check.name}: ${check.detail}`);
+      if (check.expected !== undefined) lines.push(`      expected: ${check.expected}`);
+      if (check.observed !== undefined) lines.push(`      observed: ${check.observed}`);
+      if (check.fix) lines.push(`      fix: ${check.fix}`);
+    }
+    const totals = this.counts();
+    lines.push("");
+    lines.push(
+      `VERDICT ${this.verdict()} — ${totals.pass} pass, ${totals.fail} fail, ${totals.warn} warn, ${totals.skip} skipped`,
+    );
+    return `${lines.join("\n")}\n`;
+  }
+
+  toJson() {
+    return {
+      title: this.title,
+      verdict: this.verdict(),
+      environment: this.environment,
+      counts: this.counts(),
+      checks: this.checks,
+    };
+  }
+
+  // What the tester pastes. Fenced so a GitHub comment keeps the alignment, and
+  // limited to the checklist plus environment facts, never a response body.
+  pasteBlock() {
+    const environment = Object.entries(this.environment)
+      .filter(([, value]) => value !== undefined && value !== "")
+      .map(([key, value]) => `${key}: ${value}`);
+    return [
+      "```text",
+      `${this.title}`,
+      ...environment,
+      "",
+      this.render().trimEnd(),
+      "```",
+      "",
+    ].join("\n");
+  }
+
+  exitCode() {
+    return this.failed ? 1 : 0;
+  }
+}
+
+export function truncateForReport(value, limit = 200) {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (typeof text !== "string") return String(value);
+  return text.length > limit ? `${text.slice(0, limit)}… (${text.length} chars)` : text;
+}

--- a/src/protobuf-audit.mjs
+++ b/src/protobuf-audit.mjs
@@ -1,0 +1,231 @@
+// A read-only auditor for protobuf bytes, used by provider probes.
+//
+// A protobuf decoder is deliberately forgiving: an unknown field number is
+// skipped so that an upstream can add fields without breaking a live turn.
+// That forgiveness is the reason a renumbered field is invisible. If the
+// upstream moves `deltaToolCalls` from field 6 to field 19, a decoder returns
+// a message with no tool calls and no error, and the turn reads exactly like a
+// model that chose not to call a tool.
+//
+// This module exists to make that case loud. It walks the same bytes without a
+// schema, reports every field number and wire type actually present, and then
+// classifies each observation against a schema table as matched, wire-type
+// mismatched, or unknown. A probe can then say "the frame carried field 19,
+// which this build does not know" instead of "0 tool calls".
+//
+// Field *contents* are never retained. Payload bytes on this wire carry prompt
+// text and model output, and a probe's output is meant to be pasted into a
+// public issue, so the audit keeps byte counts and nothing else.
+
+export const WIRE_VARINT = 0;
+export const WIRE_FIXED64 = 1;
+export const WIRE_LENGTH = 2;
+export const WIRE_START_GROUP = 3;
+export const WIRE_END_GROUP = 4;
+export const WIRE_FIXED32 = 5;
+
+export const WIRE_TYPE_NAMES = Object.freeze({
+  0: "varint",
+  1: "fixed64",
+  2: "length-delimited",
+  3: "start-group",
+  4: "end-group",
+  5: "fixed32",
+});
+
+const VARINT_TYPES = new Set(["bool", "enum", "int32", "int64", "uint32", "uint64", "sint32", "sint64"]);
+
+export function wireTypeName(wireType) {
+  return WIRE_TYPE_NAMES[wireType] || `wire-type-${wireType}`;
+}
+
+function toBytes(input) {
+  if (input instanceof Uint8Array) return input;
+  if (ArrayBuffer.isView(input)) return new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+  if (input instanceof ArrayBuffer) return new Uint8Array(input);
+  return Uint8Array.from(input || []);
+}
+
+function readVarint(bytes, start) {
+  let result = 0n;
+  let shift = 0n;
+  let offset = start;
+  for (;;) {
+    if (offset >= bytes.length) throw new Error("truncated varint");
+    const byte = bytes[offset];
+    offset += 1;
+    result |= BigInt(byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) return [result, offset];
+    shift += 7n;
+    if (shift > 63n) throw new Error("varint overflow");
+  }
+}
+
+// Which wire types a declared field type may legally arrive on. Repeated
+// numeric fields may also arrive packed into one length-delimited run, so both
+// forms are accepted for them; anything else is a genuine schema disagreement.
+export function expectedWireTypes(type, repeated = false) {
+  if (VARINT_TYPES.has(type)) return repeated ? [WIRE_VARINT, WIRE_LENGTH] : [WIRE_VARINT];
+  if (type === "double") return repeated ? [WIRE_FIXED64, WIRE_LENGTH] : [WIRE_FIXED64];
+  if (type === "float") return repeated ? [WIRE_FIXED32, WIRE_LENGTH] : [WIRE_FIXED32];
+  if (type === "string" || type === "bytes" || type === "message") return [WIRE_LENGTH];
+  return [];
+}
+
+// Walks the tag/value stream without consulting any schema. On malformed input
+// it returns what it read plus `truncated: true` rather than throwing: a probe
+// that stops at the first bad byte tells the tester less than one that reports
+// "read 4 fields, then the varint at offset 91 ran off the end".
+export function scanFields(input) {
+  const bytes = toBytes(input);
+  const fields = [];
+  let offset = 0;
+  try {
+    while (offset < bytes.length) {
+      const [tag, afterTag] = readVarint(bytes, offset);
+      const no = Number(tag >> 3n);
+      const wireType = Number(tag & 7n);
+      if (no === 0) throw new Error("field number 0 is not a legal tag");
+      let next = afterTag;
+      let byteLength = 0;
+      let value;
+      if (wireType === WIRE_VARINT) {
+        const [raw, after] = readVarint(bytes, next);
+        value = raw;
+        byteLength = after - next;
+        next = after;
+      } else if (wireType === WIRE_FIXED64) {
+        if (next + 8 > bytes.length) throw new Error("truncated fixed64");
+        byteLength = 8;
+        next += 8;
+      } else if (wireType === WIRE_FIXED32) {
+        if (next + 4 > bytes.length) throw new Error("truncated fixed32");
+        byteLength = 4;
+        next += 4;
+      } else if (wireType === WIRE_LENGTH) {
+        const [rawLength, after] = readVarint(bytes, next);
+        const length = Number(rawLength);
+        if (!Number.isSafeInteger(length) || length < 0) throw new Error("unusable length prefix");
+        if (after + length > bytes.length) throw new Error("length prefix runs past the end of the message");
+        value = bytes.subarray(after, after + length);
+        byteLength = length;
+        next = after + length;
+      } else {
+        throw new Error(`wire type ${wireType} is not supported`);
+      }
+      fields.push({ no, wireType, wireTypeName: wireTypeName(wireType), byteLength, value });
+      offset = next;
+    }
+  } catch (error) {
+    return { fields, truncated: true, error: error.message, consumed: offset, size: bytes.length };
+  }
+  return { fields, truncated: false, error: undefined, consumed: offset, size: bytes.length };
+}
+
+function publicObservation(raw) {
+  // `value` is deliberately dropped here: everything downstream of this call
+  // may be printed or pasted into a public issue.
+  return { no: raw.no, wireType: raw.wireType, wireTypeName: raw.wireTypeName, byteLength: raw.byteLength };
+}
+
+// Classifies every field on the wire against a schema table of the shape
+// `{ fieldName: { no, type, repeated, message } }`. Nested message fields are
+// audited recursively when the schema names a nested table, which is how a
+// probe confirms the field numbers inside `deltaToolCalls` and not merely that
+// something arrived on field 6.
+export function auditMessage(input, schema, { depth = 4 } = {}) {
+  const scan = scanFields(input);
+  const byNumber = new Map();
+  for (const [name, field] of Object.entries(schema || {})) byNumber.set(field.no, { name, field });
+
+  const observations = [];
+  for (const raw of scan.fields) {
+    const known = byNumber.get(raw.no);
+    if (!known) {
+      observations.push({ ...publicObservation(raw), status: "unknown", name: undefined, declaredType: undefined });
+      continue;
+    }
+    const allowed = expectedWireTypes(known.field.type, known.field.repeated);
+    const status = allowed.includes(raw.wireType) ? "matched" : "mismatched";
+    const observation = {
+      ...publicObservation(raw),
+      status,
+      name: known.name,
+      declaredType: known.field.type,
+      expectedWireTypeNames: allowed.map(wireTypeName),
+    };
+    if (
+      status === "matched" &&
+      known.field.type === "message" &&
+      known.field.message &&
+      depth > 0 &&
+      raw.value
+    ) {
+      observation.child = auditMessage(raw.value, known.field.message, { depth: depth - 1 });
+    }
+    observations.push(observation);
+  }
+
+  return {
+    observations,
+    truncated: scan.truncated,
+    error: scan.error,
+    size: scan.size,
+    matched: observations.filter((entry) => entry.status === "matched"),
+    mismatched: observations.filter((entry) => entry.status === "mismatched"),
+    unknown: observations.filter((entry) => entry.status === "unknown"),
+  };
+}
+
+// Folds any number of audits -- typically every frame of one stream -- into one
+// row per field number, so a probe reports "field 19: unknown, length-delimited,
+// seen 12x" once rather than per frame.
+export function fieldCensus(audits, { path = [] } = {}) {
+  const rows = new Map();
+  const record = (observation, prefix) => {
+    const key = `${prefix.join(".")}#${observation.no}`;
+    const existing = rows.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.totalBytes += observation.byteLength;
+      if (!existing.wireTypeNames.includes(observation.wireTypeName)) {
+        existing.wireTypeNames.push(observation.wireTypeName);
+      }
+      return;
+    }
+    rows.set(key, {
+      key,
+      path: prefix,
+      no: observation.no,
+      name: observation.name,
+      status: observation.status,
+      declaredType: observation.declaredType,
+      wireTypeNames: [observation.wireTypeName],
+      count: 1,
+      totalBytes: observation.byteLength,
+    });
+  };
+  const walk = (audit, prefix) => {
+    for (const observation of audit?.observations || []) {
+      record(observation, prefix);
+      if (observation.child) walk(observation.child, [...prefix, observation.name]);
+    }
+  };
+  for (const audit of Array.isArray(audits) ? audits : [audits]) walk(audit, path);
+  return [...rows.values()].sort((left, right) => left.key.localeCompare(right.key, "en"));
+}
+
+export function describeCensusRow(row) {
+  const where = row.path.length ? `${row.path.join(".")}.` : "";
+  const label = row.status === "unknown" ? "UNKNOWN" : row.name;
+  const types = row.wireTypeNames.join("/");
+  return `${where}field ${row.no} (${types}, ${row.totalBytes}B over ${row.count}) -> ${label}`;
+}
+
+export function unknownFieldRows(census) {
+  return census.filter((row) => row.status === "unknown");
+}
+
+export function mismatchedFieldRows(census) {
+  return census.filter((row) => row.status === "mismatched");
+}

--- a/test/connect-stream-audit.test.mjs
+++ b/test/connect-stream-audit.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CONNECT_CODE_STATUS,
+  COMPRESSED_FLAG,
+  END_STREAM_FLAG,
+  connectStatusFor,
+  createEnvelopeScanner,
+  encodeEnvelope,
+  isKnownConnectCode,
+  isRetriableConnectCode,
+  parseEndStreamPayload,
+  scanEnvelopes,
+} from "../src/connect-stream-audit.mjs";
+
+const utf8 = (text) => new TextEncoder().encode(text);
+const concat = (...parts) => {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+};
+
+test("a frame header is five bytes: one flag byte and a big-endian length", () => {
+  const framed = encodeEnvelope(utf8("abc"));
+  assert.deepEqual([...framed], [0, 0, 0, 0, 3, 97, 98, 99]);
+});
+
+test("a payload longer than 255 bytes gets a big-endian length, not a little-endian one", () => {
+  const framed = encodeEnvelope(new Uint8Array(300));
+  assert.deepEqual([...framed.subarray(0, 5)], [0, 0, 0, 1, 44]);
+});
+
+test("frames are read back in order with their flags", () => {
+  const stream = concat(encodeEnvelope(utf8("one")), encodeEnvelope(utf8("{}"), { flags: END_STREAM_FLAG }));
+  const { frames, pending, sawEndOfStream } = scanEnvelopes(stream);
+
+  assert.equal(pending, 0);
+  assert.equal(sawEndOfStream, true);
+  assert.deepEqual(
+    frames.map((frame) => ({ index: frame.index, endOfStream: frame.endOfStream, length: frame.length })),
+    [
+      { index: 0, endOfStream: false, length: 3 },
+      { index: 1, endOfStream: true, length: 2 },
+    ],
+  );
+});
+
+test("a frame split across chunk boundaries is invisible to the caller", () => {
+  const stream = concat(encodeEnvelope(utf8("hello")), encodeEnvelope(utf8("world")));
+  for (const size of [1, 2, 3, 4, 5, 6, 7, 9, 13]) {
+    const scanner = createEnvelopeScanner();
+    const payloads = [];
+    for (let offset = 0; offset < stream.length; offset += size) {
+      for (const frame of scanner.push(stream.subarray(offset, offset + size))) {
+        payloads.push(new TextDecoder().decode(frame.payload));
+      }
+    }
+    assert.deepEqual(payloads, ["hello", "world"], `chunk size ${size}`);
+    assert.equal(scanner.pending, 0, `chunk size ${size}`);
+  }
+});
+
+test("a header split across two chunks does not produce a short frame", () => {
+  const stream = encodeEnvelope(utf8("abcd"));
+  const scanner = createEnvelopeScanner();
+  assert.deepEqual(scanner.push(stream.subarray(0, 3)), []);
+  assert.equal(scanner.pending, 3);
+  const frames = scanner.push(stream.subarray(3));
+  assert.equal(frames.length, 1);
+  assert.equal(new TextDecoder().decode(frames[0].payload), "abcd");
+});
+
+test("a zero-length frame is a frame, not the end of the stream", () => {
+  const { frames, sawEndOfStream } = scanEnvelopes(encodeEnvelope(new Uint8Array(0)));
+  assert.equal(frames.length, 1);
+  assert.equal(frames[0].length, 0);
+  assert.equal(sawEndOfStream, false);
+});
+
+test("bytes that never completed a frame are reported rather than dropped", () => {
+  // The symptom of a connection dying mid-frame. A transport yields everything
+  // before it and stops, which reads as a short answer.
+  const stream = concat(encodeEnvelope(utf8("done")), encodeEnvelope(utf8("cut off")).subarray(0, 7));
+  const { frames, pending, sawEndOfStream } = scanEnvelopes(stream);
+  assert.equal(frames.length, 1);
+  assert.equal(pending, 7);
+  assert.equal(sawEndOfStream, false);
+});
+
+test("the compressed flag is surfaced, because a decoder handed gzip returns an empty message", () => {
+  const { frames } = scanEnvelopes(encodeEnvelope(utf8("gz"), { flags: COMPRESSED_FLAG }));
+  assert.equal(frames[0].compressed, true);
+  assert.equal(frames[0].endOfStream, false);
+});
+
+test("a frame can be both compressed and the terminator", () => {
+  const { frames } = scanEnvelopes(encodeEnvelope(utf8("{}"), { flags: COMPRESSED_FLAG | END_STREAM_FLAG }));
+  assert.equal(frames[0].compressed, true);
+  assert.equal(frames[0].endOfStream, true);
+});
+
+test("a clean terminator carries no error", () => {
+  const parsed = parseEndStreamPayload(utf8("{}"));
+  assert.equal(parsed.malformed, false);
+  assert.equal(parsed.error, undefined);
+});
+
+test("an empty terminator body is treated as clean, not as malformed", () => {
+  const parsed = parseEndStreamPayload(new Uint8Array(0));
+  assert.equal(parsed.malformed, false);
+  assert.equal(parsed.error, undefined);
+});
+
+test("an error inside the terminator is read even though HTTP already said 200", () => {
+  const parsed = parseEndStreamPayload(
+    utf8(JSON.stringify({ error: { code: "invalid_argument", message: "chat_model_uid is required" } })),
+  );
+  assert.equal(parsed.malformed, false);
+  assert.deepEqual(parsed.error, {
+    code: "invalid_argument",
+    message: "chat_model_uid is required",
+    status: 400,
+    retriable: false,
+    known: true,
+  });
+});
+
+test("a terminator that is not JSON is malformed, which is not the same as success", () => {
+  const parsed = parseEndStreamPayload(utf8("<html>502 Bad Gateway</html>"));
+  assert.equal(parsed.malformed, true);
+  assert.equal(parsed.error, undefined);
+  assert.match(parsed.text, /502 Bad Gateway/);
+});
+
+test("a terminator error with an unrecognised code is reported as unknown rather than silently mapped", () => {
+  const parsed = parseEndStreamPayload(utf8(JSON.stringify({ error: { code: "teapot" } })));
+  assert.equal(parsed.error.known, false);
+  assert.equal(parsed.error.status, 502);
+});
+
+test("every Connect error code maps to a status, including the ones a partial table misses", () => {
+  // A code that falls through to 502 is read upstream as a transient fault and
+  // retried. `unimplemented` -- the answer to a wrong service path or method
+  // name -- must never be retried, and neither must `invalid_argument`.
+  assert.equal(Object.keys(CONNECT_CODE_STATUS).length, 16);
+  assert.equal(connectStatusFor("unimplemented"), 501);
+  assert.equal(connectStatusFor("invalid_argument"), 400);
+  assert.equal(connectStatusFor("unauthenticated"), 401);
+  assert.equal(connectStatusFor("permission_denied"), 403);
+  assert.equal(connectStatusFor("resource_exhausted"), 429);
+  assert.equal(connectStatusFor("unavailable"), 503);
+  assert.equal(connectStatusFor("deadline_exceeded"), 504);
+  assert.equal(connectStatusFor("already_exists"), 409);
+  assert.equal(connectStatusFor("aborted"), 409);
+  assert.equal(connectStatusFor("out_of_range"), 400);
+  assert.equal(connectStatusFor("data_loss"), 500);
+  assert.equal(connectStatusFor("canceled"), 499);
+});
+
+test("an unrecognised or absent code falls back to the caller's status", () => {
+  assert.equal(connectStatusFor(undefined, 418), 418);
+  assert.equal(connectStatusFor("not_a_code", 418), 418);
+  assert.equal(connectStatusFor("INVALID_ARGUMENT"), 400);
+  assert.equal(isKnownConnectCode("not_a_code"), false);
+  assert.equal(isKnownConnectCode("internal"), true);
+});
+
+test("only codes another attempt could change are retriable", () => {
+  for (const code of ["unavailable", "resource_exhausted", "deadline_exceeded", "aborted"]) {
+    assert.equal(isRetriableConnectCode(code), true, code);
+  }
+  for (const code of ["invalid_argument", "unimplemented", "unauthenticated", "permission_denied", "not_found"]) {
+    assert.equal(isRetriableConnectCode(code), false, code);
+  }
+});

--- a/test/devin-cli-probe.test.mjs
+++ b/test/devin-cli-probe.test.mjs
@@ -1,0 +1,537 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import {
+  COMPRESSED_FLAG,
+  END_STREAM_FLAG,
+  createEnvelopeScanner,
+  encodeEnvelope,
+  parseEndStreamPayload,
+} from "../src/connect-stream-audit.mjs";
+import { DEFAULT_MAX_TOKENS } from "../src/devin-probe-checks.mjs";
+import { runProbe } from "../src/devin-cli-probe.mjs";
+
+// The provider's own modules land with the Devin CLI branch. The probe takes
+// them by injection so its wiring -- which stage runs, which check fires on
+// which observation, whether anything is spent -- is exercised here against a
+// fabricated upstream, on a machine with neither an account nor those sources.
+
+const utf8 = (text) => new TextEncoder().encode(text);
+
+function varint(value) {
+  const out = [];
+  let remaining = BigInt(value);
+  do {
+    let byte = Number(remaining & 0x7fn);
+    remaining >>= 7n;
+    if (remaining > 0n) byte |= 0x80;
+    out.push(byte);
+  } while (remaining > 0n);
+  return out;
+}
+
+function concatBytes(parts) {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+// A deliberately tiny writer and reader, so the fixtures below are byte-exact
+// and owe nothing to the encoder the provider ships.
+function encodeMessage(schema, value) {
+  const parts = [];
+  for (const [name, field] of Object.entries(schema || {})) {
+    const held = value?.[name];
+    if (held === undefined || held === null) continue;
+    for (const item of field.repeated ? held : [held]) {
+      if (item === undefined || item === null) continue;
+      if (field.type === "message") {
+        const nested = encodeMessage(field.message, item);
+        parts.push(Uint8Array.from([...varint(field.no * 8 + 2), ...varint(nested.length)]), nested);
+      } else if (field.type === "string") {
+        const text = utf8(String(item));
+        parts.push(Uint8Array.from([...varint(field.no * 8 + 2), ...varint(text.length)]), text);
+      } else {
+        parts.push(Uint8Array.from([...varint(field.no * 8), ...varint(field.type === "bool" ? (item ? 1 : 0) : item)]));
+      }
+    }
+  }
+  return concatBytes(parts);
+}
+
+function decodeMessage(schema, buffer) {
+  const byNumber = new Map(Object.entries(schema || {}).map(([name, field]) => [field.no, { name, field }]));
+  const bytes = Uint8Array.from(buffer || []);
+  const out = {};
+  let offset = 0;
+  const readVarint = () => {
+    let result = 0n;
+    let shift = 0n;
+    for (;;) {
+      const byte = bytes[offset];
+      offset += 1;
+      result |= BigInt(byte & 0x7f) << shift;
+      if ((byte & 0x80) === 0) return result;
+      shift += 7n;
+    }
+  };
+  while (offset < bytes.length) {
+    const tag = Number(readVarint());
+    const no = tag >>> 3;
+    const wireType = tag & 7;
+    let raw;
+    if (wireType === 2) {
+      const length = Number(readVarint());
+      raw = bytes.subarray(offset, offset + length);
+      offset += length;
+    } else {
+      raw = readVarint();
+    }
+    const known = byNumber.get(no);
+    if (!known) continue;
+    const { name, field } = known;
+    let value;
+    if (field.type === "message") value = decodeMessage(field.message, raw);
+    else if (field.type === "string") value = new TextDecoder().decode(raw);
+    else if (field.type === "bool") value = raw !== 0n;
+    else value = Number(raw);
+    if (field.repeated) (out[name] || (out[name] = [])).push(value);
+    else out[name] = value;
+  }
+  return out;
+}
+
+const TOOL_CALL = { id: { no: 1, type: "string" }, name: { no: 2, type: "string" }, argumentsJson: { no: 3, type: "string" } };
+const USAGE = { inputTokens: { no: 2, type: "uint64" }, outputTokens: { no: 3, type: "uint64" } };
+const RESPONSE = {
+  messageId: { no: 1, type: "string" },
+  deltaText: { no: 3, type: "string" },
+  stopReason: { no: 5, type: "enum" },
+  deltaToolCalls: { no: 6, type: "message", message: TOOL_CALL, repeated: true },
+  usage: { no: 7, type: "message", message: USAGE },
+  requestId: { no: 17, type: "string" },
+  actualModelUid: { no: 23, type: "string" },
+};
+const MODEL_CONFIG = {
+  label: { no: 1, type: "string" },
+  disabled: { no: 4, type: "bool" },
+  isPremium: { no: 7, type: "bool" },
+  modelUid: { no: 22, type: "string" },
+};
+const MODELS_RESPONSE = { clientModelConfigs: { no: 1, type: "message", message: MODEL_CONFIG, repeated: true } };
+const REQUEST = {
+  metadata: { no: 1, type: "message", message: { apiKey: { no: 3, type: "string" } } },
+  prompt: { no: 2, type: "string" },
+  chatMessagePrompts: { no: 3, type: "message", message: { prompt: { no: 3, type: "string" } }, repeated: true },
+  requestType: { no: 7, type: "enum" },
+  configuration: { no: 8, type: "message", message: { maxTokens: { no: 2, type: "uint64" } } },
+  chatModelUid: { no: 21, type: "string" },
+};
+
+const proto = {
+  SERVICE_PATH: "exa.api_server_pb.ApiServerService",
+  GET_CHAT_MESSAGE: "GetChatMessage",
+  GET_CASCADE_MODEL_CONFIGS: "GetCascadeModelConfigs",
+  STOP_REASON: { FUNCTION_CALL: 10, STOP_PATTERN: 2 },
+  GET_CHAT_MESSAGE_REQUEST: REQUEST,
+  GET_CHAT_MESSAGE_RESPONSE: RESPONSE,
+  GET_CASCADE_MODEL_CONFIGS_REQUEST: { metadata: { no: 1, type: "message", message: { apiKey: { no: 3, type: "string" } } } },
+  GET_CASCADE_MODEL_CONFIGS_RESPONSE: MODELS_RESPONSE,
+};
+
+function fakeProvider({ configured = true, maxTokensSeen } = {}) {
+  return {
+    status: { devinCliStatus: () => ({ configured, authPath: "/fake/credentials.toml", setup: "Run `devin auth login`" }) },
+    session: { readDevinSession: () => ({ apiKey: "TOKEN", apiServerUrl: "https://cascade.invalid" }) },
+    proto,
+    wire: { encodeMessage, decodeMessage },
+    turn: {
+      buildChatMessageRequest: (chat, { token, modelUid }) => {
+        if (maxTokensSeen) maxTokensSeen.push(chat.max_tokens);
+        return {
+          metadata: { apiKey: token },
+          prompt: "system",
+          chatMessagePrompts: (chat.messages || []).filter((m) => m.role !== "system").map((m) => ({ prompt: String(m.content) })),
+          requestType: 5,
+          configuration: { maxTokens: chat.max_tokens || 128_000 },
+          chatModelUid: modelUid,
+        };
+      },
+      usageFrom: (stats) => ({ prompt_tokens: stats.inputTokens || 0, completion_tokens: stats.outputTokens || 0 }),
+    },
+    connect: {
+      connectAuthorization: (token) => `Basic ${token}-${token}`,
+      // Mirrors the shipped client, including the part that matters most: a
+      // Connect stream reports failure inside the terminator with HTTP 200
+      // already sent, so the terminator has to be raised, not ignored.
+      async *connectServerStream({ responseSchema, fetchImpl }) {
+        const response = await fetchImpl();
+        const scanner = createEnvelopeScanner();
+        for await (const chunk of response.body) {
+          for (const frame of scanner.push(chunk)) {
+            if (frame.endOfStream) {
+              const parsed = parseEndStreamPayload(frame.payload);
+              if (parsed.error) throw new Error(parsed.error.message || parsed.error.code);
+              return;
+            }
+            yield decodeMessage(responseSchema, frame.payload);
+          }
+        }
+      },
+    },
+  };
+}
+
+function okResponse(bytes, { contentType = "application/proto" } = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: (key) => (key === "content-type" ? contentType : undefined) },
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  };
+}
+
+function streamResponse(chunks) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => "application/connect+proto" },
+    body: (async function* body() {
+      for (const chunk of chunks) yield chunk;
+    })(),
+  };
+}
+
+function errorResponse(status, payload) {
+  return {
+    ok: false,
+    status,
+    headers: { get: () => "application/json" },
+    text: async () => JSON.stringify(payload),
+  };
+}
+
+const modelsBody = (configs) => encodeMessage(MODELS_RESPONSE, { clientModelConfigs: configs });
+
+function runner({ models = [{ modelUid: "swe-1", label: "SWE 1", isPremium: true }], live } = {}) {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    if (String(url).endsWith("/GetCascadeModelConfigs")) return okResponse(modelsBody(models));
+    return live();
+  };
+  return { calls, fetchImpl };
+}
+
+async function probe(argv, provider, fetchImpl) {
+  const written = [];
+  const { code, report } = await runProbe(argv, {
+    provider,
+    fetchImpl,
+    stdout: { write: (text) => written.push(text) },
+    cliVersion: () => "3000.4.25",
+  });
+  return { code, report, output: written.join(""), checks: report?.checks || [] };
+}
+
+const statusOf = (checks, name) => checks.filter((check) => check.name === name).map((check) => check.status);
+const checkOf = (checks, name) => checks.find((check) => check.name === name);
+
+test("the free run reads the session, audits its own request and lists models without spending anything", async () => {
+  const { calls, fetchImpl } = runner({ live: () => assert.fail("the free run must not start a turn") });
+  const { code, checks, output } = await probe([], fakeProvider(), fetchImpl);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://cascade.invalid/exa.api_server_pb.ApiServerService/GetCascadeModelConfigs");
+  assert.equal(calls[0].init.headers.authorization, "Basic TOKEN-TOKEN");
+  assert.deepEqual(statusOf(checks, "request encoding"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "model list"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "live turn"), ["skip"]);
+  assert.equal(code, 0);
+  assert.match(output, /VERDICT PARTIAL/);
+  assert.match(output, /Paste everything between the fences/);
+});
+
+test("the session and the token never reach the output a tester pastes in public", async () => {
+  const { fetchImpl } = runner({ live: () => assert.fail("no live turn") });
+  const { output } = await probe([], fakeProvider(), fetchImpl);
+  assert.equal(output.includes("TOKEN"), false);
+  assert.match(output, /cascade host: cascade\.invalid/);
+});
+
+test("a model list that decodes to nothing fails and names the fields that did arrive", async () => {
+  // A ClientModelConfig whose uid moved off field 22 produces exactly this: a
+  // well-formed response, no usable model, and -- before this change -- an OK.
+  const renumbered = encodeMessage(
+    { clientModelConfigs: { no: 1, type: "message", message: { movedUid: { no: 31, type: "string" } }, repeated: true } },
+    { clientModelConfigs: [{ movedUid: "swe-1" }] },
+  );
+  const fetchImpl = async () => okResponse(renumbered);
+  const { code, checks } = await probe([], fakeProvider(), fetchImpl);
+
+  assert.deepEqual(statusOf(checks, "model list"), ["fail"]);
+  assert.match(checkOf(checks, "model list").observed, /clientModelConfigs\.field 31 .* -> UNKNOWN/);
+  assert.equal(code, 1);
+});
+
+test("an unauthenticated model list names the connect code and points at devin auth login", async () => {
+  const fetchImpl = async () => errorResponse(401, { code: "unauthenticated", message: "invalid api key" });
+  const { code, checks } = await probe([], fakeProvider(), fetchImpl);
+  const check = checkOf(checks, "model list");
+  assert.equal(check.status, "fail");
+  assert.match(check.observed, /http=401 connect-code=unauthenticated known=true retriable=false/);
+  assert.match(check.fix, /devin auth login/);
+  assert.equal(code, 1);
+});
+
+test("a wrong service path shows up as unimplemented, which the fix line says is not the account's fault", async () => {
+  const fetchImpl = async () => errorResponse(404, { code: "unimplemented", message: "unknown method" });
+  const { checks } = await probe([], fakeProvider(), fetchImpl);
+  assert.match(checkOf(checks, "model list").fix, /service path or method name is wrong/);
+});
+
+test("a missing session stops before any request is made", async () => {
+  let called = false;
+  const { checks, code } = await probe([], fakeProvider({ configured: false }), async () => {
+    called = true;
+    return okResponse(new Uint8Array(0));
+  });
+  assert.equal(called, false);
+  assert.deepEqual(statusOf(checks, "devin cli session"), ["fail"]);
+  assert.equal(code, 1);
+});
+
+test("a healthy live tool turn passes every wire assumption and caps its own spend", async () => {
+  const maxTokensSeen = [];
+  const frames = [
+    encodeEnvelope(encodeMessage(RESPONSE, { messageId: "m1", deltaText: "one moment" })),
+    encodeEnvelope(
+      encodeMessage(RESPONSE, {
+        deltaToolCalls: [{ id: "call_1", name: "ping", argumentsJson: '{"value":1}' }],
+        stopReason: 10,
+        usage: { inputTokens: 42, outputTokens: 7 },
+        requestId: "req-1",
+        actualModelUid: "swe-1",
+      }),
+    ),
+    encodeEnvelope(utf8("{}"), { flags: END_STREAM_FLAG }),
+  ];
+  const { fetchImpl } = runner({ live: () => streamResponse(frames) });
+  const { code, checks } = await probe(["--live", "--tools"], fakeProvider({ maxTokensSeen }), fetchImpl);
+
+  assert.deepEqual(statusOf(checks, "stream framing"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "frame compression"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "end-of-stream terminator"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "turn produced output"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "usage accounting"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "served model"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "tool calls decoded"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "tool call ids"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "tool call arguments"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "transport replay"), ["pass"]);
+  assert.equal(code, 0);
+  // Every turn the probe builds is capped; the default is 64, not the
+  // provider's 128k fallback.
+  assert.deepEqual(maxTokensSeen, [64, 64]);
+});
+
+test("a tool call that moved off its field number is reported as a dropped call, not a shy model", async () => {
+  // The quiet failure a prior review flagged. The upstream says it made a
+  // function call; the decoder sees field 19 and skips it.
+  const moved = { deltaToolCalls: { no: 19, type: "message", message: TOOL_CALL, repeated: true }, stopReason: { no: 5, type: "enum" } };
+  const frames = [
+    encodeEnvelope(encodeMessage(moved, { deltaToolCalls: [{ id: "call_1", name: "ping", argumentsJson: "{}" }], stopReason: 10 })),
+    encodeEnvelope(utf8("{}"), { flags: END_STREAM_FLAG }),
+  ];
+  const { fetchImpl } = runner({ live: () => streamResponse(frames) });
+  const { code, checks } = await probe(["--live", "--tools"], fakeProvider(), fetchImpl);
+
+  const check = checkOf(checks, "tool calls decoded");
+  assert.equal(check.status, "fail");
+  assert.match(check.detail, /dropped on the wire, not declined by the model/);
+  assert.match(check.observed, /field 19 .* -> UNKNOWN/);
+  assert.equal(code, 1);
+});
+
+test("a stream that ends with a Connect error after HTTP 200 fails with that error's code", async () => {
+  const frames = [
+    encodeEnvelope(
+      utf8(JSON.stringify({ error: { code: "invalid_argument", message: "chat_model_uid is required" } })),
+      { flags: END_STREAM_FLAG },
+    ),
+  ];
+  const { fetchImpl } = runner({ live: () => streamResponse(frames) });
+  const { code, checks } = await probe(["--live"], fakeProvider(), fetchImpl);
+
+  const check = checkOf(checks, "end-of-stream terminator");
+  assert.equal(check.status, "fail");
+  assert.match(check.detail, /chat_model_uid is required/);
+  assert.match(check.observed, /code=invalid_argument/);
+  assert.deepEqual(statusOf(checks, "stream framing"), ["fail"]);
+  // The transport is supposed to raise that terminator. Replaying the bytes and
+  // calling the raise a transport fault would send a tester after a defect that
+  // does not exist.
+  assert.deepEqual(statusOf(checks, "transport replay"), ["pass"]);
+  assert.equal(code, 1);
+});
+
+test("a transport that swallows a terminator error is reported as the transport's fault", async () => {
+  const frames = [encodeEnvelope(utf8(JSON.stringify({ error: { code: "internal" } })), { flags: END_STREAM_FLAG })];
+  const { fetchImpl } = runner({ live: () => streamResponse(frames) });
+  const provider = fakeProvider();
+  provider.connect.connectServerStream = async function* swallow() {};
+  const { checks } = await probe(["--live"], provider, fetchImpl);
+  const check = checkOf(checks, "transport replay");
+  assert.equal(check.status, "fail");
+  assert.match(check.detail, /did not raise/);
+});
+
+test("compressed frames fail instead of decoding to an empty answer", async () => {
+  const frames = [
+    encodeEnvelope(utf8("not really gzip"), { flags: COMPRESSED_FLAG }),
+    encodeEnvelope(utf8("{}"), { flags: END_STREAM_FLAG }),
+  ];
+  const { fetchImpl } = runner({ live: () => streamResponse(frames) });
+  const { checks } = await probe(["--live"], fakeProvider(), fetchImpl);
+
+  assert.deepEqual(statusOf(checks, "frame compression"), ["fail"]);
+  assert.deepEqual(statusOf(checks, "turn produced output"), ["fail"]);
+});
+
+test("a stream cut mid-frame is a failure, not a short answer", async () => {
+  const complete = encodeEnvelope(encodeMessage(RESPONSE, { deltaText: "hello" }));
+  const partial = encodeEnvelope(encodeMessage(RESPONSE, { deltaText: "world" })).subarray(0, 4);
+  const { fetchImpl } = runner({ live: () => streamResponse([complete, partial]) });
+  const { checks, code } = await probe(["--live"], fakeProvider(), fetchImpl);
+
+  assert.deepEqual(statusOf(checks, "stream completeness"), ["fail"]);
+  assert.deepEqual(statusOf(checks, "end-of-stream terminator"), ["fail"]);
+  assert.equal(code, 1);
+});
+
+test("frames split across arbitrary chunk boundaries read the same as whole ones", async () => {
+  const whole = concatBytes([
+    encodeEnvelope(encodeMessage(RESPONSE, { deltaText: "ready" })),
+    encodeEnvelope(utf8("{}"), { flags: END_STREAM_FLAG }),
+  ]);
+  const chunks = [];
+  for (let offset = 0; offset < whole.length; offset += 3) chunks.push(whole.subarray(offset, offset + 3));
+  const { fetchImpl } = runner({ live: () => streamResponse(chunks) });
+  const { checks, code } = await probe(["--live"], fakeProvider(), fetchImpl);
+
+  assert.deepEqual(statusOf(checks, "stream framing"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "turn produced output"), ["pass"]);
+  assert.deepEqual(statusOf(checks, "transport replay"), ["pass"]);
+  assert.equal(code, 0);
+});
+
+test("a live turn refused with invalid_argument says the request shape is wrong", async () => {
+  const { fetchImpl } = runner({ live: () => errorResponse(400, { code: "invalid_argument", message: "unknown field 21" }) });
+  const { checks, code } = await probe(["--live"], fakeProvider(), fetchImpl);
+  const check = checkOf(checks, "live turn");
+  assert.equal(check.status, "fail");
+  assert.match(check.fix, /request shape being wrong/);
+  assert.match(check.observed, /connect-code=invalid_argument/);
+  assert.equal(code, 1);
+});
+
+test("a team setting that refuses Cascade is called out as a plan question", async () => {
+  const { fetchImpl } = runner({ live: () => errorResponse(403, { code: "permission_denied", message: "cascade disabled" }) });
+  const { checks } = await probe(["--live"], fakeProvider(), fetchImpl);
+  assert.match(checkOf(checks, "live turn").fix, /disable_cascade|allowed_model_uids/);
+});
+
+test("a model uid not on the account's list is flagged before the turn is judged", async () => {
+  const frames = [encodeEnvelope(encodeMessage(RESPONSE, { deltaText: "hi" })), encodeEnvelope(utf8("{}"), { flags: END_STREAM_FLAG })];
+  const { fetchImpl } = runner({ live: () => streamResponse(frames) });
+  const { checks } = await probe(["--live", "--model", "not-listed"], fakeProvider(), fetchImpl);
+  assert.equal(statusOf(checks, "live turn")[0], "warn");
+});
+
+test("a mistyped flag fails the run instead of quietly downgrading it", async () => {
+  const { code, checks } = await probe(["--live", "--tool"], fakeProvider(), async () => assert.fail("nothing should be sent"));
+  assert.deepEqual(statusOf(checks, "arguments"), ["fail"]);
+  assert.equal(code, 1);
+});
+
+test("--help prints the cost of --live and exits clean without touching the network", async () => {
+  const { code, output } = await probe(["--help"], fakeProvider(), async () => assert.fail("nothing should be sent"));
+  assert.equal(code, 0);
+  assert.match(output, /spends ACU credit on your account/);
+});
+
+test("--json prints the same verdict as the text form", async () => {
+  const { fetchImpl } = runner({ live: () => assert.fail("no live turn") });
+  const { output, code } = await probe(["--json"], fakeProvider(), fetchImpl);
+  const parsed = JSON.parse(output);
+  assert.equal(parsed.verdict, "PARTIAL");
+  assert.equal(parsed.environment["devin cli"], "3000.4.25");
+  assert.ok(parsed.checks.some((check) => check.name === "model list" && check.status === "pass"));
+  assert.equal(code, 0);
+});
+
+test("a missing provider module is named, with the branch that carries it", async () => {
+  const absent = { missing: "./devin-proto.mjs", reason: "Cannot find module './devin-proto.mjs'" };
+  const { code, checks, output } = await probe([], absent, async () => assert.fail("nothing should be sent"));
+  const check = checkOf(checks, "devin provider sources");
+  assert.equal(check.status, "fail");
+  assert.match(check.detail, /devin-proto\.mjs is not present/);
+  assert.match(check.fix, /feat\/devin-cli-provider/);
+  assert.match(output, /VERDICT FAIL/);
+  assert.equal(code, 1);
+});
+
+test("with nothing injected the probe resolves the real modules, on either branch", async () => {
+  // The provider's sources are absent on main and present on the Devin CLI
+  // branch. Both are legitimate; what must never happen is an unhandled module
+  // resolution error, so this asserts the probe reached one outcome or the other.
+  const { checks } = await probe([], undefined, async () => {
+    throw new Error("the network is not reachable from a test");
+  });
+  const missing = checkOf(checks, "devin provider sources");
+  if (missing) assert.match(missing.fix, /feat\/devin-cli-provider/);
+  else assert.ok(checks.some((check) => check.name === "devin cli session"), "the probe should have gone on to read the session");
+});
+
+// The tester instructions live in the repository rather than in a GitHub
+// comment so they can be reviewed and cannot drift out of sync with the probe.
+// These tie the two together.
+
+test("the tester guide names the probe, the paid flag, and the cap the probe actually applies", () => {
+  const guide = readFileSync(new URL("../docs/DEVIN-CLI-PROBE.md", import.meta.url), "utf8");
+  assert.match(guide, /\.\/bin\/devin-probe --live --tools/);
+  assert.match(guide, /`--live` is the only flag that spends anything/);
+  assert.match(guide, new RegExp(`default ${DEFAULT_MAX_TOKENS}`));
+  assert.match(guide, /issues\/270/);
+});
+
+test("every failure the checks can emit is explained in the guide", () => {
+  const guide = readFileSync(new URL("../docs/DEVIN-CLI-PROBE.md", import.meta.url), "utf8");
+  for (const name of [
+    "devin cli session",
+    "request encoding",
+    "model list",
+    "live turn",
+    "stream framing",
+    "frame compression",
+    "stream completeness",
+    "end-of-stream terminator",
+    "turn produced output",
+    "tool calls decoded",
+    "tool call ids",
+    "transport replay",
+  ]) {
+    assert.ok(guide.includes(`FAIL ${name}`), `docs/DEVIN-CLI-PROBE.md does not explain a "${name}" failure`);
+  }
+});
+
+test("the guide is reachable from the README index rather than only from a link someone remembers", () => {
+  const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+  assert.match(readme, /\(docs\/DEVIN-CLI-PROBE\.md\)/);
+});

--- a/test/devin-probe-checks.test.mjs
+++ b/test/devin-probe-checks.test.mjs
@@ -1,0 +1,323 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { auditMessage, fieldCensus } from "../src/protobuf-audit.mjs";
+import {
+  DEFAULT_MAX_TOKENS,
+  liveTurnChecks,
+  modelListChecks,
+  parseProbeArgs,
+  requestShapeChecks,
+  streamFrameChecks,
+  toolCallChecks,
+} from "../src/devin-probe-checks.mjs";
+
+const statusOf = (checks, name) => checks.find((check) => check.name === name)?.status;
+const checkOf = (checks, name) => checks.find((check) => check.name === name);
+
+// The stop-reason value the shipped descriptor set gives for a function call.
+const FUNCTION_CALL = 10;
+
+test("the published flags parse, and a defaulted live run is capped", () => {
+  const parsed = parseProbeArgs(["--live", "--tools"]);
+  assert.equal(parsed.live, true);
+  assert.equal(parsed.tools, true);
+  assert.equal(parsed.maxTokens, DEFAULT_MAX_TOKENS);
+  assert.deepEqual(parsed.unknown, []);
+  assert.deepEqual(parsed.errors, []);
+});
+
+test("nothing is spent unless --live is typed", () => {
+  assert.equal(parseProbeArgs([]).live, false);
+  assert.equal(parseProbeArgs(["--tools"]).live, false);
+  assert.equal(parseProbeArgs(["--model", "x"]).live, false);
+});
+
+test("a mistyped flag is reported instead of quietly skipping the check it asked for", () => {
+  // `--tool` used to leave a passing run that never attempted a tool call.
+  const parsed = parseProbeArgs(["--live", "--tool"]);
+  assert.deepEqual(parsed.unknown, ["--tool"]);
+  assert.equal(parsed.tools, false);
+});
+
+test("a flag missing its value is an error, not a flag swallowing the next flag", () => {
+  const parsed = parseProbeArgs(["--model", "--live"]);
+  assert.deepEqual(parsed.errors, ["--model needs a value"]);
+  assert.equal(parsed.model, undefined);
+  assert.equal(parsed.live, false);
+});
+
+test("token and timeout caps refuse values that would remove the cap", () => {
+  assert.match(parseProbeArgs(["--max-tokens", "0"]).errors[0], /positive number/);
+  assert.match(parseProbeArgs(["--max-tokens", "lots"]).errors[0], /positive number/);
+  assert.match(parseProbeArgs(["--timeout", "-3"]).errors[0], /positive number/);
+  assert.equal(parseProbeArgs(["--max-tokens", "16"]).maxTokens, 16);
+  assert.equal(parseProbeArgs(["--timeout", "30"]).timeoutMs, 30_000);
+});
+
+test("an empty model list is a failure, not an 'account advertises 0 models' pass", () => {
+  const checks = modelListChecks({ models: [], census: [], httpStatus: 200 });
+  assert.equal(statusOf(checks, "model list"), "fail");
+  assert.match(checkOf(checks, "model list").observed, /decoded to nothing \(HTTP 200\)/);
+});
+
+test("an empty model list names the fields the response actually carried", () => {
+  // The exact symptom of a renumbered model_uid: a well-formed response full of
+  // fields, none of which this build knows.
+  const census = [
+    { no: 1, name: undefined, status: "unknown", path: [], wireTypeNames: ["length-delimited"], count: 3, totalBytes: 90 },
+  ];
+  const checks = modelListChecks({ models: [], census, httpStatus: 200 });
+  assert.equal(statusOf(checks, "model list"), "fail");
+  assert.match(checkOf(checks, "model list").observed, /field 1 \(length-delimited, 90B over 3\) -> UNKNOWN/);
+});
+
+test("a decoded model list passes and reports the entitlement spread", () => {
+  const checks = modelListChecks({
+    models: [
+      { id: "a", premium: true, beta: false },
+      { id: "b", premium: false, beta: true },
+      { id: "c", premium: false, beta: false },
+    ],
+    census: [],
+  });
+  assert.equal(statusOf(checks, "model list"), "pass");
+  assert.equal(checkOf(checks, "entitlement flags").detail, "1 premium, 1 beta, 1 standard");
+});
+
+test("a model that decoded without a uid fails even when the list is not empty", () => {
+  const checks = modelListChecks({ models: [{ id: "a" }, { id: "" }], census: [] });
+  assert.equal(statusOf(checks, "model uid field"), "fail");
+});
+
+test("a request that does not re-read as protobuf fails before anything is sent", () => {
+  const checks = requestShapeChecks({ audit: { truncated: true, error: "truncated varint" }, requiredFields: [] });
+  assert.equal(statusOf(checks, "request encoding"), "fail");
+  assert.equal(checkOf(checks, "request encoding").observed, "truncated varint");
+});
+
+test("a request missing a field the upstream requires is named field by field", () => {
+  const schema = { metadata: { no: 1, type: "string" }, chatModelUid: { no: 21, type: "string" } };
+  const audit = auditMessage(Uint8Array.from([0x0a, 0x01, 0x61]), schema);
+  const checks = requestShapeChecks({ audit, requiredFields: ["metadata", "chatModelUid"] });
+  assert.equal(statusOf(checks, "request encoding"), "fail");
+  assert.equal(checkOf(checks, "request encoding").observed, "missing chatModelUid");
+});
+
+test("a complete request passes and counts what it wrote", () => {
+  const schema = { metadata: { no: 1, type: "string" }, prompt: { no: 2, type: "string" } };
+  const audit = auditMessage(Uint8Array.from([0x0a, 0x01, 0x61, 0x12, 0x01, 0x62]), schema);
+  const checks = requestShapeChecks({ audit, requiredFields: ["metadata", "prompt"] });
+  assert.equal(statusOf(checks, "request encoding"), "pass");
+  assert.match(checkOf(checks, "request encoding").detail, /2 field\(s\) written, 6 bytes/);
+});
+
+test("a stream that produced no message frame fails even though HTTP said 200", () => {
+  const checks = streamFrameChecks({ frames: [], pending: 0, sawEndOfStream: false });
+  assert.equal(statusOf(checks, "stream framing"), "fail");
+  assert.equal(statusOf(checks, "end-of-stream terminator"), "fail");
+});
+
+test("a compressed frame fails loudly, because a decoder handed one returns an empty message", () => {
+  const checks = streamFrameChecks({
+    frames: [{ compressed: true, endOfStream: false }, { compressed: false, endOfStream: true }],
+    pending: 0,
+    sawEndOfStream: true,
+    terminator: { malformed: false },
+  });
+  assert.equal(statusOf(checks, "frame compression"), "fail");
+  assert.match(checkOf(checks, "frame compression").observed, /1 of 2 frames/);
+});
+
+test("trailing bytes that never formed a frame are a failure, not a short answer", () => {
+  const checks = streamFrameChecks({
+    frames: [{ compressed: false, endOfStream: false }],
+    pending: 12,
+    sawEndOfStream: false,
+  });
+  assert.equal(statusOf(checks, "stream completeness"), "fail");
+  assert.match(checkOf(checks, "stream completeness").observed, /12 trailing byte/);
+});
+
+test("an error inside the terminator is a failure with its code and retriability spelled out", () => {
+  const checks = streamFrameChecks({
+    frames: [{ compressed: false, endOfStream: true }],
+    pending: 0,
+    sawEndOfStream: true,
+    terminator: {
+      malformed: false,
+      error: { code: "invalid_argument", message: "chat_model_uid is required", status: 400, retriable: false, known: true },
+    },
+  });
+  const check = checkOf(checks, "end-of-stream terminator");
+  assert.equal(check.status, "fail");
+  assert.match(check.detail, /chat_model_uid is required/);
+  assert.match(check.observed, /code=invalid_argument known=true retriable=false mapped-status=400/);
+});
+
+test("a clean terminator with frames passes every framing check", () => {
+  const checks = streamFrameChecks({
+    frames: [{ compressed: false, endOfStream: false }, { compressed: false, endOfStream: true }],
+    pending: 0,
+    sawEndOfStream: true,
+    terminator: { malformed: false },
+  });
+  assert.deepEqual(
+    checks.map((check) => check.status),
+    ["pass", "pass", "pass"],
+  );
+});
+
+test("frames that decode to nothing fail, where the old probe printed 'streamed 0 characters'", () => {
+  const checks = liveTurnChecks({ model: "m", text: "", thinking: "", toolCalls: [], census: [] });
+  assert.equal(statusOf(checks, "turn produced output"), "fail");
+});
+
+test("a turn that produced only reasoning still counts as output", () => {
+  const checks = liveTurnChecks({ model: "m", text: "", thinking: "thinking…", toolCalls: [] });
+  assert.equal(statusOf(checks, "turn produced output"), "pass");
+});
+
+test("a model served under a different uid than requested is reported", () => {
+  const checks = liveTurnChecks({ model: "asked", actualModelUid: "served", text: "hi" });
+  const check = checkOf(checks, "served model");
+  assert.equal(check.status, "warn");
+  assert.equal(check.expected, "asked");
+  assert.equal(check.observed, "served");
+});
+
+test("a turn with no usage warns rather than passing silently", () => {
+  assert.equal(statusOf(liveTurnChecks({ model: "m", text: "hi" }), "usage accounting"), "warn");
+  assert.equal(
+    statusOf(liveTurnChecks({ model: "m", text: "hi", usage: { prompt_tokens: 10, completion_tokens: 3 } }), "usage accounting"),
+    "pass",
+  );
+});
+
+test("a run without --tools says outright that the deciding check was not attempted", () => {
+  const checks = liveTurnChecks({ model: "m", text: "ready", wantsTools: false });
+  const check = checkOf(checks, "tool calls");
+  assert.equal(check.status, "skip");
+  assert.match(check.detail, /--live --tools/);
+});
+
+test("a stop reason claiming a function call with no decoded call is named as a dropped call", () => {
+  // The quiet failure this exists for. Without this line the run is
+  // indistinguishable from a model that declined the tool.
+  const census = [{ no: 19, name: undefined, status: "unknown", path: [], wireTypeNames: ["length-delimited"], count: 1, totalBytes: 44 }];
+  const checks = toolCallChecks({
+    wantsTools: true,
+    toolCalls: [],
+    stopReason: FUNCTION_CALL,
+    functionCallStopReason: FUNCTION_CALL,
+    census,
+  });
+  const check = checkOf(checks, "tool calls decoded");
+  assert.equal(check.status, "fail");
+  assert.match(check.detail, /dropped on the wire, not declined by the model/);
+  assert.match(check.observed, /stopReason=10/);
+  assert.match(check.observed, /field 19 \(length-delimited, 44B over 1\) -> UNKNOWN/);
+});
+
+test("no tool call plus an undecoded field is reported as a possible renumbering", () => {
+  const census = [{ no: 19, name: undefined, status: "unknown", path: [], wireTypeNames: ["length-delimited"], count: 2, totalBytes: 80 }];
+  const check = checkOf(
+    toolCallChecks({ wantsTools: true, toolCalls: [], stopReason: 2, functionCallStopReason: FUNCTION_CALL, census }),
+    "tool calls decoded",
+  );
+  assert.equal(check.status, "fail");
+  assert.match(check.detail, /field number that was skipped/);
+});
+
+test("no tool call with every field understood is reported as the model declining, not as a wire fault", () => {
+  const check = checkOf(
+    toolCallChecks({
+      wantsTools: true,
+      toolCalls: [],
+      stopReason: 2,
+      functionCallStopReason: FUNCTION_CALL,
+      census: [{ no: 3, name: "deltaText", status: "matched", path: [], wireTypeNames: ["length-delimited"], count: 4, totalBytes: 40 }],
+      text: "I cannot call tools.",
+    }),
+    "tool calls decoded",
+  );
+  assert.equal(check.status, "fail");
+  assert.match(check.detail, /the model declined a forced tool choice/);
+  assert.match(check.observed, /answered in prose instead: I cannot call tools\./);
+});
+
+test("tool calls with no id fail, because the forwarder keys restatements by id", () => {
+  const checks = toolCallChecks({
+    wantsTools: true,
+    toolCalls: [{ id: "", name: "ping", argumentsJson: "{}" }],
+    functionCallStopReason: FUNCTION_CALL,
+  });
+  assert.equal(statusOf(checks, "tool calls decoded"), "pass");
+  assert.equal(statusOf(checks, "tool call ids"), "fail");
+});
+
+test("arguments that are not JSON fail with the value that arrived", () => {
+  const checks = toolCallChecks({
+    wantsTools: true,
+    toolCalls: [{ id: "a", name: "ping", argumentsJson: "value=1" }],
+    functionCallStopReason: FUNCTION_CALL,
+  });
+  const check = checkOf(checks, "tool call arguments");
+  assert.equal(check.status, "fail");
+  assert.equal(check.observed, "value=1");
+});
+
+test("an unnamed tool call fails even when it carried an id and arguments", () => {
+  const checks = toolCallChecks({
+    wantsTools: true,
+    toolCalls: [{ id: "a", name: "", argumentsJson: "{}" }],
+    functionCallStopReason: FUNCTION_CALL,
+  });
+  assert.equal(statusOf(checks, "tool call names"), "fail");
+});
+
+test("a well-formed forced tool call passes every tool check", () => {
+  const checks = toolCallChecks({
+    wantsTools: true,
+    toolCalls: [{ id: "call_1", name: "ping", argumentsJson: '{"value":1}' }],
+    stopReason: FUNCTION_CALL,
+    functionCallStopReason: FUNCTION_CALL,
+  });
+  assert.deepEqual(
+    checks.map((check) => [check.name, check.status]),
+    [
+      ["tool calls decoded", "pass"],
+      ["tool call ids", "pass"],
+      ["tool call arguments", "pass"],
+    ],
+  );
+});
+
+test("a restated call is reported as a restatement rather than as a second call", () => {
+  const checks = toolCallChecks({
+    wantsTools: true,
+    toolCalls: [
+      { id: "call_1", name: "ping", argumentsJson: "{" },
+      { id: "call_1", name: "ping", argumentsJson: '{"value":1}' },
+    ],
+    functionCallStopReason: FUNCTION_CALL,
+  });
+  assert.equal(statusOf(checks, "tool call restatement"), "info");
+});
+
+test("no tool checks run at all when --tools was not asked for", () => {
+  assert.deepEqual(toolCallChecks({ wantsTools: false, toolCalls: [] }), []);
+});
+
+test("the census a real frame produces feeds the drop detector unchanged", () => {
+  // End to end through the auditor: a frame carrying the tool call on field 19
+  // instead of field 6, which is what a renumbering looks like on the wire.
+  const schema = { deltaText: { no: 3, type: "string" }, deltaToolCalls: { no: 6, type: "message", message: {}, repeated: true } };
+  const frame = Uint8Array.from([0x9a, 0x01, 0x02, 0x7b, 0x7d]);
+  const census = fieldCensus(auditMessage(frame, schema));
+  const check = checkOf(
+    toolCallChecks({ wantsTools: true, toolCalls: [], stopReason: FUNCTION_CALL, functionCallStopReason: FUNCTION_CALL, census }),
+    "tool calls decoded",
+  );
+  assert.match(check.observed, /field 19 \(length-delimited, 2B over 1\) -> UNKNOWN/);
+});

--- a/test/probe-report.test.mjs
+++ b/test/probe-report.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ProbeReport, truncateForReport } from "../src/probe-report.mjs";
+
+test("checks render in the shape bin/doctor already uses", () => {
+  const report = new ProbeReport({ title: "probe" });
+  report.pass("session", "read from disk");
+  report.fail("model list", "nothing decoded", { expected: "one model", observed: "zero", fix: "paste this" });
+
+  const rendered = report.render();
+  assert.match(rendered, /^PASS {2}session: read from disk$/m);
+  assert.match(rendered, /^FAIL {2}model list: nothing decoded$/m);
+  assert.match(rendered, /^ {6}expected: one model$/m);
+  assert.match(rendered, /^ {6}observed: zero$/m);
+  assert.match(rendered, /^ {6}fix: paste this$/m);
+});
+
+test("a run that reached nothing is INCONCLUSIVE, not a pass", () => {
+  // The failure this whole exercise is about: a run that never got far enough
+  // to test anything must not read as confirmation.
+  const report = new ProbeReport();
+  report.skip("live turn", "not attempted");
+  assert.equal(report.verdict(), "INCONCLUSIVE");
+  assert.equal(report.exitCode(), 0);
+});
+
+test("a skipped or warned run is PARTIAL, and only a clean run is PASS", () => {
+  const partial = new ProbeReport();
+  partial.pass("session", "ok");
+  partial.skip("live turn", "not attempted");
+  assert.equal(partial.verdict(), "PARTIAL");
+
+  const clean = new ProbeReport();
+  clean.pass("session", "ok");
+  clean.info("host", "example.invalid");
+  assert.equal(clean.verdict(), "PASS");
+});
+
+test("one failure decides the verdict and the exit code no matter what else passed", () => {
+  const report = new ProbeReport();
+  for (let index = 0; index < 10; index += 1) report.pass(`check ${index}`, "ok");
+  report.fail("tool calls decoded", "none arrived");
+  assert.equal(report.verdict(), "FAIL");
+  assert.equal(report.exitCode(), 1);
+  assert.equal(report.failed, true);
+});
+
+test("the summary line counts every status", () => {
+  const report = new ProbeReport();
+  report.pass("a", "ok");
+  report.pass("b", "ok");
+  report.warn("c", "hm");
+  report.fail("d", "no");
+  report.skip("e", "later");
+  report.info("f", "note");
+
+  assert.deepEqual(report.counts(), { fail: 1, warn: 1, pass: 2, info: 1, skip: 1 });
+  assert.match(report.render(), /VERDICT FAIL — 2 pass, 1 fail, 1 warn, 1 skipped/);
+});
+
+test("the paste block is fenced and carries the environment a maintainer needs", () => {
+  const report = new ProbeReport({
+    title: "codex-router devin-cli probe",
+    environment: { node: "v22.19.0", "devin cli": "3000.4.25", empty: "", missing: undefined },
+  });
+  report.pass("session", "ok");
+
+  const block = report.pasteBlock();
+  assert.match(block, /^```text\n/);
+  assert.match(block, /```\n$/);
+  assert.match(block, /^node: v22\.19\.0$/m);
+  assert.match(block, /^devin cli: 3000\.4\.25$/m);
+  assert.equal(block.includes("empty:"), false);
+  assert.equal(block.includes("missing:"), false);
+});
+
+test("the JSON form carries the same verdict as the text form", () => {
+  const report = new ProbeReport({ title: "probe", environment: { node: "v22" } });
+  report.fail("x", "y", { observed: "z" });
+  const json = report.toJson();
+  assert.equal(json.verdict, "FAIL");
+  assert.equal(json.title, "probe");
+  assert.deepEqual(json.environment, { node: "v22" });
+  assert.deepEqual(json.checks, [{ status: "fail", name: "x", detail: "y", observed: "z" }]);
+});
+
+test("an unknown status is refused rather than rendered as one", () => {
+  const report = new ProbeReport();
+  assert.throws(() => report.add({ status: "maybe", name: "x", detail: "y" }), /unknown status maybe/);
+});
+
+test("addAll accepts the arrays the check modules return", () => {
+  const report = new ProbeReport();
+  report.addAll([
+    { status: "pass", name: "a", detail: "ok" },
+    { status: "fail", name: "b", detail: "no" },
+  ]);
+  assert.equal(report.checks.length, 2);
+  assert.equal(report.verdict(), "FAIL");
+});
+
+test("long observed values are cut with their real length attached", () => {
+  const long = "x".repeat(500);
+  const cut = truncateForReport(long, 20);
+  assert.equal(cut.startsWith("x".repeat(20)), true);
+  assert.match(cut, /\(500 chars\)$/);
+  assert.equal(truncateForReport("short", 20), "short");
+  assert.equal(truncateForReport({ a: 1 }), '{"a":1}');
+});

--- a/test/protobuf-audit.test.mjs
+++ b/test/protobuf-audit.test.mjs
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  auditMessage,
+  describeCensusRow,
+  expectedWireTypes,
+  fieldCensus,
+  mismatchedFieldRows,
+  scanFields,
+  unknownFieldRows,
+  wireTypeName,
+} from "../src/protobuf-audit.mjs";
+
+// Bytes are written by hand rather than produced by the encoder under audit.
+// An auditor checked against its own writer proves the two agree, which is not
+// the claim anyone needs.
+const bytes = (...values) => Uint8Array.from(values.flat());
+const ascii = (text) => [...text].map((character) => character.charCodeAt(0));
+// Tags above field 15 need two varint bytes; spelling that out here keeps the
+// fixtures honest about what the wire really looks like.
+const varint = (value) => {
+  const out = [];
+  let remaining = value;
+  do {
+    const byte = remaining & 0x7f;
+    remaining >>>= 7;
+    out.push(remaining > 0 ? byte | 0x80 : byte);
+  } while (remaining > 0);
+  return out;
+};
+const stringField = (no, text) => [...varint(no * 8 + 2), text.length, ...ascii(text)];
+const varintField = (no, value) => [...varint(no * 8), value];
+
+// The subset of the Cascade response this repository claims to understand.
+const TOOL_CALL = Object.freeze({
+  id: { no: 1, type: "string" },
+  name: { no: 2, type: "string" },
+  argumentsJson: { no: 3, type: "string" },
+});
+const RESPONSE = Object.freeze({
+  messageId: { no: 1, type: "string" },
+  deltaText: { no: 3, type: "string" },
+  stopReason: { no: 5, type: "enum" },
+  deltaToolCalls: { no: 6, type: "message", message: TOOL_CALL, repeated: true },
+});
+
+test("a hand-written frame is reported field by field with its wire type", () => {
+  const frame = bytes(stringField(3, "hi"), varintField(5, 10));
+  const scan = scanFields(frame);
+
+  assert.equal(scan.truncated, false);
+  assert.deepEqual(
+    scan.fields.map(({ no, wireType, byteLength }) => ({ no, wireType, byteLength })),
+    [
+      { no: 3, wireType: 2, byteLength: 2 },
+      { no: 5, wireType: 0, byteLength: 1 },
+    ],
+  );
+});
+
+test("a field the schema does not name is reported, not skipped", () => {
+  // This is the whole reason the module exists. A protobuf decoder skips field
+  // 19 silently; a tester needs to be told it was there.
+  const frame = bytes(stringField(3, "ok"), stringField(19, "surprise"));
+  const audit = auditMessage(frame, RESPONSE);
+
+  assert.deepEqual(
+    audit.matched.map((entry) => entry.name),
+    ["deltaText"],
+  );
+  assert.deepEqual(
+    audit.unknown.map((entry) => ({ no: entry.no, wireTypeName: entry.wireTypeName, byteLength: entry.byteLength })),
+    [{ no: 19, wireTypeName: "length-delimited", byteLength: 8 }],
+  );
+});
+
+test("a two-byte tag is read as one field, so field numbers above 15 are not misread", () => {
+  // 19 << 3 | 2 == 154, which does not fit in one varint byte.
+  const frame = bytes([0x9a, 0x01, 0x03], ascii("abc"));
+  const scan = scanFields(frame);
+  assert.equal(scan.fields.length, 1);
+  assert.equal(scan.fields[0].no, 19);
+  assert.equal(scan.fields[0].wireType, 2);
+});
+
+test("a field arriving on the wrong wire type is a mismatch, not an unknown", () => {
+  // deltaText is declared `string`, which may only arrive length-delimited.
+  const audit = auditMessage(bytes(varintField(3, 7)), RESPONSE);
+  assert.equal(audit.matched.length, 0);
+  assert.equal(audit.unknown.length, 0);
+  assert.deepEqual(
+    audit.mismatched.map((entry) => ({ no: entry.no, name: entry.name, observed: entry.wireTypeName })),
+    [{ no: 3, name: "deltaText", observed: "varint" }],
+  );
+  assert.deepEqual(audit.mismatched[0].expectedWireTypeNames, ["length-delimited"]);
+});
+
+test("nested message fields are audited against their own table", () => {
+  const call = bytes(stringField(1, "a"), stringField(2, "ping"), stringField(3, "{}"));
+  const frame = bytes([6 * 8 + 2, call.length], [...call]);
+  const audit = auditMessage(frame, RESPONSE);
+
+  assert.equal(audit.matched.length, 1);
+  assert.deepEqual(
+    audit.matched[0].child.matched.map((entry) => entry.name),
+    ["id", "name", "argumentsJson"],
+  );
+});
+
+test("an unknown field inside a nested message is reported with its path", () => {
+  const call = bytes(stringField(1, "a"), stringField(9, "moved"));
+  const frame = bytes([6 * 8 + 2, call.length], [...call]);
+  const census = fieldCensus(auditMessage(frame, RESPONSE));
+
+  const unknown = unknownFieldRows(census);
+  assert.equal(unknown.length, 1);
+  assert.deepEqual(unknown[0].path, ["deltaToolCalls"]);
+  assert.equal(unknown[0].no, 9);
+  assert.match(describeCensusRow(unknown[0]), /^deltaToolCalls\.field 9 \(length-delimited, 5B over 1\) -> UNKNOWN$/);
+});
+
+test("field contents never survive into the audit result", () => {
+  // The probe's output is written to be pasted into a public issue, and these
+  // payloads carry prompt text and model output.
+  const audit = auditMessage(bytes(stringField(3, "secret prompt text")), RESPONSE);
+  const serialized = JSON.stringify(audit);
+  assert.equal(serialized.includes("secret"), false);
+  assert.equal(audit.matched[0].byteLength, 18);
+});
+
+test("a frame that ends mid-field reports what it read plus the failure", () => {
+  const truncated = bytes(stringField(3, "ok"), [3 * 8 + 2, 20], ascii("short"));
+  const audit = auditMessage(truncated, RESPONSE);
+  assert.equal(audit.truncated, true);
+  assert.match(audit.error, /runs past the end/);
+  assert.equal(audit.matched.length, 1);
+});
+
+test("a truncated varint does not throw out of the auditor", () => {
+  const scan = scanFields(bytes([5 * 8, 0x80]));
+  assert.equal(scan.truncated, true);
+  assert.match(scan.error, /truncated varint/);
+});
+
+test("a zero field number is refused rather than reported as field 0", () => {
+  const scan = scanFields(bytes([0x02, 0x00]));
+  assert.equal(scan.truncated, true);
+  assert.match(scan.error, /field number 0/);
+});
+
+test("group wire types are reported as unsupported instead of being guessed at", () => {
+  const scan = scanFields(bytes([3 * 8 + 3]));
+  assert.equal(scan.truncated, true);
+  assert.match(scan.error, /wire type 3/);
+});
+
+test("the census folds many frames into one row per field", () => {
+  const audits = [
+    auditMessage(bytes(stringField(3, "ab")), RESPONSE),
+    auditMessage(bytes(stringField(3, "cde")), RESPONSE),
+    auditMessage(bytes(stringField(19, "x")), RESPONSE),
+  ];
+  const census = fieldCensus(audits);
+
+  const text = census.find((row) => row.no === 3);
+  assert.equal(text.count, 2);
+  assert.equal(text.totalBytes, 5);
+  assert.equal(text.name, "deltaText");
+  assert.equal(unknownFieldRows(census).length, 1);
+  assert.equal(mismatchedFieldRows(census).length, 0);
+});
+
+test("a repeated numeric field may arrive packed or unpacked, a singular one may not", () => {
+  assert.deepEqual(expectedWireTypes("uint32", true), [0, 2]);
+  assert.deepEqual(expectedWireTypes("uint32", false), [0]);
+  assert.deepEqual(expectedWireTypes("string", true), [2]);
+  assert.deepEqual(expectedWireTypes("double", false), [1]);
+  assert.deepEqual(expectedWireTypes("float", false), [5]);
+  assert.deepEqual(expectedWireTypes("nonsense"), []);
+  assert.equal(wireTypeName(7), "wire-type-7");
+});
+
+test("fixed-width fields are measured, not misread as length prefixes", () => {
+  const frame = bytes([5 * 8 + 1], [1, 2, 3, 4, 5, 6, 7, 8], [6 * 8 + 5], [1, 2, 3, 4]);
+  const scan = scanFields(frame);
+  assert.deepEqual(
+    scan.fields.map((field) => [field.no, field.wireTypeName, field.byteLength]),
+    [
+      [5, "fixed64", 8],
+      [6, "fixed32", 4],
+    ],
+  );
+});
+
+test("an empty message audits to nothing rather than failing", () => {
+  const audit = auditMessage(new Uint8Array(0), RESPONSE);
+  assert.equal(audit.truncated, false);
+  assert.deepEqual(audit.observations, []);
+  assert.deepEqual(fieldCensus(audit), []);
+});


### PR DESCRIPTION
Makes a single tester's run settle each Cascade transport assumption, for #270. The Devin provider landed in #271, but the transport has still never run against a live session — this makes that one run worth something.

## What the old probe proved, and what it hid

A passing run proved that `credentials.toml` parses, that `Basic <token>-<token>` is accepted by *something*, and that two endpoints return HTTP 200. That is all.

What it actively concealed:

- `line("OK", "Account advertises 0 model(s)")` — **zero models printed OK.** Zero is the exact symptom of a renumbered `modelUid` (field 22) or `clientModelConfigs` (field 1). The single most likely wire failure, reported as a success.
- `line("OK", "Live turn on X streamed 0 character(s)")` — a stream that decoded to nothing also printed OK.
- **The silent tool-call drop.** `for (const call of message.deltaToolCalls || [])` — if `deltaToolCalls` moved off field 6, `decodeMessage` skips it silently and the probe reported *"this model cannot drive a Codex turn"*. That blames the tester's model for our wire fault, with nothing to distinguish the two.
- No wire evidence anywhere: failures printed `error.message` only — no HTTP status, no Connect code, no content-type, no field census. A tester's paste was undiagnosable.
- **No cost bound.** The probe set no `max_tokens`, so `buildChatMessageRequest` defaulted to **128,000**. The "one short turn" claim was unenforced.
- `--tool` (a typo for `--tools`) silently produced a passing run that never tested tools. `--model` with no value swallowed the next flag.
- No verdict line and no environment capture — critical, since the field numbers came from build `3000.4.25`.

## What ships

Four new modules, none importing anything Devin-specific:

- **`src/protobuf-audit.mjs`** — walks raw bytes schema-free, classifies every field as matched / wire-type-mismatched / **unknown**, recurses into nested messages, folds frames into a census. Field *contents* are never retained, since the output is pasted publicly.
- **`src/connect-stream-audit.mjs`** — incremental envelope scanner, compression flag, terminator parsing, and all **16** Connect codes with retriability.
- **`src/probe-report.mjs`** — doctor-style `STATUS name: detail` with `observed:`/`fix:` lines, a **three-way** verdict (PASS / PARTIAL / **INCONCLUSIVE** — a run that reached nothing is not a pass), and a fenced paste block.
- **`src/devin-probe-checks.mjs`** — every judgement as pure functions.

`src/devin-cli-probe.mjs` is rewritten to read raw bytes itself — a probe must not test a transport using that transport — then audit its own encoded request *before sending anything*, then replay the captured bytes through the shipped `connectServerStream` for free. Capped at 64 tokens / 90 s. Folds `$HOME` → `~`. Mistyped flags now fail the run.

The decisive line, verified against #271's real schemas:

```
FAIL  tool calls decoded: the upstream reported a function-call stop reason and this build
      decoded no tool call — calls are being dropped on the wire, not declined by the model
      observed: stopReason=10; undecoded fields: field 19 (length-delimited, 27B over 1) -> UNKNOWN
```

## Unverified assumptions, now each individually reported

Most consequential first: `deltaToolCalls = 6` and `CHAT_TOOL_CALL {id 1, name 2, argumentsJson 3}`; the `tool_choice: "required"` → `optionName` vocabulary; `GET_CHAT_MESSAGE_REQUEST` field numbers; `CLIENT_MODEL_CONFIG.modelUid = 22`/`disabled = 4`; the `Basic <token>-<token>` scheme; service path and method names; assistant turns sent as `CHAT_MESSAGE_SOURCE.SYSTEM`; the delta/stop/usage field numbers; `STOP_REASON.FUNCTION_CALL = 10`; envelope compression (the client sends no `connect-accept-encoding`, and a gzipped frame currently yields an empty message with **no error**); and tool-call id stability.

## Two defects found in #271 while reading it

Not fixed here — that code is now on main and these are separate follow-ups:

1. **The Connect status table has 10 of 16 codes**, so `unimplemented` maps to 502 — and the router *retries* a call that can never succeed.
2. **`connectServerStream` ignores the envelope compression bit entirely.**

## Offline tests

**97 new tests** across 5 files, including a full end-to-end run of the probe against a fabricated provider *and* upstream: dropped tool call, compressed frames, mid-frame truncation, chunk-boundary splits, terminator errors, and 401/403/404/400 mapping. All run in CI with no account.

Verification actually performed: a lab built from #271's real sources plus a fake Cascade server driven by #271's own schemas, exercising healthy / dropped-tool / renumbered / unauthenticated / invalid_argument / stream-error paths. Every one produced the correct specific line. Two bugs in this work surfaced there and were fixed — a home-path leak, and a false "transport replay" failure when the transport correctly rethrew a terminator error.

## Docs

`docs/DEVIN-CLI-PROBE.md`, linked from the README index, with tests asserting that every emittable failure is explained there and that the doc's cost claims match the code.

Note: AGENTS.md already says "nothing may claim support until `bin/devin-probe --live --tools` passes." That rule now rests on a probe whose pass means something.

`npm run check` passes. `npm test`: 1688 pass, 0 fail, 12 skipped (+97 over baseline, same 12 skips).
