### PR TITLE
fix(opencode-go): correct GLM-5.3 context and enable standalone search

### DIFF
--- a/config/opencode/go/glm-5.3.json
+++ b/config/opencode/go/glm-5.3.json
@@ -21,12 +21,15 @@
           "description": "Maximum reasoning depth"
         }
       ],
-      "contextWindow": 200000,
-      "autoCompact": 180000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-glm-5-3-v1"
+      "searchTool": {
+        "mode": "standalone"
+      },
+      "compHash": "opencode-go-glm-5-3-v2"
     }
   ]
 }

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -419,6 +419,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
   const standaloneSearchSlugs = new Set([
     "deepseek/deepseek-v4-flash",
     "opencode-go/deepseek-v4-flash",
+    "opencode-go/glm-5.3",
     "xiaomi-mimo/mimo-v2.5",
     "zai-coding/glm-5.3",
   ]);
@@ -537,6 +538,13 @@ test("DeepSeek V4 Flash routes opt in to Codex standalone web search", () => {
   ]) {
     assert.deepEqual(MODEL_BY_SLUG.get(slug)?.searchTool, { mode: "standalone" }, slug);
   }
+});
+
+test("GLM-5.3 on OpenCode Go exposes its 1M context and standalone search", () => {
+  const model = MODEL_BY_SLUG.get("opencode-go/glm-5.3");
+  assert.equal(model?.contextWindow, 1_000_000);
+  assert.equal(model?.autoCompact, 900_000);
+  assert.deepEqual(model?.searchTool, { mode: "standalone" });
 });
 
 test("GLM-5.3 Coding Plan opts in to GPT-5.6 behavior, concise execution, and standalone search", () => {


### PR DESCRIPTION
## Summary

- advertise the OpenCode Go GLM-5.3 route with its current 1M context window
- compact at 900K, matching the repository's other million-token routes
- enable Codex standalone tool discovery for this model
- bump the capability hash and add registry regression coverage

## Context sizing

The entry was originally added at 200K as a conservative fallback because the contemporaneous Z.ai documentation exposed 1M only through a `[1m]` suffix. OpenCode's current model metadata now maps `opencode-go/glm-5.3` to `zhipuai/glm-5.3`, whose published limit is 1,000,000 tokens. This change uses the exact provider-published 1M value rather than GLM-5.2's older 1,048,576 convention.

## Standalone tool discovery

On a tool-heavy Codex installation, a fresh trivial GLM-5.3 request reached the old declared 200K ceiling immediately because Codex eagerly included the direct tool/schema surface.

Local A/B through the installed router:

```text
before: estimatedInputTokens = 200000 (clamped)
after:  estimatedInputTokens = 48241
```

A deferred GitHub-tool workflow then stayed bounded:

```text
47362 -> 53550 -> 56096
```

The model successfully discovered and invoked the GitHub connector and returned the requested issue title in a live testing.

OpenCode reported `inputTokens = 0` on these turns, so the figures above are router estimates. The pre-change 200K value was clamped to the declared window, not an exact measurement.

## Verification

- live fresh-session A/B through OpenCode Go
- live deferred GitHub connector discovery and invocation
- registry regression coverage for:
  - `contextWindow = 1_000_000`
  - `autoCompact = 900_000`
  - `searchTool.mode = "standalone"`
- CI run #854 passed:
  - `npm run check`, `npm test`, and audit on Linux, macOS, and Windows
  - desktop checks and binary builds on Linux and Windows
  - Electron control-center checks, packaging, and platform smoke tests

OX-alpha and curated-model metadata are deliberately out of scope for this focused fix.