### PR TITLE
fix(test): wait for the demotion lines instead of racing macOS pipe writes

### DIFF
--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5394,6 +5394,16 @@ test("a proven subagent is demoted by a later rejection and by a child that neve
     // Both demotions have to be readable in the log, even under the QUIET the
     // production LaunchAgent hard-sets: a picker entry that vanishes with no
     // line explaining it is unexplainable.
+    //
+    // Waited for rather than read straight off, because the demotion writes
+    // the proof file *before* it logs (`settle` in router.mjs), and the log
+    // goes down a pipe -- which node writes asynchronously on macOS. So the
+    // file the loop above polls can already say `failed` while the line
+    // explaining it is still in flight; a bare read caught that ~1% of runs
+    // and blamed the ceiling for a demotion that had in fact already fired.
+    // The wait is on the line's arrival only: what is asserted is unchanged.
+    await waitForStderr(router, /subagent demoted: deepseek\/deepseek-v4-flash/);
+    await waitForStderr(router, /subagent demoted: deepseek\/deepseek-v4-pro/);
     const errors = router.testErrors();
     assert.match(errors, /subagent demoted: deepseek\/deepseek-v4-flash/);
     assert.match(errors, /subagent demoted: deepseek\/deepseek-v4-pro/);


### PR DESCRIPTION
Test only. The `#284` ceiling is sound as shipped — this fixes how the test *reads* the evidence, not what produces it.

## What was actually failing

CI hit this twice and it was wrongly dismissed as load-induced the first time. Reproduced here at **2 failures in 210 runs** (~1%) — 1/60 idle, 1/150 under 8-way CPU load. Load is not the driver; the window is a few milliseconds wide and gets hit by chance.

`settle` (`src/router.mjs:1893-1901`) calls `recordSpawnFailure(...)`, a synchronous proof-file write, and *then* `console.error("subagent demoted: …")`. The test's `proofFor` helper polls that file and returns **synchronously on its first read** with no event-loop yield once the file has flipped.

Node writes to a pipe **asynchronously on macOS** (synchronously on Linux and Windows). So the child's last stderr bytes can still be in flight while the file it wrote first is already on disk, and the parent reads a truncated *contiguous prefix*.

That is exactly the shape of both failures: everything up to pro turn 5's timing line present, and pro turn 6's demotion line **and** its timing line — emitted in that order at `router.mjs:1899` then `router.mjs:2973` — both absent. Nothing missing from the middle.

Proved directly rather than inferred: a probe copy that kept polling stderr on mismatch hit the condition 2/200 times and reported `pro demote line was MISSING at read time; arrived after 6ms`, both times.

## The ceiling did fire

Worth stating plainly, because the failure reads as though it did not. The log assertions are the *last three lines* of the test. Everything before them passed in the failing runs:

- `assert.equal(pro.status, "failed")`
- `assert.equal(pro.spawn.turns, 6)`
- `assert.equal(pro.spawn.newInputTokens, 2_100_000)` — exact, not approximate
- `assert.match(pro.reason, /without converging/)` and `/1800000-token ceiling/`

All six child turns were counted, `acceptedInputTokens` accepted every one, and `thread-id` attribution held. The state transition is a synchronous file write inside the same call that crosses the threshold, and the token totals are deterministic. **A real user sees no defect**, and in production stderr goes to the LaunchAgent's log file, which is synchronous on macOS, so even the cosmetic ordering does not arise.

## The fix

`test/routing.test.mjs:5394-5409`, +10 lines:

```js
await waitForStderr(router, /subagent demoted: deepseek\/deepseek-v4-flash/);
await waitForStderr(router, /subagent demoted: deepseek\/deepseek-v4-pro/);
const errors = router.testErrors();
assert.match(errors, /subagent demoted: deepseek\/deepseek-v4-flash/);
assert.match(errors, /subagent demoted: deepseek\/deepseek-v4-pro/);
```

`waitForStderr` is the file's own existing helper (line 4302, 5 s bound). Both original assertions are kept verbatim — nothing weakened, skipped or split. The wait is only on arrival; a line that never arrives still fails, now with the whole buffer in the message.

## Proof

- Before: 2 / 210. After: **0 / 300** (150 under load, 150 idle). Whole file 3×: 69 pass, 0 fail each.
- **Mutation 1** — ceiling disabled (`exceeded: false` in `subagent-turns.mjs:161`): fails on the *proof-file* assertion, not the log one. Ceiling coverage does not depend on the lines touched here.
- **Mutation 2** — demotion `console.error` removed: fails with `Timed out waiting for /subagent demoted: …/`. The log assertion is not vacuous after the fix.
- Full `npm test`: 1757 tests, 1745 pass, 0 fail, 12 skipped.

## Follow-up, not fixed here

`test/routing.test.mjs:4636` (`router.testErrors().match(/estimated-input-tokens=/g).length === 2`) has the same bare-read shape and is latently exposed to the same race. Left alone deliberately: it asserts an exact *count*, so the robust form is a different change than a pattern wait, and it is not what CI has been hitting.