### PR TITLE
fix: count terminal native closes as successful

### DIFF
--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -320,6 +320,7 @@ export class ResponseUsageTransform extends Transform {
   // first token appears, and counting that silence as generation is what makes
   // a fast model read as slow. See #192.
   #firstTokenAt;
+  #completedResponseObserved = false;
 
   // `estimatedInputTokens` arrives only on routed requests large enough that a
   // reported zero cannot be true. Without it this transform observes and
@@ -520,6 +521,7 @@ export class ResponseUsageTransform extends Transform {
 
   #observe(payload) {
     this.#noteFirstToken(payload);
+    if (payload?.type === "response.completed") this.#completedResponseObserved = true;
     const usage = tokenUsageFromPayload(payload);
     if (usage) this.#usage = usage;
   }
@@ -547,5 +549,9 @@ export class ResponseUsageTransform extends Transform {
   // response never streamed one (a non-streaming reply, or an error).
   firstTokenAt() {
     return this.#firstTokenAt;
+  }
+
+  completedResponseObserved() {
+    return this.#completedResponseObserved;
   }
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -2282,6 +2282,7 @@ async function handleResponses(request, response, requestUrl) {
   let requestedModel = "";
   let route;
   let upstreamRetries;
+  let upstreamStatus;
   let upstreamLatencyMs;
   let firstTokenMs;
   let usageTransform;
@@ -2570,6 +2571,7 @@ async function handleResponses(request, response, requestUrl) {
       },
     );
     upstreamRetries = retries;
+    upstreamStatus = upstream.status;
     // Time until the upstream chain answered the request. Everything before
     // this is router-side work (body read, normalization, flattening, vision
     // bridge) plus the upstream's own time to produce response headers. For a
@@ -2618,6 +2620,7 @@ async function handleResponses(request, response, requestUrl) {
           });
           adoptRoute(moved.route, moved.built);
           upstream = moved.upstream;
+          upstreamStatus = upstream.status;
           failedBodyText = undefined;
         }
       }
@@ -2735,8 +2738,11 @@ async function handleResponses(request, response, requestUrl) {
     // goes away, but `pipeResponse` can resolve before that event fires: the
     // response socket is already destroyed at that point. Read the state
     // directly as well so a cancel that races the close event still meters 0.
+    const nativeCompletedBeforeClose =
+      !route && usageTransform?.completedResponseObserved() === true;
     const clientWalkedAway =
-      clientGone || (response.destroyed && !response.writableFinished);
+      (clientGone || (response.destroyed && !response.writableFinished)) &&
+      !nativeCompletedBeforeClose;
     finalStatus = clientWalkedAway ? 0 : upstream.status;
     emptyCompletion = emptyCompletionGuard?.isEmpty() === true && !clientWalkedAway;
     // The guard releases long turns at its byte/time budget without a verdict.
@@ -2955,6 +2961,28 @@ async function handleResponses(request, response, requestUrl) {
         usageTransform.substitutedInputTokens(),
         retryUsageTransform?.substitutedInputTokens(),
       );
+    }
+    // Codex may close a native stream immediately after response.completed.
+    // That is a successful terminal turn, not a canceled generation.
+    if (!route && clientGone && usageTransform?.completedResponseObserved() === true) {
+      finalStatus = upstreamStatus ?? response.statusCode;
+      activityStatus = finalStatus;
+      if (!usageRecorded) {
+        recordUsageEvent({
+          model: requestedModel,
+          provider: "openai",
+          status: finalStatus,
+          durationMs: Date.now() - startedAt,
+          responseStartMs: upstreamLatencyMs,
+          firstTokenMs,
+          retries: upstreamRetries,
+          ...usage,
+          estimatedInputTokens,
+          ...toolResultAging,
+        });
+        usageRecorded = true;
+      }
+      return;
     }
     // A client that walked away (canceled generation, closed stream) is not
     // a router failure; only surface errors the router or upstream produced.

--- a/test/native-retry.test.mjs
+++ b/test/native-retry.test.mjs
@@ -584,3 +584,121 @@ test("an image generation is never retried, however retryable the failure looks"
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+function cancelNativeTurnAfterMarker(port, body, marker) {
+  const base = new URL(`${routerBase(port)}/responses`);
+  return new Promise((resolve) => {
+    const request = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: base.pathname,
+        method: "POST",
+        headers: { Authorization: "Bearer caller", "Content-Type": "application/json" },
+      },
+      (response) => {
+        let received = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          received += chunk;
+          if (received.includes(marker)) {
+            request.destroy();
+            resolve(received);
+          }
+        });
+      },
+    );
+    request.once("error", () => resolve(""));
+    request.end(JSON.stringify(body));
+  });
+}
+
+test("a native terminal tool response stays successful when the client closes after completion", async () => {
+  const native = await mockServer(async (_request, response) => {
+    // Native ChatGPT Responses can arrive as SSE without a content-type. The
+    // router's prefix detector must still observe the terminal event.
+    response.writeHead(200);
+    response.write(
+      [
+        "event: response.output_item.done",
+        `data: ${JSON.stringify({
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            name: "shell",
+            call_id: "call_terminal",
+            arguments: "{}",
+          },
+        })}`,
+        "",
+        "event: response.completed",
+        `data: ${JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "resp_terminal",
+            output: [],
+            usage: { input_tokens: 40, output_tokens: 4, total_tokens: 44 },
+          },
+        })}`,
+        "",
+        "",
+      ].join("\n"),
+    );
+    // Codex is allowed to stop reading once response.completed arrives. Keep
+    // the upstream open so the client close wins the race with upstream EOF.
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  const router = startRouter({ nativePort: native.port, routerPort, stateDir, retries: 0 });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const received = await cancelNativeTurnAfterMarker(
+      routerPort,
+      { model: "gpt-5.6-sol", input: "use a tool", stream: true },
+      '"type":"response.completed"',
+    );
+    assert.match(received, /call_terminal/);
+
+    await waitUntil(() => usageEvents(stateDir).length > 0, "no usage event was recorded");
+    const event = usageEvents(stateDir).at(-1);
+    assert.equal(event.provider, "openai");
+    assert.equal(event.status, 200);
+    assert.equal(event.inputTokens, 40);
+    assert.equal(event.outputTokens, 4);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("a native client close before a terminal response still meters zero", async () => {
+  const native = await mockServer(async (_request, response) => {
+    response.writeHead(200, { "Content-Type": "text/event-stream; charset=utf-8" });
+    response.write(
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"partial"}\n\n',
+    );
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  const router = startRouter({ nativePort: native.port, routerPort, stateDir, retries: 0 });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    await cancelNativeTurnAfterMarker(
+      routerPort,
+      { model: "gpt-5.6-sol", input: "cancel me", stream: true },
+      "partial",
+    );
+
+    await waitUntil(() => usageEvents(stateDir).length > 0, "no usage event was recorded");
+    const event = usageEvents(stateDir).at(-1);
+    assert.equal(event.provider, "openai");
+    assert.equal(event.status, 0);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fix native Responses telemetry that recorded successful/tool-completing turns as `status=0` when Codex closed the HTTP stream immediately after receiving `response.completed`.

## Root cause

The router treated any client socket close before Node marked the response writable-finished as a cancellation. For native SSE turns, Codex can legitimately stop reading once it has received the terminal `response.completed` event, so successful turns were being classified as client cancellations. Those rows still carried token usage, but were excluded from `successfulRequests` and performance sampling.

## Fix

- Track whether `ResponseUsageTransform` has observed a terminal `response.completed` event.
- On the native Responses path only, preserve the upstream success status when the client closes after that terminal event.
- Keep genuine pre-terminal client cancellations at `status=0`.
- Preserve existing routed-provider cancellation behavior.

## Regression coverage

Added tests for:

- a native tool-producing response where the client closes immediately after `response.completed` → remains `status=200` and retains usage;
- a native client close before any terminal response → remains `status=0`;
- headerless native SSE, matching the ChatGPT native response shape handled by the router.

The first regression test failed `0 !== 200` before the implementation and passes afterward.

## Verification

- `npm run check` — passed
- `git diff --check` — passed
- Full suite with isolated `CODEX_HOME` and `TZ=UTC`: **1,889 passed, 34 skipped, 0 failed (1,923 total)**

`TZ=UTC` avoids the existing timezone-sensitive provider-usage calendar-bucket test on current `main`; this change does not touch provider aggregation.