### PR TITLE
fix: rebuild unusable Python environments

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -167,6 +167,12 @@ case "$(install_step python-deps)" in
     if command -v uv >/dev/null 2>&1; then
       if [ ! -x .venv/bin/python ]; then
         uv venv --python 3.12 .venv
+      elif ! .venv/bin/python -I -c 'import encodings, sys' >/dev/null 2>&1; then
+        # A venv can have a present launcher whose interpreter cannot start
+        # (for example after its temporary Python home was removed). Reusing it
+        # lets uv install packages into a runtime that will never boot.
+        echo "The virtual environment's Python cannot run; recreating the venv."
+        uv venv --clear --python 3.12 .venv
       elif ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
         # A venv whose interpreter home was cleared (macOS wipes /private/tmp,
         # and installers that recorded a temporary Python as the venv home end
@@ -192,8 +198,12 @@ case "$(install_step python-deps)" in
       python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else "Python 3.10 or newer is required.")'
       # Same clearing logic as the uv branch: a venv with a vanished interpreter
       # home must be recreated from scratch instead of installed over.
-      if node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
-        python3 -m venv .venv
+      if node src/install-plan.mjs venv-home-ok >/dev/null 2>&1 &&
+        .venv/bin/python -I -c 'import encodings, sys' >/dev/null 2>&1; then
+        # Keep a healthy venv as-is. Re-running `python3 -m venv` here can
+        # rewrite pyvenv.cfg with a different system Python while preserving
+        # the existing launcher, creating a mixed and unusable environment.
+        :
       else
         echo "The virtual environment's interpreter home is missing; recreating the venv."
         python3 -m venv --clear .venv

--- a/bin/install
+++ b/bin/install
@@ -159,29 +159,38 @@ case "$(install_step node-deps)" in
     ;;
 esac
 
+ensure_uv_venv() {
+  if [ ! -x .venv/bin/python ]; then
+    if [ -e .venv ]; then
+      echo "The virtual environment's Python launcher is missing; recreating the venv."
+      uv venv --clear --python 3.12 .venv
+    else
+      uv venv --python 3.12 .venv
+    fi
+  elif ! .venv/bin/python -I -c 'import encodings, sys' >/dev/null 2>&1; then
+    # A venv can have a present launcher whose interpreter cannot start
+    # (for example after its temporary Python home was removed). Reusing it
+    # lets uv install packages into a runtime that will never boot.
+    echo "The virtual environment's Python cannot run; recreating the venv."
+    uv venv --clear --python 3.12 .venv
+  elif ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
+    # A venv whose interpreter home was cleared (macOS wipes /private/tmp,
+    # and installers that recorded a temporary Python as the venv home end
+    # up with a dangling interpreter) must be recreated, not pip-installed
+    # into: the launcher may still exist while pyvenv.cfg points at a
+    # vanished home.
+    echo "The virtual environment's interpreter home is missing; recreating the venv."
+    uv venv --clear --python 3.12 .venv
+  fi
+}
+
 case "$(install_step python-deps)" in
   managed) echo "Homebrew manages LiteLLM; skipping Python dependency installation." ;;
   skip) echo "LiteLLM already matches the pinned versions; skipping the Python install." ;;
   *)
     packaged_dependency_refusal "LiteLLM"
     if command -v uv >/dev/null 2>&1; then
-      if [ ! -x .venv/bin/python ]; then
-        uv venv --python 3.12 .venv
-      elif ! .venv/bin/python -I -c 'import encodings, sys' >/dev/null 2>&1; then
-        # A venv can have a present launcher whose interpreter cannot start
-        # (for example after its temporary Python home was removed). Reusing it
-        # lets uv install packages into a runtime that will never boot.
-        echo "The virtual environment's Python cannot run; recreating the venv."
-        uv venv --clear --python 3.12 .venv
-      elif ! node src/install-plan.mjs venv-home-ok >/dev/null 2>&1; then
-        # A venv whose interpreter home was cleared (macOS wipes /private/tmp,
-        # and installers that recorded a temporary Python as the venv home end
-        # up with a dangling interpreter) must be recreated, not pip-installed
-        # into: the launcher may still exist while pyvenv.cfg points at a
-        # vanished home.
-        echo "The virtual environment's interpreter home is missing; recreating the venv."
-        uv venv --clear --python 3.12 .venv
-      fi
+      ensure_uv_venv
       # requirements/python.txt is the hash-verified transitive closure of the
       # pins in src/install-plan.mjs. Hash checking makes every wheel and sdist
       # in that tree verify against the lock before it is executed; without it

--- a/install.ps1
+++ b/install.ps1
@@ -314,10 +314,15 @@ try {
     Write-Host "LiteLLM already matches the pinned versions; skipping the Python install."
   } elseif (Get-Command "uv" -ErrorAction SilentlyContinue) {
     $VenvHomeOk = (& node src/install-plan.mjs venv-home-ok 2>$null | Select-Object -Last 1) -eq "ok"
+    $VenvRuntimeOk = $false
+    if (Test-Path $Python) {
+      & $Python -I -c "import encodings, sys" 2>$null | Out-Null
+      $VenvRuntimeOk = $LASTEXITCODE -eq 0
+    }
     if (-not (Test-Path $Python)) {
       & uv venv --python 3.12 .venv
       if ($LASTEXITCODE -ne 0) { throw "uv could not create the Python environment." }
-    } elseif (-not $VenvHomeOk) {
+    } elseif (-not $VenvHomeOk -or -not $VenvRuntimeOk) {
       # A venv whose interpreter home was cleared (macOS wipes /private/tmp,
       # and installers that recorded a temporary Python as the venv home end
       # up with a dangling interpreter) must be recreated, not pip-installed
@@ -338,7 +343,12 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "Recording the Python dependency state failed." }
   } else {
     $VenvHomeOk = (& node src/install-plan.mjs venv-home-ok 2>$null | Select-Object -Last 1) -eq "ok"
-    $RecreateVenv = -not $VenvHomeOk
+    $VenvRuntimeOk = $false
+    if (Test-Path $Python) {
+      & $Python -I -c "import encodings, sys" 2>$null | Out-Null
+      $VenvRuntimeOk = $LASTEXITCODE -eq 0
+    }
+    $RecreateVenv = -not $VenvHomeOk -or -not $VenvRuntimeOk
     if (Get-Command "py" -ErrorAction SilentlyContinue) {
       & py -3 -c "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)"
       if ($LASTEXITCODE -ne 0) { throw "Python 3.10 or newer is required." }

--- a/install.ps1
+++ b/install.ps1
@@ -316,11 +316,20 @@ try {
     $VenvHomeOk = (& node src/install-plan.mjs venv-home-ok 2>$null | Select-Object -Last 1) -eq "ok"
     $VenvRuntimeOk = $false
     if (Test-Path $Python) {
-      & $Python -I -c "import encodings, sys" 2>$null | Out-Null
-      $VenvRuntimeOk = $LASTEXITCODE -eq 0
+      try {
+        & $Python -I -c "import encodings, sys" 2>$null | Out-Null
+        $VenvRuntimeOk = $LASTEXITCODE -eq 0
+      } catch {
+        $VenvRuntimeOk = $false
+      }
     }
     if (-not (Test-Path $Python)) {
-      & uv venv --python 3.12 .venv
+      if (Test-Path ".venv") {
+        Write-Host "The virtual environment's Python launcher is missing; recreating the venv."
+        & uv venv --clear --python 3.12 .venv
+      } else {
+        & uv venv --python 3.12 .venv
+      }
       if ($LASTEXITCODE -ne 0) { throw "uv could not create the Python environment." }
     } elseif (-not $VenvHomeOk -or -not $VenvRuntimeOk) {
       # A venv whose interpreter home was cleared (macOS wipes /private/tmp,
@@ -345,8 +354,12 @@ try {
     $VenvHomeOk = (& node src/install-plan.mjs venv-home-ok 2>$null | Select-Object -Last 1) -eq "ok"
     $VenvRuntimeOk = $false
     if (Test-Path $Python) {
-      & $Python -I -c "import encodings, sys" 2>$null | Out-Null
-      $VenvRuntimeOk = $LASTEXITCODE -eq 0
+      try {
+        & $Python -I -c "import encodings, sys" 2>$null | Out-Null
+        $VenvRuntimeOk = $LASTEXITCODE -eq 0
+      } catch {
+        $VenvRuntimeOk = $false
+      }
     }
     $RecreateVenv = -not $VenvHomeOk -or -not $VenvRuntimeOk
     if (Get-Command "py" -ErrorAction SilentlyContinue) {

--- a/src/install-plan.mjs
+++ b/src/install-plan.mjs
@@ -18,6 +18,7 @@ import {
   readTraySupervisionPreference,
   traySupervisionPreferencePath,
 } from "./tray-supervision-preference.mjs";
+import { venvRuntimeProblem } from "./venv-runtime.mjs";
 
 export const SOURCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -374,13 +375,18 @@ export const STEPS = {
           readFile(repoPath(root, PYTHON_LOCK)) ?? "",
         ].join("\0"),
       ),
-    installed: (root, platform) => {
+    installed: (root, platform, { runtimeProblem = venvRuntimeProblem } = {}) => {
       // A venv whose interpreter home was cleared (macOS wipes /private/tmp,
       // and installers that recorded a temporary Python as the venv home end
       // up with a dangling interpreter) must read as "not installed" so the
       // next install/update rebuilds it instead of skipping a broken venv.
       if (!venvPythonHomeUsable(root)) return false;
-      if (!existsSync(venvPython(root, platform))) return false;
+      const python = venvPython(root, platform);
+      if (!existsSync(python)) return false;
+      // A launcher can remain after its stdlib or recorded interpreter home
+      // has disappeared. Use the same startup probe as doctor/start so an
+      // update repairs a venv that exists on disk but cannot execute Python.
+      if (runtimeProblem(python)) return false;
       return PYTHON_REQUIREMENTS.every((requirement) => {
         const { name, version } = requirementParts(requirement);
         return installedDistributionVersion(name, { root, platform }) === version;
@@ -460,10 +466,17 @@ export function recordTrayBuild({
   return target;
 }
 
-export function stepStatus(step, { root = SOURCE_ROOT, platform = process.platform } = {}) {
+export function stepStatus(
+  step,
+  {
+    root = SOURCE_ROOT,
+    platform = process.platform,
+    runtimeProblem = venvRuntimeProblem,
+  } = {},
+) {
   const definition = STEPS[step];
   if (!definition) throw new Error(`Unknown install step: ${step}`);
-  if (!definition.installed(root, platform)) return "run";
+  if (!definition.installed(root, platform, { runtimeProblem })) return "run";
   const stamp = readFile(definition.stamp(root));
   if (!stamp) return "run";
   try {

--- a/src/venv-runtime.mjs
+++ b/src/venv-runtime.mjs
@@ -14,16 +14,21 @@ export function venvRuntimeProblem(
 ) {
   const options = {
     encoding: "utf8",
-    stdio: ["ignore", "pipe", "ignore"],
+    stdio: ["ignore", "pipe", "pipe"],
   };
 
   // A spawnSync timeout means Windows never finished scheduling the child; it
   // is not evidence that the interpreter or its venv is damaged. Retry once
   // with a wider hard bound before reporting a condition that can be transient
   // under process-launch contention.
-  let probe = spawn(python, ["--version"], { ...options, timeout: timeoutMs });
+  // `--version` is handled before CPython initializes its standard library,
+  // so it can succeed even when the venv cannot import `encodings` and every
+  // real invocation fails. Isolated mode also keeps an operator's PYTHONHOME
+  // or PYTHONPATH from making a healthy managed environment look damaged.
+  const probeArgs = ["-I", "-c", "import encodings, sys; print(sys.prefix)"];
+  let probe = spawn(python, probeArgs, { ...options, timeout: timeoutMs });
   if (probe.error?.code === "ETIMEDOUT") {
-    probe = spawn(python, ["--version"], { ...options, timeout: retryTimeoutMs });
+    probe = spawn(python, probeArgs, { ...options, timeout: retryTimeoutMs });
   }
   if (probe.error) {
     return probe.error.code === "ETIMEDOUT"

--- a/test/install-plan.test.mjs
+++ b/test/install-plan.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -35,12 +35,33 @@ const PINNED_VERSIONS = Object.fromEntries(
     return [name, version];
   }),
 );
+const TEST_PLATFORM = process.platform === "win32" ? "win32" : "darwin";
+const healthyRuntime = () => undefined;
+
+function sitePackages(root) {
+  return TEST_PLATFORM === "win32"
+    ? path.join(root, ".venv", "Lib", "site-packages")
+    : path.join(root, ".venv", "lib", "python3.12", "site-packages");
+}
 
 function installVenv(root, versions = PINNED_VERSIONS) {
-  const site = path.join(root, ".venv", "lib", "python3.12", "site-packages");
+  const site = sitePackages(root);
   mkdirSync(site, { recursive: true });
-  mkdirSync(path.join(root, ".venv", "bin"), { recursive: true });
-  writeFileSync(path.join(root, ".venv", "bin", "python"), "");
+  const pythonBin = TEST_PLATFORM === "win32" ? "Scripts" : "bin";
+  const pythonName = TEST_PLATFORM === "win32" ? "python.exe" : "python";
+  mkdirSync(path.join(root, ".venv", pythonBin), { recursive: true });
+  // A copied macOS Node binary loses its adjacent libnode dylib. Use a
+  // wrapper instead of a symlink: the broken-runtime test deliberately
+  // rewrites this fixture, and writing through a symlink would overwrite the
+  // real Node executable that is running the test suite.
+  const python = path.join(root, ".venv", pythonBin, pythonName);
+  if (TEST_PLATFORM === "win32") {
+    copyFileSync(process.execPath, python);
+  } else {
+    const quotedExecPath = `'${process.execPath.replaceAll("'", "'\\''")}'`;
+    writeFileSync(python, `#!/bin/sh\nexec ${quotedExecPath} "$@"\n`, "utf8");
+    chmodSync(python, 0o755);
+  }
   writeFileSync(path.join(root, ".venv", "pyvenv.cfg"), "version_info = 3.12\n");
   for (const [name, version] of Object.entries(versions)) {
     mkdirSync(path.join(site, `${name}-${version}.dist-info`), { recursive: true });
@@ -50,8 +71,8 @@ function installVenv(root, versions = PINNED_VERSIONS) {
 test("a missing installation always runs its step", () => {
   const root = checkout();
   try {
-    assert.equal(stepStatus("node-deps", { root, platform: "darwin" }), "run");
-    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+    assert.equal(stepStatus("node-deps", { root, platform: TEST_PLATFORM }), "run");
+    assert.equal(stepStatus("python-deps", { root, platform: TEST_PLATFORM }), "run");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -65,11 +86,18 @@ test("recorded steps are skipped until their inputs change", () => {
     recordStep("node-deps", { root });
     recordStep("python-deps", { root });
 
-    assert.equal(stepStatus("node-deps", { root, platform: "darwin" }), "skip");
-    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "skip");
+    assert.equal(stepStatus("node-deps", { root, platform: TEST_PLATFORM }), "skip");
+    assert.equal(
+      stepStatus("python-deps", {
+        root,
+        platform: TEST_PLATFORM,
+        runtimeProblem: healthyRuntime,
+      }),
+      "skip",
+    );
 
     writeFileSync(path.join(root, "package-lock.json"), '{"lockfileVersion":3,"x":1}\n');
-    assert.equal(stepStatus("node-deps", { root, platform: "darwin" }), "run");
+    assert.equal(stepStatus("node-deps", { root, platform: TEST_PLATFORM }), "run");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -86,20 +114,20 @@ test("a stamp cannot vouch for dependencies that are no longer installed", () =>
     // A drifted transitive upgrade that downgraded a pinned distribution must
     // reinstall even though the stamp still matches the pins.
     rmSync(
-      path.join(
-        root,
-        ".venv",
-        "lib",
-        "python3.12",
-        "site-packages",
-        `litellm-${PINNED_VERSIONS.litellm}.dist-info`,
-      ),
+      path.join(sitePackages(root), `litellm-${PINNED_VERSIONS.litellm}.dist-info`),
       { recursive: true, force: true },
     );
-    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+    assert.equal(
+      stepStatus("python-deps", {
+        root,
+        platform: TEST_PLATFORM,
+        runtimeProblem: healthyRuntime,
+      }),
+      "run",
+    );
 
     rmSync(path.join(root, "node_modules", ".package-lock.json"), { force: true });
-    assert.equal(stepStatus("node-deps", { root, platform: "darwin" }), "run");
+    assert.equal(stepStatus("node-deps", { root, platform: TEST_PLATFORM }), "run");
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -111,7 +139,14 @@ test("a rebuilt virtual environment on another Python reinstalls", () => {
     installVenv(root);
     recordStep("python-deps", { root });
     writeFileSync(path.join(root, ".venv", "pyvenv.cfg"), "version = 3.13.1\n");
-    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+    assert.equal(
+      stepStatus("python-deps", {
+        root,
+        platform: TEST_PLATFORM,
+        runtimeProblem: healthyRuntime,
+      }),
+      "run",
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -129,7 +164,42 @@ test("a virtual environment whose interpreter home was cleared reinstalls", () =
       path.join(root, ".venv", "pyvenv.cfg"),
       "home = /private/tmp/codex-router-python-bin\nversion = 3.12.12\n",
     );
-    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+    assert.equal(
+      stepStatus("python-deps", {
+        root,
+        platform: TEST_PLATFORM,
+        runtimeProblem: healthyRuntime,
+      }),
+      "run",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a venv launcher that cannot start Python reinstalls", () => {
+  const root = checkout();
+  try {
+    installVenv(root);
+    recordStep("python-deps", { root });
+    let probed;
+    const runtimeProblem = (python) => {
+      probed = python;
+      return "No module named encodings";
+    };
+    assert.equal(
+      stepStatus("python-deps", { root, platform: TEST_PLATFORM, runtimeProblem }),
+      "run",
+    );
+    assert.equal(
+      probed,
+      path.join(
+        root,
+        ".venv",
+        TEST_PLATFORM === "win32" ? "Scripts" : "bin",
+        TEST_PLATFORM === "win32" ? "python.exe" : "python",
+      ),
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }
@@ -141,10 +211,10 @@ test("distribution lookup normalizes names and ignores extras", () => {
     installVenv(root, { litellm: "1.95.0", "litellm_proxy_extras": "0.4.81" });
     assert.equal(requirementParts("litellm[proxy]==1.95.0").name, "litellm");
     assert.equal(
-      installedDistributionVersion("litellm-proxy-extras", { root, platform: "darwin" }),
+      installedDistributionVersion("litellm-proxy-extras", { root, platform: TEST_PLATFORM }),
       "0.4.81",
     );
-    assert.equal(installedDistributionVersion("absent", { root, platform: "darwin" }), undefined);
+    assert.equal(installedDistributionVersion("absent", { root, platform: TEST_PLATFORM }), undefined);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -307,9 +307,12 @@ test("broken virtual environments use the venv tools' exact-target clear mode", 
   assert.doesNotMatch(posix, /rm\s+-rf\s+\.venv/);
   assert.match(posix, /uv venv --clear --python 3\.12 \.venv/);
   assert.match(posix, /python3 -m venv --clear \.venv/);
+  assert.match(posix, /\.venv\/bin\/python -I -c 'import encodings, sys'/);
   assert.doesNotMatch(windows, /Remove-Item\s+-Recurse.*\.venv/);
   assert.match(windows, /uv venv --clear --python 3\.12 \.venv/);
   assert.match(windows, /-m venv --clear \.venv/);
+  assert.match(windows, /\$Python -I -c "import encodings, sys"/);
+  assert.match(windows, /-not \$VenvHomeOk -or -not \$VenvRuntimeOk/);
 });
 
 test("the kept-update message names the way back", () => {

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -114,6 +114,15 @@ function runPosixHelper(call, args, options = {}) {
   return result.stdout;
 }
 
+function posixVenvHelper() {
+  const source = readScript("bin", "install");
+  const start = source.indexOf("ensure_uv_venv() {");
+  assert.notEqual(start, -1, "bin/install must define ensure_uv_venv");
+  const end = source.indexOf("\n}\n", start);
+  assert.notEqual(end, -1, "ensure_uv_venv must be a complete function");
+  return source.slice(start, end + 3);
+}
+
 test("install.sh is valid POSIX shell", { skip: !POSIX_SHELL_AVAILABLE }, () => {
   const result = spawnSync("sh", ["-n", path.join(root, "install.sh")], {
     encoding: "utf8",
@@ -314,6 +323,35 @@ test("broken virtual environments use the venv tools' exact-target clear mode", 
   assert.match(windows, /\$Python -I -c "import encodings, sys"/);
   assert.match(windows, /-not \$VenvHomeOk -or -not \$VenvRuntimeOk/);
 });
+
+test(
+  "a present venv with no Python launcher is cleared before uv recreates it",
+  { skip: !POSIX_SHELL_AVAILABLE },
+  () => {
+    const fixture = mkdtempSync(path.join(os.tmpdir(), "codex-router-missing-python-"));
+    const bin = path.join(fixture, "bin");
+    const calls = path.join(fixture, "uv-calls");
+    try {
+      mkdirSync(path.join(fixture, ".venv"), { recursive: true });
+      mkdirSync(bin, { recursive: true });
+      writeFileSync(
+        path.join(bin, "uv"),
+        `#!/bin/sh\nprintf '%s\\n' "$*" >>${JSON.stringify(calls)}\n`,
+        { mode: 0o755 },
+      );
+      const result = spawnSync("sh", ["-s"], {
+        cwd: fixture,
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${bin}:${process.env.PATH || ""}` },
+        input: `${posixVenvHelper()}\nensure_uv_venv\n`,
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(readFileSync(calls, "utf8"), "venv --clear --python 3.12 .venv\n");
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  },
+);
 
 test("the kept-update message names the way back", () => {
   // Keeping the update on exit 2 is the right default, but a user who wanted

--- a/test/packaged-install.test.mjs
+++ b/test/packaged-install.test.mjs
@@ -98,10 +98,23 @@ function fakeSourceRoot() {
   const venvPython = path.join(venvBin, "python");
   const liteLlm = path.join(venvBin, "litellm");
   if (process.platform === "win32") {
-    // doctor probes the bundled interpreter with `--version`. A copy of the
-    // current Node executable is a small, real Windows executable that answers
-    // that probe successfully; a text file named `.exe` is not spawnable.
-    copyFileSync(process.execPath, `${venvPython}.exe`);
+    // The health probe intentionally initializes Python's stdlib, so a copied
+    // Node executable is no longer a truthful fixture. Windows CI images ship
+    // Python; link the first launcher that passes the exact production probe.
+    const python = ["python.exe", "py.exe"]
+      .flatMap((command) => {
+        const found = spawnSync("where.exe", [command], { encoding: "utf8" });
+        return found.status === 0 ? found.stdout.split(/\r?\n/).filter(Boolean) : [];
+      })
+      .find((candidate) =>
+        spawnSync(
+          candidate,
+          ["-I", "-c", "import encodings, sys; print(sys.prefix)"],
+          { encoding: "utf8" },
+        ).status === 0
+      );
+    assert.ok(python, "Windows test host needs a runnable Python launcher");
+    symlinkSync(python, `${venvPython}.exe`, "file");
     copyFileSync(process.execPath, `${liteLlm}.exe`);
   } else {
     writeFileSync(venvPython, "#!/bin/sh\nexit 0\n");

--- a/test/python-lock.test.mjs
+++ b/test/python-lock.test.mjs
@@ -5,7 +5,15 @@
 // this work — its pin drifted twelve minor versions behind main and nothing
 // noticed.
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -151,13 +159,25 @@ test("the lock workflow is gated on every input that can invalidate the lock", (
 test("a regenerated lock reinstalls even when the pins are unchanged", () => {
   const root = mkdtempSync(path.join(tmpdir(), "python-lock-"));
   try {
+    const platform = process.platform === "win32" ? "win32" : "darwin";
     mkdirSync(path.join(root, "requirements"), { recursive: true });
     const lock = path.join(root, "requirements", "python.txt");
     writeFileSync(lock, lockText());
-    const site = path.join(root, ".venv", "lib", "python3.12", "site-packages");
+    const site = platform === "win32"
+      ? path.join(root, ".venv", "Lib", "site-packages")
+      : path.join(root, ".venv", "lib", "python3.12", "site-packages");
     mkdirSync(site, { recursive: true });
-    mkdirSync(path.join(root, ".venv", "bin"), { recursive: true });
-    writeFileSync(path.join(root, ".venv", "bin", "python"), "");
+    const pythonDirectory = platform === "win32" ? "Scripts" : "bin";
+    const pythonName = platform === "win32" ? "python.exe" : "python";
+    const python = path.join(root, ".venv", pythonDirectory, pythonName);
+    mkdirSync(path.dirname(python), { recursive: true });
+    if (platform === "win32") {
+      copyFileSync(process.execPath, python);
+    } else {
+      const quotedExecPath = `'${process.execPath.replaceAll("'", "'\\''")}'`;
+      writeFileSync(python, `#!/bin/sh\nexec ${quotedExecPath} "$@"\n`, "utf8");
+      chmodSync(python, 0o755);
+    }
     writeFileSync(path.join(root, ".venv", "pyvenv.cfg"), "version_info = 3.12\n");
     for (const requirement of PYTHON_REQUIREMENTS) {
       const [specifier, version] = requirement.split("==");
@@ -166,13 +186,19 @@ test("a regenerated lock reinstalls even when the pins are unchanged", () => {
     }
 
     recordStep("python-deps", { root });
-    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "skip");
+    assert.equal(
+      stepStatus("python-deps", { root, platform, runtimeProblem: () => undefined }),
+      "skip",
+    );
 
     // A transitive-only bump leaves PYTHON_REQUIREMENTS untouched. Without the
     // lock in the fingerprint the installer would report "already matches" and
     // never apply it.
     writeFileSync(lock, `${lockText()}\n# transitive bump\n`);
-    assert.equal(stepStatus("python-deps", { root, platform: "darwin" }), "run");
+    assert.equal(
+      stepStatus("python-deps", { root, platform, runtimeProblem: () => undefined }),
+      "run",
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/test/venv-runtime.test.mjs
+++ b/test/venv-runtime.test.mjs
@@ -3,11 +3,34 @@ import test from "node:test";
 
 import { venvRuntimeProblem } from "../src/venv-runtime.mjs";
 
-// process.execPath is the current Node binary: present on every platform
-// (Windows runners have no /usr/bin/true), and `--version` exits 0 with
-// stdout, so it is a portable "working interpreter".
+// The injected success keeps this test platform-independent while the probe
+// arguments below verify that production forces real Python initialization.
 test("a working interpreter has no runtime problem", () => {
-  assert.equal(venvRuntimeProblem(process.execPath, { timeoutMs: 5_000 }), undefined);
+  const calls = [];
+  const spawn = (python, args) => {
+    calls.push({ python, args });
+    return { error: undefined, status: 0, stderr: "", stdout: "/venv\n" };
+  };
+  assert.equal(venvRuntimeProblem("python", { spawn, timeoutMs: 5_000 }), undefined);
+  assert.deepEqual(calls, [
+    {
+      python: "python",
+      args: ["-I", "-c", "import encodings, sys; print(sys.prefix)"],
+    },
+  ]);
+});
+
+test("the probe catches a runtime whose version command would still succeed", () => {
+  const spawn = (_python, args) => {
+    assert.notDeepEqual(args, ["--version"]);
+    return {
+      error: undefined,
+      status: 1,
+      stderr: "Fatal Python error: init_fs_encoding: No module named 'encodings'\n",
+      stdout: "",
+    };
+  };
+  assert.match(venvRuntimeProblem("python", { spawn }), /encodings/);
 });
 
 test("a transient interpreter timeout is retried with a wider hard bound", () => {


### PR DESCRIPTION
Supersedes #400 with the reviewed repair rebased onto current `main`.

The installer now verifies that a managed Python launcher can initialize its standard library before reusing the virtual environment. Broken launchers are rebuilt in both POSIX and Windows installer branches, while healthy environments stay intact.

This also fixes the Windows site-packages fixture and uses a real Python runtime in packaged-install tests, so the validation exercises Python rather than a renamed Node executable.

Validation:
- `node --test test/packaged-install.test.mjs test/install-plan.test.mjs test/python-lock.test.mjs test/venv-runtime.test.mjs test/installer-scripts.test.mjs` — 65 passed, 1 platform skip
- `npm run check`
- `git diff --check origin/main...HEAD`

Closes #400 after merge.