### PR TITLE
fix(opencode-go): correct GLM-5.3 to its 1M context window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **GLM-5.3 on opencode Go serves its real 1M context.** The entry still
+  carried 200,000/180,000 -- the GLM-5.1 lineage default that #244 established
+  is wrong for 5.3, where a live probe accepted 990,020 prompt tokens. Both
+  Z.ai GLM-5.3 entries were corrected then; this opencode Go entry was missed,
+  so a session was compacting at 180K against a model that serves a million.
+  Its GLM-5.1 and GLM-5.2 siblings on the same gateway already declare
+  1,048,576, so 1,000,000/900,000 stays conservative against the relay.
+  Standalone web search stays off for this route until the opencode Go relay
+  is verified to preserve tool/function-call history.
+
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was
   required. The Grok OAuth boundary now presents that tool as `inspect_image`

--- a/config/opencode/go/glm-5.3.json
+++ b/config/opencode/go/glm-5.3.json
@@ -8,7 +8,7 @@
       "provider": "opencode-go",
       "listed": true,
       "displayName": "GLM-5.3 (opencode Go)",
-      "description": "GLM-5.3 through the opencode Go subscription.",
+      "description": "GLM-5.3 through the opencode Go subscription. Serves the GLM-5.3 1M context lineage; the 200K figure it previously carried belongs to GLM-5.1.",
       "priority": 30,
       "defaultEffort": "max",
       "reasoningLevels": [
@@ -21,12 +21,12 @@
           "description": "Maximum reasoning depth"
         }
       ],
-      "contextWindow": 200000,
-      "autoCompact": 180000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-glm-5-3-v1"
+      "compHash": "opencode-go-glm-5-3-v2"
     }
   ]
 }

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -190,8 +190,10 @@ history. The managed Codex provider table must also set
 field); older clients ignore the field and continue without standalone search.
 
 The checked-in registry currently enables this mode for DeepSeek V4 Flash on
-its direct API and opencode Go routes. Other provider/model pairs stay off
-until verified. User-model curation can opt in locally without changing the
+its direct API and opencode Go routes, DeepSeek V4 Flash Vision Exp, Xiaomi
+MiMo v2.5, and GLM-5.3 on the Z.ai Coding Plan. Other provider/model pairs
+stay off until verified -- including GLM-5.3 on the opencode Go relay, which
+is a different transport from the Z.ai route the capability was proven on. User-model curation can opt in locally without changing the
 shared registry.
 
 ## Transport and compaction

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -581,6 +581,24 @@ test("DeepSeek V4 Flash Vision Exp advertises only verified direct-API capabilit
   assert.ok(API_MODELS.includes(model));
 });
 
+test("GLM-5.3 on OpenCode Go carries the 1M GLM-5.3 window, not GLM-5.1's 200K", () => {
+  const model = MODEL_BY_SLUG.get("opencode-go/glm-5.3");
+  assert.equal(model?.contextWindow, 1_000_000);
+  assert.equal(model?.autoCompact, 900_000);
+  // The sibling GLM entries on this same gateway already serve 1,048,576, so
+  // the gateway does not clamp the family; 1M stays conservative against them.
+  for (const sibling of ["opencode-go/glm-5.1", "opencode-go/glm-5.2"]) {
+    assert.ok(
+      MODEL_BY_SLUG.get(sibling)?.contextWindow >= model.contextWindow,
+      `${sibling} should not serve less than glm-5.3`,
+    );
+  }
+  // Standalone search stays off: docs/HOW-IT-WORKS.md requires per-route
+  // verification that the upstream preserves tool/function-call history, and
+  // no probe of the opencode Go relay has been recorded.
+  assert.equal(model?.searchTool, undefined);
+});
+
 test("GLM-5.3 Coding Plan opts in to GPT-5.6 behavior, concise execution, and standalone search", () => {
   const model = MODEL_BY_SLUG.get("zai-coding/glm-5.3");
   assert.equal(model?.behaviorTemplate, "gpt-5.6-sol");


### PR DESCRIPTION
Supersedes the context half of #335. Opened as a fresh branch because #335 conflicts with main and I am deliberately **not** taking its second change.

## What this takes from #335

`config/opencode/go/glm-5.3.json` still carried `contextWindow: 200000 / autoCompact: 180000`. #244 established that figure belongs to the **GLM-5.1** lineage, not 5.3 — a live probe accepted 990,020 prompt tokens — and 908a096 moved both Z.ai GLM-5.3 entries to 1,000,000/900,000. This third route was simply missed, so sessions on it compact at 180K against a model that serves a million.

**1M is conservative for this relay, not optimistic.** `glm-5.1` and `glm-5.2` on the *same* opencode Go gateway already declare 1,048,576, so the gateway demonstrably does not clamp the GLM family the way it clamps `grok-4.5` to 500K.

## What this deliberately drops from #335

#335 also set `"searchTool": { "mode": "standalone" }`. I have left that off.

`docs/HOW-IT-WORKS.md` is explicit: *"Only enable it after verifying that the provider's model accepts Codex's web-search result items and preserves tool/function-call history."* Every existing opt-in in the tree carries that evidence — `zai-coding/glm-5.3` even records the probe in its `description`. #335 carries none, and the opencode Go relay is a **different transport** from the Z.ai endpoint where the capability was proven. An unverified opt-in fails turns silently rather than loudly, so it should land separately once someone probes a web-search turn through opencode Go.

## Also fixed

The list of standalone-search routes in `docs/HOW-IT-WORKS.md` named two of the five actually in the registry. Corrected, and it now explicitly records why opencode Go's GLM-5.3 stays off.

## Verification

- `node scripts-check.mjs` — passes
- `node --test test/*.test.mjs` — 2100 tests, **0 failures**, 13 pre-existing skips

The new registry test asserts the window, asserts it stays at or below its 1,048,576 siblings on the same gateway, and asserts `searchTool` is still `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)