### PR TITLE
fix(test): stop the suite from deleting the machine's own routed subagents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1574,6 +1574,18 @@ purpose.
   that can echo either. Regressions require fragmented/mislabeled SSE tests and
   real marker-return probes through every installed routed agent plus a
   same-thread follow-up.
+- A test that isolates the state directory must isolate `CODEX_HOME` with it.
+  `MODEL_ROUTER_STATE_DIR` and `CODEX_ROUTER_STATE_DIR` do not redirect
+  `CODEX_AGENTS_DIR`, which is `$CODEX_HOME/agents`, and `src/catalog.mjs`
+  prunes that directory to whatever the state it just read promotes to `v2`.
+  Point the state at a scratch directory while inheriting the real home and the
+  run deletes the operator's own routed agent definitions — every model
+  promoted by a local capability proof rather than by the shipped registry —
+  while `multi-agent-settings.json` and `multi-agent-proofs.json`, which live in
+  the scratch state, survive intact to report the models as still enabled. The
+  operator sees subagents that reset themselves after an unrelated command.
+  `test/state-owner.test.mjs` pins this: no test file may spawn the catalog
+  without setting `CODEX_HOME`.
 
 ## Installing the harness is one action, and it is never a side effect
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Running the test suite no longer resets your subagents.**
+  `test/state-owner.test.mjs` ran the real `src/catalog.mjs` against a scratch
+  state directory while inheriting the developer's own `CODEX_HOME`. No
+  state-directory override redirects `$CODEX_HOME/agents`, so the catalog read
+  an empty state — no proofs, no selection, no picker — and pruned the real
+  agents directory to the handful of models the shipped registry promotes on
+  its own, deleting the definition of every model this machine had promoted
+  through a local capability probe. The settings naming those models live in
+  the state directory and survived, so `subagents status` kept reporting them
+  as enabled while Codex had nothing left to spawn: subagents that appeared to
+  reset themselves after an unrelated command. The test now isolates the home
+  with the state, and a guard in the same file fails if any test spawns the
+  catalog without doing so. If your routed agents are already missing, one
+  catalog refresh from the owning checkout restores them.
+
 - **GPT-5.6 Sol can now run at the 1M context window OpenAI documents for it.**
   The catalog Codex ships declares 272,000 tokens against a documented
   1,050,000, and that figure has already moved twice

--- a/test/state-owner.test.mjs
+++ b/test/state-owner.test.mjs
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -34,6 +42,25 @@ function withState({ owner }, run) {
   }
 }
 
+// Overriding the state directory does not redirect everything a run writes.
+// `CODEX_AGENTS_DIR` is `$CODEX_HOME/agents`, and `src/catalog.mjs` prunes it
+// to whatever the state directory it just read promotes as a subagent. A test
+// that isolates the state but inherits the real home therefore deletes the
+// operator's own routed agent definitions -- every model promoted by a local
+// capability proof rather than by the shipped registry -- while their settings
+// files, which live in the isolated state, survive to say the models are still
+// enabled. Isolate both, on every spawn in this file.
+function isolatedEnv(stateDir, extraEnv = {}) {
+  const codexHome = path.join(stateDir, "codex-home");
+  mkdirSync(codexHome, { recursive: true });
+  return {
+    ...process.env,
+    CODEX_HOME: codexHome,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    ...extraEnv,
+  };
+}
+
 function ownershipStatus(stateDir, extraEnv = {}) {
   const result = spawnSync(
     process.execPath,
@@ -46,7 +73,7 @@ function ownershipStatus(stateDir, extraEnv = {}) {
     {
       cwd: root,
       encoding: "utf8",
-      env: { ...process.env, MODEL_ROUTER_STATE_DIR: stateDir, ...extraEnv },
+      env: isolatedEnv(stateDir, extraEnv),
     },
   );
   assert.equal(result.status, 0, result.stderr);
@@ -88,7 +115,7 @@ test("writing the catalog from a foreign checkout fails with guidance, not a sta
     const result = spawnSync(process.execPath, [path.join(root, "src", "catalog.mjs")], {
       cwd: root,
       encoding: "utf8",
-      env: { ...process.env, MODEL_ROUTER_STATE_DIR: stateDir },
+      env: isolatedEnv(stateDir),
     });
     assert.equal(result.status, 1);
     assert.match(result.stderr, /owned by another checkout/);
@@ -111,7 +138,7 @@ test("writing the gateway config from a foreign checkout is refused", () => {
       {
         cwd: root,
         encoding: "utf8",
-        env: { ...process.env, MODEL_ROUTER_STATE_DIR: stateDir },
+        env: isolatedEnv(stateDir),
       },
     );
     assert.equal(result.stdout, "foreign_state_owner");
@@ -133,7 +160,7 @@ test("rendering the gateway config to an explicit path stays unguarded", () => {
       {
         cwd: root,
         encoding: "utf8",
-        env: { ...process.env, MODEL_ROUTER_STATE_DIR: stateDir },
+        env: isolatedEnv(stateDir),
       },
     );
     assert.equal(result.stdout, "wrote", result.stderr);
@@ -143,15 +170,13 @@ test("rendering the gateway config to an explicit path stays unguarded", () => {
 test("the installer is allowed to take ownership", () => {
   withState({ owner: FOREIGN_OWNER }, (stateDir) => {
     // bin/install exports the override for its whole run because it rebuilds
-    // generated state before recording the new owner.
+    // generated state before recording the new owner. This is the one case in
+    // this file that clears the guard and runs the catalog for real, so it is
+    // the one that used to reach the operator's own `~/.codex/agents`.
     const result = spawnSync(process.execPath, [path.join(root, "src", "catalog.mjs")], {
       cwd: root,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        MODEL_ROUTER_STATE_DIR: stateDir,
-        MODEL_ROUTER_ALLOW_FOREIGN_STATE: "1",
-      },
+      env: isolatedEnv(stateDir, { MODEL_ROUTER_ALLOW_FOREIGN_STATE: "1" }),
     });
     assert.doesNotMatch(result.stderr || "", /owned by another checkout/);
   });
@@ -176,7 +201,7 @@ test("doctor --fix from a foreign checkout delegates to the recorded owner", () 
         {
           cwd: root,
           encoding: "utf8",
-          env: { ...process.env, MODEL_ROUTER_STATE_DIR: stateDir },
+          env: isolatedEnv(stateDir),
         },
       );
       assert.equal(result.status, 0, result.stderr);
@@ -186,4 +211,32 @@ test("doctor --fix from a foreign checkout delegates to the recorded owner", () 
   } finally {
     rmSync(owner, { recursive: true, force: true });
   }
+});
+
+// The defect this replaces: this file ran the real catalog with a scratch state
+// directory and the developer's own `CODEX_HOME`, so `npm test` deleted every
+// routed subagent definition the machine had earned through a local capability
+// proof. The settings that named those models live in the state directory and
+// survived, which is what made it look like a router update had reset the
+// subagents rather than a test run having removed the files Codex reads.
+//
+// Scoped to `path.join(..., "src", "catalog.mjs")` on purpose: that is how a
+// spawn of the catalog is spelled here, and matching the bare path string would
+// also catch the files that only read `src/catalog.mjs` as source text.
+test("no test spawns the catalog without isolating CODEX_HOME", () => {
+  const offenders = readdirSync(path.join(root, "test"))
+    .filter((entry) => entry.endsWith(".mjs"))
+    .filter((entry) => {
+      const source = readFileSync(path.join(root, "test", entry), "utf8");
+      return (
+        /["']src["']\s*,\s*["']catalog\.mjs["']/.test(source) &&
+        !source.includes("CODEX_HOME")
+      );
+    });
+  assert.deepEqual(
+    offenders,
+    [],
+    `${offenders.join(", ")} run the catalog against the real Codex home, whose ` +
+      "agents directory no state-directory override redirects",
+  );
 });


### PR DESCRIPTION
## The report

Subagents kept resetting themselves. Every setting still said they were on —
`control subagents status` listed 18 enabled models and 20 with recorded
capability proofs, and the model picker still showed every choice that had been
made — but Codex had nothing to spawn.

## What was actually happening

`test/state-owner.test.mjs` proves that the documented ownership override lets
`bin/install` rebuild generated state, and it proves it by running the real
`src/catalog.mjs`. It pointed `MODEL_ROUTER_STATE_DIR` at a scratch directory
and let `CODEX_HOME` fall through to the developer's own.

No state-directory override redirects `CODEX_AGENTS_DIR` — it is
`$CODEX_HOME/agents` (`src/paths.mjs`). So the run:

1. read subagent state out of an empty scratch directory: no
   `multi-agent-proofs.json`, no `multi-agent-settings.json`, no
   `model-picker.json`;
2. concluded the only `v2` models were the few the shipped registry promotes on
   its own;
3. had `syncRoutedCodexAgents` delete every other `router-model-*.toml` from the
   **real** agents directory.

On the machine that reported this, 19 of 23 definitions went: every model
promoted by a local capability probe rather than by the registry. Running
`npm test` was enough to do it.

What made it hard to attribute is that nothing looked broken. The settings
naming those models live in the state directory the test isolated, so they
survived untouched — only the files Codex actually reads were gone. The symptom
reaching the operator was subagents resetting after some unrelated command, with
every setting still reporting them as enabled.

## The change

- Every spawn in `test/state-owner.test.mjs` now goes through one `isolatedEnv`
  helper that sets `CODEX_HOME` alongside `MODEL_ROUTER_STATE_DIR`.
- A guard test in the same file fails if any test file spawns the catalog
  without setting `CODEX_HOME`. It matches the old file, so it would have caught
  this.
- `AGENTS.md` records the invariant under *Routed subagent regression
  prevention*; `CHANGELOG.md` describes the symptom, since anyone whose agents
  are already missing needs one catalog refresh to get them back.

No source change — the production paths were correct. `CODEX_AGENTS_DIR`
following `CODEX_HOME` is right for a real install, including one with a custom
state directory; the hazard is only a scratch state paired with a real home.

## Test plan

- [x] `node --test test/state-owner.test.mjs` — 10/10 pass
- [x] `~/.codex/agents` mtimes captured either side of that run: unchanged,
      where the pre-fix file rewrote all four surviving definitions
- [x] Guard verified against `origin/main`'s copy of the file: it matches the
      catalog spawn and finds no `CODEX_HOME`, so it fails there
- [x] `npm run check`
- [x] `npm test` — 1647 tests, 1635 pass, 0 fail, 12 skipped; `~/.codex` config and agents dir byte-identical either side of the full run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LuW2ZReXahmNySpiMnrCh