### PR TITLE
fix: make skill doctor guidance platform-aware

### DIFF
--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -1163,6 +1163,10 @@ if (proxyOptIn) {
 // describes Codex's own tools, so it is not part of a harness install.
 if (codexTarget) {
   const status = skillPackStatus(CODEX_HOME);
+  const skillOperatorCommand =
+    process.platform === "win32"
+      ? ".\\model-router.ps1 codex skills"
+      : "./bin/model-router codex skills";
   add(
     status.missing.length === 0 ? "ok" : "fail",
     "Codex skill pack",
@@ -1181,7 +1185,7 @@ if (codexTarget) {
   );
   if (status.collisions.length > 0) {
     const approvalCommand =
-      `./bin/model-router codex skills approve-external ${status.collisions.join(" ")}`;
+      `${skillOperatorCommand} approve-external ${status.collisions.join(" ")}`;
     add(
       "warn",
       "Codex skill pack collisions",
@@ -1201,20 +1205,19 @@ if (codexTarget) {
   }
   if (status.staleExternal.length > 0) {
     const reapprovable = status.staleExternal.filter((name) => status.pack.includes(name));
-    const obsolete = status.staleExternal.filter((name) => !status.pack.includes(name));
     const actions = [];
     if (reapprovable.length > 0) {
       actions.push(
-        `after review, re-approve with: ./bin/model-router codex skills approve-external ${reapprovable.join(" ")}`,
+        `after review, re-approve with: ${skillOperatorCommand} approve-external ${reapprovable.join(" ")}`,
       );
     }
-    if (obsolete.length > 0) {
-      actions.push(`remove obsolete approvals with: ./bin/install (${obsolete.join(", ")})`);
-    }
+    actions.push(
+      `revoke stale approvals with: ${skillOperatorCommand} revoke-external ${status.staleExternal.join(" ")}`,
+    );
     add(
       "warn",
       "Codex skill pack external approvals",
-      `external approvals require re-review: ${status.staleExternal.join(", ")}; ${actions.join("; ")}`,
+      `external approvals require re-review or revocation: ${status.staleExternal.join(", ")}; ${actions.join("; ")}`,
       actions.join("; "),
     );
   }

--- a/test/model-router-cli.test.mjs
+++ b/test/model-router-cli.test.mjs
@@ -31,7 +31,11 @@ test("both dispatchers expose reviewed external skill management", () => {
   assert.match(windows, /"skills"/);
   assert.match(windows, /"skills"\s*\{\s*Invoke-RouterNode "src\\skills-install\.mjs" \$Arguments/);
   const doctor = readFileSync(path.join(root, "src", "doctor.mjs"), "utf8");
-  assert.match(doctor, /model-router codex skills approve-external/);
+  assert.match(doctor, /process\.platform === "win32"/);
+  assert.match(doctor, /\.\\\\model-router\.ps1 codex skills/);
+  assert.match(doctor, /\.\/bin\/model-router codex skills/);
+  assert.match(doctor, /approve-external/);
+  assert.match(doctor, /revoke-external/);
 });
 
 test(


### PR DESCRIPTION
## Summary

Follow-up to #474 for the operator-facing doctor guidance only.

- show the supported native `\.\model-router.ps1 codex skills ...` command on Windows and `./bin/model-router codex skills ...` on POSIX;
- use that platform-specific command for collision approval and stale-approval re-review;
- add an explicit `revoke-external` remediation for stale approvals, including approvals for skills no longer shipped;
- leave skill ownership, digest, install, and uninstall semantics unchanged.

## Why

PR #474 correctly exposed external-skill approval through both POSIX and Windows CLI dispatchers, but `doctor.mjs` still hardcoded the POSIX approval command. On native Windows that remediation was not the supported launcher. The stale-approval diagnostic also offered re-approval/installation paths but no explicit `revoke-external` recovery command.

## Verification

- red/green regression: `both dispatchers expose reviewed external skill management` failed on merged `main` because doctor lacked the Windows command, then passed after the fix;
- `node --check src/doctor.mjs` — pass;
- `node --test test/model-router-cli.test.mjs test/doctor-kimi-oauth-health.test.mjs test/doctor-idle.test.mjs test/doctor-routing-mode.test.mjs` — 12 tests, 8 passed, 0 failed, 4 expected Windows skips;
- `npm.cmd run check` — pass (`v2-agent applications valid (6)`, syntax checks passed);
- `git diff --check` — clean.

No live provider/quota-consuming checks were needed for this diagnostic-only follow-up.