### PR TITLE
fix: disable unsupported external-provider websockets

### DIFF
--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -901,11 +901,17 @@ function legacyManagedRouterProvider(contents) {
     fields.get("wire_api") === "responses";
   const currentShape =
     (fields.size === 3 ||
-      (fields.size === 4 && fields.get("supports_standalone_web_search") === "true")) &&
+      (fields.size === 4 && fields.get("supports_standalone_web_search") === "true") ||
+      (fields.size === 5 &&
+        fields.get("supports_websockets") === "false" &&
+        fields.get("supports_standalone_web_search") === "true")) &&
     fields.get("name") === "Codex Router (external models)";
   const prototypeShape =
     (fields.size === 4 ||
-      (fields.size === 5 && fields.get("supports_standalone_web_search") === "true")) &&
+      (fields.size === 5 && fields.get("supports_standalone_web_search") === "true") ||
+      (fields.size === 6 &&
+        fields.get("supports_websockets") === "false" &&
+        fields.get("supports_standalone_web_search") === "true")) &&
     fields.get("name") === "Codex Router (extra providers)" &&
     fields.get("requires_openai_auth") === "true";
   return commonFieldsMatch && (currentShape || prototypeShape)
@@ -1080,6 +1086,7 @@ function enabledContents(contents) {
     'name = "Codex Router (external models)"',
     `base_url = ${JSON.stringify(routerBaseUrl)}`,
     'wire_api = "responses"',
+    "supports_websockets = false",
     "supports_standalone_web_search = true",
     providerEndMarker,
   ];

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -127,6 +127,7 @@ approval_policy = "never"
     assert.doesNotMatch(configured, /\[agents\]/);
     assert.match(configured, /\[model_providers\.codex-router\]/);
     assert.match(configured, /wire_api = "responses"/);
+    assert.match(configured, /supports_websockets = false/);
     assert.match(configured, /supports_standalone_web_search = true/);
     assert.ok(
       configured.includes(
@@ -154,8 +155,15 @@ approval_policy = "never"
       true,
     );
 
+    writeFileSync(
+      configPath,
+      configured.replace("supports_websockets = false\n", ""),
+      { mode: 0o600 },
+    );
+
     const reenabled = run("enable", codexHome);
     assert.equal(reenabled.mode, "router");
+    assert.match(readFileSync(configPath, "utf8"), /supports_websockets = false/);
     assert.equal(
       (readFileSync(configPath, "utf8").match(/# BEGIN codex-router-managed/g) || [])
         .length,
@@ -576,6 +584,7 @@ test("config manager adopts the exact legacy router-owned provider table", () =>
     )?.[0];
     assert.ok(loginFreeProvider);
     assert.doesNotMatch(loginFreeProvider, /requires_openai_auth/);
+    assert.match(loginFreeProvider, /supports_websockets = false/);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- advertise `supports_websockets = false` on the managed external-model provider used by routed Codex agents and login-free routing
- migrate exact router-owned legacy provider shapes while preserving fail-closed ownership checks
- cover fresh generation and legacy adoption in config-manager tests

## Why
Codex 0.149 attempts the Responses WebSocket transport when an active custom provider omits this capability. codex-router intentionally serves this provider over the Responses HTTP/SSE path and rejects WebSocket upgrades, so the managed `codex-router` provider must explicitly opt out.

This is intentionally scoped to the managed custom provider. Normal signed-in Codex keeps the built-in `openai` provider identity; current Codex does not allow `model_providers.openai` to override that built-in provider's WebSocket capability. Changing the root `model_provider` would also violate codex-router's task-history/provider-preservation boundary, so this PR does not claim to disable WebSockets for the built-in OpenAI root path.
## Verification
- full `node --test test/config-manager.test.mjs`: 35 passed, 1 skipped, 0 failed
- focused ownership/migration cases after syncing current upstream: 4/4 passed
- live GLM-5.3 Max with `model_provider = "codex-router"`: exit 0, exact marker returned, no Responses WebSocket/426 attempt
- `npm.cmd run check`: v2-agent applications valid (6), syntax checks passed
- `git diff --check`: passed

The remaining built-in-OpenAI WebSocket attempt is a Codex-side limitation, not addressed by this provider-scoped fix.