### PR TITLE
Apply the choice-bearing usage compat transform to opencode-go (cached_tokens=0 → real cache reads)

### DIFF
--- a/src/zai-cache-usage.mjs
+++ b/src/zai-cache-usage.mjs
@@ -89,8 +89,15 @@ export class ZaiCacheUsageCompatTransform extends Transform {
   }
 }
 
+// opencode-go (Console Go /v1/chat/completions) sends the same shape: usage on
+// the finish_reason chunk with a non-empty choices array, then [DONE]. LiteLLM
+// 1.96 discards it (BerriAI/litellm#36168), so Codex reports cached_tokens=0
+// even though Go caches the prefix (verified 2026-08-26: mimo-v2.5 returned
+// cached_tokens 2560/2571 on a repeated prefix when called directly).
+const CHOICE_BEARING_USAGE_PROVIDERS = ["zai-api", "zai-coding", "opencode-go"];
+
 export function zaiCacheUsageTransform(providerId, contentType = "") {
-  if (!["zai-api", "zai-coding"].includes(String(providerId))) return undefined;
+  if (!CHOICE_BEARING_USAGE_PROVIDERS.includes(String(providerId))) return undefined;
   if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
   return new ZaiCacheUsageCompatTransform();
 }

--- a/test/zai-cache-usage.test.mjs
+++ b/test/zai-cache-usage.test.mjs
@@ -33,6 +33,10 @@ test("cache compatibility is installed only for Z.ai event streams", () => {
   assert.ok(zaiCacheUsageTransform("zai-api", "text/event-stream; charset=utf-8"));
   assert.equal(zaiCacheUsageTransform("zai-coding", "application/json"), undefined);
   assert.equal(zaiCacheUsageTransform("deepseek", "text/event-stream"), undefined);
+  // opencode Go's chat endpoint uses the same choice-bearing terminal usage
+  // shape (litellm#36168), so the compat transform covers it too.
+  assert.ok(zaiCacheUsageTransform("opencode-go", "text/event-stream"));
+  assert.equal(zaiCacheUsageTransform("opencode-go-messages", "text/event-stream"), undefined);
 });
 
 test("non-usage and malformed SSE lines pass through byte-for-byte", async () => {


### PR DESCRIPTION
Fixes #457.

One-line gate change: `zaiCacheUsageTransform()` now also covers `opencode-go`. Console Go's Chat Completions stream has the same choice-bearing terminal usage chunk as Z.ai, which LiteLLM 1.96.0 discards (BerriAI/litellm#36168), so routed `opencode-go/*` sessions reported `cached_input_tokens=0` and an inflated `input_tokens` to Codex.

| Two-turn `opencode-go/mimo-v2.5` session, turn 2 | input_tokens | cached_input_tokens |
| --- | ---: | ---: |
| main | 54,218 | 0 |
| this branch | 37,609 | 36,416 |

`router.log` goes from `cached_tokens=unknown` to `cached_tokens=36416`; `ccusage codex session` shows the Cache Read column for the session.

Scope: `opencode-go` only — the provider whose stream I captured and verified. `opencode-go-messages` (Anthropic protocol) and `opencode-zen` were not tested and are left out. Test: added the gate assertion to `test/zai-cache-usage.test.mjs`; `node --test test/zai-cache-usage.test.mjs` passes (6/6).

And thank you for the router — it is what makes MiMo on the Go subscription usable from Codex in the first place.
