### PR TITLE
fix(kimi): inline sibling $ref pointers Moonshot rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **Kimi OAuth sessions survive the Codex App connector pack.** Moonshot
+  accepts a tool-schema `$ref` only when it points into `#/$defs/` and rejects
+  the whole request -- not the one tool -- over anything else, so the
+  sibling-property pointers connector tools ship (Wego `_flights_search` points
+  `inboundTotalDurationRange` at its own sibling `priceRange`) turned every
+  `kimi-oauth` App session into an HTTP 400 on its first message (issue #353).
+  The relay now inlines those pointers for the kimi route: the node is replaced
+  by the schema the client itself pointed at, with any constraint declared
+  beside the `$ref` still winning, and `#/$defs/` pointers left exactly as they
+  are. A pointer that cannot be resolved is left alone rather than guessed at,
+  a cyclic schema stops at the edge that would close the cycle, and an
+  expansion that outgrows its byte budget falls back to the original schema
+  rather than shipping a duplicated one. Every other provider keeps the payload
+  it gets today -- the inlining is scoped to the provider the rejection was
+  reproduced on.
+
 - **The macOS tray can load a provider's current model list and curate from
   it.** A new Provider catalogs panel asks any configured provider that
   supports live discovery for the models it serves right now, marks the ones

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -3,7 +3,11 @@ import { StringDecoder } from "node:string_decoder";
 
 import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 import { coerceFunctionCallArguments } from "./tool-arguments.mjs";
-import { nonRecursiveToolSchema, providerToolSchema } from "./tool-schema-root.mjs";
+import {
+  inlineForeignRefs,
+  nonRecursiveToolSchema,
+  providerToolSchema,
+} from "./tool-schema-root.mjs";
 import {
   buildInterruptAgentCall,
   filterAlreadyInterrupted,
@@ -306,14 +310,27 @@ const MAX_JSON_CAPTURE_BYTES = 64 * 1024 * 1024;
 // tool arrived inside a namespace. `providerToolSchema` returns anything it
 // does not recognize by identity, so an ordinary root costs one call and no
 // copy.
-export function repairToolSchemaRoot(tool, { nonRecursive = false } = {}) {
+export function repairToolSchemaRoot(
+  tool,
+  { nonRecursive = false, inlineForeignRefs: inlineRefs = false } = {},
+) {
+  // Moonshot alone rejects a `$ref` that does not point into `#/$defs/`, so
+  // only the route that asks for it pays the inlining -- every other provider
+  // keeps the exact wire payload it has today. `inlineForeignRefs` returns a
+  // schema with no foreign ref by identity, so even on that route an ordinary
+  // toolset is not copied.
+  const relaySchema = (schema) => {
+    const repaired = providerToolSchema(schema);
+    return inlineRefs ? inlineForeignRefs(repaired) : repaired;
+  };
+
   // Preserve the established shared-provider behavior byte-for-byte. Native
   // namespace traversal and inputSchema rewriting belong only to the OpenCode
   // compatibility pass below; other providers keep the original root repair.
   if (!nonRecursive) {
     const parameters = tool?.function?.parameters ?? tool?.parameters;
     if (parameters === undefined) return tool;
-    const repaired = providerToolSchema(parameters);
+    const repaired = relaySchema(parameters);
     if (repaired === parameters) return tool;
     return tool.function
       ? { ...tool, function: { ...tool.function, parameters: repaired } }
@@ -323,7 +340,10 @@ export function repairToolSchemaRoot(tool, { nonRecursive = false } = {}) {
   if (tool?.type === "namespace" && Array.isArray(tool.tools)) {
     let changed = false;
     const children = tool.tools.map((child) => {
-      const repaired = repairToolSchemaRoot(child, { nonRecursive });
+      const repaired = repairToolSchemaRoot(child, {
+        nonRecursive,
+        inlineForeignRefs: inlineRefs,
+      });
       if (repaired !== child) changed = true;
       return repaired;
     });
@@ -332,7 +352,7 @@ export function repairToolSchemaRoot(tool, { nonRecursive = false } = {}) {
 
   let repairedTool = tool;
   let changed = false;
-  const repair = (schema) => nonRecursiveToolSchema(providerToolSchema(schema));
+  const repair = (schema) => nonRecursiveToolSchema(relaySchema(schema));
 
   if (tool?.function?.parameters !== undefined) {
     const parameters = repair(tool.function.parameters);

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -561,6 +561,19 @@ function needsZenFreeToolCompatibility(route) {
   );
 }
 
+// Moonshot accepts a `$ref` only when it points into `#/$defs/` and rejects the
+// whole request -- not the one tool -- over any other pointer, including the
+// sibling-property pointers Codex App connector tools ship: Wego
+// `_flights_search` points `inboundTotalDurationRange` at its own sibling
+// `priceRange` (issue #353). Scope this to the provider the rejection was
+// reproduced on. The Moonshot platform keys (`kimi-api`, `kimi-api-cn`) reach a
+// different front end and were never observed rejecting these schemas, and
+// inlining for everyone would rewrite the wire payload for providers that work
+// today.
+function needsMoonshotDefsOnlyRefs(route) {
+  return providerForModel(route)?.id === "kimi-oauth";
+}
+
 function zenFreeCompatibleInput(input, route) {
   if (!needsZenFreeToolCompatibility(route)) return input;
   return downgradeOriginalImageDetail(agentMessagesAsUserMessages(input));
@@ -2179,6 +2192,11 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     // after both protocol branches so neither wire shape can bypass it.
     tools = repairToolSchemaRoots(tools, { nonRecursive: true });
     tools = stripSearchContentTypes(tools);
+  }
+  if (needsMoonshotDefsOnlyRefs(route)) {
+    // After the namespace flattening above, so the connector tools Codex ships
+    // inside `codex_app` are repaired in the shape Moonshot actually receives.
+    tools = repairToolSchemaRoots(tools, { inlineForeignRefs: true });
   }
   let routedInput = input;
   let routedToolChoice = payload.tool_choice;

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -199,6 +199,134 @@ export function nonRecursiveToolSchema(schema) {
   return cloneWithoutClosingRefs(schema, closing);
 }
 
+// Moonshot validates every `$ref` a tool schema carries and accepts only
+// pointers into `#/$defs/`, rejecting the whole request -- not the one tool --
+// over anything else. Codex App connector tools break that rule routinely: Wego
+// `_flights_search` points one property at a *sibling* property,
+// `#/properties/filters/properties/priceRange`, so a kimi session that never
+// searches a flight still dies on its first message (issue #353).
+//
+// Inlining replaces such a node with its resolved target merged under the
+// node's own siblings. Nothing is invented: the target is the schema the client
+// itself pointed at, and a `description` or `default` declared beside the `$ref`
+// still wins over whatever the target says. `#/$defs/` pointers are left exactly
+// as they are -- they are the form Moonshot asks for, and expanding them would
+// only grow the payload.
+//
+// Three bounds keep the walk finite. `seen` holds the refs on the current
+// expansion path, so a self-referential or mutually recursive schema stops at
+// the edge that would close the cycle and keeps that one `$ref` rather than
+// expanding forever. MAX_DEPTH caps how many ref hops a single path may take.
+// MAX_INLINE_DEPTH caps structural nesting so a pathological schema cannot
+// exhaust the JavaScript call stack.
+//
+// An unresolvable pointer -- an anchor, a dangling path, a target this module
+// cannot traverse -- is left alone. Guessing at it or deleting it would change
+// what the tool accepts, and the client may well have meant something the
+// upstream resolves for itself.
+//
+// Expanding a shared ref DAG can grow exponentially, which is why the cycle
+// repair above deliberately does not do it. Two budgets make it affordable
+// here: expansions are counted while walking, and the finished copy is measured
+// once. Exceeding either returns the *original* schema, so the worst case is
+// the rejection this repair exists to avoid rather than a multi-megabyte tool
+// list. Copy-on-write throughout: a schema with no foreign ref keeps identity,
+// and the client's object is never mutated.
+const DEFS_REF_PREFIX = "#/$defs/";
+const MAX_INLINE_DEPTH = 32;
+const MAX_INLINE_EXPANSIONS = 512;
+const MAX_INLINE_BYTES = 256 * 1024;
+
+function inlineChildRefs(node, root, state, seen, depth, refDepth) {
+  let next = node;
+  const replace = (key, value) => {
+    if (next === node) next = { ...node };
+    next[key] = value;
+  };
+  const inlineChild = (schema) =>
+    isPlainObject(schema) ? inlineNodeRefs(schema, root, state, seen, depth + 1, refDepth) : schema;
+
+  // `dependencies` is draft-07's mixed map: array values list property names
+  // rather than schemas, and `inlineChild` passes those through untouched.
+  for (const keyword of [...REF_SCHEMA_MAP_KEYWORDS, "dependencies"]) {
+    const schemas = node[keyword];
+    if (!isPlainObject(schemas)) continue;
+    let changed = false;
+    const rewritten = {};
+    for (const [name, schema] of Object.entries(schemas)) {
+      const inlined = inlineChild(schema);
+      if (inlined !== schema) changed = true;
+      rewritten[name] = inlined;
+    }
+    if (changed) replace(keyword, rewritten);
+  }
+
+  for (const keyword of [...REF_SCHEMA_ARRAY_KEYWORDS, ...REF_SCHEMA_CHILD_KEYWORDS]) {
+    const schemas = node[keyword];
+    if (Array.isArray(schemas)) {
+      let changed = false;
+      const rewritten = schemas.map((schema) => {
+        const inlined = inlineChild(schema);
+        if (inlined !== schema) changed = true;
+        return inlined;
+      });
+      if (changed) replace(keyword, rewritten);
+      continue;
+    }
+    if (!isPlainObject(schemas)) continue;
+    const inlined = inlineChild(schemas);
+    if (inlined !== schemas) replace(keyword, inlined);
+  }
+
+  return next;
+}
+
+function inlineNodeRefs(node, root, state, seen, depth, refDepth) {
+  if (!isPlainObject(node) || depth > MAX_INLINE_DEPTH || state.exceeded) return node;
+  const ref = node.$ref;
+  const expandable =
+    typeof ref === "string" &&
+    !ref.startsWith(DEFS_REF_PREFIX) &&
+    !seen.has(ref) &&
+    refDepth < MAX_DEPTH;
+  const target = expandable ? resolveRef(ref, root) : undefined;
+  if (!isPlainObject(target)) return inlineChildRefs(node, root, state, seen, depth, refDepth);
+
+  state.expansions += 1;
+  if (state.expansions > MAX_INLINE_EXPANSIONS) {
+    state.exceeded = true;
+    return node;
+  }
+  seen.add(ref);
+  // The target takes the node's place rather than nesting inside it, so the
+  // structural depth does not grow; the ref hop is what is charged.
+  const expanded = inlineNodeRefs(target, root, state, seen, depth, refDepth + 1);
+  seen.delete(ref);
+  if (state.exceeded) return node;
+  state.inlined = true;
+  const { $ref: _inlined, ...siblings } = node;
+  // Only the siblings still need walking: the target came back already inlined,
+  // and re-walking it would re-expand the very edges `seen` just protected.
+  return { ...expanded, ...inlineChildRefs(siblings, root, state, seen, depth, refDepth) };
+}
+
+function jsonByteLength(value) {
+  try {
+    return Buffer.byteLength(JSON.stringify(value) ?? "");
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+export function inlineForeignRefs(schema) {
+  if (!isPlainObject(schema)) return schema;
+  const state = { expansions: 0, exceeded: false, inlined: false };
+  const inlined = inlineNodeRefs(schema, schema, state, new Set(), 0, 0);
+  if (state.exceeded || !state.inlined || inlined === schema) return schema;
+  if (jsonByteLength(inlined) > MAX_INLINE_BYTES) return schema;
+  return inlined;
+}
+
 // Every object-typed leaf reachable from `schema` through unions and local
 // refs. `seen` guards the self-referential `$defs` Codex generates.
 function objectBranches(schema, root, seen, depth = 0) {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -1650,3 +1650,94 @@ test("a well-formed bridged call closes as the custom_tool_call it opened", asyn
     true,
   );
 });
+
+// Moonshot accepts a `$ref` only when it points into `#/$defs/`, and the Codex
+// App connector pack ships sibling-property pointers -- Wego `_flights_search`
+// points `inboundTotalDurationRange` at its own sibling `priceRange`. The
+// rejection fails the whole request, so the kimi route inlines those pointers
+// before relaying (issue #353).
+function connectorNamespace() {
+  return {
+    type: "namespace",
+    name: "wego",
+    tools: [
+      {
+        name: "_flights_search",
+        inputSchema: {
+          type: "object",
+          properties: {
+            filters: {
+              type: "object",
+              properties: {
+                priceRange: {
+                  type: "object",
+                  properties: { min: { type: "number" }, max: { type: "number" } },
+                  required: ["min"],
+                },
+                inboundTotalDurationRange: {
+                  $ref: "#/properties/filters/properties/priceRange",
+                },
+              },
+            },
+          },
+        },
+      },
+    ],
+  };
+}
+
+function siblingRefs(value, found = []) {
+  if (Array.isArray(value)) {
+    for (const entry of value) siblingRefs(entry, found);
+    return found;
+  }
+  if (!value || typeof value !== "object") return found;
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "$ref" && typeof entry === "string" && !entry.startsWith("#/$defs/")) {
+      found.push(entry);
+    } else siblingRefs(entry, found);
+  }
+  return found;
+}
+
+test("the kimi route relays connector tools with no sibling ref left", () => {
+  const { tools } = flattenNamespaceTools([connectorNamespace()]);
+  const relayed = repairToolSchemaRoots(tools, { inlineForeignRefs: true });
+  const parameters = relayed[0].parameters;
+  assert.deepEqual(siblingRefs(parameters), []);
+  const inbound = parameters.properties.filters.properties.inboundTotalDurationRange;
+  assert.deepEqual(Object.keys(inbound.properties), ["min", "max"]);
+  assert.deepEqual(inbound.required, ["min"]);
+  // The client's native declaration is not the provider-facing copy and stays
+  // exactly as Codex sent it.
+  const native = relayed[0].inputSchema.properties.filters.properties;
+  assert.equal(
+    native.inboundTotalDurationRange.$ref,
+    "#/properties/filters/properties/priceRange",
+  );
+});
+
+// The negative control is the point of the gate: every provider that accepts
+// these pointers today must keep the byte-identical payload it already gets.
+test("a provider that never asked for inlining keeps its tools by identity", () => {
+  const { tools } = flattenNamespaceTools([connectorNamespace()]);
+  assert.equal(repairToolSchemaRoots(tools), tools);
+  assert.deepEqual(siblingRefs(tools[0].parameters), [
+    "#/properties/filters/properties/priceRange",
+  ]);
+});
+
+test("the kimi route still copies nothing when no tool carries a foreign ref", () => {
+  const tools = [
+    {
+      type: "function",
+      name: "ordinary",
+      parameters: {
+        type: "object",
+        properties: { window: { $ref: "#/$defs/range" } },
+        $defs: { range: { type: "object" } },
+      },
+    },
+  ];
+  assert.equal(repairToolSchemaRoots(tools, { inlineForeignRefs: true }), tools);
+});

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -5,6 +5,7 @@ import { CODEX_APP_TOOLS } from "../src/codex-app-tools.mjs";
 import { toResponsesRequest } from "../src/grok-oauth-forwarder.mjs";
 import {
   hasObjectRoot,
+  inlineForeignRefs,
   nonRecursiveToolSchema,
   normalizeSchemaLiterals,
   objectRootToolSchema,
@@ -488,4 +489,168 @@ test("the shared relay leaves other roots alone", () => {
   // No "object" member means collapsing it would destroy the schema, not fix it.
   const notObject = { type: ["string", "null"] };
   assert.equal(providerToolSchema(notObject), notObject);
+});
+
+// Moonshot rejects every `$ref` that does not point into `#/$defs/`, and the
+// Codex App connector pack ships plenty that do not: Wego `_flights_search`
+// points `inboundTotalDurationRange` at its own sibling `priceRange`. The
+// rejection fails the whole request, so one connector tool kills a kimi session
+// that never searches a flight (issue #353).
+function flightsSearchSchema() {
+  return {
+    type: "object",
+    properties: {
+      filters: {
+        type: "object",
+        properties: {
+          priceRange: {
+            type: "object",
+            properties: {
+              min: { type: "number" },
+              max: { type: "number" },
+            },
+            required: ["min"],
+            additionalProperties: false,
+          },
+          inboundTotalDurationRange: {
+            $ref: "#/properties/filters/properties/priceRange",
+            description: "Inbound duration window, in minutes.",
+          },
+        },
+      },
+    },
+  };
+}
+
+function refPointers(value, found = []) {
+  if (Array.isArray(value)) {
+    for (const entry of value) refPointers(entry, found);
+    return found;
+  }
+  if (!value || typeof value !== "object") return found;
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "$ref" && typeof entry === "string") found.push(entry);
+    else refPointers(entry, found);
+  }
+  return found;
+}
+
+test("a sibling-property ref is inlined with the target's constraints", () => {
+  const schema = flightsSearchSchema();
+  const inlined = inlineForeignRefs(schema);
+  assert.notEqual(inlined, schema);
+  assert.deepEqual(refPointers(inlined), []);
+  const inbound = inlined.properties.filters.properties.inboundTotalDurationRange;
+  assert.equal(inbound.type, "object");
+  assert.deepEqual(Object.keys(inbound.properties), ["min", "max"]);
+  assert.deepEqual(inbound.required, ["min"]);
+  assert.equal(inbound.additionalProperties, false);
+  // A constraint declared beside the `$ref` is the client's own and outranks
+  // whatever the target says.
+  assert.equal(inbound.description, "Inbound duration window, in minutes.");
+  // The client's schema is never mutated.
+  assert.deepEqual(schema, flightsSearchSchema());
+});
+
+test("a $defs ref is the form Moonshot asks for and survives untouched", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      window: { $ref: "#/$defs/range" },
+      alias: { $ref: "#/properties/window" },
+    },
+    $defs: { range: { type: "object", properties: { min: { type: "number" } } } },
+  };
+  const inlined = inlineForeignRefs(schema);
+  assert.equal(inlined.properties.window.$ref, "#/$defs/range");
+  // The alias pointed at a property, not a definition, so it is expanded -- and
+  // what it expands to is the `$defs` pointer the property itself carries.
+  assert.equal(inlined.properties.alias.$ref, "#/$defs/range");
+  assert.deepEqual(inlined.$defs, schema.$defs);
+});
+
+test("an unresolvable ref is left alone rather than guessed at", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      dangling: { $ref: "#/properties/missing" },
+      anchor: { $ref: "#namedAnchor" },
+      remote: { $ref: "https://example.com/schema.json" },
+      resolvable: { $ref: "#/properties/known" },
+      known: { type: "string", minLength: 2 },
+    },
+  };
+  const inlined = inlineForeignRefs(schema);
+  assert.equal(inlined.properties.dangling.$ref, "#/properties/missing");
+  assert.equal(inlined.properties.anchor.$ref, "#namedAnchor");
+  assert.equal(inlined.properties.remote.$ref, "https://example.com/schema.json");
+  assert.deepEqual(inlined.properties.resolvable, { type: "string", minLength: 2 });
+});
+
+test("a self-referential foreign ref terminates and keeps the cycle edge", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      node: {
+        type: "object",
+        properties: {
+          label: { type: "string" },
+          child: { $ref: "#/properties/node" },
+        },
+      },
+      root: { $ref: "#" },
+    },
+  };
+  const inlined = inlineForeignRefs(schema);
+  // The expansion stops at the edge that would close the cycle: the innermost
+  // `child` still carries the pointer instead of another copy of `node`.
+  const child = inlined.properties.node.properties.child;
+  assert.equal(child.type, "object");
+  assert.equal(child.properties.label.type, "string");
+  assert.equal(child.properties.child.$ref, "#/properties/node");
+  assert.equal(inlined.properties.root.type, "object");
+});
+
+test("a mutually recursive pair terminates", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      a: { type: "object", properties: { next: { $ref: "#/properties/b" } } },
+      b: { type: "object", properties: { previous: { $ref: "#/properties/a" } } },
+    },
+  };
+  const inlined = inlineForeignRefs(schema);
+  assert.equal(inlined.properties.a.properties.next.type, "object");
+  assert.equal(
+    inlined.properties.a.properties.next.properties.previous.properties.next.$ref,
+    "#/properties/b",
+  );
+});
+
+// Expanding a shared ref DAG can grow exponentially, so an inlined copy that
+// outgrows its budget is worse than the rejection it was meant to avoid: it
+// would ship megabytes of duplicated schema on every turn. The original comes
+// back instead, refs and all.
+test("an expansion past the byte budget falls back to the original schema", () => {
+  const enormous = {
+    type: "string",
+    enum: Array.from({ length: 4000 }, (_, index) => `option-${index}-${"x".repeat(16)}`),
+  };
+  const properties = { enormous };
+  for (let index = 0; index < 12; index += 1) {
+    properties[`copy${index}`] = { $ref: "#/properties/enormous" };
+  }
+  const schema = { type: "object", properties };
+  assert.equal(inlineForeignRefs(schema), schema);
+});
+
+test("a schema with no foreign ref keeps identity", () => {
+  const schema = {
+    type: "object",
+    properties: { window: { $ref: "#/$defs/range" } },
+    $defs: { range: { type: "object" } },
+  };
+  assert.equal(inlineForeignRefs(schema), schema);
+  const notObject = ["not", "a", "schema"];
+  assert.equal(inlineForeignRefs(notObject), notObject);
 });


### PR DESCRIPTION
Fixes #353.

## The bug

Moonshot accepts only `#/$defs/`-style JSON Pointers and 400s a tool schema containing a sibling-property `$ref` such as `"$ref": "#/properties/filters/properties/priceRange"` — the Wego `_flights_search` connector reproduces it.

`providerToolSchema` returns a plain-object root **by identity**, so every `$ref` survives:

```js
if (!hasRootUnion(normalized) && !hasNullableObjectRoot(normalized)) return normalized;
```

`resolveRef` existed but was reachable only from `objectBranches`, which feeds the root collapse — it never inlined refs into the relayed copy. `src/namespace-relay.mjs` calls `providerToolSchema` at the three flatten sites and nothing else, and `normalizeKimiBody` in `src/oauth-forwarder.mjs` never touches `tools`. So the pointer reached Moonshot verbatim.

One detail that made this easy to miss: kimi-oauth is `kind: "oauth"` with `protocol` unset, so it resolves as a chat-completions provider, takes the flatten branch, and **never reached `repairToolSchemaRoots` at all**.

## The fix

New exported `inlineForeignRefs(schema)` in `src/tool-schema-root.mjs`. A node whose `$ref` does not start with `#/$defs/` is replaced by `{ ...resolvedTarget, ...siblingsWithout$ref }` (siblings win), reusing the existing RFC 6901 `resolveRef`. Unresolvable pointers — dangling, `#namedAnchor`, remote URLs — are left untouched rather than guessed at. Copy-on-write throughout, so a clean schema keeps identity and the client's object is never mutated.

**Expansion is bounded four ways**, because the file already warns that expanding a shared ref DAG can grow exponentially:

- a `seen` set holds refs on the current expansion path, so a cycle stops at the closing edge and keeps that one `$ref`
- the module's existing `MAX_DEPTH` (8) caps ref hops per path; a separate `MAX_INLINE_DEPTH` (32) caps structural nesting for stack safety
- `MAX_INLINE_EXPANSIONS` (512) aborts to the original if exceeded
- `MAX_INLINE_BYTES` (256 KiB) measured once on the finished copy; over budget returns the original unchanged

After a ref expands, only its *siblings* are walked, never the already-inlined target — re-walking would re-expand the edges `seen` just protected.

## Scoping

Gated per-provider, following the `needsZenFreeToolCompatibility` pattern exactly:

```js
function needsMoonshotDefsOnlyRefs(route) {
  return providerForModel(route)?.id === "kimi-oauth";
}
```

Exact provider-id match, one call site, applied as `repairToolSchemaRoots(tools, { inlineForeignRefs: true })`. `kimi-api` / `kimi-api-cn` are deliberately excluded — different front end, not reproduced — and that is documented in the comment. Applying this to every provider would change the wire payload for providers that work today and risk the blowup above.

## Tests

10 new. The negative control is the important one: an unaffected provider's tool array is returned **by identity** with its `$ref` intact, so the gate is proven to be a gate.

Coverage: the exact Wego repro, a `#/$defs/` ref surviving untouched, three unresolvable forms left alone, self-referential and mutually-recursive schemas terminating, the byte-budget fallback, identity when no foreign ref exists, and the client-native `inputSchema` left byte-identical on the kimi route.

**Verified against unmodified `main`**: `test/namespace-relay.test.mjs` fails with actual `['#/properties/filters/properties/priceRange']` vs expected `[]`, and the negative control passes on main as it must. Since the new `tool-schema-root` tests fail at import on main, they were re-run there against an identity stub (which is exactly main's behavior) for a behavioral rather than import-level proof — **5 of 7 fail**; the two that pass are the fallback tests that assert identity by design.

## Verification

- `node scripts-check.mjs` — passes
- `node --test test/*.test.mjs` — 2172 tests, **0 failures**, 13 pre-existing skips

## Known limits

- Not verified against live Moonshot — no provider quota was spent — so the `#/$defs/`-only rule is taken from the issue's reproduction.
- The non-namespace repair path still does not descend into `type: "namespace"` tools. Pre-existing, and safe here because kimi always flattens namespaces before the gate runs, but a future Responses-native Moonshot route would need that path extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
