### PR TITLE
test: isolate model discovery from user overlays

### DIFF
--- a/test/model-discovery.test.mjs
+++ b/test/model-discovery.test.mjs
@@ -3,10 +3,23 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import test from "node:test";
+import test, { after } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Discovery compares fixtures with the checked-in registry. Keep a developer's
+// locally curated models out of both this process and the child processes below
+// before model-registry.mjs resolves the overlay path at import time.
+const stateRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-model-discovery-test-"));
+const originalUserModels = process.env.MODEL_ROUTER_USER_MODELS;
+process.env.MODEL_ROUTER_USER_MODELS = path.join(stateRoot, "user-models.json");
+after(() => {
+  rmSync(stateRoot, { recursive: true, force: true });
+  if (originalUserModels === undefined) delete process.env.MODEL_ROUTER_USER_MODELS;
+  else process.env.MODEL_ROUTER_USER_MODELS = originalUserModels;
+});
+
 const { MODELS, PROVIDERS } = await import("../src/model-registry.mjs");
 const { modelCatalogMetadata } = await import("../src/model-catalog-metadata.mjs");
 const { modelContextLengths, modelIds } = await import("../src/model-discovery.mjs");


### PR DESCRIPTION
## Summary

- isolate `MODEL_ROUTER_USER_MODELS` before importing the checked-in registry in the discovery test file
- keep fixture comparisons deterministic for developers who have locally curated models
- restore the inherited environment and remove the temporary state after the test file finishes

## Reproduction

With locally curated OpenCode Go models present, `test/model-discovery.test.mjs` previously failed two assertions because both the parent test process and its discovery subprocesses loaded the developer's real `user-models.json`. Pointing the overlay at an empty temporary file made all 15 tests pass.

The override now happens before `model-registry.mjs` is imported, so the file consistently compares fixtures against the checked-in registry.

## Validation

- `npm run check`
- `node --test test/model-discovery.test.mjs test/state-owner.test.mjs` (26 passed)
- `node --test --test-reporter=dot test/*.test.mjs` (exit 0)