### PR TITLE
Fix GPT-5.6 cache retention compatibility

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -480,6 +480,20 @@ function normalizeNativeForSubstitutedCaller(payload) {
   return payload;
 }
 
+/**
+ * Remove the legacy cache-retention shape that GPT-5.6 rejects.
+ *
+ * Current Codex builds can still emit the old top-level field on a later turn.
+ * Omitting it keeps implicit prompt caching active. A caller that already uses
+ * `prompt_cache_options` passes through unchanged.
+ */
+function normalizeNativePromptCacheCompatibility(payload) {
+  if (/^gpt-5\.6(?:-|$)/.test(String(payload.model || ""))) {
+    delete payload.prompt_cache_retention;
+  }
+  return payload;
+}
+
 function routedHeaders() {
   return {
     Authorization: `Bearer ${INTERNAL_KEY}`,
@@ -2464,6 +2478,7 @@ async function handleResponses(request, response, requestUrl) {
       // the log still name the model the picker showed.
       const variantBase = nativeContextVariantBase(native.model);
       if (variantBase) native.model = variantBase;
+      normalizeNativePromptCacheCompatibility(native);
       if (Array.isArray(payload.input)) {
         native.input = normalizeNativeInput(payload.input);
         // Native turns leave here as stateless full conversations (the

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -654,6 +654,8 @@ test("router preserves native auth and isolates every external route", async () 
           model: "gpt-5.6-sol",
           input: "native test",
           previous_response_id: "remove-me",
+          prompt_cache_retention: "24h",
+          prompt_cache_options: { ttl: "30m" },
           client_metadata: { workspace: "caller-owned" },
         }),
       ),
@@ -695,6 +697,8 @@ test("router preserves native auth and isolates every external route", async () 
     assert.equal(nativeRequests[0].url, "/backend-api/codex/responses");
     assert.doesNotMatch(nativeRequests[0].url, /PROVIDER_QUERY_SECRET/);
     assert.equal(nativeRequests[0].body.previous_response_id, undefined);
+    assert.equal(nativeRequests[0].body.prompt_cache_retention, undefined);
+    assert.deepEqual(nativeRequests[0].body.prompt_cache_options, { ttl: "30m" });
     // Native OpenAI traffic owns client_metadata; only routed traffic drops it.
     assert.deepEqual(nativeRequests[0].body.client_metadata, { workspace: "caller-owned" });
     for (const request of routedRequests) {


### PR DESCRIPTION
## What changed

- Remove deprecated `prompt_cache_retention` from native GPT-5.6 requests.
- Preserve the current `prompt_cache_options` field.
- Add regression coverage for both fields.

## Why

Current Codex builds can emit the deprecated field on later turns. GPT-5.6 rejects that request shape.

## Validation

- `npm test`: 1,762 passed, 0 failed, 30 skipped.
- `npm run check`: passed.
- `git diff --check`: passed.
