### PR TITLE
Integrate validated fixes from PRs #327–#329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
+  function call when the tool was named `view_image`, even when selection was
+  required. The Grok OAuth boundary now presents that tool as `inspect_image`
+  and restores returned calls to `view_image`, without colliding with a real
+  client tool of the same alias name. This complements the existing
+  image-result transport fix: Grok can now both invoke the viewer and receive
+  its returned pixels.
+
 - **Grok OAuth keeps image-bearing tool results multimodal.** The
   Chat Completions-to-Responses hop JSON-stringified every non-string tool
   result, so Codex could complete `view_image` while Grok received JSON and

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -742,6 +742,12 @@ export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
   const disabled = new Set(settings.disabled || []);
   return models.map((model) => {
     const slug = String(model.slug);
+    // Extended-context aliases are manual parent-model choices, not distinct
+    // child-agent backends. Keep them out of spawn_agent model overrides so
+    // delegated work uses the base model's default context window.
+    if (NATIVE_CONTEXT_VARIANT_SLUGS.includes(slug)) {
+      return { ...model, multi_agent_version: "v1" };
+    }
     if (model.visibility !== "list") return model;
     if (hidden.has(slug) || disabled.has(slug)) return model;
     if (NATIVE_V2_BACKEND_SLUGS.has(slug)) {
@@ -854,10 +860,9 @@ function main() {
   const loginFree = loginFreeConfigured();
   const native = {
     ...captured,
-    // Variants join before the multi-agent pass so a switched-off one is
-    // demoted exactly like every other hidden model, and a switched-on one
-    // inherits its base model's verified backend version rather than a
-    // separate claim about the same upstream.
+    // Variants join before the multi-agent pass so the extended-context alias
+    // can remain manually selectable while being forced parent-only; delegated
+    // work must use the base model's default context window.
     models: promoteNativeMultiAgent(
       withNativeContextVariants(captured.models, { enabled: !loginFree }),
       multiAgentSettings,

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -490,9 +490,18 @@ function rewriteModelMessages(messages, model) {
   return next;
 }
 
+const NATIVE_PARALLEL_TOOL_CALL_COMPAT = new Map([["gpt-5.2", true]]);
+
 function normalizeNativeModel(model) {
+  const supportsParallelToolCalls =
+    typeof model.supports_parallel_tool_calls === "boolean"
+      ? model.supports_parallel_tool_calls
+      : NATIVE_PARALLEL_TOOL_CALL_COMPAT.get(String(model.slug));
   return {
     ...model,
+    ...(typeof supportsParallelToolCalls === "boolean"
+      ? { supports_parallel_tool_calls: supportsParallelToolCalls }
+      : {}),
     supports_reasoning_summaries:
       typeof model.supports_reasoning_summaries === "boolean"
         ? model.supports_reasoning_summaries
@@ -733,6 +742,12 @@ export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
   const disabled = new Set(settings.disabled || []);
   return models.map((model) => {
     const slug = String(model.slug);
+    // Extended-context aliases are manual parent-model choices, not distinct
+    // child-agent backends. Keep them out of spawn_agent model overrides so
+    // delegated work uses the base model's default context window.
+    if (NATIVE_CONTEXT_VARIANT_SLUGS.includes(slug)) {
+      return { ...model, multi_agent_version: "v1" };
+    }
     if (model.visibility !== "list") return model;
     if (hidden.has(slug) || disabled.has(slug)) return model;
     if (NATIVE_V2_BACKEND_SLUGS.has(slug)) {
@@ -845,10 +860,9 @@ function main() {
   const loginFree = loginFreeConfigured();
   const native = {
     ...captured,
-    // Variants join before the multi-agent pass so a switched-off one is
-    // demoted exactly like every other hidden model, and a switched-on one
-    // inherits its base model's verified backend version rather than a
-    // separate claim about the same upstream.
+    // Variants join before the multi-agent pass so the extended-context alias
+    // can remain manually selectable while being forced parent-only; delegated
+    // work must use the base model's default context window.
     models: promoteNativeMultiAgent(
       withNativeContextVariants(captured.models, { enabled: !loginFree }),
       multiAgentSettings,

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -490,9 +490,18 @@ function rewriteModelMessages(messages, model) {
   return next;
 }
 
+const NATIVE_PARALLEL_TOOL_CALL_COMPAT = new Map([["gpt-5.2", true]]);
+
 function normalizeNativeModel(model) {
+  const supportsParallelToolCalls =
+    typeof model.supports_parallel_tool_calls === "boolean"
+      ? model.supports_parallel_tool_calls
+      : NATIVE_PARALLEL_TOOL_CALL_COMPAT.get(String(model.slug));
   return {
     ...model,
+    ...(typeof supportsParallelToolCalls === "boolean"
+      ? { supports_parallel_tool_calls: supportsParallelToolCalls }
+      : {}),
     supports_reasoning_summaries:
       typeof model.supports_reasoning_summaries === "boolean"
         ? model.supports_reasoning_summaries

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -20,6 +20,11 @@ import { ensureFreshGrokOAuthToken } from "./grok-oauth-session.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { normalizeSchemaLiterals, objectRootToolSchema } from "./tool-schema-root.mjs";
 import {
+  shouldAliasViewImageForGrok,
+  toolNameForCodex,
+  toolNameForGrok,
+} from "./grok-oauth-tool-alias.mjs";
+import {
   applyResponsesEvent,
   classifyAfterToolRepair,
   createTurnState,
@@ -306,6 +311,7 @@ function normalizeToolOutputForGrok(content) {
 export function toResponsesRequest(chat, options = {}) {
   const input = [];
   let instructions;
+  const viewImageAlias = shouldAliasViewImageForGrok(chat);
   for (const message of chat.messages || []) {
     const role = message.role;
     if (role === "system" || role === "developer") {
@@ -326,7 +332,7 @@ export function toResponsesRequest(chat, options = {}) {
         input.push({
           type: "function_call",
           call_id: call.id,
-          name: call.function?.name,
+          name: toolNameForGrok(call.function?.name, { viewImageAlias }),
           arguments: call.function?.arguments || "{}",
         });
       }
@@ -345,7 +351,7 @@ export function toResponsesRequest(chat, options = {}) {
         .filter((tool) => tool?.type === "function" && tool.function?.name)
         .map((tool) => ({
           type: "function",
-          name: tool.function.name,
+          name: toolNameForGrok(tool.function.name, { viewImageAlias }),
           description: tool.function.description,
           // xAI 400s the whole request over a union-rooted parameter schema,
           // which Codex's own `automation_update` app tool ships. It rejects
@@ -366,7 +372,20 @@ export function toResponsesRequest(chat, options = {}) {
   });
   if (tools.length) {
     request.tools = tools;
-    if (chat.tool_choice) request.tool_choice = chat.tool_choice;
+    if (chat.tool_choice) {
+      request.tool_choice =
+        typeof chat.tool_choice === "object" && chat.tool_choice.function?.name
+          ? {
+              ...chat.tool_choice,
+              function: {
+                ...chat.tool_choice.function,
+                name: toolNameForGrok(chat.tool_choice.function.name, {
+                  viewImageAlias,
+                }),
+              },
+            }
+          : chat.tool_choice;
+    }
   }
   return request;
 }
@@ -476,6 +495,7 @@ async function handleChatCompletions(request, response) {
   const wantsStream = chat.stream === true;
   const model = typeof chat.model === "string" ? chat.model : "";
   const hostedSearchEnabled = hostedSearchEnabledFor(model);
+  const viewImageAlias = shouldAliasViewImageForGrok(chat);
   const responsesRequest = toResponsesRequest(chat, { hostedSearchEnabled });
   const holdOptions = {
     maxText: PROGRESS_ONLY_MAX_TEXT,
@@ -547,7 +567,9 @@ async function handleChatCompletions(request, response) {
 
   const id = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1_000);
-  const turnState = createTurnState();
+  const turnState = createTurnState({
+    toolNameMapper: (name) => toolNameForCodex(name, { viewImageAlias }),
+  });
   let emittedDeltaCount = 0;
   let streamStarted = false;
 
@@ -618,7 +640,9 @@ async function handleChatCompletions(request, response) {
         };
       }
     } else if (secondUpstream?.body) {
-      const secondState = createTurnState();
+      const secondState = createTurnState({
+        toolNameMapper: (name) => toolNameForCodex(name, { viewImageAlias }),
+      });
       await consumeResponsesStream(secondUpstream.body, (event) => {
         applyResponsesEvent(secondState, event);
       });

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -20,6 +20,11 @@ import { ensureFreshGrokOAuthToken } from "./grok-oauth-session.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { normalizeSchemaLiterals, objectRootToolSchema } from "./tool-schema-root.mjs";
 import {
+  shouldAliasViewImageForGrok,
+  toolNameForCodex,
+  toolNameForGrok,
+} from "./grok-oauth-tool-alias.mjs";
+import {
   applyResponsesEvent,
   classifyAfterToolRepair,
   createTurnState,
@@ -306,6 +311,7 @@ function normalizeToolOutputForGrok(content) {
 export function toResponsesRequest(chat, options = {}) {
   const input = [];
   let instructions;
+  const viewImageAlias = shouldAliasViewImageForGrok(chat);
   for (const message of chat.messages || []) {
     const role = message.role;
     if (role === "system" || role === "developer") {
@@ -326,7 +332,7 @@ export function toResponsesRequest(chat, options = {}) {
         input.push({
           type: "function_call",
           call_id: call.id,
-          name: call.function?.name,
+          name: toolNameForGrok(call.function?.name, { viewImageAlias }),
           arguments: call.function?.arguments || "{}",
         });
       }
@@ -345,7 +351,7 @@ export function toResponsesRequest(chat, options = {}) {
         .filter((tool) => tool?.type === "function" && tool.function?.name)
         .map((tool) => ({
           type: "function",
-          name: tool.function.name,
+          name: toolNameForGrok(tool.function.name, { viewImageAlias }),
           description: tool.function.description,
           // xAI 400s the whole request over a union-rooted parameter schema,
           // which Codex's own `automation_update` app tool ships. It rejects
@@ -366,7 +372,23 @@ export function toResponsesRequest(chat, options = {}) {
   });
   if (tools.length) {
     request.tools = tools;
-    if (chat.tool_choice) request.tool_choice = chat.tool_choice;
+    if (chat.tool_choice) {
+      request.tool_choice =
+        typeof chat.tool_choice === "object" && chat.tool_choice.function?.name
+          ? (() => {
+              // Chat Completions nests a named function under `function`, but
+              // the xAI Responses boundary accepts the flat Responses shape.
+              // Do the protocol conversion here while applying the scoped
+              // alias; forwarding the nested object makes the provider reject
+              // the request before it can select the renamed tool.
+              const { function: functionChoice, ...responsesChoice } = chat.tool_choice;
+              return {
+                ...responsesChoice,
+                name: toolNameForGrok(functionChoice.name, { viewImageAlias }),
+              };
+            })()
+          : chat.tool_choice;
+    }
   }
   return request;
 }
@@ -476,6 +498,7 @@ async function handleChatCompletions(request, response) {
   const wantsStream = chat.stream === true;
   const model = typeof chat.model === "string" ? chat.model : "";
   const hostedSearchEnabled = hostedSearchEnabledFor(model);
+  const viewImageAlias = shouldAliasViewImageForGrok(chat);
   const responsesRequest = toResponsesRequest(chat, { hostedSearchEnabled });
   const holdOptions = {
     maxText: PROGRESS_ONLY_MAX_TEXT,
@@ -547,7 +570,9 @@ async function handleChatCompletions(request, response) {
 
   const id = `chatcmpl-${randomUUID()}`;
   const created = Math.floor(Date.now() / 1_000);
-  const turnState = createTurnState();
+  const turnState = createTurnState({
+    toolNameMapper: (name) => toolNameForCodex(name, { viewImageAlias }),
+  });
   let emittedDeltaCount = 0;
   let streamStarted = false;
 
@@ -618,7 +643,9 @@ async function handleChatCompletions(request, response) {
         };
       }
     } else if (secondUpstream?.body) {
-      const secondState = createTurnState();
+      const secondState = createTurnState({
+        toolNameMapper: (name) => toolNameForCodex(name, { viewImageAlias }),
+      });
       await consumeResponsesStream(secondUpstream.body, (event) => {
         applyResponsesEvent(secondState, event);
       });

--- a/src/grok-oauth-tool-alias.mjs
+++ b/src/grok-oauth-tool-alias.mjs
@@ -1,0 +1,29 @@
+export const CODEX_VIEW_IMAGE_TOOL = "view_image";
+export const GROK_VIEW_IMAGE_TOOL = "inspect_image";
+
+export function shouldAliasViewImageForGrok(chat) {
+  // Grok 4.6 stops without a call when xAI receives this function under the
+  // native Codex name, even when tool_choice is required. A dedicated alias
+  // selects normally; keep the rewrite request-scoped so a real client tool
+  // already named inspect_image retains its own identity.
+  if (chat?.model !== "grok-4.6") return false;
+  const names = new Set(
+    (Array.isArray(chat?.tools) ? chat.tools : [])
+      .filter((tool) => tool?.type === "function")
+      .map((tool) => tool.function?.name)
+      .filter(Boolean),
+  );
+  return names.has(CODEX_VIEW_IMAGE_TOOL) && !names.has(GROK_VIEW_IMAGE_TOOL);
+}
+
+export function toolNameForGrok(name, { viewImageAlias = false } = {}) {
+  return viewImageAlias && name === CODEX_VIEW_IMAGE_TOOL
+    ? GROK_VIEW_IMAGE_TOOL
+    : name;
+}
+
+export function toolNameForCodex(name, { viewImageAlias = false } = {}) {
+  return viewImageAlias && name === GROK_VIEW_IMAGE_TOOL
+    ? CODEX_VIEW_IMAGE_TOOL
+    : name;
+}

--- a/src/grok-oauth-turn.mjs
+++ b/src/grok-oauth-turn.mjs
@@ -223,7 +223,7 @@ export function mergeMappedUsage(first, second) {
 
 const TOOL_ITEM_TYPES = new Set(["function_call", "custom_tool_call"]);
 
-export function createTurnState() {
+export function createTurnState({ toolNameMapper = (name) => name } = {}) {
   return {
     contentText: "",
     reasoningText: "",
@@ -231,6 +231,7 @@ export function createTurnState() {
     toolByItemId: new Map(),
     usage: undefined,
     deltas: [],
+    toolNameMapper,
   };
 }
 
@@ -305,7 +306,7 @@ function ensureToolCall(state, item, itemId, { complete = false } = {}) {
     entry = {
       id: item.call_id || item.id || key,
       type: "function",
-      function: { name: item.name || "", arguments: args },
+      function: { name: state.toolNameMapper(item.name || ""), arguments: args },
     };
     state.toolCalls.push(entry);
     if (key) state.toolByItemId.set(key, entry);
@@ -320,7 +321,7 @@ function ensureToolCall(state, item, itemId, { complete = false } = {}) {
       ],
     });
   } else {
-    if (item.name) entry.function.name = item.name;
+    if (item.name) entry.function.name = state.toolNameMapper(item.name);
     const args = toolArguments(item);
     if (args) entry.function.arguments = args;
   }

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -320,6 +320,7 @@ export class ResponseUsageTransform extends Transform {
   // first token appears, and counting that silence as generation is what makes
   // a fast model read as slow. See #192.
   #firstTokenAt;
+  #completedResponseObserved = false;
 
   // `estimatedInputTokens` arrives only on routed requests large enough that a
   // reported zero cannot be true. Without it this transform observes and
@@ -520,6 +521,7 @@ export class ResponseUsageTransform extends Transform {
 
   #observe(payload) {
     this.#noteFirstToken(payload);
+    if (payload?.type === "response.completed") this.#completedResponseObserved = true;
     const usage = tokenUsageFromPayload(payload);
     if (usage) this.#usage = usage;
   }
@@ -547,5 +549,9 @@ export class ResponseUsageTransform extends Transform {
   // response never streamed one (a non-streaming reply, or an error).
   firstTokenAt() {
     return this.#firstTokenAt;
+  }
+
+  completedResponseObserved() {
+    return this.#completedResponseObserved;
   }
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -2282,6 +2282,7 @@ async function handleResponses(request, response, requestUrl) {
   let requestedModel = "";
   let route;
   let upstreamRetries;
+  let upstreamStatus;
   let upstreamLatencyMs;
   let firstTokenMs;
   let usageTransform;
@@ -2570,6 +2571,7 @@ async function handleResponses(request, response, requestUrl) {
       },
     );
     upstreamRetries = retries;
+    upstreamStatus = upstream.status;
     // Time until the upstream chain answered the request. Everything before
     // this is router-side work (body read, normalization, flattening, vision
     // bridge) plus the upstream's own time to produce response headers. For a
@@ -2618,6 +2620,7 @@ async function handleResponses(request, response, requestUrl) {
           });
           adoptRoute(moved.route, moved.built);
           upstream = moved.upstream;
+          upstreamStatus = upstream.status;
           failedBodyText = undefined;
         }
       }
@@ -2735,8 +2738,11 @@ async function handleResponses(request, response, requestUrl) {
     // goes away, but `pipeResponse` can resolve before that event fires: the
     // response socket is already destroyed at that point. Read the state
     // directly as well so a cancel that races the close event still meters 0.
+    const nativeCompletedBeforeClose =
+      !route && usageTransform?.completedResponseObserved() === true;
     const clientWalkedAway =
-      clientGone || (response.destroyed && !response.writableFinished);
+      (clientGone || (response.destroyed && !response.writableFinished)) &&
+      !nativeCompletedBeforeClose;
     finalStatus = clientWalkedAway ? 0 : upstream.status;
     emptyCompletion = emptyCompletionGuard?.isEmpty() === true && !clientWalkedAway;
     // The guard releases long turns at its byte/time budget without a verdict.
@@ -2955,6 +2961,37 @@ async function handleResponses(request, response, requestUrl) {
         usageTransform.substitutedInputTokens(),
         retryUsageTransform?.substitutedInputTokens(),
       );
+      const firstTokenAt = usageTransform.firstTokenAt?.();
+      if (firstTokenAt !== undefined) firstTokenMs = firstTokenAt - startedAt;
+    }
+    // Codex may close a native stream immediately after response.completed.
+    // That is a successful terminal turn, not a canceled generation.
+    if (!route && clientGone && usageTransform?.completedResponseObserved() === true) {
+      finalStatus = upstreamStatus ?? response.statusCode;
+      activityStatus = finalStatus;
+      if (!usageRecorded) {
+        recordUsageEvent({
+          model: requestedModel,
+          provider: "openai",
+          status: finalStatus,
+          durationMs: Date.now() - startedAt,
+          responseStartMs: upstreamLatencyMs,
+          firstTokenMs,
+          ...usage,
+          estimatedInputTokens,
+          ...toolResultAging,
+          retries: (upstreamRetries || 0) + (usage?.retries || 0) || undefined,
+        });
+        usageRecorded = true;
+      }
+      if (!QUIET) {
+        console.error(
+          `[codex-router] model=${requestedModel || "unknown"} provider=openai status=${finalStatus}${
+            upstreamRetries ? ` retries=${upstreamRetries}` : ""
+          }`,
+        );
+      }
+      return;
     }
     // A client that walked away (canceled generation, closed stream) is not
     // a router failure; only surface errors the router or upstream produced.

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -2282,6 +2282,7 @@ async function handleResponses(request, response, requestUrl) {
   let requestedModel = "";
   let route;
   let upstreamRetries;
+  let upstreamStatus;
   let upstreamLatencyMs;
   let firstTokenMs;
   let usageTransform;
@@ -2570,6 +2571,7 @@ async function handleResponses(request, response, requestUrl) {
       },
     );
     upstreamRetries = retries;
+    upstreamStatus = upstream.status;
     // Time until the upstream chain answered the request. Everything before
     // this is router-side work (body read, normalization, flattening, vision
     // bridge) plus the upstream's own time to produce response headers. For a
@@ -2618,6 +2620,7 @@ async function handleResponses(request, response, requestUrl) {
           });
           adoptRoute(moved.route, moved.built);
           upstream = moved.upstream;
+          upstreamStatus = upstream.status;
           failedBodyText = undefined;
         }
       }
@@ -2735,8 +2738,11 @@ async function handleResponses(request, response, requestUrl) {
     // goes away, but `pipeResponse` can resolve before that event fires: the
     // response socket is already destroyed at that point. Read the state
     // directly as well so a cancel that races the close event still meters 0.
+    const nativeCompletedBeforeClose =
+      !route && usageTransform?.completedResponseObserved() === true;
     const clientWalkedAway =
-      clientGone || (response.destroyed && !response.writableFinished);
+      (clientGone || (response.destroyed && !response.writableFinished)) &&
+      !nativeCompletedBeforeClose;
     finalStatus = clientWalkedAway ? 0 : upstream.status;
     emptyCompletion = emptyCompletionGuard?.isEmpty() === true && !clientWalkedAway;
     // The guard releases long turns at its byte/time budget without a verdict.
@@ -2955,6 +2961,28 @@ async function handleResponses(request, response, requestUrl) {
         usageTransform.substitutedInputTokens(),
         retryUsageTransform?.substitutedInputTokens(),
       );
+    }
+    // Codex may close a native stream immediately after response.completed.
+    // That is a successful terminal turn, not a canceled generation.
+    if (!route && clientGone && usageTransform?.completedResponseObserved() === true) {
+      finalStatus = upstreamStatus ?? response.statusCode;
+      activityStatus = finalStatus;
+      if (!usageRecorded) {
+        recordUsageEvent({
+          model: requestedModel,
+          provider: "openai",
+          status: finalStatus,
+          durationMs: Date.now() - startedAt,
+          responseStartMs: upstreamLatencyMs,
+          firstTokenMs,
+          retries: upstreamRetries,
+          ...usage,
+          estimatedInputTokens,
+          ...toolResultAging,
+        });
+        usageRecorded = true;
+      }
+      return;
     }
     // A client that walked away (canceled generation, closed stream) is not
     // a router failure; only surface errors the router or upstream produced.

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -956,6 +956,20 @@ test("native listed models follow the local subagent opt-in", () => {
   assert.equal(promoted[2].multi_agent_version, "v1");
 });
 
+test("native context variants are never advertised as subagent models", () => {
+  const native = [
+    { slug: "gpt-5.6-sol", visibility: "list", multi_agent_version: "v2" },
+    { slug: "gpt-5.6-sol-1m", visibility: "list", multi_agent_version: "v2" },
+  ];
+  const promoted = promoteNativeMultiAgent(native, {
+    mode: "all",
+    enabled: ["gpt-5.6-sol-1m"],
+    disabled: [],
+  });
+  assert.equal(promoted[0].multi_agent_version, "v2");
+  assert.equal(promoted[1].multi_agent_version, "v1");
+});
+
 test("native promotion honours disabled models and picker-hidden slugs", () => {
   const native = [
     { slug: "gpt-5.6-luna", visibility: "list", multi_agent_version: "v1" },

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -411,6 +411,13 @@ test("merged catalog preserves native GPT identity while rewriting routed models
   assert.doesNotMatch(bySlug.get("grok-oauth/grok-4.5").base_instructions, /GPT-5/);
 });
 
+test("native gpt-5.2 stays parseable by older Codex catalog readers", () => {
+  const native52 = { ...template, slug: "gpt-5.2" };
+  delete native52.supports_parallel_tool_calls;
+  const merged = buildMergedCatalog({ models: [native52] }, []);
+  assert.equal(merged[0].supports_parallel_tool_calls, true);
+});
+
 test("merged catalog resolves a routed behavior template without inheriting its capabilities", () => {
   const sol = {
     ...template,

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -411,6 +411,13 @@ test("merged catalog preserves native GPT identity while rewriting routed models
   assert.doesNotMatch(bySlug.get("grok-oauth/grok-4.5").base_instructions, /GPT-5/);
 });
 
+test("native gpt-5.2 stays parseable by older Codex catalog readers", () => {
+  const native52 = { ...template, slug: "gpt-5.2" };
+  delete native52.supports_parallel_tool_calls;
+  const merged = buildMergedCatalog({ models: [native52] }, []);
+  assert.equal(merged[0].supports_parallel_tool_calls, true);
+});
+
 test("merged catalog resolves a routed behavior template without inheriting its capabilities", () => {
   const sol = {
     ...template,
@@ -947,6 +954,20 @@ test("native listed models follow the local subagent opt-in", () => {
   assert.equal(promoted[1].multi_agent_version, "v2");
   // Hidden native entries are never advertised as spawn targets.
   assert.equal(promoted[2].multi_agent_version, "v1");
+});
+
+test("native context variants are never advertised as subagent models", () => {
+  const native = [
+    { slug: "gpt-5.6-sol", visibility: "list", multi_agent_version: "v2" },
+    { slug: "gpt-5.6-sol-1m", visibility: "list", multi_agent_version: "v2" },
+  ];
+  const promoted = promoteNativeMultiAgent(native, {
+    mode: "all",
+    enabled: ["gpt-5.6-sol-1m"],
+    disabled: [],
+  });
+  assert.equal(promoted[0].multi_agent_version, "v2");
+  assert.equal(promoted[1].multi_agent_version, "v1");
 });
 
 test("native promotion honours disabled models and picker-hidden slugs", () => {

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -95,15 +95,18 @@ test("translates Chat Completions to Grok Responses and back (text + tools)", as
     res.writeHead(200, { "Content-Type": "text/event-stream" });
     // Hosted search tools are always present; only emit client function-call
     // events when the request includes a client function tool.
-    const hasClientFunction = Array.isArray(captured.tools)
-      && captured.tools.some((tool) => tool.type === "function");
-    if (hasClientFunction) {
+    const clientFunction = Array.isArray(captured.tools)
+      ? captured.tools.find((tool) => tool.type === "function")
+      : undefined;
+    if (clientFunction) {
+      const argumentsJson = clientFunction.name === "inspect_image"
+        ? '{"path":"C:\\\\image.jpg"}'
+        : '{"city":"SF"}';
       res.end(
         sse([
-          { type: "response.output_item.added", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "get_weather" } },
-          { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: '{"city":' },
-          { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: '"SF"}' },
-          { type: "response.output_item.done", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "get_weather", arguments: '{"city":"SF"}' } },
+          { type: "response.output_item.added", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: clientFunction.name } },
+          { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: argumentsJson },
+          { type: "response.output_item.done", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: clientFunction.name, arguments: argumentsJson } },
           { type: "response.completed", response: { usage: { input_tokens: 10, output_tokens: 8 } } },
         ]),
       );
@@ -238,6 +241,29 @@ test("translates Chat Completions to Grok Responses and back (text + tools)", as
     assert.deepEqual(
       captured.tools.filter((tool) => tool.type !== "function"),
       [{ type: "web_search" }, { type: "x_search" }],
+    );
+
+    // Grok 4.6 receives the provider-selectable alias, while Codex gets its
+    // native tool name back from the streamed function-call response.
+    const imageResp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "inspect the image" }],
+        tools: [
+          { type: "function", function: { name: "view_image", parameters: { type: "object" } } },
+        ],
+        stream: false,
+      }),
+    });
+    const imageTool = await imageResp.json();
+    assert.equal(captured.tools[0].name, "inspect_image");
+    assert.equal(imageTool.choices[0].finish_reason, "tool_calls");
+    assert.equal(imageTool.choices[0].message.tool_calls[0].function.name, "view_image");
+    assert.equal(
+      imageTool.choices[0].message.tool_calls[0].function.arguments,
+      '{"path":"C:\\\\image.jpg"}',
     );
   } finally {
     await stop(child);
@@ -390,6 +416,71 @@ test("toResponsesRequest sends each duplicated tool name upstream once", () => {
   });
   const fileWrites = request.tools.filter((tool) => tool.name === "file_write");
   assert.equal(fileWrites.length, 1);
+});
+
+test("toResponsesRequest aliases view_image only at the Grok boundary", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.6",
+    messages: [
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_image",
+            type: "function",
+            function: { name: "view_image", arguments: '{"path":"C:\\\\image.jpg"}' },
+          },
+        ],
+      },
+    ],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "view_image",
+          description: "View a local image.",
+          parameters: { type: "object", properties: { path: { type: "string" } } },
+        },
+      },
+    ],
+    tool_choice: { type: "function", function: { name: "view_image" } },
+  });
+
+  assert.equal(request.tools.find((tool) => tool.type === "function").name, "inspect_image");
+  assert.equal(request.input[0].name, "inspect_image");
+  assert.equal(request.tool_choice.function.name, "inspect_image");
+});
+
+test("toResponsesRequest does not alias view_image over a real inspect_image", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.6",
+    messages: [{ role: "user", content: "inspect it" }],
+    tools: [
+      { type: "function", function: { name: "view_image", parameters: { type: "object" } } },
+      { type: "function", function: { name: "inspect_image", parameters: { type: "object" } } },
+    ],
+  });
+
+  const names = request.tools
+    .filter((tool) => tool.type === "function")
+    .map((tool) => tool.name);
+  assert.deepEqual(names, ["view_image", "inspect_image"]);
+});
+
+test("toResponsesRequest leaves view_image unchanged for other Grok models", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.5",
+    messages: [{ role: "user", content: "inspect it" }],
+    tools: [
+      { type: "function", function: { name: "view_image", parameters: { type: "object" } } },
+    ],
+  });
+
+  assert.equal(
+    request.tools.find((tool) => tool.type === "function").name,
+    "view_image",
+  );
 });
 
 test("toResponsesRequest always includes hosted search tools when enabled", () => {

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -95,15 +95,18 @@ test("translates Chat Completions to Grok Responses and back (text + tools)", as
     res.writeHead(200, { "Content-Type": "text/event-stream" });
     // Hosted search tools are always present; only emit client function-call
     // events when the request includes a client function tool.
-    const hasClientFunction = Array.isArray(captured.tools)
-      && captured.tools.some((tool) => tool.type === "function");
-    if (hasClientFunction) {
+    const clientFunction = Array.isArray(captured.tools)
+      ? captured.tools.find((tool) => tool.type === "function")
+      : undefined;
+    if (clientFunction) {
+      const argumentsJson = clientFunction.name === "inspect_image"
+        ? '{"path":"C:\\\\image.jpg"}'
+        : '{"city":"SF"}';
       res.end(
         sse([
-          { type: "response.output_item.added", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "get_weather" } },
-          { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: '{"city":' },
-          { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: '"SF"}' },
-          { type: "response.output_item.done", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: "get_weather", arguments: '{"city":"SF"}' } },
+          { type: "response.output_item.added", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: clientFunction.name } },
+          { type: "response.function_call_arguments.delta", item_id: "fc_1", delta: argumentsJson },
+          { type: "response.output_item.done", item: { type: "function_call", id: "fc_1", call_id: "call_1", name: clientFunction.name, arguments: argumentsJson } },
           { type: "response.completed", response: { usage: { input_tokens: 10, output_tokens: 8 } } },
         ]),
       );
@@ -238,6 +241,29 @@ test("translates Chat Completions to Grok Responses and back (text + tools)", as
     assert.deepEqual(
       captured.tools.filter((tool) => tool.type !== "function"),
       [{ type: "web_search" }, { type: "x_search" }],
+    );
+
+    // Grok 4.6 receives the provider-selectable alias, while Codex gets its
+    // native tool name back from the streamed function-call response.
+    const imageResp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [{ role: "user", content: "inspect the image" }],
+        tools: [
+          { type: "function", function: { name: "view_image", parameters: { type: "object" } } },
+        ],
+        stream: false,
+      }),
+    });
+    const imageTool = await imageResp.json();
+    assert.equal(captured.tools[0].name, "inspect_image");
+    assert.equal(imageTool.choices[0].finish_reason, "tool_calls");
+    assert.equal(imageTool.choices[0].message.tool_calls[0].function.name, "view_image");
+    assert.equal(
+      imageTool.choices[0].message.tool_calls[0].function.arguments,
+      '{"path":"C:\\\\image.jpg"}',
     );
   } finally {
     await stop(child);
@@ -390,6 +416,73 @@ test("toResponsesRequest sends each duplicated tool name upstream once", () => {
   });
   const fileWrites = request.tools.filter((tool) => tool.name === "file_write");
   assert.equal(fileWrites.length, 1);
+});
+
+test("toResponsesRequest aliases view_image only at the Grok boundary", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.6",
+    messages: [
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [
+          {
+            id: "call_image",
+            type: "function",
+            function: { name: "view_image", arguments: '{"path":"C:\\\\image.jpg"}' },
+          },
+        ],
+      },
+    ],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "view_image",
+          description: "View a local image.",
+          parameters: { type: "object", properties: { path: { type: "string" } } },
+        },
+      },
+    ],
+    tool_choice: { type: "function", function: { name: "view_image" } },
+  });
+
+  assert.equal(request.tools.find((tool) => tool.type === "function").name, "inspect_image");
+  assert.equal(request.input[0].name, "inspect_image");
+  assert.deepEqual(request.tool_choice, { type: "function", name: "inspect_image" });
+});
+
+test("toResponsesRequest does not alias view_image over a real inspect_image", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.6",
+    messages: [{ role: "user", content: "inspect it" }],
+    tools: [
+      { type: "function", function: { name: "view_image", parameters: { type: "object" } } },
+      { type: "function", function: { name: "inspect_image", parameters: { type: "object" } } },
+    ],
+    tool_choice: { type: "function", function: { name: "view_image" } },
+  });
+
+  const names = request.tools
+    .filter((tool) => tool.type === "function")
+    .map((tool) => tool.name);
+  assert.deepEqual(names, ["view_image", "inspect_image"]);
+  assert.deepEqual(request.tool_choice, { type: "function", name: "view_image" });
+});
+
+test("toResponsesRequest leaves view_image unchanged for other Grok models", () => {
+  const request = toResponsesRequest({
+    model: "grok-4.5",
+    messages: [{ role: "user", content: "inspect it" }],
+    tools: [
+      { type: "function", function: { name: "view_image", parameters: { type: "object" } } },
+    ],
+  });
+
+  assert.equal(
+    request.tools.find((tool) => tool.type === "function").name,
+    "view_image",
+  );
 });
 
 test("toResponsesRequest always includes hosted search tools when enabled", () => {

--- a/test/grok-oauth-turn.test.mjs
+++ b/test/grok-oauth-turn.test.mjs
@@ -6,6 +6,7 @@ import {
   classifyAfterToolRepair,
   collectResponsesEvents,
   createTurnState,
+  finalizeTurn,
   isProgressOnlyStop,
   lastClientMessageWasToolResult,
   mergeMappedUsage,
@@ -38,6 +39,25 @@ test("collectResponsesEvents keeps a function_call that only appears in output_i
   assert.equal(turn.toolCalls[0].function.name, "exec_command");
   assert.equal(turn.toolCalls[0].function.arguments, '{"cmd":"dir"}');
   assert.equal(turn.deltas[0].tool_calls[0].function.arguments, '{"cmd":"dir"}');
+});
+
+test("createTurnState can restore a provider-facing tool alias", () => {
+  const state = createTurnState({
+    toolNameMapper: (name) => (name === "inspect_image" ? "view_image" : name),
+  });
+  applyResponsesEvent(state, {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      id: "fc_image",
+      call_id: "call_image",
+      name: "inspect_image",
+      arguments: '{"path":"C:\\\\image.jpg"}',
+    },
+  });
+  const turn = finalizeTurn(state);
+  assert.equal(turn.toolCalls[0].function.name, "view_image");
+  assert.equal(turn.deltas[0].tool_calls[0].function.name, "view_image");
 });
 
 test("finalizeTurn backfills streamed arguments when added is followed by done without deltas", () => {

--- a/test/native-context-variants.test.mjs
+++ b/test/native-context-variants.test.mjs
@@ -9,7 +9,6 @@ import { fileURLToPath } from "node:url";
 import { zstdDecompressSync } from "node:zlib";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
-import { buildLoginFreeCatalog, buildMergedCatalog } from "../src/catalog.mjs";
 import {
   NATIVE_CONTEXT_VARIANTS,
   NATIVE_CONTEXT_VARIANT_SLUGS,
@@ -24,6 +23,7 @@ const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
 
 const pickerStateDir = mkdtempSync(path.join(os.tmpdir(), "context-variant-picker-"));
 process.env.MODEL_ROUTER_MODEL_PICKER_STATE = path.join(pickerStateDir, "model-picker.json");
+const { buildLoginFreeCatalog, buildMergedCatalog } = await import("../src/catalog.mjs");
 const {
   MODEL_PICKER_STATE_PATH,
   readHiddenModels,

--- a/test/native-retry.test.mjs
+++ b/test/native-retry.test.mjs
@@ -584,3 +584,121 @@ test("an image generation is never retried, however retryable the failure looks"
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+function cancelNativeTurnAfterMarker(port, body, marker) {
+  const base = new URL(`${routerBase(port)}/responses`);
+  return new Promise((resolve) => {
+    const request = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: base.pathname,
+        method: "POST",
+        headers: { Authorization: "Bearer caller", "Content-Type": "application/json" },
+      },
+      (response) => {
+        let received = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          received += chunk;
+          if (received.includes(marker)) {
+            request.destroy();
+            resolve(received);
+          }
+        });
+      },
+    );
+    request.once("error", () => resolve(""));
+    request.end(JSON.stringify(body));
+  });
+}
+
+test("a native terminal tool response stays successful when the client closes after completion", async () => {
+  const native = await mockServer(async (_request, response) => {
+    // Native ChatGPT Responses can arrive as SSE without a content-type. The
+    // router's prefix detector must still observe the terminal event.
+    response.writeHead(200);
+    response.write(
+      [
+        "event: response.output_item.done",
+        `data: ${JSON.stringify({
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            name: "shell",
+            call_id: "call_terminal",
+            arguments: "{}",
+          },
+        })}`,
+        "",
+        "event: response.completed",
+        `data: ${JSON.stringify({
+          type: "response.completed",
+          response: {
+            id: "resp_terminal",
+            output: [],
+            usage: { input_tokens: 40, output_tokens: 4, total_tokens: 44 },
+          },
+        })}`,
+        "",
+        "",
+      ].join("\n"),
+    );
+    // Codex is allowed to stop reading once response.completed arrives. Keep
+    // the upstream open so the client close wins the race with upstream EOF.
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  const router = startRouter({ nativePort: native.port, routerPort, stateDir, retries: 0 });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const received = await cancelNativeTurnAfterMarker(
+      routerPort,
+      { model: "gpt-5.6-sol", input: "use a tool", stream: true },
+      '"type":"response.completed"',
+    );
+    assert.match(received, /call_terminal/);
+
+    await waitUntil(() => usageEvents(stateDir).length > 0, "no usage event was recorded");
+    const event = usageEvents(stateDir).at(-1);
+    assert.equal(event.provider, "openai");
+    assert.equal(event.status, 200);
+    assert.equal(event.inputTokens, 40);
+    assert.equal(event.outputTokens, 4);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("a native client close before a terminal response still meters zero", async () => {
+  const native = await mockServer(async (_request, response) => {
+    response.writeHead(200, { "Content-Type": "text/event-stream; charset=utf-8" });
+    response.write(
+      'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"partial"}\n\n',
+    );
+  });
+  const stateDir = stateDirectory();
+  const routerPort = await openPort();
+  const router = startRouter({ nativePort: native.port, routerPort, stateDir, retries: 0 });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    await cancelNativeTurnAfterMarker(
+      routerPort,
+      { model: "gpt-5.6-sol", input: "cancel me", stream: true },
+      "partial",
+    );
+
+    await waitUntil(() => usageEvents(stateDir).length > 0, "no usage event was recorded");
+    const event = usageEvents(stateDir).at(-1);
+    assert.equal(event.provider, "openai");
+    assert.equal(event.status, 0);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/test/provider-usage.test.mjs
+++ b/test/provider-usage.test.mjs
@@ -170,6 +170,13 @@ test("reports a rolling 24-hour window separately from calendar-day buckets", ()
 });
 
 test("publishes prefix-cache telemetry for the dashboard without inflating it", () => {
+  const localDateKey = (value) => {
+    const date = new Date(value);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  };
   const now = Date.parse("2026-07-21T18:00:00Z");
   const snapshot = aggregateProviderUsage(
     [
@@ -208,8 +215,8 @@ test("publishes prefix-cache telemetry for the dashboard without inflating it", 
     // request exactly one day earlier is still part of the window.
     last24hCachedInputTokens: 130,
     dailyCachedInputTokens: [
-      { startDate: "2026-07-20", cachedInputTokens: 80 },
-      { startDate: "2026-07-21", cachedInputTokens: 50 },
+      { startDate: localDateKey("2026-07-20T18:00:00Z"), cachedInputTokens: 80 },
+      { startDate: localDateKey("2026-07-21T17:00:00Z"), cachedInputTokens: 50 },
     ],
   });
   const deepseek = snapshot.providers.find((provider) => provider.id === "deepseek");
@@ -220,8 +227,8 @@ test("publishes prefix-cache telemetry for the dashboard without inflating it", 
   assert.equal(deepseek.last24hCachedInputTokens, 130);
   assert.equal(deepseek.regularInputTokens + deepseek.cachedInputTokens, deepseek.inputTokens);
   assert.deepEqual(deepseek.dailyUsageBuckets, [
-    { startDate: "2026-07-20", tokens: 100, requests: 1, inputTokens: 100, cachedInputTokens: 80, outputTokens: 0 },
-    { startDate: "2026-07-21", tokens: 50, requests: 2, inputTokens: 50, cachedInputTokens: 50, outputTokens: 0 },
+    { startDate: localDateKey("2026-07-20T18:00:00Z"), tokens: 100, requests: 1, inputTokens: 100, cachedInputTokens: 80, outputTokens: 0 },
+    { startDate: localDateKey("2026-07-21T17:00:00Z"), tokens: 50, requests: 2, inputTokens: 50, cachedInputTokens: 50, outputTokens: 0 },
   ]);
 });
 

--- a/test/response-usage.test.mjs
+++ b/test/response-usage.test.mjs
@@ -118,6 +118,8 @@ test("captures final SSE usage without changing streamed bytes", async () => {
     outputTokens: 8,
     totalTokens: 29,
   });
+  assert.equal(transform.completedResponseObserved(), true);
+  assert.equal(typeof transform.firstTokenAt(), "number");
 });
 
 test("captures JSON usage without changing the response", async () => {

--- a/test/state-owner.test.mjs
+++ b/test/state-owner.test.mjs
@@ -241,3 +241,24 @@ test("no test spawns the catalog without isolating CODEX_HOME", () => {
       "agents directory no state-directory override redirects",
   );
 });
+
+test("tests isolate picker state before importing the catalog", () => {
+  const offenders = readdirSync(path.join(root, "test"))
+    .filter((entry) => entry.endsWith(".mjs"))
+    .filter((entry) => {
+      const source = readFileSync(path.join(root, "test", entry), "utf8");
+      const catalogImport = source.indexOf('from "../src/catalog.mjs"');
+      const pickerOverride = source.indexOf("MODEL_ROUTER_MODEL_PICKER_STATE");
+      return (
+        entry !== "state-owner.test.mjs" &&
+        catalogImport >= 0 &&
+        pickerOverride >= 0 &&
+        pickerOverride > catalogImport
+      );
+    });
+  assert.deepEqual(
+    offenders,
+    [],
+    `${offenders.join(", ")} import the catalog before redirecting picker state`,
+  );
+});


### PR DESCRIPTION
## Summary

Integrates the independently audited fixes from #327, #328, and #329 on top of current `main`.

- Keeps test picker state isolated, preserves older Codex catalog compatibility for native `gpt-5.2`, makes local-date usage tests portable, and keeps the 1M Sol alias parent-only.
- Aliases Codex `view_image` to `inspect_image` only at the Grok 4.6 OAuth boundary, with collision-safe history/response restoration.
- Counts native streams closed after terminal `response.completed` as successful while preserving pre-terminal and routed-provider cancellation semantics.

## Audit hardening

Two reviewer findings are included beyond the submitted heads:

- Convert a named Chat Completions `tool_choice` to the flat Responses wire shape while applying the Grok alias.
- Preserve first-token timing, combined retry counts, and the ordinary status log in the native terminal-close catch path.

## Verification

- `npm run check`
- Focused catalog, picker-state, provider-usage, Grok OAuth, namespace/MCP, native retry, and response-usage suites
- Full repository suite with an isolated `CODEX_HOME` and security-compatible `umask 022`: passed
- `git diff --check`
- Exact Git tree locally verified as `3c21108b4a7caf73839ebc70657bfde957dd4595`

Issue #270 is intentionally not included: it requires a real Devin account and an explicit quota-consuming live Cascade probe.