### PR TITLE
fix(kimi): stop tool_call re-seating from emitting invalid messages

### DIFF
--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -4,6 +4,177 @@ import { pipeline } from "node:stream/promises";
 import { secretEqual } from "./caller-auth.mjs";
 import { TARGET } from "./paths.mjs";
 
+// Some Responses -> Chat Completions bridges (LiteLLM's, notably) emit one
+// assistant message per Responses item, so a stored turn of
+// `function_call`, assistant commentary `message`, `function_call_output`
+// arrives here as `assistant(tool_calls)`, `assistant(text)`, `tool`.
+// Strict chat-completions providers (Kimi K3 among them) reject that: a
+// message carrying tool_calls must be followed immediately by its tool
+// messages. Folding alone is not enough when the calling message holds
+// several tool_calls whose results are split by another calling message --
+// which the router's own subagent closer produces when it splices an
+// interrupt_agent call into the model's wait_agent message. In that shape
+// the first results answer only the leading calls; the trailing calls must
+// move down next to their own results. This pass does both: fold intervening
+// assistant text into the calling message, then re-seat any tool_calls whose
+// results are not adjacent. Messages are only ever split or merged, never
+// reordered, so the conversation's reading order is preserved.
+export function foldInterveningAssistantMessages(messages) {
+  if (!Array.isArray(messages)) return;
+  // Pass 1: merge assistant text that sits between a calling message and its
+  // results into the calling message.
+  for (let index = 0; index < messages.length; index += 1) {
+    const callingMessage = messages[index];
+    const callIds = new Set(
+      Array.isArray(callingMessage?.tool_calls)
+        ? callingMessage.tool_calls.map((call) => call?.id).filter(Boolean)
+        : [],
+    );
+    if (callingMessage?.role !== "assistant" || callIds.size === 0) continue;
+    let cursor = index + 1;
+    const intervening = [];
+    while (
+      messages[cursor]?.role === "assistant" &&
+      !Array.isArray(messages[cursor]?.tool_calls)
+    ) {
+      intervening.push(messages[cursor]);
+      cursor += 1;
+    }
+    if (intervening.length === 0) continue;
+    const followingIds = new Set();
+    while (messages[cursor]?.role === "tool") {
+      if (messages[cursor]?.tool_call_id) followingIds.add(messages[cursor].tool_call_id);
+      cursor += 1;
+    }
+    if (![...callIds].every((id) => followingIds.has(id))) continue;
+    const text = [callingMessage, ...intervening]
+      .flatMap((message) => {
+        if (typeof message.content === "string") return [message.content];
+        if (!Array.isArray(message.content)) return [];
+        return message.content
+          .filter((part) => part?.type === "text" && typeof part.text === "string")
+          .map((part) => part.text);
+      })
+      .filter((value) => value.trim());
+    if (text.length) callingMessage.content = text.join("\n");
+    messages.splice(index + 1, intervening.length);
+  }
+  // Pass 2: re-seat tool_calls whose results are not immediately after their
+  // message. Each contiguous run of tool messages is claimed by the nearest
+  // preceding calling message; calls a run cannot answer move to a new
+  // assistant message inserted directly in front of their own results.
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (message?.role !== "assistant" || !Array.isArray(message.tool_calls)) {
+      continue;
+    }
+    // The tool run directly after this message is only answerable by this
+    // message when no other calling message sits in between. If one does,
+    // the run belongs to that nearer message and every call here is an
+    // orphan to be re-seated.
+    const next = messages[index + 1];
+    const nearerCaller =
+      next?.role === "assistant" && Array.isArray(next.tool_calls) && next.tool_calls.length > 0;
+    const runIds = new Set();
+    if (!nearerCaller) {
+      let cursor = index + 1;
+      while (messages[cursor]?.role === "tool") {
+        if (messages[cursor].tool_call_id) runIds.add(messages[cursor].tool_call_id);
+        cursor += 1;
+      }
+    }
+    const keep = [];
+    const orphans = [];
+    for (const call of message.tool_calls) {
+      // A call with no usable id can never be paired with a result, so it must
+      // never be treated as an orphan: `undefined === undefined` would match
+      // any tool message that also lacks a tool_call_id, the call would be
+      // "re-seated" in front of it, and the very next turn of the outer loop
+      // would find the same unmatched call again -- splicing forever and
+      // growing the array without bound. Leave such calls where they are.
+      if (!call?.id) {
+        keep.push(call);
+        continue;
+      }
+      (runIds.has(call.id) ? keep : orphans).push(call);
+    }
+    if (orphans.length === 0) continue;
+    // A later calling message owns the intervening results, so each orphan's
+    // results live further down. Split the message: the leading calls stay,
+    // the orphans move to a new message directly in front of their results.
+    const reseatable = [];
+    for (const orphan of orphans) {
+      const resultIndex = messages.findIndex(
+        (candidate, at) =>
+          at > index &&
+          candidate?.role === "tool" &&
+          // Require a usable id on the result too, so a tool message missing
+          // its tool_call_id can never be claimed by an unrelated call.
+          Boolean(candidate.tool_call_id) &&
+          candidate.tool_call_id === orphan.id,
+      );
+      if (resultIndex === -1) {
+        // No result anywhere: leave the call in place. Dropping it would
+        // rewrite history the provider may legitimately answer.
+        keep.push(orphan);
+      } else {
+        reseatable.push({ orphan, resultIndex });
+      }
+    }
+    if (reseatable.length === 0) continue;
+    // When every call moved away, the key must go rather than hold an empty
+    // array: strict providers reject `tool_calls: []` exactly as they reject a
+    // call with no adjacent result, so leaving it turns one malformed payload
+    // into another. Without the key the message is a plain assistant turn.
+    if (keep.length) {
+      message.tool_calls = keep;
+    } else {
+      delete message.tool_calls;
+    }
+    // Insert from the bottom up so earlier result indexes stay valid.
+    reseatable.sort((a, b) => b.resultIndex - a.resultIndex);
+    for (const { orphan, resultIndex } of reseatable) {
+      messages.splice(resultIndex, 0, {
+        role: "assistant",
+        content: null,
+        tool_calls: [orphan],
+      });
+    }
+    // Dropping the key can leave a husk: a bridged `function_call` item
+    // carries no text, so a message whose every call moved away becomes
+    // `{role:"assistant",content:null}` -- no content and no calls, which
+    // several strict providers reject as an empty message. It says nothing
+    // the conversation needs, so remove it. The insertions above all landed
+    // after `index`, so the husk is still sitting at `index`; step the cursor
+    // back one so the loop does not skip whatever slides into its place.
+    if (isEmptyAssistantHusk(message)) {
+      messages.splice(index, 1);
+      index -= 1;
+    }
+  }
+}
+
+// hasUsableContent() — true when a message still carries something worth
+// sending: any non-blank string, or any structured content part at all
+// (an image part has no text but must not be discarded).
+function hasUsableContent(message) {
+  const { content } = message;
+  if (typeof content === "string") return content.trim().length > 0;
+  if (Array.isArray(content)) return content.length > 0;
+  return content !== null && content !== undefined;
+}
+
+// isEmptyAssistantHusk() — true for an assistant message left with no content,
+// no tool_calls, and no other field a provider might act on. The extra-key
+// check keeps messages carrying `name`, `refusal`, `reasoning_content` and
+// similar, so this never silently drops data it does not understand.
+function isEmptyAssistantHusk(message) {
+  if (message?.role !== "assistant") return false;
+  if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) return false;
+  if (hasUsableContent(message)) return false;
+  return Object.keys(message).every((key) => key === "role" || key === "content");
+}
+
 export const MAX_BODY_BYTES = Number(
   process.env.MODEL_ROUTER_MAX_BODY_BYTES ||
     (TARGET === "codex"

--- a/src/oauth-forwarder.mjs
+++ b/src/oauth-forwarder.mjs
@@ -2,6 +2,7 @@ import http from "node:http";
 
 import {
   applyKeepAliveTimeouts,
+  foldInterveningAssistantMessages,
   formatErrorChain,
   HOP_BY_HOP_HEADERS,
   httpErrorStatus,
@@ -48,46 +49,6 @@ const QUIET =
     (process.env.CODEX_ROUTER_QUIET === "1" || process.env.KIMI_PROXY_QUIET === "1"));
 
 if (!INTERNAL_KEY) throw new Error("MODEL_ROUTER_INTERNAL_KEY is required.");
-
-function foldInterveningAssistantMessages(messages) {
-  if (!Array.isArray(messages)) return;
-  for (let index = 0; index < messages.length; index += 1) {
-    const callingMessage = messages[index];
-    const callIds = new Set(
-      Array.isArray(callingMessage?.tool_calls)
-        ? callingMessage.tool_calls.map((call) => call?.id).filter(Boolean)
-        : [],
-    );
-    if (callingMessage?.role !== "assistant" || callIds.size === 0) continue;
-    let cursor = index + 1;
-    const intervening = [];
-    while (
-      messages[cursor]?.role === "assistant" &&
-      !Array.isArray(messages[cursor]?.tool_calls)
-    ) {
-      intervening.push(messages[cursor]);
-      cursor += 1;
-    }
-    if (intervening.length === 0) continue;
-    const followingIds = new Set();
-    while (messages[cursor]?.role === "tool") {
-      if (messages[cursor]?.tool_call_id) followingIds.add(messages[cursor].tool_call_id);
-      cursor += 1;
-    }
-    if (![...callIds].every((id) => followingIds.has(id))) continue;
-    const text = [callingMessage, ...intervening]
-      .flatMap((message) => {
-        if (typeof message.content === "string") return [message.content];
-        if (!Array.isArray(message.content)) return [];
-        return message.content
-          .filter((part) => part?.type === "text" && typeof part.text === "string")
-          .map((part) => part.text);
-      })
-      .filter((value) => value.trim());
-    if (text.length) callingMessage.content = text.join("\n");
-    messages.splice(index + 1, intervening.length);
-  }
-}
 
 function normalizeKimiBody(buffer, contentType) {
   if (!buffer.length || !String(contentType || "").includes("application/json")) {

--- a/test/fold-intervening-assistant-messages.test.mjs
+++ b/test/fold-intervening-assistant-messages.test.mjs
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { foldInterveningAssistantMessages } from "../src/http-utils.mjs";
+
+function assistant(content, toolCalls) {
+  return { role: "assistant", content, ...(toolCalls ? { tool_calls: toolCalls } : {}) };
+}
+
+function call(id, name = "exec_command") {
+  return { id, type: "function", function: { name, arguments: "{}" } };
+}
+
+function toolResult(id, content = "ok") {
+  return { role: "tool", tool_call_id: id, content };
+}
+
+// summarize() — compact, order-preserving view used to assert exact layouts.
+function summarize(messages) {
+  return messages.map((message) =>
+    message.role === "tool"
+      ? `tool:${message.tool_call_id}`
+      : (message.tool_calls ?? []).map((toolCall) => toolCall.id).join(",") ||
+        `text:${message.content}`,
+  );
+}
+
+// assertStrictProviderShape() — the invariant strict chat-completions providers
+// enforce. Deliberately stricter than "no exception thrown": it also rejects
+// the degenerate shapes an earlier version of this pass could emit, because a
+// validator that accepts them cannot prove the pass did its job.
+function assertStrictProviderShape(messages) {
+  messages.forEach((message, index) => {
+    assert.ok(
+      message && typeof message === "object",
+      `message ${index} is not an object (${JSON.stringify(message)})`,
+    );
+
+    if (message.role === "assistant") {
+      const hasCalls = Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
+      assert.ok(
+        !Array.isArray(message.tool_calls) || hasCalls,
+        `message ${index} carries an empty tool_calls array`,
+      );
+      const hasContent =
+        (typeof message.content === "string" && message.content.trim().length > 0) ||
+        (Array.isArray(message.content) && message.content.length > 0);
+      assert.ok(
+        hasCalls || hasContent,
+        `message ${index} is an empty husk: no content and no tool_calls`,
+      );
+
+      if (hasCalls) {
+        // Collect the adjacent tool run, rejecting a result that answers the
+        // same call twice — a duplicate is as malformed as a missing one.
+        const answered = new Set();
+        let cursor = index + 1;
+        while (messages[cursor]?.role === "tool") {
+          const answeredId = messages[cursor].tool_call_id;
+          assert.ok(
+            !answered.has(answeredId),
+            `call ${answeredId} is answered twice in the run after message ${index}`,
+          );
+          answered.add(answeredId);
+          cursor += 1;
+        }
+        for (const toolCall of message.tool_calls) {
+          assert.ok(toolCall?.id, `message ${index} has a tool_call with no id`);
+          assert.ok(
+            answered.has(toolCall.id),
+            `message ${index} call ${toolCall.id} is not answered by the adjacent tool run`,
+          );
+        }
+      }
+    }
+
+    if (message.role === "tool") {
+      assert.ok(
+        message.tool_call_id,
+        `tool result at ${index} has no tool_call_id`,
+      );
+      let owner = index - 1;
+      while (messages[owner]?.role === "tool") owner -= 1;
+      const calling = messages[owner];
+      assert.ok(
+        calling?.role === "assistant" &&
+          Array.isArray(calling.tool_calls) &&
+          calling.tool_calls.some((toolCall) => toolCall.id === message.tool_call_id),
+        `tool result ${message.tool_call_id} has no owning calling message above it`,
+      );
+    }
+  });
+}
+
+// runBounded() — run the pass while capping how many times it may splice the
+// array, so a non-terminating rewrite fails as an assertion instead of hanging
+// the whole suite in an unbreakable synchronous loop.
+function runBounded(messages, limit = 200) {
+  const nativeSplice = Array.prototype.splice;
+  let spliceCount = 0;
+  Array.prototype.splice = function splice(...args) {
+    if (this === messages) {
+      spliceCount += 1;
+      if (spliceCount > limit) throw new Error("pass did not terminate");
+    }
+    return nativeSplice.apply(this, args);
+  };
+  try {
+    foldInterveningAssistantMessages(messages);
+  } finally {
+    Array.prototype.splice = nativeSplice;
+  }
+  return messages;
+}
+
+test("folds assistant commentary that sits between a call and its result", () => {
+  const messages = [
+    assistant(null, [call("A")]),
+    assistant("thinking out loud"),
+    toolResult("A"),
+  ];
+
+  foldInterveningAssistantMessages(messages);
+
+  assert.equal(messages.length, 2);
+  assert.equal(messages[0].content, "thinking out loud");
+  assert.deepEqual(summarize(messages), ["A", "tool:A"]);
+  assertStrictProviderShape(messages);
+});
+
+test("re-seats trailing calls whose results are split by a nearer calling message", () => {
+  // The subagent-closer shape: interrupt_agent (B) is spliced into the model's
+  // wait_agent message, so B's result lands after an unrelated call C.
+  const messages = [
+    assistant(null, [call("A", "wait_agent"), call("B", "interrupt_agent")]),
+    toolResult("A"),
+    assistant(null, [call("C")]),
+    toolResult("C"),
+    toolResult("B"),
+  ];
+
+  foldInterveningAssistantMessages(messages);
+
+  assertStrictProviderShape(messages);
+  assert.deepEqual(summarize(messages), ["A", "tool:A", "C", "tool:C", "B", "tool:B"]);
+});
+
+test("does not leave an empty tool_calls array when every call is re-seated", () => {
+  // Regression: with commentary between the calling message and the results,
+  // pass 1 declines to fold (not all calls are answered by the next run), so
+  // pass 2 moves EVERY call away. The emptied message must lose the key
+  // entirely — `tool_calls: []` is rejected just as firmly as a call with no
+  // adjacent result, which would swap one malformed payload for another.
+  const messages = [
+    assistant("lead", [call("A"), call("B")]),
+    assistant("commentary"),
+    toolResult("A"),
+    assistant("more"),
+    toolResult("B"),
+  ];
+
+  foldInterveningAssistantMessages(messages);
+
+  const emptied = messages[0];
+  assert.equal(emptied.role, "assistant");
+  assert.equal(emptied.content, "lead");
+  assert.ok(
+    !("tool_calls" in emptied),
+    "the emptied calling message must not keep a tool_calls key",
+  );
+  assertStrictProviderShape(messages);
+});
+
+test("removes the emptied calling message when it has no text of its own", () => {
+  // A bridged `function_call` item carries no text, so the real-world shape of
+  // the case above has `content: null`. Merely dropping the key would leave
+  // `{role:"assistant",content:null}` — no content, no calls, nothing a
+  // provider can act on — so the husk goes entirely.
+  const messages = [
+    assistant(null, [call("A"), call("B")]),
+    assistant("commentary"),
+    toolResult("A"),
+    assistant("more"),
+    toolResult("B"),
+  ];
+
+  foldInterveningAssistantMessages(messages);
+
+  for (const message of messages) {
+    assert.ok(
+      message.role !== "assistant" ||
+        (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) ||
+        (typeof message.content === "string" && message.content.trim().length > 0),
+      `an empty husk survived: ${JSON.stringify(message)}`,
+    );
+  }
+  assert.deepEqual(summarize(messages), [
+    "text:commentary",
+    "A",
+    "tool:A",
+    "text:more",
+    "B",
+    "tool:B",
+  ]);
+  assertStrictProviderShape(messages);
+});
+
+test("keeps a message that carries fields beyond content and tool_calls", () => {
+  // The husk removal must not silently discard data it does not understand,
+  // so a message with any other field survives even when it looks empty.
+  const messages = [
+    { role: "assistant", content: null, reasoning_content: "deliberating", tool_calls: [call("A")] },
+    assistant("commentary"),
+    toolResult("A"),
+    assistant(null, [call("B")]),
+    toolResult("B"),
+  ];
+
+  foldInterveningAssistantMessages(messages);
+
+  const survivor = messages.find((message) => message.reasoning_content);
+  assert.ok(survivor, "a message carrying reasoning_content must not be dropped");
+});
+
+test("terminates on a tool_call that has no id", () => {
+  // Regression: an id-less call was classed as an orphan, and `undefined`
+  // matched any tool message that also lacked a tool_call_id — so the same
+  // call was re-seated on every turn of the outer loop, splicing forever and
+  // growing the array without bound. Such calls must stay where they are.
+  const messages = [
+    assistant(null, [{ type: "function", function: { name: "f", arguments: "{}" } }, call("B")]),
+    assistant("text"),
+    { role: "tool", content: "ok" },
+    toolResult("B"),
+  ];
+
+  runBounded(messages);
+
+  assert.ok(messages.length <= 6, `array grew unexpectedly to ${messages.length}`);
+  const idless = messages.find((message) =>
+    (message.tool_calls ?? []).some((toolCall) => !toolCall.id),
+  );
+  assert.ok(idless, "the id-less call must be left in place, not re-seated");
+});
+
+test("is stable when applied twice", () => {
+  const shapes = [
+    () => [
+      assistant(null, [call("A"), call("B")]),
+      toolResult("A"),
+      assistant(null, [call("C")]),
+      toolResult("C"),
+      toolResult("B"),
+    ],
+    () => [
+      assistant(null, [call("A"), call("B")]),
+      assistant("commentary"),
+      toolResult("A"),
+      assistant("more"),
+      toolResult("B"),
+    ],
+  ];
+
+  for (const build of shapes) {
+    const messages = build();
+    foldInterveningAssistantMessages(messages);
+    const afterFirstPass = JSON.stringify(messages);
+    foldInterveningAssistantMessages(messages);
+    assert.equal(JSON.stringify(messages), afterFirstPass);
+  }
+});
+
+test("leaves a call whose result never arrives exactly where it was", () => {
+  // Deliberate limitation: dropping the call would rewrite history the
+  // provider may still legitimately answer, so the pass prefers to leave it.
+  const messages = [assistant(null, [call("A"), call("B")]), toolResult("A")];
+
+  foldInterveningAssistantMessages(messages);
+
+  assert.equal(messages.length, 2);
+  assert.deepEqual(
+    messages[0].tool_calls.map((toolCall) => toolCall.id),
+    ["A", "B"],
+  );
+});
+
+// ------------------------------------------------------------
+// Known limitations — these record what the pass does NOT fix, so a future
+// change that closes either gap fails here loudly instead of going unnoticed.
+// ------------------------------------------------------------
+
+test("KNOWN GAP: a kept unanswered call still ends up with no adjacent run", () => {
+  // A never gets a result, B does but further down. B is re-seated and A is
+  // kept, leaving message 0 followed by a non-tool message — the very shape
+  // the pass exists to remove. Fixing this means deciding what to do with a
+  // call the provider never answered, which is a separate question.
+  const messages = [assistant("lead", [call("A"), call("B")]), assistant("commentary"), toolResult("B")];
+
+  foldInterveningAssistantMessages(messages);
+
+  assert.deepEqual(summarize(messages), ["A", "text:commentary", "B", "tool:B"]);
+  assert.throws(
+    () => assertStrictProviderShape(messages),
+    /not answered by the adjacent tool run/,
+    "if this stops throwing, the gap was closed and this test should become a positive one",
+  );
+});
+
+test("KNOWN GAP: an empty tool_calls array present in the input is passed through", () => {
+  // The pass only removes an array it emptied itself; one that arrived empty
+  // is left alone, even though the same providers reject it.
+  const messages = [assistant("hi", [])];
+
+  foldInterveningAssistantMessages(messages);
+
+  assert.deepEqual(messages[0].tool_calls, []);
+});


### PR DESCRIPTION
## What's wrong

`foldInterveningAssistantMessages` exists to satisfy a rule strict Chat Completions providers enforce — Kimi K3 among them: **a message carrying `tool_calls` must be followed immediately by the tool messages answering every one of those calls.** LiteLLM's Responses→Chat Completions bridge emits one assistant message per Responses item, so a stored turn arrives split into pieces that break that rule.

Pass 2 re-seats calls whose results are not adjacent. In three shapes it produced payloads the same providers reject just as firmly as the input it set out to repair — so the request still failed, just with a different error.

### 1. An emptied message kept `tool_calls: []`

When *every* call on a message was re-seated, the message kept a zero-length array. Providers that require `tool_calls` to be non-empty reject that.

```
in:  assistant("lead", tool_calls=[A,B]), assistant("commentary"),
     tool(A), assistant("more"), tool(B)

out: assistant("lead", tool_calls=[])      ← rejected
     assistant("commentary")
     assistant(tool_calls=[A]), tool(A)
     assistant("more")
     assistant(tool_calls=[B]), tool(B)
```

This is reachable on the normal path, not a corner: pass 1 declines to fold when the calls are split, which leaves the commentary in place, which makes pass 2 treat every call as an orphan.

### 2. Dropping the key alone leaves an empty husk

A bridged `function_call` item carries no text, so the real-world version of the case above has `content: null`. Removing just the key leaves `{"role":"assistant","content":null}` — no content, no calls, nothing a provider can act on. Several OpenAI-compatible providers reject that as an empty message.

### 3. A `tool_call` with no `id` loops forever

An id-less call was classed as an orphan. The result lookup then compared `undefined === undefined`, so it matched **any** tool message that also lacked a `tool_call_id`. The call was "re-seated" in front of that message, the next turn of the outer loop found the same unmatched call again, and the pass spliced forever.

```
in: assistant(tool_calls=[{no id}, B]), assistant("text"),
    tool(no tool_call_id), tool(B)

result: never terminates — one message appended per iteration
```

This is the serious one: it is an unbounded synchronous loop inside the request handler. It grows the array until the process dies, and no timeout interrupts it.

## How it's fixed

| Problem | Fix |
|---|---|
| Empty `tool_calls: []` | Delete the key instead of assigning an empty array |
| Empty husk left behind | Remove the message when it has no content **and** no calls |
| Id-less call loops forever | Never treat a call with a falsy `id` as an orphan; also require a usable `tool_call_id` on a result before it can be claimed |

Two safeguards on the husk removal, so it cannot lose data:

- **Structured content counts.** An image part with no text keeps the message alive.
- **Unknown fields keep the message.** Anything carrying `name`, `refusal`, `reasoning_content` or similar survives, so the pass never discards a field it does not understand.

## Blast radius

**Small and contained.**

- **One call site, unchanged.** `normalizeKimiBody` in `src/oauth-forwarder.mjs` is the only caller, and how it calls the function is untouched.
- **One provider path.** Only requests going through the Kimi OAuth forwarder reach this code. Other providers, the gateway, the router and the API forwarder are untouched.
- **Only reachable when the pass already rewrites.** Every change sits inside the branch that runs when calls are actually re-seated. A conversation that already satisfies the rule takes the same path it did before.
- **Nothing is dropped that was not already empty.** The only removal is a message with no content, no calls, and no other fields.
- **No dependency, config, schema or wire-format change.** Pure logic plus a test file.

**The one behaviour change to be aware of:** a message that previously survived as `{"role":"assistant","content":null}` is now removed from the array. That message could not be acted on by a provider, but it does mean the array can be one element shorter than before.

**Performance** is unchanged in practice — 12,000 messages process in ~29 ms.

## Why the function moved to `http-utils.mjs`

It was unexported inside `oauth-forwarder.mjs`, where **no unit test could reach it**: importing that module throws when `MODEL_ROUTER_INTERNAL_KEY` is unset, and then binds a listening socket at module load. Moving the pure function into `http-utils.mjs` is what makes it testable at all. No behaviour changes with the move.

Happy to split this into two commits (move, then fix) if that reads better in history.

## Testing

New file `test/fold-intervening-assistant-messages.test.mjs`, 10 tests in the repo's existing `node:test` style:

- the original fold, and the re-seat of split calls (the subagent-closer shape: `interrupt_agent` spliced into a `wait_agent` message)
- one test per fix above
- idempotency across two different shapes
- an unanswered call is left exactly where it was
- two `KNOWN GAP` tests (below)

Each fix was confirmed to be a real regression — every new test **fails against the code before this change**:

```
empty array : {"role":"assistant","content":"lead","tool_calls":[]} survived
husk        : {"role":"assistant","content":null} survived
id-less call: pass did not terminate (array reached 202 before the cap)
```

The id-less test caps how many times the pass may splice, so a non-terminating rewrite fails as an assertion instead of hanging the whole suite.

**Full suite: 1802 tests, 0 failures** on Node 24, from a clean clone after `npm ci`. `npm run check` passes.

## Known gaps, deliberately left

Both are recorded as `KNOWN GAP` tests asserting current behaviour, so whoever closes either one gets a failing test rather than silence:

1. **A kept unanswered call still ends up with no adjacent tool run.** If one call is never answered and another is re-seated, the original message keeps the unanswered call and is followed by a non-tool message. Fixing this means deciding what to do with a call the provider never answered — a policy question, and the existing code deliberately prefers leaving it over rewriting history.
2. **A `tool_calls: []` that arrives already empty is passed through.** The pass only removes an array it emptied itself.

Happy to take either on in this PR if you'd prefer them closed here.
