### PR TITLE
fix: repair Console Go Kimi tool schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **OpenCode Go Kimi K2.7 Code now accepts current Codex tool schemas.** Its
+  Moonshot-backed validator receives the same bounded decorated-`$defs` repair
+  as the first-party Kimi routes. The compatibility gate names only this
+  observed Console Go model, so unrelated OpenCode Go routes keep their tool
+  payloads unchanged.
+
 - **Translated tool streams no longer expose bridge-only assistant turns.**
   Bounded, fail-open normalization removes only empty assistant envelopes that
   LiteLLM's Chat Completions and Anthropic Messages bridges corroborate with a

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -757,11 +757,19 @@ function needsStrictOpenCodeToolCompatibility(route) {
 // whole request -- not the one tool -- over any other pointer (issue #353) or a
 // definition reference carrying sibling keywords. The OAuth and platform-key
 // routes are separate products, but their first-party validators share this
-// schema flavor. Keep the rewrite off every non-Moonshot provider.
+// schema flavor. Console Go's Kimi K2.7 Code route has now returned the same
+// validator error (#488), so include that exact measured route without
+// projecting the behavior onto unrelated OpenCode Go models.
 const MOONSHOT_PROVIDER_IDS = new Set(["kimi-oauth", "kimi-api", "kimi-api-cn"]);
+const OPENCODE_GO_MOONSHOT_MODELS = new Set(["kimi-k2.7-code"]);
 
 function needsMoonshotSchemaCompatibility(route) {
-  return MOONSHOT_PROVIDER_IDS.has(providerForModel(route)?.id);
+  const providerId = providerForModel(route)?.id;
+  return (
+    MOONSHOT_PROVIDER_IDS.has(providerId) ||
+    (providerId === "opencode-go" &&
+      OPENCODE_GO_MOONSHOT_MODELS.has(route.upstreamModel))
+  );
 }
 
 function zenFreeCompatibleInput(input, route) {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5502,6 +5502,83 @@ test("router normalizes forced tool choices before LiteLLM for auto-tool-choice 
   }
 });
 
+test("router applies Moonshot ref repair only to the proven Console Go Kimi route", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, { id: "resp_test", object: "response", output: [] });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const headers = {
+    Authorization: `Bearer ${CALLER_KEY}`,
+    "Content-Type": "application/json",
+  };
+  const decoratedRefTool = {
+    type: "function",
+    name: "review_change",
+    description: "Review one proposed change.",
+    parameters: {
+      type: "object",
+      properties: {
+        change: {
+          $ref: "#/$defs/change",
+          description: "The change to review.",
+        },
+      },
+      required: ["change"],
+      $defs: {
+        change: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+          additionalProperties: false,
+        },
+      },
+    },
+  };
+
+  async function route(model) {
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ model, input: "test", tools: [decoratedRefTool] }),
+    });
+    assert.equal(response.status, 200, router.testErrors());
+    return gatewayRequests.at(-1);
+  }
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    const kimi = await route("opencode-go/kimi-k2.7-code");
+    assert.equal(kimi.model, "opencode-go-kimi-k2-7-code");
+    assert.deepEqual(kimi.tools[0].parameters.properties.change, {
+      type: "object",
+      properties: { path: { type: "string" } },
+      required: ["path"],
+      additionalProperties: false,
+      description: "The change to review.",
+    });
+
+    // The evidence is route-specific. Another Chat model on the same provider
+    // keeps the caller's schema unchanged instead of inheriting a Kimi quirk.
+    const glm = await route("opencode-go/glm-5.2");
+    assert.equal(glm.model, "opencode-go-glm-5-2");
+    assert.deepEqual(
+      glm.tools.find((tool) => tool.name === decoratedRefTool.name),
+      decoratedRefTool,
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 test("router redirects native background turns to the configured routed model", async () => {
   const gatewayRequests = [];
   const gateway = await mockServer(async (request, response) => {


### PR DESCRIPTION
Fixes #488

## Summary
- extend the existing bounded Moonshot decorated-`$defs` repair to the exact reported `opencode-go/kimi-k2.7-code` route
- keep the compatibility boundary model-scoped rather than applying a Kimi inference to all OpenCode Go models
- add a routed integration regression proving Kimi K2.7 Code expands the invalid decorated ref
- add a negative control proving `opencode-go/glm-5.2` keeps the same caller tool unchanged

## Verification
- `npm run check`
- `git diff --check`
- `node --test test/tool-schema-root.test.mjs test/namespace-relay.test.mjs` (151/151)
- `node --test test/routing.test.mjs test/namespace-relay-routing.test.mjs` (112/112)
- `npm test` (2,865 total; 2,848 passed; 17 platform/integration skips; 0 failed)

No live provider request or quota was used. The reported upstream error supplies route-specific wire evidence; the PR reuses the already-tested repair rather than widening its semantics.