### PR TITLE
fix(desktop): poll health without spawning processes

### DIFF
--- a/apps/control-center/electron/ipc.mjs
+++ b/apps/control-center/electron/ipc.mjs
@@ -17,6 +17,7 @@ import {
 } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   assertMutationCompatibility,
   discoverSourceRoot,
@@ -473,6 +474,15 @@ async function snapshot() {
   return runControlJson(["--json"]);
 }
 
+async function readInstalledControlHealth({ fetchImpl = globalThis.fetch } = {}) {
+  const modulePath = path.join(discoverSourceRoot(), "src", "control-health.mjs");
+  const module = await import(pathToFileURL(modulePath).href);
+  if (typeof module.readControlHealth !== "function") {
+    throw new Error("The installed router does not expose direct health reads.");
+  }
+  return module.readControlHealth({ fetchImpl });
+}
+
 async function modelEntries() {
   const result = await snapshot();
   const entries = [];
@@ -587,7 +597,14 @@ async function updateProviderSelection(id, enabled) {
   return snapshot();
 }
 
-export function registerIpcHandlers({ ipcMain, BrowserWindow, shell, fetchImpl = globalThis.fetch, senderGuard = () => true } = {}) {
+export function registerIpcHandlers({
+  ipcMain,
+  BrowserWindow,
+  shell,
+  fetchImpl = globalThis.fetch,
+  healthReader = readInstalledControlHealth,
+  senderGuard = () => true,
+} = {}) {
   if (!ipcMain?.handle) throw new TypeError("ipcMain.handle is required.");
   const operations = new Map();
   // Every mutation is a fresh control.mjs process. Keep their read/modify/
@@ -744,10 +761,10 @@ export function registerIpcHandlers({ ipcMain, BrowserWindow, shell, fetchImpl =
     }
     return response;
   }, { requiresCompatibleRouter: false });
-  // The public health leaf deliberately omits per-service payloads. The
-  // control command reads the protected leaf with the local caller capability
-  // and returns only the redacted service summary the UI needs.
-  handle("getHealth", async () => runJson(["health"]));
+  // Read health in this trusted process instead of spawning a fresh
+  // ELECTRON_RUN_AS_NODE child for every one-second renderer poll. The shared
+  // reader owns the caller capability and preserves the CLI's redacted shape.
+  handle("getHealth", async () => healthReader({ fetchImpl }));
   handle("refreshAll", async () => ({
     snapshot: await snapshot(),
     providers: await runJson(["providers"]),

--- a/apps/control-center/src/App.tsx
+++ b/apps/control-center/src/App.tsx
@@ -108,6 +108,7 @@ export default function App() {
   const [toast, setToast] = useState<{ tone: "neutral" | "success" | "danger"; message: string } | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const downloadPollInFlight = useRef(false);
+  const healthPollInFlight = useRef(false);
   const previousActivityState = useRef<string | undefined>(undefined);
 
   const target = snapshot?.targets.codex;
@@ -117,11 +118,14 @@ export default function App() {
   const downloadActive = localDownloadActive || mlxOperationActive || visionDownloadActive;
 
   const refreshHealth = useCallback(async () => {
-    if (!api) return;
+    if (!api || healthPollInFlight.current || document.visibilityState !== "visible") return;
+    healthPollInFlight.current = true;
     try {
       setHealth(await api.getHealth());
     } catch (error) {
       setHealth({ ok: false, error: readableError(error), activity: { state: "offline", active: [], activeCount: 0 } });
+    } finally {
+      healthPollInFlight.current = false;
     }
   }, [api]);
 

--- a/src/control-health.mjs
+++ b/src/control-health.mjs
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+
+import { assertCallerSecret, callerBaseUrl } from "./caller-auth.mjs";
+import { CALLER_SECRET_PATH, PORTS } from "./paths.mjs";
+
+const OFFLINE_ACTIVITY = Object.freeze({ state: "offline", active: [], activeCount: 0 });
+
+function offlineHealth(error) {
+  return {
+    ok: false,
+    status: 0,
+    error,
+    activity: { ...OFFLINE_ACTIVITY },
+  };
+}
+
+function safeService(service) {
+  if (!service || typeof service !== "object") return undefined;
+  return {
+    reachable: service.reachable === true,
+    ...(typeof service.enabled === "boolean" ? { enabled: service.enabled } : {}),
+  };
+}
+
+// Read the protected health leaf and project it to the stable, credential-free
+// contract shared by the CLI, tray, and Electron Control Center. Callers may
+// provide fetch/read seams for deterministic tests; production keeps the
+// capability and its URL inside the trusted Node/Electron main process.
+export async function readControlHealth({
+  fetchImpl = globalThis.fetch,
+  readCallerSecret = () => readFileSync(CALLER_SECRET_PATH, "utf8"),
+  routerPort = PORTS.router,
+  timeoutMs = 3_000,
+} = {}) {
+  let callerSecret;
+  try {
+    callerSecret = assertCallerSecret(readCallerSecret().trim());
+  } catch {
+    return offlineHealth("The local router caller key is unavailable.");
+  }
+
+  try {
+    const response = await fetchImpl(`${callerBaseUrl(routerPort, callerSecret)}/health`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const raw = await response.json().catch(() => ({}));
+    const body = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
+    return {
+      ok: response.ok,
+      status: response.status,
+      ...(typeof body.service === "string" ? { service: body.service } : {}),
+      ...(typeof body.version === "string" ? { version: body.version } : {}),
+      ...(typeof body.router === "string" ? { router: body.router } : {}),
+      ...(Array.isArray(body.degraded) ? { degraded: body.degraded } : {}),
+      ...(body.activity && typeof body.activity === "object" ? { activity: body.activity } : {}),
+      ...(safeService(body.gateway) ? { gateway: safeService(body.gateway) } : {}),
+      ...(safeService(body.oauth) ? { oauth: safeService(body.oauth) } : {}),
+      ...(safeService(body.api) ? { api: safeService(body.api) } : {}),
+      ...(safeService(body.grokOauth) ? { grokOauth: safeService(body.grokOauth) } : {}),
+    };
+  } catch (error) {
+    const timedOut = error?.name === "AbortError" || error?.name === "TimeoutError";
+    return offlineHealth(timedOut ? "Health check timed out." : "Router is unreachable.");
+  }
+}

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { pickerCommandArgs } from "./control-args.mjs";
+import { readControlHealth } from "./control-health.mjs";
 import { nativeSubagentCertification, promoteNativeMultiAgent } from "./catalog.mjs";
 import {
   applyModelOverlayPublication,
@@ -15,10 +16,8 @@ import { withNativeContextVariants } from "./native-context-variants.mjs";
 // vary by target, so reading it here does not disturb the per-target probes
 // below that re-import paths with their own MODEL_ROUTER_TARGET.
 import {
-  CALLER_SECRET_PATH,
   DSH_CATALOG_PATH,
   GEMINI_CATALOG_PATH,
-  PORTS,
   PROVIDER_SELECTION_PATH,
 } from "./paths.mjs";
 // Same reasoning: presence is a property of the shared plane, not of a target,
@@ -2627,55 +2626,7 @@ async function handleChatGptSession(action) {
 // metadata. Read the protected health leaf here, then project it to the small
 // contract the tray and Control Center render.
 async function printHealth() {
-  const { assertCallerSecret, callerBaseUrl } = await import("./caller-auth.mjs");
-  let callerSecret;
-  try {
-    callerSecret = assertCallerSecret(readFileSync(CALLER_SECRET_PATH, "utf8").trim());
-  } catch {
-    process.stdout.write(`${JSON.stringify({
-      ok: false,
-      status: 0,
-      error: "The local router caller key is unavailable.",
-      activity: { state: "offline", active: [], activeCount: 0 },
-    })}\n`);
-    return;
-  }
-
-  const safeService = (service) => {
-    if (!service || typeof service !== "object") return undefined;
-    return {
-      reachable: service.reachable === true,
-      ...(typeof service.enabled === "boolean" ? { enabled: service.enabled } : {}),
-    };
-  };
-  try {
-    const response = await fetch(`${callerBaseUrl(PORTS.router, callerSecret)}/health`, {
-      headers: { Accept: "application/json" },
-      signal: AbortSignal.timeout(3_000),
-    });
-    const raw = await response.json().catch(() => ({}));
-    const body = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
-    process.stdout.write(`${JSON.stringify({
-      ok: response.ok,
-      status: response.status,
-      ...(typeof body.service === "string" ? { service: body.service } : {}),
-      ...(typeof body.version === "string" ? { version: body.version } : {}),
-      ...(typeof body.router === "string" ? { router: body.router } : {}),
-      ...(Array.isArray(body.degraded) ? { degraded: body.degraded } : {}),
-      ...(body.activity && typeof body.activity === "object" ? { activity: body.activity } : {}),
-      ...(safeService(body.gateway) ? { gateway: safeService(body.gateway) } : {}),
-      ...(safeService(body.oauth) ? { oauth: safeService(body.oauth) } : {}),
-      ...(safeService(body.api) ? { api: safeService(body.api) } : {}),
-      ...(safeService(body.grokOauth) ? { grokOauth: safeService(body.grokOauth) } : {}),
-    })}\n`);
-  } catch (error) {
-    process.stdout.write(`${JSON.stringify({
-      ok: false,
-      status: 0,
-      error: error?.name === "AbortError" ? "Health check timed out." : "Router is unreachable.",
-      activity: { state: "offline", active: [], activeCount: 0 },
-    })}\n`);
-  }
+  process.stdout.write(`${JSON.stringify(await readControlHealth())}\n`);
 }
 
 // --- dispatch ---------------------------------------------------------------

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -794,6 +794,8 @@ test("background usage polling is conservative while manual refresh stays immedi
   assert.match(source, /Promise\.allSettled\(\[refreshCore\(\), refreshUsage\(\)\]\)/);
   assert.match(source, /Promise\.allSettled\(\[[\s\S]*api\.getSnapshot\(\)[\s\S]*api\.getHealth\(\)/);
   assert.match(source, /downloadPollInFlight\.current/);
+  assert.match(source, /healthPollInFlight\.current/);
+  assert.match(source, /document\.visibilityState !== "visible"/);
   assert.match(source, /localDownloadActive(?: \|\| mlxOperationActive)? \? api\.getLocalModels\(\)/);
   assert.match(source, /visionDownloadActive \? api\.getVisionBridge\(\)/);
   assert.match(source, /downloadTimer = window\.setInterval\(\(\) => void refreshDownloadProgress\(\), 4_000\)/);

--- a/test/control-center-harness.test.mjs
+++ b/test/control-center-harness.test.mjs
@@ -95,6 +95,38 @@ test("session opening rejects traversal and non-UUID identifiers before launch",
   );
 });
 
+test("health IPC reads in-process and preserves the injected fetch boundary", async () => {
+  const handlers = new Map();
+  const fetchImpl = async () => { throw new Error("the reader owns fetch"); };
+  const expected = {
+    ok: true,
+    status: 200,
+    activity: { state: "idle", active: [], activeCount: 0 },
+    gateway: { reachable: true },
+  };
+  let calls = 0;
+  registerIpcHandlers({
+    ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+    BrowserWindow: { getAllWindows: () => [] },
+    shell: {},
+    fetchImpl,
+    healthReader: async (options) => {
+      calls += 1;
+      assert.equal(options.fetchImpl, fetchImpl);
+      return expected;
+    },
+    senderGuard: () => true,
+  });
+
+  const getHealth = handlers.get("router-control:getHealth");
+  assert.equal(typeof getHealth, "function");
+  assert.deepEqual(await getHealth({}), expected);
+  assert.equal(calls, 1);
+
+  const source = await readFile(new URL("../apps/control-center/electron/ipc.mjs", import.meta.url), "utf8");
+  assert.doesNotMatch(source, /handle\("getHealth"[\s\S]{0,100}runJson\(\["health"\]\)/);
+});
+
 test("Deep Code installation is a fixed interactive command with no settings read", async () => {
   const source = await readFile(new URL("../apps/control-center/electron/ipc.mjs", import.meta.url), "utf8");
   assert.match(source, /openTerminalCommand\(npm, \["install", "-g", DEEPCODE_PACKAGE\], discoverSourceRoot\(\)\)/);

--- a/test/control-health.test.mjs
+++ b/test/control-health.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readControlHealth } from "../src/control-health.mjs";
+
+const CALLER_SECRET = "test-caller-secret-0123456789abcdef";
+
+test("control health preserves the safe UI contract without returning capability data", async () => {
+  const requests = [];
+  const result = await readControlHealth({
+    routerPort: 43210,
+    readCallerSecret: () => `${CALLER_SECRET}\n`,
+    fetchImpl: async (url, options) => {
+      requests.push({ url, options });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          ok: true,
+          service: "codex-router",
+          version: "test-version",
+          router: "ready",
+          degraded: ["gateway"],
+          activity: { state: "generating", activeCount: 1, active: [{ model: "test/model" }] },
+          gateway: { reachable: false, enabled: true, credential: CALLER_SECRET },
+          oauth: { reachable: true, session: CALLER_SECRET },
+          api: { reachable: true },
+          grokOauth: { reachable: true, enabled: false },
+          credential: CALLER_SECRET,
+          callerUrl: `http://127.0.0.1:43210/${CALLER_SECRET}`,
+        }),
+      };
+    },
+  });
+
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0].url, `http://127.0.0.1:43210/_codex-router/${CALLER_SECRET}/v1/health`);
+  assert.deepEqual(requests[0].options.headers, { Accept: "application/json" });
+  assert.ok(requests[0].options.signal instanceof AbortSignal);
+  assert.deepEqual(result, {
+    ok: true,
+    status: 200,
+    service: "codex-router",
+    version: "test-version",
+    router: "ready",
+    degraded: ["gateway"],
+    activity: { state: "generating", activeCount: 1, active: [{ model: "test/model" }] },
+    gateway: { reachable: false, enabled: true },
+    oauth: { reachable: true },
+    api: { reachable: true },
+    grokOauth: { reachable: true, enabled: false },
+  });
+  assert.doesNotMatch(JSON.stringify(result), new RegExp(CALLER_SECRET));
+});
+
+test("control health fails closed before fetch when the caller capability is unavailable", async () => {
+  let fetches = 0;
+  const result = await readControlHealth({
+    readCallerSecret: () => "invalid",
+    fetchImpl: async () => {
+      fetches += 1;
+      throw new Error("fetch must not run");
+    },
+  });
+
+  assert.equal(fetches, 0);
+  assert.deepEqual(result, {
+    ok: false,
+    status: 0,
+    error: "The local router caller key is unavailable.",
+    activity: { state: "offline", active: [], activeCount: 0 },
+  });
+});
+
+test("control health preserves unreachable and timeout projections", async () => {
+  const unreachable = await readControlHealth({
+    readCallerSecret: () => CALLER_SECRET,
+    fetchImpl: async () => { throw new Error("planned transport failure"); },
+  });
+  const timeout = await readControlHealth({
+    readCallerSecret: () => CALLER_SECRET,
+    fetchImpl: async () => { throw Object.assign(new Error("planned timeout"), { name: "TimeoutError" }); },
+  });
+
+  assert.equal(unreachable.error, "Router is unreachable.");
+  assert.equal(timeout.error, "Health check timed out.");
+  assert.deepEqual(unreachable.activity, { state: "offline", active: [], activeCount: 0 });
+  assert.deepEqual(timeout.activity, { state: "offline", active: [], activeCount: 0 });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The Control Center polled health every second by launching `control.mjs health` in a new Electron child process. On Windows this repeatedly showed the busy cursor and added unnecessary process churn.

## What changed

- Move the protected, redacted health projection into a shared reader (`src/control-health.mjs`).
- Call it directly from the Electron main process via dynamic import.
- Skip overlapping and hidden-window background polls.
- Keep the CLI, preload, IPC, and renderer health contract unchanged.

## Verification

- Focused health and Control Center tests
- `test/control-health.test.mjs`: unit tests for the shared reader
- `test/control-center-harness.test.mjs`: IPC integration test proving the healthReader seam works
- `test/control-center-electron.test.mjs`: assertions for healthPollInFlight and visibilityState guards
- All tests pass

Recreates PR #437 on current main without touching the traffic lights / inset chrome from #440.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b9318af-7205-44bf-bb87-5eed6a33e31b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b9318af-7205-44bf-bb87-5eed6a33e31b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

