### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 0.4.0-beta.5
+## 0.5.0
 
 - **Subagent selection is honoured again.** `applyMultiAgentSettings` only ever
   demoted: it read `disabled` and `hidden` and nothing else, so the three modes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.4.0-beta.5
+
 - **Subagent selection is honoured again.** `applyMultiAgentSettings` only ever
   demoted: it read `disabled` and `hidden` and nothing else, so the three modes
   documented in `.claude/skills/codex-subagents/SKILL.md` — `proven`,

--- a/apps/control-center/package-lock.json
+++ b/apps/control-center/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codex-router/control-center",
-  "version": "0.4.0-beta.5",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codex-router/control-center",
-      "version": "0.4.0-beta.5",
+      "version": "0.5.0",
       "dependencies": {
         "lucide-react": "1.31.0",
         "react": "19.2.8",

--- a/apps/control-center/package-lock.json
+++ b/apps/control-center/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codex-router/control-center",
-  "version": "0.4.0-beta.4",
+  "version": "0.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codex-router/control-center",
-      "version": "0.4.0-beta.4",
+      "version": "0.4.0-beta.5",
       "dependencies": {
         "lucide-react": "1.31.0",
         "react": "19.2.8",

--- a/apps/control-center/package.json
+++ b/apps/control-center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-router/control-center",
-  "version": "0.4.0-beta.5",
+  "version": "0.5.0",
   "description": "Electron control center for Codex Router",
   "author": "Codex Router contributors",
   "private": true,

--- a/apps/control-center/package.json
+++ b/apps/control-center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-router/control-center",
-  "version": "0.4.0-beta.4",
+  "version": "0.4.0-beta.5",
   "description": "Electron control center for Codex Router",
   "author": "Codex Router contributors",
   "private": true,

--- a/apps/macos/ModelRouterTray/Tests/ControlContractTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ControlContractTests.swift
@@ -96,7 +96,7 @@ struct ControlContractTests {
     #expect(
       !RouterControlContractPolicy.matches(
         installed: installed,
-        expectedVersion: "0.5.0",
+        expectedVersion: "0.4.0-beta.4",
         expectedProtocol: 1
       )
     )

--- a/apps/macos/ModelRouterTray/Tests/ControlContractTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ControlContractTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite("Native control contract")
 struct ControlContractTests {
   private static func fixture(
-    version: String = "0.4.0-beta.4",
+    version: String = "0.4.0-beta.5",
     protocolVersion: Int = 1
   ) throws -> (root: URL, package: URL) {
     let root = FileManager.default.temporaryDirectory
@@ -85,11 +85,11 @@ struct ControlContractTests {
     let fixture = try Self.fixture()
     defer { try? FileManager.default.removeItem(at: fixture.root) }
     let installed = RouterControlContractPolicy.installedContract(sourceRoot: fixture.root)
-    #expect(installed == RouterControlContract(version: "0.4.0-beta.4", controlProtocol: 1))
+    #expect(installed == RouterControlContract(version: "0.4.0-beta.5", controlProtocol: 1))
     #expect(
       RouterControlContractPolicy.matches(
         installed: installed,
-        expectedVersion: "0.4.0-beta.4",
+        expectedVersion: "0.4.0-beta.5",
         expectedProtocol: 1
       )
     )

--- a/apps/macos/ModelRouterTray/Tests/ControlContractTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/ControlContractTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite("Native control contract")
 struct ControlContractTests {
   private static func fixture(
-    version: String = "0.4.0-beta.5",
+    version: String = "0.5.0",
     protocolVersion: Int = 1
   ) throws -> (root: URL, package: URL) {
     let root = FileManager.default.temporaryDirectory
@@ -85,18 +85,18 @@ struct ControlContractTests {
     let fixture = try Self.fixture()
     defer { try? FileManager.default.removeItem(at: fixture.root) }
     let installed = RouterControlContractPolicy.installedContract(sourceRoot: fixture.root)
-    #expect(installed == RouterControlContract(version: "0.4.0-beta.5", controlProtocol: 1))
+    #expect(installed == RouterControlContract(version: "0.5.0", controlProtocol: 1))
     #expect(
       RouterControlContractPolicy.matches(
         installed: installed,
-        expectedVersion: "0.4.0-beta.5",
+        expectedVersion: "0.5.0",
         expectedProtocol: 1
       )
     )
     #expect(
       !RouterControlContractPolicy.matches(
         installed: installed,
-        expectedVersion: "0.4.0-beta.5",
+        expectedVersion: "0.5.0",
         expectedProtocol: 1
       )
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-model-router",
-  "version": "0.4.0-beta.4",
+  "version": "0.4.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-model-router",
-      "version": "0.4.0-beta.4",
+      "version": "0.4.0-beta.5",
       "dependencies": {
         "proper-lockfile": "4.1.2",
         "undici": "8.10.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-model-router",
-  "version": "0.4.0-beta.5",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-model-router",
-      "version": "0.4.0-beta.5",
+      "version": "0.5.0",
       "dependencies": {
         "proper-lockfile": "4.1.2",
         "undici": "8.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-model-router",
-  "version": "0.4.0-beta.4",
+  "version": "0.4.0-beta.5",
   "private": true,
   "type": "module",
   "description": "Extensible local model router for Codex and Cursor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-model-router",
-  "version": "0.4.0-beta.5",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "description": "Extensible local model router for Codex and Cursor",

--- a/test/subagent-local-verification.test.mjs
+++ b/test/subagent-local-verification.test.mjs
@@ -7,7 +7,7 @@ import {
   verifiedForRoute,
 } from "../src/subagent-proofs.mjs";
 
-const ROUTER_VERSION = "0.4.0-beta.4";
+const ROUTER_VERSION = "0.5.0";
 
 function passingChecks(overrides = {}) {
   const checks = {};

--- a/test/v2-agent-applications.test.mjs
+++ b/test/v2-agent-applications.test.mjs
@@ -50,7 +50,7 @@ function acceptedProof() {
     status: "accepted",
     officialSources: ["https://api-docs.deepseek.com/models/alpha"],
     testedAt: now,
-    routerVersion: "0.4.0-beta.4",
+    routerVersion: "0.5.0",
     checks: Object.fromEntries(
       ["streaming", "toolCall", "encryptedRelay", "markerReturn", "sameThreadFollowUp"]
         .map((name) => [name, { outcome: "pass", status: 200, observedAt: now }]),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Version bump and changelog cut for v0.5.0 stable release.

## Changes

- Bumped version from `0.4.0-beta.4` to `0.5.0` in:
  - `package.json` and `package-lock.json`
  - `apps/control-center/package.json` and `apps/control-center/package-lock.json`
  - `apps/macos/ModelRouterTray/Tests/ControlContractTests.swift` (test expectations)
  - `test/subagent-local-verification.test.mjs` (ROUTER_VERSION constant)
  - `test/v2-agent-applications.test.mjs` (routerVersion fixture)
- Cut CHANGELOG.md: moved Unreleased section contents to `## 0.5.0` heading

## Release Notes

This is a **stable minor release** (0.5.0, not a beta) suitable for:
- Homebrew tap formula
- Homebrew/homebrew-core submission

## What Was NOT Changed (Historical References)

- `v2_agent/zai-coding/glm-5.3/proof.json` - recorded proof artifact
- `CHANGELOG.md` prose mentioning v0.4.0-beta.4 as a past release
- `Formula/codex-router.rb` - release workflow regenerates this after tagging

## Next Steps

After this PR merges and CI is green on the merge commit, tag `v0.5.0` (not v0.4.0-beta.5) on that commit to trigger the release workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1fb295f-8bec-4360-a282-ff464f867bb5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1fb295f-8bec-4360-a282-ff464f867bb5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

