### PR TITLE
fix(picker): repair pre-allowlist installs, and keep guided model selection opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@
   Substitute your provider ID (`./bin/model-router codex providers list --json`
   lists them), repeat per provider, then fully quit and reopen Codex.
 
+- **Guided setup asks which models go in the picker.** `./bin/setup --guided`
+  now has a model step between choosing providers and connecting credentials.
+  It starts from the picker the machine already has -- nothing on a first
+  install, the operator's existing selection on a re-run -- so enabling a
+  provider still offers its models rather than choosing them, and pressing
+  Enter through the step never changes what is already there. The selection is
+  written after the "Proceed?" confirmation, so a cancelled setup and a
+  `--selection-only` run both leave `model-picker.json` untouched, and it
+  records `hidden`/`seeded` rather than an allowlist on a pre-allowlist file,
+  because one screen of models cannot answer for the providers it never
+  showed.
+
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was
   required. The Grok OAuth boundary now presents that tool as `inspect_image`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- **An update no longer empties the picker on a pre-allowlist install.** The
+  routed picker became an allowlist in `v0.4.0-beta.4`; on an install written
+  by an older build, every routed model was absent from `seeded` rather than
+  recorded as visible, so the first catalog rebuild read "on, but never
+  written down" as "never decided" and applied the opt-in default to models
+  that were plainly already showing (issue #338). The catalog build now
+  migrates that file once, before the default runs: a routed slug in neither
+  `hidden` nor `seeded` is recorded visible, so the picker the operator was
+  looking at survives the update. Models switched off on purpose stay off, and
+  a fresh install still opts in model by model.
+
+  **If an update already hid your models,** the migration cannot tell them
+  apart from a deliberate hide -- both now sit in `hidden` and `seeded` -- and
+  deliberately does not guess. Restore a provider's models with the picker
+  command, which republishes the catalog on the way out:
+
+  ```sh
+  ./bin/control picker provider opencode-go show
+  ```
+
+  Substitute your provider ID (`./bin/model-router codex providers list --json`
+  lists them), repeat per provider, then fully quit and reopen Codex.
+
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was
   required. The Grok OAuth boundary now presents that tool as `inspect_image`

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -30,7 +30,12 @@ import {
   readMultiAgentSettings,
   subagentEligibleModels,
 } from "./multi-agent-state.mjs";
-import { modelPickerSnapshot, readHiddenModels, seedModelsHidden } from "./model-picker-state.mjs";
+import {
+  migrateLegacyVisibleModels,
+  modelPickerSnapshot,
+  readHiddenModels,
+  seedModelsHidden,
+} from "./model-picker-state.mjs";
 import { buildNativeAliasAssignments } from "./native-alias.mjs";
 import {
   NATIVE_CONTEXT_VARIANT_SLUGS,
@@ -866,10 +871,17 @@ function main() {
   // native-looking slots are router aliases and retain the existing behavior.
   // Only slugs with no recorded decision are touched, so no later rebuild can
   // undo an operator's choice.
-  seedModelsHidden([
-    ...NATIVE_CONTEXT_VARIANT_SLUGS,
-    ...(loginFree ? [] : selectedModels.map((model) => String(model.slug))),
-  ]);
+  const routedSeedSlugs = loginFree ? [] : selectedModels.map((model) => String(model.slug));
+  // First, though: an install that predates the allowlist recorded only what
+  // was switched off, so its routed models are absent from `seeded` and the
+  // opt-in default below would read "visible, never written down" as "never
+  // decided" and empty the picker on the first rebuild after an update
+  // (issue #338). This writes the old answer down once, for those slugs only,
+  // and is a no-op on a fresh install and on every later rebuild.  Native
+  // context variants are deliberately not offered to it: they have never been
+  // visible by default under either set of semantics.
+  migrateLegacyVisibleModels(routedSeedSlugs);
+  seedModelsHidden([...NATIVE_CONTEXT_VARIANT_SLUGS, ...routedSeedSlugs]);
   const hiddenModels = readHiddenModels();
   const pickerState = modelPickerSnapshot();
   const visibleModels = new Set(pickerState.visible);

--- a/src/model-picker-state.mjs
+++ b/src/model-picker-state.mjs
@@ -147,6 +147,32 @@ export function setAllModelsVisible(slugs, visible) {
   });
 }
 
+// Applies one explicit picker selection to the supplied models while leaving
+// every other provider's visibility untouched.
+export function setModelSelection(slugs, selectedSlugs) {
+  const values = [...new Set(
+    (Array.isArray(slugs) ? slugs : []).map((slug) => String(slug || "").trim()).filter(Boolean),
+  )];
+  if (values.length === 0) return modelPickerSnapshot();
+  const selected = new Set(
+    (Array.isArray(selectedSlugs) ? selectedSlugs : [])
+      .map((slug) => String(slug || "").trim())
+      .filter(Boolean),
+  );
+  const { hidden, visible, seeded } = readPickerState();
+  for (const value of values) {
+    if (selected.has(value)) {
+      hidden.delete(value);
+      visible.add(value);
+    } else {
+      hidden.add(value);
+      visible.delete(value);
+    }
+    seeded.add(value);
+  }
+  return writePickerState({ hidden, visible, seeded });
+}
+
 // Applies a shipped default to models the operator has never decided, and only
 // to those. Used by the catalog build for entries that must arrive switched off
 // (`src/native-context-variants.mjs`): they cost more per turn than the model

--- a/src/model-picker-state.mjs
+++ b/src/model-picker-state.mjs
@@ -34,6 +34,10 @@ function readPickerState() {
     visible: new Set(),
     seeded: new Set(),
     hasExplicitVisibility: false,
+    // "Nothing has ever been recorded here" and "the file says nothing is
+    // hidden" are different machines, and only the second one has a history
+    // worth preserving (see `migrateLegacyVisibleModels`).
+    recognized: false,
   };
   if (!existsSync(MODEL_PICKER_STATE_PATH)) return empty;
   try {
@@ -51,7 +55,7 @@ function readPickerState() {
       ? slugs(parsed.visible)
       : new Set([...seeded].filter((slug) => !hidden.has(slug)));
     for (const slug of hidden) visible.delete(slug);
-    return { hidden, visible, seeded, hasExplicitVisibility };
+    return { hidden, visible, seeded, hasExplicitVisibility, recognized: true };
   } catch {
     return empty;
   }
@@ -67,6 +71,23 @@ export function readHiddenModels() {
 // selection and is what every client publisher uses to decide what to show.
 export function readVisibleModels() {
   return readPickerState().visible;
+}
+
+// Answers "which of these models is the picker showing right now" with the
+// same rule every publisher applies, so a surface that offers the operator a
+// pre-filled list starts from what they are actually looking at rather than
+// from one of the two representations. A machine with no picker state has
+// decided nothing, and new router models are opt-in, so the answer there is
+// "none" -- not "all of them", which is what `hidden` being empty would say.
+export function effectiveVisibleModels(slugs) {
+  const values = [...new Set(
+    (Array.isArray(slugs) ? slugs : []).map((slug) => String(slug || "").trim()).filter(Boolean),
+  )];
+  const { hidden, visible, hasExplicitVisibility, recognized } = readPickerState();
+  if (!recognized) return new Set();
+  return new Set(
+    values.filter((value) => (hasExplicitVisibility ? visible.has(value) : !hidden.has(value))),
+  );
 }
 
 function writePickerState({ hidden, visible, seeded, hasExplicitVisibility = true }) {
@@ -168,6 +189,44 @@ export function setModelSelection(slugs, selectedSlugs) {
       hidden.add(value);
       visible.delete(value);
     }
+    seeded.add(value);
+  }
+  return writePickerState({ hidden, visible, seeded });
+}
+
+// Bridges one install from the pre-allowlist file format, exactly once.
+//
+// Before `visible` existed, "absent from `hidden`" was the whole answer to "is
+// this model in the picker", so every routed model the operator had not
+// switched off was showing. The allowlist asks a different question, and a
+// slug that was never recorded at all answers it "off" -- which is how the
+// first catalog rebuild after an update emptied a whole provider out of the
+// picker (issue #338): `seedModelsHidden` read those slugs as never-decided
+// and applied the opt-in default to models that were visibly already on.
+//
+// So record the old answer for the models that had one, in the moment before
+// the default gets to speak. Deliberately hidden stays hidden, and a slug
+// already in `seeded` has been decided by someone -- neither is this
+// function's business. A machine with no picker state has no history to
+// preserve, so opt-in stays opt-in on a fresh install.
+//
+// This cannot repair an install that has already run the new build: there the
+// slugs sit in `hidden` and `seeded`, which is byte-for-byte what a deliberate
+// hide looks like. That machine needs `control picker provider <id> show`, and
+// guessing on its behalf would switch models back on that someone switched
+// off.
+export function migrateLegacyVisibleModels(slugs) {
+  const { hidden, visible, seeded, hasExplicitVisibility, recognized } = readPickerState();
+  if (!recognized || hasExplicitVisibility) return modelPickerSnapshot();
+  const values = [...new Set(
+    (Array.isArray(slugs) ? slugs : []).map((slug) => String(slug || "").trim()).filter(Boolean),
+  )];
+  const legacy = values.filter((value) => !hidden.has(value) && !seeded.has(value));
+  if (legacy.length === 0) return modelPickerSnapshot();
+  for (const value of legacy) {
+    visible.add(value);
+    // Recording the decision is the point: without it the opt-in default
+    // immediately below would still read these slugs as never-decided.
     seeded.add(value);
   }
   return writePickerState({ hidden, visible, seeded });

--- a/src/model-picker-state.mjs
+++ b/src/model-picker-state.mjs
@@ -170,6 +170,14 @@ export function setAllModelsVisible(slugs, visible) {
 
 // Applies one explicit picker selection to the supplied models while leaving
 // every other provider's visibility untouched.
+//
+// `hasExplicitVisibility` is threaded through for the same reason
+// `seedModelsHidden` threads it: this call sees one screen's worth of models,
+// and turning a legacy file into an allowlist answers for every provider it
+// never looked at -- with "off", because they are absent from `visible`. The
+// selection is still durable on such a file, through `hidden` and `seeded`,
+// which is the representation that file already speaks. A file the catalog
+// build has migrated is an allowlist already and stays one.
 export function setModelSelection(slugs, selectedSlugs) {
   const values = [...new Set(
     (Array.isArray(slugs) ? slugs : []).map((slug) => String(slug || "").trim()).filter(Boolean),
@@ -180,7 +188,7 @@ export function setModelSelection(slugs, selectedSlugs) {
       .map((slug) => String(slug || "").trim())
       .filter(Boolean),
   );
-  const { hidden, visible, seeded } = readPickerState();
+  const { hidden, visible, seeded, hasExplicitVisibility } = readPickerState();
   for (const value of values) {
     if (selected.has(value)) {
       hidden.delete(value);
@@ -191,7 +199,7 @@ export function setModelSelection(slugs, selectedSlugs) {
     }
     seeded.add(value);
   }
-  return writePickerState({ hidden, visible, seeded });
+  return writePickerState({ hidden, visible, seeded, hasExplicitVisibility });
 }
 
 // Bridges one install from the pre-allowlist file format, exactly once.

--- a/src/setup-ui.mjs
+++ b/src/setup-ui.mjs
@@ -55,6 +55,16 @@ export function renderProviderChoices(snapshots, selected, colorEnabled = false)
     .join("\n");
 }
 
+export function renderModelChoices(models, selected) {
+  return models
+    .map((model, index) => {
+      const position = index + 1;
+      const mark = selected.has(position) ? "[x]" : "[ ]";
+      return `  ${mark} ${position}. ${model.displayName}`;
+    })
+    .join("\n");
+}
+
 export function toggleSelection(selected, input, count, { allowEmpty = false } = {}) {
   const trimmed = String(input || "").trim().toLowerCase();
   if (trimmed === "") {

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -5,8 +5,9 @@ import path from "node:path";
 
 import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigration } from "./legacy-migration.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
-import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
+import { LISTED_MODELS, PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import { ensureNodeDependencies } from "./node-dependency-install.mjs";
+import { modelPickerSnapshot, setModelSelection } from "./model-picker-state.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT, TARGET } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
@@ -16,8 +17,14 @@ import {
   oauthLoginArgs,
   providerOnboardingSnapshot,
 } from "./provider-onboarding.mjs";
-import { renderProviderChoices, stepHeader, toggleSelection } from "./setup-ui.mjs";
 import {
+  renderModelChoices,
+  renderProviderChoices,
+  stepHeader,
+  toggleSelection,
+} from "./setup-ui.mjs";
+import {
+  canonicalProviderId,
   defaultProviderIds,
   selectedConfiguredListedModels,
   validateProviderIds,
@@ -246,6 +253,44 @@ function requestedSelection() {
   return guided ? guidedSelection() : defaultProviderIds();
 }
 
+function guidedModelSelection(providers) {
+  const selectedProviders = new Set(providers);
+  const models = LISTED_MODELS.filter((model) =>
+    selectedProviders.has(canonicalProviderId(model.provider))
+  );
+  if (models.length === 0) {
+    process.stdout.write("\nThe selected providers have no preselected models.\n");
+    return { models, selectedSlugs: [] };
+  }
+
+  const hidden = new Set(modelPickerSnapshot().hidden);
+  let selected = new Set(
+    models
+      .map((model, index) => hidden.has(model.slug) ? undefined : index + 1)
+      .filter(Boolean),
+  );
+  process.stdout.write("\nChoose models from the selected providers:\n");
+  for (;;) {
+    process.stdout.write(`${renderModelChoices(models, selected)}\n`);
+    const raw = promptLine(
+      "Toggle model numbers (comma-separated), a=all, n=none; Enter to continue",
+    );
+    const result = toggleSelection(selected, raw, models.length, { allowEmpty: true });
+    selected = result.selected;
+    if (result.error) {
+      process.stdout.write(`${result.error}\n`);
+    } else if (result.done) {
+      break;
+    }
+  }
+  return {
+    models,
+    selectedSlugs: [...selected]
+      .sort((a, b) => a - b)
+      .map((position) => models[position - 1].slug),
+  };
+}
+
 function run(command, commandArgs, options = {}) {
   const result = spawnSync(command, commandArgs, {
     cwd: SOURCE_ROOT,
@@ -363,7 +408,9 @@ async function main() {
       `An unknown model router owns ${legacy.config.modelCatalogJson}; automatic setup will not replace it.`,
     );
   }
-  const stepTitles = ["Choose providers", "Connect credentials"];
+  const stepTitles = ["Choose providers"];
+  if (guided) stepTitles.push("Choose models");
+  stepTitles.push("Connect credentials");
   if (legacy.installations.length) stepTitles.push("Migrate older router");
   stepTitles.push("Review and install");
   let stepIndex = 0;
@@ -388,6 +435,13 @@ async function main() {
       "No configured provider was found. Run `./bin/setup --guided` or pass `--providers` after configuring credentials.",
     );
   }
+  let modelChoices = [];
+  let selectedModelSlugs = [];
+  if (guided) {
+    nextStep("Choose models");
+    ({ models: modelChoices, selectedSlugs: selectedModelSlugs } =
+      guidedModelSelection(providers));
+  }
   nextStep("Connect credentials");
   // Credentials are addable after the install, and the router already reports
   // an unconfigured provider clearly at request time. A declined prompt -- or
@@ -408,6 +462,9 @@ async function main() {
     }
   }
   writeProviderSelection(providers);
+  if (guided) {
+    setModelSelection(modelChoices.map((model) => model.slug), selectedModelSlugs);
+  }
   // Written on every run, not only idle ones: re-running setup without
   // --no-discovery is the exit path from idle mode, so a normal install must
   // clear the marker just as an idle install sets it.
@@ -445,7 +502,9 @@ async function main() {
   }
 
   if (selectionOnly) {
-    process.stdout.write(`${JSON.stringify({ providers, migration }, null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify({ providers, ...(guided ? { models: selectedModelSlugs } : {}), migration }, null, 2)}\n`,
+    );
     return;
   }
 
@@ -458,6 +517,7 @@ async function main() {
     process.stdout.write(
       `\nReady to install:\n` +
         `  Providers: ${providers.length ? providers.join(", ") : "none (idle install)"}\n` +
+        `  Models: ${selectedModelSlugs.length ? selectedModelSlugs.join(", ") : "none"}\n` +
         `  Migration: ${migration ? "recognized older router (rollback snapshot kept)" : "none needed"}\n` +
         (dshTarget
           ? `  Changes: per-user background service and one provider route in the harness settings document\n`

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -7,7 +7,7 @@ import { detectLegacyInstallations, applyKnownMigrations, rollbackLatestMigratio
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import { LISTED_MODELS, PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
 import { ensureNodeDependencies } from "./node-dependency-install.mjs";
-import { modelPickerSnapshot, setModelSelection } from "./model-picker-state.mjs";
+import { effectiveVisibleModels, setModelSelection } from "./model-picker-state.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { SOURCE_ROOT, TARGET } from "./paths.mjs";
 import { credentialStatus } from "./provider-credentials.mjs";
@@ -263,10 +263,16 @@ function guidedModelSelection(providers) {
     return { models, selectedSlugs: [] };
   }
 
-  const hidden = new Set(modelPickerSnapshot().hidden);
+  // Pre-check what the picker is showing right now, which on a machine that
+  // has never had one is nothing: router models are opt-in, and enabling a
+  // provider must not put its whole catalog in the picker on one keystroke
+  // (the policy `src/catalog.mjs` states at its `seedModelsHidden` call). On a
+  // re-run this is instead the operator's existing picker, so pressing Enter
+  // through this step changes nothing.
+  const visible = effectiveVisibleModels(models.map((model) => model.slug));
   let selected = new Set(
     models
-      .map((model, index) => hidden.has(model.slug) ? undefined : index + 1)
+      .map((model, index) => (visible.has(model.slug) ? index + 1 : undefined))
       .filter(Boolean),
   );
   process.stdout.write("\nChoose models from the selected providers:\n");
@@ -462,9 +468,6 @@ async function main() {
     }
   }
   writeProviderSelection(providers);
-  if (guided) {
-    setModelSelection(modelChoices.map((model) => model.slug), selectedModelSlugs);
-  }
   // Written on every run, not only idle ones: re-running setup without
   // --no-discovery is the exit path from idle mode, so a normal install must
   // clear the marker just as an idle install sets it.
@@ -529,6 +532,15 @@ async function main() {
     if (!confirm("Proceed?")) {
       throw incomplete("Setup was cancelled before installing the service.");
     }
+  }
+
+  // Below the confirmation, and below the `--selection-only` return above it:
+  // model visibility is the operator's existing configuration, so a cancelled
+  // setup and a selection-only run must both leave `model-picker.json` exactly
+  // as they found it. Steps that only report a choice may run before the
+  // answer; the step that rewrites protected state may not.
+  if (guided) {
+    setModelSelection(modelChoices.map((model) => model.slug), selectedModelSlugs);
   }
 
   try {

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   AUTO_ANNOUNCE_WINDOW_MS,
@@ -1150,3 +1153,109 @@ test("efficient routed execution silently substitutes routine missing tools", ()
   assert.match(model.base_instructions, /optional helper.*unavailable.*switch silently/i);
   assert.match(model.base_instructions, /do not send.*progress message.*fallback/i);
 });
+
+// One whole catalog publication, from a `model-picker.json` in the shape a
+// build older than the allowlist left behind, to the file Codex reads at
+// startup. The unit tests above cover the state transition; this covers the
+// only thing the operator sees, which is whether the models are still in the
+// picker after an update (issue #338).
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function writeCatalogCodexStub(directory) {
+  const windows = process.platform === "win32";
+  const target = path.join(directory, windows ? "codex-picker.cmd" : "codex-picker");
+  const models = JSON.stringify({
+    models: [
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", visibility: "list", priority: 10 },
+    ],
+  });
+  writeFileSync(
+    target,
+    windows
+      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" exit /b 0\r\nif "%1"=="debug" (echo ${models}& exit /b 0)\r\nexit /b 1\r\n`
+      : `#!/bin/sh
+case "$1" in
+  --version) echo 'codex-cli 99.0.0' ;;
+  login) exit 0 ;;
+  debug) printf '%s\\n' '${models}' ;;
+  *) exit 1 ;;
+esac
+`,
+    { mode: 0o755 },
+  );
+  return target;
+}
+
+test(
+  "an update publishes the models a pre-allowlist picker was already showing",
+  { timeout: 30_000 },
+  () => {
+    const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-picker-migration-"));
+    const stateDir = path.join(codexHome, "router-state");
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    writeFileSync(path.join(codexHome, "config.toml"), 'model = "gpt-5.6-sol"\n', {
+      mode: 0o600,
+    });
+    writeFileSync(
+      path.join(stateDir, "enabled-providers.json"),
+      `${JSON.stringify({ version: 1, providers: ["deepseek"] })}\n`,
+      { mode: 0o600 },
+    );
+    writeFileSync(path.join(stateDir, "deepseek-api-key.secret"), "test-key\n", {
+      mode: 0o600,
+    });
+    // What the previous build wrote: the extended-window variant it seeded
+    // hidden, one model this operator switched off, and no `visible` key --
+    // so the two DeepSeek models absent from the file were the ones showing.
+    writeFileSync(
+      path.join(stateDir, "model-picker.json"),
+      `${JSON.stringify({
+        version: 1,
+        hidden: ["gpt-5.6-sol-1m", "deepseek/deepseek-v4-pro"],
+        seeded: ["gpt-5.6-sol-1m", "deepseek/deepseek-v4-pro"],
+      })}\n`,
+      { mode: 0o600 },
+    );
+
+    try {
+      const catalog = spawnSync(
+        process.execPath,
+        [path.join(repoRoot, "src", "catalog.mjs"), "--refresh-native"],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            CODEX_BIN: writeCatalogCodexStub(codexHome),
+            CODEX_HOME: codexHome,
+            CODEX_ROUTER_STATE_DIR: stateDir,
+            MODEL_ROUTER_STATE_DIR: stateDir,
+            MODEL_ROUTER_TARGET: "codex",
+          },
+        },
+      );
+      assert.equal(catalog.status, 0, catalog.stderr);
+
+      const merged = JSON.parse(
+        readFileSync(path.join(stateDir, "merged-models.json"), "utf8"),
+      );
+      const visibility = new Map(
+        merged.models.map((model) => [String(model.slug), model.visibility]),
+      );
+      assert.equal(visibility.get("deepseek/deepseek-v4-flash"), "list");
+      assert.equal(visibility.get("deepseek/deepseek-v4-flash-vision-exp"), "list");
+      assert.equal(visibility.get("deepseek/deepseek-v4-pro"), "hide");
+      assert.equal(visibility.get("gpt-5.6-sol-1m"), "hide");
+
+      const picker = JSON.parse(
+        readFileSync(path.join(stateDir, "model-picker.json"), "utf8"),
+      );
+      assert.deepEqual(picker.visible, [
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-flash-vision-exp",
+      ]);
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  },
+);

--- a/test/model-picker-state.test.mjs
+++ b/test/model-picker-state.test.mjs
@@ -13,6 +13,7 @@ const {
   readHiddenModels,
   setAllModelsVisible,
   setModelVisible,
+  setModelSelection,
   setModelsVisible,
 } = await import("../src/model-picker-state.mjs");
 
@@ -56,6 +57,32 @@ test("provider-sized picker changes preserve other providers", () => {
   assert.deepEqual(modelPickerSnapshot().hidden, ["kimi-oauth/k3"]);
   assert.ok(modelPickerSnapshot().visible.includes("commandcode/kimi-k3"));
   assert.ok(modelPickerSnapshot().visible.includes("commandcode-messages/claude-opus-4.8"));
+});
+
+test("an explicit model selection changes only the supplied provider models", () => {
+  writeFileSync(
+    MODEL_PICKER_STATE_PATH,
+    `${JSON.stringify({
+      version: 1,
+      hidden: ["deepseek/deepseek-v4-pro", "kimi-oauth/k3"],
+      visible: ["deepseek/deepseek-v4-flash"],
+      seeded: [
+        "deepseek/deepseek-v4-flash",
+        "deepseek/deepseek-v4-pro",
+        "kimi-oauth/k3",
+      ],
+    })}\n`,
+    { mode: 0o600 },
+  );
+
+  setModelSelection(
+    ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"],
+    ["deepseek/deepseek-v4-pro"],
+  );
+
+  const picker = modelPickerSnapshot();
+  assert.deepEqual(picker.hidden, ["deepseek/deepseek-v4-flash", "kimi-oauth/k3"]);
+  assert.deepEqual(picker.visible, ["deepseek/deepseek-v4-pro"]);
 });
 
 test("legacy hidden-only state becomes an allowlist when a picker decision is made", () => {

--- a/test/model-picker-state.test.mjs
+++ b/test/model-picker-state.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -9,8 +9,11 @@ process.env.CODEX_ROUTER_STATE_DIR = stateDir;
 
 const {
   MODEL_PICKER_STATE_PATH,
+  effectiveVisibleModels,
+  migrateLegacyVisibleModels,
   modelPickerSnapshot,
   readHiddenModels,
+  seedModelsHidden,
   setAllModelsVisible,
   setModelVisible,
   setModelSelection,
@@ -103,4 +106,85 @@ test("legacy hidden-only state becomes an allowlist when a picker decision is ma
   const current = modelPickerSnapshot();
   assert.equal(current.hasExplicitVisibility, true);
   assert.deepEqual(current.visible, ["deepseek/deepseek-v4-flash"]);
+});
+
+// The exact shape a pre-allowlist build left behind: `hidden` and `seeded`
+// only, no `visible` key, and nothing recorded about the routed models that
+// were showing in the picker the whole time.
+const ROUTED_SLUGS = [
+  "opencode-go/gpt-5.6-sol",
+  "opencode-go/claude-opus-4.8",
+  "opencode-go/kimi-k3",
+];
+
+function writeLegacyState(state) {
+  writeFileSync(MODEL_PICKER_STATE_PATH, `${JSON.stringify(state)}\n`, { mode: 0o600 });
+}
+
+test("an update keeps the models a pre-allowlist install was already showing", () => {
+  writeLegacyState({
+    version: 1,
+    hidden: ["gpt-5.6-sol-1m", "opencode-go/kimi-k3"],
+    seeded: ["gpt-5.6-sol-1m", "opencode-go/kimi-k3"],
+  });
+
+  migrateLegacyVisibleModels(ROUTED_SLUGS);
+  seedModelsHidden(["gpt-5.6-sol-1m", ...ROUTED_SLUGS]);
+
+  const picker = modelPickerSnapshot();
+  assert.equal(picker.hasExplicitVisibility, true);
+  assert.deepEqual(picker.visible, [
+    "opencode-go/claude-opus-4.8",
+    "opencode-go/gpt-5.6-sol",
+  ]);
+  // A deliberate hide is a decision, and the extended-window variant has never
+  // shipped switched on. Neither is the migration's to reverse.
+  assert.deepEqual(picker.hidden, ["gpt-5.6-sol-1m", "opencode-go/kimi-k3"]);
+});
+
+test("the legacy picker migration runs once and then leaves the file alone", () => {
+  writeLegacyState({ version: 1, hidden: [], seeded: ["gpt-5.6-sol-1m"] });
+  migrateLegacyVisibleModels(ROUTED_SLUGS);
+  const migrated = readFileSync(MODEL_PICKER_STATE_PATH, "utf8");
+  // Everything the old `!hidden` rule was showing, written down once: the
+  // routed models it never recorded, and the variant it had recorded.
+  assert.deepEqual(
+    JSON.parse(migrated).visible,
+    ["gpt-5.6-sol-1m", ...ROUTED_SLUGS].sort(),
+  );
+
+  // A second rebuild has no legacy answer left to read, so it must not rewrite
+  // a protected file to say the same thing.
+  migrateLegacyVisibleModels([...ROUTED_SLUGS, "opencode-go/newly-curated"]);
+  assert.equal(readFileSync(MODEL_PICKER_STATE_PATH, "utf8"), migrated);
+});
+
+test("a fresh install has no picker history to migrate and stays opt-in", () => {
+  rmSync(MODEL_PICKER_STATE_PATH, { force: true });
+  migrateLegacyVisibleModels(ROUTED_SLUGS);
+  assert.equal(existsSync(MODEL_PICKER_STATE_PATH), false);
+
+  seedModelsHidden(ROUTED_SLUGS);
+  const picker = modelPickerSnapshot();
+  assert.deepEqual(picker.visible, []);
+  assert.deepEqual(picker.hidden, [...ROUTED_SLUGS].sort());
+});
+
+test("effective picker visibility reads both state formats and neither one", () => {
+  rmSync(MODEL_PICKER_STATE_PATH, { force: true });
+  assert.deepEqual([...effectiveVisibleModels(ROUTED_SLUGS)], []);
+
+  writeLegacyState({ version: 1, hidden: ["opencode-go/kimi-k3"], seeded: [] });
+  assert.deepEqual([...effectiveVisibleModels(ROUTED_SLUGS)].sort(), [
+    "opencode-go/claude-opus-4.8",
+    "opencode-go/gpt-5.6-sol",
+  ]);
+
+  writeLegacyState({
+    version: 1,
+    hidden: [],
+    visible: ["opencode-go/kimi-k3"],
+    seeded: ROUTED_SLUGS,
+  });
+  assert.deepEqual([...effectiveVisibleModels(ROUTED_SLUGS)], ["opencode-go/kimi-k3"]);
 });

--- a/test/model-picker-state.test.mjs
+++ b/test/model-picker-state.test.mjs
@@ -188,3 +188,25 @@ test("effective picker visibility reads both state formats and neither one", () 
   });
   assert.deepEqual([...effectiveVisibleModels(ROUTED_SLUGS)], ["opencode-go/kimi-k3"]);
 });
+
+test("an explicit model selection does not turn a legacy file into an allowlist", () => {
+  writeLegacyState({
+    version: 1,
+    hidden: ["deepseek/deepseek-v4-pro"],
+    seeded: ["deepseek/deepseek-v4-pro"],
+  });
+
+  setModelSelection(
+    ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"],
+    ["deepseek/deepseek-v4-flash"],
+  );
+
+  // Recording an allowlist here would answer for every provider this call
+  // never looked at, and every one of them would answer "off".
+  const persisted = JSON.parse(readFileSync(MODEL_PICKER_STATE_PATH, "utf8"));
+  assert.equal("visible" in persisted, false);
+  const picker = modelPickerSnapshot();
+  assert.equal(picker.hasExplicitVisibility, false);
+  assert.deepEqual(picker.hidden, ["deepseek/deepseek-v4-pro"]);
+  assert.ok(picker.visible.includes("deepseek/deepseek-v4-flash"));
+});

--- a/test/setup-node-deps.test.mjs
+++ b/test/setup-node-deps.test.mjs
@@ -27,7 +27,7 @@ import sys
 import termios
 import time
 
-node, setup, checkout, home, state_dir, secret, confirmation = sys.argv[1:]
+node, setup, checkout, home, state_dir, secret, confirmation, models = sys.argv[1:]
 env = os.environ.copy()
 env.update({
     "HOME": home,
@@ -40,13 +40,19 @@ env.update({
 pid, master = os.forkpty()
 if pid == 0:
     os.chdir(checkout)
-    os.execve(node, [node, setup, "--guided", "--providers", "deepseek", "--selection-only"], env)
+    args = [node, setup, "--guided", "--providers", "deepseek"]
+    # The cancel run has to reach the "Proceed?" gate, which lives past the
+    # --selection-only return.
+    if models != "cancel":
+        args.append("--selection-only")
+    os.execve(node, args, env)
 
 output = bytearray()
 models_cleared = False
 flash_selected = False
 models_confirmed = False
 confirmed = False
+proceeded = False
 key_sent = False
 while True:
     ready, _, _ = select.select([master], [], [], 15)
@@ -63,8 +69,16 @@ while True:
         break
     output.extend(chunk)
     model_prompts = output.count(b"Toggle model numbers")
-    flash = re.search(br"\[x\]\s+(\d+)\. DeepSeek V4 Flash \(API\)", output)
-    if not models_cleared and model_prompts >= 1:
+    # Whatever the step offers, checked or not: the number is what gets typed,
+    # and which mark it carries is the assertion's business, not the driver's.
+    flash = re.search(br"\[[ x]\]\s+(\d+)\. DeepSeek V4 Flash \(API\)", output)
+    if models == "defaults":
+        # The operator who reads the list and presses Enter, which is the one
+        # keystroke that decides what a first install puts in the picker.
+        if not models_confirmed and model_prompts >= 1:
+            os.write(master, b"\n")
+            models_confirmed = True
+    elif not models_cleared and model_prompts >= 1:
         os.write(master, b"n\n")
         models_cleared = True
     elif models_cleared and not flash_selected and model_prompts >= 2:
@@ -76,6 +90,9 @@ while True:
     elif flash_selected and not models_confirmed and model_prompts >= 3:
         os.write(master, b"\n")
         models_confirmed = True
+    if models == "cancel" and not proceeded and b"Proceed?" in output:
+        os.write(master, b"n\n")
+        proceeded = True
     if not confirmed and b"Enter DeepSeek API key securely now?" in output:
         os.write(master, confirmation.encode() + b"\n")
         confirmed = True
@@ -95,7 +112,7 @@ sys.stdout.buffer.write(output)
 raise SystemExit(os.waitstatus_to_exitcode(status))
 `;
 
-function withFreshGuidedSetup(confirmation, verify) {
+function withFreshGuidedSetup(confirmation, verify, models = "select-flash") {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-guided-deps-"));
   const checkout = path.join(testRoot, "checkout");
   const fakeBin = path.join(testRoot, "bin");
@@ -132,6 +149,7 @@ cp -R "$CODEX_ROUTER_TEST_NODE_MODULES" node_modules
         stateDir,
         secret,
         confirmation,
+        models,
       ],
       {
         encoding: "utf8",
@@ -163,13 +181,11 @@ test(
         readFileSync(path.join(stateDir, "deepseek-api-key.secret"), "utf8"),
         `${secret}\n`,
       );
-      const picker = JSON.parse(
-        readFileSync(path.join(stateDir, "model-picker.json"), "utf8"),
-      );
-      assert.deepEqual(picker.visible, [
-        "deepseek/deepseek-v4-flash",
-      ]);
-      assert.ok(picker.hidden.includes("deepseek/deepseek-v4-pro"));
+      // `--selection-only` is documented as saving the provider selection
+      // without installing, and the model step reports its answer the same
+      // way: the picker is rewritten by the install, not by the preview.
+      assert.equal(existsSync(path.join(stateDir, "model-picker.json")), false);
+      assert.match(result.stdout, /"models":\s*\[\s*"deepseek\/deepseek-v4-flash"\s*\]/);
       assert.match(result.stdout, /DeepSeek V4 Flash \(API\)/);
       assert.match(result.stdout, /DeepSeek V4 Pro \(API\)/);
       assert.doesNotMatch(result.stdout, /Kimi K3/);
@@ -189,5 +205,44 @@ test(
       assert.equal(existsSync(path.join(checkout, "node_modules")), false);
       assert.equal(existsSync(path.join(stateDir, "deepseek-api-key.secret")), false);
     });
+  },
+);
+
+test(
+  "guided model selection starts empty so a first install opts in model by model",
+  { skip: process.platform === "win32" || !PYTHON_AVAILABLE },
+  () => {
+    withFreshGuidedSetup(
+      "n",
+      ({ result, stateDir }) => {
+        assert.equal(result.status, 0, result.stderr || result.stdout);
+        // Enabling a provider offers its models; it does not choose them.
+        assert.match(result.stdout, /\[ \] \d+\. DeepSeek V4 Flash \(API\)/);
+        assert.match(result.stdout, /\[ \] \d+\. DeepSeek V4 Pro \(API\)/);
+        assert.doesNotMatch(result.stdout, /\[x\] \d+\. DeepSeek V4/);
+        assert.match(result.stdout, /"models":\s*\[\s*\]/);
+        assert.equal(existsSync(path.join(stateDir, "model-picker.json")), false);
+      },
+      "defaults",
+    );
+  },
+);
+
+test(
+  "a cancelled guided setup leaves the model picker exactly as it found it",
+  { skip: process.platform === "win32" || !PYTHON_AVAILABLE },
+  () => {
+    withFreshGuidedSetup(
+      "n",
+      ({ result, stateDir }) => {
+        assert.notEqual(result.status, 0);
+        assert.match(result.stdout, /Setup was cancelled before installing the service/);
+        assert.match(result.stdout, /Models: deepseek\/deepseek-v4-flash/);
+        // Answering "n" to "Proceed?" installs nothing, so it must also have
+        // rewritten none of this machine's protected picker state.
+        assert.equal(existsSync(path.join(stateDir, "model-picker.json")), false);
+      },
+      "cancel",
+    );
   },
 );

--- a/test/setup-node-deps.test.mjs
+++ b/test/setup-node-deps.test.mjs
@@ -42,6 +42,8 @@ if pid == 0:
     os.execve(node, [node, setup, "--guided", "--providers", "deepseek", "--selection-only"], env)
 
 output = bytearray()
+model_toggled = False
+models_confirmed = False
 confirmed = False
 key_sent = False
 while True:
@@ -58,6 +60,13 @@ while True:
     if not chunk:
         break
     output.extend(chunk)
+    model_prompts = output.count(b"Toggle model numbers")
+    if not model_toggled and model_prompts >= 1:
+        os.write(master, b"2\n")
+        model_toggled = True
+    elif model_toggled and not models_confirmed and model_prompts >= 2:
+        os.write(master, b"\n")
+        models_confirmed = True
     if not confirmed and b"Enter DeepSeek API key securely now?" in output:
         os.write(master, confirmation.encode() + b"\n")
         confirmed = True
@@ -145,6 +154,16 @@ test(
         readFileSync(path.join(stateDir, "deepseek-api-key.secret"), "utf8"),
         `${secret}\n`,
       );
+      const picker = JSON.parse(
+        readFileSync(path.join(stateDir, "model-picker.json"), "utf8"),
+      );
+      assert.deepEqual(picker.visible, [
+        "deepseek/deepseek-v4-flash",
+      ]);
+      assert.deepEqual(picker.hidden, ["deepseek/deepseek-v4-pro"]);
+      assert.match(result.stdout, /DeepSeek V4 Flash \(API\)/);
+      assert.match(result.stdout, /DeepSeek V4 Pro \(API\)/);
+      assert.doesNotMatch(result.stdout, /Kimi K3/);
       assert.equal(existsSync(path.join(checkout, "node_modules", ".package-lock.json")), true);
     });
   },

--- a/test/setup-node-deps.test.mjs
+++ b/test/setup-node-deps.test.mjs
@@ -21,6 +21,7 @@ const PYTHON_AVAILABLE =
 const GUIDED_SETUP_HELPER = String.raw`
 import errno
 import os
+import re
 import select
 import sys
 import termios
@@ -42,7 +43,8 @@ if pid == 0:
     os.execve(node, [node, setup, "--guided", "--providers", "deepseek", "--selection-only"], env)
 
 output = bytearray()
-model_toggled = False
+models_cleared = False
+flash_selected = False
 models_confirmed = False
 confirmed = False
 key_sent = False
@@ -61,10 +63,17 @@ while True:
         break
     output.extend(chunk)
     model_prompts = output.count(b"Toggle model numbers")
-    if not model_toggled and model_prompts >= 1:
-        os.write(master, b"2\n")
-        model_toggled = True
-    elif model_toggled and not models_confirmed and model_prompts >= 2:
+    flash = re.search(br"\[x\]\s+(\d+)\. DeepSeek V4 Flash \(API\)", output)
+    if not models_cleared and model_prompts >= 1:
+        os.write(master, b"n\n")
+        models_cleared = True
+    elif models_cleared and not flash_selected and model_prompts >= 2:
+        if flash is None:
+            os.kill(pid, 9)
+            raise SystemExit("DeepSeek V4 Flash was not listed")
+        os.write(master, flash.group(1) + b"\n")
+        flash_selected = True
+    elif flash_selected and not models_confirmed and model_prompts >= 3:
         os.write(master, b"\n")
         models_confirmed = True
     if not confirmed and b"Enter DeepSeek API key securely now?" in output:
@@ -160,7 +169,7 @@ test(
       assert.deepEqual(picker.visible, [
         "deepseek/deepseek-v4-flash",
       ]);
-      assert.deepEqual(picker.hidden, ["deepseek/deepseek-v4-pro"]);
+      assert.ok(picker.hidden.includes("deepseek/deepseek-v4-pro"));
       assert.match(result.stdout, /DeepSeek V4 Flash \(API\)/);
       assert.match(result.stdout, /DeepSeek V4 Pro \(API\)/);
       assert.doesNotMatch(result.stdout, /Kimi K3/);


### PR DESCRIPTION
Fixes #338. Supersedes #356 and #355 — this branch carries @mayrazing's commits from both, unchanged, plus two review-fix commits. **Please close #356 and #355 in favour of this** (note it therefore also contains the #362 installer work's parent commit; if #362 lands first this rebases cleanly).

These two were fixed together on purpose: they are the same flag, `hasExplicitVisibility`, and fixing #356 without #338 first would have made the production bug worse.

---

## Part 1 — issue #338: an update hides every opencode-go model

`5519c1e` changed the seed list from `seedModelsHidden(NATIVE_CONTEXT_VARIANT_SLUGS)` to also include every selected routed slug. `seedModelsHidden` treats "not in `seeded`" as "never decided" and therefore **hides** it — and on any install predating that commit, `seeded` held only the native-context-variant slugs. So every routed `opencode-go*` slug is "fresh" on the first rebuild of the new build and disappears from the picker.

The legacy migration in `readPickerState` cannot save it: it reconstructs `visible` as `seeded − hidden`, and those slugs were never in `seeded`.

**Fix:** `migrateLegacyVisibleModels(slugs)` reproduces the old "not hidden ⇒ visible" rule exactly once, at the moment the allowlist takes over, invoked immediately before `seedModelsHidden`. It is a no-op unless the state file exists *and* still lacks a `visible` key, and it promotes only slugs in neither `hidden` nor `seeded` — so a model someone deliberately hid stays hidden. Adding to `seeded` as well as `visible` is load-bearing: without it the very next `seedModelsHidden` re-hides them.

`readPickerState` now also reports `recognized`, so "no state file" and "the file says nothing is hidden" stop being the same answer.

Native context variants are deliberately **not** passed to the migration — they have never been visible-by-default under either semantics, so a pre-existing install must not have `gpt-5.6-sol-1m` promoted.

**Verified as a real regression test:** disabling the migration call makes the new end-to-end `test/catalog.test.mjs` case fail. It stages a pre-`5519c1e` picker file, spawns `src/catalog.mjs --refresh-native` against a stub Codex, and asserts the previously-showing slugs publish as `visibility: "list"` while the hidden one and the native variant publish as `"hide"`.

### Honest limitation

This only helps installs that have **not yet run** the new build. Anyone already bitten has those slugs in both `hidden` and `seeded`, which is indistinguishable from a deliberate hide — the migration is correctly a no-op for them. `CHANGELOG.md` documents the recovery command (`./bin/control picker provider <id> show`). No heuristic repair is shipped, because guessing would un-hide models operators switched off on purpose.

---

## Part 2 — PR #356 review fixes

**`setModelSelection` flipped `hasExplicitVisibility` globally from a partial view.** It called `writePickerState` without the flag, and the default is `true` — permanently switching every router-managed slug from `!hidden` to `visible.has(...)`, which is precisely the #338 mechanism. Now threaded through exactly as `seedModelsHidden` does.

**The all-models-preselected default.** `src/catalog.mjs` states the opt-in policy in code: *"simply enabling a provider or updating a catalog must not make every one of its models appear."* Pre-checking everything reversed that silently — selecting `commandcode` + `opencode-go` put ~50 models in the picker on one Enter keystroke.

A flat "start empty" would have been wrong too: it regresses re-runs, hiding an operator's own models when they press Enter. So `effectiveVisibleModels(slugs)` answers with the same rule every publisher uses (`hasExplicitVisibility ? visible : !hidden`) and returns empty when no state file exists. Result: **nothing pre-checked on a first install, the existing picker pre-checked on a re-run.** The written policy needed no amendment.

**Cancelled setups no longer mutate picker state.** The write moved below the "Proceed?" confirmation and below the migration gate that can throw. Answering "n" previously left `model-picker.json` already rewritten.

**`--selection-only` no longer persists visibility.** The same move puts the write below its early return, so the flag matches its documented "save provider selection without installing (development)" meaning. The JSON output still previews the chosen models.

> The existing test **asserted this bug** — it read `state/model-picker.json` after a `--selection-only` run and required it to exist. Rewritten to assert the file is absent.

---

## Tests

8 new, across three files: legacy migration (with the deliberately-hidden slug and the native variant both staying hidden), migration idempotence (asserts the protected file is byte-identical on a second run), fresh-install no-op, `effectiveVisibleModels` across both state formats and neither, `setModelSelection` not flipping the flag on a legacy file, the end-to-end catalog publish, the "press Enter immediately" path, and a cancelled-setup test answering "n" to "Proceed?".

- `node scripts-check.mjs` — passes
- `node --test test/*.test.mjs` — 2110 tests, **0 failures**, 13 pre-existing skips (baseline on `pr-356` was 2102 / 0 fail)

## Left alone, flagged

- `setModelsVisible` / `setAllModelsVisible` / `setModelVisible` share the same "partial view flips the flag" shape, but they are direct operator commands on named slugs and an existing test pins the flip as intended. Out of scope.
- `writeProviderSelection` still runs before "Proceed?", with the same cancelled-setup mutation shape. Pre-existing; moving it risks the vision-bridge and discovery-mode logic that reads provider selection in between.
- An install with **no** `model-picker.json` at all is treated as fresh and opts in rather than migrating. Undetectable without guessing; the CHANGELOG recovery command covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)