### PR TITLE
feat(proxy): support environment proxy settings

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -178,6 +178,20 @@ foreground commands but is not copied into launchd, systemd, or Task Scheduler.
 Use `provider-key ... set` so the per-user background service has persistent,
 protected access.
 
+## Outbound proxy
+
+The router honors `http_proxy`, `https_proxy`, and `no_proxy`, including their
+uppercase forms. Set them before running setup or install; the generated
+per-user background service preserves the values so a service started outside
+the login shell uses the same proxy. Include `localhost`, `127.0.0.1`, and
+`::1` in `no_proxy` because the router's own processes communicate over
+loopback.
+
+`all_proxy` / `ALL_PROXY` is also preserved for child processes that support
+it, but the router's Undici transport requires `http_proxy` or `https_proxy` to
+enable proxy routing. After changing these variables, rerun install to refresh
+the background service definition.
+
 ## Installer transaction
 
 Setup performs these operations in order:

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -1,4 +1,6 @@
-import { Agent, setGlobalDispatcher } from "undici";
+import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+
+import { environmentHttpProxyConfigured } from "./proxy-environment.mjs";
 
 // Node 26's bundled fetch negotiates HTTP/2 by default. A live router process
 // observed its pooled session remain destroyed after ERR_HTTP2_INVALID_SESSION,
@@ -8,9 +10,14 @@ import { Agent, setGlobalDispatcher } from "undici";
 // state while retaining keep-alive connection reuse.
 export function installStableFetchTransport({
   AgentClass = Agent,
+  EnvHttpProxyAgentClass = EnvHttpProxyAgent,
   setDispatcher = setGlobalDispatcher,
+  environment = process.env,
 } = {}) {
-  const dispatcher = new AgentClass({ allowH2: false });
+  const DispatcherClass = environmentHttpProxyConfigured(environment)
+    ? EnvHttpProxyAgentClass
+    : AgentClass;
+  const dispatcher = new DispatcherClass({ allowH2: false });
   setDispatcher(dispatcher);
   return dispatcher;
 }

--- a/src/proxy-environment.mjs
+++ b/src/proxy-environment.mjs
@@ -1,0 +1,30 @@
+const PROXY_ENVIRONMENT_VARIABLES = [
+  "http_proxy",
+  "https_proxy",
+  "all_proxy",
+  "no_proxy",
+  "HTTP_PROXY",
+  "HTTPS_PROXY",
+  "ALL_PROXY",
+  "NO_PROXY",
+];
+
+// Match EnvHttpProxyAgent's precedence exactly: a present lowercase value,
+// including an empty string, overrides its uppercase counterpart. ALL_PROXY
+// is preserved for child processes but is not supported by EnvHttpProxyAgent.
+export function environmentHttpProxyConfigured(environment = process.env) {
+  const httpProxy = environment.http_proxy ?? environment.HTTP_PROXY;
+  const httpsProxy = environment.https_proxy ?? environment.HTTPS_PROXY;
+  return Boolean(httpProxy || httpsProxy);
+}
+
+// Background service managers do not read a user's shell startup files. Keep
+// the proxy environment present during installation so the router and the
+// child processes it launches see the same network policy after a restart.
+export function serviceProxyEnvironment(environment = process.env) {
+  const values = {};
+  for (const name of PROXY_ENVIRONMENT_VARIABLES) {
+    if (environment[name] !== undefined) values[name] = environment[name];
+  }
+  return values;
+}

--- a/src/service-linux.mjs
+++ b/src/service-linux.mjs
@@ -20,6 +20,7 @@ import {
   TARGET,
   TARGET_DISPLAY_NAME,
 } from "./paths.mjs";
+import { serviceProxyEnvironment } from "./proxy-environment.mjs";
 
 const effectivePlatform = process.env.CODEX_ROUTER_SERVICE_PLATFORM || process.platform;
 const command = process.argv[2] || "status";
@@ -64,6 +65,7 @@ function unit() {
     CODEX_ROUTER_OAUTH_PORT: String(PORTS.oauth),
     CODEX_ROUTER_PORT: String(PORTS.router),
     CODEX_ROUTER_API_PORT: String(PORTS.api),
+    ...serviceProxyEnvironment(),
     ...(process.env.KIMI_CODE_HOME ? { KIMI_CODE_HOME: process.env.KIMI_CODE_HOME } : {}),
     ...(process.env.CODEX_ROUTER_SOURCE_ROOT
       ? { CODEX_ROUTER_SOURCE_ROOT: SOURCE_ROOT }
@@ -108,8 +110,10 @@ function writeUnit() {
   mkdirSync(path.dirname(unitPath), { recursive: true, mode: 0o700 });
   mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
   const temporary = `${unitPath}.tmp.${process.pid}`;
-  writeFileSync(temporary, unit(), { encoding: "utf8", mode: 0o644 });
-  chmodSync(temporary, 0o644);
+  // Proxy URLs may carry credentials, so the generated unit is private just
+  // like the state it launches with.
+  writeFileSync(temporary, unit(), { encoding: "utf8", mode: 0o600 });
+  chmodSync(temporary, 0o600);
   renameSync(temporary, unitPath);
 }
 

--- a/src/service-macos.mjs
+++ b/src/service-macos.mjs
@@ -20,6 +20,7 @@ import {
   STATE_DIR,
   TARGET,
 } from "./paths.mjs";
+import { serviceProxyEnvironment } from "./proxy-environment.mjs";
 
 const command = process.argv[2] || "status";
 const effectivePlatform = process.env.CODEX_ROUTER_SERVICE_PLATFORM || process.platform;
@@ -64,6 +65,7 @@ function environmentEntries() {
     CODEX_ROUTER_OAUTH_PORT: String(PORTS.oauth),
     CODEX_ROUTER_PORT: String(PORTS.router),
     CODEX_ROUTER_API_PORT: String(PORTS.api),
+    ...serviceProxyEnvironment(),
     ...(process.env.CODEX_ROUTER_SOURCE_ROOT
       ? { CODEX_ROUTER_SOURCE_ROOT: SOURCE_ROOT }
       : {}),
@@ -157,8 +159,10 @@ function writePlist() {
   mkdirSync(path.dirname(LAUNCH_AGENT_PATH), { recursive: true });
   mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
   const temporary = `${LAUNCH_AGENT_PATH}.tmp.${process.pid}`;
-  writeFileSync(temporary, plist(), { encoding: "utf8", mode: 0o644 });
-  chmodSync(temporary, 0o644);
+  // Proxy URLs may carry credentials, so the generated plist is private just
+  // like the state it launches with.
+  writeFileSync(temporary, plist(), { encoding: "utf8", mode: 0o600 });
+  chmodSync(temporary, 0o600);
   renameSync(temporary, LAUNCH_AGENT_PATH);
 }
 

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -21,6 +21,7 @@ import {
   readServiceProcessState,
   serviceProcessOwns,
 } from "./service-process.mjs";
+import { serviceProxyEnvironment } from "./proxy-environment.mjs";
 
 const effectivePlatform = process.env.CODEX_ROUTER_SERVICE_PLATFORM || process.platform;
 const command = process.argv[2] || "status";
@@ -58,6 +59,7 @@ function wrapper() {
     CODEX_ROUTER_OAUTH_PORT: String(PORTS.oauth),
     CODEX_ROUTER_PORT: String(PORTS.router),
     CODEX_ROUTER_API_PORT: String(PORTS.api),
+    ...serviceProxyEnvironment(),
     // The LiteLLM gateway is a Python process. Force UTF-8 output so its
     // startup banner and logs do not crash on Windows systems whose default
     // ANSI/OEM code page is not UTF-8 (e.g. Russian cp1251), where Python

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -1,19 +1,30 @@
 import assert from "node:assert/strict";
+import http from "node:http";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { getGlobalDispatcher, setGlobalDispatcher } from "undici";
 
 import { installStableFetchTransport } from "../src/fetch-transport.mjs";
 
 const SRC_DIR = fileURLToPath(new URL("../src", import.meta.url));
 
-test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
+function installFakeTransport(environment) {
   const created = [];
   const installed = [];
 
   class FakeAgent {
     constructor(options) {
+      this.kind = "direct";
+      this.options = options;
+      created.push(this);
+    }
+  }
+
+  class FakeEnvHttpProxyAgent {
+    constructor(options) {
+      this.kind = "environment-proxy";
       this.options = options;
       created.push(this);
     }
@@ -21,15 +32,117 @@ test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
 
   const dispatcher = installStableFetchTransport({
     AgentClass: FakeAgent,
+    EnvHttpProxyAgentClass: FakeEnvHttpProxyAgent,
+    environment,
     setDispatcher(value) {
       installed.push(value);
     },
   });
 
+  return { created, dispatcher, installed };
+}
+
+test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
+  const { created, dispatcher, installed } = installFakeTransport({});
+
   assert.equal(created.length, 1);
+  assert.equal(dispatcher.kind, "direct");
   assert.deepEqual(created[0].options, { allowH2: false });
   assert.equal(dispatcher, created[0]);
   assert.deepEqual(installed, [dispatcher]);
+});
+
+test("the router uses the environment proxy dispatcher only when a proxy is configured", () => {
+  for (const environment of [
+    { http_proxy: "http://proxy.example:8080" },
+    { HTTP_PROXY: "http://proxy.example:8080" },
+    { https_proxy: "http://proxy.example:8080" },
+    { HTTPS_PROXY: "http://proxy.example:8080", NO_PROXY: "localhost" },
+  ]) {
+    const { created, dispatcher } = installFakeTransport(environment);
+
+    assert.equal(created.length, 1);
+    assert.equal(dispatcher.kind, "environment-proxy");
+    assert.equal(dispatcher, created[0]);
+    assert.deepEqual(dispatcher.options, { allowH2: false });
+  }
+});
+
+test("NO_PROXY or ALL_PROXY alone keeps the lower-overhead direct agent", () => {
+  for (const environment of [
+    { NO_PROXY: "localhost,127.0.0.1" },
+    { ALL_PROXY: "socks5://proxy.example:1080" },
+    // EnvHttpProxyAgent ignores uppercase HTTP_PROXY when lowercase is present,
+    // even when the lowercase value deliberately disables it.
+    { http_proxy: "", HTTP_PROXY: "http://proxy.example:8080" },
+  ]) {
+    const { created, dispatcher } = installFakeTransport(environment);
+
+    assert.equal(created.length, 1);
+    assert.equal(dispatcher.kind, "direct");
+    assert.equal(dispatcher, created[0]);
+    assert.deepEqual(dispatcher.options, { allowH2: false });
+  }
+});
+
+test("the installed transport proxies requests and honors NO_PROXY", async () => {
+  const proxyEnvironmentNames = [
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+  ];
+  const originalEnvironment = Object.fromEntries(
+    proxyEnvironmentNames.map((name) => [name, process.env[name]]),
+  );
+  const originalDispatcher = getGlobalDispatcher();
+  let proxiedRequests = 0;
+  let directRequests = 0;
+  const target = http.createServer((_request, response) => {
+    directRequests += 1;
+    response.end("direct");
+  });
+  const proxy = http.createServer((_request, response) => {
+    proxiedRequests += 1;
+    response.end("proxied");
+  });
+  const listen = (server) =>
+    new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+    });
+  const close = (server) => new Promise((resolve) => server.close(resolve));
+
+  let dispatcher;
+  try {
+    const [targetPort, proxyPort] = await Promise.all([listen(target), listen(proxy)]);
+    for (const name of proxyEnvironmentNames) delete process.env[name];
+    process.env.HTTP_PROXY = `http://127.0.0.1:${proxyPort}`;
+
+    dispatcher = installStableFetchTransport();
+    let response = await fetch(`http://127.0.0.1:${targetPort}/through-proxy`);
+    assert.equal(await response.text(), "proxied");
+    assert.equal(proxiedRequests, 1);
+    assert.equal(directRequests, 0);
+
+    process.env.NO_PROXY = "127.0.0.1";
+    response = await fetch(`http://127.0.0.1:${targetPort}/bypass-proxy`);
+    assert.equal(await response.text(), "direct");
+    assert.equal(proxiedRequests, 1);
+    assert.equal(directRequests, 1);
+  } finally {
+    setGlobalDispatcher(originalDispatcher);
+    await dispatcher?.close();
+    await Promise.all([close(target), close(proxy)]);
+    for (const [name, value] of Object.entries(originalEnvironment)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
 });
 
 // The service is four long-lived processes, and setGlobalDispatcher only

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -7,6 +7,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -109,6 +110,103 @@ test("background service definitions render for macOS, Linux, and Windows", () =
     rmSync(testRoot, { recursive: true, force: true });
   }
 });
+
+test("background services preserve the installer's proxy environment", () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-service-proxy-"));
+  const proxyEnvironment = {
+    http_proxy: "http://proxy.example:8080",
+    HTTPS_PROXY: "http://secure-proxy.example:8443",
+    all_proxy: "socks5://proxy.example:1080",
+    NO_PROXY: "localhost,127.0.0.1,::1",
+  };
+  try {
+    const launchd = serviceCommand(
+      "service-macos.mjs",
+      "darwin",
+      testRoot,
+      "render",
+      "codex",
+      root,
+      proxyEnvironment,
+    );
+    const systemd = serviceCommand(
+      "service-linux.mjs",
+      "linux",
+      testRoot,
+      "render",
+      "codex",
+      root,
+      proxyEnvironment,
+    );
+    const windows = serviceCommand(
+      "service-windows.mjs",
+      "win32",
+      testRoot,
+      "render",
+      "codex",
+      root,
+      proxyEnvironment,
+    );
+
+    for (const [name, value] of Object.entries(proxyEnvironment)) {
+      assert.ok(
+        launchd.includes(
+          `<key>${launchdXml(name)}</key>\n    <string>${launchdXml(value)}</string>`,
+        ),
+        `launchd did not preserve ${name}`,
+      );
+      assert.ok(
+        systemd.includes(`Environment=${systemdQuoted(`${name}=${value}`)}`),
+        `systemd did not preserve ${name}`,
+      );
+      assert.ok(
+        windows.includes(`set "${name}=${value}"`),
+        `Task Scheduler wrapper did not preserve ${name}`,
+      );
+    }
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test(
+  "the generated systemd unit stays owner-only when it stores proxy settings",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-service-mode-"));
+    const stubDir = path.join(testRoot, "bin");
+    mkdirSync(stubDir, { recursive: true });
+    const systemctl = path.join(stubDir, "systemctl");
+    writeFileSync(systemctl, "#!/bin/sh\nexit 0\n", "utf8");
+    chmodSync(systemctl, 0o755);
+    try {
+      serviceCommand(
+        "service-linux.mjs",
+        "linux",
+        testRoot,
+        "install",
+        "codex",
+        root,
+        {
+          PATH: `${stubDir}${path.delimiter}${process.env.PATH || ""}`,
+          HTTPS_PROXY: "http://user:secret@proxy.example:8443",
+        },
+      );
+
+      const unitPath = path.join(
+        testRoot,
+        "xdg config",
+        "systemd",
+        "user",
+        "codex-router.service",
+      );
+      assert.equal(statSync(unitPath).mode & 0o777, 0o600);
+      assert.match(readFileSync(unitPath, "utf8"), /HTTPS_PROXY=/);
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
 
 test("packaged services preserve wrapper and PATH values with service-safe quoting", () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-packaged-service-"));


### PR DESCRIPTION
# Background

In some development environments, outbound internet access is restricted and external services can only be reached through an HTTP/HTTPS proxy. Therefore, codex-router needs to support proxy configuration to ensure reliable access to official models and other external providers.

# Changes

Use Undici's environment-aware dispatcher when HTTP(S) proxy variables are configured and preserve proxy variables in background services.

Document proxy behavior and cover direct, proxied, bypass, and service rendering paths.