### PR TITLE
fix(devin): map every Connect code, and refuse a compressed frame loudly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1205,6 +1205,18 @@ about it.
    can change under a `devin` update. When it does, the symptom is a Connect
    `invalid_argument` on every turn, not a subtle wrong answer — keep it that
    way rather than adding tolerant parsing that would mask a schema change.
+   Two rules make "loudly" mean something. First, a Connect error code must
+   reach the router as the HTTP status the protocol assigns it: the sixteen-code
+   table in `src/connect-stream-audit.mjs` is the single source, imported by the
+   client rather than restated, and a code that fell through to 502 would be
+   read one layer up as a transient fault in the chain and sent again — which is
+   precisely wrong for `unimplemented`, the answer to a service path or method
+   name that drifted. Second, the client asks for
+   `connect-accept-encoding: identity` and refuses a frame that carries the
+   compressed bit anyway (`devin_compressed_frame`). Compressed bytes are not
+   protobuf, so decoding them produces an empty turn or an unactionable wire
+   error; do not add decompression to this transport on the strength of a
+   fixture, because no maintainer can test it against Cascade.
 8. **An operator who never curated a Devin model pays nothing for it.** Unlike
    the three forwarders that always run, `src/devin-cli-forwarder.mjs` is
    spawned only when `MODELS` contains a `devin-cli` model, so an unconfigured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,32 @@
   token, because it is written to be pasted into a public issue.
   `docs/DEVIN-CLI-PROBE.md` is the tester's copy of all of it.
 
+- **The Devin CLI transport now reports a refusal as a refusal.** Its Connect
+  client carried ten of the protocol's sixteen error codes, and the six it did
+  not — `canceled`, `already_exists`, `aborted`, `out_of_range`, `data_loss`,
+  and `unimplemented` — fell through to 502. Every layer above reads a 5xx as a
+  bad moment in the chain rather than an answer: the vision bridge retries it,
+  and Codex spends its own reconnects on it. `unimplemented` is what Cascade
+  answers when the service path or method name has drifted from the binary these
+  schemas were transcribed from, so the one code that can never succeed was the
+  one dressed as worth another try. The client now imports the full table from
+  `src/connect-stream-audit.mjs` instead of restating half of it, so
+  `unimplemented` arrives as 501, `already_exists` and `aborted` as 409,
+  `out_of_range` as 400, and `canceled` as 499 — none of them retryable — on
+  both the HTTP failure path and the end-of-stream terminator.
+- **A compressed Connect frame is no longer a silently empty answer.** Each
+  Connect envelope has a flags byte whose low bit marks the message compressed,
+  and the client ignored it: the frame went to the protobuf decoder, which is
+  not being handed protobuf, and the turn ended with no text and no tool calls
+  or with a wire-type error naming nothing anyone could act on. The client now
+  asks for `connect-accept-encoding: identity` on both call shapes and, if a
+  frame arrives compressed regardless, fails with a named
+  `devin_compressed_frame` (501) instead of guessing — including on the
+  end-of-stream terminator, where a compressed frame would otherwise have read
+  as the empty `{}` that means the turn succeeded. Decompression is deliberately
+  not implemented: no maintainer can reach Cascade to test it, and a compliant
+  server has no reason to compress once it has been told identity.
+
 - **Grok OAuth no longer loses late or custom tool calls.** The forwarder now
   accepts `function_call` and `custom_tool_call` items that first appear in
   `response.output_item.done`, restores final arguments when argument deltas

--- a/docs/DEVIN-CLI-PROBE.md
+++ b/docs/DEVIN-CLI-PROBE.md
@@ -121,7 +121,7 @@ usually a `fix:` line. Those two lines are the useful part — please include th
 | `FAIL live turn … connect-code=invalid_argument` | The request shape is wrong. The upstream's message usually names the offending field — paste it verbatim, it is the single most useful thing in this document. |
 | `FAIL live turn … connect-code=permission_denied` or `failed_precondition` | Often a team setting (`disable_cascade`, `allowed_model_uids`) rather than a bug. Please say which plan you are on. |
 | `FAIL stream framing` | The upstream accepted the request and then sent no message frame. |
-| `FAIL frame compression` | The upstream compressed the stream. This transport cannot decompress and would decode every turn to nothing. |
+| `FAIL frame compression` | The upstream compressed the stream even though both the probe and the transport ask for `connect-accept-encoding: identity`. This transport cannot decompress; it refuses such a frame outright (`devin_compressed_frame`), so every turn would fail loudly rather than answer. Say which encoding the upstream used. |
 | `FAIL stream completeness` | The connection died part-way through a frame. |
 | `FAIL end-of-stream terminator` | A Connect stream reports failure *inside* its last frame, after HTTP 200 has already been sent. This line is that failure. |
 | `FAIL turn produced output` | Frames arrived and decoded to no text, no reasoning and no tool call. Check the `field census` line for `UNKNOWN` entries. |

--- a/src/connect-stream-audit.mjs
+++ b/src/connect-stream-audit.mjs
@@ -1,23 +1,35 @@
-// Connect-protocol stream inspection, kept separate from any Connect client.
+// Connect-protocol facts, owned in one place: the envelope frame layout, the
+// full error-code table, and a scanner that reads a stream without decoding it.
+//
+// The scanner exists for the probe, which must not test a transport with the
+// transport. The constants and the code table are shared with the client in
+// `devin-connect.mjs`, because the alternative -- a second table restated there
+// -- is exactly the drift this module was written to catch. Nothing here
+// imports the client, so the direction stays one-way.
 //
 // A transport reads frames in order to yield messages, and drops everything it
 // does not need: the compression bit, the frames it never completed, the shape
 // of the end-of-stream terminator. Those are exactly the things a probe has to
 // report, because each one has a quiet failure mode:
 //
-//   * A frame flagged compressed and handed straight to a protobuf decoder
-//     decodes to an empty message. No error is raised anywhere; the turn simply
-//     produces no text and no tool calls.
+//   * A frame flagged compressed carries bytes that are not protobuf. Handed
+//     straight to a decoder they yield no fields, or a wire-type error naming
+//     nothing the reader can act on; either way the turn produces no text and
+//     no tool calls. The client refuses such a frame by name and asks for
+//     `connect-accept-encoding: identity` so a compliant server never sends
+//     one.
 //   * A stream that ends mid-frame yields every complete message before it and
 //     then stops, which reads as a short answer.
 //   * A Connect stream reports failure inside the terminator with HTTP 200
 //     already sent, so a client that ignores the terminator reports success.
 //
 // The status table below is the full set of Connect error codes. An incomplete
-// table is not a cosmetic gap: a code that falls through to 502 is treated as a
-// transient upstream fault and retried, and `unimplemented` -- the code an
-// upstream returns when the service path or method name is wrong -- must never
-// be retried, because it will never succeed.
+// table is not a cosmetic gap: a code that falls through lands on 502, which is
+// the first entry in `RETRYABLE_STATUSES` (`upstream-retry.mjs`), is transient
+// to the vision bridge's "any 5xx" rule, and costs Codex one of its own
+// reconnects when relayed. `unimplemented` -- the code an upstream returns when
+// the service path or method name is wrong -- must never arrive dressed that
+// way, because it will never succeed.
 
 export const COMPRESSED_FLAG = 0x01;
 export const END_STREAM_FLAG = 0x02;

--- a/src/devin-connect.mjs
+++ b/src/devin-connect.mjs
@@ -5,10 +5,15 @@
 // sequence of length-prefixed envelopes. That is small enough to implement
 // directly, which keeps the router's dependency list where it is.
 
+import { COMPRESSED_FLAG, END_STREAM_FLAG, connectStatusFor } from "./connect-stream-audit.mjs";
 import { decodeMessage, encodeMessage } from "./protobuf-wire.mjs";
 
 const CONNECT_VERSION = "1";
-const END_STREAM_FLAG = 0x02;
+
+// The client asks for uncompressed envelopes and refuses compressed ones, so
+// there is no `zlib` here and no half-supported encoding list to keep in step
+// with a server nobody has met. See `connectServerStream` for why.
+const ENVELOPE_ENCODING = "identity";
 
 function connectError(message, { status = 502, code = "devin_upstream_error" } = {}) {
   const error = new Error(message);
@@ -17,21 +22,20 @@ function connectError(message, { status = 502, code = "devin_upstream_error" } =
   return error;
 }
 
-// Connect maps its error codes onto HTTP status codes. Preserving the
-// distinction matters upstream of here: the router retries a 429 or a 5xx and
-// must not retry an `invalid_argument`.
-const STATUS_BY_CONNECT_CODE = Object.freeze({
-  unauthenticated: 401,
-  permission_denied: 403,
-  not_found: 404,
-  invalid_argument: 400,
-  failed_precondition: 400,
-  resource_exhausted: 429,
-  unavailable: 503,
-  deadline_exceeded: 504,
-  internal: 502,
-  unknown: 502,
-});
+// The Connect code -> HTTP status table lives in `connect-stream-audit.mjs`,
+// which carries all sixteen codes the protocol defines together with which of
+// them are worth another attempt. It is imported rather than restated because
+// two tables drift, and the half-table that used to live here is what drift
+// looks like: six codes were missing, so a permanent refusal left this module
+// as a 502.
+//
+// 502 is not a neutral default. It is the first entry in
+// `RETRYABLE_STATUSES` (`upstream-retry.mjs`), the vision bridge treats any
+// 5xx as transient and reads the image again, and Codex answers a relayed 5xx
+// by spending one of its own reconnects. None of that can help a request the
+// upstream will refuse identically next time, so `already_exists`, `aborted`,
+// `out_of_range`, `canceled`, and `unimplemented` now leave here wearing
+// statuses that say so.
 
 export function connectAuthorization(token) {
   // Transcribed from the shipped client: the token is repeated either side of
@@ -59,7 +63,7 @@ async function failureFromResponse(response) {
   const code = typeof parsed?.code === "string" ? parsed.code : undefined;
   const message = parsed?.message || body.slice(0, 500) || `HTTP ${response.status}`;
   return connectError(`Devin upstream refused the request: ${message}`, {
-    status: STATUS_BY_CONNECT_CODE[code] || response.status || 502,
+    status: connectStatusFor(code, response.status || 502),
     code: code ? `devin_${code}` : "devin_upstream_error",
   });
 }
@@ -81,6 +85,7 @@ export async function connectUnary({
     headers: {
       "content-type": "application/proto",
       "connect-protocol-version": CONNECT_VERSION,
+      "connect-accept-encoding": ENVELOPE_ENCODING,
       authorization: connectAuthorization(token),
     },
     body: encodeMessage(requestSchema, message),
@@ -101,6 +106,17 @@ function envelope(payload) {
 // Yields decoded response messages until the upstream sends its end-of-stream
 // envelope. A Connect stream reports failure *inside* that final envelope with
 // HTTP 200 already sent, so the terminator is inspected rather than ignored.
+//
+// Envelope compression is refused rather than implemented, and the request says
+// so with `connect-accept-encoding: identity`. Connect allows a message to be
+// compressed independently of the HTTP body, and those bytes are not protobuf:
+// handing them to the decoder ends the turn with no text at all, or with a wire
+// type nobody can act on. Decompressing them instead would mean shipping gzip,
+// br, zstd, snappy, and deflate against a backend no maintainer has ever
+// reached -- untestable code covering a case a compliant server will never
+// produce once it has been told identity. So the transport asks for identity
+// and names the violation if one arrives, which is the answer this provider's
+// rules ask for everywhere else: fail loudly rather than parse tolerantly.
 export async function* connectServerStream({
   baseUrl,
   service,
@@ -118,6 +134,7 @@ export async function* connectServerStream({
     headers: {
       "content-type": "application/connect+proto",
       "connect-protocol-version": CONNECT_VERSION,
+      "connect-accept-encoding": ENVELOPE_ENCODING,
       authorization: connectAuthorization(token),
     },
     body: envelope(encodeMessage(requestSchema, message)),
@@ -142,6 +159,16 @@ export async function* connectServerStream({
       if (buffered.length < length + 5) break;
       const payload = buffered.subarray(5, length + 5);
       buffered = buffered.subarray(length + 5);
+      // Checked before the end-of-stream branch: the terminator carries the
+      // flag too, and a compressed one would otherwise be read as the empty
+      // `{}` that means the turn succeeded.
+      if ((flags & COMPRESSED_FLAG) !== 0) {
+        throw connectError(
+          "Devin upstream sent a compressed Connect frame; this transport asked for identity " +
+            "envelope encoding and cannot decompress one.",
+          { status: connectStatusFor("unimplemented"), code: "devin_compressed_frame" },
+        );
+      }
       if ((flags & END_STREAM_FLAG) !== 0) {
         let terminator;
         try {
@@ -154,7 +181,7 @@ export async function* connectServerStream({
           throw connectError(
             `Devin upstream ended the stream: ${terminator.error.message || code || "unknown error"}`,
             {
-              status: STATUS_BY_CONNECT_CODE[code] || 502,
+              status: connectStatusFor(code),
               code: code ? `devin_${code}` : "devin_upstream_error",
             },
           );

--- a/src/devin-probe-checks.mjs
+++ b/src/devin-probe-checks.mjs
@@ -197,14 +197,15 @@ export function streamFrameChecks({ frames = [], pending = 0, sawEndOfStream = f
   checks.push(
     compressed.length
       ? {
-          // The shipped client sends no `connect-accept-encoding`, so this
-          // should never fire. If it does, the transport hands compressed bytes
-          // to the protobuf decoder and every turn silently produces nothing.
+          // The shipped client asks for `connect-accept-encoding: identity`, so
+          // this should never fire. If it does, the upstream compressed anyway
+          // and every turn ends in the transport's `devin_compressed_frame`
+          // refusal -- loud, but no answer.
           status: "fail",
           name: "frame compression",
-          detail: "the upstream compressed frames; this transport cannot decompress and would decode them to empty messages",
+          detail: "the upstream compressed frames despite connect-accept-encoding: identity; this transport cannot decompress and refuses them",
           observed: `${compressed.length} of ${frames.length} frames carry the compressed flag`,
-          fix: "Report this. The transport must send connect-accept-encoding: identity or learn to decompress.",
+          fix: "Report this, with the encoding the upstream used. The transport would have to learn to decompress.",
         }
       : { status: "pass", name: "frame compression", detail: "no frame carried the compressed flag" },
   );

--- a/test/devin-connect.test.mjs
+++ b/test/devin-connect.test.mjs
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { gzipSync } from "node:zlib";
 
+import { CONNECT_CODE_STATUS } from "../src/connect-stream-audit.mjs";
 import { connectAuthorization, connectServerStream, connectUnary } from "../src/devin-connect.mjs";
 import { encodeMessage } from "../src/protobuf-wire.mjs";
+import { isRetryableStatus } from "../src/upstream-retry.mjs";
 
 const SCHEMA = { text: { no: 1, type: "string" } };
 
@@ -143,6 +146,167 @@ test("maps an unauthenticated rejection to 401 so the caller is told to sign in 
     (error) => {
       assert.equal(error.status, 401);
       assert.equal(error.code, "devin_unauthenticated");
+      return true;
+    },
+  );
+});
+
+// -- the full Connect code table ---------------------------------------------
+
+const refuseUnary = (code) =>
+  connectUnary({
+    baseUrl: "https://x", service: "S", method: "M", token: "t",
+    requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+    fetchImpl: async () => ({
+      ok: false,
+      status: 500,
+      text: async () => JSON.stringify({ code, message: "refused" }),
+    }),
+  });
+
+const refuseStream = async (code) => {
+  const terminator = new TextEncoder().encode(JSON.stringify({ error: { code, message: "refused" } }));
+  for await (const _ of connectServerStream({
+    baseUrl: "https://x", service: "S", method: "M", token: "t",
+    requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+    fetchImpl: async () => streamResponse([envelope(terminator, 2)]),
+  })) void _;
+};
+
+// A code the table does not carry falls through to the HTTP status the upstream
+// happened to send, which for a Connect failure is routinely a 5xx. Half the
+// spec's codes were missing, so a permanent refusal arrived wearing a transient
+// status. The mapping is not decoration: it decides whether anything above this
+// module sends the same doomed request again.
+test("every Connect error code the spec defines has a status of its own", async () => {
+  for (const [code, expected] of Object.entries(CONNECT_CODE_STATUS)) {
+    await assert.rejects(refuseUnary(code), (error) => {
+      assert.equal(error.status, expected, `unary ${code}`);
+      assert.equal(error.code, `devin_${code}`);
+      return true;
+    });
+    await assert.rejects(refuseStream(code), (error) => {
+      assert.equal(error.status, expected, `stream terminator ${code}`);
+      assert.equal(error.code, `devin_${code}`);
+      return true;
+    });
+  }
+});
+
+// `unimplemented` is what an upstream answers when the service path or the
+// method name is wrong -- a transcription that drifted, which the next attempt
+// reproduces exactly. It must never leave here wearing a status the retry
+// vocabulary reads as "the gateway had a bad moment".
+const PERMANENT_CODES = [
+  "unimplemented",
+  "invalid_argument",
+  "permission_denied",
+  "unauthenticated",
+  "not_found",
+  "failed_precondition",
+  "out_of_range",
+  "already_exists",
+  "canceled",
+];
+
+test("a refusal that can never succeed does not carry a retryable status", async () => {
+  for (const code of PERMANENT_CODES) {
+    for (const [shape, refuse] of [["unary", refuseUnary], ["stream terminator", refuseStream]]) {
+      await assert.rejects(refuse(code), (error) => {
+        assert.equal(
+          isRetryableStatus(error.status),
+          false,
+          `${shape} ${code} mapped to ${error.status}, which the router's retry table treats as transient`,
+        );
+        return true;
+      });
+    }
+  }
+});
+
+test("an unknown code still falls back to the status the upstream sent", async () => {
+  await assert.rejects(
+    connectUnary({
+      baseUrl: "https://x", service: "S", method: "M", token: "t",
+      requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+      fetchImpl: async () => ({
+        ok: false,
+        status: 418,
+        text: async () => JSON.stringify({ code: "teapot", message: "no" }),
+      }),
+    }),
+    (error) => {
+      assert.equal(error.status, 418);
+      assert.equal(error.code, "devin_teapot");
+      return true;
+    },
+  );
+});
+
+// -- the envelope compression bit --------------------------------------------
+
+test("asks for identity envelope encoding on both call shapes", async () => {
+  let unaryInit;
+  await connectUnary({
+    baseUrl: "https://x", service: "S", method: "M", token: "t",
+    requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+    fetchImpl: async (_url, init) => {
+      unaryInit = init;
+      return { ok: true, status: 200, arrayBuffer: async () => encodeMessage(SCHEMA, {}).buffer };
+    },
+  });
+  assert.equal(unaryInit.headers["connect-accept-encoding"], "identity");
+
+  let streamInit;
+  for await (const _ of connectServerStream({
+    baseUrl: "https://x", service: "S", method: "M", token: "t",
+    requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+    fetchImpl: async (_url, init) => {
+      streamInit = init;
+      return streamResponse([envelope(new TextEncoder().encode("{}"), 2)]);
+    },
+  })) void _;
+  assert.equal(streamInit.headers["connect-accept-encoding"], "identity");
+});
+
+// A compressed frame handed straight to the protobuf decoder is the worst
+// available outcome: the bytes are not protobuf, so the turn either ends with
+// no text at all or dies quoting a wire type nobody can act on. Neither says
+// what happened. Name it instead.
+test("refuses a compressed message frame by name instead of decoding the bytes", async () => {
+  const compressed = new Uint8Array(gzipSync(Buffer.from(encodeMessage(SCHEMA, { text: "hidden" }))));
+  const seen = [];
+  await assert.rejects(
+    (async () => {
+      for await (const message of connectServerStream({
+        baseUrl: "https://x", service: "S", method: "M", token: "t",
+        requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+        fetchImpl: async () => streamResponse([envelope(compressed, 1), envelope(new Uint8Array(0), 2)]),
+      })) seen.push(message);
+    })(),
+    (error) => {
+      assert.equal(error.code, "devin_compressed_frame");
+      assert.equal(error.status, 501);
+      assert.equal(isRetryableStatus(error.status), false);
+      assert.match(error.message, /compress/i);
+      return true;
+    },
+  );
+  assert.deepEqual(seen, []);
+});
+
+test("refuses a compressed end-of-stream frame rather than reading it as success", async () => {
+  const compressed = new Uint8Array(gzipSync(Buffer.from("{}")));
+  await assert.rejects(
+    (async () => {
+      for await (const _ of connectServerStream({
+        baseUrl: "https://x", service: "S", method: "M", token: "t",
+        requestSchema: SCHEMA, responseSchema: SCHEMA, message: {},
+        fetchImpl: async () => streamResponse([envelope(compressed, 3)]),
+      })) void _;
+    })(),
+    (error) => {
+      assert.equal(error.code, "devin_compressed_frame");
       return true;
     },
   );


### PR DESCRIPTION
Two defects in the Connect client that landed with #271, both surfaced by the review that produced #285's probe.

## A half-filled Connect status table

`src/devin-connect.mjs` mapped 10 of the protocol's 16 error codes. The six it did not carry — `canceled`, `already_exists`, `aborted`, `out_of_range`, `data_loss`, `unimplemented` — fell through to whatever HTTP status the upstream happened to send, and on the end-of-stream terminator path to a hard-coded `502`.

502 is not a neutral default. It is the first entry in `RETRYABLE_STATUSES`; the vision bridge treats any 5xx as transient and reads the image again (`src/vision-bridge.mjs:956`); and per `src/upstream-retry.mjs`'s own header, Codex answers a relayed 5xx by spending one of its ~five reconnects. `unimplemented` is what Cascade returns when a service path or method name has drifted from the binary these schemas were transcribed from — so the one code that can never succeed was the one dressed as worth another try.

**Worth stating precisely, because the original report overreached:** the router itself does **not** retry this. `src/router.mjs:2508` passes `retries: route ? 0 : undefined`, so routed providers get zero retries, and `classifyRoutedFailure` (`src/model-failover.mjs:84`) returns `{swap:false}` for anything ≥ 500. LiteLLM sets no `num_retries` and `api-forwarder.mjs` has no retry logic. The cost is paid in the vision bridge and by the client above the router, not in a router-side retry of a routed turn.

The client now imports the full 16-code table from `src/connect-stream-audit.mjs` rather than restating half of it — two tables drift, and the half-table is what drift looks like. `unimplemented` arrives as 501, `already_exists` and `aborted` as 409, `out_of_range` as 400, `canceled` as 499, on both the HTTP failure path and the terminator.

Two consequences worth knowing rather than discovering later:
- 501 is still ≥ 500, so it does not escape the vision bridge's coarse transient heuristic. Not widened here; that heuristic is a separate call.
- 501 is absent from `PROBE_STATUSES_ABOUT_THE_ACCOUNT` in `src/subagent-verify.mjs`, so an `unimplemented` during subagent verification now condemns the slot rather than clearing it. Arguably correct — it will never succeed — but it is a behaviour change.

## A compressed frame decoded to nothing anyone could act on

Each Connect envelope has a flags byte whose low bit marks the message compressed. `connectServerStream` read that byte only to test the end-of-stream bit.

Measured against the real decoder rather than assumed: gzip bytes raise `protobuf: unsupported wire type 7`, deflate 6, brotli 3 — so it is not always silent, but it is always unactionable. And a compressed **terminator** decodes to the empty `{}` that means the turn *succeeded*, which is silent. Either way the operator sees a model that answered nothing.

The client sent no `connect-accept-encoding` at all, so a compliant server had no instruction — a compressed frame is server misbehaviour, but responding to it this way is ours. (The probe from #285 already sends `identity`; the client did not.) Both call shapes now ask for identity, and a frame carrying the compressed bit anyway fails as `devin_compressed_frame` (501), checked **before** the end-of-stream branch so a compressed terminator cannot read as success.

Decompression is deliberately not implemented: no maintainer can reach Cascade to test it, Connect permits five encodings and supporting one while advertising identity is incoherent, and AGENTS.md rule 7 for this provider already mandates failing loudly over parsing tolerantly.

## Tests

Six new cases in `test/devin-connect.test.mjs`, all constructing frames and failures directly since these modules have no live-server coverage: every spec code through both failure paths, a retriability assertion running the permanent codes through `isRetryableStatus`, identity advertisement on both call shapes, and compressed data and terminator frames.

Reverting `src/devin-connect.mjs` to main fails 5 of that file's 13 tests. Full suite: **1738 pass, 0 fail, 12 skipped**, run twice clean — the known `mid-failover` flake passed both times.

The probe's output contract is unchanged: the `frame compression` check keeps its name, status, condition and `observed` line. Only prose this change made false was corrected — in the check text, `docs/DEVIN-CLI-PROBE.md`, and `connect-stream-audit.mjs`'s header claim that it was "kept separate from any Connect client".
