### PR TITLE
fix(grok-oauth): alias view_image for Grok 4.6 tool selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
+  function call when the tool was named `view_image`, even when selection was
+  required. The Grok OAuth boundary now presents that tool as `inspect_image`
+  and restores returned calls to `view_image`, without colliding with a real
+  client tool of the same alias name. This complements the existing
+  image-result transport fix: Grok can now both invoke the viewer and receive
+  its returned pixels.
+
 - **Grok OAuth keeps image-bearing tool results multimodal.** The
   Chat Completions-to-Responses hop JSON-stringified every non-string tool
   result, so Codex could complete `view_image` while Grok received JSON and

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -20,6 +20,11 @@ import { ensureFreshGrokOAuthToken } from "./grok-oauth-session.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { normalizeSchemaLiterals, objectRootToolSchema } from "./tool-schema-root.mjs";
 import {
+  shouldAliasViewImageForGrok,
+  toolNameForCodex,
+  toolNameForGrok,
+} from "./grok-oauth-tool-alias.mjs";
+import {
   applyResponsesEvent,
   classifyAfterToolRepair,
   createTurnState,
@@ -306,6 +311,7 @@ function normalizeToolOutputForGrok(content) {
 export function toResponsesRequest(chat, options = {}) {
   const input = [];
   let instructions;
+  const viewImageAlias = shouldAliasViewImageForGrok(chat);
   for (const message of chat.messages || []) {
     const role = message.role;
     if (role === "system" || role === "developer") {
@@ -326,7 +332,7 @@ export function toResponsesRequest(chat, options = {}) {
         input.push({
           type: "function_call",
           call_id: call.id,
-          name: call.function?.name,
+          name: toolNameForGrok(call.function?.name, { viewImageAlias }),
           arguments: call.function?.arguments || "{}",
         });
       }
@@ -345,7 +351,7 @@ export function toResponsesRequest(chat, options = {}) {
         .filter((tool) => tool?.type === "function" && tool.function?.name)
         .map((tool) => ({
           type: "function",
-          name: tool.function.name,
+          name: toolNameForGrok(tool.function.name, { viewImageAlias }),
           description: tool.function.description,
           // xAI 400s the whole request over a union-rooted parameter schema,
           // which Codex's own `automation_update` app tool ships. It rejects
@@ -366,7 +372,20 @@ export function toResponsesRequest(chat, options = {}) {
   });
   if (tools.length) {
     request.tools = tools;
-    if (chat.tool_choice) request.tool_choice = chat.tool_choice;
+    if (chat.tool_choice) {
+      request.tool_choice =
+        typeof chat.tool_choice === "object" && chat.tool_choice.function?.name
+          ? {
+              ...chat.tool_choice,
+              function: {
+                ...chat.tool_choice.function,
+                name: toolNameForGrok(chat.tool_choice.function.name, {
+                  viewImageAlias,
+                }),
+              },
+            }
+          : chat.tool_choice;
+    }
   }
   return request;
 }
@@ -476,6 +495,7 @@ async function handleChatCompletions(request, response) {
   const wantsStream = chat.stream === true;
   const model = typeof chat.model === "string" ? chat.model : "";
   const hostedSearchEnabled = hostedSearchEnabledFor(model);
+  const viewImageAlias = shouldAliasViewImageForGrok(chat);
   const responsesRequest = toResponsesRequest(chat, { hostedSearchEnabled });
   const holdOptions = {
     maxText: PROGRESS_ONLY_MAX_TEXT,
@@ -547,7 +567,9 @@ async function handleChatCompletions(request, response) {
 
   const id = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1_000);
-  const turnState = createTurnState();
+  const turnState = createTurnState({
+    toolNameMapper: (name) => toolNameForCodex(name, { viewImageAlias }),
+  });
   let emittedDeltaCount = 0;
   let streamStarted = false;
 
@@ -618,7 +640,9 @@ async function handleChatCompletions(request, response) {
         };
       }
     } else if (secondUpstream?.body) {
-      const secondState = createTurnState();
+      const secondState = createTurnState({
+        toolNameMapper: (name) => toolNameForCodex(name, { viewImageAlias }),
+      });
       await consumeResponsesStream(secondUpstream.body, (event) => {
         applyResponsesEvent(secondState, event);
       });

--- a/src/grok-oauth-tool-alias.mjs
+++ b/src/grok-oauth-tool-alias.mjs
@@ -1,0 +1,29 @@
+export const CODEX_VIEW_IMAGE_TOOL = "view_image";
+export const GROK_VIEW_IMAGE_TOOL = "inspect_image";
+
+export function shouldAliasViewImageForGrok(chat) {
+  // Grok 4.6 stops without a call when xAI receives this function under the
+  // native Codex name, even when tool_choice is required. A dedicated alias
+  // selects normally; keep the rewrite request-scoped so a real client tool
+  // already named inspect_image retains its own identity.
+  if (chat?.model !== "grok-4.6") return false;
+  const names = new Set(
+    (Array.isArray(chat?.tools) ? chat.tools : [])
+      .filter((tool) => tool?.type === "function")
+      .map((tool) => tool.function?.name)
+      .filter(Boolean),
+  );
+  return names.has(CODEX_VIEW_IMAGE_TOOL) && !names.has(GROK_VIEW_IMAGE_TOOL);
+}
+
+export function toolNameForGrok(name, { viewImageAlias = false } = {}) {
+  return viewImageAlias && name === CODEX_VIEW_IMAGE_TOOL
+    ? GROK_VIEW_IMAGE_TOOL
+    : name;
+}
+
+export function toolNameForCodex(name, { viewImageAlias = false } = {}) {
+  return viewImageAlias && name === GROK_VIEW_IMAGE_TOOL
+    ? CODEX_VIEW_IMAGE_TOOL
+    : name;
+}

--- a/src/grok-oauth-turn.mjs
+++ b/src/grok-oauth-turn.mjs
@@ -223,7 +223,7 @@ export function mergeMappedUsage(first, second) {
 
 const TOOL_ITEM_TYPES = new Set(["function_call", "custom_tool_call"]);
 
-export function createTurnState() {
+export function createTurnState({ toolNameMapper = (name) => name } = {}) {
   return {
     contentText: "",
     reasoningText: "",
@@ -231,6 +231,7 @@ export function createTurnState() {
     toolByItemId: new Map(),
     usage: undefined,
     deltas: [],
+    toolNameMapper,
   };
 }
 
@@ -305,7 +306,7 @@ function ensureToolCall(state, item, itemId, { complete = false } = {}) {
     entry = {
       id: item.call_id || item.id || key,
       type: "function",
-      function: { name: item.name || "", arguments: args },
+      function: { name: state.toolNameMapper(item.name || ""), arguments: args },
     };
     state.toolCalls.push(entry);
     if (key) state.toolByItemId.set(key, entry);
@@ -320,7 +321,7 @@ function ensureToolCall(state, item, itemId, { complete = false } = {}) {
       ],
     });
   } else {
-    if (item.name) entry.function.name = item.name;
+    if (item.name) entry.function.name = state.toolNameMapper(item.name);
     const args = toolArguments(item);
     if (args) entry.function.arguments = args;
   }

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -95,15 +95,18 @@ test("translates Chat Completions to Grok Responses and back (text + tools)", as
     res.writeHead(200, { "Content-Type": "text/event-stream" });
     // Hosted search tools are always present; only emit client function-call
     // events when the request includes a client function tool.
-    const hasClientFunction = Array.isArray(captured.tools)
-      && captured.tools.some((tool) => tool.type === "function");
-    if (hasClientFunction) {
+    const clientFunction = Array.isArray(captured.tools)
+      ? captured.tools.find((tool) => tool.type === "function")
+      : undefined;
+    if (clientFunction) {
+      const argumentsJson = clientFunction.name === "inspect_image"
+        ? '{"path":"C:\\\\image.jpg"}'
+        : '{"city":"SF"}';
       res.end(
         sse([
-          { type: "response.output_item.added", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "get_weather" } },
-          { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: '{"city":' },
-          { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: '"SF"}' },
-          { type: "response.output_item.done", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "get_weather", arguments: '{"city":"SF"}' } },
+          { type: "response.output_item.added", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: clientFunction.name } },
+          { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: argumentsJson },
+          { type: "response.output_item.done", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: clientFunction.name, arguments: argumentsJson } },
           { type: "response.completed", response: { usage: { input_tokens: 10, output_tokens: 8 } } },
         ]),
       );
@@ -238,6 +241,29 @@ test("translates Chat Completions to Grok Responses and back (text + tools)", as
     assert.deepEqual(
       captured.tools.filter((tool) => tool.type !== "function"),
       [{ type: "web_search" }, { type: "x_search" }],
+    );
+
+    // Grok 4.6 receives the provider-selectable alias, while Codex gets its
+    // native tool name back from the streamed function-call response.
+    const imageResp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "inspect the image" }],
+        tools: [
+          { type: "function", function: { name: "view_image", parameters: { type: "object" } } },
+        ],
+        stream: false,
+      }),
+    });
+    const imageTool = await imageResp.json();
+    assert.equal(captured.tools[0].name, "inspect_image");
+    assert.equal(imageTool.choices[0].finish_reason, "tool_calls");
+    assert.equal(imageTool.choices[0].message.tool_calls[0].function.name, "view_image");
+    assert.equal(
+      imageTool.choices[0].message.tool_calls[0].function.arguments,
+      '{"path":"C:\\\\image.jpg"}',
     );
   } finally {
     await stop(child);
@@ -390,6 +416,71 @@ test("toResponsesRequest sends each duplicated tool name upstream once", () => {
   });
   const fileWrites = request.tools.filter((tool) => tool.name === "file_write");
   assert.equal(fileWrites.length, 1);
+});
+
+test("toResponsesRequest aliases view_image only at the Grok boundary", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.6",
+    messages: [
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_image",
+            type: "function",
+            function: { name: "view_image", arguments: '{"path":"C:\\\\image.jpg"}' },
+          },
+        ],
+      },
+    ],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "view_image",
+          description: "View a local image.",
+          parameters: { type: "object", properties: { path: { type: "string" } } },
+        },
+      },
+    ],
+    tool_choice: { type: "function", function: { name: "view_image" } },
+  });
+
+  assert.equal(request.tools.find((tool) => tool.type === "function").name, "inspect_image");
+  assert.equal(request.input[0].name, "inspect_image");
+  assert.equal(request.tool_choice.function.name, "inspect_image");
+});
+
+test("toResponsesRequest does not alias view_image over a real inspect_image", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.6",
+    messages: [{ role: "user", content: "inspect it" }],
+    tools: [
+      { type: "function", function: { name: "view_image", parameters: { type: "object" } } },
+      { type: "function", function: { name: "inspect_image", parameters: { type: "object" } } },
+    ],
+  });
+
+  const names = request.tools
+    .filter((tool) => tool.type === "function")
+    .map((tool) => tool.name);
+  assert.deepEqual(names, ["view_image", "inspect_image"]);
+});
+
+test("toResponsesRequest leaves view_image unchanged for other Grok models", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.5",
+    messages: [{ role: "user", content: "inspect it" }],
+    tools: [
+      { type: "function", function: { name: "view_image", parameters: { type: "object" } } },
+    ],
+  });
+
+  assert.equal(
+    request.tools.find((tool) => tool.type === "function").name,
+    "view_image",
+  );
 });
 
 test("toResponsesRequest always includes hosted search tools when enabled", () => {

--- a/test/grok-oauth-turn.test.mjs
+++ b/test/grok-oauth-turn.test.mjs
@@ -6,6 +6,7 @@ import {
   classifyAfterToolRepair,
   collectResponsesEvents,
   createTurnState,
+  finalizeTurn,
   isProgressOnlyStop,
   lastClientMessageWasToolResult,
   mergeMappedUsage,
@@ -38,6 +39,25 @@ test("collectResponsesEvents keeps a function_call that only appears in output_i
   assert.equal(turn.toolCalls[0].function.name, "exec_command");
   assert.equal(turn.toolCalls[0].function.arguments, '{"cmd":"dir"}');
   assert.equal(turn.deltas[0].tool_calls[0].function.arguments, '{"cmd":"dir"}');
+});
+
+test("createTurnState can restore a provider-facing tool alias", () => {
+  const state = createTurnState({
+    toolNameMapper: (name) => (name === "inspect_image" ? "view_image" : name),
+  });
+  applyResponsesEvent(state, {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      id: "fc_image",
+      call_id: "call_image",
+      name: "inspect_image",
+      arguments: '{"path":"C:\\\\image.jpg"}',
+    },
+  });
+  const turn = finalizeTurn(state);
+  assert.equal(turn.toolCalls[0].function.name, "view_image");
+  assert.equal(turn.deltas[0].tool_calls[0].function.name, "view_image");
 });
 
 test("finalizeTurn backfills streamed arguments when added is followed by done without deltas", () => {


### PR DESCRIPTION
## What

Make Codex's native `view_image` callable by Grok 4.6 without changing the tool name that Codex executes.

The Grok OAuth boundary now:

- presents `view_image` upstream as `inspect_image`;
- restores returned `inspect_image` calls to native `view_image`;
- applies the same mapping to assistant tool-call history and named tool choice;
- disables the rewrite if a real client tool already uses `inspect_image`;
- leaves Grok 4.5 and other models unchanged.

## Why

Grok 4.6 stops without emitting a function call when xAI receives the function specifically as `view_image`. Controlled probes reproduced this with both automatic selection and `tool_choice: "required"`. The same schema under `inspect_image`, `read_image`, or `open_image` was called normally.

This complements #317 rather than replacing it:

- #317 preserves multimodal image pixels after Codex executes an image tool.
- This change fixes the earlier selection step so Grok actually invokes that tool.

A live Codex Desktop test verified the complete path:

```text
Grok selects inspect_image
→ Router restores view_image
→ Codex executes native imageView
→ function_call_output contains input_image
→ Grok accurately describes the image
```

## Validation

- `npm run check`
- request translation, history, collision, model-gating, and inbound restoration tests
- mock forwarder HTTP/SSE regression: outgoing `inspect_image` returns to Codex as `view_image`
- existing structured `input_image` transport regression
- live Codex Desktop + Grok 4.6 end-to-end test
- full fork CI green on the exact signed commit:
  - tests on Windows, macOS, and Ubuntu
  - Python lock matrix
  - Electron control center builds
  - desktop builds
  - Homebrew formula check

## Scope

This is intentionally provider- and model-specific. It does not force tool selection, alter generic file tools, or change image-result serialization.