### PR TITLE
fix(linux): prefer bundled desktop Codex CLI

### DIFF
--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -9,13 +9,27 @@ import { commandOnPath, preferSpawnablePath, spawnableCommand } from "./spawnabl
 
 export { preferSpawnablePath, spawnableCommand };
 
+const LINUX_DESKTOP_APP_ROOTS = ["/opt/codex-desktop"];
+
+export function linuxDesktopAppBundledCodex({
+  platform = process.platform,
+  roots = LINUX_DESKTOP_APP_ROOTS,
+} = {}) {
+  if (platform !== "linux") return undefined;
+  return roots
+    .map((root) => path.join(root, "resources", "codex"))
+    .find((candidate) => existsSync(candidate) && !isShimFile(candidate));
+}
+
 // The ChatGPT/Codex desktop app bundles its CLI under a version-hashed
 // directory, e.g. %LOCALAPPDATA%\OpenAI\Codex\bin\<hash>\codex.exe. That hash
 // changes on every app update, so scan for the newest installed version
 // instead of pinning a single path.
-function desktopAppBundledCodex() {
-  if (process.platform !== "win32") return undefined;
-  const localAppData = process.env.LOCALAPPDATA;
+function desktopAppBundledCodex({
+  platform = process.platform,
+  localAppData = process.env.LOCALAPPDATA,
+} = {}) {
+  if (platform !== "win32") return undefined;
   if (!localAppData) return undefined;
   const binDir = path.join(localAppData, "OpenAI", "Codex", "bin");
   if (!existsSync(binDir)) return undefined;
@@ -30,25 +44,34 @@ function desktopAppBundledCodex() {
   }
 }
 
-function candidates() {
-  const localAppData = process.env.LOCALAPPDATA;
+export function codexCandidatePaths({
+  platform = process.platform,
+  localAppData = process.env.LOCALAPPDATA,
+  home = os.homedir(),
+  linuxDesktopRoots,
+} = {}) {
   return [
     process.env.CODEX_BIN,
     process.env.CODEX_INSTALL_DIR &&
       path.join(
         process.env.CODEX_INSTALL_DIR,
-        process.platform === "win32" ? "codex.exe" : "codex",
+        platform === "win32" ? "codex.exe" : "codex",
       ),
     "/Applications/ChatGPT.app/Contents/Resources/codex",
     "/Applications/Codex.app/Contents/Resources/codex",
     "/opt/homebrew/bin/codex",
+    linuxDesktopAppBundledCodex({ platform, roots: linuxDesktopRoots }),
     "/usr/local/bin/codex",
     localAppData && path.join(localAppData, "Programs", "OpenAI", "Codex", "bin", "codex.exe"),
     localAppData && path.join(localAppData, "Programs", "Codex", "resources", "codex.exe"),
     localAppData && path.join(localAppData, "Programs", "Codex", "resources", "app", "bin", "codex.exe"),
-    desktopAppBundledCodex(),
-    path.join(os.homedir(), ".local", "bin", process.platform === "win32" ? "codex.exe" : "codex"),
+    desktopAppBundledCodex({ platform, localAppData }),
+    path.join(home, ".local", "bin", platform === "win32" ? "codex.exe" : "codex"),
   ].filter(Boolean);
+}
+
+function candidates() {
+  return codexCandidatePaths();
 }
 
 // The router must never resolve `codex` to the shim it installs in front of it.

--- a/test/codex-binary.test.mjs
+++ b/test/codex-binary.test.mjs
@@ -4,7 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { findCodexBinary, preferSpawnablePath, spawnableCommand } from "../src/codex-binary.mjs";
+import {
+  codexCandidatePaths,
+  findCodexBinary,
+  linuxDesktopAppBundledCodex,
+  preferSpawnablePath,
+  spawnableCommand,
+} from "../src/codex-binary.mjs";
 
 // Reported in #46: `where.exe codex` on an npm global install lists the
 // extensionless POSIX shim before the batch shim. Node cannot spawn the former
@@ -52,6 +58,24 @@ test("ignores blank lines in finder output", () => {
 test("returns undefined for empty finder output", () => {
   assert.equal(preferSpawnablePath([], "win32"), undefined);
   assert.equal(preferSpawnablePath(["", "   "], "darwin"), undefined);
+});
+
+test("prefers the Linux desktop app's bundled CLI over a standalone CLI", () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-linux-desktop-cli-"));
+  const bundled = path.join(testRoot, "resources", "codex");
+  mkdirSync(path.dirname(bundled), { recursive: true });
+  writeFileSync(bundled, "");
+
+  try {
+    assert.equal(
+      linuxDesktopAppBundledCodex({ platform: "linux", roots: [testRoot] }),
+      bundled,
+    );
+    const candidates = codexCandidatePaths({ platform: "linux", linuxDesktopRoots: [testRoot] });
+    assert.ok(candidates.indexOf(bundled) < candidates.indexOf("/usr/local/bin/codex"));
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
 });
 
 test("a Windows batch shim runs through cmd.exe with its path escaped", () => {


### PR DESCRIPTION
## Problem

On Linux desktop installations, the active Codex CLI can be bundled inside the app payload at `/opt/codex-desktop/resources/codex`. The resolver currently checks `/usr/local/bin/codex` before the desktop payload, so an older standalone CLI can mask the binary shipped with the running desktop app. Catalog and version probes then run against a different Codex build and may produce incompatible metadata or report the wrong installation state.

## Change

- discover the Linux desktop payload CLI at the stable app path;
- keep it ahead of the standalone `/usr/local/bin/codex` fallback;
- make candidate ordering deterministic and testable;
- preserve `CODEX_BIN` as the explicit override.

## Verification

- `npm run check`
- `node --test test/codex-binary.test.mjs test/catalog.test.mjs test/native-catalog-source.test.mjs test/codex-maintenance.test.mjs`
  - 78 passed, 1 skipped (Windows-only)
- live Linux resolution selected `/opt/codex-desktop/resources/codex` ahead of `/usr/local/bin/codex`
- `npm test` was also run with isolated HOME/XDG directories: 2,042 passed, 8 pre-existing environment-sensitive failures in configuration ownership and control-center source-root tests, unrelated to this diff

## Scope

This change is limited to Linux Codex binary discovery and regression coverage.