### PR TITLE
fix(windows): verify live launcher in service status

### DIFF
--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -28,6 +28,7 @@ import {
   skipServiceManagerCall,
   assertServiceWriteIsolated,
 } from "./service-write-guard.mjs";
+import { windowsScheduledTaskState } from "./windows-task-state.mjs";
 
 // Only this platform's own module can reach this machine's Task Scheduler.
 // Cross-platform render tests execute this module on POSIX with executable
@@ -405,6 +406,23 @@ function taskState() {
   return undefined;
 }
 
+async function taskRunning(state) {
+  if (state === "running") return true;
+  // Task Scheduler can answer Ready while its detached launcher is still
+  // serving. Reuse the process-level probe that guards startup readiness, but
+  // keep an unavailable query inconclusive so a restricted shell cannot turn
+  // an idle task into a false running service.
+  const corroborated = await windowsScheduledTaskState({
+    taskName,
+    platform: effectivePlatform,
+    timeoutMs: TASK_STATE_TIMEOUT_MS,
+  });
+  return (
+    corroborated?.launcherAlive === true ||
+    (corroborated?.launcherAlive === undefined && corroborated?.instanceCount > 0)
+  );
+}
+
 if (
   !new Set([
     "install",
@@ -487,15 +505,18 @@ if (command === "render") {
 } else if (command === "status") {
   let installed = false;
   let state = "stopped";
+  let loaded = false;
   try {
     schtasks(["/Query", "/TN", taskName, "/FO", "LIST", "/V"]);
     installed = true;
     state = taskState() || "ready";
+    loaded = await taskRunning(state);
+    if (loaded) state = "running";
   } catch {
     // Missing task.
   }
   process.stdout.write(
-    `${JSON.stringify({ installed, loaded: state === "running", state })}\n`,
+    `${JSON.stringify({ installed, loaded, state })}\n`,
   );
 } else if (command === "stop") {
   // Stopping is idempotent, like uninstall and restart: a task that is missing

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -417,10 +417,10 @@ async function taskRunning(state) {
     platform: effectivePlatform,
     timeoutMs: TASK_STATE_TIMEOUT_MS,
   });
-  return (
-    corroborated?.launcherAlive === true ||
-    (corroborated?.launcherAlive === undefined && corroborated?.instanceCount > 0)
-  );
+  // Neither signal is sufficient alone: COM instances can outlive their
+  // process, while the machine-wide launcher scan can also see a manually
+  // started router. Only their conjunction corroborates this task.
+  return corroborated?.instanceCount > 0 && corroborated?.launcherAlive === true;
 }
 
 if (

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -517,7 +517,13 @@ test(
 // They can never shadow the real executables, because the tests that use them
 // are skipped on win32.
 function schedulerStubs(directory, options = {}) {
-  const { schtasksFail = "", powershellFail = "", runningQueries = 0 } = options;
+  const {
+    schtasksFail = "",
+    powershellFail = "",
+    runningQueries = 0,
+    authoritativeState = "0|0|0",
+    authoritativeFail = false,
+  } = options;
   mkdirSync(directory, { recursive: true });
   const logPath = path.join(directory, "calls.log");
   const counterPath = path.join(directory, "state-queries");
@@ -539,6 +545,11 @@ function schedulerStubs(directory, options = {}) {
     [
       preamble(powershellFail),
       'case "$*" in',
+      "  *Schedule.Service*)",
+      authoritativeFail
+        ? "    exit 1"
+        : `    printf '%s' ${JSON.stringify(authoritativeState)}`,
+      "    ;;",
       "  *Get-ScheduledTask*)",
       "    count=0",
       `    if [ -f "${counterPath}" ]; then count=$(cat "${counterPath}"); fi`,
@@ -576,6 +587,102 @@ function runWindowsService(testRoot, command, extraEnv = {}) {
     },
   );
 }
+
+test(
+  "Windows status trusts a live launcher when Task Scheduler reports Ready",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-status-live-"));
+    try {
+      const stubs = schedulerStubs(path.join(testRoot, "scheduler"), {
+        authoritativeState: "1|267009|1",
+      });
+      const result = runWindowsService(testRoot, "status", { PATH: stubs.path });
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), {
+        installed: true,
+        loaded: true,
+        state: "running",
+      });
+      assert.equal(stubs.calls().some((line) => line.includes("Schedule.Service")), true);
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "Windows status keeps Ready when the authoritative launcher is dead",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-status-dead-"));
+    try {
+      const stubs = schedulerStubs(path.join(testRoot, "scheduler"), {
+        authoritativeState: "1|267014|0",
+      });
+      const result = runWindowsService(testRoot, "status", { PATH: stubs.path });
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), {
+        installed: true,
+        loaded: false,
+        state: "ready",
+      });
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "Windows status keeps Ready when authoritative launcher state is inconclusive",
+  { skip: process.platform === "win32" },
+  async (context) => {
+    for (const [name, options] of [
+      ["malformed", { authoritativeState: "not-task-state" }],
+      ["failed", { authoritativeFail: true }],
+    ]) {
+      await context.test(name, () => {
+        const testRoot = mkdtempSync(path.join(os.tmpdir(), `codex-router-win-status-${name}-`));
+        try {
+          const stubs = schedulerStubs(path.join(testRoot, "scheduler"), options);
+          const result = runWindowsService(testRoot, "status", { PATH: stubs.path });
+          assert.equal(result.status, 0, result.stderr);
+          assert.deepEqual(JSON.parse(result.stdout), {
+            installed: true,
+            loaded: false,
+            state: "ready",
+          });
+        } finally {
+          rmSync(testRoot, { recursive: true, force: true });
+        }
+      });
+    }
+  },
+);
+
+test(
+  "Windows status accepts Running without an authoritative fallback query",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-status-running-"));
+    try {
+      const stubs = schedulerStubs(path.join(testRoot, "scheduler"), {
+        runningQueries: 1,
+        authoritativeFail: true,
+      });
+      const result = runWindowsService(testRoot, "status", { PATH: stubs.path });
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), {
+        installed: true,
+        loaded: true,
+        state: "running",
+      });
+      assert.equal(stubs.calls().some((line) => line.includes("Schedule.Service")), false);
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
 
 test(
   "a blocked registration restarts whichever task definition survived",

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -634,6 +634,50 @@ test(
 );
 
 test(
+  "Windows status does not claim an idle task from an external launcher",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-status-external-"));
+    try {
+      const stubs = schedulerStubs(path.join(testRoot, "scheduler"), {
+        authoritativeState: "0|267009|1",
+      });
+      const result = runWindowsService(testRoot, "status", { PATH: stubs.path });
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), {
+        installed: true,
+        loaded: false,
+        state: "ready",
+      });
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "Windows status keeps Ready when launcher evidence is incomplete",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-status-partial-"));
+    try {
+      const stubs = schedulerStubs(path.join(testRoot, "scheduler"), {
+        authoritativeState: "1|267009",
+      });
+      const result = runWindowsService(testRoot, "status", { PATH: stubs.path });
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), {
+        installed: true,
+        loaded: false,
+        state: "ready",
+      });
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
   "Windows status keeps Ready when authoritative launcher state is inconclusive",
   { skip: process.platform === "win32" },
   async (context) => {


### PR DESCRIPTION
Fixes #398.

Task Scheduler can report `Ready` while the detached router launcher is still serving. Startup readiness already uses the process-level `windowsScheduledTaskState()` probe; service `status` now uses the same bounded corroboration only when the scheduler does not report `Running`. A confirmed launcher promotes the effective status to running, while dead, malformed, failed, or unavailable probes preserve the existing not-loaded result. This avoids teaching doctor to restart a healthy managed service without conflating an externally launched router with the managed task.

Validation:
- focused Windows service/readiness/doctor tests: 39 passed, 1 platform skip
- `npm run check`
- `git diff --check`

Native Windows CI is required before merge.