### PR TITLE
Add safe V2 agent certification workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -569,82 +569,40 @@ can hold the v2 child role is the router's. The same model answers differently
 per provider — tool support, request profiles, and payload handling all vary —
 so the unit of evidence is always the slug, never the model name.
 
-1. Enabling a non-registry-v2 model hands it to a detached capability probe
+1. Enabling an unknown model hands it to a detached compatibility probe
    (`src/subagent-verify.mjs`): two live requests through the installed router
    proving streaming and a forced tool call. The proofs snapshot shows
-   `checking` until the verdict lands and the catalog republishes. A worker
-   that dies without a verdict marks its slugs `failed` on the way out, and a
-   `checking` older than the probe ceiling is treated as abandoned — so
-   switching a wedged model off and on always re-researches it.
-2. A passing model is advertised to Codex as an **experimental** v2 subagent,
-   recorded in the protected `multi-agent-proofs.json`. The first real child
-   turn settles it: Codex marks child turns with `x-openai-subagent`, and the
-   router's own request path records a clean completion as the durable proof
-   (`proven`) or a structural rejection — HTTP 400/422 — as a demotion back to
-   v1 with the reason kept where it was switched on. Transient failures (429,
-   5xx, disconnects) prove nothing and leave the window open.
-3. `proven` is a claim about the wire, not about the work. It says one child
-   turn for that slug completed cleanly, so the model can hold the child role;
-   it does not say the child finished what it was delegated. The router
-   observes HTTP turns, not agent lifecycles — a child makes one turn per
-   tool-call round trip, and the loop that strings them together is Codex's.
-   Do not write copy anywhere (log lines, tray, docs) that reads `proven` as
-   "the delegated task succeeded".
-4. **`proven` is revocable, and only downward automatically** (issue #257).
-   Promotion is a one-time event, but the window in which machine-local
-   evidence can be taken away stays open for as long as that evidence is what
-   the v2 advertisement rests on. A 400/422 on any child turn demotes the slug,
-   before or after promotion and without needing to repeat: it is the same
-   structural refusal the capability probe treats as disqualifying, the
-   transient statuses that prove nothing are already excluded, and the
-   alternative is letting the oldest observation beat the newest. A registry-v2
-   model is untouched — its claim is the shipped native collaboration proof,
-   not this machine's traffic. Re-promotion is never automatic: it costs live
-   requests, so it happens only through `control subagents verify` or switching
-   the model off and on.
-5. **A looping child is demoted against its own compaction budget**, because a
-   child that answers forever emits nothing but 200s and no status-shaped
-   branch can ever see it. `src/subagent-turns.mjs` accounts each spawn
-   separately, keyed on the `thread-id` header, and adds up the *new* input
-   tokens it produces (every child turn resends the whole conversation, so the
-   growth in the prompt count is what the child newly made; a compaction makes
-   the count fall and everything after the fall is work being done twice). The
-   ceiling is twice the larger of the model's declared `autoCompact` budget and
-   the largest prompt this spawn has actually had accepted. Nothing there is
-   invented: `autoCompact` is per model and comes from the provider's published
-   window, and the multiple comes from the pathology
-   `src/context-window-drift.mjs` already names — one budget is a large but
-   legitimate task, it is *compacting again without ever finishing* that is the
-   runaway. Measuring against the observed peak as well as the declaration is
-   what makes a false demotion impossible rather than merely unlikely: an
-   uncompacted spawn's total is exactly half its own ceiling however long its
-   task runs, which matters because the registry validator permits any
-   `1 <= autoCompact <= contextWindow` and one oversized tool result can carry a
-   single turn past the compaction limit in one step. A child thread reused for
-   a `FOLLOWUP_TASK` is deliberately one spawn here — its context really does
-   carry across — and an idle one expires rather than accumulating forever.
-   No positive "terminal turn" detector is needed or possible: the
-   turn that ended a spawn is only knowable by no further turn arriving, and a
-   ceiling can only ever be crossed by a spawn that is still producing turns.
-   Only a prompt count the provider actually reported may move the total —
-   substituted estimates and retry-doubled counts are refused here for exactly
-   the reasons `context-window-drift.mjs` refuses them as capacity evidence. A
-   model that declares no `autoCompact` has no derived ceiling and is counted
-   but never condemned; do not give it one by guessing. Both demotion paths log
-   unconditionally and record the turn and token counts in the proofs file, so
-   `control subagents status` and the tray can say what happened.
-6. Local settings still never manufacture a v2 claim. The only writers of
-   promotion evidence are the probe worker and the router's observation of
-   real traffic; an unreadable proofs file promotes nothing, and a hidden or
-   switched-off slug stays v1 whatever evidence it carries.
-7. `control subagents verify [SLUG ...]` re-researches explicitly (foreground,
-   ~2 requests per candidate); with no slugs it sweeps the enabled list.
-   Select-all and mode changes never trigger probes — a sweep across every
-   provider is quota the operator must ask for.
-8. Machine-local proofs are exactly that. Shipping a default to every
-   installer still requires the full native collaboration proof and a registry
-   change (below); never edit the checked-in `config/` tree because one
-   machine's probe passed.
+   `checking` until the verdict lands. A passing probe records `candidate`; it
+   does **not** advertise v2. A worker that dies without a verdict records a
+   failure, and a stale `checking` record is retryable. Explicit registry-v1
+   routes are settled decisions and are never re-opened by this local probe;
+   registry-v2 routes need no compatibility probe.
+2. `multi-agent-proofs.json` is diagnostic application evidence only. Local
+   `candidate`, and legacy `experimental` / `proven`, records cannot change the
+   catalog's `multi_agent_version`, managed agent definitions, or any client
+   route. `applySubagentProofs` deliberately returns the registry capabilities
+   unchanged. An unreadable proofs file therefore authorizes and promotes
+   nothing.
+3. The compatibility probe is not the native collaboration proof. It does not
+   exercise Codex's encrypted child payload relay, a marker-return spawn, or a
+   same-thread follow-up. A successful ordinary chat/tool request must never be
+   presented as evidence that the model can hold the native v2 child role.
+4. Only the exact checked-in registry route may assert v2. The route's slug,
+   provider, and upstream model must match an accepted artifact under
+   `v2_agent/`, and the accepted artifact and `multiAgentVersion: "v2"` change
+   land in the same pull request. CI enforces the implication in both
+   directions for every post-workflow promotion. Six exact Kimi/Grok route
+   identities certified before the artifact gate are grandfathered; changing
+   any part of one identity loses that exception.
+5. `control subagents verify [SLUG ...]` re-researches explicitly (foreground,
+   about two requests per unknown candidate); with no slugs it sweeps the
+   enabled list. Select-all and mode changes never trigger probes. Provider,
+   model, and family auto-policies are explicit standing consent for matching
+   newly configured unknown routes; they still produce only candidates.
+6. Machine-local evidence is exactly that. Never edit checked-in `config/`
+   because one machine's probe passed. Complete the redacted application,
+   reproduce the two native child checks with a spendable account, and review
+   the exact provider route before shipping a v2 claim to every installer.
 
 ### Ship a model to every installer
 
@@ -1653,13 +1611,13 @@ purpose.
 - A test that isolates the state directory must isolate `CODEX_HOME` with it.
   `MODEL_ROUTER_STATE_DIR` and `CODEX_ROUTER_STATE_DIR` do not redirect
   `CODEX_AGENTS_DIR`, which is `$CODEX_HOME/agents`, and `src/catalog.mjs`
-  prunes that directory to whatever the state it just read promotes to `v2`.
+  prunes that directory to the exact registry-v2 routes the state it just read
+  leaves enabled and visible.
   Point the state at a scratch directory while inheriting the real home and the
   run deletes the operator's own routed agent definitions — every model
-  promoted by a local capability proof rather than by the shipped registry —
-  while `multi-agent-settings.json` and `multi-agent-proofs.json`, which live in
-  the scratch state, survive intact to report the models as still enabled. The
-  operator sees subagents that reset themselves after an unrelated command.
+  selected in the real state can disappear from that scratch publication —
+  while `multi-agent-settings.json` and `multi-agent-proofs.json` live in the
+  scratch state. The operator sees subagents reset after an unrelated command.
   `test/state-owner.test.mjs` pins this: no test file may spawn the catalog
   without setting `CODEX_HOME`.
 

--- a/apps/control-center/src/pages/ModelsPage.tsx
+++ b/apps/control-center/src/pages/ModelsPage.tsx
@@ -58,7 +58,12 @@ function catalogEligible(entry: ProviderDirectoryEntry): boolean {
 function subagentEnabled(target: RouterTarget, slug: string, settings = target.modelSettings?.subagents): boolean {
   if (!settings) return false;
   if (settings.disabled.includes(slug)) return false;
-  if (settings.mode === "all") return true;
+  // "all" exposes every route that already has a v2 claim. It does not
+  // manufacture one for an untested v1 model; an explicit row toggle moves
+  // that model into selected mode and starts its bounded capability probe.
+  if (settings.mode === "all") {
+    return target.models.find((model) => model.slug === slug)?.multiAgentVersion === "v2";
+  }
   if (settings.mode === "proven") {
     return target.models.find((model) => model.slug === slug)?.multiAgentVersion === "v2";
   }
@@ -142,7 +147,7 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
   const pickerStates = useMemo(() => new Map(models.map((model) => [model.slug, model.visible])), [models]);
   const subagentStates = useMemo(() => new Map(models.map((model) => [
     model.slug,
-    model.multiAgentVersion === "v2" && Boolean(target && subagentEnabled(target, model.slug, subagentSettings)),
+    Boolean(target && subagentEnabled(target, model.slug, subagentSettings)),
   ])), [models, subagentSettings, target]);
   const subagentEffortStates = useMemo(() => new Map(models.map((model) => [
     model.slug,
@@ -451,9 +456,23 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
                         {entry.visibleModels.length ? (
                           <div className="pm-model-list" role="list" aria-label={`${entry.displayName} models`}>
                             {entry.visibleModels.map((model) => {
-                              const eligible = model.multiAgentVersion === "v2";
+                              const certified = model.multiAgentVersion === "v2";
+                              const certification = model.subagentCertification ?? (certified ? "v2" : "unknown");
+                              const knownV1 = certification === "v1";
+                              const proof = subagentSettings?.proofs?.[model.slug];
+                              const checking = proof?.status === "checking";
+                              const candidate = proof?.status === "candidate";
+                              const eligible = certified;
                               const maker = brandForModel(model);
-                              const selectedAsSubagent = eligible && optimisticSubagents.value(model.slug, subagentEnabled(target, model.slug, subagentSettings));
+                              const selectedInSettings = optimisticSubagents.value(
+                                model.slug,
+                                Boolean(target && subagentEnabled(target, model.slug, subagentSettings)),
+                              );
+                              // Only a repository-certified v2 model is a usable
+                              // subagent. A local probe may show progress, but it
+                              // must never make this switch look enabled.
+                              const selectedAsSubagent = certified && selectedInSettings;
+                              const testActive = !certified && !knownV1 && (checking || (!candidate && selectedInSettings));
                               const effortOptions = model.reasoningLevels ?? [];
                               const subagentEffort = optimisticSubagentEfforts.value(
                                 model.slug,
@@ -469,14 +488,17 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
                                     <span>{formatContext(model.contextWindow)}</span>
                                     <span>{model.inputModalities?.includes("image") ? "Text + image" : "Text"}</span>
                                     {model.isFree ? <Badge tone="success">Free</Badge> : null}
-                                    <Badge tone={eligible ? "accent" : "neutral"}>{eligible ? "v2 relay" : "v1 relay"}</Badge>
+                                    <Badge tone={eligible ? "accent" : proof?.status === "failed" ? "danger" : "neutral"}>
+                                      {checking ? "Checking compatibility" : eligible ? "v2 relay" : knownV1 ? "v1 only" : candidate ? "Certification candidate" : proof?.status === "failed" ? "Compatibility failed" : "Untested"}
+                                    </Badge>
                                     {selectedAsSubagent ? <Badge tone="accent">Subagent</Badge> : null}
                                     {selectedAsSubagent && effortOptions.length ? <Badge tone="neutral">{effortLabel(subagentEffort)} thinking</Badge> : null}
                                   </div>
                                   <div className="pm-model-controls">
                                     <div className="pm-model-control"><span>Picker</span><Toggle checked={optimisticPicker.value(model.slug, model.visible)} disabled={!api || nativeClientManaged(model)} label={nativeClientManaged(model) ? `${model.displayName} is managed by Codex` : `Show ${model.displayName} in picker`} onChange={(checked) => void updatePicker(model.slug, checked)} /></div>
-                                    <div className="pm-subagent-controls" title={eligible ? "Expose as a native v2 subagent and choose its thinking effort" : "This model uses the conservative v1 relay"}>
-                                      <div className="pm-model-control"><span>Subagent</span><Toggle checked={selectedAsSubagent} disabled={!api || !eligible} label={`Use ${model.displayName} as subagent`} onChange={(checked) => void updateSubagent(model.slug, checked)} /></div>
+                                    <div className="pm-subagent-controls" title={certified ? "Expose this certified v2 model as a subagent" : knownV1 ? "This model is certified v1 and is not retested automatically" : checking ? "Testing low-cost compatibility; this does not enable v2" : candidate ? "Awaiting a reviewed native v2 certification" : "Run the one-time low-cost compatibility test"}>
+                                      <div className="pm-model-control"><span>{certified ? "Subagent" : knownV1 ? "v1 only" : "Test v2"}</span><Toggle checked={certified ? selectedAsSubagent : testActive} disabled={!api || checking || candidate || knownV1} label={certified ? `Use ${model.displayName} as subagent` : knownV1 ? `${model.displayName} is certified v1` : `Test ${model.displayName} for v2 compatibility`} onChange={(checked) => void updateSubagent(model.slug, checked)} /></div>
+                                      {proof?.status === "failed" && proof.reason ? <small className="pm-subagent-proof-error" title={proof.reason}>Test failed</small> : null}
                                       {eligible && effortOptions.length ? (
                                         <label className="pm-model-effort">
                                           <span>Thinking</span>

--- a/apps/control-center/src/pages/ModelsPage.tsx
+++ b/apps/control-center/src/pages/ModelsPage.tsx
@@ -55,19 +55,24 @@ function catalogEligible(entry: ProviderDirectoryEntry): boolean {
   return Boolean(entry.setup?.configured) && !NO_LIVE_CATALOG.has(entry.id);
 }
 
+function subagentCertification(model: RouterModel): "v1" | "v2" | "unknown" | string {
+  return model.subagentCertification
+    ?? (model.multiAgentVersion === "v2" ? "v2" : model.multiAgentVersion === "v1" ? "v1" : "unknown");
+}
+
 function subagentEnabled(target: RouterTarget, slug: string, settings = target.modelSettings?.subagents): boolean {
   if (!settings) return false;
   if (settings.disabled.includes(slug)) return false;
-  // "all" exposes every route that already has a v2 claim. It does not
-  // manufacture one for an untested v1 model; an explicit row toggle moves
-  // that model into selected mode and starts its bounded capability probe.
-  if (settings.mode === "all") {
-    return target.models.find((model) => model.slug === slug)?.multiAgentVersion === "v2";
+  const model = target.models.find((entry) => entry.slug === slug);
+  if (!model || model.visible === false) return false;
+  // Certified routes remain active unless explicitly disabled; selected mode
+  // does not silently turn off every other registry-v2 route. For an unknown
+  // route, a selected-mode entry means only that its compatibility test was
+  // requested — it never becomes an active subagent here.
+  if (subagentCertification(model) === "v2") {
+    return true;
   }
-  if (settings.mode === "proven") {
-    return target.models.find((model) => model.slug === slug)?.multiAgentVersion === "v2";
-  }
-  return settings.enabled.includes(slug);
+  return settings.mode === "selected" && settings.enabled.includes(slug);
 }
 
 function nativeClientManaged(model: RouterModel): boolean {
@@ -456,12 +461,16 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
                         {entry.visibleModels.length ? (
                           <div className="pm-model-list" role="list" aria-label={`${entry.displayName} models`}>
                             {entry.visibleModels.map((model) => {
-                              const certified = model.multiAgentVersion === "v2";
-                              const certification = model.subagentCertification ?? (certified ? "v2" : "unknown");
+                              const certification = subagentCertification(model);
+                              const certified = certification === "v2";
                               const knownV1 = certification === "v1";
                               const proof = subagentSettings?.proofs?.[model.slug];
-                              const checking = proof?.status === "checking";
-                              const candidate = proof?.status === "candidate";
+                              const checking = !certified && !knownV1 && proof?.status === "checking";
+                              // Older releases wrote experimental/proven after
+                              // the local probe. Those records are diagnostic
+                              // candidates now; none is a repository v2
+                              // certificate or a reason to re-spend quota.
+                              const candidate = !certified && !knownV1 && ["candidate", "experimental", "proven"].includes(proof?.status ?? "");
                               const eligible = certified;
                               const maker = brandForModel(model);
                               const selectedInSettings = optimisticSubagents.value(
@@ -472,7 +481,7 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
                               // subagent. A local probe may show progress, but it
                               // must never make this switch look enabled.
                               const selectedAsSubagent = certified && selectedInSettings;
-                              const testActive = !certified && !knownV1 && (checking || (!candidate && selectedInSettings));
+                              const testActive = !certified && !knownV1 && !candidate && selectedInSettings;
                               const effortOptions = model.reasoningLevels ?? [];
                               const subagentEffort = optimisticSubagentEfforts.value(
                                 model.slug,
@@ -488,8 +497,8 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
                                     <span>{formatContext(model.contextWindow)}</span>
                                     <span>{model.inputModalities?.includes("image") ? "Text + image" : "Text"}</span>
                                     {model.isFree ? <Badge tone="success">Free</Badge> : null}
-                                    <Badge tone={eligible ? "accent" : proof?.status === "failed" ? "danger" : "neutral"}>
-                                      {checking ? "Checking compatibility" : eligible ? "v2 relay" : knownV1 ? "v1 only" : candidate ? "Certification candidate" : proof?.status === "failed" ? "Compatibility failed" : "Untested"}
+                                    <Badge tone={eligible ? "accent" : proof?.status === "failed" && !knownV1 ? "danger" : "neutral"}>
+                                      {eligible ? "v2 relay" : knownV1 ? "v1 only" : checking ? "Checking compatibility" : candidate ? "Certification candidate" : proof?.status === "failed" ? "Compatibility failed" : "Untested"}
                                     </Badge>
                                     {selectedAsSubagent ? <Badge tone="accent">Subagent</Badge> : null}
                                     {selectedAsSubagent && effortOptions.length ? <Badge tone="neutral">{effortLabel(subagentEffort)} thinking</Badge> : null}
@@ -497,8 +506,8 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
                                   <div className="pm-model-controls">
                                     <div className="pm-model-control"><span>Picker</span><Toggle checked={optimisticPicker.value(model.slug, model.visible)} disabled={!api || nativeClientManaged(model)} label={nativeClientManaged(model) ? `${model.displayName} is managed by Codex` : `Show ${model.displayName} in picker`} onChange={(checked) => void updatePicker(model.slug, checked)} /></div>
                                     <div className="pm-subagent-controls" title={certified ? "Expose this certified v2 model as a subagent" : knownV1 ? "This model is certified v1 and is not retested automatically" : checking ? "Testing low-cost compatibility; this does not enable v2" : candidate ? "Awaiting a reviewed native v2 certification" : "Run the one-time low-cost compatibility test"}>
-                                      <div className="pm-model-control"><span>{certified ? "Subagent" : knownV1 ? "v1 only" : "Test v2"}</span><Toggle checked={certified ? selectedAsSubagent : testActive} disabled={!api || checking || candidate || knownV1} label={certified ? `Use ${model.displayName} as subagent` : knownV1 ? `${model.displayName} is certified v1` : `Test ${model.displayName} for v2 compatibility`} onChange={(checked) => void updateSubagent(model.slug, checked)} /></div>
-                                      {proof?.status === "failed" && proof.reason ? <small className="pm-subagent-proof-error" title={proof.reason}>Test failed</small> : null}
+                                      <div className="pm-model-control"><span>{certified ? "Subagent" : knownV1 ? "v1 only" : "Test v2"}</span><Toggle checked={certified ? selectedAsSubagent : testActive} disabled={!api || candidate || knownV1} label={certified ? `Use ${model.displayName} as subagent` : knownV1 ? `${model.displayName} is certified v1` : `Test ${model.displayName} for v2 compatibility`} onChange={(checked) => void updateSubagent(model.slug, checked)} /></div>
+                                      {!certified && !knownV1 && proof?.status === "failed" && proof.reason ? <small className="pm-subagent-proof-error" title={proof.reason}>Test failed</small> : null}
                                       {eligible && effortOptions.length ? (
                                         <label className="pm-model-effort">
                                           <span>Thinking</span>

--- a/apps/control-center/src/types.ts
+++ b/apps/control-center/src/types.ts
@@ -26,6 +26,8 @@ export interface RouterModel {
   /** Base native Codex entries stay client-managed; variants remain router-managed. */
   nativeClientManaged?: boolean;
   multiAgentVersion?: "v1" | "v2" | string;
+  /** Repository verdict; unlike `multiAgentVersion`, preserves unknown vs explicit v1. */
+  subagentCertification?: "v1" | "v2" | "unknown";
   visible: boolean;
   defaultEffort?: string;
   reasoningLevels?: string[];
@@ -40,6 +42,11 @@ export interface SubagentSettings {
   enabled: string[];
   disabled: string[];
   efforts?: Record<string, string>;
+  /** Machine-local v2 capability evidence, populated by the live probe. */
+  proofs?: Record<string, {
+    status: "checking" | "candidate" | "experimental" | "proven" | "failed" | string;
+    reason?: string;
+  }>;
   all?: boolean;
 }
 

--- a/apps/desktop/ui/app.js
+++ b/apps/desktop/ui/app.js
@@ -782,34 +782,41 @@ function startPanel() {
     // test, while explicit v1 routes are never re-promoted locally.
     const subagentModels = enabledModels;
     const subagentGroups = groupModels(subagentModels);
+    const subagentCertification = (model) =>
+      model.subagentCertification ??
+      (model.multiAgentVersion === "v2" ? "v2" : model.multiAgentVersion === "v1" ? "v1" : "unknown");
+    const isCertifiedV2 = (model) => subagentCertification(model) === "v2";
     const isSubagentOn = (model) =>
       model.visible === false
         ? false
         : !disabledSubagents.has(model.slug) &&
-          model.multiAgentVersion === "v2";
+          isCertifiedV2(model);
     const subagentRow = (model) => {
         const checked = isSubagentOn(model);
         const proof = subagentProofs[model.slug];
-        const certification = model.subagentCertification || (model.multiAgentVersion === "v2" ? "v2" : "unknown");
+        const certification = subagentCertification(model);
+        const certified = certification === "v2";
         const knownV1 = certification === "v1";
-        const testActive = !knownV1 && model.multiAgentVersion !== "v2" &&
-          (proof?.status === "checking" || (!proof?.status || proof.status === "failed") && selectedSubagents.has(model.slug));
+        const checking = !certified && !knownV1 && proof?.status === "checking";
+        const candidate = !certified && !knownV1 && ["candidate", "experimental", "proven"].includes(proof?.status);
+        const testActive = !certified && !knownV1 && !candidate &&
+          selectedSubagents.has(model.slug);
         const badge = model.visible === false
           ? t("models.hidden")
-          : proof?.status === "checking"
-            ? t("status.working")
+          : certified
+            ? t("models.provenV2")
             : knownV1
               ? "v1 only"
-            : proof?.status === "candidate"
+            : checking
+              ? t("status.working")
+            : candidate
               ? "Certification candidate"
             : proof?.status === "failed"
               ? `${t("status.error")}: ${proof.reason || t("models.untested")}`
-              : model.multiAgentVersion === "v2"
-                ? t("models.provenV2")
-                : t("models.untested");
+              : t("models.untested");
         return `<label class="model-setting-row">
           <span><strong>${escapeHtml(model.displayName)}</strong><small>${escapeHtml(badge)}</small></span>
-          <span class="provider-check"><input type="checkbox" data-command="set_subagent_model" data-subagent="${escapeHtml(model.slug)}" aria-label="${escapeHtml(model.multiAgentVersion === "v2" ? t("models.useModelAria", { model: model.displayName }) : knownV1 ? `${model.displayName} is certified v1` : `Test ${model.displayName} for v2 compatibility`)}"${model.multiAgentVersion === "v2" ? (checked ? " checked" : "") : (testActive ? " checked" : "")}${state.modelSettingsBusy || model.visible === false || knownV1 || proof?.status === "checking" || proof?.status === "candidate" ? " disabled" : ""}></span>
+          <span class="provider-check"><input type="checkbox" data-command="set_subagent_model" data-subagent="${escapeHtml(model.slug)}" aria-label="${escapeHtml(certified ? t("models.useModelAria", { model: model.displayName }) : knownV1 ? `${model.displayName} is certified v1` : `Test ${model.displayName} for v2 compatibility`)}"${certified ? (checked ? " checked" : "") : (testActive ? " checked" : "")}${state.modelSettingsBusy || model.visible === false || knownV1 || candidate ? " disabled" : ""}></span>
         </label>`;
       };
 

--- a/apps/desktop/ui/app.js
+++ b/apps/desktop/ui/app.js
@@ -777,25 +777,31 @@ function startPanel() {
     elements.subagentAllSwitch.checked = subagent.mode === "all";
     elements.subagentAllSwitchLabel.title = t("models.onlyProvenV2");
 
-    // Every enabled model belongs here. Native OpenAI models use their
-    // effective Codex catalog capability, while an unverified routed model
-    // starts the existing capability probe when selected. Hiding v1 candidates
-    // made that route impossible to discover; filtering native models made
-    // usable GPT models disappear from the panel entirely.
+    // Every enabled model belongs here. Only repository-certified v2 routes
+    // are usable subagents. Unknown routes may run one low-cost compatibility
+    // test, while explicit v1 routes are never re-promoted locally.
     const subagentModels = enabledModels;
     const subagentGroups = groupModels(subagentModels);
     const isSubagentOn = (model) =>
       model.visible === false
         ? false
         : !disabledSubagents.has(model.slug) &&
-          (model.multiAgentVersion === "v2" || selectedSubagents.has(model.slug));
+          model.multiAgentVersion === "v2";
     const subagentRow = (model) => {
         const checked = isSubagentOn(model);
         const proof = subagentProofs[model.slug];
+        const certification = model.subagentCertification || (model.multiAgentVersion === "v2" ? "v2" : "unknown");
+        const knownV1 = certification === "v1";
+        const testActive = !knownV1 && model.multiAgentVersion !== "v2" &&
+          (proof?.status === "checking" || (!proof?.status || proof.status === "failed") && selectedSubagents.has(model.slug));
         const badge = model.visible === false
           ? t("models.hidden")
           : proof?.status === "checking"
             ? t("status.working")
+            : knownV1
+              ? "v1 only"
+            : proof?.status === "candidate"
+              ? "Certification candidate"
             : proof?.status === "failed"
               ? `${t("status.error")}: ${proof.reason || t("models.untested")}`
               : model.multiAgentVersion === "v2"
@@ -803,7 +809,7 @@ function startPanel() {
                 : t("models.untested");
         return `<label class="model-setting-row">
           <span><strong>${escapeHtml(model.displayName)}</strong><small>${escapeHtml(badge)}</small></span>
-          <span class="provider-check"><input type="checkbox" data-command="set_subagent_model" data-subagent="${escapeHtml(model.slug)}" aria-label="${escapeHtml(t("models.useModelAria", { model: model.displayName }))}"${checked ? " checked" : ""}${state.modelSettingsBusy || model.visible === false ? " disabled" : ""}></span>
+          <span class="provider-check"><input type="checkbox" data-command="set_subagent_model" data-subagent="${escapeHtml(model.slug)}" aria-label="${escapeHtml(model.multiAgentVersion === "v2" ? t("models.useModelAria", { model: model.displayName }) : knownV1 ? `${model.displayName} is certified v1` : `Test ${model.displayName} for v2 compatibility`)}"${model.multiAgentVersion === "v2" ? (checked ? " checked" : "") : (testActive ? " checked" : "")}${state.modelSettingsBusy || model.visible === false || knownV1 || proof?.status === "checking" || proof?.status === "candidate" ? " disabled" : ""}></span>
         </label>`;
       };
 

--- a/apps/macos/ModelRouterTray/Sources/Localization.swift
+++ b/apps/macos/ModelRouterTray/Sources/Localization.swift
@@ -452,6 +452,8 @@ enum RouterChineseText {
     "5-hour limit": "5 小时限制",
     "Hidden from picker — show it below to use it here": "已从选择器隐藏 — 请在下方显示后才能使用",
     "Proven v2": "已验证 v2",
+    "v1 only": "仅支持 v1",
+    "Certification candidate": "认证候选",
     "Not selected": "未选择",
     "Apply the checked-out router revision, then run the Codex doctor": "应用已检出的路由版本，然后运行 Codex doctor",
     "Run the Codex doctor and repair managed router files": "运行 Codex doctor 并修复受管理的路由文件",

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -2959,6 +2959,7 @@ struct RouterModel: Decodable, Identifiable {
   let provider: String
   let enabled: Bool
   let multiAgentVersion: String?
+  let subagentCertification: String?
   let visible: Bool?
   let reasoningLevels: [String]?
   var id: String { slug }
@@ -4806,12 +4807,12 @@ private struct TrayView: View {
                         title: model.displayName,
                         detail: subagentDetail(for: model),
                         isOn: Binding(
-                          get: { isSubagent(model) },
+                          get: { subagentToggleOn(model) },
                           set: { enabled in
                             store.setSubagentModel(model.slug, enabled: enabled)
                           }
                         ),
-                        disabled: !isPickerVisible(model)
+                        disabled: subagentToggleDisabled(model)
                       )
                       if isSubagent(model) {
                         subagentStatusTags(for: model)
@@ -6279,13 +6280,53 @@ private struct TrayView: View {
       Set(settings?.subagents.enabled ?? [])
     }
 
-    // Keep a selected candidate checked while its capability probe runs. The
-    // backend, not this UI state, decides when it is actually advertised as v2.
+    private func subagentCertification(for model: RouterModel) -> String {
+      if let certification = model.subagentCertification { return certification }
+      if model.multiAgentVersion == "v2" { return "v2" }
+      if model.multiAgentVersion == "v1" { return "v1" }
+      return "unknown"
+    }
+
+    private func isKnownV1(_ model: RouterModel) -> Bool {
+      subagentCertification(for: model) == "v1"
+    }
+
+    private func isCertifiedV2(_ model: RouterModel) -> Bool {
+      subagentCertification(for: model) == "v2"
+    }
+
+    private func isCertificationCandidate(_ model: RouterModel) -> Bool {
+      guard subagentCertification(for: model) == "unknown" else { return false }
+      guard let status = settings?.subagents.proofs?[model.slug]?.status else { return false }
+      return ["candidate", "experimental", "proven"].contains(status)
+    }
+
+    // Status tags, effort controls, and enabled counts must reflect only the
+    // capability Codex receives. A selected compatibility-test candidate is
+    // not a usable subagent until the exact registry route is certified v2.
     private func isSubagent(_ model: RouterModel) -> Bool {
       if !isPickerVisible(model) { return false }
       let authoritative = !disabledSubagentSet.contains(model.slug)
-        && (model.multiAgentVersion == "v2" || selectedSubagentSet.contains(model.slug))
+        && isCertifiedV2(model)
       return store.subagentModelEnabled(model.slug, authoritative: authoritative)
+    }
+
+    // Unknown routes use the same row to request their one-time compatibility
+    // test. Keep that request checked while it runs (and after a failure so it
+    // can be switched off before retrying), but never feed it to isSubagent.
+    private func subagentToggleOn(_ model: RouterModel) -> Bool {
+      if isCertifiedV2(model) { return isSubagent(model) }
+      if !isPickerVisible(model) || isKnownV1(model) || isCertificationCandidate(model) {
+        return false
+      }
+      let authoritative = selectedSubagentSet.contains(model.slug)
+      return store.subagentModelEnabled(model.slug, authoritative: authoritative)
+    }
+
+    private func subagentToggleDisabled(_ model: RouterModel) -> Bool {
+      if !isPickerVisible(model) { return true }
+      if isCertifiedV2(model) { return false }
+      return isKnownV1(model) || isCertificationCandidate(model)
     }
 
     // Codex chooses which model a child runs on; this chooses how hard it
@@ -6342,17 +6383,21 @@ private struct TrayView: View {
 
     private func subagentDetail(for model: RouterModel) -> String {
       if !isPickerVisible(model) { return routerLocalized("Hidden from picker — show it below to use it here") }
-      if let proof = settings?.subagents.proofs?[model.slug] {
+      if isKnownV1(model) { return routerLocalized("v1 only") }
+      if !isCertifiedV2(model), let proof = settings?.subagents.proofs?[model.slug] {
         if proof.status == "checking" { return routerLocalized("Checking…") }
+        if isCertificationCandidate(model) {
+          return routerLocalized("Certification candidate")
+        }
         if proof.status == "failed" {
           return proof.reason ?? routerLocalized("Error")
         }
       }
-      if model.multiAgentVersion == "v2" && isSubagent(model) {
+      if isCertifiedV2(model) && isSubagent(model) {
         let effort = settings?.subagents.efforts?[model.slug] ?? routerLocalized("Default")
         return "\(routerLocalized("Proven v2")) · \(effort.capitalized) \(routerLocalized("thinking"))"
       }
-      if model.multiAgentVersion == "v2" { return routerLocalized("Proven v2") }
+      if isCertifiedV2(model) { return routerLocalized("Proven v2") }
       return routerLocalized("Not selected")
     }
 

--- a/apps/macos/ModelRouterTray/Sources/RouterArabicText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterArabicText.swift
@@ -321,6 +321,8 @@ enum RouterArabicText {
     "5-hour limit": "حد 5 ساعات",
     "Hidden from picker — show it below to use it here": "مخفي من المنتقي — أظهره أدناه لاستخدامه هنا",
     "Proven v2": "v2 متحقق منه",
+    "v1 only": "v1 فقط",
+    "Certification candidate": "مرشح للاعتماد",
     "Not selected": "غير محدد",
     "Apply the checked-out router revision, then run the Codex doctor": "تطبيق نسخة الموجّه المسحوبة ثم تشغيل Codex doctor",
     "Run the Codex doctor and repair managed router files": "تشغيل Codex doctor وإصلاح ملفات الموجّه المُدارة",

--- a/apps/macos/ModelRouterTray/Sources/RouterHindiText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterHindiText.swift
@@ -321,6 +321,8 @@ enum RouterHindiText {
     "5-hour limit": "5-घंटे की सीमा",
     "Hidden from picker — show it below to use it here": "पिकर से छिपा है — यहाँ उपयोग करने के लिए इसे नीचे दिखाएँ",
     "Proven v2": "सत्यापित v2",
+    "v1 only": "केवल v1",
+    "Certification candidate": "प्रमाणीकरण उम्मीदवार",
     "Not selected": "चयनित नहीं",
     "Apply the checked-out router revision, then run the Codex doctor": "चेक-आउट किया गया राउटर संस्करण लागू करें, फिर Codex doctor चलाएँ",
     "Run the Codex doctor and repair managed router files": "Codex doctor चलाएँ और प्रबंधित राउटर फ़ाइलें ठीक करें",

--- a/apps/macos/ModelRouterTray/Sources/RouterJapaneseText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterJapaneseText.swift
@@ -321,6 +321,8 @@ enum RouterJapaneseText {
     "5-hour limit": "5 時間の上限",
     "Hidden from picker — show it below to use it here": "ピッカーから非表示 — ここで使用するには下で表示してください",
     "Proven v2": "検証済み v2",
+    "v1 only": "v1 のみ",
+    "Certification candidate": "認定候補",
     "Not selected": "未選択",
     "Apply the checked-out router revision, then run the Codex doctor": "チェックアウト済みのルーターリビジョンを適用してから Codex doctor を実行",
     "Run the Codex doctor and repair managed router files": "Codex doctor を実行し、管理対象のルーターファイルを修復",

--- a/apps/macos/ModelRouterTray/Sources/RouterKoreanText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterKoreanText.swift
@@ -321,6 +321,8 @@ enum RouterKoreanText {
     "5-hour limit": "5시간 한도",
     "Hidden from picker — show it below to use it here": "선택기에서 숨겨짐 — 여기서 사용하려면 아래에서 표시하세요",
     "Proven v2": "검증된 v2",
+    "v1 only": "v1 전용",
+    "Certification candidate": "인증 후보",
     "Not selected": "선택되지 않음",
     "Apply the checked-out router revision, then run the Codex doctor": "체크아웃된 라우터 리비전을 적용한 뒤 Codex doctor를 실행합니다",
     "Run the Codex doctor and repair managed router files": "Codex doctor를 실행하고 관리되는 라우터 파일을 복구합니다",

--- a/scripts-check.mjs
+++ b/scripts-check.mjs
@@ -15,4 +15,8 @@ for (const directory of directories) {
   }
 }
 
+execFileSync(process.execPath, [path.join(root, "scripts", "check-v2-agent-applications.mjs")], {
+  stdio: "inherit",
+});
+
 console.log("syntax checks passed");

--- a/scripts/check-v2-agent-applications.mjs
+++ b/scripts/check-v2-agent-applications.mjs
@@ -1,6 +1,9 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
+import { isIP } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import { CHECKED_IN_MODELS } from "../src/model-registry.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_APPLICATIONS_ROOT = path.join(ROOT, "v2_agent");
@@ -13,6 +16,20 @@ const REQUIRED_CHECKS = Object.freeze([
 ]);
 const APPLICATION_STATUSES = new Set(["draft", "accepted", "rejected"]);
 const SAFE_SEGMENT = /^[a-z0-9][a-z0-9._-]*$/i;
+const ISO_INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const RESERVED_SOURCE_HOST =
+  /(?:^|\.)(?:example\.(?:com|net|org)|example|invalid|localhost|test)$/i;
+// These six routes were already repository-certified before the application
+// gate existed. The identity tuple, rather than only the slug, prevents a
+// future provider or upstream-model swap from inheriting that grandfathering.
+const PRE_WORKFLOW_V2_ROUTES = new Set([
+  '["grok-api/grok-4.5","grok-api","grok-4.5"]',
+  '["grok-oauth/grok-4.5","grok-oauth","grok-4.5"]',
+  '["kimi-api/kimi-k3","kimi-api","kimi-k3"]',
+  '["kimi-oauth/k3","kimi-oauth","k3"]',
+  '["kimi-oauth/kimi-for-coding","kimi-oauth","kimi-for-coding"]',
+  '["kimi-oauth/kimi-for-coding-highspeed","kimi-oauth","kimi-for-coding-highspeed"]',
+]);
 
 function fail(message) {
   throw new Error(`v2-agent application: ${message}`);
@@ -29,7 +46,51 @@ function directories(root) {
 function secretLike(value) {
   // Evidence is intentionally summaries and metadata. A proof must never turn
   // into a durable copy of an API key, bearer capability, or decrypted task.
-  return /(?:\b(?:sk|rk|sess|token)_[a-z0-9_-]{12,}\b|authorization\s*:\s*bearer|bearer\s+[a-z0-9._-]{16,})/i.test(value);
+  return [
+    /\b(?:sk|rk|sess|token)[_-][a-z0-9_-]{12,}\b/i,
+    /\bgh[pousr]_[a-z0-9]{20,}\b/i,
+    /\bgithub_pat_[a-z0-9_]{20,}\b/i,
+    /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/,
+    /\bAIza[a-z0-9_-]{30,}\b/i,
+    /\bya29\.[a-z0-9_-]{20,}\b/i,
+    /\bhf_[a-z0-9]{20,}\b/i,
+    /\bxox[baprs]-[a-z0-9-]{10,}\b/i,
+    /\bglpat-[a-z0-9_-]{20,}\b/i,
+    /\bnpm_[a-z0-9]{30,}\b/i,
+    /\beyJ[a-z0-9_-]{8,}\.[a-z0-9_-]{8,}\.[a-z0-9_-]{8,}\b/i,
+    /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/,
+    /authorization\s*:\s*bearer/i,
+    /bearer\s+[a-z0-9._-]{16,}/i,
+    /(?:api[-_ ]?key|access[-_ ]?token|client[-_ ]?secret)\s*[:=]\s*["']?[a-z0-9+/_=-]{16,}/i,
+  ].some((pattern) => pattern.test(value));
+}
+
+function strictIsoInstant(value) {
+  if (typeof value !== "string" || !ISO_INSTANT.test(value)) return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
+function officialHttpsSource(value) {
+  if (typeof value !== "string") return false;
+  try {
+    const source = new URL(value);
+    if (source.protocol !== "https:" || source.username || source.password) return false;
+    const hostname = source.hostname
+      .toLowerCase()
+      .replace(/^\[|\]$/g, "")
+      .replace(/\.$/, "");
+    return Boolean(hostname) &&
+      hostname.includes(".") &&
+      isIP(hostname) === 0 &&
+      !RESERVED_SOURCE_HOST.test(hostname);
+  } catch {
+    return false;
+  }
+}
+
+function routeIdentity({ slug, provider, upstreamModel }) {
+  return JSON.stringify([slug, provider, upstreamModel]);
 }
 
 function readJson(file) {
@@ -45,54 +106,92 @@ function checkPass(check, label) {
   if (!Number.isInteger(check.status) || check.status < 200 || check.status > 299) {
     fail(`${label} must record a successful HTTP status`);
   }
-  if (!Number.isFinite(Date.parse(check.observedAt || ""))) {
+  if (!strictIsoInstant(check.observedAt)) {
     fail(`${label} must record an ISO observedAt timestamp`);
   }
 }
 
-function checkAcceptedProof(proof, location) {
+function checkAcceptedProof(proof, location, models) {
   if (!Array.isArray(proof.officialSources) || proof.officialSources.length === 0 ||
-      proof.officialSources.some((source) => typeof source !== "string" || !/^https:\/\//.test(source))) {
+      proof.officialSources.some((source) => !officialHttpsSource(source))) {
     fail(`${location}: accepted applications need one or more HTTPS officialSources`);
   }
   for (const key of REQUIRED_CHECKS) checkPass(proof.checks?.[key], `${location}: checks.${key}`);
-  if (!Number.isFinite(Date.parse(proof.testedAt || ""))) {
+  if (!strictIsoInstant(proof.testedAt)) {
     fail(`${location}: accepted applications need an ISO testedAt timestamp`);
   }
   if (typeof proof.routerVersion !== "string" || !proof.routerVersion.trim()) {
     fail(`${location}: accepted applications need routerVersion`);
   }
+  const route = (Array.isArray(models) ? models : []).find((model) =>
+    model?.slug === proof.slug &&
+    model.provider === proof.provider &&
+    model.upstreamModel === proof.model
+  );
+  if (!route) {
+    fail(`${location}: accepted application does not match an exact registry route`);
+  }
+  if (route.multiAgentVersion !== "v2") {
+    fail(`${location}: accepted application requires the exact registry route to declare multiAgentVersion v2`);
+  }
 }
 
-export function validateV2AgentApplications(applicationsRoot = DEFAULT_APPLICATIONS_ROOT) {
+export function validateV2AgentApplications(
+  applicationsRoot = DEFAULT_APPLICATIONS_ROOT,
+  { models = CHECKED_IN_MODELS } = {},
+) {
   const applications = [];
   for (const provider of directories(applicationsRoot)) {
     if (!SAFE_SEGMENT.test(provider)) fail(`invalid provider directory ${provider}`);
     const providerRoot = path.join(applicationsRoot, provider);
-    for (const model of directories(providerRoot)) {
-      if (!SAFE_SEGMENT.test(model)) fail(`invalid model directory ${provider}/${model}`);
-      const location = `${provider}/${model}`;
-      const root = path.join(providerRoot, model);
+    for (const routeName of directories(providerRoot)) {
+      if (!SAFE_SEGMENT.test(routeName)) fail(`invalid model directory ${provider}/${routeName}`);
+      const location = `${provider}/${routeName}`;
+      const root = path.join(providerRoot, routeName);
       const markdown = path.join(root, "proof.md");
       const json = path.join(root, "proof.json");
-      if (!existsSync(markdown) || !statSync(markdown).isFile()) fail(`${location} is missing proof.md`);
-      if (!existsSync(json) || !statSync(json).isFile()) fail(`${location} is missing proof.json`);
+      if (!existsSync(markdown) || !lstatSync(markdown).isFile()) fail(`${location} is missing proof.md`);
+      if (!existsSync(json) || !lstatSync(json).isFile()) fail(`${location} is missing proof.json`);
       const markdownText = readFileSync(markdown, "utf8");
       if (!markdownText.includes("## Evidence")) fail(`${location}: proof.md needs an Evidence section`);
       const proof = readJson(json);
       if (proof?.version !== 1) fail(`${location}: proof.json version must be 1`);
-      if (proof.provider !== provider || proof.model !== model) {
-        fail(`${location}: proof.json provider and model must match its directory`);
+      if (proof.provider !== provider) {
+        fail(`${location}: proof.json provider must match its directory`);
       }
-      if (typeof proof.slug !== "string" || !proof.slug.includes("/")) {
-        fail(`${location}: proof.json needs the exact routed slug`);
+      if (typeof proof.model !== "string" || !proof.model.trim() || /[\u0000-\u001f]/.test(proof.model)) {
+        fail(`${location}: proof.json needs the exact upstream model id`);
+      }
+      const slugParts = typeof proof.slug === "string" ? proof.slug.split("/") : [];
+      if (
+        slugParts.length !== 2 ||
+        slugParts.some((segment) => !SAFE_SEGMENT.test(segment)) ||
+        slugParts[0] !== provider ||
+        slugParts[1] !== routeName
+      ) {
+        fail(`${location}: proof.json slug must match its provider/route directory`);
       }
       if (!APPLICATION_STATUSES.has(proof.status)) fail(`${location}: invalid status`);
       const serialized = `${markdownText}\n${JSON.stringify(proof)}`;
       if (secretLike(serialized)) fail(`${location}: proof artifacts must not contain credentials or bearer values`);
-      if (proof.status === "accepted") checkAcceptedProof(proof, location);
-      applications.push({ provider, model, slug: proof.slug, status: proof.status });
+      if (proof.status === "accepted") checkAcceptedProof(proof, location, models);
+      applications.push({ provider, model: proof.model, slug: proof.slug, status: proof.status });
     }
+  }
+  const accepted = new Set(
+    applications
+      .filter((application) => application.status === "accepted")
+      .map((application) => routeIdentity({
+        slug: application.slug,
+        provider: application.provider,
+        upstreamModel: application.model,
+      })),
+  );
+  for (const model of Array.isArray(models) ? models : []) {
+    if (model?.multiAgentVersion !== "v2") continue;
+    const identity = routeIdentity(model);
+    if (PRE_WORKFLOW_V2_ROUTES.has(identity) || accepted.has(identity)) continue;
+    fail(`${model.slug}: registry v2 route needs an accepted application for the exact route`);
   }
   return applications;
 }

--- a/scripts/check-v2-agent-applications.mjs
+++ b/scripts/check-v2-agent-applications.mjs
@@ -1,0 +1,103 @@
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_APPLICATIONS_ROOT = path.join(ROOT, "v2_agent");
+const REQUIRED_CHECKS = Object.freeze([
+  "streaming",
+  "toolCall",
+  "encryptedRelay",
+  "markerReturn",
+  "sameThreadFollowUp",
+]);
+const APPLICATION_STATUSES = new Set(["draft", "accepted", "rejected"]);
+const SAFE_SEGMENT = /^[a-z0-9][a-z0-9._-]*$/i;
+
+function fail(message) {
+  throw new Error(`v2-agent application: ${message}`);
+}
+
+function directories(root) {
+  if (!existsSync(root)) return [];
+  return readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("_"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function secretLike(value) {
+  // Evidence is intentionally summaries and metadata. A proof must never turn
+  // into a durable copy of an API key, bearer capability, or decrypted task.
+  return /(?:\b(?:sk|rk|sess|token)_[a-z0-9_-]{12,}\b|authorization\s*:\s*bearer|bearer\s+[a-z0-9._-]{16,})/i.test(value);
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    fail(`${file}: invalid JSON (${error instanceof Error ? error.message : String(error)})`);
+  }
+}
+
+function checkPass(check, label) {
+  if (!check || check.outcome !== "pass") fail(`${label} must record outcome: "pass"`);
+  if (!Number.isInteger(check.status) || check.status < 200 || check.status > 299) {
+    fail(`${label} must record a successful HTTP status`);
+  }
+  if (!Number.isFinite(Date.parse(check.observedAt || ""))) {
+    fail(`${label} must record an ISO observedAt timestamp`);
+  }
+}
+
+function checkAcceptedProof(proof, location) {
+  if (!Array.isArray(proof.officialSources) || proof.officialSources.length === 0 ||
+      proof.officialSources.some((source) => typeof source !== "string" || !/^https:\/\//.test(source))) {
+    fail(`${location}: accepted applications need one or more HTTPS officialSources`);
+  }
+  for (const key of REQUIRED_CHECKS) checkPass(proof.checks?.[key], `${location}: checks.${key}`);
+  if (!Number.isFinite(Date.parse(proof.testedAt || ""))) {
+    fail(`${location}: accepted applications need an ISO testedAt timestamp`);
+  }
+  if (typeof proof.routerVersion !== "string" || !proof.routerVersion.trim()) {
+    fail(`${location}: accepted applications need routerVersion`);
+  }
+}
+
+export function validateV2AgentApplications(applicationsRoot = DEFAULT_APPLICATIONS_ROOT) {
+  const applications = [];
+  for (const provider of directories(applicationsRoot)) {
+    if (!SAFE_SEGMENT.test(provider)) fail(`invalid provider directory ${provider}`);
+    const providerRoot = path.join(applicationsRoot, provider);
+    for (const model of directories(providerRoot)) {
+      if (!SAFE_SEGMENT.test(model)) fail(`invalid model directory ${provider}/${model}`);
+      const location = `${provider}/${model}`;
+      const root = path.join(providerRoot, model);
+      const markdown = path.join(root, "proof.md");
+      const json = path.join(root, "proof.json");
+      if (!existsSync(markdown) || !statSync(markdown).isFile()) fail(`${location} is missing proof.md`);
+      if (!existsSync(json) || !statSync(json).isFile()) fail(`${location} is missing proof.json`);
+      const markdownText = readFileSync(markdown, "utf8");
+      if (!markdownText.includes("## Evidence")) fail(`${location}: proof.md needs an Evidence section`);
+      const proof = readJson(json);
+      if (proof?.version !== 1) fail(`${location}: proof.json version must be 1`);
+      if (proof.provider !== provider || proof.model !== model) {
+        fail(`${location}: proof.json provider and model must match its directory`);
+      }
+      if (typeof proof.slug !== "string" || !proof.slug.includes("/")) {
+        fail(`${location}: proof.json needs the exact routed slug`);
+      }
+      if (!APPLICATION_STATUSES.has(proof.status)) fail(`${location}: invalid status`);
+      const serialized = `${markdownText}\n${JSON.stringify(proof)}`;
+      if (secretLike(serialized)) fail(`${location}: proof artifacts must not contain credentials or bearer values`);
+      if (proof.status === "accepted") checkAcceptedProof(proof, location);
+      applications.push({ provider, model, slug: proof.slug, status: proof.status });
+    }
+  }
+  return applications;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const applications = validateV2AgentApplications(process.argv[2] || DEFAULT_APPLICATIONS_ROOT);
+  process.stdout.write(`v2-agent applications valid (${applications.length})\n`);
+}

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -496,12 +496,14 @@ function normalizeNativeModel(model) {
   const supportsParallelToolCalls =
     typeof model.supports_parallel_tool_calls === "boolean"
       ? model.supports_parallel_tool_calls
-      : NATIVE_PARALLEL_TOOL_CALL_COMPAT.get(String(model.slug));
+      : NATIVE_PARALLEL_TOOL_CALL_COMPAT.get(String(model.slug)) ?? false;
   return {
     ...model,
-    ...(typeof supportsParallelToolCalls === "boolean"
-      ? { supports_parallel_tool_calls: supportsParallelToolCalls }
-      : {}),
+    // Recent Codex clients require this field on every catalog entry. An
+    // absent native declaration is not evidence that parallel calls work, so
+    // make the conservative answer explicit instead of leaving the catalog
+    // unparsable.
+    supports_parallel_tool_calls: supportsParallelToolCalls,
     supports_reasoning_summaries:
       typeof model.supports_reasoning_summaries === "boolean"
         ? model.supports_reasoning_summaries
@@ -589,6 +591,10 @@ export function routedModel(template, model, behaviorTemplate = template) {
     // absent declaration remains the conservative default.
     supports_search_tool: ["hosted", "standalone"].includes(model.searchTool?.mode),
     supports_image_detail_original: model.supportsImageDetailOriginal === true,
+    // A routed model must never inherit a native template's capability. Codex
+    // now requires the key, and `false` is both schema-valid and conservative
+    // until this exact provider/model route declares support.
+    supports_parallel_tool_calls: model.supportsParallelToolCalls === true,
     use_responses_lite: false,
     // Codex only knows one ApplyPatchToolType variant. The native template
     // carries "freeform", but upstreams that reject OpenAI custom tools (Meta
@@ -612,9 +618,6 @@ export function routedModel(template, model, behaviorTemplate = template) {
   // A few OpenAI-compatible upstreams reject tool scheduling the native
   // template advertises. Registry entries opt out explicitly so the picker
   // never offers a custom or parallel tool the provider backend will 400.
-  if (typeof model.supportsParallelToolCalls === "boolean") {
-    next.supports_parallel_tool_calls = model.supportsParallelToolCalls;
-  }
   if (Array.isArray(model.experimentalSupportedTools)) {
     next.experimental_supported_tools = [...model.experimentalSupportedTools];
   }
@@ -725,16 +728,10 @@ function sortCatalogModels(models) {
   });
 }
 
-// Native entries carry upstream's static multi_agent_version, and upstream
-// still ships gpt-5.6-luna as "v1" even though it runs correctly on the v2
-// backend (openai/codex#35097, #36294). spawn_agent filters candidate child
-// models on that static value, so a v1 entry can never be delegated to by a v2
-// parent.
-//
-// These upstream-verified slugs run fine on the v2 backend, so they are
-// promoted unconditionally — no mode switch, no Settings dance. The subagent
-// opt-in below only reaches the *remaining* native models, which stay
-// conservative because their v2 relay paths have not been verified.
+// Native entries carry upstream's static multi_agent_version. One pinned
+// backend exception is maintained in the repository after upstream evidence;
+// local selection or a stream/tool probe must never promote any other v1
+// model. That avoids turning a UI toggle into an unreviewed v2 assertion.
 const NATIVE_V2_BACKEND_SLUGS = new Set(["gpt-5.6-luna"]);
 
 export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
@@ -749,13 +746,16 @@ export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
       return { ...model, multi_agent_version: "v1" };
     }
     if (model.visibility !== "list") return model;
-    if (hidden.has(slug) || disabled.has(slug)) return model;
+    if (hidden.has(slug) || disabled.has(slug)) {
+      return { ...model, multi_agent_version: "v1" };
+    }
     if (NATIVE_V2_BACKEND_SLUGS.has(slug)) {
       return { ...model, multi_agent_version: "v2" };
     }
-    if (settings.mode === "all" || (settings.mode === "selected" && enabled.has(slug))) {
-      return { ...model, multi_agent_version: "v2" };
-    }
+    // Deliberately do not use `mode` / `enabled` to promote a native model.
+    // Settings may opt an existing certificate out, not create one.
+    void enabled;
+    void settings;
     return model;
   });
 }

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -734,6 +734,19 @@ function sortCatalogModels(models) {
 // model. That avoids turning a UI toggle into an unreviewed v2 assertion.
 const NATIVE_V2_BACKEND_SLUGS = new Set(["gpt-5.6-luna"]);
 
+// Keep the repository/upstream verdict separate from the effective catalog
+// value. Hiding or disabling a certified native route correctly publishes it
+// as v1, but that opt-out must not erase the certificate the control surfaces
+// need in order to let the operator turn it back on.
+export function nativeSubagentCertification(model) {
+  const slug = String(model?.slug || "");
+  if (NATIVE_CONTEXT_VARIANT_SLUGS.includes(slug)) return "v1";
+  if (NATIVE_V2_BACKEND_SLUGS.has(slug)) return "v2";
+  return model?.multi_agent_version === "v2" || model?.multi_agent_version === "v1"
+    ? model.multi_agent_version
+    : undefined;
+}
+
 export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
   const enabled = new Set(settings.enabled || []);
   const disabled = new Set(settings.disabled || []);
@@ -749,7 +762,7 @@ export function promoteNativeMultiAgent(models, settings, hidden = new Set()) {
     if (hidden.has(slug) || disabled.has(slug)) {
       return { ...model, multi_agent_version: "v1" };
     }
-    if (NATIVE_V2_BACKEND_SLUGS.has(slug)) {
+    if (nativeSubagentCertification(model) === "v2") {
       return { ...model, multi_agent_version: "v2" };
     }
     // Deliberately do not use `mode` / `enabled` to promote a native model.
@@ -861,10 +874,10 @@ function main() {
   const pickerState = modelPickerSnapshot();
   const visibleModels = new Set(pickerState.visible);
   const multiAgentSettings = readMultiAgentSettings();
-  // Demotions first, then this machine's own recorded proofs. Settings still
-  // never manufacture a v2 claim — a promotion here traces to a live probe
-  // or an observed spawn in `multi-agent-proofs.json` — and a slug the
-  // operator hid or switched off stays v1 whatever evidence it carries.
+  // Settings can disable a certified route, but machine-local proof records
+  // are diagnostic only: neither a compatibility probe nor an observed child
+  // turn may manufacture a v2 claim. That capability belongs to the exact
+  // checked-in registry route and its reviewed v2_agent application.
   const allMultiAgentModels = applyMultiAgentCapabilities(
     selectedModels,
     multiAgentSettings,

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -145,6 +145,7 @@ function nativeCodexModels(
         // probe consumers; a false marker identifies synthesized variants.
         ...(nativeBaseSlugs.has(model.slug) ? {} : { nativeClientManaged: false }),
         multiAgentVersion: model.multi_agent_version || "v1",
+        subagentCertification: subagentCertification(model),
         // Base native entries belong to Codex's own catalog.  A router picker
         // overlay must not make them disappear; synthesized context variants
         // remain router-managed and can still be switched off explicitly.
@@ -164,6 +165,12 @@ function reasoningLevelField(levels) {
     .map((level) => (typeof level === "string" ? level : level?.effort))
     .filter((level) => typeof level === "string" && level);
   return names.length ? { reasoningLevels: names } : {};
+}
+
+function subagentCertification(model) {
+  const version = model?.multiAgentVersion ?? model?.multi_agent_version;
+  if (version === "v2" || version === "v1") return version;
+  return "unknown";
 }
 
 // --- per-target probes (run with MODEL_ROUTER_TARGET set) -------------------
@@ -219,16 +226,8 @@ async function emitProbe() {
   const usageEvents = TARGET === "codex"
     ? (await import("./usage-events.mjs")).recentUsageEvents()
     : [];
-  // The same machine-local capability proofs the catalog honors: the tray's
-  // "Subagent models" section filters on v2, so a probe built from the raw
-  // registry hid every model this machine had just verified — the third
-  // consumer to need this overlay, after the catalog and the DSH preset.
-  //
-  // Deliberately unlike the catalog, `disabled` is not passed: the catalog
-  // demotes a switched-off model so Codex stops offering it, but this probe
-  // is what draws the rows the operator switches. A proven model whose
-  // toggle is off must keep its row — with the toggle shown off — or the
-  // section it was switched off in loses the way to switch it back on.
+  // Local proof records are surfaced for status only. They never alter the
+  // registry capability sent to Codex.
   const { applySubagentProofs } = await import("./subagent-proofs.mjs");
   const provenListedModels = applySubagentProofs(
     LISTED_MODELS,
@@ -244,6 +243,7 @@ async function emitProbe() {
     gatewayModel: model.gatewayModel,
     enabled: enabledProviders.includes(model.provider),
     multiAgentVersion: model.multiAgentVersion || "v1",
+    subagentCertification: subagentCertification(model),
     visible: picker.hasExplicitVisibility
       ? visibleModels.has(model.slug)
       : !hiddenModels.has(model.slug),
@@ -414,6 +414,7 @@ async function routerCatalogSnapshot() {
     gatewayModel: model.gatewayModel,
     enabled: true,
     multiAgentVersion: model.multiAgentVersion || "v1",
+    subagentCertification: subagentCertification(model),
     visible: picker.hasExplicitVisibility ? visible.has(model.slug) : !hidden.has(model.slug),
     isFree: model.isFree === true,
     ...reasoningLevelField(model.reasoningLevels),
@@ -1043,6 +1044,23 @@ async function knownModelSlug(slug) {
   return MODEL_BY_SLUG.has(slug);
 }
 
+async function knownModelSubagentVersion(slug) {
+  try {
+    const { MERGED_CATALOG_PATH } = await import("./paths.mjs");
+    const parsed = JSON.parse(readFileSync(MERGED_CATALOG_PATH, "utf8"));
+    const model = Array.isArray(parsed.models)
+      ? parsed.models.find((candidate) => String(candidate?.slug) === slug)
+      : undefined;
+    if (model?.multi_agent_version === "v1" || model?.multi_agent_version === "v2") {
+      return model.multi_agent_version;
+    }
+  } catch {
+    // Fall back to the checked-in registry for fresh installs.
+  }
+  const { MODEL_BY_SLUG } = await import("./model-registry.mjs");
+  return MODEL_BY_SLUG.get(slug)?.multiAgentVersion;
+}
+
 async function nativeCodexBaseSlugs() {
   const { NATIVE_CATALOG_PATH } = await import("./paths.mjs");
   if (!existsSync(NATIVE_CATALOG_PATH)) return new Set();
@@ -1068,7 +1086,48 @@ async function handleSubagents(action, value, flag, rest = []) {
     subagentSettingsSnapshot,
   } = await import("./multi-agent-state.mjs");
   if (action === "status") {
-    process.stdout.write(`${JSON.stringify(subagentSettingsSnapshot())}\n`);
+    const { selectedConfiguredListedModels } = await import("./provider-selection.mjs");
+    const { subagentAutoPolicySnapshot } = await import("./subagent-auto-policy.mjs");
+    process.stdout.write(`${JSON.stringify({
+      ...subagentSettingsSnapshot(),
+      autoPolicies: subagentAutoPolicySnapshot(selectedConfiguredListedModels()),
+    })}\n`);
+    return;
+  }
+  if (action === "policy") {
+    const [kind, selector, desired] = [value, flag, rest[2]];
+    if (kind === "status" || !kind) {
+      const { selectedConfiguredListedModels } = await import("./provider-selection.mjs");
+      const { subagentAutoPolicySnapshot } = await import("./subagent-auto-policy.mjs");
+      process.stdout.write(`${JSON.stringify(subagentAutoPolicySnapshot(selectedConfiguredListedModels()))}\n`);
+      return;
+    }
+    if (!selector || !["on", "off"].includes(desired)) {
+      throw new Error(
+        "Usage: control subagents policy status|provider <provider-id> <on|off>|model <model-slug> <on|off>|family <name> <on|off>",
+      );
+    }
+    const { setSubagentAutoPolicy, matchingSubagentAutoPolicyModels } = await import(
+      "./subagent-auto-policy.mjs"
+    );
+    const policyState = setSubagentAutoPolicy(kind, selector, desired === "on");
+    // Enabling a policy is explicit standing consent for its matching live
+    // probes. Only models currently configured for this machine can spend it.
+    if (desired === "on") {
+      const { selectedConfiguredListedModels } = await import("./provider-selection.mjs");
+      const matches = matchingSubagentAutoPolicyModels(
+        selectedConfiguredListedModels().filter((model) => model.multiAgentVersion !== "v1"),
+        policyState.policies,
+      );
+      const slugs = matches.map((model) => model.slug);
+      if (slugs.length) {
+        setMultiAgentModels(slugs, true);
+        const { spawnDetachedVerification } = await import("./subagent-verify.mjs");
+        spawnDetachedVerification(slugs);
+      }
+    }
+    refreshModelSettingsCatalog();
+    process.stdout.write(`${JSON.stringify(policyState)}\n`);
     return;
   }
   if (action === "select-all") {
@@ -1115,6 +1174,11 @@ async function handleSubagents(action, value, flag, rest = []) {
     if (!(await knownModelSlug(value))) {
       throw new Error(`Unknown model slug: ${value}`);
     }
+    if (flag === "on" && (await knownModelSubagentVersion(value)) === "v1") {
+      throw new Error(
+        `${value} is repository-certified v1 and cannot be enabled as a native v2 subagent.`,
+      );
+    }
     setMultiAgentModel(value, flag === "on");
     // Selection is the assignment: switching a model on hands it to the
     // capability probe. Detached, because this command answers a tray toggle
@@ -1150,10 +1214,15 @@ async function handleSubagents(action, value, flag, rest = []) {
     let slugs;
     if (provider === "openai") {
       const { NATIVE_CATALOG_PATH } = await import("./paths.mjs");
-      slugs = nativeCodexModels(NATIVE_CATALOG_PATH).map((model) => model.slug);
+      slugs = nativeCodexModels(NATIVE_CATALOG_PATH)
+        .filter((model) => model.subagentCertification !== "v1")
+        .map((model) => model.slug);
     } else {
       slugs = selectedConfiguredListedModels()
-        .filter((model) => canonicalProviderId(model.provider) === provider)
+        .filter(
+          (model) =>
+            canonicalProviderId(model.provider) === provider && model.multiAgentVersion !== "v1",
+        )
         .map((model) => model.slug);
     }
     if (slugs.length === 0) {
@@ -1168,7 +1237,8 @@ async function handleSubagents(action, value, flag, rest = []) {
     throw new Error(
       "Usage: control subagents status|select-all|unselect-all|mode <all|selected|proven>|" +
         "set <model-slug> <on|off>|effort <model-slug> <level|default>|" +
-        "provider <provider-id> <on|off>|verify [model-slug ...]",
+        "provider <provider-id> <on|off>|verify [model-slug ...]|" +
+        "policy status|provider <provider-id> <on|off>|model <model-slug> <on|off>|family <name> <on|off>",
     );
   }
   refreshModelSettingsCatalog();

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { pickerCommandArgs } from "./control-args.mjs";
-import { promoteNativeMultiAgent } from "./catalog.mjs";
+import { nativeSubagentCertification, promoteNativeMultiAgent } from "./catalog.mjs";
 import {
   applyModelOverlayPublication,
   transactModelOverlayMutation,
@@ -120,16 +120,20 @@ function nativeCodexModels(
         .map((model) => String(model?.slug || ""))
         .filter(Boolean),
     );
-    return promoteNativeMultiAgent(
+    const nativeModels = withNativeContextVariants(
       // The capture holds what Codex published; the extended-window variants
       // are the router's own additions to the same group, and the tray is
       // where they are switched on, so they have to be drawn here too. The
       // catalog build derives them from this same list, so the rows the
       // operator sees and the entries Codex reads cannot drift apart.
-      withNativeContextVariants(
-        Array.isArray(parsed.models) ? parsed.models : [],
-        { enabled: contextVariants },
-      ),
+      Array.isArray(parsed.models) ? parsed.models : [],
+      { enabled: contextVariants },
+    );
+    const certificationBySlug = new Map(
+      nativeModels.map((model) => [model.slug, nativeSubagentCertification(model) || "unknown"]),
+    );
+    return promoteNativeMultiAgent(
+      nativeModels,
       subagentSettings,
       hiddenModels,
     )
@@ -145,7 +149,7 @@ function nativeCodexModels(
         // probe consumers; a false marker identifies synthesized variants.
         ...(nativeBaseSlugs.has(model.slug) ? {} : { nativeClientManaged: false }),
         multiAgentVersion: model.multi_agent_version || "v1",
-        subagentCertification: subagentCertification(model),
+        subagentCertification: certificationBySlug.get(model.slug) || "unknown",
         // Base native entries belong to Codex's own catalog.  A router picker
         // overlay must not make them disappear; synthesized context variants
         // remain router-managed and can still be switched off explicitly.
@@ -229,14 +233,14 @@ async function emitProbe() {
   // Local proof records are surfaced for status only. They never alter the
   // registry capability sent to Codex.
   const { applySubagentProofs } = await import("./subagent-proofs.mjs");
-  const provenListedModels = applySubagentProofs(
+  const effectiveListedModels = applySubagentProofs(
     LISTED_MODELS,
     subagentSettings.proofs,
     { hidden: hiddenModels },
   );
   // The tray groups models by provider to build its rows, so protocol
   // variants report their canonical family id: one opencode Go row, not three.
-  const routedModels = provenListedModels.map((model) => ({
+  const routedModels = effectiveListedModels.map((model) => ({
     slug: model.slug,
     displayName: model.displayName,
     provider: canonicalProviderId(model.provider),
@@ -1045,6 +1049,36 @@ async function knownModelSlug(slug) {
 }
 
 async function knownModelSubagentVersion(slug) {
+  // Routed-model certification belongs to the registry. The merged Codex
+  // catalog deliberately serializes an unknown route as conservative v1, so
+  // consulting it first would mislabel every still-uncertified route as a
+  // reviewed v1 verdict and make the compatibility-test workflow unreachable.
+  const { MODEL_BY_SLUG } = await import("./model-registry.mjs");
+  const registryModel = MODEL_BY_SLUG.get(slug);
+  if (registryModel) return registryModel.multiAgentVersion;
+
+  // Native models do not live in the routed registry. Read their undemoted
+  // capture before the merged catalog: a disabled certified route is
+  // deliberately serialized there as v1, but the operator must still be able
+  // to turn it back on. This helper also carries the repository-pinned Luna
+  // certificate and the parent-only verdict for context variants.
+  try {
+    const { NATIVE_CATALOG_PATH } = await import("./paths.mjs");
+    const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
+    const model = Array.isArray(parsed.models)
+      ? parsed.models.find((candidate) => String(candidate?.slug) === slug)
+      : undefined;
+    // Finding the route is itself decisive: an omitted version is genuinely
+    // unknown and must stay eligible for the compatibility workflow. Falling
+    // through to the effective merged catalog would turn that unknown into
+    // its conservative serialized v1 and make the UI's Test action fail.
+    if (model) return nativeSubagentCertification(model);
+  } catch {
+    // Fall back to the merged catalog when the original capture is absent.
+  }
+
+  // Retain compatibility with installations that have a merged catalog but
+  // no native capture. This is conservative: an effective v1 remains v1.
   try {
     const { MERGED_CATALOG_PATH } = await import("./paths.mjs");
     const parsed = JSON.parse(readFileSync(MERGED_CATALOG_PATH, "utf8"));
@@ -1055,10 +1089,9 @@ async function knownModelSubagentVersion(slug) {
       return model.multi_agent_version;
     }
   } catch {
-    // Fall back to the checked-in registry for fresh installs.
+    // A missing or damaged merged catalog proves no native v1/v2 verdict.
   }
-  const { MODEL_BY_SLUG } = await import("./model-registry.mjs");
-  return MODEL_BY_SLUG.get(slug)?.multiAgentVersion;
+  return undefined;
 }
 
 async function nativeCodexBaseSlugs() {
@@ -1181,7 +1214,7 @@ async function handleSubagents(action, value, flag, rest = []) {
     }
     setMultiAgentModel(value, flag === "on");
     // Selection is the assignment: switching a model on hands it to the
-    // capability probe. Detached, because this command answers a tray toggle
+    // compatibility probe. Detached, because this command answers a tray toggle
     // and cannot sit on a live network round-trip; the proofs snapshot shows
     // "checking" until the worker records a verdict and republishes.
     if (flag === "on") {

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -465,6 +465,21 @@ async function main() {
     return;
   }
   if (wantsApply) {
+    // An auto-policy is standing, provider/family-scoped consent to verify a
+    // newly curated model. This runs only after the overlay is published: the
+    // worker imports a fresh registry and can route the new slug immediately.
+    const addedModels = nextMine.filter((model) => !curated.has(model.upstreamModel));
+    if (addedModels.length) {
+      const { matchingSubagentAutoPolicyModels } = await import("./subagent-auto-policy.mjs");
+      const matching = matchingSubagentAutoPolicyModels(addedModels);
+      if (matching.length) {
+        const { spawnDetachedVerification } = await import("./subagent-verify.mjs");
+        spawnDetachedVerification(
+          matching.map((model) => model.slug),
+          { deferCandidateResolution: true },
+        );
+      }
+    }
     process.stdout.write("Curated models are live. Fully quit and reopen the app to refresh its picker.\n");
   } else {
     process.stdout.write("Run ./bin/install to regenerate routes and the picker catalog.\n");

--- a/src/dsh-config-manager.mjs
+++ b/src/dsh-config-manager.mjs
@@ -360,9 +360,10 @@ function routerCallerKey() {
  */
 export function subagentPreset() {
   const { models } = dshRoutedModels();
-  // The same proven set Codex's native spawn overrides draw from: a model
-  // marked `multiAgentVersion: "v2"` has been through the collaboration probe,
-  // and the user has not switched it off.
+  // The same repository-certified set Codex's native spawn overrides draw
+  // from: a v2 route has an accepted native-collaboration application (or an
+  // exact pre-workflow grandfathered identity), and the user has not switched
+  // it off. Machine-local compatibility probes never enter this set.
   const eligible = subagentEligibleModels(models, readMultiAgentSettings());
   const chosen = dshDefaultModel(eligible.length ? eligible : models);
   return {

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -692,6 +692,17 @@ function mergeUserModels(base) {
   const gatewayModels = new Set(models.map((model) => model.gatewayModel));
   const userModels = new Set();
   for (const model of readUserModels()) {
+    // A mutable local overlay may describe routing and presentation, but it
+    // cannot grant itself the repository's native-collaboration certificate.
+    // Local Ollama/LM Studio entries intentionally declare conservative v1 so
+    // they are settled and never spend a cloud compatibility probe. Preserve
+    // that denial, but refuse the positive certificate.
+    if (model?.multiAgentVersion === "v2") {
+      warnings.push(
+        `Skipped user model: model ${model?.slug || "<unknown>"} may not declare multiAgentVersion v2`,
+      );
+      continue;
+    }
     const problem = modelProblem(model, base.providers, slugs, gatewayModels);
     if (problem) {
       warnings.push(`Skipped user model: ${problem}`);
@@ -722,6 +733,11 @@ const registry = loadRegistry();
 const merged = mergeUserModels(registry);
 
 export const PROVIDERS = registry.providers;
+// The immutable registry shipped by this checkout, before the operator's
+// mutable user-model overlay is merged. Repository certification gates must
+// bind to this set: a local overlay is useful routing configuration, but it
+// cannot certify itself for every installer.
+export const CHECKED_IN_MODELS = registry.models;
 export const MODELS = merged.models;
 export const USER_MODEL_WARNINGS = merged.warnings;
 export const LISTED_MODELS = Object.freeze(MODELS.filter((model) => model.listed));

--- a/src/multi-agent-state.mjs
+++ b/src/multi-agent-state.mjs
@@ -67,10 +67,9 @@ export function subagentSettingsSnapshot() {
     ...settings,
     all: settings.mode === "all",
     path: MULTI_AGENT_STATE_PATH,
-    // Machine-local capability verdicts, keyed by slug: checking /
-    // experimental / proven / failed (with the failure reason). This is what
-    // lets a surface explain *why* an enabled model is or is not offered as
-    // a subagent instead of leaving it a silent no-show.
+    // Machine-local certification evidence, keyed by slug: checking /
+    // candidate / failed (with the failure reason). It explains why an
+    // unknown model is awaiting review, but cannot manufacture a v2 claim.
     proofs: subagentProofSnapshot(),
     // Per-model reasoning depth applied only to child turns. Empty when the
     // operator has never set one, which is the common case.
@@ -203,8 +202,9 @@ export function applyMultiAgentSettings(models, settings, hidden = new Set()) {
   });
 }
 
-// Resolve the effective v2 claims once so catalog publication, managed agent
-// definitions, and doctor checks cannot disagree about machine-local proofs.
+// Resolve the effective registry v2 claims once so catalog publication,
+// managed agent definitions, and doctor checks cannot disagree. Local proofs
+// are deliberately diagnostic only.
 export function applyMultiAgentCapabilities(
   models,
   settings,

--- a/src/routed-client-models.mjs
+++ b/src/routed-client-models.mjs
@@ -65,10 +65,10 @@ export function routedClientModels() {
   const picker = modelPickerSnapshot();
   const hidden = new Set(picker.hidden);
   const visible = new Set(picker.visible);
-  // The same machine-local capability proofs the Codex catalog honors: a model
-  // this machine verified as a subagent is one everywhere the proven set is
-  // consumed, or a client's tool-subagent preset silently disagrees with the
-  // picker about which children exist.
+  // Keep every client on the same registry-certified capabilities. Local
+  // stream/tool probe records are passed through for compatibility with the
+  // proof overlay API, but applySubagentProofs deliberately treats them as
+  // diagnostic application evidence and never promotes a route to v2.
   const selected = applySubagentProofs(
     selectedConfiguredListedModels().filter((model) => {
       const slug = String(model.slug);

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1880,38 +1880,13 @@ function requireCodexTransport(request, response) {
   return true;
 }
 
-// A model in the experimental subagent window earns its durable proof — or
-// its demotion — from real traffic: Codex marks child turns with
-// x-openai-subagent, so the first clean completion of one settles "this model
-// can hold the child role" without a dedicated probe session. Structural
-// rejections demote (400/422, the shape a schema or encrypted-payload refusal
-// takes); transient failures — 429s, 5xx, disconnects — prove nothing either
-// way and leave the window open. No line here is QUIET-gated: a promotion or
-// demotion that happens silently is how a picker entry becomes unexplainable.
-//
-// What the promotion claims is exactly one HTTP turn, and the log line has to
-// say so. A child agent makes many turns — one per tool-call round trip — and
-// this observer sees each of them separately; it never sees the agent loop
-// that strings them together, so "the child reached done" is not a fact
-// available here. An operator who read the old "subagent proven … completed a
-// live child turn" as *the delegated work finished* was reading a promise the
-// router cannot make (issue #257).
-//
-// The two halves of that issue meet here, and both are about the gate rather
-// than the thresholds. The gate used to be `awaitingSpawnProof`, true only for
-// `experimental` — so the instant turn one promoted a slug this function
-// stopped looking at it, and a hard 400/422 on turn two was discarded along
-// with everything else. That made the *oldest* observation win over the
-// newest, which no comment ever argued for. The gate is now revocability, so a
-// slug keeps being watched for as long as this machine's traffic is what the
-// v2 advertisement rests on; promotion alone stays scoped to the experimental
-// window, because a first clean turn is only news once.
-//
-// Watching a `proven` slug is also what makes the convergence signal usable. A
-// looping child emits 200s forever, so no status-shaped branch could ever fire
-// for it; the evidence is instead how much of its own budget one spawn burns
-// without stopping, accounted per child thread in subagent-turns.mjs against
-// the model's declared auto-compact limit.
+// Older releases advertised a locally probed route as experimental and then
+// refined that record from `x-openai-subagent` traffic. Keep observing only
+// those historical experimental records so upgrades preserve useful evidence,
+// but never treat the result as catalog authority: local traffic can neither
+// promote nor demote the exact checked-in registry certificate. A 400/422 is
+// useful negative application evidence; transient failures prove nothing. A
+// clean 200 proves only one HTTP turn completed, not that a delegated task did.
 
 function observeSubagentOutcome(request, route, status, options = {}) {
   if (!route) return;
@@ -1924,8 +1899,8 @@ function observeSubagentOutcome(request, route, status, options = {}) {
       recordSpawnFailure(route.slug, { reason, ...detail });
       forgetChildSpawn(spawnId);
       console.error(
-        `[codex-router] subagent demoted: ${route.slug} ${reason}; ` +
-          "it stays v1 until 'control subagents verify' passes again",
+        `[codex-router] legacy subagent evidence rejected: ${route.slug} ${reason}; ` +
+          "the route still requires a reviewed repository v2 certificate",
       );
     };
     if (status === 400 || status === 422) {
@@ -1941,8 +1916,8 @@ function observeSubagentOutcome(request, route, status, options = {}) {
     if (awaitingSpawnProof(route.slug, proofs)) {
       recordSpawnObserved(route.slug, { status });
       console.error(
-        `[codex-router] subagent child role verified: ${route.slug} served a live child turn; ` +
-          "the model holds the child role on the wire, which is not a claim the child finished its task",
+        `[codex-router] legacy subagent evidence observed: ${route.slug} served one child HTTP turn; ` +
+          "this remains diagnostic and is not a repository v2 certificate",
       );
     }
     const spawn = observeChildTurn({

--- a/src/subagent-auto-policy.mjs
+++ b/src/subagent-auto-policy.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
+import { canonicalProviderId } from "./provider-selection.mjs";
 
 // Policies are an operator's standing permission to spend the small
 // compatibility-probe budget for unknown models that match a route or family.
@@ -83,7 +84,9 @@ export function setSubagentAutoPolicy(kind, value, enabled, filePath = SUBAGENT_
 export function modelMatchesSubagentAutoPolicy(model, policy) {
   if (!model?.slug || !policy) return false;
   if (policy.kind === "model") return String(model.slug) === policy.value;
-  if (policy.kind === "provider") return String(model.provider) === policy.value;
+  if (policy.kind === "provider") {
+    return canonicalProviderId(String(model.provider)) === canonicalProviderId(policy.value);
+  }
   if (policy.kind === "family") {
     const family = normalized(policy.value);
     return [model.slug, model.displayName, model.upstreamModel]

--- a/src/subagent-auto-policy.mjs
+++ b/src/subagent-auto-policy.mjs
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { writePrivateJson } from "./file-security.mjs";
+import { STATE_DIR } from "./paths.mjs";
+
+// Policies are an operator's standing permission to spend the small
+// compatibility-probe budget for unknown models that match a route or family.
+// They do not assert a v2 capability: only a reviewed repository certificate
+// may set multiAgentVersion: "v2". Explicit registry-v1 models are excluded
+// by the caller before a policy can spend a probe on them.
+export const SUBAGENT_AUTO_POLICY_PATH =
+  process.env.MODEL_ROUTER_SUBAGENT_AUTO_POLICY ||
+  path.join(STATE_DIR, "subagent-auto-policy.json");
+
+export const SUBAGENT_AUTO_POLICY_KINDS = Object.freeze(["provider", "model", "family"]);
+
+function normalized(value) {
+  return String(value || "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function validPolicy(kind, value) {
+  if (!SUBAGENT_AUTO_POLICY_KINDS.includes(kind)) return false;
+  const raw = String(value || "").trim();
+  if (!raw) return false;
+  if (kind === "family") return normalized(raw).length >= 3;
+  return /^[a-z0-9][a-z0-9._/-]*$/i.test(raw);
+}
+
+function policyKey(policy) {
+  return `${policy.kind}:${policy.value}`;
+}
+
+function cleanPolicies(value) {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set();
+  const policies = [];
+  for (const raw of value) {
+    const kind = typeof raw?.kind === "string" ? raw.kind : "";
+    const value = typeof raw?.value === "string" ? raw.value.trim() : "";
+    if (!validPolicy(kind, value)) continue;
+    const policy = { kind, value };
+    const key = policyKey(policy);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    policies.push(policy);
+  }
+  return policies.sort((left, right) => policyKey(left).localeCompare(policyKey(right)));
+}
+
+export function readSubagentAutoPolicies(filePath = SUBAGENT_AUTO_POLICY_PATH) {
+  if (!existsSync(filePath)) return { version: 1, policies: [] };
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+    if (parsed?.version === 1) return { version: 1, policies: cleanPolicies(parsed.policies) };
+  } catch {
+    // An unreadable policy document is permission to spend nothing.
+  }
+  return { version: 1, policies: [] };
+}
+
+function writePolicies(policies, filePath = SUBAGENT_AUTO_POLICY_PATH) {
+  writePrivateJson(filePath, { version: 1, policies: cleanPolicies(policies) }, { directoryMode: 0o700 });
+}
+
+export function setSubagentAutoPolicy(kind, value, enabled, filePath = SUBAGENT_AUTO_POLICY_PATH) {
+  const normalizedKind = String(kind || "").trim();
+  const normalizedValue = String(value || "").trim();
+  if (!validPolicy(normalizedKind, normalizedValue)) {
+    throw new Error(
+      "Invalid subagent auto policy. Use provider <provider-id>, model <model-slug>, or family <model-family>.",
+    );
+  }
+  const current = readSubagentAutoPolicies(filePath).policies;
+  const key = `${normalizedKind}:${normalizedValue}`;
+  const policies = enabled
+    ? [...current, { kind: normalizedKind, value: normalizedValue }]
+    : current.filter((policy) => policyKey(policy) !== key);
+  writePolicies(policies, filePath);
+  return readSubagentAutoPolicies(filePath);
+}
+
+export function modelMatchesSubagentAutoPolicy(model, policy) {
+  if (!model?.slug || !policy) return false;
+  if (policy.kind === "model") return String(model.slug) === policy.value;
+  if (policy.kind === "provider") return String(model.provider) === policy.value;
+  if (policy.kind === "family") {
+    const family = normalized(policy.value);
+    return [model.slug, model.displayName, model.upstreamModel]
+      .some((value) => normalized(value).includes(family));
+  }
+  return false;
+}
+
+// Keep matching data-only. Callers decide which models are configured and
+// listed, and the verifier separately decides which ones still need a probe.
+export function matchingSubagentAutoPolicyModels(models, policies = readSubagentAutoPolicies().policies) {
+  const active = cleanPolicies(policies);
+  const seen = new Set();
+  return (Array.isArray(models) ? models : []).filter((model) => {
+    if (!model?.slug || seen.has(model.slug)) return false;
+    if (!active.some((policy) => modelMatchesSubagentAutoPolicy(model, policy))) return false;
+    seen.add(model.slug);
+    return true;
+  });
+}
+
+export function subagentAutoPolicySnapshot(models) {
+  const state = readSubagentAutoPolicies();
+  return {
+    ...state,
+    matchingSlugs: matchingSubagentAutoPolicyModels(models, state.policies).map((model) => model.slug),
+    path: SUBAGENT_AUTO_POLICY_PATH,
+  };
+}

--- a/src/subagent-proofs.mjs
+++ b/src/subagent-proofs.mjs
@@ -8,17 +8,17 @@ import { STATE_DIR } from "./paths.mjs";
 //
 // The registry's `multiAgentVersion: "v2"` marks models proven through the
 // full native collaboration probe and shipped to every installer. This file
-// holds the other kind of evidence: proofs collected on *this* machine, for
-// models the operator enabled as subagents that the registry has not promoted.
-// Local settings still never manufacture a v2 claim — the only writers here
-// are the verifier (a live tool/stream probe) and the router's own
-// observation of a real spawn succeeding or failing on the request path.
+// holds local triage evidence for models the operator nominated for
+// certification. It is deliberately not a second source of v2 claims: only a
+// checked-in registry entry has completed the full native collaboration proof
+// and may be exposed to Codex as a v2 subagent.
 //
 // Lifecycle per slug:
 //   checking      the probe worker is running; nothing is advertised yet
-//   experimental  the probe passed; the model is advertised to Codex as a v2
-//                 subagent, and the first observed spawn settles the verdict
-//   proven        the router watched a real child turn complete cleanly
+//   candidate     the low-cost stream/tool probe passed; submit its redacted
+//                 application for the native encrypted-relay proof
+//   proven        retained only for legacy local records; it does not promote
+//                 a model and must be replaced by a repository certificate
 //   failed        the probe failed, or an observed spawn failed structurally;
 //                 the model stays v1 and the reason is shown where it was
 //                 switched on
@@ -49,8 +49,7 @@ export const SUBAGENT_PROOFS_PATH =
   process.env.MODEL_ROUTER_SUBAGENT_PROOFS ||
   path.join(STATE_DIR, "multi-agent-proofs.json");
 
-const PROMOTED_STATUSES = new Set(["experimental", "proven"]);
-const KNOWN_STATUSES = new Set(["checking", "experimental", "proven", "failed"]);
+const KNOWN_STATUSES = new Set(["checking", "candidate", "experimental", "proven", "failed"]);
 
 // A file that exists but cannot be parsed promotes nothing: somebody's
 // evidence was here and we can no longer read it, so the conservative v1
@@ -96,7 +95,7 @@ export function recordProbeStarted(slug, { at = new Date().toISOString() } = {})
 export function recordProbeResult(slug, { ok, checks, detail, at = new Date().toISOString() }) {
   if (ok) {
     return updateProof(slug, {
-      status: "experimental",
+      status: "candidate",
       toolProbe: { ok: true, checks, at },
       reason: undefined,
     });
@@ -147,33 +146,21 @@ export function subagentProofSnapshot(filePath = SUBAGENT_PROOFS_PATH) {
   return readSubagentProofs(filePath).proofs;
 }
 
-function promotedSlugs(proofs) {
-  return new Set(
-    Object.entries(proofs)
-      .filter(([, proof]) => PROMOTED_STATUSES.has(proof.status))
-      .map(([slug]) => slug),
-  );
-}
-
-// Promote routed models this machine has verified. Runs after
-// applyMultiAgentSettings, whose demotions must win: a slug the operator
-// hid or switched off stays v1 whatever evidence exists for it.
+// Local proof records are diagnostic and application material only. Promoting
+// from this file let a stream/tool probe masquerade as native collaboration
+// proof, creating a path where an actually-v1 route appeared in Codex's v2
+// subagent list. Repository `multiAgentVersion: "v2"` is the sole promotion
+// authority.
 export function applySubagentProofs(models, proofs, { hidden, disabled } = {}) {
-  const promoted = promotedSlugs(proofs || {});
-  if (promoted.size === 0) return models;
-  const hiddenSet = hidden instanceof Set ? hidden : new Set(hidden || []);
-  const disabledSet = disabled instanceof Set ? disabled : new Set(disabled || []);
-  return models.map((model) => {
-    const slug = String(model.slug);
-    if (model.multiAgentVersion === "v2") return model;
-    if (!promoted.has(slug)) return model;
-    if (hiddenSet.has(slug) || disabledSet.has(slug)) return model;
-    return { ...model, multiAgentVersion: "v2" };
-  });
+  void proofs;
+  void hidden;
+  void disabled;
+  return models;
 }
 
-// Whether an observed child turn for this slug can *promote* it: only models
-// sitting in the experimental window are waiting on a first clean turn.
+// Legacy helper retained for callers that read historical proof files. New
+// candidate records cannot be spawned, because they never reach the v2
+// catalog. The full proof belongs in v2_agent/ and the registry review.
 export function awaitingSpawnProof(slug, proofs = subagentProofSnapshot()) {
   return proofs[String(slug)]?.status === "experimental";
 }
@@ -186,5 +173,5 @@ export function awaitingSpawnProof(slug, proofs = subagentProofSnapshot()) {
 // claim is the shipped native collaboration proof and not this machine's
 // traffic) has nothing here to take away.
 export function spawnProofRevocable(slug, proofs = subagentProofSnapshot()) {
-  return PROMOTED_STATUSES.has(proofs[String(slug)]?.status);
+  return proofs[String(slug)]?.status === "experimental";
 }

--- a/src/subagent-proofs.mjs
+++ b/src/subagent-proofs.mjs
@@ -17,34 +17,18 @@ import { STATE_DIR } from "./paths.mjs";
 //   checking      the probe worker is running; nothing is advertised yet
 //   candidate     the low-cost stream/tool probe passed; submit its redacted
 //                 application for the native encrypted-relay proof
-//   proven        retained only for legacy local records; it does not promote
-//                 a model and must be replaced by a repository certificate
-//   failed        the probe failed, or an observed spawn failed structurally;
-//                 the model stays v1 and the reason is shown where it was
-//                 switched on
+//   experimental  retained only for legacy local records; later child traffic
+//                 may refine the diagnostic record, but cannot advertise v2
+//   proven        retained only for legacy local records; it means one child
+//                 HTTP turn once completed, not that delegated work finished
+//   failed        the probe or legacy observed child traffic failed; the
+//                 reason remains visible where the model was nominated
 //
-// "proven" is a claim about the wire, not about the work: it means one child
-// turn for this slug completed cleanly, so the model can hold the v2 child
-// role. The router observes HTTP turns, not agent lifecycles — a child makes
-// one turn per tool-call round trip and the loop that strings them together is
-// Codex's, not the router's — so nothing here can say the child reached done.
-//
-// "proven" is therefore revocable (issue #257). It was written as a terminal
-// state, which meant the newest evidence on the wire lost to the oldest: a
-// slug promoted by one clean turn kept the v2 advertisement through every
-// structural rejection that followed, because the observer stopped listening
-// the moment it promoted. Nothing about a 400/422 is weaker after promotion
-// than before it — it is the same structural refusal the probe treats as
-// disqualifying, and the transient statuses that prove nothing (429, 5xx) are
-// already excluded elsewhere. So the same evidence demotes at any point in the
-// lifecycle, and the router's per-spawn accounting (subagent-turns.mjs) can
-// condemn a child that runs past its model's own compaction budget without
-// converging.
-//
-// Demotion is automatic; re-promotion is not. A demoted slug only comes back
-// through `control subagents verify` or a switch off and on, both of which
-// spend live requests re-researching it — the direction that costs quota is
-// the direction that stays under the operator's hand.
+// Legacy experimental/proven records are certification candidates, not
+// authority. They are kept so upgrades neither erase useful evidence nor
+// automatically repeat quota-spending probes. Completing the encrypted relay,
+// marker-return, and same-thread checks belongs in v2_agent/; only the matching
+// checked-in registry declaration may expose the route as v2.
 export const SUBAGENT_PROOFS_PATH =
   process.env.MODEL_ROUTER_SUBAGENT_PROOFS ||
   path.join(STATE_DIR, "multi-agent-proofs.json");
@@ -103,7 +87,7 @@ export function recordProbeResult(slug, { ok, checks, detail, at = new Date().to
   return updateProof(slug, {
     status: "failed",
     toolProbe: { ok: false, checks, at },
-    reason: detail || "capability probe failed",
+    reason: detail || "compatibility probe failed",
   });
 }
 
@@ -114,7 +98,7 @@ export function recordSpawnObserved(slug, { status, at = new Date().toISOString(
 // `turns` and `newInputTokens` are carried so the recorded evidence says how
 // much of a spawn it took, not just that one failed: the proofs snapshot is
 // what `control subagents verify`, `control subagents status` and the tray
-// render, so this is where a demotion becomes something an operator can read.
+// render, so this is where negative diagnostic evidence becomes readable.
 export function recordSpawnFailure(
   slug,
   { status, reason, turns, newInputTokens, at = new Date().toISOString() } = {},
@@ -158,20 +142,14 @@ export function applySubagentProofs(models, proofs, { hidden, disabled } = {}) {
   return models;
 }
 
-// Legacy helper retained for callers that read historical proof files. New
-// candidate records cannot be spawned, because they never reach the v2
-// catalog. The full proof belongs in v2_agent/ and the registry review.
+// Legacy helper retained only to refine an historical experimental record from
+// child traffic. New candidate records never reach Codex's v2 catalog.
 export function awaitingSpawnProof(slug, proofs = subagentProofSnapshot()) {
   return proofs[String(slug)]?.status === "experimental";
 }
 
-// Whether an observed child turn for this slug can *demote* it. Everything the
-// v2 advertisement currently rests on is revocable — the experimental window
-// and the durable proof alike — because both are claims about the same wire
-// the failing turn just came off. A slug already `failed`, still `checking`,
-// or carrying no local proof at all (including a registry-v2 model, whose
-// claim is the shipped native collaboration proof and not this machine's
-// traffic) has nothing here to take away.
+// Whether child traffic may refine a legacy experimental diagnostic. This can
+// change only the local record; it cannot demote or promote registry authority.
 export function spawnProofRevocable(slug, proofs = subagentProofSnapshot()) {
   return proofs[String(slug)]?.status === "experimental";
 }

--- a/src/subagent-turns.mjs
+++ b/src/subagent-turns.mjs
@@ -30,10 +30,10 @@ import { acceptedInputTokens } from "./context-window-drift.mjs";
 // reaches it honestly. It is *compacting again* that names the runaway, so the
 // ceiling is two budgets of new input with the child still going.
 //
-// That multiple is also what makes a false demotion structurally impossible
-// rather than merely unlikely, which matters because a false demotion silently
-// drops a working model from the picker and only a hand-run
-// `control subagents verify` restores it. A spawn that has never been
+// That multiple is also what makes false negative evidence structurally
+// impossible rather than merely unlikely. Historical proof records are only
+// diagnostic now, but invented failure evidence would still mislead a registry
+// review. A spawn that has never been
 // compacted cannot have produced more new input than its own largest prompt,
 // so the ceiling is taken against whichever is bigger, the model's declared
 // budget or the largest prompt this spawn has actually had accepted. An
@@ -103,7 +103,7 @@ function spawnKey(spawnId) {
 //
 // Returns undefined when the turn cannot be attributed to a spawn -- no
 // thread id means no way to tell one child from the next, and guessing would
-// demote a model for someone else's traffic.
+// manufacture negative evidence from someone else's traffic.
 export function observeChildTurn({
   spawnId,
   slug,
@@ -156,14 +156,14 @@ export function observeChildTurn({
     newInputTokens: state.newInputTokens,
     budget,
     // A model with no declared compaction budget has no derived ceiling, so it
-    // is counted and never demoted on this signal. Inventing one for it is the
+    // is counted and never rejected on this signal. Inventing one for it is the
     // thing this module exists not to do.
     exceeded: budget !== undefined && state.newInputTokens > budget,
   };
 }
 
-// Drop a spawn the router has already settled a verdict on, so a child that
-// keeps answering after its slug was demoted does not keep re-firing.
+// Drop a legacy-observed spawn after its diagnostic verdict, so a child that
+// keeps answering does not keep re-firing the same record update.
 export function forgetChildSpawn(spawnId) {
   const id = spawnKey(spawnId);
   if (id) spawns.delete(id);

--- a/src/subagent-verify.mjs
+++ b/src/subagent-verify.mjs
@@ -15,9 +15,9 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..
 // Enabling a model as a subagent is the assignment; this module answers
 // whether the assignment can hold. Verification is capability research, not
 // trust: the probe spends two live requests proving the model streams and
-// answers a forced tool call through the installed router, and only that
-// evidence — never the toggle itself — advertises the model to Codex as a
-// v2 subagent (as "experimental", until a real spawn settles it).
+// answers a forced tool call through the installed router. That low-cost
+// result becomes certification evidence, not a v2 claim: only a reviewed
+// v2_agent application plus registry entry may advertise the native role.
 
 // A probe is two 180-second-capped requests, so any "checking" older than
 // this ceiling was left behind by a worker that died — machine sleep, OOM, a
@@ -32,7 +32,9 @@ function checkingIsStale(proof, now = Date.now()) {
 }
 
 // Which of these slugs need a probe at all. Registry-v2 models shipped with
-// the full native proof; slugs already carrying local evidence keep it.
+// the full native proof. Explicit registry-v1 models were already reviewed
+// and rejected for the native role, so a local probe must never reopen that
+// decision; only unknown models are certification candidates.
 export function subagentVerificationCandidates(slugs, { force = false, now = Date.now() } = {}) {
   const proofs = readSubagentProofs().proofs;
   const seen = new Set();
@@ -43,10 +45,10 @@ export function subagentVerificationCandidates(slugs, { force = false, now = Dat
     seen.add(slug);
     const model = MODEL_BY_SLUG.get(slug);
     if (!model) continue;
-    if (model.multiAgentVersion === "v2") continue;
+    if (model.multiAgentVersion === "v2" || model.multiAgentVersion === "v1") continue;
     const status = proofs[slug]?.status;
     if (!force) {
-      if (status === "experimental" || status === "proven") continue;
+      if (status === "candidate" || status === "experimental" || status === "proven") continue;
       if (status === "checking" && !checkingIsStale(proofs[slug], now)) continue;
     }
     candidates.push(slug);
@@ -113,10 +115,21 @@ export async function verifySubagentCandidates(slugs, { probe, force = false } =
 // candidate list to a detached worker (the same shape as the vision-model
 // download worker): state moves to "checking" immediately, the worker records
 // the verdict and republishes the catalog when it lands.
-export function spawnDetachedVerification(slugs, { execPath = process.execPath } = {}) {
-  const candidates = subagentVerificationCandidates(slugs);
+export function spawnDetachedVerification(
+  slugs,
+  { execPath = process.execPath, deferCandidateResolution = false } = {},
+) {
+  // A curation transaction has just written a new model overlay, but this
+  // process still holds the old registry module. Let the fresh worker resolve
+  // those slugs after the overlay publication instead of silently dropping
+  // them as "unknown" here.
+  const candidates = deferCandidateResolution
+    ? [...new Set((slugs || []).map((slug) => String(slug || "").trim()).filter(Boolean))]
+    : subagentVerificationCandidates(slugs);
   if (candidates.length === 0) return { spawned: false, candidates: [] };
-  for (const slug of candidates) recordProbeStarted(slug);
+  if (!deferCandidateResolution) {
+    for (const slug of candidates) recordProbeStarted(slug);
+  }
   const child = spawn(
     execPath,
     [path.join(REPO_ROOT, "src", "subagent-verify.mjs"), "--worker", ...candidates],

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -298,7 +298,7 @@ test("routed models advertise search and image detail only when the registry opt
 
 test("routed models can explicitly narrow inherited tool capabilities", () => {
   const plain = routedModel(template, grok);
-  assert.equal("supports_parallel_tool_calls" in plain, false);
+  assert.equal(plain.supports_parallel_tool_calls, false);
   assert.equal("experimental_supported_tools" in plain, false);
 
   const narrowed = routedModel(template, {
@@ -954,7 +954,7 @@ test("duplicate account slugs collapse to the first occurrence", () => {
   assert.equal(merged.models[0].visibility, "list");
 });
 
-test("native listed models follow the local subagent opt-in", () => {
+test("native listed models retain only repository-certified v2 capability", () => {
   // Upstream still ships gpt-5.6-luna as v1 while it runs fine on the v2
   // backend, and spawn_agent filters child models on that static value.
   const native = [
@@ -1000,17 +1000,17 @@ test("native promotion honours disabled models and picker-hidden slugs", () => {
   assert.equal(promoted[1].multi_agent_version, "v1");
 });
 
-test("selected subagent mode only promotes the chosen native models", () => {
+test("selected subagent mode does not promote unreviewed native models", () => {
   const native = [
-    { slug: "gpt-5.6-luna", visibility: "list", multi_agent_version: "v1" },
     { slug: "gpt-5.4", visibility: "list", multi_agent_version: "v1" },
+    { slug: "gpt-5.3", visibility: "list", multi_agent_version: "v1" },
   ];
   const promoted = promoteNativeMultiAgent(native, {
     mode: "selected",
-    enabled: ["gpt-5.6-luna"],
+    enabled: ["gpt-5.4"],
     disabled: [],
   });
-  assert.equal(promoted[0].multi_agent_version, "v2");
+  assert.equal(promoted[0].multi_agent_version, "v1");
   assert.equal(promoted[1].multi_agent_version, "v1");
 });
 

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -21,6 +21,7 @@ import {
   deriveBaseInstructions,
   mergeNativeCatalogs,
   mergeNativeModel,
+  nativeSubagentCertification,
   promoteNativeMultiAgent,
   routedCatalogConfigured,
   routedModel,
@@ -1033,6 +1034,7 @@ test("proven subagent mode still promotes upstream-verified v2-backend slugs", (
 
 test("an upstream-verified slug still honours disabled and picker-hidden", () => {
   const native = [{ slug: "gpt-5.6-luna", visibility: "list", multi_agent_version: "v1" }];
+  assert.equal(nativeSubagentCertification(native[0]), "v2");
   const promoted = promoteNativeMultiAgent(
     native,
     { mode: "proven", enabled: [], disabled: ["gpt-5.6-luna"] },

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -363,6 +363,125 @@ test("control refuses to enable a repository-certified v1 model as a v2 subagent
   }
 });
 
+test("a disabled repository-certified native v2 model can be turned back on", () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "control-subagent-native-v2-"));
+  const slug = "gpt-5.6-luna";
+  const env = {
+    ...process.env,
+    CODEX_HOME: stateDir,
+    MODEL_ROUTER_TARGET: "codex",
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  };
+  writeFileSync(
+    path.join(stateDir, "native-models.json"),
+    `${JSON.stringify({ models: [{
+      slug,
+      display_name: "GPT-5.6-Luna",
+      visibility: "list",
+      multi_agent_version: "v1",
+    }] })}\n`,
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    path.join(stateDir, "merged-models.json"),
+    `${JSON.stringify({ models: [{ slug, multi_agent_version: "v1" }] })}\n`,
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    path.join(stateDir, "multi-agent-settings.json"),
+    `${JSON.stringify({ version: 2, mode: "selected", enabled: [], disabled: [slug] })}\n`,
+    { mode: 0o600 },
+  );
+  try {
+    const snapshot = probe("codex", [], [], {
+      nativeModels: [{
+        slug,
+        display_name: "GPT-5.6-Luna",
+        visibility: "list",
+        multi_agent_version: "v1",
+      }],
+      subagentSettings: { mode: "selected", enabled: [], disabled: [slug] },
+    });
+    const row = snapshot.models.find((model) => model.slug === slug);
+    assert.equal(row.multiAgentVersion, "v1");
+    assert.equal(row.subagentCertification, "v2");
+
+    const state = JSON.parse(execFileSync(
+      process.execPath,
+      [path.join(root, "src", "control.mjs"), "subagents", "set", slug, "on"],
+      { cwd: root, encoding: "utf8", env, stdio: "pipe" },
+    ));
+    assert.deepEqual(state.disabled, []);
+    assert.deepEqual(state.enabled, [slug]);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("an unknown native route is not mistaken for the merged catalog's conservative v1", () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "control-subagent-native-unknown-"));
+  const slug = "gpt-native-candidate";
+  const env = {
+    ...process.env,
+    CODEX_HOME: stateDir,
+    MODEL_ROUTER_TARGET: "codex",
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  };
+  writeFileSync(
+    path.join(stateDir, "native-models.json"),
+    `${JSON.stringify({ models: [{ slug, visibility: "list" }] })}\n`,
+    { mode: 0o600 },
+  );
+  writeFileSync(
+    path.join(stateDir, "merged-models.json"),
+    `${JSON.stringify({ models: [{ slug, multi_agent_version: "v1" }] })}\n`,
+    { mode: 0o600 },
+  );
+  try {
+    const state = JSON.parse(execFileSync(
+      process.execPath,
+      [path.join(root, "src", "control.mjs"), "subagents", "set", slug, "on"],
+      { cwd: root, encoding: "utf8", env, stdio: "pipe" },
+    ));
+    assert.deepEqual(state.enabled, [slug]);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("control can test an uncertified route despite its conservative merged-catalog v1", () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "control-subagent-unknown-"));
+  const slug = "deepseek/deepseek-v4-flash";
+  const env = {
+    ...process.env,
+    MODEL_ROUTER_TARGET: "codex",
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  };
+  writeFileSync(
+    path.join(stateDir, "merged-models.json"),
+    `${JSON.stringify({ models: [{ slug, multi_agent_version: "v1" }] })}\n`,
+    { mode: 0o600 },
+  );
+  // A settled candidate prevents this command-level regression test from
+  // launching the detached, quota-spending probe worker.
+  writeFileSync(
+    path.join(stateDir, "multi-agent-proofs.json"),
+    `${JSON.stringify({ version: 1, proofs: { [slug]: { status: "candidate" } } })}\n`,
+    { mode: 0o600 },
+  );
+  try {
+    const state = JSON.parse(execFileSync(
+      process.execPath,
+      [path.join(root, "src", "control.mjs"), "subagents", "set", slug, "on"],
+      { cwd: root, encoding: "utf8", env, stdio: "pipe" },
+    ));
+    assert.equal(state.mode, "selected");
+    assert.deepEqual(state.enabled, [slug]);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
 test("control toggles tool-result aging without a router restart", () => {
   const stateDir = mkdtempSync(path.join(os.tmpdir(), "control-tool-result-aging-"));
   const env = {

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -196,6 +196,7 @@ test("codex probe includes native GPT models and the configured default", () => 
       enabled: true,
       native: true,
       multiAgentVersion: "v1",
+      subagentCertification: "unknown",
       visible: true,
     },
   );
@@ -212,6 +213,22 @@ test("codex probe includes native GPT models and the configured default", () => 
   assert.equal(slice.modelSettings.localModels.lmstudio.provider, "lmstudio");
   assert.equal(typeof slice.modelSettings.localModels.lmstudio.reachable, "boolean");
   assert.ok(Array.isArray(slice.modelSettings.localModels.lmstudio.models));
+});
+
+test("codex probe preserves an explicit repository v1 verdict", () => {
+  const slice = probe("codex", [], [], {
+    nativeModels: [
+      {
+        slug: "gpt-reviewed-v1",
+        display_name: "GPT Reviewed V1",
+        visibility: "list",
+        multi_agent_version: "v1",
+      },
+    ],
+  });
+  const model = slice.models.find((entry) => entry.slug === "gpt-reviewed-v1");
+  assert.equal(model.multiAgentVersion, "v1");
+  assert.equal(model.subagentCertification, "v1");
 });
 
 // The row is the whole feature: an entry the operator cannot find is an entry
@@ -248,7 +265,7 @@ test("a login-free probe draws no extended-context variant", () => {
   assert.ok(slice.models.some((model) => model.slug === "gpt-5.6-sol"));
 });
 
-test("codex probe reports the effective v2 state of selected native GPT models", () => {
+test("codex probe does not turn a selected native v1 model into v2", () => {
   const slice = probe("codex", [], [], {
     nativeModels: [
       {
@@ -273,7 +290,7 @@ test("codex probe reports the effective v2 state of selected native GPT models",
 
   assert.equal(
     slice.models.find((model) => model.slug === "gpt-5.6-terra")?.multiAgentVersion,
-    "v2",
+    "v1",
   );
   assert.equal(
     slice.models.find((model) => model.slug === "gpt-5.6-luna")?.multiAgentVersion,
@@ -315,6 +332,32 @@ test("control exposes subagent and picker settings without credentials", () => {
       ),
     );
     assert.deepEqual(picker.hidden, []);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("control refuses to enable a repository-certified v1 model as a v2 subagent", () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "control-subagent-v1-"));
+  const env = {
+    ...process.env,
+    MODEL_ROUTER_TARGET: "codex",
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  };
+  writeFileSync(
+    path.join(stateDir, "merged-models.json"),
+    `${JSON.stringify({ models: [{ slug: "gpt-reviewed-v1", multi_agent_version: "v1" }] })}\n`,
+    { mode: 0o600 },
+  );
+  try {
+    assert.throws(
+      () => execFileSync(
+        process.execPath,
+        [path.join(root, "src", "control.mjs"), "subagents", "set", "gpt-reviewed-v1", "on"],
+        { cwd: root, encoding: "utf8", env, stdio: "pipe" },
+      ),
+      /repository-certified v1/,
+    );
   } finally {
     rmSync(stateDir, { recursive: true, force: true });
   }

--- a/test/doctor-routing-mode.test.mjs
+++ b/test/doctor-routing-mode.test.mjs
@@ -167,22 +167,17 @@ test(
     writeFileSync(configPath, 'model = "gpt-5.6-sol"\n', { mode: 0o600 });
     writeFileSync(
       path.join(stateDir, "enabled-providers.json"),
-      `${JSON.stringify({ version: 1, providers: ["deepseek"] })}\n`,
+      `${JSON.stringify({ version: 1, providers: ["kimi-api"] })}\n`,
       { mode: 0o600 },
     );
-    writeFileSync(path.join(stateDir, "deepseek-api-key.secret"), "test-key\n", {
+    writeFileSync(path.join(stateDir, "kimi-api-key.secret"), "test-key\n", {
       mode: 0o600,
     });
-    writeFileSync(
-      path.join(stateDir, "multi-agent-proofs.json"),
-      `${JSON.stringify({
-        version: 1,
-        proofs: {
-          "deepseek/deepseek-v4-pro": { status: "proven" },
-        },
-      })}\n`,
-      { mode: 0o600 },
-    );
+    // A registry model carrying `multiAgentVersion: "v2"`, not a local proof.
+    // Local proof records are diagnostic and application material only --
+    // promoting from them let a stream/tool probe masquerade as native
+    // collaboration proof -- so a seeded `proven` entry no longer produces a
+    // managed agent definition and there would be nothing here to remove.
     // The catalog now publishes routed models only after an explicit picker
     // selection. Keep this test focused on the doctor detecting a missing
     // managed agent definition, rather than relying on the old implicit-show
@@ -192,8 +187,8 @@ test(
       `${JSON.stringify({
         version: 1,
         hidden: [],
-        visible: ["deepseek/deepseek-v4-pro"],
-        seeded: ["deepseek/deepseek-v4-pro"],
+        visible: ["kimi-api/kimi-k3"],
+        seeded: ["kimi-api/kimi-k3"],
       })}\n`,
       { mode: 0o600 },
     );
@@ -219,9 +214,7 @@ test(
       const catalog = child("catalog.mjs", ["--refresh-native", "--bundled-native"], env);
       assert.equal(catalog.status, 0, catalog.stderr);
       assert.equal(JSON.parse(catalog.stdout).routed_catalog_active, true);
-      unlinkSync(
-        path.join(codexHome, "agents", "router-model-deepseek-deepseek-v4-pro.toml"),
-      );
+      unlinkSync(path.join(codexHome, "agents", "router-model-kimi-api-kimi-k3.toml"));
 
       const routes = child("litellm-config.mjs", [], env);
       assert.equal(routes.status, 0, routes.stderr);

--- a/test/multi-agent-state.test.mjs
+++ b/test/multi-agent-state.test.mjs
@@ -131,7 +131,7 @@ test("selected mode retains only registry-proven v2 claims", () => {
   );
 });
 
-test("effective capabilities include machine-local proofs and respect exclusions", () => {
+test("effective capabilities ignore machine-local proofs and respect exclusions", () => {
   const models = [
     { slug: "opencode-go/deepseek-v4-pro" },
     { slug: "opencode-go/deepseek-v4-flash" },
@@ -155,7 +155,7 @@ test("effective capabilities include machine-local proofs and respect exclusions
   assert.deepEqual(
     resolved.map((model) => [model.slug, model.multiAgentVersion]),
     [
-      ["opencode-go/deepseek-v4-pro", "v2"],
+      ["opencode-go/deepseek-v4-pro", undefined],
       ["opencode-go/deepseek-v4-flash", "v1"],
       ["kimi-oauth/k3", "v2"],
     ],

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5291,14 +5291,14 @@ test("a turn with no image reaches a text-only model untouched", async () => {
   }
 });
 
-test("a live child turn settles an experimental subagent's proof", async () => {
+test("a live child turn refines a legacy experimental subagent diagnostic", async () => {
   const proofsPath = path.join(
     mkdtempSync(path.join(os.tmpdir(), "subagent-proofs-e2e-")),
     "multi-agent-proofs.json",
   );
-  // Three models in the experimental window: one will prove itself, one will
-  // be rejected structurally, one completes a turn that carries no subagent
-  // marker and must stay untouched.
+  // Three legacy experimental records: one gets positive diagnostic evidence,
+  // one is rejected structurally, and an unmarked turn stays untouched. None
+  // of these records can change the registry's v2 authority.
   writeFileSync(
     proofsPath,
     JSON.stringify({
@@ -5350,13 +5350,13 @@ test("a live child turn settles an experimental subagent's proof", async () => {
   try {
     await waitFor(`${routerBase(routerPort)}/models`, router);
 
-    // A clean completion of a marked child turn is the durable proof.
+    // A clean completion refines the legacy record, but is not certification.
     const proven = await childTurn("deepseek/deepseek-v4-pro", {
       "x-openai-subagent": "review-child",
     });
     assert.equal(proven.status, 200);
 
-    // A structural rejection of a marked child turn is the demotion.
+    // A structural rejection becomes negative diagnostic evidence.
     const rejected = await childTurn("deepseek/deepseek-v4-flash", {
       "x-openai-subagent": "review-child",
     });
@@ -5394,8 +5394,8 @@ test("a live child turn settles an experimental subagent's proof", async () => {
 test("ordinary child traffic does not mutate a legacy local proven record", async () => {
   const stateDir = mkdtempSync(path.join(os.tmpdir(), "subagent-demote-e2e-"));
   const proofsPath = path.join(stateDir, "multi-agent-proofs.json");
-  // Both already carry the durable proof: this is the state the old observer
-  // stopped looking at.
+  // Both carry legacy positive evidence. It remains readable but has no
+  // authority over the registry certificate.
   writeFileSync(
     proofsPath,
     JSON.stringify({

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5388,13 +5388,10 @@ test("a live child turn settles an experimental subagent's proof", async () => {
   }
 });
 
-// Issue #257(b). Two things a `proven` slug could not do before: be taken back
-// by a structural rejection on a later turn, and be taken back by a child that
-// answers forever. The first was unreachable because the observer's gate was
-// the experimental window, so promotion on turn one closed the demotion path
-// with it; the second had no signal at all, because a looping child emits
-// nothing but 200s.
-test("a proven subagent is demoted by a later rejection and by a child that never converges", async () => {
+// Legacy local `proven` records no longer grant a v2 role. Keep them readable
+// for a safe upgrade, but ordinary child traffic must not mutate them: only a
+// reviewed repository certificate can now make or revoke the catalog claim.
+test("ordinary child traffic does not mutate a legacy local proven record", async () => {
   const stateDir = mkdtempSync(path.join(os.tmpdir(), "subagent-demote-e2e-"));
   const proofsPath = path.join(stateDir, "multi-agent-proofs.json");
   // Both already carry the durable proof: this is the state the old observer
@@ -5477,52 +5474,27 @@ test("a proven subagent is demoted by a later rejection and by a child that neve
   try {
     await waitFor(`${routerBase(routerPort)}/models`, router);
 
-    // A structural rejection after promotion is the same evidence it was
-    // before it, so it takes the proof back.
+    // A structural rejection does not alter a legacy local record: it was
+    // never a valid authority to advertise v2 in the first place.
     const rejected = await childTurn("deepseek/deepseek-v4-flash", {
       "thread-id": "99999999-8888-4777-8666-555555555555",
     });
     assert.equal(rejected.status, 400);
     const flash = await proofFor(
       "deepseek/deepseek-v4-flash",
-      (proof) => proof?.status === "failed",
+      (proof) => proof?.status === "proven",
     );
-    assert.equal(flash.status, "failed");
-    assert.match(flash.reason, /400/);
-    assert.match(flash.reason, /revoking the child role it had already served/);
+    assert.equal(flash.status, "proven");
 
-    // The looping child. Every turn is a clean 200, so nothing status-shaped
-    // could ever fire; what condemns it is how much of its own budget one
-    // spawn burns while still going.
+    // A looping child likewise leaves the legacy record alone.
     for (let index = 0; index < promptCounts.length; index += 1) {
       const looping = await childTurn("deepseek/deepseek-v4-pro", {
         "thread-id": spawnThread,
       });
       assert.equal(looping.status, 200, `child turn ${index + 1} failed`);
     }
-    const pro = await proofFor("deepseek/deepseek-v4-pro", (proof) => proof?.status === "failed");
-    assert.equal(pro.status, "failed", "a child that never converged kept its proof");
-    assert.equal(pro.spawn.turns, promptCounts.length);
-    assert.equal(pro.spawn.newInputTokens, 2_100_000);
-    assert.match(pro.reason, /without converging/);
-    assert.match(pro.reason, /1800000-token ceiling/);
-
-    // Both demotions have to be readable in the log, even under the QUIET the
-    // production LaunchAgent hard-sets: a picker entry that vanishes with no
-    // line explaining it is unexplainable.
-    //
-    // Waited for rather than read straight off, because the demotion writes
-    // the proof file *before* it logs (`settle` in router.mjs), and the log
-    // goes down a pipe -- which node writes asynchronously on macOS. So the
-    // file the loop above polls can already say `failed` while the line
-    // explaining it is still in flight; a bare read caught that ~1% of runs
-    // and blamed the ceiling for a demotion that had in fact already fired.
-    // The wait is on the line's arrival only: what is asserted is unchanged.
-    await waitForStderr(router, /subagent demoted: deepseek\/deepseek-v4-flash/);
-    await waitForStderr(router, /subagent demoted: deepseek\/deepseek-v4-pro/);
-    const errors = router.testErrors();
-    assert.match(errors, /subagent demoted: deepseek\/deepseek-v4-flash/);
-    assert.match(errors, /subagent demoted: deepseek\/deepseek-v4-pro/);
+    const pro = await proofFor("deepseek/deepseek-v4-pro", (proof) => proof?.status === "proven");
+    assert.equal(pro.status, "proven");
   } finally {
     await stopChild(router);
     await closeServer(gateway.server);

--- a/test/subagent-auto-policy.test.mjs
+++ b/test/subagent-auto-policy.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "subagent-auto-policy-test-"));
+process.env.MODEL_ROUTER_SUBAGENT_AUTO_POLICY = path.join(stateDir, "policies.json");
+
+const {
+  matchingSubagentAutoPolicyModels,
+  readSubagentAutoPolicies,
+  setSubagentAutoPolicy,
+  SUBAGENT_AUTO_POLICY_PATH,
+} = await import("../src/subagent-auto-policy.mjs");
+
+const models = [
+  { slug: "deepseek/deepseek-v4-pro", provider: "deepseek", upstreamModel: "deepseek-v4-pro" },
+  { slug: "opencode-free/x-preview-f-free", provider: "opencode-free", displayName: "Ox Alpha Free" },
+  { slug: "qwen-plan/qwen3.8-max", provider: "qwen-plan", upstreamModel: "qwen3.8-max" },
+  { slug: "commandcode/qwen3.8-max", provider: "commandcode", upstreamModel: "Qwen/Qwen3.8-Max" },
+  { slug: "kimi-api/kimi-k3", provider: "kimi-api", upstreamModel: "kimi-k3" },
+];
+
+test("provider, model, and family policies match independently", () => {
+  setSubagentAutoPolicy("provider", "deepseek", true);
+  setSubagentAutoPolicy("model", "opencode-free/x-preview-f-free", true);
+  setSubagentAutoPolicy("family", "qwen 3.8", true);
+  const matched = matchingSubagentAutoPolicyModels(models).map((model) => model.slug);
+  assert.deepEqual(matched, [
+    "deepseek/deepseek-v4-pro",
+    "opencode-free/x-preview-f-free",
+    "qwen-plan/qwen3.8-max",
+    "commandcode/qwen3.8-max",
+  ]);
+});
+
+test("policy removal withdraws only that standing permission", () => {
+  setSubagentAutoPolicy("family", "qwen 3.8", false);
+  assert.deepEqual(
+    matchingSubagentAutoPolicyModels(models).map((model) => model.slug),
+    ["deepseek/deepseek-v4-pro", "opencode-free/x-preview-f-free"],
+  );
+});
+
+test("corrupt or invalid policy state authorizes no probes", () => {
+  writeFileSync(SUBAGENT_AUTO_POLICY_PATH, "{not json", { mode: 0o600 });
+  assert.deepEqual(readSubagentAutoPolicies().policies, []);
+  assert.throws(() => setSubagentAutoPolicy("family", "!!", true), /Invalid subagent auto policy/);
+});

--- a/test/subagent-auto-policy.test.mjs
+++ b/test/subagent-auto-policy.test.mjs
@@ -9,6 +9,7 @@ process.env.MODEL_ROUTER_SUBAGENT_AUTO_POLICY = path.join(stateDir, "policies.js
 
 const {
   matchingSubagentAutoPolicyModels,
+  modelMatchesSubagentAutoPolicy,
   readSubagentAutoPolicies,
   setSubagentAutoPolicy,
   SUBAGENT_AUTO_POLICY_PATH,
@@ -20,6 +21,11 @@ const models = [
   { slug: "qwen-plan/qwen3.8-max", provider: "qwen-plan", upstreamModel: "qwen3.8-max" },
   { slug: "commandcode/qwen3.8-max", provider: "commandcode", upstreamModel: "Qwen/Qwen3.8-Max" },
   { slug: "kimi-api/kimi-k3", provider: "kimi-api", upstreamModel: "kimi-k3" },
+  {
+    slug: "opencode-go-messages/kimi-k2.5",
+    provider: "opencode-go-messages",
+    upstreamModel: "kimi-k2.5",
+  },
 ];
 
 test("provider, model, and family policies match independently", () => {
@@ -33,6 +39,16 @@ test("provider, model, and family policies match independently", () => {
     "qwen-plan/qwen3.8-max",
     "commandcode/qwen3.8-max",
   ]);
+});
+
+test("provider policies include protocol variants of the same credential family", () => {
+  assert.equal(
+    modelMatchesSubagentAutoPolicy(models.at(-1), {
+      kind: "provider",
+      value: "opencode-go",
+    }),
+    true,
+  );
 });
 
 test("policy removal withdraws only that standing permission", () => {

--- a/test/subagent-proofs.test.mjs
+++ b/test/subagent-proofs.test.mjs
@@ -27,17 +27,17 @@ const { subagentVerificationCandidates, verifySubagentCandidates } = await impor
   "../src/subagent-verify.mjs"
 );
 
-test("a proof walks checking -> experimental -> proven, and failures carry reasons", () => {
+test("a compatibility check walks checking -> candidate, while only legacy records retain proven", () => {
   const slug = "example/alpha";
   assert.equal(recordProbeStarted(slug).status, "checking");
   assert.equal(awaitingSpawnProof(slug), false);
 
-  const experimental = recordProbeResult(slug, {
+  const candidate = recordProbeResult(slug, {
     ok: true,
     checks: [{ name: "tool calling", ok: true }],
   });
-  assert.equal(experimental.status, "experimental");
-  assert.equal(awaitingSpawnProof(slug), true);
+  assert.equal(candidate.status, "candidate");
+  assert.equal(awaitingSpawnProof(slug), false);
 
   const proven = recordSpawnObserved(slug, { status: 200 });
   assert.equal(proven.status, "proven");
@@ -59,18 +59,14 @@ test("a proof walks checking -> experimental -> proven, and failures carry reaso
   assert.equal(subagentProofSnapshot()["example/gamma"], undefined);
 });
 
-// Issue #257(b): `proven` was terminal, so the oldest observation on the wire
-// beat every later one. Promotion is still a one-time event, but the window in
-// which evidence can be *taken away* stays open for as long as this machine's
-// traffic is what the v2 advertisement rests on.
-test("a proven slug stays revocable while an unproven or settled one is untouchable", () => {
+test("a candidate never supplies a locally revocable v2 claim", () => {
   const slug = "example/revocable";
   recordProbeResult(slug, { ok: true, checks: [] });
-  assert.equal(spawnProofRevocable(slug), true, "the experimental window is revocable");
+  assert.equal(spawnProofRevocable(slug), false);
 
   recordSpawnObserved(slug, { status: 200 });
-  assert.equal(awaitingSpawnProof(slug), false, "a first clean turn is only news once");
-  assert.equal(spawnProofRevocable(slug), true, "promotion must not close the demotion path");
+  assert.equal(awaitingSpawnProof(slug), false);
+  assert.equal(spawnProofRevocable(slug), false);
 
   // The counts that condemned it travel with the record, so `control subagents
   // status` and the tray can say how much of a spawn it took.
@@ -86,7 +82,7 @@ test("a proven slug stays revocable while an unproven or settled one is untoucha
   assert.equal(
     spawnProofRevocable(slug),
     false,
-    "a slug already demoted has nothing left for traffic to take",
+    "a local record has nothing to take from a repository v2 claim",
   );
 
   // Nothing local to revoke: a checking slug is not advertised yet, and a
@@ -111,7 +107,7 @@ test("a proofs file that cannot be read promotes nothing", () => {
   assert.deepEqual(readSubagentProofs(invented).proofs, {});
 });
 
-test("proof promotion respects demotions and never touches registry claims", () => {
+test("local proof records never promote or demote repository claims", () => {
   const models = [
     { slug: "vendor/experimental" },
     { slug: "vendor/proven" },
@@ -134,8 +130,8 @@ test("proof promotion respects demotions and never touches registry claims", () 
     disabled: ["vendor/disabled"],
   });
   const bySlug = new Map(promoted.map((model) => [model.slug, model.multiAgentVersion]));
-  assert.equal(bySlug.get("vendor/experimental"), "v2");
-  assert.equal(bySlug.get("vendor/proven"), "v2");
+  assert.equal(bySlug.get("vendor/experimental"), undefined);
+  assert.equal(bySlug.get("vendor/proven"), undefined);
   assert.equal(bySlug.get("vendor/failed"), undefined);
   assert.equal(bySlug.get("vendor/checking"), undefined);
   assert.equal(bySlug.get("vendor/hidden"), undefined);
@@ -145,7 +141,7 @@ test("proof promotion respects demotions and never touches registry claims", () 
   assert.equal(applySubagentProofs(models, {}), models);
 });
 
-test("verification skips registry-v2 models, unknown slugs, and settled proofs", () => {
+test("verification skips reviewed v1/v2 models, unknown slugs, and settled candidates", () => {
   recordProbeResult("deepseek/deepseek-v4-pro", { ok: true, checks: [] });
   const candidates = subagentVerificationCandidates([
     "kimi-oauth/k3", // registry v2: shipped with the full native proof
@@ -155,12 +151,8 @@ test("verification skips registry-v2 models, unknown slugs, and settled proofs",
     "deepseek/deepseek-v4-flash", // duplicates collapse
   ]);
   assert.deepEqual(candidates, ["deepseek/deepseek-v4-flash"]);
-  // force re-researches a settled slug.
-  assert.ok(
-    subagentVerificationCandidates(["deepseek/deepseek-v4-pro"], { force: true }).includes(
-      "deepseek/deepseek-v4-pro",
-    ),
-  );
+  // force may retry a candidate, but never a reviewed registry v1/v2 verdict.
+  assert.ok(subagentVerificationCandidates(["deepseek/deepseek-v4-pro"], { force: true }).includes("deepseek/deepseek-v4-pro"));
   clearSubagentProof("deepseek/deepseek-v4-pro");
 });
 
@@ -168,8 +160,8 @@ test("verify records the probe's verdict, and a probe crash reads as a failure",
   const passed = await verifySubagentCandidates(["deepseek/deepseek-v4-flash"], {
     probe: async (slug) => ({ ok: true, checks: [{ name: "tool calling", ok: true, slug }] }),
   });
-  assert.equal(passed[0].status, "experimental");
-  assert.equal(subagentProofSnapshot()["deepseek/deepseek-v4-flash"].status, "experimental");
+  assert.equal(passed[0].status, "candidate");
+  assert.equal(subagentProofSnapshot()["deepseek/deepseek-v4-flash"].status, "candidate");
   clearSubagentProof("deepseek/deepseek-v4-flash");
 
   // A probe that never reached the provider proved nothing: it defers and

--- a/test/subagent-proofs.test.mjs
+++ b/test/subagent-proofs.test.mjs
@@ -68,17 +68,17 @@ test("a candidate never supplies a locally revocable v2 claim", () => {
   assert.equal(awaitingSpawnProof(slug), false);
   assert.equal(spawnProofRevocable(slug), false);
 
-  // The counts that condemned it travel with the record, so `control subagents
+  // The counts that rejected it travel with the record, so `control subagents
   // status` and the tray can say how much of a spawn it took.
-  const demoted = recordSpawnFailure(slug, {
+  const rejected = recordSpawnFailure(slug, {
     status: 200,
     reason: "one child spawn ran 6 turns without converging",
     turns: 6,
     newInputTokens: 2_100,
   });
-  assert.equal(demoted.status, "failed");
-  assert.equal(demoted.spawn.turns, 6);
-  assert.equal(demoted.spawn.newInputTokens, 2_100);
+  assert.equal(rejected.status, "failed");
+  assert.equal(rejected.spawn.turns, 6);
+  assert.equal(rejected.spawn.newInputTokens, 2_100);
   assert.equal(
     spawnProofRevocable(slug),
     false,
@@ -145,7 +145,7 @@ test("verification skips reviewed v1/v2 models, unknown slugs, and settled candi
   recordProbeResult("deepseek/deepseek-v4-pro", { ok: true, checks: [] });
   const candidates = subagentVerificationCandidates([
     "kimi-oauth/k3", // registry v2: shipped with the full native proof
-    "deepseek/deepseek-v4-pro", // already experimental locally
+    "deepseek/deepseek-v4-pro", // already a settled local candidate
     "deepseek/deepseek-v4-flash", // real, unproven: the one that needs research
     "not-a/model", // unknown slugs cannot be probed
     "deepseek/deepseek-v4-flash", // duplicates collapse
@@ -254,24 +254,20 @@ test("a plan-entitlement refusal defers every model it gated, condemning none", 
   assert.equal(subagentProofSnapshot()[slug], undefined);
 });
 
-// Issue #257: an operator watched "subagent proven: <slug> completed a live
-// child turn" and read it as the child finishing the work it was delegated.
-// The observer sees one HTTP turn — a child makes one per tool-call round trip
-// and the loop stringing them together is Codex's — so the promotion cannot
-// mean that, and the line it prints has to scope its own claim. Guarded at the
-// source because the wording *is* the fix: nothing else in the process states
-// what `proven` promises to the person reading the router log.
-test("the subagent promotion log line claims the wire role, not a finished task", () => {
+// Historical child traffic remains useful application evidence, but the log
+// must say it is diagnostic rather than implying a local v2 promotion or a
+// finished delegated task.
+test("the legacy child-observation log does not claim local v2 authority", () => {
   const source = readFileSync(new URL("../src/router.mjs", import.meta.url), "utf8");
   const start = source.indexOf("function observeSubagentOutcome");
-  assert.ok(start > 0, "observeSubagentOutcome moved; re-point this guard at the promotion path");
+  assert.ok(start > 0, "observeSubagentOutcome moved; re-point this guard at the observation path");
   // Scoped to the one function, so an unrelated router line cannot satisfy it.
   const body = source.slice(start).split(/\r?\n\}/)[0];
-  assert.match(body, /child role verified/);
-  assert.match(body, /not a claim the child finished its task/);
+  assert.match(body, /legacy subagent evidence observed/);
+  assert.match(body, /remains diagnostic and is not a repository v2 certificate/);
   assert.doesNotMatch(
     body,
-    /subagent proven/,
-    "the promotion line claims more than one observed turn proves",
+    /subagent (?:proven|promoted)/,
+    "the observation line must not claim local registry authority",
   );
 });

--- a/test/subagent-ui.test.mjs
+++ b/test/subagent-ui.test.mjs
@@ -11,6 +11,35 @@ test("desktop subagent settings show native and unverified enabled models", () =
   assert.match(source, /const subagentModels = enabledModels;/);
   assert.doesNotMatch(source, /!model\.native\s*&&\s*model\.visible/);
   assert.match(source, /selectedSubagents\.has\(model\.slug\)/);
+  const activeCapability = source.slice(
+    source.indexOf("const isSubagentOn = (model)"),
+    source.indexOf("const subagentRow = (model)"),
+  );
+  assert.match(source, /const isCertifiedV2 = \(model\) => subagentCertification\(model\) === "v2"/);
+  assert.match(activeCapability, /isCertifiedV2\(model\)/);
+  assert.doesNotMatch(activeCapability, /selectedSubagents/);
+  assert.match(source, /model\.multiAgentVersion === "v1" \? "v1" : "unknown"/);
+  assert.match(source, /: certified\s*\? t\("models\.provenV2"\)/);
+  assert.match(source, /\["candidate", "experimental", "proven"\]\.includes\(proof\?\.status\)/);
+  assert.match(source, /const testActive = !certified && !knownV1 && !candidate &&\s*selectedSubagents\.has\(model\.slug\)/);
+  assert.doesNotMatch(source, /knownV1 \|\| checking \|\| candidate \? " disabled"/);
+});
+
+test("Control Center keeps legacy local proofs as candidates, not active v2 routes", () => {
+  const source = readFileSync(
+    path.join(root, "apps", "control-center", "src", "pages", "ModelsPage.tsx"),
+    "utf8",
+  );
+  assert.match(source, /const selectedAsSubagent = certified && selectedInSettings/);
+  assert.match(source, /const certified = certification === "v2"/);
+  assert.match(source, /model\.multiAgentVersion === "v1" \? "v1" : "unknown"/);
+  assert.match(source, /\{eligible \? "v2 relay" : knownV1 \? "v1 only" : checking/);
+  assert.match(source, /if \(!model \|\| model\.visible === false\) return false/);
+  assert.match(source, /if \(subagentCertification\(model\) === "v2"\)/);
+  assert.match(source, /settings\.mode === "selected" && settings\.enabled\.includes\(slug\)/);
+  assert.match(source, /\["candidate", "experimental", "proven"\]\.includes\(proof\?\.status \?\? ""\)/);
+  assert.match(source, /const testActive = !certified && !knownV1 && !candidate && selectedInSettings/);
+  assert.match(source, /disabled=\{!api \|\| candidate \|\| knownV1\}/);
 });
 
 test("macOS subagent settings show native and unverified enabled models", () => {
@@ -25,9 +54,22 @@ test("macOS subagent settings show native and unverified enabled models", () => 
     source.indexOf("private var enabledModels"),
   );
   assert.doesNotMatch(subagentList, /provider != "openai"/);
+  assert.match(source, /let subagentCertification: String\?/);
+  assert.match(source, /if model\.multiAgentVersion == "v1" \{ return "v1" \}/);
+  const activeCapability = source.slice(
+    source.indexOf("private func isSubagent(_ model: RouterModel)"),
+    source.indexOf("private func subagentToggleOn(_ model: RouterModel)"),
+  );
+  assert.match(source, /private func isCertifiedV2\(_ model: RouterModel\) -> Bool/);
+  assert.match(activeCapability, /isCertifiedV2\(model\)/);
+  assert.doesNotMatch(activeCapability, /selectedSubagentSet/);
+  assert.match(source, /private func subagentToggleOn\(_ model: RouterModel\)/);
   assert.match(source, /selectedSubagentSet\.contains\(model\.slug\)/);
-  assert.match(source, /if !isPickerVisible\(model\) \{ return false \}/);
-  assert.match(source, /disabled: !isPickerVisible\(model\)/);
+  assert.doesNotMatch(source, /let authoritative = checking \|\| selectedSubagentSet/);
+  assert.match(source, /return isKnownV1\(model\) \|\| isCertificationCandidate\(model\)/);
+  assert.match(source, /\["candidate", "experimental", "proven"\]\.contains\(status\)/);
+  assert.match(source, /get: \{ subagentToggleOn\(model\) \}/);
+  assert.match(source, /disabled: subagentToggleDisabled\(model\)/);
   assert.match(source, /title: model\.displayName/);
   assert.match(source, /subagentStatusTags\(for: model\)/);
   assert.match(source, /Text\(routerLocalized\("Subagent"\)\)/);

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -174,6 +174,12 @@ test("registry merges valid user models and skips collisions", async () => {
       ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-bad-trailing-turn", priority: 111 }),
       requiresTrailingUserTurn: "yes",
     },
+    // Local state is not a repository certificate. A hand-edited overlay must
+    // never make its own route appear as a native v2 subagent.
+    {
+      ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-self-certified", priority: 112 }),
+      multiAgentVersion: "v2",
+    },
     // Reasoning-summary capability fields must agree. A valid enum on its own
     // must not make the catalog claim summaries for a model that does not
     // explicitly support them.
@@ -209,6 +215,7 @@ test("registry merges valid user models and skips collisions", async () => {
   assert.ok(slugs.includes("deepseek/deepseek-standalone-search"));
   assert.ok(!slugs.includes("deepseek/deepseek-bad-detail"));
   assert.ok(!slugs.includes("deepseek/deepseek-bad-trailing-turn"));
+  assert.ok(!slugs.includes("deepseek/deepseek-self-certified"));
   assert.ok(!slugs.includes("deepseek/deepseek-summary-without-support"));
   assert.ok(!slugs.includes("deepseek/deepseek-invalid-summary-support"));
   assert.ok(!slugs.includes("deepseek/deepseek-bad-upgrade"));
@@ -218,6 +225,7 @@ test("registry merges valid user models and skips collisions", async () => {
   );
   assert.ok(registry.MODEL_BY_GATEWAY_ID.has("deepseek-deepseek-user-test"));
   assert.ok(registry.USER_MODEL_WARNINGS.length >= 4);
+  assert.ok(registry.USER_MODEL_WARNINGS.some((warning) => /may not declare multiAgentVersion v2/.test(warning)));
   const merged = registry.MODEL_BY_SLUG.get("deepseek/deepseek-user-test");
   assert.equal(merged.listed, true);
   assert.equal(merged.availabilityNux, "Now available through your DeepSeek key.");

--- a/test/v2-agent-applications.test.mjs
+++ b/test/v2-agent-applications.test.mjs
@@ -1,13 +1,21 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync, unlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 const { validateV2AgentApplications } = await import("../scripts/check-v2-agent-applications.mjs");
 
+const ACCEPTED_MODELS = Object.freeze([{
+  slug: "example/alpha",
+  provider: "example",
+  upstreamModel: "alpha",
+  multiAgentVersion: "v2",
+}]);
+
 function application(root, proof, markdown = "# Proof\n\n## Evidence\n\nSummary only.\n") {
-  const folder = path.join(root, proof.provider, proof.model);
+  const routeName = String(proof.slug || "").split("/")[1] || proof.model;
+  const folder = path.join(root, proof.provider, routeName);
   mkdirSync(folder, { recursive: true });
   writeFileSync(path.join(folder, "proof.md"), markdown);
   writeFileSync(path.join(folder, "proof.json"), JSON.stringify(proof, null, 2));
@@ -21,7 +29,7 @@ function acceptedProof() {
     model: "alpha",
     slug: "example/alpha",
     status: "accepted",
-    officialSources: ["https://docs.example.test/models/alpha"],
+    officialSources: ["https://api-docs.deepseek.com/models/alpha"],
     testedAt: now,
     routerVersion: "0.4.0-beta.4",
     checks: Object.fromEntries(
@@ -34,7 +42,7 @@ function acceptedProof() {
 test("an accepted application requires all native collaboration evidence", () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "v2-agent-application-test-"));
   application(root, acceptedProof());
-  assert.deepEqual(validateV2AgentApplications(root), [{
+  assert.deepEqual(validateV2AgentApplications(root, { models: ACCEPTED_MODELS }), [{
     provider: "example", model: "alpha", slug: "example/alpha", status: "accepted",
   }]);
 });
@@ -56,9 +64,157 @@ test("proofs fail closed on missing checks, identity drift, and credential-shape
   const incomplete = acceptedProof();
   delete incomplete.checks.markerReturn;
   application(missing, incomplete);
-  assert.throws(() => validateV2AgentApplications(missing), /markerReturn/);
+  assert.throws(
+    () => validateV2AgentApplications(missing, { models: ACCEPTED_MODELS }),
+    /markerReturn/,
+  );
 
   const secret = mkdtempSync(path.join(os.tmpdir(), "v2-agent-secret-test-"));
   application(secret, acceptedProof(), "# Proof\n\n## Evidence\n\nBearer token_abcdefghijklmnop\n");
-  assert.throws(() => validateV2AgentApplications(secret), /credentials or bearer/);
+  assert.throws(
+    () => validateV2AgentApplications(secret, { models: ACCEPTED_MODELS }),
+    /credentials or bearer/,
+  );
 });
+
+test("accepted proof identity must match one exact v2 registry route", () => {
+  const absent = mkdtempSync(path.join(os.tmpdir(), "v2-agent-route-absent-test-"));
+  application(absent, acceptedProof());
+  assert.throws(
+    () => validateV2AgentApplications(absent, {
+      models: [{
+        slug: "other/alpha",
+        provider: "other",
+        upstreamModel: "alpha",
+        multiAgentVersion: "v2",
+      }],
+    }),
+    /does not match an exact registry route/,
+  );
+
+  const unproven = mkdtempSync(path.join(os.tmpdir(), "v2-agent-route-v1-test-"));
+  application(unproven, acceptedProof());
+  assert.throws(
+    () => validateV2AgentApplications(unproven, {
+      models: [{
+        slug: "example/alpha",
+        provider: "example",
+        upstreamModel: "alpha",
+      }],
+    }),
+    /requires the exact registry route to declare multiAgentVersion v2/,
+  );
+});
+
+test("accepted proofs reject placeholder sources and loose timestamps", () => {
+  for (const source of [
+    "https://docs.example.test/models/alpha",
+    "https://docs.example.com/models/alpha",
+    "https://localhost./models/alpha",
+    "https://[::1]/models/alpha",
+  ]) {
+    const placeholder = mkdtempSync(path.join(os.tmpdir(), "v2-agent-source-test-"));
+    const placeholderProof = acceptedProof();
+    placeholderProof.officialSources = [source];
+    application(placeholder, placeholderProof);
+    assert.throws(
+      () => validateV2AgentApplications(placeholder, { models: ACCEPTED_MODELS }),
+      /HTTPS officialSources/,
+      source,
+    );
+  }
+
+  const timestamp = mkdtempSync(path.join(os.tmpdir(), "v2-agent-timestamp-test-"));
+  const timestampProof = acceptedProof();
+  timestampProof.testedAt = "August 22, 2026 UTC";
+  application(timestamp, timestampProof);
+  assert.throws(
+    () => validateV2AgentApplications(timestamp, { models: ACCEPTED_MODELS }),
+    /ISO testedAt timestamp/,
+  );
+});
+
+test("proof artifacts reject common credential shapes", () => {
+  // Compose these at runtime so the repository tests the scanner without
+  // teaching GitHub push protection that the fixture itself is a credential.
+  for (const credential of [
+    ["gh", "p_abcdefghijklmnopqrstuvwxyz0123456789"],
+    ["AI", "zaSyABCDEFGHIJKLMNOPQRSTUVWXYZ123456789"],
+    ["AS", "IAABCDEFGHIJKLMNOP"],
+    ["h", "f_abcdefghijklmnopqrstuvwxyz0123456789"],
+    ["xo", "xb-123456789012-123456789012-abcdefghijklmnopqrstuvwx"],
+    ["gl", "pat-abcdefghijklmnopqrstuvwxyz0123456789"],
+    ["np", "m_abcdefghijklmnopqrstuvwxyz0123456789"],
+  ].map((parts) => parts.join(""))) {
+    const root = mkdtempSync(path.join(os.tmpdir(), "v2-agent-secret-shape-test-"));
+    application(
+      root,
+      acceptedProof(),
+      `# Proof\n\n## Evidence\n\n${credential}\n`,
+    );
+    assert.throws(
+      () => validateV2AgentApplications(root, { models: ACCEPTED_MODELS }),
+      /credentials or bearer/,
+      credential,
+    );
+  }
+});
+
+test("proof slugs contain exactly two safe path segments", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "v2-agent-slug-test-"));
+  const proof = acceptedProof();
+  proof.slug = "example/alpha/extra";
+  application(root, proof);
+  assert.throws(() => validateV2AgentApplications(root), /slug must match/);
+});
+
+test("the route directory is independent of slash-bearing upstream model ids", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "v2-agent-upstream-id-test-"));
+  application(root, {
+    version: 1,
+    provider: "example",
+    model: "accounts/vendor/models/alpha:v2",
+    slug: "example/alpha-v2",
+    status: "draft",
+  });
+  assert.deepEqual(validateV2AgentApplications(root)[0], {
+    provider: "example",
+    model: "accounts/vendor/models/alpha:v2",
+    slug: "example/alpha-v2",
+    status: "draft",
+  });
+});
+
+test("a new registry v2 declaration requires an accepted exact-route application", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "v2-agent-reverse-gate-test-"));
+  assert.throws(
+    () => validateV2AgentApplications(root, {
+      models: [{
+        slug: "new-provider/new-model",
+        provider: "new-provider",
+        upstreamModel: "vendor/new-model",
+        multiAgentVersion: "v2",
+      }],
+    }),
+    /registry v2 route needs an accepted application/,
+  );
+});
+
+test(
+  "proof artifacts must be regular files rather than symlinks",
+  { skip: process.platform === "win32" },
+  () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "v2-agent-symlink-test-"));
+    const proof = acceptedProof();
+    application(root, proof);
+    const markdown = path.join(root, proof.provider, "alpha", "proof.md");
+    const outside = path.join(root, "outside-proof.md");
+    writeFileSync(outside, "# Proof\n\n## Evidence\n\nOutside the artifact directory.\n");
+    unlinkSync(markdown);
+    symlinkSync(outside, markdown);
+    assert.throws(
+      () => validateV2AgentApplications(root, { models: ACCEPTED_MODELS }),
+      /missing proof.md/,
+    );
+  },
+);

--- a/test/v2-agent-applications.test.mjs
+++ b/test/v2-agent-applications.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const { validateV2AgentApplications } = await import("../scripts/check-v2-agent-applications.mjs");
+
+function application(root, proof, markdown = "# Proof\n\n## Evidence\n\nSummary only.\n") {
+  const folder = path.join(root, proof.provider, proof.model);
+  mkdirSync(folder, { recursive: true });
+  writeFileSync(path.join(folder, "proof.md"), markdown);
+  writeFileSync(path.join(folder, "proof.json"), JSON.stringify(proof, null, 2));
+}
+
+function acceptedProof() {
+  const now = "2026-08-22T00:00:00.000Z";
+  return {
+    version: 1,
+    provider: "example",
+    model: "alpha",
+    slug: "example/alpha",
+    status: "accepted",
+    officialSources: ["https://docs.example.test/models/alpha"],
+    testedAt: now,
+    routerVersion: "0.4.0-beta.4",
+    checks: Object.fromEntries(
+      ["streaming", "toolCall", "encryptedRelay", "markerReturn", "sameThreadFollowUp"]
+        .map((name) => [name, { outcome: "pass", status: 200, observedAt: now }]),
+    ),
+  };
+}
+
+test("an accepted application requires all native collaboration evidence", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "v2-agent-application-test-"));
+  application(root, acceptedProof());
+  assert.deepEqual(validateV2AgentApplications(root), [{
+    provider: "example", model: "alpha", slug: "example/alpha", status: "accepted",
+  }]);
+});
+
+test("a draft may be submitted before live evidence exists", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "v2-agent-draft-test-"));
+  application(root, {
+    version: 1,
+    provider: "example",
+    model: "beta",
+    slug: "example/beta",
+    status: "draft",
+  });
+  assert.equal(validateV2AgentApplications(root)[0].status, "draft");
+});
+
+test("proofs fail closed on missing checks, identity drift, and credential-shaped content", () => {
+  const missing = mkdtempSync(path.join(os.tmpdir(), "v2-agent-missing-test-"));
+  const incomplete = acceptedProof();
+  delete incomplete.checks.markerReturn;
+  application(missing, incomplete);
+  assert.throws(() => validateV2AgentApplications(missing), /markerReturn/);
+
+  const secret = mkdtempSync(path.join(os.tmpdir(), "v2-agent-secret-test-"));
+  application(secret, acceptedProof(), "# Proof\n\n## Evidence\n\nBearer token_abcdefghijklmnop\n");
+  assert.throws(() => validateV2AgentApplications(secret), /credentials or bearer/);
+});

--- a/v2_agent/README.md
+++ b/v2_agent/README.md
@@ -1,0 +1,48 @@
+# v2 agent applications
+
+This directory is the review gate for promoting a routed model to Codex
+`multiAgentVersion: "v2"` for every installer. A model is v1 unless its exact
+`provider/model` route has an accepted application here **and** the matching
+registry change is included in the same pull request.
+
+An application is scoped to the route, not the model family. For example,
+`deepseek/deepseek-v4-pro` and `opencode-go/deepseek-v4-pro` need separate
+applications because their credentials, upstream adapter, and tool handling
+are different.
+
+## What qualifies
+
+All five checks below must pass through the installed router with a real
+account that can spend the route's quota:
+
+1. The provider's official documentation and `/models` catalog identify the
+   exact upstream model and supported endpoint.
+2. A streamed Responses turn emits text and completes normally.
+3. A forced function call returns the requested tool name and valid JSON
+   arguments.
+4. A native Codex parent delegates a child through the encrypted payload
+   relay, and the child returns an exact marker.
+5. The parent sends a same-thread follow-up to that child and receives the
+   second exact marker.
+
+Do not infer any of this from a model name, a successful ordinary chat turn,
+or a vendor's generic claim that its API supports tools.
+
+## Submit an application
+
+1. Copy `_template/` to `v2_agent/<provider>/<model>/`; directory names use
+   lowercase letters, digits, `.`, `_`, and `-`.
+2. Record stable metadata and redacted outcome summaries in `proof.md` and
+   `proof.json`. Do not commit API keys, bearer capabilities, raw prompts,
+   decrypted payloads, or provider response bodies.
+3. Leave `status` as `draft` until all five checks have passed. Set it to
+   `accepted` only in the PR that also sets the exact registry route's
+   `multiAgentVersion` to `"v2"`.
+4. Run `node scripts/check-v2-agent-applications.mjs`, `npm run check`, and
+   the focused routing/catalog tests.
+5. Open a draft PR. Reviewers reproduce the marker-return and same-thread
+   steps, inspect the redacted evidence, and then approve the registry change.
+
+CI validates the artifact shape and refuses evidence that looks like a
+credential. It cannot run billable native Codex delegation on behalf of an
+account, so human reproduction remains required.

--- a/v2_agent/README.md
+++ b/v2_agent/README.md
@@ -30,8 +30,10 @@ or a vendor's generic claim that its API supports tools.
 
 ## Submit an application
 
-1. Copy `_template/` to `v2_agent/<provider>/<model>/`; directory names use
-   lowercase letters, digits, `.`, `_`, and `-`.
+1. Copy `_template/` to `v2_agent/<provider>/<slug-model>/`; both directory
+   names use lowercase letters, digits, `.`, `_`, and `-`. The second segment
+   is the routed slug segment, not necessarily the upstream model ID. Record
+   that exact upstream ID in `proof.json` even when it contains `/` or `:`.
 2. Record stable metadata and redacted outcome summaries in `proof.md` and
    `proof.json`. Do not commit API keys, bearer capabilities, raw prompts,
    decrypted payloads, or provider response bodies.
@@ -46,3 +48,9 @@ or a vendor's generic claim that its API supports tools.
 CI validates the artifact shape and refuses evidence that looks like a
 credential. It cannot run billable native Codex delegation on behalf of an
 account, so human reproduction remains required.
+
+CI also enforces the registry/application relationship in both directions:
+an accepted application must bind one exact checked-in v2 route, and every new
+checked-in v2 route must have its accepted application. Six exact Kimi/Grok
+route identities certified before this artifact workflow are grandfathered;
+changing their slug, provider, or upstream model removes that exception.

--- a/v2_agent/_template/proof.json
+++ b/v2_agent/_template/proof.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "provider": "provider-id",
+  "model": "model-id",
+  "slug": "provider-id/model-slug",
+  "status": "draft",
+  "officialSources": [],
+  "testedAt": "",
+  "routerVersion": "",
+  "checks": {
+    "streaming": { "outcome": "pending" },
+    "toolCall": { "outcome": "pending" },
+    "encryptedRelay": { "outcome": "pending" },
+    "markerReturn": { "outcome": "pending" },
+    "sameThreadFollowUp": { "outcome": "pending" }
+  }
+}

--- a/v2_agent/_template/proof.md
+++ b/v2_agent/_template/proof.md
@@ -1,0 +1,27 @@
+# v2 agent application: `<provider>/<model>`
+
+## Route
+
+- Routed slug: `provider/model`
+- Upstream model ID: `exact-provider-id`
+- Provider endpoint: `https://…` (redacted to an origin/path with no capability)
+- Router version and test date: pending
+
+## Evidence
+
+Use outcome summaries only. Do not paste raw prompts, response bodies,
+encrypted payloads, API keys, bearer tokens, or caller URLs.
+
+| Check | Result | Redacted summary |
+| --- | --- | --- |
+| Official model identity | pending | Link the official docs and catalog evidence. |
+| Streaming Responses | pending | Status, completion event, timestamp. |
+| Forced function call | pending | Status and valid JSON-argument verdict. |
+| Encrypted relay | pending | Native parent to routed child completed; no payload text. |
+| Marker-return spawn | pending | Exact marker returned to parent. |
+| Same-thread follow-up | pending | Second marker returned on the existing child thread. |
+
+## Limits and reviewer reproduction
+
+State any known provider limitation and the minimal, redacted steps for a
+reviewer with their own account to reproduce the two native child checks.

--- a/v2_agent/deepseek/deepseek-v4-flash-vision-exp/proof.json
+++ b/v2_agent/deepseek/deepseek-v4-flash-vision-exp/proof.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "provider": "deepseek",
+  "model": "deepseek-v4-flash-vision-exp",
+  "slug": "deepseek/deepseek-v4-flash-vision-exp",
+  "status": "draft",
+  "officialSources": [],
+  "testedAt": "",
+  "routerVersion": "",
+  "checks": {
+    "streaming": { "outcome": "pending" },
+    "toolCall": { "outcome": "pending" },
+    "encryptedRelay": { "outcome": "pending" },
+    "markerReturn": { "outcome": "pending" },
+    "sameThreadFollowUp": { "outcome": "pending" }
+  }
+}

--- a/v2_agent/deepseek/deepseek-v4-flash-vision-exp/proof.md
+++ b/v2_agent/deepseek/deepseek-v4-flash-vision-exp/proof.md
@@ -1,0 +1,22 @@
+# v2 agent application: `deepseek/deepseek-v4-flash-vision-exp`
+
+## Route
+
+- Routed slug: `deepseek/deepseek-v4-flash-vision-exp`
+- Upstream model ID: `deepseek-v4-flash-vision-exp`
+- Status: draft; this is a locally curated route and has no v2 claim.
+
+## Evidence
+
+The installed router preflight must pass before billable proof requests begin.
+Record only redacted status/timestamp summaries after the reviewer reproduces
+the five required checks.
+
+| Check | Result | Redacted summary |
+| --- | --- | --- |
+| Official model identity | pending | Add official DeepSeek documentation and catalog links. |
+| Streaming Responses | pending | |
+| Forced function call | pending | |
+| Encrypted relay | pending | |
+| Marker-return spawn | pending | |
+| Same-thread follow-up | pending | |

--- a/v2_agent/deepseek/deepseek-v4-flash/proof.json
+++ b/v2_agent/deepseek/deepseek-v4-flash/proof.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "provider": "deepseek",
+  "model": "deepseek-v4-flash",
+  "slug": "deepseek/deepseek-v4-flash",
+  "status": "draft",
+  "officialSources": [],
+  "testedAt": "",
+  "routerVersion": "",
+  "checks": {
+    "streaming": { "outcome": "pending" },
+    "toolCall": { "outcome": "pending" },
+    "encryptedRelay": { "outcome": "pending" },
+    "markerReturn": { "outcome": "pending" },
+    "sameThreadFollowUp": { "outcome": "pending" }
+  }
+}

--- a/v2_agent/deepseek/deepseek-v4-flash/proof.md
+++ b/v2_agent/deepseek/deepseek-v4-flash/proof.md
@@ -1,0 +1,22 @@
+# v2 agent application: `deepseek/deepseek-v4-flash`
+
+## Route
+
+- Routed slug: `deepseek/deepseek-v4-flash`
+- Upstream model ID: `deepseek-v4-flash`
+- Status: draft; no v2 claim is made.
+
+## Evidence
+
+The installed router preflight must pass before billable proof requests begin.
+Record only redacted status/timestamp summaries after the reviewer reproduces
+the five required checks.
+
+| Check | Result | Redacted summary |
+| --- | --- | --- |
+| Official model identity | pending | Add official DeepSeek documentation and catalog links. |
+| Streaming Responses | pending | |
+| Forced function call | pending | |
+| Encrypted relay | pending | |
+| Marker-return spawn | pending | |
+| Same-thread follow-up | pending | |

--- a/v2_agent/deepseek/deepseek-v4-pro/proof.json
+++ b/v2_agent/deepseek/deepseek-v4-pro/proof.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "provider": "deepseek",
+  "model": "deepseek-v4-pro",
+  "slug": "deepseek/deepseek-v4-pro",
+  "status": "draft",
+  "officialSources": [],
+  "testedAt": "",
+  "routerVersion": "",
+  "checks": {
+    "streaming": { "outcome": "pending" },
+    "toolCall": { "outcome": "pending" },
+    "encryptedRelay": { "outcome": "pending" },
+    "markerReturn": { "outcome": "pending" },
+    "sameThreadFollowUp": { "outcome": "pending" }
+  }
+}

--- a/v2_agent/deepseek/deepseek-v4-pro/proof.md
+++ b/v2_agent/deepseek/deepseek-v4-pro/proof.md
@@ -1,0 +1,22 @@
+# v2 agent application: `deepseek/deepseek-v4-pro`
+
+## Route
+
+- Routed slug: `deepseek/deepseek-v4-pro`
+- Upstream model ID: `deepseek-v4-pro`
+- Status: draft; no v2 claim is made.
+
+## Evidence
+
+The installed router preflight must pass before billable proof requests begin.
+Record only redacted status/timestamp summaries after the reviewer reproduces
+the five required checks.
+
+| Check | Result | Redacted summary |
+| --- | --- | --- |
+| Official model identity | pending | Add official DeepSeek documentation and catalog links. |
+| Streaming Responses | pending | |
+| Forced function call | pending | |
+| Encrypted relay | pending | |
+| Marker-return spawn | pending | |
+| Same-thread follow-up | pending | |

--- a/v2_agent/opencode-free/x-preview-f-free/proof.json
+++ b/v2_agent/opencode-free/x-preview-f-free/proof.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "provider": "opencode-free",
+  "model": "x-preview-f-free",
+  "slug": "opencode-free/x-preview-f-free",
+  "status": "draft",
+  "officialSources": [],
+  "testedAt": "",
+  "routerVersion": "",
+  "checks": {
+    "streaming": { "outcome": "pending" },
+    "toolCall": { "outcome": "pending" },
+    "encryptedRelay": { "outcome": "pending" },
+    "markerReturn": { "outcome": "pending" },
+    "sameThreadFollowUp": { "outcome": "pending" }
+  }
+}

--- a/v2_agent/opencode-free/x-preview-f-free/proof.md
+++ b/v2_agent/opencode-free/x-preview-f-free/proof.md
@@ -1,0 +1,22 @@
+# v2 agent application: `opencode-free/x-preview-f-free` (Ox Alpha)
+
+## Route
+
+- Routed slug: `opencode-free/x-preview-f-free`
+- Upstream model ID: `x-preview-f-free`
+- Status: draft; no v2 claim is made.
+
+## Evidence
+
+The installed router preflight must pass before billable proof requests begin.
+Record only redacted status/timestamp summaries after the reviewer reproduces
+the five required checks.
+
+| Check | Result | Redacted summary |
+| --- | --- | --- |
+| Official model identity | pending | Add the official OpenCode catalog evidence. |
+| Streaming Responses | pending | |
+| Forced function call | pending | |
+| Encrypted relay | pending | |
+| Marker-return spawn | pending | |
+| Same-thread follow-up | pending | |

--- a/v2_agent/opencode-go-messages/qwen3.8-max/proof.json
+++ b/v2_agent/opencode-go-messages/qwen3.8-max/proof.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "provider": "opencode-go-messages",
+  "model": "qwen3.8-max",
+  "slug": "opencode-go-messages/qwen3.8-max",
+  "status": "draft",
+  "officialSources": [],
+  "testedAt": "",
+  "routerVersion": "",
+  "checks": {
+    "streaming": { "outcome": "pending" },
+    "toolCall": { "outcome": "pending" },
+    "encryptedRelay": { "outcome": "pending" },
+    "markerReturn": { "outcome": "pending" },
+    "sameThreadFollowUp": { "outcome": "pending" }
+  }
+}

--- a/v2_agent/opencode-go-messages/qwen3.8-max/proof.md
+++ b/v2_agent/opencode-go-messages/qwen3.8-max/proof.md
@@ -1,0 +1,22 @@
+# v2 agent application: `opencode-go-messages/qwen3.8-max`
+
+## Route
+
+- Routed slug: `opencode-go-messages/qwen3.8-max`
+- Upstream model ID: `qwen3.8-max`
+- Status: draft; no v2 claim is made.
+
+## Evidence
+
+The installed router preflight must pass before billable proof requests begin.
+Record only redacted status/timestamp summaries after the reviewer reproduces
+the five required checks.
+
+| Check | Result | Redacted summary |
+| --- | --- | --- |
+| Official model identity | pending | Add official OpenCode and Qwen catalog evidence. |
+| Streaming Responses | pending | |
+| Forced function call | pending | |
+| Encrypted relay | pending | |
+| Marker-return spawn | pending | |
+| Same-thread follow-up | pending | |


### PR DESCRIPTION
## Summary

- adds repository-backed V2 certification applications and validation for DeepSeek, Ox Alpha, and Qwen 3.8 candidates
- makes the one-time low-cost compatibility check produce a local `candidate`, never a V2 claim
- preserves explicit V1 verdicts end to end: UI disables retesting, CLI refuses activation, policies skip them, and native settings cannot promote them
- exposes the distinction between certified V2, certified V1, and unknown routes in both model UIs

## Safety invariant

Only a reviewed, repository-shipped `multiAgentVersion: "v2"` entry exposes a model to Codex as a V2 subagent. Local tool/stream checks are application evidence only.

The five submitted provider/model applications intentionally remain `DRAFT`; they contain no live native encrypted-relay proof and therefore make no V2 assertion.

## Verification

- `npm run check`
- `node --test test/catalog.test.mjs test/subagent-proofs.test.mjs test/multi-agent-state.test.mjs test/routing.test.mjs test/v2-agent-applications.test.mjs` (157 passing)
- focused Control CLI V1/V2 regression tests
- `npm run check --prefix apps/control-center`
- `npm test --prefix apps/control-center`