### PR TITLE
Fix DeepSeek reasoning replay in OpenCode Go

### DIFF
--- a/config/opencode/go/deepseek-v4-flash.json
+++ b/config/opencode/go/deepseek-v4-flash.json
@@ -33,8 +33,8 @@
       "searchTool": {
         "mode": "standalone"
       },
-      "requestProfile": "auto-tool-choice",
-      "compHash": "opencode-go-deepseek-v4-flash-v3"
+      "requestProfile": "deepseek-thinking",
+      "compHash": "opencode-go-deepseek-v4-flash-v4"
     }
   ]
 }

--- a/config/opencode/go/deepseek-v4-pro.json
+++ b/config/opencode/go/deepseek-v4-pro.json
@@ -26,8 +26,8 @@
       "inputModalities": [
         "text"
       ],
-      "requestProfile": "auto-tool-choice",
-      "compHash": "opencode-go-deepseek-v4-pro-v2"
+      "requestProfile": "deepseek-thinking",
+      "compHash": "opencode-go-deepseek-v4-pro-v3"
     }
   ]
 }

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -167,6 +167,12 @@ function coalesceAssistantMessages(messages) {
       previous?.role === "assistant" &&
       (Array.isArray(previous.tool_calls) || Array.isArray(message.tool_calls))
     ) {
+      if (
+        previous.reasoning_content === undefined &&
+        message.reasoning_content !== undefined
+      ) {
+        previous.reasoning_content = message.reasoning_content;
+      }
       combineAssistantContent(previous, message);
       if (Array.isArray(message.tool_calls) && message.tool_calls.length) {
         previous.tool_calls = [...(previous.tool_calls || []), ...message.tool_calls];
@@ -311,9 +317,29 @@ function sanitizeGeminiImageContent(messages) {
   });
 }
 
-function sanitizeChatToolHistory(messages, provider) {
+// DeepSeek thinking mode requires an assistant `reasoning_content` field on
+// every replayed assistant message, including messages whose reasoning was
+// empty. Preserve a real value when the upstream translator supplied one and
+// use the protocol-valid empty string when the history has no trace to replay.
+// The model profile is the capability declaration; this is intentionally not
+// a provider-wide rule because other models behind the same reseller may not
+// accept the field.
+function ensureDeepSeekReasoningContent(messages, model) {
+  if (model?.requestProfile !== "deepseek-thinking") return messages;
+  return messages.map((message) => {
+    if (message?.role !== "assistant" || message.reasoning_content !== undefined) {
+      return message;
+    }
+    return { ...message, reasoning_content: "" };
+  });
+}
+
+function sanitizeChatToolHistory(messages, provider, model) {
   if (!Array.isArray(messages)) return messages;
-  const repaired = ensureToolResultsForCalls(coalesceAssistantMessages(messages));
+  const repaired = ensureDeepSeekReasoningContent(
+    ensureToolResultsForCalls(coalesceAssistantMessages(messages)),
+    model,
+  );
   return isGeminiProvider(provider)
     ? ensureGeminiThoughtSignatures(sanitizeGeminiImageContent(repaired))
     : repaired;
@@ -379,7 +405,7 @@ function normalizeBody(buffer, contentType, route) {
   // Other provider payloads keep it unchanged.
   if (provider.id === "fireworks") delete payload.web_search_options;
   if (Array.isArray(payload.messages)) {
-    payload.messages = sanitizeChatToolHistory(payload.messages, provider);
+    payload.messages = sanitizeChatToolHistory(payload.messages, provider, model);
   }
   if (provider.authProfile === "github-copilot") {
     // This is native ChatGPT account metadata, not an upstream scheduling

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3243,6 +3243,64 @@ test("API forwarder routes opencode Go chat, Messages, and Responses surfaces", 
   }
 });
 
+test("API forwarder replays DeepSeek reasoning fields for opencode Go V4", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    OPENCODE_GO_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    OPENCODE_API_KEY: "TEST_OPENCODE_GO_API_KEY",
+    OPENCODE_GO_API_KEY: "TEST_OPENCODE_GO_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const toolCall = {
+    id: "call_deepseek",
+    type: "function",
+    function: { name: "exec_command", arguments: "{}" },
+  };
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "opencode-go-deepseek-v4-flash",
+          messages: [
+            { role: "user", content: "run it" },
+            { role: "assistant", tool_calls: [toolCall] },
+            { role: "tool", tool_call_id: "call_deepseek", content: "done" },
+            {
+              role: "assistant",
+              content: "continuing",
+              reasoning_content: "preserved reasoning",
+            },
+          ],
+        }),
+      },
+    );
+    assert.equal(response.status, 200);
+    const messages = upstreamRequests[0].body.messages;
+    assert.equal(upstreamRequests[0].body.model, "deepseek-v4-flash");
+    assert.equal(messages[1].reasoning_content, "");
+    assert.equal(messages[3].reasoning_content, "preserved reasoning");
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder routes Command Code chat and Messages surfaces", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
## Summary

Preserve DeepSeek V4 reasoning content when Codex history is replayed through OpenCode Go.

The router now:
- marks OpenCode Go DeepSeek V4 Flash and Pro as thinking models;
- keeps existing reasoning_content values;
- sends an empty reasoning_content field when the history has no value;
- carries the field through split assistant tool-call messages.

This is model-profile based and does not change other providers.

## Validation

- node --test test/routing.test.mjs (60 passed)
- codex doctor
- OpenCode Go routing test added
