### PR TITLE
fix(minimax): request split reasoning instead of filtering it out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **MiniMax M3 no longer shows its chain of thought as assistant text.** The
+  Token Plan route asked for adaptive thinking but not `reasoning_split`, so
+  MiniMax embedded the reasoning in `content` as literal `<think>...</think>`
+  markup, which every client that does not know the vendor format rendered as
+  ordinary output. Requesting the split moves it to `reasoning_content`, which
+  this router already relays as reasoning. Verified against api.minimax.io: the
+  same prompt leaks `<think>` into `content` without the flag and carries a
+  populated `reasoning_content` with it. Reported in #333 by @moryk87.
+
 - **The harness caller key is written where a current harness reads it.**
   DeepSeek Harness moved `.credentials.yaml` to a `version`/`refs` envelope
   around the reference map, and the router only knew the flat root map the

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -789,8 +789,25 @@ function normalizeBody(buffer, contentType, route) {
   } else if (model.requestProfile === "minimax-m3") {
     // MiniMax uses its own thinking control on the OpenAI-compatible
     // Chat Completions endpoint instead of reasoning_effort.
+    //
+    // Without `reasoning_split`, MiniMax embeds the chain of thought in
+    // `content` as literal <think>...</think> markup, so it renders as
+    // ordinary assistant text in any client that does not know the vendor
+    // format. With it, the reasoning arrives in `reasoning_content` -- which
+    // this router already relays as reasoning -- and `content` carries only
+    // the answer. A live probe against api.minimax.io confirmed both halves:
+    // HTTP 200 either way, `<think>` present in `content` without the flag and
+    // absent with it, alongside a populated `reasoning_content`.
+    //
+    // This is why there is no output filter here. Stripping the markup
+    // downstream means running a state machine over every streamed field, and
+    // the fields it would have to walk include tool-call argument deltas --
+    // where a patch that merely mentions <think> would be corrupted into
+    // invalid JSON. Fixing the leak at the source removes that whole class of
+    // failure instead of managing it.
     delete payload.reasoning_effort;
     payload.thinking = { type: "adaptive" };
+    payload.reasoning_split = true;
   } else if (model.requestProfile === "auto-tool-choice") {
     // Some models call tools happily under "auto" but reject being forced to,
     // the way DeepSeek and Qwen do in thinking mode. Their vendor profiles

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3440,6 +3440,11 @@ test("API forwarder routes MiniMax M3 streaming tool calls with adaptive thinkin
     assert.equal(request.body.stream, true);
     assert.equal(request.body.reasoning_effort, undefined);
     assert.deepEqual(request.body.thinking, { type: "adaptive" });
+    // Without this, MiniMax returns the chain of thought inline in `content`
+    // as literal <think>...</think> markup. Verified against api.minimax.io:
+    // the same prompt leaks `<think>` into `content` without the flag and
+    // carries a populated `reasoning_content` with it.
+    assert.equal(request.body.reasoning_split, true);
     assert.equal(request.body.tools[0].function.name, "get_weather");
     assert.deepEqual(request.body.tools[0].function.parameters.required, ["city"]);
   } finally {


### PR DESCRIPTION
Fixes the leak reported in #333 by @moryk87 — whose diagnosis was right, including identifying `reasoning_split` as the vendor control.

## What the live probe showed

I ran the same prompt against `api.minimax.io/v1/chat/completions` twice, changing only that one field:

| | HTTP | `<think>` in `content` | separate reasoning field |
|---|---|---|---|
| `thinking: {type:"adaptive"}` — main today | 200 | **yes** | none |
| `+ reasoning_split: true` | 200 | **no** | `reasoning_content`, 351 chars |

Without the flag, `content` begins:

```
<think>The user wants me to calculate 17 * 23 and think through it step by step.…
```

With it, `content` carries only the answer and the reasoning arrives in `reasoning_content` — which this router **already** relays as reasoning (`src/router.mjs`, `src/http-utils.mjs`, `src/api-forwarder.mjs`). So nothing downstream needs to change.

That makes this a one-line fix.

## Why there is no output filter here

#333 also added a 163-line Responses stream transform to strip the markup. Now that the source fix is confirmed, that transform would be carrying real risk for no benefit:

- **It rewrites tool-call argument deltas.** `rewriteTextFields` walks `item`/`part`/`output`/`content` with no `event.type` dispatch, which includes `response.function_call_arguments.delta`. A model writing a file that merely mentions `<think>` — a prompt template, an SSE parser, docs about this very feature — gets its arguments truncated into invalid JSON and the tool call fails.
- **`indexOf("\n\n")` never matches CRLF**, so against a CRLF upstream nothing is emitted until flush: the whole response buffers in memory and lands in one burst.
- **An unclosed `<think>` swallows the remainder** of the response, and `_flush` drops pending text too.
- **`response.completed` is not sanitized**, so the markup still reaches session history even when the deltas were cleaned — and history then disagrees with what was displayed.

There is also a downstream interaction: `EmptyCompletionGuard` runs *after* the filter in `router.mjs`, so a turn emptied by the third point above triggers a retry — a second billed turn on content that was not actually empty.

Every one of those is a way to silently delete correct output, which is the hardest kind of failure to trace back to its cause. The underlying bug is cosmetic; a filter that eats tool calls is not. Fixing it at the source removes the whole class rather than managing it.

## Verification

- Live probe as above (small, deliberate token spend, authorized).
- The added assertion in `test/routing.test.mjs` is a real regression test: removing `payload.reasoning_split = true` makes it fail, restoring it passes.
- `node scripts-check.mjs` — passes
- `node --test test/*.test.mjs` — 2193 tests, **0 failures**, 13 pre-existing skips

Please close #333 in favour of this; the CHANGELOG credits the original report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
