### PR TITLE
fix(devin-probe): keep the spawn options a Windows shim needs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -448,7 +448,12 @@ and every client saw a bare "Connection error" naming nothing.
    used to end the service before it spawned anything, with an EINVAL naming
    neither the file nor the reason. Never reintroduce a bare
    `spawn(command, args)` in `start.mjs`; `test/gateway-restart.test.mjs` guards
-   the shape, because the behaviour itself cannot be exercised on POSIX. Note
+   the shape, because the behaviour itself cannot be exercised on POSIX. All
+   three fields of the result are load-bearing, `options` included: for a batch
+   shim it carries `windowsVerbatimArguments`, without which Node re-quotes a
+   command line that is already escaped for cmd.exe. A call site that spreads
+   only `command` and `args` is a Windows bug that POSIX CI cannot see — it was
+   how `devinCliVersion` came to report "unknown" for an installed CLI. Note
    the one cost of the batch path: the service then holds the `cmd.exe` hop
    rather than the gateway, so a signal reaches the hop and the real process is
    orphaned. That is strictly better than not starting at all, and it is another

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+- **The Devin CLI probe no longer reports "unknown" for a Devin CLI that is
+  installed and working.** `devinCliVersion` was the one call site out of
+  twenty that took `command` and `args` from `spawnableCommand` and threw away
+  the third field. For a Windows `.cmd` shim — which is what npm installs —
+  that field carries `windowsVerbatimArguments`, and without it Node re-quotes
+  a command line that has already been escaped for cmd.exe. The version came
+  back empty and the probe printed `unknown`, which reads as "you do not have
+  the CLI" to the one person running a probe written specifically to stop that
+  misdiagnosis. The probe's own convention — every outside edge injectable — now
+  covers this edge too, so the options, the cmd.exe hop, and the POSIX
+  pass-through are all asserted on every platform rather than only on Windows.
+
+- **The Windows command-line escaping is now pinned against the hazards that
+  could not previously be caught off Windows.** `spawnableCommand` builds one
+  cmd.exe command line, and until now the only proof it was armed correctly was
+  an end-to-end test that runs a real shim and therefore skips everywhere else.
+  A pipe, a redirect, a `!`, and a trailing backslash before a closing quote —
+  the four that would end the quoted span or start a second command if the
+  escaping were wrong — are now asserted in rendered form on every platform,
+  and added to the set the Windows job runs for real. No behaviour changed: the
+  escaping already matched `cross-spawn` character for character.
+
 - **Running the test suite no longer resets your subagents.**
   `test/state-owner.test.mjs` ran the real `src/catalog.mjs` against a scratch
   state directory while inheriting the developer's own `CODEX_HOME`. No

--- a/src/devin-cli-probe.mjs
+++ b/src/devin-cli-probe.mjs
@@ -92,12 +92,28 @@ async function loadProvider() {
   };
 }
 
-function devinCliVersion() {
-  const binary = commandOnPath("devin");
+// The third element of a `spawnableCommand` result is not optional decoration.
+// For a Windows `.cmd`/`.bat` shim it carries `windowsVerbatimArguments`, which
+// is what stops Node from re-quoting a line that has already been escaped for
+// cmd.exe. Dropping it hands cmd.exe a doubly-quoted command line, and the
+// probe reports "unknown" for a Devin CLI that is installed and working --
+// the exact misreading this whole module exists to avoid. Every other call
+// site in the repository spreads it; this one did not.
+export function devinCliVersion({
+  spawnSyncImpl = spawnSync,
+  lookUp = commandOnPath,
+  platform = process.platform,
+} = {}) {
+  const binary = lookUp("devin", { platform });
   if (!binary) return "not on PATH";
   try {
-    const { command, args } = spawnableCommand(binary, ["--version"]);
-    const result = spawnSync(command, args, { encoding: "utf8", timeout: 15_000, windowsHide: true });
+    const { command, args, options } = spawnableCommand(binary, ["--version"], platform);
+    const result = spawnSyncImpl(command, args, {
+      ...options,
+      encoding: "utf8",
+      timeout: 15_000,
+      windowsHide: true,
+    });
     const text = `${result.stdout || ""}${result.stderr || ""}`.trim();
     return text.split("\n")[0]?.slice(0, 120) || "unknown";
   } catch {

--- a/test/devin-cli-probe.test.mjs
+++ b/test/devin-cli-probe.test.mjs
@@ -10,7 +10,7 @@ import {
   parseEndStreamPayload,
 } from "../src/connect-stream-audit.mjs";
 import { DEFAULT_MAX_TOKENS } from "../src/devin-probe-checks.mjs";
-import { runProbe } from "../src/devin-cli-probe.mjs";
+import { devinCliVersion, runProbe } from "../src/devin-cli-probe.mjs";
 
 // The provider's own modules land with the Devin CLI branch. The probe takes
 // them by injection so its wiring -- which stage runs, which check fires on
@@ -534,4 +534,51 @@ test("every failure the checks can emit is explained in the guide", () => {
 test("the guide is reachable from the README index rather than only from a link someone remembers", () => {
   const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
   assert.match(readme, /\(docs\/DEVIN-CLI-PROBE\.md\)/);
+});
+
+// A `.cmd` shim is what npm installs on Windows, and `spawnableCommand` answers
+// for one with `windowsVerbatimArguments` set. This call site used to drop the
+// options object, so Node re-quoted a command line that was already escaped for
+// cmd.exe and the version read back empty -- reported as "unknown" for a CLI
+// that was installed and working, which is precisely the kind of misdiagnosis
+// this probe is written to prevent.
+test("the version probe keeps the spawn options a Windows shim needs", () => {
+  let seen;
+  const version = devinCliVersion({
+    platform: "win32",
+    lookUp: () => "C:\\Users\\ann\\AppData\\Roaming\\npm\\devin.cmd",
+    spawnSyncImpl: (command, args, options) => {
+      seen = { command, args, options };
+      return { stdout: "devin 1.2.3\n", stderr: "" };
+    },
+  });
+  assert.equal(version, "devin 1.2.3");
+  assert.equal(seen.options.windowsVerbatimArguments, true);
+  // The cmd.exe hop is still the one spawnableCommand built, not a raw shim.
+  assert.deepEqual(seen.args.slice(0, 3), ["/d", "/s", "/c"]);
+  assert.match(seen.args[3], /devin\.cmd --version"$/);
+  // Options the probe sets itself are not lost to the spread either.
+  assert.equal(seen.options.encoding, "utf8");
+  assert.equal(seen.options.windowsHide, true);
+});
+
+test("a Devin CLI that is not on PATH is reported as such rather than as unknown", () => {
+  assert.equal(devinCliVersion({ lookUp: () => undefined }), "not on PATH");
+});
+
+// A POSIX binary is pass-through: no cmd.exe, no options, nothing added.
+test("the version probe spawns a plain binary directly", () => {
+  let seen;
+  devinCliVersion({
+    platform: "linux",
+    lookUp: () => "/usr/local/bin/devin",
+    spawnSyncImpl: (command, args, options) => {
+      seen = { command, args, options };
+      return { stdout: "devin 9.9.9", stderr: "" };
+    },
+  });
+  assert.equal(seen.command, "/usr/local/bin/devin");
+  assert.deepEqual(seen.args, ["--version"]);
+  assert.equal(seen.options.windowsVerbatimArguments, undefined);
+  assert.equal(seen.options.shell, undefined);
 });

--- a/test/spawnable-command.test.mjs
+++ b/test/spawnable-command.test.mjs
@@ -145,6 +145,17 @@ const TRICKY_ARGUMENTS = [
   "a&b",
   "100%",
   "caret^value",
+  // A pipe and a redirect are the two that would hand cmd.exe a second command
+  // rather than an argument if the escaping were wrong, so they belong in the
+  // set that is run for real rather than only rendered.
+  "a|b",
+  "a>b<c",
+  // `!` only expands under `cmd /V:ON`, which this module never asks for --
+  // pinned so a future flag change cannot quietly turn it into an expansion.
+  "bang!value",
+  // A trailing backslash is the classic Windows argv hazard: unescaped it
+  // escapes the closing quote and swallows the rest of the command line.
+  "C:\\dir with space\\",
 ];
 
 // Deliberately awkward, and all of it legal on Windows: the runner's own temp
@@ -250,6 +261,59 @@ test("only an npm cmd-shim under node_modules/.bin takes the second escape layer
   assert.equal(needsDoubleEscape("C:\\p\\node_modules\\.bin\\codex.CMD"), true);
   assert.equal(needsDoubleEscape("C:\\Users\\ann\\AppData\\Roaming\\npm\\codex.cmd"), false);
   assert.equal(needsDoubleEscape("C:\\tools\\codex.cmd"), false);
+});
+
+// The end-to-end tests above are the ones that settle the question, but they
+// only run on Windows. These pin the rendered form of each classic cmd.exe
+// hazard on every platform, so a change to the escaping is caught by the Linux
+// and macOS runs too instead of waiting for a Windows job.
+test("every cmd.exe metacharacter is rendered as data, not as syntax", () => {
+  const escapes = {
+    // A pipe or a redirect is the pair that would start a second command.
+    "a|b": '^"a^|b^"',
+    "a>b<c": '^"a^>b^<c^"',
+    "a&b": '^"a^&b^"',
+    // `^` itself has to survive one round of caret-stripping.
+    "a^b": '^"a^^b^"',
+    // Delayed expansion is never enabled, and `!` is escaped regardless.
+    "bang!value": '^"bang^!value^"',
+    "100%": '^"100^%^"',
+    // A quote is escaped for the child's parser and armed against cmd.exe.
+    'say "hi"': '^"say^ \\^"hi\\^"^"',
+    // A trailing backslash is doubled so it cannot escape the closing quote
+    // and swallow the rest of the command line.
+    "C:\\dir with space\\": '^"C:\\dir^ with^ space\\\\^"',
+    // No metacharacter and no space means nothing to escape, trailing
+    // backslash included -- there is no quote for it to run into.
+    "C:\\dir\\": "C:\\dir\\",
+    // An empty argument still has to arrive as an empty argument.
+    "": '^"^"',
+  };
+  for (const [input, expected] of Object.entries(escapes)) {
+    assert.equal(escapeWindowsShellArgument(input), expected, `escaping ${JSON.stringify(input)}`);
+  }
+});
+
+test("a hazardous argument cannot break out of the command line it is placed in", () => {
+  // The whole line, not just the argument: this is the string cmd.exe is
+  // handed, and the only quotes it may act on are the outermost pair.
+  const line = spawnableCommand(
+    "C:\\npm\\devin.cmd",
+    ["a|b", "C:\\dir with space\\", "& shutdown /s"],
+    "win32",
+  ).args[3];
+  assert.ok(line.startsWith('"C:\\npm\\devin.cmd '), line);
+  assert.ok(line.endsWith('"'), line);
+  // `/s` makes cmd.exe strip only the outermost quote pair and take the rest
+  // verbatim, so the characters that could end that span or start a second
+  // command must all be caret-armed inside it. Spaces are the one exception:
+  // a bare space is the argument separator, and any space *within* an argument
+  // is armed by the check above.
+  const interior = line.slice(1, -1);
+  for (const [index, character] of [...interior].entries()) {
+    if (!/["&|<>]/.test(character)) continue;
+    assert.equal(interior[index - 1], "^", `unarmed ${character} at ${index} in ${interior}`);
+  }
 });
 
 test("an ordinary token is passed through bare, so a shim's %1 still matches", () => {


### PR DESCRIPTION
## The bug

`devinCliVersion` was the one call site out of twenty that destructured `command` and `args` off a `spawnableCommand` result and threw away the third field.

For a Windows `.cmd` shim — what npm installs — that field carries `windowsVerbatimArguments`, and without it Node re-quotes a command line that has already been escaped for cmd.exe. The version reads back empty and the probe prints `unknown`, which reads as "you do not have the CLI" to the one person running a probe written specifically to stop that misdiagnosis.

POSIX CI cannot see this class of bug, so the probe's own convention — every outside edge injectable — now covers this edge too (`spawnSyncImpl`, `lookUp`, `platform`). The options, the cmd.exe hop, and the POSIX pass-through are asserted on every platform.

All twenty call sites were audited; this was the only one.

## Escaping now pinned off Windows

`spawnableCommand` builds one cmd.exe command line, and the only proof it was armed correctly was an end-to-end test that runs a real shim and therefore skips everywhere else.

A pipe, a redirect, a `!`, and a trailing backslash before a closing quote — the four that would end the quoted span or start a second command if the escaping were wrong — are now asserted in rendered form on every platform, and added to the set the Windows job runs for real:

| input | rendered |
|---|---|
| `a\|b` | `^"a^\|b^"` |
| `a>b<c` | `^"a^>b^<c^"` |
| `bang!value` | `^"bang^!value^"` |
| `C:\dir with space\` | `^"C:\dir^ with^ space\\^"` (trailing backslash doubled) |
| `C:\dir\` | bare (nothing to escape) |
| `` (empty) | `^"^"` |

Plus a whole-line invariant: no unarmed `"`, `&`, `|`, `<`, `>` inside the outer quote pair.

**No behaviour changed there.** The escaping already matched `cross-spawn` character for character — verified by diff. `src/spawnable-command.mjs` is untouched, including its CVE-2024-27980 `.cmd` handling and the `where.exe` shim-ordering fix.

## On CodeQL alerts #36 and #40

Both are `js/shell-command-injection-from-environment`, and both are false positives against the query's own documented fix (`execFileSync(cmd, args)`) — which is what this code already does. Reading the SARIF dataflow rather than the alert titles:

- **#36's source is `SOURCE_ROOT`** (`src/paths.mjs:45`), not an operator-set binary override, and it lands in the **args** of `spawn(process.execPath, [...])`. Node is never a `.cmd`, so `spawnableCommand` returns pure pass-through with `options: {}` and there is no cmd.exe on that path on any platform.
- **#40's four reported flows never reach `devin-cli-probe.mjs`** — they all terminate inside `spawnable-command.mjs:136`. The alert is *located* at this call site only because CodeQL reports a shared helper's sink at every caller.

The one branch that genuinely builds a shell string (Windows `.cmd`) is guarded on both sides: `assertSpawnablePath` rejects `" < > | ? *` and control characters outright, and the escaping is byte-identical to `cross-spawn`'s. `MODEL_ROUTER_LITELLM_BIN`, `CODEX_ROUTER_SOURCE_ROOT` and `PATH` are all same-principal — anyone who can set them already chooses which program runs, so pointing them at a malicious binary is strictly easier than engineering a quoting escape. No privilege boundary is crossed.

No code change can clear them: `cmd /c` accepts only a string, so the Windows branch must concatenate, and the taint is the program's own install directory flowing into its own arguments. Nineteen instances of this identical rule and shape are already dismissed as won't-fix (#13–#35, rationale in #186); these two are new call sites of the same helper and take the same dismissal.

## Test plan

- [x] Full `npm test` — 1757 tests, 1745 pass, 0 fail, 12 skipped
- [x] New quoting tests pass on macOS (platform-independent by design)
- [ ] Windows CI job green — it runs `|`, `>`/`<`, `!`, and the trailing backslash through a real `.cmd` and npm shim for the first time
