### PR TITLE
test(reasoning): pin the plain follow-up after a thinking turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,7 +281,10 @@
   own rejection on the same providers. "Compact old tool results" was reported
   alongside this and is not involved — the aging pass only ever rewrites the
   `output` of a tool result, and now has a test proving the reasoning and
-  assistant turns around it come through by reference.
+  assistant turns around it come through by reference. A subagent is not
+  required to reach this: an ordinary follow-up after any thinking-mode answer
+  fails the same way on a build that predates the fix, and that plainest path
+  is pinned by its own test.
 - **A single bad upstream response could take the whole router down.** LiteLLM
   1.96.0 raises out of its own request handler while mapping an upstream 429 —
   opencode Zen's exhausted free tier is one reliable way to reach it — and the

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5705,3 +5705,95 @@ test("reasoning survives the replay onto tool-call and prose assistant turns ali
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+// #292: the same "The `reasoning_content` in the thinking mode must be passed
+// back to the API" 400, but reached without a subagent and without a tool call
+// anywhere -- a thinking-mode answer followed by an ordinary follow-up in the
+// same conversation. #256's coverage drives that carry through a tool loop and
+// a subagent-shaped tail in one array, so the plainest path a user can walk is
+// only covered incidentally there. Pinned separately: a regression that broke
+// just this shape would still leave #256's test green.
+test("a plain follow-up after a thinking turn replays its reasoning", async () => {
+  const gatewayBodies = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayBodies.push(await bodyJson(request));
+    json(response, 200, { output: [{ type: "message", role: "assistant", content: "ok" }] });
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "reasoning-followup-state-"));
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  // Exactly what Codex replays on turn two: the first prompt, the reasoning it
+  // stored for the thinking answer (`content: null`, which is the shape
+  // LiteLLM's Responses->chat translation drops outright), that answer, and
+  // the follow-up. No function_call, no custom_tool_call, no subagent.
+  const input = [
+    { type: "message", role: "user", content: [{ type: "input_text", text: "who wrote Dune?" }] },
+    {
+      type: "reasoning",
+      id: "rs_292",
+      summary: [{ type: "summary_text", text: "Dune is Frank Herbert's, published 1965." }],
+      content: null,
+    },
+    {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "Frank Herbert." }],
+    },
+    { type: "message", role: "user", content: [{ type: "input_text", text: "and the sequel?" }] },
+  ];
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "opencode-go/deepseek-v4-flash",
+        stream: false,
+        input,
+      }),
+    });
+    assert.equal(response.status, 200, await response.text());
+    const forwarded = gatewayBodies[0].input;
+    const text = (item) =>
+      (Array.isArray(item?.content) ? item.content : [])
+        .map((part) => (typeof part?.text === "string" ? part.text : ""))
+        .join("\n");
+
+    // The reasoning reaches the provider on the assistant turn it produced --
+    // as message content, the only place the translation preserves it.
+    const answer = forwarded.find(
+      (item) => item?.type === "message" && item.role === "assistant",
+    );
+    assert.ok(answer, "the assistant turn never reached the provider");
+    assert.match(
+      text(answer),
+      /Dune is Frank Herbert's, published 1965\./,
+      "the thinking-mode reasoning was dropped before the provider saw it",
+    );
+    // And the answer itself is still there: the carry prepends, never replaces.
+    assert.match(text(answer), /Frank Herbert\./);
+    // The follow-up is still the last thing the provider is asked about.
+    assert.equal(forwarded.at(-1).role, "user");
+
+    // One assistant message, not two in a row -- the shape opencode Go's
+    // Console endpoint rejects outright.
+    for (let index = 1; index < forwarded.length; index += 1) {
+      if (forwarded[index - 1]?.role !== "assistant") continue;
+      if (forwarded[index]?.role !== "assistant") continue;
+      assert.fail("two assistant messages ended up back to back");
+    }
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Test only. No production change — none is warranted.

## Why

#292 reports the same upstream 400 as #256 — `The reasoning_content in the thinking mode must be passed back to the API` — but through a different door: a plain follow-up in an ordinary conversation, no subagent and no tool call anywhere.

That turned out to be already fixed by #275, and the subagent in #256 was incidental. The underlying cause hits **any** assistant turn that answers in prose. But the existing coverage pinned it through the subagent path, so this specific shape could have regressed silently behind the tool-loop tests.

## Verified rather than reasoned

The new test reconstructs #292's exact reproduction — user prompt → `reasoning` item with `content: null` → assistant prose → user follow-up — against `opencode-go/deepseek-v4-flash`, driven through the routed `/responses` path:

- **Passes on current main**: the reasoning reaches the provider, merged into the assistant message.
- **Fails against `v0.4.0-beta.4`'s `src/router.mjs`** with `the thinking-mode reasoning was dropped before the provider saw it` — the assistant turn arrives as `"Frank Herbert."` with the reasoning gone.

That is the direct confirmation that the reporter's problem is a release gap: `v0.4.0-beta.4` was tagged 2026-08-15, and #275 (`097b153`) merged 2026-08-16.

It also asserts the back-to-back-assistant hazard #275 guarded against, so a future change cannot fix the carry by inserting a second assistant message.

## Remaining gaps checked, none found

- `reasoningItemText` already handles summary-string, summary-array, content-string and content-array shapes. An item with no text anywhere carries nothing because the client stored nothing — not a router gap.
- No `opencode-go`-specific message-shape correction is needed: `config/opencode/go/deepseek-v4-flash.json` uses the generic `auto-tool-choice` profile, and the generic carry produces exactly the shape Console Go wants once the assistant message holds the text.

The #256 CHANGELOG entry is amended to record that a subagent is not required to reach the bug.

## Test plan

- [x] `npm run check`
- [x] `npm test` — 1753 tests, 1741 pass, 0 fail, 12 skipped
- [x] New test fails against `v0.4.0-beta.4`'s router, passes on main