### PR TITLE
fix: harden Codex update compatibility and test isolation

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -742,6 +742,12 @@ export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
   const disabled = new Set(settings.disabled || []);
   return models.map((model) => {
     const slug = String(model.slug);
+    // Extended-context aliases are manual parent-model choices, not distinct
+    // child-agent backends. Keep them out of spawn_agent model overrides so
+    // delegated work uses the base model's default context window.
+    if (NATIVE_CONTEXT_VARIANT_SLUGS.includes(slug)) {
+      return { ...model, multi_agent_version: "v1" };
+    }
     if (model.visibility !== "list") return model;
     if (hidden.has(slug) || disabled.has(slug)) return model;
     if (NATIVE_V2_BACKEND_SLUGS.has(slug)) {
@@ -854,10 +860,9 @@ function main() {
   const loginFree = loginFreeConfigured();
   const native = {
     ...captured,
-    // Variants join before the multi-agent pass so a switched-off one is
-    // demoted exactly like every other hidden model, and a switched-on one
-    // inherits its base model's verified backend version rather than a
-    // separate claim about the same upstream.
+    // Variants join before the multi-agent pass so the extended-context alias
+    // can remain manually selectable while being forced parent-only; delegated
+    // work must use the base model's default context window.
     models: promoteNativeMultiAgent(
       withNativeContextVariants(captured.models, { enabled: !loginFree }),
       multiAgentSettings,

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -490,9 +490,18 @@ function rewriteModelMessages(messages, model) {
   return next;
 }
 
+const NATIVE_PARALLEL_TOOL_CALL_COMPAT = new Map([["gpt-5.2", true]]);
+
 function normalizeNativeModel(model) {
+  const supportsParallelToolCalls =
+    typeof model.supports_parallel_tool_calls === "boolean"
+      ? model.supports_parallel_tool_calls
+      : NATIVE_PARALLEL_TOOL_CALL_COMPAT.get(String(model.slug));
   return {
     ...model,
+    ...(typeof supportsParallelToolCalls === "boolean"
+      ? { supports_parallel_tool_calls: supportsParallelToolCalls }
+      : {}),
     supports_reasoning_summaries:
       typeof model.supports_reasoning_summaries === "boolean"
         ? model.supports_reasoning_summaries

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -956,6 +956,20 @@ test("native listed models follow the local subagent opt-in", () => {
   assert.equal(promoted[2].multi_agent_version, "v1");
 });
 
+test("native context variants are never advertised as subagent models", () => {
+  const native = [
+    { slug: "gpt-5.6-sol", visibility: "list", multi_agent_version: "v2" },
+    { slug: "gpt-5.6-sol-1m", visibility: "list", multi_agent_version: "v2" },
+  ];
+  const promoted = promoteNativeMultiAgent(native, {
+    mode: "all",
+    enabled: ["gpt-5.6-sol-1m"],
+    disabled: [],
+  });
+  assert.equal(promoted[0].multi_agent_version, "v2");
+  assert.equal(promoted[1].multi_agent_version, "v1");
+});
+
 test("native promotion honours disabled models and picker-hidden slugs", () => {
   const native = [
     { slug: "gpt-5.6-luna", visibility: "list", multi_agent_version: "v1" },

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -411,6 +411,13 @@ test("merged catalog preserves native GPT identity while rewriting routed models
   assert.doesNotMatch(bySlug.get("grok-oauth/grok-4.5").base_instructions, /GPT-5/);
 });
 
+test("native gpt-5.2 stays parseable by older Codex catalog readers", () => {
+  const native52 = { ...template, slug: "gpt-5.2" };
+  delete native52.supports_parallel_tool_calls;
+  const merged = buildMergedCatalog({ models: [native52] }, []);
+  assert.equal(merged[0].supports_parallel_tool_calls, true);
+});
+
 test("merged catalog resolves a routed behavior template without inheriting its capabilities", () => {
   const sol = {
     ...template,

--- a/test/native-context-variants.test.mjs
+++ b/test/native-context-variants.test.mjs
@@ -9,7 +9,6 @@ import { fileURLToPath } from "node:url";
 import { zstdDecompressSync } from "node:zlib";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
-import { buildLoginFreeCatalog, buildMergedCatalog } from "../src/catalog.mjs";
 import {
   NATIVE_CONTEXT_VARIANTS,
   NATIVE_CONTEXT_VARIANT_SLUGS,
@@ -24,6 +23,7 @@ const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
 
 const pickerStateDir = mkdtempSync(path.join(os.tmpdir(), "context-variant-picker-"));
 process.env.MODEL_ROUTER_MODEL_PICKER_STATE = path.join(pickerStateDir, "model-picker.json");
+const { buildLoginFreeCatalog, buildMergedCatalog } = await import("../src/catalog.mjs");
 const {
   MODEL_PICKER_STATE_PATH,
   readHiddenModels,

--- a/test/provider-usage.test.mjs
+++ b/test/provider-usage.test.mjs
@@ -170,6 +170,13 @@ test("reports a rolling 24-hour window separately from calendar-day buckets", ()
 });
 
 test("publishes prefix-cache telemetry for the dashboard without inflating it", () => {
+  const localDateKey = (value) => {
+    const date = new Date(value);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  };
   const now = Date.parse("2026-07-21T18:00:00Z");
   const snapshot = aggregateProviderUsage(
     [
@@ -208,8 +215,8 @@ test("publishes prefix-cache telemetry for the dashboard without inflating it", 
     // request exactly one day earlier is still part of the window.
     last24hCachedInputTokens: 130,
     dailyCachedInputTokens: [
-      { startDate: "2026-07-20", cachedInputTokens: 80 },
-      { startDate: "2026-07-21", cachedInputTokens: 50 },
+      { startDate: localDateKey("2026-07-20T18:00:00Z"), cachedInputTokens: 80 },
+      { startDate: localDateKey("2026-07-21T17:00:00Z"), cachedInputTokens: 50 },
     ],
   });
   const deepseek = snapshot.providers.find((provider) => provider.id === "deepseek");
@@ -220,8 +227,8 @@ test("publishes prefix-cache telemetry for the dashboard without inflating it", 
   assert.equal(deepseek.last24hCachedInputTokens, 130);
   assert.equal(deepseek.regularInputTokens + deepseek.cachedInputTokens, deepseek.inputTokens);
   assert.deepEqual(deepseek.dailyUsageBuckets, [
-    { startDate: "2026-07-20", tokens: 100, requests: 1, inputTokens: 100, cachedInputTokens: 80, outputTokens: 0 },
-    { startDate: "2026-07-21", tokens: 50, requests: 2, inputTokens: 50, cachedInputTokens: 50, outputTokens: 0 },
+    { startDate: localDateKey("2026-07-20T18:00:00Z"), tokens: 100, requests: 1, inputTokens: 100, cachedInputTokens: 80, outputTokens: 0 },
+    { startDate: localDateKey("2026-07-21T17:00:00Z"), tokens: 50, requests: 2, inputTokens: 50, cachedInputTokens: 50, outputTokens: 0 },
   ]);
 });
 

--- a/test/state-owner.test.mjs
+++ b/test/state-owner.test.mjs
@@ -241,3 +241,24 @@ test("no test spawns the catalog without isolating CODEX_HOME", () => {
       "agents directory no state-directory override redirects",
   );
 });
+
+test("tests isolate picker state before importing the catalog", () => {
+  const offenders = readdirSync(path.join(root, "test"))
+    .filter((entry) => entry.endsWith(".mjs"))
+    .filter((entry) => {
+      const source = readFileSync(path.join(root, "test", entry), "utf8");
+      const catalogImport = source.indexOf('from "../src/catalog.mjs"');
+      const pickerOverride = source.indexOf("MODEL_ROUTER_MODEL_PICKER_STATE");
+      return (
+        entry !== "state-owner.test.mjs" &&
+        catalogImport >= 0 &&
+        pickerOverride >= 0 &&
+        pickerOverride > catalogImport
+      );
+    });
+  assert.deepEqual(
+    offenders,
+    [],
+    `${offenders.join(", ")} import the catalog before redirecting picker state`,
+  );
+});


### PR DESCRIPTION
## What

Fixes four regressions exposed by updating codex-router on Windows while preserving the existing local Codex/router setup.

1. **Sol-1M picker state could be mutated by the test suite.** `test/native-context-variants.test.mjs` imported `catalog.mjs` before redirecting `MODEL_ROUTER_MODEL_PICKER_STATE`. Because the picker-state module resolves its path at import time, the cached module could point at the real `~/.codex/codex-router/model-picker.json`; running the test could therefore hide `gpt-5.6-sol-1m` in the user's actual picker. The test now redirects picker state before dynamically importing the catalog, with a regression guard in `state-owner.test.mjs`.

2. **Mixed Codex builds could reject the generated catalog.** On the reproduced machine, Codex Desktop ships `0.148.0-alpha.21` while the PATH CLI is `0.147.0`. Desktop's native `gpt-5.2` entry may omit `supports_parallel_tool_calls`, but Codex 0.147 requires that field when parsing a custom `model_catalog_json`. Native-model normalization now supplies the verified `gpt-5.2` compatibility value (`true`) only when the captured entry omits it; explicit native values still win and unknown models are untouched.

3. **Provider-usage cache telemetry test assumed UTC.** Production intentionally buckets usage by the machine's local calendar date, but one test hard-coded UTC date labels. Its expected dates now derive from the fixture timestamps using local calendar semantics, so it passes in both Asia/Bangkok and UTC without changing production behavior.

4. **The Sol-1M context alias was also advertised as a subagent model.** The variant copies its base Sol metadata, including `multi_agent_version: "v2"`, and the native multi-agent promotion pass could keep or promote that value. This made the expensive extended-context alias eligible for delegated child work. Native context variants are now forced to `v1` in the shared promotion path, so `gpt-5.6-sol-1m` remains manually selectable as a parent model while delegated work uses the base `gpt-5.6-sol` default context. The guard applies even under multi-agent mode `all` or if the variant is explicitly enabled.

## Reproduction / verification

- Reproduced the picker-state contamination before the import-order fix; the regression guard fails with `native-context-variants.test.mjs import the catalog before redirecting picker state` when the fix is reverted.
- Added RED/GREEN coverage proving default `gpt-5.6-sol` stays `v2` while `gpt-5.6-sol-1m` is forced `v1` for subagent advertisement.
- One live `gpt-5.6-sol-1m` Codex Desktop turn returned exactly `SOL1M_OK`; no additional quota-consuming model turns were used for the subagent fix.
- Verified the real generated catalog loads with both installed Codex binaries:
  - PATH CLI: `codex-cli 0.147.0`
  - Desktop bundled CLI: `codex-cli 0.148.0-alpha.21`
- Live catalog after the subagent fix: default Sol is `272000 / v2`; Sol-1M is `1000000 / 900000 / v1` and remains visible for manual selection.
- `doctor --json`: **0 failures**; Codex config, routing, background service, router health, and model catalog checks are all OK.
- Full suite: **1,890 passed, 34 skipped, 0 failed** (`1,924` tests total).
- Affected catalog/native-context/control suite: **92 passed, 0 failed**.
- `npm run check`: syntax checks passed.
- `git diff --check`: clean.
- Real picker SHA-256 stayed byte-identical before/after the full suite.

The PR still contains only router/test files. Machine-local custom agent TOMLs and the separate intentional `install.ps1` working-tree modification are not part of this PR.