### PR TITLE
fix: keep /health answering during concurrent streaming turns (reviewed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@
   streaming socket), loopback liveliness probes use a separate dispatcher so
   they cannot queue behind those streams, and `/health` serves the last probe
   result immediately while a slow LiteLLM liveliness check refreshes in the
-  background. The tray was reporting Starting and Codex "waiting for network"
-  with two or three in-flight turns even though the router was still
-  generating. Large request bodies also yield once before `JSON.parse` so a
-  health poll can be answered between them.
+  background. Probe GETs use undici's own `fetch` with that extra Agent:
+  Node's builtin `fetch` rejects an npm-undici dispatcher (`invalid
+  onRequestStart method`), every liveliness check looks dead, and startup
+  then kills a router that answered HTTP 503 for 30s. The tray was reporting
+  Starting and Codex "waiting for network" with two or three in-flight turns
+  even though the router was still generating. Large request bodies also
+  yield once before `JSON.parse` so a health poll can be answered between
+  them.
 
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,20 @@
 ## Unreleased
 
 - **Concurrent Codex turns no longer stall `/health` and the next request.**
-  The process-wide fetch pool now keeps 32 HTTP/1.1 connections per origin
-  (undici's default of 10 filled up once a parent plus subagents each held a
-  streaming socket), loopback liveliness probes use a separate dispatcher so
-  they cannot queue behind those streams, and `/health` serves the last probe
-  result immediately while a slow LiteLLM liveliness check refreshes in the
-  background. Probe GETs use undici's own `fetch` with that extra Agent:
-  Node's builtin `fetch` rejects an npm-undici dispatcher (`invalid
-  onRequestStart method`), every liveliness check looks dead, and startup
-  then kills a router that answered HTTP 503 for 30s. The tray was reporting
-  Starting and Codex "waiting for network" with two or three in-flight turns
-  even though the router was still generating. Large request bodies also
-  yield once before `JSON.parse` so a health poll can be answered between
-  them.
+  Loopback liveliness probes use a separate dispatcher so they cannot queue
+  behind long-lived SSE sockets, and `/health` serves a recent probe result
+  immediately while a slow LiteLLM liveliness check refreshes in the
+  background. The snapshot is still bounded: once it is older than 15s the
+  next `/health` waits for a live probe, so a tray-less `doctor` cannot
+  inherit an hours-old "reachable". Probe GETs use undici's own `fetch` with
+  that extra Agent (Node's builtin `fetch` rejects an npm-undici dispatcher)
+  and the same `NODE_USE_ENV_PROXY` selection as routed traffic. The
+  process-wide HTTP/1.1 pool stays unbounded -- a numeric `connections` cap
+  would queue later turns across every installed client. Disconnect handlers
+  are registered before the `JSON.parse` yield so a canceled turn cannot
+  start an upstream fetch. The tray was reporting Starting and Codex
+  "waiting for network" with two or three in-flight turns even though the
+  router was still generating.
 
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Concurrent Codex turns no longer stall `/health` and the next request.**
+  The process-wide fetch pool now keeps 32 HTTP/1.1 connections per origin
+  (undici's default of 10 filled up once a parent plus subagents each held a
+  streaming socket), loopback liveliness probes use a separate dispatcher so
+  they cannot queue behind those streams, and `/health` serves the last probe
+  result immediately while a slow LiteLLM liveliness check refreshes in the
+  background. The tray was reporting Starting and Codex "waiting for network"
+  with two or three in-flight turns even though the router was still
+  generating. Large request bodies also yield once before `JSON.parse` so a
+  health poll can be answered between them.
+
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was
   required. The Grok OAuth boundary now presents that tool as `inspect_image`

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -10,20 +10,15 @@ import { KEEPALIVE_TIMEOUT_MS } from "./http-utils.mjs";
 // require HTTP/2; an HTTP/1.1-only dispatcher removes that poisoned-session
 // state while retaining keep-alive connection reuse.
 //
-// Concurrent Codex turns (parent plus subagents) each hold one HTTP/1.1
-// streaming socket for the whole generation. Undici's default of 10
-// connections per origin plus a shared pool for loopback health probes
-// starves `/health` and the next turn: the probe waits for a free socket
-// that a long SSE response is sitting on, the tray reports Starting, and
-// Codex surfaces "waiting for network". Size the pool for several parallel
-// sessions, and keep idle sockets as long as the router server does so
+// Concurrent Codex turns each hold one HTTP/1.1 streaming socket for the
+// whole generation. Do not cap `connections`: Undici's HTTP/1.1 pool is
+// unbounded by default, and one router plane serves every installed client.
+// A numeric ceiling queues the next turn once it fills and recreates
+// "waiting for network". Keep idle sockets as long as the router server so
 // Codex's 90s client pool is not handed a dead connection.
-export const FETCH_CONNECTIONS_PER_ORIGIN = 32;
-
 export function fetchDispatcherOptions() {
   return {
     allowH2: false,
-    connections: FETCH_CONNECTIONS_PER_ORIGIN,
     pipelining: 1,
     keepAliveTimeout: KEEPALIVE_TIMEOUT_MS,
   };
@@ -54,11 +49,16 @@ export function installStableFetchTransport({
 // probe looks unreachable, and `/health` stays 503 until startup gives up.
 export function createLoopbackProbeDispatcher({
   AgentClass = Agent,
+  EnvHttpProxyAgentClass = EnvHttpProxyAgent,
+  environment = process.env,
+  execArgv = process.execArgv,
   timeoutMs = 3_000,
 } = {}) {
-  return new AgentClass({
+  const DispatcherClass = environmentHttpProxyConfigured(environment, execArgv)
+    ? EnvHttpProxyAgentClass
+    : AgentClass;
+  return new DispatcherClass({
     allowH2: false,
-    connections: 8,
     pipelining: 1,
     keepAliveTimeout: 10_000,
     headersTimeout: timeoutMs,

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -1,6 +1,7 @@
 import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 
 import { environmentHttpProxyConfigured } from "./proxy-environment.mjs";
+import { KEEPALIVE_TIMEOUT_MS } from "./http-utils.mjs";
 
 // Node 26's bundled fetch negotiates HTTP/2 by default. A live router process
 // observed its pooled session remain destroyed after ERR_HTTP2_INVALID_SESSION,
@@ -8,6 +9,26 @@ import { environmentHttpProxyConfigured } from "./proxy-environment.mjs";
 // service. Codex uses streaming Responses over ordinary HTTPS and does not
 // require HTTP/2; an HTTP/1.1-only dispatcher removes that poisoned-session
 // state while retaining keep-alive connection reuse.
+//
+// Concurrent Codex turns (parent plus subagents) each hold one HTTP/1.1
+// streaming socket for the whole generation. Undici's default of 10
+// connections per origin plus a shared pool for loopback health probes
+// starves `/health` and the next turn: the probe waits for a free socket
+// that a long SSE response is sitting on, the tray reports Starting, and
+// Codex surfaces "waiting for network". Size the pool for several parallel
+// sessions, and keep idle sockets as long as the router server does so
+// Codex's 90s client pool is not handed a dead connection.
+export const FETCH_CONNECTIONS_PER_ORIGIN = 32;
+
+export function fetchDispatcherOptions() {
+  return {
+    allowH2: false,
+    connections: FETCH_CONNECTIONS_PER_ORIGIN,
+    pipelining: 1,
+    keepAliveTimeout: KEEPALIVE_TIMEOUT_MS,
+  };
+}
+
 export function installStableFetchTransport({
   AgentClass = Agent,
   EnvHttpProxyAgentClass = EnvHttpProxyAgent,
@@ -18,7 +39,26 @@ export function installStableFetchTransport({
   const DispatcherClass = environmentHttpProxyConfigured(environment, execArgv)
     ? EnvHttpProxyAgentClass
     : AgentClass;
-  const dispatcher = new DispatcherClass({ allowH2: false });
+  const dispatcher = new DispatcherClass(fetchDispatcherOptions());
   setDispatcher(dispatcher);
   return dispatcher;
+}
+
+// Health probes must not share the streaming pool. A GET /health/liveliness
+// that queues behind five SSE POSTs to the same origin is what made the
+// unauthenticated `/health` leaf hang long enough for doctor and the tray
+// to call the router dead.
+export function createLoopbackProbeDispatcher({
+  AgentClass = Agent,
+  timeoutMs = 3_000,
+} = {}) {
+  return new AgentClass({
+    allowH2: false,
+    connections: 8,
+    pipelining: 1,
+    connect: { timeout: Math.min(1_000, timeoutMs) },
+    headersTimeout: timeoutMs,
+    bodyTimeout: timeoutMs,
+    keepAliveTimeout: 10_000,
+  });
 }

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -1,4 +1,4 @@
-import { Agent, EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+import { Agent, EnvHttpProxyAgent, fetch as undiciFetch, setGlobalDispatcher } from "undici";
 
 import { environmentHttpProxyConfigured } from "./proxy-environment.mjs";
 import { KEEPALIVE_TIMEOUT_MS } from "./http-utils.mjs";
@@ -48,6 +48,10 @@ export function installStableFetchTransport({
 // that queues behind five SSE POSTs to the same origin is what made the
 // unauthenticated `/health` leaf hang long enough for doctor and the tray
 // to call the router dead.
+//
+// Use undici's own `fetch` with this Agent. Passing an npm-undici dispatcher
+// into Node's builtin `fetch` throws `invalid onRequestStart method`, every
+// probe looks unreachable, and `/health` stays 503 until startup gives up.
 export function createLoopbackProbeDispatcher({
   AgentClass = Agent,
   timeoutMs = 3_000,
@@ -56,9 +60,12 @@ export function createLoopbackProbeDispatcher({
     allowH2: false,
     connections: 8,
     pipelining: 1,
-    connect: { timeout: Math.min(1_000, timeoutMs) },
+    keepAliveTimeout: 10_000,
     headersTimeout: timeoutMs,
     bodyTimeout: timeoutMs,
-    keepAliveTimeout: 10_000,
   });
+}
+
+export function loopbackProbeFetch(url, init = {}, dispatcher = createLoopbackProbeDispatcher()) {
+  return undiciFetch(url, { ...init, dispatcher });
 }

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -1,7 +1,6 @@
 import { Agent, EnvHttpProxyAgent, fetch as undiciFetch, setGlobalDispatcher } from "undici";
 
 import { environmentHttpProxyConfigured } from "./proxy-environment.mjs";
-import { KEEPALIVE_TIMEOUT_MS } from "./http-utils.mjs";
 
 // Node 26's bundled fetch negotiates HTTP/2 by default. A live router process
 // observed its pooled session remain destroyed after ERR_HTTP2_INVALID_SESSION,
@@ -14,13 +13,18 @@ import { KEEPALIVE_TIMEOUT_MS } from "./http-utils.mjs";
 // whole generation. Do not cap `connections`: Undici's HTTP/1.1 pool is
 // unbounded by default, and one router plane serves every installed client.
 // A numeric ceiling queues the next turn once it fills and recreates
-// "waiting for network". Keep idle sockets as long as the router server so
-// Codex's 90s client pool is not handed a dead connection.
+// "waiting for network".
+//
+// Leave `keepAliveTimeout` at Undici's 4s default. This pool is shared by
+// every outbound provider request, and an upstream that idle-closes without
+// advertising `Keep-Alive: timeout=` hands back a half-closed socket once we
+// hold connections longer than it does -- surfacing as UND_ERR_SOCKET on a
+// POST Undici will not retry. Only the loopback probe pool below, whose one
+// origin is our own server, raises it.
 export function fetchDispatcherOptions() {
   return {
     allowH2: false,
     pipelining: 1,
-    keepAliveTimeout: KEEPALIVE_TIMEOUT_MS,
   };
 }
 
@@ -66,6 +70,17 @@ export function createLoopbackProbeDispatcher({
   });
 }
 
-export function loopbackProbeFetch(url, init = {}, dispatcher = createLoopbackProbeDispatcher()) {
+// One pool for the whole process. Building the Agent in a default parameter
+// made a fresh connection pool on every probe instead, so each `/health` poll
+// left another dispatcher -- and its sockets -- behind with nothing to close
+// them. Created on first use so importing this module opens nothing.
+let sharedProbeDispatcher;
+
+export function loopbackProbeDispatcher() {
+  sharedProbeDispatcher ??= createLoopbackProbeDispatcher();
+  return sharedProbeDispatcher;
+}
+
+export function loopbackProbeFetch(url, init = {}, dispatcher = loopbackProbeDispatcher()) {
   return undiciFetch(url, { ...init, dispatcher });
 }

--- a/src/health-cache.mjs
+++ b/src/health-cache.mjs
@@ -13,24 +13,74 @@ export const DEFAULT_HEALTH_TTL_MS = 3_000;
 export function createHealthCache({
   ttlMs = DEFAULT_HEALTH_TTL_MS,
   now = () => Date.now(),
+  staleWhileRevalidate = false,
 } = {}) {
   const entries = new Map();
 
   return function cachedProbe(key, probe) {
     const existing = entries.get(key);
+    const fresh = Boolean(existing) && now() - existing.at < ttlMs;
     // Concurrent callers share the in-flight promise rather than each starting
     // their own probe, so a burst of polls costs one request, not one each.
-    if (existing && now() - existing.at < ttlMs) return existing.promise;
+    if (fresh) {
+      if (staleWhileRevalidate && existing.lastValue !== undefined) {
+        return Promise.resolve(existing.lastValue);
+      }
+      return existing.promise;
+    }
+    if (existing?.promise && existing.refreshing) {
+      if (staleWhileRevalidate && existing.lastValue !== undefined) {
+        return Promise.resolve(existing.lastValue);
+      }
+      return existing.promise;
+    }
 
     const promise = Promise.resolve()
       .then(probe)
+      .then((value) => {
+        const current = entries.get(key);
+        if (current?.promise === promise) {
+          entries.set(key, {
+            at: now(),
+            promise,
+            lastValue: value,
+            refreshing: false,
+          });
+        }
+        return value;
+      })
       .catch((error) => {
+        const current = entries.get(key);
+        if (staleWhileRevalidate && current?.lastValue !== undefined) {
+          entries.set(key, {
+            ...current,
+            refreshing: false,
+            at: now(),
+          });
+          return current.lastValue;
+        }
         // A thrown probe must not be cached as an answer: drop it so the next
         // caller retries instead of inheriting the failure for the whole TTL.
-        entries.delete(key);
+        if (current?.promise === promise) entries.delete(key);
         throw error;
       });
-    entries.set(key, { at: now(), promise });
+
+    if (staleWhileRevalidate && existing?.lastValue !== undefined) {
+      entries.set(key, {
+        at: now(),
+        promise,
+        lastValue: existing.lastValue,
+        refreshing: true,
+      });
+      return Promise.resolve(existing.lastValue);
+    }
+
+    entries.set(key, {
+      at: now(),
+      promise,
+      lastValue: existing?.lastValue,
+      refreshing: true,
+    });
     return promise;
   };
 }

--- a/src/health-cache.mjs
+++ b/src/health-cache.mjs
@@ -35,7 +35,10 @@ export function createHealthCache({
     // their own probe, so a burst of polls costs one request, not one each.
     if (fresh) {
       if (canServeStale(existing)) return Promise.resolve(existing.lastValue);
-      return existing.promise;
+      // A refresh that threw leaves the value behind but no promise: its own
+      // settled promise resolves to that snapshot, and replaying it here would
+      // hand back an answer older than `maxStaleMs`. Fall through and probe.
+      if (existing.promise) return existing.promise;
     }
     if (existing?.promise && existing.refreshing) {
       if (canServeStale(existing)) return Promise.resolve(existing.lastValue);
@@ -60,11 +63,23 @@ export function createHealthCache({
       })
       .catch((error) => {
         const current = entries.get(key);
-        if (staleWhileRevalidate && current?.lastValue !== undefined) {
+        // The last answer may stand in for a failed refresh only while it is
+        // inside the same `maxStaleMs` bound the nonblocking paths enforce.
+        // Without that check a probe that starts throwing pins `/health` to
+        // whatever it last saw, so a gateway that died an hour ago keeps
+        // reporting reachable for as long as the process lives. `lastValueAt`
+        // deliberately is not touched: the snapshot does not get younger
+        // because a probe failed, and this bound is what expires it.
+        if (canServeStale(current)) {
           entries.set(key, {
-            ...current,
-            refreshing: false,
             at: now(),
+            lastValueAt: current.lastValueAt,
+            // Drop the settled promise rather than caching it as this entry's
+            // answer: it resolves to the snapshot above, and the fresh-window
+            // short circuit would replay it past `maxStaleMs`.
+            promise: undefined,
+            lastValue: current.lastValue,
+            refreshing: false,
           });
           return current.lastValue;
         }

--- a/src/health-cache.mjs
+++ b/src/health-cache.mjs
@@ -9,13 +9,24 @@
 // short: the tray shows live service status, so a stale "reachable" is a lie
 // with a shelf life, and a few seconds is the most that is honest.
 export const DEFAULT_HEALTH_TTL_MS = 3_000;
+// Stale-while-revalidate must not serve an hours-old "reachable" to doctor on a
+// tray-less machine that has not polled since the gateway died. The TTL is the
+// companion's refresh cadence; this is the hard bound on how old a nonblocking
+// snapshot may be before `/health` waits for a live probe.
+export const DEFAULT_MAX_STALE_MS = 15_000;
 
 export function createHealthCache({
   ttlMs = DEFAULT_HEALTH_TTL_MS,
+  maxStaleMs = DEFAULT_MAX_STALE_MS,
   now = () => Date.now(),
   staleWhileRevalidate = false,
 } = {}) {
   const entries = new Map();
+
+  function canServeStale(existing) {
+    if (!staleWhileRevalidate || existing?.lastValue === undefined) return false;
+    return now() - existing.lastValueAt <= maxStaleMs;
+  }
 
   return function cachedProbe(key, probe) {
     const existing = entries.get(key);
@@ -23,15 +34,11 @@ export function createHealthCache({
     // Concurrent callers share the in-flight promise rather than each starting
     // their own probe, so a burst of polls costs one request, not one each.
     if (fresh) {
-      if (staleWhileRevalidate && existing.lastValue !== undefined) {
-        return Promise.resolve(existing.lastValue);
-      }
+      if (canServeStale(existing)) return Promise.resolve(existing.lastValue);
       return existing.promise;
     }
     if (existing?.promise && existing.refreshing) {
-      if (staleWhileRevalidate && existing.lastValue !== undefined) {
-        return Promise.resolve(existing.lastValue);
-      }
+      if (canServeStale(existing)) return Promise.resolve(existing.lastValue);
       return existing.promise;
     }
 
@@ -40,8 +47,10 @@ export function createHealthCache({
       .then((value) => {
         const current = entries.get(key);
         if (current?.promise === promise) {
+          const observedAt = now();
           entries.set(key, {
-            at: now(),
+            at: observedAt,
+            lastValueAt: observedAt,
             promise,
             lastValue: value,
             refreshing: false,
@@ -65,9 +74,10 @@ export function createHealthCache({
         throw error;
       });
 
-    if (staleWhileRevalidate && existing?.lastValue !== undefined) {
+    if (canServeStale(existing)) {
       entries.set(key, {
         at: now(),
+        lastValueAt: existing.lastValueAt,
         promise,
         lastValue: existing.lastValue,
         refreshing: true,
@@ -77,6 +87,7 @@ export function createHealthCache({
 
     entries.set(key, {
       at: now(),
+      lastValueAt: existing?.lastValueAt,
       promise,
       lastValue: existing?.lastValue,
       refreshing: true,

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -117,7 +117,10 @@ import {
 } from "./tool-result-aging-state.mjs";
 import { VERSION } from "./version.mjs";
 import { nativeSessionHeaders } from "./codex-native-session.mjs";
-import { installStableFetchTransport } from "./fetch-transport.mjs";
+import {
+  createLoopbackProbeDispatcher,
+  installStableFetchTransport,
+} from "./fetch-transport.mjs";
 
 installStableFetchTransport();
 
@@ -306,6 +309,14 @@ function parseBody(buffer) {
     wrapped.status = 400;
     throw wrapped;
   }
+}
+
+// Large Codex turns parse several megabytes of JSON on the event loop. Yield
+// first so an already-accepted GET /health can answer instead of sitting
+// behind that parse and looking like a dead router to the tray.
+async function parseBodyAsync(buffer) {
+  await new Promise((resolve) => setImmediate(resolve));
+  return parseBody(buffer);
 }
 
 function decodeBody(body, contentEncoding) {
@@ -750,7 +761,8 @@ function catalogModels() {
 
 // Shared across every /health request so a polling companion collapses into
 // one probe per service per window instead of three per poll.
-const healthCache = createHealthCache();
+const healthCache = createHealthCache({ staleWhileRevalidate: true });
+const loopbackProbeDispatcher = createLoopbackProbeDispatcher();
 
 function serviceHealth(url) {
   return healthCache(url, () => probeService(url));
@@ -761,6 +773,7 @@ async function probeService(url) {
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
       signal: AbortSignal.timeout(3_000),
+      dispatcher: loopbackProbeDispatcher,
     });
     const raw = await response.json().catch(() => undefined);
     const payload = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
@@ -2313,7 +2326,7 @@ async function handleResponses(request, response, requestUrl) {
     if (!requireCodexTransport(request, response)) return;
     const encoded = await readRequestBody(request);
     const body = decodeBody(encoded, request.headers["content-encoding"]);
-    const payload = parseBody(body);
+    const payload = await parseBodyAsync(body);
     requestedModel = typeof payload.model === "string" ? payload.model : "";
     let registeredRoute =
       MODEL_BY_SLUG.get(requestedModel) ??
@@ -3090,7 +3103,7 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
     }
     const encoded = await readRequestBody(request);
     const body = decodeBody(encoded, request.headers["content-encoding"]);
-    const payload = parseBody(body);
+    const payload = await parseBodyAsync(body);
     requestedModel =
       typeof payload.model === "string" ? payload.model : defaultModel;
     activity.setRoute({

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -320,6 +320,15 @@ async function parseBodyAsync(buffer) {
   return parseBody(buffer);
 }
 
+function bindClientAbort(request, response, onAbort) {
+  const abort = () => onAbort();
+  request.once("aborted", abort);
+  response.once("close", () => {
+    if (!response.writableEnded) abort();
+  });
+  if (request.aborted || response.destroyed) abort();
+}
+
 function decodeBody(body, contentEncoding) {
   const value = Array.isArray(contentEncoding)
     ? contentEncoding.join(",")
@@ -2326,6 +2335,11 @@ async function handleResponses(request, response, requestUrl) {
   let finalStatus;
   let activityStatus;
   let usageRecorded = false;
+  const controller = new AbortController();
+  bindClientAbort(request, response, () => {
+    clientGone = true;
+    controller.abort();
+  });
   try {
     if (!requireCodexTransport(request, response)) return;
     const encoded = await readRequestBody(request);
@@ -2379,18 +2393,6 @@ async function handleResponses(request, response, requestUrl) {
       route &&
       Array.isArray(payload.input) &&
       payload.input.at(-1)?.type === "compaction_trigger";
-
-    const controller = new AbortController();
-    request.once("aborted", () => {
-      clientGone = true;
-      controller.abort();
-    });
-    response.once("close", () => {
-      if (!response.writableEnded) {
-        clientGone = true;
-        controller.abort();
-      }
-    });
 
     if (route && (compactV1 || compactV2)) {
       const compaction = await handleRoutedCompaction(
@@ -3097,6 +3099,11 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
   const activity = beginRequestActivity();
   let clientGone = false;
   let requestedModel = defaultModel;
+  const controller = new AbortController();
+  bindClientAbort(request, response, () => {
+    clientGone = true;
+    controller.abort();
+  });
   try {
     if (!requireCodexTransport(request, response)) return;
     // Image and web-search turns are native-only; an idle install refuses
@@ -3114,18 +3121,6 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
       provider: "openai",
       model: requestedModel,
       ...activityMetadataFromHeaders(request.headers),
-    });
-
-    const controller = new AbortController();
-    request.once("aborted", () => {
-      clientGone = true;
-      controller.abort();
-    });
-    response.once("close", () => {
-      if (!response.writableEnded) {
-        clientGone = true;
-        controller.abort();
-      }
     });
 
     const headers = nativeHeaders(request);

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -120,6 +120,7 @@ import { nativeSessionHeaders } from "./codex-native-session.mjs";
 import {
   createLoopbackProbeDispatcher,
   installStableFetchTransport,
+  loopbackProbeFetch,
 } from "./fetch-transport.mjs";
 
 installStableFetchTransport();
@@ -770,11 +771,14 @@ function serviceHealth(url) {
 
 async function probeService(url) {
   try {
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
-      signal: AbortSignal.timeout(3_000),
-      dispatcher: loopbackProbeDispatcher,
-    });
+    const response = await loopbackProbeFetch(
+      url,
+      {
+        headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
+        signal: AbortSignal.timeout(3_000),
+      },
+      loopbackProbeDispatcher,
+    );
     const raw = await response.json().catch(() => undefined);
     const payload = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
     return { ...payload, reachable: response.ok };

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -118,7 +118,6 @@ import {
 import { VERSION } from "./version.mjs";
 import { nativeSessionHeaders } from "./codex-native-session.mjs";
 import {
-  createLoopbackProbeDispatcher,
   installStableFetchTransport,
   loopbackProbeFetch,
 } from "./fetch-transport.mjs";
@@ -772,7 +771,6 @@ function catalogModels() {
 // Shared across every /health request so a polling companion collapses into
 // one probe per service per window instead of three per poll.
 const healthCache = createHealthCache({ staleWhileRevalidate: true });
-const loopbackProbeDispatcher = createLoopbackProbeDispatcher();
 
 function serviceHealth(url) {
   return healthCache(url, () => probeService(url));
@@ -780,14 +778,12 @@ function serviceHealth(url) {
 
 async function probeService(url) {
   try {
-    const response = await loopbackProbeFetch(
-      url,
-      {
-        headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
-        signal: AbortSignal.timeout(3_000),
-      },
-      loopbackProbeDispatcher,
-    );
+    // No dispatcher argument: `loopbackProbeFetch` owns one shared probe pool
+    // for the process, so this cannot fork a second one.
+    const response = await loopbackProbeFetch(url, {
+      headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
+      signal: AbortSignal.timeout(3_000),
+    });
     const raw = await response.json().catch(() => undefined);
     const payload = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
     return { ...payload, reachable: response.ok };

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -10,6 +10,7 @@ import {
   createLoopbackProbeDispatcher,
   fetchDispatcherOptions,
   installStableFetchTransport,
+  loopbackProbeDispatcher,
   loopbackProbeFetch,
 } from "../src/fetch-transport.mjs";
 
@@ -53,11 +54,31 @@ test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
 
   assert.equal(created.length, 1);
   assert.equal(dispatcher.kind, "direct");
-  assert.deepEqual(created[0].options, fetchDispatcherOptions());
-  assert.equal(created[0].options.allowH2, false);
-  assert.equal("connections" in created[0].options, false);
+  assert.deepEqual(created[0].options, { allowH2: false, pipelining: 1 });
   assert.equal(dispatcher, created[0]);
   assert.deepEqual(installed, [dispatcher]);
+});
+
+// Every outbound provider request shares this pool. Holding idle sockets
+// longer than an upstream does hands the next POST a half-closed connection
+// that surfaces as UND_ERR_SOCKET, and Undici will not retry it -- so the
+// process-wide pool keeps Undici's own 4s default and only the loopback
+// probe pool, which talks to our own server, raises it.
+test("the process-wide pool does not hold idle sockets past the undici default", () => {
+  const { created } = installFakeTransport({});
+
+  assert.equal("keepAliveTimeout" in created[0].options, false);
+  assert.equal("connections" in created[0].options, false);
+
+  const probe = createLoopbackProbeDispatcher({
+    AgentClass: class {
+      constructor(options) {
+        this.options = options;
+      }
+    },
+    environment: {},
+  });
+  assert.equal(probe.options.keepAliveTimeout, 10_000);
 });
 
 test("the router uses the environment proxy dispatcher only with explicit opt-in", () => {
@@ -257,4 +278,54 @@ test("loopback probes use undici fetch so a separate Agent is accepted", async (
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
+});
+
+// A default parameter that called the factory built a new Agent -- a whole
+// connection pool -- on every probe, and the router polls /health continuously.
+test("repeated loopback probes share one dispatcher", async () => {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ ok: true }));
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const seen = [];
+  const original = loopbackProbeDispatcher();
+  try {
+    const port = server.address().port;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const response = await loopbackProbeFetch(`http://127.0.0.1:${port}/health`, {
+        signal: AbortSignal.timeout(2_000),
+      });
+      await response.json();
+      seen.push(loopbackProbeDispatcher());
+    }
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+
+  assert.equal(seen.length, 3);
+  for (const dispatcher of seen) assert.equal(dispatcher, original);
+  // The accessor returns the one singleton; the factory still makes new pools,
+  // which is what the default parameter used to do on every single probe.
+  const separate = createLoopbackProbeDispatcher();
+  try {
+    assert.notEqual(original, separate);
+  } finally {
+    await separate.close();
+  }
+});
+
+// Importing the module must not open a pool; only a probe should.
+test("the shared probe dispatcher is built on first use, not at import", () => {
+  const source = readFileSync(path.join(SRC_DIR, "fetch-transport.mjs"), "utf8");
+  assert.match(source, /let sharedProbeDispatcher;/);
+  assert.match(source, /sharedProbeDispatcher \?\?= createLoopbackProbeDispatcher\(\)/);
+  assert.doesNotMatch(
+    source,
+    /^(const|let) \w+ = createLoopbackProbeDispatcher\(\)/m,
+    "a module-level call would open a connection pool for every importer",
+  );
 });

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -6,7 +6,11 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { getGlobalDispatcher, setGlobalDispatcher } from "undici";
 
-import { installStableFetchTransport } from "../src/fetch-transport.mjs";
+import {
+  FETCH_CONNECTIONS_PER_ORIGIN,
+  fetchDispatcherOptions,
+  installStableFetchTransport,
+} from "../src/fetch-transport.mjs";
 
 const SRC_DIR = fileURLToPath(new URL("../src", import.meta.url));
 
@@ -48,7 +52,9 @@ test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
 
   assert.equal(created.length, 1);
   assert.equal(dispatcher.kind, "direct");
-  assert.deepEqual(created[0].options, { allowH2: false });
+  assert.deepEqual(created[0].options, fetchDispatcherOptions());
+  assert.equal(created[0].options.allowH2, false);
+  assert.equal(created[0].options.connections, FETCH_CONNECTIONS_PER_ORIGIN);
   assert.equal(dispatcher, created[0]);
   assert.deepEqual(installed, [dispatcher]);
 });
@@ -65,7 +71,7 @@ test("the router uses the environment proxy dispatcher only with explicit opt-in
     assert.equal(created.length, 1);
     assert.equal(dispatcher.kind, "environment-proxy");
     assert.equal(dispatcher, created[0]);
-    assert.deepEqual(dispatcher.options, { allowH2: false });
+    assert.deepEqual(dispatcher.options, fetchDispatcherOptions());
   }
 });
 
@@ -77,7 +83,7 @@ test("proxy variables alone do not opt the router into proxying", () => {
 
   assert.equal(created.length, 1);
   assert.equal(dispatcher.kind, "direct");
-  assert.deepEqual(dispatcher.options, { allowH2: false });
+  assert.deepEqual(dispatcher.options, fetchDispatcherOptions());
 });
 
 test("the router accepts the NODE_OPTIONS and command-line opt-in forms", () => {
@@ -88,7 +94,7 @@ test("the router accepts the NODE_OPTIONS and command-line opt-in forms", () => 
     const { created, dispatcher } = installFakeTransport(environment, execArgv);
     assert.equal(created.length, 1);
     assert.equal(dispatcher.kind, "environment-proxy");
-    assert.deepEqual(dispatcher.options, { allowH2: false });
+    assert.deepEqual(dispatcher.options, fetchDispatcherOptions());
   }
 });
 
@@ -105,7 +111,7 @@ test("NO_PROXY or ALL_PROXY alone keeps the lower-overhead direct agent", () => 
     assert.equal(created.length, 1);
     assert.equal(dispatcher.kind, "direct");
     assert.equal(dispatcher, created[0]);
-    assert.deepEqual(dispatcher.options, { allowH2: false });
+    assert.deepEqual(dispatcher.options, fetchDispatcherOptions());
   }
 });
 

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { getGlobalDispatcher, setGlobalDispatcher } from "undici";
 
 import {
-  FETCH_CONNECTIONS_PER_ORIGIN,
+  createLoopbackProbeDispatcher,
   fetchDispatcherOptions,
   installStableFetchTransport,
   loopbackProbeFetch,
@@ -55,7 +55,7 @@ test("the router disables HTTP/2 on its process-wide fetch dispatcher", () => {
   assert.equal(dispatcher.kind, "direct");
   assert.deepEqual(created[0].options, fetchDispatcherOptions());
   assert.equal(created[0].options.allowH2, false);
-  assert.equal(created[0].options.connections, FETCH_CONNECTIONS_PER_ORIGIN);
+  assert.equal("connections" in created[0].options, false);
   assert.equal(dispatcher, created[0]);
   assert.deepEqual(installed, [dispatcher]);
 });
@@ -202,6 +202,39 @@ test("every long-lived server process installs the stable transport", () => {
       `${name} creates a server but never installs the stable fetch transport`,
     );
   }
+});
+
+test("loopback health probes use the same proxy opt-in as routed traffic", () => {
+  const created = [];
+  class FakeAgent {
+    constructor(options) {
+      this.kind = "direct";
+      this.options = options;
+      created.push(this);
+    }
+  }
+  class FakeEnvHttpProxyAgent {
+    constructor(options) {
+      this.kind = "environment-proxy";
+      this.options = options;
+      created.push(this);
+    }
+  }
+
+  const proxied = createLoopbackProbeDispatcher({
+    AgentClass: FakeAgent,
+    EnvHttpProxyAgentClass: FakeEnvHttpProxyAgent,
+    environment: { NODE_USE_ENV_PROXY: "1", HTTP_PROXY: "http://proxy.example:8080" },
+  });
+  assert.equal(proxied.kind, "environment-proxy");
+
+  created.length = 0;
+  const direct = createLoopbackProbeDispatcher({
+    AgentClass: FakeAgent,
+    EnvHttpProxyAgentClass: FakeEnvHttpProxyAgent,
+    environment: { HTTP_PROXY: "http://proxy.example:8080" },
+  });
+  assert.equal(direct.kind, "direct");
 });
 
 test("loopback probes use undici fetch so a separate Agent is accepted", async () => {

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -10,6 +10,7 @@ import {
   FETCH_CONNECTIONS_PER_ORIGIN,
   fetchDispatcherOptions,
   installStableFetchTransport,
+  loopbackProbeFetch,
 } from "../src/fetch-transport.mjs";
 
 const SRC_DIR = fileURLToPath(new URL("../src", import.meta.url));
@@ -200,5 +201,27 @@ test("every long-lived server process installs the stable transport", () => {
       source.includes("installStableFetchTransport()"),
       `${name} creates a server but never installs the stable fetch transport`,
     );
+  }
+});
+
+test("loopback probes use undici fetch so a separate Agent is accepted", async () => {
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({ ok: true, service: "gateway" }));
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  try {
+    const port = server.address().port;
+    const response = await loopbackProbeFetch(`http://127.0.0.1:${port}/health/liveliness`, {
+      headers: { Authorization: "Bearer test" },
+      signal: AbortSignal.timeout(2_000),
+    });
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true, service: "gateway" });
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
   }
 });

--- a/test/health-cache.test.mjs
+++ b/test/health-cache.test.mjs
@@ -101,6 +101,7 @@ test("the router probes through the cache, not around it", () => {
   // goes straight to the network again the probe flood comes back silently.
   assert.match(router, /const healthCache = createHealthCache\(\{\s*staleWhileRevalidate:\s*true\s*\}\)/);
   assert.match(router, /function serviceHealth\(url\)\s*\{\s*return healthCache\(url,/);
+  assert.match(router, /loopbackProbeFetch\(/);
 });
 
 test("stale-while-revalidate returns the last answer without waiting on a slow refresh", async () => {

--- a/test/health-cache.test.mjs
+++ b/test/health-cache.test.mjs
@@ -4,7 +4,11 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { DEFAULT_HEALTH_TTL_MS, createHealthCache } from "../src/health-cache.mjs";
+import {
+  DEFAULT_HEALTH_TTL_MS,
+  DEFAULT_MAX_STALE_MS,
+  createHealthCache,
+} from "../src/health-cache.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -152,4 +156,42 @@ test("stale-while-revalidate keeps serving the last answer when the refresh thro
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(await cached("gateway", probe), { reachable: true });
   assert.equal(probes, 2);
+});
+
+test("stale-while-revalidate waits once the snapshot exceeds the max stale age", async () => {
+  const clock = fixedClock();
+  const cached = createHealthCache({
+    ttlMs: 3_000,
+    maxStaleMs: 15_000,
+    now: clock.now,
+    staleWhileRevalidate: true,
+  });
+  let probes = 0;
+  let finishRefresh;
+  const hanging = new Promise((resolve) => {
+    finishRefresh = resolve;
+  });
+  const probe = () => {
+    probes += 1;
+    if (probes === 1) return { reachable: true };
+    return hanging.then(() => ({ reachable: false }));
+  };
+
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  clock.t = 15_001;
+  let settled;
+  const pending = cached("gateway", probe).then((value) => {
+    settled = value;
+    return value;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, undefined);
+  assert.equal(probes, 2);
+  finishRefresh();
+  assert.deepEqual(await pending, { reachable: false });
+});
+
+test("the default max stale age is longer than the companion TTL and still bounded", () => {
+  assert.ok(DEFAULT_MAX_STALE_MS > DEFAULT_HEALTH_TTL_MS);
+  assert.ok(DEFAULT_MAX_STALE_MS <= 30_000);
 });

--- a/test/health-cache.test.mjs
+++ b/test/health-cache.test.mjs
@@ -20,6 +20,11 @@ function fixedClock(start = 0) {
   return clock;
 }
 
+// A background refresh settles a few microtasks after the stale answer is
+// handed back. Let it land before moving the clock, so these assert the cache
+// state a later poll actually sees rather than a half-updated entry.
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
 test("a burst of polls inside the window costs one probe", async () => {
   const clock = fixedClock();
   const cached = createHealthCache({ ttlMs: 3_000, now: clock.now });
@@ -194,4 +199,96 @@ test("stale-while-revalidate waits once the snapshot exceeds the max stale age",
 test("the default max stale age is longer than the companion TTL and still bounded", () => {
   assert.ok(DEFAULT_MAX_STALE_MS > DEFAULT_HEALTH_TTL_MS);
   assert.ok(DEFAULT_MAX_STALE_MS <= 30_000);
+});
+
+// The error branch used to return the last value whenever one existed, with no
+// age check and without moving `lastValueAt`. A gateway that died and kept
+// refusing connections therefore reported "reachable" for as long as the router
+// process lived, which is exactly the lie `maxStaleMs` exists to prevent.
+test("a refresh that keeps throwing stops serving the snapshot past the max stale age", async () => {
+  const clock = fixedClock();
+  const cached = createHealthCache({
+    ttlMs: 3_000,
+    maxStaleMs: 15_000,
+    now: clock.now,
+    staleWhileRevalidate: true,
+  });
+  let probes = 0;
+  const probe = () => {
+    probes += 1;
+    if (probes === 1) return { reachable: true };
+    throw new Error("connection refused");
+  };
+
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  // Inside the bound the last answer legitimately stands in for the failure.
+  clock.t = 3_000;
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  await settle();
+
+  clock.t = 15_001;
+  await assert.rejects(() => cached("gateway", probe), /connection refused/);
+  // And it must not reappear on the next poll: a failed probe does not make
+  // the snapshot it fell back to any younger.
+  clock.t = 20_000;
+  await assert.rejects(() => cached("gateway", probe), /connection refused/);
+  assert.equal(probes, 4);
+});
+
+// The failed refresh marks its entry fresh so a burst of polls during an
+// outage still costs one probe per TTL. That freshness must not become a
+// second way to serve the snapshot: the value's own age is the only bound.
+test("a failed refresh does not replay its snapshot inside the next TTL window", async () => {
+  const clock = fixedClock();
+  const cached = createHealthCache({
+    ttlMs: 3_000,
+    maxStaleMs: 15_000,
+    now: clock.now,
+    staleWhileRevalidate: true,
+  });
+  let probes = 0;
+  const probe = () => {
+    probes += 1;
+    if (probes === 1) return { reachable: true };
+    throw new Error("connection refused");
+  };
+
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  clock.t = 14_900;
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  await settle();
+  assert.equal(probes, 2);
+  // 200ms later the entry is still inside its TTL, but the value it holds is
+  // 15.1s old -- past `maxStaleMs`, so the caller must wait for a live probe.
+  clock.t = 15_100;
+  await assert.rejects(() => cached("gateway", probe), /connection refused/);
+  assert.equal(probes, 3);
+});
+
+// Repeated polls during an outage must still collapse: the throttle survives
+// the age bound, it is only the answer that expires.
+test("failed refreshes inside the bound are still throttled to one probe per window", async () => {
+  const clock = fixedClock();
+  const cached = createHealthCache({
+    ttlMs: 3_000,
+    maxStaleMs: 15_000,
+    now: clock.now,
+    staleWhileRevalidate: true,
+  });
+  let probes = 0;
+  const probe = () => {
+    probes += 1;
+    if (probes === 1) return { reachable: true };
+    throw new Error("connection refused");
+  };
+
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  clock.t = 3_000;
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  await settle();
+  clock.t = 4_000;
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  clock.t = 5_000;
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  assert.equal(probes, 2);
 });

--- a/test/health-cache.test.mjs
+++ b/test/health-cache.test.mjs
@@ -99,6 +99,56 @@ test("the router probes through the cache, not around it", () => {
   const router = readFileSync(path.join(root, "src", "router.mjs"), "utf8");
   // healthPayload calls serviceHealth three times per request; if that ever
   // goes straight to the network again the probe flood comes back silently.
-  assert.match(router, /const healthCache = createHealthCache\(\)/);
+  assert.match(router, /const healthCache = createHealthCache\(\{\s*staleWhileRevalidate:\s*true\s*\}\)/);
   assert.match(router, /function serviceHealth\(url\)\s*\{\s*return healthCache\(url,/);
+});
+
+test("stale-while-revalidate returns the last answer without waiting on a slow refresh", async () => {
+  const clock = fixedClock();
+  const cached = createHealthCache({
+    ttlMs: 3_000,
+    now: clock.now,
+    staleWhileRevalidate: true,
+  });
+  let probes = 0;
+  let finishRefresh;
+  const hanging = new Promise((resolve) => {
+    finishRefresh = resolve;
+  });
+  const probe = () => {
+    probes += 1;
+    if (probes === 1) return { reachable: true };
+    return hanging.then(() => ({ reachable: false }));
+  };
+
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  clock.t = 3_000;
+  const started = Date.now();
+  const stale = await cached("gateway", probe);
+  assert.ok(Date.now() - started < 50);
+  assert.deepEqual(stale, { reachable: true });
+  assert.equal(probes, 2);
+  finishRefresh();
+});
+
+test("stale-while-revalidate keeps serving the last answer when the refresh throws", async () => {
+  const clock = fixedClock();
+  const cached = createHealthCache({
+    ttlMs: 3_000,
+    now: clock.now,
+    staleWhileRevalidate: true,
+  });
+  let probes = 0;
+  const probe = () => {
+    probes += 1;
+    if (probes === 1) return { reachable: true };
+    throw new Error("connection refused");
+  };
+
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  clock.t = 3_000;
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(await cached("gateway", probe), { reachable: true });
+  assert.equal(probes, 2);
 });


### PR DESCRIPTION
Supersedes #336. Carries @Leshabeats's three commits unchanged and adds one commit fixing three review findings. **Please close #336 in favour of this** rather than merging both.

The stale-while-revalidate cache and the AbortController hoist in the original PR are sound and are kept as-is.

## 1. A global keep-alive change was riding along

`fetchDispatcherOptions()` set `keepAliveTimeout: KEEPALIVE_TIMEOUT_MS`, and `KEEPALIVE_TIMEOUT_MS` is **120_000** — a *server* setting from `src/http-utils.mjs`. It was applied to the **global** dispatcher, i.e. every outbound request to every provider. undici's default is 4s, so this was a 30x increase for xAI, DeepSeek, Fireworks, opencode, LiteLLM and everything else.

The failure mode is nasty: an upstream that idle-closes at 30–60s without advertising `Keep-Alive: timeout=` hands back a half-closed socket, and undici surfaces that as `UND_ERR_SOCKET` / "socket hang up" on a **non-idempotent POST it will not retry**. Nothing in the PR title, body or changelog mentioned it.

Removed from the global options. The dedicated loopback probe dispatcher keeps its own `keepAliveTimeout: 10_000`, which is correctly scoped to health probes.

## 2. A new undici Agent per call

`loopbackProbeFetch(url, init, dispatcher = createLoopbackProbeDispatcher())` constructed a fresh `Agent` on every call that omitted the argument — a connection-pool leak. Now a lazily-created module singleton behind `loopbackProbeDispatcher()`, still injectable for tests. `src/router.mjs` also dropped its own duplicate pool, so the process has exactly one, created on first probe rather than at import.

## 3. `/health` could report a dead gateway healthy forever

The `maxStaleMs` bound was enforced on the non-blocking short-circuits but **not** in the `catch`, which returned `current.lastValue` with no age check at all. If the probe starts throwing, `/health` serves an arbitrarily old snapshot indefinitely.

Now gated by the same `canServeStale()` helper. Two extra details found while fixing:

- `lastValueAt` must **not** advance on a failed probe — a failure does not make the snapshot younger — while `at` does, preserving the one-probe-per-TTL throttle during an outage.
- The old code also cached the *settled* promise on a `fresh` entry, so even with an age-gated catch the `if (fresh) return existing.promise` short-circuit would replay the stale value for another TTL past `maxStaleMs`. The catch now stores `promise: undefined`.

## Tests

The pre-existing `assert.deepEqual(created[0].options, fetchDispatcherOptions())` assertions compared the code to itself. Replaced with concrete literals, plus new tests for the keep-alive absence, dispatcher reuse, lazy construction, the max-stale bound, the settled-promise replay, and the outage throttle.

Both stale-cache tests were confirmed to **fail** against the unfixed `health-cache.mjs` and pass after.

## Verification

- `node scripts-check.mjs` — passes
- `node --test test/*.test.mjs` — **0 failures**, 13 pre-existing skips

## Note on the original diagnosis

The changelog's premise — that a probe GET queued behind five SSE POSTs — does not hold: undici's HTTP/1.1 pool defaults to `connections: null` (unbounded), so the probe always opened its own socket. The separate dispatcher is still reasonable isolation, but what actually stalls `/health` under load is event-loop blocking. Worth correcting in the changelog before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)