### PR TITLE
fix(installer): install Node dependencies before guided setup (reviewed)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -274,6 +274,9 @@ command -v node >/dev/null 2>&1 ||
 command -v npm >/dev/null 2>&1 ||
   die "npm is required and is normally included with Node.js"
 
+if [ -n "$configure_provider_keys" ]; then
+  node "$repo_dir/src/node-dependency-install.mjs"
+fi
 for provider_id in $configure_provider_keys; do
   "$repo_dir/bin/provider-key" "$provider_id" set
 done

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,20 @@ die() {
   exit 1
 }
 
+# The single restore path for a step that runs after the pull. Every such step
+# can leave the checkout on code the machine cannot run -- `npm ci` empties
+# node_modules before it refills it -- so failing one has to return the managed
+# checkout to the revision the service was last known to work on, exactly as a
+# failed setup does. Steps that run before the pull have nothing to restore and
+# keep using die() directly.
+restore_previous_revision() {
+  if [ -n "$previous_revision" ]; then
+    git -C "$repo_dir" switch --detach "$previous_revision" >/dev/null 2>&1 || true
+    die "$1; the managed source checkout was restored to $previous_revision"
+  fi
+  die "$1"
+}
+
 # Mirrors DIRTY_PREVIEW_LIMIT in src/update.mjs and $DirtyPreviewLimit in
 # install.ps1. test/installer-scripts.test.mjs compares all three, so they
 # cannot drift apart.
@@ -274,8 +288,13 @@ command -v node >/dev/null 2>&1 ||
 command -v npm >/dev/null 2>&1 ||
   die "npm is required and is normally included with Node.js"
 
+# The key prompt imports modules from node_modules, which a fresh clone does
+# not have yet: bin/install installs them, and it runs later. Doing it here is
+# what makes the prompt work at all, and the failure has to reach the restore
+# path rather than abort under `set -e`.
 if [ -n "$configure_provider_keys" ]; then
-  node "$repo_dir/src/node-dependency-install.mjs"
+  node "$repo_dir/src/node-dependency-install.mjs" ||
+    restore_previous_revision "installing Node dependencies failed"
 fi
 for provider_id in $configure_provider_keys; do
   "$repo_dir/bin/provider-key" "$provider_id" set
@@ -312,11 +331,7 @@ if [ "$setup_status" -eq 2 ]; then
   printf 'setup did not finish configuring; the update was kept. Re-run setup to continue, or ./bin/rollback to return to the previous revision.\n' >&2
   exit 2
 elif [ "$setup_status" -ne 0 ]; then
-  if [ -n "$previous_revision" ]; then
-    git -C "$repo_dir" switch --detach "$previous_revision" >/dev/null 2>&1 || true
-    die "setup failed; the managed source checkout was restored to $previous_revision"
-  fi
-  die "setup failed"
+  restore_previous_revision "setup failed"
 fi
 
 cat <<'EOF'

--- a/src/node-dependency-install.mjs
+++ b/src/node-dependency-install.mjs
@@ -1,0 +1,43 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { recordStep, SOURCE_ROOT, stepStatus } from "./install-plan.mjs";
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
+
+export function ensureNodeDependencies({
+  root = SOURCE_ROOT,
+  env = process.env,
+  platform = process.platform,
+} = {}) {
+  // Package managers assemble this tree themselves. Mutating their prefix with
+  // npm would violate the same ownership boundary enforced by bin/install.
+  if (env.CODEX_ROUTER_PACKAGE_MANAGER) return "managed";
+  if (stepStatus("node-deps", { root, platform }) === "skip") return "skip";
+
+  const npm = commandOnPath("npm", { platform });
+  if (!npm) throw new Error("npm is required and is normally included with Node.js.");
+  process.stdout.write("Installing Node dependencies needed for credential setup...\n");
+  const invocation = spawnableCommand(npm, ["ci", "--omit=dev"], platform);
+  const result = spawnSync(invocation.command, invocation.args, {
+    ...invocation.options,
+    cwd: root,
+    env,
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`npm dependency installation exited with status ${result.status}.`);
+  }
+  recordStep("node-deps", { root });
+  return "installed";
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    ensureNodeDependencies();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/node-dependency-install.mjs
+++ b/src/node-dependency-install.mjs
@@ -5,18 +5,42 @@ import { fileURLToPath } from "node:url";
 import { recordStep, SOURCE_ROOT, stepStatus } from "./install-plan.mjs";
 import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
 
+// A failure here is never a credential problem, and callers must not fold it
+// into one: `npm ci` empties node_modules before it refills it, so a run that
+// dies partway leaves the checkout unable to start the router at all. The tag
+// lets a caller that is deliberately lenient about credential prompts stay
+// strict about this.
+export function isNodeDependencyFailure(error) {
+  return Boolean(error?.nodeDependencyInstall);
+}
+
+function dependencyFailure(detail, options = {}) {
+  return Object.assign(new Error(`Node dependency installation failed: ${detail}`), {
+    ...options,
+    nodeDependencyInstall: true,
+  });
+}
+
 export function ensureNodeDependencies({
   root = SOURCE_ROOT,
   env = process.env,
   platform = process.platform,
 } = {}) {
   // Package managers assemble this tree themselves. Mutating their prefix with
-  // npm would violate the same ownership boundary enforced by bin/install.
-  if (env.CODEX_ROUTER_PACKAGE_MANAGER) return "managed";
+  // npm would violate the same ownership boundary enforced by bin/install --
+  // and only Homebrew is known to have assembled it already, so every other
+  // manager gets that script's refusal instead of a silent skip.
+  const manager = env.CODEX_ROUTER_PACKAGE_MANAGER;
+  if (manager === "homebrew") return "managed";
+  if (manager) {
+    throw dependencyFailure(
+      `Reinstall the codex-router package managed by ${manager} to rebuild Node dependencies.`,
+    );
+  }
   if (stepStatus("node-deps", { root, platform }) === "skip") return "skip";
 
   const npm = commandOnPath("npm", { platform });
-  if (!npm) throw new Error("npm is required and is normally included with Node.js.");
+  if (!npm) throw dependencyFailure("npm is required and is normally included with Node.js.");
   process.stdout.write("Installing Node dependencies needed for credential setup...\n");
   const invocation = spawnableCommand(npm, ["ci", "--omit=dev"], platform);
   const result = spawnSync(invocation.command, invocation.args, {
@@ -25,9 +49,15 @@ export function ensureNodeDependencies({
     env,
     stdio: "inherit",
   });
-  if (result.error) throw result.error;
+  if (result.error) throw dependencyFailure(result.error.message, { cause: result.error });
   if (result.status !== 0) {
-    throw new Error(`npm dependency installation exited with status ${result.status}.`);
+    // A signalled npm reports a null status, and "exited with status null"
+    // hides which signal ended it.
+    throw dependencyFailure(
+      result.signal
+        ? `npm ci was terminated by ${result.signal}.`
+        : `npm ci exited with status ${result.status}.`,
+    );
   }
   recordStep("node-deps", { root });
   return "installed";

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
+import { ensureNodeDependencies } from "./node-dependency-install.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT, TARGET } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
@@ -291,6 +292,7 @@ function configureProvider(provider) {
     if (!confirm(`Enter ${prompt} securely now?`)) {
       throw incomplete(`${provider.displayName} setup was cancelled.`);
     }
+    ensureNodeDependencies();
     run(process.execPath, [path.join(SOURCE_ROOT, "src", "provider-key.mjs"), provider.id, "set"]);
   }
 }

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -6,7 +6,7 @@ import path from "node:path";
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
-import { ensureNodeDependencies } from "./node-dependency-install.mjs";
+import { ensureNodeDependencies, isNodeDependencyFailure } from "./node-dependency-install.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT, TARGET } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
@@ -402,6 +402,12 @@ async function main() {
       configureProvider(provider);
     } catch (error) {
       if (!guided) throw error;
+      // The leniency above is about credential prompts. A dependency install
+      // that failed has emptied node_modules, so nothing later in this run
+      // works and no key the user could add afterwards would fix it; reporting
+      // it as "this provider still needs a credential" sends them after the
+      // wrong thing. Let it out so the installer restores the checkout.
+      if (isNodeDependencyFailure(error)) throw error;
       const reason = error instanceof Error ? error.message : String(error);
       pendingCredentials.push({ provider, reason });
       process.stderr.write(`\nWarning: ${provider.displayName} was not configured (${reason})\n`);

--- a/test/setup-node-deps.test.mjs
+++ b/test/setup-node-deps.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = path.resolve(import.meta.dirname, "..");
+const PYTHON_AVAILABLE =
+  spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+const GUIDED_SETUP_HELPER = String.raw`
+import errno
+import os
+import select
+import sys
+import termios
+import time
+
+node, setup, checkout, home, state_dir, secret, confirmation = sys.argv[1:]
+env = os.environ.copy()
+env.update({
+    "HOME": home,
+    "CODEX_HOME": home,
+    "CODEX_ROUTER_STATE_DIR": state_dir,
+    "MODEL_ROUTER_STATE_DIR": state_dir,
+    "MODEL_ROUTER_TARGET": "codex",
+    "DEEPSEEK_API_KEY": "",
+})
+pid, master = os.forkpty()
+if pid == 0:
+    os.chdir(checkout)
+    os.execve(node, [node, setup, "--guided", "--providers", "deepseek", "--selection-only"], env)
+
+output = bytearray()
+confirmed = False
+key_sent = False
+while True:
+    ready, _, _ = select.select([master], [], [], 15)
+    if not ready:
+        os.kill(pid, 9)
+        raise SystemExit("timed out waiting for guided setup")
+    try:
+        chunk = os.read(master, 4096)
+    except OSError as error:
+        if error.errno == errno.EIO:
+            break
+        raise
+    if not chunk:
+        break
+    output.extend(chunk)
+    if not confirmed and b"Enter DeepSeek API key securely now?" in output:
+        os.write(master, confirmation.encode() + b"\n")
+        confirmed = True
+    if confirmation.lower() == "y" and not key_sent and b"DeepSeek API key: " in output:
+        deadline = time.monotonic() + 2
+        while termios.tcgetattr(master)[3] & termios.ECHO:
+            if time.monotonic() >= deadline:
+                os.kill(pid, 9)
+                raise SystemExit("provider-key did not disable terminal echo")
+            time.sleep(0.01)
+        os.write(master, secret.encode() + b"\n")
+        key_sent = True
+
+_, status = os.waitpid(pid, 0)
+os.close(master)
+sys.stdout.buffer.write(output)
+raise SystemExit(os.waitstatus_to_exitcode(status))
+`;
+
+function withFreshGuidedSetup(confirmation, verify) {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-guided-deps-"));
+  const checkout = path.join(testRoot, "checkout");
+  const fakeBin = path.join(testRoot, "bin");
+  const stateDir = path.join(testRoot, "state");
+  const npmLog = path.join(testRoot, "npm.log");
+  const secret = "TEST_DEEPSEEK_GUIDED_KEY";
+
+  try {
+    mkdirSync(checkout, { recursive: true });
+    cpSync(path.join(root, "src"), path.join(checkout, "src"), { recursive: true });
+    cpSync(path.join(root, "config"), path.join(checkout, "config"), { recursive: true });
+    copyFileSync(path.join(root, "package.json"), path.join(checkout, "package.json"));
+    copyFileSync(path.join(root, "package-lock.json"), path.join(checkout, "package-lock.json"));
+
+    mkdirSync(fakeBin, { recursive: true });
+    writeFileSync(
+      path.join(fakeBin, "npm"),
+      `#!/bin/sh
+printf '%s\\n' "$*" >"$CODEX_ROUTER_NPM_LOG"
+cp -R "$CODEX_ROUTER_TEST_NODE_MODULES" node_modules
+`,
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      "python3",
+      [
+        "-c",
+        GUIDED_SETUP_HELPER,
+        process.execPath,
+        path.join(checkout, "src", "setup.mjs"),
+        checkout,
+        testRoot,
+        stateDir,
+        secret,
+        confirmation,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH || "/usr/local/bin:/usr/bin:/bin"}`,
+          CODEX_ROUTER_NPM_LOG: npmLog,
+          CODEX_ROUTER_TEST_NODE_MODULES: path.join(root, "node_modules"),
+        },
+        timeout: 25_000,
+      },
+    );
+
+    verify({ checkout, npmLog, result, secret, stateDir });
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+}
+
+test(
+  "fresh guided setup installs Node dependencies before storing a provider key",
+  { skip: process.platform === "win32" || !PYTHON_AVAILABLE },
+  () => {
+    withFreshGuidedSetup("Y", ({ checkout, npmLog, result, secret, stateDir }) => {
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.doesNotMatch(result.stdout, /ERR_MODULE_NOT_FOUND/);
+      assert.equal(readFileSync(npmLog, "utf8"), "ci --omit=dev\n");
+      assert.equal(
+        readFileSync(path.join(stateDir, "deepseek-api-key.secret"), "utf8"),
+        `${secret}\n`,
+      );
+      assert.equal(existsSync(path.join(checkout, "node_modules", ".package-lock.json")), true);
+    });
+  },
+);
+
+test(
+  "fresh guided setup does not install Node dependencies when key setup is declined",
+  { skip: process.platform === "win32" || !PYTHON_AVAILABLE },
+  () => {
+    withFreshGuidedSetup("n", ({ checkout, npmLog, result, stateDir }) => {
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /DeepSeek API setup was cancelled/);
+      assert.equal(existsSync(npmLog), false);
+      assert.equal(existsSync(path.join(checkout, "node_modules")), false);
+      assert.equal(existsSync(path.join(stateDir, "deepseek-api-key.secret")), false);
+    });
+  },
+);

--- a/test/setup-node-deps.test.mjs
+++ b/test/setup-node-deps.test.mjs
@@ -7,6 +7,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -77,7 +78,23 @@ sys.stdout.buffer.write(output)
 raise SystemExit(os.waitstatus_to_exitcode(status))
 `;
 
-function withFreshGuidedSetup(confirmation, verify) {
+// A stub that stands in for a working `npm ci`: it records the arguments and
+// materializes the dependency tree the run needs.
+const NPM_STUB_SUCCEEDS = `#!/bin/sh
+printf '%s\\n' "$*" >"$CODEX_ROUTER_NPM_LOG"
+cp -R "$CODEX_ROUTER_TEST_NODE_MODULES" node_modules
+`;
+
+// What a real `npm ci` failure looks like on disk: the tree is emptied before
+// it is refilled, so a run that dies partway leaves no node_modules at all.
+const NPM_STUB_FAILS = `#!/bin/sh
+printf '%s\\n' "$*" >"$CODEX_ROUTER_NPM_LOG"
+rm -rf node_modules
+echo "npm error code EAI_AGAIN" >&2
+exit 1
+`;
+
+function withFreshGuidedSetup(confirmation, verify, { npmStub = NPM_STUB_SUCCEEDS } = {}) {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-guided-deps-"));
   const checkout = path.join(testRoot, "checkout");
   const fakeBin = path.join(testRoot, "bin");
@@ -93,14 +110,7 @@ function withFreshGuidedSetup(confirmation, verify) {
     copyFileSync(path.join(root, "package-lock.json"), path.join(checkout, "package-lock.json"));
 
     mkdirSync(fakeBin, { recursive: true });
-    writeFileSync(
-      path.join(fakeBin, "npm"),
-      `#!/bin/sh
-printf '%s\\n' "$*" >"$CODEX_ROUTER_NPM_LOG"
-cp -R "$CODEX_ROUTER_TEST_NODE_MODULES" node_modules
-`,
-      { mode: 0o755 },
-    );
+    writeFileSync(path.join(fakeBin, "npm"), npmStub, { mode: 0o755 });
 
     const result = spawnSync(
       "python3",
@@ -161,5 +171,131 @@ test(
       assert.equal(existsSync(path.join(checkout, "node_modules")), false);
       assert.equal(existsSync(path.join(stateDir, "deepseek-api-key.secret")), false);
     });
+  },
+);
+
+test(
+  "a failed dependency install is reported as one, not as a missing credential",
+  { skip: process.platform === "win32" || !PYTHON_AVAILABLE },
+  () => {
+    withFreshGuidedSetup(
+      "Y",
+      ({ checkout, npmLog, result, stateDir }) => {
+        assert.equal(readFileSync(npmLog, "utf8"), "ci --omit=dev\n");
+        // Guided runs collect credential gaps and continue. A wiped
+        // node_modules is not a credential gap: nothing later in the run works,
+        // so it has to fail the run instead of being filed under the provider.
+        assert.notEqual(result.status, 0, result.stdout);
+        // Exit 2 means "the checkout is healthy, configuration is unfinished"
+        // and tells both installers to keep the update. The checkout is not
+        // healthy here, so this must not claim that status.
+        assert.notEqual(result.status, 2, result.stdout);
+        assert.match(result.stdout, /Node dependency installation failed/);
+        assert.match(result.stdout, /npm ci exited with status 1/);
+        assert.doesNotMatch(result.stdout, /was not configured/);
+        assert.doesNotMatch(result.stdout, /Still needs a credential/);
+        assert.equal(existsSync(path.join(checkout, "node_modules")), false);
+        assert.equal(existsSync(path.join(stateDir, "deepseek-api-key.secret")), false);
+      },
+      { npmStub: NPM_STUB_FAILS },
+    );
+  },
+);
+
+const GIT_AVAILABLE = spawnSync("git", ["--version"], { stdio: "ignore" }).status === 0;
+
+function git(cwd, ...args) {
+  const result = spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  assert.equal(result.status, 0, `git ${args.join(" ")}: ${result.stderr}`);
+  return result.stdout.trim();
+}
+
+// install.sh runs the dependency install after `git pull --ff-only` has already
+// moved the managed checkout onto the new code. `npm ci` empties node_modules
+// before it refills it, so a failure there without a rollback leaves the
+// service on code it has no dependencies for -- strictly worse than the same
+// failure inside bin/install, which has always restored the previous revision.
+test(
+  "install.sh restores the previous revision when the dependency install fails",
+  { skip: process.platform === "win32" || !GIT_AVAILABLE },
+  () => {
+    // Realpath, not the raw temp path: the module's `is this the entry point`
+    // check compares `process.argv[1]` against `import.meta.url`, and macOS
+    // hands out /var/... temp directories that resolve to /private/var/...,
+    // where the two never match and the step silently does nothing.
+    const testRoot = realpathSync(
+      mkdtempSync(path.join(os.tmpdir(), "codex-router-install-deps-")),
+    );
+    try {
+      const upstream = path.join(testRoot, "upstream");
+      const installDir = path.join(testRoot, "checkout");
+      const fakeBin = path.join(testRoot, "bin");
+      const npmLog = path.join(testRoot, "npm.log");
+
+      mkdirSync(upstream, { recursive: true });
+      assert.equal(
+        spawnSync("git", ["init", "-b", "main", upstream], { stdio: "ignore" }).status,
+        0,
+      );
+      git(upstream, "config", "user.email", "test@example.invalid");
+      git(upstream, "config", "user.name", "codex-router test");
+      cpSync(path.join(root, "src"), path.join(upstream, "src"), { recursive: true });
+      cpSync(path.join(root, "config"), path.join(upstream, "config"), { recursive: true });
+      copyFileSync(path.join(root, "package.json"), path.join(upstream, "package.json"));
+      copyFileSync(
+        path.join(root, "package-lock.json"),
+        path.join(upstream, "package-lock.json"),
+      );
+      git(upstream, "add", "-A");
+      git(upstream, "commit", "-m", "base");
+
+      assert.equal(
+        spawnSync("git", ["clone", upstream, installDir], { stdio: "ignore" }).status,
+        0,
+      );
+      const previousRevision = git(installDir, "rev-parse", "HEAD");
+
+      // The update the user is running for: without it there is nothing to
+      // restore and the regression is invisible.
+      writeFileSync(path.join(upstream, "src", "new-file.mjs"), "export const updated = true;\n");
+      git(upstream, "add", "-A");
+      git(upstream, "commit", "-m", "update");
+      const updatedRevision = git(upstream, "rev-parse", "HEAD");
+      assert.notEqual(updatedRevision, previousRevision);
+
+      mkdirSync(fakeBin, { recursive: true });
+      writeFileSync(path.join(fakeBin, "npm"), NPM_STUB_FAILS, { mode: 0o755 });
+
+      const result = spawnSync("sh", ["-s", "--", "--deepseek-api-key", "--install-dir", installDir], {
+        input: readFileSync(path.join(root, "install.sh"), "utf8"),
+        encoding: "utf8",
+        cwd: testRoot,
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH || "/usr/local/bin:/usr/bin:/bin"}`,
+          HOME: testRoot,
+          CODEX_HOME: testRoot,
+          CODEX_ROUTER_STATE_DIR: path.join(testRoot, "state"),
+          MODEL_ROUTER_STATE_DIR: path.join(testRoot, "state"),
+          CODEX_ROUTER_REPOSITORY_URL: upstream,
+          CODEX_ROUTER_NPM_LOG: npmLog,
+        },
+        timeout: 60_000,
+      });
+
+      // The run got as far as the dependency step, and stopped there: the key
+      // prompt never ran, so no credential was touched.
+      assert.equal(readFileSync(npmLog, "utf8"), "ci --omit=dev\n");
+      assert.notEqual(result.status, 0, result.stdout);
+      assert.match(result.stderr, /installing Node dependencies failed/);
+      assert.match(
+        result.stderr,
+        new RegExp(`the managed source checkout was restored to ${previousRevision}`),
+      );
+      assert.equal(git(installDir, "rev-parse", "HEAD"), previousRevision);
+      assert.equal(existsSync(path.join(installDir, "src", "new-file.mjs")), false);
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
   },
 );


### PR DESCRIPTION
Supersedes #355. Carries @mayrazing's commit unchanged and adds one commit fixing the review findings. **Please close #355 in favour of this** rather than merging both.

The underlying bug is real and correctly diagnosed: on a fresh clone `install.sh` runs `bin/provider-key`, which imports `proper-lockfile`, but `node_modules` does not exist yet because `npm ci` lives in `bin/install`, which runs *later*. The key prompt dies with `ERR_MODULE_NOT_FOUND`.

## 1. The new step sat outside the rollback window

The dependency call was inserted **above** the `setup_status` block, which holds the only `git switch --detach "$previous_revision"`. Under `set -eu` a non-zero exit aborted with no rollback — *after* `git pull --ff-only` had already moved the checkout.

Concrete: an existing user runs `./install.sh --deepseek-api-key` to rotate a key. The pull succeeds, `package-lock.json` changed, so `npm ci` runs — and `npm ci` **removes the existing `node_modules` tree first**. If it then fails (registry 503, proxy, ENOSPC, EACCES), the live service checkout is on new code with no dependency tree and no rollback ran. The router is dead until the user manually re-runs the installer.

That is strictly worse than today, where the same `npm ci` lives inside `bin/install` and its failure *does* restore the previous revision.

Fixed by extracting `restore_previous_revision()` from the existing inline rollback (same body, same `die` message shape, so the parity assertions in `test/installer-scripts.test.mjs` still match) and routing the dependency failure through it. There is now one restore path, not two.

## 2. The failure was reported as the wrong thing

`ensureNodeDependencies()` is called inside `configureProvider()`, so the guided loop reported a wiped dependency tree as `Warning: DeepSeek API was not configured (npm dependency installation exited with status 1)` — a credential problem — and marched on.

Dependency failures are now tagged and rethrown rather than swallowed. The existing leniency comment is explicitly about *credential prompts*; a missing dependency tree is not one, nothing later in the run works, and no key fixes it. Exit is plain 1 rather than the "configuration unfinished" 2, so `install.sh` rolls back — consistent with fix 1.

## 3. Package-manager handling now agrees with `bin/install`

`node-dependency-install.mjs` returned `"managed"` for *any* non-empty `CODEX_ROUTER_PACKAGE_MANAGER`, while `bin/install` short-circuits only for `homebrew` and otherwise calls `packaged_dependency_refusal()`. Under the old module a non-homebrew packaged install would silently skip and then hit the very `ERR_MODULE_NOT_FOUND` this PR exists to remove. Now homebrew-only, with `bin/install`'s own wording.

Also: signal deaths now report `npm ci was terminated by SIGKILL.` instead of `status null`.

## Tests

The existing PTY harness is parameterized with a failing npm stub that clears the dependency tree and exits 1, mimicking a real `npm ci` failure, plus two new tests:

1. a failed dependency install is reported as one, not as a missing credential;
2. `install.sh` restores the previous revision when it fails — builds a real upstream git repo, clones it as the managed checkout, adds an upstream commit, runs the update path, and asserts `HEAD` is back at the pre-pull revision and the new upstream file is gone.

Both were confirmed to **fail** against the unfixed code.

## Verification

- `node scripts-check.mjs` — passes; `sh -n install.sh` — clean
- `node --test test/*.test.mjs` — **0 failures**, 13 pre-existing skips
- The PTY tests were **not** skipped: all 4 ran and passed.

## Two things left alone, flagged

- **Latent, pre-existing:** the module's entry-point check (`path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)`) is the repo-wide idiom but fails open on a symlinked path — on macOS a `/var/folders/...` checkout resolves to `/private/var/...`, the comparison never matches, and the step **silently does nothing and exits 0**. Real install dirs are not symlinked so production is unaffected, but the failure mode is a silent skip. Worth a separate look across the ~20 files using this idiom.
- `install.ps1` gets no equivalent step, so Windows users on a fresh clone still hit the original error. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)