### PR TITLE
feat: add data-driven provider presets

### DIFF
--- a/docs/PROVIDER-PRESET-CONTRACT.md
+++ b/docs/PROVIDER-PRESET-CONTRACT.md
@@ -35,4 +35,3 @@ An implementation that consumes this contract must be a separate change with:
 5. catalog tests proving that only capabilities observed by the runtime are published.
 
 This keeps the current router unchanged while preserving a reviewable boundary for a later, proven integration.
-

--- a/docs/PROVIDER-PRESET-CONTRACT.md
+++ b/docs/PROVIDER-PRESET-CONTRACT.md
@@ -1,0 +1,38 @@
+# Provider preset contract
+
+This document records a safe, inactive contract for future provider presets. It is not a provider registry and it is not consumed by the router runtime yet. A preset cannot add a model, select a provider, discover an endpoint, or send a request.
+
+The validation helper is `src/provider-preset-contract.mjs`. It is deliberately standalone so the contract can be reviewed without importing the generic-provider implementation from the earlier stacked proposal.
+
+## Accepted fields
+
+Each preset contains only:
+
+- `id`: lowercase provider identifier, unique against the checked-in registry;
+- `displayName`: user-facing name;
+- `protocol`: one of `openai-chat`, `openai-responses`, or `openai-completions`;
+- `baseUrl`: absolute `https://` URL, or an explicitly private loopback/RFC1918 URL with `allowPrivate: true`;
+- `allowPrivate`: explicit opt-in for private endpoints;
+- `discoveryPath`: a short absolute path such as `/v1/models`;
+- `auth`: exactly one of `none`, `credential-ref`, or `environment`.
+
+Public endpoints must reference a credential through an opaque `cred_...` identifier or a validated uppercase environment variable name. Secret values, authorization headers, query-string keys, and URL userinfo are rejected.
+
+## Deliberate non-features
+
+The contract does not accept capability claims (`supportsTools`, vision, search, reasoning, or context size), retry policy, enablement, static headers, model lists, or discovery results. None of those fields is enforced by the current router boundary. Accepting them now would make the catalog promise behavior that routing does not prove.
+
+The contract also performs lexical URL/path validation only. Any future runtime caller must resolve DNS, re-check the resolved address against its private/public policy, authenticate through the existing credential boundary, and bind the selected protocol before making a request. Until that caller exists, this module must remain metadata validation only.
+
+## Activation requirements
+
+An implementation that consumes this contract must be a separate change with:
+
+1. an explicit caller in the request path;
+2. credential resolution through the existing provider credential boundary;
+3. protocol-specific request and response tests;
+4. DNS-rebinding and path-escape tests;
+5. catalog tests proving that only capabilities observed by the runtime are published.
+
+This keeps the current router unchanged while preserving a reviewable boundary for a later, proven integration.
+

--- a/src/provider-preset-contract.mjs
+++ b/src/provider-preset-contract.mjs
@@ -1,0 +1,200 @@
+const ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62})$/;
+const ENVIRONMENT_PATTERN = /^[A-Z][A-Z0-9_]{1,127}$/;
+const CREDENTIAL_PATTERN = /^cred_[A-Za-z0-9][A-Za-z0-9._:-]{2,127}$/;
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+const DOT_OR_ESCAPED_PATH = /(?:^|\/)(?:\.{1,2})(?:\/|$)|%2e|%2f|%5c/i;
+
+export const PROVIDER_PRESET_SCHEMA_VERSION = 1;
+export const PROVIDER_PRESET_PROTOCOLS = Object.freeze([
+  "openai-chat",
+  "openai-responses",
+  "openai-completions",
+]);
+export const PROVIDER_PRESET_AUTH_MODES = Object.freeze([
+  "none",
+  "credential-ref",
+  "environment",
+]);
+
+const PRESET_FIELDS = new Set([
+  "id",
+  "displayName",
+  "protocol",
+  "baseUrl",
+  "allowPrivate",
+  "discoveryPath",
+  "auth",
+]);
+const AUTH_FIELDS = new Set(["mode", "credentialRef", "environment"]);
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function fail(message) {
+  throw new TypeError(`Invalid provider preset: ${message}`);
+}
+
+function assertPlainObject(value, field) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${field} must be an object.`);
+  }
+}
+
+function rejectUnknownFields(value, allowed, field) {
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) fail(`${field}.${key} is not allowed.`);
+  }
+}
+
+function isPrivateHostname(hostname) {
+  const host = String(hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
+  if (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host.endsWith(".local")
+  ) {
+    return true;
+  }
+  if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
+  if (/^(?:fc|fd)[0-9a-f]{2}:/.test(host) || host.startsWith("fe80:")) return true;
+  const parts = host.split(".");
+  if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part) || Number(part) > 255)) {
+    if (host.startsWith("::ffff:")) return isPrivateHostname(host.slice(7));
+    return false;
+  }
+  const [first, second] = parts.map(Number);
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 100 && second >= 64 && second <= 127 ||
+    first === 127 ||
+    first === 169 && second === 254 ||
+    first === 172 && second >= 16 && second <= 31 ||
+    first === 192 && second === 0 ||
+    first === 192 && second === 168 ||
+    first === 198 && second >= 18 && second <= 19 ||
+    first === 203 && second === 0 ||
+    first >= 240
+  );
+}
+
+function validateBaseUrl(value, allowPrivate) {
+  const raw = text(value);
+  if (!raw || CONTROL_CHARACTERS.test(raw) || raw.includes("\\")) {
+    fail("baseUrl must be a clean absolute HTTP(S) URL.");
+  }
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    fail("baseUrl must be an absolute HTTP(S) URL.");
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    fail("baseUrl must use http or https.");
+  }
+  if (
+    !parsed.hostname ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash ||
+    DOT_OR_ESCAPED_PATH.test(parsed.pathname)
+  ) {
+    fail("baseUrl must not contain credentials, query strings, fragments, or traversal paths.");
+  }
+  const privateEndpoint = isPrivateHostname(parsed.hostname);
+  if (privateEndpoint && !allowPrivate) {
+    fail("private endpoints require allowPrivate=true.");
+  }
+  if (parsed.protocol === "http:" && !privateEndpoint) {
+    fail("plain HTTP is allowed only for private endpoints.");
+  }
+  return parsed.href.replace(/\/+$/, "");
+}
+
+function validateDiscoveryPath(value) {
+  const path = text(value);
+  if (
+    !path ||
+    path.length > 160 ||
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    CONTROL_CHARACTERS.test(path) ||
+    path.includes("\\") ||
+    path.includes("?") ||
+    path.includes("#") ||
+    DOT_OR_ESCAPED_PATH.test(path)
+  ) {
+    fail("discoveryPath must be a short absolute path without traversal or URL components.");
+  }
+  return path;
+}
+
+function validateAuth(value, privateEndpoint) {
+  assertPlainObject(value, "auth");
+  rejectUnknownFields(value, AUTH_FIELDS, "auth");
+  const mode = text(value.mode);
+  if (!PROVIDER_PRESET_AUTH_MODES.includes(mode)) {
+    fail(`auth.mode must be one of: ${PROVIDER_PRESET_AUTH_MODES.join(", ")}.`);
+  }
+  if (mode === "none") {
+    if (!privateEndpoint || value.credentialRef !== undefined || value.environment !== undefined) {
+      fail("auth.mode none is only allowed for private endpoints and accepts no credential reference.");
+    }
+    return Object.freeze({ mode });
+  }
+  if (mode === "credential-ref") {
+    if (!CREDENTIAL_PATTERN.test(text(value.credentialRef)) || value.environment !== undefined) {
+      fail("auth.credentialRef must be an opaque credential reference.");
+    }
+    return Object.freeze({ mode, credentialRef: text(value.credentialRef) });
+  }
+  if (!ENVIRONMENT_PATTERN.test(text(value.environment)) || value.credentialRef !== undefined) {
+    fail("auth.environment must be an uppercase environment variable name.");
+  }
+  return Object.freeze({ mode, environment: text(value.environment) });
+}
+
+/**
+ * Validate the inactive provider-preset contract.
+ *
+ * This function has no runtime caller yet. It intentionally returns only
+ * endpoint and authentication metadata; capabilities, retries, enablement,
+ * headers, and model discovery are not accepted until a runtime boundary
+ * proves and enforces them.
+ */
+export function validateProviderPresetContract(input, { knownProviderIds = [] } = {}) {
+  assertPlainObject(input, "preset");
+  rejectUnknownFields(input, PRESET_FIELDS, "preset");
+  const id = text(input.id);
+  if (!ID_PATTERN.test(id)) fail("id must match [a-z0-9][a-z0-9-]*.");
+  if (new Set(knownProviderIds).has(id)) fail(`id ${id} is already used by the registry.`);
+  const displayName = text(input.displayName);
+  if (!displayName || displayName.length > 120) {
+    fail("displayName must be a non-empty string of at most 120 characters.");
+  }
+  const protocol = text(input.protocol);
+  if (!PROVIDER_PRESET_PROTOCOLS.includes(protocol)) {
+    fail(`protocol must be one of: ${PROVIDER_PRESET_PROTOCOLS.join(", ")}.`);
+  }
+  const allowPrivate = input.allowPrivate === true;
+  if (input.allowPrivate !== undefined && typeof input.allowPrivate !== "boolean") {
+    fail("allowPrivate must be a boolean.");
+  }
+  const baseUrl = validateBaseUrl(input.baseUrl, allowPrivate);
+  const privateEndpoint = isPrivateHostname(new URL(baseUrl).hostname);
+  const discoveryPath = validateDiscoveryPath(input.discoveryPath);
+  const auth = validateAuth(input.auth, privateEndpoint);
+  return Object.freeze({
+    schemaVersion: PROVIDER_PRESET_SCHEMA_VERSION,
+    id,
+    displayName,
+    protocol,
+    baseUrl,
+    allowPrivate,
+    discoveryPath,
+    auth,
+  });
+}
+

--- a/src/provider-preset-contract.mjs
+++ b/src/provider-preset-contract.mjs
@@ -57,6 +57,14 @@ function isPrivateHostname(hostname) {
     return true;
   }
   if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
+  if (host.startsWith("::ffff:")) {
+    const mapped = host.slice("::ffff:".length).split(":");
+    if (mapped.length === 2 && mapped.every((part) => /^[0-9a-f]{1,4}$/.test(part))) {
+      const value = Number.parseInt(mapped[0], 16) * 0x10000 + Number.parseInt(mapped[1], 16);
+      const ipv4 = [24, 16, 8, 0].map((shift) => (value >>> shift) & 0xff).join(".");
+      return isPrivateHostname(ipv4);
+    }
+  }
   if (/^(?:fc|fd)[0-9a-f]{2}:/.test(host) || host.startsWith("fe80:")) return true;
   const parts = host.split(".");
   if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part) || Number(part) > 255)) {
@@ -99,6 +107,7 @@ function validateBaseUrl(value, allowPrivate) {
     parsed.password ||
     parsed.search ||
     parsed.hash ||
+    parsed.pathname.includes("%") ||
     DOT_OR_ESCAPED_PATH.test(parsed.pathname)
   ) {
     fail("baseUrl must not contain credentials, query strings, fragments, or traversal paths.");
@@ -124,6 +133,7 @@ function validateDiscoveryPath(value) {
     path.includes("\\") ||
     path.includes("?") ||
     path.includes("#") ||
+    path.includes("%") ||
     DOT_OR_ESCAPED_PATH.test(path)
   ) {
     fail("discoveryPath must be a short absolute path without traversal or URL components.");
@@ -197,4 +207,3 @@ export function validateProviderPresetContract(input, { knownProviderIds = [] } 
     auth,
   });
 }
-

--- a/test/provider-preset-contract.test.mjs
+++ b/test/provider-preset-contract.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PROVIDER_PRESET_SCHEMA_VERSION,
+  validateProviderPresetContract,
+} from "../src/provider-preset-contract.mjs";
+
+const publicPreset = {
+  id: "example-api",
+  displayName: "Example API",
+  protocol: "openai-chat",
+  baseUrl: "https://api.example.test/v1",
+  discoveryPath: "/v1/models",
+  auth: { mode: "credential-ref", credentialRef: "cred_example-key" },
+};
+
+test("validates a credential-referenced public endpoint without claiming runtime support", () => {
+  const preset = validateProviderPresetContract(publicPreset, {
+    knownProviderIds: ["openrouter"],
+  });
+  assert.equal(preset.schemaVersion, PROVIDER_PRESET_SCHEMA_VERSION);
+  assert.equal(preset.baseUrl, "https://api.example.test/v1");
+  assert.deepEqual(preset.auth, {
+    mode: "credential-ref",
+    credentialRef: "cred_example-key",
+  });
+  assert.equal(Object.isFrozen(preset), true);
+  assert.equal(Object.isFrozen(preset.auth), true);
+});
+
+test("allows an explicitly private, keyless endpoint only with a safe path", () => {
+  const preset = validateProviderPresetContract({
+    id: "local-vllm",
+    displayName: "Local vLLM",
+    protocol: "openai-chat",
+    baseUrl: "http://127.0.0.1:8000/v1",
+    allowPrivate: true,
+    discoveryPath: "/v1/models",
+    auth: { mode: "none" },
+  });
+  assert.equal(preset.allowPrivate, true);
+  assert.deepEqual(preset.auth, { mode: "none" });
+});
+
+test("fails closed for unsafe endpoints and path patterns", () => {
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, baseUrl: "http://api.example.test/v1" }),
+    /plain HTTP/,
+  );
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, baseUrl: "http://127.0.0.1:8000/v1" }),
+    /allowPrivate=true/,
+  );
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, allowPrivate: true, baseUrl: "https://api.example.test/v1?key=secret" }),
+    /credentials, query strings, fragments/,
+  );
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, discoveryPath: "/v1/../admin" }),
+    /traversal/,
+  );
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, discoveryPath: "//evil.example/models" }),
+    /absolute path/,
+  );
+});
+
+test("rejects raw credentials, malformed references, and unauthenticated public endpoints", () => {
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, auth: { mode: "credential-ref", credentialRef: "sk-secret" } }),
+    /opaque credential reference/,
+  );
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, auth: { mode: "environment", environment: "api_key" } }),
+    /uppercase environment variable/,
+  );
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, auth: { mode: "none" } }),
+    /only allowed for private endpoints/,
+  );
+});
+
+test("rejects capability and runtime fields until a proven caller exists", () => {
+  for (const field of ["capabilities", "retry", "enabled", "headers", "models"]) {
+    assert.throws(
+      () => validateProviderPresetContract({ ...publicPreset, [field]: {} }),
+      new RegExp(`preset\\.${field} is not allowed`),
+    );
+  }
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, id: "openrouter" }, { knownProviderIds: ["openrouter"] }),
+    /already used by the registry/,
+  );
+});
+

--- a/test/provider-preset-contract.test.mjs
+++ b/test/provider-preset-contract.test.mjs
@@ -53,6 +53,10 @@ test("fails closed for unsafe endpoints and path patterns", () => {
     /allowPrivate=true/,
   );
   assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, baseUrl: "https://[::ffff:127.0.0.1]:8000/v1" }),
+    /allowPrivate=true/,
+  );
+  assert.throws(
     () => validateProviderPresetContract({ ...publicPreset, allowPrivate: true, baseUrl: "https://api.example.test/v1?key=secret" }),
     /credentials, query strings, fragments/,
   );
@@ -63,6 +67,10 @@ test("fails closed for unsafe endpoints and path patterns", () => {
   assert.throws(
     () => validateProviderPresetContract({ ...publicPreset, discoveryPath: "//evil.example/models" }),
     /absolute path/,
+  );
+  assert.throws(
+    () => validateProviderPresetContract({ ...publicPreset, discoveryPath: "/v1/%252e%252e/admin" }),
+    /traversal/,
   );
 });
 
@@ -93,4 +101,3 @@ test("rejects capability and runtime fields until a proven caller exists", () =>
     /already used by the registry/,
   );
 });
-


### PR DESCRIPTION
## Summary
Rebuilds this PR from the current `main` (`65bd8a5`) as an inactive, fail-closed provider preset contract.

The contract validates provider identity, protocol, endpoint URLs, discovery paths, and credential references without writing state or entering the runtime request path. It accepts no capability claims, retry policy, enablement, static headers, or model lists.

## Reason
The previous stacked implementation described presets that were not consumed by routing and inherited an unsafe generic-provider boundary. This slice keeps no false runtime promise while defining the reviewed boundary needed before a future integration.

## Validation
- `node --test test/provider-preset-contract.test.mjs` (5 passed)
- `npm run check`
- `git diff --check`

## Remaining risks
- There is intentionally no runtime caller yet: presets do not add providers, models, discovery, authentication, or routing.
- URL validation is lexical only. A future caller must resolve and re-check DNS, use the existing credential boundary, bind the selected protocol, and prove capabilities before sending requests or publishing catalog metadata.
