### PR TITLE
perf: phase-lock the macOS thinking orb at 20 fps

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/ThinkingOrbCanvas.swift
+++ b/apps/macos/ModelRouterTray/Sources/ThinkingOrbCanvas.swift
@@ -436,6 +436,35 @@ final class ThinkingOrbRenderer {
   }
 }
 
+struct ThinkingOrbRedrawCadence {
+  let interval: TimeInterval
+  private(set) var nextDeadline: TimeInterval?
+
+  init(framesPerSecond: Double = 20) {
+    precondition(framesPerSecond > 0)
+    interval = 1.0 / framesPerSecond
+  }
+
+  mutating func reset() {
+    nextDeadline = nil
+  }
+
+  mutating func shouldSchedule(at now: TimeInterval) -> Bool {
+    guard let deadline = nextDeadline else {
+      nextDeadline = now + interval
+      return true
+    }
+    // Display-link timestamps can land a few ulps below an exact deadline.
+    guard now + interval * 1e-9 >= deadline else { return false }
+
+    // Advance from the ideal phase rather than from this callback. Advancing
+    // from `now` quantizes 20 fps to 16–18 fps on common 60/120/144 Hz panels.
+    let missedIntervals = max(0, floor((now - deadline) / interval))
+    nextDeadline = deadline + (missedIntervals + 1) * interval
+    return true
+  }
+}
+
 final class ThinkingOrbNSView: NSView {
   private let renderer: ThinkingOrbRenderer
   private var displayLink: CVDisplayLink?
@@ -443,6 +472,13 @@ final class ThinkingOrbNSView: NSView {
   private var running = false
   private let redrawLock = NSLock()
   private var redrawScheduled = false
+  private var redrawCadence = ThinkingOrbRedrawCadence()
+  /// The orb animates on wall-clock time, so redraw rate only affects smoothness,
+  /// not speed. The display link fires at the panel's refresh rate (120 Hz on
+  /// ProMotion), and each fire repaints an 18 pt status-bar view and commits it
+  /// to WindowServer — measured at over 15% of a core while a model is thinking.
+  /// The cadence limits main-thread redraw and WindowServer commit work. The
+  /// display link still wakes at the panel refresh rate.
   private var mode: ThinkingOrbMode = .shaping
   var reduceMotion = false {
     didSet {
@@ -511,6 +547,9 @@ final class ThinkingOrbNSView: NSView {
     var link: CVDisplayLink?
     CVDisplayLinkCreateWithActiveCGDisplays(&link)
     guard let link else { return }
+    redrawLock.lock()
+    redrawCadence.reset()
+    redrawLock.unlock()
     displayLink = link
     let unmanaged = Unmanaged.passUnretained(self)
     CVDisplayLinkSetOutputCallback(
@@ -531,11 +570,15 @@ final class ThinkingOrbNSView: NSView {
       CVDisplayLinkStop(displayLink)
       self.displayLink = nil
     }
+    redrawLock.lock()
+    redrawCadence.reset()
+    redrawLock.unlock()
   }
 
   private func scheduleRedraw() {
     redrawLock.lock()
-    guard !redrawScheduled else {
+    let now = CACurrentMediaTime()
+    guard !redrawScheduled, redrawCadence.shouldSchedule(at: now) else {
       redrawLock.unlock()
       return
     }

--- a/apps/macos/ModelRouterTray/Tests/ThinkingOrbCadenceTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ThinkingOrbCadenceTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+@testable import ModelRouterTray
+
+@Suite("Thinking orb redraw cadence")
+struct ThinkingOrbCadenceTests {
+  @Test("common display refresh rates preserve a 20 fps phase", arguments: [60.0, 120.0, 144.0])
+  func commonRefreshRates(refreshRate: Double) {
+    var cadence = ThinkingOrbRedrawCadence(framesPerSecond: 20)
+    let frameInterval = 1.0 / refreshRate
+    var scheduled: [TimeInterval] = []
+
+    for frame in 0...Int(refreshRate * 2) {
+      let now = Double(frame) * frameInterval
+      if cadence.shouldSchedule(at: now) { scheduled.append(now) }
+    }
+
+    #expect(scheduled.count == 41)
+    let elapsed = scheduled.last! - scheduled.first!
+    let observedRate = Double(scheduled.count - 1) / elapsed
+    #expect(abs(observedRate - 20) < 0.2)
+
+    for (index, actual) in scheduled.enumerated() {
+      let ideal = Double(index) / 20.0
+      #expect(actual + 1e-9 >= ideal)
+      #expect(actual - ideal <= frameInterval + 1e-9)
+    }
+  }
+
+  @Test("reset permits the first frame immediately")
+  func resetStartsImmediately() {
+    var cadence = ThinkingOrbRedrawCadence(framesPerSecond: 20)
+    let first = cadence.shouldSchedule(at: 10)
+    let early = cadence.shouldSchedule(at: 10.01)
+    #expect(first)
+    #expect(!early)
+
+    cadence.reset()
+
+    let afterReset = cadence.shouldSchedule(at: 10.01)
+    #expect(afterReset)
+    #expect(cadence.nextDeadline == 10.06)
+  }
+}


### PR DESCRIPTION
Supersedes #418 with a phase-preserving redraw scheduler.

The original callback-local timestamp throttle quantized 20 fps down to roughly 16–18 fps on common 60/120/144 Hz displays. This version advances an ideal deadline, coalesces outstanding main-thread redraws, resets cadence with the display-link lifecycle, and limits its performance claim to the work actually avoided.

Validation:
- `swift test --package-path apps/macos/ModelRouterTray` (83 tests)
- cadence coverage at 60, 120, and 144 Hz
- `git diff --check`