### PR TITLE
Add Kimi K3 (Ollama Cloud) model

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Linux installations support the Codex CLI.
 | Claude Opus 4.8 (API) | `anthropic-api/claude-opus-4.8` | Separately billed Anthropic API key |
 | GLM-5.2 (Ollama Cloud) | `ollama-cloud/glm-5.2` | Ollama Cloud API key |
 | Kimi K2.7 Code (Ollama Cloud) | `ollama-cloud/kimi-k2.7-code` | Ollama Cloud API key |
+| Kimi K3 (Ollama Cloud) | `ollama-cloud/kimi-k3` | Ollama Cloud API key |
 | MiniMax M3 (Ollama Cloud) | `ollama-cloud/minimax-m3` | Ollama Cloud API key |
 | DeepSeek V4 Pro (Ollama Cloud) | `ollama-cloud/deepseek-v4-pro` | Ollama Cloud API key |
 | DeepSeek V4 Flash (Ollama Cloud) | `ollama-cloud/deepseek-v4-flash` | Ollama Cloud API key |

--- a/config/ollama/cloud/kimi-k3.json
+++ b/config/ollama/cloud/kimi-k3.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "ollama-cloud/kimi-k3",
+      "gatewayModel": "ollama-cloud-kimi-k3",
+      "upstreamModel": "kimi-k3:cloud",
+      "provider": "ollama-cloud",
+      "listed": true,
+      "displayName": "Kimi K3 (Ollama Cloud)",
+      "description": "Kimi K3 hosted on Ollama Cloud, a 2.8T Mixture-of-Experts model with 16 activated experts, native multimodal support (text, image, video), tool use, reasoning, and a 1M-token context window.",
+      "priority": 25,
+      "defaultEffort": "max",
+      "reasoningLevels": [
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Balanced deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning depth"
+        }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 940000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "requestProfile": "ollama-cloud",
+      "compHash": "ollama-cloud-kimi-k3-v1"
+    }
+  ]
+}

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -107,6 +107,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "ollama-cloud/deepseek-v4-pro",
       "ollama-cloud/glm-5.2",
       "ollama-cloud/kimi-k2.7-code",
+      "ollama-cloud/kimi-k3",
       "ollama-cloud/minimax-m3",
       "opencode-go/deepseek-v4-flash",
       "opencode-go/deepseek-v4-pro",

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -471,6 +471,19 @@ test("provider registry exposes configured API and OAuth model families", () => 
     assert.equal(k3.defaultEffort, "max", slug);
     assert.equal(k3.requestProfile, "kimi-k3", slug);
   }
+  // Kimi K3 on Ollama Cloud uses the :cloud upstream tag and the shared
+  // ollama-cloud request profile; the ladder matches the other K3 providers.
+  const ollamaK3 = MODEL_BY_SLUG.get("ollama-cloud/kimi-k3");
+  assert.equal(ollamaK3.upstreamModel, "kimi-k3:cloud");
+  assert.equal(ollamaK3.requestProfile, "ollama-cloud");
+  assert.deepEqual(
+    ollamaK3.reasoningLevels.map((level) => level.effort),
+    ["low", "high", "max"],
+  );
+  assert.equal(ollamaK3.defaultEffort, "max");
+  assert.equal(ollamaK3.contextWindow, 1_048_576);
+  assert.equal(ollamaK3.autoCompact, 940_000);
+  assert.deepEqual(ollamaK3.inputModalities, ["text", "image"]);
   // Hosted search is an xAI-backend behavior. Standalone search is limited to
   // provider/model pairs verified against Codex's client-side replay path.
   for (const slug of ["grok-oauth/grok-4.5", "grok-oauth/grok-4.6"]) {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3067,6 +3067,8 @@ test("API forwarder routes Ollama Cloud models without unsupported parameters", 
       ["ollama-cloud-glm-5-2", "glm-5.2", "minimal", "none"],
       ["ollama-cloud-glm-5-2", "glm-5.2", "bogus", "high"],
       ["ollama-cloud-kimi-k2-7-code", "kimi-k2.7-code", "high", "high"],
+      ["ollama-cloud-kimi-k3", "kimi-k3:cloud", "low", "low"],
+      ["ollama-cloud-kimi-k3", "kimi-k3:cloud", "max", "max"],
     ]) {
       const response = await fetch(
         `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3157,6 +3157,52 @@ test("API forwarder routes Ollama Cloud models without unsupported parameters", 
 });
 
 
+test("API forwarder surfaces Ollama Cloud upstream failures for Kimi K3", async () => {
+  const upstream = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    json(response, 503, {
+      error: { message: "model overloaded", type: "server_error" },
+    });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    OLLAMA_CLOUD_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OLLAMA_API_KEY: "TEST_OLLAMA_CLOUD_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "ollama-cloud-kimi-k3",
+          reasoning_effort: "max",
+          messages: [{ role: "user", content: "test" }],
+        }),
+      },
+    );
+    assert.equal(response.status, 503);
+    const payload = await response.json();
+    assert.ok(
+      payload.error.message.includes("model overloaded"),
+      `expected upstream error message preserved, got: ${payload.error.message}`,
+    );
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder routes Qwen plan models without unsupported parameters", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {


### PR DESCRIPTION
## Summary

Adds Kimi K3 hosted on Ollama Cloud as a routed model.

## Changes

- `config/ollama/cloud/kimi-k3.json` — new model config
- `README.md` — model table row
- `test/registry.test.mjs` — expected slug list
- `test/routing.test.mjs` — effort mapping test cases (`low`, `max`)

## Model details

Kimi K3 is a 2.8T-parameter MoE model (16/896 experts activated) with native multimodal support (text, image, video), tool use, thinking, and a 1M-token context window. The `:cloud` tag is used as the upstream model.

Source: [ollama.com/library/kimi-k3](https://ollama.com/library/kimi-k3)

### Reasoning levels

Following the existing Kimi K3 configs (`kimi-oauth/k3`, `kimi-api/kimi-k3`, `opencode-go/kimi-k3`), this model advertises `low`, `high`, and `max` effort levels. The Ollama Cloud OpenAI-compatible endpoint accepts `reasoning_effort` values `high/medium/low/max/none`; all three advertised levels map directly without forwarder changes.

## Validation

- `npm run check` — passed
- `test/registry.test.mjs` — 11 pass, 0 fail
- `test/routing.test.mjs` — 47 pass, 0 fail
- Combined: 58 pass, 0 fail, 0 skip