### PR TITLE
fix(opencode-go): bridge Responses tool shapes

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -622,10 +622,11 @@ function normalizeBody(buffer, contentType, route) {
   // which is the reverse of what this endpoint enforces, so Meta is running an
   // older fork of the schema rather than being the strict reader of it.
   // Stripping the field for every provider would take a documented parameter
-  // away from the responses-native providers that do follow the current spec
-  // (github-copilot, opencode-go-responses), and neither has been observed to
-  // refuse it. A caller that does send Meta a real `web_search_preview` tool
-  // keeps the field, because that is the one tool this endpoint accepts it on.
+  // away from responses-native providers that do follow the current spec, such
+  // as GitHub Copilot. Console Go Responses has its separately measured strict
+  // tool boundary applied in the router before this hop. A caller that does send
+  // Meta a real `web_search_preview` tool keeps the field, because that is the
+  // one tool this endpoint accepts it on.
   if (provider.id === "meta" && Array.isArray(payload.tools)) {
     payload.tools = stripSearchContentTypes(payload.tools);
   }

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { Transform } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
 
@@ -48,12 +49,160 @@ export const NAMESPACE_DELIMITER = "__";
 const SPAWN_AGENT_MODELS = new WeakMap();
 const TOOL_SEARCH_RELAYS = new WeakMap();
 const CUSTOM_TOOL_RELAYS = new WeakMap();
+const NAME_ALIASES = new WeakMap();
+const PLAIN_TOOL_NAMES = new WeakMap();
+// A provider-facing function reference can retain the same spelling as a
+// bridged custom/tool-search relay while a later-discovered ordinary function
+// with that native name receives an alias. Object identity is the only honest
+// discriminator after both shapes have become `type: "function"`; keep it
+// request-local and garbage-collectable rather than guessing from the name.
+const SPECIAL_FUNCTION_REFERENCES = new WeakSet();
 
 const TOOL_SEARCH_FUNCTION_NAME = "tool_search";
 const CUSTOM_TOOL_INPUT_PROPERTY = "input";
 
 function providerFunctionName(tool) {
   return tool?.name ?? tool?.function?.name;
+}
+
+function withProviderFunctionName(tool, name) {
+  if (tool?.function?.name !== undefined) {
+    return { ...tool, function: { ...tool.function, name } };
+  }
+  return { ...tool, name };
+}
+
+function nativeToolKey(namespace, name) {
+  return JSON.stringify([namespace ?? null, name]);
+}
+
+function boundedNameCandidate(wireName, identity, maxNameLength, attempt) {
+  const digest = createHash("sha256")
+    .update(`${identity}\0${attempt}`)
+    .digest("hex")
+    .slice(0, 12);
+  const suffix = `_${digest}`;
+  return `${wireName.slice(0, maxNameLength - suffix.length)}${suffix}`;
+}
+
+function assignProviderName(relay, identity, wireName, native, { forceAlias = false } = {}) {
+  const existing = relay.nativeToProvider.get(identity);
+  if (existing) return existing;
+
+  let providerName = wireName;
+  if (
+    forceAlias ||
+    wireName.length > relay.maxNameLength ||
+    relay.providerOwners.has(wireName)
+  ) {
+    let attempt = 0;
+    do {
+      providerName = boundedNameCandidate(
+        wireName,
+        identity,
+        relay.maxNameLength,
+        attempt,
+      );
+      attempt += 1;
+    } while (relay.providerOwners.has(providerName));
+  }
+
+  relay.nativeToProvider.set(identity, providerName);
+  relay.providerOwners.set(providerName, identity);
+  if (native && providerName !== wireName) relay.providerToNative.set(providerName, native);
+  if (native) {
+    if (native.namespace === undefined) relay.plainProviderNames.add(providerName);
+    if (!relay.wireOwners.has(wireName)) relay.wireOwners.set(wireName, new Set());
+    relay.wireOwners.get(wireName).add(identity);
+  }
+  return providerName;
+}
+
+function initialFunctionIdentities(tools) {
+  const identities = new Map();
+  if (!Array.isArray(tools)) return identities;
+  for (const tool of tools) {
+    if (tool?.type === "namespace" && typeof tool.name === "string" && Array.isArray(tool.tools)) {
+      for (const child of tool.tools) {
+        if (child?.type !== "function" || typeof child.name !== "string" || !child.name) continue;
+        const wireName = `${tool.name}${NAMESPACE_DELIMITER}${child.name}`;
+        const native = { namespace: tool.name, name: child.name };
+        identities.set(nativeToolKey(native.namespace, native.name), { wireName, native });
+      }
+      continue;
+    }
+    if (tool?.type !== "function") continue;
+    const name = providerFunctionName(tool);
+    if (typeof name !== "string" || !name) continue;
+    const native = { name };
+    identities.set(nativeToolKey(undefined, name), { wireName: name, native });
+  }
+  return identities;
+}
+
+function initializeNameAliases(namespaces, tools, maxNameLength) {
+  if (!Number.isInteger(maxNameLength) || maxNameLength < 16) return undefined;
+  const relay = {
+    maxNameLength,
+    nativeToProvider: new Map(),
+    providerToNative: new Map(),
+    providerOwners: new Map(),
+    plainProviderNames: new Set(),
+    wireOwners: new Map(),
+  };
+  NAME_ALIASES.set(namespaces, relay);
+
+  const identities = initialFunctionIdentities(tools);
+  const wireCounts = new Map();
+  for (const { wireName } of identities.values()) {
+    wireCounts.set(wireName, (wireCounts.get(wireName) || 0) + 1);
+  }
+
+  // Reserve every legal, unique name first. Long names and native collisions
+  // are then assigned in stable identity order, so reordering an otherwise
+  // identical tool list cannot change the aliases sent to the provider.
+  const pending = [];
+  for (const [identity, entry] of [...identities].sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    if (entry.wireName.length <= maxNameLength && wireCounts.get(entry.wireName) === 1) {
+      assignProviderName(relay, identity, entry.wireName, entry.native);
+    } else {
+      pending.push([identity, entry]);
+    }
+  }
+  for (const [identity, entry] of pending) {
+    assignProviderName(relay, identity, entry.wireName, entry.native, { forceAlias: true });
+  }
+  return relay;
+}
+
+function providerNameForNative(namespaces, namespace, name) {
+  const relay = NAME_ALIASES.get(namespaces);
+  if (!relay) return namespace === undefined ? name : `${namespace}${NAMESPACE_DELIMITER}${name}`;
+  const identity = nativeToolKey(namespace, name);
+  const existing = relay.nativeToProvider.get(identity);
+  if (existing) return existing;
+  const wireName = namespace === undefined ? name : `${namespace}${NAMESPACE_DELIMITER}${name}`;
+  return assignProviderName(relay, identity, wireName, {
+    ...(namespace === undefined ? {} : { namespace }),
+    name,
+  });
+}
+
+function reserveSpecialProviderName(namespaces, identity, wireName) {
+  const relay = NAME_ALIASES.get(namespaces);
+  if (!relay) return wireName;
+  return assignProviderName(relay, identity, wireName);
+}
+
+function providerNameForWire(namespaces, wireName) {
+  const relay = NAME_ALIASES.get(namespaces);
+  if (!relay) return undefined;
+  const owners = relay.wireOwners.get(wireName);
+  if (!owners || owners.size !== 1) return undefined;
+  const [identity] = owners;
+  return relay.nativeToProvider.get(identity);
 }
 
 function providerVisibleToolNames(tools) {
@@ -122,14 +271,26 @@ export function bridgeCustomTools(
   namespaces,
   toolChoice,
   names = ["apply_patch"],
+  { maxNameLength, bridgeAll = false } = {},
 ) {
   if (!(namespaces instanceof Map)) {
     return { tools, input, toolChoice, bridged: false };
   }
+  if (Number.isInteger(maxNameLength) && !NAME_ALIASES.has(namespaces)) {
+    initializeNameAliases(namespaces, tools, maxNameLength);
+  }
   const requested = new Set(names);
+  const shouldBridge = (name) => bridgeAll || requested.has(name);
   const nativeNames = [];
   const remember = (name) => {
-    if (requested.has(name) && !nativeNames.includes(name)) nativeNames.push(name);
+    if (
+      typeof name === "string" &&
+      name &&
+      shouldBridge(name) &&
+      !nativeNames.includes(name)
+    ) {
+      nativeNames.push(name);
+    }
   };
   if (Array.isArray(tools)) {
     for (const tool of tools) if (tool?.type === "custom") remember(tool.name);
@@ -138,16 +299,28 @@ export function bridgeCustomTools(
     for (const item of input) if (item?.type === "custom_tool_call") remember(item.name);
   }
   if (toolChoice?.type === "custom") remember(toolChoice.name);
+  if (toolChoice?.type === "allowed_tools" && Array.isArray(toolChoice.tools)) {
+    for (const choice of toolChoice.tools) {
+      if (choice?.type === "custom") remember(choice.name);
+    }
+  }
   if (!nativeNames.length) return { tools, input, toolChoice, bridged: false };
 
   const ordinaryTools = Array.isArray(tools)
-    ? tools.filter((tool) => !(tool?.type === "custom" && requested.has(tool.name)))
+    ? tools.filter((tool) => !(tool?.type === "custom" && shouldBridge(tool.name)))
     : tools;
   const visibleNames = providerVisibleToolNames(ordinaryTools);
   const nativeToProvider = new Map();
   const providerToNative = new Map();
   for (const nativeName of nativeNames) {
-    const providerName = availableCustomToolName(nativeName, visibleNames);
+    const availableName = availableCustomToolName(nativeName, visibleNames);
+    const providerName = Number.isInteger(maxNameLength)
+      ? reserveSpecialProviderName(
+          namespaces,
+          `custom:${nativeName}`,
+          availableName,
+        )
+      : availableName;
     visibleNames.add(providerName);
     nativeToProvider.set(nativeName, providerName);
     providerToNative.set(providerName, nativeName);
@@ -181,11 +354,25 @@ export function bridgeCustomTools(
       })
     : tools;
 
+  let routedToolChoice = toolChoice;
   const providerChoiceName =
     toolChoice?.type === "custom" ? nativeToProvider.get(toolChoice.name) : undefined;
-  const routedToolChoice = providerChoiceName
-    ? { ...toolChoice, type: "function", name: providerChoiceName }
-    : toolChoice;
+  if (providerChoiceName) {
+    routedToolChoice = { ...toolChoice, type: "function", name: providerChoiceName };
+    SPECIAL_FUNCTION_REFERENCES.add(routedToolChoice);
+  } else if (toolChoice?.type === "allowed_tools" && Array.isArray(toolChoice.tools)) {
+    let changed = false;
+    const choices = toolChoice.tools.map((choice) => {
+      const providerName =
+        choice?.type === "custom" ? nativeToProvider.get(choice.name) : undefined;
+      if (!providerName) return choice;
+      changed = true;
+      const routedChoice = { ...choice, type: "function", name: providerName };
+      SPECIAL_FUNCTION_REFERENCES.add(routedChoice);
+      return routedChoice;
+    });
+    if (changed) routedToolChoice = { ...toolChoice, tools: choices };
+  }
   const changedToolChoice = routedToolChoice !== toolChoice;
 
   if (!Array.isArray(input)) {
@@ -207,12 +394,14 @@ export function bridgeCustomTools(
         bridgedCallIds.add(item.call_id);
       }
       changedInput = true;
-      return {
+      const routedCall = {
         ...rest,
         type: "function_call",
         name: providerName,
         arguments: JSON.stringify({ [CUSTOM_TOOL_INPUT_PROPERTY]: customInput }),
       };
+      SPECIAL_FUNCTION_REFERENCES.add(routedCall);
+      return routedCall;
     }
     if (
       item?.type === "custom_tool_call_output" &&
@@ -443,13 +632,13 @@ export function downgradeOriginalImageDetail(input) {
   return changed ? converted : input;
 }
 
-function flattenNamespaceChild(namespace, fn) {
+function flattenNamespaceChild(namespace, fn, providerName) {
   const clientSchema = fn.parameters ?? fn.inputSchema;
   const parameters =
     clientSchema === undefined ? undefined : providerToolSchema(clientSchema);
   return {
     ...fn,
-    name: `${namespace}${NAMESPACE_DELIMITER}${fn.name}`,
+    name: providerName ?? `${namespace}${NAMESPACE_DELIMITER}${fn.name}`,
     ...(parameters === undefined ? {} : { parameters }),
   };
 }
@@ -457,12 +646,24 @@ function flattenNamespaceChild(namespace, fn) {
 // Flatten every namespace entry into plain functions named
 // `<namespace>__<tool>`. Returns the set of namespaces that were flattened
 // (name -> tool names) so callers can rename history and restore calls.
-export function flattenNamespaceTools(tools, { bridgeToolSearch = true } = {}) {
+export function flattenNamespaceTools(
+  tools,
+  { bridgeToolSearch = true, maxNameLength } = {},
+) {
   if (!Array.isArray(tools)) return { tools, flattened: false, namespaces: new Map() };
   const flattened = [];
   const namespaces = new Map();
+  const plainToolNames = new Set();
+  PLAIN_TOOL_NAMES.set(namespaces, plainToolNames);
+  initializeNameAliases(namespaces, tools, maxNameLength);
   const spawnAgentModels = new Set();
-  const toolSearchName = bridgeToolSearch ? availableToolSearchName(tools) : undefined;
+  const toolSearchName = bridgeToolSearch
+    ? reserveSpecialProviderName(
+        namespaces,
+        "tool-search",
+        availableToolSearchName(tools),
+      )
+    : undefined;
   let toolSearchRelay;
   let changed = false;
   for (const tool of tools) {
@@ -509,7 +710,13 @@ export function flattenNamespaceTools(tools, { bridgeToolSearch = true } = {}) {
         // never touches automations still dies on its first message. Normalize
         // only the provider-facing copy; `inputSchema` stays exactly as the
         // client sent it.
-        flattened.push(flattenNamespaceChild(tool.name, fn));
+        flattened.push(
+          flattenNamespaceChild(
+            tool.name,
+            fn,
+            providerNameForNative(namespaces, tool.name, fn.name),
+          ),
+        );
         names.add(fn.name);
         if (tool.name === "collaboration" && fn.name === "spawn_agent") {
           schemaStringValues(fn.inputSchema?.properties?.model, spawnAgentModels);
@@ -529,7 +736,13 @@ export function flattenNamespaceTools(tools, { bridgeToolSearch = true } = {}) {
     // the flattened children left every client-declared tool to fail on the
     // provider that objects. `providerToolSchema` returns anything it does not
     // recognize unchanged, so a tool with an ordinary root is not copied.
-    const repaired = repairToolSchemaRoot(tool);
+    let repaired = repairToolSchemaRoot(tool);
+    const name = tool?.type === "function" ? providerFunctionName(repaired) : undefined;
+    if (typeof name === "string" && name) {
+      const providerName = providerNameForNative(namespaces, undefined, name);
+      if (providerName !== name) repaired = withProviderFunctionName(repaired, providerName);
+      plainToolNames.add(providerName);
+    }
     if (repaired !== tool) changed = true;
     flattened.push(repaired);
   }
@@ -550,7 +763,7 @@ function validToolSearchHistoryArguments(value) {
   return limit === undefined || (Number.isInteger(limit) && limit > 0);
 }
 
-function discoveredProviderTools(toolSpecs) {
+function discoveredProviderTools(toolSpecs, namespaces) {
   if (!Array.isArray(toolSpecs)) return [];
   const discovered = [];
   for (const tool of toolSpecs) {
@@ -558,14 +771,24 @@ function discoveredProviderTools(toolSpecs) {
       for (const fn of tool.tools) {
         if (fn?.type !== "function" || !fn.name) continue;
         discovered.push({
-          tool: flattenNamespaceChild(tool.name, fn),
+          tool: flattenNamespaceChild(
+            tool.name,
+            fn,
+            providerNameForNative(namespaces, tool.name, fn.name),
+          ),
           native: { namespace: tool.name, name: fn.name },
         });
       }
       continue;
     }
     if (tool?.type !== "function" || !providerFunctionName(tool)) continue;
-    discovered.push({ tool: repairToolSchemaRoot(tool) });
+    const nativeName = providerFunctionName(tool);
+    const providerName = providerNameForNative(namespaces, undefined, nativeName);
+    let providerTool = repairToolSchemaRoot(tool);
+    if (providerName !== nativeName) {
+      providerTool = withProviderFunctionName(providerTool, providerName);
+    }
+    discovered.push({ tool: providerTool });
   }
   return discovered;
 }
@@ -676,12 +899,14 @@ export function flattenToolSearchHistory(input, tools, namespaces) {
         arguments: searchArguments,
         ...rest
       } = item;
-      routedInput.push({
+      const routedCall = {
         ...rest,
         type: "function_call",
         name: relay.providerName,
         arguments: JSON.stringify(searchArguments),
-      });
+      };
+      SPECIAL_FUNCTION_REFERENCES.add(routedCall);
+      routedInput.push(routedCall);
       continue;
     }
 
@@ -692,12 +917,13 @@ export function flattenToolSearchHistory(input, tools, namespaces) {
     if (!outputsByIndex.has(index)) continue;
 
     const accepted = [];
-    for (const candidate of discoveredProviderTools(item.tools)) {
+    for (const candidate of discoveredProviderTools(item.tools, namespaces)) {
       const name = providerFunctionName(candidate.tool);
       if (!name || visibleNames.has(name)) continue;
       visibleNames.add(name);
       accepted.push(candidate.tool);
       addDiscoveredNamespace(namespaces, candidate.native);
+      if (!candidate.native) PLAIN_TOOL_NAMES.get(namespaces)?.add(name);
     }
     // Keep the live-name set across outputs. The first valid discovery wins;
     // later outputs omit a duplicate from both their result and the request's
@@ -736,7 +962,8 @@ export function flattenToolSearchHistory(input, tools, namespaces) {
 // and Codex answers `unsupported call` -- permanently, since every failure
 // adds another bare example. Rename the history to match the flattened tools.
 export function flattenNamespacedHistory(input, namespaces) {
-  if (!Array.isArray(input) || namespaces.size === 0) return input;
+  const nameRelay = NAME_ALIASES.get(namespaces);
+  if (!Array.isArray(input) || (namespaces.size === 0 && !nameRelay)) return input;
   const flattenedNames = new Set();
   const bareOwners = new Map();
   for (const [namespace, names] of namespaces) {
@@ -746,17 +973,50 @@ export function flattenNamespacedHistory(input, namespaces) {
       bareOwners.get(name).add(namespace);
     }
   }
+  const providerNames = new Set([
+    ...(PLAIN_TOOL_NAMES.get(namespaces) || []),
+    ...(nameRelay?.providerToNative.keys() || []),
+    ...(nameRelay?.plainProviderNames || []),
+    ...(CUSTOM_TOOL_RELAYS.get(namespaces)?.keys() || []),
+  ]);
+  const toolSearch = TOOL_SEARCH_RELAYS.get(namespaces);
+  if (toolSearch) providerNames.add(toolSearch.providerName);
   return input.map((item) => {
     if (item?.type !== "function_call") return item;
     const { name } = item;
     if (typeof name !== "string") return item;
-    // Already in the flattened form (the client stored the restored call).
-    if (flattenedNames.has(name)) return item;
     // The client stores namespaced calls as { name, namespace }.
     const namespace = item.namespace;
     if (typeof namespace === "string" && namespaces.get(namespace)?.has(name)) {
       const { namespace: _namespace, ...rest } = item;
-      return { ...rest, name: `${namespace}${NAMESPACE_DELIMITER}${name}` };
+      return { ...rest, name: providerNameForNative(namespaces, namespace, name) };
+    }
+    // A custom/tool-search call already bridged in this request owns its exact
+    // provider spelling. A later-discovered ordinary function can have the same
+    // native name but a different provider alias; object identity keeps the two
+    // histories distinct after both have become ordinary function calls.
+    if (SPECIAL_FUNCTION_REFERENCES.has(item)) return item;
+    // A plain native function may have the exact spelling a namespace child
+    // would normally flatten to (for example plain `a__b` beside namespace
+    // `a` / child `b`). Both definitions receive collision aliases. Resolve
+    // the exact plain identity before treating that spelling as a raw
+    // namespace wire name, or stored plain history would cite neither alias.
+    const plainProviderName =
+      namespace === undefined
+        ? nameRelay?.nativeToProvider.get(nativeToolKey(undefined, name))
+        : undefined;
+    if (plainProviderName && plainProviderName !== name) {
+      return { ...item, name: plainProviderName };
+    }
+    // Provider-visible plain and special-relay names take precedence only when
+    // history carries no valid native namespace or exact aliased plain identity.
+    // Otherwise a plain `read` tool could prevent `{ namespace: "mcp", name:
+    // "read" }` from being rewritten to the namespaced definition actually sent
+    // upstream.
+    if (providerNames.has(name)) return item;
+    if (flattenedNames.has(name)) {
+      const providerName = providerNameForWire(namespaces, name);
+      return providerName && providerName !== name ? { ...item, name: providerName } : item;
     }
     // Calls stored without a namespace field whose bare name belongs to
     // exactly one flattened namespace.
@@ -765,11 +1025,198 @@ export function flattenNamespacedHistory(input, namespaces) {
       if (owners && owners.size === 1) {
         const [owner] = [...owners];
         const { namespace: _namespace, ...rest } = item;
-        return { ...rest, name: `${owner}${NAMESPACE_DELIMITER}${name}` };
+        return { ...rest, name: providerNameForNative(namespaces, owner, name) };
       }
     }
     return item;
   });
+}
+
+function compactionToolIdentityInventory(input, tools) {
+  const plainNames = new Set();
+  const namespaceNames = new Map();
+  const rememberNamespace = (namespace, name) => {
+    if (typeof namespace !== "string" || !namespace || typeof name !== "string" || !name) {
+      return;
+    }
+    if (!namespaceNames.has(namespace)) namespaceNames.set(namespace, new Set());
+    namespaceNames.get(namespace).add(name);
+  };
+
+  for (const tool of Array.isArray(tools) ? tools : []) {
+    if (tool?.type === "namespace" && typeof tool.name === "string") {
+      for (const child of Array.isArray(tool.tools) ? tool.tools : []) {
+        if (child?.type === "function") rememberNamespace(tool.name, child.name);
+      }
+      continue;
+    }
+    if (tool?.type !== "function") continue;
+    const name = providerFunctionName(tool);
+    if (typeof name === "string" && name) plainNames.add(name);
+  }
+
+  const calls = (Array.isArray(input) ? input : []).filter(
+    (item) => item?.type === "function_call" && typeof item.name === "string" && item.name,
+  );
+  for (const item of calls) rememberNamespace(item.namespace, item.name);
+
+  const rawNamespaceOwners = new Map();
+  const bareNamespaceOwners = new Map();
+  for (const [namespace, names] of namespaceNames) {
+    for (const name of names) {
+      const wireName = `${namespace}${NAMESPACE_DELIMITER}${name}`;
+      if (!rawNamespaceOwners.has(wireName)) rawNamespaceOwners.set(wireName, new Set());
+      rawNamespaceOwners.get(wireName).add(namespace);
+      if (!bareNamespaceOwners.has(name)) bareNamespaceOwners.set(name, new Set());
+      bareNamespaceOwners.get(name).add(namespace);
+    }
+  }
+  for (const item of calls) {
+    if (item.namespace !== undefined) continue;
+    const rawOwners = rawNamespaceOwners.get(item.name);
+    const bareOwners = bareNamespaceOwners.get(item.name);
+    if (
+      !plainNames.has(item.name) &&
+      ((rawOwners && rawOwners.size === 1) || (bareOwners && bareOwners.size === 1))
+    ) {
+      continue;
+    }
+    plainNames.add(item.name);
+  }
+
+  return [
+    ...[...plainNames]
+      .sort((left, right) => left.localeCompare(right))
+      .map((name) => ({ type: "function", name })),
+    ...[...namespaceNames]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([name, names]) => ({
+        type: "namespace",
+        name,
+        tools: [...names]
+          .sort((left, right) => left.localeCompare(right))
+          .map((childName) => ({ type: "function", name: childName })),
+      })),
+  ];
+}
+
+// Routed compaction sends no live tools, but it still replays the complete
+// transcript to the summarizer. Console Go rejects Codex-native tool item
+// discriminators on that replay just as it does on an ordinary turn. Build a
+// names-only request-local inventory from the payload and explicit history,
+// bridge custom calls, flatten namespace history with the same bounded naming
+// contract, and remove deferred-search metadata (schemas, not tool results)
+// that cannot be consumed without a live tool_search control.
+export function strictOpenCodeCompactionInput(input, tools, { maxNameLength = 64 } = {}) {
+  if (!Array.isArray(input)) return input;
+  const inventory = compactionToolIdentityInventory(input, tools);
+  const flattened = flattenNamespaceTools(inventory, {
+    bridgeToolSearch: false,
+    maxNameLength,
+  });
+  const customNames = [
+    ...new Set(
+      input
+        .filter(
+          (item) =>
+            item?.type === "custom_tool_call" &&
+            typeof item.name === "string" &&
+            item.name,
+        )
+        .map((item) => item.name),
+    ),
+  ];
+  const custom = bridgeCustomTools(
+    [],
+    input,
+    flattened.namespaces,
+    undefined,
+    customNames,
+    { maxNameLength },
+  );
+  const withoutSearch = custom.input.filter(
+    (item) =>
+      item?.type !== "tool_search_call" &&
+      item?.type !== "tool_search_output" &&
+      item?.type !== "custom_tool_call" &&
+      item?.type !== "custom_tool_call_output",
+  );
+  return flattenNamespacedHistory(withoutSearch, flattened.namespaces);
+}
+
+function flattenToolChoiceReference(reference, namespaces) {
+  if (!reference || typeof reference !== "object" || Array.isArray(reference)) return reference;
+  const toolSearch = TOOL_SEARCH_RELAYS.get(namespaces);
+  if (reference.type === "tool_search" && toolSearch) {
+    const { execution: _execution, ...rest } = reference;
+    const routedReference = {
+      ...rest,
+      type: "function",
+      name: toolSearch.providerName,
+    };
+    SPECIAL_FUNCTION_REFERENCES.add(routedReference);
+    return routedReference;
+  }
+  if (reference.type !== "function") return reference;
+
+  const nestedName = reference.function?.name;
+  const name = typeof nestedName === "string" ? nestedName : reference.name;
+  if (typeof name !== "string" || !name) return reference;
+  const namespace =
+    typeof reference.namespace === "string" && reference.namespace
+      ? reference.namespace
+      : undefined;
+  let providerName;
+  if (namespace && namespaces.get(namespace)?.has(name)) {
+    providerName = providerNameForNative(namespaces, namespace, name);
+  } else if (!namespace) {
+    if (SPECIAL_FUNCTION_REFERENCES.has(reference)) return reference;
+    const exactPlainProviderName = NAME_ALIASES.get(namespaces)?.nativeToProvider.get(
+      nativeToolKey(undefined, name),
+    );
+    if (exactPlainProviderName && exactPlainProviderName !== name) {
+      providerName = exactPlainProviderName;
+    }
+    const alreadyProviderVisible =
+      PLAIN_TOOL_NAMES.get(namespaces)?.has(name) ||
+      NAME_ALIASES.get(namespaces)?.plainProviderNames.has(name) ||
+      CUSTOM_TOOL_RELAYS.get(namespaces)?.has(name) ||
+      TOOL_SEARCH_RELAYS.get(namespaces)?.providerName === name;
+    if (!providerName && alreadyProviderVisible) return reference;
+    providerName ||= exactPlainProviderName || providerNameForWire(namespaces, name);
+    if (!providerName) {
+      const owners = [...namespaces].filter(([, names]) => names.has(name));
+      if (owners.length === 1) {
+        providerName = providerNameForNative(namespaces, owners[0][0], name);
+      }
+    }
+  }
+  if (!providerName || (providerName === name && namespace === undefined)) return reference;
+
+  const { namespace: _namespace, ...rest } = reference;
+  if (typeof nestedName === "string") {
+    return { ...rest, function: { ...reference.function, name: providerName } };
+  }
+  return { ...rest, name: providerName };
+}
+
+// A bounded provider name is one contract across the whole request. Rewrite
+// forced references only after tool-search history has expanded the live tool
+// set, so a discovered definition and an allowed-tools choice cannot disagree.
+export function flattenToolChoice(toolChoice, namespaces) {
+  if (!toolChoice || typeof toolChoice !== "object" || Array.isArray(toolChoice)) {
+    return toolChoice;
+  }
+  if (toolChoice.type !== "allowed_tools" || !Array.isArray(toolChoice.tools)) {
+    return flattenToolChoiceReference(toolChoice, namespaces);
+  }
+  let changed = false;
+  const tools = toolChoice.tools.map((tool) => {
+    const rewritten = flattenToolChoiceReference(tool, namespaces);
+    if (rewritten !== tool) changed = true;
+    return rewritten;
+  });
+  return changed ? { ...toolChoice, tools } : toolChoice;
 }
 
 // Reverse lookups for restoring calls: flattened name -> native
@@ -777,9 +1224,13 @@ export function flattenNamespacedHistory(input, namespaces) {
 export function buildNamespaceLookups(namespaces) {
   const flatToNative = new Map();
   const bareToNamespaces = new Map();
+  const nameAliases = NAME_ALIASES.get(namespaces);
   for (const [namespace, names] of namespaces) {
     for (const name of names) {
-      flatToNative.set(`${namespace}${NAMESPACE_DELIMITER}${name}`, {
+      const providerName =
+        nameAliases?.nativeToProvider.get(nativeToolKey(namespace, name)) ||
+        `${namespace}${NAMESPACE_DELIMITER}${name}`;
+      flatToNative.set(providerName, {
         namespace,
         name,
       });
@@ -787,9 +1238,18 @@ export function buildNamespaceLookups(namespaces) {
       bareToNamespaces.get(name).add(namespace);
     }
   }
+  if (nameAliases) {
+    for (const [providerName, native] of nameAliases.providerToNative) {
+      flatToNative.set(providerName, native);
+    }
+  }
   return {
     flatToNative,
     bareToNamespaces,
+    plainToolNames: new Set([
+      ...(PLAIN_TOOL_NAMES.get(namespaces) || []),
+      ...(nameAliases?.plainProviderNames || []),
+    ]),
     spawnAgentModels: SPAWN_AGENT_MODELS.get(namespaces),
     toolSearch: TOOL_SEARCH_RELAYS.get(namespaces),
     customTools: CUSTOM_TOOL_RELAYS.get(namespaces),
@@ -930,14 +1390,18 @@ function rewriteNamespaceFunctionCallItem(
   let rewritten = item;
   const resolved = lookups.flatToNative.get(item.name);
   if (resolved) {
-    rewritten = {
-      ...item,
-      name: resolved.name,
-      namespace: resolved.namespace,
-    };
+    const { namespace: _providerNamespace, ...rest } = item;
+    rewritten = resolved.namespace === undefined
+      ? { ...rest, name: resolved.name }
+      : { ...rest, name: resolved.name, namespace: resolved.namespace };
   } else {
     const owners = lookups.bareToNamespaces.get(item.name);
-    if (item.namespace === undefined && owners && owners.size === 1) {
+    if (
+      item.namespace === undefined &&
+      !lookups.plainToolNames?.has(item.name) &&
+      owners &&
+      owners.size === 1
+    ) {
       const [namespace] = [...owners];
       rewritten = {
         ...item,

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -87,8 +87,10 @@ import {
   downgradeOriginalImageDetail,
   flattenNamespacedHistory,
   flattenNamespaceTools,
+  flattenToolChoice,
   flattenToolSearchHistory,
   repairToolSchemaRoots,
+  strictOpenCodeCompactionInput,
   stripSearchContentTypes,
 } from "./namespace-relay.mjs";
 import { collaborationToolAvailable, pendingInterruptTargets } from "./subagent-completion.mjs";
@@ -705,6 +707,22 @@ function needsZenFreeToolCompatibility(route) {
   return (
     (providerId === "opencode-free-responses" &&
       route.upstreamModel === "muse-spark-1.2-contributor-free")
+  );
+}
+
+// Console Go's Responses endpoint is Responses-shaped but implements only the
+// ordinary function-tool subset: namespace/custom/deferred-search controls are
+// rejected, as are function names over 64 characters. Keep this exact to the
+// Go Responses variant; paid Zen and other Responses providers retain their
+// native contract until their own upstream proves otherwise.
+function needsConsoleGoResponsesToolCompatibility(route) {
+  return providerForModel(route)?.id === "opencode-go-responses";
+}
+
+function needsStrictOpenCodeToolCompatibility(route) {
+  return (
+    needsZenFreeToolCompatibility(route) ||
+    needsConsoleGoResponsesToolCompatibility(route)
   );
 }
 
@@ -2083,9 +2101,17 @@ function compactionAttempts(route, aged) {
 // conversation cannot get under its context limit without one.
 async function summarizeWith(request, payload, route, aged, prepared, signal) {
   const compatibleInput = zenFreeCompatibleInput(aged.input, route);
-  const providerInput = needsZenFreeToolCompatibility(route)
-    ? bridgeCustomTools([], compatibleInput, new Map()).input
-    : compatibleInput;
+  const providerInput = needsConsoleGoResponsesToolCompatibility(route)
+    ? strictOpenCodeCompactionInput(compatibleInput, payload.tools, {
+        maxNameLength: 64,
+      })
+    : needsZenFreeToolCompatibility(route)
+      ? bridgeCustomTools(
+        [],
+        compatibleInput,
+        new Map(),
+      ).input
+      : compatibleInput;
   const bridged = await bridgeVisionInput(
     providerInput,
     route,
@@ -2105,6 +2131,7 @@ async function summarizeWith(request, payload, route, aged, prepared, signal) {
       messageItem(COMPACTION_PROMPT),
     ],
   };
+  delete body.tool_choice;
   normalizeAutoToolChoice(body, route);
   delete body.previous_response_id;
   delete body.client_metadata;
@@ -2514,6 +2541,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
   const input = Array.isArray(bridged) ? [...bridged] : bridged;
   const provider = providerForModel(route);
   const chatCompletionsProvider = provider?.protocol !== "openai-responses";
+  const consoleGoResponsesCompatibility = needsConsoleGoResponsesToolCompatibility(route);
   // Thinking chat providers need the assistant's reasoning replayed, but
   // LiteLLM drops Responses `reasoning` input items. Generic providers keep
   // the established visible-content carry used for DeepSeek. GLM's native
@@ -2560,6 +2588,14 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     if (namespacesFlattened) {
       tools = flattened.tools;
     }
+  } else if (consoleGoResponsesCompatibility) {
+    // Console Go exposes a Responses endpoint but rejects the native tool
+    // discriminators Codex sends. Translate only its tool boundary; unlike the
+    // chat-completions branch, do not inject the deferred codex_app snapshot.
+    const flattened = flattenNamespaceTools(tools, { maxNameLength: 64 });
+    namespacesFlattened = flattened.flattened;
+    flattenedNamespaces = flattened.namespaces;
+    tools = flattened.tools;
   } else {
     // Responses-native providers keep the namespace tools untouched, so nothing
     // is flattened and the list is left alone. The inventory is still built,
@@ -2569,18 +2605,19 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     flattenedNamespaces = flattenNamespaceTools(tools, {
       bridgeToolSearch: false,
     }).namespaces;
-    // Keeping the namespace shape is not the same as keeping a root the
-    // upstream rejects. `opencode-go-responses/gpt-5.6-luna` 400s a
-    // `type: ["object","null"]` parameter root while accepting the same request
-    // with a plain or union root -- so the strict-root repair has to run here
-    // too, on the tools alone, without flattening anything.
+    // Keeping the namespace shape is not the same as keeping a parameter root
+    // strict Responses providers may reject. Run the shared root repair on the
+    // tools alone without flattening their native representation.
     tools = repairToolSchemaRoots(tools);
   }
   if (needsZenFreeToolCompatibility(route)) {
-    // Ox reaches Chat Completions after namespace flattening while Muse reaches
-    // Responses with native namespaces. Run the same recursive-ref repair
-    // after both protocol branches so neither wire shape can bypass it.
+    // Zen Free's measured schema boundary rejects recursive definition edges.
+    // Console Go's evidence establishes different tool discriminators and
+    // fields only, so it must retain recursive refs until that endpoint proves
+    // otherwise.
     tools = repairToolSchemaRoots(tools, { nonRecursive: true });
+  }
+  if (needsStrictOpenCodeToolCompatibility(route)) {
     tools = stripSearchContentTypes(tools);
   }
   if (needsMoonshotSchemaCompatibility(route)) {
@@ -2590,18 +2627,22 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
   }
   let routedInput = input;
   let routedToolChoice = payload.tool_choice;
-  if (needsZenFreeToolCompatibility(route)) {
+  if (needsStrictOpenCodeToolCompatibility(route)) {
     const customTools = bridgeCustomTools(
       tools,
       routedInput,
       flattenedNamespaces,
       routedToolChoice,
+      undefined,
+      consoleGoResponsesCompatibility
+        ? { maxNameLength: 64, bridgeAll: true }
+        : undefined,
     );
     tools = customTools.tools;
     routedInput = customTools.input;
     routedToolChoice = customTools.toolChoice;
   }
-  if (chatCompletionsProvider) {
+  if (chatCompletionsProvider || consoleGoResponsesCompatibility) {
     const searchHistory = flattenToolSearchHistory(
       routedInput,
       tools,
@@ -2609,11 +2650,17 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     );
     routedInput = searchHistory.input;
     tools = searchHistory.tools;
+    if (needsZenFreeToolCompatibility(route)) {
+      tools = repairToolSchemaRoots(tools, { nonRecursive: true });
+    }
   }
   // The stored call history must use the same tool names as the tool list, or
   // the model copies the bare names out of its own transcript.
   if (namespacesFlattened) {
     routedInput = flattenNamespacedHistory(routedInput, flattenedNamespaces);
+  }
+  if (consoleGoResponsesCompatibility) {
+    routedToolChoice = flattenToolChoice(routedToolChoice, flattenedNamespaces);
   }
   const routed = {
     ...payload,

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -142,8 +142,16 @@ function run(
     encoding: "utf8",
     mode: 0o600,
   });
-  // The responses-native provider used by the protocol-crossing cases. It is a
-  // variant of opencode-go, so it authenticates with that family's credential.
+  // The genuinely Responses-native provider used by the protocol-crossing
+  // cases. OpenCode Go Responses has a function-only compatibility boundary,
+  // so it is no longer a valid exemplar for preserving native namespaces.
+  writeFileSync(path.join(stateDir, "meta-api-key.secret"), "test-meta-key\n", {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  // The pressure test deliberately uses Console Go's smaller context window;
+  // its request has no tools, so the provider's function-only compatibility
+  // boundary is not part of that assertion.
   writeFileSync(path.join(stateDir, "opencode-go-api-key.secret"), "test-opencode-go-key\n", {
     encoding: "utf8",
     mode: 0o600,
@@ -630,6 +638,10 @@ test("a fallback rebuild carries the full request, not a model swap", async () =
 // map, shipping plausible tools the response transform can no longer map back.
 
 const RESPONSES_MODEL = {
+  slug: "meta/muse-spark-1.2",
+  gatewayModel: "meta-muse-spark-1-2",
+};
+const PRESSURE_RESPONSES_MODEL = {
   slug: "opencode-go-responses/gpt-5.6-luna",
   gatewayModel: "opencode-go-responses-gpt-5-6-luna",
 };
@@ -653,7 +665,7 @@ test("failover recalculates token-maxxing pressure for the serving model", async
   });
   const routerPort = await openPort();
   const child = run(routerEnv(gw.port, routerPort), {
-    chain: [RESPONSES_MODEL.slug],
+    chain: [PRESSURE_RESPONSES_MODEL.slug],
     toolResultAging: true,
   });
   // The pristine request is larger than the fallback's context window. It can
@@ -677,11 +689,14 @@ test("failover recalculates token-maxxing pressure for the serving model", async
     assert.equal(seen[0].model, PRIMARY.gatewayModel);
     assert.equal(seen[0].input[1].output, value);
     assert.equal(seen[0].instructions, "Base instructions.");
-    assert.equal(seen[1].model, RESPONSES_MODEL.gatewayModel);
+    assert.equal(seen[1].model, PRESSURE_RESPONSES_MODEL.gatewayModel);
     assert.match(seen[1].input[1].output, /Tool result shaped by Codex Router token maxxing/u);
     assert.match(seen[1].instructions, /## Context pressure mode/u);
     const events = await waitForUsageEvents(child.stateDir, 2, child);
-    assert.equal(events.find((event) => event.model === RESPONSES_MODEL.slug).toolResultsShaped, 1);
+    assert.equal(
+      events.find((event) => event.model === PRESSURE_RESPONSES_MODEL.slug).toolResultsShaped,
+      1,
+    );
   } finally {
     await stopChild(child);
     await closeServer(gw.server);

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -494,6 +494,7 @@ function functionCallsFromSse(body) {
 async function scenario(
   stream = true,
   {
+    endpoint = "/responses",
     model = "opencode-go/deepseek-v4-flash",
     sseBody = gatewaySseBody,
     jsonBody = gatewayJsonBody,
@@ -506,10 +507,10 @@ async function scenario(
       const gatewayBody = await bodyJson(request);
       gatewayBodies.push(gatewayBody);
       if (gatewayBody.stream === false) {
-        json(response, 200, jsonBody());
+        json(response, 200, jsonBody(gatewayBody));
         return;
       }
-      const body = Buffer.from(sseBody(), "utf8");
+      const body = Buffer.from(sseBody(gatewayBody), "utf8");
       response.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Content-Length": String(body.length),
@@ -527,7 +528,7 @@ async function scenario(
   });
   try {
     await waitFor(`${routerBase(routerPort)}/models`, router);
-    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+    const response = await fetch(`${routerBase(routerPort)}${endpoint}`, {
       method: "POST",
       headers: {
         Authorization: "Bearer CODEX_CALLER_SECRET",
@@ -797,13 +798,13 @@ test("routed tool_search history declares discovered tools and restores their ca
 
 test("Responses-native routed providers inherit the model on fresh local thread calls", async () => {
   const options = {
-    model: "opencode-go-responses/gpt-5.6-luna",
+    model: "meta/muse-spark-1.2",
     sseBody: responsesProviderSseBody,
     jsonBody: responsesProviderJsonBody,
     requestPayload: routedToolSearchHistoryPayload,
   };
   const streamed = await scenario(true, options);
-  assert.equal(streamed.gatewayBodies[0].model, "opencode-go-responses-gpt-5-6-luna");
+  assert.equal(streamed.gatewayBodies[0].model, "meta-muse-spark-1-2");
   assert.ok(
     streamed.gatewayBodies[0].tools.some((tool) => tool?.type === "namespace"),
     "Responses-native tools stay namespaced",
@@ -825,7 +826,7 @@ test("Responses-native routed providers inherit the model on fresh local thread 
   assert.deepEqual(JSON.parse(streamedCall.arguments), {
     prompt: "hi",
     target: { type: "projectless" },
-    model: "opencode-go-responses/gpt-5.6-luna",
+    model: "meta/muse-spark-1.2",
   });
 
   const nonStreaming = await scenario(false, options);
@@ -833,6 +834,371 @@ test("Responses-native routed providers inherit the model on fresh local thread 
   assert.deepEqual(JSON.parse(nonStreamingCall.arguments), {
     prompt: "hi",
     target: { type: "projectless" },
-    model: "opencode-go-responses/gpt-5.6-luna",
+    model: "meta/muse-spark-1.2",
   });
+});
+
+const GO_NAMESPACE = "mcp__codex_apps__github";
+const GO_LONG_TOOL = "list_repository_pull_request_review_comments_for_branch";
+const GO_DISCOVERED_NAMESPACE = "mcp__calendar_connector_with_a_long_namespace";
+const GO_DISCOVERED_TOOL = "delete_an_event_and_notify_every_participant";
+const GO_PATCH = "*** Begin Patch\n*** End Patch";
+
+function goCompatibilityRequestPayload(
+  stream = true,
+  model = "opencode-go-responses/gpt-5.6-luna",
+) {
+  return {
+    model,
+    stream,
+    tool_choice: { type: "function", name: GO_LONG_TOOL, namespace: GO_NAMESPACE },
+    tools: [
+      {
+        type: "tool_search",
+        execution: "client",
+        description: "Search deferred tools.",
+        parameters: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+          additionalProperties: false,
+        },
+      },
+      { type: "function", name: "exec_command", parameters: { type: "object" } },
+      {
+        type: "namespace",
+        name: GO_NAMESPACE,
+        tools: [
+          {
+            type: "function",
+            name: GO_LONG_TOOL,
+            inputSchema: {
+              type: "object",
+              properties: {
+                branch: { type: "string" },
+                node: { $ref: "#/$defs/node" },
+              },
+              required: ["branch"],
+              additionalProperties: false,
+              $defs: {
+                node: {
+                  type: "object",
+                  properties: { child: { $ref: "#/$defs/node" } },
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        type: "namespace",
+        name: "codex_app",
+        tools: [{ type: "function", name: "read_thread_terminal" }],
+      },
+      {
+        type: "custom",
+        name: "apply_patch",
+        format: { type: "grammar", syntax: "lark", definition: "start: /.+/" },
+      },
+      {
+        type: "custom",
+        name: "future_custom",
+        description: "FUTURE_CUSTOM_SENTINEL",
+      },
+      {
+        type: "web_search",
+        search_content_types: ["text", "image"],
+        search_context_size: "medium",
+      },
+    ],
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+      {
+        type: "function_call",
+        name: GO_LONG_TOOL,
+        namespace: GO_NAMESPACE,
+        call_id: "history-long",
+        arguments: '{"branch":"main"}',
+      },
+      { type: "function_call_output", call_id: "history-long", output: "[]" },
+      {
+        type: "tool_search_call",
+        call_id: "search-long",
+        execution: "client",
+        arguments: { query: "calendar" },
+      },
+      {
+        type: "tool_search_output",
+        call_id: "search-long",
+        status: "completed",
+        execution: "client",
+        tools: [
+          {
+            type: "namespace",
+            name: GO_DISCOVERED_NAMESPACE,
+            tools: [{ type: "function", name: GO_DISCOVERED_TOOL }],
+          },
+        ],
+      },
+      {
+        type: "function_call",
+        name: GO_DISCOVERED_TOOL,
+        namespace: GO_DISCOVERED_NAMESPACE,
+        call_id: "history-discovered",
+        arguments: "{}",
+      },
+      { type: "function_call_output", call_id: "history-discovered", output: "done" },
+      {
+        type: "custom_tool_call",
+        name: "apply_patch",
+        call_id: "history-patch",
+        input: GO_PATCH,
+      },
+      { type: "custom_tool_call_output", call_id: "history-patch", output: "Done!" },
+      {
+        type: "custom_tool_call",
+        name: "future_custom",
+        call_id: "history-future-custom",
+        input: "opaque future input",
+      },
+      {
+        type: "custom_tool_call_output",
+        call_id: "history-future-custom",
+        output: "future done",
+      },
+    ],
+  };
+}
+
+function goProviderCalls(body) {
+  const patchTool = body.tools.find(
+    (tool) => tool.type === "function" && tool.parameters?.properties?.input,
+  );
+  return [
+    {
+      type: "function_call",
+      name: body.tool_choice.name,
+      call_id: "call-long",
+      arguments: '{"branch":"main"}',
+    },
+    {
+      type: "function_call",
+      name: "tool_search",
+      call_id: "call-search",
+      arguments: '{"query":"calendar"}',
+    },
+    {
+      type: "function_call",
+      name: patchTool.name,
+      call_id: "call-patch",
+      arguments: JSON.stringify({ input: GO_PATCH }),
+    },
+  ];
+}
+
+function goCompatibilitySseBody(body) {
+  const calls = goProviderCalls(body);
+  return [
+    ...calls.map((item) => sseEvent({ type: "response.output_item.done", item })),
+    sseEvent({
+      type: "response.completed",
+      response: { id: "resp-go", status: "completed", output: calls },
+    }),
+    "data: [DONE]\n\n",
+  ].join("");
+}
+
+function goCompatibilityJsonBody(body) {
+  return { id: "resp-go-json", status: "completed", output: goProviderCalls(body) };
+}
+
+test("OpenCode Go Responses uses one bounded function-tool contract in both response modes", async () => {
+  for (const stream of [true, false]) {
+    const result = await scenario(stream, {
+      model: "opencode-go-responses/gpt-5.6-luna",
+      requestPayload: goCompatibilityRequestPayload,
+      sseBody: goCompatibilitySseBody,
+      jsonBody: goCompatibilityJsonBody,
+    });
+    const outgoing = result.gatewayBodies[0];
+    assert.equal(outgoing.model, "opencode-go-responses-gpt-5-6-luna");
+    assert.ok(
+      outgoing.tools.every(
+        (tool) => !["namespace", "custom", "tool_search"].includes(tool?.type),
+      ),
+      "unsupported native tool discriminators do not reach Console Go",
+    );
+    assert.ok(
+      outgoing.tools
+        .filter((tool) => tool?.type === "function")
+        .every((tool) => tool.name.length <= 64),
+      "every provider-visible function name stays within Console Go's cap",
+    );
+    const webSearch = outgoing.tools.find((tool) => tool.type === "web_search");
+    assert.equal("search_content_types" in webSearch, false);
+    assert.equal(webSearch.search_context_size, "medium");
+    assert.ok(outgoing.tools.some((tool) => tool.type === "function" && tool.name === "tool_search"));
+    assert.ok(outgoing.tools.some((tool) => tool.name === "codex_app__read_thread_terminal"));
+    assert.equal(
+      outgoing.tools.some((tool) => tool.name === "codex_app__create_thread"),
+      false,
+      "the chat-only deferred app snapshot is not injected on Console Go Responses",
+    );
+    assert.ok(
+      outgoing.tools.some(
+        (tool) => tool.type === "function" && tool.parameters?.properties?.input,
+      ),
+      "the custom patch tool is bridged instead of dropped",
+    );
+    assert.ok(
+      outgoing.tools.some(
+        (tool) =>
+          tool.type === "function" && tool.description === "FUTURE_CUSTOM_SENTINEL",
+      ),
+      "Console Go bridges every custom discriminator present in the request",
+    );
+
+    const longAlias = outgoing.tool_choice.name;
+    assert.equal(outgoing.tool_choice.namespace, undefined);
+    assert.ok(longAlias.length <= 64);
+    assert.notEqual(longAlias, `${GO_NAMESPACE}__${GO_LONG_TOOL}`);
+    const longTool = outgoing.tools.find((tool) => tool.name === longAlias);
+    assert.equal(
+      longTool.parameters.$defs.node.properties.child.$ref,
+      "#/$defs/node",
+      "Console Go keeps recursive refs because no upstream rejection established otherwise",
+    );
+    assert.equal(
+      outgoing.input.find((item) => item.call_id === "history-long").name,
+      longAlias,
+    );
+    const discoveredHistory = outgoing.input.find(
+      (item) => item.call_id === "history-discovered",
+    );
+    assert.ok(discoveredHistory.name.length <= 64);
+    assert.equal(discoveredHistory.namespace, undefined);
+    assert.ok(outgoing.tools.some((tool) => tool.name === discoveredHistory.name));
+    assert.equal(
+      outgoing.input.find((item) => item.call_id === "search-long").type,
+      "function_call",
+    );
+    assert.equal(
+      outgoing.input.some(
+        (item) => item.type === "tool_search_call" || item.type === "tool_search_output",
+      ),
+      false,
+    );
+    assert.equal(
+      outgoing.input.find((item) => item.call_id === "history-patch").type,
+      "function_call",
+    );
+    const futureCustom = outgoing.input.find(
+      (item) => item.call_id === "history-future-custom" && item.type === "function_call",
+    );
+    assert.deepEqual(JSON.parse(futureCustom.arguments), { input: "opaque future input" });
+
+    const clientItems = stream
+      ? responseItemsFromSse(result.clientBody)
+      : JSON.parse(result.clientBody).output;
+    assert.deepEqual(clientItems[0], {
+      type: "function_call",
+      name: GO_LONG_TOOL,
+      namespace: GO_NAMESPACE,
+      call_id: "call-long",
+      arguments: '{"branch":"main"}',
+    });
+    assert.deepEqual(clientItems[1], {
+      type: "tool_search_call",
+      execution: "client",
+      call_id: "call-search",
+      arguments: { query: "calendar" },
+    });
+    assert.deepEqual(clientItems[2], {
+      type: "custom_tool_call",
+      name: "apply_patch",
+      call_id: "call-patch",
+      input: GO_PATCH,
+    });
+  }
+});
+
+test("OpenCode Go compaction removes native tool history before the strict endpoint", async () => {
+  const result = await scenario(false, {
+    endpoint: "/responses/compact",
+    model: "opencode-go-responses/gpt-5.6-luna",
+    requestPayload: (_stream, model) => {
+      const ordinary = goCompatibilityRequestPayload(false, model);
+      ordinary.input.push(
+        {
+          type: "custom_tool_call",
+          name: "another_custom_tool",
+          call_id: "history-other-custom",
+          input: "opaque input",
+        },
+        {
+          type: "custom_tool_call_output",
+          call_id: "history-other-custom",
+          output: "opaque output",
+        },
+        {
+          type: "custom_tool_call_output",
+          call_id: "orphan-custom-output",
+          output: "must not cross the strict boundary",
+        },
+      );
+      return {
+        model,
+        tools: [{ type: "custom", name: "future_custom" }],
+        tool_choice: { type: "custom", name: "future_custom" },
+        input: ordinary.input,
+      };
+    },
+    jsonBody: () => ({
+      id: "resp-go-compact",
+      status: "completed",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "history compacted" }],
+        },
+      ],
+    }),
+  });
+  const outgoing = result.gatewayBodies[0];
+  assert.equal(outgoing.model, "opencode-go-responses-gpt-5-6-luna");
+  assert.deepEqual(outgoing.tools, []);
+  assert.equal(outgoing.tool_choice, undefined);
+  assert.equal(
+    outgoing.input.some(
+      (item) =>
+        ["custom_tool_call", "custom_tool_call_output", "tool_search_call", "tool_search_output"]
+          .includes(item?.type) || item?.namespace !== undefined,
+    ),
+    false,
+  );
+  assert.equal(
+    outgoing.input.some((item) => item.call_id === "search-long"),
+    false,
+    "deferred search schemas are omitted when compaction sends no live tools",
+  );
+  assert.ok(
+    outgoing.input
+      .filter((item) => item?.type === "function_call")
+      .every((item) => item.name.length <= 64),
+  );
+  const namespaced = outgoing.input.find((item) => item.call_id === "history-long");
+  assert.equal(namespaced.type, "function_call");
+  assert.equal(namespaced.namespace, undefined);
+  const custom = outgoing.input.find((item) => item.call_id === "history-patch");
+  assert.equal(custom.type, "function_call");
+  assert.deepEqual(JSON.parse(custom.arguments), { input: GO_PATCH });
+  const otherCustom = outgoing.input.find(
+    (item) => item.call_id === "history-other-custom" && item.type === "function_call",
+  );
+  assert.deepEqual(JSON.parse(otherCustom.arguments), { input: "opaque input" });
+  assert.equal(
+    outgoing.input.some((item) => item.call_id === "orphan-custom-output"),
+    false,
+  );
 });

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -10,6 +10,7 @@ import {
   downgradeOriginalImageDetail,
   flattenNamespacedHistory,
   flattenNamespaceTools,
+  flattenToolChoice,
   flattenToolSearchHistory,
   rewriteNamespaceFunctionCall,
   rewriteNamespaceResponsePayload,
@@ -252,6 +253,515 @@ test("flattenNamespaceTools handles non-array and empty input", () => {
   assert.equal(flattened, false);
   assert.equal(namespaces.size, 0);
   assert.equal(tools.length, 1);
+});
+
+test("bounded function names stay consistent across definitions, history, choices, and restore", () => {
+  const namespace = "mcp__codex_apps__github";
+  const nativeName = "list_repository_pull_request_review_comments_for_branch";
+  const originalName = `${namespace}__${nativeName}`;
+  assert.ok(originalName.length > 64, "fixture must exercise the provider limit");
+
+  const definition = {
+    type: "namespace",
+    name: namespace,
+    tools: [{ type: "function", name: nativeName, inputSchema: { type: "object" } }],
+  };
+  const first = flattenNamespaceTools([definition], { maxNameLength: 64 });
+  const second = flattenNamespaceTools([definition], { maxNameLength: 64 });
+  const alias = first.tools[0].name;
+  assert.equal(alias.length, 64);
+  assert.notEqual(alias, originalName);
+  assert.equal(second.tools[0].name, alias, "the same request shape gets the same alias");
+
+  const history = flattenNamespacedHistory(
+    [
+      {
+        type: "function_call",
+        name: nativeName,
+        namespace,
+        call_id: "explicit",
+        arguments: "{}",
+      },
+      {
+        type: "function_call",
+        name: originalName,
+        call_id: "already-flat",
+        arguments: "{}",
+      },
+    ],
+    first.namespaces,
+  );
+  assert.deepEqual(history.map((item) => item.name), [alias, alias]);
+  assert.ok(history.every((item) => item.namespace === undefined));
+
+  assert.deepEqual(
+    flattenToolChoice(
+      { type: "function", name: nativeName, namespace },
+      first.namespaces,
+    ),
+    { type: "function", name: alias },
+  );
+  assert.deepEqual(
+    flattenToolChoice({ type: "function", name: nativeName }, first.namespaces),
+    { type: "function", name: alias },
+  );
+  assert.deepEqual(
+    flattenToolChoice(
+      {
+        type: "allowed_tools",
+        mode: "required",
+        tools: [{ type: "function", name: nativeName, namespace }],
+      },
+      first.namespaces,
+    ).tools,
+    [{ type: "function", name: alias }],
+  );
+
+  const restored = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        { type: "function_call", name: alias, call_id: "result", arguments: "{}" },
+      ],
+    },
+    buildNamespaceLookups(first.namespaces),
+  );
+  assert.deepEqual(restored.output[0], {
+    type: "function_call",
+    name: nativeName,
+    namespace,
+    call_id: "result",
+    arguments: "{}",
+  });
+});
+
+test("bounded aliases avoid request-local collisions without renaming the legal sibling", () => {
+  const namespace = "mcp__codex_apps__github";
+  const nativeName = "list_repository_pull_request_review_comments_for_branch";
+  const definition = {
+    type: "namespace",
+    name: namespace,
+    tools: [{ type: "function", name: nativeName }],
+  };
+  const initialAlias = flattenNamespaceTools([definition], { maxNameLength: 64 }).tools[0].name;
+  const tools = [{ type: "function", name: initialAlias }, definition];
+  const first = flattenNamespaceTools(tools, { maxNameLength: 64 });
+  const second = flattenNamespaceTools(tools, { maxNameLength: 64 });
+  assert.equal(first.tools[0].name, initialAlias, "the already-legal plain function wins");
+  assert.equal(first.tools[1].name.length, 64);
+  assert.notEqual(first.tools[1].name, initialAlias);
+  assert.deepEqual(
+    first.tools.map((tool) => tool.name),
+    second.tools.map((tool) => tool.name),
+    "collision fallback is deterministic",
+  );
+});
+
+test("bounded history keeps ordinary and bridged names ahead of bare namespace inference", () => {
+  const flattened = flattenNamespaceTools(
+    [
+      { type: "function", name: "read" },
+      clientToolSearchControl(),
+      {
+        type: "namespace",
+        name: "mcp__files",
+        tools: [
+          { type: "function", name: "read" },
+          { type: "function", name: "apply_patch" },
+          { type: "function", name: "tool_search" },
+        ],
+      },
+    ],
+    { maxNameLength: 64 },
+  );
+  const bridged = bridgeCustomTools(
+    [...flattened.tools, { type: "custom", name: "apply_patch" }],
+    [
+      { type: "function_call", name: "read", call_id: "plain", arguments: "{}" },
+      {
+        type: "custom_tool_call",
+        name: "apply_patch",
+        call_id: "patch",
+        input: "patch",
+      },
+      {
+        type: "function_call",
+        name: "tool_search",
+        call_id: "search",
+        arguments: '{"query":"files"}',
+      },
+    ],
+    flattened.namespaces,
+    undefined,
+    undefined,
+    { maxNameLength: 64 },
+  );
+  const history = flattenNamespacedHistory(bridged.input, flattened.namespaces);
+  assert.deepEqual(history.map((item) => item.name), ["read", "apply_patch", "tool_search"]);
+});
+
+test("later-discovered plain functions stay distinct from same-named custom relays", () => {
+  const nativeName = "future_custom";
+  const flattened = flattenNamespaceTools(
+    [clientToolSearchControl(), { type: "custom", name: nativeName }],
+    { maxNameLength: 64 },
+  );
+  const bridged = bridgeCustomTools(
+    flattened.tools,
+    [
+      {
+        type: "custom_tool_call",
+        name: nativeName,
+        call_id: "custom-call",
+        input: "opaque",
+      },
+      { type: "custom_tool_call_output", call_id: "custom-call", output: "done" },
+      {
+        type: "tool_search_call",
+        call_id: "search-call",
+        execution: "client",
+        arguments: { query: nativeName },
+      },
+      {
+        type: "tool_search_output",
+        call_id: "search-call",
+        execution: "client",
+        status: "completed",
+        tools: [{ type: "function", name: nativeName, parameters: { type: "object" } }],
+      },
+      { type: "function_call", name: nativeName, call_id: "plain-call", arguments: "{}" },
+    ],
+    flattened.namespaces,
+    { type: "function", name: nativeName },
+    undefined,
+    { maxNameLength: 64, bridgeAll: true },
+  );
+  const customChoice = bridgeCustomTools(
+    flattened.tools,
+    [],
+    flattened.namespaces,
+    { type: "custom", name: nativeName },
+    undefined,
+    { maxNameLength: 64, bridgeAll: true },
+  ).toolChoice;
+  const searched = flattenToolSearchHistory(
+    bridged.input,
+    bridged.tools,
+    flattened.namespaces,
+  );
+  const plainAlias = searched.tools.at(-1).name;
+  assert.notEqual(plainAlias, nativeName);
+
+  const history = flattenNamespacedHistory(searched.input, flattened.namespaces);
+  assert.equal(history.find((item) => item.call_id === "custom-call").name, nativeName);
+  assert.equal(history.find((item) => item.call_id === "plain-call").name, plainAlias);
+  assert.deepEqual(flattenToolChoice(bridged.toolChoice, flattened.namespaces), {
+    type: "function",
+    name: plainAlias,
+  });
+  assert.deepEqual(flattenToolChoice(customChoice, flattened.namespaces), {
+    type: "function",
+    name: nativeName,
+  });
+
+  const restored = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        {
+          type: "function_call",
+          name: nativeName,
+          call_id: "custom-result",
+          arguments: '{"input":"opaque"}',
+        },
+        { type: "function_call", name: plainAlias, call_id: "plain-result", arguments: "{}" },
+      ],
+    },
+    buildNamespaceLookups(flattened.namespaces),
+  );
+  assert.equal(restored.output[0].type, "custom_tool_call");
+  assert.equal(restored.output[0].name, nativeName);
+  assert.deepEqual(restored.output[1], {
+    type: "function_call",
+    name: nativeName,
+    call_id: "plain-result",
+    arguments: "{}",
+  });
+});
+
+test("later-discovered plain functions stay distinct from the tool-search relay", () => {
+  const nativeName = "tool_search";
+  const flattened = flattenNamespaceTools([clientToolSearchControl()], {
+    maxNameLength: 64,
+  });
+  const searched = flattenToolSearchHistory(
+    [
+      {
+        type: "tool_search_call",
+        call_id: "search-call",
+        execution: "client",
+        arguments: { query: nativeName },
+      },
+      {
+        type: "tool_search_output",
+        call_id: "search-call",
+        execution: "client",
+        status: "completed",
+        tools: [{ type: "function", name: nativeName, parameters: { type: "object" } }],
+      },
+      { type: "function_call", name: nativeName, call_id: "plain-call", arguments: "{}" },
+    ],
+    flattened.tools,
+    flattened.namespaces,
+  );
+  const plainAlias = searched.tools.at(-1).name;
+  assert.notEqual(plainAlias, nativeName);
+
+  const history = flattenNamespacedHistory(searched.input, flattened.namespaces);
+  assert.equal(history.find((item) => item.call_id === "search-call").name, nativeName);
+  assert.equal(history.find((item) => item.call_id === "plain-call").name, plainAlias);
+  assert.deepEqual(
+    flattenToolChoice({ type: "function", name: nativeName }, flattened.namespaces),
+    { type: "function", name: plainAlias },
+  );
+  const nativeSearchChoice = flattenToolChoice(
+    { type: "tool_search", execution: "client" },
+    flattened.namespaces,
+  );
+  assert.deepEqual(nativeSearchChoice, { type: "function", name: nativeName });
+  assert.equal(
+    flattenToolChoice(nativeSearchChoice, flattened.namespaces),
+    nativeSearchChoice,
+    "a second pass cannot retarget the native search choice to the plain alias",
+  );
+  const allowedSearchChoice = flattenToolChoice(
+    {
+      type: "allowed_tools",
+      mode: "required",
+      tools: [{ type: "tool_search", execution: "client" }],
+    },
+    flattened.namespaces,
+  );
+  assert.deepEqual(allowedSearchChoice.tools, [{ type: "function", name: nativeName }]);
+  assert.equal(
+    flattenToolChoice(allowedSearchChoice, flattened.namespaces),
+    allowedSearchChoice,
+    "allowed-tools search references stay idempotent too",
+  );
+});
+
+test("plain functions and explicit namespace history remain distinct on name collisions", () => {
+  const flattened = flattenNamespaceTools(
+    [
+      { type: "function", name: "read" },
+      {
+        type: "namespace",
+        name: "mcp__files",
+        tools: [{ type: "function", name: "read" }],
+      },
+    ],
+    { maxNameLength: 64 },
+  );
+
+  const history = flattenNamespacedHistory(
+    [
+      {
+        type: "function_call",
+        name: "read",
+        namespace: "mcp__files",
+        call_id: "namespaced",
+        arguments: "{}",
+      },
+      { type: "function_call", name: "read", call_id: "plain", arguments: "{}" },
+    ],
+    flattened.namespaces,
+  );
+  assert.deepEqual(history.map((item) => item.name), ["mcp__files__read", "read"]);
+  assert.ok(history.every((item) => item.namespace === undefined));
+
+  assert.deepEqual(
+    flattenToolChoice({ type: "function", name: "read" }, flattened.namespaces),
+    { type: "function", name: "read" },
+  );
+  assert.deepEqual(
+    flattenToolChoice(
+      { type: "function", name: "read", namespace: "mcp__files" },
+      flattened.namespaces,
+    ),
+    { type: "function", name: "mcp__files__read" },
+  );
+
+  const plainResponse = {
+    output: [
+      { type: "function_call", name: "read", call_id: "plain-result", arguments: "{}" },
+    ],
+  };
+  assert.equal(
+    rewriteNamespaceResponsePayload(
+      plainResponse,
+      buildNamespaceLookups(flattened.namespaces),
+    ),
+    undefined,
+  );
+});
+
+test("plain names equal to namespace wire names use their own aliases everywhere", () => {
+  const plainName = "mcp__files__read";
+  const flattened = flattenNamespaceTools(
+    [
+      { type: "function", name: plainName },
+      {
+        type: "namespace",
+        name: "mcp__files",
+        tools: [{ type: "function", name: "read" }],
+      },
+    ],
+    { maxNameLength: 64 },
+  );
+  const [plainAlias, namespaceAlias] = flattened.tools.map((tool) => tool.name);
+  assert.notEqual(plainAlias, plainName);
+  assert.notEqual(namespaceAlias, plainName);
+  assert.notEqual(plainAlias, namespaceAlias);
+
+  const history = flattenNamespacedHistory(
+    [
+      { type: "function_call", name: plainName, call_id: "plain", arguments: "{}" },
+      {
+        type: "function_call",
+        name: "read",
+        namespace: "mcp__files",
+        call_id: "namespaced",
+        arguments: "{}",
+      },
+    ],
+    flattened.namespaces,
+  );
+  assert.deepEqual(history.map((item) => item.name), [plainAlias, namespaceAlias]);
+
+  assert.deepEqual(
+    flattenToolChoice({ type: "function", name: plainName }, flattened.namespaces),
+    { type: "function", name: plainAlias },
+  );
+  assert.deepEqual(
+    flattenToolChoice(
+      { type: "function", name: "read", namespace: "mcp__files" },
+      flattened.namespaces,
+    ),
+    { type: "function", name: namespaceAlias },
+  );
+
+  const restored = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        { type: "function_call", name: plainAlias, call_id: "plain", arguments: "{}" },
+        {
+          type: "function_call",
+          name: namespaceAlias,
+          call_id: "namespaced",
+          arguments: "{}",
+        },
+      ],
+    },
+    buildNamespaceLookups(flattened.namespaces),
+  );
+  assert.deepEqual(restored.output, [
+    { type: "function_call", name: plainName, call_id: "plain", arguments: "{}" },
+    {
+      type: "function_call",
+      name: "read",
+      namespace: "mcp__files",
+      call_id: "namespaced",
+      arguments: "{}",
+    },
+  ]);
+});
+
+test("bounded aliases cover plain and tool-search-discovered functions", () => {
+  const plainName = "plain_function_with_a_name_that_is_deliberately_longer_than_sixty_four_characters";
+  const discoveredNamespace = "mcp__calendar_connector_with_a_long_namespace";
+  const discoveredName = "delete_an_event_and_notify_every_participant";
+  const flattened = flattenNamespaceTools(
+    [clientToolSearchControl(), { type: "function", name: plainName }],
+    { maxNameLength: 64 },
+  );
+  const plainAlias = flattened.tools.find((tool) => tool.name !== "tool_search").name;
+  assert.ok(plainAlias.length <= 64);
+  assert.notEqual(plainAlias, plainName);
+
+  const routed = flattenToolSearchHistory(
+    [
+      {
+        type: "tool_search_call",
+        call_id: "search-long",
+        execution: "client",
+        arguments: { query: "calendar" },
+      },
+      {
+        type: "tool_search_output",
+        call_id: "search-long",
+        status: "completed",
+        execution: "client",
+        tools: [
+          {
+            type: "namespace",
+            name: discoveredNamespace,
+            tools: [{ type: "function", name: discoveredName }],
+          },
+        ],
+      },
+      {
+        type: "function_call",
+        name: discoveredName,
+        namespace: discoveredNamespace,
+        call_id: "discovered-call",
+        arguments: "{}",
+      },
+      { type: "function_call", name: plainName, call_id: "plain-call", arguments: "{}" },
+    ],
+    flattened.tools,
+    flattened.namespaces,
+  );
+  const discoveredTool = routed.tools.at(-1);
+  assert.equal(discoveredTool.type, "function");
+  assert.ok(discoveredTool.name.length <= 64);
+  assert.notEqual(discoveredTool.name, `${discoveredNamespace}__${discoveredName}`);
+
+  const history = flattenNamespacedHistory(routed.input, flattened.namespaces);
+  assert.equal(
+    history.find((item) => item.call_id === "discovered-call").name,
+    discoveredTool.name,
+  );
+  assert.equal(history.find((item) => item.call_id === "plain-call").name, plainAlias);
+  assert.deepEqual(
+    flattenToolChoice({ type: "tool_search", execution: "client" }, flattened.namespaces),
+    { type: "function", name: "tool_search" },
+  );
+
+  const lookups = buildNamespaceLookups(flattened.namespaces);
+  assert.deepEqual(
+    rewriteNamespaceResponsePayload(
+      {
+        output: [
+          {
+            type: "function_call",
+            name: discoveredTool.name,
+            call_id: "result",
+            arguments: "{}",
+          },
+          { type: "function_call", name: plainAlias, call_id: "plain", arguments: "{}" },
+        ],
+      },
+      lookups,
+    ).output,
+    [
+      {
+        type: "function_call",
+        name: discoveredName,
+        namespace: discoveredNamespace,
+        call_id: "result",
+        arguments: "{}",
+      },
+      { type: "function_call", name: plainName, call_id: "plain", arguments: "{}" },
+    ],
+  );
 });
 
 test("full inventory survives merge + flatten with nothing dropped", () => {
@@ -1389,6 +1899,162 @@ test("custom-tool bridge avoids hijacking an ordinary apply_patch function", () 
     buildNamespaceLookups(namespaces).customTools.get("codex_custom_apply_patch"),
     "apply_patch",
   );
+});
+
+test("custom-tool bridge bounds its provider alias and restores the native custom call", () => {
+  const nativeName = "custom_freeform_tool_with_a_name_that_is_deliberately_longer_than_sixty_four_chars";
+  const flattened = flattenNamespaceTools([], { maxNameLength: 64 });
+  const bridged = bridgeCustomTools(
+    [{ type: "custom", name: nativeName }],
+    [
+      {
+        type: "custom_tool_call",
+        name: nativeName,
+        call_id: "custom-long",
+        input: "raw input",
+      },
+    ],
+    flattened.namespaces,
+    { type: "custom", name: nativeName },
+    [nativeName],
+    { maxNameLength: 64 },
+  );
+  const alias = bridged.tools[0].name;
+  assert.equal(alias.length, 64);
+  assert.deepEqual(bridged.toolChoice, { type: "function", name: alias });
+  assert.equal(bridged.input[0].name, alias);
+
+  const restored = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        {
+          type: "function_call",
+          name: alias,
+          call_id: "custom-result",
+          arguments: '{"input":"raw input"}',
+        },
+      ],
+    },
+    buildNamespaceLookups(flattened.namespaces),
+  );
+  assert.deepEqual(restored.output[0], {
+    type: "custom_tool_call",
+    name: nativeName,
+    call_id: "custom-result",
+    input: "raw input",
+  });
+});
+
+test("custom-tool bridge rewrites native entries inside allowed_tools", () => {
+  const nativeName = "custom_freeform_tool_with_a_name_that_is_deliberately_longer_than_sixty_four_chars";
+  const flattened = flattenNamespaceTools([], { maxNameLength: 64 });
+  const bridged = bridgeCustomTools(
+    [{ type: "custom", name: nativeName }],
+    [],
+    flattened.namespaces,
+    {
+      type: "allowed_tools",
+      mode: "required",
+      tools: [
+        { type: "custom", name: nativeName },
+        { type: "function", name: "ordinary" },
+      ],
+    },
+    [nativeName],
+    { maxNameLength: 64 },
+  );
+  const alias = bridged.tools[0].name;
+  assert.equal(alias.length, 64);
+  assert.deepEqual(bridged.toolChoice, {
+    type: "allowed_tools",
+    mode: "required",
+    tools: [
+      { type: "function", name: alias },
+      { type: "function", name: "ordinary" },
+    ],
+  });
+});
+
+test("flattened custom choices cannot be retargeted to a same-named namespace child", () => {
+  const flattened = flattenNamespaceTools(
+    [
+      {
+        type: "namespace",
+        name: "mcp__files",
+        tools: [{ type: "function", name: "apply_patch" }],
+      },
+      { type: "custom", name: "apply_patch" },
+    ],
+    { maxNameLength: 64 },
+  );
+  const forced = bridgeCustomTools(
+    flattened.tools,
+    [],
+    flattened.namespaces,
+    { type: "custom", name: "apply_patch" },
+    undefined,
+    { maxNameLength: 64 },
+  );
+  assert.deepEqual(
+    flattenToolChoice(forced.toolChoice, flattened.namespaces),
+    { type: "function", name: "apply_patch" },
+  );
+
+  const allowed = bridgeCustomTools(
+    flattened.tools,
+    [],
+    flattened.namespaces,
+    {
+      type: "allowed_tools",
+      mode: "required",
+      tools: [{ type: "custom", name: "apply_patch" }],
+    },
+    undefined,
+    { maxNameLength: 64 },
+  );
+  assert.deepEqual(
+    flattenToolChoice(allowed.toolChoice, flattened.namespaces),
+    {
+      type: "allowed_tools",
+      mode: "required",
+      tools: [{ type: "function", name: "apply_patch" }],
+    },
+  );
+});
+
+test("strict custom bridging covers non-apply_patch definitions, history, and choices", () => {
+  const flattened = flattenNamespaceTools([], { maxNameLength: 64 });
+  const bridged = bridgeCustomTools(
+    [
+      {
+        type: "custom",
+        name: "future_custom",
+        description: "A future freeform tool.",
+      },
+    ],
+    [
+      {
+        type: "custom_tool_call",
+        name: "future_custom",
+        call_id: "future-call",
+        input: "opaque",
+      },
+      {
+        type: "custom_tool_call_output",
+        call_id: "future-call",
+        output: "done",
+      },
+    ],
+    flattened.namespaces,
+    { type: "custom", name: "future_custom" },
+    undefined,
+    { maxNameLength: 64, bridgeAll: true },
+  );
+  assert.deepEqual(bridged.tools[0].parameters.required, ["input"]);
+  assert.deepEqual(bridged.toolChoice, { type: "function", name: "future_custom" });
+  assert.equal(bridged.input[0].type, "function_call");
+  assert.deepEqual(JSON.parse(bridged.input[0].arguments), { input: "opaque" });
+  assert.equal(bridged.input[1].type, "function_call_output");
 });
 
 test("custom-tool bridge reserves native namespace names and restores the aliased call", () => {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5090,8 +5090,9 @@ test("API forwarder drops the search_content_types Meta refuses, and only for Me
       { type: "web_search_preview", search_content_types: ["text", "image"] },
     ]);
 
-    // Provider-scoped, not global: OpenAI documents search_content_types on
-    // `web_search`, so the other responses-native providers keep it.
+    // Provider-scoped at this direct forwarder boundary: OpenAI documents
+    // search_content_types on `web_search`, so non-Meta traffic keeps it here.
+    // The outer router owns Console Go's separately measured compatibility.
     const opencodeTools = await send(
       "responses/opencode-go-responses-gpt-5-6-luna",
       [CODEX_WEB_SEARCH_TOOL],
@@ -7782,14 +7783,13 @@ test("Zen Free Muse bridges custom tools across JSON, history, and errors", asyn
   }
 });
 
-test("Go, paid Zen, and other Free routes keep compatibility-sensitive wire shapes", async () => {
+test("Go Chat/Messages, paid Zen, and other Free routes keep compatibility-sensitive wire shapes", async () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "routing-opencode-identity-"));
   const stateDir = path.join(testRoot, "state");
   mkdirSync(stateDir, { recursive: true });
   const specs = [
     ["opencode-go", "identity-chat"],
     ["opencode-go-messages", "identity-messages"],
-    ["opencode-go-responses", "identity-responses"],
     ["opencode-zen", "identity-paid-zen"],
     ["opencode-free", "identity-other-free"],
   ].map(([provider, upstreamModel], index) => ({


### PR DESCRIPTION
Fixes #450.

OpenCode Go Responses accepts ordinary function tools, while Codex can send native namespace, tool_search, and custom tool shapes. This change adds a request-local, collision-safe bridge scoped only to `opencode-go-responses`, restores calls in both SSE and JSON responses, and sanitizes strict compaction requests. Go Chat/Messages and paid Zen remain on their existing paths.

Verification on exact head `167ed33387d0c273c73dbdd901ec20943080cfbf`:
- `npm test`: 2,670 passed, 17 skipped, 0 failed
- focused namespace/routing/failover tests: 83 passed
- independent adversarial review: all 77 original hunks plus 13 follow-up hunks covered; one P1 collision found and fixed, no remaining findings
- `npm run check`
- `git diff --check`
- repository impact analyzer: critical protocol surface, full-suite verification completed

No quota-consuming live provider request was made; deterministic boundary and real-router tests cover the request/response wire transforms.