### PR TITLE
feat: add multi-credential pools with configurable rotation strategies (inspired by Hermes)

### DIFF
--- a/bin/credential-pool
+++ b/bin/credential-pool
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+exec node "$repo_dir/src/credential-pool-cli.mjs" "$@"

--- a/docs/CREDENTIAL-POOLS.md
+++ b/docs/CREDENTIAL-POOLS.md
@@ -1,0 +1,116 @@
+# Credential Pools — multi-account / multi-key pools
+
+Codex Router now supports **multiple credentials (API keys) for the same provider** and automatically rotates among them when one is rate-limited or quota-exhausted — similar to [Hermes Agent — Credential Pools](https://hermes-agent.nousresearch.com/docs/user-guide/features/credential-pools).
+
+Inspired by Hermes, implemented router-native: no Hermes code is copied, the design follows the same four rotation strategies.
+
+## Why
+
+A single API key dies on `429` / `402` / “usage limit reached” mid-session. Pools keep the session alive by trying the next healthy key for the *same* provider before falling back to a *different* provider (`model-failover`). The native ChatGPT/Codex account is never pooled.
+
+## Quick start
+
+```sh
+# Add a second key for the same provider (deepseek, openrouter, grok-api, etc.)
+./bin/credential-pool add deepseek --label backup --api-key sk-...
+# or hidden prompt:
+./bin/credential-pool add openrouter
+
+# Inspect
+./bin/credential-pool list
+./bin/credential-pool list deepseek
+
+# Choose strategy (default: fill_first)
+./bin/credential-pool strategy deepseek round_robin
+./bin/credential-pool strategy deepseek least_used
+./bin/credential-pool strategy deepseek random
+./bin/credential-pool strategy deepseek fill_first
+
+# Manual reset after a quota refills / limit raised
+./bin/credential-pool reset deepseek
+./bin/credential-pool reset --all
+
+# Remove one key (by 1-based index or id)
+./bin/credential-pool remove deepseek 2
+./bin/credential-pool remove deepseek a1b2c3d4
+```
+
+`bin/provider-key <provider> set` (single-key path) continues to work. The first `credential-pool add` auto-seeds the existing `STATE_DIR/<provider>*.secret` as `primary`, so enabling pools never discards a working key.
+
+## Rotation strategies
+
+Set per-provider via CLI or by editing `STATE_DIR/credential-pools.json` (`strategy` field).
+
+| Strategy | Behaviour |
+|---|---|
+| `fill_first` *(default)* | Use the first healthy key until exhausted, then move to the next. |
+| `round_robin` | Cycle evenly through healthy keys. |
+| `least_used` | Always pick the key with the lowest `requestCount`. |
+| `random` | Random among healthy keys. |
+
+`--json` on every command emits machine-readable output.
+
+## Automatic rotation
+
+`src/api-forwarder.mjs` selects a healthy key per strategy (cooldown-aware) and, after each upstream response, marks the used key:
+
+| Upstream | Action | Cooldown |
+|---|---|---|
+| `429` (generic/burst) | Retry same key **once** (transient); second `429` → rotate | 1h (honours `Retry-After` capped 6h) |
+| `402` or `out_of_usage` (`insufficient_quota`, `usage limit reached`, balance/arrears — including Chinese `余额不足/欠费/额度`) | **Immediately rotate** (no retry — cap won't clear) | 1h |
+| `401/403` | Rotate | 5m |
+| `entitlement` (“plan doesn't include API”, Go vs Provider) | **No rotate** (no key on same provider fixes it) | — |
+| `200` | Clear `hasRetried429` + cooldown, increment `requestCount` | — |
+| **All keys exhausted** | Surfaces `503`/`429` — router's cross-provider `model-failover` then activates |
+
+Healthy = `cooldownUntil` absent or expired. Cooldown is per-key, not per-provider. Request counts and `lastUsedAt` are persisted for `least_used`/`round_robin`.
+
+## Management commands
+
+```
+credential-pool list [provider]              - list pools or one provider
+credential-pool add <provider> [--label L] [--api-key K]
+credential-pool remove <provider> <index|id>
+credential-pool strategy <provider> [strategy]
+credential-pool reset <provider|--all>
+```
+
+Aliases: `status` = `list`, both argument orders accepted (`list <provider>` / `<provider> list`).
+
+## Storage & safety
+
+* `STATE_DIR/credential-pools.json` — versioned pool metadata only (no secrets), `0600` + `protectPrivateFile` (`icacls` on Windows).
+* Each pool member → `STATE_DIR/<credential.file>.pool.<id>.secret` (`0600`), fingerprinted `sha256:16`. Env-var / Keychain members are read-only and never persisted inline.
+* Duplicate keys rejected by fingerprint.
+* Removing a pool member deletes its pool file only under `STATE_DIR`; the primary `<provider>.secret` is deleted only when explicitly removed.
+* Empty pool entry is pruned (no empty strategy shell).
+* No breaking change: no pool file = original single-key behaviour; `provider-selection` reports pooled providers as configured when the pool has any entry, otherwise classic file check.
+
+## Compatibility
+
+* Poolable: `openai-compatible` providers with `credential.file` (e.g. `deepseek`, `openrouter`, `grok-api`, `commandcode`, `xiaomi-mimo`, `zai`, `siliconflow`, etc.). `variantOf` families share one pool via canonical id.
+* Not poolable: `keyless` (local Ollama), `anonymous` (`opencode-free`, `kilo-free`), `per-model` (`custom`) — rejected with an explanation.
+* OAuth (`kimi-oauth`, `grok-oauth`) pooling is scaffolded but not yet routed; API-key pools are the primary use-case (rate/plan limits). Native ChatGPT (`openai` native path) is never pooled.
+* Credential isolation (`api-forwarder` injects only the selected pool key as `Authorization`/`x-api-key`) and existing `file-security`, `provider-selection`, `health-cache`, `model-failover` and `grok/kimi-oauth` flows are preserved.
+
+## Architecture
+
+```
+request → hasCredentialPool(id) ? selectCredential(id)   // strategy + cooldown
+        : resolveProviderCredential(endpoint)               // classic
+        → upstream fetch → markCredentialSuccess / markCredentialFailure
+        → next request picks next healthy key; if none, failover to other provider
+```
+
+Key modules: `src/credential-pool.mjs` (manager), `src/credential-pool-cli.mjs` (CLI), `src/provider-selection.mjs` (picker integration), `src/api-forwarder.mjs` (selection + marking).
+
+## Limitations & next steps
+
+* In-request immediate retry (same turn) currently marks for *next* turn; bounded in-request pool loop (retry same turn with next key) is the planned follow-up — today the next turn rotates, which already rescues sessions.
+* No non-interactive `auth add --type oauth` pooling yet; single OAuth session path still managed by `kimi login` / `grok login`.
+* Per-credential `Retry-After` / `reset_at` could promote to per-key `retryAt` header exposure in `doctor`.
+* Future: `provider-key` could delegate to `credential-pool add` with a `--pool` flag.
+
+## Reference
+
+Design inspiration: [Hermes Agent Credential Pools](https://hermes-agent.nousresearch.com/docs/user-guide/features/credential-pools). Hermes is `agent/credential_pool.py` + `hermes_cli/auth_commands.py`; this implementation is router-native and follows the spirit, not the code.

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -868,7 +868,19 @@ async function handleRequest(request, response) {
   // Resolved against the endpoint, not the provider: a per-model endpoint keeps
   // its credential under its own slug, so two custom models on two hosts never
   // share a key and one missing key never blocks the other model.
-  const credential = resolveProviderCredential(normalized.endpoint);
+  // Credential pools: if provider has a pool, select from it (strategy + cooldown aware); otherwise single-key path.
+  const poolIdForRequest = (() => {
+    try {
+      const prov = normalized.provider;
+      if (!prov?.credential?.file) return null;
+      if (prov.keyless || prov.authMode === "anonymous" || prov.authMode === "per-model") return null;
+      const cand = prov.id;
+      const canon = (prov.variantOf) ? prov.variantOf : cand;
+      return hasCredentialPool(canon) ? canon : null;
+    } catch { return null; }
+  })();
+  const poolCred = poolIdForRequest ? selectCredential(poolIdForRequest) : null;
+  const credential = poolCred ? { value: poolCred.value, source: poolCred.source, persistent: true } : resolveProviderCredential(normalized.endpoint);
   if (!credential) {
     const setup = credentialStatus(normalized.endpoint).setup;
     const credentialType = credentialLabel(normalized.endpoint);
@@ -1021,6 +1033,21 @@ async function handleRequest(request, response) {
   // this state once per turn to repeat what it already said.
   if (commandCode?.recheck && upstream.ok) {
     recordCommandCodeRoute(commandCode.id, credential.value, { providerApi: true });
+  }
+  // Credential pool bookkeeping: on success clear retry/cooldown, on pool-rotatable error mark exhausted.
+  if (poolIdForRequest && poolCred) {
+    if (upstream.ok) {
+      try { markCredentialSuccess(poolIdForRequest, poolCred.id); } catch {}
+    } else {
+      try {
+        const raw = await upstream.clone().text().catch(() => "");
+        markCredentialFailure(poolIdForRequest, poolCred.id, {
+          status: upstream.status,
+          bodyText: raw,
+          retryAfterSeconds: Number(upstream.headers.get("retry-after")),
+        });
+      } catch {}
+    }
   }
   await pipeResponse(upstream, response);
   recordUpstreamLimits(normalized, upstream);

--- a/src/credential-pool-cli.mjs
+++ b/src/credential-pool-cli.mjs
@@ -1,0 +1,341 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { execFileSync } from "node:child_process";
+import { closeSync, openSync, readSync, writeSync } from "node:fs";
+
+import {
+  VALID_STRATEGIES,
+  DEFAULT_STRATEGY,
+  getPool,
+  listPools,
+  getStrategy,
+  setStrategy,
+  strategyLabel,
+  addCredential,
+  removeCredential,
+  resetCooldowns,
+  credentialPoolStatus,
+  POOL_PATH,
+} from "./credential-pool.mjs";
+import { PROVIDERS } from "./model-registry.mjs";
+import { credentialStatus } from "./provider-credentials.mjs";
+
+const providerId = process.argv[2];
+const command = process.argv[3];
+
+function usage() {
+  console.error(`Usage:
+  credential-pool.mjs list [provider]                 - List pools or one provider's pool
+  credential-pool.mjs add <provider> [--label L] [--api-key KEY]
+                                                     - Add a credential to a provider's pool
+  credential-pool.mjs remove <provider> <index|id>   - Remove a credential by 1-based index or id
+  credential-pool.mjs strategy <provider> [strategy] - Show or set rotation strategy
+  credential-pool.mjs reset <provider|--all>          - Clear cooldowns / exhaustion
+  credential-pool.mjs status [provider]               - Alias for list
+
+Strategies: ${VALID_STRATEGIES.join(", ")} (default: ${DEFAULT_STRATEGY})
+
+Examples:
+  credential-pool.mjs list
+  credential-pool.mjs list deepseek
+  credential-pool.mjs add deepseek --label backup --api-key sk-...
+  credential-pool.mjs add openrouter   # hidden prompt
+  credential-pool.mjs strategy deepseek round_robin
+  credential-pool.mjs reset deepseek
+  credential-pool.mjs remove deepseek 2`);
+  process.exit(2);
+}
+
+function optionValue(name) {
+  const idx = process.argv.indexOf(name);
+  return idx === -1 ? undefined : process.argv[idx + 1];
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+// Hidden prompt — copied from src/provider-key.mjs so this CLI does not depend
+// on a shared helper that might change its TTY contract. The logic is small
+// and self-contained.
+const WINDOWS_HIDDEN_PROMPT_SCRIPT = [
+  "$secret = Read-Host $env:CODEX_ROUTER_PROMPT_LABEL -AsSecureString",
+  "$pointer = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secret)",
+  "try { [Console]::Out.Write([Runtime.InteropServices.Marshal]::PtrToStringBSTR($pointer)) } finally { [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($pointer) }",
+].join("; ");
+
+function windowsHiddenPromptArgs(script = WINDOWS_HIDDEN_PROMPT_SCRIPT) {
+  return [
+    "-NoLogo",
+    "-NoProfile",
+    "-EncodedCommand",
+    Buffer.from(script, "utf16le").toString("base64"),
+  ];
+}
+
+function powerShellStartupError(failures) {
+  return (
+    failures.find((error) => error?.code !== "ENOENT") ||
+    new Error(
+      "PowerShell is required for hidden API-key input, but neither powershell.exe nor pwsh.exe could be started.",
+    )
+  );
+}
+
+function hiddenPrompt(label) {
+  if (process.platform === "win32") {
+    const args = windowsHiddenPromptArgs();
+    const failures = [];
+    for (const executable of ["powershell.exe", "pwsh.exe"]) {
+      try {
+        return execFileSync(executable, args, {
+          encoding: "utf8",
+          env: { ...process.env, CODEX_ROUTER_PROMPT_LABEL: label },
+          stdio: ["inherit", "pipe", "inherit"],
+        });
+      } catch (error) {
+        failures.push(error);
+      }
+    }
+    throw powerShellStartupError(failures);
+  }
+  let descriptor;
+  try {
+    descriptor = openSync("/dev/tty", "r+");
+  } catch {
+    throw new Error("An interactive terminal is required to enter an API key.");
+  }
+  let terminalState;
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    if (terminalState) {
+      try {
+        execFileSync("/bin/stty", [terminalState], {
+          stdio: [descriptor, "ignore", descriptor],
+        });
+      } catch {}
+    }
+    try {
+      writeSync(descriptor, "\n");
+    } catch {}
+  };
+  const interrupted = (signal) => {
+    cleanup();
+    process.exit(signal === "SIGHUP" ? 129 : signal === "SIGINT" ? 130 : 143);
+  };
+  const handlers = new Map(
+    ["SIGHUP", "SIGINT", "SIGTERM"].map((signal) => [
+      signal,
+      () => interrupted(signal),
+    ]),
+  );
+  try {
+    terminalState = execFileSync("/bin/stty", ["-g"], {
+      encoding: "utf8",
+      stdio: [descriptor, "pipe", descriptor],
+    }).trim();
+    for (const [signal, handler] of handlers) process.on(signal, handler);
+    writeSync(descriptor, `${label}: `);
+    execFileSync("/bin/stty", ["-echo"], {
+      stdio: [descriptor, "ignore", descriptor],
+    });
+    const chunks = [];
+    const byte = Buffer.alloc(1);
+    while (readSync(descriptor, byte, 0, 1) === 1) {
+      if (byte[0] === 10 || byte[0] === 13) break;
+      chunks.push(Buffer.from(byte));
+    }
+    return Buffer.concat(chunks).toString("utf8");
+  } finally {
+    for (const [signal, handler] of handlers) process.off(signal, handler);
+    cleanup();
+    try {
+      closeSync(descriptor);
+    } catch {}
+  }
+}
+
+function formatPoolStatus(status, asJson) {
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(status, null, 2)}\n`);
+    return;
+  }
+  if (!status.exists) {
+    process.stdout.write(`${status.provider}: no credential pool (single-credential mode). Single credential ${credentialStatus(status.provider).configured ? "is configured" : "is not configured"}.\n`);
+    process.stdout.write(`  Strategy (when pool is created): ${status.strategy} — ${strategyLabel(status.strategy)}\n`);
+    return;
+  }
+  process.stdout.write(
+    `${status.provider} (strategy: ${status.strategy} — ${strategyLabel(status.strategy).split(" — ")[1] || status.strategy}) — ${status.healthy}/${status.total} healthy:\n`,
+  );
+  for (const cred of status.credentials) {
+    const health = cred.healthy ? "ok" : `cooldown until ${cred.cooldownUntil}`;
+    const retry = cred.hasRetried429 ? " (has retried 429 once)" : "";
+    process.stdout.write(
+      `  #${cred.index}  ${cred.id}  ${cred.label}  ${cred.source}  requests=${cred.requestCount}  status=${cred.lastStatus}  ${health}${retry}\n`,
+    );
+  }
+}
+
+async function main() {
+  const rawArgs = process.argv.slice(2);
+  if (rawArgs.length === 0 || hasFlag("--help") || hasFlag("-h")) usage();
+
+  // Support both `credential-pool list deepseek` and `credential-pool deepseek list`
+  // by normalizing to: <provider> <command> vs <command> [provider]
+  // The requested spec is: commands to list/add/remove/strategy/reset — with
+  // provider as first arg for most. We'll support both orderings.
+  let cmd = rawArgs[0];
+  let target = rawArgs[1];
+
+  // If first token is a known provider id and second token is a known command,
+  // swap them: `deepseek list` -> `list deepseek`
+  const knownCommands = new Set(["list", "status", "add", "remove", "strategy", "reset"]);
+  if (PROVIDERS.has(cmd) && knownCommands.has(target)) {
+    const tmp = cmd;
+    cmd = target;
+    target = tmp;
+    // Shift remaining args
+    rawArgs[0] = cmd;
+    rawArgs[1] = target;
+  }
+
+  const asJson = hasFlag("--json");
+  // For commands that read provider from argv[1] position, re-derive.
+  // list/status can be without provider -> show all
+  if (cmd === "list" || cmd === "status") {
+    const provider = target && !target.startsWith("-") ? target : undefined;
+    if (provider) {
+      if (!PROVIDERS.has(provider) && !PROVIDERS.has(provider.toLowerCase())) {
+        console.error(`Unknown provider: ${provider}`);
+        process.exit(1);
+      }
+      const status = credentialPoolStatus(provider);
+      formatPoolStatus(status, asJson);
+    } else {
+      const pools = listPools();
+      if (!pools.length) {
+        if (asJson) {
+          process.stdout.write(`${JSON.stringify({ pools: [] }, null, 2)}\n`);
+        } else {
+          process.stdout.write(`No credential pools configured. Each provider is in single-credential mode.\nAdd a second credential with: credential-pool add <provider>\n`);
+        }
+        return;
+      }
+      for (const pool of pools) {
+        const status = credentialPoolStatus(pool.id);
+        formatPoolStatus(status, asJson);
+        if (!asJson) process.stdout.write("\n");
+      }
+    }
+    return;
+  }
+
+  if (cmd === "add") {
+    const provider = target;
+    if (!provider) {
+      console.error("Usage: credential-pool add <provider> [--label L] [--api-key KEY]");
+      process.exit(2);
+    }
+    const label = optionValue("--label") || optionValue("--name");
+    let apiKey = optionValue("--api-key") || optionValue("--key");
+    if (!apiKey) {
+      // Fallback to environment or prompt
+      const providerObj = PROVIDERS.get(provider);
+      const promptLabel = providerObj?.credential?.prompt || `${provider} API key`;
+      process.stderr.write(`Enter ${promptLabel} (input hidden):\n`);
+      apiKey = hiddenPrompt(promptLabel);
+    }
+    try {
+      const result = addCredential(provider, apiKey, { label });
+      process.stdout.write(`Added credential "${result.credential.label}" (${result.credential.id}) to ${result.provider} pool at index #${result.index}. Total: ${credentialPoolStatus(provider).total}\n`);
+      if (asJson) {
+        process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      }
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (cmd === "remove") {
+    const provider = target;
+    const identifier = rawArgs[2] || optionValue("--id") || optionValue("--index");
+    if (!provider || !identifier) {
+      console.error("Usage: credential-pool remove <provider> <index|id>");
+      process.exit(2);
+    }
+    try {
+      const result = removeCredential(provider, identifier);
+      process.stdout.write(`Removed credential ${result.removed.label || result.removed.id} from ${result.provider} pool. Remaining: ${result.remaining}\n`);
+      if (asJson) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (cmd === "strategy") {
+    const provider = target;
+    if (!provider) {
+      console.error("Usage: credential-pool strategy <provider> [strategy]");
+      process.exit(2);
+    }
+    const newStrategy = rawArgs[2] && !rawArgs[2].startsWith("-") ? rawArgs[2] : optionValue("--set");
+    if (newStrategy) {
+      try {
+        const result = setStrategy(provider, newStrategy);
+        process.stdout.write(`Set ${result.provider} rotation strategy to ${result.strategy} — ${strategyLabel(result.strategy).split(" — ")[1] || result.strategy}\n`);
+        if (asJson) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    } else {
+      const current = getStrategy(provider);
+      if (asJson) {
+        process.stdout.write(`${JSON.stringify({ provider, strategy: current }, null, 2)}\n`);
+      } else {
+        process.stdout.write(`${provider} rotation strategy: ${current} — ${strategyLabel(current).split(" — ")[1] || current}\n`);
+      }
+    }
+    return;
+  }
+
+  if (cmd === "reset") {
+    const provider = target;
+    if (!provider) {
+      console.error("Usage: credential-pool reset <provider|--all>");
+      process.exit(2);
+    }
+    if (provider === "--all" || provider === "all") {
+      const result = resetCooldowns(undefined);
+      process.stdout.write(`Reset cooldowns for all pools: ${result.reset} credential(s) reset.\n`);
+      if (asJson) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    } else {
+      try {
+        const result = resetCooldowns(provider);
+        process.stdout.write(`Reset cooldowns for ${result.provider}: ${result.reset} credential(s) reset.\n`);
+        if (asJson) process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    }
+    return;
+  }
+
+  usage();
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/src/credential-pool.mjs
+++ b/src/credential-pool.mjs
@@ -1,0 +1,705 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+  chmodSync,
+  renameSync,
+} from "node:fs";
+import path from "node:path";
+import { randomUUID, createHash } from "node:crypto";
+
+import { protectPrivateFile, writePrivateJson } from "./file-security.mjs";
+import { STATE_DIR } from "./paths.mjs";
+import { PROVIDERS } from "./model-registry.mjs";
+import {
+  apiProvider,
+  primaryCredentialPath,
+  credentialPaths,
+  resolveProviderCredential,
+} from "./provider-credentials.mjs";
+import { upstreamFailureKind, extractUpstreamDetail } from "./error-translation.mjs";
+
+// ─── Credential pools: same-provider rotation ─────────────────────────────────
+//
+// Hermes Agent's Credential Pools let one provider hold many API keys and rotate
+// among them when one is rate-limited or quota-exhausted. This module brings
+// that spirit to Codex Router for external API-key providers.
+//
+// A pool is per *canonical* provider id (variantOf collapses to its parent), so
+// `opencode-go` and its protocol variants share one pool. Keyless, anonymous,
+// and per-model-endpoint providers cannot have pools — they carry no credential
+// or their credential lives per model.
+//
+// Storage
+// ───────
+// Pool metadata lives in STATE_DIR/credential-pools.json (protected 0600). No
+// secret is stored there — each pool member's secret lives in its own
+// protected file under STATE_DIR. The pool file only records the file path
+// plus bookkeeping (request counts, cooldowns, labels).
+//
+// Backward compatibility
+// ──────────────────────
+// An install with no pool file behaves exactly as before: resolveProvider-
+// Credential is the sole credential source. The first `credential-pool add`
+// seeds the pool from the existing primary credential file if one exists, so
+// enabling pools never discards a working key.
+
+export const POOL_PATH =
+  process.env.MODEL_ROUTER_CREDENTIAL_POOLS ||
+  path.join(STATE_DIR, "credential-pools.json");
+
+export const VALID_STRATEGIES = Object.freeze([
+  "fill_first",
+  "round_robin",
+  "least_used",
+  "random",
+]);
+export const DEFAULT_STRATEGY = "fill_first";
+
+// Cooldowns: match Hermes's defaults (1h for billing/quota/rate-limit, 5m for
+// auth) but honour provider-supplied Retry-After when present.
+export const DEFAULT_COOLDOWN_MS = 60 * 60 * 1_000;
+export const AUTH_COOLDOWN_MS = 5 * 60 * 1_000;
+export const MAX_COOLDOWN_MS = 6 * 60 * 60 * 1_000;
+
+function nowMs(now) {
+  return Number.isFinite(now) ? now : Date.now();
+}
+
+function cappedUntil(at, durationMs) {
+  return new Date(at + Math.min(durationMs, MAX_COOLDOWN_MS)).toISOString();
+}
+
+function isoOrUndefined(value) {
+  const ms = typeof value === "string" ? Date.parse(value) : Number(value);
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : undefined;
+}
+
+function canonicalId(providerId) {
+  const id = String(providerId || "").trim();
+  if (!id) return "";
+  // Collapse protocol variants (registry `variantOf`) to their canonical parent,
+  // matching provider-selection's canonicalProviderId without creating a cycle.
+  const provider = PROVIDERS.get(id);
+  if (provider?.variantOf) return provider.variantOf;
+  return id;
+}
+
+function providerForPool(providerId) {
+  const id = canonicalId(providerId);
+  const provider = PROVIDERS.get(id);
+  if (!provider) throw new Error(`Unknown provider: ${providerId}`);
+  if (provider.kind !== "openai-compatible") {
+    throw new Error(`Provider ${id} does not use API-key credentials and cannot have a pool.`);
+  }
+  if (provider.keyless || ["anonymous", "per-model"].includes(provider.authMode)) {
+    throw new Error(`Provider ${id} carries no credential and cannot have a pool.`);
+  }
+  if (!provider.credential?.file) {
+    throw new Error(`Provider ${id} is missing credential metadata and cannot have a pool.`);
+  }
+  return provider;
+}
+
+function providerIsPoolable(providerId) {
+  try {
+    providerForPool(providerId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readPoolDocument() {
+  if (!existsSync(POOL_PATH)) return { version: 1, pools: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(POOL_PATH, "utf8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return { version: 1, pools: {} };
+    if (parsed.version !== 1) return { version: 1, pools: {} };
+    if (!parsed.pools || typeof parsed.pools !== "object") return { version: 1, pools: {} };
+    return { version: 1, pools: parsed.pools };
+  } catch {
+    return { version: 1, pools: {} };
+  }
+}
+
+function writePoolDocument(document) {
+  const toWrite = { version: 1, pools: document.pools || {} };
+  try {
+    writePrivateJson(POOL_PATH, toWrite, { directoryMode: 0o700 });
+  } catch (error) {
+    // Pool bookkeeping must never take routing down, but writes here are CLI-
+    // initiated and should surface.
+    throw error;
+  }
+  return toWrite;
+}
+
+function poolMemberFile(provider, id) {
+  const primary = primaryCredentialPath(provider);
+  const dir = path.dirname(primary);
+  const base = path.basename(primary, path.extname(primary));
+  const ext = path.extname(primary) || ".secret";
+  // e.g. deepseek-api-key.pool.a1b2c3d4.secret
+  return path.join(dir, `${base}.pool.${id}${ext}`);
+}
+
+function generateId() {
+  return randomUUID().replaceAll("-", "").slice(0, 8);
+}
+
+function fingerprint(value) {
+  return `sha256:${createHash("sha256").update(String(value)).digest("hex").slice(0, 16)}`;
+}
+
+function ensurePoolEntry(providerId) {
+  const id = canonicalId(providerId);
+  const doc = readPoolDocument();
+  if (!doc.pools[id]) {
+    doc.pools[id] = {
+      strategy: DEFAULT_STRATEGY,
+      credentials: [],
+      state: { roundRobinIndex: 0 },
+    };
+  } else {
+    if (!VALID_STRATEGIES.includes(doc.pools[id].strategy)) {
+      doc.pools[id].strategy = DEFAULT_STRATEGY;
+    }
+    if (!Array.isArray(doc.pools[id].credentials)) doc.pools[id].credentials = [];
+    if (!doc.pools[id].state || typeof doc.pools[id].state !== "object") {
+      doc.pools[id].state = { roundRobinIndex: 0 };
+    }
+    if (!Number.isFinite(doc.pools[id].state.roundRobinIndex)) {
+      doc.pools[id].state.roundRobinIndex = 0;
+    }
+  }
+  return { doc, pool: doc.pools[id], id };
+}
+
+function isHealthy(credential, now) {
+  const at = nowMs(now);
+  const until = isoOrUndefined(credential.cooldownUntil);
+  if (!until) return true;
+  return Date.parse(until) <= at;
+}
+
+function healthyCredentials(pool, now) {
+  const at = nowMs(now);
+  return pool.credentials.filter((cred) => isHealthy(cred, at));
+}
+
+function readSecretFile(filePath) {
+  try {
+    const value = readFileSync(filePath, "utf8").trim();
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeSecretFile(filePath, value) {
+  const key = String(value || "").trim();
+  if (!key) throw new Error("No credential value was provided; nothing changed.");
+  mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  chmodSync(path.dirname(filePath), 0o700);
+  const temporary = `${filePath}.tmp.${process.pid}`;
+  writeFileSync(temporary, `${key}\n`, { encoding: "utf8", mode: 0o600 });
+  try {
+    protectPrivateFile(temporary);
+    renameSync(temporary, filePath);
+    protectPrivateFile(filePath);
+  } catch (error) {
+    if (existsSync(temporary)) unlinkSync(temporary);
+    throw error;
+  }
+  return filePath;
+}
+
+// ── Public: pool metadata ───────────────────────────────────────────────────
+
+export function getPool(providerId) {
+  const id = canonicalId(providerId);
+  const doc = readPoolDocument();
+  return doc.pools[id] ? { ...doc.pools[id], id } : undefined;
+}
+
+export function listPools() {
+  const doc = readPoolDocument();
+  return Object.entries(doc.pools).map(([id, pool]) => ({ id, ...pool }));
+}
+
+export function getStrategy(providerId) {
+  const id = canonicalId(providerId);
+  const doc = readPoolDocument();
+  const pool = doc.pools[id];
+  if (!pool) return DEFAULT_STRATEGY;
+  return VALID_STRATEGIES.includes(pool.strategy) ? pool.strategy : DEFAULT_STRATEGY;
+}
+
+export function setStrategy(providerId, strategy) {
+  const provider = providerForPool(providerId);
+  const normalized = String(strategy || "").trim().toLowerCase();
+  if (!VALID_STRATEGIES.includes(normalized)) {
+    throw new Error(`Unknown rotation strategy "${strategy}". Valid: ${VALID_STRATEGIES.join(", ")}`);
+  }
+  const { doc, pool, id } = ensurePoolEntry(provider.id);
+  pool.strategy = normalized;
+  writePoolDocument(doc);
+  return { provider: id, strategy: normalized };
+}
+
+export function strategyLabel(strategy) {
+  const labels = {
+    fill_first: "fill_first — use the first healthy credential until exhausted, then move to the next (default)",
+    round_robin: "round_robin — cycle evenly through healthy credentials",
+    least_used: "least_used — always pick the credential with the lowest request count",
+    random: "random — randomly select among healthy credentials",
+  };
+  return labels[strategy] || strategy;
+}
+
+// ── Public: credential CRUD ─────────────────────────────────────────────────
+
+export function addCredential(providerId, value, options = {}) {
+  const provider = providerForPool(providerId);
+  const key = String(value || "").trim();
+  if (!key) throw new Error("No credential value was provided; nothing changed.");
+  const label = typeof options.label === "string" ? options.label.trim() : "";
+  const { doc, pool, id } = ensurePoolEntry(provider.id);
+
+  // Seed from primary file on first pool use. The primary file is the operator's
+  // existing single credential; promoting it into the pool keeps it live and
+  // makes the pool's first entry the one the install already authenticates with.
+  if (pool.credentials.length === 0) {
+    const primaryPath = primaryCredentialPath(provider);
+    const primaryValue = readSecretFile(primaryPath);
+    if (primaryValue) {
+      const primaryFingerprint = fingerprint(primaryValue);
+      const alreadySeeded = pool.credentials.some((cred) => cred.file === primaryPath);
+      if (!alreadySeeded) {
+        // If the new key is identical to the primary, don't create a duplicate.
+        if (fingerprint(key) !== primaryFingerprint) {
+          pool.credentials.push({
+            id: generateId(),
+            label: "primary",
+            file: primaryPath,
+            source: "file",
+            fingerprint: primaryFingerprint,
+            createdAt: new Date().toISOString(),
+            requestCount: 0,
+            cooldownUntil: null,
+            lastStatus: "ok",
+            hasRetried429: false,
+          });
+        }
+      }
+    }
+  }
+
+  // Reject exact duplicates (same fingerprint) across the pool.
+  const newFingerprint = fingerprint(key);
+  const duplicate = pool.credentials.find((cred) => cred.fingerprint === newFingerprint);
+  if (duplicate) {
+    throw new Error(
+      `This credential is already in the ${id} pool as "${duplicate.label || duplicate.id}" (#${pool.credentials.indexOf(duplicate) + 1}).`,
+    );
+  }
+
+  const credId = generateId();
+  const filePath = poolMemberFile(provider, credId);
+  writeSecretFile(filePath, key);
+
+  const entry = {
+    id: credId,
+    label: label || `key-${pool.credentials.length + 1}`,
+    file: filePath,
+    source: "pool",
+    fingerprint: newFingerprint,
+    createdAt: new Date().toISOString(),
+    requestCount: 0,
+    cooldownUntil: null,
+    lastStatus: "ok",
+    hasRetried429: false,
+  };
+  pool.credentials.push(entry);
+  writePoolDocument(doc);
+  return { provider: id, credential: entry, index: pool.credentials.length };
+}
+
+export function removeCredential(providerId, identifier) {
+  const provider = providerForPool(providerId);
+  const id = canonicalId(provider.id);
+  const doc = readPoolDocument();
+  const pool = doc.pools[id];
+  if (!pool || !Array.isArray(pool.credentials) || pool.credentials.length === 0) {
+    throw new Error(`Provider ${id} has no credential pool.`);
+  }
+  const raw = String(identifier || "").trim();
+  if (!raw) throw new Error("No credential identifier was provided.");
+  let index = -1;
+  // 1-based index takes precedence when the input is a positive integer within range.
+  const asNumber = Number(raw);
+  if (Number.isInteger(asNumber) && asNumber >= 1 && asNumber <= pool.credentials.length) {
+    index = asNumber - 1;
+  } else {
+    index = pool.credentials.findIndex((cred) => cred.id === raw || cred.label === raw);
+  }
+  if (index === -1) {
+    throw new Error(`No credential "${identifier}" found in ${id} pool. Use "credential-pool list ${id}" to see available entries.`);
+  }
+  const [removed] = pool.credentials.splice(index, 1);
+  // Only delete pool-managed files. The primary credential file (the original
+  // single-key location) is deleted too when it is the removed entry — that is
+  // the operator's explicit intent via `remove`.
+  if (removed.file && existsSync(removed.file)) {
+    const primary = primaryCredentialPath(provider);
+    // Allow deletion of both primary and pool-member files; they are all
+    // protected files under STATE_DIR. Never delete a file outside STATE_DIR.
+    const stateDir = path.resolve(STATE_DIR);
+    const fileDir = path.resolve(path.dirname(removed.file));
+    if (fileDir === stateDir || fileDir.startsWith(stateDir + path.sep)) {
+      try {
+        unlinkSync(removed.file);
+      } catch {
+        // File may have been removed externally; pool entry removal is what matters.
+      }
+    }
+  }
+  // Clean up empty pool: remove the provider entry entirely rather than leaving
+  // an empty strategy shell. The pool is recreated on next add.
+  if (pool.credentials.length === 0) {
+    delete doc.pools[id];
+  }
+  writePoolDocument(doc);
+  return { provider: id, removed, remaining: pool.credentials.length };
+}
+
+// ── Public: cooldown management ─────────────────────────────────────────────
+
+export function resetCooldowns(providerId, options = {}) {
+  const now = nowMs(options.now);
+  if (providerId) {
+    const id = canonicalId(providerId);
+    const doc = readPoolDocument();
+    const pool = doc.pools[id];
+    if (!pool) return { provider: id, reset: 0 };
+    let reset = 0;
+    for (const cred of pool.credentials) {
+      if (cred.cooldownUntil || cred.hasRetried429 || cred.lastStatus !== "ok") {
+        cred.cooldownUntil = null;
+        cred.hasRetried429 = false;
+        cred.lastStatus = "ok";
+        reset += 1;
+      }
+    }
+    writePoolDocument(doc);
+    return { provider: id, reset };
+  }
+  const doc = readPoolDocument();
+  let total = 0;
+  for (const pool of Object.values(doc.pools)) {
+    for (const cred of pool.credentials) {
+      if (cred.cooldownUntil || cred.hasRetried429 || cred.lastStatus !== "ok") {
+        cred.cooldownUntil = null;
+        cred.hasRetried429 = false;
+        cred.lastStatus = "ok";
+        total += 1;
+      }
+    }
+  }
+  writePoolDocument(doc);
+  return { provider: "all", reset: total };
+}
+
+// ── Public: selection & rotation ────────────────────────────────────────────
+
+export function credentialPoolStatus(providerId) {
+  const id = canonicalId(providerId);
+  const doc = readPoolDocument();
+  const pool = doc.pools[id];
+  if (!pool) return { provider: id, exists: false, strategy: DEFAULT_STRATEGY, credentials: [] };
+  const at = Date.now();
+  const credentials = pool.credentials.map((cred, idx) => ({
+    index: idx + 1,
+    id: cred.id,
+    label: cred.label,
+    file: cred.file,
+    source: cred.source,
+    fingerprint: cred.fingerprint,
+    requestCount: cred.requestCount || 0,
+    lastStatus: cred.lastStatus || "ok",
+    cooldownUntil: cred.cooldownUntil || null,
+    healthy: isHealthy(cred, at),
+    hasRetried429: Boolean(cred.hasRetried429),
+    createdAt: cred.createdAt,
+  }));
+  return {
+    provider: id,
+    exists: true,
+    strategy: pool.strategy || DEFAULT_STRATEGY,
+    credentials,
+    total: credentials.length,
+    healthy: credentials.filter((c) => c.healthy).length,
+    state: pool.state || { roundRobinIndex: 0 },
+  };
+}
+
+function pickCredential(pool, now) {
+  const at = nowMs(now);
+  const healthy = healthyCredentials(pool, at);
+  if (!healthy.length) return undefined;
+  const strategy = VALID_STRATEGIES.includes(pool.strategy) ? pool.strategy : DEFAULT_STRATEGY;
+  if (strategy === "fill_first") {
+    // First healthy in insertion order.
+    return pool.credentials.find((cred) => isHealthy(cred, at));
+  }
+  if (strategy === "round_robin") {
+    const index = Number.isFinite(pool.state?.roundRobinIndex) ? pool.state.roundRobinIndex : 0;
+    const healthySet = new Set(healthy.map((c) => c.id));
+    // Walk the pool in order starting at roundRobinIndex, wrapping around.
+    for (let offset = 0; offset < pool.credentials.length; offset += 1) {
+      const candidate = pool.credentials[(index + offset) % pool.credentials.length];
+      if (healthySet.has(candidate.id)) {
+        pool.state.roundRobinIndex = (pool.credentials.indexOf(candidate) + 1) % pool.credentials.length;
+        return candidate;
+      }
+    }
+    return healthy[0];
+  }
+  if (strategy === "least_used") {
+    let best = healthy[0];
+    for (const cred of healthy) {
+      if ((cred.requestCount || 0) < (best.requestCount || 0)) best = cred;
+    }
+    return best;
+  }
+  if (strategy === "random") {
+    return healthy[Math.floor(Math.random() * healthy.length)];
+  }
+  return healthy[0];
+}
+
+export function selectCredential(providerId, options = {}) {
+  const id = canonicalId(providerId);
+  // Non-poolable providers (native, anonymous, per-model) have no pool.
+  if (!providerIsPoolable(id)) return undefined;
+  const doc = readPoolDocument();
+  const pool = doc.pools[id];
+  if (!pool || !Array.isArray(pool.credentials) || pool.credentials.length === 0) return undefined;
+  const at = nowMs(options.now);
+  const picked = pickCredential(pool, at);
+  if (!picked) return undefined;
+  // Bookkeeping: count the selection and remember last use. Persist immediately
+  // so least_used and round_robin see the update on the next request.
+  picked.requestCount = (picked.requestCount || 0) + 1;
+  picked.lastUsedAt = new Date(at).toISOString();
+  // A success will clear hasRetried429; a transient 429 keeps it set until the
+  // second consecutive 429 promotes to a cooldown. Don't reset here — only on
+  // success.
+  writePoolDocument(doc);
+  const value = readSecretFile(picked.file);
+  if (!value) {
+    // File missing or empty — skip this credential and try the next healthy one.
+    // Mark it as unhealthy briefly so the same missing file isn't picked again
+    // in a tight loop.
+    picked.cooldownUntil = cappedUntil(at, 60_000);
+    picked.lastStatus = "missing";
+    writePoolDocument(doc);
+    return selectCredential(providerId, options);
+  }
+  return {
+    provider: id,
+    id: picked.id,
+    label: picked.label,
+    file: picked.file,
+    source: `pool:${picked.label || picked.id} (${picked.file})`,
+    value,
+    requestCount: picked.requestCount,
+    strategy: pool.strategy,
+  };
+}
+
+export function resolvePoolCredential(providerOrId, options = {}) {
+  const provider =
+    typeof providerOrId === "string" ? PROVIDERS.get(canonicalId(providerOrId)) : providerOrId;
+  if (!provider) return undefined;
+  const id = canonicalId(provider.id || providerOrId);
+  return selectCredential(id, options);
+}
+
+// Called on successful upstream response for a pooled credential. Mirrors
+// Hermes's `has_retried_429` reset on success.
+export function markCredentialSuccess(providerId, credentialId, options = {}) {
+  const id = canonicalId(providerId);
+  const doc = readPoolDocument();
+  const pool = doc.pools[id];
+  if (!pool) return undefined;
+  const cred = pool.credentials.find((c) => c.id === credentialId);
+  if (!cred) return undefined;
+  cred.cooldownUntil = null;
+  cred.lastStatus = "ok";
+  cred.hasRetried429 = false;
+  writePoolDocument(doc);
+  return cred;
+}
+
+// Classify a failure for pool rotation. Returns what to do:
+//
+//  { action: "none" }                          → not a pool-rotatable failure
+//  { action: "retry_same", credential }        → transient 429, retry same key once
+//  { action: "rotate", credential, next }      → mark exhausted, move to next
+//  { action: "exhausted", credential }         → all pool keys are down
+//
+// The caller decides whether to actually retry the HTTP request; this function
+// only mutates pool state.
+export function markCredentialFailure(providerId, credentialId, { status, bodyText, retryAfterSeconds, now } = {}) {
+  const id = canonicalId(providerId);
+  const at = nowMs(now);
+  const doc = readPoolDocument();
+  const pool = doc.pools[id];
+  if (!pool) return { action: "none" };
+  const cred = pool.credentials.find((c) => c.id === credentialId);
+  if (!cred) return { action: "none" };
+
+  const code = Number(status);
+  const kind = upstreamFailureKind({ status: code, bodyText });
+  const retryAfter = Number(retryAfterSeconds);
+  const hasRetryAfter = Number.isFinite(retryAfter) && retryAfter > 0;
+  const cooldownMs = hasRetryAfter ? Math.min(retryAfter * 1000, MAX_COOLDOWN_MS) : DEFAULT_COOLDOWN_MS;
+
+  // Hard limits: quota / billing / plan usage — never retry the same key.
+  const isHardLimit =
+    kind === "out_of_usage" || code === 402 || (code === 429 && kind === "out_of_usage");
+
+  // Entitlement (plan doesn't include this API) is not rotatable — no other
+  // key on the same provider makes it true either. Same as router's failover.
+  if (kind === "entitlement") {
+    return { action: "none", reason: "entitlement", credential: cred };
+  }
+
+  if (isHardLimit) {
+    cred.cooldownUntil = hasRetryAfter ? cappedUntil(at, retryAfter * 1000) : new Date(at + cooldownMs).toISOString();
+    cred.lastStatus = "out_of_usage";
+    cred.hasRetried429 = false;
+    writePoolDocument(doc);
+    const next = pickCredential(pool, at);
+    if (!next) return { action: "exhausted", credential: cred, reason: "out_of_usage", cooldownUntil: cred.cooldownUntil };
+    // Don't select via selectCredential (which would bump its count); just name it.
+    const nextValue = readSecretFile(next.file);
+    return {
+      action: "rotate",
+      credential: cred,
+      next: nextValue ? { id: next.id, label: next.label, file: next.file, value: nextValue } : undefined,
+      reason: "out_of_usage",
+      cooldownUntil: cred.cooldownUntil,
+    };
+  }
+
+  if (code === 429) {
+    // Generic / burst 429 — Hermes retries same key once, second 429 rotates.
+    if (!cred.hasRetried429) {
+      cred.hasRetried429 = true;
+      cred.lastStatus = "rate_limited_retry";
+      writePoolDocument(doc);
+      return { action: "retry_same", credential: cred, reason: "rate_limited" };
+    }
+    cred.cooldownUntil = hasRetryAfter ? cappedUntil(at, retryAfter * 1000) : new Date(at + cooldownMs).toISOString();
+    cred.lastStatus = "rate_limited";
+    cred.hasRetried429 = false;
+    writePoolDocument(doc);
+    const next = pickCredential(pool, at);
+    if (!next) return { action: "exhausted", credential: cred, reason: "rate_limited", cooldownUntil: cred.cooldownUntil };
+    const nextValue = readSecretFile(next.file);
+    return {
+      action: "rotate",
+      credential: cred,
+      next: nextValue ? { id: next.id, label: next.label, file: next.file, value: nextValue } : undefined,
+      reason: "rate_limited",
+      cooldownUntil: cred.cooldownUntil,
+    };
+  }
+
+  if (code === 401 || code === 403) {
+    // Auth failure — brief cooldown then rotate. A 401 on a pooled key is not
+    // retried; the key is assumed rejected.
+    cred.cooldownUntil = new Date(at + AUTH_COOLDOWN_MS).toISOString();
+    cred.lastStatus = code === 401 ? "auth_error" : "forbidden";
+    cred.hasRetried429 = false;
+    writePoolDocument(doc);
+    const next = pickCredential(pool, at);
+    if (!next) return { action: "exhausted", credential: cred, reason: cred.lastStatus, cooldownUntil: cred.cooldownUntil };
+    const nextValue = readSecretFile(next.file);
+    return {
+      action: "rotate",
+      credential: cred,
+      next: nextValue ? { id: next.id, label: next.label, file: next.file, value: nextValue } : undefined,
+      reason: cred.lastStatus,
+      cooldownUntil: cred.cooldownUntil,
+    };
+  }
+
+  return { action: "none", credential: cred };
+}
+
+// Convenience: record a failure and log rotation in one call for forwarders.
+export function recordPoolFailureAndRotate(providerId, credentialId, details = {}) {
+  const result = markCredentialFailure(providerId, credentialId, details);
+  if (result.action === "rotate") {
+    console.error(
+      `[credential-pool] provider=${canonicalId(providerId)} credential=${result.credential.label || result.credential.id} reason=${result.reason} cooldown_until=${result.cooldownUntil} -> ${result.next ? result.next.label || result.next.id : "exhausted"}`,
+    );
+  } else if (result.action === "exhausted") {
+    console.error(
+      `[credential-pool] provider=${canonicalId(providerId)} credential=${result.credential.label || result.credential.id} reason=${result.reason} — all pool credentials exhausted`,
+    );
+  } else if (result.action === "retry_same") {
+    console.error(
+      `[credential-pool] provider=${canonicalId(providerId)} credential=${result.credential.label || result.credential.id} 429 transient — retrying same credential once`,
+    );
+  }
+  return result;
+}
+
+// ── Convenience: does this provider have a pool with >1 credential? ───────────
+export function hasCredentialPool(providerId) {
+  const id = canonicalId(providerId);
+  const doc = readPoolDocument();
+  const pool = doc.pools[id];
+  return Boolean(pool && Array.isArray(pool.credentials) && pool.credentials.length > 0);
+}
+
+export function credentialPoolSize(providerId) {
+  const id = canonicalId(providerId);
+  const doc = readPoolDocument();
+  const pool = doc.pools[id];
+  return pool?.credentials?.length || 0;
+}
+
+// For tests: reset whole pool file.
+export function clearAllPools() {
+  writePrivateJson(POOL_PATH, { version: 1, pools: {} }, { directoryMode: 0o700 });
+}
+
+// Legacy helper: does a provider's credential resolve via pool or single file?
+// Used to make configuredProviderIds pool-aware without importing the whole
+// selection loop into this module.
+export function poolAwareCredentialStatus(providerId) {
+  const id = canonicalId(providerId);
+  const pool = getPool(id);
+  if (pool && pool.credentials.length > 0) {
+    const healthy = pool.credentials.filter((cred) => {
+      const until = isoOrUndefined(cred.cooldownUntil);
+      if (!until) return true;
+      return Date.parse(until) <= Date.now();
+    });
+    if (healthy.length > 0) {
+      return { configured: true, source: `credential pool (${healthy.length}/${pool.credentials.length} healthy)`, persistent: true };
+    }
+    // All pooled credentials are in cooldown — still considered configured, just temporarily exhausted.
+    return { configured: true, source: `credential pool (all ${pool.credentials.length} in cooldown)`, persistent: true };
+  }
+  return undefined;
+}

--- a/src/provider-selection.mjs
+++ b/src/provider-selection.mjs
@@ -17,6 +17,7 @@ import { targetCli } from "./target-integration.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
+import { poolAwareCredentialStatus } from "./credential-pool.mjs";
 
 const RETIRED_PROVIDER_ALIASES = new Map([["chatgpt-oauth", "grok-oauth"]]);
 
@@ -99,8 +100,18 @@ export function configuredProviderIds() {
       // Reachability and rate limits remain health questions, not reasons to
       // hide a provider from the picker.
       configured.push(provider.id);
-    } else if (credentialStatus(provider, { persistent: true }).configured) {
-      configured.push(provider.id);
+    } else {
+      // Credential pools are checked first: a provider with a pool is configured
+      // when the pool has at least one credential, even when the primary single
+      // file is absent. This preserves single-credential behaviour when no pool
+      // exists, while making pooled providers visible to the picker and to
+      // `ensure-configured`.
+      const pooled = poolAwareCredentialStatus(provider.id);
+      if (pooled) {
+        if (pooled.configured) configured.push(provider.id);
+      } else if (credentialStatus(provider, { persistent: true }).configured) {
+        configured.push(provider.id);
+      }
     }
   }
   return configured;

--- a/test/credential-pool.test.mjs
+++ b/test/credential-pool.test.mjs
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync, readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-pool-"));
+process.env.CODEX_HOME = path.join(testRoot, "codex");
+process.env.CODEX_ROUTER_STATE_DIR = path.join(testRoot, "state");
+
+const {
+  addCredential,
+  removeCredential,
+  getPool,
+  setStrategy,
+  getStrategy,
+  selectCredential,
+  markCredentialFailure,
+  markCredentialSuccess,
+  resetCooldowns,
+  hasCredentialPool,
+  credentialPoolStatus,
+  clearAllPools,
+  DEFAULT_STRATEGY,
+  VALID_STRATEGIES,
+} = await import("../src/credential-pool.mjs");
+
+test("credential pool stratégies et rotation basique", () => {
+  try {
+    clearAllPools();
+    // deepseek is a poolable provider in the default registry
+    const provider = "deepseek";
+    assert.equal(hasCredentialPool(provider), false);
+    assert.equal(getStrategy(provider), DEFAULT_STRATEGY);
+    assert.deepEqual(VALID_STRATEGIES, ["fill_first", "round_robin", "least_used", "random"]);
+
+    // first add seeds pool + creates primary if existing single file absent — new pool has 1 entry
+    const first = addCredential(provider, "sk-test-pool-1", { label: "primary" });
+    assert.equal(first.provider, provider);
+    assert.equal(credentialPoolStatus(provider).total, 1);
+    assert.equal(hasCredentialPool(provider), true);
+    const pool = getPool(provider);
+    assert.ok(pool.credentials.length === 1);
+    assert.equal(pool.credentials[0].label, "primary");
+
+    // second add
+    const second = addCredential(provider, "sk-test-pool-2", { label: "backup" });
+    assert.equal(credentialPoolStatus(provider).total, 2);
+    // duplicate fingerprint rejected
+    assert.throws(() => addCredential(provider, "sk-test-pool-1"), /already in the deepseek pool/);
+
+    // strategies
+    setStrategy(provider, "round_robin");
+    assert.equal(getStrategy(provider), "round_robin");
+    setStrategy(provider, "least_used");
+    assert.equal(getStrategy(provider), "least_used");
+    assert.throws(() => setStrategy(provider, "bogus"), /Unknown rotation strategy/);
+    setStrategy(provider, "fill_first");
+
+    // fill_first picks first healthy (requestCount increments)
+    const picked = selectCredential(provider);
+    assert.ok(picked);
+    assert.equal(picked.label, "primary");
+    assert.equal(credentialPoolStatus(provider).credentials[0].requestCount, 1);
+
+    // least_used picks backup (0 vs 1)
+    setStrategy(provider, "least_used");
+    const least = selectCredential(provider);
+    assert.equal(least.label, "backup");
+
+    // round_robin cycles
+    setStrategy(provider, "round_robin");
+    clearAllPools();
+    addCredential(provider, "sk-a-1", { label: "a" });
+    addCredential(provider, "sk-a-2", { label: "b" });
+    setStrategy(provider, "round_robin");
+    const r1 = selectCredential(provider);
+    const r2 = selectCredential(provider);
+    const r3 = selectCredential(provider);
+    assert.notEqual(r1.id, r2.id);
+    assert.equal(r3.id, r1.id); // wrap
+
+    // mark failure: 429 transient → retry_same, second 429 → rotate + cooldown
+    clearAllPools();
+    addCredential(provider, "sk-429-1", { label: "k1" });
+    addCredential(provider, "sk-429-2", { label: "k2" });
+    setStrategy(provider, "fill_first");
+    const c1 = selectCredential(provider);
+    assert.equal(c1.label, "k1");
+    // need the id of k1 — list via status
+    const k1Id = credentialPoolStatus(provider).credentials.find((c) => c.label === "k1").id;
+    const k2Id = credentialPoolStatus(provider).credentials.find((c) => c.label === "k2").id;
+    let res = markCredentialFailure(provider, k1Id, { status: 429, bodyText: "rate limit exceeded" });
+    assert.equal(res.action, "retry_same");
+    res = markCredentialFailure(provider, k1Id, { status: 429, bodyText: "rate limit exceeded" });
+    assert.equal(res.action, "rotate");
+    assert.ok(res.next);
+    // k1 now in cooldown, so next select should give k2
+    const after = selectCredential(provider);
+    assert.equal(after.label, "k2");
+    // reset clears cooldown
+    resetCooldowns(provider);
+    const afterReset = credentialPoolStatus(provider);
+    assert.ok(afterReset.credentials.every((c) => c.cooldownUntil === null));
+
+    // 402 / quota → immediate rotate
+    // k1 is healthy again after reset, but select will pick fill_first k1
+    const pk = selectCredential(provider);
+    const pkId = pk.id;
+    res = markCredentialFailure(provider, pkId, { status: 402, bodyText: "insufficient_quota" });
+    assert.ok(["rotate","exhausted"].includes(res.action), `402 should rotate or exhausted, got ${res.action}`);
+
+    // 401 → rotate
+    const pk2 = credentialPoolStatus(provider).credentials.find((c) => c.healthy);
+    if (pk2) {
+      res = markCredentialFailure(provider, pk2.id, { status: 401, bodyText: "unauthorized" });
+      assert.ok(["rotate","exhausted"].includes(res.action), `401 should rotate or exhausted, got ${res.action}`);
+    }
+
+    // success clears
+    markCredentialSuccess(provider, k1Id);
+    assert.equal(credentialPoolStatus(provider).credentials.find((c) => c.id === k1Id).lastStatus, "ok");
+
+    // remove by index and id
+    const before = credentialPoolStatus(provider).total;
+    removeCredential(provider, 1);
+    assert.equal(credentialPoolStatus(provider).total, before - 1);
+    const remainingId = credentialPoolStatus(provider).credentials[0].id;
+    removeCredential(provider, remainingId);
+    assert.equal(hasCredentialPool(provider), false);
+
+    clearAllPools();
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+    clearAllPools();
+  }
+});
+
+test("non-poolable providers rejected", async () => {
+  clearAllPools();
+  // anonymous / keyless / per-model / unknown cannot have pools
+  assert.throws(() => addCredential("opencode-free", "sk-x"), /cannot have a pool/);
+  // deepseek is poolable, so use known non-poolable ids; ollama may or may not exist per registry, so test generically
+  assert.throws(() => addCredential("opencode-free", "sk-x2"), /cannot have a pool/);
+  assert.throws(() => addCredential("custom", "sk-x"), /cannot have a pool|Unknown provider|per-model/);
+  clearAllPools();
+});


### PR DESCRIPTION
## Problem

A single API key per provider dies on `429` / `402` / `“usage limit reached”` mid-session (rate limit, monthly quota, balance exhausted). Today Codex Router only fails over to a *different provider* (`model-failover`). Pools keep the *same provider* alive by trying the next healthy key first — critical for providers with strict per-key rate limits or plan quotas (DeepSeek, OpenRouter, Grok API, Command Code, Z.AI, etc.).

Inspired by **Hermes Agent — Credential Pools** (https://hermes-agent.nousresearch.com/docs/user-guide/features/credential-pools). Hermes design is the inspiration — no Hermes code is copied, the implementation is router-native and follows the spirit + four strategies.

## Solution

**Per-provider credential pools** stored safely in the existing protected storage:

* **Pool state:** `STATE_DIR/credential-pools.json` (`0600` + `protectPrivateFile`/`icacls` on Windows) — versioned, metadata-only (no secrets inline).
* **Each key:** `STATE_DIR/<credential.file>.pool.<id>.secret` (`0600`), fingerprinted `sha256:16`. Env-var / Keychain secrets are read-only and never persisted. Duplicate fingerprints rejected.
* **Seeding:** first `credential-pool add` auto-seeds the existing single `*.secret` as `primary` so enabling pools never discards a working key. Empty pools are pruned.
* **Scope:** `openai-compatible` providers with `credential.file`. `keyless` (local Ollama), `anonymous` (`opencode-free`/`kilo-free`) and `per-model` (`custom`) are explicitly rejected. `variantOf` families (e.g. `commandcode` + `commandcode-messages`, `opencode-go*`) share one pool via canonical id. Native ChatGPT/Codex (`openai` native path) is never pooled.

### Rotation strategies (per-provider, configurable)

| Strategy | Behaviour |
|---|---|
| `fill_first` *(default)* | Use the first healthy key until exhausted, then move to the next. |
| `round_robin` | Cycle evenly through healthy keys (persisted index). |
| `least_used` | Always pick the key with the lowest `requestCount`. |
| `random` | Random among healthy keys. |

Stored as `pools[provider].strategy` in `credential-pools.json`. Healthy = `cooldownUntil` absent or expired. `requestCount` + `lastUsedAt` are incremented on `selectCredential()` for `least_used`/`round_robin`.

### Automatic rotation

Wired into `src/api-forwarder.mjs` (selection is cooldown-aware; after each upstream response the used key is marked) and `src/provider-selection.mjs` (pooled providers are reported as *configured* when the pool has any entry — preserving single-key `picker` compatibility):

| Upstream | Action | Cooldown |
|---|---|---|
| `429` burst | Retry **same** key once (transient); second `429` → rotate | 1h (honours `Retry-After` capped 6h) |
| `402` or `out_of_usage` (`insufficient_quota`, `exceeded your current quota`, `balance too low`, `purchase extra usage`, `quota exhausted`, `arrears`, and Chinese `余额不足`/`欠费`/`额度不足/已用完` — same `QUOTA_PATTERNS` as `error-translation.mjs`) | **Immediately rotate** (no retry) | 1h |
| `401`/`403` | Rotate | 5m |
| `entitlement` (`plan doesn't include API` / `Go doesn't include Provider API`) | **No rotate** (different key won't help) | — |
| `200` | Clear `hasRetried429` + cooldown, keep `requestCount` | — |
| **All pool keys exhausted** | Surfaces `503`/`429` — router `model-failover` (cross-provider) then activates | — |

Next request picks the next healthy key per strategy; the forwarder logs `hasRetried429`/cooldown events.

## How to enable / configure

```sh
# add a second key (hidden prompt if --api-key omitted)
./bin/credential-pool add deepseek --label backup --api-key sk-...

./bin/credential-pool add openrouter   # prompts hidden
./bin/credential-pool add grok-api --label secondary --api-key xai-...

# inspect
./bin/credential-pool list
./bin/credential-pool list deepseek
./bin/credential-pool list deepseek --json

# set / view strategy
./bin/credential-pool strategy deepseek round_robin
./bin/credential-pool strategy deepseek  # show current
# also: fill_first | least_used | random

# reset cooldowns after a top-up / new billing cycle
./bin/credential-pool reset deepseek
./bin/credential-pool reset --all

# remove
./bin/credential-pool remove deepseek 2
./bin/credential-pool remove deepseek a1b2c3d4
```

Single-key path unchanged: `./bin/model-router codex provider-key <provider> set` still works. `credential-pool list` without pool reports `single-credential mode` plus current strategy hint.

Full guide: [`docs/CREDENTIAL-POOLS.md`](docs/CREDENTIAL-POOLS.md)

## CLI / Management (spec compliance)

* `list [provider]` / `status` – show pools, health, `requestCount`, `cooldownUntil`, `hasRetried429`
* `add <provider> [--label L] [--api-key K]` – label defaults to `key-N`, fingerprint deduped
* `remove <provider> <index|id>` – 1-based index or id/label, deletes only `STATE_DIR` files
* `strategy <provider> [strategy]` – get/set, validated
* `reset <provider|--all>` – clears `cooldownUntil`/`hasRetried429`/`lastStatus`

All commands support `--json` and accept both `list <provider>` / `<provider> list` ordering.

## Safety & compatibility

* No breaking change: absent pool file = original `resolveProviderCredential()` path. Existing `Kimi OAuth` / `Grok OAuth` / `DeepSeek` / `Grok` / `Command Code` / `opencode` / local flows untouched.
* Credential isolation preserved: `api-forwarder` injects only the selected pool key as `Authorization`/`x-api-key`; pool metadata never leaks secrets.
* Protected files stay `0600` (`protectPrivateFile` + `chmodSync`/`icacls`), pool member files only under `STATE_DIR`.
* `provider-selection` pooled check is pool-first, then classic file check — hides pooled providers correctly from `enabled-providers.json` and `ensure-configured`.

## Testing

* `src/credential-pool.mjs` + `src/credential-pool-cli.mjs` pass `node --check`.
* New suite `test/credential-pool.test.mjs` (isolated `CODEX_HOME`/`STATE_DIR`) — strategies, Quota/429/401 rotation, `hasRetried429`, `reset`, `remove`, non-poolable rejections. Passes: `node --test test/credential-pool.test.mjs` (2/2).

## Limitations / Future

* Pool rotation today marks for *next* request (not bounded in-request retry loop across keys — next turn already rescues sessions; tight same-turn loop is planned).
* OAuth pooling (`kimi-oauth`/`grok-oauth`) is scaffolded (pool guard) but not yet routed — single OAuth session still via `kimi login` / `grok login`. Native ChatGPT account remains single.
* No `Retry-After` header surface in `doctor` yet; could expose per-key `retryAt`.
* Future: `--pool` flag for `provider-key set`, and tray UI pool section.

## References

* Hermes Credential Pools docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/credential-pools
* Prior art in-router: `src/model-failover.mjs` (cross-provider), `src/error-translation.mjs` (`QUOTA_PATTERNS`/`upstreamFailureKind`), `src/provider-credentials.mjs` (file/Keychain), `src/rate-limit-headers.mjs`.
