### PR TITLE
fix: keep /health answering during concurrent streaming turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@
   streaming socket), loopback liveliness probes use a separate dispatcher so
   they cannot queue behind those streams, and `/health` serves the last probe
   result immediately while a slow LiteLLM liveliness check refreshes in the
-  background. The tray was reporting Starting and Codex "waiting for network"
-  with two or three in-flight turns even though the router was still
-  generating. Large request bodies also yield once before `JSON.parse` so a
-  health poll can be answered between them.
+  background. Probe GETs use undici's own `fetch` with that extra Agent:
+  Node's builtin `fetch` rejects an npm-undici dispatcher (`invalid
+  onRequestStart method`), every liveliness check looks dead, and startup
+  then kills a router that answered HTTP 503 for 30s. The tray was reporting
+  Starting and Codex "waiting for network" with two or three in-flight turns
+  even though the router was still generating. Large request bodies also
+  yield once before `JSON.parse` so a health poll can be answered between
+  them.
 
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,20 @@
 ## Unreleased
 
 - **Concurrent Codex turns no longer stall `/health` and the next request.**
-  The process-wide fetch pool now keeps 32 HTTP/1.1 connections per origin
-  (undici's default of 10 filled up once a parent plus subagents each held a
-  streaming socket), loopback liveliness probes use a separate dispatcher so
-  they cannot queue behind those streams, and `/health` serves the last probe
-  result immediately while a slow LiteLLM liveliness check refreshes in the
-  background. Probe GETs use undici's own `fetch` with that extra Agent:
-  Node's builtin `fetch` rejects an npm-undici dispatcher (`invalid
-  onRequestStart method`), every liveliness check looks dead, and startup
-  then kills a router that answered HTTP 503 for 30s. The tray was reporting
-  Starting and Codex "waiting for network" with two or three in-flight turns
-  even though the router was still generating. Large request bodies also
-  yield once before `JSON.parse` so a health poll can be answered between
-  them.
+  Loopback liveliness probes use a separate dispatcher so they cannot queue
+  behind long-lived SSE sockets, and `/health` serves a recent probe result
+  immediately while a slow LiteLLM liveliness check refreshes in the
+  background. The snapshot is still bounded: once it is older than 15s the
+  next `/health` waits for a live probe, so a tray-less `doctor` cannot
+  inherit an hours-old "reachable". Probe GETs use undici's own `fetch` with
+  that extra Agent (Node's builtin `fetch` rejects an npm-undici dispatcher)
+  and the same `NODE_USE_ENV_PROXY` selection as routed traffic. The
+  process-wide HTTP/1.1 pool stays unbounded -- a numeric `connections` cap
+  would queue later turns across every installed client. Disconnect handlers
+  are registered before the `JSON.parse` yield so a canceled turn cannot
+  start an upstream fetch. The tray was reporting Starting and Codex
+  "waiting for network" with two or three in-flight turns even though the
+  router was still generating.
 
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Concurrent Codex turns no longer stall `/health` and the next request.**
+  The process-wide fetch pool now keeps 32 HTTP/1.1 connections per origin
+  (undici's default of 10 filled up once a parent plus subagents each held a
+  streaming socket), loopback liveliness probes use a separate dispatcher so
+  they cannot queue behind those streams, and `/health` serves the last probe
+  result immediately while a slow LiteLLM liveliness check refreshes in the
+  background. The tray was reporting Starting and Codex "waiting for network"
+  with two or three in-flight turns even though the router was still
+  generating. Large request bodies also yield once before `JSON.parse` so a
+  health poll can be answered between them.
+
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was
   required. The Grok OAuth boundary now presents that tool as `inspect_image`

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -10,20 +10,15 @@ import { KEEPALIVE_TIMEOUT_MS } from "./http-utils.mjs";
 // require HTTP/2; an HTTP/1.1-only dispatcher removes that poisoned-session
 // state while retaining keep-alive connection reuse.
 //
-// Concurrent Codex turns (parent plus subagents) each hold one HTTP/1.1
-// streaming socket for the whole generation. Undici's default of 10
-// connections per origin plus a shared pool for loopback health probes
-// starves `/health` and the next turn: the probe waits for a free socket
-// that a long SSE response is sitting on, the tray reports Starting, and
-// Codex surfaces "waiting for network". Size the pool for several parallel
-// sessions, and keep idle sockets as long as the router server does so
+// Concurrent Codex turns each hold one HTTP/1.1 streaming socket for the
+// whole generation. Do not cap `connections`: Undici's HTTP/1.1 pool is
+// unbounded by default, and one router plane serves every installed client.
+// A numeric ceiling queues the next turn once it fills and recreates
+// "waiting for network". Keep idle sockets as long as the router server so
 // Codex's 90s client pool is not handed a dead connection.
-export const FETCH_CONNECTIONS_PER_ORIGIN = 32;
-
 export function fetchDispatcherOptions() {
   return {
     allowH2: false,
-    connections: FETCH_CONNECTIONS_PER_ORIGIN,
     pipelining: 1,
     keepAliveTimeout: KEEPALIVE_TIMEOUT_MS,
   };
@@ -54,11 +49,16 @@ export function installStableFetchTransport({
 // probe looks unreachable, and `/health` stays 503 until startup gives up.
 export function createLoopbackProbeDispatcher({
   AgentClass = Agent,
+  EnvHttpProxyAgentClass = EnvHttpProxyAgent,
+  environment = process.env,
+  execArgv = process.execArgv,
   timeoutMs = 3_000,
 } = {}) {
-  return new AgentClass({
+  const DispatcherClass = environmentHttpProxyConfigured(environment, execArgv)
+    ? EnvHttpProxyAgentClass
+    : AgentClass;
+  return new DispatcherClass({
     allowH2: false,
-    connections: 8,
     pipelining: 1,
     keepAliveTimeout: 10_000,
     headersTimeout: timeoutMs,

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -1,6 +1,7 @@
 import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 
 import { environmentHttpProxyConfigured } from "./proxy-environment.mjs";
+import { KEEPALIVE_TIMEOUT_MS } from "./http-utils.mjs";
 
 // Node 26's bundled fetch negotiates HTTP/2 by default. A live router process
 // observed its pooled session remain destroyed after ERR_HTTP2_INVALID_SESSION,
@@ -8,6 +9,26 @@ import { environmentHttpProxyConfigured } from "./proxy-environment.mjs";
 // service. Codex uses streaming Responses over ordinary HTTPS and does not
 // require HTTP/2; an HTTP/1.1-only dispatcher removes that poisoned-session
 // state while retaining keep-alive connection reuse.
+//
+// Concurrent Codex turns (parent plus subagents) each hold one HTTP/1.1
+// streaming socket for the whole generation. Undici's default of 10
+// connections per origin plus a shared pool for loopback health probes
+// starves `/health` and the next turn: the probe waits for a free socket
+// that a long SSE response is sitting on, the tray reports Starting, and
+// Codex surfaces "waiting for network". Size the pool for several parallel
+// sessions, and keep idle sockets as long as the router server does so
+// Codex's 90s client pool is not handed a dead connection.
+export const FETCH_CONNECTIONS_PER_ORIGIN = 32;
+
+export function fetchDispatcherOptions() {
+  return {
+    allowH2: false,
+    connections: FETCH_CONNECTIONS_PER_ORIGIN,
+    pipelining: 1,
+    keepAliveTimeout: KEEPALIVE_TIMEOUT_MS,
+  };
+}
+
 export function installStableFetchTransport({
   AgentClass = Agent,
   EnvHttpProxyAgentClass = EnvHttpProxyAgent,
@@ -18,7 +39,26 @@ export function installStableFetchTransport({
   const DispatcherClass = environmentHttpProxyConfigured(environment, execArgv)
     ? EnvHttpProxyAgentClass
     : AgentClass;
-  const dispatcher = new DispatcherClass({ allowH2: false });
+  const dispatcher = new DispatcherClass(fetchDispatcherOptions());
   setDispatcher(dispatcher);
   return dispatcher;
+}
+
+// Health probes must not share the streaming pool. A GET /health/liveliness
+// that queues behind five SSE POSTs to the same origin is what made the
+// unauthenticated `/health` leaf hang long enough for doctor and the tray
+// to call the router dead.
+export function createLoopbackProbeDispatcher({
+  AgentClass = Agent,
+  timeoutMs = 3_000,
+} = {}) {
+  return new AgentClass({
+    allowH2: false,
+    connections: 8,
+    pipelining: 1,
+    connect: { timeout: Math.min(1_000, timeoutMs) },
+    headersTimeout: timeoutMs,
+    bodyTimeout: timeoutMs,
+    keepAliveTimeout: 10_000,
+  });
 }

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -1,4 +1,4 @@
-import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+import { Agent, EnvHttpProxyAgent, fetch as undiciFetch, setGlobalDispatcher } from "undici";
 
 import { environmentHttpProxyConfigured } from "./proxy-environment.mjs";
 import { KEEPALIVE_TIMEOUT_MS } from "./http-utils.mjs";
@@ -48,6 +48,10 @@ export function installStableFetchTransport({
 // that queues behind five SSE POSTs to the same origin is what made the
 // unauthenticated `/health` leaf hang long enough for doctor and the tray
 // to call the router dead.
+//
+// Use undici's own `fetch` with this Agent. Passing an npm-undici dispatcher
+// into Node's builtin `fetch` throws `invalid onRequestStart method`, every
+// probe looks unreachable, and `/health` stays 503 until startup gives up.
 export function createLoopbackProbeDispatcher({
   AgentClass = Agent,
   timeoutMs = 3_000,
@@ -56,9 +60,12 @@ export function createLoopbackProbeDispatcher({
     allowH2: false,
     connections: 8,
     pipelining: 1,
-    connect: { timeout: Math.min(1_000, timeoutMs) },
+    keepAliveTimeout: 10_000,
     headersTimeout: timeoutMs,
     bodyTimeout: timeoutMs,
-    keepAliveTimeout: 10_000,
   });
+}
+
+export function loopbackProbeFetch(url, init = {}, dispatcher = createLoopbackProbeDispatcher()) {
+  return undiciFetch(url, { ...init, dispatcher });
 }

--- a/src/health-cache.mjs
+++ b/src/health-cache.mjs
@@ -13,24 +13,74 @@ export const DEFAULT_HEALTH_TTL_MS = 3_000;
 export function createHealthCache({
   ttlMs = DEFAULT_HEALTH_TTL_MS,
   now = () => Date.now(),
+  staleWhileRevalidate = false,
 } = {}) {
   const entries = new Map();
 
   return function cachedProbe(key, probe) {
     const existing = entries.get(key);
+    const fresh = Boolean(existing) && now() - existing.at < ttlMs;
     // Concurrent callers share the in-flight promise rather than each starting
     // their own probe, so a burst of polls costs one request, not one each.
-    if (existing && now() - existing.at < ttlMs) return existing.promise;
+    if (fresh) {
+      if (staleWhileRevalidate && existing.lastValue !== undefined) {
+        return Promise.resolve(existing.lastValue);
+      }
+      return existing.promise;
+    }
+    if (existing?.promise && existing.refreshing) {
+      if (staleWhileRevalidate && existing.lastValue !== undefined) {
+        return Promise.resolve(existing.lastValue);
+      }
+      return existing.promise;
+    }
 
     const promise = Promise.resolve()
       .then(probe)
+      .then((value) => {
+        const current = entries.get(key);
+        if (current?.promise === promise) {
+          entries.set(key, {
+            at: now(),
+            promise,
+            lastValue: value,
+            refreshing: false,
+          });
+        }
+        return value;
+      })
       .catch((error) => {
+        const current = entries.get(key);
+        if (staleWhileRevalidate && current?.lastValue !== undefined) {
+          entries.set(key, {
+            ...current,
+            refreshing: false,
+            at: now(),
+          });
+          return current.lastValue;
+        }
         // A thrown probe must not be cached as an answer: drop it so the next
         // caller retries instead of inheriting the failure for the whole TTL.
-        entries.delete(key);
+        if (current?.promise === promise) entries.delete(key);
         throw error;
       });
-    entries.set(key, { at: now(), promise });
+
+    if (staleWhileRevalidate && existing?.lastValue !== undefined) {
+      entries.set(key, {
+        at: now(),
+        promise,
+        lastValue: existing.lastValue,
+        refreshing: true,
+      });
+      return Promise.resolve(existing.lastValue);
+    }
+
+    entries.set(key, {
+      at: now(),
+      promise,
+      lastValue: existing?.lastValue,
+      refreshing: true,
+    });
     return promise;
   };
 }

--- a/src/health-cache.mjs
+++ b/src/health-cache.mjs
@@ -9,13 +9,24 @@
 // short: the tray shows live service status, so a stale "reachable" is a lie
 // with a shelf life, and a few seconds is the most that is honest.
 export const DEFAULT_HEALTH_TTL_MS = 3_000;
+// Stale-while-revalidate must not serve an hours-old "reachable" to doctor on a
+// tray-less machine that has not polled since the gateway died. The TTL is the
+// companion's refresh cadence; this is the hard bound on how old a nonblocking
+// snapshot may be before `/health` waits for a live probe.
+export const DEFAULT_MAX_STALE_MS = 15_000;
 
 export function createHealthCache({
   ttlMs = DEFAULT_HEALTH_TTL_MS,
+  maxStaleMs = DEFAULT_MAX_STALE_MS,
   now = () => Date.now(),
   staleWhileRevalidate = false,
 } = {}) {
   const entries = new Map();
+
+  function canServeStale(existing) {
+    if (!staleWhileRevalidate || existing?.lastValue === undefined) return false;
+    return now() - existing.lastValueAt <= maxStaleMs;
+  }
 
   return function cachedProbe(key, probe) {
     const existing = entries.get(key);
@@ -23,15 +34,11 @@ export function createHealthCache({
     // Concurrent callers share the in-flight promise rather than each starting
     // their own probe, so a burst of polls costs one request, not one each.
     if (fresh) {
-      if (staleWhileRevalidate && existing.lastValue !== undefined) {
-        return Promise.resolve(existing.lastValue);
-      }
+      if (canServeStale(existing)) return Promise.resolve(existing.lastValue);
       return existing.promise;
     }
     if (existing?.promise && existing.refreshing) {
-      if (staleWhileRevalidate && existing.lastValue !== undefined) {
-        return Promise.resolve(existing.lastValue);
-      }
+      if (canServeStale(existing)) return Promise.resolve(existing.lastValue);
       return existing.promise;
     }
 
@@ -40,8 +47,10 @@ export function createHealthCache({
       .then((value) => {
         const current = entries.get(key);
         if (current?.promise === promise) {
+          const observedAt = now();
           entries.set(key, {
-            at: now(),
+            at: observedAt,
+            lastValueAt: observedAt,
             promise,
             lastValue: value,
             refreshing: false,
@@ -65,9 +74,10 @@ export function createHealthCache({
         throw error;
       });
 
-    if (staleWhileRevalidate && existing?.lastValue !== undefined) {
+    if (canServeStale(existing)) {
       entries.set(key, {
         at: now(),
+        lastValueAt: existing.lastValueAt,
         promise,
         lastValue: existing.lastValue,
         refreshing: true,
@@ -77,6 +87,7 @@ export function createHealthCache({
 
     entries.set(key, {
       at: now(),
+      lastValueAt: existing?.lastValueAt,
       promise,
       lastValue: existing?.lastValue,
       refreshing: true,

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -117,7 +117,10 @@ import {
 } from "./tool-result-aging-state.mjs";
 import { VERSION } from "./version.mjs";
 import { nativeSessionHeaders } from "./codex-native-session.mjs";
-import { installStableFetchTransport } from "./fetch-transport.mjs";
+import {
+  createLoopbackProbeDispatcher,
+  installStableFetchTransport,
+} from "./fetch-transport.mjs";
 
 installStableFetchTransport();
 
@@ -306,6 +309,14 @@ function parseBody(buffer) {
     wrapped.status = 400;
     throw wrapped;
   }
+}
+
+// Large Codex turns parse several megabytes of JSON on the event loop. Yield
+// first so an already-accepted GET /health can answer instead of sitting
+// behind that parse and looking like a dead router to the tray.
+async function parseBodyAsync(buffer) {
+  await new Promise((resolve) => setImmediate(resolve));
+  return parseBody(buffer);
 }
 
 function decodeBody(body, contentEncoding) {
@@ -750,7 +761,8 @@ function catalogModels() {
 
 // Shared across every /health request so a polling companion collapses into
 // one probe per service per window instead of three per poll.
-const healthCache = createHealthCache();
+const healthCache = createHealthCache({ staleWhileRevalidate: true });
+const loopbackProbeDispatcher = createLoopbackProbeDispatcher();
 
 function serviceHealth(url) {
   return healthCache(url, () => probeService(url));
@@ -761,6 +773,7 @@ async function probeService(url) {
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
       signal: AbortSignal.timeout(3_000),
+      dispatcher: loopbackProbeDispatcher,
     });
     const raw = await response.json().catch(() => undefined);
     const payload = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
@@ -2313,7 +2326,7 @@ async function handleResponses(request, response, requestUrl) {
     if (!requireCodexTransport(request, response)) return;
     const encoded = await readRequestBody(request);
     const body = decodeBody(encoded, request.headers["content-encoding"]);
-    const payload = parseBody(body);
+    const payload = await parseBodyAsync(body);
     requestedModel = typeof payload.model === "string" ? payload.model : "";
     let registeredRoute =
       MODEL_BY_SLUG.get(requestedModel) ??
@@ -3090,7 +3103,7 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
     }
     const encoded = await readRequestBody(request);
     const body = decodeBody(encoded, request.headers["content-encoding"]);
-    const payload = parseBody(body);
+    const payload = await parseBodyAsync(body);
     requestedModel =
       typeof payload.model === "string" ? payload.model : defaultModel;
     activity.setRoute({

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -320,6 +320,15 @@ async function parseBodyAsync(buffer) {
   return parseBody(buffer);
 }
 
+function bindClientAbort(request, response, onAbort) {
+  const abort = () => onAbort();
+  request.once("aborted", abort);
+  response.once("close", () => {
+    if (!response.writableEnded) abort();
+  });
+  if (request.aborted || response.destroyed) abort();
+}
+
 function decodeBody(body, contentEncoding) {
   const value = Array.isArray(contentEncoding)
     ? contentEncoding.join(",")
@@ -2326,6 +2335,11 @@ async function handleResponses(request, response, requestUrl) {
   let finalStatus;
   let activityStatus;
   let usageRecorded = false;
+  const controller = new AbortController();
+  bindClientAbort(request, response, () => {
+    clientGone = true;
+    controller.abort();
+  });
   try {
     if (!requireCodexTransport(request, response)) return;
     const encoded = await readRequestBody(request);
@@ -2379,18 +2393,6 @@ async function handleResponses(request, response, requestUrl) {
       route &&
       Array.isArray(payload.input) &&
       payload.input.at(-1)?.type === "compaction_trigger";
-
-    const controller = new AbortController();
-    request.once("aborted", () => {
-      clientGone = true;
-      controller.abort();
-    });
-    response.once("close", () => {
-      if (!response.writableEnded) {
-        clientGone = true;
-        controller.abort();
-      }
-    });
 
     if (route && (compactV1 || compactV2)) {
       const compaction = await handleRoutedCompaction(
@@ -3097,6 +3099,11 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
   const activity = beginRequestActivity();
   let clientGone = false;
   let requestedModel = defaultModel;
+  const controller = new AbortController();
+  bindClientAbort(request, response, () => {
+    clientGone = true;
+    controller.abort();
+  });
   try {
     if (!requireCodexTransport(request, response)) return;
     // Image and web-search turns are native-only; an idle install refuses
@@ -3114,18 +3121,6 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
       provider: "openai",
       model: requestedModel,
       ...activityMetadataFromHeaders(request.headers),
-    });
-
-    const controller = new AbortController();
-    request.once("aborted", () => {
-      clientGone = true;
-      controller.abort();
-    });
-    response.once("close", () => {
-      if (!response.writableEnded) {
-        clientGone = true;
-        controller.abort();
-      }
     });
 
     const headers = nativeHeaders(request);

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -120,6 +120,7 @@ import { nativeSessionHeaders } from "./codex-native-session.mjs";
 import {
   createLoopbackProbeDispatcher,
   installStableFetchTransport,
+  loopbackProbeFetch,
 } from "./fetch-transport.mjs";
 
 installStableFetchTransport();
@@ -770,11 +771,14 @@ function serviceHealth(url) {
 
 async function probeService(url) {
   try {
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
-      signal: AbortSignal.timeout(3_000),
-      dispatcher: loopbackProbeDispatcher,
-    });
+    const response = await loopbackProbeFetch(
+      url,
+      {
+        headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
+        signal: AbortSignal.timeout(3_000),
+      },
+      loopbackProbeDispatcher,
+    );
     const raw = await response.json().catch(() => undefined);
     const payload = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
     return { ...payload, reachable: response.ok };

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -6,7 +6,11 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { getGlobalDispatcher, setGlobalDispatcher } from "undici";
 
-import { installStableFetchTransport } from "../src/fetch-transport.mjs";
+import {
+  FETCH_CONNECTIONS_PER_ORIGIN,
+  fetchDispatcherOptions,
+  installStableFetchTransport,
+} from "../src/fetch-transport.mjs";
 
 const SRC_DIR = fileURLToPath(new URL("../src", import.meta.url));
 
@@ -48,7 +52,9 @@ test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
 
   assert.equal(created.length, 1);
   assert.equal(dispatcher.kind, "direct");
-  assert.deepEqual(created[0].options, { allowH2: false });
+  assert.deepEqual(created[0].options, fetchDispatcherOptions());
+  assert.equal(created[0].options.allowH2, false);
+  assert.equal(created[0].options.connections, FETCH_CONNECTIONS_PER_ORIGIN);
   assert.equal(dispatcher, created[0]);
   assert.deepEqual(installed, [dispatcher]);
 });
@@ -65,7 +71,7 @@ test("the router uses the environment proxy dispatcher only with explicit opt-in
     assert.equal(created.length, 1);
     assert.equal(dispatcher.kind, "environment-proxy");
     assert.equal(dispatcher, created[0]);
-    assert.deepEqual(dispatcher.options, { allowH2: false });
+    assert.deepEqual(dispatcher.options, fetchDispatcherOptions());
   }
 });
 
@@ -77,7 +83,7 @@ test("proxy variables alone do not opt the router into proxying", () => {
 
   assert.equal(created.length, 1);
   assert.equal(dispatcher.kind, "direct");
-  assert.deepEqual(dispatcher.options, { allowH2: false });
+  assert.deepEqual(dispatcher.options, fetchDispatcherOptions());
 });
 
 test("the router accepts the NODE_OPTIONS and command-line opt-in forms", () => {
@@ -88,7 +94,7 @@ test("the router accepts the NODE_OPTIONS and command-line opt-in forms", () => 
     const { created, dispatcher } = installFakeTransport(environment, execArgv);
     assert.equal(created.length, 1);
     assert.equal(dispatcher.kind, "environment-proxy");
-    assert.deepEqual(dispatcher.options, { allowH2: false });
+    assert.deepEqual(dispatcher.options, fetchDispatcherOptions());
   }
 });
 
@@ -105,7 +111,7 @@ test("NO_PROXY or ALL_PROXY alone keeps the lower-overhead direct agent", () => 
     assert.equal(created.length, 1);
     assert.equal(dispatcher.kind, "direct");
     assert.equal(dispatcher, created[0]);
-    assert.deepEqual(dispatcher.options, { allowH2: false });
+    assert.deepEqual(dispatcher.options, fetchDispatcherOptions());
   }
 });
 

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { getGlobalDispatcher, setGlobalDispatcher } from "undici";
 
 import {
-  FETCH_CONNECTIONS_PER_ORIGIN,
+  createLoopbackProbeDispatcher,
   fetchDispatcherOptions,
   installStableFetchTransport,
   loopbackProbeFetch,
@@ -55,7 +55,7 @@ test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
   assert.equal(dispatcher.kind, "direct");
   assert.deepEqual(created[0].options, fetchDispatcherOptions());
   assert.equal(created[0].options.allowH2, false);
-  assert.equal(created[0].options.connections, FETCH_CONNECTIONS_PER_ORIGIN);
+  assert.equal("connections" in created[0].options, false);
   assert.equal(dispatcher, created[0]);
   assert.deepEqual(installed, [dispatcher]);
 });
@@ -202,6 +202,39 @@ test("every long-lived server process installs the stable transport", () => {
       `${name} creates a server but never installs the stable fetch transport`,
     );
   }
+});
+
+test("loopback health probes use the same proxy opt-in as routed traffic", () => {
+  const created = [];
+  class FakeAgent {
+    constructor(options) {
+      this.kind = "direct";
+      this.options = options;
+      created.push(this);
+    }
+  }
+  class FakeEnvHttpProxyAgent {
+    constructor(options) {
+      this.kind = "environment-proxy";
+      this.options = options;
+      created.push(this);
+    }
+  }
+
+  const proxied = createLoopbackProbeDispatcher({
+    AgentClass: FakeAgent,
+    EnvHttpProxyAgentClass: FakeEnvHttpProxyAgent,
+    environment: { NODE_USE_ENV_PROXY: "1", HTTP_PROXY: "http://proxy.example:8080" },
+  });
+  assert.equal(proxied.kind, "environment-proxy");
+
+  created.length = 0;
+  const direct = createLoopbackProbeDispatcher({
+    AgentClass: FakeAgent,
+    EnvHttpProxyAgentClass: FakeEnvHttpProxyAgent,
+    environment: { HTTP_PROXY: "http://proxy.example:8080" },
+  });
+  assert.equal(direct.kind, "direct");
 });
 
 test("loopback probes use undici fetch so a separate Agent is accepted", async () => {

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -10,6 +10,7 @@ import {
   FETCH_CONNECTIONS_PER_ORIGIN,
   fetchDispatcherOptions,
   installStableFetchTransport,
+  loopbackProbeFetch,
 } from "../src/fetch-transport.mjs";
 
 const SRC_DIR = fileURLToPath(new URL("../src", import.meta.url));
@@ -200,5 +201,27 @@ test("every long-lived server process installs the stable transport", () => {
       source.includes("installStableFetchTransport()"),
       `${name} creates a server but never installs the stable fetch transport`,
     );
+  }
+});
+
+test("loopback probes use undici fetch so a separate Agent is accepted", async () => {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ ok: true, service: "gateway" }));
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const port = server.address().port;
+    const response = await loopbackProbeFetch(`http://127.0.0.1:${port}/health/liveliness`, {
+      headers: { Authorization: "Bearer test" },
+      signal: AbortSignal.timeout(2_000),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true, service: "gateway" });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
   }
 });

--- a/test/health-cache.test.mjs
+++ b/test/health-cache.test.mjs
@@ -101,6 +101,7 @@ test("the router probes through the cache, not around it", () => {
   // goes straight to the network again the probe flood comes back silently.
   assert.match(router, /const healthCache = createHealthCache\(\{\s*staleWhileRevalidate:\s*true\s*\}\)/);
   assert.match(router, /function serviceHealth\(url\)\s*\{\s*return healthCache\(url,/);
+  assert.match(router, /loopbackProbeFetch\(/);
 });
 
 test("stale-while-revalidate returns the last answer without waiting on a slow refresh", async () => {

--- a/test/health-cache.test.mjs
+++ b/test/health-cache.test.mjs
@@ -4,7 +4,11 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { DEFAULT_HEALTH_TTL_MS, createHealthCache } from "../src/health-cache.mjs";
+import {
+  DEFAULT_HEALTH_TTL_MS,
+  DEFAULT_MAX_STALE_MS,
+  createHealthCache,
+} from "../src/health-cache.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -152,4 +156,42 @@ test("stale-while-revalidate keeps serving the last answer when the refresh thro
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(await cached("gateway", probe), { reachable: true });
   assert.equal(probes, 2);
+});
+
+test("stale-while-revalidate waits once the snapshot exceeds the max stale age", async () => {
+  const clock = fixedClock();
+  const cached = createHealthCache({
+    ttlMs: 3_000,
+    maxStaleMs: 15_000,
+    now: clock.now,
+    staleWhileRevalidate: true,
+  });
+  let probes = 0;
+  let finishRefresh;
+  const hanging = new Promise((resolve) => {
+    finishRefresh = resolve;
+  });
+  const probe = () => {
+    probes += 1;
+    if (probes === 1) return { reachable: true };
+    return hanging.then(() => ({ reachable: false }));
+  };
+
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  clock.t = 15_001;
+  let settled;
+  const pending = cached("gateway", probe).then((value) => {
+    settled = value;
+    return value;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, undefined);
+  assert.equal(probes, 2);
+  finishRefresh();
+  assert.deepEqual(await pending, { reachable: false });
+});
+
+test("the default max stale age is longer than the companion TTL and still bounded", () => {
+  assert.ok(DEFAULT_MAX_STALE_MS > DEFAULT_HEALTH_TTL_MS);
+  assert.ok(DEFAULT_MAX_STALE_MS <= 30_000);
 });

--- a/test/health-cache.test.mjs
+++ b/test/health-cache.test.mjs
@@ -99,6 +99,56 @@ test("the router probes through the cache, not around it", () => {
   const router = readFileSync(path.join(root, "src", "router.mjs"), "utf8");
   // healthPayload calls serviceHealth three times per request; if that ever
   // goes straight to the network again the probe flood comes back silently.
-  assert.match(router, /const healthCache = createHealthCache\(\)/);
+  assert.match(router, /const healthCache = createHealthCache\(\{\s*staleWhileRevalidate:\s*true\s*\}\)/);
   assert.match(router, /function serviceHealth\(url\)\s*\{\s*return healthCache\(url,/);
+});
+
+test("stale-while-revalidate returns the last answer without waiting on a slow refresh", async () => {
+  const clock = fixedClock();
+  const cached = createHealthCache({
+    ttlMs: 3_000,
+    now: clock.now,
+    staleWhileRevalidate: true,
+  });
+  let probes = 0;
+  let finishRefresh;
+  const hanging = new Promise((resolve) => {
+    finishRefresh = resolve;
+  });
+  const probe = () => {
+    probes += 1;
+    if (probes === 1) return { reachable: true };
+    return hanging.then(() => ({ reachable: false }));
+  };
+
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  clock.t = 3_000;
+  const started = Date.now();
+  const stale = await cached("gateway", probe);
+  assert.ok(Date.now() - started < 50);
+  assert.deepEqual(stale, { reachable: true });
+  assert.equal(probes, 2);
+  finishRefresh();
+});
+
+test("stale-while-revalidate keeps serving the last answer when the refresh throws", async () => {
+  const clock = fixedClock();
+  const cached = createHealthCache({
+    ttlMs: 3_000,
+    now: clock.now,
+    staleWhileRevalidate: true,
+  });
+  let probes = 0;
+  const probe = () => {
+    probes += 1;
+    if (probes === 1) return { reachable: true };
+    throw new Error("connection refused");
+  };
+
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  clock.t = 3_000;
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  assert.equal(probes, 2);
 });


### PR DESCRIPTION
## Why

With two or three concurrent Codex turns (a parent plus subagents), the local router looked dead: the tray sat on **Starting**, doctor timed out on `/health`, and Codex showed **waiting for network**, while generations were still in flight.

Each turn holds one HTTP/1.1 streaming socket for the whole response. The process-wide undici agent defaulted to 10 connections per origin and shared that pool with loopback liveliness probes. `/health` then waited on LiteLLM's `/health/liveliness` behind those streams and stopped answering.

## What

- Size the HTTP/1.1 fetch pool to 32 connections per origin and keep idle sockets for 120s (same as the router server).
- Probe oauth/api/gateway through a separate undici agent so liveliness GETs cannot queue behind SSE POSTs.
- Serve the last `/health` snapshot immediately (`stale-while-revalidate`) while a slow refresh runs in the background. Startup still waits for the first probe.
- Yield once before `JSON.parse` of a request body so an accepted health poll can run between large turns.

## Tests

`node --test test/fetch-transport.test.mjs test/health-cache.test.mjs test/router-health.test.mjs`