### PR TITLE
feat: add capability-driven sidecar search

### DIFF
--- a/src/search-sidecar.mjs
+++ b/src/search-sidecar.mjs
@@ -1,7 +1,6 @@
-// Explicit, provider-agnostic web search for models that cannot consume the
-// native search tool.  This module only coordinates a caller-supplied search
-// adapter: credentials stay in the provider boundary and ordinary text turns
-// never reach it by accident.
+// Explicit, provider-agnostic web search. This module is intentionally not
+// wired into the router until a caller supplies an authorization gate and a
+// provider adapter.
 
 export const SEARCH_SIDECAR_DEFAULTS = Object.freeze({
   timeoutMs: 10_000,
@@ -17,10 +16,19 @@ const MAX_RESULT_LENGTH = 2_000;
 const MAX_URL_LENGTH = 4_096;
 const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
 const SEARCH_MODES = new Set(["auto", "native", "sidecar"]);
-
-function own(value, key) {
-  return value !== null && typeof value === "object" && Object.hasOwn(value, key);
-}
+const CONFIG_KEYS = new Set([
+  "enabled",
+  "providerId",
+  "credentialRef",
+  "destination",
+  "timeoutMs",
+  "maxResults",
+  "cacheTtlMs",
+  "cacheMaxEntries",
+  "maxAttempts",
+  "retryDelayMs",
+]);
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
 
 function positiveInteger(value, name, { max } = {}) {
   if (!Number.isInteger(value) || value < 1 || (max !== undefined && value > max)) {
@@ -37,10 +45,52 @@ function nonNegativeInteger(value, name, { max } = {}) {
 }
 
 function cleanString(value, name, max) {
-  if (typeof value !== "string" || !value.trim() || value.length > max) {
+  if (typeof value !== "string" || !value.trim() || value.length > max || CONTROL_CHARACTERS.test(value)) {
     throw new Error(`${name} must be a non-empty string of at most ${max} characters.`);
   }
   return value.trim();
+}
+
+function opaqueRef(value, name, max) {
+  const result = cleanString(value, name, max);
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:/-]*$/.test(result)) {
+    throw new Error(`${name} must be an opaque reference without whitespace or special characters.`);
+  }
+  return result;
+}
+
+function unsafeHostname(hostname) {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (normalized === "localhost" || normalized.endsWith(".localhost") || normalized.includes(":")) return true;
+  const ipv4 = normalized.split(".").map((part) => Number(part));
+  if (ipv4.length !== 4 || !ipv4.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)) return false;
+  return ipv4[0] === 0 || ipv4[0] === 10 || ipv4[0] === 127 || (ipv4[0] === 169 && ipv4[1] === 254)
+    || (ipv4[0] === 172 && ipv4[1] >= 16 && ipv4[1] <= 31) || (ipv4[0] === 192 && ipv4[1] === 168);
+}
+
+function normalizeDestination(value) {
+  const raw = cleanString(value, "destination", MAX_URL_LENGTH);
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new Error("destination must be an absolute HTTPS URL.");
+  }
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password || parsed.hash) {
+    throw new Error("destination must be an HTTPS URL without credentials or a fragment.");
+  }
+  if (unsafeHostname(parsed.hostname)) throw new Error("destination must not target localhost or a private address.");
+  return parsed.toString();
+}
+
+function sanitizeText(value, name, max) {
+  if (typeof value !== "string" || !value.trim() || value.length > max) {
+    throw new Error(`${name} must be a non-empty string of at most ${max} characters.`);
+  }
+  const text = value.replace(/[\u0000-\u001f\u007f]/g, " ");
+  const sanitized = text.replace(/<\s*(script|style)[^>]*>[\s\S]*?<\/\s*\1\s*>/gi, " ").replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
+  if (!sanitized) throw new Error(`${name} must contain visible text.`);
+  return sanitized;
 }
 
 /**
@@ -51,8 +101,8 @@ export function normalizeSearchSidecarConfig(value = {}) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("Search sidecar config must be an object.");
   }
-  for (const key of ["apiKey", "token", "secret", "password", "authorization"]) {
-    if (own(value, key)) throw new Error(`Search sidecar config cannot contain ${key}.`);
+  for (const key of Object.keys(value)) {
+    if (!CONFIG_KEYS.has(key)) throw new Error(`Search sidecar config does not accept ${key}.`);
   }
   const enabled = value.enabled === true;
   if (value.enabled !== undefined && typeof value.enabled !== "boolean") {
@@ -60,8 +110,9 @@ export function normalizeSearchSidecarConfig(value = {}) {
   }
   const result = {
     enabled,
-    ...(value.providerId !== undefined ? { providerId: cleanString(value.providerId, "providerId", 128) } : {}),
-    ...(value.credentialRef !== undefined ? { credentialRef: cleanString(value.credentialRef, "credentialRef", 256) } : {}),
+    ...(value.providerId !== undefined ? { providerId: opaqueRef(value.providerId, "providerId", 128) } : {}),
+    ...(value.credentialRef !== undefined ? { credentialRef: opaqueRef(value.credentialRef, "credentialRef", 256) } : {}),
+    ...(value.destination !== undefined ? { destination: normalizeDestination(value.destination) } : {}),
     timeoutMs: value.timeoutMs === undefined ? SEARCH_SIDECAR_DEFAULTS.timeoutMs : positiveInteger(value.timeoutMs, "timeoutMs", { max: 120_000 }),
     maxResults: value.maxResults === undefined ? SEARCH_SIDECAR_DEFAULTS.maxResults : positiveInteger(value.maxResults, "maxResults", { max: 50 }),
     cacheTtlMs: value.cacheTtlMs === undefined ? SEARCH_SIDECAR_DEFAULTS.cacheTtlMs : nonNegativeInteger(value.cacheTtlMs, "cacheTtlMs", { max: 86_400_000 }),
@@ -71,18 +122,19 @@ export function normalizeSearchSidecarConfig(value = {}) {
   };
   if (result.enabled && !result.providerId) throw new Error("An enabled search sidecar needs providerId.");
   if (result.enabled && !result.credentialRef) throw new Error("An enabled search sidecar needs credentialRef.");
+  if (result.enabled && !result.destination) throw new Error("An enabled search sidecar needs destination.");
   return Object.freeze(result);
 }
 
-/** Resolve native/sidecar transport without model-name conditionals. */
-export function resolveSearchTransport({ modelCapabilities = {}, sidecar, mode = "auto" } = {}) {
+/** Resolve only an explicitly requested sidecar; auto mode never falls back. */
+export function resolveSearchTransport({ modelCapabilities = {}, sidecar, mode = "auto", invocationAuthorized = false } = {}) {
   if (!SEARCH_MODES.has(mode)) throw new Error(`Unknown search mode ${mode}.`);
   const native = modelCapabilities?.supportsSearch === true;
   const configured = sidecar?.enabled === true;
   if (mode === "native") return native ? "native" : "disabled";
-  if (mode === "sidecar") return configured ? "sidecar" : "disabled";
+  if (mode === "sidecar") return configured && invocationAuthorized === true ? "sidecar" : "disabled";
   if (native) return "native";
-  return configured ? "sidecar" : "disabled";
+  return "disabled";
 }
 
 export function normalizeSearchRequest(request, maxResults = SEARCH_SIDECAR_DEFAULTS.maxResults) {
@@ -109,21 +161,25 @@ function normalizeResult(value, index) {
   } catch {
     throw new Error(`results[${index}].url must be an absolute URL.`);
   }
-  if (!/^https?:$/.test(parsed.protocol)) throw new Error(`results[${index}].url must use http or https.`);
+  if (!/^https?:$/.test(parsed.protocol) || parsed.username || parsed.password || parsed.hash) {
+    throw new Error(`results[${index}].url must be an HTTP(S) URL without credentials or a fragment.`);
+  }
+  if (unsafeHostname(parsed.hostname)) throw new Error(`results[${index}].url must not target localhost or a private address.`);
   return {
-    title: cleanString(value.title || parsed.hostname, `results[${index}].title`, MAX_RESULT_LENGTH),
-    url,
-    ...(value.snippet === undefined ? {} : { snippet: cleanString(value.snippet, `results[${index}].snippet`, MAX_RESULT_LENGTH) }),
-    ...(value.publishedAt === undefined ? {} : { publishedAt: cleanString(value.publishedAt, `results[${index}].publishedAt`, 128) }),
+    title: sanitizeText(value.title || parsed.hostname, `results[${index}].title`, MAX_RESULT_LENGTH),
+    url: parsed.toString(),
+    ...(value.snippet === undefined ? {} : { snippet: sanitizeText(value.snippet, `results[${index}].snippet`, MAX_RESULT_LENGTH) }),
+    ...(value.publishedAt === undefined ? {} : { publishedAt: sanitizeText(value.publishedAt, `results[${index}].publishedAt`, 128) }),
   };
 }
 
 export function normalizeSearchResponse(payload, request) {
   const raw = Array.isArray(payload) ? payload : payload?.results;
   if (!Array.isArray(raw)) throw new Error("Search sidecar returned no results array.");
-  const results = raw.slice(0, request.maxResults).map(normalizeResult);
+  const normalizedRequest = normalizeSearchRequest(request);
+  const results = raw.slice(0, normalizedRequest.maxResults).map(normalizeResult);
   return {
-    query: request.query,
+    query: normalizedRequest.query,
     results,
     citations: results.map((result, index) => ({ index: index + 1, title: result.title, url: result.url })),
   };
@@ -141,21 +197,6 @@ function retryable(error) {
   return error?.retryable === true || (status !== undefined && RETRYABLE_STATUSES.has(status));
 }
 
-function combinedSignal(signal, timeoutMs) {
-  const timeout = AbortSignal.timeout(timeoutMs);
-  if (!signal) return timeout;
-  return AbortSignal.any([signal, timeout]);
-}
-
-function abortReason(signal, timeoutMs) {
-  if (signal?.aborted) {
-    return signal.reason?.name === "TimeoutError" || signal.reason?.code === "ERR_ABORTED"
-      ? "timeout"
-      : "cancelled";
-  }
-  return timeoutMs ? "timeout" : "cancelled";
-}
-
 export class SearchSidecarError extends Error {
   constructor(message, { code = "search_sidecar_failed", status, telemetry, cause } = {}) {
     super(message, { cause });
@@ -163,6 +204,36 @@ export class SearchSidecarError extends Error {
     this.code = code;
     if (status !== undefined) this.status = status;
     this.telemetry = telemetry;
+  }
+}
+
+function abortError(code) {
+  return new SearchSidecarError(
+    code === "search_sidecar_timeout" ? "Search sidecar timed out." : "Search sidecar was cancelled.",
+    { code },
+  );
+}
+
+async function invokeBounded(fn, input, { signal, timeoutMs }) {
+  if (signal?.aborted) throw abortError("search_sidecar_cancelled");
+  const controller = new AbortController();
+  let timeoutHandle;
+  let onParentAbort;
+  let rejectAbort;
+  const abortPromise = new Promise((_, reject) => { rejectAbort = reject; });
+  const abort = (error) => {
+    if (!controller.signal.aborted) controller.abort(error);
+    rejectAbort(error);
+  };
+  onParentAbort = () => abort(abortError("search_sidecar_cancelled"));
+  signal?.addEventListener("abort", onParentAbort, { once: true });
+  timeoutHandle = setTimeout(() => abort(abortError("search_sidecar_timeout")), timeoutMs);
+  try {
+    const result = Promise.resolve().then(() => fn({ ...input, signal: controller.signal }));
+    return await Promise.race([result, abortPromise]);
+  } finally {
+    clearTimeout(timeoutHandle);
+    signal?.removeEventListener("abort", onParentAbort);
   }
 }
 
@@ -192,37 +263,55 @@ export function createSearchCache({ maxEntries = SEARCH_SIDECAR_DEFAULTS.cacheMa
   };
 }
 
-/** Execute one explicit sidecar search. The adapter owns credential lookup. */
-export async function searchWithSidecar({ config, request, searchImpl, signal, cache, now = () => Date.now(), sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)) } = {}) {
+/** Execute one authorized sidecar search. The adapter owns credential lookup. */
+export async function searchWithSidecar({ config, request, accountId, model, authorize, searchImpl, signal, cache, now = () => Date.now(), sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)) } = {}) {
   const sidecar = normalizeSearchSidecarConfig(config);
   if (!sidecar.enabled) throw new SearchSidecarError("Search sidecar is disabled.", { code: "search_sidecar_disabled" });
+  if (typeof authorize !== "function") throw new SearchSidecarError("Search sidecar invocation is not authorized.", { code: "search_sidecar_unauthorized" });
   if (typeof searchImpl !== "function") throw new Error("searchImpl must be a function.");
   const normalized = normalizeSearchRequest(request, sidecar.maxResults);
-  const key = `${sidecar.providerId}:${normalized.query}:${normalized.maxResults}`;
+  const normalizedAccountId = cleanString(accountId, "accountId", 256);
+  const normalizedModel = cleanString(model, "model", 256);
+  const authorizationInput = {
+    accountId: normalizedAccountId,
+    model: normalizedModel,
+    providerId: sidecar.providerId,
+    destination: sidecar.destination,
+    request: normalized,
+  };
+  let authorized;
+  try {
+    authorized = await invokeBounded(authorize, authorizationInput, { signal, timeoutMs: sidecar.timeoutMs });
+  } catch (error) {
+    if (error instanceof SearchSidecarError) throw error;
+    throw new SearchSidecarError("Search sidecar invocation is not authorized.", { code: "search_sidecar_unauthorized", cause: error });
+  }
+  if (authorized !== true) throw new SearchSidecarError("Search sidecar invocation is not authorized.", { code: "search_sidecar_unauthorized" });
+  const key = JSON.stringify({
+    accountId: normalizedAccountId,
+    model: normalizedModel,
+    providerId: sidecar.providerId,
+    credentialRef: sidecar.credentialRef,
+    destination: sidecar.destination,
+    query: normalized.query,
+    maxResults: normalized.maxResults,
+  });
   const cached = cache?.get(key);
   if (cached) return { ...cached, telemetry: { ...(cached.telemetry || {}), cacheHit: true } };
 
   const started = now();
   let attempts = 0;
   for (; attempts < sidecar.maxAttempts; attempts += 1) {
-    const requestSignal = combinedSignal(signal, sidecar.timeoutMs);
     try {
-      const payload = await searchImpl({
+      const payload = await invokeBounded(searchImpl, {
         query: normalized.query,
         maxResults: normalized.maxResults,
+        accountId: normalizedAccountId,
+        model: normalizedModel,
         credentialRef: sidecar.credentialRef,
         providerId: sidecar.providerId,
-        signal: requestSignal,
-      });
-      // An adapter may resolve after aborting if its underlying client does
-      // not propagate AbortSignal. Never turn that late payload into a
-      // successful result after the sidecar deadline/caller cancellation.
-      if (requestSignal.aborted || signal?.aborted) {
-        const reason = abortReason(requestSignal, sidecar.timeoutMs);
-        throw new SearchSidecarError(`Search sidecar ${reason}.`, {
-          code: reason === "timeout" ? "search_sidecar_timeout" : "search_sidecar_cancelled",
-        });
-      }
+        destination: sidecar.destination,
+      }, { signal, timeoutMs: sidecar.timeoutMs });
       const output = normalizeSearchResponse(payload, normalized);
       const result = {
         ...output,
@@ -231,27 +320,25 @@ export async function searchWithSidecar({ config, request, searchImpl, signal, c
           attempts: attempts + 1,
           durationMs: Math.max(0, now() - started),
           providerId: sidecar.providerId,
+          model: normalizedModel,
         },
       };
       cache?.set(key, result);
       return result;
     } catch (error) {
-      if (requestSignal.aborted || signal?.aborted) {
-        const reason = abortReason(requestSignal, sidecar.timeoutMs);
-        throw new SearchSidecarError(`Search sidecar ${reason}.`, {
-          code: reason === "timeout" ? "search_sidecar_timeout" : "search_sidecar_cancelled",
-          telemetry: { cacheHit: false, attempts: attempts + 1, durationMs: Math.max(0, now() - started), providerId: sidecar.providerId },
-          cause: error,
-        });
+      if (error instanceof SearchSidecarError && ["search_sidecar_timeout", "search_sidecar_cancelled"].includes(error.code)) {
+        error.telemetry = { cacheHit: false, attempts: attempts + 1, durationMs: Math.max(0, now() - started), providerId: sidecar.providerId, model: normalizedModel };
+        throw error;
       }
       if (!retryable(error) || attempts + 1 >= sidecar.maxAttempts) {
         throw new SearchSidecarError(error?.message || "Search sidecar request failed.", {
           status: statusOf(error),
-          telemetry: { cacheHit: false, attempts: attempts + 1, durationMs: Math.max(0, now() - started), providerId: sidecar.providerId },
+          telemetry: { cacheHit: false, attempts: attempts + 1, durationMs: Math.max(0, now() - started), providerId: sidecar.providerId, model: normalizedModel },
           cause: error,
         });
       }
-      await sleep(sidecar.retryDelayMs * 2 ** attempts);
+      const delayMs = sidecar.retryDelayMs * 2 ** attempts;
+      await invokeBounded(() => sleep(delayMs), {}, { signal, timeoutMs: Math.max(sidecar.timeoutMs, delayMs + 10) });
     }
   }
   throw new SearchSidecarError("Search sidecar request failed.");

--- a/src/search-sidecar.mjs
+++ b/src/search-sidecar.mjs
@@ -59,13 +59,25 @@ function opaqueRef(value, name, max) {
   return result;
 }
 
+function credentialReference(value) {
+  const result = opaqueRef(value, "credentialRef", 256);
+  if (/^(?:sk|rk|pk)-[A-Za-z0-9]{16,}$/i.test(result)
+    || /^(?:bearer|token)[:_-][A-Za-z0-9._~-]{16,}$/i.test(result)
+    || /^eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(result)) {
+    throw new Error("credentialRef must identify stored credentials, not contain a secret.");
+  }
+  return result;
+}
+
 function unsafeHostname(hostname) {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
   if (normalized === "localhost" || normalized.endsWith(".localhost") || normalized.includes(":")) return true;
   const ipv4 = normalized.split(".").map((part) => Number(part));
   if (ipv4.length !== 4 || !ipv4.every((part) => Number.isInteger(part) && part >= 0 && part <= 255)) return false;
-  return ipv4[0] === 0 || ipv4[0] === 10 || ipv4[0] === 127 || (ipv4[0] === 169 && ipv4[1] === 254)
-    || (ipv4[0] === 172 && ipv4[1] >= 16 && ipv4[1] <= 31) || (ipv4[0] === 192 && ipv4[1] === 168);
+  return ipv4[0] === 0 || ipv4[0] === 10 || ipv4[0] === 127 || (ipv4[0] === 100 && ipv4[1] >= 64 && ipv4[1] <= 127)
+    || (ipv4[0] === 169 && ipv4[1] === 254) || (ipv4[0] === 172 && ipv4[1] >= 16 && ipv4[1] <= 31)
+    || (ipv4[0] === 192 && (ipv4[1] === 168 || (ipv4[1] === 0 && ipv4[2] === 0)))
+    || (ipv4[0] === 198 && ipv4[1] >= 18 && ipv4[1] <= 19) || ipv4[0] >= 224;
 }
 
 function normalizeDestination(value) {
@@ -111,7 +123,7 @@ export function normalizeSearchSidecarConfig(value = {}) {
   const result = {
     enabled,
     ...(value.providerId !== undefined ? { providerId: opaqueRef(value.providerId, "providerId", 128) } : {}),
-    ...(value.credentialRef !== undefined ? { credentialRef: opaqueRef(value.credentialRef, "credentialRef", 256) } : {}),
+    ...(value.credentialRef !== undefined ? { credentialRef: credentialReference(value.credentialRef) } : {}),
     ...(value.destination !== undefined ? { destination: normalizeDestination(value.destination) } : {}),
     timeoutMs: value.timeoutMs === undefined ? SEARCH_SIDECAR_DEFAULTS.timeoutMs : positiveInteger(value.timeoutMs, "timeoutMs", { max: 120_000 }),
     maxResults: value.maxResults === undefined ? SEARCH_SIDECAR_DEFAULTS.maxResults : positiveInteger(value.maxResults, "maxResults", { max: 50 }),
@@ -147,6 +159,14 @@ export function normalizeSearchRequest(request, maxResults = SEARCH_SIDECAR_DEFA
   return Object.freeze({
     query,
     maxResults: positiveInteger(requested, "maxResults", { max: 50 }),
+  });
+}
+
+function capSearchRequest(request, maxResults) {
+  const normalized = normalizeSearchRequest(request, maxResults);
+  return Object.freeze({
+    query: normalized.query,
+    maxResults: Math.min(normalized.maxResults, maxResults),
   });
 }
 
@@ -269,9 +289,17 @@ export async function searchWithSidecar({ config, request, accountId, model, aut
   if (!sidecar.enabled) throw new SearchSidecarError("Search sidecar is disabled.", { code: "search_sidecar_disabled" });
   if (typeof authorize !== "function") throw new SearchSidecarError("Search sidecar invocation is not authorized.", { code: "search_sidecar_unauthorized" });
   if (typeof searchImpl !== "function") throw new Error("searchImpl must be a function.");
-  const normalized = normalizeSearchRequest(request, sidecar.maxResults);
+  const normalized = capSearchRequest(request, sidecar.maxResults);
   const normalizedAccountId = cleanString(accountId, "accountId", 256);
   const normalizedModel = cleanString(model, "model", 256);
+  const started = now();
+  const deadline = started + sidecar.timeoutMs;
+  const remainingTimeout = () => Math.max(0, deadline - now());
+  const bounded = (fn, input = {}) => {
+    const timeoutMs = remainingTimeout();
+    if (timeoutMs <= 0) throw abortError("search_sidecar_timeout");
+    return invokeBounded(fn, input, { signal, timeoutMs });
+  };
   const authorizationInput = {
     accountId: normalizedAccountId,
     model: normalizedModel,
@@ -281,12 +309,13 @@ export async function searchWithSidecar({ config, request, accountId, model, aut
   };
   let authorized;
   try {
-    authorized = await invokeBounded(authorize, authorizationInput, { signal, timeoutMs: sidecar.timeoutMs });
+    authorized = await bounded(authorize, authorizationInput);
   } catch (error) {
     if (error instanceof SearchSidecarError) throw error;
     throw new SearchSidecarError("Search sidecar invocation is not authorized.", { code: "search_sidecar_unauthorized", cause: error });
   }
   if (authorized !== true) throw new SearchSidecarError("Search sidecar invocation is not authorized.", { code: "search_sidecar_unauthorized" });
+  if (remainingTimeout() <= 0) throw abortError("search_sidecar_timeout");
   const key = JSON.stringify({
     accountId: normalizedAccountId,
     model: normalizedModel,
@@ -299,11 +328,10 @@ export async function searchWithSidecar({ config, request, accountId, model, aut
   const cached = cache?.get(key);
   if (cached) return { ...cached, telemetry: { ...(cached.telemetry || {}), cacheHit: true } };
 
-  const started = now();
   let attempts = 0;
   for (; attempts < sidecar.maxAttempts; attempts += 1) {
     try {
-      const payload = await invokeBounded(searchImpl, {
+      const payload = await bounded(searchImpl, {
         query: normalized.query,
         maxResults: normalized.maxResults,
         accountId: normalizedAccountId,
@@ -311,7 +339,7 @@ export async function searchWithSidecar({ config, request, accountId, model, aut
         credentialRef: sidecar.credentialRef,
         providerId: sidecar.providerId,
         destination: sidecar.destination,
-      }, { signal, timeoutMs: sidecar.timeoutMs });
+      });
       const output = normalizeSearchResponse(payload, normalized);
       const result = {
         ...output,
@@ -338,7 +366,20 @@ export async function searchWithSidecar({ config, request, accountId, model, aut
         });
       }
       const delayMs = sidecar.retryDelayMs * 2 ** attempts;
-      await invokeBounded(() => sleep(delayMs), {}, { signal, timeoutMs: Math.max(sidecar.timeoutMs, delayMs + 10) });
+      try {
+        await bounded(() => sleep(delayMs));
+      } catch (backoffError) {
+        if (backoffError instanceof SearchSidecarError) {
+          backoffError.telemetry = {
+            cacheHit: false,
+            attempts: attempts + 1,
+            durationMs: Math.max(0, now() - started),
+            providerId: sidecar.providerId,
+            model: normalizedModel,
+          };
+        }
+        throw backoffError;
+      }
     }
   }
   throw new SearchSidecarError("Search sidecar request failed.");

--- a/src/search-sidecar.mjs
+++ b/src/search-sidecar.mjs
@@ -1,0 +1,258 @@
+// Explicit, provider-agnostic web search for models that cannot consume the
+// native search tool.  This module only coordinates a caller-supplied search
+// adapter: credentials stay in the provider boundary and ordinary text turns
+// never reach it by accident.
+
+export const SEARCH_SIDECAR_DEFAULTS = Object.freeze({
+  timeoutMs: 10_000,
+  maxResults: 8,
+  cacheTtlMs: 60_000,
+  cacheMaxEntries: 128,
+  maxAttempts: 2,
+  retryDelayMs: 100,
+});
+
+const MAX_QUERY_LENGTH = 2_000;
+const MAX_RESULT_LENGTH = 2_000;
+const MAX_URL_LENGTH = 4_096;
+const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const SEARCH_MODES = new Set(["auto", "native", "sidecar"]);
+
+function own(value, key) {
+  return value !== null && typeof value === "object" && Object.hasOwn(value, key);
+}
+
+function positiveInteger(value, name, { max } = {}) {
+  if (!Number.isInteger(value) || value < 1 || (max !== undefined && value > max)) {
+    throw new Error(`${name} must be a positive integer${max ? ` no greater than ${max}` : ""}.`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value, name, { max } = {}) {
+  if (!Number.isInteger(value) || value < 0 || (max !== undefined && value > max)) {
+    throw new Error(`${name} must be a non-negative integer${max ? ` no greater than ${max}` : ""}.`);
+  }
+  return value;
+}
+
+function cleanString(value, name, max) {
+  if (typeof value !== "string" || !value.trim() || value.length > max) {
+    throw new Error(`${name} must be a non-empty string of at most ${max} characters.`);
+  }
+  return value.trim();
+}
+
+/**
+ * Normalize only non-secret sidecar metadata. `credentialRef` is an opaque
+ * reference resolved by the provider adapter; secret values are rejected.
+ */
+export function normalizeSearchSidecarConfig(value = {}) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Search sidecar config must be an object.");
+  }
+  for (const key of ["apiKey", "token", "secret", "password", "authorization"]) {
+    if (own(value, key)) throw new Error(`Search sidecar config cannot contain ${key}.`);
+  }
+  const enabled = value.enabled === true;
+  if (value.enabled !== undefined && typeof value.enabled !== "boolean") {
+    throw new Error("Search sidecar enabled must be a boolean.");
+  }
+  const result = {
+    enabled,
+    ...(value.providerId !== undefined ? { providerId: cleanString(value.providerId, "providerId", 128) } : {}),
+    ...(value.credentialRef !== undefined ? { credentialRef: cleanString(value.credentialRef, "credentialRef", 256) } : {}),
+    timeoutMs: value.timeoutMs === undefined ? SEARCH_SIDECAR_DEFAULTS.timeoutMs : positiveInteger(value.timeoutMs, "timeoutMs", { max: 120_000 }),
+    maxResults: value.maxResults === undefined ? SEARCH_SIDECAR_DEFAULTS.maxResults : positiveInteger(value.maxResults, "maxResults", { max: 50 }),
+    cacheTtlMs: value.cacheTtlMs === undefined ? SEARCH_SIDECAR_DEFAULTS.cacheTtlMs : nonNegativeInteger(value.cacheTtlMs, "cacheTtlMs", { max: 86_400_000 }),
+    cacheMaxEntries: value.cacheMaxEntries === undefined ? SEARCH_SIDECAR_DEFAULTS.cacheMaxEntries : positiveInteger(value.cacheMaxEntries, "cacheMaxEntries", { max: 2_000 }),
+    maxAttempts: value.maxAttempts === undefined ? SEARCH_SIDECAR_DEFAULTS.maxAttempts : positiveInteger(value.maxAttempts, "maxAttempts", { max: 3 }),
+    retryDelayMs: value.retryDelayMs === undefined ? SEARCH_SIDECAR_DEFAULTS.retryDelayMs : nonNegativeInteger(value.retryDelayMs, "retryDelayMs", { max: 10_000 }),
+  };
+  if (result.enabled && !result.providerId) throw new Error("An enabled search sidecar needs providerId.");
+  if (result.enabled && !result.credentialRef) throw new Error("An enabled search sidecar needs credentialRef.");
+  return Object.freeze(result);
+}
+
+/** Resolve native/sidecar transport without model-name conditionals. */
+export function resolveSearchTransport({ modelCapabilities = {}, sidecar, mode = "auto" } = {}) {
+  if (!SEARCH_MODES.has(mode)) throw new Error(`Unknown search mode ${mode}.`);
+  const native = modelCapabilities?.supportsSearch === true;
+  const configured = sidecar?.enabled === true;
+  if (mode === "native") return native ? "native" : "disabled";
+  if (mode === "sidecar") return configured ? "sidecar" : "disabled";
+  if (native) return "native";
+  return configured ? "sidecar" : "disabled";
+}
+
+export function normalizeSearchRequest(request, maxResults = SEARCH_SIDECAR_DEFAULTS.maxResults) {
+  const value = typeof request === "string" ? { query: request } : request;
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Search request must be an object or query string.");
+  }
+  const query = cleanString(value.query, "query", MAX_QUERY_LENGTH);
+  const requested = value.maxResults === undefined ? maxResults : value.maxResults;
+  return Object.freeze({
+    query,
+    maxResults: positiveInteger(requested, "maxResults", { max: 50 }),
+  });
+}
+
+function normalizeResult(value, index) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Search result ${index + 1} is not an object.`);
+  }
+  const url = cleanString(value.url, `results[${index}].url`, MAX_URL_LENGTH);
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`results[${index}].url must be an absolute URL.`);
+  }
+  if (!/^https?:$/.test(parsed.protocol)) throw new Error(`results[${index}].url must use http or https.`);
+  return {
+    title: cleanString(value.title || parsed.hostname, `results[${index}].title`, MAX_RESULT_LENGTH),
+    url,
+    ...(value.snippet === undefined ? {} : { snippet: cleanString(value.snippet, `results[${index}].snippet`, MAX_RESULT_LENGTH) }),
+    ...(value.publishedAt === undefined ? {} : { publishedAt: cleanString(value.publishedAt, `results[${index}].publishedAt`, 128) }),
+  };
+}
+
+export function normalizeSearchResponse(payload, request) {
+  const raw = Array.isArray(payload) ? payload : payload?.results;
+  if (!Array.isArray(raw)) throw new Error("Search sidecar returned no results array.");
+  const results = raw.slice(0, request.maxResults).map(normalizeResult);
+  return {
+    query: request.query,
+    results,
+    citations: results.map((result, index) => ({ index: index + 1, title: result.title, url: result.url })),
+  };
+}
+
+function statusOf(error) {
+  const value = error?.status ?? error?.statusCode ?? error?.response?.status;
+  const status = Number(value);
+  return Number.isInteger(status) ? status : undefined;
+}
+
+function retryable(error) {
+  if (error?.retryable === false) return false;
+  const status = statusOf(error);
+  return error?.retryable === true || (status !== undefined && RETRYABLE_STATUSES.has(status));
+}
+
+function combinedSignal(signal, timeoutMs) {
+  const timeout = AbortSignal.timeout(timeoutMs);
+  if (!signal) return timeout;
+  return AbortSignal.any([signal, timeout]);
+}
+
+function abortReason(signal, timeoutMs) {
+  if (signal?.aborted) {
+    return signal.reason?.name === "TimeoutError" || signal.reason?.code === "ERR_ABORTED"
+      ? "timeout"
+      : "cancelled";
+  }
+  return timeoutMs ? "timeout" : "cancelled";
+}
+
+export class SearchSidecarError extends Error {
+  constructor(message, { code = "search_sidecar_failed", status, telemetry, cause } = {}) {
+    super(message, { cause });
+    this.name = "SearchSidecarError";
+    this.code = code;
+    if (status !== undefined) this.status = status;
+    this.telemetry = telemetry;
+  }
+}
+
+/** Small TTL + insertion-order cache. It stores normalized public results only. */
+export function createSearchCache({ maxEntries = SEARCH_SIDECAR_DEFAULTS.cacheMaxEntries, ttlMs = SEARCH_SIDECAR_DEFAULTS.cacheTtlMs, now = () => Date.now() } = {}) {
+  positiveInteger(maxEntries, "maxEntries", { max: 2_000 });
+  nonNegativeInteger(ttlMs, "ttlMs", { max: 86_400_000 });
+  const entries = new Map();
+  return {
+    get(key) {
+      const entry = entries.get(key);
+      if (!entry || now() - entry.at >= ttlMs) {
+        if (entry) entries.delete(key);
+        return undefined;
+      }
+      entries.delete(key);
+      entries.set(key, entry);
+      return structuredClone(entry.value);
+    },
+    set(key, value) {
+      entries.delete(key);
+      entries.set(key, { at: now(), value: structuredClone(value) });
+      while (entries.size > maxEntries) entries.delete(entries.keys().next().value);
+    },
+    clear() { entries.clear(); },
+    get size() { return entries.size; },
+  };
+}
+
+/** Execute one explicit sidecar search. The adapter owns credential lookup. */
+export async function searchWithSidecar({ config, request, searchImpl, signal, cache, now = () => Date.now(), sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)) } = {}) {
+  const sidecar = normalizeSearchSidecarConfig(config);
+  if (!sidecar.enabled) throw new SearchSidecarError("Search sidecar is disabled.", { code: "search_sidecar_disabled" });
+  if (typeof searchImpl !== "function") throw new Error("searchImpl must be a function.");
+  const normalized = normalizeSearchRequest(request, sidecar.maxResults);
+  const key = `${sidecar.providerId}:${normalized.query}:${normalized.maxResults}`;
+  const cached = cache?.get(key);
+  if (cached) return { ...cached, telemetry: { ...(cached.telemetry || {}), cacheHit: true } };
+
+  const started = now();
+  let attempts = 0;
+  for (; attempts < sidecar.maxAttempts; attempts += 1) {
+    const requestSignal = combinedSignal(signal, sidecar.timeoutMs);
+    try {
+      const payload = await searchImpl({
+        query: normalized.query,
+        maxResults: normalized.maxResults,
+        credentialRef: sidecar.credentialRef,
+        providerId: sidecar.providerId,
+        signal: requestSignal,
+      });
+      // An adapter may resolve after aborting if its underlying client does
+      // not propagate AbortSignal. Never turn that late payload into a
+      // successful result after the sidecar deadline/caller cancellation.
+      if (requestSignal.aborted || signal?.aborted) {
+        const reason = abortReason(requestSignal, sidecar.timeoutMs);
+        throw new SearchSidecarError(`Search sidecar ${reason}.`, {
+          code: reason === "timeout" ? "search_sidecar_timeout" : "search_sidecar_cancelled",
+        });
+      }
+      const output = normalizeSearchResponse(payload, normalized);
+      const result = {
+        ...output,
+        telemetry: {
+          cacheHit: false,
+          attempts: attempts + 1,
+          durationMs: Math.max(0, now() - started),
+          providerId: sidecar.providerId,
+        },
+      };
+      cache?.set(key, result);
+      return result;
+    } catch (error) {
+      if (requestSignal.aborted || signal?.aborted) {
+        const reason = abortReason(requestSignal, sidecar.timeoutMs);
+        throw new SearchSidecarError(`Search sidecar ${reason}.`, {
+          code: reason === "timeout" ? "search_sidecar_timeout" : "search_sidecar_cancelled",
+          telemetry: { cacheHit: false, attempts: attempts + 1, durationMs: Math.max(0, now() - started), providerId: sidecar.providerId },
+          cause: error,
+        });
+      }
+      if (!retryable(error) || attempts + 1 >= sidecar.maxAttempts) {
+        throw new SearchSidecarError(error?.message || "Search sidecar request failed.", {
+          status: statusOf(error),
+          telemetry: { cacheHit: false, attempts: attempts + 1, durationMs: Math.max(0, now() - started), providerId: sidecar.providerId },
+          cause: error,
+        });
+      }
+      await sleep(sidecar.retryDelayMs * 2 ** attempts);
+    }
+  }
+  throw new SearchSidecarError("Search sidecar request failed.");
+}

--- a/test/search-sidecar.test.mjs
+++ b/test/search-sidecar.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSearchCache,
+  normalizeSearchResponse,
+  normalizeSearchSidecarConfig,
+  resolveSearchTransport,
+  searchWithSidecar,
+  SearchSidecarError,
+} from "../src/search-sidecar.mjs";
+
+const config = { enabled: true, providerId: "search-provider", credentialRef: "cred_search" };
+
+test("native search wins in auto mode and sidecar is explicit", () => {
+  assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: true }, sidecar: config }), "native");
+  assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: true }, sidecar: config, mode: "sidecar" }), "sidecar");
+  assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: false }, sidecar: config }), "sidecar");
+  assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: false }, sidecar: {} }), "disabled");
+});
+
+test("enabled config contains only opaque credential metadata", () => {
+  assert.throws(() => normalizeSearchSidecarConfig({ ...config, apiKey: "secret" }), /cannot contain apiKey/);
+  assert.throws(() => normalizeSearchSidecarConfig({ enabled: true, providerId: "search-provider" }), /credentialRef/);
+  assert.equal(normalizeSearchSidecarConfig(config).enabled, true);
+});
+
+test("success returns bounded results, citations and telemetry", async () => {
+  const calls = [];
+  const result = await searchWithSidecar({
+    config: { ...config, maxResults: 1 },
+    request: { query: "  latest news  " },
+    searchImpl: async (input) => {
+      calls.push(input);
+      return { results: [
+        { title: "One", url: "https://example.com/1", snippet: "summary" },
+        { title: "Two", url: "https://example.com/2" },
+      ] };
+    },
+    cache: createSearchCache(),
+  });
+  assert.equal(calls[0].credentialRef, "cred_search");
+  assert.equal(result.results.length, 1);
+  assert.deepEqual(result.citations, [{ index: 1, title: "One", url: "https://example.com/1" }]);
+  assert.equal(result.telemetry.cacheHit, false);
+});
+
+test("cache hit avoids a duplicate provider call and stays bounded", async () => {
+  let calls = 0;
+  const cache = createSearchCache({ maxEntries: 1, ttlMs: 100 });
+  const searchImpl = async () => { calls += 1; return [{ title: "One", url: "https://example.com" }]; };
+  const first = await searchWithSidecar({ config, request: "same", searchImpl, cache });
+  const second = await searchWithSidecar({ config, request: "same", searchImpl, cache });
+  assert.equal(calls, 1);
+  assert.equal(first.telemetry.cacheHit, false);
+  assert.equal(second.telemetry.cacheHit, true);
+  assert.equal(cache.size, 1);
+});
+
+test("transient errors retry, but deterministic errors do not", async () => {
+  let calls = 0;
+  const sleeps = [];
+  const result = await searchWithSidecar({
+    config: { ...config, maxAttempts: 2, retryDelayMs: 7 },
+    request: "retry",
+    searchImpl: async () => {
+      calls += 1;
+      if (calls === 1) throw Object.assign(new Error("busy"), { status: 503 });
+      return [{ title: "One", url: "https://example.com" }];
+    },
+    sleep: async (ms) => sleeps.push(ms),
+  });
+  assert.equal(calls, 2);
+  assert.deepEqual(sleeps, [7]);
+  await assert.rejects(
+    () => searchWithSidecar({ config, request: "bad", searchImpl: async () => { throw Object.assign(new Error("bad request"), { status: 400 }); } }),
+    (error) => error instanceof SearchSidecarError && error.status === 400 && error.telemetry.attempts === 1,
+  );
+});
+
+test("explicit non-retryable errors do not retry even for a transient status", async () => {
+  let calls = 0;
+  await assert.rejects(
+    () => searchWithSidecar({
+      config: { ...config, maxAttempts: 2 },
+      request: "no-retry",
+      searchImpl: async () => {
+        calls += 1;
+        throw Object.assign(new Error("provider stopped"), { status: 503, retryable: false });
+      },
+    }),
+    (error) => error instanceof SearchSidecarError && error.status === 503 && error.telemetry.attempts === 1,
+  );
+  assert.equal(calls, 1);
+});
+
+test("timeout and caller cancellation are observable", async () => {
+  await assert.rejects(
+    () => searchWithSidecar({
+      config: { ...config, timeoutMs: 5 },
+      request: "slow",
+      searchImpl: ({ signal }) => new Promise((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }),
+    }),
+    (error) => error.code === "search_sidecar_timeout" && error.telemetry.attempts === 1,
+  );
+  const controller = new AbortController();
+  controller.abort(new Error("user cancelled"));
+  await assert.rejects(
+    () => searchWithSidecar({ config, request: "cancel", signal: controller.signal, searchImpl: async ({ signal }) => { signal.throwIfAborted(); } }),
+    (error) => error.code === "search_sidecar_cancelled",
+  );
+});
+
+test("late adapter responses cannot bypass the timeout", async () => {
+  await assert.rejects(
+    () => searchWithSidecar({
+      config: { ...config, timeoutMs: 5, maxAttempts: 1 },
+      request: "late",
+      searchImpl: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return [{ title: "Late", url: "https://example.com/late" }];
+      },
+    }),
+    (error) => error.code === "search_sidecar_timeout" && error.telemetry.attempts === 1,
+  );
+});
+
+test("malformed results never enter the model-visible schema", () => {
+  assert.throws(() => normalizeSearchResponse({ results: [{ title: "bad", url: "file:///tmp/a" }] }, { query: "x", maxResults: 1 }), /http or https/);
+  assert.throws(() => normalizeSearchResponse({ results: [null] }, { query: "x", maxResults: 1 }), /Search result/);
+});

--- a/test/search-sidecar.test.mjs
+++ b/test/search-sidecar.test.mjs
@@ -32,8 +32,10 @@ test("enabled config contains only opaque credential and destination metadata", 
   assert.throws(() => normalizeSearchSidecarConfig({ ...config, destination: "http://search.example.test" }), /HTTPS/);
   assert.throws(() => normalizeSearchSidecarConfig({ ...config, destination: "https://user:pass@search.example.test" }), /credentials/);
   assert.throws(() => normalizeSearchSidecarConfig({ ...config, destination: "https://127.0.0.1/search" }), /private address/);
+  assert.throws(() => normalizeSearchSidecarConfig({ ...config, destination: "https://100.64.0.1/search" }), /private address/);
   assert.throws(() => normalizeSearchSidecarConfig({ ...config, credentialRef: "secret value" }), /opaque reference/);
   assert.throws(() => normalizeSearchSidecarConfig({ ...config, credentialRef: "secret\nvalue" }), /at most/);
+  assert.throws(() => normalizeSearchSidecarConfig({ ...config, credentialRef: "sk-12345678901234567890" }), /stored credentials/);
   assert.equal(normalizeSearchSidecarConfig(config).enabled, true);
 });
 
@@ -60,6 +62,26 @@ test("success returns bounded results, citations and telemetry", async () => {
   assert.equal(result.results.length, 1);
   assert.deepEqual(result.citations, [{ index: 1, title: "One", url: "https://example.com/1" }]);
   assert.equal(result.telemetry.cacheHit, false);
+});
+
+test("configured maxResults is a hard cap for explicit request limits", async () => {
+  let requested;
+  const result = await searchWithSidecar({
+    config: { ...config, maxResults: 1 },
+    request: { query: "bounded", maxResults: 50 },
+    accountId: "account-a",
+    model: "model-a",
+    authorize: authorized,
+    searchImpl: async (input) => {
+      requested = input.maxResults;
+      return [
+        { title: "One", url: "https://example.com/1" },
+        { title: "Two", url: "https://example.com/2" },
+      ];
+    },
+  });
+  assert.equal(requested, 1);
+  assert.equal(result.results.length, 1);
 });
 
 test("cache keys isolate account, provider and model", async () => {
@@ -172,6 +194,27 @@ test("a hung retry backoff is bounded and cancellable", async () => {
     }),
     (error) => error.code === "search_sidecar_timeout",
   );
+});
+
+test("the timeout is a total operation budget across retries", async () => {
+  const started = Date.now();
+  let calls = 0;
+  await assert.rejects(
+    () => searchWithSidecar({
+      config: { ...config, timeoutMs: 15, maxAttempts: 2, retryDelayMs: 1 },
+      request: "total-timeout",
+      accountId: "account-a",
+      model: "model-a",
+      authorize: authorized,
+      searchImpl: async ({ signal }) => new Promise((resolve, reject) => {
+        calls += 1;
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }),
+    }),
+    (error) => error.code === "search_sidecar_timeout" && error.telemetry.attempts === 1,
+  );
+  assert.equal(calls, 1);
+  assert.ok(Date.now() - started < 100, "operation should not restart the full timeout for another attempt");
 });
 
 test("authorization is mandatory and runs before cache access", async () => {

--- a/test/search-sidecar.test.mjs
+++ b/test/search-sidecar.test.mjs
@@ -10,18 +10,30 @@ import {
   SearchSidecarError,
 } from "../src/search-sidecar.mjs";
 
-const config = { enabled: true, providerId: "search-provider", credentialRef: "cred_search" };
+const config = {
+  enabled: true,
+  providerId: "search-provider",
+  credentialRef: "cred_search",
+  destination: "https://search.example.test/api/search",
+};
+const authorized = async () => true;
 
-test("native search wins in auto mode and sidecar is explicit", () => {
+test("native search wins in auto mode and sidecar requires explicit authorization", () => {
   assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: true }, sidecar: config }), "native");
-  assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: true }, sidecar: config, mode: "sidecar" }), "sidecar");
-  assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: false }, sidecar: config }), "sidecar");
+  assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: true }, sidecar: config, mode: "sidecar" }), "disabled");
+  assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: true }, sidecar: config, mode: "sidecar", invocationAuthorized: true }), "sidecar");
+  assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: false }, sidecar: config }), "disabled");
   assert.equal(resolveSearchTransport({ modelCapabilities: { supportsSearch: false }, sidecar: {} }), "disabled");
 });
 
-test("enabled config contains only opaque credential metadata", () => {
-  assert.throws(() => normalizeSearchSidecarConfig({ ...config, apiKey: "secret" }), /cannot contain apiKey/);
+test("enabled config contains only opaque credential and destination metadata", () => {
+  assert.throws(() => normalizeSearchSidecarConfig({ ...config, apiKey: "secret" }), /does not accept apiKey/);
   assert.throws(() => normalizeSearchSidecarConfig({ enabled: true, providerId: "search-provider" }), /credentialRef/);
+  assert.throws(() => normalizeSearchSidecarConfig({ ...config, destination: "http://search.example.test" }), /HTTPS/);
+  assert.throws(() => normalizeSearchSidecarConfig({ ...config, destination: "https://user:pass@search.example.test" }), /credentials/);
+  assert.throws(() => normalizeSearchSidecarConfig({ ...config, destination: "https://127.0.0.1/search" }), /private address/);
+  assert.throws(() => normalizeSearchSidecarConfig({ ...config, credentialRef: "secret value" }), /opaque reference/);
+  assert.throws(() => normalizeSearchSidecarConfig({ ...config, credentialRef: "secret\nvalue" }), /at most/);
   assert.equal(normalizeSearchSidecarConfig(config).enabled, true);
 });
 
@@ -30,6 +42,9 @@ test("success returns bounded results, citations and telemetry", async () => {
   const result = await searchWithSidecar({
     config: { ...config, maxResults: 1 },
     request: { query: "  latest news  " },
+    accountId: "account-a",
+    model: "model-a",
+    authorize: authorized,
     searchImpl: async (input) => {
       calls.push(input);
       return { results: [
@@ -40,21 +55,26 @@ test("success returns bounded results, citations and telemetry", async () => {
     cache: createSearchCache(),
   });
   assert.equal(calls[0].credentialRef, "cred_search");
+  assert.equal(calls[0].destination, config.destination);
+  assert.equal(calls[0].accountId, "account-a");
   assert.equal(result.results.length, 1);
   assert.deepEqual(result.citations, [{ index: 1, title: "One", url: "https://example.com/1" }]);
   assert.equal(result.telemetry.cacheHit, false);
 });
 
-test("cache hit avoids a duplicate provider call and stays bounded", async () => {
+test("cache keys isolate account, provider and model", async () => {
   let calls = 0;
-  const cache = createSearchCache({ maxEntries: 1, ttlMs: 100 });
+  const cache = createSearchCache({ maxEntries: 10, ttlMs: 100 });
   const searchImpl = async () => { calls += 1; return [{ title: "One", url: "https://example.com" }]; };
-  const first = await searchWithSidecar({ config, request: "same", searchImpl, cache });
-  const second = await searchWithSidecar({ config, request: "same", searchImpl, cache });
-  assert.equal(calls, 1);
+  const first = await searchWithSidecar({ config, request: "same", accountId: "account-a", model: "model-a", authorize: authorized, searchImpl, cache });
+  const second = await searchWithSidecar({ config, request: "same", accountId: "account-a", model: "model-a", authorize: authorized, searchImpl, cache });
+  await searchWithSidecar({ config, request: "same", accountId: "account-b", model: "model-a", authorize: authorized, searchImpl, cache });
+  await searchWithSidecar({ config, request: "same", accountId: "account-a", model: "model-b", authorize: authorized, searchImpl, cache });
+  await searchWithSidecar({ config: { ...config, providerId: "other-provider", credentialRef: "other_credential", destination: "https://other.example.test/search" }, request: "same", accountId: "account-a", model: "model-a", authorize: authorized, searchImpl, cache });
+  assert.equal(calls, 4);
   assert.equal(first.telemetry.cacheHit, false);
   assert.equal(second.telemetry.cacheHit, true);
-  assert.equal(cache.size, 1);
+  assert.equal(cache.size, 4);
 });
 
 test("transient errors retry, but deterministic errors do not", async () => {
@@ -63,6 +83,9 @@ test("transient errors retry, but deterministic errors do not", async () => {
   const result = await searchWithSidecar({
     config: { ...config, maxAttempts: 2, retryDelayMs: 7 },
     request: "retry",
+    accountId: "account-a",
+    model: "model-a",
+    authorize: authorized,
     searchImpl: async () => {
       calls += 1;
       if (calls === 1) throw Object.assign(new Error("busy"), { status: 503 });
@@ -73,7 +96,7 @@ test("transient errors retry, but deterministic errors do not", async () => {
   assert.equal(calls, 2);
   assert.deepEqual(sleeps, [7]);
   await assert.rejects(
-    () => searchWithSidecar({ config, request: "bad", searchImpl: async () => { throw Object.assign(new Error("bad request"), { status: 400 }); } }),
+    () => searchWithSidecar({ config, request: "bad", accountId: "account-a", model: "model-a", authorize: authorized, searchImpl: async () => { throw Object.assign(new Error("bad request"), { status: 400 }); } }),
     (error) => error instanceof SearchSidecarError && error.status === 400 && error.telemetry.attempts === 1,
   );
 });
@@ -84,6 +107,9 @@ test("explicit non-retryable errors do not retry even for a transient status", a
     () => searchWithSidecar({
       config: { ...config, maxAttempts: 2 },
       request: "no-retry",
+      accountId: "account-a",
+      model: "model-a",
+      authorize: authorized,
       searchImpl: async () => {
         calls += 1;
         throw Object.assign(new Error("provider stopped"), { status: 503, retryable: false });
@@ -99,6 +125,9 @@ test("timeout and caller cancellation are observable", async () => {
     () => searchWithSidecar({
       config: { ...config, timeoutMs: 5 },
       request: "slow",
+      accountId: "account-a",
+      model: "model-a",
+      authorize: authorized,
       searchImpl: ({ signal }) => new Promise((resolve, reject) => {
         signal.addEventListener("abort", () => reject(signal.reason), { once: true });
       }),
@@ -108,7 +137,7 @@ test("timeout and caller cancellation are observable", async () => {
   const controller = new AbortController();
   controller.abort(new Error("user cancelled"));
   await assert.rejects(
-    () => searchWithSidecar({ config, request: "cancel", signal: controller.signal, searchImpl: async ({ signal }) => { signal.throwIfAborted(); } }),
+    () => searchWithSidecar({ config, request: "cancel", accountId: "account-a", model: "model-a", authorize: authorized, signal: controller.signal, searchImpl: async ({ signal }) => { signal.throwIfAborted(); } }),
     (error) => error.code === "search_sidecar_cancelled",
   );
 });
@@ -118,6 +147,9 @@ test("late adapter responses cannot bypass the timeout", async () => {
     () => searchWithSidecar({
       config: { ...config, timeoutMs: 5, maxAttempts: 1 },
       request: "late",
+      accountId: "account-a",
+      model: "model-a",
+      authorize: authorized,
       searchImpl: async () => {
         await new Promise((resolve) => setTimeout(resolve, 20));
         return [{ title: "Late", url: "https://example.com/late" }];
@@ -127,7 +159,57 @@ test("late adapter responses cannot bypass the timeout", async () => {
   );
 });
 
+test("a hung retry backoff is bounded and cancellable", async () => {
+  await assert.rejects(
+    () => searchWithSidecar({
+      config: { ...config, timeoutMs: 5, maxAttempts: 2 },
+      request: "hung-backoff",
+      accountId: "account-a",
+      model: "model-a",
+      authorize: authorized,
+      searchImpl: async () => { throw Object.assign(new Error("busy"), { status: 503 }); },
+      sleep: async () => new Promise(() => {}),
+    }),
+    (error) => error.code === "search_sidecar_timeout",
+  );
+});
+
+test("authorization is mandatory and runs before cache access", async () => {
+  const cache = createSearchCache();
+  let calls = 0;
+  await assert.rejects(
+    () => searchWithSidecar({ config, request: "blocked", accountId: "account-a", model: "model-a", searchImpl: async () => { calls += 1; return []; }, cache }),
+    (error) => error.code === "search_sidecar_unauthorized",
+  );
+  await assert.rejects(
+    () => searchWithSidecar({ config, request: "blocked", accountId: "account-a", model: "model-a", authorize: async () => false, searchImpl: async () => { calls += 1; return []; }, cache }),
+    (error) => error.code === "search_sidecar_unauthorized",
+  );
+  assert.equal(calls, 0);
+});
+
+test("a hung authorization gate is bounded", async () => {
+  await assert.rejects(
+    () => searchWithSidecar({
+      config: { ...config, timeoutMs: 5 },
+      request: "hung-auth",
+      accountId: "account-a",
+      model: "model-a",
+      authorize: async () => new Promise(() => {}),
+      searchImpl: async () => [],
+    }),
+    (error) => error.code === "search_sidecar_timeout",
+  );
+});
+
 test("malformed results never enter the model-visible schema", () => {
-  assert.throws(() => normalizeSearchResponse({ results: [{ title: "bad", url: "file:///tmp/a" }] }, { query: "x", maxResults: 1 }), /http or https/);
+  assert.throws(() => normalizeSearchResponse({ results: [{ title: "bad", url: "file:///tmp/a" }] }, { query: "x", maxResults: 1 }), /HTTP\(S\)/);
+  assert.throws(() => normalizeSearchResponse({ results: [{ title: "bad", url: "https://user:pass@example.com" }] }, { query: "x", maxResults: 1 }), /credentials/);
+  assert.throws(() => normalizeSearchResponse({ results: [{ title: "bad", url: "http://127.0.0.1" }] }, { query: "x", maxResults: 1 }), /private address/);
   assert.throws(() => normalizeSearchResponse({ results: [null] }, { query: "x", maxResults: 1 }), /Search result/);
+  const sanitized = normalizeSearchResponse({ results: [{ title: "<b>Title</b>", url: "https://example.com", snippet: "line\n<script>alert(1)</script> two" }] }, { query: "x", maxResults: 1 });
+  assert.deepEqual(sanitized.results[0],
+    { title: "Title", url: "https://example.com/", snippet: "line two" },
+  );
+  assert.deepEqual(sanitized.citations, [{ index: 1, title: "Title", url: "https://example.com/" }]);
 });


### PR DESCRIPTION
## Summary

- Keep the search sidecar isolated and unadvertised until a real router caller and provider policy exist.
- Require explicit, bounded authorization before any sidecar call or cache lookup.
- Use native search in `auto`; sidecar search is explicit and never an automatic fallback.
- Scope cache keys by account, provider, model, credential reference, destination, query, and result limit.
- Apply one hard operation deadline across authorization, adapter attempts, and retry backoff; propagate cancellation.
- Enforce result limits, reject non-public or credential-bearing destinations and URLs, reject common raw credential values, and sanitize model-visible text/citations.
- Add adversarial tests for authorization, cache isolation, limits, unsafe destinations, retries, hung adapters/backoff, cancellation, and untrusted snippets.

## Reason

The previous sidecar could be reached without a clear caller gate, reuse results across accounts, wait indefinitely or restart its timeout on retries, and pass unsafe destination or content values through to the model. This revision closes those paths without changing native search behavior or advertising an unready provider.

## Validation

- `npm run check`
- `node --test test/search-sidecar.test.mjs` (14 passed)
- `git diff --check`
- Full `npm test` remains environment-blocked in this clean worktree because `undici` and `proper-lockfile` are not installed.

## Remaining risks

- No production adapter or router caller is included; the sidecar remains intentionally unadvertised until an explicit authorization policy and trusted destination allow-list are wired.
- Host checks are syntactic; a future adapter must use a trusted allow-list and protect against DNS rebinding.

