### PR TITLE
fix(grok-oauth): preserve images in tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Grok OAuth keeps image-bearing tool results multimodal.** The
+  Chat Completions-to-Responses hop JSON-stringified every non-string tool
+  result, so Codex could complete `view_image` while Grok received JSON and
+  base64 text instead of pixels. Structured image output now remains
+  `input_image`, preserves detail and mixed-part order, and recovers common
+  image MIME types from generic octet-stream data URLs. Text-only and other
+  structured tool results keep their previous behavior.
+
 - **A Codex Stop hook continues grok-oauth mid-task stops once.** After a
   tool result, a short status sentence with no follow-up tool call used to
   hand control back. `hooks/codex-stop-grok-oauth.mjs` is a user-level Stop

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -191,6 +191,117 @@ export function mergeHostedSearchTools(clientTools = [], { enabled = true } = {}
   return [...functions, ...hosted];
 }
 
+function normalizeToolImageUrl(url) {
+  if (typeof url !== "string") return url;
+
+  const prefix = "data:application/octet-stream;base64,";
+  if (!url.startsWith(prefix)) return url;
+
+  const base64 = url.slice(prefix.length);
+  let bytes;
+  try {
+    bytes = Buffer.from(base64.slice(0, 64), "base64");
+  } catch {
+    return url;
+  }
+
+  let mime;
+  if (
+    bytes.length >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    mime = "image/jpeg";
+  } else if (
+    bytes.length >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47
+  ) {
+    mime = "image/png";
+  } else if (
+    bytes.length >= 6 &&
+    bytes.toString("ascii", 0, 3) === "GIF"
+  ) {
+    mime = "image/gif";
+  } else if (
+    bytes.length >= 12 &&
+    bytes.toString("ascii", 0, 4) === "RIFF" &&
+    bytes.toString("ascii", 8, 12) === "WEBP"
+  ) {
+    mime = "image/webp";
+  } else {
+    return url;
+  }
+
+  return `data:${mime};base64,${base64}`;
+}
+
+function normalizeToolOutputForGrok(content) {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return JSON.stringify(content ?? "");
+
+  // Only image-bearing output becomes a Responses content-item array. Other
+  // structured tool results keep the existing JSON-text behavior.
+  const parts = [];
+  let hasImage = false;
+
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+
+    if (
+      ["text", "input_text", "output_text"].includes(part.type) &&
+      typeof part.text === "string" &&
+      part.text
+    ) {
+      parts.push({ type: "input_text", text: part.text });
+      continue;
+    }
+
+    let imageUrl;
+    let detail;
+
+    if (part.type === "input_image") {
+      imageUrl = part.image_url;
+      if (typeof part.detail === "string") detail = part.detail;
+    } else if (part.type === "image_url") {
+      imageUrl =
+        typeof part.image_url === "string"
+          ? part.image_url
+          : part.image_url?.url;
+
+      if (typeof part.detail === "string") {
+        detail = part.detail;
+      } else if (
+        part.image_url &&
+        typeof part.image_url !== "string" &&
+        typeof part.image_url.detail === "string"
+      ) {
+        detail = part.image_url.detail;
+      }
+    }
+
+    if (typeof imageUrl === "string" && imageUrl) {
+      hasImage = true;
+
+      const normalizedImage = {
+        type: "input_image",
+        image_url: normalizeToolImageUrl(imageUrl),
+      };
+
+      if (typeof detail === "string" && detail) {
+        normalizedImage.detail = detail;
+      }
+
+      parts.push(normalizedImage);
+    }
+  }
+
+  return hasImage ? parts : JSON.stringify(content ?? "");
+}
+
 // Chat Completions request -> Codex Responses request.
 export function toResponsesRequest(chat, options = {}) {
   const input = [];
@@ -204,10 +315,7 @@ export function toResponsesRequest(chat, options = {}) {
       input.push({
         type: "function_call_output",
         call_id: message.tool_call_id,
-        output:
-          typeof message.content === "string"
-            ? message.content
-            : JSON.stringify(message.content ?? ""),
+        output: normalizeToolOutputForGrok(message.content),
       });
     } else if (role === "assistant" && Array.isArray(message.tool_calls)) {
       const text = contentToText(message.content);

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -449,6 +449,124 @@ test("hostedSearchEnabledFor covers the checked-in Grok OAuth model", () => {
   assert.equal(hostedSearchEnabledFor("grok-4.6"), true);
 });
 
+test("toResponsesRequest preserves structured image tool outputs", () => {
+  function toolOutput(content) {
+    const request = toResponsesRequest(
+      {
+        model: "grok-4.6",
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                id: "call_1",
+                type: "function",
+                function: { name: "view_image", arguments: "{}" },
+              },
+            ],
+          },
+          {
+            role: "tool",
+            tool_call_id: "call_1",
+            content,
+          },
+        ],
+      },
+      { hostedSearchEnabled: false },
+    );
+
+    return request.input.find(
+      (item) => item.type === "function_call_output",
+    ).output;
+  }
+
+  // Existing string tool outputs remain unchanged.
+  assert.equal(toolOutput("plain text result"), "plain text result");
+
+  // Structured non-image outputs keep the existing JSON-string behavior.
+  assert.equal(
+    toolOutput([{ type: "text", text: "hello" }]),
+    JSON.stringify([{ type: "text", text: "hello" }]),
+  );
+
+  // Native Codex image tool results remain multimodal and preserve detail.
+  assert.deepEqual(
+    toolOutput([
+      {
+        type: "input_image",
+        image_url: "data:image/jpeg;base64,/9j/AA==",
+        detail: "original",
+      },
+    ]),
+    [
+      {
+        type: "input_image",
+        image_url: "data:image/jpeg;base64,/9j/AA==",
+        detail: "original",
+      },
+    ],
+  );
+
+  // Mixed multimodal output preserves the original part ordering.
+  assert.deepEqual(
+    toolOutput([
+      {
+        type: "input_image",
+        image_url: "data:image/jpeg;base64,/9j/AA==",
+        detail: "original",
+      },
+      { type: "text", text: "between images" },
+      {
+        type: "input_image",
+        image_url: "data:image/png;base64,iVBORw0KGgo=",
+        detail: "high",
+      },
+    ]),
+    [
+      {
+        type: "input_image",
+        image_url: "data:image/jpeg;base64,/9j/AA==",
+        detail: "original",
+      },
+      { type: "input_text", text: "between images" },
+      {
+        type: "input_image",
+        image_url: "data:image/png;base64,iVBORw0KGgo=",
+        detail: "high",
+      },
+    ],
+  );
+
+  // Some tool transports label image data as generic octet-stream.
+  // Recover a usable image MIME type from the encoded file signature.
+  for (const [mime, base64] of [
+    ["image/jpeg", "/9j/AA=="],
+    ["image/png", "iVBORw0KGgo="],
+    ["image/gif", "R0lGODlh"],
+    ["image/webp", "UklGRgAAAABXRUJQ"],
+  ]) {
+    assert.deepEqual(
+      toolOutput([
+        {
+          type: "image_url",
+          image_url: {
+            url: `data:application/octet-stream;base64,${base64}`,
+            detail: "low",
+          },
+        },
+      ]),
+      [
+        {
+          type: "input_image",
+          image_url: `data:${mime};base64,${base64}`,
+          detail: "low",
+        },
+      ],
+    );
+  }
+});
+
 test("toResponsesRequest preserves the client's image detail level", () => {
   const request = toResponsesRequest({
     model: "grok-4.5",


### PR DESCRIPTION
## What

Preserve image-bearing tool results across the Grok OAuth Chat Completions → Responses translation.

The forwarder now:
- keeps `input_image` tool-output parts multimodal instead of JSON-stringifying them;
- preserves image `detail` and mixed text/image ordering;
- accepts both the native Codex `input_image` shape and Chat Completions `image_url`;
- recovers JPEG/PNG/GIF/WebP MIME types when a transport labels a data URL as `application/octet-stream`;
- leaves string and structured non-image tool outputs on their existing paths.

## Why

Codex could execute `view_image` and report that it viewed the image while Grok still received the returned image array as JSON and base64 text rather than pixels. The loss happened in `toResponsesRequest()`, where every non-string tool result was unconditionally `JSON.stringify`-ed.

The existing vision bridge does not cover this path by design: Grok advertises native image input, so the bridge correctly leaves its requests untouched.

## Validation

- Live Codex Desktop + Grok 4.6 test on this serialization change: `view_image` returned a real screenshot and Grok correctly read its contents. The test carried a temporary diagnostic that forced `view_image` selection to remove model tool-choice nondeterminism; that diagnostic is not part of this PR.
- Regression coverage through the public `toResponsesRequest()` boundary:
  - string and structured non-image compatibility;
  - native `input_image` and Chat Completions `image_url` shapes;
  - mixed ordered text/images and `detail: "original"`;
  - JPEG/PNG/GIF/WebP normalization from generic octet-stream data URLs.
- A complete CI run on the exact final commit passed on Windows, macOS, and Ubuntu, including `npm run check`, `npm test`, audits, and desktop builds.

## Scope

This does not make Grok choose `view_image` and does not change the vision bridge. It only preserves image-bearing results after a tool has already returned them.