### PR TITLE
fix: preserve namespace relay response bytes

### DIFF
--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -1,6 +1,7 @@
 import { isUtf8 } from "node:buffer";
 import { createHash } from "node:crypto";
 import { Transform } from "node:stream";
+import { isDeepStrictEqual } from "node:util";
 
 import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 import { coerceFunctionCallArguments } from "./tool-arguments.mjs";
@@ -498,6 +499,8 @@ export function injectSessionModelForSpawnCalls(item, model) {
 }
 
 const MAX_JSON_CAPTURE_BYTES = 64 * 1024 * 1024;
+const JSON_CAPTURE_PART_BYTES = 64 * 1024;
+const MAX_TRACKED_OUTPUT_ITEMS = 4096;
 // Stop staging an undecided SSE frame before downstream response guards lose
 // sight of their own byte ceilings. Before any semantic output, crossing this
 // bound releases raw bytes and disables rewriting; after one rewrite,
@@ -508,7 +511,7 @@ const MAX_EXACT_JSON_NUMBER_LENGTH = 4096;
 const LINE_FEED = 0x0a;
 const CARRIAGE_RETURN = 0x0d;
 const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
-const JSON_NUMBER_PREFIX = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/;
+const JSON_NUMBER_AT_OFFSET = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
 const JSON_NUMBER_PARTS =
   /^(-?)(0|[1-9]\d*)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/;
 
@@ -636,10 +639,11 @@ function jsonIsUnambiguousForRewrite(text) {
   };
 
   const number = () => {
-    const match = JSON_NUMBER_PREFIX.exec(text.slice(offset));
+    JSON_NUMBER_AT_OFFSET.lastIndex = offset;
+    const match = JSON_NUMBER_AT_OFFSET.exec(text);
     if (!match) return false;
     if (!jsonNumberIsStableForRewrite(match[0])) return false;
-    offset += match[0].length;
+    offset = JSON_NUMBER_AT_OFFSET.lastIndex;
     return true;
   };
 
@@ -2091,7 +2095,9 @@ class NamespaceRelayCommittedStreamError extends Error {
 // the namespace + name shape Codex dispatches through its app runtime.
 export class NamespaceToolCallTransform extends Transform {
   #eventStream;
-  #pending = Buffer.alloc(0);
+  #pendingParts = [];
+  #pendingBytes = 0;
+  #pendingTailBytes = 0;
   #released = false;
   #headerlessDetector;
   #sseParts = [];
@@ -2102,7 +2108,9 @@ export class NamespaceToolCallTransform extends Transform {
   #sseAtStreamStart = true;
   #sseLineEnding = "\n";
   #sseLineEndingObserved = false;
+  #maxJsonCaptureBytes;
   #maxSseFrameBytes;
+  #maxTrackedOutputItems;
   #rewriteDisabled = false;
   #semanticMutationCommitted = false;
   #lookups;
@@ -2115,8 +2123,13 @@ export class NamespaceToolCallTransform extends Transform {
   #injectQueue = [];
   #injectionsDone = false;
   #lastInjectedCalls = [];
-  #customItemIds = new Set();
-  #customDeltaStates = new Map();
+  // Every observed output-item identity reserves both ids. Special relays keep
+  // their source and native shapes here until terminal validation so a stream
+  // cannot change owners or fall back to raw function-call events after its
+  // opening was rewritten.
+  #callsByItemId = new Map();
+  #callsByCallId = new Map();
+  #trackedCallCount = 0;
 
   constructor(namespaces, contentType = "", sessionModel, options = {}) {
     super();
@@ -2130,10 +2143,18 @@ export class NamespaceToolCallTransform extends Transform {
     // must not run the namespace rewrites (they exist for routed providers)
     // or re-serialize model-authored events it did not change.
     this.#injectOnly = Boolean(options.injectOnly);
+    this.#maxJsonCaptureBytes =
+      Number.isInteger(options.maxJsonCaptureBytes) && options.maxJsonCaptureBytes > 0
+        ? options.maxJsonCaptureBytes
+        : MAX_JSON_CAPTURE_BYTES;
     this.#maxSseFrameBytes =
       Number.isInteger(options.maxSseFrameBytes) && options.maxSseFrameBytes > 0
         ? options.maxSseFrameBytes
         : MAX_SSE_FRAME_BYTES;
+    this.#maxTrackedOutputItems =
+      Number.isInteger(options.maxTrackedOutputItems) && options.maxTrackedOutputItems > 0
+        ? options.maxTrackedOutputItems
+        : MAX_TRACKED_OUTPUT_ITEMS;
     const declared = String(contentType).toLowerCase();
     this.#eventStream = declared.includes("text/event-stream");
     this.#headerlessDetector =
@@ -2168,12 +2189,7 @@ export class NamespaceToolCallTransform extends Transform {
         this.push(bytes);
         return;
       }
-      this.#pending = this.#pending.length ? Buffer.concat([this.#pending, bytes]) : bytes;
-      if (this.#pending.length > MAX_JSON_CAPTURE_BYTES) {
-        this.push(this.#pending);
-        this.#pending = Buffer.alloc(0);
-        this.#released = true;
-      }
+      this.#captureJsonBytes(bytes);
       return;
     }
     if (this.#rewriteDisabled) {
@@ -2201,8 +2217,7 @@ export class NamespaceToolCallTransform extends Transform {
       for (const buffered of detected.chunks) this.#transformChunk(buffered);
     }
     if (!this.#eventStream) {
-      const body = this.#pending;
-      this.#pending = Buffer.alloc(0);
+      const body = this.#takeJsonCapture();
       if (this.#released || !body.length) {
         if (body.length) this.push(body);
         return;
@@ -2249,14 +2264,90 @@ export class NamespaceToolCallTransform extends Transform {
       this.#ssePendingLineWasBlank = false;
       this.#completeSseLine(blankLine);
     }
+    let tailSeparator;
     if (!this.#rewriteDisabled && this.#sseBytes) {
-      this.#emitSseFrame(this.#takeSseFrame());
+      const tail = this.#takeSseFrame();
+      this.#emitSseFrame(tail);
+      tailSeparator = this.#separatorAfterSseTail(tail);
+    }
+    if (!this.#rewriteDisabled && this.#hasOpenSpecialCalls()) {
+      if (this.#semanticMutationCommitted) {
+        throw new NamespaceRelayCommittedStreamError("unterminated special tool call");
+      }
+      this.#disableSseRewriting();
     }
     // Streams that omit response.completed / [DONE] still need the closes,
     // unless an ambiguous frame made observing prior calls unsafe.
     if (!this.#rewriteDisabled) {
-      for (const piece of this.#drainInterruptBlocks()) this.push(piece);
+      const blocks = this.#drainInterruptBlocks();
+      if (blocks.length && tailSeparator?.length) this.push(tailSeparator);
+      for (const piece of blocks) this.push(piece);
     }
+  }
+
+  #captureJsonBytes(bytes) {
+    // Fixed-size parts keep both copies and metadata bounded even when an
+    // upstream fragments a body into one-byte chunks. Each byte is copied once
+    // while capturing and at most once more for the final JSON parse.
+    let offset = 0;
+    while (offset < bytes.length && !this.#released) {
+      let tail = this.#pendingParts.at(-1);
+      if (!tail || this.#pendingTailBytes === tail.length) {
+        const remainingUntilRelease =
+          this.#maxJsonCaptureBytes + 1 - this.#pendingBytes;
+        tail = Buffer.allocUnsafe(
+          Math.min(JSON_CAPTURE_PART_BYTES, remainingUntilRelease),
+        );
+        this.#pendingParts.push(tail);
+        this.#pendingTailBytes = 0;
+      }
+      const copied = Math.min(tail.length - this.#pendingTailBytes, bytes.length - offset);
+      bytes.copy(
+        tail,
+        this.#pendingTailBytes,
+        offset,
+        offset + copied,
+      );
+      this.#pendingTailBytes += copied;
+      this.#pendingBytes += copied;
+      offset += copied;
+      if (this.#pendingBytes > this.#maxJsonCaptureBytes) {
+        for (let index = 0; index < this.#pendingParts.length; index += 1) {
+          const part = this.#pendingParts[index];
+          this.push(
+            index === this.#pendingParts.length - 1
+              ? part.subarray(0, this.#pendingTailBytes)
+              : part,
+          );
+        }
+        this.#pendingParts = [];
+        this.#pendingBytes = 0;
+        this.#pendingTailBytes = 0;
+        this.#released = true;
+      }
+    }
+    if (offset < bytes.length) this.push(bytes.subarray(offset));
+  }
+
+  #takeJsonCapture() {
+    if (!this.#pendingParts.length) return Buffer.alloc(0);
+    const lastIndex = this.#pendingParts.length - 1;
+    const parts = this.#pendingParts.map((part, index) =>
+      index === lastIndex ? part.subarray(0, this.#pendingTailBytes) : part,
+    );
+    const body =
+      parts.length === 1 ? parts[0] : Buffer.concat(parts, this.#pendingBytes);
+    this.#pendingParts = [];
+    this.#pendingBytes = 0;
+    this.#pendingTailBytes = 0;
+    return body;
+  }
+
+  #separatorAfterSseTail(frame) {
+    if (!frame.length) return Buffer.alloc(0);
+    const last = frame[frame.length - 1];
+    const missingLineEndings = last === CARRIAGE_RETURN || last === LINE_FEED ? 1 : 2;
+    return Buffer.from(this.#sseLineEnding.repeat(missingLineEndings), "utf8");
   }
 
   #consumeSseChunk(chunk) {
@@ -2281,14 +2372,16 @@ export class NamespaceToolCallTransform extends Transform {
     }
 
     while (offset < chunk.length) {
-      const nextCr = chunk.indexOf(CARRIAGE_RETURN, offset);
-      const nextLf = chunk.indexOf(LINE_FEED, offset);
-      let lineEnd;
-      if (nextCr === -1) lineEnd = nextLf;
-      else if (nextLf === -1) lineEnd = nextCr;
-      else lineEnd = Math.min(nextCr, nextLf);
+      let lineEnd = offset;
+      while (
+        lineEnd < chunk.length &&
+        chunk[lineEnd] !== CARRIAGE_RETURN &&
+        chunk[lineEnd] !== LINE_FEED
+      ) {
+        lineEnd += 1;
+      }
 
-      if (lineEnd === -1) {
+      if (lineEnd === chunk.length) {
         const content = chunk.subarray(offset);
         this.#sseLineBytes += content.length;
         this.#appendSsePiece(content);
@@ -2375,13 +2468,15 @@ export class NamespaceToolCallTransform extends Transform {
     const lines = [];
     let start = 0;
     while (start < frame.length) {
-      const nextCr = frame.indexOf(CARRIAGE_RETURN, start);
-      const nextLf = frame.indexOf(LINE_FEED, start);
-      let contentEnd;
-      if (nextCr === -1) contentEnd = nextLf;
-      else if (nextLf === -1) contentEnd = nextCr;
-      else contentEnd = Math.min(nextCr, nextLf);
-      if (contentEnd === -1) {
+      let contentEnd = start;
+      while (
+        contentEnd < frame.length &&
+        frame[contentEnd] !== CARRIAGE_RETURN &&
+        frame[contentEnd] !== LINE_FEED
+      ) {
+        contentEnd += 1;
+      }
+      if (contentEnd === frame.length) {
         lines.push({
           start,
           parseStart: start,
@@ -2434,8 +2529,245 @@ export class NamespaceToolCallTransform extends Transform {
     this.#rewriteDisabled = true;
     this.#injectionsDone = true;
     this.#lastInjectedCalls = [];
-    this.#customItemIds.clear();
-    this.#customDeltaStates.clear();
+    this.#callsByItemId.clear();
+    this.#callsByCallId.clear();
+    this.#trackedCallCount = 0;
+  }
+
+  #specialCallKind(item) {
+    if (item?.type === "custom_tool_call") return "custom";
+    if (item?.type === "tool_search_call") return "tool_search";
+    return undefined;
+  }
+
+  #hasOpenSpecialCalls() {
+    for (const state of this.#callsByItemId.values()) {
+      if (state.kind && !state.closed) return true;
+    }
+    return false;
+  }
+
+  #openingIdentityConflict(item) {
+    const byItemId =
+      typeof item?.id === "string" ? this.#callsByItemId.get(item.id) : undefined;
+    const byCallId =
+      typeof item?.call_id === "string"
+        ? this.#callsByCallId.get(item.call_id)
+        : undefined;
+    if (byItemId || byCallId) return "duplicate output item identity";
+    return undefined;
+  }
+
+  #registerCall(sourceItem, item) {
+    const kind = this.#specialCallKind(item);
+    const itemId = typeof item?.id === "string" && item.id ? item.id : undefined;
+    const callId =
+      typeof item?.call_id === "string" && item.call_id ? item.call_id : undefined;
+    if (
+      kind &&
+      (!itemId ||
+        !callId ||
+        sourceItem?.id !== itemId ||
+        sourceItem?.call_id !== callId)
+    ) {
+      return "special tool call opening lacks stable identity";
+    }
+    if (!itemId && !callId) return undefined;
+    const conflict = this.#openingIdentityConflict(item);
+    if (conflict) return conflict;
+    if (this.#trackedCallCount >= this.#maxTrackedOutputItems) {
+      return "output item identity limit";
+    }
+    const state = {
+      kind,
+      itemId,
+      callId,
+      sourceType: sourceItem?.type,
+      sourceName: sourceItem?.name,
+      outputType: item.type,
+      outputName: item.name,
+      argumentsDone: false,
+      finalInput: undefined,
+      finalArguments: undefined,
+      sawArgumentDelta: false,
+      deltaCharacters: 0,
+      deltaHash: kind === "custom" ? createHash("sha256") : undefined,
+      closed: false,
+      deltaState:
+        kind === "custom"
+          ? {
+              opening: "",
+              opened: false,
+              escape: "",
+              closed: false,
+              invalid: false,
+            }
+          : undefined,
+    };
+    if (state.itemId) this.#callsByItemId.set(state.itemId, state);
+    if (state.callId) this.#callsByCallId.set(state.callId, state);
+    this.#trackedCallCount += 1;
+    return undefined;
+  }
+
+  #specialCallForArgumentsEvent(event) {
+    const byItemId =
+      typeof event?.item_id === "string"
+        ? this.#callsByItemId.get(event.item_id)
+        : undefined;
+    const byCallId =
+      typeof event?.call_id === "string"
+        ? this.#callsByCallId.get(event.call_id)
+        : undefined;
+    if (byItemId && byCallId && byItemId !== byCallId) {
+      return { reason: "conflicting special tool call identity" };
+    }
+    const state = byItemId || byCallId;
+    if (!state || !state.kind) return {};
+    if (event.item_id !== state.itemId) {
+      return { reason: "mismatched special tool call item id" };
+    }
+    if (event.call_id !== undefined && event.call_id !== state.callId) {
+      return { reason: "mismatched special tool call call id" };
+    }
+    if (state.closed) return { reason: "special tool call event after close" };
+    return { state };
+  }
+
+  #customDeltaMismatch(state, input) {
+    if (!state.sawArgumentDelta) return undefined;
+    if (
+      state.deltaState.invalid ||
+      !state.deltaState.opened ||
+      !state.deltaState.closed ||
+      state.deltaState.escape
+    ) {
+      return "incomplete custom tool argument delta sequence";
+    }
+    if (state.deltaCharacters !== input.length) {
+      return "custom tool argument deltas disagree with completed input";
+    }
+    const streamed = state.deltaHash.copy().digest("hex");
+    const completed = createHash("sha256")
+      .update(Buffer.from(input, "utf16le"))
+      .digest("hex");
+    return streamed === completed
+      ? undefined
+      : "custom tool argument deltas disagree with completed input";
+  }
+
+  #closeSpecialCall(sourceItem, item) {
+    const byItemId =
+      typeof sourceItem?.id === "string"
+        ? this.#callsByItemId.get(sourceItem.id)
+        : undefined;
+    const byCallId =
+      typeof sourceItem?.call_id === "string"
+        ? this.#callsByCallId.get(sourceItem.call_id)
+        : undefined;
+    if (byItemId && byCallId && byItemId !== byCallId) {
+      return "conflicting special tool call close identity";
+    }
+    const state = byItemId || byCallId;
+    const outputKind = this.#specialCallKind(item);
+    if (!state || !state.kind) {
+      return outputKind ? "special tool call close without a matching opening" : undefined;
+    }
+    if (state.closed) return "duplicate special tool call close";
+    if (sourceItem?.id !== state.itemId || sourceItem?.call_id !== state.callId) {
+      return "mismatched special tool call close identity";
+    }
+    if (sourceItem.type !== state.sourceType || sourceItem.name !== state.sourceName) {
+      return "mismatched special tool call close source";
+    }
+    if (
+      item?.id !== state.itemId ||
+      item?.call_id !== state.callId ||
+      item?.type !== state.outputType ||
+      item?.name !== state.outputName
+    ) {
+      return "special tool call close was not restored consistently";
+    }
+    if (state.kind === "custom") {
+      if (state.argumentsDone && item.input !== state.finalInput) {
+        return "custom tool call input changed before close";
+      }
+      if (!state.argumentsDone) {
+        const reason = this.#customDeltaMismatch(state, item.input);
+        if (reason) return reason;
+        state.finalInput = item.input;
+      }
+    }
+    if (
+      state.kind === "tool_search" &&
+      state.argumentsDone &&
+      !isDeepStrictEqual(item.arguments, state.finalArguments)
+    ) {
+      return "tool search arguments changed before close";
+    }
+    if (state.kind === "tool_search") state.finalArguments = item.arguments;
+    state.closed = true;
+    return undefined;
+  }
+
+  #validateSpecialSummaryItem(sourceItem, item) {
+    const byItemId =
+      typeof sourceItem?.id === "string"
+        ? this.#callsByItemId.get(sourceItem.id)
+        : undefined;
+    const byCallId =
+      typeof sourceItem?.call_id === "string"
+        ? this.#callsByCallId.get(sourceItem.call_id)
+        : undefined;
+    if (byItemId && byCallId && byItemId !== byCallId) {
+      return "conflicting special tool call summary identity";
+    }
+    const state = byItemId || byCallId;
+    const outputKind = this.#specialCallKind(item);
+    if (!state || !state.kind) {
+      return outputKind ? "special tool call summary without a matching opening" : undefined;
+    }
+    if (!state.closed) return "special tool call summary before close";
+    if (
+      sourceItem?.id !== state.itemId ||
+      sourceItem?.call_id !== state.callId ||
+      sourceItem?.type !== state.sourceType ||
+      sourceItem?.name !== state.sourceName
+    ) {
+      return "mismatched special tool call summary source";
+    }
+    if (
+      item?.id !== state.itemId ||
+      item?.call_id !== state.callId ||
+      item?.type !== state.outputType ||
+      item?.name !== state.outputName
+    ) {
+      return "special tool call summary was not restored consistently";
+    }
+    if (state.kind === "custom" && item.input !== state.finalInput) {
+      return "custom tool call summary input changed after close";
+    }
+    if (
+      state.kind === "tool_search" &&
+      !isDeepStrictEqual(item.arguments, state.finalArguments)
+    ) {
+      return "tool search arguments changed after close";
+    }
+    return undefined;
+  }
+
+  #validateSpecialOutputItems(sourceEvent, event) {
+    for (const [sourceOutput, output] of [
+      [sourceEvent?.output, event?.output],
+      [sourceEvent?.response?.output, event?.response?.output],
+    ]) {
+      if (!Array.isArray(sourceOutput) || !Array.isArray(output)) continue;
+      for (let index = 0; index < sourceOutput.length; index += 1) {
+        const reason = this.#validateSpecialSummaryItem(sourceOutput[index], output[index]);
+        if (reason) return reason;
+      }
+    }
+    return undefined;
   }
 
   #rewrittenSseFrame(frame, lines, replacements) {
@@ -2505,6 +2837,9 @@ export class NamespaceToolCallTransform extends Transform {
       }
       // Inject before the stream terminator so Codex still executes the calls.
       if (dataText === "[DONE]") {
+        if (this.#hasOpenSpecialCalls()) {
+          return this.#unsafeSseFrame(frame, "stream ended before special tool call close");
+        }
         return [...this.#drainInterruptBlocks(), frame];
       }
       return [frame];
@@ -2525,39 +2860,91 @@ export class NamespaceToolCallTransform extends Transform {
       if (!embeddedFunctionArgumentsAreUnambiguous(event)) {
         return this.#unsafeSseFrame(frame, "ambiguous function arguments");
       }
+      const sourceEvent = event;
       const originalEventType = event?.type;
       let changed = false;
-      if (
-        !this.#injectOnly &&
-        event?.type === "response.function_call_arguments.delta" &&
-        this.#customItemIds.has(event.item_id)
-      ) {
-        const state = this.#customDeltaStates.get(event.item_id);
-        const delta = state ? customToolInputDelta(state, event.delta) : undefined;
-        if (delta === undefined) {
-          this.#commitSemanticMutation();
-          return [];
-        }
-        event = {
-          ...event,
-          type: "response.custom_tool_call_input.delta",
-          delta,
-        };
-        changed = true;
+      if (sourceEvent?.type === "response.output_item.added") {
+        const conflict = this.#openingIdentityConflict(sourceEvent.item);
+        if (conflict) return this.#unsafeSseFrame(frame, conflict);
       }
       if (
         !this.#injectOnly &&
-        event?.type === "response.function_call_arguments.done" &&
-        this.#customItemIds.has(event.item_id)
+        (sourceEvent?.type === "response.custom_tool_call_input.delta" ||
+          sourceEvent?.type === "response.custom_tool_call_input.done")
       ) {
-        const input = customToolInput(event.arguments);
-        if (input !== undefined) {
+        const matched = this.#specialCallForArgumentsEvent(sourceEvent);
+        if (matched.reason) return this.#unsafeSseFrame(frame, matched.reason);
+        if (matched.state?.sourceType === "function_call") {
+          return this.#unsafeSseFrame(
+            frame,
+            "native custom input event inside a bridged function lifecycle",
+          );
+        }
+      }
+      if (
+        !this.#injectOnly &&
+        event?.type === "response.function_call_arguments.delta"
+      ) {
+        const matched = this.#specialCallForArgumentsEvent(event);
+        if (matched.reason) return this.#unsafeSseFrame(frame, matched.reason);
+        if (matched.state) {
+          if (matched.state.argumentsDone) {
+            return this.#unsafeSseFrame(frame, "special tool call delta after arguments done");
+          }
+          if (matched.state.kind === "tool_search") {
+            this.#commitSemanticMutation();
+            return [];
+          }
+          matched.state.sawArgumentDelta = true;
+          const delta = customToolInputDelta(matched.state.deltaState, event.delta);
+          if (delta === undefined) {
+            this.#commitSemanticMutation();
+            return [];
+          }
+          matched.state.deltaHash.update(Buffer.from(delta, "utf16le"));
+          matched.state.deltaCharacters += delta.length;
+          event = {
+            ...event,
+            type: "response.custom_tool_call_input.delta",
+            delta,
+          };
+          changed = true;
+        }
+      }
+      if (
+        !this.#injectOnly &&
+        event?.type === "response.function_call_arguments.done"
+      ) {
+        const matched = this.#specialCallForArgumentsEvent(event);
+        if (matched.reason) return this.#unsafeSseFrame(frame, matched.reason);
+        if (matched.state) {
+          if (matched.state.argumentsDone) {
+            return this.#unsafeSseFrame(frame, "duplicate special tool call arguments done");
+          }
+          if (matched.state.kind === "tool_search") {
+            const argumentsObject = toolSearchArguments(event.arguments, false);
+            if (!argumentsObject) {
+              return this.#unsafeSseFrame(frame, "invalid tool search arguments done");
+            }
+            matched.state.argumentsDone = true;
+            matched.state.finalArguments = argumentsObject;
+            this.#commitSemanticMutation();
+            return [];
+          }
+          const input = customToolInput(event.arguments);
+          if (input === undefined) {
+            return this.#unsafeSseFrame(frame, "invalid custom tool arguments done");
+          }
+          const deltaReason = this.#customDeltaMismatch(matched.state, input);
+          if (deltaReason) return this.#unsafeSseFrame(frame, deltaReason);
           const { arguments: _arguments, ...rest } = event;
           event = {
             ...rest,
             type: "response.custom_tool_call_input.done",
             input,
           };
+          matched.state.argumentsDone = true;
+          matched.state.finalInput = input;
           changed = true;
         }
       }
@@ -2568,27 +2955,25 @@ export class NamespaceToolCallTransform extends Transform {
           changed = true;
         }
       }
-      if (
-        event?.type === "response.output_item.added" &&
-        event.item?.type === "custom_tool_call" &&
-        typeof event.item.id === "string"
-      ) {
-        this.#customItemIds.add(event.item.id);
-        this.#customDeltaStates.set(event.item.id, {
-          opening: "",
-          opened: false,
-          escape: "",
-          closed: false,
-          invalid: false,
-        });
+      if (sourceEvent?.type === "response.output_item.added") {
+        const reason = this.#registerCall(sourceEvent.item, event.item);
+        if (reason) return this.#unsafeSseFrame(frame, reason);
       }
-      if (
-        event?.type === "response.output_item.done" &&
-        event.item?.type === "custom_tool_call" &&
-        typeof event.item.id === "string"
-      ) {
-        this.#customItemIds.delete(event.item.id);
-        this.#customDeltaStates.delete(event.item.id);
+      if (sourceEvent?.type === "response.output_item.done") {
+        const reason = this.#closeSpecialCall(sourceEvent.item, event.item);
+        if (reason) return this.#unsafeSseFrame(frame, reason);
+      }
+      const summaryReason = this.#validateSpecialOutputItems(sourceEvent, event);
+      if (summaryReason) return this.#unsafeSseFrame(frame, summaryReason);
+      const terminalEvent =
+        event?.type === "response.completed" ||
+        event?.type === "response.done" ||
+        eventName === "response.completed" ||
+        eventName === "response.done";
+      if (terminalEvent) {
+        if (this.#hasOpenSpecialCalls()) {
+          return this.#unsafeSseFrame(frame, "terminal event before special tool call close");
+        }
       }
       this.#observeEvent(event);
       const replacements = new Map();

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -2916,15 +2916,14 @@ export class NamespaceToolCallTransform extends Transform {
     return this.#storeCallState(state);
   }
 
-  #registerAtomicOutputItem(sourceItem, item, { summarySeen = false } = {}) {
-    const sourceKind = this.#sourceSpecialCallKind(sourceItem);
-    const outputKind = this.#specialCallKind(item);
-    if (sourceKind || outputKind) {
-      return this.#registerAtomicSpecialCall(sourceItem, item, { summarySeen });
-    }
-
-    // Ordinary items reserve the same id domains. Otherwise a done-only
-    // ordinary call could donate its call_id to a later special relay.
+  #registerOrdinaryOutputItem(
+    sourceItem,
+    item,
+    { closed = true, summarySeen = false } = {},
+  ) {
+    // Ordinary items reserve the same id domains as special relays. This also
+    // covers nonterminal response snapshots, which can precede an explicit
+    // output_item.done event and therefore must not be marked closed yet.
     const itemId = typeof item?.id === "string" && item.id ? item.id : undefined;
     const callId = typeof item?.call_id === "string" && item.call_id
       ? item.call_id
@@ -2955,7 +2954,7 @@ export class NamespaceToolCallTransform extends Transform {
       (sourceHasItemId && !itemId) ||
       (sourceHasCallId && !callId)
     ) {
-      return "atomic output item lacks stable identity";
+      return "output item lacks stable identity";
     }
     if (!itemId && !callId) return undefined;
     const conflict = this.#openingIdentityConflict(item);
@@ -2978,11 +2977,23 @@ export class NamespaceToolCallTransform extends Transform {
       sawArgumentDelta: false,
       deltaCharacters: 0,
       deltaHash: undefined,
-      closed: true,
+      closed,
       summarySeen,
       deltaState: undefined,
     };
     return this.#storeCallState(state);
+  }
+
+  #registerAtomicOutputItem(sourceItem, item, { summarySeen = false } = {}) {
+    const sourceKind = this.#sourceSpecialCallKind(sourceItem);
+    const outputKind = this.#specialCallKind(item);
+    if (sourceKind || outputKind) {
+      return this.#registerAtomicSpecialCall(sourceItem, item, { summarySeen });
+    }
+    return this.#registerOrdinaryOutputItem(sourceItem, item, {
+      closed: true,
+      summarySeen,
+    });
   }
 
   #outputItemMatchesState(sourceItem, item, state) {
@@ -3133,9 +3144,13 @@ export class NamespaceToolCallTransform extends Transform {
     const outputKind = this.#specialCallKind(item);
     if (!state) {
       if (!allowAtomic) {
-        return sourceKind || outputKind
-          ? "special tool call summary without a matching opening"
-          : undefined;
+        if (sourceKind || outputKind) {
+          return "special tool call summary without a matching opening";
+        }
+        return this.#registerOrdinaryOutputItem(sourceItem, item, {
+          closed: false,
+          summarySeen: false,
+        });
       }
       return this.#registerAtomicOutputItem(sourceItem, item, { summarySeen: true });
     }
@@ -3147,8 +3162,13 @@ export class NamespaceToolCallTransform extends Transform {
         : "mismatched output item summary identity";
     }
     if (!state.kind) {
-      state.closed = true;
-      state.summarySeen = true;
+      // Progress snapshots may repeat the same ordinary item while its content
+      // grows. They reserve and validate ownership, but only a terminal output
+      // summary closes and consumes the one allowed summary transition.
+      if (allowAtomic) {
+        state.closed = true;
+        state.summarySeen = true;
+      }
       return undefined;
     }
     if (state.kind === "custom") {
@@ -3178,7 +3198,7 @@ export class NamespaceToolCallTransform extends Transform {
         return "tool search arguments changed after close";
       }
     }
-    state.summarySeen = true;
+    if (allowAtomic) state.summarySeen = true;
     return undefined;
   }
 

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -2540,6 +2540,17 @@ export class NamespaceToolCallTransform extends Transform {
     return undefined;
   }
 
+  #sourceSpecialCallKind(item) {
+    const nativeKind = this.#specialCallKind(item);
+    if (nativeKind) return nativeKind;
+    if (item?.type !== "function_call") return undefined;
+    if (this.#lookups.customTools instanceof Map && this.#lookups.customTools.has(item.name)) {
+      return "custom";
+    }
+    if (item.name === this.#lookups.toolSearch?.providerName) return "tool_search";
+    return undefined;
+  }
+
   #hasOpenSpecialCalls() {
     for (const state of this.#callsByItemId.values()) {
       if (state.kind && !state.closed) return true;
@@ -2560,6 +2571,21 @@ export class NamespaceToolCallTransform extends Transform {
 
   #registerCall(sourceItem, item) {
     const kind = this.#specialCallKind(item);
+    const sourceKind = this.#sourceSpecialCallKind(sourceItem);
+    if ((sourceKind || kind) && sourceKind !== kind) {
+      return "special tool call opening was not restored consistently";
+    }
+    if (
+      (kind === "custom" &&
+        (typeof item.name !== "string" || !item.name || item.namespace !== undefined)) ||
+      (kind === "tool_search" &&
+        (item.name !== undefined ||
+          item.namespace !== undefined ||
+          item.execution !== "client" ||
+          !plainObject(item.arguments)))
+    ) {
+      return "special tool call opening is incomplete";
+    }
     const itemId = typeof item?.id === "string" && item.id ? item.id : undefined;
     const callId =
       typeof item?.call_id === "string" && item.call_id ? item.call_id : undefined;
@@ -2584,8 +2610,10 @@ export class NamespaceToolCallTransform extends Transform {
       callId,
       sourceType: sourceItem?.type,
       sourceName: sourceItem?.name,
+      sourceNamespace: sourceItem?.namespace,
       outputType: item.type,
       outputName: item.name,
+      outputNamespace: item.namespace,
       argumentsDone: false,
       finalInput: undefined,
       finalArguments: undefined,
@@ -2593,6 +2621,7 @@ export class NamespaceToolCallTransform extends Transform {
       deltaCharacters: 0,
       deltaHash: kind === "custom" ? createHash("sha256") : undefined,
       closed: false,
+      summarySeen: false,
       deltaState:
         kind === "custom"
           ? {
@@ -2608,6 +2637,202 @@ export class NamespaceToolCallTransform extends Transform {
     if (state.callId) this.#callsByCallId.set(state.callId, state);
     this.#trackedCallCount += 1;
     return undefined;
+  }
+
+  // Some Responses bridges omit output_item.added and emit only one complete
+  // done item or a terminal output summary. Treat that self-contained item as
+  // a closed lifecycle, but reserve its identities exactly like a streamed
+  // opening so later events cannot change owners or replay it.
+  #registerAtomicSpecialCall(sourceItem, item, { summarySeen = false } = {}) {
+    const sourceKind = this.#sourceSpecialCallKind(sourceItem);
+    const kind = this.#specialCallKind(item);
+    if (!sourceKind || sourceKind !== kind) {
+      return "atomic special tool call was incomplete or restored inconsistently";
+    }
+
+    const callId = typeof item?.call_id === "string" && item.call_id
+      ? item.call_id
+      : undefined;
+    if (!callId || sourceItem?.call_id !== callId) {
+      return "atomic special tool call lacks stable identity";
+    }
+    const sourceHasItemId = Object.hasOwn(sourceItem, "id");
+    const outputHasItemId = Object.hasOwn(item, "id");
+    if (
+      sourceHasItemId !== outputHasItemId ||
+      (sourceHasItemId &&
+        (typeof item.id !== "string" || !item.id || sourceItem.id !== item.id))
+    ) {
+      return "atomic special tool call lacks stable identity";
+    }
+    const itemId = outputHasItemId ? item.id : undefined;
+
+    if (kind === "custom") {
+      if (
+        typeof item.name !== "string" ||
+        !item.name ||
+        item.namespace !== undefined ||
+        typeof item.input !== "string"
+      ) {
+        return "incomplete atomic custom tool call";
+      }
+      if (sourceItem.type === "function_call") {
+        const expectedName = this.#lookups.customTools?.get(sourceItem.name);
+        if (
+          expectedName !== item.name ||
+          customToolInput(sourceItem.arguments) !== item.input
+        ) {
+          return "atomic custom tool call was not restored consistently";
+        }
+      } else if (
+        sourceItem.name !== item.name ||
+        sourceItem.input !== item.input
+      ) {
+        return "atomic custom tool call changed native content";
+      }
+    } else {
+      if (
+        item.name !== undefined ||
+        item.namespace !== undefined ||
+        item.execution !== "client" ||
+        !plainObject(item.arguments)
+      ) {
+        return "incomplete atomic tool search call";
+      }
+      if (sourceItem.type === "function_call") {
+        const sourceArguments = toolSearchArguments(sourceItem.arguments, false);
+        if (
+          sourceItem.name !== this.#lookups.toolSearch?.providerName ||
+          !sourceArguments ||
+          !isDeepStrictEqual(sourceArguments, item.arguments)
+        ) {
+          return "atomic tool search call was not restored consistently";
+        }
+      } else if (
+        sourceItem.execution !== item.execution ||
+        !isDeepStrictEqual(sourceItem.arguments, item.arguments)
+      ) {
+        return "atomic tool search call changed native content";
+      }
+    }
+
+    const conflict = this.#openingIdentityConflict(item);
+    if (conflict) return conflict;
+    if (this.#trackedCallCount >= this.#maxTrackedOutputItems) {
+      return "output item identity limit";
+    }
+    const state = {
+      kind,
+      itemId,
+      callId,
+      sourceType: sourceItem.type,
+      sourceName: sourceItem.name,
+      sourceNamespace: sourceItem.namespace,
+      outputType: item.type,
+      outputName: item.name,
+      outputNamespace: item.namespace,
+      argumentsDone: true,
+      finalInput: kind === "custom" ? item.input : undefined,
+      finalArguments: kind === "tool_search" ? item.arguments : undefined,
+      sawArgumentDelta: false,
+      deltaCharacters: 0,
+      deltaHash: undefined,
+      closed: true,
+      summarySeen,
+      deltaState: undefined,
+    };
+    if (itemId) this.#callsByItemId.set(itemId, state);
+    this.#callsByCallId.set(callId, state);
+    this.#trackedCallCount += 1;
+    return undefined;
+  }
+
+  #registerAtomicOutputItem(sourceItem, item, { summarySeen = false } = {}) {
+    const sourceKind = this.#sourceSpecialCallKind(sourceItem);
+    const outputKind = this.#specialCallKind(item);
+    if (sourceKind || outputKind) {
+      return this.#registerAtomicSpecialCall(sourceItem, item, { summarySeen });
+    }
+
+    // Ordinary items reserve the same id domains. Otherwise a done-only
+    // ordinary call could donate its call_id to a later special relay.
+    const itemId = typeof item?.id === "string" && item.id ? item.id : undefined;
+    const callId = typeof item?.call_id === "string" && item.call_id
+      ? item.call_id
+      : undefined;
+    const sourceItemId = typeof sourceItem?.id === "string" && sourceItem.id
+      ? sourceItem.id
+      : undefined;
+    const sourceCallId = typeof sourceItem?.call_id === "string" && sourceItem.call_id
+      ? sourceItem.call_id
+      : undefined;
+    const sourceHasItemId = Boolean(
+      sourceItem && typeof sourceItem === "object" && Object.hasOwn(sourceItem, "id"),
+    );
+    const outputHasItemId = Boolean(
+      item && typeof item === "object" && Object.hasOwn(item, "id"),
+    );
+    const sourceHasCallId = Boolean(
+      sourceItem && typeof sourceItem === "object" && Object.hasOwn(sourceItem, "call_id"),
+    );
+    const outputHasCallId = Boolean(
+      item && typeof item === "object" && Object.hasOwn(item, "call_id"),
+    );
+    if (
+      sourceItemId !== itemId ||
+      sourceCallId !== callId ||
+      sourceHasItemId !== outputHasItemId ||
+      sourceHasCallId !== outputHasCallId ||
+      (sourceHasItemId && !itemId) ||
+      (sourceHasCallId && !callId)
+    ) {
+      return "atomic output item lacks stable identity";
+    }
+    if (!itemId && !callId) return undefined;
+    const conflict = this.#openingIdentityConflict(item);
+    if (conflict) return conflict;
+    if (this.#trackedCallCount >= this.#maxTrackedOutputItems) {
+      return "output item identity limit";
+    }
+    const state = {
+      kind: undefined,
+      itemId,
+      callId,
+      sourceType: sourceItem?.type,
+      sourceName: sourceItem?.name,
+      sourceNamespace: sourceItem?.namespace,
+      outputType: item?.type,
+      outputName: item?.name,
+      outputNamespace: item?.namespace,
+      argumentsDone: true,
+      finalInput: undefined,
+      finalArguments: undefined,
+      sawArgumentDelta: false,
+      deltaCharacters: 0,
+      deltaHash: undefined,
+      closed: true,
+      summarySeen,
+      deltaState: undefined,
+    };
+    if (itemId) this.#callsByItemId.set(itemId, state);
+    if (callId) this.#callsByCallId.set(callId, state);
+    this.#trackedCallCount += 1;
+    return undefined;
+  }
+
+  #outputItemMatchesState(sourceItem, item, state) {
+    return (
+      sourceItem?.id === state.itemId &&
+      sourceItem?.call_id === state.callId &&
+      sourceItem?.type === state.sourceType &&
+      sourceItem?.name === state.sourceName &&
+      sourceItem?.namespace === state.sourceNamespace &&
+      item?.id === state.itemId &&
+      item?.call_id === state.callId &&
+      item?.type === state.outputType &&
+      item?.name === state.outputName &&
+      item?.namespace === state.outputNamespace
+    );
   }
 
   #specialCallForArgumentsEvent(event) {
@@ -2656,7 +2881,7 @@ export class NamespaceToolCallTransform extends Transform {
       : "custom tool argument deltas disagree with completed input";
   }
 
-  #closeSpecialCall(sourceItem, item) {
+  #closeOutputItem(sourceItem, item) {
     const byItemId =
       typeof sourceItem?.id === "string"
         ? this.#callsByItemId.get(sourceItem.id)
@@ -2669,24 +2894,20 @@ export class NamespaceToolCallTransform extends Transform {
       return "conflicting special tool call close identity";
     }
     const state = byItemId || byCallId;
+    const sourceKind = this.#sourceSpecialCallKind(sourceItem);
     const outputKind = this.#specialCallKind(item);
-    if (!state || !state.kind) {
-      return outputKind ? "special tool call close without a matching opening" : undefined;
+    if (!state) {
+      return this.#registerAtomicOutputItem(sourceItem, item);
     }
-    if (state.closed) return "duplicate special tool call close";
-    if (sourceItem?.id !== state.itemId || sourceItem?.call_id !== state.callId) {
-      return "mismatched special tool call close identity";
+    if (state.closed) return "duplicate output item close";
+    if (!this.#outputItemMatchesState(sourceItem, item, state)) {
+      return state.kind || sourceKind || outputKind
+        ? "mismatched special tool call close identity"
+        : "mismatched output item close identity";
     }
-    if (sourceItem.type !== state.sourceType || sourceItem.name !== state.sourceName) {
-      return "mismatched special tool call close source";
-    }
-    if (
-      item?.id !== state.itemId ||
-      item?.call_id !== state.callId ||
-      item?.type !== state.outputType ||
-      item?.name !== state.outputName
-    ) {
-      return "special tool call close was not restored consistently";
+    if (!state.kind) {
+      state.closed = true;
+      return undefined;
     }
     if (state.kind === "custom") {
       if (state.argumentsDone && item.input !== state.finalInput) {
@@ -2710,7 +2931,7 @@ export class NamespaceToolCallTransform extends Transform {
     return undefined;
   }
 
-  #validateSpecialSummaryItem(sourceItem, item) {
+  #validateOutputSummaryItem(sourceItem, item, { allowAtomic = false } = {}) {
     const byItemId =
       typeof sourceItem?.id === "string"
         ? this.#callsByItemId.get(sourceItem.id)
@@ -2723,26 +2944,27 @@ export class NamespaceToolCallTransform extends Transform {
       return "conflicting special tool call summary identity";
     }
     const state = byItemId || byCallId;
+    const sourceKind = this.#sourceSpecialCallKind(sourceItem);
     const outputKind = this.#specialCallKind(item);
-    if (!state || !state.kind) {
-      return outputKind ? "special tool call summary without a matching opening" : undefined;
+    if (!state) {
+      if (!allowAtomic) {
+        return sourceKind || outputKind
+          ? "special tool call summary without a matching opening"
+          : undefined;
+      }
+      return this.#registerAtomicOutputItem(sourceItem, item, { summarySeen: true });
     }
-    if (!state.closed) return "special tool call summary before close";
-    if (
-      sourceItem?.id !== state.itemId ||
-      sourceItem?.call_id !== state.callId ||
-      sourceItem?.type !== state.sourceType ||
-      sourceItem?.name !== state.sourceName
-    ) {
-      return "mismatched special tool call summary source";
+    if (!state.closed && state.kind) return "special tool call summary before close";
+    if (state.summarySeen) return "duplicate output item summary";
+    if (!this.#outputItemMatchesState(sourceItem, item, state)) {
+      return state.kind || sourceKind || outputKind
+        ? "mismatched special tool call summary identity"
+        : "mismatched output item summary identity";
     }
-    if (
-      item?.id !== state.itemId ||
-      item?.call_id !== state.callId ||
-      item?.type !== state.outputType ||
-      item?.name !== state.outputName
-    ) {
-      return "special tool call summary was not restored consistently";
+    if (!state.kind) {
+      state.closed = true;
+      state.summarySeen = true;
+      return undefined;
     }
     if (state.kind === "custom" && item.input !== state.finalInput) {
       return "custom tool call summary input changed after close";
@@ -2753,17 +2975,20 @@ export class NamespaceToolCallTransform extends Transform {
     ) {
       return "tool search arguments changed after close";
     }
+    state.summarySeen = true;
     return undefined;
   }
 
-  #validateSpecialOutputItems(sourceEvent, event) {
+  #validateOutputItems(sourceEvent, event, { allowAtomic = false } = {}) {
     for (const [sourceOutput, output] of [
       [sourceEvent?.output, event?.output],
       [sourceEvent?.response?.output, event?.response?.output],
     ]) {
       if (!Array.isArray(sourceOutput) || !Array.isArray(output)) continue;
       for (let index = 0; index < sourceOutput.length; index += 1) {
-        const reason = this.#validateSpecialSummaryItem(sourceOutput[index], output[index]);
+        const reason = this.#validateOutputSummaryItem(sourceOutput[index], output[index], {
+          allowAtomic,
+        });
         if (reason) return reason;
       }
     }
@@ -2960,16 +3185,18 @@ export class NamespaceToolCallTransform extends Transform {
         if (reason) return this.#unsafeSseFrame(frame, reason);
       }
       if (sourceEvent?.type === "response.output_item.done") {
-        const reason = this.#closeSpecialCall(sourceEvent.item, event.item);
+        const reason = this.#closeOutputItem(sourceEvent.item, event.item);
         if (reason) return this.#unsafeSseFrame(frame, reason);
       }
-      const summaryReason = this.#validateSpecialOutputItems(sourceEvent, event);
-      if (summaryReason) return this.#unsafeSseFrame(frame, summaryReason);
       const terminalEvent =
         event?.type === "response.completed" ||
         event?.type === "response.done" ||
         eventName === "response.completed" ||
         eventName === "response.done";
+      const summaryReason = this.#validateOutputItems(sourceEvent, event, {
+        allowAtomic: terminalEvent,
+      });
+      if (summaryReason) return this.#unsafeSseFrame(frame, summaryReason);
       if (terminalEvent) {
         if (this.#hasOpenSpecialCalls()) {
           return this.#unsafeSseFrame(frame, "terminal event before special tool call close");

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -1,6 +1,6 @@
+import { isUtf8 } from "node:buffer";
 import { createHash } from "node:crypto";
 import { Transform } from "node:stream";
-import { StringDecoder } from "node:string_decoder";
 
 import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 import { coerceFunctionCallArguments } from "./tool-arguments.mjs";
@@ -12,7 +12,6 @@ import {
 import {
   buildInterruptAgentCall,
   filterAlreadyInterrupted,
-  formatSseBlock,
   interruptTargetFromCall,
 } from "./subagent-completion.mjs";
 
@@ -485,6 +484,7 @@ export function injectSessionModelForSpawnCalls(item, model) {
   if (!isSpawnModelCall(item)) return item;
   if (typeof model !== "string" || !model) return item;
   if (typeof item.arguments !== "string") return item;
+  if (!jsonArgumentsAreUnambiguous(item.arguments, { allowEmpty: true })) return item;
   let args;
   try {
     args = JSON.parse(item.arguments);
@@ -498,6 +498,234 @@ export function injectSessionModelForSpawnCalls(item, model) {
 }
 
 const MAX_JSON_CAPTURE_BYTES = 64 * 1024 * 1024;
+// Stop staging an undecided SSE frame before downstream response guards lose
+// sight of their own byte ceilings. Before any semantic output, crossing this
+// bound releases raw bytes and disables rewriting; after one rewrite,
+// suppression, or injection, it terminates the stream rather than mixing wire
+// representations.
+const MAX_SSE_FRAME_BYTES = 256 * 1024;
+const MAX_EXACT_JSON_NUMBER_LENGTH = 4096;
+const LINE_FEED = 0x0a;
+const CARRIAGE_RETURN = 0x0d;
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+const JSON_NUMBER_PREFIX = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/;
+const JSON_NUMBER_PARTS =
+  /^(-?)(0|[1-9]\d*)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/;
+
+function sseFieldValue(line, prefixLength) {
+  const value = line.slice(prefixLength);
+  // The SSE grammar removes one optional U+0020 after the colon. Tabs,
+  // repeated spaces, and trailing spaces are event data, not formatting.
+  return value.startsWith(" ") ? value.slice(1) : value;
+}
+
+function isSseField(line, name) {
+  return line === name || line.startsWith(`${name}:`);
+}
+
+function sseLineFieldValue(line, name) {
+  return line === name ? "" : sseFieldValue(line, name.length + 1);
+}
+
+// Normalize a bounded JSON number as exact decimal coefficient + power. This
+// compares mathematical decimal values rather than spellings, so 1.0 and 1e3
+// can survive a rewrite when JSON.stringify emits 1 and 1000 respectively,
+// while underflow and rounded high-precision tokens cannot.
+function canonicalDecimalToken(token) {
+  if (typeof token !== "string" || token.length > MAX_EXACT_JSON_NUMBER_LENGTH) {
+    return undefined;
+  }
+  const match = JSON_NUMBER_PARTS.exec(token);
+  if (!match) return undefined;
+  const [, sign, integer, fraction = "", exponentText = "0"] = match;
+  let digits = integer + fraction;
+  if (/^0+$/u.test(digits)) return sign === "-" ? "-0" : "0";
+
+  const exponentSign = exponentText.startsWith("-") ? -1 : 1;
+  const unsignedExponent = exponentText.replace(/^[+-]/u, "");
+  const significantExponent = unsignedExponent.replace(/^0+/u, "") || "0";
+  // A non-zero finite Number cannot retain an exponent remotely this large;
+  // bounding it also prevents attacker-controlled giant integer arithmetic.
+  if (significantExponent.length > 6) return undefined;
+  let exponent = exponentSign * Number(significantExponent) - fraction.length;
+
+  digits = digits.replace(/^0+/u, "");
+  const trailingZeros = /0+$/u.exec(digits)?.[0].length || 0;
+  if (trailingZeros) {
+    digits = digits.slice(0, -trailingZeros);
+    exponent += trailingZeros;
+  }
+  return `${sign}${digits}e${exponent}`;
+}
+
+function jsonNumberIsStableForRewrite(token) {
+  if (token.length > MAX_EXACT_JSON_NUMBER_LENGTH) return false;
+  const parsed = Number(token);
+  if (
+    !Number.isFinite(parsed) ||
+    Object.is(parsed, -0) ||
+    (Number.isInteger(parsed) && !Number.isSafeInteger(parsed))
+  ) {
+    return false;
+  }
+  const original = canonicalDecimalToken(token);
+  const serialized = canonicalDecimalToken(JSON.stringify(parsed));
+  return original !== undefined && original === serialized;
+}
+
+// JSON.parse deliberately accepts duplicate object members and keeps the last
+// one. That is useful for ordinary application input, but unsafe at a rewrite
+// boundary: the bytes can name one tool first and another tool last, while a
+// downstream parser is free to make the opposite choice. Parsing also rounds
+// unsafe integers and accepts overflowing exponents that stringify as null.
+// Audit the complete JSON grammar before parsing, compare decoded key values
+// so spellings such as `"name"` and `"\u006eame"` collide, and reject numeric
+// values whose parse/stringify semantics are known to be lossy.
+function jsonIsUnambiguousForRewrite(text) {
+  if (typeof text !== "string") return false;
+  let offset = 0;
+
+  const skipWhitespace = () => {
+    while (
+      offset < text.length &&
+      (text[offset] === " " ||
+        text[offset] === "\t" ||
+        text[offset] === "\r" ||
+        text[offset] === "\n")
+    ) {
+      offset += 1;
+    }
+  };
+
+  const stringToken = () => {
+    if (text[offset] !== '"') return undefined;
+    const start = offset;
+    offset += 1;
+    while (offset < text.length) {
+      const code = text.charCodeAt(offset);
+      const character = text[offset];
+      if (character === '"') {
+        offset += 1;
+        return text.slice(start, offset);
+      }
+      if (code < 0x20) return undefined;
+      if (character !== "\\") {
+        offset += 1;
+        continue;
+      }
+      offset += 1;
+      const escape = text[offset];
+      if (escape === "u") {
+        const digits = text.slice(offset + 1, offset + 5);
+        if (digits.length !== 4 || !/^[0-9a-fA-F]{4}$/.test(digits)) return undefined;
+        offset += 5;
+        continue;
+      }
+      if (!['"', "\\", "/", "b", "f", "n", "r", "t"].includes(escape)) {
+        return undefined;
+      }
+      offset += 1;
+    }
+    return undefined;
+  };
+
+  const literal = (value) => {
+    if (!text.startsWith(value, offset)) return false;
+    offset += value.length;
+    return true;
+  };
+
+  const number = () => {
+    const match = JSON_NUMBER_PREFIX.exec(text.slice(offset));
+    if (!match) return false;
+    if (!jsonNumberIsStableForRewrite(match[0])) return false;
+    offset += match[0].length;
+    return true;
+  };
+
+  const value = () => {
+    skipWhitespace();
+    const character = text[offset];
+    if (character === "{") return object();
+    if (character === "[") return array();
+    if (character === '"') return stringToken() !== undefined;
+    if (character === "t") return literal("true");
+    if (character === "f") return literal("false");
+    if (character === "n") return literal("null");
+    return number();
+  };
+
+  const object = () => {
+    offset += 1;
+    skipWhitespace();
+    if (text[offset] === "}") {
+      offset += 1;
+      return true;
+    }
+    const keys = new Set();
+    while (offset < text.length) {
+      skipWhitespace();
+      const token = stringToken();
+      if (token === undefined) return false;
+      let key;
+      try {
+        key = JSON.parse(token);
+      } catch {
+        return false;
+      }
+      if (keys.has(key)) return false;
+      keys.add(key);
+      skipWhitespace();
+      if (text[offset] !== ":") return false;
+      offset += 1;
+      if (!value()) return false;
+      skipWhitespace();
+      if (text[offset] === "}") {
+        offset += 1;
+        return true;
+      }
+      if (text[offset] !== ",") return false;
+      offset += 1;
+    }
+    return false;
+  };
+
+  const array = () => {
+    offset += 1;
+    skipWhitespace();
+    if (text[offset] === "]") {
+      offset += 1;
+      return true;
+    }
+    while (offset < text.length) {
+      if (!value()) return false;
+      skipWhitespace();
+      if (text[offset] === "]") {
+        offset += 1;
+        return true;
+      }
+      if (text[offset] !== ",") return false;
+      offset += 1;
+    }
+    return false;
+  };
+
+  try {
+    if (!value()) return false;
+    skipWhitespace();
+    return offset === text.length;
+  } catch {
+    // Excessive nesting and any other scanner failure are ambiguity, not
+    // permission to fall back to JSON.parse's lossy interpretation.
+    return false;
+  }
+}
+
+function jsonArgumentsAreUnambiguous(value, { allowEmpty = false } = {}) {
+  if (typeof value !== "string") return true;
+  if (allowEmpty && value.trim() === "") return true;
+  return jsonIsUnambiguousForRewrite(value);
+}
 
 // Repair one tool's parameter root, or return it untouched. Providers reject a
 // union or nullable-object root by name -- xAI, DeepSeek V4, and the
@@ -1491,6 +1719,7 @@ function sanitizeSpawnAgentModel(item, lookups) {
   if (!(allowed instanceof Set) || allowed.size === 0 || typeof item.arguments !== "string") {
     return item;
   }
+  if (!jsonArgumentsAreUnambiguous(item.arguments)) return item;
   let args;
   try {
     args = JSON.parse(item.arguments);
@@ -1510,6 +1739,7 @@ function sanitizeSpawnAgentModel(item, lookups) {
 // rather than guessing which runtime owns it.
 function rewriteFunctionCallArguments(item) {
   if (!item || typeof item !== "object") return item;
+  if (!jsonArgumentsAreUnambiguous(item.arguments, { allowEmpty: true })) return item;
   const argumentsText = coerceFunctionCallArguments(item.arguments);
   if (argumentsText === item.arguments) return item;
   return { ...item, arguments: argumentsText };
@@ -1519,6 +1749,7 @@ function toolSearchArguments(value, allowPlaceholder) {
   if (plainObject(value)) return value;
   if (typeof value !== "string") return undefined;
   if (allowPlaceholder && value.trim() === "") return {};
+  if (!jsonArgumentsAreUnambiguous(value)) return undefined;
   try {
     return plainObject(JSON.parse(value));
   } catch {
@@ -1560,6 +1791,7 @@ function customToolInput(value, allowPlaceholder = false) {
   if (allowPlaceholder && (value === undefined || value === "")) return "";
   const argumentsText = coerceFunctionCallArguments(value);
   if (typeof argumentsText !== "string") return undefined;
+  if (!jsonArgumentsAreUnambiguous(argumentsText)) return undefined;
   try {
     const parsed = JSON.parse(argumentsText);
     return typeof parsed?.[CUSTOM_TOOL_INPUT_PROPERTY] === "string"
@@ -1604,6 +1836,7 @@ function rewriteNamespaceFunctionCallItem(
   { allowIncompleteToolSearch = false } = {},
 ) {
   if (!item || item.type !== "function_call") return undefined;
+  if (!jsonArgumentsAreUnambiguous(item.arguments, { allowEmpty: true })) return undefined;
   const exactPlainProviderIdentity =
     lookups.identityAliases &&
     item.namespace === undefined &&
@@ -1673,6 +1906,24 @@ function rewriteOutputItems(output, lookups, sessionModel) {
   return changed ? rewritten : undefined;
 }
 
+function embeddedFunctionArgumentsAreUnambiguous(payload) {
+  const safeItem = (item) =>
+    item?.type !== "function_call" ||
+    jsonArgumentsAreUnambiguous(item.arguments, { allowEmpty: true });
+  if (!safeItem(payload?.item)) return false;
+  if (
+    payload?.type === "response.function_call_arguments.done" &&
+    !jsonArgumentsAreUnambiguous(payload.arguments, { allowEmpty: true })
+  ) {
+    return false;
+  }
+  for (const output of [payload?.output, payload?.response?.output]) {
+    if (!Array.isArray(output)) continue;
+    if (!output.every(safeItem)) return false;
+  }
+  return true;
+}
+
 // Non-streaming Responses return completed function calls in an `output`
 // array instead of SSE `item` events. Restore both shapes through the same
 // exact request-local lookup so stream mode cannot change dispatch semantics.
@@ -1683,7 +1934,11 @@ export function rewriteNamespaceResponsePayload(payload, lookups, sessionModel) 
   let changed = rewritten !== payload;
 
   if (payload.type === "response.function_call_arguments.done") {
-    const argumentsText = coerceFunctionCallArguments(rewritten.arguments);
+    const argumentsText = jsonArgumentsAreUnambiguous(rewritten.arguments, {
+      allowEmpty: true,
+    })
+      ? coerceFunctionCallArguments(rewritten.arguments)
+      : rewritten.arguments;
     if (argumentsText !== rewritten.arguments) {
       rewritten = { ...rewritten, arguments: argumentsText };
       changed = true;
@@ -1821,15 +2076,35 @@ function customToolInputDelta(state, fragment) {
   return decoded.length ? decoded.join("") : undefined;
 }
 
+class NamespaceRelayCommittedStreamError extends Error {
+  constructor(reason) {
+    super(
+      `The provider response became unsafe to relay after namespace output was committed (${reason}).`,
+    );
+    this.name = "NamespaceRelayCommittedStreamError";
+    this.code = "ERR_NAMESPACE_RELAY_COMMITTED_STREAM";
+    this.status = 502;
+  }
+}
+
 // Rewrites LiteLLM's flattened `<namespace>__<tool>` function calls back to
 // the namespace + name shape Codex dispatches through its app runtime.
 export class NamespaceToolCallTransform extends Transform {
   #eventStream;
-  #decoder = new StringDecoder("utf8");
-  #buffer = "";
   #pending = Buffer.alloc(0);
   #released = false;
   #headerlessDetector;
+  #sseParts = [];
+  #sseBytes = 0;
+  #sseLineBytes = 0;
+  #ssePendingCr = false;
+  #ssePendingLineWasBlank = false;
+  #sseAtStreamStart = true;
+  #sseLineEnding = "\n";
+  #sseLineEndingObserved = false;
+  #maxSseFrameBytes;
+  #rewriteDisabled = false;
+  #semanticMutationCommitted = false;
   #lookups;
   #sessionModel;
   #pendingInterrupts;
@@ -1855,6 +2130,10 @@ export class NamespaceToolCallTransform extends Transform {
     // must not run the namespace rewrites (they exist for routed providers)
     // or re-serialize model-authored events it did not change.
     this.#injectOnly = Boolean(options.injectOnly);
+    this.#maxSseFrameBytes =
+      Number.isInteger(options.maxSseFrameBytes) && options.maxSseFrameBytes > 0
+        ? options.maxSseFrameBytes
+        : MAX_SSE_FRAME_BYTES;
     const declared = String(contentType).toLowerCase();
     this.#eventStream = declared.includes("text/event-stream");
     this.#headerlessDetector =
@@ -1864,29 +2143,32 @@ export class NamespaceToolCallTransform extends Transform {
   }
 
   _transform(chunk, _encoding, callback) {
-    if (this.#headerlessDetector) {
-      const detected = this.#headerlessDetector.write(chunk);
-      if (detected.decision === "pending") {
-        callback();
-        return;
+    let error;
+    try {
+      if (this.#headerlessDetector) {
+        const detected = this.#headerlessDetector.write(chunk);
+        if (detected.decision !== "pending") {
+          this.#headerlessDetector = undefined;
+          this.#eventStream = detected.decision === "event-stream";
+          for (const buffered of detected.chunks) this.#transformChunk(buffered);
+        }
+      } else {
+        this.#transformChunk(chunk);
       }
-      this.#headerlessDetector = undefined;
-      this.#eventStream = detected.decision === "event-stream";
-      for (const buffered of detected.chunks) this.#transformChunk(buffered);
-      callback();
-      return;
+    } catch (caught) {
+      error = caught;
     }
-    this.#transformChunk(chunk);
-    callback();
+    callback(error);
   }
 
   #transformChunk(chunk) {
+    const bytes = Buffer.from(chunk);
     if (!this.#eventStream) {
       if (this.#released) {
-        this.push(chunk);
+        this.push(bytes);
         return;
       }
-      this.#pending = this.#pending.length ? Buffer.concat([this.#pending, chunk]) : chunk;
+      this.#pending = this.#pending.length ? Buffer.concat([this.#pending, bytes]) : bytes;
       if (this.#pending.length > MAX_JSON_CAPTURE_BYTES) {
         this.push(this.#pending);
         this.#pending = Buffer.alloc(0);
@@ -1894,11 +2176,24 @@ export class NamespaceToolCallTransform extends Transform {
       }
       return;
     }
-    this.#buffer += this.#decoder.write(chunk);
-    this.#emitCompleteEvents();
+    if (this.#rewriteDisabled) {
+      this.push(bytes);
+      return;
+    }
+    this.#consumeSseChunk(bytes);
   }
 
   _flush(callback) {
+    let error;
+    try {
+      this.#flushTransform();
+    } catch (caught) {
+      error = caught;
+    }
+    callback(error);
+  }
+
+  #flushTransform() {
     if (this.#headerlessDetector) {
       const detected = this.#headerlessDetector.end();
       this.#headerlessDetector = undefined;
@@ -1910,82 +2205,328 @@ export class NamespaceToolCallTransform extends Transform {
       this.#pending = Buffer.alloc(0);
       if (this.#released || !body.length) {
         if (body.length) this.push(body);
-        callback();
         return;
       }
+      if (!isUtf8(body)) {
+        this.push(body);
+        return;
+      }
+      const text = body.toString("utf8");
+      if (!jsonIsUnambiguousForRewrite(text)) {
+        this.push(body);
+        return;
+      }
+      let original;
       try {
-        const original = JSON.parse(body.toString("utf8"));
-        let payload = original;
-        if (!this.#injectOnly) {
-          const rewritten = rewriteNamespaceResponsePayload(
-            payload,
-            this.#lookups,
-            this.#sessionModel,
-          );
-          if (rewritten) payload = rewritten;
-        }
-        payload = this.#injectJsonInterrupts(payload);
-        // An inject-only relay that injected nothing returns the exact bytes
-        // it was handed rather than a re-serialization of them.
-        if (this.#injectOnly && payload === original) {
-          this.push(body);
-        } else {
-          this.push(Buffer.from(JSON.stringify(payload), "utf8"));
-        }
+        original = JSON.parse(text);
       } catch {
         this.push(body);
+        return;
       }
-      callback();
+      if (!embeddedFunctionArgumentsAreUnambiguous(original)) {
+        this.push(body);
+        return;
+      }
+      let payload = original;
+      if (!this.#injectOnly) {
+        const rewritten = rewriteNamespaceResponsePayload(
+          payload,
+          this.#lookups,
+          this.#sessionModel,
+        );
+        if (rewritten) payload = rewritten;
+      }
+      payload = this.#injectJsonInterrupts(payload);
+      // Parsing is only permission to inspect. A response the transform did
+      // not semantically change retains its exact original representation.
+      if (payload !== original) this.#commitSemanticMutation();
+      this.push(payload === original ? body : Buffer.from(JSON.stringify(payload), "utf8"));
       return;
     }
-    this.#buffer += this.#decoder.end();
-    this.#emitCompleteEvents(true);
-    // Streams that omit response.completed / [DONE] still need the closes.
-    for (const piece of this.#drainInterruptBlocks()) {
-      this.push(Buffer.from(piece));
-      if (!piece.endsWith("\n\n")) this.push(Buffer.from("\n\n"));
+    if (this.#ssePendingCr && !this.#rewriteDisabled) {
+      const blankLine = this.#ssePendingLineWasBlank;
+      this.#ssePendingCr = false;
+      this.#ssePendingLineWasBlank = false;
+      this.#completeSseLine(blankLine);
     }
-    callback();
+    if (!this.#rewriteDisabled && this.#sseBytes) {
+      this.#emitSseFrame(this.#takeSseFrame());
+    }
+    // Streams that omit response.completed / [DONE] still need the closes,
+    // unless an ambiguous frame made observing prior calls unsafe.
+    if (!this.#rewriteDisabled) {
+      for (const piece of this.#drainInterruptBlocks()) this.push(piece);
+    }
   }
 
-  #emitCompleteEvents(flush = false) {
-    const blocks = this.#buffer.split(/\r?\n\r?\n/);
-    this.#buffer = flush ? "" : blocks.pop() || "";
-    for (const block of blocks) {
-      const pieces = this.#rewriteBlock(block);
-      for (const piece of pieces) {
-        this.push(Buffer.from(piece));
-        if (!piece.endsWith("\n\n")) this.push(Buffer.from("\n\n"));
+  #consumeSseChunk(chunk) {
+    let offset = 0;
+    if (this.#ssePendingCr) {
+      const followedByLf = chunk[0] === LINE_FEED;
+      if (followedByLf) {
+        if (!this.#appendSsePiece(chunk.subarray(0, 1))) {
+          if (chunk.length > 1) this.push(chunk.subarray(1));
+          return;
+        }
+        offset = 1;
+      }
+      const blankLine = this.#ssePendingLineWasBlank;
+      this.#ssePendingCr = false;
+      this.#ssePendingLineWasBlank = false;
+      this.#completeSseLine(blankLine);
+      if (this.#rewriteDisabled) {
+        if (offset < chunk.length) this.push(chunk.subarray(offset));
+        return;
+      }
+    }
+
+    while (offset < chunk.length) {
+      const nextCr = chunk.indexOf(CARRIAGE_RETURN, offset);
+      const nextLf = chunk.indexOf(LINE_FEED, offset);
+      let lineEnd;
+      if (nextCr === -1) lineEnd = nextLf;
+      else if (nextLf === -1) lineEnd = nextCr;
+      else lineEnd = Math.min(nextCr, nextLf);
+
+      if (lineEnd === -1) {
+        const content = chunk.subarray(offset);
+        this.#sseLineBytes += content.length;
+        this.#appendSsePiece(content);
+        return;
+      }
+      if (lineEnd > offset) {
+        const content = chunk.subarray(offset, lineEnd);
+        this.#sseLineBytes += content.length;
+        if (!this.#appendSsePiece(content)) {
+          this.push(chunk.subarray(lineEnd));
+          return;
+        }
+      }
+
+      const blankLine = this.#sseLineBytes === 0;
+      if (chunk[lineEnd] === CARRIAGE_RETURN) {
+        if (!this.#appendSsePiece(chunk.subarray(lineEnd, lineEnd + 1))) {
+          if (lineEnd + 1 < chunk.length) this.push(chunk.subarray(lineEnd + 1));
+          return;
+        }
+        if (lineEnd + 1 === chunk.length) {
+          this.#ssePendingCr = true;
+          this.#ssePendingLineWasBlank = blankLine;
+          this.#sseLineBytes = 0;
+          return;
+        }
+        if (chunk[lineEnd + 1] === LINE_FEED) {
+          if (!this.#appendSsePiece(chunk.subarray(lineEnd + 1, lineEnd + 2))) {
+            if (lineEnd + 2 < chunk.length) this.push(chunk.subarray(lineEnd + 2));
+            return;
+          }
+          offset = lineEnd + 2;
+        } else {
+          offset = lineEnd + 1;
+        }
+      } else {
+        if (!this.#appendSsePiece(chunk.subarray(lineEnd, lineEnd + 1))) {
+          if (lineEnd + 1 < chunk.length) this.push(chunk.subarray(lineEnd + 1));
+          return;
+        }
+        offset = lineEnd + 1;
+      }
+      this.#completeSseLine(blankLine);
+      if (this.#rewriteDisabled) {
+        if (offset < chunk.length) this.push(chunk.subarray(offset));
+        return;
       }
     }
   }
 
-  #rewriteBlock(block) {
-    const lines = block.split(/\r?\n/);
-    const eventName = lines
-      .find((line) => line.startsWith("event:"))
-      ?.slice(6)
-      .trim();
-    let dataLineIndex = -1;
-    let dataText = "";
-    for (let index = 0; index < lines.length; index += 1) {
+  #appendSsePiece(piece) {
+    if (!piece.length) return true;
+    this.#sseParts.push(piece);
+    this.#sseBytes += piece.length;
+    if (this.#sseBytes <= this.#maxSseFrameBytes) return true;
+    const buffered = this.#takeSseFrame();
+    if (this.#semanticMutationCommitted) {
+      throw new NamespaceRelayCommittedStreamError("SSE frame byte limit");
+    }
+    this.#disableSseRewriting();
+    this.push(buffered);
+    return false;
+  }
+
+  #completeSseLine(blankLine) {
+    this.#sseLineBytes = 0;
+    if (blankLine) this.#emitSseFrame(this.#takeSseFrame());
+  }
+
+  #takeSseFrame() {
+    const frame =
+      this.#sseParts.length === 1
+        ? this.#sseParts[0]
+        : Buffer.concat(this.#sseParts, this.#sseBytes);
+    this.#sseParts = [];
+    this.#sseBytes = 0;
+    this.#sseLineBytes = 0;
+    this.#ssePendingCr = false;
+    this.#ssePendingLineWasBlank = false;
+    return frame;
+  }
+
+  #sseLines(frame) {
+    const lines = [];
+    let start = 0;
+    while (start < frame.length) {
+      const nextCr = frame.indexOf(CARRIAGE_RETURN, start);
+      const nextLf = frame.indexOf(LINE_FEED, start);
+      let contentEnd;
+      if (nextCr === -1) contentEnd = nextLf;
+      else if (nextLf === -1) contentEnd = nextCr;
+      else contentEnd = Math.min(nextCr, nextLf);
+      if (contentEnd === -1) {
+        lines.push({
+          start,
+          parseStart: start,
+          contentEnd: frame.length,
+          end: frame.length,
+        });
+        break;
+      }
+      const end =
+        frame[contentEnd] === CARRIAGE_RETURN && frame[contentEnd + 1] === LINE_FEED
+          ? contentEnd + 2
+          : contentEnd + 1;
+      lines.push({ start, parseStart: start, contentEnd, end });
+      start = end;
+    }
+    return lines;
+  }
+
+  #rememberSseLineEnding(frame, lines) {
+    if (this.#sseLineEndingObserved) return;
+    for (const line of lines) {
+      if (line.end === line.contentEnd) continue;
+      const terminator = frame.subarray(line.contentEnd, line.end);
+      if (terminator.equals(Buffer.from("\r\n"))) this.#sseLineEnding = "\r\n";
+      else if (terminator.equals(Buffer.from("\n"))) this.#sseLineEnding = "\n";
+      else if (terminator.equals(Buffer.from("\r"))) this.#sseLineEnding = "\r";
+      else continue;
+      this.#sseLineEndingObserved = true;
+      return;
+    }
+  }
+
+  #emitSseFrame(frame) {
+    for (const piece of this.#rewriteSseFrame(frame)) this.push(piece);
+  }
+
+  #commitSemanticMutation() {
+    this.#semanticMutationCommitted = true;
+  }
+
+  #unsafeSseFrame(frame, reason) {
+    if (this.#semanticMutationCommitted) {
+      throw new NamespaceRelayCommittedStreamError(reason);
+    }
+    this.#disableSseRewriting();
+    return [frame];
+  }
+
+  #disableSseRewriting() {
+    this.#rewriteDisabled = true;
+    this.#injectionsDone = true;
+    this.#lastInjectedCalls = [];
+    this.#customItemIds.clear();
+    this.#customDeltaStates.clear();
+  }
+
+  #rewrittenSseFrame(frame, lines, replacements) {
+    const pieces = [];
+    let cursor = 0;
+    for (const [index, replacement] of [...replacements].sort(
+      ([left], [right]) => left - right,
+    )) {
       const line = lines[index];
-      if (!line.startsWith("data:")) continue;
-      dataLineIndex = index;
-      dataText = line.slice(5).trimStart();
-      break;
-    }
-    if (dataLineIndex === -1) return [block];
-    if (!dataText || dataText === "[DONE]") {
-      // Inject before the stream terminator so Codex still executes the calls.
-      if (dataText === "[DONE]" || eventName === "response.done") {
-        return [...this.#drainInterruptBlocks(), block];
+      if (!line) continue;
+      if (line.start > cursor) pieces.push(frame.subarray(cursor, line.start));
+      if (line.parseStart > line.start) {
+        pieces.push(frame.subarray(line.start, line.parseStart));
       }
-      return [block];
+      pieces.push(Buffer.from(replacement, "utf8"));
+      cursor = line.contentEnd;
+    }
+    if (cursor < frame.length) pieces.push(frame.subarray(cursor));
+    return Buffer.concat(pieces);
+  }
+
+  #rewriteSseFrame(frame) {
+    const atStreamStart = this.#sseAtStreamStart;
+    this.#sseAtStreamStart = false;
+    // No decoder is allowed to see an undecided frame. Its replacement
+    // character would make fail-open lossy before we knew whether to rewrite.
+    if (!isUtf8(frame)) {
+      return this.#unsafeSseFrame(frame, "invalid UTF-8");
+    }
+    const lines = this.#sseLines(frame);
+    if (atStreamStart && frame.subarray(0, UTF8_BOM.length).equals(UTF8_BOM) && lines[0]) {
+      lines[0].parseStart += UTF8_BOM.length;
+    }
+    this.#rememberSseLineEnding(frame, lines);
+    const lineTexts = lines.map((line) =>
+      frame.subarray(line.parseStart, line.contentEnd).toString("utf8"),
+    );
+    const eventLineIndexes = lineTexts
+      .map((line, index) => (isSseField(line, "event") ? index : -1))
+      .filter((index) => index !== -1);
+    const dataLineIndexes = lineTexts
+      .map((line, index) => (isSseField(line, "data") ? index : -1))
+      .filter((index) => index !== -1);
+    // SSE formally concatenates multiple data fields and gives repeated event
+    // fields ordering semantics. Rewriting just one field would create bytes
+    // whose EventSource meaning differs from the JSON we inspected. The
+    // Responses wire uses exactly one of each, so anything else is preserved
+    // and disables stateful rewriting for the remainder of this response.
+    if (eventLineIndexes.length > 1 || dataLineIndexes.length > 1) {
+      return this.#unsafeSseFrame(frame, "repeated SSE event or data field");
+    }
+    const eventLineIndex = eventLineIndexes[0] ?? -1;
+    const eventName =
+      eventLineIndex === -1
+        ? undefined
+        : sseLineFieldValue(lineTexts[eventLineIndex], "event");
+    const dataLineIndex = dataLineIndexes[0] ?? -1;
+    const dataText =
+      dataLineIndex === -1 ? "" : sseLineFieldValue(lineTexts[dataLineIndex], "data");
+    if (dataLineIndex === -1) return [frame];
+    if (!dataText || dataText === "[DONE]") {
+      if (eventName && eventName !== "message") {
+        return this.#unsafeSseFrame(
+          frame,
+          "non-generic SSE event without a matching JSON type",
+        );
+      }
+      // Inject before the stream terminator so Codex still executes the calls.
+      if (dataText === "[DONE]") {
+        return [...this.#drainInterruptBlocks(), frame];
+      }
+      return [frame];
+    }
+    if (!jsonIsUnambiguousForRewrite(dataText)) {
+      return this.#unsafeSseFrame(frame, "ambiguous or malformed JSON event");
     }
     try {
       let event = JSON.parse(dataText);
+      const payloadType = event?.type;
+      const genericEventName = !eventName || eventName === "message";
+      if (!genericEventName && payloadType !== eventName) {
+        // The event field and JSON body are two claims about the same Responses
+        // event. Do not choose whichever terminal/rewrite behavior is more
+        // convenient when both claims are present and disagree.
+        return this.#unsafeSseFrame(frame, "conflicting SSE event and JSON type");
+      }
+      if (!embeddedFunctionArgumentsAreUnambiguous(event)) {
+        return this.#unsafeSseFrame(frame, "ambiguous function arguments");
+      }
       const originalEventType = event?.type;
+      let changed = false;
       if (
         !this.#injectOnly &&
         event?.type === "response.function_call_arguments.delta" &&
@@ -1993,12 +2534,16 @@ export class NamespaceToolCallTransform extends Transform {
       ) {
         const state = this.#customDeltaStates.get(event.item_id);
         const delta = state ? customToolInputDelta(state, event.delta) : undefined;
-        if (delta === undefined) return [];
+        if (delta === undefined) {
+          this.#commitSemanticMutation();
+          return [];
+        }
         event = {
           ...event,
           type: "response.custom_tool_call_input.delta",
           delta,
         };
+        changed = true;
       }
       if (
         !this.#injectOnly &&
@@ -2013,11 +2558,15 @@ export class NamespaceToolCallTransform extends Transform {
             type: "response.custom_tool_call_input.done",
             input,
           };
+          changed = true;
         }
       }
       if (!this.#injectOnly) {
         const next = rewriteNamespaceResponsePayload(event, this.#lookups, this.#sessionModel);
-        if (next) event = next;
+        if (next) {
+          event = next;
+          changed = true;
+        }
       }
       if (
         event?.type === "response.output_item.added" &&
@@ -2042,38 +2591,48 @@ export class NamespaceToolCallTransform extends Transform {
         this.#customDeltaStates.delete(event.item.id);
       }
       this.#observeEvent(event);
-      const rebuilt = [...lines];
-      const eventLineIndex = rebuilt.findIndex((line) => line.startsWith("event:"));
+      const replacements = new Map();
       if (
         eventLineIndex !== -1 &&
         typeof event?.type === "string" &&
         event.type !== originalEventType
       ) {
-        rebuilt[eventLineIndex] = `event: ${event.type}`;
+        replacements.set(eventLineIndex, `event: ${event.type}`);
       }
-      rebuilt[dataLineIndex] = `data: ${JSON.stringify(event)}`;
       // Inject finished-child interrupts before the response closes so Codex
       // still executes them as ordinary tool calls in this turn.
       if (event?.type === "response.completed" || eventName === "response.completed") {
         const interruptBlocks = this.#drainInterruptBlocks();
         const withOutput = this.#mergeInjectedIntoCompleted(event);
-        // Nothing injected and nothing rewritten: the event goes out as it
-        // came in, not as a JSON round-trip of itself.
-        if (this.#injectOnly && !interruptBlocks.length && withOutput === event) {
-          return [block];
+        if (withOutput !== event) {
+          event = withOutput;
+          changed = true;
         }
-        rebuilt[dataLineIndex] = `data: ${JSON.stringify(withOutput)}`;
-        return [...interruptBlocks, rebuilt.join("\n")];
+        if (!changed) return [...interruptBlocks, frame];
+        this.#commitSemanticMutation();
+        replacements.set(dataLineIndex, `data: ${JSON.stringify(event)}`);
+        return [
+          ...interruptBlocks,
+          this.#rewrittenSseFrame(frame, lines, replacements),
+        ];
       }
       if (event?.type === "response.done" || eventName === "response.done") {
         const interruptBlocks = this.#drainInterruptBlocks();
-        if (this.#injectOnly) return [...interruptBlocks, block];
-        return [...interruptBlocks, rebuilt.join("\n")];
+        if (!changed) return [...interruptBlocks, frame];
+        this.#commitSemanticMutation();
+        replacements.set(dataLineIndex, `data: ${JSON.stringify(event)}`);
+        return [
+          ...interruptBlocks,
+          this.#rewrittenSseFrame(frame, lines, replacements),
+        ];
       }
-      if (this.#injectOnly) return [block];
-      return [rebuilt.join("\n")];
-    } catch {
-      return [block];
+      if (!changed) return [frame];
+      this.#commitSemanticMutation();
+      replacements.set(dataLineIndex, `data: ${JSON.stringify(event)}`);
+      return [this.#rewrittenSseFrame(frame, lines, replacements)];
+    } catch (error) {
+      if (error instanceof NamespaceRelayCommittedStreamError) throw error;
+      return this.#unsafeSseFrame(frame, "event rewrite failure");
     }
   }
 
@@ -2103,6 +2662,7 @@ export class NamespaceToolCallTransform extends Transform {
       this.#lastInjectedCalls = [];
       return [];
     }
+    this.#commitSemanticMutation();
     const blocks = [];
     const injectedCalls = [];
     for (const target of remaining) {
@@ -2136,12 +2696,24 @@ export class NamespaceToolCallTransform extends Transform {
           arguments: call.arguments,
         },
       };
-      blocks.push(formatSseBlock("response.output_item.added", added).trimEnd() + "\n");
-      blocks.push(formatSseBlock("response.output_item.done", done).trimEnd() + "\n");
+      blocks.push(
+        Buffer.from(
+          `event: response.output_item.added${this.#sseLineEnding}` +
+            `data: ${JSON.stringify(added)}${this.#sseLineEnding}${this.#sseLineEnding}`,
+          "utf8",
+        ),
+      );
+      blocks.push(
+        Buffer.from(
+          `event: response.output_item.done${this.#sseLineEnding}` +
+            `data: ${JSON.stringify(done)}${this.#sseLineEnding}${this.#sseLineEnding}`,
+          "utf8",
+        ),
+      );
     }
     this.#lastInjectedCalls = injectedCalls;
     this.#injectionsDone = true;
-    return blocks.map((block) => block.replace(/\n$/, ""));
+    return blocks;
   }
 
   #mergeInjectedIntoCompleted(event) {

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -502,6 +502,8 @@ const MAX_JSON_CAPTURE_BYTES = 64 * 1024 * 1024;
 const CAPTURE_PART_BYTES = 64 * 1024;
 const INITIAL_SSE_CAPTURE_PART_BYTES = 1024;
 const MAX_TRACKED_OUTPUT_ITEMS = 4096;
+const MAX_TRACKED_STATE_BYTES = 8 * 1024 * 1024;
+const TRACKED_STATE_FIXED_BYTES = 512;
 // Streaming and non-streaming Responses payloads share the same maximum
 // capturable JSON value. A terminal SSE event can carry the complete response,
 // including large custom-tool input, so it is not valid to impose the much
@@ -529,6 +531,105 @@ function sseFieldValue(line, prefixLength) {
 
 function sseLineFieldValue(line, name) {
   return line === name ? "" : sseFieldValue(line, name.length + 1);
+}
+
+function stringFingerprint(value) {
+  return {
+    length: value.length,
+    digest: createHash("sha256").update(value, "utf16le").digest(),
+  };
+}
+
+function canonicalJsonFingerprint(value) {
+  const hash = createHash("sha256");
+  let length = 0;
+  const update = (part, encoding = "utf8") => {
+    hash.update(part, encoding);
+    length += Buffer.byteLength(part, encoding);
+  };
+  const updateString = (marker, text) => {
+    update(`${marker}${text.length}:`, "ascii");
+    update(text, "utf16le");
+  };
+  const stack = [{ kind: "value", value }];
+  while (stack.length) {
+    const frame = stack.pop();
+    if (frame.kind === "array") {
+      if (frame.index >= frame.value.length) {
+        update("]", "ascii");
+        continue;
+      }
+      stack.push({ ...frame, index: frame.index + 1 });
+      stack.push({ kind: "value", value: frame.value[frame.index] });
+      continue;
+    }
+    if (frame.kind === "object") {
+      if (frame.index >= frame.keys.length) {
+        update("}", "ascii");
+        continue;
+      }
+      const key = frame.keys[frame.index];
+      stack.push({ ...frame, index: frame.index + 1 });
+      stack.push({ kind: "value", value: frame.value[key] });
+      stack.push({ kind: "key", value: key });
+      continue;
+    }
+    if (frame.kind === "key") {
+      updateString("k", frame.value);
+      continue;
+    }
+
+    const current = frame.value;
+    if (current === null) {
+      update("n", "ascii");
+    } else if (typeof current === "string") {
+      updateString("s", current);
+    } else if (typeof current === "number") {
+      const number = Number.isNaN(current)
+        ? "NaN"
+        : Object.is(current, -0)
+          ? "-0"
+          : String(current);
+      updateString("d", number);
+    } else if (typeof current === "boolean") {
+      update(current ? "t" : "f", "ascii");
+    } else if (Array.isArray(current)) {
+      update(`a${current.length}:[`, "ascii");
+      stack.push({ kind: "array", value: current, index: 0 });
+    } else if (typeof current === "object") {
+      const keys = Object.keys(current).sort();
+      update(`o${keys.length}:{`, "ascii");
+      stack.push({ kind: "object", value: current, keys, index: 0 });
+    } else {
+      throw new TypeError("Tool-search arguments contain a non-JSON value.");
+    }
+  }
+  return { length, digest: hash.digest() };
+}
+
+function fingerprintMatches(fingerprint, length, digest) {
+  return (
+    fingerprint.length === length &&
+    Buffer.isBuffer(digest) &&
+    fingerprint.digest.equals(digest)
+  );
+}
+
+function trackedStateBytes(state) {
+  let bytes = TRACKED_STATE_FIXED_BYTES;
+  for (const field of [
+    "itemId",
+    "callId",
+    "sourceType",
+    "sourceName",
+    "sourceNamespace",
+    "outputType",
+    "outputName",
+    "outputNamespace",
+  ]) {
+    if (typeof state[field] === "string") bytes += Buffer.byteLength(state[field], "utf8");
+  }
+  return bytes;
 }
 
 // Normalize a bounded JSON number as exact decimal coefficient + power. This
@@ -2114,6 +2215,7 @@ export class NamespaceToolCallTransform extends Transform {
   #maxJsonCaptureBytes;
   #maxSseFrameBytes;
   #maxTrackedOutputItems;
+  #maxTrackedStateBytes;
   #rewriteDisabled = false;
   #semanticMutationCommitted = false;
   #lookups;
@@ -2133,6 +2235,7 @@ export class NamespaceToolCallTransform extends Transform {
   #callsByItemId = new Map();
   #callsByCallId = new Map();
   #trackedCallCount = 0;
+  #trackedStateBytes = 0;
 
   constructor(namespaces, contentType = "", sessionModel, options = {}) {
     super();
@@ -2158,6 +2261,10 @@ export class NamespaceToolCallTransform extends Transform {
       Number.isInteger(options.maxTrackedOutputItems) && options.maxTrackedOutputItems > 0
         ? options.maxTrackedOutputItems
         : MAX_TRACKED_OUTPUT_ITEMS;
+    this.#maxTrackedStateBytes =
+      Number.isInteger(options.maxTrackedStateBytes) && options.maxTrackedStateBytes > 0
+        ? options.maxTrackedStateBytes
+        : MAX_TRACKED_STATE_BYTES;
     const declared = String(contentType).toLowerCase();
     this.#eventStream = declared.includes("text/event-stream");
     this.#headerlessDetector =
@@ -2580,6 +2687,7 @@ export class NamespaceToolCallTransform extends Transform {
     this.#callsByItemId.clear();
     this.#callsByCallId.clear();
     this.#trackedCallCount = 0;
+    this.#trackedStateBytes = 0;
   }
 
   #specialCallKind(item) {
@@ -2617,6 +2725,21 @@ export class NamespaceToolCallTransform extends Transform {
     return undefined;
   }
 
+  #storeCallState(state) {
+    if (this.#trackedCallCount >= this.#maxTrackedOutputItems) {
+      return "output item identity limit";
+    }
+    const retainedBytes = trackedStateBytes(state);
+    if (retainedBytes > this.#maxTrackedStateBytes - this.#trackedStateBytes) {
+      return "output item state byte limit";
+    }
+    if (state.itemId) this.#callsByItemId.set(state.itemId, state);
+    if (state.callId) this.#callsByCallId.set(state.callId, state);
+    this.#trackedCallCount += 1;
+    this.#trackedStateBytes += retainedBytes;
+    return undefined;
+  }
+
   #registerCall(sourceItem, item) {
     const kind = this.#specialCallKind(item);
     const sourceKind = this.#sourceSpecialCallKind(sourceItem);
@@ -2649,9 +2772,6 @@ export class NamespaceToolCallTransform extends Transform {
     if (!itemId && !callId) return undefined;
     const conflict = this.#openingIdentityConflict(item);
     if (conflict) return conflict;
-    if (this.#trackedCallCount >= this.#maxTrackedOutputItems) {
-      return "output item identity limit";
-    }
     const state = {
       kind,
       itemId,
@@ -2663,8 +2783,10 @@ export class NamespaceToolCallTransform extends Transform {
       outputName: item.name,
       outputNamespace: item.namespace,
       argumentsDone: false,
-      finalInput: undefined,
-      finalArguments: undefined,
+      finalInputLength: undefined,
+      finalInputDigest: undefined,
+      finalArgumentsLength: undefined,
+      finalArgumentsDigest: undefined,
       sawArgumentDelta: false,
       deltaCharacters: 0,
       deltaHash: kind === "custom" ? createHash("sha256") : undefined,
@@ -2681,10 +2803,7 @@ export class NamespaceToolCallTransform extends Transform {
             }
           : undefined,
     };
-    if (state.itemId) this.#callsByItemId.set(state.itemId, state);
-    if (state.callId) this.#callsByCallId.set(state.callId, state);
-    this.#trackedCallCount += 1;
-    return undefined;
+    return this.#storeCallState(state);
   }
 
   // Some Responses bridges omit output_item.added and emit only one complete
@@ -2766,9 +2885,12 @@ export class NamespaceToolCallTransform extends Transform {
 
     const conflict = this.#openingIdentityConflict(item);
     if (conflict) return conflict;
-    if (this.#trackedCallCount >= this.#maxTrackedOutputItems) {
-      return "output item identity limit";
-    }
+    const finalInputFingerprint = kind === "custom"
+      ? stringFingerprint(item.input)
+      : undefined;
+    const finalArgumentsFingerprint = kind === "tool_search"
+      ? canonicalJsonFingerprint(item.arguments)
+      : undefined;
     const state = {
       kind,
       itemId,
@@ -2780,8 +2902,10 @@ export class NamespaceToolCallTransform extends Transform {
       outputName: item.name,
       outputNamespace: item.namespace,
       argumentsDone: true,
-      finalInput: kind === "custom" ? item.input : undefined,
-      finalArguments: kind === "tool_search" ? item.arguments : undefined,
+      finalInputLength: finalInputFingerprint?.length,
+      finalInputDigest: finalInputFingerprint?.digest,
+      finalArgumentsLength: finalArgumentsFingerprint?.length,
+      finalArgumentsDigest: finalArgumentsFingerprint?.digest,
       sawArgumentDelta: false,
       deltaCharacters: 0,
       deltaHash: undefined,
@@ -2789,10 +2913,7 @@ export class NamespaceToolCallTransform extends Transform {
       summarySeen,
       deltaState: undefined,
     };
-    if (itemId) this.#callsByItemId.set(itemId, state);
-    this.#callsByCallId.set(callId, state);
-    this.#trackedCallCount += 1;
-    return undefined;
+    return this.#storeCallState(state);
   }
 
   #registerAtomicOutputItem(sourceItem, item, { summarySeen = false } = {}) {
@@ -2839,9 +2960,6 @@ export class NamespaceToolCallTransform extends Transform {
     if (!itemId && !callId) return undefined;
     const conflict = this.#openingIdentityConflict(item);
     if (conflict) return conflict;
-    if (this.#trackedCallCount >= this.#maxTrackedOutputItems) {
-      return "output item identity limit";
-    }
     const state = {
       kind: undefined,
       itemId,
@@ -2853,8 +2971,10 @@ export class NamespaceToolCallTransform extends Transform {
       outputName: item?.name,
       outputNamespace: item?.namespace,
       argumentsDone: true,
-      finalInput: undefined,
-      finalArguments: undefined,
+      finalInputLength: undefined,
+      finalInputDigest: undefined,
+      finalArgumentsLength: undefined,
+      finalArgumentsDigest: undefined,
       sawArgumentDelta: false,
       deltaCharacters: 0,
       deltaHash: undefined,
@@ -2862,10 +2982,7 @@ export class NamespaceToolCallTransform extends Transform {
       summarySeen,
       deltaState: undefined,
     };
-    if (itemId) this.#callsByItemId.set(itemId, state);
-    if (callId) this.#callsByCallId.set(callId, state);
-    this.#trackedCallCount += 1;
-    return undefined;
+    return this.#storeCallState(state);
   }
 
   #outputItemMatchesState(sourceItem, item, state) {
@@ -2907,7 +3024,7 @@ export class NamespaceToolCallTransform extends Transform {
     return { state };
   }
 
-  #customDeltaMismatch(state, input) {
+  #customDeltaMismatch(state, inputFingerprint) {
     if (!state.sawArgumentDelta) return undefined;
     if (
       state.deltaState.invalid ||
@@ -2917,14 +3034,11 @@ export class NamespaceToolCallTransform extends Transform {
     ) {
       return "incomplete custom tool argument delta sequence";
     }
-    if (state.deltaCharacters !== input.length) {
+    if (state.deltaCharacters !== inputFingerprint.length) {
       return "custom tool argument deltas disagree with completed input";
     }
-    const streamed = state.deltaHash.copy().digest("hex");
-    const completed = createHash("sha256")
-      .update(Buffer.from(input, "utf16le"))
-      .digest("hex");
-    return streamed === completed
+    const streamed = state.deltaHash.copy().digest();
+    return streamed.equals(inputFingerprint.digest)
       ? undefined
       : "custom tool argument deltas disagree with completed input";
   }
@@ -2958,23 +3072,46 @@ export class NamespaceToolCallTransform extends Transform {
       return undefined;
     }
     if (state.kind === "custom") {
-      if (state.argumentsDone && item.input !== state.finalInput) {
+      if (typeof item.input !== "string") {
+        return "custom tool call input changed before close";
+      }
+      const inputFingerprint = stringFingerprint(item.input);
+      if (
+        state.argumentsDone &&
+        !fingerprintMatches(
+          inputFingerprint,
+          state.finalInputLength,
+          state.finalInputDigest,
+        )
+      ) {
         return "custom tool call input changed before close";
       }
       if (!state.argumentsDone) {
-        const reason = this.#customDeltaMismatch(state, item.input);
+        const reason = this.#customDeltaMismatch(state, inputFingerprint);
         if (reason) return reason;
-        state.finalInput = item.input;
+        state.finalInputLength = inputFingerprint.length;
+        state.finalInputDigest = inputFingerprint.digest;
       }
+      state.argumentsDone = true;
+      state.deltaHash = undefined;
+      state.deltaState = undefined;
     }
-    if (
-      state.kind === "tool_search" &&
-      state.argumentsDone &&
-      !isDeepStrictEqual(item.arguments, state.finalArguments)
-    ) {
-      return "tool search arguments changed before close";
+    if (state.kind === "tool_search") {
+      const argumentsFingerprint = canonicalJsonFingerprint(item.arguments);
+      if (
+        state.argumentsDone &&
+        !fingerprintMatches(
+          argumentsFingerprint,
+          state.finalArgumentsLength,
+          state.finalArgumentsDigest,
+        )
+      ) {
+        return "tool search arguments changed before close";
+      }
+      state.finalArgumentsLength = argumentsFingerprint.length;
+      state.finalArgumentsDigest = argumentsFingerprint.digest;
+      state.argumentsDone = true;
     }
-    if (state.kind === "tool_search") state.finalArguments = item.arguments;
     state.closed = true;
     return undefined;
   }
@@ -3014,14 +3151,32 @@ export class NamespaceToolCallTransform extends Transform {
       state.summarySeen = true;
       return undefined;
     }
-    if (state.kind === "custom" && item.input !== state.finalInput) {
-      return "custom tool call summary input changed after close";
+    if (state.kind === "custom") {
+      if (typeof item.input !== "string") {
+        return "custom tool call summary input changed after close";
+      }
+      const inputFingerprint = stringFingerprint(item.input);
+      if (
+        !fingerprintMatches(
+          inputFingerprint,
+          state.finalInputLength,
+          state.finalInputDigest,
+        )
+      ) {
+        return "custom tool call summary input changed after close";
+      }
     }
-    if (
-      state.kind === "tool_search" &&
-      !isDeepStrictEqual(item.arguments, state.finalArguments)
-    ) {
-      return "tool search arguments changed after close";
+    if (state.kind === "tool_search") {
+      const argumentsFingerprint = canonicalJsonFingerprint(item.arguments);
+      if (
+        !fingerprintMatches(
+          argumentsFingerprint,
+          state.finalArgumentsLength,
+          state.finalArgumentsDigest,
+        )
+      ) {
+        return "tool search arguments changed after close";
+      }
     }
     state.summarySeen = true;
     return undefined;
@@ -3193,8 +3348,10 @@ export class NamespaceToolCallTransform extends Transform {
             if (!argumentsObject) {
               return this.#unsafeSseFrame(frame, "invalid tool search arguments done");
             }
+            const argumentsFingerprint = canonicalJsonFingerprint(argumentsObject);
             matched.state.argumentsDone = true;
-            matched.state.finalArguments = argumentsObject;
+            matched.state.finalArgumentsLength = argumentsFingerprint.length;
+            matched.state.finalArgumentsDigest = argumentsFingerprint.digest;
             this.#commitSemanticMutation();
             return [];
           }
@@ -3202,7 +3359,11 @@ export class NamespaceToolCallTransform extends Transform {
           if (input === undefined) {
             return this.#unsafeSseFrame(frame, "invalid custom tool arguments done");
           }
-          const deltaReason = this.#customDeltaMismatch(matched.state, input);
+          const inputFingerprint = stringFingerprint(input);
+          const deltaReason = this.#customDeltaMismatch(
+            matched.state,
+            inputFingerprint,
+          );
           if (deltaReason) return this.#unsafeSseFrame(frame, deltaReason);
           const { arguments: _arguments, ...rest } = event;
           event = {
@@ -3211,7 +3372,10 @@ export class NamespaceToolCallTransform extends Transform {
             input,
           };
           matched.state.argumentsDone = true;
-          matched.state.finalInput = input;
+          matched.state.finalInputLength = inputFingerprint.length;
+          matched.state.finalInputDigest = inputFingerprint.digest;
+          matched.state.deltaHash = undefined;
+          matched.state.deltaState = undefined;
           changed = true;
         }
       }

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -499,18 +499,23 @@ export function injectSessionModelForSpawnCalls(item, model) {
 }
 
 const MAX_JSON_CAPTURE_BYTES = 64 * 1024 * 1024;
-const JSON_CAPTURE_PART_BYTES = 64 * 1024;
+const CAPTURE_PART_BYTES = 64 * 1024;
+const INITIAL_SSE_CAPTURE_PART_BYTES = 1024;
 const MAX_TRACKED_OUTPUT_ITEMS = 4096;
-// Stop staging an undecided SSE frame before downstream response guards lose
-// sight of their own byte ceilings. Before any semantic output, crossing this
-// bound releases raw bytes and disables rewriting; after one rewrite,
+// Streaming and non-streaming Responses payloads share the same maximum
+// capturable JSON value. A terminal SSE event can carry the complete response,
+// including large custom-tool input, so it is not valid to impose the much
+// smaller pre-content guard on one frame. Before any semantic output, crossing
+// this bound releases raw bytes and disables rewriting; after one rewrite,
 // suppression, or injection, it terminates the stream rather than mixing wire
 // representations.
-const MAX_SSE_FRAME_BYTES = 256 * 1024;
+const MAX_SSE_FRAME_BYTES = MAX_JSON_CAPTURE_BYTES;
 const MAX_EXACT_JSON_NUMBER_LENGTH = 4096;
 const LINE_FEED = 0x0a;
 const CARRIAGE_RETURN = 0x0d;
 const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+const SSE_EVENT_FIELD = Buffer.from("event", "ascii");
+const SSE_DATA_FIELD = Buffer.from("data", "ascii");
 const JSON_NUMBER_AT_OFFSET = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
 const JSON_NUMBER_PARTS =
   /^(-?)(0|[1-9]\d*)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/;
@@ -520,10 +525,6 @@ function sseFieldValue(line, prefixLength) {
   // The SSE grammar removes one optional U+0020 after the colon. Tabs,
   // repeated spaces, and trailing spaces are event data, not formatting.
   return value.startsWith(" ") ? value.slice(1) : value;
-}
-
-function isSseField(line, name) {
-  return line === name || line.startsWith(`${name}:`);
 }
 
 function sseLineFieldValue(line, name) {
@@ -2102,6 +2103,8 @@ export class NamespaceToolCallTransform extends Transform {
   #headerlessDetector;
   #sseParts = [];
   #sseBytes = 0;
+  #sseTailBytes = 0;
+  #sseNextPartBytes = INITIAL_SSE_CAPTURE_PART_BYTES;
   #sseLineBytes = 0;
   #ssePendingCr = false;
   #ssePendingLineWasBlank = false;
@@ -2296,7 +2299,7 @@ export class NamespaceToolCallTransform extends Transform {
         const remainingUntilRelease =
           this.#maxJsonCaptureBytes + 1 - this.#pendingBytes;
         tail = Buffer.allocUnsafe(
-          Math.min(JSON_CAPTURE_PART_BYTES, remainingUntilRelease),
+          Math.min(CAPTURE_PART_BYTES, remainingUntilRelease),
         );
         this.#pendingParts.push(tail);
         this.#pendingTailBytes = 0;
@@ -2434,8 +2437,32 @@ export class NamespaceToolCallTransform extends Transform {
 
   #appendSsePiece(piece) {
     if (!piece.length) return true;
-    this.#sseParts.push(piece);
-    this.#sseBytes += piece.length;
+    // Copy into fixed-size parts exactly as the non-streaming capture does.
+    // Retaining one view per upstream chunk would let a one-byte-fragmented
+    // frame allocate millions of Buffer objects before reaching its byte cap.
+    let offset = 0;
+    while (offset < piece.length && this.#sseBytes <= this.#maxSseFrameBytes) {
+      let tail = this.#sseParts.at(-1);
+      if (!tail || this.#sseTailBytes === tail.length) {
+        const remainingUntilRelease =
+          this.#maxSseFrameBytes + 1 - this.#sseBytes;
+        const remainingPieceBytes = piece.length - offset;
+        const partBytes = Math.min(
+          CAPTURE_PART_BYTES,
+          Math.max(this.#sseNextPartBytes, Math.min(CAPTURE_PART_BYTES, remainingPieceBytes)),
+          remainingUntilRelease,
+        );
+        tail = Buffer.allocUnsafe(partBytes);
+        this.#sseParts.push(tail);
+        this.#sseTailBytes = 0;
+        this.#sseNextPartBytes = Math.min(CAPTURE_PART_BYTES, partBytes * 2);
+      }
+      const copied = Math.min(tail.length - this.#sseTailBytes, piece.length - offset);
+      piece.copy(tail, this.#sseTailBytes, offset, offset + copied);
+      this.#sseTailBytes += copied;
+      this.#sseBytes += copied;
+      offset += copied;
+    }
     if (this.#sseBytes <= this.#maxSseFrameBytes) return true;
     const buffered = this.#takeSseFrame();
     if (this.#semanticMutationCommitted) {
@@ -2443,6 +2470,7 @@ export class NamespaceToolCallTransform extends Transform {
     }
     this.#disableSseRewriting();
     this.push(buffered);
+    if (offset < piece.length) this.push(piece.subarray(offset));
     return false;
   }
 
@@ -2452,21 +2480,29 @@ export class NamespaceToolCallTransform extends Transform {
   }
 
   #takeSseFrame() {
-    const frame =
-      this.#sseParts.length === 1
-        ? this.#sseParts[0]
-        : Buffer.concat(this.#sseParts, this.#sseBytes);
+    if (!this.#sseParts.length) return Buffer.alloc(0);
+    const lastIndex = this.#sseParts.length - 1;
+    const parts = this.#sseParts.map((part, index) =>
+      index === lastIndex ? part.subarray(0, this.#sseTailBytes) : part,
+    );
+    const frame = parts.length === 1 ? parts[0] : Buffer.concat(parts, this.#sseBytes);
     this.#sseParts = [];
     this.#sseBytes = 0;
+    this.#sseTailBytes = 0;
+    this.#sseNextPartBytes = INITIAL_SSE_CAPTURE_PART_BYTES;
     this.#sseLineBytes = 0;
     this.#ssePendingCr = false;
     this.#ssePendingLineWasBlank = false;
     return frame;
   }
 
-  #sseLines(frame) {
-    const lines = [];
+  #sseFields(frame, atStreamStart) {
+    let eventLine;
+    let dataLine;
+    let lineEndingLine;
+    let repeated = false;
     let start = 0;
+    let firstLine = true;
     while (start < frame.length) {
       let contentEnd = start;
       while (
@@ -2476,37 +2512,49 @@ export class NamespaceToolCallTransform extends Transform {
       ) {
         contentEnd += 1;
       }
-      if (contentEnd === frame.length) {
-        lines.push({
-          start,
-          parseStart: start,
-          contentEnd: frame.length,
-          end: frame.length,
-        });
-        break;
-      }
-      const end =
-        frame[contentEnd] === CARRIAGE_RETURN && frame[contentEnd + 1] === LINE_FEED
+      const end = contentEnd === frame.length
+        ? frame.length
+        : frame[contentEnd] === CARRIAGE_RETURN && frame[contentEnd + 1] === LINE_FEED
           ? contentEnd + 2
           : contentEnd + 1;
-      lines.push({ start, parseStart: start, contentEnd, end });
+      let parseStart = start;
+      if (
+        firstLine &&
+        atStreamStart &&
+        frame.subarray(start, start + UTF8_BOM.length).equals(UTF8_BOM)
+      ) {
+        parseStart += UTF8_BOM.length;
+      }
+      firstLine = false;
+      const line = { start, parseStart, contentEnd, end };
+      if (!lineEndingLine && end > contentEnd) lineEndingLine = line;
+      const lineLength = contentEnd - parseStart;
+      const fieldLine = (name) =>
+        lineLength >= name.length &&
+        frame.subarray(parseStart, parseStart + name.length).equals(name) &&
+        (lineLength === name.length || frame[parseStart + name.length] === 0x3a);
+      if (fieldLine(SSE_EVENT_FIELD)) {
+        if (eventLine) repeated = true;
+        else eventLine = line;
+      }
+      if (fieldLine(SSE_DATA_FIELD)) {
+        if (dataLine) repeated = true;
+        else dataLine = line;
+      }
+      if (repeated || contentEnd === frame.length) break;
       start = end;
     }
-    return lines;
+    return { eventLine, dataLine, lineEndingLine, repeated };
   }
 
-  #rememberSseLineEnding(frame, lines) {
-    if (this.#sseLineEndingObserved) return;
-    for (const line of lines) {
-      if (line.end === line.contentEnd) continue;
-      const terminator = frame.subarray(line.contentEnd, line.end);
-      if (terminator.equals(Buffer.from("\r\n"))) this.#sseLineEnding = "\r\n";
-      else if (terminator.equals(Buffer.from("\n"))) this.#sseLineEnding = "\n";
-      else if (terminator.equals(Buffer.from("\r"))) this.#sseLineEnding = "\r";
-      else continue;
-      this.#sseLineEndingObserved = true;
-      return;
-    }
+  #rememberSseLineEnding(frame, line) {
+    if (this.#sseLineEndingObserved || !line || line.end === line.contentEnd) return;
+    const terminator = frame.subarray(line.contentEnd, line.end);
+    if (terminator.equals(Buffer.from("\r\n"))) this.#sseLineEnding = "\r\n";
+    else if (terminator.equals(Buffer.from("\n"))) this.#sseLineEnding = "\n";
+    else if (terminator.equals(Buffer.from("\r"))) this.#sseLineEnding = "\r";
+    else return;
+    this.#sseLineEndingObserved = true;
   }
 
   #emitSseFrame(frame) {
@@ -2995,13 +3043,12 @@ export class NamespaceToolCallTransform extends Transform {
     return undefined;
   }
 
-  #rewrittenSseFrame(frame, lines, replacements) {
+  #rewrittenSseFrame(frame, replacements) {
     const pieces = [];
     let cursor = 0;
-    for (const [index, replacement] of [...replacements].sort(
-      ([left], [right]) => left - right,
+    for (const [line, replacement] of [...replacements].sort(
+      ([left], [right]) => left.start - right.start,
     )) {
-      const line = lines[index];
       if (!line) continue;
       if (line.start > cursor) pieces.push(frame.subarray(cursor, line.start));
       if (line.parseStart > line.start) {
@@ -3022,37 +3069,32 @@ export class NamespaceToolCallTransform extends Transform {
     if (!isUtf8(frame)) {
       return this.#unsafeSseFrame(frame, "invalid UTF-8");
     }
-    const lines = this.#sseLines(frame);
-    if (atStreamStart && frame.subarray(0, UTF8_BOM.length).equals(UTF8_BOM) && lines[0]) {
-      lines[0].parseStart += UTF8_BOM.length;
-    }
-    this.#rememberSseLineEnding(frame, lines);
-    const lineTexts = lines.map((line) =>
-      frame.subarray(line.parseStart, line.contentEnd).toString("utf8"),
+    const { eventLine, dataLine, lineEndingLine, repeated } = this.#sseFields(
+      frame,
+      atStreamStart,
     );
-    const eventLineIndexes = lineTexts
-      .map((line, index) => (isSseField(line, "event") ? index : -1))
-      .filter((index) => index !== -1);
-    const dataLineIndexes = lineTexts
-      .map((line, index) => (isSseField(line, "data") ? index : -1))
-      .filter((index) => index !== -1);
+    this.#rememberSseLineEnding(frame, lineEndingLine);
     // SSE formally concatenates multiple data fields and gives repeated event
     // fields ordering semantics. Rewriting just one field would create bytes
     // whose EventSource meaning differs from the JSON we inspected. The
     // Responses wire uses exactly one of each, so anything else is preserved
     // and disables stateful rewriting for the remainder of this response.
-    if (eventLineIndexes.length > 1 || dataLineIndexes.length > 1) {
+    if (repeated) {
       return this.#unsafeSseFrame(frame, "repeated SSE event or data field");
     }
-    const eventLineIndex = eventLineIndexes[0] ?? -1;
-    const eventName =
-      eventLineIndex === -1
-        ? undefined
-        : sseLineFieldValue(lineTexts[eventLineIndex], "event");
-    const dataLineIndex = dataLineIndexes[0] ?? -1;
-    const dataText =
-      dataLineIndex === -1 ? "" : sseLineFieldValue(lineTexts[dataLineIndex], "data");
-    if (dataLineIndex === -1) return [frame];
+    const eventText = eventLine
+      ? frame.subarray(eventLine.parseStart, eventLine.contentEnd).toString("utf8")
+      : undefined;
+    const eventName = eventText === undefined
+      ? undefined
+      : sseLineFieldValue(eventText, "event");
+    const dataTextLine = dataLine
+      ? frame.subarray(dataLine.parseStart, dataLine.contentEnd).toString("utf8")
+      : undefined;
+    const dataText = dataTextLine === undefined
+      ? ""
+      : sseLineFieldValue(dataTextLine, "data");
+    if (!dataLine) return [frame];
     if (!dataText || dataText === "[DONE]") {
       if (eventName && eventName !== "message") {
         return this.#unsafeSseFrame(
@@ -3203,13 +3245,13 @@ export class NamespaceToolCallTransform extends Transform {
         }
       }
       this.#observeEvent(event);
-      const replacements = new Map();
+      const replacements = [];
       if (
-        eventLineIndex !== -1 &&
+        eventLine &&
         typeof event?.type === "string" &&
         event.type !== originalEventType
       ) {
-        replacements.set(eventLineIndex, `event: ${event.type}`);
+        replacements.push([eventLine, `event: ${event.type}`]);
       }
       // Inject finished-child interrupts before the response closes so Codex
       // still executes them as ordinary tool calls in this turn.
@@ -3222,26 +3264,26 @@ export class NamespaceToolCallTransform extends Transform {
         }
         if (!changed) return [...interruptBlocks, frame];
         this.#commitSemanticMutation();
-        replacements.set(dataLineIndex, `data: ${JSON.stringify(event)}`);
+        replacements.push([dataLine, `data: ${JSON.stringify(event)}`]);
         return [
           ...interruptBlocks,
-          this.#rewrittenSseFrame(frame, lines, replacements),
+          this.#rewrittenSseFrame(frame, replacements),
         ];
       }
       if (event?.type === "response.done" || eventName === "response.done") {
         const interruptBlocks = this.#drainInterruptBlocks();
         if (!changed) return [...interruptBlocks, frame];
         this.#commitSemanticMutation();
-        replacements.set(dataLineIndex, `data: ${JSON.stringify(event)}`);
+        replacements.push([dataLine, `data: ${JSON.stringify(event)}`]);
         return [
           ...interruptBlocks,
-          this.#rewrittenSseFrame(frame, lines, replacements),
+          this.#rewrittenSseFrame(frame, replacements),
         ];
       }
       if (!changed) return [frame];
       this.#commitSemanticMutation();
-      replacements.set(dataLineIndex, `data: ${JSON.stringify(event)}`);
-      return [this.#rewrittenSseFrame(frame, lines, replacements)];
+      replacements.push([dataLine, `data: ${JSON.stringify(event)}`]);
+      return [this.#rewrittenSseFrame(frame, replacements)];
     } catch (error) {
       if (error instanceof NamespaceRelayCommittedStreamError) throw error;
       return this.#unsafeSseFrame(frame, "event rewrite failure");

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -504,14 +504,14 @@ const INITIAL_SSE_CAPTURE_PART_BYTES = 1024;
 const MAX_TRACKED_OUTPUT_ITEMS = 4096;
 const MAX_TRACKED_STATE_BYTES = 8 * 1024 * 1024;
 const TRACKED_STATE_FIXED_BYTES = 512;
-// Streaming and non-streaming Responses payloads share the same maximum
-// capturable JSON value. A terminal SSE event can carry the complete response,
-// including large custom-tool input, so it is not valid to impose the much
-// smaller pre-content guard on one frame. Before any semantic output, crossing
-// this bound releases raw bytes and disables rewriting; after one rewrite,
-// suppression, or injection, it terminates the stream rather than mixing wire
-// representations.
-const MAX_SSE_FRAME_BYTES = MAX_JSON_CAPTURE_BYTES;
+// Before any semantic output, stop staging an undecided SSE frame before
+// downstream response guards lose sight of their own byte ceilings. Once a
+// namespace rewrite, suppression, or injection has committed the wire shape,
+// a later terminal event may carry the complete response and therefore shares
+// the non-streaming JSON capture bound. Crossing either phase's bound releases
+// raw bytes before a commit and terminates the stream after one.
+const MAX_SSE_FRAME_BYTES = 256 * 1024;
+const MAX_COMMITTED_SSE_FRAME_BYTES = MAX_JSON_CAPTURE_BYTES;
 const MAX_EXACT_JSON_NUMBER_LENGTH = 4096;
 const LINE_FEED = 0x0a;
 const CARRIAGE_RETURN = 0x0d;
@@ -2214,6 +2214,7 @@ export class NamespaceToolCallTransform extends Transform {
   #sseLineEndingObserved = false;
   #maxJsonCaptureBytes;
   #maxSseFrameBytes;
+  #maxCommittedSseFrameBytes;
   #maxTrackedOutputItems;
   #maxTrackedStateBytes;
   #rewriteDisabled = false;
@@ -2253,10 +2254,17 @@ export class NamespaceToolCallTransform extends Transform {
       Number.isInteger(options.maxJsonCaptureBytes) && options.maxJsonCaptureBytes > 0
         ? options.maxJsonCaptureBytes
         : MAX_JSON_CAPTURE_BYTES;
-    this.#maxSseFrameBytes =
+    const configuredSseFrameBytes =
       Number.isInteger(options.maxSseFrameBytes) && options.maxSseFrameBytes > 0
         ? options.maxSseFrameBytes
-        : MAX_SSE_FRAME_BYTES;
+        : undefined;
+    this.#maxSseFrameBytes = configuredSseFrameBytes ?? MAX_SSE_FRAME_BYTES;
+    this.#maxCommittedSseFrameBytes =
+      Number.isInteger(options.maxCommittedSseFrameBytes) &&
+      options.maxCommittedSseFrameBytes > 0
+        ? options.maxCommittedSseFrameBytes
+        : configuredSseFrameBytes ??
+          Math.min(this.#maxJsonCaptureBytes, MAX_COMMITTED_SSE_FRAME_BYTES);
     this.#maxTrackedOutputItems =
       Number.isInteger(options.maxTrackedOutputItems) && options.maxTrackedOutputItems > 0
         ? options.maxTrackedOutputItems
@@ -2548,11 +2556,14 @@ export class NamespaceToolCallTransform extends Transform {
     // Retaining one view per upstream chunk would let a one-byte-fragmented
     // frame allocate millions of Buffer objects before reaching its byte cap.
     let offset = 0;
-    while (offset < piece.length && this.#sseBytes <= this.#maxSseFrameBytes) {
+    const frameByteLimit = this.#semanticMutationCommitted
+      ? this.#maxCommittedSseFrameBytes
+      : this.#maxSseFrameBytes;
+    while (offset < piece.length && this.#sseBytes <= frameByteLimit) {
       let tail = this.#sseParts.at(-1);
       if (!tail || this.#sseTailBytes === tail.length) {
         const remainingUntilRelease =
-          this.#maxSseFrameBytes + 1 - this.#sseBytes;
+          frameByteLimit + 1 - this.#sseBytes;
         const remainingPieceBytes = piece.length - offset;
         const partBytes = Math.min(
           CAPTURE_PART_BYTES,
@@ -2570,7 +2581,7 @@ export class NamespaceToolCallTransform extends Transform {
       this.#sseBytes += copied;
       offset += copied;
     }
-    if (this.#sseBytes <= this.#maxSseFrameBytes) return true;
+    if (this.#sseBytes <= frameByteLimit) return true;
     const buffered = this.#takeSseFrame();
     if (this.#semanticMutationCommitted) {
       throw new NamespaceRelayCommittedStreamError("SSE frame byte limit");

--- a/src/sse-prefix.mjs
+++ b/src/sse-prefix.mjs
@@ -27,7 +27,12 @@ export function classifySsePrefix(value, { end = false } = {}) {
   const text = bytes.toString("utf8");
   let offset = 0;
   while (offset < text.length) {
-    const newline = text.indexOf("\n", offset);
+    const nextCr = text.indexOf("\r", offset);
+    const nextLf = text.indexOf("\n", offset);
+    let newline;
+    if (nextCr === -1) newline = nextLf;
+    else if (nextLf === -1) newline = nextCr;
+    else newline = Math.min(nextCr, nextLf);
     if (newline === -1) {
       const line = text.slice(offset);
       if (line.startsWith(":")) return "event-stream";
@@ -40,9 +45,11 @@ export function classifySsePrefix(value, { end = false } = {}) {
       return end && SSE_FIELD.test(line) ? "event-stream" : "other";
     }
 
-    let line = text.slice(offset, newline);
-    if (line.endsWith("\r")) line = line.slice(0, -1);
-    offset = newline + 1;
+    const line = text.slice(offset, newline);
+    offset =
+      text[newline] === "\r" && text[newline + 1] === "\n"
+        ? newline + 2
+        : newline + 1;
     if (!line) continue;
     if (line.startsWith(":") || SSE_FIELD.test(line)) return "event-stream";
     return "other";

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { Readable, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import test from "node:test";
@@ -4029,7 +4030,75 @@ test("special relay identities cannot be reused or changed after conversion", as
   );
   assert.equal(boundedCommitted.error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
   assert.doesNotMatch(boundedCommitted.output.toString("utf8"), /post-commit-identity-limit/u);
+
+  const stateBounded = await collectUntilPipelineError(
+    [Buffer.from(overLimitSource, "utf8")],
+    new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+      maxTrackedStateBytes: 1024,
+    }),
+  );
+  assert.equal(stateBounded.error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.doesNotMatch(stateBounded.output.toString("utf8"), /post-commit-identity-limit/u);
 });
+
+test(
+  "closed special-call tracking retains fingerprints instead of payload-scale strings",
+  { timeout: 30_000 },
+  () => {
+    const moduleUrl = new URL("../src/namespace-relay.mjs", import.meta.url).href;
+    const script = String.raw`
+      import { once } from "node:events";
+      import { bridgeCustomTools, NamespaceToolCallTransform } from ${JSON.stringify(moduleUrl)};
+      const namespaces = new Map();
+      bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], namespaces);
+      const transform = new NamespaceToolCallTransform(namespaces, "text/event-stream");
+      transform.on("data", () => {});
+      global.gc();
+      const before = process.memoryUsage();
+      let payloadCharacters = 0;
+      const calls = 256;
+      for (let index = 0; index < calls; index += 1) {
+        const input = String(index) + ":" +
+          String.fromCharCode(65 + (index % 26)).repeat(180_000);
+        payloadCharacters += input.length;
+        const event = {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_" + index,
+            call_id: "call_" + index,
+            name: "apply_patch",
+            arguments: JSON.stringify({ input }),
+          },
+        };
+        const frame = Buffer.from("data: " + JSON.stringify(event) + "\n\n");
+        if (!transform.write(frame)) await once(transform, "drain");
+      }
+      global.gc();
+      const after = process.memoryUsage();
+      process.stdout.write(JSON.stringify({
+        calls,
+        payloadCharacters,
+        heapDelta: after.heapUsed - before.heapUsed,
+      }));
+      transform.destroy();
+    `;
+    const child = spawnSync(
+      process.execPath,
+      ["--expose-gc", "--input-type=module", "--eval", script],
+      { encoding: "utf8", timeout: 25_000, maxBuffer: 1024 * 1024 },
+    );
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+    const measurement = JSON.parse(child.stdout);
+    assert.equal(measurement.calls, 256);
+    assert.ok(measurement.payloadCharacters > 40 * 1024 * 1024);
+    assert.ok(
+      measurement.heapDelta < 8 * 1024 * 1024,
+      `retained heap grew by ${measurement.heapDelta} bytes for ` +
+        `${measurement.payloadCharacters} payload characters`,
+    );
+  },
+);
 
 test("complete special closes and terminal summaries establish atomic lifecycles", async () => {
   const collaboration = {
@@ -4503,6 +4572,50 @@ test("invalid or inconsistent tool_search arguments fail closed after conversion
     assert.doesNotMatch(output.toString("utf8"), /function_call_arguments\.done/u);
     assert.doesNotMatch(output.toString("utf8"), /response\.output_item\.done/u);
   }
+});
+
+test("tool_search lifecycle fingerprints ignore object key order", async () => {
+  const { namespaces } = flattenNamespaceTools([clientToolSearchControl()]);
+  const open = {
+    type: "response.output_item.added",
+    item: {
+      type: "function_call",
+      id: "fc_search_canonical",
+      call_id: "call_search_canonical",
+      name: "tool_search",
+      arguments: "",
+    },
+  };
+  const argumentsDone = {
+    type: "response.function_call_arguments.done",
+    item_id: "fc_search_canonical",
+    call_id: "call_search_canonical",
+    arguments: JSON.stringify({ query: "calendar", limit: 4 }),
+  };
+  const closeItem = {
+    ...open.item,
+    arguments: JSON.stringify({ limit: 4, query: "calendar" }),
+  };
+  const events = [
+    open,
+    argumentsDone,
+    { type: "response.output_item.done", item: closeItem },
+    { type: "response.completed", response: { output: [closeItem] } },
+  ];
+  const output = await collect(
+    Readable.from(
+      events.map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`),
+    ).pipe(new NamespaceToolCallTransform(namespaces, "text/event-stream")),
+  );
+  const payloads = output
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice(6)));
+  assert.deepEqual(payloads.at(-2).item.arguments, { limit: 4, query: "calendar" });
+  assert.deepEqual(payloads.at(-1).response.output[0].arguments, {
+    limit: 4,
+    query: "calendar",
+  });
 });
 
 test("converted custom and tool_search calls must close before terminal or EOF", async () => {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -1843,13 +1843,14 @@ test("response transform restores flattened calls to the native namespace shape"
   assert.doesNotMatch(output, /collaboration__spawn_agent|codex_app__create_thread|mcp__node_repl__js/);
 });
 
-test("tool_search response bridge covers SSE added, delta, done, and completed", async () => {
+test("tool_search response bridge suppresses function argument events across its lifecycle", async () => {
   const { namespaces } = flattenNamespaceTools([clientToolSearchControl()]);
   const events = [
     {
       type: "response.output_item.added",
       item: {
         type: "function_call",
+        id: "fc_search_1",
         name: "tool_search",
         call_id: "search-1",
         arguments: "",
@@ -1862,9 +1863,16 @@ test("tool_search response bridge covers SSE added, delta, done, and completed",
       delta: '{"query":"cal',
     },
     {
+      type: "response.function_call_arguments.done",
+      item_id: "fc_search_1",
+      call_id: "search-1",
+      arguments: '{"query":"calendar","limit":2}',
+    },
+    {
       type: "response.output_item.done",
       item: {
         type: "function_call",
+        id: "fc_search_1",
         name: "tool_search",
         call_id: "search-1",
         arguments: '{"query":"calendar","limit":2.0}',
@@ -1877,6 +1885,7 @@ test("tool_search response bridge covers SSE added, delta, done, and completed",
         output: [
           {
             type: "function_call",
+            id: "fc_search_1",
             name: "tool_search",
             call_id: "search-1",
             arguments: '{"query":"calendar","limit":2}',
@@ -1897,28 +1906,26 @@ test("tool_search response bridge covers SSE added, delta, done, and completed",
 
   assert.deepEqual(parsed[0].item, {
     type: "tool_search_call",
+    id: "fc_search_1",
     call_id: "search-1",
     execution: "client",
     arguments: {},
   });
-  assert.deepEqual(parsed[1], {
-    type: "response.function_call_arguments.delta",
-    item_id: "fc_search_1",
-    call_id: "search-1",
-    delta: '{"query":"cal',
-  });
-  assert.deepEqual(parsed[2].item, {
+  assert.deepEqual(parsed[1].item, {
     type: "tool_search_call",
+    id: "fc_search_1",
     call_id: "search-1",
     execution: "client",
     arguments: { query: "calendar", limit: 2 },
   });
-  assert.deepEqual(parsed[3].response.output[0], {
+  assert.deepEqual(parsed[2].response.output[0], {
     type: "tool_search_call",
+    id: "fc_search_1",
     call_id: "search-1",
     execution: "client",
     arguments: { query: "calendar", limit: 2 },
   });
+  assert.doesNotMatch(output, /response\.function_call_arguments/u);
 });
 
 test("tool_search response bridge fails closed without native control or valid arguments", () => {
@@ -2306,6 +2313,34 @@ test("ambiguous non-streaming JSON is preserved byte for byte", async () => {
   }
 });
 
+test("chunked JSON capture releases byte-exactly at its configured bound", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const source = Buffer.from(
+    '{"output":[{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}]}',
+    "utf8",
+  );
+  const chunks = [];
+  for (let offset = 0; offset < source.length; offset += 3) {
+    chunks.push(source.subarray(offset, offset + 3));
+  }
+  const output = await collectBuffer(
+    Readable.from(chunks).pipe(
+      new NamespaceToolCallTransform(namespaces, "application/json", undefined, {
+        maxJsonCaptureBytes: 31,
+      }),
+    ),
+  );
+  assert.deepEqual(output, source);
+  assert.match(output.toString("utf8"), /collaboration__spawn_agent/u);
+  assert.doesNotMatch(output.toString("utf8"), /"namespace":"collaboration"/u);
+});
+
 test("lossy JSON numbers fail closed before SSE or JSON namespace rewrites", async () => {
   const { namespaces } = flattenNamespaceTools([
     {
@@ -2425,6 +2460,20 @@ test("exactly equivalent decimal spellings remain eligible for namespace rewrite
     assert.equal(payload.output[0].namespace, "collaboration");
   }
 });
+
+test(
+  "dense JSON number arrays are scanned within a linear-time bound",
+  { timeout: 3000 },
+  async () => {
+    const source = Buffer.from(`[${"1,".repeat(128 * 1024 - 1)}1]`, "utf8");
+    const output = await collectBuffer(
+      Readable.from([source]).pipe(
+        new NamespaceToolCallTransform(new Map(), "application/json"),
+      ),
+    );
+    assert.deepEqual(output, source);
+  },
+);
 
 test("inject-only responses preserve lossy decimal payloads without injecting", async () => {
   const { namespaces } = flattenNamespaceTools([
@@ -2762,6 +2811,55 @@ test("interrupt injection adopts the provider's CRLF framing", async () => {
     if (output[index] === 0x0a) assert.equal(output[index - 1], 0x0d);
   }
 });
+
+test("EOF interrupt injection separates an unterminated final SSE frame", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "interrupt_agent" }],
+    },
+  ]);
+  for (const lineEnding of ["", "\n", "\r", "\r\n"]) {
+    const source = Buffer.from(
+      `data: {"type":"response.created","sequence_number":1}${lineEnding}`,
+      "utf8",
+    );
+    const output = await collectBuffer(
+      Readable.from([source]).pipe(
+        new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+          pendingInterrupts: ["/root/finished"],
+        }),
+      ),
+    );
+    const separator = lineEnding || "\n\n";
+    assert.deepEqual(output.subarray(0, source.length), source, JSON.stringify(lineEnding));
+    assert.ok(
+      output
+        .subarray(source.length)
+        .toString("utf8")
+        .startsWith(`${separator}event: response.output_item.added${lineEnding || "\n"}`),
+      JSON.stringify(lineEnding),
+    );
+    assert.match(output.toString("utf8"), /"name":"interrupt_agent"/u);
+  }
+});
+
+test(
+  "dense LF-only SSE frames are scanned within a linear-time bound",
+  { timeout: 3000 },
+  async () => {
+    const source = Buffer.from(`:x\n`.repeat(Math.floor((512 * 1024) / 3) - 1) + "\n");
+    const output = await collectBuffer(
+      Readable.from([source]).pipe(
+        new NamespaceToolCallTransform(new Map(), "text/event-stream", undefined, {
+          maxSseFrameBytes: source.length + 1,
+        }),
+      ),
+    );
+    assert.deepEqual(output, source);
+  },
+);
 
 test("oversized SSE framing releases bytes and disables later rewrites", async () => {
   const { namespaces } = flattenNamespaceTools([
@@ -3567,15 +3665,7 @@ test("a bridged custom tool keeps its description above the grammar", () => {
   assert.match(description, /`input` string is freeform text, not JSON/);
 });
 
-// Known gap, pinned rather than repaired: a model that ignores the bridged
-// `{ input: "..." }` schema opens as a custom_tool_call and closes as a
-// function_call, because the close events only convert when the accumulated
-// arguments actually parse. Codex is left with a mismatched pair and no input
-// events at all. Choosing the recovery semantics -- surface the raw text as
-// the patch and let apply_patch reject it, or refuse to convert the open --
-// is a behavior decision, not a cleanup; this test exists so that decision
-// cannot be made by accident.
-test("malformed bridged arguments close a custom_tool_call as a function_call", async () => {
+test("malformed bridged arguments fail closed after a custom_tool_call opens", async () => {
   const namespaces = new Map();
   bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], namespaces);
   const argumentsText = JSON.stringify({ patch: "*** Begin Patch\n*** End Patch" });
@@ -3606,27 +3696,503 @@ test("malformed bridged arguments close a custom_tool_call as a function_call", 
   const source = events
     .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
     .join("");
-  const transform = new NamespaceToolCallTransform(namespaces, "text/event-stream");
-  const output = await collect(Readable.from([Buffer.from(source, "utf8")]).pipe(transform));
-  const payloads = output
-    .split(/\n\n/)
-    .filter(Boolean)
-    .map((block) => JSON.parse(block.split("\n").find((line) => line.startsWith("data: ")).slice(6)));
+  const { output, error } = await collectUntilPipelineError(
+    [Buffer.from(source, "utf8")],
+    new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+  );
+  assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.equal(error.status, 502);
+  assert.match(output.toString("utf8"), /"type":"custom_tool_call"/u);
+  assert.doesNotMatch(output.toString("utf8"), /function_call_arguments\.done/u);
+  assert.doesNotMatch(output.toString("utf8"), /response\.output_item\.done/u);
+});
 
-  assert.deepEqual(
-    payloads.map((event) => event.type),
+test("special relay identities cannot be reused or changed after conversion", async () => {
+  const namespaces = new Map();
+  bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], namespaces);
+  const argumentsText = JSON.stringify({ input: "*** Begin Patch\n*** End Patch" });
+  const open = {
+    type: "response.output_item.added",
+    item: {
+      type: "function_call",
+      id: "fc_identity",
+      call_id: "call_identity",
+      name: "apply_patch",
+      arguments: "",
+    },
+  };
+  const close = {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      id: "fc_identity",
+      call_id: "call_identity",
+      name: "apply_patch",
+      arguments: argumentsText,
+    },
+  };
+  const cases = [
+    {
+      name: "duplicate-item-id",
+      events: [
+        open,
+        {
+          type: "response.output_item.added",
+          marker: "duplicate-item-id",
+          item: {
+            type: "function_call",
+            id: "fc_identity",
+            call_id: "call_ordinary",
+            name: "exec_command",
+            arguments: "",
+          },
+        },
+      ],
+    },
+    {
+      name: "duplicate-call-id",
+      events: [
+        open,
+        {
+          type: "response.output_item.added",
+          marker: "duplicate-call-id",
+          item: {
+            type: "function_call",
+            id: "fc_ordinary",
+            call_id: "call_identity",
+            name: "exec_command",
+            arguments: "",
+          },
+        },
+      ],
+    },
+    {
+      name: "mismatched-close",
+      events: [
+        open,
+        {
+          ...close,
+          marker: "mismatched-close",
+          item: { ...close.item, call_id: "call_other" },
+        },
+      ],
+    },
+    {
+      name: "mismatched-arguments",
+      events: [
+        open,
+        {
+          type: "response.function_call_arguments.done",
+          marker: "mismatched-arguments",
+          item_id: "fc_other",
+          call_id: "call_identity",
+          arguments: argumentsText,
+        },
+      ],
+    },
+    {
+      name: "mismatched-delta-content",
+      events: [
+        open,
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "fc_identity",
+          call_id: "call_identity",
+          delta: JSON.stringify({ input: "first" }),
+        },
+        {
+          type: "response.function_call_arguments.done",
+          marker: "mismatched-delta-content",
+          item_id: "fc_identity",
+          call_id: "call_identity",
+          arguments: JSON.stringify({ input: "second" }),
+        },
+      ],
+    },
+    {
+      name: "mixed-native-delta",
+      events: [
+        open,
+        {
+          type: "response.custom_tool_call_input.delta",
+          marker: "mixed-native-delta",
+          item_id: "fc_identity",
+          call_id: "call_identity",
+          delta: "patch",
+        },
+      ],
+    },
+    {
+      name: "duplicate-close",
+      events: [open, close, { ...close, marker: "duplicate-close" }],
+    },
+    {
+      name: "mismatched-completed-summary",
+      events: [
+        open,
+        close,
+        {
+          type: "response.completed",
+          marker: "mismatched-completed-summary",
+          response: {
+            output: [
+              {
+                type: "function_call",
+                id: "fc_identity",
+                call_id: "call_identity",
+                name: "exec_command",
+                arguments: "{}",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ];
+
+  for (const fixture of cases) {
+    const source = fixture.events
+      .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+      .join("");
+    const { output, error } = await collectUntilPipelineError(
+      [Buffer.from(source, "utf8")],
+      new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+    );
+    assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM", fixture.name);
+    assert.match(output.toString("utf8"), /"type":"custom_tool_call"/u);
+    assert.doesNotMatch(output.toString("utf8"), new RegExp(fixture.name, "u"));
+  }
+
+  const ordinaryFirst = [
+    {
+      type: "response.output_item.added",
+      item: {
+        type: "function_call",
+        id: "fc_shared",
+        call_id: "call_ordinary_first",
+        name: "exec_command",
+        arguments: "",
+      },
+    },
+    {
+      type: "response.output_item.added",
+      item: {
+        type: "function_call",
+        id: "fc_shared",
+        call_id: "call_custom_second",
+        name: "apply_patch",
+        arguments: "",
+      },
+    },
+  ];
+  const ordinaryFirstSource = Buffer.from(
+    ordinaryFirst
+      .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+      .join(""),
+    "utf8",
+  );
+  const ordinaryFirstOutput = await collectBuffer(
+    Readable.from([ordinaryFirstSource]).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+    ),
+  );
+  assert.deepEqual(ordinaryFirstOutput, ordinaryFirstSource);
+
+  const boundedOrdinary = [
+    {
+      type: "response.output_item.added",
+      item: { type: "message", id: "msg_1" },
+    },
+    {
+      type: "response.output_item.added",
+      item: { type: "message", id: "msg_2" },
+    },
+  ];
+  const boundedOrdinarySource = Buffer.from(
+    boundedOrdinary
+      .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+      .join(""),
+    "utf8",
+  );
+  const boundedOrdinaryOutput = await collectBuffer(
+    Readable.from([boundedOrdinarySource]).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+        maxTrackedOutputItems: 1,
+      }),
+    ),
+  );
+  assert.deepEqual(boundedOrdinaryOutput, boundedOrdinarySource);
+
+  const overLimit = {
+    type: "response.output_item.added",
+    marker: "post-commit-identity-limit",
+    item: { type: "message", id: "msg_after_custom" },
+  };
+  const overLimitSource = [open, overLimit]
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  const boundedCommitted = await collectUntilPipelineError(
+    [Buffer.from(overLimitSource, "utf8")],
+    new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+      maxTrackedOutputItems: 1,
+    }),
+  );
+  assert.equal(boundedCommitted.error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.doesNotMatch(boundedCommitted.output.toString("utf8"), /post-commit-identity-limit/u);
+});
+
+test("special closes and terminal summaries require a registered opening", async () => {
+  const collaboration = {
+    type: "namespace",
+    name: "collaboration",
+    tools: [{ type: "function", name: "spawn_agent" }],
+  };
+  const custom = flattenNamespaceTools([collaboration]);
+  bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], custom.namespaces);
+  const search = flattenNamespaceTools([collaboration, clientToolSearchControl()]);
+  const specials = [
+    {
+      name: "custom",
+      namespaces: custom.namespaces,
+      item: {
+        type: "function_call",
+        id: "fc_done_only_custom",
+        call_id: "call_done_only_custom",
+        name: "apply_patch",
+        arguments: JSON.stringify({ input: "patch" }),
+      },
+    },
+    {
+      name: "tool-search",
+      namespaces: search.namespaces,
+      item: {
+        type: "function_call",
+        id: "fc_done_only_search",
+        call_id: "call_done_only_search",
+        name: "tool_search",
+        arguments: JSON.stringify({ query: "calendar" }),
+      },
+    },
+  ];
+  const prefix = {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      name: "collaboration__spawn_agent",
+      arguments: "{}",
+    },
+  };
+
+  for (const special of specials) {
+    for (const shape of ["done", "summary"]) {
+      const marker = `${special.name}-${shape}-without-open`;
+      const event =
+        shape === "done"
+          ? { type: "response.output_item.done", marker, item: special.item }
+          : {
+              type: "response.completed",
+              marker,
+              response: { output: [special.item] },
+            };
+      const frame = Buffer.from(
+        `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+        "utf8",
+      );
+      const preserved = await collectBuffer(
+        Readable.from([frame]).pipe(
+          new NamespaceToolCallTransform(special.namespaces, "text/event-stream"),
+        ),
+      );
+      assert.deepEqual(preserved, frame, marker);
+
+      const committedPrefix = Buffer.from(
+        `event: ${prefix.type}\ndata: ${JSON.stringify(prefix)}\n\n`,
+        "utf8",
+      );
+      const { output, error } = await collectUntilPipelineError(
+        [committedPrefix, frame],
+        new NamespaceToolCallTransform(special.namespaces, "text/event-stream"),
+      );
+      assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM", marker);
+      assert.match(output.toString("utf8"), /"namespace":"collaboration"/u);
+      assert.doesNotMatch(output.toString("utf8"), new RegExp(marker, "u"));
+    }
+  }
+});
+
+test("invalid or inconsistent tool_search arguments fail closed after conversion", async () => {
+  const { namespaces } = flattenNamespaceTools([clientToolSearchControl()]);
+  const open = {
+    type: "response.output_item.added",
+    item: {
+      type: "function_call",
+      id: "fc_search_bad",
+      call_id: "call_search_bad",
+      name: "tool_search",
+      arguments: "",
+    },
+  };
+  const fixtures = [
     [
-      "response.output_item.added",
-      "response.function_call_arguments.done",
-      "response.output_item.done",
+      {
+        type: "response.function_call_arguments.done",
+        item_id: "fc_search_bad",
+        call_id: "call_search_bad",
+        arguments: "[]",
+      },
     ],
-  );
-  assert.equal(payloads[0].item.type, "custom_tool_call");
-  assert.equal(payloads[2].item.type, "function_call");
-  assert.equal(
-    payloads.some((event) => event.type.startsWith("response.custom_tool_call_input.")),
-    false,
-  );
+    [
+      {
+        type: "response.function_call_arguments.done",
+        item_id: "fc_search_bad",
+        call_id: "call_search_bad",
+        arguments: JSON.stringify({ query: "calendar" }),
+      },
+      {
+        type: "response.output_item.done",
+        item: {
+          ...open.item,
+          arguments: JSON.stringify({ query: "mail" }),
+        },
+      },
+    ],
+  ];
+  for (const tail of fixtures) {
+    const source = [open, ...tail]
+      .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+      .join("");
+    const { output, error } = await collectUntilPipelineError(
+      [Buffer.from(source, "utf8")],
+      new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+    );
+    assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+    assert.match(output.toString("utf8"), /"type":"tool_search_call"/u);
+    assert.doesNotMatch(output.toString("utf8"), /function_call_arguments\.done/u);
+    assert.doesNotMatch(output.toString("utf8"), /response\.output_item\.done/u);
+  }
+});
+
+test("converted custom and tool_search calls must close before terminal or EOF", async () => {
+  const customNamespaces = new Map();
+  bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], customNamespaces);
+  const { namespaces: searchNamespaces } = flattenNamespaceTools([clientToolSearchControl()]);
+  const fixtures = [
+    {
+      name: "custom-eof",
+      namespaces: customNamespaces,
+      item: {
+        type: "function_call",
+        id: "fc_custom_eof",
+        call_id: "call_custom_eof",
+        name: "apply_patch",
+        arguments: "",
+      },
+      terminal: "",
+    },
+    {
+      name: "custom-done",
+      namespaces: customNamespaces,
+      item: {
+        type: "function_call",
+        id: "fc_custom_done",
+        call_id: "call_custom_done",
+        name: "apply_patch",
+        arguments: "",
+      },
+      terminal: "data: [DONE]\n\n",
+    },
+    {
+      name: "custom-completed",
+      namespaces: customNamespaces,
+      item: {
+        type: "function_call",
+        id: "fc_custom_completed",
+        call_id: "call_custom_completed",
+        name: "apply_patch",
+        arguments: "",
+      },
+      terminal:
+        'event: response.completed\ndata: {"type":"response.completed","response":{"output":[]}}\n\n',
+    },
+    {
+      name: "tool-search-eof",
+      namespaces: searchNamespaces,
+      item: {
+        type: "function_call",
+        id: "fc_search_eof",
+        call_id: "call_search_eof",
+        name: "tool_search",
+        arguments: "",
+      },
+      terminal: "",
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const added = {
+      type: "response.output_item.added",
+      item: fixture.item,
+    };
+    const source =
+      `event: ${added.type}\ndata: ${JSON.stringify(added)}\n\n` + fixture.terminal;
+    const { output, error } = await collectUntilPipelineError(
+      [Buffer.from(source, "utf8")],
+      new NamespaceToolCallTransform(fixture.namespaces, "text/event-stream"),
+    );
+    assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM", fixture.name);
+    assert.match(output.toString("utf8"), /"type":"(?:custom_tool_call|tool_search_call)"/u);
+    assert.doesNotMatch(output.toString("utf8"), /\[DONE\]|response\.completed/u);
+  }
+});
+
+test("special openings without stable identities fail open before byte mutation", async () => {
+  const customNamespaces = new Map();
+  bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], customNamespaces);
+  const { namespaces: searchNamespaces } = flattenNamespaceTools([clientToolSearchControl()]);
+  const fixtures = [
+    {
+      namespaces: customNamespaces,
+      item: {
+        type: "function_call",
+        call_id: "call_missing_item",
+        name: "apply_patch",
+        arguments: "",
+      },
+    },
+    {
+      namespaces: customNamespaces,
+      item: {
+        type: "function_call",
+        id: "fc_missing_call",
+        name: "apply_patch",
+        arguments: "",
+      },
+    },
+    {
+      namespaces: searchNamespaces,
+      item: {
+        type: "function_call",
+        id: "",
+        call_id: "call_search_missing_item",
+        name: "tool_search",
+        arguments: "",
+      },
+    },
+  ];
+
+  for (const fixture of fixtures) {
+    const event = { type: "response.output_item.added", item: fixture.item };
+    const source = Buffer.from(
+      `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+      "utf8",
+    );
+    const output = await collectBuffer(
+      Readable.from([source]).pipe(
+        new NamespaceToolCallTransform(fixture.namespaces, "text/event-stream"),
+      ),
+    );
+    assert.deepEqual(output, source);
+  }
 });
 
 test("a well-formed bridged call closes as the custom_tool_call it opened", async () => {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { Readable } from "node:stream";
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import test from "node:test";
 
 import {
@@ -29,6 +30,36 @@ function collect(stream) {
     stream.on("end", () => resolve(output));
     stream.on("error", reject);
   });
+}
+
+function collectBuffer(stream) {
+  return new Promise((resolve, reject) => {
+    const output = [];
+    stream.on("data", (chunk) => output.push(Buffer.from(chunk)));
+    stream.on("end", () => resolve(Buffer.concat(output)));
+    stream.on("error", reject);
+  });
+}
+
+async function collectUntilPipelineError(chunks, transform) {
+  const output = [];
+  let error;
+  try {
+    await pipeline(
+      Readable.from(chunks),
+      transform,
+      new Writable({
+        write(chunk, _encoding, callback) {
+          output.push(Buffer.from(chunk));
+          callback();
+        },
+      }),
+    );
+  } catch (caught) {
+    error = caught;
+  }
+  assert.ok(error, "the transform should fail after committing semantic output");
+  return { output: Buffer.concat(output), error };
 }
 
 // The reduced codex_app namespace the client actually sends on routed requests
@@ -2103,6 +2134,763 @@ test("non-streaming rewrite covers nested output and leaves malformed JSON untou
   const malformed = "{not valid json\n";
   const transform = new NamespaceToolCallTransform(namespaces, "application/json");
   assert.equal(await collect(Readable.from([malformed]).pipe(transform)), malformed);
+});
+
+test("response transform preserves no-op SSE and JSON bytes exactly", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const sse = Buffer.from(
+    'event: response.created\r\n' +
+      'id: provider-spelling\r\n' +
+      'data: { "type" : "response.created", "ratio": 1.00e+2, "nested": { "ok": true } }\r\n' +
+      "\r\n",
+    "utf8",
+  );
+  const streamed = await collectBuffer(
+    Readable.from([...sse].map((byte) => Buffer.from([byte]))).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+    ),
+  );
+  assert.deepEqual(streamed, sse);
+
+  const jsonBody = Buffer.from(
+    '\r\n { "id" : "resp-noop", "ratio" : 1.00e+2, "output" : [ { "type" : "message", "content" : [] } ] } \t',
+    "utf8",
+  );
+  const jsonOutput = await collectBuffer(
+    Readable.from([jsonBody.subarray(0, 7), jsonBody.subarray(7)]).pipe(
+      new NamespaceToolCallTransform(namespaces, "application/json"),
+    ),
+  );
+  assert.deepEqual(jsonOutput, jsonBody);
+});
+
+test("ambiguous SSE frames fail closed before namespace rewriting", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const later = Buffer.from(
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n',
+    "utf8",
+  );
+  const duplicate = Buffer.from(
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"ordinary","\\u006eame":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n',
+    "utf8",
+  );
+  const malformed = Buffer.from('data: {"type":\r\n\r\n', "utf8");
+  const invalidUtf8 = Buffer.concat([
+    Buffer.from("data: ", "ascii"),
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from("\r\n\r\n", "ascii"),
+  ]);
+
+  for (const ambiguous of [duplicate, malformed, invalidUtf8]) {
+    const source = Buffer.concat([ambiguous, later]);
+    const output = await collectBuffer(
+      Readable.from([...source].map((byte) => Buffer.from([byte]))).pipe(
+        new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+      ),
+    );
+    assert.deepEqual(output, source);
+  }
+});
+
+test("repeated SSE data or event fields disable rewriting without normalizing CRLF", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const later =
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n';
+  const repeatedData =
+    'event: response.output_item.done\r\n' +
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n' +
+    'data: {"second":"competing EventSource payload"}\r\n\r\n';
+  const repeatedEvent =
+    'event: response.output_item.done\r\n' +
+    'event: response.completed\r\n' +
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n';
+  for (const ambiguous of [repeatedData, repeatedEvent]) {
+    const source = Buffer.from(ambiguous + later, "utf8");
+    const fragments = [...source].map((byte) => Buffer.from([byte]));
+    const output = await collectBuffer(
+      Readable.from(fragments).pipe(
+        new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+      ),
+    );
+    assert.deepEqual(output, source);
+  }
+});
+
+test("raw SSE framing honors downstream backpressure and aborts cleanly", async () => {
+  const source = Buffer.from(
+    'event: response.created\r\ndata: { "type": "response.created", "value": 1.00e+2 }\r\n\r\n',
+    "utf8",
+  );
+  const output = [];
+  await pipeline(
+    Readable.from([...source].map((byte) => Buffer.from([byte]))),
+    new NamespaceToolCallTransform(new Map(), "text/event-stream"),
+    new Writable({
+      highWaterMark: 1,
+      write(chunk, _encoding, callback) {
+        output.push(Buffer.from(chunk));
+        setImmediate(callback);
+      },
+    }),
+  );
+  assert.deepEqual(Buffer.concat(output), source);
+
+  const controller = new AbortController();
+  const transform = new NamespaceToolCallTransform(new Map(), "");
+  let prefixSent = false;
+  const stalledSource = new Readable({
+    read() {
+      if (prefixSent) return;
+      prefixSent = true;
+      this.push(Buffer.from("da", "ascii"));
+    },
+  });
+  const aborted = pipeline(
+    stalledSource,
+    transform,
+    new Writable({ write(_chunk, _encoding, callback) { callback(); } }),
+    { signal: controller.signal },
+  );
+  setImmediate(() => controller.abort());
+  await assert.rejects(aborted, { name: "AbortError" });
+  assert.equal(transform.destroyed, true);
+  stalledSource.destroy();
+});
+
+test("ambiguous non-streaming JSON is preserved byte for byte", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const duplicate = Buffer.from(
+    '{"output":[{"type":"function_call","name":"ordinary","\\u006eame":"collaboration__spawn_agent","arguments":"{}"}]}',
+    "utf8",
+  );
+  const malformed = Buffer.from('{"output":[', "utf8");
+  const invalidUtf8 = Buffer.concat([
+    Buffer.from(
+      '{"output":[{"type":"function_call","name":"collaboration__spawn_agent","note":"',
+      "utf8",
+    ),
+    Buffer.from([0xff]),
+    Buffer.from('","arguments":"{}"}]}', "utf8"),
+  ]);
+  for (const body of [duplicate, malformed, invalidUtf8]) {
+    const output = await collectBuffer(
+      Readable.from([body.subarray(0, 3), body.subarray(3)]).pipe(
+        new NamespaceToolCallTransform(namespaces, "application/json"),
+      ),
+    );
+    assert.deepEqual(output, body);
+  }
+});
+
+test("lossy JSON numbers fail closed before SSE or JSON namespace rewrites", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const call =
+    '"item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}';
+  const output =
+    '"output":[{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}]';
+  const later =
+    'event: response.output_item.done\r\n' +
+    `data: {"type":"response.output_item.done",${call}}\r\n\r\n`;
+
+  for (const numberText of [
+    "9007199254740993",
+    "1e999",
+    "-0",
+    "1e-324",
+    "0.100000000000000005",
+  ]) {
+    const sse = Buffer.from(
+      'event: response.output_item.done\r\n' +
+        `data: {"type":"response.output_item.done","provider_number":${numberText},${call}}\r\n\r\n` +
+        later,
+      "utf8",
+    );
+    const streamed = await collectBuffer(
+      Readable.from([...sse].map((byte) => Buffer.from([byte]))).pipe(
+        new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+      ),
+    );
+    assert.deepEqual(streamed, sse, numberText);
+
+    const json = Buffer.from(`{"provider_number":${numberText},${output}}`, "utf8");
+    const jsonOutput = await collectBuffer(
+      Readable.from([json.subarray(0, 5), json.subarray(5)]).pipe(
+        new NamespaceToolCallTransform(namespaces, "application/json"),
+      ),
+    );
+    assert.deepEqual(jsonOutput, json, numberText);
+
+    const argumentsLiteral = JSON.stringify(`{"provider_number":${numberText}}`);
+    const nestedItem =
+      '"item":{"type":"function_call","name":"collaboration__spawn_agent",' +
+      `"arguments":${argumentsLiteral}}`;
+    const nestedSse = Buffer.from(
+      'event: response.output_item.done\r\n' +
+        `data: {"type":"response.output_item.done",${nestedItem}}\r\n\r\n` +
+        later,
+      "utf8",
+    );
+    const nestedStreamed = await collectBuffer(
+      Readable.from([nestedSse]).pipe(
+        new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+      ),
+    );
+    assert.deepEqual(nestedStreamed, nestedSse, `nested ${numberText}`);
+
+    const nestedJson = Buffer.from(
+      '{"output":[{"type":"function_call","name":"collaboration__spawn_agent",' +
+        `"arguments":${argumentsLiteral}}]}`,
+      "utf8",
+    );
+    const nestedJsonOutput = await collectBuffer(
+      Readable.from([nestedJson]).pipe(
+        new NamespaceToolCallTransform(namespaces, "application/json"),
+      ),
+    );
+    assert.deepEqual(nestedJsonOutput, nestedJson, `nested ${numberText}`);
+  }
+});
+
+test("exactly equivalent decimal spellings remain eligible for namespace rewrites", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  for (const [numberText, expected] of [["1.0", 1], ["1e3", 1000]]) {
+    const item =
+      '"item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}';
+    const sse = Buffer.from(
+      'event: response.output_item.done\r\n' +
+        `data: {"type":"response.output_item.done","provider_number":${numberText},${item}}\r\n\r\n`,
+      "utf8",
+    );
+    const streamed = await collect(
+      Readable.from([sse]).pipe(
+        new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+      ),
+    );
+    const event = JSON.parse(
+      streamed.split(/\r?\n/u).find((line) => line.startsWith("data: ")).slice(6),
+    );
+    assert.equal(event.provider_number, expected);
+    assert.equal(event.item.name, "spawn_agent");
+    assert.equal(event.item.namespace, "collaboration");
+
+    const json = Buffer.from(
+      `{"provider_number":${numberText},"output":[{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}]}`,
+      "utf8",
+    );
+    const payload = JSON.parse(
+      await collect(
+        Readable.from([json]).pipe(
+          new NamespaceToolCallTransform(namespaces, "application/json"),
+        ),
+      ),
+    );
+    assert.equal(payload.provider_number, expected);
+    assert.equal(payload.output[0].name, "spawn_agent");
+    assert.equal(payload.output[0].namespace, "collaboration");
+  }
+});
+
+test("inject-only responses preserve lossy decimal payloads without injecting", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "interrupt_agent" }],
+    },
+  ]);
+  for (const numberText of ["1e-324", "0.100000000000000005"]) {
+    const sse = Buffer.from(
+      'event: response.completed\r\n' +
+        `data: {"type":"response.completed","provider_number":${numberText},"response":{"output":[]}}\r\n\r\n`,
+      "utf8",
+    );
+    const streamed = await collectBuffer(
+      Readable.from([sse]).pipe(
+        new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+          injectOnly: true,
+          pendingInterrupts: ["/root/finished"],
+        }),
+      ),
+    );
+    assert.deepEqual(streamed, sse, numberText);
+
+    const json = Buffer.from(
+      `{"provider_number":${numberText},"output":[]}`,
+      "utf8",
+    );
+    const jsonOutput = await collectBuffer(
+      Readable.from([json]).pipe(
+        new NamespaceToolCallTransform(namespaces, "application/json", undefined, {
+          injectOnly: true,
+          pendingInterrupts: ["/root/finished"],
+        }),
+      ),
+    );
+    assert.deepEqual(jsonOutput, json, numberText);
+  }
+});
+
+test("conflicting SSE event and payload types disable terminal decisions", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [
+        { type: "function", name: "spawn_agent" },
+        { type: "function", name: "interrupt_agent" },
+      ],
+    },
+  ]);
+  const mismatchByEvent =
+    'event: response.completed\r\n' +
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n';
+  const mismatchByPayload =
+    'event: response.output_item.done\r\n' +
+    'data: {"type":"response.completed","response":{"output":[]}}\r\n\r\n';
+  const missingPayloadType =
+    'event: response.completed\r\n' +
+    'data: {"response":{"output":[]}}\r\n\r\n';
+  const nullPayloadType =
+    'event: response.completed\r\n' +
+    'data: {"type":null,"response":{"output":[]}}\r\n\r\n';
+  const tabIsPartOfEventValue =
+    'event:\tresponse.output_item.done\r\n' +
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n';
+  const secondSpaceIsPartOfEventValue =
+    'event:  response.output_item.done\r\n' +
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n';
+  const later =
+    'event: response.output_item.done\r\n' +
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n';
+
+  for (const mismatch of [
+    mismatchByEvent,
+    mismatchByPayload,
+    missingPayloadType,
+    nullPayloadType,
+    tabIsPartOfEventValue,
+    secondSpaceIsPartOfEventValue,
+  ]) {
+    const source = Buffer.from(mismatch + later, "utf8");
+    const transformed = await collectBuffer(
+      Readable.from([...source].map((byte) => Buffer.from([byte]))).pipe(
+        new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+          pendingInterrupts: ["/root/finished"],
+        }),
+      ),
+    );
+    assert.deepEqual(transformed, source);
+  }
+});
+
+test("raw SSE framing handles CR, LF, and CRLF across one-byte chunks", async () => {
+  const source = Buffer.from(
+    'event: response.created\rdata: { "type": "response.created", "kind": "cr" }\r\r' +
+      'event: response.created\ndata: { "type": "response.created", "kind": "lf" }\n\n' +
+      'event: response.created\r\ndata: { "type": "response.created", "kind": "crlf" }\r\n\r\n',
+    "utf8",
+  );
+  const output = await collectBuffer(
+    Readable.from([...source].map((byte) => Buffer.from([byte]))).pipe(
+      new NamespaceToolCallTransform(new Map(), "text/event-stream"),
+    ),
+  );
+  assert.deepEqual(output, source);
+});
+
+test("headerless bare-CR streams rewrite and generated interrupts adopt CR", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [
+        { type: "function", name: "spawn_agent" },
+        { type: "function", name: "interrupt_agent" },
+      ],
+    },
+  ]);
+  const source = Buffer.from(
+    '\r: provider prelude\r' +
+      'event: response.output_item.done\r' +
+      'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\r',
+    "utf8",
+  );
+  const output = await collectBuffer(
+    Readable.from([...source].map((byte) => Buffer.from([byte]))).pipe(
+      new NamespaceToolCallTransform(namespaces, ""),
+    ),
+  );
+  assert.match(output.toString("utf8"), /"namespace":"collaboration"/u);
+  assert.equal(output.includes(0x0a), false);
+
+  const terminal = Buffer.from(
+    'event: response.completed\r' +
+      'data: {"type":"response.completed","response":{"output":[]}}\r\r',
+    "utf8",
+  );
+  const injected = await collectBuffer(
+    Readable.from([...terminal].map((byte) => Buffer.from([byte]))).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+        pendingInterrupts: ["/root/finished"],
+      }),
+    ),
+  );
+  assert.match(injected.toString("utf8"), /"name":"interrupt_agent"/u);
+  assert.equal(injected.includes(0x0a), false);
+});
+
+test("an initial SSE BOM is ignored for parsing and preserved in output", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [
+        { type: "function", name: "spawn_agent" },
+        { type: "function", name: "interrupt_agent" },
+      ],
+    },
+  ]);
+  const bom = Buffer.from([0xef, 0xbb, 0xbf]);
+  const matching = Buffer.concat([
+    bom,
+    Buffer.from(
+      'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n',
+      "utf8",
+    ),
+  ]);
+  const rewritten = await collectBuffer(
+    Readable.from([...matching].map((byte) => Buffer.from([byte]))).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+    ),
+  );
+  assert.deepEqual(rewritten.subarray(0, bom.length), bom);
+  assert.match(rewritten.toString("utf8"), /"namespace":"collaboration"/u);
+
+  const disagreement = Buffer.concat([
+    bom,
+    Buffer.from(
+      'event: response.completed\r\n' +
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n' +
+        'event: response.output_item.done\r\n' +
+        'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n',
+      "utf8",
+    ),
+  ]);
+  const preserved = await collectBuffer(
+    Readable.from([...disagreement].map((byte) => Buffer.from([byte]))).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+        pendingInterrupts: ["/root/finished"],
+      }),
+    ),
+  );
+  assert.deepEqual(preserved, disagreement);
+});
+
+test("colonless event and data fields participate in repeated-field ambiguity", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const data =
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n';
+  const later = `${data}\r\n`;
+  for (const ambiguous of [
+    `data\r\n${data}\r\n`,
+    `event\r\nevent: response.output_item.done\r\n${data}\r\n`,
+  ]) {
+    const source = Buffer.from(ambiguous + later, "utf8");
+    const output = await collectBuffer(
+      Readable.from([...source].map((byte) => Buffer.from([byte]))).pipe(
+        new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+      ),
+    );
+    assert.deepEqual(output, source);
+  }
+});
+
+test("duplicate embedded interrupt arguments cannot steer terminal injection state", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "interrupt_agent" }],
+    },
+  ]);
+  const ambiguousArguments =
+    '{"target":"/root/first","\\u0074arget":"/root/second"}';
+  const ambiguousCall = {
+    type: "function_call",
+    name: "interrupt_agent",
+    namespace: "collaboration",
+    call_id: "call_ambiguous",
+    arguments: ambiguousArguments,
+  };
+  const pendingInterrupts = ["/root/first", "/root/second"];
+
+  const events = [
+    {
+      type: "response.output_item.done",
+      sequence_number: 1,
+      item: ambiguousCall,
+    },
+    {
+      type: "response.completed",
+      sequence_number: 2,
+      response: { output: [ambiguousCall] },
+    },
+  ];
+  const sse = Buffer.from(
+    events
+      .map((event) => `event: ${event.type}\r\ndata: ${JSON.stringify(event)}\r\n\r\n`)
+      .join(""),
+    "utf8",
+  );
+  const streamed = await collectBuffer(
+    Readable.from([...sse].map((byte) => Buffer.from([byte]))).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+        pendingInterrupts,
+      }),
+    ),
+  );
+  assert.deepEqual(streamed, sse);
+
+  const jsonBody = Buffer.from(
+    JSON.stringify({ id: "resp_ambiguous", output: [ambiguousCall] }),
+    "utf8",
+  );
+  const jsonOutput = await collectBuffer(
+    Readable.from([jsonBody]).pipe(
+      new NamespaceToolCallTransform(namespaces, "application/json", undefined, {
+        pendingInterrupts,
+      }),
+    ),
+  );
+  assert.deepEqual(jsonOutput, jsonBody);
+});
+
+test("changed SSE retains provider CRLF framing", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const source = Buffer.from(
+    'event: response.output_item.done\r\n' +
+      'id: provider-id\r\n' +
+      'data: { "type": "response.output_item.done", "item": { "type": "function_call", "name": "collaboration__spawn_agent", "arguments": "{}" } }\r\n' +
+      "\r\n",
+    "utf8",
+  );
+  const output = await collectBuffer(
+    Readable.from([source.subarray(0, 13), source.subarray(13)]).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+    ),
+  );
+  const text = output.toString("utf8");
+  assert.match(text, /"name":"spawn_agent"/);
+  assert.match(text, /"namespace":"collaboration"/);
+  assert.ok(text.startsWith("event: response.output_item.done\r\nid: provider-id\r\n"));
+  for (let index = 0; index < output.length; index += 1) {
+    if (output[index] === 0x0a) assert.equal(output[index - 1], 0x0d);
+  }
+});
+
+test("interrupt injection adopts the provider's CRLF framing", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "interrupt_agent" }],
+    },
+  ]);
+  const source = Buffer.from(
+    'event: response.completed\r\n' +
+      'data: {"type":"response.completed","sequence_number":7,"response":{"output":[]}}\r\n' +
+      "\r\n",
+    "utf8",
+  );
+  const output = await collectBuffer(
+    Readable.from([source]).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+        pendingInterrupts: ["/root/finished"],
+      }),
+    ),
+  );
+  assert.match(output.toString("utf8"), /"name":"interrupt_agent"/);
+  for (let index = 0; index < output.length; index += 1) {
+    if (output[index] === 0x0a) assert.equal(output[index - 1], 0x0d);
+  }
+});
+
+test("oversized SSE framing releases bytes and disables later rewrites", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const source = Buffer.from(
+    `data: ${"x".repeat(40)}\n\n` +
+      'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\n\n',
+    "utf8",
+  );
+  const output = await collectBuffer(
+    Readable.from([source]).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+        maxSseFrameBytes: 32,
+      }),
+    ),
+  );
+  assert.deepEqual(output, source);
+});
+
+test("post-rewrite ambiguity errors without leaking raw custom lifecycle bytes", async () => {
+  const namespaces = new Map();
+  bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], namespaces);
+  const committed = Buffer.from(
+    'event: response.output_item.added\n' +
+      'data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_guard","call_id":"call_guard","name":"apply_patch","arguments":""}}\n\n',
+    "utf8",
+  );
+  const marker = "flattened-done-must-not-leak";
+  const ambiguousFrames = [
+    Buffer.from(
+      'event: response.output_item.done\n' +
+        `data: {"type":"response.output_item.done","raw_marker":"${marker}","item":{"type":"function_call","name":"apply_patch"\n\n`,
+      "utf8",
+    ),
+    Buffer.from(
+      'event: response.output_item.done\n' +
+        `data: {"type":"response.output_item.done","raw_marker":"${marker}","item":{"type":"function_call","name":"ordinary","\\u006eame":"apply_patch","arguments":"{}"}}\n\n`,
+      "utf8",
+    ),
+    Buffer.concat([
+      Buffer.from(
+        'event: response.output_item.done\n' +
+          `data: {"type":"response.output_item.done","raw_marker":"${marker}","item":{"type":"function_call","name":"apply_patch","note":"`,
+        "utf8",
+      ),
+      Buffer.from([0xff]),
+      Buffer.from('","arguments":"{}"}}\n\n', "utf8"),
+    ]),
+    Buffer.from(
+      'event: response.output_item.done\n' +
+        `data: {"type":"response.output_item.done","raw_marker":"${marker}","item":{"type":"function_call","name":"apply_patch","arguments":"{}"}}\n` +
+        'data: {"competing":true}\n\n',
+      "utf8",
+    ),
+    Buffer.from(
+      `data: {"type":"response.output_item.done","raw_marker":"${marker}"`,
+      "utf8",
+    ),
+    Buffer.from(
+      'event: response.output_item.done\n' +
+        `data: {"type":"response.output_item.done","raw_marker":"${marker}","item":{"type":"function_call","name":"apply_patch","arguments":"{}"},"padding":"${"x".repeat(1024)}"}\n\n`,
+      "utf8",
+    ),
+  ];
+
+  for (const ambiguous of ambiguousFrames) {
+    const source = Buffer.concat([committed, ambiguous]);
+    const { output, error } = await collectUntilPipelineError(
+      [...source].map((byte) => Buffer.from([byte])),
+      new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+        maxSseFrameBytes: 512,
+      }),
+    );
+    assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+    const text = output.toString("utf8");
+    assert.match(text, /"type":"custom_tool_call"/u);
+    assert.doesNotMatch(text, new RegExp(marker, "u"));
+    assert.doesNotMatch(text, /response\.output_item\.done/u);
+  }
+});
+
+test("suppression and injection also commit the SSE safety boundary", async () => {
+  const marker = "post-commit-ambiguity-must-not-leak";
+  const ambiguous = Buffer.from(
+    'event: response.output_item.done\n' +
+      `data: {"type":"response.output_item.done","raw_marker":"${marker}"\n\n`,
+    "utf8",
+  );
+
+  const suppressionPrefix = Buffer.from(
+    'event: response.output_item.added\n' +
+      'data: {"type":"response.output_item.added","item":{"type":"custom_tool_call","id":"fc_native","call_id":"call_native","name":"apply_patch","input":""}}\n\n' +
+      'event: response.function_call_arguments.delta\n' +
+      'data: {"type":"response.function_call_arguments.delta","item_id":"fc_native","delta":"{\\"input\\":\\""}\n\n',
+    "utf8",
+  );
+  const suppressed = await collectUntilPipelineError(
+    [suppressionPrefix, ambiguous],
+    new NamespaceToolCallTransform(new Map(), "text/event-stream"),
+  );
+  assert.equal(suppressed.error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.match(suppressed.output.toString("utf8"), /"type":"custom_tool_call"/u);
+  assert.doesNotMatch(suppressed.output.toString("utf8"), new RegExp(marker, "u"));
+  assert.doesNotMatch(
+    suppressed.output.toString("utf8"),
+    /response\.function_call_arguments\.delta/u,
+  );
+
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "interrupt_agent" }],
+    },
+  ]);
+  const injected = await collectUntilPipelineError(
+    [Buffer.from("data: [DONE]\n\n", "utf8"), ambiguous],
+    new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+      pendingInterrupts: ["/root/finished"],
+    }),
+  );
+  assert.equal(injected.error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.match(injected.output.toString("utf8"), /"name":"interrupt_agent"/u);
+  assert.doesNotMatch(injected.output.toString("utf8"), new RegExp(marker, "u"));
 });
 
 test("response transform leaves ambiguous and ordinary calls alone", async () => {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -4056,10 +4056,10 @@ test(
       global.gc();
       const before = process.memoryUsage();
       let payloadCharacters = 0;
-      const calls = 256;
+      const calls = 4096;
       for (let index = 0; index < calls; index += 1) {
         const input = String(index) + ":" +
-          String.fromCharCode(65 + (index % 26)).repeat(180_000);
+          String.fromCharCode(65 + (index % 26)).repeat(12_000);
         payloadCharacters += input.length;
         const event = {
           type: "response.output_item.done",
@@ -4090,10 +4090,10 @@ test(
     );
     assert.equal(child.status, 0, child.stderr || child.stdout);
     const measurement = JSON.parse(child.stdout);
-    assert.equal(measurement.calls, 256);
+    assert.equal(measurement.calls, 4096);
     assert.ok(measurement.payloadCharacters > 40 * 1024 * 1024);
     assert.ok(
-      measurement.heapDelta < 8 * 1024 * 1024,
+      measurement.heapDelta < 12 * 1024 * 1024,
       `retained heap grew by ${measurement.heapDelta} bytes for ` +
         `${measurement.payloadCharacters} payload characters`,
     );

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -3941,7 +3941,7 @@ test("special relay identities cannot be reused or changed after conversion", as
   assert.doesNotMatch(boundedCommitted.output.toString("utf8"), /post-commit-identity-limit/u);
 });
 
-test("special closes and terminal summaries require a registered opening", async () => {
+test("complete special closes and terminal summaries establish atomic lifecycles", async () => {
   const collaboration = {
     type: "namespace",
     name: "collaboration",
@@ -3961,14 +3961,153 @@ test("special closes and terminal summaries require a registered opening", async
         name: "apply_patch",
         arguments: JSON.stringify({ input: "patch" }),
       },
+      expected: {
+        type: "custom_tool_call",
+        id: "fc_done_only_custom",
+        call_id: "call_done_only_custom",
+        name: "apply_patch",
+        input: "patch",
+      },
     },
     {
       name: "tool-search",
       namespaces: search.namespaces,
       item: {
         type: "function_call",
-        id: "fc_done_only_search",
         call_id: "call_done_only_search",
+        name: "tool_search",
+        arguments: JSON.stringify({ query: "calendar" }),
+      },
+      expected: {
+        type: "tool_search_call",
+        call_id: "call_done_only_search",
+        execution: "client",
+        arguments: { query: "calendar" },
+      },
+    },
+  ];
+
+  for (const special of specials) {
+    for (const shape of ["done", "summary"]) {
+      const event =
+        shape === "done"
+          ? { type: "response.output_item.done", item: special.item }
+          : {
+              type: "response.completed",
+              response: { output: [special.item] },
+            };
+      const output = await collect(
+        Readable.from([
+          `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+        ]).pipe(
+          new NamespaceToolCallTransform(special.namespaces, "text/event-stream"),
+        ),
+      );
+      const parsed = JSON.parse(
+        output.split("\n").find((line) => line.startsWith("data:")).slice(5).trimStart(),
+      );
+      assert.deepEqual(
+        shape === "done" ? parsed.item : parsed.response.output[0],
+        special.expected,
+        `${special.name}-${shape}`,
+      );
+    }
+
+    const done = { type: "response.output_item.done", item: special.item };
+    const summary = {
+      type: "response.completed",
+      response: { output: [special.item] },
+    };
+    const output = await collect(
+      Readable.from(
+        [done, summary].map(
+          (event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+        ),
+      ).pipe(
+        new NamespaceToolCallTransform(special.namespaces, "text/event-stream"),
+      ),
+    );
+    const parsed = output
+      .split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => JSON.parse(line.slice(5).trimStart()));
+    assert.deepEqual(parsed[0].item, special.expected, `${special.name}-atomic-done`);
+    assert.deepEqual(
+      parsed[1].response.output[0],
+      special.expected,
+      `${special.name}-matching-summary`,
+    );
+  }
+});
+
+test("malformed, contradictory, or reused atomic special lifecycles fail safely", async () => {
+  const collaboration = {
+    type: "namespace",
+    name: "collaboration",
+    tools: [{ type: "function", name: "spawn_agent" }],
+  };
+  const custom = flattenNamespaceTools([collaboration]);
+  bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], custom.namespaces);
+  const search = flattenNamespaceTools([collaboration, clientToolSearchControl()]);
+  const malformed = [
+    {
+      name: "custom-incomplete-arguments",
+      namespaces: custom.namespaces,
+      item: {
+        type: "function_call",
+        id: "fc_bad_custom_arguments",
+        call_id: "call_bad_custom_arguments",
+        name: "apply_patch",
+        arguments: "{}",
+      },
+    },
+    {
+      name: "custom-missing-call-id",
+      namespaces: custom.namespaces,
+      item: {
+        type: "function_call",
+        id: "fc_bad_custom_identity",
+        name: "apply_patch",
+        arguments: JSON.stringify({ input: "patch" }),
+      },
+    },
+    {
+      name: "custom-empty-item-id",
+      namespaces: custom.namespaces,
+      item: {
+        type: "function_call",
+        id: "",
+        call_id: "call_bad_custom_item_id",
+        name: "apply_patch",
+        arguments: JSON.stringify({ input: "patch" }),
+      },
+    },
+    {
+      name: "custom-provider-namespace",
+      namespaces: custom.namespaces,
+      item: {
+        type: "function_call",
+        namespace: "unexpected",
+        call_id: "call_bad_custom_namespace",
+        name: "apply_patch",
+        arguments: JSON.stringify({ input: "patch" }),
+      },
+    },
+    {
+      name: "tool-search-incomplete-arguments",
+      namespaces: search.namespaces,
+      item: {
+        type: "function_call",
+        call_id: "call_bad_search_arguments",
+        name: "tool_search",
+        arguments: "[]",
+      },
+    },
+    {
+      name: "tool-search-missing-call-id",
+      namespaces: search.namespaces,
+      item: {
+        type: "function_call",
         name: "tool_search",
         arguments: JSON.stringify({ query: "calendar" }),
       },
@@ -3983,27 +4122,26 @@ test("special closes and terminal summaries require a registered opening", async
     },
   };
 
-  for (const special of specials) {
+  for (const fixture of malformed) {
     for (const shape of ["done", "summary"]) {
-      const marker = `${special.name}-${shape}-without-open`;
-      const event =
-        shape === "done"
-          ? { type: "response.output_item.done", marker, item: special.item }
-          : {
-              type: "response.completed",
-              marker,
-              response: { output: [special.item] },
-            };
+      const marker = `${fixture.name}-${shape}`;
+      const event = shape === "done"
+        ? { type: "response.output_item.done", marker, item: fixture.item }
+        : {
+            type: "response.completed",
+            marker,
+            response: { output: [fixture.item] },
+          };
       const frame = Buffer.from(
         `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
         "utf8",
       );
       const preserved = await collectBuffer(
         Readable.from([frame]).pipe(
-          new NamespaceToolCallTransform(special.namespaces, "text/event-stream"),
+          new NamespaceToolCallTransform(fixture.namespaces, "text/event-stream"),
         ),
       );
-      assert.deepEqual(preserved, frame, marker);
+      assert.deepEqual(preserved, frame, `${marker}-precommit`);
 
       const committedPrefix = Buffer.from(
         `event: ${prefix.type}\ndata: ${JSON.stringify(prefix)}\n\n`,
@@ -4011,13 +4149,218 @@ test("special closes and terminal summaries require a registered opening", async
       );
       const { output, error } = await collectUntilPipelineError(
         [committedPrefix, frame],
-        new NamespaceToolCallTransform(special.namespaces, "text/event-stream"),
+        new NamespaceToolCallTransform(fixture.namespaces, "text/event-stream"),
       );
       assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM", marker);
       assert.match(output.toString("utf8"), /"namespace":"collaboration"/u);
       assert.doesNotMatch(output.toString("utf8"), new RegExp(marker, "u"));
     }
   }
+
+  const nonterminalSummary = {
+    type: "response.in_progress",
+    marker: "nonterminal-atomic-summary",
+    response: {
+      output: [
+        {
+          type: "function_call",
+          id: "fc_nonterminal_summary",
+          call_id: "call_nonterminal_summary",
+          name: "apply_patch",
+          arguments: JSON.stringify({ input: "patch" }),
+        },
+      ],
+    },
+  };
+  const nonterminalFrame = Buffer.from(
+    `event: ${nonterminalSummary.type}\ndata: ${JSON.stringify(nonterminalSummary)}\n\n`,
+    "utf8",
+  );
+  const nonterminalPreserved = await collectBuffer(
+    Readable.from([nonterminalFrame]).pipe(
+      new NamespaceToolCallTransform(custom.namespaces, "text/event-stream"),
+    ),
+  );
+  assert.deepEqual(nonterminalPreserved, nonterminalFrame);
+
+  const atomicCustom = (id, callId, marker) => ({
+    type: "response.output_item.done",
+    marker,
+    item: {
+      type: "function_call",
+      id,
+      call_id: callId,
+      name: "apply_patch",
+      arguments: JSON.stringify({ input: "patch" }),
+    },
+  });
+  const atomicOrdinary = (id, callId, marker) => ({
+    type: "response.output_item.done",
+    marker,
+    item: {
+      type: "function_call",
+      id,
+      call_id: callId,
+      name: "exec_command",
+      arguments: "{}",
+    },
+  });
+  const first = atomicCustom("fc_atomic_first", "call_atomic_first");
+  const second = atomicCustom("fc_atomic_second", "call_atomic_second");
+  const crossWired = atomicCustom(
+    "fc_atomic_first",
+    "call_atomic_second",
+    "cross-wired-atomic-identity",
+  );
+  const crossWiredSource = [first, second, crossWired]
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  const crossWiredResult = await collectUntilPipelineError(
+    [Buffer.from(crossWiredSource, "utf8")],
+    new NamespaceToolCallTransform(custom.namespaces, "text/event-stream"),
+  );
+  assert.equal(crossWiredResult.error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.doesNotMatch(
+    crossWiredResult.output.toString("utf8"),
+    /cross-wired-atomic-identity/u,
+  );
+
+  const summaryOnly = {
+    type: "response.completed",
+    response: {
+      output: [atomicCustom("fc_summary_once", "call_summary_once").item],
+    },
+  };
+  const duplicateSummary = {
+    ...summaryOnly,
+    marker: "duplicate-atomic-summary",
+  };
+  const duplicateSummarySource = [summaryOnly, duplicateSummary]
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  const duplicateSummaryResult = await collectUntilPipelineError(
+    [Buffer.from(duplicateSummarySource, "utf8")],
+    new NamespaceToolCallTransform(custom.namespaces, "text/event-stream"),
+  );
+  assert.equal(duplicateSummaryResult.error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.doesNotMatch(
+    duplicateSummaryResult.output.toString("utf8"),
+    /duplicate-atomic-summary/u,
+  );
+
+  const ordinaryThenSpecial = [
+    atomicOrdinary("fc_shared_done", "call_shared_done"),
+    atomicCustom(
+      "fc_shared_done",
+      "call_shared_done",
+      "ordinary-then-special-done-reuse",
+    ),
+  ];
+  const ordinaryThenSpecialSource = Buffer.from(
+    ordinaryThenSpecial
+      .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+      .join(""),
+    "utf8",
+  );
+  const ordinaryThenSpecialOutput = await collectBuffer(
+    Readable.from([ordinaryThenSpecialSource]).pipe(
+      new NamespaceToolCallTransform(custom.namespaces, "text/event-stream"),
+    ),
+  );
+  assert.deepEqual(ordinaryThenSpecialOutput, ordinaryThenSpecialSource);
+
+  const specialThenOrdinary = [
+    atomicCustom("fc_special_first", "call_special_first"),
+    atomicOrdinary(
+      "fc_special_first",
+      "call_special_first",
+      "special-then-ordinary-done-reuse",
+    ),
+  ];
+  const specialThenOrdinarySource = specialThenOrdinary
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  const specialThenOrdinaryResult = await collectUntilPipelineError(
+    [Buffer.from(specialThenOrdinarySource, "utf8")],
+    new NamespaceToolCallTransform(custom.namespaces, "text/event-stream"),
+  );
+  assert.equal(specialThenOrdinaryResult.error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.doesNotMatch(
+    specialThenOrdinaryResult.output.toString("utf8"),
+    /special-then-ordinary-done-reuse/u,
+  );
+
+  for (const [name, items] of [
+    [
+      "ordinary-then-special-summary-reuse",
+      [
+        atomicOrdinary("fc_shared_summary", "call_shared_summary").item,
+        atomicCustom("fc_shared_summary", "call_shared_summary").item,
+      ],
+    ],
+    [
+      "special-then-ordinary-summary-reuse",
+      [
+        atomicCustom("fc_shared_summary", "call_shared_summary").item,
+        atomicOrdinary("fc_shared_summary", "call_shared_summary").item,
+      ],
+    ],
+  ]) {
+    const event = {
+      type: "response.completed",
+      marker: name,
+      response: { output: items },
+    };
+    const frame = Buffer.from(
+      `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+      "utf8",
+    );
+    const preserved = await collectBuffer(
+      Readable.from([frame]).pipe(
+        new NamespaceToolCallTransform(custom.namespaces, "text/event-stream"),
+      ),
+    );
+    assert.deepEqual(preserved, frame, `${name}-precommit`);
+
+    const committedPrefix = Buffer.from(
+      `event: ${prefix.type}\ndata: ${JSON.stringify(prefix)}\n\n`,
+      "utf8",
+    );
+    const result = await collectUntilPipelineError(
+      [committedPrefix, frame],
+      new NamespaceToolCallTransform(custom.namespaces, "text/event-stream"),
+    );
+    assert.equal(result.error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM", name);
+    assert.doesNotMatch(result.output.toString("utf8"), new RegExp(name, "u"));
+  }
+
+  const ordinary = {
+    type: "response.output_item.added",
+    item: {
+      type: "function_call",
+      id: "fc_prior_ordinary",
+      call_id: "call_prior_owner",
+      name: "exec_command",
+      arguments: "",
+    },
+  };
+  const contradictory = atomicCustom(
+    "fc_later_special",
+    "call_prior_owner",
+    "contradictory-atomic-owner",
+  );
+  const contradictorySource = Buffer.from(
+    [ordinary, contradictory]
+      .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+      .join(""),
+    "utf8",
+  );
+  const contradictoryOutput = await collectBuffer(
+    Readable.from([contradictorySource]).pipe(
+      new NamespaceToolCallTransform(custom.namespaces, "text/event-stream"),
+    ),
+  );
+  assert.deepEqual(contradictoryOutput, contradictorySource);
 });
 
 test("invalid or inconsistent tool_search arguments fail closed after conversion", async () => {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -2884,6 +2884,96 @@ test("oversized SSE framing releases bytes and disables later rewrites", async (
   assert.deepEqual(output, source);
 });
 
+test("large terminal SSE frames remain valid after a namespace rewrite", async () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const call = {
+    type: "function_call",
+    id: "fc_large_terminal",
+    call_id: "call_large_terminal",
+    name: "collaboration__spawn_agent",
+    arguments: "{}",
+  };
+  const events = [
+    { type: "response.output_item.done", item: call },
+    {
+      type: "response.completed",
+      response: {
+        output: [
+          call,
+          {
+            type: "message",
+            id: "msg_large_terminal",
+            content: [{ type: "output_text", text: "x".repeat(320 * 1024) }],
+          },
+        ],
+      },
+    },
+  ];
+  const frames = events.map((event) =>
+    Buffer.from(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`, "utf8"),
+  );
+  assert.ok(frames[1].length > 256 * 1024);
+
+  const output = await collect(
+    Readable.from(frames).pipe(
+      new NamespaceToolCallTransform(namespaces, "text/event-stream"),
+    ),
+  );
+  const payloads = output
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice(6)));
+  assert.equal(payloads.length, 2);
+  assert.equal(payloads[0].item.namespace, "collaboration");
+  assert.equal(payloads[1].response.output[0].namespace, "collaboration");
+  assert.equal(payloads[1].response.output[1].content[0].text.length, 320 * 1024);
+});
+
+test("unterminated oversized SSE frames release or fail at a fixed byte bound", async () => {
+  const limit = 64 * 1024;
+  const marker = "unterminated-oversized-frame-must-not-leak";
+  const oversized = Buffer.from(
+    `data: {"marker":"${marker}","padding":"${"x".repeat(limit * 2)}`,
+    "utf8",
+  );
+  const precommit = await collectBuffer(
+    Readable.from([oversized]).pipe(
+      new NamespaceToolCallTransform(new Map(), "text/event-stream", undefined, {
+        maxSseFrameBytes: limit,
+      }),
+    ),
+  );
+  assert.deepEqual(precommit, oversized);
+
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  const committed = Buffer.from(
+    'event: response.output_item.done\n' +
+      'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\n\n',
+    "utf8",
+  );
+  const { output, error } = await collectUntilPipelineError(
+    [committed, oversized],
+    new NamespaceToolCallTransform(namespaces, "text/event-stream", undefined, {
+      maxSseFrameBytes: limit,
+    }),
+  );
+  assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.match(output.toString("utf8"), /"namespace":"collaboration"/u);
+  assert.doesNotMatch(output.toString("utf8"), new RegExp(marker, "u"));
+});
+
 test("post-rewrite ambiguity errors without leaking raw custom lifecycle bytes", async () => {
   const namespaces = new Map();
   bridgeCustomTools([{ type: "custom", name: "apply_patch" }], [], namespaces);

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -4522,6 +4522,95 @@ test("malformed, contradictory, or reused atomic special lifecycles fail safely"
   assert.deepEqual(contradictoryOutput, contradictorySource);
 });
 
+test("ordinary nonterminal snapshots reserve identities across compatible repeats", async () => {
+  const flattened = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [{ type: "function", name: "spawn_agent" }],
+    },
+  ]);
+  bridgeCustomTools(
+    [{ type: "custom", name: "apply_patch" }],
+    [],
+    flattened.namespaces,
+  );
+  const ordinary = {
+    type: "function_call",
+    id: "fc_progress_shared",
+    call_id: "call_progress_shared",
+    name: "collaboration__spawn_agent",
+    arguments: "{}",
+  };
+  const progress = {
+    type: "response.in_progress",
+    response: { id: "resp_progress", object: "response", output: [ordinary] },
+  };
+  const progressFrame = Buffer.from(
+    `event: ${progress.type}\ndata: ${JSON.stringify(progress)}\n\n`,
+    "utf8",
+  );
+  const done = { type: "response.output_item.done", item: ordinary };
+  const doneFrame = Buffer.from(
+    `event: ${done.type}\ndata: ${JSON.stringify(done)}\n\n`,
+    "utf8",
+  );
+  const completed = {
+    type: "response.completed",
+    response: { id: "resp_progress", object: "response", output: [ordinary] },
+  };
+  const completedFrame = Buffer.from(
+    `event: ${completed.type}\ndata: ${JSON.stringify(completed)}\n\n`,
+    "utf8",
+  );
+  const compatible = await collect(
+    Readable.from([progressFrame, progressFrame, doneFrame, completedFrame]).pipe(
+      new NamespaceToolCallTransform(flattened.namespaces, "text/event-stream"),
+    ),
+  );
+  const compatiblePayloads = compatible
+    .split("\n")
+    .filter((line) => line.startsWith("data: "))
+    .map((line) => JSON.parse(line.slice(6)));
+  assert.equal(compatiblePayloads.length, 4);
+  const compatibleItems = [
+    compatiblePayloads[0].response.output[0],
+    compatiblePayloads[1].response.output[0],
+    compatiblePayloads[2].item,
+    compatiblePayloads[3].response.output[0],
+  ];
+  for (const item of compatibleItems) {
+    assert.equal(item.id, "fc_progress_shared");
+    assert.equal(item.call_id, "call_progress_shared");
+    assert.equal(item.name, "spawn_agent");
+    assert.equal(item.namespace, "collaboration");
+  }
+
+  const reused = {
+    type: "response.output_item.done",
+    marker: "ordinary-progress-to-special-reuse",
+    item: {
+      type: "function_call",
+      id: "fc_progress_shared",
+      call_id: "call_progress_shared",
+      name: "apply_patch",
+      arguments: JSON.stringify({ input: "patch" }),
+    },
+  };
+  const reusedFrame = Buffer.from(
+    `event: ${reused.type}\ndata: ${JSON.stringify(reused)}\n\n`,
+    "utf8",
+  );
+  const { output, error } = await collectUntilPipelineError(
+    [progressFrame, progressFrame, reusedFrame],
+    new NamespaceToolCallTransform(flattened.namespaces, "text/event-stream"),
+  );
+  assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.equal((output.toString("utf8").match(/"namespace":"collaboration"/gu) || []).length, 2);
+  assert.doesNotMatch(output.toString("utf8"), /ordinary-progress-to-special-reuse/u);
+  assert.doesNotMatch(output.toString("utf8"), /"type":"custom_tool_call"/u);
+});
+
 test("invalid or inconsistent tool_search arguments fail closed after conversion", async () => {
   const { namespaces } = flattenNamespaceTools([clientToolSearchControl()]);
   const open = {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -7463,6 +7463,141 @@ test("router does not compact the same blank-message shape on non-DeepSeek route
   }
 });
 
+test("router response pipelines preserve ambiguous provider bytes exactly", async () => {
+  const validNamespaceEvent = Buffer.from(
+    'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n',
+    "utf8",
+  );
+  const duplicateSse = Buffer.concat([
+    Buffer.from(
+      'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"ordinary","\\u006eame":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n',
+      "utf8",
+    ),
+    validNamespaceEvent,
+  ]);
+  const malformedSse = Buffer.concat([
+    Buffer.from('data: {"type":\r\n\r\n', "utf8"),
+    validNamespaceEvent,
+  ]);
+  const invalidSse = Buffer.concat([
+    Buffer.from("data: ", "ascii"),
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from("\r\n\r\n", "ascii"),
+    validNamespaceEvent,
+  ]);
+  const duplicateJson = Buffer.from(
+    '{"output":[{"type":"function_call","name":"ordinary","\\u006eame":"collaboration__spawn_agent","arguments":"{}"}]}',
+    "utf8",
+  );
+  const malformedJson = Buffer.from('{"output":[', "utf8");
+  const invalidJson = Buffer.concat([
+    Buffer.from(
+      '{"output":[{"type":"function_call","name":"collaboration__spawn_agent","note":"',
+      "utf8",
+    ),
+    Buffer.from([0xff]),
+    Buffer.from('","arguments":"{}"}]}', "utf8"),
+  ]);
+  const postCommitMarker = "raw-flattened-done-must-not-leak";
+  const postCommitFailure = Buffer.from(
+    'event: response.output_item.added\n' +
+      'data: {"type":"response.output_item.added","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":""}}\n\n' +
+      'event: response.output_item.done\n' +
+      `data: {"type":"response.output_item.done","raw_marker":"${postCommitMarker}","item":{"type":"function_call","name":"collaboration__spawn_agent"\n\n`,
+    "utf8",
+  );
+  const replies = new Map([
+    ["duplicate-sse", ["text/event-stream", duplicateSse]],
+    ["malformed-sse", ["text/event-stream", malformedSse]],
+    ["invalid-sse", ["text/event-stream", invalidSse]],
+    ["duplicate-json", ["application/json", duplicateJson]],
+    ["malformed-json", ["application/json", malformedJson]],
+    ["invalid-json", ["application/json", invalidJson]],
+    ["post-commit-failure", ["text/event-stream", postCommitFailure]],
+  ]);
+  const gateway = await mockServer(async (request, response) => {
+    const body = await bodyJson(request);
+    const [contentType, source] = replies.get(body.input);
+    response.writeHead(200, { "Content-Type": contentType });
+    response.end(source);
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+    CODEX_ROUTER_EMPTY_COMPLETION_RETRY: "0",
+  });
+  const tools = [
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [
+        {
+          type: "function",
+          name: "spawn_agent",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    },
+  ];
+  const turn = async (marker, model, stream) => {
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model, input: marker, tools, stream }),
+    });
+    const body = Buffer.from(await response.arrayBuffer());
+    assert.equal(response.status, 200, body.toString("utf8"));
+    return body;
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    // DeepSeek installs its empty-tool-message compatibility transform ahead
+    // of namespace restoration. Malformed and duplicate frames must survive
+    // both stages, and must prevent the later ambiguous call from rewriting.
+    assert.deepEqual(
+      await turn("duplicate-sse", "deepseek/deepseek-v4-flash-vision-exp", true),
+      duplicateSse,
+    );
+    assert.deepEqual(
+      await turn("malformed-sse", "deepseek/deepseek-v4-flash-vision-exp", true),
+      malformedSse,
+    );
+    // Invalid UTF-8 and non-streaming JSON exercise the same namespace stage
+    // inside the ordinary routed pipeline without a text decoder in front.
+    assert.deepEqual(
+      await turn("invalid-sse", "opencode-go/deepseek-v4-flash", true),
+      invalidSse,
+    );
+    assert.deepEqual(
+      await turn("duplicate-json", "opencode-go/deepseek-v4-flash", false),
+      duplicateJson,
+    );
+    assert.deepEqual(
+      await turn("malformed-json", "opencode-go/deepseek-v4-flash", false),
+      malformedJson,
+    );
+    assert.deepEqual(
+      await turn("invalid-json", "opencode-go/deepseek-v4-flash", false),
+      invalidJson,
+    );
+    const failed = await turn(
+      "post-commit-failure",
+      "opencode-go/deepseek-v4-flash",
+      true,
+    );
+    const failureText = failed.toString("utf8");
+    assert.match(failureText, /"namespace":"collaboration"/u);
+    assert.match(failureText, /event: error/u);
+    assert.match(failureText, /local_router_stream_failed/u);
+    assert.doesNotMatch(failureText, new RegExp(postCommitMarker, "u"));
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
 
 test("router repairs malformed Z.ai message envelopes after LiteLLM Responses translation", async () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "zai-responses-compat-router-"));

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -7506,6 +7506,14 @@ test("router response pipelines preserve ambiguous provider bytes exactly", asyn
       `data: {"type":"response.output_item.done","raw_marker":"${postCommitMarker}","item":{"type":"function_call","name":"collaboration__spawn_agent"\n\n`,
     "utf8",
   );
+  const lifecycleMarker = "raw-special-lifecycle-close-must-not-leak";
+  const lifecycleFailure = Buffer.from(
+    'event: response.output_item.added\n' +
+      'data: {"type":"response.output_item.added","item":{"type":"function_call","id":"fc_lifecycle","call_id":"call_lifecycle","name":"apply_patch","arguments":""}}\n\n' +
+      'event: response.function_call_arguments.done\n' +
+      `data: {"type":"response.function_call_arguments.done","raw_marker":"${lifecycleMarker}","item_id":"fc_lifecycle","call_id":"call_lifecycle","arguments":"{\\"patch\\":\\"wrong shape\\"}"}\n\n`,
+    "utf8",
+  );
   const replies = new Map([
     ["duplicate-sse", ["text/event-stream", duplicateSse]],
     ["malformed-sse", ["text/event-stream", malformedSse]],
@@ -7514,6 +7522,7 @@ test("router response pipelines preserve ambiguous provider bytes exactly", asyn
     ["malformed-json", ["application/json", malformedJson]],
     ["invalid-json", ["application/json", invalidJson]],
     ["post-commit-failure", ["text/event-stream", postCommitFailure]],
+    ["special-lifecycle-failure", ["text/event-stream", lifecycleFailure]],
   ]);
   const gateway = await mockServer(async (request, response) => {
     const body = await bodyJson(request);
@@ -7529,6 +7538,7 @@ test("router response pipelines preserve ambiguous provider bytes exactly", asyn
     CODEX_ROUTER_EMPTY_COMPLETION_RETRY: "0",
   });
   const tools = [
+    { type: "custom", name: "apply_patch" },
     {
       type: "namespace",
       name: "collaboration",
@@ -7593,6 +7603,16 @@ test("router response pipelines preserve ambiguous provider bytes exactly", asyn
     assert.match(failureText, /event: error/u);
     assert.match(failureText, /local_router_stream_failed/u);
     assert.doesNotMatch(failureText, new RegExp(postCommitMarker, "u"));
+    const lifecycleFailed = await turn(
+      "special-lifecycle-failure",
+      "opencode-go-responses/grok-4.5",
+      true,
+    );
+    const lifecycleFailureText = lifecycleFailed.toString("utf8");
+    assert.match(lifecycleFailureText, /"type":"custom_tool_call"/u);
+    assert.match(lifecycleFailureText, /event: error/u);
+    assert.match(lifecycleFailureText, /local_router_stream_failed/u);
+    assert.doesNotMatch(lifecycleFailureText, new RegExp(lifecycleMarker, "u"));
   } finally {
     await stopChild(router);
     await closeServer(gateway.server);


### PR DESCRIPTION
## Summary

- preserve JSON and SSE response bytes through namespace relay handling, including large numeric literals, BOMs, invalid UTF-8, and original line endings
- bind tool-search relay lifecycle to the requested tool and call identity, failing closed on cross-wired, duplicate, incomplete, or contradictory streams
- accept self-contained terminal namespace results while retaining bounded, linear-time parsing and safe EOF interruption

## Verification

- full repository suite: 2,780 tests, 2,763 passed, 17 skipped, 0 failed
- namespace relay tests: 102 passed
- namespace routing tests: 19 passed
- focused router control tests: 502 passed
- npm check and git diff --check passed

This is the byte-preserving namespace prerequisite for the translated empty-assistant fix tracked in issue #473. It intentionally does not close that issue by itself.