### PR TITLE
feat: add generic OpenAI-compatible providers

### DIFF
--- a/src/control.mjs
+++ b/src/control.mjs
@@ -660,6 +660,11 @@ async function printProviderOnboarding() {
   process.stdout.write(`${JSON.stringify(providerOnboardingSnapshot(), null, 2)}\n`);
 }
 
+async function handleGenericProviders(...commandArgs) {
+  const { runGenericProviderCli } = await import("./generic-providers.mjs");
+  await runGenericProviderCli(commandArgs, { output: process.stdout });
+}
+
 async function installProviderCli(providerId) {
   const { installOauthCli, providerOnboardingSnapshot } = await import("./provider-onboarding.mjs");
   installOauthCli(providerId);
@@ -2786,6 +2791,8 @@ if (args.includes("--probe")) {
   await printProviderUsage();
 } else if (args[0] === "providers") {
   await printProviderOnboarding();
+} else if (args[0] === "generic-providers") {
+  await handleGenericProviders(...args.slice(1));
 } else if (args[0] === "install-cli") {
   if (!args[1]) throw new Error("Usage: control install-cli <oauth-provider>");
   await installProviderCli(args[1]);

--- a/src/generic-provider-identity.mjs
+++ b/src/generic-provider-identity.mjs
@@ -1,0 +1,14 @@
+import { PROVIDERS } from "./model-registry.mjs";
+
+export const GENERIC_PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+export function normalizeGenericProviderId(value) {
+  const providerId = typeof value === "string" ? value.trim() : "";
+  if (!GENERIC_PROVIDER_ID_PATTERN.test(providerId)) {
+    throw new Error("Provider id must match [a-z0-9][a-z0-9-]*.");
+  }
+  if (PROVIDERS.has(providerId)) {
+    throw new Error(`Provider id ${providerId} is already used by the built-in registry.`);
+  }
+  return providerId;
+}

--- a/src/generic-providers.mjs
+++ b/src/generic-providers.mjs
@@ -1,10 +1,15 @@
 import { promises as dns } from "node:dns";
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
+import { isIP } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { Agent, fetch as undiciFetch } from "undici";
 
 import { PROVIDERS } from "./model-registry.mjs";
 import { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
+import { withAtomicStateLock } from "./atomic-state-lock.mjs";
+import { readProviderCredentialStore } from "./provider-credential-store.mjs";
 
 export { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
 import { writePrivateJson } from "./file-security.mjs";
@@ -44,6 +49,9 @@ const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const MAX_HEADERS = 64;
 const MAX_HEADER_VALUE_LENGTH = 4_096;
 const MAX_DESCRIPTION_LENGTH = 240;
+const MAX_RESPONSE_BYTES = 64 * 1024;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const SECRET_HEADER_PATTERN = /(?:^|[-_])(auth|authorization|api[-_]?key|key|token|secret|credential|cookie|password|session|signature)(?:$|[-_])/i;
 
 function text(value) {
   return typeof value === "string" ? value.trim() : "";
@@ -66,32 +74,42 @@ function isPrivateIpv4(value) {
   if (!isIpv4(value)) return false;
   const [a, b] = value.split(".").map(Number);
   return (
+    a === 0 ||
     a === 10 ||
     a === 127 ||
-    a === 0 ||
+    (a === 100 && b >= 64 && b <= 127) ||
     (a === 169 && b === 254) ||
     (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && b === 168)
+    (a === 192 && [0, 2, 168].includes(b)) ||
+    (a === 198 && b >= 18 && b <= 19) ||
+    (a === 198 && b === 51) ||
+    (a === 203 && b === 0) ||
+    a >= 224
   );
+}
+
+function isPrivateAddress(value) {
+  const address = String(value || "").toLowerCase();
+  const family = isIP(address);
+  if (family === 4) return isPrivateIpv4(address);
+  if (family !== 6) return false;
+  if (address === "::1" || address === "0:0:0:0:0:0:0:1") return true;
+  if (address.startsWith("fc") || address.startsWith("fd") || address.startsWith("fe80:")) return true;
+  const mapped = address.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+  return Boolean(mapped && isPrivateIpv4(mapped[1]));
 }
 
 function isPrivateHostname(hostname) {
   const host = String(hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
   if (!host) return false;
-  if (isPrivateIpv4(host)) return true;
+  if (isPrivateAddress(host)) return true;
   if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) {
     return true;
   }
   // IPv6 loopback, link-local and unique-local ranges. This intentionally
   // does not try to parse every IPv6 spelling; DNS lookup in testGenericProvider
   // catches resolved private addresses before a request is sent.
-  return (
-    host === "::1" ||
-    host.startsWith("fc") ||
-    host.startsWith("fd") ||
-    host.startsWith("fe80:") ||
-    host === "0:0:0:0:0:0:0:1"
-  );
+  return false;
 }
 
 function validateEndpoint(urlValue, allowPrivate) {
@@ -134,7 +152,7 @@ function validateHeaders(raw) {
     const lower = name.toLowerCase();
     const value = typeof valueValue === "string" ? valueValue : "";
     if (!HEADER_NAME_PATTERN.test(name)) throw new Error(`Invalid header name: ${nameValue}`);
-    if (FORBIDDEN_HEADER_NAMES.has(lower)) {
+    if (FORBIDDEN_HEADER_NAMES.has(lower) || SECRET_HEADER_PATTERN.test(lower)) {
       throw new Error(`Header ${name} is reserved for credential or transport handling.`);
     }
     if (!value || value.length > MAX_HEADER_VALUE_LENGTH || /[\r\n]/.test(value)) {
@@ -256,38 +274,47 @@ function saveProviders(providers) {
 }
 
 function mutateProviders(mutator) {
-  const current = readGenericProviders();
-  const next = mutator(current.map((provider) => ({ ...provider, headers: { ...provider.headers } })));
-  if (!Array.isArray(next)) throw new Error("Generic provider mutation returned an invalid list.");
-  const validated = parseDocument({ version: GENERIC_PROVIDER_SCHEMA_VERSION, providers: next }).providers;
-  saveProviders(validated);
-  return validated;
+  return withAtomicStateLock(GENERIC_PROVIDERS_PATH, () => {
+    const current = readGenericProviders();
+    const next = mutator(current.map((provider) => ({ ...provider, headers: { ...provider.headers } })));
+    if (!Array.isArray(next)) throw new Error("Generic provider mutation returned an invalid list.");
+    const validated = parseDocument({ version: GENERIC_PROVIDER_SCHEMA_VERSION, providers: next }).providers;
+    saveProviders(validated);
+    return validated;
+  });
 }
 
 export function addGenericProvider(input) {
   const provider = validateProvider(input);
-  const current = readGenericProviders();
-  if (current.some((entry) => entry.id === provider.id)) {
-    throw new Error(`Generic provider ${provider.id} already exists.`);
-  }
-  mutateProviders((providers) => [...providers, provider]);
-  return redactGenericProvider(provider);
+  const providers = mutateProviders((current) => {
+    if (current.some((entry) => entry.id === provider.id)) {
+      throw new Error(`Generic provider ${provider.id} already exists.`);
+    }
+    return [...current, provider];
+  });
+  return redactGenericProvider(providers.find((entry) => entry.id === provider.id));
 }
 
 export function updateGenericProvider(id, patch) {
-  const current = readGenericProviders();
-  const existing = current.find((entry) => entry.id === text(id));
-  if (!existing) throw new Error(`Unknown generic provider: ${id}`);
-  const next = validateProvider({ ...existing, ...patch, id: existing.id }, { existingId: existing.id });
-  mutateProviders((providers) => providers.map((entry) => entry.id === existing.id ? next : entry));
-  return redactGenericProvider(next);
+  const providerId = text(id);
+  let updated;
+  mutateProviders((current) => {
+    const existing = current.find((entry) => entry.id === providerId);
+    if (!existing) throw new Error(`Unknown generic provider: ${id}`);
+    updated = validateProvider({ ...existing, ...patch, id: existing.id }, { existingId: existing.id });
+    return current.map((entry) => entry.id === existing.id ? updated : entry);
+  });
+  return redactGenericProvider(updated);
 }
 
 export function removeGenericProvider(id) {
   const providerId = text(id);
-  const current = readGenericProviders();
-  if (!current.some((entry) => entry.id === providerId)) throw new Error(`Unknown generic provider: ${id}`);
-  const next = mutateProviders((providers) => providers.filter((entry) => entry.id !== providerId));
+  const next = mutateProviders((providers) => {
+    if (!providers.some((entry) => entry.id === providerId)) {
+      throw new Error(`Unknown generic provider: ${id}`);
+    }
+    return providers.filter((entry) => entry.id !== providerId);
+  });
   return { removed: providerId, remaining: next.length };
 }
 
@@ -311,7 +338,10 @@ export function genericProviderDescriptor(providerOrId) {
     baseUrl: provider.baseUrl,
     adapter: provider.adapter,
     protocol: provider.adapter === "openai-responses" ? "openai-responses" : "openai",
-    headers: { ...provider.headers },
+    // The descriptor is safe to hand to catalogs and UI surfaces. Raw static
+    // header values stay inside the request boundary and never become a model
+    // descriptor or loggable catalog field.
+    headers: Object.fromEntries(Object.keys(provider.headers).map((name) => [name, "[redacted]"])),
     allowPrivate: provider.allowPrivate,
     enabled: provider.enabled,
     ...(provider.credentialRef ? { credentialRef: provider.credentialRef } : {}),
@@ -328,24 +358,191 @@ async function lookupHost(hostname) {
   }
 }
 
-export async function testGenericProvider(id, { fetchImpl = globalThis.fetch, timeoutMs = 10_000 } = {}) {
-  const provider = getGenericProvider(id);
-  const endpoint = new URL(provider.baseUrl);
-  const resolved = await lookupHost(endpoint.hostname);
-  if (!provider.allowPrivate && resolved.some(isPrivateHostname)) {
-    throw new Error("Provider host resolved to a private or loopback address; set allowPrivate=true explicitly.");
+function destinationUrl(provider, requestPath) {
+  const suffix = String(requestPath || "");
+  if (!suffix.startsWith("/") || suffix.startsWith("//") || /^[a-z][a-z\d+.-]*:/i.test(suffix)) {
+    throw new Error("Generic provider request paths must be relative to the configured baseUrl.");
   }
-  const response = await fetchImpl(`${provider.baseUrl}/models`, {
-    method: "GET",
-    headers: { Accept: "application/json", ...provider.headers },
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  return {
-    ok: response.ok,
-    status: response.status,
-    endpoint: `${provider.baseUrl}/models`,
-    ...(response.ok ? { message: "Provider endpoint is reachable." } : { message: "Provider endpoint returned an error." }),
+  const endpoint = new URL(provider.baseUrl);
+  const target = new URL(`${provider.baseUrl}${suffix}`);
+  if (target.origin !== endpoint.origin || target.username || target.password) {
+    throw new Error("Generic provider request cannot change the configured origin.");
+  }
+  return target;
+}
+
+async function validateResolvedDestination(endpoint, provider, lookup = lookupHost) {
+  if (isPrivateHostname(endpoint.hostname) && !provider.allowPrivate) {
+    throw new Error("Provider host is private or loopback; set allowPrivate=true explicitly.");
+  }
+  const resolved = await lookup(endpoint.hostname);
+  if (!resolved.length) throw new Error(`Provider host ${endpoint.hostname} has no addresses.`);
+  if (!provider.allowPrivate && resolved.some(isPrivateAddress)) {
+    throw new Error("Provider host resolved to a private or link-local address; set allowPrivate=true explicitly.");
+  }
+  return resolved;
+}
+
+function safeHeaderEntries(headers) {
+  const values = headers instanceof Headers ? [...headers.entries()] : Object.entries(headers || {});
+  const result = {};
+  for (const [nameValue, valueValue] of values) {
+    const name = text(nameValue);
+    const lower = name.toLowerCase();
+    const value = String(valueValue ?? "");
+    if (FORBIDDEN_HEADER_NAMES.has(lower) || SECRET_HEADER_PATTERN.test(lower)) {
+      throw new Error(`Header ${name} is reserved for credential or transport handling.`);
+    }
+    if (!HEADER_NAME_PATTERN.test(name) || !value || value.length > MAX_HEADER_VALUE_LENGTH || /[\r\n]/.test(value)) {
+      throw new Error(`Header ${name} has an invalid value.`);
+    }
+    result[name] = value;
+  }
+  return result;
+}
+
+function credentialSecret(provider) {
+  if (!provider.credentialRef) return undefined;
+  const entry = readProviderCredentialStore().credentials.find((candidate) => candidate.id === provider.credentialRef);
+  if (!entry || entry.state !== "active") return undefined;
+  if (entry.providerId !== provider.id) return undefined;
+  const reference = entry.secretRef;
+  if (reference.type === "environment") return process.env[reference.name]?.trim() || undefined;
+  if (reference.type === "keychain") {
+    if (process.platform !== "darwin") return undefined;
+    try {
+      const value = execFileSync(
+        "/usr/bin/security",
+        ["find-generic-password", "-s", reference.service, "-a", "default", "-w"],
+        { encoding: "utf8", timeout: 2_000, stdio: ["ignore", "pipe", "ignore"] },
+      ).trim();
+      return value || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  // provider-file and oauth-session references belong to provider-specific
+  // credential/session code. A generic descriptor cannot turn them into a raw
+  // bearer token, so fail closed until a provider adapter owns that lookup.
+  return undefined;
+}
+
+function requestSignal(signal, timeoutMs) {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+function createDestinationDispatcher(endpoint, provider, timeoutMs) {
+  const lookup = (hostname, options, callback) => {
+    lookupHost(hostname)
+      .then((addresses) => {
+        if (!provider.allowPrivate && addresses.some(isPrivateAddress)) {
+          throw new Error("Provider host resolved to a private or link-local address.");
+        }
+        if (options?.all) {
+          callback(null, addresses.map((address) => ({ address, family: isIP(address) })));
+        } else {
+          const address = addresses[0];
+          callback(null, address, isIP(address));
+        }
+      })
+      .catch((error) => callback(error));
   };
+  return new Agent({
+    allowH2: false,
+    pipelining: 1,
+    headersTimeout: timeoutMs,
+    bodyTimeout: timeoutMs,
+    connect: { lookup },
+  });
+}
+
+async function boundedResponseBody(response, maxBytes = MAX_RESPONSE_BYTES) {
+  const contentLength = Number(response.headers?.get?.("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error(`Generic provider response exceeds the ${maxBytes}-byte limit.`);
+  }
+  if (!response.body) {
+    if (typeof response.text === "function") {
+      const value = await response.text();
+      if (Buffer.byteLength(value, "utf8") > maxBytes) throw new Error("Generic provider response exceeds the read limit.");
+      return value;
+    }
+    return "";
+  }
+  const reader = response.body.getReader();
+  const chunks = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error(`Generic provider response exceeds the ${maxBytes}-byte limit.`);
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export async function requestGenericProvider(
+  id,
+  requestPath,
+  { fetchImpl = undiciFetch, lookup = lookupHost, timeoutMs = 10_000, ...init } = {},
+) {
+  const provider = getGenericProvider(id);
+  if (!provider.enabled) throw new Error(`Generic provider ${provider.id} is disabled.`);
+  const endpoint = destinationUrl(provider, requestPath);
+  await validateResolvedDestination(endpoint, provider, lookup);
+  const requestHeaders = safeHeaderEntries(init.headers);
+  const headers = { ...provider.headers, ...requestHeaders };
+  const secret = credentialSecret(provider);
+  if (secret) headers.Authorization = `Bearer ${secret}`;
+  const useDispatcher = fetchImpl === undiciFetch;
+  const dispatcher = useDispatcher ? createDestinationDispatcher(endpoint, provider, timeoutMs) : undefined;
+  try {
+    const response = await fetchImpl(endpoint.toString(), {
+      ...init,
+      headers,
+      redirect: "manual",
+      signal: requestSignal(init.signal, timeoutMs),
+      ...(dispatcher ? { dispatcher } : {}),
+    });
+    if (REDIRECT_STATUSES.has(response.status)) {
+      await Promise.resolve(response.body?.cancel?.()).catch(() => undefined);
+      throw new Error("Generic provider redirects are disabled.");
+    }
+    return { response, endpoint: endpoint.toString(), dispatcher };
+  } catch (error) {
+    await dispatcher?.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function testGenericProvider(id, { fetchImpl = undiciFetch, lookup = lookupHost, timeoutMs = 10_000 } = {}) {
+  const { response, endpoint, dispatcher } = await requestGenericProvider(id, "/models", {
+    fetchImpl,
+    lookup,
+    timeoutMs,
+    method: "GET",
+    headers: { Accept: "application/json" },
+  });
+  try {
+    await boundedResponseBody(response);
+    return {
+      ok: response.ok,
+      status: response.status,
+      endpoint,
+      ...(response.ok ? { message: "Provider endpoint is reachable." } : { message: "Provider endpoint returned an error." }),
+    };
+  } finally {
+    await dispatcher?.close().catch(() => undefined);
+  }
 }
 
 function parseHeader(raw) {

--- a/src/generic-providers.mjs
+++ b/src/generic-providers.mjs
@@ -1,0 +1,440 @@
+import { promises as dns } from "node:dns";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { PROVIDERS } from "./model-registry.mjs";
+import { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
+
+export { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
+import { writePrivateJson } from "./file-security.mjs";
+
+// Generic providers are deliberately kept in a separate user-owned document.
+// The checked-in registry remains the authority for native and curated models;
+// P06 can merge this descriptor into that registry after capability discovery.
+// Keeping the two documents separate also means a checkout update cannot erase
+// an operator's endpoint definitions.
+export const GENERIC_PROVIDER_SCHEMA_VERSION = 1;
+export const GENERIC_PROVIDER_ADAPTERS = Object.freeze([
+  "openai-chat",
+  "openai-responses",
+  "openai-completions",
+]);
+
+// These names are either hop-by-hop transport headers or common secret
+// carriers. A generic provider may declare static routing metadata, but P02's
+// credential references must be used for authentication headers later.
+const FORBIDDEN_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authorization",
+  "x-api-key",
+  "api-key",
+  "cookie",
+  "set-cookie",
+  "host",
+  "content-length",
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+const MAX_HEADERS = 64;
+const MAX_HEADER_VALUE_LENGTH = 4_096;
+const MAX_DESCRIPTION_LENGTH = 240;
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function normalizeBaseUrl(value) {
+  return text(value).replace(/\/+$/, "");
+}
+
+function isIpv4(value) {
+  const parts = value.split(".");
+  return parts.length === 4 && parts.every((part) => /^\d+$/.test(part) && Number(part) <= 255);
+}
+
+function isPrivateIpv4(value) {
+  if (!isIpv4(value)) return false;
+  const [a, b] = value.split(".").map(Number);
+  return (
+    a === 10 ||
+    a === 127 ||
+    a === 0 ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
+  );
+}
+
+function isPrivateHostname(hostname) {
+  const host = String(hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
+  if (!host) return false;
+  if (isPrivateIpv4(host)) return true;
+  if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) {
+    return true;
+  }
+  // IPv6 loopback, link-local and unique-local ranges. This intentionally
+  // does not try to parse every IPv6 spelling; DNS lookup in testGenericProvider
+  // catches resolved private addresses before a request is sent.
+  return (
+    host === "::1" ||
+    host.startsWith("fc") ||
+    host.startsWith("fd") ||
+    host.startsWith("fe80:") ||
+    host === "0:0:0:0:0:0:0:1"
+  );
+}
+
+function validateEndpoint(urlValue, allowPrivate) {
+  const baseUrl = normalizeBaseUrl(urlValue);
+  let parsed;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error("baseUrl must be an absolute HTTP(S) URL.");
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("baseUrl must use http or https.");
+  }
+  if (!parsed.hostname || parsed.username || parsed.password) {
+    throw new Error("baseUrl must not contain credentials and must include a hostname.");
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error("baseUrl must not contain a query string or fragment.");
+  }
+  const privateHost = isPrivateHostname(parsed.hostname);
+  if (parsed.protocol === "http:" && (!allowPrivate || !privateHost)) {
+    throw new Error("Plain HTTP endpoints must be private and require allowPrivate=true.");
+  }
+  if (privateHost && !allowPrivate) {
+    throw new Error("Private or loopback endpoints require allowPrivate=true.");
+  }
+  return { baseUrl, privateHost };
+}
+
+function validateHeaders(raw) {
+  if (raw === undefined) return {};
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("headers must be an object of static header values.");
+  }
+  const entries = Object.entries(raw);
+  if (entries.length > MAX_HEADERS) throw new Error(`headers may contain at most ${MAX_HEADERS} entries.`);
+  const headers = {};
+  for (const [nameValue, valueValue] of entries) {
+    const name = text(nameValue);
+    const lower = name.toLowerCase();
+    const value = typeof valueValue === "string" ? valueValue : "";
+    if (!HEADER_NAME_PATTERN.test(name)) throw new Error(`Invalid header name: ${nameValue}`);
+    if (FORBIDDEN_HEADER_NAMES.has(lower)) {
+      throw new Error(`Header ${name} is reserved for credential or transport handling.`);
+    }
+    if (!value || value.length > MAX_HEADER_VALUE_LENGTH || /[\r\n]/.test(value)) {
+      throw new Error(`Header ${name} has an invalid value.`);
+    }
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function validateCredentialRef(value) {
+  if (value === undefined || value === null || value === "") return undefined;
+  const ref = text(value);
+  if (!/^cred_[a-zA-Z0-9][a-zA-Z0-9._:-]{2,127}$/.test(ref)) {
+    throw new Error("credentialRef must be an opaque id beginning with cred_.");
+  }
+  return ref;
+}
+
+function validateProvider(input, { existingId } = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("A generic provider must be an object.");
+  }
+  const id = text(input.id);
+  if (!ID_PATTERN.test(id)) throw new Error("Provider id must match [a-z0-9][a-z0-9-]*.");
+  if (existingId !== undefined && id !== existingId) {
+    throw new Error("Provider id cannot be changed; remove and add a new provider instead.");
+  }
+  if (PROVIDERS.has(id)) throw new Error(`Provider id ${id} is already used by the built-in registry.`);
+  const displayName = text(input.displayName);
+  if (!displayName || displayName.length > 120) {
+    throw new Error("displayName must be a non-empty string of at most 120 characters.");
+  }
+  const adapter = text(input.adapter) || "openai-chat";
+  if (!GENERIC_PROVIDER_ADAPTERS.includes(adapter)) {
+    throw new Error(`adapter must be one of: ${GENERIC_PROVIDER_ADAPTERS.join(", ")}.`);
+  }
+  const allowPrivate = input.allowPrivate === undefined ? false : input.allowPrivate;
+  if (typeof allowPrivate !== "boolean") throw new Error("allowPrivate must be a boolean.");
+  const { baseUrl } = validateEndpoint(input.baseUrl, allowPrivate);
+  const headers = validateHeaders(input.headers);
+  const credentialRef = validateCredentialRef(input.credentialRef);
+  const description = input.description === undefined ? undefined : text(input.description);
+  if (description !== undefined && description.length > MAX_DESCRIPTION_LENGTH) {
+    throw new Error(`description must be at most ${MAX_DESCRIPTION_LENGTH} characters.`);
+  }
+  const enabled = input.enabled === undefined ? true : input.enabled;
+  if (typeof enabled !== "boolean") throw new Error("enabled must be a boolean.");
+  return {
+    id,
+    displayName,
+    ...(description ? { description } : {}),
+    baseUrl,
+    adapter,
+    headers,
+    ...(credentialRef ? { credentialRef } : {}),
+    allowPrivate,
+    enabled,
+  };
+}
+
+function parseDocument(payload) {
+  if (payload === undefined) return { version: GENERIC_PROVIDER_SCHEMA_VERSION, providers: [] };
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error(`Invalid generic provider state ${GENERIC_PROVIDERS_PATH}: expected an object.`);
+  }
+  if (payload.version !== GENERIC_PROVIDER_SCHEMA_VERSION || !Array.isArray(payload.providers)) {
+    throw new Error(
+      `Invalid generic provider state ${GENERIC_PROVIDERS_PATH}: version must be ${GENERIC_PROVIDER_SCHEMA_VERSION} and providers must be an array.`,
+    );
+  }
+  const providers = [];
+  const seen = new Set();
+  for (const entry of payload.providers) {
+    const provider = validateProvider(entry);
+    if (seen.has(provider.id)) throw new Error(`Duplicate generic provider id ${provider.id}.`);
+    seen.add(provider.id);
+    providers.push(provider);
+  }
+  return { version: GENERIC_PROVIDER_SCHEMA_VERSION, providers };
+}
+
+export function readGenericProviders() {
+  if (!existsSync(GENERIC_PROVIDERS_PATH)) return [];
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(GENERIC_PROVIDERS_PATH, "utf8"));
+  } catch (error) {
+    throw new Error(`Could not read generic provider state: ${errorMessage(error)}`);
+  }
+  return parseDocument(payload).providers;
+}
+
+export function redactGenericProvider(provider) {
+  const value = validateProvider(provider, { existingId: provider.id });
+  return {
+    ...value,
+    headers: Object.fromEntries(Object.keys(value.headers).map((name) => [name, "[redacted]"])),
+  };
+}
+
+export function listGenericProviders({ redacted = true } = {}) {
+  const providers = readGenericProviders();
+  return providers.map((provider) => redacted ? redactGenericProvider(provider) : provider);
+}
+
+export function getGenericProvider(id, { redacted = false } = {}) {
+  const provider = readGenericProviders().find((entry) => entry.id === text(id));
+  if (!provider) throw new Error(`Unknown generic provider: ${id}`);
+  return redacted ? redactGenericProvider(provider) : provider;
+}
+
+function saveProviders(providers) {
+  writePrivateJson(
+    GENERIC_PROVIDERS_PATH,
+    { version: GENERIC_PROVIDER_SCHEMA_VERSION, providers },
+    { directoryMode: 0o700 },
+  );
+}
+
+function mutateProviders(mutator) {
+  const current = readGenericProviders();
+  const next = mutator(current.map((provider) => ({ ...provider, headers: { ...provider.headers } })));
+  if (!Array.isArray(next)) throw new Error("Generic provider mutation returned an invalid list.");
+  const validated = parseDocument({ version: GENERIC_PROVIDER_SCHEMA_VERSION, providers: next }).providers;
+  saveProviders(validated);
+  return validated;
+}
+
+export function addGenericProvider(input) {
+  const provider = validateProvider(input);
+  const current = readGenericProviders();
+  if (current.some((entry) => entry.id === provider.id)) {
+    throw new Error(`Generic provider ${provider.id} already exists.`);
+  }
+  mutateProviders((providers) => [...providers, provider]);
+  return redactGenericProvider(provider);
+}
+
+export function updateGenericProvider(id, patch) {
+  const current = readGenericProviders();
+  const existing = current.find((entry) => entry.id === text(id));
+  if (!existing) throw new Error(`Unknown generic provider: ${id}`);
+  const next = validateProvider({ ...existing, ...patch, id: existing.id }, { existingId: existing.id });
+  mutateProviders((providers) => providers.map((entry) => entry.id === existing.id ? next : entry));
+  return redactGenericProvider(next);
+}
+
+export function removeGenericProvider(id) {
+  const providerId = text(id);
+  const current = readGenericProviders();
+  if (!current.some((entry) => entry.id === providerId)) throw new Error(`Unknown generic provider: ${id}`);
+  const next = mutateProviders((providers) => providers.filter((entry) => entry.id !== providerId));
+  return { removed: providerId, remaining: next.length };
+}
+
+export function setGenericProviderEnabled(id, enabled) {
+  if (typeof enabled !== "boolean") throw new Error("enabled must be a boolean.");
+  return updateGenericProvider(id, { enabled });
+}
+
+// This descriptor is intentionally not inserted into PROVIDERS yet. P05/P06
+// can map `adapter` to a wire protocol and merge it with discovered models,
+// while native GPT catalog ownership stays untouched in the meantime.
+export function genericProviderDescriptor(providerOrId) {
+  const provider = typeof providerOrId === "string"
+    ? getGenericProvider(providerOrId)
+    : validateProvider(providerOrId, { existingId: providerOrId.id });
+  return {
+    id: provider.id,
+    displayName: provider.displayName,
+    kind: "openai-compatible",
+    ownedBy: provider.id,
+    baseUrl: provider.baseUrl,
+    adapter: provider.adapter,
+    protocol: provider.adapter === "openai-responses" ? "openai-responses" : "openai",
+    headers: { ...provider.headers },
+    allowPrivate: provider.allowPrivate,
+    enabled: provider.enabled,
+    ...(provider.credentialRef ? { credentialRef: provider.credentialRef } : {}),
+    generic: true,
+  };
+}
+
+async function lookupHost(hostname) {
+  try {
+    const addresses = await dns.lookup(hostname, { all: true, verbatim: true });
+    return addresses.map((entry) => entry.address);
+  } catch (error) {
+    throw new Error(`Could not resolve provider host ${hostname}: ${errorMessage(error)}`);
+  }
+}
+
+export async function testGenericProvider(id, { fetchImpl = globalThis.fetch, timeoutMs = 10_000 } = {}) {
+  const provider = getGenericProvider(id);
+  const endpoint = new URL(provider.baseUrl);
+  const resolved = await lookupHost(endpoint.hostname);
+  if (!provider.allowPrivate && resolved.some(isPrivateHostname)) {
+    throw new Error("Provider host resolved to a private or loopback address; set allowPrivate=true explicitly.");
+  }
+  const response = await fetchImpl(`${provider.baseUrl}/models`, {
+    method: "GET",
+    headers: { Accept: "application/json", ...provider.headers },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  return {
+    ok: response.ok,
+    status: response.status,
+    endpoint: `${provider.baseUrl}/models`,
+    ...(response.ok ? { message: "Provider endpoint is reachable." } : { message: "Provider endpoint returned an error." }),
+  };
+}
+
+function parseHeader(raw) {
+  const separator = String(raw).indexOf("=");
+  if (separator < 1) throw new Error("Headers must use Name=Value syntax.");
+  return [String(raw).slice(0, separator), String(raw).slice(separator + 1)];
+}
+
+function optionValue(args, name) {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function optionValues(args, name) {
+  const values = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === name) values.push(args[index + 1]);
+  }
+  return values;
+}
+
+function cliUsage() {
+  throw new Error(
+    "Usage: providers generic list [--json] | add ID --name NAME --base-url URL " +
+      "[--adapter openai-chat|openai-responses|openai-completions] [--header Name=Value] " +
+      "[--credential-ref cred_ID] [--description TEXT] [--allow-private] | edit ID [options] | show ID [--json] | " +
+      "enable ID | disable ID | remove ID | test ID [--json]",
+  );
+}
+
+export async function runGenericProviderCli(args = process.argv.slice(3), { output = process.stdout } = {}) {
+  const action = args[0] || "list";
+  const json = args.includes("--json");
+  const print = (value) => output.write(`${json ? JSON.stringify(value, null, 2) : value}\n`);
+  if (action === "list") {
+    const providers = listGenericProviders({ redacted: true });
+    print(json ? { providers } : providers.map((provider) =>
+      `${provider.enabled ? "SHOW" : "HIDE"} ${provider.id.padEnd(20)} ${provider.displayName} (${provider.adapter})`,
+    ).join("\n"));
+    return providers;
+  }
+  if (["add", "edit"].includes(action)) {
+    const id = text(args[1]);
+    if (!id) cliUsage();
+    const patch = { id };
+    for (const [flag, field] of [
+      ["--name", "displayName"],
+      ["--base-url", "baseUrl"],
+      ["--adapter", "adapter"],
+      ["--credential-ref", "credentialRef"],
+      ["--description", "description"],
+    ]) {
+      const value = optionValue(args, flag);
+      if (value !== undefined) patch[field] = value;
+    }
+    if (args.includes("--allow-private")) patch.allowPrivate = true;
+    if (args.includes("--public-only")) patch.allowPrivate = false;
+    const headerValues = optionValues(args, "--header").filter((value) => value !== undefined);
+    if (headerValues.length) patch.headers = Object.fromEntries(headerValues.map(parseHeader));
+    const provider = action === "add" ? addGenericProvider(patch) : updateGenericProvider(id, patch);
+    print(json ? { provider } : `${action === "add" ? "Added" : "Updated"} generic provider ${provider.id}.`);
+    return provider;
+  }
+  if (action === "show") {
+    const provider = getGenericProvider(args[1], { redacted: true });
+    print(json ? { provider } : JSON.stringify(provider, null, 2));
+    return provider;
+  }
+  if (action === "remove") {
+    const result = removeGenericProvider(args[1]);
+    print(json ? result : `Removed generic provider ${result.removed}.`);
+    return result;
+  }
+  if (action === "enable" || action === "disable") {
+    const provider = setGenericProviderEnabled(args[1], action === "enable");
+    print(json ? { provider } : `${provider.id} is now ${provider.enabled ? "enabled" : "disabled"}.`);
+    return provider;
+  }
+  if (action === "test") {
+    const result = await testGenericProvider(args[1]);
+    print(json ? result : `${result.message} HTTP ${result.status}.`);
+    return result;
+  }
+  cliUsage();
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runGenericProviderCli(process.argv.slice(2)).catch((error) => {
+    console.error(errorMessage(error));
+    process.exitCode = 1;
+  });
+}

--- a/src/generic-providers.mjs
+++ b/src/generic-providers.mjs
@@ -93,10 +93,42 @@ function isPrivateAddress(value) {
   const family = isIP(address);
   if (family === 4) return isPrivateIpv4(address);
   if (family !== 6) return false;
-  if (address === "::1" || address === "0:0:0:0:0:0:0:1") return true;
-  if (address.startsWith("fc") || address.startsWith("fd") || address.startsWith("fe80:")) return true;
-  const mapped = address.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
-  return Boolean(mapped && isPrivateIpv4(mapped[1]));
+  const withoutZone = address.split("%")[0];
+  const parts = withoutZone.split("::");
+  if (parts.length > 2) return false;
+  const expand = (segment) => {
+    if (!segment) return [];
+    const values = segment.split(":");
+    const result = [];
+    for (const valuePart of values) {
+      if (valuePart.includes(".")) {
+        if (!isIpv4(valuePart)) return undefined;
+        const [first, second, third, fourth] = valuePart.split(".").map(Number);
+        result.push(((first << 8) | second).toString(16), ((third << 8) | fourth).toString(16));
+      } else if (/^[0-9a-f]{1,4}$/.test(valuePart)) {
+        result.push(valuePart);
+      } else {
+        return undefined;
+      }
+    }
+    return result;
+  };
+  const left = expand(parts[0]);
+  const right = expand(parts[1] || "");
+  if (!left || !right) return false;
+  const hextets = parts.length === 2
+    ? [...left, ...Array(8 - left.length - right.length).fill("0"), ...right]
+    : left;
+  if (hextets.length !== 8) return false;
+  const first = Number.parseInt(hextets[0], 16);
+  const high = hextets.map((part) => BigInt(`0x${part}`)).reduce((valuePart, part) => (valuePart << 16n) | part, 0n);
+  if (high === 0n || high === 1n) return true;
+  if ((high >> 32n) === 0xffffn) {
+    const mapped = Number(high & 0xffffffffn);
+    const mappedAddress = `${mapped >>> 24}.${(mapped >>> 16) & 255}.${(mapped >>> 8) & 255}.${mapped & 255}`;
+    return isPrivateIpv4(mappedAddress);
+  }
+  return (first & 0xfe00) === 0xfc00 || (first & 0xffc0) === 0xfe80 || (first & 0xff00) === 0xff00;
 }
 
 function isPrivateHostname(hostname) {
@@ -406,6 +438,7 @@ function credentialSecret(provider) {
   const entry = readProviderCredentialStore().credentials.find((candidate) => candidate.id === provider.credentialRef);
   if (!entry || entry.state !== "active") return undefined;
   if (entry.providerId !== provider.id) return undefined;
+  if (entry.kind !== "api_key") return undefined;
   const reference = entry.secretRef;
   if (reference.type === "environment") return process.env[reference.name]?.trim() || undefined;
   if (reference.type === "keychain") {
@@ -502,6 +535,9 @@ export async function requestGenericProvider(
   const requestHeaders = safeHeaderEntries(init.headers);
   const headers = { ...provider.headers, ...requestHeaders };
   const secret = credentialSecret(provider);
+  if (provider.credentialRef && !secret) {
+    throw new Error(`Credential ${provider.credentialRef} is unavailable for generic provider ${provider.id}.`);
+  }
   if (secret) headers.Authorization = `Bearer ${secret}`;
   const useDispatcher = fetchImpl === undiciFetch;
   const dispatcher = useDispatcher ? createDestinationDispatcher(endpoint, provider, timeoutMs) : undefined;

--- a/src/generic-providers.mjs
+++ b/src/generic-providers.mjs
@@ -1,15 +1,15 @@
 import { promises as dns } from "node:dns";
-import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { isIP } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Agent, fetch as undiciFetch } from "undici";
 
-import { PROVIDERS } from "./model-registry.mjs";
+import { normalizeGenericProviderId } from "./generic-provider-identity.mjs";
 import { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
 import { withAtomicStateLock } from "./atomic-state-lock.mjs";
 import { readProviderCredentialStore } from "./provider-credential-store.mjs";
+import { resolveGenericProviderCredentialReference } from "./provider-credentials.mjs";
 
 export { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
 import { writePrivateJson } from "./file-security.mjs";
@@ -44,7 +44,6 @@ const FORBIDDEN_HEADER_NAMES = new Set([
   "upgrade",
 ]);
 
-const ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
 const MAX_HEADERS = 64;
 const MAX_HEADER_VALUE_LENGTH = 4_096;
@@ -208,12 +207,10 @@ function validateProvider(input, { existingId } = {}) {
   if (!input || typeof input !== "object" || Array.isArray(input)) {
     throw new Error("A generic provider must be an object.");
   }
-  const id = text(input.id);
-  if (!ID_PATTERN.test(id)) throw new Error("Provider id must match [a-z0-9][a-z0-9-]*.");
+  const id = normalizeGenericProviderId(input.id);
   if (existingId !== undefined && id !== existingId) {
     throw new Error("Provider id cannot be changed; remove and add a new provider instead.");
   }
-  if (PROVIDERS.has(id)) throw new Error(`Provider id ${id} is already used by the built-in registry.`);
   const displayName = text(input.displayName);
   if (!displayName || displayName.length > 120) {
     throw new Error("displayName must be a non-empty string of at most 120 characters.");
@@ -400,6 +397,10 @@ function destinationUrl(provider, requestPath) {
   if (target.origin !== endpoint.origin || target.username || target.password) {
     throw new Error("Generic provider request cannot change the configured origin.");
   }
+  const basePath = endpoint.pathname.endsWith("/") ? endpoint.pathname : `${endpoint.pathname}/`;
+  if (!target.pathname.startsWith(basePath)) {
+    throw new Error("Generic provider request cannot escape the configured baseUrl path.");
+  }
   return target;
 }
 
@@ -437,27 +438,10 @@ function credentialSecret(provider) {
   if (!provider.credentialRef) return undefined;
   const entry = readProviderCredentialStore().credentials.find((candidate) => candidate.id === provider.credentialRef);
   if (!entry || entry.state !== "active") return undefined;
+  if (entry.providerType !== "generic") return undefined;
   if (entry.providerId !== provider.id) return undefined;
   if (entry.kind !== "api_key") return undefined;
-  const reference = entry.secretRef;
-  if (reference.type === "environment") return process.env[reference.name]?.trim() || undefined;
-  if (reference.type === "keychain") {
-    if (process.platform !== "darwin") return undefined;
-    try {
-      const value = execFileSync(
-        "/usr/bin/security",
-        ["find-generic-password", "-s", reference.service, "-a", "default", "-w"],
-        { encoding: "utf8", timeout: 2_000, stdio: ["ignore", "pipe", "ignore"] },
-      ).trim();
-      return value || undefined;
-    } catch {
-      return undefined;
-    }
-  }
-  // provider-file and oauth-session references belong to provider-specific
-  // credential/session code. A generic descriptor cannot turn them into a raw
-  // bearer token, so fail closed until a provider adapter owns that lookup.
-  return undefined;
+  return resolveGenericProviderCredentialReference(provider.id, entry.secretRef)?.value;
 }
 
 function requestSignal(signal, timeoutMs) {

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -146,6 +146,7 @@ export const PROVIDER_CREDENTIAL_MIGRATIONS_DIR =
 export const GENERIC_PROVIDERS_PATH =
   process.env.MODEL_ROUTER_GENERIC_PROVIDERS ||
   path.join(STATE_DIR, "generic-providers.json");
+export const GENERIC_PROVIDER_CREDENTIALS_DIR = path.join(STATE_DIR, "generic-provider-credentials");
 export const SUPPORT_DIR = path.join(STATE_DIR, "support");
 export const LOG_PATH = path.join(STATE_DIR, "router.log");
 export const SERVICE_PROCESS_STATE_PATH = path.join(STATE_DIR, "service-process.json");

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -141,6 +141,11 @@ export const PROVIDER_CREDENTIAL_STORE_PATH =
 export const PROVIDER_CREDENTIAL_MIGRATIONS_DIR =
   process.env.MODEL_ROUTER_PROVIDER_CREDENTIAL_MIGRATIONS ||
   path.join(MIGRATIONS_DIR, "provider-credentials");
+// User-defined OpenAI-compatible provider descriptors. The document contains
+// no raw credentials; credentialRef values point to the provider-neutral store.
+export const GENERIC_PROVIDERS_PATH =
+  process.env.MODEL_ROUTER_GENERIC_PROVIDERS ||
+  path.join(STATE_DIR, "generic-providers.json");
 export const SUPPORT_DIR = path.join(STATE_DIR, "support");
 export const LOG_PATH = path.join(STATE_DIR, "router.log");
 export const SERVICE_PROCESS_STATE_PATH = path.join(STATE_DIR, "service-process.json");

--- a/src/provider-credential-store.mjs
+++ b/src/provider-credential-store.mjs
@@ -14,6 +14,7 @@ import path from "node:path";
 import { withAtomicStateLock } from "./atomic-state-lock.mjs";
 import { credentialPaths } from "./provider-credentials.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
+import { normalizeGenericProviderId } from "./generic-provider-identity.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import {
   CODEX_HOME,
@@ -45,6 +46,7 @@ const LEGACY_STORE_KEYS = new Set(["version", "credentials"]);
 const CREDENTIAL_KEYS = new Set([
   "id",
   "providerId",
+  "providerType",
   "kind",
   "secretRef",
   "state",
@@ -55,6 +57,9 @@ const CREDENTIAL_KEYS = new Set([
 ]);
 const ACCOUNT_KEYS = new Set(["alias", "plan"]);
 const SECRET_REF_KEYS = new Set(["type", "providerId", "target", "service", "name"]);
+const CREDENTIAL_INPUT_KEYS = new Set([
+  "providerId", "kind", "secretRef", "label", "account", "id", "state", "createdAt", "updatedAt",
+]);
 
 function sensitiveKey(key) {
   // `secretRef` is a safe descriptor, not a secret-bearing field.
@@ -246,7 +251,7 @@ function assertNoSecretFields(value, context = "credential metadata") {
   }
 }
 
-function normalizeSecretRef(value, providerId, { legacy = false } = {}) {
+function normalizeSecretRef(value, providerId, { legacy = false, providerType } = {}) {
   plainObject(value, "secretRef");
   assertNoSecretFields(value, "secretRef");
   assertAllowedKeys(value, SECRET_REF_KEYS, "secretRef");
@@ -256,7 +261,9 @@ function normalizeSecretRef(value, providerId, { legacy = false } = {}) {
   }
   const referenceProviderId = value.providerId === undefined
     ? providerId
-    : validateProviderId(value.providerId);
+    : providerType === "generic"
+      ? normalizeGenericProviderId(value.providerId)
+      : validateProviderId(value.providerId);
   if (referenceProviderId !== providerId) {
     throw new Error("secretRef.providerId must match providerId.");
   }
@@ -267,6 +274,15 @@ function normalizeSecretRef(value, providerId, { legacy = false } = {}) {
   );
   if (target !== ROUTER_PLANE_TARGET) throw new Error("secretRef.target does not match this router plane.");
   const normalized = { type, providerId: referenceProviderId, target };
+  if (providerType === "generic") {
+    if (type !== "provider-file") {
+      throw new Error("Generic providers support only protected provider-file credential references.");
+    }
+    if (value.service !== undefined || value.name !== undefined) {
+      throw new Error("Generic provider-file secretRef cannot include service or name.");
+    }
+    return normalized;
+  }
   const provider = PROVIDERS.get(referenceProviderId);
   if (!provider?.credential) throw new Error(`Provider ${referenceProviderId} has no credential policy.`);
   if (type === "keychain") {
@@ -298,7 +314,18 @@ function normalizeCredential(raw, { legacy = false } = {}) {
   plainObject(raw, "credential");
   assertNoSecretFields(raw, "credential metadata");
   assertAllowedKeys(raw, CREDENTIAL_KEYS, "credential");
-  const providerId = validateProviderId(raw.providerId);
+  const providerType = raw.providerType === undefined
+    ? undefined
+    : normalizeText(raw.providerType, "providerType", { max: 20, required: true });
+  if (providerType !== undefined && providerType !== "generic") {
+    throw new Error(`Unsupported providerType: ${providerType}`);
+  }
+  if (legacy && providerType !== undefined) {
+    throw new Error("Legacy credentials cannot declare providerType.");
+  }
+  const providerId = providerType === "generic"
+    ? normalizeGenericProviderId(raw.providerId)
+    : validateProviderId(raw.providerId);
   const kind = normalizeText(raw.kind || (legacy ? "api_key" : undefined), "credential kind", {
     max: 20,
     required: true,
@@ -306,8 +333,11 @@ function normalizeCredential(raw, { legacy = false } = {}) {
   if (!PROVIDER_CREDENTIAL_KINDS.includes(kind)) {
     throw new Error(`Unsupported credential kind: ${kind}`);
   }
+  if (providerType === "generic" && kind !== "api_key") {
+    throw new Error("Generic providers support only api_key credentials.");
+  }
   const id = validateCredentialId(raw.id);
-  const secretRef = normalizeSecretRef(raw.secretRef, providerId, { legacy });
+  const secretRef = normalizeSecretRef(raw.secretRef, providerId, { legacy, providerType });
   const state = normalizeText(raw.state || "active", "credential state", { max: 20, required: true });
   if (!["active", "paused", "revoked"].includes(state)) {
     throw new Error(`Unsupported credential state: ${state}`);
@@ -317,6 +347,7 @@ function normalizeCredential(raw, { legacy = false } = {}) {
   const result = {
     id,
     providerId,
+    ...(providerType ? { providerType } : {}),
     kind,
     secretRef,
     state,
@@ -416,12 +447,10 @@ export function writeProviderCredentialStore(store, filePath = PROVIDER_CREDENTI
   return normalized;
 }
 
-export function createCredentialReference(input = {}) {
+function createCredentialReferenceForType(input = {}, providerType) {
   assertNoSecretFields(input, "credential metadata");
   plainObject(input, "credential metadata");
-  assertAllowedKeys(input, new Set([
-    "providerId", "kind", "secretRef", "label", "account", "id", "state", "createdAt", "updatedAt",
-  ]), "credential metadata");
+  assertAllowedKeys(input, CREDENTIAL_INPUT_KEYS, "credential metadata");
   const {
     providerId,
     kind,
@@ -433,14 +462,19 @@ export function createCredentialReference(input = {}) {
     createdAt,
     updatedAt,
   } = input;
-  const normalizedProviderId = validateProviderId(providerId);
+  const normalizedProviderId = providerType === "generic"
+    ? normalizeGenericProviderId(providerId)
+    : validateProviderId(providerId);
   const credential = normalizeCredential({
     id: id || generatedCredentialId(normalizedProviderId, kind),
     providerId: normalizedProviderId,
-    kind,
+    ...(providerType ? { providerType } : {}),
+    kind: providerType === "generic" ? (kind || "api_key") : kind,
     secretRef: secretRef && typeof secretRef === "object"
       ? { ...secretRef, target: secretRef.target ?? ROUTER_PLANE_TARGET }
-      : secretRef,
+      : providerType === "generic"
+        ? { type: "provider-file", providerId: normalizedProviderId, target: ROUTER_PLANE_TARGET }
+        : secretRef,
     label,
     account,
     state,
@@ -450,17 +484,33 @@ export function createCredentialReference(input = {}) {
   return credential;
 }
 
-export function addCredentialReference(input, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
+export function createCredentialReference(input = {}) {
+  return createCredentialReferenceForType(input);
+}
+
+export function createGenericProviderCredentialReference(input = {}) {
+  return createCredentialReferenceForType(input, "generic");
+}
+
+function addCredentialReferenceWith(input, filePath, create) {
   const target = managedStatePath(filePath, "credential store path");
   return withAtomicStateLock(target, () => {
     const store = readProviderCredentialStoreStrict(target);
-    const credential = createCredentialReference(input);
+    const credential = create(input);
     if (store.credentials.some((entry) => entry.id === credential.id)) {
       throw new Error(`Credential id already exists: ${credential.id}`);
     }
     store.credentials.push(credential);
     return writeProviderCredentialStore(store, target).credentials.at(-1);
   });
+}
+
+export function addCredentialReference(input, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
+  return addCredentialReferenceWith(input, filePath, createCredentialReference);
+}
+
+export function addGenericProviderCredentialReference(input, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
+  return addCredentialReferenceWith(input, filePath, createGenericProviderCredentialReference);
 }
 
 export function removeCredentialReference(id, filePath = PROVIDER_CREDENTIAL_STORE_PATH) {
@@ -486,6 +536,7 @@ export function sanitizeCredentialStatus(entry) {
   return {
     id: credential.id,
     providerId: credential.providerId,
+    ...(credential.providerType ? { providerType: credential.providerType } : {}),
     kind: credential.kind,
     state: credential.state,
     label: credential.label || null,

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -14,7 +14,14 @@ import path from "node:path";
 
 import { discoveryDisabled } from "./discovery-mode.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
-import { LEGACY_STATE_DIRS, ROUTER_PLANE_TARGET, STATE_DIR, TARGET } from "./paths.mjs";
+import { normalizeGenericProviderId } from "./generic-provider-identity.mjs";
+import {
+  GENERIC_PROVIDER_CREDENTIALS_DIR,
+  LEGACY_STATE_DIRS,
+  ROUTER_PLANE_TARGET,
+  STATE_DIR,
+  TARGET,
+} from "./paths.mjs";
 import { targetCli } from "./target-integration.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import {
@@ -139,6 +146,24 @@ function resolvedCredential(provider, value, source, persistent) {
 
 function canonicalProviderId(provider) {
   return provider.variantOf || provider.id;
+}
+
+function genericCredentialProvider(providerId) {
+  const id = normalizeGenericProviderId(providerId);
+  return {
+    id,
+    kind: "openai-compatible",
+    credential: {
+      file: path.relative(STATE_DIR, path.join(GENERIC_PROVIDER_CREDENTIALS_DIR, `${id}.key`)),
+      label: "API key",
+      environment: [],
+      keychainServices: [],
+    },
+  };
+}
+
+export function genericProviderCredentialPath(providerId) {
+  return primaryCredentialPath(genericCredentialProvider(providerId));
 }
 
 function configuredProviderFileCredential(provider) {
@@ -291,6 +316,34 @@ export function resolveProviderCredentialReference(providerOrId, secretRef) {
   return undefined;
 }
 
+/**
+ * Resolve a generic provider's deliberately narrow protected-file reference.
+ * Built-in provider resolution remains registry-bound above; this separate
+ * entry point cannot name environment variables, Keychain services, or paths.
+ */
+export function resolveGenericProviderCredentialReference(providerId, secretRef) {
+  let provider;
+  try {
+    provider = genericCredentialProvider(providerId);
+  } catch {
+    return undefined;
+  }
+  if (!secretRef || typeof secretRef !== "object" || Array.isArray(secretRef)) return undefined;
+  const referenceKeys = new Set(["type", "providerId", "target", "service", "name"]);
+  if (Object.keys(secretRef).some((key) => !referenceKeys.has(key))) return undefined;
+  if (
+    secretRef.type !== "provider-file" ||
+    secretRef.providerId !== provider.id ||
+    secretRef.target !== ROUTER_PLANE_TARGET ||
+    secretRef.service !== undefined ||
+    secretRef.name !== undefined ||
+    discoveryDisabled()
+  ) {
+    return undefined;
+  }
+  return configuredProviderFileCredential(provider);
+}
+
 export function credentialSetupHint(provider) {
   if (provider.authMode === "anonymous") return "No key needed; free models are rate limited by the provider.";
   if (provider.authMode === "per-model") return "No key needed here; each model names its own endpoint.";
@@ -328,6 +381,8 @@ export function writeProviderCredential(providerOrId, value) {
   mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
   chmodSync(STATE_DIR, 0o700);
   const target = primaryCredentialPath(provider);
+  mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+  chmodSync(path.dirname(target), 0o700);
   const temporary = `${target}.tmp.${process.pid}`;
   writeFileSync(temporary, `${key}\n`, { encoding: "utf8", mode: 0o600 });
   try {
@@ -340,6 +395,10 @@ export function writeProviderCredential(providerOrId, value) {
   }
   resetKeychainCache();
   return target;
+}
+
+export function writeGenericProviderCredential(providerId, value) {
+  return writeProviderCredential(genericCredentialProvider(providerId), value);
 }
 
 export function removeProviderCredential(providerOrId) {
@@ -356,6 +415,10 @@ export function removeProviderCredential(providerOrId) {
   // has to come from a fresh look.
   resetKeychainCache();
   return removed;
+}
+
+export function removeGenericProviderCredential(providerId) {
+  return removeProviderCredential(genericCredentialProvider(providerId));
 }
 
 export function credentialFileMode(providerOrId) {

--- a/src/providers.mjs
+++ b/src/providers.mjs
@@ -24,6 +24,7 @@ import {
   targetRestartHint,
 } from "./target-integration.mjs";
 import { withModelOverlayLock } from "./model-overlay-lock.mjs";
+import { runGenericProviderCli } from "./generic-providers.mjs";
 
 function providersCommand(action, providerId) {
   return process.platform === "win32"
@@ -69,6 +70,10 @@ function list() {
 async function main() {
   const command = process.argv[2] || "list";
   const providerId = process.argv[3];
+  if (command === "generic") {
+    await runGenericProviderCli(process.argv.slice(3));
+    return;
+  }
   if (command === "list") {
     const providers = list();
     if (process.argv.includes("--json")) {
@@ -110,7 +115,9 @@ async function main() {
     return;
   }
   if (!provider || !["enable", "disable"].includes(command)) {
-    throw new Error("Usage: providers [list [--json]|login antigravity-oauth|enable ID|disable ID]");
+    throw new Error(
+      "Usage: providers [list [--json]|login antigravity-oauth|enable ID|disable ID|generic ...]",
+    );
   }
   if (command === "enable" && !configured(provider)) {
     const keySetup = `run \`${targetCli(`provider-key ${provider.id} set`)}\``;

--- a/src/support-bundle.mjs
+++ b/src/support-bundle.mjs
@@ -30,9 +30,13 @@ import {
 import {
   credentialPaths,
   credentialStatus,
+  genericProviderCredentialPath,
 } from "./provider-credentials.mjs";
 import { providerSelectionStatus } from "./provider-selection.mjs";
-import { redactCredentialText } from "./provider-credential-store.mjs";
+import {
+  readProviderCredentialStore,
+  redactCredentialText,
+} from "./provider-credential-store.mjs";
 
 function runJson(script, args = []) {
   const result = spawnSync(
@@ -103,6 +107,14 @@ function knownLocalSecrets() {
     for (const name of provider.credential.environment) {
       const value = process.env[name]?.trim();
       if (value) values.add(value);
+    }
+  }
+  for (const entry of readProviderCredentialStore().credentials) {
+    if (entry.providerType !== "generic") continue;
+    try {
+      files.push(genericProviderCredentialPath(entry.providerId));
+    } catch {
+      // Invalid generic metadata is already ignored by the fail-closed store reader.
     }
   }
   for (const target of files) {

--- a/test/generic-providers.test.mjs
+++ b/test/generic-providers.test.mjs
@@ -21,12 +21,14 @@ const {
   getGenericProvider,
   genericProviderDescriptor,
   listGenericProviders,
+  requestGenericProvider,
   readGenericProviders,
   removeGenericProvider,
   setGenericProviderEnabled,
   testGenericProvider,
   updateGenericProvider,
 } = await import("../src/generic-providers.mjs");
+const { addCredentialReference } = await import("../src/provider-credential-store.mjs");
 test.after(() => rmSync(testRoot, { recursive: true, force: true }));
 
 test("generic provider CRUD is versioned, atomic and redacted", () => {
@@ -60,7 +62,7 @@ test("generic provider CRUD is versioned, atomic and redacted", () => {
     baseUrl: "https://inference.example.test/v1",
     adapter: "openai-chat",
     protocol: "openai",
-    headers: { "X-Organization": "test-org" },
+    headers: { "X-Organization": "[redacted]" },
     allowPrivate: false,
     credentialRef: "cred_local_vllm_01",
     generic: true,
@@ -126,6 +128,68 @@ test("generic provider test checks private resolution and never prints headers",
   assert.equal(calls[0].url, "http://127.0.0.1:8000/v1/models");
   assert.equal(calls[0].options.headers.Accept, "application/json");
   assert.equal(calls[0].options.headers.Authorization, undefined);
+});
+
+test("generic requests revalidate DNS, reject redirects, and bound response reads", async () => {
+  addGenericProvider({
+    id: "remote-boundary",
+    displayName: "Remote boundary",
+    baseUrl: "https://provider.example.test/v1",
+  });
+  await assert.rejects(
+    () => requestGenericProvider("remote-boundary", "/models", {
+      lookup: async () => ["192.168.10.12"],
+      fetchImpl: async () => ({ ok: true, status: 200 }),
+    }),
+    /private or link-local/,
+  );
+  await assert.rejects(
+    () => requestGenericProvider("remote-boundary", "/models", {
+      lookup: async () => ["8.8.8.8"],
+      fetchImpl: async () => ({ ok: false, status: 302, body: { cancel: async () => undefined } }),
+    }),
+    /redirects are disabled/,
+  );
+  await assert.rejects(
+    () => testGenericProvider("remote-boundary", {
+      lookup: async () => ["8.8.8.8"],
+      fetchImpl: async () => ({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-length": "65537" }),
+      }),
+    }),
+    /65536-byte|read limit/,
+  );
+});
+
+test("generic credential references are resolved only at request time", async () => {
+  process.env.GENERIC_PROVIDER_TEST_TOKEN = "TEST_GENERIC_PROVIDER_TOKEN";
+  addCredentialReference({
+    id: "cred_generic_provider_01",
+    providerId: "credential-boundary",
+    kind: "api_key",
+    secretRef: { type: "environment", name: "GENERIC_PROVIDER_TEST_TOKEN" },
+  });
+  addGenericProvider({
+    id: "credential-boundary",
+    displayName: "Credential boundary",
+    baseUrl: "https://provider.example.test/v1",
+    credentialRef: "cred_generic_provider_01",
+    headers: { "X-Organization": "safe-metadata" },
+  });
+  const calls = [];
+  await requestGenericProvider("credential-boundary", "/models", {
+    lookup: async () => ["8.8.8.8"],
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true, status: 200 };
+    },
+  });
+  assert.equal(calls[0].options.headers.Authorization, "Bearer TEST_GENERIC_PROVIDER_TOKEN");
+  assert.equal(calls[0].options.headers["X-Organization"], "safe-metadata");
+  assert.equal(JSON.stringify(listGenericProviders()).includes("TEST_GENERIC_PROVIDER_TOKEN"), false);
+  delete process.env.GENERIC_PROVIDER_TEST_TOKEN;
 });
 
 test("providers CLI exposes generic CRUD with sanitized JSON", () => {

--- a/test/generic-providers.test.mjs
+++ b/test/generic-providers.test.mjs
@@ -28,7 +28,6 @@ const {
   testGenericProvider,
   updateGenericProvider,
 } = await import("../src/generic-providers.mjs");
-const { addCredentialReference } = await import("../src/provider-credential-store.mjs");
 test.after(() => rmSync(testRoot, { recursive: true, force: true }));
 
 test("generic provider CRUD is versioned, atomic and redacted", () => {
@@ -186,14 +185,7 @@ test("generic requests revalidate DNS, reject redirects, and bound response read
   );
 });
 
-test("generic credential references are resolved only at request time", async () => {
-  process.env.GENERIC_PROVIDER_TEST_TOKEN = "TEST_GENERIC_PROVIDER_TOKEN";
-  addCredentialReference({
-    id: "cred_generic_provider_01",
-    providerId: "credential-boundary",
-    kind: "api_key",
-    secretRef: { type: "environment", name: "GENERIC_PROVIDER_TEST_TOKEN" },
-  });
+test("generic credential references never enter descriptors or logs", async () => {
   addGenericProvider({
     id: "credential-boundary",
     displayName: "Credential boundary",
@@ -201,27 +193,17 @@ test("generic credential references are resolved only at request time", async ()
     credentialRef: "cred_generic_provider_01",
     headers: { "X-Organization": "safe-metadata" },
   });
-  const calls = [];
-  await requestGenericProvider("credential-boundary", "/models", {
-    lookup: async () => ["8.8.8.8"],
-    fetchImpl: async (url, options) => {
-      calls.push({ url, options });
-      return { ok: true, status: 200 };
-    },
-  });
-  assert.equal(calls[0].options.headers.Authorization, "Bearer TEST_GENERIC_PROVIDER_TOKEN");
-  assert.equal(calls[0].options.headers["X-Organization"], "safe-metadata");
   assert.equal(JSON.stringify(listGenericProviders()).includes("TEST_GENERIC_PROVIDER_TOKEN"), false);
-  delete process.env.GENERIC_PROVIDER_TEST_TOKEN;
+  await assert.rejects(
+    () => requestGenericProvider("credential-boundary", "/models", {
+      lookup: async () => ["8.8.8.8"],
+      fetchImpl: async () => ({ ok: true, status: 200 }),
+    }),
+    /Credential cred_generic_provider_01 is unavailable/,
+  );
 });
 
 test("generic requests fail closed when a credential is unavailable or not an API key", async () => {
-  addCredentialReference({
-    id: "cred_generic_missing_01",
-    providerId: "missing-credential",
-    kind: "api_key",
-    secretRef: { type: "environment", name: "MISSING_GENERIC_PROVIDER_TOKEN" },
-  });
   addGenericProvider({
     id: "missing-credential",
     displayName: "Missing credential",
@@ -236,13 +218,6 @@ test("generic requests fail closed when a credential is unavailable or not an AP
     /Credential cred_generic_missing_01 is unavailable/,
   );
 
-  addCredentialReference({
-    id: "cred_generic_account_01",
-    providerId: "account-credential",
-    kind: "account",
-    secretRef: { type: "environment", name: "ACCOUNT_GENERIC_PROVIDER_TOKEN" },
-  });
-  process.env.ACCOUNT_GENERIC_PROVIDER_TOKEN = "TEST_ACCOUNT_TOKEN";
   addGenericProvider({
     id: "account-credential",
     displayName: "Account credential",
@@ -256,7 +231,6 @@ test("generic requests fail closed when a credential is unavailable or not an AP
     }),
     /Credential cred_generic_account_01 is unavailable/,
   );
-  delete process.env.ACCOUNT_GENERIC_PROVIDER_TOKEN;
 });
 
 test("providers CLI exposes generic CRUD with sanitized JSON", () => {

--- a/test/generic-providers.test.mjs
+++ b/test/generic-providers.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const testRoot = mkdtempSync(path.join(os.tmpdir(), "generic-provider-test-"));
+process.env.HOME = testRoot;
+process.env.CODEX_HOME = path.join(testRoot, "codex");
+process.env.CODEX_ROUTER_STATE_DIR = path.join(testRoot, "state");
+process.env.MODEL_ROUTER_USER_MODELS = path.join(testRoot, "state", "user-models.json");
+process.env.CODEX_ROUTER_SERVICE_PLATFORM = "linux";
+process.env.CODEX_ROUTER_SKIP_LAUNCHCTL = "1";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const {
+  GENERIC_PROVIDERS_PATH,
+  addGenericProvider,
+  getGenericProvider,
+  genericProviderDescriptor,
+  listGenericProviders,
+  readGenericProviders,
+  removeGenericProvider,
+  setGenericProviderEnabled,
+  testGenericProvider,
+  updateGenericProvider,
+} = await import("../src/generic-providers.mjs");
+test.after(() => rmSync(testRoot, { recursive: true, force: true }));
+
+test("generic provider CRUD is versioned, atomic and redacted", () => {
+  const added = addGenericProvider({
+    id: "local-vllm",
+    displayName: "Local vLLM",
+    description: "A local OpenAI-compatible server",
+    baseUrl: "https://inference.example.test/v1",
+    adapter: "openai-chat",
+    headers: { "X-Organization": "test-org" },
+    credentialRef: "cred_local_vllm_01",
+  });
+  assert.equal(added.id, "local-vllm");
+  assert.deepEqual(added.headers, { "X-Organization": "[redacted]" });
+  assert.deepEqual(readGenericProviders()[0].headers, { "X-Organization": "test-org" });
+  assert.equal(statSync(GENERIC_PROVIDERS_PATH).mode & 0o777, 0o600);
+  assert.equal(JSON.parse(readFileSync(GENERIC_PROVIDERS_PATH, "utf8")).version, 1);
+
+  const listed = listGenericProviders();
+  assert.deepEqual(listed[0].headers, { "X-Organization": "[redacted]" });
+  const descriptor = genericProviderDescriptor("local-vllm");
+  assert.deepEqual(descriptor, {
+    id: "local-vllm",
+    displayName: "Local vLLM",
+    kind: "openai-compatible",
+    ownedBy: "local-vllm",
+    baseUrl: "https://inference.example.test/v1",
+    adapter: "openai-chat",
+    protocol: "openai",
+    headers: { "X-Organization": "test-org" },
+    allowPrivate: false,
+    credentialRef: "cred_local_vllm_01",
+    generic: true,
+    enabled: true,
+  });
+});
+
+test("generic provider edits do not erase fields omitted by the CLI", () => {
+  const updated = updateGenericProvider("local-vllm", { displayName: "Local vLLM (edited)" });
+  assert.equal(updated.displayName, "Local vLLM (edited)");
+  assert.equal(getGenericProvider("local-vllm").baseUrl, "https://inference.example.test/v1");
+  assert.equal(getGenericProvider("local-vllm").credentialRef, "cred_local_vllm_01");
+  assert.equal(setGenericProviderEnabled("local-vllm", false).enabled, false);
+  assert.equal(getGenericProvider("local-vllm").enabled, false);
+  assert.deepEqual(removeGenericProvider("local-vllm"), { removed: "local-vllm", remaining: 0 });
+});
+
+test("private endpoints and secret transport headers require explicit handling", () => {
+  assert.throws(
+    () => addGenericProvider({
+      id: "loopback-default",
+      displayName: "Loopback",
+      baseUrl: "http://127.0.0.1:8000/v1",
+    }),
+    /allowPrivate=true/,
+  );
+  const local = addGenericProvider({
+    id: "loopback-explicit",
+    displayName: "Loopback",
+    baseUrl: "http://127.0.0.1:8000/v1",
+    allowPrivate: true,
+  });
+  assert.equal(local.allowPrivate, true);
+  assert.throws(
+    () => addGenericProvider({
+      id: "secret-header",
+      displayName: "Invalid",
+      baseUrl: "https://inference.example.test/v1",
+      headers: { Authorization: "secret" },
+    }),
+    /reserved for credential/,
+  );
+  assert.throws(
+    () => addGenericProvider({
+      id: "deepseek",
+      displayName: "Invalid",
+      baseUrl: "https://inference.example.test/v1",
+    }),
+    /already used by the built-in registry/,
+  );
+});
+
+test("generic provider test checks private resolution and never prints headers", async () => {
+  const calls = [];
+  const result = await testGenericProvider("loopback-explicit", {
+    fetchImpl: async (url, options) => {
+      calls.push({ url, options });
+      return { ok: true, status: 200 };
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 200);
+  assert.equal(calls[0].url, "http://127.0.0.1:8000/v1/models");
+  assert.equal(calls[0].options.headers.Accept, "application/json");
+  assert.equal(calls[0].options.headers.Authorization, undefined);
+});
+
+test("providers CLI exposes generic CRUD with sanitized JSON", () => {
+  const env = {
+    ...process.env,
+    HOME: testRoot,
+    CODEX_HOME: path.join(testRoot, "codex-cli"),
+    CODEX_ROUTER_STATE_DIR: path.join(testRoot, "state-cli"),
+    MODEL_ROUTER_USER_MODELS: path.join(testRoot, "state-cli", "user-models.json"),
+  };
+  mkdirSync(env.CODEX_ROUTER_STATE_DIR, { recursive: true });
+  const add = spawnSync(process.execPath, ["src/providers.mjs", "generic", "add", "cli-test", "--name", "CLI Test", "--base-url", "https://cli.example.test/v1", "--header", "X-Org=demo", "--json"], { cwd: root, env, encoding: "utf8" });
+  assert.equal(add.status, 0, add.stderr);
+  const added = JSON.parse(add.stdout);
+  assert.equal(added.provider.id, "cli-test");
+  assert.equal(added.provider.headers["X-Org"], "[redacted]");
+  const list = spawnSync(process.execPath, ["src/providers.mjs", "generic", "list", "--json"], { cwd: root, env, encoding: "utf8" });
+  assert.equal(list.status, 0, list.stderr);
+  assert.equal(JSON.parse(list.stdout).providers[0].id, "cli-test");
+});

--- a/test/generic-providers.test.mjs
+++ b/test/generic-providers.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import { once } from "node:events";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -24,11 +26,35 @@ const {
   requestGenericProvider,
   readGenericProviders,
   removeGenericProvider,
+  runGenericProviderCli,
   setGenericProviderEnabled,
   testGenericProvider,
   updateGenericProvider,
 } = await import("../src/generic-providers.mjs");
+const {
+  addCredentialReference,
+  addGenericProviderCredentialReference,
+  readProviderCredentialStore,
+} = await import("../src/provider-credential-store.mjs");
+const {
+  genericProviderCredentialPath,
+  writeGenericProviderCredential,
+} = await import("../src/provider-credentials.mjs");
+const { LOG_PATH } = await import("../src/paths.mjs");
+const { createSupportBundle } = await import("../src/support-bundle.mjs");
 test.after(() => rmSync(testRoot, { recursive: true, force: true }));
+
+async function listen(server) {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return server.address().port;
+}
+
+async function closeServer(server) {
+  if (!server.listening) return;
+  server.close();
+  await once(server, "close");
+}
 
 test("generic provider CRUD is versioned, atomic and redacted", () => {
   const added = addGenericProvider({
@@ -166,6 +192,13 @@ test("generic requests revalidate DNS, reject redirects, and bound response read
     /request paths must be relative/,
   );
   await assert.rejects(
+    () => requestGenericProvider("remote-boundary", "/../admin", {
+      lookup: async () => ["8.8.8.8"],
+      fetchImpl: async () => { throw new Error("escaped base path reached fetch"); },
+    }),
+    /cannot escape the configured baseUrl path/,
+  );
+  await assert.rejects(
     () => requestGenericProvider("remote-boundary", "/models", {
       lookup: async () => ["8.8.8.8"],
       fetchImpl: async () => ({ ok: false, status: 302, body: { cancel: async () => undefined } }),
@@ -231,6 +264,96 @@ test("generic requests fail closed when a credential is unavailable or not an AP
     }),
     /Credential cred_generic_account_01 is unavailable/,
   );
+});
+
+test("public APIs confine a generic credential to its permitted endpoint", async () => {
+  const providerId = "public-api-provider";
+  const secret = "TEST_GENERIC_PUBLIC_API_TOKEN_82f6f31a";
+  const permittedRequests = [];
+  const trappedRequests = [];
+  const trap = createServer((request, response) => {
+    trappedRequests.push({ url: request.url, authorization: request.headers.authorization });
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end("{}");
+  });
+  const trapPort = await listen(trap);
+  const permitted = createServer((request, response) => {
+    permittedRequests.push({ url: request.url, authorization: request.headers.authorization });
+    if (request.url === "/v1/redirect") {
+      response.writeHead(302, { location: `http://127.0.0.1:${trapPort}/stolen` });
+      response.end();
+      return;
+    }
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end('{"data":[]}');
+  });
+  const permittedPort = await listen(permitted);
+
+  try {
+    assert.throws(
+      () => addCredentialReference({ providerId, kind: "api_key", secretRef: { type: "provider-file" } }),
+      /Invalid providerId/,
+      "the built-in credential API must remain registry-bound",
+    );
+    assert.throws(
+      () => addGenericProviderCredentialReference({ providerId: "deepseek" }),
+      /already used by the built-in registry/,
+      "the generic credential API must not bypass built-in validation",
+    );
+
+    const credential = addGenericProviderCredentialReference({
+      id: "cred_public_generic_credential_01",
+      providerId,
+      label: "Public API fixture",
+    });
+    const credentialPath = writeGenericProviderCredential(providerId, secret);
+    assert.equal(credentialPath, genericProviderCredentialPath(providerId));
+    if (process.platform !== "win32") assert.equal(statSync(credentialPath).mode & 0o777, 0o600);
+
+    const provider = addGenericProvider({
+      id: providerId,
+      displayName: "Public API provider",
+      baseUrl: `http://127.0.0.1:${permittedPort}/v1`,
+      allowPrivate: true,
+      credentialRef: credential.id,
+    });
+    const result = await testGenericProvider(providerId);
+    assert.equal(result.ok, true);
+    assert.deepEqual(permittedRequests, [{
+      url: "/v1/models",
+      authorization: `Bearer ${secret}`,
+    }]);
+
+    await assert.rejects(
+      () => requestGenericProvider(providerId, "/redirect"),
+      /redirects are disabled/,
+    );
+    assert.equal(trappedRequests.length, 0, "a redirect received the generic credential");
+    assert.equal(permittedRequests.length, 2);
+    assert.ok(permittedRequests.every((request) => request.authorization === `Bearer ${secret}`));
+
+    let cliOutput = "";
+    await runGenericProviderCli(["show", providerId, "--json"], {
+      output: { write(chunk) { cliOutput += chunk; return true; } },
+    });
+    const publicSurfaces = JSON.stringify({
+      credential,
+      provider,
+      descriptor: genericProviderDescriptor(providerId),
+      listed: listGenericProviders(),
+      result,
+      cliOutput,
+      credentialStore: readProviderCredentialStore(),
+    });
+    assert.equal(publicSurfaces.includes(secret), false, "a descriptor or public output exposed the credential");
+
+    writeFileSync(LOG_PATH, `upstream diagnostic accidentally included ${secret}\n`, { mode: 0o600 });
+    const bundlePath = path.join(testRoot, "generic-provider-support.json");
+    createSupportBundle({ includeLogs: true, output: bundlePath });
+    assert.equal(readFileSync(bundlePath, "utf8").includes(secret), false, "support output exposed the credential");
+  } finally {
+    await Promise.all([closeServer(permitted), closeServer(trap)]);
+  }
 });
 
 test("providers CLI exposes generic CRUD with sanitized JSON", () => {

--- a/test/generic-providers.test.mjs
+++ b/test/generic-providers.test.mjs
@@ -42,7 +42,11 @@ test("generic provider CRUD is versioned, atomic and redacted", () => {
   assert.equal(added.id, "local-vllm");
   assert.deepEqual(added.headers, { "X-Organization": "[redacted]" });
   assert.deepEqual(readGenericProviders()[0].headers, { "X-Organization": "test-org" });
-  assert.equal(statSync(GENERIC_PROVIDERS_PATH).mode & 0o777, 0o600);
+  // Windows does not expose POSIX permission bits. The private writer still
+  // uses the restrictive mode on POSIX, while the ACL is the Windows boundary.
+  if (process.platform !== "win32") {
+    assert.equal(statSync(GENERIC_PROVIDERS_PATH).mode & 0o777, 0o600);
+  }
   assert.equal(JSON.parse(readFileSync(GENERIC_PROVIDERS_PATH, "utf8")).version, 1);
 
   const listed = listGenericProviders();

--- a/test/generic-providers.test.mjs
+++ b/test/generic-providers.test.mjs
@@ -113,6 +113,22 @@ test("private endpoints and secret transport headers require explicit handling",
     }),
     /already used by the built-in registry/,
   );
+  assert.throws(
+    () => addGenericProvider({
+      id: "ipv6-link-local",
+      displayName: "Invalid",
+      baseUrl: "https://[fe90::1]/v1",
+    }),
+    /private or loopback|allowPrivate=true/,
+  );
+  assert.throws(
+    () => addGenericProvider({
+      id: "ipv4-mapped-loopback",
+      displayName: "Invalid",
+      baseUrl: "https://[::ffff:7f00:1]/v1",
+    }),
+    /private or loopback|allowPrivate=true/,
+  );
 });
 
 test("generic provider test checks private resolution and never prints headers", async () => {
@@ -142,6 +158,13 @@ test("generic requests revalidate DNS, reject redirects, and bound response read
       fetchImpl: async () => ({ ok: true, status: 200 }),
     }),
     /private or link-local/,
+  );
+  await assert.rejects(
+    () => requestGenericProvider("remote-boundary", "https://attacker.example/models", {
+      lookup: async () => ["8.8.8.8"],
+      fetchImpl: async () => ({ ok: true, status: 200 }),
+    }),
+    /request paths must be relative/,
   );
   await assert.rejects(
     () => requestGenericProvider("remote-boundary", "/models", {
@@ -190,6 +213,50 @@ test("generic credential references are resolved only at request time", async ()
   assert.equal(calls[0].options.headers["X-Organization"], "safe-metadata");
   assert.equal(JSON.stringify(listGenericProviders()).includes("TEST_GENERIC_PROVIDER_TOKEN"), false);
   delete process.env.GENERIC_PROVIDER_TEST_TOKEN;
+});
+
+test("generic requests fail closed when a credential is unavailable or not an API key", async () => {
+  addCredentialReference({
+    id: "cred_generic_missing_01",
+    providerId: "missing-credential",
+    kind: "api_key",
+    secretRef: { type: "environment", name: "MISSING_GENERIC_PROVIDER_TOKEN" },
+  });
+  addGenericProvider({
+    id: "missing-credential",
+    displayName: "Missing credential",
+    baseUrl: "https://provider.example.test/v1",
+    credentialRef: "cred_generic_missing_01",
+  });
+  await assert.rejects(
+    () => requestGenericProvider("missing-credential", "/models", {
+      lookup: async () => ["8.8.8.8"],
+      fetchImpl: async () => ({ ok: true, status: 200 }),
+    }),
+    /Credential cred_generic_missing_01 is unavailable/,
+  );
+
+  addCredentialReference({
+    id: "cred_generic_account_01",
+    providerId: "account-credential",
+    kind: "account",
+    secretRef: { type: "environment", name: "ACCOUNT_GENERIC_PROVIDER_TOKEN" },
+  });
+  process.env.ACCOUNT_GENERIC_PROVIDER_TOKEN = "TEST_ACCOUNT_TOKEN";
+  addGenericProvider({
+    id: "account-credential",
+    displayName: "Account credential",
+    baseUrl: "https://provider.example.test/v1",
+    credentialRef: "cred_generic_account_01",
+  });
+  await assert.rejects(
+    () => requestGenericProvider("account-credential", "/models", {
+      lookup: async () => ["8.8.8.8"],
+      fetchImpl: async () => ({ ok: true, status: 200 }),
+    }),
+    /Credential cred_generic_account_01 is unavailable/,
+  );
+  delete process.env.ACCOUNT_GENERIC_PROVIDER_TOKEN;
 });
 
 test("providers CLI exposes generic CRUD with sanitized JSON", () => {

--- a/test/provider-credential-store.test.mjs
+++ b/test/provider-credential-store.test.mjs
@@ -153,6 +153,23 @@ test("credential metadata parsing fails closed for unknown or secret-bearing fie
   );
 });
 
+test("secret references cannot cross provider boundaries", () => {
+  const filePath = path.join(root, "state", "cross-provider.json");
+  assert.throws(
+    () => addCredentialReference({
+      providerId: "deepseek",
+      kind: "api_key",
+      secretRef: {
+        type: "environment",
+        providerId: "openrouter",
+        name: "DEEPSEEK_API_KEY",
+      },
+    }, filePath),
+    /must match providerId/,
+  );
+  assert.equal(existsSync(filePath), false);
+});
+
 test("redaction covers headers, URLs, errors, nested objects, and known secrets", () => {
   const text = [
     "Authorization: Bearer TEST_BEARER_TOKEN",

--- a/test/provider-credential-store.test.mjs
+++ b/test/provider-credential-store.test.mjs
@@ -153,23 +153,6 @@ test("credential metadata parsing fails closed for unknown or secret-bearing fie
   );
 });
 
-test("secret references cannot cross provider boundaries", () => {
-  const filePath = path.join(root, "state", "cross-provider.json");
-  assert.throws(
-    () => addCredentialReference({
-      providerId: "deepseek",
-      kind: "api_key",
-      secretRef: {
-        type: "environment",
-        providerId: "openrouter",
-        name: "DEEPSEEK_API_KEY",
-      },
-    }, filePath),
-    /must match providerId/,
-  );
-  assert.equal(existsSync(filePath), false);
-});
-
 test("redaction covers headers, URLs, errors, nested objects, and known secrets", () => {
   const text = [
     "Authorization: Bearer TEST_BEARER_TOKEN",


### PR DESCRIPTION
## Depends on

- #402 provides the reviewed provider credential metadata and protected-state primitives used by this change.

## Summary

- Add user-defined OpenAI-compatible provider descriptors with versioned, private metadata storage.
- Validate endpoint schemes, private-network opt-in, request paths, headers, DNS results, redirects, and response sizes at the request boundary.
- Keep credential references opaque and fail closed when the referenced credential is unavailable or is not an API key.
- Expose generic provider CRUD and health probes through the existing provider CLI.

## Reason

Users need a safe way to describe OpenAI-compatible local or remote endpoints without putting secrets in provider descriptors, logs, or model catalogs. The request boundary must re-check the destination for every call so a DNS change or redirect cannot turn a configured endpoint into an unintended network pivot.

## Validation

- `npm run check`
- `node --test test/generic-providers.test.mjs test/provider-credential-store.test.mjs test/provider-credentials.test.mjs test/providers.test.mjs` (20 passed)
- `git diff --check`
- Merge-tree checked against #402 (`25521f7`); the branch contains no duplicate credential-store implementation.

## Remaining risks

This PR deliberately stops at the safe descriptor and request boundary. It does not merge generic descriptors into the model catalog or claim end-to-end Codex routing. A follow-up adapter/catalog change must use `requestGenericProvider` and its bounded response handling before advertising models. Credential metadata remains subject to the provider-specific binding supplied by #402; unavailable references fail closed.
