### PR TITLE
feat: add virtual model combos with weighted failover

### DIFF
--- a/docs/MODEL-COMBOS.md
+++ b/docs/MODEL-COMBOS.md
@@ -23,9 +23,10 @@ Targets use the canonical registry `slug` and its owning `provider`:
 
 Use `beginComboAttempt` to select a target without changing state. Call
 `completeComboAttempt` only after the request attempt has ended. Successful
-attempts commit bounded stickiness; retryable failures clear the affinity and
-advance the weighted cursor past the failed target. A stale concurrent attempt
-is rejected instead of overwriting the persisted cursor.
+attempts commit bounded stickiness; retryable failures clear the session
+affinity and, for round-robin, advance the weighted cursor past the failed
+target. Every completion advances a per-combo revision, so a stale concurrent
+attempt is rejected instead of overwriting persisted state.
 
 Health is fail-closed: every candidate needs an explicit healthy snapshot (or
 an `isHealthy` callback returning `true`). Missing health, missing model

--- a/docs/MODEL-COMBOS.md
+++ b/docs/MODEL-COMBOS.md
@@ -1,0 +1,38 @@
+# Model combo policy
+
+`src/model-combos.mjs` is a pure policy module. It validates a virtual combo,
+selects a healthy target, and returns serializable state for the caller to
+persist. It does not publish a model, read credentials, call a provider, or
+change the router request path.
+
+Targets use the canonical registry `slug` and its owning `provider`:
+
+```json
+{
+  "id": "coding-fallback",
+  "displayName": "Coding fallback",
+  "strategy": "failover",
+  "sticky": true,
+  "stickyLimit": 20,
+  "targets": [
+    { "provider": "openrouter", "slug": "openrouter/qwen-max", "weight": 1 },
+    { "provider": "local", "slug": "local/qwen", "weight": 1 }
+  ]
+}
+```
+
+Use `beginComboAttempt` to select a target without changing state. Call
+`completeComboAttempt` only after the request attempt has ended. Successful
+attempts commit bounded stickiness; retryable failures clear the affinity and
+advance the weighted cursor past the failed target. A stale concurrent attempt
+is rejected instead of overwriting the persisted cursor.
+
+Health is fail-closed: every candidate needs an explicit healthy snapshot (or
+an `isHealthy` callback returning `true`). Missing health, missing model
+metadata, unknown capabilities, and context-window mismatches make a target
+ineligible.
+
+Runtime catalog publication and request-path failover are intentionally not
+part of this change. A future integration must connect this policy to the
+router's real attempt boundary and preserve the same no-byte-replay safety
+rules before advertising combo models.

--- a/src/model-combos.mjs
+++ b/src/model-combos.mjs
@@ -45,16 +45,30 @@ function normalizedCapabilities(value) {
 }
 
 function declaredCapability(model, capability) {
-  if (typeof model?.supportsTools === "boolean" && capability === "tools") return model.supportsTools;
+  if (capability === "tools") {
+    for (const key of [
+      "supportsTools",
+      "supports_tools",
+      "supportsToolCalling",
+      "supports_tool_calling",
+      "toolCalling",
+      "tool_calling",
+      "tools",
+    ]) {
+      if (typeof model?.[key] === "boolean") return model[key];
+    }
+  }
   if (typeof model?.supportsVision === "boolean" && capability === "vision") return model.supportsVision;
+  if (typeof model?.supports_vision === "boolean" && capability === "vision") return model.supports_vision;
   if (typeof model?.supportsSearch === "boolean" && capability === "search") return model.supportsSearch;
-  if (typeof model?.toolCalling === "boolean" && capability === "tools") return model.toolCalling;
-  if (typeof model?.tools === "boolean" && capability === "tools") return model.tools;
+  if (typeof model?.supports_search === "boolean" && capability === "search") return model.supports_search;
   if (Array.isArray(model?.capabilities)) return model.capabilities.map((item) => text(item).toLowerCase()).includes(capability);
   if (Array.isArray(model?.supportedCapabilities)) return model.supportedCapabilities.map((item) => text(item).toLowerCase()).includes(capability);
   if (Array.isArray(model?.experimentalSupportedTools) && capability === "tools") return model.experimentalSupportedTools.length > 0;
   if (Array.isArray(model?.supportedTools) && capability === "tools") return model.supportedTools.length > 0;
+  if (Array.isArray(model?.supported_tools) && capability === "tools") return model.supported_tools.length > 0;
   if (Array.isArray(model?.inputModalities) && capability === "vision") return model.inputModalities.some((item) => text(item).toLowerCase() === "image");
+  if (Array.isArray(model?.input_modalities) && capability === "vision") return model.input_modalities.some((item) => text(item).toLowerCase() === "image");
   if (capability === "search" && model?.searchTool && typeof model.searchTool === "object" && !Array.isArray(model.searchTool)) return true;
   return undefined;
 }
@@ -80,11 +94,12 @@ function healthForTarget(target, health) {
   if (value === true) return { healthy: true };
   if (value === false) return { healthy: false, reason: "unhealthy" };
   if (!value || typeof value !== "object" || Array.isArray(value)) return { healthy: false, reason: "health-unknown" };
-  if (value.healthy === true || ["healthy", "ready", "ok", "available"].includes(text(value.status).toLowerCase())) return { healthy: true };
-  if (value.healthy === false || ["unhealthy", "cooldown", "unavailable"].includes(text(value.status).toLowerCase())) {
+  const status = text(value.status).toLowerCase();
+  if (value.healthy === false || ["unhealthy", "cooldown", "unavailable", "degraded"].includes(status)) {
     const reason = text(value.reason).toLowerCase();
-    return { healthy: false, reason: /^[a-z0-9][a-z0-9._:-]{0,63}$/.test(reason) ? reason : text(value.status).toLowerCase() || "unhealthy" };
+    return { healthy: false, reason: /^[a-z0-9][a-z0-9._:-]{0,63}$/.test(reason) ? reason : status || "unhealthy" };
   }
+  if (value.healthy === true || ["healthy", "ready", "ok", "available"].includes(status)) return { healthy: true };
   return { healthy: false, reason: "health-unknown" };
 }
 
@@ -133,10 +148,13 @@ export function validateComboDefinition(raw) {
 }
 
 function cloneState(raw) {
-  const state = { version: 1, cursors: {}, affinity: {} };
+  const state = { version: 1, cursors: {}, affinity: {}, revisions: {} };
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return state;
   for (const [comboId, value] of Object.entries(raw.cursors || {})) {
     if (COMBO_ID.test(comboId) && Number.isInteger(value) && value >= 0) state.cursors[comboId] = value;
+  }
+  for (const [comboId, value] of Object.entries(raw.revisions || {})) {
+    if (COMBO_ID.test(comboId) && Number.isInteger(value) && value >= 0) state.revisions[comboId] = value;
   }
   for (const [comboId, sessions] of Object.entries(raw.affinity || {})) {
     if (!COMBO_ID.test(comboId) || !sessions || typeof sessions !== "object" || Array.isArray(sessions)) continue;
@@ -202,10 +220,14 @@ function resolveWithState(combo, options) {
     }
     let health;
     if (typeof options.isHealthy === "function") {
-      const observed = options.isHealthy(target, model);
-      health = observed === true
-        ? { healthy: true }
-        : { healthy: false, reason: observed === false ? "unhealthy" : "health-unknown" };
+      try {
+        const observed = options.isHealthy(target, model);
+        health = observed === true
+          ? { healthy: true }
+          : { healthy: false, reason: observed === false ? "unhealthy" : "health-unknown" };
+      } catch {
+        health = { healthy: false, reason: "health-unknown" };
+      }
     } else {
       health = healthForTarget(target, options.health);
     }
@@ -259,7 +281,8 @@ function resolveWithState(combo, options) {
     return { ok: false, reason: diagnostics.reason, state, affinityState: state.affinity, diagnostics };
   }
   const selectedKey = targetKey(selected);
-  const attempt = Object.freeze({ version: 1, comboId: combo.id, targetKey: selectedKey, sessionKey: requestedSession || undefined, cursor });
+  const revision = Number.isInteger(state.revisions[combo.id]) ? state.revisions[combo.id] : 0;
+  const attempt = Object.freeze({ version: 1, comboId: combo.id, targetKey: selectedKey, sessionKey: requestedSession || undefined, cursor, revision });
   diagnostics.selected = selectedKey;
   diagnostics.reason = diagnostics.stickyHit ? "sticky" : "selected";
   return {
@@ -289,6 +312,10 @@ export function completeComboAttempt(definition, rawState, attempt, { outcome = 
   if (!OUTCOMES.has(outcome)) throw new Error("Combo attempt outcome is invalid.");
   const target = combo.targets.find((candidate) => targetKey(candidate) === attempt.targetKey);
   if (!target) throw new Error("Combo attempt target is not part of this combo.");
+  const currentRevision = Number.isInteger(state.revisions[combo.id]) ? state.revisions[combo.id] : 0;
+  if (!Number.isInteger(attempt.revision) || currentRevision !== attempt.revision) {
+    throw new Error("Combo attempt is stale; refusing to overwrite persisted state.");
+  }
   if (combo.strategy === "round-robin") {
     const current = Number.isInteger(state.cursors[combo.id]) ? state.cursors[combo.id] : 0;
     if (Number.isInteger(attempt.cursor) && current !== attempt.cursor) throw new Error("Combo attempt is stale; refusing to overwrite the persisted cursor.");
@@ -301,10 +328,11 @@ export function completeComboAttempt(definition, rawState, attempt, { outcome = 
       const previous = state.affinity[combo.id][session];
       const count = previous?.target === attempt.targetKey ? Math.min(combo.stickyLimit, previous.count + 1) : 1;
       state.affinity[combo.id][session] = { target: attempt.targetKey, count };
-    } else if (state.affinity[combo.id]?.[session]?.target === attempt.targetKey) {
-      delete state.affinity[combo.id][session];
+    } else {
+      if (state.affinity[combo.id]) delete state.affinity[combo.id][session];
     }
   }
+  state.revisions[combo.id] = currentRevision + 1;
   return state;
 }
 

--- a/src/model-combos.mjs
+++ b/src/model-combos.mjs
@@ -1,0 +1,322 @@
+const COMBO_ID = /^[a-z0-9][a-z0-9._-]{0,79}$/;
+const IDENTIFIER = /^[^\s\x00-\x1f\x7f]{1,240}$/;
+const STRATEGIES = new Set(["failover", "round-robin"]);
+const CAPABILITIES = new Set(["tools", "vision", "search"]);
+const OUTCOMES = new Set(["success", "retryable_failure", "terminal_failure"]);
+const MAX_WEIGHT = 1_000;
+const MAX_TARGETS = 100;
+const MAX_STICKY_LIMIT = 100_000;
+const MAX_SESSIONS = 1_000;
+const DEFAULT_STICKY_LIMIT = 20;
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function identifier(value) {
+  const result = text(value);
+  return result && IDENTIFIER.test(result) ? result : "";
+}
+
+function targetSlug(target) {
+  const model = text(target?.model);
+  const slug = text(target?.slug);
+  if (model && slug && model !== slug) {
+    throw new Error("A combo target cannot declare different model and slug identities.");
+  }
+  return slug || model;
+}
+
+function targetKey(target) {
+  return target.slug;
+}
+
+function modelIdentity(model) {
+  return text(model?.slug);
+}
+
+function modelProvider(model) {
+  return text(model?.provider);
+}
+
+function normalizedCapabilities(value) {
+  if (!Array.isArray(value)) return [];
+  return [...new Set(value.map((item) => text(item).toLowerCase()).filter(Boolean))];
+}
+
+function declaredCapability(model, capability) {
+  if (typeof model?.supportsTools === "boolean" && capability === "tools") return model.supportsTools;
+  if (typeof model?.supportsVision === "boolean" && capability === "vision") return model.supportsVision;
+  if (typeof model?.supportsSearch === "boolean" && capability === "search") return model.supportsSearch;
+  if (typeof model?.toolCalling === "boolean" && capability === "tools") return model.toolCalling;
+  if (typeof model?.tools === "boolean" && capability === "tools") return model.tools;
+  if (Array.isArray(model?.capabilities)) return model.capabilities.map((item) => text(item).toLowerCase()).includes(capability);
+  if (Array.isArray(model?.supportedCapabilities)) return model.supportedCapabilities.map((item) => text(item).toLowerCase()).includes(capability);
+  if (Array.isArray(model?.experimentalSupportedTools) && capability === "tools") return model.experimentalSupportedTools.length > 0;
+  if (Array.isArray(model?.supportedTools) && capability === "tools") return model.supportedTools.length > 0;
+  if (Array.isArray(model?.inputModalities) && capability === "vision") return model.inputModalities.some((item) => text(item).toLowerCase() === "image");
+  if (capability === "search" && model?.searchTool && typeof model.searchTool === "object" && !Array.isArray(model.searchTool)) return true;
+  return undefined;
+}
+
+function capabilityStatus(model, required, estimatedTokens) {
+  const requested = normalizedCapabilities(required);
+  const unsupported = requested.filter((capability) => !CAPABILITIES.has(capability));
+  if (unsupported.length) return { eligible: false, reason: `unsupported-capability:${unsupported.join(",")}` };
+  const unknown = requested.filter((capability) => declaredCapability(model, capability) === undefined);
+  if (unknown.length) return { eligible: false, reason: `capability-unknown:${unknown.join(",")}` };
+  const missing = requested.filter((capability) => declaredCapability(model, capability) !== true);
+  if (missing.length) return { eligible: false, reason: `missing-capability:${missing.join(",")}` };
+  if (Number.isFinite(estimatedTokens) && Number.isFinite(Number(model?.contextWindow)) && Number(model.contextWindow) < estimatedTokens) {
+    return { eligible: false, reason: "context-window-too-small" };
+  }
+  return { eligible: true };
+}
+
+function healthForTarget(target, health) {
+  if (!health) return { healthy: false, reason: "health-unknown" };
+  const key = targetKey(target);
+  const value = health instanceof Map ? health.get(key) : health[key];
+  if (value === true) return { healthy: true };
+  if (value === false) return { healthy: false, reason: "unhealthy" };
+  if (!value || typeof value !== "object" || Array.isArray(value)) return { healthy: false, reason: "health-unknown" };
+  if (value.healthy === true || ["healthy", "ready", "ok", "available"].includes(text(value.status).toLowerCase())) return { healthy: true };
+  if (value.healthy === false || ["unhealthy", "cooldown", "unavailable"].includes(text(value.status).toLowerCase())) {
+    const reason = text(value.reason).toLowerCase();
+    return { healthy: false, reason: /^[a-z0-9][a-z0-9._:-]{0,63}$/.test(reason) ? reason : text(value.status).toLowerCase() || "unhealthy" };
+  }
+  return { healthy: false, reason: "health-unknown" };
+}
+
+function normalizeTarget(raw, index) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error(`targets[${index}] must be an object.`);
+  const provider = identifier(raw.provider || raw.providerId);
+  let slug = identifier(targetSlug(raw));
+  if (!provider) throw new Error(`targets[${index}].provider must be a non-empty id.`);
+  if (!slug) throw new Error(`targets[${index}].slug must be a non-empty model slug.`);
+  if (!slug.includes("/")) slug = `${provider}/${slug}`;
+  if (!slug.startsWith(`${provider}/`)) throw new Error(`targets[${index}].slug must be namespaced under its provider.`);
+  const weight = raw.weight === undefined ? 1 : raw.weight;
+  if (!Number.isInteger(weight) || weight < 1 || weight > MAX_WEIGHT) throw new Error(`targets[${index}].weight must be an integer between 1 and ${MAX_WEIGHT}.`);
+  return Object.freeze({ provider, slug, weight });
+}
+
+export function normalizeComboDefinition(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("Combo must be an object.");
+  const id = text(raw.id || raw.name);
+  if (!COMBO_ID.test(id)) throw new Error("Combo id must be lower-case letters, numbers, dot, underscore or dash.");
+  const displayName = text(raw.displayName || raw.label || id);
+  if (!displayName || displayName.length > 240) throw new Error("Combo displayName must be non-empty and at most 240 characters.");
+  const strategy = text(raw.strategy || "failover").toLowerCase();
+  if (!STRATEGIES.has(strategy)) throw new Error("Combo strategy must be failover or round-robin.");
+  const sticky = raw.sticky === undefined ? false : raw.sticky;
+  if (typeof sticky !== "boolean") throw new Error("Combo sticky must be a boolean.");
+  const stickyLimit = raw.stickyLimit === undefined ? DEFAULT_STICKY_LIMIT : raw.stickyLimit;
+  if (!Number.isInteger(stickyLimit) || stickyLimit < 1 || stickyLimit > MAX_STICKY_LIMIT) throw new Error("Combo stickyLimit must be a positive integer no greater than 100000.");
+  if (!Array.isArray(raw.targets) || raw.targets.length === 0 || raw.targets.length > MAX_TARGETS) throw new Error(`Combo targets must contain between 1 and ${MAX_TARGETS} entries.`);
+  const targets = raw.targets.map(normalizeTarget);
+  const seen = new Set();
+  for (const target of targets) {
+    const key = targetKey(target);
+    if (seen.has(key)) throw new Error(`Combo targets contain duplicate ${key}.`);
+    seen.add(key);
+  }
+  return Object.freeze({ id, displayName, strategy, sticky, stickyLimit, targets: Object.freeze(targets) });
+}
+
+export function validateComboDefinition(raw) {
+  try {
+    return { ok: true, definition: normalizeComboDefinition(raw), errors: [] };
+  } catch (error) {
+    return { ok: false, errors: [error instanceof Error ? error.message : String(error)] };
+  }
+}
+
+function cloneState(raw) {
+  const state = { version: 1, cursors: {}, affinity: {} };
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return state;
+  for (const [comboId, value] of Object.entries(raw.cursors || {})) {
+    if (COMBO_ID.test(comboId) && Number.isInteger(value) && value >= 0) state.cursors[comboId] = value;
+  }
+  for (const [comboId, sessions] of Object.entries(raw.affinity || {})) {
+    if (!COMBO_ID.test(comboId) || !sessions || typeof sessions !== "object" || Array.isArray(sessions)) continue;
+    const entries = Object.entries(sessions).slice(0, MAX_SESSIONS);
+    state.affinity[comboId] = {};
+    for (const [session, value] of entries) {
+      if (!identifier(session) || !value || typeof value !== "object" || Array.isArray(value)) continue;
+      const target = identifier(value.target);
+      const count = Number.isInteger(value.count) && value.count > 0 ? value.count : 0;
+      if (target && count) state.affinity[comboId][session] = { target, count };
+    }
+  }
+  return state;
+}
+
+export function normalizeComboState(raw) {
+  if (raw !== undefined && raw !== null && (typeof raw !== "object" || Array.isArray(raw))) throw new Error("Combo state must be an object.");
+  return cloneState(raw);
+}
+
+export function createComboState() {
+  return normalizeComboState();
+}
+
+function modelForTarget(target, models) {
+  if (!Array.isArray(models)) return undefined;
+  return models.find((model) => modelProvider(model) === target.provider && modelIdentity(model) === target.slug);
+}
+
+function expandedTargets(targets) {
+  return targets.flatMap((target) => Array.from({ length: target.weight }, () => target));
+}
+
+function nextCursorFor(targets, current, selectedKey, failed) {
+  const cycle = expandedTargets(targets);
+  if (!cycle.length) return 0;
+  const start = ((current % cycle.length) + cycle.length) % cycle.length;
+  let selected = start;
+  while (targetKey(cycle[selected]) !== selectedKey) selected = (selected + 1) % cycle.length;
+  if (failed) {
+    let candidate = (selected + 1) % cycle.length;
+    while (candidate !== selected && targetKey(cycle[candidate]) === selectedKey) candidate = (candidate + 1) % cycle.length;
+    return candidate;
+  }
+  return (selected + 1) % cycle.length;
+}
+
+function resolveWithState(combo, options) {
+  const state = normalizeComboState(options.state ?? options.affinityState);
+  const requestedSession = identifier(options.sessionKey);
+  const skipped = [];
+  const eligible = [];
+  for (const target of combo.targets) {
+    const model = modelForTarget(target, options.models);
+    if (!model) {
+      skipped.push({ target: targetKey(target), reason: "missing-model-metadata" });
+      continue;
+    }
+    const capability = capabilityStatus(model, options.requiredCapabilities, options.estimatedTokens);
+    if (!capability.eligible) {
+      skipped.push({ target: targetKey(target), reason: capability.reason });
+      continue;
+    }
+    let health;
+    if (typeof options.isHealthy === "function") {
+      const observed = options.isHealthy(target, model);
+      health = observed === true
+        ? { healthy: true }
+        : { healthy: false, reason: observed === false ? "unhealthy" : "health-unknown" };
+    } else {
+      health = healthForTarget(target, options.health);
+    }
+    if (!health.healthy) {
+      skipped.push({ target: targetKey(target), reason: health.reason });
+      continue;
+    }
+    eligible.push(target);
+  }
+  const diagnostics = {
+    combo: combo.id,
+    strategy: combo.strategy,
+    requestedCapabilities: normalizedCapabilities(options.requiredCapabilities),
+    candidateCount: combo.targets.length,
+    eligibleCount: eligible.length,
+    skipped,
+    stickyHit: false,
+  };
+  if (!eligible.length) {
+    diagnostics.reason = skipped.length && skipped.every((entry) => ["unhealthy", "cooldown", "health-unknown"].includes(entry.reason))
+      ? "no-healthy-target"
+      : "no-eligible-target";
+    return { ok: false, reason: diagnostics.reason, state, affinityState: state.affinity, diagnostics };
+  }
+
+  const affinity = requestedSession && combo.sticky ? state.affinity[combo.id]?.[requestedSession] : undefined;
+  const stickyTarget = affinity && affinity.count < combo.stickyLimit
+    ? eligible.find((target) => targetKey(target) === affinity.target)
+    : undefined;
+  let selected = stickyTarget;
+  let cursor = Number.isInteger(state.cursors[combo.id]) ? state.cursors[combo.id] : 0;
+  if (selected) diagnostics.stickyHit = true;
+  if (!selected && combo.strategy === "failover") {
+    const expired = affinity?.count >= combo.stickyLimit ? affinity.target : undefined;
+    selected = eligible.find((target) => targetKey(target) !== expired) || eligible[0];
+  }
+  if (!selected && combo.strategy === "round-robin") {
+    const cycle = expandedTargets(combo.targets);
+    cursor = ((cursor % cycle.length) + cycle.length) % cycle.length;
+    for (let offset = 0; offset < cycle.length; offset += 1) {
+      const candidate = cycle[(cursor + offset) % cycle.length];
+      if (eligible.some((entry) => targetKey(entry) === targetKey(candidate))) {
+        cursor = (cursor + offset) % cycle.length;
+        selected = candidate;
+        break;
+      }
+    }
+  }
+  if (!selected) {
+    diagnostics.reason = "no-selection";
+    return { ok: false, reason: diagnostics.reason, state, affinityState: state.affinity, diagnostics };
+  }
+  const selectedKey = targetKey(selected);
+  const attempt = Object.freeze({ version: 1, comboId: combo.id, targetKey: selectedKey, sessionKey: requestedSession || undefined, cursor });
+  diagnostics.selected = selectedKey;
+  diagnostics.reason = diagnostics.stickyHit ? "sticky" : "selected";
+  return {
+    ok: true,
+    combo: { id: combo.id, displayName: combo.displayName, strategy: combo.strategy },
+    target: selected,
+    targetKey: selectedKey,
+    attempt,
+    state,
+    affinityState: state.affinity,
+    diagnostics,
+  };
+}
+
+export function beginComboAttempt(definition, options = {}) {
+  return resolveWithState(normalizeComboDefinition(definition), options);
+}
+
+export function resolveComboTarget(definition, options = {}) {
+  return beginComboAttempt(definition, options);
+}
+
+export function completeComboAttempt(definition, rawState, attempt, { outcome = "success" } = {}) {
+  const combo = normalizeComboDefinition(definition);
+  const state = normalizeComboState(rawState);
+  if (!attempt || attempt.version !== 1 || attempt.comboId !== combo.id) throw new Error("Combo attempt does not belong to this combo.");
+  if (!OUTCOMES.has(outcome)) throw new Error("Combo attempt outcome is invalid.");
+  const target = combo.targets.find((candidate) => targetKey(candidate) === attempt.targetKey);
+  if (!target) throw new Error("Combo attempt target is not part of this combo.");
+  if (combo.strategy === "round-robin") {
+    const current = Number.isInteger(state.cursors[combo.id]) ? state.cursors[combo.id] : 0;
+    if (Number.isInteger(attempt.cursor) && current !== attempt.cursor) throw new Error("Combo attempt is stale; refusing to overwrite the persisted cursor.");
+    state.cursors[combo.id] = nextCursorFor(combo.targets, current, attempt.targetKey, outcome === "retryable_failure");
+  }
+  const session = identifier(attempt.sessionKey);
+  if (combo.sticky && session) {
+    if (outcome === "success") {
+      if (!state.affinity[combo.id]) state.affinity[combo.id] = {};
+      const previous = state.affinity[combo.id][session];
+      const count = previous?.target === attempt.targetKey ? Math.min(combo.stickyLimit, previous.count + 1) : 1;
+      state.affinity[combo.id][session] = { target: attempt.targetKey, count };
+    } else if (state.affinity[combo.id]?.[session]?.target === attempt.targetKey) {
+      delete state.affinity[combo.id][session];
+    }
+  }
+  return state;
+}
+
+export function comboTargetKey(target) {
+  const provider = identifier(target?.provider || target?.providerId);
+  let slug = identifier(targetSlug(target));
+  if (!provider || !slug) throw new Error("Combo target must include provider and slug.");
+  if (!slug.includes("/")) slug = `${provider}/${slug}`;
+  if (!slug.startsWith(`${provider}/`)) throw new Error("Combo target slug must be namespaced under its provider.");
+  return slug;
+}
+
+export function comboModelIdentity(model) {
+  return modelIdentity(model);
+}

--- a/test/model-combos.test.mjs
+++ b/test/model-combos.test.mjs
@@ -64,6 +64,12 @@ test("health is explicit and unknown health fails closed", () => {
   assert.ok(missing.diagnostics.skipped.every((item) => item.reason === "health-unknown"));
   const selected = resolveComboTarget(failoverCombo(), { models, health: health(), requiredCapabilities: ["tools"] });
   assert.equal(selected.targetKey, "openrouter/qwen-max");
+  const contradictory = resolveComboTarget(failoverCombo(), {
+    models,
+    health: health({ "openrouter/qwen-max": { healthy: true, status: "unhealthy" } }),
+    requiredCapabilities: ["tools"],
+  });
+  assert.equal(contradictory.targetKey, "local/qwen");
 });
 
 test("a successful attempt commits stickiness, while failure clears it for recovery", () => {
@@ -101,6 +107,20 @@ test("sticky affinity expires only after its committed success limit", () => {
   assert.equal(expired.diagnostics.stickyHit, false);
 });
 
+test("retryable failure clears expired affinity so failover can recover", () => {
+  const combo = failoverCombo();
+  let state = createComboState();
+  for (let i = 0; i < combo.stickyLimit; i += 1) {
+    const attempt = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], sessionKey: "session-1", state });
+    state = completeComboAttempt(combo, state, attempt.attempt, { outcome: "success" });
+  }
+  const moved = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], sessionKey: "session-1", state });
+  assert.equal(moved.targetKey, "local/qwen");
+  state = completeComboAttempt(combo, state, moved.attempt, { outcome: "retryable_failure" });
+  const recovered = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], sessionKey: "session-1", state });
+  assert.equal(recovered.targetKey, "openrouter/qwen-max");
+});
+
 test("round-robin persists weighted cursor and skips a failed target's remaining weight", () => {
   const combo = failoverCombo({
     strategy: "round-robin",
@@ -134,6 +154,15 @@ test("stale concurrent attempts cannot overwrite the persisted cursor", () => {
   assert.throws(() => completeComboAttempt(combo, committed, second.attempt, { outcome: "success" }), /stale/);
 });
 
+test("stale concurrent failover attempts cannot overwrite affinity", () => {
+  const combo = failoverCombo();
+  const state = createComboState();
+  const first = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], sessionKey: "session-1", state });
+  const second = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], sessionKey: "session-1", state });
+  const committed = completeComboAttempt(combo, state, first.attempt, { outcome: "success" });
+  assert.throws(() => completeComboAttempt(combo, committed, second.attempt, { outcome: "success" }), /stale/);
+});
+
 test("tool capability accepts declared capability metadata and rejects unknown declarations", () => {
   const compatible = resolveComboTarget(failoverCombo({ sticky: false }), { models, health: health(), requiredCapabilities: ["tools"] });
   assert.equal(compatible.targetKey, "openrouter/qwen-max");
@@ -142,6 +171,24 @@ test("tool capability accepts declared capability metadata and rejects unknown d
   assert.equal(unknown.diagnostics.skipped[0].reason, "missing-capability:tools");
   const undeclared = resolveComboTarget(failoverCombo({ targets: [{ provider: "local", slug: "local/qwen" }] }), { models: [{ provider: "local", slug: "local/qwen", contextWindow: 50_000 }], health: health(), requiredCapabilities: ["tools"] });
   assert.equal(undeclared.diagnostics.skipped[0].reason, "capability-unknown:tools");
+  const snakeCase = resolveComboTarget(failoverCombo({ sticky: false, targets: [{ provider: "local", slug: "local/qwen" }] }), {
+    models: [{ provider: "local", slug: "local/qwen", supports_tools: true, contextWindow: 50_000 }],
+    health: health(),
+    requiredCapabilities: ["tools"],
+  });
+  assert.equal(snakeCase.targetKey, "local/qwen");
+});
+
+test("health callback failures fail closed", () => {
+  const result = resolveComboTarget(failoverCombo(), {
+    models,
+    isHealthy() {
+      throw new Error("provider probe failed");
+    },
+    requiredCapabilities: ["tools"],
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "no-healthy-target");
 });
 
 test("state normalization drops malformed and oversized session records", () => {

--- a/test/model-combos.test.mjs
+++ b/test/model-combos.test.mjs
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  beginComboAttempt,
+  comboModelIdentity,
+  comboTargetKey,
+  completeComboAttempt,
+  createComboState,
+  normalizeComboDefinition,
+  normalizeComboState,
+  resolveComboTarget,
+  validateComboDefinition,
+} from "../src/model-combos.mjs";
+
+const models = [
+  { provider: "openrouter", slug: "openrouter/qwen-max", capabilities: ["tools", "vision"], contextWindow: 100_000 },
+  { provider: "local", slug: "local/qwen", supportsTools: true, supportsSearch: true, contextWindow: 50_000 },
+  { provider: "backup", slug: "backup/text", supportsTools: false, contextWindow: 10_000 },
+];
+
+function health(overrides = {}) {
+  return {
+    "openrouter/qwen-max": { status: "healthy" },
+    "local/qwen": { healthy: true },
+    "backup/text": { healthy: true },
+    ...overrides,
+  };
+}
+
+function failoverCombo(overrides = {}) {
+  return {
+    id: "fast-coding",
+    displayName: "Fast Coding",
+    strategy: "failover",
+    sticky: true,
+    stickyLimit: 2,
+    targets: [
+      { provider: "openrouter", slug: "openrouter/qwen-max" },
+      { provider: "local", slug: "local/qwen" },
+    ],
+    ...overrides,
+  };
+}
+
+test("definitions use canonical slugs and reject ambiguous identities", () => {
+  const normalized = normalizeComboDefinition(failoverCombo());
+  assert.equal(normalized.targets[0].slug, "openrouter/qwen-max");
+  assert.equal(comboTargetKey(normalized.targets[0]), "openrouter/qwen-max");
+  assert.equal(comboModelIdentity(models[0]), "openrouter/qwen-max");
+  assert.equal(resolveComboTarget(failoverCombo({ sticky: false, targets: [{ provider: "openrouter", slug: "openrouter/qwen-max" }] }), {
+    models: [{ provider: "openrouter", slug: "openrouter/qwen-max", model: "wrong-upstream-id", capabilities: ["tools"] }],
+    health: { "openrouter/qwen-max": true },
+    requiredCapabilities: ["tools"],
+  }).targetKey, "openrouter/qwen-max");
+  assert.equal(validateComboDefinition({ ...failoverCombo(), targets: [{ provider: "openrouter", model: "old", slug: "new" }] }).ok, false);
+  assert.equal(validateComboDefinition({ ...failoverCombo(), id: "Bad Name" }).ok, false);
+});
+
+test("health is explicit and unknown health fails closed", () => {
+  const missing = resolveComboTarget(failoverCombo(), { models, requiredCapabilities: ["tools"] });
+  assert.equal(missing.ok, false);
+  assert.equal(missing.reason, "no-healthy-target");
+  assert.ok(missing.diagnostics.skipped.every((item) => item.reason === "health-unknown"));
+  const selected = resolveComboTarget(failoverCombo(), { models, health: health(), requiredCapabilities: ["tools"] });
+  assert.equal(selected.targetKey, "openrouter/qwen-max");
+});
+
+test("a successful attempt commits stickiness, while failure clears it for recovery", () => {
+  const combo = failoverCombo();
+  let state = createComboState();
+  const first = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], sessionKey: "session-1", state });
+  assert.equal(first.targetKey, "openrouter/qwen-max");
+  assert.deepEqual(state, createComboState());
+  state = completeComboAttempt(combo, state, first.attempt, { outcome: "success" });
+  const sticky = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], sessionKey: "session-1", state });
+  assert.equal(sticky.targetKey, first.targetKey);
+  assert.equal(sticky.diagnostics.stickyHit, true);
+  state = completeComboAttempt(combo, state, sticky.attempt, { outcome: "retryable_failure" });
+  const recovered = beginComboAttempt(combo, {
+    models,
+    health: health({ "openrouter/qwen-max": { healthy: false, reason: "cooldown" } }),
+    requiredCapabilities: ["tools"],
+    sessionKey: "session-1",
+    state,
+  });
+  assert.equal(recovered.targetKey, "local/qwen");
+  assert.equal(recovered.diagnostics.stickyHit, false);
+});
+
+test("sticky affinity expires only after its committed success limit", () => {
+  const combo = failoverCombo();
+  let state = createComboState();
+  for (let i = 0; i < 2; i += 1) {
+    const attempt = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], sessionKey: "session-1", state });
+    assert.equal(attempt.targetKey, "openrouter/qwen-max");
+    state = completeComboAttempt(combo, state, attempt.attempt, { outcome: "success" });
+  }
+  const expired = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], sessionKey: "session-1", state });
+  assert.equal(expired.targetKey, "local/qwen");
+  assert.equal(expired.diagnostics.stickyHit, false);
+});
+
+test("round-robin persists weighted cursor and skips a failed target's remaining weight", () => {
+  const combo = failoverCombo({
+    strategy: "round-robin",
+    sticky: false,
+    targets: [
+      { provider: "openrouter", slug: "openrouter/qwen-max", weight: 2 },
+      { provider: "local", slug: "local/qwen", weight: 1 },
+    ],
+  });
+  let state = createComboState();
+  const selected = [];
+  for (let i = 0; i < 3; i += 1) {
+    const attempt = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], state });
+    selected.push(attempt.targetKey);
+    state = completeComboAttempt(combo, state, attempt.attempt, { outcome: "success" });
+  }
+  assert.deepEqual(selected, ["openrouter/qwen-max", "openrouter/qwen-max", "local/qwen"]);
+  state = createComboState();
+  const failed = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], state });
+  state = completeComboAttempt(combo, state, failed.attempt, { outcome: "retryable_failure" });
+  const recovery = beginComboAttempt(combo, { models, health: health(), requiredCapabilities: ["tools"], state });
+  assert.equal(recovery.targetKey, "local/qwen");
+});
+
+test("stale concurrent attempts cannot overwrite the persisted cursor", () => {
+  const combo = failoverCombo({ strategy: "round-robin", sticky: false });
+  const state = createComboState();
+  const first = beginComboAttempt(combo, { models, health: health(), state });
+  const second = beginComboAttempt(combo, { models, health: health(), state });
+  const committed = completeComboAttempt(combo, state, first.attempt, { outcome: "success" });
+  assert.throws(() => completeComboAttempt(combo, committed, second.attempt, { outcome: "success" }), /stale/);
+});
+
+test("tool capability accepts declared capability metadata and rejects unknown declarations", () => {
+  const compatible = resolveComboTarget(failoverCombo({ sticky: false }), { models, health: health(), requiredCapabilities: ["tools"] });
+  assert.equal(compatible.targetKey, "openrouter/qwen-max");
+  const unknown = resolveComboTarget(failoverCombo({ targets: [{ provider: "backup", slug: "backup/text" }] }), { models, health: health(), requiredCapabilities: ["tools"] });
+  assert.equal(unknown.reason, "no-eligible-target");
+  assert.equal(unknown.diagnostics.skipped[0].reason, "missing-capability:tools");
+  const undeclared = resolveComboTarget(failoverCombo({ targets: [{ provider: "local", slug: "local/qwen" }] }), { models: [{ provider: "local", slug: "local/qwen", contextWindow: 50_000 }], health: health(), requiredCapabilities: ["tools"] });
+  assert.equal(undeclared.diagnostics.skipped[0].reason, "capability-unknown:tools");
+});
+
+test("state normalization drops malformed and oversized session records", () => {
+  const sessions = Object.fromEntries(Array.from({ length: 1_005 }, (_, index) => [`s-${index}`, { target: "local/qwen", count: 1 }]));
+  const state = normalizeComboState({ version: 99, cursors: { "fast-coding": 3, bad: -1 }, affinity: { "fast-coding": sessions } });
+  assert.equal(state.version, 1);
+  assert.equal(state.cursors["fast-coding"], 3);
+  assert.equal(Object.keys(state.affinity["fast-coding"]).length, 1_000);
+});


### PR DESCRIPTION
## Summary

- Harden virtual model-combo selection with canonical slugs, explicit health, capability checks, bounded sticky affinity, weighted cursor state, and attempt-boundary commits.
- Reject stale completions instead of overwriting concurrent state.
- Keep combo policy unadvertised: no catalog publication or request-path wiring is included.

## Reason

This makes the resolver safe to integrate later without optimistic health, unstable weights, stale cursor/affinity writes, or provider metadata mismatches.

## Validation

- `node --test test/model-combos.test.mjs` (11 passed)
- `npm run check`
- `git diff --check`

## Remaining risks

Runtime catalog publication and provider request failover are intentionally not implemented here. The future integration must persist the returned state at the actual request attempt boundary and only advertise combos after end-to-end provider/recovery tests.
