### PR TITLE
Fix false empty-completion limits on large stream prologues

### DIFF
--- a/src/empty-completion-guard.mjs
+++ b/src/empty-completion-guard.mjs
@@ -366,6 +366,7 @@ export class EmptyCompletionGuard extends Transform {
   #bufferedBytes = 0;
   #sawContent = false;
   #sawTerminal = false;
+  #sawParseableEvent = false;
   #empty = false;
   #released = false;
   #keepParsingAfterRelease = false;
@@ -476,7 +477,10 @@ export class EmptyCompletionGuard extends Transform {
       if (!this.#settled()) {
         this.#parseBuffer += this.#decoder.write(bytes);
         this.#consumeBlocks();
-        if (Buffer.byteLength(this.#parseBuffer) > this.#maxPreludeBytes) {
+        if (
+          !this.#settled() &&
+          Buffer.byteLength(this.#parseBuffer) > this.#maxPreludeBytes
+        ) {
           this.#failPrelude("bytes");
         }
         if (!this.#settled()) this.#startTimer({ reset: true });
@@ -488,7 +492,20 @@ export class EmptyCompletionGuard extends Transform {
     this.#parseBuffer += this.#decoder.write(bytes);
     this.#consumeBlocks();
     if (!this.#released && this.#bufferedBytes > this.#maxPreludeBytes) {
-      this.#failPrelude("bytes");
+      // A large but well-framed prologue is not a broken stream. Providers can
+      // echo substantial response metadata before the first delta; relaying a
+      // completed JSON event bounds our staging memory while parsing behind
+      // the relay preserves the eventual empty/content verdict. An unframed or
+      // unparseable body still fails closed at the same byte limit.
+      if (
+        this.#sawParseableEvent &&
+        !this.#sawTerminal &&
+        Buffer.byteLength(this.#parseBuffer) <= this.#maxPreludeBytes
+      ) {
+        this.#release({ preludeLimit: "bytes" });
+      } else {
+        this.#failPrelude("bytes");
+      }
     }
   }
 
@@ -570,6 +587,18 @@ export class EmptyCompletionGuard extends Transform {
 
   #classifyBlock(block) {
     const { eventType, dataText } = this.#fields(block);
+    if (dataText === "[DONE]") {
+      this.#sawParseableEvent = true;
+    } else if (dataText) {
+      try {
+        JSON.parse(dataText);
+        this.#sawParseableEvent = true;
+      } catch {
+        // `#contentOf` below keeps malformed terminal data indeterminate. The
+        // byte-budget decision remains fail-closed unless another complete
+        // JSON event already established framing.
+      }
+    }
     // Content is decided before the terminal check: a gateway that puts the
     // whole turn in `response.completed` emits a terminal event that is also
     // the only content event in the stream.

--- a/test/empty-completion-guard.test.mjs
+++ b/test/empty-completion-guard.test.mjs
@@ -602,6 +602,79 @@ test("a byte limit fails before relaying any staged bytes", async () => {
   assert.equal(Buffer.concat(chunks).length, 0);
 });
 
+test("a large parseable prologue is relayed at the byte budget and later content wins", async () => {
+  const prologue = [
+    "event: response.created",
+    `data: ${JSON.stringify({
+      type: "response.created",
+      response: { id: "r1", metadata: "x".repeat(256) },
+    })}`,
+    "",
+    "",
+  ].join("\n");
+  const answer = [
+    "event: response.output_text.delta",
+    'data: {"type":"response.output_text.delta","delta":"ok"}',
+    "",
+    "event: response.completed",
+    'data: {"type":"response.completed","response":{"id":"r1","output":[]}}',
+    "",
+    "",
+  ].join("\n");
+  const guard = new EmptyCompletionGuard("text/event-stream", {
+    maxPreludeBytes: 64,
+    maxPreludeMs: 1_000,
+  });
+  const chunks = [];
+  await pipeline(
+    Readable.from([Buffer.from(prologue), Buffer.from(answer)]),
+    guard,
+    new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    }),
+  );
+  assert.equal(guard.hasContent(), true);
+  assert.equal(guard.isEmpty(), false);
+  assert.equal(guard.suppressedPrologue(), false);
+  assert.equal(guard.preludeLimitKind(), "bytes");
+  assert.equal(Buffer.concat(chunks).toString("utf8"), prologue + answer);
+});
+
+test("a valid event does not excuse a later oversized unterminated event", async () => {
+  const created = [
+    "event: response.created",
+    'data: {"type":"response.created","response":{"id":"r1"}}',
+    "",
+    "",
+  ].join("\n");
+  const guard = new EmptyCompletionGuard("text/event-stream", {
+    maxPreludeBytes: 64,
+    maxPreludeMs: 1_000,
+  });
+  const chunks = [];
+  await assert.rejects(
+    pipeline(
+      Readable.from([
+        Buffer.from(created + `event: response.in_progress\ndata: ${"x".repeat(128)}`),
+      ]),
+      guard,
+      new Writable({
+        write(chunk, _encoding, callback) {
+          chunks.push(Buffer.from(chunk));
+          callback();
+        },
+      }),
+    ),
+    (error) =>
+      error instanceof EmptyCompletionPreludeLimitError && error.kind === "bytes",
+  );
+  assert.equal(guard.suppressedPrologue(), true);
+  assert.equal(Buffer.concat(chunks).length, 0);
+});
+
 test("a time limit relays the staged stream but keeps its empty verdict", async () => {
   const split = SILENT_TURN.indexOf("event: response.completed");
   async function* delayedTurn() {


### PR DESCRIPTION
## Problem

PR #426 changed the empty-completion guard's 1 MiB pre-content budget from a conservative release into a hard failure. Some routed Responses streams send more than 1 MiB of valid, parseable response metadata before their first visible output delta. Those turns generated output, but the router retried them and eventually returned:

> The model produced no output before the router's safety limit.

This reproduced consistently with GLM-5.3 and Kimi K3 through opencode Go. Failed usage rows sometimes already had a first-token timestamp or output-token count, confirming that the upstream model was not silent.

## Cause

Two guard conditions combined:

1. Crossing the byte budget always threw, even after complete JSON SSE events had established that the stream was well framed.
2. After a budget/liveness release, the guard checked the residual parse buffer even when parsing the same chunk had just recognized output and settled the stream.

The second condition could therefore turn an already recognized output delta into a false byte-limit error.

## Fix

- Relay a large prologue at the byte budget when at least one complete JSON SSE event has parsed, no terminal event has arrived, and the current partial event remains within the parser bound.
- Re-check settlement before applying the post-release residual-buffer limit.
- Keep malformed or oversized unterminated events fail-closed.

This restores the coherent-attempt behavior from the original empty-completion work in PR #145 without removing PR #426's bounds or retry/error semantics.

## Verification

- `node test/empty-completion-guard.test.mjs` — 36 passed
- `node test/empty-completion-router.test.mjs` — 25 passed
- `node test/pipe-response.test.mjs` — 8 passed
- `npm run check` — passed
- `git diff --check` — passed
- Live GLM-5.3 probe after restarting the narrowed build: exact `GLM_STREAM_OK`, HTTP 200, 4 output tokens; telemetry recorded `emptyCompletionPreludeLimit: "bytes"`, proving the repaired budget-release path was exercised.

The regression tests include both the valid large-prologue case and a negative control proving that an earlier valid event cannot excuse a later oversized unterminated event.
