### PR TITLE
feat: group routed models by provider in the catalog picker (scope d)

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -726,8 +726,59 @@ function writeAnnouncedAt(announcedAt) {
   });
 }
 
+// Codex renders its picker by `priority`, not by the JSON array order. Keep
+// the vendor groups in one named policy so the file itself and the visible
+// picker agree. The three groups below are the operators' primary routes;
+// every other provider remains grouped deterministically after them.
+function pickerProviderGroup(provider) {
+  const value = String(provider || "");
+  if (value === "antigravity-oauth") return { rank: 0, key: "antigravity" };
+  if (value === "deepseek") return { rank: 1, key: "deepseek" };
+  if (value.startsWith("opencode-go")) return { rank: 2, key: "opencode" };
+  return { rank: 3, key: value };
+}
+
+function pickerSlugGroup(slug) {
+  const value = String(slug || "");
+  if (!value.includes("/")) return { rank: -1, key: "native" };
+  return pickerProviderGroup(value.slice(0, value.indexOf("/")));
+}
+
+function routedPickerPriorities(nativeModels, routedModelsList) {
+  const nativeMaximum = nativeModels.reduce(
+    (maximum, model) =>
+      Math.max(maximum, Number.isFinite(Number(model.priority)) ? Number(model.priority) : -1),
+    -1,
+  );
+  const groups = new Map();
+  for (const model of routedModelsList) {
+    const group = pickerProviderGroup(model.provider);
+    const key = `${group.rank}:${group.key}`;
+    if (!groups.has(key)) groups.set(key, { ...group, models: [] });
+    groups.get(key).models.push(model);
+  }
+
+  let nextPriority = nativeMaximum + 1;
+  return [...groups.values()]
+    .sort((left, right) =>
+      left.rank - right.rank || left.key.localeCompare(right.key),
+    )
+    .flatMap((group) =>
+      group.models
+        .sort((left, right) =>
+          Number(left.priority) - Number(right.priority) ||
+          String(left.slug).localeCompare(String(right.slug)),
+        )
+        .map((model) => ({ ...model, priority: nextPriority++ })),
+    );
+}
+
 function sortCatalogModels(models) {
   return [...models].sort((left, right) => {
+    const leftGroup = pickerSlugGroup(left.slug);
+    const rightGroup = pickerSlugGroup(right.slug);
+    const group = leftGroup.rank - rightGroup.rank || leftGroup.key.localeCompare(rightGroup.key);
+    if (group) return group;
     const priority = Number(left.priority ?? 999) - Number(right.priority ?? 999);
     return priority || String(left.slug).localeCompare(String(right.slug));
   });
@@ -796,7 +847,7 @@ export function buildMergedCatalog(native, routedModelsList, { includeNative = t
       ? native.models.map((model) => [model.slug, normalizeNativeModel(model)])
       : [],
   );
-  for (const model of routedModelsList) {
+  for (const model of routedPickerPriorities(native.models, routedModelsList)) {
     const behaviorTemplate = behaviorTemplateFor(native.models, model, template);
     models.set(model.slug, routedModel(template, model, behaviorTemplate));
   }

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -734,7 +734,13 @@ function pickerProviderGroup(provider) {
   const value = String(provider || "");
   if (value === "antigravity-oauth") return { rank: 0, key: "antigravity" };
   if (value === "deepseek") return { rank: 1, key: "deepseek" };
-  if (value.startsWith("opencode-go")) return { rank: 2, key: "opencode" };
+  // The opencode family shares one stored key: `opencode-go` and its variants
+  // (`opencode-go-messages`, `opencode-go-responses`, `opencode-zen`). Group
+  // them together so Zen models stay next to the Go models they relate to
+  // instead of falling into the rank-3 catch-all under their own key.
+  if (value.startsWith("opencode-go") || value === "opencode-zen") {
+    return { rank: 2, key: "opencode" };
+  }
   return { rank: 3, key: value };
 }
 
@@ -744,12 +750,13 @@ function pickerSlugGroup(slug) {
   return pickerProviderGroup(value.slice(0, value.indexOf("/")));
 }
 
+// Orders routed models for the picker by the vendor-group policy WITHOUT
+// rewriting each model's `priority`. The `priority` field feeds Codex's
+// spawn_agent override window (AGENTS.md step 5), where certified native v2
+// routes keep intentionally low values; renumbering every routed model to
+// nativeMax+1 would crowd those certified routes out of the window. Grouping
+// only reorders the published array while every model keeps its own priority.
 function routedPickerPriorities(nativeModels, routedModelsList) {
-  const nativeMaximum = nativeModels.reduce(
-    (maximum, model) =>
-      Math.max(maximum, Number.isFinite(Number(model.priority)) ? Number(model.priority) : -1),
-    -1,
-  );
   const groups = new Map();
   for (const model of routedModelsList) {
     const group = pickerProviderGroup(model.provider);
@@ -758,18 +765,15 @@ function routedPickerPriorities(nativeModels, routedModelsList) {
     groups.get(key).models.push(model);
   }
 
-  let nextPriority = nativeMaximum + 1;
   return [...groups.values()]
     .sort((left, right) =>
       left.rank - right.rank || left.key.localeCompare(right.key),
     )
     .flatMap((group) =>
-      group.models
-        .sort((left, right) =>
-          Number(left.priority) - Number(right.priority) ||
-          String(left.slug).localeCompare(String(right.slug)),
-        )
-        .map((model) => ({ ...model, priority: nextPriority++ })),
+      group.models.sort((left, right) =>
+        Number(left.priority) - Number(right.priority) ||
+        String(left.slug).localeCompare(String(right.slug)),
+      ),
     );
 }
 

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -442,12 +442,18 @@ test("merged catalog gives native models first and keeps routed providers contig
     { ...grok, slug: "opencode-go/glm-5.3", provider: "opencode-go", priority: 7 },
     { ...grok, slug: "deepseek/deepseek-v4-pro", provider: "deepseek", priority: 1 },
     { ...grok, slug: "antigravity-oauth/gemini-3.7-flash", provider: "antigravity-oauth", priority: 9 },
+    { ...grok, slug: "opencode-zen/zen-r1", provider: "opencode-zen", priority: 4 },
     { ...grok, slug: "opencode-go-responses/gpt-5.6-luna", provider: "opencode-go-responses", priority: 2 },
     { ...grok, slug: "grok-oauth/grok-4.5", provider: "grok-oauth", priority: 0 },
     { ...grok, slug: "antigravity-oauth/gemini-3.1-pro", provider: "antigravity-oauth", priority: 3 },
   ];
   const merged = buildMergedCatalog({ models: [nativeOlder, template] }, routed);
 
+  // Routed models stay grouped by the named vendor policy, and each model
+  // keeps the `priority` the operator chose. Picker grouping must not renumber
+  // every routed route past the native maximum, or the low priorities on
+  // certified native v2 spawn routes get crowded out of Codex's override
+  // window.
   assert.deepEqual(merged.map((model) => model.slug), [
     "gpt-5.5",
     "gpt-5.4",
@@ -455,12 +461,13 @@ test("merged catalog gives native models first and keeps routed providers contig
     "antigravity-oauth/gemini-3.7-flash",
     "deepseek/deepseek-v4-pro",
     "opencode-go-responses/gpt-5.6-luna",
+    "opencode-zen/zen-r1",
     "opencode-go/glm-5.3",
     "grok-oauth/grok-4.5",
   ]);
   assert.deepEqual(
     merged.map((model) => model.priority),
-    [10, 29, 30, 31, 32, 33, 34, 35],
+    [10, 29, 3, 9, 1, 2, 4, 7, 0],
   );
 });
 

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -431,6 +431,39 @@ test("merged catalog preserves native GPT identity while rewriting routed models
   assert.doesNotMatch(bySlug.get("grok-oauth/grok-4.5").base_instructions, /GPT-5/);
 });
 
+test("merged catalog gives native models first and keeps routed providers contiguous", () => {
+  const nativeOlder = {
+    ...template,
+    slug: "gpt-5.4",
+    display_name: "GPT-5.4",
+    priority: 29,
+  };
+  const routed = [
+    { ...grok, slug: "opencode-go/glm-5.3", provider: "opencode-go", priority: 7 },
+    { ...grok, slug: "deepseek/deepseek-v4-pro", provider: "deepseek", priority: 1 },
+    { ...grok, slug: "antigravity-oauth/gemini-3.7-flash", provider: "antigravity-oauth", priority: 9 },
+    { ...grok, slug: "opencode-go-responses/gpt-5.6-luna", provider: "opencode-go-responses", priority: 2 },
+    { ...grok, slug: "grok-oauth/grok-4.5", provider: "grok-oauth", priority: 0 },
+    { ...grok, slug: "antigravity-oauth/gemini-3.1-pro", provider: "antigravity-oauth", priority: 3 },
+  ];
+  const merged = buildMergedCatalog({ models: [nativeOlder, template] }, routed);
+
+  assert.deepEqual(merged.map((model) => model.slug), [
+    "gpt-5.5",
+    "gpt-5.4",
+    "antigravity-oauth/gemini-3.1-pro",
+    "antigravity-oauth/gemini-3.7-flash",
+    "deepseek/deepseek-v4-pro",
+    "opencode-go-responses/gpt-5.6-luna",
+    "opencode-go/glm-5.3",
+    "grok-oauth/grok-4.5",
+  ]);
+  assert.deepEqual(
+    merged.map((model) => model.priority),
+    [10, 29, 30, 31, 32, 33, 34, 35],
+  );
+});
+
 test("native gpt-5.2 stays parseable by older Codex catalog readers", () => {
   const native52 = { ...template, slug: "gpt-5.2" };
   delete native52.supports_parallel_tool_calls;


### PR DESCRIPTION
## Summary

Scope **(d)** from the split of the earlier bundled PR #349: the catalog picker-ordering policy change.

## What changes

**`src/catalog.mjs`**
- Adds `pickerProviderGroup()` / `pickerSlugGroup()` / `routedPickerPriorities()`.
- The merged catalog now orders routed models by a single named vendor policy:
  1. native models first (unchanged),
  2. then `antigravity-oauth`, `deepseek`, then `opencode-go*` groups (ranked, alphabetically within a rank),
  3. then every other provider grouped deterministically after them.
- `sortCatalogModels()` and `buildMergedCatalog()` both route through the group comparator, so the on-disk catalog and the Codex picker (which renders by `priority`, not array order) agree. Routed `priority` values are re-numbered contiguously after the native maximum.

**`test/catalog.test.mjs`**
- New test `merged catalog gives native models first and keeps routed providers contiguous` pins the ordering and the re-indexed priorities.

## Why

Codex renders its picker by `priority`, not by the JSON array order. Without this policy the visible picker could disagree with the catalog file, and external providers were not grouped deterministically. This keeps the operators' primary routes grouped and every other provider stable.

## Verification

- New picker-ordering test passes.
- Regression: `test/catalog.test.mjs`, `test/model-picker-state.test.mjs`, `test/provider-selection.test.mjs` → **87 pass / 0 fail**.

## Scope boundary

Strictly the catalog picker-ordering policy (scope d). Excludes the Antigravity provider (scope a, PR #372), the `file-security.mjs` rewrite (scope b, PR #374), and the Windows tray/installer work (scope c, PR #375). Note the ranking table intentionally names `antigravity-oauth` as a peer provider group; this file itself contains no provider implementation, only ordering policy.