### PR TITLE
fix(kimi): expand definition refs with siblings

### DIFF
--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -314,11 +314,11 @@ export function repairToolSchemaRoot(
   tool,
   { nonRecursive = false, inlineForeignRefs: inlineRefs = false } = {},
 ) {
-  // Moonshot alone rejects a `$ref` that does not point into `#/$defs/`, so
-  // only the route that asks for it pays the inlining -- every other provider
-  // keeps the exact wire payload it has today. `inlineForeignRefs` returns a
-  // schema with no foreign ref by identity, so even on that route an ordinary
-  // toolset is not copied.
+  // Moonshot alone rejects a `$ref` that does not point into `#/$defs/` or one
+  // that carries sibling keywords, so only the route that asks for it pays the
+  // inlining -- every other provider keeps the exact wire payload it has today.
+  // The normalizer returns a clean schema by identity, so an ordinary toolset
+  // is not copied.
   const relaySchema = (schema) => {
     const repaired = providerToolSchema(schema);
     return inlineRefs ? inlineForeignRefs(repaired) : repaired;

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -594,17 +594,15 @@ function needsZenFreeToolCompatibility(route) {
   );
 }
 
-// Moonshot accepts a `$ref` only when it points into `#/$defs/` and rejects the
-// whole request -- not the one tool -- over any other pointer, including the
-// sibling-property pointers Codex App connector tools ship: Wego
-// `_flights_search` points `inboundTotalDurationRange` at its own sibling
-// `priceRange` (issue #353). Scope this to the provider the rejection was
-// reproduced on. The Moonshot platform keys (`kimi-api`, `kimi-api-cn`) reach a
-// different front end and were never observed rejecting these schemas, and
-// inlining for everyone would rewrite the wire payload for providers that work
-// today.
-function needsMoonshotDefsOnlyRefs(route) {
-  return providerForModel(route)?.id === "kimi-oauth";
+// Moonshot accepts only pure `$ref` pointers into `#/$defs/`, and rejects the
+// whole request -- not the one tool -- over any other pointer (issue #353) or a
+// definition reference carrying sibling keywords. The OAuth and platform-key
+// routes are separate products, but their first-party validators share this
+// schema flavor. Keep the rewrite off every non-Moonshot provider.
+const MOONSHOT_PROVIDER_IDS = new Set(["kimi-oauth", "kimi-api", "kimi-api-cn"]);
+
+function needsMoonshotSchemaCompatibility(route) {
+  return MOONSHOT_PROVIDER_IDS.has(providerForModel(route)?.id);
 }
 
 function zenFreeCompatibleInput(input, route) {
@@ -2321,7 +2319,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     tools = repairToolSchemaRoots(tools, { nonRecursive: true });
     tools = stripSearchContentTypes(tools);
   }
-  if (needsMoonshotDefsOnlyRefs(route)) {
+  if (needsMoonshotSchemaCompatibility(route)) {
     // After the namespace flattening above, so the connector tools Codex ships
     // inside `codex_app` are repaired in the shape Moonshot actually receives.
     tools = repairToolSchemaRoots(tools, { inlineForeignRefs: true });

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -1,3 +1,5 @@
+import { isDeepStrictEqual } from "node:util";
+
 // xAI rejects any tool whose parameter schema does not have an object at the
 // root: "tool parameter root must be an object type (root schema is an
 // anyOf/oneOf union with a non-object branch)". The rejection fails the whole
@@ -199,19 +201,23 @@ export function nonRecursiveToolSchema(schema) {
   return cloneWithoutClosingRefs(schema, closing);
 }
 
-// Moonshot validates every `$ref` a tool schema carries and accepts only
+// Moonshot validates every `$ref` a tool schema carries. It accepts only pure
 // pointers into `#/$defs/`, rejecting the whole request -- not the one tool --
-// over anything else. Codex App connector tools break that rule routinely: Wego
-// `_flights_search` points one property at a *sibling* property,
+// over other pointers and over a `$ref` that carries sibling keywords. Codex App
+// connector tools break the first rule routinely: Wego `_flights_search` points
+// one property at a *sibling* property,
 // `#/properties/filters/properties/priceRange`, so a kimi session that never
-// searches a flight still dies on its first message (issue #353).
+// searches a flight still dies on its first message (issue #353). Codex's
+// zod-generated dynamic tools break the second when a `$defs` entry combines a
+// reference with `type`, `format`, or validation constraints.
 //
 // Inlining replaces such a node with its resolved target merged under the
 // node's own siblings. Nothing is invented: the target is the schema the client
 // itself pointed at, and a `description` or `default` declared beside the `$ref`
-// still wins over whatever the target says. `#/$defs/` pointers are left exactly
-// as they are -- they are the form Moonshot asks for, and expanding them would
-// only grow the payload.
+// still wins over whatever the target says. Pure `#/$defs/` pointers are left
+// exactly as they are -- they are the form Moonshot asks for -- while a
+// definition reference carrying siblings is expanded only on a route that asks
+// for this strict validation flavor.
 //
 // Three bounds keep the walk finite. `seen` holds the refs on the current
 // expansion path, so a self-referential or mutually recursive schema stops at
@@ -237,14 +243,24 @@ const MAX_INLINE_DEPTH = 32;
 const MAX_INLINE_EXPANSIONS = 512;
 const MAX_INLINE_BYTES = 256 * 1024;
 
-function inlineChildRefs(node, root, state, seen, depth, refDepth) {
+function inlineChildRefs(node, root, state, seen, depth, refDepth, inlineDefsWithSiblings) {
   let next = node;
   const replace = (key, value) => {
     if (next === node) next = { ...node };
     next[key] = value;
   };
   const inlineChild = (schema) =>
-    isPlainObject(schema) ? inlineNodeRefs(schema, root, state, seen, depth + 1, refDepth) : schema;
+    isPlainObject(schema)
+      ? inlineNodeRefs(
+          schema,
+          root,
+          state,
+          seen,
+          depth + 1,
+          refDepth,
+          inlineDefsWithSiblings,
+        )
+      : schema;
 
   // `dependencies` is draft-07's mixed map: array values list property names
   // rather than schemas, and `inlineChild` passes those through untouched.
@@ -281,16 +297,45 @@ function inlineChildRefs(node, root, state, seen, depth, refDepth) {
   return next;
 }
 
-function inlineNodeRefs(node, root, state, seen, depth, refDepth) {
+function inlineNodeRefs(
+  node,
+  root,
+  state,
+  seen,
+  depth,
+  refDepth,
+  inlineDefsWithSiblings,
+  resolveDefsAliases = false,
+) {
   if (!isPlainObject(node) || depth > MAX_INLINE_DEPTH || state.exceeded) return node;
   const ref = node.$ref;
+  const hasSiblings = Object.keys(node).some((key) => key !== "$ref");
+  const isDefsRef = typeof ref === "string" && ref.startsWith(DEFS_REF_PREFIX);
+  const foreignRef = typeof ref === "string" && !ref.startsWith(DEFS_REF_PREFIX);
+  const defsRefWithSiblings =
+    inlineDefsWithSiblings &&
+    isDefsRef &&
+    hasSiblings;
+  // A decorated definition can point through a chain of pure aliases. Resolve
+  // those only while expanding that decorated reference; an ordinary pure
+  // definition elsewhere remains the valid untouched form Moonshot accepts.
+  const pureDefsAlias = inlineDefsWithSiblings && resolveDefsAliases && isDefsRef;
   const expandable =
-    typeof ref === "string" &&
-    !ref.startsWith(DEFS_REF_PREFIX) &&
+    (foreignRef || defsRefWithSiblings || pureDefsAlias) &&
     !seen.has(ref) &&
     refDepth < MAX_DEPTH;
   const target = expandable ? resolveRef(ref, root) : undefined;
-  if (!isPlainObject(target)) return inlineChildRefs(node, root, state, seen, depth, refDepth);
+  if (!isPlainObject(target)) {
+    return inlineChildRefs(
+      node,
+      root,
+      state,
+      seen,
+      depth,
+      refDepth,
+      inlineDefsWithSiblings,
+    );
+  }
 
   state.expansions += 1;
   if (state.expansions > MAX_INLINE_EXPANSIONS) {
@@ -300,14 +345,46 @@ function inlineNodeRefs(node, root, state, seen, depth, refDepth) {
   seen.add(ref);
   // The target takes the node's place rather than nesting inside it, so the
   // structural depth does not grow; the ref hop is what is charged.
-  const expanded = inlineNodeRefs(target, root, state, seen, depth, refDepth + 1);
+  const expanded = inlineNodeRefs(
+    target,
+    root,
+    state,
+    seen,
+    depth,
+    refDepth + 1,
+    inlineDefsWithSiblings,
+    isDefsRef,
+  );
   seen.delete(ref);
   if (state.exceeded) return node;
   state.inlined = true;
   const { $ref: _inlined, ...siblings } = node;
   // Only the siblings still need walking: the target came back already inlined,
   // and re-walking it would re-expand the very edges `seen` just protected.
-  return { ...expanded, ...inlineChildRefs(siblings, root, state, seen, depth, refDepth) };
+  const rewrittenSiblings = inlineChildRefs(
+    siblings,
+    root,
+    state,
+    seen,
+    depth,
+    refDepth,
+    inlineDefsWithSiblings,
+  );
+  const strictDefsRef = inlineDefsWithSiblings && isDefsRef;
+  // A definition expansion that still carries its own reference reached a
+  // cycle. Moonshot accepts that pure edge, but not the siblings this node
+  // added around it.
+  if (strictDefsRef && expanded.$ref !== undefined) return { $ref: ref };
+  if (strictDefsRef) {
+    const conflicts = Object.keys(rewrittenSiblings).some((key) => (
+      Object.hasOwn(expanded, key) && !isDeepStrictEqual(rewrittenSiblings[key], expanded[key])
+    ));
+    // Overwriting a conflicting assertion would weaken the schema the target
+    // declares. Keep the pure reference instead; the client's sibling and target
+    // already disagree, so this malformed case has no lossless expansion.
+    if (conflicts) return { $ref: ref };
+  }
+  return { ...expanded, ...rewrittenSiblings };
 }
 
 function jsonByteLength(value) {
@@ -321,7 +398,7 @@ function jsonByteLength(value) {
 export function inlineForeignRefs(schema) {
   if (!isPlainObject(schema)) return schema;
   const state = { expansions: 0, exceeded: false, inlined: false };
-  const inlined = inlineNodeRefs(schema, schema, state, new Set(), 0, 0);
+  const inlined = inlineNodeRefs(schema, schema, state, new Set(), 0, 0, true);
   if (state.exceeded || !state.inlined || inlined === schema) return schema;
   if (jsonByteLength(inlined) > MAX_INLINE_BYTES) return schema;
   return inlined;

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -372,17 +372,18 @@ function inlineNodeRefs(
   );
   const strictDefsRef = inlineDefsWithSiblings && isDefsRef;
   // A definition expansion that still carries its own reference reached a
-  // cycle. Moonshot accepts that pure edge, but not the siblings this node
-  // added around it.
-  if (strictDefsRef && expanded.$ref !== undefined) return { $ref: ref };
+  // cycle. Removing this node's siblings would weaken the original schema, so
+  // keep the decorated node intact and let the provider fail closed if it
+  // cannot represent that conjunction.
+  if (strictDefsRef && expanded.$ref !== undefined) return node;
   if (strictDefsRef) {
     const conflicts = Object.keys(rewrittenSiblings).some((key) => (
       Object.hasOwn(expanded, key) && !isDeepStrictEqual(rewrittenSiblings[key], expanded[key])
     ));
-    // Overwriting a conflicting assertion would weaken the schema the target
-    // declares. Keep the pure reference instead; the client's sibling and target
-    // already disagree, so this malformed case has no lossless expansion.
-    if (conflicts) return { $ref: ref };
+    // Overwriting either assertion would weaken one side of the conjunction.
+    // Keep the original decorated node instead; this malformed case has no
+    // lossless expansion.
+    if (conflicts) return node;
   }
   return { ...expanded, ...rewrittenSiblings };
 }

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -16,7 +16,7 @@ import {
   repairToolSchemaRoots,
   stripSearchContentTypes,
 } from "../src/namespace-relay.mjs";
-import { mergeCodexAppTools } from "../src/codex-app-tools.mjs";
+import { CODEX_APP_TOOLS, mergeCodexAppTools } from "../src/codex-app-tools.mjs";
 
 function collect(stream) {
   return new Promise((resolve, reject) => {
@@ -1700,6 +1700,19 @@ function siblingRefs(value, found = []) {
   return found;
 }
 
+function refsWithSiblings(value, found = []) {
+  if (Array.isArray(value)) {
+    for (const entry of value) refsWithSiblings(entry, found);
+    return found;
+  }
+  if (!value || typeof value !== "object") return found;
+  if (typeof value.$ref === "string" && Object.keys(value).length > 1) {
+    found.push(value.$ref);
+  }
+  for (const entry of Object.values(value)) refsWithSiblings(entry, found);
+  return found;
+}
+
 test("the kimi route relays connector tools with no sibling ref left", () => {
   const { tools } = flattenNamespaceTools([connectorNamespace()]);
   const relayed = repairToolSchemaRoots(tools, { inlineForeignRefs: true });
@@ -1715,6 +1728,18 @@ test("the kimi route relays connector tools with no sibling ref left", () => {
     native.inboundTotalDurationRange.$ref,
     "#/properties/filters/properties/priceRange",
   );
+});
+
+test("the kimi route expands Codex automation definitions with sibling refs", () => {
+  const { tools } = flattenNamespaceTools(CODEX_APP_TOOLS);
+  const automation = tools.find((tool) => tool.name.endsWith("__automation_update"));
+  assert.ok(automation);
+  assert.notDeepEqual(refsWithSiblings(automation.parameters), []);
+
+  const relayed = repairToolSchemaRoots(tools, { inlineForeignRefs: true });
+  const repaired = relayed.find((tool) => tool.name.endsWith("__automation_update"));
+  assert.deepEqual(refsWithSiblings(repaired.parameters), []);
+  assert.equal(repaired.parameters.$defs.__schema0.$ref, undefined);
 });
 
 // The negative control is the point of the gate: every provider that accepts

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -626,7 +626,7 @@ test("a decorated $defs alias chain resolves through pure aliases", () => {
   assert.deepEqual(schema.$defs.decorated.$ref, "#/$defs/alias");
 });
 
-test("a conflicting $defs ref sibling degrades to a pure reference", () => {
+test("a conflicting $defs ref sibling remains intact", () => {
   const schema = {
     type: "object",
     properties: { value: { $ref: "#/$defs/narrow" } },
@@ -641,10 +641,32 @@ test("a conflicting $defs ref sibling degrades to a pure reference", () => {
   };
   assert.deepEqual(inlineForeignRefs(schema).$defs.narrow, {
     $ref: "#/$defs/base",
+    type: "string",
+    minLength: 1,
   });
 });
 
-test("a cyclic $defs ref sibling keeps only the cycle-edge reference", () => {
+test("a conflicting stricter $defs ref sibling also remains intact", () => {
+  const schema = {
+    type: "object",
+    properties: { value: { $ref: "#/$defs/narrow" } },
+    $defs: {
+      base: { type: "string", minLength: 1 },
+      narrow: {
+        $ref: "#/$defs/base",
+        type: "string",
+        minLength: 2,
+      },
+    },
+  };
+  assert.deepEqual(inlineForeignRefs(schema).$defs.narrow, {
+    $ref: "#/$defs/base",
+    type: "string",
+    minLength: 2,
+  });
+});
+
+test("a cyclic $defs ref sibling remains intact", () => {
   const schema = {
     type: "object",
     properties: { node: { $ref: "#/$defs/node" } },
@@ -658,6 +680,8 @@ test("a cyclic $defs ref sibling keeps only the cycle-edge reference", () => {
   };
   assert.deepEqual(inlineForeignRefs(schema).$defs.node, {
     $ref: "#/$defs/node",
+    type: "object",
+    description: "Cyclic node.",
   });
 });
 

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -569,6 +569,98 @@ test("a $defs ref is the form Moonshot asks for and survives untouched", () => {
   assert.deepEqual(inlined.$defs, schema.$defs);
 });
 
+test("a $defs ref with sibling keywords is inlined for Moonshot", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      targetThreadId: { $ref: "#/$defs/__schema20" },
+    },
+    $defs: {
+      __schema2: { type: "string", minLength: 1 },
+      __schema20: {
+        $ref: "#/$defs/__schema2",
+        type: "string",
+        minLength: 1,
+        format: "uuid",
+        description: "Target thread UUID for heartbeat automations.",
+      },
+    },
+  };
+  const inlined = inlineForeignRefs(schema);
+  assert.equal(inlined.properties.targetThreadId.$ref, "#/$defs/__schema20");
+  assert.deepEqual(inlined.$defs.__schema2, { type: "string", minLength: 1 });
+  assert.deepEqual(inlined.$defs.__schema20, {
+    type: "string",
+    minLength: 1,
+    format: "uuid",
+    description: "Target thread UUID for heartbeat automations.",
+  });
+  assert.deepEqual(schema.$defs.__schema20.$ref, "#/$defs/__schema2");
+});
+
+test("a decorated $defs alias chain resolves through pure aliases", () => {
+  const schema = {
+    type: "object",
+    properties: { value: { $ref: "#/$defs/decorated" } },
+    $defs: {
+      base: { type: "string", minLength: 2 },
+      alias: { $ref: "#/$defs/base" },
+      decorated: {
+        $ref: "#/$defs/alias",
+        type: "string",
+        minLength: 2,
+        format: "uuid",
+        description: "Decorated alias.",
+      },
+    },
+  };
+  const inlined = inlineForeignRefs(schema);
+  assert.equal(inlined.properties.value.$ref, "#/$defs/decorated");
+  assert.deepEqual(inlined.$defs.alias, { $ref: "#/$defs/base" });
+  assert.deepEqual(inlined.$defs.decorated, {
+    type: "string",
+    minLength: 2,
+    format: "uuid",
+    description: "Decorated alias.",
+  });
+  assert.deepEqual(schema.$defs.decorated.$ref, "#/$defs/alias");
+});
+
+test("a conflicting $defs ref sibling degrades to a pure reference", () => {
+  const schema = {
+    type: "object",
+    properties: { value: { $ref: "#/$defs/narrow" } },
+    $defs: {
+      base: { type: "string", minLength: 2 },
+      narrow: {
+        $ref: "#/$defs/base",
+        type: "string",
+        minLength: 1,
+      },
+    },
+  };
+  assert.deepEqual(inlineForeignRefs(schema).$defs.narrow, {
+    $ref: "#/$defs/base",
+  });
+});
+
+test("a cyclic $defs ref sibling keeps only the cycle-edge reference", () => {
+  const schema = {
+    type: "object",
+    properties: { node: { $ref: "#/$defs/node" } },
+    $defs: {
+      node: {
+        $ref: "#/$defs/node",
+        type: "object",
+        description: "Cyclic node.",
+      },
+    },
+  };
+  assert.deepEqual(inlineForeignRefs(schema).$defs.node, {
+    $ref: "#/$defs/node",
+  });
+});
+
 test("an unresolvable ref is left alone rather than guessed at", () => {
   const schema = {
     type: "object",


### PR DESCRIPTION
Follow-up to #353. This is separate from the deferred Kimi Coding endpoint and model-id work discussed in #179.

## Bug

Current Codex `automation_update` tool schemas include `$defs` entries such as:

```json
{
  "description": "Automation id...",
  "$ref": "#/$defs/__schema1"
}
```

Moonshot rejects a `$ref` that carries sibling keywords. #367 already handles sibling-property pointers, but it intentionally leaves every `#/$defs/` pointer untouched. A current Codex build now puts sibling keywords on definitions themselves, so `kimi-api` receives the invalid shape and returns the observed HTTP 400 schema rejection.

The bundled snapshot scan finds eight sibling-ref definitions in `automation_update` before repair and zero after this patch.

## Fix

Extend the existing strict-route inliner to expand a `#/$defs/` reference when it has siblings:

- merge the resolved target with the reference node siblings, with siblings winning as before;
- resolve acyclic pure definition aliases while expanding a decorated reference;
- preserve ordinary pure `#/$defs/` references exactly;
- keep the existing depth, expansion, cycle, and byte-budget protections;
- on a genuine cycle or conflicting assertion, keep only the pure reference rather than silently weakening either side;
- apply the compatibility pass to `kimi-oauth`, `kimi-api`, and `kimi-api-cn`, while leaving every non-Moonshot provider wire payload unchanged.

The Kimi API routes now share the gate because the new shape was reproduced with the separately billed Kimi Platform API key, not only OAuth.

## Tests

- exact synthetic sibling-definition expansion;
- decorated definition through a pure alias chain;
- conflicting sibling handling;
- cyclic sibling handling;
- regression against the bundled Codex `automation_update` snapshot: sibling refs present before repair, absent after repair, and `__schema0` expanded;
- existing negative control proving a provider that does not request inlining remains unchanged.

## Verification

- `npm run check`
- `git diff --check`
- `node --test test/namespace-relay.test.mjs test/tool-schema-root.test.mjs`
- `npm test`: 2,557 tests, 2,539 passed, 18 intentional skips, 0 failures

No live provider request was made from this change, so no quota was spent.