### PR TITLE
Add OpenCode Go Grok 4.6 on Responses API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Grok 4.6 ships on opencode Go.** OpenCode's current Go list and endpoint
+  table publish `grok-4.6` on `/zen/go/v1/responses` (not chat, not messages).
+  The checked-in route is `opencode-go-responses/grok-4.6`, 500,000 context
+  with auto-compact at 440,000, text+image, and the low/medium/high/xhigh
+  ladder models.dev publishes for this id, defaulting to high. No Free twin
+  exists. Grok 4.5 stays on the same Responses variant.
+
 - **Subagent selection is honoured again.** `applyMultiAgentSettings` only ever
   demoted: it read `disabled` and `hidden` and nothing else, so the three modes
   documented in `.claude/skills/codex-subagents/SKILL.md` — `proven`,

--- a/config/opencode/go-responses/grok-4.6.json
+++ b/config/opencode/go-responses/grok-4.6.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "opencode-go-responses/grok-4.6",
+      "gatewayModel": "opencode-go-responses-grok-4-6",
+      "upstreamModel": "grok-4.6",
+      "provider": "opencode-go-responses",
+      "listed": true,
+      "displayName": "Grok 4.6 (opencode Go)",
+      "description": "Grok 4.6 through the opencode Go subscription using the Responses API documented by OpenCode.",
+      "priority": 30,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "medium",
+          "description": "Balanced reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "xhigh",
+          "description": "Maximum reasoning depth"
+        }
+      ],
+      "contextWindow": 500000,
+      "autoCompact": 440000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "compHash": "opencode-go-responses-grok-4-6-v1"
+    }
+  ]
+}

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -203,6 +203,7 @@ const CURATION_ROUTES = Object.freeze({
     responsesModels: Object.freeze([
       "gpt-5.6-luna",
       "grok-4.5",
+      "grok-4.6",
       "muse-spark-1.2-contributor",
     ]),
     primaryModels: Object.freeze([

--- a/test/model-discovery.test.mjs
+++ b/test/model-discovery.test.mjs
@@ -238,7 +238,7 @@ test("the current OpenCode catalogs remain fully fetchable without preselecting 
 
   const goLive = [
     "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro", "glm-5", "glm-5.1", "glm-5.2", "glm-5.3",
-    "gpt-5.6-luna", "grok-4.5", "hy3", "hy3-preview", "kimi-k2.5", "kimi-k2.6",
+    "gpt-5.6-luna", "grok-4.5", "grok-4.6", "hy3", "hy3-preview", "kimi-k2.5", "kimi-k2.6",
     "kimi-k2.7-code", "kimi-k3", "mimo-v2-omni", "mimo-v2-pro", "mimo-v2.5",
     "mimo-v2.5-pro", "minimax-m2.5", "minimax-m2.7", "minimax-m3",
     "muse-spark-1.2-contributor", "ox-alpha-free", "qwen3.5-plus", "qwen3.6-plus",
@@ -253,7 +253,7 @@ test("the current OpenCode catalogs remain fully fetchable without preselecting 
 test("the checked-in OpenCode Go set matches the official current-model table", () => {
   const documented = [
     "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro", "glm-5.1", "glm-5.2", "glm-5.3",
-    "gpt-5.6-luna", "grok-4.5", "hy3", "kimi-k2.6", "kimi-k2.7-code", "kimi-k3",
+    "gpt-5.6-luna", "grok-4.5", "grok-4.6", "hy3", "kimi-k2.6", "kimi-k2.7-code", "kimi-k3",
     "mimo-v2.5", "mimo-v2.5-pro", "minimax-m2.5", "minimax-m2.7", "minimax-m3",
     "muse-spark-1.2-contributor", "ox-alpha-free", "qwen3.6-plus", "qwen3.7-max",
     "qwen3.7-plus", "qwen3.8-max",

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -132,6 +132,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "opencode-go-messages/qwen3.8-max",
       "opencode-go-responses/gpt-5.6-luna",
       "opencode-go-responses/grok-4.5",
+      "opencode-go-responses/grok-4.6",
       "opencode-go-responses/muse-spark-1.2-contributor",
       "opencode-free/ox-alpha",
       "openrouter/ox-alpha",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `opencode-go-responses/grok-4.6` as a listed model following the existing Grok 4.5 pattern. This is a catalog addition only, based on the live OpenCode Go catalog (fetched 2026-08-26) which now includes `grok-4.6` alongside `grok-4.5`.

## Changes

- **New model JSON**: `config/opencode/go-responses/grok-4.6.json`
  - Provider: `opencode-go-responses` (Responses API, not chat)
  - Slug: `opencode-go-responses/grok-4.6`
  - Context: 500,000 tokens (autoCompact at 440,000)
  - Input modalities: text + image
  - Reasoning ladder: low/medium/high/xhigh (from models.dev)
  - Default effort: high (matches grok-4.5 and grok-oauth/grok-4.6)
  - Priority: 30 (same as grok-4.5)

- **Curation support**: Added `grok-4.6` to `src/opencode-curation.mjs` `responsesModels` array so `curate-models` and discovery recognize this id on the Responses protocol

- **Tests**: Updated `test/registry.test.mjs` LISTED_MODELS with the new slug

- **CHANGELOG**: Added unreleased entry

## Notes

- No static alias needed (unlike grok-4.5, this model never lived on chat)
- No Free variant exists
- Grok 4.5 remains unchanged on the same Responses route
- Does not touch PR #453 (v0.5.0 bump) or PR #455 (Nous catalog)

## Verification

✅ `node --test test/registry.test.mjs` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-818b45c7-d599-4b4b-b259-5022a8f64250?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-818b45c7-d599-4b4b-b259-5022a8f64250&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

