### PR TITLE
fix: hide leaked MiniMax thinking output

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -767,9 +767,13 @@ function normalizeBody(buffer, contentType, route) {
     }
   } else if (model.requestProfile === "minimax-m3") {
     // MiniMax uses its own thinking control on the OpenAI-compatible
-    // Chat Completions endpoint instead of reasoning_effort.
+    // Chat Completions endpoint instead of reasoning_effort. Without
+    // reasoning_split, MiniMax embeds the chain of thought in `content` as
+    // literal <think>...</think> markup, which makes it visible as ordinary
+    // assistant text in clients that do not recognize the vendor format.
     delete payload.reasoning_effort;
     payload.thinking = { type: "adaptive" };
+    payload.reasoning_split = true;
   } else if (model.requestProfile === "auto-tool-choice") {
     // Some models call tools happily under "auto" but reject being forced to,
     // the way DeepSeek and Qwen do in thinking mode. Their vendor profiles

--- a/src/minimax-responses-compat.mjs
+++ b/src/minimax-responses-compat.mjs
@@ -1,0 +1,124 @@
+import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+function isMiniMaxModel(model) {
+  return [model?.provider, model?.upstreamModel, model?.gatewayModel, model?.slug]
+    .some((value) => typeof value === "string" && value.toLowerCase().includes("minimax"));
+}
+
+function stripThinking(text) {
+  return typeof text === "string"
+    ? text.replace(/<think\b[^>]*>[\s\S]*?<\/think\s*>/gi, "")
+    : text;
+}
+
+function parseSseBlock(block) {
+  const lines = block.split(/\r?\n/);
+  const index = lines.findIndex((line) => line.startsWith("data:"));
+  if (index === -1) return undefined;
+  const data = lines[index].slice(5).trim();
+  if (!data || data === "[DONE]") return undefined;
+  try {
+    return { lines, index, event: JSON.parse(data) };
+  } catch {
+    return undefined;
+  }
+}
+
+function rewrite(block, parsed, event) {
+  const lines = [...parsed.lines];
+  lines[parsed.index] = `data: ${JSON.stringify(event)}`;
+  return lines.join(block.includes("\r\n") ? "\r\n" : "\n");
+}
+
+function rewriteTextFields(value, sanitize = stripThinking) {
+  if (!value || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map((entry) => rewriteTextFields(entry, sanitize));
+  const copy = { ...value };
+  for (const key of ["text", "delta"]) {
+    if (typeof copy[key] === "string") copy[key] = sanitize(copy[key]);
+  }
+  if (copy.item) copy.item = rewriteTextFields(copy.item, sanitize);
+  if (copy.part) copy.part = rewriteTextFields(copy.part, sanitize);
+  if (copy.output) copy.output = rewriteTextFields(copy.output, sanitize);
+  if (copy.content) copy.content = rewriteTextFields(copy.content, sanitize);
+  return copy;
+}
+
+export class MiniMaxResponsesCompatTransform extends Transform {
+  #decoder = new StringDecoder("utf8");
+  #buffer = "";
+  #insideThink = false;
+  #pending = "";
+
+  _transform(chunk, _encoding, callback) {
+    this.#buffer += this.#decoder.write(chunk);
+    this.#emit(false);
+    callback();
+  }
+
+  _flush(callback) {
+    this.#buffer += this.#decoder.end();
+    this.#emit(true);
+    callback();
+  }
+
+  #emit(flush) {
+    while (this.#buffer.length) {
+      const lf = this.#buffer.indexOf("\n\n");
+      if (lf === -1) {
+        if (!flush) return;
+        const block = this.#buffer;
+        this.#buffer = "";
+        this.push(Buffer.from(this.#rewrite(block)));
+        return;
+      }
+      const block = this.#buffer.slice(0, lf);
+      this.#buffer = this.#buffer.slice(lf + 2);
+      this.push(Buffer.from(`${this.#rewrite(block)}\n\n`));
+    }
+  }
+
+  #rewrite(block) {
+    const parsed = parseSseBlock(block);
+    if (!parsed) return block;
+    const next = rewriteTextFields(parsed.event, (text) => this.#consume(text));
+    return rewrite(block, parsed, next);
+  }
+
+  #consume(text) {
+    if (typeof text !== "string") return text;
+    let input = this.#pending + text;
+    this.#pending = "";
+    let output = "";
+    while (input) {
+      if (this.#insideThink) {
+        const close = input.search(/<\/think\s*>/i);
+        if (close === -1) return output;
+        input = input.slice(close).replace(/^<\/think\s*>/i, "");
+        this.#insideThink = false;
+        continue;
+      }
+      const open = input.search(/<think\b[^>]*>/i);
+      if (open === -1) {
+        const partial = input.match(/<\/?think\b[^>]*$/i)?.[0];
+        if (partial) {
+          this.#pending = partial;
+          return output + input.slice(0, -partial.length);
+        }
+        return output + input;
+      }
+      output += input.slice(0, open);
+      input = input.slice(open).replace(/^<think\b[^>]*>/i, "");
+      this.#insideThink = true;
+    }
+    return output;
+  }
+}
+
+export function minimaxResponsesCompatTransform(model, contentType = "") {
+  if (!isMiniMaxModel(model) || !contentType.toLowerCase().includes("text/event-stream")) {
+    return undefined;
+  }
+  return new MiniMaxResponsesCompatTransform();
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -32,6 +32,7 @@ import {
 } from "./http-utils.mjs";
 import { EmptyCompletionGuard } from "./empty-completion-guard.mjs";
 import { zaiResponsesCompatTransform } from "./zai-responses-compat.mjs";
+import { minimaxResponsesCompatTransform } from "./minimax-responses-compat.mjs";
 import {
   MERGED_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
@@ -2697,6 +2698,10 @@ async function handleResponses(request, response, requestUrl) {
         ? zaiResponsesCompatTransform(route.provider, contentType)
         : undefined;
       if (zaiCompat) transforms.push(zaiCompat);
+      const minimaxCompat = route
+        ? minimaxResponsesCompatTransform(route, contentType)
+        : undefined;
+      if (minimaxCompat) transforms.push(minimaxCompat);
       // Restore flattened namespace calls for routed chat-completions providers,
       // and inject missing finished-child interrupts for both routed and native
       // multi-agent parents (San Francisco uses native GPT).

--- a/test/minimax-responses-compat.test.mjs
+++ b/test/minimax-responses-compat.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { once } from "node:events";
+import test from "node:test";
+
+import { MiniMaxResponsesCompatTransform, minimaxResponsesCompatTransform } from "../src/minimax-responses-compat.mjs";
+
+async function transform(chunks) {
+  const stream = Readable.from(chunks).pipe(new MiniMaxResponsesCompatTransform());
+  const output = [];
+  stream.on("data", (chunk) => output.push(chunk));
+  await once(stream, "end");
+  return Buffer.concat(output).toString("utf8");
+}
+
+test("MiniMax Responses compatibility removes leaked think markup from deltas", async () => {
+  const result = await transform([
+    'data: {"type":"response.output_text.delta","delta":"<think>internal"}\n\n',
+    'data: {"type":"response.output_text.delta","delta":" reasoning</think>answer"}\n\n',
+  ]);
+  assert.match(result, /"delta":"answer"/);
+  assert.doesNotMatch(result, /internal|reasoning|<think>/);
+});
+
+test("MiniMax compatibility is scoped to MiniMax models", () => {
+  assert.ok(minimaxResponsesCompatTransform({ slug: "opencode-go-messages/minimax-m3" }, "text/event-stream"));
+  assert.equal(minimaxResponsesCompatTransform({ slug: "opencode-go/glm-5.2" }, "text/event-stream"), undefined);
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3275,6 +3275,7 @@ test("API forwarder routes MiniMax M3 streaming tool calls with adaptive thinkin
     assert.equal(request.body.stream, true);
     assert.equal(request.body.reasoning_effort, undefined);
     assert.deepEqual(request.body.thinking, { type: "adaptive" });
+    assert.equal(request.body.reasoning_split, true);
     assert.equal(request.body.tools[0].function.name, "get_weather");
     assert.deepEqual(request.body.tools[0].function.parameters.required, ["city"]);
   } finally {


### PR DESCRIPTION
## Summary

Prevent MiniMax M3 internal <think>...</think> reasoning from leaking into assistant-visible Responses text while keeping adaptive reasoning enabled.

The change is scoped to minimax-token-plan/minimax-m3.

## Root cause

MiniMax can return reasoning markup in the visible text channel. Restarting Codex does not restart the separately managed io.github.codex-router launchd service, so the installed process could continue running the old router code.

## Fix

- Keep MiniMax M3 adaptive thinking enabled and request split reasoning.
- Add a MiniMax-scoped Responses stream transform that removes <think>...</think> blocks, including tags split across SSE chunks.
- Preserve ordinary assistant text, tool calls, and follow-up routing.
- Add focused regression coverage and routing assertions.

## Verification

- node --test test/minimax-responses-compat.test.mjs — 2 passed
- node --test test/routing.test.mjs — 74 passed
- git diff --check
- Live io.github.codex-router restart: PID 47497, /health ok=true, degraded=[]
- Live MiniMax smoke request: HTTP 200, marker received
- Direct Responses visibility check: hasThink=false
- New MiniMax log entries after restart: status=200