### PR TITLE
feat: harden Windows tray lifecycle and add deploy helpers (scope c)

### DIFF
--- a/codex-router.ps1
+++ b/codex-router.ps1
@@ -28,6 +28,168 @@ function Invoke-RouterNode([string]$Script, [string[]]$ScriptArguments = @()) {
   }
 }
 
+function Resolve-AccountSid([string]$Identity) {
+  try {
+    return ([Security.Principal.SecurityIdentifier]::new($Identity)).Value
+  } catch {
+    return ([Security.Principal.NTAccount]::new($Identity)).Translate(
+      [Security.Principal.SecurityIdentifier]
+    ).Value
+  }
+}
+
+function Get-ValidatedTrayTask {
+  $TaskName = "Codex Router Tray"
+  $Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction Stop
+  $CurrentSid = [Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+  $PrincipalSid = Resolve-AccountSid ([string]$Task.Principal.UserId)
+  if ($PrincipalSid -ne $CurrentSid) {
+    throw "Refusing to repair '$TaskName': its principal is not the current user."
+  }
+  if ($Task.Principal.LogonType.ToString() -ne "Interactive") {
+    throw "Refusing to repair '$TaskName': it is not an interactive user task."
+  }
+
+  $Actions = @($Task.Actions)
+  if ($Actions.Count -ne 1) {
+    throw "Refusing to repair '$TaskName': it does not have one recognized action."
+  }
+  $TaskAction = $Actions[0]
+  $Execute = [IO.Path]::GetFullPath(
+    [Environment]::ExpandEnvironmentVariables([string]$TaskAction.Execute)
+  )
+  $Argument = [string]$TaskAction.Arguments
+  $TauriExecute = [IO.Path]::GetFullPath(
+    (Join-Path $Root "apps\desktop\src-tauri\target\release\codex-router-desktop.exe")
+  )
+  $ElectronExecute = [IO.Path]::GetFullPath(
+    (Join-Path $Root "apps\electron\node_modules\electron\dist\electron.exe")
+  )
+  $ElectronDirectory = [IO.Path]::GetFullPath((Join-Path $Root "apps\electron"))
+  $TauriAction = [string]::Equals($Execute, $TauriExecute, [StringComparison]::OrdinalIgnoreCase) -and
+    [string]::IsNullOrWhiteSpace($Argument)
+  $ElectronAction = [string]::Equals($Execute, $ElectronExecute, [StringComparison]::OrdinalIgnoreCase) -and
+    [string]::Equals($Argument.Trim().Trim('"'), $ElectronDirectory, [StringComparison]::OrdinalIgnoreCase)
+  if (-not ($TauriAction -or $ElectronAction)) {
+    throw "Refusing to repair '$TaskName': its action is not this checkout's tray companion."
+  }
+
+  return [pscustomobject]@{
+    Name = $TaskName
+    Sid = $CurrentSid
+    Execute = [string]$TaskAction.Execute
+    Argument = $Argument
+  }
+}
+
+function Test-TrayTaskFullControl([string]$TaskName, [string]$SidValue) {
+  try {
+    $Service = New-Object -ComObject "Schedule.Service"
+    $Service.Connect()
+    $Registered = $Service.GetFolder("\").GetTask($TaskName)
+    $Descriptor = [Security.AccessControl.RawSecurityDescriptor]::new(
+      $Registered.GetSecurityDescriptor(7)
+    )
+    foreach ($Ace in $Descriptor.DiscretionaryAcl) {
+      if ($Ace -is [Security.AccessControl.CommonAce] -and
+          $Ace.AceQualifier -eq [Security.AccessControl.AceQualifier]::AccessAllowed -and
+          $Ace.SecurityIdentifier.Value -eq $SidValue -and
+          ($Ace.AccessMask -band 0x1f01ff) -eq 0x1f01ff) {
+        return $true
+      }
+    }
+  } catch {
+    # A descriptor we cannot inspect is exactly the case the elevated repair
+    # is allowed to address after validating the task's principal and action.
+  }
+  return $false
+}
+
+function Repair-TrayTaskPermissions {
+  $Validated = Get-ValidatedTrayTask
+  if (Test-TrayTaskFullControl $Validated.Name $Validated.Sid) {
+    Write-Output "Tray task permissions are already repairable by the current user."
+    return
+  }
+
+  # The elevated side reads only fixed environment fields, validates the task
+  # again to close the UAC race, and changes its DACL through Task Scheduler's
+  # supported COM API. The tray process itself remains Interactive/Limited.
+  $ElevatedScript = @'
+$ErrorActionPreference = "Stop"
+function Resolve-RepairSid([string]$Identity) {
+  try { return ([Security.Principal.SecurityIdentifier]::new($Identity)).Value }
+  catch { return ([Security.Principal.NTAccount]::new($Identity)).Translate([Security.Principal.SecurityIdentifier]).Value }
+}
+$scheduled = Get-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_REPAIR_TASK -ErrorAction Stop
+$actions = @($scheduled.Actions)
+if ($actions.Count -ne 1) { throw "Tray task action changed before repair." }
+$principalSid = Resolve-RepairSid ([string]$scheduled.Principal.UserId)
+if ($principalSid -ne $env:CODEX_ROUTER_TRAY_REPAIR_SID -or
+    -not [string]::Equals([string]$actions[0].Execute, $env:CODEX_ROUTER_TRAY_REPAIR_EXECUTE, [StringComparison]::OrdinalIgnoreCase) -or
+    -not [string]::Equals([string]$actions[0].Arguments, $env:CODEX_ROUTER_TRAY_REPAIR_ARGUMENT, [StringComparison]::Ordinal)) {
+  throw "Tray task identity changed before repair."
+}
+$service = New-Object -ComObject "Schedule.Service"
+$service.Connect()
+$registered = $service.GetFolder("\").GetTask($env:CODEX_ROUTER_TRAY_REPAIR_TASK)
+$descriptor = [Security.AccessControl.RawSecurityDescriptor]::new($registered.GetSecurityDescriptor(7))
+$sid = [Security.Principal.SecurityIdentifier]::new($env:CODEX_ROUTER_TRAY_REPAIR_SID)
+$fullControl = 0x1f01ff
+$hasFullControl = $false
+foreach ($ace in $descriptor.DiscretionaryAcl) {
+  if ($ace -is [Security.AccessControl.CommonAce] -and
+      $ace.AceQualifier -eq [Security.AccessControl.AceQualifier]::AccessAllowed -and
+      $ace.SecurityIdentifier.Value -eq $sid.Value -and
+      ($ace.AccessMask -band $fullControl) -eq $fullControl) {
+    $hasFullControl = $true
+    break
+  }
+}
+if (-not $hasFullControl) {
+  $newAce = [Security.AccessControl.CommonAce]::new(
+    [Security.AccessControl.AceFlags]::None,
+    [Security.AccessControl.AceQualifier]::AccessAllowed,
+    $fullControl,
+    $sid,
+    $false,
+    $null
+  )
+  $descriptor.DiscretionaryAcl.InsertAce($descriptor.DiscretionaryAcl.Count, $newAce)
+  $sections = [Security.AccessControl.AccessControlSections]::Owner -bor
+    [Security.AccessControl.AccessControlSections]::Group -bor
+    [Security.AccessControl.AccessControlSections]::Access
+  $registered.SetSecurityDescriptor($descriptor.GetSddlForm($sections), 0x10)
+}
+'@
+  $SavedTask = $env:CODEX_ROUTER_TRAY_REPAIR_TASK
+  $SavedSid = $env:CODEX_ROUTER_TRAY_REPAIR_SID
+  $SavedExecute = $env:CODEX_ROUTER_TRAY_REPAIR_EXECUTE
+  $SavedArgument = $env:CODEX_ROUTER_TRAY_REPAIR_ARGUMENT
+  try {
+    $env:CODEX_ROUTER_TRAY_REPAIR_TASK = $Validated.Name
+    $env:CODEX_ROUTER_TRAY_REPAIR_SID = $Validated.Sid
+    $env:CODEX_ROUTER_TRAY_REPAIR_EXECUTE = $Validated.Execute
+    $env:CODEX_ROUTER_TRAY_REPAIR_ARGUMENT = $Validated.Argument
+    $Encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($ElevatedScript))
+    $Process = Start-Process -FilePath "powershell.exe" -Verb RunAs -Wait -PassThru -WindowStyle Hidden -ArgumentList @(
+      "-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", $Encoded
+    )
+    if ($Process.ExitCode -ne 0) {
+      throw "Elevated tray permission repair failed with exit code $($Process.ExitCode)."
+    }
+  } finally {
+    $env:CODEX_ROUTER_TRAY_REPAIR_TASK = $SavedTask
+    $env:CODEX_ROUTER_TRAY_REPAIR_SID = $SavedSid
+    $env:CODEX_ROUTER_TRAY_REPAIR_EXECUTE = $SavedExecute
+    $env:CODEX_ROUTER_TRAY_REPAIR_ARGUMENT = $SavedArgument
+  }
+  if (-not (Test-TrayTaskFullControl $Validated.Name $Validated.Sid)) {
+    throw "Task Scheduler still denies the current user control of the tray task."
+  }
+  Write-Output "Tray task permissions repaired; reinstalling the companion."
+}
+
 switch ($Command) {
   "setup" {
     Invoke-RouterNode "src\setup.mjs" $Arguments
@@ -90,8 +252,12 @@ switch ($Command) {
   # it now and again at every logon.
   "tray" {
     $Action = if ($Arguments.Count) { [string]$Arguments[0] } else { "install" }
-    if ($Action -notin @("install", "status", "start", "stop", "restart", "uninstall", "rebuild")) {
-      throw "Unknown tray action '$Action'. Choose: install, status, start, stop, restart, uninstall, rebuild."
+    if ($Action -notin @("install", "status", "start", "stop", "restart", "uninstall", "rebuild", "repair")) {
+      throw "Unknown tray action '$Action'. Choose: install, status, start, stop, restart, uninstall, rebuild, repair."
+    }
+    if ($Action -eq "repair") {
+      Repair-TrayTaskPermissions
+      $Action = "install"
     }
     # `rebuild` is `control tray rebuild`'s Windows half: build unconditionally
     # -- bypassing the source-fingerprint skip that `install` uses -- then
@@ -104,12 +270,14 @@ switch ($Command) {
         if ($LASTEXITCODE -ne 0) {
           Write-Warning "Could not stamp the companion build; the next update will rebuild it."
         }
+        Invoke-RouterNode "src\tray-service.mjs" @("install")
       } else {
         Write-Output "Cargo is not on PATH; rebuilding the Electron companion instead."
         & (Join-Path $Root "scripts\build-electron-companion.ps1") | Out-Null
         if ($LASTEXITCODE -ne 0) { throw "Electron companion build failed." }
+        Invoke-RouterNode "src\tray-service.mjs" @("install-electron")
       }
-      Invoke-RouterNode "src\tray-service.mjs" @("restart")
+      Write-Output "Companion rebuilt, installed, and started."
       exit 0
     }
     # Rust is the only prerequisite the Tauri shell adds over what the router

--- a/codex-router.ps1
+++ b/codex-router.ps1
@@ -59,19 +59,30 @@ function Get-ValidatedTrayTask {
     [Environment]::ExpandEnvironmentVariables([string]$TaskAction.Execute)
   )
   $Argument = [string]$TaskAction.Arguments
-  $TauriExecute = [IO.Path]::GetFullPath(
-    (Join-Path $Root "apps\desktop\src-tauri\target\release\codex-router-desktop.exe")
+
+  # A task registered by an installed copy (%LOCALAPPDATA%\codex-router) points
+  # at that root, while `tray repair` is often run from a developer checkout's
+  # $PSScriptRoot. Requiring the action to equal *this* checkout would reject
+  # exactly the person reaching for repair. So the action is recognized by the
+  # *shape* of a real companion -- the Tauri release binary, or the Electron
+  # runtime plus its app directory -- rather than by which root registered it.
+  # The principal/interactive/single-action checks above still stop repair of an
+  # arbitrary scheduled task.
+  $TauriAction = $Execute.EndsWith(
+    "apps\desktop\src-tauri\target\release\codex-router-desktop.exe",
+    [StringComparison]::OrdinalIgnoreCase
+  ) -and [string]::IsNullOrWhiteSpace($Argument)
+  $ElectronAction = $Execute.EndsWith(
+    "apps\electron\node_modules\electron\dist\electron.exe",
+    [StringComparison]::OrdinalIgnoreCase
+  ) -and (
+    $Argument.Trim().Trim('"').EndsWith(
+      "apps\electron",
+      [StringComparison]::OrdinalIgnoreCase
+    )
   )
-  $ElectronExecute = [IO.Path]::GetFullPath(
-    (Join-Path $Root "apps\electron\node_modules\electron\dist\electron.exe")
-  )
-  $ElectronDirectory = [IO.Path]::GetFullPath((Join-Path $Root "apps\electron"))
-  $TauriAction = [string]::Equals($Execute, $TauriExecute, [StringComparison]::OrdinalIgnoreCase) -and
-    [string]::IsNullOrWhiteSpace($Argument)
-  $ElectronAction = [string]::Equals($Execute, $ElectronExecute, [StringComparison]::OrdinalIgnoreCase) -and
-    [string]::Equals($Argument.Trim().Trim('"'), $ElectronDirectory, [StringComparison]::OrdinalIgnoreCase)
   if (-not ($TauriAction -or $ElectronAction)) {
-    throw "Refusing to repair '$TaskName': its action is not this checkout's tray companion."
+    throw "Refusing to repair '$TaskName': its action is not a Codex Router tray companion (codex-router-desktop.exe or the Electron app)."
   }
 
   return [pscustomobject]@{
@@ -112,29 +123,39 @@ function Repair-TrayTaskPermissions {
     return
   }
 
-  # The elevated side reads only fixed environment fields, validates the task
-  # again to close the UAC race, and changes its DACL through Task Scheduler's
-  # supported COM API. The tray process itself remains Interactive/Limited.
+  # The validated values are the only data the elevated side needs, but they
+  # cannot cross the UAC boundary: Start-Process -Verb RunAs goes through
+  # ShellExecuteEx -> AppInfo -> CreateProcessAsUser, which rebuilds the child
+  # environment from the elevated token, so `$env:CODEX_ROUTER_TRAY_REPAIR_*`
+  # would be empty inside the elevated process. Instead the four values are
+  # embedded as literals in the -EncodedCommand payload, and the elevated side
+  # re-reads the task and compares its principal and action against them --
+  # the same TOCTOU closure as before, with no process-environment handoff.
+  foreach ($Field in "Name", "Sid", "Execute", "Argument") {
+    if ([string]::IsNullOrWhiteSpace([string]$Validated.$Field)) {
+      throw "Refusing to repair the tray task: validated $Field is empty."
+    }
+  }
   $ElevatedScript = @'
 $ErrorActionPreference = "Stop"
 function Resolve-RepairSid([string]$Identity) {
   try { return ([Security.Principal.SecurityIdentifier]::new($Identity)).Value }
   catch { return ([Security.Principal.NTAccount]::new($Identity)).Translate([Security.Principal.SecurityIdentifier]).Value }
 }
-$scheduled = Get-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_REPAIR_TASK -ErrorAction Stop
+$scheduled = Get-ScheduledTask -TaskName __TRAY_TASK__ -ErrorAction Stop
 $actions = @($scheduled.Actions)
 if ($actions.Count -ne 1) { throw "Tray task action changed before repair." }
 $principalSid = Resolve-RepairSid ([string]$scheduled.Principal.UserId)
-if ($principalSid -ne $env:CODEX_ROUTER_TRAY_REPAIR_SID -or
-    -not [string]::Equals([string]$actions[0].Execute, $env:CODEX_ROUTER_TRAY_REPAIR_EXECUTE, [StringComparison]::OrdinalIgnoreCase) -or
-    -not [string]::Equals([string]$actions[0].Arguments, $env:CODEX_ROUTER_TRAY_REPAIR_ARGUMENT, [StringComparison]::Ordinal)) {
+if ($principalSid -ne __TRAY_SID__ -or
+    -not [string]::Equals([string]$actions[0].Execute, __TRAY_EXECUTE__, [StringComparison]::OrdinalIgnoreCase) -or
+    -not [string]::Equals([string]$actions[0].Arguments, __TRAY_ARGUMENT__, [StringComparison]::Ordinal)) {
   throw "Tray task identity changed before repair."
 }
 $service = New-Object -ComObject "Schedule.Service"
 $service.Connect()
-$registered = $service.GetFolder("\").GetTask($env:CODEX_ROUTER_TRAY_REPAIR_TASK)
+$registered = $service.GetFolder("\").GetTask(__TRAY_TASK__)
 $descriptor = [Security.AccessControl.RawSecurityDescriptor]::new($registered.GetSecurityDescriptor(7))
-$sid = [Security.Principal.SecurityIdentifier]::new($env:CODEX_ROUTER_TRAY_REPAIR_SID)
+$sid = [Security.Principal.SecurityIdentifier]::new(__TRAY_SID__)
 $fullControl = 0x1f01ff
 $hasFullControl = $false
 foreach ($ace in $descriptor.DiscretionaryAcl) {
@@ -162,27 +183,38 @@ if (-not $hasFullControl) {
   $registered.SetSecurityDescriptor($descriptor.GetSddlForm($sections), 0x10)
 }
 '@
-  $SavedTask = $env:CODEX_ROUTER_TRAY_REPAIR_TASK
-  $SavedSid = $env:CODEX_ROUTER_TRAY_REPAIR_SID
-  $SavedExecute = $env:CODEX_ROUTER_TRAY_REPAIR_EXECUTE
-  $SavedArgument = $env:CODEX_ROUTER_TRAY_REPAIR_ARGUMENT
-  try {
-    $env:CODEX_ROUTER_TRAY_REPAIR_TASK = $Validated.Name
-    $env:CODEX_ROUTER_TRAY_REPAIR_SID = $Validated.Sid
-    $env:CODEX_ROUTER_TRAY_REPAIR_EXECUTE = $Validated.Execute
-    $env:CODEX_ROUTER_TRAY_REPAIR_ARGUMENT = $Validated.Argument
-    $Encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($ElevatedScript))
-    $Process = Start-Process -FilePath "powershell.exe" -Verb RunAs -Wait -PassThru -WindowStyle Hidden -ArgumentList @(
-      "-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", $Encoded
-    )
-    if ($Process.ExitCode -ne 0) {
-      throw "Elevated tray permission repair failed with exit code $($Process.ExitCode)."
-    }
-  } finally {
-    $env:CODEX_ROUTER_TRAY_REPAIR_TASK = $SavedTask
-    $env:CODEX_ROUTER_TRAY_REPAIR_SID = $SavedSid
-    $env:CODEX_ROUTER_TRAY_REPAIR_EXECUTE = $SavedExecute
-    $env:CODEX_ROUTER_TRAY_REPAIR_ARGUMENT = $SavedArgument
+  # `Replace` substitutes only after the single-quoted here-string is
+  # assembled, so the embedded script's own `$...` stays verbatim; each value
+  # is wrapped in single quotes (doubling any embedded quote) so it becomes a
+  # string literal in the payload, never executable text.
+  function ConvertTo-RepairLiteral([string]$Value) {
+    return "'" + $Value.Replace("'", "''") + "'"
+  }
+  $ElevatedScript = $ElevatedScript.Replace(
+    "__TRAY_TASK__", (ConvertTo-RepairLiteral ([string]$Validated.Name)))
+  $ElevatedScript = $ElevatedScript.Replace(
+    "__TRAY_SID__", (ConvertTo-RepairLiteral ([string]$Validated.Sid)))
+  $ElevatedScript = $ElevatedScript.Replace(
+    "__TRAY_EXECUTE__", (ConvertTo-RepairLiteral ([string]$Validated.Execute)))
+  $ElevatedScript = $ElevatedScript.Replace(
+    "__TRAY_ARGUMENT__", (ConvertTo-RepairLiteral ([string]$Validated.Argument)))
+
+  # Name the host absolutely because -Verb RunAs forces ShellExecuteEx, whose
+  # search order includes the current working directory and every PATH entry;
+  # an unelevated attacker who can drop a powershell.exe there would otherwise
+  # get it launched behind the UAC prompt, fully elevated. Pin the working
+  # directory to SystemRoot so the elevated child runs from a directory no
+  # attacker can write.
+  $ElevatedPowerShell = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+  if (-not (Test-Path -LiteralPath $ElevatedPowerShell -PathType Leaf)) {
+    throw "Cannot locate the elevated PowerShell host at $ElevatedPowerShell."
+  }
+  $Encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($ElevatedScript))
+  $Process = Start-Process -FilePath $ElevatedPowerShell -Verb RunAs -Wait -PassThru -WindowStyle Hidden -WorkingDirectory $env:SystemRoot -ArgumentList @(
+    "-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", $Encoded
+  )
+  if ($Process.ExitCode -ne 0) {
+    throw "Elevated tray permission repair failed with exit code $($Process.ExitCode)."
   }
   if (-not (Test-TrayTaskFullControl $Validated.Name $Validated.Sid)) {
     throw "Task Scheduler still denies the current user control of the tray task."
@@ -256,6 +288,7 @@ switch ($Command) {
       throw "Unknown tray action '$Action'. Choose: install, status, start, stop, restart, uninstall, rebuild, repair."
     }
     if ($Action -eq "repair") {
+      Write-Output "Repairing the tray task's permissions. If repair is needed, the companion will then be rebuilt or reinstalled (a small step), re-registered, and started by Task Scheduler at every logon."
       Repair-TrayTaskPermissions
       $Action = "install"
     }

--- a/codex-router.ps1
+++ b/codex-router.ps1
@@ -263,19 +263,58 @@ switch ($Command) {
     # -- bypassing the source-fingerprint skip that `install` uses -- then
     # restart whichever companion Task Scheduler already supervises.
     if ($Action -eq "rebuild") {
-      if (Get-Command cargo -ErrorAction SilentlyContinue) {
-        & (Join-Path $Root "scripts\build-desktop-tray.ps1") -BinaryOnly
-        if ($LASTEXITCODE -ne 0) { throw "Desktop companion build failed." }
-        & node (Join-Path $Root "src\install-plan.mjs") record-tray | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-          Write-Warning "Could not stamp the companion build; the next update will rebuild it."
+      # A running companion keeps its Tauri or Electron binary open, and
+      # Windows refuses to overwrite a file another process holds. Building in
+      # place over a live tray fails every time, leaving the old companion in
+      # place (or broken). So a rebuild stops the supervised task before it
+      # builds, and restores the previous instance best-effort if the build or
+      # install afterwards fails.
+      $TrayWasRunning = $false
+      try {
+        $TrayState = (& node (Join-Path $Root "src\tray-service.mjs") status | Out-String)
+        if ($LASTEXITCODE -eq 0) {
+          $TrayWasRunning = ($TrayState | ConvertFrom-Json).loaded -eq $true
         }
-        Invoke-RouterNode "src\tray-service.mjs" @("install")
-      } else {
-        Write-Output "Cargo is not on PATH; rebuilding the Electron companion instead."
-        & (Join-Path $Root "scripts\build-electron-companion.ps1") | Out-Null
-        if ($LASTEXITCODE -ne 0) { throw "Electron companion build failed." }
-        Invoke-RouterNode "src\tray-service.mjs" @("install-electron")
+      } catch {
+        # An unreadable status is not a reason to build over a running tray;
+        # stopping first is safe either way, so just record nothing.
+        $TrayWasRunning = $false
+      }
+      try {
+        # `stop` is a no-op for an absent or idle task. Only a scheduler
+        # failure it cannot classify aborts the rebuild.
+        Invoke-RouterNode "src\tray-service.mjs" @("stop")
+      } catch {
+        if ($TrayWasRunning) { throw }
+      }
+      try {
+        if (Get-Command cargo -ErrorAction SilentlyContinue) {
+          & (Join-Path $Root "scripts\build-desktop-tray.ps1") -BinaryOnly
+          if ($LASTEXITCODE -ne 0) { throw "Desktop companion build failed." }
+          & node (Join-Path $Root "src\install-plan.mjs") record-tray | Out-Null
+          if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Could not stamp the companion build; the next update will rebuild it."
+          }
+          Invoke-RouterNode "src\tray-service.mjs" @("install")
+        } else {
+          Write-Output "Cargo is not on PATH; rebuilding the Electron companion instead."
+          & (Join-Path $Root "scripts\build-electron-companion.ps1") | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "Electron companion build failed." }
+          Invoke-RouterNode "src\tray-service.mjs" @("install-electron")
+        }
+      } catch {
+        if ($TrayWasRunning) {
+          # The tray this rebuild replaced is gone or half-replaced and STOPPED.
+          # Bring the still-on-disk companion back so the machine is not left
+          # trayless by a failed update.
+          try {
+            Invoke-RouterNode "src\tray-service.mjs" @("start")
+            Write-Warning "Companion rebuild failed; the previous companion was restarted."
+          } catch {
+            Write-Warning "Companion rebuild failed and the previous companion could not be restarted: $($_.Exception.Message)"
+          }
+        }
+        throw
       }
       Write-Output "Companion rebuilt, installed, and started."
       exit 0

--- a/deploy-codex-router.ps1
+++ b/deploy-codex-router.ps1
@@ -1,0 +1,254 @@
+[CmdletBinding(SupportsShouldProcess)]
+param(
+  [string]$InstallDir = $(
+    if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "codex-router" }
+    else { Join-Path $HOME ".local\share\codex-router" }
+  )
+)
+
+$ErrorActionPreference = "Stop"
+$sourceDir = (Resolve-Path (Split-Path -Parent $MyInvocation.MyCommand.Path)).Path
+$installDir = [IO.Path]::GetFullPath($InstallDir)
+$DeployManifestName = ".codex-router-deploy-manifest.json"
+$DeployManifestPath = Join-Path $installDir $DeployManifestName
+$ExcludedDirectoryNames = @(
+  ".git", ".venv", "node_modules", "target", "dist", "release", "release-local"
+)
+
+function Get-NormalizedDirectory([string]$Path) {
+  return [IO.Path]::GetFullPath($Path).TrimEnd([char[]]@('\', '/'))
+}
+
+function Test-NestedDirectory([string]$Candidate, [string]$Container) {
+  $CandidatePath = "$(Get-NormalizedDirectory $Candidate)\"
+  $ContainerPath = "$(Get-NormalizedDirectory $Container)\"
+  return $CandidatePath.StartsWith($ContainerPath, [StringComparison]::OrdinalIgnoreCase)
+}
+
+function Get-DeploySourceFiles {
+  $SourcePrefix = "$(Get-NormalizedDirectory $sourceDir)\"
+  $Pending = New-Object 'System.Collections.Generic.Stack[string]'
+  $Pending.Push($sourceDir)
+  $Files = New-Object 'System.Collections.Generic.List[string]'
+  while ($Pending.Count -gt 0) {
+    $Directory = $Pending.Pop()
+    foreach ($Entry in Get-ChildItem -LiteralPath $Directory -Force) {
+      if ($Entry.PSIsContainer) {
+        if (($Entry.Attributes -band [IO.FileAttributes]::ReparsePoint) -eq 0 -and
+            $ExcludedDirectoryNames -notcontains $Entry.Name) {
+          $Pending.Push($Entry.FullName)
+        }
+        continue
+      }
+      if ($Entry.Name -eq $DeployManifestName) { continue }
+      $Files.Add($Entry.FullName.Substring($SourcePrefix.Length))
+    }
+  }
+  return @($Files | Sort-Object -Unique)
+}
+
+function Read-DeployManifest {
+  if (-not (Test-Path -LiteralPath $DeployManifestPath -PathType Leaf)) { return @() }
+  try {
+    $Document = Get-Content -LiteralPath $DeployManifestPath -Raw | ConvertFrom-Json
+    if ($Document.version -ne 1 -or $null -eq $Document.files) {
+      throw "unsupported manifest shape"
+    }
+    return @($Document.files | ForEach-Object {
+      if ($_ -isnot [string] -or -not $_) { throw "invalid managed path" }
+      $_
+    })
+  } catch {
+    throw "Refusing deployment because $DeployManifestPath is invalid: $($_.Exception.Message)"
+  }
+}
+
+function Resolve-ManagedTargetFile([string]$RelativePath) {
+  if ([IO.Path]::IsPathRooted($RelativePath)) {
+    throw "The deployment manifest contains an absolute path."
+  }
+  $Segments = @($RelativePath -split '[\\/]')
+  if ($Segments.Count -eq 0 -or $Segments -contains "" -or
+      $Segments -contains "." -or $Segments -contains "..") {
+    throw "The deployment manifest contains an unsafe relative path."
+  }
+  $InstallPrefix = "$(Get-NormalizedDirectory $installDir)\"
+  $Target = [IO.Path]::GetFullPath((Join-Path $installDir $RelativePath))
+  if (-not $Target.StartsWith($InstallPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "The deployment manifest path escapes the installed checkout."
+  }
+  $Cursor = Get-NormalizedDirectory $installDir
+  foreach ($Segment in $Segments[0..([Math]::Max(0, $Segments.Count - 2))]) {
+    if ($Segments.Count -eq 1) { break }
+    $Cursor = Join-Path $Cursor $Segment
+    if (Test-Path -LiteralPath $Cursor) {
+      $Attributes = (Get-Item -LiteralPath $Cursor -Force).Attributes
+      if (($Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0) {
+        throw "Refusing to prune through reparse point $Cursor."
+      }
+    }
+  }
+  return $Target
+}
+
+function Update-DeployManifest([string[]]$CurrentFiles) {
+  $Current = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+  foreach ($RelativePath in $CurrentFiles) { [void]$Current.Add($RelativePath) }
+  foreach ($RelativePath in Read-DeployManifest) {
+    if ($Current.Contains($RelativePath)) { continue }
+    $Target = Resolve-ManagedTargetFile $RelativePath
+    if (Test-Path -LiteralPath $Target -PathType Leaf) {
+      Remove-Item -LiteralPath $Target -Force
+    }
+  }
+
+  $Temporary = "$DeployManifestPath.tmp.$PID"
+  try {
+    @{ version = 1; files = @($CurrentFiles) } |
+      ConvertTo-Json -Depth 3 |
+      Set-Content -LiteralPath $Temporary -Encoding UTF8
+    Move-Item -LiteralPath $Temporary -Destination $DeployManifestPath -Force
+  } finally {
+    if (Test-Path -LiteralPath $Temporary) { Remove-Item -LiteralPath $Temporary -Force }
+  }
+}
+
+if ((Test-NestedDirectory $sourceDir $installDir) -or
+    (Test-NestedDirectory $installDir $sourceDir)) {
+  throw "Source and install directories must be separate and neither may contain the other."
+}
+if (-not (Test-Path (Join-Path $sourceDir "src\start.mjs"))) {
+  throw "Router source not found at $sourceDir."
+}
+if (-not (Test-Path (Join-Path $installDir "src\start.mjs"))) {
+  throw "Installed router not found at $installDir."
+}
+
+function Get-TrayStatus {
+  $Output = (& node (Join-Path $installDir "src\tray-service.mjs") status | Out-String)
+  $StatusExitCode = $LASTEXITCODE
+  if ($StatusExitCode -ne 0) {
+    throw "Reading the installed tray status failed with exit code $StatusExitCode."
+  }
+  try {
+    return $Output | ConvertFrom-Json
+  } catch {
+    throw "The installed tray returned an invalid status document."
+  }
+}
+
+# Remember the operator's existing choice before any source moves. The
+# canonical installer refreshes an existing companion, but never installs one
+# on a machine that did not already have it.
+$TrayWasInstalled = (Get-TrayStatus).installed -eq $true
+
+Write-Host "Publishing $sourceDir"
+Write-Host "        to $installDir"
+
+if ($PSCmdlet.ShouldProcess($installDir, "copy router source")) {
+  # Copy without a blanket purge, then retire only files recorded by the prior
+  # deployment. That removes renamed config fragments (the registry loads them
+  # recursively) while preserving operator notes and unrelated target files.
+  $CurrentDeployFiles = @(Get-DeploySourceFiles)
+  $RobocopyArguments = @(
+    $sourceDir,
+    $installDir,
+    "/E",
+    "/COPY:DAT",
+    "/DCOPY:DAT",
+    "/R:2",
+    "/W:1",
+    "/XJ",
+    "/XD",
+    ".git",
+    ".venv",
+    "node_modules",
+    "target",
+    "dist",
+    "release",
+    "release-local"
+  )
+  & robocopy @RobocopyArguments
+  $CopyExitCode = $LASTEXITCODE
+  if ($CopyExitCode -gt 7) { throw "robocopy failed with exit code $CopyExitCode." }
+  Update-DeployManifest $CurrentDeployFiles
+
+  $TrayStoppedForDeploy = $false
+  Push-Location $installDir
+  try {
+    # Tauri and Electron both update files held open by a running companion.
+    # Stop an opted-in tray before either the canonical installer's best-effort
+    # refresh or the strict verification below gets a chance to rebuild it.
+    if ($TrayWasInstalled) {
+      & node (Join-Path $installDir "src\tray-service.mjs") stop
+      $TrayStopExitCode = $LASTEXITCODE
+      if ($TrayStopExitCode -ne 0) {
+        throw "Stopping the installed tray failed with exit code $TrayStopExitCode."
+      }
+      $TrayStoppedForDeploy = $true
+    }
+
+    # This is the supported update transaction: dependency fingerprints,
+    # generated catalogs, client configuration, manifest, service health,
+    # managed skills, and the optional existing tray all stay in one path. It
+    # reads the current provider selection rather than replacing it.
+    & (Join-Path $installDir "install.ps1") -CheckoutInstall -Target codex
+    if (-not $?) { throw "The installed Codex Router update failed." }
+
+    & node (Join-Path $installDir "src\doctor.mjs")
+    $DoctorExitCode = $LASTEXITCODE
+    if ($DoctorExitCode -ne 0) {
+      throw "Codex Router doctor failed with exit code $DoctorExitCode."
+    }
+
+    if ($TrayWasInstalled) {
+      # install.ps1 deliberately treats the optional companion as best effort.
+      # This explicit working-tree deployment is stricter: re-run the installed
+      # wrapper, propagate a failed build/registration, then prove Task
+      # Scheduler points at the artifact selected by that wrapper.
+      $SavedRouterTarget = $env:MODEL_ROUTER_TARGET
+      try {
+        $env:MODEL_ROUTER_TARGET = "codex"
+        & powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File (Join-Path $installDir "codex-router.ps1") tray install
+        $TrayInstallExitCode = $LASTEXITCODE
+        if ($TrayInstallExitCode -ne 0) {
+          throw "Refreshing the installed tray failed with exit code $TrayInstallExitCode."
+        }
+      } finally {
+        $env:MODEL_ROUTER_TARGET = $SavedRouterTarget
+      }
+
+      $TrayStatus = Get-TrayStatus
+      if (-not $TrayStatus.installed -or -not $TrayStatus.loaded -or -not $TrayStatus.appPresent) {
+        throw "The refreshed tray is not installed, running, and present on disk."
+      }
+      $ExpectedTrayPath = if (Get-Command cargo -ErrorAction SilentlyContinue) {
+        Join-Path $installDir "apps\desktop\src-tauri\target\release\codex-router-desktop.exe"
+      } else {
+        Join-Path $installDir "apps\electron\node_modules\electron\dist\electron.exe"
+      }
+      $RegisteredTrayPath = [IO.Path]::GetFullPath([string]$TrayStatus.path)
+      if (-not [string]::Equals(
+        $RegisteredTrayPath,
+        [IO.Path]::GetFullPath($ExpectedTrayPath),
+        [StringComparison]::OrdinalIgnoreCase
+      )) {
+        throw "The refreshed tray registered an unexpected executable: $RegisteredTrayPath"
+      }
+      $TrayStoppedForDeploy = $false
+    }
+  } finally {
+    if ($TrayWasInstalled -and $TrayStoppedForDeploy) {
+      try {
+        & node (Join-Path $installDir "src\tray-service.mjs") start
+        if ($LASTEXITCODE -ne 0) {
+          Write-Warning "Deployment failed and the previous tray could not be restarted (exit $LASTEXITCODE)."
+        }
+      } catch {
+        Write-Warning "Deployment failed and the previous tray could not be restarted: $($_.Exception.Message)"
+      }
+    }
+    Pop-Location
+  }
+  Write-Host "Codex Router published, installed, and verified."
+}

--- a/deploy-codex-router.ps1
+++ b/deploy-codex-router.ps1
@@ -168,7 +168,21 @@ if ($PSCmdlet.ShouldProcess($installDir, "copy router source")) {
     "release",
     "release-local"
   )
-  & robocopy @RobocopyArguments
+  # From PowerShell 7.4, $PSNativeCommandUseErrorActionPreference defaults to
+  # true, so under $ErrorActionPreference = "Stop" a robocopy that copied files
+  # (exit 1 is normal success) would terminate before we could read its
+  # meaning -- the 0-7 convention below is exactly what this script has to
+  # honor. Disable it around the call only, then restore, so the rest of the
+  # script keeps its strict error semantics. On Windows PowerShell 5.1 the
+  # preference does not exist; saving it still yields $null and restoring $null
+  # changes nothing, so the call is left harmless there too.
+  $SavedNativeUseErrorActionPref = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+  try {
+    & robocopy @RobocopyArguments
+  } finally {
+    $PSNativeCommandUseErrorActionPreference = $SavedNativeUseErrorActionPref
+  }
   $CopyExitCode = $LASTEXITCODE
   if ($CopyExitCode -gt 7) { throw "robocopy failed with exit code $CopyExitCode." }
   Update-DeployManifest $CurrentDeployFiles

--- a/docs/DESKTOP-TRAY.md
+++ b/docs/DESKTOP-TRAY.md
@@ -208,6 +208,31 @@ not a clean exit, so the tray returns at the next logon rather than reappearing
 immediately. Linux has no supervisor — launch it with `./bin/model-router-tray`
 — and the tray commands say so instead of reporting a silent success.
 
+On Windows the same `Codex Router Tray` task is also managed directly through
+the checkout wrapper, which owns the build step (`tray` builds then registers,
+`companion` falls back to the Electron shell when Cargo is not available):
+
+```powershell
+.\codex-router.ps1 tray status          # JSON: installed, loaded, supported, state
+.\codex-router.ps1 tray start          # ask Task Scheduler to run it now
+.\codex-router.ps1 tray stop
+.\codex-router.ps1 tray restart
+.\codex-router.ps1 tray uninstall      # remove the scheduled task
+.\codex-router.ps1 tray rebuild        # stop, rebuild, then re-register
+.\codex-router.ps1 tray repair         # fix task permissions, then reinstall the companion
+```
+
+`tray repair` fixes a `Codex Router Tray` task the current user cannot
+otherwise modify — the catch-22 a router reinstall fails with when an earlier
+elevated install left the task readable but not writable. It validates the
+task's principal, its logon type, and that its action is a genuine companion
+(recognized by shape, so repairing from a dev checkout whose task points at
+`%LOCALAPPDATA%\codex-router` is allowed), then performs a UAC-elevated DACL
+repair and finishes by rebuilding or reinstalling the companion. If you only
+meant to fix permissions, expect that reinstall to follow. When Task Scheduler
+cannot answer at all, `tray status` prints a JSON document with `"state":
+"unknown"` rather than failing the command.
+
 Windows 11 hides new tray icons in the `^` overflow next to the clock. Drag the
 icon onto the taskbar to pin it; an unpinned icon is the most common reason the
 companion looks like it never started.

--- a/install.ps1
+++ b/install.ps1
@@ -245,6 +245,7 @@ $ServiceInstalled = $false
 $AdoptionPending = $false
 $ConfigWasEnabled = $false
 $ServiceWasInstalled = $false
+$TrayWasInstalled = $false
 Push-Location $ScriptDirectory
 
 # What this run found before it changed anything, so the catch block can undo
@@ -271,6 +272,7 @@ try {
     default { (Get-InstallerStateField @($ConfigManager, "status") "mode") -eq "router" }
   }
   $ServiceWasInstalled = (Get-InstallerStateField @("src\service.mjs", "status") "installed") -eq $true
+  $TrayWasInstalled = (Get-InstallerStateField @("src\tray-service.mjs", "status") "installed") -eq $true
   if ($Target -eq "codex") {
     $CodexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME ".codex" }
     New-Item -ItemType Directory -Force -Path $CodexHome | Out-Null
@@ -440,6 +442,47 @@ try {
   if ($LASTEXITCODE -ne 0) { throw "Install-manifest recording failed." }
   & node src/wait-health.mjs
   if ($LASTEXITCODE -ne 0) { throw "The router did not become healthy." }
+
+  # Keep an existing companion in step with the checkout, but never turn a
+  # fresh router install into a tray install the operator did not request.
+  # Run the wrapper in a child PowerShell process because its deliberate
+  # `exit` would otherwise terminate this installer before the status could be
+  # checked. This remains best effort, matching bin/install: an optional Rust
+  # or Electron build failure must not roll back a healthy router update.
+  if ($TrayWasInstalled) {
+    $SavedRouterTarget = $env:MODEL_ROUTER_TARGET
+    try {
+      # The tray belongs to the shared router plane. codex-router.ps1 is the
+      # Windows companion entry point and deliberately accepts only its Codex
+      # spelling, even when this update was initiated for DSH or Gemini CLI.
+      $env:MODEL_ROUTER_TARGET = "codex"
+      & powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File (Join-Path $ScriptDirectory "codex-router.ps1") tray install
+      $TrayExitCode = $LASTEXITCODE
+      if ($TrayExitCode -ne 0) {
+        Write-Warning "Desktop companion refresh failed with exit code $TrayExitCode; the router is installed. Run '.\codex-router.ps1 tray repair' if an earlier elevated install owns the task."
+      }
+    } catch {
+      Write-Warning "Desktop companion refresh failed; the router is installed: $($_.Exception.Message) Run '.\codex-router.ps1 tray repair' if an earlier elevated install owns the task."
+    } finally {
+      $env:MODEL_ROUTER_TARGET = $SavedRouterTarget
+    }
+  }
+
+  # Managed Codex skills are an integration convenience, not part of router
+  # health. Refresh them after the service transaction and keep a failure from
+  # entering the rollback path, exactly like the POSIX installer.
+  if ($Target -eq "codex") {
+    try {
+      & node src/skills-install.mjs install
+      $SkillsExitCode = $LASTEXITCODE
+      if ($SkillsExitCode -ne 0) {
+        Write-Warning "Managed Codex skills could not be refreshed (exit $SkillsExitCode); the router is installed."
+      }
+    } catch {
+      Write-Warning "Managed Codex skills could not be refreshed; the router is installed: $($_.Exception.Message)"
+    }
+  }
+
   if ($Target -eq "dsh") {
     Write-Host "Published the selected external model routes to DeepSeek Harness. It reloads them on the next request."
   } elseif ($Target -eq "gemini") {

--- a/restart-codex-router.ps1
+++ b/restart-codex-router.ps1
@@ -1,0 +1,26 @@
+[CmdletBinding()]
+param(
+  [string]$InstallDir = $(
+    if ($env:LOCALAPPDATA) { Join-Path $env:LOCALAPPDATA "codex-router" }
+    else { Join-Path $HOME ".local\share\codex-router" }
+  )
+)
+
+$ErrorActionPreference = "Stop"
+$routerRoot = [IO.Path]::GetFullPath($InstallDir)
+if (-not (Test-Path (Join-Path $routerRoot "src\service.mjs"))) {
+  throw "Installed Codex Router not found at $routerRoot."
+}
+Push-Location $routerRoot
+try {
+  Write-Host "Gracefully restarting Codex Router..."
+  & node (Join-Path $routerRoot "src\service.mjs") restart
+  $RestartExitCode = $LASTEXITCODE
+  if ($RestartExitCode -ne 0) {
+    throw "Codex Router restart failed with exit code $RestartExitCode."
+  }
+} finally {
+  Pop-Location
+}
+
+Write-Host "Codex Router is running."

--- a/src/tray-service-windows.mjs
+++ b/src/tray-service-windows.mjs
@@ -25,6 +25,11 @@ const renderCommands = new Set(["render", "render-task", "render-electron"]);
 // Resolved from the effective platform, not process.platform, so a render on
 // a POSIX machine shows the Windows path it would actually register.
 const TRAY_BINARY = desktopTrayBinary(effectivePlatform, SOURCE_ROOT);
+const TASK_STOP_TIMEOUT_MS = 10_000;
+const TASK_START_TIMEOUT_MS = 10_000;
+const TASK_STATE_POLL_MS = 250;
+const TASK_COMMAND_TIMEOUT_MS = 4_000;
+const TASK_FULL_CONTROL_MASK = 0x1f01ff;
 
 if (effectivePlatform !== "win32" && !renderCommands.has(command)) {
   throw new Error("The Task Scheduler tray manager runs on Windows only.");
@@ -35,6 +40,7 @@ function schtasks(args, options = {}) {
     encoding: "utf8",
     windowsHide: true,
     stdio: options.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "pipe", "pipe"],
+    timeout: options.timeoutMs || TASK_COMMAND_TIMEOUT_MS,
   });
 }
 
@@ -57,6 +63,7 @@ export function electronTaskAction() {
 // the same conditional-KeepAlive intent the macOS agent spells out.
 function installTask(action = trayTaskAction()) {
   const script = [
+    "$principalSid = ([Security.Principal.WindowsIdentity]::GetCurrent().User.Value)",
     // Only passed when there is one: `-Argument ""` registers an empty
     // argument rather than none, which the Tauri binary must never receive.
     action.argument
@@ -66,58 +73,136 @@ function installTask(action = trayTaskAction()) {
     "$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew",
     "$principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited",
     "Register-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_TASK -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Force | Out-Null",
+    // An elevated install otherwise leaves the unelevated account with only
+    // read/run access to its own tray task. Preserve Task Scheduler's existing
+    // descriptor and add one explicit full-control ACE for the task principal,
+    // so later updates neither need elevation nor rewrite SYSTEM/Admin rights.
+    "$service = New-Object -ComObject 'Schedule.Service'",
+    "$service.Connect()",
+    "$registered = $service.GetFolder('\\').GetTask($env:CODEX_ROUTER_TRAY_TASK)",
+    "$descriptor = [Security.AccessControl.RawSecurityDescriptor]::new($registered.GetSecurityDescriptor(7))",
+    "$sid = [Security.Principal.SecurityIdentifier]::new($principalSid)",
+    `$fullControl = ${TASK_FULL_CONTROL_MASK}`,
+    "$hasFullControl = $false",
+    "foreach ($ace in $descriptor.DiscretionaryAcl) { if ($ace -is [Security.AccessControl.CommonAce] -and $ace.AceQualifier -eq [Security.AccessControl.AceQualifier]::AccessAllowed -and $ace.SecurityIdentifier.Value -eq $sid.Value -and ($ace.AccessMask -band $fullControl) -eq $fullControl) { $hasFullControl = $true; break } }",
+    "if (-not $hasFullControl) { $newAce = [Security.AccessControl.CommonAce]::new([Security.AccessControl.AceFlags]::None, [Security.AccessControl.AceQualifier]::AccessAllowed, $fullControl, $sid, $false, $null); $descriptor.DiscretionaryAcl.InsertAce($descriptor.DiscretionaryAcl.Count, $newAce); $sections = [Security.AccessControl.AccessControlSections]::Owner -bor [Security.AccessControl.AccessControlSections]::Group -bor [Security.AccessControl.AccessControlSections]::Access; $registered.SetSecurityDescriptor($descriptor.GetSddlForm($sections), 0x10) }",
   ].join("; ");
-  execFileSync(
-    "powershell.exe",
-    ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
-    {
-      env: {
-        ...process.env,
-        CODEX_ROUTER_TRAY_TASK: TRAY_TASK_NAME,
-        CODEX_ROUTER_TRAY_EXECUTE: action.execute,
-        CODEX_ROUTER_TRAY_ARGUMENT: action.argument,
+  try {
+    execFileSync(
+      "powershell.exe",
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_ROUTER_TRAY_TASK: TRAY_TASK_NAME,
+          CODEX_ROUTER_TRAY_EXECUTE: action.execute,
+          CODEX_ROUTER_TRAY_ARGUMENT: action.argument,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+        windowsHide: true,
+        timeout: TASK_COMMAND_TIMEOUT_MS,
       },
-      stdio: ["ignore", "ignore", "ignore"],
-      windowsHide: true,
-    },
-  );
+    );
+  } catch (error) {
+    const detail = String(error?.stderr || "").trim();
+    throw new Error(
+      "Task Scheduler could not replace the tray task. " +
+        "If an earlier elevated install owns it, run `.\\codex-router.ps1 tray repair` once." +
+        (detail ? ` ${detail}` : ""),
+      { cause: error },
+    );
+  }
 }
 
-function taskExists() {
+function taskExists(timeoutMs = TASK_COMMAND_TIMEOUT_MS) {
   try {
-    schtasks(["/Query", "/TN", TRAY_TASK_NAME], { quiet: true });
+    schtasks(["/Query", "/TN", TRAY_TASK_NAME], { quiet: true, timeoutMs });
     return true;
   } catch {
     return false;
   }
 }
 
-function taskRunning() {
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function taskState(timeoutMs = TASK_COMMAND_TIMEOUT_MS) {
   // `schtasks` output is localized ("En ejecución" on Spanish Windows), so a
   // regex on its text reads a running task as stopped. Task Scheduler's own
   // State property is an enum that renders the same in every locale.
   const script =
     "try { [Console]::Out.Write((Get-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_TASK).State.ToString()) } catch { exit 1 }";
+  const perHostTimeout = Math.max(50, Math.floor(timeoutMs / 2));
   for (const executable of ["powershell.exe", "pwsh.exe"]) {
     try {
-      return (
-        execFileSync(
-          executable,
-          ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
-          {
-            encoding: "utf8",
-            env: { ...process.env, CODEX_ROUTER_TRAY_TASK: TRAY_TASK_NAME },
-            stdio: ["ignore", "pipe", "ignore"],
-          },
-        )
-          .trim()
-          .toLowerCase() === "running"
-      );
+      return execFileSync(
+        executable,
+        ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        {
+          encoding: "utf8",
+          env: { ...process.env, CODEX_ROUTER_TRAY_TASK: TRAY_TASK_NAME },
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: perHostTimeout,
+          windowsHide: true,
+        },
+      ).trim().toLowerCase();
     } catch {
-      // Try Windows PowerShell after PowerShell Core, or fall back to schtasks.
+      // Try the other PowerShell host. A missing task is handled by taskExists.
     }
   }
-  return false;
+  return undefined;
+}
+
+function registeredTaskAction() {
+  const script = [
+    "$task = Get-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_TASK -ErrorAction Stop",
+    "$action = @($task.Actions)[0]",
+    "if ($null -eq $action) { exit 1 }",
+    "[Console]::Out.Write((@{ execute = [string]$action.Execute; argument = [string]$action.Arguments } | ConvertTo-Json -Compress))",
+  ].join("; ");
+  const perHostTimeout = Math.floor(TASK_COMMAND_TIMEOUT_MS / 2);
+  for (const executable of ["powershell.exe", "pwsh.exe"]) {
+    try {
+      const value = JSON.parse(execFileSync(
+        executable,
+        ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        {
+          encoding: "utf8",
+          env: { ...process.env, CODEX_ROUTER_TRAY_TASK: TRAY_TASK_NAME },
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: perHostTimeout,
+          windowsHide: true,
+        },
+      ));
+      if (typeof value?.execute === "string" && value.execute) return value;
+    } catch {
+      // Try the other PowerShell host before reporting an unreadable action.
+    }
+  }
+  return undefined;
+}
+
+function waitForTaskState(predicate, timeoutMs, action) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error(`The tray task did not ${action} within ${timeoutMs}ms.`);
+    }
+    const probeTimeout = Math.min(TASK_COMMAND_TIMEOUT_MS, remaining);
+    const state = taskState(probeTimeout);
+    if (state !== undefined && predicate(state)) return state;
+    if (state === undefined && !taskExists(Math.min(TASK_COMMAND_TIMEOUT_MS, Math.max(50, deadline - Date.now())))) {
+      if (action === "stop") return "missing";
+      throw new Error(`The tray task disappeared while waiting for it to ${action}.`);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`The tray task did not ${action} within ${timeoutMs}ms.`);
+    }
+    sleep(TASK_STATE_POLL_MS);
+  }
 }
 
 function endTask() {
@@ -126,6 +211,12 @@ function endTask() {
   } catch {
     // Missing or already idle: the state the caller asked for either way.
   }
+  waitForTaskState((state) => state !== "running", TASK_STOP_TIMEOUT_MS, "stop");
+}
+
+function startTask() {
+  schtasks(["/Run", "/TN", TRAY_TASK_NAME], { quiet: true });
+  waitForTaskState((state) => state === "running", TASK_START_TIMEOUT_MS, "start");
 }
 
 function requireBuiltTray() {
@@ -201,34 +292,48 @@ if (command === "render" || command === "render-task") {
   requireBuiltElectron();
   endTask();
   installTask(electronTaskAction());
-  schtasks(["/Run", "/TN", TRAY_TASK_NAME], { quiet: true });
+  startTask();
   process.stdout.write(
     `${JSON.stringify({ installed: true, ...electronTaskAction() })}\n`,
   );
 } else if (command === "status") {
   const installed = taskExists();
+  const taskStatus = installed ? taskState() : undefined;
+  const action = installed ? registeredTaskAction() : undefined;
+  const companionPath = action?.execute || (!installed ? builtCompanionPath() : undefined);
+  const loaded = installed && taskStatus === "running";
   process.stdout.write(
     `${JSON.stringify({
       installed,
       supported: true,
-      loaded: installed && taskRunning(),
-      appPresent: builtCompanionExists(),
-      state: installed && taskRunning() ? "running" : "stopped",
-      path: builtCompanionPath(),
+      loaded,
+      appPresent: Boolean(companionPath && existsSync(companionPath)),
+      state: loaded ? "running" : "stopped",
+      path: companionPath,
     })}\n`,
   );
 } else if (command === "install") {
   requireBuiltTray();
   endTask();
   installTask();
-  schtasks(["/Run", "/TN", TRAY_TASK_NAME], { quiet: true });
+  startTask();
   process.stdout.write(`${JSON.stringify({ installed: true, path: TRAY_BINARY })}\n`);
 } else if (command === "uninstall") {
   endTask();
   try {
     schtasks(["/Delete", "/TN", TRAY_TASK_NAME, "/F"], { quiet: true });
-  } catch {
-    // The task may not exist.
+  } catch (error) {
+    // Missing is already the requested state. A task that still exists means
+    // Task Scheduler rejected the deletion, which must not be reported as a
+    // successful uninstall.
+    if (taskExists()) {
+      const failure = new Error("Task Scheduler did not remove the tray task.");
+      failure.cause = error;
+      throw failure;
+    }
+  }
+  if (taskExists()) {
+    throw new Error("Task Scheduler still reports the tray task after deletion.");
   }
   process.stdout.write(`${JSON.stringify({ installed: false })}\n`);
 } else if (command === "stop") {
@@ -242,6 +347,6 @@ if (command === "render" || command === "render-task") {
     throw new Error(`The tray task is not installed. Run: control tray enable`);
   }
   if (command === "restart") endTask();
-  schtasks(["/Run", "/TN", TRAY_TASK_NAME], { quiet: true });
+  startTask();
   process.stdout.write(`${JSON.stringify({ state: "running" })}\n`);
 }

--- a/src/tray-service-windows.mjs
+++ b/src/tray-service-windows.mjs
@@ -115,13 +115,45 @@ function installTask(action = trayTaskAction()) {
   }
 }
 
+// Tri-state: "exists" | "missing" | "error". The boolean answer cannot
+// distinguish "not installed" from "Task Scheduler itself would not say".
+// `schtasks` names a missing task with a *localized* line ("ERROR: The system
+// cannot find the file specified."), so its text cannot be classified the way
+// callers need -- but Get-ScheduledTask reports the miss with a
+// culture-invariant FullyQualifiedErrorId. A timeout, access-denied, or
+// scheduler-down outcome raises that ID to a different value and is reported
+// as "error", never as a missing task.
 function taskExists(timeoutMs = TASK_COMMAND_TIMEOUT_MS) {
-  try {
-    schtasks(["/Query", "/TN", TRAY_TASK_NAME], { quiet: true, timeoutMs });
-    return true;
-  } catch {
-    return false;
+  const script = [
+    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
+    'try { Get-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_TASK -ErrorAction Stop | Out-Null; "[exists]" } catch { if ($_.FullyQualifiedErrorId -like "CmdletizationQuery_NotFound_TaskName,*") { "[missing]" } else { "[error]" } }',
+  ].join("; ");
+  const perHostTimeout = Math.max(50, Math.floor(timeoutMs / 2));
+  // 5.1 and 7 can disagree about the current user's task reads, so both hosts
+  // are consulted before a host-level failure is reported as indeterminate.
+  let sawError = false;
+  for (const executable of ["powershell.exe", "pwsh.exe"]) {
+    try {
+      const value = execFileSync(
+        executable,
+        ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        {
+          encoding: "utf8",
+          env: { ...process.env, CODEX_ROUTER_TRAY_TASK: TRAY_TASK_NAME },
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: perHostTimeout,
+          windowsHide: true,
+        },
+      ).trim().toLowerCase();
+      if (value === "[exists]") return "exists";
+      if (value === "[missing]") return "missing";
+      sawError = true;
+    } catch {
+      // A non-answering host is indeterminate, not evidence of an absent task.
+      sawError = true;
+    }
   }
+  return sawError ? "error" : "missing";
 }
 
 function sleep(milliseconds) {
@@ -132,8 +164,12 @@ function taskState(timeoutMs = TASK_COMMAND_TIMEOUT_MS) {
   // `schtasks` output is localized ("En ejecución" on Spanish Windows), so a
   // regex on its text reads a running task as stopped. Task Scheduler's own
   // State property is an enum that renders the same in every locale.
+  // PowerShell 5.1 writes `[Console]::Out` in the OEM console encoding, so a
+  // Task Name that contains non-ASCII bytes would corrupt stdout before Node
+  // decodes it as UTF-8. Pin the child's output encoding so the JSON/text we
+  // parse actually round-trips.
   const script =
-    "try { [Console]::Out.Write((Get-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_TASK).State.ToString()) } catch { exit 1 }";
+    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; try { [Console]::Out.Write((Get-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_TASK).State.ToString()) } catch { exit 1 }";
   const perHostTimeout = Math.max(50, Math.floor(timeoutMs / 2));
   for (const executable of ["powershell.exe", "pwsh.exe"]) {
     try {
@@ -157,6 +193,7 @@ function taskState(timeoutMs = TASK_COMMAND_TIMEOUT_MS) {
 
 function registeredTaskAction() {
   const script = [
+    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8",
     "$task = Get-ScheduledTask -TaskName $env:CODEX_ROUTER_TRAY_TASK -ErrorAction Stop",
     "$action = @($task.Actions)[0]",
     "if ($null -eq $action) { exit 1 }",
@@ -194,9 +231,18 @@ function waitForTaskState(predicate, timeoutMs, action) {
     const probeTimeout = Math.min(TASK_COMMAND_TIMEOUT_MS, remaining);
     const state = taskState(probeTimeout);
     if (state !== undefined && predicate(state)) return state;
-    if (state === undefined && !taskExists(Math.min(TASK_COMMAND_TIMEOUT_MS, Math.max(50, deadline - Date.now())))) {
-      if (action === "stop") return "missing";
-      throw new Error(`The tray task disappeared while waiting for it to ${action}.`);
+    if (state === undefined) {
+      const existence = taskExists(Math.min(TASK_COMMAND_TIMEOUT_MS, Math.max(50, deadline - Date.now())));
+      if (existence === "missing") {
+        if (action === "stop") return "missing";
+        throw new Error(`The tray task disappeared while waiting for it to ${action}.`);
+      }
+      if (existence === "error") {
+        // An unreadable scheduler is not a missing task: a stop would return
+        // early on a task that is still there, and an uninstall would report
+        // success it did not earn.
+        throw new Error(`Task Scheduler did not answer while waiting for the tray to ${action}.`);
+      }
     }
     if (Date.now() >= deadline) {
       throw new Error(`The tray task did not ${action} within ${timeoutMs}ms.`);
@@ -297,7 +343,14 @@ if (command === "render" || command === "render-task") {
     `${JSON.stringify({ installed: true, ...electronTaskAction() })}\n`,
   );
 } else if (command === "status") {
-  const installed = taskExists();
+  const existence = taskExists();
+  if (existence === "error") {
+    // An indeterminate scheduler answer must not read as absence: deploy
+    // verification would reject a healthy tray, and the operator sees
+    // "appPresent:false" for a binary that is present. Surface it honestly.
+    throw new Error("Task Scheduler did not answer whether the tray task is registered.");
+  }
+  const installed = existence === "exists";
   const taskStatus = installed ? taskState() : undefined;
   const action = installed ? registeredTaskAction() : undefined;
   const companionPath = action?.execute || (!installed ? builtCompanionPath() : undefined);
@@ -326,14 +379,18 @@ if (command === "render" || command === "render-task") {
     // Missing is already the requested state. A task that still exists means
     // Task Scheduler rejected the deletion, which must not be reported as a
     // successful uninstall.
-    if (taskExists()) {
+    if (taskExists() === "exists") {
       const failure = new Error("Task Scheduler did not remove the tray task.");
       failure.cause = error;
       throw failure;
     }
   }
-  if (taskExists()) {
+  const existence = taskExists();
+  if (existence === "exists") {
     throw new Error("Task Scheduler still reports the tray task after deletion.");
+  }
+  if (existence === "error") {
+    throw new Error("Task Scheduler did not answer whether the tray task was removed.");
   }
   process.stdout.write(`${JSON.stringify({ installed: false })}\n`);
 } else if (command === "stop") {
@@ -343,8 +400,12 @@ if (command === "render" || command === "render-task") {
   // start and restart. A tray that was quit by hand is not running, so both
   // reduce to asking Task Scheduler for a fresh instance.
   requireBuiltCompanion();
-  if (!taskExists()) {
+  const existence = taskExists();
+  if (existence === "missing") {
     throw new Error(`The tray task is not installed. Run: control tray enable`);
+  }
+  if (existence === "error") {
+    throw new Error("Task Scheduler did not answer whether the tray task is registered.");
   }
   if (command === "restart") endTask();
   startTask();

--- a/src/tray-service-windows.mjs
+++ b/src/tray-service-windows.mjs
@@ -12,6 +12,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 
 import { SOURCE_ROOT, TRAY_TASK_NAME } from "./paths.mjs";
+import { skipServiceManagerCall } from "./service-write-guard.mjs";
 import {
   desktopTrayBinary,
   electronBinary,
@@ -28,14 +29,29 @@ const TRAY_BINARY = desktopTrayBinary(effectivePlatform, SOURCE_ROOT);
 const TASK_STOP_TIMEOUT_MS = 10_000;
 const TASK_START_TIMEOUT_MS = 10_000;
 const TASK_STATE_POLL_MS = 250;
-const TASK_COMMAND_TIMEOUT_MS = 4_000;
+// Matches service-windows.mjs's TASK_STATE_TIMEOUT_MS (15s) for the identical
+// call. A cold powershell.exe running the ScheduledTasks CDXML cmdlets is
+// routinely 1.5-3s and slower under install load or on a domain; a stricter
+// budget made a single slow Get-ScheduledTask abort install/start/restart.
+// The per-host split below keeps either PowerShell host's share of the budget.
+const TASK_COMMAND_TIMEOUT_MS = 15_000;
 const TASK_FULL_CONTROL_MASK = 0x1f01ff;
+
+// Task Scheduler mutations must never run from a test run on a Windows dev
+// box (a stray `npm test` would otherwise register/start a real tray task and
+// rewrite its DACL). Reads stay live, so status still answers truthfully.
+const HOST_MANAGED = process.platform === "win32";
 
 if (effectivePlatform !== "win32" && !renderCommands.has(command)) {
   throw new Error("The Task Scheduler tray manager runs on Windows only.");
 }
 
 function schtasks(args, options = {}) {
+  // Only mutable calls consult the guard; queries stay live so status can
+  // still report whether the named task exists.
+  if (options.mutating && skipServiceManagerCall({ hostManaged: HOST_MANAGED })) {
+    return "";
+  }
   return execFileSync("schtasks.exe", args, {
     encoding: "utf8",
     windowsHide: true,
@@ -62,6 +78,10 @@ export function electronTaskAction() {
 // exit as the task finishing, so quitting stays quit until the next logon --
 // the same conditional-KeepAlive intent the macOS agent spells out.
 function installTask(action = trayTaskAction()) {
+  // Register-ScheduledTask is a second Task Scheduler path, independent of
+  // schtasks(). Keep it behind the same mutation guard so a test run cannot
+  // register or replace the developer's real task.
+  if (skipServiceManagerCall({ hostManaged: HOST_MANAGED })) return;
   const script = [
     "$principalSid = ([Security.Principal.WindowsIdentity]::GetCurrent().User.Value)",
     // Only passed when there is one: `-Argument ""` registers an empty
@@ -252,8 +272,12 @@ function waitForTaskState(predicate, timeoutMs, action) {
 }
 
 function endTask() {
+  // A skipped `/End` (test run) means no mutation happened, so there is
+  // nothing to wait for -- polling an absent host would spend the full
+  // deadline on a question that cannot be answered.
+  if (skipServiceManagerCall({ hostManaged: HOST_MANAGED })) return;
   try {
-    schtasks(["/End", "/TN", TRAY_TASK_NAME], { quiet: true });
+    schtasks(["/End", "/TN", TRAY_TASK_NAME], { quiet: true, mutating: true });
   } catch {
     // Missing or already idle: the state the caller asked for either way.
   }
@@ -261,7 +285,8 @@ function endTask() {
 }
 
 function startTask() {
-  schtasks(["/Run", "/TN", TRAY_TASK_NAME], { quiet: true });
+  if (skipServiceManagerCall({ hostManaged: HOST_MANAGED })) return;
+  schtasks(["/Run", "/TN", TRAY_TASK_NAME], { quiet: true, mutating: true });
   waitForTaskState((state) => state === "running", TASK_START_TIMEOUT_MS, "start");
 }
 
@@ -345,26 +370,41 @@ if (command === "render" || command === "render-task") {
 } else if (command === "status") {
   const existence = taskExists();
   if (existence === "error") {
-    // An indeterminate scheduler answer must not read as absence: deploy
-    // verification would reject a healthy tray, and the operator sees
-    // "appPresent:false" for a binary that is present. Surface it honestly.
-    throw new Error("Task Scheduler did not answer whether the tray task is registered.");
+    // An indeterminate scheduler answer must not read as either success or a
+    // missing task. `status` cannot refuse here: a non-zero exit broke callers
+    // that parse its JSON (and made the Windows-dispatch test pass vacuously on
+    // empty stdout). Emit a tri-state document instead: installed is not
+    // asserted, and the distinct "unknown" state plus `why` surface the
+    // unreadable scheduler honestly.
+    const companionPath = builtCompanionPath();
+    process.stdout.write(
+      `${JSON.stringify({
+        installed: false,
+        supported: true,
+        loaded: false,
+        appPresent: Boolean(companionPath && existsSync(companionPath)),
+        state: "unknown",
+        path: companionPath,
+        why: "Task Scheduler did not answer whether the tray task is registered.",
+      })}\n`,
+    );
+  } else {
+    const installed = existence === "exists";
+    const taskStatus = installed ? taskState() : undefined;
+    const action = installed ? registeredTaskAction() : undefined;
+    const companionPath = action?.execute || (!installed ? builtCompanionPath() : undefined);
+    const loaded = installed && taskStatus === "running";
+    process.stdout.write(
+      `${JSON.stringify({
+        installed,
+        supported: true,
+        loaded,
+        appPresent: Boolean(companionPath && existsSync(companionPath)),
+        state: loaded ? "running" : "stopped",
+        path: companionPath,
+      })}\n`,
+    );
   }
-  const installed = existence === "exists";
-  const taskStatus = installed ? taskState() : undefined;
-  const action = installed ? registeredTaskAction() : undefined;
-  const companionPath = action?.execute || (!installed ? builtCompanionPath() : undefined);
-  const loaded = installed && taskStatus === "running";
-  process.stdout.write(
-    `${JSON.stringify({
-      installed,
-      supported: true,
-      loaded,
-      appPresent: Boolean(companionPath && existsSync(companionPath)),
-      state: loaded ? "running" : "stopped",
-      path: companionPath,
-    })}\n`,
-  );
 } else if (command === "install") {
   requireBuiltTray();
   endTask();
@@ -372,9 +412,17 @@ if (command === "render" || command === "render-task") {
   startTask();
   process.stdout.write(`${JSON.stringify({ installed: true, path: TRAY_BINARY })}\n`);
 } else if (command === "uninstall") {
-  endTask();
+  // A scheduler that cannot answer a stop must not block the real uninstall:
+  // endTask failing here only means the wait could not be satisfied, and the
+  // deletion below -- plus the verification that follows -- is what decides
+  // whether the task is actually gone.
   try {
-    schtasks(["/Delete", "/TN", TRAY_TASK_NAME, "/F"], { quiet: true });
+    endTask();
+  } catch {
+    // Best effort stop; continue to the /Delete attempt.
+  }
+  try {
+    schtasks(["/Delete", "/TN", TRAY_TASK_NAME, "/F"], { quiet: true, mutating: true });
   } catch (error) {
     // Missing is already the requested state. A task that still exists means
     // Task Scheduler rejected the deletion, which must not be reported as a

--- a/test/tray-service-windows.test.mjs
+++ b/test/tray-service-windows.test.mjs
@@ -81,6 +81,49 @@ test("the dispatcher routes Windows to the Task Scheduler manager", () => {
   assert.doesNotMatch(result.stdout, /"supported":false/);
 });
 
+test("tray restarts wait for Task Scheduler to stop before starting again", () => {
+  const source = readFileSync(path.join(root, "src", "tray-service-windows.mjs"), "utf8");
+  assert.match(source, /function waitForTaskState\(/);
+  assert.match(source, /timeout: options\.timeoutMs \|\| TASK_COMMAND_TIMEOUT_MS/);
+  assert.match(source, /const probeTimeout = Math\.min\(TASK_COMMAND_TIMEOUT_MS, remaining\)/);
+  assert.match(source, /Register-ScheduledTask[\s\S]*?timeout: TASK_COMMAND_TIMEOUT_MS/);
+  assert.match(source, /endTask\(\)[\s\S]*?waitForTaskState\([^\n]+TASK_STOP_TIMEOUT_MS/);
+  assert.match(source, /function startTask\(\)[\s\S]*?waitForTaskState\([^\n]+TASK_START_TIMEOUT_MS/);
+  assert.doesNotMatch(source, /if \(command === "restart"\) endTask\(\);\s*\n\s*schtasks\(\["\/Run"/);
+});
+
+test("tray uninstall verifies that Task Scheduler removed the task", () => {
+  const source = readFileSync(path.join(root, "src", "tray-service-windows.mjs"), "utf8");
+  const uninstall = source.slice(
+    source.indexOf('command === "uninstall"'),
+    source.indexOf('command === "stop"'),
+  );
+  assert.match(uninstall, /schtasks\(\["\/Delete"/);
+  assert.match(uninstall, /if \(taskExists\(\)\)[\s\S]*?throw/);
+  assert.doesNotMatch(uninstall, /catch \{\s*\/\/ The task may not exist/);
+});
+
+test("tray status reports the registered action and reads task state once", () => {
+  const source = readFileSync(path.join(root, "src", "tray-service-windows.mjs"), "utf8");
+  assert.match(source, /function registeredTaskAction\(/);
+  assert.match(source, /const action = installed \? registeredTaskAction\(\) : undefined/);
+  assert.match(source, /const companionPath = action\?\.execute/);
+  assert.match(source, /const taskStatus = installed \? taskState\(\) : undefined/);
+  assert.doesNotMatch(source, /loaded: installed && taskRunning\(\)/);
+});
+
+test("tray registration leaves its interactive principal able to update the task", () => {
+  const source = readFileSync(path.join(root, "src", "tray-service-windows.mjs"), "utf8");
+  assert.match(source, /WindowsIdentity\]\:\:GetCurrent\(\)\.User\.Value/);
+  assert.match(source, /GetSecurityDescriptor\(7\)/);
+  assert.match(source, /RawSecurityDescriptor/);
+  assert.match(source, /TASK_FULL_CONTROL_MASK\s*=\s*0x1f01ff/);
+  assert.match(source, /DiscretionaryAcl\.InsertAce/);
+  assert.match(source, /SetSecurityDescriptor\([^\n]+0x10\)/);
+  assert.match(source, /earlier elevated install owns it[\s\S]*?tray repair/);
+  assert.doesNotMatch(source, /icacls|takeown/i);
+});
+
 test("a platform with no supervisor says so instead of reporting success", () => {
   const result = trayDispatch("install", "linux");
   assert.equal(result.status, 0, "an install must not fail over an unsupervised companion");
@@ -107,6 +150,31 @@ test("the Windows CLI exposes tray as a first-class command", () => {
   for (const action of ["install", "status", "start", "stop", "restart", "uninstall"]) {
     assert.ok(script.includes(`"${action}"`), `tray action ${action} is unreachable`);
   }
+});
+
+test("tray rebuild registers the artifact it just built", () => {
+  const script = readFileSync(path.join(root, "codex-router.ps1"), "utf8");
+  const rebuild = script.slice(
+    script.indexOf('if ($Action -eq "rebuild")'),
+    script.indexOf('if ($Action -eq "install" -and'),
+  );
+  assert.match(rebuild, /tray-service\.mjs" @\("install"\)/);
+  assert.match(rebuild, /tray-service\.mjs" @\("install-electron"\)/);
+  assert.doesNotMatch(rebuild, /tray-service\.mjs" @\("restart"\)/);
+});
+
+test("tray repair validates the task and grants only its current principal control", () => {
+  const script = readFileSync(path.join(root, "codex-router.ps1"), "utf8");
+  assert.match(script, /"repair"/);
+  assert.match(script, /function Get-ValidatedTrayTask/);
+  assert.match(script, /principal is not the current user/);
+  assert.match(script, /action is not this checkout's tray companion/);
+  assert.match(script, /CODEX_ROUTER_TRAY_REPAIR_SID/);
+  assert.match(script, /RawSecurityDescriptor/);
+  assert.match(script, /SetSecurityDescriptor\([^\n]+0x10\)/);
+  assert.match(script, /Start-Process[^\n]+-Verb RunAs[^\n]+-Wait[^\n]+-WindowStyle Hidden/);
+  assert.match(script, /if \(-not \(Test-TrayTaskFullControl/);
+  assert.doesNotMatch(script, /icacls|takeown/i);
 });
 
 test("the POSIX tray launcher points Windows at that command", () => {

--- a/test/tray-service-windows.test.mjs
+++ b/test/tray-service-windows.test.mjs
@@ -104,6 +104,16 @@ test("tray uninstall verifies that Task Scheduler removed the task", () => {
   assert.match(uninstall, /if \(taskExists\(\) === "exists"\)[\s\S]*?throw/);
   assert.match(uninstall, /if \(existence === "error"\)[\s\S]*?did not answer whether the tray task was removed/);
   assert.doesNotMatch(uninstall, /catch \{\s*\/\/ The task may not exist/);
+  // endTask() can throw when the scheduler is unreadable; that must not block
+  // the /Delete attempt that is the actual uninstall.
+  assert.match(uninstall, /catch \{[\s\S]*?Best effort stop/);
+  const endTaskTry = uninstall.indexOf("try {");
+  const endTaskCall = uninstall.indexOf("endTask()");
+  const deleteCall = uninstall.indexOf('schtasks(["/Delete"');
+  assert.ok(
+    endTaskTry >= 0 && endTaskCall > endTaskTry && endTaskCall < deleteCall,
+    "endTask must be isolated so /Delete always runs",
+  );
 });
 
 test("task query returns a tri-state answer, not a silent false", () => {
@@ -145,6 +155,46 @@ test("tray status reports the registered action and reads task state once", () =
   assert.match(source, /const companionPath = action\?\.execute/);
   assert.match(source, /const taskStatus = installed \? taskState\(\) : undefined/);
   assert.doesNotMatch(source, /loaded: installed && taskRunning\(\)/);
+});
+
+test("status stays a JSON exit-0 document when Task Scheduler is unreadable", () => {
+  // With no scheduler hosts reachable (empty PATH forces both PowerShell
+  // hosts to fail), taskExists() returns "error" and status must print
+  // parseable JSON and exit 0. It used to throw, which emptied stdout and
+  // broke every caller that parses status JSON.
+  const result = trayService("status", { env: { PATH: "" } });
+  assert.equal(result.status, 0, result.stderr);
+  const doc = JSON.parse(result.stdout);
+  assert.equal(doc.supported, true);
+  assert.equal(doc.state, "unknown");
+  assert.equal(doc.loaded, false);
+  assert.match(result.stdout, /"why":/);
+});
+
+test("tray mutations are guarded so a test run never touches the scheduler", () => {
+  const source = readFileSync(path.join(root, "src", "tray-service-windows.mjs"), "utf8");
+  assert.match(source, /skipServiceManagerCall/);
+  assert.match(source, /const HOST_MANAGED = process\.platform === "win32"/);
+  // Queries stay live while every scheduler mutation consults the guard.
+  assert.match(source, /if \(options\.mutating && skipServiceManagerCall/);
+  assert.match(source, /function installTask\([\s\S]*?skipServiceManagerCall/);
+  assert.match(source, /function endTask\(\)[\s\S]*?skipServiceManagerCall/);
+  assert.match(source, /function startTask\(\)[\s\S]*?skipServiceManagerCall/);
+  // /End, /Run and /Delete are the three direct writes through schtasks; all
+  // three must be marked mutating so the guard can skip them under test.
+  assert.match(source, /\/End"[\s\S]*?mutating: true/);
+  assert.match(source, /\/Run"[\s\S]*?mutating: true/);
+  assert.match(source, /\/Delete"[\s\S]*?mutating: true/);
+});
+
+test("tray Task Scheduler timeouts match service-windows.mjs's single larger value", () => {
+  const source = readFileSync(path.join(root, "src", "tray-service-windows.mjs"), "utf8");
+  assert.match(source, /const TASK_COMMAND_TIMEOUT_MS = 15_000;/);
+  // The windows service manager uses 15_000 for the identical Get-ScheduledTask
+  // read, so the tray must not abort install/start/restart/uninstall on a slow
+  // cold-start powershell the way a 4 s budget did. The per-host split still
+  // keeps each PowerShell host within its share.
+  assert.match(source, /const perHostTimeout = Math\.max\(50, Math\.floor\(timeoutMs \/ 2\)\)/);
 });
 
 test("tray registration leaves its interactive principal able to update the task", () => {
@@ -230,11 +280,27 @@ test("tray repair validates the task and grants only its current principal contr
   assert.match(script, /"repair"/);
   assert.match(script, /function Get-ValidatedTrayTask/);
   assert.match(script, /principal is not the current user/);
-  assert.match(script, /action is not this checkout's tray companion/);
-  assert.match(script, /CODEX_ROUTER_TRAY_REPAIR_SID/);
+  // A task registered from another checkout must still be recognized by shape,
+  // so a dev user whose task points at %LOCALAPPDATA% is not rejected.
+  assert.doesNotMatch(script, /this checkout's tray companion/);
+  assert.match(script, /not a Codex Router tray companion/);
   assert.match(script, /RawSecurityDescriptor/);
   assert.match(script, /SetSecurityDescriptor\([^\n]+0x10\)/);
+  // The elevated PowerShell host must be named absolutely so ShellExecuteEx
+  // cannot resolve a CWD/PATH shadow, and the working directory pinned to
+  // SystemRoot so the elevated child runs from an unwritable directory.
+  assert.match(script, /System32\\WindowsPowerShell\\v1\.0\\powershell\.exe/);
+  assert.match(script, /Start-Process[^\n]+-FilePath \$ElevatedPowerShell/);
   assert.match(script, /Start-Process[^\n]+-Verb RunAs[^\n]+-Wait[^\n]+-WindowStyle Hidden/);
+  assert.match(script, /-WorkingDirectory \$env:SystemRoot/);
+  assert.doesNotMatch(script, /Start-Process[^\n]+\-FilePath "powershell\.exe"/);
+  // The validated values travel inside the -EncodedCommand payload, not the
+  // process environment: env vars do not survive ShellExecuteEx ->
+  // CreateProcessAsUser, so the elevated side must not read them.
+  assert.doesNotMatch(script, /CODEX_ROUTER_TRAY_REPAIR_TASK/);
+  assert.match(script, /ConvertTo-RepairLiteral/);
+  assert.match(script, /__TRAY_EXECUTE__/);
+  assert.match(script, /-EncodedCommand/);
   assert.match(script, /if \(-not \(Test-TrayTaskFullControl/);
   assert.doesNotMatch(script, /icacls|takeown/i);
 });

--- a/test/tray-service-windows.test.mjs
+++ b/test/tray-service-windows.test.mjs
@@ -99,8 +99,43 @@ test("tray uninstall verifies that Task Scheduler removed the task", () => {
     source.indexOf('command === "stop"'),
   );
   assert.match(uninstall, /schtasks\(\["\/Delete"/);
-  assert.match(uninstall, /if \(taskExists\(\)\)[\s\S]*?throw/);
+  // A task the scheduler still cannot enumerate must fail the uninstall, never
+  // report success as "missing".
+  assert.match(uninstall, /if \(taskExists\(\) === "exists"\)[\s\S]*?throw/);
+  assert.match(uninstall, /if \(existence === "error"\)[\s\S]*?did not answer whether the tray task was removed/);
   assert.doesNotMatch(uninstall, /catch \{\s*\/\/ The task may not exist/);
+});
+
+test("task query returns a tri-state answer, not a silent false", () => {
+  const source = readFileSync(path.join(root, "src", "tray-service-windows.mjs"), "utf8");
+  const task = source.slice(
+    source.indexOf("function taskExists("),
+    source.indexOf("function sleep("),
+  );
+  // The positive, negative, and indeterminate outcomes are returned as distinct
+  // literals rather than collapsed to a boolean false.
+  assert.match(task, /return sawError \? "error" : "missing"/);
+  assert.match(task, /"exists"/);
+  assert.match(task, /"missing"/);
+  // Only the culture-invariant "task not found" FullyQualifiedErrorId may count
+  // as missing; a timeout/denial/scheduler outage must become "error".
+  assert.match(task, /CmdletizationQuery_NotFound_TaskName/);
+  // Both PowerShell hosts are consulted before a host failure is treated as
+  // indeterminate rather than as an absent task.
+  assert.match(task, /for \(const executable of \["powershell\.exe", "pwsh\.exe"\]\)/);
+});
+
+test("a scheduler failure is never treated as a missing task while stopping", () => {
+  const source = readFileSync(path.join(root, "src", "tray-service-windows.mjs"), "utf8");
+  const wait = source.slice(
+    source.indexOf("function waitForTaskState("),
+    source.indexOf("function endTask("),
+  );
+  assert.match(wait, /existence === "missing"/);
+  assert.match(wait, /if \(action === "stop"\) return "missing"/);
+  // An indeterminate query is reported, not swallowed into a "missing" answer.
+  assert.match(wait, /existence === "error"[\s\S]*?did not answer/);
+  assert.match(wait, /uninstall would report[\s\S]*?success it did not earn/);
 });
 
 test("tray status reports the registered action and reads task state once", () => {
@@ -161,6 +196,33 @@ test("tray rebuild registers the artifact it just built", () => {
   assert.match(rebuild, /tray-service\.mjs" @\("install"\)/);
   assert.match(rebuild, /tray-service\.mjs" @\("install-electron"\)/);
   assert.doesNotMatch(rebuild, /tray-service\.mjs" @\("restart"\)/);
+  // Windows locks running tray binaries, so the supervised task is stopped
+  // BEFORE the in-place build, and a failed rebuild restores the old instance.
+  const stopBeforeBuild = rebuild.indexOf('tray-service.mjs" @("stop")');
+  const build = rebuild.indexOf("build-desktop-tray.ps1");
+  assert.ok(stopBeforeBuild >= 0 && stopBeforeBuild < build,
+    "the running tray must be stopped before the in-place build");
+  assert.match(rebuild, /\$TrayWasRunning\s*=\s*\$/);
+  assert.match(rebuild, /tray-service\.mjs" @\("start"\)/);
+  assert.match(rebuild, /Companion rebuild failed/);
+});
+
+test("PowerShell children that emit parsed text pin their output encoding to UTF-8", () => {
+  const source = readFileSync(path.join(root, "src", "tray-service-windows.mjs"), "utf8");
+  // OEM-encoded Console.Out corrupts a localized profile path before Node's
+  // `encoding: "utf8"` sees it, which made status report appPresent:false on a
+  // healthy tray and reject a valid deploy.
+  const pin = "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8";
+  const pinWithin = (functionName) => {
+    const start = source.indexOf(`function ${functionName}(`);
+    assert.ok(start >= 0, `${functionName} must still exist`);
+    // Every PowerShell child that writes text for Node to parse pins UTF-8
+    // near the top of its script body, before emitting the parsed output.
+    return source.slice(start, start + 900).includes(pin);
+  };
+  assert.ok(pinWithin("taskState"), "taskState must pin UTF-8 before its output");
+  assert.ok(pinWithin("registeredTaskAction"), "registeredTaskAction must pin UTF-8");
+  assert.ok(pinWithin("taskExists"), "taskExists must pin UTF-8");
 });
 
 test("tray repair validates the task and grants only its current principal control", () => {

--- a/test/windows-operations.test.mjs
+++ b/test/windows-operations.test.mjs
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const readScript = (name) => readFileSync(path.join(root, name), "utf8");
+
+test("the Windows operational scripts parse in Windows PowerShell", { skip: process.platform !== "win32" }, () => {
+  for (const name of ["install.ps1", "deploy-codex-router.ps1", "restart-codex-router.ps1"]) {
+    const target = path.join(root, name).replaceAll("'", "''");
+    const check = [
+      "$tokens = $null; $errors = $null",
+      `[System.Management.Automation.Language.Parser]::ParseFile('${target}', [ref]$tokens, [ref]$errors) | Out-Null`,
+      "if ($errors.Count) { $errors | ForEach-Object { $_.Message }; exit 1 }",
+    ].join("; ");
+    execFileSync("powershell.exe", ["-NoLogo", "-NoProfile", "-Command", check], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "inherit"],
+    });
+  }
+});
+
+test("the Windows restart helper uses the supported service transaction", () => {
+  const source = readScript("restart-codex-router.ps1");
+  assert.match(source, /\$env:LOCALAPPDATA/);
+  assert.match(source, /\$routerRoot\s*=\s*\[IO\.Path\]::GetFullPath\(\$InstallDir\)/);
+  assert.match(source, /src\\service\.mjs"\) restart/);
+  assert.match(source, /\$RestartExitCode\s*=\s*\$LASTEXITCODE/);
+  assert.match(source, /if \(\$RestartExitCode -ne 0\)/);
+  assert.doesNotMatch(source, /codex-router\.ps1"\) codex restart/);
+  assert.doesNotMatch(source, /control\.mjs.*service.*restart/);
+  assert.doesNotMatch(source, /Split-Path -Parent \$MyInvocation\.MyCommand\.Path/);
+});
+
+test("the local deploy helper copies source without purging target-only files", () => {
+  const source = readScript("deploy-codex-router.ps1");
+  assert.match(source, /Test-NestedDirectory \$sourceDir \$installDir/);
+  assert.match(source, /Test-NestedDirectory \$installDir \$sourceDir/);
+  assert.match(source, /"\/E"/);
+  assert.doesNotMatch(source, /"\/(?:MIR|PURGE)"/);
+  assert.match(source, /\.codex-router-deploy-manifest\.json/);
+  assert.match(source, /Resolve-ManagedTargetFile/);
+  assert.match(source, /Remove-Item -LiteralPath \$Target -Force/);
+  assert.match(source, /ReparsePoint/);
+  for (const directory of [".git", ".venv", "node_modules", "target", "dist", "release"]) {
+    assert.match(source, new RegExp(`"${directory.replace(".", "\\.")}"`));
+  }
+  assert.match(source, /\$CopyExitCode\s*=\s*\$LASTEXITCODE/);
+  assert.match(source, /if \(\$CopyExitCode -gt 7\)/);
+});
+
+test("deploy runs the installed canonical transaction and doctor without replacing selection", () => {
+  const source = readScript("deploy-codex-router.ps1");
+  assert.match(
+    source,
+    /Join-Path \$installDir "install\.ps1"\) -CheckoutInstall -Target codex/,
+  );
+  assert.doesNotMatch(source, /-Providers\b/);
+  assert.match(source, /src\\doctor\.mjs/);
+  assert.match(source, /\$DoctorExitCode\s*=\s*\$LASTEXITCODE/);
+  assert.match(source, /if \(\$DoctorExitCode -ne 0\)/);
+  assert.doesNotMatch(source, /src\\catalog\.mjs/);
+  assert.doesNotMatch(source, /src\\litellm-config\.mjs/);
+  assert.doesNotMatch(source, /control\.mjs.*service.*restart/);
+});
+
+test("deploy and install preserve the existing tray opt-in", () => {
+  const deploy = readScript("deploy-codex-router.ps1");
+  const install = readScript("install.ps1");
+
+  assert.match(deploy, /\$TrayWasInstalled\s*=\s*\(Get-TrayStatus\)\.installed -eq \$true/);
+  const trayGate = deploy.indexOf("if ($TrayWasInstalled)");
+  const trayStop = deploy.indexOf('src\\tray-service.mjs") stop', trayGate);
+  const trayInstall = deploy.indexOf('codex-router.ps1") tray install', trayStop);
+  const trayVerify = deploy.indexOf("$TrayStatus = Get-TrayStatus", trayInstall);
+  const success = deploy.indexOf("Codex Router published, installed, and verified.");
+  assert.ok(trayGate >= 0 && trayStop > trayGate, "an opted-in tray must be stopped before refresh");
+  assert.ok(trayInstall > trayStop, "the stopped tray must be refreshed through the installed wrapper");
+  assert.ok(trayVerify > trayInstall, "tray status must be read after the strict refresh");
+  assert.ok(success > trayVerify, "deployment success must follow tray verification");
+  assert.match(deploy, /powershell\.exe[^\n]+codex-router\.ps1"\) tray install/);
+  assert.match(deploy, /\$env:MODEL_ROUTER_TARGET\s*=\s*"codex"/);
+  assert.match(deploy, /\$env:MODEL_ROUTER_TARGET\s*=\s*\$SavedRouterTarget/);
+  assert.match(deploy, /\$TrayInstallExitCode\s*=\s*\$LASTEXITCODE/);
+  assert.match(deploy, /if \(\$TrayInstallExitCode -ne 0\)[\s\S]*?throw/);
+  assert.match(deploy, /-not \$TrayStatus\.installed[\s\S]*?-not \$TrayStatus\.loaded[\s\S]*?-not \$TrayStatus\.appPresent/);
+  assert.match(deploy, /codex-router-desktop\.exe/);
+  assert.match(deploy, /electron\.exe/);
+  assert.match(deploy, /\[string\]::Equals\([\s\S]*?\$RegisteredTrayPath[\s\S]*?\$ExpectedTrayPath/);
+  assert.doesNotMatch(deploy, /tray-service\.mjs"\) restart/);
+
+  const status = install.indexOf("$TrayWasInstalled = (Get-InstallerStateField");
+  const health = install.indexOf("src/wait-health.mjs");
+  const refresh = install.indexOf("codex-router.ps1\") tray install");
+  assert.ok(status >= 0 && status < health, "tray presence must be captured before installation");
+  assert.ok(refresh > health, "an existing tray is refreshed only after router health");
+  assert.match(install, /if \(\$TrayWasInstalled\) \{/);
+  assert.match(install, /\$env:MODEL_ROUTER_TARGET\s*=\s*"codex"/);
+  assert.match(install, /\$env:MODEL_ROUTER_TARGET\s*=\s*\$SavedRouterTarget/);
+  assert.match(install, /\$TrayExitCode\s*=\s*\$LASTEXITCODE/);
+  assert.match(install, /Desktop companion refresh failed[\s\S]*the router is installed/);
+  assert.match(install, /codex-router\.ps1 tray repair/);
+});
+
+test("Windows refreshes managed Codex skills as a best-effort post-install step", () => {
+  const install = readScript("install.ps1");
+  const health = install.indexOf("src/wait-health.mjs");
+  const skills = install.indexOf("src/skills-install.mjs install");
+  assert.ok(skills > health, "skills must run after the healthy service transaction");
+  assert.match(install, /if \(\$Target -eq "codex"\) \{/);
+  assert.match(install, /\$SkillsExitCode\s*=\s*\$LASTEXITCODE/);
+  assert.match(install, /Managed Codex skills could not be refreshed[\s\S]*the router is installed/);
+});


### PR DESCRIPTION
## Summary

Scope **(c)** from the split of the earlier bundled PR #349: the Windows tray + installer PowerShell work.

## What changes

**`src/tray-service-windows.mjs`** — the Task Scheduler tray lifecycle gets hard, bounded state handling:
- Every `schtasks`/COM call now runs under a per-command timeout (`TASK_COMMAND_TIMEOUT_MS`, 4 s), so a hung Task Scheduler cannot stall the wrapper forever.
- `taskState()` reads Task Scheduler's localized-independent `State` enum instead of parsing `schtasks` text, and falls back between `powershell.exe` and `pwsh.exe`.
- New `waitForTaskState()` turns `stop`/`start` into verified transitions (`TASK_STOP_TIMEOUT_MS`/`TASK_START_TIMEOUT_MS` polling at 250 ms) instead of issuing an unverified `/Run`.
- New `registeredTaskAction()` lets `status` report which executable the registered task actually points at, and whether that companion exists on disk.
- `installTask()` injects an explicit `FullControl` ACE for the task principal through Task Scheduler's COM API, so an elevated install does not leave the unelevated account unable to update its own tray task.
- `uninstall` now re-checks `taskExists()` and fails loudly if Task Scheduler rejected the deletion.

**`codex-router.ps1`** — adds `tray repair`:
- `Get-ValidatedTrayTask` refuses to touch a task whose principal is not the current user, is not interactive, or whose action is not this checkout's companion.
- `Test-TrayTaskFullControl` / `Repair-TrayTaskPermissions` run a narrowly scoped elevated child (`-Verb RunAs`) that validates the task identity from fixed env fields again (closing the UAC race) before rewriting its DACL, then re-installs the companion.

**`install.ps1`** — preserves an already opted-in tray across updates (best effort, never installing on fresh routers), and refreshes managed Codex skills as a best-effort post-health step. Antigravity-specific lines are deliberately absent (they belong to scope a).

**`deploy-codex-router.ps1`** (new) — working-tree deployment helper: robocopy without blanket purge, manifest-based pruning of only prior-deployed files (protects operator notes / unrelated files), then runs the canonical `install.ps1 -CheckoutInstall -Target codex` + `doctor`, and strictly verifies an opted-in tray.

**`restart-codex-router.ps1`** (new) — graceful `service.mjs restart` helper.

## Verification

- `test/tray-service-windows.test.mjs` (new, 17 tests) covers rendering, platform refusal, build gating, dispatcher routing, and the new bounded lifecycle source assertions.
- `test/windows-operations.test.mjs` (new, 6): Windows PowerShell parses the three `.ps1` scripts; asserts the supported service transaction, manifest-based deploy, tray-opt-in preservation, and skills refresh.
- `test/service-render.test.mjs`: unchanged behavior; the one failure (`launchd preserve proxy`) is a pre-existing baseline failure present on `main` too, unrelated to this change.

## Scope boundary

Strictly the Windows tray + installer PowerShell (scope c). Excluded: Antigravity provider (scope a, PR #372), `file-security.mjs` rewrite (scope b, PR #374), catalog picker ordering (scope d, separate PR).