### PR TITLE
fix(panel): serve i18n.mjs so the browser panel renders

### DIFF
--- a/src/desktop-panel.mjs
+++ b/src/desktop-panel.mjs
@@ -29,6 +29,7 @@ const ASSETS = new Map([
   ["/panel/styles.css", { file: "styles.css", type: "text/css; charset=utf-8" }],
   ["/panel/app.js", { file: "app.js", type: "text/javascript; charset=utf-8" }],
   ["/panel/model.mjs", { file: "model.mjs", type: "text/javascript; charset=utf-8" }],
+  ["/panel/i18n.mjs", { file: "i18n.mjs", type: "text/javascript; charset=utf-8" }],
   [
     "/panel/thinking-orb.mjs",
     { file: "thinking-orb.mjs", type: "text/javascript; charset=utf-8" },

--- a/test/desktop-panel.test.mjs
+++ b/test/desktop-panel.test.mjs
@@ -71,11 +71,43 @@ test("the panel serves each asset the UI loads", async () => {
       ["/panel/styles.css", /text\/css/],
       ["/panel/app.js", /javascript/],
       ["/panel/model.mjs", /javascript/],
+      ["/panel/i18n.mjs", /javascript/],
       ["/panel/thinking-orb.mjs", /javascript/],
     ]) {
       const response = await fetch(url(asset));
       assert.equal(response.status, 200, `${asset} did not serve`);
       assert.match(response.headers.get("content-type"), pattern, asset);
+    }
+  } finally {
+    await close();
+  }
+});
+
+// #350: i18n.mjs shipped in apps/desktop/ui and was imported by both app.js and
+// model.mjs, but was never added to the panel's allowlist, so the module graph
+// failed to load and the panel rendered blank. The list above is hand-written
+// and drifted; this derives the expectation from what the UI actually imports,
+// so the next module added to the graph cannot repeat it.
+test("every module the panel UI imports is on the allowlist", async () => {
+  const entryPoints = ["app.js", "model.mjs", "thinking-orb.mjs", "i18n.mjs"];
+  const required = new Set();
+  for (const entry of entryPoints) {
+    const source = readFileSync(new URL(`../apps/desktop/ui/${entry}`, import.meta.url), "utf8");
+    for (const [, specifier] of source.matchAll(/from\s+"\.\/([\w.-]+\.m?js)"/g)) {
+      required.add(specifier);
+    }
+  }
+  assert.ok(required.has("i18n.mjs"), "expected the UI to import i18n.mjs");
+
+  const { url, close } = await serve();
+  try {
+    for (const file of required) {
+      const response = await fetch(url(`/panel/${file}`));
+      assert.equal(
+        response.status,
+        200,
+        `${file} is imported by the panel UI but is not served; add it to ASSETS in src/desktop-panel.mjs`,
+      );
     }
   } finally {
     await close();


### PR DESCRIPTION
Fixes #350.

`apps/desktop/ui/i18n.mjs` shipped with the Arabic/Hindi/Japanese/Korean UI work and is imported by **both** `app.js` and `model.mjs`, but it was never added to the panel's `ASSETS` allowlist in `src/desktop-panel.mjs`. `isPanelRoute` gates on `ASSETS.has(route)`, so the request 404'd, the ES module graph rejected, and the panel rendered blank.

The reporter's diagnosis and suggested one-line patch were both correct.

## Why it got through

`test/desktop-panel.test.mjs` already had "the panel serves each asset the UI loads" — but it carried a **hand-written** list of modules, so it could not notice a new one. That is the drift that produced this bug.

This adds a second test that derives the expectation from the `from "./X.mjs"` imports in the UI's own entry points, so a module added to the graph without an allowlist entry now fails loudly with an actionable message.

## Verification

Confirmed the new test is a real regression test — with the `ASSETS` entry removed it fails with:

```
i18n.mjs is imported by the panel UI but is not served; add it to ASSETS in src/desktop-panel.mjs
```

- `node scripts-check.mjs` — passes
- `node --test test/*.test.mjs` — 2099 tests, **0 failures**, 13 pre-existing environmental skips

No behavior change beyond serving one additional static module: the route stays behind the same caller capability, GET-only, with the same CSP and `nosniff` headers as the other modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)