### PR TITLE
fix: filter empty DeepSeek assistant messages after tool calls

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -45,6 +45,7 @@ import {
   writeStreamErrorEvent,
 } from "./http-utils.mjs";
 import { EmptyCompletionGuard } from "./empty-completion-guard.mjs";
+import { toolMessageCompatTransform } from "./tool-message-compat.mjs";
 import {
   ZaiResponsesCompatTransform,
   zaiResponsesCompatTransform,
@@ -2912,6 +2913,10 @@ async function handleResponses(request, response, requestUrl) {
             : undefined,
       });
       const transforms = [usageObserver];
+      const toolMessageCompat = route
+        ? toolMessageCompatTransform(contentType)
+        : undefined;
+      if (toolMessageCompat) transforms.push(toolMessageCompat);
       let envelopeCompat = route
         ? zaiResponsesCompatTransform(route.provider, contentType)
         : undefined;

--- a/src/tool-message-compat.mjs
+++ b/src/tool-message-compat.mjs
@@ -1,0 +1,339 @@
+import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+function parsedEventBlock(block) {
+  const newline = block.includes("\r\n") ? "\r\n" : "\n";
+  const lines = block.split(/\r?\n/);
+  const dataLineIndex = lines.findIndex((line) => line.startsWith("data:"));
+  if (dataLineIndex === -1) return undefined;
+  const dataText = lines[dataLineIndex].slice(5).trimStart();
+  if (!dataText || dataText === "[DONE]") return undefined;
+  try {
+    return { lines, dataLineIndex, newline, event: JSON.parse(dataText) };
+  } catch {
+    return undefined;
+  }
+}
+
+function rewrittenBlock(parsed, event) {
+  const lines = [...parsed.lines];
+  lines[parsed.dataLineIndex] = `data: ${JSON.stringify(event)}`;
+  return lines.join(parsed.newline);
+}
+
+function isToolCall(item) {
+  return item?.type === "function_call" || item?.type === "custom_tool_call";
+}
+
+function isBlankPart(part) {
+  if (!part || typeof part !== "object") return false;
+  if (!["output_text", "text"].includes(part.type)) return false;
+  return typeof part.text !== "string" || part.text.trim() === "";
+}
+
+function hasNonblankMessageText(part) {
+  return (
+    part != null &&
+    typeof part === "object" &&
+    ["output_text", "text"].includes(part.type) &&
+    typeof part.text === "string" &&
+    part.text.trim() !== ""
+  );
+}
+
+function isBlankMessage(item) {
+  if (item?.type !== "message") return false;
+  if (typeof item.content === "string") return item.content.trim() === "";
+  if (!Array.isArray(item.content)) return false;
+  return item.content.length === 0 || item.content.every(isBlankPart);
+}
+
+function itemId(value) {
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function eventBelongsToMessage(event, id) {
+  if (!id || !event) return false;
+  if (
+    ["response.output_item.added", "response.output_item.done"].includes(event.type) &&
+    event.item?.type === "message"
+  ) {
+    return itemId(event.item.id) === id;
+  }
+  return (
+    [
+      "response.content_part.added",
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.content_part.done",
+    ].includes(event.type) && itemId(event.item_id) === id
+  );
+}
+
+// Removes the empty message lifecycle that LiteLLM appends to a tool-only
+// Chat-Completions -> Responses stream. LiteLLM may announce that message from
+// an initial empty role chunk before the provider emits its tool call, so the
+// announcement is held until text proves the message is real.
+export class ToolMessageCompatTransform extends Transform {
+  #decoder = new StringDecoder("utf8");
+  #buffer = "";
+  #announcedMessages = new Set();
+  #heldFrames = [];
+  #heldMessageId;
+  #messagesWithText = new Set();
+  #sawToolCall = false;
+  #suppressedMessages = new Set();
+
+  _transform(chunk, _encoding, callback) {
+    this.#buffer += this.#decoder.write(chunk);
+    this.#emitCompleteBlocks();
+    callback();
+  }
+
+  _flush(callback) {
+    this.#buffer += this.#decoder.end();
+    this.#emitCompleteBlocks(true);
+    for (const piece of this.#drainHeldFrames()) this.push(Buffer.from(piece));
+    callback();
+  }
+
+  #emitCompleteBlocks(flush = false) {
+    while (this.#buffer.length) {
+      const crlf = this.#buffer.indexOf("\r\n\r\n");
+      const lf = this.#buffer.indexOf("\n\n");
+      let index = -1;
+      let separator = "";
+      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+        index = crlf;
+        separator = "\r\n\r\n";
+      } else if (lf !== -1) {
+        index = lf;
+        separator = "\n\n";
+      }
+      if (index === -1) {
+        if (!flush) return;
+        const block = this.#buffer;
+        this.#buffer = "";
+        for (const piece of this.#rewriteFrame(block, "")) this.push(Buffer.from(piece));
+        return;
+      }
+      const block = this.#buffer.slice(0, index);
+      this.#buffer = this.#buffer.slice(index + separator.length);
+      for (const piece of this.#rewriteFrame(block, separator)) {
+        this.push(Buffer.from(piece));
+      }
+    }
+  }
+
+  #messageIsUnannouncedAndBlank(id, blank) {
+    return (
+      this.#sawToolCall &&
+      Boolean(id) &&
+      blank &&
+      !this.#announcedMessages.has(id) &&
+      !this.#messagesWithText.has(id)
+    );
+  }
+
+  #drainHeldFrames(suppressId) {
+    const held = this.#heldFrames;
+    this.#heldFrames = [];
+    this.#heldMessageId = undefined;
+    if (!suppressId) return held.map((frame) => frame.original);
+
+    this.#suppressedMessages.add(suppressId);
+    const output = [];
+    for (const frame of held) {
+      const event = frame.parsed?.event;
+      if (eventBelongsToMessage(event, suppressId)) continue;
+      if (event?.type !== "response.completed" || !Array.isArray(event.response?.output)) {
+        output.push(frame.original);
+        continue;
+      }
+      const filtered = event.response.output.filter(
+        (item) => !(itemId(item?.id) === suppressId && isBlankMessage(item)),
+      );
+      output.push(
+        filtered.length === event.response.output.length
+          ? frame.original
+          : `${rewrittenBlock(frame.parsed, {
+              ...event,
+              response: { ...event.response, output: filtered },
+            })}${frame.separator}`,
+      );
+    }
+    return output;
+  }
+
+  #holdFrame(parsed, original, separator) {
+    const event = parsed.event;
+    const type = event?.type;
+    const heldId = this.#heldMessageId;
+
+    if (
+      type === "response.output_item.added" &&
+      event?.item?.type === "message" &&
+      itemId(event.item.id) !== heldId
+    ) {
+      const released = this.#drainHeldFrames();
+      const id = itemId(event.item.id);
+      if (!id) return [...released, original];
+      this.#announcedMessages.add(id);
+      this.#heldMessageId = id;
+      this.#heldFrames.push({ original, parsed, separator });
+      return released;
+    }
+
+    this.#heldFrames.push({ original, parsed, separator });
+    if (
+      ["response.output_item.added", "response.output_item.done"].includes(type) &&
+      isToolCall(event?.item)
+    ) {
+      this.#sawToolCall = true;
+    }
+
+    const nonblankText =
+      (type === "response.output_text.delta" &&
+        itemId(event.item_id) === heldId &&
+        typeof event.delta === "string" &&
+        event.delta.trim() !== "") ||
+      (type === "response.output_text.done" &&
+        itemId(event.item_id) === heldId &&
+        typeof event.text === "string" &&
+        event.text.trim() !== "") ||
+      (type === "response.content_part.done" &&
+        itemId(event.item_id) === heldId &&
+        hasNonblankMessageText(event.part)) ||
+      (type === "response.output_item.done" &&
+        itemId(event.item?.id) === heldId &&
+        event.item?.type === "message" &&
+        !isBlankMessage(event.item));
+    if (nonblankText) {
+      this.#messagesWithText.add(heldId);
+      return this.#drainHeldFrames();
+    }
+
+    if (
+      type === "response.output_item.done" &&
+      itemId(event.item?.id) === heldId &&
+      isBlankMessage(event.item)
+    ) {
+      return this.#drainHeldFrames(this.#sawToolCall ? heldId : undefined);
+    }
+
+    if (type === "response.completed") {
+      const output = Array.isArray(event.response?.output) ? event.response.output : [];
+      const hasToolCall = output.some(isToolCall);
+      const hasBlankHeldMessage = output.some(
+        (item) => itemId(item?.id) === heldId && isBlankMessage(item),
+      );
+      return this.#drainHeldFrames(
+        hasToolCall && hasBlankHeldMessage ? heldId : undefined,
+      );
+    }
+
+    return [];
+  }
+
+  #rewriteFrame(block, separator) {
+    const original = `${block}${separator}`;
+    const parsed = parsedEventBlock(block);
+    if (!parsed) {
+      if (!this.#heldMessageId) return [original];
+      this.#heldFrames.push({ original, parsed: undefined, separator });
+      return block.includes("data: [DONE]") ? this.#drainHeldFrames() : [];
+    }
+    if (this.#heldMessageId) return this.#holdFrame(parsed, original, separator);
+
+    const event = parsed.event;
+    const type = event?.type;
+
+    if (
+      ["response.output_item.added", "response.output_item.done"].includes(type) &&
+      isToolCall(event?.item)
+    ) {
+      this.#sawToolCall = true;
+      return [original];
+    }
+
+    if (type === "response.output_item.added" && event?.item?.type === "message") {
+      const id = itemId(event.item.id);
+      if (!id) return [original];
+      this.#announcedMessages.add(id);
+      this.#heldMessageId = id;
+      this.#heldFrames.push({ original, parsed, separator });
+      return [];
+    }
+
+    if (type === "response.content_part.added") {
+      const id = itemId(event.item_id);
+      if (id) this.#announcedMessages.add(id);
+      return [original];
+    }
+
+    if (type === "response.output_text.delta") {
+      const id = itemId(event.item_id);
+      if (id && typeof event.delta === "string" && event.delta.trim() !== "") {
+        this.#messagesWithText.add(id);
+      }
+      return [original];
+    }
+
+    if (type === "response.output_text.done") {
+      const id = itemId(event.item_id);
+      if (id && typeof event.text === "string" && event.text.trim() !== "") {
+        this.#messagesWithText.add(id);
+      }
+      return this.#messageIsUnannouncedAndBlank(
+        id,
+        typeof event.text === "string" && event.text.trim() === "",
+      )
+        ? []
+        : [original];
+    }
+
+    if (type === "response.content_part.done") {
+      const id = itemId(event.item_id);
+      if (id && hasNonblankMessageText(event.part)) this.#messagesWithText.add(id);
+      return this.#messageIsUnannouncedAndBlank(id, isBlankPart(event.part))
+        ? []
+        : [original];
+    }
+
+    if (type === "response.output_item.done" && event?.item?.type === "message") {
+      const id = itemId(event.item.id);
+      return this.#messageIsUnannouncedAndBlank(id, isBlankMessage(event.item))
+        ? []
+        : [original];
+    }
+
+    if (type === "response.completed" && Array.isArray(event?.response?.output)) {
+      const output = event.response.output;
+      const hasToolCall = output.some(isToolCall);
+      if (!hasToolCall) return [original];
+      this.#sawToolCall = true;
+      const filtered = output.filter((item) => {
+        if (!isBlankMessage(item)) return true;
+        const id = itemId(item.id);
+        if (id && this.#suppressedMessages.has(id)) return false;
+        return !this.#messageIsUnannouncedAndBlank(id, true);
+      });
+      if (filtered.length === output.length) return [original];
+      return [
+        `${rewrittenBlock(parsed, {
+            ...event,
+            response: { ...event.response, output: filtered },
+          })}${separator}`,
+      ];
+    }
+
+    return [original];
+  }
+}
+
+export function toolMessageCompatTransform(contentType = "") {
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) {
+    return undefined;
+  }
+  return new ToolMessageCompatTransform();
+}

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -6714,6 +6714,137 @@ test("a plain follow-up after a thinking turn replays its reasoning", async () =
   }
 });
 
+test("router drops LiteLLM's announced blank message from a tool-only response", async () => {
+  const blankMessage = {
+    id: "msg_blank",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "", annotations: [] }],
+  };
+  const functionCall = {
+    id: "call_list",
+    type: "function_call",
+    call_id: "call_list",
+    name: "exec_command",
+    arguments: "{}",
+    status: "completed",
+  };
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    const events = [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          id: "msg_blank",
+          type: "message",
+          status: "in_progress",
+          role: "assistant",
+          content: [],
+        },
+      },
+      {
+        type: "response.content_part.added",
+        item_id: "msg_blank",
+        output_index: 0,
+        content_index: 0,
+        part: { type: "output_text", text: "", annotations: [] },
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 1,
+        item: { ...functionCall, arguments: "", status: "in_progress" },
+      },
+      {
+        type: "response.function_call_arguments.done",
+        item_id: "call_list",
+        output_index: 1,
+        arguments: "{}",
+      },
+      { type: "response.output_item.done", output_index: 1, item: functionCall },
+      {
+        type: "response.output_text.done",
+        item_id: "msg_blank",
+        output_index: 0,
+        content_index: 0,
+        text: "",
+      },
+      {
+        type: "response.content_part.done",
+        item_id: "msg_blank",
+        output_index: 0,
+        content_index: 0,
+        part: {
+          type: "reasoning_text",
+          reasoning: "I should call the requested diagnostic tool.",
+        },
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: blankMessage,
+      },
+      {
+        type: "response.completed",
+        response: {
+          id: "resp_tool_only",
+          status: "completed",
+          output: [blankMessage, functionCall],
+          usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+        },
+      },
+    ];
+    response.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "deepseek/deepseek-v4-flash-vision-exp",
+        input: "list files",
+        stream: true,
+      }),
+    });
+    const text = await response.text();
+    assert.equal(response.status, 200, text);
+    const events = text.split(/\r?\n/)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+
+    assert.ok(events.some((event) => event.item?.type === "function_call"));
+    assert.equal(
+      events.some((event) => event.item?.type === "message"),
+      false,
+      "blank message item reached the Codex client",
+    );
+    assert.equal(
+      events.some(
+        (event) =>
+          event.item_id === "msg_blank" &&
+          ["response.output_text.done", "response.content_part.done"].includes(event.type),
+      ),
+      false,
+      "blank message close events reached the Codex client",
+    );
+    const completed = events.find((event) => event.type === "response.completed");
+    assert.deepEqual(completed.response.output, [functionCall]);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 
 test("router repairs malformed Z.ai message envelopes after LiteLLM Responses translation", async () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "zai-responses-compat-router-"));


### PR DESCRIPTION
## Why

While using DeepSeek, we found that tool-call responses can include an additional empty assistant message.

Codex treats this empty message as a separate content block, causing unusually large gaps between tool activity entries.

In the actual response, the empty message was preceded by a `reasoning_text` event. The previous filter incorrectly treated this event as visible assistant text and released the empty message.

## What

- Correct the detection of empty assistant messages.
- Do not treat `reasoning_text` as visible assistant text.
- Treat only non-empty `output_text` or `text` as visible assistant text.
- Prevent empty messages associated with tool calls, along with their related events, from being forwarded to Codex.
- Add a regression test matching the event sequence observed in the actual DeepSeek response.

## Test

- Reproduced and confirmed the event sequence with one real DeepSeek request.
- Updated the test fixture to include the `reasoning_text` event observed in the actual response.
- Before the fix, the regression test failed because the empty assistant message reached Codex.
- After the fix, the same regression test passed.
- `node --check src/tool-message-compat.mjs` passed.
- `git diff --check` passed.

## Test Scope

Only DeepSeek was tested with a real request in this change.

The filtering logic applies to external models connected through the Router. If another external model returns the same empty-message pattern, this logic will also run, but no real requests were made to other external models as part of this change.

Native Codex GPT models do not pass through this external-model filtering logic and are therefore unaffected.