### PR TITLE
fix(zai): use GPT-5.6 behavior instructions for GLM-5.3

### DIFF
--- a/config/zai/coding/glm-5.3.json
+++ b/config/zai/coding/glm-5.3.json
@@ -33,6 +33,7 @@
       "searchTool": {
         "mode": "standalone"
       },
+      "behaviorTemplate": "gpt-5.6-sol",
       "requestProfile": "glm-thinking",
       "compHash": "zai-coding-glm-5-3-v2"
     }

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -498,9 +498,11 @@ function normalizeNativeModel(model) {
   };
 }
 
-export function routedModel(template, model) {
+export function routedModel(template, model, behaviorTemplate = template) {
   const next = {
     ...template,
+    base_instructions: behaviorTemplate.base_instructions,
+    model_messages: behaviorTemplate.model_messages,
     slug: model.slug,
     display_name: model.displayName,
     description: model.description,
@@ -713,6 +715,11 @@ export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
   });
 }
 
+function behaviorTemplateFor(nativeModels, model, fallback) {
+  if (!model.behaviorTemplate) return fallback;
+  return nativeModels.find((candidate) => candidate.slug === model.behaviorTemplate) || fallback;
+}
+
 export function buildMergedCatalog(native, routedModelsList, { includeNative = true } = {}) {
   const template =
     native.models.find((model) => model.slug === "gpt-5.5") ||
@@ -727,7 +734,8 @@ export function buildMergedCatalog(native, routedModelsList, { includeNative = t
       : [],
   );
   for (const model of routedModelsList) {
-    models.set(model.slug, routedModel(template, model));
+    const behaviorTemplate = behaviorTemplateFor(native.models, model, template);
+    models.set(model.slug, routedModel(template, model, behaviorTemplate));
   }
   return sortCatalogModels(models.values());
 }
@@ -755,7 +763,11 @@ export function buildLoginFreeCatalog(native, routedModelsList) {
   );
   const models = [
     ...assignments.map(({ nativeModel, model }) => ({
-      ...routedModel(nativeModel, model),
+      ...routedModel(
+        nativeModel,
+        model,
+        behaviorTemplateFor(native.models, model, nativeModel),
+      ),
       slug: nativeModel.slug,
       priority: nativeModel.priority,
     })),

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -482,6 +482,12 @@ function modelProblem(model, providers, slugs, gatewayModels) {
   }
   const endpoint = endpointProblem(model, provider);
   if (endpoint) return endpoint;
+  if (
+    model.behaviorTemplate !== undefined &&
+    (typeof model.behaviorTemplate !== "string" || !model.behaviorTemplate.trim())
+  ) {
+    return `model ${model.slug} has an invalid behaviorTemplate`;
+  }
   if (model.requestProfile !== undefined && typeof model.requestProfile !== "string") {
     return `model ${model.slug} has an invalid requestProfile`;
   }

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -152,6 +152,27 @@ test("routed models rewrite GPT identity text to the external model name", () =>
   assert.equal(model.multi_agent_version, "v2");
 });
 
+test("routed models can borrow native behavior instructions without inheriting capabilities", () => {
+  const behaviorTemplate = {
+    ...template,
+    slug: "gpt-5.6-sol",
+    base_instructions: "You are Codex, an agent based on GPT-5. SOL_BEHAVIOR",
+    model_messages: {
+      instructions_template: "You are Codex, an agent based on GPT-5. SOL_TEMPLATE {{ personality }}",
+      instructions_variables: { personality_default: "" },
+    },
+    tool_mode: "code_mode_only",
+    use_responses_lite: true,
+  };
+  const model = routedModel(template, { ...grok, behaviorTemplate: "gpt-5.6-sol" }, behaviorTemplate);
+
+  assert.match(model.base_instructions, /based on Grok 4\.5/);
+  assert.match(model.base_instructions, /SOL_BEHAVIOR/);
+  assert.match(model.model_messages.instructions_template, /SOL_TEMPLATE/);
+  assert.equal(model.tool_mode, undefined);
+  assert.equal(model.use_responses_lite, false);
+});
+
 test("routed models are native v2 spawn-agent model overrides", () => {
   const model = routedModel(template, grok);
   assert.equal(model.visibility, "list");
@@ -331,6 +352,30 @@ test("merged catalog preserves native GPT identity while rewriting routed models
   assert.equal(bySlug.get("gpt-5.5").supports_reasoning_summaries, false);
   assert.match(bySlug.get("grok-oauth/grok-4.5").base_instructions, /based on Grok 4\.5/);
   assert.doesNotMatch(bySlug.get("grok-oauth/grok-4.5").base_instructions, /GPT-5/);
+});
+
+test("merged catalog resolves a routed behavior template without inheriting its capabilities", () => {
+  const sol = {
+    ...template,
+    slug: "gpt-5.6-sol",
+    base_instructions: "You are Codex, an agent based on GPT-5. SOL_BEHAVIOR",
+    model_messages: {
+      instructions_template: "You are Codex, an agent based on GPT-5. SOL_TEMPLATE {{ personality }}",
+      instructions_variables: { personality_default: "" },
+    },
+    tool_mode: "code_mode_only",
+    use_responses_lite: true,
+  };
+  const merged = buildMergedCatalog(
+    { models: [template, sol] },
+    [{ ...grok, behaviorTemplate: "gpt-5.6-sol" }],
+  );
+  const routed = merged.find((model) => model.slug === grok.slug);
+
+  assert.match(routed.base_instructions, /SOL_BEHAVIOR/);
+  assert.match(routed.model_messages.instructions_template, /SOL_TEMPLATE/);
+  assert.equal(routed.tool_mode, undefined);
+  assert.equal(routed.use_responses_lite, false);
 });
 
 test("merged catalog preserves an explicit native reasoning summary capability", () => {

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -527,8 +527,9 @@ test("DeepSeek V4 Flash routes opt in to Codex standalone web search", () => {
   }
 });
 
-test("GLM-5.3 Coding Plan opts in to standalone web search", () => {
+test("GLM-5.3 Coding Plan opts in to the GPT-5.6 behavior template and standalone web search", () => {
   const model = MODEL_BY_SLUG.get("zai-coding/glm-5.3");
+  assert.equal(model?.behaviorTemplate, "gpt-5.6-sol");
   assert.deepEqual(model?.searchTool, { mode: "standalone" });
 });
 


### PR DESCRIPTION
## Summary

Give `zai-coding/glm-5.3` the current native `gpt-5.6-sol` Codex behavior instructions without inheriting Sol-only transport or tool capabilities.

## Why

The routed catalog currently builds every external model from the `gpt-5.5` template. On current Codex builds, GPT-5.6 Sol/Luna use a different instruction set that is materially more concise and execution-oriented. GLM therefore receives older behavioral guidance even though its provider/model capabilities are otherwise configured independently.

## Change

- Add an optional per-model `behaviorTemplate` registry field.
- Configure GLM-5.3 Coding Plan with `behaviorTemplate: "gpt-5.6-sol"`.
- Borrow only `base_instructions` and `model_messages` from that native entry.
- Keep the existing conservative routed template for all capability/protocol fields.
- Fall back to the existing routed template if the requested native behavior entry is absent from the captured catalog.

This PR deliberately does **not** enable `tool_mode = code_mode_only`, Responses Lite, or any provider transport change.

## Verification

- TDD regressions cover direct `routedModel()` use and merged/login-free catalog resolution.
- Live metadata check against the current captured native `gpt-5.6-sol` entry confirmed GLM receives the Sol instruction structure while retaining `use_responses_lite = false` and no `tool_mode`.
- `npm.cmd run check`: pass.
- Full test suite: 1,794 total, 1,761 passed, 33 skipped, 0 failed.
- `git diff --check`: pass.