### PR TITLE
Require opt-in for ChatGPT session sharing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,8 @@ translation layer and nothing else.
    proof. Relaying it upstream would put a router secret on a hop that can be
    substituted onto a provider — and leaving the header off is also what makes
    `callerBroughtNoUpstreamCredential` true, which is how a client with no
-   ChatGPT session of its own reaches native models.
+   ChatGPT session of its own reaches native models after the user explicitly
+   authorizes the shared router plane once.
 7. **The default model is written, and that is deliberate.** Gemini CLI's own
    default is `gemini-2.5-pro`, which this router does not route, so an install
    that left it alone would 404 on the user's first turn. `GEMINI_MODEL`
@@ -314,16 +315,18 @@ beside ours, so everything else in them is somebody else's work.
    the same bound the harness itself holds them to, and status output reports
    the redacted URL exactly as the Codex manager does. Never print the complete
    managed base URL.
-4. **Routed models are always published; native ones only while a session backs
-   them.** Publish only the selected, credentialed, listed, non-hidden routed
+4. **Routed models are always published; native ones require authorization and
+   a session.** Publish only the selected, credentialed, listed, non-hidden routed
    models. An unregistered slug on the router's `/v1/responses` endpoint is
    treated as native GPT traffic needing a ChatGPT session, which a harness
-   request does not carry — so a native model is advertised only while
+   request does not carry — so a native model is advertised only while the user
+   has explicitly authorized this shared local router plane and
    `nativeSessionStatus().usable` reports the session this machine is signed in
-   with as spendable, and is withheld again the moment it is not. Publishing one
-   the router cannot authorize offers a turn that 401s, which is the failure
-   this gate exists to prevent; never widen it to presence alone, because an
-   expired session is present.
+   with as spendable. `nativeSessionAvailable()` is the combined gate. Missing
+   consent, an unreadable consent marker, sign-out, or expiry withholds the model.
+   Publishing one the router cannot authorize offers a turn that 401s, which is
+   the failure this gate exists to prevent; never widen it to presence alone,
+   because an expired session is present.
    The vision-bridge engine candidates still exclude native models: that call
    site admits an engine on evidence the *caller's* session can spend it, and a
    substituted session is not the caller's.
@@ -1754,10 +1757,12 @@ user has to find in the docs, so `src/dsh-install.mjs` owns the other half.
   get right — the PATH a spawn inherits, where npm drops binaries per platform,
   which line of npm's output is worth showing — are exactly what drifts.
 - Native GPT models are published only while `codex-native-session.mjs` reports
-  a usable session: they need a ChatGPT session, a harness request carries none
-  of its own, and the fallback spends the one this machine is already signed in
-  with. They are withheld again the moment it is missing or expired. The count
-  the button reports is the routable set, not the picker.
+  both explicit shared-plane authorization and a usable session: they need a
+  ChatGPT session, and a harness request carries none of its own. One
+  `chatgpt-session enable` applies to every local client for this OS user; they
+  are withheld again the moment authorization is revoked or the session is
+  missing or expired. The count the button reports is the routable set, not the
+  picker.
 
 `src/dsh-web.mjs` starts and finds the browser UI, so the tray's button can be
 `Open site` once there is a site to open.
@@ -1811,9 +1816,18 @@ attaches both. A harness turn attaches neither, so native models advertised to
 it were models it could never spend.
 
 `src/codex-native-session.mjs` closes that by falling back to the session this
-machine is already signed in with, in `$CODEX_HOME/auth.json`. The user is
-signed in to Codex here; asking them to sign in again for a client running as
-the same user on the same machine buys nothing.
+machine is already signed in with, in `$CODEX_HOME/auth.json`, only after the
+user authorizes that use once. `native-session-consent.json` is an owner-only
+marker carrying no credential and belongs to the shared router plane: asking
+the same OS user to sign in or authorize once per harness buys nothing.
+
+- **Consent fails closed.** A missing, malformed, or unrecognized marker means
+  off. `chatgpt-session enable` refuses until `codex login` has produced a
+  usable session, then republishes every installed client; `disable` removes
+  the marker and republishes them again without signing Codex out. The
+  `CODEX_ROUTER_NATIVE_SESSION_FALLBACK=1` environment override is the explicit
+  headless opt-in, while `0` is an emergency off switch. No other value is
+  consent.
 
 - **Fallback, never override.** Injection happens only when the request carried
   no *upstream* credential. Codex always carries one, so a Codex turn is
@@ -1847,10 +1861,11 @@ the same user on the same machine buys nothing.
   a status call, and not put in an error message. `nativeSessionStatus()` reports
   presence, usability, and age — `test/codex-native-session.test.mjs` asserts the
   serialized status contains neither the token nor the account id.
-- **It widens the caller key.** With the fallback on, anything holding that key
-  spends the ChatGPT subscription and not only the API-key providers. That is a
-  deliberate, user-made tradeoff; `CODEX_ROUTER_NATIVE_SESSION_FALLBACK=0` turns
-  it off and the harness silently drops back to routed models only.
+- **It widens the caller key.** With sharing authorized, anything holding that
+  local key spends the ChatGPT subscription and not only the API-key providers.
+  That is a deliberate, user-made tradeoff recorded once for the shared plane;
+  `chatgpt-session disable` revokes it everywhere and the clients silently drop
+  back to routed models only.
 - **The access token lives about ten days, and Codex renews it only when Codex
   is used.** A harness-only stretch longer than that would otherwise leave the
   router sending a dead token. `nativeSessionHeaders()` reads the `exp` claim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **ChatGPT subscription access for non-Codex clients is now an explicit,
+  one-time local authorization.** A discovered Codex `auth.json` no longer
+  silently lets DeepSeek Harness, Gemini CLI, or another caller-key client
+  spend the account. After `codex login`, the user runs `model-router codex
+  chatgpt-session enable` once; an owner-only, credential-free marker applies
+  that decision to every client on the shared loopback router plane. Disabling
+  it revokes native GPT publication everywhere without signing Codex out. A
+  missing or malformed authorization and a missing or expired session both
+  fail closed. External model routes and Codex's own session pass-through are
+  unchanged.
+
 - **Ox Alpha ships on six routes.** The stealth 1M-context reasoning model is
   now checked in for `opencode-free` (no key), `opencode-go`, `openrouter`,
   `commandcode`, `nousresearch`, and `venice`, each under the upstream id that

--- a/README.md
+++ b/README.md
@@ -1520,20 +1520,31 @@ comments, and your other stored keys are left exactly as they were —
 A settings file this build cannot read unambiguously is refused with the file
 untouched rather than rewritten on a guess.
 
-**Native GPT models publish while this machine has a usable Codex session.**
-They are authorized by a ChatGPT session and a harness request carries none of
-its own, so the router falls back to the session Codex is already signed in with
-here — you are logged in on this machine, and a client running as the same user
-should not have to log in again. They are withheld the moment that session is
-missing or expired, so the picker never offers a turn that would 401. If they
-disappear, open Codex once to renew it; `./bin/model-router doctor` says so too.
+**Native GPT models require one explicit local authorization.** They are
+authorized by a ChatGPT session and a harness request carries none of its own.
+Sign in through the official Codex browser flow, then authorize this shared
+router plane once:
+
+```sh
+codex login
+./bin/model-router codex chatgpt-session enable
+```
+
+DeepSeek Harness, Gemini CLI, and future clients installed for this same OS
+user then reuse that one authorization over the loopback; there is no login per
+harness and the marker stores no credential. Native models are withheld until
+both the authorization and a usable Codex session exist, and disappear again
+when the session is missing or expired. Run `codex login` to renew the session;
+the one-time authorization remains in place.
 
 It is a fallback and never an override: a request that presents its own
-credential is relayed untouched, so nothing about a Codex turn changes. Worth
-knowing before leaving it on — it widens what the caller key reaches, from the
-API-key providers to your ChatGPT subscription as well. Set
-`CODEX_ROUTER_NATIVE_SESSION_FALLBACK=0` to turn it off, and the harness
-publishes routed models only.
+credential is relayed untouched, so nothing about a Codex turn changes. The
+authorization widens what the local caller key reaches, from API-key providers
+to your ChatGPT subscription as well. Revoke it everywhere with
+`./bin/model-router codex chatgpt-session disable`; Codex stays signed in and
+keeps its own native models. Headless operators may set
+`CODEX_ROUTER_NATIVE_SESSION_FALLBACK=1` as an explicit opt-in (`0` always
+forces it off).
 
 **Subagents.** A child spawned by `dsh-tool-subagent` with no model of its own
 inherits the default model selection, so it is already routed once this route
@@ -1591,8 +1602,8 @@ fabricated vector would be worse than an error. `:countTokens` is answered from
 a byte-count estimate rather than by spending a real turn upstream.
 
 **Native GPT models** publish here under the same rule as the harness, described
-above: while this machine has a usable Codex session, and withheld the moment it
-does not.
+above: after the one-time shared-plane authorization, while this machine has a
+usable Codex session, and withheld the moment either condition stops holding.
 
 ## macOS tray control panel
 

--- a/bin/chatgpt-session
+++ b/bin/chatgpt-session
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+exec node "$repo_dir/src/chatgpt-session.mjs" "$@"

--- a/bin/codex-router
+++ b/bin/codex-router
@@ -35,6 +35,7 @@ Setup and status
 Providers and models
   providers         List providers and their authentication state
   provider-key      Store or clear a provider API key
+  chatgpt-session   Authorize or revoke shared native GPT access
   curate-models     Add, edit, or remove locally curated models
   discover-models   Probe a provider for the models it exposes
   refresh-catalog   Rebuild the merged model catalog

--- a/bin/enable
+++ b/bin/enable
@@ -88,9 +88,11 @@ service_installed=false
 trap - EXIT HUP INT TERM
 if [ "$target" = dsh ]; then
   echo "External model routes published to DeepSeek Harness. It reloads them on the next request."
+  echo "Optional native GPT models: run 'codex login', then './bin/model-router codex chatgpt-session enable' once; every local client will reuse it."
 elif [ "$target" = gemini ]; then
   echo "External model routes published to Gemini CLI. The next \`gemini\` run picks them up."
   echo "Choose \"Use Gemini API key\" once if it asks how to authenticate; the key is this router's local caller capability."
+  echo "Optional native GPT models: run 'codex login', then './bin/model-router codex chatgpt-session enable' once; every local client will reuse it."
 else
   echo "External model routes enabled. Fully quit and reopen Codex."
 fi

--- a/bin/model-router
+++ b/bin/model-router
@@ -18,14 +18,15 @@ command writes, not which router it talks to.
 
 Commands:
   setup, install, doctor, status, provider-key, providers, enable, disable,
-  multi-agent, media, panel, local-mlx, uninstall, smoke-test, start, stop, update,
-  rollback, shim, subagent-preset (dsh only)
+  chatgpt-session, multi-agent, media, panel, local-mlx, uninstall, smoke-test,
+  start, stop, update, rollback, shim, subagent-preset (dsh only)
 
 Examples:
   ./bin/model-router codex doctor
   ./bin/model-router codex status
   ./bin/model-router codex panel
   ./bin/model-router codex local-mlx install --yes
+  ./bin/model-router codex chatgpt-session enable
   ./bin/model-router codex shim install
   ./bin/model-router dsh enable
   ./bin/model-router dsh status
@@ -63,7 +64,7 @@ case "$target" in
 esac
 
 case "$command" in
-  setup|install|doctor|status|provider-key|providers|enable|disable|multi-agent|media|panel|local-mlx|uninstall|smoke-test|start|stop|update|rollback|subagent-preset|shim) ;;
+  setup|install|doctor|status|provider-key|providers|enable|disable|chatgpt-session|multi-agent|media|panel|local-mlx|uninstall|smoke-test|start|stop|update|rollback|subagent-preset|shim) ;;
   *) echo "Unknown command: $command" >&2; usage >&2; exit 2 ;;
 esac
 

--- a/codex-router.ps1
+++ b/codex-router.ps1
@@ -14,7 +14,7 @@ $Command = if ($args.Count) { [string]$args[0] } else { "status" }
 $Arguments = @(if ($args.Count -gt 1) { $args[1..($args.Count - 1)] })
 $Commands = @(
   "setup", "install", "doctor", "status", "providers", "provider-key", "enable",
-  "disable", "uninstall", "update", "rollback", "support-bundle",
+  "disable", "chatgpt-session", "uninstall", "update", "rollback", "support-bundle",
   "smoke-test", "start", "stop", "test-model", "discover-models", "local-mlx",
   "signed-routing", "refresh-catalog", "media", "tray", "panel", "companion"
 )
@@ -234,6 +234,7 @@ switch ($Command) {
   }
   "providers" { Invoke-RouterNode "src\providers.mjs" $Arguments }
   "provider-key" { Invoke-RouterNode "src\provider-key.mjs" $Arguments }
+  "chatgpt-session" { Invoke-RouterNode "src\chatgpt-session.mjs" $Arguments }
   # `bin/install` accepts --prepare-only/--migrate-known/--force-deps, so the
   # Windows wrapper has to pass the equivalent switches through instead of
   # dropping them; `./model-router.ps1 codex install -ForceDeps` was silently

--- a/src/chatgpt-session.mjs
+++ b/src/chatgpt-session.mjs
@@ -1,0 +1,82 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  nativeSessionStatus,
+  setNativeSessionSharingEnabled,
+} from "./codex-native-session.mjs";
+import { refreshTargetPickerIfInstalled } from "./target-integration.mjs";
+
+function usage() {
+  return "Usage: chatgpt-session enable|disable|status [--json]";
+}
+
+function safeStatus() {
+  const status = nativeSessionStatus();
+  return {
+    sharing: status.sharingEnabled ? "enabled" : "disabled",
+    session: status.usable ? "usable" : status.expired ? "expired" : "unavailable",
+    present: status.present,
+    expiresInHours: status.expiresInHours,
+  };
+}
+
+export function setChatGptSessionSharing(enabled) {
+  setNativeSessionSharingEnabled(enabled);
+  const refreshed = refreshTargetPickerIfInstalled();
+  return { ...safeStatus(), refreshed };
+}
+
+function printStatus(status, { json = false } = {}) {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(status)}\n`);
+    return;
+  }
+  if (status.sharing === "enabled") {
+    if (status.session !== "usable") {
+      process.stdout.write(
+        "ChatGPT session sharing is authorized, but no usable Codex login is available. Native GPT models are withheld from other local clients until you run `codex login`.\n",
+      );
+      return;
+    }
+    const expiry = status.expiresInHours === undefined
+      ? ""
+      : ` (session valid for about ${status.expiresInHours}h)`;
+    process.stdout.write(
+      `ChatGPT session sharing is enabled for this user's local Codex Router clients${expiry}.\n`,
+    );
+  } else {
+    process.stdout.write(
+      "ChatGPT session sharing is disabled. Native GPT models stay available to Codex itself, but are not exposed to other local clients.\n",
+    );
+  }
+}
+
+export function runChatGptSessionCommand(args = process.argv.slice(2)) {
+  const command = args[0] || "status";
+  const json = args.includes("--json");
+  const extras = args.slice(1).filter((argument) => argument !== "--json");
+  if (!["enable", "disable", "status"].includes(command) || extras.length > 0) {
+    throw Object.assign(new Error(usage()), { exitCode: 2 });
+  }
+  if (command === "status") {
+    const status = safeStatus();
+    printStatus(status, { json });
+    return status;
+  }
+  const status = setChatGptSessionSharing(command === "enable");
+  printStatus(status, { json });
+  if (!json && status.refreshed) {
+    process.stdout.write("Installed client model catalogs were refreshed.\n");
+  }
+  return status;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    runChatGptSessionCommand();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(error?.exitCode || 1);
+  }
+}

--- a/src/codex-native-session.mjs
+++ b/src/codex-native-session.mjs
@@ -1,8 +1,9 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 
 import { discoveryDisabled } from "./discovery-mode.mjs";
-import { CODEX_HOME } from "./paths.mjs";
+import { writePrivateJson } from "./file-security.mjs";
+import { CODEX_HOME, NATIVE_SESSION_CONSENT_PATH } from "./paths.mjs";
 
 // The ChatGPT session the local Codex install already holds.
 //
@@ -11,11 +12,13 @@ import { CODEX_HOME } from "./paths.mjs";
 // Codex attaches both. A DeepSeek Harness turn attaches neither, so a native
 // model advertised to the harness used to be a model it could not spend.
 //
-// This module lets the router fall back to the session already sitting in
-// `$CODEX_HOME/auth.json` -- the user is signed in to Codex on this machine, and
-// asking them to sign in again for a client running as the same user on the same
-// machine buys nothing. It is a *fallback*: a caller that presents its own
-// credential is always relayed unchanged, so Codex is untouched by this.
+// This module can fall back to the session already sitting in
+// `$CODEX_HOME/auth.json`, but only after the user authorizes that once for the
+// shared router plane. The authorization is one owner-only marker carrying no
+// credential. DeepSeek Harness, Gemini CLI, and any future local client then
+// share that decision; asking the same OS user to sign in once per harness buys
+// nothing. It is still a *fallback*: a caller that presents its own credential
+// is always relayed unchanged, so Codex is untouched by this.
 //
 // The values are never logged, never returned by a status call, and never put
 // in an error message. `nativeSessionStatus` reports presence and age only,
@@ -23,15 +26,37 @@ import { CODEX_HOME } from "./paths.mjs";
 export const CODEX_AUTH_PATH =
   process.env.MODEL_ROUTER_CODEX_AUTH || path.join(CODEX_HOME, "auth.json");
 
-// Off switch. The fallback widens what the caller key reaches -- with it, a
-// local process holding that key can spend the ChatGPT subscription and not
-// only the API-key providers -- so there has to be a way to say no.
-export function nativeSessionFallbackEnabled() {
+function consentMarkerEnabled() {
+  if (!existsSync(NATIVE_SESSION_CONSENT_PATH)) return false;
+  try {
+    const parsed = JSON.parse(readFileSync(NATIVE_SESSION_CONSENT_PATH, "utf8"));
+    return parsed?.version === 1 && parsed.sharing === "enabled";
+  } catch {
+    // This marker is an authorization boundary. An unreadable or unrecognized
+    // file cannot prove consent, so it must fail closed.
+    return false;
+  }
+}
+
+// The fallback widens what the caller key reaches -- with it, a local process
+// holding that key can spend the ChatGPT subscription and not only API-key
+// providers. Missing state therefore means off, unlike the old implicit
+// discovery behavior. `1` is an explicit headless opt-in and `0` an emergency
+// off switch; any other environment value is not consent.
+export function nativeSessionSharingEnabled() {
   // --no-discovery composes with the dedicated env switch: the Codex session
   // is a credential this process did not receive from its caller, so an idle
   // install must never spend it.
   if (discoveryDisabled()) return false;
-  return process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK !== "0";
+  const override = process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
+  if (override !== undefined) return override === "1";
+  return consentMarkerEnabled();
+}
+
+// Kept as an API alias for callers and integrations written against the first
+// version of this feature. The behavior is now explicit sharing consent.
+export function nativeSessionFallbackEnabled() {
+  return nativeSessionSharingEnabled();
 }
 
 // The `exp` claim, in epoch milliseconds. Only the claim is read; the token
@@ -78,6 +103,48 @@ function readSession() {
     // the way it did before, with the upstream's own 401.
     return undefined;
   }
+}
+
+/**
+ * Records or revokes the user's one-time, shared-plane authorization.
+ *
+ * Enabling is allowed only while the official Codex login is usable. The
+ * router never creates, copies, or refreshes that credential itself. A forced
+ * environment policy must be removed before the saved decision can be changed.
+ */
+export function setNativeSessionSharingEnabled(enabled) {
+  if (!enabled) {
+    if (process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK === "1") {
+      throw new Error(
+        "CODEX_ROUTER_NATIVE_SESSION_FALLBACK=1 forces ChatGPT session sharing on. Remove that environment override, then run this disable command again.",
+      );
+    }
+    rmSync(NATIVE_SESSION_CONSENT_PATH, { force: true });
+    return false;
+  }
+  if (discoveryDisabled()) {
+    throw new Error(
+      "ChatGPT session sharing cannot be enabled while credential discovery is disabled.",
+    );
+  }
+  const override = process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
+  if (override !== undefined && override !== "1") {
+    throw new Error(
+      "ChatGPT session sharing is forced off by CODEX_ROUTER_NATIVE_SESSION_FALLBACK. Remove that environment override or set it to 1 before enabling sharing.",
+    );
+  }
+  const session = readSession();
+  if (!session || session.expired) {
+    throw new Error(
+      "No usable ChatGPT session is available. Run `codex login`, complete the browser sign-in, then retry.",
+    );
+  }
+  writePrivateJson(
+    NATIVE_SESSION_CONSENT_PATH,
+    { version: 1, sharing: "enabled" },
+    { directoryMode: 0o700 },
+  );
+  return true;
 }
 
 // Codex owns this credential and is the only thing that may rewrite it.
@@ -135,7 +202,7 @@ export async function refreshViaCodex({ now = Date.now() } = {}) {
  * the request exactly as it arrived.
  */
 export function nativeSessionHeaders() {
-  if (!nativeSessionFallbackEnabled()) return undefined;
+  if (!nativeSessionSharingEnabled()) return undefined;
   const session = readSession();
   if (!session) return undefined;
   if (session.expired) {
@@ -175,6 +242,7 @@ export function nativeSessionStatus() {
       expired: false,
       expiresInHours: undefined,
       ageHours: undefined,
+      sharingEnabled: false,
       fallbackEnabled: false,
     };
   }
@@ -188,11 +256,13 @@ export function nativeSessionStatus() {
       ageHours = undefined;
     }
   }
+  const sharingEnabled = nativeSessionSharingEnabled();
   return {
     path: CODEX_AUTH_PATH,
     present,
-    // Usable means spendable: present, parseable, and not expired. This is what
-    // gates publishing, so the harness is never offered a model that would 401.
+    // Usable means the credential itself is spendable: present, parseable, and
+    // not expired. Publishing additionally requires explicit sharing consent,
+    // which `nativeSessionAvailable()` applies.
     usable: Boolean(session) && !session.expired,
     hasAccountId: Boolean(session?.accountId),
     expired: Boolean(session?.expired),
@@ -204,6 +274,7 @@ export function nativeSessionStatus() {
         ? undefined
         : Math.round(((session.expiresAtMs - Date.now()) / 36e5) * 10) / 10,
     ageHours,
-    fallbackEnabled: nativeSessionFallbackEnabled(),
+    sharingEnabled,
+    fallbackEnabled: sharingEnabled,
   };
 }

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -1061,15 +1061,28 @@ add(
 try {
   const { nativeSessionStatus } = await import("./codex-native-session.mjs");
   const session = nativeSessionStatus();
-  if (session.present && session.fallbackEnabled) {
+  if (session.sharingEnabled) {
     const hours = session.expiresInHours;
     add(
       session.usable ? "ok" : "warn",
-      "Codex session for harness models",
+      "ChatGPT session for local clients",
       session.usable
         ? `valid${hours === undefined ? "" : ` for ${hours}h`}`
-        : "expired; open Codex once to renew it (native models are withheld until then)",
-      "Open Codex, or run `codex login`.",
+        : session.present
+          ? "expired; native models are withheld from non-Codex clients until sign-in is renewed"
+          : "sharing is enabled, but no Codex login is available; native models are withheld",
+      "Run `codex login`; the existing one-time sharing authorization will be reused.",
+    );
+  } else if (session.present) {
+    add(
+      session.usable ? "ok" : "warn",
+      "ChatGPT session for local clients",
+      session.usable
+        ? "not shared; the router exposes no native GPT models to other local clients"
+        : "not shared and not currently usable; the router exposes no native GPT models to other local clients",
+      session.usable
+        ? "To authorize every local router client once, run `./bin/model-router codex chatgpt-session enable`."
+        : "Run `codex login`, then authorize every local router client once with `./bin/model-router codex chatgpt-session enable`.",
     );
   }
 } catch {

--- a/src/dsh-catalog.mjs
+++ b/src/dsh-catalog.mjs
@@ -9,8 +9,9 @@
 // Routed models are always published. An unregistered slug on the router's
 // `/v1/responses` endpoint is treated as native GPT traffic, which needs a
 // ChatGPT session the harness does not carry — so a native model is published
-// only while `codex-native-session.mjs` can substitute the one this machine is
-// signed in with, and is withheld again the moment it cannot. See
+// only after this user authorizes the shared router plane and while
+// `codex-native-session.mjs` can substitute the session this machine is signed
+// in with. It is withheld again the moment either condition stops holding. See
 // `dshNativeModels` below.
 
 import { applyVisionBridge } from "./vision-bridge.mjs";

--- a/src/dsh-config-manager.mjs
+++ b/src/dsh-config-manager.mjs
@@ -359,10 +359,11 @@ function restoreDefaultModel(contents) {
  * The routed models the harness should be offered, vision bridge included.
  *
  * The rule is not the harness's own -- what may be published to a client that
- * carries no ChatGPT session of its own is the same question for every such
- * client -- so it lives in `routed-client-models.mjs` and both integrations
- * read it. Two copies would drift, and the way that shows is one picker
- * offering a model the other just lost.
+ * carries no ChatGPT session of its own, after the user's one-time router-plane
+ * authorization, is the same question for every such client -- so it lives in
+ * `routed-client-models.mjs` and both integrations read it. Two copies would
+ * drift, and the way that shows is one picker offering a model the other just
+ * lost.
  */
 export function dshRoutedModels() {
   return routedClientModels();

--- a/src/dsh-install.mjs
+++ b/src/dsh-install.mjs
@@ -154,11 +154,11 @@ export async function setupHarness({ force = false, setDefaultModel = false } = 
     installedNow: install.changed,
     published,
     web: await dshWebState(),
-    // `published` is the routed count. Native GPT models ride the Codex session
-    // this machine is signed in with, so they come and go with it -- reporting
-    // the routed set beats a number that changes when nobody published
-    // anything, and beats letting somebody count the picker and conclude the
-    // publish dropped them.
+    // `published` is the routed count. Native GPT models require this user's
+    // one-time shared-plane authorization plus a usable Codex session, so they
+    // come and go independently -- reporting the routed set beats a number
+    // that changes when nobody published anything, and beats letting somebody
+    // count the picker and conclude the publish dropped them.
     launch: `${DSH_EXECUTABLE} web`,
   };
 }

--- a/src/gemini-surface.mjs
+++ b/src/gemini-surface.mjs
@@ -109,7 +109,8 @@ function upstreamMessage(text) {
 // it presented it on is already the proof. Relaying it upstream would put a
 // router secret on a hop that can be substituted onto a provider; leaving the
 // header off is also what makes `callerBroughtNoUpstreamCredential` true, which
-// is how a client with no ChatGPT session of its own reaches native models.
+// is how a client with no ChatGPT session of its own reaches native models
+// after this user explicitly authorizes the shared local router plane.
 function loopbackHeaders() {
   return { "content-type": "application/json", accept: "text/event-stream" };
 }

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -119,6 +119,13 @@ export const SIGNED_PROVIDER_MODE_PATH = path.join(STATE_DIR, "signed-provider-m
 export const CODEX_DEFAULT_MODEL_PATH = path.join(STATE_DIR, "codex-default-model.json");
 export const PROVIDER_SELECTION_PATH = path.join(STATE_DIR, "enabled-providers.json");
 export const DISCOVERY_MODE_PATH = path.join(STATE_DIR, "discovery-mode.json");
+// Explicit, shared-plane consent for letting router-authenticated local clients
+// use the ChatGPT session owned by this user's Codex installation. The file
+// carries no credential; its presence records only the user's authorization.
+export const NATIVE_SESSION_CONSENT_PATH = path.join(
+  STATE_DIR,
+  "native-session-consent.json",
+);
 // The last model list each provider published for itself. It is a convenience
 // cache for the curation surfaces, never an authority: what is registered
 // locally is always recomputed from the live registry.

--- a/src/routed-client-models.mjs
+++ b/src/routed-client-models.mjs
@@ -78,11 +78,9 @@ export function routedClientModels() {
     { hidden, disabled: readMultiAgentSettings().disabled },
   );
   // Native GPT models are authorized by a ChatGPT session rather than an API
-  // key. A published client carries none of its own -- but this machine is
-  // signed in to Codex, and the router relays that session for a caller that
-  // brought nothing (see `codex-native-session.mjs`). So they are publishable
-  // exactly while that fallback can supply one, and withheld the moment it
-  // cannot.
+  // key. A published client carries none of its own, so they are publishable
+  // only after this user authorizes the shared local router plane and while the
+  // signed-in Codex session remains usable (see `codex-native-session.mjs`).
   const native = nativeSessionAvailable() ? nativeClientModels(readNativeCatalogModels()) : [];
   // The vision engine still resolves over routed candidates only. A native
   // engine is spent per-caller, and `vision-engines` wants each call site to

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -613,11 +613,13 @@ async function main() {
   process.stdout.write(
     dshTarget
       ? `\nDeepSeek Harness is ready with: ${providerSummary}\n` +
-        `It reloads its settings document on the next request, so there is nothing to restart.\n`
+        `It reloads its settings document on the next request, so there is nothing to restart.\n` +
+        `For native GPT models, run \`codex login\`, then \`./bin/model-router codex chatgpt-session enable\` once; that authorization is shared by every local client.\n`
       : geminiTarget
         ? `\nGemini CLI is ready with: ${providerSummary}\n` +
           `It reads its environment at startup, so the next \`gemini\` run picks this up.\n` +
-          `If it asks how to authenticate, choose "Use Gemini API key" once -- the key is this router's local caller capability.\n`
+          `If it asks how to authenticate, choose "Use Gemini API key" once -- the key is this router's local caller capability.\n` +
+          `For native GPT models, run \`codex login\`, then \`./bin/model-router codex chatgpt-session enable\` once; that authorization is shared by every local client.\n`
         : `\nCodex Router is ready with: ${providerSummary}\nFully quit Codex, reopen it, and start a new task.\n`,
   );
   if (visionBridge?.enabled && visionBridge.engine) {

--- a/test/chatgpt-session.test.mjs
+++ b/test/chatgpt-session.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = mkdtempSync(path.join(os.tmpdir(), "chatgpt-session-command-"));
+const checkoutRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const authPath = path.join(root, "codex", "auth.json");
+process.env.MODEL_ROUTER_CODEX_AUTH = authPath;
+process.env.MODEL_ROUTER_STATE_DIR = path.join(root, "state");
+process.env.CODEX_HOME = path.join(root, "codex");
+delete process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
+
+const { setChatGptSessionSharing } = await import("../src/chatgpt-session.mjs");
+const { nativeSessionAvailable, nativeSessionStatus } = await import(
+  "../src/codex-native-session.mjs"
+);
+
+function writeAuth() {
+  mkdirSync(path.dirname(authPath), { recursive: true });
+  writeFileSync(
+    authPath,
+    JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: { access_token: "test-access", account_id: "test-account" },
+    }),
+    { encoding: "utf8", flag: "w" },
+  );
+}
+
+test("enable requires the user's own Codex login", () => {
+  assert.throws(() => setChatGptSessionSharing(true), /codex login/i);
+  assert.equal(nativeSessionStatus().sharingEnabled, false);
+});
+
+test("one authorization applies to the shared local router plane and can be revoked", () => {
+  writeAuth();
+  const enabled = setChatGptSessionSharing(true);
+  assert.deepEqual(
+    { sharing: enabled.sharing, session: enabled.session, refreshed: enabled.refreshed },
+    { sharing: "enabled", session: "usable", refreshed: false },
+  );
+  assert.equal(nativeSessionAvailable(), true);
+
+  const disabled = setChatGptSessionSharing(false);
+  assert.equal(disabled.sharing, "disabled");
+  assert.equal(nativeSessionAvailable(), false);
+  assert.equal(nativeSessionStatus().usable, true, "revocation does not sign Codex out");
+});
+
+test("the command does not pretend to override an operator environment policy", () => {
+  process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK = "0";
+  assert.throws(
+    () => setChatGptSessionSharing(true),
+    /forced off by CODEX_ROUTER_NATIVE_SESSION_FALLBACK/,
+  );
+
+  delete process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
+  setChatGptSessionSharing(true);
+  process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK = "1";
+  assert.throws(
+    () => setChatGptSessionSharing(false),
+    /forces ChatGPT session sharing on/,
+  );
+  assert.equal(nativeSessionStatus().sharingEnabled, true);
+  delete process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
+  assert.equal(
+    nativeSessionStatus().sharingEnabled,
+    true,
+    "the saved authorization remains coherent until disable can republish",
+  );
+  setChatGptSessionSharing(false);
+  assert.equal(nativeSessionStatus().sharingEnabled, false);
+});
+
+test(
+  "both POSIX dispatchers expose the safe status command",
+  { skip: process.platform === "win32" ? "POSIX dispatchers are not the Windows entry point" : false },
+  () => {
+    for (const invocation of [
+      [path.join(checkoutRoot, "bin", "model-router"), "codex", "chatgpt-session"],
+      [path.join(checkoutRoot, "bin", "codex-router"), "chatgpt-session"],
+    ]) {
+      const result = spawnSync(invocation[0], [...invocation.slice(1), "status", "--json"], {
+        encoding: "utf8",
+        env: process.env,
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), {
+        sharing: "disabled",
+        session: "usable",
+        present: true,
+      });
+      assert.doesNotMatch(result.stdout, /test-access|test-account/);
+    }
+  },
+);
+
+test.after(() => {
+  rmSync(root, { recursive: true, force: true });
+});

--- a/test/codex-native-session.test.mjs
+++ b/test/codex-native-session.test.mjs
@@ -1,5 +1,13 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
@@ -7,13 +15,18 @@ import { test } from "node:test";
 const home = mkdtempSync(path.join(os.tmpdir(), "native-session-"));
 const authPath = path.join(home, "auth.json");
 process.env.MODEL_ROUTER_CODEX_AUTH = authPath;
+process.env.MODEL_ROUTER_STATE_DIR = path.join(home, "state");
+delete process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
 
 const {
+  nativeSessionSharingEnabled,
   nativeSessionAvailable,
   nativeSessionHeaders,
   nativeSessionStatus,
+  setNativeSessionSharingEnabled,
   tokenExpiryMs,
 } = await import("../src/codex-native-session.mjs");
+const { NATIVE_SESSION_CONSENT_PATH } = await import("../src/paths.mjs");
 
 const { dshNativeModels } = await import("../src/dsh-catalog.mjs");
 
@@ -28,6 +41,12 @@ function clearAuth() {
   rmSync(authPath, { force: true });
 }
 
+test.beforeEach(() => {
+  clearAuth();
+  setNativeSessionSharingEnabled(false);
+  delete process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
+});
+
 test("no session on disk means no fallback rather than an error", () => {
   clearAuth();
   assert.equal(nativeSessionAvailable(), false);
@@ -35,21 +54,42 @@ test("no session on disk means no fallback rather than an error", () => {
   assert.equal(nativeSessionStatus().present, false);
 });
 
-test("a signed-in session becomes the two headers a native turn needs", () => {
+test("a signed-in session stays private until the user authorizes sharing once", () => {
   writeAuth({ access_token: ACCESS, account_id: ACCOUNT });
+  assert.equal(nativeSessionSharingEnabled(), false);
+  assert.equal(nativeSessionHeaders(), undefined);
+  assert.equal(nativeSessionStatus().usable, true, "login usability is reported independently");
+
+  setNativeSessionSharingEnabled(true);
+  assert.equal(nativeSessionSharingEnabled(), true);
   assert.deepEqual(nativeSessionHeaders(), {
     authorization: `Bearer ${ACCESS}`,
     "chatgpt-account-id": ACCOUNT,
   });
   assert.equal(nativeSessionAvailable(), true);
+  assert.equal(existsSync(NATIVE_SESSION_CONSENT_PATH), true);
+  if (process.platform !== "win32") {
+    assert.equal(statSync(NATIVE_SESSION_CONSENT_PATH).mode & 0o777, 0o600);
+  }
+  assert.doesNotMatch(readFileSync(NATIVE_SESSION_CONSENT_PATH, "utf8"), /access|account/i);
+});
+
+test("sharing cannot be enabled before the user signs in", () => {
+  assert.throws(
+    () => setNativeSessionSharingEnabled(true),
+    /run `codex login`/i,
+  );
+  assert.equal(existsSync(NATIVE_SESSION_CONSENT_PATH), false);
 });
 
 test("status reports presence, never the credential", () => {
   writeAuth({ access_token: ACCESS, account_id: ACCOUNT });
+  setNativeSessionSharingEnabled(true);
   const status = nativeSessionStatus();
   assert.equal(status.present, true);
   assert.equal(status.usable, true);
   assert.equal(status.hasAccountId, true);
+  assert.equal(status.sharingEnabled, true);
   // The whole point of the status shape: it is safe to print, log, and paste
   // into an issue. A token that reaches any of those has to be rotated.
   const serialized = JSON.stringify(status);
@@ -70,6 +110,7 @@ test("a session with no access token is not a session", () => {
 
 test("the fallback can be switched off", () => {
   writeAuth({ access_token: ACCESS, account_id: ACCOUNT });
+  setNativeSessionSharingEnabled(true);
   process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK = "0";
   try {
     assert.equal(nativeSessionHeaders(), undefined);
@@ -78,6 +119,24 @@ test("the fallback can be switched off", () => {
   } finally {
     delete process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
   }
+});
+
+test("the environment override is explicit in both directions", () => {
+  writeAuth({ access_token: ACCESS, account_id: ACCOUNT });
+  process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK = "1";
+  assert.equal(nativeSessionAvailable(), true);
+
+  process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK = "yes";
+  assert.equal(nativeSessionAvailable(), false, "an ambiguous value is not consent");
+});
+
+test("an unrecognized consent marker fails closed", () => {
+  writeAuth({ access_token: ACCESS, account_id: ACCOUNT });
+  mkdirSync(path.dirname(NATIVE_SESSION_CONSENT_PATH), { recursive: true });
+  writeFileSync(NATIVE_SESSION_CONSENT_PATH, "not json", "utf8");
+  assert.equal(nativeSessionAvailable(), false);
+  writeFileSync(NATIVE_SESSION_CONSENT_PATH, '{"version":99,"sharing":"enabled"}\n', "utf8");
+  assert.equal(nativeSessionAvailable(), false);
 });
 
 test("native models map for the harness, minus Codex's internal variants", () => {
@@ -239,6 +298,7 @@ test("an expired session is withheld rather than spent on a certain 401", () => 
   // test is the withholding itself.
   process.env.CODEX_BIN = "/nonexistent/codex";
   try {
+    process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK = "1";
     writeAuth({ access_token: jwtWithExp(seconds - 3600), account_id: ACCOUNT });
     assert.equal(nativeSessionHeaders(), undefined, "a dead token must not be sent");
     assert.equal(nativeSessionStatus().expired, true);
@@ -255,12 +315,14 @@ test("an expired session is withheld rather than spent on a certain 401", () => 
     assert.ok(nativeSessionStatus().expiresInHours > 47);
   } finally {
     delete process.env.CODEX_BIN;
+    delete process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
   }
 });
 
 test("status reports the remaining life, never the token", () => {
   const seconds = Math.floor(Date.now() / 1000);
   writeAuth({ access_token: jwtWithExp(seconds + 36000), account_id: ACCOUNT });
+  setNativeSessionSharingEnabled(true);
   const status = nativeSessionStatus();
   assert.ok(status.expiresInHours > 9 && status.expiresInHours <= 10);
   assert.doesNotMatch(JSON.stringify(status), new RegExp(ACCOUNT));
@@ -295,4 +357,8 @@ test("the bearer parser is linear and rejects the shapes it should", () => {
   assert.equal(bearer(hostile), undefined);
   const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
   assert.ok(elapsedMs < 250, `parsing took ${elapsedMs.toFixed(1)}ms, which suggests backtracking`);
+});
+
+test.after(() => {
+  rmSync(home, { recursive: true, force: true });
 });

--- a/test/gemini-surface.test.mjs
+++ b/test/gemini-surface.test.mjs
@@ -141,7 +141,8 @@ test("the caller's own key is never relayed upstream", async () => {
   // The key the CLI sends is this router's caller capability. Forwarding it on
   // the loopback would put a router secret into a request that can be
   // substituted onto a real provider hop -- and `callerBroughtNoUpstreamCredential`
-  // is what lets a client with no ChatGPT session of its own reach native models.
+  // is what lets an explicitly authorized client with no ChatGPT session of
+  // its own reach native models.
   const back = await upstream((request, response) => {
     writeJson(response, 200, { status: "completed", output: [] });
   });

--- a/test/native-session-publication.test.mjs
+++ b/test/native-session-publication.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = mkdtempSync(path.join(os.tmpdir(), "native-session-publication-"));
+const stateDir = path.join(root, "state");
+const authPath = path.join(root, "codex", "auth.json");
+process.env.CODEX_HOME = path.join(root, "codex");
+process.env.MODEL_ROUTER_CODEX_AUTH = authPath;
+process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+delete process.env.CODEX_ROUTER_NATIVE_SESSION_FALLBACK;
+
+mkdirSync(path.dirname(authPath), { recursive: true });
+mkdirSync(stateDir, { recursive: true });
+writeFileSync(
+  authPath,
+  JSON.stringify({
+    auth_mode: "chatgpt",
+    tokens: { access_token: "test-access", account_id: "test-account" },
+  }),
+);
+writeFileSync(
+  path.join(stateDir, "enabled-providers.json"),
+  `${JSON.stringify({ version: 1, providers: [] })}\n`,
+);
+writeFileSync(
+  path.join(stateDir, "native-models.json"),
+  `${JSON.stringify({
+    models: [{
+      slug: "gpt-test-native",
+      display_name: "GPT Test Native",
+      visibility: "list",
+      context_window: 128_000,
+      input_modalities: ["text"],
+    }],
+  })}\n`,
+);
+
+const { routedClientModels } = await import("../src/routed-client-models.mjs");
+const { setNativeSessionSharingEnabled } = await import("../src/codex-native-session.mjs");
+
+test("a usable login is not published until the shared plane is authorized", () => {
+  assert.deepEqual(routedClientModels().models, []);
+
+  setNativeSessionSharingEnabled(true);
+  assert.deepEqual(
+    routedClientModels().models.map((model) => model.slug),
+    ["gpt-test-native"],
+  );
+
+  setNativeSessionSharingEnabled(false);
+  assert.deepEqual(routedClientModels().models, []);
+});
+
+test.after(() => {
+  rmSync(root, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary

- require an explicit, one-time authorization before a caller-key client can reuse Codex's ChatGPT session
- keep that authorization on the shared per-user router plane, so DeepSeek Harness, Gemini CLI, and future local clients reuse it without separate logins
- fail closed for missing or malformed consent, require a usable official `codex login` session before enabling, and republish every installed client on enable or revoke
- preserve Codex's own credential pass-through and every external provider route unchanged

## User flow

```sh
codex login
./bin/model-router codex chatgpt-session enable
```

That is done once per OS user/router plane, not once per harness. `chatgpt-session disable` revokes native GPT publication everywhere without signing Codex out. The stored marker is owner-only and contains no token or account ID.

## Verification

- `npm run check`
- `npm test` — 2,330 passed, 0 failed, 17 expected skips
- affected installer/doctor/DSH/Gemini/Windows-parity suite — 123 passed, 0 failed, 2 expected skips
- repo-maintainer critical-change review — 63/63 hunks reviewed, no findings

Context: https://x.com/thsottiaux/status/2091406082497552557
