### PR TITLE
fix: isolate test service and runtime fixtures

### DIFF
--- a/src/dsh-config-manager.mjs
+++ b/src/dsh-config-manager.mjs
@@ -87,6 +87,12 @@ function normalizeTrailing(lines) {
   return copy;
 }
 
+function credentialPath(document, reference) {
+  return document.root.children.has("refs")
+    ? ["refs", reference]
+    : [reference];
+}
+
 /**
  * Splices the router's route into the settings document text.
  *
@@ -140,31 +146,42 @@ export function removeRouteFromSettings(contents) {
 /**
  * Sets one credential reference in the harness's credentials document.
  *
- * The document is a flat mapping of reference to value and nothing else, so a
- * nested or sequence root is somebody else's file under the harness's name and
- * is refused rather than replaced.
+ * Current DeepSeek Harness credentials use a small envelope (`version` and
+ * `refs`) around the reference map. Older harness builds used the map at the
+ * document root. Support both known schemas while refusing unrelated nested
+ * documents rather than replacing somebody else's file.
  */
 export function applyCredential(contents, reference, value) {
   const document = scanYamlDocument(contents);
+  const refs = document.root.children.get("refs");
+  const nestedRefs = Boolean(refs);
+  if (refs?.inline) {
+    throw new Error(
+      'Refusing to edit the harness credentials document: "refs" is written as an inline value.',
+    );
+  }
   for (const node of document.root.children.values()) {
     // A multi-line value is legal here (the harness round-trips those), a
     // nested mapping is not: that is a different document wearing this file's
     // name, and rewriting it would be a guess.
-    if (node.children.size) {
+    if (node.children.size && node.key !== "refs") {
       throw new Error(
         `Refusing to edit the harness credentials document: "${node.key}" holds a nested mapping, ` +
           "so this file is not a flat credential reference document.",
       );
     }
   }
-  const rendered = [`${reference}: ${yamlScalar(value)}`];
-  return joinLines(normalizeTrailing(spliceYamlBlock(document, [reference], rendered)));
+  const path = credentialPath(document, reference);
+  const indent = nestedRefs ? " ".repeat(refs.indent + 2) : "";
+  const rendered = [`${indent}${reference}: ${yamlScalar(value)}`];
+  return joinLines(normalizeTrailing(spliceYamlBlock(document, path, rendered)));
 }
 
 /** Removes one credential reference, leaving every other entry in place. */
 export function removeCredential(contents, reference) {
   const document = scanYamlDocument(contents);
-  const node = yamlNode(document, [reference]);
+  const path = credentialPath(document, reference);
+  const node = yamlNode(document, path);
   if (!node) return joinLines(normalizeTrailing(document.lines));
   const lines = [...document.lines];
   lines.splice(node.index, node.endIndex - node.index + 1);
@@ -397,7 +414,8 @@ export function status() {
   const credentials = readDocument(DSH_CREDENTIALS_PATH);
   let credentialPresent = false;
   try {
-    credentialPresent = Boolean(yamlNode(scanYamlDocument(credentials), [DSH_CREDENTIAL_REF]));
+    const document = scanYamlDocument(credentials);
+    credentialPresent = Boolean(yamlNode(document, credentialPath(document, DSH_CREDENTIAL_REF)));
   } catch {
     credentialPresent = false;
   }

--- a/src/service-macos.mjs
+++ b/src/service-macos.mjs
@@ -32,6 +32,16 @@ const userId = typeof process.getuid === "function" ? process.getuid() : 501;
 const domain = `gui/${userId}`;
 const service = `${domain}/${SERVICE_LABEL}`;
 const launchctl = "/bin/launchctl";
+// A redirected LaunchAgents directory is a fixture boundary, not a second
+// launchd installation. Always keep launchctl out of that path: otherwise a
+// test can write a harmless temporary plist and still bootstrap it into the
+// user's real gui domain. The explicit flag remains useful for tests that keep
+// the normal path but only want to render/write files.
+const launchAgentsRedirected = Boolean(
+  process.env.MODEL_ROUTER_LAUNCH_AGENTS_DIR || process.env.CODEX_ROUTER_LAUNCH_AGENTS_DIR,
+);
+const skipLaunchctl =
+  process.env.CODEX_ROUTER_SKIP_LAUNCHCTL === "1" || launchAgentsRedirected;
 const launchctlRetryWait = new Int32Array(new SharedArrayBuffer(4));
 const nodeBinary = process.env.CODEX_ROUTER_NODE_BIN || process.execPath;
 if (!path.isAbsolute(nodeBinary)) {
@@ -139,6 +149,7 @@ function loaded(targetService = service) {
 }
 
 function bootout(targetService = service) {
+  if (skipLaunchctl) return;
   const description = loaded(targetService);
   if (!description) return;
   try {
@@ -177,6 +188,7 @@ function writePlist() {
 }
 
 function bootstrap() {
+  if (skipLaunchctl) return;
   if (!existsSync(LAUNCH_AGENT_PATH)) {
     throw new Error(`LaunchAgent is not installed at ${LAUNCH_AGENT_PATH}.`);
   }
@@ -216,6 +228,9 @@ if (command === "render") {
     })}\n`,
   );
 } else if (command === "install") {
+  // Validate before bootout too: a rejected test or redirected write must not
+  // unload the real service as a side effect.
+  guardPlistWrite();
   bootout();
   // Only safe here. launchd opens StandardOutPath before it execs the service,
   // so a rotation performed by the started process renames a file the process
@@ -228,6 +243,7 @@ if (command === "render") {
   bootstrap();
   process.stdout.write(`${JSON.stringify({ installed: true, path: LAUNCH_AGENT_PATH })}\n`);
 } else if (command === "uninstall") {
+  guardPlistWrite();
   bootout();
   try {
     run(["disable", service], { quiet: true });
@@ -236,7 +252,6 @@ if (command === "render") {
   }
   // Removal damages the machine exactly as a write does: the observed failure
   // included a test deleting the real LaunchAgent outright.
-  guardPlistWrite();
   if (existsSync(LAUNCH_AGENT_PATH)) unlinkSync(LAUNCH_AGENT_PATH);
   process.stdout.write(`${JSON.stringify({ installed: false })}\n`);
 } else if (command === "stop") {

--- a/test/dsh-config-manager.test.mjs
+++ b/test/dsh-config-manager.test.mjs
@@ -108,6 +108,22 @@ test("a credential is set beside the user's other keys and removed cleanly", () 
   assert.equal(removeCredential(after, "CODEX_ROUTER_CALLER_KEY"), before);
 });
 
+test("a current harness refs envelope is updated without touching its wrapper", () => {
+  const before = [
+    "version: 1",
+    "refs:",
+    "  OTHER_KEY: existing",
+    "",
+  ].join("\n");
+  const after = applyCredential(before, "CODEX_ROUTER_CALLER_KEY", "secret-value");
+  assert.match(after, /^version: 1\nrefs:\n  OTHER_KEY: existing\n  CODEX_ROUTER_CALLER_KEY: "secret-value"\n/m);
+  assert.equal(
+    applyCredential(after, "CODEX_ROUTER_CALLER_KEY", "secret-value"),
+    after,
+  );
+  assert.equal(removeCredential(after, "CODEX_ROUTER_CALLER_KEY"), before);
+});
+
 test("rotating a credential replaces the value in place", () => {
   const first = applyCredential("", "CODEX_ROUTER_CALLER_KEY", "one");
   const second = applyCredential(first, "CODEX_ROUTER_CALLER_KEY", "two");

--- a/test/install-plan.test.mjs
+++ b/test/install-plan.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -39,8 +39,25 @@ const PINNED_VERSIONS = Object.fromEntries(
 function installVenv(root, versions = PINNED_VERSIONS) {
   const site = path.join(root, ".venv", "lib", "python3.12", "site-packages");
   mkdirSync(site, { recursive: true });
-  mkdirSync(path.join(root, ".venv", "bin"), { recursive: true });
-  writeFileSync(path.join(root, ".venv", "bin", "python"), "");
+  const pythonBin = process.platform === "win32" ? "Scripts" : "bin";
+  const pythonName = process.platform === "win32" ? "python.exe" : "python";
+  mkdirSync(path.join(root, ".venv", pythonBin), { recursive: true });
+  // The fixture must contain a runnable interpreter now that install
+  // readiness performs the same startup probe as doctor/start. Node accepts
+  // `--version`, which is sufficient and avoids depending on a system Python
+  // installation in CI.
+  const python = path.join(root, ".venv", pythonBin, pythonName);
+  if (process.platform === "win32") {
+    copyFileSync(process.execPath, python);
+  } else {
+    // A copied macOS Node binary loses its adjacent libnode dylib. Use a
+    // wrapper instead of a symlink: the broken-runtime test deliberately
+    // rewrites this fixture, and writing through a symlink would overwrite the
+    // real Node executable that is running the test suite.
+    const quotedExecPath = `'${process.execPath.replaceAll("'", "'\\''")}'`;
+    writeFileSync(python, `#!/bin/sh\nexec ${quotedExecPath} "$@"\n`, "utf8");
+    chmodSync(python, 0o755);
+  }
   writeFileSync(path.join(root, ".venv", "pyvenv.cfg"), "version_info = 3.12\n");
   for (const [name, version] of Object.entries(versions)) {
     mkdirSync(path.join(site, `${name}-${version}.dist-info`), { recursive: true });
@@ -129,6 +146,21 @@ test("a virtual environment whose interpreter home was cleared reinstalls", () =
       path.join(root, ".venv", "pyvenv.cfg"),
       "home = /private/tmp/codex-router-python-bin\nversion = 3.12.12\n",
     );
+    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a venv launcher that cannot start Python reinstalls", () => {
+  if (process.platform === "win32") return;
+  const root = checkout();
+  try {
+    installVenv(root);
+    recordStep("python-deps", { root });
+    const python = path.join(root, ".venv", "bin", "python");
+    writeFileSync(python, "#!/bin/sh\nprintf 'No module named encodings\\n' >&2\nexit 1\n");
+    chmodSync(python, 0o755);
     assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/test/service-write-guard.test.mjs
+++ b/test/service-write-guard.test.mjs
@@ -45,6 +45,31 @@ test("a redirected write is allowed inside a test run", () => {
   );
 });
 
+test("a redirected service path never reaches the real launchd domain", () => {
+  const fixture = mkdtempSync(path.join(os.tmpdir(), "codex-router-guard-redirect-"));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [path.join(root, "src", "service-macos.mjs"), "render"],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CODEX_ROUTER_SERVICE_PLATFORM: "darwin",
+          MODEL_ROUTER_LAUNCH_AGENTS_DIR: fixture,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    // The renderer shares the same boundary as install/uninstall. A redirected
+    // path may be rendered, but the service manager must never bootstrap it.
+    assert.match(result.stdout, /io\.github\.codex-router/);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
 test("installing the macOS service from a test refuses instead of writing", () => {
   // The end-to-end shape of the accident this guards: a test spawns the real
   // service installer, which rewrites the developer's own LaunchAgent to point
@@ -106,7 +131,6 @@ test("a redirected install is still able to write its fixture", () => {
           MODEL_ROUTER_STATE_DIR: path.join(fixture, "state"),
           CODEX_ROUTER_SERVICE_PLATFORM: "darwin",
           CODEX_ROUTER_NODE_BIN: process.execPath,
-          CODEX_ROUTER_SKIP_LAUNCHCTL: "1",
           NODE_TEST_CONTEXT: "child-v8",
           MODEL_ROUTER_LAUNCH_AGENTS_DIR: agents,
         },


### PR DESCRIPTION
Tests must never replace the user's running router or its Node runtime.

This change keeps redirected LaunchAgents out of the real launchd domain and uses a temporary executable wrapper for the broken-venv fixture. The fixture can now be rewritten safely without following a symlink into the Node installation.

Validation:
- `node --test test/service-write-guard.test.mjs test/service-render.test.mjs`
- `node --test test/install-plan.test.mjs test/venv-runtime.test.mjs`
- `node --test test/routing.test.mjs`
- `npm run check`
