### PR TITLE
fix: retry a Grok OAuth progress-only stop once under the author contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ## Unreleased
 
-- **Grok OAuth retries a genuine progress-only stop once, under the same
-  contract as empty-completion retry.** When the client offered tools and the
-  first turn ends with short visible text, no tool calls, and enough output
-  tokens to be reasoning-heavy, the forwarder holds the first byte, retries
-  once with a trailing user nudge (not a developer/system prefix rewrite),
-  keeps the first answer unless the retry actually calls a tool, sums both
-  attempts into `usage` with `retries: 1`, and logs the retry even when
-  `MODEL_ROUTER_QUIET=1`. The hold is capped at 1 MiB / 30 s and ends as soon
-  as a tool call or a long visible answer appears. Set
+- **Grok OAuth retries a genuine progress-only stop once, without holding
+  the first byte.** Attempt 1 streams live. If the client offered tools and
+  the turn ends with short visible text, no tool calls, and enough output
+  tokens to be reasoning-heavy, the forwarder retries once with a trailing
+  user nudge and *appends* only the retry's tool-call deltas plus
+  `finish_reason: "tool_calls"` onto the same open stream. The first answer
+  is kept when the retry also has no tools. Both attempts are summed into
+  `usage` with `progress_only_retried: true`; that marker is what
+  `acceptedInputTokens` excludes, not a bare transport `retries` count. The
+  retry log is not gated on `MODEL_ROUTER_QUIET`. Set
   `CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0` to pay once and see the raw
-  first attempt. `dispatchSseBlock` now catches only `JSON.parse`, so a
-  handler bug is no longer swallowed as a malformed event.
+  first attempt. `dispatchSseBlock` now catches only `JSON.parse`.
 
 - **The Devin CLI probe no longer reports "unknown" for a Devin CLI that is
   installed and working.** `devinCliVersion` was the one call site out of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,27 @@
 
 ## Unreleased
 
-- **Grok OAuth retries a genuine progress-only stop once, without holding
-  the first byte.** Attempt 1 streams live. If the client offered tools and
-  the turn ends with short visible text, no tool calls, and enough output
-  tokens to be reasoning-heavy, the forwarder retries once with a trailing
-  user nudge and *appends* only the retry's tool-call deltas plus
-  `finish_reason: "tool_calls"` onto the same open stream. The first answer
-  is kept when the retry also has no tools. Both attempts are summed into
-  `usage` with `progress_only_retried: true`; that marker is what
-  `acceptedInputTokens` excludes, not a bare transport `retries` count. The
-  retry log is not gated on `MODEL_ROUTER_QUIET`. Set
-  `CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0` to pay once and see the raw
-  first attempt. `dispatchSseBlock` now catches only `JSON.parse`.
+- **Grok OAuth retries a progress-only stop once, without holding the first
+  byte.** Attempt 1 streams live. If the client offered tools and the turn
+  ends with short visible text, no tool calls, and enough output tokens to be
+  reasoning-heavy, the forwarder retries once with a trailing user nudge and
+  *appends* only the retry's tool-call deltas plus `finish_reason:
+  "tool_calls"` onto the same open stream. The first answer is kept when the
+  retry also has no tools. Both attempts are summed into `usage` with
+  `progress_only_retried: true`; that marker is what `acceptedInputTokens`
+  excludes, not a bare transport `retries` count. The retry log is not gated
+  on `MODEL_ROUTER_QUIET`. Set `CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0` to
+  pay once and see the raw first attempt. `dispatchSseBlock` now catches only
+  `JSON.parse`.
+
+  The trigger is a shape and cannot be anything else: a finished task answered
+  in one line — "Yes, that is correct." after 1,500 reasoning tokens — is
+  indistinguishable from a turn that stopped early, so it is retried too. The
+  nudge therefore offers the no-tool branch first ("if that already completed
+  the task, restate the final answer and call no tool"), which routes the
+  finished case into keep-first. An imperative nudge makes such a turn invent
+  a tool call, and the forwarder would graft it onto the answer for the client
+  to run. A false positive now costs one round trip, not a wrong action.
 
 - **The Devin CLI probe no longer reports "unknown" for a Devin CLI that is
   installed and working.** `devinCliVersion` was the one call site out of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Grok OAuth retries a genuine progress-only stop once, under the same
+  contract as empty-completion retry.** When the client offered tools and the
+  first turn ends with short visible text, no tool calls, and enough output
+  tokens to be reasoning-heavy, the forwarder holds the first byte, retries
+  once with a trailing user nudge (not a developer/system prefix rewrite),
+  keeps the first answer unless the retry actually calls a tool, sums both
+  attempts into `usage` with `retries: 1`, and logs the retry even when
+  `MODEL_ROUTER_QUIET=1`. The hold is capped at 1 MiB / 30 s and ends as soon
+  as a tool call or a long visible answer appears. Set
+  `CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0` to pay once and see the raw
+  first attempt. `dispatchSseBlock` now catches only `JSON.parse`, so a
+  handler bug is no longer swallowed as a malformed event.
+
 - **The Devin CLI probe no longer reports "unknown" for a Devin CLI that is
   installed and working.** `devinCliVersion` was the one call site out of
   twenty that took `command` and `args` from `spawnableCommand` and threw away

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -304,17 +304,16 @@ arguments without holding the full turn, so Codex sees the tool call instead of
 mistaking the preceding status text for the completed task.
 
 A remaining Grok OAuth shape is a genuine progress-only stop: the model
-reasons, emits a short status sentence, and never calls a tool. When the
-client actually offered tools, the forwarder holds the first relayed byte
-until it can classify that turn (or until the 1 MiB / 30 s hold budget), then
-retries once with a trailing user nudge. The first answer is kept unless the
-retry produces a tool call. Both attempts are billed; the usage object sums
-them and sets `retries: 1`, and the log line
-`progress-only-retried=true` is never gated on `MODEL_ROUTER_QUIET`. To pay
-once and see the raw first attempt, set
-`CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0`. The retry does not run when the
-request offered no tools, after the first byte has already been relayed, or
-after the hold budget trips.
+reasons, emits a short status sentence, and never calls a tool. Attempt 1
+still streams live. When the client actually offered tools, the forwarder
+retries once with a trailing user nudge and appends only the retry's tool
+calls onto the same open stream, so Codex sees the status sentence followed
+by the tool call. The first answer is kept if the retry also produces no
+tools. Both attempts are billed; the usage object sums them and sets
+`progress_only_retried: true`, and the log line `progress-only-retried=true`
+is never gated on `MODEL_ROUTER_QUIET`. To pay once and see the raw first
+attempt, set `CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0`. The retry does not
+run when the request offered no tools.
 
 The router holds the entire response until it knows the turn produced something.
 When nothing arrives it discards that attempt and retries the identical request

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -303,6 +303,19 @@ line. The forwarder now accepts all three shapes and restores final tool
 arguments without holding the full turn, so Codex sees the tool call instead of
 mistaking the preceding status text for the completed task.
 
+A remaining Grok OAuth shape is a genuine progress-only stop: the model
+reasons, emits a short status sentence, and never calls a tool. When the
+client actually offered tools, the forwarder holds the first relayed byte
+until it can classify that turn (or until the 1 MiB / 30 s hold budget), then
+retries once with a trailing user nudge. The first answer is kept unless the
+retry produces a tool call. Both attempts are billed; the usage object sums
+them and sets `retries: 1`, and the log line
+`progress-only-retried=true` is never gated on `MODEL_ROUTER_QUIET`. To pay
+once and see the raw first attempt, set
+`CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0`. The retry does not run when the
+request offered no tools, after the first byte has already been relayed, or
+after the hold budget trips.
+
 The router holds the entire response until it knows the turn produced something.
 When nothing arrives it discards that attempt and retries the identical request
 once, so the client sees only one response head, response ID, and sequence space.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -303,13 +303,27 @@ line. The forwarder now accepts all three shapes and restores final tool
 arguments without holding the full turn, so Codex sees the tool call instead of
 mistaking the preceding status text for the completed task.
 
-A remaining Grok OAuth shape is a genuine progress-only stop: the model
-reasons, emits a short status sentence, and never calls a tool. Attempt 1
-still streams live. When the client actually offered tools, the forwarder
-retries once with a trailing user nudge and appends only the retry's tool
-calls onto the same open stream, so Codex sees the status sentence followed
-by the tool call. The first answer is kept if the retry also produces no
-tools. Both attempts are billed; the usage object sums them and sets
+A remaining Grok OAuth shape is a progress-only stop: the model reasons,
+emits a short status sentence, and never calls a tool. Attempt 1 still
+streams live. When the client actually offered tools, the forwarder retries
+once with a trailing user nudge and appends only the retry's tool calls onto
+the same open stream, so Codex sees the status sentence followed by the tool
+call. The first answer is kept if the retry also produces no tools.
+
+The trigger is a shape, not a diagnosis, and it is worth knowing which turns
+pay for it. Nothing in a finished turn distinguishes it from a stalled one, so
+**a completed task answered in one line is retried too** — "Yes, that is
+correct." with 1,500 reasoning-heavy output tokens looks exactly like "Next I
+will update the deck.". Because grok-4.6 reasons by default, the
+`output_tokens` floor is met on essentially every turn, so what actually
+decides is the 120-character text limit. That is why the nudge offers the
+no-tool branch first: a finished turn restates its answer, calls nothing, and
+keeps the first answer rather than being talked into a tool call the client
+would then run. The cost of a false positive is one extra round trip, not a
+wrong action. Raise `CODEX_ROUTER_GROK_PROGRESS_ONLY_MIN_OUTPUT_TOKENS` or
+lower `CODEX_ROUTER_GROK_PROGRESS_ONLY_MAX_TEXT` to fire less often.
+
+Both attempts are billed; the usage object sums them and sets
 `progress_only_retried: true`, and the log line `progress-only-retried=true`
 is never gated on `MODEL_ROUTER_QUIET`. To pay once and see the raw first
 attempt, set `CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0`. The retry does not

--- a/src/context-window-drift.mjs
+++ b/src/context-window-drift.mjs
@@ -35,11 +35,15 @@ function positiveInteger(value) {
 // retry -- and the remediation this check prints is "raise the window", so the
 // bad sample would talk an operator into doubling a correct number.
 // provider-usage.mjs drops these same events from its throughput math for the
-// same reason: a merged pair is not one measurement.
+// same reason: a merged pair is not one measurement. `progressOnlyRetried` is
+// the Grok OAuth equivalent: two billed attempts summed, not one measurement.
+// Bare `retries` is not excluded — a transport retry records only the
+// successful attempt's tokens.
 export function acceptedInputTokens(event) {
   if (event?.status !== 200) return undefined;
   if (event?.estimatedInputTokens !== undefined) return undefined;
   if (event?.emptyCompletionRetried === true) return undefined;
+  if (event?.progressOnlyRetried === true) return undefined;
   return positiveInteger(event?.inputTokens);
 }
 

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -30,7 +30,7 @@ import {
   parseSseBlockEvent,
   requestOffersClientTools,
   shouldPreferRetryTurn,
-  shouldReleaseProgressOnlyHold,
+  toolCallDeltas,
   withProgressOnlyNudge,
 } from "./grok-oauth-turn.mjs";
 import { VERSION } from "./version.mjs";
@@ -57,8 +57,6 @@ const PROGRESS_ONLY_MIN_OUTPUT_TOKENS = envNonNegativeInt(
   "CODEX_ROUTER_GROK_PROGRESS_ONLY_MIN_OUTPUT_TOKENS",
   DEFAULT_PROGRESS_ONLY_MIN_OUTPUT_TOKENS,
 );
-const MAX_PROGRESS_HOLD_BYTES = 1024 * 1024;
-const MAX_PROGRESS_HOLD_MS = 30_000;
 
 function envNonNegativeInt(name, fallback) {
   const parsed = Number(process.env[name]);
@@ -334,14 +332,13 @@ function dispatchSseBlock(rawEvent, handlers) {
   handlers(event);
 }
 
-async function consumeResponsesStream(upstreamBody, handlers, { onBytes } = {}) {
+async function consumeResponsesStream(upstreamBody, handlers) {
   const reader = upstreamBody.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
   for (;;) {
     const { value, done } = await reader.read();
     if (done) break;
-    if (value) onBytes?.(value.byteLength);
     buffer += decoder.decode(value, { stream: true });
     let boundary;
     while ((boundary = nextSseBoundary(buffer))) {
@@ -436,30 +433,20 @@ async function handleChatCompletions(request, response) {
 
   const id = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1_000);
-  let turnState = createTurnState();
+  const turnState = createTurnState();
   let emittedDeltaCount = 0;
-  let holding = Boolean(mayRetry && wantsStream);
-  let holdBytes = 0;
-  let holdTimer;
 
-  const beginStream = () => {
-    if (!wantsStream || response.headersSent) return;
-    holding = false;
-    if (holdTimer) {
-      clearTimeout(holdTimer);
-      holdTimer = undefined;
-    }
+  if (wantsStream) {
     response.writeHead(200, {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
       Connection: "keep-alive",
     });
     response.write(OPENAI_ROLE_CHUNK(id, created, model, { role: "assistant", content: "" }));
-  };
+  }
 
   const emitPendingDeltas = () => {
-    if (!wantsStream || holding) return;
-    beginStream();
+    if (!wantsStream) return;
     while (emittedDeltaCount < turnState.deltas.length) {
       response.write(
         OPENAI_ROLE_CHUNK(id, created, model, turnState.deltas[emittedDeltaCount]),
@@ -468,42 +455,16 @@ async function handleChatCompletions(request, response) {
     }
   };
 
-  const releaseHold = () => {
-    if (!holding) return;
-    holding = false;
-    emitPendingDeltas();
-  };
-
-  const onEvent = (event) => {
+  await consumeResponsesStream(upstream.body, (event) => {
     applyResponsesEvent(turnState, event);
-    if (holding && shouldReleaseProgressOnlyHold(turnState, holdOptions)) {
-      releaseHold();
-      return;
-    }
     emitPendingDeltas();
-  };
-
-  if (wantsStream && !holding) beginStream();
-  if (holding) {
-    holdTimer = setTimeout(() => releaseHold(), MAX_PROGRESS_HOLD_MS);
-    if (typeof holdTimer.unref === "function") holdTimer.unref();
-  }
-
-  await consumeResponsesStream(upstream.body, onEvent, {
-    onBytes: (n) => {
-      holdBytes += n;
-      if (holding && holdBytes > MAX_PROGRESS_HOLD_BYTES) releaseHold();
-    },
   });
-  if (holdTimer) {
-    clearTimeout(holdTimer);
-    holdTimer = undefined;
-  }
 
   let turn = finalizeTurn(turnState);
+  emitPendingDeltas();
   let retried = false;
 
-  if (mayRetry && !response.headersSent && isProgressOnlyStop(turn, holdOptions)) {
+  if (mayRetry && isProgressOnlyStop(turn, holdOptions)) {
     const retryChat = withProgressOnlyNudge(chat);
     const retryRequest = toResponsesRequest(retryChat, { hostedSearchEnabled });
     let secondUpstream;
@@ -528,23 +489,30 @@ async function handleChatCompletions(request, response) {
       const second = finalizeTurn(secondState);
       const mergedUsage = mergeMappedUsage(turn.usage, second.usage);
       retried = true;
+      const preferTools = shouldPreferRetryTurn(second);
       console.error(
-        `[grok-oauth] progress-only-retried=true retries=1 model=${model} prefer=${shouldPreferRetryTurn(second) ? "retry" : "first"}`,
+        `[grok-oauth] progress-only-retried=true retries=1 model=${model} prefer=${preferTools ? "retry" : "first"}`,
       );
-      if (shouldPreferRetryTurn(second)) {
-        turn = { ...second, usage: mergedUsage || second.usage };
-        turnState = secondState;
-        emittedDeltaCount = 0;
+      if (preferTools) {
+        if (wantsStream) {
+          for (const delta of toolCallDeltas(second)) {
+            response.write(OPENAI_ROLE_CHUNK(id, created, model, delta));
+          }
+        }
+        turn = {
+          contentText: turn.contentText,
+          toolCalls: second.toolCalls,
+          usage: mergedUsage,
+          deltas: [...turn.deltas, ...toolCallDeltas(second)],
+          finishReason: "tool_calls",
+        };
       } else {
-        turn = { ...turn, usage: mergedUsage || turn.usage };
+        turn = { ...turn, usage: mergedUsage };
       }
     }
   }
 
-  emitPendingDeltas();
-
   if (wantsStream) {
-    beginStream();
     response.write(OPENAI_ROLE_CHUNK(id, created, model, {}, turn.finishReason));
     if (turn.usage) {
       response.write(

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -22,8 +22,16 @@ import { normalizeSchemaLiterals, objectRootToolSchema } from "./tool-schema-roo
 import {
   applyResponsesEvent,
   createTurnState,
+  DEFAULT_PROGRESS_ONLY_MAX_TEXT,
+  DEFAULT_PROGRESS_ONLY_MIN_OUTPUT_TOKENS,
   finalizeTurn,
-  sseDataFromBlock,
+  isProgressOnlyStop,
+  mergeMappedUsage,
+  parseSseBlockEvent,
+  requestOffersClientTools,
+  shouldPreferRetryTurn,
+  shouldReleaseProgressOnlyHold,
+  withProgressOnlyNudge,
 } from "./grok-oauth-turn.mjs";
 import { VERSION } from "./version.mjs";
 import { installStableFetchTransport } from "./fetch-transport.mjs";
@@ -40,6 +48,39 @@ const GROK_BASE = (
 ).replace(/\/+$/, "");
 const INTERNAL_KEY = process.env.MODEL_ROUTER_INTERNAL_KEY;
 const QUIET = process.env.MODEL_ROUTER_QUIET === "1";
+const PROGRESS_ONLY_RETRY = process.env.CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY !== "0";
+const PROGRESS_ONLY_MAX_TEXT = envNonNegativeInt(
+  "CODEX_ROUTER_GROK_PROGRESS_ONLY_MAX_TEXT",
+  DEFAULT_PROGRESS_ONLY_MAX_TEXT,
+);
+const PROGRESS_ONLY_MIN_OUTPUT_TOKENS = envNonNegativeInt(
+  "CODEX_ROUTER_GROK_PROGRESS_ONLY_MIN_OUTPUT_TOKENS",
+  DEFAULT_PROGRESS_ONLY_MIN_OUTPUT_TOKENS,
+);
+const MAX_PROGRESS_HOLD_BYTES = 1024 * 1024;
+const MAX_PROGRESS_HOLD_MS = 30_000;
+
+function envNonNegativeInt(name, fallback) {
+  const parsed = Number(process.env[name]);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
+}
+
+async function drainUpstreamBody(body) {
+  if (!body) return;
+  try {
+    if (typeof body.cancel === "function") {
+      await body.cancel();
+      return;
+    }
+  } catch {
+    // Fall through to a read-drain when cancel is unavailable or rejected.
+  }
+  try {
+    await body.arrayBuffer();
+  } catch {
+    // A failed retry must not leave the socket unread.
+  }
+}
 
 // Hosted search tools run on xAI's Responses backend, matching Grok Build:
 // attach bare web_search + x_search and let the model choose when/how to search.
@@ -288,22 +329,19 @@ function nextSseBoundary(buffer) {
 }
 
 function dispatchSseBlock(rawEvent, handlers) {
-  const data = sseDataFromBlock(rawEvent);
-  if (!data || data === "[DONE]") return;
-  try {
-    handlers(JSON.parse(data));
-  } catch {
-    // Ignore malformed upstream events while preserving the rest of the stream.
-  }
+  const event = parseSseBlockEvent(rawEvent);
+  if (event === undefined) return;
+  handlers(event);
 }
 
-async function consumeResponsesStream(upstreamBody, handlers) {
+async function consumeResponsesStream(upstreamBody, handlers, { onBytes } = {}) {
   const reader = upstreamBody.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
   for (;;) {
     const { value, done } = await reader.read();
     if (done) break;
+    if (value) onBytes?.(value.byteLength);
     buffer += decoder.decode(value, { stream: true });
     let boundary;
     while ((boundary = nextSseBoundary(buffer))) {
@@ -329,9 +367,13 @@ async function handleChatCompletions(request, response) {
   const chat = JSON.parse((await readRequestBody(request)).toString("utf8"));
   const wantsStream = chat.stream === true;
   const model = typeof chat.model === "string" ? chat.model : "";
-  const responsesRequest = toResponsesRequest(chat, {
-    hostedSearchEnabled: hostedSearchEnabledFor(model),
-  });
+  const hostedSearchEnabled = hostedSearchEnabledFor(model);
+  const responsesRequest = toResponsesRequest(chat, { hostedSearchEnabled });
+  const holdOptions = {
+    maxText: PROGRESS_ONLY_MAX_TEXT,
+    minOutputTokens: PROGRESS_ONLY_MIN_OUTPUT_TOKENS,
+  };
+  const mayRetry = PROGRESS_ONLY_RETRY && requestOffersClientTools(chat);
 
   const controller = new AbortController();
   request.once("aborted", () => controller.abort());
@@ -339,10 +381,10 @@ async function handleChatCompletions(request, response) {
     if (!response.writableEnded) controller.abort();
   });
 
-  const requestUpstream = (accessToken) => fetch(`${GROK_BASE}/responses`, {
+  const requestUpstream = (accessToken, body) => fetch(`${GROK_BASE}/responses`, {
     method: "POST",
     headers: upstreamHeaders(accessToken, model, chat?.messages),
-    body: JSON.stringify(responsesRequest),
+    body: JSON.stringify(body),
     signal: controller.signal,
   });
   let accessToken;
@@ -358,12 +400,12 @@ async function handleChatCompletions(request, response) {
     });
     return;
   }
-  let upstream = await requestUpstream(accessToken);
+  let upstream = await requestUpstream(accessToken, responsesRequest);
   if (upstream.status === 401) {
     await upstream.arrayBuffer();
     try {
       accessToken = await ensureFreshGrokOAuthToken({ force: true });
-      upstream = await requestUpstream(accessToken);
+      upstream = await requestUpstream(accessToken, responsesRequest);
     } catch {
       writeJson(response, 401, {
         error: {
@@ -394,20 +436,30 @@ async function handleChatCompletions(request, response) {
 
   const id = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1_000);
-  const turnState = createTurnState();
+  let turnState = createTurnState();
   let emittedDeltaCount = 0;
+  let holding = Boolean(mayRetry && wantsStream);
+  let holdBytes = 0;
+  let holdTimer;
 
-  if (wantsStream) {
+  const beginStream = () => {
+    if (!wantsStream || response.headersSent) return;
+    holding = false;
+    if (holdTimer) {
+      clearTimeout(holdTimer);
+      holdTimer = undefined;
+    }
     response.writeHead(200, {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
       Connection: "keep-alive",
     });
     response.write(OPENAI_ROLE_CHUNK(id, created, model, { role: "assistant", content: "" }));
-  }
+  };
 
   const emitPendingDeltas = () => {
-    if (!wantsStream) return;
+    if (!wantsStream || holding) return;
+    beginStream();
     while (emittedDeltaCount < turnState.deltas.length) {
       response.write(
         OPENAI_ROLE_CHUNK(id, created, model, turnState.deltas[emittedDeltaCount]),
@@ -416,16 +468,83 @@ async function handleChatCompletions(request, response) {
     }
   };
 
-  const onEvent = (event) => {
-    applyResponsesEvent(turnState, event);
+  const releaseHold = () => {
+    if (!holding) return;
+    holding = false;
     emitPendingDeltas();
   };
 
-  await consumeResponsesStream(upstream.body, onEvent);
-  const turn = finalizeTurn(turnState);
+  const onEvent = (event) => {
+    applyResponsesEvent(turnState, event);
+    if (holding && shouldReleaseProgressOnlyHold(turnState, holdOptions)) {
+      releaseHold();
+      return;
+    }
+    emitPendingDeltas();
+  };
+
+  if (wantsStream && !holding) beginStream();
+  if (holding) {
+    holdTimer = setTimeout(() => releaseHold(), MAX_PROGRESS_HOLD_MS);
+    if (typeof holdTimer.unref === "function") holdTimer.unref();
+  }
+
+  await consumeResponsesStream(upstream.body, onEvent, {
+    onBytes: (n) => {
+      holdBytes += n;
+      if (holding && holdBytes > MAX_PROGRESS_HOLD_BYTES) releaseHold();
+    },
+  });
+  if (holdTimer) {
+    clearTimeout(holdTimer);
+    holdTimer = undefined;
+  }
+
+  let turn = finalizeTurn(turnState);
+  let retried = false;
+
+  if (mayRetry && !response.headersSent && isProgressOnlyStop(turn, holdOptions)) {
+    const retryChat = withProgressOnlyNudge(chat);
+    const retryRequest = toResponsesRequest(retryChat, { hostedSearchEnabled });
+    let secondUpstream;
+    try {
+      secondUpstream = await requestUpstream(accessToken, retryRequest);
+    } catch (error) {
+      console.error(
+        `[grok-oauth] progress-only-retry-failed=true model=${model} error=${error?.name || "Error"}`,
+      );
+      secondUpstream = undefined;
+    }
+    if (secondUpstream && (!secondUpstream.ok || !secondUpstream.body)) {
+      await drainUpstreamBody(secondUpstream.body);
+      console.error(
+        `[grok-oauth] progress-only-retry-failed=true model=${model} status=${secondUpstream.status}`,
+      );
+    } else if (secondUpstream?.body) {
+      const secondState = createTurnState();
+      await consumeResponsesStream(secondUpstream.body, (event) => {
+        applyResponsesEvent(secondState, event);
+      });
+      const second = finalizeTurn(secondState);
+      const mergedUsage = mergeMappedUsage(turn.usage, second.usage);
+      retried = true;
+      console.error(
+        `[grok-oauth] progress-only-retried=true retries=1 model=${model} prefer=${shouldPreferRetryTurn(second) ? "retry" : "first"}`,
+      );
+      if (shouldPreferRetryTurn(second)) {
+        turn = { ...second, usage: mergedUsage || second.usage };
+        turnState = secondState;
+        emittedDeltaCount = 0;
+      } else {
+        turn = { ...turn, usage: mergedUsage || turn.usage };
+      }
+    }
+  }
+
   emitPendingDeltas();
 
   if (wantsStream) {
+    beginStream();
     response.write(OPENAI_ROLE_CHUNK(id, created, model, {}, turn.finishReason));
     if (turn.usage) {
       response.write(
@@ -447,7 +566,7 @@ async function handleChatCompletions(request, response) {
     });
   }
 
-  if (!QUIET) {
+  if (!QUIET && !retried) {
     console.error(`[grok-oauth] model=${model} status=${upstream.status}`);
   }
 }

--- a/src/grok-oauth-turn.mjs
+++ b/src/grok-oauth-turn.mjs
@@ -11,6 +11,95 @@ export function sseDataFromBlock(rawEvent) {
   return dataLines.length ? dataLines.join("\n") : undefined;
 }
 
+// Parse one SSE block to a JSON event. Malformed JSON is a skipped event;
+// the caller must not wrap `handlers()` in the same try/catch.
+export function parseSseBlockEvent(rawEvent) {
+  const data = sseDataFromBlock(rawEvent);
+  if (!data || data === "[DONE]") return undefined;
+  try {
+    return JSON.parse(data);
+  } catch {
+    return undefined;
+  }
+}
+
+export const DEFAULT_PROGRESS_ONLY_MAX_TEXT = 120;
+export const DEFAULT_PROGRESS_ONLY_MIN_OUTPUT_TOKENS = 400;
+const PROGRESS_ONLY_NUDGE = "Continue the same task by calling tools now.";
+
+export function requestOffersClientTools(chat) {
+  return (
+    Array.isArray(chat?.tools) &&
+    chat.tools.some((tool) => tool?.type === "function" && tool.function?.name)
+  );
+}
+
+export function isProgressOnlyStop(
+  turn,
+  {
+    maxText = DEFAULT_PROGRESS_ONLY_MAX_TEXT,
+    minOutputTokens = DEFAULT_PROGRESS_ONLY_MIN_OUTPUT_TOKENS,
+  } = {},
+) {
+  if (!turn || (turn.toolCalls && turn.toolCalls.length > 0)) return false;
+  const text = typeof turn.contentText === "string" ? turn.contentText : "";
+  if (text.length > maxText) return false;
+  const tokens = Number(turn.usage?.completion_tokens);
+  return Number.isFinite(tokens) && tokens >= minOutputTokens;
+}
+
+export function shouldReleaseProgressOnlyHold(
+  state,
+  { maxText = DEFAULT_PROGRESS_ONLY_MAX_TEXT } = {},
+) {
+  if (state?.toolCalls?.length) return true;
+  return (state?.contentText || "").length > maxText;
+}
+
+// Prefer the retry only when it actually called a tool. A second short
+// status sentence is not an improvement; keep the first answer.
+export function shouldPreferRetryTurn(second) {
+  return Boolean(second?.toolCalls?.length);
+}
+
+export function withProgressOnlyNudge(chat) {
+  const messages = Array.isArray(chat?.messages) ? chat.messages : [];
+  return {
+    ...chat,
+    messages: [...messages, { role: "user", content: PROGRESS_ONLY_NUDGE }],
+  };
+}
+
+export function mergeMappedUsage(first, second) {
+  if (!first) return second;
+  if (!second) return first;
+  const prompt = (first.prompt_tokens || 0) + (second.prompt_tokens || 0);
+  const completion = (first.completion_tokens || 0) + (second.completion_tokens || 0);
+  const cached =
+    first.prompt_tokens_details?.cached_tokens === undefined &&
+    second.prompt_tokens_details?.cached_tokens === undefined
+      ? undefined
+      : (first.prompt_tokens_details?.cached_tokens || 0) +
+        (second.prompt_tokens_details?.cached_tokens || 0);
+  const reasoning =
+    first.completion_tokens_details?.reasoning_tokens === undefined &&
+    second.completion_tokens_details?.reasoning_tokens === undefined
+      ? undefined
+      : (first.completion_tokens_details?.reasoning_tokens || 0) +
+        (second.completion_tokens_details?.reasoning_tokens || 0);
+  const merged = {
+    prompt_tokens: prompt,
+    completion_tokens: completion,
+    total_tokens: prompt + completion,
+    retries: 1,
+  };
+  if (cached !== undefined) merged.prompt_tokens_details = { cached_tokens: cached };
+  if (reasoning !== undefined) {
+    merged.completion_tokens_details = { reasoning_tokens: reasoning };
+  }
+  return merged;
+}
+
 const TOOL_ITEM_TYPES = new Set(["function_call", "custom_tool_call"]);
 
 export function createTurnState() {

--- a/src/grok-oauth-turn.mjs
+++ b/src/grok-oauth-turn.mjs
@@ -48,18 +48,16 @@ export function isProgressOnlyStop(
   return Number.isFinite(tokens) && tokens >= minOutputTokens;
 }
 
-export function shouldReleaseProgressOnlyHold(
-  state,
-  { maxText = DEFAULT_PROGRESS_ONLY_MAX_TEXT } = {},
-) {
-  if (state?.toolCalls?.length) return true;
-  return (state?.contentText || "").length > maxText;
-}
-
 // Prefer the retry only when it actually called a tool. A second short
 // status sentence is not an improvement; keep the first answer.
 export function shouldPreferRetryTurn(second) {
   return Boolean(second?.toolCalls?.length);
+}
+
+export function toolCallDeltas(turn) {
+  return (turn?.deltas || []).filter(
+    (delta) => Array.isArray(delta.tool_calls) && delta.tool_calls.length > 0,
+  );
 }
 
 export function withProgressOnlyNudge(chat) {
@@ -70,9 +68,14 @@ export function withProgressOnlyNudge(chat) {
   };
 }
 
+function markProgressOnlyUsage(usage) {
+  if (!usage) return { retries: 1, progress_only_retried: true };
+  return { ...usage, retries: 1, progress_only_retried: true };
+}
+
 export function mergeMappedUsage(first, second) {
-  if (!first) return second;
-  if (!second) return first;
+  if (!first) return markProgressOnlyUsage(second);
+  if (!second) return markProgressOnlyUsage(first);
   const prompt = (first.prompt_tokens || 0) + (second.prompt_tokens || 0);
   const completion = (first.completion_tokens || 0) + (second.completion_tokens || 0);
   const cached =
@@ -92,6 +95,7 @@ export function mergeMappedUsage(first, second) {
     completion_tokens: completion,
     total_tokens: prompt + completion,
     retries: 1,
+    progress_only_retried: true,
   };
   if (cached !== undefined) merged.prompt_tokens_details = { cached_tokens: cached };
   if (reasoning !== undefined) {

--- a/src/grok-oauth-turn.mjs
+++ b/src/grok-oauth-turn.mjs
@@ -25,7 +25,16 @@ export function parseSseBlockEvent(rawEvent) {
 
 export const DEFAULT_PROGRESS_ONLY_MAX_TEXT = 120;
 export const DEFAULT_PROGRESS_ONLY_MIN_OUTPUT_TOKENS = 400;
-const PROGRESS_ONLY_NUDGE = "Continue the same task by calling tools now.";
+// The trigger below cannot tell a stalled turn from a finished one -- a task
+// that ends "Done." is byte-for-byte the same shape as one that stops after
+// "Next I will update the deck.". So the nudge must let the model decline. An
+// imperative "call tools now" makes a finished turn invent a tool call, and
+// `shouldPreferRetryTurn` would then graft that call onto the answer and the
+// client would run it. Offering the no-tool branch first routes the finished
+// case into keep-first instead.
+const PROGRESS_ONLY_NUDGE =
+  "If your previous message already completed the task, restate the final answer " +
+  "and call no tool. Otherwise continue the same task now by calling the tools you need.";
 
 export function requestOffersClientTools(chat) {
   return (
@@ -34,6 +43,11 @@ export function requestOffersClientTools(chat) {
   );
 }
 
+// Not a detector for "the model stalled" -- no such signal exists in the turn.
+// This matches the observable shape: short visible text, no client tool call,
+// and enough output tokens that the model clearly reasoned. A finished task
+// answered in one line matches too, which is why the retry has to be safe to
+// lose rather than accurate to fire. See PROGRESS_ONLY_NUDGE.
 export function isProgressOnlyStop(
   turn,
   {

--- a/src/provider-usage.mjs
+++ b/src/provider-usage.mjs
@@ -153,7 +153,8 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
       event.status < 400 &&
       !event.retries &&
       event.emptyCompletion !== true &&
-      event.emptyCompletionRetried !== true;
+      event.emptyCompletionRetried !== true &&
+      event.progressOnlyRetried !== true;
     // Detection can fail on a converted stream -- the first token is noticed
     // near the end, so thousands of tokens appear to arrive in milliseconds.
     // No served model streams anywhere near this fast, so treat it as a broken

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -159,11 +159,13 @@ export function normalizeTokenUsage(value) {
       value.prompt_tokens_details?.cached_tokens ??
       value.prompt_cache_hit_tokens,
   );
+  const retries = tokenCount(value.retries);
   return {
     inputTokens: inputTokens || 0,
     outputTokens: outputTokens || 0,
     totalTokens,
     ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+    ...(retries !== undefined && retries > 0 ? { retries } : {}),
   };
 }
 
@@ -177,11 +179,16 @@ export function mergeTokenUsage(first, second) {
     first.cachedInputTokens === undefined && second.cachedInputTokens === undefined
       ? undefined
       : (first.cachedInputTokens || 0) + (second.cachedInputTokens || 0);
+  const retries =
+    first.retries === undefined && second.retries === undefined
+      ? undefined
+      : (first.retries || 0) + (second.retries || 0);
   return {
     inputTokens: (first.inputTokens || 0) + (second.inputTokens || 0),
     outputTokens: (first.outputTokens || 0) + (second.outputTokens || 0),
     totalTokens: (first.totalTokens || 0) + (second.totalTokens || 0),
     ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
+    ...(retries !== undefined && retries > 0 ? { retries } : {}),
   };
 }
 

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -160,12 +160,15 @@ export function normalizeTokenUsage(value) {
       value.prompt_cache_hit_tokens,
   );
   const retries = tokenCount(value.retries);
+  const progressOnlyRetried =
+    value.progress_only_retried === true || value.progressOnlyRetried === true;
   return {
     inputTokens: inputTokens || 0,
     outputTokens: outputTokens || 0,
     totalTokens,
     ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
     ...(retries !== undefined && retries > 0 ? { retries } : {}),
+    ...(progressOnlyRetried ? { progressOnlyRetried: true } : {}),
   };
 }
 

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1926,6 +1926,7 @@ function observeSubagentOutcome(request, route, status, options = {}) {
         inputTokens: options.usage?.inputTokens,
         estimatedInputTokens: options.estimatedInputTokens,
         emptyCompletionRetried: options.emptyCompletionRetried,
+        progressOnlyRetried: options.progressOnlyRetried === true,
       },
     });
     if (!spawn?.exceeded) return;
@@ -2841,12 +2842,13 @@ async function handleResponses(request, response, requestUrl) {
       durationMs: Date.now() - startedAt,
       responseStartMs: upstreamLatencyMs,
       firstTokenMs,
-      retries: upstreamRetries,
       ...usage,
       estimatedInputTokens,
       ...toolResultAging,
+      retries: (upstreamRetries || 0) + (usage?.retries || 0) || undefined,
       ...(emptyCompletion ? { emptyCompletion: true } : {}),
       ...(emptyCompletionRetried ? { emptyCompletionRetried: true } : {}),
+      ...(usage?.progressOnlyRetried ? { progressOnlyRetried: true } : {}),
       ...(emptyCompletionUnrepairable ? { emptyCompletionUnrepairable: true } : {}),
       ...(guardReleasedForBudget ? { emptyCompletionGuardReleased: true } : {}),
       ...(failoverFrom ? { failoverFrom } : {}),
@@ -2859,6 +2861,7 @@ async function handleResponses(request, response, requestUrl) {
       usage,
       estimatedInputTokens,
       emptyCompletionRetried,
+      progressOnlyRetried: usage?.progressOnlyRetried === true,
     });
     usageRecorded = true;
     activityStatus = finalStatus;

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -98,6 +98,10 @@ export function recordUsageEvent({
   // cover both attempts, because both were sent and both were billed. This
   // marker is what says the reported spend belongs to two attempts at one turn.
   emptyCompletionRetried,
+  // True when the Grok OAuth forwarder retried a progress-only stop and summed
+  // both attempts into this event. Distinct from transport `retries`, which do
+  // not double the token counts.
+  progressOnlyRetried,
   // True when the turn was empty and the router could not repair it, because
   // the attempt had already been relayed: the upstream proved it was generating
   // before it produced nothing, so the hold was over and a retry would have
@@ -156,6 +160,7 @@ export function recordUsageEvent({
     ...(streamAborted === true ? { streamAborted: true } : {}),
     ...(emptyCompletion === true ? { emptyCompletion: true } : {}),
     ...(emptyCompletionRetried === true ? { emptyCompletionRetried: true } : {}),
+    ...(progressOnlyRetried === true ? { progressOnlyRetried: true } : {}),
     ...(emptyCompletionUnrepairable === true
       ? { emptyCompletionUnrepairable: true }
       : {}),
@@ -392,6 +397,7 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
           ...(event.emptyCompletionRetried === true
             ? { emptyCompletionRetried: true }
             : {}),
+          ...(event.progressOnlyRetried === true ? { progressOnlyRetried: true } : {}),
           ...(event.emptyCompletionGuardReleased === true
             ? { emptyCompletionGuardReleased: true }
             : {}),

--- a/test/context-window-drift.test.mjs
+++ b/test/context-window-drift.test.mjs
@@ -67,6 +67,11 @@ test("a retried turn's doubled prompt count is not evidence of capacity", () => 
     acceptedInputTokens(event("m", 900_000, { emptyCompletionRetried: true })),
     undefined,
   );
+  assert.equal(
+    acceptedInputTokens(event("m", 525_000, { progressOnlyRetried: true })),
+    undefined,
+  );
+  assert.equal(acceptedInputTokens(event("m", 900_000, { retries: 2 })), 900_000);
   assert.equal(acceptedInputTokens(event("m", 900_000)), 900_000);
   const drift = contextWindowDrift(MODELS, [
     event("qwen-plan/qwen3.8-max", 524_288, { emptyCompletionRetried: true }),

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -668,7 +668,13 @@ test("retries a progress-only stop once and prefers a retry that calls tools", a
     assert.equal(json.usage.progress_only_retried, true);
     const retryBody = JSON.parse(bodies[1]);
     assert.equal(retryBody.instructions, "You are Codex.");
-    assert.match(JSON.stringify(retryBody.input), /Continue the same task by calling tools now/);
+    // The nudge offers the no-tool branch first so a finished turn can decline
+    // instead of inventing a call. See "a finished task ... declines".
+    assert.match(
+      JSON.stringify(retryBody.input),
+      /already completed the task, restate the final answer and call no tool/,
+    );
+    assert.match(JSON.stringify(retryBody.input), /Otherwise continue the same task now/);
     assert.match(child.testErrors(), /progress-only-retried=true/);
   } finally {
     await stop(child);
@@ -724,6 +730,85 @@ test("keeps the first progress-only answer when the retry also has no tools", as
     assert.equal(json.choices[0].finish_reason, "stop");
     assert.equal(json.usage.completion_tokens, 1_660 + 500);
     assert.equal(json.usage.retries, 1);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// A finished task answered in one line is byte-for-byte the shape the trigger
+// looks for, so the retry fires on it and always will. What must not happen is
+// the retry manufacturing a tool call the model never meant to make and the
+// forwarder grafting it onto the answer -- the client would then run it. The
+// nudge's no-tool branch is what routes this into keep-first.
+test("a finished task answered in one line declines the retry instead of calling a tool", async () => {
+  let inbound = 0;
+  const bodies = [];
+  const backend = await mockBackend(async (req, res) => {
+    inbound += 1;
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    bodies.push(Buffer.concat(chunks).toString("utf8"));
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(
+      sse(
+        inbound === 1
+          ? [
+              { type: "response.output_text.delta", delta: "Yes, that is correct." },
+              {
+                type: "response.completed",
+                response: {
+                  usage: {
+                    input_tokens: 5_000,
+                    output_tokens: 1_500,
+                    output_tokens_details: { reasoning_tokens: 1_490 },
+                  },
+                },
+              },
+            ]
+          : // The model takes the no-tool branch the nudge offers.
+            [
+              { type: "response.output_text.delta", delta: "Yes. Nothing further to do." },
+              {
+                type: "response.completed",
+                response: { usage: { input_tokens: 5_010, output_tokens: 60 } },
+              },
+            ],
+      ),
+    );
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-finished-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "Is the config right?" }],
+        tools: [
+          { type: "function", function: { name: "exec_command", parameters: { type: "object" } } },
+        ],
+        stream: false,
+      }),
+    });
+    const json = await resp.json();
+    assert.equal(inbound, 2);
+    assert.equal(json.choices[0].finish_reason, "stop");
+    assert.equal(json.choices[0].message.content, "Yes, that is correct.");
+    assert.equal(json.choices[0].message.tool_calls, undefined);
+    // Both attempts were billed, and the marker says so.
+    assert.equal(json.usage.prompt_tokens, 5_000 + 5_010);
+    assert.equal(json.usage.progress_only_retried, true);
+    const retryBody = JSON.parse(bodies[1]);
+    assert.match(
+      JSON.stringify(retryBody.input),
+      /already completed the task, restate the final answer and call no tool/,
+    );
   } finally {
     await stop(child);
     await new Promise((r) => backend.server.close(r));

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -30,7 +30,7 @@ async function mockBackend(handler) {
   return { server, port: server.address().port };
 }
 
-function startForwarder(port, backendPort, authPath) {
+function startForwarder(port, backendPort, authPath, extraEnv = {}) {
   const child = spawn(process.execPath, [path.join(root, "src", "grok-oauth-forwarder.mjs")], {
     cwd: root,
     env: {
@@ -42,6 +42,7 @@ function startForwarder(port, backendPort, authPath) {
       GROK_CLI: path.join(root, "test", "fixtures", "missing-grok-cli"),
       GROK_AUTH_PATH: authPath,
       MODEL_ROUTER_QUIET: "1",
+      ...extraEnv,
     },
     stdio: ["ignore", "ignore", "pipe"],
   });
@@ -556,29 +557,151 @@ test("streams a function call that appears only in a final unterminated SSE bloc
   }
 });
 
-test("forwards a short reasoning-heavy answer once without retrying", async () => {
+const PROGRESS_EVENTS = [
+  { type: "response.output_text.delta", delta: "Next I will update the deck." },
+  {
+    type: "response.completed",
+    response: {
+      usage: {
+        input_tokens: 105_882,
+        output_tokens: 1_660,
+        output_tokens_details: { reasoning_tokens: 1_620 },
+      },
+    },
+  },
+];
+
+const TOOL_EVENTS = [
+  {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      id: "fc_retry",
+      call_id: "call_retry",
+      name: "exec_command",
+      arguments: '{"cmd":"dir"}',
+    },
+  },
+  {
+    type: "response.completed",
+    response: {
+      usage: {
+        input_tokens: 106_000,
+        output_tokens: 40,
+        output_tokens_details: { reasoning_tokens: 10 },
+      },
+    },
+  },
+];
+
+test("does not retry a short reasoning-heavy answer when the client offered no tools", async () => {
+  let inbound = 0;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(sse(PROGRESS_EVENTS));
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-no-tools-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "update the deck" }],
+        stream: false,
+      }),
+    });
+    const json = await resp.json();
+    assert.equal(json.choices[0].message.content, "Next I will update the deck.");
+    assert.equal(json.choices[0].finish_reason, "stop");
+    assert.equal(inbound, 1);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("retries a progress-only stop once and prefers a retry that calls tools", async () => {
+  let inbound = 0;
+  const bodies = [];
+  const backend = await mockBackend(async (req, res) => {
+    inbound += 1;
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    bodies.push(Buffer.concat(chunks).toString("utf8"));
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(sse(inbound === 1 ? PROGRESS_EVENTS : TOOL_EVENTS));
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-retry-tools-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [
+          { role: "system", content: "You are Codex." },
+          { role: "user", content: "update the deck" },
+        ],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: false,
+      }),
+    });
+    const json = await resp.json();
+    assert.equal(inbound, 2);
+    assert.equal(json.choices[0].finish_reason, "tool_calls");
+    assert.equal(json.choices[0].message.tool_calls[0].function.name, "exec_command");
+    assert.equal(json.usage.prompt_tokens, 105_882 + 106_000);
+    assert.equal(json.usage.completion_tokens, 1_660 + 40);
+    assert.equal(json.usage.retries, 1);
+    const retryBody = JSON.parse(bodies[1]);
+    assert.equal(retryBody.instructions, "You are Codex.");
+    assert.match(JSON.stringify(retryBody.input), /Continue the same task by calling tools now/);
+    assert.match(child.testErrors(), /progress-only-retried=true/);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("keeps the first progress-only answer when the retry also has no tools", async () => {
   let inbound = 0;
   const backend = await mockBackend(async (_req, res) => {
     inbound += 1;
     res.writeHead(200, { "Content-Type": "text/event-stream" });
     res.end(
-      sse([
-        { type: "response.output_text.delta", delta: "Next I will update the deck." },
-        {
-          type: "response.completed",
-          response: {
-            usage: {
-              input_tokens: 105_882,
-              output_tokens: 1_660,
-              output_tokens_details: { reasoning_tokens: 1_620 },
-            },
-          },
-        },
-      ]),
+      sse(
+        inbound === 1
+          ? PROGRESS_EVENTS
+          : [
+              { type: "response.output_text.delta", delta: "Still thinking about it." },
+              {
+                type: "response.completed",
+                response: {
+                  usage: {
+                    input_tokens: 106_000,
+                    output_tokens: 500,
+                    output_tokens_details: { reasoning_tokens: 480 },
+                  },
+                },
+              },
+            ],
+      ),
     );
   });
   const port = await openPort();
-  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-short-answer-"));
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-keep-first-"));
   const child = startForwarder(port, backend.port, writeSession(dir));
   const base = `http://127.0.0.1:${port}`;
   try {
@@ -594,11 +717,157 @@ test("forwards a short reasoning-heavy answer once without retrying", async () =
       }),
     });
     const json = await resp.json();
+    assert.equal(inbound, 2);
     assert.equal(json.choices[0].message.content, "Next I will update the deck.");
     assert.equal(json.choices[0].finish_reason, "stop");
-    assert.equal(json.usage.completion_tokens_details.reasoning_tokens, 1_620);
-    assert.equal(inbound, 1);
+    assert.equal(json.usage.completion_tokens, 1_660 + 500);
+    assert.equal(json.usage.retries, 1);
   } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("progress-only kill switch leaves the first attempt alone", async () => {
+  let inbound = 0;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(sse(PROGRESS_EVENTS));
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-kill-switch-"));
+  const child = startForwarder(port, backend.port, writeSession(dir), {
+    CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY: "0",
+  });
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "update the deck" }],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: false,
+      }),
+    });
+    const json = await resp.json();
+    assert.equal(inbound, 1);
+    assert.equal(json.choices[0].finish_reason, "stop");
+    assert.equal(json.usage.retries, undefined);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("drains a failed progress-only retry and keeps the first answer", async () => {
+  let inbound = 0;
+  let secondBodyRead = false;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    if (inbound === 1) {
+      res.writeHead(200, { "Content-Type": "text/event-stream" });
+      res.end(sse(PROGRESS_EVENTS));
+      return;
+    }
+    res.writeHead(502, { "Content-Type": "text/plain" });
+    res.write("upstream retry exploded");
+    res.end();
+    secondBodyRead = true;
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-retry-fail-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "update the deck" }],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: false,
+      }),
+    });
+    const json = await resp.json();
+    assert.equal(inbound, 2);
+    assert.equal(secondBodyRead, true);
+    assert.equal(json.choices[0].message.content, "Next I will update the deck.");
+    assert.match(child.testErrors(), /progress-only-retry-failed=true/);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("streams a long tool-offered answer before the upstream turn completes", async () => {
+  let releaseCompletion;
+  const completionGate = new Promise((resolve) => {
+    releaseCompletion = resolve;
+  });
+  const longText = "x".repeat(160);
+  const backend = await mockBackend(async (_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.write(sse([{ type: "response.output_text.delta", delta: longText }]));
+    await completionGate;
+    res.end(
+      sse([
+        { type: "response.completed", response: { usage: { input_tokens: 10, output_tokens: 40 } } },
+      ]),
+    );
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-live-long-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "continue" }],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: true,
+      }),
+    });
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let body = "";
+    let timeout;
+    await Promise.race([
+      (async () => {
+        while (!body.includes(longText)) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          body += decoder.decode(value, { stream: true });
+        }
+      })(),
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("long visible output was buffered until completion")),
+          2_000,
+        );
+      }),
+    ]);
+    clearTimeout(timeout);
+    assert.match(body, new RegExp(longText));
+    releaseCompletion();
+    for (;;) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+  } finally {
+    releaseCompletion?.();
     await stop(child);
     await new Promise((r) => backend.server.close(r));
     rmSync(dir, { recursive: true, force: true });

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -660,10 +660,12 @@ test("retries a progress-only stop once and prefers a retry that calls tools", a
     const json = await resp.json();
     assert.equal(inbound, 2);
     assert.equal(json.choices[0].finish_reason, "tool_calls");
+    assert.equal(json.choices[0].message.content, "Next I will update the deck.");
     assert.equal(json.choices[0].message.tool_calls[0].function.name, "exec_command");
     assert.equal(json.usage.prompt_tokens, 105_882 + 106_000);
     assert.equal(json.usage.completion_tokens, 1_660 + 40);
     assert.equal(json.usage.retries, 1);
+    assert.equal(json.usage.progress_only_retried, true);
     const retryBody = JSON.parse(bodies[1]);
     assert.equal(retryBody.instructions, "You are Codex.");
     assert.match(JSON.stringify(retryBody.input), /Continue the same task by calling tools now/);
@@ -868,6 +870,175 @@ test("streams a long tool-offered answer before the upstream turn completes", as
     }
   } finally {
     releaseCompletion?.();
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+async function readAll(resp) {
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let body = "";
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    body += decoder.decode(value, { stream: true });
+  }
+  return body;
+}
+
+test("streams a short tool-offered answer before the upstream turn completes", async () => {
+  let releaseCompletion;
+  const completionGate = new Promise((resolve) => {
+    releaseCompletion = resolve;
+  });
+  const backend = await mockBackend(async (_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.write(sse([{ type: "response.output_text.delta", delta: "Done." }]));
+    await completionGate;
+    res.end(
+      sse([
+        {
+          type: "response.completed",
+          response: { usage: { input_tokens: 20, output_tokens: 5 } },
+        },
+      ]),
+    );
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-live-short-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "say done" }],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: true,
+      }),
+    });
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let body = "";
+    let timeout;
+    await Promise.race([
+      (async () => {
+        while (!body.includes('"content":"Done."')) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          body += decoder.decode(value, { stream: true });
+        }
+      })(),
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("short visible output was buffered until completion")),
+          2_000,
+        );
+      }),
+    ]);
+    clearTimeout(timeout);
+    assert.match(body, /"content":"Done\."/);
+    releaseCompletion();
+    for (;;) {
+      const { done } = await reader.read();
+      if (done) break;
+    }
+  } finally {
+    releaseCompletion?.();
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("appends retry tool-call deltas onto a live progress-only stream", async () => {
+  let inbound = 0;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(sse(inbound === 1 ? PROGRESS_EVENTS : TOOL_EVENTS));
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-stream-retry-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "update the deck" }],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: true,
+      }),
+    });
+    const body = await readAll(resp);
+    assert.equal(inbound, 2);
+    assert.match(body, /Next I will update the deck/);
+    assert.match(body, /exec_command/);
+    assert.match(body, /"finish_reason":"tool_calls"/);
+    assert.match(body, /"progress_only_retried":true/);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("keeps the first streamed answer when the retry also has no tools", async () => {
+  let inbound = 0;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(
+      sse(
+        inbound === 1
+          ? PROGRESS_EVENTS
+          : [
+              { type: "response.output_text.delta", delta: "Still thinking about it." },
+              {
+                type: "response.completed",
+                response: {
+                  usage: {
+                    input_tokens: 106_000,
+                    output_tokens: 500,
+                    output_tokens_details: { reasoning_tokens: 480 },
+                  },
+                },
+              },
+            ],
+      ),
+    );
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-stream-keep-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const resp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "update the deck" }],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: true,
+      }),
+    });
+    const body = await readAll(resp);
+    assert.equal(inbound, 2);
+    assert.match(body, /Next I will update the deck/);
+    assert.doesNotMatch(body, /Still thinking about it/);
+    assert.match(body, /"finish_reason":"stop"/);
+  } finally {
     await stop(child);
     await new Promise((r) => backend.server.close(r));
     rmSync(dir, { recursive: true, force: true });

--- a/test/grok-oauth-turn.test.mjs
+++ b/test/grok-oauth-turn.test.mjs
@@ -200,7 +200,11 @@ test("withProgressOnlyNudge appends a user message so the instructions prefix st
   });
   assert.equal(nudged.messages[0].role, "system");
   assert.equal(nudged.messages.at(-1).role, "user");
-  assert.match(nudged.messages.at(-1).content, /calling tools now/);
+  // The no-tool branch comes first so a finished turn can decline rather than
+  // invent a call the client would run.
+  assert.match(nudged.messages.at(-1).content, /^If your previous message already completed/);
+  assert.match(nudged.messages.at(-1).content, /call no tool/);
+  assert.match(nudged.messages.at(-1).content, /Otherwise continue the same task now/);
 });
 
 test("mergeMappedUsage adds both attempts and marks retries", () => {

--- a/test/grok-oauth-turn.test.mjs
+++ b/test/grok-oauth-turn.test.mjs
@@ -10,8 +10,8 @@ import {
   parseSseBlockEvent,
   requestOffersClientTools,
   shouldPreferRetryTurn,
-  shouldReleaseProgressOnlyHold,
   sseDataFromBlock,
+  toolCallDeltas,
   withProgressOnlyNudge,
 } from "../src/grok-oauth-turn.mjs";
 
@@ -185,18 +185,6 @@ test("requestOffersClientTools ignores hosted-only or empty tool lists", () => {
   );
 });
 
-test("shouldReleaseProgressOnlyHold trips on a tool call or long visible text", () => {
-  assert.equal(shouldReleaseProgressOnlyHold({ contentText: "short", toolCalls: [] }), false);
-  assert.equal(
-    shouldReleaseProgressOnlyHold({ contentText: "x".repeat(121), toolCalls: [] }),
-    true,
-  );
-  assert.equal(
-    shouldReleaseProgressOnlyHold({ contentText: "short", toolCalls: [{ id: "c1" }] }),
-    true,
-  );
-});
-
 test("shouldPreferRetryTurn keeps the first answer when the retry also has no tools", () => {
   assert.equal(shouldPreferRetryTurn({ toolCalls: [] }), false);
   assert.equal(shouldPreferRetryTurn({ toolCalls: [{ id: "c1" }] }), true);
@@ -238,4 +226,28 @@ test("mergeMappedUsage adds both attempts and marks retries", () => {
   assert.equal(merged.prompt_tokens_details.cached_tokens, 160);
   assert.equal(merged.completion_tokens_details.reasoning_tokens, 1610);
   assert.equal(merged.retries, 1);
+  assert.equal(merged.progress_only_retried, true);
+});
+
+test("mergeMappedUsage still marks retries when one attempt reported no usage", () => {
+  const onlySecond = mergeMappedUsage(undefined, {
+    prompt_tokens: 10,
+    completion_tokens: 4,
+    total_tokens: 14,
+  });
+  assert.equal(onlySecond.prompt_tokens, 10);
+  assert.equal(onlySecond.retries, 1);
+  assert.equal(onlySecond.progress_only_retried, true);
+});
+
+test("toolCallDeltas drops text and keeps only tool-call chunks", () => {
+  const deltas = toolCallDeltas({
+    deltas: [
+      { content: "Next I will update the deck." },
+      { tool_calls: [{ index: 0, function: { name: "exec_command", arguments: "{" } }] },
+      { content: "ignored retry prose" },
+    ],
+  });
+  assert.equal(deltas.length, 1);
+  assert.equal(deltas[0].tool_calls[0].function.name, "exec_command");
 });

--- a/test/grok-oauth-turn.test.mjs
+++ b/test/grok-oauth-turn.test.mjs
@@ -5,7 +5,14 @@ import {
   applyResponsesEvent,
   collectResponsesEvents,
   createTurnState,
+  isProgressOnlyStop,
+  mergeMappedUsage,
+  parseSseBlockEvent,
+  requestOffersClientTools,
+  shouldPreferRetryTurn,
+  shouldReleaseProgressOnlyHold,
   sseDataFromBlock,
+  withProgressOnlyNudge,
 } from "../src/grok-oauth-turn.mjs";
 
 test("collectResponsesEvents keeps a function_call that only appears in output_item.done", () => {
@@ -134,4 +141,101 @@ test("sseDataFromBlock joins repeated data fields the way SSE requires", () => {
 test("sseDataFromBlock keeps a single data field", () => {
   assert.equal(sseDataFromBlock("data: [DONE]"), "[DONE]");
   assert.equal(sseDataFromBlock("event: ping"), undefined);
+});
+
+test("parseSseBlockEvent skips malformed JSON and leaves handlers to throw", () => {
+  assert.equal(parseSseBlockEvent("data: {not json"), undefined);
+  assert.equal(parseSseBlockEvent("data: [DONE]"), undefined);
+  assert.deepEqual(parseSseBlockEvent('data: {"type":"response.output_text.delta","delta":"x"}'), {
+    type: "response.output_text.delta",
+    delta: "x",
+  });
+});
+
+test("isProgressOnlyStop requires short text, no tools, and enough output tokens", () => {
+  const progress = {
+    contentText: "Next I will update the deck.",
+    toolCalls: [],
+    usage: { completion_tokens: 1660 },
+  };
+  assert.equal(isProgressOnlyStop(progress), true);
+  assert.equal(isProgressOnlyStop({ ...progress, toolCalls: [{ id: "c1" }] }), false);
+  assert.equal(
+    isProgressOnlyStop({ ...progress, contentText: "x".repeat(121) }),
+    false,
+  );
+  assert.equal(
+    isProgressOnlyStop({ ...progress, usage: { completion_tokens: 12 } }),
+    false,
+  );
+});
+
+test("requestOffersClientTools ignores hosted-only or empty tool lists", () => {
+  assert.equal(requestOffersClientTools({}), false);
+  assert.equal(requestOffersClientTools({ tools: [] }), false);
+  assert.equal(
+    requestOffersClientTools({ tools: [{ type: "web_search" }] }),
+    false,
+  );
+  assert.equal(
+    requestOffersClientTools({
+      tools: [{ type: "function", function: { name: "exec_command" } }],
+    }),
+    true,
+  );
+});
+
+test("shouldReleaseProgressOnlyHold trips on a tool call or long visible text", () => {
+  assert.equal(shouldReleaseProgressOnlyHold({ contentText: "short", toolCalls: [] }), false);
+  assert.equal(
+    shouldReleaseProgressOnlyHold({ contentText: "x".repeat(121), toolCalls: [] }),
+    true,
+  );
+  assert.equal(
+    shouldReleaseProgressOnlyHold({ contentText: "short", toolCalls: [{ id: "c1" }] }),
+    true,
+  );
+});
+
+test("shouldPreferRetryTurn keeps the first answer when the retry also has no tools", () => {
+  assert.equal(shouldPreferRetryTurn({ toolCalls: [] }), false);
+  assert.equal(shouldPreferRetryTurn({ toolCalls: [{ id: "c1" }] }), true);
+});
+
+test("withProgressOnlyNudge appends a user message so the instructions prefix stays put", () => {
+  const nudged = withProgressOnlyNudge({
+    model: "grok-4.6",
+    messages: [
+      { role: "system", content: "You are Codex." },
+      { role: "user", content: "update the deck" },
+    ],
+  });
+  assert.equal(nudged.messages[0].role, "system");
+  assert.equal(nudged.messages.at(-1).role, "user");
+  assert.match(nudged.messages.at(-1).content, /calling tools now/);
+});
+
+test("mergeMappedUsage adds both attempts and marks retries", () => {
+  const merged = mergeMappedUsage(
+    {
+      prompt_tokens: 100,
+      completion_tokens: 1660,
+      total_tokens: 1760,
+      prompt_tokens_details: { cached_tokens: 80 },
+      completion_tokens_details: { reasoning_tokens: 1600 },
+    },
+    {
+      prompt_tokens: 110,
+      completion_tokens: 40,
+      total_tokens: 150,
+      prompt_tokens_details: { cached_tokens: 80 },
+      completion_tokens_details: { reasoning_tokens: 10 },
+    },
+  );
+  assert.equal(merged.prompt_tokens, 210);
+  assert.equal(merged.completion_tokens, 1700);
+  assert.equal(merged.total_tokens, 1910);
+  assert.equal(merged.prompt_tokens_details.cached_tokens, 160);
+  assert.equal(merged.completion_tokens_details.reasoning_tokens, 1610);
+  assert.equal(merged.retries, 1);
 });

--- a/test/response-usage.test.mjs
+++ b/test/response-usage.test.mjs
@@ -34,8 +34,20 @@ test("normalizes Responses and Chat Completions token usage", () => {
     { inputTokens: 9, outputTokens: 4, totalTokens: 13 },
   );
   assert.deepEqual(
-    normalizeTokenUsage({ prompt_tokens: 10, completion_tokens: 4, total_tokens: 14, retries: 1 }),
-    { inputTokens: 10, outputTokens: 4, totalTokens: 14, retries: 1 },
+    normalizeTokenUsage({
+      prompt_tokens: 10,
+      completion_tokens: 4,
+      total_tokens: 14,
+      retries: 1,
+      progress_only_retried: true,
+    }),
+    {
+      inputTokens: 10,
+      outputTokens: 4,
+      totalTokens: 14,
+      retries: 1,
+      progressOnlyRetried: true,
+    },
   );
 });
 

--- a/test/response-usage.test.mjs
+++ b/test/response-usage.test.mjs
@@ -33,6 +33,10 @@ test("normalizes Responses and Chat Completions token usage", () => {
     tokenUsageFromPayload({ usage: { prompt_tokens: 9, completion_tokens: 4, total_tokens: 13 } }),
     { inputTokens: 9, outputTokens: 4, totalTokens: 13 },
   );
+  assert.deepEqual(
+    normalizeTokenUsage({ prompt_tokens: 10, completion_tokens: 4, total_tokens: 14, retries: 1 }),
+    { inputTokens: 10, outputTokens: 4, totalTokens: 14, retries: 1 },
+  );
 });
 
 test("captures provider-reported prefix-cache hits when they exist", () => {

--- a/test/subagent-turns.test.mjs
+++ b/test/subagent-turns.test.mjs
@@ -126,13 +126,22 @@ test("estimated, retry-doubled, and failed turns count as turns but not as token
   assert.equal(retried.turns, 2);
   assert.equal(retried.newInputTokens, 0);
 
+  const progressOnly = observeChildTurn({
+    spawnId: "spawn-d",
+    slug: "vendor/looper",
+    autoCompact: AUTO_COMPACT,
+    event: { status: 200, inputTokens: 5_000, progressOnlyRetried: true },
+  });
+  assert.equal(progressOnly.turns, 3);
+  assert.equal(progressOnly.newInputTokens, 0);
+
   const failed = observeChildTurn({
     spawnId: "spawn-d",
     slug: "vendor/looper",
     autoCompact: AUTO_COMPACT,
     event: { status: 503, inputTokens: 5_000 },
   });
-  assert.equal(failed.turns, 3);
+  assert.equal(failed.turns, 4);
   assert.equal(failed.newInputTokens, 0);
 
   // The next believable sample folds in the growth the skipped ones hid, so a


### PR DESCRIPTION
## Why

#264 landed the parser/mapping fixes. Genuine progress-only stops remain: short visible text, no tool calls, high `output_tokens` because Grok counts reasoning in that total. The merge note asked for a later retry PR that treats the six review points as one contract, plus a narrower `dispatchSseBlock` try/catch.

## Contract

1. **Tools gate.** Retry only when the client request offered function tools. A no-`tools` turn is never retried, even if hosted search is injected.
2. **Keep the first answer.** Prefer the retry only when it actually produces a tool call. A second short status sentence is discarded.
3. **Bounded hold, live stream afterwards.** The first byte is held only while a retry is still legal. The hold ends on a tool call, visible text above 120 characters, 1 MiB, or 30 s. Requests without client tools stream live, unchanged from #264.
4. **Logged and metered.** The retry log line is not gated on `MODEL_ROUTER_QUIET`. Emitted `usage` sums both attempts and sets `retries: 1`; `normalizeTokenUsage` forwards that into the router usage event.
5. **Kill switch.** `CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0` disables it. Thresholds are overridable.
6. **Drain a failed retry body.**

The nudge is a trailing **user** message, not `developer`/`system`, so `toResponsesRequest` does not fold it into `instructions` and cold-miss the #265 prefix cache. `x-grok-conv-id` is still derived from the original opening messages.

`dispatchSseBlock` now catches only `JSON.parse`. A handler exception is no longer swallowed as a malformed event.

## Liveness deviation, stated plainly

`EmptyCompletionGuard` releases on reasoning liveness because that path has something to show the client. This forwarder speaks Chat Completions to Codex and has no reasoning channel. Releasing on Grok reasoning would send the first client byte and make a silent retry illegal — which is the original repro. Reasoning therefore does not end the hold; the 30 s / 1 MiB caps do.

## Tests

Targeted suite: grok-oauth turn + forwarder + response-usage, 64 pass, 0 fail. `npm run check` passes.
