### PR TITLE
fix(installer): install Node dependencies before guided credential setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -274,6 +274,9 @@ command -v node >/dev/null 2>&1 ||
 command -v npm >/dev/null 2>&1 ||
   die "npm is required and is normally included with Node.js"
 
+if [ -n "$configure_provider_keys" ]; then
+  node "$repo_dir/src/node-dependency-install.mjs"
+fi
 for provider_id in $configure_provider_keys; do
   "$repo_dir/bin/provider-key" "$provider_id" set
 done

--- a/src/node-dependency-install.mjs
+++ b/src/node-dependency-install.mjs
@@ -1,0 +1,43 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { recordStep, SOURCE_ROOT, stepStatus } from "./install-plan.mjs";
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
+
+export function ensureNodeDependencies({
+  root = SOURCE_ROOT,
+  env = process.env,
+  platform = process.platform,
+} = {}) {
+  // Package managers assemble this tree themselves. Mutating their prefix with
+  // npm would violate the same ownership boundary enforced by bin/install.
+  if (env.CODEX_ROUTER_PACKAGE_MANAGER) return "managed";
+  if (stepStatus("node-deps", { root, platform }) === "skip") return "skip";
+
+  const npm = commandOnPath("npm", { platform });
+  if (!npm) throw new Error("npm is required and is normally included with Node.js.");
+  process.stdout.write("Installing Node dependencies needed for credential setup...\n");
+  const invocation = spawnableCommand(npm, ["ci", "--omit=dev"], platform);
+  const result = spawnSync(invocation.command, invocation.args, {
+    ...invocation.options,
+    cwd: root,
+    env,
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`npm dependency installation exited with status ${result.status}.`);
+  }
+  recordStep("node-deps", { root });
+  return "installed";
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    ensureNodeDependencies();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
+import { ensureNodeDependencies } from "./node-dependency-install.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT, TARGET } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
@@ -291,6 +292,7 @@ function configureProvider(provider) {
     if (!confirm(`Enter ${prompt} securely now?`)) {
       throw incomplete(`${provider.displayName} setup was cancelled.`);
     }
+    ensureNodeDependencies();
     run(process.execPath, [path.join(SOURCE_ROOT, "src", "provider-key.mjs"), provider.id, "set"]);
   }
 }

--- a/test/setup-node-deps.test.mjs
+++ b/test/setup-node-deps.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "..");
+const PYTHON_AVAILABLE =
+  spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+const GUIDED_SETUP_HELPER = String.raw`
+import errno
+import os
+import select
+import sys
+import termios
+import time
+
+node, setup, checkout, home, state_dir, secret, confirmation = sys.argv[1:]
+env = os.environ.copy()
+env.update({
+    "HOME": home,
+    "CODEX_HOME": home,
+    "CODEX_ROUTER_STATE_DIR": state_dir,
+    "MODEL_ROUTER_STATE_DIR": state_dir,
+    "MODEL_ROUTER_TARGET": "codex",
+    "DEEPSEEK_API_KEY": "",
+})
+pid, master = os.forkpty()
+if pid == 0:
+    os.chdir(checkout)
+    os.execve(node, [node, setup, "--guided", "--providers", "deepseek", "--selection-only"], env)
+
+output = bytearray()
+confirmed = False
+key_sent = False
+while True:
+    ready, _, _ = select.select([master], [], [], 15)
+    if not ready:
+        os.kill(pid, 9)
+        raise SystemExit("timed out waiting for guided setup")
+    try:
+        chunk = os.read(master, 4096)
+    except OSError as error:
+        if error.errno == errno.EIO:
+            break
+        raise
+    if not chunk:
+        break
+    output.extend(chunk)
+    if not confirmed and b"Enter DeepSeek API key securely now?" in output:
+        os.write(master, confirmation.encode() + b"\n")
+        confirmed = True
+    if confirmation.lower() == "y" and not key_sent and b"DeepSeek API key: " in output:
+        deadline = time.monotonic() + 2
+        while termios.tcgetattr(master)[3] & termios.ECHO:
+            if time.monotonic() >= deadline:
+                os.kill(pid, 9)
+                raise SystemExit("provider-key did not disable terminal echo")
+            time.sleep(0.01)
+        os.write(master, secret.encode() + b"\n")
+        key_sent = True
+
+_, status = os.waitpid(pid, 0)
+os.close(master)
+sys.stdout.buffer.write(output)
+raise SystemExit(os.waitstatus_to_exitcode(status))
+`;
+
+function withFreshGuidedSetup(confirmation, verify) {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-guided-deps-"));
+  const checkout = path.join(testRoot, "checkout");
+  const fakeBin = path.join(testRoot, "bin");
+  const stateDir = path.join(testRoot, "state");
+  const npmLog = path.join(testRoot, "npm.log");
+  const secret = "TEST_DEEPSEEK_GUIDED_KEY";
+
+  try {
+    mkdirSync(checkout, { recursive: true });
+    cpSync(path.join(root, "src"), path.join(checkout, "src"), { recursive: true });
+    cpSync(path.join(root, "config"), path.join(checkout, "config"), { recursive: true });
+    copyFileSync(path.join(root, "package.json"), path.join(checkout, "package.json"));
+    copyFileSync(path.join(root, "package-lock.json"), path.join(checkout, "package-lock.json"));
+
+    mkdirSync(fakeBin, { recursive: true });
+    writeFileSync(
+      path.join(fakeBin, "npm"),
+      `#!/bin/sh
+printf '%s\\n' "$*" >"$CODEX_ROUTER_NPM_LOG"
+cp -R "$CODEX_ROUTER_TEST_NODE_MODULES" node_modules
+`,
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      "python3",
+      [
+        "-c",
+        GUIDED_SETUP_HELPER,
+        process.execPath,
+        path.join(checkout, "src", "setup.mjs"),
+        checkout,
+        testRoot,
+        stateDir,
+        secret,
+        confirmation,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH || "/usr/local/bin:/usr/bin:/bin"}`,
+          CODEX_ROUTER_NPM_LOG: npmLog,
+          CODEX_ROUTER_TEST_NODE_MODULES: path.join(root, "node_modules"),
+        },
+        timeout: 25_000,
+      },
+    );
+
+    verify({ checkout, npmLog, result, secret, stateDir });
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+}
+
+test(
+  "fresh guided setup installs Node dependencies before storing a provider key",
+  { skip: process.platform === "win32" || !PYTHON_AVAILABLE },
+  () => {
+    withFreshGuidedSetup("Y", ({ checkout, npmLog, result, secret, stateDir }) => {
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.doesNotMatch(result.stdout, /ERR_MODULE_NOT_FOUND/);
+      assert.equal(readFileSync(npmLog, "utf8"), "ci --omit=dev\n");
+      assert.equal(
+        readFileSync(path.join(stateDir, "deepseek-api-key.secret"), "utf8"),
+        `${secret}\n`,
+      );
+      assert.equal(existsSync(path.join(checkout, "node_modules", ".package-lock.json")), true);
+    });
+  },
+);
+
+test(
+  "fresh guided setup does not install Node dependencies when key setup is declined",
+  { skip: process.platform === "win32" || !PYTHON_AVAILABLE },
+  () => {
+    withFreshGuidedSetup("n", ({ checkout, npmLog, result, stateDir }) => {
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /DeepSeek API setup was cancelled/);
+      assert.equal(existsSync(npmLog), false);
+      assert.equal(existsSync(path.join(checkout, "node_modules")), false);
+      assert.equal(existsSync(path.join(stateDir, "deepseek-api-key.secret")), false);
+    });
+  },
+);


### PR DESCRIPTION
### Why

On a fresh install, `node_modules` does not exist yet.

However, the installer tries to configure the DeepSeek API key using code that depends on `proper-lockfile`. This causes an `ERR_MODULE_NOT_FOUND` error.

In short, the installer runs the code before installing its dependencies.

### What

Fix the installation order:

- Install the Node dependencies after the user confirms they want to enter an API key.
- Save the API key after the dependencies are installed.
- Do not install dependencies if the user declines.
- Add regression tests to prevent this issue from happening again.

### Tests

All 51 related tests passed, with 2 skipped on the current platform.

The following checks also passed:

```text
npm run check
sh -n install.sh
git diff --check
```