### PR TITLE
feat: add safe provider API-key pools

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -30,7 +30,7 @@ import { stripImages, supportsImageInput } from "./vision-bridge.mjs";
 import {
   credentialLabel,
   credentialStatus,
-  resolveProviderCredential,
+  resolveProviderCredentialReference,
 } from "./provider-credentials.mjs";
 import {
   ensureFreshGitHubCopilotSession,
@@ -45,6 +45,12 @@ import { relayCommandCodeGenerate } from "./commandcode-relay.mjs";
 import { VERSION } from "./version.mjs";
 import { installStableFetchTransport } from "./fetch-transport.mjs";
 import { zaiCacheUsageTransform } from "./zai-cache-usage.mjs";
+import { threadIdFromHeaders } from "./codex-session-names.mjs";
+import {
+  recordProviderApiKeyRequestOutcome,
+  resolveProviderApiKeyForRequest,
+} from "./provider-api-key-routing.mjs";
+import { runProviderApiKeyAttempts } from "./provider-api-key-pool.mjs";
 
 installStableFetchTransport();
 
@@ -1003,10 +1009,17 @@ async function handleRequest(request, response) {
   const normalized = normalizeBody(original, request.headers["content-type"], route);
   // Resolved against the endpoint, not the provider: a per-model endpoint keeps
   // its credential under its own slug, so two custom models on two hosts never
-  // share a key and one missing key never blocks the other model.
-  const credential = resolveProviderCredential(normalized.endpoint);
+  // share a key and one missing key never blocks the other model. A configured
+  // pool is authoritative; the routing helper deliberately refuses to fall
+  // back to the legacy single key when the pool has no usable entry.
+  const poolRouting = await resolveProviderApiKeyForRequest(normalized.endpoint, {
+    sessionId: threadIdFromHeaders(request.headers),
+  });
+  const credential = poolRouting.credential;
   if (!credential) {
-    const setup = credentialStatus(normalized.endpoint).setup;
+    const setup = poolRouting.pooled
+      ? "Add a usable credential reference to the provider API-key pool."
+      : credentialStatus(normalized.endpoint).setup;
     const credentialType = credentialLabel(normalized.endpoint);
     const label = credentialType === "API key" ? "key" : credentialType.toLowerCase();
     // Name whichever of the two the operator would go and configure. For a
@@ -1017,9 +1030,11 @@ async function handleRequest(request, response) {
       : normalized.provider.displayName;
     writeJson(response, 503, {
       error: {
-        type: credentialType === "API key"
-          ? "provider_api_key_missing"
-          : "provider_credential_missing",
+        type: poolRouting.pooled
+          ? "provider_api_key_pool_unavailable"
+          : credentialType === "API key"
+            ? "provider_api_key_missing"
+            : "provider_credential_missing",
         provider: normalized.provider.id,
         message: `${subject} ${label} is not configured. ${setup}.`,
       },
@@ -1057,6 +1072,12 @@ async function handleRequest(request, response) {
     // headers, so it reports limits and cooldowns exactly as the documented
     // one does. Skipping this would leave the router blind to an exhausted
     // plan on the very accounts this route exists to serve.
+    await recordProviderApiKeyRequestOutcome(poolRouting, normalized.endpoint, {
+      status: outcome.status,
+      ok: outcome.ok,
+      committed: true,
+      error: outcome.ok ? undefined : `upstream status ${outcome.status}`,
+    });
     recordUpstreamLimits(normalized, outcome);
     if (!QUIET) {
       console.error(
@@ -1075,30 +1096,107 @@ async function handleRequest(request, response) {
   const upstreamBody = normalized.provider.authProfile === "github-copilot"
     ? normalized.body.toString("utf8")
     : normalized.body;
-  let session = await upstreamSession(
-    normalized.provider,
-    credential,
-    normalized.payload,
-    {},
-    normalized.endpoint,
-  );
-  let target = `${session.baseUrl}${route}${requestUrl.search}`;
-  let upstream = await fetch(target, {
-    method: request.method,
-    headers: upstreamHeaders(
-      request.headers,
-      upstreamBody,
-      session.apiKey,
+  let session;
+  let target;
+  let upstream;
+  if (poolRouting.pooled) {
+    const pooled = await runProviderApiKeyAttempts(normalized.endpoint.id, {
+      filePath: undefined,
+      resolveSecret: (reference) =>
+        // The first selection already resolved this reference. The resolver
+        // is repeated only for a pre-commit failover candidate and remains
+        // constrained by the provider's registry-declared sources.
+        resolveProviderCredentialReference(normalized.endpoint, reference),
+      initialSelection: poolRouting.selection,
+      sessionId: threadIdFromHeaders(request.headers),
+      isResponseCommitted: () => response.headersSent || response.writableEnded || response.writableFinished,
+      send: async ({ apiKey }) => {
+        const attemptCredential = { ...credential, value: apiKey };
+        const attemptSession = await upstreamSession(
+          normalized.provider,
+          attemptCredential,
+          normalized.payload,
+          {},
+          normalized.endpoint,
+        );
+        const attemptTarget = `${attemptSession.baseUrl}${route}${requestUrl.search}`;
+        const attemptResponse = await fetch(attemptTarget, {
+          method: request.method,
+          headers: upstreamHeaders(
+            request.headers,
+            upstreamBody,
+            attemptSession.apiKey,
+            normalized.provider,
+            attemptSession.headers,
+            normalized.endpoint,
+          ),
+          body: upstreamBody,
+          signal: controller.signal,
+        });
+        if (!attemptResponse.ok) {
+          const bodyText = await attemptResponse.text().catch(() => "");
+          return {
+            status: attemptResponse.status,
+            ok: false,
+            committed: false,
+            bodyText,
+            headers: attemptResponse.headers,
+            session: attemptSession,
+            target: attemptTarget,
+          };
+        }
+        return {
+          status: attemptResponse.status,
+          ok: true,
+          committed: false,
+          response: attemptResponse,
+          session: attemptSession,
+          target: attemptTarget,
+        };
+      },
+    });
+    const result = pooled.result;
+    if (!result || (result.response === undefined && result.bodyText === undefined)) {
+      writeJson(response, 503, {
+        error: {
+          type: "provider_api_key_pool_unavailable",
+          message: "The provider API-key pool could not complete this request before response bytes were committed.",
+        },
+      });
+      return;
+    }
+    session = result.session;
+    target = result.target;
+    upstream = result.response || new Response(result.bodyText || "", {
+      status: result.status,
+      headers: result.headers,
+    });
+  } else {
+    session = await upstreamSession(
       normalized.provider,
-      session.headers,
+      credential,
+      normalized.payload,
+      {},
       normalized.endpoint,
-    ),
-    body: upstreamBody,
-    signal: controller.signal,
-  });
+    );
+    target = `${session.baseUrl}${route}${requestUrl.search}`;
+    upstream = await fetch(target, {
+      method: request.method,
+      headers: upstreamHeaders(
+        request.headers,
+        upstreamBody,
+        session.apiKey,
+        normalized.provider,
+        session.headers,
+        normalized.endpoint,
+      ),
+      body: upstreamBody,
+      signal: controller.signal,
+    });
+  }
   // Account routing can change with plan or policy. Re-resolve and replay once
   // before any response byte reaches the caller; every other status is relayed.
-  if (normalized.provider.authProfile === "github-copilot" && upstream.status === 401) {
+  if (!poolRouting.pooled && normalized.provider.authProfile === "github-copilot" && upstream.status === 401) {
     await upstream.body?.cancel().catch(() => undefined);
     session = await upstreamSession(
       normalized.provider,

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -130,6 +130,9 @@ export const NATIVE_SESSION_CONSENT_PATH = path.join(
 // cache for the curation surfaces, never an authority: what is registered
 // locally is always recomputed from the live registry.
 export const PROVIDER_CATALOG_CACHE_PATH = path.join(STATE_DIR, "provider-catalog-cache.json");
+export const PROVIDER_API_KEY_POOL_PATH =
+  process.env.MODEL_ROUTER_API_KEY_POOL_PATH ||
+  path.join(STATE_DIR, "provider-api-key-pools.json");
 export const INSTALL_MANIFEST_PATH = path.join(STATE_DIR, "install-manifest.json");
 export const SKILL_OWNERSHIP_PATH = path.join(STATE_DIR, "managed-skills.json");
 export const MIGRATIONS_DIR = path.join(STATE_DIR, "migrations");

--- a/src/provider-api-key-pool.mjs
+++ b/src/provider-api-key-pool.mjs
@@ -1,0 +1,878 @@
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import lockfile from "proper-lockfile";
+
+import { writePrivateJson } from "./file-security.mjs";
+import { PROVIDER_API_KEY_POOL_PATH, STATE_DIR } from "./paths.mjs";
+
+export const PROVIDER_API_KEY_POOL_SCHEMA_VERSION = 1;
+export const PROVIDER_API_KEY_POOL_STRATEGIES = Object.freeze([
+  "quota",
+  "round-robin",
+  "fill-first",
+]);
+export const PROVIDER_API_KEY_POOL_PATH_DEFAULT = PROVIDER_API_KEY_POOL_PATH;
+
+const PROVIDER_ID = /^[a-z0-9][a-z0-9-]{0,99}$/;
+const CREDENTIAL_ID = /^cred_[A-Za-z0-9_-]{8,96}$/;
+const REFERENCE_ID = /^ref_[A-Za-z0-9_-]{8,128}$/;
+const SESSION_ID_LIMIT = 256;
+const MAX_PROVIDERS = 128;
+const MAX_CREDENTIALS = 256;
+const MAX_SESSIONS = 2_048;
+const MAX_ERROR_LENGTH = 512;
+const MAX_COOLDOWN_SECONDS = 24 * 60 * 60;
+const DEFAULT_LOCK_WAIT_MS = 120_000;
+const DEFAULT_LOCK_RETRY_MS = 25;
+const DEFAULT_LOCK_STALE_MS = 10 * 60_000;
+
+const TRANSIENT_STATUS = new Set([
+  401,
+  403,
+  408,
+  429,
+  500,
+  501,
+  502,
+  503,
+  504,
+  505,
+  506,
+  507,
+  508,
+  509,
+  510,
+  511,
+]);
+const TRANSIENT_ERROR_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+function record(value) {
+  return value && typeof value === "object" && !Array.isArray(value);
+}
+
+function text(value, field, { max = 256, required = false } = {}) {
+  if (typeof value !== "string") {
+    if (required) throw new Error(`${field} must be a string.`);
+    return undefined;
+  }
+  const normalized = value.trim();
+  if (!normalized && required) throw new Error(`${field} must not be empty.`);
+  if (normalized.length > max || /[\u0000-\u001f\u007f]/.test(normalized)) {
+    throw new Error(`${field} is invalid.`);
+  }
+  return normalized || undefined;
+}
+
+function providerId(value) {
+  const normalized = text(value, "provider id", { max: 100, required: true }).toLowerCase();
+  if (!PROVIDER_ID.test(normalized)) throw new Error(`Invalid provider id: ${normalized}`);
+  return normalized;
+}
+
+function credentialId(value) {
+  const normalized = text(value, "credential id", { max: 100, required: true });
+  if (!CREDENTIAL_ID.test(normalized)) throw new Error("Credential id is invalid.");
+  return normalized;
+}
+
+function sessionId(value) {
+  if (value === undefined || value === null || value === "") return undefined;
+  const normalized = text(value, "session id", { max: SESSION_ID_LIMIT, required: true });
+  return normalized;
+}
+
+function finiteNumber(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function integer(value, fallback, { min = 0, max = Number.MAX_SAFE_INTEGER } = {}) {
+  const parsed = finiteNumber(value);
+  return parsed === undefined ? fallback : Math.min(max, Math.max(min, Math.floor(parsed)));
+}
+
+function isoTimestamp(value) {
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? new Date(parsed).toISOString() : undefined;
+}
+
+function nowMs(value) {
+  return Number.isFinite(value) ? value : Date.now();
+}
+
+function isoNow(value) {
+  return new Date(nowMs(value)).toISOString();
+}
+
+function assertAllowedKeys(value, allowed, context) {
+  for (const key of Object.keys(value || {})) {
+    if (!allowed.has(key)) throw new Error(`${context} contains unsupported field ${key}.`);
+  }
+}
+
+export function normalizeProviderApiKeySecretRef(value) {
+  if (!record(value)) {
+    throw new Error("secretRef must be a reference object.");
+  }
+  assertAllowedKeys(value, new Set(["type", "id", "name", "service", "providerId"]), "secretRef");
+  const type = text(value.type, "secretRef.type", { max: 32, required: true });
+  if (!["opaque", "provider-file", "keychain", "environment"].includes(type)) {
+    throw new Error("secretRef.type is unsupported.");
+  }
+  if (type === "opaque") {
+    if (value.name !== undefined || value.service !== undefined || value.providerId !== undefined) {
+      throw new Error("Opaque secret references may only contain type and id.");
+    }
+    const id = text(value.id, "secretRef.id", { max: 140, required: true });
+    if (!REFERENCE_ID.test(id)) throw new Error("secretRef.id is invalid.");
+    return { type, id };
+  }
+  if (value.id !== undefined) throw new Error(`${type} secret references do not accept id.`);
+  const providerIdValue = value.providerId === undefined
+    ? undefined
+    : text(value.providerId, "secretRef.providerId", { max: 100, required: true });
+  if (type === "keychain") {
+    if (value.name !== undefined) throw new Error("Keychain references use service.");
+    const service = text(value.service, "secretRef.service", { max: 200, required: true });
+    return { type, service, ...(providerIdValue ? { providerId: providerIdValue } : {}) };
+  }
+  if (value.service !== undefined) throw new Error(`${type} references use name.`);
+  const name = text(value.name, "secretRef.name", { max: 200, required: true });
+  return { type, name, ...(providerIdValue ? { providerId: providerIdValue } : {}) };
+}
+
+export function providerApiKeySecretRefIdentity(value) {
+  const ref = normalizeProviderApiKeySecretRef(value);
+  const source = ref.id || ref.name || ref.service;
+  return `${ref.providerId || ""}:${ref.type}:${source}`;
+}
+
+function normalizeQuota(value) {
+  if (!record(value)) return undefined;
+  assertAllowedKeys(value, new Set(["limit", "remaining", "used", "resetAt", "observedAt"]), "quota");
+  const limit = finiteNumber(value.limit);
+  const remaining = finiteNumber(value.remaining);
+  if (limit === undefined || limit <= 0 || remaining === undefined) return undefined;
+  const result = {
+    limit,
+    remaining: Math.max(0, Math.min(limit, remaining)),
+  };
+  const used = finiteNumber(value.used);
+  const resetAt = isoTimestamp(value.resetAt);
+  const observedAt = isoTimestamp(value.observedAt);
+  if (used !== undefined && used >= 0) result.used = used;
+  if (resetAt) result.resetAt = resetAt;
+  if (observedAt) result.observedAt = observedAt;
+  return result;
+}
+
+function normalizeHealth(value, now = Date.now()) {
+  const source = record(value) ? value : {};
+  assertAllowedKeys(
+    source,
+    new Set(["state", "cooldownUntil", "lastSuccessAt", "lastErrorAt", "lastUsedAt", "lastStatus", "lastError", "failureCount"]),
+    "health",
+  );
+  const state = ["healthy", "cooldown", "failed"].includes(source.state)
+    ? source.state
+    : "healthy";
+  const result = { state };
+  for (const field of ["cooldownUntil", "lastSuccessAt", "lastErrorAt", "lastUsedAt"]) {
+    const timestamp = isoTimestamp(source[field]);
+    if (timestamp) result[field] = timestamp;
+  }
+  const status = integer(source.lastStatus, undefined, { min: 100, max: 999 });
+  if (status !== undefined) result.lastStatus = status;
+  const error = text(source.lastError, "health.lastError", { max: MAX_ERROR_LENGTH });
+  if (error) result.lastError = error;
+  const failures = integer(source.failureCount, 0, { max: 100_000 });
+  if (failures) result.failureCount = failures;
+  if (result.cooldownUntil && Date.parse(result.cooldownUntil) <= nowMs(now)) {
+    delete result.cooldownUntil;
+    if (result.state === "cooldown") result.state = "healthy";
+  }
+  return result;
+}
+
+function normalizeCredential(value, provider, now = Date.now()) {
+  if (!record(value)) throw new Error("Each pool credential must be an object.");
+  assertAllowedKeys(
+    value,
+    new Set(["id", "providerId", "secretRef", "state", "paused", "priority", "quota", "health", "requestCount", "tokenCount"]),
+    "pool credential",
+  );
+  const id = credentialId(value.id);
+  if (value.providerId !== undefined && providerId(value.providerId) !== provider) {
+    throw new Error(`Credential ${id} belongs to a different provider.`);
+  }
+  const secretRef = normalizeProviderApiKeySecretRef(value.secretRef);
+  const state = ["active", "paused", "revoked"].includes(value.state)
+    ? value.state
+    : "active";
+  const priority = integer(value.priority, 50, { max: 100_000 });
+  const requestCount = integer(value.requestCount, 0);
+  const tokenCount = integer(value.tokenCount, 0);
+  const result = {
+    id,
+    providerId: provider,
+    secretRef,
+    state,
+    paused: value.paused === true,
+    priority,
+    health: normalizeHealth(value.health, now),
+    requestCount,
+    tokenCount,
+  };
+  const quota = normalizeQuota(value.quota);
+  if (quota) result.quota = quota;
+  return result;
+}
+
+function normalizePolicy(value) {
+  const source = record(value) ? value : {};
+  assertAllowedKeys(
+    source,
+    new Set(["strategy", "autoSwitchThreshold", "sticky", "stickyLimit", "maxCooldownSeconds", "priorityOrder", "pausedCredentialIds"]),
+    "pool policy",
+  );
+  const strategy = PROVIDER_API_KEY_POOL_STRATEGIES.includes(source.strategy)
+    ? source.strategy
+    : "quota";
+  const threshold = finiteNumber(source.autoSwitchThreshold);
+  const priorityOrder = Array.isArray(source.priorityOrder)
+    ? [...new Set(source.priorityOrder.map((id) => text(id, "priority credential id", { max: 100 })).filter((id) => id && CREDENTIAL_ID.test(id)))].slice(0, MAX_CREDENTIALS)
+    : [];
+  const pausedCredentialIds = Array.isArray(source.pausedCredentialIds)
+    ? [...new Set(source.pausedCredentialIds.map((id) => text(id, "paused credential id", { max: 100 })).filter((id) => id && CREDENTIAL_ID.test(id)))].slice(0, MAX_CREDENTIALS)
+    : [];
+  return {
+    strategy,
+    autoSwitchThreshold: threshold === undefined ? 0.1 : Math.min(1, Math.max(0, threshold)),
+    sticky: source.sticky !== false,
+    stickyLimit: integer(source.stickyLimit, 50, { min: 1, max: MAX_SESSIONS }),
+    maxCooldownSeconds: integer(source.maxCooldownSeconds, 300, { max: MAX_COOLDOWN_SECONDS }),
+    priorityOrder,
+    pausedCredentialIds,
+  };
+}
+
+function normalizeSession(value, now = Date.now()) {
+  if (!record(value)) throw new Error("Each pool session must be an object.");
+  assertAllowedKeys(value, new Set(["credentialId", "turns", "requests", "boundAt", "updatedAt", "reboundAt", "lastReason"]), "pool session");
+  const credential = credentialId(value.credentialId);
+  const result = {
+    credentialId: credential,
+    turns: integer(value.turns, 0),
+    requests: integer(value.requests, 0),
+    boundAt: isoTimestamp(value.boundAt) || isoNow(now),
+    updatedAt: isoTimestamp(value.updatedAt) || isoNow(now),
+  };
+  const reboundAt = isoTimestamp(value.reboundAt);
+  const reason = text(value.lastReason, "session.lastReason", { max: 120 });
+  if (reboundAt) result.reboundAt = reboundAt;
+  if (reason) result.lastReason = reason;
+  return result;
+}
+
+function normalizePool(value, provider, now = Date.now()) {
+  if (value !== undefined && !record(value)) throw new Error(`Provider ${provider} pool must be an object.`);
+  const source = value || {};
+  assertAllowedKeys(source, new Set(["providerId", "policy", "roundRobinCursor", "credentials", "sessions"]), `${provider} pool`);
+  if (source.providerId !== undefined && providerId(source.providerId) !== provider) {
+    throw new Error(`Provider pool identity does not match ${provider}.`);
+  }
+  const result = {
+    providerId: provider,
+    policy: normalizePolicy(source.policy),
+    roundRobinCursor: integer(source.roundRobinCursor, 0),
+    credentials: {},
+    sessions: {},
+  };
+  const credentials = source.credentials === undefined
+    ? []
+    : record(source.credentials)
+      ? Object.entries(source.credentials)
+      : (() => { throw new Error(`${provider} credentials must be an object.`); })();
+  const refs = new Set();
+  for (const [id, raw] of credentials.slice(0, MAX_CREDENTIALS)) {
+    const normalized = normalizeCredential({ ...(record(raw) ? raw : {}), id }, provider, now);
+    const refIdentity = providerApiKeySecretRefIdentity(normalized.secretRef);
+    if (refs.has(refIdentity)) throw new Error(`Provider ${provider} contains duplicate secret references.`);
+    refs.add(refIdentity);
+    result.credentials[normalized.id] = normalized;
+  }
+  const sessions = source.sessions === undefined
+    ? []
+    : record(source.sessions)
+      ? Object.entries(source.sessions)
+      : (() => { throw new Error(`${provider} sessions must be an object.`); })();
+  for (const [id, raw] of sessions.slice(0, MAX_SESSIONS)) {
+    const normalizedId = sessionId(id);
+    if (!normalizedId) continue;
+    const normalized = normalizeSession(raw, now);
+    if (!result.credentials[normalized.credentialId]) continue;
+    result.sessions[normalizedId] = normalized;
+  }
+  return result;
+}
+
+function normalizeState(value, now = Date.now()) {
+  if (!record(value) || value.version !== PROVIDER_API_KEY_POOL_SCHEMA_VERSION) {
+    throw new Error("Unsupported provider API-key pool state.");
+  }
+  assertAllowedKeys(value, new Set(["version", "providers"]), "provider API-key pool state");
+  if (!record(value.providers)) throw new Error("Provider API-key pool providers must be an object.");
+  const result = { version: PROVIDER_API_KEY_POOL_SCHEMA_VERSION, providers: {} };
+  for (const [rawProvider, rawPool] of Object.entries(value.providers).slice(0, MAX_PROVIDERS)) {
+    const provider = providerId(rawProvider);
+    if (result.providers[provider]) throw new Error(`Duplicate provider pool: ${provider}`);
+    result.providers[provider] = normalizePool(rawPool, provider, now);
+  }
+  return result;
+}
+
+function emptyState() {
+  return { version: PROVIDER_API_KEY_POOL_SCHEMA_VERSION, providers: {} };
+}
+
+export function readProviderApiKeyPoolState(filePath = PROVIDER_API_KEY_POOL_PATH_DEFAULT, { now = Date.now() } = {}) {
+  if (!existsSync(filePath)) return { ...emptyState(), valid: true };
+  try {
+    return { ...normalizeState(JSON.parse(readFileSync(filePath, "utf8")), now), valid: true };
+  } catch {
+    return { ...emptyState(), valid: false };
+  }
+}
+
+function stateForWrite(state, now = Date.now()) {
+  return normalizeState({ version: PROVIDER_API_KEY_POOL_SCHEMA_VERSION, providers: state?.providers || {} }, now);
+}
+
+function poolStatus(providerOrId, filePath, now = Date.now()) {
+  const provider = providerId(providerOrId);
+  const state = readProviderApiKeyPoolState(filePath, { now });
+  const configured = !state.valid || Object.prototype.hasOwnProperty.call(state.providers, provider);
+  return {
+    providerId: provider,
+    configured,
+    valid: state.valid,
+    pool: state.providers[provider],
+  };
+}
+
+export function providerApiKeyPoolStatus(providerOrId, { filePath = PROVIDER_API_KEY_POOL_PATH_DEFAULT, now = Date.now() } = {}) {
+  return poolStatus(providerOrId, filePath, now);
+}
+
+export function sanitizeProviderApiKeyPoolCredential(value) {
+  if (!value) return null;
+  return {
+    id: value.id,
+    providerId: value.providerId,
+    secretRef: { ...value.secretRef },
+    state: value.state,
+    paused: value.paused === true,
+    priority: value.priority,
+    ...(value.quota ? { quota: { ...value.quota } } : {}),
+    health: { ...value.health },
+    requestCount: value.requestCount,
+    tokenCount: value.tokenCount,
+  };
+}
+
+export function sanitizeProviderApiKeyPool(providerOrId, value) {
+  const provider = providerId(providerOrId);
+  const pool = normalizePool(value, provider);
+  return {
+    providerId: provider,
+    policy: { ...pool.policy },
+    roundRobinCursor: pool.roundRobinCursor,
+    credentials: Object.values(pool.credentials).map(sanitizeProviderApiKeyPoolCredential),
+    sessions: Object.fromEntries(Object.entries(pool.sessions).map(([id, session]) => [id, { ...session }])),
+  };
+}
+
+export function getProviderApiKeyPool(providerOrId, { filePath = PROVIDER_API_KEY_POOL_PATH_DEFAULT, now = Date.now() } = {}) {
+  const status = poolStatus(providerOrId, filePath, now);
+  if (!status.valid) return { providerId: status.providerId, valid: false, configured: true, credentials: [], sessions: {} };
+  return {
+    ...sanitizeProviderApiKeyPool(status.providerId, status.pool || { }),
+    configured: status.configured,
+    valid: true,
+  };
+}
+
+function quotaRatio(meta) {
+  if (!meta?.quota || !(meta.quota.limit > 0) || !Number.isFinite(meta.quota.remaining)) return undefined;
+  return Math.max(0, Math.min(1, meta.quota.remaining / meta.quota.limit));
+}
+
+function cooldownActive(meta, at) {
+  const until = Date.parse(meta?.health?.cooldownUntil || "");
+  return Number.isFinite(until) && until > at;
+}
+
+function eligibleMeta(pool, at, exclude = new Set()) {
+  return Object.values(pool.credentials).filter((meta) => {
+    if (exclude.has(meta.id) || meta.state !== "active" || meta.paused) return false;
+    if (pool.policy.pausedCredentialIds.includes(meta.id)) return false;
+    if (cooldownActive(meta, at) || meta.health.state === "failed") return false;
+    const ratio = quotaRatio(meta);
+    const reset = Date.parse(meta.quota?.resetAt || "");
+    return !(ratio !== undefined && ratio <= 0 && (!Number.isFinite(reset) || reset > at));
+  });
+}
+
+function orderMeta(pool, candidates) {
+  const rank = (id) => {
+    const index = pool.policy.priorityOrder.indexOf(id);
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+  };
+  return [...candidates].sort((left, right) => {
+    const rankDiff = rank(left.id) - rank(right.id);
+    if (rankDiff) return rankDiff;
+    const priorityDiff = right.priority - left.priority;
+    return priorityDiff || left.id.localeCompare(right.id);
+  });
+}
+
+function chooseMeta(pool, candidates) {
+  const ordered = orderMeta(pool, candidates);
+  if (!ordered.length) return undefined;
+  if (pool.policy.strategy === "round-robin") {
+    return ordered[pool.roundRobinCursor % ordered.length];
+  }
+  const aboveThreshold = ordered.filter((candidate) => {
+    const ratio = quotaRatio(candidate);
+    return ratio === undefined || ratio > pool.policy.autoSwitchThreshold;
+  });
+  const eligible = aboveThreshold.length ? aboveThreshold : ordered;
+  if (pool.policy.strategy === "fill-first") return eligible[0];
+  return [...eligible].sort((left, right) => {
+    const leftRatio = quotaRatio(left);
+    const rightRatio = quotaRatio(right);
+    if (leftRatio !== undefined && rightRatio === undefined) return -1;
+    if (leftRatio === undefined && rightRatio !== undefined) return 1;
+    if (leftRatio !== undefined && rightRatio !== undefined && leftRatio !== rightRatio) {
+      return rightRatio - leftRatio;
+    }
+    return orderMeta(pool, [left, right]).indexOf(left) - orderMeta(pool, [left, right]).indexOf(right);
+  })[0];
+}
+
+function resolveValue(result) {
+  if (typeof result === "string") return result.trim() || undefined;
+  if (record(result) && typeof result.value === "string") return result.value.trim() || undefined;
+  return undefined;
+}
+
+function duplicateResolvedSecrets(entries) {
+  const seen = new Map();
+  for (const entry of entries) {
+    const digest = createHash("sha256").update(entry.value).digest("hex");
+    const previous = seen.get(digest);
+    if (previous && previous !== entry.meta.id) return true;
+    seen.set(digest, entry.meta.id);
+  }
+  return false;
+}
+
+async function resolvedCandidates(pool, { resolveSecret, now, exclude }) {
+  if (typeof resolveSecret !== "function") return { entries: [], reason: "secret_resolver_required" };
+  const entries = [];
+  for (const meta of eligibleMeta(pool, now, exclude)) {
+    let resolved;
+    try {
+      resolved = await resolveSecret({ ...meta.secretRef });
+    } catch {
+      resolved = undefined;
+    }
+    const value = resolveValue(resolved);
+    if (value) entries.push({ meta, value });
+  }
+  if (duplicateResolvedSecrets(entries)) return { entries: [], reason: "duplicate_secret_reference" };
+  return { entries };
+}
+
+function sessionCanStay(pool, session, meta, at) {
+  if (!pool.policy.sticky || !session || !meta) return false;
+  if (session.turns >= pool.policy.stickyLimit) return false;
+  return !cooldownActive(meta, at) && meta.state === "active" && !meta.paused;
+}
+
+function selectedResult(provider, pool, selected, value, session, rebound = false) {
+  return {
+    configured: true,
+    valid: true,
+    providerId: provider,
+    credentialId: selected?.id || null,
+    credentialRef: selected ? { ...selected.secretRef } : undefined,
+    credentialValue: value,
+    reason: selected ? (rebound ? "rebound" : session ? "sticky" : "selected") : "no_eligible_credentials",
+    strategy: pool.policy.strategy,
+    ...(session ? { session: { ...session } } : {}),
+  };
+}
+
+async function selectFromState(providerOrId, options = {}) {
+  const provider = providerId(providerOrId);
+  const filePath = options.filePath || PROVIDER_API_KEY_POOL_PATH_DEFAULT;
+  const at = nowMs(options.now);
+  const state = options.state || readProviderApiKeyPoolState(filePath, { now: at });
+  if (!state.valid) {
+    return { configured: true, valid: false, providerId: provider, credentialId: null, reason: "invalid_pool_state", fallbackAllowed: false };
+  }
+  const pool = state.providers[provider];
+  if (!pool) {
+    return { configured: false, valid: true, providerId: provider, credentialId: null, reason: "pool_not_configured", fallbackAllowed: true };
+  }
+  const excluded = new Set((options.excludeCredentialIds || []).map((id) => credentialId(id)));
+  const resolved = await resolvedCandidates(pool, {
+    resolveSecret: options.resolveSecret,
+    now: at,
+    exclude: excluded,
+  });
+  if (!resolved.entries.length) {
+    return selectedResult(provider, pool, undefined, undefined, undefined);
+  }
+  const session = sessionId(options.sessionId);
+  const bound = session ? pool.sessions[session] : undefined;
+  const boundEntry = bound
+    ? resolved.entries.find((entry) => entry.meta.id === bound.credentialId)
+    : undefined;
+  let selectedEntry = boundEntry && sessionCanStay(pool, bound, boundEntry.meta, at)
+    ? boundEntry
+    : undefined;
+  let rebound = false;
+  if (!selectedEntry) {
+    selectedEntry = { meta: chooseMeta(pool, resolved.entries.map((entry) => entry.meta)) };
+    selectedEntry.value = resolved.entries.find((entry) => entry.meta.id === selectedEntry.meta.id)?.value;
+    rebound = Boolean(bound && selectedEntry.meta && selectedEntry.meta.id !== bound.credentialId);
+  }
+  if (!selectedEntry?.meta || !selectedEntry.value) return selectedResult(provider, pool, undefined, undefined, undefined);
+  if (options.commit !== false) {
+    selectedEntry.meta.health.lastUsedAt = isoNow(at);
+    if (pool.policy.strategy === "round-robin" && !boundEntry) {
+      pool.roundRobinCursor = (pool.roundRobinCursor + 1) % Math.max(1, resolved.entries.length);
+    }
+    if (session) {
+      const previous = pool.sessions[session];
+      pool.sessions[session] = {
+        credentialId: selectedEntry.meta.id,
+        turns: rebound ? 1 : (previous?.turns || 0) + 1,
+        requests: rebound ? 1 : (previous?.requests || 0) + 1,
+        boundAt: rebound && previous ? previous.boundAt : previous?.boundAt || isoNow(at),
+        updatedAt: isoNow(at),
+        ...(rebound && previous ? { reboundAt: isoNow(at) } : {}),
+        ...(rebound ? { lastReason: options.rebindReason || "credential_unavailable" } : {}),
+      };
+    }
+  }
+  return selectedResult(provider, pool, selectedEntry.meta, selectedEntry.value, session ? pool.sessions[session] : undefined, rebound);
+}
+
+function lockTarget(filePath) {
+  return `${filePath}.pool-lock-target`;
+}
+
+function lockError(waitMs, cause) {
+  const error = new Error(`Provider API-key pool is locked; retry after ${Math.max(1, Math.ceil(waitMs / 1_000))}s.`, { cause });
+  error.code = "provider_api_key_pool_locked";
+  return error;
+}
+
+export async function withProviderApiKeyPoolLock(operation, {
+  filePath = PROVIDER_API_KEY_POOL_PATH_DEFAULT,
+  waitMs = DEFAULT_LOCK_WAIT_MS,
+  retryMs = DEFAULT_LOCK_RETRY_MS,
+  staleMs = DEFAULT_LOCK_STALE_MS,
+} = {}) {
+  const directory = path.dirname(filePath);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const normalizedWait = Math.max(0, Math.floor(Number(waitMs) || 0));
+  const normalizedRetry = Math.max(1, Math.floor(Number(retryMs) || DEFAULT_LOCK_RETRY_MS));
+  const retries = Math.max(0, Math.ceil(normalizedWait / normalizedRetry) - 1);
+  let release;
+  try {
+    release = await lockfile.lock(lockTarget(filePath), {
+      realpath: false,
+      lockfilePath: `${filePath}.pool-lock`,
+      stale: Math.max(2_000, Math.floor(Number(staleMs) || DEFAULT_LOCK_STALE_MS)),
+      retries: {
+        retries,
+        factor: 1,
+        minTimeout: normalizedRetry,
+        maxTimeout: normalizedRetry,
+        randomize: false,
+      },
+    });
+  } catch (error) {
+    if (error?.code === "ELOCKED") throw lockError(normalizedWait, error);
+    throw error;
+  }
+  try {
+    return await operation();
+  } finally {
+    await release();
+  }
+}
+
+async function mutatePool(filePath, operation) {
+  return withProviderApiKeyPoolLock(async () => {
+    const state = readProviderApiKeyPoolState(filePath);
+    if (!state.valid) throw new Error("Provider API-key pool state is invalid; refusing to overwrite it.");
+    const next = { version: PROVIDER_API_KEY_POOL_SCHEMA_VERSION, providers: state.providers };
+    const result = await operation(next);
+    writePrivateJson(filePath, stateForWrite(next), { directoryMode: 0o700 });
+    return result;
+  }, { filePath });
+}
+
+export function selectProviderApiKey(providerOrId, options = {}) {
+  return selectFromState(providerOrId, { ...options, commit: false });
+}
+
+export async function selectProviderApiKeyLocked(providerOrId, options = {}) {
+  const filePath = options.filePath || PROVIDER_API_KEY_POOL_PATH_DEFAULT;
+  return withProviderApiKeyPoolLock(
+    () => mutateSelect(providerOrId, { ...options, filePath }),
+    { filePath, waitMs: options.waitMs, retryMs: options.retryMs, staleMs: options.staleMs },
+  );
+}
+
+async function mutateSelect(providerOrId, options) {
+  const filePath = options.filePath || PROVIDER_API_KEY_POOL_PATH_DEFAULT;
+  const state = readProviderApiKeyPoolState(filePath, { now: nowMs(options.now) });
+  if (!state.valid) return { configured: true, valid: false, providerId: providerId(providerOrId), credentialId: null, reason: "invalid_pool_state", fallbackAllowed: false };
+  const result = await selectFromState(providerOrId, { ...options, state, filePath, commit: true });
+  if (state.providers[result.providerId]) {
+    writePrivateJson(filePath, stateForWrite(state, nowMs(options.now)), { directoryMode: 0o700 });
+  }
+  return result;
+}
+
+export async function upsertProviderApiKey(providerOrId, credential, {
+  filePath = PROVIDER_API_KEY_POOL_PATH_DEFAULT,
+} = {}) {
+  const provider = providerId(providerOrId);
+  const normalized = normalizeCredential({ ...credential, providerId: provider }, provider);
+  return mutatePool(filePath, async (state) => {
+    const pool = state.providers[provider] || {
+      providerId: provider,
+      policy: normalizePolicy(),
+      roundRobinCursor: 0,
+      credentials: {},
+      sessions: {},
+    };
+    for (const current of Object.values(pool.credentials)) {
+      if (current.id !== normalized.id && providerApiKeySecretRefIdentity(current.secretRef) === providerApiKeySecretRefIdentity(normalized.secretRef)) {
+        throw new Error(`Provider ${provider} already contains this secret reference.`);
+      }
+    }
+    pool.credentials[normalized.id] = normalized;
+    state.providers[provider] = pool;
+    return sanitizeProviderApiKeyPoolCredential(normalized);
+  });
+}
+
+export async function setProviderApiKeyPoolPolicy(providerOrId, patch, {
+  filePath = PROVIDER_API_KEY_POOL_PATH_DEFAULT,
+} = {}) {
+  const provider = providerId(providerOrId);
+  return mutatePool(filePath, async (state) => {
+    const pool = state.providers[provider];
+    if (!pool) throw new Error(`Provider ${provider} API-key pool is not configured.`);
+    pool.policy = normalizePolicy({ ...pool.policy, ...(patch || {}) });
+    return { ...pool.policy };
+  });
+}
+
+export async function setProviderApiKeyPaused(providerOrId, credentialOrId, paused, {
+  filePath = PROVIDER_API_KEY_POOL_PATH_DEFAULT,
+} = {}) {
+  const provider = providerId(providerOrId);
+  const id = credentialId(credentialOrId);
+  if (typeof paused !== "boolean") throw new Error("paused must be a boolean.");
+  return mutatePool(filePath, async (state) => {
+    const pool = state.providers[provider];
+    if (!pool?.credentials[id]) throw new Error(`Credential ${id} is not configured for ${provider}.`);
+    pool.credentials[id].paused = paused;
+    pool.credentials[id].state = paused ? "paused" : "active";
+    pool.policy.pausedCredentialIds = paused
+      ? [...new Set([...pool.policy.pausedCredentialIds, id])]
+      : pool.policy.pausedCredentialIds.filter((entry) => entry !== id);
+    return sanitizeProviderApiKeyPoolCredential(pool.credentials[id]);
+  });
+}
+
+export function isRetryableProviderApiKeyFailure({ status, errorCode, committed = false } = {}) {
+  if (committed) return false;
+  const normalizedStatus = Number(status);
+  if (Number.isInteger(normalizedStatus)) return TRANSIENT_STATUS.has(normalizedStatus);
+  return TRANSIENT_ERROR_CODES.has(String(errorCode || ""));
+}
+
+function cooldownSeconds(pool, { status, retryAfterSeconds } = {}) {
+  const max = pool.policy.maxCooldownSeconds;
+  const retryAfter = finiteNumber(retryAfterSeconds);
+  if (retryAfter !== undefined && retryAfter > 0) return Math.min(max, retryAfter);
+  if (status === 429) return Math.min(max, 60);
+  if (status >= 500) return Math.min(max, 30);
+  if (status === 401 || status === 403) return max;
+  return 0;
+}
+
+export async function recordProviderApiKeyOutcome(providerOrId, credentialOrId, outcome = {}, {
+  filePath = PROVIDER_API_KEY_POOL_PATH_DEFAULT,
+} = {}) {
+  const provider = providerId(providerOrId);
+  const id = credentialId(credentialOrId);
+  const at = nowMs(outcome.now);
+  return mutatePool(filePath, async (state) => {
+    const pool = state.providers[provider];
+    const meta = pool?.credentials[id];
+    if (!meta) return { recorded: false, rebindRecommended: false };
+    const status = Number.isInteger(Number(outcome.status)) ? Number(outcome.status) : undefined;
+    const committed = outcome.committed === true;
+    const ok = outcome.ok === true || (status !== undefined && status >= 200 && status < 400);
+    meta.health.lastStatus = status;
+    meta.health.lastUsedAt = isoNow(at);
+    meta.requestCount += 1;
+    if (Number.isFinite(outcome.tokens) && outcome.tokens >= 0) meta.tokenCount += Math.floor(outcome.tokens);
+    if (ok) {
+      meta.health.state = "healthy";
+      meta.health.lastSuccessAt = isoNow(at);
+      delete meta.health.cooldownUntil;
+      delete meta.health.lastError;
+      meta.health.failureCount = 0;
+    } else {
+      const retryable = isRetryableProviderApiKeyFailure({
+        status,
+        errorCode: outcome.errorCode,
+        committed,
+      });
+      const seconds = retryable ? cooldownSeconds(pool, { status, retryAfterSeconds: outcome.retryAfterSeconds }) : 0;
+      meta.health.lastErrorAt = isoNow(at);
+      const error = text(outcome.error || outcome.message, "outcome error", { max: MAX_ERROR_LENGTH });
+      if (error) meta.health.lastError = error;
+      meta.health.failureCount = integer(meta.health.failureCount, 0) + 1;
+      if (retryable && seconds > 0) {
+        meta.health.state = "cooldown";
+        meta.health.cooldownUntil = new Date(at + seconds * 1_000).toISOString();
+      }
+      return {
+        recorded: true,
+        rebindRecommended: retryable && !committed,
+        committed,
+        credential: sanitizeProviderApiKeyPoolCredential(meta),
+      };
+    }
+    return {
+      recorded: true,
+      rebindRecommended: false,
+      committed,
+      credential: sanitizeProviderApiKeyPoolCredential(meta),
+    };
+  });
+}
+
+export async function runProviderApiKeyAttempts(providerOrId, {
+  resolveSecret,
+  send,
+  sessionId: sessionValue,
+  initialSelection,
+  filePath = PROVIDER_API_KEY_POOL_PATH_DEFAULT,
+  maxAttempts = MAX_CREDENTIALS,
+  isResponseCommitted,
+  now = Date.now,
+} = {}) {
+  const provider = providerId(providerOrId);
+  if (typeof send !== "function") throw new Error("send must be a function.");
+  const status = poolStatus(provider, filePath, now());
+  if (!status.configured) return { configured: false, fallbackAllowed: true, providerId: provider };
+  if (!status.valid) return { configured: true, valid: false, fallbackAllowed: false, providerId: provider, reason: "invalid_pool_state" };
+  const attempted = new Set();
+  const attempts = [];
+  for (let index = 0; index < Math.min(MAX_CREDENTIALS, Math.max(1, Math.floor(maxAttempts))); index += 1) {
+    if (typeof isResponseCommitted === "function" && isResponseCommitted()) {
+      return { configured: true, valid: true, providerId: provider, attempts, committed: true, reason: "response_committed" };
+    }
+    const selection = initialSelection && index === 0
+      ? initialSelection
+      : await selectProviderApiKeyLocked(provider, {
+          filePath,
+          resolveSecret,
+          sessionId: sessionValue,
+          excludeCredentialIds: [...attempted],
+          now: now(),
+          rebindReason: "previous_credential_failed_before_response",
+        });
+    if (!selection.credentialId || !selection.credentialValue) {
+      return { configured: true, valid: true, providerId: provider, attempts, reason: selection.reason };
+    }
+    attempted.add(selection.credentialId);
+    let result;
+    let error;
+    try {
+      result = await send({
+        apiKey: selection.credentialValue,
+        credentialId: selection.credentialId,
+        secretRef: { ...selection.credentialRef },
+        attempt: index,
+      });
+    } catch (caught) {
+      error = caught;
+    }
+    const responseCommitted = typeof isResponseCommitted === "function"
+      ? isResponseCommitted()
+      : typeof result?.committed === "boolean"
+        ? result.committed
+        : true;
+    const statusCode = Number.isInteger(Number(result?.status)) ? Number(result.status) : undefined;
+    const ok = !error && (result?.ok === true || (statusCode !== undefined && statusCode >= 200 && statusCode < 400));
+    const errorCode = error?.code || result?.errorCode;
+    const outcome = await recordProviderApiKeyOutcome(provider, selection.credentialId, {
+      status: statusCode,
+      ok,
+      committed: responseCommitted,
+      errorCode,
+      error: error?.message || result?.error,
+      retryAfterSeconds: Number(result?.retryAfterSeconds),
+      now: now(),
+    }, { filePath });
+    const attempt = {
+      credentialId: selection.credentialId,
+      status: statusCode,
+      ok,
+      committed: responseCommitted,
+      ...(outcome?.rebindRecommended ? { rebound: true } : {}),
+    };
+    attempts.push(attempt);
+    if (error) {
+      if (!isRetryableProviderApiKeyFailure({ errorCode, committed: responseCommitted })) {
+        return { configured: true, valid: true, providerId: provider, result, error, attempts, reason: "failed" };
+      }
+    } else if (ok || responseCommitted || !isRetryableProviderApiKeyFailure({ status: statusCode, committed: responseCommitted })) {
+      return { configured: true, valid: true, providerId: provider, result, attempts, reason: ok ? "success" : "failed" };
+    }
+  }
+  return { configured: true, valid: true, providerId: provider, attempts, reason: "no_retry_candidate" };
+}

--- a/src/provider-api-key-pool.mjs
+++ b/src/provider-api-key-pool.mjs
@@ -10,6 +10,7 @@ import lockfile from "proper-lockfile";
 
 import { writePrivateJson } from "./file-security.mjs";
 import { PROVIDER_API_KEY_POOL_PATH, STATE_DIR } from "./paths.mjs";
+import { canonicalProviderId } from "./provider-selection.mjs";
 
 export const PROVIDER_API_KEY_POOL_SCHEMA_VERSION = 1;
 export const PROVIDER_API_KEY_POOL_STRATEGIES = Object.freeze([
@@ -84,7 +85,7 @@ function text(value, field, { max = 256, required = false } = {}) {
 function providerId(value) {
   const normalized = text(value, "provider id", { max: 100, required: true }).toLowerCase();
   if (!PROVIDER_ID.test(normalized)) throw new Error(`Invalid provider id: ${normalized}`);
-  return normalized;
+  return canonicalProviderId(normalized);
 }
 
 function credentialId(value) {
@@ -159,10 +160,13 @@ export function normalizeProviderApiKeySecretRef(value) {
   return { type, name, ...(providerIdValue ? { providerId: providerIdValue } : {}) };
 }
 
-export function providerApiKeySecretRefIdentity(value) {
+export function providerApiKeySecretRefIdentity(value, providerScope) {
   const ref = normalizeProviderApiKeySecretRef(value);
   const source = ref.id || ref.name || ref.service;
-  return `${ref.providerId || ""}:${ref.type}:${source}`;
+  const scope = providerScope === undefined
+    ? ref.providerId || ""
+    : providerId(providerScope);
+  return `${scope}:${ref.type}:${source}`;
 }
 
 function normalizeQuota(value) {
@@ -314,7 +318,7 @@ function normalizePool(value, provider, now = Date.now()) {
   const refs = new Set();
   for (const [id, raw] of credentials.slice(0, MAX_CREDENTIALS)) {
     const normalized = normalizeCredential({ ...(record(raw) ? raw : {}), id }, provider, now);
-    const refIdentity = providerApiKeySecretRefIdentity(normalized.secretRef);
+    const refIdentity = providerApiKeySecretRefIdentity(normalized.secretRef, provider);
     if (refs.has(refIdentity)) throw new Error(`Provider ${provider} contains duplicate secret references.`);
     refs.add(refIdentity);
     result.credentials[normalized.id] = normalized;
@@ -498,7 +502,7 @@ function duplicateResolvedSecrets(entries) {
 async function resolvedCandidates(pool, { resolveSecret, now, exclude }) {
   if (typeof resolveSecret !== "function") return { entries: [], reason: "secret_resolver_required" };
   const entries = [];
-  for (const meta of eligibleMeta(pool, now, exclude)) {
+  for (const meta of eligibleMeta(pool, now)) {
     let resolved;
     try {
       resolved = await resolveSecret({ ...meta.secretRef });
@@ -509,7 +513,7 @@ async function resolvedCandidates(pool, { resolveSecret, now, exclude }) {
     if (value) entries.push({ meta, value });
   }
   if (duplicateResolvedSecrets(entries)) return { entries: [], reason: "duplicate_secret_reference" };
-  return { entries };
+  return { entries: entries.filter((entry) => !exclude.has(entry.meta.id)) };
 }
 
 function sessionCanStay(pool, session, meta, at) {
@@ -551,7 +555,9 @@ async function selectFromState(providerOrId, options = {}) {
     exclude: excluded,
   });
   if (!resolved.entries.length) {
-    return selectedResult(provider, pool, undefined, undefined, undefined);
+    const result = selectedResult(provider, pool, undefined, undefined, undefined);
+    if (resolved.reason) result.reason = resolved.reason;
+    return result;
   }
   const session = sessionId(options.sessionId);
   const bound = session ? pool.sessions[session] : undefined;
@@ -683,7 +689,11 @@ export async function upsertProviderApiKey(providerOrId, credential, {
       sessions: {},
     };
     for (const current of Object.values(pool.credentials)) {
-      if (current.id !== normalized.id && providerApiKeySecretRefIdentity(current.secretRef) === providerApiKeySecretRefIdentity(normalized.secretRef)) {
+      if (
+        current.id !== normalized.id &&
+        providerApiKeySecretRefIdentity(current.secretRef, provider) ===
+          providerApiKeySecretRefIdentity(normalized.secretRef, provider)
+      ) {
         throw new Error(`Provider ${provider} already contains this secret reference.`);
       }
     }

--- a/src/provider-api-key-routing.mjs
+++ b/src/provider-api-key-routing.mjs
@@ -1,0 +1,117 @@
+import {
+  providerApiKeyPoolStatus,
+  recordProviderApiKeyOutcome,
+  selectProviderApiKeyLocked,
+} from "./provider-api-key-pool.mjs";
+import {
+  resolveProviderCredential,
+  resolveProviderCredentialReference,
+} from "./provider-credentials.mjs";
+
+/**
+ * Resolve one request credential without silently falling back around a pool.
+ *
+ * An absent provider entry means the legacy single-key path is still in use.
+ * Once an entry exists, the pool is authoritative: invalid state, a lock
+ * failure, an unavailable secret, or an empty pool returns no credential.
+ * This is deliberately fail-closed because falling back to a different key
+ * can spend the wrong account and hide a broken pool configuration.
+ */
+export async function resolveProviderApiKeyForRequest(
+  provider,
+  {
+    sessionId,
+    now = Date.now(),
+    poolStatePath,
+    resolveLegacy = () => resolveProviderCredential(provider),
+    waitMs,
+    retryMs,
+    staleMs,
+  } = {},
+) {
+  const status = providerApiKeyPoolStatus(provider.id, {
+    filePath: poolStatePath,
+    now,
+  });
+  if (!status.configured) {
+    return {
+      credential: resolveLegacy(),
+      pooled: false,
+      configured: false,
+      fallbackAllowed: true,
+    };
+  }
+  if (!status.valid) {
+    return {
+      credential: undefined,
+      pooled: true,
+      configured: true,
+      fallbackAllowed: false,
+      reason: "invalid_pool_state",
+    };
+  }
+  let selection;
+  try {
+    selection = await selectProviderApiKeyLocked(provider.id, {
+      filePath: poolStatePath,
+      sessionId,
+      now,
+      waitMs,
+      retryMs,
+      staleMs,
+      resolveSecret: (reference) => resolveProviderCredentialReference(provider, reference),
+    });
+  } catch (error) {
+    return {
+      credential: undefined,
+      pooled: true,
+      configured: true,
+      fallbackAllowed: false,
+      reason: error?.code === "provider_api_key_pool_locked" ? "pool_locked" : "pool_error",
+      error,
+    };
+  }
+  if (!selection?.credentialValue) {
+    return {
+      credential: undefined,
+      pooled: true,
+      configured: true,
+      fallbackAllowed: false,
+      selection,
+      reason: selection?.reason || "no_eligible_credentials",
+    };
+  }
+  return {
+    credential: {
+      value: selection.credentialValue,
+      source: `provider API-key pool (${selection.credentialId})`,
+      persistent: true,
+    },
+    pooled: true,
+    configured: true,
+    fallbackAllowed: false,
+    selection,
+  };
+}
+
+export async function recordProviderApiKeyRequestOutcome(
+  routing,
+  provider,
+  outcome,
+  { poolStatePath } = {},
+) {
+  if (!routing?.pooled || !routing.selection?.credentialId) return undefined;
+  try {
+    return await recordProviderApiKeyOutcome(
+      provider.id,
+      routing.selection.credentialId,
+      outcome,
+      { filePath: poolStatePath },
+    );
+  } catch {
+    // The upstream result is already determined; telemetry failure must not
+    // rewrite or truncate a response. The next request still fails closed if
+    // the pool state or lock remains unavailable.
+    return undefined;
+  }
+}

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -150,6 +150,7 @@ export function resolveProviderCredentialReference(providerOrId, reference, { pe
   if (!provider?.credential || provider.authMode === "anonymous" || provider.authMode === "per-model") {
     return undefined;
   }
+  if (discoveryDisabled()) return undefined;
   if (!reference || typeof reference !== "object" || Array.isArray(reference)) {
     throw new Error("Credential reference must be an object.");
   }

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -118,6 +118,84 @@ function keychainSecret(service, now) {
   return result;
 }
 
+const PROVIDER_REFERENCE_TYPES = Object.freeze([
+  "provider-file",
+  "keychain",
+  "environment",
+]);
+
+function providerReferenceText(value, field, max = 256) {
+  if (typeof value !== "string") {
+    throw new Error(`${field} must be a string.`);
+  }
+  const normalized = value.trim();
+  if (!normalized || normalized.length > max || /[\u0000-\u001f\u007f]/.test(normalized)) {
+    throw new Error(`${field} is invalid.`);
+  }
+  return normalized;
+}
+
+/**
+ * Resolve a pool reference only against sources declared by this provider.
+ *
+ * A pool stores descriptors, never values. The descriptor is intentionally
+ * constrained to the provider registry: callers cannot turn it into an
+ * arbitrary file, environment variable, or Keychain lookup. This function is
+ * the only boundary that turns one of those descriptors into an in-memory
+ * credential for a request.
+ */
+export function resolveProviderCredentialReference(providerOrId, reference, { persistent = true } = {}) {
+  const provider =
+    typeof providerOrId === "string" ? apiProvider(providerOrId) : providerOrId;
+  if (!provider?.credential || provider.authMode === "anonymous" || provider.authMode === "per-model") {
+    return undefined;
+  }
+  if (!reference || typeof reference !== "object" || Array.isArray(reference)) {
+    throw new Error("Credential reference must be an object.");
+  }
+  const type = providerReferenceText(reference.type, "credential reference type", 40);
+  if (!PROVIDER_REFERENCE_TYPES.includes(type)) {
+    throw new Error(`Unsupported credential reference type: ${type}`);
+  }
+  const referenceProvider = reference.providerId === undefined
+    ? provider.id
+    : providerReferenceText(reference.providerId, "credential reference provider", 100);
+  if (referenceProvider !== provider.id && referenceProvider !== provider.variantOf) {
+    throw new Error("Credential reference belongs to a different provider.");
+  }
+
+  if (type === "environment") {
+    const name = providerReferenceText(reference.name, "credential environment name", 100);
+    if (!provider.credential.environment.includes(name)) {
+      throw new Error(`Environment variable ${name} is not declared by ${provider.id}.`);
+    }
+    const value = process.env[name]?.trim();
+    return value ? resolvedCredential(provider, value, `environment (${name})`, false) : undefined;
+  }
+
+  if (type === "keychain") {
+    const service = providerReferenceText(reference.service, "credential Keychain service", 200);
+    if (!provider.credential.keychainServices?.includes(service)) {
+      throw new Error(`Keychain service ${service} is not declared by ${provider.id}.`);
+    }
+    if (process.platform !== "darwin" || TARGET !== "codex") return undefined;
+    const found = keychainSecret(service, Date.now());
+    return found ? resolvedCredential(provider, found.value, found.source, true) : undefined;
+  }
+
+  const name = providerReferenceText(reference.name, "credential file name", 200);
+  const allowed = [provider.credential.file, ...(provider.credential.legacyFiles || [])];
+  if (!allowed.includes(name)) {
+    throw new Error(`Credential file ${name} is not declared by ${provider.id}.`);
+  }
+  const candidate = credentialPaths(provider).find((entry) => path.basename(entry) === name);
+  if (!candidate || !existsSync(candidate)) return undefined;
+  const value = readFileSync(candidate, "utf8").trim();
+  if (!value) return undefined;
+  const credential = resolvedCredential(provider, value, `protected file (${candidate})`, persistent);
+  return credential;
+}
+
 function keyFromKeychain(provider) {
   if (process.platform !== "darwin" || TARGET !== "codex") return undefined;
   const now = Date.now();

--- a/test/provider-api-key-pool.test.mjs
+++ b/test/provider-api-key-pool.test.mjs
@@ -77,14 +77,23 @@ test("a configured pool is authoritative and never falls back when empty or inva
 
 test("duplicate secret references are rejected rather than selecting one arbitrarily", async () => {
   const filePath = path.join(root, "duplicates.json");
-  const first = metadata(credential("first", "A"));
-  const second = metadata({ ...credential("second", "B"), secretRef: first.secretRef });
+  const first = metadata({
+    ...credential("first", "A"),
+    secretRef: { type: "provider-file", name: "openrouter-api-key.secret" },
+  });
+  const second = metadata({
+    ...credential("second", "B"),
+    secretRef: { ...first.secretRef, providerId: "openrouter" },
+  });
   await upsertProviderApiKey("openrouter", first, { filePath });
   await assert.rejects(
     upsertProviderApiKey("openrouter", second, { filePath }),
     /already contains this secret reference/,
   );
-  assert.equal(providerApiKeySecretRefIdentity(first.secretRef), providerApiKeySecretRefIdentity(second.secretRef));
+  assert.equal(
+    providerApiKeySecretRefIdentity(first.secretRef, "openrouter"),
+    providerApiKeySecretRefIdentity(second.secretRef, "openrouter"),
+  );
 });
 
 test("resolution refuses duplicate secret values even when references differ", async () => {
@@ -96,7 +105,7 @@ test("resolution refuses duplicate secret values even when references differ", a
     resolveSecret: () => "SAME",
   });
   assert.equal(result.credentialId, null);
-  assert.equal(result.reason, "no_eligible_credentials");
+  assert.equal(result.reason, "duplicate_secret_reference");
 });
 
 test("quota and round-robin selection never returns the secret value in metadata", async () => {
@@ -205,6 +214,22 @@ test("runProviderApiKeyAttempts retries before relay and stops after relay begin
   assert.equal(lateCalls, 1);
   assert.equal(late.attempts[0].committed, true);
   assert.equal(late.reason, "failed");
+});
+
+test("duplicate resolved secrets remain blocked after a failed candidate is excluded", async () => {
+  const filePath = path.join(root, "duplicate-failover.json");
+  const first = metadata(credential("first", "SAME", { priority: 2 }));
+  const second = metadata(credential("second", "SAME", { priority: 1 }));
+  await upsertProviderApiKey("openrouter", first, { filePath });
+  await upsertProviderApiKey("openrouter", second, { filePath });
+  const result = await runProviderApiKeyAttempts("openrouter", {
+    filePath,
+    resolveSecret: () => "SAME",
+    send: async () => ({ status: 401, ok: false, committed: false }),
+    now: () => NOW,
+  });
+  assert.equal(result.attempts.length, 0);
+  assert.equal(result.reason, "duplicate_secret_reference");
 });
 
 test("lock serializes concurrent state updates and preserves every session turn", async () => {

--- a/test/provider-api-key-pool.test.mjs
+++ b/test/provider-api-key-pool.test.mjs
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = mkdtempSync(path.join(os.tmpdir(), "codex-router-api-key-pool-"));
+const statePath = path.join(root, "provider-api-key-pools.json");
+const NOW = Date.parse("2026-08-24T00:00:00.000Z");
+
+const {
+  getProviderApiKeyPool,
+  isRetryableProviderApiKeyFailure,
+  providerApiKeyPoolStatus,
+  providerApiKeySecretRefIdentity,
+  readProviderApiKeyPoolState,
+  recordProviderApiKeyOutcome,
+  runProviderApiKeyAttempts,
+  selectProviderApiKey,
+  selectProviderApiKeyLocked,
+  setProviderApiKeyPaused,
+  setProviderApiKeyPoolPolicy,
+  upsertProviderApiKey,
+} = await import("../src/provider-api-key-pool.mjs");
+
+const ref = (id) => ({ type: "opaque", id: `ref_${id}_12345678` });
+const credential = (id, secret, patch = {}) => ({
+  id: `cred_${id}_12345678`,
+  secretRef: ref(id),
+  ...patch,
+  _secret: secret,
+});
+
+function metadata(value) {
+  const { _secret, ...safe } = value;
+  return safe;
+}
+
+test.after(() => rmSync(root, { recursive: true, force: true }));
+
+test("an absent pool explicitly permits the legacy single-key path", async () => {
+  const result = await selectProviderApiKey("openrouter", {
+    filePath: path.join(root, "absent.json"),
+    resolveSecret: () => "unused",
+  });
+  assert.equal(result.configured, false);
+  assert.equal(result.fallbackAllowed, true);
+});
+
+test("a configured pool is authoritative and never falls back when empty or invalid", async () => {
+  const emptyPath = path.join(root, "empty.json");
+  await upsertProviderApiKey("openrouter", metadata(credential("one", "ONE")), { filePath: emptyPath });
+  await setProviderApiKeyPaused("openrouter", "cred_one_12345678", true, { filePath: emptyPath });
+  const empty = await selectProviderApiKey("openrouter", {
+    filePath: emptyPath,
+    resolveSecret: () => undefined,
+  });
+  assert.equal(empty.configured, true);
+  assert.equal(empty.credentialId, null);
+  assert.equal(empty.fallbackAllowed, undefined);
+
+  const invalidPath = path.join(root, "invalid.json");
+  writeFileSync(invalidPath, '{"version":1,"providers":{"openrouter":{"credentials":{"bad": {}}}}}');
+  const invalid = providerApiKeyPoolStatus("openrouter", { filePath: invalidPath });
+  assert.equal(invalid.configured, true);
+  assert.equal(invalid.valid, false);
+  const selected = await selectProviderApiKey("openrouter", { filePath: invalidPath, resolveSecret: () => "LEGACY" });
+  assert.equal(selected.reason, "invalid_pool_state");
+  assert.equal(selected.fallbackAllowed, false);
+});
+
+test("duplicate secret references are rejected rather than selecting one arbitrarily", async () => {
+  const filePath = path.join(root, "duplicates.json");
+  const first = metadata(credential("first", "A"));
+  const second = metadata({ ...credential("second", "B"), secretRef: first.secretRef });
+  await upsertProviderApiKey("openrouter", first, { filePath });
+  await assert.rejects(
+    upsertProviderApiKey("openrouter", second, { filePath }),
+    /already contains this secret reference/,
+  );
+  assert.equal(providerApiKeySecretRefIdentity(first.secretRef), providerApiKeySecretRefIdentity(second.secretRef));
+});
+
+test("resolution refuses duplicate secret values even when references differ", async () => {
+  const filePath = path.join(root, "duplicate-values.json");
+  await upsertProviderApiKey("openrouter", metadata(credential("first", "SAME")), { filePath });
+  await upsertProviderApiKey("openrouter", metadata(credential("second", "SAME")), { filePath });
+  const result = await selectProviderApiKey("openrouter", {
+    filePath,
+    resolveSecret: () => "SAME",
+  });
+  assert.equal(result.credentialId, null);
+  assert.equal(result.reason, "no_eligible_credentials");
+});
+
+test("quota and round-robin selection never returns the secret value in metadata", async () => {
+  const filePath = path.join(root, "selection.json");
+  await upsertProviderApiKey("openrouter", metadata(credential("low", "LOW", { priority: 1, quota: { limit: 100, remaining: 10 } })), { filePath });
+  await upsertProviderApiKey("openrouter", metadata(credential("high", "HIGH", { priority: 2, quota: { limit: 100, remaining: 90 } })), { filePath });
+  const result = await selectProviderApiKey("openrouter", {
+    filePath,
+    resolveSecret: ({ id }) => id.includes("high") ? "HIGH" : "LOW",
+    now: NOW,
+  });
+  assert.equal(result.credentialId, "cred_high_12345678");
+  assert.equal(result.credentialValue, "HIGH");
+  const snapshot = getProviderApiKeyPool("openrouter", { filePath, now: NOW });
+  assert.equal(snapshot.credentials[0].secretRef.type, "opaque");
+  assert.doesNotMatch(readFileSync(filePath, "utf8"), /HIGH|LOW/);
+});
+
+test("ordinary 400 and 404 responses do not disable a key", async () => {
+  const filePath = path.join(root, "ordinary-errors.json");
+  const entry = metadata(credential("ordinary", "ORDINARY"));
+  await upsertProviderApiKey("openrouter", entry, { filePath });
+  for (const status of [400, 404]) {
+    const outcome = await recordProviderApiKeyOutcome("openrouter", entry.id, {
+      status,
+      ok: false,
+      committed: false,
+      now: NOW,
+    }, { filePath });
+    assert.equal(outcome.rebindRecommended, false);
+    assert.equal(outcome.credential.health.state, "healthy");
+  }
+  const selected = await selectProviderApiKey("openrouter", {
+    filePath,
+    resolveSecret: () => "ORDINARY",
+    now: NOW,
+  });
+  assert.equal(selected.credentialId, entry.id);
+});
+
+test("only pre-commit transient failures recommend a rebind", async () => {
+  const filePath = path.join(root, "commit-boundary.json");
+  const first = metadata(credential("first", "FIRST"));
+  const second = metadata(credential("second", "SECOND"));
+  await upsertProviderApiKey("openrouter", first, { filePath });
+  await upsertProviderApiKey("openrouter", second, { filePath });
+
+  const committed = await recordProviderApiKeyOutcome("openrouter", first.id, {
+    status: 401,
+    ok: false,
+    committed: true,
+    now: NOW,
+  }, { filePath });
+  assert.equal(committed.rebindRecommended, false);
+  assert.notEqual(committed.credential.health.state, "cooldown");
+
+  const precommit = await recordProviderApiKeyOutcome("openrouter", second.id, {
+    status: 401,
+    ok: false,
+    committed: false,
+    now: NOW,
+  }, { filePath });
+  assert.equal(precommit.rebindRecommended, true);
+  assert.equal(precommit.credential.health.state, "cooldown");
+  assert.equal(isRetryableProviderApiKeyFailure({ status: 400 }), false);
+  assert.equal(isRetryableProviderApiKeyFailure({ status: 404 }), false);
+  assert.equal(isRetryableProviderApiKeyFailure({ status: 401, committed: true }), false);
+  assert.equal(isRetryableProviderApiKeyFailure({ status: 401, committed: false }), true);
+});
+
+test("runProviderApiKeyAttempts retries before relay and stops after relay begins", async () => {
+  const filePath = path.join(root, "attempts.json");
+  const first = metadata(credential("first", "FIRST", { priority: 2 }));
+  const second = metadata(credential("second", "SECOND", { priority: 1 }));
+  await upsertProviderApiKey("openrouter", first, { filePath });
+  await upsertProviderApiKey("openrouter", second, { filePath });
+  const secrets = new Map([[first.secretRef.id, "FIRST"], [second.secretRef.id, "SECOND"]]);
+  let calls = 0;
+  const recovered = await runProviderApiKeyAttempts("openrouter", {
+    filePath,
+    resolveSecret: ({ id }) => secrets.get(id),
+    send: async ({ apiKey }) => {
+      calls += 1;
+      return apiKey === "FIRST"
+        ? { status: 401, ok: false, committed: false }
+        : { status: 200, ok: true, committed: false };
+    },
+    now: () => NOW,
+  });
+  assert.equal(calls, 2);
+  assert.equal(recovered.result.status, 200);
+  assert.deepEqual(recovered.attempts.map((attempt) => attempt.credentialId), [first.id, second.id]);
+
+  const latePath = path.join(root, "late.json");
+  await upsertProviderApiKey("openrouter", metadata(credential("late", "LATE")), { filePath: latePath });
+  let lateCalls = 0;
+  const late = await runProviderApiKeyAttempts("openrouter", {
+    filePath: latePath,
+    resolveSecret: () => "LATE",
+    send: async () => {
+      lateCalls += 1;
+      return { status: 401, ok: false, committed: true };
+    },
+    now: () => NOW,
+  });
+  assert.equal(lateCalls, 1);
+  assert.equal(late.attempts[0].committed, true);
+  assert.equal(late.reason, "failed");
+});
+
+test("lock serializes concurrent state updates and preserves every session turn", async () => {
+  const filePath = path.join(root, "concurrency.json");
+  const entry = metadata(credential("concurrent", "CONCURRENT"));
+  await upsertProviderApiKey("openrouter", entry, { filePath });
+  const results = await Promise.all(Array.from({ length: 12 }, () => selectProviderApiKeyLocked("openrouter", {
+    filePath,
+    sessionId: "session-1",
+    resolveSecret: () => "CONCURRENT",
+    now: NOW,
+  })));
+  assert.equal(new Set(results.map((result) => result.credentialId)).size, 1);
+  const state = readProviderApiKeyPoolState(filePath, { now: NOW });
+  assert.equal(state.providers.openrouter.sessions["session-1"].turns, 12);
+  assert.equal(existsSync(`${filePath}.pool-lock`), false);
+});

--- a/test/provider-api-key-routing.test.mjs
+++ b/test/provider-api-key-routing.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const root = mkdtempSync(path.join(os.tmpdir(), "codex-router-api-key-routing-"));
+process.env.CODEX_HOME = path.join(root, "codex");
+process.env.CODEX_ROUTER_STATE_DIR = path.join(root, "state");
+delete process.env.OPENROUTER_API_KEY;
+
+const { PROVIDERS } = await import("../src/model-registry.mjs");
+const { writeProviderCredential, resolveProviderCredentialReference } = await import("../src/provider-credentials.mjs");
+const { resolveProviderApiKeyForRequest } = await import("../src/provider-api-key-routing.mjs");
+const { setProviderApiKeyPaused, upsertProviderApiKey } = await import("../src/provider-api-key-pool.mjs");
+
+const provider = PROVIDERS.get("openrouter");
+const statePath = path.join(root, "pool.json");
+const credentialId = "cred_primary_12345678";
+
+test.after(() => rmSync(root, { recursive: true, force: true }));
+
+test("registry-bound provider-file references resolve without accepting arbitrary paths", async () => {
+  writeProviderCredential(provider, "POOL_PRIMARY_SECRET");
+  const reference = {
+    type: "provider-file",
+    name: provider.credential.file,
+  };
+  assert.equal(resolveProviderCredentialReference(provider, reference)?.value, "POOL_PRIMARY_SECRET");
+  assert.throws(
+    () => resolveProviderCredentialReference(provider, { type: "provider-file", name: "../outside.secret" }),
+    /not declared/,
+  );
+  await upsertProviderApiKey(provider.id, {
+    id: credentialId,
+    secretRef: reference,
+  }, { filePath: statePath });
+  const routing = await resolveProviderApiKeyForRequest(provider, { poolStatePath: statePath });
+  assert.equal(routing.pooled, true);
+  assert.equal(routing.fallbackAllowed, false);
+  assert.equal(routing.credential.value, "POOL_PRIMARY_SECRET");
+});
+
+test("an empty configured pool refuses the legacy key instead of silently using it", async () => {
+  await setProviderApiKeyPaused(provider.id, credentialId, true, { filePath: statePath });
+  const routing = await resolveProviderApiKeyForRequest(provider, { poolStatePath: statePath });
+  assert.equal(routing.pooled, true);
+  assert.equal(routing.credential, undefined);
+  assert.equal(routing.fallbackAllowed, false);
+});

--- a/test/provider-api-key-routing.test.mjs
+++ b/test/provider-api-key-routing.test.mjs
@@ -15,6 +15,7 @@ const { resolveProviderApiKeyForRequest } = await import("../src/provider-api-ke
 const { setProviderApiKeyPaused, upsertProviderApiKey } = await import("../src/provider-api-key-pool.mjs");
 
 const provider = PROVIDERS.get("openrouter");
+const opencodeMessages = PROVIDERS.get("opencode-go-messages");
 const statePath = path.join(root, "pool.json");
 const credentialId = "cred_primary_12345678";
 
@@ -47,4 +48,22 @@ test("an empty configured pool refuses the legacy key instead of silently using 
   assert.equal(routing.pooled, true);
   assert.equal(routing.credential, undefined);
   assert.equal(routing.fallbackAllowed, false);
+});
+
+test("protocol variants use the canonical provider pool", async () => {
+  const opencodeStatePath = path.join(root, "opencode-pool.json");
+  writeProviderCredential(PROVIDERS.get("opencode-go"), "OPENCODE_POOL_SECRET");
+  await upsertProviderApiKey("opencode-go", {
+    id: "cred_opencode_12345678",
+    secretRef: {
+      type: "provider-file",
+      name: opencodeMessages.credential.file,
+    },
+  }, { filePath: opencodeStatePath });
+  const routing = await resolveProviderApiKeyForRequest(opencodeMessages, {
+    poolStatePath: opencodeStatePath,
+  });
+  assert.equal(routing.pooled, true);
+  assert.equal(routing.credential?.value, "OPENCODE_POOL_SECRET");
+  assert.equal(routing.selection?.providerId, "opencode-go");
 });

--- a/test/provider-credentials.test.mjs
+++ b/test/provider-credentials.test.mjs
@@ -24,8 +24,10 @@ const {
   removeProviderCredential,
   resetKeychainCache,
   resolveProviderCredential,
+  resolveProviderCredentialReference,
   writeProviderCredential,
 } = await import("../src/provider-credentials.mjs");
+const { PROVIDERS } = await import("../src/model-registry.mjs");
 const { privateFileIsProtected } = await import("../src/file-security.mjs");
 
 test("provider credentials use protected files and remove legacy managed keys", () => {
@@ -125,6 +127,14 @@ test("--no-discovery blinds the resolver to stored keys without a single keychai
     const before = keychainProbeCount();
     assert.equal(resolveProviderCredential("deepseek"), undefined);
     assert.equal(resolveProviderCredential("openrouter", { persistent: true }), undefined);
+    assert.equal(
+      resolveProviderCredentialReference("deepseek", {
+        type: "provider-file",
+        name: PROVIDERS.get("deepseek").credential.file,
+      }),
+      undefined,
+      "the pool reference resolver bypassed --no-discovery",
+    );
     assert.equal(keychainProbeCount(), before, "the kill-switch still spawned /usr/bin/security");
 
     // Sources that read nothing keep answering: anonymous and keyless


### PR DESCRIPTION
## Summary

Add a provider-scoped API-key pool that stores validated secret references and metadata, never raw keys. A configured pool is authoritative, uses locked atomic state updates, rejects duplicate references and resolved secrets, and retries only transient failures before response bytes are committed. Provider protocol variants share their canonical pool; pool references are constrained to registry-declared sources and honor `--no-discovery`.

## Reason

Keep one broken key from taking down a provider while preventing accidental legacy-key fallback, cross-provider credential use, duplicate-secret routing, and retries after the client has received response bytes.

## Validation

- `npm run check`
- `node --test test/provider-api-key-pool.test.mjs test/provider-api-key-routing.test.mjs test/provider-credentials.test.mjs test/routing.test.mjs` (101 passed)
- `git diff --check`

## Remaining risks

This PR adds the provider-scoped pool primitive and its forwarder boundary. It does not add automatic account pooling or ChatGPT subscription routing.

