### PR TITLE
feat: add safe client configuration exports

### DIFF
--- a/src/client-exports.mjs
+++ b/src/client-exports.mjs
@@ -1,34 +1,10 @@
+import { CALLER_PATH_PREFIX } from "./caller-auth.mjs";
 import { PORTS } from "./paths.mjs";
 
-// Client exports are deliberately descriptors, not rendered target files.  A
-// descriptor is safe to hand to a client-specific adapter later: it names the
-// loopback capability and model metadata without copying provider credentials.
 export const CLIENT_EXPORT_SCHEMA_VERSION = 1;
 
-export const CLIENT_EXPORT_CLIENTS = Object.freeze([
-  "openai-compatible",
-  "opencode",
-  "deepseek-harness",
-]);
-
-const CAPABILITY_NAMES = Object.freeze([
-  "responses",
-  "chat",
-  "completions",
-  "tools",
-  "parallelTools",
-  "vision",
-  "webSearch",
-  "streaming",
-]);
-
-const ID_PATTERN = /^[a-z0-9][a-z0-9._:/-]{0,199}$/i;
 const ENV_PATTERN = /^[A-Z][A-Z0-9_]{0,127}$/;
-// Export metadata is copied into client-facing files.  Keep the descriptor
-// deliberately text-only, but reject fields that are normally used to carry a
-// secret instead of silently serializing them.
-const SENSITIVE_METADATA_KEY =
-  /(?:api[-_]?key|authorization|bearer|caller[-_]?key|cookie|credential|password|private[-_]?key|secret|token)/i;
+const SUPPORTED_OPTIONS = new Set(["baseUrl", "secretEnv"]);
 
 function text(value) {
   return typeof value === "string" ? value.trim() : "";
@@ -36,14 +12,6 @@ function text(value) {
 
 function invalid(message) {
   throw new Error(`Invalid client export: ${message}`);
-}
-
-function normalizeClient(value) {
-  const client = text(value).toLowerCase();
-  if (!CLIENT_EXPORT_CLIENTS.includes(client)) {
-    invalid(`client must be one of: ${CLIENT_EXPORT_CLIENTS.join(", ")}.`);
-  }
-  return client;
 }
 
 function normalizeSecretEnv(value) {
@@ -54,122 +22,81 @@ function normalizeSecretEnv(value) {
   return name;
 }
 
-function validateBaseUrl(value) {
-  const baseUrl = text(value);
-  if (!baseUrl) invalid("baseUrl is required.");
-  // URL escapes braces in an env placeholder.  Validate a temporary URL while
-  // retaining the original template for clients that perform interpolation.
-  const candidate = baseUrl.replace(/\$\{[A-Z][A-Z0-9_]{0,127}\}/g, "router-secret");
-  let parsed;
-  try {
-    parsed = new URL(candidate);
-  } catch {
-    invalid("baseUrl must be an absolute HTTP(S) URL.");
+function rejectUnsupportedOptions(options) {
+  for (const key of Object.keys(options)) {
+    if (SUPPORTED_OPTIONS.has(key)) continue;
+    if (key === "client") {
+      invalid("client-specific adapters are not wired.");
+    }
+    invalid(`${key} is not supported by the router endpoint export.`);
   }
-  if (!["http:", "https:"].includes(parsed.protocol) || parsed.username || parsed.password) {
-    invalid("baseUrl must use HTTP(S) and must not contain credentials.");
-  }
-  if (parsed.search || parsed.hash) invalid("baseUrl must not contain a query or fragment.");
-  // A generated export may contain an environment placeholder, but a literal
-  // caller capability would be a secret leak.  Require callers to use
-  // secretEnv instead of pasting the token into an export.
-  const callerSegment = baseUrl.match(/\/_codex-router\/([^/]+)\//i)?.[1];
-  if (callerSegment && !/^\$\{[A-Z][A-Z0-9_]{0,127}\}$/.test(callerSegment)) {
-    invalid("baseUrl must reference the caller key through an environment placeholder.");
-  }
-  return baseUrl.replace(/\/+$/, "");
 }
 
 function defaultBaseUrl(secretEnv) {
-  return `http://127.0.0.1:${PORTS.router}/_codex-router/\${${secretEnv}}/v1`;
+  return `http://127.0.0.1:${PORTS.router}${CALLER_PATH_PREFIX}/\${${secretEnv}}/v1`;
 }
 
-function normalizeCapabilities(value) {
-  if (value === undefined) return {};
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    invalid("capabilities must be an object of booleans.");
+function validateBaseUrl(value, secretEnv) {
+  const baseUrl = text(value).replace(/\/+$/, "");
+  const expected = defaultBaseUrl(secretEnv);
+  if (baseUrl !== expected) {
+    invalid("baseUrl must be the configured loopback router endpoint.");
   }
-  const capabilities = {};
-  for (const [name, enabled] of Object.entries(value)) {
-    if (!CAPABILITY_NAMES.includes(name)) invalid(`unknown capability ${name}.`);
-    if (typeof enabled !== "boolean") invalid(`capability ${name} must be boolean.`);
-    capabilities[name] = enabled;
-  }
-  return capabilities;
-}
 
-function normalizeModels(value) {
-  if (value === undefined) return [];
-  if (!Array.isArray(value)) invalid("models must be an array.");
-  return value.map((entry, index) => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-      invalid(`models[${index}] must be an object.`);
-    }
-    const id = text(entry.id || entry.slug);
-    if (!ID_PATTERN.test(id)) invalid(`models[${index}].id is invalid.`);
-    const alias = text(entry.alias || entry.name || id);
-    if (!alias || alias.length > 200) invalid(`models[${index}].alias is invalid.`);
-    const model = { id, alias };
-    const description = text(entry.description);
-    if (description) model.description = description.slice(0, 240);
-    if (entry.capabilities !== undefined) {
-      model.capabilities = normalizeCapabilities(entry.capabilities);
-    }
-    return model;
-  });
+  let parsed;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    invalid("baseUrl must be an absolute loopback HTTP URL.");
+  }
+  const expectedPort = PORTS.router === 80 ? "" : String(PORTS.router);
+  if (
+    parsed.protocol !== "http:" ||
+    parsed.hostname !== "127.0.0.1" ||
+    parsed.port !== expectedPort ||
+    parsed.username ||
+    parsed.password ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    invalid("baseUrl must target the configured loopback router endpoint.");
+  }
+  return baseUrl;
 }
 
 /**
- * Build a versioned, provider-agnostic client export descriptor.
- *
- * `secretEnv` is a reference only.  The generated endpoint contains an env
- * placeholder and never the caller capability or an upstream provider key.
+ * Build the one export shape the router can currently stand behind. The
+ * descriptor contains an environment reference, never the caller capability.
+ * Client-specific adapters stay out until they have a real writer and reader.
  */
-export function buildClientExport({
-  client = "openai-compatible",
-  baseUrl,
-  secretEnv,
-  models,
-  capabilities,
-  metadata,
-} = {}) {
-  const normalizedClient = normalizeClient(client);
-  const normalizedSecretEnv = normalizeSecretEnv(secretEnv);
-  const endpoint = baseUrl ? validateBaseUrl(baseUrl) : defaultBaseUrl(normalizedSecretEnv);
-  const result = {
+export function buildRouterEndpointExport(options = {}) {
+  if (!options || typeof options !== "object" || Array.isArray(options)) {
+    invalid("options must be an object.");
+  }
+  rejectUnsupportedOptions(options);
+  const secretEnv = normalizeSecretEnv(options.secretEnv);
+  const baseUrl = options.baseUrl
+    ? validateBaseUrl(options.baseUrl, secretEnv)
+    : defaultBaseUrl(secretEnv);
+  return {
     schemaVersion: CLIENT_EXPORT_SCHEMA_VERSION,
-    client: normalizedClient,
+    kind: "router-endpoint",
     gateway: {
-      baseUrl: endpoint,
+      baseUrl,
       protocol: "openai-compatible",
       auth: {
         type: "path-capability",
-        secretRef: { type: "environment", name: normalizedSecretEnv },
+        secretRef: { type: "environment", name: secretEnv },
       },
     },
-    models: normalizeModels(models),
-    capabilities: normalizeCapabilities(capabilities),
   };
-  if (metadata !== undefined) {
-    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
-      invalid("metadata must be an object.");
-    }
-    // Keep metadata intentionally shallow and text-only.  This makes it safe
-    // for adapters to copy labels without accidentally carrying credentials.
-    result.metadata = Object.fromEntries(
-      Object.entries(metadata)
-        .filter(([key, value]) => {
-          if (SENSITIVE_METADATA_KEY.test(key)) {
-            invalid(`metadata.${key} cannot contain a secret; use secretEnv instead.`);
-          }
-          return /^[a-z][a-zA-Z0-9_.-]{0,63}$/.test(key) && typeof value === "string";
-        })
-        .map(([key, value]) => [key, value.slice(0, 240)]),
-    );
-  }
-  return result;
 }
 
-export function renderClientExport(options = {}) {
-  return `${JSON.stringify(buildClientExport(options), null, 2)}\n`;
+export function renderRouterEndpointExport(options = {}) {
+  return `${JSON.stringify(buildRouterEndpointExport(options), null, 2)}\n`;
 }
+
+// Keep the original helper names for callers of the draft PR while exposing no
+// client list or client-specific contract.
+export const buildClientExport = buildRouterEndpointExport;
+export const renderClientExport = renderRouterEndpointExport;

--- a/src/client-exports.mjs
+++ b/src/client-exports.mjs
@@ -1,0 +1,175 @@
+import { PORTS } from "./paths.mjs";
+
+// Client exports are deliberately descriptors, not rendered target files.  A
+// descriptor is safe to hand to a client-specific adapter later: it names the
+// loopback capability and model metadata without copying provider credentials.
+export const CLIENT_EXPORT_SCHEMA_VERSION = 1;
+
+export const CLIENT_EXPORT_CLIENTS = Object.freeze([
+  "openai-compatible",
+  "opencode",
+  "deepseek-harness",
+]);
+
+const CAPABILITY_NAMES = Object.freeze([
+  "responses",
+  "chat",
+  "completions",
+  "tools",
+  "parallelTools",
+  "vision",
+  "webSearch",
+  "streaming",
+]);
+
+const ID_PATTERN = /^[a-z0-9][a-z0-9._:/-]{0,199}$/i;
+const ENV_PATTERN = /^[A-Z][A-Z0-9_]{0,127}$/;
+// Export metadata is copied into client-facing files.  Keep the descriptor
+// deliberately text-only, but reject fields that are normally used to carry a
+// secret instead of silently serializing them.
+const SENSITIVE_METADATA_KEY =
+  /(?:api[-_]?key|authorization|bearer|caller[-_]?key|cookie|credential|password|private[-_]?key|secret|token)/i;
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function invalid(message) {
+  throw new Error(`Invalid client export: ${message}`);
+}
+
+function normalizeClient(value) {
+  const client = text(value).toLowerCase();
+  if (!CLIENT_EXPORT_CLIENTS.includes(client)) {
+    invalid(`client must be one of: ${CLIENT_EXPORT_CLIENTS.join(", ")}.`);
+  }
+  return client;
+}
+
+function normalizeSecretEnv(value) {
+  const name = text(value) || "CODEX_ROUTER_CALLER_KEY";
+  if (!ENV_PATTERN.test(name)) {
+    invalid("secretEnv must be an environment variable name.");
+  }
+  return name;
+}
+
+function validateBaseUrl(value) {
+  const baseUrl = text(value);
+  if (!baseUrl) invalid("baseUrl is required.");
+  // URL escapes braces in an env placeholder.  Validate a temporary URL while
+  // retaining the original template for clients that perform interpolation.
+  const candidate = baseUrl.replace(/\$\{[A-Z][A-Z0-9_]{0,127}\}/g, "router-secret");
+  let parsed;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    invalid("baseUrl must be an absolute HTTP(S) URL.");
+  }
+  if (!["http:", "https:"].includes(parsed.protocol) || parsed.username || parsed.password) {
+    invalid("baseUrl must use HTTP(S) and must not contain credentials.");
+  }
+  if (parsed.search || parsed.hash) invalid("baseUrl must not contain a query or fragment.");
+  // A generated export may contain an environment placeholder, but a literal
+  // caller capability would be a secret leak.  Require callers to use
+  // secretEnv instead of pasting the token into an export.
+  const callerSegment = baseUrl.match(/\/_codex-router\/([^/]+)\//i)?.[1];
+  if (callerSegment && !/^\$\{[A-Z][A-Z0-9_]{0,127}\}$/.test(callerSegment)) {
+    invalid("baseUrl must reference the caller key through an environment placeholder.");
+  }
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function defaultBaseUrl(secretEnv) {
+  return `http://127.0.0.1:${PORTS.router}/_codex-router/\${${secretEnv}}/v1`;
+}
+
+function normalizeCapabilities(value) {
+  if (value === undefined) return {};
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    invalid("capabilities must be an object of booleans.");
+  }
+  const capabilities = {};
+  for (const [name, enabled] of Object.entries(value)) {
+    if (!CAPABILITY_NAMES.includes(name)) invalid(`unknown capability ${name}.`);
+    if (typeof enabled !== "boolean") invalid(`capability ${name} must be boolean.`);
+    capabilities[name] = enabled;
+  }
+  return capabilities;
+}
+
+function normalizeModels(value) {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) invalid("models must be an array.");
+  return value.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      invalid(`models[${index}] must be an object.`);
+    }
+    const id = text(entry.id || entry.slug);
+    if (!ID_PATTERN.test(id)) invalid(`models[${index}].id is invalid.`);
+    const alias = text(entry.alias || entry.name || id);
+    if (!alias || alias.length > 200) invalid(`models[${index}].alias is invalid.`);
+    const model = { id, alias };
+    const description = text(entry.description);
+    if (description) model.description = description.slice(0, 240);
+    if (entry.capabilities !== undefined) {
+      model.capabilities = normalizeCapabilities(entry.capabilities);
+    }
+    return model;
+  });
+}
+
+/**
+ * Build a versioned, provider-agnostic client export descriptor.
+ *
+ * `secretEnv` is a reference only.  The generated endpoint contains an env
+ * placeholder and never the caller capability or an upstream provider key.
+ */
+export function buildClientExport({
+  client = "openai-compatible",
+  baseUrl,
+  secretEnv,
+  models,
+  capabilities,
+  metadata,
+} = {}) {
+  const normalizedClient = normalizeClient(client);
+  const normalizedSecretEnv = normalizeSecretEnv(secretEnv);
+  const endpoint = baseUrl ? validateBaseUrl(baseUrl) : defaultBaseUrl(normalizedSecretEnv);
+  const result = {
+    schemaVersion: CLIENT_EXPORT_SCHEMA_VERSION,
+    client: normalizedClient,
+    gateway: {
+      baseUrl: endpoint,
+      protocol: "openai-compatible",
+      auth: {
+        type: "path-capability",
+        secretRef: { type: "environment", name: normalizedSecretEnv },
+      },
+    },
+    models: normalizeModels(models),
+    capabilities: normalizeCapabilities(capabilities),
+  };
+  if (metadata !== undefined) {
+    if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+      invalid("metadata must be an object.");
+    }
+    // Keep metadata intentionally shallow and text-only.  This makes it safe
+    // for adapters to copy labels without accidentally carrying credentials.
+    result.metadata = Object.fromEntries(
+      Object.entries(metadata)
+        .filter(([key, value]) => {
+          if (SENSITIVE_METADATA_KEY.test(key)) {
+            invalid(`metadata.${key} cannot contain a secret; use secretEnv instead.`);
+          }
+          return /^[a-z][a-zA-Z0-9_.-]{0,63}$/.test(key) && typeof value === "string";
+        })
+        .map(([key, value]) => [key, value.slice(0, 240)]),
+    );
+  }
+  return result;
+}
+
+export function renderClientExport(options = {}) {
+  return `${JSON.stringify(buildClientExport(options), null, 2)}\n`;
+}

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -2593,6 +2593,19 @@ async function handleHarness(action) {
   process.stdout.write(`${JSON.stringify(result)}\n`);
 }
 
+async function handleClientExport() {
+  const values = args.slice(1);
+  let secretEnv;
+  for (let index = 0; index < values.length; index += 1) {
+    if (values[index] !== "--secret-env" || !values[index + 1]) {
+      throw new Error("Usage: control client-export [--secret-env NAME]");
+    }
+    secretEnv = values[++index];
+  }
+  const { renderRouterEndpointExport } = await import("./client-exports.mjs");
+  process.stdout.write(renderRouterEndpointExport(secretEnv ? { secretEnv } : {}));
+}
+
 async function handlePresence(action, value) {
   const { PRESENCE_MODES, presenceSnapshot, setPresenceMode } = await import(
     "./presence-state.mjs"
@@ -2746,6 +2759,8 @@ if (args.includes("--probe")) {
   handleTray(args[1]);
 } else if (args[0] === "harness") {
   await handleHarness(args[1]);
+} else if (args[0] === "client-export") {
+  await handleClientExport();
 } else if (args[0] === "presence") {
   await handlePresence(args[1], args[2]);
 } else if (args[0] === "chatgpt-session") {

--- a/test/client-exports.test.mjs
+++ b/test/client-exports.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { buildClientExport, renderClientExport } = await import("../src/client-exports.mjs");
+
+test("builds a versioned OpenCode descriptor without a raw secret", () => {
+  const descriptor = buildClientExport({
+    client: "opencode",
+    models: [{ id: "deepseek/deepseek-v4-flash-latest", alias: "DeepSeek Flash", capabilities: { tools: true } }],
+    capabilities: { chat: true, tools: true, streaming: true },
+    metadata: { source: "codex-router" },
+  });
+
+  assert.equal(descriptor.schemaVersion, 1);
+  assert.equal(descriptor.client, "opencode");
+  assert.match(descriptor.gateway.baseUrl, /\$\{CODEX_ROUTER_CALLER_KEY\}/);
+  assert.equal(descriptor.gateway.auth.secretRef.name, "CODEX_ROUTER_CALLER_KEY");
+  assert.deepEqual(descriptor.models[0], {
+    id: "deepseek/deepseek-v4-flash-latest",
+    alias: "DeepSeek Flash",
+    capabilities: { tools: true },
+  });
+  assert.ok(!JSON.stringify(descriptor).includes("sk-"));
+});
+
+test("supports an explicit endpoint template and custom environment reference", () => {
+  const descriptor = buildClientExport({
+    client: "openai-compatible",
+    baseUrl: "https://router.example.test/v1",
+    secretEnv: "MY_ROUTER_KEY",
+  });
+  assert.equal(descriptor.gateway.baseUrl, "https://router.example.test/v1");
+  assert.equal(descriptor.gateway.auth.secretRef.name, "MY_ROUTER_KEY");
+  assert.match(renderClientExport({ client: "deepseek-harness", secretEnv: "DSH_ROUTER_KEY" }), /"client": "deepseek-harness"/);
+});
+
+test("rejects unsupported clients, invalid capabilities and literal caller secrets", () => {
+  assert.throws(() => buildClientExport({ client: "pi" }), /client must be one of/);
+  assert.throws(() => buildClientExport({ capabilities: { tools: "yes" } }), /must be boolean/);
+  assert.throws(
+    () => buildClientExport({ baseUrl: "http://127.0.0.1:4202/_codex-router/raw-secret/v1" }),
+    /environment placeholder/,
+  );
+  assert.throws(() => buildClientExport({ secretEnv: "router-key" }), /environment variable name/);
+});
+
+test("does not serialize secret-bearing metadata fields", () => {
+  for (const key of ["apiKey", "authorization", "callerKey", "credentialRef", "token"]) {
+    assert.throws(
+      () => buildClientExport({ metadata: { [key]: "not-safe-to-export" } }),
+      /cannot contain a secret/,
+    );
+  }
+});

--- a/test/client-exports.test.mjs
+++ b/test/client-exports.test.mjs
@@ -1,54 +1,96 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import test from "node:test";
 
-const { buildClientExport, renderClientExport } = await import("../src/client-exports.mjs");
+const {
+  buildClientExport,
+  buildRouterEndpointExport,
+  renderClientExport,
+} = await import("../src/client-exports.mjs");
+const { PORTS } = await import("../src/paths.mjs");
 
-test("builds a versioned OpenCode descriptor without a raw secret", () => {
-  const descriptor = buildClientExport({
-    client: "opencode",
-    models: [{ id: "deepseek/deepseek-v4-flash-latest", alias: "DeepSeek Flash", capabilities: { tools: true } }],
-    capabilities: { chat: true, tools: true, streaming: true },
-    metadata: { source: "codex-router" },
-  });
+const expectedBase = (name = "CODEX_ROUTER_CALLER_KEY") =>
+  `http://127.0.0.1:${PORTS.router}/_codex-router/\${${name}}/v1`;
+
+test("builds only the wired loopback router descriptor", () => {
+  const descriptor = buildRouterEndpointExport();
 
   assert.equal(descriptor.schemaVersion, 1);
-  assert.equal(descriptor.client, "opencode");
-  assert.match(descriptor.gateway.baseUrl, /\$\{CODEX_ROUTER_CALLER_KEY\}/);
-  assert.equal(descriptor.gateway.auth.secretRef.name, "CODEX_ROUTER_CALLER_KEY");
-  assert.deepEqual(descriptor.models[0], {
-    id: "deepseek/deepseek-v4-flash-latest",
-    alias: "DeepSeek Flash",
-    capabilities: { tools: true },
+  assert.equal(descriptor.kind, "router-endpoint");
+  assert.equal(descriptor.gateway.baseUrl, expectedBase());
+  assert.equal(descriptor.gateway.protocol, "openai-compatible");
+  assert.deepEqual(descriptor.gateway.auth, {
+    type: "path-capability",
+    secretRef: { type: "environment", name: "CODEX_ROUTER_CALLER_KEY" },
   });
-  assert.ok(!JSON.stringify(descriptor).includes("sk-"));
+  assert.equal(Object.hasOwn(descriptor, "client"), false);
+  assert.equal(Object.hasOwn(descriptor, "models"), false);
+  assert.equal(Object.hasOwn(descriptor, "capabilities"), false);
+  assert.equal(Object.hasOwn(descriptor, "metadata"), false);
 });
 
-test("supports an explicit endpoint template and custom environment reference", () => {
-  const descriptor = buildClientExport({
-    client: "openai-compatible",
-    baseUrl: "https://router.example.test/v1",
-    secretEnv: "MY_ROUTER_KEY",
-  });
-  assert.equal(descriptor.gateway.baseUrl, "https://router.example.test/v1");
+test("keeps the caller capability as an environment reference only", () => {
+  const descriptor = buildClientExport({ secretEnv: "MY_ROUTER_KEY" });
+  const rendered = renderClientExport({ secretEnv: "MY_ROUTER_KEY" });
+
+  assert.equal(descriptor.gateway.baseUrl, expectedBase("MY_ROUTER_KEY"));
   assert.equal(descriptor.gateway.auth.secretRef.name, "MY_ROUTER_KEY");
-  assert.match(renderClientExport({ client: "deepseek-harness", secretEnv: "DSH_ROUTER_KEY" }), /"client": "deepseek-harness"/);
+  assert.match(rendered, /MY_ROUTER_KEY/);
+  assert.doesNotMatch(rendered, /codex-router-local|sk-[A-Za-z0-9]|raw-secret/);
 });
 
-test("rejects unsupported clients, invalid capabilities and literal caller secrets", () => {
-  assert.throws(() => buildClientExport({ client: "pi" }), /client must be one of/);
-  assert.throws(() => buildClientExport({ capabilities: { tools: "yes" } }), /must be boolean/);
-  assert.throws(
-    () => buildClientExport({ baseUrl: "http://127.0.0.1:4202/_codex-router/raw-secret/v1" }),
-    /environment placeholder/,
-  );
-  assert.throws(() => buildClientExport({ secretEnv: "router-key" }), /environment variable name/);
-});
+test("accepts only the configured loopback origin and router path", () => {
+  const accepted = buildClientExport({
+    baseUrl: `${expectedBase("ROUTER_KEY")}/`,
+    secretEnv: "ROUTER_KEY",
+  });
+  assert.equal(accepted.gateway.baseUrl, expectedBase("ROUTER_KEY"));
 
-test("does not serialize secret-bearing metadata fields", () => {
-  for (const key of ["apiKey", "authorization", "callerKey", "credentialRef", "token"]) {
+  for (const baseUrl of [
+    `https://127.0.0.1:${PORTS.router}/_codex-router/\${ROUTER_KEY}/v1`,
+    `http://localhost:${PORTS.router}/_codex-router/\${ROUTER_KEY}/v1`,
+    `http://127.0.0.2:${PORTS.router}/_codex-router/\${ROUTER_KEY}/v1`,
+    `http://127.0.0.1:${PORTS.router + 1}/_codex-router/\${ROUTER_KEY}/v1`,
+    `http://127.0.0.1:${PORTS.router}/_codex-router/\${ROUTER_KEY}/panel`,
+    `http://127.0.0.1:${PORTS.router}/_codex-router/\${ROUTER_KEY}/v1?redirect=https://evil.test`,
+    `http://user:password@127.0.0.1:${PORTS.router}/_codex-router/\${ROUTER_KEY}/v1`,
+  ]) {
     assert.throws(
-      () => buildClientExport({ metadata: { [key]: "not-safe-to-export" } }),
-      /cannot contain a secret/,
+      () => buildClientExport({ baseUrl, secretEnv: "ROUTER_KEY" }),
+      /configured loopback router endpoint/,
+      baseUrl,
     );
   }
+});
+
+test("rejects client adapters and secret-bearing values until wired", () => {
+  assert.throws(
+    () => buildClientExport({ client: "opencode" }),
+    /client-specific adapters are not wired/,
+  );
+  for (const options of [
+    { models: [{ id: "model" }] },
+    { capabilities: { tools: true } },
+    { metadata: { token: "do-not-export" } },
+    { callerCapability: "do-not-export" },
+    { token: "do-not-export" },
+  ]) {
+    assert.throws(() => buildClientExport(options), /not supported/);
+  }
+  assert.throws(() => buildClientExport({ secretEnv: "router-key" }), /environment variable/);
+});
+
+test("control exposes the same safe descriptor without embedding a token", () => {
+  const result = spawnSync(
+    process.execPath,
+    [path.resolve("src/control.mjs"), "client-export", "--secret-env", "TEST_ROUTER_KEY"],
+    { cwd: path.resolve("."), encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const descriptor = JSON.parse(result.stdout);
+  assert.equal(descriptor.kind, "router-endpoint");
+  assert.equal(descriptor.gateway.auth.secretRef.name, "TEST_ROUTER_KEY");
+  assert.match(descriptor.gateway.baseUrl, /127\.0\.0\.1/);
+  assert.doesNotMatch(result.stdout, /raw-secret|sk-[A-Za-z0-9]/);
 });


### PR DESCRIPTION
## Summary

- Add a versioned router-endpoint descriptor for the one client export the router currently supports.
- Expose it through `bin/control client-export`.
- Keep caller capabilities as environment references and reject client-specific adapters until they have real, tested contracts.

## Reason

The previous export draft could interpolate a caller capability into arbitrary destinations and advertised integrations that were not wired. This revision makes the export useful without allowing credentials or local capabilities to leave the validated loopback router boundary.

## Validation

- `npm run check`
- `node --test test/client-exports.test.mjs test/caller-auth.test.mjs test/control-center-electron.test.mjs` (55 passed)
- `git diff --check`

## Remaining risks

- This PR intentionally exports a descriptor only. OpenCode, DeepSeek Harness, and other client-specific writers/importers remain separate work until their exact supported contracts are implemented and tested.
- Consumers must provide the referenced environment variable with the router's caller capability; the descriptor never embeds or verifies that value.

