### PR TITLE
fix: keep provider icons within tray icon bounds

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -951,10 +951,15 @@ struct ProviderIcon: View {
           .resizable()
           .interpolation(.high)
           .scaledToFit()
+          // Keep provider marks inside the same point-sized slot as preset
+          // icons in both the menu bar and Dynamic Island.
+          .frame(width: size, height: size)
+          .clipped()
       } else {
         Image(systemName: "cpu")
           .font(.system(size: size * 0.5, weight: .semibold))
           .foregroundStyle(routerMuted)
+          .frame(width: size, height: size)
       }
     }
     .frame(width: size, height: size)

--- a/apps/macos/ModelRouterTray/Tests/ProviderIconTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ProviderIconTests.swift
@@ -1,0 +1,26 @@
+import AppKit
+import SwiftUI
+import Testing
+
+@testable import ModelRouterTray
+
+@Suite("Provider icon sizing")
+struct ProviderIconTests {
+  @Test("provider marks render at their requested size")
+  @MainActor
+  func providerMarksUseRequestedSize() throws {
+    let requestedSize: CGFloat = 18
+    let renderer = ImageRenderer(
+      content: ProviderIcon(providerID: "openai", size: requestedSize, showsHelp: false)
+    )
+    renderer.scale = 1
+
+    guard let image = renderer.nsImage else {
+      Issue.record("ProviderIcon did not produce an image")
+      return
+    }
+
+    #expect(image.size.width == requestedSize)
+    #expect(image.size.height == requestedSize)
+  }
+}


### PR DESCRIPTION
Provider marks could render larger than the tray slot. This keeps provider and fallback icons inside the same fixed bounds used by preset icons in the menu bar and Dynamic Island. It keeps the current assets and adds a rendering regression test.

Reason:
Fixes oversized provider logos in the menu bar and Dynamic Island.

Validation:
- swift test (67 tests passed)
- Release build via Swift package test build