### PR TITLE
fix(windows): drain startup handles before exit (split from #372)

### DIFF
--- a/src/start.mjs
+++ b/src/start.mjs
@@ -395,4 +395,8 @@ try {
     }
   }
 }
-process.exit(exitCode);
+// All children have exited, so let Node drain its own child-process bookkeeping
+// before terminating. A synchronous process.exit() here races libuv's Windows
+// async-handle close path and can abort with UV_HANDLE_CLOSING after a child
+// fails during startup (for example, an EADDRINUSE forwarder).
+process.exitCode = exitCode;


### PR DESCRIPTION
Carries **@Zzy-min's `d32f8a9` unchanged** (`fix(windows): drain startup handles before exit`) from #372, split out on its own because it fixes a latent bug that is already on `main` and is not specific to the Antigravity provider it currently rides behind.

## The bug

`src/start.mjs` ended with a synchronous `process.exit(exitCode)`. When a child forwarder dies during startup — an `EADDRINUSE` on its port, for example — that call races libuv's Windows async-handle close path and aborts the process:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 94
3221226505 !== 1
```

The error message is printed correctly; the process then dies with `0xC0000409` instead of exiting `1`, so any test asserting the exit code fails.

## Why split it out

It is non-deterministic, so it does not fail every run — `main`'s own CI passed at `a44f498`. But it has now been observed on two unrelated PRs, in two different tests of the same shape:

- **#374** (`file-security` ACLs — touches nothing in this path) — `test/devin-forwarder-gating.test.mjs:224`, *"a curated Devin model that cannot bind its port still fails startup by name"*
- **#377** (Antigravity) — `test/antigravity-forwarder-gating.test.mjs:226`, *"a stored Antigravity session that cannot bind its port still fails startup by name"*

Both aborted with the identical libuv assertion. #374 was green on its previous base and went red purely on being refreshed onto current `main`, which is what surfaced this: it is a dice roll against every Windows run, and it will keep failing unrelated PRs until it is fixed.

`devin-forwarder-gating.test.mjs` is currently the only test on `main` that exercises the path; a second one arrives with the Antigravity provider.

## Why `process.exitCode` is safe here

The assignment is the last statement in the file, so Node exits naturally once the loop drains. Nothing holds it open: the `finally` block already `await`s every child's exit, `start.mjs` opens no listener of its own, and its single timer is `.unref()`'d (`src/start.mjs:235`).

Empirically — #372, whose HEAD is exactly this commit, is green on both `test (windows-latest)` and `desktop (windows-latest)`.

## Credit

The commit and the diagnosis are @Zzy-min's, from #372. Nothing was changed; it is cherry-picked with authorship intact. #372 keeps the commit in its own history and will merge through it harmlessly.
