### PR TITLE
docs: update Devin probe instructions for main

### DIFF
--- a/docs/DEVIN-CLI-PROBE.md
+++ b/docs/DEVIN-CLI-PROBE.md
@@ -48,24 +48,11 @@ You also need Node.js 22.19 or newer (`node --version`).
 ```sh
 git clone https://github.com/duolahypercho/codex-router
 cd codex-router
-git fetch origin feat/devin-cli-provider feat/issue-270-devin-probe-hardening
-git checkout feat/devin-cli-provider
-git merge --no-edit origin/feat/issue-270-devin-probe-hardening
 npm install
 
 ./bin/devin-probe                  # free
 ./bin/devin-probe --live --tools   # one short turn of ACU credit
 ```
-
-If the merge reports a conflict in `src/devin-cli-probe.mjs`, take this
-branch's version and continue — it is the newer probe:
-
-```sh
-git checkout --theirs src/devin-cli-probe.mjs && git add src/devin-cli-probe.mjs && git commit --no-edit
-```
-
-Once both branches have landed on `main`, the two `git fetch`/`git merge` lines
-above are unnecessary; a plain checkout of `main` is enough.
 
 Add `--model <uid>` to test a specific model from the list the free run printed.
 `--json` prints the same checklist as machine-readable JSON.

--- a/src/devin-cli-probe.mjs
+++ b/src/devin-cli-probe.mjs
@@ -549,7 +549,7 @@ export async function runProbe(argv = [], { provider: injected, fetchImpl = fetc
   if (provider.missing) {
     report.fail("devin provider sources", `${provider.missing} is not present in this checkout`, {
       observed: truncateForReport(provider.reason, 160),
-      fix: "The provider lands with PR #271: `git fetch origin feat/devin-cli-provider && git checkout feat/devin-cli-provider`, then merge this branch on top. See docs/DEVIN-CLI-PROBE.md.",
+      fix: "The provider sources ship on main. Update or reclone the repository, run `npm install`, and retry. See docs/DEVIN-CLI-PROBE.md.",
     });
   } else if (!report.failed) {
     const context = await runFreeStage(report, provider, args, fetchImpl);

--- a/test/devin-cli-probe.test.mjs
+++ b/test/devin-cli-probe.test.mjs
@@ -476,26 +476,26 @@ test("--json prints the same verdict as the text form", async () => {
   assert.equal(code, 0);
 });
 
-test("a missing provider module is named, with the branch that carries it", async () => {
+test("a missing provider module points to the current main checkout", async () => {
   const absent = { missing: "./devin-proto.mjs", reason: "Cannot find module './devin-proto.mjs'" };
   const { code, checks, output } = await probe([], absent, async () => assert.fail("nothing should be sent"));
   const check = checkOf(checks, "devin provider sources");
   assert.equal(check.status, "fail");
   assert.match(check.detail, /devin-proto\.mjs is not present/);
-  assert.match(check.fix, /feat\/devin-cli-provider/);
+  assert.match(check.fix, /ship on main/);
+  assert.match(check.fix, /npm install/);
   assert.match(output, /VERDICT FAIL/);
   assert.equal(code, 1);
 });
 
-test("with nothing injected the probe resolves the real modules, on either branch", async () => {
-  // The provider's sources are absent on main and present on the Devin CLI
-  // branch. Both are legitimate; what must never happen is an unhandled module
-  // resolution error, so this asserts the probe reached one outcome or the other.
+test("with nothing injected the probe resolves the real modules from main", async () => {
+  // What must never happen is an unhandled module resolution error, so this
+  // asserts the probe reached a named outcome even in an incomplete checkout.
   const { checks } = await probe([], undefined, async () => {
     throw new Error("the network is not reachable from a test");
   });
   const missing = checkOf(checks, "devin provider sources");
-  if (missing) assert.match(missing.fix, /feat\/devin-cli-provider/);
+  if (missing) assert.match(missing.fix, /ship on main/);
   else assert.ok(checks.some((check) => check.name === "devin cli session"), "the probe should have gone on to read the session");
 });
 
@@ -509,6 +509,7 @@ test("the tester guide names the probe, the paid flag, and the cap the probe act
   assert.match(guide, /`--live` is the only flag that spends anything/);
   assert.match(guide, new RegExp(`default ${DEFAULT_MAX_TOKENS}`));
   assert.match(guide, /issues\/270/);
+  assert.doesNotMatch(guide, /feat\/devin/);
 });
 
 test("every failure the checks can emit is explained in the guide", () => {


### PR DESCRIPTION
Issue #270 still needs a real Devin-account live probe, but its tester guide points at two deleted feature branches and therefore cannot be followed.

This updates the guide and missing-module diagnostics to use the provider and probe sources already shipped on `main`, and adds a regression assertion that deleted feature-branch commands do not return.

Validation: `node --test test/devin-cli-probe.test.mjs test/devin-probe-checks.test.mjs test/probe-report.test.mjs` (69 passed).