### PR TITLE
Throttle the macOS tray thinking orb's repaint to 20 fps

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/ThinkingOrbCanvas.swift
+++ b/apps/macos/ModelRouterTray/Sources/ThinkingOrbCanvas.swift
@@ -443,6 +443,13 @@ final class ThinkingOrbNSView: NSView {
   private var running = false
   private let redrawLock = NSLock()
   private var redrawScheduled = false
+  private var lastRedrawTime: CFTimeInterval = 0
+  /// The orb animates on wall-clock time, so redraw rate only affects smoothness,
+  /// not speed. The display link fires at the panel's refresh rate (120 Hz on
+  /// ProMotion), and each fire repaints an 18 pt status-bar view and commits it
+  /// to WindowServer — measured at over 15% of a core while a model is thinking.
+  /// 20 fps is indistinguishable at this size and cuts that by ~6x.
+  private static let redrawInterval: CFTimeInterval = 1.0 / 20.0
   private var mode: ThinkingOrbMode = .shaping
   var reduceMotion = false {
     didSet {
@@ -535,11 +542,13 @@ final class ThinkingOrbNSView: NSView {
 
   private func scheduleRedraw() {
     redrawLock.lock()
-    guard !redrawScheduled else {
+    let now = CACurrentMediaTime()
+    guard !redrawScheduled, now - lastRedrawTime >= Self.redrawInterval else {
       redrawLock.unlock()
       return
     }
     redrawScheduled = true
+    lastRedrawTime = now
     redrawLock.unlock()
 
     DispatchQueue.main.async { [weak self] in


### PR DESCRIPTION
## Problem

The thinking orb's `CVDisplayLink` fires at the display's refresh rate — 120 Hz on ProMotion MacBooks — and every fire repaints the 18 pt status-bar view and commits it to WindowServer. Measured on an M-series MacBook Pro, ModelRouterTray sat above 15% of a core (sustained) for as long as a model was thinking, which is long enough to spin fans on laptops running agent workloads.

## Fix

The animation is driven by wall-clock time (`elapsed * rendererSpeed`), so repaint rate only affects smoothness, never animation speed. This coalesces redraws to at most one per 50 ms inside `scheduleRedraw`, under the lock that already guards `redrawScheduled`.

- 20 fps is visually indistinguishable from 120 fps at an 18 pt canvas.
- Active-state CPU drops by roughly 6x (repaints per second: 120 → 20).
- Idle cost is unchanged — the display link already stops when the orb is not running, and the existing reduce-motion and window-visibility guards are untouched.

`swift test` passes (20 tests, 4 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)