### PR TITLE
fix: keep native compaction stateless across model switches

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1898,15 +1898,27 @@ async function bridgeVisionInput(input, route, request) {
 // the wire contract calls `encrypted_content` opaque; a token's current shape
 // cannot prove which backend issued it.
 function isOpaqueEncryptedContent(value) {
-  return isNativeEncryptedToken(value);
+  // Preserve the historical direct-credential behavior. The field's wire
+  // contract is opaque, so a future valid format must not be discarded merely
+  // because it stops using today's Fernet-shaped prefix.
+  return typeof value === "string" && value.length > 0 && !/\s/.test(value);
 }
 
 function reasoningSummaryText(item) {
-  if (!Array.isArray(item?.summary)) return undefined;
-  const parts = item.summary
-    .filter((part) => part?.type === "summary_text" && typeof part.text === "string")
-    .map((part) => part.text);
-  return parts.length > 0 ? parts.join("") : undefined;
+  if (!Array.isArray(item?.summary) || item.summary.length === 0) return undefined;
+  const canonical = item.summary.every((part) => {
+    return (
+      part != null &&
+      typeof part === "object" &&
+      !Array.isArray(part) &&
+      Object.keys(part).every((key) => key === "type" || key === "text") &&
+      part.type === "summary_text" &&
+      typeof part.text === "string"
+    );
+  });
+  if (!canonical) return undefined;
+  const text = item.summary.map((part) => part.text).join("");
+  return text.length > 0 ? text : undefined;
 }
 
 function sanitizeReasoningForNative(item, { stateless = false } = {}) {
@@ -1918,6 +1930,10 @@ function sanitizeReasoningForNative(item, { stateless = false } = {}) {
     // token. Drop that foreign item rather than asking native storage to resolve
     // its `rs_` id. Preserve every other non-empty opaque value byte-identical:
     // its format is intentionally unspecified and may evolve.
+    if (
+      typeof item.encrypted_content !== "string" ||
+      item.encrypted_content.length === 0
+    ) return undefined;
     const summary = reasoningSummaryText(item);
     return summary !== undefined && item.encrypted_content === summary ? undefined : item;
   }
@@ -1981,15 +1997,20 @@ function sanitizeCollaborationForNative(item) {
   };
 }
 
-function normalizeNativeInput(input, { stateless = false } = {}) {
+function normalizeNativeInput(
+  input,
+  { statelessReasoning = false, dropUnstoredReasoningReferences = false } = {},
+) {
   if (!Array.isArray(input)) return input;
   return input.flatMap((item) => {
     if (item?.type === "reasoning") {
-      const reasoning = sanitizeReasoningForNative(item, { stateless });
+      const reasoning = sanitizeReasoningForNative(item, {
+        stateless: statelessReasoning,
+      });
       return reasoning === undefined ? [] : [reasoning];
     }
     if (
-      stateless &&
+      dropUnstoredReasoningReferences &&
       item?.type === "item_reference" &&
       typeof item.id === "string" &&
       item.id.startsWith("rs_")
@@ -3132,8 +3153,10 @@ async function handleResponses(request, response, requestUrl) {
       ...activityMetadataFromHeaders(request.headers),
     });
     const compactV1 = /\/responses\/compact$/.test(requestUrl.pathname);
+    // Codex remote compaction V2 uses the ordinary Responses endpoint with a
+    // terminal trigger. Detect the protocol shape before route dispatch so the
+    // native path can also preserve the full tool results being summarized.
     const compactV2 =
-      route &&
       Array.isArray(payload.input) &&
       payload.input.at(-1)?.type === "compaction_trigger";
 
@@ -3291,17 +3314,18 @@ async function handleResponses(request, response, requestUrl) {
       normalizeNativePromptCacheCompatibility(native);
       if (Array.isArray(payload.input)) {
         native.input = normalizeNativeInput(payload.input, {
-          // V1 compaction has its own stored-reference contract. Remote
-          // compaction V2 is an ordinary Responses request and remains
-          // stateless, so only the dedicated endpoint is exempt here.
-          stateless: substitutedCaller && !compactV1,
+          // Every substituted caller needs provenance-safe full reasoning.
+          // V1 compaction alone has a stored-reference contract, so it keeps
+          // bare rs_ references while ordinary/V2 stateless replay drops them.
+          statelessReasoning: substitutedCaller,
+          dropUnstoredReasoningReferences: substitutedCaller && !compactV1,
         });
         // Native turns leave here as stateless full conversations (the
         // previous_response_id below is stripped), so an old tool result costs
         // its full size on every turn of this path too. Compaction turns are
         // exempt: compactV1 keeps its chaining, and a summary should read the
         // true content rather than a receipt.
-        if (!compactV1) {
+        if (!compactV1 && !compactV2) {
           const aged = ageToolResults(native.input, {
             enabled: nativeToolResultAgingEnabled(),
           });

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -645,6 +645,7 @@ const NATIVE_UNSUPPORTED_PARAMS = Object.freeze([
   "user",
   "truncation",
 ]);
+const NATIVE_STATELESS_REASONING_INCLUDE = "reasoning.encrypted_content";
 
 /**
  * Make a generic Responses request acceptable to the native endpoint.
@@ -661,8 +662,27 @@ function normalizeNativeForSubstitutedCaller(payload, { compact = false } = {}) 
   // Injecting `store: false` there also makes its referenced `rs_...` items
   // look deliberately unpersisted, so omit the field rather than choosing a
   // persistence policy the compact request never exposed.
-  if (compact) delete payload.store;
-  else payload.store = false;
+  if (compact) {
+    delete payload.store;
+    // `/responses/compact` has its own narrow request schema. `include` belongs
+    // to ordinary Responses creation and must not leak across this boundary if
+    // a generic caller reuses its normal request options for compaction.
+    delete payload.include;
+  } else {
+    payload.store = false;
+    // The encrypted reasoning payload is the continuation token for a
+    // stateless Responses conversation. A caller that expected storage may not
+    // have requested it; forcing store=false without also requesting this field
+    // leaves only rs_ ids for the next turn, which cannot be retrieved.
+    if (payload.include === undefined) {
+      payload.include = [NATIVE_STATELESS_REASONING_INCLUDE];
+    } else if (
+      Array.isArray(payload.include) &&
+      !payload.include.includes(NATIVE_STATELESS_REASONING_INCLUDE)
+    ) {
+      payload.include = [...payload.include, NATIVE_STATELESS_REASONING_INCLUDE];
+    }
+  }
   for (const key of NATIVE_UNSUPPORTED_PARAMS) delete payload[key];
   return payload;
 }
@@ -1871,23 +1891,39 @@ async function bridgeVisionInput(input, route, request) {
   return result.input;
 }
 
-// OpenAI-issued reasoning `encrypted_content` is an opaque token (Fernet-style,
-// e.g. "gAAAAAB...") with no whitespace. Some local Responses providers (notably
-// Ollama) mimic the reasoning-item shape but fill `encrypted_content` with the
-// plain-text reasoning summary. Codex stores those items, and when the
-// conversation is later replayed to OpenAI's native Responses API, OpenAI
-// rejects the undecryptable blob with "Encrypted content could not be decrypted
-// or parsed." Strip the non-opaque value before sending to native; the item's
-// `summary` still carries the readable reasoning.
+// Credential-bearing callers keep the historical format repair below: they
+// can fall back to the native stored-item namespace after an unreadable
+// encrypted payload is removed. A substituted caller has no such namespace,
+// so its stateless repair must be stricter about provenance. In particular,
+// the wire contract calls `encrypted_content` opaque; a token's current shape
+// cannot prove which backend issued it.
 function isOpaqueEncryptedContent(value) {
-  return typeof value === "string" && value.length > 0 && !/\s/.test(value);
+  return isNativeEncryptedToken(value);
 }
 
-function sanitizeReasoningForNative(item) {
-  if (item?.encrypted_content === undefined) return item;
+function reasoningSummaryText(item) {
+  if (!Array.isArray(item?.summary)) return undefined;
+  const parts = item.summary
+    .filter((part) => part?.type === "summary_text" && typeof part.text === "string")
+    .map((part) => part.text);
+  return parts.length > 0 ? parts.join("") : undefined;
+}
+
+function sanitizeReasoningForNative(item, { stateless = false } = {}) {
+  if (item?.encrypted_content === undefined) return stateless ? undefined : item;
+  if (stateless) {
+    // Translated Responses providers have been observed copying the visible
+    // reasoning summary into `encrypted_content`. Exact equality is evidence
+    // local to this item that the value is a plaintext echo, not a continuation
+    // token. Drop that foreign item rather than asking native storage to resolve
+    // its `rs_` id. Preserve every other non-empty opaque value byte-identical:
+    // its format is intentionally unspecified and may evolve.
+    const summary = reasoningSummaryText(item);
+    return summary !== undefined && item.encrypted_content === summary ? undefined : item;
+  }
   if (isOpaqueEncryptedContent(item.encrypted_content)) return item;
-  const { encrypted_content, ...rest } = item;
-  return rest;
+  const { encrypted_content: _encryptedContent, ...storedItem } = item;
+  return storedItem;
 }
 
 // The mirror of normalizeRoutedAgentInput. When the parent agent is routed, its
@@ -1945,14 +1981,28 @@ function sanitizeCollaborationForNative(item) {
   };
 }
 
-function normalizeNativeInput(input) {
+function normalizeNativeInput(input, { stateless = false } = {}) {
   if (!Array.isArray(input)) return input;
-  return input.map((item) => {
-    if (item?.type === "reasoning") return sanitizeReasoningForNative(item);
-    if (item?.type !== "compaction") return sanitizeCollaborationForNative(item);
-    return isRouterCompactionValue(item.encrypted_content)
+  return input.flatMap((item) => {
+    if (item?.type === "reasoning") {
+      const reasoning = sanitizeReasoningForNative(item, { stateless });
+      return reasoning === undefined ? [] : [reasoning];
+    }
+    if (
+      stateless &&
+      item?.type === "item_reference" &&
+      typeof item.id === "string" &&
+      item.id.startsWith("rs_")
+    ) {
+      // A substituted caller has no native storage namespace to resolve an
+      // `rs_` reference against. Full reasoning items with encrypted content
+      // remain above; bare references cannot be made stateless and are dropped.
+      return [];
+    }
+    if (item?.type !== "compaction") return [sanitizeCollaborationForNative(item)];
+    return [isRouterCompactionValue(item.encrypted_content)
       ? messageItem(renderCompactionValue(item.encrypted_content))
-      : item;
+      : item];
   });
 }
 
@@ -3228,6 +3278,7 @@ async function handleResponses(request, response, requestUrl) {
       }
     } else {
       const native = { ...payload };
+      const substitutedCaller = callerBroughtNoUpstreamCredential(request);
       // An extended-window variant is the model it was derived from, published
       // under a second slug so the picker can offer a different context
       // window (`src/native-context-variants.mjs`). chatgpt.com has never
@@ -3239,7 +3290,12 @@ async function handleResponses(request, response, requestUrl) {
       if (variantBase) native.model = variantBase;
       normalizeNativePromptCacheCompatibility(native);
       if (Array.isArray(payload.input)) {
-        native.input = normalizeNativeInput(payload.input);
+        native.input = normalizeNativeInput(payload.input, {
+          // V1 compaction has its own stored-reference contract. Remote
+          // compaction V2 is an ordinary Responses request and remains
+          // stateless, so only the dedicated endpoint is exempt here.
+          stateless: substitutedCaller && !compactV1,
+        });
         // Native turns leave here as stateless full conversations (the
         // previous_response_id below is stripped), so an old tool result costs
         // its full size on every turn of this path too. Compaction turns are
@@ -3263,7 +3319,7 @@ async function handleResponses(request, response, requestUrl) {
         namespaces: flattenedNamespaces,
       });
       if (!compactV1) delete native.previous_response_id;
-      if (callerBroughtNoUpstreamCredential(request)) {
+      if (substitutedCaller) {
         normalizeNativeForSubstitutedCaller(native, { compact: compactV1 });
       }
       target = nativeTarget(requestUrl.pathname);

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -805,7 +805,11 @@ test("router preserves native auth and isolates every external route", async () 
 test("substituted native compaction omits the ordinary Responses store policy", async () => {
   const nativeRequests = [];
   const native = await mockServer(async (request, response) => {
-    nativeRequests.push({ url: request.url, headers: request.headers, body: await bodyJson(request) });
+    nativeRequests.push({
+      url: request.url,
+      headers: request.headers,
+      body: await bodyJson(request),
+    });
     json(response, 200, { id: "native-ok", output: [] });
   });
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "native-compact-store-"));
@@ -845,6 +849,32 @@ test("substituted native compaction omits the ordinary Responses store policy", 
     });
     assert.equal(ordinary.status, 200, await ordinary.text());
 
+    const ordinaryWithInclude = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "gpt-5.6-sol",
+        input: "hello again",
+        include: ["web_search_call.action.sources"],
+      }),
+    });
+    assert.equal(ordinaryWithInclude.status, 200, await ordinaryWithInclude.text());
+
+    const ordinaryWithReasoningInclude = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "gpt-5.6-sol",
+        input: "one more time",
+        include: ["reasoning.encrypted_content", "web_search_call.action.sources"],
+      }),
+    });
+    assert.equal(
+      ordinaryWithReasoningInclude.status,
+      200,
+      await ordinaryWithReasoningInclude.text(),
+    );
+
     const compact = await fetch(`${routerBase(routerPort)}/responses/compact`, {
       method: "POST",
       headers,
@@ -852,16 +882,27 @@ test("substituted native compaction omits the ordinary Responses store policy", 
         model: "gpt-5.6-sol",
         input: [{ type: "item_reference", id: "rs_not-persisted-by-prior-turn" }],
         store: true,
+        include: ["reasoning.encrypted_content"],
       }),
     });
     assert.equal(compact.status, 200, await compact.text());
 
-    assert.equal(nativeRequests.length, 2);
+    assert.equal(nativeRequests.length, 4);
     assert.equal(nativeRequests[0].url, "/backend-api/codex/responses");
     assert.equal(nativeRequests[0].body.store, false);
-    assert.equal(nativeRequests[1].url, "/backend-api/codex/responses/compact");
-    assert.equal("store" in nativeRequests[1].body, false);
-    assert.deepEqual(nativeRequests[1].body.input, [
+    assert.deepEqual(nativeRequests[0].body.include, ["reasoning.encrypted_content"]);
+    assert.deepEqual(nativeRequests[1].body.include, [
+      "web_search_call.action.sources",
+      "reasoning.encrypted_content",
+    ]);
+    assert.deepEqual(nativeRequests[2].body.include, [
+      "reasoning.encrypted_content",
+      "web_search_call.action.sources",
+    ]);
+    assert.equal(nativeRequests[3].url, "/backend-api/codex/responses/compact");
+    assert.equal("store" in nativeRequests[3].body, false);
+    assert.equal("include" in nativeRequests[3].body, false);
+    assert.deepEqual(nativeRequests[3].body.input, [
       { type: "item_reference", id: "rs_not-persisted-by-prior-turn" },
     ]);
     for (const request of nativeRequests) {
@@ -1917,20 +1958,36 @@ test("compaction never treats reasoning as final text and falls back to chat con
   }
 });
 
-test("router strips non-OpenAI reasoning encrypted_content before replaying to native", async () => {
+test("router drops foreign reasoning items before stateless native replay", async () => {
   const nativeRequests = [];
   const native = await mockServer(async (request, response) => {
-    nativeRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    nativeRequests.push({ url: request.url, headers: request.headers, body: await bodyJson(request) });
     json(response, 200, { route: "native" });
   });
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "native-stateless-reasoning-"));
+  const authPath = path.join(testRoot, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: {
+        access_token: "test-native-session-token",
+        account_id: "test-native-account",
+      },
+    }),
+    { mode: 0o600 },
+  );
   const routerPort = await openPort();
   const router = run("router.mjs", {
     CODEX_ROUTER_PORT: String(routerPort),
     CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_NATIVE_SESSION_FALLBACK: "1",
+    MODEL_ROUTER_CODEX_AUTH: authPath,
+    MODEL_ROUTER_STATE_DIR: path.join(testRoot, "state"),
     CODEX_ROUTER_QUIET: "1",
   });
   const headers = {
-    Authorization: "Bearer CODEX_CALLER_SECRET",
+    Authorization: `Bearer ${CALLER_KEY}`,
     "Content-Type": "application/json",
   };
 
@@ -1945,9 +2002,22 @@ test("router strips non-OpenAI reasoning encrypted_content before replaying to n
       content: null,
       encrypted_content: "The user is frustrated.",
     };
-    const genuineReasoning = {
+    const unknownOpaqueReasoning = {
       type: "reasoning",
-      id: "rs_real",
+      id: "rs_unknown_opaque",
+      summary: [{ type: "summary_text", text: "draft" }],
+      content: null,
+      encrypted_content: "not-a-native-ciphertext",
+    };
+    const missingStatelessPayload = {
+      type: "reasoning",
+      id: "rs_unstored_without_ciphertext",
+      summary: [],
+      content: null,
+    };
+    const futureOpaqueReasoning = {
+      type: "reasoning",
+      id: "rs_future_opaque",
       summary: [],
       content: null,
       encrypted_content: "gAAAAABkZmtM7cT9w_XY_zThisIsAnOpaqueBlobWithNoWhitespace",
@@ -1957,25 +2027,117 @@ test("router strips non-OpenAI reasoning encrypted_content before replaying to n
       role: "user",
       content: [{ type: "input_text", text: "continue" }],
     };
+    const staleReasoningReference = {
+      type: "item_reference",
+      id: "rs_external_reference",
+    };
+    const nonReasoningReference = {
+      type: "item_reference",
+      id: "msg_native_reference",
+    };
     const replay = await fetch(`${routerBase(routerPort)}/responses`, {
       method: "POST",
       headers,
       body: JSON.stringify({
         model: "gpt-5.6-sol",
-        input: [bogusReasoning, genuineReasoning, userMessage],
+        input: [
+          bogusReasoning,
+          unknownOpaqueReasoning,
+          missingStatelessPayload,
+          futureOpaqueReasoning,
+          staleReasoningReference,
+          nonReasoningReference,
+          userMessage,
+        ],
       }),
     });
     assert.equal(replay.status, 200);
     const sent = nativeRequests[0].body.input;
-    const sentBogus = sent.find((item) => item?.id === "rs_518653");
-    const sentGenuine = sent.find((item) => item?.id === "rs_real");
-    assert.equal(sentBogus.type, "reasoning");
-    assert.equal(sentBogus.encrypted_content, undefined);
-    assert.deepEqual(sentBogus.summary, bogusReasoning.summary);
-    assert.equal(sentGenuine.encrypted_content, genuineReasoning.encrypted_content);
+    const sentUnknown = sent.find((item) => item?.id === "rs_unknown_opaque");
+    const sentFuture = sent.find((item) => item?.id === "rs_future_opaque");
+    // A foreign rs_ id without a valid stateless payload makes OpenAI try to
+    // retrieve an item the translated provider never stored. The draft is not
+    // a model-visible answer, so remove the whole item instead of manufacturing
+    // a broken reference.
+    assert.equal(sent.some((item) => item?.id === "rs_518653"), false);
+    assert.equal(sent.some((item) => item?.id === "rs_unstored_without_ciphertext"), false);
+    assert.equal(sent.some((item) => item?.id === "rs_external_reference"), false);
+    assert.deepEqual(sent.find((item) => item?.id === "msg_native_reference"), nonReasoningReference);
+    // Opaque means opaque: neither a current Fernet-like prefix nor its
+    // absence proves provenance. Unknown non-echo values are retained exactly
+    // so a future native encoding is not destroyed by this compatibility path.
+    assert.deepEqual(sentUnknown, unknownOpaqueReasoning);
+    assert.deepEqual(sentFuture, futureOpaqueReasoning);
+    assert.deepEqual(sent.at(-1), userMessage);
+    assert.deepEqual(nativeRequests[0].body.include, ["reasoning.encrypted_content"]);
+
+    // Remote compaction V2 uses the ordinary Responses endpoint and appends a
+    // trigger. It must receive the same stateless-safe history; otherwise the
+    // stale rs_ id is looked up before compaction can run.
+    const compactV2 = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "gpt-5.6-sol",
+        input: [
+          bogusReasoning,
+          staleReasoningReference,
+          userMessage,
+          { type: "compaction_trigger" },
+        ],
+        store: true,
+      }),
+    });
+    assert.equal(compactV2.status, 200);
+    assert.equal(nativeRequests[1].url, "/backend-api/codex/responses");
+    assert.equal(nativeRequests[1].body.store, false);
+    assert.deepEqual(nativeRequests[1].body.include, ["reasoning.encrypted_content"]);
+    assert.equal(nativeRequests[1].body.input.some((item) => item?.id === "rs_518653"), false);
+    assert.equal(
+      nativeRequests[1].body.input.some((item) => item?.id === "rs_external_reference"),
+      false,
+    );
+    assert.deepEqual(nativeRequests[1].body.input.at(-1), { type: "compaction_trigger" });
+
+    // A caller that supplies its own native credential can still rely on the
+    // backend's stored-item namespace. Preserve bare rs_ references and the
+    // reasoning item itself, stripping only ciphertext that the current native
+    // backend cannot parse as an issued continuation token.
+    const storedReplay = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer DIRECT_NATIVE_CALLER_TOKEN",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-5.6-sol",
+        input: [bogusReasoning, missingStatelessPayload, staleReasoningReference, userMessage],
+        store: true,
+        include: ["web_search_call.action.sources"],
+      }),
+    });
+    assert.equal(storedReplay.status, 200);
+    const stored = nativeRequests[2].body;
+    assert.equal(stored.store, true);
+    assert.deepEqual(stored.include, ["web_search_call.action.sources"]);
+    assert.deepEqual(stored.input.find((item) => item?.id === "rs_518653"), {
+      type: "reasoning",
+      id: "rs_518653",
+      summary: bogusReasoning.summary,
+      content: null,
+    });
+    assert.deepEqual(
+      stored.input.find((item) => item?.id === "rs_unstored_without_ciphertext"),
+      missingStatelessPayload,
+    );
+    assert.deepEqual(
+      stored.input.find((item) => item?.id === "rs_external_reference"),
+      staleReasoningReference,
+    );
   } finally {
     await stopChild(router);
     await closeServer(native.server);
+    rmSync(testRoot, { recursive: true, force: true });
   }
 });
 

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -623,15 +623,16 @@ test("native tool-result aging is opt-in and rewrites only consumed old results"
       output: `small result ${n}`,
     })),
   ];
-  const send = async (routerPort) =>
+  const sendInput = async (routerPort, input) =>
     fetch(`${routerBase(routerPort)}/responses`, {
       method: "POST",
       headers: {
         Authorization: "Bearer CODEX_CALLER_SECRET",
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ model: "gpt-5.6-sol", input: agableInput }),
+      body: JSON.stringify({ model: "gpt-5.6-sol", input }),
     });
+  const send = async (routerPort) => sendInput(routerPort, agableInput);
 
   // Default state: the native path forwards the blob untouched.
   const defaultPort = await openPort();
@@ -670,6 +671,15 @@ test("native tool-result aging is opt-in and rewrites only consumed old results"
     assert.match(forwarded[1].output, /^\[Older tool result compacted by Codex Router/);
     assert.match(forwarded[1].output, /sha256:[0-9a-f]{64}/);
     assert.equal(forwarded.at(-1).output, "small result 4");
+
+    // Remote compaction V2 arrives on the ordinary Responses endpoint. Even
+    // when the operator opted native turns into aging, the summary must read
+    // the original tool output rather than the router's compact receipt.
+    const compactInput = [...agableInput, { type: "compaction_trigger" }];
+    assert.equal((await sendInput(agingPort, compactInput)).status, 200);
+    const compactForwarded = nativeRequests.at(-1).body.input;
+    assert.equal(compactForwarded[1].output, bigOutput);
+    assert.deepEqual(compactForwarded.at(-1), { type: "compaction_trigger" });
     // The usage event is appended after the response is relayed; give the
     // router a moment to flush it rather than racing the write.
     const eventsPath = path.join(stateDir, "usage-events.jsonl");
@@ -2015,6 +2025,27 @@ test("router drops foreign reasoning items before stateless native replay", asyn
       summary: [],
       content: null,
     };
+    const invalidStatelessPayloads = [
+      { id: "rs_null_ciphertext", encrypted_content: null },
+      { id: "rs_empty_ciphertext", encrypted_content: "" },
+      { id: "rs_non_string_ciphertext", encrypted_content: 42 },
+    ].map(({ id, encrypted_content }) => ({
+      type: "reasoning",
+      id,
+      summary: [],
+      content: null,
+      encrypted_content,
+    }));
+    const mixedSummaryReasoning = {
+      type: "reasoning",
+      id: "rs_mixed_summary",
+      summary: [
+        { type: "summary_text", text: "draft" },
+        { type: "future_summary", text: "must not be ignored" },
+      ],
+      content: null,
+      encrypted_content: "draft",
+    };
     const futureOpaqueReasoning = {
       type: "reasoning",
       id: "rs_future_opaque",
@@ -2044,6 +2075,8 @@ test("router drops foreign reasoning items before stateless native replay", asyn
           bogusReasoning,
           unknownOpaqueReasoning,
           missingStatelessPayload,
+          ...invalidStatelessPayloads,
+          mixedSummaryReasoning,
           futureOpaqueReasoning,
           staleReasoningReference,
           nonReasoningReference,
@@ -2061,6 +2094,9 @@ test("router drops foreign reasoning items before stateless native replay", asyn
     // a broken reference.
     assert.equal(sent.some((item) => item?.id === "rs_518653"), false);
     assert.equal(sent.some((item) => item?.id === "rs_unstored_without_ciphertext"), false);
+    for (const item of invalidStatelessPayloads) {
+      assert.equal(sent.some((candidate) => candidate?.id === item.id), false);
+    }
     assert.equal(sent.some((item) => item?.id === "rs_external_reference"), false);
     assert.deepEqual(sent.find((item) => item?.id === "msg_native_reference"), nonReasoningReference);
     // Opaque means opaque: neither a current Fernet-like prefix nor its
@@ -2068,6 +2104,10 @@ test("router drops foreign reasoning items before stateless native replay", asyn
     // so a future native encoding is not destroyed by this compatibility path.
     assert.deepEqual(sentUnknown, unknownOpaqueReasoning);
     assert.deepEqual(sentFuture, futureOpaqueReasoning);
+    assert.deepEqual(
+      sent.find((item) => item?.id === mixedSummaryReasoning.id),
+      mixedSummaryReasoning,
+    );
     assert.deepEqual(sent.at(-1), userMessage);
     assert.deepEqual(nativeRequests[0].body.include, ["reasoning.encrypted_content"]);
 
@@ -2099,10 +2139,52 @@ test("router drops foreign reasoning items before stateless native replay", asyn
     );
     assert.deepEqual(nativeRequests[1].body.input.at(-1), { type: "compaction_trigger" });
 
+    // V1 compaction keeps its valid stored-reference contract, but a full
+    // foreign reasoning item still needs substituted-caller provenance cleanup
+    // before it can make native compaction fail by its rs_ id.
+    const compactV1 = await fetch(`${routerBase(routerPort)}/responses/compact`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "gpt-5.6-sol",
+        input: [
+          bogusReasoning,
+          missingStatelessPayload,
+          ...invalidStatelessPayloads,
+          mixedSummaryReasoning,
+          staleReasoningReference,
+          userMessage,
+        ],
+        store: true,
+        include: ["reasoning.encrypted_content"],
+      }),
+    });
+    assert.equal(compactV1.status, 200);
+    const compactV1Body = nativeRequests[2].body;
+    assert.equal(nativeRequests[2].url, "/backend-api/codex/responses/compact");
+    assert.equal("store" in compactV1Body, false);
+    assert.equal("include" in compactV1Body, false);
+    assert.equal(compactV1Body.input.some((item) => item?.id === bogusReasoning.id), false);
+    assert.equal(
+      compactV1Body.input.some((item) => item?.id === missingStatelessPayload.id),
+      false,
+    );
+    for (const item of invalidStatelessPayloads) {
+      assert.equal(compactV1Body.input.some((candidate) => candidate?.id === item.id), false);
+    }
+    assert.deepEqual(
+      compactV1Body.input.find((item) => item?.id === mixedSummaryReasoning.id),
+      mixedSummaryReasoning,
+    );
+    assert.deepEqual(
+      compactV1Body.input.find((item) => item?.id === staleReasoningReference.id),
+      staleReasoningReference,
+    );
+
     // A caller that supplies its own native credential can still rely on the
     // backend's stored-item namespace. Preserve bare rs_ references and the
-    // reasoning item itself, stripping only ciphertext that the current native
-    // backend cannot parse as an issued continuation token.
+    // reasoning item itself. Preserve unknown non-whitespace opaque formats;
+    // only the historical whitespace-bearing plaintext repair is applied.
     const storedReplay = await fetch(`${routerBase(routerPort)}/responses`, {
       method: "POST",
       headers: {
@@ -2111,13 +2193,21 @@ test("router drops foreign reasoning items before stateless native replay", asyn
       },
       body: JSON.stringify({
         model: "gpt-5.6-sol",
-        input: [bogusReasoning, missingStatelessPayload, staleReasoningReference, userMessage],
+        input: [
+          bogusReasoning,
+          unknownOpaqueReasoning,
+          futureOpaqueReasoning,
+          mixedSummaryReasoning,
+          missingStatelessPayload,
+          staleReasoningReference,
+          userMessage,
+        ],
         store: true,
         include: ["web_search_call.action.sources"],
       }),
     });
     assert.equal(storedReplay.status, 200);
-    const stored = nativeRequests[2].body;
+    const stored = nativeRequests[3].body;
     assert.equal(stored.store, true);
     assert.deepEqual(stored.include, ["web_search_call.action.sources"]);
     assert.deepEqual(stored.input.find((item) => item?.id === "rs_518653"), {
@@ -2133,6 +2223,18 @@ test("router drops foreign reasoning items before stateless native replay", asyn
     assert.deepEqual(
       stored.input.find((item) => item?.id === "rs_external_reference"),
       staleReasoningReference,
+    );
+    assert.deepEqual(
+      stored.input.find((item) => item?.id === unknownOpaqueReasoning.id),
+      unknownOpaqueReasoning,
+    );
+    assert.deepEqual(
+      stored.input.find((item) => item?.id === futureOpaqueReasoning.id),
+      futureOpaqueReasoning,
+    );
+    assert.deepEqual(
+      stored.input.find((item) => item?.id === mixedSummaryReasoning.id),
+      mixedSummaryReasoning,
     );
   } finally {
     await stopChild(router);


### PR DESCRIPTION
Closes #467

This completes the native compaction repair across both supported contracts. It preserves store:false for ordinary substituted native turns while requesting encrypted reasoning content, strips unsupported persistence fields from POST /responses/compact, recognizes V2 compaction triggers on ordinary /responses, and removes only provenance-unsafe reasoning artifacts before they can be referenced by a stateless request.

Safety properties:
- V1 keeps valid bare rs_ references but removes foreign full reasoning items.
- V2 and ordinary stateless turns remove server-side response references.
- malformed, missing, and plaintext reasoning content cannot cross the substituted-caller boundary.
- direct credential behavior remains backward compatible.
- native compaction turns are exempt from routed tool-result aging.

Verification on exact main base d3fc728a260fb0a7b7973c3a3ac7f3c6e7b068bd:
- focused compaction and routing regressions pass
- all five review findings have pre-fix negative controls
- full suite: 2719 passed, 17 skipped, 0 failed
- npm run check passes
- maintenance analyzer passes
- git diff --check clean
- independent complete-diff review clean

Residual risk: the backend contract is exercised with deterministic protocol fixtures; no quota-consuming live ChatGPT request was used.