### PR TITLE
fix(homebrew): dispatch the packaged command through bin/codex-router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **Homebrew installs can reach every command again.** The formula's PATH shim
+  exec'd `bin/model-router codex`, whose fixed whitelist has no entry for
+  `curate-models`, `discover-models`, `refresh-catalog`, `test-model`,
+  `support-bundle`, or `control` -- so a packaged user had no way to add a
+  custom provider's models, and a bare `codex-router` or `codex-router --help`
+  printed `model-router`'s usage instead of the packaged command list. The shim
+  now dispatches through `bin/codex-router`, which exists for exactly this
+  case. `post_install` gets its own private entry point, because
+  `bin/codex-router` refuses `install` by design. Reported in #334.
+
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was
   required. The Grok OAuth boundary now presents that tool as `inspect_image`

--- a/Formula/codex-router.rb
+++ b/Formula/codex-router.rb
@@ -603,6 +603,12 @@ class CodexRouter < Formula
       end
     end
 
+    # bin/codex-router is the dispatcher written for exactly this case: a
+    # package manager puts one name on PATH, not a directory of them. Routing
+    # through "bin/model-router codex" instead stranded every command outside
+    # that script's fixed whitelist -- curate-models, discover-models,
+    # refresh-catalog, test-model, support-bundle, control -- and made a bare
+    # "codex-router" or "codex-router --help" print model-router's usage.
     (bin/"codex-router").write <<~SH
       #!/bin/sh
       source_root=$(CDPATH= cd -- "#{opt_libexec}" && pwd -P)
@@ -610,8 +616,24 @@ class CodexRouter < Formula
       export CODEX_ROUTER_SOURCE_ROOT="$source_root"
       export CODEX_ROUTER_NODE_BIN="#{formula_opt_bin("node")}/node"
       export CODEX_ROUTER_PACKAGE_MANAGER=homebrew
-      exec "$source_root/bin/model-router" codex "$@"
+      exec "$source_root/bin/codex-router" "$@"
     SH
+
+    # bin/codex-router deliberately refuses "install": a packaged install has
+    # no writable checkout to rewrite, so it must never be a user-facing verb.
+    # post_install still legitimately needs the installer after brew upgrade,
+    # so it gets its own private entry point rather than a hole in the
+    # dispatcher.
+    (libexec/"packaged-install").write <<~SH
+      #!/bin/sh
+      source_root=$(CDPATH= cd -- "#{opt_libexec}" && pwd -P)
+      export PATH="#{formula_opt_bin("node")}:$PATH"
+      export CODEX_ROUTER_SOURCE_ROOT="$source_root"
+      export CODEX_ROUTER_NODE_BIN="#{formula_opt_bin("node")}/node"
+      export CODEX_ROUTER_PACKAGE_MANAGER=homebrew
+      exec "$source_root/bin/install" "$@"
+    SH
+    chmod 0755, libexec/"packaged-install"
   end
 
   def post_install
@@ -623,7 +645,7 @@ class CodexRouter < Formula
     manifest = JSON.parse(manifest_path.read)
     return if manifest.dig("current", "packageManager") != "homebrew"
 
-    system bin/"codex-router", "install"
+    system libexec/"packaged-install"
   rescue JSON::ParserError
     opoo "Existing Codex Router install manifest is invalid; run `codex-router setup`."
   end
@@ -632,6 +654,10 @@ class CodexRouter < Formula
     <<~EOS
       Finish the one-time Codex integration with:
         codex-router setup --guided
+
+      List every available command, including `codex-router curate-models`
+      for adding a custom provider's models, with:
+        codex-router help
 
       Before `brew uninstall codex-router`, remove the per-user service and
       managed Codex config with:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,33 @@ Upgrade an existing Homebrew installation with:
 brew upgrade codex-router
 ```
 
+#### Homebrew command equivalents
+
+A Homebrew install puts a single `codex-router` command on your PATH instead
+of this repository's `bin/` directory. Wherever the rest of this README shows
+`./bin/model-router codex <command>` or `./bin/<command>`, run:
+
+```sh
+codex-router <command>
+```
+
+List everything the packaged build exposes with:
+
+```sh
+codex-router help
+```
+
+To add a custom provider's models — the packaged equivalent of
+`./bin/curate-models <provider>` — run:
+
+```sh
+codex-router curate-models <provider>
+```
+
+`codex-router install` is deliberately unavailable: a Homebrew install has no
+writable checkout to rewrite, and `brew upgrade codex-router` performs that
+step itself.
+
 Before removing the formula, remove the per-user service and managed Codex
 configuration that Homebrew does not own:
 

--- a/packaging/homebrew/generate-formula.mjs
+++ b/packaging/homebrew/generate-formula.mjs
@@ -303,6 +303,12 @@ ${exclusionComment}${resourceBlocks}
       end
     end
 
+    # bin/codex-router is the dispatcher written for exactly this case: a
+    # package manager puts one name on PATH, not a directory of them. Routing
+    # through "bin/model-router codex" instead stranded every command outside
+    # that script's fixed whitelist -- curate-models, discover-models,
+    # refresh-catalog, test-model, support-bundle, control -- and made a bare
+    # "codex-router" or "codex-router --help" print model-router's usage.
     (bin/"codex-router").write <<~SH
       #!/bin/sh
       source_root=$(CDPATH= cd -- "#{opt_libexec}" && pwd -P)
@@ -310,8 +316,24 @@ ${exclusionComment}${resourceBlocks}
       export CODEX_ROUTER_SOURCE_ROOT="$source_root"
       export CODEX_ROUTER_NODE_BIN="#{formula_opt_bin("node")}/node"
       export CODEX_ROUTER_PACKAGE_MANAGER=homebrew
-      exec "$source_root/bin/model-router" codex "$@"
+      exec "$source_root/bin/codex-router" "$@"
     SH
+
+    # bin/codex-router deliberately refuses "install": a packaged install has
+    # no writable checkout to rewrite, so it must never be a user-facing verb.
+    # post_install still legitimately needs the installer after brew upgrade,
+    # so it gets its own private entry point rather than a hole in the
+    # dispatcher.
+    (libexec/"packaged-install").write <<~SH
+      #!/bin/sh
+      source_root=$(CDPATH= cd -- "#{opt_libexec}" && pwd -P)
+      export PATH="#{formula_opt_bin("node")}:$PATH"
+      export CODEX_ROUTER_SOURCE_ROOT="$source_root"
+      export CODEX_ROUTER_NODE_BIN="#{formula_opt_bin("node")}/node"
+      export CODEX_ROUTER_PACKAGE_MANAGER=homebrew
+      exec "$source_root/bin/install" "$@"
+    SH
+    chmod 0755, libexec/"packaged-install"
   end
 
   def post_install
@@ -323,7 +345,7 @@ ${exclusionComment}${resourceBlocks}
     manifest = JSON.parse(manifest_path.read)
     return if manifest.dig("current", "packageManager") != "homebrew"
 
-    system bin/"codex-router", "install"
+    system libexec/"packaged-install"
   rescue JSON::ParserError
     opoo "Existing Codex Router install manifest is invalid; run \`codex-router setup\`."
   end
@@ -332,6 +354,10 @@ ${exclusionComment}${resourceBlocks}
     <<~EOS
       Finish the one-time Codex integration with:
         codex-router setup --guided
+
+      List every available command, including \`codex-router curate-models\`
+      for adding a custom provider's models, with:
+        codex-router help
 
       Before \`brew uninstall codex-router\`, remove the per-user service and
       managed Codex config with:

--- a/test/homebrew-formula.test.mjs
+++ b/test/homebrew-formula.test.mjs
@@ -156,7 +156,18 @@ test("the generated formula owns upgrades and preserves one-time setup", () => {
   assert.match(formula, /install_plan = libexec\/"src\/install-plan\.mjs"/);
   assert.match(formula, /if install_plan\.exist\?/);
   assert.match(formula, /install_plan, "record", "node-deps"/);
-  assert.match(formula, /exec "\$source_root\/bin\/model-router" codex "\$@"/);
+  // #334: the PATH shim used to exec `bin/model-router codex`, whose fixed
+  // whitelist stranded curate-models, discover-models, refresh-catalog,
+  // test-model, support-bundle and control, and made a bare `codex-router`
+  // print the wrong usage. It must go through the packaged dispatcher.
+  assert.match(formula, /exec "\$source_root\/bin\/codex-router" "\$@"/);
+  assert.doesNotMatch(formula, /bin\/model-router" codex/);
+  // bin/codex-router refuses `install` on purpose, so post_install must not
+  // reach the installer through the dispatcher -- that pairing would break
+  // every `brew upgrade` the moment the shim was repointed.
+  assert.match(formula, /system libexec\/"packaged-install"/);
+  assert.doesNotMatch(formula, /system bin\/"codex-router", "install"/);
+  assert.match(formula, /exec "\$source_root\/bin\/install" "\$@"/);
   assert.match(formula, /manifest\.dig\("current", "packageManager"\) != "homebrew"/);
   assert.match(formula, /codex-router setup --guided/);
   assert.match(formula, /codex-router uninstall/);


### PR DESCRIPTION
Fixes #334.

## The bug

The formula's PATH shim exec'd `bin/model-router codex "$@"`. That script takes a **fixed command whitelist**:

```
setup|install|doctor|status|provider-key|providers|enable|disable|multi-agent|media|panel|local-mlx|uninstall|smoke-test|start|stop|update|rollback|subagent-preset|shim
```

Anything else exits 2. So on a Homebrew install, `curate-models`, `discover-models`, `refresh-catalog`, `test-model`, `support-bundle`, `api-key` and `control` were all **unreachable** — and `curate-models` is *the* command for adding a custom provider's models. That is precisely the reporter's "cannot find a way to config a custom providers".

`--help` is not in that list either, which is why `codex-router --help` printed `Unknown command: --help`, and a bare `codex-router` printed `Usage: model-router TARGET COMMAND`.

## The fix

`bin/codex-router` already exists for exactly this case — its header comment says *"a package manager puts one name on PATH, not a directory of them"* — and it carries the correct grouped help. The shim now dispatches to it.

Target selection is unchanged: `bin/codex-router` sets no `MODEL_ROUTER_TARGET`, and `src/paths.mjs` defaults `TARGET` to `"codex"`, so every command that worked before behaves identically.

## The trap this had to avoid

`post_install` ran `system bin/"codex-router", "install"` — and `bin/codex-router` **deliberately refuses `install`**, because a packaged install has no writable checkout to rewrite. Repointing the shim alone would have broken every `brew upgrade`.

`post_install` now runs a private `libexec/packaged-install` entry point instead, which keeps `install` out of the user-facing dispatcher while still letting the formula reach the installer.

## Verified behavior

Before → `Unknown command: --help` + `model-router` usage.
After → the packaged grouped help, and all five previously-stranded commands dispatch.

## Also

- `README.md` gains a "Homebrew command equivalents" section naming `codex-router curate-models <provider>` for custom models, since every other command in the README is shown in checkout-only form.
- `caveats` points at `codex-router help`.
- The formula test previously asserted the `model-router` shim **verbatim**, pinning the bug in place. It now asserts the dispatcher form and guards the `post_install` pairing in both directions, so this cannot silently regress.
- `Formula/codex-router.rb` regenerated; `packaging/homebrew/check-formula.mjs` reports `{"checked":true,"drifted":false}`.

## Verification

- `node scripts-check.mjs` — passes
- `node --test test/*.test.mjs` — 2099 tests, **0 failures**, 13 pre-existing skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)