### PR TITLE
fix(meta): drop the search_content_types Meta's older schema copy refuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,6 +377,25 @@
   not disable expiry — it stops the router rewriting request context, and expiry
   is disk hygiene for bytes that are already written.
 
+- **Every turn against a Meta model failed on the web search tool.** Meta's
+  Responses surface answered each one with a 400 reading
+  "`tools[].search_content_types` is only supported for web_search_preview
+  tools", so Muse Spark 1.1, 1.2, and 1.2 Contributor were unusable rather than
+  degraded — the tool is declared on the turn whenever web search is enabled,
+  so this had nothing to do with whether the model actually searched. Codex
+  sends the current spelling of
+  that tool (`type: "web_search"`, carrying `search_content_types` beside
+  `external_web_access`, `filters`, and `user_location`); Meta validates it
+  against the legacy `web_search_preview` schema, which is the one place it
+  accepts the field. The forwarder now drops `search_content_types` from a Meta
+  request, and nothing else: the search tool itself still reaches the model with
+  the rest of its settings, and a caller that sends Meta a real
+  `web_search_preview` tool keeps the field on it. Scoped to Meta on purpose —
+  OpenAI documents `search_content_types` on `web_search` and not on
+  `web_search_preview`, the reverse of what this endpoint enforces, so the other
+  Responses-native providers keep a parameter the current spec grants them.
+  (#286)
+
 - **The free Qwen3.8 endpoint refused any conversation whose system message
   arrived late or twice.** Its chat template answers those with a 400 reading
   "System message must be at the beginning", and a real Codex session reaches

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -406,6 +406,39 @@ function normalizeQwen38SystemMessages(messages) {
   return [...rest.slice(0, insertAt), merged, ...rest.slice(insertAt)];
 }
 
+// Meta's Responses surface validates the hosted search tool against the legacy
+// `web_search_preview` schema: any other tool carrying `search_content_types`
+// is answered with HTTP 400 "`tools[].search_content_types` is only supported
+// for web_search_preview tools" (param `tools[].search_content_types`).
+//
+// The field is dropped, never renamed and never moved onto another tool. What
+// the caller asked for is a search-result content filter; the endpoint that
+// refuses the field is telling us it will not apply it, and inventing a
+// `web_search_preview` tool to carry it would change which hosted tool the
+// model is offered.
+//
+// The returned array is a copy only when something was actually removed, so a
+// request with no such tool is forwarded byte-identical to what arrived.
+function stripSearchContentTypes(tools) {
+  if (!Array.isArray(tools)) return tools;
+  let stripped = false;
+  const repaired = tools.map((tool) => {
+    if (
+      !tool ||
+      typeof tool !== "object" ||
+      Array.isArray(tool) ||
+      tool.type === "web_search_preview" ||
+      !("search_content_types" in tool)
+    ) {
+      return tool;
+    }
+    stripped = true;
+    const { search_content_types: _refused, ...rest } = tool;
+    return rest;
+  });
+  return stripped ? repaired : tools;
+}
+
 function normalizeBody(buffer, contentType, route) {
   if (!buffer.length || !String(contentType || "").includes("application/json")) {
     const error = new Error("API-provider requests require a JSON body.");
@@ -465,6 +498,28 @@ function normalizeBody(buffer, contentType, route) {
   // Fireworks rejects this OpenAI search parameter instead of ignoring it.
   // Other provider payloads keep it unchanged.
   if (provider.id === "fireworks") delete payload.web_search_options;
+  // Meta refuses `search_content_types` on anything but a `web_search_preview`
+  // tool, and Codex only ever sends the current spelling: its hosted search
+  // tool is `type: "web_search"`, carrying search_content_types beside
+  // external_web_access, indexed_web_access, filters, user_location, and
+  // search_context_size (read out of the shipped 0.147 binary, which contains
+  // no occurrence of `web_search_preview` at all). The tool is declared on the
+  // turn whenever web search is enabled, not only when the model searches, so
+  // the reporter's "running anything" is literal: every turn 400s and the
+  // provider is unusable rather than degraded (#286).
+  //
+  // Deliberately scoped to Meta and not applied everywhere. OpenAI documents
+  // `search_content_types` on `web_search` and *not* on `web_search_preview`,
+  // which is the reverse of what this endpoint enforces, so Meta is running an
+  // older fork of the schema rather than being the strict reader of it.
+  // Stripping the field for every provider would take a documented parameter
+  // away from the responses-native providers that do follow the current spec
+  // (github-copilot, opencode-go-responses), and neither has been observed to
+  // refuse it. A caller that does send Meta a real `web_search_preview` tool
+  // keeps the field, because that is the one tool this endpoint accepts it on.
+  if (provider.id === "meta" && Array.isArray(payload.tools)) {
+    payload.tools = stripSearchContentTypes(payload.tools);
+  }
   if (Array.isArray(payload.messages)) {
     payload.messages = sanitizeChatToolHistory(payload.messages, provider);
   }

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3962,6 +3962,103 @@ test("API forwarder keeps Xiaomi MiMo web search options on chat completions", a
   }
 });
 
+// The exact tool Codex 0.147 serializes when web search is on: `web_search`
+// (the binary contains no occurrence of `web_search_preview`), carrying
+// search_content_types beside the rest of the current hosted-search schema.
+// Meta answers that with HTTP 400 "`tools[].search_content_types` is only
+// supported for web_search_preview tools", which fails every turn (#286).
+const CODEX_WEB_SEARCH_TOOL = Object.freeze({
+  type: "web_search",
+  external_web_access: true,
+  indexed_web_access: true,
+  filters: { allowed_domains: ["example.com"] },
+  search_context_size: "medium",
+  search_content_types: ["text", "image"],
+  user_location: { type: "approximate", country: "US" },
+});
+
+test("API forwarder drops the search_content_types Meta refuses, and only for Meta", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ url: request.url, body: await bodyJson(request) });
+    json(response, 200, {
+      id: "resp_test",
+      object: "response",
+      status: "completed",
+      model: "test",
+      output: [],
+    });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    META_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    META_API_KEY: "TEST_META_API_KEY",
+    OPENCODE_GO_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    OPENCODE_API_KEY: "TEST_OPENCODE_GO_API_KEY",
+    OPENCODE_GO_API_KEY: "TEST_OPENCODE_GO_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const send = async (model, tools) => {
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model, input: "test", tools }),
+    });
+    assert.equal(response.status, 200, forwarder.testErrors());
+    return upstreamRequests.at(-1).body.tools;
+  };
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+
+    // The reported turn: the one refused field goes, the rest of the hosted
+    // search tool and every function tool beside it arrive unchanged. The tool
+    // itself is never dropped -- web search still reaches the model.
+    const shell = { type: "function", name: "shell", parameters: { type: "object" } };
+    const metaTools = await send("meta-muse-spark-1-2-contributor", [
+      CODEX_WEB_SEARCH_TOOL,
+      shell,
+    ]);
+    assert.deepEqual(metaTools, [
+      {
+        type: "web_search",
+        external_web_access: true,
+        indexed_web_access: true,
+        filters: { allowed_domains: ["example.com"] },
+        search_context_size: "medium",
+        user_location: { type: "approximate", country: "US" },
+      },
+      shell,
+    ]);
+
+    // The one tool this endpoint does accept the field on keeps it, so a
+    // caller that speaks Meta's own spelling is not quietly downgraded.
+    const previewTools = await send("meta-muse-spark-1-2-contributor", [
+      { type: "web_search_preview", search_content_types: ["text", "image"] },
+    ]);
+    assert.deepEqual(previewTools, [
+      { type: "web_search_preview", search_content_types: ["text", "image"] },
+    ]);
+
+    // Provider-scoped, not global: OpenAI documents search_content_types on
+    // `web_search`, so the other responses-native providers keep it.
+    const opencodeTools = await send(
+      "responses/opencode-go-responses-gpt-5-6-luna",
+      [CODEX_WEB_SEARCH_TOOL],
+    );
+    assert.deepEqual(opencodeTools, [CODEX_WEB_SEARCH_TOOL]);
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("router strips Fireworks web_search_options on routed and compaction requests", async () => {
   const gatewayRequests = [];
   const gateway = await mockServer(async (request, response) => {


### PR DESCRIPTION
Fixes #286. Every turn against Muse Spark 1.1, 1.2 and 1.2 Contributor was 400ing.

## Root cause

`normalizeBody` in `src/api-forwarder.mjs` — the last hop before the provider — never touched `payload.tools`, so the client's tool list reached Meta verbatim.

The tool carrying the field is **`web_search`**, not `web_search_preview`. Proven off the shipped Codex 0.147 binary: its serde field table reads `web_search | external_web_access | indexed_web_access | filters | user_location | search_context_size | search_content_types`, and `strings | grep -c web_search_preview` returns **0**. Codex never emits the legacy spelling.

Meta is `protocol: "openai-responses"` (`config/meta/meta.json:9`) and its Responses implementation validates the hosted search tool against the legacy `web_search_preview` schema, so it rejects the field.

Codex declares the search tool whenever web search is **enabled**, not only when the model actually searches — which is why the reporter's "running anything" is literal.

## Why provider-scoped, not a general strip

The obvious alternative was to strip `search_content_types` from any tool that is not `web_search_preview`, on the theory that it is only meaningful there. **That theory is backwards.**

OpenAI's current Responses docs list `search_content_types` (`["image","text"]`) as a **`web_search`** parameter, alongside `filters`, `return_token_budget`, `image_settings` and `external_web_access`. `web_search_preview` is the *legacy* tool, documented with only `type` and `sources` and explicitly without `filters`/`return_token_budget`.

So Meta is running an older fork of the schema, not being a strict reader of it. A general strip would remove a documented, spec-granted parameter from every provider for zero proven benefit — and against AGENTS.md's "shape needs that same proof, not a plausible reading."

The fix adds `stripSearchContentTypes()` plus a `provider.id === "meta"` guard, beside the existing Gemini/Fireworks per-provider corrections — the same hop and the same rationale as the qwen38-community tool repairs in #258/#259.

The field is **dropped, not renamed** and not moved onto a synthesized `web_search_preview` tool; that would change which hosted tool the model is offered. The tool itself and all its other settings still reach Meta.

## Blast radius

Only three providers speak `openai-responses` and therefore ever see a raw hosted-tool object: `meta`, `github-copilot`, `opencode-go-responses`. Chat-completions providers never receive it — LiteLLM's Responses→Chat bridge converts the tool list first.

Of the three, only Meta is observed to refuse the field, and the field is spec-valid on `web_search`, so Copilot and opencode-go-responses are deliberately left alone. A test pins that. All three Meta models share the one endpoint and are all fixed by the single guard.

## Web search is preserved

Three assertions in one test:

1. Meta + Codex's real `web_search` tool → `search_content_types` gone; `external_web_access`, `indexed_web_access`, `filters`, `search_context_size`, `user_location` and the sibling function tool all byte-identical; tool not dropped.
2. Meta + a `web_search_preview` tool carrying `search_content_types` → forwarded untouched, since that is the one shape Meta accepts it on.
3. `opencode-go-responses` + the identical `web_search` tool → forwarded untouched.

Non-matching payloads return the original array object, so a request with no such tool is byte-identical.

## Tests

`test/routing.test.mjs` +97 — "API forwarder drops the search_content_types Meta refuses, and only for Meta". Verified genuine: with `src/api-forwarder.mjs` reverted it fails on `+ search_content_types: ['text','image']` in the forwarded tool.

`npm test`: 1635 pass, 0 fail, 12 skipped.

## Known limitation

There is evidence for this one field only. If Meta's schema copy is older in other ways, a second 400 naming a different `tools[]` field is possible — `filters` and `external_web_access` are the likely candidates. Deliberately not pre-emptively stripped, since that would be guessing at a shape rather than correcting an observed rejection.
