### PR TITLE
feat: add OpenAI Responses protocol boundary

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -45,6 +45,11 @@ import { relayCommandCodeGenerate } from "./commandcode-relay.mjs";
 import { VERSION } from "./version.mjs";
 import { installStableFetchTransport } from "./fetch-transport.mjs";
 import { zaiCacheUsageTransform } from "./zai-cache-usage.mjs";
+import {
+  createResponsesJsonTransform,
+  createResponsesStreamTransform,
+  normalizeOpenAIRequest,
+} from "./openai-adapters.mjs";
 
 installStableFetchTransport();
 
@@ -523,7 +528,7 @@ function normalizeBody(buffer, contentType, route) {
     error.status = 400;
     throw error;
   }
-  const payload = JSON.parse(buffer.toString("utf8"));
+  let payload = JSON.parse(buffer.toString("utf8"));
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     const error = new Error("Request JSON must be an object.");
     error.status = 400;
@@ -554,6 +559,13 @@ function normalizeBody(buffer, contentType, route) {
     const error = new Error(`Model ${model.gatewayModel} does not support ${route}.`);
     error.status = 400;
     throw error;
+  }
+
+  // Responses providers get one checked boundary here. The request remains a
+  // Responses request, but legacy aliases are normalized before any provider
+  // sees it and the original payload remains available for retries.
+  if (provider.protocol === "openai-responses") {
+    payload = normalizeOpenAIRequest(payload);
   }
 
   // OpenAI Chat Completions providers place terminal usage in a final empty
@@ -859,7 +871,14 @@ function normalizeBody(buffer, contentType, route) {
   // endpoint answers where the request goes and what authenticates it. For
   // every provider but a per-model-endpoint one they are the same object.
   const endpoint = endpointForModel(model);
-  return { body: Buffer.from(JSON.stringify(payload), "utf8"), model, provider, endpoint, payload };
+  return {
+    body: Buffer.from(JSON.stringify(payload), "utf8"),
+    model,
+    provider,
+    endpoint,
+    payload,
+    responseAdapter: provider.protocol === "openai-responses" ? "responses" : undefined,
+  };
 }
 
 function upstreamHeaders(requestHeaders, body, apiKey, provider, extraHeaders = {}, endpoint = provider) {
@@ -1158,12 +1177,22 @@ async function handleRequest(request, response) {
   if (commandCode?.recheck && upstream.ok) {
     recordCommandCodeRoute(commandCode.id, credential.value, { providerApi: true });
   }
-  await pipeResponse(
-    upstream,
-    response,
-    undefined,
-    zaiCacheUsageTransform(normalized.provider.id, upstream.headers.get("content-type")),
-  );
+  const upstreamContentType = upstream.headers.get("content-type") || "";
+  const responsesStream = normalized.responseAdapter === "responses" &&
+    upstream.ok && upstreamContentType.toLowerCase().includes("text/event-stream");
+  const responsesJson = normalized.responseAdapter === "responses" &&
+    upstream.ok && upstreamContentType.toLowerCase().includes("application/json");
+  const transform = [
+    responsesStream ? createResponsesStreamTransform() : undefined,
+    responsesJson ? createResponsesJsonTransform() : undefined,
+    zaiCacheUsageTransform(normalized.provider.id, upstreamContentType),
+  ].filter(Boolean);
+  const denylist = transform.length
+    ? new Set([...HOP_BY_HOP_HEADERS, "content-type"])
+    : undefined;
+  if (responsesStream) response.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  if (responsesJson) response.setHeader("Content-Type", "application/json; charset=utf-8");
+  await pipeResponse(upstream, response, denylist, transform);
   recordUpstreamLimits(normalized, upstream);
   if (!QUIET) {
     console.error(

--- a/src/openai-adapters.mjs
+++ b/src/openai-adapters.mjs
@@ -9,6 +9,13 @@ function adapterError(message, code = "invalid_responses_request") {
   return error;
 }
 
+function upstreamResponseError(message, code = "invalid_responses_response") {
+  const error = new Error(message);
+  error.status = 502;
+  error.code = code;
+  return error;
+}
+
 function clone(value) {
   if (value === undefined) return undefined;
   try {
@@ -191,9 +198,12 @@ function normalizeResponsesRequest(payload) {
 }
 
 function normalizeResponseBody(payload) {
-  const next = object(clone(payload), "Responses response");
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw upstreamResponseError("The upstream Responses response must be an object.");
+  }
+  const next = clone(payload);
   if (next.output !== undefined && !Array.isArray(next.output)) {
-    throw new Error("The upstream Responses response has an invalid output array.");
+    throw upstreamResponseError("The upstream Responses response has an invalid output array.");
   }
   return next;
 }
@@ -222,7 +232,10 @@ function frameData(frame) {
   try {
     return JSON.parse(frame.data);
   } catch {
-    return frame.data;
+    throw upstreamResponseError(
+      "The upstream Responses stream emitted malformed JSON event data.",
+      "invalid_responses_stream",
+    );
   }
 }
 
@@ -414,11 +427,18 @@ export function createResponsesJsonTransform() {
       callback();
     },
     flush(callback) {
+      let parsed;
       try {
-        const parsed = JSON.parse(body);
-        this.push(JSON.stringify(normalizeResponseBody(parsed)));
+        parsed = JSON.parse(body);
       } catch {
-        this.push(body);
+        callback(upstreamResponseError("The upstream Responses response was not valid JSON."));
+        return;
+      }
+      try {
+        this.push(JSON.stringify(normalizeResponseBody(parsed)));
+      } catch (error) {
+        callback(error);
+        return;
       }
       callback();
     },

--- a/src/openai-adapters.mjs
+++ b/src/openai-adapters.mjs
@@ -1,0 +1,359 @@
+import { Transform } from "node:stream";
+
+const RESPONSE_PROTOCOL = "openai-responses";
+
+function adapterError(message, code = "invalid_responses_request") {
+  const error = new Error(message);
+  error.status = 400;
+  error.code = code;
+  return error;
+}
+
+function clone(value) {
+  if (value === undefined) return undefined;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    throw adapterError("The Responses request must contain JSON values.");
+  }
+}
+
+function object(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw adapterError(`${name} must be an object.`);
+  }
+  return value;
+}
+
+function contentToResponses(content) {
+  if (content === undefined || content === null) return content;
+  if (typeof content === "string") return [{ type: "input_text", text: content }];
+  if (!Array.isArray(content)) return clone(content);
+  return content.map((part) => {
+    if (!part || typeof part !== "object" || Array.isArray(part)) return clone(part);
+    if (part.type === "text") return { ...part, type: "input_text" };
+    if (part.type === "image_url") {
+      const imageUrl = typeof part.image_url === "string" ? part.image_url : part.image_url?.url;
+      if (!imageUrl) throw adapterError("An image_url content part requires a URL.");
+      return {
+        type: "input_image",
+        image_url: imageUrl,
+        ...(part.detail || part.image_url?.detail ? { detail: part.detail || part.image_url.detail } : {}),
+      };
+    }
+    return clone(part);
+  });
+}
+
+function chatMessageToResponses(message) {
+  object(message, "message");
+  const role = typeof message.role === "string" && message.role ? message.role : "user";
+  if (role === "tool") {
+    if (typeof message.tool_call_id !== "string" || !message.tool_call_id) {
+      throw adapterError("A tool message requires tool_call_id.");
+    }
+    return [{
+      type: "function_call_output",
+      call_id: message.tool_call_id,
+      output: typeof message.content === "string" ? message.content : JSON.stringify(message.content ?? ""),
+    }];
+  }
+  const output = [];
+  if (typeof message.reasoning_content === "string" && message.reasoning_content) {
+    output.push({ type: "reasoning", summary: [{ type: "summary_text", text: message.reasoning_content }] });
+  }
+  const content = contentToResponses(message.content);
+  output.push({
+    type: "message",
+    role,
+    content: content === undefined || content === null ? [] : content,
+    ...(typeof message.name === "string" && message.name ? { name: message.name } : {}),
+  });
+  for (const call of message.tool_calls || []) {
+    object(call, "tool call");
+    const fn = object(call.function || {}, "tool call function");
+    if (typeof call.id !== "string" || !call.id || typeof fn.name !== "string" || !fn.name) {
+      throw adapterError("A function tool call requires id and function name.");
+    }
+    const args = typeof fn.arguments === "string" ? fn.arguments : JSON.stringify(fn.arguments ?? {});
+    output.push({ type: "function_call", call_id: call.id, name: fn.name, arguments: args });
+  }
+  return output;
+}
+
+function chatMessagesToResponses(messages) {
+  if (!Array.isArray(messages)) return messages;
+  return messages.flatMap((message) => chatMessageToResponses(message));
+}
+
+function normalizeTool(tool) {
+  if (!tool || typeof tool !== "object" || Array.isArray(tool)) return clone(tool);
+  if (tool.type !== "function" || !tool.function) return clone(tool);
+  const fn = object(tool.function, "function tool");
+  if (typeof fn.name !== "string" || !fn.name) throw adapterError("A function tool requires a name.");
+  const { function: _function, ...rest } = tool;
+  return { ...rest, name: fn.name, ...(fn.description !== undefined ? { description: fn.description } : {}), ...(fn.parameters !== undefined ? { parameters: fn.parameters } : {}), ...(fn.strict !== undefined ? { strict: fn.strict } : {}) };
+}
+
+function normalizeToolChoice(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  if (value.type !== "function" || !value.function) return clone(value);
+  const name = value.function.name;
+  if (typeof name !== "string" || !name) throw adapterError("A function tool_choice requires a name.");
+  return { type: "function", name };
+}
+
+function normalizeResponseFormat(payload) {
+  if (payload.response_format === undefined) return;
+  if (payload.text !== undefined) throw adapterError("Use either response_format or text.format, not both.");
+  const format = object(payload.response_format, "response_format");
+  if (format.type === "json_object") {
+    payload.text = { format: { type: "json_object" } };
+  } else if (format.type === "json_schema") {
+    const schema = object(format.json_schema, "response_format.json_schema");
+    payload.text = {
+      format: {
+        type: "json_schema",
+        ...(schema.name !== undefined ? { name: schema.name } : {}),
+        ...(schema.schema !== undefined ? { schema: schema.schema } : {}),
+        ...(schema.strict !== undefined ? { strict: schema.strict } : {}),
+      },
+    };
+  } else {
+    throw adapterError(`Unsupported response_format type ${String(format.type)}.`);
+  }
+  delete payload.response_format;
+}
+
+function normalizeResponsesRequest(payload) {
+  const next = object(clone(payload), "Responses request");
+  if (typeof next.model !== "string" || !next.model) throw adapterError("A Responses request requires model.");
+  if (next.input !== undefined && next.messages !== undefined) {
+    throw adapterError("A Responses request cannot contain both input and messages.");
+  }
+  if (next.input === undefined && next.messages !== undefined) {
+    next.input = chatMessagesToResponses(next.messages);
+    delete next.messages;
+  }
+  if (next.input !== undefined && !Array.isArray(next.input) && typeof next.input !== "string") {
+    throw adapterError("Responses input must be a string or array.");
+  }
+  if (Array.isArray(next.input)) {
+    next.input = next.input.map((item) => {
+      object(item, "input item");
+      if (item.type === "message" && item.content !== undefined) {
+        return { ...item, content: contentToResponses(item.content) };
+      }
+      if (item.type === "function_call" && (!item.call_id || !item.name)) {
+        throw adapterError("A function_call input item requires call_id and name.");
+      }
+      if (item.type === "function_call_output" && (!item.call_id || item.output === undefined)) {
+        throw adapterError("A function_call_output input item requires call_id and output.");
+      }
+      return clone(item);
+    });
+  }
+  if (Array.isArray(next.tools)) next.tools = next.tools.map(normalizeTool);
+  if (next.tool_choice !== undefined) next.tool_choice = normalizeToolChoice(next.tool_choice);
+  if (next.reasoning_effort !== undefined) {
+    if (next.reasoning !== undefined) throw adapterError("Use either reasoning or reasoning_effort, not both.");
+    next.reasoning = { effort: next.reasoning_effort };
+    delete next.reasoning_effort;
+  }
+  if (next.max_tokens !== undefined) {
+    if (next.max_output_tokens !== undefined && next.max_output_tokens !== next.max_tokens) {
+      throw adapterError("max_tokens and max_output_tokens must not disagree.");
+    }
+    next.max_output_tokens ??= next.max_tokens;
+    delete next.max_tokens;
+  }
+  normalizeResponseFormat(next);
+  if (next.parallel_tool_calls !== undefined && typeof next.parallel_tool_calls !== "boolean") {
+    throw adapterError("parallel_tool_calls must be a boolean.");
+  }
+  if (next.stream !== undefined && typeof next.stream !== "boolean") {
+    throw adapterError("stream must be a boolean.");
+  }
+  return next;
+}
+
+function normalizeResponseBody(payload) {
+  const next = object(clone(payload), "Responses response");
+  if (next.output !== undefined && !Array.isArray(next.output)) {
+    throw new Error("The upstream Responses response has an invalid output array.");
+  }
+  return next;
+}
+
+function parseFrame(frame) {
+  const lines = frame.replace(/\r/g, "").split("\n");
+  const data = [];
+  let event;
+  let id;
+  let retry;
+  for (const line of lines) {
+    if (!line || line.startsWith(":")) continue;
+    const separator = line.indexOf(":");
+    const field = separator === -1 ? line : line.slice(0, separator);
+    const value = separator === -1 ? "" : line.slice(separator + 1).replace(/^ /, "");
+    if (field === "event") event = value;
+    else if (field === "id") id = value;
+    else if (field === "retry") retry = value;
+    else if (field === "data") data.push(value);
+  }
+  return { event, id, retry, data: data.join("\n") };
+}
+
+function frameData(frame) {
+  if (frame.data === "[DONE]" || frame.data === "") return frame.data;
+  try {
+    return JSON.parse(frame.data);
+  } catch {
+    return frame.data;
+  }
+}
+
+function serializeFrame(frame, data = frame.data) {
+  const lines = [];
+  if (frame.event) lines.push(`event: ${frame.event}`);
+  if (frame.id !== undefined) lines.push(`id: ${frame.id}`);
+  if (frame.retry !== undefined) lines.push(`retry: ${frame.retry}`);
+  const text = typeof data === "string" ? data : JSON.stringify(data);
+  for (const line of String(text).split("\n")) lines.push(`data: ${line}`);
+  return `${lines.join("\n")}\n\n`;
+}
+
+function streamState() {
+  return {
+    responseId: undefined,
+    outputIndex: 0,
+    itemIndexes: new Map(),
+    sawEvent: false,
+    terminal: false,
+  };
+}
+
+const TERMINAL_EVENTS = new Set([
+  "response.completed",
+  "response.incomplete",
+  "response.failed",
+  "response.error",
+]);
+
+function validOutputIndex(value) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function normalizeResponsesEvent(frame, state) {
+  const data = frameData(frame);
+  state.sawEvent = true;
+  if (frame.event === "error") state.terminal = true;
+  if (data === "[DONE]") {
+    state.terminal = true;
+    return serializeFrame(frame, data);
+  }
+  if (!data || typeof data !== "object" || Array.isArray(data)) return serializeFrame(frame, data);
+  if (typeof data.type === "string" && TERMINAL_EVENTS.has(data.type)) state.terminal = true;
+  if (data.type === "response.created") {
+    state.responseId ||= data.response?.id || data.response_id;
+  }
+  if (data.type === "response.output_item.added") {
+    const item = data.item && typeof data.item === "object" ? data.item : undefined;
+    let index = validOutputIndex(data.output_index) ? data.output_index : item?.output_index;
+    if (!validOutputIndex(index)) index = state.outputIndex;
+    state.outputIndex = Math.max(state.outputIndex, index + 1);
+    if (item?.id) state.itemIndexes.set(item.id, index);
+    if (item?.call_id) state.itemIndexes.set(item.call_id, index);
+    if (!validOutputIndex(data.output_index)) data.output_index = index;
+  }
+  if (data.type === "response.function_call_arguments.delta" || data.type === "response.function_call_arguments.done") {
+    const key = data.call_id || data.item_id;
+    let index = validOutputIndex(data.output_index) ? data.output_index : state.itemIndexes.get(key);
+    if (!validOutputIndex(index) && key) {
+      index = state.outputIndex;
+      state.outputIndex += 1;
+      state.itemIndexes.set(key, index);
+    }
+    if (validOutputIndex(index) && !validOutputIndex(data.output_index)) data.output_index = index;
+  }
+  if (data.type === "response.output_text.delta" && !validOutputIndex(data.output_index) && state.outputIndex > 0) {
+    data.output_index = state.outputIndex - 1;
+  }
+  if (data.type === "response.completed" && data.response && typeof data.response === "object" && state.responseId && !data.response.id) {
+    data.response.id = state.responseId;
+  }
+  return serializeFrame(frame, data);
+}
+
+export function createResponsesStreamTransform() {
+  let buffer = "";
+  const state = streamState();
+  const decoder = new TextDecoder();
+  const nextBoundary = (value) => {
+    const match = /\r?\n\r?\n/.exec(value);
+    return match ? { index: match.index, length: match[0].length } : undefined;
+  };
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      try {
+        buffer += typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+        let boundary;
+        while ((boundary = nextBoundary(buffer))) {
+          const frame = buffer.slice(0, boundary.index);
+          buffer = buffer.slice(boundary.index + boundary.length);
+          if (frame.trim()) this.push(normalizeResponsesEvent(parseFrame(frame), state));
+        }
+        callback();
+      } catch (error) {
+        callback(error);
+      }
+    },
+    flush(callback) {
+      try {
+        buffer += decoder.decode();
+        if (buffer.trim()) this.push(normalizeResponsesEvent(parseFrame(buffer), state));
+        if (state.sawEvent && !state.terminal) {
+          this.push(serializeFrame({ event: "error" }, {
+            type: "error",
+            code: "upstream_stream_incomplete",
+            message: "The upstream Responses stream ended before a terminal event.",
+            param: null,
+          }));
+        }
+        callback();
+      } catch (error) {
+        callback(error);
+      }
+    },
+  });
+}
+
+export function createResponsesJsonTransform() {
+  let body = "";
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      body += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      callback();
+    },
+    flush(callback) {
+      try {
+        const parsed = JSON.parse(body);
+        this.push(JSON.stringify(normalizeResponseBody(parsed)));
+      } catch {
+        this.push(body);
+      }
+      callback();
+    },
+  });
+}
+
+export function normalizeOpenAIRequest(payload, { adapter = RESPONSE_PROTOCOL } = {}) {
+  if (adapter !== RESPONSE_PROTOCOL && adapter !== "responses") {
+    throw adapterError(`Unsupported OpenAI adapter ${String(adapter)}.`, "unsupported_openai_adapter");
+  }
+  return normalizeResponsesRequest(payload);
+}
+
+export function normalizeOpenAIResponse(payload) {
+  return normalizeResponseBody(payload);
+}

--- a/src/openai-adapters.mjs
+++ b/src/openai-adapters.mjs
@@ -69,6 +69,9 @@ function chatMessageToResponses(message) {
     content: content === undefined || content === null ? [] : content,
     ...(typeof message.name === "string" && message.name ? { name: message.name } : {}),
   });
+  if (message.tool_calls !== undefined && !Array.isArray(message.tool_calls)) {
+    throw adapterError("message.tool_calls must be an array.");
+  }
   for (const call of message.tool_calls || []) {
     object(call, "tool call");
     const fn = object(call.function || {}, "tool call function");
@@ -115,6 +118,7 @@ function normalizeResponseFormat(payload) {
       format: {
         type: "json_schema",
         ...(schema.name !== undefined ? { name: schema.name } : {}),
+        ...(schema.description !== undefined ? { description: schema.description } : {}),
         ...(schema.schema !== undefined ? { schema: schema.schema } : {}),
         ...(schema.strict !== undefined ? { strict: schema.strict } : {}),
       },
@@ -144,14 +148,23 @@ function normalizeResponsesRequest(payload) {
       if (item.type === "message" && item.content !== undefined) {
         return { ...item, content: contentToResponses(item.content) };
       }
-      if (item.type === "function_call" && (!item.call_id || !item.name)) {
+      if (
+        item.type === "function_call" &&
+        (typeof item.call_id !== "string" || !item.call_id || typeof item.name !== "string" || !item.name)
+      ) {
         throw adapterError("A function_call input item requires call_id and name.");
       }
-      if (item.type === "function_call_output" && (!item.call_id || item.output === undefined)) {
+      if (
+        item.type === "function_call_output" &&
+        (typeof item.call_id !== "string" || !item.call_id || item.output === undefined)
+      ) {
         throw adapterError("A function_call_output input item requires call_id and output.");
       }
       return clone(item);
     });
+  }
+  if (next.tools !== undefined && !Array.isArray(next.tools)) {
+    throw adapterError("tools must be an array.");
   }
   if (Array.isArray(next.tools)) next.tools = next.tools.map(normalizeTool);
   if (next.tool_choice !== undefined) next.tool_choice = normalizeToolChoice(next.tool_choice);
@@ -230,6 +243,7 @@ function streamState() {
     itemIndexes: new Map(),
     sawEvent: false,
     terminal: false,
+    invalid: false,
   };
 }
 
@@ -244,43 +258,101 @@ function validOutputIndex(value) {
   return Number.isInteger(value) && value >= 0;
 }
 
+function invalidStream(state, message) {
+  if (state.invalid) return "";
+  state.invalid = true;
+  state.terminal = true;
+  return serializeFrame({ event: "error" }, {
+    type: "error",
+    code: "invalid_responses_stream",
+    message,
+    param: null,
+  });
+}
+
+function rememberStreamIndex(state, key, index) {
+  if (!key) return true;
+  const previous = state.itemIndexes.get(key);
+  if (previous !== undefined && previous !== index) return false;
+  state.itemIndexes.set(key, index);
+  return true;
+}
+
 function normalizeResponsesEvent(frame, state) {
   const data = frameData(frame);
   state.sawEvent = true;
+  if (state.invalid) return "";
+  if (state.terminal && data !== "[DONE]") {
+    return invalidStream(state, "The Responses stream emitted data after its terminal event.");
+  }
   if (frame.event === "error") state.terminal = true;
   if (data === "[DONE]") {
+    if (!state.terminal) {
+      return invalidStream(state, "The Responses stream ended without a terminal event.");
+    }
     state.terminal = true;
     return serializeFrame(frame, data);
   }
   if (!data || typeof data !== "object" || Array.isArray(data)) return serializeFrame(frame, data);
   if (typeof data.type === "string" && TERMINAL_EVENTS.has(data.type)) state.terminal = true;
   if (data.type === "response.created") {
-    state.responseId ||= data.response?.id || data.response_id;
+    const responseId = data.response?.id || data.response_id;
+    if (state.responseId && responseId && state.responseId !== responseId) {
+      return invalidStream(state, "The Responses stream changed response IDs.");
+    }
+    state.responseId ||= responseId;
   }
   if (data.type === "response.output_item.added") {
     const item = data.item && typeof data.item === "object" ? data.item : undefined;
-    let index = validOutputIndex(data.output_index) ? data.output_index : item?.output_index;
+    if (!item) return invalidStream(state, "A Responses output item event requires an item.");
+    if (Object.hasOwn(data, "output_index") && !validOutputIndex(data.output_index)) {
+      return invalidStream(state, "A Responses output item used an invalid output index.");
+    }
+    if (Object.hasOwn(item, "output_index") && !validOutputIndex(item.output_index)) {
+      return invalidStream(state, "A Responses output item used an invalid item index.");
+    }
+    if (validOutputIndex(data.output_index) && validOutputIndex(item.output_index) && data.output_index !== item.output_index) {
+      return invalidStream(state, "A Responses output item used conflicting output indices.");
+    }
+    let index = validOutputIndex(data.output_index) ? data.output_index : item.output_index;
     if (!validOutputIndex(index)) index = state.outputIndex;
-    state.outputIndex = Math.max(state.outputIndex, index + 1);
-    if (item?.id) state.itemIndexes.set(item.id, index);
-    if (item?.call_id) state.itemIndexes.set(item.call_id, index);
+    if (index !== state.outputIndex) {
+      return invalidStream(state, "A Responses output item used a non-sequential output index.");
+    }
+    if (item.type === "function_call" && !item.id && !item.call_id) {
+      return invalidStream(state, "A Responses function call item requires an id or call_id.");
+    }
+    if (!rememberStreamIndex(state, item.id, index) || !rememberStreamIndex(state, item.call_id, index)) {
+      return invalidStream(state, "A Responses output item reused an ID with a different index.");
+    }
+    state.outputIndex = index + 1;
     if (!validOutputIndex(data.output_index)) data.output_index = index;
   }
   if (data.type === "response.function_call_arguments.delta" || data.type === "response.function_call_arguments.done") {
     const key = data.call_id || data.item_id;
-    let index = validOutputIndex(data.output_index) ? data.output_index : state.itemIndexes.get(key);
-    if (!validOutputIndex(index) && key) {
-      index = state.outputIndex;
-      state.outputIndex += 1;
-      state.itemIndexes.set(key, index);
+    if (typeof key !== "string" || !key) {
+      return invalidStream(state, "A Responses function call arguments event requires call_id or item_id.");
     }
-    if (validOutputIndex(index) && !validOutputIndex(data.output_index)) data.output_index = index;
+    if (Object.hasOwn(data, "output_index") && !validOutputIndex(data.output_index)) {
+      return invalidStream(state, "A Responses function call arguments event used an invalid output index.");
+    }
+    const index = state.itemIndexes.get(key);
+    if (!validOutputIndex(index)) {
+      return invalidStream(state, "A Responses function call arguments event referenced an unknown item.");
+    }
+    if (validOutputIndex(data.output_index) && data.output_index !== index) {
+      return invalidStream(state, "A Responses function call arguments event used the wrong output index.");
+    }
+    if (!validOutputIndex(data.output_index)) data.output_index = index;
   }
   if (data.type === "response.output_text.delta" && !validOutputIndex(data.output_index) && state.outputIndex > 0) {
     data.output_index = state.outputIndex - 1;
   }
-  if (data.type === "response.completed" && data.response && typeof data.response === "object" && state.responseId && !data.response.id) {
-    data.response.id = state.responseId;
+  if (data.type === "response.completed" && data.response && typeof data.response === "object") {
+    if (state.responseId && data.response.id && data.response.id !== state.responseId) {
+      return invalidStream(state, "The Responses completion used a different response ID.");
+    }
+    if (state.responseId && !data.response.id) data.response.id = state.responseId;
   }
   return serializeFrame(frame, data);
 }
@@ -301,7 +373,10 @@ export function createResponsesStreamTransform() {
         while ((boundary = nextBoundary(buffer))) {
           const frame = buffer.slice(0, boundary.index);
           buffer = buffer.slice(boundary.index + boundary.length);
-          if (frame.trim()) this.push(normalizeResponsesEvent(parseFrame(frame), state));
+          if (frame.trim()) {
+            const normalized = normalizeResponsesEvent(parseFrame(frame), state);
+            if (normalized) this.push(normalized);
+          }
         }
         callback();
       } catch (error) {
@@ -311,8 +386,11 @@ export function createResponsesStreamTransform() {
     flush(callback) {
       try {
         buffer += decoder.decode();
-        if (buffer.trim()) this.push(normalizeResponsesEvent(parseFrame(buffer), state));
-        if (state.sawEvent && !state.terminal) {
+        if (buffer.trim()) {
+          const normalized = normalizeResponsesEvent(parseFrame(buffer), state);
+          if (normalized) this.push(normalized);
+        }
+        if (state.sawEvent && !state.terminal && !state.invalid) {
           this.push(serializeFrame({ event: "error" }, {
             type: "error",
             code: "upstream_stream_incomplete",

--- a/test/openai-adapters.test.mjs
+++ b/test/openai-adapters.test.mjs
@@ -198,6 +198,18 @@ test("Responses provider errors stay structured and do not gain a second termina
   }]);
 });
 
+test("Responses stream rejects malformed JSON event data without relaying it", async () => {
+  await assert.rejects(
+    transformText(createResponsesStreamTransform(), [
+      "event: response.output_text.delta\ndata: {not-json}\n\n",
+    ]),
+    (error) =>
+      error.status === 502 &&
+      error.code === "invalid_responses_stream" &&
+      /malformed JSON/.test(error.message),
+  );
+});
+
 test("Responses JSON transform preserves usage and error-shaped payloads", async () => {
   const response = {
     id: "resp-3",
@@ -208,4 +220,21 @@ test("Responses JSON transform preserves usage and error-shaped payloads", async
   assert.deepEqual(JSON.parse(await transformText(createResponsesJsonTransform(), [JSON.stringify(response)])), response);
   const errorPayload = { error: { type: "invalid_request_error", message: "bad" } };
   assert.deepEqual(JSON.parse(await transformText(createResponsesJsonTransform(), [JSON.stringify(errorPayload)])), errorPayload);
+});
+
+test("Responses JSON transform rejects malformed and invalid upstream bodies", async () => {
+  await assert.rejects(
+    transformText(createResponsesJsonTransform(), ["{not-json}"]),
+    (error) =>
+      error.status === 502 &&
+      error.code === "invalid_responses_response" &&
+      /not valid JSON/.test(error.message),
+  );
+  await assert.rejects(
+    transformText(createResponsesJsonTransform(), [JSON.stringify({ output: {} })]),
+    (error) =>
+      error.status === 502 &&
+      error.code === "invalid_responses_response" &&
+      /invalid output array/.test(error.message),
+  );
 });

--- a/test/openai-adapters.test.mjs
+++ b/test/openai-adapters.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import { once } from "node:events";
+import test from "node:test";
+
+import {
+  createResponsesJsonTransform,
+  createResponsesStreamTransform,
+  normalizeOpenAIRequest,
+} from "../src/openai-adapters.mjs";
+
+async function transformText(transform, chunks) {
+  const output = [];
+  transform.on("data", (chunk) => output.push(Buffer.from(chunk)));
+  Readable.from(chunks).pipe(transform);
+  await once(transform, "end");
+  return Buffer.concat(output).toString("utf8");
+}
+
+function frames(text) {
+  return text.trim().split(/\n\n+/).map((frame) => {
+    const event = frame.match(/^event: (.*)$/m)?.[1];
+    const dataLine = frame.split("\n").find((line) => line.startsWith("data: ")) || "data: ";
+    const raw = dataLine.slice(6);
+    return { event, data: raw === "[DONE]" ? raw : JSON.parse(raw) };
+  });
+}
+
+test("Responses requests normalize legacy aliases without dropping fields", () => {
+  const input = {
+    model: "responses-model",
+    messages: [
+      { role: "system", content: "be concise" },
+      {
+        role: "assistant",
+        reasoning_content: "private reasoning",
+        content: "answer",
+        tool_calls: [
+          { id: "call-a", type: "function", function: { name: "lookup", arguments: '{"a":1}' } },
+          { id: "call-b", type: "function", function: { name: "lookup", arguments: '{"b":2}' } },
+        ],
+      },
+      { role: "tool", tool_call_id: "call-a", content: "one" },
+      { role: "tool", tool_call_id: "call-b", content: "two" },
+    ],
+    tools: [{ type: "function", function: { name: "lookup", description: "look up", parameters: { type: "object" }, strict: true } }],
+    tool_choice: { type: "function", function: { name: "lookup" } },
+    reasoning_effort: "high",
+    max_tokens: 64,
+    response_format: { type: "json_object" },
+    metadata: { request_tag: "kept" },
+  };
+  const output = normalizeOpenAIRequest(input);
+  assert.equal(output.messages, undefined);
+  assert.equal(output.max_tokens, undefined);
+  assert.equal(output.max_output_tokens, 64);
+  assert.deepEqual(output.reasoning, { effort: "high" });
+  assert.deepEqual(output.text, { format: { type: "json_object" } });
+  assert.deepEqual(output.metadata, { request_tag: "kept" });
+  assert.deepEqual(output.tools, [{
+    type: "function",
+    name: "lookup",
+    description: "look up",
+    parameters: { type: "object" },
+    strict: true,
+  }]);
+  assert.deepEqual(output.tool_choice, { type: "function", name: "lookup" });
+  assert.deepEqual(output.input.slice(0, 2), [
+    { type: "message", role: "system", content: [{ type: "input_text", text: "be concise" }] },
+    { type: "reasoning", summary: [{ type: "summary_text", text: "private reasoning" }] },
+  ]);
+  assert.deepEqual(output.input.slice(-2), [
+    { type: "function_call_output", call_id: "call-a", output: "one" },
+    { type: "function_call_output", call_id: "call-b", output: "two" },
+  ]);
+  assert.deepEqual(input.messages[1].tool_calls[0].function, { name: "lookup", arguments: '{"a":1}' });
+});
+
+test("Responses input stays lossless and invalid tool lifecycle fails closed", () => {
+  const input = {
+    model: "responses-model",
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hello" }], custom: { keep: true } },
+      { type: "function_call", call_id: "call-1", name: "one", arguments: "{}" },
+      { type: "function_call_output", call_id: "call-1", output: "done" },
+    ],
+    include: ["reasoning.encrypted_content"],
+  };
+  const output = normalizeOpenAIRequest(input);
+  assert.deepEqual(output.input, input.input);
+  assert.deepEqual(output.include, input.include);
+  assert.throws(
+    () => normalizeOpenAIRequest({ model: "m", input: [{ type: "function_call_output", output: "missing id" }] }),
+    (error) => error.status === 400 && error.code === "invalid_responses_request",
+  );
+  assert.throws(
+    () => normalizeOpenAIRequest({ model: "m", input: [], max_tokens: 1, max_output_tokens: 2 }),
+    /must not disagree/,
+  );
+});
+
+test("Responses stream keeps independent tool indices and usage across chunk boundaries", async () => {
+  const source = [
+    "event: response.created\r\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-1\"}}\r\n\r\n",
+    "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"item-a\",\"type\":\"function_call\",\"call_id\":\"call-a\"}}\n\n",
+    "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"call_id\":\"call-a\",\"delta\":\"{\\\"a\\\":1}\"}\n\n",
+    "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"item-b\",\"type\":\"function_call\",\"call_id\":\"call-b\"}}\n\n",
+    "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"call_id\":\"call-b\",\"delta\":\"{\\\"b\\\":2}\"}\n\n",
+    "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":4,\"output_tokens\":3}}}\n\n",
+    "data: [DONE]\n\n",
+  ];
+  const output = frames(await transformText(createResponsesStreamTransform(), source));
+  const added = output.filter((frame) => frame.data?.type === "response.output_item.added");
+  const deltas = output.filter((frame) => frame.data?.type === "response.function_call_arguments.delta");
+  assert.deepEqual(added.map((frame) => frame.data.output_index), [0, 1]);
+  assert.deepEqual(deltas.map((frame) => frame.data.output_index), [0, 1]);
+  assert.deepEqual(output.find((frame) => frame.data?.type === "response.completed").data.response.usage, {
+    input_tokens: 4,
+    output_tokens: 3,
+  });
+  assert.equal(output.at(-1).data, "[DONE]");
+});
+
+test("Responses stream emits a terminal error instead of silently ending", async () => {
+  const output = frames(await transformText(createResponsesStreamTransform(), [
+    "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-2\"}}\n\n",
+  ]));
+  assert.equal(output.at(-1).event, "error");
+  assert.deepEqual(output.at(-1).data, {
+    type: "error",
+    code: "upstream_stream_incomplete",
+    message: "The upstream Responses stream ended before a terminal event.",
+    param: null,
+  });
+});
+
+test("Responses provider errors stay structured and do not gain a second terminal frame", async () => {
+  const output = frames(await transformText(createResponsesStreamTransform(), [
+    "event: error\ndata: {\"type\":\"error\",\"code\":\"provider_failed\",\"message\":\"upstream rejected\"}\n\n",
+  ]));
+  assert.deepEqual(output, [{
+    event: "error",
+    data: { type: "error", code: "provider_failed", message: "upstream rejected" },
+  }]);
+});
+
+test("Responses JSON transform preserves usage and error-shaped payloads", async () => {
+  const response = {
+    id: "resp-3",
+    object: "response",
+    output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "ok" }] }],
+    usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+  };
+  assert.deepEqual(JSON.parse(await transformText(createResponsesJsonTransform(), [JSON.stringify(response)])), response);
+  const errorPayload = { error: { type: "invalid_request_error", message: "bad" } };
+  assert.deepEqual(JSON.parse(await transformText(createResponsesJsonTransform(), [JSON.stringify(errorPayload)])), errorPayload);
+});

--- a/test/openai-adapters.test.mjs
+++ b/test/openai-adapters.test.mjs
@@ -74,6 +74,11 @@ test("Responses requests normalize legacy aliases without dropping fields", () =
     { type: "function_call_output", call_id: "call-b", output: "two" },
   ]);
   assert.deepEqual(input.messages[1].tool_calls[0].function, { name: "lookup", arguments: '{"a":1}' });
+  assert.throws(
+    () => normalizeOpenAIRequest({ model: "m", messages: [{ role: "assistant", tool_calls: {} }] }),
+    /tool_calls must be an array/,
+  );
+  assert.throws(() => normalizeOpenAIRequest({ model: "m", tools: {} }), /tools must be an array/);
 });
 
 test("Responses input stays lossless and invalid tool lifecycle fails closed", () => {
@@ -97,6 +102,30 @@ test("Responses input stays lossless and invalid tool lifecycle fails closed", (
     () => normalizeOpenAIRequest({ model: "m", input: [], max_tokens: 1, max_output_tokens: 2 }),
     /must not disagree/,
   );
+});
+
+test("Responses schema aliases keep their descriptive metadata", () => {
+  const output = normalizeOpenAIRequest({
+    model: "responses-model",
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        name: "answer",
+        description: "A short answer",
+        schema: { type: "object" },
+        strict: true,
+      },
+    },
+  });
+  assert.deepEqual(output.text, {
+    format: {
+      type: "json_schema",
+      name: "answer",
+      description: "A short answer",
+      schema: { type: "object" },
+      strict: true,
+    },
+  });
 });
 
 test("Responses stream keeps independent tool indices and usage across chunk boundaries", async () => {
@@ -132,6 +161,31 @@ test("Responses stream emits a terminal error instead of silently ending", async
     message: "The upstream Responses stream ended before a terminal event.",
     param: null,
   });
+});
+
+test("Responses stream rejects unknown, conflicting, and post-terminal tool indices", async () => {
+  const output = frames(await transformText(createResponsesStreamTransform(), [
+    "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-4\"}}\n\n",
+    "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"item-a\",\"type\":\"function_call\",\"call_id\":\"call-a\"}}\n\n",
+    "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"call_id\":\"unknown\",\"delta\":\"{}\"}\n\n",
+    "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-4\"}}\n\n",
+  ]));
+  assert.equal(output.at(-1).event, "error");
+  assert.equal(output.at(-1).data.code, "invalid_responses_stream");
+  assert.match(output.at(-1).data.message, /unknown item/);
+
+  const mismatch = frames(await transformText(createResponsesStreamTransform(), [
+    "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"id\":\"item-a\",\"type\":\"function_call\",\"call_id\":\"call-a\"}}\n\n",
+    "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"call_id\":\"call-a\",\"output_index\":1,\"delta\":\"{}\"}\n\n",
+  ]));
+  assert.equal(mismatch.at(-1).data.code, "invalid_responses_stream");
+
+  const afterTerminal = frames(await transformText(createResponsesStreamTransform(), [
+    "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-5\"}}\n\n",
+    "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"late\"}\n\n",
+  ]));
+  assert.equal(afterTerminal.at(-1).data.code, "invalid_responses_stream");
+  assert.match(afterTerminal.at(-1).data.message, /after its terminal/);
 });
 
 test("Responses provider errors stay structured and do not gain a second terminal frame", async () => {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -4437,6 +4437,19 @@ test("API forwarder opts streamed Chat Completions into usage without changing l
       return;
     }
     if (request.url.endsWith("/responses")) {
+      if (body.stream === true) {
+        response.writeHead(200, { "Content-Type": "text/event-stream" });
+        response.end([
+          'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_stream_options"}}\n\n',
+          'event: response.output_item.added\ndata: {"type":"response.output_item.added","item":{"id":"item-a","type":"function_call","call_id":"call-a"}}\n\n',
+          'event: response.function_call_arguments.delta\ndata: {"type":"response.function_call_arguments.delta","call_id":"call-a","delta":"{}"}\n\n',
+          'event: response.output_item.added\ndata: {"type":"response.output_item.added","item":{"id":"item-b","type":"function_call","call_id":"call-b"}}\n\n',
+          'event: response.function_call_arguments.delta\ndata: {"type":"response.function_call_arguments.delta","call_id":"call-b","delta":"{}"}\n\n',
+          'event: response.completed\ndata: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":2}}}\n\n',
+          "data: [DONE]\n\n",
+        ].join(""));
+        return;
+      }
       json(response, 200, {
         id: "resp_stream_options",
         object: "response",
@@ -4569,6 +4582,11 @@ test("API forwarder opts streamed Chat Completions into usage without changing l
     assert.equal(responses.status, 200);
     assert.equal(upstreamRequests.at(-1).url, "/v1/responses");
     assert.deepEqual(upstreamRequests.at(-1).body.stream_options, { custom_option: "keep" });
+    const responseStream = await responses.text();
+    assert.match(responseStream, /response\.function_call_arguments\.delta/);
+    assert.match(responseStream, /"output_index":0/);
+    assert.match(responseStream, /"output_index":1/);
+    assert.match(responseStream, /"input_tokens":2/);
   } finally {
     await stopChild(forwarder);
     await closeServer(upstream.server);


### PR DESCRIPTION
## Summary

- Add one OpenAI Responses protocol boundary in the API forwarder.
- Normalize supported request aliases before the provider receives them.
- Validate and frame Responses JSON/SSE output while preserving usage, errors, metadata, and independent tool indices.

## Reason

Responses providers must not receive silently repaired or ambiguous tool histories. Invalid indices and post-terminal events can produce corrupted tool calls or appear as successful turns. The router now fails closed while preserving valid provider data.

## Validation

- `npm run check`
- `node --test test/openai-adapters.test.mjs test/provider-credential-store.test.mjs test/provider-credentials.test.mjs` (10 passed)
- `node --test --test-name-pattern='API forwarder routes opencode Go|API forwarder opts streamed Chat Completions' test/routing.test.mjs` (2 passed)
- `git diff --check`

## Remaining risks

This PR covers the declared OpenAI Responses route only. It does not advertise or implement legacy `/completions`, generic Chat-to-Responses conversion, or unsupported protocol conversions for providers that have not declared a Responses route.

