### PR TITLE
feat(discovery): audit provider model catalogs on a schedule

### DIFF
--- a/.github/workflows/model-discovery.yml
+++ b/.github/workflows/model-discovery.yml
@@ -1,21 +1,25 @@
 name: Provider model discovery
 
 "on":
+  pull_request: {}
+  schedule:
+    # Monday 04:17 UTC. The offset avoids the busiest top-of-hour window.
+    - cron: "17 4 * * 1"
   workflow_dispatch:
     inputs:
       provider:
-        description: API-key provider to inspect
+        description: Provider ID to inspect, or all configured providers
         required: true
-        type: choice
-        options:
-          - deepseek
-          - kimi-api
+        default: all
+        type: string
 
 permissions:
   contents: read
 
 jobs:
-  discover:
+  deterministic:
+    if: github.event_name == 'pull_request'
+    name: Deterministic discovery tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -24,21 +28,80 @@ jobs:
           node-version: "24"
           cache: npm
       - run: npm ci
-      - name: Compare official model list with the registry
+      - name: Verify fixture-backed discovery and workflow isolation
+        run: node --test test/model-discovery-audit.test.mjs test/model-discovery.test.mjs
+
+  live-audit:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    name: Live provider catalog audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # Scheduled and manual audits always execute the default branch. A user
+      # cannot select a feature branch and expose repository secrets to it.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+      - run: npm ci
+      - name: Audit official provider model lists
         env:
+          PROVIDER: ${{ github.event_name == 'workflow_dispatch' && inputs.provider || 'all' }}
+          # Only secrets present in repository settings become configured
+          # provider credentials. Scope them to this step so checkout, setup,
+          # and npm lifecycle scripts never receive provider keys.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+          CHUTES_API_KEY: ${{ secrets.CHUTES_API_KEY }}
+          CLINE_API_KEY: ${{ secrets.CLINE_API_KEY }}
+          COMMAND_CODE_API_KEY: ${{ secrets.COMMAND_CODE_API_KEY }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          HUGGINGFACE_API_KEY: ${{ secrets.HUGGINGFACE_API_KEY }}
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
-          PROVIDER: ${{ inputs.provider }}
+          KIMI_API_CN_KEY: ${{ secrets.KIMI_API_CN_KEY }}
+          META_API_KEY: ${{ secrets.META_API_KEY }}
+          MIMO_API_KEY: ${{ secrets.MIMO_API_KEY }}
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          NANOGPT_API_KEY: ${{ secrets.NANOGPT_API_KEY }}
+          NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}
+          NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
+          OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          ORCAROUTER_API_KEY: ${{ secrets.ORCAROUTER_API_KEY }}
+          QWEN_PLAN_API_KEY: ${{ secrets.QWEN_PLAN_API_KEY }}
+          SILICONFLOW_API_KEY: ${{ secrets.SILICONFLOW_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          VENICE_API_KEY: ${{ secrets.VENICE_API_KEY }}
+          XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+          ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
+          ZAI_PLATFORM_API_KEY: ${{ secrets.ZAI_PLATFORM_API_KEY }}
         shell: bash
         run: |
-          if [ "$PROVIDER" = deepseek ] && [ -z "$DEEPSEEK_API_KEY" ]; then
-            echo "Configure the DEEPSEEK_API_KEY repository secret before running discovery." >&2
-            exit 1
+          set -euo pipefail
+          args=(
+            --provider "$PROVIDER"
+            --output provider-model-audit.json
+            --summary "$GITHUB_STEP_SUMMARY"
+            --fail-on-error
+          )
+          if [ "$PROVIDER" != all ]; then
+            args+=(--fail-on-skipped)
           fi
-          if [ "$PROVIDER" = kimi-api ] && [ -z "$KIMI_API_KEY" ]; then
-            echo "Configure the KIMI_API_KEY repository secret before running discovery." >&2
-            exit 1
-          fi
-          node src/model-discovery.mjs "$PROVIDER" --json | tee discovery.json
-          summary=$(node -e 'const x=require("./discovery.json"); console.log(`New candidates: ${x.unregistered.join(", ")||"none"}\nUnavailable: ${x.unavailable.join(", ")||"none"}`)')
-          printf '## %s model discovery\n\n%s\n' "$PROVIDER" "$summary" >> "$GITHUB_STEP_SUMMARY"
+          node src/model-discovery-audit.mjs "${args[@]}"
+      - name: Upload provider model audit
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: provider-model-audit-${{ github.run_id }}
+          path: provider-model-audit.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -52,6 +52,32 @@ the account endpoint, caches the validated account routing briefly, allowlists
 the returned inference host, and builds provider identity headers. Do not reuse
 that profile for another vendor.
 
+## Audit provider model catalogs
+
+The **Provider model discovery** GitHub workflow has three deliberately
+separate paths:
+
+- Pull requests run only fixture-backed discovery tests. They receive no
+  provider secrets and never call a live model endpoint.
+- A weekly default-branch run audits every anonymous catalog and every API-key
+  catalog whose matching repository secret is configured.
+- A manual run accepts `all`, one provider ID, or a comma-separated set. A
+  targeted run fails when a requested provider's credential is absent; an
+  `all` run records unconfigured providers as skipped so one missing
+  subscription does not hide the rest of the audit.
+
+Repository secret names match the provider credential environment names in
+`config/`; the workflow maps the supported names explicitly. Add only the
+providers the repository is authorized to audit. GitHub Copilot requires the
+fine-grained PAT described above in `COPILOT_GITHUB_TOKEN` rather than the
+workflow's ordinary `GITHUB_TOKEN`.
+
+Each live run uploads `provider-model-audit.json` and writes a job summary with
+new candidates, unavailable registered IDs, skips, and failures. The report is
+research input only: `src/model-discovery-audit.mjs` never invokes curation or
+changes the registry. A newly advertised slug still needs the normal live
+compatibility proof before it can become a listed model.
+
 ## Registry rules
 
 The registry is intentionally declarative. `src/model-registry.mjs` rejects

--- a/src/model-discovery-audit.mjs
+++ b/src/model-discovery-audit.mjs
@@ -1,0 +1,287 @@
+import {
+  appendFileSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { discoverProviderModels } from "./model-discovery.mjs";
+import { PROVIDERS } from "./model-registry.mjs";
+import {
+  providerCatalogKind,
+  providerCatalogRouteIds,
+  providerCatalogSources,
+} from "./provider-catalogs.mjs";
+import { resolveProviderCredential } from "./provider-credentials.mjs";
+
+function option(args, name) {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+function normalizeRequestedProviders(value) {
+  const ids = String(value || "all")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  return ids.length ? [...new Set(ids)] : ["all"];
+}
+
+function canonicalProviderIds(providers) {
+  return [...providers.values()]
+    .filter((provider) => !provider.variantOf && providerCatalogSources(provider.id, providers).length)
+    .map((provider) => provider.id)
+    .sort();
+}
+
+// One provider card may own several endpoints, while protocol variants on the
+// same endpoint must be queried only once. Keep that grouping identical to the
+// Control Center so the weekly report and the list a user opens cannot drift.
+export function auditCatalogSourceIds(requested = "all", providers = PROVIDERS) {
+  const requestedIds = normalizeRequestedProviders(requested);
+  const roots = requestedIds.includes("all")
+    ? canonicalProviderIds(providers)
+    : requestedIds;
+  const sourceIds = [];
+  for (const id of roots) {
+    const provider = providers.get(id);
+    if (!provider) throw new Error(`Unknown provider: ${id}`);
+    const sources = providerCatalogSources(id, providers);
+    if (!sources.length) throw new Error(`${provider.displayName} does not expose a discoverable model catalog.`);
+    // An explicit endpoint variant such as opencode-zen means that endpoint;
+    // selecting its canonical provider card means every distinct endpoint the
+    // card owns. Same-endpoint variants fold to the source descriptor above.
+    const exact = provider.variantOf && sources.find((source) => (
+      providerCatalogRouteIds(source.id, providers).includes(id)
+    ));
+    sourceIds.push(...(exact ? [exact.id] : sources.map((source) => source.id)));
+  }
+  return [...new Set(sourceIds)].sort();
+}
+
+function defaultReadiness(provider) {
+  if (providerCatalogKind(provider) === "devin") {
+    return {
+      ready: false,
+      reason: "This catalog requires a local Devin CLI session and cannot use a repository API-key secret.",
+    };
+  }
+  if (provider.kind !== "openai-compatible") {
+    return { ready: false, reason: "This provider has no repository-auditable model endpoint." };
+  }
+  return resolveProviderCredential(provider)
+    ? { ready: true }
+    : { ready: false, reason: "No repository secret is configured for this provider." };
+}
+
+function secretValues(provider, credentialResolver) {
+  if (provider.kind !== "openai-compatible") return [];
+  try {
+    const credential = credentialResolver(provider);
+    return typeof credential?.value === "string" && credential.value
+      ? [credential.value]
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function redactAuditError(error, secrets = []) {
+  let message = error instanceof Error ? error.message : String(error);
+  for (const secret of secrets) {
+    if (secret.length >= 4) message = message.split(secret).join("[redacted]");
+  }
+  return message
+    .replace(/Bearer\s+[^\s,;]+/gi, "Bearer [redacted]")
+    .replace(/((?:api[_ -]?key|access[_ -]?token|authorization)\s*[:=]\s*)[^\s,;]+/gi, "$1[redacted]")
+    .slice(0, 1_000);
+}
+
+function sortedStrings(values) {
+  return [...new Set(Array.isArray(values) ? values.map(String) : [])].sort();
+}
+
+function safeDiscoveryResult(result) {
+  const blocked = Object.fromEntries(
+    Object.entries(result.blocked || {}).sort(([left], [right]) => left.localeCompare(right)),
+  );
+  const contextLengths = Object.fromEntries(
+    Object.entries(result.contextLengths || {}).sort(([left], [right]) => left.localeCompare(right)),
+  );
+  return {
+    models: sortedStrings(result.discovered),
+    registered: sortedStrings(result.registered),
+    unregistered: sortedStrings(result.unregistered),
+    addable: sortedStrings(result.addable),
+    blocked,
+    unavailable: sortedStrings(result.unavailable),
+    contextLengths,
+    ...(Array.isArray(result.free) ? { free: sortedStrings(result.free) } : {}),
+  };
+}
+
+function auditSummary(results) {
+  const succeeded = results.filter(({ status }) => status === "succeeded");
+  return {
+    catalogs: results.length,
+    succeeded: succeeded.length,
+    skipped: results.filter(({ status }) => status === "skipped").length,
+    failed: results.filter(({ status }) => status === "failed").length,
+    models: succeeded.reduce((total, result) => total + result.models.length, 0),
+    unregistered: succeeded.reduce((total, result) => total + result.unregistered.length, 0),
+    unavailable: succeeded.reduce((total, result) => total + result.unavailable.length, 0),
+  };
+}
+
+export async function auditProviderModels({
+  requested = "all",
+  providers = PROVIDERS,
+  discover = (providerId) => discoverProviderModels(providerId, { refresh: true, cache: false }),
+  readiness = defaultReadiness,
+  credentialResolver = resolveProviderCredential,
+  generatedAt = new Date().toISOString(),
+} = {}) {
+  const sources = auditCatalogSourceIds(requested, providers);
+  const results = [];
+  for (const providerId of sources) {
+    const provider = providers.get(providerId);
+    const available = await readiness(provider);
+    if (!available?.ready) {
+      results.push({
+        provider: providerId,
+        displayName: provider.displayName,
+        status: "skipped",
+        reason: available?.reason || "This catalog is not configured for repository discovery.",
+      });
+      continue;
+    }
+    try {
+      const result = await discover(providerId);
+      results.push({
+        provider: providerId,
+        displayName: provider.displayName,
+        status: "succeeded",
+        ...safeDiscoveryResult(result),
+      });
+    } catch (error) {
+      results.push({
+        provider: providerId,
+        displayName: provider.displayName,
+        status: "failed",
+        error: redactAuditError(error, secretValues(provider, credentialResolver)),
+      });
+    }
+  }
+  return {
+    version: 1,
+    generatedAt,
+    requested: normalizeRequestedProviders(requested),
+    results,
+    summary: auditSummary(results),
+    note: "This audit reports provider catalogs only. It never edits the registry or lists an unverified model in Codex.",
+  };
+}
+
+function markdownCell(value) {
+  return String(value ?? "").replaceAll("|", "\\|").replace(/\s+/g, " ").trim();
+}
+
+function summarizeIds(ids, limit = 8) {
+  const values = Array.isArray(ids) ? ids : [];
+  const visible = values.slice(0, limit).join(", ");
+  return values.length > limit ? `${visible} (+${values.length - limit} more)` : visible;
+}
+
+export function renderAuditMarkdown(audit) {
+  const lines = [
+    "## Provider model audit",
+    "",
+    `Generated: ${audit.generatedAt}`,
+    "",
+    "| Provider | Status | Models | New | Unavailable | Detail |",
+    "| --- | --- | ---: | ---: | ---: | --- |",
+  ];
+  for (const result of audit.results) {
+    const detail = result.status === "failed"
+      ? result.error
+      : result.status === "skipped"
+        ? result.reason
+        : result.unregistered.length
+          ? summarizeIds(result.unregistered)
+          : "No catalog drift";
+    lines.push(
+      `| ${markdownCell(result.provider)} | ${result.status} | ${result.models?.length ?? 0} | ` +
+        `${result.unregistered?.length ?? 0} | ${result.unavailable?.length ?? 0} | ${markdownCell(detail)} |`,
+    );
+  }
+  lines.push(
+    "",
+    `Succeeded: ${audit.summary.succeeded}; skipped: ${audit.summary.skipped}; failed: ${audit.summary.failed}.`,
+    `Discovered models: ${audit.summary.models}; new candidates: ${audit.summary.unregistered}; unavailable registered IDs: ${audit.summary.unavailable}.`,
+    "",
+    audit.note,
+    "",
+  );
+  return lines.join("\n");
+}
+
+function fixtureDiscovery(fixtureDirectory) {
+  return async (providerId) => {
+    const fixture = path.join(fixtureDirectory, `${providerId}.json`);
+    const payload = JSON.parse(readFileSync(fixture, "utf8"));
+    return discoverProviderModels(providerId, {
+      cache: false,
+      fixture: true,
+      loadPayload: async () => payload,
+    });
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--help")) {
+    process.stdout.write(`Usage: model-discovery-audit.mjs [--provider all|ID[,ID...]]
+  [--output FILE] [--summary FILE] [--fixture-dir DIR] [--generated-at ISO]
+  [--fail-on-error] [--fail-on-skipped]
+
+Audits each canonical provider catalog and writes a credential-free JSON report.
+Missing credentials are skipped during an all-provider audit. The command never
+edits the registry or curates discovered model IDs.
+`);
+    return;
+  }
+  for (const name of ["--provider", "--output", "--summary", "--fixture-dir", "--generated-at"]) {
+    if (args.includes(name) && (!option(args, name) || option(args, name).startsWith("--"))) {
+      throw new Error(`${name} requires a value.`);
+    }
+  }
+  const fixtureDirectory = option(args, "--fixture-dir");
+  const generatedAt = option(args, "--generated-at") || new Date().toISOString();
+  if (Number.isNaN(Date.parse(generatedAt))) throw new Error("--generated-at must be an ISO date-time.");
+  const audit = await auditProviderModels({
+    requested: option(args, "--provider") || "all",
+    ...(fixtureDirectory
+      ? {
+          discover: fixtureDiscovery(path.resolve(fixtureDirectory)),
+          readiness: () => ({ ready: true }),
+        }
+      : {}),
+    generatedAt: new Date(generatedAt).toISOString(),
+  });
+  const serialized = `${JSON.stringify(audit, null, 2)}\n`;
+  const output = option(args, "--output");
+  if (output) writeFileSync(path.resolve(output), serialized, { encoding: "utf8", mode: 0o600 });
+  else process.stdout.write(serialized);
+  const summary = option(args, "--summary");
+  if (summary) appendFileSync(path.resolve(summary), renderAuditMarkdown(audit), "utf8");
+  if (args.includes("--fail-on-error") && audit.summary.failed) process.exitCode = 1;
+  if (args.includes("--fail-on-skipped") && audit.summary.skipped) process.exitCode = 1;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`codex-router model-discovery-audit: ${redactAuditError(error)}`);
+    process.exit(1);
+  });
+}

--- a/src/model-discovery.mjs
+++ b/src/model-discovery.mjs
@@ -239,7 +239,7 @@ async function providerPayload(provider, identity) {
  */
 export async function discoverProviderModels(
   providerId,
-  { refresh = false, cache = true, loadPayload = providerPayload } = {},
+  { refresh = false, cache = true, fixture = false, loadPayload = providerPayload } = {},
 ) {
   const provider = PROVIDERS.get(providerId);
   if (!provider) throw new Error(`Unknown provider: ${providerId}`);
@@ -259,7 +259,7 @@ export async function discoverProviderModels(
   // A fixture is a file the caller handed in, not what the provider serves.
   // It must never be answered from the stored list and must never become it,
   // whichever entrypoint asked -- discovery's own CLI or curation's.
-  const usingFixture = option("--fixture") !== undefined;
+  const usingFixture = fixture || option("--fixture") !== undefined;
   const storeAnswer = cache && !usingFixture;
   let cached;
   let identity;

--- a/test/model-discovery-audit.test.mjs
+++ b/test/model-discovery-audit.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const { PROVIDERS } = await import("../src/model-registry.mjs");
+const { providerCatalogKind } = await import("../src/provider-catalogs.mjs");
+const {
+  auditCatalogSourceIds,
+  auditProviderModels,
+  redactAuditError,
+  renderAuditMarkdown,
+} = await import("../src/model-discovery-audit.mjs");
+
+test("the audit folds same-endpoint variants and keeps distinct family catalogs", () => {
+  const opencode = auditCatalogSourceIds("opencode-go");
+  assert.deepEqual(opencode, ["opencode-go", "opencode-zen"]);
+  assert.deepEqual(auditCatalogSourceIds("opencode-go-messages"), ["opencode-go"]);
+  assert.deepEqual(auditCatalogSourceIds("opencode-zen"), ["opencode-zen"]);
+  assert.equal(new Set(auditCatalogSourceIds("all")).size, auditCatalogSourceIds("all").length);
+});
+
+test("the audit preserves successes when another configured provider fails", async () => {
+  const secret = "audit-secret-value";
+  const audit = await auditProviderModels({
+    requested: "deepseek,kimi-api",
+    generatedAt: "2026-08-25T00:00:00.000Z",
+    readiness: () => ({ ready: true }),
+    credentialResolver: () => ({ value: secret }),
+    discover: async (providerId) => {
+      if (providerId === "kimi-api") {
+        throw new Error(`Authorization: Bearer ${secret}`);
+      }
+      return {
+        discovered: ["new-model", "deepseek-v4-pro", "new-model"],
+        registered: ["deepseek-v4-pro"],
+        unregistered: ["new-model"],
+        addable: ["new-model"],
+        blocked: {},
+        unavailable: [],
+        contextLengths: { "new-model": 200_000 },
+      };
+    },
+  });
+  assert.deepEqual(audit.summary, {
+    catalogs: 2,
+    succeeded: 1,
+    skipped: 0,
+    failed: 1,
+    models: 2,
+    unregistered: 1,
+    unavailable: 0,
+  });
+  assert.deepEqual(audit.results[0].models, ["deepseek-v4-pro", "new-model"]);
+  assert.equal(audit.results[1].status, "failed");
+  assert.doesNotMatch(JSON.stringify(audit), new RegExp(secret));
+  assert.match(audit.results[1].error, /\[redacted\]/);
+});
+
+test("missing credentials are reported as skips without attempting discovery", async () => {
+  let calls = 0;
+  const audit = await auditProviderModels({
+    requested: "deepseek",
+    generatedAt: "2026-08-25T00:00:00.000Z",
+    readiness: () => ({ ready: false, reason: "No repository secret is configured." }),
+    discover: async () => {
+      calls += 1;
+      throw new Error("must not run");
+    },
+  });
+  assert.equal(calls, 0);
+  assert.equal(audit.summary.skipped, 1);
+  assert.equal(audit.results[0].status, "skipped");
+});
+
+test("fixture-backed CLI output is deterministic and never edits the registry", () => {
+  const temporary = mkdtempSync(path.join(os.tmpdir(), "codex-router-model-audit-"));
+  const fixture = path.join(temporary, "deepseek.json");
+  const first = path.join(temporary, "first.json");
+  const second = path.join(temporary, "second.json");
+  const registryBefore = readFileSync(path.join(root, "config/deepseek/deepseek.json"), "utf8");
+  writeFileSync(fixture, JSON.stringify({ data: [{ id: "deepseek-v4-pro" }, { id: "future-model" }] }));
+  const command = [
+    "src/model-discovery-audit.mjs",
+    "--provider", "deepseek",
+    "--fixture-dir", temporary,
+    "--generated-at", "2026-08-25T00:00:00Z",
+  ];
+  try {
+    execFileSync(process.execPath, [...command, "--output", first], {
+      cwd: root,
+      env: {
+        ...process.env,
+        CODEX_ROUTER_STATE_DIR: path.join(temporary, "empty-state"),
+        DEEPSEEK_API_KEY: "",
+      },
+    });
+    execFileSync(process.execPath, [...command, "--output", second], {
+      cwd: root,
+      env: {
+        ...process.env,
+        CODEX_ROUTER_STATE_DIR: path.join(temporary, "empty-state"),
+        DEEPSEEK_API_KEY: "",
+      },
+    });
+    assert.equal(readFileSync(first, "utf8"), readFileSync(second, "utf8"));
+    const audit = JSON.parse(readFileSync(first, "utf8"));
+    assert.deepEqual(audit.results[0].models, ["deepseek-v4-pro", "future-model"]);
+    assert.deepEqual(audit.results[0].unregistered, ["future-model"]);
+    assert.equal(
+      readFileSync(path.join(root, "config/deepseek/deepseek.json"), "utf8"),
+      registryBefore,
+    );
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+});
+
+test("the audit markdown summarizes drift without exposing multiline output", async () => {
+  const ids = Array.from({ length: 12 }, (_, index) => `future-${index + 1}`);
+  const audit = await auditProviderModels({
+    requested: "deepseek",
+    generatedAt: "2026-08-25T00:00:00.000Z",
+    readiness: () => ({ ready: true }),
+    discover: async () => ({
+      discovered: ["future|model", ...ids],
+      registered: [],
+      unregistered: ["future|model", ...ids],
+      addable: ["future|model", ...ids],
+      blocked: {},
+      unavailable: [],
+      contextLengths: {},
+    }),
+  });
+  const markdown = renderAuditMarkdown(audit);
+  assert.match(markdown, /\| deepseek \| succeeded \| 13 \| 13 \| 0 \|/);
+  assert.match(markdown, /\(\+5 more\)/);
+  assert.doesNotMatch(markdown, /future-9/);
+  assert.match(markdown, /never edits the registry/);
+});
+
+test("generic audit error redaction covers bearer and API-key assignments", () => {
+  const message = redactAuditError("Bearer abcdef API_KEY=ghijkl");
+  assert.equal(message, "Bearer [redacted] API_KEY=[redacted]");
+});
+
+test("the discovery workflow keeps live secrets away from pull-request code", () => {
+  const workflow = readFileSync(path.join(root, ".github/workflows/model-discovery.yml"), "utf8");
+  assert.match(workflow, /^\s*pull_request:/m);
+  assert.match(workflow, /^\s*schedule:/m);
+  assert.match(workflow, /^\s*workflow_dispatch:/m);
+  assert.doesNotMatch(workflow, /pull_request_target/);
+  assert.match(workflow, /if: github\.event_name == 'pull_request'/);
+  assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
+  assert.match(workflow, /node --test test\/model-discovery-audit\.test\.mjs test\/model-discovery\.test\.mjs/);
+  assert.match(workflow, /actions\/upload-artifact@v7/);
+  assert.match(workflow, /if: always\(\)/);
+  const auditStep = workflow.indexOf("name: Audit official provider model lists");
+  assert.ok(auditStep > 0);
+  assert.doesNotMatch(
+    workflow.slice(0, auditStep),
+    /\$\{\{ secrets\./,
+    "provider secrets must be scoped to the live audit step",
+  );
+  for (const provider of PROVIDERS.values()) {
+    if (
+      provider.variantOf ||
+      providerCatalogKind(provider) !== "models-endpoint" ||
+      provider.authMode === "anonymous" ||
+      provider.keyless
+    ) continue;
+    const names = provider.credential?.environment || [];
+    assert.ok(
+      names.some((name) => workflow.includes(`secrets.${name}`)),
+      `${provider.id} has no repository secret mapping in the live audit step`,
+    );
+  }
+});


### PR DESCRIPTION
## What

Adds `src/model-discovery-audit.mjs` (287 lines), which walks every anonymous catalog and every API-key catalog whose credential is configured, reporting new candidates, unavailable registered IDs, skips, and failures.

**The report is research input only.** It never invokes curation and never changes the registry, so a newly advertised slug still needs the normal live compatibility proof before it can become a listed model.

## Workflow paths

Three deliberately separate paths:

| Trigger | Behaviour | Secrets |
|---|---|---|
| Pull request | Fixture-backed discovery tests only | **None** |
| Weekly cron (Mon 04:17 UTC) | Live audit of all configured providers | Scoped to the audit step |
| Manual dispatch | `all`, one provider ID, or a comma-separated set | Scoped to the audit step |

Two safety properties worth reviewing:

- Scheduled and manual runs pin checkout to the repository's **default branch**, so a user cannot select a feature branch and expose the provider secrets to it.
- Credentials are declared on the audit step rather than the job, so checkout, setup, and npm lifecycle scripts never receive provider keys.

A targeted run fails when a requested provider's credential is absent; an `all` run records unconfigured providers as skipped, so one missing subscription does not hide the rest of the audit.

## Supporting change

`discoverProviderModels` takes a `fixture` option so the tests can exercise the audit without a live endpoint and without touching the stored list.

## Tests

19 passing across `model-discovery-audit.test.mjs` and `model-discovery.test.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
