### PR TITLE
feat: certify GLM-5.3 for v2 agents

### DIFF
--- a/config/zai/coding/glm-5.3.json
+++ b/config/zai/coding/glm-5.3.json
@@ -36,6 +36,7 @@
       "behaviorTemplate": "gpt-5.6-sol",
       "instructionOverlay": "efficient-agentic",
       "requestProfile": "glm-thinking",
+      "multiAgentVersion": "v2",
       "compHash": "zai-coding-glm-5-3-v2"
     }
   ]

--- a/test/v2-agent-applications.test.mjs
+++ b/test/v2-agent-applications.test.mjs
@@ -56,7 +56,7 @@ test("a draft may be submitted before live evidence exists", () => {
     slug: "example/beta",
     status: "draft",
   });
-  assert.equal(validateV2AgentApplications(root)[0].status, "draft");
+  assert.equal(validateV2AgentApplications(root, { models: [] })[0].status, "draft");
 });
 
 test("proofs fail closed on missing checks, identity drift, and credential-shaped content", () => {
@@ -177,7 +177,7 @@ test("the route directory is independent of slash-bearing upstream model ids", (
     slug: "example/alpha-v2",
     status: "draft",
   });
-  assert.deepEqual(validateV2AgentApplications(root)[0], {
+  assert.deepEqual(validateV2AgentApplications(root, { models: [] })[0], {
     provider: "example",
     model: "accounts/vendor/models/alpha:v2",
     slug: "example/alpha-v2",

--- a/v2_agent/zai-coding/glm-5.3/proof.json
+++ b/v2_agent/zai-coding/glm-5.3/proof.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "provider": "zai-coding",
+  "model": "glm-5.3",
+  "slug": "zai-coding/glm-5.3",
+  "status": "accepted",
+  "officialSources": [
+    "https://z.ai/blog/glm-5.3",
+    "https://z.ai/subscribe"
+  ],
+  "testedAt": "2026-08-23T18:26:52.888Z",
+  "routerVersion": "0.4.0-beta.4",
+  "checks": {
+    "streaming": { "outcome": "pass", "status": 200, "observedAt": "2026-08-16T20:40:23.293Z" },
+    "toolCall": { "outcome": "pass", "status": 200, "observedAt": "2026-08-16T20:40:23.293Z" },
+    "encryptedRelay": { "outcome": "pass", "status": 200, "observedAt": "2026-08-23T18:24:22.075Z" },
+    "markerReturn": { "outcome": "pass", "status": 200, "observedAt": "2026-08-23T18:24:22.075Z" },
+    "sameThreadFollowUp": { "outcome": "pass", "status": 200, "observedAt": "2026-08-23T18:26:52.885Z" }
+  }
+}

--- a/v2_agent/zai-coding/glm-5.3/proof.md
+++ b/v2_agent/zai-coding/glm-5.3/proof.md
@@ -1,0 +1,24 @@
+# v2 agent application: `zai-coding/glm-5.3`
+
+## Route
+
+- Routed slug: `zai-coding/glm-5.3`
+- Upstream model ID: `glm-5.3`
+- Provider: Z.ai GLM Coding Plan
+- Router version: `0.4.0-beta.4`
+- Test completed: `2026-08-23T18:26:52.888Z`
+
+## Evidence
+
+| Check | Result | Redacted summary |
+| --- | --- | --- |
+| Official model identity | pass | Z.ai's GLM-5.3 release identifies the model, its coding focus, and low/high/max reasoning with max recommended for coding; the Coding Plan page confirms GLM-5.3 availability for coding agents. |
+| Streaming Responses | pass | Router probe completed with HTTP 200 and verified streamed text plus a completion event at `2026-08-16T20:40:23.293Z`. |
+| Forced function call | pass | Router probe completed with HTTP 200 and verified a function call with valid JSON arguments at `2026-08-16T20:40:23.293Z`. |
+| Encrypted relay | pass | Codex `0.149.0-alpha.4.1` created a named GLM-5.3 child at max reasoning; its persisted child turn received an encrypted parent task and completed through the routed model with HTTP 200. |
+| Marker-return spawn | pass | The real child returned the first exact certification marker and completed successfully; corresponding routed GLM-5.3 metering recorded HTTP 200 at `2026-08-23T18:24:22.075Z`. |
+| Same-thread follow-up | pass | The existing child thread received a second task and returned the second exact marker; corresponding routed GLM-5.3 metering recorded HTTP 200 at `2026-08-23T18:26:52.885Z`. |
+
+## Limits and reviewer reproduction
+
+Reproduction requires an active Z.ai Coding Plan route and a Codex client with native multi-agent v2 enabled. Spawn a named GLM-5.3 child at max reasoning, wait for one exact marker, send a second marker task to the same child thread, and verify both child turns and HTTP-success metering. Do not record prompts, response bodies, encrypted payloads, credentials, or capability-bearing router URLs in repository evidence.


### PR DESCRIPTION
## Summary
- certify `zai-coding/glm-5.3` as a repository-authoritative native v2 agent route
- add redacted accepted evidence for streaming, forced tool calls, encrypted parent-to-child relay, exact marker return, and same-thread follow-up using GLM-5.3 at max reasoning
- isolate two v2-application parser tests from the repository's live model registry so new certified routes do not contaminate synthetic fixtures

## Verification
- `node scripts/check-v2-agent-applications.mjs`
- `node --test test/v2-agent-applications.test.mjs test/codex-agent-catalog.test.mjs test/subagent-proofs.test.mjs test/subagent-effort.test.mjs` (35 passed, 1 Windows symlink test skipped)
- `npm run check`
- `git diff --check`

The proof artifacts contain only redacted status/timestamp summaries and official Z.ai links; no prompts, response bodies, encrypted payloads, credentials, or capability-bearing router URLs are included.