### PR TITLE
fix: size tray provider icons consistently

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -961,22 +961,18 @@ enum ProviderIconLayout {
     guard let representation = image.representations
       .compactMap({ $0 as? NSBitmapImageRep })
       .max(by: { ($0.pixelsWide * $0.pixelsHigh) < ($1.pixelsWide * $1.pixelsHigh) }),
-      let data = representation.bitmapData,
       representation.hasAlpha
     else {
       return NSRect(origin: .zero, size: image.size)
     }
 
-    let bytesPerPixel = max(1, representation.bitsPerPixel / 8)
-    let alphaIndex = representation.samplesPerPixel - 1
     var minX = representation.pixelsWide
     var minY = representation.pixelsHigh
     var maxX = -1
     var maxY = -1
     for y in 0..<representation.pixelsHigh {
       for x in 0..<representation.pixelsWide {
-        let offset = y * representation.bytesPerRow + x * bytesPerPixel
-        if data[offset + alphaIndex] > 8 {
+        if representation.colorAt(x: x, y: y)?.alphaComponent ?? 0 > 8.0 / 255.0 {
           minX = min(minX, x)
           minY = min(minY, y)
           maxX = max(maxX, x)

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -941,9 +941,12 @@ private struct IslandUsageLineChart: View {
 // ModelRouterTrayApp.swift render the same provider mark.
 enum ProviderIconLayout {
   static func fittedRect(sourceRect: NSRect, targetSize: NSSize) -> NSRect {
+    guard sourceRect.width > 0, sourceRect.height > 0, targetSize.width > 0, targetSize.height > 0 else {
+      return .zero
+    }
     let scale = min(
-      targetSize.width / max(sourceRect.width, 1),
-      targetSize.height / max(sourceRect.height, 1)
+      targetSize.width / sourceRect.width,
+      targetSize.height / sourceRect.height
     )
     let drawSize = NSSize(width: sourceRect.width * scale, height: sourceRect.height * scale)
     return NSRect(
@@ -951,6 +954,44 @@ enum ProviderIconLayout {
       y: (targetSize.height - drawSize.height) / 2,
       width: drawSize.width,
       height: drawSize.height
+    )
+  }
+
+  static func visibleImageRect(_ image: NSImage) -> NSRect {
+    guard let representation = image.representations
+      .compactMap({ $0 as? NSBitmapImageRep })
+      .max(by: { ($0.pixelsWide * $0.pixelsHigh) < ($1.pixelsWide * $1.pixelsHigh) }),
+      let data = representation.bitmapData,
+      representation.hasAlpha
+    else {
+      return NSRect(origin: .zero, size: image.size)
+    }
+
+    let bytesPerPixel = max(1, representation.bitsPerPixel / 8)
+    let alphaIndex = representation.samplesPerPixel - 1
+    var minX = representation.pixelsWide
+    var minY = representation.pixelsHigh
+    var maxX = -1
+    var maxY = -1
+    for y in 0..<representation.pixelsHigh {
+      for x in 0..<representation.pixelsWide {
+        let offset = y * representation.bytesPerRow + x * bytesPerPixel
+        if data[offset + alphaIndex] > 8 {
+          minX = min(minX, x)
+          minY = min(minY, y)
+          maxX = max(maxX, x)
+          maxY = max(maxY, y)
+        }
+      }
+    }
+    guard maxX >= minX, maxY >= minY else {
+      return NSRect(origin: .zero, size: image.size)
+    }
+    return NSRect(
+      x: image.size.width * CGFloat(minX) / CGFloat(representation.pixelsWide),
+      y: image.size.height * CGFloat(minY) / CGFloat(representation.pixelsHigh),
+      width: image.size.width * CGFloat(maxX - minX + 1) / CGFloat(representation.pixelsWide),
+      height: image.size.height * CGFloat(maxY - minY + 1) / CGFloat(representation.pixelsHigh)
     )
   }
 }
@@ -1007,7 +1048,7 @@ struct ProviderIcon: View {
 
   private func fittedProviderImage(_ image: NSImage) -> NSImage {
     let targetSize = NSSize(width: max(1, size), height: max(1, size))
-    let sourceRect = visibleImageRect(image)
+    let sourceRect = ProviderIconLayout.visibleImageRect(image)
     let drawRect = ProviderIconLayout.fittedRect(sourceRect: sourceRect, targetSize: targetSize)
     let fitted = NSImage(size: targetSize)
     fitted.lockFocus()
@@ -1022,44 +1063,6 @@ struct ProviderIcon: View {
     )
     fitted.unlockFocus()
     return fitted
-  }
-
-  private func visibleImageRect(_ image: NSImage) -> NSRect {
-    guard let representation = image.representations
-      .compactMap({ $0 as? NSBitmapImageRep })
-      .max(by: { ($0.pixelsWide * $0.pixelsHigh) < ($1.pixelsWide * $1.pixelsHigh) }),
-      let data = representation.bitmapData,
-      representation.hasAlpha
-    else {
-      return NSRect(origin: .zero, size: image.size)
-    }
-
-    let bytesPerPixel = max(1, representation.bitsPerPixel / 8)
-    let alphaIndex = representation.samplesPerPixel - 1
-    var minX = representation.pixelsWide
-    var minY = representation.pixelsHigh
-    var maxX = -1
-    var maxY = -1
-    for y in 0..<representation.pixelsHigh {
-      for x in 0..<representation.pixelsWide {
-        let offset = y * representation.bytesPerRow + x * bytesPerPixel
-        if data[offset + alphaIndex] > 8 {
-          minX = min(minX, x)
-          minY = min(minY, y)
-          maxX = max(maxX, x)
-          maxY = max(maxY, y)
-        }
-      }
-    }
-    guard maxX >= minX, maxY >= minY else {
-      return NSRect(origin: .zero, size: image.size)
-    }
-    return NSRect(
-      x: image.size.width * CGFloat(minX) / CGFloat(representation.pixelsWide),
-      y: image.size.height * CGFloat(minY) / CGFloat(representation.pixelsHigh),
-      width: image.size.width * CGFloat(maxX - minX + 1) / CGFloat(representation.pixelsWide),
-      height: image.size.height * CGFloat(maxY - minY + 1) / CGFloat(representation.pixelsHigh)
-    )
   }
 
   private var assetName: String? {

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -957,7 +957,7 @@ struct ProviderIcon: View {
           .clipped()
       } else {
         Image(systemName: "cpu")
-          .font(.system(size: size * 0.5, weight: .semibold))
+          .font(.system(size: size * 0.82, weight: .semibold))
           .foregroundStyle(routerMuted)
           .frame(width: size, height: size)
       }
@@ -985,7 +985,75 @@ struct ProviderIcon: View {
       withExtension: assetExtension,
       subdirectory: "ProviderIcons"
     ) ?? resources.url(forResource: assetName, withExtension: assetExtension)
-    return url.flatMap(NSImage.init(contentsOf:))
+    guard let image = url.flatMap(NSImage.init(contentsOf:)) else { return nil }
+    return fittedProviderImage(image)
+  }
+
+  private func fittedProviderImage(_ image: NSImage) -> NSImage {
+    let targetSize = NSSize(width: max(1, size), height: max(1, size))
+    let sourceRect = visibleImageRect(image)
+    let scale = min(
+      targetSize.width / max(sourceRect.width, 1),
+      targetSize.height / max(sourceRect.height, 1)
+    )
+    let drawSize = NSSize(width: sourceRect.width * scale, height: sourceRect.height * scale)
+    let drawRect = NSRect(
+      x: (targetSize.width - drawSize.width) / 2,
+      y: (targetSize.height - drawSize.height) / 2,
+      width: drawSize.width,
+      height: drawSize.height
+    )
+    let fitted = NSImage(size: targetSize)
+    fitted.lockFocus()
+    NSGraphicsContext.current?.imageInterpolation = .high
+    image.draw(
+      in: drawRect,
+      from: sourceRect,
+      operation: .sourceOver,
+      fraction: 1,
+      respectFlipped: true,
+      hints: [.interpolation: NSImageInterpolation.high]
+    )
+    fitted.unlockFocus()
+    return fitted
+  }
+
+  private func visibleImageRect(_ image: NSImage) -> NSRect {
+    guard let representation = image.representations
+      .compactMap({ $0 as? NSBitmapImageRep })
+      .max(by: { ($0.pixelsWide * $0.pixelsHigh) < ($1.pixelsWide * $1.pixelsHigh) }),
+      let data = representation.bitmapData,
+      representation.hasAlpha
+    else {
+      return NSRect(origin: .zero, size: image.size)
+    }
+
+    let bytesPerPixel = max(1, representation.bitsPerPixel / 8)
+    let alphaIndex = representation.samplesPerPixel - 1
+    var minX = representation.pixelsWide
+    var minY = representation.pixelsHigh
+    var maxX = -1
+    var maxY = -1
+    for y in 0..<representation.pixelsHigh {
+      for x in 0..<representation.pixelsWide {
+        let offset = y * representation.bytesPerRow + x * bytesPerPixel
+        if data[offset + alphaIndex] > 8 {
+          minX = min(minX, x)
+          minY = min(minY, y)
+          maxX = max(maxX, x)
+          maxY = max(maxY, y)
+        }
+      }
+    }
+    guard maxX >= minX, maxY >= minY else {
+      return NSRect(origin: .zero, size: image.size)
+    }
+    return NSRect(
+      x: image.size.width * CGFloat(minX) / CGFloat(representation.pixelsWide),
+      y: image.size.height * CGFloat(minY) / CGFloat(representation.pixelsHigh),
+      width: image.size.width * CGFloat(maxX - minX + 1) / CGFloat(representation.pixelsWide),
+      height: image.size.height * CGFloat(maxY - minY + 1) / CGFloat(representation.pixelsHigh)
+    )
   }
 
   private var assetName: String? {

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -939,6 +939,22 @@ private struct IslandUsageLineChart: View {
 
 // Internal rather than private: the status panel's quota-reset rows in
 // ModelRouterTrayApp.swift render the same provider mark.
+enum ProviderIconLayout {
+  static func fittedRect(sourceRect: NSRect, targetSize: NSSize) -> NSRect {
+    let scale = min(
+      targetSize.width / max(sourceRect.width, 1),
+      targetSize.height / max(sourceRect.height, 1)
+    )
+    let drawSize = NSSize(width: sourceRect.width * scale, height: sourceRect.height * scale)
+    return NSRect(
+      x: (targetSize.width - drawSize.width) / 2,
+      y: (targetSize.height - drawSize.height) / 2,
+      width: drawSize.width,
+      height: drawSize.height
+    )
+  }
+}
+
 struct ProviderIcon: View {
   let providerID: String
   let size: CGFloat
@@ -992,17 +1008,7 @@ struct ProviderIcon: View {
   private func fittedProviderImage(_ image: NSImage) -> NSImage {
     let targetSize = NSSize(width: max(1, size), height: max(1, size))
     let sourceRect = visibleImageRect(image)
-    let scale = min(
-      targetSize.width / max(sourceRect.width, 1),
-      targetSize.height / max(sourceRect.height, 1)
-    )
-    let drawSize = NSSize(width: sourceRect.width * scale, height: sourceRect.height * scale)
-    let drawRect = NSRect(
-      x: (targetSize.width - drawSize.width) / 2,
-      y: (targetSize.height - drawSize.height) / 2,
-      width: drawSize.width,
-      height: drawSize.height
-    )
+    let drawRect = ProviderIconLayout.fittedRect(sourceRect: sourceRect, targetSize: targetSize)
     let fitted = NSImage(size: targetSize)
     fitted.lockFocus()
     NSGraphicsContext.current?.imageInterpolation = .high

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -4451,7 +4451,9 @@ struct MenuBarSettings: Equatable {
 
 enum MenuBarLayoutMetrics {
   static let standardReservedWidth: CGFloat = 180
+  static let standardHeight: CGFloat = 22
   static let iconOnlyWidth: CGFloat = 28
+  static let iconOnlyHeight: CGFloat = 22
   static let iconOnlyIconSize: CGFloat = 17
   static let attentionPulseScale: CGFloat = 1.4
   static let activityBadgeSize: CGFloat = 5
@@ -4470,6 +4472,16 @@ enum MenuBarLayoutMetrics {
     let badgeWidth = showsActivityBadge ? activityBadgeSize * activityBadgePulseScale : 0
     let spacing = showsActivityBadge ? iconOnlySpacing : 0
     return max(iconOnlyWidth, ceil(iconWidth + spacing + badgeWidth))
+  }
+
+  nonisolated static func statusItemHeight(
+    displayMode: TrayMenuBarDisplayMode,
+    pulsing: Bool = false
+  ) -> CGFloat {
+    guard displayMode == .iconOnly, pulsing else {
+      return standardHeight
+    }
+    return max(iconOnlyHeight, ceil(iconOnlyIconSize * attentionPulseScale))
   }
 
   nonisolated static func showsActivityBadge(iconStyle: TrayMenuBarIconStyle, isIdle: Bool) -> Bool {
@@ -4710,7 +4722,10 @@ private struct StatusItemLabel: View {
             isIdle: store.activityState == .idle
           )
         ),
-        height: 22
+        height: MenuBarLayoutMetrics.statusItemHeight(
+          displayMode: store.menuBarDisplayMode,
+          pulsing: pulsing
+        )
       )
       .clipped()
       .contentShape(Rectangle())
@@ -4758,7 +4773,14 @@ private struct StatusItemLabel: View {
             .truncationMode(.tail)
         }
       }
-      .frame(width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode, pulsing: pulsing), alignment: .leading)
+      .frame(
+        width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode, pulsing: pulsing),
+        height: MenuBarLayoutMetrics.statusItemHeight(
+          displayMode: store.menuBarDisplayMode,
+          pulsing: pulsing
+        ),
+        alignment: .leading
+      )
       .clipped()
       .help(tooltipText)
       .onChange(of: store.attentionPulse) { _ in

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -4452,9 +4452,24 @@ struct MenuBarSettings: Equatable {
 enum MenuBarLayoutMetrics {
   static let standardReservedWidth: CGFloat = 180
   static let iconOnlyWidth: CGFloat = 28
+  static let iconOnlyIconSize: CGFloat = 17
+  static let attentionPulseScale: CGFloat = 1.4
+  static let activityBadgeSize: CGFloat = 5
+  static let activityBadgePulseScale: CGFloat = 1.6
+  static let standardIndicatorPulseScale: CGFloat = 2.1
+  static let iconOnlySpacing: CGFloat = 4
 
-  nonisolated static func statusItemWidth(displayMode: TrayMenuBarDisplayMode) -> CGFloat {
-    displayMode == .iconOnly ? iconOnlyWidth : standardReservedWidth
+  nonisolated static func statusItemWidth(
+    displayMode: TrayMenuBarDisplayMode,
+    pulsing: Bool = false,
+    showsActivityBadge: Bool = false
+  ) -> CGFloat {
+    guard displayMode == .iconOnly else { return standardReservedWidth }
+    guard pulsing else { return iconOnlyWidth }
+    let iconWidth = iconOnlyIconSize * attentionPulseScale
+    let badgeWidth = showsActivityBadge ? activityBadgeSize * activityBadgePulseScale : 0
+    let spacing = showsActivityBadge ? iconOnlySpacing : 0
+    return max(iconOnlyWidth, ceil(iconWidth + spacing + badgeWidth))
   }
 
   nonisolated static func showsActivityBadge(iconStyle: TrayMenuBarIconStyle, isIdle: Bool) -> Bool {
@@ -4671,19 +4686,32 @@ private struct StatusItemLabel: View {
   var body: some View {
     if store.menuBarDisplayMode == .iconOnly {
       HStack(spacing: 4) {
-        MenuBarIconView(store: store, size: 17)
-        if MenuBarLayoutMetrics.showsActivityBadge(
+        MenuBarIconView(store: store, size: MenuBarLayoutMetrics.iconOnlyIconSize)
+          .scaleEffect(pulsing ? MenuBarLayoutMetrics.attentionPulseScale : 1)
+          .animation(.easeOut(duration: 0.45), value: pulsing)
+        let showsActivityBadge = MenuBarLayoutMetrics.showsActivityBadge(
           iconStyle: store.menuBarIconStyle,
           isIdle: store.activityState == .idle
-        ) {
+        )
+        if showsActivityBadge {
           Circle()
             .fill(store.activityState.tint)
-            .frame(width: 5, height: 5)
-            .scaleEffect(pulsing ? 1.6 : 1)
+            .frame(width: MenuBarLayoutMetrics.activityBadgeSize, height: MenuBarLayoutMetrics.activityBadgeSize)
+            .scaleEffect(pulsing ? MenuBarLayoutMetrics.activityBadgePulseScale : 1)
             .animation(.easeOut(duration: 0.45), value: pulsing)
         }
       }
-      .frame(width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode), height: 22)
+      .frame(
+        width: MenuBarLayoutMetrics.statusItemWidth(
+          displayMode: store.menuBarDisplayMode,
+          pulsing: pulsing,
+          showsActivityBadge: MenuBarLayoutMetrics.showsActivityBadge(
+            iconStyle: store.menuBarIconStyle,
+            isIdle: store.activityState == .idle
+          )
+        ),
+        height: 22
+      )
       .clipped()
       .contentShape(Rectangle())
       .help(tooltipText)
@@ -4702,11 +4730,13 @@ private struct StatusItemLabel: View {
             .frame(width: 6, height: 6)
             .aspectRatio(1, contentMode: .fit)
             .clipShape(Circle())
-            .scaleEffect(pulsing ? 1.6 : 1)
+            .scaleEffect(pulsing ? MenuBarLayoutMetrics.standardIndicatorPulseScale : 1)
             .opacity(pulsing ? 0.55 : 1)
             .animation(.easeOut(duration: 0.45), value: pulsing)
         } else {
           MenuBarIconView(store: store, size: 15)
+            .scaleEffect(pulsing ? MenuBarLayoutMetrics.attentionPulseScale : 1)
+            .animation(.easeOut(duration: 0.45), value: pulsing)
         }
         if store.menuBarShowModelName {
           Text(store.hasConcurrentActivity ? store.activitySummaryLabel : store.selectedUsageProvider.shortName)
@@ -4728,7 +4758,7 @@ private struct StatusItemLabel: View {
             .truncationMode(.tail)
         }
       }
-      .frame(width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode), alignment: .leading)
+      .frame(width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode, pulsing: pulsing), alignment: .leading)
       .clipped()
       .help(tooltipText)
       .onChange(of: store.attentionPulse) { _ in

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -4451,7 +4451,7 @@ struct MenuBarSettings: Equatable {
 
 enum MenuBarLayoutMetrics {
   static let standardReservedWidth: CGFloat = 180
-  static let iconOnlyWidth: CGFloat = 24
+  static let iconOnlyWidth: CGFloat = 28
 
   nonisolated static func statusItemWidth(displayMode: TrayMenuBarDisplayMode) -> CGFloat {
     displayMode == .iconOnly ? iconOnlyWidth : standardReservedWidth
@@ -4671,9 +4671,7 @@ private struct StatusItemLabel: View {
   var body: some View {
     if store.menuBarDisplayMode == .iconOnly {
       HStack(spacing: 4) {
-        MenuBarIconView(store: store, size: 14)
-          .scaleEffect(pulsing ? 1.4 : 1)
-          .animation(.easeOut(duration: 0.45), value: pulsing)
+        MenuBarIconView(store: store, size: 17)
         if MenuBarLayoutMetrics.showsActivityBadge(
           iconStyle: store.menuBarIconStyle,
           isIdle: store.activityState == .idle
@@ -4681,6 +4679,8 @@ private struct StatusItemLabel: View {
           Circle()
             .fill(store.activityState.tint)
             .frame(width: 5, height: 5)
+            .scaleEffect(pulsing ? 1.6 : 1)
+            .animation(.easeOut(duration: 0.45), value: pulsing)
         }
       }
       .frame(width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode), height: 22)
@@ -4700,13 +4700,13 @@ private struct StatusItemLabel: View {
           Circle()
             .fill(store.activityState.tint)
             .frame(width: 6, height: 6)
-            .scaleEffect(pulsing ? 2.1 : 1)
+            .aspectRatio(1, contentMode: .fit)
+            .clipShape(Circle())
+            .scaleEffect(pulsing ? 1.6 : 1)
             .opacity(pulsing ? 0.55 : 1)
             .animation(.easeOut(duration: 0.45), value: pulsing)
         } else {
-          MenuBarIconView(store: store, size: 13)
-            .scaleEffect(pulsing ? 1.4 : 1)
-            .animation(.easeOut(duration: 0.45), value: pulsing)
+          MenuBarIconView(store: store, size: 15)
         }
         if store.menuBarShowModelName {
           Text(store.hasConcurrentActivity ? store.activitySummaryLabel : store.selectedUsageProvider.shortName)

--- a/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
@@ -124,6 +124,49 @@ struct MenuBarSettingsTests {
     #expect(drawRect.maxY <= 18)
   }
 
+  @Test("provider layout handles alpha-first bitmap representations")
+  func providerLayoutHandlesAlphaFirstBitmaps() {
+    guard let representation = NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: 10,
+      pixelsHigh: 8,
+      bitsPerSample: 8,
+      samplesPerPixel: 4,
+      hasAlpha: true,
+      isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bitmapFormat: .alphaFirst,
+      bytesPerRow: 0,
+      bitsPerPixel: 0
+    ) else {
+      Issue.record("Alpha-first bitmap fixture could not be created")
+      return
+    }
+
+    func setPixel(_ values: [Int], atX x: Int, y: Int) {
+      var values = values
+      values.withUnsafeMutableBufferPointer { buffer in
+        representation.setPixel(buffer.baseAddress!, atX: x, y: y)
+      }
+    }
+
+    for y in 0..<representation.pixelsHigh {
+      for x in 0..<representation.pixelsWide {
+        setPixel([0, 0, 0, 0], atX: x, y: y)
+      }
+    }
+    setPixel([255, 255, 255, 255], atX: 2, y: 1)
+    setPixel([255, 255, 255, 255], atX: 7, y: 6)
+    let image = NSImage(size: NSSize(width: 10, height: 8))
+    image.addRepresentation(representation)
+
+    let visibleRect = ProviderIconLayout.visibleImageRect(image)
+    #expect(visibleRect.minX == 2)
+    #expect(visibleRect.minY == 1)
+    #expect(visibleRect.width == 6)
+    #expect(visibleRect.height == 6)
+  }
+
   @Test("the activity badge is not a second dot on the indicator style")
   func indicatorHasNoSideBadge() {
     #expect(MenuBarLayoutMetrics.showsActivityBadge(iconStyle: .indicator, isIdle: false) == false)

--- a/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
@@ -59,6 +59,39 @@ struct MenuBarSettingsTests {
     #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .iconOnly) == 28)
   }
 
+  @Test("the icon-only pulse reserves space for the rendered mark and badge")
+  func iconOnlyPulseKeepsScaledContentInsideBounds() {
+    #expect(
+      MenuBarLayoutMetrics.statusItemWidth(
+        displayMode: .iconOnly,
+        pulsing: true,
+        showsActivityBadge: false
+      ) == 28
+    )
+    #expect(
+      MenuBarLayoutMetrics.statusItemWidth(
+        displayMode: .iconOnly,
+        pulsing: true,
+        showsActivityBadge: true
+      ) == 36
+    )
+    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard, pulsing: true) == 180)
+  }
+
+  @Test("provider marks fit transparent crops without leaving the target slot")
+  func providerMarkCropFitsTargetSlot() {
+    let drawRect = ProviderIconLayout.fittedRect(
+      sourceRect: NSRect(x: 2, y: 1, width: 6, height: 8),
+      targetSize: NSSize(width: 20, height: 20)
+    )
+    #expect(drawRect.width == 15)
+    #expect(drawRect.height == 20)
+    #expect(drawRect.minX >= 0)
+    #expect(drawRect.maxX <= 20)
+    #expect(drawRect.minY >= 0)
+    #expect(drawRect.maxY <= 20)
+  }
+
   @Test("the activity badge is not a second dot on the indicator style")
   func indicatorHasNoSideBadge() {
     #expect(MenuBarLayoutMetrics.showsActivityBadge(iconStyle: .indicator, isIdle: false) == false)

--- a/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
@@ -56,7 +56,7 @@ struct MenuBarSettingsTests {
   @Test("standard mode keeps a reserved width even when the name is hidden")
   func standardWidthIsReserved() {
     #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard) == 180)
-    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .iconOnly) == 24)
+    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .iconOnly) == 28)
   }
 
   @Test("the activity badge is not a second dot on the indicator style")

--- a/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 
@@ -57,6 +58,8 @@ struct MenuBarSettingsTests {
   func standardWidthIsReserved() {
     #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard) == 180)
     #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .iconOnly) == 28)
+    #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .standard) == 22)
+    #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .iconOnly) == 22)
   }
 
   @Test("the icon-only pulse reserves space for the rendered mark and badge")
@@ -75,7 +78,9 @@ struct MenuBarSettingsTests {
         showsActivityBadge: true
       ) == 36
     )
+    #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .iconOnly, pulsing: true) == 24)
     #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard, pulsing: true) == 180)
+    #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .standard, pulsing: true) == 22)
   }
 
   @Test("provider marks fit transparent crops without leaving the target slot")
@@ -90,6 +95,33 @@ struct MenuBarSettingsTests {
     #expect(drawRect.maxX <= 20)
     #expect(drawRect.minY >= 0)
     #expect(drawRect.maxY <= 20)
+  }
+
+  @Test("provider layout finds visible content in a transparent bitmap")
+  func providerLayoutFindsVisibleContent() {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Resources/ProviderIcons/openai.png")
+    guard let image = NSImage(contentsOf: url) else {
+      Issue.record("Provider icon fixture could not be loaded")
+      return
+    }
+
+    let visibleRect = ProviderIconLayout.visibleImageRect(image)
+    #expect(visibleRect.width > 0)
+    #expect(visibleRect.height > 0)
+    #expect(visibleRect.width <= image.size.width)
+    #expect(visibleRect.height <= image.size.height)
+    #expect(visibleRect.width < image.size.width || visibleRect.height < image.size.height)
+    let drawRect = ProviderIconLayout.fittedRect(
+      sourceRect: visibleRect,
+      targetSize: NSSize(width: 18, height: 18)
+    )
+    #expect(drawRect.minX >= 0)
+    #expect(drawRect.maxX <= 18)
+    #expect(drawRect.minY >= 0)
+    #expect(drawRect.maxY <= 18)
   }
 
   @Test("the activity badge is not a second dot on the indicator style")

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -1267,8 +1267,9 @@ test("the status item keeps a reserved width in both menu-bar modes", () => {
   assert.match(source, /static let iconOnlyWidth: CGFloat = 28/);
   assert.match(
     source,
-    /\.frame\(width: MenuBarLayoutMetrics\.statusItemWidth\(displayMode: store\.menuBarDisplayMode\)/,
+    /statusItemWidth\(\s*displayMode: store\.menuBarDisplayMode/,
   );
+  assert.match(source, /statusItemHeight\(\s*displayMode: store\.menuBarDisplayMode/);
   assert.doesNotMatch(
     source,
     /\.frame\(width: store\.menuBarShowModelName \? Self\.reservedWidth : nil/,

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -1264,7 +1264,7 @@ test("the status item keeps a reserved width in both menu-bar modes", () => {
     path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),
     "utf8",
   );
-  assert.match(source, /static let iconOnlyWidth: CGFloat = 24/);
+  assert.match(source, /static let iconOnlyWidth: CGFloat = 28/);
   assert.match(
     source,
     /\.frame\(width: MenuBarLayoutMetrics\.statusItemWidth\(displayMode: store\.menuBarDisplayMode\)/,


### PR DESCRIPTION
## Summary

Provider icons now crop transparent asset padding before fitting into their tray slot. The existing attention pulse remains active for provider, preset, custom, and activity-dot styles. Menu-bar layout bounds reserve the scaled mark and activity badge while a pulse is drawn, keeping dots circular and visible in both standard and icon-only modes.

## Reason

Large transparent canvases made provider marks appear too small, while fixed tray bounds could clip the attention pulse. The previous implementation also lacked focused coverage for alpha cropping and scale-aware layout. This change keeps the existing tray behavior and makes icon sizing predictable across bitmap representations.

## Validation

- `swift test --package-path apps/macos/ModelRouterTray` (87 tests passed)
- `node --test test/tray-rebuild.test.mjs` (43 tests passed)
- Swift package build completed as part of the test run
- Focused tests cover transparent provider-image bounds, alpha-first bitmap representations, fitted draw rectangles, icon-only pulse width/height, activity-badge behavior, and standard-mode pulse sizing
- Branch is based on current `origin/main` (`65bd8a5`)

## Remaining risks

- The tests validate geometry and rendered provider-image sizing, but do not capture a full macOS menu-bar screenshot.
- The status-item width can temporarily grow during an icon-only pulse so the scaled content is not clipped; this is intentional and returns to the normal reserved width after the pulse.
