### PR TITLE
fix(test): stop three flakes, and make a forwarder that cannot bind say so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@
   with the state, and a guard in the same file fails if any test spawns the
   catalog without doing so. If your routed agents are already missing, one
   catalog refresh from the owning checkout restores them.
+- **A forwarder that cannot bind its port now says so.** The four forwarders
+  the service starts — `kimi-oauth`, `api-forwarder`, `grok-oauth`, and
+  `devin-cli` — called `listen` with no `'error'` handler, so a port already in
+  use killed the process with Node's unhandled-`'error'` crash dump: `throw er`
+  and a libuv stack, in a log the four of them share, naming neither the
+  forwarder nor the port. Startup then reported only that *some* forwarder had
+  exited before becoming healthy. Each one now reports the bind failure the way
+  the router already did since #171 — one line naming itself, the address, and
+  the reason — and exits with the router's own listen-failure codes (98 for
+  `EADDRINUSE`, 97 for `EACCES`, 96 otherwise), so one line in the service log
+  classifies the death for a supervisor and a human alike.
 
 - **GPT-5.6 Sol can now run at the 1M context window OpenAI documents for it.**
   The catalog Codex ships declares 272,000 tokens against a documented

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -7,6 +7,7 @@ import {
   httpErrorStatus,
   pipeResponse,
   readRequestBody,
+  reportListenFailure,
   requireInternalAuth,
   writeJson,
 } from "./http-utils.mjs";
@@ -1053,6 +1054,7 @@ const server = http.createServer((request, response) => {
 });
 
 applyKeepAliveTimeouts(server);
+reportListenFailure(server, { label: "api-forwarder", host: LISTEN_HOST, port: LISTEN_PORT });
 server.listen(LISTEN_PORT, LISTEN_HOST, () => {
   console.error("[api-forwarder] listening");
 });

--- a/src/devin-cli-forwarder.mjs
+++ b/src/devin-cli-forwarder.mjs
@@ -8,6 +8,7 @@ import {
   formatErrorChain,
   httpErrorStatus,
   readRequestBody,
+  reportListenFailure,
   requireInternalAuth,
   writeJson,
 } from "./http-utils.mjs";
@@ -307,6 +308,7 @@ if (isMain) {
   });
 
   applyKeepAliveTimeouts(server);
+  reportListenFailure(server, { label: "devin-cli", host: LISTEN_HOST, port: LISTEN_PORT });
   server.listen(LISTEN_PORT, LISTEN_HOST, () => {
     console.error("[devin-cli] listening");
   });

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -10,6 +10,7 @@ import {
   formatErrorChain,
   httpErrorStatus,
   readRequestBody,
+  reportListenFailure,
   requireInternalAuth,
   writeJson,
 } from "./http-utils.mjs";
@@ -508,6 +509,7 @@ if (isMain) {
   });
 
   applyKeepAliveTimeouts(server);
+  reportListenFailure(server, { label: "grok-oauth", host: LISTEN_HOST, port: LISTEN_PORT });
   server.listen(LISTEN_PORT, LISTEN_HOST, () => {
     console.error("[grok-oauth] listening");
   });

--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -50,6 +50,41 @@ export function applyKeepAliveTimeouts(server) {
   return server;
 }
 
+// A `listen` that fails emits `'error'`, and with no handler Node rethrows it
+// from the event loop: the log gets `node:events:487 / throw er; // Unhandled
+// 'error' event` and a libuv stack, with the *label of the process that died
+// nowhere in it. Every forwarder here is spawned by start.mjs with inherited
+// stdio into one shared stream, so an unlabelled crash cannot even be
+// attributed to a forwarder -- a real Windows CI failure (#271's gating test)
+// showed only `EADDRINUSE 127.0.0.1:22624` and left which of the four had
+// died an open question.
+//
+// `src/router.mjs` has carried its own copy of this since #171 for the same
+// reason. This is that treatment, shared, so the forwarders name themselves
+// and the port they wanted. The exit codes match the router's, so one line in
+// the service log classifies the death for a supervisor and a human alike.
+export function reportListenFailure(server, { label, host, port }) {
+  server.on("error", (error) => {
+    if (error?.code === "EADDRINUSE") {
+      console.error(
+        `[${label}] cannot listen: ${host}:${port} is already in use. Another instance or an unrelated process holds it; stop that process, then start the service again.`,
+      );
+      process.exit(98);
+    }
+    if (error?.code === "EACCES") {
+      console.error(`[${label}] cannot listen: permission denied binding ${host}:${port}.`);
+      process.exit(97);
+    }
+    console.error(
+      `[${label}] server error: ${
+        error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+      }${error?.code ? ` (${error.code})` : ""}`,
+    );
+    process.exit(96);
+  });
+  return server;
+}
+
 export async function readRequestBody(request) {
   const chunks = [];
   let total = 0;

--- a/src/oauth-forwarder.mjs
+++ b/src/oauth-forwarder.mjs
@@ -7,6 +7,7 @@ import {
   httpErrorStatus,
   pipeResponse,
   readRequestBody,
+  reportListenFailure,
   requireInternalAuth,
   writeJson,
 } from "./http-utils.mjs";
@@ -253,6 +254,7 @@ const server = http.createServer((request, response) => {
 });
 
 applyKeepAliveTimeouts(server);
+reportListenFailure(server, { label: "kimi-oauth", host: LISTEN_HOST, port: LISTEN_PORT });
 server.listen(LISTEN_PORT, LISTEN_HOST, () => {
   console.error("[kimi-oauth] listening");
 });

--- a/test/devin-forwarder-gating.test.mjs
+++ b/test/devin-forwarder-gating.test.mjs
@@ -70,7 +70,18 @@ async function squat(port) {
   // the port being unavailable is meant to look like.
   server.on("connection", (socket) => socket.destroy());
   await new Promise((resolve, reject) => {
-    server.once("error", reject);
+    // Named, because this bind failing is a failure of the *fixture*, not of
+    // the gate under test, and the two read identically in CI otherwise: both
+    // arrive as `EADDRINUSE 127.0.0.1:<port>` with nothing saying which end
+    // wanted the port.
+    server.once("error", (error) =>
+      reject(
+        new Error(
+          `the test could not hold 127.0.0.1:${port} for the Devin forwarder to collide with: ${error.code || error.message}`,
+          { cause: error },
+        ),
+      ),
+    );
     server.listen(port, "127.0.0.1", resolve);
   });
   return {
@@ -146,9 +157,35 @@ async function runStartup({ curatedDevinModel = false, occupyDevinPort = false }
     // after this function returns, by which point it is gone either way.
     return { exit, errors, devinPort, squatterHeldPort: squatter ? squatter.listening() : undefined };
   } finally {
-    if (child.exitCode === null && child.signalCode === null) child.kill("SIGTERM");
+    // start.mjs writes into `stateDir` and re-creates it on the way (every
+    // state writer here does `mkdirSync` with `recursive` before it appends),
+    // so removing the tree while it is still winding down races its own
+    // teardown: `rmSync` unlinks the children, the child re-creates one, and
+    // the final `rmdir` fails with ENOTEMPTY. Wait for it to be gone first.
+    await stopChild(child);
     if (squatter) await squatter.close();
     rmSync(rootDir, { recursive: true, force: true });
+  }
+}
+
+// SIGTERM is not a signal on Windows: Node emulates it with TerminateProcess,
+// so a process that is already exiting on its own may never be reachable. Fall
+// back to SIGKILL rather than waiting out a run.
+async function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  const exited = new Promise((resolve) => child.once("exit", resolve));
+  let hardStop;
+  await Promise.race([
+    exited,
+    new Promise((resolve) => {
+      hardStop = setTimeout(resolve, 5_000);
+    }),
+  ]);
+  clearTimeout(hardStop);
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+    await exited;
   }
 }
 

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -860,6 +860,17 @@ test("a non-streaming turn fails over the same way", async () => {
 
 test("a client that leaves mid-failover does not hang or crash the router", async () => {
   let fallbackStarted = 0;
+  // Resolved the instant the fallback hop reaches the gateway. The abort has to
+  // land *during* that hop, and the only honest way to know the hop is in
+  // flight is to be told by the end that received it. A wall-clock delay only
+  // guesses at it: on a loaded machine the router had not finished the 429 and
+  // reopened against the fallback before the guess expired, so the caller left
+  // before there was a failover to leave, and the run failed on
+  // `fallbackStarted >= 1` roughly one time in five.
+  let announceFallback;
+  const fallbackInFlight = new Promise((resolve) => {
+    announceFallback = resolve;
+  });
   const gw = await gateway(async (request, response) => {
     const body = await bodyJson(request);
     if (body.model === PRIMARY.gatewayModel) {
@@ -872,8 +883,11 @@ test("a client that leaves mid-failover does not hang or crash the router", asyn
       return;
     }
     // The fallback is slow, so the abort lands while the hop is in flight --
-    // the window the failover loop has to notice the caller is gone.
+    // the window the failover loop has to notice the caller is gone. The hold
+    // is far longer than the abort needs, so the abort is inside it whatever
+    // the machine is doing.
     fallbackStarted += 1;
+    announceFallback();
     setTimeout(() => {
       if (response.writableEnded) return;
       response.writeHead(200, { "Content-Type": "text/event-stream" });
@@ -885,6 +899,7 @@ test("a client that leaves mid-failover does not hang or crash the router", asyn
   try {
     await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
     const base = new URL(`${callerBaseUrl(routerPort, CALLER_KEY)}/responses`);
+    let leave;
     const aborted = new Promise((resolve) => {
       const outbound = http.request(
         {
@@ -898,11 +913,23 @@ test("a client that leaves mid-failover does not hang or crash the router", asyn
       );
       outbound.on("error", () => resolve());
       outbound.end(JSON.stringify(TURN_BODY));
-      setTimeout(() => {
+      leave = () => {
         outbound.destroy();
         resolve();
-      }, 800);
+      };
     });
+    // Leave as soon as the fallback hop is on the gateway's floor. The deadline
+    // is only there so a router that never gets that far fails on the assertion
+    // below rather than hanging the run.
+    let deadline;
+    await Promise.race([
+      fallbackInFlight,
+      new Promise((resolve) => {
+        deadline = setTimeout(resolve, 20_000);
+      }),
+    ]);
+    clearTimeout(deadline);
+    leave();
     await aborted;
 
     // The router must still be serving, and a later turn must behave normally.

--- a/test/port-pool.mjs
+++ b/test/port-pool.mjs
@@ -95,9 +95,18 @@ export async function freePort() {
   for (let offset = 0; offset < block.size; offset += 1) {
     const port = block.start + offset;
     if (issued.has(port)) continue;
+    // Claimed before the probe, not after it. Callers draw several ports at
+    // once (`Promise.all(Array.from({ length: 6 }, freePort))`), and with the
+    // claim on the far side of the `await` every one of those starts at the
+    // same offset and they sort themselves out only by colliding on the bind:
+    // six draws deliberately provoke fifteen EADDRINUSE failures. That is
+    // wasteful everywhere and worse on Windows, where each losing bind is a
+    // socket the next attempt has to wait out. Claiming first makes concurrent
+    // draws walk disjoint offsets and never contend at all. A port that then
+    // probes busy stays claimed: it is not usable this run either way.
+    issued.add(port);
     // eslint-disable-next-line no-await-in-loop -- probing in order is the point
     if (!(await isFree(port))) continue;
-    issued.add(port);
     return port;
   }
   throw new Error(

--- a/test/router-resilience.test.mjs
+++ b/test/router-resilience.test.mjs
@@ -200,7 +200,12 @@ test("a gateway that dies mid-stream ends the routed body and logs the cause", a
 
     // The log has to name the cause; the bare string it used to write is why
     // this was undiagnosable in production.
-    const deadline = Date.now() + 2_000;
+    // A wait, not a bound: nothing here is asserting how *fast* the router
+    // logs, only that it does, and 2s was short enough that a loaded machine
+    // could still be scheduling the write. Wait as long as the rest of this
+    // file waits for anything else. A router that never logs the cause still
+    // fails on the assertion below, which is the property under test.
+    const deadline = Date.now() + 10_000;
     while (!/request failed: /.test(router.testErrors()) && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 25));
     }

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5479,8 +5479,15 @@ test("a subagent effort reaches child turns and leaves parent turns alone", asyn
     assert.equal(seen[1].effort, "low", "the parent turn was re-tuned by a subagent setting");
     assert.equal(seen[2].effort, "low", "an unconfigured model was altered");
   } finally {
-    router.kill("SIGTERM");
-    gateway.server.close();
+    // The router meters a turn *after* its response head is on the wire, and
+    // `recordUsageEvent` re-creates the state directory (`mkdirSync` with
+    // `recursive`) before appending. A bare `kill` only queues the signal, so
+    // an unawaited router is still appending while `rmSync` walks the same
+    // directory -- it unlinks the children, the router re-creates one, and the
+    // final `rmdir` fails with ENOTEMPTY. Wait for the process to be gone
+    // before removing what it writes into.
+    await stopChild(router);
+    await closeServer(gateway.server);
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
@@ -5573,8 +5580,11 @@ test("a subagent effort overrides the effort Codex nested in the reasoning objec
     );
     assert.equal(seen[1].effort, undefined, "the parent turn grew a flat effort field");
   } finally {
-    router.kill("SIGTERM");
-    gateway.server.close();
+    // See the sibling test above: removing the state directory out from under
+    // a router that has been signalled but not awaited is what produced the
+    // ENOTEMPTY on this directory.
+    await stopChild(router);
+    await closeServer(gateway.server);
     rmSync(stateDir, { recursive: true, force: true });
   }
 });

--- a/test/vision-bridge-e2e.test.mjs
+++ b/test/vision-bridge-e2e.test.mjs
@@ -105,6 +105,12 @@ async function closeServer(server) {
 async function bridgeUpstreams({ visionDelayMs = VISION_DELAY_MS } = {}) {
   const state = {
     visionRequests: [],
+    // How many reads the engine was serving at once, and the most it ever
+    // served at once. Parallelism is a fact about this number, not about a
+    // stopwatch: three reads that overlap peak at 3 and three that queue peak
+    // at 1, whatever the machine's load does to the elapsed time.
+    visionInFlight: 0,
+    visionPeakInFlight: 0,
     gatewayRequests: [],
     visionStatus: 200,
     transcript: TRANSCRIPT,
@@ -117,16 +123,22 @@ async function bridgeUpstreams({ visionDelayMs = VISION_DELAY_MS } = {}) {
     if (request.url === "/vision/v1/chat/completions") {
       const body = await bodyJson(request);
       state.visionRequests.push(body);
-      if (visionDelayMs) {
-        await new Promise((resolve) => setTimeout(resolve, visionDelayMs));
+      state.visionInFlight += 1;
+      state.visionPeakInFlight = Math.max(state.visionPeakInFlight, state.visionInFlight);
+      try {
+        if (visionDelayMs) {
+          await new Promise((resolve) => setTimeout(resolve, visionDelayMs));
+        }
+        if (state.visionStatus !== 200) {
+          json(response, state.visionStatus, { error: { message: "engine unavailable" } });
+          return;
+        }
+        json(response, 200, {
+          choices: [{ message: { role: "assistant", content: state.transcript } }],
+        });
+      } finally {
+        state.visionInFlight -= 1;
       }
-      if (state.visionStatus !== 200) {
-        json(response, state.visionStatus, { error: { message: "engine unavailable" } });
-        return;
-      }
-      json(response, 200, {
-        choices: [{ message: { role: "assistant", content: state.transcript } }],
-      });
       return;
     }
     if (request.url === "/v1/responses") {
@@ -619,9 +631,16 @@ test("images in one turn are read together, not one after another", async () => 
     assert.equal(result.status, 200);
     assert.equal(upstreams.state.visionRequests.length, 3);
     report(`3 images in one turn: ${result.ms.toFixed(0)}ms for 3 x ${VISION_DELAY_MS}ms reads`);
-    assert.ok(
-      result.ms < VISION_DELAY_MS * 2.5,
-      `3 reads finished in ${result.ms.toFixed(0)}ms, which is no better than serial`,
+    // Was: `result.ms < VISION_DELAY_MS * 2.5`. That measured the machine as
+    // much as the router -- a busy box pushed a perfectly parallel turn past
+    // the bound -- and it was also weaker than it looked, since two reads
+    // together followed by a third fits under 2.5x while still being partly
+    // serial. The engine counting its own concurrent callers settles the same
+    // question exactly: all three overlapped, or they did not.
+    assert.equal(
+      upstreams.state.visionPeakInFlight,
+      3,
+      `the three reads never overlapped: at most ${upstreams.state.visionPeakInFlight} was in flight at once`,
     );
     const evidence = textParts(upstreams.state.gatewayRequests.at(-1).input).filter((text) =>
       text.includes("<<<IMAGE EVIDENCE"),


### PR DESCRIPTION
Three failures that have cost review time, and one product defect underneath the newest of them.

## A test that removed a directory the router was still writing to

`test/routing.test.mjs`'s two subagent-effort tests tore down with `router.kill("SIGTERM")` and then `rmSync(stateDir)`. The signal is only queued. The router meters a turn *after* its response head is on the wire, and `recordUsageEvent` (`src/usage-events.mjs:204`) re-creates the state directory before appending to it — so the still-live router put a file back while `rmSync` was walking the tree, and the final `rmdir` failed with `ENOTEMPTY`.

I could not reproduce the ENOTEMPTY directly — 100+ instrumented iterations under CPU starvation, and with the removal window widened by 12,000 padding files, produced zero hits. It is genuinely rare. So it is proven two other ways instead:

- **Mechanism**: a writer doing exactly `mkdirSync(recursive)` + `appendFileSync` against a directory being `rmSync`'d fails with `ENOTEMPTY: directory not empty, rmdir …` in **3 of 30** runs.
- **Hazard**: at the instant the test's `rmSync` runs, was the router still able to write there? **Before: 30/30. After: 0/30.** In 29 of those 30 it still owed a usage-event append to that directory.

The fix awaits the child via the file's own `stopChild`/`closeServer` helpers, already used by 64 other tests here. No retries — the race is eliminable, so it was eliminated.

**Same defect class found elsewhere, not fixed here** (worth a follow-up): `test/startup-cleanup.test.mjs:142` kills without awaiting exit and then `rmSync`s the root dir; `test/gateway-restart.test.mjs:178` sleeps 500 ms instead of awaiting.

## A test that guessed when a failover was in flight

`a client that leaves mid-failover does not hang or crash the router` destroyed the client on a fixed 800 ms timer and then asserted the fallback hop had been attempted. On a loaded machine the router had not finished the primary 429 and reopened against the fallback by then, so the caller left before there was a failover to leave.

**4 failures in 20 runs**, always that assertion, never a hang, a crash, or a missing usage event. The router's disconnect handling is correct; this was a test defect.

The gateway now resolves a promise the moment the fallback hop's body lands, and the test awaits that before destroying the client. The hop is held 3 s, so the abort is inside it whatever the machine is doing, and a 20 s deadline backs it so a router that never gets there fails on the existing assertion rather than hanging. **0 failures in 25 runs.** Nothing asserted was weakened.

## A test that timed parallelism with a stopwatch

`images in one turn are read together` asserted `elapsed < 2.5 × read delay`. That measures the machine as much as the router — and it was weaker than it looked, since two reads together followed by a third fits under 2.5× while still being partly serial.

The mock engine now tracks its own peak concurrent callers and the test asserts it reached 3. Load-independent and strictly stronger: mutation-proven by setting `VISION_READ_CONCURRENCY = 1`, which fails it with *"the three reads never overlapped: at most 1 was in flight at once"*.

`router-resilience.test.mjs:203` waited 2 s for a log line it does not time; raised to 10 s, matching the file's other waits. That is a wait, not a latency bound — the assertion still fails if the line never appears.

## A forwarder that could not bind died without saying which one it was

#271's Windows CI failure showed `EADDRINUSE 127.0.0.1:22624` under `node:events / throw er; // Unhandled 'error' event`, and nothing in it says which of the four forwarders wanted the port.

**None of them attached an `error` handler to `listen`.** `src/router.mjs:3215` has had one since #171. All four now report a bind failure the way the router does — one line naming itself, the address and the reason — and exit with the router's listen-failure codes. Verified by hand: `exit code: 98`, `[devin-cli] cannot listen: 127.0.0.1:52617 is already in use…`, crash dump gone.

The port helper is not issuing duplicates — blocks are disjoint per file and `issued` prevents reuse — but it claimed a port *after* probing, so six concurrent draws all start at the same offset and sort themselves out by deliberately colliding on the bind: fifteen provoked `EADDRINUSE`s per draw, each one a socket Windows makes the next attempt wait out. Claiming first makes concurrent draws walk disjoint offsets.

The gating test's own fixture now names itself when it cannot hold the port, so a fixture failure and a gate failure stop reading identically, and its teardown waits for `start.mjs` to exit (SIGTERM→SIGKILL escalation, since SIGTERM is `TerminateProcess` on Windows) before removing the tree.

No test was skipped, deleted, or weakened.

## Test plan

- [x] `npm test` — 1752 tests, 1740 pass, 0 fail, 12 skipped; three consecutive runs under CPU load
- [x] `npm run check`
- [x] Flake 1 hazard: router writable at removal 30/30 → 0/30; subagent-effort tests 0/20 under load
- [x] Flake 2: 4/20 → 0/25 under load
- [x] Vision and resilience: 0/20 before, 0/15 after; vision assertion mutation-proven against `VISION_READ_CONCURRENCY = 1`
- [x] Devin gate mutation-proven both ways: forcing it on fails the no-model case, forcing it off fails the two routed cases
- [x] Forwarder bind failure verified by hand: exit 98, one named line, no crash dump
- [ ] Windows: the flake-3 failure could not be reproduced or verified locally (macOS only)
