### PR TITLE
fix(zai): preserve GLM reasoning across tool turns

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -187,6 +187,34 @@ function coalesceAssistantMessages(messages) {
   return coalesced;
 }
 
+function restoreGlmReasoningContent(messages) {
+  if (!Array.isArray(messages)) return messages;
+  return messages.map((message) => {
+    if (message?.role !== "assistant" || !Array.isArray(message.content)) return message;
+    const reasoning = [];
+    const visible = [];
+    for (const part of message.content) {
+      if (part?.type === "thinking") {
+        const text = typeof part.text === "string" ? part.text : part.thinking;
+        if (typeof text === "string" && text) {
+          reasoning.push(text);
+          continue;
+        }
+      }
+      visible.push(part);
+    }
+    if (!reasoning.length) return message;
+    return {
+      ...message,
+      content: visible.length ? visible : null,
+      reasoning_content:
+        typeof message.reasoning_content === "string" && message.reasoning_content
+          ? message.reasoning_content
+          : reasoning.join("\n"),
+    };
+  });
+}
+
 // Strict chat-completions providers (Console Go / MiniMax / similar) reject any
 // assistant tool_calls message whose matching tool results are incomplete or
 // separated by non-tool traffic. LiteLLM's Responses->chat translation and
@@ -626,7 +654,8 @@ function normalizeBody(buffer, contentType, route) {
       payload.tool_choice = "auto";
     }
   } else if (model.requestProfile === "glm-thinking") {
-    payload.thinking = { type: "enabled" };
+    payload.thinking = { type: "enabled", clear_thinking: false };
+    payload.messages = restoreGlmReasoningContent(payload.messages);
     // Each GLM entry declares exactly the tiers Z.ai documents for it, and the
     // requested effort is clamped onto them. Models whose registry entry offers
     // a single level (GLM-5-Turbo, GLM-4.7) do not support the parameter at

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1229,7 +1229,7 @@ async function readVisionEvidence({ url, engine, nativeCall, effort, question, k
 // *next* request for a reasoning_content it had never been given. A subagent
 // always ends that way, which is why spawning one failed every time and an
 // ordinary tool loop did not (#256).
-function carryReasoningThroughInput(input) {
+function carryReasoningThroughInput(input, { nativeThinking = false } = {}) {
   if (!Array.isArray(input) || input.length < 2) return;
   for (let index = 0; index < input.length - 1; index += 1) {
     if (input[index]?.type !== "reasoning") continue;
@@ -1251,7 +1251,7 @@ function carryReasoningThroughInput(input) {
     // length for every other pass over it.
     if (text && next) {
       if (next.type === "function_call" || next.type === "custom_tool_call") {
-        input[end - 1] = assistantTextItem(text);
+        input[end - 1] = assistantTextItem(text, nativeThinking);
       } else if (next.type === "message" && next.role === "assistant") {
         // Merged into the assistant message rather than inserted in front of
         // it. A separate message would put two assistant turns back to back,
@@ -1259,26 +1259,26 @@ function carryReasoningThroughInput(input) {
         // and the tool-call branch above ends up merged anyway, because
         // LiteLLM folds a following function_call into the assistant message
         // it already emitted.
-        input[end] = mergeAssistantText(next, text);
+        input[end] = mergeAssistantText(next, text, nativeThinking);
       }
     }
     index = end - 1;
   }
 }
 
-function assistantTextItem(text) {
+function assistantTextItem(text, nativeThinking = false) {
   return {
     type: "message",
     role: "assistant",
-    content: [{ type: "output_text", text }],
+    content: [{ type: nativeThinking ? "thinking" : "output_text", text }],
   };
 }
 
 // The reasoning goes in front of the answer it produced. `content` is an array
 // of parts on everything Codex stores, but a bare string is equally legal on
 // the Responses API, so both shapes are handled rather than assumed away.
-function mergeAssistantText(item, text) {
-  const part = { type: "output_text", text };
+function mergeAssistantText(item, text, nativeThinking = false) {
+  const part = { type: nativeThinking ? "thinking" : "output_text", text };
   if (typeof item.content === "string") {
     return {
       ...item,
@@ -1977,13 +1977,16 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   // -- a turn that still reaches the provider, and still reads as a 200,
   // having quietly replaced the prompt with its own letters.
   const input = Array.isArray(bridged) ? [...bridged] : bridged;
-  // DeepSeek thinking mode requires the assistant's reasoning to be replayed,
-  // but LiteLLM's Responses->chat translation drops `reasoning` input items
-  // entirely. Merge each reasoning run into the assistant message of the turn
-  // it belongs to so the translation carries it there.
-  carryReasoningThroughInput(input);
   const provider = providerForModel(route);
   const chatCompletionsProvider = provider?.protocol !== "openai-responses";
+  // Thinking chat providers need the assistant's reasoning replayed, but
+  // LiteLLM drops Responses `reasoning` input items. Generic providers keep
+  // the established visible-content carry used for DeepSeek. GLM's native
+  // preserved-thinking contract needs reasoning kept structurally separate so
+  // the API forwarder can restore it as `reasoning_content` before Z.ai.
+  carryReasoningThroughInput(input, {
+    nativeThinking: chatCompletionsProvider && route.requestProfile === "glm-thinking",
+  });
   let tools = payload.tools;
   // LiteLLM's Responses -> Chat Completions bridge drops namespace tools, which
   // is how the client ships the collaboration runtime, the app toolset

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3339,11 +3339,66 @@ test("API forwarder routes GLM coding-plan models with thinking enabled", async 
       assert.equal(request.headers["chatgpt-account-id"], undefined);
       assert.equal(request.headers["x-codex-installation-id"], undefined);
       assert.equal(request.body.model, upstreamModel);
-      assert.deepEqual(request.body.thinking, { type: "enabled" });
+      assert.deepEqual(request.body.thinking, { type: "enabled", clear_thinking: false });
       assert.equal(request.body.reasoning_effort, expectedEffort);
       assert.equal(request.body.temperature, undefined);
       assert.equal(request.body.top_p, undefined);
     }
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
+test("API forwarder restores bridged GLM thinking as native reasoning_content", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    ZAI_CODING_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    ZAI_API_KEY: "TEST_ZAI_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "zai-coding-glm-5-3",
+          messages: [
+            { role: "user", content: "first" },
+            {
+              role: "assistant",
+              content: [
+                { type: "thinking", text: "reason one" },
+                { type: "thinking", text: "reason two" },
+                { type: "text", text: "visible answer" },
+              ],
+            },
+            { role: "user", content: "follow up" },
+          ],
+        }),
+      },
+    );
+    assert.equal(response.status, 200);
+    const request = upstreamRequests[0].body;
+    const assistant = request.messages[1];
+    assert.equal(assistant.reasoning_content, "reason one\nreason two");
+    assert.deepEqual(assistant.content, [{ type: "text", text: "visible answer" }]);
+    assert.deepEqual(request.thinking, { type: "enabled", clear_thinking: false });
   } finally {
     await stopChild(forwarder);
     await closeServer(upstream.server);
@@ -3398,7 +3453,7 @@ test("API forwarder bills the Z.ai platform on its own endpoint and key", async 
       const request = upstreamRequests.at(-1);
       assert.equal(request.headers.authorization, "Bearer TEST_ZAI_PLATFORM_KEY");
       assert.equal(request.body.model, upstreamModel);
-      assert.deepEqual(request.body.thinking, { type: "enabled" });
+      assert.deepEqual(request.body.thinking, { type: "enabled", clear_thinking: false });
       assert.equal(request.body.reasoning_effort, expectedEffort);
     }
   } finally {
@@ -5699,6 +5754,84 @@ test("reasoning survives the replay onto tool-call and prose assistant turns ali
       if (previous?.role !== "assistant" || current?.role !== "assistant") continue;
       assert.fail("two assistant messages ended up back to back");
     }
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("GLM reasoning stays structurally separate while crossing the Responses bridge", async () => {
+  const gatewayBodies = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayBodies.push(await bodyJson(request));
+    json(response, 200, { output: [{ type: "message", role: "assistant", content: "ok" }] });
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "glm-reasoning-replay-state-"));
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const input = [
+    { type: "message", role: "user", content: [{ type: "input_text", text: "first" }] },
+    {
+      type: "reasoning",
+      id: "rs_glm_tool",
+      summary: [{ type: "summary_text", text: "tool-call reasoning" }],
+      content: null,
+    },
+    { type: "function_call", call_id: "glm-call", name: "lookup_number", arguments: "{}" },
+    { type: "function_call_output", call_id: "glm-call", output: "323" },
+    {
+      type: "reasoning",
+      id: "rs_glm_answer",
+      summary: [{ type: "summary_text", text: "provider-native reasoning" }],
+      content: null,
+    },
+    {
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "visible answer" }],
+    },
+    { type: "message", role: "user", content: [{ type: "input_text", text: "follow up" }] },
+  ];
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: "zai-coding/glm-5.3", stream: false, input }),
+    });
+    assert.equal(response.status, 200, await response.text());
+    const forwarded = gatewayBodies[0].input;
+    const callIndex = forwarded.findIndex((item) => item?.type === "function_call");
+    const beforeCall = forwarded[callIndex - 1];
+    assert.equal(beforeCall?.role, "assistant");
+    assert.deepEqual(beforeCall.content, [{ type: "thinking", text: "tool-call reasoning" }]);
+
+    const assistant = forwarded.find(
+      (item) =>
+        item?.type === "message" &&
+        item.role === "assistant" &&
+        Array.isArray(item.content) &&
+        item.content.some((part) => part?.text === "visible answer"),
+    );
+    assert.ok(assistant);
+    const parts = assistant.content;
+    assert.deepEqual(parts[0], { type: "thinking", text: "provider-native reasoning" });
+    assert.deepEqual(parts[1], { type: "output_text", text: "visible answer" });
+    assert.equal(
+      parts.filter((part) => part.type === "output_text").some((part) => /reasoning/.test(part.text)),
+      false,
+      "provider reasoning leaked into visible assistant content",
+    );
   } finally {
     await stopChild(router);
     await closeServer(gateway.server);


### PR DESCRIPTION
## Summary

Preserve GLM thinking across Codex Responses -> LiteLLM -> Z.ai tool turns without exposing the reasoning as ordinary assistant content.

## Why

Codex stores routed-model reasoning as Responses `reasoning` items. LiteLLM's Responses-to-Chat-Completions bridge drops those input items, so the router previously carried their summary text into ordinary assistant content. That keeps some strict thinking providers alive, but it does not satisfy Z.ai's preserved-thinking contract, which expects historical assistant `reasoning_content` to be replayed with subsequent turns.

## Change

- Keep the existing generic content replay for providers such as DeepSeek unchanged.
- For `requestProfile: "glm-thinking"`, carry Codex reasoning structurally as `thinking` content blocks through the Responses bridge.
- At the Z.ai API forwarder boundary, restore those blocks to native assistant `reasoning_content` and remove them from visible assistant content.
- Send `thinking: { type: "enabled", clear_thinking: false }` so Z.ai preserves thinking across turns.
- Cover both reasoning-before-tool-call and reasoning-before-prose-answer paths.

## Compatibility

This is intentionally scoped to GLM's `glm-thinking` request profile. Existing DeepSeek replay behavior and tests remain unchanged and green.

## Verification

- TDD regressions reproduce both missing `reasoning_content` at the Z.ai boundary and visible-content leakage before the fix.
- Existing DeepSeek issue #256/#292 replay regressions remain green.
- Live Z.ai Coding Plan two-turn tool test through an isolated forwarder passed: turn 1 returned real `reasoning_content` plus one tool call; the exact reasoning was replayed; turn 2 was accepted and the final answer used the tool result.
- `npm.cmd run check`: pass.
- Full test suite: 1,794 total, 1,761 passed, 33 skipped, 0 failed.
- `git diff --check`: pass.

The live installed router was not modified or restarted while validating this PR.