### PR TITLE
fix: preserve configured proxy in stable fetch transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Stable fetch transport preserves an explicitly configured environment
+  proxy.** `installStableFetchTransport` used to replace Node's
+  `NODE_USE_ENV_PROXY` dispatcher with a plain HTTP/1.1 agent, causing native
+  Responses traffic to bypass `HTTP_PROXY` / `HTTPS_PROXY`. It now installs an
+  `EnvHttpProxyAgent` when either proxy variable is set while retaining the
+  existing HTTP/2-disable policy.
+
 - **A Codex Stop hook continues grok-oauth mid-task stops once.** After a
   tool result, a short status sentence with no follow-up tool call used to
   hand control back. `hooks/codex-stop-grok-oauth.mjs` is a user-level Stop

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -1,4 +1,4 @@
-import { Agent, setGlobalDispatcher } from "undici";
+import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 
 // Node 26's bundled fetch negotiates HTTP/2 by default. A live router process
 // observed its pooled session remain destroyed after ERR_HTTP2_INVALID_SESSION,
@@ -8,9 +8,18 @@ import { Agent, setGlobalDispatcher } from "undici";
 // state while retaining keep-alive connection reuse.
 export function installStableFetchTransport({
   AgentClass = Agent,
+  EnvProxyClass = EnvHttpProxyAgent,
   setDispatcher = setGlobalDispatcher,
+  env = process.env,
 } = {}) {
-  const dispatcher = new AgentClass({ allowH2: false });
+  // NODE_USE_ENV_PROXY only seeds the global dispatcher at process start. The
+  // plain Agent below would overwrite it, so preserve an explicitly configured
+  // outbound proxy while keeping the same HTTP/1.1-only policy.
+  const proxyConfigured =
+    env.HTTPS_PROXY || env.https_proxy || env.HTTP_PROXY || env.http_proxy;
+  const dispatcher = proxyConfigured
+    ? new EnvProxyClass({ allowH2: false })
+    : new AgentClass({ allowH2: false });
   setDispatcher(dispatcher);
   return dispatcher;
 }

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -8,7 +8,7 @@ import { installStableFetchTransport } from "../src/fetch-transport.mjs";
 
 const SRC_DIR = fileURLToPath(new URL("../src", import.meta.url));
 
-test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
+test("the router disables HTTP/2 on its direct process-wide fetch dispatcher", () => {
   const created = [];
   const installed = [];
 
@@ -21,6 +21,39 @@ test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
 
   const dispatcher = installStableFetchTransport({
     AgentClass: FakeAgent,
+    env: {},
+    setDispatcher(value) {
+      installed.push(value);
+    },
+  });
+
+  assert.equal(created.length, 1);
+  assert.deepEqual(created[0].options, { allowH2: false });
+  assert.equal(dispatcher, created[0]);
+  assert.deepEqual(installed, [dispatcher]);
+});
+
+test("the router preserves the environment proxy in its stable fetch dispatcher", () => {
+  const created = [];
+  const installed = [];
+
+  class UnexpectedDirectAgent {
+    constructor() {
+      assert.fail("the direct dispatcher must not replace a configured proxy");
+    }
+  }
+
+  class FakeEnvProxyAgent {
+    constructor(options) {
+      this.options = options;
+      created.push(this);
+    }
+  }
+
+  const dispatcher = installStableFetchTransport({
+    AgentClass: UnexpectedDirectAgent,
+    EnvProxyClass: FakeEnvProxyAgent,
+    env: { HTTPS_PROXY: "http://127.0.0.1:7897" },
     setDispatcher(value) {
       installed.push(value);
     },


### PR DESCRIPTION
## Problem

The router service sets `NODE_USE_ENV_PROXY` together with `HTTP_PROXY` / `HTTPS_PROXY`, but `installStableFetchTransport()` immediately replaces Node’s environment-aware global dispatcher with a plain `Agent`.

That makes native Responses traffic bypass the explicitly configured outbound proxy. Long-lived streams such as remote compaction can then fail mid-response even though the router service was configured to use the proxy.

## Fix

- install `EnvHttpProxyAgent` when an HTTP(S) proxy environment variable is present
- retain the existing `allowH2: false` transport policy
- retain the direct `Agent` path when no proxy is configured
- add deterministic coverage for both branches

## Verification

- `node --test test/fetch-transport.test.mjs test/router-resilience.test.mjs` — 8/8 passed
- `npm run check` — passed
- `git diff --check` — passed

## Scope

This does not add Responses WebSocket forwarding. The router still rejects WebSocket upgrades and relies on Codex HTTP fallback; WebSocket support should be addressed separately because it changes the protocol boundary rather than the dispatcher selection.