### PR TITLE
fix(setup): add model selection to guided setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -274,6 +274,9 @@ command -v node >/dev/null 2>&1 ||
 command -v npm >/dev/null 2>&1 ||
   die "npm is required and is normally included with Node.js"
 
+if [ -n "$configure_provider_keys" ]; then
+  node "$repo_dir/src/node-dependency-install.mjs"
+fi
 for provider_id in $configure_provider_keys; do
   "$repo_dir/bin/provider-key" "$provider_id" set
 done

--- a/src/model-picker-state.mjs
+++ b/src/model-picker-state.mjs
@@ -147,6 +147,32 @@ export function setAllModelsVisible(slugs, visible) {
   });
 }
 
+// Applies one explicit picker selection to the supplied models while leaving
+// every other provider's visibility untouched.
+export function setModelSelection(slugs, selectedSlugs) {
+  const values = [...new Set(
+    (Array.isArray(slugs) ? slugs : []).map((slug) => String(slug || "").trim()).filter(Boolean),
+  )];
+  if (values.length === 0) return modelPickerSnapshot();
+  const selected = new Set(
+    (Array.isArray(selectedSlugs) ? selectedSlugs : [])
+      .map((slug) => String(slug || "").trim())
+      .filter(Boolean),
+  );
+  const { hidden, visible, seeded } = readPickerState();
+  for (const value of values) {
+    if (selected.has(value)) {
+      hidden.delete(value);
+      visible.add(value);
+    } else {
+      hidden.add(value);
+      visible.delete(value);
+    }
+    seeded.add(value);
+  }
+  return writePickerState({ hidden, visible, seeded });
+}
+
 // Applies a shipped default to models the operator has never decided, and only
 // to those. Used by the catalog build for entries that must arrive switched off
 // (`src/native-context-variants.mjs`): they cost more per turn than the model

--- a/src/node-dependency-install.mjs
+++ b/src/node-dependency-install.mjs
@@ -1,0 +1,43 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { recordStep, SOURCE_ROOT, stepStatus } from "./install-plan.mjs";
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
+
+export function ensureNodeDependencies({
+  root = SOURCE_ROOT,
+  env = process.env,
+  platform = process.platform,
+} = {}) {
+  // Package managers assemble this tree themselves. Mutating their prefix with
+  // npm would violate the same ownership boundary enforced by bin/install.
+  if (env.CODEX_ROUTER_PACKAGE_MANAGER) return "managed";
+  if (stepStatus("node-deps", { root, platform }) === "skip") return "skip";
+
+  const npm = commandOnPath("npm", { platform });
+  if (!npm) throw new Error("npm is required and is normally included with Node.js.");
+  process.stdout.write("Installing Node dependencies needed for credential setup...\n");
+  const invocation = spawnableCommand(npm, ["ci", "--omit=dev"], platform);
+  const result = spawnSync(invocation.command, invocation.args, {
+    ...invocation.options,
+    cwd: root,
+    env,
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`npm dependency installation exited with status ${result.status}.`);
+  }
+  recordStep("node-deps", { root });
+  return "installed";
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    ensureNodeDependencies();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/setup-ui.mjs
+++ b/src/setup-ui.mjs
@@ -55,6 +55,16 @@ export function renderProviderChoices(snapshots, selected, colorEnabled = false)
     .join("\n");
 }
 
+export function renderModelChoices(models, selected) {
+  return models
+    .map((model, index) => {
+      const position = index + 1;
+      const mark = selected.has(position) ? "[x]" : "[ ]";
+      return `  ${mark} ${position}. ${model.displayName}`;
+    })
+    .join("\n");
+}
+
 export function toggleSelection(selected, input, count, { allowEmpty = false } = {}) {
   const trimmed = String(input || "").trim().toLowerCase();
   if (trimmed === "") {

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
+import { ensureNodeDependencies } from "./node-dependency-install.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT, TARGET } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
@@ -291,6 +292,7 @@ function configureProvider(provider) {
     if (!confirm(`Enter ${prompt} securely now?`)) {
       throw incomplete(`${provider.displayName} setup was cancelled.`);
     }
+    ensureNodeDependencies();
     run(process.execPath, [path.join(SOURCE_ROOT, "src", "provider-key.mjs"), provider.id, "set"]);
   }
 }

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -5,8 +5,9 @@ import path from "node:path";
 
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
-import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
+import { LISTED_MODELS, PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import { ensureNodeDependencies } from "./node-dependency-install.mjs";
+import { modelPickerSnapshot, setModelSelection } from "./model-picker-state.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT, TARGET } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
@@ -16,8 +17,14 @@ import {
   oauthLoginArgs,
   providerOnboardingSnapshot,
 } from "./provider-onboarding.mjs";
-import { renderProviderChoices, stepHeader, toggleSelection } from "./setup-ui.mjs";
 import {
+  renderModelChoices,
+  renderProviderChoices,
+  stepHeader,
+  toggleSelection,
+} from "./setup-ui.mjs";
+import {
+  canonicalProviderId,
   defaultProviderIds,
   selectedConfiguredListedModels,
   validateProviderIds,
@@ -246,6 +253,44 @@ function requestedSelection() {
   return guided ? guidedSelection() : defaultProviderIds();
 }
 
+function guidedModelSelection(providers) {
+  const selectedProviders = new Set(providers);
+  const models = LISTED_MODELS.filter((model) =>
+    selectedProviders.has(canonicalProviderId(model.provider))
+  );
+  if (models.length === 0) {
+    process.stdout.write("\nThe selected providers have no preselected models.\n");
+    return { models, selectedSlugs: [] };
+  }
+
+  const hidden = new Set(modelPickerSnapshot().hidden);
+  let selected = new Set(
+    models
+      .map((model, index) => hidden.has(model.slug) ? undefined : index + 1)
+      .filter(Boolean),
+  );
+  process.stdout.write("\nChoose models from the selected providers:\n");
+  for (;;) {
+    process.stdout.write(`${renderModelChoices(models, selected)}\n`);
+    const raw = promptLine(
+      "Toggle model numbers (comma-separated), a=all, n=none; Enter to continue",
+    );
+    const result = toggleSelection(selected, raw, models.length, { allowEmpty: true });
+    selected = result.selected;
+    if (result.error) {
+      process.stdout.write(`${result.error}\n`);
+    } else if (result.done) {
+      break;
+    }
+  }
+  return {
+    models,
+    selectedSlugs: [...selected]
+      .sort((a, b) => a - b)
+      .map((position) => models[position - 1].slug),
+  };
+}
+
 function run(command, commandArgs, options = {}) {
   const result = spawnSync(command, commandArgs, {
     cwd: SOURCE_ROOT,
@@ -363,7 +408,9 @@ async function main() {
       `An unknown model router owns ${legacy.config.modelCatalogJson}; automatic setup will not replace it.`,
     );
   }
-  const stepTitles = ["Choose providers", "Connect credentials"];
+  const stepTitles = ["Choose providers"];
+  if (guided) stepTitles.push("Choose models");
+  stepTitles.push("Connect credentials");
   if (legacy.installations.length) stepTitles.push("Migrate older router");
   stepTitles.push("Review and install");
   let stepIndex = 0;
@@ -388,6 +435,13 @@ async function main() {
       "No configured provider was found. Run `./bin/setup --guided` or pass `--providers` after configuring credentials.",
     );
   }
+  let modelChoices = [];
+  let selectedModelSlugs = [];
+  if (guided) {
+    nextStep("Choose models");
+    ({ models: modelChoices, selectedSlugs: selectedModelSlugs } =
+      guidedModelSelection(providers));
+  }
   nextStep("Connect credentials");
   // Credentials are addable after the install, and the router already reports
   // an unconfigured provider clearly at request time. A declined prompt -- or
@@ -408,6 +462,9 @@ async function main() {
     }
   }
   writeProviderSelection(providers);
+  if (guided) {
+    setModelSelection(modelChoices.map((model) => model.slug), selectedModelSlugs);
+  }
   // Written on every run, not only idle ones: re-running setup without
   // --no-discovery is the exit path from idle mode, so a normal install must
   // clear the marker just as an idle install sets it.
@@ -445,7 +502,9 @@ async function main() {
   }
 
   if (selectionOnly) {
-    process.stdout.write(`${JSON.stringify({ providers, migration }, null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify({ providers, ...(guided ? { models: selectedModelSlugs } : {}), migration }, null, 2)}\n`,
+    );
     return;
   }
 
@@ -458,6 +517,7 @@ async function main() {
     process.stdout.write(
       `\nReady to install:\n` +
         `  Providers: ${providers.length ? providers.join(", ") : "none (idle install)"}\n` +
+        `  Models: ${selectedModelSlugs.length ? selectedModelSlugs.join(", ") : "none"}\n` +
         `  Migration: ${migration ? "recognized older router (rollback snapshot kept)" : "none needed"}\n` +
         (dshTarget
           ? `  Changes: per-user background service and one provider route in the harness settings document\n`

--- a/test/model-picker-state.test.mjs
+++ b/test/model-picker-state.test.mjs
@@ -13,6 +13,7 @@ const {
   readHiddenModels,
   setAllModelsVisible,
   setModelVisible,
+  setModelSelection,
   setModelsVisible,
 } = await import("../src/model-picker-state.mjs");
 
@@ -56,6 +57,32 @@ test("provider-sized picker changes preserve other providers", () => {
   assert.deepEqual(modelPickerSnapshot().hidden, ["kimi-oauth/k3"]);
   assert.ok(modelPickerSnapshot().visible.includes("commandcode/kimi-k3"));
   assert.ok(modelPickerSnapshot().visible.includes("commandcode-messages/claude-opus-4.8"));
+});
+
+test("an explicit model selection changes only the supplied provider models", () => {
+  writeFileSync(
+    MODEL_PICKER_STATE_PATH,
+    `${JSON.stringify({
+      version: 1,
+      hidden: ["deepseek/deepseek-v4-pro", "kimi-oauth/k3"],
+      visible: ["deepseek/deepseek-v4-flash"],
+      seeded: [
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-pro",
+        "kimi-oauth/k3",
+      ],
+    })}\n`,
+    { mode: 0o600 },
+  );
+
+  setModelSelection(
+    ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"],
+    ["deepseek/deepseek-v4-pro"],
+  );
+
+  const picker = modelPickerSnapshot();
+  assert.deepEqual(picker.hidden, ["deepseek/deepseek-v4-flash", "kimi-oauth/k3"]);
+  assert.deepEqual(picker.visible, ["deepseek/deepseek-v4-pro"]);
 });
 
 test("legacy hidden-only state becomes an allowlist when a picker decision is made", () => {

--- a/test/setup-node-deps.test.mjs
+++ b/test/setup-node-deps.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "..");
+const PYTHON_AVAILABLE =
+  spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+const GUIDED_SETUP_HELPER = String.raw`
+import errno
+import os
+import select
+import sys
+import termios
+import time
+
+node, setup, checkout, home, state_dir, secret, confirmation = sys.argv[1:]
+env = os.environ.copy()
+env.update({
+    "HOME": home,
+    "CODEX_HOME": home,
+    "CODEX_ROUTER_STATE_DIR": state_dir,
+    "MODEL_ROUTER_STATE_DIR": state_dir,
+    "MODEL_ROUTER_TARGET": "codex",
+    "DEEPSEEK_API_KEY": "",
+})
+pid, master = os.forkpty()
+if pid == 0:
+    os.chdir(checkout)
+    os.execve(node, [node, setup, "--guided", "--providers", "deepseek", "--selection-only"], env)
+
+output = bytearray()
+confirmed = False
+key_sent = False
+while True:
+    ready, _, _ = select.select([master], [], [], 15)
+    if not ready:
+        os.kill(pid, 9)
+        raise SystemExit("timed out waiting for guided setup")
+    try:
+        chunk = os.read(master, 4096)
+    except OSError as error:
+        if error.errno == errno.EIO:
+            break
+        raise
+    if not chunk:
+        break
+    output.extend(chunk)
+    if not confirmed and b"Enter DeepSeek API key securely now?" in output:
+        os.write(master, confirmation.encode() + b"\n")
+        confirmed = True
+    if confirmation.lower() == "y" and not key_sent and b"DeepSeek API key: " in output:
+        deadline = time.monotonic() + 2
+        while termios.tcgetattr(master)[3] & termios.ECHO:
+            if time.monotonic() >= deadline:
+                os.kill(pid, 9)
+                raise SystemExit("provider-key did not disable terminal echo")
+            time.sleep(0.01)
+        os.write(master, secret.encode() + b"\n")
+        key_sent = True
+
+_, status = os.waitpid(pid, 0)
+os.close(master)
+sys.stdout.buffer.write(output)
+raise SystemExit(os.waitstatus_to_exitcode(status))
+`;
+
+function withFreshGuidedSetup(confirmation, verify) {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-guided-deps-"));
+  const checkout = path.join(testRoot, "checkout");
+  const fakeBin = path.join(testRoot, "bin");
+  const stateDir = path.join(testRoot, "state");
+  const npmLog = path.join(testRoot, "npm.log");
+  const secret = "TEST_DEEPSEEK_GUIDED_KEY";
+
+  try {
+    mkdirSync(checkout, { recursive: true });
+    cpSync(path.join(root, "src"), path.join(checkout, "src"), { recursive: true });
+    cpSync(path.join(root, "config"), path.join(checkout, "config"), { recursive: true });
+    copyFileSync(path.join(root, "package.json"), path.join(checkout, "package.json"));
+    copyFileSync(path.join(root, "package-lock.json"), path.join(checkout, "package-lock.json"));
+
+    mkdirSync(fakeBin, { recursive: true });
+    writeFileSync(
+      path.join(fakeBin, "npm"),
+      `#!/bin/sh
+printf '%s\\n' "$*" >"$CODEX_ROUTER_NPM_LOG"
+cp -R "$CODEX_ROUTER_TEST_NODE_MODULES" node_modules
+`,
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      "python3",
+      [
+        "-c",
+        GUIDED_SETUP_HELPER,
+        process.execPath,
+        path.join(checkout, "src", "setup.mjs"),
+        checkout,
+        testRoot,
+        stateDir,
+        secret,
+        confirmation,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH || "/usr/local/bin:/usr/bin:/bin"}`,
+          CODEX_ROUTER_NPM_LOG: npmLog,
+          CODEX_ROUTER_TEST_NODE_MODULES: path.join(root, "node_modules"),
+        },
+        timeout: 25_000,
+      },
+    );
+
+    verify({ checkout, npmLog, result, secret, stateDir });
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+}
+
+test(
+  "fresh guided setup installs Node dependencies before storing a provider key",
+  { skip: process.platform === "win32" || !PYTHON_AVAILABLE },
+  () => {
+    withFreshGuidedSetup("Y", ({ checkout, npmLog, result, secret, stateDir }) => {
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.doesNotMatch(result.stdout, /ERR_MODULE_NOT_FOUND/);
+      assert.equal(readFileSync(npmLog, "utf8"), "ci --omit=dev\n");
+      assert.equal(
+        readFileSync(path.join(stateDir, "deepseek-api-key.secret"), "utf8"),
+        `${secret}\n`,
+      );
+      assert.equal(existsSync(path.join(checkout, "node_modules", ".package-lock.json")), true);
+    });
+  },
+);
+
+test(
+  "fresh guided setup does not install Node dependencies when key setup is declined",
+  { skip: process.platform === "win32" || !PYTHON_AVAILABLE },
+  () => {
+    withFreshGuidedSetup("n", ({ checkout, npmLog, result, stateDir }) => {
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /DeepSeek API setup was cancelled/);
+      assert.equal(existsSync(npmLog), false);
+      assert.equal(existsSync(path.join(checkout, "node_modules")), false);
+      assert.equal(existsSync(path.join(stateDir, "deepseek-api-key.secret")), false);
+    });
+  },
+);

--- a/test/setup-node-deps.test.mjs
+++ b/test/setup-node-deps.test.mjs
@@ -42,6 +42,8 @@ if pid == 0:
     os.execve(node, [node, setup, "--guided", "--providers", "deepseek", "--selection-only"], env)
 
 output = bytearray()
+model_toggled = False
+models_confirmed = False
 confirmed = False
 key_sent = False
 while True:
@@ -58,6 +60,13 @@ while True:
     if not chunk:
         break
     output.extend(chunk)
+    model_prompts = output.count(b"Toggle model numbers")
+    if not model_toggled and model_prompts >= 1:
+        os.write(master, b"2\n")
+        model_toggled = True
+    elif model_toggled and not models_confirmed and model_prompts >= 2:
+        os.write(master, b"\n")
+        models_confirmed = True
     if not confirmed and b"Enter DeepSeek API key securely now?" in output:
         os.write(master, confirmation.encode() + b"\n")
         confirmed = True
@@ -145,6 +154,16 @@ test(
         readFileSync(path.join(stateDir, "deepseek-api-key.secret"), "utf8"),
         `${secret}\n`,
       );
+      const picker = JSON.parse(
+        readFileSync(path.join(stateDir, "model-picker.json"), "utf8"),
+      );
+      assert.deepEqual(picker.visible, [
+        "deepseek/deepseek-v4-flash",
+      ]);
+      assert.deepEqual(picker.hidden, ["deepseek/deepseek-v4-pro"]);
+      assert.match(result.stdout, /DeepSeek V4 Flash \(API\)/);
+      assert.match(result.stdout, /DeepSeek V4 Pro \(API\)/);
+      assert.doesNotMatch(result.stdout, /Kimi K3/);
       assert.equal(existsSync(path.join(checkout, "node_modules", ".package-lock.json")), true);
     });
   },

--- a/test/setup-node-deps.test.mjs
+++ b/test/setup-node-deps.test.mjs
@@ -21,6 +21,7 @@ const PYTHON_AVAILABLE =
 const GUIDED_SETUP_HELPER = String.raw`
 import errno
 import os
+import re
 import select
 import sys
 import termios
@@ -42,7 +43,8 @@ if pid == 0:
     os.execve(node, [node, setup, "--guided", "--providers", "deepseek", "--selection-only"], env)
 
 output = bytearray()
-model_toggled = False
+models_cleared = False
+flash_selected = False
 models_confirmed = False
 confirmed = False
 key_sent = False
@@ -61,10 +63,17 @@ while True:
         break
     output.extend(chunk)
     model_prompts = output.count(b"Toggle model numbers")
-    if not model_toggled and model_prompts >= 1:
-        os.write(master, b"2\n")
-        model_toggled = True
-    elif model_toggled and not models_confirmed and model_prompts >= 2:
+    flash = re.search(br"\[x\]\s+(\d+)\. DeepSeek V4 Flash \(API\)", output)
+    if not models_cleared and model_prompts >= 1:
+        os.write(master, b"n\n")
+        models_cleared = True
+    elif models_cleared and not flash_selected and model_prompts >= 2:
+        if flash is None:
+            os.kill(pid, 9)
+            raise SystemExit("DeepSeek V4 Flash was not listed")
+        os.write(master, flash.group(1) + b"\n")
+        flash_selected = True
+    elif flash_selected and not models_confirmed and model_prompts >= 3:
         os.write(master, b"\n")
         models_confirmed = True
     if not confirmed and b"Enter DeepSeek API key securely now?" in output:
@@ -160,7 +169,7 @@ test(
       assert.deepEqual(picker.visible, [
         "deepseek/deepseek-v4-flash",
       ]);
-      assert.deepEqual(picker.hidden, ["deepseek/deepseek-v4-pro"]);
+      assert.ok(picker.hidden.includes("deepseek/deepseek-v4-pro"));
       assert.match(result.stdout, /DeepSeek V4 Flash \(API\)/);
       assert.match(result.stdout, /DeepSeek V4 Pro \(API\)/);
       assert.doesNotMatch(result.stdout, /Kimi K3/);


### PR DESCRIPTION
## Why

Guided setup currently lets users select providers, but not individual models.

The project requires models to be explicitly selected before they appear in the Codex model picker. As a result, setup can finish successfully and save the API key, while the new models remain hidden.

## What

- Add a model selection step after provider selection.
- Show only models from the selected providers.
- Publish only the models selected by the user.
- Preserve model visibility settings for other providers.
- Show the selected models on the installation review screen.

For example, selecting DeepSeek lists the available DeepSeek models for the user to choose from.

## Test

- Verified that selecting DeepSeek only lists DeepSeek models.
- Verified that selecting only Flash shows Flash and hides Pro.
- Verified that changing DeepSeek models does not affect other providers.
- Relevant tests: 123 passed, 1 skipped.
- `npm run check` passed.