### PR TITLE
fix(start): restart the managed service and restore the installed proxy

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -2,4 +2,29 @@
 set -eu
 
 repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
-exec node "$repo_dir/src/start.mjs"
+
+# `stop` unloads the background service, so `start` has to be able to put it
+# back. It used to exec the supervisor in the foreground instead, which made the
+# obvious `stop; start` pair asymmetric: the managed service went away and an
+# unmanaged copy took its place, carrying the calling shell's environment rather
+# than the installed one and dying with the shell that started it. A shell
+# spawned by a desktop app has no proxy variables, so the replacement dialled
+# every upstream directly and answered with a 502 naming an opt-in that was
+# already set -- in the service definition it had just unloaded.
+#
+# The foreground supervisor is still reachable, just never by accident.
+case "${1-}" in
+  --foreground)
+    shift
+    exec node "$repo_dir/src/start.mjs" "$@"
+    ;;
+  "")
+    ;;
+  *)
+    echo "Usage: start [--foreground]" >&2
+    exit 2
+    ;;
+esac
+
+cd "$repo_dir"
+node src/service.mjs start

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -342,7 +342,7 @@ The full lifecycle works in this state:
 ./bin/model-router codex status
 ./bin/model-router codex doctor    # exits 0; idle state reports as warnings
 ./bin/model-router codex stop
-./bin/model-router codex start     # foreground; the service restarts it otherwise
+./bin/model-router codex start     # starts the background service again
 ./bin/model-router codex uninstall
 ```
 

--- a/src/proxy-environment.mjs
+++ b/src/proxy-environment.mjs
@@ -201,3 +201,28 @@ export function serviceProxyEnvironment(
   }
   return values;
 }
+
+// The proxy environment a router process should adopt when its own is silent.
+//
+// `serviceProxyEnvironment` keeps the proxy alive across restarts by writing it
+// into the service definition, which covers every launchd/systemd/Task
+// Scheduler start. Nothing covers a router started any other way: `bin/start`
+// run from a terminal, a debugging foreground run, or -- the case that cost a
+// real installation -- a `stop; start` pair issued from a shell that a desktop
+// app spawned with no proxy variables at all. Such a process inherits the
+// caller's environment, finds no opt-in, dials every upstream directly, and
+// times out on a network that requires the proxy. The 502 surfaces far from
+// the cause and names an opt-in the operator can prove is already set, because
+// it is set -- in the service definition, not in this process.
+//
+// Silence is the only trigger. `proxyEnvironmentDeclared` treats a named proxy
+// or any `NODE_USE_ENV_PROXY`, including `0`, as the operator speaking, so a
+// deliberate unproxied run stays unproxied.
+export function inheritedProxyEnvironment(
+  environment = process.env,
+  { recorded, manifestPath, execArgv } = {},
+) {
+  if (proxyEnvironmentDeclared(environment, execArgv ?? process.execArgv)) return {};
+  const preserved = recorded !== undefined ? recorded : recordedProxyEnvironment(manifestPath);
+  return preserved ? { ...preserved } : {};
+}

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -25,8 +25,38 @@ import { ensureOllamaHeadless } from "./ollama-runtime.mjs";
 import { venvRuntimeProblem } from "./venv-runtime.mjs";
 import { dependencyRepairHint } from "./dependency-repair.mjs";
 import { clearServiceProcessState, writeServiceProcessState } from "./service-process.mjs";
-import { environmentProxyOptedIn } from "./proxy-environment.mjs";
+import {
+  environmentProxyOptedIn,
+  inheritedProxyEnvironment,
+  redactProxyCredentials,
+} from "./proxy-environment.mjs";
 import { antigravityOAuthStatus } from "./antigravity-oauth-status.mjs";
+
+// Before anything reads the environment or spawns a child. A service manager
+// hands this process the proxy the install recorded; a shell hands it whatever
+// the shell had, which for a desktop-app-spawned shell is nothing. Restoring
+// the recorded values here makes every start path -- managed, foreground, or
+// accidental -- reach upstreams the same way, and `commonEnv` below propagates
+// them to the router and the forwarders through `process.env`.
+const restoredProxy = inheritedProxyEnvironment();
+for (const [name, value] of Object.entries(restoredProxy)) {
+  process.env[name] = value;
+}
+// Unconditionally, and never behind MODEL_ROUTER_QUIET: this silently changes
+// where every upstream request goes, and the whole reason the original failure
+// took so long to find is that nothing near the router ever said which network
+// path it was using. A managed start never reaches here -- its environment is
+// declared -- so this line appears only on the paths that need it. The
+// credential in a proxy URL is stripped; the host and port are the point.
+if (Object.keys(restoredProxy).length > 0) {
+  const address = restoredProxy.https_proxy ?? restoredProxy.HTTPS_PROXY
+    ?? restoredProxy.http_proxy ?? restoredProxy.HTTP_PROXY;
+  const shown = redactProxyCredentials({ address }).address;
+  console.error(
+    "[model-router] no proxy environment was inherited; restored the installed one" +
+    `${shown ? ` (${shown})` : ""} from the install manifest.`,
+  );
+}
 
 const dependencyFix = dependencyRepairHint();
 

--- a/test/proxy-environment.test.mjs
+++ b/test/proxy-environment.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  inheritedProxyEnvironment,
   proxyEnvironmentDeclared,
   recordedProxyEnvironment,
   redactProxyCredentials,
@@ -323,5 +324,74 @@ test("a login session's bypass list does not wipe the recorded proxy", () => {
     );
   } finally {
     cleanup();
+  }
+});
+
+test("a router started with a silent environment adopts the recorded proxy", () => {
+  const manifest = manifestWith({ proxyEnvironment: PROXIED });
+  try {
+    // The case that cost a live installation: a shell a desktop app spawned
+    // carries no proxy variables at all, so the router it starts would dial
+    // every upstream directly.
+    assert.deepEqual(
+      inheritedProxyEnvironment({ PATH: "/usr/bin" }, { manifestPath: manifest.file, execArgv: [] }),
+      PROXIED,
+    );
+    // A bypass list on its own is still silence -- it names no proxy and gives
+    // no permission to use one.
+    assert.deepEqual(
+      inheritedProxyEnvironment(
+        { no_proxy: "localhost" },
+        { manifestPath: manifest.file, execArgv: [] },
+      ),
+      PROXIED,
+    );
+  } finally {
+    manifest.cleanup();
+  }
+});
+
+test("an environment that speaks about the proxy is never overridden", () => {
+  const manifest = manifestWith({ proxyEnvironment: PROXIED });
+  try {
+    // Turning the proxy off is a decision, and the recorded values must not
+    // reinstate it behind the operator's back.
+    assert.deepEqual(
+      inheritedProxyEnvironment(
+        { NODE_USE_ENV_PROXY: "0" },
+        { manifestPath: manifest.file, execArgv: [] },
+      ),
+      {},
+    );
+    // So is naming a different proxy.
+    assert.deepEqual(
+      inheritedProxyEnvironment(
+        { HTTP_PROXY: "http://other:8080" },
+        { manifestPath: manifest.file, execArgv: [] },
+      ),
+      {},
+    );
+    // And so is the command-line form of the opt-in.
+    assert.deepEqual(
+      inheritedProxyEnvironment(
+        { PATH: "/usr/bin" },
+        { manifestPath: manifest.file, execArgv: ["--use-env-proxy"] },
+      ),
+      {},
+    );
+  } finally {
+    manifest.cleanup();
+  }
+});
+
+test("an install that recorded no proxy leaves a silent environment alone", () => {
+  const manifest = manifestWith({});
+  try {
+    assert.deepEqual(
+      inheritedProxyEnvironment({ PATH: "/usr/bin" }, { manifestPath: manifest.file, execArgv: [] }),
+      {},
+    );
+  } finally {
+    manifest.cleanup();
   }
 });

--- a/test/service-lifecycle.test.mjs
+++ b/test/service-lifecycle.test.mjs
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const PROXY = "http://127.0.0.1:3213";
+
+// `bin/start` resolves `node` from PATH. A shim that records its arguments and
+// exits instead of running them turns "which layer does this verb reach" into
+// an observable fact, without touching this machine's launchd.
+function withNodeShim(run) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-lifecycle-"));
+  const log = path.join(directory, "argv.log");
+  const shim = path.join(directory, "node");
+  writeFileSync(shim, `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(log)}\nexit 0\n`);
+  chmodSync(shim, 0o755);
+  writeFileSync(log, "");
+  try {
+    return run({
+      env: { ...process.env, PATH: `${directory}${path.delimiter}${process.env.PATH}` },
+      readLog: () => readFileSync(log, "utf8").trim(),
+    });
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("start and stop act on the same layer", { skip: process.platform === "win32" }, () => {
+  withNodeShim(({ env, readLog }) => {
+    execFileSync(path.join(root, "bin", "start"), [], { env, encoding: "utf8" });
+    const started = readLog();
+    // Not `src/start.mjs`. A `start` that execs the supervisor leaves the
+    // service that `stop` unloaded still unloaded, and puts an unmanaged copy
+    // carrying the calling shell's environment in its place.
+    assert.match(started, /src\/service\.mjs start$/);
+    assert.doesNotMatch(started, /start\.mjs$/);
+  });
+
+  withNodeShim(({ env, readLog }) => {
+    execFileSync(path.join(root, "bin", "stop"), [], { env, encoding: "utf8" });
+    assert.match(readLog(), /src\/service\.mjs stop$/);
+  });
+});
+
+test("the foreground supervisor is reachable, but only on purpose", { skip: process.platform === "win32" }, () => {
+  withNodeShim(({ env, readLog }) => {
+    execFileSync(path.join(root, "bin", "start"), ["--foreground"], { env, encoding: "utf8" });
+    assert.match(readLog(), /src\/start\.mjs$/);
+  });
+
+  // An unrecognized argument is refused rather than quietly falling through to
+  // either layer.
+  withNodeShim(({ env, readLog }) => {
+    const result = spawnSync(path.join(root, "bin", "start"), ["--deamon"], { env, encoding: "utf8" });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /Usage: start \[--foreground\]/);
+    assert.equal(readLog(), "");
+  });
+});
+
+test("a supervisor started with no proxy environment adopts the installed one", () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-lifecycle-state-"));
+  try {
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      path.join(stateDir, "install-manifest.json"),
+      JSON.stringify({
+        version: 1,
+        current: {
+          proxyEnvironment: {
+            HTTP_PROXY: `http://user:hunter2@127.0.0.1:3213`,
+            HTTPS_PROXY: PROXY,
+            NODE_USE_ENV_PROXY: "1",
+          },
+        },
+        history: [],
+      }),
+    );
+
+    // Nothing here names a proxy -- exactly what a shell spawned by a desktop
+    // app hands the supervisor. Startup stops at the missing gateway binary,
+    // which is well after the restore and costs no ports or children.
+    const result = spawnSync(process.execPath, [path.join(root, "src", "start.mjs")], {
+      cwd: root,
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        MODEL_ROUTER_TARGET: "codex",
+        MODEL_ROUTER_STATE_DIR: stateDir,
+        MODEL_ROUTER_LITELLM_BIN: path.join(stateDir, "no-such-litellm"),
+      },
+      encoding: "utf8",
+    });
+
+    assert.match(result.stderr, /restored the installed one \(http:\/\/127\.0\.0\.1:3213\)/);
+    // The manifest may hold a proxy password. The log is not where it leaks.
+    assert.doesNotMatch(result.stderr, /hunter2/);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("a declared proxy environment is left exactly as the operator set it", () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-lifecycle-state-"));
+  try {
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      path.join(stateDir, "install-manifest.json"),
+      JSON.stringify({
+        version: 1,
+        current: { proxyEnvironment: { HTTPS_PROXY: PROXY, NODE_USE_ENV_PROXY: "1" } },
+        history: [],
+      }),
+    );
+
+    // This is the managed path: the service definition already carries the
+    // proxy, so there is nothing to restore and nothing to announce.
+    const result = spawnSync(process.execPath, [path.join(root, "src", "start.mjs")], {
+      cwd: root,
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        MODEL_ROUTER_TARGET: "codex",
+        MODEL_ROUTER_STATE_DIR: stateDir,
+        MODEL_ROUTER_LITELLM_BIN: path.join(stateDir, "no-such-litellm"),
+        HTTPS_PROXY: PROXY,
+        NODE_USE_ENV_PROXY: "1",
+      },
+      encoding: "utf8",
+    });
+    assert.doesNotMatch(result.stderr, /restored the installed one/);
+
+    // And an operator who turned the proxy off keeps it off.
+    const off = spawnSync(process.execPath, [path.join(root, "src", "start.mjs")], {
+      cwd: root,
+      env: {
+        PATH: process.env.PATH,
+        HOME: process.env.HOME,
+        MODEL_ROUTER_TARGET: "codex",
+        MODEL_ROUTER_STATE_DIR: stateDir,
+        MODEL_ROUTER_LITELLM_BIN: path.join(stateDir, "no-such-litellm"),
+        NODE_USE_ENV_PROXY: "0",
+      },
+      encoding: "utf8",
+    });
+    assert.doesNotMatch(off.stderr, /restored the installed one/);
+  } finally {
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

`stop` unloads the background service, but `start` exec'd the *foreground* supervisor. The obvious `stop; start` pair was therefore asymmetric: the managed service went away and an unmanaged copy took its place, carrying the calling shell's environment rather than the installed one, and dying with the shell that started it.

A shell spawned by a desktop app has no proxy variables. So the replacement dialled every upstream directly and answered with **a 502 naming an opt-in that was already set** — set in the service definition it had just unloaded. The error surfaced far from its cause.

## Change

- `bin/start` restarts the managed service. The foreground supervisor stays reachable, but only behind an explicit `--foreground`.
- `inheritedProxyEnvironment()` restores the recorded proxy for any start path whose own environment is silent. Silence is the only trigger — `NODE_USE_ENV_PROXY=0` counts as the operator speaking, so a deliberately unproxied run stays unproxied.
- `src/start.mjs` applies it before anything reads the environment or spawns a child, and logs the restored host unconditionally (credential redacted). Nothing near the router previously said which network path it was using, which is the main reason the original failure took so long to find.

## Tests

21 passing, including `start and stop act on the same layer`, `the foreground supervisor is reachable, but only on purpose`, and `a declared proxy environment is left exactly as the operator set it`. Verified the live launchd service is untouched by the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
