### PR TITLE
Give Linux and Windows the macOS inset Control Center chrome

### DIFF
--- a/apps/control-center/README.md
+++ b/apps/control-center/README.md
@@ -77,9 +77,11 @@ The main window keeps the operating system's native window controls. On macOS,
 the frameless window uses a hidden-inset title bar so native traffic lights sit
 over the content while the sidebar controls and page toolbar share the same top
 row as Codex; the renderer marks that row draggable without recreating the
-controls. Other platforms retain their standard native frame. Close, minimize,
-maximize, keyboard shortcuts, accessibility behavior, and platform-specific
-placement remain native. The Hermes artwork is used consistently for the
+controls. Windows and Linux hide the system title bar the same way so the
+toolbar occupies that row, and the renderer draws macOS-style traffic lights
+on the left. The File/Edit/View application menu is removed on Windows and
+Linux. macOS keeps native traffic lights. Close, minimize, maximize, keyboard
+shortcuts, and accessibility behavior still work. The Hermes artwork is used consistently for the
 Electron window, standalone Dock entry, application bundle, and installer; the
 unified macOS host keeps its separate outer-bundle icon.
 

--- a/apps/control-center/electron/main.mjs
+++ b/apps/control-center/electron/main.mjs
@@ -105,19 +105,18 @@ function createWindow() {
     show: false,
     title: "Codex Router",
     icon: appIconPath(),
-    // Keep the platform-managed traffic lights while the renderer supplies
-    // the draggable toolbar surface. The renderer never recreates
-    // close/minimize/maximize buttons with HTML/CSS.
-    frame: process.platform !== "darwin",
-    // Codex keeps the native macOS traffic lights while letting its toolbar
-    // occupy the titlebar row. Other platforms retain their normal framed
-    // window chrome.
+    // macOS keeps native traffic lights. Windows/Linux are frameless with
+    // no overlay so the renderer can place left-side lights like macOS.
+    frame: false,
     ...(process.platform === "darwin"
       ? {
           titleBarStyle: "hiddenInset",
           trafficLightPosition: { x: 16, y: 16 },
         }
-      : {}),
+      : {
+          titleBarStyle: "hidden",
+          autoHideMenuBar: true,
+        }),
     backgroundColor: "#ffffff",
     webPreferences: {
       preload: path.join(HERE, "preload.cjs"),
@@ -277,6 +276,9 @@ if (primaryInstance && !quitForUpdateInvocation) {
   // lock. The ready bit is raised only after the full Electron boundary is set.
   publishLifecycleState();
   app.whenReady().then(() => {
+    if (process.platform !== "darwin") {
+      Menu.setApplicationMenu(null);
+    }
     if (process.platform === "darwin") {
       if (nativeTrayOwnedByHost) app.dock?.hide();
       else app.dock?.setIcon(appIconPath());

--- a/apps/control-center/src/App.tsx
+++ b/apps/control-center/src/App.tsx
@@ -85,7 +85,7 @@ function initialView(): ViewId {
 
 export default function App() {
   const api = window.routerControl;
-  const nativeTitlebar = api?.platform === "darwin";
+  const nativeTitlebar = Boolean(api);
   const [view, setView] = useState<ViewId>(initialView);
   const [modelFocusRequest, setModelFocusRequest] = useState<ModelViewFocusRequest>();
   const modelFocusSequence = useRef(0);
@@ -352,9 +352,16 @@ export default function App() {
   })();
 
   return (
-    <div className={classNames("app-shell", nativeTitlebar && "native-titlebar", !sidebarOpen && "sidebar-collapsed")}>
+    <div className={classNames("app-shell", nativeTitlebar && "native-titlebar", api && `native-titlebar-${api.platform}`, !sidebarOpen && "sidebar-collapsed")}>
       <aside className="app-sidebar" aria-label="Codex Router sidebar" inert={sidebarSearchOpen ? true : undefined}>
         <header className="sidebar-window-row">
+          {api && api.platform !== "darwin" && sidebarOpen ? (
+            <div className="traffic-lights">
+              <button type="button" className="traffic-light traffic-light-close" aria-label="Close window" onClick={() => void api.closeWindow()} />
+              <button type="button" className="traffic-light traffic-light-minimize" aria-label="Minimize window" onClick={() => void api.minimizeWindow()} />
+              <button type="button" className="traffic-light traffic-light-maximize" aria-label="Maximize or restore window" onClick={() => void api.toggleMaximizeWindow()} />
+            </div>
+          ) : null}
           <button className="sidebar-toggle" type="button" aria-label="Collapse sidebar" onClick={() => setSidebarOpen(false)}><PanelLeftClose aria-hidden size={15} strokeWidth={1.7} /></button>
           <button className="sidebar-toggle" type="button" aria-label="Go back" disabled={historyIndex === 0} onClick={() => moveHistory(-1)}><ArrowLeft aria-hidden size={15} strokeWidth={1.7} /></button>
           <button className="sidebar-toggle" type="button" aria-label="Go forward" disabled={historyIndex >= viewHistory.length - 1} onClick={() => moveHistory(1)}><ArrowRight aria-hidden size={15} strokeWidth={1.7} /></button>
@@ -386,6 +393,13 @@ export default function App() {
 
       <main className="app-main" inert={sidebarSearchOpen ? true : undefined}>
         <div className="titlebar">
+          {api && api.platform !== "darwin" && !sidebarOpen ? (
+            <div className="traffic-lights">
+              <button type="button" className="traffic-light traffic-light-close" aria-label="Close window" onClick={() => void api.closeWindow()} />
+              <button type="button" className="traffic-light traffic-light-minimize" aria-label="Minimize window" onClick={() => void api.minimizeWindow()} />
+              <button type="button" className="traffic-light traffic-light-maximize" aria-label="Maximize or restore window" onClick={() => void api.toggleMaximizeWindow()} />
+            </div>
+          ) : null}
           {!sidebarOpen ? <button className="titlebar-toggle" type="button" aria-label="Expand sidebar" onClick={() => setSidebarOpen(true)}><PanelLeftOpen aria-hidden size={15} strokeWidth={1.7} /></button> : null}
           <div className="title-tabs"><strong>{activeMeta.label}</strong><span>Overview</span></div>
           <div className="titlebar-spacer" />

--- a/apps/control-center/src/styles.css
+++ b/apps/control-center/src/styles.css
@@ -155,9 +155,9 @@ button {
   padding: 6px 8px 2px 13px;
 }
 
-/* Electron's macOS hidden-inset titlebar leaves the native traffic lights in
-   the content surface. Reserve that same leading space for the sidebar
-   controls so the renderer and OS chrome share one toolbar row, like Codex. */
+/* Hidden titlebar chrome leaves native window buttons in the content
+   surface. Reserve that same leading/trailing space so the renderer and OS
+   chrome share one toolbar row, like Codex. */
 .native-titlebar .sidebar-window-row,
 .native-titlebar .titlebar {
   min-height: 44px;
@@ -169,7 +169,6 @@ button {
 .native-titlebar .sidebar-window-row {
   padding-top: 9px;
   padding-bottom: 7px;
-  padding-left: 88px;
   border-bottom: 0;
   background: var(--surface-1);
 }
@@ -179,9 +178,50 @@ button {
   background: var(--surface-0);
 }
 
-.native-titlebar.sidebar-collapsed .titlebar {
+/* macOS hiddenInset traffic lights sit over the sidebar, or the titlebar
+   when the sidebar is collapsed. */
+.native-titlebar-darwin .sidebar-window-row {
   padding-left: 88px;
 }
+
+.native-titlebar-darwin.sidebar-collapsed .titlebar {
+  padding-left: 88px;
+}
+
+/* Windows/Linux draw macOS-style traffic lights on the left. */
+.native-titlebar-win32 .sidebar-window-row,
+.native-titlebar-linux .sidebar-window-row {
+  padding-left: 16px;
+}
+
+.native-titlebar-win32.sidebar-collapsed .titlebar,
+.native-titlebar-linux.sidebar-collapsed .titlebar {
+  padding-left: 16px;
+}
+
+.traffic-lights {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-right: 10px;
+  -webkit-app-region: no-drag;
+}
+
+.traffic-light {
+  width: 12px;
+  height: 12px;
+  border: 0;
+  padding: 0;
+  border-radius: 50%;
+  background: #d0d0d0;
+}
+
+.traffic-light-close { background: #ff5f57; }
+.traffic-light-minimize { background: #febc2e; }
+.traffic-light-maximize { background: #28c840; }
+
+.traffic-light:hover { filter: brightness(0.92); }
+.traffic-light:active { filter: brightness(0.82); }
 
 .sidebar-collapsed .titlebar-toggle {
   position: relative;

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -699,9 +699,12 @@ test("electron boundary does not enable node integration or shell argv", async (
   assert.match(main, /contextIsolation:\s*true/);
   assert.match(main, /nodeIntegration:\s*false/);
   assert.match(main, /sandbox:\s*true/);
-  assert.match(main, /frame:\s*process\.platform\s*!==\s*"darwin"/);
+  assert.match(main, /frame:\s*false/);
   assert.match(main, /titleBarStyle:\s*"hiddenInset"/);
   assert.match(main, /trafficLightPosition:\s*\{\s*x:\s*16,\s*y:\s*16\s*\}/);
+  assert.match(main, /titleBarStyle:\s*"hidden"/);
+  assert.doesNotMatch(main, /titleBarOverlay/);
+  assert.match(main, /setApplicationMenu\(null\)/);
   assert.match(main, /icon:\s*appIconPath\(\)/);
   assert.match(main, /app\.dock\?\.setIcon\(appIconPath\(\)\)/);
   assert.match(main, /setWindowOpenHandler\(\(\) => \(\{ action: "deny" \}\)\)/);
@@ -754,17 +757,17 @@ test("electron boundary does not enable node integration or shell argv", async (
   assert.match(compatibilityMain, /import "\.\/electron\/main\.mjs"/);
   assert.doesNotMatch(compatibilityMain, /BrowserWindow|ipcMain|registerIpcHandlers/);
   const renderer = await readFile(new URL("../apps/control-center/src/App.tsx", import.meta.url), "utf8");
-  assert.doesNotMatch(renderer, /WindowControls|traffic-lights|window-control/);
+  assert.match(renderer, /traffic-lights/);
   assert.match(renderer, /native-titlebar/);
   const styles = await readFile(new URL("../apps/control-center/src/styles.css", import.meta.url), "utf8");
-  assert.doesNotMatch(styles, /traffic-lights|window-control|window-close|window-minimize|window-maximize/);
+  assert.match(styles, /\\.traffic-lights/);
   assert.match(styles, /native-titlebar/);
-  assert.match(styles, /native-titlebar\.sidebar-collapsed \.titlebar[\s\S]*padding-left:\s*88px/);
+  assert.match(styles, /native-titlebar-darwin\.sidebar-collapsed \.titlebar[\s\S]*padding-left:\s*88px/);
   assert.doesNotMatch(renderer, /drag-region|no-drag/);
   assert.match(styles, /-webkit-app-region:\s*drag/);
   assert.match(styles, /-webkit-app-region:\s*no-drag/);
   for (const label of ["Close window", "Minimize window", "Maximize or restore window"]) {
-    assert.doesNotMatch(renderer, new RegExp(`aria-label=\\"${label}\\"`));
+    assert.match(renderer, new RegExp(`aria-label=\\"${label}\\"`));
   }
   const runner = await readFile(new URL("../apps/control-center/electron/command-runner.mjs", import.meta.url), "utf8");
   assert.match(runner, /shell:\s*false/);

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -760,7 +760,7 @@ test("electron boundary does not enable node integration or shell argv", async (
   assert.match(renderer, /traffic-lights/);
   assert.match(renderer, /native-titlebar/);
   const styles = await readFile(new URL("../apps/control-center/src/styles.css", import.meta.url), "utf8");
-  assert.match(styles, /\\.traffic-lights/);
+  assert.match(styles, /\.traffic-lights/);
   assert.match(styles, /native-titlebar/);
   assert.match(styles, /native-titlebar-darwin\.sidebar-collapsed \.titlebar[\s\S]*padding-left:\s*88px/);
   assert.doesNotMatch(renderer, /drag-region|no-drag/);


### PR DESCRIPTION
## Summary
- Linux and Windows Control Center now use a frameless inset toolbar instead of the old File/Edit/View framed window.
- Those platforms draw left-side traffic lights (close / minimize / maximize) on the shared toolbar, matching the macOS look.
- macOS is unchanged: it still uses native `hiddenInset` traffic lights.

## Test plan
- [x] Verified on Linux Electron against the Vite dev server: no menu bar, lights on the left, window still draggable.
- [ ] Spot-check Windows Control Center (same Electron chrome; not run here).
- [ ] Confirm macOS still shows native traffic lights only.
- [ ] `node --test test/control-center-electron.test.mjs`