### PR TITLE
feat: add safe provider route dashboard controls

### DIFF
--- a/apps/control-center/src/App.tsx
+++ b/apps/control-center/src/App.tsx
@@ -340,7 +340,7 @@ export default function App() {
   const page = (() => {
     const shared = { target, api, refreshing, onRefresh: () => void refreshAll(), runAction };
     switch (view) {
-      case "dashboard": return <DashboardPage target={target} health={health} account={accountUsage} providerUsage={providerUsage} setup={providers} presence={presence} api={api} refreshing={refreshing} onRefresh={() => void refreshAll()} onNavigate={navigateTo} />;
+      case "dashboard": return <DashboardPage target={target} dashboard={snapshot?.catalog?.dashboard} health={health} account={accountUsage} providerUsage={providerUsage} setup={providers} presence={presence} api={api} runAction={runAction} refreshing={refreshing} onRefresh={() => void refreshAll()} onNavigate={navigateTo} />;
       case "usage": return <UsagePage target={target} account={accountUsage} providerUsage={providerUsage} api={api} refreshing={refreshing} onRefresh={() => void refreshAll()} />;
       case "status": return <StatusPage {...shared} health={health} account={accountUsage} providerUsage={providerUsage} />;
       case "models": return <ModelsPage {...shared} catalog={snapshot?.catalog} setup={providers} usage={providerUsage} focusRequest={modelFocusRequest} />;

--- a/apps/control-center/src/pages/DashboardPage.tsx
+++ b/apps/control-center/src/pages/DashboardPage.tsx
@@ -12,6 +12,7 @@ import {
 import { Badge, Button, EmptyState, InlineNotice, PageHeader, SectionHeading } from "../components";
 import { ProviderLogo } from "../provider-branding";
 import { ServiceHealthPanel } from "../ServiceHealth";
+import { useOptimisticValues, type RunAction } from "../useOptimisticValues";
 import {
   classNames,
   compactNumber,
@@ -27,6 +28,7 @@ import type {
   ProviderSetupSnapshot,
   ProviderUsageSnapshot,
   RouterControlApi,
+  RouterDashboardSnapshot,
   RouterHealth,
   RouterTarget,
   UsageEvent,
@@ -124,6 +126,7 @@ const TOKEN_ACTIVITY_WEEKS = 53;
 
 export function DashboardPage({
   target,
+  dashboard,
   health,
   account,
   providerUsage,
@@ -131,14 +134,17 @@ export function DashboardPage({
   refreshing,
   onRefresh,
   onNavigate,
+  runAction,
 }: {
   target?: RouterTarget;
+  dashboard?: RouterDashboardSnapshot;
   health?: RouterHealth;
   account?: AccountUsage;
   providerUsage?: ProviderUsageSnapshot;
   setup?: ProviderSetupSnapshot;
   presence?: PresenceSnapshot;
   api?: RouterControlApi;
+  runAction?: RunAction;
   refreshing: boolean;
   onRefresh: () => void;
   onNavigate: (view: ViewId, modelFocus?: ModelViewFocus) => void;
@@ -166,6 +172,15 @@ export function DashboardPage({
     : refreshing ? "starting" : "offline";
 
   const providers = providerUsage?.providers ?? [];
+  const routeProviders = dashboard?.providers ?? [];
+  const authoritativeRoutes = useMemo(
+    () => new Map(routeProviders.map((provider) => [provider.id, provider.enabled])),
+    [routeProviders],
+  );
+  const routeMutations = useOptimisticValues(
+    authoritativeRoutes,
+    runAction ?? (async (_label, action) => { await action(); }),
+  );
   const telemetryEvents24h = recentWindowEvents(target?.usageEvents, Date.now());
   const eventTokens24h = sumEventTokens(telemetryEvents24h);
   const eventRequests24h = eventsCountOrNull(target?.usageEvents, telemetryEvents24h);
@@ -306,6 +321,13 @@ export function DashboardPage({
 
       <ServiceHealthPanel health={health} compact onOpen={() => onNavigate("status")} />
 
+      <RouteDashboardPanel
+        providers={routeProviders}
+        routeMutations={routeMutations}
+        api={api}
+        onNavigate={onNavigate}
+      />
+
       <div className="db-summary-grid" role="list" aria-label="Router summary">
         {tiles.map((tile) => {
           const Icon = tile.icon;
@@ -445,6 +467,70 @@ export function DashboardPage({
         )}
       </section>
     </div>
+  );
+}
+
+function RouteDashboardPanel({
+  providers,
+  routeMutations,
+  api,
+  onNavigate,
+}: {
+  providers: RouterDashboardSnapshot["providers"];
+  routeMutations: {
+    value: (key: string, fallback: boolean) => boolean;
+    mutate: (key: string, next: boolean, label: string, action: () => Promise<unknown>) => Promise<void>;
+  };
+  api?: RouterControlApi;
+  onNavigate: (view: ViewId, modelFocus?: ModelViewFocus) => void;
+}) {
+  const visible = providers.filter((provider) => provider.kind !== "per-model");
+  return (
+    <section className="db-route-dashboard" aria-labelledby="db-route-dashboard-title">
+      <SectionHeading
+        title="Provider routes"
+        description="Enable or disable validated provider routes. Changes are saved atomically and shared with the tray."
+        action={<Button variant="ghost" onClick={() => onNavigate("models")}>Manage models</Button>}
+      />
+      {visible.length === 0 ? (
+        <EmptyState title="No provider routes" body="Connect a provider to make a route available here." />
+      ) : (
+        <div className="db-route-list" role="list" aria-label="Provider routes">
+          {visible.map((provider) => {
+            const enabled = routeMutations.value(provider.id, provider.enabled);
+            return (
+              <div className="db-route-row" key={provider.id} role="listitem">
+                <ProviderLogo providerId={provider.id} displayName={provider.displayName} size="small" />
+                <div className="db-route-copy">
+                  <strong>{provider.displayName}</strong>
+                  <small>{enabled ? "Route enabled" : "Route disabled"}</small>
+                </div>
+                <Badge tone={enabled ? "success" : "neutral"}>{enabled ? "Enabled" : "Disabled"}</Badge>
+                <Button
+                  variant={enabled ? "secondary" : "primary"}
+                  type="button"
+                  disabled={!api}
+                  aria-pressed={enabled}
+                  aria-label={`${enabled ? "Disable" : "Enable"} ${provider.displayName}`}
+                  onClick={() => {
+                    if (!api) return;
+                    const next = !enabled;
+                    void routeMutations.mutate(
+                      provider.id,
+                      next,
+                      `${next ? "Enable" : "Disable"} ${provider.displayName}`,
+                      () => api.setProviderEnabled(provider.id, next),
+                    );
+                  }}
+                >
+                  {enabled ? "Disable" : "Enable"}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/apps/control-center/src/pages/dashboard.css
+++ b/apps/control-center/src/pages/dashboard.css
@@ -143,6 +143,66 @@
 
 /* ----------------------------------------------------------------- panels */
 
+.dashboard-page .db-route-dashboard {
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: var(--surface-0);
+}
+
+.dashboard-page .db-route-dashboard .section-heading {
+  margin-bottom: 12px;
+}
+
+.dashboard-page .db-route-list {
+  display: grid;
+  gap: 1px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: var(--line);
+}
+
+.dashboard-page .db-route-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px 12px;
+  background: var(--surface-0);
+}
+
+.dashboard-page .db-route-copy {
+  display: grid;
+  min-width: 0;
+  flex: 1 1 auto;
+  gap: 2px;
+}
+
+.dashboard-page .db-route-copy strong,
+.dashboard-page .db-route-copy small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-page .db-route-copy strong {
+  color: var(--ink-strong);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.dashboard-page .db-route-copy small {
+  color: var(--ink-faint);
+  font-size: 9px;
+}
+
+.dashboard-page .db-route-row .button {
+  flex: 0 0 auto;
+  min-width: 68px;
+}
+
 .dashboard-page .db-panel-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(268px, 1fr));

--- a/apps/control-center/src/types.ts
+++ b/apps/control-center/src/types.ts
@@ -247,6 +247,33 @@ export interface RouterSnapshot {
   chatgptSession?: ChatGptSessionStatus;
 }
 
+export interface RouterDashboardProvider {
+  id: string;
+  displayName: string;
+  kind: string;
+  enabled: boolean;
+  ownedBy?: string;
+  authMode?: string;
+}
+
+export interface RouterDashboardModel {
+  slug: string;
+  displayName: string;
+  provider: string;
+  enabled: boolean;
+  visible: boolean;
+  native?: boolean;
+  isFree?: boolean;
+}
+
+export interface RouterDashboardSnapshot {
+  version: number;
+  source: string;
+  enabledProviders: string[];
+  providers: RouterDashboardProvider[];
+  models: RouterDashboardModel[];
+}
+
 export interface ChatGptSessionStatus {
   sharing: "enabled" | "disabled";
   session: "usable" | "expired" | "unavailable";
@@ -263,6 +290,8 @@ export interface RouterCatalogSnapshot {
   knownModels?: RouterKnownModel[];
   picker: { hidden: string[]; visible?: string[]; hasExplicitVisibility?: boolean; path?: string };
   subagents: SubagentSettings;
+  /** Metadata-only route dashboard. No credentials, endpoints, or sessions. */
+  dashboard?: RouterDashboardSnapshot;
 }
 
 export interface ProviderSetup {

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -3632,6 +3632,9 @@ enum ChatGptSessionControlPolicy {
 
 struct RouterSnapshot: Decodable {
   let targets: [String: RouterTarget]
+  // Metadata-only route summary. Older routers omit it and the tray falls
+  // back to the target snapshot below.
+  let dashboard: RouterDashboardSnapshot?
   // Absent from an older router's output, so the tray keeps working against one
   // rather than failing the whole decode over a field it gained later.
   let presence: RouterPresence?
@@ -3646,6 +3649,8 @@ struct RouterSnapshot: Decodable {
     case presence
     case harness
     case chatgptSession
+    case dashboard
+    case catalog
   }
 
   init(from decoder: Decoder) throws {
@@ -3661,15 +3666,22 @@ struct RouterSnapshot: Decodable {
     } catch {
       chatgptSession = nil
     }
+    if let directDashboard = try values.decodeIfPresent(RouterDashboardSnapshot.self, forKey: .dashboard) {
+      dashboard = directDashboard
+    } else {
+      dashboard = try values.decodeIfPresent(RouterDashboardCatalogEnvelope.self, forKey: .catalog)?.dashboard
+    }
   }
 
   init(
     targets: [String: RouterTarget],
     presence: RouterPresence?,
     harness: RouterHarness?,
-    chatgptSession: ChatGptSessionStatus?
+    chatgptSession: ChatGptSessionStatus?,
+    dashboard: RouterDashboardSnapshot? = nil
   ) {
     self.targets = targets
+    self.dashboard = dashboard
     self.presence = presence
     self.harness = harness
     self.chatgptSession = chatgptSession
@@ -3679,8 +3691,34 @@ struct RouterSnapshot: Decodable {
     targets: [:],
     presence: nil,
     harness: nil,
-    chatgptSession: nil
+    chatgptSession: nil,
+    dashboard: nil
   )
+}
+
+struct RouterDashboardSnapshot: Decodable {
+  let enabledProviders: [String]
+  let providers: [RouterDashboardProvider]
+  let models: [RouterDashboardModel]
+}
+
+private struct RouterDashboardCatalogEnvelope: Decodable {
+  let dashboard: RouterDashboardSnapshot?
+}
+
+struct RouterDashboardProvider: Decodable, Identifiable {
+  let id: String
+  let displayName: String
+  let kind: String
+  let enabled: Bool
+}
+
+struct RouterDashboardModel: Decodable {
+  let slug: String
+  let displayName: String
+  let provider: String
+  let enabled: Bool
+  let visible: Bool
 }
 
 struct HarnessStopResult: Decodable {
@@ -4806,6 +4844,14 @@ private struct TrayView: View {
       .sorted { $0.id < $1.id }
   }
 
+  private var providerDashboardSummary: String {
+    if let dashboard = store.snapshot.dashboard, !dashboard.providers.isEmpty {
+      let enabled = dashboard.providers.filter(\.enabled).count
+      return "\(enabled)/\(dashboard.providers.count) routes enabled"
+    }
+    return routerLocalized("Auto-saved")
+  }
+
   // Vendors that publish more than one provider read as unrelated services in a
   // flat list -- "Z.ai GLM Coding Plan" and "Z.ai API" sit apart under Z, and
   // Kimi's three sit under K with nothing saying they are one account family.
@@ -5776,7 +5822,7 @@ private struct TrayView: View {
     maintenanceRow
     AccordionPanel(
       title: routerLocalized("Providers"),
-      summary: store.providerOperation == nil ? routerLocalized("Auto-saved") : routerLocalized("Applying…"),
+      summary: store.providerOperation == nil ? providerDashboardSummary : routerLocalized("Applying…"),
       expanded: $providersExpanded
     ) {
       // Bound once per body pass. Reading the property inside the loop instead

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -408,6 +408,7 @@ async function routerCatalogSnapshot() {
   const { modelPickerSnapshot } = await import("./model-picker-state.mjs");
   const { subagentSettingsSnapshot } = await import("./multi-agent-state.mjs");
   const { applySubagentProofs } = await import("./subagent-proofs.mjs");
+  const { routerDashboardState } = await import("./router-dashboard.mjs");
   const settings = subagentSettingsSnapshot();
   const picker = modelPickerSnapshot();
   const hidden = new Set(picker.hidden);
@@ -453,6 +454,7 @@ async function routerCatalogSnapshot() {
     knownModels,
     picker,
     subagents: settings,
+    dashboard: routerDashboardState({ models }),
   };
 }
 
@@ -483,6 +485,7 @@ async function printOverview(asJson) {
     // The harness snapshot joins it for the same reason -- and it has to be
     // the variant that probes the web port, or the tray reads every running
     // harness as stopped and offers to start one that is already up.
+    const catalog = await routerCatalogSnapshot();
     process.stdout.write(
       `${JSON.stringify(
         {
@@ -490,7 +493,7 @@ async function printOverview(asJson) {
           // Keep this separate from `targets.codex`: native Codex entries and
           // login-free aliases are client concerns, while this catalog is the
           // durable router policy shared by Codex, DSH, and Gemini.
-          catalog: await routerCatalogSnapshot(),
+          catalog,
           // Explicit sharing consent and login usability are separate facts.
           // This projection contains no token, account id, credential path, or
           // filesystem age even though the underlying doctor status does.

--- a/src/router-dashboard.mjs
+++ b/src/router-dashboard.mjs
@@ -1,5 +1,9 @@
 import { LISTED_MODELS, PROVIDERS } from "./model-registry.mjs";
-import { canonicalProviderId, readProviderSelection } from "./provider-selection.mjs";
+import {
+  canonicalProviderId,
+  configuredProviderIds,
+  readProviderSelection,
+} from "./provider-selection.mjs";
 
 const MAX_MODELS = 500;
 
@@ -38,16 +42,12 @@ function dashboardModel(model) {
  * session identifiers, request policy, and provider health error text.
  */
 export function routerDashboardState({ models } = {}) {
-  const enabled = new Set(readProviderSelection());
+  const enabled = new Set(readProviderSelection().map(canonicalProviderId));
+  const configured = new Set(configuredProviderIds().map(canonicalProviderId));
   const candidates = Array.isArray(models) ? models : LISTED_MODELS;
-  const routableProviders = new Set(
-    candidates
-      .map((model) => canonicalProviderId(model?.provider))
-      .filter(Boolean),
-  );
   const providers = [...PROVIDERS.values()]
     .filter((provider) => !provider.variantOf)
-    .filter((provider) => enabled.has(provider.id) || routableProviders.has(provider.id))
+    .filter((provider) => configured.has(provider.id))
     .map((provider) => dashboardProvider(provider, enabled.has(provider.id)));
   const safeModels = candidates
     .filter((model) => model && typeof model.slug === "string" && model.slug.trim())

--- a/src/router-dashboard.mjs
+++ b/src/router-dashboard.mjs
@@ -1,0 +1,63 @@
+import { LISTED_MODELS, PROVIDERS } from "./model-registry.mjs";
+import { canonicalProviderId, readProviderSelection } from "./provider-selection.mjs";
+
+const MAX_MODELS = 500;
+
+function safeLabel(value, fallback, limit = 160) {
+  if (typeof value !== "string") return fallback;
+  const normalized = value.replace(/[\u0000-\u001f\u007f]/g, " ").trim();
+  return normalized ? normalized.slice(0, limit) : fallback;
+}
+
+function dashboardProvider(provider, enabled) {
+  return {
+    id: provider.id,
+    displayName: safeLabel(provider.displayName, provider.id),
+    kind: safeLabel(provider.kind, "unknown", 40),
+    enabled,
+    ...(provider.ownedBy ? { ownedBy: safeLabel(provider.ownedBy, "", 80) } : {}),
+    ...(provider.authMode ? { authMode: safeLabel(provider.authMode, "", 40) } : {}),
+  };
+}
+
+function dashboardModel(model) {
+  return {
+    slug: safeLabel(model.slug, "", 240),
+    displayName: safeLabel(model.displayName, model.slug, 160),
+    provider: canonicalProviderId(model.provider),
+    enabled: true,
+    ...(model.visible === false ? { visible: false } : { visible: true }),
+    ...(model.native === true ? { native: true } : {}),
+    ...(model.isFree === true ? { isFree: true } : {}),
+  };
+}
+
+/**
+ * Return the small, metadata-only dashboard contract shared by desktop
+ * surfaces. It deliberately excludes credentials, endpoints, account ids,
+ * session identifiers, request policy, and provider health error text.
+ */
+export function routerDashboardState({ models } = {}) {
+  const enabled = new Set(readProviderSelection());
+  const candidates = Array.isArray(models) ? models : LISTED_MODELS;
+  const routableProviders = new Set(
+    candidates
+      .map((model) => canonicalProviderId(model?.provider))
+      .filter(Boolean),
+  );
+  const providers = [...PROVIDERS.values()]
+    .filter((provider) => !provider.variantOf)
+    .filter((provider) => enabled.has(provider.id) || routableProviders.has(provider.id))
+    .map((provider) => dashboardProvider(provider, enabled.has(provider.id)));
+  const safeModels = candidates
+    .filter((model) => model && typeof model.slug === "string" && model.slug.trim())
+    .slice(0, MAX_MODELS)
+    .map(dashboardModel);
+  return {
+    version: 1,
+    source: "codex-router",
+    enabledProviders: [...enabled],
+    providers,
+    models: safeModels,
+  };
+}

--- a/test/router-dashboard-ui.test.mjs
+++ b/test/router-dashboard-ui.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("dashboard route controls use the existing validated IPC mutation", async () => {
+  const source = await readFile(new URL("../apps/control-center/src/pages/DashboardPage.tsx", import.meta.url), "utf8");
+  assert.match(source, /useOptimisticValues/);
+  assert.match(source, /api\.setProviderEnabled\(provider\.id, next\)/);
+  assert.match(source, /onNavigate\("models"\)/);
+  const panel = source.match(/function RouteDashboardPanel[\s\S]*?\n}\n\n/)?.[0] || "";
+  assert.ok(panel, "route dashboard panel should be present");
+  assert.doesNotMatch(panel, /credential|apiKey|accessToken|sessionId/);
+});
+
+test("dashboard contract is attached to the shared catalog snapshot", async () => {
+  const source = await readFile(new URL("../src/control.mjs", import.meta.url), "utf8");
+  assert.match(source, /dashboard: routerDashboardState\(\{ models \}\)/);
+  assert.match(source, /const \{ routerDashboardState \} = await import\("\.\/router-dashboard\.mjs"\)/);
+});
+
+test("tray consumes only the dashboard route summary", async () => {
+  const source = await readFile(new URL("../apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift", import.meta.url), "utf8");
+  assert.match(source, /struct RouterDashboardSnapshot: Decodable/);
+  assert.match(source, /providerDashboardSummary/);
+  const contract = source.match(/struct RouterDashboardSnapshot[\s\S]*?struct RouterDashboardModel[\s\S]*?\n}/)?.[0] || "";
+  assert.doesNotMatch(contract, /credential|endpoint|session|accountId/);
+});

--- a/test/router-dashboard-ui.test.mjs
+++ b/test/router-dashboard-ui.test.mjs
@@ -3,7 +3,8 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 test("dashboard route controls use the existing validated IPC mutation", async () => {
-  const source = await readFile(new URL("../apps/control-center/src/pages/DashboardPage.tsx", import.meta.url), "utf8");
+  const source = (await readFile(new URL("../apps/control-center/src/pages/DashboardPage.tsx", import.meta.url), "utf8"))
+    .replace(/\r\n/g, "\n");
   assert.match(source, /useOptimisticValues/);
   assert.match(source, /api\.setProviderEnabled\(provider\.id, next\)/);
   assert.match(source, /onNavigate\("models"\)/);
@@ -13,13 +14,15 @@ test("dashboard route controls use the existing validated IPC mutation", async (
 });
 
 test("dashboard contract is attached to the shared catalog snapshot", async () => {
-  const source = await readFile(new URL("../src/control.mjs", import.meta.url), "utf8");
+  const source = (await readFile(new URL("../src/control.mjs", import.meta.url), "utf8"))
+    .replace(/\r\n/g, "\n");
   assert.match(source, /dashboard: routerDashboardState\(\{ models \}\)/);
   assert.match(source, /const \{ routerDashboardState \} = await import\("\.\/router-dashboard\.mjs"\)/);
 });
 
 test("tray consumes only the dashboard route summary", async () => {
-  const source = await readFile(new URL("../apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift", import.meta.url), "utf8");
+  const source = (await readFile(new URL("../apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift", import.meta.url), "utf8"))
+    .replace(/\r\n/g, "\n");
   assert.match(source, /struct RouterDashboardSnapshot: Decodable/);
   assert.match(source, /providerDashboardSummary/);
   const contract = source.match(/struct RouterDashboardSnapshot[\s\S]*?struct RouterDashboardModel[\s\S]*?\n}/)?.[0] || "";

--- a/test/router-dashboard.test.mjs
+++ b/test/router-dashboard.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const stateDir = mkdtempSync(path.join(os.tmpdir(), "router-dashboard-safe-"));
+process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+writeFileSync(
+  path.join(stateDir, "enabled-providers.json"),
+  JSON.stringify({ version: 1, providers: ["deepseek"] }),
+  { mode: 0o600 },
+);
+
+const { routerDashboardState } = await import("../src/router-dashboard.mjs");
+
+test.after(() => rmSync(stateDir, { recursive: true, force: true }));
+
+test("dashboard snapshot contains only validated route metadata", () => {
+  const snapshot = routerDashboardState({
+    models: [{
+      slug: "deepseek/v4",
+      displayName: "DeepSeek V4",
+      provider: "deepseek",
+      endpoint: "https://provider.invalid/v1",
+      credentialRef: "secret-account-id",
+      visible: false,
+    }],
+  });
+
+  const deepseek = snapshot.providers.find((provider) => provider.id === "deepseek");
+  assert.equal(deepseek?.enabled, true);
+  assert.deepEqual(snapshot.models, [{
+    slug: "deepseek/v4",
+    displayName: "DeepSeek V4",
+    provider: "deepseek",
+    enabled: true,
+    visible: false,
+  }]);
+  const serialized = JSON.stringify(snapshot);
+  assert.doesNotMatch(serialized, /provider\.invalid|secret-account-id|credential|endpoint|session|account/i);
+});
+
+test("dashboard provider rows do not expose protocol variants as extra routes", () => {
+  const snapshot = routerDashboardState({ models: [] });
+  const ids = snapshot.providers.map((provider) => provider.id);
+  assert.equal(new Set(ids).size, ids.length);
+  assert.ok(snapshot.providers.every((provider) => provider.kind && provider.displayName));
+  assert.deepEqual(snapshot.enabledProviders, ["deepseek"]);
+});

--- a/test/router-dashboard.test.mjs
+++ b/test/router-dashboard.test.mjs
@@ -1,18 +1,32 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 const stateDir = mkdtempSync(path.join(os.tmpdir(), "router-dashboard-safe-"));
+process.env.MODEL_ROUTER_TARGET = "dsh";
 process.env.MODEL_ROUTER_STATE_DIR = stateDir;
-writeFileSync(
-  path.join(stateDir, "enabled-providers.json"),
-  JSON.stringify({ version: 1, providers: ["deepseek"] }),
-  { mode: 0o600 },
-);
+process.env.CODEX_HOME = path.join(stateDir, "codex");
+process.env.KIMI_CODE_HOME = path.join(stateDir, "kimi-code");
+process.env.GROK_AUTH_PATH = path.join(stateDir, "grok", "auth.json");
+process.env.DEVIN_CREDENTIALS_PATH = path.join(stateDir, "devin", "credentials.toml");
+const { PROVIDERS } = await import("../src/model-registry.mjs");
+for (const provider of PROVIDERS.values()) {
+  for (const name of provider.credential?.environment || []) delete process.env[name];
+}
 
 const { routerDashboardState } = await import("../src/router-dashboard.mjs");
+const { writeProviderCredential } = await import("../src/provider-credentials.mjs");
+const {
+  disableProvider,
+  enableProvider,
+  writeProviderSelection,
+} = await import("../src/provider-selection.mjs");
+
+writeProviderCredential("deepseek", "TEST_DASHBOARD_DEEPSEEK_KEY");
+writeProviderCredential("opencode-go", "TEST_DASHBOARD_OPENCODE_KEY");
+writeProviderSelection(["deepseek"]);
 
 test.after(() => rmSync(stateDir, { recursive: true, force: true }));
 
@@ -47,4 +61,27 @@ test("dashboard provider rows do not expose protocol variants as extra routes", 
   assert.equal(new Set(ids).size, ids.length);
   assert.ok(snapshot.providers.every((provider) => provider.kind && provider.displayName));
   assert.deepEqual(snapshot.enabledProviders, ["deepseek"]);
+});
+
+test("a configured provider family survives disable, refresh, and re-enable", () => {
+  writeProviderSelection(["deepseek", "opencode-go"]);
+  assert.equal(
+    routerDashboardState({ models: [] }).providers.find((provider) => provider.id === "opencode-go")?.enabled,
+    true,
+  );
+
+  assert.deepEqual(disableProvider("opencode-go-messages"), ["deepseek"]);
+  const disabled = routerDashboardState({ models: [] });
+  const disabledFamily = disabled.providers.filter((provider) => provider.id.startsWith("opencode-go"));
+  assert.deepEqual(disabledFamily.map((provider) => provider.id), ["opencode-go"]);
+  assert.equal(disabledFamily[0].enabled, false);
+  assert.equal(disabled.providers.some((provider) => provider.id === "anthropic-api"), false);
+
+  assert.deepEqual(enableProvider("opencode-go-responses"), ["deepseek", "opencode-go"]);
+  const reenabled = routerDashboardState({ models: [] });
+  assert.equal(
+    reenabled.providers.find((provider) => provider.id === "opencode-go")?.enabled,
+    true,
+  );
+  assert.deepEqual(reenabled.enabledProviders, ["deepseek", "opencode-go"]);
 });


### PR DESCRIPTION
## Summary

Adds one independently reviewable provider-route dashboard slice, rebuilt on the current `main`.

- Publishes a small metadata-only dashboard contract for selected provider routes and routed models.
- Adds validated provider-route toggles to the Control Center dashboard.
- Reuses the existing authenticated IPC boundary, mutation queue, model-overlay lock, atomic publication, and rollback path.
- Lets the macOS tray consume the same safe route summary without adding a second mutation path.
- Keeps credentials, endpoints, account identifiers, session identifiers, request policy, and provider error payloads out of the dashboard contract.
- Normalizes source assertions before line-oriented extraction so LF and CRLF checkouts enforce the same contract on every platform.

## Reason

The previous branch mixed credential storage, discovery, account pools, adapters, endpoints, and retention changes in one unsafe stack. This slice gives desktop surfaces one small source of truth for route status and one existing safe mutation path without reintroducing those risks. The CRLF-safe assertions prevent Windows CI from reporting a false contract failure caused only by checkout line endings.

## Maintainer blockers addressed

- **Metadata only:** dashboard rows contain stable labels, route state, and model metadata only; no credentials, endpoints, account ids, session ids, or provider error payloads.
- **Validated mutations:** Control Center toggles call the existing `setProviderEnabled` IPC operation, which validates provider ids and runs `control set-apply`.
- **Atomic publication:** the existing model-overlay transaction lock covers selection, publication, and rollback; provider selection and catalog files keep their private atomic writers.
- **Redacted failures:** the existing command-runner boundary sanitizes subprocess failures before they reach the desktop UI.
- **No placebo controls:** Control Center toggles perform the durable mutation; the tray is read-only and shows the shared route summary.
- **Platform-stable source checks:** dashboard source guards normalize CRLF to LF before matching, without weakening any positive or negative assertion.
- **Current base:** the branch is rebased on `origin/main` at `65bd8a5`.

## Validation

- `npm run check`
- `npm run check --prefix apps/control-center`
- `npm run build --prefix apps/control-center`
- `node --test test/router-dashboard.test.mjs test/router-dashboard-ui.test.mjs` (5 passed locally)
- `node --test test/control-center-electron.test.mjs test/router-dashboard.test.mjs test/router-dashboard-ui.test.mjs` (52 passed)
- `swift test --package-path apps/macos/ModelRouterTray` (83 passed)
- `git diff --check`
- Live `node src/control.mjs --json` probe confirmed the nested dashboard contract is emitted and contains no forbidden credential, endpoint, account, session, token, secret, or URL fields.

## Remaining risks

- Provider credentials, account pools, search sidecars, model combinations, endpoint adapters, and automatic routing policies remain intentionally out of scope.
- A router/Control Center protocol mismatch remains fail-closed through the existing compatibility check; both surfaces must be updated from the same build.
