### PR TITLE
feat: reload provider catalogs from tray (rebased + hardened)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **The macOS tray can load a provider's current model list and curate from
+  it.** A new Provider catalogs panel asks any configured provider that
+  supports live discovery for the models it serves right now, marks the ones
+  already routed, and adds a selection through the same `curate-models.mjs`
+  path the desktop app uses -- so the tray no longer has to hand people back
+  to a terminal to pick up a model their provider shipped after install. The
+  first open is answered from the router's stored list, so it costs no round
+  trip and works offline; only Reload re-asks upstream. Model ids coming back
+  from a provider are held to the same slug rule the Electron app enforces
+  before any of them reaches curation, and every discovery or curation run is
+  bounded by the Electron timeouts, so a provider that accepts the connection
+  and never answers can no longer wedge the panel's buttons for the rest of
+  the session. The panel is translated in all six tray languages.
+
 - **Grok 4.6 can select Codex's native image viewer.** xAI stopped without a
   function call when the tool was named `view_image`, even when selection was
   required. The Grok OAuth boundary now presents that tool as `inspect_image`

--- a/apps/control-center/src/ServiceHealth.tsx
+++ b/apps/control-center/src/ServiceHealth.tsx
@@ -37,34 +37,38 @@ export function ServiceHealthPanel({ health, compact = false, onOpen, onRepair, 
     </section>
   ) : (
     <section className="panel-section service-health-panel">
-      <details
-        className="service-health-accordion"
-        open={detailsOpen}
-        onToggle={(event) => setDetailsOpen(event.currentTarget.open)}
-      >
-        <summary>
+      <div className="service-health-accordion">
+        <div className="service-health-accordion-header">
+          <button
+            type="button"
+            className="service-health-toggle"
+            aria-expanded={detailsOpen}
+            aria-controls="service-health-details"
+            onClick={() => setDetailsOpen((open) => !open)}
+          >
           <span className="service-health-summary-copy">
             <strong>Service health</strong>
             <small>{attention ? "A local dependency needs attention." : "Router and local dependencies."}</small>
           </span>
-          <span className="service-health-summary-status">
+            <ChevronDown className={detailsOpen ? "is-open" : undefined} aria-hidden size={15} strokeWidth={1.7} />
+          </button>
+          <div className="service-health-header-actions">
             <Badge tone={attention ? "warning" : health ? "success" : "neutral"}>{summary}</Badge>
-            <ChevronDown aria-hidden size={15} strokeWidth={1.7} />
-          </span>
-        </summary>
-        <div className="service-health-details">
-          <div className="service-health-actions">
             {onRepair && attention ? (
               <Button variant="secondary" disabled={repairing} onClick={onRepair}>
                 {repairing ? "Repairing…" : "Fix"}
               </Button>
             ) : null}
           </div>
+        </div>
+        {detailsOpen ? (
+          <div id="service-health-details" className="service-health-details">
           <div className="service-health-list" role="list" aria-label="Router service health">
             {rows.map((row) => <ServiceHealthRowView key={row.id} row={row} />)}
           </div>
-        </div>
-      </details>
+          </div>
+        ) : null}
+      </div>
     </section>
   );
 }

--- a/apps/control-center/src/ServiceHealth.tsx
+++ b/apps/control-center/src/ServiceHealth.tsx
@@ -46,10 +46,10 @@ export function ServiceHealthPanel({ health, compact = false, onOpen, onRepair, 
             aria-controls="service-health-details"
             onClick={() => setDetailsOpen((open) => !open)}
           >
-          <span className="service-health-summary-copy">
-            <strong>Service health</strong>
-            <small>{attention ? "A local dependency needs attention." : "Router and local dependencies."}</small>
-          </span>
+            <span className="service-health-summary-copy">
+              <strong>Service health</strong>
+              <small>{attention ? "A local dependency needs attention." : "Router and local dependencies."}</small>
+            </span>
             <ChevronDown className={detailsOpen ? "is-open" : undefined} aria-hidden size={15} strokeWidth={1.7} />
           </button>
           <div className="service-health-header-actions">
@@ -61,13 +61,14 @@ export function ServiceHealthPanel({ health, compact = false, onOpen, onRepair, 
             ) : null}
           </div>
         </div>
-        {detailsOpen ? (
-          <div id="service-health-details" className="service-health-details">
+        {/* Kept mounted and `hidden` rather than unmounted: the toggle's
+            aria-controls has to resolve to a real element in both states, and
+            `hidden` is what tells assistive tech the region is collapsed. */}
+        <div id="service-health-details" className="service-health-details" hidden={!detailsOpen}>
           <div className="service-health-list" role="list" aria-label="Router service health">
             {rows.map((row) => <ServiceHealthRowView key={row.id} row={row} />)}
           </div>
-          </div>
-        ) : null}
+        </div>
       </div>
     </section>
   );

--- a/apps/control-center/src/pages/StatusPage.tsx
+++ b/apps/control-center/src/pages/StatusPage.tsx
@@ -289,7 +289,7 @@ export function StatusPage({
             description="Live work from the local health endpoint, grouped by chat and named agent."
           />
           <div className="st-router-state">
-            <span className={`st-status-orb state-${state}`} aria-hidden="true"><i /></span>
+            <RouterActivityOrb state={state} />
             <div>
               <strong>{activityLabel(state)}</strong>
               <small>{activity?.model || (health?.ok
@@ -602,6 +602,20 @@ export function StatusPage({
         )}
       </section>
     </div>
+  );
+}
+
+function RouterActivityOrb({ state }: { state: string }) {
+  return (
+    <span className={`st-status-orb state-${state}`} aria-hidden="true">
+      <i className="st-orb-core" />
+      <span className="st-orb-particle" />
+      <span className="st-orb-particle" />
+      <span className="st-orb-particle" />
+      <span className="st-orb-particle" />
+      <span className="st-orb-particle" />
+      <span className="st-orb-particle" />
+    </span>
   );
 }
 

--- a/apps/control-center/src/pages/usage-status.css
+++ b/apps/control-center/src/pages/usage-status.css
@@ -1132,72 +1132,115 @@
 }
 
 .status-page .st-status-orb {
-  display: grid;
-  width: 38px;
-  height: 38px;
+  position: relative;
+  display: block;
+  width: 42px;
+  height: 42px;
   flex: 0 0 auto;
-  place-items: center;
   border-radius: 50%;
-  background: var(--surface-2);
+  border: 1px solid color-mix(in srgb, var(--line-strong) 72%, transparent);
+  background: radial-gradient(circle at 38% 32%, color-mix(in srgb, var(--surface-0) 78%, transparent), var(--surface-2));
+  overflow: hidden;
 }
 
-.status-page .st-status-orb i {
-  width: 9px;
-  height: 9px;
+.status-page .st-orb-core,
+.status-page .st-orb-particle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
   border-radius: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.status-page .st-orb-core {
+  width: 10px;
+  height: 10px;
   background: var(--ink-faint);
 }
 
-.status-page .st-status-orb.state-generating i {
-  position: relative;
-  width: 10px;
-  height: 10px;
+.status-page .st-orb-particle {
+  width: 4px;
+  height: 4px;
+  background: color-mix(in srgb, var(--ink-faint) 70%, var(--surface-0));
+  opacity: 0.54;
+}
+
+.status-page .st-orb-particle:nth-of-type(1) { --orb-angle: 12deg; --orb-delay: -0.12s; }
+.status-page .st-orb-particle:nth-of-type(2) { --orb-angle: 72deg; --orb-delay: -0.45s; }
+.status-page .st-orb-particle:nth-of-type(3) { --orb-angle: 132deg; --orb-delay: -0.83s; }
+.status-page .st-orb-particle:nth-of-type(4) { --orb-angle: 192deg; --orb-delay: -0.26s; }
+.status-page .st-orb-particle:nth-of-type(5) { --orb-angle: 252deg; --orb-delay: -1.04s; }
+.status-page .st-orb-particle:nth-of-type(6) { --orb-angle: 312deg; --orb-delay: -0.64s; }
+
+.status-page .st-status-orb.state-idle .st-orb-core {
+  animation: st-orb-idle-core 4.4s ease-in-out infinite;
+}
+
+.status-page .st-status-orb.state-idle .st-orb-particle {
+  transform: translate(-50%, -50%) rotate(var(--orb-angle)) translateY(-13px);
+  animation: st-orb-idle-particle 4.4s ease-in-out var(--orb-delay) infinite;
+}
+
+.status-page .st-status-orb.state-generating {
+  border-color: color-mix(in srgb, var(--success) 35%, var(--line));
+  background: radial-gradient(circle at 42% 36%, color-mix(in srgb, var(--success) 16%, var(--surface-0)), var(--surface-2));
+}
+
+.status-page .st-status-orb.state-generating .st-orb-core {
   background: var(--success);
-  filter: drop-shadow(0 0 6px color-mix(in srgb, var(--success) 44%, transparent));
-  animation: st-thinking-core 1.35s ease-in-out infinite;
+  animation: st-orb-working-core 1.45s cubic-bezier(.42, 0, .2, 1) infinite;
 }
 
-.status-page .st-status-orb.state-generating i::before,
-.status-page .st-status-orb.state-generating i::after {
-  position: absolute;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  content: "";
+.status-page .st-status-orb.state-generating .st-orb-particle {
+  background: color-mix(in srgb, var(--success) 72%, var(--accent));
+  animation: st-orb-working-particle 1.8s cubic-bezier(.42, 0, .2, 1) var(--orb-delay) infinite;
 }
 
-.status-page .st-status-orb.state-generating i::before {
-  top: -6px;
-  right: -5px;
-  background: color-mix(in srgb, var(--accent) 68%, var(--success));
-  box-shadow: 0 0 9px color-mix(in srgb, var(--accent) 30%, transparent);
-  animation: st-thinking-orbit-one 1.35s ease-in-out infinite;
+.status-page .st-status-orb.state-starting .st-orb-core {
+  background: var(--warning);
+  animation: st-orb-connecting-core 1.6s ease-in-out infinite;
 }
 
-.status-page .st-status-orb.state-generating i::after {
-  bottom: -5px;
-  left: -6px;
-  background: color-mix(in srgb, var(--success) 55%, white);
-  animation: st-thinking-orbit-two 1.35s ease-in-out infinite;
+.status-page .st-status-orb.state-starting .st-orb-particle {
+  background: color-mix(in srgb, var(--warning) 76%, var(--surface-0));
+  animation: st-orb-working-particle 2.2s linear var(--orb-delay) infinite;
 }
 
-.status-page .st-status-orb.state-starting i { background: var(--warning); }
-.status-page .st-status-orb.state-error i,
-.status-page .st-status-orb.state-offline i { background: var(--danger); }
+.status-page .st-status-orb.state-error .st-orb-core,
+.status-page .st-status-orb.state-offline .st-orb-core { background: var(--danger); }
 
-@keyframes st-thinking-core {
-  0%, 100% { transform: scale(0.78); opacity: 0.72; }
-  50% { transform: scale(1.1); opacity: 1; }
+.status-page .st-status-orb.state-error .st-orb-particle,
+.status-page .st-status-orb.state-offline .st-orb-particle { display: none; }
+
+@keyframes st-orb-idle-core {
+  0%, 100% { transform: translate(-50%, -50%) scale(.88); opacity: .7; }
+  50% { transform: translate(-50%, -50%) scale(1); opacity: .92; }
 }
 
-@keyframes st-thinking-orbit-one {
-  0%, 100% { transform: translate(-2px, 2px) scale(0.72); opacity: 0.52; }
-  50% { transform: translate(2px, -2px) scale(1.08); opacity: 1; }
+@keyframes st-orb-idle-particle {
+  0%, 100% { opacity: .25; }
+  50% { opacity: .58; }
 }
 
-@keyframes st-thinking-orbit-two {
-  0%, 100% { transform: translate(2px, -2px) scale(1.04); opacity: 0.84; }
-  50% { transform: translate(-2px, 2px) scale(0.68); opacity: 0.42; }
+@keyframes st-orb-working-core {
+  0%, 100% { transform: translate(-50%, -50%) scale(.76); }
+  48% { transform: translate(-50%, -50%) scale(1.08); }
+}
+
+@keyframes st-orb-working-particle {
+  0% { transform: translate(-50%, -50%) rotate(var(--orb-angle)) translateY(-8px) scale(.55); opacity: .22; }
+  48% { transform: translate(-50%, -50%) rotate(calc(var(--orb-angle) + 82deg)) translateY(-15px) scale(1.1); opacity: 1; }
+  100% { transform: translate(-50%, -50%) rotate(calc(var(--orb-angle) + 164deg)) translateY(-8px) scale(.55); opacity: .22; }
+}
+
+@keyframes st-orb-connecting-core {
+  0%, 100% { transform: translate(-50%, -50%) scale(.74); opacity: .68; }
+  50% { transform: translate(-50%, -50%) scale(1.04); opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-page .st-status-orb *,
+  .status-page .st-status-orb { animation: none !important; }
 }
 
 .status-page .st-subsection-heading {

--- a/apps/control-center/src/styles.css
+++ b/apps/control-center/src/styles.css
@@ -787,17 +787,36 @@ textarea::placeholder {
   overflow: hidden;
 }
 
-.service-health-accordion > summary {
+.service-health-accordion-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 16px 20px;
-  cursor: pointer;
-  list-style: none;
+  min-height: 62px;
+  padding: 10px 12px 10px 20px;
 }
 
-.service-health-accordion > summary::-webkit-details-marker { display: none; }
+.service-health-toggle {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 10px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.service-health-toggle > svg {
+  flex: 0 0 auto;
+  color: var(--ink-faint);
+  transition: transform 160ms ease;
+}
+
+.service-health-toggle > svg.is-open { transform: rotate(180deg); }
 
 .service-health-summary-copy {
   display: grid;
@@ -819,30 +838,16 @@ textarea::placeholder {
   white-space: nowrap;
 }
 
-.service-health-summary-status {
+.service-health-header-actions {
   display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   gap: 8px;
-  color: var(--ink-faint);
 }
 
-.service-health-accordion[open] > summary {
-  border-bottom: 1px solid var(--line);
-}
-
-.service-health-accordion[open] > summary svg { transform: rotate(180deg); }
-
-.service-health-summary-status svg { transition: transform 160ms ease; }
-
-.service-health-details { padding: 0 20px 8px; }
-
-.service-health-actions {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
-  padding-top: 10px;
+.service-health-details {
+  padding: 0 20px 5px;
+  border-top: 1px solid var(--line);
 }
 
 .service-health-list {
@@ -855,9 +860,12 @@ textarea::placeholder {
   gap: 9px;
   min-width: 0;
   align-items: center;
-  padding: 12px 0;
-  border-top: 1px solid var(--line);
+  min-height: 54px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--line);
 }
+
+.service-health-row:last-child { border-bottom: 0; }
 
 .service-health-row > svg {
   color: var(--ink-faint);
@@ -876,7 +884,7 @@ textarea::placeholder {
 .service-health-row strong {
   overflow: hidden;
   color: var(--ink-strong);
-  font-size: 10.5px;
+  font-size: 11px;
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -885,7 +893,7 @@ textarea::placeholder {
 .service-health-row small {
   overflow: hidden;
   color: var(--ink-faint);
-  font-size: 9.5px;
+  font-size: 9px;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/apps/control-center/src/styles.css
+++ b/apps/control-center/src/styles.css
@@ -850,6 +850,10 @@ textarea::placeholder {
   border-top: 1px solid var(--line);
 }
 
+/* The collapsed region stays mounted so the toggle's aria-controls resolves;
+   this keeps `hidden` authoritative if the rule above ever gains a display. */
+.service-health-details[hidden] { display: none; }
+
 .service-health-list {
   display: grid;
 }

--- a/apps/macos/ModelRouterTray/Sources/Localization.swift
+++ b/apps/macos/ModelRouterTray/Sources/Localization.swift
@@ -512,5 +512,28 @@ enum RouterChineseText {
     // "思考强度" is the vocabulary already used for effort elsewhere here.
     "Subagent": "子代理",
     "thinking": "思考强度",
+
+    // Provider catalogs: the on-demand panel that asks a configured
+    // provider for its current model list and curates from it.
+    "Provider catalogs": "服务商模型目录",
+    "Load the latest provider models": "加载服务商的最新模型",
+    "Connect a supported provider to load its latest models.": "先连接受支持的服务商，才能加载其最新模型。",
+    "Load models asks that provider for its current list. Choosing models adds them to the router and republishes every installed client.": "“加载模型”会向该服务商索取当前列表。选择模型后会将其加入路由，并重新发布所有已安装的客户端。",
+    "Reload provider models": "重新加载服务商模型",
+    "Reloading provider models…": "正在重新加载服务商模型…",
+    "Fetch the current catalog from every connected provider that supports live model discovery.": "从每个支持实时模型发现的已连接服务商获取当前目录。",
+    "Refresh models": "刷新模型",
+    "Reload installed and available local models from the router.": "从路由重新加载已安装和可用的本地模型。",
+    "Loading models": "正在加载模型",
+    "Search available models": "搜索可用模型",
+    "No provider models match this search.": "没有服务商模型匹配此搜索。",
+    "Added": "已添加",
+    "Showing the first 80 matches. Search to narrow the list.": "仅显示前 80 条匹配结果。请搜索以缩小范围。",
+    "%d selected": "已选择 %d 个",
+    "Add selected": "添加所选",
+    "Load the current list from this provider.": "从该服务商加载当前列表。",
+    "saved list": "已保存列表",
+    "live list": "实时列表",
+    "%d models · %d added · %@": "%d 个模型 · 已添加 %d 个 · %@",
   ]
 }

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -203,6 +203,11 @@ final class RouterStore: ObservableObject {
   @Published private(set) var providerUsage: ProviderUsageSnapshot?
   @Published private(set) var providerUsageError: String?
   @Published private(set) var providerSetup: [String: ProviderSetupState] = [:]
+  // Provider discovery is deliberately on-demand. Unlike router status, this
+  // may make a network request to a provider, so the tray only does it after
+  // the user presses Load/Reload models for that provider.
+  @Published private(set) var providerCatalogs: [String: ProviderModelCatalog] = [:]
+  @Published private(set) var providerCatalogLoading = Set<String>()
   @Published private(set) var providerOperation: String?
   @Published private(set) var visionDownload: VisionDownloadState?
   @Published private(set) var localDownload: VisionDownloadState?
@@ -1391,6 +1396,55 @@ final class RouterStore: ObservableObject {
     } catch {
       let nextMessage = error.localizedDescription
       if message != nextMessage { message = nextMessage }
+    }
+  }
+
+  func reloadProviderCatalog(_ provider: String) async {
+    guard !providerCatalogLoading.contains(provider) else { return }
+    providerCatalogLoading.insert(provider)
+    defer { providerCatalogLoading.remove(provider) }
+    do {
+      let output = try await runRouterScript(
+        "model-discovery.mjs",
+        arguments: [provider, "--refresh", "--json"]
+      )
+      let catalog = try JSONDecoder().decode(ProviderModelCatalog.self, from: output)
+      providerCatalogs[provider] = catalog
+      message = "\(catalog.discovered.count) current \(provider) models loaded. Select the ones to add below."
+    } catch {
+      message = "\(provider): \(error.localizedDescription)"
+    }
+  }
+
+  func reloadAvailableProviderCatalogs() async {
+    let providers = providerSetup.values
+      .filter { $0.configured && $0.supportsLiveModelCatalog }
+      .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+    guard !providers.isEmpty, providerCatalogLoading.isEmpty else { return }
+    for provider in providers {
+      await reloadProviderCatalog(provider.id)
+    }
+    message = "Reloaded current models for \(providers.count) provider\(providers.count == 1 ? "" : "s")."
+  }
+
+  func addProviderCatalogModels(_ provider: String, modelIDs: [String]) async {
+    let unique = Array(Set(modelIDs)).sorted()
+    guard !unique.isEmpty, unique.count <= 200, !providerCatalogLoading.contains(provider) else { return }
+    providerCatalogLoading.insert(provider)
+    do {
+      // Curation repeats a live discovery before committing, then atomically
+      // republishes every installed client. Never turn a cached list directly
+      // into routes that may already have been withdrawn upstream.
+      _ = try await runRouterScript("curate-models.mjs", arguments: [
+        provider, "--models", unique.joined(separator: ","), "--refresh", "--apply",
+      ])
+      await refresh()
+      providerCatalogLoading.remove(provider)
+      await reloadProviderCatalog(provider)
+      message = "\(unique.count) \(provider) model\(unique.count == 1 ? "" : "s") added. Restart Codex to refresh its picker."
+    } catch {
+      providerCatalogLoading.remove(provider)
+      message = "\(provider): \(error.localizedDescription)"
     }
   }
 
@@ -2592,6 +2646,49 @@ final class RouterStore: ObservableObject {
     }.value
   }
 
+  // These are two UI-owned entry points that the generic control plane does
+  // not expose. Keep the allow-list here: provider ids and model ids are data,
+  // never a command path, and the tray must not become an arbitrary script
+  // launcher just to mirror Electron's catalog controls.
+  private func runRouterScript(_ script: String, arguments: [String]) async throws -> Data {
+    guard ["model-discovery.mjs", "curate-models.mjs"].contains(script) else {
+      throw RouterError("Unsupported Model Router script.")
+    }
+    let root = try sourceRoot()
+    let scriptURL = root.appendingPathComponent("src").appendingPathComponent(script)
+    return try await Task.detached {
+      let task = Process()
+      task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+      task.arguments = ["node", scriptURL.path] + arguments
+      task.currentDirectoryURL = root
+      var environment = ProcessInfo.processInfo.environment
+      let home = FileManager.default.homeDirectoryForCurrentUser.path
+      let preferredPaths = [
+        "\(home)/.npm-global/bin",
+        "\(home)/.local/bin",
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+      ]
+      environment["PATH"] = (preferredPaths + [environment["PATH"] ?? ""]).joined(separator: ":")
+      task.environment = environment
+      let output = Pipe()
+      let errors = Pipe()
+      task.standardOutput = output
+      task.standardError = errors
+      try task.run()
+      let stdoutReader = Task.detached { output.fileHandleForReading.readDataToEndOfFile() }
+      let stderrReader = Task.detached { errors.fileHandleForReading.readDataToEndOfFile() }
+      task.waitUntilExit()
+      let stdout = await stdoutReader.value
+      let stderr = await stderrReader.value
+      guard task.terminationStatus == 0 else {
+        let detail = String(data: stderr, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        throw RouterError(detail?.isEmpty == false ? detail! : "Model Router command failed.")
+      }
+      return stdout
+    }.value
+  }
+
   private func sourceRoot() throws -> URL {
     guard let configured = Bundle.main.object(forInfoDictionaryKey: "ModelRouterSourceRoot") as? String,
       !configured.isEmpty
@@ -3506,6 +3603,25 @@ struct ProviderSetupState: Decodable, Identifiable, Equatable {
   // rather than after a 403 lands in Codex.
   let planNote: String?
   let anonymousNote: String?
+
+  // Match the Electron catalog surface: these sources either have no single
+  // provider endpoint to interrogate or are owned by the client/runtime.
+  // Showing a Load button for them would promise a request that discovery
+  // correctly refuses.
+  var supportsLiveModelCatalog: Bool {
+    !["openai", "local", "lmstudio", "custom", "devin-cli", "anthropic-api"].contains(id)
+  }
+}
+
+struct ProviderModelCatalog: Decodable, Equatable {
+  let provider: String
+  let discovered: [String]
+  let registered: [String]
+  let unregistered: [String]
+  let unavailable: [String]
+  let cached: Bool?
+  let stale: Bool?
+  let fetchedAt: String?
 }
 
 private struct MenuBarIconView: View {
@@ -4650,6 +4766,7 @@ private struct TrayView: View {
     let target: RouterTarget
     @State private var subagentsExpanded = true
     @State private var pickerExpanded = true
+    @State private var providerCatalogsExpanded = true
     @State private var visionExpanded = true
     // Local models are a first-class install surface. Keep this section open
     // on launch so the catalog is not hidden behind the other settings cards.
@@ -4706,6 +4823,10 @@ private struct TrayView: View {
           if $0.provider != $1.provider { return $0.provider < $1.provider }
           return $0.slug < $1.slug
         }
+    }
+
+    private var canReloadProviderCatalogs: Bool {
+      store.providerSetup.values.contains { $0.configured && $0.supportsLiveModelCatalog }
     }
 
     private func providerGroups(_ models: [RouterModel]) -> [ProviderModels] {
@@ -4838,9 +4959,24 @@ private struct TrayView: View {
           expanded: $pickerExpanded
         ) {
           VStack(alignment: .leading, spacing: 8) {
-            Text(routerLocalized("Hidden models stay connected but are not offered by Codex."))
-              .font(.system(size: 9))
-              .foregroundStyle(routerMuted)
+            HStack(alignment: .top, spacing: 8) {
+              Text(routerLocalized("Hidden models stay connected but are not offered by Codex."))
+                .font(.system(size: 9))
+                .foregroundStyle(routerMuted)
+              Spacer(minLength: 0)
+              Button(
+                store.providerCatalogLoading.isEmpty
+                  ? routerLocalized("Reload provider models")
+                  : routerLocalized("Reloading provider models…")
+              ) {
+                Task { await store.reloadAvailableProviderCatalogs() }
+              }
+              .buttonStyle(.borderless)
+              .font(.system(size: 9, weight: .medium))
+              .foregroundStyle(routerMint)
+              .disabled(!canReloadProviderCatalogs || !store.providerCatalogLoading.isEmpty)
+              .help(routerLocalized("Fetch the current catalog from every connected provider that supports live model discovery."))
+            }
             toolbar(
               buttons: [
                 ("Show all", { Task { await store.showAllPickerModels() } }),
@@ -4891,6 +5027,14 @@ private struct TrayView: View {
           localLlmPanel
         }
 
+        AccordionPanel(
+          title: routerLocalized("Provider catalogs"),
+          summary: routerLocalized("Load the latest provider models"),
+          expanded: $providerCatalogsExpanded
+        ) {
+          providerCatalogPanel
+        }
+
         // Header says "Vision" and nothing else; the state it used to summarise
         // is one line below, in the toggle's own detail.
         AccordionPanel(
@@ -4934,9 +5078,20 @@ private struct TrayView: View {
     // phrases truncate in place instead of making the panel wider or taller.
     @ViewBuilder private var localLlmPanel: some View {
       VStack(alignment: .leading, spacing: 10) {
-        Text(routerLocalized("Run local models through Ollama or the curated MLX runtime. Installed models are wired into the same Codex proxy."))
-          .font(.system(size: 9))
-          .foregroundStyle(routerMuted)
+        HStack(alignment: .top, spacing: 8) {
+          Text(routerLocalized("Run local models through Ollama or the curated MLX runtime. Installed models are wired into the same Codex proxy."))
+            .font(.system(size: 9))
+            .foregroundStyle(routerMuted)
+          Spacer(minLength: 0)
+          Button(store.isRefreshing ? routerLocalized("Refreshing…") : routerLocalized("Refresh models")) {
+            Task { await store.refresh() }
+          }
+          .buttonStyle(.borderless)
+          .font(.system(size: 9, weight: .medium))
+          .foregroundStyle(routerMint)
+          .disabled(store.isRefreshing)
+          .help(routerLocalized("Reload installed and available local models from the router."))
+        }
         localMlxSection
         if let operation = store.localModelOperation {
           localModelOperationStatus(operation)
@@ -4962,6 +5117,35 @@ private struct TrayView: View {
         }
       }
       .animation(.easeOut(duration: 0.2), value: store.localModelOperation)
+    }
+
+    private var catalogProviders: [ProviderSetupState] {
+      store.providerSetup.values
+        .filter { $0.configured && $0.supportsLiveModelCatalog }
+        .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
+    }
+
+    @ViewBuilder private var providerCatalogPanel: some View {
+      VStack(alignment: .leading, spacing: 8) {
+        if catalogProviders.isEmpty {
+          Text(routerLocalized("Connect a supported provider to load its latest models."))
+            .font(.system(size: 9))
+            .foregroundStyle(routerMuted)
+        } else {
+          Text(routerLocalized("Load models asks that provider for its current list. Choosing models adds them to the router and republishes every installed client."))
+            .font(.system(size: 9))
+            .foregroundStyle(routerMuted)
+          ForEach(catalogProviders) { provider in
+            ProviderCatalogRow(
+              provider: provider,
+              catalog: store.providerCatalogs[provider.id],
+              isLoading: store.providerCatalogLoading.contains(provider.id),
+              onReload: { Task { await store.reloadProviderCatalog(provider.id) } },
+              onAdd: { models in Task { await store.addProviderCatalogModels(provider.id, modelIDs: models) } }
+            )
+          }
+        }
+      }
     }
 
     /// The curated MLX install is deliberately separate from Ollama: it has a
@@ -6512,6 +6696,132 @@ private struct TrayView: View {
         Color.primary.opacity(0.045),
         in: RoundedRectangle(cornerRadius: 10, style: .continuous)
       )
+    }
+  }
+
+  private struct ProviderCatalogRow: View {
+    let provider: ProviderSetupState
+    let catalog: ProviderModelCatalog?
+    let isLoading: Bool
+    let onReload: () -> Void
+    let onAdd: ([String]) -> Void
+
+    @State private var query = ""
+    @State private var selected = Set<String>()
+
+    private var matchingModels: [String] {
+      guard let catalog else { return [] }
+      let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+      return catalog.discovered.filter { needle.isEmpty || $0.lowercased().contains(needle) }
+    }
+
+    var body: some View {
+      VStack(alignment: .leading, spacing: 7) {
+        HStack(spacing: 8) {
+          VStack(alignment: .leading, spacing: 2) {
+            Text(provider.displayName)
+              .font(.system(size: 10, weight: .medium))
+            Text(catalogDetail)
+              .font(.system(size: 8))
+              .foregroundStyle(routerMutedStrong)
+          }
+          Spacer()
+          Button(isLoading ? routerLocalized("Loading models") : routerLocalized(catalog == nil ? "Load models" : "Reload models"), action: onReload)
+            .buttonStyle(.borderless)
+            .font(.system(size: 9, weight: .medium))
+            .foregroundStyle(routerMint)
+            .disabled(isLoading)
+        }
+
+        if let catalog {
+          let registered = Set(catalog.registered)
+          TextField(routerLocalized("Search available models"), text: $query)
+            .textFieldStyle(.roundedBorder)
+            .font(.system(size: 9))
+
+          if matchingModels.isEmpty {
+            Text(routerLocalized("No provider models match this search."))
+              .font(.system(size: 8))
+              .foregroundStyle(routerMutedStrong)
+              .padding(.vertical, 2)
+          } else {
+            VStack(spacing: 0) {
+              ForEach(Array(matchingModels.prefix(80)), id: \.self) { model in
+                HStack(spacing: 7) {
+                  if registered.contains(model) {
+                    Image(systemName: "checkmark.circle.fill")
+                      .font(.system(size: 10))
+                      .foregroundStyle(routerMint)
+                      .frame(width: 14)
+                  } else {
+                    Toggle("", isOn: Binding(
+                      get: { selected.contains(model) },
+                      set: { checked in
+                        if checked { selected.insert(model) } else { selected.remove(model) }
+                      }
+                    ))
+                    .labelsHidden()
+                    .toggleStyle(.checkbox)
+                    .controlSize(.mini)
+                    .frame(width: 14)
+                    .disabled(isLoading)
+                  }
+                  Text(model)
+                    .font(.system(size: 8, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                  Spacer(minLength: 0)
+                  if registered.contains(model) {
+                    Text(routerLocalized("Added"))
+                      .font(.system(size: 8, weight: .medium))
+                      .foregroundStyle(routerMutedStrong)
+                  }
+                }
+                .padding(.vertical, 3)
+                if model != matchingModels.prefix(80).last {
+                  Divider()
+                }
+              }
+            }
+            .padding(.horizontal, 3)
+            .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            if matchingModels.count > 80 {
+              Text(routerLocalized("Showing the first 80 matches. Search to narrow the list."))
+                .font(.system(size: 8))
+                .foregroundStyle(routerMutedStrong)
+            }
+          }
+
+          if !selected.isEmpty {
+            HStack(spacing: 8) {
+              Text("\(selected.count) \(routerLocalized("selected"))")
+                .font(.system(size: 8))
+                .foregroundStyle(routerMutedStrong)
+              Spacer()
+              Button(routerLocalized("Add selected")) {
+                onAdd(selected.sorted())
+              }
+              .buttonStyle(.borderless)
+              .font(.system(size: 9, weight: .medium))
+              .foregroundStyle(routerMint)
+              .disabled(isLoading)
+            }
+          }
+        }
+      }
+      .padding(8)
+      .background(Color.primary.opacity(0.035), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+      .onChange(of: catalog?.fetchedAt) { _ in
+        selected.formIntersection(Set(catalog?.unregistered ?? []))
+      }
+    }
+
+    private var catalogDetail: String {
+      guard let catalog else { return routerLocalized("Load the current list from this provider.") }
+      let available = catalog.discovered.count
+      let added = catalog.registered.count
+      let freshness = catalog.cached == true ? routerLocalized("saved list") : routerLocalized("live list")
+      return "\(available) \(routerLocalized("models")) · \(added) \(routerLocalized("added")) · \(freshness)"
     }
   }
 

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -2846,7 +2846,9 @@ final class RouterScriptWatchdog: @unchecked Sendable {
   private let lock = NSLock()
   private var finished = false
   private var timedOut = false
-  private var timer: DispatchWorkItem?
+  // Signalled by `disarm` so a deadline that is no longer needed stops waiting
+  // immediately instead of sleeping out a 330s curation budget.
+  private let gate = DispatchSemaphore(value: 0)
 
   init(task: Process) { self.task = task }
 
@@ -2856,21 +2858,31 @@ final class RouterScriptWatchdog: @unchecked Sendable {
     return timedOut
   }
 
+  /// The deadline runs on a thread of its own, deliberately.
+  ///
+  /// The first version scheduled it with `DispatchQueue.global().asyncAfter`.
+  /// That deadlocks against the very condition this class exists to break:
+  /// the caller blocks a thread in `waitUntilExit()`, the pipe readers hold
+  /// two more, and on a small machine libdispatch had no thread left to run
+  /// the work item -- so a wedged child ran to completion and the watchdog
+  /// never fired. CI caught it on a 3-core macOS runner, where a `sleep 60`
+  /// armed at 0.4s exited normally after 60s. A dedicated thread cannot be
+  /// starved by the blocked callers it is supposed to rescue.
   func arm(after timeout: TimeInterval) {
-    let item = DispatchWorkItem { [weak self] in self?.fire() }
-    lock.lock()
-    timer = item
-    lock.unlock()
-    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: item)
+    let thread = Thread { [weak self] in
+      guard let self else { return }
+      if self.gate.wait(timeout: .now() + timeout) == .timedOut { self.fire() }
+    }
+    thread.name = "codex-router.script-watchdog"
+    thread.stackSize = 64 << 10
+    thread.start()
   }
 
   func disarm() {
     lock.lock()
     finished = true
-    let item = timer
-    timer = nil
     lock.unlock()
-    item?.cancel()
+    gate.signal()
   }
 
   private func fire() {
@@ -2884,13 +2896,14 @@ final class RouterScriptWatchdog: @unchecked Sendable {
     task.terminate()
     lock.unlock()
     guard pid > 0 else { return }
-    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + Self.terminationGrace) { [weak self] in
-      guard let self else { return }
-      self.lock.lock()
-      defer { self.lock.unlock() }
-      guard !self.finished, self.task.isRunning else { return }
-      kill(pid, SIGKILL)
-    }
+    // Escalation sleeps on the watchdog's own thread rather than queueing:
+    // this runs after `terminate()` on a wedged child, which is exactly when
+    // libdispatch's pool may have nothing free to hand a work item.
+    Thread.sleep(forTimeInterval: Self.terminationGrace)
+    lock.lock()
+    defer { lock.unlock() }
+    guard !finished, task.isRunning else { return }
+    kill(pid, SIGKILL)
   }
 }
 

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -1399,20 +1399,34 @@ final class RouterStore: ObservableObject {
     }
   }
 
-  func reloadProviderCatalog(_ provider: String) async {
-    guard !providerCatalogLoading.contains(provider) else { return }
-    providerCatalogLoading.insert(provider)
-    defer { providerCatalogLoading.remove(provider) }
+  /// `refresh` re-asks the provider; without it the router answers from its
+  /// stored list, so opening a provider costs no round trip and still works
+  /// offline. That is the same split `discoverProviderModels` makes in
+  /// apps/control-center/electron/ipc.mjs, and the reason the decoded
+  /// `cached`/`stale` fields exist at all.
+  func reloadProviderCatalog(_ provider: String, refresh: Bool = false) async {
+    let providerID: String
+    do {
+      providerID = try ProviderCatalogInput.validatedProviderID(provider)
+    } catch {
+      message = "\(provider): \(error.localizedDescription)"
+      return
+    }
+    guard !providerCatalogLoading.contains(providerID) else { return }
+    providerCatalogLoading.insert(providerID)
+    defer { providerCatalogLoading.remove(providerID) }
     do {
       let output = try await runRouterScript(
         "model-discovery.mjs",
-        arguments: [provider, "--refresh", "--json"]
+        arguments: [providerID, "--json"] + (refresh ? ["--refresh"] : []),
+        timeout: RouterScriptWatchdog.discoveryTimeout
       )
       let catalog = try JSONDecoder().decode(ProviderModelCatalog.self, from: output)
-      providerCatalogs[provider] = catalog
-      message = "\(catalog.discovered.count) current \(provider) models loaded. Select the ones to add below."
+      providerCatalogs[providerID] = catalog
+      let origin = catalog.cached == true ? "saved" : "current"
+      message = "\(catalog.discovered.count) \(origin) \(providerID) models loaded. Select the ones to add below."
     } catch {
-      message = "\(provider): \(error.localizedDescription)"
+      message = "\(providerID): \(error.localizedDescription)"
     }
   }
 
@@ -1422,29 +1436,47 @@ final class RouterStore: ObservableObject {
       .sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
     guard !providers.isEmpty, providerCatalogLoading.isEmpty else { return }
     for provider in providers {
-      await reloadProviderCatalog(provider.id)
+      // The button says "Reload", so this one is the explicit re-ask. Every
+      // other entry point is cache-first.
+      await reloadProviderCatalog(provider.id, refresh: true)
     }
     message = "Reloaded current models for \(providers.count) provider\(providers.count == 1 ? "" : "s")."
   }
 
   func addProviderCatalogModels(_ provider: String, modelIDs: [String]) async {
-    let unique = Array(Set(modelIDs)).sorted()
-    guard !unique.isEmpty, unique.count <= 200, !providerCatalogLoading.contains(provider) else { return }
-    providerCatalogLoading.insert(provider)
+    // Model ids arrive from the provider's own HTTP response and end up in a
+    // single comma-separated `--models` argument, so they are validated to the
+    // same shape Electron's `addProviderModels` enforces before any of them is
+    // allowed to reach curation.
+    let providerID: String
+    let unique: [String]
+    do {
+      providerID = try ProviderCatalogInput.validatedProviderID(provider)
+      unique = try ProviderCatalogInput.validatedModelIDs(modelIDs)
+    } catch {
+      message = "\(provider): \(error.localizedDescription)"
+      return
+    }
+    guard !providerCatalogLoading.contains(providerID) else { return }
+    providerCatalogLoading.insert(providerID)
     do {
       // Curation repeats a live discovery before committing, then atomically
       // republishes every installed client. Never turn a cached list directly
       // into routes that may already have been withdrawn upstream.
-      _ = try await runRouterScript("curate-models.mjs", arguments: [
-        provider, "--models", unique.joined(separator: ","), "--refresh", "--apply",
-      ])
+      _ = try await runRouterScript(
+        "curate-models.mjs",
+        arguments: [providerID, "--models", unique.joined(separator: ","), "--refresh", "--apply"],
+        timeout: RouterScriptWatchdog.catalogMutationTimeout
+      )
       await refresh()
-      providerCatalogLoading.remove(provider)
-      await reloadProviderCatalog(provider)
-      message = "\(unique.count) \(provider) model\(unique.count == 1 ? "" : "s") added. Restart Codex to refresh its picker."
+      providerCatalogLoading.remove(providerID)
+      // Curation just re-asked upstream and rewrote the stored list, so the
+      // cache-first read here is the fresh answer without a second round trip.
+      await reloadProviderCatalog(providerID)
+      message = "\(unique.count) \(providerID) model\(unique.count == 1 ? "" : "s") added. Restart Codex to refresh its picker."
     } catch {
-      providerCatalogLoading.remove(provider)
-      message = "\(provider): \(error.localizedDescription)"
+      providerCatalogLoading.remove(providerID)
+      message = "\(providerID): \(error.localizedDescription)"
     }
   }
 
@@ -2650,7 +2682,11 @@ final class RouterStore: ObservableObject {
   // not expose. Keep the allow-list here: provider ids and model ids are data,
   // never a command path, and the tray must not become an arbitrary script
   // launcher just to mirror Electron's catalog controls.
-  private func runRouterScript(_ script: String, arguments: [String]) async throws -> Data {
+  private func runRouterScript(
+    _ script: String,
+    arguments: [String],
+    timeout: TimeInterval
+  ) async throws -> Data {
     guard ["model-discovery.mjs", "curate-models.mjs"].contains(script) else {
       throw RouterError("Unsupported Model Router script.")
     }
@@ -2676,11 +2712,28 @@ final class RouterStore: ObservableObject {
       task.standardOutput = output
       task.standardError = errors
       try task.run()
+      // Drain both pipes before waiting. A provider list easily exceeds the
+      // 64KB pipe buffer, and a child blocked on a full pipe never exits, so
+      // waiting first would deadlock even without a hostile endpoint.
       let stdoutReader = Task.detached { output.fileHandleForReading.readDataToEndOfFile() }
       let stderrReader = Task.detached { errors.fileHandleForReading.readDataToEndOfFile() }
+      // A provider that accepts the connection and then never answers would
+      // otherwise park `waitUntilExit` forever, and with it the caller's
+      // `defer` that clears the loading flag -- which permanently disables
+      // both catalog buttons for the rest of the app's life. Terminating the
+      // child closes the pipes, so the readers finish and the wait returns.
+      let watchdog = RouterScriptWatchdog(task: task)
+      watchdog.arm(after: timeout)
       task.waitUntilExit()
+      watchdog.disarm()
       let stdout = await stdoutReader.value
       let stderr = await stderrReader.value
+      if watchdog.didTimeOut {
+        throw RouterError(
+          "\(script) did not answer within \(Int(timeout.rounded())) seconds and was stopped. "
+            + "The provider may be unreachable; try again."
+        )
+      }
       guard task.terminationStatus == 0 else {
         let detail = String(data: stderr, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
         throw RouterError(detail?.isEmpty == false ? detail! : "Model Router command failed.")
@@ -2770,6 +2823,75 @@ struct RouterActiveRequest: Decodable, Identifiable, Equatable {
   let agentNickname: String?
   let isSubagent: Bool?
   let startedAt: Double
+}
+
+/// Bounds a child `Process` so a wedged provider cannot hold the tray's
+/// catalog UI hostage. `arm` schedules a SIGTERM, escalating to SIGKILL if the
+/// child ignores it, and `disarm` cancels the timer once the process is gone.
+/// The `finished` flag is what makes `disarm` safe: it is set under the same
+/// lock the watchdog takes, so a timer firing during teardown cannot signal a
+/// process the caller has already reaped.
+final class RouterScriptWatchdog: @unchecked Sendable {
+  /// Electron's discovery budget (`{ timeoutMs: 45_000 }` in
+  /// apps/control-center/electron/ipc.mjs). One provider HTTP round trip.
+  static let discoveryTimeout: TimeInterval = 45
+  /// Electron's `CATALOG_MUTATION_TIMEOUT_MS` (330_000). Curation waits on a
+  /// cross-process publish lock and rebuilds every installed client, so it
+  /// gets the same long budget rather than a discovery-sized one.
+  static let catalogMutationTimeout: TimeInterval = 330
+  /// Grace period between SIGTERM and SIGKILL, for a child that traps TERM.
+  static let terminationGrace: TimeInterval = 5
+
+  private let task: Process
+  private let lock = NSLock()
+  private var finished = false
+  private var timedOut = false
+  private var timer: DispatchWorkItem?
+
+  init(task: Process) { self.task = task }
+
+  var didTimeOut: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return timedOut
+  }
+
+  func arm(after timeout: TimeInterval) {
+    let item = DispatchWorkItem { [weak self] in self?.fire() }
+    lock.lock()
+    timer = item
+    lock.unlock()
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout, execute: item)
+  }
+
+  func disarm() {
+    lock.lock()
+    finished = true
+    let item = timer
+    timer = nil
+    lock.unlock()
+    item?.cancel()
+  }
+
+  private func fire() {
+    lock.lock()
+    guard !finished, task.isRunning else {
+      lock.unlock()
+      return
+    }
+    timedOut = true
+    let pid = task.processIdentifier
+    task.terminate()
+    lock.unlock()
+    guard pid > 0 else { return }
+    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + Self.terminationGrace) { [weak self] in
+      guard let self else { return }
+      self.lock.lock()
+      defer { self.lock.unlock() }
+      guard !self.finished, self.task.isRunning else { return }
+      kill(pid, SIGKILL)
+    }
+  }
 }
 
 private struct RouterError: LocalizedError {
@@ -3608,8 +3730,102 @@ struct ProviderSetupState: Decodable, Identifiable, Equatable {
   // provider endpoint to interrogate or are owned by the client/runtime.
   // Showing a Load button for them would promise a request that discovery
   // correctly refuses.
+  //
+  // The authority is `NO_LIVE_CATALOG` in
+  // apps/control-center/src/pages/ModelsPage.tsx. ProviderCatalogTests reads
+  // that file and fails if the two ever diverge.
+  static let liveModelCatalogExclusions: Set<String> = [
+    "openai", "local", "lmstudio", "custom", "devin-cli", "anthropic-api",
+  ]
+
   var supportsLiveModelCatalog: Bool {
-    !["openai", "local", "lmstudio", "custom", "devin-cli", "anthropic-api"].contains(id)
+    !Self.liveModelCatalogExclusions.contains(id)
+  }
+}
+
+/// The Swift half of the catalog input contract that
+/// `apps/control-center/electron/ipc.mjs` enforces for the same two scripts.
+/// Both surfaces hand provider-supplied ids straight to `curate-models.mjs`,
+/// so both have to agree on what an id may contain.
+///
+/// There is no shell here -- `Process` runs `/usr/bin/env` with an argv array
+/// -- so this is not about command injection. It is about the wire format:
+/// `--models` takes one comma-separated list, so a single id containing a
+/// comma silently becomes two ids the user never selected, and a leading `-`
+/// would be read as another flag.
+enum ProviderCatalogInput {
+  /// Mirrors `MODEL_SLUG` in ipc.mjs: `^[A-Za-z0-9][A-Za-z0-9._/:+-]{0,200}$`.
+  static let maxModelIDLength = 201
+  /// Mirrors `PROVIDER_ID` in ipc.mjs: `^[a-z0-9][a-z0-9-]{0,80}$`.
+  static let maxProviderIDLength = 81
+  /// Mirrors the 1...200 array bound ipc.mjs puts on `addProviderModels`.
+  static let maxModelIDCount = 200
+
+  private static let asciiAlphanumerics = Set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+  private static let modelIDBody = asciiAlphanumerics.union("._/:+-")
+  private static let providerIDBody = Set("abcdefghijklmnopqrstuvwxyz0123456789-")
+  private static let providerIDHead = Set("abcdefghijklmnopqrstuvwxyz0123456789")
+
+  static func isValidModelID(_ value: String) -> Bool {
+    matches(value, head: asciiAlphanumerics, body: modelIDBody, maxLength: maxModelIDLength)
+  }
+
+  static func isValidProviderID(_ value: String) -> Bool {
+    matches(value, head: providerIDHead, body: providerIDBody, maxLength: maxProviderIDLength)
+  }
+
+  private static func matches(
+    _ value: String,
+    head: Set<Character>,
+    body: Set<Character>,
+    maxLength: Int
+  ) -> Bool {
+    guard let first = value.first, head.contains(first) else { return false }
+    guard value.count <= maxLength else { return false }
+    return value.dropFirst().allSatisfy { body.contains($0) }
+  }
+
+  enum Failure: LocalizedError, Equatable {
+    case emptySelection
+    case tooManyModels(Int)
+    case invalidModelID(String)
+    case duplicateModelID
+    case invalidProviderID(String)
+
+    var errorDescription: String? {
+      switch self {
+      case .emptySelection, .tooManyModels:
+        return "Choose between 1 and \(ProviderCatalogInput.maxModelIDCount) provider models."
+      case .invalidModelID(let id):
+        return "Model id is invalid: \(id)"
+      case .duplicateModelID:
+        return "Provider model ids must be unique."
+      case .invalidProviderID(let id):
+        return "Provider is invalid: \(id)"
+      }
+    }
+  }
+
+  /// Rejects, rather than silently repairs, a selection Electron would refuse.
+  /// Deduplicating here would hide a catalog that served the same id twice.
+  static func validatedModelIDs(_ modelIDs: [String]) throws -> [String] {
+    guard !modelIDs.isEmpty else { throw Failure.emptySelection }
+    guard modelIDs.count <= maxModelIDCount else { throw Failure.tooManyModels(modelIDs.count) }
+    var seen = Set<String>()
+    for id in modelIDs {
+      let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard isValidModelID(trimmed) else { throw Failure.invalidModelID(id) }
+      guard seen.insert(trimmed).inserted else { throw Failure.duplicateModelID }
+    }
+    return modelIDs
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .sorted()
+  }
+
+  static func validatedProviderID(_ provider: String) throws -> String {
+    let trimmed = provider.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard isValidProviderID(trimmed) else { throw Failure.invalidProviderID(provider) }
+    return trimmed
   }
 }
 
@@ -5140,7 +5356,14 @@ private struct TrayView: View {
               provider: provider,
               catalog: store.providerCatalogs[provider.id],
               isLoading: store.providerCatalogLoading.contains(provider.id),
-              onReload: { Task { await store.reloadProviderCatalog(provider.id) } },
+              // Any catalog run in flight -- including a bulk reload started
+              // from the picker panel -- freezes every row. Otherwise a user
+              // can stack concurrent `Process` runs and starve the pipe
+              // readers draining them.
+              isBusy: !store.providerCatalogLoading.isEmpty,
+              onReload: { refresh in
+                Task { await store.reloadProviderCatalog(provider.id, refresh: refresh) }
+              },
               onAdd: { models in Task { await store.addProviderCatalogModels(provider.id, modelIDs: models) } }
             )
           }
@@ -6703,7 +6926,10 @@ private struct TrayView: View {
     let provider: ProviderSetupState
     let catalog: ProviderModelCatalog?
     let isLoading: Bool
-    let onReload: () -> Void
+    let isBusy: Bool
+    /// `true` re-asks the provider. The first load is cache-first; only an
+    /// explicit Reload spends a round trip.
+    let onReload: (Bool) -> Void
     let onAdd: ([String]) -> Void
 
     @State private var query = ""
@@ -6726,11 +6952,17 @@ private struct TrayView: View {
               .foregroundStyle(routerMutedStrong)
           }
           Spacer()
-          Button(isLoading ? routerLocalized("Loading models") : routerLocalized(catalog == nil ? "Load models" : "Reload models"), action: onReload)
-            .buttonStyle(.borderless)
-            .font(.system(size: 9, weight: .medium))
-            .foregroundStyle(routerMint)
-            .disabled(isLoading)
+          Button(
+            isLoading
+              ? routerLocalized("Loading models")
+              : routerLocalized(catalog == nil ? "Load models" : "Reload models")
+          ) {
+            onReload(catalog != nil)
+          }
+          .buttonStyle(.borderless)
+          .font(.system(size: 9, weight: .medium))
+          .foregroundStyle(routerMint)
+          .disabled(isLoading || isBusy)
         }
 
         if let catalog {
@@ -6764,7 +6996,7 @@ private struct TrayView: View {
                     .toggleStyle(.checkbox)
                     .controlSize(.mini)
                     .frame(width: 14)
-                    .disabled(isLoading)
+                    .disabled(isLoading || isBusy)
                   }
                   Text(model)
                     .font(.system(size: 8, design: .monospaced))
@@ -6794,7 +7026,7 @@ private struct TrayView: View {
 
           if !selected.isEmpty {
             HStack(spacing: 8) {
-              Text("\(selected.count) \(routerLocalized("selected"))")
+              Text(routerFormat("%d selected", selected.count))
                 .font(.system(size: 8))
                 .foregroundStyle(routerMutedStrong)
               Spacer()
@@ -6804,7 +7036,7 @@ private struct TrayView: View {
               .buttonStyle(.borderless)
               .font(.system(size: 9, weight: .medium))
               .foregroundStyle(routerMint)
-              .disabled(isLoading)
+              .disabled(isLoading || isBusy)
             }
           }
         }
@@ -6816,12 +7048,18 @@ private struct TrayView: View {
       }
     }
 
+    // One format string rather than number + noun fragments glued together:
+    // a translator can move the nouns around the numbers, which concatenation
+    // makes impossible and which reads wrong in Arabic.
     private var catalogDetail: String {
       guard let catalog else { return routerLocalized("Load the current list from this provider.") }
-      let available = catalog.discovered.count
-      let added = catalog.registered.count
       let freshness = catalog.cached == true ? routerLocalized("saved list") : routerLocalized("live list")
-      return "\(available) \(routerLocalized("models")) · \(added) \(routerLocalized("added")) · \(freshness)"
+      return routerFormat(
+        "%d models · %d added · %@",
+        catalog.discovered.count,
+        catalog.registered.count,
+        freshness
+      )
     }
   }
 

--- a/apps/macos/ModelRouterTray/Sources/RouterArabicText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterArabicText.swift
@@ -376,5 +376,28 @@ enum RouterArabicText {
     "External forwarders": "وكلاء التمرير الخارجيون",
     "Subagent": "وكيل فرعي",
     "thinking": "التفكير",
+
+    // Provider catalogs: the on-demand panel that asks a configured
+    // provider for its current model list and curates from it.
+    "Provider catalogs": "كتالوجات المزوّدين",
+    "Load the latest provider models": "حمّل أحدث نماذج المزوّد",
+    "Connect a supported provider to load its latest models.": "اتصل بمزوّد مدعوم لتحميل أحدث نماذجه.",
+    "Load models asks that provider for its current list. Choosing models adds them to the router and republishes every installed client.": "يطلب «تحميل النماذج» من المزوّد قائمته الحالية. واختيار النماذج يضيفها إلى الموجّه ويعيد نشر كل عميل مثبَّت.",
+    "Reload provider models": "إعادة تحميل نماذج المزوّدين",
+    "Reloading provider models…": "جارٍ إعادة تحميل نماذج المزوّدين…",
+    "Fetch the current catalog from every connected provider that supports live model discovery.": "اجلب الكتالوج الحالي من كل مزوّد متصل يدعم اكتشاف النماذج المباشر.",
+    "Refresh models": "تحديث النماذج",
+    "Reload installed and available local models from the router.": "أعد تحميل النماذج المحلية المثبَّتة والمتاحة من الموجّه.",
+    "Loading models": "جارٍ تحميل النماذج",
+    "Search available models": "ابحث في النماذج المتاحة",
+    "No provider models match this search.": "لا توجد نماذج مزوّد تطابق هذا البحث.",
+    "Added": "مُضاف",
+    "Showing the first 80 matches. Search to narrow the list.": "يتم عرض أول 80 نتيجة مطابقة. ابحث لتضييق القائمة.",
+    "%d selected": "%d محدَّد",
+    "Add selected": "أضف المحدَّد",
+    "Load the current list from this provider.": "حمّل القائمة الحالية من هذا المزوّد.",
+    "saved list": "قائمة محفوظة",
+    "live list": "قائمة مباشرة",
+    "%d models · %d added · %@": "%d نموذج · %d مُضاف · %@",
   ]
 }

--- a/apps/macos/ModelRouterTray/Sources/RouterHindiText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterHindiText.swift
@@ -376,5 +376,28 @@ enum RouterHindiText {
     "External forwarders": "बाहरी फ़ॉरवर्डर",
     "Subagent": "उप-एजेंट",
     "thinking": "विचार",
+
+    // Provider catalogs: the on-demand panel that asks a configured
+    // provider for its current model list and curates from it.
+    "Provider catalogs": "प्रदाता कैटलॉग",
+    "Load the latest provider models": "प्रदाता के नवीनतम मॉडल लोड करें",
+    "Connect a supported provider to load its latest models.": "इसके नवीनतम मॉडल लोड करने के लिए एक समर्थित प्रदाता कनेक्ट करें।",
+    "Load models asks that provider for its current list. Choosing models adds them to the router and republishes every installed client.": "\"मॉडल लोड करें\" उस प्रदाता से उसकी वर्तमान सूची माँगता है। मॉडल चुनने पर वे राउटर में जुड़ते हैं और हर इंस्टॉल किए गए क्लाइंट को फिर से प्रकाशित किया जाता है।",
+    "Reload provider models": "प्रदाता मॉडल फिर से लोड करें",
+    "Reloading provider models…": "प्रदाता मॉडल फिर से लोड हो रहे हैं…",
+    "Fetch the current catalog from every connected provider that supports live model discovery.": "लाइव मॉडल खोज का समर्थन करने वाले हर कनेक्टेड प्रदाता से वर्तमान कैटलॉग प्राप्त करें।",
+    "Refresh models": "मॉडल रीफ़्रेश करें",
+    "Reload installed and available local models from the router.": "राउटर से इंस्टॉल किए गए और उपलब्ध लोकल मॉडल फिर से लोड करें।",
+    "Loading models": "मॉडल लोड हो रहे हैं",
+    "Search available models": "उपलब्ध मॉडल खोजें",
+    "No provider models match this search.": "इस खोज से कोई प्रदाता मॉडल मेल नहीं खाता।",
+    "Added": "जोड़ा गया",
+    "Showing the first 80 matches. Search to narrow the list.": "पहले 80 मिलान दिखाए जा रहे हैं। सूची सीमित करने के लिए खोजें।",
+    "%d selected": "%d चयनित",
+    "Add selected": "चयनित जोड़ें",
+    "Load the current list from this provider.": "इस प्रदाता से वर्तमान सूची लोड करें।",
+    "saved list": "सहेजी गई सूची",
+    "live list": "लाइव सूची",
+    "%d models · %d added · %@": "%d मॉडल · %d जोड़े गए · %@",
   ]
 }

--- a/apps/macos/ModelRouterTray/Sources/RouterJapaneseText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterJapaneseText.swift
@@ -376,5 +376,28 @@ enum RouterJapaneseText {
     "External forwarders": "外部フォワーダー",
     "Subagent": "サブエージェント",
     "thinking": "思考",
+
+    // Provider catalogs: the on-demand panel that asks a configured
+    // provider for its current model list and curates from it.
+    "Provider catalogs": "プロバイダーカタログ",
+    "Load the latest provider models": "プロバイダーの最新モデルを読み込む",
+    "Connect a supported provider to load its latest models.": "対応プロバイダーを接続すると最新モデルを読み込めます。",
+    "Load models asks that provider for its current list. Choosing models adds them to the router and republishes every installed client.": "「モデルを読み込む」はプロバイダーに現在の一覧を問い合わせます。モデルを選ぶとルーターに追加され、インストール済みのすべてのクライアントが再発行されます。",
+    "Reload provider models": "プロバイダーモデルを再読み込み",
+    "Reloading provider models…": "プロバイダーモデルを再読み込み中…",
+    "Fetch the current catalog from every connected provider that supports live model discovery.": "ライブのモデル探索に対応する接続済みプロバイダーすべてから現在のカタログを取得します。",
+    "Refresh models": "モデルを更新",
+    "Reload installed and available local models from the router.": "ルーターからインストール済みおよび利用可能なローカルモデルを再読み込みします。",
+    "Loading models": "モデルを読み込み中",
+    "Search available models": "利用可能なモデルを検索",
+    "No provider models match this search.": "この検索に一致するプロバイダーモデルはありません。",
+    "Added": "追加済み",
+    "Showing the first 80 matches. Search to narrow the list.": "最初の 80 件の一致のみ表示しています。検索して絞り込んでください。",
+    "%d selected": "%d 件選択中",
+    "Add selected": "選択項目を追加",
+    "Load the current list from this provider.": "このプロバイダーから現在の一覧を読み込みます。",
+    "saved list": "保存済みの一覧",
+    "live list": "最新の一覧",
+    "%d models · %d added · %@": "%d 個のモデル · %d 個追加済み · %@",
   ]
 }

--- a/apps/macos/ModelRouterTray/Sources/RouterKoreanText.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterKoreanText.swift
@@ -376,5 +376,28 @@ enum RouterKoreanText {
     "External forwarders": "외부 포워더",
     "Subagent": "서브에이전트",
     "thinking": "추론",
+
+    // Provider catalogs: the on-demand panel that asks a configured
+    // provider for its current model list and curates from it.
+    "Provider catalogs": "제공자 카탈로그",
+    "Load the latest provider models": "제공자의 최신 모델 불러오기",
+    "Connect a supported provider to load its latest models.": "지원되는 제공자를 연결하면 최신 모델을 불러올 수 있습니다.",
+    "Load models asks that provider for its current list. Choosing models adds them to the router and republishes every installed client.": "\"모델 불러오기\"는 해당 제공자에게 현재 목록을 요청합니다. 모델을 선택하면 라우터에 추가되고 설치된 모든 클라이언트가 다시 게시됩니다.",
+    "Reload provider models": "제공자 모델 다시 불러오기",
+    "Reloading provider models…": "제공자 모델을 다시 불러오는 중…",
+    "Fetch the current catalog from every connected provider that supports live model discovery.": "실시간 모델 검색을 지원하는 연결된 모든 제공자에서 현재 카탈로그를 가져옵니다.",
+    "Refresh models": "모델 새로 고침",
+    "Reload installed and available local models from the router.": "라우터에서 설치된 로컬 모델과 사용 가능한 로컬 모델을 다시 불러옵니다.",
+    "Loading models": "모델 불러오는 중",
+    "Search available models": "사용 가능한 모델 검색",
+    "No provider models match this search.": "이 검색과 일치하는 제공자 모델이 없습니다.",
+    "Added": "추가됨",
+    "Showing the first 80 matches. Search to narrow the list.": "일치하는 항목 중 처음 80개만 표시합니다. 검색해 목록을 좁히세요.",
+    "%d selected": "%d개 선택됨",
+    "Add selected": "선택 항목 추가",
+    "Load the current list from this provider.": "이 제공자에서 현재 목록을 불러옵니다.",
+    "saved list": "저장된 목록",
+    "live list": "실시간 목록",
+    "%d models · %d added · %@": "모델 %d개 · %d개 추가됨 · %@",
   ]
 }

--- a/apps/macos/ModelRouterTray/Tests/ProviderCatalogTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ProviderCatalogTests.swift
@@ -1,0 +1,368 @@
+import Foundation
+import Testing
+
+@testable import ModelRouterTray
+
+/// The tray's provider-catalog panel is a second implementation of a surface
+/// Electron already ships. Everything it agrees with lives in another language
+/// in another directory, so these tests read those files rather than restating
+/// their contents -- a copy that drifts is the whole failure mode here.
+@Suite("Provider catalogs")
+struct ProviderCatalogTests {
+  /// apps/macos/ModelRouterTray/Tests/ThisFile.swift -> repository root.
+  static let repositoryRoot: URL = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()  // Tests
+    .deletingLastPathComponent()  // ModelRouterTray
+    .deletingLastPathComponent()  // macos
+    .deletingLastPathComponent()  // apps
+    .deletingLastPathComponent()  // <root>
+
+  static func repositoryFile(_ relativePath: String) throws -> String {
+    let url = repositoryRoot.appendingPathComponent(relativePath)
+    return try String(contentsOf: url, encoding: .utf8)
+  }
+
+  // MARK: - Parity with the Electron surface
+
+  @Test("the live-catalog exclusions match NO_LIVE_CATALOG in the Electron app")
+  func exclusionsMatchElectron() throws {
+    let source = try Self.repositoryFile("apps/control-center/src/pages/ModelsPage.tsx")
+    guard let line = source
+      .split(separator: "\n")
+      .first(where: { $0.contains("const NO_LIVE_CATALOG") })
+    else {
+      Issue.record("ModelsPage.tsx no longer declares NO_LIVE_CATALOG")
+      return
+    }
+
+    let ids = try Self.quotedStrings(in: String(line))
+    #expect(!ids.isEmpty, "parsed no ids out of: \(line)")
+    #expect(
+      Set(ids) == ProviderSetupState.liveModelCatalogExclusions,
+      "tray: \(ProviderSetupState.liveModelCatalogExclusions.sorted()), Electron: \(ids.sorted())"
+    )
+  }
+
+  @Test("supportsLiveModelCatalog answers per provider id")
+  func supportsLiveModelCatalogPerProvider() throws {
+    for excluded in ProviderSetupState.liveModelCatalogExclusions {
+      #expect(Self.providerSetup(id: excluded).supportsLiveModelCatalog == false)
+    }
+    for included in ["deepseek", "kimi", "zai", "orca"] {
+      #expect(Self.providerSetup(id: included).supportsLiveModelCatalog)
+    }
+  }
+
+  @Test("the model-id rule is the one ipc.mjs declares")
+  func modelSlugMatchesElectron() throws {
+    let source = try Self.repositoryFile("apps/control-center/electron/ipc.mjs")
+    // If the Electron pattern is edited, this fails and points at the Swift
+    // copy that has to move with it.
+    #expect(
+      source.contains("const MODEL_SLUG = /^[A-Za-z0-9][A-Za-z0-9._/:+-]{0,200}$/;"),
+      "MODEL_SLUG in ipc.mjs changed; update ProviderCatalogInput to match"
+    )
+    #expect(
+      source.contains("const PROVIDER_ID = /^[a-z0-9][a-z0-9-]{0,80}$/;"),
+      "PROVIDER_ID in ipc.mjs changed; update ProviderCatalogInput to match"
+    )
+    #expect(source.contains("const CATALOG_MUTATION_TIMEOUT_MS = 330_000;"))
+    #expect(source.contains("{ timeoutMs: 45_000 }"))
+  }
+
+  @Test("the tray's script timeouts are the Electron budgets")
+  func timeoutsMatchElectron() {
+    #expect(RouterScriptWatchdog.discoveryTimeout == 45)
+    #expect(RouterScriptWatchdog.catalogMutationTimeout == 330)
+  }
+
+  // MARK: - Decoding the discovery payload
+
+  /// Verbatim `node src/model-discovery.mjs deepseek --fixture … --json`.
+  /// Keys the tray does not read (`contextLengths`, `note`, provider-specific
+  /// `free`) are present on purpose: dropping one must not break decoding.
+  static let discoveryOutput = """
+  {
+    "provider": "deepseek",
+    "discovered": [
+      "deepseek-v4-pro",
+      "deepseek-v5-preview"
+    ],
+    "registered": [
+      "deepseek-chat",
+      "deepseek-reasoner",
+      "deepseek-v4-flash",
+      "deepseek-v4-flash-vision-exp",
+      "deepseek-v4-pro"
+    ],
+    "unregistered": [
+      "deepseek-v5-preview"
+    ],
+    "unavailable": [
+      "deepseek-chat",
+      "deepseek-reasoner",
+      "deepseek-v4-flash",
+      "deepseek-v4-flash-vision-exp"
+    ],
+    "contextLengths": {},
+    "cached": false,
+    "stale": false,
+    "fetchedAt": "2026-08-22T17:52:15.003Z",
+    "note": "Discovery never edits the registry. New models must pass the live compatibility test before they are listed in Codex."
+  }
+  """
+
+  @Test("a real discovery payload decodes into the catalog the panel renders")
+  func decodesDiscoveryOutput() throws {
+    let catalog = try JSONDecoder().decode(
+      ProviderModelCatalog.self,
+      from: Data(Self.discoveryOutput.utf8)
+    )
+    #expect(catalog.provider == "deepseek")
+    #expect(catalog.discovered == ["deepseek-v4-pro", "deepseek-v5-preview"])
+    #expect(catalog.unregistered == ["deepseek-v5-preview"])
+    #expect(catalog.unavailable.count == 4)
+    #expect(catalog.registered.contains("deepseek-v4-pro"))
+    #expect(catalog.cached == false)
+    #expect(catalog.stale == false)
+    #expect(catalog.fetchedAt == "2026-08-22T17:52:15.003Z")
+  }
+
+  @Test("the freshness fields stay optional so an older router still decodes")
+  func decodesWithoutFreshnessFields() throws {
+    let catalog = try JSONDecoder().decode(
+      ProviderModelCatalog.self,
+      from: Data("""
+      {
+        "provider": "kimi",
+        "discovered": ["kimi-k2.6"],
+        "registered": [],
+        "unregistered": ["kimi-k2.6"],
+        "unavailable": []
+      }
+      """.utf8)
+    )
+    #expect(catalog.cached == nil)
+    #expect(catalog.stale == nil)
+    #expect(catalog.fetchedAt == nil)
+  }
+
+  @Test("every discovered id the router can publish passes the tray's own rule")
+  func discoveredIdsAreAcceptable() throws {
+    let catalog = try JSONDecoder().decode(
+      ProviderModelCatalog.self,
+      from: Data(Self.discoveryOutput.utf8)
+    )
+    for id in catalog.discovered + catalog.registered {
+      #expect(ProviderCatalogInput.isValidModelID(id), "\(id) was rejected")
+    }
+  }
+
+  // MARK: - Model-id validation
+
+  @Test(
+    "ids the providers actually serve are accepted",
+    arguments: [
+      "deepseek-v4-pro",
+      "deepseek/deepseek-v4-flash",
+      "Qwen3.8-27B",
+      "meta-llama/Llama-4.2:free",
+      "gpt-5.5+preview",
+      "a",
+      "0",
+    ]
+  )
+  func acceptsRealModelIDs(id: String) {
+    #expect(ProviderCatalogInput.isValidModelID(id))
+  }
+
+  @Test(
+    "ids that would change the meaning of the --models argument are rejected",
+    arguments: [
+      // The concrete bug: one selection silently becomes two ids.
+      "deepseek-v4,deepseek-secret",
+      // Would be read as another flag rather than a model.
+      "--apply",
+      "-refresh",
+      // Not a slug at all.
+      "",
+      " ",
+      "model id",
+      "model\nid",
+      "model\"id",
+      "model$id",
+      "model;id",
+      "モデル",
+      "/leading-slash",
+      ".leading-dot",
+    ]
+  )
+  func rejectsHostileModelIDs(id: String) {
+    #expect(ProviderCatalogInput.isValidModelID(id) == false)
+  }
+
+  @Test("the length ceiling is the one the Electron pattern encodes")
+  func enforcesLengthCeiling() {
+    let atLimit = "a" + String(repeating: "b", count: 200)
+    #expect(atLimit.count == ProviderCatalogInput.maxModelIDLength)
+    #expect(ProviderCatalogInput.isValidModelID(atLimit))
+    #expect(ProviderCatalogInput.isValidModelID(atLimit + "b") == false)
+  }
+
+  @Test("a selection carrying an invalid id is refused whole, not filtered")
+  func refusesSelectionWithInvalidID() {
+    #expect(throws: ProviderCatalogInput.Failure.invalidModelID("good,evil")) {
+      _ = try ProviderCatalogInput.validatedModelIDs(["fine-model", "good,evil"])
+    }
+  }
+
+  @Test("duplicates are rejected rather than silently collapsed")
+  func rejectsDuplicates() {
+    // Electron reports this instead of deduplicating, so a catalog that served
+    // the same id twice is surfaced rather than hidden.
+    #expect(throws: ProviderCatalogInput.Failure.duplicateModelID) {
+      _ = try ProviderCatalogInput.validatedModelIDs(["a-model", "a-model"])
+    }
+    #expect(throws: ProviderCatalogInput.Failure.duplicateModelID) {
+      _ = try ProviderCatalogInput.validatedModelIDs(["a-model", " a-model "])
+    }
+  }
+
+  @Test("the selection size bounds match the Electron handler")
+  func enforcesSelectionBounds() {
+    #expect(throws: ProviderCatalogInput.Failure.emptySelection) {
+      _ = try ProviderCatalogInput.validatedModelIDs([])
+    }
+    let tooMany = (0...ProviderCatalogInput.maxModelIDCount).map { "model-\($0)" }
+    #expect(throws: ProviderCatalogInput.Failure.tooManyModels(tooMany.count)) {
+      _ = try ProviderCatalogInput.validatedModelIDs(tooMany)
+    }
+    let atLimit = (1...ProviderCatalogInput.maxModelIDCount).map { "model-\($0)" }
+    #expect(throws: Never.self) {
+      _ = try ProviderCatalogInput.validatedModelIDs(atLimit)
+    }
+  }
+
+  @Test("a valid selection is trimmed and ordered deterministically")
+  func normalizesValidSelection() throws {
+    let ids = try ProviderCatalogInput.validatedModelIDs(["b-model", " a-model ", "c-model"])
+    #expect(ids == ["a-model", "b-model", "c-model"])
+    // What actually reaches `--models`.
+    #expect(ids.joined(separator: ",") == "a-model,b-model,c-model")
+  }
+
+  @Test(
+    "provider ids are held to the lowercase rule ipc.mjs uses",
+    arguments: [
+      ("deepseek", true),
+      ("github-copilot", true),
+      ("z-ai-2", true),
+      ("DeepSeek", false),
+      ("-leading", false),
+      ("has_underscore", false),
+      ("has/slash", false),
+      ("", false),
+    ]
+  )
+  func validatesProviderIDs(id: String, expected: Bool) {
+    #expect(ProviderCatalogInput.isValidProviderID(id) == expected)
+  }
+
+  // MARK: - Helpers
+
+  static func providerSetup(id: String) -> ProviderSetupState {
+    let json = """
+    {
+      "id": "\(id)",
+      "displayName": "\(id)",
+      "kind": "api",
+      "configured": true,
+      "action": "connect"
+    }
+    """
+    // Force-tried: a decode failure here means the struct's own contract broke,
+    // which every other test in this file already depends on.
+    return try! JSONDecoder().decode(ProviderSetupState.self, from: Data(json.utf8))
+  }
+
+  static func quotedStrings(in line: String) throws -> [String] {
+    let pattern = try NSRegularExpression(pattern: "\"([^\"]*)\"")
+    let range = NSRange(line.startIndex..., in: line)
+    return pattern.matches(in: line, range: range).compactMap {
+      Range($0.range(at: 1), in: line).map { String(line[$0]) }
+    }
+  }
+}
+
+/// `runRouterScript` is private, so these exercise the watchdog it installs
+/// against real child processes -- including the two failures that motivated
+/// it: a child that never exits, and a child that outfills the 64KB pipe.
+@Suite("Router script watchdog")
+struct RouterScriptWatchdogTests {
+  /// Mirrors the ordering inside `runRouterScript`: drain both pipes, arm the
+  /// watchdog, then wait. Reversing the first two would deadlock on the large
+  /// output case below.
+  private func run(
+    _ command: String,
+    timeout: TimeInterval
+  ) async throws -> (stdout: Data, timedOut: Bool, status: Int32) {
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/bin/sh")
+    task.arguments = ["-c", command]
+    let output = Pipe()
+    let errors = Pipe()
+    task.standardOutput = output
+    task.standardError = errors
+    try task.run()
+    let stdoutReader = Task.detached { output.fileHandleForReading.readDataToEndOfFile() }
+    let stderrReader = Task.detached { errors.fileHandleForReading.readDataToEndOfFile() }
+    let watchdog = RouterScriptWatchdog(task: task)
+    watchdog.arm(after: timeout)
+    task.waitUntilExit()
+    watchdog.disarm()
+    let stdout = await stdoutReader.value
+    _ = await stderrReader.value
+    return (stdout, watchdog.didTimeOut, task.terminationStatus)
+  }
+
+  @Test("a child that never answers is stopped instead of hanging the caller")
+  func terminatesAWedgedChild() async throws {
+    // The concrete failure: a provider endpoint that accepts the connection
+    // and then goes silent. Without the watchdog this never returns, the
+    // caller's `defer` never clears the loading flag, and both catalog
+    // buttons stay disabled for the rest of the app's life.
+    let started = Date()
+    let result = try await run("sleep 60", timeout: 0.4)
+    #expect(result.timedOut)
+    #expect(result.status != 0)
+    #expect(Date().timeIntervalSince(started) < 20)
+  }
+
+  @Test("a child that finishes in time is never signalled")
+  func leavesAFastChildAlone() async throws {
+    let result = try await run("printf ok", timeout: 30)
+    #expect(result.timedOut == false)
+    #expect(result.status == 0)
+    #expect(String(data: result.stdout, encoding: .utf8) == "ok")
+  }
+
+  @Test("output larger than the pipe buffer still arrives whole")
+  func drainsPastThePipeBuffer() async throws {
+    // 200KB is comfortably past the 64KB pipe: a child blocked writing into a
+    // full pipe never exits, so waiting before draining would deadlock and the
+    // watchdog would report a timeout that is really the caller's own bug.
+    let result = try await run("head -c 200000 /dev/zero | tr '\\0' a", timeout: 30)
+    #expect(result.timedOut == false)
+    #expect(result.status == 0)
+    #expect(result.stdout.count == 200_000)
+  }
+
+  @Test("disarming after the process is gone is inert")
+  func disarmIsIdempotent() async throws {
+    let result = try await run("printf ok", timeout: 0.05)
+    // The timer may well have fired during teardown; it must not have signalled
+    // a reaped process nor claimed a timeout on a run that completed.
+    #expect(result.status == 0)
+    #expect(String(data: result.stdout, encoding: .utf8) == "ok")
+  }
+}

--- a/apps/macos/ModelRouterTray/Tests/ProviderCatalogTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ProviderCatalogTests.swift
@@ -302,7 +302,7 @@ struct RouterScriptWatchdogTests {
   /// Mirrors the ordering inside `runRouterScript`: drain both pipes, arm the
   /// watchdog, then wait. Reversing the first two would deadlock on the large
   /// output case below.
-  private func run(
+  private static func runScript(
     _ command: String,
     timeout: TimeInterval
   ) async throws -> (stdout: Data, timedOut: Bool, status: Int32) {
@@ -332,15 +332,46 @@ struct RouterScriptWatchdogTests {
     // caller's `defer` never clears the loading flag, and both catalog
     // buttons stay disabled for the rest of the app's life.
     let started = Date()
-    let result = try await run("sleep 60", timeout: 0.4)
+    let result = try await Self.runScript("sleep 60", timeout: 0.4)
     #expect(result.timedOut)
     #expect(result.status != 0)
     #expect(Date().timeIntervalSince(started) < 20)
   }
 
+  @Test("wedged children are stopped even when every other thread is blocked")
+  func terminatesWedgedChildrenUnderThreadPressure() async throws {
+    // This is the case CI caught and the single-child test above misses. Each
+    // in-flight run blocks a thread in `waitUntilExit()` and holds two more in
+    // its pipe readers. The first watchdog scheduled its deadline on
+    // libdispatch's global queue, which on a small machine had no thread left
+    // to run it -- so every child ran to completion and nothing was killed.
+    // Run enough of them at once to starve the pool on a CI-sized box.
+    let started = Date()
+    let wedged = 8
+    let results = try await withThrowingTaskGroup(of: (Bool, Int32).self) { group in
+      for _ in 0 ..< wedged {
+        group.addTask {
+          let result = try await Self.runScript("sleep 60", timeout: 0.4)
+          return (result.timedOut, result.status)
+        }
+      }
+      var collected: [(Bool, Int32)] = []
+      for try await result in group { collected.append(result) }
+      return collected
+    }
+
+    #expect(results.count == wedged)
+    for (timedOut, status) in results {
+      #expect(timedOut, "a wedged child was not stopped by the watchdog")
+      #expect(status != 0, "a wedged child exited normally instead of being signalled")
+    }
+    // Generous, but far below the 60s a starved watchdog produces.
+    #expect(Date().timeIntervalSince(started) < 30)
+  }
+
   @Test("a child that finishes in time is never signalled")
   func leavesAFastChildAlone() async throws {
-    let result = try await run("printf ok", timeout: 30)
+    let result = try await Self.runScript("printf ok", timeout: 30)
     #expect(result.timedOut == false)
     #expect(result.status == 0)
     #expect(String(data: result.stdout, encoding: .utf8) == "ok")
@@ -351,7 +382,7 @@ struct RouterScriptWatchdogTests {
     // 200KB is comfortably past the 64KB pipe: a child blocked writing into a
     // full pipe never exits, so waiting before draining would deadlock and the
     // watchdog would report a timeout that is really the caller's own bug.
-    let result = try await run("head -c 200000 /dev/zero | tr '\\0' a", timeout: 30)
+    let result = try await Self.runScript("head -c 200000 /dev/zero | tr '\\0' a", timeout: 30)
     #expect(result.timedOut == false)
     #expect(result.status == 0)
     #expect(result.stdout.count == 200_000)
@@ -359,7 +390,7 @@ struct RouterScriptWatchdogTests {
 
   @Test("disarming after the process is gone is inert")
   func disarmIsIdempotent() async throws {
-    let result = try await run("printf ok", timeout: 0.05)
+    let result = try await Self.runScript("printf ok", timeout: 0.05)
     // The timer may well have fired during teardown; it must not have signalled
     // a reaped process nor claimed a timeout on a run that completed.
     #expect(result.status == 0)


### PR DESCRIPTION
Supersedes #340, which reports CONFLICTING. **Please close #340 in favour of this.**

## The "conflict" was two duplicate commits — but the obvious rebase was a trap

`pr-340` carried three commits; two were already on main with identical patch-ids (`--stable`): `692ba26`↔`ba7503f` and `f33b382`↔`8cff790`. The three reported conflicts were that duplicate colliding with itself.

The obvious move — `git rebase --onto origin/main d3ca7a6` and let git drop duplicates by patch-id — **silently reverts main.** Git dropped only `f33b382`. It re-applied `692ba26` as a non-empty commit, because 12 of its 13 files were already upstream but a *later* main commit, `43bf2c2` ("test: seat the doctor's routed-agent check on a registry v2 claim"), had since rewritten `test/doctor-routing-mode.test.mjs`. Re-applying re-added 14 lines that `43bf2c2` deliberately removed.

Dropped explicitly instead with a second `git rebase --onto origin/main a48137f`. Verified: this branch does not touch `test/doctor-routing-mode.test.mjs` at all, so `43bf2c2` is preserved.

The real feature is one commit, 5 files / 469 insertions. It cherry-picks onto main with zero conflicts.

## Hardening: the Electron surface was ported without its guards

**No model-id validation.** `addProviderCatalogModels` checked only non-empty and `count <= 200`. Not command injection — `Process` with `executableURL = /usr/bin/env` and an argv array, no shell — but `unique.joined(separator: ",")` makes a comma-bearing id become two ids, and a leading `-` becomes a flag. Model ids come from the provider's own HTTP response.

New `ProviderCatalogInput` mirrors `ipc.mjs`'s `MODEL_SLUG` and `PROVIDER_ID` patterns, the count bound, and the explicit duplicate rejection. Selections are rejected whole rather than silently filtered.

**No subprocess timeout, and a hang bricked the UI permanently.** `runRouterScript` called `task.waitUntilExit()` unbounded. A provider that accepts the TCP connection and never responds meant `defer { providerCatalogLoading.remove(provider) }` never ran, so that id stayed in the set forever and `.disabled(!store.providerCatalogLoading.isEmpty)` disabled **both** the per-provider and bulk reload buttons for the rest of the app's lifetime. Only quitting recovered.

New `RouterScriptWatchdog`: SIGTERM at the deadline, SIGKILL after a 5s grace, with a `finished` flag set under the same lock so a timer firing during teardown cannot signal a reaped process. Armed *after* both pipe readers start, preserving the drain-before-wait ordering that prevents the 64KB-pipe deadlock. Budgets match Electron: 45s discovery, 330s curation.

## Also

- **Cache-first first load.** `reloadProviderCatalog` hardcoded `--refresh`, defeating the discovery cache that exists so opening a provider costs no round trip and works offline. Now `refresh: Bool = false`; only "Reload models" and the bulk button re-ask. The post-curation reload is cache-first too, since curation just refreshed the stored list.
- **Row buttons lock during a bulk reload**, so concurrent `Process` runs can't stack and starve the pipe readers.
- **20 new strings translated into all five tables.** The PR added them with zero translations, so a whole new panel rendered in English inside an otherwise fully-translated tray. `catalogDetail` and the selection count now use `routerFormat("%d models · %d added · %@", …)` instead of concatenating number+noun fragments, which cannot be reordered by a translator and renders wrong in Arabic. Note `LocalizationTests`'s `specifierParity` compares the *ordered* specifier list, so positional `%1$d` reordering would fail the suite — specifier order is kept stable and translators move the nouns.
- `ServiceHealth.tsx` renders the details region always with `hidden={!detailsOpen}`, so `aria-controls` resolves in both states (it previously pointed at an unmounted element — an ARIA violation), plus a `[hidden] { display: none }` rule so a future `display` rule can't defeat it.

## Tests: 46 → 65

The PR added **zero** tests for 469 lines. New `Tests/ProviderCatalogTests.swift` resolves the repo root from `#filePath` and:

- reads `NO_LIVE_CATALOG` out of `ModelsPage.tsx` and compares it to the Swift exclusion list, so the two cannot drift apart
- greps both id regex literals and both timeout constants out of `ipc.mjs`, so a drift on the Electron side fails here
- decodes `ProviderModelCatalog` against a **generated** capture of `node src/model-discovery.mjs deepseek --fixture … --json` (not hand-written), plus a payload missing the optional freshness fields
- validation: real ids accepted; comma/flag/space/newline/quote/`$`/`;`/non-ASCII/leading-punct rejected; length ceiling; duplicates; 200 vs 201 bounds
- `RouterScriptWatchdogTests` drives real child processes: `sleep 60` is killed and reports `timedOut`, a fast child is never signalled, and a 200KB writer (past the 64KB pipe) completes whole — pinning the drain-before-wait ordering

## Verification

- `swift build` — `Build complete!`, no warnings
- `swift test` — **65 tests in 10 suites passed** (baseline with the new file removed: 46 in 8)
- `node scripts-check.mjs` — passes
- `node --test test/*.test.mjs` — 2099 tests, **0 failures**, 13 pre-existing skips
- `apps/control-center` `tsc --noEmit` — exits 0

## Left alone, flagged

- `store.message` strings are raw English, but so are ~25 other `message =` sites in `RouterStore`; localizing only these would be inconsistent.
- **`runControl` has the same unbounded `waitUntilExit()`.** Pre-existing on main and untouched by this PR, but it is the same latent hang and deserves its own fix.
- Bulk reload still fans out N forced refreshes serially. Now bounded at 45s each with the row buttons locked; a concurrency limit would be a design change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)