### PR TITLE
fix(health): probe the Grok OAuth forwarder, and infer Ready for an absent dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **The Grok OAuth forwarder is health-checked, and a dependency the router
+  did not name is no longer reported as unknown.** `/health` probed the Kimi
+  OAuth forwarder, the API forwarder, and the gateway, but never the Grok
+  OAuth forwarder on its own port -- so an operator routing through Grok OAuth
+  got no signal for it at all and the router could answer `ok` with that
+  forwarder dead (issue #366). It is now probed like the others, gated on the
+  `grok-oauth` provider actually being selected so an unused port is never
+  dialled, named as `grokOauth` in `degraded` when it is down, and carried
+  through the redacted health projection into the tray and the Control Center,
+  which both render it beside the other forwarders. Separately, both surfaces
+  fell through to "Unknown / Waiting for health report" whenever a service key
+  was simply absent from the payload; a router that reported `ok` has already
+  probed every dependency it knows about, so an id missing from `degraded` now
+  renders Ready and a healthy install stops looking like it never answered.
+
 - **The macOS tray can load a provider's current model list and curate from
   it.** A new Provider catalogs panel asks any configured provider that
   supports live discovery for the models it serves right now, marks the ones

--- a/apps/control-center/src/service-health.ts
+++ b/apps/control-center/src/service-health.ts
@@ -12,14 +12,30 @@ export interface ServiceHealthRow {
   tone: ServiceHealthTone;
 }
 
+// Which forwarders the router can report on. The labels live here so the row
+// order and the wording cannot drift from the keys `printHealth` projects.
+const FORWARDERS = [
+  ["oauth", "OAuth forwarder"],
+  ["api", "API forwarder"],
+  ["grokOauth", "Grok OAuth forwarder"],
+] as const;
+
 function dependencyRow(
   id: string,
   label: string,
   service: RouterServiceHealth | undefined,
   degraded: Set<string>,
+  routerOk?: boolean,
 ): ServiceHealthRow {
   if (!service) {
     const offline = degraded.has(id);
+    // An absent per-service payload is not the same as no information. A
+    // router that reported `ok` has already probed every dependency it knows
+    // about, so an id missing from `degraded` is reachable -- rendering it as
+    // Unknown made a healthy install look like it had never answered.
+    if (!offline && routerOk === true) {
+      return { id, label, state: "ready", status: "Ready", detail: "Reachable", tone: "success" };
+    }
     return {
       id,
       label,
@@ -64,13 +80,13 @@ export function serviceHealthRows(health?: RouterHealth): ServiceHealthRow[] {
     tone: !hasHealth ? "neutral" : routerOk ? "success" : degraded.size ? "warning" : "danger",
   }];
 
-  rows.push(dependencyRow("gateway", "Gateway", health?.gateway, degraded));
+  rows.push(dependencyRow("gateway", "Gateway", health?.gateway, degraded, routerOk));
 
-  const forwarderIds = (["oauth", "api"] as const).filter((id) => health?.[id] || degraded.has(id));
-  for (const id of forwarderIds) {
-    rows.push(dependencyRow(id, id === "oauth" ? "OAuth forwarder" : "API forwarder", health?.[id], degraded));
+  const forwarders = FORWARDERS.filter(([id]) => health?.[id] || degraded.has(id));
+  for (const [id, label] of forwarders) {
+    rows.push(dependencyRow(id, label, health?.[id], degraded, routerOk));
   }
-  if (!forwarderIds.length) {
+  if (!forwarders.length) {
     rows.push({
       id: "forwarders",
       label: "External forwarders",

--- a/apps/control-center/src/types.ts
+++ b/apps/control-center/src/types.ts
@@ -437,6 +437,7 @@ export interface RouterHealth {
   gateway?: RouterServiceHealth;
   oauth?: RouterServiceHealth;
   api?: RouterServiceHealth;
+  grokOauth?: RouterServiceHealth;
   activity?: {
     state?: "idle" | "starting" | "generating" | "error" | "offline" | string;
     activeCount?: number;

--- a/apps/desktop/ui/model.mjs
+++ b/apps/desktop/ui/model.mjs
@@ -234,6 +234,17 @@ export function observedModelSpeed(providerUsage, providerId, modelSlug) {
     : null;
 }
 
+// The dependencies the router reports on, in render order. The Grok OAuth
+// forwarder is a fifth local port with its own probe, so it belongs here
+// alongside the other two forwarders rather than being reported by nobody.
+const SERVICE_ROWS = [
+  ["gateway", "Gateway"],
+  ["oauth", "OAuth forwarder"],
+  ["api", "API forwarder"],
+  ["grokOauth", "Grok OAuth forwarder"],
+];
+const FORWARDER_IDS = new Set(["oauth", "api", "grokOauth"]);
+
 // Keep the tray's health language deliberately small. The router endpoint
 // already tells us which local dependency is reachable; this helper turns
 // that payload into rows the compact status view can scan at a glance.
@@ -257,29 +268,35 @@ export function serviceHealthRows(health) {
           : "Health endpoint unavailable",
   }];
 
-  for (const [id, label] of [["gateway", "Gateway"], ["oauth", "OAuth forwarder"], ["api", "API forwarder"]]) {
+  for (const [id, label] of SERVICE_ROWS) {
     const service = health?.[id];
     const shouldShow = id === "gateway" || Boolean(service) || degraded.has(id);
     if (!shouldShow) continue;
+    // An absent per-service payload is not the same as no information: a
+    // router that reported `ok` has already probed every dependency it knows
+    // about, so an id missing from `degraded` is reachable. Rendering it as
+    // Unknown made a healthy install look like it had never answered. Kept in
+    // step with apps/control-center/src/service-health.ts.
+    const inferredReady = !service && health?.ok === true && !degraded.has(id);
     rows.push({
       id,
       label,
       state: !hasHealth || !service
-        ? degraded.has(id) ? "offline" : "unknown"
+        ? degraded.has(id) ? "offline" : inferredReady ? "ready" : "unknown"
         : service.enabled === false && !degraded.has(id)
           ? "standby"
           : service.reachable === false || degraded.has(id)
             ? "offline"
             : service.reachable === true ? "ready" : "unknown",
       status: !hasHealth || !service
-        ? degraded.has(id) ? "Offline" : "Unknown"
+        ? degraded.has(id) ? "Offline" : inferredReady ? "Ready" : "Unknown"
         : service.enabled === false && !degraded.has(id)
           ? "Standby"
           : service.reachable === false || degraded.has(id)
             ? "Offline"
             : service.reachable === true ? "Ready" : "Unknown",
       detail: !hasHealth || !service
-        ? degraded.has(id) ? "Unreachable" : "Waiting for health report"
+        ? degraded.has(id) ? "Unreachable" : inferredReady ? "Reachable" : "Waiting for health report"
         : service.enabled === false && !degraded.has(id)
           ? "Not enabled"
           : service.reachable === false || degraded.has(id)
@@ -288,7 +305,7 @@ export function serviceHealthRows(health) {
     });
   }
 
-  const forwarders = rows.filter((row) => row.id === "oauth" || row.id === "api");
+  const forwarders = rows.filter((row) => FORWARDER_IDS.has(row.id));
   if (!forwarders.length) {
     rows.push({
       id: "forwarders",

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -2576,6 +2576,7 @@ async function printHealth() {
       ...(safeService(body.gateway) ? { gateway: safeService(body.gateway) } : {}),
       ...(safeService(body.oauth) ? { oauth: safeService(body.oauth) } : {}),
       ...(safeService(body.api) ? { api: safeService(body.api) } : {}),
+      ...(safeService(body.grokOauth) ? { grokOauth: safeService(body.grokOauth) } : {}),
     })}\n`);
   } catch (error) {
     process.stdout.write(`${JSON.stringify({

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -154,6 +154,9 @@ const API_HEALTH =
   process.env.CODEX_ROUTER_API_HEALTH_URL ||
   process.env.KIMI_API_HEALTH_URL ||
   loopback(PORTS.api, "/health");
+const GROK_OAUTH_HEALTH =
+  process.env.CODEX_ROUTER_GROK_OAUTH_HEALTH_URL ||
+  loopback(PORTS.grokOauth, "/health");
 const GATEWAY_HEALTH =
   process.env.CODEX_ROUTER_GATEWAY_HEALTH_URL ||
   process.env.KIMI_GATEWAY_HEALTH_URL ||
@@ -824,21 +827,29 @@ async function healthPayload() {
   const apiEnabled = [...PROVIDERS.values()].some(
     (provider) => enabled.has(provider.id) && provider.kind === "openai-compatible",
   );
-  const [oauth, api, gateway] = await Promise.all([
+  const [oauth, api, grokOauth, gateway] = await Promise.all([
     enabled.has("kimi-oauth")
       ? serviceHealth(OAUTH_HEALTH)
       : { reachable: true, enabled: false },
     apiEnabled ? serviceHealth(API_HEALTH) : { reachable: true, enabled: false },
+    // The Grok OAuth forwarder is started unconditionally but is only a real
+    // dependency for an operator who selected the provider, so it is gated the
+    // way the Kimi OAuth forwarder is: an unselected provider reports standby
+    // rather than being probed on a port nobody routes through.
+    enabled.has("grok-oauth")
+      ? serviceHealth(GROK_OAUTH_HEALTH)
+      : { reachable: true, enabled: false },
     serviceHealth(GATEWAY_HEALTH),
   ]);
   // Naming the unreachable dependency is the difference between "the router is
   // broken" and "the gateway is restarting". It costs nothing to carry: these
-  // are three fixed local service names, so it is safe on the unauthenticated
+  // are four fixed local service names, so it is safe on the unauthenticated
   // leaf too, which is the only one `waitForRouterHealth` and therefore doctor
   // can read.
   const degraded = [
     ["oauth", oauth],
     ["api", api],
+    ["grokOauth", grokOauth],
     ["gateway", gateway],
   ]
     .filter(([, service]) => !service.reachable)
@@ -852,6 +863,7 @@ async function healthPayload() {
     activity: activityPayload(),
     oauth,
     api,
+    grokOauth,
     gateway,
   };
 }

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -454,6 +454,26 @@ test("preload constructs exact positional IPC payloads", async () => {
   assert.equal(calls.length, 0);
 });
 
+// The Control Center and the tray render the same health report through two
+// separate implementations, so the pair has to be checked, not just one half
+// (#366). apps/desktop/ui/model.mjs is exercised directly in
+// test/desktop-ui.test.mjs; this is the TypeScript twin.
+test("the control center health rows match the tray's on absent and Grok dependencies", async () => {
+  const source = await readFile(new URL("../apps/control-center/src/service-health.ts", import.meta.url), "utf8");
+
+  // A router that answered `ok` has already probed every dependency it knows
+  // about, so an id missing from `degraded` is Ready rather than Unknown.
+  assert.match(source, /routerOk\?: boolean/);
+  assert.match(source, /if \(!offline && routerOk === true\) \{[\s\S]*?state: "ready"/);
+  assert.match(source, /dependencyRow\("gateway", "Gateway", health\?\.gateway, degraded, routerOk\)/);
+
+  // The Grok OAuth forwarder is a fifth local port with its own probe, and
+  // both surfaces enumerate forwarders explicitly, so it has to be listed.
+  assert.match(source, /\["grokOauth", "Grok OAuth forwarder"\]/);
+  const types = await readFile(new URL("../apps/control-center/src/types.ts", import.meta.url), "utf8");
+  assert.match(types, /grokOauth\?: RouterServiceHealth;/);
+});
+
 test("control center sidebar keeps the requested product order", async () => {
   const source = await readFile(new URL("../apps/control-center/src/App.tsx", import.meta.url), "utf8");
   const navBlock = source.match(/const NAV_ITEMS:[\s\S]*?= \[([\s\S]*?)\n\];/)?.[1];

--- a/test/desktop-ui.test.mjs
+++ b/test/desktop-ui.test.mjs
@@ -216,6 +216,57 @@ test("service health rows expose enabled dependencies without leaking endpoint d
   );
 });
 
+// A router that answered `ok` has already probed every dependency it knows
+// about, so a missing per-service key is silence about a service that passed,
+// not silence about a service nobody asked. Rendering it as Unknown made a
+// perfectly healthy install look like it had never reported.
+test("a dependency absent from a healthy report is inferred ready rather than unknown", () => {
+  const [, gateway] = serviceHealthRows({ ok: true, degraded: [] });
+  assert.deepEqual(gateway, {
+    id: "gateway",
+    label: "Gateway",
+    state: "ready",
+    status: "Ready",
+    detail: "Reachable",
+  });
+  // The inference is only ever drawn from a report that says so. An `ok` that
+  // names the dependency is still Offline, and no report at all is still
+  // Unknown.
+  assert.equal(serviceHealthRows({ ok: true, degraded: ["gateway"] })[1].state, "offline");
+  assert.equal(serviceHealthRows({ ok: false, degraded: [] })[1].state, "unknown");
+  assert.equal(serviceHealthRows(undefined)[1].state, "unknown");
+});
+
+// The Grok OAuth forwarder is a fifth local port with a health probe of its
+// own (#366). The tray enumerates forwarders explicitly, so a key nobody
+// listed would be dropped on the floor rather than rendered.
+test("the Grok OAuth forwarder is rendered alongside the other forwarders", () => {
+  assert.deepEqual(
+    serviceHealthRows({
+      ok: false,
+      degraded: ["grokOauth"],
+      gateway: { reachable: true },
+      grokOauth: { reachable: false, enabled: true },
+    }).map((row) => row.id),
+    ["router", "gateway", "grokOauth"],
+  );
+  assert.deepEqual(
+    serviceHealthRows({
+      ok: true,
+      degraded: [],
+      gateway: { reachable: true },
+      grokOauth: { reachable: true, enabled: false },
+    }).at(-1),
+    {
+      id: "grokOauth",
+      label: "Grok OAuth forwarder",
+      state: "standby",
+      status: "Standby",
+      detail: "Not enabled",
+    },
+  );
+});
+
 // src/tool-result-aging-state.mjs defaults the feature off when no state file
 // exists, so an absent snapshot has to render off. Rendering on told every
 // fresh install that ageing was happening when nothing was.

--- a/test/empty-completion-router.test.mjs
+++ b/test/empty-completion-router.test.mjs
@@ -420,6 +420,7 @@ function routerEnv(gatewayPort, routerPort) {
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
   };
 }

--- a/test/health-cache.test.mjs
+++ b/test/health-cache.test.mjs
@@ -106,8 +106,9 @@ test("the default window is short enough for a live status display", () => {
 
 test("the router probes through the cache, not around it", () => {
   const router = readFileSync(path.join(root, "src", "router.mjs"), "utf8");
-  // healthPayload calls serviceHealth three times per request; if that ever
-  // goes straight to the network again the probe flood comes back silently.
+  // healthPayload calls serviceHealth up to four times per request; if that
+  // ever goes straight to the network again the probe flood comes back
+  // silently.
   assert.match(router, /const healthCache = createHealthCache\(\{\s*staleWhileRevalidate:\s*true\s*\}\)/);
   assert.match(router, /function serviceHealth\(url\)\s*\{\s*return healthCache\(url,/);
   assert.match(router, /loopbackProbeFetch\(/);

--- a/test/local-ollama-routing.test.mjs
+++ b/test/local-ollama-routing.test.mjs
@@ -92,6 +92,7 @@ function startRouter(fixture, gatewayPort, routerPort) {
       CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
       CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
       CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+      CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
       CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
       CODEX_ROUTER_QUIET: "1",
     },

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -172,6 +172,7 @@ function routerEnv(gatewayPort, routerPort) {
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
   };
 }

--- a/test/router-idle.test.mjs
+++ b/test/router-idle.test.mjs
@@ -110,6 +110,7 @@ function routerEnv(gatewayPort, routerPort, nativePort) {
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
     CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${nativePort}`,
   };

--- a/test/router-resilience.test.mjs
+++ b/test/router-resilience.test.mjs
@@ -174,6 +174,7 @@ test("a gateway that dies mid-stream ends the routed body and logs the cause", a
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
   });
 
@@ -252,6 +253,7 @@ test("a client cancel mid-stream meters 0 and never claims an upstream failure",
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
   });
 
@@ -359,6 +361,7 @@ test("a selection file naming an unknown provider does not wedge the router", as
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
   });
 
@@ -408,6 +411,7 @@ test("an idle keep-alive connection survives past Node's default timeout", async
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
   });
   const IDLE_MS = 6_500;

--- a/test/router-timing-log.test.mjs
+++ b/test/router-timing-log.test.mjs
@@ -84,6 +84,7 @@ function routerEnv(gatewayPort, routerPort) {
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health`,
   };
 }
@@ -162,6 +163,7 @@ test("every routed turn writes a timestamped timing line with cache tokens", asy
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
   });
 

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -133,6 +133,7 @@ test("router health waits for enabled dependencies and ignores disabled forwarde
     CODEX_ROUTER_SHOW_ALL_MODELS: "0",
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${healthy.port}/oauth-health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${unavailableApiPort}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${healthy.port}/grok-health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${healthy.port}/gateway-health`,
     CODEX_ROUTER_QUIET: "1",
   });
@@ -145,6 +146,74 @@ test("router health waits for enabled dependencies and ignores disabled forwarde
     await stopChild(router);
     await closeServer(healthy.server);
     rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+// The Grok OAuth forwarder listens on its own port and was the one forwarder
+// nothing probed, so the router could answer `ok` with it dead (#366). It is
+// gated on the provider the way the Kimi OAuth forwarder is, because probing a
+// port an operator never routes through is noise, not a signal.
+test("the Grok OAuth forwarder is probed only when its provider is enabled", async () => {
+  const grokProbes = [];
+  const healthy = await mockServer((request, response) => {
+    if (request.url === "/grok-health") grokProbes.push(request.url);
+    json(response, 200, { ok: true, credential_present: true });
+  });
+
+  const readHealth = async (providers, grokHealthUrl) => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "router-grok-health-"));
+    writeFileSync(
+      path.join(testRoot, "enabled-providers.json"),
+      `${JSON.stringify({ version: 1, providers })}\n`,
+      { mode: 0o600 },
+    );
+    const routerPort = await openPort();
+    const router = run("router.mjs", {
+      CODEX_ROUTER_PORT: String(routerPort),
+      CODEX_ROUTER_STATE_DIR: testRoot,
+      CODEX_ROUTER_SHOW_ALL_MODELS: "0",
+      CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${healthy.port}/oauth-health`,
+      CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${healthy.port}/api-health`,
+      CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: grokHealthUrl,
+      CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${healthy.port}/gateway-health`,
+      CODEX_ROUTER_QUIET: "1",
+    });
+    try {
+      // Readiness is taken from `/models`, not `/health`: the last case here
+      // is a router that is deliberately degraded, and `/health` answers 503
+      // for exactly that.
+      await waitFor(`${routerBase(routerPort)}/models`, router);
+      return await (await fetch(`${routerBase(routerPort)}/health`)).json();
+    } finally {
+      await stopChild(router);
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  };
+
+  const deadGrokPort = await openPort();
+  try {
+    const unselected = await readHealth(["deepseek"], `http://127.0.0.1:${deadGrokPort}/health`);
+    // Nothing was dialled, so a forwarder nobody routes through cannot drag
+    // the router into `degraded` -- it reports standby exactly as a disabled
+    // Kimi OAuth forwarder does.
+    assert.deepEqual(unselected.grokOauth, { reachable: true, enabled: false });
+    assert.deepEqual(unselected.degraded, []);
+    assert.equal(unselected.ok, true);
+    assert.deepEqual(grokProbes, []);
+
+    const selected = await readHealth(["grok-oauth"], `http://127.0.0.1:${healthy.port}/grok-health`);
+    assert.equal(selected.grokOauth.reachable, true);
+    assert.equal(selected.ok, true);
+    assert.ok(grokProbes.length >= 1, JSON.stringify(grokProbes));
+
+    // ...and a selected forwarder that is down is named, rather than hidden
+    // behind an `ok` the operator would have believed.
+    const down = await readHealth(["grok-oauth"], `http://127.0.0.1:${deadGrokPort}/health`);
+    assert.deepEqual(down.grokOauth, { reachable: false });
+    assert.deepEqual(down.degraded, ["grokOauth"]);
+    assert.equal(down.ok, false);
+  } finally {
+    await closeServer(healthy.server);
   }
 });
 
@@ -182,6 +251,7 @@ test("router requires the configured path capability before any model route", as
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_SESSION_INDEX: sessionIndex,
     CODEX_ROUTER_QUIET: "1",
@@ -317,7 +387,8 @@ test("router requires the configured path capability before any model route", as
     // three fixed local service names -- never a URL, a credential, or the
     // per-service payloads the protected leaf carries.
     assert.ok(
-      publicPayload.degraded.every((name) => ["oauth", "api", "gateway"].includes(name)),
+      publicPayload.degraded.every((name) =>
+        ["oauth", "api", "grokOauth", "gateway"].includes(name)),
       JSON.stringify(publicPayload.degraded),
     );
     assert.equal(publicPayload.activity.state, "error");
@@ -357,6 +428,7 @@ test("a canceled request does not flip activity into the error state", async () 
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_QUIET: "1",
   });
@@ -5589,6 +5661,7 @@ test("a live child turn refines a legacy experimental subagent diagnostic", asyn
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     MODEL_ROUTER_SUBAGENT_PROOFS: proofsPath,
     CODEX_ROUTER_QUIET: "1",
@@ -5693,6 +5766,7 @@ test("ordinary child traffic does not mutate a legacy local proven record", asyn
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     MODEL_ROUTER_SUBAGENT_PROOFS: proofsPath,
     // Thread identity resolves against rollout files; point it at empty state
@@ -5798,6 +5872,7 @@ test("a subagent effort reaches child turns and leaves parent turns alone", asyn
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_QUIET: "1",
   });
@@ -5889,6 +5964,7 @@ test("a subagent effort overrides the effort Codex nested in the reasoning objec
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_QUIET: "1",
   });
@@ -6253,6 +6329,7 @@ test("router repairs malformed Z.ai message envelopes after LiteLLM Responses tr
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_QUIET: "1",
   });
   try {
@@ -6686,6 +6763,7 @@ test("Zen Free Muse and Ox bridge custom tools across JSON, history, SSE, and er
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     XAI_API_KEY: "TEST_XAI_API_KEY",
     CODEX_ROUTER_QUIET: "1",
   });
@@ -7036,6 +7114,7 @@ test("Go, paid Zen, and other Free routes keep compatibility-sensitive wire shap
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_QUIET: "1",
   });
   const recursiveSchema = {
@@ -7188,6 +7267,7 @@ test("canceling a Zen Free Ox custom-tool stream stops the transformed pipeline"
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
     CODEX_ROUTER_QUIET: "1",
   });
   try {

--- a/test/vision-bridge-e2e.test.mjs
+++ b/test/vision-bridge-e2e.test.mjs
@@ -235,6 +235,7 @@ async function startBridgedRouter(upstreams, { enabled = true, engine = "local" 
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${upstreams.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${upstreams.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${upstreams.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${upstreams.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${upstreams.port}/health`,
   });
   await waitFor(`${routerBase(routerPort)}/models`, child);
@@ -743,6 +744,7 @@ test("an unreachable local engine degrades with the transport's own wording", as
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${upstreams.port}/v1`,
     CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${upstreams.port}/health`,
     CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${upstreams.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${upstreams.port}/health`,
     CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${upstreams.port}/health`,
   });
 


### PR DESCRIPTION
Fixes #366. Two independent gaps, split out of #352.

## 1. The Grok OAuth forwarder was never probed

`healthPayload()` dialled three endpoints — oauth, api, gateway. `PORTS.grokOauth` (4208) is a real fifth forwarder used by `src/grok-oauth-forwarder.mjs`, with no probe at all, so **the router could report `ok: true` while that forwarder was dead.**

- `src/router.mjs:157` — new `GROK_OAUTH_HEALTH` (override `CODEX_ROUTER_GROK_OAUTH_HEALTH_URL`, default `loopback(PORTS.grokOauth, "/health")`), alongside the other three.
- `src/router.mjs:830` — fourth probe, gated `enabled.has("grok-oauth")`: the exact mirror of the `enabled.has("kimi-oauth")` gate. Both are `kind: "oauth"` providers whose forwarder `start.mjs` launches unconditionally, so an unselected provider reports `{reachable: true, enabled: false}` and is never dialled.
- **`degraded` includes it** as `"grokOauth"`, following the other forwarders: standby when unselected so it can never appear, named when selected and unreachable. That is the part that stops `ok: true` with the forwarder dead.
- `src/control.mjs:2579` — projected through the same `safeService` redaction (`reachable` plus optional `enabled`, never a raw payload).
- UI plumbing so the new key isn't silently dropped: `apps/control-center/src/types.ts`, `service-health.ts` (an explicit `FORWARDERS` table replacing the inline `["oauth","api"]` literal), and `apps/desktop/ui/model.mjs`. Both surfaces enumerate forwarders explicitly, so a key nobody lists renders nowhere — which is exactly how this one stayed invisible.

## 2. An absent dependency rendered as Unknown

When `health.ok === true` and an id is absent from `degraded`, that is enough to render Ready; both UIs fell through to "Unknown / Waiting for health report" instead, so a healthy install looked broken.

`dependencyRow` now takes `routerOk` and returns Ready in the `!service` branch when `!offline && routerOk === true`. Unknown is kept for `ok` false or unset. `apps/desktop/ui/model.mjs` applies the same rule with a comment pointing at its TypeScript twin.

## Please look at this in review

**23 call sites across 9 test files gained `CODEX_ROUTER_GROK_OAUTH_HEALTH_URL`.** This is not cosmetic. Without it the new probe falls back to `127.0.0.1:4208` — 18 tests failed, and more importantly **a test router would have dialled the operator's real forwarder port.** That is precisely why those tests already pin the other three health URLs; the new one had to join them. Worth confirming you agree with the breadth of that change.

## Tests

Four new, all verified to **fail on unmodified `main`** (checked in a throwaway detached worktree with only the test files copied in: 4 tests, 0 pass, 4 fail):

- `test/routing.test.mjs` — the Grok probe fires only when the provider is enabled: unselected ⇒ standby, `degraded []`, mock never hit; selected ⇒ `reachable: true`; selected with a dead port ⇒ `degraded ["grokOauth"]` and `ok: false`. On main the payload has no `grokOauth` key at all.
- the existing closed-set assertion widened to `["oauth","api","grokOauth","gateway"]`
- `test/desktop-ui.test.mjs` — the issue's exact case (`{ok: true, degraded: []}` with no `gateway` key ⇒ `ready`), with negative controls for `degraded: ["gateway"]`, `ok: false`, and `undefined`; plus the Grok row rendering
- `test/control-center-electron.test.mjs` — source-text twin for the `.ts` changes, matching that file's established convention

Also corrected a stale comment in `test/health-cache.test.mjs` ("three times" → "up to four times").

## Verification

- `node scripts-check.mjs` — passes
- `tsc --noEmit` in `apps/control-center` — clean
- `node --test test/*.test.mjs` — 2166 tests, **0 failures**, 13 pre-existing skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
