### PR TITLE
feat: add new deepseek model

### DIFF
--- a/config/deepseek/deepseek-v4-flash-vision-exp.json
+++ b/config/deepseek/deepseek-v4-flash-vision-exp.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "deepseek/deepseek-v4-flash-vision-exp",
+      "gatewayModel": "deepseek-v4-flash-vision-exp",
+      "upstreamModel": "deepseek-v4-flash-vision-exp",
+      "provider": "deepseek",
+      "listed": true,
+      "displayName": "DeepSeek V4 Flash Vision Exp (API)",
+      "description": "DeepSeek V4 Flash Vision Exp via the DeepSeek API; fast reasoning, image understanding, tool calls, and a 1M context window.",
+      "priority": 6,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning for complex agent work"
+        }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 900000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "searchTool": {
+        "mode": "standalone"
+      },
+      "requestProfile": "deepseek-thinking",
+      "supportsReasoningSummaries": true,
+      "compHash": "deepseek-v4-flash-vision-exp-v1"
+    }
+  ]
+}


### PR DESCRIPTION
## Why

DeepSeek shipped `deepseek-v4-flash-vision-exp`, a vision-capable model that accepts text and image input with a 1M-token context window at the same price as `deepseek-v4-flash`. The router registry had no entry for it, so it could not be selected in Codex.

## What

- Add `config/deepseek/deepseek-v4-flash-vision-exp.json`, modeled on the existing `deepseek-v4-flash.json` entry.
- `slug` / `gatewayModel` / `upstreamModel` are all `deepseek/deepseek-v4-flash-vision-exp`, preserving the `-exp` suffix end to end.
- Declare `inputModalities: ["text", "image"]` to enable image understanding.
- Use `requestProfile: deepseek-thinking` with a 1M context window and reasoning support, matching the official model page.

## Tests

`node --test test/catalog.test.mjs test/model-failover.test.mjs`