### PR TITLE
fix: avoid false Windows service liveness

### DIFF
--- a/src/windows-task-state.mjs
+++ b/src/windows-task-state.mjs
@@ -2,9 +2,10 @@ import { execFile as execFileCallback } from "node:child_process";
 
 // Task Scheduler's `State` can remain Running after its only instance has
 // gone, and the COM instance enumeration can outlive its process too. The
-// launcher process tree is therefore probed directly: a wscript/cmd/node
-// process whose command line references the generated launcher is the one
-// authoritative sign that the managed task is still executing anything. A
+// launcher process tree is therefore probed directly: the registered task's
+// wscript process must still reference its exact generated VBS launcher. A
+// manually started `src/start.mjs` is deliberately not enough to prove that
+// Task Scheduler is supervising anything. A
 // query failure is deliberately inconclusive so a restricted shell cannot
 // turn a slow-but-valid startup into a false failure.
 export async function windowsScheduledTaskState({
@@ -25,10 +26,16 @@ export async function windowsScheduledTaskState({
     "  $scheduler = New-Object -ComObject Schedule.Service",
     "  $scheduler.Connect()",
     "  $task = $scheduler.GetFolder('\\').GetTask($env:CODEX_ROUTER_TASK)",
-    "  $instances = [array]$task.GetInstances(0)",
-    "  $launcher = Get-CimInstance Win32_Process -ErrorAction Stop |",
-    "    Where-Object { $_.ProcessId -ne $PID -and $_.CommandLine -and ($_.CommandLine -like '*start-codex-router*' -or $_.CommandLine -like '*codex-router*src*start.mjs*') } |",
-    "    Select-Object -First 1",
+    "  $instances = @($task.GetInstances(0) | Where-Object { $null -ne $_ })",
+    "  $action = $task.Definition.Actions.Item(1)",
+    "  $launcherMatch = [regex]::Match([string]$action.Arguments, '\"([^\"]*start-codex-router-hidden\\.vbs)\"', [Text.RegularExpressions.RegexOptions]::IgnoreCase)",
+    "  $launcherPath = if ($launcherMatch.Success) { $launcherMatch.Groups[1].Value } else { $null }",
+    "  $launcher = $null",
+    "  if ($launcherPath -and [IO.Path]::GetFileName([string]$action.Path) -ieq 'wscript.exe') {",
+    "    $launcher = Get-CimInstance Win32_Process -ErrorAction Stop |",
+    "      Where-Object { $_.ProcessId -ne $PID -and $_.Name -ieq 'wscript.exe' -and $_.CommandLine -and $_.CommandLine.IndexOf($launcherPath, [StringComparison]::OrdinalIgnoreCase) -ge 0 } |",
+    "      Select-Object -First 1",
+    "  }",
     "  [Console]::Out.Write($instances.Count.ToString() + '|' + $info.LastTaskResult + '|' + $(if ($launcher) { '1' } else { '0' }))",
     "} catch { exit 1 }",
   ].join("\n");

--- a/test/windows-task-state.test.mjs
+++ b/test/windows-task-state.test.mjs
@@ -35,6 +35,24 @@ test("parses the authoritative instance count, result, and launcher liveness", a
   assert.match(script, /ProcessId -ne \$PID/);
 });
 
+test("launcher discovery ignores manual foreground router processes", async () => {
+  let script;
+  const execFile = (_executable, args, _options, callback) => {
+    script = args.at(-1);
+    callback(null, "0|267014|0\n");
+  };
+
+  assert.deepEqual(await windowsScheduledTaskState({ execFile, platform: "win32" }), {
+    instanceCount: 0,
+    lastTaskResult: 267014,
+    launcherAlive: false,
+  });
+  assert.match(script, /\$task\.Definition\.Actions\.Item\(1\)/);
+  assert.match(script, /start-codex-router-hidden/);
+  assert.match(script, /\$null -ne \$_/);
+  assert.doesNotMatch(script, /src\*start\.mjs/);
+});
+
 test("a dead launcher process is reported as not alive", async () => {
   const execFile = (_e, _a, _o, callback) => callback(null, "1|267014|0\n");
   // Pinned like every other query test: off Windows the platform


### PR DESCRIPTION
## Summary

Fix Windows background-service status/readiness incorrectly treating an unrelated manually started foreground router as the Task Scheduler-managed service.

The bug has two causes in `windowsScheduledTaskState()`:

- `[array]$task.GetInstances(0)` turns a null COM result into a one-element array, so zero real task instances can be reported as `instanceCount: 1`.
- launcher discovery accepted any process whose command line matched `*codex-router*src*start.mjs*`, so a manually started foreground router could satisfy `launcherAlive: true` even when the scheduled task itself was idle.

The fix normalizes null COM instances out and derives launcher liveness from the registered task action itself: it requires `wscript.exe` and the exact generated `start-codex-router-hidden.vbs` path from that task definition. A manual `src/start.mjs` process is deliberately not evidence that Task Scheduler is supervising the router.

## Reproduction

On a real Windows install with the scheduled task in `Ready` state, no `wscript`/CMD launcher process, and only a manually started foreground `src/start.mjs` running, current main reported:

```json
{"instanceCount":1,"lastTaskResult":267014,"launcherAlive":true}
```

With this patch, the same machine reports:

```json
{"instanceCount":0,"lastTaskResult":267014,"launcherAlive":false}
```

This tightens the live-launcher verification introduced by #432 rather than replacing its two-signal design.

## Verification

Rebased onto `0eac3ff`.

- regression test was RED before the implementation and GREEN after it
- focused service/readiness tests — pass
- post-rebase bounded suite covering Windows task state plus the new upstream GLM-5.3 Flash / registry / routing changes — **159 tests, 159 passed, 0 failed**
- `npm.cmd run check` — pass (`v2-agent applications valid (6)`, syntax checks passed)
- `git diff origin/main..HEAD --check` — clean
- GitHub CI — pass
- Provider model discovery workflow — pass
- no live provider/quota-consuming calls were used

### Live Windows verification — 2026-08-27

The exact Ready-task + manual-router case was exercised on a Windows 11 host after the review comment requesting native validation.

Positive control with the scheduler-managed service running:

```json
{"instanceCount":1,"lastTaskResult":267009,"launcherAlive":true}
```

Controlled negative case:

1. Stop the installed service from its canonical checkout and verify Task Scheduler is `Ready`, COM instance count is `0`, no generated VBS launcher is running, and no router root remains.
2. Manually launch the generated CMD wrapper outside Task Scheduler; one `node ...\\src\\start.mjs` router root is then live while Task Scheduler remains `Ready`, COM instance count remains `0`, and no `wscript.exe` launcher exists.
3. Run this branch's probe and service status.

Observed result:

```json
{"instanceCount":0,"lastTaskResult":267014,"launcherAlive":false}
```

```json
{"installed":true,"loaded":false,"state":"ready"}
```

The manual router was then stopped and the scheduler-managed service restored. Final positive control:

```json
{"instanceCount":1,"lastTaskResult":267009,"launcherAlive":true}
```

```json
{"installed":true,"loaded":true,"state":"running"}
```

No Codex Desktop process was restarted or terminated during this validation.