### PR TITLE
fix: stop quota retry storms

### DIFF
--- a/src/litellm-config.mjs
+++ b/src/litellm-config.mjs
@@ -79,6 +79,16 @@ export function renderLiteLlmConfig() {
     // fix a rejected credential. Relay the provider's real status instead.
     "router_settings:",
     "  disable_cooldowns: true",
+    // Z.ai Coding Plan reports a five-hour account quota as HTTP 429. LiteLLM
+    // otherwise retries that same exhausted plan twice before the outer router
+    // can inspect the provider body and classify it as out_of_usage. Scope the
+    // override to Coding Plan model groups only: pay-per-token Z.ai and every
+    // other provider retain LiteLLM's normal transient rate-limit behavior.
+    "  model_group_retry_policy:",
+    ...MODELS.filter(({ provider }) => provider === "zai-coding").flatMap((model) => [
+      `    ${model.gatewayModel}:`,
+      "      RateLimitErrorRetries: 0",
+    ]),
     "",
     "general_settings:",
     "  disable_spend_logs: true",

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1149,6 +1149,42 @@ function visionEngineProvider(engine) {
 // refusal again.
 const visionReadsInFlight = new Map();
 
+// A provider can report account quota exhaustion without a trustworthy reset
+// header. Do not invent a provider cooldown in that case, but also do not buy
+// the exact same failed image read again on every rapid follow-up turn. This is
+// deliberately a short, per-read anti-storm backoff rather than a claim about
+// when the provider quota resets. Provider-named reset windows still use the
+// durable cooldown store below.
+const VISION_FAILURE_BACKOFF_MS = 60_000;
+const VISION_FAILURE_CACHE_MAX_ENTRIES = 128;
+const visionFailedReads = new Map();
+
+function visionFailureCacheKey(readKey) {
+  return createHash("sha256").update(readKey).digest("base64url");
+}
+
+function cachedVisionFailure(readKey, now = Date.now()) {
+  const cacheKey = visionFailureCacheKey(readKey);
+  const cached = visionFailedReads.get(cacheKey);
+  if (!cached) return undefined;
+  if (cached.expiresAt > now) return cached.error;
+  visionFailedReads.delete(cacheKey);
+  return undefined;
+}
+
+function rememberVisionFailure(readKey, error, now = Date.now()) {
+  // A reset-bearing 429 is handled by providerCooldown(), which is broader and
+  // more accurate. The negative cache exists only for quota exhaustion where
+  // the provider named no usable reset window.
+  if (error?.failureKind !== "out_of_usage" || error?.cooldownUntil) return;
+  const cacheKey = visionFailureCacheKey(readKey);
+  visionFailedReads.delete(cacheKey);
+  visionFailedReads.set(cacheKey, { error, expiresAt: now + VISION_FAILURE_BACKOFF_MS });
+  while (visionFailedReads.size > VISION_FAILURE_CACHE_MAX_ENTRIES) {
+    visionFailedReads.delete(visionFailedReads.keys().next().value);
+  }
+}
+
 // Codex resends the whole conversation every turn, so the same screenshot
 // arrives again on every follow-up. Without the hash cache a five-turn
 // conversation about one image would buy the same transcript five times.
@@ -1179,6 +1215,8 @@ async function visionEvidenceFor(url, engine, request, effort, question = "", re
   // record of spend, not of calls the router avoided.
   if (cached !== undefined) return cached;
   const readKey = `${key}\u0000${question}`;
+  const failed = cachedVisionFailure(readKey);
+  if (failed) throw failed;
   const running = visionReadsInFlight.get(readKey);
   if (running) return running;
   // Deliberately not tied to the caller's AbortSignal. The read is shared, so
@@ -1190,6 +1228,9 @@ async function visionEvidenceFor(url, engine, request, effort, question = "", re
   visionReadsInFlight.set(readKey, read);
   try {
     return await read;
+  } catch (error) {
+    rememberVisionFailure(readKey, error);
+    throw error;
   } finally {
     visionReadsInFlight.delete(readKey);
   }
@@ -1219,6 +1260,22 @@ async function readVisionEvidence({ url, engine, nativeCall, effort, question, k
     });
     status = 200;
     return evidenceCache.set(key, question, text);
+  } catch (error) {
+    const errorStatus = Number(error?.status);
+    if (Number.isFinite(errorStatus)) status = errorStatus;
+    const reason =
+      error?.failureKind === "out_of_usage"
+        ? "out_of_usage"
+        : errorStatus === 429 && error?.cooldownUntil
+          ? "rate_limited"
+          : undefined;
+    if (reason && error?.cooldownUntil) {
+      recordProviderCooldown(visionEngineProvider(engine), {
+        until: error.cooldownUntil,
+        reason,
+      });
+    }
+    throw error;
   } finally {
     recordUsageEvent({
       model: engine.slug,
@@ -1396,12 +1453,26 @@ async function bridgeVisionInput(input, route, request) {
   }
   const { effort } = settings;
   let fellBack = 0;
+  // A quota exhaustion is account/provider-wide evidence, not a reason to walk
+  // every model slug backed by that same account. Keep this set scoped to the
+  // current bridge call when the provider did not name a reset window; that
+  // avoids duplicate spend without inventing how long the quota will stay
+  // empty. A provider-named window is persisted by readVisionEvidence instead.
+  const exhaustedProviders = new Set();
   // Each engine in turn until one reads the image. The first is the operator's
   // choice and answers nearly always; the rest exist so a lapsed session or a
   // provider outage costs a slower read rather than the whole image.
   const readWithAnyEngine = async (url, question) => {
     let lastError;
     for (const [index, engine] of engines.entries()) {
+      const provider = canonicalProviderId(visionEngineProvider(engine));
+      const cooled = providerCooldown(provider);
+      if (cooled || exhaustedProviders.has(provider)) {
+        lastError ??= new Error(
+          `${engine.displayName || engine.slug} is temporarily unavailable because its provider reported a quota or rate limit`,
+        );
+        continue;
+      }
       // Retry the engine only when there is nothing else to try. Waiting out a
       // 250ms + 1s ladder against an endpoint that is down, when a working
       // engine is sitting right behind it, is how a fallback that works turns
@@ -1421,6 +1492,7 @@ async function bridgeVisionInput(input, route, request) {
         return { text, engineName: engine.displayName || engine.slug };
       } catch (error) {
         lastError = error;
+        if (error?.failureKind === "out_of_usage") exhaustedProviders.add(provider);
       }
     }
     // Every engine refused, so the turn says what the last one said -- the

--- a/src/vision-bridge.mjs
+++ b/src/vision-bridge.mjs
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
 
+import { upstreamFailureKind } from "./error-translation.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
+import { cooldownUntil, parseRateLimitHeaders } from "./rate-limit-headers.mjs";
 
 // A text-only model cannot read a pasted screenshot, so the router reads it on
 // the model's behalf: every image part is sent to a vision-capable model the
@@ -964,7 +966,23 @@ function isTransientError(error) {
   return !["TimeoutError", "AbortError"].includes(error?.name);
 }
 
-class TransientVisionError extends Error {}
+export class VisionUpstreamError extends Error {
+  constructor(message, { status, failureKind, cooldownUntil: until, retryable = false } = {}) {
+    super(message);
+    this.name = "VisionUpstreamError";
+    this.status = Number.isFinite(Number(status)) ? Number(status) : undefined;
+    this.failureKind = failureKind;
+    this.cooldownUntil = until;
+    this.retryable = retryable;
+  }
+}
+
+class TransientVisionError extends VisionUpstreamError {
+  constructor(message, metadata = {}) {
+    super(message, { ...metadata, retryable: true });
+    this.name = "TransientVisionError";
+  }
+}
 
 export async function describeImage({
   engine,
@@ -1000,11 +1018,12 @@ export async function describeImage({
         timeoutMs,
       });
     } catch (error) {
-      if (!(error instanceof TransientVisionError)) throw error;
+      if (error?.retryable !== true) throw error;
       lastTransient = error;
     }
   }
-  throw new Error(lastTransient?.message || `${engine.displayName || engine.slug} could not be reached`);
+  if (lastTransient) throw lastTransient;
+  throw new Error(`${engine.displayName || engine.slug} could not be reached`);
 }
 
 async function attemptDescribe({
@@ -1047,10 +1066,25 @@ async function attemptDescribe({
   }
   if (!upstream.ok) {
     // Never echo the gateway body: it can carry provider error text that names
-    // credential state.
+    // credential state. It is still safe to classify that text locally so an
+    // exhausted account is not mistaken for a one-second burst limit.
     const message = `${engine.displayName || engine.slug} answered HTTP ${upstream.status}`;
-    if (isTransientStatus(upstream.status)) throw new TransientVisionError(message);
-    throw new Error(message);
+    const bodyText = bytes.toString("utf8");
+    const failureKind = upstreamFailureKind({ status: upstream.status, bodyText });
+    const rateLimit = upstream.status === 429 ? parseRateLimitHeaders(upstream.headers) : undefined;
+    const until = cooldownUntil(rateLimit);
+    const metadata = {
+      status: upstream.status,
+      failureKind,
+      ...(until ? { cooldownUntil: until } : {}),
+    };
+    const retryable =
+      isTransientStatus(upstream.status) &&
+      failureKind !== "out_of_usage" &&
+      failureKind !== "entitlement" &&
+      !until;
+    if (retryable) throw new TransientVisionError(message, metadata);
+    throw new VisionUpstreamError(message, metadata);
   }
   let text;
   try {

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -65,6 +65,17 @@ test("classifyRoutedFailure swaps on OpenCode FreeUsageLimitError", () => {
   assert.deepEqual(verdict, { swap: true, reason: "out_of_usage" });
 });
 
+test("classifyRoutedFailure recognizes the observed Z.ai five-hour window message", () => {
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaBody(
+      "Usage limit reached for 5 hour. Your limit will reset at 2026-08-21 04:40:42.",
+    ),
+    now: NOW,
+  });
+  assert.deepEqual(verdict, { swap: true, reason: "out_of_usage" });
+});
+
 test("classifyRoutedFailure swaps on 402 whatever the body says", () => {
   const verdict = classifyRoutedFailure({ status: 402, bodyText: "{}", now: NOW });
   assert.deepEqual(verdict, { swap: true, reason: "out_of_usage" });

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -650,6 +650,19 @@ test("the gateway config disables deployment cooldowns", () => {
   assert.equal(new Set(names).size, names.length, "one deployment per model_name");
 });
 
+test("only Z.ai Coding Plan model groups disable LiteLLM rate-limit retries", () => {
+  const rendered = renderLiteLlmConfig();
+  for (const model of MODELS.filter(({ provider }) => provider === "zai-coding")) {
+    assert.match(
+      rendered,
+      new RegExp(`${model.gatewayModel}:\\n\\s+RateLimitErrorRetries: 0`),
+      model.slug,
+    );
+  }
+  assert.doesNotMatch(rendered, /^  retry_policy:/m);
+  assert.doesNotMatch(rendered, /zai-api-glm-5-3:\n\s+RateLimitErrorRetries: 0/);
+});
+
 test("LiteLLM configuration is generated from every registry route", () => {
   const rendered = renderLiteLlmConfig();
   for (const model of MODELS) {

--- a/test/vision-bridge.test.mjs
+++ b/test/vision-bridge.test.mjs
@@ -822,6 +822,68 @@ test("a read that fails transiently is asked again; a refusal is not", async () 
   assert.equal(attempts, 3);
 });
 
+test("a quota-window 429 is not retried and keeps only safe routing metadata", async () => {
+  let calls = 0;
+  const observedAt = Date.now();
+  await assert.rejects(
+    describeImage({
+      engine: FLASH_VISION,
+      imageUrl: "data:image/png;base64,AAAA",
+      gatewayBase: "http://127.0.0.1:4100/v1",
+      headers: {},
+      retryDelaysMs: [1, 1],
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response(
+          JSON.stringify({
+            error: {
+              message:
+                "Usage limit reached for 5 hour. Your limit will reset later. secret-body-marker",
+            },
+          }),
+          { status: 429, headers: { "Retry-After": "600" } },
+        );
+      },
+    }),
+    (error) => {
+      assert.equal(error.message, "Qwen3.6 Flash answered HTTP 429");
+      assert.equal(error.status, 429);
+      assert.equal(error.failureKind, "out_of_usage");
+      assert.ok(Date.parse(error.cooldownUntil) >= observedAt + 599_000);
+      assert.doesNotMatch(error.message, /secret-body-marker|Usage limit reached/);
+      return true;
+    },
+  );
+  assert.equal(calls, 1, "a known exhausted quota must not spend the retry ladder");
+});
+
+test("an explicit rate-limit reset is not retried on the same vision engine", async () => {
+  let calls = 0;
+  await assert.rejects(
+    describeImage({
+      engine: FLASH_VISION,
+      imageUrl: "data:image/png;base64,AAAA",
+      gatewayBase: "http://127.0.0.1:4100/v1",
+      headers: {},
+      retryDelaysMs: [1, 1],
+      fetchImpl: async () => {
+        calls += 1;
+        return new Response(JSON.stringify({ error: { message: "Too many requests" } }), {
+          status: 429,
+          headers: { "Retry-After": "120" },
+        });
+      },
+    }),
+    (error) => {
+      assert.equal(error.status, 429);
+      assert.equal(error.failureKind, undefined);
+      assert.ok(error.cooldownUntil);
+      return true;
+    },
+  );
+  assert.equal(calls, 1, "a provider-named reset must be honored instead of blind retrying");
+});
+
 // A slow engine is not retried: the per-attempt budget is already two minutes,
 // and spending another two turns one late answer into a turn that never ends.
 test("a timeout is reported rather than tried again", async () => {
@@ -1549,6 +1611,38 @@ test("a bridged read is recorded rather than spent silently", async () => {
 // The list only helps if the read path actually walks it. Asserted against the
 // source because the loop lives inside the request handler, the same way the
 // QUIET and usage-event rules above are asserted.
+test("the router remembers provider quota evidence and skips sibling vision engines", async () => {
+  const source = await readFile(path.join(repoRoot, "src/router.mjs"), "utf8");
+  const evidence = source.slice(
+    source.indexOf("async function readVisionEvidence"),
+    source.indexOf("// DeepSeek thinking mode"),
+  );
+  assert.match(evidence, /const errorStatus = Number\(error\?\.status\)/);
+  assert.match(evidence, /recordProviderCooldown\(visionEngineProvider\(engine\)/);
+  assert.match(source, /const VISION_FAILURE_BACKOFF_MS = 60_000/);
+  assert.match(source, /const visionFailedReads = new Map\(\)/);
+  assert.match(source, /function visionFailureCacheKey\(readKey\)/);
+  assert.match(source, /createHash\("sha256"\)\.update\(readKey\)\.digest\("base64url"\)/);
+  const readPath = source.slice(
+    source.indexOf("async function visionEvidenceFor"),
+    source.indexOf("async function readVisionEvidence"),
+  );
+  assert.match(readPath, /cachedVisionFailure\(readKey\)/);
+  assert.match(readPath, /rememberVisionFailure\(readKey, error\)/);
+  assert.match(source, /error\?\.failureKind !== "out_of_usage"/);
+  const bridge = source.slice(
+    source.indexOf("async function bridgeVisionInput"),
+    source.indexOf("function isOpaqueEncryptedContent"),
+  );
+  assert.match(bridge, /const exhaustedProviders = new Set\(\)/);
+  assert.match(bridge, /providerCooldown\(provider\)/);
+  assert.match(bridge, /exhaustedProviders\.has\(provider\)/);
+  assert.match(
+    bridge,
+    /error\?\.failureKind === "out_of_usage"\) exhaustedProviders\.add\(provider\)/,
+  );
+});
+
 test("the read path tries every resolved engine before giving up on an image", async () => {
   const source = await readFile(path.join(repoRoot, "src/router.mjs"), "utf8");
   const bridge = source.slice(


### PR DESCRIPTION
## Summary

- stop LiteLLM from internally retrying Z.ai Coding Plan 429s by applying `RateLimitErrorRetries: 0` only to `zai-coding` model groups
- preserve safe vision failure metadata, honor provider-supplied reset windows, and skip sibling vision engines after provider quota exhaustion
- add a bounded 60-second negative cache for repeated quota-failed image reads when the provider supplies no usable reset window; keys are SHA-256 hashes so image/data-URI payloads are not retained
- add regressions for the observed Z.ai five-hour usage-limit response and vision quota/reset behavior

## Verification

- `npm run check` — pass on rebased head `3cbe067`
- `node --test test\vision-bridge-e2e.test.mjs test\namespace-relay-routing.test.mjs` — 14/14 pass on rebased head
- dynamic namespace/tool-search serialization remains deterministic and byte-identical for identical inputs
- live GLM-5.3 compatibility after quota reset — basic response, streaming, tool calling, and compaction passed before the conflict-free rebase onto current `main`

Current Windows `npm test` result on `main` + this commit: 2,067 tests, 2,014 pass, 46 skipped, 7 fail. All seven failures reproduce identically on pristine `origin/main` at `9b2b88a`:

- `test/codex-router-cli.test.mjs`: POSIX shell syntax probe returns `status=null` on Windows
- `test/packaged-install.test.mjs`: three POSIX/package-manager subprocess probes return `status=null`, and three packaged-doctor fixtures fail creating symlinks with Windows `EPERM`

Before those packaging tests landed upstream, the full suite was 1,935 tests, 1,901 pass, 34 skipped, 0 fail with this patch. The seven current failures are therefore current-main Windows test-environment failures, not regressions introduced here.