### PR TITLE
fix: drop DeepSeek phantom tool messages safely

### DIFF
--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -1,0 +1,470 @@
+import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+const MAX_CANDIDATE_BYTES = 64 * 1024;
+const MAX_CANDIDATE_MS = 1_000;
+const MAX_FRAME_BYTES = 256 * 1024;
+
+function parsedBlock(block) {
+  const newline = block.includes("\r\n") ? "\r\n" : "\n";
+  const lines = block.split(/\r?\n/);
+  const dataLineIndexes = lines
+    .map((line, index) => (line.startsWith("data:") ? index : -1))
+    .filter((index) => index !== -1);
+  const eventLines = lines.filter((line) => line.startsWith("event:"));
+  if (dataLineIndexes.length !== 1 || eventLines.length > 1) return undefined;
+  const [dataLineIndex] = dataLineIndexes;
+  const dataText = lines[dataLineIndex].slice(5).trimStart();
+  if (!dataText || dataText === "[DONE]") return undefined;
+  try {
+    const event = JSON.parse(dataText);
+    if (
+      eventLines.length === 1 &&
+      eventLines[0].slice(6).trim() !== event?.type
+    ) {
+      return undefined;
+    }
+    return { lines, dataLineIndex, newline, event };
+  } catch {
+    return undefined;
+  }
+}
+
+function rewrittenBlock(parsed, event, separator) {
+  const lines = [...parsed.lines];
+  lines[parsed.dataLineIndex] = `data: ${JSON.stringify(event)}`;
+  return `${lines.join(parsed.newline)}${separator}`;
+}
+
+function itemId(value) {
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function eventItemReference(event) {
+  const direct = itemId(event?.item_id);
+  const nested = itemId(event?.item?.id);
+  return {
+    id: direct ?? nested,
+    conflict: direct !== undefined && nested !== undefined && direct !== nested,
+  };
+}
+
+function eventItemId(event) {
+  return eventItemReference(event).id;
+}
+
+function isToolCall(item) {
+  return item?.type === "function_call" || item?.type === "custom_tool_call";
+}
+
+function candidateStart(item) {
+  return (
+    item?.type === "message" &&
+    item.role === "assistant" &&
+    Array.isArray(item.content) &&
+    item.content.length === 0
+  );
+}
+
+function finiteLimit(value, fallback, { minimum = 0, integer = false } = {}) {
+  if (!Number.isFinite(value) || value < minimum) return fallback;
+  return integer ? Math.floor(value) : value;
+}
+
+function exactEmptyPart(part) {
+  return (
+    part != null &&
+    typeof part === "object" &&
+    ["output_text", "text"].includes(part.type) &&
+    part.text === ""
+  );
+}
+
+function exactEmptyMessage(item) {
+  return (
+    item?.type === "message" &&
+    item.role === "assistant" &&
+    Array.isArray(item.content) &&
+    item.content.length > 0 &&
+    item.content.every(exactEmptyPart)
+  );
+}
+
+function candidateLifecycle(event, id) {
+  if (eventItemId(event) !== id) return false;
+  return [
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.output_text.delta",
+    "response.output_text.done",
+    "response.content_part.done",
+    "response.output_item.done",
+  ].includes(event?.type);
+}
+
+function exactEmptyCandidateEvent(event) {
+  switch (event?.type) {
+    case "response.output_item.added":
+      return candidateStart(event.item);
+    case "response.content_part.added":
+      return exactEmptyPart(event.part);
+    case "response.output_text.delta":
+      return event.delta === "";
+    case "response.output_text.done":
+      return event.text === "";
+    case "response.content_part.done":
+      return (
+        exactEmptyPart(event.part) ||
+        (event.part?.type === "reasoning_text" &&
+          typeof event.part.reasoning === "string")
+      );
+    case "response.output_item.done":
+      return exactEmptyMessage(event.item);
+    default:
+      return false;
+  }
+}
+
+// LiteLLM's Chat-Completions -> Responses bridge can announce an empty
+// assistant message before a DeepSeek tool call, then close that message after
+// the call. Codex renders the empty lifecycle as a separate assistant turn.
+//
+// The tool cannot be renumbered until the preceding message is conclusively
+// known to be empty: a legitimate mixed text/tool response has the same prefix.
+// This transform therefore holds only that ambiguous interval under strict
+// byte and time budgets. Every ambiguous, malformed, large, or slow shape fails
+// open byte-for-byte and permanently disables the repair for that response.
+export class DeepseekToolMessageCompatTransform extends Transform {
+  #decoder = new StringDecoder("utf8");
+  #buffer = "";
+  #candidate;
+  #disabled = false;
+  #suppressed;
+  #maxCandidateBytes;
+  #maxCandidateMs;
+  #maxFrameBytes;
+  #timer;
+
+  constructor({
+    maxCandidateBytes = MAX_CANDIDATE_BYTES,
+    maxCandidateMs = MAX_CANDIDATE_MS,
+    maxFrameBytes = MAX_FRAME_BYTES,
+  } = {}) {
+    super();
+    this.#maxCandidateBytes = finiteLimit(
+      maxCandidateBytes,
+      MAX_CANDIDATE_BYTES,
+      { integer: true },
+    );
+    this.#maxCandidateMs = finiteLimit(maxCandidateMs, MAX_CANDIDATE_MS);
+    this.#maxFrameBytes = finiteLimit(maxFrameBytes, MAX_FRAME_BYTES, {
+      minimum: 1,
+      integer: true,
+    });
+  }
+
+  _transform(chunk, _encoding, callback) {
+    this.#buffer += this.#decoder.write(chunk);
+    if (this.#disabled) {
+      this.#pushBuffered();
+      callback();
+      return;
+    }
+    this.#emitCompleteBlocks();
+    if (this.#disabled) {
+      this.#pushBuffered();
+    } else if (Buffer.byteLength(this.#buffer) > this.#maxFrameBytes) {
+      this.#failOpen();
+      this.#pushBuffered();
+    }
+    callback();
+  }
+
+  _flush(callback) {
+    this.#clearTimer();
+    this.#buffer += this.#decoder.end();
+    if (this.#disabled) {
+      this.#pushBuffered();
+      callback();
+      return;
+    }
+    this.#emitCompleteBlocks(true);
+    if (this.#candidate) this.#failOpen();
+    this.#pushBuffered();
+    callback();
+  }
+
+  _destroy(error, callback) {
+    this.#clearTimer();
+    callback(error);
+  }
+
+  #emitCompleteBlocks(flush = false) {
+    while (this.#buffer.length && !this.#disabled) {
+      const crlf = this.#buffer.indexOf("\r\n\r\n");
+      const lf = this.#buffer.indexOf("\n\n");
+      let index = -1;
+      let separator = "";
+      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+        index = crlf;
+        separator = "\r\n\r\n";
+      } else if (lf !== -1) {
+        index = lf;
+        separator = "\n\n";
+      }
+      if (index === -1) {
+        if (!flush) return;
+        const block = this.#buffer;
+        this.#buffer = "";
+        if (Buffer.byteLength(block) > this.#maxFrameBytes) {
+          this.#oversizedFrame(block);
+          return;
+        }
+        this.#handleBlock(block, "");
+        return;
+      }
+      const block = this.#buffer.slice(0, index);
+      this.#buffer = this.#buffer.slice(index + separator.length);
+      if (Buffer.byteLength(block) + Buffer.byteLength(separator) > this.#maxFrameBytes) {
+        this.#oversizedFrame(`${block}${separator}`);
+        return;
+      }
+      this.#handleBlock(block, separator);
+    }
+  }
+
+  #handleBlock(block, separator) {
+    const frame = {
+      original: `${block}${separator}`,
+      parsed: parsedBlock(block),
+      separator,
+    };
+    if (!frame.parsed) {
+      if (this.#candidate) this.#failOpen(frame);
+      else this.push(Buffer.from(frame.original));
+      return;
+    }
+    const event = frame.parsed.event;
+    if (this.#suppressed) {
+      this.#pushCompacted(frame);
+      return;
+    }
+
+    if (eventItemReference(event).conflict) {
+      this.#failOpen(frame);
+      return;
+    }
+
+    if (!this.#candidate) {
+      if (
+        event.type === "response.output_item.added" &&
+        candidateStart(event.item) &&
+        itemId(event.item?.id) &&
+        Number.isInteger(event.output_index) &&
+        event.output_index >= 0
+      ) {
+        this.#candidate = {
+          id: event.item.id,
+          outputIndex: event.output_index,
+          frames: [],
+          bytes: 0,
+          sawTool: false,
+          closed: false,
+          itemIndexes: new Map([[event.item.id, event.output_index]]),
+          indexItems: new Map([[event.output_index, event.item.id]]),
+        };
+        this.#startTimer();
+        this.#hold(frame);
+      } else {
+        this.push(Buffer.from(frame.original));
+      }
+      return;
+    }
+
+    const candidate = this.#candidate;
+    const attachedId = eventItemId(event);
+    if (attachedId === candidate.id && !candidateLifecycle(event, candidate.id)) {
+      this.#failOpen(frame);
+      return;
+    }
+    if (candidateLifecycle(event, candidate.id)) {
+      if (
+        candidate.closed ||
+        !Number.isInteger(event.output_index) ||
+        event.output_index !== candidate.outputIndex ||
+        !exactEmptyCandidateEvent(event)
+      ) {
+        this.#failOpen(frame);
+        return;
+      }
+    } else if (event.type === "response.output_item.added") {
+      const id = itemId(event.item?.id);
+      const index = event.output_index;
+      if (
+        !id ||
+        candidateStart(event.item) ||
+        !Number.isInteger(index) ||
+        index < 0 ||
+        index <= candidate.outputIndex ||
+        candidate.itemIndexes.has(id) ||
+        candidate.indexItems.has(index)
+      ) {
+        this.#failOpen(frame);
+        return;
+      }
+      candidate.itemIndexes.set(id, index);
+      candidate.indexItems.set(index, id);
+      if (isToolCall(event.item)) candidate.sawTool = true;
+    } else if (attachedId) {
+      const expectedIndex = candidate.itemIndexes.get(attachedId);
+      if (
+        expectedIndex === undefined ||
+        !Number.isInteger(event.output_index) ||
+        event.output_index !== expectedIndex
+      ) {
+        this.#failOpen(frame);
+        return;
+      }
+      if (isToolCall(event.item) && event.type !== "response.output_item.done") {
+        this.#failOpen(frame);
+        return;
+      }
+    }
+
+    this.#hold(frame);
+    if (!this.#candidate) return;
+
+    if (
+      event.type === "response.output_item.done" &&
+      attachedId === candidate.id
+    ) {
+      candidate.closed = true;
+      return;
+    }
+
+    if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
+      if (this.#terminalMatchesCandidate(event.response.output, candidate)) {
+        this.#suppress();
+      } else this.#failOpen();
+    }
+  }
+
+  #hold(frame) {
+    if (!this.#candidate) return;
+    const bytes = Buffer.byteLength(frame.original);
+    if (this.#candidate.bytes + bytes > this.#maxCandidateBytes) {
+      this.#failOpen(frame);
+      return;
+    }
+    this.#candidate.frames.push(frame);
+    this.#candidate.bytes += bytes;
+  }
+
+  #terminalMatchesCandidate(output, candidate) {
+    if (!candidate.closed || !candidate.sawTool) return false;
+    if (candidate.outputIndex >= output.length) return false;
+    if (!exactEmptyMessage(output[candidate.outputIndex])) return false;
+    if (itemId(output[candidate.outputIndex]?.id) !== candidate.id) return false;
+    const ids = new Set();
+    for (let index = candidate.outputIndex; index < output.length; index += 1) {
+      const id = itemId(output[index]?.id);
+      if (!id || ids.has(id)) return false;
+      ids.add(id);
+      if (candidate.itemIndexes.get(id) !== index) return false;
+    }
+    return ids.size === candidate.itemIndexes.size;
+  }
+
+  #suppress() {
+    const candidate = this.#candidate;
+    if (!candidate) return;
+    this.#candidate = undefined;
+    this.#suppressed = { id: candidate.id, outputIndex: candidate.outputIndex };
+    this.#clearTimer();
+    for (const frame of candidate.frames) this.#pushCompacted(frame);
+  }
+
+  #failOpen(extraFrame) {
+    const candidate = this.#candidate;
+    this.#candidate = undefined;
+    this.#clearTimer();
+    if (candidate) {
+      for (const frame of candidate.frames) this.push(Buffer.from(frame.original));
+    }
+    if (extraFrame) this.push(Buffer.from(extraFrame.original));
+    this.#disabled = true;
+  }
+
+  #pushCompacted(frame) {
+    const event = frame.parsed?.event;
+    const suppressed = this.#suppressed;
+    if (!event || !suppressed) {
+      this.push(Buffer.from(frame.original));
+      return;
+    }
+    if (candidateLifecycle(event, suppressed.id)) return;
+    let next = event;
+    let changed = false;
+    if (
+      Number.isInteger(event.output_index) &&
+      event.output_index > suppressed.outputIndex
+    ) {
+      next = { ...next, output_index: event.output_index - 1 };
+      changed = true;
+    }
+    if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
+      const output = event.response.output.filter(
+        (item) => itemId(item?.id) !== suppressed.id,
+      );
+      next = {
+        ...next,
+        response: {
+          ...event.response,
+          output,
+        },
+      };
+      changed ||= output.length !== event.response.output.length;
+    }
+    this.push(
+      Buffer.from(
+        changed ? rewrittenBlock(frame.parsed, next, frame.separator) : frame.original,
+      ),
+    );
+  }
+
+  #oversizedFrame(original) {
+    const frame = { original };
+    if (this.#candidate) this.#failOpen(frame);
+    else {
+      this.push(Buffer.from(original));
+      this.#disabled = true;
+    }
+  }
+
+  #pushBuffered() {
+    if (!this.#buffer) return;
+    this.push(Buffer.from(this.#buffer));
+    this.#buffer = "";
+  }
+
+  #startTimer() {
+    if (this.#timer || !this.#candidate) return;
+    this.#timer = setTimeout(() => {
+      this.#failOpen();
+      this.#pushBuffered();
+    }, this.#maxCandidateMs);
+    this.#timer.unref?.();
+  }
+
+  #clearTimer() {
+    if (!this.#timer) return;
+    clearTimeout(this.#timer);
+    this.#timer = undefined;
+  }
+}
+
+export function deepseekToolMessageCompatTransform(providerId, contentType = "") {
+  if (String(providerId) !== "deepseek") return undefined;
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
+  return new DeepseekToolMessageCompatTransform();
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -53,6 +53,7 @@ import {
   ZaiResponsesCompatTransform,
   zaiResponsesCompatTransform,
 } from "./zai-responses-compat.mjs";
+import { deepseekToolMessageCompatTransform } from "./deepseek-tool-message-compat.mjs";
 import {
   MERGED_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
@@ -3046,6 +3047,10 @@ async function handleResponses(request, response, requestUrl) {
         envelopeCompat = new ZaiResponsesCompatTransform();
       }
       if (envelopeCompat) transforms.push(envelopeCompat);
+      const deepseekToolMessageCompat = route
+        ? deepseekToolMessageCompatTransform(route.provider, contentType)
+        : undefined;
+      if (deepseekToolMessageCompat) transforms.push(deepseekToolMessageCompat);
       // Restore flattened namespace calls for routed chat-completions providers,
       // and inject missing finished-child interrupts for both routed and native
       // multi-agent parents (San Francisco uses native GPT).

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -1,0 +1,511 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import test from "node:test";
+
+import {
+  DeepseekToolMessageCompatTransform,
+  deepseekToolMessageCompatTransform,
+} from "../src/deepseek-tool-message-compat.mjs";
+
+function block(event, newline = "\n") {
+  return `event: ${event.type}${newline}data: ${JSON.stringify(event)}${newline}${newline}`;
+}
+
+function events(text) {
+  return text
+    .split(/\r?\n\r?\n/)
+    .map((frame) => frame.split(/\r?\n/).find((line) => line.startsWith("data:")))
+    .filter((line) => line && line !== "data: [DONE]")
+    .map((line) => JSON.parse(line.slice(5).trimStart()));
+}
+
+async function transformed(input, options = {}, chunkSize = 0) {
+  const stream = new DeepseekToolMessageCompatTransform(options);
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  if (chunkSize > 0) {
+    const bytes = Buffer.from(input);
+    for (let at = 0; at < bytes.length; at += chunkSize) {
+      stream.write(bytes.subarray(at, at + chunkSize));
+    }
+  } else {
+    stream.write(input);
+  }
+  stream.end();
+  await once(stream, "end");
+  return output;
+}
+
+const blankMessage = {
+  id: "msg_blank",
+  type: "message",
+  status: "completed",
+  role: "assistant",
+  content: [{ type: "output_text", text: "", annotations: [] }],
+};
+
+const functionCall = {
+  id: "call_list",
+  type: "function_call",
+  call_id: "call_list",
+  name: "exec_command",
+  arguments: "{}",
+  status: "completed",
+};
+
+function phantomToolStream(newline = "\n") {
+  return [
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      sequence_number: 1,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    }, newline),
+    block({
+      type: "response.content_part.added",
+      item_id: blankMessage.id,
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 2,
+      part: { type: "output_text", text: "", annotations: [] },
+    }, newline),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      sequence_number: 3,
+      item: { ...functionCall, status: "in_progress", arguments: "" },
+    }, newline),
+    block({
+      type: "response.function_call_arguments.delta",
+      item_id: functionCall.id,
+      output_index: 1,
+      sequence_number: 4,
+      delta: "{}",
+    }, newline),
+    block({
+      type: "response.output_item.done",
+      output_index: 1,
+      sequence_number: 5,
+      item: functionCall,
+    }, newline),
+    block({
+      type: "response.output_text.done",
+      item_id: blankMessage.id,
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 6,
+      text: "",
+    }, newline),
+    block({
+      type: "response.content_part.done",
+      item_id: blankMessage.id,
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 7,
+      part: { type: "reasoning_text", reasoning: "private reasoning" },
+    }, newline),
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      sequence_number: 8,
+      item: blankMessage,
+    }, newline),
+    block({
+      type: "response.completed",
+      sequence_number: 9,
+      response: { id: "resp_1", status: "completed", output: [blankMessage, functionCall] },
+    }, newline),
+    `data: [DONE]${newline}${newline}`,
+  ].join("");
+}
+
+test("removes DeepSeek's confirmed blank tool message and compacts indexes", async () => {
+  const output = await transformed(phantomToolStream(), {}, 7);
+  const seen = events(output);
+  assert.equal(output.includes(blankMessage.id), false);
+  assert.equal(output.includes("private reasoning"), false);
+  assert.match(output, /data: \[DONE\]/);
+  const toolEvents = seen.filter((event) => eventItem(event) === functionCall.id);
+  assert.ok(toolEvents.length >= 3);
+  assert.ok(toolEvents.every((event) => event.output_index === 0));
+  assert.deepEqual(toolEvents.map((event) => event.sequence_number), [3, 4, 5]);
+  assert.deepEqual(
+    seen.find((event) => event.type === "response.completed").response.output,
+    [functionCall],
+  );
+});
+
+function eventItem(event) {
+  return event.item_id ?? event.item?.id;
+}
+
+test("preserves CRLF framing while compacting the stream", async () => {
+  const output = await transformed(phantomToolStream("\r\n"), {}, 11);
+  assert.ok(output.includes("\r\n\r\n"));
+  assert.equal(output.replaceAll("\r\n\r\n", "").includes("\n\n"), false);
+  assert.ok(events(output).every((event) => {
+    return !Number.isInteger(event.output_index) || event.output_index === 0;
+  }));
+});
+
+test("fails open when the candidate later contains visible text", async () => {
+  const input = [
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    }),
+    block({
+      type: "response.output_text.delta",
+      output_index: 0,
+      item_id: blankMessage.id,
+      delta: "I will inspect it.",
+    }),
+    block({ type: "response.output_item.added", output_index: 1, item: functionCall }),
+  ].join("");
+  assert.equal(await transformed(input), input);
+});
+
+test("leaves a blank response without a tool call byte-identical", async () => {
+  const input = [
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    }),
+    block({ type: "response.output_item.done", output_index: 0, item: blankMessage }),
+  ].join("");
+  assert.equal(await transformed(input), input);
+});
+
+test("compacts separate reasoning and multiple later output items consistently", async () => {
+  const reasoning = { id: "rs_1", type: "reasoning", summary: [] };
+  const secondTool = { ...functionCall, id: "call_two", call_id: "call_two" };
+  const input = [
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    }),
+    block({ type: "response.output_item.added", output_index: 1, item: reasoning }),
+    block({ type: "response.output_item.done", output_index: 1, item: reasoning }),
+    block({ type: "response.output_item.added", output_index: 2, item: functionCall }),
+    block({
+      type: "response.function_call_arguments.done",
+      output_index: 2,
+      item_id: functionCall.id,
+      arguments: "{}",
+    }),
+    block({ type: "response.output_item.added", output_index: 3, item: secondTool }),
+    block({ type: "response.output_item.done", output_index: 0, item: blankMessage }),
+    block({
+      type: "response.completed",
+      response: { output: [blankMessage, reasoning, functionCall, secondTool] },
+    }),
+  ].join("");
+  const seen = events(await transformed(input));
+  assert.deepEqual(
+    seen.filter((event) => event.type === "response.output_item.added")
+      .map((event) => [event.item.id, event.output_index]),
+    [[reasoning.id, 0], [functionCall.id, 1], [secondTool.id, 2]],
+  );
+  assert.equal(
+    seen.find((event) => event.type === "response.function_call_arguments.done").output_index,
+    1,
+  );
+  assert.deepEqual(
+    seen.find((event) => event.type === "response.completed").response.output,
+    [reasoning, functionCall, secondTool],
+  );
+});
+
+test("byte budget expiry releases the entire stream unchanged", async () => {
+  const input = phantomToolStream();
+  assert.equal(
+    await transformed(input, { maxCandidateBytes: 32, maxCandidateMs: 60_000 }),
+    input,
+  );
+});
+
+test("timer expiry releases pending bytes and subsequent chunks immediately", async () => {
+  const start = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const tail = block({ type: "response.output_item.added", output_index: 1, item: functionCall });
+  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 5 });
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  stream.write(start);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(output, start);
+  stream.write(tail);
+  assert.equal(output, start + tail);
+  stream.end();
+  await once(stream, "end");
+});
+
+test("malformed and duplicate candidate lifecycles fail open", async () => {
+  const start = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const malformed = "event: response.output_item.added\ndata: {not-json}\n\n";
+  assert.equal(await transformed(start + malformed), start + malformed);
+
+  const second = block({
+    type: "response.output_item.added",
+    output_index: 1,
+    item: { ...blankMessage, id: "msg_two", status: "in_progress", content: [] },
+  });
+  assert.equal(await transformed(start + second), start + second);
+});
+
+test("conflicting item references and non-assistant messages fail open", async () => {
+  const conflicting = block({
+    type: "response.output_item.added",
+    item_id: "msg_other",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const tail = phantomToolStream().slice(phantomToolStream().indexOf("\n\n") + 2);
+  assert.equal(await transformed(conflicting + tail), conflicting + tail);
+
+  const nonAssistant = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: {
+      ...blankMessage,
+      role: "user",
+      status: "in_progress",
+      content: [],
+    },
+  });
+  assert.equal(await transformed(nonAssistant + tail), nonAssistant + tail);
+});
+
+test("refusal and unknown message parts are never classified as empty", async () => {
+  const start = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const tool = block({
+    type: "response.output_item.added",
+    output_index: 1,
+    item: { ...functionCall, status: "in_progress" },
+  });
+  for (const part of [
+    { type: "refusal", refusal: "cannot comply" },
+    { type: "audio", audio: "opaque" },
+  ]) {
+    const close = block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { ...blankMessage, content: [part] },
+    });
+    assert.equal(await transformed(start + tool + close), start + tool + close);
+  }
+  const refusal = block({
+    type: "response.refusal.delta",
+    output_index: 0,
+    item_id: blankMessage.id,
+    delta: "cannot comply",
+  });
+  assert.equal(await transformed(start + tool + refusal), start + tool + refusal);
+});
+
+test("mismatched, duplicate, missing, and negative indexes fail open", async () => {
+  const start = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const toolAtTwo = block({
+    type: "response.output_item.added",
+    output_index: 2,
+    item: { ...functionCall, status: "in_progress" },
+  });
+  const wrongDelta = block({
+    type: "response.function_call_arguments.delta",
+    output_index: 1,
+    item_id: functionCall.id,
+    delta: "{}",
+  });
+  assert.equal(
+    await transformed(start + toolAtTwo + wrongDelta),
+    start + toolAtTwo + wrongDelta,
+  );
+
+  const duplicateIndex = block({
+    type: "response.output_item.added",
+    output_index: 2,
+    item: { ...functionCall, id: "call_duplicate" },
+  });
+  assert.equal(
+    await transformed(start + toolAtTwo + duplicateIndex),
+    start + toolAtTwo + duplicateIndex,
+  );
+
+  const missingIndex = block({
+    type: "response.function_call_arguments.done",
+    item_id: functionCall.id,
+    arguments: "{}",
+  });
+  assert.equal(
+    await transformed(start + toolAtTwo + missingIndex),
+    start + toolAtTwo + missingIndex,
+  );
+
+  const negative = block({
+    type: "response.output_item.added",
+    output_index: -1,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  assert.equal(await transformed(negative + toolAtTwo), negative + toolAtTwo);
+});
+
+test("tool proof requires a valid added lifecycle and matching terminal order", async () => {
+  const start = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const blankDone = block({
+    type: "response.output_item.done",
+    output_index: 0,
+    item: blankMessage,
+  });
+  const toolDoneOnly = block({
+    type: "response.output_item.done",
+    output_index: 1,
+    item: functionCall,
+  });
+  assert.equal(
+    await transformed(start + toolDoneOnly + blankDone),
+    start + toolDoneOnly + blankDone,
+  );
+
+  const terminalOnly = block({
+    type: "response.completed",
+    response: { output: [blankMessage, functionCall] },
+  });
+  assert.equal(
+    await transformed(start + blankDone + terminalOnly),
+    start + blankDone + terminalOnly,
+  );
+
+  const toolAdded = block({
+    type: "response.output_item.added",
+    output_index: 1,
+    item: { ...functionCall, status: "in_progress" },
+  });
+  const wrongOrder = block({
+    type: "response.completed",
+    response: { output: [functionCall, blankMessage] },
+  });
+  assert.equal(
+    await transformed(start + toolAdded + blankDone + wrongOrder),
+    start + toolAdded + blankDone + wrongOrder,
+  );
+});
+
+test("an oversized unterminated frame fails open without retaining the body", async () => {
+  const start = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const tail = `data: ${"x".repeat(256)}`;
+  assert.equal(
+    await transformed(start + tail, { maxFrameBytes: 64, maxCandidateMs: 60_000 }),
+    start + tail,
+  );
+});
+
+test("delimiter-terminated frames and single-frame cap crossings are bounded", async () => {
+  const start = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const huge = block({
+    type: "response.function_call_arguments.delta",
+    output_index: 1,
+    item_id: functionCall.id,
+    delta: "x".repeat(2_000),
+  });
+  assert.equal(
+    await transformed(start + huge, { maxFrameBytes: 512, maxCandidateMs: 60_000 }),
+    start + huge,
+  );
+
+  const tool = block({
+    type: "response.output_item.added",
+    output_index: 1,
+    item: { ...functionCall, status: "in_progress" },
+  });
+  assert.equal(
+    await transformed(start + tool, {
+      maxCandidateBytes: Buffer.byteLength(start) + 1,
+      maxCandidateMs: 60_000,
+    }),
+    start + tool,
+  );
+});
+
+test("timer expiry also releases an incomplete buffered frame", async () => {
+  const start = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const partial = "event: response.output_item.added\ndata: {\"type\":";
+  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 5 });
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  stream.write(start + partial);
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(output, start + partial);
+  stream.end();
+  await once(stream, "end");
+});
+
+test("destroying a pending stream clears its hold without later output", async () => {
+  const start = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 5 });
+  let output = "";
+  stream.on("data", (chunk) => { output += chunk.toString("utf8"); });
+  stream.write(start);
+  stream.destroy();
+  await once(stream, "close");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(output, "");
+});
+
+test("post-suppression frames without shifted indexes remain byte-identical", async () => {
+  const untouched = "event: response.done\ndata:  {\"type\":\"response.done\",\"response\":{\"id\":\"r1\"}}\n\n";
+  const output = await transformed(phantomToolStream().replace("data: [DONE]\n\n", untouched));
+  assert.ok(output.endsWith(untouched));
+});
+
+test("factory is provider-scoped, SSE-only, and returns fresh retry transforms", () => {
+  const first = deepseekToolMessageCompatTransform("deepseek", "text/event-stream");
+  const retry = deepseekToolMessageCompatTransform("deepseek", "text/event-stream");
+  assert.ok(first instanceof DeepseekToolMessageCompatTransform);
+  assert.ok(retry instanceof DeepseekToolMessageCompatTransform);
+  assert.notEqual(first, retry);
+  for (const provider of ["opencode-go", "commandcode", "qwen-plan", "zai-api"]) {
+    assert.equal(deepseekToolMessageCompatTransform(provider, "text/event-stream"), undefined);
+  }
+  assert.equal(deepseekToolMessageCompatTransform("deepseek", "application/json"), undefined);
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -6880,6 +6880,190 @@ test("a plain follow-up after a thinking turn replays its reasoning", async () =
   }
 });
 
+test("router removes DeepSeek's confirmed blank message before a tool call", async () => {
+  const blankMessage = {
+    id: "msg_blank",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "", annotations: [] }],
+  };
+  const functionCall = {
+    id: "call_list",
+    type: "function_call",
+    call_id: "call_list",
+    name: "exec_command",
+    arguments: "{}",
+    status: "completed",
+  };
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    const events = [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { ...blankMessage, status: "in_progress", content: [] },
+      },
+      {
+        type: "response.content_part.added",
+        item_id: blankMessage.id,
+        output_index: 0,
+        content_index: 0,
+        part: { type: "output_text", text: "", annotations: [] },
+      },
+      {
+        type: "response.output_item.added",
+        output_index: 1,
+        item: { ...functionCall, arguments: "", status: "in_progress" },
+      },
+      {
+        type: "response.function_call_arguments.done",
+        item_id: functionCall.id,
+        output_index: 1,
+        arguments: "{}",
+      },
+      { type: "response.output_item.done", output_index: 1, item: functionCall },
+      {
+        type: "response.output_text.done",
+        item_id: blankMessage.id,
+        output_index: 0,
+        content_index: 0,
+        text: "",
+      },
+      {
+        type: "response.content_part.done",
+        item_id: blankMessage.id,
+        output_index: 0,
+        content_index: 0,
+        part: { type: "reasoning_text", reasoning: "private reasoning" },
+      },
+      { type: "response.output_item.done", output_index: 0, item: blankMessage },
+      {
+        type: "response.completed",
+        response: {
+          id: "resp_tool_only",
+          status: "completed",
+          output: [blankMessage, functionCall],
+          usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+        },
+      },
+    ];
+    response.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "deepseek/deepseek-v4-flash-vision-exp",
+        input: "list files",
+        stream: true,
+      }),
+    });
+    const text = await response.text();
+    assert.equal(response.status, 200, text);
+    const events = text.split(/\r?\n/)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+    assert.equal(text.includes(blankMessage.id), false);
+    assert.equal(text.includes("private reasoning"), false);
+    const toolEvents = events.filter(
+      (event) => (event.item_id ?? event.item?.id) === functionCall.id,
+    );
+    assert.ok(toolEvents.length >= 3);
+    assert.ok(toolEvents.every((event) => event.output_index === 0));
+    assert.deepEqual(
+      events.find((event) => event.type === "response.completed").response.output,
+      [functionCall],
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
+test("router does not compact the same blank-message shape on non-DeepSeek routes", async () => {
+  const blank = {
+    id: "msg_blank",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "", annotations: [] }],
+  };
+  const tool = {
+    id: "call_list",
+    type: "function_call",
+    call_id: "call_id",
+    name: "exec_command",
+    arguments: "{}",
+    status: "completed",
+  };
+  const source = [
+    { type: "response.output_item.added", output_index: 0, item: { ...blank, status: "in_progress", content: [] } },
+    { type: "response.output_item.added", output_index: 1, item: { ...tool, status: "in_progress" } },
+    { type: "response.output_item.done", output_index: 0, item: blank },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_tool_only",
+        status: "completed",
+        output: [blank, tool],
+        usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+      },
+    },
+  ].map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(source);
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "opencode-go/deepseek-v4-flash",
+        input: "list files",
+        stream: true,
+      }),
+    });
+    const text = await response.text();
+    assert.equal(response.status, 200, text);
+    const events = text.split(/\r?\n/)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+    assert.ok(text.includes(blank.id));
+    assert.equal(
+      events.find((event) => event.item?.id === tool.id).output_index,
+      1,
+    );
+    assert.deepEqual(
+      events.find((event) => event.type === "response.completed").response.output,
+      [blank, tool],
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 
 test("router repairs malformed Z.ai message envelopes after LiteLLM Responses translation", async () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "zai-responses-compat-router-"));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Recreates #435 by @duolahypercho on current main.

This implements a provider-scoped, bounded SSE transform that removes LiteLLM's blank assistant-message lifecycle before direct DeepSeek tool calls.

## What this does

The transform:
- Removes LiteLLM's blank assistant-message lifecycle before direct DeepSeek tool calls
- Compacts surviving `output_index` values and terminal `response.output` consistently  
- Applies **only** to the direct `deepseek` provider on Responses SSE streams
- Fails open byte-for-byte for visible/refusal/unknown content, malformed lifecycles, conflicting item identities, inconsistent indexes, oversized frames, or timeout
- Preserves existing Z.ai, namespace, usage, and empty-completion pipeline ordering

## Files changed

- **New**: `src/deepseek-tool-message-compat.mjs` - Bounded SSE transform with fail-open design
- **Modified**: `src/router.mjs` - Small hook in `handleResponses` to apply the transform
- **New**: `test/deepseek-tool-message-compat.test.mjs` - Comprehensive unit tests
- **Modified**: `test/routing.test.mjs` - Integration tests for DeepSeek/non-DeepSeek/Z.ai

## Background

The original bug report is #385 by @mayrazing. PR #435 superseded #385 with a DeepSeek-only fail-open implementation rather than a global transform. This PR rebases that work onto current main, resolving conflicts in `router.mjs` where later commits modified the `handleResponses` pipeline.

## Testing

All DeepSeek-specific unit tests pass:
```
✓ removes DeepSeek's confirmed blank tool message and compacts indexes
✓ preserves CRLF framing while compacting the stream
✓ fails open when the candidate later contains visible text
✓ leaves a blank response without a tool call byte-identical
✓ compacts separate reasoning and multiple later output items consistently
✓ byte budget expiry releases the entire stream unchanged
✓ timer expiry releases pending bytes and subsequent chunks immediately
✓ malformed and duplicate candidate lifecycles fail open
✓ conflicting item references and non-assistant messages fail open
✓ refusal and unknown message parts are never classified as empty
✓ mismatched, duplicate, missing, and negative indexes fail open
✓ tool proof requires a valid added lifecycle and matching terminal order
✓ an oversized unterminated frame fails open without retaining the body
✓ delimiter-terminated frames and single-frame cap crossings are bounded
✓ timer expiry also releases an incomplete buffered frame
✓ destroying a pending stream clears its hold without later output
✓ post-suppression frames without shifted indexes remain byte-identical
✓ factory is provider-scoped, SSE-only, and returns fresh retry transforms
```

Integration tests verify:
- DeepSeek routes have the blank message removed and indexes compacted
- Non-DeepSeek routes with identical message shapes remain unchanged
- Z.ai transforms continue to work correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27165185-9c7f-4ca6-a6e9-d41ce973813e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27165185-9c7f-4ca6-a6e9-d41ce973813e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

