### PR TITLE
feat: add secure provider credential primitives

### DIFF
--- a/src/atomic-state-lock.mjs
+++ b/src/atomic-state-lock.mjs
@@ -1,0 +1,81 @@
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+const WAIT_MS = 25;
+const MAX_WAIT_MS = 2_000;
+const STALE_MS = 30_000;
+
+function sleep(milliseconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
+function lockPath(target) {
+  return `${target}.lock`;
+}
+
+function staleLock(pathname) {
+  try {
+    const stat = lstatSync(pathname);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    return Date.now() - stat.mtimeMs > STALE_MS;
+  } catch {
+    return false;
+  }
+}
+
+function acquire(target) {
+  const pathname = lockPath(target);
+  mkdirSync(path.dirname(pathname), { recursive: true, mode: 0o700 });
+  const started = Date.now();
+  while (true) {
+    try {
+      mkdirSync(pathname, { recursive: false, mode: 0o700 });
+      try {
+        writeFileSync(`${pathname}/owner`, `${process.pid}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+      } catch {
+        rmSync(pathname, { recursive: true, force: true });
+        throw new Error(`Could not initialize state lock: ${pathname}`);
+      }
+      return () => rmSync(pathname, { recursive: true, force: true });
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      let link = false;
+      try {
+        link = lstatSync(pathname).isSymbolicLink();
+      } catch {
+        continue;
+      }
+      if (link) throw new Error(`Refusing to use a symbolic-link state lock: ${pathname}`);
+      if (staleLock(pathname)) {
+        rmSync(pathname, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() - started >= MAX_WAIT_MS) {
+        let owner = "";
+        try { owner = readFileSync(`${pathname}/owner`, "utf8").trim(); } catch { /* lock holder may be creating it */ }
+        throw new Error(`Timed out waiting for state lock${owner ? ` held by ${owner}` : ""}: ${pathname}`);
+      }
+      sleep(WAIT_MS);
+    }
+  }
+}
+
+export function withAtomicStateLock(target, operation) {
+  if (typeof operation !== "function") throw new TypeError("State lock operation must be a function.");
+  const release = acquire(target);
+  try {
+    return operation();
+  } finally {
+    release();
+  }
+}
+
+export function atomicStateLockPath(target) {
+  return lockPath(target);
+}

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -133,6 +133,14 @@ export const PROVIDER_CATALOG_CACHE_PATH = path.join(STATE_DIR, "provider-catalo
 export const INSTALL_MANIFEST_PATH = path.join(STATE_DIR, "install-manifest.json");
 export const SKILL_OWNERSHIP_PATH = path.join(STATE_DIR, "managed-skills.json");
 export const MIGRATIONS_DIR = path.join(STATE_DIR, "migrations");
+// Provider credential metadata contains only opaque references. The actual
+// token remains in the existing provider file/keychain/OAuth store.
+export const PROVIDER_CREDENTIAL_STORE_PATH =
+  process.env.MODEL_ROUTER_PROVIDER_CREDENTIAL_STORE ||
+  path.join(STATE_DIR, "provider-credentials.json");
+export const PROVIDER_CREDENTIAL_MIGRATIONS_DIR =
+  process.env.MODEL_ROUTER_PROVIDER_CREDENTIAL_MIGRATIONS ||
+  path.join(MIGRATIONS_DIR, "provider-credentials");
 export const SUPPORT_DIR = path.join(STATE_DIR, "support");
 export const LOG_PATH = path.join(STATE_DIR, "router.log");
 export const SERVICE_PROCESS_STATE_PATH = path.join(STATE_DIR, "service-process.json");

--- a/src/provider-credential-store.mjs
+++ b/src/provider-credential-store.mjs
@@ -1,0 +1,450 @@
+import { createHash, randomBytes } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+} from "node:fs";
+import path from "node:path";
+
+import { credentialPaths } from "./provider-credentials.mjs";
+import { writePrivateFile, writePrivateJson } from "./file-security.mjs";
+import { PROVIDERS } from "./model-registry.mjs";
+import {
+  PROVIDER_CREDENTIAL_MIGRATIONS_DIR,
+  PROVIDER_CREDENTIAL_STORE_PATH,
+} from "./paths.mjs";
+
+/**
+ * Metadata for a credential is deliberately separate from the credential
+ * itself. This module never accepts or writes a token, API key, cookie, or
+ * OAuth secret. `secretRef` names an existing protected provider store and is
+ * resolved by the provider-specific credential code when a request is made.
+ */
+export const PROVIDER_CREDENTIAL_SCHEMA_VERSION = 1;
+export const PROVIDER_CREDENTIAL_KINDS = Object.freeze(["account", "api_key"]);
+export const SECRET_REFERENCE_TYPES = Object.freeze([
+  "provider-file",
+  "keychain",
+  "oauth-session",
+  "environment",
+]);
+
+const SENSITIVE_KEY = /(?:authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|secret|password|cookie|credential|private[-_]?key|signed[-_]?url)/i;
+const PROVIDER_ID = /^[a-z0-9][a-z0-9-]*$/i;
+const CREDENTIAL_ID = /^cred_[A-Za-z0-9_-]{16,64}$/;
+const LABEL_LIMIT = 160;
+
+function sensitiveKey(key) {
+  // `secretRef` is a safe descriptor, not a secret-bearing field. Every
+  // other key matching the broad pattern is rejected/redacted.
+  return key !== "secretRef" && SENSITIVE_KEY.test(key);
+}
+
+function now() {
+  return new Date().toISOString();
+}
+
+function emptyStore() {
+  return { schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION, credentials: [] };
+}
+
+function normalizeText(value, field, { max = LABEL_LIMIT, required = false } = {}) {
+  if (typeof value !== "string") {
+    if (required) throw new Error(`${field} must be a string.`);
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (required && !normalized) throw new Error(`${field} must not be empty.`);
+  if (normalized.length > max) throw new Error(`${field} is too long.`);
+  return normalized || undefined;
+}
+
+function validateProviderId(value) {
+  const providerId = normalizeText(value, "providerId", { max: 100, required: true });
+  if (!PROVIDER_ID.test(providerId)) throw new Error(`Invalid providerId: ${providerId}`);
+  return providerId;
+}
+
+function validateCredentialId(value) {
+  const id = normalizeText(value, "credential id", { max: 80, required: true });
+  if (!CREDENTIAL_ID.test(id)) throw new Error("Credential id must be an opaque cred_ identifier.");
+  return id;
+}
+
+function generatedCredentialId(providerId, kind) {
+  // Random IDs are used for new entries. Migration uses this deterministic
+  // form so running the migration twice never creates duplicate references.
+  const random = randomBytes(18).toString("base64url");
+  return `cred_${random}`;
+}
+
+function migratedCredentialId(providerId, kind) {
+  const digest = createHash("sha256")
+    .update(`codex-router-provider-credential:${providerId}:${kind}`)
+    .digest("base64url")
+    .slice(0, 24);
+  return `cred_${digest}`;
+}
+
+function assertNoSecretFields(value, context = "credential metadata") {
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value)) {
+    if (sensitiveKey(key)) {
+      throw new Error(`${context} cannot contain secret field ${key}.`);
+    }
+    if (child && typeof child === "object") assertNoSecretFields(child, `${context}.${key}`);
+  }
+}
+
+function normalizeSecretRef(value, providerId) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("secretRef must be an object reference; raw secrets are not accepted.");
+  }
+  assertNoSecretFields(value, "secretRef");
+  const type = normalizeText(value.type, "secretRef.type", { max: 40, required: true });
+  if (!SECRET_REFERENCE_TYPES.includes(type)) {
+    throw new Error(`Unsupported secretRef type: ${type}`);
+  }
+  const referenceProviderId = value.providerId === undefined
+    ? providerId
+    : validateProviderId(value.providerId);
+  const normalized = { type, providerId: referenceProviderId };
+  if (type === "keychain") {
+    const service = normalizeText(value.service, "secretRef.service", { max: 200, required: true });
+    normalized.service = service;
+  } else if (type === "environment") {
+    const name = normalizeText(value.name, "secretRef.name", { max: 100, required: true });
+    if (!/^[A-Z][A-Z0-9_]*$/.test(name)) throw new Error("secretRef.name must be an environment variable name.");
+    normalized.name = name;
+  }
+  return normalized;
+}
+
+function normalizeCredential(raw, { legacy = false } = {}) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Each credential must be an object.");
+  }
+  assertNoSecretFields(raw, "credential metadata");
+  const providerId = validateProviderId(raw.providerId);
+  const kind = normalizeText(raw.kind || (legacy ? "api_key" : undefined), "credential kind", {
+    max: 20,
+    required: true,
+  });
+  if (!PROVIDER_CREDENTIAL_KINDS.includes(kind)) {
+    throw new Error(`Unsupported credential kind: ${kind}`);
+  }
+  const id = validateCredentialId(raw.id);
+  const secretRef = normalizeSecretRef(raw.secretRef, providerId);
+  const state = normalizeText(raw.state || "active", "credential state", { max: 20, required: true });
+  if (!["active", "paused", "revoked"].includes(state)) {
+    throw new Error(`Unsupported credential state: ${state}`);
+  }
+  const createdAt = normalizeText(raw.createdAt || now(), "createdAt", { max: 80, required: true });
+  const updatedAt = normalizeText(raw.updatedAt || createdAt, "updatedAt", { max: 80, required: true });
+  const result = {
+    id,
+    providerId,
+    kind,
+    secretRef,
+    state,
+    createdAt,
+    updatedAt,
+  };
+  const label = normalizeText(raw.label, "label");
+  if (label) result.label = label;
+  // Account metadata is intentionally narrow. Do not persist arbitrary
+  // provider responses or email/token-shaped fields in this store.
+  if (raw.account && typeof raw.account === "object" && !Array.isArray(raw.account)) {
+    const account = {};
+    const alias = normalizeText(raw.account.alias, "account.alias");
+    const plan = normalizeText(raw.account.plan, "account.plan", { max: 80 });
+    if (alias) account.alias = alias;
+    if (plan) account.plan = plan;
+    if (Object.keys(account).length) result.account = account;
+  }
+  return result;
+}
+
+function normalizeStore(raw, { legacy = false } = {}) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Credential store must be an object.");
+  }
+  const entries = Array.isArray(raw.credentials) ? raw.credentials : [];
+  const seen = new Set();
+  const credentials = entries.map((entry) => {
+    const normalized = normalizeCredential(entry, { legacy });
+    if (seen.has(normalized.id)) throw new Error(`Duplicate credential id: ${normalized.id}`);
+    seen.add(normalized.id);
+    return normalized;
+  });
+  return { schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION, credentials };
+}
+
+function parseStore(contents, { allowLegacy = false } = {}) {
+  const parsed = JSON.parse(contents);
+  if (parsed?.schemaVersion === PROVIDER_CREDENTIAL_SCHEMA_VERSION) {
+    return normalizeStore(parsed);
+  }
+  // The migration accepts the older `{ version: 1, credentials: [...] }`
+  // shape used by early local experiments, but the normal reader never writes
+  // it back unless an explicit migration is requested.
+  if (allowLegacy && parsed?.version === 1 && Array.isArray(parsed.credentials)) {
+    return normalizeStore(parsed, { legacy: true });
+  }
+  throw new Error("Unsupported provider credential store schema.");
+}
+
+export function readProviderCredentialStore(filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
+  if (!existsSync(filePath)) return emptyStore();
+  try {
+    return parseStore(readFileSync(filePath, "utf8"));
+  } catch {
+    // A malformed store must not become a source of credentials. Returning an
+    // empty, safe state lets health/catalog paths continue while migration and
+    // explicit writes remain strict and report the repair needed.
+    return emptyStore();
+  }
+}
+
+export function writeProviderCredentialStore(store, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
+  const normalized = normalizeStore({
+    schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+    credentials: store?.credentials,
+  });
+  writePrivateJson(filePath, normalized, { directoryMode: 0o700 });
+  return normalized;
+}
+
+export function createCredentialReference(input = {}) {
+  assertNoSecretFields(input, "credential metadata");
+  const {
+    providerId,
+    kind,
+    secretRef,
+    label,
+    account,
+    id,
+    state,
+    createdAt,
+    updatedAt,
+  } = input;
+  const normalizedProviderId = validateProviderId(providerId);
+  const credential = normalizeCredential({
+    id: id || generatedCredentialId(normalizedProviderId, kind),
+    providerId: normalizedProviderId,
+    kind,
+    secretRef,
+    label,
+    account,
+    state,
+    createdAt,
+    updatedAt,
+  });
+  return credential;
+}
+
+export function addCredentialReference(input, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
+  const store = readProviderCredentialStoreStrict(filePath);
+  const credential = createCredentialReference(input);
+  if (store.credentials.some((entry) => entry.id === credential.id)) {
+    throw new Error(`Credential id already exists: ${credential.id}`);
+  }
+  store.credentials.push(credential);
+  return writeProviderCredentialStore(store, filePath).credentials.at(-1);
+}
+
+export function removeCredentialReference(id, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
+  const credentialId = validateCredentialId(id);
+  const store = readProviderCredentialStoreStrict(filePath);
+  const next = store.credentials.filter((entry) => entry.id !== credentialId);
+  if (next.length === store.credentials.length) return false;
+  writeProviderCredentialStore({ credentials: next }, filePath);
+  return true;
+}
+
+function readProviderCredentialStoreStrict(filePath) {
+  if (!existsSync(filePath)) return emptyStore();
+  return parseStore(readFileSync(filePath, "utf8"));
+}
+
+export function sanitizeCredentialStatus(entry) {
+  const credential = normalizeCredential(entry);
+  return {
+    id: credential.id,
+    providerId: credential.providerId,
+    kind: credential.kind,
+    state: credential.state,
+    label: credential.label || null,
+    account: credential.account ? { ...credential.account } : null,
+    secretRef: { type: credential.secretRef.type, providerId: credential.secretRef.providerId },
+    createdAt: credential.createdAt,
+    updatedAt: credential.updatedAt,
+  };
+}
+
+export function sanitizedCredentialStore(filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
+  const store = readProviderCredentialStore(filePath);
+  return {
+    schemaVersion: store.schemaVersion,
+    credentials: store.credentials.map(sanitizeCredentialStatus),
+  };
+}
+
+function redactString(value) {
+  let result = String(value ?? "");
+  result = result
+    .replace(/(authorization\s*[:=]\s*bearer\s+)[^\s"'&,}]+/gi, "$1[REDACTED]")
+    .replace(/([?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|key)=)[^&#\s]+/gi, "$1[REDACTED]")
+    .replace(/((?:["']?(?:api[_-]?key|access[_-]?token|refresh[_-]?token)["']?)\s*[:=]\s*["']?)[^\s"',}]+/gi, "$1[REDACTED]")
+    .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/gi, "$1[REDACTED]@[REDACTED]")
+    .replace(/\b(?:sk|ghp|gho|github_pat)-[A-Za-z0-9_-]{8,}\b/g, "[REDACTED_KEY]");
+  return result;
+}
+
+export function redactCredentialText(value, knownSecrets = []) {
+  let result = redactString(value);
+  for (const secret of knownSecrets) {
+    const normalized = String(secret || "");
+    if (normalized.length >= 4) result = result.replaceAll(normalized, "[REDACTED]");
+  }
+  return result;
+}
+
+export function redactCredentialObject(value, knownSecrets = []) {
+  if (typeof value === "string") return redactCredentialText(value, knownSecrets);
+  if (Array.isArray(value)) return value.map((item) => redactCredentialObject(item, knownSecrets));
+  if (!value || typeof value !== "object") return value;
+  const result = {};
+  for (const [key, child] of Object.entries(value)) {
+    result[key] = sensitiveKey(key)
+      ? "[REDACTED]"
+      : redactCredentialObject(child, knownSecrets);
+  }
+  return result;
+}
+
+function migrationTimestamp() {
+  return `${new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-")}-${process.pid}`;
+}
+
+function migrationManifestPath(directory) {
+  return path.join(directory, "migration.json");
+}
+
+function readMigrationManifest(manifestPath) {
+  return JSON.parse(readFileSync(manifestPath, "utf8"));
+}
+
+function existingProviderFileReferences() {
+  const entries = [];
+  const seen = new Set();
+  for (const provider of PROVIDERS.values()) {
+    if (provider.kind !== "openai-compatible" || !provider.credential) continue;
+    const providerId = provider.variantOf || provider.id;
+    const referenceKey = `${providerId}:api_key`;
+    if (seen.has(referenceKey)) continue;
+    const file = credentialPaths(provider).find((candidate) => existsSync(candidate));
+    if (!file) continue;
+    seen.add(referenceKey);
+    entries.push({
+      id: migratedCredentialId(providerId, "api_key"),
+      providerId,
+      kind: "api_key",
+      label: provider.credential.label,
+      secretRef: { type: "provider-file", providerId },
+      state: "active",
+      createdAt: now(),
+      updatedAt: now(),
+    });
+  }
+  return entries;
+}
+
+export function migrateProviderCredentialStore(
+  filePath = PROVIDER_CREDENTIAL_STORE_PATH,
+  { migrationDirectory = PROVIDER_CREDENTIAL_MIGRATIONS_DIR } = {},
+) {
+  if (existsSync(filePath)) {
+    const contents = readFileSync(filePath, "utf8");
+    try {
+      const current = parseStore(contents);
+      return { migrated: false, store: current };
+    } catch {
+      // Continue only when this is the explicitly supported legacy shape. A
+      // foreign or malformed file is never silently overwritten.
+      const legacy = parseStore(contents, { allowLegacy: true });
+      const directory = path.join(migrationDirectory, migrationTimestamp());
+      mkdirSync(directory, { recursive: true, mode: 0o700 });
+      const previousPath = path.join(directory, "provider-credentials.before-migration.json");
+      // Keep rollback useful without copying unknown fields from the legacy
+      // document. `parseStore` already reduced it to the supported metadata
+      // shape; snapshot that normalized shape instead of preserving arbitrary
+      // values that may contain a secret under an unrecognised key.
+      writePrivateJson(previousPath, { version: 1, credentials: legacy.credentials });
+      const manifestPath = migrationManifestPath(directory);
+      writePrivateJson(
+        manifestPath,
+        {
+          schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+          createdAt: now(),
+          targetPath: filePath,
+          previousExists: true,
+          previousPath,
+        },
+        { directoryMode: 0o700 },
+      );
+      const store = writeProviderCredentialStore(legacy, filePath);
+      writePrivateJson(
+        path.join(migrationDirectory, "latest.json"),
+        { schemaVersion: 1, manifestPath },
+        { directoryMode: 0o700 },
+      );
+      return { migrated: true, store, legacy: true, manifestPath };
+    }
+  }
+
+  const entries = existingProviderFileReferences();
+  const store = { schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION, credentials: entries };
+  mkdirSync(migrationDirectory, { recursive: true, mode: 0o700 });
+  const directory = path.join(migrationDirectory, migrationTimestamp());
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const snapshot = {
+    schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+    createdAt: now(),
+    targetPath: filePath,
+    previousExists: false,
+    previousPath: null,
+  };
+  const manifestPath = migrationManifestPath(directory);
+  writePrivateJson(manifestPath, snapshot, { directoryMode: 0o700 });
+  writeProviderCredentialStore(store, filePath);
+  writePrivateJson(path.join(migrationDirectory, "latest.json"), { schemaVersion: 1, manifestPath }, { directoryMode: 0o700 });
+  return { migrated: true, store, manifestPath };
+}
+
+export function rollbackProviderCredentialStore(
+  manifestPath,
+  { migrationDirectory = PROVIDER_CREDENTIAL_MIGRATIONS_DIR } = {},
+) {
+  let selected = manifestPath;
+  if (!selected) {
+    const latestPath = path.join(migrationDirectory, "latest.json");
+    if (!existsSync(latestPath)) throw new Error("No provider credential migration snapshot is available.");
+    selected = JSON.parse(readFileSync(latestPath, "utf8")).manifestPath;
+  }
+  if (!selected || !existsSync(selected)) throw new Error("Provider credential migration snapshot is missing.");
+  const manifest = readMigrationManifest(selected);
+  if (manifest.schemaVersion !== PROVIDER_CREDENTIAL_SCHEMA_VERSION || typeof manifest.targetPath !== "string") {
+    throw new Error("Unsupported provider credential migration snapshot.");
+  }
+  if (manifest.previousExists) {
+    if (!manifest.previousPath || !existsSync(manifest.previousPath)) {
+      throw new Error("Provider credential rollback snapshot is missing.");
+    }
+    writePrivateFile(manifest.targetPath, readFileSync(manifest.previousPath, "utf8"));
+  } else if (existsSync(manifest.targetPath)) {
+    unlinkSync(manifest.targetPath);
+  }
+  return { rolledBack: true, targetPath: manifest.targetPath };
+}

--- a/src/provider-credential-store.mjs
+++ b/src/provider-credential-store.mjs
@@ -1,18 +1,25 @@
 import { createHash, randomBytes } from "node:crypto";
 import {
+  chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
+  renameSync,
   unlinkSync,
+  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
 import { credentialPaths } from "./provider-credentials.mjs";
-import { writePrivateFile, writePrivateJson } from "./file-security.mjs";
+import { protectPrivateFile } from "./file-security.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import {
+  CODEX_HOME,
   PROVIDER_CREDENTIAL_MIGRATIONS_DIR,
   PROVIDER_CREDENTIAL_STORE_PATH,
+  STATE_DIR,
+  TARGET,
 } from "./paths.mjs";
 
 /**
@@ -21,24 +28,151 @@ import {
  * OAuth secret. `secretRef` names an existing protected provider store and is
  * resolved by the provider-specific credential code when a request is made.
  */
-export const PROVIDER_CREDENTIAL_SCHEMA_VERSION = 1;
+export const PROVIDER_CREDENTIAL_SCHEMA_VERSION = 2;
 export const PROVIDER_CREDENTIAL_KINDS = Object.freeze(["account", "api_key"]);
 export const SECRET_REFERENCE_TYPES = Object.freeze([
   "provider-file",
   "keychain",
-  "oauth-session",
   "environment",
 ]);
 
-const SENSITIVE_KEY = /(?:authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|secret|password|cookie|credential|private[-_]?key|signed[-_]?url)/i;
-const PROVIDER_ID = /^[a-z0-9][a-z0-9-]*$/i;
+const SENSITIVE_KEY = /(?:authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|token|secret|password|cookie|credential|private[-_]?key|signed[-_]?url)/i;
 const CREDENTIAL_ID = /^cred_[A-Za-z0-9_-]{16,64}$/;
 const LABEL_LIMIT = 160;
+const STORE_KEYS = new Set(["schemaVersion", "credentials"]);
+const LEGACY_STORE_KEYS = new Set(["version", "credentials"]);
+const CREDENTIAL_KEYS = new Set([
+  "id",
+  "providerId",
+  "kind",
+  "secretRef",
+  "state",
+  "createdAt",
+  "updatedAt",
+  "label",
+  "account",
+]);
+const ACCOUNT_KEYS = new Set(["alias", "plan"]);
+const SECRET_REF_KEYS = new Set(["type", "providerId", "target", "service", "name"]);
 
 function sensitiveKey(key) {
-  // `secretRef` is a safe descriptor, not a secret-bearing field. Every
-  // other key matching the broad pattern is rejected/redacted.
-  return key !== "secretRef" && SENSITIVE_KEY.test(key);
+  // `secretRef` is a safe descriptor, not a secret-bearing field.
+  return !["secretRef", "credentials"].includes(key) && SENSITIVE_KEY.test(key);
+}
+
+function plainObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${field} must be an object.`);
+  }
+  return value;
+}
+
+function assertAllowedKeys(value, allowed, field) {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`${field} contains unsupported field ${key}.`);
+  }
+}
+
+function isWithin(base, target) {
+  const relative = path.relative(base, target);
+  return relative === "" || (
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function assertNoSymlinkComponents(target, field, boundary) {
+  const absolute = path.resolve(target);
+  const base = boundary ? path.resolve(boundary) : undefined;
+  const root = path.parse(absolute).root;
+  const components = absolute.slice(root.length).split(path.sep).filter(Boolean);
+  let current = root;
+  for (const component of components) {
+    current = path.join(current, component);
+    try {
+      const atOrBelowBoundary = !base || isWithin(base, current);
+      if (atOrBelowBoundary && lstatSync(current).isSymbolicLink()) {
+        throw new Error(`${field} cannot contain a symbolic link.`);
+      }
+    } catch (error) {
+      if (error?.code === "ENOENT") break;
+      throw error;
+    }
+  }
+}
+
+function managedStatePath(value, field, { allowDirectory = false } = {}) {
+  if (typeof value !== "string" || !path.isAbsolute(value)) {
+    throw new Error(`${field} must be an absolute path.`);
+  }
+  const target = path.resolve(value);
+  const base = path.resolve(STATE_DIR);
+  if (!isWithin(base, target) || (!allowDirectory && target === base)) {
+    throw new Error(`${field} must stay inside the router state directory.`);
+  }
+  assertNoSymlinkComponents(target, field, base);
+  return target;
+}
+
+function managedSourcePath(value, field) {
+  if (typeof value !== "string" || !path.isAbsolute(value)) {
+    throw new Error(`${field} must be an absolute path.`);
+  }
+  const target = path.resolve(value);
+  const bases = [path.resolve(CODEX_HOME), path.resolve(STATE_DIR)];
+  const base = bases.find((candidate) => isWithin(candidate, target));
+  if (!base || target === base) {
+    throw new Error(`${field} must stay inside a managed credential directory.`);
+  }
+  assertNoSymlinkComponents(target, field, base);
+  return target;
+}
+
+function readRegularBytes(filePath, field) {
+  const target = path.resolve(filePath);
+  let stat;
+  try {
+    stat = lstatSync(target);
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    throw error;
+  }
+  if (stat.isSymbolicLink() || !stat.isFile()) {
+    throw new Error(`${field} must be a regular file.`);
+  }
+  return readFileSync(target);
+}
+
+function atomicPrivateBytes(filePath, bytes, { directoryMode = 0o700 } = {}) {
+  const target = managedStatePath(filePath, "target path");
+  const directory = path.dirname(target);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  chmodSync(directory, directoryMode);
+  const temporary = path.join(
+    directory,
+    `.${path.basename(target)}.tmp-${process.pid}-${randomBytes(8).toString("hex")}`,
+  );
+  try {
+    writeFileSync(temporary, bytes, { mode: 0o600 });
+    protectPrivateFile(temporary);
+    renameSync(temporary, target);
+    protectPrivateFile(target);
+  } catch (error) {
+    try { unlinkSync(temporary); } catch (cleanupError) {
+      if (cleanupError?.code !== "ENOENT") error.cleanupError = cleanupError;
+    }
+    throw error;
+  }
+  return target;
+}
+
+function serializedStore(store) {
+  return Buffer.from(`${JSON.stringify(store, null, 2)}\n`, "utf8");
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
 }
 
 function now() {
@@ -62,8 +196,11 @@ function normalizeText(value, field, { max = LABEL_LIMIT, required = false } = {
 
 function validateProviderId(value) {
   const providerId = normalizeText(value, "providerId", { max: 100, required: true });
-  if (!PROVIDER_ID.test(providerId)) throw new Error(`Invalid providerId: ${providerId}`);
-  return providerId;
+  const provider = PROVIDERS.get(providerId);
+  if (!provider || provider.kind !== "openai-compatible" || !provider.credential) {
+    throw new Error(`Invalid providerId: ${providerId}`);
+  }
+  return provider.variantOf || provider.id;
 }
 
 function validateCredentialId(value) {
@@ -97,11 +234,10 @@ function assertNoSecretFields(value, context = "credential metadata") {
   }
 }
 
-function normalizeSecretRef(value, providerId) {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("secretRef must be an object reference; raw secrets are not accepted.");
-  }
+function normalizeSecretRef(value, providerId, { legacy = false } = {}) {
+  plainObject(value, "secretRef");
   assertNoSecretFields(value, "secretRef");
+  assertAllowedKeys(value, SECRET_REF_KEYS, "secretRef");
   const type = normalizeText(value.type, "secretRef.type", { max: 40, required: true });
   if (!SECRET_REFERENCE_TYPES.includes(type)) {
     throw new Error(`Unsupported secretRef type: ${type}`);
@@ -109,23 +245,47 @@ function normalizeSecretRef(value, providerId) {
   const referenceProviderId = value.providerId === undefined
     ? providerId
     : validateProviderId(value.providerId);
-  const normalized = { type, providerId: referenceProviderId };
+  if (referenceProviderId !== providerId) {
+    throw new Error("secretRef.providerId must match providerId.");
+  }
+  const target = value.target === undefined && legacy ? TARGET : normalizeText(
+    value.target,
+    "secretRef.target",
+    { max: 20, required: true },
+  );
+  if (target !== TARGET) throw new Error("secretRef.target does not match this router target.");
+  const normalized = { type, providerId: referenceProviderId, target };
+  const provider = PROVIDERS.get(referenceProviderId);
+  if (!provider?.credential) throw new Error(`Provider ${referenceProviderId} has no credential policy.`);
   if (type === "keychain") {
     const service = normalizeText(value.service, "secretRef.service", { max: 200, required: true });
+    if (!provider.credential.keychainServices?.includes(service)) {
+      throw new Error("secretRef.service is not configured for this provider.");
+    }
     normalized.service = service;
   } else if (type === "environment") {
     const name = normalizeText(value.name, "secretRef.name", { max: 100, required: true });
-    if (!/^[A-Z][A-Z0-9_]*$/.test(name)) throw new Error("secretRef.name must be an environment variable name.");
+    if (!provider.credential.environment?.includes(name)) {
+      throw new Error("secretRef.name is not configured for this provider.");
+    }
     normalized.name = name;
+  }
+  if (type === "provider-file" && (value.service !== undefined || value.name !== undefined)) {
+    throw new Error("provider-file secretRef cannot include service or name.");
+  }
+  if (type === "keychain" && value.name !== undefined) {
+    throw new Error("keychain secretRef cannot include name.");
+  }
+  if (type === "environment" && value.service !== undefined) {
+    throw new Error("environment secretRef cannot include service.");
   }
   return normalized;
 }
 
 function normalizeCredential(raw, { legacy = false } = {}) {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error("Each credential must be an object.");
-  }
+  plainObject(raw, "credential");
   assertNoSecretFields(raw, "credential metadata");
+  assertAllowedKeys(raw, CREDENTIAL_KEYS, "credential");
   const providerId = validateProviderId(raw.providerId);
   const kind = normalizeText(raw.kind || (legacy ? "api_key" : undefined), "credential kind", {
     max: 20,
@@ -135,7 +295,7 @@ function normalizeCredential(raw, { legacy = false } = {}) {
     throw new Error(`Unsupported credential kind: ${kind}`);
   }
   const id = validateCredentialId(raw.id);
-  const secretRef = normalizeSecretRef(raw.secretRef, providerId);
+  const secretRef = normalizeSecretRef(raw.secretRef, providerId, { legacy });
   const state = normalizeText(raw.state || "active", "credential state", { max: 20, required: true });
   if (!["active", "paused", "revoked"].includes(state)) {
     throw new Error(`Unsupported credential state: ${state}`);
@@ -155,7 +315,9 @@ function normalizeCredential(raw, { legacy = false } = {}) {
   if (label) result.label = label;
   // Account metadata is intentionally narrow. Do not persist arbitrary
   // provider responses or email/token-shaped fields in this store.
-  if (raw.account && typeof raw.account === "object" && !Array.isArray(raw.account)) {
+  if (raw.account !== undefined) {
+    plainObject(raw.account, "account");
+    assertAllowedKeys(raw.account, ACCOUNT_KEYS, "account");
     const account = {};
     const alias = normalizeText(raw.account.alias, "account.alias");
     const plan = normalizeText(raw.account.plan, "account.plan", { max: 80 });
@@ -167,10 +329,14 @@ function normalizeCredential(raw, { legacy = false } = {}) {
 }
 
 function normalizeStore(raw, { legacy = false } = {}) {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error("Credential store must be an object.");
+  plainObject(raw, "Credential store");
+  assertNoSecretFields(raw, "Credential store");
+  assertAllowedKeys(raw, legacy ? LEGACY_STORE_KEYS : STORE_KEYS, "Credential store");
+  if (!Array.isArray(raw.credentials)) throw new Error("Credential store credentials must be an array.");
+  if (!legacy && raw.schemaVersion !== PROVIDER_CREDENTIAL_SCHEMA_VERSION) {
+    throw new Error("Unsupported provider credential store schema.");
   }
-  const entries = Array.isArray(raw.credentials) ? raw.credentials : [];
+  const entries = raw.credentials;
   const seen = new Set();
   const credentials = entries.map((entry) => {
     const normalized = normalizeCredential(entry, { legacy });
@@ -182,23 +348,38 @@ function normalizeStore(raw, { legacy = false } = {}) {
 }
 
 function parseStore(contents, { allowLegacy = false } = {}) {
-  const parsed = JSON.parse(contents);
+  if (typeof contents !== "string" && !Buffer.isBuffer(contents)) {
+    throw new Error("Credential store contents must be bytes.");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(Buffer.from(contents).toString("utf8"));
+  } catch {
+    throw new Error("Credential store is not valid JSON.");
+  }
   if (parsed?.schemaVersion === PROVIDER_CREDENTIAL_SCHEMA_VERSION) {
     return normalizeStore(parsed);
   }
-  // The migration accepts the older `{ version: 1, credentials: [...] }`
-  // shape used by early local experiments, but the normal reader never writes
-  // it back unless an explicit migration is requested.
-  if (allowLegacy && parsed?.version === 1 && Array.isArray(parsed.credentials)) {
-    return normalizeStore(parsed, { legacy: true });
+  if (
+    allowLegacy &&
+    ((parsed?.version === 1) || (parsed?.schemaVersion === 1)) &&
+    Array.isArray(parsed.credentials)
+  ) {
+    assertAllowedKeys(
+      parsed,
+      parsed.version === 1 ? LEGACY_STORE_KEYS : new Set(["schemaVersion", "credentials"]),
+      "Credential store",
+    );
+    return normalizeStore({ version: 1, credentials: parsed.credentials }, { legacy: true });
   }
   throw new Error("Unsupported provider credential store schema.");
 }
 
 export function readProviderCredentialStore(filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
-  if (!existsSync(filePath)) return emptyStore();
+  const target = managedStatePath(filePath, "credential store path");
+  if (!existsSync(target)) return emptyStore();
   try {
-    return parseStore(readFileSync(filePath, "utf8"));
+    return parseStore(readRegularBytes(target, "credential store"));
   } catch {
     // A malformed store must not become a source of credentials. Returning an
     // empty, safe state lets health/catalog paths continue while migration and
@@ -208,16 +389,27 @@ export function readProviderCredentialStore(filePath = PROVIDER_CREDENTIAL_STORE
 }
 
 export function writeProviderCredentialStore(store, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
+  const target = managedStatePath(filePath, "credential store path");
+  plainObject(store, "Credential store");
+  assertNoSecretFields(store, "Credential store");
+  assertAllowedKeys(store, STORE_KEYS, "Credential store");
+  if (store.schemaVersion !== undefined && store.schemaVersion !== PROVIDER_CREDENTIAL_SCHEMA_VERSION) {
+    throw new Error("Unsupported provider credential store schema.");
+  }
   const normalized = normalizeStore({
     schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
     credentials: store?.credentials,
   });
-  writePrivateJson(filePath, normalized, { directoryMode: 0o700 });
+  atomicPrivateBytes(target, serializedStore(normalized));
   return normalized;
 }
 
 export function createCredentialReference(input = {}) {
   assertNoSecretFields(input, "credential metadata");
+  plainObject(input, "credential metadata");
+  assertAllowedKeys(input, new Set([
+    "providerId", "kind", "secretRef", "label", "account", "id", "state", "createdAt", "updatedAt",
+  ]), "credential metadata");
   const {
     providerId,
     kind,
@@ -234,7 +426,9 @@ export function createCredentialReference(input = {}) {
     id: id || generatedCredentialId(normalizedProviderId, kind),
     providerId: normalizedProviderId,
     kind,
-    secretRef,
+    secretRef: secretRef && typeof secretRef === "object"
+      ? { ...secretRef, target: secretRef.target ?? TARGET }
+      : secretRef,
     label,
     account,
     state,
@@ -245,27 +439,30 @@ export function createCredentialReference(input = {}) {
 }
 
 export function addCredentialReference(input, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
-  const store = readProviderCredentialStoreStrict(filePath);
+  const target = managedStatePath(filePath, "credential store path");
+  const store = readProviderCredentialStoreStrict(target);
   const credential = createCredentialReference(input);
   if (store.credentials.some((entry) => entry.id === credential.id)) {
     throw new Error(`Credential id already exists: ${credential.id}`);
   }
   store.credentials.push(credential);
-  return writeProviderCredentialStore(store, filePath).credentials.at(-1);
+  return writeProviderCredentialStore(store, target).credentials.at(-1);
 }
 
 export function removeCredentialReference(id, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
   const credentialId = validateCredentialId(id);
-  const store = readProviderCredentialStoreStrict(filePath);
+  const target = managedStatePath(filePath, "credential store path");
+  const store = readProviderCredentialStoreStrict(target);
   const next = store.credentials.filter((entry) => entry.id !== credentialId);
   if (next.length === store.credentials.length) return false;
-  writeProviderCredentialStore({ credentials: next }, filePath);
+  writeProviderCredentialStore({ credentials: next }, target);
   return true;
 }
 
 function readProviderCredentialStoreStrict(filePath) {
-  if (!existsSync(filePath)) return emptyStore();
-  return parseStore(readFileSync(filePath, "utf8"));
+  const target = managedStatePath(filePath, "credential store path");
+  if (!existsSync(target)) return emptyStore();
+  return parseStore(readRegularBytes(target, "credential store"));
 }
 
 export function sanitizeCredentialStatus(entry) {
@@ -277,7 +474,11 @@ export function sanitizeCredentialStatus(entry) {
     state: credential.state,
     label: credential.label || null,
     account: credential.account ? { ...credential.account } : null,
-    secretRef: { type: credential.secretRef.type, providerId: credential.secretRef.providerId },
+    secretRef: {
+      type: credential.secretRef.type,
+      providerId: credential.secretRef.providerId,
+      target: credential.secretRef.target,
+    },
     createdAt: credential.createdAt,
     updatedAt: credential.updatedAt,
   };
@@ -295,8 +496,9 @@ function redactString(value) {
   let result = String(value ?? "");
   result = result
     .replace(/(authorization\s*[:=]\s*bearer\s+)[^\s"'&,}]+/gi, "$1[REDACTED]")
-    .replace(/([?&](?:api[_-]?key|access[_-]?token|refresh[_-]?token|token|key)=)[^&#\s]+/gi, "$1[REDACTED]")
-    .replace(/((?:["']?(?:api[_-]?key|access[_-]?token|refresh[_-]?token)["']?)\s*[:=]\s*["']?)[^\s"',}]+/gi, "$1[REDACTED]")
+    .replace(/((?:x[-_]?api[-_]?key|api[_-]?key|access[-_]?token|refresh[-_]?token|token|key)\s*[:=]\s*(?:bearer\s+)?)[^\s"'&,}]+/gi, "$1[REDACTED]")
+    .replace(/([?&](?:x[-_]?api[-_]?key|api[_-]?key|access[-_]?token|refresh[-_]?token|token|key)=)[^&#\s]+/gi, "$1[REDACTED]")
+    .replace(/((?:["']?(?:x[-_]?api[-_]?key|api[_-]?key|access[-_]?token|refresh[-_]?token|token|secret)["']?)\s*[:=]\s*["']?)([^\s"',}]+)/gi, "$1[REDACTED]")
     .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/gi, "$1[REDACTED]@[REDACTED]")
     .replace(/\b(?:sk|ghp|gho|github_pat)-[A-Za-z0-9_-]{8,}\b/g, "[REDACTED_KEY]");
   return result;
@@ -325,15 +527,47 @@ export function redactCredentialObject(value, knownSecrets = []) {
 }
 
 function migrationTimestamp() {
-  return `${new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-")}-${process.pid}`;
+  return `${new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-")}-${process.pid}-${randomBytes(6).toString("hex")}`;
 }
 
 function migrationManifestPath(directory) {
   return path.join(directory, "migration.json");
 }
 
-function readMigrationManifest(manifestPath) {
-  return JSON.parse(readFileSync(manifestPath, "utf8"));
+function readMigrationManifest(manifestPath, migrationDirectory, expectedTarget) {
+  const selected = managedStatePath(manifestPath, "migration manifest path");
+  const directory = managedStatePath(migrationDirectory, "migration directory", { allowDirectory: true });
+  if (!isWithin(directory, selected) || path.basename(selected) !== "migration.json") {
+    throw new Error("Migration manifest must stay inside the migration directory.");
+  }
+  const parsed = JSON.parse(readRegularBytes(selected, "migration manifest").toString("utf8"));
+  plainObject(parsed, "migration manifest");
+  assertAllowedKeys(parsed, new Set([
+    "schemaVersion", "createdAt", "targetPath", "previousExists", "previousPath", "previousSha256", "afterSha256",
+  ]), "migration manifest");
+  if (parsed.schemaVersion !== PROVIDER_CREDENTIAL_SCHEMA_VERSION || typeof parsed.targetPath !== "string") {
+    throw new Error("Unsupported provider credential migration snapshot.");
+  }
+  const target = managedStatePath(parsed.targetPath, "migration target path");
+  if (target !== expectedTarget) throw new Error("Migration target does not match the requested store.");
+  if (typeof parsed.afterSha256 !== "string" || !/^[a-f0-9]{64}$/.test(parsed.afterSha256)) {
+    throw new Error("Migration snapshot has no valid post-migration digest.");
+  }
+  if (typeof parsed.previousExists !== "boolean") throw new Error("Migration snapshot has invalid previous state.");
+  if (parsed.previousExists) {
+    const previous = managedStatePath(parsed.previousPath, "migration rollback path");
+    if (path.dirname(previous) !== path.dirname(selected) || path.basename(previous) !== "provider-credentials.before-migration.json") {
+      throw new Error("Migration rollback path is outside its snapshot directory.");
+    }
+    if (typeof parsed.previousSha256 !== "string" || !/^[a-f0-9]{64}$/.test(parsed.previousSha256)) {
+      throw new Error("Migration snapshot has no valid previous digest.");
+    }
+    parsed.previousPath = previous;
+  } else if (parsed.previousPath !== null || parsed.previousSha256 !== null) {
+    throw new Error("Migration snapshot has an unexpected previous path.");
+  }
+  parsed.targetPath = target;
+  return parsed;
 }
 
 function existingProviderFileReferences() {
@@ -344,7 +578,14 @@ function existingProviderFileReferences() {
     const providerId = provider.variantOf || provider.id;
     const referenceKey = `${providerId}:api_key`;
     if (seen.has(referenceKey)) continue;
-    const file = credentialPaths(provider).find((candidate) => existsSync(candidate));
+    const file = credentialPaths(provider).map((candidate) => {
+      try {
+        const managed = managedSourcePath(candidate, "provider credential path");
+        return readRegularBytes(managed, "provider credential") === undefined ? undefined : managed;
+      } catch {
+        return undefined;
+      }
+    }).find(Boolean);
     if (!file) continue;
     seen.add(referenceKey);
     entries.push({
@@ -352,7 +593,7 @@ function existingProviderFileReferences() {
       providerId,
       kind: "api_key",
       label: provider.credential.label,
-      secretRef: { type: "provider-file", providerId },
+      secretRef: { type: "provider-file", providerId, target: TARGET },
       state: "active",
       createdAt: now(),
       updatedAt: now(),
@@ -365,86 +606,106 @@ export function migrateProviderCredentialStore(
   filePath = PROVIDER_CREDENTIAL_STORE_PATH,
   { migrationDirectory = PROVIDER_CREDENTIAL_MIGRATIONS_DIR } = {},
 ) {
-  if (existsSync(filePath)) {
-    const contents = readFileSync(filePath, "utf8");
+  const target = managedStatePath(filePath, "credential store path");
+  const migrations = managedStatePath(migrationDirectory, "migration directory", { allowDirectory: true });
+  const existing = readRegularBytes(target, "credential store");
+  if (existing !== undefined) {
     try {
-      const current = parseStore(contents);
+      const current = parseStore(existing);
       return { migrated: false, store: current };
     } catch {
-      // Continue only when this is the explicitly supported legacy shape. A
-      // foreign or malformed file is never silently overwritten.
-      const legacy = parseStore(contents, { allowLegacy: true });
-      const directory = path.join(migrationDirectory, migrationTimestamp());
+      const legacy = parseStore(existing, { allowLegacy: true });
+      const directory = path.join(migrations, migrationTimestamp());
       mkdirSync(directory, { recursive: true, mode: 0o700 });
       const previousPath = path.join(directory, "provider-credentials.before-migration.json");
-      // Keep rollback useful without copying unknown fields from the legacy
-      // document. `parseStore` already reduced it to the supported metadata
-      // shape; snapshot that normalized shape instead of preserving arbitrary
-      // values that may contain a secret under an unrecognised key.
-      writePrivateJson(previousPath, { version: 1, credentials: legacy.credentials });
+      const store = {
+        schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+        credentials: legacy.credentials,
+      };
+      const after = serializedStore(store);
       const manifestPath = migrationManifestPath(directory);
-      writePrivateJson(
+      atomicPrivateBytes(previousPath, existing);
+      atomicPrivateBytes(manifestPath, Buffer.from(JSON.stringify({
+        schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+        createdAt: now(),
+        targetPath: target,
+        previousExists: true,
+        previousPath,
+        previousSha256: sha256(existing),
+        afterSha256: sha256(after),
+      }, null, 2) + "\n"));
+      atomicPrivateBytes(target, after);
+      atomicPrivateBytes(path.join(migrations, "latest.json"), Buffer.from(JSON.stringify({
+        schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
         manifestPath,
-        {
-          schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
-          createdAt: now(),
-          targetPath: filePath,
-          previousExists: true,
-          previousPath,
-        },
-        { directoryMode: 0o700 },
-      );
-      const store = writeProviderCredentialStore(legacy, filePath);
-      writePrivateJson(
-        path.join(migrationDirectory, "latest.json"),
-        { schemaVersion: 1, manifestPath },
-        { directoryMode: 0o700 },
-      );
+      }, null, 2) + "\n"));
       return { migrated: true, store, legacy: true, manifestPath };
     }
   }
 
   const entries = existingProviderFileReferences();
   const store = { schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION, credentials: entries };
-  mkdirSync(migrationDirectory, { recursive: true, mode: 0o700 });
-  const directory = path.join(migrationDirectory, migrationTimestamp());
+  const after = serializedStore(store);
+  mkdirSync(migrations, { recursive: true, mode: 0o700 });
+  const directory = path.join(migrations, migrationTimestamp());
   mkdirSync(directory, { recursive: true, mode: 0o700 });
   const snapshot = {
     schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
     createdAt: now(),
-    targetPath: filePath,
+    targetPath: target,
     previousExists: false,
     previousPath: null,
+    previousSha256: null,
+    afterSha256: sha256(after),
   };
   const manifestPath = migrationManifestPath(directory);
-  writePrivateJson(manifestPath, snapshot, { directoryMode: 0o700 });
-  writeProviderCredentialStore(store, filePath);
-  writePrivateJson(path.join(migrationDirectory, "latest.json"), { schemaVersion: 1, manifestPath }, { directoryMode: 0o700 });
+  atomicPrivateBytes(manifestPath, Buffer.from(`${JSON.stringify(snapshot, null, 2)}\n`));
+  atomicPrivateBytes(target, after);
+  atomicPrivateBytes(path.join(migrations, "latest.json"), Buffer.from(`${JSON.stringify({
+    schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+    manifestPath,
+  }, null, 2)}\n`));
   return { migrated: true, store, manifestPath };
 }
 
 export function rollbackProviderCredentialStore(
   manifestPath,
-  { migrationDirectory = PROVIDER_CREDENTIAL_MIGRATIONS_DIR } = {},
+  {
+    migrationDirectory = PROVIDER_CREDENTIAL_MIGRATIONS_DIR,
+    targetPath = PROVIDER_CREDENTIAL_STORE_PATH,
+  } = {},
 ) {
-  let selected = manifestPath;
+  const migrations = managedStatePath(migrationDirectory, "migration directory", { allowDirectory: true });
+  const target = managedStatePath(targetPath, "credential store path");
+  let selected = manifestPath ? managedStatePath(manifestPath, "migration manifest path") : undefined;
   if (!selected) {
-    const latestPath = path.join(migrationDirectory, "latest.json");
-    if (!existsSync(latestPath)) throw new Error("No provider credential migration snapshot is available.");
-    selected = JSON.parse(readFileSync(latestPath, "utf8")).manifestPath;
+    const latestPath = path.join(migrations, "latest.json");
+    const latest = readRegularBytes(latestPath, "latest migration pointer");
+    if (!latest) throw new Error("No provider credential migration snapshot is available.");
+    const parsed = JSON.parse(latest.toString("utf8"));
+    plainObject(parsed, "latest migration pointer");
+    assertAllowedKeys(parsed, new Set(["schemaVersion", "manifestPath"]), "latest migration pointer");
+    if (parsed.schemaVersion !== PROVIDER_CREDENTIAL_SCHEMA_VERSION || typeof parsed.manifestPath !== "string") {
+      throw new Error("Unsupported latest migration pointer.");
+    }
+    selected = managedStatePath(parsed.manifestPath, "migration manifest path");
   }
   if (!selected || !existsSync(selected)) throw new Error("Provider credential migration snapshot is missing.");
-  const manifest = readMigrationManifest(selected);
-  if (manifest.schemaVersion !== PROVIDER_CREDENTIAL_SCHEMA_VERSION || typeof manifest.targetPath !== "string") {
-    throw new Error("Unsupported provider credential migration snapshot.");
+  const manifest = readMigrationManifest(selected, migrations, target);
+  const current = readRegularBytes(target, "credential store");
+  if (current !== undefined && sha256(current) !== manifest.afterSha256) {
+    throw new Error("Refusing rollback because the credential store changed after migration.");
   }
   if (manifest.previousExists) {
-    if (!manifest.previousPath || !existsSync(manifest.previousPath)) {
+    const previous = readRegularBytes(manifest.previousPath, "migration rollback snapshot");
+    if (!previous || sha256(previous) !== manifest.previousSha256) {
       throw new Error("Provider credential rollback snapshot is missing.");
     }
-    writePrivateFile(manifest.targetPath, readFileSync(manifest.previousPath, "utf8"));
-  } else if (existsSync(manifest.targetPath)) {
-    unlinkSync(manifest.targetPath);
+    atomicPrivateBytes(target, previous);
+  } else if (current !== undefined) {
+    const stat = lstatSync(target);
+    if (stat.isSymbolicLink() || !stat.isFile()) throw new Error("Credential store is not a regular file.");
+    unlinkSync(target);
   }
-  return { rolledBack: true, targetPath: manifest.targetPath };
+  return { rolledBack: true, targetPath: target };
 }

--- a/src/provider-credential-store.mjs
+++ b/src/provider-credential-store.mjs
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 
+import { withAtomicStateLock } from "./atomic-state-lock.mjs";
 import { credentialPaths } from "./provider-credentials.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
@@ -18,8 +19,8 @@ import {
   CODEX_HOME,
   PROVIDER_CREDENTIAL_MIGRATIONS_DIR,
   PROVIDER_CREDENTIAL_STORE_PATH,
+  ROUTER_PLANE_TARGET,
   STATE_DIR,
-  TARGET,
 } from "./paths.mjs";
 
 /**
@@ -259,12 +260,12 @@ function normalizeSecretRef(value, providerId, { legacy = false } = {}) {
   if (referenceProviderId !== providerId) {
     throw new Error("secretRef.providerId must match providerId.");
   }
-  const target = value.target === undefined && legacy ? TARGET : normalizeText(
+  const target = value.target === undefined && legacy ? ROUTER_PLANE_TARGET : normalizeText(
     value.target,
     "secretRef.target",
     { max: 20, required: true },
   );
-  if (target !== TARGET) throw new Error("secretRef.target does not match this router target.");
+  if (target !== ROUTER_PLANE_TARGET) throw new Error("secretRef.target does not match this router plane.");
   const normalized = { type, providerId: referenceProviderId, target };
   const provider = PROVIDERS.get(referenceProviderId);
   if (!provider?.credential) throw new Error(`Provider ${referenceProviderId} has no credential policy.`);
@@ -438,7 +439,7 @@ export function createCredentialReference(input = {}) {
     providerId: normalizedProviderId,
     kind,
     secretRef: secretRef && typeof secretRef === "object"
-      ? { ...secretRef, target: secretRef.target ?? TARGET }
+      ? { ...secretRef, target: secretRef.target ?? ROUTER_PLANE_TARGET }
       : secretRef,
     label,
     account,
@@ -451,23 +452,27 @@ export function createCredentialReference(input = {}) {
 
 export function addCredentialReference(input, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
   const target = managedStatePath(filePath, "credential store path");
-  const store = readProviderCredentialStoreStrict(target);
-  const credential = createCredentialReference(input);
-  if (store.credentials.some((entry) => entry.id === credential.id)) {
-    throw new Error(`Credential id already exists: ${credential.id}`);
-  }
-  store.credentials.push(credential);
-  return writeProviderCredentialStore(store, target).credentials.at(-1);
+  return withAtomicStateLock(target, () => {
+    const store = readProviderCredentialStoreStrict(target);
+    const credential = createCredentialReference(input);
+    if (store.credentials.some((entry) => entry.id === credential.id)) {
+      throw new Error(`Credential id already exists: ${credential.id}`);
+    }
+    store.credentials.push(credential);
+    return writeProviderCredentialStore(store, target).credentials.at(-1);
+  });
 }
 
 export function removeCredentialReference(id, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
   const credentialId = validateCredentialId(id);
   const target = managedStatePath(filePath, "credential store path");
-  const store = readProviderCredentialStoreStrict(target);
-  const next = store.credentials.filter((entry) => entry.id !== credentialId);
-  if (next.length === store.credentials.length) return false;
-  writeProviderCredentialStore({ credentials: next }, target);
-  return true;
+  return withAtomicStateLock(target, () => {
+    const store = readProviderCredentialStoreStrict(target);
+    const next = store.credentials.filter((entry) => entry.id !== credentialId);
+    if (next.length === store.credentials.length) return false;
+    writeProviderCredentialStore({ credentials: next }, target);
+    return true;
+  });
 }
 
 function readProviderCredentialStoreStrict(filePath) {
@@ -604,7 +609,7 @@ function existingProviderFileReferences() {
       providerId,
       kind: "api_key",
       label: provider.credential.label,
-      secretRef: { type: "provider-file", providerId, target: TARGET },
+      secretRef: { type: "provider-file", providerId, target: ROUTER_PLANE_TARGET },
       state: "active",
       createdAt: now(),
       updatedAt: now(),

--- a/src/provider-credential-store.mjs
+++ b/src/provider-credential-store.mjs
@@ -167,6 +167,17 @@ function atomicPrivateBytes(filePath, bytes, { directoryMode = 0o700 } = {}) {
   return target;
 }
 
+function restoreMigrationTarget(target, before, after) {
+  const current = readRegularBytes(target, "credential store");
+  const afterDigest = sha256(after);
+  if (current === undefined || sha256(current) !== afterDigest) return;
+  if (before === undefined) {
+    unlinkSync(target);
+  } else {
+    atomicPrivateBytes(target, before);
+  }
+}
+
 function serializedStore(store) {
   return Buffer.from(`${JSON.stringify(store, null, 2)}\n`, "utf8");
 }
@@ -624,21 +635,30 @@ export function migrateProviderCredentialStore(
       };
       const after = serializedStore(store);
       const manifestPath = migrationManifestPath(directory);
-      atomicPrivateBytes(previousPath, existing);
-      atomicPrivateBytes(manifestPath, Buffer.from(JSON.stringify({
-        schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
-        createdAt: now(),
-        targetPath: target,
-        previousExists: true,
-        previousPath,
-        previousSha256: sha256(existing),
-        afterSha256: sha256(after),
-      }, null, 2) + "\n"));
-      atomicPrivateBytes(target, after);
-      atomicPrivateBytes(path.join(migrations, "latest.json"), Buffer.from(JSON.stringify({
-        schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
-        manifestPath,
-      }, null, 2) + "\n"));
+      try {
+        atomicPrivateBytes(previousPath, existing);
+        atomicPrivateBytes(manifestPath, Buffer.from(JSON.stringify({
+          schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+          createdAt: now(),
+          targetPath: target,
+          previousExists: true,
+          previousPath,
+          previousSha256: sha256(existing),
+          afterSha256: sha256(after),
+        }, null, 2) + "\n"));
+        atomicPrivateBytes(target, after);
+        atomicPrivateBytes(path.join(migrations, "latest.json"), Buffer.from(JSON.stringify({
+          schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+          manifestPath,
+        }, null, 2) + "\n"));
+      } catch (error) {
+        try {
+          restoreMigrationTarget(target, existing, after);
+        } catch (rollbackError) {
+          error.rollbackError = rollbackError;
+        }
+        throw error;
+      }
       return { migrated: true, store, legacy: true, manifestPath };
     }
   }
@@ -659,12 +679,21 @@ export function migrateProviderCredentialStore(
     afterSha256: sha256(after),
   };
   const manifestPath = migrationManifestPath(directory);
-  atomicPrivateBytes(manifestPath, Buffer.from(`${JSON.stringify(snapshot, null, 2)}\n`));
-  atomicPrivateBytes(target, after);
-  atomicPrivateBytes(path.join(migrations, "latest.json"), Buffer.from(`${JSON.stringify({
-    schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
-    manifestPath,
-  }, null, 2)}\n`));
+  try {
+    atomicPrivateBytes(manifestPath, Buffer.from(`${JSON.stringify(snapshot, null, 2)}\n`));
+    atomicPrivateBytes(target, after);
+    atomicPrivateBytes(path.join(migrations, "latest.json"), Buffer.from(`${JSON.stringify({
+      schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+      manifestPath,
+    }, null, 2)}\n`));
+  } catch (error) {
+    try {
+      restoreMigrationTarget(target, undefined, after);
+    } catch (rollbackError) {
+      error.rollbackError = rollbackError;
+    }
+    throw error;
+  }
   return { migrated: true, store, manifestPath };
 }
 

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -198,6 +198,49 @@ export function resolveProviderCredential(providerOrId, options = {}) {
   return undefined;
 }
 
+/**
+ * Resolve one metadata-only credential reference without changing the
+ * provider's existing single-credential path. The reference is an opaque
+ * pointer to a provider-owned file, Keychain item, or environment variable;
+ * this helper never accepts a raw secret or an arbitrary filesystem path.
+ */
+export function resolveProviderCredentialReference(providerOrId, secretRef) {
+  const provider =
+    typeof providerOrId === "string" ? PROVIDERS.get(providerOrId) : providerOrId;
+  if (!provider || provider.kind !== "openai-compatible") return undefined;
+  if (!secretRef || typeof secretRef !== "object" || Array.isArray(secretRef)) {
+    return undefined;
+  }
+  if (secretRef.providerId && secretRef.providerId !== provider.id && secretRef.providerId !== provider.variantOf) {
+    return undefined;
+  }
+  if (discoveryDisabled()) return undefined;
+  const type = typeof secretRef.type === "string" ? secretRef.type.trim() : "";
+  if (type === "provider-file") {
+    return resolveProviderCredential(provider, { persistent: true });
+  }
+  if (type === "environment") {
+    const name = typeof secretRef.name === "string" ? secretRef.name.trim() : "";
+    if (!/^[A-Z][A-Z0-9_]*$/.test(name)) return undefined;
+    const value = process.env[name]?.trim();
+    if (!value) return undefined;
+    return resolvedCredential(provider, value, `environment (${name})`, false);
+  }
+  if (type === "keychain") {
+    if (process.platform !== "darwin") return undefined;
+    const service = typeof secretRef.service === "string" ? secretRef.service.trim() : "";
+    if (!service || service.length > 200) return undefined;
+    const found = keychainSecret(service, Date.now());
+    return found
+      ? resolvedCredential(provider, found.value, `macOS Keychain (${service})`, true)
+      : undefined;
+  }
+  // OAuth sessions are provider-specific and remain owned by their existing
+  // refresh/session implementations. Returning undefined keeps a pool entry
+  // from accidentally forwarding an opaque session id as an API key.
+  return undefined;
+}
+
 export function credentialSetupHint(provider) {
   if (provider.authMode === "anonymous") return "No key needed; free models are rate limited by the provider.";
   if (provider.authMode === "per-model") return "No key needed here; each model names its own endpoint.";

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -211,16 +211,27 @@ export function resolveProviderCredential(providerOrId, options = {}) {
     }
   }
   for (const candidate of credentialPaths(provider)) {
-    if (!existsSync(candidate)) continue;
-    const value = readFileSync(candidate, "utf8").trim();
-    if (value) {
-      const credential = resolvedCredential(
-        provider,
-        value,
-        `protected file (${candidate})`,
-        true,
-      );
-      if (credential) return credential;
+    let stat;
+    try {
+      stat = lstatSync(candidate);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      continue;
+    }
+    if (stat.isSymbolicLink() || !stat.isFile()) continue;
+    try {
+      const value = readFileSync(candidate, "utf8").trim();
+      if (value) {
+        const credential = resolvedCredential(
+          provider,
+          value,
+          `protected file (${candidate})`,
+          true,
+        );
+        if (credential) return credential;
+      }
+    } catch {
+      // An unreadable or non-text file is not a usable credential source.
     }
   }
   const keychain = keyFromKeychain(provider);

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -14,7 +14,7 @@ import path from "node:path";
 
 import { discoveryDisabled } from "./discovery-mode.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
-import { LEGACY_STATE_DIRS, STATE_DIR, TARGET } from "./paths.mjs";
+import { LEGACY_STATE_DIRS, ROUTER_PLANE_TARGET, STATE_DIR, TARGET } from "./paths.mjs";
 import { targetCli } from "./target-integration.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import {
@@ -257,7 +257,7 @@ export function resolveProviderCredentialReference(providerOrId, secretRef) {
   }
   const referenceKeys = new Set(["type", "providerId", "target", "service", "name"]);
   if (Object.keys(secretRef).some((key) => !referenceKeys.has(key))) return undefined;
-  if (secretRef.target !== TARGET) return undefined;
+  if (secretRef.target !== ROUTER_PLANE_TARGET) return undefined;
   if (secretRef.providerId !== canonicalProviderId(provider)) {
     return undefined;
   }

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   renameSync,
@@ -136,6 +137,38 @@ function resolvedCredential(provider, value, source, persistent) {
   return { value, source, persistent };
 }
 
+function canonicalProviderId(provider) {
+  return provider.variantOf || provider.id;
+}
+
+function configuredProviderFileCredential(provider) {
+  for (const candidate of credentialPaths(provider)) {
+    let stat;
+    try {
+      stat = lstatSync(candidate);
+    } catch (error) {
+      if (error?.code === "ENOENT") continue;
+      continue;
+    }
+    if (stat.isSymbolicLink() || !stat.isFile()) continue;
+    try {
+      const value = readFileSync(candidate, "utf8").trim();
+      if (value) {
+        const credential = resolvedCredential(
+          provider,
+          value,
+          "protected file",
+          true,
+        );
+        if (credential) return credential;
+      }
+    } catch {
+      // A file that cannot be read is not a usable credential source.
+    }
+  }
+  return undefined;
+}
+
 export function resolveProviderCredential(providerOrId, options = {}) {
   const provider =
     typeof providerOrId === "string" ? PROVIDERS.get(providerOrId) : providerOrId;
@@ -200,9 +233,9 @@ export function resolveProviderCredential(providerOrId, options = {}) {
 
 /**
  * Resolve one metadata-only credential reference without changing the
- * provider's existing single-credential path. The reference is an opaque
- * pointer to a provider-owned file, Keychain item, or environment variable;
- * this helper never accepts a raw secret or an arbitrary filesystem path.
+ * provider's existing single-credential path. References are bound to this
+ * target and to source names declared by the provider registry; raw secrets,
+ * arbitrary paths, services, and environment variables are rejected.
  */
 export function resolveProviderCredentialReference(providerOrId, secretRef) {
   const provider =
@@ -211,25 +244,31 @@ export function resolveProviderCredentialReference(providerOrId, secretRef) {
   if (!secretRef || typeof secretRef !== "object" || Array.isArray(secretRef)) {
     return undefined;
   }
-  if (secretRef.providerId && secretRef.providerId !== provider.id && secretRef.providerId !== provider.variantOf) {
+  const referenceKeys = new Set(["type", "providerId", "target", "service", "name"]);
+  if (Object.keys(secretRef).some((key) => !referenceKeys.has(key))) return undefined;
+  if (secretRef.target !== TARGET) return undefined;
+  if (secretRef.providerId !== canonicalProviderId(provider)) {
     return undefined;
   }
   if (discoveryDisabled()) return undefined;
   const type = typeof secretRef.type === "string" ? secretRef.type.trim() : "";
   if (type === "provider-file") {
-    return resolveProviderCredential(provider, { persistent: true });
+    if (secretRef.service !== undefined || secretRef.name !== undefined) return undefined;
+    return configuredProviderFileCredential(provider);
   }
   if (type === "environment") {
+    if (secretRef.service !== undefined) return undefined;
     const name = typeof secretRef.name === "string" ? secretRef.name.trim() : "";
-    if (!/^[A-Z][A-Z0-9_]*$/.test(name)) return undefined;
+    if (!provider.credential?.environment?.includes(name)) return undefined;
     const value = process.env[name]?.trim();
     if (!value) return undefined;
     return resolvedCredential(provider, value, `environment (${name})`, false);
   }
   if (type === "keychain") {
+    if (secretRef.name !== undefined) return undefined;
     if (process.platform !== "darwin") return undefined;
     const service = typeof secretRef.service === "string" ? secretRef.service.trim() : "";
-    if (!service || service.length > 200) return undefined;
+    if (!provider.credential?.keychainServices?.includes(service)) return undefined;
     const found = keychainSecret(service, Date.now());
     return found
       ? resolvedCredential(provider, found.value, `macOS Keychain (${service})`, true)

--- a/src/support-bundle.mjs
+++ b/src/support-bundle.mjs
@@ -31,6 +31,7 @@ import {
   credentialStatus,
 } from "./provider-credentials.mjs";
 import { providerSelectionStatus } from "./provider-selection.mjs";
+import { redactCredentialText } from "./provider-credential-store.mjs";
 
 function runJson(script, args = []) {
   const result = spawnSync(
@@ -70,11 +71,7 @@ function fileMetadata(target) {
 }
 
 function redactLogs(contents) {
-  return redactCallerUrl(contents)
-    .replace(/(authorization\s*[:=]\s*bearer\s+)[^\s"']+/gi, "$1[REDACTED]")
-    .replace(/("(?:api[_-]?key|access[_-]?token|refresh[_-]?token)"\s*:\s*")[^"]+/gi, "$1[REDACTED]")
-    .replace(/((?:api[_-]?key|access[_-]?token|refresh[_-]?token)\s*[=:]\s*["']?)[^\s"',}]+/gi, "$1[REDACTED]")
-    .replace(/\bsk-[A-Za-z0-9_-]{12,}\b/g, "[REDACTED_KEY]");
+  return redactCredentialText(redactCallerUrl(contents));
 }
 
 function logTail() {
@@ -142,11 +139,7 @@ function sharableInstallManifest() {
 }
 
 function redactBundle(contents) {
-  let redacted = redactCallerUrl(contents);
-  for (const secret of knownLocalSecrets()) {
-    redacted = redacted.replaceAll(secret, "[REDACTED]");
-  }
-  return redacted;
+  return redactCredentialText(redactCallerUrl(contents), knownLocalSecrets());
 }
 
 function outputOption() {

--- a/src/support-bundle.mjs
+++ b/src/support-bundle.mjs
@@ -2,6 +2,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   readFileSync,
   statSync,
@@ -70,6 +71,16 @@ function fileMetadata(target) {
   };
 }
 
+function privateText(target) {
+  try {
+    const metadata = lstatSync(target);
+    if (metadata.isSymbolicLink() || !metadata.isFile()) return undefined;
+    return readFileSync(target, "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
 function redactLogs(contents) {
   return redactCredentialText(redactCallerUrl(contents));
 }
@@ -95,8 +106,7 @@ function knownLocalSecrets() {
     }
   }
   for (const target of files) {
-    if (!existsSync(target)) continue;
-    const value = readFileSync(target, "utf8").trim();
+    const value = privateText(target)?.trim();
     if (value) values.add(value);
   }
   // Not a provider credential and not stored in the state directory, but a
@@ -105,9 +115,10 @@ function knownLocalSecrets() {
   const clientSecret = process.env.ANTIGRAVITY_CLIENT_SECRET?.trim();
   if (clientSecret) values.add(clientSecret);
   const oauthPath = antigravityTokenPath();
-  if (existsSync(oauthPath)) {
+  const oauthContents = privateText(oauthPath);
+  if (oauthContents !== undefined) {
     try {
-      const token = JSON.parse(readFileSync(oauthPath, "utf8"));
+      const token = JSON.parse(oauthContents);
       for (const field of ["access_token", "refresh_token"]) {
         const value = token?.[field];
         if (typeof value === "string" && value.trim()) values.add(value.trim());

--- a/test/provider-credential-store.test.mjs
+++ b/test/provider-credential-store.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = mkdtempSync(path.join(os.tmpdir(), "codex-router-credential-store-"));
+process.env.CODEX_HOME = path.join(root, "codex");
+process.env.CODEX_ROUTER_STATE_DIR = path.join(root, "state");
+process.env.MODEL_ROUTER_PROVIDER_CREDENTIAL_STORE = path.join(root, "state", "provider-credentials.json");
+process.env.MODEL_ROUTER_PROVIDER_CREDENTIAL_MIGRATIONS = path.join(root, "state", "migrations", "provider-credentials");
+for (const name of ["DEEPSEEK_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY"]) delete process.env[name];
+
+const {
+  addCredentialReference,
+  migrateProviderCredentialStore,
+  PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+  readProviderCredentialStore,
+  redactCredentialObject,
+  redactCredentialText,
+  removeCredentialReference,
+  rollbackProviderCredentialStore,
+  sanitizeCredentialStatus,
+  sanitizedCredentialStore,
+  writeProviderCredentialStore,
+} = await import("../src/provider-credential-store.mjs");
+const { writeProviderCredential } = await import("../src/provider-credentials.mjs");
+const { privateFileIsProtected } = await import("../src/file-security.mjs");
+
+test.after(() => rmSync(root, { recursive: true, force: true }));
+
+test("credential references contain no secret and use protected metadata storage", () => {
+  const filePath = path.join(root, "state", "references.json");
+  const entry = addCredentialReference(
+    {
+      providerId: "deepseek",
+      kind: "api_key",
+      secretRef: { type: "provider-file" },
+      label: "Primary DeepSeek",
+      account: { alias: "main", plan: "api" },
+    },
+    filePath,
+  );
+  assert.match(entry.id, /^cred_[A-Za-z0-9_-]{16,64}$/);
+  assert.equal(entry.secretRef.providerId, "deepseek");
+  assert.equal("value" in entry, false);
+  assert.equal(privateFileIsProtected(filePath), true);
+  if (process.platform !== "win32") assert.equal(statSync(filePath).mode & 0o777, 0o600);
+  const raw = readFileSync(filePath, "utf8");
+  assert.doesNotMatch(raw, /api[_-]?key\s*[:=]/i);
+  assert.deepEqual(sanitizedCredentialStore(filePath).credentials[0], sanitizeCredentialStatus(entry));
+  assert.equal(removeCredentialReference(entry.id, filePath), true);
+  assert.deepEqual(readProviderCredentialStore(filePath).credentials, []);
+});
+
+test("raw secret fields are rejected instead of being copied into the store", () => {
+  const filePath = path.join(root, "state", "reject.json");
+  assert.throws(
+    () => addCredentialReference({
+      providerId: "deepseek",
+      kind: "api_key",
+      secretRef: { type: "provider-file" },
+      apiKey: "TEST_DO_NOT_STORE",
+    }, filePath),
+    /secret field apiKey/,
+  );
+  assert.equal(existsSync(filePath), false);
+});
+
+test("redaction covers headers, URLs, errors, nested objects, and known secrets", () => {
+  const text = [
+    "Authorization: Bearer TEST_BEARER_TOKEN",
+    "https://user:password@example.test/v1?api_key=QUERY_SECRET",
+    "{\"access_token\":\"JSON_SECRET\",\"message\":\"TEST_KNOWN_SECRET\"}",
+    "sk-test_secret_value",
+  ].join(" ");
+  const redacted = redactCredentialText(text, ["TEST_KNOWN_SECRET"]);
+  assert.doesNotMatch(redacted, /TEST_BEARER_TOKEN|password|QUERY_SECRET|JSON_SECRET|TEST_KNOWN_SECRET|sk-test_secret_value/);
+  const object = redactCredentialObject({
+    headers: { Authorization: "Bearer TEST_HEADER_SECRET" },
+    nested: { refreshToken: "TEST_REFRESH_SECRET", message: "TEST_KNOWN_SECRET" },
+  }, ["TEST_KNOWN_SECRET"]);
+  assert.equal(object.headers.Authorization, "[REDACTED]");
+  assert.equal(object.nested.refreshToken, "[REDACTED]");
+  assert.equal(object.nested.message, "[REDACTED]");
+});
+
+test("migration discovers existing protected provider files without copying secrets", () => {
+  const filePath = path.join(root, "state", "migrated.json");
+  const migrationDirectory = path.join(root, "state", "migration-test");
+  const providerPath = writeProviderCredential("deepseek", "TEST_MIGRATION_SECRET");
+  const first = migrateProviderCredentialStore(filePath, { migrationDirectory });
+  assert.equal(first.migrated, true);
+  assert.equal(first.store.schemaVersion, PROVIDER_CREDENTIAL_SCHEMA_VERSION);
+  assert.equal(first.store.credentials.some((entry) => entry.providerId === "deepseek"), true);
+  assert.doesNotMatch(readFileSync(filePath, "utf8"), /TEST_MIGRATION_SECRET/);
+  assert.equal(privateFileIsProtected(first.manifestPath), true);
+  const second = migrateProviderCredentialStore(filePath, { migrationDirectory });
+  assert.equal(second.migrated, false, "the second run must be idempotent");
+
+  rollbackProviderCredentialStore(first.manifestPath, { migrationDirectory });
+  assert.equal(existsSync(filePath), false);
+  assert.equal(readFileSync(providerPath, "utf8"), "TEST_MIGRATION_SECRET\n");
+});
+
+test("legacy metadata migration creates a protected rollback snapshot", () => {
+  const filePath = path.join(root, "state", "legacy.json");
+  const migrationDirectory = path.join(root, "state", "legacy-migration-test");
+  const legacy = {
+    version: 1,
+    credentials: [{
+      id: "cred_legacy_reference_123456",
+      providerId: "openrouter",
+      kind: "api_key",
+      secretRef: { type: "provider-file" },
+      state: "active",
+    }],
+    // Unknown legacy fields are deliberately discarded from the rollback
+    // snapshot; they are not part of the supported metadata contract.
+    opaque: "TEST_LEGACY_SECRET",
+  };
+  writeFileSync(filePath, `${JSON.stringify(legacy)}\n`, { mode: 0o600 });
+  const migration = migrateProviderCredentialStore(filePath, { migrationDirectory });
+  assert.equal(migration.legacy, true);
+  assert.equal(JSON.parse(readFileSync(filePath, "utf8")).schemaVersion, 1);
+  assert.equal(privateFileIsProtected(path.join(migrationDirectory, "latest.json")), true);
+  const snapshot = readFileSync(path.join(path.dirname(migration.manifestPath), "provider-credentials.before-migration.json"), "utf8");
+  assert.doesNotMatch(snapshot, /TEST_LEGACY_SECRET/);
+  rollbackProviderCredentialStore(undefined, { migrationDirectory });
+  const rolledBack = JSON.parse(readFileSync(filePath, "utf8"));
+  assert.equal(rolledBack.version, 1);
+  assert.equal(rolledBack.credentials.length, 1);
+  assert.equal(rolledBack.credentials[0].id, legacy.credentials[0].id);
+  assert.equal(rolledBack.credentials[0].secretRef.providerId, "openrouter");
+  assert.equal("opaque" in rolledBack, false);
+});

--- a/test/provider-credential-store.test.mjs
+++ b/test/provider-credential-store.test.mjs
@@ -4,6 +4,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   statSync,
   writeFileSync,
 } from "node:fs";
@@ -20,6 +21,7 @@ for (const name of ["DEEPSEEK_API_KEY", "OPENROUTER_API_KEY", "ANTHROPIC_API_KEY
 
 const {
   addCredentialReference,
+  createCredentialReference,
   migrateProviderCredentialStore,
   PROVIDER_CREDENTIAL_SCHEMA_VERSION,
   readProviderCredentialStore,
@@ -31,10 +33,19 @@ const {
   sanitizedCredentialStore,
   writeProviderCredentialStore,
 } = await import("../src/provider-credential-store.mjs");
-const { writeProviderCredential } = await import("../src/provider-credentials.mjs");
+const {
+  credentialPaths,
+  resolveProviderCredentialReference,
+  writeProviderCredential,
+} = await import("../src/provider-credentials.mjs");
+const { PROVIDERS } = await import("../src/model-registry.mjs");
 const { privateFileIsProtected } = await import("../src/file-security.mjs");
 
 test.after(() => rmSync(root, { recursive: true, force: true }));
+
+function ref(providerId = "deepseek") {
+  return { type: "provider-file", providerId, target: "codex" };
+}
 
 test("credential references contain no secret and use protected metadata storage", () => {
   const filePath = path.join(root, "state", "references.json");
@@ -42,7 +53,7 @@ test("credential references contain no secret and use protected metadata storage
     {
       providerId: "deepseek",
       kind: "api_key",
-      secretRef: { type: "provider-file" },
+      secretRef: ref(),
       label: "Primary DeepSeek",
       account: { alias: "main", plan: "api" },
     },
@@ -50,6 +61,7 @@ test("credential references contain no secret and use protected metadata storage
   );
   assert.match(entry.id, /^cred_[A-Za-z0-9_-]{16,64}$/);
   assert.equal(entry.secretRef.providerId, "deepseek");
+  assert.equal(entry.secretRef.target, "codex");
   assert.equal("value" in entry, false);
   assert.equal(privateFileIsProtected(filePath), true);
   if (process.platform !== "win32") assert.equal(statSync(filePath).mode & 0o777, 0o600);
@@ -60,39 +72,59 @@ test("credential references contain no secret and use protected metadata storage
   assert.deepEqual(readProviderCredentialStore(filePath).credentials, []);
 });
 
-test("raw secret fields are rejected instead of being copied into the store", () => {
-  const filePath = path.join(root, "state", "reject.json");
+test("credential metadata parsing fails closed for unknown or secret-bearing fields", () => {
   assert.throws(
-    () => addCredentialReference({
+    () => createCredentialReference({
       providerId: "deepseek",
       kind: "api_key",
-      secretRef: { type: "provider-file" },
+      secretRef: ref(),
       apiKey: "TEST_DO_NOT_STORE",
-    }, filePath),
+    }),
     /secret field apiKey/,
   );
-  assert.equal(existsSync(filePath), false);
+  assert.throws(
+    () => createCredentialReference({
+      providerId: "deepseek",
+      kind: "api_key",
+      secretRef: { ...ref(), name: "NOT_ALLOWED" },
+    }),
+    /provider-file secretRef cannot include service or name/,
+  );
+  assert.throws(
+    () => createCredentialReference({
+      providerId: "deepseek",
+      kind: "api_key",
+      secretRef: { type: "environment", providerId: "deepseek", target: "codex", name: "UNRELATED_SECRET" },
+    }),
+    /not configured for this provider/,
+  );
+  assert.throws(
+    () => writeProviderCredentialStore({ credentials: [], accessToken: "TEST_STORE_SECRET" }, path.join(root, "state", "unsafe.json")),
+    /secret field accessToken/,
+  );
 });
 
 test("redaction covers headers, URLs, errors, nested objects, and known secrets", () => {
   const text = [
     "Authorization: Bearer TEST_BEARER_TOKEN",
+    "X-Api-Key: TEST_HEADER_KEY",
     "https://user:password@example.test/v1?api_key=QUERY_SECRET",
     "{\"access_token\":\"JSON_SECRET\",\"message\":\"TEST_KNOWN_SECRET\"}",
     "sk-test_secret_value",
   ].join(" ");
   const redacted = redactCredentialText(text, ["TEST_KNOWN_SECRET"]);
-  assert.doesNotMatch(redacted, /TEST_BEARER_TOKEN|password|QUERY_SECRET|JSON_SECRET|TEST_KNOWN_SECRET|sk-test_secret_value/);
+  assert.doesNotMatch(redacted, /TEST_BEARER_TOKEN|TEST_HEADER_KEY|password|QUERY_SECRET|JSON_SECRET|TEST_KNOWN_SECRET|sk-test_secret_value/);
   const object = redactCredentialObject({
-    headers: { Authorization: "Bearer TEST_HEADER_SECRET" },
+    headers: { Authorization: "Bearer TEST_HEADER_SECRET", "X-Api-Key": "TEST_API_SECRET" },
     nested: { refreshToken: "TEST_REFRESH_SECRET", message: "TEST_KNOWN_SECRET" },
   }, ["TEST_KNOWN_SECRET"]);
   assert.equal(object.headers.Authorization, "[REDACTED]");
+  assert.equal(object.headers["X-Api-Key"], "[REDACTED]");
   assert.equal(object.nested.refreshToken, "[REDACTED]");
   assert.equal(object.nested.message, "[REDACTED]");
 });
 
-test("migration discovers existing protected provider files without copying secrets", () => {
+test("migration discovers configured provider files without copying secret bytes", () => {
   const filePath = path.join(root, "state", "migrated.json");
   const migrationDirectory = path.join(root, "state", "migration-test");
   const providerPath = writeProviderCredential("deepseek", "TEST_MIGRATION_SECRET");
@@ -105,15 +137,15 @@ test("migration discovers existing protected provider files without copying secr
   const second = migrateProviderCredentialStore(filePath, { migrationDirectory });
   assert.equal(second.migrated, false, "the second run must be idempotent");
 
-  rollbackProviderCredentialStore(first.manifestPath, { migrationDirectory });
+  rollbackProviderCredentialStore(first.manifestPath, { migrationDirectory, targetPath: filePath });
   assert.equal(existsSync(filePath), false);
   assert.equal(readFileSync(providerPath, "utf8"), "TEST_MIGRATION_SECRET\n");
 });
 
-test("legacy metadata migration creates a protected rollback snapshot", () => {
+test("legacy migration preserves exact bytes and rejects changed targets", () => {
   const filePath = path.join(root, "state", "legacy.json");
   const migrationDirectory = path.join(root, "state", "legacy-migration-test");
-  const legacy = {
+  const legacyBytes = Buffer.from(JSON.stringify({
     version: 1,
     credentials: [{
       id: "cred_legacy_reference_123456",
@@ -122,22 +154,70 @@ test("legacy metadata migration creates a protected rollback snapshot", () => {
       secretRef: { type: "provider-file" },
       state: "active",
     }],
-    // Unknown legacy fields are deliberately discarded from the rollback
-    // snapshot; they are not part of the supported metadata contract.
-    opaque: "TEST_LEGACY_SECRET",
-  };
-  writeFileSync(filePath, `${JSON.stringify(legacy)}\n`, { mode: 0o600 });
+  }) + "\n", "utf8");
+  writeFileSync(filePath, legacyBytes, { mode: 0o600 });
   const migration = migrateProviderCredentialStore(filePath, { migrationDirectory });
   assert.equal(migration.legacy, true);
-  assert.equal(JSON.parse(readFileSync(filePath, "utf8")).schemaVersion, 1);
-  assert.equal(privateFileIsProtected(path.join(migrationDirectory, "latest.json")), true);
-  const snapshot = readFileSync(path.join(path.dirname(migration.manifestPath), "provider-credentials.before-migration.json"), "utf8");
-  assert.doesNotMatch(snapshot, /TEST_LEGACY_SECRET/);
-  rollbackProviderCredentialStore(undefined, { migrationDirectory });
-  const rolledBack = JSON.parse(readFileSync(filePath, "utf8"));
-  assert.equal(rolledBack.version, 1);
-  assert.equal(rolledBack.credentials.length, 1);
-  assert.equal(rolledBack.credentials[0].id, legacy.credentials[0].id);
-  assert.equal(rolledBack.credentials[0].secretRef.providerId, "openrouter");
-  assert.equal("opaque" in rolledBack, false);
+  assert.equal(JSON.parse(readFileSync(filePath, "utf8")).schemaVersion, PROVIDER_CREDENTIAL_SCHEMA_VERSION);
+  const snapshotPath = path.join(path.dirname(migration.manifestPath), "provider-credentials.before-migration.json");
+  assert.deepEqual(readFileSync(snapshotPath), legacyBytes);
+  writeFileSync(filePath, Buffer.from("changed\n"));
+  assert.throws(
+    () => rollbackProviderCredentialStore(migration.manifestPath, { migrationDirectory, targetPath: filePath }),
+    /changed after migration/,
+  );
+  assert.equal(readFileSync(filePath, "utf8"), "changed\n");
+  writeFileSync(filePath, Buffer.from(JSON.stringify({
+    schemaVersion: PROVIDER_CREDENTIAL_SCHEMA_VERSION,
+    credentials: migration.store.credentials,
+  }, null, 2) + "\n"));
+  rollbackProviderCredentialStore(undefined, { migrationDirectory, targetPath: filePath });
+  assert.deepEqual(readFileSync(filePath), legacyBytes);
+});
+
+test("migration rejects unknown legacy fields and confined paths", () => {
+  const filePath = path.join(root, "state", "bad-legacy.json");
+  writeFileSync(filePath, `${JSON.stringify({ version: 1, credentials: [], opaque: "TEST_SECRET" })}\n`, { mode: 0o600 });
+  assert.throws(
+    () => migrateProviderCredentialStore(filePath, { migrationDirectory: path.join(root, "state", "bad-migration") }),
+    /unsupported field opaque/,
+  );
+  assert.throws(
+    () => migrateProviderCredentialStore(path.join(root, "outside", "store.json")),
+    /inside the router state directory/,
+  );
+  const link = path.join(root, "state", "linked.json");
+  symlinkSync(path.join(root, "state", "target.json"), link);
+  assert.throws(
+    () => addCredentialReference({ providerId: "deepseek", kind: "api_key", secretRef: ref() }, link),
+    /symbolic link/,
+  );
+});
+
+test("credential references are target- and provider-bound at resolution time", () => {
+  const providerPath = writeProviderCredential("deepseek", "TEST_BOUND_SECRET");
+  const configured = resolveProviderCredentialReference("deepseek", ref());
+  assert.equal(configured?.value, "TEST_BOUND_SECRET");
+  assert.equal(resolveProviderCredentialReference("deepseek", { ...ref(), target: "gemini" }), undefined);
+  assert.equal(resolveProviderCredentialReference("openrouter", ref("deepseek")), undefined);
+  assert.equal(resolveProviderCredentialReference("deepseek", { ...ref(), path: "/tmp/outside" }), undefined);
+  assert.equal(resolveProviderCredentialReference("deepseek", {
+    type: "environment",
+    providerId: "deepseek",
+    target: "codex",
+    name: "UNRELATED_SECRET",
+  }), undefined);
+  assert.equal(resolveProviderCredentialReference("deepseek", {
+    type: "keychain",
+    providerId: "deepseek",
+    target: "codex",
+    service: "arbitrary-service",
+  }), undefined);
+
+  const external = path.join(root, "outside-secret.txt");
+  writeFileSync(external, "TEST_SYMLINK_SECRET\n", { mode: 0o600 });
+  rmSync(providerPath);
+  symlinkSync(external, providerPath);
+  assert.equal(resolveProviderCredentialReference("deepseek", ref()), undefined);
+  assert.deepEqual(credentialPaths(PROVIDERS.get("deepseek")).filter((candidate) => candidate === providerPath), [providerPath]);
 });

--- a/test/provider-credential-store.test.mjs
+++ b/test/provider-credential-store.test.mjs
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
   symlinkSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -35,6 +37,7 @@ const {
 } = await import("../src/provider-credential-store.mjs");
 const {
   credentialPaths,
+  resolveProviderCredential,
   resolveProviderCredentialReference,
   writeProviderCredential,
 } = await import("../src/provider-credentials.mjs");
@@ -192,6 +195,54 @@ test("migration rejects unknown legacy fields and confined paths", () => {
     () => addCredentialReference({ providerId: "deepseek", kind: "api_key", secretRef: ref() }, link),
     /symbolic link/,
   );
+});
+
+test("credential writes and resolution do not traverse symlinked paths", () => {
+  const outside = path.join(root, "outside-credential-state");
+  const linkedDirectory = path.join(root, "state", "linked-directory");
+  mkdirSync(outside, { recursive: true });
+  symlinkSync(outside, linkedDirectory, "dir");
+  assert.throws(
+    () => writeProviderCredentialStore(
+      { credentials: [] },
+      path.join(linkedDirectory, "store.json"),
+    ),
+    /symbolic link/,
+  );
+
+  const providerPath = writeProviderCredential("deepseek", "TEST_SYMLINK_RESOLUTION_SECRET");
+  const external = path.join(root, "outside-resolution-secret.txt");
+  writeFileSync(external, "TEST_SYMLINK_RESOLUTION_SECRET\n", { mode: 0o600 });
+  unlinkSync(providerPath);
+  symlinkSync(external, providerPath);
+  assert.equal(resolveProviderCredential("deepseek"), undefined);
+});
+
+test("failed migration restores the exact original bytes", () => {
+  const filePath = path.join(root, "state", "transactional-legacy.json");
+  const migrationDirectory = path.join(root, "state", "transactional-migration");
+  const legacyBytes = Buffer.from(JSON.stringify({
+    version: 1,
+    credentials: [{
+      id: "cred_transactional_123456",
+      providerId: "deepseek",
+      kind: "api_key",
+      secretRef: { type: "provider-file" },
+      state: "active",
+    }],
+  }) + "\n", "utf8");
+  writeFileSync(filePath, legacyBytes, { mode: 0o600 });
+  const latestPath = path.join(migrationDirectory, "latest.json");
+  mkdirSync(migrationDirectory, { recursive: true, mode: 0o700 });
+  const outside = path.join(root, "latest-target.json");
+  writeFileSync(outside, "do not touch\n", { mode: 0o600 });
+  symlinkSync(outside, latestPath);
+  assert.throws(
+    () => migrateProviderCredentialStore(filePath, { migrationDirectory }),
+    /symbolic link/,
+  );
+  assert.deepEqual(readFileSync(filePath), legacyBytes);
+  assert.equal(readFileSync(outside, "utf8"), "do not touch\n");
 });
 
 test("credential references are target- and provider-bound at resolution time", () => {

--- a/test/provider-credential-store.test.mjs
+++ b/test/provider-credential-store.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync, spawn } from "node:child_process";
 import {
   existsSync,
   mkdirSync,
@@ -13,6 +14,10 @@ import {
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
+
+const atomicStateLockModule = new URL("../src/atomic-state-lock.mjs", import.meta.url).href;
+const credentialStoreModule = new URL("../src/provider-credential-store.mjs", import.meta.url).href;
+const providerCredentialsModule = new URL("../src/provider-credentials.mjs", import.meta.url).href;
 
 const root = mkdtempSync(path.join(os.tmpdir(), "codex-router-credential-store-"));
 process.env.CODEX_HOME = path.join(root, "codex");
@@ -48,6 +53,47 @@ test.after(() => rmSync(root, { recursive: true, force: true }));
 
 function ref(providerId = "deepseek") {
   return { type: "provider-file", providerId, target: "codex" };
+}
+
+async function holdStateLock(filePath, milliseconds = 350) {
+  const script = `
+    import { withAtomicStateLock } from ${JSON.stringify(atomicStateLockModule)};
+    withAtomicStateLock(process.argv[1], () => {
+      process.stdout.write("locked\\n");
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Number(process.argv[2]));
+    });
+  `;
+  const child = spawn(process.execPath, [
+    "--input-type=module",
+    "--eval",
+    script,
+    filePath,
+    String(milliseconds),
+  ], {
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  let errors = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => { errors += chunk; });
+  const exited = new Promise((resolve) => {
+    child.once("exit", (code, signal) => resolve({ code, signal }));
+  });
+  await new Promise((resolve, reject) => {
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      output += chunk;
+      if (output.includes("locked\n")) resolve();
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (!output.includes("locked\n")) {
+        reject(new Error(`Lock holder exited before acquiring the lock (${code ?? signal}): ${errors}`));
+      }
+    });
+  });
+  return { exited, errors: () => errors };
 }
 
 test("credential references contain no secret and use protected metadata storage", () => {
@@ -245,7 +291,7 @@ test("failed migration restores the exact original bytes", () => {
   assert.equal(readFileSync(outside, "utf8"), "do not touch\n");
 });
 
-test("credential references are target- and provider-bound at resolution time", () => {
+test("credential references are router-plane- and provider-bound at resolution time", () => {
   const providerPath = writeProviderCredential("deepseek", "TEST_BOUND_SECRET");
   const configured = resolveProviderCredentialReference("deepseek", ref());
   assert.equal(configured?.value, "TEST_BOUND_SECRET");
@@ -271,4 +317,76 @@ test("credential references are target- and provider-bound at resolution time", 
   symlinkSync(external, providerPath);
   assert.equal(resolveProviderCredentialReference("deepseek", ref()), undefined);
   assert.deepEqual(credentialPaths(PROVIDERS.get("deepseek")).filter((candidate) => candidate === providerPath), [providerPath]);
+});
+
+test("credential references written by every client resolve through the shared router plane", () => {
+  writeProviderCredential("deepseek", "TEST_SHARED_PLANE_SECRET");
+  const storePath = path.join(root, "state", "cross-target-references.json");
+  const script = `
+    const { addCredentialReference } = await import(${JSON.stringify(credentialStoreModule)});
+    const { resolveProviderCredentialReference } = await import(${JSON.stringify(providerCredentialsModule)});
+    const client = process.env.MODEL_ROUTER_TARGET;
+    const entry = addCredentialReference({
+      id: \`cred_cross_target_\${client}_123456\`,
+      providerId: "deepseek",
+      kind: "api_key",
+      secretRef: { type: "provider-file", providerId: "deepseek" },
+    });
+    const credential = resolveProviderCredentialReference("deepseek", entry.secretRef);
+    process.stdout.write(JSON.stringify({
+      client,
+      referenceTarget: entry.secretRef.target,
+      resolved: credential?.value === "TEST_SHARED_PLANE_SECRET",
+    }));
+  `;
+  for (const client of ["codex", "dsh", "gemini"]) {
+    const result = JSON.parse(execFileSync(process.execPath, [
+      "--input-type=module",
+      "--eval",
+      script,
+    ], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        MODEL_ROUTER_TARGET: client,
+        MODEL_ROUTER_PROVIDER_CREDENTIAL_STORE: storePath,
+      },
+    }));
+    assert.deepEqual(result, {
+      client,
+      referenceTarget: "codex",
+      resolved: true,
+    });
+  }
+  const stored = JSON.parse(readFileSync(storePath, "utf8"));
+  assert.equal(stored.credentials.length, 3);
+  assert.deepEqual(new Set(stored.credentials.map((entry) => entry.secretRef.target)), new Set(["codex"]));
+});
+
+test("credential reference add and remove wait for concurrent state transactions", async () => {
+  const filePath = path.join(root, "state", "concurrent-references.json");
+  const id = "cred_concurrent_write_123456";
+  const input = {
+    id,
+    providerId: "deepseek",
+    kind: "api_key",
+    secretRef: ref(),
+  };
+
+  const addHolder = await holdStateLock(filePath);
+  const addStarted = Date.now();
+  addCredentialReference(input, filePath);
+  const addElapsed = Date.now() - addStarted;
+  const addExit = await addHolder.exited;
+  assert.equal(addExit.code, 0, addHolder.errors());
+  assert.ok(addElapsed >= 200, `add bypassed the state lock (${addElapsed}ms)`);
+
+  const removeHolder = await holdStateLock(filePath);
+  const removeStarted = Date.now();
+  assert.equal(removeCredentialReference(id, filePath), true);
+  const removeElapsed = Date.now() - removeStarted;
+  const removeExit = await removeHolder.exited;
+  assert.equal(removeExit.code, 0, removeHolder.errors());
+  assert.ok(removeElapsed >= 200, `remove bypassed the state lock (${removeElapsed}ms)`);
+  assert.deepEqual(readProviderCredentialStore(filePath).credentials, []);
 });


### PR DESCRIPTION
## Summary

Adds provider-neutral credential references with strict metadata validation, target binding, confined protected storage, redacted support output, and safe migration rollback. Existing provider files and Keychain entries remain the secret authority.

## Reason

Prevent provider credentials from being copied into router metadata, logs, support bundles, or arbitrary paths while keeping migration recoverable.

## Validation

- `npm run check`
- `node --test test/provider-credential-store.test.mjs test/provider-credentials.test.mjs test/support-bundle.test.mjs` (13 passed)
- `git diff --check`
- Broader provider/catalog suites require missing local dependencies (`undici`, `proper-lockfile`) in this checkout.

## Remaining risks

This is protected metadata and reference-based credential handling, not encrypted secret storage. Existing provider-specific files, environment variables, and Keychain remain responsible for secret protection. The PR does not claim encryption.

