### PR TITLE
feat: add safe generic OpenAI-compatible providers

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -18,6 +18,7 @@ import {
   API_MODELS,
   MODEL_BY_GATEWAY_ID,
   PROVIDERS,
+  RUNTIME_PROVIDERS,
   providerForModel,
   endpointForModel,
   resolveProviderBaseUrl,
@@ -50,6 +51,9 @@ import {
   createResponsesStreamTransform,
   normalizeOpenAIRequest,
 } from "./openai-adapters.mjs";
+import { stripCodexEncryptedSchemaAnnotation } from "./tool-schema-root.mjs";
+import { requestGenericProvider } from "./generic-providers.mjs";
+import { genericProviderConfigured } from "./generic-provider-readiness.mjs";
 
 installStableFetchTransport();
 
@@ -304,6 +308,7 @@ function ensureToolResultsForCalls(messages) {
 const GEMINI_THOUGHT_SIGNATURE_SENTINEL = "skip_thought_signature_validator";
 
 function isGeminiProvider(provider, model) {
+  if (provider?.generic === true) return false;
   if (provider?.id === "gemini-api" || provider?.ownedBy?.toLowerCase?.() === "google") {
     return true;
   }
@@ -316,6 +321,29 @@ function isGeminiProvider(provider, model) {
     model?.gatewayModel,
     model?.model,
   ].some((value) => typeof value === "string" && value.toLowerCase().includes("gemini"));
+}
+
+function stripEncryptedToolSchemaAnnotations(payload, protocol) {
+  if (!Array.isArray(payload.tools)) return;
+  let changed = false;
+  const tools = payload.tools.map((tool) => {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool) || tool.type !== "function") {
+      return tool;
+    }
+    if (protocol === "openai-responses") {
+      const repaired = stripCodexEncryptedSchemaAnnotation(tool.parameters);
+      if (repaired === tool.parameters) return tool;
+      changed = true;
+      return { ...tool, parameters: repaired };
+    }
+    const fn = tool.function;
+    if (!fn || typeof fn !== "object" || Array.isArray(fn)) return tool;
+    const repaired = stripCodexEncryptedSchemaAnnotation(fn.parameters);
+    if (repaired === fn.parameters) return tool;
+    changed = true;
+    return { ...tool, function: { ...fn, parameters: repaired } };
+  });
+  if (changed) payload.tools = tools;
 }
 
 // A trailing model turn is a destructive rewrite: it discards part of the
@@ -668,6 +696,9 @@ function normalizeBody(buffer, contentType, route) {
       );
     }
   }
+  if (model.requestProfile === "codex-encrypted-schema") {
+    stripEncryptedToolSchemaAnnotations(payload, provider.protocol);
+  }
   if (model.requestProfile === "clinepass") {
     delete payload.reasoning_effort;
     delete payload.thinking;
@@ -905,10 +936,11 @@ function upstreamHeaders(requestHeaders, body, apiKey, provider, extraHeaders = 
     }
     if (value !== undefined) headers[name] = Array.isArray(value) ? value.join(", ") : value;
   }
-  if (endpoint.authMode === "anonymous") {
+  if (provider.generic === true || endpoint.authMode === "anonymous") {
     // The upstream explicitly permits anonymous access -- for a reseller's
-    // free-model subset, or for a single allowlisted community endpoint.
-    // Never forward the gateway's internal bearer token to either.
+    // free-model subset, a single allowlisted community endpoint, or the
+    // generic-provider boundary which injects its own confined credential.
+    // Never forward the gateway's internal bearer token to any of them.
   } else if (provider.protocol === "anthropic") {
     headers["x-api-key"] = apiKey;
     headers["anthropic-version"] ||= "2023-06-01";
@@ -922,6 +954,31 @@ function upstreamHeaders(requestHeaders, body, apiKey, provider, extraHeaders = 
   // redundant, and the HTTP/1.1 dispatcher rejects the request outright
   // (UND_ERR_INVALID_ARG) when a caller-supplied value accompanies a body.
   return headers;
+}
+
+async function relayUpstreamResponse(normalized, upstream, response, startedAt) {
+  const upstreamContentType = upstream.headers.get("content-type") || "";
+  const responsesStream = normalized.responseAdapter === "responses" &&
+    upstream.ok && upstreamContentType.toLowerCase().includes("text/event-stream");
+  const responsesJson = normalized.responseAdapter === "responses" &&
+    upstream.ok && upstreamContentType.toLowerCase().includes("application/json");
+  const transform = [
+    responsesStream ? createResponsesStreamTransform() : undefined,
+    responsesJson ? createResponsesJsonTransform() : undefined,
+    zaiCacheUsageTransform(normalized.provider.id, upstreamContentType),
+  ].filter(Boolean);
+  const denylist = transform.length
+    ? new Set([...HOP_BY_HOP_HEADERS, "content-type"])
+    : undefined;
+  if (responsesStream) response.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  if (responsesJson) response.setHeader("Content-Type", "application/json; charset=utf-8");
+  await pipeResponse(upstream, response, denylist, transform);
+  recordUpstreamLimits(normalized, upstream);
+  if (!QUIET) {
+    console.error(
+      `[api-forwarder] provider=${normalized.provider.id} model=${normalized.model.upstreamModel} status=${upstream.status} duration_ms=${Date.now() - startedAt}`,
+    );
+  }
 }
 
 async function upstreamSession(provider, credential, payload, options = {}, endpoint = provider) {
@@ -967,8 +1024,18 @@ function recordUpstreamLimits(normalized, upstream) {
 function healthPayload() {
   const providers = {};
   const enabled = new Set(readProviderSelection());
-  for (const provider of PROVIDERS.values()) {
-    if (provider.kind !== "openai-compatible" || !enabled.has(provider.id)) continue;
+  for (const provider of RUNTIME_PROVIDERS.values()) {
+    if (provider.kind !== "openai-compatible") continue;
+    if (provider.generic === true) {
+      const configured = genericProviderConfigured(provider.id);
+      providers[provider.id] = {
+        generic: true,
+        credential_present: configured,
+        credential_source: provider.credentialRef ? "bound credential reference" : "not required",
+      };
+      continue;
+    }
+    if (!enabled.has(provider.id)) continue;
     const status = credentialStatus(provider);
     providers[provider.id] = {
       credential_present: status.configured,
@@ -1020,6 +1087,44 @@ async function handleRequest(request, response) {
 
   const original = await readRequestBody(request);
   const normalized = normalizeBody(original, request.headers["content-type"], route);
+  const controller = new AbortController();
+  request.once("aborted", () => controller.abort());
+  response.once("close", () => {
+    if (!response.writableEnded) controller.abort();
+  });
+
+  // Generic providers own a stricter request boundary than checked-in routes:
+  // it re-reads the operator descriptor, revalidates DNS, rejects redirects,
+  // and injects only the credential reference bound to that provider. Do not
+  // resolve it through the built-in credential path or construct its URL here;
+  // either would bypass the confinement #404 established.
+  if (normalized.provider.generic === true) {
+    const { response: upstream, dispatcher } = await requestGenericProvider(
+      normalized.provider.id,
+      `${route}${requestUrl.search}`,
+      {
+        method: request.method,
+        headers: upstreamHeaders(
+          request.headers,
+          normalized.body,
+          undefined,
+          normalized.provider,
+        ),
+        body: normalized.body,
+        signal: controller.signal,
+        // A model generation lives as long as its caller. Discovery and the
+        // explicit provider test remain separately bounded.
+        timeoutMs: 0,
+      },
+    );
+    try {
+      await relayUpstreamResponse(normalized, upstream, response, startedAt);
+    } finally {
+      await dispatcher?.close().catch(() => undefined);
+    }
+    return;
+  }
+
   // Resolved against the endpoint, not the provider: a per-model endpoint keeps
   // its credential under its own slug, so two custom models on two hosts never
   // share a key and one missing key never blocks the other model.
@@ -1046,11 +1151,6 @@ async function handleRequest(request, response) {
     return;
   }
 
-  const controller = new AbortController();
-  request.once("aborted", () => controller.abort());
-  response.once("close", () => {
-    if (!response.writableEnded) controller.abort();
-  });
   // Command Code's documented API is an entitlement, not a credential: the
   // same key that runs its CLI is refused by /provider/v1 on the plans most of
   // its customers buy. The CLI's own route serves those plans, so an account
@@ -1177,28 +1277,7 @@ async function handleRequest(request, response) {
   if (commandCode?.recheck && upstream.ok) {
     recordCommandCodeRoute(commandCode.id, credential.value, { providerApi: true });
   }
-  const upstreamContentType = upstream.headers.get("content-type") || "";
-  const responsesStream = normalized.responseAdapter === "responses" &&
-    upstream.ok && upstreamContentType.toLowerCase().includes("text/event-stream");
-  const responsesJson = normalized.responseAdapter === "responses" &&
-    upstream.ok && upstreamContentType.toLowerCase().includes("application/json");
-  const transform = [
-    responsesStream ? createResponsesStreamTransform() : undefined,
-    responsesJson ? createResponsesJsonTransform() : undefined,
-    zaiCacheUsageTransform(normalized.provider.id, upstreamContentType),
-  ].filter(Boolean);
-  const denylist = transform.length
-    ? new Set([...HOP_BY_HOP_HEADERS, "content-type"])
-    : undefined;
-  if (responsesStream) response.setHeader("Content-Type", "text/event-stream; charset=utf-8");
-  if (responsesJson) response.setHeader("Content-Type", "application/json; charset=utf-8");
-  await pipeResponse(upstream, response, denylist, transform);
-  recordUpstreamLimits(normalized, upstream);
-  if (!QUIET) {
-    console.error(
-      `[api-forwarder] provider=${normalized.provider.id} model=${normalized.model.upstreamModel} status=${upstream.status} duration_ms=${Date.now() - startedAt}`,
-    );
-  }
+  await relayUpstreamResponse(normalized, upstream, response, startedAt);
 }
 
 const server = http.createServer((request, response) => {

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -661,8 +661,12 @@ async function printProviderOnboarding() {
 }
 
 async function handleGenericProviders(...commandArgs) {
-  const { runGenericProviderCli } = await import("./generic-providers.mjs");
-  await runGenericProviderCli(commandArgs, { output: process.stdout });
+  // The control center and the provider CLI must cross the same publication
+  // boundary. Calling the descriptor CRUD layer directly here can leave a
+  // running route and every installed client's picker on the pre-mutation
+  // registry until some unrelated later apply.
+  const { runGenericCommand } = await import("./providers.mjs");
+  await runGenericCommand(commandArgs);
 }
 
 async function installProviderCli(providerId) {

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -2,7 +2,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { discoverProviderModels } from "./model-discovery.mjs";
-import { CHECKED_IN_MODELS, PROVIDERS, USER_MODEL_WARNINGS } from "./model-registry.mjs";
+import {
+  CHECKED_IN_MODELS,
+  RUNTIME_PROVIDERS,
+  RUNTIME_PROVIDER_WARNINGS,
+  USER_MODEL_WARNINGS,
+} from "./model-registry.mjs";
 import { confirm, promptLine } from "./setup-shared.mjs";
 import { toggleSelection } from "./setup-ui.mjs";
 import {
@@ -33,6 +38,7 @@ import {
   MODEL_PICKER_STATE_PATH,
   setModelsVisible,
 } from "./model-picker-state.mjs";
+import { CURATABLE_REQUEST_PROFILES, curatableRequestProfile } from "./request-profiles.mjs";
 
 // Interactive curation: list the provider's live models that are not part of
 // the checked-in registry, let the user toggle the ones they want, and persist
@@ -83,7 +89,14 @@ const AUTO_TOOL_CHOICE = "auto-tool-choice";
 const REQUEST_PROFILE_DESCRIPTIONS = {
   [AUTO_TOOL_CHOICE]:
     'reject a forced tool_choice ("required") while still calling tools under "auto"',
+  "codex-encrypted-schema":
+    "reject Codex's encrypted annotation on JSON-Schema nodes while accepting the same tool schema without it",
 };
+
+if (Object.keys(REQUEST_PROFILE_DESCRIPTIONS).some((profile) => !curatableRequestProfile(profile)) ||
+    CURATABLE_REQUEST_PROFILES.some((profile) => !REQUEST_PROFILE_DESCRIPTIONS[profile])) {
+  throw new Error("Curatable request-profile descriptions are out of sync.");
+}
 
 // Codex compacts at this fraction of the declared window.
 const AUTO_COMPACT_RATIO = 0.85;
@@ -287,9 +300,17 @@ export function parseEfforts(raw) {
 }
 
 if (!requestedProviderId) usage();
-const provider = PROVIDERS.get(providerId);
+const provider = RUNTIME_PROVIDERS.get(providerId);
 if (!provider) {
+  for (const warning of RUNTIME_PROVIDER_WARNINGS) console.error(warning);
   console.error(`Unknown provider: ${providerId}`);
+  process.exit(2);
+}
+if (provider.generic === true && provider.adapter === "openai-completions") {
+  console.error(
+    `${provider.displayName} exposes legacy OpenAI Completions. Codex Router can discover ` +
+      "that catalog but has no completions caller surface, so those models cannot be curated or published.",
+  );
   process.exit(2);
 }
 const flagEfforts = (() => {
@@ -344,6 +365,7 @@ function chooseInteractively(candidates, curated) {
 
 
 async function main() {
+  for (const warning of RUNTIME_PROVIDER_WARNINGS) console.error(warning);
   for (const warning of USER_MODEL_WARNINGS) console.error(warning);
   const existing = readUserModels();
   const familyProviderIds = curationProviderIds(providerId);

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -10,7 +10,13 @@ import { privateFileIsProtected } from "./file-security.mjs";
 import { grokCliPreflight } from "./grok-cli.mjs";
 import { detectLegacyInstallations } from "./legacy-migration.mjs";
 import { routedCatalogConfigured } from "./catalog.mjs";
-import { MODEL_BY_SLUG, PROVIDERS } from "./model-registry.mjs";
+import {
+  MODEL_BY_SLUG,
+  MODELS,
+  PROVIDERS,
+  RUNTIME_PROVIDERS,
+  RUNTIME_PROVIDER_WARNINGS,
+} from "./model-registry.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
 import {
   antigravityOAuthHealth,
@@ -48,6 +54,7 @@ import {
 } from "./skills-install.mjs";
 import { discoveryDisabled } from "./discovery-mode.mjs";
 import { credentialLabel, credentialStatus } from "./provider-credentials.mjs";
+import { genericProviderConfigured } from "./generic-provider-readiness.mjs";
 import { providerNeedsCuration } from "./provider-onboarding.mjs";
 import { stateOwnershipStatus } from "./state-owner.mjs";
 import {
@@ -842,6 +849,39 @@ if (!credentialDiscoveryOff) {
     antigravityHealth.detail,
     antigravityHealth.fix,
   );
+}
+
+for (const warning of RUNTIME_PROVIDER_WARNINGS) {
+  add(
+    "fail",
+    "Generic provider registry",
+    warning,
+    "Repair or remove the malformed generic provider descriptor, then rerun the doctor.",
+  );
+}
+
+for (const provider of RUNTIME_PROVIDERS.values()) {
+  if (provider.generic !== true) continue;
+  const configured = genericProviderConfigured(provider.id);
+  const curated = MODELS.filter((model) => model.provider === provider.id).length;
+  add(
+    configured ? "ok" : "fail",
+    `${provider.displayName} generic provider`,
+    configured
+      ? `${provider.credentialRef ? "bound credential is available" : "no credential required"}; ${curated} curated model route(s)`
+      : "the bound credential is unavailable",
+    configured
+      ? `Run ./bin/curate-models ${provider.id} to review its routed models.`
+      : "Repair the provider-bound credential reference, then rerun the doctor.",
+  );
+  if (configured && curated === 0) {
+    add(
+      "warn",
+      `${provider.displayName} models`,
+      "provider is registered but has no curated model routes",
+      `Run ./bin/curate-models ${provider.id} in an interactive terminal.`,
+    );
+  }
 }
 
 for (const provider of PROVIDERS.values()) {

--- a/src/generic-provider-identity.mjs
+++ b/src/generic-provider-identity.mjs
@@ -1,13 +1,19 @@
-import { PROVIDERS } from "./model-registry.mjs";
-
 export const GENERIC_PROVIDER_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
-export function normalizeGenericProviderId(value) {
+export function normalizeGenericProviderIdSyntax(value) {
   const providerId = typeof value === "string" ? value.trim() : "";
   if (!GENERIC_PROVIDER_ID_PATTERN.test(providerId)) {
     throw new Error("Provider id must match [a-z0-9][a-z0-9-]*.");
   }
-  if (PROVIDERS.has(providerId)) {
+  return providerId;
+}
+
+export function normalizeGenericProviderId(value, { reservedProviderIds } = {}) {
+  const providerId = normalizeGenericProviderIdSyntax(value);
+  if (!reservedProviderIds?.has) {
+    throw new Error("Generic provider identity validation requires the checked-in provider registry.");
+  }
+  if (reservedProviderIds?.has?.(providerId)) {
     throw new Error(`Provider id ${providerId} is already used by the built-in registry.`);
   }
   return providerId;

--- a/src/generic-provider-readiness.mjs
+++ b/src/generic-provider-readiness.mjs
@@ -1,0 +1,32 @@
+import { readGenericProviders } from "./generic-provider-state.mjs";
+import { PROVIDERS } from "./model-registry.mjs";
+import { readProviderCredentialStore } from "./provider-credential-store.mjs";
+import { resolveGenericProviderCredentialReference } from "./provider-credentials.mjs";
+
+function credentialAvailable(provider) {
+  const entry = readProviderCredentialStore().credentials.find(
+    (candidate) => candidate.id === provider.credentialRef,
+  );
+  if (!entry || entry.state !== "active") return false;
+  if (entry.providerType !== "generic" || entry.providerId !== provider.id) return false;
+  if (entry.kind !== "api_key") return false;
+  return Boolean(
+    resolveGenericProviderCredentialReference(provider.id, entry.secretRef)?.value,
+  );
+}
+
+// Catalog publication needs a boolean readiness answer, never the credential
+// itself. Keep this separate from generic-providers.mjs so setup and provider
+// selection do not import the undici request transport before npm dependencies
+// have been installed. A credentialless endpoint is ready only after an
+// operator explicitly registered and enabled it in generic provider state.
+export function genericProviderConfigured(providerId) {
+  try {
+    const provider = readGenericProviders({ reservedProviderIds: PROVIDERS })
+      .find((entry) => entry.id === providerId);
+    if (!provider?.enabled) return false;
+    return !provider.credentialRef || credentialAvailable(provider);
+  } catch {
+    return false;
+  }
+}

--- a/src/generic-provider-state.mjs
+++ b/src/generic-provider-state.mjs
@@ -1,0 +1,303 @@
+import { existsSync, readFileSync } from "node:fs";
+import { isIP } from "node:net";
+
+import {
+  normalizeGenericProviderId,
+  normalizeGenericProviderIdSyntax,
+} from "./generic-provider-identity.mjs";
+import { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
+
+export { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
+
+// This module is intentionally dependency-light. The checked-in model
+// registry reads it while constructing the runtime provider map, so importing
+// model-registry (directly or through credential/request helpers) from here
+// would make provider loading depend on an initialization cycle.
+export const GENERIC_PROVIDER_SCHEMA_VERSION = 1;
+export const GENERIC_PROVIDER_ADAPTERS = Object.freeze([
+  "openai-chat",
+  "openai-responses",
+  "openai-completions",
+]);
+
+const FORBIDDEN_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authorization",
+  "x-api-key",
+  "api-key",
+  "cookie",
+  "set-cookie",
+  "host",
+  "content-length",
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+const MAX_HEADERS = 64;
+const MAX_HEADER_VALUE_LENGTH = 4_096;
+const MAX_DESCRIPTION_LENGTH = 240;
+const SECRET_HEADER_PATTERN = /(?:^|[-_])(auth|authorization|api[-_]?key|key|token|secret|credential|cookie|password|session|signature)(?:$|[-_])/i;
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function normalizeBaseUrl(value) {
+  return text(value).replace(/\/+$/, "");
+}
+
+function isIpv4(value) {
+  const parts = value.split(".");
+  return parts.length === 4 && parts.every((part) => /^\d+$/.test(part) && Number(part) <= 255);
+}
+
+function isPrivateIpv4(value) {
+  if (!isIpv4(value)) return false;
+  const [a, b] = value.split(".").map(Number);
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && [0, 2, 168].includes(b)) ||
+    (a === 198 && b >= 18 && b <= 19) ||
+    (a === 198 && b === 51) ||
+    (a === 203 && b === 0) ||
+    a >= 224
+  );
+}
+
+export function isPrivateGenericProviderAddress(value) {
+  const address = String(value || "").toLowerCase();
+  const family = isIP(address);
+  if (family === 4) return isPrivateIpv4(address);
+  if (family !== 6) return false;
+  const withoutZone = address.split("%")[0];
+  const parts = withoutZone.split("::");
+  if (parts.length > 2) return false;
+  const expand = (segment) => {
+    if (!segment) return [];
+    const values = segment.split(":");
+    const result = [];
+    for (const valuePart of values) {
+      if (valuePart.includes(".")) {
+        if (!isIpv4(valuePart)) return undefined;
+        const [first, second, third, fourth] = valuePart.split(".").map(Number);
+        result.push(((first << 8) | second).toString(16), ((third << 8) | fourth).toString(16));
+      } else if (/^[0-9a-f]{1,4}$/.test(valuePart)) {
+        result.push(valuePart);
+      } else {
+        return undefined;
+      }
+    }
+    return result;
+  };
+  const left = expand(parts[0]);
+  const right = expand(parts[1] || "");
+  if (!left || !right) return false;
+  const hextets = parts.length === 2
+    ? [...left, ...Array(8 - left.length - right.length).fill("0"), ...right]
+    : left;
+  if (hextets.length !== 8) return false;
+  const first = Number.parseInt(hextets[0], 16);
+  const high = hextets.map((part) => BigInt(`0x${part}`)).reduce((valuePart, part) => (valuePart << 16n) | part, 0n);
+  if (high === 0n || high === 1n) return true;
+  if ((high >> 32n) === 0xffffn) {
+    const mapped = Number(high & 0xffffffffn);
+    const mappedAddress = `${mapped >>> 24}.${(mapped >>> 16) & 255}.${(mapped >>> 8) & 255}.${mapped & 255}`;
+    return isPrivateIpv4(mappedAddress);
+  }
+  return (first & 0xfe00) === 0xfc00 || (first & 0xffc0) === 0xfe80 || (first & 0xff00) === 0xff00;
+}
+
+export function isPrivateGenericProviderHostname(hostname) {
+  const host = String(hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
+  if (!host) return false;
+  if (isPrivateGenericProviderAddress(host)) return true;
+  return host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local");
+}
+
+function validateEndpoint(urlValue, allowPrivate) {
+  const baseUrl = normalizeBaseUrl(urlValue);
+  let parsed;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error("baseUrl must be an absolute HTTP(S) URL.");
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("baseUrl must use http or https.");
+  }
+  if (!parsed.hostname || parsed.username || parsed.password) {
+    throw new Error("baseUrl must not contain credentials and must include a hostname.");
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error("baseUrl must not contain a query string or fragment.");
+  }
+  const privateHost = isPrivateGenericProviderHostname(parsed.hostname);
+  if (parsed.protocol === "http:" && (!allowPrivate || !privateHost)) {
+    throw new Error("Plain HTTP endpoints must be private and require allowPrivate=true.");
+  }
+  if (privateHost && !allowPrivate) {
+    throw new Error("Private or loopback endpoints require allowPrivate=true.");
+  }
+  return { baseUrl };
+}
+
+export function validateGenericProviderHeaders(raw) {
+  if (raw === undefined) return {};
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("headers must be an object of static header values.");
+  }
+  const entries = Object.entries(raw);
+  if (entries.length > MAX_HEADERS) throw new Error(`headers may contain at most ${MAX_HEADERS} entries.`);
+  const headers = {};
+  for (const [nameValue, valueValue] of entries) {
+    const name = text(nameValue);
+    const lower = name.toLowerCase();
+    const value = typeof valueValue === "string" ? valueValue : "";
+    if (!HEADER_NAME_PATTERN.test(name)) throw new Error(`Invalid header name: ${nameValue}`);
+    if (FORBIDDEN_HEADER_NAMES.has(lower) || SECRET_HEADER_PATTERN.test(lower)) {
+      throw new Error(`Header ${name} is reserved for credential or transport handling.`);
+    }
+    if (!value || value.length > MAX_HEADER_VALUE_LENGTH || /[\r\n]/.test(value)) {
+      throw new Error(`Header ${name} has an invalid value.`);
+    }
+    headers[name] = value;
+  }
+  return headers;
+}
+
+function validateCredentialRef(value) {
+  if (value === undefined || value === null || value === "") return undefined;
+  const ref = text(value);
+  if (!/^cred_[a-zA-Z0-9][a-zA-Z0-9._:-]{2,127}$/.test(ref)) {
+    throw new Error("credentialRef must be an opaque id beginning with cred_.");
+  }
+  return ref;
+}
+
+export function validateGenericProvider(input, { existingId, reservedProviderIds } = {}) {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("A generic provider must be an object.");
+  }
+  const id = reservedProviderIds
+    ? normalizeGenericProviderId(input.id, { reservedProviderIds })
+    : normalizeGenericProviderIdSyntax(input.id);
+  if (existingId !== undefined && id !== existingId) {
+    throw new Error("Provider id cannot be changed; remove and add a new provider instead.");
+  }
+  const displayName = text(input.displayName);
+  if (!displayName || displayName.length > 120) {
+    throw new Error("displayName must be a non-empty string of at most 120 characters.");
+  }
+  const adapter = text(input.adapter) || "openai-chat";
+  if (!GENERIC_PROVIDER_ADAPTERS.includes(adapter)) {
+    throw new Error(`adapter must be one of: ${GENERIC_PROVIDER_ADAPTERS.join(", ")}.`);
+  }
+  const allowPrivate = input.allowPrivate === undefined ? false : input.allowPrivate;
+  if (typeof allowPrivate !== "boolean") throw new Error("allowPrivate must be a boolean.");
+  const { baseUrl } = validateEndpoint(input.baseUrl, allowPrivate);
+  const headers = validateGenericProviderHeaders(input.headers);
+  const credentialRef = validateCredentialRef(input.credentialRef);
+  const description = input.description === undefined ? undefined : text(input.description);
+  if (description !== undefined && description.length > MAX_DESCRIPTION_LENGTH) {
+    throw new Error(`description must be at most ${MAX_DESCRIPTION_LENGTH} characters.`);
+  }
+  const enabled = input.enabled === undefined ? true : input.enabled;
+  if (typeof enabled !== "boolean") throw new Error("enabled must be a boolean.");
+  return {
+    id,
+    displayName,
+    ...(description ? { description } : {}),
+    baseUrl,
+    adapter,
+    headers,
+    ...(credentialRef ? { credentialRef } : {}),
+    allowPrivate,
+    enabled,
+  };
+}
+
+export function parseGenericProviderDocument(payload, { reservedProviderIds } = {}) {
+  if (payload === undefined) return { version: GENERIC_PROVIDER_SCHEMA_VERSION, providers: [] };
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error(`Invalid generic provider state ${GENERIC_PROVIDERS_PATH}: expected an object.`);
+  }
+  if (payload.version !== GENERIC_PROVIDER_SCHEMA_VERSION || !Array.isArray(payload.providers)) {
+    throw new Error(
+      `Invalid generic provider state ${GENERIC_PROVIDERS_PATH}: version must be ${GENERIC_PROVIDER_SCHEMA_VERSION} and providers must be an array.`,
+    );
+  }
+  const providers = [];
+  const seen = new Set();
+  for (const entry of payload.providers) {
+    const provider = validateGenericProvider(entry, { reservedProviderIds });
+    if (seen.has(provider.id)) throw new Error(`Duplicate generic provider id ${provider.id}.`);
+    seen.add(provider.id);
+    providers.push(provider);
+  }
+  return { version: GENERIC_PROVIDER_SCHEMA_VERSION, providers };
+}
+
+export function readGenericProviders({ reservedProviderIds } = {}) {
+  if (!existsSync(GENERIC_PROVIDERS_PATH)) return [];
+  let serialized;
+  try {
+    serialized = readFileSync(GENERIC_PROVIDERS_PATH, "utf8");
+  } catch (error) {
+    throw new Error(`Could not read generic provider state: ${errorMessage(error)}`);
+  }
+  let payload;
+  try {
+    payload = JSON.parse(serialized);
+  } catch {
+    // JSON parser messages can quote input fragments. This state may contain
+    // raw static header values, so diagnostics identify the document without
+    // reflecting any of its bytes.
+    throw new Error(`Invalid generic provider state ${GENERIC_PROVIDERS_PATH}: document is not valid JSON.`);
+  }
+  return parseGenericProviderDocument(payload, { reservedProviderIds }).providers;
+}
+
+export function redactGenericProvider(provider, { reservedProviderIds } = {}) {
+  const value = validateGenericProvider(provider, {
+    existingId: provider.id,
+    reservedProviderIds,
+  });
+  return {
+    ...value,
+    headers: Object.fromEntries(Object.keys(value.headers).map((name) => [name, "[redacted]"])),
+  };
+}
+
+export function genericProviderRuntimeDescriptor(provider) {
+  const value = validateGenericProvider(provider, { existingId: provider.id });
+  return Object.freeze({
+    id: value.id,
+    displayName: value.displayName,
+    kind: "openai-compatible",
+    ownedBy: value.id,
+    baseUrl: value.baseUrl,
+    adapter: value.adapter,
+    protocol: value.adapter === "openai-responses" ? "openai-responses" : "openai",
+    // Raw static header values stay inside the request boundary and never
+    // become model registry or diagnostic data.
+    headers: Object.freeze(
+      Object.fromEntries(Object.keys(value.headers).map((name) => [name, "[redacted]"])),
+    ),
+    allowPrivate: value.allowPrivate,
+    enabled: value.enabled,
+    ...(value.credentialRef ? { credentialRef: value.credentialRef } : {}),
+    generic: true,
+  });
+}

--- a/src/generic-providers.mjs
+++ b/src/generic-providers.mjs
@@ -1,58 +1,38 @@
 import { promises as dns } from "node:dns";
-import { existsSync, readFileSync } from "node:fs";
 import { isIP } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Agent, fetch as undiciFetch } from "undici";
 
-import { normalizeGenericProviderId } from "./generic-provider-identity.mjs";
-import { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
 import { withAtomicStateLock } from "./atomic-state-lock.mjs";
+import {
+  GENERIC_PROVIDER_SCHEMA_VERSION,
+  GENERIC_PROVIDERS_PATH,
+  genericProviderRuntimeDescriptor,
+  isPrivateGenericProviderAddress,
+  isPrivateGenericProviderHostname,
+  parseGenericProviderDocument,
+  readGenericProviders as readGenericProviderState,
+  redactGenericProvider as redactGenericProviderState,
+  validateGenericProvider,
+  validateGenericProviderHeaders,
+} from "./generic-provider-state.mjs";
 import { providerCatalogIdentityFingerprint } from "./model-catalog-cache.mjs";
+import { PROVIDERS } from "./model-registry.mjs";
 import { readProviderCredentialStore } from "./provider-credential-store.mjs";
 import { resolveGenericProviderCredentialReference } from "./provider-credentials.mjs";
 
-export { GENERIC_PROVIDERS_PATH } from "./paths.mjs";
+export {
+  GENERIC_PROVIDER_ADAPTERS,
+  GENERIC_PROVIDER_SCHEMA_VERSION,
+  GENERIC_PROVIDERS_PATH,
+} from "./generic-provider-state.mjs";
+export { genericProviderConfigured } from "./generic-provider-readiness.mjs";
 import { writePrivateJson } from "./file-security.mjs";
 import { fetchUntrustedModelCatalog } from "./untrusted-model-discovery.mjs";
 
-// Generic providers are deliberately kept in a separate user-owned document.
-// The checked-in registry remains the authority for native and curated models;
-// P06 can merge this descriptor into that registry after capability discovery.
-// Keeping the two documents separate also means a checkout update cannot erase
-// an operator's endpoint definitions.
-export const GENERIC_PROVIDER_SCHEMA_VERSION = 1;
-export const GENERIC_PROVIDER_ADAPTERS = Object.freeze([
-  "openai-chat",
-  "openai-responses",
-  "openai-completions",
-]);
-
-// These names are either hop-by-hop transport headers or common secret
-// carriers. A generic provider may declare static routing metadata, but P02's
-// credential references must be used for authentication headers later.
-const FORBIDDEN_HEADER_NAMES = new Set([
-  "authorization",
-  "proxy-authorization",
-  "x-api-key",
-  "api-key",
-  "cookie",
-  "set-cookie",
-  "host",
-  "content-length",
-  "connection",
-  "keep-alive",
-  "transfer-encoding",
-  "upgrade",
-]);
-
-const HEADER_NAME_PATTERN = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
-const MAX_HEADERS = 64;
-const MAX_HEADER_VALUE_LENGTH = 4_096;
-const MAX_DESCRIPTION_LENGTH = 240;
 const MAX_RESPONSE_BYTES = 64 * 1024;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
-const SECRET_HEADER_PATTERN = /(?:^|[-_])(auth|authorization|api[-_]?key|key|token|secret|credential|cookie|password|session|signature)(?:$|[-_])/i;
 
 function text(value) {
   return typeof value === "string" ? value.trim() : "";
@@ -62,227 +42,18 @@ function errorMessage(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
-function normalizeBaseUrl(value) {
-  return text(value).replace(/\/+$/, "");
-}
-
-function isIpv4(value) {
-  const parts = value.split(".");
-  return parts.length === 4 && parts.every((part) => /^\d+$/.test(part) && Number(part) <= 255);
-}
-
-function isPrivateIpv4(value) {
-  if (!isIpv4(value)) return false;
-  const [a, b] = value.split(".").map(Number);
-  return (
-    a === 0 ||
-    a === 10 ||
-    a === 127 ||
-    (a === 100 && b >= 64 && b <= 127) ||
-    (a === 169 && b === 254) ||
-    (a === 172 && b >= 16 && b <= 31) ||
-    (a === 192 && [0, 2, 168].includes(b)) ||
-    (a === 198 && b >= 18 && b <= 19) ||
-    (a === 198 && b === 51) ||
-    (a === 203 && b === 0) ||
-    a >= 224
-  );
-}
-
-function isPrivateAddress(value) {
-  const address = String(value || "").toLowerCase();
-  const family = isIP(address);
-  if (family === 4) return isPrivateIpv4(address);
-  if (family !== 6) return false;
-  const withoutZone = address.split("%")[0];
-  const parts = withoutZone.split("::");
-  if (parts.length > 2) return false;
-  const expand = (segment) => {
-    if (!segment) return [];
-    const values = segment.split(":");
-    const result = [];
-    for (const valuePart of values) {
-      if (valuePart.includes(".")) {
-        if (!isIpv4(valuePart)) return undefined;
-        const [first, second, third, fourth] = valuePart.split(".").map(Number);
-        result.push(((first << 8) | second).toString(16), ((third << 8) | fourth).toString(16));
-      } else if (/^[0-9a-f]{1,4}$/.test(valuePart)) {
-        result.push(valuePart);
-      } else {
-        return undefined;
-      }
-    }
-    return result;
-  };
-  const left = expand(parts[0]);
-  const right = expand(parts[1] || "");
-  if (!left || !right) return false;
-  const hextets = parts.length === 2
-    ? [...left, ...Array(8 - left.length - right.length).fill("0"), ...right]
-    : left;
-  if (hextets.length !== 8) return false;
-  const first = Number.parseInt(hextets[0], 16);
-  const high = hextets.map((part) => BigInt(`0x${part}`)).reduce((valuePart, part) => (valuePart << 16n) | part, 0n);
-  if (high === 0n || high === 1n) return true;
-  if ((high >> 32n) === 0xffffn) {
-    const mapped = Number(high & 0xffffffffn);
-    const mappedAddress = `${mapped >>> 24}.${(mapped >>> 16) & 255}.${(mapped >>> 8) & 255}.${mapped & 255}`;
-    return isPrivateIpv4(mappedAddress);
-  }
-  return (first & 0xfe00) === 0xfc00 || (first & 0xffc0) === 0xfe80 || (first & 0xff00) === 0xff00;
-}
-
-function isPrivateHostname(hostname) {
-  const host = String(hostname || "").toLowerCase().replace(/^\[|\]$/g, "");
-  if (!host) return false;
-  if (isPrivateAddress(host)) return true;
-  if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) {
-    return true;
-  }
-  // IPv6 loopback, link-local and unique-local ranges. This intentionally
-  // does not try to parse every IPv6 spelling; DNS lookup in testGenericProvider
-  // catches resolved private addresses before a request is sent.
-  return false;
-}
-
-function validateEndpoint(urlValue, allowPrivate) {
-  const baseUrl = normalizeBaseUrl(urlValue);
-  let parsed;
-  try {
-    parsed = new URL(baseUrl);
-  } catch {
-    throw new Error("baseUrl must be an absolute HTTP(S) URL.");
-  }
-  if (!["http:", "https:"].includes(parsed.protocol)) {
-    throw new Error("baseUrl must use http or https.");
-  }
-  if (!parsed.hostname || parsed.username || parsed.password) {
-    throw new Error("baseUrl must not contain credentials and must include a hostname.");
-  }
-  if (parsed.search || parsed.hash) {
-    throw new Error("baseUrl must not contain a query string or fragment.");
-  }
-  const privateHost = isPrivateHostname(parsed.hostname);
-  if (parsed.protocol === "http:" && (!allowPrivate || !privateHost)) {
-    throw new Error("Plain HTTP endpoints must be private and require allowPrivate=true.");
-  }
-  if (privateHost && !allowPrivate) {
-    throw new Error("Private or loopback endpoints require allowPrivate=true.");
-  }
-  return { baseUrl, privateHost };
-}
-
-function validateHeaders(raw) {
-  if (raw === undefined) return {};
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    throw new Error("headers must be an object of static header values.");
-  }
-  const entries = Object.entries(raw);
-  if (entries.length > MAX_HEADERS) throw new Error(`headers may contain at most ${MAX_HEADERS} entries.`);
-  const headers = {};
-  for (const [nameValue, valueValue] of entries) {
-    const name = text(nameValue);
-    const lower = name.toLowerCase();
-    const value = typeof valueValue === "string" ? valueValue : "";
-    if (!HEADER_NAME_PATTERN.test(name)) throw new Error(`Invalid header name: ${nameValue}`);
-    if (FORBIDDEN_HEADER_NAMES.has(lower) || SECRET_HEADER_PATTERN.test(lower)) {
-      throw new Error(`Header ${name} is reserved for credential or transport handling.`);
-    }
-    if (!value || value.length > MAX_HEADER_VALUE_LENGTH || /[\r\n]/.test(value)) {
-      throw new Error(`Header ${name} has an invalid value.`);
-    }
-    headers[name] = value;
-  }
-  return headers;
-}
-
-function validateCredentialRef(value) {
-  if (value === undefined || value === null || value === "") return undefined;
-  const ref = text(value);
-  if (!/^cred_[a-zA-Z0-9][a-zA-Z0-9._:-]{2,127}$/.test(ref)) {
-    throw new Error("credentialRef must be an opaque id beginning with cred_.");
-  }
-  return ref;
-}
-
-function validateProvider(input, { existingId } = {}) {
-  if (!input || typeof input !== "object" || Array.isArray(input)) {
-    throw new Error("A generic provider must be an object.");
-  }
-  const id = normalizeGenericProviderId(input.id);
-  if (existingId !== undefined && id !== existingId) {
-    throw new Error("Provider id cannot be changed; remove and add a new provider instead.");
-  }
-  const displayName = text(input.displayName);
-  if (!displayName || displayName.length > 120) {
-    throw new Error("displayName must be a non-empty string of at most 120 characters.");
-  }
-  const adapter = text(input.adapter) || "openai-chat";
-  if (!GENERIC_PROVIDER_ADAPTERS.includes(adapter)) {
-    throw new Error(`adapter must be one of: ${GENERIC_PROVIDER_ADAPTERS.join(", ")}.`);
-  }
-  const allowPrivate = input.allowPrivate === undefined ? false : input.allowPrivate;
-  if (typeof allowPrivate !== "boolean") throw new Error("allowPrivate must be a boolean.");
-  const { baseUrl } = validateEndpoint(input.baseUrl, allowPrivate);
-  const headers = validateHeaders(input.headers);
-  const credentialRef = validateCredentialRef(input.credentialRef);
-  const description = input.description === undefined ? undefined : text(input.description);
-  if (description !== undefined && description.length > MAX_DESCRIPTION_LENGTH) {
-    throw new Error(`description must be at most ${MAX_DESCRIPTION_LENGTH} characters.`);
-  }
-  const enabled = input.enabled === undefined ? true : input.enabled;
-  if (typeof enabled !== "boolean") throw new Error("enabled must be a boolean.");
-  return {
-    id,
-    displayName,
-    ...(description ? { description } : {}),
-    baseUrl,
-    adapter,
-    headers,
-    ...(credentialRef ? { credentialRef } : {}),
-    allowPrivate,
-    enabled,
-  };
-}
-
-function parseDocument(payload) {
-  if (payload === undefined) return { version: GENERIC_PROVIDER_SCHEMA_VERSION, providers: [] };
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
-    throw new Error(`Invalid generic provider state ${GENERIC_PROVIDERS_PATH}: expected an object.`);
-  }
-  if (payload.version !== GENERIC_PROVIDER_SCHEMA_VERSION || !Array.isArray(payload.providers)) {
-    throw new Error(
-      `Invalid generic provider state ${GENERIC_PROVIDERS_PATH}: version must be ${GENERIC_PROVIDER_SCHEMA_VERSION} and providers must be an array.`,
-    );
-  }
-  const providers = [];
-  const seen = new Set();
-  for (const entry of payload.providers) {
-    const provider = validateProvider(entry);
-    if (seen.has(provider.id)) throw new Error(`Duplicate generic provider id ${provider.id}.`);
-    seen.add(provider.id);
-    providers.push(provider);
-  }
-  return { version: GENERIC_PROVIDER_SCHEMA_VERSION, providers };
+function unavailable(message) {
+  const error = new Error(message);
+  error.status = 503;
+  return error;
 }
 
 export function readGenericProviders() {
-  if (!existsSync(GENERIC_PROVIDERS_PATH)) return [];
-  let payload;
-  try {
-    payload = JSON.parse(readFileSync(GENERIC_PROVIDERS_PATH, "utf8"));
-  } catch (error) {
-    throw new Error(`Could not read generic provider state: ${errorMessage(error)}`);
-  }
-  return parseDocument(payload).providers;
+  return readGenericProviderState({ reservedProviderIds: PROVIDERS });
 }
 
 export function redactGenericProvider(provider) {
-  const value = validateProvider(provider, { existingId: provider.id });
-  return {
-    ...value,
-    headers: Object.fromEntries(Object.keys(value.headers).map((name) => [name, "[redacted]"])),
-  };
+  return redactGenericProviderState(provider, { reservedProviderIds: PROVIDERS });
 }
 
 export function listGenericProviders({ redacted = true } = {}) {
@@ -309,14 +80,17 @@ function mutateProviders(mutator) {
     const current = readGenericProviders();
     const next = mutator(current.map((provider) => ({ ...provider, headers: { ...provider.headers } })));
     if (!Array.isArray(next)) throw new Error("Generic provider mutation returned an invalid list.");
-    const validated = parseDocument({ version: GENERIC_PROVIDER_SCHEMA_VERSION, providers: next }).providers;
+    const validated = parseGenericProviderDocument(
+      { version: GENERIC_PROVIDER_SCHEMA_VERSION, providers: next },
+      { reservedProviderIds: PROVIDERS },
+    ).providers;
     saveProviders(validated);
     return validated;
   });
 }
 
 export function addGenericProvider(input) {
-  const provider = validateProvider(input);
+  const provider = validateGenericProvider(input, { reservedProviderIds: PROVIDERS });
   const providers = mutateProviders((current) => {
     if (current.some((entry) => entry.id === provider.id)) {
       throw new Error(`Generic provider ${provider.id} already exists.`);
@@ -332,7 +106,10 @@ export function updateGenericProvider(id, patch) {
   mutateProviders((current) => {
     const existing = current.find((entry) => entry.id === providerId);
     if (!existing) throw new Error(`Unknown generic provider: ${id}`);
-    updated = validateProvider({ ...existing, ...patch, id: existing.id }, { existingId: existing.id });
+    updated = validateGenericProvider(
+      { ...existing, ...patch, id: existing.id },
+      { existingId: existing.id, reservedProviderIds: PROVIDERS },
+    );
     return current.map((entry) => entry.id === existing.id ? updated : entry);
   });
   return redactGenericProvider(updated);
@@ -354,30 +131,14 @@ export function setGenericProviderEnabled(id, enabled) {
   return updateGenericProvider(id, { enabled });
 }
 
-// This descriptor is intentionally not inserted into PROVIDERS yet. P05/P06
-// can map `adapter` to a wire protocol and merge it with discovered models,
-// while native GPT catalog ownership stays untouched in the meantime.
 export function genericProviderDescriptor(providerOrId) {
   const provider = typeof providerOrId === "string"
     ? getGenericProvider(providerOrId)
-    : validateProvider(providerOrId, { existingId: providerOrId.id });
-  return {
-    id: provider.id,
-    displayName: provider.displayName,
-    kind: "openai-compatible",
-    ownedBy: provider.id,
-    baseUrl: provider.baseUrl,
-    adapter: provider.adapter,
-    protocol: provider.adapter === "openai-responses" ? "openai-responses" : "openai",
-    // The descriptor is safe to hand to catalogs and UI surfaces. Raw static
-    // header values stay inside the request boundary and never become a model
-    // descriptor or loggable catalog field.
-    headers: Object.fromEntries(Object.keys(provider.headers).map((name) => [name, "[redacted]"])),
-    allowPrivate: provider.allowPrivate,
-    enabled: provider.enabled,
-    ...(provider.credentialRef ? { credentialRef: provider.credentialRef } : {}),
-    generic: true,
-  };
+    : validateGenericProvider(providerOrId, {
+        existingId: providerOrId.id,
+        reservedProviderIds: PROVIDERS,
+      });
+  return genericProviderRuntimeDescriptor(provider);
 }
 
 async function lookupHost(hostname) {
@@ -407,12 +168,12 @@ function destinationUrl(provider, requestPath) {
 }
 
 async function validateResolvedDestination(endpoint, provider, lookup = lookupHost) {
-  if (isPrivateHostname(endpoint.hostname) && !provider.allowPrivate) {
+  if (isPrivateGenericProviderHostname(endpoint.hostname) && !provider.allowPrivate) {
     throw new Error("Provider host is private or loopback; set allowPrivate=true explicitly.");
   }
   const resolved = await lookup(endpoint.hostname);
   if (!resolved.length) throw new Error(`Provider host ${endpoint.hostname} has no addresses.`);
-  if (!provider.allowPrivate && resolved.some(isPrivateAddress)) {
+  if (!provider.allowPrivate && resolved.some(isPrivateGenericProviderAddress)) {
     throw new Error("Provider host resolved to a private or link-local address; set allowPrivate=true explicitly.");
   }
   return resolved;
@@ -420,20 +181,9 @@ async function validateResolvedDestination(endpoint, provider, lookup = lookupHo
 
 function safeHeaderEntries(headers) {
   const values = headers instanceof Headers ? [...headers.entries()] : Object.entries(headers || {});
-  const result = {};
-  for (const [nameValue, valueValue] of values) {
-    const name = text(nameValue);
-    const lower = name.toLowerCase();
-    const value = String(valueValue ?? "");
-    if (FORBIDDEN_HEADER_NAMES.has(lower) || SECRET_HEADER_PATTERN.test(lower)) {
-      throw new Error(`Header ${name} is reserved for credential or transport handling.`);
-    }
-    if (!HEADER_NAME_PATTERN.test(name) || !value || value.length > MAX_HEADER_VALUE_LENGTH || /[\r\n]/.test(value)) {
-      throw new Error(`Header ${name} has an invalid value.`);
-    }
-    result[name] = value;
-  }
-  return result;
+  return validateGenericProviderHeaders(
+    Object.fromEntries(values.map(([name, value]) => [name, String(value ?? "")])),
+  );
 }
 
 function credentialSecret(provider) {
@@ -491,6 +241,7 @@ export function genericProviderDiscoverySnapshot(id) {
 }
 
 function requestSignal(signal, timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return signal;
   const timeout = AbortSignal.timeout(timeoutMs);
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }
@@ -499,7 +250,7 @@ function createDestinationDispatcher(endpoint, provider, timeoutMs) {
   const lookup = (hostname, options, callback) => {
     lookupHost(hostname)
       .then((addresses) => {
-        if (!provider.allowPrivate && addresses.some(isPrivateAddress)) {
+        if (!provider.allowPrivate && addresses.some(isPrivateGenericProviderAddress)) {
           throw new Error("Provider host resolved to a private or link-local address.");
         }
         if (options?.all) {
@@ -514,10 +265,25 @@ function createDestinationDispatcher(endpoint, provider, timeoutMs) {
   return new Agent({
     allowH2: false,
     pipelining: 1,
-    headersTimeout: timeoutMs,
-    bodyTimeout: timeoutMs,
+    // Discovery and `providers generic test` are bounded. A generation request
+    // passes zero and lives exactly as long as its caller: an arbitrary
+    // ten-second body timeout would cut off healthy streamed model output.
+    headersTimeout: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 0,
+    bodyTimeout: Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 0,
     connect: { lookup },
   });
+}
+
+function mergeRequestHeaders(requestHeaders, staticHeaders) {
+  const result = { ...requestHeaders };
+  for (const [name, value] of Object.entries(staticHeaders)) {
+    const lower = name.toLowerCase();
+    for (const existing of Object.keys(result)) {
+      if (existing.toLowerCase() === lower) delete result[existing];
+    }
+    result[name] = value;
+  }
+  return result;
 }
 
 async function boundedResponseBody(response, maxBytes = MAX_RESPONSE_BYTES) {
@@ -559,14 +325,17 @@ export async function requestGenericProvider(
   { fetchImpl = undiciFetch, lookup = lookupHost, timeoutMs = 10_000, ...init } = {},
 ) {
   const provider = getGenericProvider(id);
-  if (!provider.enabled) throw new Error(`Generic provider ${provider.id} is disabled.`);
+  if (!provider.enabled) throw unavailable(`Generic provider ${provider.id} is disabled.`);
   const endpoint = destinationUrl(provider, requestPath);
   await validateResolvedDestination(endpoint, provider, lookup);
   const requestHeaders = safeHeaderEntries(init.headers);
-  const headers = { ...provider.headers, ...requestHeaders };
+  // Static provider headers are operator-owned routing metadata. A caller can
+  // add ordinary content-negotiation headers, but cannot replace tenant or
+  // gateway selection chosen in the protected provider descriptor.
+  const headers = mergeRequestHeaders(requestHeaders, provider.headers);
   const secret = credentialSecret(provider);
   if (provider.credentialRef && !secret) {
-    throw new Error(`Credential ${provider.credentialRef} is unavailable for generic provider ${provider.id}.`);
+    throw unavailable(`The bound credential is unavailable for generic provider ${provider.id}.`);
   }
   if (secret) headers.Authorization = `Bearer ${secret}`;
   const useDispatcher = fetchImpl === undiciFetch;
@@ -635,7 +404,7 @@ function cliUsage() {
     "Usage: providers generic list [--json] | add ID --name NAME --base-url URL " +
       "[--adapter openai-chat|openai-responses|openai-completions] [--header Name=Value] " +
       "[--credential-ref cred_ID] [--description TEXT] [--allow-private] | edit ID [options] | show ID [--json] | " +
-      "enable ID | disable ID | remove ID | test ID [--json]",
+      "enable ID | disable ID | remove ID | test ID [--json]. Descriptor mutations also accept --no-apply only while no curated routes exist.",
   );
 }
 

--- a/src/model-capabilities.mjs
+++ b/src/model-capabilities.mjs
@@ -2,11 +2,12 @@
 // the registry or publish a Codex catalog: live provider data is untrusted
 // input, and native GPT metadata remains owned by Codex itself.
 
+import { requestProfileKnown } from "./request-profiles.mjs";
+
 const MODALITIES = new Set(["text", "image", "audio", "video", "file"]);
 const MAX_CONTEXT_WINDOW = 16_777_216;
 const MAX_MODEL_ID_LENGTH = 512;
 const MAX_DISPLAY_NAME_LENGTH = 240;
-const PROFILE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,79}$/;
 const COST_FIELDS = [
   "input",
   "output",
@@ -96,10 +97,10 @@ function normalizeCost(value) {
 
 function normalizeRequestProfile(value) {
   if (value === undefined) return undefined;
-  if (typeof value !== "string" || !PROFILE_PATTERN.test(value.trim())) {
-    throw new Error("requestProfile must be a short lower-case profile id.");
+  if (!requestProfileKnown(value)) {
+    throw new Error("requestProfile must name a supported router profile.");
   }
-  return value.trim();
+  return value;
 }
 
 /**

--- a/src/model-discovery.mjs
+++ b/src/model-discovery.mjs
@@ -19,7 +19,7 @@ import {
   anonymousModelAllowed,
   CHECKED_IN_MODELS,
   MODELS,
-  PROVIDERS,
+  RUNTIME_PROVIDERS,
   resolveProviderBaseUrl,
 } from "./model-registry.mjs";
 import { curatedModelBlockReason } from "./opencode-curation.mjs";
@@ -325,8 +325,22 @@ export async function discoverProviderModels(
   providerId,
   { refresh = false, cache = true, fixture = false, scope, loadPayload = providerPayload } = {},
 ) {
-  const provider = PROVIDERS.get(providerId);
+  const provider = RUNTIME_PROVIDERS.get(providerId);
   if (!provider) throw new Error(`Unknown provider: ${providerId}`);
+  if (provider.generic === true) {
+    const fixturePath = option("--fixture");
+    const genericFixture = fixturePath
+      ? JSON.parse(readFileSync(path.resolve(fixturePath), "utf8"))
+      : fixture && fixture !== true
+        ? fixture
+        : undefined;
+    return discoverGenericProviderModels(providerId, {
+      refresh,
+      cache,
+      scope,
+      ...(genericFixture !== undefined ? { fixture: genericFixture } : {}),
+    });
+  }
   // Discovery asks one endpoint what it serves. A per-model-endpoint provider
   // is not an endpoint, so there is no single host to ask and no answer that
   // would mean anything for the models under it. Refusing beats picking one of
@@ -533,16 +547,43 @@ export async function discoverGenericProviderModels(
   const merged = mergeDiscoveredModels({
     providerId,
     live: Object.values(modelMetadata),
+    userOverrides: providerUserMetadata(providerId),
     defaults: {},
   });
+  const registered = MODELS
+    .filter((model) => model.provider === providerId)
+    .map((model) => model.upstreamModel)
+    .sort();
+  const registeredSet = new Set(registered);
+  const discoveredSet = new Set(discovered);
+  const unregistered = discovered.filter((id) => !registeredSet.has(id));
+  const publicationBlocked = descriptor.adapter === "openai-completions"
+    ? "This endpoint exposes legacy OpenAI Completions. Codex Router can inspect its catalog, but has no completions caller surface and will not publish an unusable route."
+    : undefined;
+  const blocked = publicationBlocked
+    ? Object.fromEntries(unregistered.map((id) => [id, publicationBlocked]))
+    : {};
+  const contextLengths = Object.fromEntries(
+    Object.entries(modelMetadata)
+      .filter(([, metadata]) => Number.isInteger(metadata?.contextWindow))
+      .map(([id, metadata]) => [id, metadata.contextWindow]),
+  );
   return {
     provider: providerId,
     descriptor: { ...descriptor, headers: undefined },
     discovered,
+    registered,
+    unregistered,
+    addable: unregistered.filter((id) => !Object.hasOwn(blocked, id)),
+    blocked,
+    unavailable: registered.filter((id) => !discoveredSet.has(id)),
+    contextLengths,
     modelMetadata: merged,
     cached: Boolean(cached),
     stale: Boolean(cached?.stale),
     fetchedAt,
+    note: publicationBlocked ||
+      "Discovery never grants request behavior or edits the registry; curation must explicitly select every published model and any request profile.",
   };
 }
 

--- a/src/model-picker-state.mjs
+++ b/src/model-picker-state.mjs
@@ -200,6 +200,29 @@ export function migrateModelVisibility(replacements) {
     : modelPickerSnapshot();
 }
 
+// Remove decisions for routing identities that no longer exist. Provider
+// removal is stronger than hiding a model: retaining the old visible/hidden
+// decision would silently apply it if a different endpoint were later
+// registered under the same provider id and curated the same slug.
+export function forgetModelVisibility(slugs) {
+  const values = [...new Set(
+    (Array.isArray(slugs) ? slugs : [])
+      .map((slug) => String(slug || "").trim())
+      .filter(Boolean),
+  )];
+  if (values.length === 0) return modelPickerSnapshot();
+  const { hidden, visible, seeded, hasExplicitVisibility } = readPickerState();
+  let changed = false;
+  for (const value of values) {
+    changed = hidden.delete(value) || changed;
+    changed = visible.delete(value) || changed;
+    changed = seeded.delete(value) || changed;
+  }
+  return changed
+    ? writePickerState({ hidden, visible, seeded, hasExplicitVisibility })
+    : modelPickerSnapshot();
+}
+
 export function setAllModelsVisible(slugs, visible) {
   const known = [...new Set(slugs.map((slug) => String(slug).trim()).filter(Boolean))];
   const { hidden: currentHidden, visible: currentVisible, seeded } = readPickerState();

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -1,9 +1,14 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
+import {
+  genericProviderRuntimeDescriptor,
+  readGenericProviders,
+} from "./generic-provider-state.mjs";
 import { instructionOverlayExists } from "./instruction-overlays.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import { officialModelDisplayName, readUserModels } from "./user-models.mjs";
+import { curatableRequestProfile, requestProfileKnown } from "./request-profiles.mjs";
 
 export const REGISTRY_PATH =
   process.env.MODEL_ROUTER_REGISTRY ||
@@ -56,7 +61,7 @@ export function anonymousModelAllowed(provider, modelId) {
 // chain accept one unchanged rather than growing a parallel implementation.
 // Its `id` is the model slug, which is what makes a per-model credential file
 // and Keychain entry distinct from every other endpoint's.
-export function endpointForModel(model, providers = PROVIDERS) {
+export function endpointForModel(model, providers = RUNTIME_PROVIDERS) {
   const provider = providers.get(model?.provider);
   return provider?.perModelEndpoint ? model.endpoint : provider;
 }
@@ -382,6 +387,38 @@ function loadRegistry() {
   };
 }
 
+// Operator-defined providers extend only the runtime view. The checked-in
+// registry stays immutable and authoritative for built-in provider identity,
+// native capabilities, and repository-certified model behavior. A malformed
+// generic document is one failed optional layer: keep every built-in route and
+// expose a diagnostic instead of taking down the router at module import.
+function loadRuntimeProviders(checkedInProviders) {
+  const providers = new Map(checkedInProviders);
+  const warnings = [];
+  try {
+    const genericProviders = readGenericProviders({
+      reservedProviderIds: checkedInProviders,
+    });
+    for (const provider of genericProviders) {
+      if (!provider.enabled) continue;
+      const descriptor = genericProviderRuntimeDescriptor(provider);
+      if (providers.has(descriptor.id)) {
+        throw new Error(`generic provider ${descriptor.id} collides with the checked-in registry`);
+      }
+      providers.set(descriptor.id, descriptor);
+    }
+  } catch (error) {
+    warnings.push(
+      `Ignored generic provider state: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return {
+      providers: new Map(checkedInProviders),
+      warnings: Object.freeze(warnings),
+    };
+  }
+  return { providers, warnings: Object.freeze(warnings) };
+}
+
 // Codex only renders the upgrade modal when the target slug is in the picker,
 // so a prompt pointing at a missing or unlisted model can never fire. Catch
 // that at load time instead of shipping a silent no-op. Targets may be
@@ -530,8 +567,21 @@ function modelProblem(model, providers, slugs, gatewayModels) {
   if (model.instructionOverlay !== undefined && !instructionOverlayExists(model.instructionOverlay)) {
     return `model ${model.slug} has an invalid instructionOverlay`;
   }
-  if (model.requestProfile !== undefined && typeof model.requestProfile !== "string") {
+  if (model.requestProfile !== undefined && !requestProfileKnown(model.requestProfile)) {
     return `model ${model.slug} has an invalid requestProfile`;
+  }
+  if (
+    provider.generic === true &&
+    model.requestProfile !== undefined &&
+    !curatableRequestProfile(model.requestProfile)
+  ) {
+    return `generic model ${model.slug} may use only an explicitly curatable requestProfile`;
+  }
+  // The router exposes Chat Completions and Responses request surfaces. A
+  // legacy text-completions catalog can still be inspected, but publishing a
+  // model from it would create a route no caller endpoint can execute.
+  if (provider.generic === true && provider.adapter === "openai-completions") {
+    return `generic model ${model.slug} uses unsupported openai-completions publication`;
   }
   if (
     model.requiresTrailingUserTurn !== undefined &&
@@ -846,9 +896,18 @@ function mergeUserModels(base, staticAliases) {
 
 const registry = loadRegistry();
 const staticAliases = validatedStaticModelSlugAliases(registry);
-const merged = mergeUserModels(registry, staticAliases);
+const runtime = loadRuntimeProviders(registry.providers);
+const merged = mergeUserModels(
+  { ...registry, providers: runtime.providers },
+  staticAliases,
+);
 
 export const PROVIDERS = registry.providers;
+// Runtime routing and curation use this union. Keeping it separate from
+// PROVIDERS prevents mutable local state from becoming checked-in authority in
+// callers that intentionally audit or certify the repository registry.
+export const RUNTIME_PROVIDERS = runtime.providers;
+export const RUNTIME_PROVIDER_WARNINGS = runtime.warnings;
 // The immutable registry shipped by this checkout, before the operator's
 // mutable user-model overlay is merged. Repository certification gates must
 // bind to this set: a local overlay is useful routing configuration, but it
@@ -865,7 +924,7 @@ export const MODEL_SLUG_ALIASES = new Map([
 ]);
 export const LISTED_MODELS = Object.freeze(MODELS.filter((model) => model.listed));
 export const API_MODELS = Object.freeze(
-  MODELS.filter((model) => PROVIDERS.get(model.provider)?.kind === "openai-compatible"),
+  MODELS.filter((model) => RUNTIME_PROVIDERS.get(model.provider)?.kind === "openai-compatible"),
 );
 export const MODEL_BY_SLUG = new Map(MODELS.map((model) => [model.slug, model]));
 for (const [from, to] of MODEL_SLUG_ALIASES) {
@@ -877,5 +936,5 @@ export const MODEL_BY_GATEWAY_ID = new Map(
 );
 
 export function providerForModel(model) {
-  return PROVIDERS.get(model.provider);
+  return RUNTIME_PROVIDERS.get(model.provider);
 }

--- a/src/provider-credential-store.mjs
+++ b/src/provider-credential-store.mjs
@@ -262,7 +262,7 @@ function normalizeSecretRef(value, providerId, { legacy = false, providerType } 
   const referenceProviderId = value.providerId === undefined
     ? providerId
     : providerType === "generic"
-      ? normalizeGenericProviderId(value.providerId)
+      ? normalizeGenericProviderId(value.providerId, { reservedProviderIds: PROVIDERS })
       : validateProviderId(value.providerId);
   if (referenceProviderId !== providerId) {
     throw new Error("secretRef.providerId must match providerId.");
@@ -324,7 +324,7 @@ function normalizeCredential(raw, { legacy = false } = {}) {
     throw new Error("Legacy credentials cannot declare providerType.");
   }
   const providerId = providerType === "generic"
-    ? normalizeGenericProviderId(raw.providerId)
+    ? normalizeGenericProviderId(raw.providerId, { reservedProviderIds: PROVIDERS })
     : validateProviderId(raw.providerId);
   const kind = normalizeText(raw.kind || (legacy ? "api_key" : undefined), "credential kind", {
     max: 20,
@@ -463,7 +463,7 @@ function createCredentialReferenceForType(input = {}, providerType) {
     updatedAt,
   } = input;
   const normalizedProviderId = providerType === "generic"
-    ? normalizeGenericProviderId(providerId)
+    ? normalizeGenericProviderId(providerId, { reservedProviderIds: PROVIDERS })
     : validateProviderId(providerId);
   const credential = normalizeCredential({
     id: id || generatedCredentialId(normalizedProviderId, kind),

--- a/src/provider-credentials.mjs
+++ b/src/provider-credentials.mjs
@@ -149,7 +149,7 @@ function canonicalProviderId(provider) {
 }
 
 function genericCredentialProvider(providerId) {
-  const id = normalizeGenericProviderId(providerId);
+  const id = normalizeGenericProviderId(providerId, { reservedProviderIds: PROVIDERS });
   return {
     id,
     kind: "openai-compatible",

--- a/src/provider-selection.mjs
+++ b/src/provider-selection.mjs
@@ -11,8 +11,14 @@ import { fileURLToPath } from "node:url";
 
 import { discoveryDisabled } from "./discovery-mode.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
+import { genericProviderConfigured } from "./generic-provider-readiness.mjs";
 import { PROVIDER_SELECTION_PATH, STATE_DIR, TARGET } from "./paths.mjs";
-import { LISTED_MODELS, PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
+import {
+  LISTED_MODELS,
+  PROVIDERS,
+  RUNTIME_PROVIDERS,
+  providerNeedsNoKey,
+} from "./model-registry.mjs";
 import { targetCli } from "./target-integration.mjs";
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { grokOAuthStatus } from "./grok-oauth-status.mjs";
@@ -88,8 +94,10 @@ export function configuredProviderIds() {
   // all of those stay empty until the operator re-runs setup.
   if (discoveryDisabled()) return [];
   const configured = [];
-  for (const provider of PROVIDERS.values()) {
-    if (provider.kind === "oauth") {
+  for (const provider of RUNTIME_PROVIDERS.values()) {
+    if (provider.generic === true) {
+      if (genericProviderConfigured(provider.id)) configured.push(provider.id);
+    } else if (provider.kind === "oauth") {
       if (provider.id === "kimi-oauth" && kimiOAuthStatus().configured) {
         configured.push(provider.id);
       } else if (provider.id === "grok-oauth" && grokOAuthStatus().configured) {
@@ -124,7 +132,10 @@ export function defaultProviderIds() {
   // third-party address reached with no credential. "Enabling this sends
   // prompts off-box" has to stay a choice somebody made.
   return configuredProviderIds().filter(
-    (id) => !["anonymous", "per-model"].includes(PROVIDERS.get(id)?.authMode),
+    (id) => {
+      const provider = RUNTIME_PROVIDERS.get(id);
+      return provider?.generic !== true && !["anonymous", "per-model"].includes(provider?.authMode);
+    },
   );
 }
 
@@ -229,14 +240,18 @@ export function disableProvider(providerId) {
 
 export function selectedListedModels() {
   const selected = new Set(readProviderSelection());
-  return LISTED_MODELS.filter((model) => selected.has(model.provider));
+  return LISTED_MODELS.filter((model) => (
+    selected.has(model.provider) || RUNTIME_PROVIDERS.get(model.provider)?.generic === true
+  ));
 }
 
 export function selectedConfiguredListedModels() {
   const selected = new Set(readProviderSelection());
   const configured = new Set(configuredProviderIds());
   return LISTED_MODELS.filter(
-    (model) => selected.has(model.provider) && configured.has(model.provider),
+    (model) => (
+      selected.has(model.provider) || RUNTIME_PROVIDERS.get(model.provider)?.generic === true
+    ) && configured.has(model.provider),
   );
 }
 

--- a/src/providers.mjs
+++ b/src/providers.mjs
@@ -24,7 +24,23 @@ import {
   targetRestartHint,
 } from "./target-integration.mjs";
 import { withModelOverlayLock } from "./model-overlay-lock.mjs";
-import { runGenericProviderCli } from "./generic-providers.mjs";
+import {
+  GENERIC_PROVIDERS_PATH,
+  runGenericProviderCli,
+} from "./generic-providers.mjs";
+import {
+  applyModelOverlayPublication,
+  transactModelOverlayMutation,
+} from "./model-overlay-publication.mjs";
+import {
+  USER_MODELS_PATH,
+  readUserModels,
+  writeUserModels,
+} from "./user-models.mjs";
+import {
+  MODEL_PICKER_STATE_PATH,
+  forgetModelVisibility,
+} from "./model-picker-state.mjs";
 
 function providersCommand(action, providerId) {
   return process.platform === "win32"
@@ -67,11 +83,73 @@ function list() {
     }));
 }
 
+const GENERIC_MUTATIONS = new Set(["add", "edit", "enable", "disable", "remove"]);
+
+export async function runGenericCommand(args) {
+  const action = args[0] || "list";
+  if (!GENERIC_MUTATIONS.has(action)) {
+    return runGenericProviderCli(args);
+  }
+  const providerId = String(args[1] || "").trim();
+  const noApply = args.includes("--no-apply");
+  let output = "";
+  let result;
+  let routedModels = [];
+  await transactModelOverlayMutation({
+    files: [GENERIC_PROVIDERS_PATH, USER_MODELS_PATH, MODEL_PICKER_STATE_PATH],
+    mutate: async () => {
+      // Read after the cross-process overlay lock is held. A curation command
+      // may have committed while this command was queued, and descriptor
+      // removal must not leave those newly added routes or picker decisions
+      // behind.
+      routedModels = readUserModels().filter((model) => model?.provider === providerId);
+      if (noApply && routedModels.length > 0) {
+        throw new Error(
+          `--no-apply is unsafe while ${providerId} has ${routedModels.length} curated model route(s); rerun without it so the running route cannot drift.`,
+        );
+      }
+      result = await runGenericProviderCli(args, {
+        output: { write: (chunk) => { output += String(chunk); } },
+      });
+      if (action !== "remove") return;
+      const allModels = readUserModels();
+      writeUserModels(allModels.filter((model) => model?.provider !== providerId));
+      forgetModelVisibility(routedModels.map((model) => model.slug));
+    },
+    restart: !noApply,
+    applyPublication: noApply
+      ? async () => ({ published: false })
+      : applyModelOverlayPublication,
+  });
+  process.stdout.write(output);
+  const json = args.includes("--json");
+  if (noApply) {
+    if (!json) {
+      process.stdout.write("Saved generic provider state without publishing an unused route.\n");
+    }
+    return result;
+  }
+  if (action === "remove") {
+    if (!json) {
+      process.stdout.write(
+        `Removed ${routedModels.length} curated model route(s) and their picker decisions.\n`,
+      );
+    }
+  } else {
+    if (!json) {
+      process.stdout.write(
+        `Republished the routing plane (${routedModels.length} curated model route(s)) and reloaded the installed router if present.\n`,
+      );
+    }
+  }
+  return result;
+}
+
 async function main() {
   const command = process.argv[2] || "list";
   const providerId = process.argv[3];
   if (command === "generic") {
-    await runGenericProviderCli(process.argv.slice(3));
+    await runGenericCommand(process.argv.slice(3));
     return;
   }
   if (command === "list") {

--- a/src/request-profiles.mjs
+++ b/src/request-profiles.mjs
@@ -1,0 +1,42 @@
+// Request profiles are executable router behavior, not free-form metadata.
+// Keep the complete set closed here so neither a live provider catalog nor a
+// hand-edited model overlay can mint a new behavior merely by naming it.
+export const REQUEST_PROFILES = Object.freeze([
+  "anthropic-reasoning",
+  "antigravity",
+  "auto-tool-choice",
+  "clinepass",
+  "codex-encrypted-schema",
+  "deepseek-nonthinking",
+  "deepseek-thinking",
+  "glm-thinking",
+  "kimi-k3",
+  "kimi-oauth",
+  "minimax-m3",
+  "ollama-cloud",
+  "ollama-cloud-auto-tool-choice",
+  "ox-alpha",
+  "qwen-plan",
+  "qwen38-community",
+  "xai-reasoning",
+]);
+
+const PROFILE_SET = new Set(REQUEST_PROFILES);
+
+// Most profiles encode a checked-in vendor contract and are never sensible to
+// lend to an arbitrary model. These two are deliberately model-scoped
+// compatibility observations an operator can make while curating a route.
+export const CURATABLE_REQUEST_PROFILES = Object.freeze([
+  "auto-tool-choice",
+  "codex-encrypted-schema",
+]);
+
+const CURATABLE_PROFILE_SET = new Set(CURATABLE_REQUEST_PROFILES);
+
+export function requestProfileKnown(value) {
+  return typeof value === "string" && PROFILE_SET.has(value);
+}
+
+export function curatableRequestProfile(value) {
+  return typeof value === "string" && CURATABLE_PROFILE_SET.has(value);
+}

--- a/src/support-bundle.mjs
+++ b/src/support-bundle.mjs
@@ -18,7 +18,12 @@ import { readInstallManifest } from "./install-manifest.mjs";
 import { redactProxyCredentials } from "./proxy-environment.mjs";
 import { protectPrivateFile } from "./file-security.mjs";
 import { detectLegacyInstallations } from "./legacy-migration.mjs";
-import { PROVIDERS, providerNeedsNoKey } from "./model-registry.mjs";
+import {
+  PROVIDERS,
+  RUNTIME_PROVIDERS,
+  providerNeedsNoKey,
+} from "./model-registry.mjs";
+import { genericProviderConfigured } from "./generic-provider-readiness.mjs";
 import {
   CALLER_SECRET_PATH,
   CONFIG_PATH,
@@ -180,6 +185,17 @@ export function createSupportBundle(options = {}) {
     const status = credentialStatus(provider);
     credentialSources[provider.id] = status.configured
       ? { configured: true, source: status.source, persistent: status.persistent }
+      : { configured: false };
+  }
+  for (const provider of RUNTIME_PROVIDERS.values()) {
+    if (provider.generic !== true) continue;
+    const configured = genericProviderConfigured(provider.id);
+    credentialSources[provider.id] = configured
+      ? {
+          configured: true,
+          source: provider.credentialRef ? "bound credential reference" : "not required",
+          persistent: Boolean(provider.credentialRef),
+        }
       : { configured: false };
   }
   let selection;

--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -201,6 +201,87 @@ export function nonRecursiveToolSchema(schema) {
   return cloneWithoutClosingRefs(schema, closing);
 }
 
+// Some strict upstream JSON-Schema validators reject Codex's private
+// `encrypted` annotation. It is metadata on a schema node, not a JSON-Schema
+// keyword and not the same thing as a user property whose name is
+// "encrypted". Walk only positions that JSON Schema defines as child schemas;
+// never recurse into const/default/examples/enum or arbitrary extension data.
+//
+// Copy-on-write keeps an ordinary schema byte-shape identical. The depth cap
+// makes a hostile hand-built object bounded; a node beyond it is left intact,
+// which fails closed at the strict upstream instead of broadening the schema.
+const MAX_ANNOTATION_DEPTH = 32;
+
+export function stripCodexEncryptedSchemaAnnotation(schema) {
+  const active = new WeakSet();
+
+  const visit = (node, depth) => {
+    if (!isPlainObject(node) || depth > MAX_ANNOTATION_DEPTH || active.has(node)) return node;
+    active.add(node);
+    let next = node;
+    const replace = (key, value) => {
+      if (next === node) next = { ...node };
+      next[key] = value;
+    };
+
+    if (Object.hasOwn(node, "encrypted")) {
+      const { encrypted: _annotation, ...withoutAnnotation } = node;
+      next = withoutAnnotation;
+    }
+
+    for (const keyword of [...REF_SCHEMA_MAP_KEYWORDS, "dependencies"]) {
+      const schemas = node[keyword];
+      if (!isPlainObject(schemas)) continue;
+      let changed = false;
+      const rewritten = { ...schemas };
+      for (const [name, child] of Object.entries(schemas)) {
+        if (!isPlainObject(child)) continue;
+        const repaired = visit(child, depth + 1);
+        if (repaired !== child) {
+          rewritten[name] = repaired;
+          changed = true;
+        }
+      }
+      if (changed) replace(keyword, rewritten);
+    }
+
+    for (const keyword of REF_SCHEMA_ARRAY_KEYWORDS) {
+      const schemas = node[keyword];
+      if (!Array.isArray(schemas)) continue;
+      let changed = false;
+      const rewritten = schemas.map((child) => {
+        if (!isPlainObject(child)) return child;
+        const repaired = visit(child, depth + 1);
+        if (repaired !== child) changed = true;
+        return repaired;
+      });
+      if (changed) replace(keyword, rewritten);
+    }
+
+    for (const keyword of REF_SCHEMA_CHILD_KEYWORDS) {
+      const child = node[keyword];
+      if (Array.isArray(child)) {
+        let changed = false;
+        const rewritten = child.map((entry) => {
+          if (!isPlainObject(entry)) return entry;
+          const repaired = visit(entry, depth + 1);
+          if (repaired !== entry) changed = true;
+          return repaired;
+        });
+        if (changed) replace(keyword, rewritten);
+      } else if (isPlainObject(child)) {
+        const repaired = visit(child, depth + 1);
+        if (repaired !== child) replace(keyword, repaired);
+      }
+    }
+
+    active.delete(node);
+    return next;
+  };
+
+  return visit(schema, 0);
+}
+
 // Moonshot validates every `$ref` a tool schema carries. It accepts only pure
 // pointers into `#/$defs/`, rejecting the whole request -- not the one tool --
 // over other pointers and over a `$ref` that carries sibling keywords. Codex App

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -432,6 +432,13 @@ test("a curated model can opt into the auto tool-choice profile", () => {
   assert.equal(parseRequestProfile("auto-tool-choice"), "auto-tool-choice");
 });
 
+test("a curated model can opt into the narrow encrypted-schema profile", () => {
+  assert.equal(
+    parseRequestProfile("codex-encrypted-schema"),
+    "codex-encrypted-schema",
+  );
+});
+
 test("an unknown request profile is rejected by name", () => {
   // Nothing validates requestProfile downstream — the forwarder just runs no
   // branch — so a typo would store a model that silently keeps failing.

--- a/test/generic-doctor.test.mjs
+++ b/test/generic-doctor.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { userModelEntry } from "../src/user-models.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function environment(directory) {
+  const stateDir = path.join(directory, "state");
+  return {
+    ...process.env,
+    HOME: directory,
+    CODEX_HOME: path.join(directory, "codex"),
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_GENERIC_PROVIDERS: path.join(stateDir, "generic-providers.json"),
+    MODEL_ROUTER_USER_MODELS: path.join(stateDir, "user-models.json"),
+    CODEX_ROUTER_SERVICE_PLATFORM: "linux",
+    CODEX_ROUTER_LAUNCH_AGENTS_DIR: path.join(directory, "LaunchAgents"),
+    CODEX_ROUTER_SKIP_LAUNCHCTL: "1",
+    CODEX_ROUTER_SKIP_SYSTEMCTL: "1",
+    KIMI_CODE_HOME: path.join(directory, "kimi-code"),
+    GROK_AUTH_PATH: path.join(directory, "grok", "auth.json"),
+  };
+}
+
+function doctor(env) {
+  const result = spawnSync(process.execPath, ["src/doctor.mjs", "--json"], {
+    cwd: root,
+    env,
+    encoding: "utf8",
+  });
+  assert.ok(result.stdout, result.stderr);
+  return { result, report: JSON.parse(result.stdout) };
+}
+
+test("doctor reports generic readiness without endpoint or header values", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "generic-doctor-"));
+  const env = environment(directory);
+  const stateDir = env.CODEX_ROUTER_STATE_DIR;
+  const headerSecret = "DOCTOR_GENERIC_HEADER_MUST_NOT_LEAK";
+  const endpointSecret = "private-path-must-not-leak";
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(env.MODEL_ROUTER_GENERIC_PROVIDERS, `${JSON.stringify({
+    version: 1,
+    providers: [{
+      id: "doctor-generic",
+      displayName: "Doctor Generic",
+      baseUrl: `https://doctor-generic.example.test/${endpointSecret}/v1`,
+      adapter: "openai-chat",
+      headers: { "X-Private-Routing": headerSecret },
+      allowPrivate: false,
+      enabled: true,
+    }],
+  }, null, 2)}\n`, { mode: 0o600 });
+  const model = userModelEntry({
+    providerId: "doctor-generic",
+    upstreamId: "model-a",
+    priority: 100,
+  });
+  writeFileSync(env.MODEL_ROUTER_USER_MODELS, `${JSON.stringify({
+    version: 1,
+    models: [model],
+  }, null, 2)}\n`, { mode: 0o600 });
+
+  try {
+    const { report } = doctor(env);
+    const row = report.checks.find((check) => check.name === "Doctor Generic generic provider");
+    assert.equal(row.status, "ok");
+    assert.match(row.detail, /no credential required; 1 curated model route/);
+    const serialized = JSON.stringify(report);
+    assert.equal(serialized.includes(headerSecret), false);
+    assert.equal(serialized.includes(endpointSecret), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("doctor names malformed generic state without reflecting its bytes", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "generic-doctor-malformed-"));
+  const env = environment(directory);
+  const stateDir = env.CODEX_ROUTER_STATE_DIR;
+  const secret = "MALFORMED_GENERIC_STATE_SECRET_MUST_NOT_LEAK";
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  writeFileSync(env.MODEL_ROUTER_GENERIC_PROVIDERS, `${secret} is not json\n`, { mode: 0o600 });
+
+  try {
+    const { report } = doctor(env);
+    const row = report.checks.find((check) => check.name === "Generic provider registry");
+    assert.equal(row.status, "fail");
+    assert.match(row.detail, /document is not valid JSON/);
+    assert.equal(JSON.stringify(report).includes(secret), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/test/generic-providers.test.mjs
+++ b/test/generic-providers.test.mjs
@@ -43,6 +43,7 @@ const {
 const { LOG_PATH } = await import("../src/paths.mjs");
 const { createSupportBundle } = await import("../src/support-bundle.mjs");
 const { discoverGenericProviderModels } = await import("../src/model-discovery.mjs");
+const { userModelEntry } = await import("../src/user-models.mjs");
 test.after(() => rmSync(testRoot, { recursive: true, force: true }));
 
 async function listen(server) {
@@ -219,6 +220,34 @@ test("generic requests revalidate DNS, reject redirects, and bound response read
   );
 });
 
+test("generic request transport keeps operator headers authoritative and can follow caller lifetime", async () => {
+  addGenericProvider({
+    id: "request-transport",
+    displayName: "Request transport",
+    baseUrl: "https://provider.example.test/v1",
+    headers: { "X-Tenant": "operator-tenant" },
+  });
+  const controller = new AbortController();
+  let observed;
+  const { dispatcher } = await requestGenericProvider("request-transport", "/chat/completions", {
+    lookup: async () => ["8.8.8.8"],
+    fetchImpl: async (_url, options) => {
+      observed = options;
+      return { ok: true, status: 200 };
+    },
+    timeoutMs: 0,
+    signal: controller.signal,
+    method: "POST",
+    headers: { "x-tenant": "caller-tenant", "Content-Type": "application/json" },
+    body: "{}",
+  });
+  assert.equal(dispatcher, undefined);
+  assert.equal(observed.headers["X-Tenant"], "operator-tenant");
+  assert.equal(observed.headers["x-tenant"], undefined);
+  assert.equal(observed.headers["Content-Type"], "application/json");
+  assert.equal(observed.signal, controller.signal);
+});
+
 test("generic credential references never enter descriptors or logs", async () => {
   addGenericProvider({
     id: "credential-boundary",
@@ -233,7 +262,7 @@ test("generic credential references never enter descriptors or logs", async () =
       lookup: async () => ["8.8.8.8"],
       fetchImpl: async () => ({ ok: true, status: 200 }),
     }),
-    /Credential cred_generic_provider_01 is unavailable/,
+    /bound credential is unavailable/,
   );
 });
 
@@ -249,7 +278,7 @@ test("generic requests fail closed when a credential is unavailable or not an AP
       lookup: async () => ["8.8.8.8"],
       fetchImpl: async () => ({ ok: true, status: 200 }),
     }),
-    /Credential cred_generic_missing_01 is unavailable/,
+    /bound credential is unavailable/,
   );
 
   addGenericProvider({
@@ -263,7 +292,7 @@ test("generic requests fail closed when a credential is unavailable or not an AP
       lookup: async () => ["8.8.8.8"],
       fetchImpl: async () => ({ ok: true, status: 200 }),
     }),
-    /Credential cred_generic_account_01 is unavailable/,
+    /bound credential is unavailable/,
   );
 });
 
@@ -374,9 +403,13 @@ test("providers CLI exposes generic CRUD with sanitized JSON", () => {
     CODEX_HOME: path.join(testRoot, "codex-cli"),
     CODEX_ROUTER_STATE_DIR: path.join(testRoot, "state-cli"),
     MODEL_ROUTER_USER_MODELS: path.join(testRoot, "state-cli", "user-models.json"),
+    MODEL_ROUTER_MODEL_PICKER_STATE: path.join(testRoot, "state-cli", "model-picker.json"),
   };
   mkdirSync(env.CODEX_ROUTER_STATE_DIR, { recursive: true });
-  const add = spawnSync(process.execPath, ["src/providers.mjs", "generic", "add", "cli-test", "--name", "CLI Test", "--base-url", "https://cli.example.test/v1", "--header", "X-Org=demo", "--json"], { cwd: root, env, encoding: "utf8" });
+  // The control-center entry point must use the same transactional
+  // publication command as bin/providers rather than mutating descriptors
+  // directly and leaving a running route stale.
+  const add = spawnSync(process.execPath, ["src/control.mjs", "generic-providers", "add", "cli-test", "--name", "CLI Test", "--base-url", "https://cli.example.test/v1", "--header", "X-Org=demo", "--no-apply", "--json"], { cwd: root, env, encoding: "utf8" });
   assert.equal(add.status, 0, add.stderr);
   const added = JSON.parse(add.stdout);
   assert.equal(added.provider.id, "cli-test");
@@ -384,4 +417,45 @@ test("providers CLI exposes generic CRUD with sanitized JSON", () => {
   const list = spawnSync(process.execPath, ["src/providers.mjs", "generic", "list", "--json"], { cwd: root, env, encoding: "utf8" });
   assert.equal(list.status, 0, list.stderr);
   assert.equal(JSON.parse(list.stdout).providers[0].id, "cli-test");
+
+  const model = userModelEntry({
+    providerId: "cli-test",
+    upstreamId: "curated-model",
+    priority: 100,
+  });
+  writeFileSync(
+    env.MODEL_ROUTER_USER_MODELS,
+    `${JSON.stringify({ version: 1, models: [model] }, null, 2)}\n`,
+  );
+  writeFileSync(
+    env.MODEL_ROUTER_MODEL_PICKER_STATE,
+    `${JSON.stringify({
+      version: 1,
+      hidden: [],
+      visible: [model.slug],
+      seeded: [model.slug],
+    }, null, 2)}\n`,
+  );
+
+  const unsafeDrift = spawnSync(
+    process.execPath,
+    ["src/providers.mjs", "generic", "disable", "cli-test", "--no-apply"],
+    { cwd: root, env, encoding: "utf8" },
+  );
+  assert.equal(unsafeDrift.status, 1);
+  assert.match(unsafeDrift.stderr, /--no-apply is unsafe/);
+  assert.equal(JSON.parse(readFileSync(path.join(env.CODEX_ROUTER_STATE_DIR, "generic-providers.json"), "utf8")).providers[0].enabled, true);
+
+  const remove = spawnSync(
+    process.execPath,
+    ["src/providers.mjs", "generic", "remove", "cli-test", "--json"],
+    { cwd: root, env, encoding: "utf8" },
+  );
+  assert.equal(remove.status, 0, remove.stderr);
+  assert.equal(JSON.parse(remove.stdout).removed, "cli-test");
+  assert.deepEqual(JSON.parse(readFileSync(env.MODEL_ROUTER_USER_MODELS, "utf8")).models, []);
+  const picker = JSON.parse(readFileSync(env.MODEL_ROUTER_MODEL_PICKER_STATE, "utf8"));
+  assert.deepEqual(picker.visible, []);
+  assert.deepEqual(picker.hidden, []);
+  assert.deepEqual(picker.seeded, []);
 });

--- a/test/generic-routing.test.mjs
+++ b/test/generic-routing.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { userModelEntry } from "../src/user-models.mjs";
+import { openPort } from "./port-pool.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INTERNAL_KEY = "generic-routing-internal-key-with-sufficient-length";
+
+function json(response, status, payload) {
+  const body = Buffer.from(JSON.stringify(payload), "utf8");
+  response.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": String(body.length),
+  });
+  response.end(body);
+}
+
+async function requestJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+async function listen(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  return { server, port: address.port };
+}
+
+async function close(server) {
+  await new Promise((resolve) => server.close(resolve));
+}
+
+function runForwarder(env) {
+  const child = spawn(process.execPath, [path.join(root, "src", "api-forwarder.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MODEL_ROUTER_TARGET: "codex",
+      MODEL_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+      MODEL_ROUTER_QUIET: "1",
+      ...env,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let errors = "";
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+  child.testErrors = () => errors;
+  return child;
+}
+
+async function waitForForwarder(port, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Forwarder exited early (${child.exitCode}): ${child.testErrors()}`);
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/health`, {
+        headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
+      });
+      if (response.ok) return;
+    } catch {
+      // Listener is not ready yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Forwarder did not become healthy: ${child.testErrors()}`);
+}
+
+async function stop(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await new Promise((resolve) => child.once("exit", resolve));
+}
+
+test("one generic gateway routes ordinary and explicitly profiled models without inference", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "generic-routing-"));
+  const providersFile = path.join(directory, "generic-providers.json");
+  const userModelsFile = path.join(directory, "user-models.json");
+  const stateDir = path.join(directory, "state");
+  const upstreamRequests = [];
+  const upstream = await listen(async (request, response) => {
+    upstreamRequests.push({
+      url: request.url,
+      headers: request.headers,
+      body: await requestJson(request),
+    });
+    json(response, 200, {
+      id: `chatcmpl-${upstreamRequests.length}`,
+      object: "chat.completion",
+      model: upstreamRequests.at(-1).body.model,
+      choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+    });
+  });
+  const ordinary = userModelEntry({
+    providerId: "mixed-gateway",
+    upstreamId: "gemini-named-but-ordinary",
+    priority: 100,
+  });
+  const profiled = userModelEntry({
+    providerId: "mixed-gateway",
+    upstreamId: "strict-profiled-model",
+    requestProfile: "codex-encrypted-schema",
+    priority: 101,
+  });
+  writeFileSync(providersFile, `${JSON.stringify({
+    version: 1,
+    providers: [{
+      id: "mixed-gateway",
+      displayName: "Mixed Gateway",
+      baseUrl: `http://127.0.0.1:${upstream.port}/v1`,
+      adapter: "openai-chat",
+      headers: { "X-Tenant": "operator-owned" },
+      allowPrivate: true,
+      enabled: true,
+    }],
+  }, null, 2)}\n`);
+  writeFileSync(userModelsFile, `${JSON.stringify({
+    version: 1,
+    models: [ordinary, profiled],
+  }, null, 2)}\n`);
+  const forwarderPort = await openPort();
+  const forwarder = runForwarder({
+    MODEL_ROUTER_API_PORT: String(forwarderPort),
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_GENERIC_PROVIDERS: providersFile,
+    MODEL_ROUTER_USER_MODELS: userModelsFile,
+  });
+  const schema = {
+    type: "object",
+    encrypted: true,
+    properties: {
+      value: { type: "string", encrypted: true },
+      encrypted: {
+        type: "object",
+        properties: { retained: { type: "boolean" } },
+      },
+    },
+    required: ["value", "encrypted"],
+  };
+
+  try {
+    await waitForForwarder(forwarderPort, forwarder);
+    const health = await fetch(`http://127.0.0.1:${forwarderPort}/health`, {
+      headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
+    });
+    assert.equal(health.status, 200);
+    assert.deepEqual((await health.json()).providers["mixed-gateway"], {
+      generic: true,
+      credential_present: true,
+      credential_source: "not required",
+    });
+    for (const model of [ordinary, profiled]) {
+      const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+          "X-Tenant": "caller-must-not-win",
+          "X-Ordinary-Metadata": "kept",
+        },
+        body: JSON.stringify({
+          model: model.gatewayModel,
+          messages: [{ role: "user", content: "Use the tool." }],
+          tools: [{
+            type: "function",
+            function: { name: "inspect", description: "Inspect data.", parameters: schema },
+          }],
+        }),
+      });
+      assert.equal(response.status, 200, forwarder.testErrors());
+      assert.equal((await response.json()).choices[0].message.content, "ok");
+    }
+
+    assert.equal(upstreamRequests.length, 2);
+    assert.ok(upstreamRequests.every((entry) => entry.url === "/v1/chat/completions"));
+    assert.ok(upstreamRequests.every((entry) => entry.headers.authorization === undefined));
+    assert.ok(upstreamRequests.every((entry) => entry.headers["x-tenant"] === "operator-owned"));
+    assert.ok(upstreamRequests.every((entry) => entry.headers["x-ordinary-metadata"] === "kept"));
+    assert.equal(upstreamRequests[0].body.model, ordinary.upstreamModel);
+    assert.deepEqual(upstreamRequests[0].body.tools[0].function.parameters, schema);
+    assert.equal(upstreamRequests[1].body.model, profiled.upstreamModel);
+    const normalized = upstreamRequests[1].body.tools[0].function.parameters;
+    assert.equal("encrypted" in normalized, false);
+    assert.equal("encrypted" in normalized.properties.value, false);
+    assert.deepEqual(normalized.properties.encrypted, schema.properties.encrypted);
+    assert.deepEqual(normalized.required, ["value", "encrypted"]);
+  } finally {
+    await stop(forwarder);
+    await close(upstream.server);
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/test/generic-runtime-registry.test.mjs
+++ b/test/generic-runtime-registry.test.mjs
@@ -1,0 +1,355 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { userModelEntry } from "../src/user-models.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function environment(directory, providersFile, userModelsFile) {
+  return {
+    ...process.env,
+    HOME: directory,
+    CODEX_HOME: path.join(directory, "codex"),
+    CODEX_ROUTER_STATE_DIR: path.join(directory, "state"),
+    MODEL_ROUTER_GENERIC_PROVIDERS: providersFile,
+    MODEL_ROUTER_USER_MODELS: userModelsFile,
+    MODEL_ROUTER_MODEL_PICKER_STATE: path.join(directory, "state", "model-picker.json"),
+    CODEX_ROUTER_SERVICE_PLATFORM: "linux",
+    CODEX_ROUTER_SKIP_SYSTEMCTL: "1",
+  };
+}
+
+function provider(id, adapter = "openai-chat", extra = {}) {
+  return {
+    id,
+    displayName: `Runtime ${id}`,
+    baseUrl: `https://${id}.example.test/v1`,
+    adapter,
+    headers: { "X-Routing-Metadata": `private-${id}` },
+    enabled: true,
+    allowPrivate: false,
+    ...extra,
+  };
+}
+
+function runJson(script, env) {
+  const result = spawnSync(process.execPath, ["--input-type=module", "-e", script], {
+    cwd: root,
+    env,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return JSON.parse(result.stdout);
+}
+
+test("runtime providers merge enabled generic descriptors without changing checked-in authority", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "generic-runtime-registry-"));
+  const providersFile = path.join(directory, "generic-providers.json");
+  const userModelsFile = path.join(directory, "user-models.json");
+  const providers = [
+    provider("runtime-chat"),
+    provider("runtime-responses", "openai-responses"),
+    provider("runtime-completions", "openai-completions"),
+    provider("runtime-needs-key", "openai-chat", {
+      credentialRef: "cred_runtime_needs_key_01",
+    }),
+    provider("runtime-disabled", "openai-chat", { enabled: false }),
+  ];
+  const models = [
+    userModelEntry({
+      providerId: "runtime-chat",
+      upstreamId: "vendor/model-a",
+      requestProfile: "codex-encrypted-schema",
+      priority: 100,
+    }),
+    userModelEntry({
+      providerId: "runtime-responses",
+      upstreamId: "vendor/model-b",
+      requestProfile: "auto-tool-choice",
+      priority: 101,
+    }),
+    userModelEntry({
+      providerId: "runtime-chat",
+      upstreamId: "vendor/forged-profile",
+      requestProfile: "qwen-plan",
+      priority: 102,
+    }),
+    userModelEntry({
+      providerId: "runtime-completions",
+      upstreamId: "legacy-text-model",
+      priority: 103,
+    }),
+    userModelEntry({
+      providerId: "runtime-needs-key",
+      upstreamId: "credential-bound-model",
+      priority: 104,
+    }),
+    userModelEntry({
+      providerId: "runtime-disabled",
+      upstreamId: "disabled-model",
+      priority: 105,
+    }),
+    userModelEntry({
+      providerId: "runtime-removed",
+      upstreamId: "removed-model",
+      priority: 106,
+    }),
+  ];
+  writeFileSync(providersFile, `${JSON.stringify({ version: 1, providers }, null, 2)}\n`);
+  writeFileSync(userModelsFile, `${JSON.stringify({ version: 1, models }, null, 2)}\n`);
+
+  try {
+    const result = runJson(`
+      const registry = await import("./src/model-registry.mjs");
+      const selection = await import("./src/provider-selection.mjs");
+      selection.writeProviderSelection(["deepseek"]);
+      const genericModels = registry.MODELS.filter((model) => model.provider.startsWith("runtime-"));
+      process.stdout.write(JSON.stringify({
+        checkedInHasGeneric: registry.PROVIDERS.has("runtime-chat"),
+        runtimeProviders: [...registry.RUNTIME_PROVIDERS.keys()].filter((id) => id.startsWith("runtime-")).sort(),
+        descriptors: [...registry.RUNTIME_PROVIDERS.values()]
+          .filter((entry) => entry.generic === true)
+          .map((entry) => ({ id: entry.id, adapter: entry.adapter, protocol: entry.protocol, headers: entry.headers })),
+        models: genericModels.map((model) => ({ slug: model.slug, requestProfile: model.requestProfile })),
+        apiModels: registry.API_MODELS.filter((model) => model.provider.startsWith("runtime-")).map((model) => model.slug),
+        selectedConfigured: selection.selectedConfiguredListedModels()
+          .filter((model) => model.provider.startsWith("runtime-"))
+          .map((model) => model.slug),
+        persistedSelection: selection.providerSelectionStatus().providers,
+        warnings: registry.USER_MODEL_WARNINGS,
+        runtimeWarnings: registry.RUNTIME_PROVIDER_WARNINGS,
+      }));
+    `, environment(directory, providersFile, userModelsFile));
+
+    assert.equal(result.checkedInHasGeneric, false);
+    assert.deepEqual(result.runtimeProviders, [
+      "runtime-chat",
+      "runtime-completions",
+      "runtime-needs-key",
+      "runtime-responses",
+    ]);
+    assert.deepEqual(result.models, [
+      { slug: "runtime-chat/vendor/model-a", requestProfile: "codex-encrypted-schema" },
+      { slug: "runtime-responses/vendor/model-b", requestProfile: "auto-tool-choice" },
+      { slug: "runtime-needs-key/credential-bound-model" },
+    ]);
+    assert.deepEqual(result.apiModels, [
+      "runtime-chat/vendor/model-a",
+      "runtime-responses/vendor/model-b",
+      "runtime-needs-key/credential-bound-model",
+    ]);
+    assert.deepEqual(result.selectedConfigured, [
+      "runtime-chat/vendor/model-a",
+      "runtime-responses/vendor/model-b",
+    ]);
+    assert.deepEqual(result.persistedSelection, ["deepseek"]);
+    assert.ok(result.descriptors.every(({ headers }) => (
+      headers["X-Routing-Metadata"] === "[redacted]"
+    )));
+    assert.equal(JSON.stringify(result).includes("private-runtime"), false);
+    assert.equal(result.runtimeWarnings.length, 0);
+    assert.ok(result.warnings.some((warning) => /explicitly curatable requestProfile/.test(warning)));
+    assert.ok(result.warnings.some((warning) => /unsupported openai-completions publication/.test(warning)));
+    assert.ok(result.warnings.some((warning) => /unknown provider runtime-disabled/.test(warning)));
+    assert.ok(result.warnings.some((warning) => /unknown provider runtime-removed/.test(warning)));
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("invalid generic state fails closed while built-in providers remain usable", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "generic-runtime-invalid-"));
+  const providersFile = path.join(directory, "generic-providers.json");
+  const userModelsFile = path.join(directory, "user-models.json");
+  const env = environment(directory, providersFile, userModelsFile);
+  try {
+    const diagnosticSecret = "STATIC_HEADER_VALUE_MUST_NOT_LEAK";
+    writeFileSync(providersFile, `${diagnosticSecret} is not json\n`);
+    const malformed = runJson(`
+      const registry = await import("./src/model-registry.mjs");
+      process.stdout.write(JSON.stringify({
+        sameProviders: [...registry.PROVIDERS.keys()].every((id) => registry.RUNTIME_PROVIDERS.get(id) === registry.PROVIDERS.get(id)) &&
+          registry.PROVIDERS.size === registry.RUNTIME_PROVIDERS.size,
+        deepseek: registry.RUNTIME_PROVIDERS.get("deepseek")?.displayName,
+        warnings: registry.RUNTIME_PROVIDER_WARNINGS,
+      }));
+    `, env);
+    assert.equal(malformed.sameProviders, true);
+    assert.ok(malformed.deepseek);
+    assert.match(malformed.warnings[0], /Ignored generic provider state: Invalid generic provider state/);
+    assert.equal(JSON.stringify(malformed).includes(diagnosticSecret), false);
+
+    writeFileSync(providersFile, `${JSON.stringify({
+      version: 1,
+      providers: [provider("deepseek")],
+    })}\n`);
+    const collision = runJson(`
+      const registry = await import("./src/model-registry.mjs?collision");
+      process.stdout.write(JSON.stringify({
+        sameProviders: [...registry.PROVIDERS.keys()].every((id) => registry.RUNTIME_PROVIDERS.get(id) === registry.PROVIDERS.get(id)) &&
+          registry.PROVIDERS.size === registry.RUNTIME_PROVIDERS.size,
+        genericDeepseek: registry.RUNTIME_PROVIDERS.get("deepseek")?.generic === true,
+        warnings: registry.RUNTIME_PROVIDER_WARNINGS,
+      }));
+    `, env);
+    assert.equal(collision.sameProviders, true);
+    assert.equal(collision.genericDeepseek, false);
+    assert.match(collision.warnings[0], /already used by the built-in registry/);
+
+    writeFileSync(providersFile, `${JSON.stringify({
+      version: 1,
+      providers: [
+        provider("otherwise-valid", "openai-chat", {
+          headers: { "X-Routing-Metadata": diagnosticSecret },
+        }),
+        provider("invalid-sibling", "openai-chat", { enabled: "yes" }),
+      ],
+    })}\n`);
+    const invalidSibling = runJson(`
+      const registry = await import("./src/model-registry.mjs?invalid-sibling");
+      process.stdout.write(JSON.stringify({
+        sameProviders: [...registry.PROVIDERS.keys()].every((id) => registry.RUNTIME_PROVIDERS.get(id) === registry.PROVIDERS.get(id)) &&
+          registry.PROVIDERS.size === registry.RUNTIME_PROVIDERS.size,
+        warnings: registry.RUNTIME_PROVIDER_WARNINGS,
+      }));
+    `, env);
+    assert.equal(invalidSibling.sameProviders, true);
+    assert.match(invalidSibling.warnings[0], /enabled must be a boolean/);
+    assert.equal(JSON.stringify(invalidSibling).includes(diagnosticSecret), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("generic discovery stays non-authoritative and curation stores only explicit closed profiles", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "generic-runtime-curation-"));
+  const providersFile = path.join(directory, "generic-providers.json");
+  const userModelsFile = path.join(directory, "user-models.json");
+  const fixtureFile = path.join(directory, "models.json");
+  const providers = [
+    provider("runtime-chat"),
+    provider("runtime-completions", "openai-completions"),
+  ];
+  const fixture = {
+    object: "list",
+    data: [
+      {
+        id: "vendor/model-a",
+        context_length: 200_000,
+        requestProfile: "qwen-plan",
+      },
+      {
+        id: "vendor/model-b",
+        context_length: 400_000,
+        requestProfile: "anthropic-reasoning",
+      },
+    ],
+  };
+  writeFileSync(providersFile, `${JSON.stringify({ version: 1, providers }, null, 2)}\n`);
+  writeFileSync(fixtureFile, `${JSON.stringify(fixture, null, 2)}\n`);
+  const env = environment(directory, providersFile, userModelsFile);
+
+  try {
+    const discovery = spawnSync(
+      process.execPath,
+      ["src/model-discovery.mjs", "runtime-chat", "--fixture", fixtureFile, "--json"],
+      { cwd: root, env, encoding: "utf8" },
+    );
+    assert.equal(discovery.status, 0, discovery.stderr);
+    const discovered = JSON.parse(discovery.stdout);
+    assert.deepEqual(discovered.addable, ["vendor/model-a", "vendor/model-b"]);
+    assert.deepEqual(discovered.contextLengths, {
+      "vendor/model-a": 200_000,
+      "vendor/model-b": 400_000,
+    });
+    assert.ok(discovered.modelMetadata.every((model) => model.requestProfile === undefined));
+    assert.equal(JSON.stringify(discovered).includes("private-runtime-chat"), false);
+
+    const curation = spawnSync(
+      process.execPath,
+      [
+        "src/curate-models.mjs",
+        "runtime-chat",
+        "--fixture",
+        fixtureFile,
+        "--models",
+        "vendor/model-a,vendor/model-b",
+        "--request-profile",
+        "codex-encrypted-schema",
+        "--no-apply",
+      ],
+      { cwd: root, env, encoding: "utf8" },
+    );
+    assert.equal(curation.status, 0, curation.stderr);
+    const stored = JSON.parse(readFileSync(userModelsFile, "utf8")).models;
+    assert.deepEqual(stored.map((model) => model.slug), [
+      "runtime-chat/vendor/model-a",
+      "runtime-chat/vendor/model-b",
+    ]);
+    assert.ok(stored.every((model) => model.requestProfile === "codex-encrypted-schema"));
+    assert.deepEqual(stored.map((model) => model.contextWindow), [200_000, 400_000]);
+
+    const untrustedProfile = spawnSync(
+      process.execPath,
+      [
+        "src/curate-models.mjs",
+        "runtime-chat",
+        "--fixture",
+        fixtureFile,
+        "--models",
+        "vendor/model-a",
+        "--request-profile",
+        "qwen-plan",
+        "--no-apply",
+      ],
+      { cwd: root, env, encoding: "utf8" },
+    );
+    assert.equal(untrustedProfile.status, 2);
+    assert.match(untrustedProfile.stderr, /Unknown request profile/);
+
+    const completionsDiscovery = spawnSync(
+      process.execPath,
+      ["src/model-discovery.mjs", "runtime-completions", "--fixture", fixtureFile, "--json"],
+      { cwd: root, env, encoding: "utf8" },
+    );
+    assert.equal(completionsDiscovery.status, 0, completionsDiscovery.stderr);
+    const legacy = JSON.parse(completionsDiscovery.stdout);
+    assert.deepEqual(legacy.addable, []);
+    assert.deepEqual(Object.keys(legacy.blocked), ["vendor/model-a", "vendor/model-b"]);
+
+    const completionsCuration = spawnSync(
+      process.execPath,
+      [
+        "src/curate-models.mjs",
+        "runtime-completions",
+        "--fixture",
+        fixtureFile,
+        "--models",
+        "vendor/model-a",
+        "--no-apply",
+      ],
+      { cwd: root, env, encoding: "utf8" },
+    );
+    assert.equal(completionsCuration.status, 2);
+    assert.match(completionsCuration.stderr, /has no completions caller surface/);
+    assert.equal(
+      JSON.parse(readFileSync(userModelsFile, "utf8")).models.some(
+        (model) => model.provider === "runtime-completions",
+      ),
+      false,
+    );
+  } finally {
+    if (existsSync(directory)) rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/test/model-capabilities.test.mjs
+++ b/test/model-capabilities.test.mjs
@@ -39,6 +39,16 @@ test("untrusted provider metadata cannot select a router request profile", () =>
   );
 });
 
+test("trusted metadata still cannot mint an unknown router request profile", () => {
+  assert.throws(
+    () => modelMetadataFromProviderRecord(
+      { id: "provider/model", requestProfile: "provider-invented" },
+      { trusted: true },
+    ),
+    /supported router profile/,
+  );
+});
+
 test("metadata precedence is user, verified, live, then conservative defaults", () => {
   const merged = mergeModelMetadata({
     providerId: "example",

--- a/test/model-picker-state.test.mjs
+++ b/test/model-picker-state.test.mjs
@@ -10,6 +10,7 @@ process.env.CODEX_ROUTER_STATE_DIR = stateDir;
 const {
   MODEL_PICKER_STATE_PATH,
   effectiveVisibleModels,
+  forgetModelVisibility,
   migrateLegacyVisibleModels,
   migrateModelVisibility,
   modelPickerSnapshot,
@@ -61,6 +62,23 @@ test("provider-sized picker changes preserve other providers", () => {
   assert.deepEqual(modelPickerSnapshot().hidden, ["kimi-oauth/k3"]);
   assert.ok(modelPickerSnapshot().visible.includes("commandcode/kimi-k3"));
   assert.ok(modelPickerSnapshot().visible.includes("commandcode-messages/claude-opus-4.8"));
+});
+
+test("forgetting retired routes removes every old picker decision", () => {
+  setModelsVisible(["generic/visible", "generic/hidden"], true);
+  setModelVisible("generic/hidden", false);
+  setModelVisible("other/retained", true);
+
+  forgetModelVisibility(["generic/visible", "generic/hidden"]);
+
+  const snapshot = modelPickerSnapshot();
+  assert.equal(snapshot.visible.includes("generic/visible"), false);
+  assert.equal(snapshot.hidden.includes("generic/hidden"), false);
+  assert.equal(snapshot.visible.includes("other/retained"), true);
+  const persisted = JSON.parse(readFileSync(MODEL_PICKER_STATE_PATH, "utf8"));
+  assert.equal(persisted.seeded.includes("generic/visible"), false);
+  assert.equal(persisted.seeded.includes("generic/hidden"), false);
+  assert.equal(persisted.seeded.includes("other/retained"), true);
 });
 
 test("an explicit model selection changes only the supplied provider models", () => {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -3680,6 +3680,8 @@ function curatedOpenRouterModels() {
       models: [
         entry("openrouter", "qwen/qwen3.8-max", "openrouter-qwen-qwen3-8-max", "auto-tool-choice"),
         entry("openrouter", "openai/gpt-5.3", "openrouter-openai-gpt-5-3"),
+        entry("openrouter", "vendor/strict-schema", "openrouter-vendor-strict-schema", "codex-encrypted-schema"),
+        entry("openrouter", "vendor/ordinary-schema", "openrouter-vendor-ordinary-schema"),
         entry("chutes", "moonshotai/Kimi-K3-TEE", "chutes-moonshotai-kimi-k3-tee"),
       ],
     }),
@@ -3690,6 +3692,8 @@ function curatedOpenRouterModels() {
     file,
     restricted: "openrouter-qwen-qwen3-8-max",
     unrestricted: "openrouter-openai-gpt-5-3",
+    strictSchema: "openrouter-vendor-strict-schema",
+    ordinarySchema: "openrouter-vendor-ordinary-schema",
     chutes: "chutes-moonshotai-kimi-k3-tee",
   };
 }
@@ -3794,6 +3798,70 @@ test("API forwarder downgrades forced tool choices only for models that declare 
     assert.equal(chutes.body.model, "moonshotai/Kimi-K3-TEE");
     assert.equal(chutes.body.tool_choice, "required");
     assert.equal(chutes.body.reasoning_effort, "high");
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+    rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
+test("API forwarder strips Codex schema annotations only for an explicitly profiled model", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const curated = curatedOpenRouterModels();
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    MODEL_ROUTER_USER_MODELS: curated.file,
+    OPENROUTER_API_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OPENROUTER_API_KEY: "TEST_OPENROUTER_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const parameters = {
+    type: "object",
+    properties: {
+      value: { type: "string", encrypted: true },
+      encrypted: { type: "string", description: "A real argument name." },
+    },
+    default: { encrypted: true },
+  };
+
+  async function forward(model) {
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "test" }],
+        tools: [{
+          type: "function",
+          function: { name: "save", description: "Save a value.", parameters },
+        }],
+      }),
+    });
+    assert.equal(response.status, 200);
+    return upstreamRequests.at(-1).body.tools[0].function.parameters;
+  }
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    assert.deepEqual(await forward(curated.ordinarySchema), parameters);
+    assert.deepEqual(await forward(curated.strictSchema), {
+      type: "object",
+      properties: {
+        value: { type: "string" },
+        encrypted: { type: "string", description: "A real argument name." },
+      },
+      default: { encrypted: true },
+    });
   } finally {
     await stopChild(forwarder);
     await closeServer(upstream.server);

--- a/test/support-bundle.test.mjs
+++ b/test/support-bundle.test.mjs
@@ -17,6 +17,25 @@ delete process.env.CHUTES_API_KEY;
 delete process.env.KIMI_API_KEY;
 delete process.env.MOONSHOT_API_KEY;
 
+mkdirSync(process.env.CODEX_ROUTER_STATE_DIR, { recursive: true, mode: 0o700 });
+const genericHeaderSentinel = "TEST_SUPPORT_GENERIC_HEADER_MUST_NOT_APPEAR";
+writeFileSync(
+  path.join(process.env.CODEX_ROUTER_STATE_DIR, "generic-providers.json"),
+  `${JSON.stringify({
+    version: 1,
+    providers: [{
+      id: "support-generic",
+      displayName: "Support Generic",
+      baseUrl: "https://support-generic.example.test/v1",
+      adapter: "openai-chat",
+      headers: { "X-Private-Routing": genericHeaderSentinel },
+      allowPrivate: false,
+      enabled: true,
+    }],
+  }, null, 2)}\n`,
+  { mode: 0o600 },
+);
+
 const { createSupportBundle } = await import("../src/support-bundle.mjs");
 
 test("support bundle reports credential presence without including values", () => {
@@ -63,10 +82,16 @@ model_catalog_json = ${JSON.stringify(path.join(stateDir, "merged-models.json"))
     assert.equal(bundle.credentialSources.deepseek.configured, true);
     assert.equal(bundle.credentialSources.chutes.configured, true);
     assert.equal(bundle.credentialSources["github-copilot"].configured, true);
+    assert.deepEqual(bundle.credentialSources["support-generic"], {
+      configured: true,
+      source: "not required",
+      persistent: false,
+    });
     assert.doesNotMatch(contents, new RegExp(sentinel));
     assert.doesNotMatch(contents, new RegExp(chutesSentinel));
     assert.doesNotMatch(contents, new RegExp(copilotSentinel));
     assert.doesNotMatch(contents, new RegExp(callerSentinel));
+    assert.doesNotMatch(contents, new RegExp(genericHeaderSentinel));
     assert.match(bundle.config.openai_base_url, /\[REDACTED\]/);
     assert.equal("redactedLogTail" in bundle, false);
   } finally {

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -10,7 +10,47 @@ import {
   normalizeSchemaLiterals,
   objectRootToolSchema,
   providerToolSchema,
+  stripCodexEncryptedSchemaAnnotation,
 } from "../src/tool-schema-root.mjs";
+
+test("Codex encrypted annotations are removed only from JSON-Schema nodes", () => {
+  const ordinary = {
+    type: "object",
+    properties: { value: { type: "string" } },
+  };
+  assert.equal(stripCodexEncryptedSchemaAnnotation(ordinary), ordinary);
+
+  const schema = {
+    type: "object",
+    encrypted: true,
+    properties: {
+      encrypted: {
+        type: "string",
+        description: "A legitimate user property named encrypted.",
+      },
+      nested: {
+        type: "object",
+        properties: {
+          value: { type: "string", encrypted: true },
+        },
+      },
+    },
+    default: { encrypted: true },
+    examples: [{ encrypted: true }],
+  };
+  const repaired = stripCodexEncryptedSchemaAnnotation(schema);
+  assert.notEqual(repaired, schema);
+  assert.equal("encrypted" in repaired, false);
+  assert.deepEqual(repaired.properties.encrypted, {
+    type: "string",
+    description: "A legitimate user property named encrypted.",
+  });
+  assert.equal("encrypted" in repaired.properties.nested.properties.value, false);
+  assert.deepEqual(repaired.default, { encrypted: true });
+  assert.deepEqual(repaired.examples, [{ encrypted: true }]);
+  assert.equal(schema.encrypted, true, "the caller's schema must not be mutated");
+  assert.equal(schema.properties.nested.properties.value.encrypted, true);
+});
 
 test("recursive local refs keep definitions and only the cycle edge becomes permissive", () => {
   const schema = {


### PR DESCRIPTION
Closes #491.

Adds operator-managed generic OpenAI-compatible providers without extending trusted built-in provider identities.

Security and lifecycle boundaries:
- only an explicit closed request-profile allowlist is accepted
- live discovery cannot mint compatibility profiles
- credentials stay in the protected credential store and are injected only after endpoint, DNS, origin, and redirect validation
- generic CRUD applies catalog publication and service restart transactionally, with rollback
- doctor, health, and support output remain sanitized
- disabled or unavailable credentials fail closed with 503

Verification before opening:
- npm run check
- 78 focused generic routing, registry, curation, picker, capability, schema, doctor, and support-bundle tests passed
- no live provider or quota-consuming calls were made

This is draft-gated on the exact-head Linux, macOS, and Windows CI matrix.