### PR TITLE
feat(opencode): support Zen Free Muse and Ox safely

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ user.
    interactive terminal to choose models. If they did not specify and
    credentials already exist, use
    `configured` rather than showing providers that cannot authenticate.
-   The anonymous providers `opencode-free` and `kilo-free` are also selectable,
+   The anonymous providers `opencode-free` and `kilo-free` are also selectable
+   (`opencode-free-responses` is an internal, single-model protocol variant of
+   the former and is never selected or curated separately),
    but they need no credential only for their documented free model subsets.
    Both are catalog-only: they ship no preselected models and need
    `bin/curate-models PROVIDER` after selection. `custom` is selectable on the

--- a/README.md
+++ b/README.md
@@ -399,7 +399,13 @@ in code to its official endpoint.
 
 Both are catalog-only and deliberately ship no checked-in model metadata: the
 provider's live `/models` response is filtered to the free subset and then added
-locally with `./bin/curate-models`.
+locally with `./bin/curate-models`. OpenCode Free curation routes
+`muse-spark-1.2-contributor-free` through its internal Responses sibling while
+keeping Ox Alpha Free (`x-preview-f-free`) and the other free IDs on Chat
+Completions; the provider remains one selection in setup and the picker. An
+existing Chat-routed copy of that one Muse model is migrated only when the
+operator explicitly runs `curate-models`; install, update, and catalog reads do
+not rewrite the user model or picker state.
 
 ```sh
 ./bin/model-router codex providers enable opencode-free

--- a/config/opencode-free/opencode-free.json
+++ b/config/opencode-free/opencode-free.json
@@ -10,6 +10,21 @@
       "authMode": "anonymous",
       "anonymousModelPolicy": "opencode-console",
       "anonymousNote": "No API key is needed for OpenCode Zen free models. Use at your own risk: access is a published exception, not an entitlement, and the free catalog and limits can change without notice."
+    },
+    {
+      "id": "opencode-free-responses",
+      "displayName": "OpenCode Free Responses",
+      "kind": "openai-compatible",
+      "ownedBy": "opencode",
+      "variantOf": "opencode-free",
+      "protocol": "openai-responses",
+      "baseUrl": "https://opencode.ai/zen/v1",
+      "authMode": "anonymous",
+      "anonymousModelPolicy": "explicit-models",
+      "anonymousModels": [
+        "muse-spark-1.2-contributor-free"
+      ],
+      "anonymousNote": "No API key is needed for Muse Spark 1.2 Contributor Free. This internal Responses route accepts only that documented free model. Use at your own risk: access is a published exception, not an entitlement, and limits can change without notice."
     }
   ]
 }

--- a/docs/research/opencode-catalog-2026-08-21.md
+++ b/docs/research/opencode-catalog-2026-08-21.md
@@ -26,6 +26,21 @@ without notice. Both catalogs are fetched by `discover-models` / `curate-models`
 from their official `/models` endpoints; the repository does not turn their
 live contents into an implicit provider selection.
 
+The anonymous endpoint table is model-specific:
+`muse-spark-1.2-contributor-free` uses `/responses`, while Ox Alpha Free
+(`x-preview-f-free`) uses `/chat/completions`. Local OpenCode Free curation
+therefore stores only that exact Muse Contributor Free ID on an internal
+Responses variant and leaves Ox and every other free ID on the existing Chat
+Completions route. The variant accepts no other anonymous model ID and shares
+the base provider's selection.
+
+The paid `/zen` catalog and the subscription `/zen/go` catalog are separate
+server surfaces with separate billing semantics. This change deliberately does
+not add a paid Zen variant or alter the existing Go/Zen selection, routes,
+gateway model IDs, or cooldown scopes. Migration of an older Chat-routed free
+Muse entry occurs only inside an explicit `curate-models opencode-free` run;
+install, update, registry load, and catalog discovery remain read-only.
+
 The Go documentation names 20 current subscription models. The checked-in
 registry contains those exact upstream IDs and uses the endpoint family the
 official table specifies (`chat/completions`, `messages`, or `responses`). The

--- a/docs/research/opencode-catalog-2026-08-21.md
+++ b/docs/research/opencode-catalog-2026-08-21.md
@@ -6,6 +6,7 @@ Primary sources:
 - Go live catalog: https://opencode.ai/zen/go/v1/models
 - Zen documentation, endpoint table, free pricing, and deprecations: https://opencode.ai/docs/zen
 - Zen live catalog: https://opencode.ai/zen/v1/models
+- OpenCode Zen model metadata (`opencode` provider): https://models.dev/api.json
 
 The anonymous `opencode-free` provider remains catalog-only. Its live Zen
 catalog currently exposes these nine IDs through the router's documented
@@ -26,6 +27,12 @@ without notice. Both catalogs are fetched by `discover-models` / `curate-models`
 from their official `/models` endpoints; the repository does not turn their
 live contents into an implicit provider selection.
 
+The Zen `/models` records currently contain ids but no context limits. The
+OpenCode Zen metadata record publishes `1,048,576` for Muse Contributor Free
+and `1,000,000` for Ox Alpha Free. Scripted curation uses those values only for
+the two exact ids instead of the generic 131K fallback; if Zen later publishes
+a served context limit in `/models`, that live value takes precedence.
+
 The anonymous endpoint table is model-specific:
 `muse-spark-1.2-contributor-free` uses `/responses`, while Ox Alpha Free
 (`x-preview-f-free`) uses `/chat/completions`. Local OpenCode Free curation
@@ -39,7 +46,9 @@ server surfaces with separate billing semantics. This change deliberately does
 not add a paid Zen variant or alter the existing Go/Zen selection, routes,
 gateway model IDs, or cooldown scopes. Migration of an older Chat-routed free
 Muse entry occurs only inside an explicit `curate-models opencode-free` run;
-install, update, registry load, and catalog discovery remain read-only.
+the same run upgrades the exact generic `131072` / `110000` sizing pair on
+these two ids while preserving any user-tuned value. Install, update, registry
+load, and catalog discovery remain read-only.
 
 The Go documentation names 20 current subscription models. The checked-in
 registry contains those exact upstream IDs and uses the endpoint family the

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -14,16 +14,26 @@ import {
   writeUserModels,
 } from "./user-models.mjs";
 import {
+  curationPrimaryProviderId,
+  curationProviderIds,
+  curatedModelProviderId,
+} from "./opencode-curation.mjs";
+import {
   applyModelOverlayPublication,
   transactModelOverlayMutation,
 } from "./model-overlay-publication.mjs";
-import { MODEL_PICKER_STATE_PATH, setModelsVisible } from "./model-picker-state.mjs";
+import {
+  migrateModelVisibility,
+  MODEL_PICKER_STATE_PATH,
+  setModelsVisible,
+} from "./model-picker-state.mjs";
 
 // Interactive curation: list the provider's live models that are not part of
 // the checked-in registry, let the user toggle the ones they want, and persist
 // them as user models. Discovery never edits the checked-in config/ registry tree.
 
-const providerId = process.argv[2];
+const requestedProviderId = process.argv[2];
+const providerId = curationPrimaryProviderId(requestedProviderId);
 const modelsOption = (() => {
   const index = process.argv.indexOf("--models");
   return index === -1 ? undefined : process.argv[index + 1];
@@ -139,19 +149,47 @@ export function planCuration({ mine, chosen, removals, interactive }) {
 // contain a newer user's edit that this run cannot safely reconcile.
 export function mergeCurationIntoCurrent(
   current,
-  { providerId, expectedMine, nextMine },
+  { providerId, providerIds = [providerId], expectedMine, nextMine },
 ) {
   const models = Array.isArray(current) ? current : [];
-  const currentMine = models.filter((model) => model.provider === providerId);
+  const owned = new Set(providerIds);
+  const currentMine = models.filter((model) => owned.has(model.provider));
   if (JSON.stringify(currentMine) !== JSON.stringify(expectedMine)) {
     throw new Error(
       `Curated ${providerId} models changed while this command was running; review them and retry.`,
     );
   }
   return [
-    ...models.filter((model) => model.provider !== providerId),
+    ...models.filter((model) => !owned.has(model.provider)),
     ...nextMine,
   ];
+}
+
+// Normalize every entry in one local curation set onto the protocol OpenCode
+// documents for that upstream id. Existing metadata is left byte-for-byte
+// alone; only the provider-derived routing identity moves. Prefer an already
+// correct entry if an older run left both protocol copies behind.
+export function normalizeCurationModels(models, providerId) {
+  const normalized = new Map();
+  for (const model of models) {
+    const targetProvider = curatedModelProviderId(providerId, model.upstreamModel);
+    const routed = model.provider === targetProvider
+      ? model
+      : {
+          ...model,
+          ...userModelIdentity({
+            providerId: targetProvider,
+            upstreamId: model.upstreamModel,
+            metadata: model,
+          }),
+          provider: targetProvider,
+        };
+    const existing = normalized.get(model.upstreamModel);
+    if (!existing || model.provider === targetProvider) {
+      normalized.set(model.upstreamModel, routed);
+    }
+  }
+  return [...normalized.values()];
 }
 
 export function parseEfforts(raw) {
@@ -174,7 +212,7 @@ export function parseEfforts(raw) {
   };
 }
 
-if (!providerId) usage();
+if (!requestedProviderId) usage();
 const provider = PROVIDERS.get(providerId);
 if (!provider) {
   console.error(`Unknown provider: ${providerId}`);
@@ -234,7 +272,10 @@ function chooseInteractively(candidates, curated) {
 async function main() {
   for (const warning of USER_MODEL_WARNINGS) console.error(warning);
   const existing = readUserModels();
-  const mine = existing.filter((model) => model.provider === providerId);
+  const familyProviderIds = curationProviderIds(providerId);
+  const familyProviders = new Set(familyProviderIds);
+  const storedMine = existing.filter((model) => familyProviders.has(model.provider));
+  const mine = normalizeCurationModels(storedMine, providerId);
   const curated = new Set(mine.map((model) => model.upstreamModel));
   if (modelsOption !== undefined && removeOption !== undefined) {
     throw new Error("Use --models to add models or --remove to prune them, not both.");
@@ -306,7 +347,7 @@ async function main() {
   }
 
   const inheritedProfile = MODELS.find(
-    (model) => model.provider === providerId && model.requestProfile,
+    (model) => familyProviders.has(model.provider) && model.requestProfile,
   )?.requestProfile;
 
   // Metadata comes from the user, not from any online catalog: which models
@@ -387,8 +428,9 @@ async function main() {
       // Ask for metadata before the profile so interactive prompts stay under
       // one model heading and in the order they are printed.
       const metadata = metadataFor(id);
+      const routedProviderId = curatedModelProviderId(providerId, id);
       return userModelEntry({
-        providerId,
+        providerId: routedProviderId,
         upstreamId: id,
         requestProfile: requestProfileFor(id),
         priority: 100 + mine.length + index,
@@ -416,6 +458,15 @@ async function main() {
   const pickerSelections = nextMine
     .filter((model) => chosen.includes(model.upstreamModel))
     .map((model) => model.slug);
+  const normalizedByUpstream = new Map(
+    nextMine.map((model) => [model.upstreamModel, model]),
+  );
+  const pickerMigrations = storedMine
+    .map((model) => ({
+      from: model.slug,
+      to: normalizedByUpstream.get(model.upstreamModel)?.slug,
+    }))
+    .filter(({ from, to }) => to && from !== to);
 
   const wantsApply =
     !noApply && (
@@ -434,9 +485,11 @@ async function main() {
       const current = readUserModels();
       target = writeUserModels(mergeCurationIntoCurrent(current, {
         providerId,
-        expectedMine: mine,
+        providerIds: familyProviderIds,
+        expectedMine: storedMine,
         nextMine,
       }));
+      if (pickerMigrations.length) migrateModelVisibility(pickerMigrations);
       if (pickerSelections.length) setModelsVisible(pickerSelections, true);
     },
     restart: wantsApply,

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -6,6 +6,7 @@ import { MODELS, PROVIDERS, USER_MODEL_WARNINGS } from "./model-registry.mjs";
 import { confirm, promptLine } from "./setup-shared.mjs";
 import { toggleSelection } from "./setup-ui.mjs";
 import {
+  DEFAULT_AUTO_COMPACT,
   DEFAULT_CONTEXT_WINDOW,
   USER_MODELS_PATH,
   readUserModels,
@@ -16,6 +17,7 @@ import {
 import {
   curationPrimaryProviderId,
   curationProviderIds,
+  curatedModelContextLength,
   curatedModelProviderId,
 } from "./opencode-curation.mjs";
 import {
@@ -166,9 +168,10 @@ export function mergeCurationIntoCurrent(
 }
 
 // Normalize every entry in one local curation set onto the protocol OpenCode
-// documents for that upstream id. Existing metadata is left byte-for-byte
-// alone; only the provider-derived routing identity moves. Prefer an already
-// correct entry if an older run left both protocol copies behind.
+// documents for that upstream id. Existing metadata stays byte-for-byte alone
+// except for the untouched generic sizing pair on an exact documented model;
+// that pair is evidence curation had no model-specific answer, not a user tune.
+// Prefer an already correct entry if an older run left both protocol copies.
 export function normalizeCurationModels(models, providerId) {
   const normalized = new Map();
   for (const model of models) {
@@ -184,9 +187,18 @@ export function normalizeCurationModels(models, providerId) {
           }),
           provider: targetProvider,
         };
+    const documented = curatedSizing(
+      curatedModelContextLength(providerId, model.upstreamModel),
+    );
+    const sized =
+      documented &&
+      routed.contextWindow === DEFAULT_CONTEXT_WINDOW &&
+      routed.autoCompact === DEFAULT_AUTO_COMPACT
+        ? { ...routed, ...documented }
+        : routed;
     const existing = normalized.get(model.upstreamModel);
     if (!existing || model.provider === targetProvider) {
-      normalized.set(model.upstreamModel, routed);
+      normalized.set(model.upstreamModel, sized);
     }
   }
   return [...normalized.values()];
@@ -350,10 +362,10 @@ async function main() {
     (model) => familyProviders.has(model.provider) && model.requestProfile,
   )?.requestProfile;
 
-  // Metadata comes from the user, not from any online catalog: which models
-  // exist is decided by the provider's own /v1/models endpoint above, and the
-  // sizing/effort details are asked interactively (or default conservatively
-  // in --models mode). Existing curated entries are never touched.
+  // Which models exist is decided by the provider's own /v1/models endpoint.
+  // Metadata comes from that catalog, the interactive user, or the narrow
+  // documented OpenCode exceptions whose catalog records omit their size.
+  // Existing curated entries are never touched.
   const interactive = interactiveSelection && Boolean(process.stdin.isTTY);
 
   const metadataFor = (id) => {
@@ -361,16 +373,20 @@ async function main() {
       ...(flagEfforts || {}),
       ...(discovery.free?.includes(id) ? { isFree: true } : {}),
     };
-    // The provider already published this model's size; asking the user to
-    // retype it, or defaulting past it, is how a million-token model ends up
-    // stored as a 131K one. A catalog that said nothing still falls back.
+    // The served catalog value wins when present. OpenCode's exact documented
+    // free-model size is the fallback for its id-only Zen catalog; every other
+    // silent catalog still gets the conservative generic default.
     const advertised = curatedSizing(discovery.contextLengths?.[id]);
-    if (advertised) Object.assign(metadata, advertised);
+    const documented = curatedSizing(curatedModelContextLength(providerId, id));
+    const sizing = advertised || documented;
+    if (sizing) Object.assign(metadata, sizing);
     if (!interactive) return Object.keys(metadata).length > 0 ? metadata : undefined;
     process.stdout.write(`\nMetadata for ${id} (Enter keeps the default):\n`);
-    const suggested = advertised?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+    const suggested = sizing?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
     const rawContext = promptLine(
-      `  Context window in tokens [${suggested}${advertised ? ", advertised" : ""}]`,
+      `  Context window in tokens [${suggested}${
+        advertised ? ", advertised" : documented ? ", documented" : ""
+      }]`,
     ).trim();
     if (rawContext) {
       const context = Number.parseInt(rawContext, 10);

--- a/src/model-discovery.mjs
+++ b/src/model-discovery.mjs
@@ -12,6 +12,7 @@ import {
   PROVIDERS,
   resolveProviderBaseUrl,
 } from "./model-registry.mjs";
+import { curationProviderIds } from "./opencode-curation.mjs";
 import { credentialStatus, resolveProviderCredential } from "./provider-credentials.mjs";
 import {
   ensureFreshGitHubCopilotSession,
@@ -214,8 +215,9 @@ export async function discoverProviderModels(providerId, { refresh = false, cach
     fetchedAt = new Date().toISOString();
     if (storeAnswer) writeProviderCatalogCache(providerId, { discovered, free, contextLengths, fetchedAt });
   }
+  const curationProviders = new Set(curationProviderIds(providerId));
   const registered = MODELS
-    .filter((model) => model.provider === providerId)
+    .filter((model) => curationProviders.has(model.provider))
     .map((model) => model.upstreamModel)
     .sort();
   const discoveredSet = new Set(discovered);

--- a/src/model-picker-state.mjs
+++ b/src/model-picker-state.mjs
@@ -131,6 +131,50 @@ export function setModelsVisible(slugs, visible) {
   return writePickerState({ hidden, visible: visibleSet, seeded });
 }
 
+// Move an operator's picker decision when a curated model's routing identity
+// changes. Protocol migrations change the slug even though the upstream model
+// is the same; dropping the old decision would make an explicitly selected
+// model disappear from the allowlisted picker on the next catalog rebuild.
+// A decision already recorded on the destination wins over stale source state.
+export function migrateModelVisibility(replacements) {
+  const pairs = (Array.isArray(replacements) ? replacements : [])
+    .map(({ from, to }) => ({
+      from: String(from || "").trim(),
+      to: String(to || "").trim(),
+    }))
+    .filter(({ from, to }) => from && to && from !== to);
+  if (pairs.length === 0) return modelPickerSnapshot();
+
+  const { hidden, visible, seeded, hasExplicitVisibility } = readPickerState();
+  let changed = false;
+  for (const { from, to } of pairs) {
+    const sourceHidden = hidden.has(from);
+    const sourceVisible = visible.has(from);
+    const sourceSeeded = seeded.has(from);
+    if (!sourceHidden && !sourceVisible && !sourceSeeded) continue;
+
+    const destinationDecided = seeded.has(to);
+    hidden.delete(from);
+    visible.delete(from);
+    seeded.delete(from);
+    changed = true;
+
+    if (!destinationDecided) {
+      if (sourceHidden) {
+        hidden.add(to);
+        visible.delete(to);
+      } else if (sourceVisible) {
+        hidden.delete(to);
+        visible.add(to);
+      }
+    }
+    if (sourceSeeded) seeded.add(to);
+  }
+  return changed
+    ? writePickerState({ hidden, visible, seeded, hasExplicitVisibility })
+    : modelPickerSnapshot();
+}
+
 export function setAllModelsVisible(slugs, visible) {
   const known = [...new Set(slugs.map((slug) => String(slug).trim()).filter(Boolean))];
   const { hidden: currentHidden, visible: currentVisible, seeded } = readPickerState();

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -20,6 +20,7 @@ function fail(message) {
 // credential-free exfiltration path.
 const ANONYMOUS_ENDPOINTS = Object.freeze({
   "opencode-free": "https://opencode.ai/zen/v1",
+  "opencode-free-responses": "https://opencode.ai/zen/v1",
   "kilo-free": "https://api.kilo.ai/api/gateway",
 });
 
@@ -41,6 +42,9 @@ export function anonymousModelAllowed(provider, modelId) {
     return id === "big-pickle" || id.endsWith("-free");
   }
   if (provider.anonymousModelPolicy === "suffix-free") return id.endsWith(":free");
+  if (provider.anonymousModelPolicy === "explicit-models") {
+    return Array.isArray(provider.anonymousModels) && provider.anonymousModels.includes(id);
+  }
   return false;
 }
 
@@ -260,15 +264,36 @@ function loadRegistry() {
         if (provider.keyless || provider.credential !== undefined) {
           fail(`anonymous provider ${provider.id} must not declare keyless or credential metadata`);
         }
-        if (
-          !["opencode-console", "suffix-free"].includes(provider.anonymousModelPolicy)
-        ) {
+        if (![
+          "explicit-models",
+          "opencode-console",
+          "suffix-free",
+        ].includes(provider.anonymousModelPolicy)) {
           fail(`anonymous provider ${provider.id} requires a supported anonymousModelPolicy`);
+        }
+        if (provider.anonymousModelPolicy === "explicit-models") {
+          const models = provider.anonymousModels;
+          if (
+            !Array.isArray(models) ||
+            models.length === 0 ||
+            models.some((model) =>
+              typeof model !== "string" || !model.trim() || model !== model.trim()
+            ) ||
+            new Set(models).size !== models.length
+          ) {
+            fail(`anonymous provider ${provider.id} requires a valid anonymousModels allowlist`);
+          }
+        } else if (provider.anonymousModels !== undefined) {
+          fail(`anonymous provider ${provider.id} may declare anonymousModels only with explicit-models policy`);
         }
         if (typeof provider.anonymousNote !== "string" || !provider.anonymousNote.trim()) {
           fail(`anonymous provider ${provider.id} requires an anonymousNote`);
         }
-      } else if (provider.anonymousModelPolicy !== undefined || provider.anonymousNote !== undefined) {
+      } else if (
+        provider.anonymousModelPolicy !== undefined ||
+        provider.anonymousModels !== undefined ||
+        provider.anonymousNote !== undefined
+      ) {
         fail(`provider ${provider.id} has anonymous metadata without authMode anonymous`);
       }
       if (

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -3,7 +3,7 @@ import { StringDecoder } from "node:string_decoder";
 
 import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 import { coerceFunctionCallArguments } from "./tool-arguments.mjs";
-import { providerToolSchema } from "./tool-schema-root.mjs";
+import { nonRecursiveToolSchema, providerToolSchema } from "./tool-schema-root.mjs";
 import {
   buildInterruptAgentCall,
   filterAlreadyInterrupted,
@@ -43,8 +43,10 @@ export const NAMESPACE_DELIMITER = "__";
 // letting the response path validate model-generated overrides.
 const SPAWN_AGENT_MODELS = new WeakMap();
 const TOOL_SEARCH_RELAYS = new WeakMap();
+const CUSTOM_TOOL_RELAYS = new WeakMap();
 
 const TOOL_SEARCH_FUNCTION_NAME = "tool_search";
+const CUSTOM_TOOL_INPUT_PROPERTY = "input";
 
 function providerFunctionName(tool) {
   return tool?.name ?? tool?.function?.name;
@@ -55,6 +57,7 @@ function providerVisibleToolNames(tools) {
   if (!Array.isArray(tools)) return names;
   for (const tool of tools) {
     if (tool?.type === "namespace" && Array.isArray(tool.tools)) {
+      if (typeof tool.name === "string" && tool.name) names.add(tool.name);
       for (const fn of tool.tools) {
         if (fn?.name) names.add(`${tool.name}${NAMESPACE_DELIMITER}${fn.name}`);
       }
@@ -64,6 +67,137 @@ function providerVisibleToolNames(tools) {
     if (typeof name === "string" && name) names.add(name);
   }
   return names;
+}
+
+function availableCustomToolName(nativeName, visibleNames) {
+  if (!visibleNames.has(nativeName)) return nativeName;
+  const stem = `codex_custom_${nativeName}`;
+  if (!visibleNames.has(stem)) return stem;
+  let suffix = 1;
+  while (visibleNames.has(`${stem}_${suffix}`)) suffix += 1;
+  return `${stem}_${suffix}`;
+}
+
+// OpenCode accepts ordinary JSON-schema function tools but rejects OpenAI's
+// freeform `type: "custom"` definition. Codex exposes apply_patch only in that
+// native form. Present the same raw-patch contract as one required string
+// property, translate matching history and a forced native custom choice, and
+// retain a request-local reverse map so the response path can restore the exact
+// custom-tool shape Codex executes. An unrelated function or native namespace
+// with the same name receives a collision-safe alias and is otherwise untouched.
+export function bridgeCustomTools(
+  tools,
+  input,
+  namespaces,
+  toolChoice,
+  names = ["apply_patch"],
+) {
+  if (!(namespaces instanceof Map)) {
+    return { tools, input, toolChoice, bridged: false };
+  }
+  const requested = new Set(names);
+  const nativeNames = [];
+  const remember = (name) => {
+    if (requested.has(name) && !nativeNames.includes(name)) nativeNames.push(name);
+  };
+  if (Array.isArray(tools)) {
+    for (const tool of tools) if (tool?.type === "custom") remember(tool.name);
+  }
+  if (Array.isArray(input)) {
+    for (const item of input) if (item?.type === "custom_tool_call") remember(item.name);
+  }
+  if (toolChoice?.type === "custom") remember(toolChoice.name);
+  if (!nativeNames.length) return { tools, input, toolChoice, bridged: false };
+
+  const ordinaryTools = Array.isArray(tools)
+    ? tools.filter((tool) => !(tool?.type === "custom" && requested.has(tool.name)))
+    : tools;
+  const visibleNames = providerVisibleToolNames(ordinaryTools);
+  const nativeToProvider = new Map();
+  const providerToNative = new Map();
+  for (const nativeName of nativeNames) {
+    const providerName = availableCustomToolName(nativeName, visibleNames);
+    visibleNames.add(providerName);
+    nativeToProvider.set(nativeName, providerName);
+    providerToNative.set(providerName, nativeName);
+  }
+  CUSTOM_TOOL_RELAYS.set(namespaces, providerToNative);
+
+  let changedTools = false;
+  const routedTools = Array.isArray(tools)
+    ? tools.map((tool) => {
+        const providerName =
+          tool?.type === "custom" ? nativeToProvider.get(tool.name) : undefined;
+        if (!providerName) return tool;
+        changedTools = true;
+        return {
+          type: "function",
+          name: providerName,
+          ...(typeof tool.description === "string" ? { description: tool.description } : {}),
+          parameters: {
+            type: "object",
+            properties: {
+              [CUSTOM_TOOL_INPUT_PROPERTY]: {
+                type: "string",
+                description: "The complete raw freeform input for this tool, preserved verbatim.",
+              },
+            },
+            required: [CUSTOM_TOOL_INPUT_PROPERTY],
+            additionalProperties: false,
+          },
+        };
+      })
+    : tools;
+
+  const providerChoiceName =
+    toolChoice?.type === "custom" ? nativeToProvider.get(toolChoice.name) : undefined;
+  const routedToolChoice = providerChoiceName
+    ? { ...toolChoice, type: "function", name: providerChoiceName }
+    : toolChoice;
+  const changedToolChoice = routedToolChoice !== toolChoice;
+
+  if (!Array.isArray(input)) {
+    return {
+      tools: routedTools,
+      input,
+      toolChoice: routedToolChoice,
+      bridged: changedTools || changedToolChoice,
+    };
+  }
+  const bridgedCallIds = new Set();
+  let changedInput = false;
+  const routedInput = input.map((item) => {
+    const providerName =
+      item?.type === "custom_tool_call" ? nativeToProvider.get(item.name) : undefined;
+    if (providerName && typeof item.input === "string") {
+      const { type: _type, input: customInput, name: _name, ...rest } = item;
+      if (typeof item.call_id === "string" && item.call_id) {
+        bridgedCallIds.add(item.call_id);
+      }
+      changedInput = true;
+      return {
+        ...rest,
+        type: "function_call",
+        name: providerName,
+        arguments: JSON.stringify({ [CUSTOM_TOOL_INPUT_PROPERTY]: customInput }),
+      };
+    }
+    if (
+      item?.type === "custom_tool_call_output" &&
+      typeof item.call_id === "string" &&
+      bridgedCallIds.has(item.call_id)
+    ) {
+      changedInput = true;
+      return { ...item, type: "function_call_output" };
+    }
+    return item;
+  });
+  return {
+    tools: routedTools,
+    input: changedInput ? routedInput : input,
+    toolChoice: routedToolChoice,
+    bridged: changedTools || changedInput || changedToolChoice,
+  };
 }
 
 function availableToolSearchName(tools) {
@@ -144,29 +278,121 @@ const MAX_JSON_CAPTURE_BYTES = 64 * 1024 * 1024;
 // tool arrived inside a namespace. `providerToolSchema` returns anything it
 // does not recognize by identity, so an ordinary root costs one call and no
 // copy.
-export function repairToolSchemaRoot(tool) {
-  const parameters = tool?.function?.parameters ?? tool?.parameters;
-  if (parameters === undefined) return tool;
-  const repaired = providerToolSchema(parameters);
-  if (repaired === parameters) return tool;
-  return tool.function
-    ? { ...tool, function: { ...tool.function, parameters: repaired } }
-    : { ...tool, parameters: repaired };
+export function repairToolSchemaRoot(tool, { nonRecursive = false } = {}) {
+  // Preserve the established shared-provider behavior byte-for-byte. Native
+  // namespace traversal and inputSchema rewriting belong only to the OpenCode
+  // compatibility pass below; other providers keep the original root repair.
+  if (!nonRecursive) {
+    const parameters = tool?.function?.parameters ?? tool?.parameters;
+    if (parameters === undefined) return tool;
+    const repaired = providerToolSchema(parameters);
+    if (repaired === parameters) return tool;
+    return tool.function
+      ? { ...tool, function: { ...tool.function, parameters: repaired } }
+      : { ...tool, parameters: repaired };
+  }
+
+  if (tool?.type === "namespace" && Array.isArray(tool.tools)) {
+    let changed = false;
+    const children = tool.tools.map((child) => {
+      const repaired = repairToolSchemaRoot(child, { nonRecursive });
+      if (repaired !== child) changed = true;
+      return repaired;
+    });
+    return changed ? { ...tool, tools: children } : tool;
+  }
+
+  let repairedTool = tool;
+  let changed = false;
+  const repair = (schema) => nonRecursiveToolSchema(providerToolSchema(schema));
+
+  if (tool?.function?.parameters !== undefined) {
+    const parameters = repair(tool.function.parameters);
+    if (parameters !== tool.function.parameters) {
+      repairedTool = {
+        ...repairedTool,
+        function: { ...repairedTool.function, parameters },
+      };
+      changed = true;
+    }
+  }
+  // Flattened namespace children deliberately carry both inputSchema (the
+  // client-native declaration) and parameters (the Chat Completions alias).
+  // Repair both: choosing inputSchema first would leave the provider-facing
+  // parameters recursive on Ox even though the Responses branch was fixed.
+  for (const field of ["parameters", "inputSchema"]) {
+    if (tool?.[field] === undefined) continue;
+    const schema = repair(tool[field]);
+    if (schema === tool[field]) continue;
+    repairedTool = { ...repairedTool, [field]: schema };
+    changed = true;
+  }
+  return changed ? repairedTool : tool;
 }
 
 // Array form for callers that relay tools without flattening them --
 // Responses-native providers keep the namespace shape but still need a root
 // their upstream accepts. Returns the original array when nothing needed
 // repair, so the common request is not copied.
-export function repairToolSchemaRoots(tools) {
+export function repairToolSchemaRoots(tools, options) {
   if (!Array.isArray(tools)) return tools;
   let changed = false;
   const repaired = tools.map((tool) => {
-    const next = repairToolSchemaRoot(tool);
+    const next = repairToolSchemaRoot(tool, options);
     if (next !== tool) changed = true;
     return next;
   });
   return changed ? repaired : tools;
+}
+
+// OpenCode currently accepts search_content_types only on the legacy
+// web_search_preview shape. Codex sends the field on web_search, so remove only
+// that unsupported extension and preserve every other search-tool option.
+export function stripSearchContentTypes(tools) {
+  if (!Array.isArray(tools)) return tools;
+  let changed = false;
+  const stripped = tools.map((tool) => {
+    if (tool?.type !== "web_search" || !("search_content_types" in tool)) return tool;
+    changed = true;
+    const { search_content_types: _unsupported, ...rest } = tool;
+    return rest;
+  });
+  return changed ? stripped : tools;
+}
+
+// agent_message is a Codex collaboration input item, not part of the public
+// Responses schema OpenCode implements. The readable handoff has already been
+// recovered before this boundary, so keep its content and present it as the
+// equivalent user message strict compatible endpoints accept.
+export function agentMessagesAsUserMessages(input) {
+  if (!Array.isArray(input)) return input;
+  let changed = false;
+  const converted = input.map((item) => {
+    if (item?.type !== "agent_message" || !Array.isArray(item.content)) return item;
+    changed = true;
+    return { type: "message", role: "user", content: item.content };
+  });
+  return changed ? converted : input;
+}
+
+// Codex can inherit an image with detail:"original" from the parent thread.
+// OpenCode rejects that OpenAI-only hint but accepts the same image as auto.
+// Preserve the image bytes and surrounding transcript; change only the hint.
+export function downgradeOriginalImageDetail(input) {
+  if (!Array.isArray(input)) return input;
+  let changed = false;
+  const converted = input.map((item) => {
+    if (!Array.isArray(item?.content)) return item;
+    let contentChanged = false;
+    const content = item.content.map((part) => {
+      if (part?.type !== "input_image" || part.detail !== "original") return part;
+      changed = true;
+      contentChanged = true;
+      return { ...part, detail: "auto" };
+    });
+    return contentChanged ? { ...item, content } : item;
+  });
+  return changed ? converted : input;
 }
 
 function flattenNamespaceChild(namespace, fn) {
@@ -518,6 +744,7 @@ export function buildNamespaceLookups(namespaces) {
     bareToNamespaces,
     spawnAgentModels: SPAWN_AGENT_MODELS.get(namespaces),
     toolSearch: TOOL_SEARCH_RELAYS.get(namespaces),
+    customTools: CUSTOM_TOOL_RELAYS.get(namespaces),
   };
 }
 
@@ -592,6 +819,47 @@ function rewriteToolSearchFunctionCallItem(item, lookups, allowPlaceholder) {
   };
 }
 
+function customToolInput(value, allowPlaceholder = false) {
+  if (allowPlaceholder && (value === undefined || value === "")) return "";
+  const argumentsText = coerceFunctionCallArguments(value);
+  if (typeof argumentsText !== "string") return undefined;
+  try {
+    const parsed = JSON.parse(argumentsText);
+    return typeof parsed?.[CUSTOM_TOOL_INPUT_PROPERTY] === "string"
+      ? parsed[CUSTOM_TOOL_INPUT_PROPERTY]
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function rewriteCustomToolFunctionCallItem(item, lookups, allowPlaceholder) {
+  if (
+    item?.type !== "function_call" ||
+    item.namespace !== undefined ||
+    !(lookups.customTools instanceof Map)
+  ) {
+    return undefined;
+  }
+  const nativeName = lookups.customTools.get(item.name);
+  if (!nativeName) return undefined;
+  const input = customToolInput(item.arguments, allowPlaceholder);
+  if (input === undefined) return undefined;
+  const {
+    type: _type,
+    name: _name,
+    arguments: _arguments,
+    encrypted_function_args: _encryptedFunctionArgs,
+    ...rest
+  } = item;
+  return {
+    ...rest,
+    type: "custom_tool_call",
+    name: nativeName,
+    ...(allowPlaceholder && input === "" ? {} : { input }),
+  };
+}
+
 function rewriteNamespaceFunctionCallItem(
   item,
   lookups,
@@ -599,6 +867,12 @@ function rewriteNamespaceFunctionCallItem(
   { allowIncompleteToolSearch = false } = {},
 ) {
   if (!item || item.type !== "function_call") return undefined;
+  const customTool = rewriteCustomToolFunctionCallItem(
+    item,
+    lookups,
+    allowIncompleteToolSearch,
+  );
+  if (customTool) return customTool;
   const toolSearch = rewriteToolSearchFunctionCallItem(
     item,
     lookups,
@@ -712,6 +986,90 @@ function appendInterruptCallsToOutput(output, pending, interrupted) {
   return { output: base, injected: still.length, remaining: still };
 }
 
+const CUSTOM_TOOL_OPENING_LIMIT = 1024;
+const JSON_ESCAPES = Object.freeze({
+  '"': '"',
+  "\\": "\\",
+  "/": "/",
+  b: "\b",
+  f: "\f",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+});
+
+// Decode one new function-argument fragment into the native custom-tool input.
+// The wrapper prefix is bounded and every encoded patch character is visited
+// once. Only an incomplete escape (at most six characters) is retained between
+// calls, avoiding the quadratic full-patch rescans that large streamed patches
+// would otherwise trigger.
+function customToolInputDelta(state, fragment) {
+  if (typeof fragment !== "string" || state.invalid || state.closed) return undefined;
+  let encoded = fragment;
+  if (!state.opened) {
+    state.opening += encoded;
+    const opening = state.opening.match(/^\s*\{\s*"input"\s*:\s*"/);
+    if (!opening) {
+      if (state.opening.length > CUSTOM_TOOL_OPENING_LIMIT) {
+        state.opening = "";
+        state.invalid = true;
+      }
+      return undefined;
+    }
+    state.opened = true;
+    encoded = state.opening.slice(opening[0].length);
+    state.opening = "";
+  }
+
+  if (state.escape) {
+    encoded = state.escape + encoded;
+    state.escape = "";
+  }
+  const decoded = [];
+  for (let index = 0; index < encoded.length; index += 1) {
+    const character = encoded[index];
+    if (character === '"') {
+      state.closed = true;
+      break;
+    }
+    if (character !== "\\") {
+      if (character.charCodeAt(0) < 0x20) {
+        state.invalid = true;
+        break;
+      }
+      decoded.push(character);
+      continue;
+    }
+
+    const escape = encoded[index + 1];
+    if (escape === undefined) {
+      state.escape = "\\";
+      break;
+    }
+    if (escape === "u") {
+      const digits = encoded.slice(index + 2, index + 6);
+      if (!/^[0-9a-fA-F]*$/.test(digits)) {
+        state.invalid = true;
+        break;
+      }
+      if (digits.length < 4) {
+        state.escape = encoded.slice(index);
+        break;
+      }
+      decoded.push(String.fromCharCode(Number.parseInt(digits, 16)));
+      index += 5;
+      continue;
+    }
+    if (!(escape in JSON_ESCAPES)) {
+      state.invalid = true;
+      break;
+    }
+    decoded.push(JSON_ESCAPES[escape]);
+    index += 1;
+  }
+  return decoded.length ? decoded.join("") : undefined;
+}
+
 // Rewrites LiteLLM's flattened `<namespace>__<tool>` function calls back to
 // the namespace + name shape Codex dispatches through its app runtime.
 export class NamespaceToolCallTransform extends Transform {
@@ -731,6 +1089,8 @@ export class NamespaceToolCallTransform extends Transform {
   #injectQueue = [];
   #injectionsDone = false;
   #lastInjectedCalls = [];
+  #customItemIds = new Set();
+  #customDeltaStates = new Map();
 
   constructor(namespaces, contentType = "", sessionModel, options = {}) {
     super();
@@ -874,12 +1234,72 @@ export class NamespaceToolCallTransform extends Transform {
     }
     try {
       let event = JSON.parse(dataText);
+      const originalEventType = event?.type;
+      if (
+        !this.#injectOnly &&
+        event?.type === "response.function_call_arguments.delta" &&
+        this.#customItemIds.has(event.item_id)
+      ) {
+        const state = this.#customDeltaStates.get(event.item_id);
+        const delta = state ? customToolInputDelta(state, event.delta) : undefined;
+        if (delta === undefined) return [];
+        event = {
+          ...event,
+          type: "response.custom_tool_call_input.delta",
+          delta,
+        };
+      }
+      if (
+        !this.#injectOnly &&
+        event?.type === "response.function_call_arguments.done" &&
+        this.#customItemIds.has(event.item_id)
+      ) {
+        const input = customToolInput(event.arguments);
+        if (input !== undefined) {
+          const { arguments: _arguments, ...rest } = event;
+          event = {
+            ...rest,
+            type: "response.custom_tool_call_input.done",
+            input,
+          };
+        }
+      }
       if (!this.#injectOnly) {
         const next = rewriteNamespaceResponsePayload(event, this.#lookups, this.#sessionModel);
         if (next) event = next;
       }
+      if (
+        event?.type === "response.output_item.added" &&
+        event.item?.type === "custom_tool_call" &&
+        typeof event.item.id === "string"
+      ) {
+        this.#customItemIds.add(event.item.id);
+        this.#customDeltaStates.set(event.item.id, {
+          opening: "",
+          opened: false,
+          escape: "",
+          closed: false,
+          invalid: false,
+        });
+      }
+      if (
+        event?.type === "response.output_item.done" &&
+        event.item?.type === "custom_tool_call" &&
+        typeof event.item.id === "string"
+      ) {
+        this.#customItemIds.delete(event.item.id);
+        this.#customDeltaStates.delete(event.item.id);
+      }
       this.#observeEvent(event);
       const rebuilt = [...lines];
+      const eventLineIndex = rebuilt.findIndex((line) => line.startsWith("event:"));
+      if (
+        eventLineIndex !== -1 &&
+        typeof event?.type === "string" &&
+        event.type !== originalEventType
+      ) {
+        rebuilt[eventLineIndex] = `event: ${event.type}`;
+      }
       rebuilt[dataLineIndex] = `data: ${JSON.stringify(event)}`;
       // Inject finished-child interrupts before the response closes so Codex
       // still executes them as ordinary tool calls in this turn.

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -1,0 +1,32 @@
+// OpenCode's anonymous catalog exposes one documented free model on Responses.
+// Keep this mapping deliberately separate from paid Zen and the Go subscription
+// family: those providers have different catalogs and billing semantics.
+const CURATION_ROUTES = Object.freeze({
+  "opencode-free": Object.freeze({
+    providers: Object.freeze(["opencode-free", "opencode-free-responses"]),
+    responsesProvider: "opencode-free-responses",
+    responsesModels: Object.freeze(["muse-spark-1.2-contributor-free"]),
+  }),
+});
+
+const PRIMARY_BY_PROVIDER = new Map(
+  Object.entries(CURATION_ROUTES).flatMap(([primary, route]) =>
+    route.providers.map((provider) => [provider, primary]),
+  ),
+);
+
+export function curationPrimaryProviderId(providerId) {
+  return PRIMARY_BY_PROVIDER.get(providerId) || providerId;
+}
+
+export function curationProviderIds(providerId) {
+  const primary = curationPrimaryProviderId(providerId);
+  return [...(CURATION_ROUTES[primary]?.providers || [primary])];
+}
+
+export function curatedModelProviderId(providerId, upstreamModel) {
+  const primary = curationPrimaryProviderId(providerId);
+  const route = CURATION_ROUTES[primary];
+  if (route?.responsesModels.includes(upstreamModel)) return route.responsesProvider;
+  return primary;
+}

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -6,6 +6,15 @@ const CURATION_ROUTES = Object.freeze({
     providers: Object.freeze(["opencode-free", "opencode-free-responses"]),
     responsesProvider: "opencode-free-responses",
     responsesModels: Object.freeze(["muse-spark-1.2-contributor-free"]),
+    // Zen's live /models response currently publishes only ids. OpenCode's
+    // published model metadata sizes these exact free routes, so
+    // keep scripted curation from falling back to the generic 131K guess and
+    // making Codex compact every tool-bearing turn. A future catalog value is
+    // still preferred by curate-models because it describes the served route.
+    contextWindows: Object.freeze({
+      "muse-spark-1.2-contributor-free": 1_048_576,
+      "x-preview-f-free": 1_000_000,
+    }),
   }),
 });
 
@@ -29,4 +38,9 @@ export function curatedModelProviderId(providerId, upstreamModel) {
   const route = CURATION_ROUTES[primary];
   if (route?.responsesModels.includes(upstreamModel)) return route.responsesProvider;
   return primary;
+}
+
+export function curatedModelContextLength(providerId, upstreamModel) {
+  const primary = curationPrimaryProviderId(providerId);
+  return CURATION_ROUTES[primary]?.contextWindows?.[upstreamModel];
 }

--- a/src/provider-onboarding.mjs
+++ b/src/provider-onboarding.mjs
@@ -12,6 +12,7 @@ import { devinCliStatus } from "./devin-cli-status.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { KIMI_CLI_NPM_PACKAGE } from "./kimi-oauth-onboarding.mjs";
 import { MODELS, PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
+import { curationProviderIds } from "./opencode-curation.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import {
   apiProvider,
@@ -259,5 +260,6 @@ export function removeApiCredential(providerId) {
 // use this to name the curation step instead of reporting a provider that
 // looks enabled but shows nothing.
 export function providerNeedsCuration(providerId, models = MODELS) {
-  return !models.some((model) => model.provider === providerId);
+  const providers = new Set(curationProviderIds(providerId));
+  return !models.some((model) => providers.has(model.provider));
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -33,7 +33,10 @@ import {
   writeStreamErrorEvent,
 } from "./http-utils.mjs";
 import { EmptyCompletionGuard } from "./empty-completion-guard.mjs";
-import { zaiResponsesCompatTransform } from "./zai-responses-compat.mjs";
+import {
+  ZaiResponsesCompatTransform,
+  zaiResponsesCompatTransform,
+} from "./zai-responses-compat.mjs";
 import {
   MERGED_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
@@ -60,10 +63,14 @@ import {
 import { fetchWithRetry } from "./upstream-retry.mjs";
 import {
   NamespaceToolCallTransform,
+  agentMessagesAsUserMessages,
+  bridgeCustomTools,
+  downgradeOriginalImageDetail,
   flattenNamespacedHistory,
   flattenNamespaceTools,
   flattenToolSearchHistory,
   repairToolSchemaRoots,
+  stripSearchContentTypes,
 } from "./namespace-relay.mjs";
 import { collaborationToolAvailable, pendingInterruptTargets } from "./subagent-completion.mjs";
 import {
@@ -519,6 +526,24 @@ function normalizeAutoToolChoice(payload, route) {
   ) {
     payload.tool_choice = "auto";
   }
+}
+
+// The documented Zen Free pair has two different wire contracts: Ox uses Chat
+// Completions and Muse Contributor Free uses Responses. Their observed strict
+// tool/input limitations do not establish a contract for paid Zen, Go, or any
+// other free model, so keep this compatibility boundary exact.
+function needsZenFreeToolCompatibility(route) {
+  const providerId = providerForModel(route)?.id;
+  return (
+    (providerId === "opencode-free" && route.upstreamModel === "x-preview-f-free") ||
+    (providerId === "opencode-free-responses" &&
+      route.upstreamModel === "muse-spark-1.2-contributor-free")
+  );
+}
+
+function zenFreeCompatibleInput(input, route) {
+  if (!needsZenFreeToolCompatibility(route)) return input;
+  return downgradeOriginalImageDetail(agentMessagesAsUserMessages(input));
 }
 
 function nativeTarget(pathname, search = "") {
@@ -1696,7 +1721,15 @@ function compactionAttempts(route, aged) {
 // turn -- a compaction that fails ends the session just as hard, because the
 // conversation cannot get under its context limit without one.
 async function summarizeWith(request, payload, route, aged, signal) {
-  const bridged = await bridgeVisionInput(aged.input, route, request);
+  const compatibleInput = zenFreeCompatibleInput(aged.input, route);
+  const providerInput = needsZenFreeToolCompatibility(route)
+    ? bridgeCustomTools([], compatibleInput, new Map()).input
+    : compatibleInput;
+  const bridged = await bridgeVisionInput(
+    providerInput,
+    route,
+    request,
+  );
   const body = {
     ...payload,
     model: route.gatewayModel,
@@ -2039,7 +2072,11 @@ function observeSubagentOutcome(request, route, status, options = {}) {
 async function buildRoutedRequest({ request, payload, route, agedInput }) {
   let namespacesFlattened = false;
   let flattenedNamespaces = new Map();
-  const bridged = await bridgeVisionInput(agedInput, route, request);
+  const bridged = await bridgeVisionInput(
+    zenFreeCompatibleInput(agedInput, route),
+    route,
+    request,
+  );
   // `bridgeVisionInput` returns its argument unchanged when there is no image
   // to read, and `carryReasoningThroughInput` writes into the array it is
   // given -- so without this copy the first build would rewrite the shared
@@ -2114,7 +2151,26 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     // too, on the tools alone, without flattening anything.
     tools = repairToolSchemaRoots(tools);
   }
+  if (needsZenFreeToolCompatibility(route)) {
+    // Ox reaches Chat Completions after namespace flattening while Muse reaches
+    // Responses with native namespaces. Run the same recursive-ref repair
+    // after both protocol branches so neither wire shape can bypass it.
+    tools = repairToolSchemaRoots(tools, { nonRecursive: true });
+    tools = stripSearchContentTypes(tools);
+  }
   let routedInput = input;
+  let routedToolChoice = payload.tool_choice;
+  if (needsZenFreeToolCompatibility(route)) {
+    const customTools = bridgeCustomTools(
+      tools,
+      routedInput,
+      flattenedNamespaces,
+      routedToolChoice,
+    );
+    tools = customTools.tools;
+    routedInput = customTools.input;
+    routedToolChoice = customTools.toolChoice;
+  }
   if (chatCompletionsProvider) {
     const searchHistory = flattenToolSearchHistory(
       routedInput,
@@ -2135,6 +2191,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     model: route.gatewayModel,
     input: routedInput,
   };
+  if (routedToolChoice !== payload.tool_choice) routed.tool_choice = routedToolChoice;
   // Codex chooses a child's model; this is where an operator gets to choose its
   // depth. Applied only to turns Codex marked as a child, so a parent
   // conversation on the same model is untouched -- running one model
@@ -2179,9 +2236,12 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     flattenedNamespaces,
     // Close finished children the parent left Working. Only when the
     // collaboration toolset is actually available on this turn.
-    pendingInterrupts: pendingInterruptTargets(input, {
-      namespaces: flattenedNamespaces,
-    }),
+    pendingInterrupts: pendingInterruptTargets(
+      needsZenFreeToolCompatibility(route) ? agedInput : input,
+      {
+        namespaces: flattenedNamespaces,
+      },
+    ),
   };
 }
 
@@ -2746,10 +2806,20 @@ async function handleResponses(request, response, requestUrl) {
             : undefined,
       });
       const transforms = [usageObserver];
-      const zaiCompat = route
+      let envelopeCompat = route
         ? zaiResponsesCompatTransform(route.provider, contentType)
         : undefined;
-      if (zaiCompat) transforms.push(zaiCompat);
+      // LiteLLM's Ox Chat -> Responses bridge can start assistant text after
+      // reasoning without its message envelope. Keep that repair exact.
+      if (
+        !envelopeCompat &&
+        route?.provider === "opencode-free" &&
+        route.upstreamModel === "x-preview-f-free" &&
+        String(contentType).toLowerCase().includes("text/event-stream")
+      ) {
+        envelopeCompat = new ZaiResponsesCompatTransform();
+      }
+      if (envelopeCompat) transforms.push(envelopeCompat);
       // Restore flattened namespace calls for routed chat-completions providers,
       // and inject missing finished-child interrupts for both routed and native
       // multi-agent parents (San Francisco uses native GPT).

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -22,17 +22,181 @@ function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-// Resolves the local `#/$defs/...` and `#/definitions/...` pointers Codex
-// emits. Anything else (remote refs, unusual pointers) resolves to undefined
-// and the branch is skipped rather than guessed at.
+// Resolves only local URI-fragment JSON Pointers: `#` and `#/...`. RFC 6901
+// fragment decoding happens before `~1` / `~0` token decoding. Object own keys
+// and canonical in-range array indexes are traversable; malformed fragments,
+// anchors such as `#node`, and unsupported targets remain unresolved. The
+// cycle repair deliberately does not infer semantics for `$dynamicRef` or
+// `$recursiveRef` -- only an actual `$ref` crosses this boundary.
 function resolveRef(ref, root) {
-  if (typeof ref !== "string" || !ref.startsWith("#/")) return undefined;
+  if (typeof ref !== "string" || !ref.startsWith("#")) return undefined;
+  let pointer;
+  try {
+    pointer = decodeURIComponent(ref.slice(1));
+  } catch {
+    return undefined;
+  }
+  if (pointer === "") return isPlainObject(root) ? root : undefined;
+  if (!pointer.startsWith("/")) return undefined;
+
   let node = root;
-  for (const rawSegment of ref.slice(2).split("/")) {
-    if (!isPlainObject(node)) return undefined;
-    node = node[rawSegment.replace(/~1/g, "/").replace(/~0/g, "~")];
+  for (const rawSegment of pointer.slice(1).split("/")) {
+    if (/~(?:[^01]|$)/.test(rawSegment)) return undefined;
+    const segment = rawSegment.replace(/~1/g, "/").replace(/~0/g, "~");
+    if (Array.isArray(node)) {
+      if (!/^(?:0|[1-9]\d*)$/.test(segment)) return undefined;
+      const index = Number(segment);
+      if (!Number.isSafeInteger(index) || index >= node.length || !(index in node)) {
+        return undefined;
+      }
+      node = node[index];
+      continue;
+    }
+    if (!isPlainObject(node) || !Object.hasOwn(node, segment)) return undefined;
+    node = node[segment];
   }
   return isPlainObject(node) ? node : undefined;
+}
+
+// OpenCode's Responses-compatible surfaces reject recursive local refs in a
+// tool schema before the model sees the request. Keep definitions and every
+// acyclic, boolean, or unresolved ref intact: expanding a shared ref DAG can
+// grow exponentially, while deleting `$defs` leaves those refs dangling.
+//
+// A graph DFS marks only ref occurrences whose targets are still on the active
+// stack. It follows only JSON Schema keywords that actually contain schemas;
+// `$ref` strings inside const/default/examples/enum objects are literal data.
+// Removing the marked back edges makes the reference graph acyclic. The second
+// pass clones once and removes `$ref` only from the marked occurrence,
+// preserving any sibling constraints. Both passes are iterative so a valid
+// deeply nested tool schema cannot exhaust the JavaScript call stack. Schemas
+// with no cycle keep identity.
+const REF_SCHEMA_MAP_KEYWORDS = [
+  "$defs",
+  "definitions",
+  "properties",
+  "patternProperties",
+  "dependentSchemas",
+];
+const REF_SCHEMA_ARRAY_KEYWORDS = ["allOf", "anyOf", "oneOf", "prefixItems"];
+const REF_SCHEMA_CHILD_KEYWORDS = [
+  "additionalItems",
+  "additionalProperties",
+  "contains",
+  "contentSchema",
+  "else",
+  "if",
+  "items",
+  "not",
+  "propertyNames",
+  "then",
+  "unevaluatedItems",
+  "unevaluatedProperties",
+];
+
+function schemaEdges(node, root) {
+  const edges = [];
+  const resolved = resolveRef(node.$ref, root);
+  if (isPlainObject(resolved)) edges.push({ node: resolved, ref: true });
+
+  for (const keyword of REF_SCHEMA_MAP_KEYWORDS) {
+    const schemas = node[keyword];
+    if (!isPlainObject(schemas)) continue;
+    for (const schema of Object.values(schemas)) {
+      if (isPlainObject(schema)) edges.push({ node: schema, ref: false });
+    }
+  }
+  for (const keyword of REF_SCHEMA_ARRAY_KEYWORDS) {
+    const schemas = node[keyword];
+    if (!Array.isArray(schemas)) continue;
+    for (const schema of schemas) {
+      if (isPlainObject(schema)) edges.push({ node: schema, ref: false });
+    }
+  }
+  for (const keyword of REF_SCHEMA_CHILD_KEYWORDS) {
+    const schema = node[keyword];
+    if (Array.isArray(schema)) {
+      // Drafts before 2020-12 allowed tuple schemas directly under `items`.
+      for (const entry of schema) {
+        if (isPlainObject(entry)) edges.push({ node: entry, ref: false });
+      }
+    } else if (isPlainObject(schema)) {
+      edges.push({ node: schema, ref: false });
+    }
+  }
+  // Draft-07 `dependencies` mixes property-name arrays with schema values.
+  const dependencies = node.dependencies;
+  if (isPlainObject(dependencies)) {
+    for (const schema of Object.values(dependencies)) {
+      if (isPlainObject(schema)) edges.push({ node: schema, ref: false });
+    }
+  }
+  return edges;
+}
+
+function cycleClosingLocalRefs(schema) {
+  const state = new WeakMap();
+  const closing = new WeakSet();
+  let count = 0;
+  state.set(schema, 1);
+  const stack = [{ node: schema, edges: schemaEdges(schema, schema), index: 0 }];
+  while (stack.length) {
+    const frame = stack.at(-1);
+    if (frame.index >= frame.edges.length) {
+      state.set(frame.node, 2);
+      stack.pop();
+      continue;
+    }
+    const edge = frame.edges[frame.index];
+    frame.index += 1;
+    const targetState = state.get(edge.node);
+    if (targetState === 1) {
+      if (edge.ref && !closing.has(frame.node)) {
+        closing.add(frame.node);
+        count += 1;
+      }
+      continue;
+    }
+    if (targetState === 2) continue;
+    state.set(edge.node, 1);
+    stack.push({ node: edge.node, edges: schemaEdges(edge.node, schema), index: 0 });
+  }
+  return { closing, count };
+}
+
+function cloneWithoutClosingRefs(root, closing) {
+  const clones = new WeakMap();
+  const rootCopy = {};
+  clones.set(root, rootCopy);
+  const stack = [{ source: root, target: rootCopy }];
+  while (stack.length) {
+    const { source, target } = stack.pop();
+    const entries = Array.isArray(source)
+      ? source.map((value, index) => [index, value])
+      : Object.entries(source);
+    for (const [key, value] of entries) {
+      if (key === "$ref" && closing.has(source)) continue;
+      if (!Array.isArray(value) && !isPlainObject(value)) {
+        target[key] = value;
+        continue;
+      }
+      let copy = clones.get(value);
+      if (!copy) {
+        copy = Array.isArray(value) ? [] : {};
+        clones.set(value, copy);
+        stack.push({ source: value, target: copy });
+      }
+      target[key] = copy;
+    }
+  }
+  return rootCopy;
+}
+
+export function nonRecursiveToolSchema(schema) {
+  if (!isPlainObject(schema)) return schema;
+  const { closing, count } = cycleClosingLocalRefs(schema);
+  if (!count) return schema;
+  return cloneWithoutClosingRefs(schema, closing);
 }
 
 // Every object-typed leaf reachable from `schema` through unions and local

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -19,7 +19,7 @@ export const USER_MODELS_PATH =
 // number is a guess, and a guess eight times too small compacts a session that
 // had the room (#266).
 export const DEFAULT_CONTEXT_WINDOW = 131072;
-const DEFAULT_AUTO_COMPACT = 110000;
+export const DEFAULT_AUTO_COMPACT = 110000;
 
 // Curation may adjust presentation, sizing, and effort metadata only;
 // identity and routing fields always come from the provider id and the

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -24,9 +24,11 @@ const {
   renderRows,
 } =
   await import("../src/curate-models.mjs");
-const { curatedModelProviderId, curationProviderIds } = await import(
-  "../src/opencode-curation.mjs"
-);
+const {
+  curatedModelContextLength,
+  curatedModelProviderId,
+  curationProviderIds,
+} = await import("../src/opencode-curation.mjs");
 const { userModelEntry } = await import("../src/user-models.mjs");
 process.argv = savedArgv;
 process.exitCode = 0;
@@ -84,6 +86,18 @@ test("OpenCode curation pairs only the anonymous Free protocol variants", () => 
   );
 });
 
+test("OpenCode Free curation knows the documented windows its live catalog omits", () => {
+  assert.equal(
+    curatedModelContextLength("opencode-free", "muse-spark-1.2-contributor-free"),
+    1_048_576,
+  );
+  assert.equal(
+    curatedModelContextLength("opencode-free", "x-preview-f-free"),
+    1_000_000,
+  );
+  assert.equal(curatedModelContextLength("opencode-free", "mimo-v2.5-free"), undefined);
+});
+
 test("paid Zen curation identity remains byte-for-byte unchanged", () => {
   const paidZen = userModelEntry({
     providerId: "opencode-zen",
@@ -132,6 +146,18 @@ test("OpenCode protocol normalization preserves metadata and deduplicates old ro
     normalizeCurationModels([old, correct], "opencode-free"),
     [correct],
   );
+
+  const defaultOx = userModelEntry({
+    providerId: "opencode-free",
+    upstreamId: "x-preview-f-free",
+    priority: 149,
+  });
+  const [sizedOx] = normalizeCurationModels([defaultOx], "opencode-free");
+  assert.equal(sizedOx.contextWindow, 1_000_000);
+  assert.equal(sizedOx.autoCompact, 850_000);
+
+  const tunedOx = { ...defaultOx, autoCompact: 100_000 };
+  assert.strictEqual(normalizeCurationModels([tunedOx], "opencode-free")[0], tunedOx);
 });
 
 test("an additive model run keeps unrelated curated metadata", () => {
@@ -397,7 +423,9 @@ test("OpenCode Free curation migrates Muse to Responses while Ox stays on Chat",
   writeFileSync(fixture, JSON.stringify({
     data: [
       { id: museId, context_length: 1_048_576 },
-      { id: oxId, context_length: 262_144 },
+      // Zen currently serves this exact id-only record. The documented
+      // fallback must keep a fresh scripted curation from storing 131K.
+      { id: oxId },
     ],
   }));
   const env = {
@@ -454,6 +482,8 @@ test("OpenCode Free curation migrates Muse to Responses while Ox stays on Chat",
     assert.equal(muse.requestProfile, oldMuse.requestProfile);
     assert.equal(ox.provider, "opencode-free");
     assert.equal(ox.slug, `opencode-free/${oxId}`);
+    assert.equal(ox.contextWindow, 1_000_000);
+    assert.equal(ox.autoCompact, 850_000);
 
     const picker = JSON.parse(readFileSync(pickerFile, "utf8"));
     assert.deepEqual(picker.visible, [muse.slug, ox.slug].sort());

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -17,12 +17,17 @@ process.argv = [process.argv[0], "curate-models.mjs", "gemini-api"];
 const {
   curatedSizing,
   mergeCurationIntoCurrent,
+  normalizeCurationModels,
   parseEfforts,
   parseRequestProfile,
   planCuration,
   renderRows,
 } =
   await import("../src/curate-models.mjs");
+const { curatedModelProviderId, curationProviderIds } = await import(
+  "../src/opencode-curation.mjs"
+);
+const { userModelEntry } = await import("../src/user-models.mjs");
 process.argv = savedArgv;
 process.exitCode = 0;
 
@@ -50,6 +55,82 @@ test("curation merges current unrelated providers and rejects stale same-provide
       { providerId: "fireworks", expectedMine: [mine], nextMine: [replacement] },
     ),
     /changed while this command was running/,
+  );
+});
+
+test("OpenCode curation pairs only the anonymous Free protocol variants", () => {
+  assert.deepEqual(curationProviderIds("opencode-free"), [
+    "opencode-free",
+    "opencode-free-responses",
+  ]);
+  assert.deepEqual(curationProviderIds("opencode-free-responses"), [
+    "opencode-free",
+    "opencode-free-responses",
+  ]);
+  assert.deepEqual(curationProviderIds("opencode-zen"), ["opencode-zen"]);
+  assert.deepEqual(curationProviderIds("opencode-go"), ["opencode-go"]);
+  assert.deepEqual(curationProviderIds("opencode-go-messages"), ["opencode-go-messages"]);
+  assert.equal(
+    curatedModelProviderId("opencode-free", "muse-spark-1.2-contributor-free"),
+    "opencode-free-responses",
+  );
+  assert.equal(
+    curatedModelProviderId("opencode-zen", "muse-spark-1.2"),
+    "opencode-zen",
+  );
+  assert.equal(
+    curatedModelProviderId("opencode-free", "x-preview-f-free"),
+    "opencode-free",
+  );
+});
+
+test("paid Zen curation identity remains byte-for-byte unchanged", () => {
+  const paidZen = userModelEntry({
+    providerId: "opencode-zen",
+    upstreamId: "muse-spark-1.2",
+    priority: 151,
+    requestProfile: "auto-tool-choice",
+    metadata: { contextWindow: 1_048_576 },
+  });
+  const [normalized] = normalizeCurationModels([paidZen], "opencode-zen");
+  assert.strictEqual(normalized, paidZen);
+  assert.equal(normalized.slug, "opencode-zen/muse-spark-1.2");
+  assert.equal(normalized.gatewayModel, "opencode-zen-muse-spark-1-2");
+});
+
+test("OpenCode protocol normalization preserves metadata and deduplicates old routes", () => {
+  const upstreamModel = "muse-spark-1.2-contributor-free";
+  const old = userModelEntry({
+    providerId: "opencode-free",
+    upstreamId: upstreamModel,
+    priority: 147,
+    requestProfile: "auto-tool-choice",
+    metadata: {
+      contextWindow: 1_048_576,
+      autoCompact: 900_000,
+      inputModalities: ["text", "image"],
+      isFree: true,
+    },
+  });
+  old.displayName = "Preserved Muse metadata";
+  const correct = userModelEntry({
+    providerId: "opencode-free-responses",
+    upstreamId: upstreamModel,
+    priority: 148,
+    metadata: { contextWindow: 262_144 },
+  });
+
+  const [migrated] = normalizeCurationModels([old], "opencode-free");
+  assert.equal(migrated.provider, "opencode-free-responses");
+  assert.equal(migrated.slug, `opencode-free-responses/${upstreamModel}`);
+  assert.equal(migrated.gatewayModel, "opencode-free-responses-muse-spark-1-2-contributor-free");
+  assert.equal(migrated.displayName, old.displayName);
+  assert.equal(migrated.contextWindow, old.contextWindow);
+  assert.equal(migrated.requestProfile, old.requestProfile);
+
+  assert.deepEqual(
+    normalizeCurationModels([old, correct], "opencode-free"),
+    [correct],
   );
 });
 
@@ -281,6 +362,189 @@ test("scripted curation stores the advertised window, not the conservative guess
     const unsized = stored.models.find((model) => model.upstreamModel === "vendor/unsized");
     assert.equal(unsized.contextWindow, 131072);
     assert.ok(unsized.autoCompact <= unsized.contextWindow);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode Free curation migrates Muse to Responses while Ox stays on Chat", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "curate-opencode-free-protocol-"));
+  const file = path.join(dir, "user-models.json");
+  const pickerFile = path.join(dir, "model-picker.json");
+  const fixture = path.join(dir, "models.json");
+  const museId = "muse-spark-1.2-contributor-free";
+  const oxId = "x-preview-f-free";
+  const oldMuse = userModelEntry({
+    providerId: "opencode-free",
+    upstreamId: museId,
+    priority: 147,
+    requestProfile: "auto-tool-choice",
+    metadata: {
+      contextWindow: 1_048_576,
+      autoCompact: 900_000,
+      inputModalities: ["text", "image"],
+      isFree: true,
+    },
+  });
+  oldMuse.displayName = "Muse metadata from the existing curation";
+  writeFileSync(file, JSON.stringify({ version: 1, models: [oldMuse] }));
+  writeFileSync(pickerFile, JSON.stringify({
+    version: 1,
+    hidden: [],
+    visible: [oldMuse.slug],
+    seeded: [oldMuse.slug],
+  }));
+  writeFileSync(fixture, JSON.stringify({
+    data: [
+      { id: museId, context_length: 1_048_576 },
+      { id: oxId, context_length: 262_144 },
+    ],
+  }));
+  const env = {
+    ...process.env,
+    CODEX_HOME: path.join(dir, "codex"),
+    MODEL_ROUTER_STATE_DIR: dir,
+    MODEL_ROUTER_USER_MODELS: file,
+    MODEL_ROUTER_MODEL_PICKER_STATE: pickerFile,
+    OPENCODE_API_KEY: "",
+    OPENCODE_GO_API_KEY: "",
+  };
+  const run = () => spawnSync(
+    process.execPath,
+    [
+      path.join(root, "src", "curate-models.mjs"),
+      "opencode-free",
+      "--models",
+      `${museId},${oxId}`,
+      "--fixture",
+      fixture,
+      "--no-apply",
+    ],
+    { cwd: root, encoding: "utf8", env },
+  );
+  try {
+    const modelsBeforeDiscovery = readFileSync(file, "utf8");
+    const pickerBeforeDiscovery = readFileSync(pickerFile, "utf8");
+    const discovery = spawnSync(
+      process.execPath,
+      [
+        path.join(root, "src", "model-discovery.mjs"),
+        "opencode-free",
+        "--fixture",
+        fixture,
+        "--json",
+      ],
+      { cwd: root, encoding: "utf8", env },
+    );
+    assert.equal(discovery.status, 0, discovery.stderr);
+    assert.equal(readFileSync(file, "utf8"), modelsBeforeDiscovery);
+    assert.equal(readFileSync(pickerFile, "utf8"), pickerBeforeDiscovery);
+
+    const first = run();
+    assert.equal(first.status, 0, first.stderr);
+    const stored = JSON.parse(readFileSync(file, "utf8"));
+    assert.equal(stored.models.length, 2);
+    const muse = stored.models.find((model) => model.upstreamModel === museId);
+    const ox = stored.models.find((model) => model.upstreamModel === oxId);
+    assert.equal(muse.provider, "opencode-free-responses");
+    assert.equal(muse.slug, `opencode-free-responses/${museId}`);
+    assert.equal(muse.displayName, oldMuse.displayName);
+    assert.equal(muse.contextWindow, oldMuse.contextWindow);
+    assert.deepEqual(muse.inputModalities, oldMuse.inputModalities);
+    assert.equal(muse.requestProfile, oldMuse.requestProfile);
+    assert.equal(ox.provider, "opencode-free");
+    assert.equal(ox.slug, `opencode-free/${oxId}`);
+
+    const picker = JSON.parse(readFileSync(pickerFile, "utf8"));
+    assert.deepEqual(picker.visible, [muse.slug, ox.slug].sort());
+    assert.equal(picker.visible.includes(oldMuse.slug), false);
+
+    const configResult = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        "const { renderLiteLlmConfig } = await import('./src/litellm-config.mjs');" +
+          "process.stdout.write(renderLiteLlmConfig());",
+      ],
+      { cwd: root, encoding: "utf8", env },
+    );
+    assert.equal(configResult.status, 0, configResult.stderr);
+    const blockFor = (gatewayModel) => {
+      const start = configResult.stdout.indexOf(`model_name: "${gatewayModel}"`);
+      assert.ok(start >= 0, `missing LiteLLM route for ${gatewayModel}`);
+      const next = configResult.stdout.indexOf("model_name:", start + 1);
+      return configResult.stdout.slice(start, next === -1 ? undefined : next);
+    };
+    const museBlock = blockFor(muse.gatewayModel);
+    assert.match(
+      museBlock,
+      /model: "openai\/responses\/opencode-free-responses-muse-spark-1-2-contributor-free"/,
+    );
+    assert.doesNotMatch(museBlock, /use_chat_completions_api/);
+    const oxBlock = blockFor(ox.gatewayModel);
+    assert.match(oxBlock, /model: "openai\/opencode-free-x-preview-f-free"/);
+    assert.match(oxBlock, /use_chat_completions_api: true/);
+
+    const beforeRepeat = readFileSync(file, "utf8");
+    const pickerBeforeRepeat = readFileSync(pickerFile, "utf8");
+    const second = run();
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(readFileSync(file, "utf8"), beforeRepeat);
+    assert.equal(readFileSync(pickerFile, "utf8"), pickerBeforeRepeat);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("removing an old Chat-routed Muse does not create a stale Responses picker entry", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "curate-opencode-free-remove-"));
+  const file = path.join(dir, "user-models.json");
+  const pickerFile = path.join(dir, "model-picker.json");
+  const museId = "muse-spark-1.2-contributor-free";
+  const oldMuse = userModelEntry({
+    providerId: "opencode-free",
+    upstreamId: museId,
+    priority: 147,
+  });
+  writeFileSync(file, JSON.stringify({ version: 1, models: [oldMuse] }));
+  writeFileSync(pickerFile, JSON.stringify({
+    version: 1,
+    hidden: [],
+    visible: [oldMuse.slug],
+    seeded: [oldMuse.slug],
+  }));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(root, "src", "curate-models.mjs"),
+        "opencode-free",
+        "--remove",
+        museId,
+        "--no-apply",
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_HOME: path.join(dir, "codex"),
+          MODEL_ROUTER_STATE_DIR: dir,
+          MODEL_ROUTER_USER_MODELS: file,
+          MODEL_ROUTER_MODEL_PICKER_STATE: pickerFile,
+          OPENCODE_API_KEY: "",
+          OPENCODE_GO_API_KEY: "",
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(readFileSync(file, "utf8")).models, []);
+    const picker = JSON.parse(readFileSync(pickerFile, "utf8"));
+    assert.deepEqual(picker.visible, [oldMuse.slug]);
+    assert.equal(
+      picker.visible.includes(`opencode-free-responses/${museId}`),
+      false,
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/model-picker-state.test.mjs
+++ b/test/model-picker-state.test.mjs
@@ -9,6 +9,7 @@ process.env.CODEX_ROUTER_STATE_DIR = stateDir;
 
 const {
   MODEL_PICKER_STATE_PATH,
+  migrateModelVisibility,
   modelPickerSnapshot,
   readHiddenModels,
   setAllModelsVisible,
@@ -56,6 +57,16 @@ test("provider-sized picker changes preserve other providers", () => {
   assert.deepEqual(modelPickerSnapshot().hidden, ["kimi-oauth/k3"]);
   assert.ok(modelPickerSnapshot().visible.includes("commandcode/kimi-k3"));
   assert.ok(modelPickerSnapshot().visible.includes("commandcode-messages/claude-opus-4.8"));
+});
+
+test("a protocol migration carries the existing picker decision to the new slug", () => {
+  const oldSlug = "opencode-free/muse-spark-1.2-contributor-free";
+  const newSlug = "opencode-free-responses/muse-spark-1.2-contributor-free";
+  setModelVisible(oldSlug, true);
+  migrateModelVisibility([{ from: oldSlug, to: newSlug }]);
+  const migrated = modelPickerSnapshot();
+  assert.equal(migrated.visible.includes(oldSlug), false);
+  assert.equal(migrated.visible.includes(newSlug), true);
 });
 
 test("legacy hidden-only state becomes an allowlist when a picker decision is made", () => {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -4,13 +4,17 @@ import test from "node:test";
 
 import {
   NamespaceToolCallTransform,
+  agentMessagesAsUserMessages,
+  bridgeCustomTools,
   buildNamespaceLookups,
+  downgradeOriginalImageDetail,
   flattenNamespacedHistory,
   flattenNamespaceTools,
   flattenToolSearchHistory,
   rewriteNamespaceFunctionCall,
   rewriteNamespaceResponsePayload,
   repairToolSchemaRoots,
+  stripSearchContentTypes,
 } from "../src/namespace-relay.mjs";
 import { mergeCodexAppTools } from "../src/codex-app-tools.mjs";
 
@@ -1242,4 +1246,235 @@ test("repairToolSchemaRoots fixes roots without flattening", () => {
 test("repairToolSchemaRoots returns the original array when nothing needs repair", () => {
   const tools = [{ type: "function", name: "fine", parameters: { type: "object", properties: { a: {} } } }];
   assert.equal(repairToolSchemaRoots(tools), tools);
+});
+
+test("OpenCode search repair strips only search_content_types on web_search", () => {
+  const webSearch = {
+    type: "web_search",
+    search_content_types: ["text", "image"],
+    filters: { allowed_domains: ["example.com"] },
+  };
+  const preview = { type: "web_search_preview", search_content_types: ["text"] };
+  const ordinary = {
+    type: "function",
+    name: "ordinary",
+    search_content_types: ["application-specific"],
+  };
+  const stripped = stripSearchContentTypes([webSearch, preview, ordinary]);
+  assert.deepEqual(stripped[0], {
+    type: "web_search",
+    filters: { allowed_domains: ["example.com"] },
+  });
+  assert.deepEqual(stripped[1], preview);
+  assert.deepEqual(stripped[2], ordinary);
+});
+
+test("OpenCode input repair preserves collaboration text and inherited images", () => {
+  const agent = {
+    type: "agent_message",
+    id: "amsg_1",
+    author: "/root",
+    recipient: "/root/reviewer",
+    content: [
+      { type: "input_text", text: "Message Type: NEW_TASK\nPayload:\nEdit it." },
+      {
+        type: "input_image",
+        image_url: "data:image/png;base64,AAA",
+        detail: "original",
+      },
+    ],
+  };
+  const publicInput = agentMessagesAsUserMessages([agent]);
+  assert.deepEqual(publicInput[0], {
+    type: "message",
+    role: "user",
+    content: agent.content,
+  });
+  const compatible = downgradeOriginalImageDetail(publicInput);
+  assert.deepEqual(compatible[0].content[0], agent.content[0]);
+  assert.equal(compatible[0].content[1].image_url, "data:image/png;base64,AAA");
+  assert.equal(compatible[0].content[1].detail, "auto");
+});
+
+test("custom-tool bridge maps apply_patch definitions and paired history losslessly", () => {
+  const namespaces = new Map();
+  const patch = "*** Begin Patch\n*** Update File: seed.txt\n@@\n-before\n+after\n*** End Patch";
+  const ordinary = { type: "function", name: "read_file", parameters: { type: "object" } };
+  const unrelatedCall = {
+    type: "function_call",
+    name: "read_file",
+    call_id: "call_read",
+    arguments: '{"path":"seed.txt"}',
+  };
+  const bridged = bridgeCustomTools(
+    [
+      {
+        type: "custom",
+        name: "apply_patch",
+        description: "Apply a patch.",
+        format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+      },
+      ordinary,
+    ],
+    [
+      {
+        type: "custom_tool_call",
+        id: "ctc_1",
+        call_id: "call_patch_1",
+        name: "apply_patch",
+        input: patch,
+      },
+      { type: "custom_tool_call_output", call_id: "call_patch_1", output: "Done!" },
+      unrelatedCall,
+    ],
+    namespaces,
+    { type: "custom", name: "apply_patch" },
+  );
+  assert.deepEqual(bridged.tools[0].parameters.required, ["input"]);
+  assert.equal(bridged.tools[0].format, undefined);
+  assert.deepEqual(bridged.tools[1], ordinary);
+  assert.deepEqual(bridged.toolChoice, { type: "function", name: "apply_patch" });
+  assert.deepEqual(bridged.input[0], {
+    id: "ctc_1",
+    call_id: "call_patch_1",
+    type: "function_call",
+    name: "apply_patch",
+    arguments: JSON.stringify({ input: patch }),
+  });
+  assert.equal(bridged.input[1].type, "function_call_output");
+  assert.deepEqual(bridged.input[2], unrelatedCall);
+  assert.equal(buildNamespaceLookups(namespaces).customTools.get("apply_patch"), "apply_patch");
+});
+
+test("custom-tool bridge avoids hijacking an ordinary apply_patch function", () => {
+  const namespaces = new Map();
+  const ordinary = { type: "function", name: "apply_patch", parameters: { type: "object" } };
+  const bridged = bridgeCustomTools(
+    [ordinary, { type: "custom", name: "apply_patch" }],
+    [],
+    namespaces,
+  );
+  assert.deepEqual(bridged.tools[0], ordinary);
+  assert.equal(bridged.tools[1].name, "codex_custom_apply_patch");
+  assert.equal(
+    buildNamespaceLookups(namespaces).customTools.get("codex_custom_apply_patch"),
+    "apply_patch",
+  );
+});
+
+test("custom-tool bridge reserves native namespace names and restores the aliased call", () => {
+  const namespaces = new Map();
+  const namespace = {
+    type: "namespace",
+    name: "apply_patch",
+    tools: [{ type: "function", name: "inspect", inputSchema: { type: "object" } }],
+  };
+  const bridged = bridgeCustomTools(
+    [namespace, { type: "custom", name: "apply_patch" }],
+    [],
+    namespaces,
+    { type: "custom", name: "apply_patch" },
+  );
+
+  assert.deepEqual(bridged.tools[0], namespace);
+  assert.equal(bridged.tools[1].name, "codex_custom_apply_patch");
+  assert.deepEqual(bridged.toolChoice, {
+    type: "function",
+    name: "codex_custom_apply_patch",
+  });
+  const rewritten = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        {
+          type: "function_call",
+          id: "fc_patch_json",
+          call_id: "call_patch_json",
+          name: "codex_custom_apply_patch",
+          arguments: JSON.stringify({ input: "*** Begin Patch\n*** End Patch" }),
+        },
+      ],
+    },
+    buildNamespaceLookups(namespaces),
+  );
+  assert.deepEqual(rewritten.output[0], {
+    type: "custom_tool_call",
+    id: "fc_patch_json",
+    call_id: "call_patch_json",
+    name: "apply_patch",
+    input: "*** Begin Patch\n*** End Patch",
+  });
+});
+
+test("one-byte fragmented SSE preserves escaped and multibyte custom input", async () => {
+  const namespaces = new Map();
+  bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], namespaces);
+  const patch =
+    "*** Begin Patch\n+quote=\"yes\" slash=\\ tab=\t snowman=☃ emoji=🧩\n*** End Patch";
+  const argumentsText = JSON.stringify({ input: patch });
+  const fragments = [];
+  for (let index = 0; index < argumentsText.length; index += 1) {
+    fragments.push(argumentsText.slice(index, index + 1));
+  }
+  const events = [
+    {
+      type: "response.output_item.added",
+      item: {
+        type: "function_call",
+        id: "fc_1",
+        call_id: "call_patch_1",
+        name: "apply_patch",
+        arguments: "",
+      },
+    },
+    ...fragments.map((delta) => ({
+      type: "response.function_call_arguments.delta",
+      item_id: "fc_1",
+      delta,
+    })),
+    {
+      type: "response.function_call_arguments.done",
+      item_id: "fc_1",
+      arguments: argumentsText,
+    },
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "fc_1",
+        call_id: "call_patch_1",
+        name: "apply_patch",
+        arguments: argumentsText,
+      },
+    },
+  ];
+  const source = events
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  const sourceBytes = Buffer.from(source, "utf8");
+  const chunks = [];
+  for (let index = 0; index < sourceBytes.length; index += 1) {
+    chunks.push(sourceBytes.subarray(index, index + 1));
+  }
+  const transform = new NamespaceToolCallTransform(namespaces, "text/event-stream");
+  const output = await collect(Readable.from(chunks).pipe(transform));
+  const blocks = output.split(/\n\n/).filter(Boolean);
+  const payloads = blocks.map((block) => {
+    const data = block.split("\n").find((line) => line.startsWith("data: "));
+    return JSON.parse(data.slice(6));
+  });
+  assert.equal(payloads[0].item.type, "custom_tool_call");
+  const deltas = payloads
+    .filter((event) => event.type === "response.custom_tool_call_input.delta")
+    .map((event) => event.delta)
+    .join("");
+  assert.equal(deltas, patch);
+  const done = payloads.find(
+    (event) => event.type === "response.custom_tool_call_input.done",
+  );
+  assert.equal(done.input, patch);
+  assert.equal(payloads.at(-1).item.type, "custom_tool_call");
+  assert.equal(payloads.at(-1).item.input, patch);
+  assert.doesNotMatch(output, /response\.function_call_arguments/);
+  assert.match(output, /event: response\.custom_tool_call_input\.delta/);
+  assert.match(output, /event: response\.custom_tool_call_input\.done/);
 });

--- a/test/provider-key.test.mjs
+++ b/test/provider-key.test.mjs
@@ -206,3 +206,16 @@ test("a curated model silences the curation hint", () => {
   const models = [{ provider: "gemini-api", slug: "gemini-api/curated" }];
   assert.equal(providerNeedsCuration("gemini-api", models), false);
 });
+
+test("the OpenCode Free Responses sibling does not widen paid curation sets", () => {
+  const models = [
+    { provider: "opencode-free-responses", slug: "opencode-free-responses/muse" },
+    { provider: "opencode-go", slug: "opencode-go/kimi-k3" },
+  ];
+  assert.equal(providerNeedsCuration("opencode-free", models), false);
+  assert.equal(providerNeedsCuration("opencode-free-responses", models), false);
+  assert.equal(providerNeedsCuration("opencode-zen", models), true);
+  // Checked-in Go models remain their own exact set and do not populate paid
+  // Zen curation just because those providers share a selection credential.
+  assert.equal(providerNeedsCuration("opencode-go", models), false);
+});

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -56,6 +56,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
       "lmstudio",
       "local",
       "opencode-free",
+      "opencode-free-responses",
     ]);
     assert.deepEqual(defaultProviderIds(), ["lmstudio", "local"]);
     delete process.env.KIMI_API_KEY;
@@ -67,6 +68,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
       "lmstudio",
       "local",
       "opencode-free",
+      "opencode-free-responses",
     ]);
     assert.deepEqual(defaultProviderIds(), ["deepseek", "lmstudio", "local"]);
 
@@ -137,6 +139,23 @@ test("opencode Go protocol variants follow their parent as one family", () => {
         .map((model) => model.slug)
         .includes("opencode-go-messages/minimax-m2.7"),
     );
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("OpenCode Free protocol variants follow the anonymous parent as one family", () => {
+  try {
+    writeProviderSelection(["opencode-free-responses"]);
+    assert.deepEqual(
+      JSON.parse(readFileSync(PROVIDER_SELECTION_PATH, "utf8")).providers,
+      ["opencode-free"],
+    );
+    assert.deepEqual(readProviderSelection(), [
+      "opencode-free",
+      "opencode-free-responses",
+    ]);
+    assert.deepEqual(disableProvider("opencode-free-responses"), []);
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -183,8 +183,15 @@ test("provider registry exposes configured API and OAuth model families", () => 
   assert.equal(PROVIDERS.get("opencode-go").baseUrl, "https://opencode.ai/zen/go/v1");
   assert.equal(PROVIDERS.get("opencode-go-messages").baseUrl, "https://opencode.ai/zen/go/v1");
   assert.equal(PROVIDERS.get("opencode-go-responses").baseUrl, "https://opencode.ai/zen/go/v1");
+  assert.equal(PROVIDERS.get("opencode-zen").baseUrl, "https://opencode.ai/zen/v1");
+  assert.equal(PROVIDERS.get("opencode-zen").baseUrlEnv, "OPENCODE_ZEN_BASE_URL");
+  assert.equal(PROVIDERS.get("opencode-zen").protocol, undefined);
   assert.equal(PROVIDERS.get("opencode-go-messages").protocol, "anthropic");
   assert.equal(PROVIDERS.get("opencode-go-responses").protocol, "openai-responses");
+  const goMuse = MODEL_BY_SLUG.get("opencode-go-responses/muse-spark-1.2-contributor");
+  assert.equal(goMuse.provider, "opencode-go-responses");
+  assert.equal(goMuse.upstreamModel, "muse-spark-1.2-contributor");
+  assert.equal(goMuse.gatewayModel, "opencode-go-responses-muse-spark-1-2-contributor");
   assert.equal(PROVIDERS.get("commandcode").baseUrl, "https://api.commandcode.ai/provider/v1");
   assert.equal(PROVIDERS.get("commandcode-messages").baseUrl, "https://api.commandcode.ai/provider/v1");
   assert.equal(PROVIDERS.get("commandcode-messages").protocol, "anthropic");
@@ -199,6 +206,8 @@ test("provider registry exposes configured API and OAuth model families", () => 
   assert.equal(PROVIDERS.get("opencode-go").variantOf, undefined);
   assert.equal(PROVIDERS.get("opencode-go-messages").variantOf, "opencode-go");
   assert.equal(PROVIDERS.get("opencode-go-responses").variantOf, "opencode-go");
+  assert.equal(PROVIDERS.get("opencode-zen").variantOf, "opencode-go");
+  assert.equal(PROVIDERS.has("opencode-zen-responses"), false);
   assert.equal(PROVIDERS.get("commandcode").variantOf, undefined);
   assert.equal(PROVIDERS.get("commandcode-messages").variantOf, "commandcode");
   assert.equal(
@@ -262,9 +271,25 @@ test("provider registry exposes configured API and OAuth model families", () => 
   assert.deepEqual(chutes.credential.keychainServices, ["codex-router-chutes"]);
   assert.equal(LISTED_MODELS.some(({ provider }) => provider === "chutes"), false);
   const opencodeFree = PROVIDERS.get("opencode-free");
+  const opencodeFreeResponses = PROVIDERS.get("opencode-free-responses");
   assert.equal(opencodeFree.authMode, "anonymous");
   assert.equal(opencodeFree.baseUrl, "https://opencode.ai/zen/v1");
   assert.equal(opencodeFree.credential, undefined);
+  assert.equal(opencodeFreeResponses.variantOf, "opencode-free");
+  assert.equal(opencodeFreeResponses.protocol, "openai-responses");
+  assert.equal(opencodeFreeResponses.authMode, "anonymous");
+  assert.equal(opencodeFreeResponses.baseUrl, "https://opencode.ai/zen/v1");
+  assert.equal(opencodeFreeResponses.baseUrlEnv, undefined);
+  assert.equal(opencodeFreeResponses.credential, undefined);
+  assert.equal(opencodeFreeResponses.anonymousModelPolicy, "explicit-models");
+  assert.deepEqual(opencodeFreeResponses.anonymousModels, [
+    "muse-spark-1.2-contributor-free",
+  ]);
+  assert.equal(anonymousModelAllowed(opencodeFreeResponses, "muse-spark-1.2-contributor-free"), true);
+  assert.equal(anonymousModelAllowed(opencodeFreeResponses, "x-preview-f-free"), false);
+  assert.equal(anonymousModelAllowed(opencodeFreeResponses, "big-pickle"), false);
+  assert.equal(anonymousModelAllowed(opencodeFreeResponses, "arbitrary-free"), false);
+  assert.equal(anonymousModelAllowed(opencodeFreeResponses, "muse-spark-1.2"), false);
   assert.equal(anonymousModelAllowed(opencodeFree, "big-pickle"), true);
   assert.equal(anonymousModelAllowed(opencodeFree, "mimo-v2.5-free"), true);
   assert.equal(anonymousModelAllowed(opencodeFree, "glm-5.1"), false);
@@ -718,6 +743,10 @@ test("LiteLLM configuration is generated from every registry route", () => {
     rendered,
     /model: "openai\/responses\/opencode-go-responses-gpt-5-6-luna"/,
   );
+  assert.match(
+    rendered,
+    /model: "openai\/responses\/opencode-go-responses-muse-spark-1-2-contributor"/,
+  );
   assert.equal(
     MODELS.some((model) => model.provider === "github-copilot"),
     false,
@@ -1002,6 +1031,60 @@ test("credential-free endpoints are allowlisted addresses, at the provider and a
     });
     assert.equal(redirected.status, 1);
     assert.match(redirected.stderr, /anonymous provider opencode-free must use its fixed official endpoint/);
+
+    const redirectedResponses = load((registry) => {
+      registry.providers = registry.providers.map((provider) =>
+        provider.id === "opencode-free-responses"
+          ? { ...provider, baseUrl: "https://example.com/v1" }
+          : provider,
+      );
+    });
+    assert.equal(redirectedResponses.status, 1);
+    assert.match(
+      redirectedResponses.stderr,
+      /anonymous provider opencode-free-responses must use its fixed official endpoint/,
+    );
+
+    const invalidAllowlist = load((registry) => {
+      registry.providers = registry.providers.map((provider) =>
+        provider.id === "opencode-free-responses"
+          ? { ...provider, anonymousModels: [] }
+          : provider,
+      );
+    });
+    assert.equal(invalidAllowlist.status, 1);
+    assert.match(
+      invalidAllowlist.stderr,
+      /anonymous provider opencode-free-responses requires a valid anonymousModels allowlist/,
+    );
+
+    const wrongPolicy = load((registry) => {
+      registry.providers = registry.providers.map((provider) =>
+        provider.id === "opencode-free-responses"
+          ? { ...provider, anonymousModelPolicy: "opencode-console" }
+          : provider,
+      );
+    });
+    assert.equal(wrongPolicy.status, 1);
+    assert.match(
+      wrongPolicy.stderr,
+      /may declare anonymousModels only with explicit-models policy/,
+    );
+
+    const wrongResponseModel = load((registry) => {
+      registry.models.push({
+        slug: "opencode-free-responses/x-preview-f-free",
+        gatewayModel: "opencode-free-responses-x-preview-f-free",
+        upstreamModel: "x-preview-f-free",
+        provider: "opencode-free-responses",
+        listed: true,
+      });
+    });
+    assert.equal(wrongResponseModel.status, 1);
+    assert.match(
+      wrongResponseModel.stderr,
+      /anonymous provider opencode-free-responses only accepts its documented free-model ids/,
+    );
 
     const keyed = load((registry) => {
       registry.providers = registry.providers.map((provider) =>

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -1239,6 +1239,18 @@ test("router synthesizes routed compaction and safely replays it to native model
     await waitFor(`${routerBase(routerPort)}/models`, router);
     const input = [
       { type: "message", role: "user", content: [{ type: "input_text", text: "keep me" }] },
+      {
+        type: "custom_tool_call",
+        id: "ctc_non_opencode",
+        call_id: "call_non_opencode",
+        name: "apply_patch",
+        input: "*** Begin Patch\n*** End Patch",
+      },
+      {
+        type: "custom_tool_call_output",
+        call_id: "call_non_opencode",
+        output: "Done!",
+      },
     ];
     const v1 = await fetch(`${routerBase(routerPort)}/responses/compact`, {
       method: "POST",
@@ -1249,6 +1261,9 @@ test("router synthesizes routed compaction and safely replays it to native model
     const v1Body = await v1.json();
     assert.equal(v1Body.output.at(-1).role, "user");
     assert.match(v1Body.output.at(-1).content[0].text, /compact summary/);
+    assert.equal(gatewayRequests[0].body.input[1].type, "custom_tool_call");
+    assert.equal(gatewayRequests[0].body.input[1].name, "apply_patch");
+    assert.equal(gatewayRequests[0].body.input[2].type, "custom_tool_call_output");
 
     const v2 = await fetch(`${routerBase(routerPort)}/responses`, {
       method: "POST",
@@ -6265,5 +6280,952 @@ test("router repairs malformed Z.ai message envelopes after LiteLLM Responses tr
     await stopChild(router);
     await closeServer(gateway.server);
     rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+function curatedZenFreeCompatibilityModels() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "routing-opencode-tool-model-"));
+  const file = path.join(dir, "user-models.json");
+  const ox = {
+    slug: "opencode-free/x-preview-f-free",
+    gatewayModel: "opencode-free-x-preview-f-free",
+    upstreamModel: "x-preview-f-free",
+    provider: "opencode-free",
+  };
+  const muse = {
+    slug: "opencode-free-responses/muse-spark-1.2-contributor-free",
+    gatewayModel: "opencode-free-responses-muse-spark-1-2-contributor-free",
+    upstreamModel: "muse-spark-1.2-contributor-free",
+    provider: "opencode-free-responses",
+  };
+  writeFileSync(
+    file,
+    JSON.stringify({
+      version: 1,
+      models: [
+        {
+          ...ox,
+          listed: true,
+          displayName: "Ox Preview (compatibility fixture)",
+          description: "Test fixture.",
+          priority: 500,
+          defaultEffort: "high",
+          reasoningLevels: [{ effort: "high", description: "Deep reasoning" }],
+          contextWindow: 131072,
+          autoCompact: 110000,
+          inputModalities: ["text", "image"],
+          compHash: "opencode-free-x-preview-f-free-user-v1",
+        },
+        {
+          ...muse,
+          listed: true,
+          displayName: "Muse Contributor Free (compatibility fixture)",
+          description: "Test fixture.",
+          priority: 499,
+          defaultEffort: "high",
+          reasoningLevels: [{ effort: "high", description: "Deep reasoning" }],
+          contextWindow: 131072,
+          autoCompact: 110000,
+          inputModalities: ["text", "image"],
+          compHash: "opencode-free-responses-muse-contributor-free-user-v1",
+        },
+      ],
+    }),
+    "utf8",
+  );
+  return { dir, file, ox, muse };
+}
+
+function zenFreeCompatibilityTools() {
+  const recursiveSchema = {
+    type: "object",
+    properties: { task: { $ref: "#/$defs/task" } },
+    $defs: {
+      task: {
+        type: "object",
+        properties: {
+          label: { type: "string" },
+          child: { $ref: "#/$defs/task" },
+        },
+      },
+    },
+  };
+  return [
+    {
+      type: "custom",
+      name: "apply_patch",
+      description: "Apply a patch to the workspace.",
+      format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+    },
+    {
+      type: "function",
+      name: "read_file",
+      parameters: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+      },
+    },
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [
+        {
+          type: "function",
+          name: "spawn_agent",
+          description: "Spawn a worker.",
+          inputSchema: recursiveSchema,
+        },
+      ],
+    },
+    {
+      type: "namespace",
+      name: "apply_patch",
+      tools: [
+        {
+          type: "function",
+          name: "inspect",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    },
+    {
+      type: "web_search",
+      search_content_types: ["text", "image"],
+      filters: { allowed_domains: ["example.com"] },
+    },
+    {
+      type: "web_search_preview",
+      search_content_types: ["text"],
+    },
+  ];
+}
+
+function openCodeAgentMessage(marker) {
+  return {
+    type: "agent_message",
+    id: `amsg_${marker}`,
+    author: "/root",
+    recipient: "/root/worker",
+    content: [
+      { type: "input_text", text: marker },
+      {
+        type: "input_image",
+        image_url: "data:image/png;base64,AA==",
+        detail: "original",
+      },
+    ],
+  };
+}
+
+function jsonFunctionCallResponse(name, patch, callId = "call_patch_json") {
+  return {
+    id: "resp_patch_json",
+    object: "response",
+    status: "completed",
+    output: [
+      {
+        type: "function_call",
+        id: "fc_patch_json",
+        call_id: callId,
+        name,
+        arguments: JSON.stringify({ input: patch }),
+      },
+    ],
+    usage: { input_tokens: 10, output_tokens: 4, total_tokens: 14 },
+  };
+}
+
+async function writeFragmentedFunctionCallSse(response, { model, patch }) {
+  const id = "fc_patch_sse";
+  const callId = "call_patch_sse";
+  const argumentsText = JSON.stringify({ input: patch });
+  const argumentDeltas = [];
+  for (let index = 0; index < argumentsText.length; index += 3) {
+    argumentDeltas.push(argumentsText.slice(index, index + 3));
+  }
+  const functionCall = {
+    type: "function_call",
+    id,
+    call_id: callId,
+    name: "apply_patch",
+    arguments: argumentsText,
+  };
+  const events = [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...functionCall, arguments: "", status: "in_progress" },
+    },
+    ...argumentDeltas.map((delta) => ({
+      type: "response.function_call_arguments.delta",
+      item_id: id,
+      output_index: 0,
+      delta,
+    })),
+    {
+      type: "response.function_call_arguments.done",
+      item_id: id,
+      output_index: 0,
+      arguments: argumentsText,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { ...functionCall, status: "completed" },
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_patch_sse",
+        model,
+        status: "completed",
+        output: [functionCall],
+        usage: { input_tokens: 12, output_tokens: 5, total_tokens: 17 },
+      },
+    },
+  ];
+  const source = events
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  response.writeHead(200, { "Content-Type": "text/event-stream" });
+  for (let index = 0; index < source.length; index += 5) {
+    response.write(source.slice(index, index + 5));
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  response.end();
+}
+
+test("Zen Free Muse and Ox bridge custom tools across JSON, history, SSE, and errors", async () => {
+  const curated = curatedZenFreeCompatibilityModels();
+  const { muse, ox } = curated;
+  const stateDir = path.join(curated.dir, "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    `${JSON.stringify({
+      version: 1,
+      providers: ["opencode-free", "opencode-go", "grok-api"],
+    })}\n`,
+  );
+  writeFileSync(
+    path.join(stateDir, "failover.json"),
+    `${JSON.stringify({
+      version: 1,
+      enabled: true,
+      chain: ["grok-api/grok-4.5"],
+    })}\n`,
+  );
+  writeFileSync(path.join(stateDir, "xai-api-key.secret"), "TEST_XAI_API_KEY\n");
+  const museSlug = muse.slug;
+  const museGatewayModel = muse.gatewayModel;
+  const jsonPatch =
+    "*** Begin Patch\n*** Update File: seed.txt\n@@\n-before\n+after\n*** End Patch";
+  const ssePatch =
+    "*** Begin Patch\n*** Update File: seed.txt\n@@\n-old\n+quoted=\\\"yes\\\" and snowman=☃\n*** End Patch";
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET") {
+      json(response, 200, {
+        ok: true,
+        credential_present: true,
+        credential_source: "test",
+      });
+      return;
+    }
+    const body = await bodyJson(request);
+    gatewayRequests.push(body);
+    const inputText = JSON.stringify(body.input);
+    if (inputText.includes("REJECT_TOOL_REQUEST_400")) {
+      json(response, 400, {
+        error: {
+          message: "STRICT_TOOL_SCHEMA_SENTINEL",
+          type: "invalid_request_error",
+          param: "tools",
+        },
+      });
+      return;
+    }
+    if (
+      inputText.includes("FAILOVER_CONTROL_402") &&
+      body.model === ox.gatewayModel
+    ) {
+      json(response, 402, {
+        error: { message: "insufficient credits", type: "billing_error" },
+      });
+      return;
+    }
+    if (
+      inputText.includes("FAILOVER_CONTROL_402") &&
+      body.model === "grok-api-grok-4-5"
+    ) {
+      json(response, 200, {
+        id: "resp_failover_control",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "eligible alternate reached" }],
+          },
+        ],
+      });
+      return;
+    }
+    if (inputText.includes("CONTEXT CHECKPOINT COMPACTION")) {
+      if (
+        body.input.some((item) =>
+          ["custom_tool_call", "custom_tool_call_output"].includes(item?.type),
+        )
+      ) {
+        json(response, 400, {
+          error: { message: "CUSTOM_HISTORY_NOT_BRIDGED", type: "invalid_request_error" },
+        });
+        return;
+      }
+      const compactCall = body.input.find(
+        (item) => item?.type === "function_call" && item.call_id === "call_compact_patch",
+      );
+      const compactOutput = body.input.find(
+        (item) =>
+          item?.type === "function_call_output" &&
+          item.call_id === "call_compact_patch",
+      );
+      if (!compactCall || !compactOutput) {
+        json(response, 400, {
+          error: { message: "FUNCTION_HISTORY_MISSING", type: "invalid_request_error" },
+        });
+        return;
+      }
+      json(response, 200, {
+        id: "resp_compact_tools",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "custom history compacted" }],
+          },
+        ],
+        usage: { input_tokens: 30, output_tokens: 3, total_tokens: 33 },
+      });
+      return;
+    }
+    if (
+      body.model === ox.gatewayModel &&
+      inputText.includes("OX_TEXT_ENVELOPE")
+    ) {
+      response.writeHead(200, { "Content-Type": "text/event-stream" });
+      const events = [
+        {
+          type: "response.output_item.added",
+          output_index: 0,
+          model: ox.gatewayModel,
+          item: { id: "rs_ox", type: "reasoning", status: "in_progress", summary: [] },
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 0,
+          model: ox.gatewayModel,
+          item: { id: "rs_ox", type: "reasoning", status: "completed", summary: [] },
+        },
+        {
+          type: "response.output_text.delta",
+          output_index: 0,
+          content_index: 0,
+          item_id: "msg_ox",
+          model: ox.gatewayModel,
+          delta: "OX_OK",
+        },
+      ];
+      response.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+      return;
+    }
+    if (body.model === ox.gatewayModel) {
+      await writeFragmentedFunctionCallSse(response, {
+        model: ox.gatewayModel,
+        patch: ssePatch,
+      });
+      return;
+    }
+    if (
+      Array.isArray(body.input) &&
+      body.input.some(
+        (item) =>
+          item?.type === "function_call_output" &&
+          item.call_id === "call_patch_json",
+      )
+    ) {
+      json(response, 200, {
+        id: "resp_readback",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: "readback confirmed" }],
+          },
+        ],
+        usage: { input_tokens: 20, output_tokens: 2, total_tokens: 22 },
+      });
+      return;
+    }
+    const forcedFunction =
+      body.tool_choice?.type === "function" ? body.tool_choice.name : "apply_patch";
+    json(response, 200, jsonFunctionCallResponse(forcedFunction, jsonPatch));
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_SHOW_ALL_MODELS: "0",
+    MODEL_ROUTER_USER_MODELS: curated.file,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    XAI_API_KEY: "TEST_XAI_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  const send = (payload, signal) =>
+    fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal,
+    });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    const first = await send({
+      model: museSlug,
+      stream: false,
+      tool_choice: { type: "custom", name: "apply_patch" },
+      tools: zenFreeCompatibilityTools(),
+      input: [openCodeAgentMessage("MUSE_JSON")],
+    });
+    assert.equal(first.status, 200, router.testErrors());
+    const firstPayload = await first.json();
+    assert.deepEqual(firstPayload.output[0], {
+      type: "custom_tool_call",
+      id: "fc_patch_json",
+      call_id: "call_patch_json",
+      name: "apply_patch",
+      input: jsonPatch,
+    });
+
+    const museRequest = gatewayRequests[0];
+    assert.equal(museRequest.model, museGatewayModel);
+    assert.deepEqual(museRequest.tool_choice, {
+      type: "function",
+      name: "codex_custom_apply_patch",
+    });
+    const musePatchTool = museRequest.tools.find(
+      (tool) => tool.type === "function" && tool.name === "codex_custom_apply_patch",
+    );
+    assert.deepEqual(musePatchTool.parameters.required, ["input"]);
+    assert.equal(musePatchTool.parameters.properties.input.type, "string");
+    assert.equal(musePatchTool.format, undefined);
+    assert.deepEqual(
+      museRequest.tools.find((tool) => tool.name === "read_file").parameters.required,
+      ["path"],
+    );
+    const museNamespace = museRequest.tools.find(
+      (tool) => tool.type === "namespace" && tool.name === "collaboration",
+    );
+    assert.ok(museNamespace, "Responses provider lost the native namespace");
+    const museSpawn = museNamespace.tools.find((tool) => tool.name === "spawn_agent");
+    assert.equal(museSpawn.inputSchema.properties.task.$ref, "#/$defs/task");
+    assert.deepEqual(museSpawn.inputSchema.$defs.task.properties.child, {});
+    assert.ok(
+      museRequest.tools.some(
+        (tool) => tool.type === "namespace" && tool.name === "apply_patch",
+      ),
+      "Responses provider lost the colliding native namespace",
+    );
+    assert.equal(
+      "search_content_types" in
+        museRequest.tools.find((tool) => tool.type === "web_search"),
+      false,
+    );
+    assert.deepEqual(
+      museRequest.tools.find((tool) => tool.type === "web_search_preview")
+        .search_content_types,
+      ["text"],
+    );
+    const museMessage = museRequest.input.find(
+      (item) =>
+        item.type === "message" &&
+        item.role === "user" &&
+        item.content?.some((part) => part.text === "MUSE_JSON"),
+    );
+    assert.ok(museMessage, "agent_message was not converted on the owned provider route");
+    assert.equal(
+      museMessage.content.find((part) => part.type === "input_image").detail,
+      "auto",
+    );
+
+    const followup = await send({
+      model: museSlug,
+      stream: false,
+      tools: zenFreeCompatibilityTools(),
+      input: [
+        { type: "message", role: "user", content: "Edit the seed." },
+        firstPayload.output[0],
+        {
+          type: "custom_tool_call_output",
+          call_id: "call_patch_json",
+          output: "Done!",
+        },
+      ],
+    });
+    assert.equal(followup.status, 200, router.testErrors());
+    const followupPayload = await followup.json();
+    assert.equal(followupPayload.output[0].type, "message");
+    assert.equal(followupPayload.output[0].content[0].text, "readback confirmed");
+    const forwardedHistory = gatewayRequests[1].input;
+    const functionCall = forwardedHistory.find(
+      (item) => item.type === "function_call" && item.call_id === "call_patch_json",
+    );
+    assert.equal(functionCall.name, "codex_custom_apply_patch");
+    assert.deepEqual(JSON.parse(functionCall.arguments), { input: jsonPatch });
+    assert.equal(
+      forwardedHistory.find((item) => item.call_id === "call_patch_json" && "output" in item)
+        .type,
+      "function_call_output",
+    );
+
+    const oxResponse = await send({
+      model: ox.slug,
+      stream: true,
+      tool_choice: "required",
+      tools: zenFreeCompatibilityTools(),
+      input: [
+        openCodeAgentMessage("OX_SSE"),
+        {
+          type: "custom_tool_call",
+          id: "ctc_prior_ox",
+          call_id: "call_prior_ox",
+          name: "apply_patch",
+          input: "*** Begin Patch\n*** End Patch",
+        },
+        {
+          type: "custom_tool_call_output",
+          call_id: "call_prior_ox",
+          output: "Done!",
+        },
+      ],
+    });
+    assert.equal(oxResponse.status, 200, router.testErrors());
+    const oxText = await oxResponse.text();
+    const oxEvents = oxText
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+    assert.equal(oxEvents[0].item.type, "custom_tool_call");
+    assert.equal(oxEvents[0].item.name, "apply_patch");
+    assert.equal(
+      oxEvents
+        .filter((event) => event.type === "response.custom_tool_call_input.delta")
+        .map((event) => event.delta)
+        .join(""),
+      ssePatch,
+    );
+    assert.equal(
+      oxEvents.find((event) => event.type === "response.custom_tool_call_input.done")
+        .input,
+      ssePatch,
+    );
+    assert.equal(
+      oxEvents.find((event) => event.type === "response.output_item.done").item.input,
+      ssePatch,
+    );
+    assert.equal(
+      oxEvents.find((event) => event.type === "response.completed").response.output[0]
+        .type,
+      "custom_tool_call",
+    );
+    assert.doesNotMatch(oxText, /response\.function_call_arguments/);
+    assert.match(oxText, /event: response\.custom_tool_call_input\.delta/);
+
+    const oxRequest = gatewayRequests[2];
+    assert.equal(oxRequest.model, ox.gatewayModel);
+    assert.equal(oxRequest.tool_choice, "required");
+    const flattenedSpawn = oxRequest.tools.find(
+      (tool) => tool.name === "collaboration__spawn_agent",
+    );
+    assert.ok(flattenedSpawn, "Chat provider did not receive the flattened namespace tool");
+    assert.equal(flattenedSpawn.parameters.properties.task.$ref, "#/$defs/task");
+    assert.deepEqual(flattenedSpawn.parameters.$defs.task.properties.child, {});
+    assert.equal(flattenedSpawn.inputSchema.properties.task.$ref, "#/$defs/task");
+    assert.deepEqual(flattenedSpawn.inputSchema.$defs.task.properties.child, {});
+    assert.equal(
+      oxRequest.input.find((item) => item.call_id === "call_prior_ox").type,
+      "function_call",
+    );
+    assert.equal(
+      oxRequest.input.find(
+        (item) => item.call_id === "call_prior_ox" && "output" in item,
+      ).type,
+      "function_call_output",
+    );
+
+    // LiteLLM 1.96's Chat -> Responses bridge consumes its only
+    // output_item.added marker on the reasoning item, then starts assistant
+    // text without a message or content-part envelope. That live Ox shape must
+    // be repaired before Codex sees the first text delta.
+    const oxTextResponse = await send({
+      model: ox.slug,
+      stream: true,
+      input: [{ type: "message", role: "user", content: "OX_TEXT_ENVELOPE" }],
+    });
+    assert.equal(oxTextResponse.status, 200, router.testErrors());
+    const oxTextEvents = (await oxTextResponse.text())
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+    const oxTextDelta = oxTextEvents.findIndex(
+      (event) => event.type === "response.output_text.delta",
+    );
+    assert.equal(oxTextEvents[oxTextDelta - 2]?.type, "response.output_item.added");
+    assert.equal(oxTextEvents[oxTextDelta - 2]?.item?.type, "message");
+    assert.equal(oxTextEvents[oxTextDelta - 1]?.type, "response.content_part.added");
+    assert.equal(oxTextEvents[oxTextDelta]?.output_index, 1);
+
+    const compactPatch = "*** Begin Patch\n*** Update File: seed.txt\n*** End Patch";
+    const beforeCompaction = gatewayRequests.length;
+    const compacted = await fetch(`${routerBase(routerPort)}/responses/compact`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: museSlug,
+        input: [
+          { type: "message", role: "user", content: "Preserve the edit history." },
+          {
+            type: "custom_tool_call",
+            id: "ctc_compact",
+            call_id: "call_compact_patch",
+            name: "apply_patch",
+            input: compactPatch,
+          },
+          {
+            type: "custom_tool_call_output",
+            call_id: "call_compact_patch",
+            output: "Done!",
+          },
+        ],
+      }),
+    });
+    assert.equal(compacted.status, 200, router.testErrors());
+    const compactedPayload = await compacted.json();
+    assert.equal(compactedPayload.output.at(-1).role, "user");
+    assert.match(compactedPayload.output.at(-1).content[0].text, /custom history compacted/);
+    const compactRequest = gatewayRequests[beforeCompaction];
+    assert.equal(compactRequest.model, museGatewayModel);
+    assert.deepEqual(compactRequest.tools, []);
+    const compactFunctionCall = compactRequest.input.find(
+      (item) => item.call_id === "call_compact_patch" && item.type === "function_call",
+    );
+    assert.deepEqual(JSON.parse(compactFunctionCall.arguments), { input: compactPatch });
+    assert.equal(
+      compactRequest.input.find(
+        (item) =>
+          item.call_id === "call_compact_patch" && item.type === "function_call_output",
+      ).output,
+      "Done!",
+    );
+
+    const beforeRejection = gatewayRequests.length;
+    const rejected = await send({
+      model: ox.slug,
+      stream: false,
+      tools: zenFreeCompatibilityTools(),
+      input: [{ type: "message", role: "user", content: "REJECT_TOOL_REQUEST_400" }],
+    });
+    assert.equal(rejected.status, 400);
+    const rejection = await rejected.json();
+    assert.match(rejection.error.message, /STRICT_TOOL_SCHEMA_SENTINEL/);
+    assert.equal(rejection.error.code, "400");
+    assert.equal(gatewayRequests.length, beforeRejection + 1);
+    assert.equal(gatewayRequests.at(-1).model, ox.gatewayModel);
+    assert.ok(
+      !gatewayRequests
+        .slice(beforeRejection)
+        .some((request) => request.model === "grok-api-grok-4-5"),
+      "generic HTTP 400 contacted the configured failover route",
+    );
+
+    // Positive control: the same selected, credentialed, v2-capable alternate
+    // is genuinely eligible when the provider reports exhausted usage. This
+    // keeps the preceding no-failover assertion from passing vacuously.
+    const beforeControl = gatewayRequests.length;
+    const control = await send({
+      model: ox.slug,
+      stream: false,
+      tools: zenFreeCompatibilityTools(),
+      input: [{ type: "message", role: "user", content: "FAILOVER_CONTROL_402" }],
+    });
+    assert.equal(control.status, 200, router.testErrors());
+    assert.deepEqual(
+      gatewayRequests.slice(beforeControl).map((request) => request.model),
+      [ox.gatewayModel, "grok-api-grok-4-5"],
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
+test("Go, paid Zen, and other Free routes keep compatibility-sensitive wire shapes", async () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "routing-opencode-identity-"));
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true });
+  const specs = [
+    ["opencode-go", "identity-chat"],
+    ["opencode-go-messages", "identity-messages"],
+    ["opencode-go-responses", "identity-responses"],
+    ["opencode-zen", "identity-paid-zen"],
+    ["opencode-free", "identity-other-free"],
+  ].map(([provider, upstreamModel], index) => ({
+    slug: `${provider}/${upstreamModel}`,
+    gatewayModel: `${provider}-${upstreamModel}`,
+    upstreamModel,
+    provider,
+    listed: true,
+    displayName: `${provider} identity fixture`,
+    description: "Compatibility boundary fixture.",
+    priority: 450 - index,
+    defaultEffort: "high",
+    reasoningLevels: [{ effort: "high", description: "Deep reasoning" }],
+    contextWindow: 131072,
+    autoCompact: 110000,
+    inputModalities: ["text", "image"],
+    compHash: `${provider}-${upstreamModel}-identity-v1`,
+  }));
+  const userModels = path.join(testRoot, "user-models.json");
+  writeFileSync(userModels, JSON.stringify({ version: 1, models: specs }), "utf8");
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    `${JSON.stringify({ version: 1, providers: ["opencode-go", "opencode-free"] })}\n`,
+  );
+  writeFileSync(path.join(stateDir, "opencode-go-api-key.secret"), "TEST_OPENCODE_KEY\n");
+
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET") {
+      json(response, 200, { ok: true, credential_present: true });
+      return;
+    }
+    const body = await bodyJson(request);
+    gatewayRequests.push(body);
+    await writeFragmentedFunctionCallSse(response, {
+      model: body.model,
+      patch: "*** Begin Patch\n*** End Patch",
+    });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_USER_MODELS: userModels,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const recursiveSchema = {
+    type: "object",
+    properties: { node: { $ref: "#/$defs/node" } },
+    $defs: {
+      node: {
+        type: "object",
+        properties: { child: { $ref: "#/$defs/node" } },
+      },
+    },
+  };
+  const customChoice = { type: "custom", name: "apply_patch" };
+  const customCall = {
+    type: "custom_tool_call",
+    id: "ctc_identity",
+    call_id: "call_identity",
+    name: "apply_patch",
+    input: "*** Begin Patch\n*** End Patch",
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    for (const spec of specs) {
+      const response = await fetch(`${routerBase(routerPort)}/responses`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: spec.slug,
+          stream: true,
+          tool_choice: customChoice,
+          tools: [
+            {
+              type: "custom",
+              name: "apply_patch",
+              format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+            },
+            { type: "function", name: "recursive", parameters: recursiveSchema },
+            { type: "web_search", search_content_types: ["text", "image"] },
+          ],
+          input: [
+            {
+              type: "agent_message",
+              role: "assistant",
+              content: [
+                { type: "input_text", text: `identity ${spec.provider}` },
+                {
+                  type: "input_image",
+                  image_url: "data:image/png;base64,AAA",
+                  detail: "original",
+                },
+              ],
+            },
+            customCall,
+            {
+              type: "custom_tool_call_output",
+              call_id: "call_identity",
+              output: "Done!",
+            },
+          ],
+        }),
+      });
+      assert.equal(response.status, 200, `${spec.provider}: ${router.testErrors()}`);
+      const responseText = await response.text();
+      assert.match(responseText, /response\.function_call_arguments\.delta/);
+      assert.doesNotMatch(responseText, /response\.custom_tool_call_input/);
+
+      const forwarded = gatewayRequests.at(-1);
+      assert.equal(forwarded.model, spec.gatewayModel);
+      assert.deepEqual(forwarded.tool_choice, customChoice);
+      assert.equal(
+        forwarded.tools.find((tool) => tool.name === "apply_patch").type,
+        "custom",
+      );
+      const recursive = forwarded.tools.find((tool) => tool.name === "recursive");
+      assert.equal(recursive.parameters.$defs.node.properties.child.$ref, "#/$defs/node");
+      assert.deepEqual(
+        forwarded.tools.find((tool) => tool.type === "web_search").search_content_types,
+        ["text", "image"],
+      );
+      assert.equal(forwarded.input[0].type, "agent_message");
+      assert.equal(forwarded.input[0].content[1].detail, "original");
+      assert.deepEqual(forwarded.input[1], customCall);
+      assert.equal(forwarded.input[2].type, "custom_tool_call_output");
+    }
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("canceling a Zen Free Ox custom-tool stream stops the transformed pipeline", async () => {
+  const curated = curatedZenFreeCompatibilityModels();
+  const { ox } = curated;
+  const stateDir = path.join(curated.dir, "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    `${JSON.stringify({ version: 1, providers: ["opencode-free"] })}\n`,
+  );
+  let gatewayRequests = 0;
+  let gatewayClosed = false;
+  let terminalWritten = false;
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET") {
+      json(response, 200, { ok: true, credential_present: true });
+      return;
+    }
+    await bodyJson(request);
+    gatewayRequests += 1;
+    response.once("close", () => {
+      gatewayClosed = true;
+    });
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.write(
+      `event: response.output_item.added\ndata: ${JSON.stringify({
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_cancel",
+          call_id: "call_cancel",
+          name: "apply_patch",
+          arguments: "",
+        },
+      })}\n\n`,
+    );
+    await Promise.race([
+      new Promise((resolve) => response.once("close", resolve)),
+      new Promise((resolve) => setTimeout(resolve, 1_000)),
+    ]);
+    if (!response.destroyed) {
+      terminalWritten = true;
+      response.end(
+        `event: response.function_call_arguments.done\ndata: ${JSON.stringify({
+          type: "response.function_call_arguments.done",
+          item_id: "fc_cancel",
+          arguments: JSON.stringify({ input: "*** Begin Patch\n*** End Patch" }),
+        })}\n\n`,
+      );
+    }
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_SHOW_ALL_MODELS: "0",
+    MODEL_ROUTER_USER_MODELS: curated.file,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const canceler = new AbortController();
+    const routed = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: ox.slug,
+        stream: true,
+        tools: zenFreeCompatibilityTools(),
+        input: [{ type: "message", role: "user", content: "Begin, then wait." }],
+      }),
+      signal: canceler.signal,
+    });
+    assert.equal(routed.status, 200, router.testErrors());
+    const reader = routed.body.getReader();
+    let received = "";
+    while (!received.includes("response.output_item.added")) {
+      const { done, value } = await reader.read();
+      assert.equal(done, false);
+      received += Buffer.from(value).toString("utf8");
+    }
+    assert.match(received, /"type":"custom_tool_call"/);
+    canceler.abort();
+    await reader.read().catch(() => undefined);
+    const closeDeadline = Date.now() + 1_200;
+    while (!gatewayClosed && Date.now() < closeDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.equal(gatewayClosed, true);
+    assert.equal(terminalWritten, false);
+    assert.equal(gatewayRequests, 1);
+    assert.doesNotMatch(received, /custom_tool_call_input\.done/);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(curated.dir, { recursive: true, force: true });
   }
 });

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -5,10 +5,194 @@ import { CODEX_APP_TOOLS } from "../src/codex-app-tools.mjs";
 import { toResponsesRequest } from "../src/grok-oauth-forwarder.mjs";
 import {
   hasObjectRoot,
+  nonRecursiveToolSchema,
   normalizeSchemaLiterals,
   objectRootToolSchema,
   providerToolSchema,
 } from "../src/tool-schema-root.mjs";
+
+test("recursive local refs keep definitions and only the cycle edge becomes permissive", () => {
+  const schema = {
+    type: "object",
+    properties: { node: { $ref: "#/$defs/node" } },
+    $defs: {
+      node: {
+        type: "object",
+        properties: {
+          label: { type: "string" },
+          child: { $ref: "#/$defs/node", description: "optional child" },
+        },
+      },
+    },
+  };
+  const repaired = nonRecursiveToolSchema(schema);
+  assert.notEqual(repaired, schema);
+  assert.equal(repaired.properties.node.$ref, "#/$defs/node");
+  assert.equal(repaired.$defs.node.type, "object");
+  assert.equal(repaired.$defs.node.properties.label.type, "string");
+  assert.deepEqual(repaired.$defs.node.properties.child, {
+    description: "optional child",
+  });
+});
+
+test("mutually recursive refs retain their shared definitions and break one back edge", () => {
+  const schema = {
+    type: "object",
+    properties: { first: { $ref: "#/$defs/a" } },
+    $defs: {
+      a: {
+        type: "object",
+        properties: { name: { type: "string" }, next: { $ref: "#/$defs/b" } },
+      },
+      b: {
+        type: "object",
+        properties: { count: { type: "integer" }, previous: { $ref: "#/$defs/a" } },
+      },
+    },
+  };
+  const repaired = nonRecursiveToolSchema(schema);
+  assert.equal(repaired.properties.first.$ref, "#/$defs/a");
+  assert.equal(repaired.$defs.a.properties.next.$ref, "#/$defs/b");
+  assert.deepEqual(repaired.$defs.b.properties.previous, {});
+});
+
+test("local ref pointers repair root and array cycles without resolving anchors", () => {
+  const root = nonRecursiveToolSchema({
+    properties: { self: { $ref: "#", description: "recursive root" } },
+  });
+  assert.deepEqual(root.properties.self, { description: "recursive root" });
+
+  const array = nonRecursiveToolSchema({
+    anyOf: [
+      {
+        properties: {
+          self: { $ref: "#/anyOf/0" },
+          anchor: { $ref: "#node" },
+        },
+      },
+    ],
+  });
+  assert.deepEqual(array.anyOf[0].properties.self, {});
+  assert.equal(array.anyOf[0].properties.anchor.$ref, "#node");
+});
+
+test("shared ref DAGs stay bounded when another definition is recursive", () => {
+  const $defs = {
+    d0: { type: "string" },
+  };
+  for (let depth = 1; depth <= 18; depth += 1) {
+    $defs[`d${depth}`] = {
+      anyOf: [
+        { $ref: `#/$defs/d${depth - 1}` },
+        { $ref: `#/$defs/d${depth - 1}` },
+      ],
+    };
+  }
+  $defs.recursive = {
+    type: "object",
+    properties: { child: { $ref: "#/$defs/recursive" } },
+  };
+  const schema = {
+    type: "object",
+    properties: {
+      dag: { $ref: "#/$defs/d18" },
+      recursive: { $ref: "#/$defs/recursive" },
+    },
+    $defs,
+  };
+  const sourceBytes = Buffer.byteLength(JSON.stringify(schema));
+  const repaired = nonRecursiveToolSchema(schema);
+  const repairedBytes = Buffer.byteLength(JSON.stringify(repaired));
+
+  assert.equal(repaired.properties.dag.$ref, "#/$defs/d18");
+  assert.equal(repaired.$defs.d18.anyOf[0].$ref, "#/$defs/d17");
+  assert.deepEqual(repaired.$defs.recursive.properties.child, {});
+  assert.ok(
+    repairedBytes < sourceBytes * 2,
+    `shared DAG expanded from ${sourceBytes} to ${repairedBytes} bytes`,
+  );
+});
+
+test("cycle repair preserves boolean and unresolved local refs", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      allowed: { $ref: "#/$defs/allowed" },
+      unknown: { $ref: "#/$defs/missing" },
+      recursive: { $ref: "#/$defs/recursive" },
+    },
+    $defs: {
+      allowed: true,
+      recursive: {
+        type: "object",
+        properties: { next: { $ref: "#/$defs/recursive" } },
+      },
+    },
+  };
+  const repaired = nonRecursiveToolSchema(schema);
+  assert.equal(repaired.$defs.allowed, true);
+  assert.equal(repaired.properties.allowed.$ref, "#/$defs/allowed");
+  assert.equal(repaired.properties.unknown.$ref, "#/$defs/missing");
+  assert.deepEqual(repaired.$defs.recursive.properties.next, {});
+});
+
+// The recursive implementation overflowed at depth 2,000 on the supported
+// Node 22 runtime. Use 4,000 so this regression remains effective on runtimes
+// whose JavaScript stack happens to be larger.
+test("a 4,000-level recursive schema is repaired", () => {
+  const depth = 4_000;
+  let node = {
+    properties: { cycle: { $ref: "#/$defs/node" } },
+  };
+  for (let index = 0; index < depth; index += 1) {
+    node = { properties: { next: node } };
+  }
+  const repaired = nonRecursiveToolSchema({ $defs: { node } });
+  let cursor = repaired.$defs.node;
+  for (let index = 0; index < depth; index += 1) {
+    cursor = cursor.properties.next;
+  }
+  assert.deepEqual(cursor.properties.cycle, {});
+});
+
+test("cycle repair never interprets refs inside literal JSON Schema payloads", () => {
+  const literalPayloads = {
+    const: {
+      $ref: "#/$defs/recursive",
+      nested: { $ref: "#/properties/payload" },
+    },
+    default: { $ref: "#/$defs/recursive" },
+    examples: [{ $ref: "#/$defs/recursive" }],
+    enum: [{ $ref: "#/$defs/recursive" }, { ordinary: true }],
+  };
+  const schema = {
+    type: "object",
+    properties: {
+      payload: { type: "object", ...literalPayloads },
+      recursive: { $ref: "#/$defs/recursive" },
+    },
+    $defs: {
+      recursive: {
+        type: "object",
+        properties: { next: { $ref: "#/$defs/recursive" } },
+      },
+    },
+  };
+  const before = JSON.stringify(literalPayloads);
+
+  const repaired = nonRecursiveToolSchema(schema);
+  const payload = repaired.properties.payload;
+  assert.equal(
+    JSON.stringify({
+      const: payload.const,
+      default: payload.default,
+      examples: payload.examples,
+      enum: payload.enum,
+    }),
+    before,
+  );
+  assert.deepEqual(repaired.$defs.recursive.properties.next, {});
+});
 
 test("object-rooted schemas are returned untouched", () => {
   const schema = { type: "object", properties: { path: { type: "string" } }, required: ["path"] };


### PR DESCRIPTION
Supersedes #341 on current main after #348 fixed the stream shutdown blocker.

This clean replacement preserves the two original feature commits byte-for-byte:
- route Muse Contributor Free through the Responses variant
- bridge Muse and Ox custom tools with model-exact, collision-safe transforms

Verification:
- npm run check
- 229 focused tests: 228 passed, 1 Windows-only skip, 0 failed
- cancellation regression completes in about 3.16 seconds instead of about 118 seconds
- full local test suite completed with no failures
- independent Luna exact-head audit: MERGE

Merge only after every required GitHub check is green.