### PR TITLE
docs: add OpenCodex parity roadmap

### DIFF
--- a/docs/OPENCODEX_FEATURE_GAP_SPEC.md
+++ b/docs/OPENCODEX_FEATURE_GAP_SPEC.md
@@ -1,0 +1,789 @@
+# OpenCodex feature gap specification for Codex Router
+
+Status: implementation handoff
+
+Baseline: 2026-08-24
+
+Implementation tracking: [OpenCodex parity implementation roadmap](./OPENCODEX_IMPLEMENTATION_ROADMAP.md)
+
+This document describes the OpenCodex features that are not currently present in
+Codex Router, or that are present only in a narrower form. It is written for an
+AI coding agent. The agent must verify the live checkout and upstream APIs before
+changing code; this is a design and acceptance specification, not a request to
+copy OpenCodex code.
+
+## 1. Source baseline
+
+- [OpenCodex](https://github.com/lidge-jun/opencodex), inspected at the `main`
+  branch release represented by version `2.31.0`.
+- [Codex Router](https://github.com/duolahypercho/codex-router), inspected at
+  the current `main` documentation and the local `0.4.0-beta.4` checkout.
+- The OpenCodex registry and types are the source for feature names. The
+  Codex Router source and its generated catalog are authoritative for what is
+  already supported here.
+
+Provider names below are OpenCodex registry IDs. Some IDs are aliases or protocol
+variants rather than independent companies. “Missing” means that Codex Router
+has no equivalent first-class route today; it does not mean that a user can never
+reach the service through a manually configured endpoint.
+
+## 2. Executive summary
+
+Codex Router already has a strong, deliberately narrow path for the Codex App,
+Codex CLI, DeepSeek Harness and Gemini CLI. It preserves the native GPT catalog,
+native default model, and native speed controls. It also has provider/model
+failover, cooldowns, usage reporting, a vision bridge, standalone-search metadata,
+and a large set of configured providers.
+
+OpenCodex is broader in three areas:
+
+1. It treats credentials as routable pools, not only as one credential per
+   provider. This includes multiple ChatGPT/Codex accounts, API-key pools,
+   account priority, quota-aware selection, sticky account affinity and
+   re-authentication.
+2. It has a generic provider management layer. A user can add any OpenAI-
+   compatible endpoint, discover or register its models, set headers and key
+   transport, and expose it through the same routing surface.
+3. It includes more adapters, client integrations, virtual combo models, a
+   provider-agnostic web-search sidecar, and a dashboard for live management.
+
+The implementation target is additive parity. It must not replace the native
+Codex path, silently change a user's default model, remove GPT speed tiers,
+rewrite existing provider logins, or weaken the current verified-model safety
+policy.
+
+## 3. Current capability matrix
+
+| Area | Codex Router today | OpenCodex behavior | Gap |
+| --- | --- | --- | --- |
+| Native GPT catalog/login | Native Codex-owned catalog and login are preserved | OpenAI/ChatGPT route plus pooled Codex accounts | Add pooled accounts without taking ownership of native GPT metadata |
+| Provider failover | Automatic model/provider failover and cooldowns | Failover plus user-defined combos and account pools | Add explicit combos and credential-level failover |
+| Per-model custom endpoint | `custom` provider supports a per-model endpoint and metadata | Generic provider can be added/edited with base URL, adapter, headers and models | Promote the capability to a reusable provider object |
+| OpenAI-compatible protocol | Several curated routes and custom model routes | Any OpenAI-compatible provider; OpenAI Responses and Chat Completions adapters | Add generic adapter/capability negotiation and broader endpoint pass-through |
+| API keys | Provider-specific credential handling | Multiple API keys per provider, active key, key health and rotation | Add a provider-scoped key pool |
+| ChatGPT accounts | One native Codex login flow | Multiple accounts, quota tracking, strategies, sticky affinity and re-auth | Add a policy-controlled account pool |
+| Anthropic | API route | API and OAuth account pool | Add OAuth only if the provider terms and auth contract permit it |
+| Model catalog | Curated registry, verified metadata, custom model files | Live model discovery plus add/edit/remove/enable/disable/selected models | Add provider-scoped discovery and user catalog overrides |
+| Search | Native client-side standalone search for verified models; hosted provider-specific search where available | Web-search sidecar that can serve models which cannot consume the native search tool | Add an explicit sidecar, with bounded results and opt-in policy |
+| Vision | Vision bridge and local vision support already exist | Vision translation across adapters and sidecars | Reuse current bridge; add capability declarations, not another image shim |
+| Sub-agents | v1/v2 and certified model metadata | Any model, fallback chains, effort/injection controls | Add opt-in unverified models and per-agent fallback policy |
+| Virtual models | Internal model/provider fallback | Named combos with failover or weighted round-robin, weights and sticky limits | Add persisted combo definitions |
+| Dashboard | macOS tray/control center and operational views | Web dashboard for providers, models, accounts, combos, logs and usage | Add a browser control plane only where the existing UI cannot manage a feature |
+| Client exports | Codex, DSH and Gemini-oriented integration | OpenCode, Pi, OMP, Hermes, OpenClaw, Kimi, Gajae, DSH, MCode, ZCode, Prime Agent and others | Add exports only after the gateway contracts are stable |
+
+## 4. Gap A: account and credential pooling
+
+### 4.1 Required concepts
+
+Implement a provider-neutral credential store with two credential classes:
+
+- `account`: an OAuth or first-party login identity, for example a ChatGPT/Codex
+  account or an Anthropic OAuth account;
+- `api_key`: a key or token for an API provider.
+
+Each credential must have a stable opaque ID. Email addresses, provider account
+IDs and aliases are metadata, not routing keys. Secrets must remain encrypted at
+rest and must never be returned by list/status endpoints or written to ordinary
+request logs.
+
+Logical account fields:
+
+```json
+{
+  "id": "acct_opaque_id",
+  "provider": "openai",
+  "kind": "account",
+  "alias": "personal",
+  "email": "redacted-or-local-only",
+  "plan": "unknown",
+  "providerAccountId": "provider-id-if-available",
+  "auth": {
+    "accessTokenRef": "secret-ref",
+    "refreshTokenRef": "secret-ref",
+    "expiresAt": "2026-08-24T12:00:00Z"
+  },
+  "state": "healthy",
+  "paused": false,
+  "priority": 50,
+  "usage": {
+    "window5h": {"used": 0, "limit": null, "resetAt": null},
+    "weekly": {"used": 0, "limit": null, "resetAt": null},
+    "monthly": {"used": 0, "limit": null, "resetAt": null}
+  },
+  "lastUsedAt": null,
+  "lastErrorAt": null
+}
+```
+
+Logical API-key fields:
+
+```json
+{
+  "id": "key_opaque_id",
+  "provider": "openrouter",
+  "kind": "api_key",
+  "alias": "primary",
+  "secretRef": "secret-ref",
+  "transport": "authorization-bearer",
+  "state": "healthy",
+  "paused": false,
+  "priority": 50,
+  "usage": {"requests": 0, "tokens": 0, "resetAt": null}
+}
+```
+
+The exact persistence format may follow the existing Codex Router state store.
+Do not create a second unencrypted credentials database.
+
+### 4.2 Pool policies
+
+Support these policies for each provider pool:
+
+- `quota`: choose the healthy account with the most remaining quota, or the
+  highest remaining score when a provider exposes several windows;
+- `round-robin`: distribute new requests across eligible credentials;
+- `fill-first`: keep using the highest-priority eligible credential until it
+  reaches the configured threshold, then move to the next one.
+
+Common policy fields:
+
+```json
+{
+  "strategy": "quota",
+  "autoSwitchThreshold": 0.10,
+  "sticky": true,
+  "stickyLimit": 50,
+  "maxCooldownSeconds": 300,
+  "pausedCredentialIds": [],
+  "priorityOrder": ["acct_opaque_id"]
+}
+```
+
+The threshold is a fraction of the provider-reported remaining quota. If quota is
+unknown, the router must not invent a percentage; use health, priority and the
+selected non-quota strategy instead.
+
+### 4.3 Selection and affinity
+
+1. A new conversation receives one eligible credential.
+2. The selected credential is stored in conversation/session state.
+3. Subsequent turns keep that credential while it is healthy and within policy.
+4. A credential may be rebound on expiry, explicit pause, 401/403, rate limit,
+   provider outage or quota threshold crossing.
+5. Rebinding must be atomic for the conversation. Two concurrent turns must not
+   select different credentials for the same session.
+6. Streaming failures may retry only before any assistant bytes are committed.
+   After output starts, report the error and preserve the transcript; do not
+   silently duplicate a tool call.
+
+OpenCodex's sticky limit is a pool policy, not a global timeout. Implement it as
+the maximum number of turns or requests that may retain a binding before a
+re-evaluation. Make the unit explicit in the configuration and API.
+
+### 4.4 Lifecycle operations
+
+Provide authenticated control operations for:
+
+- list accounts/keys with health, quota snapshot and last error;
+- add, remove, pause and resume a credential;
+- select a credential for the next new session;
+- set priority and pool strategy;
+- refresh or re-authenticate OAuth credentials;
+- clear cooldown and reset local usage counters;
+- test a credential with a non-billable metadata request where supported.
+
+Provider quota refresh must be cached and rate-limited. A request must not block
+on a quota API call unless the cache is expired and the operation is explicitly a
+health check.
+
+### 4.5 Policy and safety constraints
+
+Pooling is for continuity, quota-aware routing and operational resilience. It
+must not be marketed or implemented as a way to evade provider limits, account
+enforcement or terms of service. Show a warning before adding a pool and keep an
+audit record of account changes without storing token values. Never accept a pool
+of credentials from an untrusted remote control client.
+
+## 5. Gap B: generic OpenAI-compatible providers
+
+### 5.1 Desired user model
+
+A user should be able to add a provider without a source-code change:
+
+```text
+router provider add local-vllm \
+  --adapter openai-chat \
+  --base-url http://127.0.0.1:8000/v1 \
+  --api-key-ref env:LOCAL_VLLM_KEY \
+  --allow-private-network
+```
+
+The provider then exposes models from `/v1/models`, or accepts explicitly
+registered model IDs when discovery is unavailable. A provider may contain many
+models and many credentials. The current `custom` route remains supported as a
+compatibility alias for a single model endpoint.
+
+### 5.2 Provider object
+
+Use one logical schema, mapped to the existing Codex Router state/config system:
+
+```json
+{
+  "id": "local-vllm",
+  "displayName": "Local vLLM",
+  "enabled": true,
+  "adapter": "openai-chat",
+  "baseUrl": "http://127.0.0.1:8000/v1",
+  "auth": {
+    "mode": "api_key",
+    "keyIds": ["key_opaque_id"],
+    "transport": "authorization-bearer",
+    "headers": {"X-Tenant": "local"}
+  },
+  "network": {
+    "allowPrivate": true,
+    "connectTimeoutMs": 10000,
+    "requestTimeoutMs": 300000
+  },
+  "discovery": {
+    "enabled": true,
+    "path": "/models",
+    "refreshSeconds": 900
+  },
+  "models": {
+    "qwen-local": {
+      "upstreamId": "Qwen/Qwen3.8-27B",
+      "displayName": "Qwen 3.8 27B (Local)",
+      "modalities": ["text"],
+      "supportsTools": true,
+      "supportsReasoning": true,
+      "supportsVision": false,
+      "contextWindow": 131072,
+      "requestProfile": "auto-tool-choice"
+    }
+  }
+}
+```
+
+Private or loopback endpoints must require an explicit local opt-in. Remote
+control requests must not be allowed to use arbitrary private-network URLs.
+Validate URL schemes, reject file URLs, and protect against DNS rebinding where
+the process is exposed beyond loopback.
+
+### 5.3 Adapters and capabilities
+
+Implement adapters as protocol translators, not provider-name conditionals:
+
+- `openai-responses`: `/v1/responses`, streaming events, tool calls and
+  reasoning items;
+- `openai-chat`: `/v1/chat/completions`, streamed deltas and tool calls;
+- `openai-completions`: legacy `/v1/completions` for text-only models;
+- `anthropic-messages`: `/v1/messages` where the provider has a supported
+  Anthropic contract;
+- `google-generative-ai`: Gemini-native request/response mapping;
+- `azure-openai`: Azure URL/version/auth rules.
+
+The adapter must advertise capabilities before translating a request:
+
+```json
+{
+  "inputModalities": ["text"],
+  "outputModalities": ["text"],
+  "streaming": true,
+  "tools": true,
+  "parallelToolCalls": false,
+  "reasoning": "field-or-none",
+  "vision": false,
+  "webSearch": false,
+  "structuredOutput": true,
+  "maxOutputTokensField": "max_tokens"
+}
+```
+
+Unsupported fields must be omitted or translated according to the capability
+profile. Never send `image_url`, native search tools, reasoning fields or
+`parallel_tool_calls` to a model that declares those capabilities as unsupported.
+Do not infer a capability from a marketing name; use provider metadata, a
+verified preset or an explicit user override.
+
+### 5.4 OpenAI endpoint coverage
+
+The generic provider layer should expose a capability-aware pass-through for the
+following OpenAI-compatible routes:
+
+| Route | Priority | Requirement |
+| --- | --- | --- |
+| `GET /v1/models` | P0 | Discovery, filtering and model health |
+| `POST /v1/responses` | P0 | Codex-native route and Responses-compatible providers |
+| `POST /v1/chat/completions` | P0 | Main compatibility path |
+| `POST /v1/completions` | P1 | Legacy text-only providers |
+| `POST /v1/embeddings` | P2 | Expose only if a client calls it; never advertise it as a chat model |
+| `POST /v1/images/generations` | P2 | Expose only for a provider/model declaring image generation |
+| `POST /v1/audio/speech` | P2 | Expose only for TTS-capable providers |
+| `POST /v1/audio/transcriptions` | P2 | Expose only for transcription-capable providers |
+| `POST /v1/audio/translations` | P2 | Same capability gate as transcription |
+| `POST /v1/moderations` | P2 | Expose only for moderation-capable providers |
+| `POST /v1/files` and `DELETE /v1/files/{id}` | P2 | Multipart upload/list/retrieve/delete with size limits |
+| `POST /v1/batches` and batch status routes | P3 | Long-running jobs, polling and cancellation |
+| Fine-tuning job routes | P3 | Expose only when the upstream and client contract support them |
+| Assistants/threads/runs/vector stores | P3 | Legacy/extended compatibility; verify current OpenAI contract first |
+
+P0 is required for Codex Router feature parity. P1/P2 are general OpenAI API
+compatibility and must not be wired into the Codex model selector unless the
+client contract supports them. Keep endpoint forwarding separate from model
+selection so a provider cannot accidentally claim to be a chat model.
+
+For literal full-API compatibility, add `supportedEndpoints` to the provider
+manifest and route only declared paths. The router should support the OpenAI
+resource families above as a transparent, capability-aware proxy, but it must
+not pretend that a chat model supports files, fine-tuning or vector stores. File
+uploads require independent size/type limits, streaming routes require
+cancellation propagation, and long-running jobs require an idempotency key plus
+polling state. The implementing agent must re-check the current OpenAI API
+reference before enabling the P3 legacy resources; the compatibility surface has
+changed over time and should not be hard-coded from an old SDK.
+
+For every route:
+
+- preserve request IDs and trace IDs;
+- preserve streaming backpressure and cancellation;
+- redact authorization, cookies and sensitive headers;
+- normalize upstream errors without losing provider status and request ID;
+- apply the same timeout, retry and cooldown policy as chat requests;
+- never retry a non-idempotent request after upstream bytes are committed.
+
+### 5.5 Model discovery and registration
+
+Discovery must be provider-scoped, cached and observable. A refresh must not
+delete user-defined models. Merge precedence should be:
+
+1. explicit user override;
+2. verified provider preset;
+3. live provider metadata;
+4. conservative defaults.
+
+Persist `upstreamId`, display name, context window, input/output modalities,
+tool/reasoning/search support, cost metadata when available, and the selected
+request profile. Keep the upstream ID separate from the clean UI label.
+
+## 6. Provider parity plan
+
+### 6.1 Already covered or substantially covered
+
+Do not duplicate these as new providers. Reuse the existing implementation and
+only add missing protocol or credential features:
+
+`openai` native Codex, `xai` (`grok-oauth`/`grok-api`), `command-code`,
+`anthropic-apikey` (API only), `kimi`, `openrouter`, `opencode-go`,
+`opencode-zen`, `deepseek`, `groq`, `cerebras`, `chutes`, `github-copilot`,
+`huggingface`, `nvidia` through `nvidia-nim`, `mistral`, `siliconflow`,
+`together`, `fireworks`, `ollama` through `local`, `ollama-cloud`, `lm-studio`,
+`google` through the Gemini API compatibility route, `qwen-cloud` through the
+Qwen plan route, `zai`, `xiaomi-mimo`, `orcarouter` through `orca`, `minimax`,
+`cline-pass`, and `opencode-free`.
+
+These are equivalences, not proof that every adapter, login flow, model or
+pricing feature is identical. Preserve the current provider-specific behavior.
+
+### 6.2 Missing first-party, OAuth or client-specific adapters
+
+| OpenCodex ID | Gap in Codex Router | Implementation note |
+| --- | --- | --- |
+| `cursor` | No Cursor adapter and Cursor is not a supported target | Add only with a documented auth contract; never scrape a desktop session |
+| `anthropic` | Anthropic OAuth account route missing | Reuse Anthropic messages adapter and implement official OAuth only if permitted |
+| `kiro` | Missing | Add an adapter/auth preset after verifying API contract |
+| `nous` | Missing | Add generic OpenAI-compatible preset if protocol is confirmed |
+| `openai-apikey` | Direct OpenAI API-key provider missing | Separate from native ChatGPT/Codex login and native GPT catalog |
+| `umans` | Missing | Generic preset plus live model discovery |
+| `neuralwatt` | Missing | Generic preset plus health/quota behavior |
+| `cline` | Distinct provider from `clinepass`; missing | Do not alias without checking auth and endpoint semantics |
+| `kimi-code` | Direct `api.kimi.com/coding/v1` route missing | Keep separate from Kimi API Platform and OAuth |
+| `gitlab-duo` | Missing | Requires GitLab auth and tenant/project context |
+| `cloudflare-ai-gateway` | Missing | Gateway URL and credential/header mapping |
+| `cloudflare-workers-ai` | Missing | Workers AI account/endpoint mapping; not the same as an AI Gateway |
+
+### 6.3 Missing cloud, aggregator and infrastructure providers
+
+`bizrouter`, `deepinfra`, `hyperbolic`, `nscale`, `vultr`, `baseten`,
+`sambanova`, `nebius`, `digitalocean`, `scaleway`, `featherless`, `novita`,
+`venice`, `nanogpt`, `synthetic`, `litellm`, `vercel-ai-gateway`, `zenmux`,
+and `parallel` are absent as first-class routes.
+
+Implement these as data-driven provider presets on top of the generic provider
+layer whenever they are OpenAI-compatible. Add a custom adapter only when the
+wire contract differs. A preset must contain base URL, auth transport, discovery
+path, supported adapters, default timeout, retry policy and capability defaults.
+
+### 6.4 Missing regional, coding-plan and product variants
+
+`google-vertex`, `google-antigravity`, `azure-openai`, `vllm`, `firepass`,
+`zhipu-bigmodel`, `zhipu-bigmodel-coding`, `tencent-coding-plan`, `volcengine`,
+`volcengine-coding-plan`, `volcengine-agent-plan`, `qianfan`, `alibaba`,
+`alibaba-token-plan`, `alibaba-token-plan-intl`, `mimo-free`, paid `kilo`, and
+the Anthropic-compatible `xiaomi` variant are missing or only partially covered.
+
+Do not collapse plan-specific products into a generic API route when their
+credentials, quotas or model IDs differ. Model aliases may be shared only after
+the provider contract is proven equivalent.
+
+### 6.5 Implementation order for provider parity
+
+1. Generic OpenAI Responses/Chat provider and model discovery.
+2. Direct OpenAI API key and Azure OpenAI.
+3. Google Vertex and Gemini-native adapter.
+4. Local vLLM and other OpenAI-compatible infrastructure presets.
+5. Regional/coding-plan presets with explicit auth and quota adapters.
+6. Product-specific OAuth/client integrations (`cursor`, `kiro`, `gitlab-duo`,
+   and similar) only after a maintained official auth flow exists.
+
+This order maximizes coverage without adding dozens of provider-specific code
+paths.
+
+## 7. Other OpenCodex capabilities to port
+
+### 7.1 Combos (virtual models)
+
+Add a persisted virtual model that points to provider/model targets:
+
+```json
+{
+  "id": "fast-coding",
+  "displayName": "Fast Coding",
+  "strategy": "failover",
+  "sticky": true,
+  "stickyLimit": 20,
+  "targets": [
+    {"provider": "openrouter", "model": "qwen/qwen3.8-max", "weight": 1},
+    {"provider": "local-vllm", "model": "qwen-local", "weight": 1}
+  ]
+}
+```
+
+Supported strategies: `failover` and weighted `round-robin`. A combo must be
+resolved before request translation, preserve the selected target for a sticky
+session, and use the normal provider/model capability gate. A combo must never
+hide an incompatible tool, vision or search capability.
+
+### 7.2 Web-search sidecar
+
+Codex Router currently has native standalone-search metadata for verified models.
+The missing OpenCodex feature is a provider-agnostic sidecar for models that do
+not accept the native search tool.
+
+Design requirements:
+
+- explicit per-provider/model opt-in;
+- a bounded search query and result schema;
+- ChatGPT-native search account as a sidecar credential, kept separate from the
+  selected generation account;
+- result citations and source URLs preserved in the model-visible payload;
+- timeout, cancellation, retry and cache policy;
+- no search sidecar when the model already supports native search unless the user
+  explicitly selects it;
+- no hidden search calls on ordinary text requests;
+- clear telemetry showing sidecar latency and failure reason.
+
+This must be capability-driven. Do not add model-name conditionals.
+
+### 7.3 Broad sub-agent roster and fallback
+
+Codex Router already supports v1/v2 sub-agents and certified model metadata. Add:
+
+- `allowUnverifiedModels` as an explicit opt-in, default `false`;
+- per-agent model chains with provider/model targets and weights;
+- fallback on pre-commit transport failures only;
+- tool/vision/search capability validation before assigning a model;
+- per-agent token/time budgets and concurrency limits;
+- clear display labels and an audit trail of the actual target used.
+
+Do not expand the default roster merely because a provider advertises a model.
+
+### 7.4 Dashboard and live management
+
+OpenCodex's web dashboard manages providers, models, accounts, combos, sidecars,
+logs and usage. Codex Router's macOS tray remains the primary local UI, but the
+control API should expose equivalent authenticated operations:
+
+- providers and credentials;
+- model discovery and overrides;
+- combos and sub-agent policies;
+- quota/health/cooldown state;
+- sidecar configuration;
+- bounded logs and request traces;
+- export/import of non-secret configuration.
+
+The UI must show whether a value is native, verified, user-defined, live-
+discovered or inferred. Do not overwrite native GPT labels or speed controls.
+
+### 7.5 Client integrations and exports
+
+OpenCodex provides exports or integrations for OpenCode, Pi, OMP, Hermes,
+OpenClaw, Kimi, Gajae, DeepSeek Harness, MiniMax Code, ZCode and Prime Agent,
+plus Claude Code/Desktop and Grok Build flows. Codex Router currently targets
+Codex, DeepSeek Harness and Gemini CLI; OpenCode is a provider rather than a
+supported target.
+
+Implement exports as generated, versioned adapters. Each export must declare the
+gateway URL, auth mechanism, model aliases and whether tool/search/vision
+features are supported. Never copy secrets into generated files by default.
+
+### 7.6 Memory and cache controls
+
+OpenCodex exposes an app-owned memory budget and cache retention controls. Codex
+Router already has operational logs and retention behavior, but parity requires:
+
+- bounded in-memory queues and response buffers;
+- explicit cache retention and maximum size;
+- eviction metrics;
+- a diagnostic report showing active memory budget and retained stores;
+- no unbounded transcript or tool-result retention in the router process.
+
+This is an operational hardening item, not a reason to cache prompts or provider
+secrets.
+
+## 8. Proposed architecture
+
+Keep the existing gateway and provider registry. Add layers with single
+responsibilities:
+
+```text
+Control API / tray / CLI
+        |
+Config + encrypted credential store
+        |
+Pool policy + session affinity + cooldown
+        |
+Combo resolver + model capability registry
+        |
+Protocol adapter (Responses / Chat / Anthropic / Gemini / Azure)
+        |
+Existing Codex Router gateway and request/stream pipeline
+```
+
+Suggested module boundaries (adapt names to the checkout):
+
+- `credentials`: encrypted secret references, account/key lifecycle;
+- `pools`: eligibility, strategy, quota snapshots and session bindings;
+- `providers`: provider manifests, generic provider CRUD and discovery;
+- `models`: live catalog merge, capability profiles and user overrides;
+- `combos`: virtual model resolution and sticky target state;
+- `adapters`: protocol translation and endpoint capability gates;
+- `sidecars`: web search and other explicit auxiliary services;
+- `control`: authenticated API, CLI and tray operations;
+- `exports`: generated client-specific configuration.
+
+Avoid provider-specific branches in the core router. A provider manifest should
+provide data and adapter selection; an adapter should provide protocol behavior.
+
+### 8.1 Routing order
+
+For every request, use this deterministic order:
+
+1. authenticate the control/client request;
+2. resolve native or user-selected provider/model/combo;
+3. load merged model capabilities;
+4. choose a session-bound credential or run pool selection;
+5. validate requested tools, images, search and reasoning against capabilities;
+6. choose the protocol adapter;
+7. translate only supported fields;
+8. send the request with cancellation and trace propagation;
+9. update quota, health, cooldown and session state;
+10. expose the selected provider/model/credential alias in diagnostics, never the
+    secret.
+
+## 9. Control API and CLI contract
+
+The exact HTTP prefix must follow the existing Codex Router control namespace.
+The following are logical contracts, not permission to expose an unauthenticated
+server.
+
+| Operation | Method | Result |
+| --- | --- | --- |
+| List providers | `GET /control/providers` | Sanitized provider manifests |
+| Add provider | `POST /control/providers` | Provider ID and validation result |
+| Discover models | `POST /control/providers/{id}/discover` | Merged model catalog |
+| Add credential | `POST /control/providers/{id}/credentials` | Credential ID only |
+| List credential health | `GET /control/providers/{id}/credentials` | State/quota/alias, no secret |
+| Set pool policy | `PUT /control/providers/{id}/pool` | Effective policy |
+| Bind session | `PUT /control/sessions/{id}/credential` | Sanitized binding |
+| Manage combos | `/control/combos` | CRUD and validation |
+| Test route | `POST /control/routes/test` | Redacted request/response metadata |
+| Export client config | `POST /control/exports/{client}` | Generated config with secret refs |
+
+CLI equivalents should be scriptable and non-interactive:
+
+```text
+router provider list
+router provider add NAME --adapter openai-chat --base-url URL
+router provider discover NAME
+router provider test NAME/MODEL
+router credential add PROVIDER --kind account|api-key
+router credential list PROVIDER
+router pool set PROVIDER --strategy quota --sticky-limit 50
+router combo set NAME PROVIDER/MODEL[:WEIGHT]...
+router model list --provider NAME
+router export CLIENT --output PATH
+```
+
+Commands that accept secrets must support environment variables or OS keychain
+references. Do not print the value in shell history or command output.
+
+## 10. Security requirements
+
+- Store OAuth tokens and API keys in the existing OS keychain/secure store or an
+  encrypted store with a process-local key reference.
+- Redact `Authorization`, cookies, refresh tokens, API keys, signed URLs and
+  provider-specific secret headers from logs, errors, traces and exports.
+- Bind control operations to loopback by default and require an explicit,
+  authenticated opt-in for remote access.
+- Validate provider URLs, including scheme, redirects, private-network access,
+  DNS rebinding and maximum redirect count.
+- Apply per-provider and per-credential rate limits; avoid retry storms.
+- Separate provider/account scopes in cache, cooldown, quota and session state.
+- Do not use account pooling to bypass provider restrictions. Surface terms and
+  require explicit confirmation for multi-account configuration.
+- Preserve native Codex authentication and model metadata. A custom provider
+  must not be able to overwrite native GPT display name, speed or default model.
+- Treat upstream model metadata as untrusted input; validate lengths, IDs,
+  modalities and numeric limits before persisting or displaying them.
+
+## 11. Compatibility and migration
+
+The implementation must satisfy all of the following:
+
+1. Existing provider configs continue to load without a migration command.
+2. Existing `custom` per-model endpoints continue to work unchanged.
+3. Existing native GPT models, labels, default model and `normal`/`fast` speed
+   controls remain client-owned and untouched.
+4. Existing OAuth/API logins remain valid; migration must copy references, not
+   re-print or re-enter secrets.
+5. A failed migration leaves the previous state loadable and provides rollback.
+6. New generic providers are disabled until explicitly enabled and tested.
+7. Live discovery never deletes manually configured model entries.
+8. Existing sub-agent certification and tool safety defaults remain unchanged.
+9. Config export/import is versioned and rejects unknown destructive changes.
+10. Update/rollback works with the current supervised macOS tray installation.
+
+Add a schema version and an idempotent migration. Back up only encrypted state
+and non-secret configuration; do not create plaintext copies of credentials.
+
+## 12. Test plan
+
+### Unit tests (P0)
+
+- pool eligibility, quota unknown, threshold and priority;
+- round-robin and fill-first ordering;
+- sticky session binding and atomic rebind;
+- cooldown after 401/403/429/5xx and recovery;
+- no retry after a committed stream;
+- provider URL and private-network validation;
+- secret redaction in logs and errors;
+- capability gate for tools, image input, search, reasoning and structured output;
+- live catalog merge precedence and preservation of user models;
+- combo failover, weights, sticky limit and capability validation;
+- migration idempotence and rollback.
+
+### Protocol contract tests (P0/P1)
+
+Use local fixtures for:
+
+- OpenAI Responses streaming;
+- OpenAI Chat Completions streaming;
+- tool calls and parallel tool calls;
+- reasoning content in both Responses and Chat formats;
+- image input accepted and rejected;
+- upstream error/status/request ID propagation;
+- `/v1/models` discovery;
+- legacy Completions and optional embeddings/images/audio routes.
+
+### Integration tests
+
+- one provider with two API keys;
+- one ChatGPT account pool with simulated quota windows;
+- two providers behind one combo;
+- sidecar search success, timeout, cancellation and cache hit;
+- private loopback provider with explicit opt-in and remote rejection;
+- tray/control API and CLI produce the same state;
+- generated client exports contain secret references, not secret values.
+
+### End-to-end acceptance
+
+Run a real text turn, streamed tool call, image turn and native web-search turn
+for at least one verified provider. Run the same text/tool cases through a local
+generic OpenAI-compatible fixture. Verify that a restart preserves session
+affinity, pool health and native GPT selector state. Record provider-specific
+limitations instead of marking an unsupported capability as passed.
+
+## 13. Phased implementation plan
+
+### P0: safe foundation
+
+- credential abstractions and encrypted storage;
+- provider-scoped API-key pool;
+- generic OpenAI Chat/Responses provider;
+- model discovery and capability profiles;
+- control API/CLI with redaction;
+- migration, rollback and regression tests for native GPT.
+
+### P1: routing parity
+
+- ChatGPT/Codex account pool;
+- quota strategies, sticky affinity and re-auth;
+- virtual combos;
+- direct OpenAI API key, Azure, Vertex and local vLLM presets;
+- capability-driven request field filtering.
+
+### P2: ecosystem parity
+
+- web-search sidecar;
+- remaining OpenAI-compatible provider manifests;
+- broader sub-agent opt-in and fallback chains;
+- dashboard views and usage/health diagnostics;
+- client exports for OpenCode and the other maintained integrations.
+
+### P3: product-specific adapters
+
+- OAuth/client integrations such as Anthropic OAuth, Cursor, Kiro and GitLab Duo;
+- regional coding plans and non-OpenAI protocol adapters;
+- optional OpenAI non-chat endpoints (embeddings, images and audio).
+
+Each phase must be independently shippable and must pass all prior acceptance
+tests.
+
+## 14. Definition of done
+
+The work is complete only when:
+
+- a user can add an arbitrary OpenAI-compatible provider and model without a
+  source change;
+- two API keys can be rotated with a documented policy and no secret leakage;
+- a supported ChatGPT account pool retains conversation affinity and safely
+  rebinds on an explicit failure;
+- a named combo can fail over or distribute requests without violating model
+  capabilities;
+- a model without vision or native search receives no unsupported image/search
+  fields;
+- native GPT labels, default selection and speed controls are unchanged;
+- at least one missing provider category is implemented through a data-driven
+  preset rather than a core-router conditional;
+- control API, tray and CLI show consistent sanitized state;
+- migration, restart, rollback and end-to-end streaming tests pass.
+
+## 15. Open questions for the implementing agent
+
+Resolve these from current provider documentation before implementation:
+
+1. Which official OAuth flows and account-pool use cases are permitted by each
+   provider's terms?
+2. Which providers expose reliable 5-hour, weekly or monthly quota APIs?
+3. Does the current Codex client require only Responses, or should the gateway
+   expose the full optional OpenAI endpoint set to other clients?
+4. Which providers support native reasoning fields versus plain text reasoning?
+5. What is the exact existing control API authentication and persistence contract?
+6. Should the dashboard be added to the tray package, the router process, or a
+   separately supervised local UI?
+7. Which exports are still maintained upstream and therefore worth implementing?
+
+When a provider's contract is unknown, keep it disabled and expose it as an
+experimental preset. Do not guess endpoint paths, auth headers, quota behavior
+or model capabilities.

--- a/docs/OPENCODEX_FEATURE_GAP_SPEC.md
+++ b/docs/OPENCODEX_FEATURE_GAP_SPEC.md
@@ -10,16 +10,23 @@ claim that any item is already available. The current `README.md`, source, and
 tests are authoritative for shipped behavior. An implementation must re-check
 those sources and the upstream provider contract before changing code.
 
+The comparison reference is the public [OpenCodex repository](https://github.com/lidge-jun/opencodex).
+OpenCodex behavior is a comparison input, not a claim about Codex Router. Re-check
+the referenced project and its current contracts before implementing a proposal.
+
 ## 1. Verified current baseline
 
 The current router already provides a shared local service for Codex, with
-optional publication to DeepSeek Harness and Gemini CLI. It preserves the
-native GPT catalog, login, default model, reasoning metadata, and speed
-controls. It routes the checked-in provider registry and explicitly curated
-local models through the Responses path, with protocol-specific forwarding for
-supported providers. It also has model discovery, usage/cooldown handling,
-model failover, capability-aware vision handling, provider-specific hosted
-search where available, verified sub-agent metadata, a macOS tray, and a
+optional publication to DeepSeek Harness and Gemini CLI. These are the only
+supported client targets on `main`; no OpenCode or Cursor client target is
+shipped. It preserves the native GPT catalog and login, and keeps the native
+default model, reasoning metadata, and speed controls client-owned by default.
+A routed default is available only through an explicit router-owned opt-in. It
+routes the checked-in provider registry and explicitly curated local models
+through the Responses path, with protocol-specific forwarding for supported
+providers. It also has selected-provider model discovery, usage/cooldown
+handling, model failover, capability-aware vision handling, provider-specific
+hosted search where available, verified sub-agent metadata, a macOS tray, and a
 Control Center.
 
 The current credential boundary is protected owner-only files or documented

--- a/docs/OPENCODEX_FEATURE_GAP_SPEC.md
+++ b/docs/OPENCODEX_FEATURE_GAP_SPEC.md
@@ -1,231 +1,116 @@
 # OpenCodex feature gap specification for Codex Router
 
-Status: implementation handoff
+Status: proposed design; not a record of shipped features
 
-Baseline: 2026-08-24
+Implementation tracking: [OpenCodex parity roadmap](./OPENCODEX_IMPLEMENTATION_ROADMAP.md)
 
-Implementation tracking: [OpenCodex parity implementation roadmap](./OPENCODEX_IMPLEMENTATION_ROADMAP.md)
+This document describes possible parity work after comparing OpenCodex with the
+current Codex Router `main` branch. It is an implementation handoff, not a
+claim that any item is already available. The current `README.md`, source, and
+tests are authoritative for shipped behavior. An implementation must re-check
+those sources and the upstream provider contract before changing code.
 
-This document describes the OpenCodex features that are not currently present in
-Codex Router, or that are present only in a narrower form. It is written for an
-AI coding agent. The agent must verify the live checkout and upstream APIs before
-changing code; this is a design and acceptance specification, not a request to
-copy OpenCodex code.
+## 1. Verified current baseline
 
-## 1. Source baseline
+The current router already provides a shared local service for Codex, with
+optional publication to DeepSeek Harness and Gemini CLI. It preserves the
+native GPT catalog, login, default model, reasoning metadata, and speed
+controls. It routes the checked-in provider registry and explicitly curated
+local models through the Responses path, with protocol-specific forwarding for
+supported providers. It also has model discovery, usage/cooldown handling,
+model failover, capability-aware vision handling, provider-specific hosted
+search where available, verified sub-agent metadata, a macOS tray, and a
+Control Center.
 
-- [OpenCodex](https://github.com/lidge-jun/opencodex), inspected at the `main`
-  branch release represented by version `2.31.0`.
-- [Codex Router](https://github.com/duolahypercho/codex-router), inspected at
-  the current `main` documentation and the local `0.4.0-beta.4` checkout.
-- The OpenCodex registry and types are the source for feature names. The
-  Codex Router source and its generated catalog are authoritative for what is
-  already supported here.
+The current credential boundary is protected owner-only files or documented
+environment/session sources. The repository does **not** currently ship a
+provider-neutral encrypted credential database, an API-key pool, or a
+multi-account ChatGPT pool. The managed `multi_agent_v2` concurrency value is
+6. These facts are constraints for every proposal below.
 
-Provider names below are OpenCodex registry IDs. Some IDs are aliases or protocol
-variants rather than independent companies. “Missing” means that Codex Router
-has no equivalent first-class route today; it does not mean that a user can never
-reach the service through a manually configured endpoint.
+Useful source and test anchors:
 
-## 2. Executive summary
+- Targets: `src/paths.mjs`, `src/target-integration.mjs`,
+  `test/target-integration.test.mjs`.
+- Native catalog and config ownership: `src/native-catalog-source.mjs`,
+  `src/catalog.mjs`, `src/config-manager.mjs`, `test/config-manager.test.mjs`.
+- Provider routing and discovery: `src/router.mjs`, `src/api-forwarder.mjs`,
+  `src/model-discovery.mjs`, `test/routing.test.mjs`,
+  `test/model-discovery.test.mjs`.
+- Credentials and redaction: `src/provider-credentials.mjs`,
+  `src/file-security.mjs`, `test/provider-credentials.test.mjs`.
+- Failover and usage: `src/model-failover.mjs`, `src/provider-cooldown.mjs`,
+  `src/provider-usage.mjs`, `test/model-failover.test.mjs`.
+- Vision and collaboration: `src/vision-bridge.mjs`,
+  `src/subagent-proofs.mjs`, `src/multi-agent-state.mjs`, and their tests.
 
-Codex Router already has a strong, deliberately narrow path for the Codex App,
-Codex CLI, DeepSeek Harness and Gemini CLI. It preserves the native GPT catalog,
-native default model, and native speed controls. It also has provider/model
-failover, cooldowns, usage reporting, a vision bridge, standalone-search metadata,
-and a large set of configured providers.
+## 2. Comparison summary
 
-OpenCodex is broader in three areas:
+OpenCodex is broader in several areas that are not first-class features in the
+current router:
 
-1. It treats credentials as routable pools, not only as one credential per
-   provider. This includes multiple ChatGPT/Codex accounts, API-key pools,
-   account priority, quota-aware selection, sticky account affinity and
-   re-authentication.
-2. It has a generic provider management layer. A user can add any OpenAI-
-   compatible endpoint, discover or register its models, set headers and key
-   transport, and expose it through the same routing surface.
-3. It includes more adapters, client integrations, virtual combo models, a
-   provider-agnostic web-search sidecar, and a dashboard for live management.
+1. credential pools with account/key selection and session affinity;
+2. generic provider definitions and broader endpoint pass-through;
+3. named virtual model combinations;
+4. a provider-agnostic web-search sidecar;
+5. broader sub-agent policy and fallback controls;
+6. a live management API/dashboard and versioned client exports.
 
-The implementation target is additive parity. It must not replace the native
-Codex path, silently change a user's default model, remove GPT speed tiers,
-rewrite existing provider logins, or weaken the current verified-model safety
-policy.
+These are proposed gaps. They must not be represented as completed modules or
+enabled by default without a separately reviewed implementation.
 
-## 3. Current capability matrix
+## 3. Proposed gap A: credential and account pooling
 
-| Area | Codex Router today | OpenCodex behavior | Gap |
-| --- | --- | --- | --- |
-| Native GPT catalog/login | Native Codex-owned catalog and login are preserved | OpenAI/ChatGPT route plus pooled Codex accounts | Add pooled accounts without taking ownership of native GPT metadata |
-| Provider failover | Automatic model/provider failover and cooldowns | Failover plus user-defined combos and account pools | Add explicit combos and credential-level failover |
-| Per-model custom endpoint | `custom` provider supports a per-model endpoint and metadata | Generic provider can be added/edited with base URL, adapter, headers and models | Promote the capability to a reusable provider object |
-| OpenAI-compatible protocol | Several curated routes and custom model routes | Any OpenAI-compatible provider; OpenAI Responses and Chat Completions adapters | Add generic adapter/capability negotiation and broader endpoint pass-through |
-| API keys | Provider-specific credential handling | Multiple API keys per provider, active key, key health and rotation | Add a provider-scoped key pool |
-| ChatGPT accounts | One native Codex login flow | Multiple accounts, quota tracking, strategies, sticky affinity and re-auth | Add a policy-controlled account pool |
-| Anthropic | API route | API and OAuth account pool | Add OAuth only if the provider terms and auth contract permit it |
-| Model catalog | Curated registry, verified metadata, custom model files | Live model discovery plus add/edit/remove/enable/disable/selected models | Add provider-scoped discovery and user catalog overrides |
-| Search | Native client-side standalone search for verified models; hosted provider-specific search where available | Web-search sidecar that can serve models which cannot consume the native search tool | Add an explicit sidecar, with bounded results and opt-in policy |
-| Vision | Vision bridge and local vision support already exist | Vision translation across adapters and sidecars | Reuse current bridge; add capability declarations, not another image shim |
-| Sub-agents | v1/v2 and certified model metadata | Any model, fallback chains, effort/injection controls | Add opt-in unverified models and per-agent fallback policy |
-| Virtual models | Internal model/provider fallback | Named combos with failover or weighted round-robin, weights and sticky limits | Add persisted combo definitions |
-| Dashboard | macOS tray/control center and operational views | Web dashboard for providers, models, accounts, combos, logs and usage | Add a browser control plane only where the existing UI cannot manage a feature |
-| Client exports | Codex, DSH and Gemini-oriented integration | OpenCode, Pi, OMP, Hermes, OpenClaw, Kimi, Gajae, DSH, MCode, ZCode, Prime Agent and others | Add exports only after the gateway contracts are stable |
+### 3.1 Logical model
 
-## 4. Gap A: account and credential pooling
+Add one provider-neutral abstraction for two credential kinds:
 
-### 4.1 Required concepts
+- `account`: an OAuth or first-party login identity;
+- `api_key`: a provider API key or token.
 
-Implement a provider-neutral credential store with two credential classes:
+Each row needs a stable opaque ID, provider, kind, display alias, health state,
+pause state, priority, last-used/error timestamps, and provider-reported usage
+when available. Email and provider account IDs are metadata, not routing keys.
+Secrets remain in an approved protected store and are never returned by list or
+status operations.
 
-- `account`: an OAuth or first-party login identity, for example a ChatGPT/Codex
-  account or an Anthropic OAuth account;
-- `api_key`: a key or token for an API provider.
+This is a future security requirement. It must not be documented as current
+encryption until an implementation and tests actually provide encryption.
 
-Each credential must have a stable opaque ID. Email addresses, provider account
-IDs and aliases are metadata, not routing keys. Secrets must remain encrypted at
-rest and must never be returned by list/status endpoints or written to ordinary
-request logs.
+### 3.2 Selection policies
 
-Logical account fields:
+The proposed policies are:
 
-```json
-{
-  "id": "acct_opaque_id",
-  "provider": "openai",
-  "kind": "account",
-  "alias": "personal",
-  "email": "redacted-or-local-only",
-  "plan": "unknown",
-  "providerAccountId": "provider-id-if-available",
-  "auth": {
-    "accessTokenRef": "secret-ref",
-    "refreshTokenRef": "secret-ref",
-    "expiresAt": "2026-08-24T12:00:00Z"
-  },
-  "state": "healthy",
-  "paused": false,
-  "priority": 50,
-  "usage": {
-    "window5h": {"used": 0, "limit": null, "resetAt": null},
-    "weekly": {"used": 0, "limit": null, "resetAt": null},
-    "monthly": {"used": 0, "limit": null, "resetAt": null}
-  },
-  "lastUsedAt": null,
-  "lastErrorAt": null
-}
-```
+- `quota`: choose the healthy credential with the most reliable remaining quota;
+- `round-robin`: distribute new sessions across eligible credentials;
+- `fill-first`: use the highest-priority credential until a configured threshold.
 
-Logical API-key fields:
+Unknown quota must remain unknown; the router must not invent a percentage.
+Selection must be cached and non-blocking for ordinary requests. A session
+binding may change only on an explicit switch, expiry, pause, provider refusal,
+rate limit, or another documented policy event.
 
-```json
-{
-  "id": "key_opaque_id",
-  "provider": "openrouter",
-  "kind": "api_key",
-  "alias": "primary",
-  "secretRef": "secret-ref",
-  "transport": "authorization-bearer",
-  "state": "healthy",
-  "paused": false,
-  "priority": 50,
-  "usage": {"requests": 0, "tokens": 0, "resetAt": null}
-}
-```
+Streaming failures may retry only before response bytes are committed. Two
+concurrent turns for one session must not create two bindings.
 
-The exact persistence format may follow the existing Codex Router state store.
-Do not create a second unencrypted credentials database.
+### 3.3 Lifecycle and safety
 
-### 4.2 Pool policies
+Future control operations may list sanitized health/quota, add/remove/pause/
+resume a credential, set priority and strategy, refresh an OAuth session, clear
+cooldown, and run a provider-supported non-billable test. Pooling must not be
+presented as a way to bypass provider limits or terms. Remote callers must not
+be able to submit arbitrary credential pools.
 
-Support these policies for each provider pool:
+Acceptance evidence: isolated fixtures, expiry/401/403/429/5xx handling,
+concurrent selection, restart/rollback, redaction, permission checks, and a
+native GPT catalog regression.
 
-- `quota`: choose the healthy account with the most remaining quota, or the
-  highest remaining score when a provider exposes several windows;
-- `round-robin`: distribute new requests across eligible credentials;
-- `fill-first`: keep using the highest-priority eligible credential until it
-  reaches the configured threshold, then move to the next one.
+## 4. Proposed gap B: generic OpenAI-compatible providers
 
-Common policy fields:
+### 4.1 User-facing provider object
 
-```json
-{
-  "strategy": "quota",
-  "autoSwitchThreshold": 0.10,
-  "sticky": true,
-  "stickyLimit": 50,
-  "maxCooldownSeconds": 300,
-  "pausedCredentialIds": [],
-  "priorityOrder": ["acct_opaque_id"]
-}
-```
-
-The threshold is a fraction of the provider-reported remaining quota. If quota is
-unknown, the router must not invent a percentage; use health, priority and the
-selected non-quota strategy instead.
-
-### 4.3 Selection and affinity
-
-1. A new conversation receives one eligible credential.
-2. The selected credential is stored in conversation/session state.
-3. Subsequent turns keep that credential while it is healthy and within policy.
-4. A credential may be rebound on expiry, explicit pause, 401/403, rate limit,
-   provider outage or quota threshold crossing.
-5. Rebinding must be atomic for the conversation. Two concurrent turns must not
-   select different credentials for the same session.
-6. Streaming failures may retry only before any assistant bytes are committed.
-   After output starts, report the error and preserve the transcript; do not
-   silently duplicate a tool call.
-
-OpenCodex's sticky limit is a pool policy, not a global timeout. Implement it as
-the maximum number of turns or requests that may retain a binding before a
-re-evaluation. Make the unit explicit in the configuration and API.
-
-### 4.4 Lifecycle operations
-
-Provide authenticated control operations for:
-
-- list accounts/keys with health, quota snapshot and last error;
-- add, remove, pause and resume a credential;
-- select a credential for the next new session;
-- set priority and pool strategy;
-- refresh or re-authenticate OAuth credentials;
-- clear cooldown and reset local usage counters;
-- test a credential with a non-billable metadata request where supported.
-
-Provider quota refresh must be cached and rate-limited. A request must not block
-on a quota API call unless the cache is expired and the operation is explicitly a
-health check.
-
-### 4.5 Policy and safety constraints
-
-Pooling is for continuity, quota-aware routing and operational resilience. It
-must not be marketed or implemented as a way to evade provider limits, account
-enforcement or terms of service. Show a warning before adding a pool and keep an
-audit record of account changes without storing token values. Never accept a pool
-of credentials from an untrusted remote control client.
-
-## 5. Gap B: generic OpenAI-compatible providers
-
-### 5.1 Desired user model
-
-A user should be able to add a provider without a source-code change:
-
-```text
-router provider add local-vllm \
-  --adapter openai-chat \
-  --base-url http://127.0.0.1:8000/v1 \
-  --api-key-ref env:LOCAL_VLLM_KEY \
-  --allow-private-network
-```
-
-The provider then exposes models from `/v1/models`, or accepts explicitly
-registered model IDs when discovery is unavailable. A provider may contain many
-models and many credentials. The current `custom` route remains supported as a
-compatibility alias for a single model endpoint.
-
-### 5.2 Provider object
-
-Use one logical schema, mapped to the existing Codex Router state/config system:
+The current registry and custom/per-model paths are the baseline. A future
+provider object could contain:
 
 ```json
 {
@@ -234,216 +119,75 @@ Use one logical schema, mapped to the existing Codex Router state/config system:
   "enabled": true,
   "adapter": "openai-chat",
   "baseUrl": "http://127.0.0.1:8000/v1",
-  "auth": {
-    "mode": "api_key",
-    "keyIds": ["key_opaque_id"],
-    "transport": "authorization-bearer",
-    "headers": {"X-Tenant": "local"}
-  },
-  "network": {
-    "allowPrivate": true,
-    "connectTimeoutMs": 10000,
-    "requestTimeoutMs": 300000
-  },
-  "discovery": {
-    "enabled": true,
-    "path": "/models",
-    "refreshSeconds": 900
-  },
+  "auth": {"mode": "api_key", "keyIds": ["key_opaque_id"]},
+  "network": {"allowPrivate": true},
+  "discovery": {"enabled": true, "path": "/models"},
   "models": {
     "qwen-local": {
       "upstreamId": "Qwen/Qwen3.8-27B",
-      "displayName": "Qwen 3.8 27B (Local)",
-      "modalities": ["text"],
+      "inputModalities": ["text"],
       "supportsTools": true,
-      "supportsReasoning": true,
-      "supportsVision": false,
-      "contextWindow": 131072,
-      "requestProfile": "auto-tool-choice"
+      "supportsVision": false
     }
   }
 }
 ```
 
-Private or loopback endpoints must require an explicit local opt-in. Remote
-control requests must not be allowed to use arbitrary private-network URLs.
-Validate URL schemes, reject file URLs, and protect against DNS rebinding where
-the process is exposed beyond loopback.
+This schema is illustrative only. It must map to the existing state/config
+system, preserve old custom model files, keep provider IDs separate from UI
+labels, and require an explicit local/private-network opt-in.
 
-### 5.3 Adapters and capabilities
+### 4.2 Adapter and capability rules
 
-Implement adapters as protocol translators, not provider-name conditionals:
+Future adapters may cover Responses, Chat Completions, legacy Completions,
+Anthropic Messages, Gemini-native, or other verified protocols. Every adapter
+must declare input/output modalities, streaming, tools, reasoning, search,
+structured output, and endpoint support before translating a request.
 
-- `openai-responses`: `/v1/responses`, streaming events, tool calls and
-  reasoning items;
-- `openai-chat`: `/v1/chat/completions`, streamed deltas and tool calls;
-- `openai-completions`: legacy `/v1/completions` for text-only models;
-- `anthropic-messages`: `/v1/messages` where the provider has a supported
-  Anthropic contract;
-- `google-generative-ai`: Gemini-native request/response mapping;
-- `azure-openai`: Azure URL/version/auth rules.
+Unsupported fields must be omitted or mapped from the capability profile. Do
+not infer support from a model name. Validate URL scheme, redirects, private
+network access, DNS behavior, timeouts, and maximum body sizes.
 
-The adapter must advertise capabilities before translating a request:
+### 4.3 Endpoint scope
 
-```json
-{
-  "inputModalities": ["text"],
-  "outputModalities": ["text"],
-  "streaming": true,
-  "tools": true,
-  "parallelToolCalls": false,
-  "reasoning": "field-or-none",
-  "vision": false,
-  "webSearch": false,
-  "structuredOutput": true,
-  "maxOutputTokensField": "max_tokens"
-}
-```
+The Codex route remains the priority. Optional future forwarding may cover:
 
-Unsupported fields must be omitted or translated according to the capability
-profile. Never send `image_url`, native search tools, reasoning fields or
-`parallel_tool_calls` to a model that declares those capabilities as unsupported.
-Do not infer a capability from a marketing name; use provider metadata, a
-verified preset or an explicit user override.
-
-### 5.4 OpenAI endpoint coverage
-
-The generic provider layer should expose a capability-aware pass-through for the
-following OpenAI-compatible routes:
-
-| Route | Priority | Requirement |
+| Endpoint family | Proposed priority | Boundary |
 | --- | --- | --- |
-| `GET /v1/models` | P0 | Discovery, filtering and model health |
-| `POST /v1/responses` | P0 | Codex-native route and Responses-compatible providers |
-| `POST /v1/chat/completions` | P0 | Main compatibility path |
-| `POST /v1/completions` | P1 | Legacy text-only providers |
-| `POST /v1/embeddings` | P2 | Expose only if a client calls it; never advertise it as a chat model |
-| `POST /v1/images/generations` | P2 | Expose only for a provider/model declaring image generation |
-| `POST /v1/audio/speech` | P2 | Expose only for TTS-capable providers |
-| `POST /v1/audio/transcriptions` | P2 | Expose only for transcription-capable providers |
-| `POST /v1/audio/translations` | P2 | Same capability gate as transcription |
-| `POST /v1/moderations` | P2 | Expose only for moderation-capable providers |
-| `POST /v1/files` and `DELETE /v1/files/{id}` | P2 | Multipart upload/list/retrieve/delete with size limits |
-| `POST /v1/batches` and batch status routes | P3 | Long-running jobs, polling and cancellation |
-| Fine-tuning job routes | P3 | Expose only when the upstream and client contract support them |
-| Assistants/threads/runs/vector stores | P3 | Legacy/extended compatibility; verify current OpenAI contract first |
+| `/v1/models` | P0 | Discovery and health only; never erase user models. |
+| `/v1/responses` and `/v1/chat/completions` | P0 | Main model-routing contracts. |
+| `/v1/messages` | P0 | Only for providers with a verified Messages contract. |
+| Legacy completions, embeddings, media, moderation, files, batches | P1/P2 | Advertise only when the provider and caller contract support them. |
 
-P0 is required for Codex Router feature parity. P1/P2 are general OpenAI API
-compatibility and must not be wired into the Codex model selector unless the
-client contract supports them. Keep endpoint forwarding separate from model
-selection so a provider cannot accidentally claim to be a chat model.
+Non-chat endpoints must not be advertised as chat models. Multipart limits,
+idempotency, cancellation, request IDs, and non-idempotent retry boundaries are
+required for any future endpoint.
 
-For literal full-API compatibility, add `supportedEndpoints` to the provider
-manifest and route only declared paths. The router should support the OpenAI
-resource families above as a transparent, capability-aware proxy, but it must
-not pretend that a chat model supports files, fine-tuning or vector stores. File
-uploads require independent size/type limits, streaming routes require
-cancellation propagation, and long-running jobs require an idempotency key plus
-polling state. The implementing agent must re-check the current OpenAI API
-reference before enabling the P3 legacy resources; the compatibility surface has
-changed over time and should not be hard-coded from an old SDK.
+Acceptance evidence: local OpenAI-compatible fixture, remote URL validation,
+discovery cache behavior, capability filtering, restart persistence, old custom
+model regression, and request/response/error contract tests.
 
-For every route:
+## 5. Proposed gap C: provider parity
 
-- preserve request IDs and trace IDs;
-- preserve streaming backpressure and cancellation;
-- redact authorization, cookies and sensitive headers;
-- normalize upstream errors without losing provider status and request ID;
-- apply the same timeout, retry and cooldown policy as chat requests;
-- never retry a non-idempotent request after upstream bytes are committed.
+Provider additions are only justified when the official endpoint, auth, model
+IDs, quota semantics, and capabilities are documented and tested. Prefer a
+data-only registry entry over a provider-specific branch. Keep experimental or
+unknown providers disabled until a fixture and a live, explicitly approved
+probe pass.
 
-### 5.5 Model discovery and registration
+The implementation order should be:
 
-Discovery must be provider-scoped, cached and observable. A refresh must not
-delete user-defined models. Merge precedence should be:
+1. stabilize the generic provider object and capability profiles;
+2. add direct OpenAI-compatible and regional presets with verified auth;
+3. add non-OpenAI protocol adapters only where the wire contract is stable;
+4. add plan-specific quota/account handling only when the provider exposes it.
 
-1. explicit user override;
-2. verified provider preset;
-3. live provider metadata;
-4. conservative defaults.
+Do not add a client integration or target that is not supported by the current
+repository policy. A provider route and a client target are separate concepts.
 
-Persist `upstreamId`, display name, context window, input/output modalities,
-tool/reasoning/search support, cost metadata when available, and the selected
-request profile. Keep the upstream ID separate from the clean UI label.
+## 6. Proposed gap D: virtual combos
 
-## 6. Provider parity plan
-
-### 6.1 Already covered or substantially covered
-
-Do not duplicate these as new providers. Reuse the existing implementation and
-only add missing protocol or credential features:
-
-`openai` native Codex, `xai` (`grok-oauth`/`grok-api`), `command-code`,
-`anthropic-apikey` (API only), `kimi`, `openrouter`, `opencode-go`,
-`opencode-zen`, `deepseek`, `groq`, `cerebras`, `chutes`, `github-copilot`,
-`huggingface`, `nvidia` through `nvidia-nim`, `mistral`, `siliconflow`,
-`together`, `fireworks`, `ollama` through `local`, `ollama-cloud`, `lm-studio`,
-`google` through the Gemini API compatibility route, `qwen-cloud` through the
-Qwen plan route, `zai`, `xiaomi-mimo`, `orcarouter` through `orca`, `minimax`,
-`cline-pass`, and `opencode-free`.
-
-These are equivalences, not proof that every adapter, login flow, model or
-pricing feature is identical. Preserve the current provider-specific behavior.
-
-### 6.2 Missing first-party, OAuth or client-specific adapters
-
-| OpenCodex ID | Gap in Codex Router | Implementation note |
-| --- | --- | --- |
-| `cursor` | No Cursor adapter and Cursor is not a supported target | Add only with a documented auth contract; never scrape a desktop session |
-| `anthropic` | Anthropic OAuth account route missing | Reuse Anthropic messages adapter and implement official OAuth only if permitted |
-| `kiro` | Missing | Add an adapter/auth preset after verifying API contract |
-| `nous` | Missing | Add generic OpenAI-compatible preset if protocol is confirmed |
-| `openai-apikey` | Direct OpenAI API-key provider missing | Separate from native ChatGPT/Codex login and native GPT catalog |
-| `umans` | Missing | Generic preset plus live model discovery |
-| `neuralwatt` | Missing | Generic preset plus health/quota behavior |
-| `cline` | Distinct provider from `clinepass`; missing | Do not alias without checking auth and endpoint semantics |
-| `kimi-code` | Direct `api.kimi.com/coding/v1` route missing | Keep separate from Kimi API Platform and OAuth |
-| `gitlab-duo` | Missing | Requires GitLab auth and tenant/project context |
-| `cloudflare-ai-gateway` | Missing | Gateway URL and credential/header mapping |
-| `cloudflare-workers-ai` | Missing | Workers AI account/endpoint mapping; not the same as an AI Gateway |
-
-### 6.3 Missing cloud, aggregator and infrastructure providers
-
-`bizrouter`, `deepinfra`, `hyperbolic`, `nscale`, `vultr`, `baseten`,
-`sambanova`, `nebius`, `digitalocean`, `scaleway`, `featherless`, `novita`,
-`venice`, `nanogpt`, `synthetic`, `litellm`, `vercel-ai-gateway`, `zenmux`,
-and `parallel` are absent as first-class routes.
-
-Implement these as data-driven provider presets on top of the generic provider
-layer whenever they are OpenAI-compatible. Add a custom adapter only when the
-wire contract differs. A preset must contain base URL, auth transport, discovery
-path, supported adapters, default timeout, retry policy and capability defaults.
-
-### 6.4 Missing regional, coding-plan and product variants
-
-`google-vertex`, `google-antigravity`, `azure-openai`, `vllm`, `firepass`,
-`zhipu-bigmodel`, `zhipu-bigmodel-coding`, `tencent-coding-plan`, `volcengine`,
-`volcengine-coding-plan`, `volcengine-agent-plan`, `qianfan`, `alibaba`,
-`alibaba-token-plan`, `alibaba-token-plan-intl`, `mimo-free`, paid `kilo`, and
-the Anthropic-compatible `xiaomi` variant are missing or only partially covered.
-
-Do not collapse plan-specific products into a generic API route when their
-credentials, quotas or model IDs differ. Model aliases may be shared only after
-the provider contract is proven equivalent.
-
-### 6.5 Implementation order for provider parity
-
-1. Generic OpenAI Responses/Chat provider and model discovery.
-2. Direct OpenAI API key and Azure OpenAI.
-3. Google Vertex and Gemini-native adapter.
-4. Local vLLM and other OpenAI-compatible infrastructure presets.
-5. Regional/coding-plan presets with explicit auth and quota adapters.
-6. Product-specific OAuth/client integrations (`cursor`, `kiro`, `gitlab-duo`,
-   and similar) only after a maintained official auth flow exists.
-
-This order maximizes coverage without adding dozens of provider-specific code
-paths.
-
-## 7. Other OpenCodex capabilities to port
-
-### 7.1 Combos (virtual models)
-
-Add a persisted virtual model that points to provider/model targets:
+A future named combo may resolve several provider/model targets:
 
 ```json
 {
@@ -451,339 +195,140 @@ Add a persisted virtual model that points to provider/model targets:
   "displayName": "Fast Coding",
   "strategy": "failover",
   "sticky": true,
-  "stickyLimit": 20,
   "targets": [
-    {"provider": "openrouter", "model": "qwen/qwen3.8-max", "weight": 1},
-    {"provider": "local-vllm", "model": "qwen-local", "weight": 1}
+    {"provider": "provider-a", "model": "model-a", "weight": 1},
+    {"provider": "provider-b", "model": "model-b", "weight": 1}
   ]
 }
 ```
 
-Supported strategies: `failover` and weighted `round-robin`. A combo must be
-resolved before request translation, preserve the selected target for a sticky
-session, and use the normal provider/model capability gate. A combo must never
-hide an incompatible tool, vision or search capability.
+Resolve a combo before protocol translation, preserve a sticky binding only for
+the documented unit, run normal capability gates, and never retry after stream
+commit. Diagnostics must show the actual target without exposing credentials.
 
-### 7.2 Web-search sidecar
+Acceptance evidence: failover, weighted selection, all-targets-unhealthy,
+capability mismatch, sticky session, and native catalog tests.
 
-Codex Router currently has native standalone-search metadata for verified models.
-The missing OpenCodex feature is a provider-agnostic sidecar for models that do
-not accept the native search tool.
+## 7. Proposed gap E: web-search sidecar
 
-Design requirements:
+The current router preserves native standalone search and provider-specific
+hosted search. A future sidecar may be offered only as an explicit opt-in for a
+model that cannot consume the native search tool.
 
-- explicit per-provider/model opt-in;
-- a bounded search query and result schema;
-- ChatGPT-native search account as a sidecar credential, kept separate from the
-  selected generation account;
-- result citations and source URLs preserved in the model-visible payload;
-- timeout, cancellation, retry and cache policy;
-- no search sidecar when the model already supports native search unless the user
-  explicitly selects it;
-- no hidden search calls on ordinary text requests;
-- clear telemetry showing sidecar latency and failure reason.
+Requirements:
 
-This must be capability-driven. Do not add model-name conditionals.
+- bounded query/result schema with citations and source URLs;
+- separate credential scope from generation credentials;
+- timeout, cancellation, retry, and cache policy;
+- no sidecar call for a route that already supports native search unless the
+  user explicitly selects it;
+- observable latency and failure reason;
+- capability-driven selection, never a model-name special case.
 
-### 7.3 Broad sub-agent roster and fallback
+Acceptance evidence: success, timeout, cancellation, cache hit, malformed
+result, native-search bypass, redaction, and request accounting.
 
-Codex Router already supports v1/v2 sub-agents and certified model metadata. Add:
+## 8. Proposed gap F: sub-agent policy
 
-- `allowUnverifiedModels` as an explicit opt-in, default `false`;
-- per-agent model chains with provider/model targets and weights;
-- fallback on pre-commit transport failures only;
-- tool/vision/search capability validation before assigning a model;
-- per-agent token/time budgets and concurrency limits;
-- clear display labels and an audit trail of the actual target used.
+Current sub-agent availability is registry- and proof-driven, with a managed
+concurrency value of 6. Future work may add explicit opt-in unverified models,
+per-agent chains, fallback, budgets, and actual-target diagnostics.
 
-Do not expand the default roster merely because a provider advertises a model.
+Defaults must remain conservative. A child model must pass tool, vision,
+search, reasoning, and context checks before selection. Fallback is legal only
+before stream commit. Any concurrency change must be explicit, tested, and
+separate from provider parity.
 
-### 7.4 Dashboard and live management
+## 9. Proposed control surfaces
 
-OpenCodex's web dashboard manages providers, models, accounts, combos, sidecars,
-logs and usage. Codex Router's macOS tray remains the primary local UI, but the
-control API should expose equivalent authenticated operations:
+The current macOS tray and Control Center remain the primary local UI. A future
+control API may expose sanitized, authenticated operations for providers,
+discovery, credentials, pools, combos, sidecars, usage, cooldowns, and
+diagnostics. A browser dashboard or client export is proposed only if the
+existing local surfaces cannot manage the accepted feature.
 
-- providers and credentials;
-- model discovery and overrides;
-- combos and sub-agent policies;
-- quota/health/cooldown state;
-- sidecar configuration;
-- bounded logs and request traces;
-- export/import of non-secret configuration.
+Every new setting must use existing rows, pickers, spacing, typography, colors,
+accessibility labels, and Dynamic Island behavior. Native GPT labels, defaults,
+speed controls, and existing settings must remain untouched.
 
-The UI must show whether a value is native, verified, user-defined, live-
-discovered or inferred. Do not overwrite native GPT labels or speed controls.
+## 10. Proposed architecture
 
-### 7.5 Client integrations and exports
-
-OpenCodex provides exports or integrations for OpenCode, Pi, OMP, Hermes,
-OpenClaw, Kimi, Gajae, DeepSeek Harness, MiniMax Code, ZCode and Prime Agent,
-plus Claude Code/Desktop and Grok Build flows. Codex Router currently targets
-Codex, DeepSeek Harness and Gemini CLI; OpenCode is a provider rather than a
-supported target.
-
-Implement exports as generated, versioned adapters. Each export must declare the
-gateway URL, auth mechanism, model aliases and whether tool/search/vision
-features are supported. Never copy secrets into generated files by default.
-
-### 7.6 Memory and cache controls
-
-OpenCodex exposes an app-owned memory budget and cache retention controls. Codex
-Router already has operational logs and retention behavior, but parity requires:
-
-- bounded in-memory queues and response buffers;
-- explicit cache retention and maximum size;
-- eviction metrics;
-- a diagnostic report showing active memory budget and retained stores;
-- no unbounded transcript or tool-result retention in the router process.
-
-This is an operational hardening item, not a reason to cache prompts or provider
-secrets.
-
-## 8. Proposed architecture
-
-Keep the existing gateway and provider registry. Add layers with single
-responsibilities:
+Keep the existing gateway and registry. Add narrowly scoped layers only when a
+feature is accepted:
 
 ```text
 Control API / tray / CLI
         |
-Config + encrypted credential store
+Provider/model state and protected credential references
         |
-Pool policy + session affinity + cooldown
+Pool policy, session affinity, cooldown
         |
-Combo resolver + model capability registry
+Combo resolver and capability registry
         |
-Protocol adapter (Responses / Chat / Anthropic / Gemini / Azure)
+Protocol adapter and endpoint gates
         |
-Existing Codex Router gateway and request/stream pipeline
+Existing router request/stream pipeline
 ```
 
-Suggested module boundaries (adapt names to the checkout):
+The request order should be deterministic:
 
-- `credentials`: encrypted secret references, account/key lifecycle;
-- `pools`: eligibility, strategy, quota snapshots and session bindings;
-- `providers`: provider manifests, generic provider CRUD and discovery;
-- `models`: live catalog merge, capability profiles and user overrides;
-- `combos`: virtual model resolution and sticky target state;
-- `adapters`: protocol translation and endpoint capability gates;
-- `sidecars`: web search and other explicit auxiliary services;
-- `control`: authenticated API, CLI and tray operations;
-- `exports`: generated client-specific configuration.
+1. authenticate the local caller;
+2. resolve native, user, or combo model;
+3. load validated capabilities;
+4. choose a credential or session binding;
+5. validate tools, images, search, and reasoning;
+6. translate only supported fields;
+7. send with cancellation and trace propagation;
+8. update health, usage, cooldown, and sanitized diagnostics.
 
-Avoid provider-specific branches in the core router. A provider manifest should
-provide data and adapter selection; an adapter should provide protocol behavior.
+## 11. Security and migration requirements
 
-### 8.1 Routing order
+These are requirements for future implementations, not claims about current
+storage:
 
-For every request, use this deterministic order:
+- use the existing protected-file/OS credential boundary or a separately
+  reviewed encrypted store; never create a second plaintext database;
+- redact authorization, cookies, refresh tokens, API keys, signed URLs, and
+  provider-specific secret headers from logs, errors, traces, and exports;
+- keep control operations loopback-bound and authenticated by default;
+- validate endpoint schemes, redirects, private-network access, and DNS
+  behavior;
+- scope caches, cooldowns, quota, and session state by provider/credential;
+- preserve native Codex auth and metadata;
+- make migrations idempotent, reversible, and safe under concurrent writers;
+- fail closed on unknown capability or identity data.
 
-1. authenticate the control/client request;
-2. resolve native or user-selected provider/model/combo;
-3. load merged model capabilities;
-4. choose a session-bound credential or run pool selection;
-5. validate requested tools, images, search and reasoning against capabilities;
-6. choose the protocol adapter;
-7. translate only supported fields;
-8. send the request with cancellation and trace propagation;
-9. update quota, health, cooldown and session state;
-10. expose the selected provider/model/credential alias in diagnostics, never the
-    secret.
+## 12. Test plan for accepted features
 
-## 9. Control API and CLI contract
+Each implementation must add only the focused tests it needs, then run the
+existing regression gates:
 
-The exact HTTP prefix must follow the existing Codex Router control namespace.
-The following are logical contracts, not permission to expose an unauthenticated
-server.
+- unit/state: normalization, migration, redaction, permissions, locking;
+- protocol: text, streaming, tools, reasoning, images, unsupported fields,
+  cancellation, errors, and request IDs;
+- routing: provider selection, capability gates, cooldown, failover, and
+  stream commit boundaries;
+- integration: restart, rollback, concurrent writes, target publication, and
+  native GPT preservation;
+- UI: Control Center build/renderer tests and Swift build/tests for tray work;
+- live checks: only with explicit approval, and never with secrets in fixtures
+  or output.
 
-| Operation | Method | Result |
-| --- | --- | --- |
-| List providers | `GET /control/providers` | Sanitized provider manifests |
-| Add provider | `POST /control/providers` | Provider ID and validation result |
-| Discover models | `POST /control/providers/{id}/discover` | Merged model catalog |
-| Add credential | `POST /control/providers/{id}/credentials` | Credential ID only |
-| List credential health | `GET /control/providers/{id}/credentials` | State/quota/alias, no secret |
-| Set pool policy | `PUT /control/providers/{id}/pool` | Effective policy |
-| Bind session | `PUT /control/sessions/{id}/credential` | Sanitized binding |
-| Manage combos | `/control/combos` | CRUD and validation |
-| Test route | `POST /control/routes/test` | Redacted request/response metadata |
-| Export client config | `POST /control/exports/{client}` | Generated config with secret refs |
+No feature is complete because a helper module compiles, a draft PR exists, or
+an isolated unit test passes. The code must be merged to current `main` and its
+end-to-end evidence must be recorded in the corresponding PR.
 
-CLI equivalents should be scriptable and non-interactive:
+## 13. Open questions
 
-```text
-router provider list
-router provider add NAME --adapter openai-chat --base-url URL
-router provider discover NAME
-router provider test NAME/MODEL
-router credential add PROVIDER --kind account|api-key
-router credential list PROVIDER
-router pool set PROVIDER --strategy quota --sticky-limit 50
-router combo set NAME PROVIDER/MODEL[:WEIGHT]...
-router model list --provider NAME
-router export CLIENT --output PATH
-```
+Resolve these from current provider and client documentation before coding:
 
-Commands that accept secrets must support environment variables or OS keychain
-references. Do not print the value in shell history or command output.
+1. Which official account and OAuth flows permit multiple saved identities?
+2. Which providers expose reliable quota windows and reset timestamps?
+3. Which optional OpenAI endpoint families are needed by a supported caller?
+4. Which protocol fields are lossless for tools, reasoning, images, and search?
+5. Which state/control API contract should tray and CLI share?
+6. Which maintained client integration is worth an export after the gateway is
+   stable?
 
-## 10. Security requirements
-
-- Store OAuth tokens and API keys in the existing OS keychain/secure store or an
-  encrypted store with a process-local key reference.
-- Redact `Authorization`, cookies, refresh tokens, API keys, signed URLs and
-  provider-specific secret headers from logs, errors, traces and exports.
-- Bind control operations to loopback by default and require an explicit,
-  authenticated opt-in for remote access.
-- Validate provider URLs, including scheme, redirects, private-network access,
-  DNS rebinding and maximum redirect count.
-- Apply per-provider and per-credential rate limits; avoid retry storms.
-- Separate provider/account scopes in cache, cooldown, quota and session state.
-- Do not use account pooling to bypass provider restrictions. Surface terms and
-  require explicit confirmation for multi-account configuration.
-- Preserve native Codex authentication and model metadata. A custom provider
-  must not be able to overwrite native GPT display name, speed or default model.
-- Treat upstream model metadata as untrusted input; validate lengths, IDs,
-  modalities and numeric limits before persisting or displaying them.
-
-## 11. Compatibility and migration
-
-The implementation must satisfy all of the following:
-
-1. Existing provider configs continue to load without a migration command.
-2. Existing `custom` per-model endpoints continue to work unchanged.
-3. Existing native GPT models, labels, default model and `normal`/`fast` speed
-   controls remain client-owned and untouched.
-4. Existing OAuth/API logins remain valid; migration must copy references, not
-   re-print or re-enter secrets.
-5. A failed migration leaves the previous state loadable and provides rollback.
-6. New generic providers are disabled until explicitly enabled and tested.
-7. Live discovery never deletes manually configured model entries.
-8. Existing sub-agent certification and tool safety defaults remain unchanged.
-9. Config export/import is versioned and rejects unknown destructive changes.
-10. Update/rollback works with the current supervised macOS tray installation.
-
-Add a schema version and an idempotent migration. Back up only encrypted state
-and non-secret configuration; do not create plaintext copies of credentials.
-
-## 12. Test plan
-
-### Unit tests (P0)
-
-- pool eligibility, quota unknown, threshold and priority;
-- round-robin and fill-first ordering;
-- sticky session binding and atomic rebind;
-- cooldown after 401/403/429/5xx and recovery;
-- no retry after a committed stream;
-- provider URL and private-network validation;
-- secret redaction in logs and errors;
-- capability gate for tools, image input, search, reasoning and structured output;
-- live catalog merge precedence and preservation of user models;
-- combo failover, weights, sticky limit and capability validation;
-- migration idempotence and rollback.
-
-### Protocol contract tests (P0/P1)
-
-Use local fixtures for:
-
-- OpenAI Responses streaming;
-- OpenAI Chat Completions streaming;
-- tool calls and parallel tool calls;
-- reasoning content in both Responses and Chat formats;
-- image input accepted and rejected;
-- upstream error/status/request ID propagation;
-- `/v1/models` discovery;
-- legacy Completions and optional embeddings/images/audio routes.
-
-### Integration tests
-
-- one provider with two API keys;
-- one ChatGPT account pool with simulated quota windows;
-- two providers behind one combo;
-- sidecar search success, timeout, cancellation and cache hit;
-- private loopback provider with explicit opt-in and remote rejection;
-- tray/control API and CLI produce the same state;
-- generated client exports contain secret references, not secret values.
-
-### End-to-end acceptance
-
-Run a real text turn, streamed tool call, image turn and native web-search turn
-for at least one verified provider. Run the same text/tool cases through a local
-generic OpenAI-compatible fixture. Verify that a restart preserves session
-affinity, pool health and native GPT selector state. Record provider-specific
-limitations instead of marking an unsupported capability as passed.
-
-## 13. Phased implementation plan
-
-### P0: safe foundation
-
-- credential abstractions and encrypted storage;
-- provider-scoped API-key pool;
-- generic OpenAI Chat/Responses provider;
-- model discovery and capability profiles;
-- control API/CLI with redaction;
-- migration, rollback and regression tests for native GPT.
-
-### P1: routing parity
-
-- ChatGPT/Codex account pool;
-- quota strategies, sticky affinity and re-auth;
-- virtual combos;
-- direct OpenAI API key, Azure, Vertex and local vLLM presets;
-- capability-driven request field filtering.
-
-### P2: ecosystem parity
-
-- web-search sidecar;
-- remaining OpenAI-compatible provider manifests;
-- broader sub-agent opt-in and fallback chains;
-- dashboard views and usage/health diagnostics;
-- client exports for OpenCode and the other maintained integrations.
-
-### P3: product-specific adapters
-
-- OAuth/client integrations such as Anthropic OAuth, Cursor, Kiro and GitLab Duo;
-- regional coding plans and non-OpenAI protocol adapters;
-- optional OpenAI non-chat endpoints (embeddings, images and audio).
-
-Each phase must be independently shippable and must pass all prior acceptance
-tests.
-
-## 14. Definition of done
-
-The work is complete only when:
-
-- a user can add an arbitrary OpenAI-compatible provider and model without a
-  source change;
-- two API keys can be rotated with a documented policy and no secret leakage;
-- a supported ChatGPT account pool retains conversation affinity and safely
-  rebinds on an explicit failure;
-- a named combo can fail over or distribute requests without violating model
-  capabilities;
-- a model without vision or native search receives no unsupported image/search
-  fields;
-- native GPT labels, default selection and speed controls are unchanged;
-- at least one missing provider category is implemented through a data-driven
-  preset rather than a core-router conditional;
-- control API, tray and CLI show consistent sanitized state;
-- migration, restart, rollback and end-to-end streaming tests pass.
-
-## 15. Open questions for the implementing agent
-
-Resolve these from current provider documentation before implementation:
-
-1. Which official OAuth flows and account-pool use cases are permitted by each
-   provider's terms?
-2. Which providers expose reliable 5-hour, weekly or monthly quota APIs?
-3. Does the current Codex client require only Responses, or should the gateway
-   expose the full optional OpenAI endpoint set to other clients?
-4. Which providers support native reasoning fields versus plain text reasoning?
-5. What is the exact existing control API authentication and persistence contract?
-6. Should the dashboard be added to the tray package, the router process, or a
-   separately supervised local UI?
-7. Which exports are still maintained upstream and therefore worth implementing?
-
-When a provider's contract is unknown, keep it disabled and expose it as an
-experimental preset. Do not guess endpoint paths, auth headers, quota behavior
-or model capabilities.
+When a contract is unknown, leave it proposed and disabled. Do not guess an
+endpoint, auth header, quota rule, or model capability.

--- a/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
+++ b/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
@@ -61,11 +61,11 @@ earlier state and record the reason in the notes column.
 | P10 | `feat: add capability-driven sidecar search` | Explicit web-search sidecar for models without native search | P02, P06 | complete and submitted (#409) |
 | P11 | `feat: extend verified sub-agent routing` | Opt-in unverified models, per-agent chains and safe fallback | P06, P09 | complete and submitted (#410) |
 | P12 | `feat: add missing provider presets` | Data-driven manifests for high-value missing OpenCodex providers | P04, P05, P06 | complete and submitted (#412) |
-| P13 | `feat: expose provider and pool controls in tray` | Native-style settings rows for provider/account/key/pool management | P02, P03, P04 | to implement |
+| P13 | `feat: expose provider and pool controls in tray` | Native-style settings rows for provider/account/key/pool management | P02, P03, P04 | implemented (pool controls still missing) |
 | P14 | `feat: expose combos and sidecars in tray` | Existing tray UI patterns for combos, search sidecar and sub-agent policy | P09, P10, P11 | to implement |
-| P15 | `feat: add provider and account dashboard API` | Authenticated control API parity for live management and diagnostics | P02-P11 | to implement |
+| P15 | `feat: add provider and account dashboard API` | Authenticated control API parity for live management and diagnostics | P02-P11 | implemented (snapshot wiring needs isolated PR) |
 | P16 | `feat: add client exports for supported integrations` | Versioned OpenCode/Pi/DSH/etc. exports without plaintext secrets | P04, P06, P15 | complete and submitted (#413) |
-| P17 | `perf: bound router cache and memory retention` | Explicit bounded buffers, retention policy and diagnostics | P02, P15 | to implement |
+| P17 | `perf: bound router cache and memory retention` | Explicit bounded buffers, retention policy and diagnostics | P02, P15 | implemented (hard request cap and eviction metrics pending) |
 | P18 | `test: add end-to-end parity and migration suite` | Full regression matrix, restart, rollback, tray and native GPT checks | P01-P17 | to implement |
 | P19 | `fix: raise managed subagent concurrency` | Keep router-managed Codex configuration aligned with the 100-thread user setting | P00 | implemented |
 

--- a/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
+++ b/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
@@ -1,453 +1,116 @@
-# OpenCodex parity implementation roadmap
+# OpenCodex parity roadmap
 
-Status: implementation in progress
+Status: verified baseline and proposed work
 
 Parent specification: [OpenCodex feature gap specification](./OPENCODEX_FEATURE_GAP_SPEC.md)
 
-Baseline: 2026-08-24
-
-This document breaks the parent specification into small, reviewable pull
-requests. Every item has one owner, one narrow purpose, explicit tests and a
-status. A pull request is not considered complete until its tests pass, its
-description is present in simple English, its behavior is checked in the app or
-tray when applicable, and it is submitted to the upstream repository.
-
-## Status values
-
-- `to implement`: scope is defined, no implementation accepted;
-- `implemented`: code exists, focused tests are still required;
-- `to test`: implementation is ready for validation;
-- `tested`: focused and regression tests passed locally;
-- `complete and submitted`: tests passed and the PR was opened/submitted with
-  the required title and short description.
-
-Do not skip a state. If a PR fails review or tests, move it back to the relevant
-earlier state and record the reason in the notes column.
-
-## Global rules for every PR
-
-1. Preserve native GPT catalog ownership, default model, labels and `normal` /
-   `fast` speed controls.
-2. Preserve existing provider credentials, custom per-model endpoints and tray
-   settings. Migrations must be reversible and idempotent.
-3. Keep the current frontend visual language. Add controls using existing tray
-   rows, pickers, cards, spacing, typography and colors; do not introduce a new
-   design system or change the Dynamic Island silhouette.
-4. Any new provider/model capability must be data-driven. Do not add model-name
-   conditionals to the request path.
-5. Secrets never appear in source, fixtures, logs, PR text, screenshots,
-   generated exports or test output.
-6. Each PR must pass `npm run check`, the relevant `npm test` subset, and the
-   relevant Swift package tests/build when it touches the tray.
-7. Every PR description must be short, human, and written in Simplified
-   Technical English. It must include a clear `Reason` section that says what
-   problem the PR solves. Use the title and body templates in this document.
-8. Do not merge unrelated formatting or generated build artifacts.
-
-## PR queue and dependency graph
-
-| ID | Proposed PR title | Scope | Depends on | Status |
-| --- | --- | --- | --- | --- |
-| P00 | `docs: add OpenCodex parity implementation roadmap` | This roadmap, linked from the parent specification | None | implemented |
-| P01 | `fix: keep provider icons within tray icon bounds` | Fix oversized provider mark in menu bar and Dynamic Island; add Swift regression coverage | None | complete and submitted (#401) |
-| P02 | `feat: add secure provider credential primitives` | Encrypted account/key references, redaction, lifecycle types and migration | P00 | complete and submitted (#402) |
-| P03 | `feat: add provider-scoped API key pools` | Key pool state, quota/health policy, rotation and control operations | P02 | complete and submitted (#403) |
-| P04 | `feat: add generic OpenAI-compatible providers` | Provider CRUD, base URL, headers, adapter selection and private-network guard | P02 | complete and submitted (#404) |
-| P05 | `feat: add OpenAI Responses and Chat adapters` | Capability-aware Responses/Chat translation and streaming tests | P04 | complete and submitted (#405) |
-| P06 | `feat: add live model discovery and capability overrides` | `/v1/models`, merge precedence, model labels/modalities/tool metadata | P04, P05 | complete and submitted (#406) |
-| P07 | `feat: add capability-gated OpenAI API endpoints` | Completions, embeddings, images, audio, moderation, files and optional batches | P05, P06 | to implement |
-| P08 | `feat: add ChatGPT account pool routing` | OAuth account pool, quota windows, sticky affinity, re-auth and safe rebind | P02 | complete and submitted (#407) |
-| P09 | `feat: add provider combos and weighted failover` | Virtual models, failover/round-robin, weights, sticky limits and validation | P06 | complete and submitted (#408) |
-| P10 | `feat: add capability-driven sidecar search` | Explicit web-search sidecar for models without native search | P02, P06 | complete and submitted (#409) |
-| P11 | `feat: extend verified sub-agent routing` | Opt-in unverified models, per-agent chains and safe fallback | P06, P09 | complete and submitted (#410) |
-| P12 | `feat: add missing provider presets` | Data-driven manifests for high-value missing OpenCodex providers | P04, P05, P06 | complete and submitted (#412) |
-| P13 | `feat: expose provider and pool controls in tray` | Native-style settings rows for provider/account/key/pool management | P02, P03, P04 | implemented (pool controls still missing) |
-| P14 | `feat: expose combos and sidecars in tray` | Existing tray UI patterns for combos, search sidecar and sub-agent policy | P09, P10, P11 | to implement |
-| P15 | `feat: add provider and account dashboard API` | Authenticated control API parity for live management and diagnostics | P02-P11 | implemented (snapshot wiring needs isolated PR) |
-| P16 | `feat: add client exports for supported integrations` | Versioned OpenCode/Pi/DSH/etc. exports without plaintext secrets | P04, P06, P15 | complete and submitted (#413) |
-| P17 | `perf: bound router cache and memory retention` | Explicit bounded buffers, retention policy and diagnostics | P02, P15 | implemented (hard request cap and eviction metrics pending) |
-| P18 | `test: add end-to-end parity and migration suite` | Full regression matrix, restart, rollback, tray and native GPT checks | P01-P17 | to implement |
-| P19 | `fix: raise managed subagent concurrency` | Keep router-managed Codex configuration aligned with the 100-thread user setting | P00 | implemented |
-
-The initial implementation order is P01, P02, P04, P05, P06, P03, P08, P09,
-P10, P11, P12, then the UI/API/export/hardening items. P01 is independent and
-can be submitted first. P02/P04/P05/P06 form the generic-provider foundation;
-do not implement dozens of provider-specific branches before that foundation is
-tested.
-
-The submitted feature PRs are intentionally small foundations. P08-P11 expose
-pure policy modules where the consumer/UI wiring is still a later task. PRs
-#402, #404, #405 and #406 are stacked prerequisite branches; review and merge
-them in dependency order. Every submitted PR now includes a `Reason` section
-in its description.
-
-## P00 — roadmap document
-
-Status: `implemented`
-
-This document and the parent specification are the planning artifacts. No
-runtime code is part of P00. The parent document must link here before the first
-feature PR is opened.
-
-## P19 — managed subagent concurrency
-
-Status: `implemented`
-
-The local Codex configuration now uses the structured `multi_agent_v2` setting
-with a 100-thread limit. The router's managed default and installer documentation
-use the same value, while an existing user-owned limit remains authoritative.
-
-Title: `fix: raise managed subagent concurrency`
-
-Description template:
-
-> Raises the Codex Router managed sub-agent limit to 100 threads and keeps the
-> structured Codex v2 setting valid. User-owned limits are still preserved.
-
-Validation: config-manager tests, real Codex config parse/login status and a
-full Codex restart before using the extra slots.
-
-## P01 — provider icon sizing
-
-Title: `fix: keep provider icons within tray icon bounds`
-
-Description template:
-
-> Provider marks could render larger than the tray slot. This clamps provider
-> images to the same fixed bounds used by preset icons in the menu bar and
-> Dynamic Island, while keeping the existing provider assets and style.
-
-Implementation:
-
-- Make the shared `ProviderIcon` layout have an explicit fixed slot and clip the
-  rendered image to that slot.
-- Keep aspect ratio and transparent padding; do not crop provider logos.
-- Keep all current call-site sizes (14, 18, 22, 24, 26) unless a test proves a
-  caller is wrong.
-- Ensure menu bar `.provider`, compact Island, expanded Island and quota rows
-  all use the same component behavior.
-- Do not change the Dynamic Island shape, animation or typography.
-
-Validation:
-
-- Add a Swift test for the sizing/layout contract if the current test target can
-  express it; otherwise add a pure helper test for the normalized slot size.
-- Build `apps/macos/ModelRouterTray` in release mode.
-- Run existing `MenuBarSettingsTests` and `IslandModeTests`.
-- Inspect the installed tray on macOS with provider icon, preset icon and idle
-  indicator styles.
-- Verify the screenshot case: the provider mark is icon-sized, not a large
-  logo clipped by the menu bar or island.
-
-## P02 — secure credential primitives
-
-Title: `feat: add secure provider credential primitives`
-
-Description template:
-
-> Adds provider-neutral account and API-key references with encrypted storage and
-> redacted status output. Existing credentials remain compatible and no secret is
-> copied into configuration or logs.
-
-Implementation:
-
-- Add opaque credential IDs and `account` / `api_key` kinds.
-- Reuse the existing secure store and file-protection helpers.
-- Add schema version, idempotent migration and rollback snapshot.
-- Provide lifecycle types and sanitized status output before adding routing.
-- Add redaction tests for headers, URLs, errors, support bundles and exports.
-
-Validation: unit tests, migration twice, rollback, permission check and
-`bin/model-router codex doctor` with the current user's existing credentials.
-
-## P03 — provider-scoped API-key pools
-
-Title: `feat: add provider-scoped API key pools`
-
-Description template:
-
-> Adds optional API-key pools with health-aware selection and safe rotation.
-> Single-key providers keep their current behavior and existing credentials are
-> not changed.
-
-Implementation:
-
-- Add `quota`, `round-robin` and `fill-first` strategies.
-- Track health, cooldown, priority and paused state per key.
-- Keep session affinity and rebind only on pre-commit failure.
-- Make quota refresh cached and non-blocking for ordinary requests.
-- Expose sanitized list/add/pause/resume/test operations.
-
-Validation: two-key fixture, 401/403/429/5xx cooldowns, stream commit boundary,
-concurrent session selection and no secret leakage.
-
-## P04 — generic OpenAI-compatible provider
-
-Title: `feat: add generic OpenAI-compatible providers`
-
-Description template:
-
-> Adds a reusable provider definition with base URL, adapter, headers and secure
-> credentials. Users can connect compatible endpoints without adding provider-
-> specific code, while private-network access stays explicit and protected.
-
-Implementation:
-
-- Promote the current per-model `custom` behavior to a provider object without
-  breaking old custom model files.
-- Add provider CRUD and test operations through the existing control/CLI plane.
-- Add explicit `allowPrivate` validation and loopback-only default.
-- Keep provider/model IDs separate from display labels.
-- Do not let a generic provider overwrite native GPT catalog metadata.
-
-Validation: local OpenAI fixture, remote URL validation, DNS/private-network
-guard, CRUD idempotence, existing `custom` regression and restart persistence.
-
-## P05 — Responses and Chat adapters
-
-Title: `feat: add OpenAI Responses and Chat adapters`
-
-Description template:
-
-> Adds capability-aware OpenAI Responses and Chat Completions translation with
-> streaming, tool calls, reasoning fields and cancellation coverage.
-
-Implementation: separate protocol adapters, stream backpressure, request IDs,
-tool-call normalization, reasoning mapping, error normalization and omission of
-unsupported fields. Never retry after response bytes are committed.
-
-Validation: local fixtures for text, streaming, tools, reasoning, cancellation,
-unsupported vision/search and upstream error/request-ID propagation.
-
-## P06 — live models and capabilities
-
-Title: `feat: add live model discovery and capability overrides`
-
-Description template:
-
-> Adds cached provider-scoped model discovery and safe metadata overrides. Live
-> refresh preserves user-defined models and native GPT metadata.
-
-Implementation: `/v1/models`, merge precedence (user > verified preset > live >
-conservative default), display labels, context windows, modalities, tools,
-reasoning, vision, search, cost metadata and request profiles.
-
-Validation: discovery cache, refresh failure, user model preservation, invalid
-metadata rejection and catalog publication regression tests.
-
-## P07 — extended OpenAI endpoints
-
-Title: `feat: add capability-gated OpenAI API endpoints`
-
-Description template:
-
-> Adds optional OpenAI-compatible endpoint forwarding with explicit capability
-> gates. Chat model routing remains separate from embeddings, media and job APIs.
-
-Implementation priority: legacy Completions first; then embeddings, image/audio,
-moderation, files and batches. Verify the current OpenAI contract before any
-legacy Assistants/Threads/Vector Stores implementation. Add `supportedEndpoints`,
-multipart limits, idempotency and polling state.
-
-Validation: route allowlist, file size/type limits, streaming cancellation,
-non-idempotent retry protection and endpoint capability tests.
-
-## P08 — ChatGPT account pool
-
-Title: `feat: add ChatGPT account pool routing`
-
-Description template:
-
-> Adds an optional ChatGPT/Codex account pool with quota-aware selection, session
-> affinity and safe re-authentication. The native single-account path remains
-> unchanged unless pooling is explicitly enabled.
-
-Implementation: encrypted OAuth account rows, quota windows, priority, paused
-accounts, `quota`/`round-robin`/`fill-first`, sticky limit, atomic rebind and
-provider-policy warning. Do not use this feature to evade provider restrictions.
-
-Validation: simulated quota windows, expiry, 401/403/429, session affinity,
-concurrent turns, restart persistence and native GPT selector regression.
-
-## P09 — virtual combos
-
-Title: `feat: add provider combos and weighted failover`
-
-Description template:
-
-> Adds named virtual models that fail over or distribute requests across
-> provider/model targets. Capability checks run before a target is selected.
-
-Implementation: persisted combo definitions, failover/weighted round-robin,
-sticky limit, weights, sanitized diagnostics and model selector labels.
-
-Validation: weights, all targets unhealthy, capability mismatch, sticky session,
-stream commit boundary and native model list regression.
-
-## P10 — web-search sidecar
-
-Title: `feat: add capability-driven search sidecar`
-
-Description template:
-
-> Adds an explicit web-search sidecar for models that cannot consume native
-> search tools. It is bounded, observable and disabled unless configured.
-
-Implementation: sidecar credential, result schema, citations, cache, timeout,
-cancellation, retry, latency telemetry and no duplicate call for native-search
-models. Never infer sidecar support from a model name.
-
-Validation: success, timeout, cancellation, cache hit, malformed result and
-native-search bypass.
-
-## P11 — sub-agent parity
-
-Title: `feat: extend verified sub-agent routing`
-
-Description template:
-
-> Adds opt-in unverified sub-agent models and safe per-agent fallback chains.
-> Existing verified-model defaults and tool safety remain unchanged.
-
-Implementation: `allowUnverifiedModels=false` by default, capability validation,
-per-agent chains, budgets, concurrency limits and actual-target diagnostics.
-
-Validation: verified default, explicit opt-in, tool/vision/search mismatch,
-fallback before stream commit and concurrency budget tests.
-
-## P12 — missing provider presets
-
-Title: `feat: add data-driven missing provider presets`
-
-Description template:
-
-> Adds high-value missing provider manifests on top of the generic adapter layer.
-> Presets define endpoints and capabilities without adding provider branches to
-> the core router.
-
-Implementation order: direct OpenAI API key, Azure OpenAI, Google Vertex,
-Gemini-native, local vLLM, then regional and infrastructure providers. Keep
-experimental/unknown presets disabled until their official contracts are tested.
-
-Validation: one fixture per adapter family, auth transport, discovery, model
-capabilities, health and quota behavior.
-
-## P13 — tray provider/account controls
-
-Title: `feat: expose provider and pool controls in tray`
-
-Description template:
-
-> Adds provider and pool controls to the existing tray settings using the current
-> visual language. Native GPT settings and Dynamic Island layout are unchanged.
-
-Implementation: reuse existing settings rows, sheets, picker styles, spacing,
-localization and status cards. Add sanitized provider/account/key health and
-strategy controls. Never show secrets.
-
-Validation: Swift tests, release build, tray interaction, Dynamic Island modes,
-keyboard/accessibility labels and native GPT settings regression.
-
-## P14 — tray combos, sidecar and sub-agent controls
-
-Title: `feat: expose routing policies in tray`
-
-Description template:
-
-> Adds combo, search-sidecar and sub-agent policy controls to the existing tray
-> without changing its visual style or Dynamic Island silhouette.
-
-Implementation: follow existing cards/pickers and show capability/health state;
-keep advanced settings opt-in and preserve all current defaults.
-
-Validation: Swift UI tests where available, control API round trips, tray build,
-Dynamic Island compact/peek/expanded states and restart persistence.
-
-## P15 — dashboard control API
-
-Title: `feat: add authenticated provider management API`
-
-Description template:
-
-> Adds authenticated control endpoints for providers, models, credentials,
-> pools, combos, sidecars and diagnostics. Responses are sanitized and local by
-> default.
-
-Implementation: reuse current control namespace/authentication; loopback default,
-remote opt-in, audit events, no plaintext secrets and consistent CLI/tray state.
-
-Validation: authorization, loopback/remote policy, redaction, concurrent writes,
-idempotence and tray/CLI parity.
-
-## P16 — client exports
-
-Title: `feat: add versioned client configuration exports`
-
-Description template:
-
-> Adds safe exports for supported clients using local gateway URLs and secret
-> references. Generated files never contain raw provider credentials.
-
-Implementation: start with OpenCode and DeepSeek Harness where contracts are
-stable; add other clients only when maintained and tested. Preserve unrelated
-settings/comments in target files.
-
-Validation: export/import, secret reference checks, target config preservation and
-live client smoke tests that do not spend a paid request unless explicitly
-approved.
-
-## P17 — bounded memory and cache
-
-Title: `perf: bound router cache and memory retention`
-
-Description template:
-
-> Adds explicit limits and diagnostics for router buffers and caches. Request
-> routing behavior is unchanged and secrets are never cached in plaintext.
-
-Implementation: bounded queues, response/tool-result retention, eviction metrics,
-cache TTL/size settings and support diagnostics.
-
-Validation: stress fixture, eviction, restart, memory ceiling and no transcript or
-credential over-retention.
-
-## P18 — final parity suite
-
-Title: `test: add OpenCodex parity and migration suite`
-
-Description template:
-
-> Adds the end-to-end regression matrix for provider pools, generic endpoints,
-> combos, sidecars, sub-agents, tray behavior and native GPT preservation.
-
-Validation: `npm run check`, `npm test`, Swift package tests/build, local provider
-fixture, restart/rollback, one verified streamed tool call, one image-capability
-case, one search case and tray/Dynamic Island inspection.
-
-## PR submission checklist
-
-Before opening any PR:
-
-- verify the change is not already in upstream `main` or an open PR;
-- confirm only the intended files changed;
-- run focused tests, then the relevant global checks;
-- test the live app/tray surface for UI-affecting work;
-- update this roadmap status to `tested` only after evidence exists;
-- open the PR with a short title and description in Simplified Technical
-  English;
-- record the PR URL/number and move the state to `complete and submitted` only
-  after the PR is actually submitted.
-
-PR body template:
+Baseline: the current `main` branch at the time this document is reviewed.
+
+This document is a planning aid, not a runtime capability catalogue. The
+repository's `README.md`, source, and tests are authoritative. A feature is
+listed as shipped only when the current `main` branch contains the code and a
+focused test or documented operational check. Everything else is marked
+proposed. Historical branch or pull-request names are intentionally not used as
+proof of current behavior.
+
+## Current shipped behavior
+
+The following statements describe the behavior that is present and testable on
+current `main`:
+
+| Area | Shipped behavior | Evidence |
+| --- | --- | --- |
+| Client integrations | One shared router plane can publish routed models for Codex, DeepSeek Harness, and Gemini CLI. | `src/paths.mjs`, `src/target-integration.mjs`, `test/target-integration.test.mjs`, `README.md` |
+| Native Codex path | Native GPT catalog, login, default model, reasoning metadata, and native speed controls remain client-owned. | `src/native-catalog-source.mjs`, `src/catalog.mjs`, `src/config-manager.mjs`, `test/native-catalog-source.test.mjs`, `test/config-manager.test.mjs`, `README.md` |
+| Routed inference | Codex requests use the local Responses route. Supported providers are translated through Responses, Chat Completions, or Anthropic Messages adapters where their registry entry declares that protocol. | `src/router.mjs`, `src/api-forwarder.mjs`, `test/routing.test.mjs`, `test/anthropic-api-integration.test.mjs` |
+| Provider registry | Providers and model metadata are checked in under `config/`; local model files and explicit curation extend the catalog without adding request-path branches. | `src/model-registry.mjs`, `src/user-models.mjs`, `src/curate-models.mjs`, `README.md` |
+| Model discovery | Selected API providers can be queried through their `/models` endpoint. Results are cached and merged with the checked-in registry; discovery does not replace user model state. | `src/model-discovery.mjs`, `src/model-catalog-cache.mjs`, `test/model-discovery.test.mjs`, `test/provider-catalog-cache.test.mjs` |
+| Credentials | Provider API keys are read from protected owner-only files or documented environment sources; OAuth providers use their documented local sessions. Status and diagnostics redact values. This is file protection, not an encrypted credential database. | `src/provider-credentials.mjs`, `src/file-security.mjs`, `test/provider-credentials.test.mjs`, `README.md` |
+| Provider resilience | Model failover, provider cooldowns, usage accounting, and bounded retries are implemented for the supported routed paths. | `src/model-failover.mjs`, `src/provider-cooldown.mjs`, `src/provider-usage.mjs`, `test/model-failover.test.mjs`, `test/model-failover-router.test.mjs` |
+| Tools and images | Capability metadata gates tool/vision handling. The vision bridge can use a configured cloud or local engine; it does not make an unsupported model support images. | `src/vision-bridge.mjs`, `src/vision-bridge-state.mjs`, `test/vision-bridge.test.mjs`, `test/vision-bridge-e2e.test.mjs`, `README.md` |
+| Web search | Native Codex standalone search and provider-specific hosted search are preserved where the selected route supports them. There is no provider-agnostic search sidecar. | `src/config-manager.mjs`, `src/grok-oauth-forwarder.mjs`, `src/catalog.mjs`, `docs/HOW-IT-WORKS.md` |
+| Sub-agents | The router publishes the registry's verified v1/v2 collaboration metadata and manages the structured `multi_agent_v2` setting. The managed concurrency value is **6**; user-owned settings remain authoritative. | `src/multi-agent-state.mjs`, `src/subagent-proofs.mjs`, `src/config-manager.mjs`, `test/config-manager.test.mjs`, `test/subagent-*.test.mjs` |
+| Local models | Ollama, LM Studio, MLX, and other explicitly configured local paths are opt-in and remain loopback-bound. | `src/local-models.mjs`, `src/lmstudio-models.mjs`, `src/local-mlx.mjs`, `test/lmstudio-provider.test.mjs`, `test/local-models.test.mjs`, `README.md` |
+| Control surfaces | The macOS tray and Control Center expose the shipped provider, model, usage, health, local-model, and target controls using the existing visual language. | `apps/macos/ModelRouterTray`, `apps/control-center`, `test/control-center-electron.test.mjs`, Swift package tests |
+
+The router currently has one credential per configured API provider. It does not
+provide a provider-neutral API-key pool or a multi-account ChatGPT pool on
+`main`. It also does not provide virtual combo models, a browser dashboard, or
+general client configuration exports. These are proposed items below, not
+completed modules.
+
+The router-managed sub-agent setting intentionally remains at six concurrent
+threads. A request to raise that value is a separate configuration change and
+must not be represented as an already-shipped parity feature.
+
+## Proposed work
+
+The following items are future design work. They have no shipped status until
+their code, focused tests, and supported client behavior land on `main`.
+
+| ID | Proposed scope | Exit evidence |
+| --- | --- | --- |
+| P01 | Provider-neutral credential primitives and migration, using the existing protected-file boundary. | Schema and migration tests, redaction tests, rollback, permissions, and a doctor run with existing credentials. |
+| P02 | Provider-scoped API-key pools with explicit selection, health, cooldown, and rotation policy. | Two-key fixture, 401/403/429/5xx handling, streaming commit boundary, concurrent selection, and no secret leakage. |
+| P03 | Native ChatGPT account switching or pooling, only after the native profile and catalog ownership rules are settled. | Isolated profiles, identity binding, closed-app switching, rollback, restart persistence, usage identity, and native catalog regression tests. |
+| P04 | Generic OpenAI-compatible provider definitions above the current checked-in/custom model paths. | Provider CRUD, base URL and header validation, private-network policy, discovery, restart persistence, and legacy custom-model regression. |
+| P05 | Additional OpenAI-compatible endpoints such as legacy completions, embeddings, media, moderation, files, and long-running jobs. | Per-endpoint capability gates, limits, cancellation, idempotency, and non-idempotent retry tests. |
+| P06 | Named virtual models and explicit weighted/failover combinations. | Weight and failover behavior, capability checks, sticky-session semantics, stream commit boundary, and catalog regression tests. |
+| P07 | An opt-in, provider-agnostic web-search sidecar for models that cannot consume native search tools. | Bounded result schema, citations, timeout/cancellation, cache, telemetry, and native-search bypass tests. |
+| P08 | Broader sub-agent policy controls, only for models with explicit capability evidence. | Default-safe behavior, opt-in validation, tool/vision/search mismatch tests, actual-target diagnostics, and concurrency budget tests. |
+| P09 | Tray and Control Center controls for any new policy that is accepted. | Existing UI style, accessibility labels, restart persistence, release build, and native GPT/Dynamic Island regression checks. |
+| P10 | Authenticated local management endpoints for the accepted provider/model policies. | Loopback authorization, redaction, concurrent writes, idempotence, and CLI/tray parity. |
+| P11 | Versioned configuration exports for a maintained client integration. | Target-file preservation, secret-reference checks, import/export round trip, and a live non-paid smoke test. |
+| P12 | A bounded end-to-end parity and migration suite. | `npm run check`, targeted Node tests, Swift build/tests where relevant, restart/rollback, one streamed tool call, one image case, one search case, and native GPT preservation. |
+
+The IDs are planning labels only. They are not pull-request numbers and must
+not be marked complete from a branch or draft PR. A proposal moves to shipped
+only after it is merged to `main` and its evidence is reproducible there.
+
+## Invariants for future changes
+
+Every implementation must:
+
+1. Preserve native GPT catalog ownership, native defaults, labels, reasoning
+   metadata, and `normal`/`fast` speed controls.
+2. Preserve existing provider credentials, local model configuration, target
+   settings, and tray preferences. Migrations must be reversible and
+   idempotent.
+3. Use data-driven provider/model capabilities. Do not add model-name branches
+   to the request path.
+4. Keep secrets out of source, fixtures, logs, PR text, screenshots, exports,
+   and diagnostics. Protected files must remain owner-only; do not claim
+   encryption unless the implementation and tests actually provide it.
+5. Fail closed on ambiguous process identity, endpoint validation, capability
+   metadata, or credential state.
+6. Keep the shared router plane single-instance. A new client integration must
+   not create a second service or credential store.
+7. Keep the current tray and Control Center visual language. Do not change the
+   Dynamic Island silhouette or native GPT controls as a side effect.
+
+## Verification and status rules
+
+Before a future item is described as shipped:
+
+- rebase the implementation onto the current `main`;
+- verify the scope is not already implemented or removed by current policy;
+- run the narrowest focused tests, then `npm run check`;
+- run Control Center and Swift build/tests when those surfaces change;
+- perform a live app/tray check for UI-affecting work;
+- inspect the final diff for unrelated files or generated artifacts;
+- record the exact evidence in the implementation PR and update this document
+  only after the code is merged.
+
+PR descriptions should use short Simplified Technical English and include:
 
 ```text
 ## What changed
 
-<One or two short sentences in simple English.>
+<One or two short sentences.>
 
-## Why
+## Reason
 
-<The user-visible or reliability reason.>
+<What user-visible or reliability problem this solves.>
 
 ## Validation
 
@@ -455,9 +118,5 @@ PR body template:
 - <regression/build check>
 ```
 
-## Final acceptance gate
-
-The entire roadmap is complete only when every runtime PR is `complete and
-submitted`, P18 passes, the current app and tray continue to work after a full
-restart, Dynamic Island modes remain visually consistent, provider icons stay at
-preset-icon size, and native GPT model/default/speed controls remain unchanged.
+No item in this roadmap is complete merely because a draft PR exists, a helper
+module compiles in isolation, or a local branch has unmerged changes.

--- a/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
+++ b/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
@@ -60,11 +60,11 @@ earlier state and record the reason in the notes column.
 | P09 | `feat: add provider combos and weighted failover` | Virtual models, failover/round-robin, weights, sticky limits and validation | P06 | complete and submitted (#408) |
 | P10 | `feat: add capability-driven sidecar search` | Explicit web-search sidecar for models without native search | P02, P06 | complete and submitted (#409) |
 | P11 | `feat: extend verified sub-agent routing` | Opt-in unverified models, per-agent chains and safe fallback | P06, P09 | complete and submitted (#410) |
-| P12 | `feat: add missing provider presets` | Data-driven manifests for high-value missing OpenCodex providers | P04, P05, P06 | to implement |
+| P12 | `feat: add missing provider presets` | Data-driven manifests for high-value missing OpenCodex providers | P04, P05, P06 | complete and submitted (#412) |
 | P13 | `feat: expose provider and pool controls in tray` | Native-style settings rows for provider/account/key/pool management | P02, P03, P04 | to implement |
 | P14 | `feat: expose combos and sidecars in tray` | Existing tray UI patterns for combos, search sidecar and sub-agent policy | P09, P10, P11 | to implement |
 | P15 | `feat: add provider and account dashboard API` | Authenticated control API parity for live management and diagnostics | P02-P11 | to implement |
-| P16 | `feat: add client exports for supported integrations` | Versioned OpenCode/Pi/DSH/etc. exports without plaintext secrets | P04, P06, P15 | to implement |
+| P16 | `feat: add client exports for supported integrations` | Versioned OpenCode/Pi/DSH/etc. exports without plaintext secrets | P04, P06, P15 | complete and submitted (#413) |
 | P17 | `perf: bound router cache and memory retention` | Explicit bounded buffers, retention policy and diagnostics | P02, P15 | to implement |
 | P18 | `test: add end-to-end parity and migration suite` | Full regression matrix, restart, rollback, tray and native GPT checks | P01-P17 | to implement |
 | P19 | `fix: raise managed subagent concurrency` | Keep router-managed Codex configuration aligned with the 100-thread user setting | P00 | implemented |

--- a/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
+++ b/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
@@ -20,8 +20,8 @@ current `main`:
 
 | Area | Shipped behavior | Evidence |
 | --- | --- | --- |
-| Client integrations | One shared router plane can publish routed models for Codex, DeepSeek Harness, and Gemini CLI. | `src/paths.mjs`, `src/target-integration.mjs`, `test/target-integration.test.mjs`, `README.md` |
-| Native Codex path | Native GPT catalog, login, default model, reasoning metadata, and native speed controls remain client-owned. | `src/native-catalog-source.mjs`, `src/catalog.mjs`, `src/config-manager.mjs`, `test/native-catalog-source.test.mjs`, `test/config-manager.test.mjs`, `README.md` |
+| Client integrations | One shared router plane can publish routed models for Codex, DeepSeek Harness, and Gemini CLI. These are the only supported client targets on `main`; OpenCode and Cursor are not shipped targets. | `src/paths.mjs`, `src/target-integration.mjs`, `test/target-integration.test.mjs`, `README.md` |
+| Native Codex path | Native GPT catalog and login remain client-owned. The native default model, reasoning metadata, and speed controls remain client-owned by default; a routed default requires an explicit opt-in. | `src/native-catalog-source.mjs`, `src/catalog.mjs`, `src/config-manager.mjs`, `test/native-catalog-source.test.mjs`, `test/config-manager.test.mjs`, `README.md` |
 | Routed inference | Codex requests use the local Responses route. Supported providers are translated through Responses, Chat Completions, or Anthropic Messages adapters where their registry entry declares that protocol. | `src/router.mjs`, `src/api-forwarder.mjs`, `test/routing.test.mjs`, `test/anthropic-api-integration.test.mjs` |
 | Provider registry | Providers and model metadata are checked in under `config/`; local model files and explicit curation extend the catalog without adding request-path branches. | `src/model-registry.mjs`, `src/user-models.mjs`, `src/curate-models.mjs`, `README.md` |
 | Model discovery | Selected API providers can be queried through their `/models` endpoint. Results are cached and merged with the checked-in registry; discovery does not replace user model state. | `src/model-discovery.mjs`, `src/model-catalog-cache.mjs`, `test/model-discovery.test.mjs`, `test/provider-catalog-cache.test.mjs` |
@@ -33,11 +33,11 @@ current `main`:
 | Local models | Ollama, LM Studio, MLX, and other explicitly configured local paths are opt-in and remain loopback-bound. | `src/local-models.mjs`, `src/lmstudio-models.mjs`, `src/local-mlx.mjs`, `test/lmstudio-provider.test.mjs`, `test/local-models.test.mjs`, `README.md` |
 | Control surfaces | The macOS tray and Control Center expose the shipped provider, model, usage, health, local-model, and target controls using the existing visual language. | `apps/macos/ModelRouterTray`, `apps/control-center`, `test/control-center-electron.test.mjs`, Swift package tests |
 
-The router currently has one credential per configured API provider. It does not
-provide a provider-neutral API-key pool or a multi-account ChatGPT pool on
-`main`. It also does not provide virtual combo models, a browser dashboard, or
-general client configuration exports. These are proposed items below, not
-completed modules.
+The router currently has one active credential per configured API-provider
+entry. It does not provide a provider-neutral API-key pool or a multi-account
+ChatGPT pool on `main`. It also does not provide virtual combo models, a browser
+dashboard, or general client configuration exports. These are proposed items
+below, not completed modules.
 
 The router-managed sub-agent setting intentionally remains at six concurrent
 threads. A request to raise that value is a separate configuration change and

--- a/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
+++ b/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
@@ -1,0 +1,463 @@
+# OpenCodex parity implementation roadmap
+
+Status: implementation in progress
+
+Parent specification: [OpenCodex feature gap specification](./OPENCODEX_FEATURE_GAP_SPEC.md)
+
+Baseline: 2026-08-24
+
+This document breaks the parent specification into small, reviewable pull
+requests. Every item has one owner, one narrow purpose, explicit tests and a
+status. A pull request is not considered complete until its tests pass, its
+description is present in simple English, its behavior is checked in the app or
+tray when applicable, and it is submitted to the upstream repository.
+
+## Status values
+
+- `to implement`: scope is defined, no implementation accepted;
+- `implemented`: code exists, focused tests are still required;
+- `to test`: implementation is ready for validation;
+- `tested`: focused and regression tests passed locally;
+- `complete and submitted`: tests passed and the PR was opened/submitted with
+  the required title and short description.
+
+Do not skip a state. If a PR fails review or tests, move it back to the relevant
+earlier state and record the reason in the notes column.
+
+## Global rules for every PR
+
+1. Preserve native GPT catalog ownership, default model, labels and `normal` /
+   `fast` speed controls.
+2. Preserve existing provider credentials, custom per-model endpoints and tray
+   settings. Migrations must be reversible and idempotent.
+3. Keep the current frontend visual language. Add controls using existing tray
+   rows, pickers, cards, spacing, typography and colors; do not introduce a new
+   design system or change the Dynamic Island silhouette.
+4. Any new provider/model capability must be data-driven. Do not add model-name
+   conditionals to the request path.
+5. Secrets never appear in source, fixtures, logs, PR text, screenshots,
+   generated exports or test output.
+6. Each PR must pass `npm run check`, the relevant `npm test` subset, and the
+   relevant Swift package tests/build when it touches the tray.
+7. Every PR description must be short, human, and written in Simplified
+   Technical English. It must include a clear `Reason` section that says what
+   problem the PR solves. Use the title and body templates in this document.
+8. Do not merge unrelated formatting or generated build artifacts.
+
+## PR queue and dependency graph
+
+| ID | Proposed PR title | Scope | Depends on | Status |
+| --- | --- | --- | --- | --- |
+| P00 | `docs: add OpenCodex parity implementation roadmap` | This roadmap, linked from the parent specification | None | implemented |
+| P01 | `fix: keep provider icons within tray icon bounds` | Fix oversized provider mark in menu bar and Dynamic Island; add Swift regression coverage | None | complete and submitted (#401) |
+| P02 | `feat: add secure provider credential primitives` | Encrypted account/key references, redaction, lifecycle types and migration | P00 | complete and submitted (#402) |
+| P03 | `feat: add provider-scoped API key pools` | Key pool state, quota/health policy, rotation and control operations | P02 | complete and submitted (#403) |
+| P04 | `feat: add generic OpenAI-compatible providers` | Provider CRUD, base URL, headers, adapter selection and private-network guard | P02 | complete and submitted (#404) |
+| P05 | `feat: add OpenAI Responses and Chat adapters` | Capability-aware Responses/Chat translation and streaming tests | P04 | complete and submitted (#405) |
+| P06 | `feat: add live model discovery and capability overrides` | `/v1/models`, merge precedence, model labels/modalities/tool metadata | P04, P05 | complete and submitted (#406) |
+| P07 | `feat: add capability-gated OpenAI API endpoints` | Completions, embeddings, images, audio, moderation, files and optional batches | P05, P06 | to implement |
+| P08 | `feat: add ChatGPT account pool routing` | OAuth account pool, quota windows, sticky affinity, re-auth and safe rebind | P02 | complete and submitted (#407) |
+| P09 | `feat: add provider combos and weighted failover` | Virtual models, failover/round-robin, weights, sticky limits and validation | P06 | complete and submitted (#408) |
+| P10 | `feat: add capability-driven sidecar search` | Explicit web-search sidecar for models without native search | P02, P06 | complete and submitted (#409) |
+| P11 | `feat: extend verified sub-agent routing` | Opt-in unverified models, per-agent chains and safe fallback | P06, P09 | complete and submitted (#410) |
+| P12 | `feat: add missing provider presets` | Data-driven manifests for high-value missing OpenCodex providers | P04, P05, P06 | to implement |
+| P13 | `feat: expose provider and pool controls in tray` | Native-style settings rows for provider/account/key/pool management | P02, P03, P04 | to implement |
+| P14 | `feat: expose combos and sidecars in tray` | Existing tray UI patterns for combos, search sidecar and sub-agent policy | P09, P10, P11 | to implement |
+| P15 | `feat: add provider and account dashboard API` | Authenticated control API parity for live management and diagnostics | P02-P11 | to implement |
+| P16 | `feat: add client exports for supported integrations` | Versioned OpenCode/Pi/DSH/etc. exports without plaintext secrets | P04, P06, P15 | to implement |
+| P17 | `perf: bound router cache and memory retention` | Explicit bounded buffers, retention policy and diagnostics | P02, P15 | to implement |
+| P18 | `test: add end-to-end parity and migration suite` | Full regression matrix, restart, rollback, tray and native GPT checks | P01-P17 | to implement |
+| P19 | `fix: raise managed subagent concurrency` | Keep router-managed Codex configuration aligned with the 100-thread user setting | P00 | implemented |
+
+The initial implementation order is P01, P02, P04, P05, P06, P03, P08, P09,
+P10, P11, P12, then the UI/API/export/hardening items. P01 is independent and
+can be submitted first. P02/P04/P05/P06 form the generic-provider foundation;
+do not implement dozens of provider-specific branches before that foundation is
+tested.
+
+The submitted feature PRs are intentionally small foundations. P08-P11 expose
+pure policy modules where the consumer/UI wiring is still a later task. PRs
+#402, #404, #405 and #406 are stacked prerequisite branches; review and merge
+them in dependency order. Every submitted PR now includes a `Reason` section
+in its description.
+
+## P00 — roadmap document
+
+Status: `implemented`
+
+This document and the parent specification are the planning artifacts. No
+runtime code is part of P00. The parent document must link here before the first
+feature PR is opened.
+
+## P19 — managed subagent concurrency
+
+Status: `implemented`
+
+The local Codex configuration now uses the structured `multi_agent_v2` setting
+with a 100-thread limit. The router's managed default and installer documentation
+use the same value, while an existing user-owned limit remains authoritative.
+
+Title: `fix: raise managed subagent concurrency`
+
+Description template:
+
+> Raises the Codex Router managed sub-agent limit to 100 threads and keeps the
+> structured Codex v2 setting valid. User-owned limits are still preserved.
+
+Validation: config-manager tests, real Codex config parse/login status and a
+full Codex restart before using the extra slots.
+
+## P01 — provider icon sizing
+
+Title: `fix: keep provider icons within tray icon bounds`
+
+Description template:
+
+> Provider marks could render larger than the tray slot. This clamps provider
+> images to the same fixed bounds used by preset icons in the menu bar and
+> Dynamic Island, while keeping the existing provider assets and style.
+
+Implementation:
+
+- Make the shared `ProviderIcon` layout have an explicit fixed slot and clip the
+  rendered image to that slot.
+- Keep aspect ratio and transparent padding; do not crop provider logos.
+- Keep all current call-site sizes (14, 18, 22, 24, 26) unless a test proves a
+  caller is wrong.
+- Ensure menu bar `.provider`, compact Island, expanded Island and quota rows
+  all use the same component behavior.
+- Do not change the Dynamic Island shape, animation or typography.
+
+Validation:
+
+- Add a Swift test for the sizing/layout contract if the current test target can
+  express it; otherwise add a pure helper test for the normalized slot size.
+- Build `apps/macos/ModelRouterTray` in release mode.
+- Run existing `MenuBarSettingsTests` and `IslandModeTests`.
+- Inspect the installed tray on macOS with provider icon, preset icon and idle
+  indicator styles.
+- Verify the screenshot case: the provider mark is icon-sized, not a large
+  logo clipped by the menu bar or island.
+
+## P02 — secure credential primitives
+
+Title: `feat: add secure provider credential primitives`
+
+Description template:
+
+> Adds provider-neutral account and API-key references with encrypted storage and
+> redacted status output. Existing credentials remain compatible and no secret is
+> copied into configuration or logs.
+
+Implementation:
+
+- Add opaque credential IDs and `account` / `api_key` kinds.
+- Reuse the existing secure store and file-protection helpers.
+- Add schema version, idempotent migration and rollback snapshot.
+- Provide lifecycle types and sanitized status output before adding routing.
+- Add redaction tests for headers, URLs, errors, support bundles and exports.
+
+Validation: unit tests, migration twice, rollback, permission check and
+`bin/model-router codex doctor` with the current user's existing credentials.
+
+## P03 — provider-scoped API-key pools
+
+Title: `feat: add provider-scoped API key pools`
+
+Description template:
+
+> Adds optional API-key pools with health-aware selection and safe rotation.
+> Single-key providers keep their current behavior and existing credentials are
+> not changed.
+
+Implementation:
+
+- Add `quota`, `round-robin` and `fill-first` strategies.
+- Track health, cooldown, priority and paused state per key.
+- Keep session affinity and rebind only on pre-commit failure.
+- Make quota refresh cached and non-blocking for ordinary requests.
+- Expose sanitized list/add/pause/resume/test operations.
+
+Validation: two-key fixture, 401/403/429/5xx cooldowns, stream commit boundary,
+concurrent session selection and no secret leakage.
+
+## P04 — generic OpenAI-compatible provider
+
+Title: `feat: add generic OpenAI-compatible providers`
+
+Description template:
+
+> Adds a reusable provider definition with base URL, adapter, headers and secure
+> credentials. Users can connect compatible endpoints without adding provider-
+> specific code, while private-network access stays explicit and protected.
+
+Implementation:
+
+- Promote the current per-model `custom` behavior to a provider object without
+  breaking old custom model files.
+- Add provider CRUD and test operations through the existing control/CLI plane.
+- Add explicit `allowPrivate` validation and loopback-only default.
+- Keep provider/model IDs separate from display labels.
+- Do not let a generic provider overwrite native GPT catalog metadata.
+
+Validation: local OpenAI fixture, remote URL validation, DNS/private-network
+guard, CRUD idempotence, existing `custom` regression and restart persistence.
+
+## P05 — Responses and Chat adapters
+
+Title: `feat: add OpenAI Responses and Chat adapters`
+
+Description template:
+
+> Adds capability-aware OpenAI Responses and Chat Completions translation with
+> streaming, tool calls, reasoning fields and cancellation coverage.
+
+Implementation: separate protocol adapters, stream backpressure, request IDs,
+tool-call normalization, reasoning mapping, error normalization and omission of
+unsupported fields. Never retry after response bytes are committed.
+
+Validation: local fixtures for text, streaming, tools, reasoning, cancellation,
+unsupported vision/search and upstream error/request-ID propagation.
+
+## P06 — live models and capabilities
+
+Title: `feat: add live model discovery and capability overrides`
+
+Description template:
+
+> Adds cached provider-scoped model discovery and safe metadata overrides. Live
+> refresh preserves user-defined models and native GPT metadata.
+
+Implementation: `/v1/models`, merge precedence (user > verified preset > live >
+conservative default), display labels, context windows, modalities, tools,
+reasoning, vision, search, cost metadata and request profiles.
+
+Validation: discovery cache, refresh failure, user model preservation, invalid
+metadata rejection and catalog publication regression tests.
+
+## P07 — extended OpenAI endpoints
+
+Title: `feat: add capability-gated OpenAI API endpoints`
+
+Description template:
+
+> Adds optional OpenAI-compatible endpoint forwarding with explicit capability
+> gates. Chat model routing remains separate from embeddings, media and job APIs.
+
+Implementation priority: legacy Completions first; then embeddings, image/audio,
+moderation, files and batches. Verify the current OpenAI contract before any
+legacy Assistants/Threads/Vector Stores implementation. Add `supportedEndpoints`,
+multipart limits, idempotency and polling state.
+
+Validation: route allowlist, file size/type limits, streaming cancellation,
+non-idempotent retry protection and endpoint capability tests.
+
+## P08 — ChatGPT account pool
+
+Title: `feat: add ChatGPT account pool routing`
+
+Description template:
+
+> Adds an optional ChatGPT/Codex account pool with quota-aware selection, session
+> affinity and safe re-authentication. The native single-account path remains
+> unchanged unless pooling is explicitly enabled.
+
+Implementation: encrypted OAuth account rows, quota windows, priority, paused
+accounts, `quota`/`round-robin`/`fill-first`, sticky limit, atomic rebind and
+provider-policy warning. Do not use this feature to evade provider restrictions.
+
+Validation: simulated quota windows, expiry, 401/403/429, session affinity,
+concurrent turns, restart persistence and native GPT selector regression.
+
+## P09 — virtual combos
+
+Title: `feat: add provider combos and weighted failover`
+
+Description template:
+
+> Adds named virtual models that fail over or distribute requests across
+> provider/model targets. Capability checks run before a target is selected.
+
+Implementation: persisted combo definitions, failover/weighted round-robin,
+sticky limit, weights, sanitized diagnostics and model selector labels.
+
+Validation: weights, all targets unhealthy, capability mismatch, sticky session,
+stream commit boundary and native model list regression.
+
+## P10 — web-search sidecar
+
+Title: `feat: add capability-driven search sidecar`
+
+Description template:
+
+> Adds an explicit web-search sidecar for models that cannot consume native
+> search tools. It is bounded, observable and disabled unless configured.
+
+Implementation: sidecar credential, result schema, citations, cache, timeout,
+cancellation, retry, latency telemetry and no duplicate call for native-search
+models. Never infer sidecar support from a model name.
+
+Validation: success, timeout, cancellation, cache hit, malformed result and
+native-search bypass.
+
+## P11 — sub-agent parity
+
+Title: `feat: extend verified sub-agent routing`
+
+Description template:
+
+> Adds opt-in unverified sub-agent models and safe per-agent fallback chains.
+> Existing verified-model defaults and tool safety remain unchanged.
+
+Implementation: `allowUnverifiedModels=false` by default, capability validation,
+per-agent chains, budgets, concurrency limits and actual-target diagnostics.
+
+Validation: verified default, explicit opt-in, tool/vision/search mismatch,
+fallback before stream commit and concurrency budget tests.
+
+## P12 — missing provider presets
+
+Title: `feat: add data-driven missing provider presets`
+
+Description template:
+
+> Adds high-value missing provider manifests on top of the generic adapter layer.
+> Presets define endpoints and capabilities without adding provider branches to
+> the core router.
+
+Implementation order: direct OpenAI API key, Azure OpenAI, Google Vertex,
+Gemini-native, local vLLM, then regional and infrastructure providers. Keep
+experimental/unknown presets disabled until their official contracts are tested.
+
+Validation: one fixture per adapter family, auth transport, discovery, model
+capabilities, health and quota behavior.
+
+## P13 — tray provider/account controls
+
+Title: `feat: expose provider and pool controls in tray`
+
+Description template:
+
+> Adds provider and pool controls to the existing tray settings using the current
+> visual language. Native GPT settings and Dynamic Island layout are unchanged.
+
+Implementation: reuse existing settings rows, sheets, picker styles, spacing,
+localization and status cards. Add sanitized provider/account/key health and
+strategy controls. Never show secrets.
+
+Validation: Swift tests, release build, tray interaction, Dynamic Island modes,
+keyboard/accessibility labels and native GPT settings regression.
+
+## P14 — tray combos, sidecar and sub-agent controls
+
+Title: `feat: expose routing policies in tray`
+
+Description template:
+
+> Adds combo, search-sidecar and sub-agent policy controls to the existing tray
+> without changing its visual style or Dynamic Island silhouette.
+
+Implementation: follow existing cards/pickers and show capability/health state;
+keep advanced settings opt-in and preserve all current defaults.
+
+Validation: Swift UI tests where available, control API round trips, tray build,
+Dynamic Island compact/peek/expanded states and restart persistence.
+
+## P15 — dashboard control API
+
+Title: `feat: add authenticated provider management API`
+
+Description template:
+
+> Adds authenticated control endpoints for providers, models, credentials,
+> pools, combos, sidecars and diagnostics. Responses are sanitized and local by
+> default.
+
+Implementation: reuse current control namespace/authentication; loopback default,
+remote opt-in, audit events, no plaintext secrets and consistent CLI/tray state.
+
+Validation: authorization, loopback/remote policy, redaction, concurrent writes,
+idempotence and tray/CLI parity.
+
+## P16 — client exports
+
+Title: `feat: add versioned client configuration exports`
+
+Description template:
+
+> Adds safe exports for supported clients using local gateway URLs and secret
+> references. Generated files never contain raw provider credentials.
+
+Implementation: start with OpenCode and DeepSeek Harness where contracts are
+stable; add other clients only when maintained and tested. Preserve unrelated
+settings/comments in target files.
+
+Validation: export/import, secret reference checks, target config preservation and
+live client smoke tests that do not spend a paid request unless explicitly
+approved.
+
+## P17 — bounded memory and cache
+
+Title: `perf: bound router cache and memory retention`
+
+Description template:
+
+> Adds explicit limits and diagnostics for router buffers and caches. Request
+> routing behavior is unchanged and secrets are never cached in plaintext.
+
+Implementation: bounded queues, response/tool-result retention, eviction metrics,
+cache TTL/size settings and support diagnostics.
+
+Validation: stress fixture, eviction, restart, memory ceiling and no transcript or
+credential over-retention.
+
+## P18 — final parity suite
+
+Title: `test: add OpenCodex parity and migration suite`
+
+Description template:
+
+> Adds the end-to-end regression matrix for provider pools, generic endpoints,
+> combos, sidecars, sub-agents, tray behavior and native GPT preservation.
+
+Validation: `npm run check`, `npm test`, Swift package tests/build, local provider
+fixture, restart/rollback, one verified streamed tool call, one image-capability
+case, one search case and tray/Dynamic Island inspection.
+
+## PR submission checklist
+
+Before opening any PR:
+
+- verify the change is not already in upstream `main` or an open PR;
+- confirm only the intended files changed;
+- run focused tests, then the relevant global checks;
+- test the live app/tray surface for UI-affecting work;
+- update this roadmap status to `tested` only after evidence exists;
+- open the PR with a short title and description in Simplified Technical
+  English;
+- record the PR URL/number and move the state to `complete and submitted` only
+  after the PR is actually submitted.
+
+PR body template:
+
+```text
+## What changed
+
+<One or two short sentences in simple English.>
+
+## Why
+
+<The user-visible or reliability reason.>
+
+## Validation
+
+- <focused test>
+- <regression/build check>
+```
+
+## Final acceptance gate
+
+The entire roadmap is complete only when every runtime PR is `complete and
+submitted`, P18 passes, the current app and tray continue to work after a full
+restart, Dynamic Island modes remain visually consistent, provider icons stay at
+preset-icon size, and native GPT model/default/speed controls remain unchanged.


### PR DESCRIPTION
## Summary

Adds a verified OpenCodex feature-gap specification and implementation roadmap. The documents separate current Codex Router behavior from proposed work, with source and test evidence for shipped items.

## Reason

Makes parity work reviewable without documenting unsupported targets or unwired features as shipped. It preserves the current six-agent concurrency setting, the exact Codex/DeepSeek Harness/Gemini target boundary, native GPT ownership, and the current protected-file credential model.

## Validation

- `npm run check`
- `git diff --check`
- Reviewed the docs against `origin/main` and the current source and test contracts.

## Remaining risks

- Proposed OpenCodex capabilities still require re-checking the upstream project and provider contracts before implementation.
- No runtime feature is introduced by this documentation-only PR; future work requires focused code/tests and merge to current `main`.
