### PR TITLE
fix: expose native web search for routed models

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,11 @@ Other routed providers can use Codex's client-side (standalone) web search when
 the selected model has been verified for it. DeepSeek V4 Flash is enabled on
 its direct API and opencode Go routes. A compatible model declares
 `"searchTool": { "mode": "standalone" }` in its registry or user-model
-metadata, and the managed Codex provider table advertises
-`supports_standalone_web_search = true`. This is intentionally opt-in per
-model; the router does not infer search compatibility from an OpenAI-compatible
-endpoint.
+metadata. This capability is resolved from the selected model/provider pair;
+the router does not enable a global web-search switch or infer compatibility
+from an OpenAI-compatible endpoint. A model is advertised only after its
+provider path has been verified to preserve Codex search-result items and
+tool-call history.
 
 ```sh
 npm install -g @xai-official/grok
@@ -924,7 +925,6 @@ model_catalog_json = "/absolute/path/to/.codex/codex-router/merged-models.json"
 name = "Codex Router (external models)"
 base_url = "http://127.0.0.1:4202/_codex-router/<generated-capability>/v1"
 wire_api = "responses"
-supports_standalone_web_search = true
 # END codex-router-provider-managed
 ```
 

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -185,9 +185,11 @@ Codex sends the search result back through the normal routed Responses turn.
 This is a per-model compatibility declaration, not a claim that the upstream
 provider hosts search. Only enable it after verifying that the provider's
 model accepts Codex's web-search result items and preserves tool/function-call
-history. The managed Codex provider table must also set
-`supports_standalone_web_search = true` (on Codex versions that support that
-field); older clients ignore the field and continue without standalone search.
+history. Do not enable a global Codex feature or provider flag for this: Codex
+does not use those settings to gate the tool per model, so they would expose
+`web.run` to unrelated routed models and could select a native OpenAI search
+path without the required ChatGPT session. The registry declaration is the
+only capability switch, and it is scoped to the exact model/provider route.
 
 The checked-in registry currently enables this mode for DeepSeek V4 Flash on
 its direct API and opencode Go routes, DeepSeek V4 Flash Vision Exp, Xiaomi

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -66,6 +66,10 @@ const agentConcurrencyStartMarker = "# BEGIN codex-router-agent-concurrency-mana
 const agentConcurrencyEndMarker = "# END codex-router-agent-concurrency-managed";
 const multiAgentV2StartMarker = "# BEGIN codex-router-multi-agent-v2-managed";
 const multiAgentV2EndMarker = "# END codex-router-multi-agent-v2-managed";
+const standaloneWebSearchStartMarker =
+  "# BEGIN codex-router-standalone-web-search-managed";
+const standaloneWebSearchEndMarker =
+  "# END codex-router-standalone-web-search-managed";
 const createdAgentsTableMarker = "# codex-router-created-agents-table";
 const managedAgentMaxConcurrency = 6;
 // Codex 0.147 records a child's FINAL_ANSWER as subAgentActivity
@@ -110,6 +114,7 @@ const markerPairs = [
   ],
   [agentConcurrencyStartMarker, agentConcurrencyEndMarker],
   [multiAgentV2StartMarker, multiAgentV2EndMarker],
+  [standaloneWebSearchStartMarker, standaloneWebSearchEndMarker],
   ["# BEGIN kimi-codex-router-managed", "# END kimi-codex-router-managed"],
   ["# BEGIN kimi-codex-proxy-managed", "# END kimi-codex-proxy-managed"],
 ];
@@ -352,6 +357,97 @@ function withManagedMultiAgentV2(input) {
     multiAgentV2StartMarker,
     featureLine,
     multiAgentV2EndMarker,
+  ];
+  const lines = cleaned.split("\n");
+  const featuresHeader = lines.findIndex((line) =>
+    /^\s*\[features\]\s*(?:#.*)?$/.test(line),
+  );
+  if (featuresHeader === -1) {
+    const firstTable = lines.findIndex((line) => /^\s*\[/.test(line));
+    const insertionIndex = firstTable === -1 ? lines.length : firstTable;
+    lines.splice(insertionIndex, 0, "", "[features]", ...managedLines);
+    return `${lines.join("\n").trimEnd()}\n`;
+  }
+  let tableEnd = featuresHeader + 1;
+  while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd])) tableEnd += 1;
+  lines.splice(tableEnd, 0, ...managedLines, "");
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+function hasStandaloneWebSearchConfig(input) {
+  const lines = input.split("\n");
+  if (lines.some((line) => /^\s*features\.standalone_web_search\s*=/.test(line))) {
+    return true;
+  }
+  const featuresHeader = lines.findIndex((line) =>
+    /^\s*\[features\]\s*(?:#.*)?$/.test(line),
+  );
+  if (featuresHeader === -1) return false;
+  let tableEnd = featuresHeader + 1;
+  while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd])) tableEnd += 1;
+  return lines
+    .slice(featuresHeader + 1, tableEnd)
+    .some((line) => /^\s*standalone_web_search\s*=/.test(line));
+}
+
+// Standalone web search is a Codex feature flag, not a router-side tool. Probe
+// the installed Codex schema before writing it so older clients keep loading
+// their config instead of failing on an unknown feature.
+let codexSupportsStandaloneWebSearch;
+function installedCodexSupportsStandaloneWebSearch() {
+  if (codexSupportsStandaloneWebSearch !== undefined) {
+    return codexSupportsStandaloneWebSearch;
+  }
+  codexSupportsStandaloneWebSearch = probeStandaloneWebSearchSupport();
+  return codexSupportsStandaloneWebSearch;
+}
+
+function probeStandaloneWebSearchSupport() {
+  const binary = findCodexBinary();
+  if (!binary) return false;
+  const probeHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-search-probe-"));
+  try {
+    writeFileSync(
+      path.join(probeHome, "config.toml"),
+      "[features]\nstandalone_web_search = true\n",
+      { encoding: "utf8", mode: 0o600 },
+    );
+    const probe = spawnableCommand(binary, ["login", "status"]);
+    const result = spawnSync(probe.command, probe.args, {
+      ...probe.options,
+      encoding: "utf8",
+      timeout: 10_000,
+      windowsHide: true,
+      env: { ...process.env, CODEX_HOME: probeHome },
+    });
+    if (result.error) return false;
+    return !/Error loading configuration/i.test(
+      `${result.stdout || ""}\n${result.stderr || ""}`,
+    );
+  } catch {
+    return false;
+  } finally {
+    rmSync(probeHome, { recursive: true, force: true });
+  }
+}
+
+function withManagedStandaloneWebSearch(input) {
+  const cleaned = removeMarkerPair(
+    input,
+    standaloneWebSearchStartMarker,
+    standaloneWebSearchEndMarker,
+  );
+  if (
+    hasStandaloneWebSearchConfig(cleaned) ||
+    !installedCodexSupportsStandaloneWebSearch()
+  ) {
+    return cleaned;
+  }
+
+  const managedLines = [
+    standaloneWebSearchStartMarker,
+    "standalone_web_search = true",
+    standaloneWebSearchEndMarker,
   ];
   const lines = cleaned.split("\n");
   const featuresHeader = lines.findIndex((line) =>
@@ -1083,8 +1179,10 @@ function enabledContents(contents) {
     "supports_standalone_web_search = true",
     providerEndMarker,
   ];
-  return withManagedAgentConcurrency(
-    `${withManagedMultiAgentV2(`${next.join("\n").trimEnd()}\n`).trimEnd()}\n\n${providerBlock.join("\n")}\n`,
+  return withManagedStandaloneWebSearch(
+    withManagedAgentConcurrency(
+      `${withManagedMultiAgentV2(`${next.join("\n").trimEnd()}\n`).trimEnd()}\n\n${providerBlock.join("\n")}\n`,
+    ),
   );
 }
 

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -558,11 +558,19 @@ function managedSignedProviderBlock(providerId, baseUrl) {
     `base_url = ${JSON.stringify(baseUrl)}`,
     'wire_api = "responses"',
     "requires_openai_auth = true",
+    // Current Codex builds expose the standalone web-search client tool only
+    // when both the provider and the selected model advertise support. Keep
+    // the provider half enabled; the catalog's supports_search_tool field is
+    // the per-model gate.
+    "supports_standalone_web_search = true",
     "supports_websockets = false",
     signedProviderEndMarker,
   ].join("\n");
 }
 
+// Keep accepting the pre-standalone-search managed block while upgrading it
+// in place. Existing signed state must not become user-owned merely because
+// this optional Codex capability was added.
 function managedSignedProviderBlockLegacy(providerId, baseUrl) {
   const headerId = /^[A-Za-z0-9_-]+$/.test(providerId)
     ? providerId
@@ -579,28 +587,10 @@ function managedSignedProviderBlockLegacy(providerId, baseUrl) {
   ].join("\n");
 }
 
-function managedSignedProviderBlockWithSearch(providerId, baseUrl) {
-  const headerId = /^[A-Za-z0-9_-]+$/.test(providerId)
-    ? providerId
-    : JSON.stringify(providerId);
-  return [
-    signedProviderStartMarker,
-    `[model_providers.${headerId}]`,
-    'name = "Codex Router (with ChatGPT)"',
-    `base_url = ${JSON.stringify(baseUrl)}`,
-    'wire_api = "responses"',
-    "requires_openai_auth = true",
-    "supports_standalone_web_search = true",
-    "supports_websockets = false",
-    signedProviderEndMarker,
-  ].join("\n");
-}
-
 function managedSignedProviderBlockMatches(actual, providerId, baseUrl) {
   return [
     managedSignedProviderBlock(providerId, baseUrl),
     managedSignedProviderBlockLegacy(providerId, baseUrl),
-    managedSignedProviderBlockWithSearch(providerId, baseUrl),
   ].includes(actual);
 }
 
@@ -1095,6 +1085,10 @@ function enabledContents(contents) {
     'name = "Codex Router (external models)"',
     `base_url = ${JSON.stringify(routerBaseUrl)}`,
     'wire_api = "responses"',
+    // Provider support is necessary but not sufficient: Codex also reads the
+    // selected catalog model's supports_search_tool value before exposing the
+    // standalone web-search client tool.
+    "supports_standalone_web_search = true",
     providerEndMarker,
   ];
   return withManagedAgentConcurrency(

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -374,97 +374,6 @@ function withManagedMultiAgentV2(input) {
   return `${lines.join("\n").trimEnd()}\n`;
 }
 
-function hasStandaloneWebSearchConfig(input) {
-  const lines = input.split("\n");
-  if (lines.some((line) => /^\s*features\.standalone_web_search\s*=/.test(line))) {
-    return true;
-  }
-  const featuresHeader = lines.findIndex((line) =>
-    /^\s*\[features\]\s*(?:#.*)?$/.test(line),
-  );
-  if (featuresHeader === -1) return false;
-  let tableEnd = featuresHeader + 1;
-  while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd])) tableEnd += 1;
-  return lines
-    .slice(featuresHeader + 1, tableEnd)
-    .some((line) => /^\s*standalone_web_search\s*=/.test(line));
-}
-
-// Standalone web search is a Codex feature flag, not a router-side tool. Probe
-// the installed Codex schema before writing it so older clients keep loading
-// their config instead of failing on an unknown feature.
-let codexSupportsStandaloneWebSearch;
-function installedCodexSupportsStandaloneWebSearch() {
-  if (codexSupportsStandaloneWebSearch !== undefined) {
-    return codexSupportsStandaloneWebSearch;
-  }
-  codexSupportsStandaloneWebSearch = probeStandaloneWebSearchSupport();
-  return codexSupportsStandaloneWebSearch;
-}
-
-function probeStandaloneWebSearchSupport() {
-  const binary = findCodexBinary();
-  if (!binary) return false;
-  const probeHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-search-probe-"));
-  try {
-    writeFileSync(
-      path.join(probeHome, "config.toml"),
-      "[features]\nstandalone_web_search = true\n",
-      { encoding: "utf8", mode: 0o600 },
-    );
-    const probe = spawnableCommand(binary, ["login", "status"]);
-    const result = spawnSync(probe.command, probe.args, {
-      ...probe.options,
-      encoding: "utf8",
-      timeout: 10_000,
-      windowsHide: true,
-      env: { ...process.env, CODEX_HOME: probeHome },
-    });
-    if (result.error) return false;
-    return !/Error loading configuration/i.test(
-      `${result.stdout || ""}\n${result.stderr || ""}`,
-    );
-  } catch {
-    return false;
-  } finally {
-    rmSync(probeHome, { recursive: true, force: true });
-  }
-}
-
-function withManagedStandaloneWebSearch(input) {
-  const cleaned = removeMarkerPair(
-    input,
-    standaloneWebSearchStartMarker,
-    standaloneWebSearchEndMarker,
-  );
-  if (
-    hasStandaloneWebSearchConfig(cleaned) ||
-    !installedCodexSupportsStandaloneWebSearch()
-  ) {
-    return cleaned;
-  }
-
-  const managedLines = [
-    standaloneWebSearchStartMarker,
-    "standalone_web_search = true",
-    standaloneWebSearchEndMarker,
-  ];
-  const lines = cleaned.split("\n");
-  const featuresHeader = lines.findIndex((line) =>
-    /^\s*\[features\]\s*(?:#.*)?$/.test(line),
-  );
-  if (featuresHeader === -1) {
-    const firstTable = lines.findIndex((line) => /^\s*\[/.test(line));
-    const insertionIndex = firstTable === -1 ? lines.length : firstTable;
-    lines.splice(insertionIndex, 0, "", "[features]", ...managedLines);
-    return `${lines.join("\n").trimEnd()}\n`;
-  }
-  let tableEnd = featuresHeader + 1;
-  while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd])) tableEnd += 1;
-  lines.splice(tableEnd, 0, ...managedLines, "");
-  return `${lines.join("\n").trimEnd()}\n`;
-}
-
 // Some Codex builds reject a managed concurrency scalar and block the whole
 // config from loading. Ask the installed binary instead of maintaining a
 // version table: have it load a config containing only the root-level scalar
@@ -649,19 +558,11 @@ function managedSignedProviderBlock(providerId, baseUrl) {
     `base_url = ${JSON.stringify(baseUrl)}`,
     'wire_api = "responses"',
     "requires_openai_auth = true",
-    // Codex 0.146+ performs standalone web search on the client and sends
-    // the resulting items back through the selected custom provider. Keep
-    // this opt-in on the managed provider table; older Codex versions ignore
-    // the unknown field and retain their existing behavior.
-    "supports_standalone_web_search = true",
     "supports_websockets = false",
     signedProviderEndMarker,
   ].join("\n");
 }
 
-// Keep accepting the pre-standalone-search managed block while upgrading it
-// in place. Existing signed state must not become "user-owned" merely because
-// this optional Codex capability was added.
 function managedSignedProviderBlockLegacy(providerId, baseUrl) {
   const headerId = /^[A-Za-z0-9_-]+$/.test(providerId)
     ? providerId
@@ -678,10 +579,28 @@ function managedSignedProviderBlockLegacy(providerId, baseUrl) {
   ].join("\n");
 }
 
+function managedSignedProviderBlockWithSearch(providerId, baseUrl) {
+  const headerId = /^[A-Za-z0-9_-]+$/.test(providerId)
+    ? providerId
+    : JSON.stringify(providerId);
+  return [
+    signedProviderStartMarker,
+    `[model_providers.${headerId}]`,
+    'name = "Codex Router (with ChatGPT)"',
+    `base_url = ${JSON.stringify(baseUrl)}`,
+    'wire_api = "responses"',
+    "requires_openai_auth = true",
+    "supports_standalone_web_search = true",
+    "supports_websockets = false",
+    signedProviderEndMarker,
+  ].join("\n");
+}
+
 function managedSignedProviderBlockMatches(actual, providerId, baseUrl) {
   return [
     managedSignedProviderBlock(providerId, baseUrl),
     managedSignedProviderBlockLegacy(providerId, baseUrl),
+    managedSignedProviderBlockWithSearch(providerId, baseUrl),
   ].includes(actual);
 }
 
@@ -1176,13 +1095,10 @@ function enabledContents(contents) {
     'name = "Codex Router (external models)"',
     `base_url = ${JSON.stringify(routerBaseUrl)}`,
     'wire_api = "responses"',
-    "supports_standalone_web_search = true",
     providerEndMarker,
   ];
-  return withManagedStandaloneWebSearch(
-    withManagedAgentConcurrency(
-      `${withManagedMultiAgentV2(`${next.join("\n").trimEnd()}\n`).trimEnd()}\n\n${providerBlock.join("\n")}\n`,
-    ),
+  return withManagedAgentConcurrency(
+    `${withManagedMultiAgentV2(`${next.join("\n").trimEnd()}\n`).trimEnd()}\n\n${providerBlock.join("\n")}\n`,
   );
 }
 

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -3413,6 +3413,16 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
       writeIdleNoProviderError(response);
       return;
     }
+    const headers = nativeHeaders(request);
+    if (!hasNativeSession(headers)) {
+      writeJson(response, 401, {
+        error: {
+          type: "native_session_required",
+          message: "This native OpenAI route requires an active ChatGPT/Codex session.",
+        },
+      });
+      return;
+    }
     const encoded = await readRequestBody(request);
     const body = decodeBody(encoded, request.headers["content-encoding"]);
     const payload = await parseBodyAsync(body);
@@ -3424,7 +3434,6 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
       ...activityMetadataFromHeaders(request.headers),
     });
 
-    const headers = nativeHeaders(request);
     // The same slug translation the turn path does, for the same reason: these
     // endpoints normally carry their own model ("gpt-image-2", the search
     // model), but nothing stops a client from naming the picked one, and an

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -281,23 +281,31 @@ test("ClinePass routed models omit the unsupported reasoning-effort selector", (
   assert.deepEqual(normal.supported_reasoning_levels, grok.reasoningLevels);
 });
 
-test("routed models advertise search and image detail only when the registry opts in", () => {
-  // Defaults stay off: external models must not claim capabilities untested.
+test("current Codex search contract distinguishes supported and unsupported routed models", () => {
+  // The managed provider opts in globally, while this catalog field is the
+  // second, per-model gate Codex requires before it exposes standalone search.
   const plain = routedModel(template, grok);
   assert.equal(plain.supports_search_tool, false);
-  assert.equal(plain.supports_image_detail_original, false);
-  const capable = routedModel(template, {
+  const hosted = routedModel(template, {
     ...grok,
     searchTool: { mode: "hosted" },
-    supportsImageDetailOriginal: true,
   });
-  assert.equal(capable.supports_search_tool, true);
-  assert.equal(capable.supports_image_detail_original, true);
+  assert.equal(hosted.supports_search_tool, true);
   const standalone = routedModel(template, {
     ...grok,
     searchTool: { mode: "standalone" },
   });
   assert.equal(standalone.supports_search_tool, true);
+});
+
+test("routed models advertise original image detail only when the registry opts in", () => {
+  const plain = routedModel(template, grok);
+  assert.equal(plain.supports_image_detail_original, false);
+  const capable = routedModel(template, {
+    ...grok,
+    supportsImageDetailOriginal: true,
+  });
+  assert.equal(capable.supports_image_detail_original, true);
 });
 
 test("routed models can explicitly narrow inherited tool capabilities", () => {

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -60,6 +60,18 @@ exit 1
   writeFileSync(file, contents, { mode: 0o755 });
   return file;
 })();
+const standaloneRejectingCodex = (() => {
+  const isWindows = process.platform === "win32";
+  const file = path.join(
+    codexStubDir,
+    isWindows ? "codex-no-standalone-search.cmd" : "codex-no-standalone-search",
+  );
+  const contents = isWindows
+    ? `@echo off\r\nfindstr /c:"standalone_web_search" "%CODEX_HOME%\\config.toml" >nul 2>&1\r\nif %errorlevel% equ 0 (\r\n  echo Error loading configuration: unknown feature standalone_web_search 1>&2\r\n  exit /b 1\r\n)\r\necho Not logged in 1>&2\r\nexit /b 1\r\n`
+    : `#!/bin/sh\nif grep -q standalone_web_search "$CODEX_HOME/config.toml" 2>/dev/null; then\n  echo 'Error loading configuration: unknown feature standalone_web_search' >&2\n  exit 1\nfi\necho 'Not logged in' >&2\nexit 1\n`;
+  writeFileSync(file, contents, { mode: 0o755 });
+  return file;
+})();
 
 function run(
   command,
@@ -118,6 +130,8 @@ approval_policy = "never"
     assert.match(configured, /# BEGIN codex-router-managed/);
     assert.match(configured, /# BEGIN codex-router-provider-managed/);
     assert.match(configured, /# BEGIN codex-router-multi-agent-v2-managed/);
+    assert.match(configured, /# BEGIN codex-router-standalone-web-search-managed/);
+    assert.match(configured, /^standalone_web_search = true$/m);
     assert.match(
       configured,
       /multi_agent_v2 = \{ enabled = true, max_concurrent_threads_per_session = 6, expose_spawn_agent_model_overrides = true, usage_hint_enabled = true, root_agent_usage_hint_text = "When a child agent finishes \(FINAL_ANSWER, task_complete, or an idle\/errored wait snapshot\), call interrupt_agent on that child so Codex can mark it done\. Do not leave finished children in the working state\." \}/,
@@ -161,6 +175,12 @@ approval_policy = "never"
         .length,
       1,
     );
+    assert.equal(
+      (readFileSync(configPath, "utf8").match(
+        /# BEGIN codex-router-standalone-web-search-managed/g,
+      ) || []).length,
+      1,
+    );
 
     const disabled = run("disable", codexHome);
     assert.equal(disabled.mode, "native");
@@ -168,13 +188,59 @@ approval_policy = "never"
     const restored = readFileSync(configPath, "utf8");
     assert.doesNotMatch(
       restored,
-      /codex-router-(?:(?:provider|agent-concurrency|multi-agent-v2)-)?managed|codex-router-created-agents-table|openai_base_url|model_catalog_json|experimental_realtime_(?:webrtc_call|ws)_base_url/,
+      /codex-router-(?:(?:provider|agent-concurrency|multi-agent-v2|standalone-web-search)-)?managed|codex-router-created-agents-table|openai_base_url|model_catalog_json|experimental_realtime_(?:webrtc_call|ws)_base_url/,
     );
     assert.doesNotMatch(restored, /\[agents\]|max_concurrent_threads_per_session/);
     assert.match(restored, /model = "gpt-5\.6-sol"/);
     assert.match(restored, /model_provider = "openai"/);
     assert.match(restored, /model_reasoning_effort = "xhigh"/);
     assert.match(restored, /\[profiles\.work\]/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager preserves a user-owned standalone web search setting", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-config-"));
+  const configPath = path.join(codexHome, "config.toml");
+  const original = `model = "gpt-5.6-sol"
+model_provider = "openai"
+
+[features]
+standalone_web_search = false
+apps = true
+`;
+  writeFileSync(configPath, original, { mode: 0o600 });
+
+  try {
+    run("enable", codexHome);
+    const configured = readFileSync(configPath, "utf8");
+    assert.match(configured, /^standalone_web_search = false$/m);
+    assert.doesNotMatch(configured, /codex-router-standalone-web-search-managed/);
+
+    run("disable", codexHome);
+    const restored = readFileSync(configPath, "utf8");
+    assert.match(restored, /^standalone_web_search = false$/m);
+    assert.match(restored, /^apps = true$/m);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager skips standalone web search on unsupported Codex builds", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-config-"));
+  const configPath = path.join(codexHome, "config.toml");
+  writeFileSync(
+    configPath,
+    'model = "gpt-5.6-sol"\nmodel_provider = "openai"\n',
+    { mode: 0o600 },
+  );
+
+  try {
+    run("enable", codexHome, undefined, [], { CODEX_BIN: standaloneRejectingCodex });
+    const configured = readFileSync(configPath, "utf8");
+    assert.doesNotMatch(configured, /codex-router-standalone-web-search-managed/);
+    assert.doesNotMatch(configured, /^standalone_web_search = true$/m);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -60,19 +60,6 @@ exit 1
   writeFileSync(file, contents, { mode: 0o755 });
   return file;
 })();
-const standaloneRejectingCodex = (() => {
-  const isWindows = process.platform === "win32";
-  const file = path.join(
-    codexStubDir,
-    isWindows ? "codex-no-standalone-search.cmd" : "codex-no-standalone-search",
-  );
-  const contents = isWindows
-    ? `@echo off\r\nfindstr /c:"standalone_web_search" "%CODEX_HOME%\\config.toml" >nul 2>&1\r\nif %errorlevel% equ 0 (\r\n  echo Error loading configuration: unknown feature standalone_web_search 1>&2\r\n  exit /b 1\r\n)\r\necho Not logged in 1>&2\r\nexit /b 1\r\n`
-    : `#!/bin/sh\nif grep -q standalone_web_search "$CODEX_HOME/config.toml" 2>/dev/null; then\n  echo 'Error loading configuration: unknown feature standalone_web_search' >&2\n  exit 1\nfi\necho 'Not logged in' >&2\nexit 1\n`;
-  writeFileSync(file, contents, { mode: 0o755 });
-  return file;
-})();
-
 function run(
   command,
   codexHome,
@@ -130,8 +117,8 @@ approval_policy = "never"
     assert.match(configured, /# BEGIN codex-router-managed/);
     assert.match(configured, /# BEGIN codex-router-provider-managed/);
     assert.match(configured, /# BEGIN codex-router-multi-agent-v2-managed/);
-    assert.match(configured, /# BEGIN codex-router-standalone-web-search-managed/);
-    assert.match(configured, /^standalone_web_search = true$/m);
+    assert.doesNotMatch(configured, /codex-router-standalone-web-search-managed/);
+    assert.doesNotMatch(configured, /^standalone_web_search\s*=/m);
     assert.match(
       configured,
       /multi_agent_v2 = \{ enabled = true, max_concurrent_threads_per_session = 6, expose_spawn_agent_model_overrides = true, usage_hint_enabled = true, root_agent_usage_hint_text = "When a child agent finishes \(FINAL_ANSWER, task_complete, or an idle\/errored wait snapshot\), call interrupt_agent on that child so Codex can mark it done\. Do not leave finished children in the working state\." \}/,
@@ -141,7 +128,7 @@ approval_policy = "never"
     assert.doesNotMatch(configured, /\[agents\]/);
     assert.match(configured, /\[model_providers\.codex-router\]/);
     assert.match(configured, /wire_api = "responses"/);
-    assert.match(configured, /supports_standalone_web_search = true/);
+    assert.doesNotMatch(configured, /supports_standalone_web_search\s*=/);
     assert.ok(
       configured.includes(
         `openai_base_url = "http://127.0.0.1:46192/_codex-router/${CALLER_KEY}/v1"`,
@@ -175,12 +162,7 @@ approval_policy = "never"
         .length,
       1,
     );
-    assert.equal(
-      (readFileSync(configPath, "utf8").match(
-        /# BEGIN codex-router-standalone-web-search-managed/g,
-      ) || []).length,
-      1,
-    );
+    assert.doesNotMatch(readFileSync(configPath, "utf8"), /standalone_web_search\s*=/);
 
     const disabled = run("disable", codexHome);
     assert.equal(disabled.mode, "native");
@@ -227,20 +209,35 @@ apps = true
   }
 });
 
-test("config manager skips standalone web search on unsupported Codex builds", () => {
+test("config manager removes only router-owned standalone web search state", () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-config-"));
   const configPath = path.join(codexHome, "config.toml");
   writeFileSync(
     configPath,
-    'model = "gpt-5.6-sol"\nmodel_provider = "openai"\n',
+    `model = "gpt-5.6-sol"
+model_provider = "openai"
+
+# BEGIN codex-router-standalone-web-search-managed
+standalone_web_search = true
+# END codex-router-standalone-web-search-managed
+
+# BEGIN codex-router-provider-managed
+[model_providers.codex-router]
+name = "Codex Router (external models)"
+base_url = "http://127.0.0.1:46192/_codex-router/${CALLER_KEY}/v1"
+wire_api = "responses"
+supports_standalone_web_search = true
+# END codex-router-provider-managed
+`,
     { mode: 0o600 },
   );
 
   try {
-    run("enable", codexHome, undefined, [], { CODEX_BIN: standaloneRejectingCodex });
+    run("enable", codexHome);
     const configured = readFileSync(configPath, "utf8");
     assert.doesNotMatch(configured, /codex-router-standalone-web-search-managed/);
-    assert.doesNotMatch(configured, /^standalone_web_search = true$/m);
+    assert.doesNotMatch(configured, /^standalone_web_search\s*=/m);
+    assert.doesNotMatch(configured, /^supports_standalone_web_search\s*=/m);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }
@@ -970,7 +967,7 @@ Authorization = "Bearer PROVIDER_HEADER_SECRET"
     assert.match(configured, new RegExp(`base_url = "http://127\\.0\\.0\\.1:46192/_codex-router/${CALLER_KEY}/v1"`));
     assert.match(configured, /requires_openai_auth = true/);
     assert.match(configured, /supports_websockets = false/);
-    assert.match(configured, /supports_standalone_web_search = true/);
+    assert.doesNotMatch(configured, /supports_standalone_web_search\s*=/);
     assert.doesNotMatch(configured, /PROVIDER_(?:QUERY|AUTH|HEADER)_SECRET/);
     assert.doesNotMatch(
       configured,

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -128,7 +128,7 @@ approval_policy = "never"
     assert.doesNotMatch(configured, /\[agents\]/);
     assert.match(configured, /\[model_providers\.codex-router\]/);
     assert.match(configured, /wire_api = "responses"/);
-    assert.doesNotMatch(configured, /supports_standalone_web_search\s*=/);
+    assert.match(configured, /^supports_standalone_web_search = true$/m);
     assert.ok(
       configured.includes(
         `openai_base_url = "http://127.0.0.1:46192/_codex-router/${CALLER_KEY}/v1"`,
@@ -162,7 +162,7 @@ approval_policy = "never"
         .length,
       1,
     );
-    assert.doesNotMatch(readFileSync(configPath, "utf8"), /standalone_web_search\s*=/);
+    assert.doesNotMatch(readFileSync(configPath, "utf8"), /^standalone_web_search\s*=/m);
 
     const disabled = run("disable", codexHome);
     assert.equal(disabled.mode, "native");
@@ -237,7 +237,7 @@ supports_standalone_web_search = true
     const configured = readFileSync(configPath, "utf8");
     assert.doesNotMatch(configured, /codex-router-standalone-web-search-managed/);
     assert.doesNotMatch(configured, /^standalone_web_search\s*=/m);
-    assert.doesNotMatch(configured, /^supports_standalone_web_search\s*=/m);
+    assert.match(configured, /^supports_standalone_web_search = true$/m);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }
@@ -967,7 +967,7 @@ Authorization = "Bearer PROVIDER_HEADER_SECRET"
     assert.match(configured, new RegExp(`base_url = "http://127\\.0\\.0\\.1:46192/_codex-router/${CALLER_KEY}/v1"`));
     assert.match(configured, /requires_openai_auth = true/);
     assert.match(configured, /supports_websockets = false/);
-    assert.doesNotMatch(configured, /supports_standalone_web_search\s*=/);
+    assert.match(configured, /^supports_standalone_web_search = true$/m);
     assert.doesNotMatch(configured, /PROVIDER_(?:QUERY|AUTH|HEADER)_SECRET/);
     assert.doesNotMatch(
       configured,

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -1291,6 +1291,48 @@ test("router sends standalone web search only to the native OpenAI backend", asy
   }
 });
 
+test("native web search fails closed without a ChatGPT session", async () => {
+  let nativeRequests = 0;
+  const native = await mockServer(async (request, response) => {
+    nativeRequests += 1;
+    await bodyJson(request);
+    json(response, 200, { output: "unexpected native response" });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_NATIVE_SESSION_FALLBACK: "0",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/alpha/search?source=codex`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${CALLER_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "deepseek/deepseek-v4-flash",
+        commands: { search_query: [{ q: "OpenAI news" }] },
+      }),
+    });
+    assert.equal(response.status, 401);
+    assert.deepEqual(await response.json(), {
+      error: {
+        type: "native_session_required",
+        message: "This native OpenAI route requires an active ChatGPT/Codex session.",
+      },
+    });
+    assert.equal(nativeRequests, 0);
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+  }
+});
+
 test("router synthesizes routed compaction and safely replays it to native models", async () => {
   const gatewayRequests = [];
   const finalContract = JSON.stringify({


### PR DESCRIPTION
## Summary

Expose Codex standalone web search only for verified model/provider routes.

## Reason

A global Codex flag and provider-wide capability advertised search for every routed model and could send requests to OpenAI's native search endpoint without a ChatGPT session.

## Changes

- Removed router-managed global `standalone_web_search` and provider-wide `supports_standalone_web_search` settings.
- Kept standalone search as an explicit per-model registry/catalog capability.
- Preserved user-owned config and legacy cleanup without schema probing.
- Added a fail-closed native endpoint guard: native search/image requests require an active caller or shared ChatGPT/Codex session before any upstream request.
- Added regression coverage for config ownership, model capability scoping, and unauthenticated native search.

## Validation

- `npm run check`
- `node --test test/config-manager.test.mjs test/registry.test.mjs test/catalog.test.mjs` (129 passed)
- `node --test --test-name-pattern='native web search fails closed|router sends standalone web search' test/routing.test.mjs` (2 passed)
- `git diff --check`

## Remaining risks

The full routing file still has an unrelated pre-existing pending-handle interruption after 82 passing tests; the targeted standalone-search tests pass. End-to-end provider verification remains limited to the already verified routes in the registry.

