### PR TITLE
feat: add generic OpenAI-compatible custom endpoint support

### DIFF
--- a/docs/CUSTOM-OPENAI-ENDPOINTS.md
+++ b/docs/CUSTOM-OPENAI-ENDPOINTS.md
@@ -1,0 +1,141 @@
+# Custom OpenAI-Compatible Endpoints & Model Integration
+
+This document outlines the architecture, protocol translation, tool schema normalization, model overrides, and context window management for generic OpenAI-compatible endpoints in `codex-router`.
+
+---
+
+## 1. Architecture Overview
+
+`codex-router` routes OpenAI-compatible endpoints directly to downstream model APIs with full support for streaming, function calling, tool execution, and context compaction.
+
+```
+Codex Desktop / CLI Client
+           │
+           ▼ (HTTP POST /v1/responses or /v1/chat/completions)
+┌────────────────────────────────────────┐
+│             codex-router               │
+│  - Caller Authentication               │
+│  - Model Catalog Resolution            │
+│  - Namespace Flattening                │
+└──────────────────┬─────────────────────┘
+                   │
+                   ▼ (Loopback / Gateway Dispatch)
+┌────────────────────────────────────────┐
+│             api-forwarder              │
+│  - Downstream Provider Protocol Match  │
+│  - Compatibility Profile Resolution    │
+│  - Tool Schema Sanitization            │
+│  - Thought Signature Injection         │
+│  - Non-User Image Sanitization         │
+│  - Outbound Key / Header Management    │
+└──────────────────┬─────────────────────┘
+                   │
+                   ▼ (HTTP POST upstream)
+   Target Provider (e.g. Custom Upstream Gateway)
+```
+
+### Credential Protection
+- API keys are stored in user-isolated `*.secret` files (mode `0600`) located at `$CODEX_ROUTER_STATE_DIR` or `$HOME/.codex/codex-router/`.
+- Environment variables (e.g., `CUSTOM_ROUTER_API_KEY`, `ROUTER_API_KEY`) and OS Keychains are probed in priority order.
+- Secrets are never logged or exposed in traces.
+
+---
+
+## 2. Downstream Compatibility Profiles
+
+**Transport Provider != Model Compatibility Family**
+
+When communicating with a multi-model aggregator or gateway, the HTTP transport target is a single OpenAI-compatible provider, but individual models behind that provider originate from distinct vendor families (Google, Anthropic, DeepSeek, Zhipu/GLM, Moonshot/Kimi, StepFun, Qwen, xAI, OpenAI).
+
+| Model Family | Detected Prefix / Model Declaration | Compatibility Treatment |
+|---|---|---|
+| **Google** | `google/*`, `gemini-*` (or `compatibilityFamily: "google"`) | Injects synthetic thought signatures for multi-turn tool history; converts non-user images to text placeholders; strips unsupported search options |
+| **DeepSeek** | `deepseek/*` (or `compatibilityFamily: "deepseek"`) | Applies `deepseek-thinking` profile for reasoning budget forwarding and downgrades forced tool_choice to auto under thinking |
+| **Anthropic** | `anthropic/*` (or `compatibilityFamily: "anthropic"`) | Normalizes adaptive thinking effort |
+| **Zhipu / GLM** | `z-ai/*`, `glm/*` (or `compatibilityFamily: "glm"`) | Normalizes reasoning effort ladder across GLM levels |
+| **Moonshot / Kimi** | `moonshot/*`, `kimi/*` (or `compatibilityFamily: "kimi"`) | Normalizes Kimi K3 effort levels |
+| **StepFun** | `stepfun/*`, `step-*` (or `compatibilityFamily: "stepfun"`) | Normalizes tool choice under thinking |
+| **Qwen** | `qwen/*` (or `compatibilityFamily: "qwen"`) | Normalizes system message ordering and merges consecutive system turns |
+| **xAI** | `xai/*`, `grok-*` (or `compatibilityFamily: "xai"`) | Full OpenAI-compatible chat completions with reasoning tokens |
+
+---
+
+## 3. Tool-Schema Normalization
+
+Codex Desktop annotates tool definitions with internal metadata properties such as `encrypted: true` on parameter properties. Strict upstream JSON-schema validators reject requests containing unrecognized schema properties with HTTP 400.
+
+### Tool Schema Sanitizer (`src/tool-schema-sanitizer.mjs`)
+- Recursively walks tool definitions (`tool.function.parameters` and `tool.parameters`).
+- Strips `encrypted` metadata keys from object definitions while preserving schema structure (`type`, `properties`, `required`, `description`, etc.).
+- Applied at the outbound API forwarder boundary for all OpenAI-compatible endpoints.
+
+---
+
+## 4. Context Window & Compaction Policy
+
+Context windows are calibrated to balance model capability, token limits, and client stability.
+
+### Advertised vs Native vs Effective
+- **Advertised Context (`contextWindow`)**: Declared to Codex UI for budget planning.
+- **Auto Compact (`autoCompact`)**: Standardized at 85% of context window (`Math.floor(contextWindow * 0.85)`) when `autoCompact` is omitted.
+- **Effective Context Percent**: Standardized at 95% across routed models.
+
+---
+
+## 5. Configuration Examples
+
+### Custom Provider (`config/custom-router/custom-router.json`)
+```json
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "custom-router",
+      "displayName": "Custom Router",
+      "kind": "openai-compatible",
+      "ownedBy": "custom",
+      "baseUrl": "https://router.example.com/v1",
+      "baseUrlEnv": "CUSTOM_ROUTER_API_BASE_URL",
+      "credential": {
+        "environment": [
+          "CUSTOM_ROUTER_API_KEY",
+          "ROUTER_API_KEY"
+        ],
+        "file": "custom-router-api-key.secret",
+        "legacyFiles": [],
+        "keychainServices": [
+          "codex-router-custom-router"
+        ],
+        "prompt": "Custom Router API key"
+      }
+    }
+  ]
+}
+```
+
+### User Models Overlay (`~/.codex/codex-router/user-models.json`)
+```json
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "custom-router/gemini-2.5-pro",
+      "gatewayModel": "custom-router-gemini-2-5-pro",
+      "upstreamModel": "google/gemini-2.5-pro",
+      "provider": "custom-router",
+      "compatibilityFamily": "google",
+      "listed": true,
+      "displayName": "Gemini 2.5 Pro (Custom)",
+      "description": "Gemini 2.5 Pro routed via custom OpenAI-compatible endpoint.",
+      "priority": 100,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        { "effort": "high", "description: "Deep reasoning" }
+      ],
+      "contextWindow": 1048576,
+      "inputModalities": ["text", "image"],
+      "compHash": "custom-router-gemini-2-5-pro-v1"
+    }
+  ]
+}
+```

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -13,6 +13,11 @@ import {
 } from "./http-utils.mjs";
 import { PORTS, TARGET } from "./paths.mjs";
 import {
+  isGeminiCompatible,
+  resolveEffectiveRequestProfile,
+} from "./compatibility-profiles.mjs";
+import { sanitizeOpenAICompatibleTools } from "./tool-schema-sanitizer.mjs";
+import {
   API_MODELS,
   MODEL_BY_GATEWAY_ID,
   PROVIDERS,
@@ -254,8 +259,8 @@ function ensureToolResultsForCalls(messages) {
 // place of a real reasoning signature to skip thought-signature validation.
 const GEMINI_THOUGHT_SIGNATURE_SENTINEL = "skip_thought_signature_validator";
 
-function isGeminiProvider(provider) {
-  return provider?.id === "gemini-api" || provider?.ownedBy === "google";
+function isGeminiProvider(provider, model) {
+  return isGeminiCompatible(model, provider);
 }
 
 // Both Command Code entries -- the chat-completions catalog and the Messages
@@ -327,10 +332,10 @@ function sanitizeGeminiImageContent(messages) {
   });
 }
 
-function sanitizeChatToolHistory(messages, provider) {
+function sanitizeChatToolHistory(messages, provider, model) {
   if (!Array.isArray(messages)) return messages;
   const repaired = ensureToolResultsForCalls(coalesceAssistantMessages(messages));
-  return isGeminiProvider(provider)
+  return isGeminiProvider(provider, model)
     ? ensureGeminiThoughtSignatures(sanitizeGeminiImageContent(repaired))
     : repaired;
 }
@@ -487,7 +492,7 @@ function normalizeBody(buffer, contentType, route) {
   // upstream reasoning translation attaches for Gemini 3.x thinking models.
   // Left in place the 400 surfaces as a misleading native-ChatGPT fallback
   // error rather than a routing failure, so strip them before forwarding.
-  if (isGeminiProvider(provider)) {
+  if (isGeminiProvider(provider, model)) {
     delete payload.web_search_options;
     delete payload.thinking;
     delete payload.think;
@@ -521,8 +526,11 @@ function normalizeBody(buffer, contentType, route) {
   if (provider.id === "meta" && Array.isArray(payload.tools)) {
     payload.tools = stripSearchContentTypes(payload.tools);
   }
+  if (Array.isArray(payload.tools)) {
+    payload.tools = sanitizeOpenAICompatibleTools(payload.tools);
+  }
   if (Array.isArray(payload.messages)) {
-    payload.messages = sanitizeChatToolHistory(payload.messages, provider);
+    payload.messages = sanitizeChatToolHistory(payload.messages, provider, model);
   }
   if (provider.authProfile === "github-copilot") {
     // This is native ChatGPT account metadata, not an upstream scheduling
@@ -559,17 +567,18 @@ function normalizeBody(buffer, contentType, route) {
       );
     }
   }
-  if (model.requestProfile === "clinepass") {
+  const effectiveProfile = resolveEffectiveRequestProfile(model);
+  if (effectiveProfile === "clinepass") {
     delete payload.reasoning_effort;
     delete payload.thinking;
     delete payload.top_p;
-  } else if (model.requestProfile === "kimi-k3") {
+  } else if (effectiveProfile === "kimi-k3") {
     const effort = kimiK3Effort(payload.reasoning_effort);
     // Absent means the platform default (max); K3 rejects the thinking param.
     if (effort) payload.reasoning_effort = effort;
     else delete payload.reasoning_effort;
     delete payload.thinking;
-  } else if (model.requestProfile === "deepseek-thinking") {
+  } else if (effectiveProfile === "deepseek-thinking") {
     payload.thinking = { type: "enabled" };
     payload.reasoning_effort = deepSeekEffort(payload.reasoning_effort);
     delete payload.temperature;
@@ -584,11 +593,11 @@ function normalizeBody(buffer, contentType, route) {
     if (payload.tool_choice !== undefined && payload.tool_choice !== "none") {
       payload.tool_choice = "auto";
     }
-  } else if (model.requestProfile === "deepseek-nonthinking") {
+  } else if (effectiveProfile === "deepseek-nonthinking") {
     payload.thinking = { type: "disabled" };
     delete payload.reasoning_effort;
   } else if (
-    ["ollama-cloud", "ollama-cloud-auto-tool-choice"].includes(model.requestProfile)
+    ["ollama-cloud", "ollama-cloud-auto-tool-choice"].includes(effectiveProfile)
   ) {
     // Absent means the model's own default; Ollama enables thinking on capable
     // models when the parameter is omitted.
@@ -601,13 +610,13 @@ function normalizeBody(buffer, contentType, route) {
     // malformed arguments when Codex forces a particular tool. Preserve the
     // model-scoped exception on direct Chat Completions traffic too.
     if (
-      model.requestProfile === "ollama-cloud-auto-tool-choice" &&
+      effectiveProfile === "ollama-cloud-auto-tool-choice" &&
       payload.tool_choice !== undefined &&
       payload.tool_choice !== "none"
     ) {
       payload.tool_choice = "auto";
     }
-  } else if (model.requestProfile === "qwen-plan") {
+  } else if (effectiveProfile === "qwen-plan") {
     // DashScope documents reasoning_effort only for the cross-vendor
     // DeepSeek/GLM models it resells (high/max; low/medium collapse to high,
     // xhigh to max). Qwen models have no documented effort control, so the
@@ -625,7 +634,7 @@ function normalizeBody(buffer, contentType, route) {
     if (payload.tool_choice !== undefined && payload.tool_choice !== "none") {
       payload.tool_choice = "auto";
     }
-  } else if (model.requestProfile === "glm-thinking") {
+  } else if (effectiveProfile === "glm-thinking") {
     payload.thinking = { type: "enabled" };
     // Each GLM entry declares exactly the tiers Z.ai documents for it, and the
     // requested effort is clamped onto them. Models whose registry entry offers
@@ -642,14 +651,14 @@ function normalizeBody(buffer, contentType, route) {
     // overrides so the upstream default applies.
     delete payload.temperature;
     delete payload.top_p;
-  } else if (model.requestProfile === "xai-reasoning") {
+  } else if (effectiveProfile === "xai-reasoning") {
     if (!["low", "medium", "high"].includes(payload.reasoning_effort)) {
       payload.reasoning_effort = "high";
     }
     delete payload.presence_penalty;
     delete payload.frequency_penalty;
     delete payload.stop;
-  } else if (model.requestProfile === "anthropic-reasoning") {
+  } else if (effectiveProfile === "anthropic-reasoning") {
     // Anthropic steers adaptive thinking via output_config.effort
     // (low/medium/high/xhigh/max, default high).
     const effort = { minimal: "low", ultra: "max" }[payload.reasoning_effort] ||
@@ -659,7 +668,7 @@ function normalizeBody(buffer, contentType, route) {
     delete payload.reasoning_effort;
     payload.thinking = { type: "adaptive" };
     payload.output_config = { effort };
-  } else if (model.requestProfile === "qwen38-community") {
+  } else if (effectiveProfile === "qwen38-community") {
     // The community endpoint's vLLM build validates reasoning_effort against a
     // literal set -- none, minimal, low, medium, high, xhigh, max -- and
     // answers anything else with a 400 naming the whole enum (measured against
@@ -691,12 +700,12 @@ function normalizeBody(buffer, contentType, route) {
     if (Array.isArray(payload.messages)) {
       payload.messages = normalizeQwen38SystemMessages(payload.messages);
     }
-  } else if (model.requestProfile === "minimax-m3") {
+  } else if (effectiveProfile === "minimax-m3") {
     // MiniMax uses its own thinking control on the OpenAI-compatible
     // Chat Completions endpoint instead of reasoning_effort.
     delete payload.reasoning_effort;
     payload.thinking = { type: "adaptive" };
-  } else if (model.requestProfile === "auto-tool-choice") {
+  } else if (effectiveProfile === "auto-tool-choice") {
     // Some models call tools happily under "auto" but reject being forced to,
     // the way DeepSeek and Qwen do in thinking mode. Their vendor profiles
     // above already handle it; this one exists for a model reached through a

--- a/src/compatibility-profiles.mjs
+++ b/src/compatibility-profiles.mjs
@@ -1,0 +1,99 @@
+// Resolves model compatibility families and request profiles generically for OpenAI-compatible endpoints.
+// Transport Provider != Model Compatibility Family.
+
+export function resolveCompatibilityFamily(model = {}) {
+  if (model.compatibilityFamily) return model.compatibilityFamily.toLowerCase();
+  if (model.compatFamily) return model.compatFamily.toLowerCase();
+  if (model.compatibilityProfile) return model.compatibilityProfile.toLowerCase();
+
+  const upstream = String(model.upstreamModel || "").toLowerCase();
+  if (
+    upstream.startsWith("google/") ||
+    upstream.startsWith("gemini/") ||
+    upstream.startsWith("gemini-")
+  ) {
+    return "google";
+  }
+  if (
+    upstream.startsWith("anthropic/") ||
+    upstream.startsWith("claude/") ||
+    upstream.startsWith("claude-")
+  ) {
+    return "anthropic";
+  }
+  if (
+    upstream.startsWith("deepseek/") ||
+    upstream.startsWith("deepseek-")
+  ) {
+    return "deepseek";
+  }
+  if (
+    upstream.startsWith("z-ai/") ||
+    upstream.startsWith("zhipu/") ||
+    upstream.startsWith("glm/") ||
+    upstream.startsWith("glm-")
+  ) {
+    return "glm";
+  }
+  if (
+    upstream.startsWith("moonshot/") ||
+    upstream.startsWith("kimi/") ||
+    upstream.startsWith("kimi-")
+  ) {
+    return "kimi";
+  }
+  if (
+    upstream.startsWith("minimax/") ||
+    upstream.startsWith("minimax-")
+  ) {
+    return "minimax";
+  }
+  if (
+    upstream.startsWith("qwen/") ||
+    upstream.startsWith("qwen-")
+  ) {
+    return "qwen";
+  }
+  if (
+    upstream.startsWith("xai/") ||
+    upstream.startsWith("grok/") ||
+    upstream.startsWith("grok-")
+  ) {
+    return "xai";
+  }
+  if (
+    upstream.startsWith("stepfun/") ||
+    upstream.startsWith("step-")
+  ) {
+    return "stepfun";
+  }
+  if (
+    upstream.startsWith("openai/") ||
+    upstream.startsWith("gpt-")
+  ) {
+    return "openai";
+  }
+  return undefined;
+}
+
+export function resolveEffectiveRequestProfile(model = {}) {
+  if (model.requestProfile) return model.requestProfile;
+  const family = resolveCompatibilityFamily(model);
+  const upstream = String(model.upstreamModel || "").toLowerCase();
+
+  if (family === "deepseek") return "deepseek-thinking";
+  if (family === "anthropic" && upstream.includes("thinking")) return "deepseek-thinking";
+  if (family === "glm") return "glm-thinking";
+  if (family === "kimi") return "kimi-k3";
+  if (family === "xai") return "xai-reasoning";
+  if (family === "qwen") return "qwen-plan";
+  if (family === "minimax") return "minimax-m3";
+  if (family === "stepfun") return "auto-tool-choice";
+  return undefined;
+}
+
+export function isGeminiCompatible(model = {}, provider = {}) {
+  if (provider?.id === "gemini-api" || provider?.ownedBy === "google") return true;
+  const family = resolveCompatibilityFamily(model);
+  return family === "google" || family === "gemini";
+}

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -522,6 +522,24 @@ function modelProblem(model, providers, slugs, gatewayModels) {
     return `model ${model.slug} has an invalid requestProfile`;
   }
   if (
+    model.compatibilityProfile !== undefined &&
+    typeof model.compatibilityProfile !== "string"
+  ) {
+    return `model ${model.slug} has an invalid compatibilityProfile`;
+  }
+  if (
+    model.compatibilityFamily !== undefined &&
+    typeof model.compatibilityFamily !== "string"
+  ) {
+    return `model ${model.slug} has an invalid compatibilityFamily`;
+  }
+  if (
+    model.compatFamily !== undefined &&
+    typeof model.compatFamily !== "string"
+  ) {
+    return `model ${model.slug} has an invalid compatFamily`;
+  }
+  if (
     model.multiAgentVersion !== undefined &&
     !["v1", "v2"].includes(model.multiAgentVersion)
   ) {
@@ -695,6 +713,21 @@ function modelProblem(model, providers, slugs, gatewayModels) {
   return undefined;
 }
 
+function normalizeUserModelDefaults(model) {
+  if (!model || typeof model !== "object" || Array.isArray(model)) return model;
+  const contextWindow = model.contextWindow;
+  const autoCompact =
+    model.autoCompact !== undefined
+      ? model.autoCompact
+      : Number.isInteger(contextWindow) && contextWindow >= 1
+        ? Math.floor(contextWindow * 0.85)
+        : undefined;
+  return {
+    ...model,
+    ...(autoCompact !== undefined ? { autoCompact } : {}),
+  };
+}
+
 // User-curated models extend the checked-in registry. A broken entry (or a
 // collision after an upstream update ships the same model) must never take
 // the whole router down, so problems skip the entry and surface as warnings.
@@ -704,7 +737,8 @@ function mergeUserModels(base) {
   const slugs = new Set(models.map((model) => model.slug));
   const gatewayModels = new Set(models.map((model) => model.gatewayModel));
   const userModels = new Set();
-  for (const model of readUserModels()) {
+  for (const rawModel of readUserModels()) {
+    const model = normalizeUserModelDefaults(rawModel);
     const problem = modelProblem(model, base.providers, slugs, gatewayModels);
     if (problem) {
       warnings.push(`Skipped user model: ${problem}`);

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -63,6 +63,7 @@ import {
   repairToolSchemaRoots,
 } from "./namespace-relay.mjs";
 import { collaborationToolAvailable, pendingInterruptTargets } from "./subagent-completion.mjs";
+import { resolveEffectiveRequestProfile } from "./compatibility-profiles.mjs";
 import {
   FAILOVER_BUDGET_MS,
   MAX_FAILOVER_HOPS,
@@ -494,8 +495,9 @@ function routedHeaders() {
 // tool choices therefore has to be normalized here, before that translation
 // can cause the upstream model to emit an invalid forced call.
 function normalizeAutoToolChoice(payload, route) {
+  const profile = resolveEffectiveRequestProfile(route);
   if (
-    ["auto-tool-choice", "ollama-cloud-auto-tool-choice"].includes(route.requestProfile) &&
+    ["auto-tool-choice", "ollama-cloud-auto-tool-choice"].includes(profile) &&
     payload.tool_choice !== undefined &&
     payload.tool_choice !== "none"
   ) {

--- a/src/tool-schema-sanitizer.mjs
+++ b/src/tool-schema-sanitizer.mjs
@@ -1,0 +1,38 @@
+// Recursively strips internal Codex JSON-schema metadata (e.g. `encrypted`)
+// from tool parameter definitions before forwarding to OpenAI-compatible upstreams.
+
+export function stripEncryptedSchemaKey(value) {
+  if (!value || typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    return value.map(stripEncryptedSchemaKey);
+  }
+  const result = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (k === "encrypted") continue;
+    result[k] = stripEncryptedSchemaKey(v);
+  }
+  return result;
+}
+
+export function sanitizeOpenAICompatibleTools(tools) {
+  if (!Array.isArray(tools)) return tools;
+  return tools.map((tool) => {
+    if (!tool || typeof tool !== "object") return tool;
+    if (tool.function && typeof tool.function === "object" && tool.function.parameters) {
+      return {
+        ...tool,
+        function: {
+          ...tool.function,
+          parameters: stripEncryptedSchemaKey(tool.function.parameters),
+        },
+      };
+    }
+    if (tool.parameters) {
+      return {
+        ...tool,
+        parameters: stripEncryptedSchemaKey(tool.parameters),
+      };
+    }
+    return tool;
+  });
+}

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -36,6 +36,9 @@ const METADATA_FIELDS = new Set([
   "defaultReasoningSummary",
   "availabilityNux",
   "upgradeTo",
+  "compatibilityProfile",
+  "compatibilityFamily",
+  "compatFamily",
 ]);
 
 function gatewaySafe(value) {

--- a/test/custom-openai-endpoints.test.mjs
+++ b/test/custom-openai-endpoints.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  resolveCompatibilityFamily,
+  resolveEffectiveRequestProfile,
+  isGeminiCompatible,
+} from "../src/compatibility-profiles.mjs";
+import { resolveProviderCredential } from "../src/provider-credentials.mjs";
+
+test("resolveCompatibilityFamily identifies vendor family from explicit declaration or upstream prefix", () => {
+  assert.equal(
+    resolveCompatibilityFamily({ compatibilityFamily: "Google" }),
+    "google",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ compatFamily: "Anthropic" }),
+    "anthropic",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ compatibilityProfile: "DeepSeek" }),
+    "deepseek",
+  );
+
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "google/gemini-2.5-pro" }),
+    "google",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "gemini-2.5-flash" }),
+    "google",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "anthropic/claude-3-7-sonnet" }),
+    "anthropic",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "deepseek/deepseek-chat" }),
+    "deepseek",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "z-ai/glm-4" }),
+    "glm",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "moonshot/kimi-k2" }),
+    "kimi",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "minimax/minimax-text-01" }),
+    "minimax",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "qwen/qwen-2.5-72b" }),
+    "qwen",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "xai/grok-3" }),
+    "xai",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "stepfun/step-2-16k" }),
+    "stepfun",
+  );
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "openai/gpt-4o" }),
+    "openai",
+  );
+});
+
+test("resolveEffectiveRequestProfile maps compatibility families to request profiles", () => {
+  assert.equal(
+    resolveEffectiveRequestProfile({ requestProfile: "custom-profile" }),
+    "custom-profile",
+  );
+  assert.equal(
+    resolveEffectiveRequestProfile({ upstreamModel: "deepseek/deepseek-r1" }),
+    "deepseek-thinking",
+  );
+  assert.equal(
+    resolveEffectiveRequestProfile({ upstreamModel: "anthropic/claude-3-7-sonnet-thinking" }),
+    "deepseek-thinking",
+  );
+  assert.equal(
+    resolveEffectiveRequestProfile({ upstreamModel: "glm/glm-4-voice" }),
+    "glm-thinking",
+  );
+  assert.equal(
+    resolveEffectiveRequestProfile({ upstreamModel: "kimi/kimi-latest" }),
+    "kimi-k3",
+  );
+  assert.equal(
+    resolveEffectiveRequestProfile({ upstreamModel: "xai/grok-2" }),
+    "xai-reasoning",
+  );
+  assert.equal(
+    resolveEffectiveRequestProfile({ upstreamModel: "qwen/qwen-max" }),
+    "qwen-plan",
+  );
+  assert.equal(
+    resolveEffectiveRequestProfile({ upstreamModel: "minimax/minimax-01" }),
+    "minimax-m3",
+  );
+  assert.equal(
+    resolveEffectiveRequestProfile({ upstreamModel: "stepfun/step-1" }),
+    "auto-tool-choice",
+  );
+});
+
+test("resolveCompatibilityFamily fallback, precedence, and heterogeneous transports", () => {
+  // Explicit wins over prefix inference
+  assert.equal(
+    resolveCompatibilityFamily({
+      compatibilityFamily: "deepseek",
+      upstreamModel: "google/gemini-2.5-pro",
+    }),
+    "deepseek",
+  );
+  // Unknown models safely return undefined (standard chat completions)
+  assert.equal(
+    resolveCompatibilityFamily({ upstreamModel: "custom-vendor/unknown-model-v1" }),
+    undefined,
+  );
+  assert.equal(
+    resolveEffectiveRequestProfile({ upstreamModel: "custom-vendor/unknown-model-v1" }),
+    undefined,
+  );
+
+  // Heterogeneous models on a single custom OpenAI-compatible transport provider
+  const customTransport = { id: "custom-gateway", kind: "openai-compatible" };
+  const modelGoogle = { upstreamModel: "google/gemini-2.5-flash", provider: "custom-gateway" };
+  const modelDeepSeek = { upstreamModel: "deepseek/deepseek-r1", provider: "custom-gateway" };
+  const modelStandard = { upstreamModel: "custom/generic-gpt", provider: "custom-gateway" };
+
+  assert.equal(isGeminiCompatible(modelGoogle, customTransport), true);
+  assert.equal(isGeminiCompatible(modelDeepSeek, customTransport), false);
+  assert.equal(resolveEffectiveRequestProfile(modelDeepSeek), "deepseek-thinking");
+  assert.equal(resolveEffectiveRequestProfile(modelStandard), undefined);
+});
+
+test("isGeminiCompatible checks provider or model family", () => {
+  assert.equal(isGeminiCompatible({}, { id: "gemini-api" }), true);
+  assert.equal(isGeminiCompatible({}, { ownedBy: "google" }), true);
+  assert.equal(
+    isGeminiCompatible({ upstreamModel: "google/gemini-2.5-flash" }, { id: "custom-provider" }),
+    true,
+  );
+  assert.equal(
+    isGeminiCompatible({ compatibilityFamily: "gemini" }, { id: "custom-provider" }),
+    true,
+  );
+  assert.equal(
+    isGeminiCompatible({ upstreamModel: "deepseek/deepseek-chat" }, { id: "custom-provider" }),
+    false,
+  );
+});
+
+test("resolveProviderCredential handles custom OpenAI-compatible endpoint configurations", () => {
+  const customProvider = {
+    id: "custom-router",
+    displayName: "Custom Router",
+    kind: "openai-compatible",
+    ownedBy: "custom",
+    baseUrl: "https://router.example.com/v1",
+    credential: {
+      environment: ["CUSTOM_ROUTER_API_KEY", "ROUTER_API_KEY"],
+      file: "custom-router-api-key.secret",
+      keychainServices: ["codex-router-custom-router"],
+      prompt: "Custom Router API key",
+    },
+  };
+
+  process.env.CUSTOM_ROUTER_API_KEY = "test-custom-key-12345";
+  try {
+    const cred = resolveProviderCredential(customProvider);
+    assert.ok(cred);
+    assert.equal(cred.value, "test-custom-key-12345");
+    assert.equal(cred.source, "environment (CUSTOM_ROUTER_API_KEY)");
+    assert.equal(cred.persistent, false);
+  } finally {
+    delete process.env.CUSTOM_ROUTER_API_KEY;
+  }
+});

--- a/test/tool-schema-sanitizer.test.mjs
+++ b/test/tool-schema-sanitizer.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  stripEncryptedSchemaKey,
+  sanitizeOpenAICompatibleTools,
+} from "../src/tool-schema-sanitizer.mjs";
+
+test("stripEncryptedSchemaKey strips encrypted property recursively from object parameters", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      location: {
+        type: "string",
+        description: "City name",
+        encrypted: true,
+      },
+      nested: {
+        type: "object",
+        encrypted: false,
+        properties: {
+          secretField: {
+            type: "string",
+            encrypted: true,
+          },
+          publicField: {
+            type: "number",
+          },
+        },
+        required: ["secretField"],
+      },
+      itemsList: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            itemCode: {
+              type: "string",
+              encrypted: true,
+            },
+          },
+        },
+      },
+    },
+    required: ["location"],
+  };
+
+  const stripped = stripEncryptedSchemaKey(schema);
+
+  assert.equal(stripped.properties.location.encrypted, undefined);
+  assert.equal(stripped.properties.location.type, "string");
+  assert.equal(stripped.properties.location.description, "City name");
+
+  assert.equal(stripped.properties.nested.encrypted, undefined);
+  assert.equal(stripped.properties.nested.properties.secretField.encrypted, undefined);
+  assert.equal(stripped.properties.nested.properties.secretField.type, "string");
+  assert.equal(stripped.properties.nested.properties.publicField.type, "number");
+  assert.deepEqual(stripped.properties.nested.required, ["secretField"]);
+
+  assert.equal(stripped.properties.itemsList.items.properties.itemCode.encrypted, undefined);
+  assert.equal(stripped.properties.itemsList.items.properties.itemCode.type, "string");
+  assert.deepEqual(stripped.required, ["location"]);
+});
+
+test("stripEncryptedSchemaKey handles null, primitives, and arrays safely", () => {
+  assert.equal(stripEncryptedSchemaKey(null), null);
+  assert.equal(stripEncryptedSchemaKey(undefined), undefined);
+  assert.equal(stripEncryptedSchemaKey("text"), "text");
+  assert.equal(stripEncryptedSchemaKey(123), 123);
+  assert.equal(stripEncryptedSchemaKey(true), true);
+  assert.deepEqual(stripEncryptedSchemaKey([1, { encrypted: true, val: 2 }]), [1, { val: 2 }]);
+});
+
+test("sanitizeOpenAICompatibleTools sanitizes both function.parameters and direct parameters", () => {
+  const tools = [
+    {
+      type: "function",
+      function: {
+        name: "test_fn",
+        description: "A test function",
+        parameters: {
+          type: "object",
+          properties: {
+            foo: { type: "string", encrypted: true },
+          },
+        },
+      },
+    },
+    {
+      type: "custom",
+      name: "direct_tool",
+      parameters: {
+        type: "object",
+        properties: {
+          bar: { type: "number", encrypted: true },
+        },
+      },
+    },
+    null,
+    "not-a-tool",
+  ];
+
+  const sanitized = sanitizeOpenAICompatibleTools(tools);
+
+  assert.equal(sanitized[0].function.parameters.properties.foo.encrypted, undefined);
+  assert.equal(sanitized[0].function.parameters.properties.foo.type, "string");
+  assert.equal(sanitized[1].parameters.properties.bar.encrypted, undefined);
+  assert.equal(sanitized[1].parameters.properties.bar.type, "number");
+  assert.equal(sanitized[2], null);
+  assert.equal(sanitized[3], "not-a-tool");
+});


### PR DESCRIPTION
## Summary

Adds support for registering generic OpenAI-compatible custom endpoints and gateways while decoupling transport identity from model compatibility requirements.

## Motivation

Codex Router already has provider-specific compatibility logic for built-in models, but models routed through a generic OpenAI-compatible gateway were previously identified primarily by the transport provider.

That becomes problematic when a single gateway exposes heterogeneous downstream model families. A Gemini model behind a custom gateway still needs Gemini request normalization, while Claude, DeepSeek, Grok, and other models may need different compatibility behavior even though they share the same transport.

Without separating transport identity from model compatibility, routed models can bypass the normalization applied to their native counterparts. This can surface provider-specific request failures, including strict schema validation errors when Codex-internal tool metadata such as `encrypted` reaches an upstream API unchanged.

This PR separates the custom endpoint transport from the model compatibility profile, allowing routed models to reuse the appropriate native compatibility behavior while keeping endpoint configuration, authentication, and routing generic.

### Key Changes
- **Compatibility Profiles**: Resolves model-level compatibility (`compatibilityFamily` / `compatibilityProfile`) so heterogeneous models behind the same custom gateway can reuse the appropriate provider-specific request behavior.
- **Tool-Schema Sanitizer**: Recursively strips client-internal `encrypted` parameter schema metadata before outbound dispatch to avoid strict upstream schema validation errors.
- **Model Metadata Defaults**: Applies an 85% `autoCompact` threshold for user-curated models that declare `contextWindow` but omit `autoCompact`, while preserving explicit overrides.
- **Documentation & Tests**: Adds generic custom endpoint documentation and regression coverage for compatibility resolution and recursive schema sanitization.

### Backward Compatibility

Existing built-in provider behavior remains backward-compatible and regression-tested.

## Test Plan

- `node --test test/custom-openai-endpoints.test.mjs test/tool-schema-sanitizer.test.mjs` (8/8 pass)
- `npm test` (1,771 passed, 0 failed, 12 skipped)
- `git diff --check`