### PR TITLE
fix(errors): anonymous providers have no stored credential to refresh

### DIFF
--- a/src/error-translation.mjs
+++ b/src/error-translation.mjs
@@ -188,6 +188,7 @@ function describeFailure({
   modelName,
   providerName,
   providerKind,
+  providerAuthMode,
   retryAfterSeconds,
 }) {
   // Ahead of both the quota and the credential branches: an entitlement
@@ -212,6 +213,15 @@ function describeFailure({
       return {
         type: "authentication_error",
         message: `${providerName} rejected the OAuth session while serving ${modelName}. Sign in to ${providerName} again.`,
+      };
+    }
+    // An anonymous provider holds no credential at all, so there is nothing
+    // to refresh and no setup to re-run. Its refusal is about the request or
+    // its free-route policy, both of which change without notice.
+    if (providerAuthMode === "anonymous") {
+      return {
+        type: "authentication_error",
+        message: `${providerName} serves ${modelName} anonymously, so there is no stored credential to refresh. ${providerName} rejected this request on its free route; the free catalog and limits change without notice, so retry later or switch models.`,
       };
     }
     return {
@@ -258,6 +268,7 @@ export function translateGatewayError({
   modelName,
   providerName,
   providerKind,
+  providerAuthMode,
   retryAfterSeconds,
 }) {
   const detail = extractUpstreamDetail(bodyText);
@@ -286,6 +297,7 @@ export function translateGatewayError({
     modelName,
     providerName,
     providerKind,
+    providerAuthMode,
     retryAfterSeconds,
   });
   const suffix = detail ? ` (HTTP ${status}: ${detail})` : ` (HTTP ${status})`;

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -2868,6 +2868,7 @@ async function handleResponses(request, response, requestUrl) {
               ? "Ollama"
               : provider?.ownedBy || provider?.displayName || route.provider,
           providerKind: provider?.kind,
+          providerAuthMode: provider?.authMode,
           retryAfterSeconds: Number.isFinite(retryAfterSeconds)
             ? retryAfterSeconds
             : undefined,

--- a/test/error-translation.test.mjs
+++ b/test/error-translation.test.mjs
@@ -165,6 +165,41 @@ test("a 401 from an OAuth provider says sign in again, not re-run setup", () => 
   assert.ok(!payload.error.message.includes("codex-router setup"));
 });
 
+// Captured from a live opencode-free outage: OpenCode Zen answered 401 with
+// its ModelError while serving an anonymous free model. The provider holds no
+// credential, so advising a setup re-run sends the operator looking for
+// something that does not exist.
+test("a 401 from an anonymous provider never advises refreshing credentials", () => {
+  const payload = translateGatewayError({
+    status: 401,
+    bodyText: JSON.stringify({
+      type: "error",
+      error: { type: "ModelError", message: "Model  is not supported" },
+    }),
+    modelName: "Ox Alpha Free",
+    providerName: "opencode",
+    providerKind: "openai-compatible",
+    providerAuthMode: "anonymous",
+  });
+  assert.equal(
+    payload.error.message,
+    "opencode serves Ox Alpha Free anonymously, so there is no stored credential to refresh. opencode rejected this request on its free route; the free catalog and limits change without notice, so retry later or switch models. (HTTP 401: Model  is not supported)",
+  );
+  assert.equal(payload.error.type, "authentication_error");
+  assert.ok(!payload.error.message.includes("codex-router setup"));
+});
+
+test("an anonymous provider without the auth mode keeps the credential wording", () => {
+  const payload = translateGatewayError({
+    status: 401,
+    bodyText: JSON.stringify({ error: { message: "invalid api key" } }),
+    modelName: "DeepSeek V4 Pro",
+    providerName: "deepseek",
+    providerKind: "openai-compatible",
+  });
+  assert.match(payload.error.message, /Re-run codex-router setup/);
+});
+
 // Captured from a live Kimi OAuth 403: an exhausted plan arrives on the same
 // status as a rejected session, so the body has to win. Telling the user to
 // sign in again would send them through a login that cannot fix anything.


### PR DESCRIPTION
## Summary

Anonymous providers (`opencode-free`, `kilo-free`) hold no credential, but a 401 from their upstream told the operator to "re-run codex-router setup to refresh them" — advice pointing at something that does not exist.

## Live case

OpenCode Zen intermittently answers its free route with `401 {"type":"error","error":{"type":"ModelError","message":"Model  is not supported"}}` (note the blank model slot) for a model its own `/models` endpoint lists. During one such window the router relayed:

> opencode rejected the stored credentials while serving Ox Alpha Free. Re-run codex-router setup to refresh them.

The same request succeeded minutes later, and direct anonymous calls to the documented endpoint succeeded throughout — so nothing is stored, and nothing can be refreshed.

## Change

- Plumb the provider's `authMode` into `translateGatewayError` beside the existing `providerKind`.
- A 401/403 from an `authMode: "anonymous"` provider now says there is no stored credential to refresh, that free catalogs and limits change without notice, and to retry later or switch models.
- Providers without an authMode keep the existing wording unchanged; OAuth keeps its sign-in wording; quota and entitlement classification still run first and are untouched.

## Tests

`test/error-translation.test.mjs` gains the captured live body as a fixture asserting the anonymous wording never advises setup, plus a guard that the default credential wording survives when no authMode is present.
