### PR TITLE
fix(groq): enforce the 128-tool boundary safely

### DIFF
--- a/src/chat-tool-surface.mjs
+++ b/src/chat-tool-surface.mjs
@@ -1,0 +1,266 @@
+import { CODEX_APP_TOOLS, mergeCodexAppTools } from "./codex-app-tools.mjs";
+import { flattenNamespaceTools, NAMESPACE_DELIMITER } from "./namespace-relay.mjs";
+
+export const GROQ_MAX_TOOLS = 128;
+export const GROQ_TOOL_LIMIT_CODE = "groq_tool_limit_exceeded";
+
+export class GroqToolLimitError extends Error {
+  constructor({
+    clientToolCount,
+    expandedToolCount,
+    historyToolCapacity,
+    historyToolCount,
+    referencedToolCapacity,
+    referencedToolCount,
+  }) {
+    const historyOverflow = Number.isInteger(historyToolCount);
+    const referencedOverflow = Number.isInteger(referencedToolCount);
+    let message;
+    if (historyOverflow) {
+      message = `Groq accepts at most ${GROQ_MAX_TOOLS} tools. The current surface contains ` +
+        `${clientToolCount}, and stored history references ${historyToolCount} discovered ` +
+        `tools while only ${historyToolCapacity} slots remain. The router refused to drop ` +
+        "a tool used by the transcript or send an inconsistent request.";
+    } else if (referencedOverflow) {
+      message = `Groq accepts at most ${GROQ_MAX_TOOLS} tools. The client declared ` +
+        `${clientToolCount}, and the request references ${referencedToolCount} deferred app ` +
+        `tools while only ${referencedToolCapacity} slots remain. The router refused to drop ` +
+        "a referenced tool or send an inconsistent request.";
+    } else {
+      message = `Groq accepts at most ${GROQ_MAX_TOOLS} tools, but routed app-tool expansion ` +
+        `would send ${expandedToolCount} and the client-visible surface already contains ` +
+        `${clientToolCount}. The router refused to drop client tools or send an invalid request.`;
+    }
+    super(message);
+    this.name = "GroqToolLimitError";
+    this.code = GROQ_TOOL_LIMIT_CODE;
+    this.status = 400;
+    this.provider = "groq";
+    this.limit = GROQ_MAX_TOOLS;
+    this.clientToolCount = clientToolCount;
+    this.expandedToolCount = expandedToolCount;
+    if (historyOverflow) {
+      this.historyToolCapacity = historyToolCapacity;
+      this.historyToolCount = historyToolCount;
+    }
+    if (referencedOverflow) {
+      this.referencedToolCapacity = referencedToolCapacity;
+      this.referencedToolCount = referencedToolCount;
+    }
+  }
+}
+
+function appIdentityKey(namespace, name) {
+  return JSON.stringify([namespace, name]);
+}
+
+const APP_NAMESPACE_BY_NAME = new Map();
+const APP_TOOL_BY_IDENTITY = new Map();
+const APP_TOOL_IDENTITIES_BY_PROVIDER_NAME = new Map();
+const APP_TOOL_IDENTITIES_BY_BARE_NAME = new Map();
+for (const namespace of CODEX_APP_TOOLS) {
+  if (namespace?.type !== "namespace" || typeof namespace.name !== "string") continue;
+  APP_NAMESPACE_BY_NAME.set(namespace.name, namespace);
+  for (const tool of Array.isArray(namespace.tools) ? namespace.tools : []) {
+    if (tool?.type !== "function" || typeof tool.name !== "string" || !tool.name) continue;
+    const identity = {
+      namespace: namespace.name,
+      name: tool.name,
+      definition: tool,
+    };
+    const key = appIdentityKey(identity.namespace, identity.name);
+    const providerName = `${identity.namespace}${NAMESPACE_DELIMITER}${identity.name}`;
+    APP_TOOL_BY_IDENTITY.set(key, identity);
+    if (!APP_TOOL_IDENTITIES_BY_PROVIDER_NAME.has(providerName)) {
+      APP_TOOL_IDENTITIES_BY_PROVIDER_NAME.set(providerName, []);
+    }
+    APP_TOOL_IDENTITIES_BY_PROVIDER_NAME.get(providerName).push(identity);
+    if (!APP_TOOL_IDENTITIES_BY_BARE_NAME.has(identity.name)) {
+      APP_TOOL_IDENTITIES_BY_BARE_NAME.set(identity.name, []);
+    }
+    APP_TOOL_IDENTITIES_BY_BARE_NAME.get(identity.name).push(identity);
+  }
+}
+
+function providerFunctionName(tool) {
+  return tool?.name ?? tool?.function?.name;
+}
+
+function clientToolInventory(tools) {
+  const plainNames = new Set();
+  const nativeIdentities = new Set();
+  const bareNamespaceOwners = new Map();
+  const wireNamespaceOwners = new Map();
+  for (const tool of Array.isArray(tools) ? tools : []) {
+    if (tool?.type === "namespace" && typeof tool.name === "string") {
+      for (const child of Array.isArray(tool.tools) ? tool.tools : []) {
+        if (child?.type !== "function" || typeof child.name !== "string" || !child.name) {
+          continue;
+        }
+        const key = appIdentityKey(tool.name, child.name);
+        nativeIdentities.add(key);
+        if (!bareNamespaceOwners.has(child.name)) bareNamespaceOwners.set(child.name, new Set());
+        bareNamespaceOwners.get(child.name).add(key);
+        const wireName = `${tool.name}${NAMESPACE_DELIMITER}${child.name}`;
+        if (!wireNamespaceOwners.has(wireName)) wireNamespaceOwners.set(wireName, new Set());
+        wireNamespaceOwners.get(wireName).add(key);
+      }
+      continue;
+    }
+    if (tool?.type !== "function") continue;
+    const name = providerFunctionName(tool);
+    if (typeof name === "string" && name) plainNames.add(name);
+  }
+  return { plainNames, nativeIdentities, bareNamespaceOwners, wireNamespaceOwners };
+}
+
+function uniqueIdentity(identities) {
+  return Array.isArray(identities) && identities.length === 1 ? identities[0] : undefined;
+}
+
+function appToolIdentity(value, inventory) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const nestedName = value.function?.name;
+  const name = typeof nestedName === "string" ? nestedName : value.name;
+  if (typeof name !== "string" || !name) return undefined;
+  const namespace =
+    typeof value.namespace === "string" && value.namespace ? value.namespace : undefined;
+  if (namespace) return APP_TOOL_BY_IDENTITY.get(appIdentityKey(namespace, name));
+
+  // An unqualified reference whose exact spelling is client-declared belongs
+  // to that plain function. Stored app calls can still identify themselves
+  // unambiguously with the native namespace field.
+  if (inventory.plainNames.has(name)) return undefined;
+
+  const flattened = uniqueIdentity(APP_TOOL_IDENTITIES_BY_PROVIDER_NAME.get(name));
+  if (flattened) {
+    const owners = inventory.wireNamespaceOwners.get(name);
+    const flattenedKey = appIdentityKey(flattened.namespace, flattened.name);
+    if (!owners || [...owners].every((owner) => owner === flattenedKey)) return flattened;
+  }
+
+  const bare = uniqueIdentity(APP_TOOL_IDENTITIES_BY_BARE_NAME.get(name));
+  if (!bare) return undefined;
+  const owners = inventory.bareNamespaceOwners.get(name);
+  if (owners && [...owners].some((owner) => owner !== appIdentityKey(bare.namespace, bare.name))) {
+    return undefined;
+  }
+  return bare;
+}
+
+function referencedAppTools(input, toolChoice, inventory) {
+  const referenced = new Map();
+  const remember = (value) => {
+    const identity = appToolIdentity(value, inventory);
+    if (identity) referenced.set(appIdentityKey(identity.namespace, identity.name), identity);
+  };
+  for (const item of Array.isArray(input) ? input : []) {
+    if (item?.type !== "function_call") continue;
+    remember(item);
+  }
+  if (toolChoice?.type === "allowed_tools" && Array.isArray(toolChoice.tools)) {
+    for (const choice of toolChoice.tools) {
+      if (choice?.type === "function") remember(choice);
+    }
+  } else if (toolChoice?.type === "function") {
+    remember(toolChoice);
+  }
+  return referenced;
+}
+
+function withRequiredAppTools(tools, required) {
+  if (!required.size) return tools;
+  const selected = [];
+  const fulfilled = new Set();
+  for (const tool of tools) {
+    if (tool?.type !== "namespace" || !APP_NAMESPACE_BY_NAME.has(tool.name)) {
+      selected.push(tool);
+      continue;
+    }
+    const additions = [];
+    for (const identity of required.values()) {
+      if (identity.namespace !== tool.name || fulfilled.has(appIdentityKey(identity.namespace, identity.name))) {
+        continue;
+      }
+      additions.push(identity.definition);
+      fulfilled.add(appIdentityKey(identity.namespace, identity.name));
+    }
+    selected.push(additions.length
+      ? { ...tool, tools: [...(Array.isArray(tool.tools) ? tool.tools : []), ...additions] }
+      : tool);
+  }
+  for (const namespace of CODEX_APP_TOOLS) {
+    const additions = [];
+    for (const identity of required.values()) {
+      const key = appIdentityKey(identity.namespace, identity.name);
+      if (identity.namespace !== namespace.name || fulfilled.has(key)) continue;
+      additions.push(identity.definition);
+      fulfilled.add(key);
+    }
+    if (additions.length) selected.push({ ...namespace, tools: additions });
+  }
+  return selected;
+}
+
+// Chat-completions providers need namespace flattening and normally receive
+// the app definitions Codex registered with deferLoading but omitted from the
+// live request. Groq alone caps a request at 128 tools. When that expansion is
+// the only thing crossing the cap, keep every client-declared tool and omit the
+// injected definitions the current transcript does not require. Curated Groq
+// models do not advertise native tool_search, so this cannot depend on a live
+// relay. Stored app calls and forced app choices are evidence that an omitted
+// definition is required; those definitions are added back before the request
+// is admitted. A client surface (or client + required definitions) over the cap
+// is refused locally rather than truncated.
+export function chatProviderToolSurface(
+  tools,
+  providerId,
+  { input, toolChoice } = {},
+) {
+  const merged = mergeCodexAppTools(tools);
+  if (providerId !== "groq") return flattenNamespaceTools(merged.tools);
+
+  // Groq has no OpenCode-style length bound, but it still needs deterministic
+  // aliases when two distinct native identities have the same flattened wire
+  // spelling. Keep that collision safety independent from the 64-byte route.
+  const expanded = flattenNamespaceTools(merged.tools, { aliasCollisions: true });
+  if (!Array.isArray(expanded.tools) || expanded.tools.length <= GROQ_MAX_TOOLS) return expanded;
+
+  const client = flattenNamespaceTools(tools, { aliasCollisions: true });
+  const clientToolCount = Array.isArray(client.tools) ? client.tools.length : 0;
+  if (!Array.isArray(client.tools) || clientToolCount > GROQ_MAX_TOOLS) {
+    throw new GroqToolLimitError({
+      clientToolCount,
+      expandedToolCount: expanded.tools.length,
+    });
+  }
+
+  const inventory = clientToolInventory(tools);
+  const referenced = referencedAppTools(input, toolChoice, inventory);
+  const requiredDefinitions = new Map(
+    [...referenced].filter(([key]) => !inventory.nativeIdentities.has(key)),
+  );
+  const referencedToolCapacity = GROQ_MAX_TOOLS - clientToolCount;
+  if (requiredDefinitions.size > referencedToolCapacity) {
+    throw new GroqToolLimitError({
+      clientToolCount,
+      expandedToolCount: expanded.tools.length,
+      referencedToolCapacity,
+      referencedToolCount: requiredDefinitions.size,
+    });
+  }
+
+  const selected = flattenNamespaceTools(
+    withRequiredAppTools(tools, requiredDefinitions),
+    { aliasCollisions: true },
+  );
+  if (!Array.isArray(selected.tools) || selected.tools.length > GROQ_MAX_TOOLS) {
+    throw new GroqToolLimitError({
+      clientToolCount,
+      expandedToolCount: expanded.tools.length,
+      referencedToolCapacity,
+      referencedToolCount: requiredDefinitions.size,
+    });
+  }
+  return selected;
+}

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -61,6 +61,10 @@ const SPECIAL_FUNCTION_REFERENCES = new WeakSet();
 const TOOL_SEARCH_FUNCTION_NAME = "tool_search";
 const CUSTOM_TOOL_INPUT_PROPERTY = "input";
 
+export function toolSearchRelayAvailable(namespaces) {
+  return TOOL_SEARCH_RELAYS.has(namespaces);
+}
+
 function providerFunctionName(tool) {
   return tool?.name ?? tool?.function?.name;
 }
@@ -82,6 +86,7 @@ function boundedNameCandidate(wireName, identity, maxNameLength, attempt) {
     .digest("hex")
     .slice(0, 12);
   const suffix = `_${digest}`;
+  if (!Number.isFinite(maxNameLength)) return `${wireName}${suffix}`;
   return `${wireName.slice(0, maxNameLength - suffix.length)}${suffix}`;
 }
 
@@ -140,10 +145,11 @@ function initialFunctionIdentities(tools) {
   return identities;
 }
 
-function initializeNameAliases(namespaces, tools, maxNameLength) {
-  if (!Number.isInteger(maxNameLength) || maxNameLength < 16) return undefined;
+function initializeNameAliases(namespaces, tools, maxNameLength, aliasCollisions = false) {
+  const bounded = Number.isInteger(maxNameLength) && maxNameLength >= 16;
+  if (!bounded && !aliasCollisions) return undefined;
   const relay = {
-    maxNameLength,
+    maxNameLength: bounded ? maxNameLength : Infinity,
     nativeToProvider: new Map(),
     providerToNative: new Map(),
     providerOwners: new Map(),
@@ -165,7 +171,7 @@ function initializeNameAliases(namespaces, tools, maxNameLength) {
   for (const [identity, entry] of [...identities].sort(([left], [right]) =>
     left.localeCompare(right),
   )) {
-    if (entry.wireName.length <= maxNameLength && wireCounts.get(entry.wireName) === 1) {
+    if (entry.wireName.length <= relay.maxNameLength && wireCounts.get(entry.wireName) === 1) {
       assignProviderName(relay, identity, entry.wireName, entry.native);
     } else {
       pending.push([identity, entry]);
@@ -648,14 +654,14 @@ function flattenNamespaceChild(namespace, fn, providerName) {
 // (name -> tool names) so callers can rename history and restore calls.
 export function flattenNamespaceTools(
   tools,
-  { bridgeToolSearch = true, maxNameLength } = {},
+  { bridgeToolSearch = true, maxNameLength, aliasCollisions = false } = {},
 ) {
   if (!Array.isArray(tools)) return { tools, flattened: false, namespaces: new Map() };
   const flattened = [];
   const namespaces = new Map();
   const plainToolNames = new Set();
   PLAIN_TOOL_NAMES.set(namespaces, plainToolNames);
-  initializeNameAliases(namespaces, tools, maxNameLength);
+  initializeNameAliases(namespaces, tools, maxNameLength, aliasCollisions);
   const spawnAgentModels = new Set();
   const toolSearchName = bridgeToolSearch
     ? reserveSpecialProviderName(
@@ -777,6 +783,8 @@ function discoveredProviderTools(toolSpecs, namespaces) {
             providerNameForNative(namespaces, tool.name, fn.name),
           ),
           native: { namespace: tool.name, name: fn.name },
+          nativeName: fn.name,
+          identity: nativeToolKey(tool.name, fn.name),
         });
       }
       continue;
@@ -788,7 +796,11 @@ function discoveredProviderTools(toolSpecs, namespaces) {
     if (providerName !== nativeName) {
       providerTool = withProviderFunctionName(providerTool, providerName);
     }
-    discovered.push({ tool: providerTool });
+    discovered.push({
+      tool: providerTool,
+      nativeName,
+      identity: nativeToolKey(undefined, nativeName),
+    });
   }
   return discovered;
 }
@@ -803,16 +815,35 @@ function addDiscoveredNamespace(namespaces, native) {
   names.add(native.name);
 }
 
+export class ToolSearchHistoryCapacityError extends Error {
+  constructor({ available, required }) {
+    super(
+      `Stored tool_search history references ${required} discovered tools, but only ` +
+        `${available} provider tool slots remain.`,
+    );
+    this.name = "ToolSearchHistoryCapacityError";
+    this.available = available;
+    this.required = required;
+  }
+}
+
 // A native tool_search output changes what the model may call on the next
 // turn. The Responses API understands that special history item directly;
 // LiteLLM's chat-completions bridge does not. Translate matched call/output
 // pairs into ordinary function history and add the returned definitions to
-// this request's provider-facing tool list. Live top-level schemas win on a
+// this request's provider-facing tool list. A model switch may leave no live
+// search relay; in that explicitly enabled mode, preserve the definitions but
+// drop the now-unusable native control pair. Live top-level schemas win on a
 // name collision. Native items that do not form one unique, ordered,
 // well-formed pair are dropped: a chat-completions provider cannot consume
 // them, and forwarding one would make the transcript promise unavailable
 // tools.
-export function flattenToolSearchHistory(input, tools, namespaces) {
+export function flattenToolSearchHistory(
+  input,
+  tools,
+  namespaces,
+  { maxTools = Infinity, recoverWithoutRelay = false, toolChoice } = {},
+) {
   const relay = TOOL_SEARCH_RELAYS.get(namespaces);
   if (!Array.isArray(input)) {
     return { input, tools, flattened: false };
@@ -877,7 +908,7 @@ export function flattenToolSearchHistory(input, tools, namespaces) {
 
   const callsByIndex = new Map();
   const outputsByIndex = new Map();
-  if (relay) {
+  if (relay || recoverWithoutRelay) {
     for (const [id, record] of callsById) {
       if (!record.output || invalidIds.has(id)) continue;
       callsByIndex.set(record.callIndex, record);
@@ -885,13 +916,197 @@ export function flattenToolSearchHistory(input, tools, namespaces) {
     }
   }
 
+  const toolCapacity = Number.isInteger(maxTools) && maxTools >= 0 ? maxTools : Infinity;
+  const remainingToolCapacity = Math.max(0, toolCapacity - tools.length);
   const visibleNames = providerVisibleToolNames(tools);
+  const initialNameAliases = new Map(
+    NAME_ALIASES.get(namespaces)?.nativeToProvider || [],
+  );
+  const definitionOwnersByName = new Map();
+  const discoveries = [];
+  const discoveriesByOutputIndex = new Map();
+  for (let index = 0; index < input.length; index += 1) {
+    const item = input[index];
+    if (!outputsByIndex.has(index)) continue;
+    const records = [];
+    for (const candidate of discoveredProviderTools(item.tools, namespaces)) {
+      const name = providerFunctionName(candidate.tool);
+      if (!name) continue;
+      const priorOwner = definitionOwnersByName.get(name);
+      const shadowedByClient = visibleNames.has(name) && !priorOwner;
+      const record = {
+        ...candidate,
+        name,
+        outputIndex: index,
+        shadowed: shadowedByClient || priorOwner !== undefined,
+        definitionOwner: shadowedByClient ? undefined : priorOwner,
+      };
+      if (!visibleNames.has(name)) {
+        visibleNames.add(name);
+        definitionOwnersByName.set(name, record);
+        record.definitionOwner = record;
+      }
+      discoveries.push(record);
+      records.push(record);
+    }
+    discoveriesByOutputIndex.set(index, records);
+  }
+
+  // A bounded provider surface may omit only unused discoveries. Resolve each
+  // stored call against the definitions that existed at that point in the
+  // transcript, using the same precedence as flattenNamespacedHistory: an
+  // explicit namespace is exact, an exact plain native identity wins over a
+  // stale flattened namespace spelling, then provider aliases/raw namespace
+  // spellings, then a unique bare namespace name. Later discoveries must not
+  // retroactively make an earlier bare call ambiguous. A forced tool choice is
+  // evaluated after all stored discoveries and reserves its schema too.
+  const CURRENT_DEFINITION = Symbol("current-tool-definition");
+  const identityOwners = new Map();
+  const plainNativeOwners = new Map();
+  const providerOwners = new Map();
+  const wireNamespaceOwners = new Map();
+  const bareNamespaceOwners = new Map();
+  const addOwner = (owners, name, owner) => {
+    if (typeof name !== "string" || !name) return;
+    if (!owners.has(name)) owners.set(name, new Set());
+    owners.get(name).add(owner);
+  };
+  const uniqueOwner = (owners) => owners?.size === 1 ? [...owners][0] : undefined;
+  const rememberIdentity = ({ identity, native, nativeName, name, owner }) => {
+    if (!identityOwners.has(identity)) identityOwners.set(identity, owner);
+    addOwner(providerOwners, name, identity);
+    if (native) {
+      addOwner(
+        wireNamespaceOwners,
+        `${native.namespace}${NAMESPACE_DELIMITER}${native.name}`,
+        identity,
+      );
+      addOwner(bareNamespaceOwners, native.name, identity);
+    } else {
+      addOwner(plainNativeOwners, nativeName, identity);
+    }
+  };
+
+  for (const [namespace, names] of namespaces) {
+    for (const name of names) {
+      rememberIdentity({
+        identity: nativeToolKey(namespace, name),
+        native: { namespace, name },
+        name: providerNameForNative(namespaces, namespace, name),
+        owner: CURRENT_DEFINITION,
+      });
+    }
+  }
+  if (initialNameAliases.size) {
+    for (const [identity, providerName] of initialNameAliases) {
+      let decoded;
+      try {
+        decoded = JSON.parse(identity);
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(decoded) || decoded.length !== 2 || decoded[0] !== null) continue;
+      rememberIdentity({
+        identity,
+        nativeName: decoded[1],
+        name: providerName,
+        owner: CURRENT_DEFINITION,
+      });
+    }
+  } else {
+    for (const name of PLAIN_TOOL_NAMES.get(namespaces) || []) {
+      rememberIdentity({
+        identity: nativeToolKey(undefined, name),
+        nativeName: name,
+        name,
+        owner: CURRENT_DEFINITION,
+      });
+    }
+  }
+  // Custom/tool-search relays are provider-visible but are never ordinary
+  // discovered definitions. Reserve their spellings as current identities so
+  // a matching model-visible name cannot be attributed to a discovery.
+  for (const name of CUSTOM_TOOL_RELAYS.get(namespaces)?.keys() || []) {
+    const identity = `special:custom:${name}`;
+    identityOwners.set(identity, CURRENT_DEFINITION);
+    addOwner(providerOwners, name, identity);
+  }
+  const toolSearch = TOOL_SEARCH_RELAYS.get(namespaces);
+  if (toolSearch) {
+    const identity = "special:tool-search";
+    identityOwners.set(identity, CURRENT_DEFINITION);
+    addOwner(providerOwners, toolSearch.providerName, identity);
+  }
+
+  const referencedDefinitions = new Set();
+  const referencedIdentities = new Set();
+  const markReference = (reference) => {
+    if (!reference || typeof reference !== "object" || Array.isArray(reference)) return;
+    const nestedName = reference.function?.name;
+    const name = typeof nestedName === "string" ? nestedName : reference.name;
+    if (typeof name !== "string" || !name) return;
+    const namespace =
+      typeof reference.namespace === "string" && reference.namespace
+        ? reference.namespace
+        : undefined;
+    let identity;
+    if (namespace) {
+      const exact = nativeToolKey(namespace, name);
+      if (identityOwners.has(exact)) identity = exact;
+    } else if (!SPECIAL_FUNCTION_REFERENCES.has(reference)) {
+      identity = uniqueOwner(plainNativeOwners.get(name));
+      identity ??= uniqueOwner(providerOwners.get(name));
+      identity ??= uniqueOwner(wireNamespaceOwners.get(name));
+      identity ??= uniqueOwner(bareNamespaceOwners.get(name));
+    }
+    if (!identity) return;
+    referencedIdentities.add(identity);
+    const owner = identityOwners.get(identity);
+    if (owner && owner !== CURRENT_DEFINITION) referencedDefinitions.add(owner);
+  };
+  const discoveriesByIndex = new Map();
+  for (const discovery of discoveries) {
+    if (!discoveriesByIndex.has(discovery.outputIndex)) {
+      discoveriesByIndex.set(discovery.outputIndex, []);
+    }
+    discoveriesByIndex.get(discovery.outputIndex).push(discovery);
+  }
+  for (let index = 0; index < input.length; index += 1) {
+    for (const discovery of discoveriesByIndex.get(index) || []) {
+      const owner = discovery.definitionOwner || CURRENT_DEFINITION;
+      rememberIdentity({ ...discovery, owner });
+    }
+    const item = input[index];
+    if (item?.type === "function_call") markReference(item);
+  }
+  if (toolChoice?.type === "allowed_tools" && Array.isArray(toolChoice.tools)) {
+    for (const choice of toolChoice.tools) {
+      if (choice?.type === "function") markReference(choice);
+    }
+  } else if (toolChoice?.type === "function") {
+    markReference(toolChoice);
+  }
+  const requiredDefinitions = [...referencedDefinitions];
+  if (requiredDefinitions.length > remainingToolCapacity) {
+    throw new ToolSearchHistoryCapacityError({
+      available: remainingToolCapacity,
+      required: requiredDefinitions.length,
+    });
+  }
+  const acceptedDiscoveries = new Set(requiredDefinitions);
+  for (const discovery of discoveries) {
+    if (acceptedDiscoveries.size >= remainingToolCapacity) break;
+    if (discovery.shadowed) continue;
+    acceptedDiscoveries.add(discovery);
+  }
+
   let routedTools = tools;
   const routedInput = [];
   for (let index = 0; index < input.length; index += 1) {
     const item = input[index];
     if (item?.type === "tool_search_call") {
       if (!callsByIndex.has(index)) continue;
+      if (!relay) continue;
       const {
         type: _type,
         execution: _execution,
@@ -917,13 +1132,21 @@ export function flattenToolSearchHistory(input, tools, namespaces) {
     if (!outputsByIndex.has(index)) continue;
 
     const accepted = [];
-    for (const candidate of discoveredProviderTools(item.tools, namespaces)) {
-      const name = providerFunctionName(candidate.tool);
-      if (!name || visibleNames.has(name)) continue;
-      visibleNames.add(name);
-      accepted.push(candidate.tool);
-      addDiscoveredNamespace(namespaces, candidate.native);
-      if (!candidate.native) PLAIN_TOOL_NAMES.get(namespaces)?.add(name);
+    for (const discovery of discoveriesByOutputIndex.get(index) || []) {
+      if (acceptedDiscoveries.has(discovery)) {
+        accepted.push(discovery.tool);
+        addDiscoveredNamespace(namespaces, discovery.native);
+        if (!discovery.native) PLAIN_TOOL_NAMES.get(namespaces)?.add(discovery.name);
+      } else if (
+        recoverWithoutRelay &&
+        discovery.shadowed &&
+        referencedIdentities.has(discovery.identity)
+      ) {
+        // A current client definition owns the provider-visible name and its
+        // schema must win. The stored native identity is still needed to
+        // flatten the later historical call and restore any repeated call.
+        addDiscoveredNamespace(namespaces, discovery.native);
+      }
     }
     // Keep the live-name set across outputs. The first valid discovery wins;
     // later outputs omit a duplicate from both their result and the request's
@@ -932,6 +1155,11 @@ export function flattenToolSearchHistory(input, tools, namespaces) {
       if (routedTools === tools) routedTools = [...tools];
       routedTools.push(...accepted);
     }
+
+    // The current provider cannot execute a fresh native tool_search call.
+    // Preserve the discovered definitions above, but remove the now-unusable
+    // call/output control pair from the chat-completions transcript.
+    if (!relay) continue;
 
     const {
       type: _type,
@@ -1250,6 +1478,7 @@ export function buildNamespaceLookups(namespaces) {
       ...(PLAIN_TOOL_NAMES.get(namespaces) || []),
       ...(nameAliases?.plainProviderNames || []),
     ]),
+    identityAliases: Boolean(nameAliases),
     spawnAgentModels: SPAWN_AGENT_MODELS.get(namespaces),
     toolSearch: TOOL_SEARCH_RELAYS.get(namespaces),
     customTools: CUSTOM_TOOL_RELAYS.get(namespaces),
@@ -1375,6 +1604,10 @@ function rewriteNamespaceFunctionCallItem(
   { allowIncompleteToolSearch = false } = {},
 ) {
   if (!item || item.type !== "function_call") return undefined;
+  const exactPlainProviderIdentity =
+    lookups.identityAliases &&
+    item.namespace === undefined &&
+    lookups.plainToolNames?.has(item.name);
   const customTool = rewriteCustomToolFunctionCallItem(
     item,
     lookups,
@@ -1410,7 +1643,13 @@ function rewriteNamespaceFunctionCallItem(
     }
   }
   rewritten = sanitizeSpawnAgentModel(rewritten, lookups);
-  rewritten = injectSessionModelForSpawnCalls(rewritten, sessionModel);
+  // A client may declare an ordinary function whose literal name is
+  // `codex_app__create_thread`. Its request-local alias resolves back to that
+  // exact plain identity, not the app namespace. Do not infer app semantics
+  // from the restored spelling after the lookup has already proved otherwise.
+  if (!exactPlainProviderIdentity) {
+    rewritten = injectSessionModelForSpawnCalls(rewritten, sessionModel);
+  }
   rewritten = rewriteFunctionCallArguments(rewritten);
   return rewritten === item ? undefined : rewritten;
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -92,7 +92,14 @@ import {
   repairToolSchemaRoots,
   strictOpenCodeCompactionInput,
   stripSearchContentTypes,
+  ToolSearchHistoryCapacityError,
 } from "./namespace-relay.mjs";
+import {
+  chatProviderToolSurface,
+  GROQ_MAX_TOOLS,
+  GroqToolLimitError,
+  GROQ_TOOL_LIMIT_CODE,
+} from "./chat-tool-surface.mjs";
 import { collaborationToolAvailable, pendingInterruptTargets } from "./subagent-completion.mjs";
 import {
   FAILOVER_BUDGET_MS,
@@ -113,7 +120,6 @@ import {
 } from "./subagent-proofs.mjs";
 import { forgetChildSpawn, observeChildTurn } from "./subagent-turns.mjs";
 import { subagentEffort } from "./multi-agent-state.mjs";
-import { mergeCodexAppTools } from "./codex-app-tools.mjs";
 import {
   activityMetadataFromHeaders,
   threadIdFromHeaders,
@@ -2524,8 +2530,42 @@ function observeSubagentOutcome(request, route, status, options = {}) {
 async function buildRoutedRequest({ request, payload, route, agedInput, tokenMaxxing = false }) {
   let namespacesFlattened = false;
   let flattenedNamespaces = new Map();
+  const provider = providerForModel(route);
+  const chatCompletionsProvider = provider?.protocol !== "openai-responses";
+  const consoleGoResponsesCompatibility = needsConsoleGoResponsesToolCompatibility(route);
+  const compatibleInput = zenFreeCompatibleInput(agedInput, route);
+  // Image substitution may spend another provider's quota. Every Groq tool
+  // limit that is already knowable from the client request and stored history
+  // must fail locally before that work starts; the normal post-bridge pass
+  // below runs again so any later transformation cannot bypass the invariant.
+  if (provider?.id === "groq" && chatCompletionsProvider) {
+    const preflight = chatProviderToolSurface(payload.tools, provider.id, {
+      input: compatibleInput,
+      toolChoice: payload.tool_choice,
+    });
+    try {
+      flattenToolSearchHistory(
+        compatibleInput,
+        preflight.tools,
+        preflight.namespaces,
+        {
+          maxTools: GROQ_MAX_TOOLS,
+          recoverWithoutRelay: true,
+          toolChoice: payload.tool_choice,
+        },
+      );
+    } catch (error) {
+      if (!(error instanceof ToolSearchHistoryCapacityError)) throw error;
+      throw new GroqToolLimitError({
+        clientToolCount: preflight.tools.length,
+        expandedToolCount: preflight.tools.length + error.required,
+        historyToolCapacity: error.available,
+        historyToolCount: error.required,
+      });
+    }
+  }
   const bridged = await bridgeVisionInput(
-    zenFreeCompatibleInput(agedInput, route),
+    compatibleInput,
     route,
     request,
   );
@@ -2539,9 +2579,6 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
   // -- a turn that still reaches the provider, and still reads as a 200,
   // having quietly replaced the prompt with its own letters.
   const input = Array.isArray(bridged) ? [...bridged] : bridged;
-  const provider = providerForModel(route);
-  const chatCompletionsProvider = provider?.protocol !== "openai-responses";
-  const consoleGoResponsesCompatibility = needsConsoleGoResponsesToolCompatibility(route);
   // Thinking chat providers need the assistant's reasoning replayed, but
   // LiteLLM drops Responses `reasoning` input items. Generic providers keep
   // the established visible-content carry used for DeepSeek. GLM's native
@@ -2576,13 +2613,16 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     // Relay the app's full native toolset (threads, automations, app
     // navigation) to the provider. The client registers these tools with
     // deferLoading and executes the calls natively, but only sends a reduced
-    // codex_app namespace on routed requests; merge the deferred definitions in
-    // so routed models see what native models see. The router never executes
-    // these calls -- the app owns thread, automation, and navigation state --
-    // it only relays definitions and results.
-    const merged = mergeCodexAppTools(tools);
-    if (merged.merged) tools = merged.tools;
-    const flattened = flattenNamespaceTools(tools);
+    // codex_app namespace on routed requests; normally merge the deferred
+    // definitions in so routed models see what native models see. A provider
+    // with a hard tool cap may omit unreferenced injected definitions and add
+    // back only those required by stored calls or a forced choice. The router
+    // never executes these calls -- the app owns thread, automation, and
+    // navigation state -- it only relays definitions and results.
+    const flattened = chatProviderToolSurface(tools, provider?.id, {
+      input,
+      toolChoice: payload.tool_choice,
+    });
     namespacesFlattened = flattened.flattened;
     flattenedNamespaces = flattened.namespaces;
     if (namespacesFlattened) {
@@ -2643,13 +2683,39 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     routedToolChoice = customTools.toolChoice;
   }
   if (chatCompletionsProvider || consoleGoResponsesCompatibility) {
-    const searchHistory = flattenToolSearchHistory(
-      routedInput,
-      tools,
-      flattenedNamespaces,
-    );
+    let searchHistory;
+    try {
+      searchHistory = flattenToolSearchHistory(
+        routedInput,
+        tools,
+        flattenedNamespaces,
+        provider?.id === "groq"
+          ? {
+              maxTools: GROQ_MAX_TOOLS,
+              recoverWithoutRelay: true,
+              toolChoice: routedToolChoice,
+            }
+          : undefined,
+      );
+    } catch (error) {
+      if (provider?.id !== "groq" || !(error instanceof ToolSearchHistoryCapacityError)) {
+        throw error;
+      }
+      throw new GroqToolLimitError({
+        clientToolCount: tools.length,
+        expandedToolCount: tools.length + error.required,
+        historyToolCapacity: error.available,
+        historyToolCount: error.required,
+      });
+    }
     routedInput = searchHistory.input;
     tools = searchHistory.tools;
+    if (
+      provider?.id === "groq" &&
+      (searchHistory.flattened || flattenedNamespaces.size > 0)
+    ) {
+      namespacesFlattened = true;
+    }
     if (needsZenFreeToolCompatibility(route)) {
       tools = repairToolSchemaRoots(tools, { nonRecursive: true });
     }
@@ -2658,6 +2724,12 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
   // the model copies the bare names out of its own transcript.
   if (namespacesFlattened) {
     routedInput = flattenNamespacedHistory(routedInput, flattenedNamespaces);
+    if (provider?.id === "groq") {
+      routedToolChoice = flattenToolChoice(
+        routedToolChoice,
+        flattenedNamespaces,
+      );
+    }
   }
   if (consoleGoResponsesCompatibility) {
     routedToolChoice = flattenToolChoice(routedToolChoice, flattenedNamespaces);
@@ -3112,23 +3184,37 @@ async function handleResponses(request, response, requestUrl) {
       const settings = readFailoverSettings();
       const cooled = settings.enabled ? providerCooldown(route.provider) : undefined;
       if (cooled) {
-        const [next] = failoverCandidates({
+        const candidates = failoverCandidates({
           route,
           agedInput,
           flattenedNamespaces,
           chain: settings.chain,
-        });
-        if (next) {
-          const candidate = await prepareRoutedRequest({
-            request,
-            payload,
-            route: next.model,
-            normalizedInput,
-            agingEnabled,
-          });
+        }).slice(0, MAX_FAILOVER_HOPS);
+        for (const next of candidates) {
+          let candidate;
+          try {
+            candidate = await prepareRoutedRequest({
+              request,
+              payload,
+              route: next.model,
+              normalizedInput,
+              agingEnabled,
+            });
+          } catch (error) {
+            if (error?.code !== GROQ_TOOL_LIMIT_CODE || error?.provider !== "groq") throw error;
+            logFailover(
+              route,
+              next.model,
+              `cooled_until_${cooled.until}`,
+              "not-sent",
+              `compatibility/${error.code}`,
+            );
+            continue;
+          }
           if (routedRequestFits(next.model, candidate.body)) {
             logFailover(route, next.model, `cooled_until_${cooled.until}`, "not-sent", "swapped");
             adoptRoute(next.model, candidate);
+            break;
           } else {
             logFailover(
               route,
@@ -3739,6 +3825,32 @@ async function handleResponses(request, response, requestUrl) {
           message: "The router canceled a request that exceeded its execution deadline.",
         });
       }
+      return;
+    }
+    if (
+      error?.code === GROQ_TOOL_LIMIT_CODE &&
+      error?.provider === "groq" &&
+      !response.headersSent
+    ) {
+      finalStatus = error.status;
+      activityStatus = error.status;
+      writeJson(response, error.status, {
+        error: {
+          type: "provider_compatibility_error",
+          code: error.code,
+          provider: error.provider,
+          limit: error.limit,
+          message: error.message,
+        },
+      });
+      recordUsageEvent({
+        model: route?.slug || requestedModel,
+        provider: route ? canonicalProviderId(route.provider) : "openai",
+        status: error.status,
+        durationMs: Date.now() - startedAt,
+        responseStartMs: upstreamLatencyMs,
+      });
+      usageRecorded = true;
       return;
     }
     if (retryEmptyCompletionGuard?.hasContent()) emptyCompletion = false;

--- a/test/chat-tool-surface.test.mjs
+++ b/test/chat-tool-surface.test.mjs
@@ -1,0 +1,345 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  chatProviderToolSurface,
+  GROQ_MAX_TOOLS,
+  GROQ_TOOL_LIMIT_CODE,
+} from "../src/chat-tool-surface.mjs";
+import { mergeCodexAppTools } from "../src/codex-app-tools.mjs";
+import {
+  buildNamespaceLookups,
+  flattenNamespacedHistory,
+  flattenNamespaceTools,
+  flattenToolChoice,
+  rewriteNamespaceResponsePayload,
+  toolSearchRelayAvailable,
+} from "../src/namespace-relay.mjs";
+
+function clientToolSearch() {
+  return {
+    type: "tool_search",
+    execution: "client",
+    description: "Search deferred tools.",
+    parameters: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+      additionalProperties: false,
+    },
+  };
+}
+
+function largeClientSurface({
+  plainTools = 111,
+  toolSearch = false,
+  appTools = [
+    { type: "function", name: "load_workspace_dependencies" },
+    { type: "function", name: "navigate_to_codex_page" },
+    { type: "function", name: "read_thread_terminal" },
+  ],
+} = {}) {
+  return [
+    ...(toolSearch ? [clientToolSearch()] : []),
+    ...Array.from({ length: plainTools }, (_, index) => ({
+      type: "function",
+      name: `core_tool_${index}`,
+      parameters: { type: "object" },
+    })),
+    {
+      type: "namespace",
+      name: "codex_app",
+      tools: appTools,
+    },
+  ];
+}
+
+test("Groq defers only injected app definitions without requiring tool_search", () => {
+  const client = largeClientSurface();
+  const normallyExpanded = flattenNamespaceTools(mergeCodexAppTools(client).tools);
+  assert.equal(normallyExpanded.tools.length, 129, "regression fixture reproduces issue #449");
+
+  const routed = chatProviderToolSurface(client, "groq");
+  const clientFlattened = flattenNamespaceTools(client);
+  assert.equal(routed.tools.length, 114);
+  assert.deepEqual(routed.tools, clientFlattened.tools);
+  assert.equal(toolSearchRelayAvailable(routed.namespaces), false);
+
+  const routedNames = new Set(routed.tools.map((tool) => tool.name));
+  for (const tool of clientFlattened.tools) {
+    assert.ok(routedNames.has(tool.name), `client tool ${tool.name} must survive`);
+  }
+  assert.equal(routedNames.has("codex_app__create_thread"), false);
+  assert.equal(routedNames.has("plugin_management__uninstall_plugin"), false);
+});
+
+test("Groq refuses an over-limit surface instead of dropping client tools", () => {
+  assert.throws(
+    () => chatProviderToolSurface(largeClientSurface({ plainTools: 126 }), "groq"),
+    (error) => {
+      assert.equal(error.code, GROQ_TOOL_LIMIT_CODE);
+      assert.equal(error.status, 400);
+      assert.equal(error.limit, GROQ_MAX_TOOLS);
+      assert.equal(error.clientToolCount, 129);
+      return true;
+    },
+  );
+});
+
+test("Groq restores injected app definitions referenced by native and flattened history", () => {
+  const input = [
+    {
+      type: "function_call",
+      name: "create_thread",
+      namespace: "codex_app",
+      call_id: "thread-1",
+      arguments: "{}",
+    },
+    {
+      type: "function_call",
+      name: "codex_app__read_thread",
+      call_id: "thread-2",
+      arguments: "{}",
+    },
+  ];
+  const routed = chatProviderToolSurface(largeClientSurface(), "groq", { input });
+  assert.equal(routed.tools.length, 116);
+  assert.ok(routed.tools.some((tool) => tool.name === "codex_app__create_thread"));
+  assert.ok(routed.tools.some((tool) => tool.name === "codex_app__read_thread"));
+  const history = flattenNamespacedHistory(input, routed.namespaces);
+  assert.deepEqual(history[0], {
+    type: "function_call",
+    name: "codex_app__create_thread",
+    call_id: "thread-1",
+    arguments: "{}",
+  });
+  assert.equal(history[1], input[1], "already-flattened history stays byte-identical");
+});
+
+test("Groq restores an injected app definition referenced by a forced choice", () => {
+  const toolChoice = {
+    type: "function",
+    name: "send_message_to_thread",
+    namespace: "codex_app",
+  };
+  const routed = chatProviderToolSurface(largeClientSurface(), "groq", { toolChoice });
+  assert.ok(
+    routed.tools.some((tool) => tool.name === "codex_app__send_message_to_thread"),
+  );
+  assert.deepEqual(flattenToolChoice(toolChoice, routed.namespaces), {
+    type: "function",
+    name: "codex_app__send_message_to_thread",
+  });
+});
+
+test("Groq admits nested and allowed-tools app choices without rewriting other choice types", () => {
+  const nestedChoice = {
+    type: "function",
+    namespace: "codex_app",
+    function: { name: "create_thread" },
+  };
+  const nested = chatProviderToolSurface(largeClientSurface(), "groq", {
+    toolChoice: nestedChoice,
+  });
+  assert.ok(nested.tools.some((tool) => tool.name === "codex_app__create_thread"));
+  assert.deepEqual(flattenToolChoice(nestedChoice, nested.namespaces), {
+    type: "function",
+    function: { name: "codex_app__create_thread" },
+  });
+
+  const allowedChoice = {
+    type: "allowed_tools",
+    mode: "auto",
+    tools: [
+      { type: "function", namespace: "codex_app", name: "send_message_to_thread" },
+      { type: "function", function: { name: "codex_app__read_thread" } },
+      { type: "custom", name: "apply_patch" },
+      { type: "tool_search", execution: "client" },
+    ],
+  };
+  const allowed = chatProviderToolSurface(largeClientSurface(), "groq", {
+    toolChoice: allowedChoice,
+  });
+  assert.ok(
+    allowed.tools.some((tool) => tool.name === "codex_app__send_message_to_thread"),
+  );
+  assert.ok(allowed.tools.some((tool) => tool.name === "codex_app__read_thread"));
+  assert.deepEqual(flattenToolChoice(allowedChoice, allowed.namespaces), {
+    ...allowedChoice,
+    tools: [
+      { type: "function", name: "codex_app__send_message_to_thread" },
+      allowedChoice.tools[1],
+      allowedChoice.tools[2],
+      allowedChoice.tools[3],
+    ],
+  });
+});
+
+test("Groq infers a unique bare deferred app name from stored history", () => {
+  const input = [{ type: "function_call", name: "create_thread", call_id: "bare-1" }];
+  const routed = chatProviderToolSurface(largeClientSurface(), "groq", { input });
+  assert.ok(routed.tools.some((tool) => tool.name === "codex_app__create_thread"));
+  assert.deepEqual(flattenNamespacedHistory(input, routed.namespaces), [{
+    type: "function_call",
+    name: "codex_app__create_thread",
+    call_id: "bare-1",
+  }]);
+});
+
+test("Groq refuses an absent forced app when the client already occupies 128 slots", () => {
+  assert.throws(
+    () => chatProviderToolSurface(largeClientSurface({ plainTools: 125 }), "groq", {
+      toolChoice: { type: "function", function: { name: "codex_app__create_thread" } },
+    }),
+    (error) => {
+      assert.equal(error.code, GROQ_TOOL_LIMIT_CODE);
+      assert.equal(error.clientToolCount, 128);
+      assert.equal(error.referencedToolCapacity, 0);
+      assert.equal(error.referencedToolCount, 1);
+      return true;
+    },
+  );
+});
+
+test("Groq aliases a plain flattened spelling away from its injected app identity", () => {
+  const client = [
+    ...largeClientSurface({ plainTools: 110 }),
+    { type: "function", name: "codex_app__create_thread", parameters: { type: "object" } },
+  ];
+  const input = [
+    { type: "function_call", name: "codex_app__create_thread", call_id: "plain" },
+    {
+      type: "function_call",
+      namespace: "codex_app",
+      name: "create_thread",
+      call_id: "app",
+    },
+  ];
+  const routed = chatProviderToolSurface(client, "groq", { input });
+  const history = flattenNamespacedHistory(input, routed.namespaces);
+  assert.notEqual(history[0].name, history[1].name);
+  assert.match(history[0].name, /^codex_app__create_thread_/);
+  assert.match(history[1].name, /^codex_app__create_thread_/);
+  assert.equal(history[0].name.length, "codex_app__create_thread".length + 13);
+  assert.equal(history[1].name.length, "codex_app__create_thread".length + 13);
+
+  const restored = rewriteNamespaceResponsePayload({
+    output: [
+      { type: "function_call", name: history[0].name, call_id: "plain", arguments: "{}" },
+      { type: "function_call", name: history[1].name, call_id: "app", arguments: "{}" },
+    ],
+  }, buildNamespaceLookups(routed.namespaces));
+  assert.deepEqual(restored.output[0], {
+    type: "function_call",
+    name: "codex_app__create_thread",
+    call_id: "plain",
+    arguments: "{}",
+  });
+  assert.deepEqual(restored.output[1], {
+    type: "function_call",
+    name: "create_thread",
+    namespace: "codex_app",
+    call_id: "app",
+    arguments: "{}",
+  });
+});
+
+test("an exact plain create_thread wins while an explicit app identity remains available", () => {
+  const client = [
+    ...largeClientSurface({ plainTools: 110 }),
+    { type: "function", name: "create_thread", parameters: { type: "object" } },
+  ];
+  const plainOnly = chatProviderToolSurface(client, "groq", {
+    input: [{ type: "function_call", name: "create_thread" }],
+  });
+  assert.equal(
+    plainOnly.tools.some((tool) => tool.name === "codex_app__create_thread"),
+    false,
+  );
+
+  const routed = chatProviderToolSurface(client, "groq", {
+    input: [{ type: "function_call", namespace: "codex_app", name: "create_thread" }],
+  });
+  const restored = rewriteNamespaceResponsePayload({
+    output: [
+      { type: "function_call", name: "create_thread", arguments: "{}" },
+      { type: "function_call", name: "codex_app__create_thread", arguments: "{}" },
+    ],
+  }, buildNamespaceLookups(routed.namespaces));
+  assert.deepEqual(restored.output, [
+    { type: "function_call", name: "create_thread", arguments: "{}" },
+    {
+      type: "function_call",
+      name: "create_thread",
+      namespace: "codex_app",
+      arguments: "{}",
+    },
+  ]);
+});
+
+test("a client app definition wins over the injected snapshot on Groq", () => {
+  const clientDefinition = {
+    type: "function",
+    name: "create_thread",
+    description: "Current client schema wins.",
+    inputSchema: {
+      type: "object",
+      properties: { current: { type: "boolean" } },
+    },
+  };
+  const client = largeClientSurface({
+    appTools: [
+      { type: "function", name: "load_workspace_dependencies" },
+      { type: "function", name: "navigate_to_codex_page" },
+      { type: "function", name: "read_thread_terminal" },
+      clientDefinition,
+    ],
+  });
+  const routed = chatProviderToolSurface(client, "groq", {
+    input: [{
+      type: "function_call",
+      name: "create_thread",
+      namespace: "codex_app",
+    }],
+  });
+  const selected = routed.tools.filter((tool) => tool.name === "codex_app__create_thread");
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0].description, clientDefinition.description);
+  assert.deepEqual(selected[0].inputSchema, clientDefinition.inputSchema);
+});
+
+test("Groq refuses when client plus referenced app definitions exceed the cap", () => {
+  assert.throws(
+    () => chatProviderToolSurface(
+      largeClientSurface({ plainTools: 125 }),
+      "groq",
+      {
+        input: [
+          { type: "function_call", name: "codex_app__create_thread" },
+          { type: "function_call", name: "codex_app__send_message_to_thread" },
+        ],
+      },
+    ),
+    (error) => {
+      assert.equal(error.code, GROQ_TOOL_LIMIT_CODE);
+      assert.equal(error.clientToolCount, 128);
+      assert.equal(error.referencedToolCapacity, 0);
+      assert.equal(error.referencedToolCount, 2);
+      return true;
+    },
+  );
+});
+
+test("non-Groq providers preserve the normally expanded tool surface", () => {
+  const client = largeClientSurface();
+  const expected = flattenNamespaceTools(mergeCodexAppTools(client).tools);
+  const routed = chatProviderToolSurface(client, "openrouter");
+  assert.equal(routed.tools.length, 129);
+  assert.equal(
+    JSON.stringify(routed.tools),
+    JSON.stringify(expected.tools),
+    "the non-Groq provider-facing tool bytes stay unchanged",
+  );
+  assert.deepEqual(routed.tools, expected.tools);
+  assert.deepEqual([...routed.namespaces], [...expected.namespaces]);
+});

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -20,6 +20,22 @@ const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
 // credentials for.
 const PRIMARY = { slug: "deepseek/deepseek-v4-pro", gatewayModel: "deepseek-v4-pro" };
 const FALLBACK = { slug: "zai-api/glm-5.2", gatewayModel: "zai-api-glm-5-2" };
+const GROQ_CANDIDATE = {
+  slug: "groq/tool-limit-failover-fixture",
+  gatewayModel: "groq-tool-limit-failover-fixture",
+  upstreamModel: "openai/gpt-oss-120b",
+  provider: "groq",
+  listed: true,
+  displayName: "Groq tool-limit failover fixture",
+  description: "Local routing test fixture.",
+  priority: 500,
+  defaultEffort: "high",
+  reasoningLevels: [{ effort: "high", description: "Adaptive reasoning" }],
+  contextWindow: 131_072,
+  autoCompact: 111_411,
+  inputModalities: ["text"],
+  compHash: "groq-tool-limit-failover-fixture-v1",
+};
 
 const TURN_BODY = { model: PRIMARY.slug, input: "hello", stream: true };
 
@@ -109,7 +125,13 @@ function bodyJson(request) {
 
 function run(
   env,
-  { chain = [FALLBACK.slug], enabled = true, cooldowns, toolResultAging = false } = {},
+  {
+    chain = [FALLBACK.slug],
+    enabled = true,
+    cooldowns,
+    toolResultAging = false,
+    userModels,
+  } = {},
 ) {
   const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-failover-router-state-"));
   if (chain !== null) {
@@ -130,6 +152,13 @@ function run(
     writeFileSync(
       path.join(stateDir, "tool-result-aging.json"),
       JSON.stringify({ version: 1, enabled: true, nativeEnabled: false }),
+      "utf8",
+    );
+  }
+  if (Array.isArray(userModels)) {
+    writeFileSync(
+      path.join(stateDir, "user-models.json"),
+      JSON.stringify({ version: 1, models: userModels }),
       "utf8",
     );
   }
@@ -156,6 +185,12 @@ function run(
     encoding: "utf8",
     mode: 0o600,
   });
+  if (userModels?.some((model) => model?.provider === "groq")) {
+    writeFileSync(path.join(stateDir, "groq-api-key.secret"), "test-groq-key\n", {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+  }
   const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
     cwd: root,
     env: {
@@ -564,6 +599,59 @@ test("a provider that answers again clears the cooldown this router recorded", a
       readFileSync(path.join(child.stateDir, "provider-cooldowns.json"), "utf8"),
     );
     assert.equal(cooldowns.deepseek, undefined);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("cooldown failover skips a locally incompatible Groq candidate", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("safe-candidate"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), {
+    chain: [GROQ_CANDIDATE.slug, FALLBACK.slug],
+    cooldowns: {
+      deepseek: {
+        until: new Date(Date.now() + 30 * 60_000).toISOString(),
+        reason: "out_of_usage",
+      },
+    },
+    userModels: [GROQ_CANDIDATE],
+  });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, {
+      ...TURN_BODY,
+      tools: Array.from({ length: 129 }, (_, index) => ({
+        type: "function",
+        name: `client_tool_${index}`,
+        parameters: { type: "object" },
+      })),
+    });
+    assert.equal(result.status, 200);
+    assert.match(result.body, /answered-by-safe-candidate/);
+    assert.equal(seen.length, 1, "neither the cooled route nor rejected Groq candidate is sent");
+    assert.equal(seen[0].model, FALLBACK.gatewayModel);
+
+    const logs = child.testErrors();
+    assert.match(
+      logs,
+      /-> groq\/tool-limit-failover-fixture outcome=compatibility\/groq_tool_limit_exceeded/,
+    );
+    assert.match(logs, /-> zai-api\/glm-5\.2 outcome=swapped/);
+
+    const events = await waitForUsageEvents(child.stateDir, 1, child);
+    assert.equal(events.length, 1);
+    assert.equal(events[0].model, FALLBACK.slug);
+    assert.equal(events[0].provider, "zai-api");
+    assert.equal(events[0].failoverFrom, PRIMARY.slug);
+    assert.equal(events[0].status, 200);
   } finally {
     await stopChild(child);
     await closeServer(gw.server);

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -22,6 +22,9 @@ import { callerBaseUrl } from "../src/caller-auth.mjs";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
 const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
+const IMAGE =
+  "data:image/png;base64," +
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
 
 function routerBase(port) {
   return callerBaseUrl(port, CALLER_KEY);
@@ -284,6 +287,302 @@ function routedToolSearchHistoryPayload(
   return payload;
 }
 
+function groqToolSurfacePayload(
+  stream,
+  model,
+  {
+    plainTools = 111,
+    discoveredTools = 0,
+    toolSearch = false,
+    input = [{ type: "message", role: "user", content: "hi" }],
+    toolChoice,
+  } = {},
+) {
+  const payload = {
+    model,
+    stream,
+    input,
+    tools: [
+      ...(toolSearch ? [{
+        type: "tool_search",
+        execution: "client",
+        description: "Search deferred tools.",
+        parameters: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+      }] : []),
+      ...Array.from({ length: plainTools }, (_, index) => ({
+        type: "function",
+        name: `core_tool_${index}`,
+        parameters: { type: "object" },
+      })),
+      {
+        type: "namespace",
+        name: "codex_app",
+        tools: [
+          { type: "function", name: "load_workspace_dependencies" },
+          { type: "function", name: "navigate_to_codex_page" },
+          { type: "function", name: "read_thread_terminal" },
+        ],
+      },
+    ],
+    ...(toolChoice === undefined ? {} : { tool_choice: toolChoice }),
+  };
+  if (discoveredTools > 0) {
+    payload.input.push(
+      {
+        type: "tool_search_call",
+        call_id: "groq-history-search",
+        execution: "client",
+        arguments: { query: "deferred" },
+      },
+      {
+        type: "tool_search_output",
+        call_id: "groq-history-search",
+        status: "completed",
+        execution: "client",
+        tools: Array.from({ length: discoveredTools }, (_, index) => ({
+          type: "function",
+          name: `discovered_tool_${index}`,
+          parameters: { type: "object" },
+        })),
+      },
+    );
+  }
+  return payload;
+}
+
+function groqReferencedHistoryOverflowPayload(stream, model) {
+  const payload = groqToolSurfacePayload(stream, model, { discoveredTools: 0 });
+  const tools = Array.from({ length: 15 }, (_, index) => ({
+    type: "function",
+    name: `referenced_discovery_${index}`,
+    parameters: { type: "object" },
+  }));
+  payload.input.push(
+    {
+      type: "tool_search_call",
+      call_id: "referenced-overflow-search",
+      execution: "client",
+      arguments: { query: "referenced" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "referenced-overflow-search",
+      status: "completed",
+      execution: "client",
+      tools,
+    },
+    ...tools.map((tool, index) => ({
+      type: "function_call",
+      name: tool.name,
+      call_id: `referenced-call-${index}`,
+      arguments: "{}",
+    })),
+  );
+  return payload;
+}
+
+function groqForcedDiscoveryPayload(stream, model, { plainTools = 124 } = {}) {
+  return groqToolSurfacePayload(stream, model, {
+    plainTools,
+    input: [
+      { type: "message", role: "user", content: "hi" },
+      {
+        type: "tool_search_call",
+        call_id: "forced-discovery-search",
+        execution: "client",
+        arguments: { query: "forced" },
+      },
+      {
+        type: "tool_search_output",
+        call_id: "forced-discovery-search",
+        status: "completed",
+        execution: "client",
+        tools: [{
+          type: "namespace",
+          name: "mcp__forced",
+          tools: [
+            { type: "function", name: "unused", parameters: { type: "object" } },
+            { type: "function", name: "required", parameters: { type: "object" } },
+          ],
+        }],
+      },
+    ],
+    toolChoice: {
+      type: "function",
+      namespace: "mcp__forced",
+      function: { name: "required" },
+    },
+  });
+}
+
+function groqInjectedAppHistoryPayload(stream, model) {
+  return groqToolSurfacePayload(stream, model, {
+    input: [
+      { type: "message", role: "user", content: "hi" },
+      {
+        type: "function_call",
+        name: "create_thread",
+        namespace: "codex_app",
+        call_id: "prior-create-thread",
+        arguments: "{}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "prior-create-thread",
+        output: "{}",
+      },
+    ],
+  });
+}
+
+function groqForcedAppChoicePayload(stream, model) {
+  return groqToolSurfacePayload(stream, model, {
+    toolChoice: {
+      type: "function",
+      name: "codex_app__send_message_to_thread",
+    },
+  });
+}
+
+function groqNestedForcedAppChoicePayload(stream, model, { plainTools = 111 } = {}) {
+  return groqToolSurfacePayload(stream, model, {
+    plainTools,
+    toolChoice: {
+      type: "function",
+      namespace: "codex_app",
+      function: { name: "create_thread" },
+    },
+  });
+}
+
+function groqAllowedAppChoicePayload(stream, model) {
+  return groqToolSurfacePayload(stream, model, {
+    toolSearch: true,
+    toolChoice: {
+      type: "allowed_tools",
+      mode: "required",
+      tools: [
+        { type: "function", namespace: "codex_app", name: "send_message_to_thread" },
+        { type: "function", function: { name: "codex_app__read_thread" } },
+        { type: "custom", name: "apply_patch" },
+        { type: "tool_search", execution: "client" },
+      ],
+    },
+  });
+}
+
+function groqResponseCollisionPayload(stream, model) {
+  const payload = groqToolSurfacePayload(stream, model, {
+    plainTools: 110,
+    input: [
+      { type: "message", role: "user", content: "hi" },
+      {
+        type: "function_call",
+        name: "codex_app__create_thread",
+        call_id: "plain-collision",
+        arguments: "{}",
+      },
+      {
+        type: "function_call",
+        namespace: "codex_app",
+        name: "create_thread",
+        call_id: "app-collision",
+        arguments: '{"model":"fixed"}',
+      },
+    ],
+  });
+  payload.tools.push({
+    type: "function",
+    name: "codex_app__create_thread",
+    parameters: { type: "object" },
+  });
+  return payload;
+}
+
+function groqReferencedAppOverflowPayload(stream, model) {
+  return groqToolSurfacePayload(stream, model, {
+    plainTools: 125,
+    input: [{
+      type: "function_call",
+      name: "create_thread",
+      namespace: "codex_app",
+      call_id: "overflow-create-thread",
+      arguments: "{}",
+    }],
+  });
+}
+
+function groqModelSwitchHistoryPayload(stream, model, { referencedTools = 1 } = {}) {
+  const discovered = Array.from({ length: 15 }, (_, index) => ({
+    type: "function",
+    name: `switched_tool_${index}`,
+    parameters: { type: "object" },
+  }));
+  const payload = groqToolSurfacePayload(stream, model);
+  payload.input.push(
+    {
+      type: "tool_search_call",
+      call_id: "prior-model-search",
+      execution: "client",
+      arguments: { query: "switched" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "prior-model-search",
+      status: "completed",
+      execution: "client",
+      tools: [{
+        type: "namespace",
+        name: "mcp__switched",
+        tools: discovered,
+      }],
+    },
+    ...discovered.slice(15 - referencedTools).map((tool, index) => ({
+      type: "function_call",
+      name: tool.name,
+      namespace: "mcp__switched",
+      call_id: `switched-call-${index}`,
+      arguments: "{}",
+    })),
+  );
+  return payload;
+}
+
+function groqModelFixture() {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "groq-tool-surface-"));
+  const userModels = path.join(directory, "user-models.json");
+  writeFileSync(
+    userModels,
+    JSON.stringify({
+      version: 1,
+      models: [
+        {
+          slug: "groq/tool-limit-fixture",
+          gatewayModel: "groq-tool-limit-fixture",
+          upstreamModel: "openai/gpt-oss-120b",
+          provider: "groq",
+          listed: true,
+          displayName: "Groq tool-limit fixture",
+          description: "Local routing test fixture.",
+          priority: 500,
+          defaultEffort: "high",
+          reasoningLevels: [{ effort: "high", description: "Adaptive reasoning" }],
+          contextWindow: 131072,
+          autoCompact: 111411,
+          inputModalities: ["text"],
+          compHash: "groq-tool-limit-fixture-user-v1",
+        },
+      ],
+    }),
+    "utf8",
+  );
+  return { directory, userModels, model: "groq/tool-limit-fixture" };
+}
+
 function sseEvent(event) {
   return `data: ${JSON.stringify(event)}\n\n`;
 }
@@ -499,10 +798,25 @@ async function scenario(
     sseBody = gatewaySseBody,
     jsonBody = gatewayJsonBody,
     requestPayload = routedRequestPayload,
+    routerEnv = {},
+    prepareRouterEnv,
+    visionJsonBody,
+    expectedStatus = 200,
   } = {},
 ) {
   const gatewayBodies = [];
+  const visionBodies = [];
   const gateway = await mockServer(async (request, response) => {
+    if (request.url === "/vision/v1/chat/completions" && visionJsonBody) {
+      const visionBody = await bodyJson(request);
+      visionBodies.push(visionBody);
+      json(
+        response,
+        200,
+        typeof visionJsonBody === "function" ? visionJsonBody(visionBody) : visionJsonBody,
+      );
+      return;
+    }
     if (request.url === "/v1/responses") {
       const gatewayBody = await bodyJson(request);
       gatewayBodies.push(gatewayBody);
@@ -521,10 +835,15 @@ async function scenario(
     json(response, 404, { error: { message: `unexpected ${request.url}` } });
   });
   const routerPort = await openPort();
+  const preparedRouterEnv = prepareRouterEnv
+    ? prepareRouterEnv({ gatewayPort: gateway.port })
+    : {};
   const router = run("router.mjs", {
     CODEX_ROUTER_PORT: String(routerPort),
     CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
     CODEX_ROUTER_QUIET: "1",
+    ...routerEnv,
+    ...preparedRouterEnv,
   });
   try {
     await waitFor(`${routerBase(routerPort)}/models`, router);
@@ -536,14 +855,449 @@ async function scenario(
       },
       body: JSON.stringify(requestPayload(stream, model)),
     });
-    assert.equal(response.status, 200, `router status ${response.status}`);
+    assert.equal(response.status, expectedStatus, `router status ${response.status}`);
     const clientBody = await response.text();
-    return { gatewayBodies, clientBody, router };
+    return { gatewayBodies, visionBodies, clientBody, router, status: response.status };
   } finally {
     await stopChild(router);
     await closeServer(gateway.server);
   }
 }
+
+test("a curated no-search Groq model routes a 129-tool expansion safely", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: (stream, model) => groqToolSurfacePayload(stream, model),
+      jsonBody: () => ({ id: "groq-safe", output: [] }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+    });
+    assert.equal(result.gatewayBodies.length, 1);
+    const outgoing = result.gatewayBodies[0];
+    assert.equal(outgoing.model, "groq-tool-limit-fixture");
+    assert.ok(outgoing.tools.length <= 128);
+    assert.equal(outgoing.tools.length, 114);
+    const names = new Set(outgoing.tools.map((tool) => tool.name));
+    for (let index = 0; index < 111; index += 1) {
+      assert.ok(names.has(`core_tool_${index}`), `core_tool_${index} survives`);
+    }
+    for (const name of [
+      "codex_app__load_workspace_dependencies",
+      "codex_app__navigate_to_codex_page",
+      "codex_app__read_thread_terminal",
+    ]) {
+      assert.ok(names.has(name), `${name} survives`);
+    }
+    assert.equal(names.has("tool_search"), false);
+    assert.equal(names.has("codex_app__create_thread"), false);
+    assert.equal(names.has("plugin_management__uninstall_plugin"), false);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq refuses more than 128 client tools before contacting the gateway", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: (stream, model) =>
+        groqToolSurfacePayload(stream, model, { plainTools: 126 }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+      expectedStatus: 400,
+    });
+    assert.equal(result.gatewayBodies.length, 0);
+    const error = JSON.parse(result.clientBody).error;
+    assert.deepEqual(
+      {
+        type: error.type,
+        code: error.code,
+        provider: error.provider,
+        limit: error.limit,
+      },
+      {
+        type: "provider_compatibility_error",
+        code: "groq_tool_limit_exceeded",
+        provider: "groq",
+        limit: 128,
+      },
+    );
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq re-adds a deferred app definition used by prior native history", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: groqInjectedAppHistoryPayload,
+      jsonBody: () => ({ id: "groq-prior-app-history", output: [] }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+    });
+    assert.equal(result.gatewayBodies.length, 1);
+    const outgoing = result.gatewayBodies[0];
+    assert.ok(outgoing.tools.some((tool) => tool.name === "codex_app__create_thread"));
+    const call = outgoing.input.find((item) => item.call_id === "prior-create-thread");
+    assert.equal(call.name, "codex_app__create_thread");
+    assert.equal(call.namespace, undefined);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq re-adds and flattens a forced deferred app choice", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: groqForcedAppChoicePayload,
+      jsonBody: () => ({ id: "groq-forced-app-choice", output: [] }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+    });
+    assert.equal(result.gatewayBodies.length, 1);
+    const outgoing = result.gatewayBodies[0];
+    assert.ok(
+      outgoing.tools.some((tool) => tool.name === "codex_app__send_message_to_thread"),
+    );
+    assert.deepEqual(outgoing.tool_choice, {
+      type: "function",
+      name: "codex_app__send_message_to_thread",
+    });
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq admits nested and mixed allowed-tools choices through the same identity map", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const nested = await scenario(false, {
+      model: fixture.model,
+      requestPayload: groqNestedForcedAppChoicePayload,
+      jsonBody: () => ({ id: "groq-nested-choice", output: [] }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+    });
+    assert.equal(nested.gatewayBodies.length, 1);
+    assert.ok(
+      nested.gatewayBodies[0].tools.some((tool) => tool.name === "codex_app__create_thread"),
+    );
+    assert.deepEqual(nested.gatewayBodies[0].tool_choice, {
+      type: "function",
+      function: { name: "codex_app__create_thread" },
+    });
+
+    const allowed = await scenario(false, {
+      model: fixture.model,
+      requestPayload: groqAllowedAppChoicePayload,
+      jsonBody: () => ({ id: "groq-allowed-choice", output: [] }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+    });
+    assert.equal(allowed.gatewayBodies.length, 1);
+    const outgoing = allowed.gatewayBodies[0];
+    assert.ok(
+      outgoing.tools.some((tool) => tool.name === "codex_app__send_message_to_thread"),
+    );
+    assert.ok(outgoing.tools.some((tool) => tool.name === "codex_app__read_thread"));
+    assert.deepEqual(outgoing.tool_choice, {
+      type: "allowed_tools",
+      mode: "required",
+      tools: [
+        { type: "function", name: "codex_app__send_message_to_thread" },
+        { type: "function", function: { name: "codex_app__read_thread" } },
+        { type: "custom", name: "apply_patch" },
+        { type: "function", name: "tool_search" },
+      ],
+    });
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq refuses a nested absent forced app at exactly 128 before upstream", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: (stream, model) =>
+        groqNestedForcedAppChoicePayload(stream, model, { plainTools: 125 }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+      expectedStatus: 400,
+    });
+    assert.equal(result.gatewayBodies.length, 0);
+    const error = JSON.parse(result.clientBody).error;
+    assert.equal(error.code, "groq_tool_limit_exceeded");
+    assert.match(error.message, /request references 1 deferred app tools/);
+    assert.match(error.message, /only 0 slots remain/);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq response aliases distinguish a plain flattened spelling from the app tool", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: groqResponseCollisionPayload,
+      jsonBody: (outgoing) => {
+        const plain = outgoing.input.find((item) => item.call_id === "plain-collision");
+        const app = outgoing.input.find((item) => item.call_id === "app-collision");
+        assert.notEqual(plain.name, app.name);
+        assert.equal(plain.namespace, undefined);
+        assert.equal(app.namespace, undefined);
+        return {
+          id: "groq-response-collision",
+          output: [
+            { type: "function_call", name: plain.name, call_id: "plain-result", arguments: "{}" },
+            {
+              type: "function_call",
+              name: app.name,
+              call_id: "app-result",
+              arguments: '{"model":"fixed"}',
+            },
+          ],
+        };
+      },
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+    });
+    assert.equal(result.gatewayBodies.length, 1);
+    const response = JSON.parse(result.clientBody);
+    assert.deepEqual(response.output, [
+      {
+        type: "function_call",
+        name: "codex_app__create_thread",
+        call_id: "plain-result",
+        arguments: "{}",
+      },
+      {
+        type: "function_call",
+        name: "create_thread",
+        namespace: "codex_app",
+        call_id: "app-result",
+        arguments: '{"model":"fixed"}',
+      },
+    ]);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq refuses referenced app overflow before contacting the gateway", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: groqReferencedAppOverflowPayload,
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+      expectedStatus: 400,
+    });
+    assert.equal(result.gatewayBodies.length, 0);
+    const error = JSON.parse(result.clientBody).error;
+    assert.equal(error.type, "provider_compatibility_error");
+    assert.equal(error.code, "groq_tool_limit_exceeded");
+    assert.equal(error.provider, "groq");
+    assert.equal(error.limit, 128);
+    assert.match(error.message, /request references 1 deferred app tools/);
+    assert.match(error.message, /only 0 slots remain/);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq preserves model-switch discoveries while dropping stale search controls", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: groqModelSwitchHistoryPayload,
+      jsonBody: () => ({
+        id: "groq-model-switch-history",
+        output: [{
+          type: "function_call",
+          name: "mcp__switched__switched_tool_14",
+          call_id: "switched-again",
+          arguments: "{}",
+        }],
+      }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+    });
+    assert.equal(result.gatewayBodies.length, 1);
+    const outgoing = result.gatewayBodies[0];
+    assert.equal(outgoing.tools.length, 128);
+    assert.ok(
+      outgoing.tools.some((tool) => tool.name === "mcp__switched__switched_tool_14"),
+      "the later referenced discovery survives capacity selection",
+    );
+    assert.equal(
+      outgoing.input.some(
+        (item) => item.type === "tool_search_call" || item.type === "tool_search_output",
+      ),
+      false,
+    );
+    const storedCall = outgoing.input.find((item) => item.call_id === "switched-call-0");
+    assert.equal(storedCall.name, "mcp__switched__switched_tool_14");
+    assert.equal(storedCall.namespace, undefined);
+    assert.equal(
+      outgoing.input.some(
+        (item) => item.type === "function_call" && item.namespace !== undefined,
+      ),
+      false,
+      "no native namespace field reaches the chat bridge",
+    );
+    const response = JSON.parse(result.clientBody);
+    assert.deepEqual(response.output[0], {
+      type: "function_call",
+      name: "switched_tool_14",
+      namespace: "mcp__switched",
+      call_id: "switched-again",
+      arguments: "{}",
+    });
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq reserves a forced model-switch discovery and refuses it when no slot remains", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const admitted = await scenario(false, {
+      model: fixture.model,
+      requestPayload: groqForcedDiscoveryPayload,
+      jsonBody: () => ({ id: "groq-forced-discovery", output: [] }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+    });
+    assert.equal(admitted.gatewayBodies.length, 1);
+    const outgoing = admitted.gatewayBodies[0];
+    assert.equal(outgoing.tools.length, 128);
+    assert.ok(outgoing.tools.some((tool) => tool.name === "mcp__forced__required"));
+    assert.equal(outgoing.tools.some((tool) => tool.name === "mcp__forced__unused"), false);
+    assert.deepEqual(outgoing.tool_choice, {
+      type: "function",
+      function: { name: "mcp__forced__required" },
+    });
+    assert.equal(
+      outgoing.input.some(
+        (item) => item.type === "tool_search_call" || item.type === "tool_search_output",
+      ),
+      false,
+    );
+
+    const refused = await scenario(false, {
+      model: fixture.model,
+      requestPayload: (stream, model) =>
+        groqForcedDiscoveryPayload(stream, model, { plainTools: 125 }),
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+      expectedStatus: 400,
+    });
+    assert.equal(refused.gatewayBodies.length, 0);
+    const error = JSON.parse(refused.clientBody).error;
+    assert.equal(error.code, "groq_tool_limit_exceeded");
+    assert.match(error.message, /stored history references 1 discovered tools/);
+    assert.match(error.message, /only 0 slots remain/);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq refuses referenced discovery overflow before contacting the gateway", async () => {
+  const fixture = groqModelFixture();
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: groqReferencedHistoryOverflowPayload,
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+      expectedStatus: 400,
+    });
+    assert.equal(result.gatewayBodies.length, 0);
+    const error = JSON.parse(result.clientBody).error;
+    assert.equal(error.type, "provider_compatibility_error");
+    assert.equal(error.code, "groq_tool_limit_exceeded");
+    assert.equal(error.provider, "groq");
+    assert.equal(error.limit, 128);
+    assert.match(error.message, /stored history references 15 discovered tools/);
+    assert.match(error.message, /only 14 slots remain/);
+  } finally {
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("Groq rejects a known history overflow before spending a vision or gateway call", async () => {
+  const fixture = groqModelFixture();
+  const stateDirectory = mkdtempSync(path.join(os.tmpdir(), "groq-preflight-vision-state-"));
+  try {
+    const result = await scenario(false, {
+      model: fixture.model,
+      requestPayload: (stream, model) => {
+        const payload = groqReferencedHistoryOverflowPayload(stream, model);
+        payload.input[0] = {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_text", text: "read this" },
+            { type: "input_image", image_url: IMAGE },
+          ],
+        };
+        return payload;
+      },
+      routerEnv: { MODEL_ROUTER_USER_MODELS: fixture.userModels },
+      prepareRouterEnv: ({ gatewayPort }) => {
+        writeFileSync(
+          path.join(stateDirectory, "vision-bridge.json"),
+          JSON.stringify({
+            version: 1,
+            enabled: true,
+            engine: "local",
+            effort: null,
+            local: {
+              model: "mock-vision-1b",
+              baseUrl: `http://127.0.0.1:${gatewayPort}/vision/v1`,
+            },
+          }),
+          { encoding: "utf8", mode: 0o600 },
+        );
+        return { MODEL_ROUTER_STATE_DIR: stateDirectory };
+      },
+      visionJsonBody: {
+        choices: [{ message: { role: "assistant", content: "an image" } }],
+      },
+      expectedStatus: 400,
+    });
+    assert.equal(result.visionBodies.length, 0);
+    assert.equal(result.gatewayBodies.length, 0);
+    const error = JSON.parse(result.clientBody).error;
+    assert.equal(error.code, "groq_tool_limit_exceeded");
+  } finally {
+    rmSync(stateDirectory, { recursive: true, force: true });
+    rmSync(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("non-Groq routes preserve the full expanded and discovered tool surface", async () => {
+  const result = await scenario(false, {
+    requestPayload: (stream, model) => groqToolSurfacePayload(stream, model, {
+      plainTools: 110,
+      discoveredTools: 20,
+      toolSearch: true,
+    }),
+    jsonBody: () => ({ id: "non-groq-unchanged", output: [] }),
+  });
+  assert.equal(result.gatewayBodies.length, 1);
+  const outgoing = result.gatewayBodies[0];
+  assert.equal(outgoing.tools.length, 149);
+  const names = new Set(outgoing.tools.map((tool) => tool.name));
+  assert.ok(names.has("codex_app__create_thread"));
+  assert.ok(names.has("plugin_management__uninstall_plugin"));
+  for (let index = 0; index < 20; index += 1) {
+    assert.ok(names.has(`discovered_tool_${index}`));
+  }
+  const searchOutput = outgoing.input.find(
+    (item) => item.call_id === "groq-history-search" && item.type === "function_call_output",
+  );
+  assert.equal(JSON.parse(searchOutput.output).tools.length, 20);
+});
 
 test("routed request flattens every namespace to the gateway and restores calls to the client", async () => {
   const first = await scenario();

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -16,6 +16,7 @@ import {
   rewriteNamespaceResponsePayload,
   repairToolSchemaRoots,
   stripSearchContentTypes,
+  ToolSearchHistoryCapacityError,
 } from "../src/namespace-relay.mjs";
 import { CODEX_APP_TOOLS, mergeCodexAppTools } from "../src/codex-app-tools.mjs";
 
@@ -354,6 +355,74 @@ test("bounded aliases avoid request-local collisions without renaming the legal 
     second.tools.map((tool) => tool.name),
     "collision fallback is deterministic",
   );
+});
+
+test("collision-only aliases preserve long Groq names without applying the OpenCode bound", () => {
+  const namespace = `mcp__${"very_long_namespace_".repeat(4)}`;
+  const nativeName = "read";
+  const wireName = `${namespace}__${nativeName}`;
+  const flattened = flattenNamespaceTools([
+    { type: "function", name: wireName },
+    {
+      type: "namespace",
+      name: namespace,
+      tools: [{ type: "function", name: nativeName }],
+    },
+  ], { aliasCollisions: true });
+  const names = flattened.tools.map((tool) => tool.name);
+  assert.equal(new Set(names).size, 2);
+  assert.ok(names.every((name) => name.startsWith(`${wireName}_`)));
+  assert.ok(names.every((name) => name.length > 64));
+
+  const history = flattenNamespacedHistory([
+    { type: "function_call", name: wireName, call_id: "plain" },
+    { type: "function_call", namespace, name: nativeName, call_id: "native" },
+  ], flattened.namespaces);
+  assert.notEqual(history[0].name, history[1].name);
+  const restored = rewriteNamespaceResponsePayload({ output: history }, buildNamespaceLookups(
+    flattened.namespaces,
+  ));
+  assert.deepEqual(restored.output[0], {
+    type: "function_call",
+    name: wireName,
+    call_id: "plain",
+  });
+  assert.deepEqual(restored.output[1], {
+    type: "function_call",
+    namespace,
+    name: nativeName,
+    call_id: "native",
+  });
+});
+
+test("delimiter-colliding namespace identities round-trip through distinct aliases", () => {
+  const flattened = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "a__b",
+      tools: [{ type: "function", name: "c" }],
+    },
+    {
+      type: "namespace",
+      name: "a",
+      tools: [{ type: "function", name: "b__c" }],
+    },
+  ], { aliasCollisions: true });
+  assert.equal(new Set(flattened.tools.map((tool) => tool.name)).size, 2);
+  const history = flattenNamespacedHistory([
+    { type: "function_call", namespace: "a__b", name: "c" },
+    { type: "function_call", namespace: "a", name: "b__c" },
+  ], flattened.namespaces);
+  assert.notEqual(history[0].name, history[1].name);
+
+  const restored = rewriteNamespaceResponsePayload(
+    { output: history },
+    buildNamespaceLookups(flattened.namespaces),
+  );
+  assert.deepEqual(restored.output, [
+    { type: "function_call", namespace: "a__b", name: "c" },
+    { type: "function_call", namespace: "a", name: "b__c" },
+  ]);
 });
 
 test("bounded history keeps ordinary and bridged names ahead of bare namespace inference", () => {
@@ -957,6 +1026,509 @@ test("matched tool_search history declares discovered tools and expands namespac
   });
 });
 
+test("tool_search history admits only definitions within provider capacity", () => {
+  const flattened = flattenNamespaceTools([
+    clientToolSearchControl(),
+    ...Array.from({ length: 126 }, (_, index) => ({
+      type: "function",
+      name: `core_tool_${index}`,
+    })),
+  ]);
+  assert.equal(flattened.tools.length, 127);
+  const history = [
+    {
+      type: "tool_search_call",
+      call_id: "capacity-search",
+      execution: "client",
+      arguments: { query: "calendar" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "capacity-search",
+      status: "completed",
+      execution: "client",
+      tools: [
+        {
+          type: "namespace",
+          name: "mcp__calendar",
+          tools: [
+            { type: "function", name: "first" },
+            { type: "function", name: "second" },
+          ],
+        },
+        { type: "function", name: "third" },
+      ],
+    },
+  ];
+
+  const routed = flattenToolSearchHistory(
+    history,
+    flattened.tools,
+    flattened.namespaces,
+    { maxTools: 128 },
+  );
+  assert.equal(routed.tools.length, 128);
+  assert.deepEqual(
+    routed.tools.slice(127).map((tool) => tool.name),
+    ["mcp__calendar__first"],
+  );
+  assert.deepEqual(
+    JSON.parse(routed.input[1].output).tools.map((tool) => tool.name),
+    ["mcp__calendar__first"],
+    "translated history promises only definitions actually admitted",
+  );
+  assert.deepEqual([...flattened.namespaces.get("mcp__calendar")], ["first"]);
+});
+
+test("tool_search capacity reserves every supported forced-choice function shape", () => {
+  const choices = [
+    { type: "function", namespace: "mcp__x", name: "forced" },
+    { type: "function", namespace: "mcp__x", function: { name: "forced" } },
+    {
+      type: "allowed_tools",
+      mode: "required",
+      tools: [
+        { type: "custom", name: "apply_patch" },
+        { type: "function", name: "mcp__x__forced" },
+        { type: "tool_search", execution: "client" },
+      ],
+    },
+  ];
+  for (const toolChoice of choices) {
+    const flattened = flattenNamespaceTools([
+      clientToolSearchControl(),
+      ...Array.from({ length: 126 }, (_, index) => ({
+        type: "function",
+        name: `core_tool_${index}`,
+      })),
+    ], { aliasCollisions: true });
+    const routed = flattenToolSearchHistory(
+      referencedDiscoveryHistory(undefined).slice(0, 2),
+      flattened.tools,
+      flattened.namespaces,
+      { maxTools: 128, toolChoice },
+    );
+    assert.equal(routed.tools.length, 128);
+    assert.equal(routed.tools.at(-1).name, "mcp__x__forced");
+  }
+});
+
+test("a forced discovered tool over capacity fails closed", () => {
+  const flattened = flattenNamespaceTools([
+    clientToolSearchControl(),
+    ...Array.from({ length: 127 }, (_, index) => ({
+      type: "function",
+      name: `core_tool_${index}`,
+    })),
+  ], { aliasCollisions: true });
+  assert.throws(
+    () => flattenToolSearchHistory(
+      referencedDiscoveryHistory(undefined).slice(0, 2),
+      flattened.tools,
+      flattened.namespaces,
+      {
+        maxTools: 128,
+        toolChoice: { type: "function", namespace: "mcp__x", name: "forced" },
+      },
+    ),
+    (error) => {
+      assert.ok(error instanceof ToolSearchHistoryCapacityError);
+      assert.equal(error.available, 0);
+      assert.equal(error.required, 1);
+      return true;
+    },
+  );
+});
+
+test("discovery references follow request-local identity and transcript time", () => {
+  const collision = flattenNamespaceTools([{
+    type: "namespace",
+    name: "a",
+    tools: [{ type: "function", name: "b" }],
+  }], { aliasCollisions: true });
+  const collisionHistory = [
+    {
+      type: "tool_search_call",
+      call_id: "plain-collision-search",
+      execution: "client",
+      arguments: { query: "plain collision" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "plain-collision-search",
+      execution: "client",
+      status: "completed",
+      tools: [
+        { type: "function", name: "unused" },
+        { type: "function", name: "a__b" },
+      ],
+    },
+    { type: "function_call", name: "a__b", call_id: "plain-collision-call" },
+  ];
+  const collisionRouted = flattenToolSearchHistory(
+    collisionHistory,
+    collision.tools,
+    collision.namespaces,
+    { maxTools: 2, recoverWithoutRelay: true },
+  );
+  assert.equal(collisionRouted.tools.length, 2);
+  const discoveredPlainAlias = collisionRouted.tools.at(-1).name;
+  assert.notEqual(discoveredPlainAlias, "a__b");
+  assert.equal(
+    flattenNamespacedHistory(collisionRouted.input, collision.namespaces)[0].name,
+    discoveredPlainAlias,
+  );
+
+  const differing = flattenNamespaceTools([clientToolSearchControl()]);
+  const differingHistory = [
+    {
+      type: "tool_search_call",
+      call_id: "different-namespace-search",
+      execution: "client",
+      arguments: { query: "different namespace" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "different-namespace-search",
+      execution: "client",
+      status: "completed",
+      tools: [
+        { type: "function", name: "unused" },
+        { type: "function", name: "x" },
+      ],
+    },
+    { type: "function_call", namespace: "mcp__other", name: "x" },
+  ];
+  const differingRouted = flattenToolSearchHistory(
+    differingHistory,
+    differing.tools,
+    differing.namespaces,
+    { maxTools: 2 },
+  );
+  assert.equal(differingRouted.tools.at(-1).name, "unused");
+
+  const temporal = flattenNamespaceTools([clientToolSearchControl()]);
+  const temporalHistory = [
+    {
+      type: "tool_search_call",
+      call_id: "temporal-a",
+      execution: "client",
+      arguments: { query: "first" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "temporal-a",
+      execution: "client",
+      status: "completed",
+      tools: [
+        { type: "function", name: "unused" },
+        {
+          type: "namespace",
+          name: "mcp__a",
+          tools: [{ type: "function", name: "read" }],
+        },
+      ],
+    },
+    { type: "function_call", name: "read", call_id: "temporal-read" },
+    {
+      type: "tool_search_call",
+      call_id: "temporal-b",
+      execution: "client",
+      arguments: { query: "second" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "temporal-b",
+      execution: "client",
+      status: "completed",
+      tools: [{
+        type: "namespace",
+        name: "mcp__b",
+        tools: [{ type: "function", name: "read" }],
+      }],
+    },
+  ];
+  const temporalRouted = flattenToolSearchHistory(
+    temporalHistory,
+    temporal.tools,
+    temporal.namespaces,
+    { maxTools: 2 },
+  );
+  assert.equal(temporalRouted.tools.at(-1).name, "mcp__a__read");
+});
+
+function referencedDiscoveryHistory(call) {
+  return [
+    {
+      type: "tool_search_call",
+      call_id: "referenced-search",
+      execution: "client",
+      arguments: { query: "deferred" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: "referenced-search",
+      status: "completed",
+      execution: "client",
+      tools: [
+        {
+          type: "namespace",
+          name: "mcp__x",
+          tools: [
+            { type: "function", name: "unused" },
+            { type: "function", name: call === undefined ? "forced" : "used" },
+          ],
+        },
+      ],
+    },
+    ...(call === undefined ? [] : [call]),
+  ];
+}
+
+test("tool_search capacity reserves a later namespace-referenced discovery", () => {
+  const flattened = flattenNamespaceTools([clientToolSearchControl()]);
+  const routed = flattenToolSearchHistory(
+    referencedDiscoveryHistory({
+      type: "function_call",
+      name: "used",
+      namespace: "mcp__x",
+      call_id: "used-call",
+      arguments: "{}",
+    }),
+    flattened.tools,
+    flattened.namespaces,
+    { maxTools: 2 },
+  );
+  assert.deepEqual(
+    routed.tools.map((tool) => tool.name),
+    ["tool_search", "mcp__x__used"],
+  );
+  assert.deepEqual(
+    JSON.parse(routed.input[1].output).tools.map((tool) => tool.name),
+    ["mcp__x__used"],
+  );
+  const history = flattenNamespacedHistory(routed.input, flattened.namespaces);
+  assert.equal(history[2].name, "mcp__x__used");
+  assert.equal(history[2].namespace, undefined);
+});
+
+test("tool_search capacity reserves a uniquely owned bare history name", () => {
+  const flattened = flattenNamespaceTools([clientToolSearchControl()]);
+  const routed = flattenToolSearchHistory(
+    referencedDiscoveryHistory({
+      type: "function_call",
+      name: "used",
+      call_id: "bare-used-call",
+      arguments: "{}",
+    }),
+    flattened.tools,
+    flattened.namespaces,
+    { maxTools: 2 },
+  );
+  assert.deepEqual(
+    routed.tools.map((tool) => tool.name),
+    ["tool_search", "mcp__x__used"],
+  );
+  const history = flattenNamespacedHistory(routed.input, flattened.namespaces);
+  assert.equal(history[2].name, "mcp__x__used");
+});
+
+test("referenced tool_search discoveries exceeding capacity fail closed", () => {
+  const flattened = flattenNamespaceTools([clientToolSearchControl()]);
+  const history = referencedDiscoveryHistory({
+    type: "function_call",
+    name: "used",
+    namespace: "mcp__x",
+    call_id: "used-call",
+    arguments: "{}",
+  });
+  history.push({
+    type: "function_call",
+    name: "unused",
+    namespace: "mcp__x",
+    call_id: "also-used-call",
+    arguments: "{}",
+  });
+  assert.throws(
+    () =>
+      flattenToolSearchHistory(history, flattened.tools, flattened.namespaces, {
+        maxTools: 2,
+      }),
+    (error) => {
+      assert.ok(error instanceof ToolSearchHistoryCapacityError);
+      assert.equal(error.available, 1);
+      assert.equal(error.required, 2);
+      return true;
+    },
+  );
+  assert.equal(flattened.namespaces.has("mcp__x"), false);
+});
+
+test("a referenced duplicate discovery still reserves its shared definition", () => {
+  const flattened = flattenNamespaceTools([clientToolSearchControl()]);
+  const pair = (suffix) => [
+    {
+      type: "tool_search_call",
+      call_id: `duplicate-search-${suffix}`,
+      execution: "client",
+      arguments: { query: "duplicate" },
+    },
+    {
+      type: "tool_search_output",
+      call_id: `duplicate-search-${suffix}`,
+      status: "completed",
+      execution: "client",
+      tools: [{
+        type: "namespace",
+        name: "mcp__x",
+        tools: [{ type: "function", name: "used" }],
+      }],
+    },
+  ];
+  const history = [
+    ...pair("first"),
+    ...pair("second"),
+    {
+      type: "function_call",
+      name: "used",
+      namespace: "mcp__x",
+      call_id: "duplicate-used-call",
+      arguments: "{}",
+    },
+  ];
+  assert.throws(
+    () => flattenToolSearchHistory(
+      history,
+      flattened.tools,
+      flattened.namespaces,
+      { maxTools: 1 },
+    ),
+    (error) => {
+      assert.ok(error instanceof ToolSearchHistoryCapacityError);
+      assert.equal(error.available, 0);
+      assert.equal(error.required, 1);
+      return true;
+    },
+  );
+  assert.equal(flattened.namespaces.has("mcp__x"), false);
+});
+
+test("model-switch history recovers referenced discoveries without a live search relay", () => {
+  const flattened = flattenNamespaceTools([
+    { type: "function", name: "exec_command" },
+  ]);
+  const routed = flattenToolSearchHistory(
+    referencedDiscoveryHistory({
+      type: "function_call",
+      name: "used",
+      namespace: "mcp__x",
+      call_id: "used-after-switch",
+      arguments: "{}",
+    }),
+    flattened.tools,
+    flattened.namespaces,
+    { maxTools: 2, recoverWithoutRelay: true },
+  );
+  assert.deepEqual(
+    routed.tools.map((tool) => tool.name),
+    ["exec_command", "mcp__x__used"],
+  );
+  assert.deepEqual(
+    routed.input.map((item) => item.type),
+    ["function_call"],
+    "the unusable native search control pair is removed",
+  );
+  const history = flattenNamespacedHistory(routed.input, flattened.namespaces);
+  assert.equal(history[0].name, "mcp__x__used");
+  assert.equal(history[0].namespace, undefined);
+  const restored = rewriteNamespaceResponsePayload(
+    {
+      output: [{
+        type: "function_call",
+        name: "mcp__x__used",
+        call_id: "used-again",
+        arguments: "{}",
+      }],
+    },
+    buildNamespaceLookups(flattened.namespaces),
+  );
+  assert.deepEqual(restored.output[0], {
+    type: "function_call",
+    name: "used",
+    namespace: "mcp__x",
+    call_id: "used-again",
+    arguments: "{}",
+  });
+});
+
+test("model-switch discovery collisions keep the current client schema", () => {
+  const current = {
+    type: "function",
+    name: "mcp__x__used",
+    description: "Current client schema wins.",
+    parameters: {
+      type: "object",
+      properties: { current: { type: "boolean" } },
+    },
+  };
+  const flattened = flattenNamespaceTools([current]);
+  const routed = flattenToolSearchHistory(
+    referencedDiscoveryHistory({
+      type: "function_call",
+      name: "used",
+      namespace: "mcp__x",
+      call_id: "colliding-used-call",
+      arguments: "{}",
+    }),
+    flattened.tools,
+    flattened.namespaces,
+    { maxTools: 1, recoverWithoutRelay: true },
+  );
+  assert.equal(routed.tools.length, 1);
+  assert.equal(routed.tools[0], current);
+  const history = flattenNamespacedHistory(routed.input, flattened.namespaces);
+  assert.equal(history[0].name, "mcp__x__used");
+  assert.equal(history[0].namespace, undefined);
+});
+
+test("model-switch referenced discovery overflow fails before mutating identities", () => {
+  const flattened = flattenNamespaceTools([
+    ...Array.from({ length: 127 }, (_, index) => ({
+      type: "function",
+      name: `core_tool_${index}`,
+    })),
+  ]);
+  const history = referencedDiscoveryHistory({
+    type: "function_call",
+    name: "used",
+    namespace: "mcp__x",
+    call_id: "used-call",
+    arguments: "{}",
+  });
+  history.push({
+    type: "function_call",
+    name: "unused",
+    namespace: "mcp__x",
+    call_id: "also-used-call",
+    arguments: "{}",
+  });
+  assert.throws(
+    () => flattenToolSearchHistory(
+      history,
+      flattened.tools,
+      flattened.namespaces,
+      { maxTools: 128, recoverWithoutRelay: true },
+    ),
+    (error) => {
+      assert.ok(error instanceof ToolSearchHistoryCapacityError);
+      assert.equal(error.available, 1);
+      assert.equal(error.required, 2);
+      return true;
+    },
+  );
+  assert.equal(flattened.namespaces.has("mcp__x"), false);
+});
+
 test("parallel tool_search calls pair by call_id when all outputs follow the calls", () => {
   const flattened = flattenNamespaceTools([clientToolSearchControl()]);
   const history = [
@@ -1155,7 +1727,7 @@ test("history rename is idempotent and leaves other namespaces alone", () => {
   const { namespaces } = flattenNamespaceTools(clientRoutedTools());
   const alreadyFlat = {
     type: "function_call",
-    name: "codex_app__list_threads",
+    name: "codex_app__navigate_to_codex_page",
     namespace: "codex_app",
     call_id: "call_2",
   };
@@ -1166,7 +1738,7 @@ test("history rename is idempotent and leaves other namespaces alone", () => {
     call_id: "call_3",
   };
   const input = flattenNamespacedHistory([alreadyFlat, unknownNamespace], namespaces);
-  assert.equal(input[0].name, "codex_app__list_threads");
+  assert.equal(input[0].name, "codex_app__navigate_to_codex_page");
   assert.equal(input[0].namespace, "codex_app");
   assert.deepEqual(input[1], unknownNamespace);
 });


### PR DESCRIPTION
## Summary

- keep every client-declared tool while omitting only unreferenced router-injected app tools when Groq's hard 128-tool limit would otherwise be exceeded
- reserve schemas required by stored `tool_search` history and supported forced tool choices, with collision-safe identity tracking
- reject an irreducible overflow locally before any vision bridge or Groq request, and let cooldown failover skip an incompatible Groq candidate
- preserve existing behavior for providers without Groq's cap

## Risk and verification

This touches the provider tool boundary, stored discovery replay, response restoration, and proactive failover, so it received an independent blocker review plus broad verification.

- focused namespace/router/tool-surface tests: 131 passed
- full suite: 2,736 total; 2,719 passed; 17 skipped; 0 failed
- `npm run check`
- `git diff --check`
- repository-maintainer impact analysis

No quota-consuming live Groq request was made. The deterministic tests prove the transformed request never exceeds 128 tools, irreducible requests make zero upstream calls, and non-Groq behavior remains unchanged.

Closes #449
