### PR TITLE
fix(zai): preserve authoritative usage through LiteLLM

### DIFF
--- a/.github/workflows/python-lock.yml
+++ b/.github/workflows/python-lock.yml
@@ -27,6 +27,9 @@ name: Python lock
       - "install.ps1"
       - "src/install-plan.mjs"
       - "scripts/verify-python-lock.py"
+      - "scripts/verify-zai-litellm-usage.mjs"
+      - "src/api-forwarder.mjs"
+      - "src/zai-cache-usage.mjs"
       - ".github/workflows/python-lock.yml"
   pull_request:
     paths:
@@ -36,6 +39,9 @@ name: Python lock
       - "install.ps1"
       - "src/install-plan.mjs"
       - "scripts/verify-python-lock.py"
+      - "scripts/verify-zai-litellm-usage.mjs"
+      - "src/api-forwarder.mjs"
+      - "src/zai-cache-usage.mjs"
       - ".github/workflows/python-lock.yml"
   # The lock is static but PyPI is not: a yanked file, or a pip that changes
   # how it selects one, breaks an unchanged lock. The paths filter above would
@@ -249,3 +255,13 @@ jobs:
             set -- "$@" --requirement "$requirement"
           done < declared-requirements.txt
           "$venv_python" scripts/verify-python-lock.py --venv .venv "$@"
+
+      - name: Verify Z.ai streaming usage survives LiteLLM
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = Windows ]; then
+            venv_python=.venv/Scripts/python.exe
+          else
+            venv_python=.venv/bin/python
+          fi
+          node scripts/verify-zai-litellm-usage.mjs "$venv_python"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -469,7 +469,20 @@ and every client saw a bare "Connection error" naming nothing.
    wheel-availability floor. `scripts/verify-zai-litellm-usage.mjs` exercises
    the pinned LiteLLM bridge with synthetic authoritative usage on every Python
    lock job.
-9. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
+9. **Z.ai Responses streams need a post-LiteLLM message-envelope repair.**
+   Live GLM-5.3 traffic through LiteLLM 1.96 can finish a reasoning item and
+   then emit `response.output_text.delta` for the assistant message without the
+   required `response.output_item.added` / `response.content_part.added`
+   envelope. The same malformed stream can reuse reasoning's `output_index=0`
+   for the message and close the message with a `reasoning_text` content part.
+   `src/zai-responses-compat.mjs` repairs only that Z.ai event-stream shape
+   after LiteLLM translation: valid streams remain byte-identical, native
+   OpenAI traffic is never attached to the transform, and provider reasoning
+   must never be copied into assistant-visible message content. A real Codex
+   live probe is the regression oracle: no `OutputTextDelta without active
+   item` warnings and the message occupies the next output index after
+   reasoning.
+10. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
    security floor and a wheel-availability decision (see the lock section
    above), any change to it has to be proven by booting the proxy rather than by
    a successful resolve, and a router that survives its gateway is worth having

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,7 +459,17 @@ and every client saw a bare "Connection error" naming nothing.
    rather than the gateway, so a signal reaches the hop and the real process is
    orphaned. That is strictly better than not starting at all, and it is another
    reason the installer produces an `.exe`.
-8. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
+8. **Z.ai choice-bearing terminal usage is normalized before LiteLLM.** LiteLLM
+   1.95/1.96 can discard authoritative usage when an OpenAI-compatible provider
+   puts `finish_reason` and `usage` on the same streaming chunk. Z.ai does that,
+   so `src/zai-cache-usage.mjs` rewrites only that provider shape into the
+   standard usage-only terminal chunk and preserves explicit cached-token
+   details. Do not replace missing usage with estimates at this boundary and do
+   not downgrade LiteLLM to escape the bug; the pin is also a security and
+   wheel-availability floor. `scripts/verify-zai-litellm-usage.mjs` exercises
+   the pinned LiteLLM bridge with synthetic authoritative usage on every Python
+   lock job.
+9. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
    security floor and a wheel-availability decision (see the lock section
    above), any change to it has to be proven by booting the proxy rather than by
    a successful resolve, and a router that survives its gateway is worth having

--- a/scripts/verify-zai-litellm-usage.mjs
+++ b/scripts/verify-zai-litellm-usage.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import http from "node:http";
+import { Readable } from "node:stream";
+
+import { ZaiCacheUsageCompatTransform } from "../src/zai-cache-usage.mjs";
+
+const python = process.argv[2];
+if (!python) {
+  throw new Error("usage: node scripts/verify-zai-litellm-usage.mjs <venv-python>");
+}
+
+const providerChunk = {
+  id: "chatcmpl-zai-usage-proof",
+  object: "chat.completion.chunk",
+  created: 1_787_167_000,
+  model: "glm-5.3",
+  choices: [{ index: 0, delta: { content: "ok" }, finish_reason: "stop" }],
+  usage: {
+    prompt_tokens: 1200,
+    completion_tokens: 8,
+    total_tokens: 1208,
+    prompt_tokens_details: { cached_tokens: 800 },
+  },
+};
+
+async function normalize(body) {
+  const stream = Readable.from([body]).pipe(new ZaiCacheUsageCompatTransform());
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+const normalized = await normalize(
+  `data: ${JSON.stringify(providerChunk)}\n\ndata: [DONE]\n\n`,
+);
+let receivedRequest;
+const server = http.createServer(async (request, response) => {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  receivedRequest = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  response.writeHead(200, { "Content-Type": "text/event-stream" });
+  response.end(normalized);
+});
+await new Promise((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", resolve);
+});
+
+const { port } = server.address();
+const pythonCode = String.raw`
+import json
+import sys
+import litellm
+
+port = int(sys.argv[1])
+completed = None
+stream = litellm.responses(
+    model="openai/zai-coding-glm-5-3",
+    input="cached prompt",
+    stream=True,
+    api_base=f"http://127.0.0.1:{port}/v1",
+    api_key="test-zai-usage-proof",
+    use_chat_completions_api=True,
+)
+for event in stream:
+    if getattr(event, "type", None) == "response.completed":
+        completed = event.response.usage.model_dump()
+if completed is None:
+    raise AssertionError("LiteLLM did not emit response.completed usage")
+assert completed["input_tokens"] == 1200, completed
+assert completed["output_tokens"] == 8, completed
+assert completed["input_tokens_details"]["cached_tokens"] == 800, completed
+print(json.dumps(completed, sort_keys=True))
+`;
+
+const child = spawn(python, ["-c", pythonCode, String(port)], {
+  stdio: ["ignore", "pipe", "pipe"],
+});
+let stdout = "";
+let stderr = "";
+child.stdout.setEncoding("utf8");
+child.stderr.setEncoding("utf8");
+child.stdout.on("data", (chunk) => { stdout += chunk; });
+child.stderr.on("data", (chunk) => { stderr += chunk; });
+const exitCode = await new Promise((resolve) => child.once("exit", resolve));
+await new Promise((resolve) => server.close(resolve));
+
+assert.equal(exitCode, 0, stderr || stdout);
+assert.equal(receivedRequest?.stream, true);
+assert.equal(receivedRequest?.stream_options?.include_usage, true);
+process.stdout.write(stdout);

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -42,6 +42,7 @@ import {
 import { relayCommandCodeGenerate } from "./commandcode-relay.mjs";
 import { VERSION } from "./version.mjs";
 import { installStableFetchTransport } from "./fetch-transport.mjs";
+import { zaiCacheUsageTransform } from "./zai-cache-usage.mjs";
 
 installStableFetchTransport();
 
@@ -1022,7 +1023,12 @@ async function handleRequest(request, response) {
   if (commandCode?.recheck && upstream.ok) {
     recordCommandCodeRoute(commandCode.id, credential.value, { providerApi: true });
   }
-  await pipeResponse(upstream, response);
+  await pipeResponse(
+    upstream,
+    response,
+    undefined,
+    zaiCacheUsageTransform(normalized.provider.id, upstream.headers.get("content-type")),
+  );
   recordUpstreamLimits(normalized, upstream);
   if (!QUIET) {
     console.error(

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -31,6 +31,7 @@ import {
   writeStreamErrorEvent,
 } from "./http-utils.mjs";
 import { EmptyCompletionGuard } from "./empty-completion-guard.mjs";
+import { zaiResponsesCompatTransform } from "./zai-responses-compat.mjs";
 import {
   MERGED_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
@@ -2644,6 +2645,10 @@ async function handleResponses(request, response, requestUrl) {
             : undefined,
       });
       const transforms = [usageObserver];
+      const zaiCompat = route
+        ? zaiResponsesCompatTransform(route.provider, contentType)
+        : undefined;
+      if (zaiCompat) transforms.push(zaiCompat);
       // Restore flattened namespace calls for routed chat-completions providers,
       // and inject missing finished-child interrupts for both routed and native
       // multi-agent parents (San Francisco uses native GPT).

--- a/src/zai-cache-usage.mjs
+++ b/src/zai-cache-usage.mjs
@@ -2,14 +2,24 @@ import { Transform } from "node:stream";
 
 const LINE_FEED = 0x0a;
 
-// Z.ai reports cache reads in usage.prompt_tokens_details.cached_tokens. The
-// generic LiteLLM streaming bridge can lose that nested detail before its
-// Chat-Completions -> Responses conversion, while its Usage compatibility
-// layer explicitly recognizes prompt_cache_hit_tokens. Mirror only an
-// authoritative provider count; never infer a hit or turn missing data into 0.
+// Z.ai reports authoritative prompt/cache usage on the same terminal chunk as
+// finish_reason. LiteLLM 1.95/1.96 loses usage details on that choice-bearing
+// shape, but preserves the standard OpenAI usage-only terminal chunk. Normalize
+// the provider stream before it reaches LiteLLM and mirror cached_tokens into
+// the compatibility field LiteLLM already understands. Never infer usage.
 function cachedTokens(payload) {
   const value = payload?.usage?.prompt_tokens_details?.cached_tokens;
   return Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function usageObject(payload) {
+  return payload?.usage && typeof payload.usage === "object" && !Array.isArray(payload.usage)
+    ? payload.usage
+    : undefined;
+}
+
+function choiceBearingUsage(payload) {
+  return Array.isArray(payload?.choices) && payload.choices.length > 0 && usageObject(payload);
 }
 
 export class ZaiCacheUsageCompatTransform extends Transform {
@@ -53,10 +63,28 @@ export class ZaiCacheUsageCompatTransform extends Transform {
     } catch {
       return line;
     }
+
+    const usage = usageObject(payload);
+    if (usage === undefined) return line;
     const cached = cachedTokens(payload);
-    if (cached === undefined || payload?.usage?.prompt_cache_hit_tokens !== undefined) return line;
-    payload.usage.prompt_cache_hit_tokens = cached;
-    return Buffer.from(`data: ${JSON.stringify(payload)}${terminator}`, "utf8");
+    let changed = false;
+    if (cached !== undefined && usage.prompt_cache_hit_tokens === undefined) {
+      usage.prompt_cache_hit_tokens = cached;
+      changed = true;
+    }
+
+    if (!choiceBearingUsage(payload)) {
+      return changed ? Buffer.from(`data: ${JSON.stringify(payload)}${terminator}`, "utf8") : line;
+    }
+
+    const terminal = { ...payload };
+    delete terminal.usage;
+    const usageOnly = { ...payload, choices: [], usage };
+    const separator = terminator || "\n";
+    return Buffer.from(
+      `data: ${JSON.stringify(terminal)}${separator}${separator}data: ${JSON.stringify(usageOnly)}${terminator}`,
+      "utf8",
+    );
   }
 }
 

--- a/src/zai-cache-usage.mjs
+++ b/src/zai-cache-usage.mjs
@@ -1,0 +1,67 @@
+import { Transform } from "node:stream";
+
+const LINE_FEED = 0x0a;
+
+// Z.ai reports cache reads in usage.prompt_tokens_details.cached_tokens. The
+// generic LiteLLM streaming bridge can lose that nested detail before its
+// Chat-Completions -> Responses conversion, while its Usage compatibility
+// layer explicitly recognizes prompt_cache_hit_tokens. Mirror only an
+// authoritative provider count; never infer a hit or turn missing data into 0.
+function cachedTokens(payload) {
+  const value = payload?.usage?.prompt_tokens_details?.cached_tokens;
+  return Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+export class ZaiCacheUsageCompatTransform extends Transform {
+  #pending = Buffer.alloc(0);
+
+  _transform(chunk, _encoding, callback) {
+    this.#pending = this.#pending.length ? Buffer.concat([this.#pending, chunk]) : chunk;
+    this.#consumeLines();
+    callback();
+  }
+
+  _flush(callback) {
+    this.#consumeLines(true);
+    callback();
+  }
+
+  #consumeLines(flush = false) {
+    while (true) {
+      const index = this.#pending.indexOf(LINE_FEED);
+      if (index === -1) break;
+      const line = this.#pending.subarray(0, index + 1);
+      this.#pending = this.#pending.subarray(index + 1);
+      this.push(this.#rewriteLine(line));
+    }
+    if (flush && this.#pending.length) {
+      this.push(this.#rewriteLine(this.#pending));
+      this.#pending = Buffer.alloc(0);
+    }
+  }
+
+  #rewriteLine(line) {
+    const text = line.toString("utf8");
+    const terminator = text.endsWith("\r\n") ? "\r\n" : text.endsWith("\n") ? "\n" : "";
+    const content = terminator ? text.slice(0, -terminator.length) : text;
+    if (!content.startsWith("data:")) return line;
+    const data = content.slice(5).trim();
+    if (!data || data === "[DONE]") return line;
+    let payload;
+    try {
+      payload = JSON.parse(data);
+    } catch {
+      return line;
+    }
+    const cached = cachedTokens(payload);
+    if (cached === undefined || payload?.usage?.prompt_cache_hit_tokens !== undefined) return line;
+    payload.usage.prompt_cache_hit_tokens = cached;
+    return Buffer.from(`data: ${JSON.stringify(payload)}${terminator}`, "utf8");
+  }
+}
+
+export function zaiCacheUsageTransform(providerId, contentType = "") {
+  if (!["zai-api", "zai-coding"].includes(String(providerId))) return undefined;
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
+  return new ZaiCacheUsageCompatTransform();
+}

--- a/src/zai-responses-compat.mjs
+++ b/src/zai-responses-compat.mjs
@@ -1,0 +1,207 @@
+import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+function eventBlock(block) {
+  const newline = block.includes("\r\n") ? "\r\n" : "\n";
+  const lines = block.split(/\r?\n/);
+  const dataLineIndex = lines.findIndex((line) => line.startsWith("data:"));
+  if (dataLineIndex === -1) return undefined;
+  const dataText = lines[dataLineIndex].slice(5).trimStart();
+  if (!dataText || dataText === "[DONE]") return undefined;
+  try {
+    return { lines, dataLineIndex, newline, event: JSON.parse(dataText) };
+  } catch {
+    return undefined;
+  }
+}
+
+function rewrittenBlock(parsed, event) {
+  const lines = [...parsed.lines];
+  lines[parsed.dataLineIndex] = `data: ${JSON.stringify(event)}`;
+  return lines.join(parsed.newline);
+}
+
+function syntheticBlock(type, event, parsed) {
+  const hasEventLine = parsed.lines.some((line) => line.startsWith("event:"));
+  const lines = hasEventLine ? [`event: ${type}`] : [];
+  lines.push(`data: ${JSON.stringify({ type, ...event })}`);
+  return lines.join(parsed.newline);
+}
+
+export class ZaiResponsesCompatTransform extends Transform {
+  #decoder = new StringDecoder("utf8");
+  #buffer = "";
+  #maxOutputIndex = -1;
+  #message;
+
+  _transform(chunk, _encoding, callback) {
+    this.#buffer += this.#decoder.write(chunk);
+    this.#emitCompleteBlocks();
+    callback();
+  }
+
+  _flush(callback) {
+    this.#buffer += this.#decoder.end();
+    this.#emitCompleteBlocks(true);
+    callback();
+  }
+
+  #emitCompleteBlocks(flush = false) {
+    while (this.#buffer.length) {
+      const crlf = this.#buffer.indexOf("\r\n\r\n");
+      const lf = this.#buffer.indexOf("\n\n");
+      let index = -1;
+      let separator = "";
+      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+        index = crlf;
+        separator = "\r\n\r\n";
+      } else if (lf !== -1) {
+        index = lf;
+        separator = "\n\n";
+      }
+      if (index === -1) {
+        if (!flush) return;
+        const block = this.#buffer;
+        this.#buffer = "";
+        for (const piece of this.#rewriteBlock(block)) this.push(Buffer.from(piece));
+        return;
+      }
+      const block = this.#buffer.slice(0, index);
+      this.#buffer = this.#buffer.slice(index + separator.length);
+      const pieces = this.#rewriteBlock(block);
+      for (const piece of pieces) this.push(Buffer.from(`${piece}${separator}`));
+    }
+  }
+
+  #messageIndex(event) {
+    if (this.#message) return this.#message.outputIndex;
+    const reported = Number.isInteger(event?.output_index) ? event.output_index : 0;
+    return this.#maxOutputIndex >= 0
+      ? Math.max(this.#maxOutputIndex + 1, reported)
+      : reported;
+  }
+
+  #startMessage(event, parsed) {
+    const outputIndex = this.#messageIndex(event);
+    const contentIndex = Number.isInteger(event?.content_index) ? event.content_index : 0;
+    this.#message = {
+      id: String(event?.item_id || ""),
+      outputIndex,
+      contentIndex,
+      text: "",
+      contentStarted: true,
+    };
+    const common = {
+      output_index: outputIndex,
+      ...(typeof event?.model === "string" ? { model: event.model } : {}),
+    };
+    return [
+      syntheticBlock("response.output_item.added", {
+        ...common,
+        item: {
+          id: this.#message.id,
+          type: "message",
+          status: "in_progress",
+          role: "assistant",
+          content: [],
+        },
+      }, parsed),
+      syntheticBlock("response.content_part.added", {
+        ...common,
+        item_id: this.#message.id,
+        content_index: contentIndex,
+        part: { type: "output_text", text: "", annotations: [] },
+      }, parsed),
+    ];
+  }
+
+  #rewriteMessageEvent(event) {
+    if (!this.#message) return event;
+    if (event.output_index === this.#message.outputIndex) return event;
+    return { ...event, output_index: this.#message.outputIndex };
+  }
+
+  #rewriteBlock(block) {
+    const parsed = eventBlock(block);
+    if (!parsed) return [block];
+    const event = parsed.event;
+    const type = event?.type;
+    if (type === "response.output_item.added") {
+      if (Number.isInteger(event.output_index)) {
+        this.#maxOutputIndex = Math.max(this.#maxOutputIndex, event.output_index);
+      }
+      if (event?.item?.type === "message") {
+        this.#message = {
+          id: String(event.item.id || ""),
+          outputIndex: Number.isInteger(event.output_index) ? event.output_index : 0,
+          contentIndex: 0,
+          text: "",
+          contentStarted: false,
+        };
+      }
+      return [block];
+    }
+
+    if (type === "response.content_part.added" && this.#message?.id === event.item_id) {
+      this.#message.contentStarted = true;
+      return [block];
+    }
+
+    if (type === "response.output_item.done" && event?.item?.type === "reasoning") {
+      if (Number.isInteger(event.output_index)) {
+        this.#maxOutputIndex = Math.max(this.#maxOutputIndex, event.output_index);
+      }
+      return [block];
+    }
+
+    if (type === "response.output_text.delta" || type === "response.output_text.done") {
+      const injected = this.#message ? [] : this.#startMessage(event, parsed);
+      let next = this.#rewriteMessageEvent(event);
+      if (type === "response.output_text.delta" && typeof event.delta === "string") {
+        this.#message.text += event.delta;
+      }
+      if (type === "response.output_text.done" && typeof event.text === "string") {
+        this.#message.text = event.text;
+      }
+      return [...injected, next === event ? block : rewrittenBlock(parsed, next)];
+    }
+
+    if (type === "response.content_part.done" && this.#message?.id === event.item_id) {
+      let next = this.#rewriteMessageEvent(event);
+      const part = event.part;
+      if (part?.type !== "output_text" || typeof part?.reasoning === "string") {
+        next = {
+          ...next,
+          part: {
+            type: "output_text",
+            text: this.#message.text,
+            annotations: Array.isArray(part?.annotations) ? part.annotations : [],
+          },
+        };
+      }
+      return [next === event ? block : rewrittenBlock(parsed, next)];
+    }
+
+    if (type === "response.output_item.done" && event?.item?.type === "message") {
+      if (!this.#message) {
+        this.#message = {
+          id: String(event.item.id || ""),
+          outputIndex: this.#messageIndex(event),
+          contentIndex: 0,
+          text: "",
+          contentStarted: false,
+        };
+      }
+      const next = this.#rewriteMessageEvent(event);
+      return [next === event ? block : rewrittenBlock(parsed, next)];
+    }
+
+    return [block];
+  }
+}
+
+export function zaiResponsesCompatTransform(providerId, contentType = "") {
+  if (!["zai-api", "zai-coding"].includes(String(providerId))) return undefined;
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
+  return new ZaiResponsesCompatTransform();
+}

--- a/test/python-lock.test.mjs
+++ b/test/python-lock.test.mjs
@@ -247,3 +247,20 @@ test("the CI gateway verifier starts LiteLLM with the environment start.mjs uses
 function repoFileIn(root, relative) {
   return path.join(root, ...relative.split("/"));
 }
+
+
+test("the Python gateway workflow guards the Z.ai LiteLLM usage bridge", () => {
+  const workflow = readFileSync(repoFile(LOCK_WORKFLOW), "utf8");
+  for (const input of [
+    "src/api-forwarder.mjs",
+    "src/zai-cache-usage.mjs",
+    "scripts/verify-zai-litellm-usage.mjs",
+  ]) {
+    assert.ok(workflow.includes(`"${input}"`), `${LOCK_WORKFLOW} does not run when ${input} changes`);
+  }
+  assert.match(
+    workflow,
+    /node scripts\/verify-zai-litellm-usage\.mjs "\$venv_python"/,
+    "the installed LiteLLM bridge must be exercised after the lock is installed",
+  );
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5852,3 +5852,68 @@ test("a plain follow-up after a thinking turn replays its reasoning", async () =
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+
+test("router repairs malformed Z.ai message envelopes after LiteLLM Responses translation", async () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "zai-responses-compat-router-"));
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    `${JSON.stringify({ version: 1, providers: ["zai-coding"] })}\n`,
+  );
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET") {
+      json(response, 200, { ok: true, credential_present: true, credential_source: "test" });
+      return;
+    }
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    const events = [
+      { type: "response.output_item.added", output_index: 0, model: "zai-coding-glm-5-3", item: { id: "rs_1", type: "reasoning", status: "in_progress", summary: [] } },
+      { type: "response.output_item.done", output_index: 0, sequence_number: 6, model: "zai-coding-glm-5-3", item: { id: "rs_1", type: "reasoning", summary: [] } },
+      { type: "response.output_text.delta", output_index: 0, content_index: 0, item_id: "msg_1", model: "zai-coding-glm-5-3", delta: "ROUTER_OK" },
+      { type: "response.output_text.done", output_index: 0, content_index: 0, item_id: "msg_1", model: "zai-coding-glm-5-3", text: "ROUTER_OK" },
+      { type: "response.content_part.done", output_index: 0, content_index: 0, item_id: "msg_1", model: "zai-coding-glm-5-3", part: { type: "reasoning_text", reasoning: "private reasoning" } },
+      { type: "response.output_item.done", output_index: 0, sequence_number: 1, model: "zai-coding-glm-5-3", item: { id: "msg_1", type: "message", status: "completed", role: "assistant", content: [{ type: "output_text", text: "ROUTER_OK", annotations: [] }] } },
+      { type: "response.completed", response: { id: "resp_1", status: "completed", output: [], usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 } } },
+    ];
+    response.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_SHOW_ALL_MODELS: "0",
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "zai-coding/glm-5.3", input: "test", stream: true }),
+    });
+    assert.equal(response.status, 200);
+    const text = await response.text();
+    const events = text.split(/\r?\n/)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+    const deltaIndex = events.findIndex((event) => event.type === "response.output_text.delta");
+    assert.equal(events[deltaIndex - 2]?.type, "response.output_item.added");
+    assert.equal(events[deltaIndex - 2]?.item?.type, "message");
+    assert.equal(events[deltaIndex - 2]?.output_index, 1);
+    assert.equal(events[deltaIndex - 1]?.type, "response.content_part.added");
+    assert.equal(events[deltaIndex]?.output_index, 1);
+    const partDone = events.find((event) => event.type === "response.content_part.done");
+    assert.deepEqual(partDone?.part, { type: "output_text", text: "ROUTER_OK", annotations: [] });
+    assert.ok(!text.includes("private reasoning"));
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3350,6 +3350,61 @@ test("API forwarder routes GLM coding-plan models with thinking enabled", async 
   }
 });
 
+test("API forwarder preserves Z.ai cached-token telemetry across the LiteLLM bridge", async () => {
+  const upstream = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(
+      `data: ${JSON.stringify({
+        id: "chatcmpl-cache",
+        choices: [{ index: 0, delta: { content: "ok" }, finish_reason: "stop" }],
+        usage: {
+          prompt_tokens: 1200,
+          completion_tokens: 8,
+          total_tokens: 1208,
+          prompt_tokens_details: { cached_tokens: 800 },
+        },
+      })}\n\ndata: [DONE]\n\n`,
+    );
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    ZAI_CODING_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    ZAI_API_KEY: "TEST_ZAI_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "zai-coding-glm-5-3",
+        stream: true,
+        messages: [{ role: "user", content: "test" }],
+      }),
+    });
+    assert.equal(response.status, 200);
+    const data = (await response.text())
+      .split(/\r?\n/)
+      .find((line) => line.startsWith("data: {") && line.includes('"usage"'));
+    assert.ok(data);
+    const chunk = JSON.parse(data.slice(5).trim());
+    assert.equal(chunk.usage.prompt_tokens_details.cached_tokens, 800);
+    assert.equal(chunk.usage.prompt_cache_hit_tokens, 800);
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder bills the Z.ai platform on its own endpoint and key", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3350,7 +3350,7 @@ test("API forwarder routes GLM coding-plan models with thinking enabled", async 
   }
 });
 
-test("API forwarder preserves Z.ai cached-token telemetry across the LiteLLM bridge", async () => {
+test("API forwarder preserves Z.ai cached-token telemetry before the LiteLLM bridge", async () => {
   const upstream = await mockServer(async (request, response) => {
     await bodyJson(request);
     response.writeHead(200, { "Content-Type": "text/event-stream" });

--- a/test/zai-cache-usage.test.mjs
+++ b/test/zai-cache-usage.test.mjs
@@ -39,3 +39,34 @@ test("non-usage and malformed SSE lines pass through byte-for-byte", async () =>
   const input = 'event: message\r\ndata: {not-json}\r\ndata: [DONE]\r\n';
   assert.equal(await transformed([input]), input);
 });
+
+
+test("Z.ai choice-bearing terminal usage is normalized to a usage-only chunk", async () => {
+  const terminal = {
+    id: "chatcmpl-cache",
+    model: "glm-5.3",
+    choices: [{ index: 0, delta: { content: "" }, finish_reason: "stop" }],
+    usage: {
+      prompt_tokens: 1200,
+      completion_tokens: 8,
+      total_tokens: 1208,
+      prompt_tokens_details: { cached_tokens: 800 },
+    },
+  };
+  const output = await transformed([
+    `data: ${JSON.stringify(terminal)}\n\ndata: [DONE]\n\n`,
+  ]);
+  const payloads = output
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data: {") && line.includes('"id"'))
+    .map((line) => JSON.parse(line.slice(5).trim()));
+
+  assert.equal(payloads.length, 2);
+  assert.deepEqual(payloads[0].choices, terminal.choices);
+  assert.equal(payloads[0].usage, undefined);
+  assert.deepEqual(payloads[1].choices, []);
+  assert.equal(payloads[1].usage.prompt_tokens, 1200);
+  assert.equal(payloads[1].usage.completion_tokens, 8);
+  assert.equal(payloads[1].usage.prompt_tokens_details.cached_tokens, 800);
+  assert.equal(payloads[1].usage.prompt_cache_hit_tokens, 800);
+});

--- a/test/zai-cache-usage.test.mjs
+++ b/test/zai-cache-usage.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { test } from "node:test";
+
+import {
+  ZaiCacheUsageCompatTransform,
+  zaiCacheUsageTransform,
+} from "../src/zai-cache-usage.mjs";
+
+async function transformed(chunks) {
+  const stream = Readable.from(chunks).pipe(new ZaiCacheUsageCompatTransform());
+  const output = [];
+  for await (const chunk of stream) output.push(chunk);
+  return Buffer.concat(output).toString("utf8");
+}
+
+test("Z.ai cache usage compatibility survives split SSE chunks and explicit zero", async () => {
+  const prefix = 'data: {"usage":{"prompt_tokens":12,"prompt_tokens_details":{"cached_tokens":';
+  const output = await transformed([prefix, '0}}}\r\n', 'data: [DONE]\r\n']);
+  const usageLine = output.split(/\r?\n/).find((line) => line.includes('"usage"'));
+  const payload = JSON.parse(usageLine.slice(5).trim());
+  assert.equal(payload.usage.prompt_tokens_details.cached_tokens, 0);
+  assert.equal(payload.usage.prompt_cache_hit_tokens, 0);
+});
+
+test("Z.ai cache compatibility never overwrites a provider-supplied compatibility count", async () => {
+  const line = 'data: {"usage":{"prompt_tokens_details":{"cached_tokens":800},"prompt_cache_hit_tokens":700}}\n';
+  assert.equal(await transformed([line]), line);
+});
+
+test("cache compatibility is installed only for Z.ai event streams", () => {
+  assert.ok(zaiCacheUsageTransform("zai-coding", "text/event-stream"));
+  assert.ok(zaiCacheUsageTransform("zai-api", "text/event-stream; charset=utf-8"));
+  assert.equal(zaiCacheUsageTransform("zai-coding", "application/json"), undefined);
+  assert.equal(zaiCacheUsageTransform("deepseek", "text/event-stream"), undefined);
+});
+
+test("non-usage and malformed SSE lines pass through byte-for-byte", async () => {
+  const input = 'event: message\r\ndata: {not-json}\r\ndata: [DONE]\r\n';
+  assert.equal(await transformed([input]), input);
+});

--- a/test/zai-responses-compat.test.mjs
+++ b/test/zai-responses-compat.test.mjs
@@ -1,0 +1,104 @@
+﻿import assert from "node:assert/strict";
+import { once } from "node:events";
+import test from "node:test";
+
+import {
+  ZaiResponsesCompatTransform,
+  zaiResponsesCompatTransform,
+} from "../src/zai-responses-compat.mjs";
+
+async function transformed(chunks) {
+  const stream = new ZaiResponsesCompatTransform();
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  for (const chunk of chunks) stream.write(chunk);
+  stream.end();
+  await once(stream, "end");
+  return output;
+}
+
+function block(event) {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+function dataEvents(text) {
+  return text.split(/\r?\n\r?\n/).filter(Boolean).map((part) => {
+    const line = part.split(/\r?\n/).find((value) => value.startsWith("data:"));
+    return line ? JSON.parse(line.slice(5).trim()) : undefined;
+  }).filter(Boolean);
+}
+
+test("repairs the live LiteLLM reasoning-to-message Responses envelope", async () => {
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, model: "zai-coding-glm-5-3", item: { id: "rs_1", type: "reasoning", status: "in_progress", summary: [] } }),
+    block({ type: "response.output_item.done", output_index: 0, sequence_number: 6, model: "zai-coding-glm-5-3", item: { id: "rs_1", type: "reasoning", summary: [] } }),
+    block({ type: "response.output_text.delta", output_index: 0, content_index: 0, item_id: "msg_1", model: "zai-coding-glm-5-3", delta: "HELLO" }),
+    block({ type: "response.output_text.done", output_index: 0, content_index: 0, item_id: "msg_1", model: "zai-coding-glm-5-3", text: "HELLO" }),
+    block({ type: "response.content_part.done", output_index: 0, content_index: 0, item_id: "msg_1", model: "zai-coding-glm-5-3", part: { type: "reasoning_text", reasoning: "private reasoning" } }),
+    block({ type: "response.output_item.done", output_index: 0, sequence_number: 1, model: "zai-coding-glm-5-3", item: { id: "msg_1", type: "message", status: "completed", role: "assistant", content: [{ type: "output_text", text: "HELLO", annotations: [] }] } }),
+    block({ type: "response.completed", response: { id: "resp_1", status: "completed", output: [] } }),
+  ].join("");
+
+  const output = await transformed([input.slice(0, 157), input.slice(157)]);
+  const events = dataEvents(output);
+  const deltaIndex = events.findIndex((event) => event.type === "response.output_text.delta");
+  assert.ok(deltaIndex >= 2);
+  assert.equal(events[deltaIndex - 2].type, "response.output_item.added");
+  assert.equal(events[deltaIndex - 2].item.type, "message");
+  assert.equal(events[deltaIndex - 2].item.id, "msg_1");
+  assert.equal(events[deltaIndex - 2].output_index, 1);
+  assert.equal(events[deltaIndex - 1].type, "response.content_part.added");
+  assert.equal(events[deltaIndex - 1].part.type, "output_text");
+  assert.equal(events[deltaIndex].output_index, 1);
+
+  const textDone = events.find((event) => event.type === "response.output_text.done");
+  const partDone = events.find((event) => event.type === "response.content_part.done");
+  const messageDone = events.find((event) => event.type === "response.output_item.done" && event.item?.type === "message");
+  assert.equal(textDone.output_index, 1);
+  assert.equal(partDone.output_index, 1);
+  assert.deepEqual(partDone.part, { type: "output_text", text: "HELLO", annotations: [] });
+  assert.equal(messageDone.output_index, 1);
+  assert.ok(!output.includes("private reasoning"));
+});
+
+test("leaves an already valid message stream byte-identical", async () => {
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "msg_ok", type: "message", status: "in_progress", role: "assistant", content: [] } }),
+    block({ type: "response.content_part.added", output_index: 0, content_index: 0, item_id: "msg_ok", part: { type: "output_text", text: "", annotations: [] } }),
+    block({ type: "response.output_text.delta", output_index: 0, content_index: 0, item_id: "msg_ok", delta: "OK" }),
+  ].join("");
+  assert.equal(await transformed([input]), input);
+});
+
+test("compatibility factory is scoped to Z.ai Responses event streams", () => {
+  assert.ok(zaiResponsesCompatTransform("zai-coding", "text/event-stream"));
+  assert.ok(zaiResponsesCompatTransform("zai-api", "text/event-stream; charset=utf-8"));
+  assert.equal(zaiResponsesCompatTransform("openai", "text/event-stream"), undefined);
+  assert.equal(zaiResponsesCompatTransform("zai-coding", "application/json"), undefined);
+});
+
+test("repairs a message-only LiteLLM stream without shifting its zero output index", async () => {
+  const input = [
+    block({ type: "response.output_text.delta", output_index: 0, content_index: 0, item_id: "msg_only", delta: "OK" }),
+    block({ type: "response.output_text.done", output_index: 0, content_index: 0, item_id: "msg_only", text: "OK" }),
+    block({ type: "response.output_item.done", output_index: 0, item: { id: "msg_only", type: "message", status: "completed", role: "assistant", content: [{ type: "output_text", text: "OK", annotations: [] }] } }),
+  ].join("");
+  const events = dataEvents(await transformed([input]));
+  assert.deepEqual(events.slice(0, 3).map((event) => event.type), [
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.output_text.delta",
+  ]);
+  assert.ok(events.every((event) => !Number.isInteger(event.output_index) || event.output_index === 0));
+});
+
+test("preserves CRLF framing while repairing the malformed message envelope", async () => {
+  const input = [
+    `data: ${JSON.stringify({ type: "response.output_item.done", output_index: 0, item: { id: "rs", type: "reasoning" } })}\r\n\r\n`,
+    `data: ${JSON.stringify({ type: "response.output_text.delta", output_index: 0, content_index: 0, item_id: "msg", delta: "X" })}\r\n\r\n`,
+  ].join("");
+  const output = await transformed([input]);
+  assert.ok(output.includes("\r\n\r\n"));
+  assert.equal(output.replace(/\r\n\r\n/g, "").includes("\n\n"), false);
+});


### PR DESCRIPTION
## Summary

Preserve authoritative Z.ai prompt/cache usage through LiteLLM **and** repair the malformed Z.ai Responses message envelope LiteLLM emits to Codex clients.

## Root causes

Two compatibility failures were confirmed in the Codex -> router -> LiteLLM -> Z.ai path:

1. **Authoritative usage loss.** Z.ai can emit terminal streaming chunks containing both a non-empty `choices` array and `usage`. Installed LiteLLM 1.96.0 reconstructs local token estimates for that shape instead of preserving provider usage, dropping cached-token telemetry.
2. **Malformed Responses message envelope.** In a live GLM-5.3 Codex tool round-trip, LiteLLM completed a reasoning item and then emitted `response.output_text.delta` for the assistant message without first emitting the required `response.output_item.added` / `response.content_part.added` events. It also reused `output_index=0` after reasoning and closed the assistant message with a `reasoning_text` content part. Codex logged repeated `OutputTextDelta without active item` warnings even though the completion ultimately succeeded.

## Fix

### Usage compatibility

At the Z.ai API-forwarder SSE boundary:

- apply only to `zai-coding` and `zai-api` event streams;
- preserve only explicit provider usage; never invent or estimate usage there;
- mirror explicit non-negative `usage.prompt_tokens_details.cached_tokens` into the compatibility field LiteLLM understands without overwriting a provider-supplied value;
- split Z.ai terminal `choices + usage` chunks into the standard choice chunk followed by a usage-only `choices: []` chunk;
- leave malformed, non-usage, `[DONE]`, non-Z.ai, and non-streaming traffic unchanged.

### Responses envelope compatibility

On routed Z.ai `text/event-stream` responses after LiteLLM translation:

- inject the missing assistant `response.output_item.added` and `response.content_part.added` events only when LiteLLM omitted them;
- assign the assistant message the next output index when a reasoning item already occupied index 0;
- normalize subsequent assistant delta/done indices to the repaired message index;
- replace the malformed message-closing `reasoning_text` part with an `output_text` part built from the actual completed assistant text;
- never expose provider reasoning as visible assistant content;
- leave already-valid Z.ai Responses streams byte-identical;
- do not touch native OpenAI traffic or non-Z.ai routed providers.

## Live validation

With GLM-5.3 Coding Plan quota available again:

- the unfixed path reproduced repeated `OutputTextDelta without active item` warnings;
- raw SSE inspection reproduced the missing assistant envelope, reused output index, and malformed `reasoning_text` close;
- the patched isolated router emitted a valid reasoning -> message sequence with the assistant at `output_index=1`;
- a real Codex tool round-trip through the patched router completed with **0 `OutputTextDelta without active item` warnings** while cache accounting remained present;
- after installation into the combined local stack, a fresh marker tool round-trip completed successfully with **115,550 input / 14,144 cached input tokens** and zero envelope warnings;
- a later 1,200-line targeted-search probe reported **117,025 input / 74,240 cached input tokens** and again produced zero envelope warnings.

## Regression coverage

- Installed-LiteLLM synthetic bridge proof returns exactly **1200 input / 8 output / 800 cached**.
- Transform coverage covers malformed reasoning-to-message streams, valid-stream byte identity, message-only streams, split chunks, and CRLF framing.
- Router-level coverage proves the repair is installed on the routed Z.ai Responses path.
- Existing reasoning replay and cache/usage tests remain green.

## Verification

PR branch on Windows:
- `test/routing.test.mjs`: **72/72 passed**;
- Z.ai Responses compatibility tests: **5/5 passed**;
- `npm.cmd run check`: passed;
- `git diff --check`: passed;
- full branch suite: **1,805 total; 1,772 passed; 33 skipped; 0 failed**;
- live raw-SSE validation: passed;
- live Codex tool round-trip: passed with zero malformed-envelope warnings.

Final integrated local stack with #313/#314/#315 and this PR:
- focused GLM/config/routing suite: **224 total; 223 passed; 1 skipped; 0 failed**;
- final full suite: **1,821 total; 1,788 passed; 33 skipped; 0 failed**;
- catalog refresh, config refresh, service restart, and doctor: passed.

## Separate WebSocket observation

A normal routed Codex session still makes one initial WebSocket attempt against the router and receives `426 Upgrade Required` before Codex falls back to HTTP for the session. This was investigated in #325. The proposed config flag was live-tested and falsified: normal router mode uses Codex's reserved built-in `openai` provider, which cannot be overridden, while the separate `codex-router` table is dormant and custom providers already default WebSockets off. #325 was therefore reverted and closed rather than shipping a placebo change. This observation is separate from the Z.ai/LiteLLM envelope defect fixed here.