### PR TITLE
api-forwarder: keep streamed usage flowing from OpenAI-compatible providers

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,22 @@
+# Local LiteLLM patches
+
+## litellm-responses-stream-usage.patch
+
+`LiteLLMCompletionStreamingIterator` (the Responses -> Chat Completions
+bridge) never copies the upstream chat-stream usage chunk into the final
+`response.completed` event, so clients receive `input_tokens: 0` whenever
+the provider reports usage only on that chunk.
+
+The patch captures `chunk.usage` in both the sync and async iteration
+loops and applies it to the assembled model response before the
+completed event is emitted.
+
+Apply after dependency installation:
+
+```sh
+patch -d .venv/lib/python3.12/site-packages \
+  -p3 < patches/litellm-responses-stream-usage.patch
+```
+
+Note: `bin/install --force-deps` and `model-router codex doctor --fix`
+rebuild the venv, which reverts this patch; re-apply it afterwards.

--- a/patches/litellm-responses-stream-usage.patch
+++ b/patches/litellm-responses-stream-usage.patch
@@ -1,5 +1,5 @@
 --- a/venv/lib/python3.12/site-packages/litellm/responses/litellm_completion_transformation/streaming_iterator.py
-+++ .venv/lib/python3.12/site-packages/litellm/responses/litellm_completion_transformation/streaming_iterator.py	2026-08-21 22:33:19
++++ .venv/lib/python3.12/site-packages/litellm/responses/litellm_completion_transformation/streaming_iterator.py	2026-08-21 23:04:50
 @@ -82,6 +82,7 @@
          self.sent_output_item_done_event: bool = False
          self.sent_annotation_events: bool = False
@@ -8,7 +8,16 @@
          self.final_text: str = ""
          self._cached_item_id: str | None = None
          self._cached_response_id: str | None = None
-@@ -690,6 +691,8 @@
+@@ -125,6 +126,8 @@
+             return None
+ 
+     def _is_reasoning_end(self, chunk):
++        if not chunk.choices:
++            return False
+         delta = chunk.choices[0].delta
+ 
+         # if this indicates reasoning content, don't consider reasoning ended
+@@ -690,6 +693,8 @@
          if not self.litellm_model_response or isinstance(self.litellm_model_response, TextCompletionResponse):
              self.litellm_model_response = self.create_litellm_model_response()
          if self.litellm_model_response:
@@ -17,7 +26,16 @@
              # If tool calls exist, emit tool events before finishing/response.completed.
              if isinstance(self.litellm_model_response, ModelResponse):
                  self._queue_final_tool_call_done_events(self.litellm_model_response)
-@@ -806,6 +809,9 @@
+@@ -722,6 +727,8 @@
+         # Change: Never return a value, just enqueue output item events
+         if self.sent_output_item_added_event:
+             return
++        if not chunk.choices:
++            return
+         delta = chunk.choices[0].delta
+ 
+         self._sequence_number += 1
+@@ -806,6 +813,9 @@
                      chunk = await self.litellm_custom_stream_wrapper.__anext__()
                      if chunk is not None:
                          chunk = cast(ModelResponseStream, chunk)
@@ -27,7 +45,7 @@
                          self._ensure_output_item_for_chunk(chunk)
                          # Accumulate provider_specific_fields from chunk and delta
                          for src in (
-@@ -904,6 +910,9 @@
+@@ -904,6 +914,9 @@
                      return self._pending_tool_events.pop(0)
                  try:
                      chunk = self.litellm_custom_stream_wrapper.__next__()
@@ -37,3 +55,12 @@
                      self._ensure_output_item_for_chunk(chunk)
                      # Accumulate provider_specific_fields from chunk and delta
                      for src in (
+@@ -1033,6 +1046,8 @@
+ 
+         It's unclear how users expect litellm to translate multiple-choices-per-chunk to the responses API output.
+         """
++        if not choices:
++            return ""
+         choice = choices[0]
+         chat_completion_delta: ChatCompletionDelta = choice.delta
+         return chat_completion_delta.content or ""

--- a/patches/litellm-responses-stream-usage.patch
+++ b/patches/litellm-responses-stream-usage.patch
@@ -1,0 +1,39 @@
+--- a/venv/lib/python3.12/site-packages/litellm/responses/litellm_completion_transformation/streaming_iterator.py
++++ .venv/lib/python3.12/site-packages/litellm/responses/litellm_completion_transformation/streaming_iterator.py	2026-08-21 22:33:19
+@@ -82,6 +82,7 @@
+         self.sent_output_item_done_event: bool = False
+         self.sent_annotation_events: bool = False
+         self.litellm_model_response: ModelResponse | TextCompletionResponse | None = None
++        self._upstream_chunk_usage = None
+         self.final_text: str = ""
+         self._cached_item_id: str | None = None
+         self._cached_response_id: str | None = None
+@@ -690,6 +691,8 @@
+         if not self.litellm_model_response or isinstance(self.litellm_model_response, TextCompletionResponse):
+             self.litellm_model_response = self.create_litellm_model_response()
+         if self.litellm_model_response:
++            if isinstance(self.litellm_model_response, ModelResponse) and self._upstream_chunk_usage is not None:
++                self.litellm_model_response.usage = self._upstream_chunk_usage
+             # If tool calls exist, emit tool events before finishing/response.completed.
+             if isinstance(self.litellm_model_response, ModelResponse):
+                 self._queue_final_tool_call_done_events(self.litellm_model_response)
+@@ -806,6 +809,9 @@
+                     chunk = await self.litellm_custom_stream_wrapper.__anext__()
+                     if chunk is not None:
+                         chunk = cast(ModelResponseStream, chunk)
++                        _cu = getattr(chunk, "usage", None)
++                        if _cu is not None and getattr(_cu, "total_tokens", 0):
++                            self._upstream_chunk_usage = _cu
+                         self._ensure_output_item_for_chunk(chunk)
+                         # Accumulate provider_specific_fields from chunk and delta
+                         for src in (
+@@ -904,6 +910,9 @@
+                     return self._pending_tool_events.pop(0)
+                 try:
+                     chunk = self.litellm_custom_stream_wrapper.__next__()
++                    _cu = getattr(chunk, "usage", None)
++                    if _cu is not None and getattr(_cu, "total_tokens", 0):
++                        self._upstream_chunk_usage = _cu
+                     self._ensure_output_item_for_chunk(chunk)
+                     # Accumulate provider_specific_fields from chunk and delta
+                     for src in (

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -528,6 +528,14 @@ function normalizeBody(buffer, contentType, route) {
   // Codex tags outbound payloads with caller identity that no upstream
   // provider consumes; strict providers reject the unknown field outright.
   delete payload.client_metadata;
+  if (route === "/chat/completions") {
+    if (payload.stream === true) {
+      payload.stream_options = { ...(payload.stream_options ?? {}), include_usage: true };
+    }
+    if (Array.isArray(payload.tools) && payload.tools.length === 0) {
+      delete payload.tools;
+    }
+  }
   const requestedModel = String(payload.model || "");
   // LiteLLM's Responses bridge prefixes the gateway id with `responses/` on
   // the upstream wire format; the forwarder still owns the id translation.


### PR DESCRIPTION
## Problem

Running a routed model through the Responses bridge against OpenCode's free
Zen models (e.g. `opencode-free/x-preview-f-free`), Codex showed
"Context window: 100% full (125k / 125k tokens)" after a single "hello!"
turn.

Root cause chain, observed on 0.4.0-beta.4 (`9b2b88a`) with Codex CLI/App
0.149.0:

1. OpenCode's chat-completions stream sometimes emits the usage chunk
   **after** the terminating `data: [DONE]` line — reproducibly when the
   request carries an empty `tools: []` array alongside
   `tool_choice`/`parallel_tool_calls`, but also intermittently without.
   Codex always sends empty `tools`, so routed turns hit this constantly.
2. LiteLLM's bridge stops at `[DONE]` (correctly), so the completed event
   reaches the client with `input_tokens: 0`.
3. `ResponseUsageTransform` then substitutes its byte-based estimate, which
   for real app payloads is large enough to hit the clamp at
   `contextWindow` — and the client renders a full window.

## Fix

Two normalizations on the outbound `/chat/completions` body in
`normalizeBody`:

- set `stream_options.include_usage: true` on streamed calls;
- drop empty `tools` arrays, which trigger the post-`[DONE]` usage
  placement on OpenCode.

With this, streamed turns meter real upstream tokens again (verified
end-to-end through gateway -> LiteLLM -> forwarder ->
opencode.ai/zen/v1; doctor green).

## Related

- LiteLLM itself drops the post-`[DONE]` chunk by spec; when a provider
  places usage there nothing client-side can recover it. We carry a small
  venv patch that copies `chunk.usage` into the assembled model response in
  `LiteLLMCompletionStreamingIterator`
  (`patches/litellm-responses-stream-usage.patch`, included with a README)
  so operators have a recovery path; happy to rework how it's shipped if
  you'd prefer a different mechanism.
- Operators can also opt out of estimate substitution entirely with
  `CODEX_ROUTER_ZERO_INPUT_ESTIMATE=0`.

## Testing

- `node --check src/api-forwarder.mjs`
- End-to-end streamed request via the authenticated gateway:
  `response.completed.usage` now reports real upstream counts
  (`input_tokens: 9`) instead of `0`/clamped estimates; recorded
  `usage-events.jsonl` shows `inputTokens: 9, estimatedInputTokens: null`.
- `bin/model-router codex doctor`: 0 failures before and after.
