### PR TITLE
fix: normalize translated phantom assistant items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Translated tool streams no longer expose bridge-only assistant turns.**
+  Bounded, fail-open normalization removes only empty assistant envelopes that
+  LiteLLM's Chat Completions and Anthropic Messages bridges corroborate with a
+  completed tool lifecycle, then compacts the affected output indexes. Real
+  text, reasoning, refusals, malformed or ambiguous streams, and native
+  Responses routes remain untouched. Non-streaming bodies receive equivalent
+  bounded, fail-open handling under an exact terminal-output proof.
+
 - **Live model certification now proves the requested route.** Compatibility
   and smoke probes disable router failover, so a healthy alternate can no
   longer certify a broken preset. Direct probes retained GLM-5.3-Flash on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@
   completed tool lifecycle, then compacts the affected output indexes. Real
   text, reasoning, refusals, malformed or ambiguous streams, and native
   Responses routes remain untouched. Non-streaming bodies receive equivalent
-  bounded, fail-open handling under an exact terminal-output proof.
+  bounded, fail-open handling under an exact terminal-output proof. Direct
+  DeepSeek keeps its narrower provider-specific proof: the historical
+  no-prelude bridge drops its corroborated private-reasoning blank, while the
+  current bridge reconstructs candidate-attached reasoning under the terminal
+  reasoning ID and removes only the separately corroborated blank output.
 
 - **Live model certification now proves the requested route.** Compatibility
   and smoke probes disable router failover, so a healthy alternate can no

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -13,6 +13,7 @@ const MAX_FRAME_JSON_KEY_CODE_UNITS = 128 * 1024;
 const MAX_BODY_JSON_KEY_CODE_UNITS = 1024 * 1024;
 const LF_FRAME_SEPARATOR = Buffer.from("\n\n");
 const CRLF_FRAME_SEPARATOR = Buffer.from("\r\n\r\n");
+const TERMINAL_ONLY_CANDIDATE_SLOT = Symbol("terminal-only-candidate");
 const RESPONSE_EVENT_KEYS = new Set(["type", "sequence_number", "response"]);
 const OUTPUT_ITEM_EVENT_KEYS = new Set([
   "type",
@@ -191,7 +192,10 @@ function validObfuscation(event) {
 
 function exactEventKeys(event) {
   const allowed = EVENT_KEYS.get(event?.type);
-  return allowed !== undefined && exactKeys(event, allowed) && validSequenceNumber(event);
+  const object = plainObject(event);
+  return allowed !== undefined && object !== undefined &&
+    Object.keys(object).every((key) => allowed.has(key) || key === "model") &&
+    validSequenceNumber(event);
 }
 
 function fatalUtf8(buffer) {
@@ -829,6 +833,12 @@ export class TranslatedToolMessageCompatTransform extends Transform {
   #indexItems = new Map();
   #lastSequence = -1;
   #usedTerminalCandidateSequenceReset = false;
+  #modelProvenanceInitialized = false;
+  #eventModelPresent = false;
+  #eventModel;
+  #responseModelPresent = false;
+  #responseModel;
+  #allowTerminalOnlyCandidate;
   #preludeBytes = 0;
   #maxCandidateBytes;
   #maxCandidateMs;
@@ -843,6 +853,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     maxJsonDepth,
     maxJsonMembers,
     maxJsonKeyCodeUnits,
+    allowTerminalOnlyCandidate = false,
   } = {}) {
     super();
     this.#maxCandidateBytes = finiteLimit(
@@ -862,6 +873,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
         maxKeyCodeUnits: MAX_FRAME_JSON_KEY_CODE_UNITS,
       },
     );
+    this.#allowTerminalOnlyCandidate = allowTerminalOnlyCandidate === true;
   }
 
   _transform(chunk, _encoding, callback) {
@@ -965,6 +977,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     if (
       !exactEventKeys(event) ||
       eventItemReference(event).conflict ||
+      !this.#acceptModelProvenance(event) ||
       !this.#acceptSequence(event)
     ) {
       this.#failOpen(frame);
@@ -1036,6 +1049,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     const record = id ? this.#items.get(id) : undefined;
     if (
       this.#usedTerminalCandidateSequenceReset ||
+      this.#lastSequence <= 1 ||
       event.sequence_number !== 1 ||
       event.type !== "response.output_item.done" ||
       !this.#capture ||
@@ -1051,9 +1065,51 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     return true;
   }
 
+  #acceptModelProvenance(event) {
+    const eventModelPresent = Object.prototype.hasOwnProperty.call(event, "model");
+    const eventModel = event.model;
+    const responseEvent = plainObject(event.response);
+    const responseModelPresent = responseEvent !== undefined &&
+      Object.prototype.hasOwnProperty.call(responseEvent, "model");
+    const responseModel = responseEvent?.model;
+    if (
+      (eventModelPresent && (typeof eventModel !== "string" || !eventModel)) ||
+      (responseModelPresent && (typeof responseModel !== "string" || !responseModel)) ||
+      (eventModelPresent && responseModelPresent && eventModel !== responseModel)
+    ) return false;
+
+    if (!this.#modelProvenanceInitialized) {
+      if (event.type !== "response.created") return false;
+      this.#eventModelPresent = eventModelPresent;
+      this.#eventModel = eventModel;
+      this.#responseModelPresent = responseModelPresent;
+      this.#responseModel = responseModel;
+      this.#modelProvenanceInitialized = true;
+      return true;
+    }
+
+    if (
+      eventModelPresent !== this.#eventModelPresent ||
+      (eventModelPresent && eventModel !== this.#eventModel)
+    ) return false;
+    if (responseEvent !== undefined && (
+      responseModelPresent !== this.#responseModelPresent ||
+      (responseModelPresent && responseModel !== this.#responseModel)
+    )) return false;
+    return true;
+  }
+
   #handleAdded(frame, event) {
     const id = itemId(event.item?.id);
     const outputIndex = event.output_index;
+    if (this.#capture?.candidates.some(
+      (candidate) => candidate.terminalOnly && candidate.id !== undefined,
+    )) {
+      this.#failOpen(frame);
+      return;
+    }
+    const terminalOnlyStart = this.#canStartTerminalOnlyCandidate(event);
+    if (terminalOnlyStart) this.#startTerminalOnlyCandidate();
     if (
       !id ||
       !Number.isInteger(outputIndex) ||
@@ -1143,9 +1199,46 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     this.#pushOrHold(frame);
   }
 
+  #canStartTerminalOnlyCandidate(event) {
+    return Boolean(
+      this.#allowTerminalOnlyCandidate &&
+      !this.#capture &&
+      this.#items.size === 0 &&
+      this.#indexItems.size === 0 &&
+      this.#sawInProgress &&
+      this.#eventModelPresent &&
+      this.#responseModelPresent &&
+      this.#responseId?.startsWith("resp_") &&
+      event.output_index === 1 &&
+      exactToolCall(event.item)
+    );
+  }
+
+  #startTerminalOnlyCandidate() {
+    const candidate = {
+      id: undefined,
+      outputIndex: 0,
+      kind: "candidate",
+      done: false,
+      sawTool: false,
+      contentStarted: true,
+      textDone: false,
+      partDone: false,
+      terminalOnly: true,
+    };
+    this.#capture = {
+      frames: [],
+      bytes: 0,
+      candidates: [candidate],
+    };
+    this.#indexItems.set(0, TERMINAL_ONLY_CANDIDATE_SLOT);
+    this.#startTimer();
+  }
+
   #handleItemLifecycle(frame, event) {
     const id = eventItemId(event);
-    const record = id ? this.#items.get(id) : undefined;
+    let record = id ? this.#items.get(id) : undefined;
+    if (!record) record = this.#bindTerminalOnlyCandidate(event, id);
     if (!record || !eventIndexMatches(event, record)) {
       this.#failOpen(frame);
       return;
@@ -1165,6 +1258,30 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       return;
     }
     this.#pushOrHold(frame);
+  }
+
+  #bindTerminalOnlyCandidate(event, id) {
+    const candidate = this.#capture?.candidates.at(-1);
+    const observed = [...this.#items.values()];
+    if (
+      !id ||
+      !candidate?.terminalOnly ||
+      candidate.id !== undefined ||
+      event.type !== "response.output_text.done" ||
+      event.output_index !== 0 ||
+      event.content_index !== 0 ||
+      event.text !== "" ||
+      !(event.logprobs === undefined || event.logprobs === null ||
+        (Array.isArray(event.logprobs) && event.logprobs.length === 0)) ||
+      observed.length === 0 ||
+      observed.some((record) => record.kind === "candidate" || !record.done) ||
+      this.#items.has(id) ||
+      this.#indexItems.get(0) !== TERMINAL_ONLY_CANDIDATE_SLOT
+    ) return undefined;
+    candidate.id = id;
+    this.#items.set(id, candidate);
+    this.#indexItems.set(0, id);
+    return candidate;
   }
 
   #trackPrelude(frame) {
@@ -1387,8 +1504,10 @@ export class TranslatedToolMessageCompatTransform extends Transform {
   }
 
   #handleCompleted(frame, event) {
+    const terminalResponseId = itemId(event.response?.id);
     if (
-      !successfulResponseEnvelope(event.response, "completed", this.#responseId)
+      !successfulResponseEnvelope(event.response, "completed") ||
+      !this.#acceptTerminalResponseId(terminalResponseId)
     ) {
       this.#failOpen(frame);
       return;
@@ -1398,12 +1517,45 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       this.#finished = true;
       return;
     }
-    if (!this.#terminalMatchesCapture(event.response.output)) {
+    if (!this.#terminalMatchesCapture(event.response.output, terminalResponseId)) {
       this.#failOpen(frame);
       return;
     }
     this.#hold(frame);
     if (this.#capture) this.#suppress();
+  }
+
+  #acceptTerminalResponseId(terminalResponseId) {
+    const terminalOnly = this.#capture?.candidates.some(
+      (candidate) => candidate.terminalOnly,
+    );
+    if (terminalOnly) {
+      return Boolean(
+        terminalResponseId !== this.#responseId &&
+        this.#sawInProgress &&
+        this.#usedTerminalCandidateSequenceReset &&
+        this.#eventModelPresent &&
+        this.#responseModelPresent &&
+        this.#responseId?.startsWith("resp_") &&
+        terminalResponseId?.startsWith("resp_")
+      );
+    }
+    if (terminalResponseId === this.#responseId) return true;
+    // The same pinned LiteLLM bridge that resets the empty message's terminal
+    // sequence also rebuilds response.completed under a new resp_* id. Permit
+    // that identity change only after the whole distinctive wire contract has
+    // been observed: in-progress envelope, consistent explicit model fields,
+    // an active captured candidate, and the one admitted terminal reset. The
+    // completed output still has to corroborate every streamed item below.
+    return Boolean(
+      this.#capture &&
+      this.#sawInProgress &&
+      this.#usedTerminalCandidateSequenceReset &&
+      this.#eventModelPresent &&
+      this.#responseModelPresent &&
+      this.#responseId?.startsWith("resp_") &&
+      terminalResponseId?.startsWith("resp_")
+    );
   }
 
   #pushOrHold(frame) {
@@ -1422,9 +1574,9 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     this.#capture.bytes += bytes;
   }
 
-  #terminalMatchesCapture(output) {
+  #terminalMatchesCapture(output, terminalResponseId = this.#responseId) {
     if (output.length !== this.#items.size) return false;
-    const ids = new Set([this.#responseId]);
+    const ids = new Set([this.#responseId, terminalResponseId]);
     for (let index = 0; index < output.length; index += 1) {
       const recordId = this.#indexItems.get(index);
       const record = recordId ? this.#items.get(recordId) : undefined;
@@ -1435,6 +1587,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       ids.add(id);
       if (record.kind === "candidate") {
         if (!record.sawTool || !exactCompletedEmptyMessage(item)) return false;
+        if (record.terminalOnly && id !== record.id) return false;
         // The pinned LiteLLM bridge uses a generated msg_* ID for streaming,
         // but the originating chat-completion ID for this exact terminal
         // empty item. Permit only that candidate slot to change identity; a
@@ -1686,7 +1839,13 @@ export function translatedToolMessageCompatTransform(provider, contentType = "")
   if (!translatedProtocol(provider)) return undefined;
   const mediaType = String(contentType).split(";", 1)[0].trim().toLowerCase();
   if (mediaType === "text/event-stream") {
-    return new TranslatedToolMessageCompatTransform();
+    return new TranslatedToolMessageCompatTransform({
+      // LiteLLM's Anthropic bridge can omit the empty message's opening events
+      // and reveal its index-zero slot only after the first tool has closed.
+      // The stream transform admits that exact terminal-only lifecycle only on
+      // providers whose upstream protocol is Messages.
+      allowTerminalOnlyCandidate: provider.protocol === "anthropic",
+    });
   }
   if (mediaType === "application/json" || mediaType.endsWith("+json")) {
     return new TranslatedToolMessageJsonCompatTransform();

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -1,6 +1,8 @@
 import { Transform } from "node:stream";
 import { isDeepStrictEqual, TextDecoder } from "node:util";
 
+import { jsonNumberIsStableForRewrite } from "./json-number-rewrite.mjs";
+
 const MAX_CANDIDATE_BYTES = 64 * 1024;
 const MAX_CANDIDATE_MS = 1_000;
 const MAX_DIRECT_CAPTURE_MS = 60_000;
@@ -162,6 +164,101 @@ const DIRECT_REASONING_OUTPUT_PART_KEYS = new Set([
   "annotations",
 ]);
 const DIRECT_HISTORICAL_RESPONSE_KEYS = new Set(["id", "status", "output"]);
+
+// Keep an undecided SSE frame in one reusable, geometrically grown buffer.
+// Every input byte is copied and scanned once; completing a frame makes the
+// one independent copy its lifecycle may need to retain. This avoids both the
+// repeated Buffer.concat of a fragmented frame and the repeated whole-buffer
+// delimiter scans that otherwise make one-byte upstream chunks quadratic.
+class SseFrameAccumulator {
+  #storage = Buffer.alloc(0);
+  #length = 0;
+  #maxFrameBytes;
+
+  constructor(maxFrameBytes) {
+    this.#maxFrameBytes = maxFrameBytes;
+  }
+
+  write(value, onFrame) {
+    const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value);
+    for (let index = 0; index < bytes.length; index += 1) {
+      this.#append(bytes[index]);
+      const separator = this.#separator();
+      if (separator) {
+        const original = this.take();
+        if (original.length > this.#maxFrameBytes) {
+          return {
+            oversized: original,
+            remainder: Buffer.from(bytes.subarray(index + 1)),
+          };
+        }
+        const block = original.subarray(0, original.length - separator.length);
+        if (onFrame(block, separator, original) === false) {
+          return {
+            stopped: true,
+            remainder: Buffer.from(bytes.subarray(index + 1)),
+          };
+        }
+        continue;
+      }
+      if (this.#length > this.#maxFrameBytes) {
+        const original = this.take();
+        return {
+          oversized: original,
+          remainder: Buffer.from(bytes.subarray(index + 1)),
+        };
+      }
+    }
+    return undefined;
+  }
+
+  flush(onFrame) {
+    if (!this.#length) return;
+    const original = this.take();
+    onFrame(original, Buffer.alloc(0), original);
+  }
+
+  take() {
+    if (!this.#length) return Buffer.alloc(0);
+    const value = Buffer.from(this.#storage.subarray(0, this.#length));
+    this.#length = 0;
+    return value;
+  }
+
+  #append(byte) {
+    const required = this.#length + 1;
+    if (required > this.#storage.length) {
+      const maximum = this.#maxFrameBytes + 1;
+      const doubled = this.#storage.length ? this.#storage.length * 2 : 1024;
+      const capacity = Math.min(maximum, Math.max(required, doubled));
+      const next = Buffer.allocUnsafe(capacity);
+      if (this.#length) this.#storage.copy(next, 0, 0, this.#length);
+      this.#storage = next;
+    }
+    this.#storage[this.#length] = byte;
+    this.#length = required;
+  }
+
+  #separator() {
+    if (
+      this.#length >= LF_FRAME_SEPARATOR.length &&
+      this.#storage[this.#length - 2] === 0x0a &&
+      this.#storage[this.#length - 1] === 0x0a
+    ) {
+      return LF_FRAME_SEPARATOR;
+    }
+    if (
+      this.#length >= CRLF_FRAME_SEPARATOR.length &&
+      this.#storage[this.#length - 4] === 0x0d &&
+      this.#storage[this.#length - 3] === 0x0a &&
+      this.#storage[this.#length - 2] === 0x0d &&
+      this.#storage[this.#length - 1] === 0x0a
+    ) {
+      return CRLF_FRAME_SEPARATOR;
+    }
+    return undefined;
+  }
+}
 
 const EVENT_KEYS = new Map([
   ["response.created", RESPONSE_EVENT_KEYS],
@@ -339,12 +436,7 @@ function strictJsonPreflight(source, limits) {
         offset += 1;
       }
     }
-    const value = Number(source.slice(start, offset));
-    return (
-      Number.isFinite(value) &&
-      !Object.is(value, -0) &&
-      (!Number.isInteger(value) || Number.isSafeInteger(value))
-    );
+    return jsonNumberIsStableForRewrite(source.slice(start, offset));
   };
   const completeValue = () => {
     const parent = stack.at(-1);
@@ -998,7 +1090,7 @@ function exactDirectCompletedTool(item, tool, expectedArguments) {
 // and bounded. Any deviation releases the held bytes unchanged and disables
 // the repair for the rest of the response.
 export class DeepseekToolMessageCompatTransform extends Transform {
-  #buffer = Buffer.alloc(0);
+  #frames;
   #capture;
   #disabled = false;
   #finished = false;
@@ -1034,6 +1126,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       minimum: 1,
       integer: true,
     });
+    this.#frames = new SseFrameAccumulator(this.#maxFrameBytes);
     this.#jsonLimits = jsonScanLimits(
       { maxJsonDepth, maxJsonMembers, maxJsonKeyCodeUnits },
       {
@@ -1045,36 +1138,34 @@ export class DeepseekToolMessageCompatTransform extends Transform {
 
   _transform(chunk, _encoding, callback) {
     const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    this.#buffer = this.#buffer.length
-      ? Buffer.concat([this.#buffer, piece])
-      : Buffer.from(piece);
     if (this.#disabled || this.#finished) {
-      this.#pushBuffered();
+      this.push(Buffer.from(piece));
       callback();
       return;
     }
-    this.#emitCompleteBlocks();
-    if (this.#disabled || this.#finished) {
-      this.#pushBuffered();
-    } else if (this.#buffer.length > this.#maxFrameBytes) {
-      this.#failOpen();
-      this.#pushBuffered();
-    }
+    const outcome = this.#frames.write(piece, (block, separator, original) => {
+      this.#handleBlock(block, separator, original);
+      return !this.#disabled && !this.#finished;
+    });
+    if (outcome?.oversized) this.#oversizedFrame(outcome.oversized);
+    if (outcome?.remainder?.length) this.push(outcome.remainder);
     callback();
   }
 
   _flush(callback) {
     this.#clearTimers();
     if (this.#disabled || this.#finished) {
-      this.#pushBuffered();
+      this.#pushPendingFrameBytes();
       callback();
       return;
     }
-    this.#emitCompleteBlocks(true);
+    this.#frames.flush((block, separator, original) => {
+      this.#handleBlock(block, separator, original);
+    });
     if (["completed", "sentinel"].includes(this.#capture?.stage)) {
       this.#finishAtEof();
     } else if (this.#capture) this.#failOpen();
-    this.#pushBuffered();
+    this.#pushPendingFrameBytes();
     callback();
   }
 
@@ -1083,46 +1174,10 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     callback(error);
   }
 
-  #emitCompleteBlocks(flush = false) {
-    while (this.#buffer.length && !this.#disabled && !this.#finished) {
-      const crlf = this.#buffer.indexOf(CRLF_FRAME_SEPARATOR);
-      const lf = this.#buffer.indexOf(LF_FRAME_SEPARATOR);
-      let index = -1;
-      let separator = Buffer.alloc(0);
-      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
-        index = crlf;
-        separator = CRLF_FRAME_SEPARATOR;
-      } else if (lf !== -1) {
-        index = lf;
-        separator = LF_FRAME_SEPARATOR;
-      }
-      if (index === -1) {
-        if (!flush) return;
-        const block = Buffer.from(this.#buffer);
-        this.#buffer = Buffer.alloc(0);
-        if (block.length > this.#maxFrameBytes) {
-          this.#oversizedFrame(block);
-          return;
-        }
-        this.#handleBlock(block, Buffer.alloc(0));
-        return;
-      }
-      const end = index + separator.length;
-      const block = Buffer.from(this.#buffer.subarray(0, index));
-      const original = Buffer.from(this.#buffer.subarray(0, end));
-      this.#buffer = Buffer.from(this.#buffer.subarray(end));
-      if (original.length > this.#maxFrameBytes) {
-        this.#oversizedFrame(original);
-        return;
-      }
-      this.#handleBlock(block, separator);
-    }
-  }
-
-  #handleBlock(block, separator) {
+  #handleBlock(block, separator, original = Buffer.concat([block, separator])) {
     const parsedResult = parsedBlock(block, this.#jsonLimits);
     const frame = {
-      original: Buffer.concat([block, separator]),
+      original,
       parsed: parsedResult.parsed,
       separator: separator.toString("ascii"),
     };
@@ -1722,10 +1777,9 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     this.#failOpen(frame);
   }
 
-  #pushBuffered() {
-    if (!this.#buffer.length) return;
-    this.push(this.#buffer);
-    this.#buffer = Buffer.alloc(0);
+  #pushPendingFrameBytes() {
+    const pending = this.#frames.take();
+    if (pending.length) this.push(pending);
   }
 
   #resetWatchdog() {
@@ -1733,7 +1787,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     if (!this.#capture) return;
     this.#watchdogTimer = setTimeout(() => {
       this.#failOpen();
-      this.#pushBuffered();
+      this.#pushPendingFrameBytes();
     }, this.#maxCandidateMs);
     this.#watchdogTimer.unref?.();
   }
@@ -1742,7 +1796,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     if (this.#deadlineTimer || !this.#capture) return;
     this.#deadlineTimer = setTimeout(() => {
       this.#failOpen();
-      this.#pushBuffered();
+      this.#pushPendingFrameBytes();
     }, this.#maxCaptureMs);
     this.#deadlineTimer.unref?.();
   }
@@ -1771,7 +1825,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
 // byte and time budgets. Every ambiguous, malformed, large, or slow shape fails
 // open byte-for-byte and permanently disables the repair for that response.
 export class TranslatedToolMessageCompatTransform extends Transform {
-  #buffer = Buffer.alloc(0);
+  #frames;
   #capture;
   #disabled = false;
   #finished = false;
@@ -1814,6 +1868,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       minimum: 1,
       integer: true,
     });
+    this.#frames = new SseFrameAccumulator(this.#maxFrameBytes);
     this.#jsonLimits = jsonScanLimits(
       { maxJsonDepth, maxJsonMembers, maxJsonKeyCodeUnits },
       {
@@ -1826,36 +1881,34 @@ export class TranslatedToolMessageCompatTransform extends Transform {
 
   _transform(chunk, _encoding, callback) {
     const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    this.#buffer = this.#buffer.length
-      ? Buffer.concat([this.#buffer, piece])
-      : Buffer.from(piece);
     if (this.#disabled || this.#finished) {
-      this.#pushBuffered();
+      this.push(Buffer.from(piece));
       callback();
       return;
     }
-    this.#emitCompleteBlocks();
-    if (this.#disabled || this.#finished) {
-      this.#pushBuffered();
-    } else if (this.#buffer.length > this.#maxFrameBytes) {
-      this.#failOpen();
-      this.#pushBuffered();
-    }
+    const outcome = this.#frames.write(piece, (block, separator, original) => {
+      this.#handleBlock(block, separator, original);
+      return !this.#disabled && !this.#finished;
+    });
+    if (outcome?.oversized) this.#oversizedFrame(outcome.oversized);
+    if (outcome?.remainder?.length) this.push(outcome.remainder);
     callback();
   }
 
   _flush(callback) {
     this.#clearTimer();
     if (this.#disabled || this.#finished) {
-      this.#pushBuffered();
+      this.#pushPendingFrameBytes();
       callback();
       return;
     }
-    this.#emitCompleteBlocks(true);
+    this.#frames.flush((block, separator, original) => {
+      this.#handleBlock(block, separator, original);
+    });
     if (["completed", "sentinel"].includes(this.#capture?.stage)) {
       this.#suppress();
     } else if (this.#capture) this.#failOpen();
-    this.#pushBuffered();
+    this.#pushPendingFrameBytes();
     callback();
   }
 
@@ -1864,46 +1917,10 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     callback(error);
   }
 
-  #emitCompleteBlocks(flush = false) {
-    while (this.#buffer.length && !this.#disabled && !this.#finished) {
-      const crlf = this.#buffer.indexOf(CRLF_FRAME_SEPARATOR);
-      const lf = this.#buffer.indexOf(LF_FRAME_SEPARATOR);
-      let index = -1;
-      let separator = Buffer.alloc(0);
-      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
-        index = crlf;
-        separator = CRLF_FRAME_SEPARATOR;
-      } else if (lf !== -1) {
-        index = lf;
-        separator = LF_FRAME_SEPARATOR;
-      }
-      if (index === -1) {
-        if (!flush) return;
-        const block = Buffer.from(this.#buffer);
-        this.#buffer = Buffer.alloc(0);
-        if (block.length > this.#maxFrameBytes) {
-          this.#oversizedFrame(block);
-          return;
-        }
-        this.#handleBlock(block, Buffer.alloc(0));
-        return;
-      }
-      const end = index + separator.length;
-      const block = Buffer.from(this.#buffer.subarray(0, index));
-      const original = Buffer.from(this.#buffer.subarray(0, end));
-      this.#buffer = Buffer.from(this.#buffer.subarray(end));
-      if (original.length > this.#maxFrameBytes) {
-        this.#oversizedFrame(original);
-        return;
-      }
-      this.#handleBlock(block, separator);
-    }
-  }
-
-  #handleBlock(block, separator) {
+  #handleBlock(block, separator, original = Buffer.concat([block, separator])) {
     const parsedResult = parsedBlock(block, this.#jsonLimits);
     const frame = {
-      original: Buffer.concat([block, separator]),
+      original,
       parsed: parsedResult.parsed,
       separator: separator.toString("ascii"),
     };
@@ -2666,17 +2683,16 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     }
   }
 
-  #pushBuffered() {
-    if (!this.#buffer.length) return;
-    this.push(this.#buffer);
-    this.#buffer = Buffer.alloc(0);
+  #pushPendingFrameBytes() {
+    const pending = this.#frames.take();
+    if (pending.length) this.push(pending);
   }
 
   #startTimer() {
     if (this.#timer || !this.#capture) return;
     this.#timer = setTimeout(() => {
       this.#failOpen();
-      this.#pushBuffered();
+      this.#pushPendingFrameBytes();
     }, this.#maxCandidateMs);
     this.#timer.unref?.();
   }

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -1,11 +1,132 @@
 import { Transform } from "node:stream";
-import { StringDecoder } from "node:string_decoder";
+import { TextDecoder } from "node:util";
 
 const MAX_CANDIDATE_BYTES = 64 * 1024;
 const MAX_CANDIDATE_MS = 1_000;
 const MAX_FRAME_BYTES = 256 * 1024;
 const MAX_JSON_BYTES = 8 * 1024 * 1024;
 const MAX_JSON_MS = 1_000;
+const LF_FRAME_SEPARATOR = Buffer.from("\n\n");
+const CRLF_FRAME_SEPARATOR = Buffer.from("\r\n\r\n");
+const RESPONSE_EVENT_KEYS = new Set(["type", "sequence_number", "response"]);
+const OUTPUT_ITEM_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "output_index",
+  "item",
+]);
+const CONTENT_PART_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "item_id",
+  "output_index",
+  "content_index",
+  "part",
+]);
+const TEXT_DELTA_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "item_id",
+  "output_index",
+  "content_index",
+  "delta",
+  "logprobs",
+  "obfuscation",
+]);
+const TEXT_DONE_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "item_id",
+  "output_index",
+  "content_index",
+  "text",
+  "logprobs",
+]);
+const TOOL_DELTA_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "item_id",
+  "output_index",
+  "delta",
+  "obfuscation",
+]);
+const FUNCTION_DONE_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "item_id",
+  "output_index",
+  "arguments",
+]);
+const CUSTOM_DONE_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "item_id",
+  "output_index",
+  "input",
+]);
+const REASONING_PART_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "item_id",
+  "output_index",
+  "summary_index",
+  "content_index",
+  "part",
+]);
+const REASONING_TEXT_DELTA_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "item_id",
+  "output_index",
+  "summary_index",
+  "content_index",
+  "delta",
+  "obfuscation",
+]);
+const REASONING_TEXT_DONE_EVENT_KEYS = new Set([
+  "type",
+  "sequence_number",
+  "item_id",
+  "output_index",
+  "summary_index",
+  "content_index",
+  "text",
+]);
+const CANDIDATE_MESSAGE_KEYS = new Set([
+  "id",
+  "type",
+  "status",
+  "role",
+  "content",
+  "phase",
+]);
+const FUNCTION_CALL_KEYS = new Set([
+  "id",
+  "type",
+  "status",
+  "arguments",
+  "call_id",
+  "name",
+]);
+const CUSTOM_TOOL_CALL_KEYS = new Set([
+  "id",
+  "type",
+  "status",
+  "input",
+  "call_id",
+  "name",
+]);
+const REASONING_ITEM_KEYS = new Set([
+  "id",
+  "type",
+  "status",
+  "summary",
+  "content",
+  "encrypted_content",
+]);
+const REASONING_PART_KEYS = new Set(["type", "text"]);
+const EMPTY_REASONING_PART_KEYS = new Set(["type", "reasoning"]);
+const REFUSAL_PART_KEYS = new Set(["type", "refusal"]);
 const TERMINAL_EMPTY_PART_KEYS = new Set([
   "type",
   "text",
@@ -21,35 +142,107 @@ const TERMINAL_EMPTY_MESSAGE_KEYS = new Set([
   "phase",
 ]);
 
-function parsedBlock(block) {
+const EVENT_KEYS = new Map([
+  ["response.created", RESPONSE_EVENT_KEYS],
+  ["response.in_progress", RESPONSE_EVENT_KEYS],
+  ["response.completed", RESPONSE_EVENT_KEYS],
+  ["response.output_item.added", OUTPUT_ITEM_EVENT_KEYS],
+  ["response.output_item.done", OUTPUT_ITEM_EVENT_KEYS],
+  ["response.content_part.added", CONTENT_PART_EVENT_KEYS],
+  ["response.content_part.done", CONTENT_PART_EVENT_KEYS],
+  ["response.output_text.delta", TEXT_DELTA_EVENT_KEYS],
+  ["response.output_text.done", TEXT_DONE_EVENT_KEYS],
+  ["response.function_call_arguments.delta", TOOL_DELTA_EVENT_KEYS],
+  ["response.function_call_arguments.done", FUNCTION_DONE_EVENT_KEYS],
+  ["response.custom_tool_call_input.delta", TOOL_DELTA_EVENT_KEYS],
+  ["response.custom_tool_call_input.done", CUSTOM_DONE_EVENT_KEYS],
+  ["response.reasoning_summary_part.added", REASONING_PART_EVENT_KEYS],
+  ["response.reasoning_summary_part.done", REASONING_PART_EVENT_KEYS],
+  ["response.reasoning_summary_text.delta", REASONING_TEXT_DELTA_EVENT_KEYS],
+  ["response.reasoning_summary_text.done", REASONING_TEXT_DONE_EVENT_KEYS],
+  ["response.reasoning_text.delta", REASONING_TEXT_DELTA_EVENT_KEYS],
+  ["response.reasoning_text.done", REASONING_TEXT_DONE_EVENT_KEYS],
+]);
+
+function plainObject(value) {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? value
+    : undefined;
+}
+
+function exactKeys(value, allowed) {
+  const object = plainObject(value);
+  return object !== undefined && Object.keys(object).every((key) => allowed.has(key));
+}
+
+function validSequenceNumber(event) {
+  return event.sequence_number === undefined ||
+    (Number.isInteger(event.sequence_number) && event.sequence_number >= 0);
+}
+
+function validObfuscation(event) {
+  return event.obfuscation === undefined || typeof event.obfuscation === "string";
+}
+
+function exactEventKeys(event) {
+  const allowed = EVENT_KEYS.get(event?.type);
+  return allowed !== undefined && exactKeys(event, allowed) && validSequenceNumber(event);
+}
+
+function fatalUtf8(buffer) {
+  // Preserve a leading BOM as a real code point. It is not part of the
+  // confirmed bridge grammar, so the parser will fail open instead of silently
+  // dropping three raw bytes while decoding a frame or JSON body.
+  return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
+}
+
+function parsedBlock(blockBytes) {
+  let block;
+  try {
+    block = fatalUtf8(blockBytes);
+  } catch {
+    return { invalidUtf8: true };
+  }
   const newline = block.includes("\r\n") ? "\r\n" : "\n";
   const lines = block.split(/\r?\n/);
   const dataLineIndexes = lines
     .map((line, index) => (line.startsWith("data:") ? index : -1))
     .filter((index) => index !== -1);
   const eventLines = lines.filter((line) => line.startsWith("event:"));
-  if (dataLineIndexes.length !== 1 || eventLines.length > 1) return undefined;
+  const unknownLines = lines.filter((line) => {
+    return line !== "" && !line.startsWith("data:") && !line.startsWith("event:");
+  });
+  if (
+    dataLineIndexes.length !== 1 ||
+    eventLines.length > 1 ||
+    unknownLines.length > 0
+  ) {
+    return { malformed: true };
+  }
   const [dataLineIndex] = dataLineIndexes;
   const dataText = lines[dataLineIndex].slice(5).trimStart();
-  if (!dataText || dataText === "[DONE]") return undefined;
+  if (!dataText) return { malformed: true };
+  if (dataText === "[DONE]") {
+    return eventLines.length === 0 ? { done: true } : { malformed: true };
+  }
   try {
     const event = JSON.parse(dataText);
     if (
       eventLines.length === 1 &&
       eventLines[0].slice(6).trim() !== event?.type
     ) {
-      return undefined;
+      return { malformed: true };
     }
-    return { lines, dataLineIndex, newline, event };
+    return { parsed: { lines, dataLineIndex, newline, event } };
   } catch {
-    return undefined;
+    return { malformed: true };
   }
 }
 
 function rewrittenBlock(parsed, event, separator) {
   const lines = [...parsed.lines];
   lines[parsed.dataLineIndex] = `data: ${JSON.stringify(event)}`;
-  return `${lines.join(parsed.newline)}${separator}`;
+  return Buffer.from(`${lines.join(parsed.newline)}${separator}`);
 }
 
 function itemId(value) {
@@ -75,10 +268,13 @@ function isToolCall(item) {
 
 function candidateStart(item) {
   return (
+    exactKeys(item, CANDIDATE_MESSAGE_KEYS) &&
     item?.type === "message" &&
     item.role === "assistant" &&
+    item.status === "in_progress" &&
     Array.isArray(item.content) &&
-    item.content.length === 0
+    item.content.length === 0 &&
+    (item.phase === undefined || item.phase === null)
   );
 }
 
@@ -89,20 +285,27 @@ function finiteLimit(value, fallback, { minimum = 0, integer = false } = {}) {
 
 function exactEmptyPart(part) {
   return (
-    part != null &&
-    typeof part === "object" &&
+    exactKeys(part, TERMINAL_EMPTY_PART_KEYS) &&
     ["output_text", "text"].includes(part.type) &&
-    part.text === ""
+    part.text === "" &&
+    (part.annotations === undefined ||
+      (Array.isArray(part.annotations) && part.annotations.length === 0)) &&
+    (part.logprobs === undefined || part.logprobs === null ||
+      (Array.isArray(part.logprobs) && part.logprobs.length === 0))
   );
 }
 
 function exactEmptyMessage(item) {
   return (
+    exactKeys(item, CANDIDATE_MESSAGE_KEYS) &&
     item?.type === "message" &&
     item.role === "assistant" &&
+    item.status === "completed" &&
     Array.isArray(item.content) &&
-    item.content.length > 0 &&
-    item.content.every(exactEmptyPart)
+    item.content.length === 1 &&
+    item.content.every(exactEmptyPart) &&
+    itemId(item.id) !== undefined &&
+    (item.phase === undefined || item.phase === null)
   );
 }
 
@@ -127,18 +330,52 @@ function exactTerminalEmptyPart(part) {
 
 function exactCompletedEmptyMessage(item) {
   return (
-    item != null &&
-    typeof item === "object" &&
-    !Array.isArray(item) &&
-    Object.keys(item).every((key) => TERMINAL_EMPTY_MESSAGE_KEYS.has(key)) &&
+    exactKeys(item, TERMINAL_EMPTY_MESSAGE_KEYS) &&
     item?.type === "message" &&
+    item.role === "assistant" &&
+    item.status === "completed" &&
+    Array.isArray(item.content) &&
+    item.content.length === 1 &&
+    item.content.every(exactTerminalEmptyPart) &&
+    itemId(item.id) !== undefined &&
+    (item.phase === undefined || item.phase === null)
+  );
+}
+
+function exactVisibleTextPart(part) {
+  return (
+    exactKeys(part, TERMINAL_EMPTY_PART_KEYS) &&
+    ["output_text", "text"].includes(part.type) &&
+    typeof part.text === "string" &&
+    (part.annotations === undefined || Array.isArray(part.annotations)) &&
+    (part.logprobs === undefined || part.logprobs === null ||
+      Array.isArray(part.logprobs))
+  );
+}
+
+function exactRefusalPart(part) {
+  return (
+    exactKeys(part, REFUSAL_PART_KEYS) &&
+    part.type === "refusal" &&
+    typeof part.refusal === "string"
+  );
+}
+
+function exactCompletedMessage(item) {
+  return (
+    exactKeys(item, TERMINAL_EMPTY_MESSAGE_KEYS) &&
+    item?.type === "message" &&
+    itemId(item.id) !== undefined &&
+    item.status === "completed" &&
     item.role === "assistant" &&
     Array.isArray(item.content) &&
     item.content.length > 0 &&
-    item.content.every(exactTerminalEmptyPart) &&
-    itemId(item.id) !== undefined &&
-    (item.phase === undefined || item.phase === null) &&
-    (item.status === undefined || item.status === "completed")
+    item.content.every((part) => {
+      return exactTerminalEmptyPart(part) ||
+        exactVisibleTextPart(part) ||
+        exactRefusalPart(part);
+    }) &&
+    (item.phase === undefined || item.phase === null || typeof item.phase === "string")
   );
 }
 
@@ -146,23 +383,62 @@ function isReasoningItem(item) {
   return item?.type === "reasoning";
 }
 
-function hasValidToolCallIdentity(item) {
+function exactReasoningArrayPart(part, type) {
   return (
-    isToolCall(item) &&
+    exactKeys(part, REASONING_PART_KEYS) &&
+    part.type === type &&
+    typeof part.text === "string"
+  );
+}
+
+function exactReasoningItem(item, { completed = false } = {}) {
+  return (
+    exactKeys(item, REASONING_ITEM_KEYS) &&
+    item?.type === "reasoning" &&
+    itemId(item.id) !== undefined &&
+    (item.status === undefined || item.status === (completed ? "completed" : "in_progress")) &&
+    (item.summary === undefined ||
+      (Array.isArray(item.summary) &&
+        item.summary.every((part) => exactReasoningArrayPart(part, "summary_text")))) &&
+    (item.content === undefined ||
+      (Array.isArray(item.content) &&
+        item.content.every((part) => exactReasoningArrayPart(part, "reasoning_text")))) &&
+    (item.encrypted_content === undefined || item.encrypted_content === null ||
+      typeof item.encrypted_content === "string")
+  );
+}
+
+function toolValueField(type) {
+  return type === "function_call" ? "arguments" : "input";
+}
+
+function exactToolCall(item, { completed = false } = {}) {
+  if (!isToolCall(item)) return false;
+  const allowed = item.type === "function_call" ? FUNCTION_CALL_KEYS : CUSTOM_TOOL_CALL_KEYS;
+  const valueField = toolValueField(item.type);
+  return (
+    exactKeys(item, allowed) &&
     itemId(item.id) !== undefined &&
     itemId(item.call_id) !== undefined &&
     typeof item.name === "string" &&
-    item.name.length > 0
+    item.name.length > 0 &&
+    typeof item[valueField] === "string" &&
+    item.status === (completed ? "completed" : "in_progress")
   );
+}
+
+function hasValidToolCallIdentity(item, options) {
+  return exactToolCall(item, options);
 }
 
 function matchesToolCallIdentity(item, expected) {
   return (
     expected !== undefined &&
-    hasValidToolCallIdentity(item) &&
+    hasValidToolCallIdentity(item, { completed: true }) &&
     item.type === expected.type &&
     item.name === expected.name &&
-    item.call_id === expected.callId
+    item.call_id === expected.callId &&
+    item[toolValueField(item.type)] === expected.value
   );
 }
 
@@ -190,16 +466,16 @@ function removableJsonMessageIndexes(output) {
       continue;
     }
     if (ambiguousRun) {
-      if (!isReasoningItem(item)) ambiguousRun = false;
+      if (!exactReasoningItem(item, { completed: true })) ambiguousRun = false;
       continue;
     }
     if (pending === undefined) continue;
-    if (hasValidToolCallIdentity(item)) {
+    if (hasValidToolCallIdentity(item, { completed: true })) {
       removable.push(pending);
       pending = undefined;
       continue;
     }
-    if (!isReasoningItem(item)) pending = undefined;
+    if (!exactReasoningItem(item, { completed: true })) pending = undefined;
   }
   return removable;
 }
@@ -207,44 +483,66 @@ function removableJsonMessageIndexes(output) {
 function jsonResponseOutput(payload) {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
   if (payload.error !== undefined && payload.error !== null) return undefined;
-  if (payload.object !== undefined && payload.object !== "response") return undefined;
-  if (payload.status !== undefined && payload.status !== "completed") return undefined;
-  return Array.isArray(payload.output) ? payload.output : undefined;
-}
-
-function candidateLifecycle(event, id) {
-  if (eventItemId(event) !== id) return false;
-  return [
-    "response.output_item.added",
-    "response.content_part.added",
-    "response.output_text.delta",
-    "response.output_text.done",
-    "response.content_part.done",
-    "response.output_item.done",
-  ].includes(event?.type);
-}
-
-function exactEmptyCandidateEvent(event) {
-  switch (event?.type) {
-    case "response.output_item.added":
-      return candidateStart(event.item);
-    case "response.content_part.added":
-      return exactEmptyPart(event.part);
-    case "response.output_text.delta":
-      return event.delta === "";
-    case "response.output_text.done":
-      return event.text === "";
-    case "response.content_part.done":
-      return (
-        exactEmptyPart(event.part) ||
-        (event.part?.type === "reasoning_text" &&
-          event.part.reasoning === "")
-      );
-    case "response.output_item.done":
-      return exactEmptyMessage(event.item);
-    default:
-      return false;
+  if (payload.object !== "response" || payload.status !== "completed") return undefined;
+  const responseId = itemId(payload.id);
+  if (!responseId || !Array.isArray(payload.output)) return undefined;
+  const ids = new Set([responseId]);
+  for (const item of payload.output) {
+    const id = itemId(item?.id);
+    if (!id || ids.has(id)) return undefined;
+    ids.add(id);
+    if (item?.type === "message") {
+      if (!exactCompletedMessage(item)) return undefined;
+      continue;
+    }
+    if (isReasoningItem(item)) {
+      if (!exactReasoningItem(item, { completed: true })) return undefined;
+      continue;
+    }
+    if (!hasValidToolCallIdentity(item, { completed: true })) return undefined;
   }
+  return payload.output;
+}
+
+function successfulResponseEnvelope(response, status, responseId) {
+  return (
+    plainObject(response) !== undefined &&
+    itemId(response.id) !== undefined &&
+    (responseId === undefined || response.id === responseId) &&
+    response.object === "response" &&
+    response.status === status &&
+    (response.error === undefined || response.error === null) &&
+    Array.isArray(response.output)
+  );
+}
+
+function exactReasoningPart(part) {
+  return (
+    exactKeys(part, REASONING_PART_KEYS) &&
+    part.type === "summary_text" &&
+    typeof part.text === "string"
+  );
+}
+
+function eventIndexMatches(event, record) {
+  return (
+    eventItemId(event) === record.id &&
+    Number.isInteger(event.output_index) &&
+    event.output_index === record.outputIndex
+  );
+}
+
+function terminalCandidateLifecycle(event, candidateId) {
+  return (
+    eventItemId(event) === candidateId &&
+    [
+      "response.content_part.added",
+      "response.output_text.delta",
+      "response.output_text.done",
+      "response.content_part.done",
+      "response.output_item.done",
+    ].includes(event?.type)
+  );
 }
 
 // LiteLLM's Chat-Completions/Anthropic -> Responses bridge can announce an
@@ -257,11 +555,16 @@ function exactEmptyCandidateEvent(event) {
 // byte and time budgets. Every ambiguous, malformed, large, or slow shape fails
 // open byte-for-byte and permanently disables the repair for that response.
 export class TranslatedToolMessageCompatTransform extends Transform {
-  #decoder = new StringDecoder("utf8");
-  #buffer = "";
+  #buffer = Buffer.alloc(0);
   #capture;
   #disabled = false;
-  #suppressed;
+  #finished = false;
+  #responseId;
+  #sawInProgress = false;
+  #items = new Map();
+  #indexItems = new Map();
+  #lastSequence = -1;
+  #preludeBytes = 0;
   #maxCandidateBytes;
   #maxCandidateMs;
   #maxFrameBytes;
@@ -286,16 +589,19 @@ export class TranslatedToolMessageCompatTransform extends Transform {
   }
 
   _transform(chunk, _encoding, callback) {
-    this.#buffer += this.#decoder.write(chunk);
-    if (this.#disabled) {
+    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.#buffer = this.#buffer.length
+      ? Buffer.concat([this.#buffer, piece])
+      : Buffer.from(piece);
+    if (this.#disabled || this.#finished) {
       this.#pushBuffered();
       callback();
       return;
     }
     this.#emitCompleteBlocks();
-    if (this.#disabled) {
+    if (this.#disabled || this.#finished) {
       this.#pushBuffered();
-    } else if (Buffer.byteLength(this.#buffer) > this.#maxFrameBytes) {
+    } else if (this.#buffer.length > this.#maxFrameBytes) {
       this.#failOpen();
       this.#pushBuffered();
     }
@@ -304,8 +610,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
 
   _flush(callback) {
     this.#clearTimer();
-    this.#buffer += this.#decoder.end();
-    if (this.#disabled) {
+    if (this.#disabled || this.#finished) {
       this.#pushBuffered();
       callback();
       return;
@@ -322,33 +627,35 @@ export class TranslatedToolMessageCompatTransform extends Transform {
   }
 
   #emitCompleteBlocks(flush = false) {
-    while (this.#buffer.length && !this.#disabled) {
-      const crlf = this.#buffer.indexOf("\r\n\r\n");
-      const lf = this.#buffer.indexOf("\n\n");
+    while (this.#buffer.length && !this.#disabled && !this.#finished) {
+      const crlf = this.#buffer.indexOf(CRLF_FRAME_SEPARATOR);
+      const lf = this.#buffer.indexOf(LF_FRAME_SEPARATOR);
       let index = -1;
-      let separator = "";
+      let separator = Buffer.alloc(0);
       if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
         index = crlf;
-        separator = "\r\n\r\n";
+        separator = CRLF_FRAME_SEPARATOR;
       } else if (lf !== -1) {
         index = lf;
-        separator = "\n\n";
+        separator = LF_FRAME_SEPARATOR;
       }
       if (index === -1) {
         if (!flush) return;
-        const block = this.#buffer;
-        this.#buffer = "";
-        if (Buffer.byteLength(block) > this.#maxFrameBytes) {
+        const block = Buffer.from(this.#buffer);
+        this.#buffer = Buffer.alloc(0);
+        if (block.length > this.#maxFrameBytes) {
           this.#oversizedFrame(block);
           return;
         }
-        this.#handleBlock(block, "");
+        this.#handleBlock(block, Buffer.alloc(0));
         return;
       }
-      const block = this.#buffer.slice(0, index);
-      this.#buffer = this.#buffer.slice(index + separator.length);
-      if (Buffer.byteLength(block) + Buffer.byteLength(separator) > this.#maxFrameBytes) {
-        this.#oversizedFrame(`${block}${separator}`);
+      const end = index + separator.length;
+      const block = Buffer.from(this.#buffer.subarray(0, index));
+      const original = Buffer.from(this.#buffer.subarray(0, end));
+      this.#buffer = Buffer.from(this.#buffer.subarray(end));
+      if (original.length > this.#maxFrameBytes) {
+        this.#oversizedFrame(original);
         return;
       }
       this.#handleBlock(block, separator);
@@ -356,162 +663,431 @@ export class TranslatedToolMessageCompatTransform extends Transform {
   }
 
   #handleBlock(block, separator) {
+    const parsedResult = parsedBlock(block);
     const frame = {
-      original: `${block}${separator}`,
-      parsed: parsedBlock(block),
-      separator,
+      original: Buffer.concat([block, separator]),
+      parsed: parsedResult.parsed,
+      separator: separator.toString("ascii"),
     };
-    if (!frame.parsed) {
+    if (parsedResult.invalidUtf8 || parsedResult.malformed) {
+      this.#failOpen(frame);
+      return;
+    }
+    if (parsedResult.done) {
       if (this.#capture) this.#failOpen(frame);
-      else this.push(Buffer.from(frame.original));
+      else {
+        this.push(frame.original);
+        this.#finished = true;
+      }
+      return;
+    }
+    if (!frame.parsed) {
+      this.#failOpen(frame);
       return;
     }
     const event = frame.parsed.event;
-    if (this.#suppressed) {
-      this.#pushCompacted(frame);
-      return;
-    }
-
-    if (eventItemReference(event).conflict) {
+    if (
+      !exactEventKeys(event) ||
+      eventItemReference(event).conflict ||
+      !this.#acceptSequence(event)
+    ) {
       this.#failOpen(frame);
       return;
     }
 
-    if (!this.#capture) {
+    if (event.type === "response.created") {
       if (
-        event.type === "response.output_item.added" &&
-        candidateStart(event.item) &&
-        itemId(event.item?.id) &&
-        Number.isInteger(event.output_index) &&
-        event.output_index >= 0
+        this.#responseId !== undefined ||
+        !successfulResponseEnvelope(event.response, "in_progress") ||
+        event.response.output.length !== 0
       ) {
-        const candidate = {
-          id: event.item.id,
-          outputIndex: event.output_index,
-          sawTool: false,
-          closed: false,
-        };
+        this.#failOpen(frame);
+        return;
+      }
+      this.#responseId = event.response.id;
+      this.push(frame.original);
+      return;
+    }
+
+    if (this.#responseId === undefined) {
+      this.#failOpen(frame);
+      return;
+    }
+
+    if (event.type === "response.in_progress") {
+      if (
+        this.#sawInProgress ||
+        this.#capture ||
+        this.#items.size > 0 ||
+        !successfulResponseEnvelope(event.response, "in_progress", this.#responseId) ||
+        event.response.output.length !== 0
+      ) {
+        this.#failOpen(frame);
+        return;
+      }
+      this.#sawInProgress = true;
+      this.push(frame.original);
+      return;
+    }
+
+    if (event.type === "response.completed") {
+      this.#handleCompleted(frame, event);
+      return;
+    }
+
+    if (event.type === "response.output_item.added") {
+      this.#handleAdded(frame, event);
+      return;
+    }
+
+    this.#handleItemLifecycle(frame, event);
+  }
+
+  #acceptSequence(event) {
+    if (event.sequence_number === undefined) return true;
+    if (event.sequence_number <= this.#lastSequence) return false;
+    this.#lastSequence = event.sequence_number;
+    return true;
+  }
+
+  #handleAdded(frame, event) {
+    const id = itemId(event.item?.id);
+    const outputIndex = event.output_index;
+    if (
+      !id ||
+      !Number.isInteger(outputIndex) ||
+      outputIndex < 0 ||
+      outputIndex !== this.#indexItems.size ||
+      this.#items.has(id) ||
+      this.#indexItems.has(outputIndex)
+    ) {
+      this.#failOpen(frame);
+      return;
+    }
+
+    let record;
+    if (candidateStart(event.item)) {
+      const previous = this.#capture?.candidates.at(-1);
+      if (
+        previous &&
+        (!previous.sawTool ||
+          !previous.done ||
+          [...this.#items.values()].some((item) => !item.done))
+      ) {
+        this.#failOpen(frame);
+        return;
+      }
+      record = {
+        id,
+        outputIndex,
+        kind: "candidate",
+        done: false,
+        sawTool: false,
+        contentStarted: false,
+        textDone: false,
+        partDone: false,
+      };
+    } else if (exactReasoningItem(event.item)) {
+      record = {
+        id,
+        outputIndex,
+        kind: "reasoning",
+        done: false,
+        parts: new Set(),
+        partDones: new Set(),
+        textDones: new Set(),
+        textDeltas: new Set(),
+        textValues: new Map(),
+        doneTexts: new Map(),
+      };
+    } else if (exactToolCall(event.item)) {
+      const valueField = toolValueField(event.item.type);
+      record = {
+        id,
+        outputIndex,
+        kind: event.item.type,
+        done: false,
+        name: event.item.name,
+        callId: event.item.call_id,
+        valueField,
+        delta: event.item[valueField],
+        value: undefined,
+        valueDone: false,
+      };
+    } else {
+      // A visible assistant message or an unknown output item makes the whole
+      // envelope ineligible. Nothing before this point has been rewritten.
+      this.#failOpen(frame);
+      return;
+    }
+
+    if (record.kind !== "candidate" && !this.#trackPrelude(frame)) return;
+
+    this.#items.set(id, record);
+    this.#indexItems.set(outputIndex, id);
+    if (record.kind === "candidate") {
+      if (!this.#capture) {
         this.#capture = {
-          firstOutputIndex: event.output_index,
           frames: [],
           bytes: 0,
-          candidates: new Map([[candidate.id, candidate]]),
-          candidateOrder: [candidate],
-          itemIndexes: new Map([[event.item.id, event.output_index]]),
-          indexItems: new Map([[event.output_index, event.item.id]]),
-          toolItems: new Map(),
+          candidates: [],
         };
         this.#startTimer();
-        this.#hold(frame);
-      } else {
-        this.push(Buffer.from(frame.original));
       }
+      this.#capture.candidates.push(record);
+    } else if (isToolCall(event.item) && this.#capture) {
+      this.#capture.candidates.at(-1).sawTool = true;
+    }
+    this.#pushOrHold(frame);
+  }
+
+  #handleItemLifecycle(frame, event) {
+    const id = eventItemId(event);
+    const record = id ? this.#items.get(id) : undefined;
+    if (!record || !eventIndexMatches(event, record)) {
+      this.#failOpen(frame);
       return;
     }
+    if (!this.#trackPrelude(frame)) return;
 
-    const capture = this.#capture;
-    const attachedId = eventItemId(event);
-    const attachedCandidate = capture.candidates.get(attachedId);
+    let valid = false;
+    if (record.kind === "candidate") {
+      valid = this.#advanceCandidate(event, record);
+    } else if (record.kind === "reasoning") {
+      valid = this.#advanceReasoning(event, record);
+    } else {
+      valid = this.#advanceTool(event, record);
+    }
+    if (!valid) {
+      this.#failOpen(frame);
+      return;
+    }
+    this.#pushOrHold(frame);
+  }
+
+  #trackPrelude(frame) {
+    if (this.#capture) return true;
+    if (this.#preludeBytes + frame.original.length > this.#maxCandidateBytes) {
+      this.#failOpen(frame);
+      return false;
+    }
+    this.#preludeBytes += frame.original.length;
+    return true;
+  }
+
+  #advanceCandidate(event, record) {
+    if (record.done || !terminalCandidateLifecycle(event, record.id)) return false;
+    if (event.type === "response.content_part.added") {
+      if (
+        record.contentStarted ||
+        event.content_index !== 0 ||
+        !exactEmptyPart(event.part)
+      ) return false;
+      record.contentStarted = true;
+      return true;
+    }
+    if (event.type === "response.output_text.delta") {
+      return (
+        record.contentStarted &&
+        !record.textDone &&
+        !record.partDone &&
+        event.content_index === 0 &&
+        event.delta === "" &&
+        validObfuscation(event) &&
+        (event.logprobs === undefined || event.logprobs === null ||
+          (Array.isArray(event.logprobs) && event.logprobs.length === 0))
+      );
+    }
+    if (event.type === "response.output_text.done") {
+      if (
+        !record.contentStarted ||
+        record.textDone ||
+        record.partDone ||
+        event.content_index !== 0 ||
+        event.text !== "" ||
+        !(event.logprobs === undefined || event.logprobs === null ||
+          (Array.isArray(event.logprobs) && event.logprobs.length === 0))
+      ) return false;
+      record.textDone = true;
+      return true;
+    }
+    if (event.type === "response.content_part.done") {
+      if (
+        !record.contentStarted ||
+        !record.textDone ||
+        record.partDone ||
+        event.content_index !== 0 ||
+        !(
+          exactEmptyPart(event.part) ||
+          (exactKeys(event.part, EMPTY_REASONING_PART_KEYS) &&
+            event.part.type === "reasoning_text" &&
+            event.part.reasoning === "")
+        )
+      ) return false;
+      record.partDone = true;
+      return true;
+    }
+    if (event.type !== "response.output_item.done") return false;
     if (
-      attachedCandidate &&
-      !candidateLifecycle(event, attachedCandidate.id)
+      !exactEmptyMessage(event.item) ||
+      event.item.id !== record.id ||
+      (record.contentStarted && (!record.textDone || !record.partDone))
+    ) return false;
+    record.done = true;
+    return true;
+  }
+
+  #advanceTool(event, record) {
+    if (record.done) return false;
+    const isFunction = record.kind === "function_call";
+    const deltaType = isFunction
+      ? "response.function_call_arguments.delta"
+      : "response.custom_tool_call_input.delta";
+    const doneType = isFunction
+      ? "response.function_call_arguments.done"
+      : "response.custom_tool_call_input.done";
+    if (event.type === deltaType) {
+      if (
+        record.valueDone ||
+        typeof event.delta !== "string" ||
+        !validObfuscation(event)
+      ) return false;
+      record.delta += event.delta;
+      return true;
+    }
+    if (event.type === doneType) {
+      const value = event[record.valueField];
+      if (
+        record.valueDone ||
+        typeof value !== "string" ||
+        (record.delta && record.delta !== value)
+      ) return false;
+      record.value = value;
+      record.valueDone = true;
+      return true;
+    }
+    if (event.type !== "response.output_item.done") return false;
+    const expected = {
+      type: record.kind,
+      name: record.name,
+      callId: record.callId,
+      value: record.valueDone
+        ? record.value
+        : record.delta || event.item?.[record.valueField],
+    };
+    if (
+      event.item?.id !== record.id ||
+      !matchesToolCallIdentity(event.item, expected)
+    ) return false;
+    record.value = event.item[record.valueField];
+    record.valueDone = true;
+    record.done = true;
+    return true;
+  }
+
+  #reasoningIndex(event, prefix) {
+    const expectedKey = prefix === "summary" ? "summary_index" : "content_index";
+    const otherKey = prefix === "summary" ? "content_index" : "summary_index";
+    if (
+      !Number.isInteger(event[expectedKey]) ||
+      event[expectedKey] < 0 ||
+      event[otherKey] !== undefined
+    ) return undefined;
+    return `${prefix}:${event[expectedKey]}`;
+  }
+
+  #advanceReasoning(event, record) {
+    if (record.done) return false;
+    if (event.type === "response.output_item.done") {
+      if (
+        event.item?.id !== record.id ||
+        !exactReasoningItem(event.item, { completed: true })
+      ) return false;
+      for (const key of record.parts) if (!record.partDones.has(key)) return false;
+      for (const key of record.textDeltas) if (!record.textDones.has(key)) return false;
+      record.done = true;
+      return true;
+    }
+
+    const summary = event.type.startsWith("response.reasoning_summary_");
+    const reasoningText = event.type.startsWith("response.reasoning_text.");
+    if (!summary && !reasoningText) return false;
+    const key = this.#reasoningIndex(event, summary ? "summary" : "content");
+    if (!key) return false;
+    if (event.type.endsWith("part.added")) {
+      if (record.parts.has(key) || !exactReasoningPart(event.part)) return false;
+      record.parts.add(key);
+      record.textValues.set(key, event.part.text);
+      return true;
+    }
+    if (event.type.endsWith("part.done")) {
+      if (
+        !record.parts.has(key) ||
+        record.partDones.has(key) ||
+        !exactReasoningPart(event.part) ||
+        (record.textDeltas.has(key) && !record.textDones.has(key)) ||
+        event.part.text !== (record.doneTexts.get(key) ?? record.textValues.get(key))
+      ) return false;
+      record.partDones.add(key);
+      return true;
+    }
+    if (event.type.endsWith(".delta")) {
+      if (
+        !record.parts.has(key) ||
+        record.partDones.has(key) ||
+        record.textDones.has(key) ||
+        typeof event.delta !== "string" ||
+        !validObfuscation(event)
+      ) {
+        return false;
+      }
+      record.textDeltas.add(key);
+      record.textValues.set(key, `${record.textValues.get(key) ?? ""}${event.delta}`);
+      return true;
+    }
+    if (event.type.endsWith(".done")) {
+      if (
+        !record.parts.has(key) ||
+        record.partDones.has(key) ||
+        record.textDones.has(key) ||
+        typeof event.text !== "string" ||
+        (record.textDeltas.has(key) && event.text !== record.textValues.get(key))
+      ) return false;
+      record.textDones.add(key);
+      record.doneTexts.set(key, event.text);
+      return true;
+    }
+    return false;
+  }
+
+  #handleCompleted(frame, event) {
+    if (
+      !successfulResponseEnvelope(event.response, "completed", this.#responseId)
     ) {
       this.#failOpen(frame);
       return;
     }
-    if (attachedCandidate) {
-      if (
-        attachedCandidate.closed ||
-        event.type === "response.output_item.added" ||
-        !Number.isInteger(event.output_index) ||
-        event.output_index !== attachedCandidate.outputIndex ||
-        !exactEmptyCandidateEvent(event)
-      ) {
-        this.#failOpen(frame);
-        return;
-      }
-    } else if (event.type === "response.output_item.added") {
-      const id = itemId(event.item?.id);
-      const index = event.output_index;
-      if (
-        !id ||
-        !Number.isInteger(index) ||
-        index < 0 ||
-        index <= capture.firstOutputIndex ||
-        capture.itemIndexes.has(id) ||
-        capture.indexItems.has(index)
-      ) {
-        this.#failOpen(frame);
-        return;
-      }
-      if (candidateStart(event.item)) {
-        const previous = capture.candidateOrder.at(-1);
-        if (!previous?.sawTool) {
-          this.#failOpen(frame);
-          return;
-        }
-        const candidate = { id, outputIndex: index, sawTool: false, closed: false };
-        capture.candidates.set(id, candidate);
-        capture.candidateOrder.push(candidate);
-      } else if (isToolCall(event.item)) {
-        if (!hasValidToolCallIdentity(event.item)) {
-          this.#failOpen(frame);
-          return;
-        }
-        capture.candidateOrder.at(-1).sawTool = true;
-        capture.toolItems.set(id, {
-          type: event.item.type,
-          name: event.item.name,
-          callId: event.item.call_id,
-        });
-      }
-      capture.itemIndexes.set(id, index);
-      capture.indexItems.set(index, id);
-    } else if (attachedId) {
-      const expectedIndex = capture.itemIndexes.get(attachedId);
-      if (
-        expectedIndex === undefined ||
-        !Number.isInteger(event.output_index) ||
-        event.output_index !== expectedIndex
-      ) {
-        this.#failOpen(frame);
-        return;
-      }
-      if (isToolCall(event.item)) {
-        if (
-          event.type !== "response.output_item.done" ||
-          !matchesToolCallIdentity(
-            event.item,
-            capture.toolItems.get(attachedId),
-          )
-        ) {
-          this.#failOpen(frame);
-          return;
-        }
-      }
-    }
-
-    this.#hold(frame);
-    if (!this.#capture) return;
-
-    if (
-      event.type === "response.output_item.done" &&
-      attachedCandidate
-    ) {
-      attachedCandidate.closed = true;
+    if (!this.#capture) {
+      this.push(frame.original);
+      this.#finished = true;
       return;
     }
-
-    if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
-      if (this.#terminalMatchesCapture(event.response.output, capture)) {
-        this.#suppress();
-      } else this.#failOpen();
+    if (!this.#terminalMatchesCapture(event.response.output)) {
+      this.#failOpen(frame);
+      return;
     }
+    this.#hold(frame);
+    if (this.#capture) this.#suppress();
+  }
+
+  #pushOrHold(frame) {
+    if (this.#capture) this.#hold(frame);
+    else this.push(frame.original);
   }
 
   #hold(frame) {
     if (!this.#capture) return;
-    const bytes = Buffer.byteLength(frame.original);
+    const bytes = frame.original.length;
     if (this.#capture.bytes + bytes > this.#maxCandidateBytes) {
       this.#failOpen(frame);
       return;
@@ -520,50 +1096,56 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     this.#capture.bytes += bytes;
   }
 
-  #terminalMatchesCapture(output, capture) {
-    const candidatesByIndex = new Map();
-    for (const candidate of capture.candidateOrder) {
-      if (!candidate.closed || !candidate.sawTool) return false;
-      if (candidate.outputIndex >= output.length) return false;
-      if (!exactCompletedEmptyMessage(output[candidate.outputIndex])) return false;
-      candidatesByIndex.set(candidate.outputIndex, candidate);
-    }
-    for (const [id, expected] of capture.toolItems) {
-      const item = output[capture.itemIndexes.get(id)];
-      if (!matchesToolCallIdentity(item, expected)) return false;
-    }
-    const ids = new Set();
+  #terminalMatchesCapture(output) {
+    if (output.length !== this.#items.size) return false;
+    const ids = new Set([this.#responseId]);
     for (let index = 0; index < output.length; index += 1) {
-      const id = itemId(output[index]?.id);
+      const recordId = this.#indexItems.get(index);
+      const record = recordId ? this.#items.get(recordId) : undefined;
+      const item = output[index];
+      const id = itemId(item?.id);
+      if (!record || !record.done) return false;
       if (!id || ids.has(id)) return false;
       ids.add(id);
-      if (index < capture.firstOutputIndex) continue;
-      const mappedIndex = capture.itemIndexes.get(id);
-      if (candidatesByIndex.has(index)) {
+      if (record.kind === "candidate") {
+        if (!record.sawTool || !exactCompletedEmptyMessage(item)) return false;
         // The pinned LiteLLM bridge uses a generated msg_* ID for streaming,
         // but the originating chat-completion ID for this exact terminal
         // empty item. Permit only that candidate slot to change identity; a
         // collision with any other streamed item remains ambiguous.
-        if (mappedIndex !== undefined && mappedIndex !== index) return false;
-      } else if (mappedIndex !== index) return false;
+        if (id !== record.id && this.#items.has(id)) return false;
+        continue;
+      }
+      if (id !== record.id) return false;
+      if (record.kind === "reasoning") {
+        if (!exactReasoningItem(item, { completed: true })) return false;
+        continue;
+      }
+      if (!matchesToolCallIdentity(item, {
+        type: record.kind,
+        name: record.name,
+        callId: record.callId,
+        value: record.value,
+      })) return false;
     }
-    return output.length - capture.firstOutputIndex === capture.itemIndexes.size;
+    return true;
   }
 
   #suppress() {
     const capture = this.#capture;
     if (!capture) return;
     this.#capture = undefined;
-    const items = capture.candidateOrder
+    const items = capture.candidates
       .map(({ id, outputIndex }) => ({ id, outputIndex }))
       .sort((left, right) => left.outputIndex - right.outputIndex);
-    this.#suppressed = {
+    const suppressed = {
       items,
       streamIds: new Set(items.map(({ id }) => id)),
       outputIndexes: new Set(items.map(({ outputIndex }) => outputIndex)),
     };
     this.#clearTimer();
-    for (const frame of capture.frames) this.#pushCompacted(frame);
+    for (const frame of capture.frames) this.#pushCompacted(frame, suppressed);
+    this.#finished = true;
   }
 
   #failOpen(extraFrame) {
@@ -571,23 +1153,23 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     this.#capture = undefined;
     this.#clearTimer();
     if (capture) {
-      for (const frame of capture.frames) this.push(Buffer.from(frame.original));
+      for (const frame of capture.frames) this.push(frame.original);
     }
-    if (extraFrame) this.push(Buffer.from(extraFrame.original));
+    if (extraFrame) this.push(extraFrame.original);
     this.#disabled = true;
   }
 
-  #pushCompacted(frame) {
+  #pushCompacted(frame, suppressed) {
     const event = frame.parsed?.event;
-    const suppressed = this.#suppressed;
     if (!event || !suppressed) {
-      this.push(Buffer.from(frame.original));
+      this.push(frame.original);
       return;
     }
     const attachedId = eventItemId(event);
     if (
       suppressed.streamIds.has(attachedId) &&
-      candidateLifecycle(event, attachedId)
+      (event.type === "response.output_item.added" ||
+        terminalCandidateLifecycle(event, attachedId))
     ) return;
     let next = event;
     let changed = false;
@@ -611,26 +1193,22 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       };
       changed ||= output.length !== event.response.output.length;
     }
-    this.push(
-      Buffer.from(
-        changed ? rewrittenBlock(frame.parsed, next, frame.separator) : frame.original,
-      ),
-    );
+    this.push(changed ? rewrittenBlock(frame.parsed, next, frame.separator) : frame.original);
   }
 
   #oversizedFrame(original) {
-    const frame = { original };
+    const frame = { original: Buffer.isBuffer(original) ? original : Buffer.from(original) };
     if (this.#capture) this.#failOpen(frame);
     else {
-      this.push(Buffer.from(original));
+      this.push(frame.original);
       this.#disabled = true;
     }
   }
 
   #pushBuffered() {
-    if (!this.#buffer) return;
-    this.push(Buffer.from(this.#buffer));
-    this.#buffer = "";
+    if (!this.#buffer.length) return;
+    this.push(this.#buffer);
+    this.#buffer = Buffer.alloc(0);
   }
 
   #startTimer() {
@@ -702,8 +1280,7 @@ export class TranslatedToolMessageJsonCompatTransform extends Transform {
       return;
     }
     try {
-      const source = body.toString("utf8");
-      if (!Buffer.from(source).equals(body)) throw new Error("invalid utf-8");
+      const source = fatalUtf8(body);
       const payload = JSON.parse(source);
       const output = jsonResponseOutput(payload);
       const indexes = removableJsonMessageIndexes(output);

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -486,7 +486,12 @@ function parsedBlock(blockBytes, jsonLimits) {
     return { malformed: true };
   }
   const [dataLineIndex] = dataLineIndexes;
-  const dataText = lines[dataLineIndex].slice(5).trimStart();
+  const dataValue = lines[dataLineIndex].slice(5);
+  // The SSE grammar removes at most one U+0020 after a field colon. Leave
+  // every other code point to JSON.parse: it accepts JSON's own ASCII
+  // whitespace, while a BOM or non-JSON Unicode whitespace remains invalid
+  // instead of being silently normalized into trusted bridge evidence.
+  const dataText = dataValue.startsWith(" ") ? dataValue.slice(1) : dataValue;
   if (!dataText) return { malformed: true };
   if (dataText === "[DONE]") {
     return eventLines.length === 0 ? { done: true } : { malformed: true };
@@ -494,11 +499,12 @@ function parsedBlock(blockBytes, jsonLimits) {
   try {
     if (!uniqueJsonObjectMembers(dataText, jsonLimits)) return { malformed: true };
     const event = JSON.parse(dataText);
-    if (
-      eventLines.length === 1 &&
-      eventLines[0].slice(6).trim() !== event?.type
-    ) {
-      return { malformed: true };
+    if (eventLines.length === 1) {
+      const eventValue = eventLines[0].slice(6);
+      const declaredType = eventValue.startsWith(" ")
+        ? eventValue.slice(1)
+        : eventValue;
+      if (declaredType !== event?.type) return { malformed: true };
     }
     return { parsed: { lines, dataLineIndex, newline, event } };
   } catch {
@@ -1014,8 +1020,9 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       return;
     }
     this.#emitCompleteBlocks(true);
-    if (this.#capture?.stage === "completed") this.#repairCapture();
-    else if (this.#capture) this.#failOpen();
+    if (["completed", "sentinel"].includes(this.#capture?.stage)) {
+      this.#finishAtEof();
+    } else if (this.#capture) this.#failOpen();
     this.#pushBuffered();
     callback();
   }
@@ -1073,9 +1080,11 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       return;
     }
     if (parsedResult.done) {
-      if (this.#capture?.stage === "completed") this.#repairCapture();
-      else if (this.#capture) this.#failOpen(frame);
-      if (!this.#disabled) {
+      if (this.#capture?.stage === "completed") {
+        this.#holdSentinel(frame);
+      } else if (this.#capture) {
+        this.#failOpen(frame);
+      } else if (!this.#disabled) {
         this.push(frame.original);
         this.#finished = true;
       }
@@ -1188,8 +1197,8 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       terminalTool: undefined,
       terminalReasoning: undefined,
       terminalBlank: undefined,
+      sentinel: undefined,
     };
-    this.#startTimer();
     this.#hold(frame);
   }
 
@@ -1509,6 +1518,12 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     else if (this.#capture?.mode === "current") this.#repairCurrent();
   }
 
+  #finishAtEof() {
+    const sentinel = this.#capture?.sentinel;
+    this.#repairCapture();
+    if (sentinel) this.push(sentinel.original);
+  }
+
   #repairHistorical() {
     const capture = this.#capture;
     if (!capture) return;
@@ -1620,6 +1635,22 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     }
     this.#capture.frames.push(frame);
     this.#capture.bytes += frame.original.length;
+    this.#resetWatchdog();
+  }
+
+  #holdSentinel(frame) {
+    if (!this.#capture || this.#capture.sentinel) {
+      this.#failOpen(frame);
+      return;
+    }
+    if (this.#capture.bytes + frame.original.length > this.#maxCandidateBytes) {
+      this.#failOpen(frame);
+      return;
+    }
+    this.#capture.sentinel = frame;
+    this.#capture.bytes += frame.original.length;
+    this.#capture.stage = "sentinel";
+    this.#resetWatchdog();
   }
 
   #failOpen(extraFrame) {
@@ -1628,6 +1659,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     this.#clearTimer();
     if (capture) {
       for (const frame of capture.frames) this.push(frame.original);
+      if (capture.sentinel) this.push(capture.sentinel.original);
     }
     if (extraFrame) this.push(extraFrame.original);
     this.#disabled = true;
@@ -1644,8 +1676,9 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     this.#buffer = Buffer.alloc(0);
   }
 
-  #startTimer() {
-    if (this.#timer || !this.#capture) return;
+  #resetWatchdog() {
+    this.#clearTimer();
+    if (!this.#capture) return;
     this.#timer = setTimeout(() => {
       this.#failOpen();
       this.#pushBuffered();

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -3,6 +3,7 @@ import { isDeepStrictEqual, TextDecoder } from "node:util";
 
 const MAX_CANDIDATE_BYTES = 64 * 1024;
 const MAX_CANDIDATE_MS = 1_000;
+const MAX_DIRECT_CAPTURE_MS = 60_000;
 const MAX_FRAME_BYTES = 256 * 1024;
 const MAX_JSON_BYTES = 8 * 1024 * 1024;
 const MAX_JSON_MS = 1_000;
@@ -220,11 +221,13 @@ function fatalUtf8(buffer) {
 }
 
 // JSON.parse silently keeps only the last occurrence of a duplicate object
-// member. That is unsafe here because a later stringify could then erase an
-// earlier visible/error value. Scan the bounded source first, decoding only
-// object keys so equivalent escape spellings compare as the same member while
-// value strings and number spellings remain JSON.parse's responsibility.
-function uniqueJsonObjectMembers(source, limits) {
+// member and accepts numbers that JSON.stringify cannot reproduce faithfully.
+// Either is unsafe here because a later stringify could erase an earlier
+// visible/error value or change numeric provenance. Scan the bounded source
+// first, decoding object keys so equivalent escape spellings compare as the
+// same member and rejecting the parsed-number classes that are lossy on the
+// return trip.
+function strictJsonPreflight(source, limits) {
   let offset = 0;
   let rootState = "value";
   let memberCount = 0;
@@ -307,6 +310,7 @@ function uniqueJsonObjectMembers(source, limits) {
     return undefined;
   };
   const scanNumber = () => {
+    const start = offset;
     if (source[offset] === "-") offset += 1;
     if (source[offset] === "0") {
       offset += 1;
@@ -335,7 +339,12 @@ function uniqueJsonObjectMembers(source, limits) {
         offset += 1;
       }
     }
-    return true;
+    const value = Number(source.slice(start, offset));
+    return (
+      Number.isFinite(value) &&
+      !Object.is(value, -0) &&
+      (!Number.isInteger(value) || Number.isSafeInteger(value))
+    );
   };
   const completeValue = () => {
     const parent = stack.at(-1);
@@ -462,6 +471,43 @@ function uniqueJsonObjectMembers(source, limits) {
   return rootState === "done" && stack.length === 0;
 }
 
+// Function-call arguments are JSON carried inside a JSON string. When an
+// eligible lifecycle is reserialized, validate the complete argument strings
+// with the same numeric and duplicate-member preflight instead of treating the
+// inner document as opaque trusted evidence. Empty opening arguments and
+// partial delta strings are deliberately excluded.
+function strictFunctionArgumentJson(value, limits) {
+  const pending = [value];
+  while (pending.length) {
+    const current = pending.pop();
+    if (Array.isArray(current)) {
+      for (const entry of current) pending.push(entry);
+      continue;
+    }
+    const object = plainObject(current);
+    if (!object) continue;
+    let source;
+    if (object.type === "function_call" && typeof object.arguments === "string") {
+      source = object.arguments;
+    } else if (
+      object.type === "response.function_call_arguments.done" &&
+      typeof object.arguments === "string"
+    ) {
+      source = object.arguments;
+    }
+    if (source) {
+      try {
+        if (!strictJsonPreflight(source, limits)) return false;
+        JSON.parse(source);
+      } catch {
+        return false;
+      }
+    }
+    for (const entry of Object.values(object)) pending.push(entry);
+  }
+  return true;
+}
+
 function parsedBlock(blockBytes, jsonLimits) {
   let block;
   try {
@@ -497,8 +543,9 @@ function parsedBlock(blockBytes, jsonLimits) {
     return eventLines.length === 0 ? { done: true } : { malformed: true };
   }
   try {
-    if (!uniqueJsonObjectMembers(dataText, jsonLimits)) return { malformed: true };
+    if (!strictJsonPreflight(dataText, jsonLimits)) return { malformed: true };
     const event = JSON.parse(dataText);
+    if (!strictFunctionArgumentJson(event, jsonLimits)) return { malformed: true };
     if (eventLines.length === 1) {
       const eventValue = eventLines[0].slice(6);
       const declaredType = eventValue.startsWith(" ")
@@ -960,13 +1007,16 @@ export class DeepseekToolMessageCompatTransform extends Transform {
   #model;
   #maxCandidateBytes;
   #maxCandidateMs;
+  #maxCaptureMs;
   #maxFrameBytes;
   #jsonLimits;
-  #timer;
+  #watchdogTimer;
+  #deadlineTimer;
 
   constructor({
     maxCandidateBytes = MAX_CANDIDATE_BYTES,
     maxCandidateMs = MAX_CANDIDATE_MS,
+    maxCaptureMs = MAX_DIRECT_CAPTURE_MS,
     maxFrameBytes = MAX_FRAME_BYTES,
     maxJsonDepth,
     maxJsonMembers,
@@ -979,6 +1029,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       { integer: true },
     );
     this.#maxCandidateMs = finiteLimit(maxCandidateMs, MAX_CANDIDATE_MS);
+    this.#maxCaptureMs = finiteLimit(maxCaptureMs, MAX_DIRECT_CAPTURE_MS);
     this.#maxFrameBytes = finiteLimit(maxFrameBytes, MAX_FRAME_BYTES, {
       minimum: 1,
       integer: true,
@@ -1013,7 +1064,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
   }
 
   _flush(callback) {
-    this.#clearTimer();
+    this.#clearTimers();
     if (this.#disabled || this.#finished) {
       this.#pushBuffered();
       callback();
@@ -1028,7 +1079,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
   }
 
   _destroy(error, callback) {
-    this.#clearTimer();
+    this.#clearTimers();
     callback(error);
   }
 
@@ -1199,6 +1250,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       terminalBlank: undefined,
       sentinel: undefined,
     };
+    this.#startDeadline();
     this.#hold(frame);
   }
 
@@ -1528,7 +1580,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     const capture = this.#capture;
     if (!capture) return;
     this.#capture = undefined;
-    this.#clearTimer();
+    this.#clearTimers();
     for (const frame of capture.frames) {
       const event = frame.parsed.event;
       const attached = eventItemId(event);
@@ -1555,7 +1607,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
     const capture = this.#capture;
     if (!capture) return;
     this.#capture = undefined;
-    this.#clearTimer();
+    this.#clearTimers();
     const reasoning = {
       id: capture.terminalReasoning.id,
       type: "reasoning",
@@ -1656,7 +1708,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
   #failOpen(extraFrame) {
     const capture = this.#capture;
     this.#capture = undefined;
-    this.#clearTimer();
+    this.#clearTimers();
     if (capture) {
       for (const frame of capture.frames) this.push(frame.original);
       if (capture.sentinel) this.push(capture.sentinel.original);
@@ -1677,19 +1729,35 @@ export class DeepseekToolMessageCompatTransform extends Transform {
   }
 
   #resetWatchdog() {
-    this.#clearTimer();
+    this.#clearWatchdog();
     if (!this.#capture) return;
-    this.#timer = setTimeout(() => {
+    this.#watchdogTimer = setTimeout(() => {
       this.#failOpen();
       this.#pushBuffered();
     }, this.#maxCandidateMs);
-    this.#timer.unref?.();
+    this.#watchdogTimer.unref?.();
   }
 
-  #clearTimer() {
-    if (!this.#timer) return;
-    clearTimeout(this.#timer);
-    this.#timer = undefined;
+  #startDeadline() {
+    if (this.#deadlineTimer || !this.#capture) return;
+    this.#deadlineTimer = setTimeout(() => {
+      this.#failOpen();
+      this.#pushBuffered();
+    }, this.#maxCaptureMs);
+    this.#deadlineTimer.unref?.();
+  }
+
+  #clearWatchdog() {
+    if (!this.#watchdogTimer) return;
+    clearTimeout(this.#watchdogTimer);
+    this.#watchdogTimer = undefined;
+  }
+
+  #clearTimers() {
+    this.#clearWatchdog();
+    if (!this.#deadlineTimer) return;
+    clearTimeout(this.#deadlineTimer);
+    this.#deadlineTimer = undefined;
   }
 }
 
@@ -1784,7 +1852,9 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       return;
     }
     this.#emitCompleteBlocks(true);
-    if (this.#capture) this.#failOpen();
+    if (["completed", "sentinel"].includes(this.#capture?.stage)) {
+      this.#suppress();
+    } else if (this.#capture) this.#failOpen();
     this.#pushBuffered();
     callback();
   }
@@ -1842,8 +1912,11 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       return;
     }
     if (parsedResult.done) {
-      if (this.#capture) this.#failOpen(frame);
-      else {
+      if (this.#capture?.stage === "completed") {
+        this.#holdSentinel(frame);
+      } else if (this.#capture) {
+        this.#failOpen(frame);
+      } else {
         this.push(frame.original);
         this.#finished = true;
       }
@@ -1854,6 +1927,10 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       return;
     }
     const event = frame.parsed.event;
+    if (["completed", "sentinel"].includes(this.#capture?.stage)) {
+      this.#failOpen(frame);
+      return;
+    }
     if (
       !exactEventKeys(event) ||
       eventItemReference(event).conflict ||
@@ -2069,6 +2146,8 @@ export class TranslatedToolMessageCompatTransform extends Transform {
           frames: [],
           bytes: 0,
           candidates: [],
+          stage: "active",
+          sentinel: undefined,
         };
         this.#startTimer();
       }
@@ -2110,6 +2189,8 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       frames: [],
       bytes: 0,
       candidates: [candidate],
+      stage: "active",
+      sentinel: undefined,
     };
     this.#indexItems.set(0, TERMINAL_ONLY_CANDIDATE_SLOT);
     this.#startTimer();
@@ -2402,7 +2483,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       return;
     }
     this.#hold(frame);
-    if (this.#capture) this.#suppress();
+    if (this.#capture) this.#capture.stage = "completed";
   }
 
   #acceptTerminalResponseId(terminalResponseId) {
@@ -2452,6 +2533,21 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     }
     this.#capture.frames.push(frame);
     this.#capture.bytes += bytes;
+  }
+
+  #holdSentinel(frame) {
+    if (!this.#capture || this.#capture.sentinel) {
+      this.#failOpen(frame);
+      return;
+    }
+    const bytes = frame.original.length;
+    if (this.#capture.bytes + bytes > this.#maxCandidateBytes) {
+      this.#failOpen(frame);
+      return;
+    }
+    this.#capture.sentinel = frame;
+    this.#capture.bytes += bytes;
+    this.#capture.stage = "sentinel";
   }
 
   #terminalMatchesCapture(output, terminalResponseId = this.#responseId) {
@@ -2508,6 +2604,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     };
     this.#clearTimer();
     for (const frame of capture.frames) this.#pushCompacted(frame, suppressed);
+    if (capture.sentinel) this.push(capture.sentinel.original);
     this.#finished = true;
   }
 
@@ -2517,6 +2614,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     this.#clearTimer();
     if (capture) {
       for (const frame of capture.frames) this.push(frame.original);
+      if (capture.sentinel) this.push(capture.sentinel.original);
     }
     if (extraFrame) this.push(extraFrame.original);
     this.#disabled = true;
@@ -2658,12 +2756,17 @@ export class TranslatedToolMessageJsonCompatTransform extends Transform {
     }
     try {
       const source = fatalUtf8(body);
-      if (!uniqueJsonObjectMembers(source, this.#jsonLimits)) {
+      if (!strictJsonPreflight(source, this.#jsonLimits)) {
         this.push(body);
         callback();
         return;
       }
       const payload = JSON.parse(source);
+      if (!strictFunctionArgumentJson(payload, this.#jsonLimits)) {
+        this.push(body);
+        callback();
+        return;
+      }
       const output = jsonResponseOutput(payload);
       const indexes = removableJsonMessageIndexes(output);
       if (!indexes.length) {

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -147,6 +147,20 @@ const TERMINAL_EMPTY_MESSAGE_KEYS = new Set([
   "content",
   "phase",
 ]);
+const DIRECT_MESSAGE_KEYS = new Set(["id", "type", "status", "role", "content"]);
+const DIRECT_REASONING_ITEM_KEYS = new Set([
+  "id",
+  "type",
+  "status",
+  "role",
+  "content",
+]);
+const DIRECT_REASONING_OUTPUT_PART_KEYS = new Set([
+  "type",
+  "text",
+  "annotations",
+]);
+const DIRECT_HISTORICAL_RESPONSE_KEYS = new Set(["id", "status", "output"]);
 
 const EVENT_KEYS = new Map([
   ["response.created", RESPONSE_EVENT_KEYS],
@@ -498,6 +512,14 @@ function rewrittenBlock(parsed, event, separator) {
   return Buffer.from(`${lines.join(parsed.newline)}${separator}`);
 }
 
+function rewrittenEventBlock(parsed, event, separator) {
+  const lines = parsed.lines.map((line) => (
+    line.startsWith("event:") ? `event: ${event.type}` : line
+  ));
+  lines[parsed.dataLineIndex] = `data: ${JSON.stringify(event)}`;
+  return Buffer.from(`${lines.join(parsed.newline)}${separator}`);
+}
+
 function itemId(value) {
   return typeof value === "string" && value ? value : undefined;
 }
@@ -811,6 +833,831 @@ function terminalCandidateLifecycle(event, candidateId) {
       "response.output_item.done",
     ].includes(event?.type)
   );
+}
+
+function exactOwnKeys(value, keys) {
+  const object = plainObject(value);
+  if (!object || Object.keys(object).length !== keys.length) return false;
+  return keys.every((key) => Object.prototype.hasOwnProperty.call(object, key));
+}
+
+function exactDirectEvent(event, type, keys, { model } = {}) {
+  const expected = model === undefined ? keys : [...keys, "model"];
+  return (
+    exactOwnKeys(event, expected) &&
+    event.type === type &&
+    (model === undefined ? event.model === undefined : event.model === model)
+  );
+}
+
+function exactDirectCandidateStart(item) {
+  return (
+    exactOwnKeys(item, [...DIRECT_MESSAGE_KEYS]) &&
+    candidateStart(item)
+  );
+}
+
+function exactDirectEmptyPart(part) {
+  return (
+    exactOwnKeys(part, ["type", "text", "annotations"]) &&
+    part.type === "output_text" &&
+    part.text === "" &&
+    Array.isArray(part.annotations) &&
+    part.annotations.length === 0
+  );
+}
+
+function exactDirectCompletedBlank(item, { omittedText = false } = {}) {
+  if (
+    !exactOwnKeys(item, [...DIRECT_MESSAGE_KEYS]) ||
+    item.type !== "message" ||
+    item.status !== "completed" ||
+    item.role !== "assistant" ||
+    !itemId(item.id) ||
+    !Array.isArray(item.content) ||
+    item.content.length !== 1
+  ) return false;
+  const [part] = item.content;
+  if (omittedText) {
+    return (
+      exactOwnKeys(part, ["type", "annotations"]) &&
+      part.type === "output_text" &&
+      Array.isArray(part.annotations) &&
+      part.annotations.length === 0
+    );
+  }
+  return exactDirectEmptyPart(part);
+}
+
+function exactDirectReasoningItem(item, text) {
+  if (
+    !exactOwnKeys(item, [...DIRECT_REASONING_ITEM_KEYS]) ||
+    !itemId(item.id)?.startsWith("rs_") ||
+    item.type !== "reasoning" ||
+    item.status !== "completed" ||
+    item.role !== "assistant" ||
+    !Array.isArray(item.content) ||
+    item.content.length !== 1
+  ) return false;
+  const [part] = item.content;
+  return (
+    exactOwnKeys(part, [...DIRECT_REASONING_OUTPUT_PART_KEYS]) &&
+    part.type === "output_text" &&
+    part.text === text &&
+    Array.isArray(part.annotations) &&
+    part.annotations.length === 0
+  );
+}
+
+function directToolIdentity(item) {
+  if (!exactToolCall(item)) return undefined;
+  return item.type === "function_call"
+    ? {
+        id: item.id,
+        callId: item.call_id,
+        name: item.name,
+        arguments: item.arguments,
+      }
+    : undefined;
+}
+
+function exactDirectCompletedTool(item, tool, expectedArguments) {
+  return Boolean(
+    tool &&
+    exactToolCall(item, { completed: true }) &&
+    item.type === "function_call" &&
+    item.id === tool.id &&
+    item.call_id === tool.callId &&
+    item.name === tool.name &&
+    item.arguments === expectedArguments
+  );
+}
+
+// Direct DeepSeek has produced two provider-specific bridge defects that do
+// not share the generic translated-route grammar. The historical bridge
+// omitted response.created entirely and buried private reasoning in the empty
+// message's close. The current LiteLLM 1.96.0 bridge emits a normal prelude but
+// attaches reasoning deltas to that same empty message, later synthesizing a
+// malformed reasoning item and a second blank terminal item.
+//
+// Keep both fingerprints here, behind the direct provider id. Each grammar is
+// ordered, identity-bound, model-bound where the wire supplies provenance,
+// and bounded. Any deviation releases the held bytes unchanged and disables
+// the repair for the rest of the response.
+export class DeepseekToolMessageCompatTransform extends Transform {
+  #buffer = Buffer.alloc(0);
+  #capture;
+  #disabled = false;
+  #finished = false;
+  #prelude = "start";
+  #openingResponseId;
+  #model;
+  #maxCandidateBytes;
+  #maxCandidateMs;
+  #maxFrameBytes;
+  #jsonLimits;
+  #timer;
+
+  constructor({
+    maxCandidateBytes = MAX_CANDIDATE_BYTES,
+    maxCandidateMs = MAX_CANDIDATE_MS,
+    maxFrameBytes = MAX_FRAME_BYTES,
+    maxJsonDepth,
+    maxJsonMembers,
+    maxJsonKeyCodeUnits,
+  } = {}) {
+    super();
+    this.#maxCandidateBytes = finiteLimit(
+      maxCandidateBytes,
+      MAX_CANDIDATE_BYTES,
+      { integer: true },
+    );
+    this.#maxCandidateMs = finiteLimit(maxCandidateMs, MAX_CANDIDATE_MS);
+    this.#maxFrameBytes = finiteLimit(maxFrameBytes, MAX_FRAME_BYTES, {
+      minimum: 1,
+      integer: true,
+    });
+    this.#jsonLimits = jsonScanLimits(
+      { maxJsonDepth, maxJsonMembers, maxJsonKeyCodeUnits },
+      {
+        maxMembers: MAX_FRAME_JSON_MEMBERS,
+        maxKeyCodeUnits: MAX_FRAME_JSON_KEY_CODE_UNITS,
+      },
+    );
+  }
+
+  _transform(chunk, _encoding, callback) {
+    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.#buffer = this.#buffer.length
+      ? Buffer.concat([this.#buffer, piece])
+      : Buffer.from(piece);
+    if (this.#disabled || this.#finished) {
+      this.#pushBuffered();
+      callback();
+      return;
+    }
+    this.#emitCompleteBlocks();
+    if (this.#disabled || this.#finished) {
+      this.#pushBuffered();
+    } else if (this.#buffer.length > this.#maxFrameBytes) {
+      this.#failOpen();
+      this.#pushBuffered();
+    }
+    callback();
+  }
+
+  _flush(callback) {
+    this.#clearTimer();
+    if (this.#disabled || this.#finished) {
+      this.#pushBuffered();
+      callback();
+      return;
+    }
+    this.#emitCompleteBlocks(true);
+    if (this.#capture?.stage === "completed") this.#repairCapture();
+    else if (this.#capture) this.#failOpen();
+    this.#pushBuffered();
+    callback();
+  }
+
+  _destroy(error, callback) {
+    this.#clearTimer();
+    callback(error);
+  }
+
+  #emitCompleteBlocks(flush = false) {
+    while (this.#buffer.length && !this.#disabled && !this.#finished) {
+      const crlf = this.#buffer.indexOf(CRLF_FRAME_SEPARATOR);
+      const lf = this.#buffer.indexOf(LF_FRAME_SEPARATOR);
+      let index = -1;
+      let separator = Buffer.alloc(0);
+      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+        index = crlf;
+        separator = CRLF_FRAME_SEPARATOR;
+      } else if (lf !== -1) {
+        index = lf;
+        separator = LF_FRAME_SEPARATOR;
+      }
+      if (index === -1) {
+        if (!flush) return;
+        const block = Buffer.from(this.#buffer);
+        this.#buffer = Buffer.alloc(0);
+        if (block.length > this.#maxFrameBytes) {
+          this.#oversizedFrame(block);
+          return;
+        }
+        this.#handleBlock(block, Buffer.alloc(0));
+        return;
+      }
+      const end = index + separator.length;
+      const block = Buffer.from(this.#buffer.subarray(0, index));
+      const original = Buffer.from(this.#buffer.subarray(0, end));
+      this.#buffer = Buffer.from(this.#buffer.subarray(end));
+      if (original.length > this.#maxFrameBytes) {
+        this.#oversizedFrame(original);
+        return;
+      }
+      this.#handleBlock(block, separator);
+    }
+  }
+
+  #handleBlock(block, separator) {
+    const parsedResult = parsedBlock(block, this.#jsonLimits);
+    const frame = {
+      original: Buffer.concat([block, separator]),
+      parsed: parsedResult.parsed,
+      separator: separator.toString("ascii"),
+    };
+    if (parsedResult.invalidUtf8 || parsedResult.malformed) {
+      this.#failOpen(frame);
+      return;
+    }
+    if (parsedResult.done) {
+      if (this.#capture?.stage === "completed") this.#repairCapture();
+      else if (this.#capture) this.#failOpen(frame);
+      if (!this.#disabled) {
+        this.push(frame.original);
+        this.#finished = true;
+      }
+      return;
+    }
+    const event = frame.parsed?.event;
+    if (!event || eventItemReference(event).conflict) {
+      this.#failOpen(frame);
+      return;
+    }
+    if (!this.#capture) {
+      this.#handlePrelude(frame, event);
+      return;
+    }
+    const valid = this.#capture.mode === "historical"
+      ? this.#advanceHistorical(frame, event)
+      : this.#advanceCurrent(frame, event);
+    if (!valid) this.#failOpen(frame);
+  }
+
+  #handlePrelude(frame, event) {
+    if (this.#prelude === "start" && this.#acceptCurrentPrelude(event, "created")) {
+      this.#prelude = "created";
+      this.push(frame.original);
+      return;
+    }
+    if (this.#prelude === "created" && this.#acceptCurrentPrelude(event, "in_progress")) {
+      this.#prelude = "ready";
+      this.push(frame.original);
+      return;
+    }
+    if (this.#prelude === "start" && this.#historicalCandidateStart(event)) {
+      this.#startCapture(frame, event, "historical");
+      return;
+    }
+    if (this.#prelude === "ready" && this.#currentCandidateStart(event)) {
+      this.#startCapture(frame, event, "current");
+      return;
+    }
+    this.#failOpen(frame);
+  }
+
+  #acceptCurrentPrelude(event, phase) {
+    const type = phase === "created" ? "response.created" : "response.in_progress";
+    if (
+      !exactOwnKeys(event, ["type", "response", "model"]) ||
+      event.type !== type ||
+      typeof event.model !== "string" ||
+      !event.model
+    ) return false;
+    if (phase === "created") {
+      if (
+        !successfulResponseEnvelope(event.response, "in_progress") ||
+        event.response.output.length !== 0 ||
+        event.response.model !== event.model ||
+        !event.response.id.startsWith("resp_")
+      ) return false;
+      this.#openingResponseId = event.response.id;
+      this.#model = event.model;
+      return true;
+    }
+    return (
+      event.model === this.#model &&
+      successfulResponseEnvelope(event.response, "in_progress", this.#openingResponseId) &&
+      event.response.output.length === 0 &&
+      event.response.model === this.#model
+    );
+  }
+
+  #historicalCandidateStart(event) {
+    return (
+      exactDirectEvent(
+        event,
+        "response.output_item.added",
+        ["type", "output_index", "sequence_number", "item"],
+      ) &&
+      event.output_index === 0 &&
+      event.sequence_number === 1 &&
+      exactDirectCandidateStart(event.item)
+    );
+  }
+
+  #currentCandidateStart(event) {
+    return (
+      exactDirectEvent(
+        event,
+        "response.output_item.added",
+        ["type", "output_index", "item"],
+        { model: this.#model },
+      ) &&
+      event.output_index === 0 &&
+      exactDirectCandidateStart(event.item) &&
+      ![this.#openingResponseId].includes(event.item.id)
+    );
+  }
+
+  #startCapture(frame, event, mode) {
+    this.#capture = {
+      mode,
+      stage: "candidate-added",
+      candidateId: event.item.id,
+      frames: [],
+      bytes: 0,
+      reasoningFrames: [],
+      reasoningText: "",
+      toolFrames: [],
+      tool: undefined,
+      toolArguments: "",
+      sawToolDelta: false,
+      terminalTool: undefined,
+      terminalReasoning: undefined,
+      terminalBlank: undefined,
+    };
+    this.#startTimer();
+    this.#hold(frame);
+  }
+
+  #advanceHistorical(frame, event) {
+    const capture = this.#capture;
+    if (!capture) return false;
+    const id = capture.candidateId;
+    let valid = false;
+    if (capture.stage === "candidate-added") {
+      valid = exactDirectEvent(
+        event,
+        "response.content_part.added",
+        [
+          "type",
+          "item_id",
+          "output_index",
+          "content_index",
+          "sequence_number",
+          "part",
+        ],
+      ) && event.item_id === id && event.output_index === 0 &&
+        event.content_index === 0 && event.sequence_number === 2 &&
+        exactDirectEmptyPart(event.part);
+      if (valid) capture.stage = "candidate-part";
+    } else if (capture.stage === "candidate-part") {
+      const tool = directToolIdentity(event.item);
+      valid = exactDirectEvent(
+        event,
+        "response.output_item.added",
+        ["type", "output_index", "sequence_number", "item"],
+      ) && event.output_index === 1 && event.sequence_number === 3 &&
+        tool !== undefined && tool.arguments === "" &&
+        ![id].includes(tool.id);
+      if (valid) {
+        capture.tool = tool;
+        capture.toolFrames.push(frame);
+        capture.stage = "tool-added";
+      }
+    } else if (capture.stage === "tool-added") {
+      valid = exactDirectEvent(
+        event,
+        "response.function_call_arguments.delta",
+        ["type", "item_id", "output_index", "sequence_number", "delta"],
+      ) && event.item_id === capture.tool.id && event.output_index === 1 &&
+        event.sequence_number === 4 && typeof event.delta === "string" &&
+        event.delta.length > 0;
+      if (valid) {
+        capture.toolArguments = event.delta;
+        capture.sawToolDelta = true;
+        capture.toolFrames.push(frame);
+        capture.stage = "tool-delta";
+      }
+    } else if (capture.stage === "tool-delta") {
+      valid = exactDirectEvent(
+        event,
+        "response.output_item.done",
+        ["type", "output_index", "sequence_number", "item"],
+      ) && event.output_index === 1 && event.sequence_number === 5 &&
+        exactDirectCompletedTool(event.item, capture.tool, capture.toolArguments);
+      if (valid) {
+        capture.terminalTool = event.item;
+        capture.toolFrames.push(frame);
+        capture.stage = "tool-done";
+      }
+    } else if (capture.stage === "tool-done") {
+      valid = exactDirectEvent(
+        event,
+        "response.output_text.done",
+        [
+          "type",
+          "item_id",
+          "output_index",
+          "content_index",
+          "sequence_number",
+          "text",
+        ],
+      ) && event.item_id === id && event.output_index === 0 &&
+        event.content_index === 0 && event.sequence_number === 6 && event.text === "";
+      if (valid) capture.stage = "text-done";
+    } else if (capture.stage === "text-done") {
+      valid = exactDirectEvent(
+        event,
+        "response.content_part.done",
+        [
+          "type",
+          "item_id",
+          "output_index",
+          "content_index",
+          "sequence_number",
+          "part",
+        ],
+      ) && event.item_id === id && event.output_index === 0 &&
+        event.content_index === 0 && event.sequence_number === 7 &&
+        exactOwnKeys(event.part, ["type", "reasoning"]) &&
+        event.part.type === "reasoning_text" &&
+        typeof event.part.reasoning === "string" && event.part.reasoning.length > 0;
+      if (valid) capture.stage = "part-done";
+    } else if (capture.stage === "part-done") {
+      valid = exactDirectEvent(
+        event,
+        "response.output_item.done",
+        ["type", "output_index", "sequence_number", "item"],
+      ) && event.output_index === 0 && event.sequence_number === 8 &&
+        exactDirectCompletedBlank(event.item) && event.item.id === id;
+      if (valid) capture.stage = "candidate-done";
+    } else if (capture.stage === "candidate-done") {
+      valid = this.#acceptHistoricalCompleted(event);
+      if (valid) {
+        this.#hold(frame);
+        if (this.#capture) this.#capture.stage = "completed";
+        return true;
+      }
+    }
+    if (!valid) return false;
+    this.#hold(frame);
+    return true;
+  }
+
+  #acceptHistoricalCompleted(event) {
+    const capture = this.#capture;
+    if (
+      !capture ||
+      !exactDirectEvent(
+        event,
+        "response.completed",
+        ["type", "sequence_number", "response"],
+      ) ||
+      event.sequence_number !== 9 ||
+      !exactOwnKeys(event.response, [...DIRECT_HISTORICAL_RESPONSE_KEYS]) ||
+      !itemId(event.response.id)?.startsWith("resp_") ||
+      event.response.status !== "completed" ||
+      !Array.isArray(event.response.output) ||
+      event.response.output.length !== 2
+    ) return false;
+    const [blank, tool] = event.response.output;
+    if (
+      !exactDirectCompletedBlank(blank) ||
+      blank.id !== capture.candidateId ||
+      !exactDirectCompletedTool(tool, capture.tool, capture.toolArguments)
+    ) return false;
+    const ids = new Set([
+      event.response.id,
+      capture.candidateId,
+      capture.tool.id,
+    ]);
+    if (ids.size !== 3) return false;
+    capture.terminalTool = tool;
+    return true;
+  }
+
+  #advanceCurrent(frame, event) {
+    const capture = this.#capture;
+    if (!capture) return false;
+    const id = capture.candidateId;
+    let valid = false;
+    if (capture.stage === "candidate-added") {
+      valid = exactDirectEvent(
+        event,
+        "response.content_part.added",
+        ["type", "item_id", "output_index", "content_index", "part"],
+        { model: this.#model },
+      ) && event.item_id === id && event.output_index === 0 &&
+        event.content_index === 0 && exactDirectEmptyPart(event.part);
+      if (valid) capture.stage = "reasoning";
+    } else if (capture.stage === "reasoning") {
+      if (exactDirectEvent(
+        event,
+        "response.reasoning_summary_text.delta",
+        ["type", "item_id", "output_index", "delta"],
+        { model: this.#model },
+      )) {
+        valid = event.item_id === id && event.output_index === 0 &&
+          typeof event.delta === "string" && event.delta.length > 0;
+        if (valid) {
+          capture.reasoningText += event.delta;
+          capture.reasoningFrames.push(frame);
+        }
+      } else {
+        const tool = directToolIdentity(event.item);
+        valid = capture.reasoningFrames.length > 0 &&
+          exactDirectEvent(
+            event,
+            "response.output_item.added",
+            ["type", "output_index", "item"],
+            { model: this.#model },
+          ) && event.output_index === 1 && tool !== undefined &&
+          tool.arguments === "" &&
+          ![this.#openingResponseId, id].includes(tool.id);
+        if (valid) {
+          capture.tool = tool;
+          capture.toolFrames.push(frame);
+          capture.stage = "tool-added";
+        }
+      }
+    } else if (capture.stage === "tool-added") {
+      if (exactDirectEvent(
+        event,
+        "response.function_call_arguments.delta",
+        ["type", "item_id", "output_index", "delta"],
+        { model: this.#model },
+      )) {
+        valid = event.item_id === capture.tool.id && event.output_index === 1 &&
+          typeof event.delta === "string" && event.delta.length > 0;
+        if (valid) {
+          capture.toolArguments += event.delta;
+          capture.sawToolDelta = true;
+          capture.toolFrames.push(frame);
+        }
+      } else {
+        valid = capture.sawToolDelta && exactDirectEvent(
+          event,
+          "response.function_call_arguments.done",
+          ["type", "item_id", "output_index", "arguments"],
+          { model: this.#model },
+        ) && event.item_id === capture.tool.id && event.output_index === 1 &&
+          event.arguments === capture.toolArguments;
+        if (valid) {
+          capture.toolFrames.push(frame);
+          capture.stage = "arguments-done";
+        }
+      }
+    } else if (capture.stage === "arguments-done") {
+      valid = exactDirectEvent(
+        event,
+        "response.output_item.done",
+        ["type", "output_index", "sequence_number", "item"],
+        { model: this.#model },
+      ) && event.output_index === 1 && event.sequence_number === 16 &&
+        exactDirectCompletedTool(event.item, capture.tool, capture.toolArguments);
+      if (valid) {
+        capture.terminalTool = event.item;
+        capture.toolFrames.push(frame);
+        capture.stage = "tool-done";
+      }
+    } else if (capture.stage === "tool-done") {
+      valid = exactDirectEvent(
+        event,
+        "response.output_text.done",
+        ["type", "item_id", "output_index", "content_index", "text"],
+        { model: this.#model },
+      ) && event.item_id === id && event.output_index === 0 &&
+        event.content_index === 0 && event.text === "";
+      if (valid) capture.stage = "text-done";
+    } else if (capture.stage === "text-done") {
+      valid = exactDirectEvent(
+        event,
+        "response.content_part.done",
+        ["type", "item_id", "output_index", "content_index", "part"],
+        { model: this.#model },
+      ) && event.item_id === id && event.output_index === 0 &&
+        event.content_index === 0 && exactOwnKeys(event.part, ["type", "reasoning"]) &&
+        event.part.type === "reasoning_text" &&
+        event.part.reasoning === capture.reasoningText;
+      if (valid) capture.stage = "part-done";
+    } else if (capture.stage === "part-done") {
+      valid = exactDirectEvent(
+        event,
+        "response.output_item.done",
+        ["type", "output_index", "sequence_number", "item"],
+        { model: this.#model },
+      ) && event.output_index === 0 && event.sequence_number === 1 &&
+        exactDirectCompletedBlank(event.item) && event.item.id === id;
+      if (valid) capture.stage = "candidate-done";
+    } else if (capture.stage === "candidate-done") {
+      valid = this.#acceptCurrentCompleted(event);
+      if (valid) {
+        this.#hold(frame);
+        if (this.#capture) this.#capture.stage = "completed";
+        return true;
+      }
+    }
+    if (!valid) return false;
+    this.#hold(frame);
+    return true;
+  }
+
+  #acceptCurrentCompleted(event) {
+    const capture = this.#capture;
+    if (
+      !capture ||
+      !exactDirectEvent(
+        event,
+        "response.completed",
+        ["type", "response"],
+        { model: this.#model },
+      ) ||
+      !successfulResponseEnvelope(event.response, "completed") ||
+      event.response.id === this.#openingResponseId ||
+      !event.response.id.startsWith("resp_") ||
+      event.response.model !== this.#model ||
+      event.response.output.length !== 3
+    ) return false;
+    const [reasoning, blank, tool] = event.response.output;
+    if (
+      !exactDirectReasoningItem(reasoning, capture.reasoningText) ||
+      !exactDirectCompletedBlank(blank, { omittedText: true }) ||
+      blank.id === capture.candidateId ||
+      !exactDirectCompletedTool(tool, capture.tool, capture.toolArguments)
+    ) return false;
+    const ids = new Set([
+      this.#openingResponseId,
+      event.response.id,
+      capture.candidateId,
+      reasoning.id,
+      blank.id,
+      capture.tool.id,
+    ]);
+    if (ids.size !== 6) return false;
+    capture.terminalReasoning = reasoning;
+    capture.terminalBlank = blank;
+    capture.terminalTool = tool;
+    return true;
+  }
+
+  #repairCapture() {
+    if (this.#capture?.mode === "historical") this.#repairHistorical();
+    else if (this.#capture?.mode === "current") this.#repairCurrent();
+  }
+
+  #repairHistorical() {
+    const capture = this.#capture;
+    if (!capture) return;
+    this.#capture = undefined;
+    this.#clearTimer();
+    for (const frame of capture.frames) {
+      const event = frame.parsed.event;
+      const attached = eventItemId(event);
+      if (attached === capture.candidateId) continue;
+      if (event.type === "response.completed") {
+        this.push(rewrittenBlock(frame.parsed, {
+          ...event,
+          response: { ...event.response, output: [capture.terminalTool] },
+        }, frame.separator));
+        continue;
+      }
+      if (attached === capture.tool.id && event.output_index === 1) {
+        this.push(rewrittenBlock(
+          frame.parsed,
+          { ...event, output_index: 0 },
+          frame.separator,
+        ));
+      }
+    }
+    this.#finished = true;
+  }
+
+  #repairCurrent() {
+    const capture = this.#capture;
+    if (!capture) return;
+    this.#capture = undefined;
+    this.#clearTimer();
+    const reasoning = {
+      id: capture.terminalReasoning.id,
+      type: "reasoning",
+      status: "completed",
+      summary: [{ type: "summary_text", text: capture.reasoningText }],
+    };
+    const inProgressReasoning = {
+      id: reasoning.id,
+      type: "reasoning",
+      status: "in_progress",
+      summary: [],
+    };
+    const template = capture.frames[0];
+    const emit = (event) => this.push(
+      rewrittenEventBlock(template.parsed, event, template.separator),
+    );
+    emit({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: inProgressReasoning,
+      model: this.#model,
+    });
+    emit({
+      type: "response.reasoning_summary_part.added",
+      item_id: reasoning.id,
+      output_index: 0,
+      summary_index: 0,
+      part: { type: "summary_text", text: "" },
+      model: this.#model,
+    });
+    for (const frame of capture.reasoningFrames) {
+      this.push(rewrittenBlock(frame.parsed, {
+        ...frame.parsed.event,
+        item_id: reasoning.id,
+        summary_index: 0,
+      }, frame.separator));
+    }
+    emit({
+      type: "response.reasoning_summary_text.done",
+      item_id: reasoning.id,
+      output_index: 0,
+      summary_index: 0,
+      text: capture.reasoningText,
+      model: this.#model,
+    });
+    emit({
+      type: "response.reasoning_summary_part.done",
+      item_id: reasoning.id,
+      output_index: 0,
+      summary_index: 0,
+      part: { type: "summary_text", text: capture.reasoningText },
+      model: this.#model,
+    });
+    emit({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: reasoning,
+      model: this.#model,
+    });
+    for (const frame of capture.toolFrames) this.push(frame.original);
+    const completed = capture.frames.at(-1);
+    this.push(rewrittenBlock(completed.parsed, {
+      ...completed.parsed.event,
+      response: {
+        ...completed.parsed.event.response,
+        output: [reasoning, capture.terminalTool],
+      },
+    }, completed.separator));
+    this.#finished = true;
+  }
+
+  #hold(frame) {
+    if (!this.#capture) return;
+    if (this.#capture.bytes + frame.original.length > this.#maxCandidateBytes) {
+      this.#failOpen(frame);
+      return;
+    }
+    this.#capture.frames.push(frame);
+    this.#capture.bytes += frame.original.length;
+  }
+
+  #failOpen(extraFrame) {
+    const capture = this.#capture;
+    this.#capture = undefined;
+    this.#clearTimer();
+    if (capture) {
+      for (const frame of capture.frames) this.push(frame.original);
+    }
+    if (extraFrame) this.push(extraFrame.original);
+    this.#disabled = true;
+  }
+
+  #oversizedFrame(original) {
+    const frame = { original: Buffer.isBuffer(original) ? original : Buffer.from(original) };
+    this.#failOpen(frame);
+  }
+
+  #pushBuffered() {
+    if (!this.#buffer.length) return;
+    this.push(this.#buffer);
+    this.#buffer = Buffer.alloc(0);
+  }
+
+  #startTimer() {
+    if (this.#timer || !this.#capture) return;
+    this.#timer = setTimeout(() => {
+      this.#failOpen();
+      this.#pushBuffered();
+    }, this.#maxCandidateMs);
+    this.#timer.unref?.();
+  }
+
+  #clearTimer() {
+    if (!this.#timer) return;
+    clearTimeout(this.#timer);
+    this.#timer = undefined;
+  }
 }
 
 // LiteLLM's Chat-Completions/Anthropic -> Responses bridge can announce an
@@ -1839,6 +2686,7 @@ export function translatedToolMessageCompatTransform(provider, contentType = "")
   if (!translatedProtocol(provider)) return undefined;
   const mediaType = String(contentType).split(";", 1)[0].trim().toLowerCase();
   if (mediaType === "text/event-stream") {
+    if (provider.id === "deepseek") return new DeepseekToolMessageCompatTransform();
     return new TranslatedToolMessageCompatTransform({
       // LiteLLM's Anthropic bridge can omit the empty message's opening events
       // and reveal its index-zero slot only after the first tool has closed.
@@ -1858,11 +2706,6 @@ export function translatedToolMessageCompatTransform(provider, contentType = "")
 export function deepseekToolMessageCompatTransform(providerId, contentType = "") {
   if (String(providerId) !== "deepseek") return undefined;
   return String(contentType).toLowerCase().includes("text/event-stream")
-    ? new TranslatedToolMessageCompatTransform()
+    ? new DeepseekToolMessageCompatTransform()
     : undefined;
 }
-
-// Kept as an internal compatibility alias for code that imported the original
-// provider-specific class directly before the transform became protocol-scoped.
-export const DeepseekToolMessageCompatTransform =
-  TranslatedToolMessageCompatTransform;

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -1,11 +1,16 @@
 import { Transform } from "node:stream";
-import { TextDecoder } from "node:util";
+import { isDeepStrictEqual, TextDecoder } from "node:util";
 
 const MAX_CANDIDATE_BYTES = 64 * 1024;
 const MAX_CANDIDATE_MS = 1_000;
 const MAX_FRAME_BYTES = 256 * 1024;
 const MAX_JSON_BYTES = 8 * 1024 * 1024;
 const MAX_JSON_MS = 1_000;
+const MAX_JSON_DEPTH = 256;
+const MAX_FRAME_JSON_MEMBERS = 8 * 1024;
+const MAX_BODY_JSON_MEMBERS = 64 * 1024;
+const MAX_FRAME_JSON_KEY_CODE_UNITS = 128 * 1024;
+const MAX_BODY_JSON_KEY_CODE_UNITS = 1024 * 1024;
 const LF_FRAME_SEPARATOR = Buffer.from("\n\n");
 const CRLF_FRAME_SEPARATOR = Buffer.from("\r\n\r\n");
 const RESPONSE_EVENT_KEYS = new Set(["type", "sequence_number", "response"]);
@@ -196,7 +201,250 @@ function fatalUtf8(buffer) {
   return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
 }
 
-function parsedBlock(blockBytes) {
+// JSON.parse silently keeps only the last occurrence of a duplicate object
+// member. That is unsafe here because a later stringify could then erase an
+// earlier visible/error value. Scan the bounded source first, decoding only
+// object keys so equivalent escape spellings compare as the same member while
+// value strings and number spellings remain JSON.parse's responsibility.
+function uniqueJsonObjectMembers(source, limits) {
+  let offset = 0;
+  let rootState = "value";
+  let memberCount = 0;
+  let keyCodeUnits = 0;
+  const stack = [];
+
+  const whitespace = (code) => (
+    code === 0x20 || code === 0x09 || code === 0x0a || code === 0x0d
+  );
+  const hexValue = (code) => {
+    if (code >= 0x30 && code <= 0x39) return code - 0x30;
+    if (code >= 0x41 && code <= 0x46) return code - 0x41 + 10;
+    if (code >= 0x61 && code <= 0x66) return code - 0x61 + 10;
+    return -1;
+  };
+  const scanString = (decodeKey = false) => {
+    if (source.charCodeAt(offset) !== 0x22) return undefined;
+    offset += 1;
+    let segmentStart = offset;
+    let decodedLength = 0;
+    const parts = decodeKey ? [] : undefined;
+    const appendRawSegment = (end) => {
+      if (!decodeKey || end === segmentStart) return true;
+      decodedLength += end - segmentStart;
+      if (keyCodeUnits + decodedLength > limits.maxKeyCodeUnits) return false;
+      parts.push(source.slice(segmentStart, end));
+      return true;
+    };
+    while (offset < source.length) {
+      const code = source.charCodeAt(offset);
+      if (code === 0x22) {
+        if (!appendRawSegment(offset)) return undefined;
+        offset += 1;
+        return decodeKey
+          ? { key: parts.join(""), codeUnits: decodedLength }
+          : { codeUnits: 0 };
+      }
+      if (code < 0x20) return undefined;
+      if (code !== 0x5c) {
+        offset += 1;
+        continue;
+      }
+      if (!appendRawSegment(offset)) return undefined;
+      offset += 1;
+      if (offset >= source.length) return undefined;
+      const escape = source[offset];
+      let decoded;
+      if (escape === "u") {
+        if (offset + 4 >= source.length) return undefined;
+        let value = 0;
+        for (let index = 1; index <= 4; index += 1) {
+          const hex = hexValue(source.charCodeAt(offset + index));
+          if (hex < 0) return undefined;
+          value = (value * 16) + hex;
+        }
+        decoded = String.fromCharCode(value);
+        offset += 5;
+      } else {
+        const escapes = {
+          '"': '"',
+          "\\": "\\",
+          "/": "/",
+          b: "\b",
+          f: "\f",
+          n: "\n",
+          r: "\r",
+          t: "\t",
+        };
+        decoded = escapes[escape];
+        if (decoded === undefined) return undefined;
+        offset += 1;
+      }
+      if (decodeKey) {
+        decodedLength += 1;
+        if (keyCodeUnits + decodedLength > limits.maxKeyCodeUnits) return undefined;
+        parts.push(decoded);
+      }
+      segmentStart = offset;
+    }
+    return undefined;
+  };
+  const scanNumber = () => {
+    if (source[offset] === "-") offset += 1;
+    if (source[offset] === "0") {
+      offset += 1;
+    } else {
+      const first = source.charCodeAt(offset);
+      if (first < 0x31 || first > 0x39) return false;
+      offset += 1;
+      while (source.charCodeAt(offset) >= 0x30 && source.charCodeAt(offset) <= 0x39) {
+        offset += 1;
+      }
+    }
+    if (source[offset] === ".") {
+      offset += 1;
+      const first = source.charCodeAt(offset);
+      if (first < 0x30 || first > 0x39) return false;
+      while (source.charCodeAt(offset) >= 0x30 && source.charCodeAt(offset) <= 0x39) {
+        offset += 1;
+      }
+    }
+    if (source[offset] === "e" || source[offset] === "E") {
+      offset += 1;
+      if (source[offset] === "+" || source[offset] === "-") offset += 1;
+      const first = source.charCodeAt(offset);
+      if (first < 0x30 || first > 0x39) return false;
+      while (source.charCodeAt(offset) >= 0x30 && source.charCodeAt(offset) <= 0x39) {
+        offset += 1;
+      }
+    }
+    return true;
+  };
+  const completeValue = () => {
+    const parent = stack.at(-1);
+    if (!parent) {
+      if (rootState !== "value") return false;
+      rootState = "done";
+      return true;
+    }
+    if (parent.state !== "value") return false;
+    parent.state = "commaOrEnd";
+    return true;
+  };
+  const beginContainer = (kind) => {
+    if (stack.length >= limits.maxDepth) return false;
+    stack.push(kind === "object"
+      ? { kind, state: "keyOrEnd", keys: new Set() }
+      : { kind, state: "valueOrEnd" });
+    return true;
+  };
+  const scanValue = () => {
+    const token = source[offset];
+    if (token === "{") {
+      offset += 1;
+      return beginContainer("object");
+    }
+    if (token === "[") {
+      offset += 1;
+      return beginContainer("array");
+    }
+    if (token === '"') {
+      if (!scanString()) return false;
+      return completeValue();
+    }
+    for (const literal of ["true", "false", "null"]) {
+      if (source.startsWith(literal, offset)) {
+        offset += literal.length;
+        return completeValue();
+      }
+    }
+    if (token === "-" || (token >= "0" && token <= "9")) {
+      if (!scanNumber()) return false;
+      return completeValue();
+    }
+    return false;
+  };
+
+  while (offset < source.length) {
+    while (offset < source.length && whitespace(source.charCodeAt(offset))) offset += 1;
+    if (offset >= source.length) break;
+    const frame = stack.at(-1);
+    if (!frame) {
+      if (rootState !== "value" || !scanValue()) return false;
+      continue;
+    }
+    const token = source[offset];
+    if (frame.kind === "object") {
+      if (frame.state === "keyOrEnd" || frame.state === "key") {
+        if (frame.state === "keyOrEnd" && token === "}") {
+          offset += 1;
+          stack.pop();
+          if (!completeValue()) return false;
+          continue;
+        }
+        const parsed = scanString(true);
+        if (!parsed) return false;
+        memberCount += 1;
+        keyCodeUnits += parsed.codeUnits;
+        if (
+          memberCount > limits.maxMembers ||
+          keyCodeUnits > limits.maxKeyCodeUnits ||
+          frame.keys.has(parsed.key)
+        ) return false;
+        frame.keys.add(parsed.key);
+        frame.state = "colon";
+        continue;
+      }
+      if (frame.state === "colon") {
+        if (token !== ":") return false;
+        offset += 1;
+        frame.state = "value";
+        continue;
+      }
+      if (frame.state === "value") {
+        if (!scanValue()) return false;
+        continue;
+      }
+      if (token === ",") {
+        offset += 1;
+        frame.state = "key";
+        continue;
+      }
+      if (token === "}") {
+        offset += 1;
+        stack.pop();
+        if (!completeValue()) return false;
+        continue;
+      }
+      return false;
+    }
+    if (frame.state === "valueOrEnd" && token === "]") {
+      offset += 1;
+      stack.pop();
+      if (!completeValue()) return false;
+      continue;
+    }
+    if (frame.state === "valueOrEnd" || frame.state === "value") {
+      frame.state = "value";
+      if (!scanValue()) return false;
+      continue;
+    }
+    if (token === ",") {
+      offset += 1;
+      frame.state = "value";
+      continue;
+    }
+    if (token === "]") {
+      offset += 1;
+      stack.pop();
+      if (!completeValue()) return false;
+      continue;
+    }
+    return false;
+  }
+  return rootState === "done" && stack.length === 0;
+}
+
+function parsedBlock(blockBytes, jsonLimits) {
   let block;
   try {
     block = fatalUtf8(blockBytes);
@@ -226,6 +474,7 @@ function parsedBlock(blockBytes) {
     return eventLines.length === 0 ? { done: true } : { malformed: true };
   }
   try {
+    if (!uniqueJsonObjectMembers(dataText, jsonLimits)) return { malformed: true };
     const event = JSON.parse(dataText);
     if (
       eventLines.length === 1 &&
@@ -281,6 +530,21 @@ function candidateStart(item) {
 function finiteLimit(value, fallback, { minimum = 0, integer = false } = {}) {
   if (!Number.isFinite(value) || value < minimum) return fallback;
   return integer ? Math.floor(value) : value;
+}
+
+function jsonScanLimits(
+  { maxJsonDepth, maxJsonMembers, maxJsonKeyCodeUnits },
+  { maxMembers, maxKeyCodeUnits },
+) {
+  const capped = (value, maximum) => Math.min(
+    finiteLimit(value, maximum, { minimum: 1, integer: true }),
+    maximum,
+  );
+  return {
+    maxDepth: capped(maxJsonDepth, MAX_JSON_DEPTH),
+    maxMembers: capped(maxJsonMembers, maxMembers),
+    maxKeyCodeUnits: capped(maxJsonKeyCodeUnits, maxKeyCodeUnits),
+  };
 }
 
 function exactEmptyPart(part) {
@@ -568,12 +832,16 @@ export class TranslatedToolMessageCompatTransform extends Transform {
   #maxCandidateBytes;
   #maxCandidateMs;
   #maxFrameBytes;
+  #jsonLimits;
   #timer;
 
   constructor({
     maxCandidateBytes = MAX_CANDIDATE_BYTES,
     maxCandidateMs = MAX_CANDIDATE_MS,
     maxFrameBytes = MAX_FRAME_BYTES,
+    maxJsonDepth,
+    maxJsonMembers,
+    maxJsonKeyCodeUnits,
   } = {}) {
     super();
     this.#maxCandidateBytes = finiteLimit(
@@ -586,6 +854,13 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       minimum: 1,
       integer: true,
     });
+    this.#jsonLimits = jsonScanLimits(
+      { maxJsonDepth, maxJsonMembers, maxJsonKeyCodeUnits },
+      {
+        maxMembers: MAX_FRAME_JSON_MEMBERS,
+        maxKeyCodeUnits: MAX_FRAME_JSON_KEY_CODE_UNITS,
+      },
+    );
   }
 
   _transform(chunk, _encoding, callback) {
@@ -663,7 +938,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
   }
 
   #handleBlock(block, separator) {
-    const parsedResult = parsedBlock(block);
+    const parsedResult = parsedBlock(block, this.#jsonLimits);
     const frame = {
       original: Buffer.concat([block, separator]),
       parsed: parsedResult.parsed,
@@ -799,6 +1074,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
         textDeltas: new Set(),
         textValues: new Map(),
         doneTexts: new Map(),
+        terminalItem: undefined,
       };
     } else if (exactToolCall(event.item)) {
       const valueField = toolValueField(event.item.type);
@@ -1001,10 +1277,12 @@ export class TranslatedToolMessageCompatTransform extends Transform {
     if (event.type === "response.output_item.done") {
       if (
         event.item?.id !== record.id ||
-        !exactReasoningItem(event.item, { completed: true })
+        !exactReasoningItem(event.item, { completed: true }) ||
+        !this.#reasoningLifecycleMatchesTerminal(event.item, record)
       ) return false;
       for (const key of record.parts) if (!record.partDones.has(key)) return false;
       for (const key of record.textDeltas) if (!record.textDones.has(key)) return false;
+      record.terminalItem = event.item;
       record.done = true;
       return true;
     }
@@ -1058,6 +1336,28 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       return true;
     }
     return false;
+  }
+
+  #reasoningLifecycleMatchesTerminal(item, record) {
+    for (const [prefix, field, type] of [
+      ["summary", "summary", "summary_text"],
+      ["content", "content", "reasoning_text"],
+    ]) {
+      const keys = [...record.parts].filter((key) => key.startsWith(`${prefix}:`));
+      if (!keys.length) continue;
+      const parts = item[field];
+      if (!Array.isArray(parts) || parts.length !== keys.length) return false;
+      for (let index = 0; index < parts.length; index += 1) {
+        const key = `${prefix}:${index}`;
+        const text = record.doneTexts.get(key) ?? record.textValues.get(key);
+        if (
+          !record.parts.has(key) ||
+          !record.partDones.has(key) ||
+          !isDeepStrictEqual(parts[index], { type, text })
+        ) return false;
+      }
+    }
+    return true;
   }
 
   #handleCompleted(frame, event) {
@@ -1118,7 +1418,11 @@ export class TranslatedToolMessageCompatTransform extends Transform {
       }
       if (id !== record.id) return false;
       if (record.kind === "reasoning") {
-        if (!exactReasoningItem(item, { completed: true })) return false;
+        if (
+          !exactReasoningItem(item, { completed: true }) ||
+          !record.terminalItem ||
+          !isDeepStrictEqual(item, record.terminalItem)
+        ) return false;
         continue;
       }
       if (!matchesToolCallIdentity(item, {
@@ -1237,15 +1541,29 @@ export class TranslatedToolMessageJsonCompatTransform extends Transform {
   #released = false;
   #maxBytes;
   #maxMs;
+  #jsonLimits;
   #timer;
 
-  constructor({ maxBytes = MAX_JSON_BYTES, maxMs = MAX_JSON_MS } = {}) {
+  constructor({
+    maxBytes = MAX_JSON_BYTES,
+    maxMs = MAX_JSON_MS,
+    maxJsonDepth,
+    maxJsonMembers,
+    maxJsonKeyCodeUnits,
+  } = {}) {
     super();
     this.#maxBytes = finiteLimit(maxBytes, MAX_JSON_BYTES, {
       minimum: 1,
       integer: true,
     });
     this.#maxMs = finiteLimit(maxMs, MAX_JSON_MS);
+    this.#jsonLimits = jsonScanLimits(
+      { maxJsonDepth, maxJsonMembers, maxJsonKeyCodeUnits },
+      {
+        maxMembers: MAX_BODY_JSON_MEMBERS,
+        maxKeyCodeUnits: MAX_BODY_JSON_KEY_CODE_UNITS,
+      },
+    );
   }
 
   _transform(chunk, _encoding, callback) {
@@ -1281,6 +1599,11 @@ export class TranslatedToolMessageJsonCompatTransform extends Transform {
     }
     try {
       const source = fatalUtf8(body);
+      if (!uniqueJsonObjectMembers(source, this.#jsonLimits)) {
+        this.push(body);
+        callback();
+        return;
+      }
       const payload = JSON.parse(source);
       const output = jsonResponseOutput(payload);
       const indexes = removableJsonMessageIndexes(output);

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -828,6 +828,7 @@ export class TranslatedToolMessageCompatTransform extends Transform {
   #items = new Map();
   #indexItems = new Map();
   #lastSequence = -1;
+  #usedTerminalCandidateSequenceReset = false;
   #preludeBytes = 0;
   #maxCandidateBytes;
   #maxCandidateMs;
@@ -1020,8 +1021,33 @@ export class TranslatedToolMessageCompatTransform extends Transform {
 
   #acceptSequence(event) {
     if (event.sequence_number === undefined) return true;
-    if (event.sequence_number <= this.#lastSequence) return false;
-    this.#lastSequence = event.sequence_number;
+    if (event.sequence_number > this.#lastSequence) {
+      this.#lastSequence = event.sequence_number;
+      return true;
+    }
+
+    // LiteLLM 1.96.0 hard-codes sequence_number=1 on the terminal
+    // output_item.done for the empty Chat-Completions bridge message, even
+    // after it has emitted higher-numbered tool events. Admit only that one
+    // pinned wire defect, after the active candidate and its tool evidence are
+    // already known. Keep the high-water mark so every later numbered event
+    // must still advance the real stream sequence.
+    const id = eventItemId(event);
+    const record = id ? this.#items.get(id) : undefined;
+    if (
+      this.#usedTerminalCandidateSequenceReset ||
+      event.sequence_number !== 1 ||
+      event.type !== "response.output_item.done" ||
+      !this.#capture ||
+      record?.kind !== "candidate" ||
+      record.done ||
+      !record.sawTool ||
+      !eventIndexMatches(event, record) ||
+      !exactEmptyMessage(event.item) ||
+      event.item.id !== record.id
+    ) return false;
+
+    this.#usedTerminalCandidateSequenceReset = true;
     return true;
   }
 

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -4,6 +4,22 @@ import { StringDecoder } from "node:string_decoder";
 const MAX_CANDIDATE_BYTES = 64 * 1024;
 const MAX_CANDIDATE_MS = 1_000;
 const MAX_FRAME_BYTES = 256 * 1024;
+const MAX_JSON_BYTES = 8 * 1024 * 1024;
+const MAX_JSON_MS = 1_000;
+const TERMINAL_EMPTY_PART_KEYS = new Set([
+  "type",
+  "text",
+  "annotations",
+  "logprobs",
+]);
+const TERMINAL_EMPTY_MESSAGE_KEYS = new Set([
+  "id",
+  "type",
+  "status",
+  "role",
+  "content",
+  "phase",
+]);
 
 function parsedBlock(block) {
   const newline = block.includes("\r\n") ? "\r\n" : "\n";
@@ -90,6 +106,112 @@ function exactEmptyMessage(item) {
   );
 }
 
+// LiteLLM 1.96.0's terminal Chat-Completions -> Responses object represents
+// the same empty text part as either null or an omitted `text` property. The
+// streamed lifecycle is kept stricter above: every event must still explicitly
+// prove an empty string before we consider suppressing it.
+function exactTerminalEmptyPart(part) {
+  return (
+    part != null &&
+    typeof part === "object" &&
+    !Array.isArray(part) &&
+    Object.keys(part).every((key) => TERMINAL_EMPTY_PART_KEYS.has(key)) &&
+    ["output_text", "text"].includes(part.type) &&
+    (part.text === "" || part.text === null || part.text === undefined) &&
+    (part.annotations === undefined ||
+      (Array.isArray(part.annotations) && part.annotations.length === 0)) &&
+    (part.logprobs === undefined || part.logprobs === null ||
+      (Array.isArray(part.logprobs) && part.logprobs.length === 0))
+  );
+}
+
+function exactCompletedEmptyMessage(item) {
+  return (
+    item != null &&
+    typeof item === "object" &&
+    !Array.isArray(item) &&
+    Object.keys(item).every((key) => TERMINAL_EMPTY_MESSAGE_KEYS.has(key)) &&
+    item?.type === "message" &&
+    item.role === "assistant" &&
+    Array.isArray(item.content) &&
+    item.content.length > 0 &&
+    item.content.every(exactTerminalEmptyPart) &&
+    itemId(item.id) !== undefined &&
+    (item.phase === undefined || item.phase === null) &&
+    (item.status === undefined || item.status === "completed")
+  );
+}
+
+function isReasoningItem(item) {
+  return item?.type === "reasoning";
+}
+
+function hasValidToolCallIdentity(item) {
+  return (
+    isToolCall(item) &&
+    itemId(item.id) !== undefined &&
+    itemId(item.call_id) !== undefined &&
+    typeof item.name === "string" &&
+    item.name.length > 0
+  );
+}
+
+function matchesToolCallIdentity(item, expected) {
+  return (
+    expected !== undefined &&
+    hasValidToolCallIdentity(item) &&
+    item.type === expected.type &&
+    item.name === expected.name &&
+    item.call_id === expected.callId
+  );
+}
+
+// Non-streaming Responses bodies have no lifecycle events to corroborate an
+// empty message. Keep the proof deliberately narrower: the item must be a
+// completed, exactly empty assistant message, and the only output allowed
+// between it and the function call that proves the bridge pattern is
+// reasoning. A visible/refusal/unknown item ends that candidate.
+function removableJsonMessageIndexes(output) {
+  if (!Array.isArray(output)) return [];
+  const removable = [];
+  let pending;
+  let ambiguousRun = false;
+  for (let index = 0; index < output.length; index += 1) {
+    const item = output[index];
+    if (exactCompletedEmptyMessage(item)) {
+      // Two empty messages with no intervening tool are ambiguous. Preserve
+      // both instead of letting one tool retroactively prove both envelopes.
+      if (pending !== undefined || ambiguousRun) {
+        pending = undefined;
+        ambiguousRun = true;
+      } else {
+        pending = index;
+      }
+      continue;
+    }
+    if (ambiguousRun) {
+      if (!isReasoningItem(item)) ambiguousRun = false;
+      continue;
+    }
+    if (pending === undefined) continue;
+    if (hasValidToolCallIdentity(item)) {
+      removable.push(pending);
+      pending = undefined;
+      continue;
+    }
+    if (!isReasoningItem(item)) pending = undefined;
+  }
+  return removable;
+}
+
+function jsonResponseOutput(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return undefined;
+  if (payload.error !== undefined && payload.error !== null) return undefined;
+  if (payload.object !== undefined && payload.object !== "response") return undefined;
+  if (payload.status !== undefined && payload.status !== "completed") return undefined;
+  return Array.isArray(payload.output) ? payload.output : undefined;
+}
+
 function candidateLifecycle(event, id) {
   if (eventItemId(event) !== id) return false;
   return [
@@ -116,7 +238,7 @@ function exactEmptyCandidateEvent(event) {
       return (
         exactEmptyPart(event.part) ||
         (event.part?.type === "reasoning_text" &&
-          typeof event.part.reasoning === "string")
+          event.part.reasoning === "")
       );
     case "response.output_item.done":
       return exactEmptyMessage(event.item);
@@ -125,8 +247,8 @@ function exactEmptyCandidateEvent(event) {
   }
 }
 
-// LiteLLM's Chat-Completions -> Responses bridge can announce an empty
-// assistant message before a DeepSeek tool call, then close that message after
+// LiteLLM's Chat-Completions/Anthropic -> Responses bridge can announce an
+// empty assistant message before a tool call, then close that message after
 // the call. Codex renders the empty lifecycle as a separate assistant turn.
 //
 // The tool cannot be renumbered until the preceding message is conclusively
@@ -134,10 +256,10 @@ function exactEmptyCandidateEvent(event) {
 // This transform therefore holds only that ambiguous interval under strict
 // byte and time budgets. Every ambiguous, malformed, large, or slow shape fails
 // open byte-for-byte and permanently disables the repair for that response.
-export class DeepseekToolMessageCompatTransform extends Transform {
+export class TranslatedToolMessageCompatTransform extends Transform {
   #decoder = new StringDecoder("utf8");
   #buffer = "";
-  #candidate;
+  #capture;
   #disabled = false;
   #suppressed;
   #maxCandidateBytes;
@@ -189,7 +311,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       return;
     }
     this.#emitCompleteBlocks(true);
-    if (this.#candidate) this.#failOpen();
+    if (this.#capture) this.#failOpen();
     this.#pushBuffered();
     callback();
   }
@@ -240,7 +362,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       separator,
     };
     if (!frame.parsed) {
-      if (this.#candidate) this.#failOpen(frame);
+      if (this.#capture) this.#failOpen(frame);
       else this.push(Buffer.from(frame.original));
       return;
     }
@@ -255,7 +377,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       return;
     }
 
-    if (!this.#candidate) {
+    if (!this.#capture) {
       if (
         event.type === "response.output_item.added" &&
         candidateStart(event.item) &&
@@ -263,15 +385,21 @@ export class DeepseekToolMessageCompatTransform extends Transform {
         Number.isInteger(event.output_index) &&
         event.output_index >= 0
       ) {
-        this.#candidate = {
+        const candidate = {
           id: event.item.id,
           outputIndex: event.output_index,
-          frames: [],
-          bytes: 0,
           sawTool: false,
           closed: false,
+        };
+        this.#capture = {
+          firstOutputIndex: event.output_index,
+          frames: [],
+          bytes: 0,
+          candidates: new Map([[candidate.id, candidate]]),
+          candidateOrder: [candidate],
           itemIndexes: new Map([[event.item.id, event.output_index]]),
           indexItems: new Map([[event.output_index, event.item.id]]),
+          toolItems: new Map(),
         };
         this.#startTimer();
         this.#hold(frame);
@@ -281,17 +409,22 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       return;
     }
 
-    const candidate = this.#candidate;
+    const capture = this.#capture;
     const attachedId = eventItemId(event);
-    if (attachedId === candidate.id && !candidateLifecycle(event, candidate.id)) {
+    const attachedCandidate = capture.candidates.get(attachedId);
+    if (
+      attachedCandidate &&
+      !candidateLifecycle(event, attachedCandidate.id)
+    ) {
       this.#failOpen(frame);
       return;
     }
-    if (candidateLifecycle(event, candidate.id)) {
+    if (attachedCandidate) {
       if (
-        candidate.closed ||
+        attachedCandidate.closed ||
+        event.type === "response.output_item.added" ||
         !Number.isInteger(event.output_index) ||
-        event.output_index !== candidate.outputIndex ||
+        event.output_index !== attachedCandidate.outputIndex ||
         !exactEmptyCandidateEvent(event)
       ) {
         this.#failOpen(frame);
@@ -302,21 +435,40 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       const index = event.output_index;
       if (
         !id ||
-        candidateStart(event.item) ||
         !Number.isInteger(index) ||
         index < 0 ||
-        index <= candidate.outputIndex ||
-        candidate.itemIndexes.has(id) ||
-        candidate.indexItems.has(index)
+        index <= capture.firstOutputIndex ||
+        capture.itemIndexes.has(id) ||
+        capture.indexItems.has(index)
       ) {
         this.#failOpen(frame);
         return;
       }
-      candidate.itemIndexes.set(id, index);
-      candidate.indexItems.set(index, id);
-      if (isToolCall(event.item)) candidate.sawTool = true;
+      if (candidateStart(event.item)) {
+        const previous = capture.candidateOrder.at(-1);
+        if (!previous?.sawTool) {
+          this.#failOpen(frame);
+          return;
+        }
+        const candidate = { id, outputIndex: index, sawTool: false, closed: false };
+        capture.candidates.set(id, candidate);
+        capture.candidateOrder.push(candidate);
+      } else if (isToolCall(event.item)) {
+        if (!hasValidToolCallIdentity(event.item)) {
+          this.#failOpen(frame);
+          return;
+        }
+        capture.candidateOrder.at(-1).sawTool = true;
+        capture.toolItems.set(id, {
+          type: event.item.type,
+          name: event.item.name,
+          callId: event.item.call_id,
+        });
+      }
+      capture.itemIndexes.set(id, index);
+      capture.indexItems.set(index, id);
     } else if (attachedId) {
-      const expectedIndex = candidate.itemIndexes.get(attachedId);
+      const expectedIndex = capture.itemIndexes.get(attachedId);
       if (
         expectedIndex === undefined ||
         !Number.isInteger(event.output_index) ||
@@ -325,71 +477,101 @@ export class DeepseekToolMessageCompatTransform extends Transform {
         this.#failOpen(frame);
         return;
       }
-      if (isToolCall(event.item) && event.type !== "response.output_item.done") {
-        this.#failOpen(frame);
-        return;
+      if (isToolCall(event.item)) {
+        if (
+          event.type !== "response.output_item.done" ||
+          !matchesToolCallIdentity(
+            event.item,
+            capture.toolItems.get(attachedId),
+          )
+        ) {
+          this.#failOpen(frame);
+          return;
+        }
       }
     }
 
     this.#hold(frame);
-    if (!this.#candidate) return;
+    if (!this.#capture) return;
 
     if (
       event.type === "response.output_item.done" &&
-      attachedId === candidate.id
+      attachedCandidate
     ) {
-      candidate.closed = true;
+      attachedCandidate.closed = true;
       return;
     }
 
     if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
-      if (this.#terminalMatchesCandidate(event.response.output, candidate)) {
+      if (this.#terminalMatchesCapture(event.response.output, capture)) {
         this.#suppress();
       } else this.#failOpen();
     }
   }
 
   #hold(frame) {
-    if (!this.#candidate) return;
+    if (!this.#capture) return;
     const bytes = Buffer.byteLength(frame.original);
-    if (this.#candidate.bytes + bytes > this.#maxCandidateBytes) {
+    if (this.#capture.bytes + bytes > this.#maxCandidateBytes) {
       this.#failOpen(frame);
       return;
     }
-    this.#candidate.frames.push(frame);
-    this.#candidate.bytes += bytes;
+    this.#capture.frames.push(frame);
+    this.#capture.bytes += bytes;
   }
 
-  #terminalMatchesCandidate(output, candidate) {
-    if (!candidate.closed || !candidate.sawTool) return false;
-    if (candidate.outputIndex >= output.length) return false;
-    if (!exactEmptyMessage(output[candidate.outputIndex])) return false;
-    if (itemId(output[candidate.outputIndex]?.id) !== candidate.id) return false;
+  #terminalMatchesCapture(output, capture) {
+    const candidatesByIndex = new Map();
+    for (const candidate of capture.candidateOrder) {
+      if (!candidate.closed || !candidate.sawTool) return false;
+      if (candidate.outputIndex >= output.length) return false;
+      if (!exactCompletedEmptyMessage(output[candidate.outputIndex])) return false;
+      candidatesByIndex.set(candidate.outputIndex, candidate);
+    }
+    for (const [id, expected] of capture.toolItems) {
+      const item = output[capture.itemIndexes.get(id)];
+      if (!matchesToolCallIdentity(item, expected)) return false;
+    }
     const ids = new Set();
-    for (let index = candidate.outputIndex; index < output.length; index += 1) {
+    for (let index = 0; index < output.length; index += 1) {
       const id = itemId(output[index]?.id);
       if (!id || ids.has(id)) return false;
       ids.add(id);
-      if (candidate.itemIndexes.get(id) !== index) return false;
+      if (index < capture.firstOutputIndex) continue;
+      const mappedIndex = capture.itemIndexes.get(id);
+      if (candidatesByIndex.has(index)) {
+        // The pinned LiteLLM bridge uses a generated msg_* ID for streaming,
+        // but the originating chat-completion ID for this exact terminal
+        // empty item. Permit only that candidate slot to change identity; a
+        // collision with any other streamed item remains ambiguous.
+        if (mappedIndex !== undefined && mappedIndex !== index) return false;
+      } else if (mappedIndex !== index) return false;
     }
-    return ids.size === candidate.itemIndexes.size;
+    return output.length - capture.firstOutputIndex === capture.itemIndexes.size;
   }
 
   #suppress() {
-    const candidate = this.#candidate;
-    if (!candidate) return;
-    this.#candidate = undefined;
-    this.#suppressed = { id: candidate.id, outputIndex: candidate.outputIndex };
+    const capture = this.#capture;
+    if (!capture) return;
+    this.#capture = undefined;
+    const items = capture.candidateOrder
+      .map(({ id, outputIndex }) => ({ id, outputIndex }))
+      .sort((left, right) => left.outputIndex - right.outputIndex);
+    this.#suppressed = {
+      items,
+      streamIds: new Set(items.map(({ id }) => id)),
+      outputIndexes: new Set(items.map(({ outputIndex }) => outputIndex)),
+    };
     this.#clearTimer();
-    for (const frame of candidate.frames) this.#pushCompacted(frame);
+    for (const frame of capture.frames) this.#pushCompacted(frame);
   }
 
   #failOpen(extraFrame) {
-    const candidate = this.#candidate;
-    this.#candidate = undefined;
+    const capture = this.#capture;
+    this.#capture = undefined;
     this.#clearTimer();
-    if (candidate) {
-      for (const frame of candidate.frames) this.push(Buffer.from(frame.original));
+    if (capture) {
+      for (const frame of capture.frames) this.push(Buffer.from(frame.original));
     }
     if (extraFrame) this.push(Buffer.from(extraFrame.original));
     this.#disabled = true;
@@ -402,19 +584,23 @@ export class DeepseekToolMessageCompatTransform extends Transform {
       this.push(Buffer.from(frame.original));
       return;
     }
-    if (candidateLifecycle(event, suppressed.id)) return;
+    const attachedId = eventItemId(event);
+    if (
+      suppressed.streamIds.has(attachedId) &&
+      candidateLifecycle(event, attachedId)
+    ) return;
     let next = event;
     let changed = false;
-    if (
-      Number.isInteger(event.output_index) &&
-      event.output_index > suppressed.outputIndex
-    ) {
-      next = { ...next, output_index: event.output_index - 1 };
-      changed = true;
+    if (Number.isInteger(event.output_index)) {
+      const shift = suppressed.items.filter(
+        ({ outputIndex }) => outputIndex < event.output_index,
+      ).length;
+      if (shift > 0) next = { ...next, output_index: event.output_index - shift };
+      changed = shift > 0;
     }
     if (event.type === "response.completed" && Array.isArray(event.response?.output)) {
       const output = event.response.output.filter(
-        (item) => itemId(item?.id) !== suppressed.id,
+        (_item, index) => !suppressed.outputIndexes.has(index),
       );
       next = {
         ...next,
@@ -434,7 +620,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
 
   #oversizedFrame(original) {
     const frame = { original };
-    if (this.#candidate) this.#failOpen(frame);
+    if (this.#capture) this.#failOpen(frame);
     else {
       this.push(Buffer.from(original));
       this.#disabled = true;
@@ -448,7 +634,7 @@ export class DeepseekToolMessageCompatTransform extends Transform {
   }
 
   #startTimer() {
-    if (this.#timer || !this.#candidate) return;
+    if (this.#timer || !this.#capture) return;
     this.#timer = setTimeout(() => {
       this.#failOpen();
       this.#pushBuffered();
@@ -463,8 +649,135 @@ export class DeepseekToolMessageCompatTransform extends Transform {
   }
 }
 
+// Non-streaming translated responses can be normalized without inventing an
+// event lifecycle. Hold one bounded JSON body, change only exact empty message
+// items proven by a later function call, and release malformed, oversized, or
+// slow bodies byte-for-byte.
+export class TranslatedToolMessageJsonCompatTransform extends Transform {
+  #pending = [];
+  #pendingBytes = 0;
+  #released = false;
+  #maxBytes;
+  #maxMs;
+  #timer;
+
+  constructor({ maxBytes = MAX_JSON_BYTES, maxMs = MAX_JSON_MS } = {}) {
+    super();
+    this.#maxBytes = finiteLimit(maxBytes, MAX_JSON_BYTES, {
+      minimum: 1,
+      integer: true,
+    });
+    this.#maxMs = finiteLimit(maxMs, MAX_JSON_MS);
+  }
+
+  _transform(chunk, _encoding, callback) {
+    if (this.#released) {
+      this.push(chunk);
+      callback();
+      return;
+    }
+    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.#startTimer();
+    if (this.#pendingBytes + piece.length > this.#maxBytes) {
+      this.#clearTimer();
+      this.#releasePending();
+      this.push(piece);
+      this.#released = true;
+      callback();
+      return;
+    }
+    this.#pending.push(piece);
+    this.#pendingBytes += piece.length;
+    callback();
+  }
+
+  _flush(callback) {
+    this.#clearTimer();
+    const body = Buffer.concat(this.#pending, this.#pendingBytes);
+    this.#pending = [];
+    this.#pendingBytes = 0;
+    if (this.#released || !body.length) {
+      if (body.length) this.push(body);
+      callback();
+      return;
+    }
+    try {
+      const source = body.toString("utf8");
+      if (!Buffer.from(source).equals(body)) throw new Error("invalid utf-8");
+      const payload = JSON.parse(source);
+      const output = jsonResponseOutput(payload);
+      const indexes = removableJsonMessageIndexes(output);
+      if (!indexes.length) {
+        this.push(body);
+      } else {
+        const removed = new Set(indexes);
+        this.push(Buffer.from(JSON.stringify({
+          ...payload,
+          output: output.filter((_item, index) => !removed.has(index)),
+        })));
+      }
+    } catch {
+      this.push(body);
+    }
+    callback();
+  }
+
+  _destroy(error, callback) {
+    this.#clearTimer();
+    callback(error);
+  }
+
+  #startTimer() {
+    if (this.#timer || this.#released) return;
+    this.#timer = setTimeout(() => {
+      this.#timer = undefined;
+      this.#releasePending();
+      this.#released = true;
+    }, this.#maxMs);
+    this.#timer.unref?.();
+  }
+
+  #clearTimer() {
+    if (!this.#timer) return;
+    clearTimeout(this.#timer);
+    this.#timer = undefined;
+  }
+
+  #releasePending() {
+    for (const piece of this.#pending) this.push(piece);
+    this.#pending = [];
+    this.#pendingBytes = 0;
+  }
+}
+
+function translatedProtocol(provider) {
+  if (!provider || typeof provider !== "object") return false;
+  const protocol = provider.protocol ?? "openai";
+  return protocol === "openai" || protocol === "anthropic";
+}
+
+export function translatedToolMessageCompatTransform(provider, contentType = "") {
+  if (!translatedProtocol(provider)) return undefined;
+  const mediaType = String(contentType).split(";", 1)[0].trim().toLowerCase();
+  if (mediaType === "text/event-stream") {
+    return new TranslatedToolMessageCompatTransform();
+  }
+  if (mediaType === "application/json" || mediaType.endsWith("+json")) {
+    return new TranslatedToolMessageJsonCompatTransform();
+  }
+  return undefined;
+}
+
+// Preserve the previous provider-specific factory for internal consumers while
+// keeping its original SSE-only behavior.
 export function deepseekToolMessageCompatTransform(providerId, contentType = "") {
   if (String(providerId) !== "deepseek") return undefined;
-  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
-  return new DeepseekToolMessageCompatTransform();
+  return String(contentType).toLowerCase().includes("text/event-stream")
+    ? new TranslatedToolMessageCompatTransform()
+    : undefined;
 }
+
+// Kept as an internal compatibility alias for code that imported the original
+// provider-specific class directly before the transform became protocol-scoped.
+export const DeepseekToolMessageCompatTransform =
+  TranslatedToolMessageCompatTransform;

--- a/src/json-number-rewrite.mjs
+++ b/src/json-number-rewrite.mjs
@@ -1,0 +1,56 @@
+const MAX_EXACT_JSON_NUMBER_LENGTH = 4096;
+const JSON_NUMBER_PARTS =
+  /^(-?)(0|[1-9]\d*)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/;
+
+// Normalize a bounded JSON number as an exact decimal coefficient + power.
+// This compares mathematical decimal values rather than spellings, so 1.0 and
+// 1e3 can survive a rewrite when JSON.stringify emits 1 and 1000 respectively,
+// while underflow and rounded high-precision tokens cannot.
+function canonicalDecimalToken(token) {
+  if (typeof token !== "string" || token.length > MAX_EXACT_JSON_NUMBER_LENGTH) {
+    return undefined;
+  }
+  const match = JSON_NUMBER_PARTS.exec(token);
+  if (!match) return undefined;
+  const [, sign, integer, fraction = "", exponentText = "0"] = match;
+  let digits = integer + fraction;
+  if (/^0+$/u.test(digits)) return sign === "-" ? "-0" : "0";
+
+  const exponentSign = exponentText.startsWith("-") ? -1 : 1;
+  const unsignedExponent = exponentText.replace(/^[+-]/u, "");
+  const significantExponent = unsignedExponent.replace(/^0+/u, "") || "0";
+  // A non-zero finite Number cannot retain an exponent remotely this large;
+  // bounding it also prevents attacker-controlled giant integer arithmetic.
+  if (significantExponent.length > 6) return undefined;
+  let exponent = exponentSign * Number(significantExponent) - fraction.length;
+
+  digits = digits.replace(/^0+/u, "");
+  const trailingZeros = /0+$/u.exec(digits)?.[0].length || 0;
+  if (trailingZeros) {
+    digits = digits.slice(0, -trailingZeros);
+    exponent += trailingZeros;
+  }
+  return `${sign}${digits}e${exponent}`;
+}
+
+// Permission to JSON.parse and later JSON.stringify a numeric token without
+// changing its exact mathematical decimal value. JavaScript's Number parser
+// can otherwise underflow or round a token while still returning a finite
+// value, which would silently mutate unrelated response fields during a
+// compatibility rewrite.
+export function jsonNumberIsStableForRewrite(token) {
+  if (typeof token !== "string" || token.length > MAX_EXACT_JSON_NUMBER_LENGTH) {
+    return false;
+  }
+  const parsed = Number(token);
+  if (
+    !Number.isFinite(parsed) ||
+    Object.is(parsed, -0) ||
+    (Number.isInteger(parsed) && !Number.isSafeInteger(parsed))
+  ) {
+    return false;
+  }
+  const original = canonicalDecimalToken(token);
+  const serialized = canonicalDecimalToken(JSON.stringify(parsed));
+  return original !== undefined && original === serialized;
+}

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { Transform } from "node:stream";
 import { isDeepStrictEqual } from "node:util";
 
+import { jsonNumberIsStableForRewrite } from "./json-number-rewrite.mjs";
 import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 import { coerceFunctionCallArguments } from "./tool-arguments.mjs";
 import {
@@ -512,15 +513,12 @@ const TRACKED_STATE_FIXED_BYTES = 512;
 // raw bytes before a commit and terminates the stream after one.
 const MAX_SSE_FRAME_BYTES = 256 * 1024;
 const MAX_COMMITTED_SSE_FRAME_BYTES = MAX_JSON_CAPTURE_BYTES;
-const MAX_EXACT_JSON_NUMBER_LENGTH = 4096;
 const LINE_FEED = 0x0a;
 const CARRIAGE_RETURN = 0x0d;
 const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
 const SSE_EVENT_FIELD = Buffer.from("event", "ascii");
 const SSE_DATA_FIELD = Buffer.from("data", "ascii");
 const JSON_NUMBER_AT_OFFSET = /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
-const JSON_NUMBER_PARTS =
-  /^(-?)(0|[1-9]\d*)(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/;
 
 function sseFieldValue(line, prefixLength) {
   const value = line.slice(prefixLength);
@@ -630,52 +628,6 @@ function trackedStateBytes(state) {
     if (typeof state[field] === "string") bytes += Buffer.byteLength(state[field], "utf8");
   }
   return bytes;
-}
-
-// Normalize a bounded JSON number as exact decimal coefficient + power. This
-// compares mathematical decimal values rather than spellings, so 1.0 and 1e3
-// can survive a rewrite when JSON.stringify emits 1 and 1000 respectively,
-// while underflow and rounded high-precision tokens cannot.
-function canonicalDecimalToken(token) {
-  if (typeof token !== "string" || token.length > MAX_EXACT_JSON_NUMBER_LENGTH) {
-    return undefined;
-  }
-  const match = JSON_NUMBER_PARTS.exec(token);
-  if (!match) return undefined;
-  const [, sign, integer, fraction = "", exponentText = "0"] = match;
-  let digits = integer + fraction;
-  if (/^0+$/u.test(digits)) return sign === "-" ? "-0" : "0";
-
-  const exponentSign = exponentText.startsWith("-") ? -1 : 1;
-  const unsignedExponent = exponentText.replace(/^[+-]/u, "");
-  const significantExponent = unsignedExponent.replace(/^0+/u, "") || "0";
-  // A non-zero finite Number cannot retain an exponent remotely this large;
-  // bounding it also prevents attacker-controlled giant integer arithmetic.
-  if (significantExponent.length > 6) return undefined;
-  let exponent = exponentSign * Number(significantExponent) - fraction.length;
-
-  digits = digits.replace(/^0+/u, "");
-  const trailingZeros = /0+$/u.exec(digits)?.[0].length || 0;
-  if (trailingZeros) {
-    digits = digits.slice(0, -trailingZeros);
-    exponent += trailingZeros;
-  }
-  return `${sign}${digits}e${exponent}`;
-}
-
-function jsonNumberIsStableForRewrite(token) {
-  if (token.length > MAX_EXACT_JSON_NUMBER_LENGTH) return false;
-  const parsed = Number(token);
-  if (
-    !Number.isFinite(parsed) ||
-    Object.is(parsed, -0) ||
-    (Number.isInteger(parsed) && !Number.isSafeInteger(parsed))
-  ) {
-    return false;
-  }
-  const original = canonicalDecimalToken(token);
-  const serialized = canonicalDecimalToken(JSON.stringify(parsed));
-  return original !== undefined && original === serialized;
 }
 
 // JSON.parse deliberately accepts duplicate object members and keeps the last

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -55,7 +55,7 @@ import {
   ZaiResponsesCompatTransform,
   zaiResponsesCompatTransform,
 } from "./zai-responses-compat.mjs";
-import { deepseekToolMessageCompatTransform } from "./deepseek-tool-message-compat.mjs";
+import { translatedToolMessageCompatTransform } from "./deepseek-tool-message-compat.mjs";
 import { exactRouteProbeRequested } from "./exact-route-probe.mjs";
 import {
   MERGED_CATALOG_PATH,
@@ -3541,10 +3541,13 @@ async function handleResponses(request, response, requestUrl) {
         envelopeCompat = new ZaiResponsesCompatTransform();
       }
       if (envelopeCompat) transforms.push(envelopeCompat);
-      const deepseekToolMessageCompat = route
-        ? deepseekToolMessageCompatTransform(route.provider, contentType)
+      // LiteLLM can add blank assistant envelopes while translating either
+      // Chat Completions or Messages. The factory refuses native traffic and
+      // providers that already speak Responses, so those paths gain no stage.
+      const translatedToolMessageCompat = route
+        ? translatedToolMessageCompatTransform(providerForModel(route), contentType)
         : undefined;
-      if (deepseekToolMessageCompat) transforms.push(deepseekToolMessageCompat);
+      if (translatedToolMessageCompat) transforms.push(translatedToolMessageCompat);
       // Restore flattened namespace calls for routed chat-completions providers,
       // and inject missing finished-child interrupts for both routed and native
       // multi-agent parents (San Francisco uses native GPT).

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -40,6 +40,23 @@ async function transformed(input, options = {}, chunkSize = 0) {
   return output;
 }
 
+async function transformedBytes(input, options = {}, chunkSize = 0) {
+  const stream = new TranslatedToolMessageCompatTransform(options);
+  const output = [];
+  stream.on("data", (chunk) => { output.push(Buffer.from(chunk)); });
+  const bytes = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  if (chunkSize > 0) {
+    for (let at = 0; at < bytes.length; at += chunkSize) {
+      stream.write(bytes.subarray(at, at + chunkSize));
+    }
+  } else {
+    stream.write(bytes);
+  }
+  stream.end();
+  await once(stream, "end");
+  return Buffer.concat(output);
+}
+
 async function transformedJson(input, options = {}, chunkSize = 0) {
   const stream = new TranslatedToolMessageJsonCompatTransform(options);
   let output = "";
@@ -75,11 +92,66 @@ const functionCall = {
   status: "completed",
 };
 
+function responseCreated(
+  id = "resp_1",
+  { newline = "\n", sequenceNumber, response = {} } = {},
+) {
+  const event = {
+    type: "response.created",
+    response: {
+      id,
+      object: "response",
+      status: "in_progress",
+      error: null,
+      output: [],
+      ...response,
+    },
+  };
+  if (sequenceNumber !== undefined) event.sequence_number = sequenceNumber;
+  return block(event, newline);
+}
+
+function responseCompleted(
+  output,
+  {
+    id = "resp_1",
+    newline = "\n",
+    sequenceNumber,
+    response = {},
+  } = {},
+) {
+  const event = {
+    type: "response.completed",
+    response: {
+      id,
+      object: "response",
+      status: "completed",
+      error: null,
+      output,
+      ...response,
+    },
+  };
+  if (sequenceNumber !== undefined) event.sequence_number = sequenceNumber;
+  return block(event, newline);
+}
+
+function jsonResponse(output, overrides = {}) {
+  return {
+    id: "resp_json",
+    object: "response",
+    status: "completed",
+    error: null,
+    output,
+    ...overrides,
+  };
+}
+
 function phantomToolStream(
   newline = "\n",
   { terminalBlank = blankMessage, terminalReasoning = "" } = {},
 ) {
   return [
+    responseCreated("resp_1", { newline, sequenceNumber: 0 }),
     block({
       type: "response.output_item.added",
       output_index: 0,
@@ -135,11 +207,11 @@ function phantomToolStream(
       sequence_number: 8,
       item: blankMessage,
     }, newline),
-    block({
-      type: "response.completed",
-      sequence_number: 9,
-      response: { id: "resp_1", status: "completed", output: [terminalBlank, functionCall] },
-    }, newline),
+    responseCompleted([terminalBlank, functionCall], {
+      id: "resp_1",
+      newline,
+      sequenceNumber: 9,
+    }),
     `data: [DONE]${newline}${newline}`,
   ].join("");
 }
@@ -203,6 +275,27 @@ test("preserves real reasoning and ambiguous terminal identity byte-for-byte", a
   assert.equal(await transformed(visibleTerminal), visibleTerminal);
 });
 
+test("accepts only the pinned empty reasoning_text bridge terminator", async () => {
+  const exact = block({
+    type: "response.content_part.done",
+    item_id: blankMessage.id,
+    output_index: 0,
+    content_index: 0,
+    sequence_number: 7,
+    part: { type: "reasoning_text", reasoning: "" },
+  });
+  const widened = block({
+    type: "response.content_part.done",
+    item_id: blankMessage.id,
+    output_index: 0,
+    content_index: 0,
+    sequence_number: 7,
+    part: { type: "reasoning_text", reasoning: "", unexpected: true },
+  });
+  const input = phantomToolStream().replace(exact, widened);
+  assert.equal(await transformed(input), input);
+});
+
 function eventItem(event) {
   return event.item_id ?? event.item?.id;
 }
@@ -218,24 +311,38 @@ test("preserves CRLF framing while compacting the stream", async () => {
 
 test("fails open when the candidate later contains visible text", async () => {
   const input = [
+    responseCreated(),
     block({
       type: "response.output_item.added",
       output_index: 0,
       item: { ...blankMessage, status: "in_progress", content: [] },
     }),
     block({
+      type: "response.content_part.added",
+      output_index: 0,
+      item_id: blankMessage.id,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }),
+    block({
       type: "response.output_text.delta",
       output_index: 0,
       item_id: blankMessage.id,
+      content_index: 0,
       delta: "I will inspect it.",
     }),
-    block({ type: "response.output_item.added", output_index: 1, item: functionCall }),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { ...functionCall, status: "in_progress", arguments: "" },
+    }),
   ].join("");
   assert.equal(await transformed(input), input);
 });
 
 test("leaves a blank response without a tool call byte-identical", async () => {
   const input = [
+    responseCreated(),
     block({
       type: "response.output_item.added",
       output_index: 0,
@@ -247,28 +354,53 @@ test("leaves a blank response without a tool call byte-identical", async () => {
 });
 
 test("compacts separate reasoning and multiple later output items consistently", async () => {
-  const reasoning = { id: "rs_1", type: "reasoning", summary: [] };
+  const reasoning = {
+    id: "rs_1",
+    type: "reasoning",
+    status: "completed",
+    summary: [],
+  };
   const secondTool = { ...functionCall, id: "call_two", call_id: "call_two" };
   const input = [
+    responseCreated("resp_reasoning"),
     block({
       type: "response.output_item.added",
       output_index: 0,
       item: { ...blankMessage, status: "in_progress", content: [] },
     }),
-    block({ type: "response.output_item.added", output_index: 1, item: reasoning }),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { ...reasoning, status: "in_progress" },
+    }),
     block({ type: "response.output_item.done", output_index: 1, item: reasoning }),
-    block({ type: "response.output_item.added", output_index: 2, item: functionCall }),
+    block({
+      type: "response.output_item.added",
+      output_index: 2,
+      item: { ...functionCall, status: "in_progress", arguments: "" },
+    }),
     block({
       type: "response.function_call_arguments.done",
       output_index: 2,
       item_id: functionCall.id,
       arguments: "{}",
     }),
-    block({ type: "response.output_item.added", output_index: 3, item: secondTool }),
-    block({ type: "response.output_item.done", output_index: 0, item: blankMessage }),
+    block({ type: "response.output_item.done", output_index: 2, item: functionCall }),
     block({
-      type: "response.completed",
-      response: { output: [blankMessage, reasoning, functionCall, secondTool] },
+      type: "response.output_item.added",
+      output_index: 3,
+      item: { ...secondTool, status: "in_progress", arguments: "" },
+    }),
+    block({
+      type: "response.function_call_arguments.done",
+      output_index: 3,
+      item_id: secondTool.id,
+      arguments: "{}",
+    }),
+    block({ type: "response.output_item.done", output_index: 3, item: secondTool }),
+    block({ type: "response.output_item.done", output_index: 0, item: blankMessage }),
+    responseCompleted([blankMessage, reasoning, functionCall, secondTool], {
+      id: "resp_reasoning",
     }),
   ].join("");
   const seen = events(await transformed(input));
@@ -292,8 +424,14 @@ test("removes multiple independently confirmed bridge messages in one stream", a
   const secondBlank = { ...blankMessage, id: "msg_blank_two" };
   const firstTool = { ...functionCall, id: "call_one", call_id: "call_one" };
   const secondTool = { ...functionCall, id: "call_two", call_id: "call_two" };
-  const reasoning = { id: "rs_between", type: "reasoning", summary: [] };
+  const reasoning = {
+    id: "rs_between",
+    type: "reasoning",
+    status: "completed",
+    summary: [],
+  };
   const source = [
+    responseCreated("resp_multiple", { sequenceNumber: 0 }),
     block({
       type: "response.output_item.added",
       output_index: 0,
@@ -335,7 +473,7 @@ test("removes multiple independently confirmed bridge messages in one stream", a
       type: "response.output_item.added",
       output_index: 3,
       sequence_number: 7,
-      item: reasoning,
+      item: { ...reasoning, status: "in_progress" },
     }),
     block({
       type: "response.output_item.done",
@@ -368,14 +506,10 @@ test("removes multiple independently confirmed bridge messages in one stream", a
       sequence_number: 12,
       item: secondBlank,
     }),
-    block({
-      type: "response.completed",
-      sequence_number: 13,
-      response: {
-        id: "resp_multiple",
-        output: [firstBlank, firstTool, secondBlank, reasoning, secondTool],
-      },
-    }),
+    responseCompleted(
+      [firstBlank, firstTool, secondBlank, reasoning, secondTool],
+      { id: "resp_multiple", sequenceNumber: 13 },
+    ),
   ].join("");
 
   const seen = events(await transformed(source, {}, 5));
@@ -387,7 +521,7 @@ test("removes multiple independently confirmed bridge messages in one stream", a
   );
   assert.deepEqual(
     seen.map((event) => event.sequence_number),
-    [2, 3, 4, 7, 8, 9, 10, 11, 13],
+    [0, 2, 3, 4, 7, 8, 9, 10, 11, 13],
   );
   assert.deepEqual(
     seen.find((event) => event.type === "response.completed").response.output,
@@ -404,58 +538,64 @@ test("byte budget expiry releases the entire stream unchanged", async () => {
 });
 
 test("timer expiry releases pending bytes and subsequent chunks immediately", async () => {
+  const created = responseCreated();
   const start = block({
     type: "response.output_item.added",
     output_index: 0,
     item: { ...blankMessage, status: "in_progress", content: [] },
   });
-  const tail = block({ type: "response.output_item.added", output_index: 1, item: functionCall });
+  const tail = block({
+    type: "response.output_item.added",
+    output_index: 1,
+    item: { ...functionCall, status: "in_progress", arguments: "" },
+  });
   const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 5 });
   let output = "";
   stream.setEncoding("utf8");
   stream.on("data", (chunk) => { output += chunk; });
-  stream.write(start);
+  stream.write(created + start);
   await new Promise((resolve) => setTimeout(resolve, 20));
-  assert.equal(output, start);
+  assert.equal(output, created + start);
   stream.write(tail);
-  assert.equal(output, start + tail);
+  assert.equal(output, created + start + tail);
   stream.end();
   await once(stream, "end");
 });
 
 test("malformed and duplicate candidate lifecycles fail open", async () => {
+  const created = responseCreated();
   const start = block({
     type: "response.output_item.added",
     output_index: 0,
     item: { ...blankMessage, status: "in_progress", content: [] },
   });
   const malformed = "event: response.output_item.added\ndata: {not-json}\n\n";
-  assert.equal(await transformed(start + malformed), start + malformed);
+  assert.equal(await transformed(created + start + malformed), created + start + malformed);
 
   const duplicate = block({
     type: "response.output_item.added",
     output_index: 0,
     item: { ...blankMessage, status: "in_progress", content: [] },
   });
-  assert.equal(await transformed(start + duplicate), start + duplicate);
+  assert.equal(await transformed(created + start + duplicate), created + start + duplicate);
 
   const second = block({
     type: "response.output_item.added",
     output_index: 1,
     item: { ...blankMessage, id: "msg_two", status: "in_progress", content: [] },
   });
-  assert.equal(await transformed(start + second), start + second);
+  assert.equal(await transformed(created + start + second), created + start + second);
 });
 
 test("conflicting item references and non-assistant messages fail open", async () => {
+  const created = responseCreated();
   const conflicting = block({
     type: "response.output_item.added",
     item_id: "msg_other",
     output_index: 0,
     item: { ...blankMessage, status: "in_progress", content: [] },
   });
-  const tail = phantomToolStream().slice(phantomToolStream().indexOf("\n\n") + 2);
-  assert.equal(await transformed(conflicting + tail), conflicting + tail);
+  assert.equal(await transformed(created + conflicting), created + conflicting);
 
   const nonAssistant = block({
     type: "response.output_item.added",
@@ -467,10 +607,11 @@ test("conflicting item references and non-assistant messages fail open", async (
       content: [],
     },
   });
-  assert.equal(await transformed(nonAssistant + tail), nonAssistant + tail);
+  assert.equal(await transformed(created + nonAssistant), created + nonAssistant);
 });
 
 test("refusal and unknown message parts are never classified as empty", async () => {
+  const created = responseCreated();
   const start = block({
     type: "response.output_item.added",
     output_index: 0,
@@ -479,7 +620,7 @@ test("refusal and unknown message parts are never classified as empty", async ()
   const tool = block({
     type: "response.output_item.added",
     output_index: 1,
-    item: { ...functionCall, status: "in_progress" },
+    item: { ...functionCall, status: "in_progress", arguments: "" },
   });
   for (const part of [
     { type: "refusal", refusal: "cannot comply" },
@@ -490,7 +631,10 @@ test("refusal and unknown message parts are never classified as empty", async ()
       output_index: 0,
       item: { ...blankMessage, content: [part] },
     });
-    assert.equal(await transformed(start + tool + close), start + tool + close);
+    assert.equal(
+      await transformed(created + start + tool + close),
+      created + start + tool + close,
+    );
   }
   const refusal = block({
     type: "response.refusal.delta",
@@ -498,39 +642,49 @@ test("refusal and unknown message parts are never classified as empty", async ()
     item_id: blankMessage.id,
     delta: "cannot comply",
   });
-  assert.equal(await transformed(start + tool + refusal), start + tool + refusal);
+  assert.equal(
+    await transformed(created + start + tool + refusal),
+    created + start + tool + refusal,
+  );
 });
 
 test("mismatched, duplicate, missing, and negative indexes fail open", async () => {
+  const created = responseCreated();
   const start = block({
     type: "response.output_item.added",
     output_index: 0,
     item: { ...blankMessage, status: "in_progress", content: [] },
   });
-  const toolAtTwo = block({
+  const toolAtOne = block({
     type: "response.output_item.added",
-    output_index: 2,
-    item: { ...functionCall, status: "in_progress" },
+    output_index: 1,
+    item: { ...functionCall, status: "in_progress", arguments: "" },
   });
   const wrongDelta = block({
     type: "response.function_call_arguments.delta",
-    output_index: 1,
+    output_index: 0,
     item_id: functionCall.id,
     delta: "{}",
   });
   assert.equal(
-    await transformed(start + toolAtTwo + wrongDelta),
-    start + toolAtTwo + wrongDelta,
+    await transformed(created + start + toolAtOne + wrongDelta),
+    created + start + toolAtOne + wrongDelta,
   );
 
   const duplicateIndex = block({
     type: "response.output_item.added",
-    output_index: 2,
-    item: { ...functionCall, id: "call_duplicate" },
+    output_index: 1,
+    item: {
+      ...functionCall,
+      id: "call_duplicate",
+      call_id: "call_duplicate",
+      status: "in_progress",
+      arguments: "",
+    },
   });
   assert.equal(
-    await transformed(start + toolAtTwo + duplicateIndex),
-    start + toolAtTwo + duplicateIndex,
+    await transformed(created + start + toolAtOne + duplicateIndex),
+    created + start + toolAtOne + duplicateIndex,
   );
 
   const missingIndex = block({
@@ -539,8 +693,8 @@ test("mismatched, duplicate, missing, and negative indexes fail open", async () 
     arguments: "{}",
   });
   assert.equal(
-    await transformed(start + toolAtTwo + missingIndex),
-    start + toolAtTwo + missingIndex,
+    await transformed(created + start + toolAtOne + missingIndex),
+    created + start + toolAtOne + missingIndex,
   );
 
   const negative = block({
@@ -548,10 +702,14 @@ test("mismatched, duplicate, missing, and negative indexes fail open", async () 
     output_index: -1,
     item: { ...blankMessage, status: "in_progress", content: [] },
   });
-  assert.equal(await transformed(negative + toolAtTwo), negative + toolAtTwo);
+  assert.equal(
+    await transformed(created + negative + toolAtOne),
+    created + negative + toolAtOne,
+  );
 });
 
 test("tool proof requires a valid added lifecycle and matching terminal order", async () => {
+  const created = responseCreated();
   const start = block({
     type: "response.output_item.added",
     output_index: 0,
@@ -568,32 +726,29 @@ test("tool proof requires a valid added lifecycle and matching terminal order", 
     item: functionCall,
   });
   assert.equal(
-    await transformed(start + toolDoneOnly + blankDone),
-    start + toolDoneOnly + blankDone,
+    await transformed(created + start + toolDoneOnly + blankDone),
+    created + start + toolDoneOnly + blankDone,
   );
 
-  const terminalOnly = block({
-    type: "response.completed",
-    response: { output: [blankMessage, functionCall] },
-  });
+  const terminalOnly = responseCompleted([blankMessage, functionCall]);
   assert.equal(
-    await transformed(start + blankDone + terminalOnly),
-    start + blankDone + terminalOnly,
+    await transformed(created + start + blankDone + terminalOnly),
+    created + start + blankDone + terminalOnly,
   );
 
   const toolAdded = block({
     type: "response.output_item.added",
     output_index: 1,
-    item: { ...functionCall, status: "in_progress" },
+    item: { ...functionCall, status: "in_progress", arguments: "" },
   });
   const malformedTool = block({
     type: "response.output_item.added",
     output_index: 1,
-    item: { ...functionCall, name: "", status: "in_progress" },
+    item: { ...functionCall, name: "", status: "in_progress", arguments: "" },
   });
   assert.equal(
-    await transformed(start + malformedTool + blankDone),
-    start + malformedTool + blankDone,
+    await transformed(created + start + malformedTool + blankDone),
+    created + start + malformedTool + blankDone,
   );
 
   const changedToolDone = block({
@@ -602,45 +757,51 @@ test("tool proof requires a valid added lifecycle and matching terminal order", 
     item: { ...functionCall, name: "different_tool" },
   });
   assert.equal(
-    await transformed(start + toolAdded + changedToolDone + blankDone),
-    start + toolAdded + changedToolDone + blankDone,
+    await transformed(created + start + toolAdded + changedToolDone + blankDone),
+    created + start + toolAdded + changedToolDone + blankDone,
   );
 
-  const wrongOrder = block({
-    type: "response.completed",
-    response: { output: [functionCall, blankMessage] },
+  const validToolDone = block({
+    type: "response.output_item.done",
+    output_index: 1,
+    item: functionCall,
   });
+
+  const wrongOrder = responseCompleted([functionCall, blankMessage]);
   assert.equal(
-    await transformed(start + toolAdded + blankDone + wrongOrder),
-    start + toolAdded + blankDone + wrongOrder,
+    await transformed(created + start + toolAdded + validToolDone + blankDone + wrongOrder),
+    created + start + toolAdded + validToolDone + blankDone + wrongOrder,
   );
 
-  const changedTool = block({
-    type: "response.completed",
-    response: {
-      output: [blankMessage, { ...functionCall, name: "different_tool" }],
-    },
-  });
+  const changedTool = responseCompleted([
+    blankMessage,
+    { ...functionCall, name: "different_tool" },
+  ]);
   assert.equal(
-    await transformed(start + toolAdded + blankDone + changedTool),
-    start + toolAdded + blankDone + changedTool,
+    await transformed(created + start + toolAdded + validToolDone + blankDone + changedTool),
+    created + start + toolAdded + validToolDone + blankDone + changedTool,
   );
 });
 
 test("an oversized unterminated frame fails open without retaining the body", async () => {
+  const created = responseCreated();
   const start = block({
     type: "response.output_item.added",
     output_index: 0,
     item: { ...blankMessage, status: "in_progress", content: [] },
   });
-  const tail = `data: ${"x".repeat(256)}`;
+  const tail = `data: ${"x".repeat(1_024)}`;
   assert.equal(
-    await transformed(start + tail, { maxFrameBytes: 64, maxCandidateMs: 60_000 }),
-    start + tail,
+    await transformed(created + start + tail, {
+      maxFrameBytes: 512,
+      maxCandidateMs: 60_000,
+    }),
+    created + start + tail,
   );
 });
 
 test("delimiter-terminated frames and single-frame cap crossings are bounded", async () => {
+  const created = responseCreated();
   const start = block({
     type: "response.output_item.added",
     output_index: 0,
@@ -653,25 +814,29 @@ test("delimiter-terminated frames and single-frame cap crossings are bounded", a
     delta: "x".repeat(2_000),
   });
   assert.equal(
-    await transformed(start + huge, { maxFrameBytes: 512, maxCandidateMs: 60_000 }),
-    start + huge,
+    await transformed(created + start + huge, {
+      maxFrameBytes: 512,
+      maxCandidateMs: 60_000,
+    }),
+    created + start + huge,
   );
 
   const tool = block({
     type: "response.output_item.added",
     output_index: 1,
-    item: { ...functionCall, status: "in_progress" },
+    item: { ...functionCall, status: "in_progress", arguments: "" },
   });
   assert.equal(
-    await transformed(start + tool, {
+    await transformed(created + start + tool, {
       maxCandidateBytes: Buffer.byteLength(start) + 1,
       maxCandidateMs: 60_000,
     }),
-    start + tool,
+    created + start + tool,
   );
 });
 
 test("timer expiry also releases an incomplete buffered frame", async () => {
+  const created = responseCreated();
   const start = block({
     type: "response.output_item.added",
     output_index: 0,
@@ -682,14 +847,15 @@ test("timer expiry also releases an incomplete buffered frame", async () => {
   let output = "";
   stream.setEncoding("utf8");
   stream.on("data", (chunk) => { output += chunk; });
-  stream.write(start + partial);
+  stream.write(created + start + partial);
   await new Promise((resolve) => setTimeout(resolve, 20));
-  assert.equal(output, start + partial);
+  assert.equal(output, created + start + partial);
   stream.end();
   await once(stream, "end");
 });
 
 test("destroying a pending stream clears its hold without later output", async () => {
+  const created = responseCreated();
   const start = block({
     type: "response.output_item.added",
     output_index: 0,
@@ -698,17 +864,565 @@ test("destroying a pending stream clears its hold without later output", async (
   const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 5 });
   let output = "";
   stream.on("data", (chunk) => { output += chunk.toString("utf8"); });
-  stream.write(start);
+  stream.write(created + start);
   stream.destroy();
   await once(stream, "close");
   await new Promise((resolve) => setTimeout(resolve, 20));
-  assert.equal(output, "");
+  assert.equal(output, created);
 });
 
 test("post-suppression frames without shifted indexes remain byte-identical", async () => {
   const untouched = "event: response.done\ndata:  {\"type\":\"response.done\",\"response\":{\"id\":\"r1\"}}\n\n";
   const output = await transformed(phantomToolStream().replace("data: [DONE]\n\n", untouched));
   assert.ok(output.endsWith(untouched));
+});
+
+test("binds the response id and requires an exact successful terminal envelope", async () => {
+  const source = phantomToolStream();
+  const validCreated = responseCreated("resp_1", { sequenceNumber: 0 });
+  const validCompleted = responseCompleted([blankMessage, functionCall], {
+    sequenceNumber: 9,
+  });
+  const invalidCreated = [
+    responseCreated("resp_1", {
+      sequenceNumber: 0,
+      response: { object: undefined },
+    }),
+    responseCreated("resp_1", {
+      sequenceNumber: 0,
+      response: { status: "completed" },
+    }),
+    responseCreated("", { sequenceNumber: 0 }),
+    responseCreated("resp_1", {
+      sequenceNumber: 0,
+      response: { output: [blankMessage] },
+    }),
+  ];
+  for (const created of invalidCreated) {
+    const input = source.replace(validCreated, created);
+    assert.equal(await transformed(input), input);
+  }
+
+  const invalidCompleted = [
+    responseCompleted([blankMessage, functionCall], {
+      id: "resp_other",
+      sequenceNumber: 9,
+    }),
+    responseCompleted([blankMessage, functionCall], {
+      sequenceNumber: 9,
+      response: { object: undefined },
+    }),
+    responseCompleted([blankMessage, functionCall], {
+      sequenceNumber: 9,
+      response: { status: "incomplete" },
+    }),
+    responseCompleted([blankMessage, functionCall], {
+      sequenceNumber: 9,
+      response: { error: { message: "upstream failed" } },
+    }),
+    responseCompleted(
+      [{ ...blankMessage, id: "resp_1" }, functionCall],
+      { sequenceNumber: 9 },
+    ),
+    block({
+      type: "response.completed",
+      sequence_number: 9,
+      unexpected: true,
+      response: {
+        id: "resp_1",
+        object: "response",
+        status: "completed",
+        error: null,
+        output: [blankMessage, functionCall],
+      },
+    }),
+  ];
+  for (const completed of invalidCompleted) {
+    const input = source.replace(validCompleted, completed);
+    assert.equal(await transformed(input), input);
+  }
+});
+
+test("unknown item, event, and SSE frame fields disable compaction byte-for-byte", async () => {
+  const created = responseCreated();
+  const candidate = {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  };
+  const reasoning = {
+    id: "rs_strict",
+    type: "reasoning",
+    status: "in_progress",
+    summary: [],
+  };
+  const custom = {
+    id: "custom_strict",
+    type: "custom_tool_call",
+    status: "in_progress",
+    call_id: "custom_strict",
+    name: "shell",
+    input: "",
+  };
+  const cases = [
+    block({ ...candidate, unexpected: true }),
+    block({ ...candidate, item: { ...candidate.item, unexpected: true } }),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { ...reasoning, unexpected: true },
+    }),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      item: {
+        ...reasoning,
+        summary: [{ type: "opaque_reasoning", text: "visible" }],
+      },
+    }),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      item: {
+        ...reasoning,
+        content: [{ type: "reasoning_text", reasoning: "ambiguous" }],
+      },
+    }),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      item: {
+        ...functionCall,
+        status: "in_progress",
+        arguments: "",
+        unexpected: true,
+      },
+    }),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { ...custom, unexpected: true },
+    }),
+    [
+      block({
+        type: "response.output_item.added",
+        output_index: 1,
+        item: { ...functionCall, status: "in_progress", arguments: "" },
+      }),
+      block({
+        type: "response.function_call_arguments.delta",
+        output_index: 1,
+        item_id: functionCall.id,
+        delta: "{}",
+        unexpected: true,
+      }),
+    ].join(""),
+    [
+      block({
+        type: "response.output_item.added",
+        output_index: 1,
+        item: custom,
+      }),
+      block({
+        type: "response.custom_tool_call_input.delta",
+        output_index: 1,
+        item_id: custom.id,
+        delta: "echo",
+        unexpected: true,
+      }),
+    ].join(""),
+    [
+      block({
+        type: "response.output_item.added",
+        output_index: 1,
+        item: reasoning,
+      }),
+      block({
+        type: "response.reasoning_summary_part.added",
+        output_index: 1,
+        item_id: reasoning.id,
+        summary_index: 0,
+        part: { type: "summary_text", text: "" },
+        unexpected: true,
+      }),
+    ].join(""),
+    block({
+      type: "response.unknown.delta",
+      output_index: 0,
+      item_id: blankMessage.id,
+      delta: "opaque",
+    }),
+    `id: opaque\n${block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: blankMessage,
+    })}`,
+  ];
+  for (const tail of cases) {
+    const input = created + block(candidate) + tail;
+    assert.equal(await transformed(input), input);
+  }
+});
+
+test("ambiguous response, message, and tool lifecycle transitions fail open", async () => {
+  const inProgress = block({
+    type: "response.in_progress",
+    response: {
+      id: "resp_1",
+      object: "response",
+      status: "in_progress",
+      error: null,
+      output: [],
+    },
+  });
+  const duplicateProgress = responseCreated() + inProgress + inProgress;
+  assert.equal(await transformed(duplicateProgress), duplicateProgress);
+
+  const source = phantomToolStream();
+  const toolDone = block({
+    type: "response.output_item.done",
+    output_index: 1,
+    sequence_number: 5,
+    item: functionCall,
+  });
+  const mismatchedToolDone = block({
+    type: "response.output_item.done",
+    output_index: 1,
+    sequence_number: 5,
+    item: { ...functionCall, arguments: "[]" },
+  });
+  const mismatchedTool = source.replace(toolDone, mismatchedToolDone);
+  assert.equal(await transformed(mismatchedTool), mismatchedTool);
+
+  const candidateDone = block({
+    type: "response.output_item.done",
+    output_index: 0,
+    sequence_number: 8,
+    item: blankMessage,
+  });
+  const ambiguousCandidateDone = block({
+    type: "response.output_item.done",
+    output_index: 0,
+    sequence_number: 8,
+    item: {
+      ...blankMessage,
+      content: [blankMessage.content[0], { ...blankMessage.content[0] }],
+    },
+  });
+  const ambiguousCandidate = source.replace(candidateDone, ambiguousCandidateDone);
+  assert.equal(await transformed(ambiguousCandidate), ambiguousCandidate);
+
+  const repeatedSequence = source.replace(
+    '"output_index":1,"sequence_number":5',
+    '"output_index":1,"sequence_number":4',
+  );
+  assert.notEqual(repeatedSequence, source);
+  assert.equal(await transformed(repeatedSequence), repeatedSequence);
+
+  const invalidObfuscation = [
+    responseCreated(),
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    }),
+    block({
+      type: "response.content_part.added",
+      output_index: 0,
+      item_id: blankMessage.id,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    }),
+    block({
+      type: "response.output_text.delta",
+      output_index: 0,
+      item_id: blankMessage.id,
+      content_index: 0,
+      delta: "",
+      obfuscation: { unexpected: true },
+    }),
+  ].join("");
+  assert.equal(await transformed(invalidObfuscation), invalidObfuscation);
+});
+
+test("pre-candidate tracking is bounded and becomes passthrough on overflow", async () => {
+  const reasoning = {
+    id: "rs_prelude",
+    type: "reasoning",
+    status: "in_progress",
+    summary: [],
+  };
+  const input = [
+    responseCreated(),
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: reasoning,
+    }),
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { ...reasoning, status: "completed" },
+    }),
+    phantomToolStream(),
+  ].join("");
+  assert.equal(
+    await transformed(input, { maxCandidateBytes: 64, maxCandidateMs: 60_000 }),
+    input,
+  );
+});
+
+test("compacts a strictly confirmed custom-tool lifecycle without changing its identity", async () => {
+  const custom = {
+    id: "custom_shell",
+    type: "custom_tool_call",
+    status: "completed",
+    call_id: "custom_shell_call",
+    name: "shell",
+    input: "echo ready",
+  };
+  const input = [
+    responseCreated("resp_custom", { sequenceNumber: 0 }),
+    block({
+      type: "response.output_item.added",
+      sequence_number: 1,
+      output_index: 0,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    }),
+    block({
+      type: "response.output_item.added",
+      sequence_number: 2,
+      output_index: 1,
+      item: { ...custom, status: "in_progress", input: "" },
+    }),
+    block({
+      type: "response.custom_tool_call_input.delta",
+      sequence_number: 3,
+      output_index: 1,
+      item_id: custom.id,
+      delta: "echo ready",
+    }),
+    block({
+      type: "response.custom_tool_call_input.done",
+      sequence_number: 4,
+      output_index: 1,
+      item_id: custom.id,
+      input: "echo ready",
+    }),
+    block({
+      type: "response.output_item.done",
+      sequence_number: 5,
+      output_index: 1,
+      item: custom,
+    }),
+    block({
+      type: "response.output_item.done",
+      sequence_number: 6,
+      output_index: 0,
+      item: blankMessage,
+    }),
+    responseCompleted([blankMessage, custom], {
+      id: "resp_custom",
+      sequenceNumber: 7,
+    }),
+  ].join("");
+
+  const seen = events(await transformed(input, {}, 1));
+  const customEvents = seen.filter((event) => eventItem(event) === custom.id);
+  assert.deepEqual(
+    customEvents.map((event) => [event.type, event.output_index, event.sequence_number]),
+    [
+      ["response.output_item.added", 0, 2],
+      ["response.custom_tool_call_input.delta", 0, 3],
+      ["response.custom_tool_call_input.done", 0, 4],
+      ["response.output_item.done", 0, 5],
+    ],
+  );
+  assert.deepEqual(
+    seen.find((event) => event.type === "response.completed").response.output,
+    [custom],
+  );
+});
+
+test("preserves real reasoning bytes, ids, and sequence numbers while compacting", async () => {
+  const reasoningDone = {
+    id: "rs_real",
+    type: "reasoning",
+    status: "completed",
+    summary: [{ type: "summary_text", text: "real private reasoning" }],
+  };
+  const input = [
+    responseCreated("resp_reasoning_real", { sequenceNumber: 0 }),
+    block({
+      type: "response.output_item.added",
+      sequence_number: 1,
+      output_index: 0,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    }),
+    block({
+      type: "response.output_item.added",
+      sequence_number: 2,
+      output_index: 1,
+      item: { ...reasoningDone, status: "in_progress", summary: [] },
+    }),
+    block({
+      type: "response.reasoning_summary_part.added",
+      sequence_number: 3,
+      item_id: reasoningDone.id,
+      output_index: 1,
+      summary_index: 0,
+      part: { type: "summary_text", text: "" },
+    }),
+    block({
+      type: "response.reasoning_summary_text.delta",
+      sequence_number: 4,
+      item_id: reasoningDone.id,
+      output_index: 1,
+      summary_index: 0,
+      delta: "real private reasoning",
+    }),
+    block({
+      type: "response.reasoning_summary_text.done",
+      sequence_number: 5,
+      item_id: reasoningDone.id,
+      output_index: 1,
+      summary_index: 0,
+      text: "real private reasoning",
+    }),
+    block({
+      type: "response.reasoning_summary_part.done",
+      sequence_number: 6,
+      item_id: reasoningDone.id,
+      output_index: 1,
+      summary_index: 0,
+      part: { type: "summary_text", text: "real private reasoning" },
+    }),
+    block({
+      type: "response.output_item.done",
+      sequence_number: 7,
+      output_index: 1,
+      item: reasoningDone,
+    }),
+    block({
+      type: "response.output_item.added",
+      sequence_number: 8,
+      output_index: 2,
+      item: { ...functionCall, status: "in_progress", arguments: "" },
+    }),
+    block({
+      type: "response.output_item.done",
+      sequence_number: 9,
+      output_index: 2,
+      item: functionCall,
+    }),
+    block({
+      type: "response.output_item.done",
+      sequence_number: 10,
+      output_index: 0,
+      item: blankMessage,
+    }),
+    responseCompleted([blankMessage, reasoningDone, functionCall], {
+      id: "resp_reasoning_real",
+      sequenceNumber: 11,
+    }),
+  ].join("");
+
+  const output = await transformed(input, {}, 1);
+  assert.match(output, /real private reasoning/);
+  const seen = events(output);
+  assert.deepEqual(
+    seen.map((event) => event.sequence_number),
+    [0, 2, 3, 4, 5, 6, 7, 8, 9, 11],
+  );
+  assert.ok(
+    seen
+      .filter((event) => eventItem(event) === reasoningDone.id)
+      .every((event) => event.output_index === 0),
+  );
+  assert.ok(
+    seen
+      .filter((event) => eventItem(event) === functionCall.id)
+      .every((event) => event.output_index === 1),
+  );
+  assert.deepEqual(
+    seen.find((event) => event.type === "response.completed").response.output,
+    [reasoningDone, functionCall],
+  );
+});
+
+test("stops rewriting after the first bound terminal envelope", async () => {
+  const first = phantomToolStream().replace("data: [DONE]\n\n", "");
+  const normalizedFirst = await transformed(first, {}, 1);
+  const second = phantomToolStream()
+    .replaceAll("resp_1", "resp_second")
+    .replaceAll("msg_blank", "msg_second")
+    .replaceAll("call_list", "call_second");
+  const invalidTrailingBytes = Buffer.from([0xc0, 0xff, 0x00, 0x0a]);
+  const input = Buffer.concat([
+    Buffer.from(first),
+    Buffer.from(second),
+    invalidTrailingBytes,
+  ]);
+  const expected = Buffer.concat([
+    Buffer.from(normalizedFirst),
+    Buffer.from(second),
+    invalidTrailingBytes,
+  ]);
+
+  assert.deepEqual(await transformedBytes(input, {}, 1), expected);
+});
+
+test("invalid fragmented UTF-8 during a held candidate fails open byte-for-byte", async () => {
+  const prefix = [
+    responseCreated(),
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    }),
+  ].join("");
+  const invalidFrame = Buffer.concat([
+    Buffer.from("event: response.output_item.done\ndata: "),
+    Buffer.from([0xc0]),
+    Buffer.from("\n\n"),
+  ]);
+  const opaqueTail = Buffer.from([0xff, 0x00, 0x61, 0x0a]);
+  const input = Buffer.concat([Buffer.from(prefix), invalidFrame, opaqueTail]);
+
+  assert.deepEqual(await transformedBytes(input, {}, 1), input);
+
+  const bomPrefixed = Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    Buffer.from(phantomToolStream()),
+  ]);
+  assert.deepEqual(await transformedBytes(bomPrefixed, {}, 1), bomPrefixed);
+});
+
+test("a failed attempt cannot poison a fresh retry transform", async () => {
+  const provider = { id: "deepseek", protocol: "openai" };
+  const failed = translatedToolMessageCompatTransform(provider, "text/event-stream");
+  const retry = translatedToolMessageCompatTransform(provider, "text/event-stream");
+  const malformed = Buffer.concat([
+    Buffer.from(responseCreated()),
+    Buffer.from([0xc0]),
+    Buffer.from("\n\n"),
+  ]);
+  const failedOutput = [];
+  failed.on("data", (chunk) => { failedOutput.push(Buffer.from(chunk)); });
+  failed.end(malformed);
+  await once(failed, "end");
+  assert.deepEqual(Buffer.concat(failedOutput), malformed);
+
+  let retryOutput = "";
+  retry.setEncoding("utf8");
+  retry.on("data", (chunk) => { retryOutput += chunk; });
+  retry.end(phantomToolStream());
+  await once(retry, "end");
+  assert.equal(retryOutput.includes(blankMessage.id), false);
+  assert.deepEqual(
+    events(retryOutput).find((event) => event.type === "response.completed").response.output,
+    [functionCall],
+  );
 });
 
 test("non-streaming responses remove only exact empty messages proven by tool traffic", async () => {
@@ -730,6 +1444,7 @@ test("non-streaming responses remove only exact empty messages proven by tool tr
   const payload = {
     id: "resp_json",
     object: "response",
+    status: "completed",
     error: null,
     output: [blankMessage, reasoning, functionCall, secondBlank, secondTool, visible],
     usage: { input_tokens: 7, output_tokens: 3, total_tokens: 10 },
@@ -741,25 +1456,98 @@ test("non-streaming responses remove only exact empty messages proven by tool tr
   });
 });
 
+test("non-streaming normalization requires a successful envelope and unique ids", async () => {
+  const valid = jsonResponse([blankMessage, functionCall]);
+  const invalidPayloads = [
+    { ...valid, id: "" },
+    { ...valid, object: undefined },
+    { ...valid, object: "list" },
+    { ...valid, status: undefined },
+    { ...valid, status: "incomplete" },
+    { ...valid, error: { message: "failed" } },
+    jsonResponse([
+      blankMessage,
+      { ...functionCall, id: blankMessage.id },
+    ]),
+    jsonResponse([
+      { ...blankMessage, id: "resp_json" },
+      functionCall,
+    ]),
+    jsonResponse([
+      { ...blankMessage, id: "" },
+      functionCall,
+    ]),
+    jsonResponse([
+      blankMessage,
+      {
+        id: "rs_unknown",
+        type: "reasoning",
+        summary: [{ type: "opaque_reasoning", text: "visible" }],
+      },
+      functionCall,
+    ]),
+  ];
+  for (const payload of invalidPayloads) {
+    const input = JSON.stringify(payload, null, 2);
+    assert.equal(await transformedJson(input, {}, 1), input);
+  }
+});
+
+test("non-streaming malformed neighboring messages make the whole body fail open", async () => {
+  const secondBlank = { ...blankMessage, id: "msg_after_malformed" };
+  const secondTool = {
+    ...functionCall,
+    id: "call_after_malformed",
+    call_id: "call_after_malformed",
+  };
+  const baseNeighbor = {
+    id: "msg_malformed_neighbor",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "visible", annotations: [] }],
+  };
+  const malformedNeighbors = [
+    { ...baseNeighbor, role: "user" },
+    { ...baseNeighbor, content: "visible" },
+    { ...baseNeighbor, content: [] },
+    { ...baseNeighbor, content: [{ type: "opaque", value: "visible" }] },
+    { ...baseNeighbor, phase: { value: "final" } },
+  ];
+  for (const neighbor of malformedNeighbors) {
+    const input = JSON.stringify(
+      jsonResponse([blankMessage, neighbor, secondBlank, secondTool]),
+      null,
+      2,
+    );
+    assert.equal(await transformedJson(input, {}, 1), input);
+  }
+});
+
 test("non-streaming ambiguous, malformed, and oversized bodies fail open byte-for-byte", async () => {
   const secondBlank = { ...blankMessage, id: "msg_second" };
-  const consecutive = JSON.stringify({
-    output: [blankMessage, secondBlank, functionCall],
-  }, null, 2);
+  const consecutive = JSON.stringify(
+    jsonResponse([blankMessage, secondBlank, functionCall]),
+    null,
+    2,
+  );
   assert.equal(await transformedJson(consecutive), consecutive);
 
-  const visible = JSON.stringify({
-    output: [
+  const visible = JSON.stringify(
+    jsonResponse([
       blankMessage,
       {
         id: "msg_visible",
         type: "message",
+        status: "completed",
         role: "assistant",
         content: [{ type: "output_text", text: "real text" }],
       },
       functionCall,
-    ],
-  }, null, 2);
+    ]),
+    null,
+    2,
+  );
   assert.equal(await transformedJson(visible), visible);
 
   const malformed = "{not-json";
@@ -774,21 +1562,22 @@ test("non-streaming ambiguous, malformed, and oversized bodies fail open byte-fo
       functionCall,
     ],
   ]) {
-    const malformedItems = JSON.stringify({ output }, null, 2);
+    const malformedItems = JSON.stringify(jsonResponse(output), null, 2);
     assert.equal(await transformedJson(malformedItems), malformedItems);
   }
 
   const incomplete = JSON.stringify({
+    id: "resp_incomplete",
     object: "response",
     status: "incomplete",
+    error: null,
     output: [blankMessage, functionCall],
   }, null, 2);
   assert.equal(await transformedJson(incomplete), incomplete);
 
-  const oversized = JSON.stringify({
-    output: [blankMessage, functionCall],
+  const oversized = JSON.stringify(jsonResponse([blankMessage, functionCall], {
     opaque: "x".repeat(256),
-  });
+  }));
   assert.equal(await transformedJson(oversized, { maxBytes: 64 }, 11), oversized);
 
   const invalidUtf8 = Buffer.from('{"output":"\xc0"}', "latin1");
@@ -798,10 +1587,21 @@ test("non-streaming ambiguous, malformed, and oversized bodies fail open byte-fo
   stream.end(invalidUtf8);
   await once(stream, "end");
   assert.deepEqual(Buffer.concat(chunks), invalidUtf8);
+
+  const bomJson = Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    Buffer.from(JSON.stringify(jsonResponse([blankMessage, functionCall]))),
+  ]);
+  const bomStream = new TranslatedToolMessageJsonCompatTransform();
+  const bomChunks = [];
+  bomStream.on("data", (chunk) => { bomChunks.push(chunk); });
+  bomStream.end(bomJson);
+  await once(bomStream, "end");
+  assert.deepEqual(Buffer.concat(bomChunks), bomJson);
 });
 
 test("a slow non-streaming body releases pending bytes and becomes passthrough", async () => {
-  const source = JSON.stringify({ output: [blankMessage, functionCall] });
+  const source = JSON.stringify(jsonResponse([blankMessage, functionCall]));
   const split = Math.floor(source.length / 2);
   const stream = new TranslatedToolMessageJsonCompatTransform({ maxMs: 5 });
   let output = "";

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -103,6 +103,36 @@ async function transformedThroughNamespace(
   return output;
 }
 
+async function transformedBytesThroughNamespace(
+  input,
+  namespaces,
+  {
+    contentType = "text/event-stream",
+    json = false,
+    compatOptions = {},
+  } = {},
+  chunkSize = 0,
+) {
+  const compat = json
+    ? new TranslatedToolMessageJsonCompatTransform(compatOptions)
+    : new TranslatedToolMessageCompatTransform(compatOptions);
+  const namespace = new NamespaceToolCallTransform(namespaces, contentType);
+  const output = [];
+  namespace.on("data", (chunk) => { output.push(Buffer.from(chunk)); });
+  compat.pipe(namespace);
+  const bytes = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  if (chunkSize > 0) {
+    for (let at = 0; at < bytes.length; at += chunkSize) {
+      compat.write(bytes.subarray(at, at + chunkSize));
+    }
+  } else {
+    compat.write(bytes);
+  }
+  compat.end();
+  await once(namespace, "end");
+  return Buffer.concat(output);
+}
+
 async function transformedJson(input, options = {}, chunkSize = 0) {
   const stream = new TranslatedToolMessageJsonCompatTransform(options);
   let output = "";
@@ -2656,6 +2686,171 @@ test("blank compaction composes with ordinary, custom, and tool_search restorati
   assert.equal(completed.response.output[0].name, "read_file");
   assert.equal(completed.response.output[1].input, "*** Begin Patch\n*** End Patch");
   assert.deepEqual(completed.response.output[2].arguments, { query: "calendar" });
+});
+
+test("compat and namespace stages preserve invalid UTF-8 byte-for-byte", async () => {
+  const flattened = flattenNamespaceTools([{
+    type: "namespace",
+    name: "mcp__files",
+    tools: [{
+      type: "function",
+      name: "read_file",
+      inputSchema: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+        additionalProperties: false,
+      },
+    }],
+  }]);
+  const namespaceCall = {
+    ...functionCall,
+    name: "mcp__files__read_file",
+    arguments: '{"path":"README.md"}',
+  };
+  const source = pinnedLiteLlmPhantomToolStream((wireEvents) => {
+    for (const event of wireEvents) {
+      if (event.type === "response.function_call_arguments.delta") {
+        event.delta = namespaceCall.arguments;
+      } else if (event.type === "response.function_call_arguments.done") {
+        event.arguments = namespaceCall.arguments;
+      } else if (event.item?.type === "function_call") {
+        Object.assign(event.item, namespaceCall);
+      } else if (event.type === "response.completed") {
+        Object.assign(
+          event.response.output.find((item) => item.type === "function_call"),
+          namespaceCall,
+        );
+      }
+    }
+  });
+  const insertAt = source.indexOf("event: response.output_item.added");
+  assert.ok(insertAt > 0);
+  const invalidSse = Buffer.concat([
+    Buffer.from(source.slice(0, insertAt)),
+    Buffer.from("event: opaque\ndata: ", "ascii"),
+    Buffer.from([0xff]),
+    Buffer.from("\n\n", "ascii"),
+    Buffer.from(source.slice(insertAt)),
+  ]);
+  assert.deepEqual(
+    await transformedBytesThroughNamespace(
+      invalidSse,
+      flattened.namespaces,
+      {},
+      1,
+    ),
+    invalidSse,
+  );
+
+  const jsonPrefix = Buffer.from(
+    `{"id":"resp_invalid_utf8","status":"completed","output":[${JSON.stringify(blankMessage)},`,
+  );
+  const jsonSuffix = Buffer.from(
+    `${JSON.stringify(namespaceCall)}],"opaque":"tail"}`,
+  );
+  const invalidJson = Buffer.concat([
+    jsonPrefix,
+    Buffer.from('{"invalid":"', "ascii"),
+    Buffer.from([0xff]),
+    Buffer.from('"},', "ascii"),
+    jsonSuffix,
+  ]);
+  assert.deepEqual(
+    await transformedBytesThroughNamespace(
+      invalidJson,
+      flattened.namespaces,
+      { contentType: "application/json", json: true },
+      1,
+    ),
+    invalidJson,
+  );
+});
+
+test("compat and namespace stages jointly reject lossy numeric rewrites", async () => {
+  const flattened = flattenNamespaceTools([{
+    type: "namespace",
+    name: "mcp__files",
+    tools: [{
+      type: "function",
+      name: "read_file",
+      inputSchema: {
+        type: "object",
+        properties: { path: { type: "string" } },
+        required: ["path"],
+        additionalProperties: false,
+      },
+    }],
+  }]);
+  const namespaceCall = {
+    ...functionCall,
+    name: "mcp__files__read_file",
+    arguments: '{"path":"README.md"}',
+  };
+  const source = pinnedLiteLlmPhantomToolStream((wireEvents) => {
+    for (const event of wireEvents) {
+      if (event.type === "response.function_call_arguments.delta") {
+        event.delta = namespaceCall.arguments;
+      } else if (event.type === "response.function_call_arguments.done") {
+        event.arguments = namespaceCall.arguments;
+      } else if (event.item?.type === "function_call") {
+        Object.assign(event.item, namespaceCall);
+      } else if (event.type === "response.completed") {
+        Object.assign(
+          event.response.output.find((item) => item.type === "function_call"),
+          namespaceCall,
+        );
+      }
+    }
+  });
+  const jsonTemplate = JSON.stringify({
+    id: "resp_lossy_composed",
+    object: "response",
+    error: null,
+    status: "completed",
+    numeric_provenance: 123,
+    output: [blankMessage, namespaceCall],
+  });
+
+  for (const literal of [
+    "1e-324",
+    "1.0000000000000001",
+    "0.10000000000000001",
+  ]) {
+    const unsafeSse = source.replace(
+      '"error":null',
+      `"error":null,"numeric_provenance":${literal}`,
+    );
+    assert.notEqual(unsafeSse, source);
+    const unsafeSseBytes = Buffer.from(unsafeSse);
+    assert.deepEqual(
+      await transformedBytesThroughNamespace(
+        unsafeSseBytes,
+        flattened.namespaces,
+        {},
+        1,
+      ),
+      unsafeSseBytes,
+      `SSE ${literal}`,
+    );
+
+    const unsafeJson = jsonTemplate.replace(
+      '"numeric_provenance":123',
+      `"numeric_provenance":${literal}`,
+    );
+    assert.notEqual(unsafeJson, jsonTemplate);
+    const unsafeJsonBytes = Buffer.from(unsafeJson);
+    assert.deepEqual(
+      await transformedBytesThroughNamespace(
+        unsafeJsonBytes,
+        flattened.namespaces,
+        { contentType: "application/json", json: true },
+        1,
+      ),
+      unsafeJsonBytes,
+      `JSON ${literal}`,
+    );
+  }
 });
 
 test("preserves real reasoning bytes, ids, and sequence numbers while compacting", async () => {

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -14,6 +14,10 @@ function block(event, newline = "\n") {
   return `event: ${event.type}${newline}data: ${JSON.stringify(event)}${newline}${newline}`;
 }
 
+function rawBlock(type, json, newline = "\n") {
+  return `event: ${type}${newline}data: ${json}${newline}${newline}`;
+}
+
 function events(text) {
   return text
     .split(/\r?\n\r?\n/)
@@ -1350,6 +1354,64 @@ test("preserves real reasoning bytes, ids, and sequence numbers while compacting
   );
 });
 
+test("reasoning output-item provenance must match the terminal response", async () => {
+  const reasoningDone = {
+    id: "rs_provenance",
+    type: "reasoning",
+    status: "completed",
+    summary: [{ type: "summary_text", text: "alpha" }],
+  };
+  const terminalReasoning = {
+    ...reasoningDone,
+    summary: [{ type: "summary_text", text: "beta" }],
+  };
+  const input = [
+    responseCreated("resp_reasoning_provenance", { sequenceNumber: 0 }),
+    block({
+      type: "response.output_item.added",
+      sequence_number: 1,
+      output_index: 0,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    }),
+    block({
+      type: "response.output_item.added",
+      sequence_number: 2,
+      output_index: 1,
+      item: { ...reasoningDone, status: "in_progress", summary: [] },
+    }),
+    block({
+      type: "response.output_item.done",
+      sequence_number: 3,
+      output_index: 1,
+      item: reasoningDone,
+    }),
+    block({
+      type: "response.output_item.added",
+      sequence_number: 4,
+      output_index: 2,
+      item: { ...functionCall, status: "in_progress", arguments: "" },
+    }),
+    block({
+      type: "response.output_item.done",
+      sequence_number: 5,
+      output_index: 2,
+      item: functionCall,
+    }),
+    block({
+      type: "response.output_item.done",
+      sequence_number: 6,
+      output_index: 0,
+      item: blankMessage,
+    }),
+    responseCompleted([blankMessage, terminalReasoning, functionCall], {
+      id: "resp_reasoning_provenance",
+      sequenceNumber: 7,
+    }),
+  ].join("");
+
+  assert.equal(await transformed(input, {}, 1), input);
+});
+
 test("stops rewriting after the first bound terminal envelope", async () => {
   const first = phantomToolStream().replace("data: [DONE]\n\n", "");
   const normalizedFirst = await transformed(first, {}, 1);
@@ -1425,6 +1487,112 @@ test("a failed attempt cannot poison a fresh retry transform", async () => {
   );
 });
 
+test("duplicate SSE lifecycle members fail open before last-wins parsing", async () => {
+  const source = phantomToolStream();
+  const valid = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    sequence_number: 1,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  const visible = {
+    ...blankMessage,
+    status: "in_progress",
+    content: [{ type: "output_text", text: "MUST_KEEP_LIFECYCLE" }],
+  };
+  const duplicate = rawBlock(
+    "response.output_item.added",
+    `{"type":"response.output_item.added","output_index":0,"sequence_number":1,` +
+      `"item":${JSON.stringify(visible)},` +
+      `"\\u0069tem":${JSON.stringify({
+        ...blankMessage,
+        status: "in_progress",
+        content: [],
+      })}}`,
+  );
+  const input = source.replace(valid, duplicate);
+  assert.notEqual(input, source);
+  assert.equal(await transformed(input, {}, 1), input);
+});
+
+test("duplicate terminal SSE members preserve visible and error values byte-for-byte", async () => {
+  const source = phantomToolStream();
+  const completedEvent = {
+    type: "response.completed",
+    sequence_number: 9,
+    response: {
+      id: "resp_1",
+      object: "response",
+      status: "completed",
+      error: null,
+      output: [blankMessage, functionCall],
+    },
+  };
+  const valid = responseCompleted([blankMessage, functionCall], {
+    id: "resp_1",
+    sequenceNumber: 9,
+  });
+  const visible = {
+    id: "msg_must_keep",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "MUST_KEEP_OUTPUT" }],
+  };
+  const json = JSON.stringify(completedEvent);
+  const cases = [
+    json.replace(
+      `"output":${JSON.stringify(completedEvent.response.output)}`,
+      `"output":${JSON.stringify([visible])},` +
+        `"output":${JSON.stringify(completedEvent.response.output)}`,
+    ),
+    json.replace(
+      '"error":null',
+      '"error":{"message":"MUST_KEEP_ERROR"},"error":null',
+    ),
+    json.replace(
+      '"status":"completed"',
+      '"status":"failed","status":"completed"',
+    ),
+    json.replace('"text":""', '"text":"MUST_KEEP_TEXT","text":""'),
+    json.replace(
+      '"arguments":"{}"',
+      '"arguments":"MUST_KEEP_TOOL","arguments":"{}"',
+    ),
+  ];
+  for (const duplicateJson of cases) {
+    const input = source.replace(
+      valid,
+      rawBlock("response.completed", duplicateJson),
+    );
+    assert.notEqual(input, source);
+    assert.equal(await transformed(input, {}, 1), input);
+  }
+});
+
+test("bounded uniqueness scanning fails open and accepts unique escaped keys", async () => {
+  const source = phantomToolStream();
+  for (const options of [
+    { maxJsonDepth: 1 },
+    { maxJsonMembers: 1 },
+    { maxJsonKeyCodeUnits: 1 },
+  ]) {
+    assert.equal(await transformed(source, options, 1), source);
+  }
+
+  const escaped = source.replace(
+    '"sequence_number":3',
+    '"\\u0073equence_number":3',
+  );
+  assert.notEqual(escaped, source);
+  const normalized = await transformed(escaped, {}, 1);
+  assert.equal(normalized.includes(blankMessage.id), false);
+  assert.deepEqual(
+    events(normalized).find((event) => event.type === "response.completed").response.output,
+    [functionCall],
+  );
+});
+
 test("non-streaming responses remove only exact empty messages proven by tool traffic", async () => {
   const secondBlank = {
     ...blankMessage,
@@ -1454,6 +1622,80 @@ test("non-streaming responses remove only exact empty messages proven by tool tr
     ...payload,
     output: [reasoning, functionCall, secondTool, visible],
   });
+});
+
+test("duplicate non-streaming members never erase earlier output or metadata", async () => {
+  const visible = {
+    id: "msg_must_keep_json",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "MUST_KEEP_OUTPUT" }],
+  };
+  const reasoning = {
+    id: "rs_duplicate_json",
+    type: "reasoning",
+    status: "completed",
+    summary: [{ type: "summary_text", text: "kept reasoning" }],
+  };
+  const base = JSON.stringify(jsonResponse([blankMessage, functionCall]));
+  const reasoningBase = JSON.stringify(
+    jsonResponse([blankMessage, reasoning, functionCall]),
+  );
+  const cases = [
+    base.replace(
+      `"output":${JSON.stringify([blankMessage, functionCall])}`,
+      `"output":${JSON.stringify([visible])},` +
+        `"output":${JSON.stringify([blankMessage, functionCall])}`,
+    ),
+    base.replace(
+      '"error":null',
+      '"error":{"message":"MUST_KEEP_ERROR"},"\\u0065rror":null',
+    ),
+    base.replace(
+      '"status":"completed"',
+      '"status":"failed","status":"completed"',
+    ),
+    base.replace('"text":""', '"text":"MUST_KEEP_TEXT","text":""'),
+    base.replace(
+      '"arguments":"{}"',
+      '"arguments":"MUST_KEEP_TOOL","arguments":"{}"',
+    ),
+    reasoningBase.replace(
+      `"summary":${JSON.stringify(reasoning.summary)}`,
+      `"summary":[{"type":"summary_text","text":"MUST_KEEP_REASONING"}],` +
+        `"summary":${JSON.stringify(reasoning.summary)}`,
+    ),
+  ];
+  for (const input of cases) {
+    assert.equal(await transformedJson(input, {}, 1), input);
+  }
+});
+
+test("non-streaming uniqueness limits fail open while unique JSON remains eligible", async () => {
+  const source = JSON.stringify(jsonResponse([blankMessage, functionCall]));
+  for (const options of [
+    { maxJsonDepth: 1 },
+    { maxJsonMembers: 1 },
+    { maxJsonKeyCodeUnits: 1 },
+  ]) {
+    assert.equal(await transformedJson(source, options, 1), source);
+  }
+
+  const unique = source.replace(
+    '"error":null',
+    '"\\u0065rror":null,"metadata":{' +
+      '"astral":"\\ud83d\\ude00","lone":"\\ud800",' +
+      '"fraction":-1.25e+3,"huge":123456789012345678901234567890}',
+  );
+  const normalized = await transformedJson(unique, {}, 1);
+  assert.notEqual(normalized, unique);
+  const payload = JSON.parse(normalized);
+  assert.deepEqual(payload.output, [functionCall]);
+  assert.equal(payload.metadata.astral, "😀");
+  assert.equal(payload.metadata.lone, "\ud800");
+  assert.equal(payload.metadata.fraction, -1250);
+  assert.equal(typeof payload.metadata.huge, "number");
 });
 
 test("non-streaming normalization requires a successful envelope and unique ids", async () => {

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -28,6 +28,10 @@ function events(text) {
 
 async function transformed(input, options = {}, chunkSize = 0) {
   const stream = new TranslatedToolMessageCompatTransform(options);
+  return transformedBy(stream, input, chunkSize);
+}
+
+async function transformedBy(stream, input, chunkSize = 0) {
   let output = "";
   stream.setEncoding("utf8");
   stream.on("data", (chunk) => { output += chunk; });
@@ -225,28 +229,27 @@ function phantomToolStream(
 // message item is hard-coded to sequence_number=1 after higher-numbered tool
 // events, while its output_text/content_part closes are unnumbered.
 function pinnedLiteLlmPhantomEvents() {
+  const model = "opencode-go-deepseek-v4-flash";
   const inProgressResponse = {
     id: "resp_pinned_litellm",
+    model,
     object: "response",
     status: "in_progress",
     error: null,
     output: [],
   };
-  return [
+  const wireEvents = [
     {
       type: "response.created",
-      sequence_number: 1,
       response: { ...inProgressResponse },
     },
     {
       type: "response.in_progress",
-      sequence_number: 2,
       response: { ...inProgressResponse },
     },
     {
       type: "response.output_item.added",
       output_index: 0,
-      sequence_number: 3,
       item: { ...blankMessage, status: "in_progress", content: [] },
     },
     {
@@ -254,26 +257,29 @@ function pinnedLiteLlmPhantomEvents() {
       item_id: blankMessage.id,
       output_index: 0,
       content_index: 0,
-      sequence_number: 4,
       part: { type: "output_text", text: "", annotations: [] },
     },
     {
       type: "response.output_item.added",
       output_index: 1,
-      sequence_number: 5,
       item: { ...functionCall, status: "in_progress", arguments: "" },
     },
     {
       type: "response.function_call_arguments.delta",
       item_id: functionCall.id,
       output_index: 1,
-      sequence_number: 6,
       delta: "{}",
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: functionCall.id,
+      output_index: 1,
+      arguments: "{}",
     },
     {
       type: "response.output_item.done",
       output_index: 1,
-      sequence_number: 7,
+      sequence_number: 9,
       item: { ...functionCall },
     },
     {
@@ -299,18 +305,42 @@ function pinnedLiteLlmPhantomEvents() {
     {
       type: "response.completed",
       response: {
-        id: inProgressResponse.id,
+        id: "resp_pinned_litellm_terminal",
+        model,
         object: "response",
         status: "completed",
         error: null,
-        output: [{ ...blankMessage }, { ...functionCall }],
+        output: [
+          { ...blankMessage, id: "chatcmpl-pinned-terminal" },
+          { ...functionCall },
+        ],
       },
     },
   ];
+  return wireEvents.map((event) => ({ ...event, model }));
 }
 
 function pinnedLiteLlmPhantomToolStream(mutate) {
   const wireEvents = pinnedLiteLlmPhantomEvents();
+  if (mutate) mutate(wireEvents);
+  return `${wireEvents.map((event) => block(event)).join("")}data: [DONE]\n\n`;
+}
+
+// LiteLLM's Anthropic -> Responses bridge omits the empty message's opening
+// item/content events. Its first visible output item is therefore the tool at
+// index one; the bridge reveals the index-zero phantom only while closing it.
+function pinnedAnthropicTerminalOnlyEvents() {
+  const wireEvents = pinnedLiteLlmPhantomEvents().filter((event) => !(
+    (event.type === "response.output_item.added" && event.output_index === 0) ||
+    (event.type === "response.content_part.added" && event.output_index === 0)
+  ));
+  const terminal = wireEvents.find((event) => event.type === "response.completed");
+  terminal.response.output[0].id = blankMessage.id;
+  return wireEvents;
+}
+
+function pinnedAnthropicTerminalOnlyStream(mutate) {
+  const wireEvents = pinnedAnthropicTerminalOnlyEvents();
   if (mutate) mutate(wireEvents);
   return `${wireEvents.map((event) => block(event)).join("")}data: [DONE]\n\n`;
 }
@@ -325,9 +355,10 @@ test("repairs LiteLLM 1.96.0's pinned terminal sequence reset", async () => {
     seen.filter((event) => eventItem(event) === functionCall.id)
       .map((event) => [event.type, event.output_index, event.sequence_number]),
     [
-      ["response.output_item.added", 0, 5],
-      ["response.function_call_arguments.delta", 0, 6],
-      ["response.output_item.done", 0, 7],
+      ["response.output_item.added", 0, undefined],
+      ["response.function_call_arguments.delta", 0, undefined],
+      ["response.function_call_arguments.done", 0, undefined],
+      ["response.output_item.done", 0, 9],
     ],
   );
   assert.deepEqual(
@@ -336,44 +367,285 @@ test("repairs LiteLLM 1.96.0's pinned terminal sequence reset", async () => {
   );
 });
 
+test("repairs the Anthropic bridge's terminal-only phantom slot", async () => {
+  const source = pinnedAnthropicTerminalOnlyStream();
+  assert.equal(await transformed(source), source);
+
+  const output = await transformed(source, { allowTerminalOnlyCandidate: true }, 3);
+  const seen = events(output);
+  assert.equal(output.includes(blankMessage.id), false);
+  assert.deepEqual(
+    seen.filter((event) => eventItem(event) === functionCall.id)
+      .map((event) => [event.type, event.output_index]),
+    [
+      ["response.output_item.added", 0],
+      ["response.function_call_arguments.delta", 0],
+      ["response.function_call_arguments.done", 0],
+      ["response.output_item.done", 0],
+    ],
+  );
+  assert.deepEqual(
+    seen.find((event) => event.type === "response.completed").response.output,
+    [functionCall],
+  );
+});
+
+test("only the Anthropic factory path admits a terminal-only phantom slot", async () => {
+  const source = pinnedAnthropicTerminalOnlyStream();
+  const anthropic = translatedToolMessageCompatTransform(
+    { id: "opencode-go-messages", protocol: "anthropic" },
+    "text/event-stream; charset=utf-8",
+  );
+  const openai = translatedToolMessageCompatTransform(
+    { id: "opencode-go", protocol: "openai" },
+    "text/event-stream; charset=utf-8",
+  );
+  const repaired = await transformedBy(anthropic, source, 2);
+  assert.equal(repaired.includes(blankMessage.id), false);
+  assert.equal(await transformedBy(openai, source, 2), source);
+});
+
+test("the terminal-only slot compacts multiple corroborated tool calls", async () => {
+  const secondTool = {
+    ...functionCall,
+    id: "call_second",
+    call_id: "call_second",
+    name: "second_tool",
+  };
+  const source = pinnedAnthropicTerminalOnlyStream((wireEvents) => {
+    const model = wireEvents[0].model;
+    const firstCandidateClose = wireEvents.findIndex(
+      (event) => event.type === "response.output_text.done",
+    );
+    wireEvents.splice(firstCandidateClose, 0,
+      {
+        type: "response.output_item.added",
+        output_index: 2,
+        item: { ...secondTool, status: "in_progress", arguments: "" },
+        model,
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: secondTool.id,
+        output_index: 2,
+        delta: "{}",
+        model,
+      },
+      {
+        type: "response.function_call_arguments.done",
+        item_id: secondTool.id,
+        output_index: 2,
+        arguments: "{}",
+        model,
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 2,
+        sequence_number: 10,
+        item: secondTool,
+        model,
+      },
+    );
+    const terminal = wireEvents.find((event) => event.type === "response.completed");
+    terminal.response.output.push(secondTool);
+  });
+  const output = await transformed(source, { allowTerminalOnlyCandidate: true }, 5);
+  const seen = events(output);
+  assert.deepEqual(
+    seen.filter((event) => event.type === "response.output_item.done")
+      .map((event) => [event.item.id, event.output_index]),
+    [[functionCall.id, 0], [secondTool.id, 1]],
+  );
+  assert.deepEqual(
+    seen.find((event) => event.type === "response.completed").response.output,
+    [functionCall, secondTool],
+  );
+});
+
+test("the terminal-only candidate exception fails open on adjacent shapes", async () => {
+  const cases = [
+    ["visible text close", (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.output_text.done").text = "visible";
+    }],
+    ["visible part close", (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.content_part.done").part.text = "visible";
+    }],
+    ["mismatched close id", (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.content_part.done").item_id = "msg_other";
+    }],
+    ["mismatched close index", (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.output_text.done").output_index = 1;
+    }],
+    ["changed terminal candidate id", (wireEvents) => {
+      const terminal = wireEvents.find((event) => event.type === "response.completed");
+      terminal.response.output[0].id = "chatcmpl-other";
+    }],
+    ["missing in-progress proof", (wireEvents) => {
+      wireEvents.splice(wireEvents.findIndex((event) => event.type === "response.in_progress"), 1);
+    }],
+    ["missing response model proof", (wireEvents) => {
+      for (const event of wireEvents) {
+        if (event.response) delete event.response.model;
+      }
+    }],
+    ["tool starts at index zero", (wireEvents) => {
+      for (const event of wireEvents) {
+        if (event.output_index === 1) event.output_index = 0;
+      }
+      const terminal = wireEvents.find((event) => event.type === "response.completed");
+      terminal.response.output = [terminal.response.output[1], terminal.response.output[0]];
+    }],
+    ["candidate closes before the tool", (wireEvents) => {
+      wireEvents.find(
+        (event) => event.type === "response.function_call_arguments.done",
+      ).sequence_number = 8;
+      const firstClose = wireEvents.findIndex(
+        (event) => event.type === "response.output_text.done",
+      );
+      const candidate = wireEvents.splice(firstClose, 3);
+      const toolDone = wireEvents.findIndex(
+        (event) => event.type === "response.output_item.done" && event.output_index === 1,
+      );
+      wireEvents.splice(toolDone, 0, ...candidate);
+    }],
+    ["a tool starts after the candidate suffix", (wireEvents) => {
+      const model = wireEvents[0].model;
+      const secondTool = {
+        ...functionCall,
+        id: "call_late",
+        call_id: "call_late",
+        name: "late_tool",
+      };
+      const afterTextDone = wireEvents.findIndex(
+        (event) => event.type === "response.output_text.done",
+      ) + 1;
+      wireEvents.splice(afterTextDone, 0,
+        {
+          type: "response.output_item.added",
+          output_index: 2,
+          item: { ...secondTool, status: "in_progress", arguments: "" },
+          model,
+        },
+        {
+          type: "response.function_call_arguments.done",
+          item_id: secondTool.id,
+          output_index: 2,
+          arguments: "{}",
+          model,
+        },
+        {
+          type: "response.output_item.done",
+          output_index: 2,
+          sequence_number: 10,
+          item: secondTool,
+          model,
+        },
+      );
+      const terminal = wireEvents.find((event) => event.type === "response.completed");
+      terminal.response.output.push(secondTool);
+    }],
+    ["candidate terminal does not reset", (wireEvents) => {
+      wireEvents.find(
+        (event) => event.type === "response.output_item.done" && event.output_index === 0,
+      ).sequence_number = 10;
+    }],
+    ["no higher sequence precedes the reset", (wireEvents) => {
+      wireEvents.find(
+        (event) => event.type === "response.output_item.done" && event.output_index === 1,
+      ).sequence_number = 1;
+    }],
+    ["terminal response id does not change", (wireEvents) => {
+      const created = wireEvents.find((event) => event.type === "response.created");
+      const terminal = wireEvents.find((event) => event.type === "response.completed");
+      terminal.response.id = created.response.id;
+    }],
+  ];
+  for (const [name, mutate] of cases) {
+    const source = pinnedAnthropicTerminalOnlyStream(mutate);
+    assert.equal(
+      await transformed(source, { allowTerminalOnlyCandidate: true }, 7),
+      source,
+      name,
+    );
+  }
+});
+
 test("the pinned sequence exception fails open for every adjacent ambiguity", async () => {
   const cases = [
     ["a different reset value", (wireEvents) => {
-      wireEvents[9].sequence_number = 2;
+      wireEvents[10].sequence_number = 2;
     }],
     ["a reset before tool evidence", (wireEvents) => {
-      const [terminal] = wireEvents.splice(9, 1);
+      const [terminal] = wireEvents.splice(10, 1);
       wireEvents.splice(4, 0, terminal);
     }],
     ["a mismatched output index", (wireEvents) => {
-      wireEvents[9].output_index = 1;
+      wireEvents[10].output_index = 1;
     }],
     ["a mismatched item id", (wireEvents) => {
-      wireEvents[9].item = { ...wireEvents[9].item, id: "msg_other" };
+      wireEvents[10].item = { ...wireEvents[10].item, id: "msg_other" };
     }],
     ["visible terminal content", (wireEvents) => {
-      wireEvents[9].item = {
-        ...wireEvents[9].item,
+      wireEvents[10].item = {
+        ...wireEvents[10].item,
         content: [{ type: "output_text", text: "visible", annotations: [] }],
       };
     }],
     ["a reset on a tool item", (wireEvents) => {
-      wireEvents[6].sequence_number = 1;
+      wireEvents[6].sequence_number = 8;
+      wireEvents[7].sequence_number = 1;
     }],
     ["a second terminal reset", (wireEvents) => {
-      wireEvents.splice(10, 0, {
-        ...wireEvents[9],
-        item: { ...wireEvents[9].item },
+      wireEvents.splice(11, 0, {
+        ...wireEvents[10],
+        item: { ...wireEvents[10].item },
       });
     }],
     ["a later event below the retained high-water mark", (wireEvents) => {
-      wireEvents[10].sequence_number = 7;
+      wireEvents[11].sequence_number = 9;
+    }],
+    ["a changed response id without the pinned reset", (wireEvents) => {
+      wireEvents[10].sequence_number = 10;
+    }],
+    ["a changed response id outside the Responses namespace", (wireEvents) => {
+      wireEvents[11].response.id = "chatcmpl-terminal";
+    }],
+    ["a changed response id without an in-progress envelope", (wireEvents) => {
+      wireEvents.splice(1, 1);
     }],
   ];
 
   for (const [name, mutate] of cases) {
     const source = pinnedLiteLlmPhantomToolStream(mutate);
     assert.equal(await transformed(source, {}, 3), source, name);
+  }
+});
+
+test("the pinned LiteLLM model field is consistent across the whole lifecycle", async () => {
+  const cases = [
+    ["a missing event model", (wireEvents) => {
+      delete wireEvents[4].model;
+    }],
+    ["a changed event model", (wireEvents) => {
+      wireEvents[5].model = "another-model";
+    }],
+    ["a non-string event model", (wireEvents) => {
+      wireEvents[3].model = 7;
+    }],
+    ["a mismatched created response model", (wireEvents) => {
+      wireEvents[0].response.model = "another-model";
+    }],
+    ["a missing completed response model", (wireEvents) => {
+      delete wireEvents[11].response.model;
+    }],
+    ["a changed completed response model", (wireEvents) => {
+      wireEvents[11].response.model = "another-model";
+    }],
+  ];
+
+  for (const [name, mutate] of cases) {
+    const source = pinnedLiteLlmPhantomToolStream(mutate);
+    assert.equal(await transformed(source, {}, 4), source, name);
   }
 });
 

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -31,6 +31,11 @@ async function transformed(input, options = {}, chunkSize = 0) {
   return transformedBy(stream, input, chunkSize);
 }
 
+async function transformedDirect(input, options = {}, chunkSize = 0) {
+  const stream = new DeepseekToolMessageCompatTransform(options);
+  return transformedBy(stream, input, chunkSize);
+}
+
 async function transformedBy(stream, input, chunkSize = 0) {
   let output = "";
   stream.setEncoding("utf8");
@@ -344,6 +349,462 @@ function pinnedAnthropicTerminalOnlyStream(mutate) {
   if (mutate) mutate(wireEvents);
   return `${wireEvents.map((event) => block(event)).join("")}data: [DONE]\n\n`;
 }
+
+function historicalDirectDeepseekEvents() {
+  const blank = { ...blankMessage, id: "msg_direct_historical" };
+  const tool = {
+    ...functionCall,
+    id: "call_direct_historical",
+    call_id: "call_direct_historical",
+  };
+  return [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      sequence_number: 1,
+      item: { ...blank, status: "in_progress", content: [] },
+    },
+    {
+      type: "response.content_part.added",
+      item_id: blank.id,
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 2,
+      part: { type: "output_text", text: "", annotations: [] },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 1,
+      sequence_number: 3,
+      item: { ...tool, status: "in_progress", arguments: "" },
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: tool.id,
+      output_index: 1,
+      sequence_number: 4,
+      delta: "{}",
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 1,
+      sequence_number: 5,
+      item: tool,
+    },
+    {
+      type: "response.output_text.done",
+      item_id: blank.id,
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 6,
+      text: "",
+    },
+    {
+      type: "response.content_part.done",
+      item_id: blank.id,
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 7,
+      part: { type: "reasoning_text", reasoning: "private reasoning" },
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      sequence_number: 8,
+      item: blank,
+    },
+    {
+      type: "response.completed",
+      sequence_number: 9,
+      response: {
+        id: "resp_direct_historical",
+        status: "completed",
+        output: [blank, tool],
+      },
+    },
+  ];
+}
+
+function historicalDirectDeepseekStream(mutate) {
+  const wireEvents = historicalDirectDeepseekEvents();
+  if (mutate) mutate(wireEvents);
+  return `${wireEvents.map((event) => block(event)).join("")}data: [DONE]\n\n`;
+}
+
+const currentDirectReasoning =
+  "The user wants me to call codex_router_probe exactly once with value \"ok\", " +
+  "and not answer normally. Let me do that.";
+
+function currentDirectDeepseekEvents() {
+  const model = "deepseek-v4-flash";
+  const responseId = "resp_direct_live_open";
+  const candidate = { ...blankMessage, id: "msg_direct_live" };
+  const tool = {
+    ...functionCall,
+    id: "call_direct_live",
+    call_id: "call_direct_live",
+    name: "codex_router_probe",
+    arguments: "{\"value\":\"ok\"}",
+  };
+  const inProgress = {
+    id: responseId,
+    model,
+    object: "response",
+    status: "in_progress",
+    error: null,
+    output: [],
+  };
+  const events = [
+    { type: "response.created", response: { ...inProgress }, model },
+    { type: "response.in_progress", response: { ...inProgress }, model },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...candidate, status: "in_progress", content: [] },
+      model,
+    },
+    {
+      type: "response.content_part.added",
+      item_id: candidate.id,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+      model,
+    },
+  ];
+  for (const delta of [
+    "The user wants me to call codex_router_probe exactly once ",
+    "with value \"ok\", and not answer normally. ",
+    "Let me do that.",
+  ]) {
+    events.push({
+      type: "response.reasoning_summary_text.delta",
+      item_id: candidate.id,
+      output_index: 0,
+      delta,
+      model,
+    });
+  }
+  events.push(
+    {
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { ...tool, status: "in_progress", arguments: "" },
+      model,
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: tool.id,
+      output_index: 1,
+      delta: "{\"value\":",
+      model,
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: tool.id,
+      output_index: 1,
+      delta: "\"ok\"}",
+      model,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: tool.id,
+      output_index: 1,
+      arguments: tool.arguments,
+      model,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 1,
+      sequence_number: 16,
+      item: tool,
+      model,
+    },
+    {
+      type: "response.output_text.done",
+      item_id: candidate.id,
+      output_index: 0,
+      content_index: 0,
+      text: "",
+      model,
+    },
+    {
+      type: "response.content_part.done",
+      item_id: candidate.id,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "reasoning_text", reasoning: currentDirectReasoning },
+      model,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      sequence_number: 1,
+      item: candidate,
+      model,
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_direct_live_closed",
+        model,
+        object: "response",
+        status: "completed",
+        error: null,
+        output: [
+          {
+            id: "rs_-8853496868378332836",
+            type: "reasoning",
+            status: "completed",
+            role: "assistant",
+            content: [{
+              type: "output_text",
+              text: currentDirectReasoning,
+              annotations: [],
+            }],
+          },
+          {
+            id: "04847f40-ed33-4239-80d2-d392fe38fcc3",
+            type: "message",
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "output_text", annotations: [] }],
+          },
+          tool,
+        ],
+        usage: { input_tokens: 17, output_tokens: 8, total_tokens: 25 },
+      },
+      model,
+    },
+  );
+  return events;
+}
+
+function currentDirectDeepseekStream(mutate) {
+  const wireEvents = currentDirectDeepseekEvents();
+  if (mutate) mutate(wireEvents);
+  return `${wireEvents.map((event) => block(event)).join("")}data: [DONE]\n\n`;
+}
+
+test("restores the merged direct-DeepSeek historical no-prelude regression", async () => {
+  const source = historicalDirectDeepseekStream();
+  const output = await transformedDirect(source, {}, 3);
+  const seen = events(output);
+  const tool = historicalDirectDeepseekEvents()[2].item;
+
+  assert.equal(output.includes("msg_direct_historical"), false);
+  assert.equal(output.includes("private reasoning"), false);
+  assert.deepEqual(
+    seen.filter((event) => eventItem(event) === tool.id)
+      .map((event) => [event.type, event.output_index, event.sequence_number]),
+    [
+      ["response.output_item.added", 0, 3],
+      ["response.function_call_arguments.delta", 0, 4],
+      ["response.output_item.done", 0, 5],
+    ],
+  );
+  assert.deepEqual(
+    seen.find((event) => event.type === "response.completed").response.output,
+    [{ ...tool, status: "completed", arguments: "{}" }],
+  );
+});
+
+test("normalizes current direct-DeepSeek reasoning and removes only the blank slot", async () => {
+  const sourceEvents = currentDirectDeepseekEvents();
+  const source = currentDirectDeepseekStream();
+  const output = await transformedDirect(source, {}, 2);
+  const seen = events(output);
+  const terminal = sourceEvents.at(-1).response;
+  const incomingReasoning = terminal.output[0];
+  const incomingBlank = terminal.output[1];
+  const tool = terminal.output[2];
+  const normalizedReasoning = {
+    id: incomingReasoning.id,
+    type: "reasoning",
+    status: "completed",
+    summary: [{ type: "summary_text", text: currentDirectReasoning }],
+  };
+
+  assert.equal(output.includes("msg_direct_live"), false);
+  assert.equal(output.includes(incomingBlank.id), false);
+  const lifecycle = seen.filter((event) => (
+    eventItem(event) === normalizedReasoning.id || eventItem(event) === tool.id
+  ));
+  assert.deepEqual(
+    lifecycle.map((event) => [event.type, eventItem(event), event.output_index]),
+    [
+      ["response.output_item.added", normalizedReasoning.id, 0],
+      ["response.reasoning_summary_part.added", normalizedReasoning.id, 0],
+      ["response.reasoning_summary_text.delta", normalizedReasoning.id, 0],
+      ["response.reasoning_summary_text.delta", normalizedReasoning.id, 0],
+      ["response.reasoning_summary_text.delta", normalizedReasoning.id, 0],
+      ["response.reasoning_summary_text.done", normalizedReasoning.id, 0],
+      ["response.reasoning_summary_part.done", normalizedReasoning.id, 0],
+      ["response.output_item.done", normalizedReasoning.id, 0],
+      ["response.output_item.added", tool.id, 1],
+      ["response.function_call_arguments.delta", tool.id, 1],
+      ["response.function_call_arguments.delta", tool.id, 1],
+      ["response.function_call_arguments.done", tool.id, 1],
+      ["response.output_item.done", tool.id, 1],
+    ],
+  );
+  assert.equal(
+    lifecycle
+      .filter((event) => event.type === "response.reasoning_summary_text.delta")
+      .map((event) => event.delta)
+      .join(""),
+    currentDirectReasoning,
+  );
+  assert.deepEqual(
+    seen.filter((event) => event.sequence_number !== undefined)
+      .map((event) => event.sequence_number),
+    [16],
+  );
+  const completed = seen.find((event) => event.type === "response.completed").response;
+  assert.deepEqual(completed.output, [normalizedReasoning, tool]);
+  assert.deepEqual(completed.usage, terminal.usage);
+});
+
+test("current direct-DeepSeek grammar is provider-scoped", async () => {
+  const source = currentDirectDeepseekStream();
+  const direct = translatedToolMessageCompatTransform(
+    { id: "deepseek", protocol: "openai" },
+    "text/event-stream",
+  );
+  const translated = translatedToolMessageCompatTransform(
+    { id: "opencode-go", protocol: "openai" },
+    "text/event-stream",
+  );
+  const repaired = await transformedBy(direct, source, 1);
+  assert.notEqual(repaired, source);
+  assert.equal(repaired.includes("msg_direct_live"), false);
+  assert.equal(await transformedBy(translated, source, 1), source);
+});
+
+test("current direct-DeepSeek repair fails open on adjacent reasoning and identity shapes", async (t) => {
+  const mutations = new Map([
+    ["mismatched reasoning close", (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.content_part.done")
+        .part.reasoning += " changed";
+    }],
+    ["mismatched terminal reasoning", (wireEvents) => {
+      wireEvents.at(-1).response.output[0].content[0].text = "different";
+    }],
+    ["missing terminal reasoning", (wireEvents) => {
+      wireEvents.at(-1).response.output.shift();
+    }],
+    ["extra terminal reasoning", (wireEvents) => {
+      wireEvents.at(-1).response.output.unshift({
+        ...wireEvents.at(-1).response.output[0],
+        id: "rs_extra",
+      });
+    }],
+    ["reasoning id collision", (wireEvents) => {
+      wireEvents.at(-1).response.output[0].id = "call_direct_live";
+    }],
+    ["terminal blank id collision", (wireEvents) => {
+      wireEvents.at(-1).response.output[1].id = "msg_direct_live";
+    }],
+    ["wrong lifecycle ordering", (wireEvents) => {
+      const done = wireEvents.findIndex(
+        (event) => event.type === "response.function_call_arguments.done",
+      );
+      [wireEvents[done], wireEvents[done + 1]] = [wireEvents[done + 1], wireEvents[done]];
+    }],
+    ["visible streamed text", (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.output_text.done").text = "visible";
+    }],
+    ["visible terminal blank", (wireEvents) => {
+      wireEvents.at(-1).response.output[1].content[0].text = "visible";
+    }],
+    ["changed model provenance", (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.output_text.done").model = "other";
+    }],
+    ["changed response model provenance", (wireEvents) => {
+      wireEvents.at(-1).response.model = "other";
+    }],
+    ["unexpected lifecycle field", (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.output_text.done")
+        .unexpected = true;
+    }],
+    ["missing in-progress envelope", (wireEvents) => {
+      wireEvents.splice(1, 1);
+    }],
+    ["wrong terminal blank sequence", (wireEvents) => {
+      wireEvents.find((event) => (
+        event.type === "response.output_item.done" && event.output_index === 0
+      )).sequence_number = 2;
+    }],
+    ["wrong tool terminal sequence", (wireEvents) => {
+      wireEvents.find((event) => (
+        event.type === "response.output_item.done" && event.output_index === 1
+      )).sequence_number = 15;
+    }],
+    ["mismatched tool arguments", (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.function_call_arguments.done")
+        .arguments = "{}";
+    }],
+    ["mismatched terminal tool identity", (wireEvents) => {
+      wireEvents.at(-1).response.output[2] = {
+        ...wireEvents.at(-1).response.output[2],
+        call_id: "other_call",
+      };
+    }],
+    ["unchanged terminal response id", (wireEvents) => {
+      wireEvents.at(-1).response.id = "resp_direct_live_open";
+    }],
+    ["extra event after terminal envelope", (wireEvents) => {
+      wireEvents.push({
+        type: "response.output_item.added",
+        output_index: 2,
+        item: {
+          id: "msg_after_terminal",
+          type: "message",
+          status: "in_progress",
+          role: "assistant",
+          content: [],
+        },
+        model: "deepseek-v4-flash",
+      });
+    }],
+  ]);
+  for (const [name, mutate] of mutations) {
+    await t.test(name, async () => {
+      const input = currentDirectDeepseekStream(mutate);
+      assert.equal(await transformedDirect(input, {}, 1), input);
+    });
+  }
+});
+
+test("historical direct-DeepSeek grammar remains exact and bounded", async () => {
+  for (const mutate of [
+    (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.content_part.done")
+        .part.reasoning = "";
+    },
+    (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.output_text.done").text = "visible";
+    },
+    (wireEvents) => {
+      wireEvents.at(-1).response.output[0].id = "changed_blank";
+    },
+    (wireEvents) => {
+      wireEvents.find((event) => event.type === "response.output_item.done")
+        .sequence_number = 6;
+    },
+  ]) {
+    const input = historicalDirectDeepseekStream(mutate);
+    assert.equal(await transformedDirect(input, {}, 1), input);
+  }
+  const source = historicalDirectDeepseekStream();
+  assert.equal(
+    await transformedDirect(source, {
+      maxCandidateBytes: 64,
+      maxCandidateMs: 60_000,
+    }),
+    source,
+  );
+});
 
 test("repairs LiteLLM 1.96.0's pinned terminal sequence reset", async () => {
   const source = pinnedLiteLlmPhantomToolStream();
@@ -1007,7 +1468,7 @@ test("timer expiry releases pending bytes and subsequent chunks immediately", as
     output_index: 1,
     item: { ...functionCall, status: "in_progress", arguments: "" },
   });
-  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 5 });
+  const stream = new TranslatedToolMessageCompatTransform({ maxCandidateMs: 5 });
   let output = "";
   stream.setEncoding("utf8");
   stream.on("data", (chunk) => { output += chunk; });
@@ -1301,7 +1762,7 @@ test("timer expiry also releases an incomplete buffered frame", async () => {
     item: { ...blankMessage, status: "in_progress", content: [] },
   });
   const partial = "event: response.output_item.added\ndata: {\"type\":";
-  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 5 });
+  const stream = new TranslatedToolMessageCompatTransform({ maxCandidateMs: 5 });
   let output = "";
   stream.setEncoding("utf8");
   stream.on("data", (chunk) => { output += chunk; });
@@ -1319,7 +1780,7 @@ test("destroying a pending stream clears its hold without later output", async (
     output_index: 0,
     item: { ...blankMessage, status: "in_progress", content: [] },
   });
-  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 5 });
+  const stream = new TranslatedToolMessageCompatTransform({ maxCandidateMs: 5 });
   let output = "";
   stream.on("data", (chunk) => { output += chunk.toString("utf8"); });
   stream.write(created + start);
@@ -1932,12 +2393,13 @@ test("a failed attempt cannot poison a fresh retry transform", async () => {
   let retryOutput = "";
   retry.setEncoding("utf8");
   retry.on("data", (chunk) => { retryOutput += chunk; });
-  retry.end(phantomToolStream());
+  retry.end(historicalDirectDeepseekStream());
   await once(retry, "end");
-  assert.equal(retryOutput.includes(blankMessage.id), false);
+  const historicalTerminal = historicalDirectDeepseekEvents().at(-1).response;
+  assert.equal(retryOutput.includes(historicalTerminal.output[0].id), false);
   assert.deepEqual(
     events(retryOutput).find((event) => event.type === "response.completed").response.output,
-    [functionCall],
+    [historicalTerminal.output[1]],
   );
 });
 
@@ -2315,9 +2777,8 @@ test("factory is translated-protocol scoped and returns fresh retry transforms",
   const provider = { id: "deepseek" };
   const first = translatedToolMessageCompatTransform(provider, "text/event-stream");
   const retry = translatedToolMessageCompatTransform(provider, "text/event-stream");
-  assert.ok(first instanceof TranslatedToolMessageCompatTransform);
   assert.ok(first instanceof DeepseekToolMessageCompatTransform);
-  assert.ok(retry instanceof TranslatedToolMessageCompatTransform);
+  assert.ok(retry instanceof DeepseekToolMessageCompatTransform);
   assert.notEqual(first, retry);
   for (const translated of [
     { id: "opencode-go" },
@@ -2344,7 +2805,7 @@ test("factory is translated-protocol scoped and returns fresh retry transforms",
   assert.equal(translatedToolMessageCompatTransform(provider, "text/plain"), undefined);
   assert.ok(
     deepseekToolMessageCompatTransform("deepseek", "TEXT/EVENT-STREAM; charset=utf-8")
-      instanceof TranslatedToolMessageCompatTransform,
+      instanceof DeepseekToolMessageCompatTransform,
   );
   assert.equal(
     deepseekToolMessageCompatTransform("opencode-go", "text/event-stream"),

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -4,7 +4,10 @@ import test from "node:test";
 
 import {
   DeepseekToolMessageCompatTransform,
+  TranslatedToolMessageCompatTransform,
+  TranslatedToolMessageJsonCompatTransform,
   deepseekToolMessageCompatTransform,
+  translatedToolMessageCompatTransform,
 } from "../src/deepseek-tool-message-compat.mjs";
 
 function block(event, newline = "\n") {
@@ -20,7 +23,25 @@ function events(text) {
 }
 
 async function transformed(input, options = {}, chunkSize = 0) {
-  const stream = new DeepseekToolMessageCompatTransform(options);
+  const stream = new TranslatedToolMessageCompatTransform(options);
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  if (chunkSize > 0) {
+    const bytes = Buffer.from(input);
+    for (let at = 0; at < bytes.length; at += chunkSize) {
+      stream.write(bytes.subarray(at, at + chunkSize));
+    }
+  } else {
+    stream.write(input);
+  }
+  stream.end();
+  await once(stream, "end");
+  return output;
+}
+
+async function transformedJson(input, options = {}, chunkSize = 0) {
+  const stream = new TranslatedToolMessageJsonCompatTransform(options);
   let output = "";
   stream.setEncoding("utf8");
   stream.on("data", (chunk) => { output += chunk; });
@@ -54,7 +75,10 @@ const functionCall = {
   status: "completed",
 };
 
-function phantomToolStream(newline = "\n") {
+function phantomToolStream(
+  newline = "\n",
+  { terminalBlank = blankMessage, terminalReasoning = "" } = {},
+) {
   return [
     block({
       type: "response.output_item.added",
@@ -103,7 +127,7 @@ function phantomToolStream(newline = "\n") {
       output_index: 0,
       content_index: 0,
       sequence_number: 7,
-      part: { type: "reasoning_text", reasoning: "private reasoning" },
+      part: { type: "reasoning_text", reasoning: terminalReasoning },
     }, newline),
     block({
       type: "response.output_item.done",
@@ -114,7 +138,7 @@ function phantomToolStream(newline = "\n") {
     block({
       type: "response.completed",
       sequence_number: 9,
-      response: { id: "resp_1", status: "completed", output: [blankMessage, functionCall] },
+      response: { id: "resp_1", status: "completed", output: [terminalBlank, functionCall] },
     }, newline),
     `data: [DONE]${newline}${newline}`,
   ].join("");
@@ -124,7 +148,6 @@ test("removes DeepSeek's confirmed blank tool message and compacts indexes", asy
   const output = await transformed(phantomToolStream(), {}, 7);
   const seen = events(output);
   assert.equal(output.includes(blankMessage.id), false);
-  assert.equal(output.includes("private reasoning"), false);
   assert.match(output, /data: \[DONE\]/);
   const toolEvents = seen.filter((event) => eventItem(event) === functionCall.id);
   assert.ok(toolEvents.length >= 3);
@@ -134,6 +157,50 @@ test("removes DeepSeek's confirmed blank tool message and compacts indexes", asy
     seen.find((event) => event.type === "response.completed").response.output,
     [functionCall],
   );
+});
+
+test("matches the pinned LiteLLM bridge's changed terminal id and null text", async () => {
+  for (const content of [
+    [{ type: "output_text", text: null, annotations: [] }],
+    [{ type: "output_text", annotations: [] }],
+  ]) {
+    const terminalBlank = {
+      ...blankMessage,
+      id: "chatcmpl_probe",
+      content,
+    };
+    const output = await transformed(phantomToolStream("\n", { terminalBlank }), {}, 3);
+    const seen = events(output);
+    assert.equal(output.includes(blankMessage.id), false);
+    assert.equal(output.includes(terminalBlank.id), false);
+    assert.deepEqual(
+      seen.find((event) => event.type === "response.completed").response.output,
+      [functionCall],
+    );
+  }
+});
+
+test("preserves real reasoning and ambiguous terminal identity byte-for-byte", async () => {
+  const reasoning = phantomToolStream("\n", { terminalReasoning: "keep this reasoning" });
+  assert.equal(await transformed(reasoning), reasoning);
+
+  const collidingId = phantomToolStream("\n", {
+    terminalBlank: {
+      ...blankMessage,
+      id: functionCall.id,
+      content: [{ type: "output_text", text: null, annotations: [] }],
+    },
+  });
+  assert.equal(await transformed(collidingId), collidingId);
+
+  const visibleTerminal = phantomToolStream("\n", {
+    terminalBlank: {
+      ...blankMessage,
+      id: "chatcmpl_visible",
+      content: [{ type: "output_text", text: "real text", annotations: [] }],
+    },
+  });
+  assert.equal(await transformed(visibleTerminal), visibleTerminal);
 });
 
 function eventItem(event) {
@@ -220,6 +287,114 @@ test("compacts separate reasoning and multiple later output items consistently",
   );
 });
 
+test("removes multiple independently confirmed bridge messages in one stream", async () => {
+  const firstBlank = { ...blankMessage, id: "msg_blank_one" };
+  const secondBlank = { ...blankMessage, id: "msg_blank_two" };
+  const firstTool = { ...functionCall, id: "call_one", call_id: "call_one" };
+  const secondTool = { ...functionCall, id: "call_two", call_id: "call_two" };
+  const reasoning = { id: "rs_between", type: "reasoning", summary: [] };
+  const source = [
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      sequence_number: 1,
+      item: { ...firstBlank, status: "in_progress", content: [] },
+    }),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      sequence_number: 2,
+      item: { ...firstTool, status: "in_progress", arguments: "" },
+    }),
+    block({
+      type: "response.function_call_arguments.delta",
+      item_id: firstTool.id,
+      output_index: 1,
+      sequence_number: 3,
+      delta: "{}",
+    }),
+    block({
+      type: "response.output_item.done",
+      output_index: 1,
+      sequence_number: 4,
+      item: firstTool,
+    }),
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      sequence_number: 5,
+      item: firstBlank,
+    }),
+    block({
+      type: "response.output_item.added",
+      output_index: 2,
+      sequence_number: 6,
+      item: { ...secondBlank, status: "in_progress", content: [] },
+    }),
+    block({
+      type: "response.output_item.added",
+      output_index: 3,
+      sequence_number: 7,
+      item: reasoning,
+    }),
+    block({
+      type: "response.output_item.done",
+      output_index: 3,
+      sequence_number: 8,
+      item: reasoning,
+    }),
+    block({
+      type: "response.output_item.added",
+      output_index: 4,
+      sequence_number: 9,
+      item: { ...secondTool, status: "in_progress", arguments: "" },
+    }),
+    block({
+      type: "response.function_call_arguments.done",
+      item_id: secondTool.id,
+      output_index: 4,
+      sequence_number: 10,
+      arguments: "{}",
+    }),
+    block({
+      type: "response.output_item.done",
+      output_index: 4,
+      sequence_number: 11,
+      item: secondTool,
+    }),
+    block({
+      type: "response.output_item.done",
+      output_index: 2,
+      sequence_number: 12,
+      item: secondBlank,
+    }),
+    block({
+      type: "response.completed",
+      sequence_number: 13,
+      response: {
+        id: "resp_multiple",
+        output: [firstBlank, firstTool, secondBlank, reasoning, secondTool],
+      },
+    }),
+  ].join("");
+
+  const seen = events(await transformed(source, {}, 5));
+  assert.deepEqual(
+    seen
+      .filter((event) => event.type === "response.output_item.added")
+      .map((event) => [event.item.id, event.output_index]),
+    [[firstTool.id, 0], [reasoning.id, 1], [secondTool.id, 2]],
+  );
+  assert.deepEqual(
+    seen.map((event) => event.sequence_number),
+    [2, 3, 4, 7, 8, 9, 10, 11, 13],
+  );
+  assert.deepEqual(
+    seen.find((event) => event.type === "response.completed").response.output,
+    [firstTool, reasoning, secondTool],
+  );
+});
+
 test("byte budget expiry releases the entire stream unchanged", async () => {
   const input = phantomToolStream();
   assert.equal(
@@ -256,6 +431,13 @@ test("malformed and duplicate candidate lifecycles fail open", async () => {
   });
   const malformed = "event: response.output_item.added\ndata: {not-json}\n\n";
   assert.equal(await transformed(start + malformed), start + malformed);
+
+  const duplicate = block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { ...blankMessage, status: "in_progress", content: [] },
+  });
+  assert.equal(await transformed(start + duplicate), start + duplicate);
 
   const second = block({
     type: "response.output_item.added",
@@ -404,6 +586,26 @@ test("tool proof requires a valid added lifecycle and matching terminal order", 
     output_index: 1,
     item: { ...functionCall, status: "in_progress" },
   });
+  const malformedTool = block({
+    type: "response.output_item.added",
+    output_index: 1,
+    item: { ...functionCall, name: "", status: "in_progress" },
+  });
+  assert.equal(
+    await transformed(start + malformedTool + blankDone),
+    start + malformedTool + blankDone,
+  );
+
+  const changedToolDone = block({
+    type: "response.output_item.done",
+    output_index: 1,
+    item: { ...functionCall, name: "different_tool" },
+  });
+  assert.equal(
+    await transformed(start + toolAdded + changedToolDone + blankDone),
+    start + toolAdded + changedToolDone + blankDone,
+  );
+
   const wrongOrder = block({
     type: "response.completed",
     response: { output: [functionCall, blankMessage] },
@@ -411,6 +613,17 @@ test("tool proof requires a valid added lifecycle and matching terminal order", 
   assert.equal(
     await transformed(start + toolAdded + blankDone + wrongOrder),
     start + toolAdded + blankDone + wrongOrder,
+  );
+
+  const changedTool = block({
+    type: "response.completed",
+    response: {
+      output: [blankMessage, { ...functionCall, name: "different_tool" }],
+    },
+  });
+  assert.equal(
+    await transformed(start + toolAdded + blankDone + changedTool),
+    start + toolAdded + blankDone + changedTool,
   );
 });
 
@@ -498,14 +711,151 @@ test("post-suppression frames without shifted indexes remain byte-identical", as
   assert.ok(output.endsWith(untouched));
 });
 
-test("factory is provider-scoped, SSE-only, and returns fresh retry transforms", () => {
-  const first = deepseekToolMessageCompatTransform("deepseek", "text/event-stream");
-  const retry = deepseekToolMessageCompatTransform("deepseek", "text/event-stream");
-  assert.ok(first instanceof DeepseekToolMessageCompatTransform);
-  assert.ok(retry instanceof DeepseekToolMessageCompatTransform);
-  assert.notEqual(first, retry);
-  for (const provider of ["opencode-go", "commandcode", "qwen-plan", "zai-api"]) {
-    assert.equal(deepseekToolMessageCompatTransform(provider, "text/event-stream"), undefined);
+test("non-streaming responses remove only exact empty messages proven by tool traffic", async () => {
+  const secondBlank = {
+    ...blankMessage,
+    id: "msg_second",
+    content: [{ type: "output_text", text: null, annotations: [] }],
+    phase: null,
+  };
+  const secondTool = { ...functionCall, id: "call_second", call_id: "call_second" };
+  const reasoning = { id: "rs_json", type: "reasoning", summary: [{ type: "summary_text", text: "kept" }] };
+  const visible = {
+    id: "msg_visible",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "done", annotations: [] }],
+  };
+  const payload = {
+    id: "resp_json",
+    object: "response",
+    error: null,
+    output: [blankMessage, reasoning, functionCall, secondBlank, secondTool, visible],
+    usage: { input_tokens: 7, output_tokens: 3, total_tokens: 10 },
+  };
+  const result = JSON.parse(await transformedJson(JSON.stringify(payload, null, 2), {}, 7));
+  assert.deepEqual(result, {
+    ...payload,
+    output: [reasoning, functionCall, secondTool, visible],
+  });
+});
+
+test("non-streaming ambiguous, malformed, and oversized bodies fail open byte-for-byte", async () => {
+  const secondBlank = { ...blankMessage, id: "msg_second" };
+  const consecutive = JSON.stringify({
+    output: [blankMessage, secondBlank, functionCall],
+  }, null, 2);
+  assert.equal(await transformedJson(consecutive), consecutive);
+
+  const visible = JSON.stringify({
+    output: [
+      blankMessage,
+      {
+        id: "msg_visible",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "real text" }],
+      },
+      functionCall,
+    ],
+  }, null, 2);
+  assert.equal(await transformedJson(visible), visible);
+
+  const malformed = "{not-json";
+  assert.equal(await transformedJson(malformed), malformed);
+
+  for (const output of [
+    [{ ...blankMessage, id: undefined }, functionCall],
+    [blankMessage, { ...functionCall, name: "" }],
+    [blankMessage, { ...functionCall, call_id: undefined }],
+    [
+      { ...blankMessage, content: [{ type: "refusal", refusal: "kept" }] },
+      functionCall,
+    ],
+  ]) {
+    const malformedItems = JSON.stringify({ output }, null, 2);
+    assert.equal(await transformedJson(malformedItems), malformedItems);
   }
-  assert.equal(deepseekToolMessageCompatTransform("deepseek", "application/json"), undefined);
+
+  const incomplete = JSON.stringify({
+    object: "response",
+    status: "incomplete",
+    output: [blankMessage, functionCall],
+  }, null, 2);
+  assert.equal(await transformedJson(incomplete), incomplete);
+
+  const oversized = JSON.stringify({
+    output: [blankMessage, functionCall],
+    opaque: "x".repeat(256),
+  });
+  assert.equal(await transformedJson(oversized, { maxBytes: 64 }, 11), oversized);
+
+  const invalidUtf8 = Buffer.from('{"output":"\xc0"}', "latin1");
+  const stream = new TranslatedToolMessageJsonCompatTransform();
+  const chunks = [];
+  stream.on("data", (chunk) => { chunks.push(chunk); });
+  stream.end(invalidUtf8);
+  await once(stream, "end");
+  assert.deepEqual(Buffer.concat(chunks), invalidUtf8);
+});
+
+test("a slow non-streaming body releases pending bytes and becomes passthrough", async () => {
+  const source = JSON.stringify({ output: [blankMessage, functionCall] });
+  const split = Math.floor(source.length / 2);
+  const stream = new TranslatedToolMessageJsonCompatTransform({ maxMs: 5 });
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  stream.write(source.slice(0, split));
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(output, source.slice(0, split));
+  stream.end(source.slice(split));
+  await once(stream, "end");
+  assert.equal(output, source);
+});
+
+test("factory is translated-protocol scoped and returns fresh retry transforms", () => {
+  const provider = { id: "deepseek" };
+  const first = translatedToolMessageCompatTransform(provider, "text/event-stream");
+  const retry = translatedToolMessageCompatTransform(provider, "text/event-stream");
+  assert.ok(first instanceof TranslatedToolMessageCompatTransform);
+  assert.ok(first instanceof DeepseekToolMessageCompatTransform);
+  assert.ok(retry instanceof TranslatedToolMessageCompatTransform);
+  assert.notEqual(first, retry);
+  for (const translated of [
+    { id: "opencode-go" },
+    { id: "commandcode", protocol: "anthropic" },
+    { id: "generic", protocol: "openai" },
+  ]) {
+    assert.ok(
+      translatedToolMessageCompatTransform(translated, "text/event-stream")
+        instanceof TranslatedToolMessageCompatTransform,
+    );
+  }
+  assert.ok(
+    translatedToolMessageCompatTransform(provider, "application/json; charset=utf-8")
+      instanceof TranslatedToolMessageJsonCompatTransform,
+  );
+  assert.equal(
+    translatedToolMessageCompatTransform(
+      { id: "opencode-go-responses", protocol: "openai-responses" },
+      "text/event-stream",
+    ),
+    undefined,
+  );
+  assert.equal(translatedToolMessageCompatTransform(undefined, "text/event-stream"), undefined);
+  assert.equal(translatedToolMessageCompatTransform(provider, "text/plain"), undefined);
+  assert.ok(
+    deepseekToolMessageCompatTransform("deepseek", "TEXT/EVENT-STREAM; charset=utf-8")
+      instanceof TranslatedToolMessageCompatTransform,
+  );
+  assert.equal(
+    deepseekToolMessageCompatTransform("opencode-go", "text/event-stream"),
+    undefined,
+  );
+  assert.equal(
+    deepseekToolMessageCompatTransform("deepseek", "application/json"),
+    undefined,
+  );
 });

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -220,6 +220,188 @@ function phantomToolStream(
   ].join("");
 }
 
+// LiteLLM 1.96.0 emits this non-monotonic sequence on its
+// Chat-Completions -> Responses bridge. In particular, the terminal empty
+// message item is hard-coded to sequence_number=1 after higher-numbered tool
+// events, while its output_text/content_part closes are unnumbered.
+function pinnedLiteLlmPhantomEvents() {
+  const inProgressResponse = {
+    id: "resp_pinned_litellm",
+    object: "response",
+    status: "in_progress",
+    error: null,
+    output: [],
+  };
+  return [
+    {
+      type: "response.created",
+      sequence_number: 1,
+      response: { ...inProgressResponse },
+    },
+    {
+      type: "response.in_progress",
+      sequence_number: 2,
+      response: { ...inProgressResponse },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      sequence_number: 3,
+      item: { ...blankMessage, status: "in_progress", content: [] },
+    },
+    {
+      type: "response.content_part.added",
+      item_id: blankMessage.id,
+      output_index: 0,
+      content_index: 0,
+      sequence_number: 4,
+      part: { type: "output_text", text: "", annotations: [] },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 1,
+      sequence_number: 5,
+      item: { ...functionCall, status: "in_progress", arguments: "" },
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: functionCall.id,
+      output_index: 1,
+      sequence_number: 6,
+      delta: "{}",
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 1,
+      sequence_number: 7,
+      item: { ...functionCall },
+    },
+    {
+      type: "response.output_text.done",
+      item_id: blankMessage.id,
+      output_index: 0,
+      content_index: 0,
+      text: "",
+    },
+    {
+      type: "response.content_part.done",
+      item_id: blankMessage.id,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      sequence_number: 1,
+      item: { ...blankMessage },
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: inProgressResponse.id,
+        object: "response",
+        status: "completed",
+        error: null,
+        output: [{ ...blankMessage }, { ...functionCall }],
+      },
+    },
+  ];
+}
+
+function pinnedLiteLlmPhantomToolStream(mutate) {
+  const wireEvents = pinnedLiteLlmPhantomEvents();
+  if (mutate) mutate(wireEvents);
+  return `${wireEvents.map((event) => block(event)).join("")}data: [DONE]\n\n`;
+}
+
+test("repairs LiteLLM 1.96.0's pinned terminal sequence reset", async () => {
+  const source = pinnedLiteLlmPhantomToolStream();
+  const output = await transformed(source, {}, 5);
+  const seen = events(output);
+
+  assert.equal(output.includes(blankMessage.id), false);
+  assert.deepEqual(
+    seen.filter((event) => eventItem(event) === functionCall.id)
+      .map((event) => [event.type, event.output_index, event.sequence_number]),
+    [
+      ["response.output_item.added", 0, 5],
+      ["response.function_call_arguments.delta", 0, 6],
+      ["response.output_item.done", 0, 7],
+    ],
+  );
+  assert.deepEqual(
+    seen.find((event) => event.type === "response.completed").response.output,
+    [functionCall],
+  );
+});
+
+test("the pinned sequence exception fails open for every adjacent ambiguity", async () => {
+  const cases = [
+    ["a different reset value", (wireEvents) => {
+      wireEvents[9].sequence_number = 2;
+    }],
+    ["a reset before tool evidence", (wireEvents) => {
+      const [terminal] = wireEvents.splice(9, 1);
+      wireEvents.splice(4, 0, terminal);
+    }],
+    ["a mismatched output index", (wireEvents) => {
+      wireEvents[9].output_index = 1;
+    }],
+    ["a mismatched item id", (wireEvents) => {
+      wireEvents[9].item = { ...wireEvents[9].item, id: "msg_other" };
+    }],
+    ["visible terminal content", (wireEvents) => {
+      wireEvents[9].item = {
+        ...wireEvents[9].item,
+        content: [{ type: "output_text", text: "visible", annotations: [] }],
+      };
+    }],
+    ["a reset on a tool item", (wireEvents) => {
+      wireEvents[6].sequence_number = 1;
+    }],
+    ["a second terminal reset", (wireEvents) => {
+      wireEvents.splice(10, 0, {
+        ...wireEvents[9],
+        item: { ...wireEvents[9].item },
+      });
+    }],
+    ["a later event below the retained high-water mark", (wireEvents) => {
+      wireEvents[10].sequence_number = 7;
+    }],
+  ];
+
+  for (const [name, mutate] of cases) {
+    const source = pinnedLiteLlmPhantomToolStream(mutate);
+    assert.equal(await transformed(source, {}, 3), source, name);
+  }
+});
+
+test("a reasoning terminal cannot use the pinned candidate reset", async () => {
+  const reasoning = {
+    id: "rs_reset",
+    type: "reasoning",
+    status: "completed",
+    summary: [],
+  };
+  const source = [
+    responseCreated("resp_reasoning_reset", { sequenceNumber: 1 }),
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      sequence_number: 2,
+      item: { ...reasoning, status: "in_progress" },
+    }),
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      sequence_number: 1,
+      item: reasoning,
+    }),
+  ].join("");
+  assert.equal(await transformed(source), source);
+});
+
 test("removes DeepSeek's confirmed blank tool message and compacts indexes", async () => {
   const output = await transformed(phantomToolStream(), {}, 7);
   const seen = events(output);

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -350,6 +350,53 @@ function pinnedAnthropicTerminalOnlyStream(mutate) {
   return `${wireEvents.map((event) => block(event)).join("")}data: [DONE]\n\n`;
 }
 
+function pinnedAnthropicTerminalOnlyMultiToolStream() {
+  const secondTool = {
+    ...functionCall,
+    id: "call_second",
+    call_id: "call_second",
+    name: "second_tool",
+  };
+  const source = pinnedAnthropicTerminalOnlyStream((wireEvents) => {
+    const model = wireEvents[0].model;
+    const firstCandidateClose = wireEvents.findIndex(
+      (event) => event.type === "response.output_text.done",
+    );
+    wireEvents.splice(firstCandidateClose, 0,
+      {
+        type: "response.output_item.added",
+        output_index: 2,
+        item: { ...secondTool, status: "in_progress", arguments: "" },
+        model,
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: secondTool.id,
+        output_index: 2,
+        delta: "{}",
+        model,
+      },
+      {
+        type: "response.function_call_arguments.done",
+        item_id: secondTool.id,
+        output_index: 2,
+        arguments: "{}",
+        model,
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 2,
+        sequence_number: 10,
+        item: secondTool,
+        model,
+      },
+    );
+    const terminal = wireEvents.find((event) => event.type === "response.completed");
+    terminal.response.output.push(secondTool);
+  });
+  return { source, secondTool };
+}
+
 function historicalDirectDeepseekEvents() {
   const blank = { ...blankMessage, id: "msg_direct_historical" };
   const tool = {
@@ -875,6 +922,50 @@ test("direct DeepSeek watchdog measures inactivity rather than total capture tim
   assert.notEqual(output, source);
 });
 
+test("direct DeepSeek absolute deadline bounds an otherwise active capture", async () => {
+  const absoluteTimeout = 1_000;
+  const frames = currentDirectDeepseekEvents().slice(0, 5).map((event) => block(event));
+  const stream = new DeepseekToolMessageCompatTransform({
+    maxCandidateMs: 5_000,
+    maxCaptureMs: absoluteTimeout,
+  });
+  let input = frames.join("");
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  stream.write(input);
+
+  let interval;
+  const released = new Promise((resolve, reject) => {
+    const guard = setTimeout(
+      () => reject(new Error("absolute capture deadline did not release the stream")),
+      absoluteTimeout * 3,
+    );
+    stream.on("data", () => {
+      if (!output.includes("msg_direct_live")) return;
+      clearTimeout(guard);
+      resolve();
+    });
+  });
+  const deltaTemplate = currentDirectDeepseekEvents()[4];
+  interval = setInterval(() => {
+    const next = block({ ...deltaTemplate, delta: "still active" });
+    input += next;
+    stream.write(next);
+  }, 100);
+
+  try {
+    await released;
+  } finally {
+    clearInterval(interval);
+  }
+  const tail = "opaque bytes after absolute release";
+  input += tail;
+  stream.end(tail);
+  await once(stream, "end");
+  assert.equal(output, input);
+});
+
 test("direct DeepSeek watchdog fails open after one inactive gap", async () => {
   const frames = historicalDirectDeepseekEvents().map((event) => block(event));
   const source = `${frames.join("")}data: [DONE]\n\n`;
@@ -904,16 +995,26 @@ test("direct DeepSeek watchdog releases an incomplete frame byte-for-byte", asyn
   assert.equal(output, start + partial);
 });
 
-test("destroying a pending direct DeepSeek capture cancels its watchdog", async () => {
+test("destroying a pending direct DeepSeek capture cancels both timers", async () => {
   const start = block(historicalDirectDeepseekEvents()[0]);
-  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 20 });
+  const stream = new DeepseekToolMessageCompatTransform({
+    maxCandidateMs: 20,
+    maxCaptureMs: 25,
+  });
   let output = "";
+  let latePushes = 0;
+  const push = stream.push.bind(stream);
+  stream.push = (...args) => {
+    latePushes += 1;
+    return push(...args);
+  };
   stream.on("data", (chunk) => { output += chunk.toString("utf8"); });
   stream.write(start);
   stream.destroy();
   await once(stream, "close");
   await new Promise((resolve) => setTimeout(resolve, 60));
   assert.equal(output, "");
+  assert.equal(latePushes, 0);
 });
 
 test("SSE field parsing removes only one optional ASCII space", async () => {
@@ -1001,49 +1102,7 @@ test("only the Anthropic factory path admits a terminal-only phantom slot", asyn
 });
 
 test("the terminal-only slot compacts multiple corroborated tool calls", async () => {
-  const secondTool = {
-    ...functionCall,
-    id: "call_second",
-    call_id: "call_second",
-    name: "second_tool",
-  };
-  const source = pinnedAnthropicTerminalOnlyStream((wireEvents) => {
-    const model = wireEvents[0].model;
-    const firstCandidateClose = wireEvents.findIndex(
-      (event) => event.type === "response.output_text.done",
-    );
-    wireEvents.splice(firstCandidateClose, 0,
-      {
-        type: "response.output_item.added",
-        output_index: 2,
-        item: { ...secondTool, status: "in_progress", arguments: "" },
-        model,
-      },
-      {
-        type: "response.function_call_arguments.delta",
-        item_id: secondTool.id,
-        output_index: 2,
-        delta: "{}",
-        model,
-      },
-      {
-        type: "response.function_call_arguments.done",
-        item_id: secondTool.id,
-        output_index: 2,
-        arguments: "{}",
-        model,
-      },
-      {
-        type: "response.output_item.done",
-        output_index: 2,
-        sequence_number: 10,
-        item: secondTool,
-        model,
-      },
-    );
-    const terminal = wireEvents.find((event) => event.type === "response.completed");
-    terminal.response.output.push(secondTool);
-  });
+  const { source, secondTool } = pinnedAnthropicTerminalOnlyMultiToolStream();
   const output = await transformed(source, { allowTerminalOnlyCandidate: true }, 5);
   const seen = events(output);
   assert.deepEqual(
@@ -1055,6 +1114,65 @@ test("the terminal-only slot compacts multiple corroborated tool calls", async (
     seen.find((event) => event.type === "response.completed").response.output,
     [functionCall, secondTool],
   );
+});
+
+test("translated repairs commit only at EOF and every trailer fails open", async () => {
+  const multiTool = pinnedAnthropicTerminalOnlyMultiToolStream();
+  const fixtures = [
+    ["classic", phantomToolStream(), {}, blankMessage.id],
+    ["current OpenAI", pinnedLiteLlmPhantomToolStream(), {}, blankMessage.id],
+    [
+      "current terminal-only Anthropic",
+      pinnedAnthropicTerminalOnlyStream(),
+      { allowTerminalOnlyCandidate: true },
+      blankMessage.id,
+    ],
+    [
+      "terminal-only Anthropic with multiple tools",
+      multiTool.source,
+      { allowTerminalOnlyCandidate: true },
+      blankMessage.id,
+    ],
+  ];
+  const trailingEvent = block({
+    type: "response.output_item.added",
+    output_index: 9,
+    item: {
+      id: "msg_after_completed",
+      type: "message",
+      status: "in_progress",
+      role: "assistant",
+      content: [],
+    },
+  });
+  const malformed = "event: response.created\ndata: {not-json}\n\n";
+
+  for (const [name, source, options, blankId] of fixtures) {
+    const stream = new TranslatedToolMessageCompatTransform(options);
+    let held = "";
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => { held += chunk; });
+    stream.write(source);
+    assert.equal(held.includes("response.completed"), false, `${name}: held terminal`);
+    stream.end();
+    await once(stream, "end");
+    assert.equal(held.includes(blankId), false, `${name}: repaired blank`);
+    assert.match(held, /data: \[DONE\]\n\n$/, `${name}: preserved sentinel`);
+
+    const withoutSentinel = source.replace(/data: \[DONE\]\n\n$/, "");
+    const eofOutput = await transformed(withoutSentinel, options, 3);
+    assert.equal(eofOutput.includes(blankId), false, `${name}: EOF repair`);
+
+    for (const input of [
+      `${source}data: [DONE]\n\n`,
+      source + trailingEvent,
+      source + malformed,
+      source + "opaque trailing byte",
+      withoutSentinel + trailingEvent,
+    ]) {
+      assert.equal(await transformed(input, options, 1), input, `${name}: trailer`);
+    }
+  }
 });
 
 test("the terminal-only candidate exception fails open on adjacent shapes", async () => {
@@ -1924,10 +2042,10 @@ test("destroying a pending stream clears its hold without later output", async (
   assert.equal(output, created);
 });
 
-test("post-suppression frames without shifted indexes remain byte-identical", async () => {
+test("a post-completion event prevents suppression byte-for-byte", async () => {
   const untouched = "event: response.done\ndata:  {\"type\":\"response.done\",\"response\":{\"id\":\"r1\"}}\n\n";
-  const output = await transformed(phantomToolStream().replace("data: [DONE]\n\n", untouched));
-  assert.ok(output.endsWith(untouched));
+  const input = phantomToolStream().replace("data: [DONE]\n\n", untouched);
+  assert.equal(await transformed(input), input);
 });
 
 test("binds the response id and requires an exact successful terminal envelope", async () => {
@@ -2461,9 +2579,8 @@ test("reasoning output-item provenance must match the terminal response", async 
   assert.equal(await transformed(input, {}, 1), input);
 });
 
-test("stops rewriting after the first bound terminal envelope", async () => {
+test("a second response after a terminal envelope cancels the pending rewrite", async () => {
   const first = phantomToolStream().replace("data: [DONE]\n\n", "");
-  const normalizedFirst = await transformed(first, {}, 1);
   const second = phantomToolStream()
     .replaceAll("resp_1", "resp_second")
     .replaceAll("msg_blank", "msg_second")
@@ -2474,13 +2591,7 @@ test("stops rewriting after the first bound terminal envelope", async () => {
     Buffer.from(second),
     invalidTrailingBytes,
   ]);
-  const expected = Buffer.concat([
-    Buffer.from(normalizedFirst),
-    Buffer.from(second),
-    invalidTrailingBytes,
-  ]);
-
-  assert.deepEqual(await transformedBytes(input, {}, 1), expected);
+  assert.deepEqual(await transformedBytes(input, {}, 1), input);
 });
 
 test("invalid fragmented UTF-8 during a held candidate fails open byte-for-byte", async () => {
@@ -2643,6 +2754,63 @@ test("bounded uniqueness scanning fails open and accepts unique escaped keys", a
   );
 });
 
+test("SSE rewrites reject lossy outer and nested argument numbers", async () => {
+  const source = phantomToolStream();
+  const terminal = responseCompleted([blankMessage, functionCall], {
+    id: "resp_1",
+    sequenceNumber: 9,
+  });
+  for (const literal of ["1e400", "-0", "9007199254740993"]) {
+    const unsafeTerminal = terminal.replace(
+      '"error":null',
+      `"error":null,"numeric_provenance":${literal}`,
+    );
+    const input = source.replace(terminal, unsafeTerminal);
+    assert.notEqual(input, source);
+    assert.equal(await transformed(input, {}, 1), input, `outer ${literal}`);
+
+    const argumentsJson = `{"numeric_provenance":${literal}}`;
+    const nested = pinnedLiteLlmPhantomToolStream((wireEvents) => {
+      for (const event of wireEvents) {
+        if (event.type === "response.function_call_arguments.delta") {
+          event.delta = argumentsJson;
+        } else if (event.type === "response.function_call_arguments.done") {
+          event.arguments = argumentsJson;
+        } else if (
+          event.type === "response.output_item.done" &&
+          event.item?.type === "function_call"
+        ) {
+          event.item.arguments = argumentsJson;
+        } else if (event.type === "response.completed") {
+          event.response.output.find((item) => item.type === "function_call").arguments =
+            argumentsJson;
+        }
+      }
+    });
+    assert.equal(await transformed(nested, {}, 1), nested, `nested ${literal}`);
+  }
+
+  const safeArguments = `{"numeric_provenance":${Number.MAX_SAFE_INTEGER}}`;
+  const safe = pinnedLiteLlmPhantomToolStream((wireEvents) => {
+    for (const event of wireEvents) {
+      if (event.type === "response.function_call_arguments.delta") {
+        event.delta = safeArguments;
+      } else if (event.type === "response.function_call_arguments.done") {
+        event.arguments = safeArguments;
+      } else if (
+        event.type === "response.output_item.done" &&
+        event.item?.type === "function_call"
+      ) {
+        event.item.arguments = safeArguments;
+      } else if (event.type === "response.completed") {
+        event.response.output.find((item) => item.type === "function_call").arguments =
+          safeArguments;
+      }
+    }
+  });
+  assert.equal((await transformed(safe, {}, 1)).includes(blankMessage.id), false);
+});
+
 test("non-streaming responses remove only exact empty messages proven by tool traffic", async () => {
   const secondBlank = {
     ...blankMessage,
@@ -2736,7 +2904,7 @@ test("non-streaming uniqueness limits fail open while unique JSON remains eligib
     '"error":null',
     '"\\u0065rror":null,"metadata":{' +
       '"astral":"\\ud83d\\ude00","lone":"\\ud800",' +
-      '"fraction":-1.25e+3,"huge":123456789012345678901234567890}',
+      `"fraction":-1.25e+3,"safe":${Number.MAX_SAFE_INTEGER}}`,
   );
   const normalized = await transformedJson(unique, {}, 1);
   assert.notEqual(normalized, unique);
@@ -2745,7 +2913,25 @@ test("non-streaming uniqueness limits fail open while unique JSON remains eligib
   assert.equal(payload.metadata.astral, "😀");
   assert.equal(payload.metadata.lone, "\ud800");
   assert.equal(payload.metadata.fraction, -1250);
-  assert.equal(typeof payload.metadata.huge, "number");
+  assert.equal(payload.metadata.safe, Number.MAX_SAFE_INTEGER);
+});
+
+test("non-streaming rewrites reject lossy outer and nested argument numbers", async () => {
+  const base = JSON.stringify(jsonResponse([blankMessage, functionCall]));
+  for (const literal of ["1e400", "-0", "9007199254740993"]) {
+    const outer = base.replace(
+      '"error":null',
+      `"error":null,"metadata":{"numeric_provenance":${literal}}`,
+    );
+    assert.equal(await transformedJson(outer, {}, 1), outer, `outer ${literal}`);
+
+    const nestedTool = {
+      ...functionCall,
+      arguments: `{"numeric_provenance":${literal}}`,
+    };
+    const nested = JSON.stringify(jsonResponse([blankMessage, nestedTool]));
+    assert.equal(await transformedJson(nested, {}, 1), nested, `nested ${literal}`);
+  }
 });
 
 test("non-streaming normalization requires a successful envelope and unique ids", async () => {

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -9,6 +9,11 @@ import {
   deepseekToolMessageCompatTransform,
   translatedToolMessageCompatTransform,
 } from "../src/deepseek-tool-message-compat.mjs";
+import {
+  NamespaceToolCallTransform,
+  bridgeCustomTools,
+  flattenNamespaceTools,
+} from "../src/namespace-relay.mjs";
 
 function block(event, newline = "\n") {
   return `event: ${event.type}${newline}data: ${JSON.stringify(event)}${newline}${newline}`;
@@ -68,6 +73,34 @@ async function transformedBytes(input, options = {}, chunkSize = 0) {
   stream.end();
   await once(stream, "end");
   return Buffer.concat(output);
+}
+
+async function transformedThroughNamespace(
+  input,
+  namespaces,
+  options = {},
+  chunkSize = 0,
+) {
+  const compat = new TranslatedToolMessageCompatTransform(options);
+  const namespace = new NamespaceToolCallTransform(
+    namespaces,
+    "text/event-stream",
+  );
+  let output = "";
+  namespace.setEncoding("utf8");
+  namespace.on("data", (chunk) => { output += chunk; });
+  compat.pipe(namespace);
+  const bytes = Buffer.isBuffer(input) ? input : Buffer.from(input);
+  if (chunkSize > 0) {
+    for (let at = 0; at < bytes.length; at += chunkSize) {
+      compat.write(bytes.subarray(at, at + chunkSize));
+    }
+  } else {
+    compat.write(bytes);
+  }
+  compat.end();
+  await once(namespace, "end");
+  return output;
 }
 
 async function transformedJson(input, options = {}, chunkSize = 0) {
@@ -2006,6 +2039,74 @@ test("delimiter-terminated frames and single-frame cap crossings are bounded", a
   );
 });
 
+test("one-byte fragmented frames use bounded concatenation in both SSE paths", async () => {
+  const source = `event: opaque\ndata: ${"x".repeat(128 * 1024)}`;
+  const options = {
+    maxFrameBytes: Buffer.byteLength(source) + 1,
+    maxCandidateMs: 60_000,
+  };
+  const originalConcat = Buffer.concat;
+  let concatenations = 0;
+  Buffer.concat = function countedConcat(...args) {
+    concatenations += 1;
+    return originalConcat.apply(this, args);
+  };
+  try {
+    assert.equal(await transformed(source, options, 1), source);
+    assert.equal(await transformedDirect(source, options, 1), source);
+  } finally {
+    Buffer.concat = originalConcat;
+  }
+  assert.ok(
+    concatenations <= 4,
+    `fragment accumulation performed ${concatenations} Buffer.concat calls`,
+  );
+});
+
+test("dense one-byte fragmented tool frames compact in one transaction", async () => {
+  const argumentText = `{"dense":"${"x".repeat(2_000)}"}`;
+  const wireEvents = pinnedLiteLlmPhantomEvents();
+  const deltaAt = wireEvents.findIndex(
+    (event) => event.type === "response.function_call_arguments.delta",
+  );
+  const deltaTemplate = wireEvents[deltaAt];
+  wireEvents.splice(
+    deltaAt,
+    1,
+    ...[...argumentText].map((delta) => ({ ...deltaTemplate, delta })),
+  );
+  for (const event of wireEvents) {
+    if (event.type === "response.function_call_arguments.done") {
+      event.arguments = argumentText;
+    } else if (
+      event.type === "response.output_item.done" &&
+      event.item?.type === "function_call"
+    ) {
+      event.item.arguments = argumentText;
+    } else if (event.type === "response.completed") {
+      event.response.output.find((item) => item.type === "function_call").arguments =
+        argumentText;
+    }
+  }
+  const source = `${wireEvents.map((event) => block(event)).join("")}data: [DONE]\n\n`;
+  const output = await transformed(source, {
+    maxCandidateBytes: Buffer.byteLength(source) + 1,
+    maxCandidateMs: 60_000,
+  }, 1);
+  const seen = events(output);
+
+  assert.equal(output.includes(blankMessage.id), false);
+  assert.equal(
+    seen.filter((event) => event.type === "response.function_call_arguments.delta").length,
+    argumentText.length,
+  );
+  assert.equal(
+    seen.find((event) => event.type === "response.completed")
+      .response.output[0].arguments,
+    argumentText,
+  );
+});
+
 test("timer expiry also releases an incomplete buffered frame", async () => {
   const created = responseCreated();
   const start = block({
@@ -2415,6 +2516,148 @@ test("compacts a strictly confirmed custom-tool lifecycle without changing its i
   );
 });
 
+test("blank compaction composes with ordinary, custom, and tool_search restoration", async () => {
+  const flattened = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "mcp__files",
+      tools: [{
+        type: "function",
+        name: "read_file",
+        inputSchema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+          additionalProperties: false,
+        },
+      }],
+    },
+    { type: "custom", name: "apply_patch" },
+    {
+      type: "tool_search",
+      execution: "client",
+      parameters: {
+        type: "object",
+        properties: { query: { type: "string" } },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+  ]);
+  const bridged = bridgeCustomTools(
+    flattened.tools,
+    [],
+    flattened.namespaces,
+  );
+  const providerNames = new Set(bridged.tools.map((tool) => tool.name));
+  assert.deepEqual(
+    providerNames,
+    new Set(["mcp__files__read_file", "apply_patch", "tool_search"]),
+  );
+
+  const tools = [
+    {
+      id: "call_namespace",
+      type: "function_call",
+      call_id: "call_namespace",
+      name: "mcp__files__read_file",
+      arguments: '{"path":"README.md"}',
+      status: "completed",
+    },
+    {
+      id: "call_custom",
+      type: "function_call",
+      call_id: "call_custom",
+      name: "apply_patch",
+      arguments: '{"input":"*** Begin Patch\\n*** End Patch"}',
+      status: "completed",
+    },
+    {
+      id: "call_search",
+      type: "function_call",
+      call_id: "call_search",
+      name: "tool_search",
+      arguments: '{"query":"calendar"}',
+      status: "completed",
+    },
+  ];
+  const wireEvents = pinnedLiteLlmPhantomEvents();
+  const model = wireEvents[0].model;
+  const lifecycle = (tool, outputIndex, sequenceNumber) => [
+    {
+      type: "response.output_item.added",
+      output_index: outputIndex,
+      item: { ...tool, status: "in_progress", arguments: "" },
+      model,
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: tool.id,
+      output_index: outputIndex,
+      delta: tool.arguments,
+      model,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: tool.id,
+      output_index: outputIndex,
+      arguments: tool.arguments,
+      model,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: outputIndex,
+      sequence_number: sequenceNumber,
+      item: tool,
+      model,
+    },
+  ];
+  wireEvents.splice(4, 4, ...lifecycle(tools[0], 1, 9));
+  const candidateCloseAt = wireEvents.findIndex(
+    (event) => event.type === "response.output_text.done",
+  );
+  wireEvents.splice(
+    candidateCloseAt,
+    0,
+    ...lifecycle(tools[1], 2, 10),
+    ...lifecycle(tools[2], 3, 11),
+  );
+  wireEvents.find((event) => event.type === "response.completed")
+    .response.output = [
+      { ...blankMessage, id: "chatcmpl-pinned-terminal" },
+      ...tools,
+    ];
+  const source = `${wireEvents.map((event) => block(event)).join("")}data: [DONE]\n\n`;
+  const output = await transformedThroughNamespace(
+    source,
+    flattened.namespaces,
+    { maxCandidateMs: 60_000 },
+    1,
+  );
+  const seen = events(output);
+  const added = seen.filter((event) => event.type === "response.output_item.added");
+  const completed = seen.find((event) => event.type === "response.completed");
+
+  assert.equal(output.includes(blankMessage.id), false);
+  assert.deepEqual(added.map((event) => event.output_index), [0, 1, 2]);
+  assert.deepEqual(
+    added.map((event) => [event.item.type, event.item.name, event.item.namespace]),
+    [
+      ["function_call", "read_file", "mcp__files"],
+      ["custom_tool_call", "apply_patch", undefined],
+      ["tool_search_call", undefined, undefined],
+    ],
+  );
+  assert.deepEqual(
+    completed.response.output.map((item) => item.type),
+    ["function_call", "custom_tool_call", "tool_search_call"],
+  );
+  assert.equal(completed.response.output[0].namespace, "mcp__files");
+  assert.equal(completed.response.output[0].name, "read_file");
+  assert.equal(completed.response.output[1].input, "*** Begin Patch\n*** End Patch");
+  assert.deepEqual(completed.response.output[2].arguments, { query: "calendar" });
+});
+
 test("preserves real reasoning bytes, ids, and sequence numbers while compacting", async () => {
   const reasoningDone = {
     id: "rs_real",
@@ -2754,13 +2997,22 @@ test("bounded uniqueness scanning fails open and accepts unique escaped keys", a
   );
 });
 
+const lossyJsonNumbers = [
+  "1e400",
+  "-0",
+  "9007199254740993",
+  "1e-324",
+  "1.0000000000000001",
+  "0.10000000000000001",
+];
+
 test("SSE rewrites reject lossy outer and nested argument numbers", async () => {
   const source = phantomToolStream();
   const terminal = responseCompleted([blankMessage, functionCall], {
     id: "resp_1",
     sequenceNumber: 9,
   });
-  for (const literal of ["1e400", "-0", "9007199254740993"]) {
+  for (const literal of lossyJsonNumbers) {
     const unsafeTerminal = terminal.replace(
       '"error":null',
       `"error":null,"numeric_provenance":${literal}`,
@@ -2809,6 +3061,19 @@ test("SSE rewrites reject lossy outer and nested argument numbers", async () => 
     }
   });
   assert.equal((await transformed(safe, {}, 1)).includes(blankMessage.id), false);
+});
+
+test("direct DeepSeek terminal JSON keeps lossy numeric provenance byte-identical", async () => {
+  const source = currentDirectDeepseekStream();
+  for (const literal of [
+    "1e-324",
+    "1.0000000000000001",
+    "0.10000000000000001",
+  ]) {
+    const input = source.replace('"input_tokens":17', `"input_tokens":${literal}`);
+    assert.notEqual(input, source);
+    assert.equal(await transformedDirect(input, {}, 1), input, literal);
+  }
 });
 
 test("non-streaming responses remove only exact empty messages proven by tool traffic", async () => {
@@ -2918,7 +3183,7 @@ test("non-streaming uniqueness limits fail open while unique JSON remains eligib
 
 test("non-streaming rewrites reject lossy outer and nested argument numbers", async () => {
   const base = JSON.stringify(jsonResponse([blankMessage, functionCall]));
-  for (const literal of ["1e400", "-0", "9007199254740993"]) {
+  for (const literal of lossyJsonNumbers) {
     const outer = base.replace(
       '"error":null',
       `"error":null,"metadata":{"numeric_provenance":${literal}}`,

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -806,6 +806,140 @@ test("historical direct-DeepSeek grammar remains exact and bounded", async () =>
   );
 });
 
+test("direct DeepSeek holds one terminal sentinel until EOF and rejects every trailer", async () => {
+  const fixtures = [
+    [historicalDirectDeepseekStream, "msg_direct_historical"],
+    [currentDirectDeepseekStream, "msg_direct_live"],
+  ];
+  for (const [fixture, blankId] of fixtures) {
+    const source = fixture();
+    const stream = new DeepseekToolMessageCompatTransform();
+    let heldOutput = "";
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => { heldOutput += chunk; });
+    stream.write(source);
+    assert.equal(heldOutput.includes("[DONE]"), false);
+    stream.end();
+    await once(stream, "end");
+    assert.equal(heldOutput.includes(blankId), false);
+    assert.match(heldOutput, /data: \[DONE\]\n\n$/);
+
+    const withoutSentinel = source.replace(/data: \[DONE\]\n\n$/, "");
+    const eofOutput = await transformedDirect(withoutSentinel, {}, 1);
+    assert.equal(eofOutput.includes(blankId), false);
+
+    const trailingEvent = block({
+      type: "response.output_item.added",
+      output_index: 9,
+      item: {
+        id: "msg_after_done",
+        type: "message",
+        status: "in_progress",
+        role: "assistant",
+        content: [],
+      },
+    });
+    for (const suffix of [
+      "data: [DONE]\n\n",
+      trailingEvent,
+      "opaque trailing byte",
+    ]) {
+      const input = source + suffix;
+      assert.equal(await transformedDirect(input, {}, 1), input);
+    }
+  }
+});
+
+test("direct DeepSeek watchdog measures inactivity rather than total capture time", async () => {
+  const timeout = 1_000;
+  const gap = 150;
+  const frames = historicalDirectDeepseekEvents().map((event) => block(event));
+  const source = `${frames.join("")}data: [DONE]\n\n`;
+  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: timeout });
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  const started = Date.now();
+  for (const frame of frames) {
+    stream.write(frame);
+    await new Promise((resolve) => setTimeout(resolve, gap));
+  }
+  stream.write("data: [DONE]\n\n");
+  await new Promise((resolve) => setTimeout(resolve, gap));
+  stream.end();
+  await once(stream, "end");
+
+  assert.ok(Date.now() - started > timeout);
+  assert.equal(output.includes("msg_direct_historical"), false);
+  assert.match(output, /data: \[DONE\]\n\n$/);
+  assert.notEqual(output, source);
+});
+
+test("direct DeepSeek watchdog fails open after one inactive gap", async () => {
+  const frames = historicalDirectDeepseekEvents().map((event) => block(event));
+  const source = `${frames.join("")}data: [DONE]\n\n`;
+  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 20 });
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  stream.write(frames[0]);
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  stream.end(`${frames.slice(1).join("")}data: [DONE]\n\n`);
+  await once(stream, "end");
+  assert.equal(output, source);
+});
+
+test("direct DeepSeek watchdog releases an incomplete frame byte-for-byte", async () => {
+  const start = block(historicalDirectDeepseekEvents()[0]);
+  const partial = "event: response.content_part.added\ndata: {\"type\":";
+  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 20 });
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  stream.write(start + partial);
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  assert.equal(output, start + partial);
+  stream.end();
+  await once(stream, "end");
+  assert.equal(output, start + partial);
+});
+
+test("destroying a pending direct DeepSeek capture cancels its watchdog", async () => {
+  const start = block(historicalDirectDeepseekEvents()[0]);
+  const stream = new DeepseekToolMessageCompatTransform({ maxCandidateMs: 20 });
+  let output = "";
+  stream.on("data", (chunk) => { output += chunk.toString("utf8"); });
+  stream.write(start);
+  stream.destroy();
+  await once(stream, "close");
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  assert.equal(output, "");
+});
+
+test("SSE field parsing removes only one optional ASCII space", async () => {
+  const source = historicalDirectDeepseekStream();
+  for (const prefix of ["data:  {", "data: \t  {"]) {
+    const spaced = source.replace("data: {", prefix);
+    const output = await transformedDirect(spaced, {}, 1);
+    assert.equal(output.includes("msg_direct_historical"), false);
+  }
+
+  for (const invalid of [
+    source.replace("data: {", "data: \ufeff{"),
+    source.replace("data: {", "data: \u00a0{"),
+    source.replace(
+      "event: response.output_item.added",
+      "event: \ufeffresponse.output_item.added",
+    ),
+    source.replace(
+      "event: response.output_item.added",
+      "event:  response.output_item.added",
+    ),
+  ]) {
+    assert.equal(await transformedDirect(invalid, {}, 1), invalid);
+  }
+});
+
 test("repairs LiteLLM 1.96.0's pinned terminal sequence reset", async () => {
   const source = pinnedLiteLlmPhantomToolStream();
   const output = await transformed(source, {}, 5);

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -7279,21 +7279,41 @@ test("a plain follow-up after a thinking turn replays its reasoning", async () =
   }
 });
 
-test("router removes DeepSeek's confirmed blank message before a tool call", async () => {
+test("router normalizes direct DeepSeek's live reasoning bridge and removes its blank", async () => {
+  const model = "deepseek-v4-flash";
+  const reasoningText = "Inspect the request, then call the tool exactly once.";
   const blankMessage = {
-    id: "msg_blank",
+    id: "msg_direct_live",
     type: "message",
     status: "completed",
     role: "assistant",
     content: [{ type: "output_text", text: "", annotations: [] }],
   };
   const functionCall = {
-    id: "call_list",
+    id: "call_direct_live",
     type: "function_call",
-    call_id: "call_list",
+    call_id: "call_direct_live",
     name: "exec_command",
     arguments: "{}",
     status: "completed",
+  };
+  const terminalReasoning = {
+    id: "rs_-8853496868378332836",
+    type: "reasoning",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: reasoningText, annotations: [] }],
+  };
+  const terminalBlank = {
+    ...blankMessage,
+    id: "04847f40-ed33-4239-80d2-d392fe38fcc3",
+    content: [{ type: "output_text", annotations: [] }],
+  };
+  const normalizedReasoning = {
+    id: terminalReasoning.id,
+    type: "reasoning",
+    status: "completed",
+    summary: [{ type: "summary_text", text: reasoningText }],
   };
   const gateway = await mockServer(async (request, response) => {
     await bodyJson(request);
@@ -7302,17 +7322,32 @@ test("router removes DeepSeek's confirmed blank message before a tool call", asy
       {
         type: "response.created",
         response: {
-          id: "resp_tool_only",
+          id: "resp_direct_live_open",
+          model,
           object: "response",
           status: "in_progress",
           error: null,
           output: [],
         },
+        model,
+      },
+      {
+        type: "response.in_progress",
+        response: {
+          id: "resp_direct_live_open",
+          model,
+          object: "response",
+          status: "in_progress",
+          error: null,
+          output: [],
+        },
+        model,
       },
       {
         type: "response.output_item.added",
         output_index: 0,
         item: { ...blankMessage, status: "in_progress", content: [] },
+        model,
       },
       {
         type: "response.content_part.added",
@@ -7320,44 +7355,84 @@ test("router removes DeepSeek's confirmed blank message before a tool call", asy
         output_index: 0,
         content_index: 0,
         part: { type: "output_text", text: "", annotations: [] },
+        model,
+      },
+      {
+        type: "response.reasoning_summary_text.delta",
+        item_id: blankMessage.id,
+        output_index: 0,
+        delta: "Inspect the request, then ",
+        model,
+      },
+      {
+        type: "response.reasoning_summary_text.delta",
+        item_id: blankMessage.id,
+        output_index: 0,
+        delta: "call the tool exactly once.",
+        model,
       },
       {
         type: "response.output_item.added",
         output_index: 1,
         item: { ...functionCall, arguments: "", status: "in_progress" },
+        model,
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: functionCall.id,
+        output_index: 1,
+        delta: "{}",
+        model,
       },
       {
         type: "response.function_call_arguments.done",
         item_id: functionCall.id,
         output_index: 1,
         arguments: "{}",
+        model,
       },
-      { type: "response.output_item.done", output_index: 1, item: functionCall },
+      {
+        type: "response.output_item.done",
+        output_index: 1,
+        sequence_number: 16,
+        item: functionCall,
+        model,
+      },
       {
         type: "response.output_text.done",
         item_id: blankMessage.id,
         output_index: 0,
         content_index: 0,
         text: "",
+        model,
       },
       {
         type: "response.content_part.done",
         item_id: blankMessage.id,
         output_index: 0,
         content_index: 0,
-        part: { type: "output_text", text: "", annotations: [] },
+        part: { type: "reasoning_text", reasoning: reasoningText },
+        model,
       },
-      { type: "response.output_item.done", output_index: 0, item: blankMessage },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        sequence_number: 1,
+        item: blankMessage,
+        model,
+      },
       {
         type: "response.completed",
         response: {
-          id: "resp_tool_only",
+          id: "resp_direct_live_closed",
+          model,
           object: "response",
           status: "completed",
           error: null,
-          output: [blankMessage, functionCall],
+          output: [terminalReasoning, terminalBlank, functionCall],
           usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
         },
+        model,
       },
     ];
     response.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
@@ -7386,14 +7461,35 @@ test("router removes DeepSeek's confirmed blank message before a tool call", asy
       .filter((line) => line.startsWith("data: {"))
       .map((line) => JSON.parse(line.slice(5).trim()));
     assert.equal(text.includes(blankMessage.id), false);
+    assert.equal(text.includes(terminalBlank.id), false);
+    const reasoningEvents = events.filter(
+      (event) => (event.item_id ?? event.item?.id) === terminalReasoning.id,
+    );
+    assert.deepEqual(
+      reasoningEvents.map((event) => [event.type, event.output_index]),
+      [
+        ["response.output_item.added", 0],
+        ["response.reasoning_summary_part.added", 0],
+        ["response.reasoning_summary_text.delta", 0],
+        ["response.reasoning_summary_text.delta", 0],
+        ["response.reasoning_summary_text.done", 0],
+        ["response.reasoning_summary_part.done", 0],
+        ["response.output_item.done", 0],
+      ],
+    );
     const toolEvents = events.filter(
       (event) => (event.item_id ?? event.item?.id) === functionCall.id,
     );
     assert.ok(toolEvents.length >= 3);
-    assert.ok(toolEvents.every((event) => event.output_index === 0));
+    assert.ok(toolEvents.every((event) => event.output_index === 1));
+    assert.deepEqual(
+      events.filter((event) => event.sequence_number !== undefined)
+        .map((event) => event.sequence_number),
+      [16],
+    );
     assert.deepEqual(
       events.find((event) => event.type === "response.completed").response.output,
-      [functionCall],
+      [normalizedReasoning, functionCall],
     );
   } finally {
     await stopChild(router);

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -7701,6 +7701,151 @@ test("router response pipelines preserve ambiguous provider bytes exactly", asyn
   }
 });
 
+test("router enables the terminal-only bridge repair only for Messages routes", async () => {
+  const model = "opencode-go-messages-minimax-m3";
+  const blank = {
+    id: "chatcmpl_terminal_only",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "", annotations: [] }],
+  };
+  const tool = {
+    id: "call_terminal_only",
+    type: "function_call",
+    call_id: "call_terminal_only",
+    name: "exec_command",
+    arguments: "{}",
+    status: "completed",
+  };
+  const inProgress = {
+    id: "resp_terminal_only_open",
+    model,
+    object: "response",
+    status: "in_progress",
+    error: null,
+    output: [],
+  };
+  const source = [
+    { type: "response.created", response: { ...inProgress }, model },
+    { type: "response.in_progress", response: { ...inProgress }, model },
+    {
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { ...tool, arguments: "", status: "in_progress" },
+      model,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: tool.id,
+      output_index: 1,
+      arguments: "{}",
+      model,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 1,
+      sequence_number: 8,
+      item: tool,
+      model,
+    },
+    {
+      type: "response.output_text.done",
+      item_id: blank.id,
+      output_index: 0,
+      content_index: 0,
+      text: "",
+      model,
+    },
+    {
+      type: "response.content_part.done",
+      item_id: blank.id,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+      model,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      sequence_number: 1,
+      item: blank,
+      model,
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_terminal_only_closed",
+        model,
+        object: "response",
+        status: "completed",
+        error: null,
+        output: [blank, tool],
+      },
+      model,
+    },
+  ].map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(source);
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  const route = async (routeModel) => {
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: routeModel,
+        input: "list files",
+        stream: true,
+      }),
+    });
+    const text = await response.text();
+    assert.equal(response.status, 200, text);
+    return {
+      text,
+      events: text.split(/\r?\n/)
+        .filter((line) => line.startsWith("data: {"))
+        .map((line) => JSON.parse(line.slice(5).trim())),
+    };
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const messages = await route("opencode-go-messages/minimax-m3");
+    assert.equal(messages.text.includes(blank.id), false);
+    assert.equal(
+      messages.events.find((event) => event.item?.id === tool.id).output_index,
+      0,
+    );
+    assert.deepEqual(
+      messages.events.find((event) => event.type === "response.completed").response.output,
+      [tool],
+    );
+
+    const openai = await route("opencode-go/deepseek-v4-flash");
+    assert.ok(openai.text.includes(blank.id));
+    assert.equal(
+      openai.events.find((event) => event.item?.id === tool.id).output_index,
+      1,
+    );
+    assert.deepEqual(
+      openai.events.find((event) => event.type === "response.completed").response.output,
+      [blank, tool],
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 test("router applies the translated empty-message repair to bounded JSON responses", async () => {
   const blank = {
     id: "msg_blank_json",

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -7300,6 +7300,16 @@ test("router removes DeepSeek's confirmed blank message before a tool call", asy
     response.writeHead(200, { "Content-Type": "text/event-stream" });
     const events = [
       {
+        type: "response.created",
+        response: {
+          id: "resp_tool_only",
+          object: "response",
+          status: "in_progress",
+          error: null,
+          output: [],
+        },
+      },
+      {
         type: "response.output_item.added",
         output_index: 0,
         item: { ...blankMessage, status: "in_progress", content: [] },
@@ -7342,7 +7352,9 @@ test("router removes DeepSeek's confirmed blank message before a tool call", asy
         type: "response.completed",
         response: {
           id: "resp_tool_only",
+          object: "response",
           status: "completed",
+          error: null,
           output: [blankMessage, functionCall],
           usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
         },
@@ -7425,14 +7437,31 @@ test("router compacts translated OpenCode routes but leaves Responses-native rou
     }],
   }];
   const source = [
+    {
+      type: "response.created",
+      response: {
+        id: "resp_tool_only",
+        object: "response",
+        status: "in_progress",
+        error: null,
+        output: [],
+      },
+    },
     { type: "response.output_item.added", output_index: 0, item: { ...blank, status: "in_progress", content: [] } },
-    { type: "response.output_item.added", output_index: 1, item: { ...tool, status: "in_progress" } },
+    {
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { ...tool, arguments: "", status: "in_progress" },
+    },
+    { type: "response.output_item.done", output_index: 1, item: tool },
     { type: "response.output_item.done", output_index: 0, item: blank },
     {
       type: "response.completed",
       response: {
         id: "resp_tool_only",
+        object: "response",
         status: "completed",
+        error: null,
         output: [terminalBlank, tool],
         usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
       },

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -7335,7 +7335,7 @@ test("router removes DeepSeek's confirmed blank message before a tool call", asy
         item_id: blankMessage.id,
         output_index: 0,
         content_index: 0,
-        part: { type: "reasoning_text", reasoning: "private reasoning" },
+        part: { type: "output_text", text: "", annotations: [] },
       },
       { type: "response.output_item.done", output_index: 0, item: blankMessage },
       {
@@ -7374,7 +7374,6 @@ test("router removes DeepSeek's confirmed blank message before a tool call", asy
       .filter((line) => line.startsWith("data: {"))
       .map((line) => JSON.parse(line.slice(5).trim()));
     assert.equal(text.includes(blankMessage.id), false);
-    assert.equal(text.includes("private reasoning"), false);
     const toolEvents = events.filter(
       (event) => (event.item_id ?? event.item?.id) === functionCall.id,
     );
@@ -7390,7 +7389,7 @@ test("router removes DeepSeek's confirmed blank message before a tool call", asy
   }
 });
 
-test("router does not compact the same blank-message shape on non-DeepSeek routes", async () => {
+test("router compacts translated OpenCode routes but leaves Responses-native routes unchanged", async () => {
   const blank = {
     id: "msg_blank",
     type: "message",
@@ -7398,14 +7397,33 @@ test("router does not compact the same blank-message shape on non-DeepSeek route
     role: "assistant",
     content: [{ type: "output_text", text: "", annotations: [] }],
   };
+  const terminalBlank = {
+    ...blank,
+    id: "chatcmpl_tool_only",
+    content: [{ type: "output_text", annotations: [] }],
+  };
   const tool = {
     id: "call_list",
     type: "function_call",
     call_id: "call_id",
-    name: "exec_command",
+    name: "collaboration__spawn_agent",
     arguments: "{}",
     status: "completed",
   };
+  const restoredTool = {
+    ...tool,
+    name: "spawn_agent",
+    namespace: "collaboration",
+  };
+  const tools = [{
+    type: "namespace",
+    name: "collaboration",
+    tools: [{
+      type: "function",
+      name: "spawn_agent",
+      inputSchema: { type: "object", properties: {} },
+    }],
+  }];
   const source = [
     { type: "response.output_item.added", output_index: 0, item: { ...blank, status: "in_progress", content: [] } },
     { type: "response.output_item.added", output_index: 1, item: { ...tool, status: "in_progress" } },
@@ -7415,7 +7433,7 @@ test("router does not compact the same blank-message shape on non-DeepSeek route
       response: {
         id: "resp_tool_only",
         status: "completed",
-        output: [blank, tool],
+        output: [terminalBlank, tool],
         usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
       },
     },
@@ -7434,28 +7452,63 @@ test("router does not compact the same blank-message shape on non-DeepSeek route
 
   try {
     await waitFor(`${routerBase(routerPort)}/models`, router);
-    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+    const translatedResponse = await fetch(`${routerBase(routerPort)}/responses`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         model: "opencode-go/deepseek-v4-flash",
         input: "list files",
         stream: true,
+        tools,
       }),
     });
-    const text = await response.text();
-    assert.equal(response.status, 200, text);
-    const events = text.split(/\r?\n/)
+    const translatedText = await translatedResponse.text();
+    assert.equal(translatedResponse.status, 200, translatedText);
+    const translatedEvents = translatedText.split(/\r?\n/)
       .filter((line) => line.startsWith("data: {"))
       .map((line) => JSON.parse(line.slice(5).trim()));
-    assert.ok(text.includes(blank.id));
+    assert.equal(translatedText.includes(blank.id), false);
+    assert.equal(translatedText.includes(terminalBlank.id), false);
+    const translatedToolEvent = translatedEvents.find(
+      (event) => event.item?.id === tool.id,
+    );
+    assert.equal(translatedToolEvent.output_index, 0);
+    assert.deepEqual(
+      {
+        id: translatedToolEvent.item.id,
+        name: translatedToolEvent.item.name,
+        namespace: translatedToolEvent.item.namespace,
+      },
+      { id: tool.id, name: "spawn_agent", namespace: "collaboration" },
+    );
+    assert.deepEqual(
+      translatedEvents.find((event) => event.type === "response.completed").response.output,
+      [restoredTool],
+    );
+
+    const nativeResponse = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "opencode-go-responses/gpt-5.6-luna",
+        input: "list files",
+        stream: true,
+        tools,
+      }),
+    });
+    const nativeText = await nativeResponse.text();
+    assert.equal(nativeResponse.status, 200, nativeText);
+    const nativeEvents = nativeText.split(/\r?\n/)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+    assert.ok(nativeText.includes(blank.id));
     assert.equal(
-      events.find((event) => event.item?.id === tool.id).output_index,
+      nativeEvents.find((event) => event.item?.id === tool.id).output_index,
       1,
     );
     assert.deepEqual(
-      events.find((event) => event.type === "response.completed").response.output,
-      [blank, tool],
+      nativeEvents.find((event) => event.type === "response.completed").response.output,
+      [terminalBlank, restoredTool],
     );
   } finally {
     await stopChild(router);
@@ -7613,6 +7666,76 @@ test("router response pipelines preserve ambiguous provider bytes exactly", asyn
     assert.match(lifecycleFailureText, /event: error/u);
     assert.match(lifecycleFailureText, /local_router_stream_failed/u);
     assert.doesNotMatch(lifecycleFailureText, new RegExp(lifecycleMarker, "u"));
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
+test("router applies the translated empty-message repair to bounded JSON responses", async () => {
+  const blank = {
+    id: "msg_blank_json",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: null, annotations: [] }],
+    phase: null,
+  };
+  const tool = {
+    id: "call_json",
+    type: "function_call",
+    call_id: "call_json",
+    name: "exec_command",
+    arguments: "{}",
+    status: "completed",
+  };
+  const payload = {
+    id: "resp_json_tool",
+    object: "response",
+    error: null,
+    status: "completed",
+    output: [blank, tool],
+    usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+  };
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(JSON.stringify(payload));
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const translatedResponse = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "opencode-go/deepseek-v4-flash",
+        input: "list files",
+        stream: false,
+      }),
+    });
+    const translated = await translatedResponse.json();
+    assert.equal(translatedResponse.status, 200, JSON.stringify(translated));
+    assert.deepEqual(translated.output, [tool]);
+
+    const nativeResponse = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "opencode-go-responses/gpt-5.6-luna",
+        input: "list files",
+        stream: false,
+      }),
+    });
+    const native = await nativeResponse.json();
+    assert.equal(nativeResponse.status, 200, JSON.stringify(native));
+    assert.deepEqual(native.output, [blank, tool]);
   } finally {
     await stopChild(router);
     await closeServer(gateway.server);


### PR DESCRIPTION
Fixes #473

## Summary
- remove only bridge-proven empty assistant envelopes before translated tool traffic
- preserve native Responses traffic and fail open on ambiguous, malformed, lossy-numeric, invalid-UTF-8, or over-budget input
- keep real content, IDs, indexes, sequence numbers, tool calls, and tool-schema namespace restoration intact
- cover both streaming and bounded JSON responses, including direct DeepSeek compatibility and pinned LiteLLM lifecycle variants
- use linear, bounded parsing and transactional output so a rejected repair is byte-for-byte unchanged

## Verification
- `npm run check`
- `node --test test/deepseek-tool-message-compat.test.mjs test/namespace-relay.test.mjs` (197/197)
- `node --test test/routing.test.mjs test/namespace-relay-routing.test.mjs` (111/111)
- `npm test` (2,864 total; 2,847 passed; 17 skipped; 0 failed)

The skipped cases are existing platform/integration gates. No live provider request was made.