### PR TITLE
fix(antigravity): stringify protobuf enum values

### DIFF
--- a/src/antigravity-oauth-shape.mjs
+++ b/src/antigravity-oauth-shape.mjs
@@ -374,7 +374,11 @@ function cleanAntigravitySchema(schema, depth = 0) {
   for (const [key, value] of Object.entries(schema)) {
     if (UNSUPPORTED_SCHEMA_KEYWORDS.includes(key)) continue;
     if (key === "const") {
-      if (!Array.isArray(schema.enum)) next.enum = [value];
+      if (!Array.isArray(schema.enum)) next.enum = [String(value)];
+      continue;
+    }
+    if (key === "enum" && Array.isArray(value)) {
+      next.enum = value.map((entry) => String(entry));
       continue;
     }
     if (["properties"].includes(key) && isPlainObject(value)) {

--- a/test/antigravity-oauth-shape.test.mjs
+++ b/test/antigravity-oauth-shape.test.mjs
@@ -118,6 +118,8 @@ test("sanitizes unsupported JSON Schema constructs for Antigravity", () => {
               type: "object",
               properties: {
                 mode: { type: "string", const: "fast" },
+                retries: { type: "integer", enum: [1, 2] },
+                enabled: { type: "boolean", const: true },
                 count: { type: "integer", default: 1, encrypted: true },
                 bounded: { type: "number", minimum: 0, exclusiveMaximum: 10 },
               },
@@ -131,6 +133,8 @@ test("sanitizes unsupported JSON Schema constructs for Antigravity", () => {
   );
   const declaration = request.request.tools[0].functionDeclarations[0];
   assert.equal(declaration.parameters.properties.mode.enum[0], "fast");
+  assert.deepEqual(declaration.parameters.properties.retries.enum, ["1", "2"]);
+  assert.deepEqual(declaration.parameters.properties.enabled.enum, ["true"]);
   assert.equal("const" in declaration.parameters.properties.mode, false);
   assert.equal("default" in declaration.parameters.properties.count, false);
   assert.equal("encrypted" in declaration.parameters.properties.count, false);


### PR DESCRIPTION
## Summary

- coerce every Antigravity protobuf `enum` entry to a string
- coerce JSON Schema `const` values when rewriting them to `enum`
- keep the normalization inside the Antigravity-only request-shape boundary

## Verification

- `node --test test/antigravity-oauth-*.test.mjs test/protobuf-*.test.mjs` (77 passed)
- `npm run check`
- `npm test` (2,655 passed, 17 skipped, 0 failed)
- `git diff --check`

Fixes #454