### PR TITLE
fix: size tray provider icons consistently

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -939,6 +939,59 @@ private struct IslandUsageLineChart: View {
 
 // Internal rather than private: the status panel's quota-reset rows in
 // ModelRouterTrayApp.swift render the same provider mark.
+enum ProviderIconLayout {
+  static func fittedRect(sourceRect: NSRect, targetSize: NSSize) -> NSRect {
+    guard sourceRect.width > 0, sourceRect.height > 0, targetSize.width > 0, targetSize.height > 0 else {
+      return .zero
+    }
+    let scale = min(
+      targetSize.width / sourceRect.width,
+      targetSize.height / sourceRect.height
+    )
+    let drawSize = NSSize(width: sourceRect.width * scale, height: sourceRect.height * scale)
+    return NSRect(
+      x: (targetSize.width - drawSize.width) / 2,
+      y: (targetSize.height - drawSize.height) / 2,
+      width: drawSize.width,
+      height: drawSize.height
+    )
+  }
+
+  static func visibleImageRect(_ image: NSImage) -> NSRect {
+    guard let representation = image.representations
+      .compactMap({ $0 as? NSBitmapImageRep })
+      .max(by: { ($0.pixelsWide * $0.pixelsHigh) < ($1.pixelsWide * $1.pixelsHigh) }),
+      representation.hasAlpha
+    else {
+      return NSRect(origin: .zero, size: image.size)
+    }
+
+    var minX = representation.pixelsWide
+    var minY = representation.pixelsHigh
+    var maxX = -1
+    var maxY = -1
+    for y in 0..<representation.pixelsHigh {
+      for x in 0..<representation.pixelsWide {
+        if representation.colorAt(x: x, y: y)?.alphaComponent ?? 0 > 8.0 / 255.0 {
+          minX = min(minX, x)
+          minY = min(minY, y)
+          maxX = max(maxX, x)
+          maxY = max(maxY, y)
+        }
+      }
+    }
+    guard maxX >= minX, maxY >= minY else {
+      return NSRect(origin: .zero, size: image.size)
+    }
+    return NSRect(
+      x: image.size.width * CGFloat(minX) / CGFloat(representation.pixelsWide),
+      y: image.size.height * CGFloat(minY) / CGFloat(representation.pixelsHigh),
+      width: image.size.width * CGFloat(maxX - minX + 1) / CGFloat(representation.pixelsWide),
+      height: image.size.height * CGFloat(maxY - minY + 1) / CGFloat(representation.pixelsHigh)
+    )
+  }
+}
+
 struct ProviderIcon: View {
   let providerID: String
   let size: CGFloat
@@ -957,7 +1010,7 @@ struct ProviderIcon: View {
           .clipped()
       } else {
         Image(systemName: "cpu")
-          .font(.system(size: size * 0.5, weight: .semibold))
+          .font(.system(size: size * 0.82, weight: .semibold))
           .foregroundStyle(routerMuted)
           .frame(width: size, height: size)
       }
@@ -985,7 +1038,27 @@ struct ProviderIcon: View {
       withExtension: assetExtension,
       subdirectory: "ProviderIcons"
     ) ?? resources.url(forResource: assetName, withExtension: assetExtension)
-    return url.flatMap(NSImage.init(contentsOf:))
+    guard let image = url.flatMap(NSImage.init(contentsOf:)) else { return nil }
+    return fittedProviderImage(image)
+  }
+
+  private func fittedProviderImage(_ image: NSImage) -> NSImage {
+    let targetSize = NSSize(width: max(1, size), height: max(1, size))
+    let sourceRect = ProviderIconLayout.visibleImageRect(image)
+    let drawRect = ProviderIconLayout.fittedRect(sourceRect: sourceRect, targetSize: targetSize)
+    let fitted = NSImage(size: targetSize)
+    fitted.lockFocus()
+    NSGraphicsContext.current?.imageInterpolation = .high
+    image.draw(
+      in: drawRect,
+      from: sourceRect,
+      operation: .sourceOver,
+      fraction: 1,
+      respectFlipped: true,
+      hints: [.interpolation: NSImageInterpolation.high]
+    )
+    fitted.unlockFocus()
+    return fitted
   }
 
   private var assetName: String? {

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -4472,10 +4472,37 @@ struct MenuBarSettings: Equatable {
 
 enum MenuBarLayoutMetrics {
   static let standardReservedWidth: CGFloat = 180
-  static let iconOnlyWidth: CGFloat = 24
+  static let standardHeight: CGFloat = 22
+  static let iconOnlyWidth: CGFloat = 28
+  static let iconOnlyHeight: CGFloat = 22
+  static let iconOnlyIconSize: CGFloat = 17
+  static let attentionPulseScale: CGFloat = 1.4
+  static let activityBadgeSize: CGFloat = 5
+  static let activityBadgePulseScale: CGFloat = 1.6
+  static let standardIndicatorPulseScale: CGFloat = 2.1
+  static let iconOnlySpacing: CGFloat = 4
 
-  nonisolated static func statusItemWidth(displayMode: TrayMenuBarDisplayMode) -> CGFloat {
-    displayMode == .iconOnly ? iconOnlyWidth : standardReservedWidth
+  nonisolated static func statusItemWidth(
+    displayMode: TrayMenuBarDisplayMode,
+    pulsing: Bool = false,
+    showsActivityBadge: Bool = false
+  ) -> CGFloat {
+    guard displayMode == .iconOnly else { return standardReservedWidth }
+    guard pulsing else { return iconOnlyWidth }
+    let iconWidth = iconOnlyIconSize * attentionPulseScale
+    let badgeWidth = showsActivityBadge ? activityBadgeSize * activityBadgePulseScale : 0
+    let spacing = showsActivityBadge ? iconOnlySpacing : 0
+    return max(iconOnlyWidth, ceil(iconWidth + spacing + badgeWidth))
+  }
+
+  nonisolated static func statusItemHeight(
+    displayMode: TrayMenuBarDisplayMode,
+    pulsing: Bool = false
+  ) -> CGFloat {
+    guard displayMode == .iconOnly, pulsing else {
+      return standardHeight
+    }
+    return max(iconOnlyHeight, ceil(iconOnlyIconSize * attentionPulseScale))
   }
 
   nonisolated static func showsActivityBadge(iconStyle: TrayMenuBarIconStyle, isIdle: Bool) -> Bool {
@@ -4693,20 +4720,36 @@ private struct StatusItemLabel: View {
   var body: some View {
     if store.menuBarDisplayMode == .iconOnly {
       HStack(spacing: 4) {
-        MenuBarIconView(store: store, size: 14)
-          .scaleEffect(pulsing ? 1.4 : 1)
+        MenuBarIconView(store: store, size: MenuBarLayoutMetrics.iconOnlyIconSize)
+          .scaleEffect(pulsing ? MenuBarLayoutMetrics.attentionPulseScale : 1)
           .animation(.easeOut(duration: 0.45), value: pulsing)
-        if MenuBarLayoutMetrics.showsActivityBadge(
+        let showsActivityBadge = MenuBarLayoutMetrics.showsActivityBadge(
           iconStyle: store.menuBarIconStyle,
           isIdle: store.activityState == .idle
-        ) {
-          Image(nsImage: MenuBarActivityDotImage.make(state: store.activityState, size: 5))
+        )
+        if showsActivityBadge {
+          Image(nsImage: MenuBarActivityDotImage.make(state: store.activityState, size: MenuBarLayoutMetrics.activityBadgeSize))
             .resizable()
             .interpolation(.high)
-            .frame(width: 5, height: 5)
+            .frame(width: MenuBarLayoutMetrics.activityBadgeSize, height: MenuBarLayoutMetrics.activityBadgeSize)
+            .scaleEffect(pulsing ? MenuBarLayoutMetrics.activityBadgePulseScale : 1)
+            .animation(.easeOut(duration: 0.45), value: pulsing)
         }
       }
-      .frame(width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode), height: 22)
+      .frame(
+        width: MenuBarLayoutMetrics.statusItemWidth(
+          displayMode: store.menuBarDisplayMode,
+          pulsing: pulsing,
+          showsActivityBadge: MenuBarLayoutMetrics.showsActivityBadge(
+            iconStyle: store.menuBarIconStyle,
+            isIdle: store.activityState == .idle
+          )
+        ),
+        height: MenuBarLayoutMetrics.statusItemHeight(
+          displayMode: store.menuBarDisplayMode,
+          pulsing: pulsing
+        )
+      )
       .clipped()
       .contentShape(Rectangle())
       .help(tooltipText)
@@ -4724,12 +4767,14 @@ private struct StatusItemLabel: View {
             .resizable()
             .interpolation(.high)
             .frame(width: 6, height: 6)
-            .scaleEffect(pulsing ? 2.1 : 1)
+            .aspectRatio(1, contentMode: .fit)
+            .clipShape(Circle())
+            .scaleEffect(pulsing ? MenuBarLayoutMetrics.standardIndicatorPulseScale : 1)
             .opacity(pulsing ? 0.55 : 1)
             .animation(.easeOut(duration: 0.45), value: pulsing)
         } else {
-          MenuBarIconView(store: store, size: 13)
-            .scaleEffect(pulsing ? 1.4 : 1)
+          MenuBarIconView(store: store, size: 15)
+            .scaleEffect(pulsing ? MenuBarLayoutMetrics.attentionPulseScale : 1)
             .animation(.easeOut(duration: 0.45), value: pulsing)
         }
         if store.menuBarShowModelName {
@@ -4752,7 +4797,14 @@ private struct StatusItemLabel: View {
             .truncationMode(.tail)
         }
       }
-      .frame(width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode), alignment: .leading)
+      .frame(
+        width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode, pulsing: pulsing),
+        height: MenuBarLayoutMetrics.statusItemHeight(
+          displayMode: store.menuBarDisplayMode,
+          pulsing: pulsing
+        ),
+        alignment: .leading
+      )
       .clipped()
       .help(tooltipText)
       .onChange(of: store.attentionPulse) { _ in

--- a/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Testing
 
@@ -67,7 +68,114 @@ struct MenuBarSettingsTests {
   @Test("standard mode keeps a reserved width even when the name is hidden")
   func standardWidthIsReserved() {
     #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard) == 180)
-    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .iconOnly) == 24)
+    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .iconOnly) == 28)
+    #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .standard) == 22)
+    #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .iconOnly) == 22)
+  }
+
+  @Test("the icon-only pulse reserves space for the rendered mark and badge")
+  func iconOnlyPulseKeepsScaledContentInsideBounds() {
+    #expect(
+      MenuBarLayoutMetrics.statusItemWidth(
+        displayMode: .iconOnly,
+        pulsing: true,
+        showsActivityBadge: false
+      ) == 28
+    )
+    #expect(
+      MenuBarLayoutMetrics.statusItemWidth(
+        displayMode: .iconOnly,
+        pulsing: true,
+        showsActivityBadge: true
+      ) == 36
+    )
+    #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .iconOnly, pulsing: true) == 24)
+    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard, pulsing: true) == 180)
+    #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .standard, pulsing: true) == 22)
+  }
+
+  @Test("provider marks fit transparent crops without leaving the target slot")
+  func providerMarkCropFitsTargetSlot() {
+    let drawRect = ProviderIconLayout.fittedRect(
+      sourceRect: NSRect(x: 2, y: 1, width: 6, height: 8),
+      targetSize: NSSize(width: 20, height: 20)
+    )
+    #expect(drawRect.width == 15)
+    #expect(drawRect.height == 20)
+    #expect(drawRect.minX >= 0)
+    #expect(drawRect.maxX <= 20)
+    #expect(drawRect.minY >= 0)
+    #expect(drawRect.maxY <= 20)
+  }
+
+  @Test("provider layout finds visible content in a transparent bitmap")
+  func providerLayoutFindsVisibleContent() {
+    let url = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .appendingPathComponent("Sources/Resources/ProviderIcons/openai.png")
+    guard let image = NSImage(contentsOf: url) else {
+      Issue.record("Provider icon fixture could not be loaded")
+      return
+    }
+
+    let visibleRect = ProviderIconLayout.visibleImageRect(image)
+    #expect(visibleRect.width > 0)
+    #expect(visibleRect.height > 0)
+    #expect(visibleRect.width <= image.size.width)
+    #expect(visibleRect.height <= image.size.height)
+    #expect(visibleRect.width < image.size.width || visibleRect.height < image.size.height)
+    let drawRect = ProviderIconLayout.fittedRect(
+      sourceRect: visibleRect,
+      targetSize: NSSize(width: 18, height: 18)
+    )
+    #expect(drawRect.minX >= 0)
+    #expect(drawRect.maxX <= 18)
+    #expect(drawRect.minY >= 0)
+    #expect(drawRect.maxY <= 18)
+  }
+
+  @Test("provider layout handles alpha-first bitmap representations")
+  func providerLayoutHandlesAlphaFirstBitmaps() {
+    guard let representation = NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: 10,
+      pixelsHigh: 8,
+      bitsPerSample: 8,
+      samplesPerPixel: 4,
+      hasAlpha: true,
+      isPlanar: false,
+      colorSpaceName: .deviceRGB,
+      bitmapFormat: .alphaFirst,
+      bytesPerRow: 0,
+      bitsPerPixel: 0
+    ) else {
+      Issue.record("Alpha-first bitmap fixture could not be created")
+      return
+    }
+
+    func setPixel(_ values: [Int], atX x: Int, y: Int) {
+      var values = values
+      values.withUnsafeMutableBufferPointer { buffer in
+        representation.setPixel(buffer.baseAddress!, atX: x, y: y)
+      }
+    }
+
+    for y in 0..<representation.pixelsHigh {
+      for x in 0..<representation.pixelsWide {
+        setPixel([0, 0, 0, 0], atX: x, y: y)
+      }
+    }
+    setPixel([255, 255, 255, 255], atX: 2, y: 1)
+    setPixel([255, 255, 255, 255], atX: 7, y: 6)
+    let image = NSImage(size: NSSize(width: 10, height: 8))
+    image.addRepresentation(representation)
+
+    let visibleRect = ProviderIconLayout.visibleImageRect(image)
+    #expect(visibleRect.minX == 2)
+    #expect(visibleRect.minY == 1)
+    #expect(visibleRect.width == 6)
+    #expect(visibleRect.height == 6)
   }
 
   @Test("the activity badge is not a second dot on the indicator style")

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -1264,11 +1264,12 @@ test("the status item keeps a reserved width in both menu-bar modes", () => {
     path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),
     "utf8",
   );
-  assert.match(source, /static let iconOnlyWidth: CGFloat = 24/);
+  assert.match(source, /static let iconOnlyWidth: CGFloat = 28/);
   assert.match(
     source,
-    /\.frame\(width: MenuBarLayoutMetrics\.statusItemWidth\(displayMode: store\.menuBarDisplayMode\)/,
+    /statusItemWidth\(\s*displayMode: store\.menuBarDisplayMode/,
   );
+  assert.match(source, /statusItemHeight\(\s*displayMode: store\.menuBarDisplayMode/);
   assert.doesNotMatch(
     source,
     /\.frame\(width: store\.menuBarShowModelName \? Self\.reservedWidth : nil/,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Provider icons now crop transparent asset padding before fitting into their tray slot. The existing attention pulse remains active for provider, preset, custom, and activity-dot styles. Menu-bar layout bounds reserve the scaled mark and activity badge while a pulse is drawn, keeping dots circular and visible in both standard and icon-only modes.

This recreates PR #420 on current main, preserving the `MenuBarActivityDotImage` behavior from PR #438 (activity dot colors in menu bar).

## Changes

- Added `ProviderIconLayout` enum with `fittedRect` and `visibleImageRect` methods to crop transparent padding from provider icons
- Updated `ProviderIcon` to use `fittedProviderImage` which applies the alpha-crop and fitted-rect logic
- Increased default CPU icon size from 0.5 to 0.82 to match the fitted provider icons
- Updated `MenuBarLayoutMetrics` with new constants for pulse scaling and activity badge sizing
- Enhanced `statusItemWidth` and `statusItemHeight` methods to account for pulsing state and activity badges
- Updated `StatusItemLabel` to use the new layout metrics and preserve PR #438's activity dot rendering
- Added comprehensive Swift tests covering transparent bitmap cropping, alpha-first representations, and pulse bounds
- Updated JavaScript tests to verify the new icon sizing constants

## Reason

Large transparent canvases made provider marks appear too small, while fixed tray bounds could clip the attention pulse. The previous implementation also lacked focused coverage for alpha cropping and scale-aware layout. This change keeps the existing tray behavior (including PR #438's activity dot colors) and makes icon sizing predictable across bitmap representations.

## Validation

- `node --test test/tray-rebuild.test.mjs` — 43 tests passed
- Swift tests not run in this environment (no Swift compiler available)
- All changes are isolated to macOS tray layout (IslandOverlay / ModelRouterTrayApp + tests)
- No changes to router, credentials, catalog, or health polling
- PR #438 activity-dot behavior remains intact

## Relationship to Original PRs

- **PR #420**: Original icon-sizing fix that conflicted with main
- **PR #438**: Activity dot colors (merged) - this PR preserves its `MenuBarActivityDotImage.make()` calls
- **This PR**: Recreates #420's icon-sizing logic on current main without reverting #438
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55625901-b9c0-45f2-9f11-23f8137900dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55625901-b9c0-45f2-9f11-23f8137900dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

