### PR TITLE
fix(curation): source Zen free-model metadata, and withhold windows that fail the headroom check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,7 +538,18 @@ to ship tested support to every installer.
    advertises for that model (`modelContextLengths` in
    `src/model-discovery.mjs`), because `autoCompact` is derived from it and an
    understated window makes Codex compact a session that had the room. Only a
-   model the catalog sizes in silence falls back to 131072. An entry curated
+   model the catalog sizes in silence falls back to 131072.
+   OpenCode Zen's anonymous catalog publishes ids and nothing else, so its free
+   models are sized and laddered from `src/opencode-curation.mjs`, which
+   records OpenCode's own published `limit` and `reasoning_options` for each
+   *free id* along with the sourcing. A documented window is stored only when
+   the 0.85 auto-compact ratio still reserves that id's published
+   `limit.output`; otherwise the id keeps 131072 and its description says the
+   window is unknown, because a window a full-length completion can overrun
+   fails the turn outright. An id OpenCode documents nothing usable for keeps
+   the stock "conservative default metadata" description, which is how a
+   stored entry says every value in it is a default rather than an advertised
+   capability. An explicit `--efforts` always wins over a documented ladder. An entry curated
    before this landed keeps its stored window — an additive run never rewrites
    existing metadata — so repair it by editing `user-models.json` or by
    `--remove`-ing and re-curating the model. An optional `availabilityNux` string on a model becomes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+- **Curated OpenCode Zen free models now ship the effort ladder and context
+  window OpenCode publishes for them, and say which values are still
+  guesses.** Zen's anonymous `/models` endpoint returns ids and nothing else,
+  and the deterministic curation path is never interactive, so every free
+  model landed in the picker with a generic 131,072-token window and a single
+  `high` effort no matter what the route actually supported (#352).
+  `src/opencode-curation.mjs` now carries OpenCode's own published `limit` and
+  `reasoning_options` per *free id* -- adding real windows for
+  `nemotron-3-ultra-free` (1,000,000) and `laguna-s-2.1-free` (256,000)
+  alongside the two that already had them, and real effort ladders for
+  `muse-spark-1.2-contributor-free`, `x-preview-f-free`,
+  `laguna-s-2.1-free`, `deepseek-v4-flash-free`, and `hy3-free`. A window is
+  declared only when curation's 0.85 auto-compact ratio still reserves that
+  id's published output limit, so compaction fires before a completion can
+  overrun the window the entry just declared; `deepseek-v4-flash-free`,
+  `hy3-free`, `mimo-v2.5-free`, and `nemotron-3.5-lightning-free` therefore
+  keep the conservative default rather than a number a full-length answer
+  could walk off the end of. Each entry's description now names the provenance
+  of every capability it carries *and* the ones that stayed unknown, so a
+  reader can tell a documented value from a default without leaving the file.
+  Hand-tuned entries are still never rewritten: the upgrade path touches only
+  an entry still holding the untouched generic sizing pair and the untouched
+  single-`high` ladder, and an explicit `--efforts` always wins.
+
 - **The macOS tray can load a provider's current model list and curate from
   it.** A new Provider catalogs panel asks any configured provider that
   supports live discovery for the models it serves right now, marks the ones

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -10,6 +10,7 @@ import {
   DEFAULT_CONTEXT_WINDOW,
   USER_MODELS_PATH,
   defaultUserModelDescription,
+  hasDefaultUserModelReasoning,
   readUserModels,
   userModelEntry,
   userModelIdentity,
@@ -21,6 +22,7 @@ import {
   curatedModelContextLength,
   curatedModelDescription,
   curatedModelProviderId,
+  curatedModelReasoningLevels,
 } from "./opencode-curation.mjs";
 import {
   applyModelOverlayPublication,
@@ -189,29 +191,44 @@ export function normalizeCurationModels(models, providerId) {
           }),
           provider: targetProvider,
         };
+    // The untouched generic sizing pair is the one signal that nobody has been
+    // inside this entry by hand. Every documented value below is gated on it,
+    // so an operator who tuned the window keeps their whole entry byte for
+    // byte -- including an effort ladder they may have edited beside it.
+    const untuned =
+      routed.contextWindow === DEFAULT_CONTEXT_WINDOW &&
+      routed.autoCompact === DEFAULT_AUTO_COMPACT;
     const documented = curatedSizing(
       curatedModelContextLength(providerId, model.upstreamModel),
     );
-    const upgradeSizing =
-      documented &&
-      routed.contextWindow === DEFAULT_CONTEXT_WINDOW &&
-      routed.autoCompact === DEFAULT_AUTO_COMPACT;
+    const upgradeSizing = Boolean(documented) && untuned;
+    // The same upgrade for the effort ladder: high-only is what curation
+    // stores when nothing documents the model's efforts, so replacing it with
+    // a published ladder is finishing the job, not overruling a choice. A
+    // ladder that is no longer the stock one was chosen by someone.
+    const documentedEfforts = curatedModelReasoningLevels(providerId, model.upstreamModel);
+    const efforts = documentedEfforts
+      ? parseEfforts(documentedEfforts.join(","))
+      : undefined;
+    const upgradeEfforts =
+      Boolean(efforts) && untuned && hasDefaultUserModelReasoning(routed);
     // The stock description says the entry carries conservative defaults, so
-    // it stops being true the moment the sizing is upgraded. Replace it with
+    // it stops being true the moment any of them is upgraded. Replace it with
     // the sourcing note only while it is still the untouched stock string;
     // anything the user wrote there is theirs.
     const documentedDescription = curatedModelDescription(providerId, model.upstreamModel);
     const upgradeDescription =
-      upgradeSizing &&
+      (upgradeSizing || upgradeEfforts) &&
       documentedDescription &&
       // An entry rerouted onto the Responses variant still carries the stock
       // string naming the provider it was curated under, so accept either.
       (routed.description === defaultUserModelDescription(routed.provider) ||
         routed.description === defaultUserModelDescription(model.provider));
-    const sized = upgradeSizing
+    const sized = upgradeSizing || upgradeEfforts
       ? {
           ...routed,
-          ...documented,
+          ...(upgradeSizing ? documented : {}),
+          ...(upgradeEfforts ? efforts : {}),
           ...(upgradeDescription ? { description: documentedDescription } : {}),
         }
       : routed;
@@ -399,14 +416,32 @@ async function main() {
     const documented = curatedSizing(curatedModelContextLength(providerId, id));
     const sizing = advertised || documented;
     if (sizing) Object.assign(metadata, sizing);
-    // A documented window is not a conservative default, and this repository
-    // records where such a number came from in the entry's own description
-    // rather than only in a source comment. The live catalog's own figure
-    // needs no note; it is first-hand and already labeled "advertised".
-    if (!advertised && documented) {
-      const description = curatedModelDescription(providerId, id);
-      if (description) metadata.description = description;
+    // OpenCode publishes an effort ladder per free id where the route has one,
+    // and the id-only Zen catalog carries none -- so without this every free
+    // model ships the single conservative `high` level whatever it supports
+    // (#352). An explicit --efforts is the operator speaking and still wins.
+    const documentedEfforts = curatedModelReasoningLevels(providerId, id);
+    if (!flagEfforts && documentedEfforts) {
+      Object.assign(metadata, parseEfforts(documentedEfforts.join(",")) || {});
     }
+    // A documented window or effort ladder is not a conservative default, and
+    // this repository records where such a value came from in the entry's own
+    // description rather than only in a source comment. The same note names
+    // the capabilities that stayed unknown, so the stored entry says which of
+    // its values are real and which are still defaults. The live catalog's own
+    // figure needs no note; it is first-hand and already labeled "advertised".
+    let omitContextNote = Boolean(advertised);
+    let omitReasoningNote = Boolean(flagEfforts);
+    const describe = () => {
+      if (!documented && !documentedEfforts) return;
+      const description = curatedModelDescription(providerId, id, {
+        omitContextNote,
+        omitReasoningNote,
+      });
+      if (description) metadata.description = description;
+      else delete metadata.description;
+    };
+    describe();
     if (!interactive) return Object.keys(metadata).length > 0 ? metadata : undefined;
     process.stdout.write(`\nMetadata for ${id} (Enter keeps the default):\n`);
     const suggested = sizing?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
@@ -421,19 +456,26 @@ async function main() {
       if (!sizing) throw new Error(`Invalid context window: ${rawContext}`);
       Object.assign(metadata, sizing);
       // The sourcing note describes the documented figure. The user just
-      // replaced it, so the note no longer matches what is stored.
-      if (context !== documented?.contextWindow) delete metadata.description;
+      // replaced it, so that clause no longer matches what is stored.
+      if (context !== documented?.contextWindow) omitContextNote = true;
     }
     if (confirm(`  Does ${id} accept image input?`)) {
       metadata.inputModalities = ["text", "image"];
     }
     if (!flagEfforts) {
+      const ladder = metadata.reasoningLevels?.map((level) => level.effort).join(",") || "high";
       const rawEfforts = promptLine(
         "  Reasoning efforts, comma-separated from " +
-          `${Object.keys(EFFORT_DESCRIPTIONS).join(",")} [high]`,
+          `${Object.keys(EFFORT_DESCRIPTIONS).join(",")} [${ladder}${
+            documentedEfforts ? ", documented" : ""
+          }]`,
       ).trim();
-      if (rawEfforts) Object.assign(metadata, parseEfforts(rawEfforts) || {});
+      if (rawEfforts) {
+        Object.assign(metadata, parseEfforts(rawEfforts) || {});
+        omitReasoningNote = true;
+      }
     }
+    describe();
     return Object.keys(metadata).length > 0 ? metadata : undefined;
   };
 

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -1,56 +1,145 @@
-// OpenCode's anonymous catalog exposes one documented free model on Responses.
-// Keep this mapping deliberately separate from paid Zen and the Go subscription
-// family: those providers have different catalogs and billing semantics.
+// OpenCode's anonymous catalog exposes documented free models on Chat
+// Completions and one on Responses. Keep this mapping deliberately separate
+// from paid Zen and the Go subscription family: those providers have different
+// catalogs and billing semantics.
+//
+// Zen's live /models response publishes ids, `object`, `created`, and
+// `owned_by` -- no context limit and no effort control for any model. Without
+// documented metadata every free id falls back to the generic 131,072 window
+// and a single `high` effort, which compacts every tool-bearing turn on a
+// million-token route (#266) and hides an effort ladder the model really has
+// (#352).
+//
+// Everything below comes from OpenCode's own published model metadata (the
+// `opencode` provider in https://models.dev/api.json, whose record points at
+// https://opencode.ai/zen/v1 and https://opencode.ai/docs/zen). That dataset
+// keys `limit` and `reasoning_options` per *free id*, not per model, and
+// demonstrably records a smaller window when the free route is capped below
+// the paid one -- `deepseek-v4-flash` publishes 1,000,000 while
+// `deepseek-v4-flash-free` publishes 200,000, and `minimax-m3` publishes
+// 512,000 against `minimax-m3-free`'s 200,000. So a free id's figure describes
+// the free route's own served cap.
+//
+// A documented window is stored only when curation's 0.85 auto-compact ratio
+// still leaves at least the id's published `limit.output` in reserve, so
+// compaction fires before a completion can overrun the window the entry just
+// declared. Where it does not, the id keeps the conservative default and says
+// so in its own description rather than declaring a window a full-length
+// answer can walk off the end of. Two live free ids are therefore absent from
+// this table entirely, because neither their window nor an effort ladder
+// survives that test: `mimo-v2.5-free` (200,000 window, 32,000 output, so
+// 0.85 leaves 30,000) and `nemotron-3.5-lightning-free` (262,144 window and a
+// 262,144 output limit, which no ratio can reserve room for). Both publish an
+// empty `reasoning_options`. They keep the stock "conservative default
+// metadata" description, which is this repository's existing way of saying
+// every value in the entry is a default rather than a documented capability.
+//
+// Evidence is restated in `descriptions` because that is where this
+// repository records metadata that is not a conservative default (see
+// config/zai/coding/glm-5.3.json). A future figure in Zen's own /models
+// response is still preferred by curate-models, because that one describes the
+// served route first-hand.
+
+const UNDOCUMENTED_EFFORTS =
+  "OpenCode documents no effort control for this free id -- its `reasoning_options` in " +
+  "that record is empty -- so the stored single `high` level is this repository's " +
+  "conservative default, not an advertised capability.";
+
+const OPENCODE_FREE_MODELS = Object.freeze({
+  "muse-spark-1.2-contributor-free": Object.freeze({
+    contextWindow: 1_048_576,
+    outputLimit: 131_072,
+    reasoningLevels: Object.freeze(["minimal", "low", "medium", "high", "xhigh"]),
+    summary:
+      "Muse Spark 1.2 Contributor Free through OpenCode Zen's anonymous Responses route.",
+    contextNote:
+      "The 1,048,576-token window is OpenCode's own published figure for this exact free id " +
+      "(the `opencode` provider in models.dev/api.json), not the paid model's: that dataset " +
+      "publishes a smaller window on free ids whose route is capped below their paid twin, " +
+      "and this one is not. Zen's /models endpoint publishes no context limits.",
+    reasoningNote:
+      "The minimal/low/medium/high/xhigh ladder is that same record's `reasoning_options` " +
+      "for this free id; Zen's /models endpoint advertises no effort control.",
+  }),
+  "x-preview-f-free": Object.freeze({
+    contextWindow: 1_000_000,
+    outputLimit: 131_072,
+    reasoningLevels: Object.freeze(["low", "high", "max"]),
+    summary: "Ox Alpha Free through OpenCode Zen's anonymous Chat Completions route.",
+    contextNote:
+      "The 1,000,000-token window is OpenCode's own published figure for this exact free id " +
+      "(the `opencode` provider in models.dev/api.json); the catalog carries no paid Ox entry " +
+      "for a model-level number to have been copied from, and it publishes a smaller window " +
+      "on free ids whose route is capped lower. Zen's /models endpoint publishes no context " +
+      "limits.",
+    reasoningNote:
+      "The low/high/max ladder is that same record's `reasoning_options` for this free id; " +
+      "Zen's /models endpoint advertises no effort control.",
+  }),
+  "nemotron-3-ultra-free": Object.freeze({
+    contextWindow: 1_000_000,
+    outputLimit: 128_000,
+    summary: "Nemotron 3 Ultra Free through OpenCode Zen's anonymous Chat Completions route.",
+    contextNote:
+      "The 1,000,000-token window is OpenCode's own published figure for this exact free id " +
+      "(the `opencode` provider in models.dev/api.json); the catalog carries no paid Nemotron " +
+      "entry for a model-level number to have been copied from, and it publishes a smaller " +
+      "window on free ids whose route is capped lower. Zen's /models endpoint publishes no " +
+      "context limits.",
+    reasoningNote: UNDOCUMENTED_EFFORTS,
+  }),
+  "laguna-s-2.1-free": Object.freeze({
+    contextWindow: 256_000,
+    outputLimit: 32_000,
+    reasoningLevels: Object.freeze(["low", "medium", "high"]),
+    summary: "Laguna S 2.1 Free through OpenCode Zen's anonymous Chat Completions route.",
+    contextNote:
+      "The 256,000-token window is OpenCode's own published figure for this exact free id " +
+      "(the `opencode` provider in models.dev/api.json); the catalog carries no paid Laguna " +
+      "entry for a model-level number to have been copied from, and it publishes a smaller " +
+      "window on free ids whose route is capped lower. Zen's /models endpoint publishes no " +
+      "context limits.",
+    reasoningNote:
+      "The low/medium/high ladder is that same record's `reasoning_options` for this free id; " +
+      "Zen's /models endpoint advertises no effort control.",
+  }),
+  // Window deliberately withheld: documented, but not safely declarable.
+  "deepseek-v4-flash-free": Object.freeze({
+    outputLimit: 128_000,
+    reasoningLevels: Object.freeze(["low", "high", "max"]),
+    summary: "DeepSeek V4 Flash Free through OpenCode Zen's anonymous Chat Completions route.",
+    contextNote:
+      "The context window is unknown here and stays on the conservative default. models.dev " +
+      "does publish 200,000 for this free id (throttled from the paid `deepseek-v4-flash`'s " +
+      "1,000,000), but curation's 0.85 auto-compact ratio would leave only 30,000 tokens " +
+      "against the same record's 128,000-token output limit, so declaring 200,000 would let a " +
+      "full-length completion overrun the window the entry just declared.",
+    reasoningNote:
+      "The low/high/max ladder is that same record's `reasoning_options` for this free id; " +
+      "Zen's /models endpoint advertises no effort control.",
+  }),
+  "hy3-free": Object.freeze({
+    outputLimit: 64_000,
+    reasoningLevels: Object.freeze(["low", "medium", "high"]),
+    summary: "Hy3 Free through OpenCode Zen's anonymous Chat Completions route.",
+    contextNote:
+      "The context window is unknown here and stays on the conservative default. models.dev " +
+      "does publish 190,000 for this free id, but curation's 0.85 auto-compact ratio would " +
+      "leave only 28,500 tokens against the same record's 64,000-token output limit, so " +
+      "declaring 190,000 would let a full-length completion overrun the window the entry just " +
+      "declared.",
+    reasoningNote:
+      "The low/medium/high ladder is that same record's `reasoning_options` for this free id; " +
+      "Zen's /models endpoint advertises no effort control.",
+  }),
+});
+
 const CURATION_ROUTES = Object.freeze({
   "opencode-free": Object.freeze({
     providers: Object.freeze(["opencode-free", "opencode-free-responses"]),
     responsesProvider: "opencode-free-responses",
     responsesModels: Object.freeze(["muse-spark-1.2-contributor-free"]),
-    // Zen's live /models response publishes ids, `object`, `created`, and
-    // `owned_by` -- no context limit for any model. Without a documented size
-    // these two ids fall back to the generic 131K guess and Codex compacts
-    // every tool-bearing turn on a million-token route.
-    //
-    // The sizes below come from OpenCode's own published model metadata (the
-    // `opencode` provider in https://models.dev/api.json, whose record points
-    // at https://opencode.ai/zen/v1 and https://opencode.ai/docs/zen). That
-    // dataset keys `limit` per *free id*, not per model, and demonstrably
-    // records a smaller window when the free route is capped below the paid
-    // one -- `deepseek-v4-flash` publishes 1,000,000 while
-    // `deepseek-v4-flash-free` publishes 200,000, and `minimax-m3` publishes
-    // 512,000 against `minimax-m3-free`'s 200,000. So a free id's figure is
-    // the free route's own served cap, and these two are safe to declare:
-    // `muse-spark-1.2-contributor-free` matches its paid twin rather than
-    // being throttled, and `x-preview-f-free` has no paid Ox counterpart in
-    // the catalog at all for a model-level number to have leaked in from.
-    //
-    // `curatedSizing` derives autoCompact at 0.85, which leaves 157,287 and
-    // 150,000 tokens respectively -- both above each id's published 131,072
-    // output limit, so compaction fires before a completion can overrun the
-    // window. The evidence is restated in `descriptions` because that is where
-    // this repository records a context window that is not a conservative
-    // default (see config/zai/coding/glm-5.3.json). A future value in Zen's
-    // own /models response is still preferred by curate-models, because that
-    // one describes the served route first-hand.
-    contextWindows: Object.freeze({
-      "muse-spark-1.2-contributor-free": 1_048_576,
-      "x-preview-f-free": 1_000_000,
-    }),
-    descriptions: Object.freeze({
-      "muse-spark-1.2-contributor-free":
-        "Muse Spark 1.2 Contributor Free through OpenCode Zen's anonymous Responses route. " +
-        "The 1,048,576-token window is OpenCode's own published figure for this exact free id " +
-        "(the `opencode` provider in models.dev/api.json), not the paid model's: that dataset " +
-        "publishes a smaller window on free ids whose route is capped below their paid twin, " +
-        "and this one is not. Zen's /models endpoint publishes no context limits.",
-      "x-preview-f-free":
-        "Ox Alpha Free through OpenCode Zen's anonymous Chat Completions route. " +
-        "The 1,000,000-token window is OpenCode's own published figure for this exact free id " +
-        "(the `opencode` provider in models.dev/api.json); the catalog carries no paid Ox entry " +
-        "for a model-level number to have been copied from, and it publishes a smaller window " +
-        "on free ids whose route is capped lower. Zen's /models endpoint publishes no context " +
-        "limits.",
-    }),
+    models: OPENCODE_FREE_MODELS,
   }),
 });
 
@@ -76,15 +165,59 @@ export function curatedModelProviderId(providerId, upstreamModel) {
   return primary;
 }
 
-export function curatedModelContextLength(providerId, upstreamModel) {
+function curatedModelRecord(providerId, upstreamModel) {
   const primary = curationPrimaryProviderId(providerId);
-  return CURATION_ROUTES[primary]?.contextWindows?.[upstreamModel];
+  return CURATION_ROUTES[primary]?.models?.[upstreamModel];
 }
 
-// The picker text that carries the sourcing for a documented context window.
-// Only defined for an id this module sizes; every other curated model keeps
-// the generic "conservative default metadata" description it earns.
-export function curatedModelDescription(providerId, upstreamModel) {
+export function curatedModelContextLength(providerId, upstreamModel) {
+  return curatedModelRecord(providerId, upstreamModel)?.contextWindow;
+}
+
+// The output limit OpenCode publishes for this id. Exported so the safety
+// margin behind a declared window is checkable rather than a claim in a
+// comment: auto-compaction has to fire while at least this many tokens are
+// still free, or a full-length completion runs past the declared window.
+export function curatedModelOutputLimit(providerId, upstreamModel) {
+  return curatedModelRecord(providerId, upstreamModel)?.outputLimit;
+}
+
+// The documented effort ladder for an id, or undefined when OpenCode publishes
+// none. Curation turns this into `reasoningLevels`; an id without one keeps
+// the single `high` default rather than inventing levels the route may reject.
+export function curatedModelReasoningLevels(providerId, upstreamModel) {
+  const levels = curatedModelRecord(providerId, upstreamModel)?.reasoningLevels;
+  return levels ? [...levels] : undefined;
+}
+
+// The picker text that carries the sourcing for every value this module knows
+// about -- and, just as importantly, names the capabilities it does not know,
+// so a reader can tell a documented value from a conservative default without
+// leaving the entry. Undefined for an id this module documents nothing for;
+// that entry keeps the generic "conservative default metadata" description,
+// which already means every value in it is a default.
+// A clause is omitted when the stored value did not come from this module --
+// a window the provider's live catalog advertised, or a ladder the operator
+// set with --efforts. The note has to describe what the entry actually holds.
+export function curatedModelDescription(
+  providerId,
+  upstreamModel,
+  { omitContextNote = false, omitReasoningNote = false } = {},
+) {
+  const record = curatedModelRecord(providerId, upstreamModel);
+  if (!record) return undefined;
+  return [
+    record.summary,
+    omitContextNote ? undefined : record.contextNote,
+    omitReasoningNote ? undefined : record.reasoningNote,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+// Every id this module carries metadata for. Tests enumerate it to prove each
+// declared window keeps its output limit in reserve.
+export function curatedModelIds(providerId) {
   const primary = curationPrimaryProviderId(providerId);
-  return CURATION_ROUTES[primary]?.descriptions?.[upstreamModel];
+  return Object.keys(CURATION_ROUTES[primary]?.models || {});
 }

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -21,6 +21,34 @@ export const USER_MODELS_PATH =
 export const DEFAULT_CONTEXT_WINDOW = 131072;
 export const DEFAULT_AUTO_COMPACT = 110000;
 
+// The effort ladder a curated entry carries until something documents a real
+// one. A single level is not a claim that the model has one effort: it is the
+// only value every OpenAI-compatible route is guaranteed to accept, so it is
+// the conservative default the same way DEFAULT_CONTEXT_WINDOW is. Exported so
+// curation can tell "nobody documented this model's efforts" apart from a
+// ladder a user or a provider's own catalog supplied (#352).
+export const DEFAULT_EFFORT = "high";
+export const DEFAULT_REASONING_LEVELS = Object.freeze([
+  Object.freeze({ effort: DEFAULT_EFFORT, description: "Adaptive reasoning" }),
+]);
+
+export function defaultUserModelReasoning() {
+  return {
+    defaultEffort: DEFAULT_EFFORT,
+    reasoningLevels: DEFAULT_REASONING_LEVELS.map((level) => ({ ...level })),
+  };
+}
+
+// True while an entry still holds exactly the untouched default ladder. The
+// sizing pair plays the same role for the context window: it is the evidence
+// curation had no model-specific answer, not a value the operator chose.
+export function hasDefaultUserModelReasoning(entry) {
+  return (
+    entry?.defaultEffort === DEFAULT_EFFORT &&
+    JSON.stringify(entry?.reasoningLevels) === JSON.stringify(DEFAULT_REASONING_LEVELS)
+  );
+}
+
 // Curation may adjust presentation, sizing, and effort metadata only;
 // identity and routing fields always come from the provider id and the
 // discovered model id.
@@ -99,8 +127,7 @@ export function userModelEntry({ providerId, upstreamId, requestProfile, priorit
     displayName: officialModelDisplayName(providerId, upstreamId) || `${upstreamId} (curated)`,
     description: defaultUserModelDescription(providerId),
     priority,
-    defaultEffort: "high",
-    reasoningLevels: [{ effort: "high", description: "Adaptive reasoning" }],
+    ...defaultUserModelReasoning(),
     contextWindow: DEFAULT_CONTEXT_WINDOW,
     autoCompact: DEFAULT_AUTO_COMPACT,
     inputModalities: ["text"],

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -27,11 +27,19 @@ const {
 const {
   curatedModelContextLength,
   curatedModelDescription,
+  curatedModelIds,
+  curatedModelOutputLimit,
   curatedModelProviderId,
+  curatedModelReasoningLevels,
   curationProviderIds,
 } = await import("../src/opencode-curation.mjs");
-const { defaultUserModelDescription, userModelEntry } =
-  await import("../src/user-models.mjs");
+const {
+  DEFAULT_AUTO_COMPACT,
+  DEFAULT_CONTEXT_WINDOW,
+  defaultUserModelDescription,
+  hasDefaultUserModelReasoning,
+  userModelEntry,
+} = await import("../src/user-models.mjs");
 process.argv = savedArgv;
 process.exitCode = 0;
 
@@ -701,6 +709,244 @@ test("scripted OpenCode Free curation stores the documented window and its sourc
     const other = stored.models.find((model) => model.upstreamModel === otherId);
     assert.equal(other.contextWindow, 131072);
     assert.equal(other.description, defaultUserModelDescription("opencode-free"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+
+// The context window is this repository's one departure from "conservative
+// default", so a declared one has to be safe as well as sourced: Codex
+// compacts at `curatedSizing`'s ratio, and whatever is left has to still hold
+// a full-length completion or the turn runs past the window the entry itself
+// declared. An id whose published output limit does not fit in that reserve
+// keeps the default rather than declaring a number it cannot honour.
+test("every documented OpenCode Free window reserves room for its output limit", () => {
+  const ids = curatedModelIds("opencode-free");
+  assert.ok(ids.length > 0);
+  let declared = 0;
+  for (const id of ids) {
+    const output = curatedModelOutputLimit("opencode-free", id);
+    assert.equal(typeof output, "number", `${id} records no published output limit`);
+    const window = curatedModelContextLength("opencode-free", id);
+    if (window === undefined) {
+      // A withheld window has to say so in the entry, not only in a comment.
+      assert.match(curatedModelDescription("opencode-free", id), /unknown/);
+      continue;
+    }
+    declared += 1;
+    const sizing = curatedSizing(window);
+    assert.ok(
+      sizing.contextWindow - sizing.autoCompact >= output,
+      `${id} compacts at ${sizing.autoCompact} of ${sizing.contextWindow}, ` +
+        `which leaves less than its ${output}-token output limit`,
+    );
+  }
+  assert.ok(declared >= 4, "the documented windows regressed");
+});
+
+test("documented OpenCode Free effort ladders are real Codex efforts", () => {
+  let ladders = 0;
+  for (const id of curatedModelIds("opencode-free")) {
+    const efforts = curatedModelReasoningLevels("opencode-free", id);
+    if (!efforts) {
+      // No published ladder means the entry keeps the single `high` default,
+      // and its description has to admit that rather than imply a capability.
+      assert.match(curatedModelDescription("opencode-free", id), /conservative default/);
+      continue;
+    }
+    ladders += 1;
+    const parsed = parseEfforts(efforts.join(","));
+    assert.deepEqual(parsed.reasoningLevels.map((level) => level.effort), efforts);
+    assert.equal(parsed.defaultEffort, "high");
+  }
+  assert.ok(ladders >= 4, "the documented effort ladders regressed");
+});
+
+test("an untuned entry gains the documented ladder while a tuned one is untouched", () => {
+  const stock = userModelEntry({
+    providerId: "opencode-free",
+    upstreamId: "laguna-s-2.1-free",
+    priority: 152,
+  });
+  assert.ok(hasDefaultUserModelReasoning(stock));
+  const [upgraded] = normalizeCurationModels([stock], "opencode-free");
+  assert.deepEqual(
+    upgraded.reasoningLevels.map((level) => level.effort),
+    ["low", "medium", "high"],
+  );
+  assert.equal(upgraded.contextWindow, 256_000);
+  assert.equal(upgraded.autoCompact, 217_600);
+
+  // A ladder-only id keeps the conservative window and still gains the ladder.
+  const flash = userModelEntry({
+    providerId: "opencode-free",
+    upstreamId: "deepseek-v4-flash-free",
+    priority: 153,
+  });
+  const [ladderOnly] = normalizeCurationModels([flash], "opencode-free");
+  assert.deepEqual(
+    ladderOnly.reasoningLevels.map((level) => level.effort),
+    ["low", "high", "max"],
+  );
+  assert.equal(ladderOnly.contextWindow, DEFAULT_CONTEXT_WINDOW);
+  assert.equal(ladderOnly.autoCompact, DEFAULT_AUTO_COMPACT);
+
+  // Hand-tuned metadata survives byte for byte, ladder included.
+  const tuned = {
+    ...stock,
+    autoCompact: 100_000,
+    reasoningLevels: [{ effort: "medium", description: "Mine" }],
+    defaultEffort: "medium",
+  };
+  assert.strictEqual(normalizeCurationModels([tuned], "opencode-free")[0], tuned);
+  const tunedSizingOnly = { ...stock, contextWindow: 200_000, autoCompact: 170_000 };
+  assert.strictEqual(
+    normalizeCurationModels([tunedSizingOnly], "opencode-free")[0],
+    tunedSizingOnly,
+  );
+
+  // An id this module documents nothing for keeps every default it started with.
+  const undocumented = userModelEntry({
+    providerId: "opencode-free",
+    upstreamId: "mimo-v2.5-free",
+    priority: 154,
+  });
+  assert.strictEqual(normalizeCurationModels([undocumented], "opencode-free")[0], undocumented);
+});
+
+test("a non-interactive OpenCode Free curation stores documented windows and ladders", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "curate-opencode-free-ladders-"));
+  const file = path.join(dir, "user-models.json");
+  const fixture = path.join(dir, "models.json");
+  const lagunaId = "laguna-s-2.1-free";
+  const flashId = "deepseek-v4-flash-free";
+  const undocumentedId = "mimo-v2.5-free";
+  // Zen serves these exact id-only records: no context limit, no effort control.
+  writeFileSync(fixture, JSON.stringify({
+    data: [{ id: lagunaId }, { id: flashId }, { id: undocumentedId }],
+  }));
+  const env = {
+    ...process.env,
+    CODEX_HOME: path.join(dir, "codex"),
+    MODEL_ROUTER_STATE_DIR: dir,
+    MODEL_ROUTER_USER_MODELS: file,
+    MODEL_ROUTER_MODEL_PICKER_STATE: path.join(dir, "model-picker.json"),
+    OPENCODE_API_KEY: "",
+    OPENCODE_GO_API_KEY: "",
+  };
+  const curate = (extra = []) => spawnSync(
+    process.execPath,
+    [
+      path.join(root, "src", "curate-models.mjs"),
+      "opencode-free",
+      "--models",
+      `${lagunaId},${flashId},${undocumentedId}`,
+      "--fixture",
+      fixture,
+      "--no-apply",
+      ...extra,
+    ],
+    { cwd: root, encoding: "utf8", env },
+  );
+  try {
+    const result = curate();
+    assert.equal(result.status, 0, result.stderr);
+    const stored = JSON.parse(readFileSync(file, "utf8"));
+    const find = (id) => stored.models.find((model) => model.upstreamModel === id);
+
+    // Documented window and documented ladder.
+    const laguna = find(lagunaId);
+    assert.equal(laguna.contextWindow, 256_000);
+    assert.equal(laguna.autoCompact, 217_600);
+    assert.ok(
+      laguna.contextWindow - laguna.autoCompact >=
+        curatedModelOutputLimit("opencode-free", lagunaId),
+    );
+    assert.deepEqual(
+      laguna.reasoningLevels.map((level) => level.effort),
+      ["low", "medium", "high"],
+    );
+    assert.equal(laguna.defaultEffort, "high");
+    assert.equal(laguna.description, curatedModelDescription("opencode-free", lagunaId));
+    assert.match(laguna.description, /256,000/);
+    assert.match(laguna.description, /models\.dev/);
+
+    // Documented ladder, window deliberately left on the conservative default.
+    const flash = find(flashId);
+    assert.deepEqual(
+      flash.reasoningLevels.map((level) => level.effort),
+      ["low", "high", "max"],
+    );
+    assert.equal(flash.contextWindow, DEFAULT_CONTEXT_WINDOW);
+    assert.equal(flash.autoCompact, DEFAULT_AUTO_COMPACT);
+    // The entry itself says which half is documented and which is unknown.
+    assert.match(flash.description, /unknown/);
+    assert.match(flash.description, /low\/high\/max/);
+
+    // Nothing documented: every value stays a conservative default, and the
+    // stock description keeps saying exactly that.
+    const undocumented = find(undocumentedId);
+    assert.equal(undocumented.contextWindow, DEFAULT_CONTEXT_WINDOW);
+    assert.equal(undocumented.autoCompact, DEFAULT_AUTO_COMPACT);
+    assert.ok(hasDefaultUserModelReasoning(undocumented));
+    assert.equal(undocumented.description, defaultUserModelDescription("opencode-free"));
+
+    // A rerun is additive and must not rewrite what it already stored.
+    const before = readFileSync(file, "utf8");
+    const second = curate();
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(readFileSync(file, "utf8"), before);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("--efforts still overrides a documented ladder", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "curate-opencode-free-efforts-"));
+  const file = path.join(dir, "user-models.json");
+  const fixture = path.join(dir, "models.json");
+  const lagunaId = "laguna-s-2.1-free";
+  writeFileSync(fixture, JSON.stringify({ data: [{ id: lagunaId }] }));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(root, "src", "curate-models.mjs"),
+        "opencode-free",
+        "--models",
+        lagunaId,
+        "--efforts",
+        "medium,high",
+        "--fixture",
+        fixture,
+        "--no-apply",
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_HOME: path.join(dir, "codex"),
+          MODEL_ROUTER_STATE_DIR: dir,
+          MODEL_ROUTER_USER_MODELS: file,
+          MODEL_ROUTER_MODEL_PICKER_STATE: path.join(dir, "model-picker.json"),
+          OPENCODE_API_KEY: "",
+          OPENCODE_GO_API_KEY: "",
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const [stored] = JSON.parse(readFileSync(file, "utf8")).models;
+    assert.deepEqual(
+      stored.reasoningLevels.map((level) => level.effort),
+      ["medium", "high"],
+    );
+    // The stored ladder is the operator's, so the note must not claim OpenCode
+    // published it -- while the documented window it did supply keeps its note.
+    assert.equal(stored.contextWindow, 256_000);
+    assert.match(stored.description, /256,000/);
+    assert.doesNotMatch(stored.description, /low\/medium\/high ladder/);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -7,9 +7,13 @@ import { test } from "node:test";
 const stateDir = mkdtempSync(path.join(os.tmpdir(), "user-models-test-"));
 process.env.CODEX_ROUTER_STATE_DIR = stateDir;
 
-const { userModelEntry, readUserModels, writeUserModels, USER_MODELS_PATH } = await import(
-  "../src/user-models.mjs"
-);
+const {
+  userModelEntry,
+  readUserModels,
+  writeUserModels,
+  hasDefaultUserModelReasoning,
+  USER_MODELS_PATH,
+} = await import("../src/user-models.mjs");
 
 test("userModelEntry fills conservative picker metadata", () => {
   const entry = userModelEntry({
@@ -233,4 +237,45 @@ test("registry merges valid user models and skips collisions", async () => {
     registry.MODEL_BY_SLUG.get("deepseek/deepseek-standalone-search").searchTool,
     { mode: "standalone" },
   );
+});
+
+
+// Curation has to be able to tell "nobody documented this model's efforts"
+// apart from a ladder somebody chose, the same way the untouched
+// 131072/110000 pair marks untuned sizing. Without that distinction an upgrade
+// path cannot add a published ladder without risking an operator's own (#352).
+test("a defaulted effort ladder is distinguishable from a chosen one", () => {
+  const stock = userModelEntry({
+    providerId: "ollama-cloud",
+    upstreamId: "gpt-oss:120b",
+    priority: 101,
+  });
+  assert.equal(hasDefaultUserModelReasoning(stock), true);
+  assert.equal(stock.defaultEffort, "high");
+  assert.deepEqual(stock.reasoningLevels, [{ effort: "high", description: "Adaptive reasoning" }]);
+
+  const chosen = userModelEntry({
+    providerId: "ollama-cloud",
+    upstreamId: "gpt-oss:120b",
+    priority: 101,
+    metadata: {
+      defaultEffort: "high",
+      reasoningLevels: [
+        { effort: "low", description: "Quick reasoning" },
+        { effort: "high", description: "Deep reasoning" },
+      ],
+    },
+  });
+  assert.equal(hasDefaultUserModelReasoning(chosen), false);
+
+  // A single high level someone worded differently is still theirs.
+  assert.equal(
+    hasDefaultUserModelReasoning({
+      defaultEffort: "high",
+      reasoningLevels: [{ effort: "high", description: "My own wording" }],
+    }),
+    false,
+  );
+  assert.equal(hasDefaultUserModelReasoning({}), false);
+  assert.equal(hasDefaultUserModelReasoning(undefined), false);
 });


### PR DESCRIPTION
Fixes the curation-metadata half of #352. The gateway-status half was already fixed on `main`; the two residual health gaps it surfaced are split into #366.

## A. Context windows — and four I deliberately did **not** declare

Zen's live `/models` serves **8** free ids and publishes no context limits for any of them, which is why the fallback table exists. All 8 were sourced from `models.dev` (provider `opencode`), which keys `limit` per *free id* and demonstrably records throttling — `deepseek-v4-flash` is 1,000,000 but `deepseek-v4-flash-free` is 200,000.

Each candidate was checked against the repo's own criterion — `contextWindow - autoCompact >= limit.output` at the established 0.85 ratio — so compaction fires before a completion can overrun the declared window:

| free id | old | new | models.dev context / output | headroom | |
|---|---|---|---|---|---|
| `muse-spark-1.2-contributor-free` | 1,048,576 | unchanged | 1,048,576 / 131,072 | 157,287 | pass |
| `x-preview-f-free` | 1,000,000 | unchanged | 1,000,000 / 131,072 | 150,000 | pass |
| `nemotron-3-ultra-free` | 131,072 | **1,000,000** | 1,000,000 / 128,000 | 150,000 | **added** |
| `laguna-s-2.1-free` | 131,072 | **256,000** | 256,000 / 32,000 | 38,400 | **added** |
| `deepseek-v4-flash-free` | 131,072 | held | 200,000 / 128,000 | 30,000 | **withheld** |
| `hy3-free` | 131,072 | held | 190,000 / 64,000 | 28,500 | **withheld** |
| `mimo-v2.5-free` | 131,072 | held | 200,000 / 32,000 | 30,000 | **withheld** |
| `nemotron-3.5-lightning-free` | 131,072 | held | 262,144 / 262,144 | 39,322 | **withheld** |

The four withheld rows are the point. `AGENTS.md` calls the context window the explicit exception to conservative defaults precisely because `autoCompact` derives from it: under-declaring compacts early, **over-declaring fails the turn outright**. Declaring 200,000 for a model that can emit 128,000 output tokens leaves 30,000 of headroom — not enough, so the entry stays on the conservative default and the reason is recorded on it.

`nemotron-3.5-lightning-free` shows this is a real gate rather than a ratio-tuning problem: its output limit *equals* its context limit, so no ratio can reserve room. That is why it is implemented as a gate rather than by loosening `curatedSizing`. The whole table is now machine-checked by a test via a new `curatedModelOutputLimit()` export, so it cannot silently regress.

`longcat-2.0-free` passes the check in models.dev but Zen no longer serves it, so it is not curatable and was not speculated on.

## B. reasoningLevels

The table now carries `reasoningLevels` per free id, sourced from models.dev `reasoning_options` (`type: "effort"` values only; `toggle`/`budget_tokens` ignored), consumed by `metadataFor` and mapped through the existing `parseEfforts` so ordering and `defaultEffort` follow repo convention.

Three ids — `nemotron-3-ultra-free`, `mimo-v2.5-free`, `nemotron-3.5-lightning-free` — have empty `reasoning_options`, so **no ladder was invented**; they keep the single `high` default. An explicit `--efforts` still wins, and the interactive prompt now offers the documented ladder as its default.

## C. Marking unknown capabilities

Kept to the repo's existing provenance mechanism — the entry's own `description` — with no new schema fields. A stored entry now states, per capability, whether the value is documented (with source) or still a default. `deepseek-v4-flash-free` for example carries an explicit note that its window is unknown here, that models.dev publishes 200,000, and why that was not adopted. Ids with nothing documented keep the stock description, which already means "everything here is a default".

## Correction to the issue's diagnosis

The comment on #352 claimed `--free-only` is the path used for `opencode-free`. That is wrong: `freeModelIds()` returns `[]` for anything but `orca`, so `curate-models opencode-free --free-only` errors out (verified by running it). It doesn't change the outcome — `anonymousModelPolicy: "opencode-console"` already restricts discovery to `-free` ids, so the whole catalog is free and `--models` is the real non-interactive path. The tests target that path.

## Hand-tuned values are preserved

The upgrade path fills in a documented ladder only when the entry still holds **both** the untouched generic `131072`/`110000` sizing pair **and** the untouched single-`high` ladder. A tuned `autoCompact`, a tuned window, or a tuned ladder each returns the identical object (`assert.strictEqual`), and every pre-existing byte-for-byte assertion still passes unmodified.

## Verification

- **On unmodified `main`**: all 6 new tests fail (46 tests, 40 pass, 6 fail), all pre-existing pass
- On the branch: 46/46 pass
- `node scripts-check.mjs` — passes
- `node --test test/*.test.mjs` — 2168 tests, **0 failures**, 13 pre-existing skips

No provider quota spent — only read-only GETs of `models.dev/api.json` and `opencode.ai/zen/v1/models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
