### PR TITLE
feat: safely add DeepSeek V4 Flash Vision Exp

### DIFF
--- a/config/deepseek/deepseek-v4-flashvision-exp.json
+++ b/config/deepseek/deepseek-v4-flashvision-exp.json
@@ -1,0 +1,43 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "deepseek/deepseek-v4-flash-vision-exp",
+      "gatewayModel": "deepseek-v4-flash-vision-exp",
+      "upstreamModel": "deepseek-v4-flash-vision-exp",
+      "provider": "deepseek",
+      "listed": true,
+      "displayName": "DeepSeek V4 Flash Vision Exp (API)",
+      "description": "DeepSeek V4 Flash Vision Exp via the DeepSeek API; fast reasoning, image understanding, tool calls, and a 1M context window.",
+      "priority": 6,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning for complex agent work"
+        }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 900000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsImageDetailOriginal": true,
+      "searchTool": {
+        "mode": "standalone"
+      },
+      "requestProfile": "deepseek-thinking",
+      "supportsReasoningSummaries": true,
+      "compHash": "deepseek-v4-flash-vision-exp-v1"
+    }
+  ]
+}

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -485,6 +485,7 @@ test("login-free control selects a ready external model and restores Codex defau
         .map((model) => [model.slug, model.visibility]),
       [
         ["deepseek/deepseek-v4-flash", "hide"],
+        ["deepseek/deepseek-v4-flash-vision-exp", "list"],
         ["deepseek/deepseek-v4-pro", "list"],
       ],
     );

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -80,11 +80,19 @@ test("provider selection keeps backward compatibility and can hide the final pro
     }
     assert.deepEqual(
       selectedListedModels().map((model) => model.slug),
-      ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"],
+      [
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash-vision-exp",
+        "deepseek/deepseek-v4-pro",
+      ],
     );
     assert.deepEqual(
       selectedConfiguredListedModels().map((model) => model.slug),
-      ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"],
+      [
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash-vision-exp",
+        "deepseek/deepseek-v4-pro",
+      ],
     );
 
     assert.deepEqual(disableProvider("deepseek"), []);
@@ -186,7 +194,11 @@ test("an unknown provider id in the selection file is filtered out, not fatal", 
     // The surviving provider still routes and still filters the catalog.
     assert.deepEqual(
       selectedListedModels().map((model) => model.slug),
-      ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"],
+      [
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash-vision-exp",
+        "deepseek/deepseek-v4-pro",
+      ],
     );
     // Doctor and the support bundle read through this, so the damage is
     // reportable instead of arriving as a 502 on every request.

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -83,6 +83,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "commandcode/step-3.7-flash",
       "custom/qwen3.8-27b",
       "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-flash-vision-exp",
       "deepseek/deepseek-v4-pro",
       "grok-api/grok-4.5",
       "grok-oauth/grok-4.5",
@@ -419,6 +420,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
   }
   const standaloneSearchSlugs = new Set([
     "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-v4-flash-vision-exp",
     "opencode-go/deepseek-v4-flash",
     "xiaomi-mimo/mimo-v2.5",
     "zai-coding/glm-5.3",
@@ -435,6 +437,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
   ).map((model) => model.slug);
   assert.deepEqual(originalDetailSlugs.sort(), [
     "anthropic-api/claude-opus-4.8",
+    "deepseek/deepseek-v4-flash-vision-exp",
     "grok-api/grok-4.5",
     "grok-oauth/grok-4.5",
     "grok-oauth/grok-4.6",
@@ -502,6 +505,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
     "grok-oauth/grok-4.5",
     "grok-api/grok-4.5",
     "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-v4-flash-vision-exp",
     "deepseek/deepseek-v4-pro",
     "deepseek/deepseek-reasoner",
   ]) {
@@ -510,13 +514,26 @@ test("provider registry exposes configured API and OAuth model families", () => 
   assert.equal(MODEL_BY_SLUG.get("deepseek/deepseek-chat").supportsReasoningSummaries, undefined);
   for (const slug of [
     "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-v4-flash-vision-exp",
     "deepseek/deepseek-v4-pro",
   ]) {
     const model = MODEL_BY_SLUG.get(slug);
     assert.equal(model.contextWindow, 1_048_576);
+    assert.equal(model.autoCompact, 900_000);
     assert.match(model.description, /DeepSeek V4/);
-    assert.deepEqual(model.inputModalities, ["text"]);
   }
+  assert.deepEqual(
+    MODEL_BY_SLUG.get("deepseek/deepseek-v4-flash").inputModalities,
+    ["text"],
+  );
+  assert.deepEqual(
+    MODEL_BY_SLUG.get("deepseek/deepseek-v4-pro").inputModalities,
+    ["text"],
+  );
+  assert.deepEqual(
+    MODEL_BY_SLUG.get("deepseek/deepseek-v4-flash-vision-exp").inputModalities,
+    ["text", "image"],
+  );
 });
 
 test("only checked-in Gemini reseller models opt into trailing model-turn trimming", () => {
@@ -534,10 +551,34 @@ test("only checked-in Gemini reseller models opt into trailing model-turn trimmi
 test("DeepSeek V4 Flash routes opt in to Codex standalone web search", () => {
   for (const slug of [
     "deepseek/deepseek-v4-flash",
+    "deepseek/deepseek-v4-flash-vision-exp",
     "opencode-go/deepseek-v4-flash",
   ]) {
     assert.deepEqual(MODEL_BY_SLUG.get(slug)?.searchTool, { mode: "standalone" }, slug);
   }
+});
+
+test("DeepSeek V4 Flash Vision Exp advertises only verified direct-API capabilities", () => {
+  const model = MODEL_BY_SLUG.get("deepseek/deepseek-v4-flash-vision-exp");
+  assert.ok(model);
+  assert.equal(model.provider, "deepseek");
+  assert.equal(model.gatewayModel, "deepseek-v4-flash-vision-exp");
+  assert.equal(model.upstreamModel, "deepseek-v4-flash-vision-exp");
+  assert.equal(model.listed, true);
+  assert.equal(model.requestProfile, "deepseek-thinking");
+  assert.equal(model.defaultEffort, "high");
+  assert.deepEqual(
+    model.reasoningLevels.map((level) => level.effort),
+    ["low", "high", "max"],
+  );
+  assert.equal(model.contextWindow, 1_048_576);
+  assert.equal(model.autoCompact, 900_000);
+  assert.deepEqual(model.inputModalities, ["text", "image"]);
+  assert.equal(model.supportsImageDetailOriginal, true);
+  assert.deepEqual(model.searchTool, { mode: "standalone" });
+  assert.equal(model.supportsReasoningSummaries, true);
+  assert.equal(endpointForModel(model), PROVIDERS.get("deepseek"));
+  assert.ok(API_MODELS.includes(model));
 });
 
 test("GLM-5.3 Coding Plan opts in to GPT-5.6 behavior, concise execution, and standalone search", () => {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -1805,6 +1805,81 @@ test("API forwarder replaces an image a text-only model cannot read", async () =
   }
 });
 
+test("API forwarder keeps images for DeepSeek V4 Flash Vision Exp", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push(await bodyJson(request));
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    DEEPSEEK_API_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    DEEPSEEK_API_KEY: "TEST_DEEPSEEK_API_KEY",
+    KIMI_PROXY_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "deepseek-v4-flash-vision-exp",
+        reasoning_effort: "high",
+        temperature: 0.2,
+        tool_choice: "required",
+        tools: [
+          {
+            type: "function",
+            function: { name: "lookup", parameters: { type: "object", properties: {} } },
+          },
+        ],
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "what does this say?" },
+              {
+                type: "image_url",
+                image_url: {
+                  url: "data:image/png;base64,AAAA",
+                  detail: "original",
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    assert.equal(response.status, 200);
+    const body = upstreamRequests[0];
+    assert.equal(body.model, "deepseek-v4-flash-vision-exp");
+    assert.deepEqual(body.thinking, { type: "enabled" });
+    assert.equal(body.reasoning_effort, "high");
+    assert.equal(body.temperature, undefined);
+    assert.equal(body.tool_choice, "auto");
+    assert.deepEqual(body.messages[0].content, [
+      { type: "text", text: "what does this say?" },
+      {
+        type: "image_url",
+        image_url: {
+          url: "data:image/png;base64,AAAA",
+          detail: "original",
+        },
+      },
+    ]);
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder fills only missing Gemini thought signatures", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {
@@ -2151,6 +2226,8 @@ test("API forwarder supports all DeepSeek V4 models and normalizes thinking", as
     for (const [gatewayModel, upstreamModel, sentEffort, effort] of [
       ["deepseek-v4-flash", "deepseek-v4-flash", "low", "low"],
       ["deepseek-v4-flash", "deepseek-v4-flash", "medium", "high"],
+      ["deepseek-v4-flash-vision-exp", "deepseek-v4-flash-vision-exp", "low", "low"],
+      ["deepseek-v4-flash-vision-exp", "deepseek-v4-flash-vision-exp", "medium", "high"],
       ["deepseek-v4-pro", "deepseek-v4-pro", "xhigh", "max"],
     ]) {
       const response = await fetch(
@@ -2231,6 +2308,7 @@ test("API forwarder downgrades forced tool choices for DeepSeek thinking models"
     // object form, so both must arrive as auto rather than failing the turn.
     for (const gatewayModel of [
       "deepseek-v4-flash",
+      "deepseek-v4-flash-vision-exp",
       "deepseek-v4-pro",
       "deepseek-legacy-reasoner",
     ]) {


### PR DESCRIPTION
Supersedes #337 while preserving the contributor attribution.

This replacement adds the direct DeepSeek API route for deepseek-v4-flash-vision-exp with the documented 1M context window, text and image input, original image detail, thinking profile, tool-choice normalization, and standalone search support.

Safety changes over the original:
- keeps the ordinary DeepSeek V4 Flash route first in deterministic registry order, so login-free default selection does not change
- keeps the exact upstream model ID end to end
- adds registry, provider-selection, login-free, request-profile, image-forwarding, thinking, and forced-tool-choice regression coverage

Local verification:
- npm run check
- npm test: 2,057 passed, 0 failed, 13 skipped

A billable live DeepSeek request was intentionally not run.