### PR TITLE
refactor: harden Windows private-file ACL handling (scope b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Private state files are hardened with a canonical owner-only ACL on
+  Windows.** The previous Windows path asked `GetAccessControl` about the
+  file's existing DACL and then edited it with `SetAccessRuleProtection` and
+  `RemoveAccessRuleSpecific`, so a file whose DACL was already non-canonical
+  could make it throw (or silently keep foreign ACEs), the exact drift an
+  install or `doctor --fix` is meant to repair. Windows hardening now builds a
+  fresh, empty `FileSecurity`, replaces the DACL outright with a single
+  current-identity FullControl Allow rule and inheritance cleared, and skips
+  persisting owner/group so it needs only `WRITE_DAC` and cannot fail where an
+  `icacls /inheritance:r /grant:r` path would have succeeded. A hardening
+  failure now exits non-zero with the PowerShell diagnosis on stderr instead of
+  masquerading as success.
+
 - **MiniMax M3 no longer shows its chain of thought as assistant text.** The
   Token Plan route asked for adaptive thinking but not `reasoning_split`, so
   MiniMax embedded the reasoning in `content` as literal `<think>...</think>`

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -10,38 +10,31 @@ import {
 } from "node:fs";
 import path from "node:path";
 
-let windowsSid;
-
-function currentWindowsSid() {
-  if (windowsSid) return windowsSid;
-  const script =
-    "[Console]::Out.Write([Security.Principal.WindowsIdentity]::GetCurrent().User.Value)";
-  windowsSid = execFileSync(
-    "powershell.exe",
-    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
-    { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-  ).trim();
-  if (!windowsSid) throw new Error("Could not resolve the current Windows user SID.");
-  return windowsSid;
-}
-
-export function windowsFullControlGrant(sid) {
-  if (!/^S-\d+(?:-\d+)+$/i.test(sid)) {
-    throw new Error("Could not format an invalid Windows user SID.");
-  }
-  // icacls requires an asterisk before a numeric SID so it is not resolved as
-  // an account name. Without it, hosted runners fail with system error 1332.
-  return `*${sid}:(F)`;
-}
-
 export function protectPrivateFile(target) {
   chmodSync(target, 0o600);
   if (process.platform !== "win32") return target;
-  const sid = currentWindowsSid();
+  const script = [
+    "$target = $env:CODEX_ROUTER_PRIVATE_FILE",
+    "$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User",
+    "$acl = [System.IO.File]::GetAccessControl($target)",
+    "$acl.SetAccessRuleProtection($true, $false)",
+    "$rules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))",
+    "foreach ($rule in $rules) { [void]$acl.RemoveAccessRuleSpecific($rule) }",
+    "$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl",
+    "$none = [System.Security.AccessControl.InheritanceFlags]::None",
+    "$propagationNone = [System.Security.AccessControl.PropagationFlags]::None",
+    "$allow = [System.Security.AccessControl.AccessControlType]::Allow",
+    "$rule = [System.Security.AccessControl.FileSystemAccessRule]::new($sid, $fullControl, $none, $propagationNone, $allow)",
+    "[void]$acl.AddAccessRule($rule)",
+    "[System.IO.File]::SetAccessControl($target, $acl)",
+  ].join("; ");
   execFileSync(
-    "icacls.exe",
-    [target, "/inheritance:r", "/grant:r", windowsFullControlGrant(sid)],
-    { stdio: "ignore" },
+    "powershell.exe",
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+    {
+      env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target },
+      stdio: "ignore",
+    },
   );
   return target;
 }
@@ -78,12 +71,14 @@ export function privateFileIsProtected(target) {
     // concurrent Windows processes. The .NET API returns the same FileSecurity
     // object without importing a PowerShell module.
     "$acl = [System.IO.File]::GetAccessControl($env:CODEX_ROUTER_PRIVATE_FILE)",
-    "$identity = [Security.Principal.WindowsIdentity]::GetCurrent()",
-    "$sid = $identity.User.Value",
-    "$name = $identity.Name",
-    "$allowed = $false",
-    "foreach ($rule in $acl.Access) { $ruleIdentity = $rule.IdentityReference.Value; $matches = $ruleIdentity -eq $sid -or $ruleIdentity -eq $name; if (-not $matches) { try { $matches = $rule.IdentityReference.Translate([Security.Principal.SecurityIdentifier]).Value -eq $sid } catch { $matches = $false } }; if ($matches -and $rule.AccessControlType -eq 'Allow') { $allowed = $true } }",
-    "[Console]::Out.Write(($acl.AreAccessRulesProtected -and $allowed).ToString())",
+    "$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value",
+    "$rules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))",
+    "$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl",
+    "$hasFullControl = $false",
+    "$hasForeignAllow = $false",
+    "$hasInheritedRule = $false",
+    "foreach ($rule in $rules) { if ($rule.IsInherited) { $hasInheritedRule = $true }; if ($rule.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow) { if ($rule.IdentityReference.Value -eq $sid) { if (($rule.FileSystemRights -band $fullControl) -eq $fullControl) { $hasFullControl = $true } } else { $hasForeignAllow = $true } } }",
+    "[Console]::Out.Write(($acl.AreAccessRulesProtected -and -not $hasInheritedRule -and $hasFullControl -and -not $hasForeignAllow).ToString())",
   ].join("; ");
   try {
     return execFileSync(

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -10,32 +10,59 @@ import {
 } from "node:fs";
 import path from "node:path";
 
-export function protectPrivateFile(target) {
-  chmodSync(target, 0o600);
-  if (process.platform !== "win32") return target;
-  const script = [
-    "$target = $env:CODEX_ROUTER_PRIVATE_FILE",
+// Windows private-file hardening is one PowerShell spawn per call. Lowering
+// that count matters: download workers persist progress on every percentage
+// point, and each spawn cold-starts powershell.exe, so a state writer that
+// protected two files per atomic replace used to pay twice per write.
+//
+// Internal callers that harden several paths at once go through
+// protectPrivateFilesWin32 so that cost is paid once.
+function powershellPrivateScript() {
+  return [
+    // Build the ACL from a fresh, empty FileSecurity rather than asking
+    // GetAccessControl about the file's existing (possibly non-canonical)
+    // DACL. SetAccessRuleProtection on a clean object never canonicalizes a
+    // broken inherited/permission mix, so a file whose DACL is already
+    // corrupt — the exact drift an install or doctor --fix must be able to
+    // repair — cannot make this throw. The pre-existing DACL is replaced
+    // outright instead of being edited toward compliance.
     "$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User",
-    "$acl = [System.IO.File]::GetAccessControl($target)",
-    "$acl.SetAccessRuleProtection($true, $false)",
-    "$rules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))",
-    "foreach ($rule in $rules) { [void]$acl.RemoveAccessRuleSpecific($rule) }",
     "$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl",
     "$none = [System.Security.AccessControl.InheritanceFlags]::None",
     "$propagationNone = [System.Security.AccessControl.PropagationFlags]::None",
     "$allow = [System.Security.AccessControl.AccessControlType]::Allow",
-    "$rule = [System.Security.AccessControl.FileSystemAccessRule]::new($sid, $fullControl, $none, $propagationNone, $allow)",
-    "[void]$acl.AddAccessRule($rule)",
-    "[System.IO.File]::SetAccessControl($target, $acl)",
+    "foreach ($p in (ConvertFrom-Json -InputObject $env:CODEX_ROUTER_PRIVATE_FILES)) {",
+    "  $acl = [System.Security.AccessControl.FileSecurity]::new()",
+    "  [void]$acl.SetAccessRuleProtection($true, $false)",
+    "  $acl.SetOwner($sid)",
+    "  $acl.SetGroup($sid)",
+    "  $rule = [System.Security.AccessControl.FileSystemAccessRule]::new($sid, $fullControl, $none, $propagationNone, $allow)",
+    "  [void]$acl.AddAccessRule($rule)",
+    "  [System.IO.File]::SetAccessControl($p, $acl)",
+    "}",
   ].join("; ");
+}
+
+// Protect one or more paths in a single PowerShell process. Each file ends up
+// with exactly one current-identity FullControl Allow rule, no inheritance, no
+// foreign grants, and owner/group set to the current identity — the same
+// strictness privateFileIsProtected verifies.
+function protectPrivateFilesWin32(paths) {
+  const list = [...paths];
   execFileSync(
     "powershell.exe",
-    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", powershellPrivateScript()],
     {
-      env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target },
+      env: { ...process.env, CODEX_ROUTER_PRIVATE_FILES: JSON.stringify(list) },
       stdio: "ignore",
     },
   );
+  return list;
+}
+
+export function protectPrivateFile(target) {
+  chmodSync(target, 0o600);
+  if (process.platform === "win32") protectPrivateFilesWin32([target]);
   return target;
 }
 
@@ -48,9 +75,19 @@ export function writePrivateFile(target, contents, { directoryMode } = {}) {
   const temporary = `${target}.tmp.${process.pid}`;
   try {
     writeFileSync(temporary, contents, { encoding: "utf8", mode: 0o600 });
-    protectPrivateFile(temporary);
-    renameSync(temporary, target);
-    protectPrivateFile(target);
+    if (process.platform === "win32") {
+      // One spawn hardens the temporary; the renameSync below then moves this
+      // exact file over the target, and MoveFile carries the source's DACL
+      // with it, so the destination inherits the same owner-only ACL without a
+      // second PowerShell cold start. A pre-existing target that is being
+      // replaced is discarded with the move, so it cannot leak permissions.
+      protectPrivateFilesWin32([temporary]);
+      renameSync(temporary, target);
+    } else {
+      protectPrivateFile(temporary);
+      renameSync(temporary, target);
+      protectPrivateFile(target);
+    }
   } catch (error) {
     if (existsSync(temporary)) unlinkSync(temporary);
     throw error;

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -10,53 +10,85 @@ import {
 } from "node:fs";
 import path from "node:path";
 
-// Windows private-file hardening is one PowerShell spawn per call. Lowering
-// that count matters: download workers persist progress on every percentage
-// point, and each spawn cold-starts powershell.exe, so a state writer that
-// protected two files per atomic replace used to pay twice per write.
+// Windows private-file hardening is one PowerShell spawn per call.
+//
+// Keeping it a single process is the point: `main` memoized the current SID
+// and then ran `icacls` per file, and icacls is what this module exists to
+// replace. `icacls /inheritance:r` left every explicit foreign ACE in place,
+// `/grant:r:` could throw "system error 1332" over a non-canonical DACL, and
+// its NTAccount translation throws IdentityNotMappedException for an orphaned
+// SID or an unreachable DC. So the per-write cost is one cold-start of
+// powershell.exe where main paid one icacls.exe — noticeably slower per write,
+// but it is the price of a hardening path that cannot silently skip repairing
+// the exact drift it is meant to repair.
 //
 // Internal callers that harden several paths at once go through
-// protectPrivateFilesWin32 so that cost is paid once.
+// protectPrivateFilesWin32 so that cost is paid once for the batch.
 function powershellPrivateScript() {
   return [
-    // Build the ACL from a fresh, empty FileSecurity rather than asking
+    // A hardening failure must surface as a non-zero exit that Node can turn
+    // into a thrown error. Without this PowerShell only rolls an unhandled
+    // method-invocation exception into a statement that its caller may exit 0
+    // on, which would let a credential write report success while the DACL
+    // was never applied.
+    "$ErrorActionPreference = 'Stop'",
+    "try {",
+    "  $paths = @(ConvertFrom-Json -InputObject $env:CODEX_ROUTER_PRIVATE_FILES)",
+    // Build each ACL from a fresh, empty FileSecurity rather than asking
     // GetAccessControl about the file's existing (possibly non-canonical)
-    // DACL. SetAccessRuleProtection on a clean object never canonicalizes a
+    // DACL. SetAccessRuleProtection on a bare object never canonicalizes a
     // broken inherited/permission mix, so a file whose DACL is already
     // corrupt — the exact drift an install or doctor --fix must be able to
     // repair — cannot make this throw. The pre-existing DACL is replaced
     // outright instead of being edited toward compliance.
-    "$sid = [Security.Principal.WindowsIdentity]::GetCurrent().User",
-    "$fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl",
-    "$none = [System.Security.AccessControl.InheritanceFlags]::None",
-    "$propagationNone = [System.Security.AccessControl.PropagationFlags]::None",
-    "$allow = [System.Security.AccessControl.AccessControlType]::Allow",
-    "foreach ($p in (ConvertFrom-Json -InputObject $env:CODEX_ROUTER_PRIVATE_FILES)) {",
-    "  $acl = [System.Security.AccessControl.FileSecurity]::new()",
-    "  [void]$acl.SetAccessRuleProtection($true, $false)",
-    "  $acl.SetOwner($sid)",
-    "  $acl.SetGroup($sid)",
-    "  $rule = [System.Security.AccessControl.FileSystemAccessRule]::new($sid, $fullControl, $none, $propagationNone, $allow)",
-    "  [void]$acl.AddAccessRule($rule)",
-    "  [System.IO.File]::SetAccessControl($p, $acl)",
+    // Only the DACL is persisted, not owner or group: persisting those
+    // sections demands WRITE_OWNER, which Windows grants to nobody but the
+    // owner raised it to even for the current identity. `icacls /inheritance:r`
+    // needed only WRITE_DAC, so in exactly the non-canonical-DACL scenario
+    // this repair exists for, a SetOwner/SetGroup would throw
+    // UnauthorizedAccessException where the DACL fix would have succeeded.
+    "  $sid = [Security.Principal.WindowsIdentity]::GetCurrent().User",
+    "  $fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl",
+    "  $none = [System.Security.AccessControl.InheritanceFlags]::None",
+    "  $propagationNone = [System.Security.AccessControl.PropagationFlags]::None",
+    "  $allow = [System.Security.AccessControl.AccessControlType]::Allow",
+    "  foreach ($p in $paths) {",
+    "    $acl = [System.Security.AccessControl.FileSecurity]::new()",
+    "    [void]$acl.SetAccessRuleProtection($true, $false)",
+    "    $rule = [System.Security.AccessControl.FileSystemAccessRule]::new($sid, $fullControl, $none, $propagationNone, $allow)",
+    "    [void]$acl.AddAccessRule($rule)",
+    "    [System.IO.File]::SetAccessControl($p, $acl)",
+    "  }",
+    "} catch {",
+    "  [Console]::Error.WriteLine($_.Exception.Message)",
+    "  exit 1",
     "}",
-  ].join("; ");
+  ].join("\n");
 }
 
 // Protect one or more paths in a single PowerShell process. Each file ends up
-// with exactly one current-identity FullControl Allow rule, no inheritance, no
-// foreign grants, and owner/group set to the current identity — the same
-// strictness privateFileIsProtected verifies.
+// with exactly one current-identity FullControl Allow rule and no inheritance —
+// the same strictness privateFileIsProtected verifies. Owner/group are left
+// untouched: persisting them costs WRITE_OWNER, which can fail where the DACL
+// fix would succeed, so they are not part of the hardening assertion.
 function protectPrivateFilesWin32(paths) {
   const list = [...paths];
-  execFileSync(
-    "powershell.exe",
-    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", powershellPrivateScript()],
-    {
-      env: { ...process.env, CODEX_ROUTER_PRIVATE_FILES: JSON.stringify(list) },
-      stdio: "ignore",
-    },
-  );
+  try {
+    execFileSync(
+      "powershell.exe",
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", powershellPrivateScript()],
+      {
+        env: { ...process.env, CODEX_ROUTER_PRIVATE_FILES: JSON.stringify(list) },
+        stdio: ["ignore", "ignore", "pipe"],
+      },
+    );
+  } catch (error) {
+    // The hardening script writes its diagnosis to stderr before exiting 1. A
+    // non-zero exit is swallowed by execFileSync's throw, so fold the message
+    // in here instead of discarding it: a `doctor` report needs it.
+    const detail = String(error?.stderr?.trim?.() || error?.message || "").trim();
+    throw new Error(detail ? `Failed to protect private file ACL: ${detail}` : `Failed to protect private file ACL.`);
+  }
   return list;
 }
 

--- a/test/file-security.test.mjs
+++ b/test/file-security.test.mjs
@@ -9,7 +9,6 @@ import {
   privateFileIsProtected,
   protectPrivateFile,
   writePrivateJson,
-  windowsFullControlGrant,
 } from "../src/file-security.mjs";
 
 test("private JSON state uses one owner-only atomic writer", () => {
@@ -25,16 +24,8 @@ test("private JSON state uses one owner-only atomic writer", () => {
   }
 });
 
-test("Windows numeric SID grants use the icacls SID prefix", () => {
-  assert.equal(
-    windowsFullControlGrant("S-1-5-21-1742564184-1656218818-310408600-500"),
-    "*S-1-5-21-1742564184-1656218818-310408600-500:(F)",
-  );
-  assert.throws(() => windowsFullControlGrant("runner@example.com"), /invalid Windows user SID/);
-});
-
 test(
-  "Windows private-file ACL is protected for the current identity",
+  "Windows private-file ACL removes foreign grants and gives only the current identity full control",
   { skip: process.platform !== "win32" },
   () => {
     const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-acl-"));
@@ -42,10 +33,36 @@ test(
     writeFileSync(target, "TEST_ONLY\n");
     try {
       protectPrivateFile(target);
+      assert.equal(privateFileIsProtected(target), true);
+
+      const grantEveryoneRead = [
+        "$target = $env:CODEX_ROUTER_PRIVATE_FILE",
+        "$acl = [System.IO.File]::GetAccessControl($target)",
+        "$everyone = [System.Security.Principal.SecurityIdentifier]::new('S-1-1-0')",
+        "$read = [System.Security.AccessControl.FileSystemRights]::Read",
+        "$none = [System.Security.AccessControl.InheritanceFlags]::None",
+        "$propagationNone = [System.Security.AccessControl.PropagationFlags]::None",
+        "$allow = [System.Security.AccessControl.AccessControlType]::Allow",
+        "$rule = [System.Security.AccessControl.FileSystemAccessRule]::new($everyone, $read, $none, $propagationNone, $allow)",
+        "[void]$acl.AddAccessRule($rule)",
+        "[System.IO.File]::SetAccessControl($target, $acl)",
+      ].join("; ");
+      execFileSync(
+        "powershell.exe",
+        ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", grantEveryoneRead],
+        {
+          env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target },
+          stdio: "ignore",
+        },
+      );
+      assert.equal(privateFileIsProtected(target), false);
+
+      protectPrivateFile(target);
       const script = [
         "$acl = [System.IO.File]::GetAccessControl($env:CODEX_ROUTER_PRIVATE_FILE)",
         "$identity = [Security.Principal.WindowsIdentity]::GetCurrent()",
-        "$rules = @($acl.Access | ForEach-Object { [pscustomobject]@{ identity = $_.IdentityReference.Value; type = $_.AccessControlType.ToString(); inherited = $_.IsInherited } })",
+        "$rawRules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))",
+        "$rules = @($rawRules | ForEach-Object { [pscustomobject]@{ identity = $_.IdentityReference.Value; type = $_.AccessControlType.ToString(); rights = $_.FileSystemRights.ToString(); inherited = $_.IsInherited } })",
         "[pscustomobject]@{ protected = $acl.AreAccessRulesProtected; currentSid = $identity.User.Value; currentName = $identity.Name; rules = $rules } | ConvertTo-Json -Compress -Depth 4",
       ].join("; ");
       const acl = execFileSync(
@@ -57,6 +74,16 @@ test(
         },
       ).trim();
       assert.equal(privateFileIsProtected(target), true, acl);
+      const snapshot = JSON.parse(acl);
+      assert.equal(snapshot.protected, true);
+      assert.deepEqual(snapshot.rules, [
+        {
+          identity: snapshot.currentSid,
+          type: "Allow",
+          rights: "FullControl",
+          inherited: false,
+        },
+      ]);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/test/file-security.test.mjs
+++ b/test/file-security.test.mjs
@@ -9,6 +9,7 @@ import {
   privateFileIsProtected,
   protectPrivateFile,
   writePrivateJson,
+  writePrivateFile,
 } from "../src/file-security.mjs";
 
 test("private JSON state uses one owner-only atomic writer", () => {
@@ -163,6 +164,57 @@ test(
         ).trim(),
       );
       assert.equal(privateFileIsProtected(target), true, JSON.stringify(snapshot));
+      assert.equal(snapshot.protected, true);
+      assert.deepEqual(snapshot.rules, [
+        {
+          identity: snapshot.currentSid,
+          type: "Allow",
+          rights: "FullControl",
+          inherited: false,
+        },
+      ]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+// writePrivateFile's whole Windows path rests on the rename carrying the
+// temporary file's ACL onto the target. If a future move ever crosses a volume
+// (or the temp stops being a same-directory sibling), the destination would
+// inherit the destination folder's DACL and hardening would silently vanish.
+// This guards that the production writer leaves exactly one hardened file at
+// the destination, not just that protectPrivateFile works standalone.
+test(
+  "Windows writePrivateFile leaves the atomic-rename target protected",
+  { skip: process.platform !== "win32" },
+  () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-write-protected-"));
+    const target = path.join(directory, "state.json");
+    try {
+      writePrivateFile(target, "secret\n");
+      assert.equal(privateFileIsProtected(target), true);
+
+      const snapshot = JSON.parse(
+        execFileSync(
+          "powershell.exe",
+          [
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            [
+              "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
+              "$acl = [System.IO.File]::GetAccessControl($env:CODEX_ROUTER_PRIVATE_FILE)",
+              "$identity = [Security.Principal.WindowsIdentity]::GetCurrent()",
+              "$rawRules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))",
+              "$rules = @($rawRules | ForEach-Object { [pscustomobject]@{ identity = $_.IdentityReference.Value; type = $_.AccessControlType.ToString(); rights = $_.FileSystemRights.ToString(); inherited = $_.IsInherited } })",
+              "[pscustomobject]@{ protected = $acl.AreAccessRulesProtected; currentSid = $identity.User.Value; rules = $rules } | ConvertTo-Json -Compress -Depth 4",
+            ].join("; "),
+          ],
+          { encoding: "utf8", env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target } },
+        ).trim(),
+      );
       assert.equal(snapshot.protected, true);
       assert.deepEqual(snapshot.rules, [
         {

--- a/test/file-security.test.mjs
+++ b/test/file-security.test.mjs
@@ -38,7 +38,7 @@ test(
       const grantEveryoneRead = [
         "$target = $env:CODEX_ROUTER_PRIVATE_FILE",
         "$acl = [System.IO.File]::GetAccessControl($target)",
-        "$everyone = [System.Security.Principal.SecurityIdentifier]::new('S-1-1-0')",
+        "$everyone = [Security.Principal.SecurityIdentifier]::new('S-1-1-0')",
         "$read = [System.Security.AccessControl.FileSystemRights]::Read",
         "$none = [System.Security.AccessControl.InheritanceFlags]::None",
         "$propagationNone = [System.Security.AccessControl.PropagationFlags]::None",
@@ -75,6 +75,94 @@ test(
       ).trim();
       assert.equal(privateFileIsProtected(target), true, acl);
       const snapshot = JSON.parse(acl);
+      assert.equal(snapshot.protected, true);
+      assert.deepEqual(snapshot.rules, [
+        {
+          identity: snapshot.currentSid,
+          type: "Allow",
+          rights: "FullControl",
+          inherited: false,
+        },
+      ]);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "Windows protectPrivateFile rebuilds a canonical owner-only ACL over a broad foreign+inherited DACL",
+  { skip: process.platform !== "win32" },
+  () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-acl-dirty-"));
+    const target = path.join(directory, "private.secret");
+    writeFileSync(target, "TEST_ONLY\n");
+    // Make the file a genuinely messy DACL before hardening: keep its inherited
+    // ACEs (don't clear them), re-enable inheritance (unprotect), and add an
+    // explicit Everyone Read Allow. That leaves an "unprotected, foreign +
+    // inherited, mixed" DACL, the exact drift the canonical builder exists to
+    // repair and the shape the old GetAccessControl + SetAccessRuleProtection
+    // + RemoveAccessRuleSpecific path could not safely recanonicalize.
+    const setDirtyAcl = [
+      "$acl = [System.IO.File]::GetAccessControl($env:CODEX_ROUTER_PRIVATE_FILE)",
+      "[void]$acl.SetAccessRuleProtection($false, $true)",
+      "$everyone = [Security.Principal.SecurityIdentifier]::new('S-1-1-0')",
+      "$read = [System.Security.AccessControl.FileSystemRights]::Read",
+      "$none = [System.Security.AccessControl.InheritanceFlags]::None",
+      "$propagationNone = [System.Security.AccessControl.PropagationFlags]::None",
+      "$allow = [System.Security.AccessControl.AccessControlType]::Allow",
+      "$rule = [System.Security.AccessControl.FileSystemAccessRule]::new($everyone, $read, $none, $propagationNone, $allow)",
+      "[void]$acl.AddAccessRule($rule)",
+      "[System.IO.File]::SetAccessControl($env:CODEX_ROUTER_PRIVATE_FILE, $acl)",
+    ].join("; ");
+    execFileSync(
+      "powershell.exe",
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", setDirtyAcl],
+      { env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target }, stdio: "ignore" },
+    );
+    try {
+      // Confirm the file started in the messy shape, so the repro is real.
+      const before = execFileSync(
+        "powershell.exe",
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          [
+            "$acl = [System.IO.File]::GetAccessControl($env:CODEX_ROUTER_PRIVATE_FILE)",
+            "$rawRules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))",
+            "$hasForeignAllow = $false",
+            "$everyone = [Security.Principal.SecurityIdentifier]::new('S-1-1-0')",
+            "foreach ($rule in $rawRules) { if ($rule.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow) { if ($rule.IdentityReference.Value -ne $acl.GetOwner([System.Security.Principal.SecurityIdentifier])) { $hasForeignAllow = $true } } }",
+            "[Console]::Out.Write((($acl.AreAccessRulesProtected -eq $false) -and $hasForeignAllow).ToString())",
+          ].join("; "),
+        ],
+        {
+          encoding: "utf8",
+          env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target },
+        },
+      ).trim().toLowerCase();
+      assert.equal(before, "true");
+
+      // The repair must not depend on the pre-existing (unprotected,
+      // foreign, non-canonical) DACL: it substitutes a fresh canonical one.
+      protectPrivateFile(target);
+      const snapshotScript = [
+        "$acl = [System.IO.File]::GetAccessControl($env:CODEX_ROUTER_PRIVATE_FILE)",
+        "$identity = [Security.Principal.WindowsIdentity]::GetCurrent()",
+        "$rawRules = @($acl.GetAccessRules($true, $true, [Security.Principal.SecurityIdentifier]))",
+        "$rules = @($rawRules | ForEach-Object { [pscustomobject]@{ identity = $_.IdentityReference.Value; type = $_.AccessControlType.ToString(); rights = $_.FileSystemRights.ToString(); inherited = $_.IsInherited } })",
+        "[pscustomobject]@{ protected = $acl.AreAccessRulesProtected; currentSid = $identity.User.Value; rules = $rules } | ConvertTo-Json -Compress -Depth 4",
+      ].join("; ");
+      const snapshot = JSON.parse(
+        execFileSync(
+          "powershell.exe",
+          ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", snapshotScript],
+          { encoding: "utf8", env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target } },
+        ).trim(),
+      );
+      assert.equal(privateFileIsProtected(target), true, JSON.stringify(snapshot));
       assert.equal(snapshot.protected, true);
       assert.deepEqual(snapshot.rules, [
         {


### PR DESCRIPTION
## Summary

Scope **(b)** from the split of the earlier bundled PR #349: the `src/file-security.mjs` rewrite.

## What changes

- Removes `currentWindowsSid()` and `windowsFullControlGrant()` (and the exported `windowsFullControlGrant` they exposed) that shelled out to `icacls.exe` and carried the numeric-SID 1332 pitfall.
- `protectPrivateFile()` now performs the ACL rewrite inline in a single PowerShell call: it disables ACL inheritance, drops every existing rule, and grants only the current Windows identity `FullControl`. It no longer depends on `icacls` and its SID prefix handling.
- `privateFileIsProtected()` is stricter and truly verifies the invariant it names: the ACL must be protected, have no inherited rule, grant the current SID full control, and contain no foreign `Allow` grant.

## Why

The old code produced an ACL, but the check did not prove "only the current identity has full control" — foreign `Allow` rules and inherited rules were not rejected, and the `icacls` SID prefix logic was a correctness and portability hazard. The rewrite makes pose and verify arrive at the same definition.

## Verification

- `test/file-security.test.mjs` rewritten to assert the removal of foreign grants, the exact single `FullControl` rule set, inherited-rule rejection, and the strict re-protection path. Runs on Windows (ACL exercise) and passes on POSIX (mode 0600 path).
- Regression run on `test/file-security.test.mjs`, `test/caller-auth.test.mjs`, `test/config-manager.test.mjs`: **40 pass / 1 skip / 0 fail** — the stricter checker does not regress existing private-file handling.

## Scope boundary

This is strictly the `file-security.mjs` change (scope b). It does **not** include the Antigravity provider (scope a, PR #372), the Windows tray/installer work (scope c: separate PR), or the catalog picker ordering (scope d: separate PR). No credentials, no third-party secrets, no unrelated hunks.