### PR TITLE
fix: record state ownership before installing the service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Reinstalling over a state directory owned by another checkout no longer
+  deadlocks.** The installers recorded the state directory's new owner only
+  after the background service reported healthy, while the service itself
+  refuses to boot for as long as the record still names another checkout
+  (`foreign_state_owner`): an install that followed one from a different
+  checkout crash-looped for the full 300-second readiness budget, rolled
+  back, and repeated on every retry, and deleting the whole state directory
+  -- every stored provider key with it -- was the only escape. The record now
+  precedes the service step it describes, so the service boots against its
+  own ownership. Linux readiness also fails fast once the service manager's
+  restart counter shows a crash loop, instead of waiting out the whole
+  budget, and names the journal and the router log in the error.
+
 - **OpenCode Go Kimi K2.7 Code now accepts current Codex tool schemas.** Its
   Moonshot-backed validator receives the same bounded decorated-`$defs` repair
   as the first-party Kimi routes. The compatibility gate names only this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,16 @@
   back, and repeated on every retry, and deleting the whole state directory
   -- every stored provider key with it -- was the only escape. The record now
   precedes the service step it describes, so the service boots against its
-  own ownership. Linux readiness also fails fast once the service manager's
-  restart counter shows a crash loop, instead of waiting out the whole
-  budget, and names the journal and the router log in the error.
+  own ownership. The ownership override the installers run under is scoped
+  to that full, ownership-transferring install on both platforms: a
+  prepare-only run meets the guard like any other writer (and the Windows
+  installer restores the caller's environment when it finishes). Linux
+  readiness also fails fast once the service manager's restart counter shows
+  a crash loop, instead of waiting out the whole budget, and names the
+  journal and the router log in the error; the counter query itself is
+  killed inside a bounded slice of the remaining budget, so a blocked
+  `systemctl` cannot stretch the wait, and a health answer that lands as the
+  threshold is crossed still wins over the crash-loop verdict.
 
 - **OpenCode Go Kimi K2.7 Code now accepts current Codex tool schemas.** Its
   Moonshot-backed validator receives the same bounded decorated-`$defs` repair

--- a/bin/install
+++ b/bin/install
@@ -8,12 +8,6 @@ adopt_native_catalog=false
 force_deps=false
 target=${MODEL_ROUTER_TARGET:-codex}
 
-# Installing is the sanctioned way for a checkout to take over a state
-# directory: generated files are rebuilt here and the new owner is recorded at
-# the end, so the ownership guard must not block this run.
-MODEL_ROUTER_ALLOW_FOREIGN_STATE=1
-export MODEL_ROUTER_ALLOW_FOREIGN_STATE
-
 case "$target" in
   codex|dsh|gemini) ;;
   *) echo "MODEL_ROUTER_TARGET must be codex, dsh, or gemini." >&2; exit 2 ;;
@@ -28,6 +22,18 @@ for argument in "$@"; do
     *) echo "Usage: $0 [--prepare-only] [--migrate-known] [--adopt-native-catalog] [--force-deps]" >&2; exit 2 ;;
   esac
 done
+
+# Installing is the sanctioned way for a checkout to take over a state
+# directory: generated files are rebuilt here and the new owner is recorded at
+# the end, so the ownership guard must not block this run. The override is
+# scoped to that full install, and only after the arguments are known: a
+# --prepare-only run rewrites the same generated state but exits before the
+# manifest record, so letting it past the guard would let a second checkout
+# rebuild foreign-owned state with no ownership transfer ever recorded.
+if [ "$prepare_only" != true ]; then
+  MODEL_ROUTER_ALLOW_FOREIGN_STATE=1
+  export MODEL_ROUTER_ALLOW_FOREIGN_STATE
+fi
 
 if [ "$prepare_only" = true ] && [ "$migrate_known" = true ]; then
   echo "--prepare-only cannot migrate an active older router." >&2

--- a/bin/install
+++ b/bin/install
@@ -334,16 +334,19 @@ if [ "$adopt_native_catalog" = true ]; then
 else
   node "$config_manager" "$config_enable_command"
 fi
+# Record before the service starts, not after. The generated state above was
+# written by this checkout, so ownership is already this checkout's in fact;
+# the manifest is provenance for exactly that -- which checkout owns the state,
+# and the proxy environment a later repair must restore -- and the desktop app
+# resolves its source root from the field. The service itself needs the record
+# in place first: start.mjs rewrites the gateway config on every boot and
+# refuses while the manifest still names another checkout, so recording after
+# `service.mjs install` -- a step that contains the health wait -- let an
+# install over a foreign-owned state directory crash-loop for the whole
+# readiness budget while the ownership transfer it needed never ran.
+node src/install-manifest.mjs record >/dev/null
 service_installed=true
 node src/service.mjs install
-# Record before the health wait, not after. The manifest is provenance for the
-# install that just happened -- which checkout owns the state, and the proxy
-# environment a later repair must restore -- and `service.mjs install` has
-# already put that checkout's service in place. Recording it only after a
-# health check that a cold-starting gateway can lose left the manifest naming
-# the previous owner while the running service pointed somewhere else, and the
-# desktop app resolves its source root from that field.
-node src/install-manifest.mjs record >/dev/null
 node src/wait-health.mjs
 # A companion that is never rebuilt drifts behind the router on every update
 # and keeps running its old binary. Rebuild only when one is already installed

--- a/install.ps1
+++ b/install.ps1
@@ -243,6 +243,11 @@ $ConfigDisableCommand = if ($Target -eq "codex") { "disable" } else { "uninstall
 $ConfigEnabled = $false
 $ServiceInstalled = $false
 $AdoptionPending = $false
+# The foreign-state override below is set inside the try and must be undone in
+# the finally even when a step throws first, so both halves of the caller's
+# environment are captured up front.
+$SavedForeignStateOverride = $null
+$HadForeignStateOverride = $false
 $ConfigWasEnabled = $false
 $ServiceWasInstalled = $false
 $TrayWasInstalled = $false
@@ -393,6 +398,19 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "Recording the Python dependency state failed." }
   }
 
+  # Installing is the sanctioned way for a checkout to take over a state
+  # directory: the generated files below are rebuilt here and the new owner is
+  # recorded before the service step, so the ownership guard must not block a
+  # full install. The override is scoped to exactly that run and only after
+  # -PrepareOnly is known: a -PrepareOnly run rewrites the same generated state
+  # but exits before the manifest record, so letting it past the guard would
+  # let a second checkout rebuild foreign-owned state with no ownership
+  # transfer ever recorded. The caller's own value is restored in the finally.
+  if (-not $PrepareOnly) {
+    $HadForeignStateOverride = $null -ne (Get-Item Env:\MODEL_ROUTER_ALLOW_FOREIGN_STATE -ErrorAction SilentlyContinue)
+    $SavedForeignStateOverride = $env:MODEL_ROUTER_ALLOW_FOREIGN_STATE
+    $env:MODEL_ROUTER_ALLOW_FOREIGN_STATE = "1"
+  }
   & node src/secret.mjs ensure
   if ($LASTEXITCODE -ne 0) { throw "Local router-key setup failed." }
   # The state root is read by both arms below, so it is computed once rather
@@ -545,5 +563,13 @@ try {
   }
   throw
 } finally {
+  # Restore the caller's environment exactly as it was found: a value this run
+  # did not set is removed, and a pre-existing one is put back verbatim. The
+  # scoped override must never outlive the install process that justified it.
+  if ($HadForeignStateOverride) {
+    $env:MODEL_ROUTER_ALLOW_FOREIGN_STATE = $SavedForeignStateOverride
+  } else {
+    Remove-Item Env:\MODEL_ROUTER_ALLOW_FOREIGN_STATE -ErrorAction SilentlyContinue
+  }
   Pop-Location
 }

--- a/install.ps1
+++ b/install.ps1
@@ -457,17 +457,19 @@ try {
   & node @ConfigArguments
   if ($LASTEXITCODE -ne 0) { throw "$Target configuration update failed." }
   $AdoptionPending = $false
+  # Record before the service starts, not after. The manifest is provenance for
+  # the install that just happened -- which checkout owns the state, and the
+  # proxy environment a later repair must restore -- and the service itself
+  # needs the record in place first: start.mjs rewrites the gateway config on
+  # every boot and refuses while the manifest still names another checkout, so
+  # recording after `service.mjs install` -- a step that contains the health
+  # wait -- let an install over a foreign-owned state directory crash-loop for
+  # the whole readiness budget while the ownership transfer never ran.
+  & node src/install-manifest.mjs record | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw "Install-manifest recording failed." }
   $ServiceInstalled = $true
   & node src/service.mjs install
   if ($LASTEXITCODE -ne 0) { throw "Background-service installation failed." }
-  # Record before the health wait, not after. The manifest is provenance for
-  # the install that just happened -- which checkout owns the state, and the
-  # proxy environment a later repair must restore -- and the service is already
-  # in place. Recording it only after a health check that a cold-starting
-  # gateway can lose left the manifest naming the previous owner while the
-  # running service pointed somewhere else.
-  & node src/install-manifest.mjs record | Out-Null
-  if ($LASTEXITCODE -ne 0) { throw "Install-manifest recording failed." }
   & node src/wait-health.mjs
   if ($LASTEXITCODE -ne 0) { throw "The router did not become healthy." }
 

--- a/src/service-linux.mjs
+++ b/src/service-linux.mjs
@@ -158,8 +158,8 @@ function writeUnit() {
   renameSync(temporary, unitPath);
 }
 
-if (!new Set(["install", "uninstall", "start", "stop", "restart", "status", "render"]).has(command)) {
-  console.error("Usage: service-linux.mjs install|uninstall|start|stop|restart|status|render");
+if (!new Set(["install", "uninstall", "start", "stop", "restart", "status", "render", "restart-count"]).has(command)) {
+  console.error("Usage: service-linux.mjs install|uninstall|start|stop|restart|status|render|restart-count");
   process.exit(2);
 }
 
@@ -200,6 +200,23 @@ if (command === "render") {
   process.stdout.write(
     `${JSON.stringify({ installed: existsSync(unitPath), loaded: state === "active", state })}\n`,
   );
+} else if (command === "restart-count") {
+  // The automatic-restart counter systemd tracks for the unit. It is what
+  // moves during a crash loop -- with Restart=always the unit state cycles
+  // back to "active" after every crash -- and it is compared against the
+  // value at wait start, so residue from before this install only ever
+  // understates the loop. A unit systemd does not know reports no count.
+  let restarts = null;
+  try {
+    const parsed = Number.parseInt(
+      systemctl(["show", unitName, "--property=NRestarts", "--value"]).trim(),
+      10,
+    );
+    if (Number.isSafeInteger(parsed) && parsed >= 0) restarts = parsed;
+  } catch {
+    // No user systemd session, or the unit is not loaded.
+  }
+  process.stdout.write(`${JSON.stringify({ restarts })}\n`);
 } else {
   const verb = { start: "start", stop: "stop", restart: "restart" }[command];
   systemctl([verb, unitName], { quiet: true });

--- a/src/service-readiness.mjs
+++ b/src/service-readiness.mjs
@@ -1,8 +1,14 @@
 import { waitForRouterHealth } from "./router-health.mjs";
+import { STATE_DIR } from "./paths.mjs";
 import { windowsScheduledTaskState } from "./windows-task-state.mjs";
 
 const TASK_LAUNCH_GRACE_MS = 15_000;
 const TASK_STATE_POLL_MS = 1_000;
+// A systemd unit with Restart=always re-enters "active" after every crash, so
+// the unit state never reads "failed" during a crash loop and health alone
+// cannot distinguish one from a slow start. The restart counter is what
+// moves; this many restarts since the wait began is a crash loop.
+const CRASH_LOOP_RESTARTS = 3;
 
 function sleep(milliseconds) {
   return milliseconds <= 0
@@ -22,6 +28,17 @@ async function settleHealth(waitForHealth, timeoutMs) {
   }
 }
 
+// A restart-count query failure is inconclusive, exactly like a failed Task
+// Scheduler query on Windows, and never fails the wait by itself.
+async function settleRestarts(getServiceRestarts) {
+  try {
+    const restarts = await getServiceRestarts();
+    return Number.isSafeInteger(restarts) && restarts >= 0 ? restarts : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Wait for router health while honoring Windows' authoritative task state.
  *
@@ -32,6 +49,12 @@ async function settleHealth(waitForHealth, timeoutMs) {
  * launch for longer than the launch grace, readiness fails with the task's
  * own result instead of polling health for the full budget. A query failure
  * is inconclusive and never fails the wait by itself.
+ *
+ * On the POSIX service managers the analogous early verdict is the restart
+ * counter: a unit that accumulates restarts while health never answers is
+ * crash-looping, and polling health for the full budget only delays the
+ * operator's look at the service log. When no counter is available the wait
+ * stays health-only, which is the shape macOS launchd has.
  */
 export async function waitForServiceReadiness({
   platform = process.platform,
@@ -39,6 +62,7 @@ export async function waitForServiceReadiness({
   launchGraceMs = TASK_LAUNCH_GRACE_MS,
   pollMs = TASK_STATE_POLL_MS,
   getWindowsTaskState = windowsScheduledTaskState,
+  getServiceRestarts,
   waitForHealth = waitForRouterHealth,
 } = {}) {
   const deadline = Date.now() + Math.max(0, timeoutMs);
@@ -53,6 +77,39 @@ export async function waitForServiceReadiness({
     new Error(outcome.health?.error || "service did not become healthy");
 
   if (platform !== "win32") {
+    if (typeof getServiceRestarts !== "function") {
+      const winner = await healthWinner;
+      if (winner.outcome.healthy) return winner.outcome.health;
+      throw failureOf(winner.outcome);
+    }
+    // Restart counts are compared against the value at wait start, not
+    // absolute: a unit can carry restarts from before this install touched
+    // it, and only restarts this wait observes are evidence of a loop.
+    let baseline = await settleRestarts(getServiceRestarts);
+    let restartsSince = 0;
+    while (Date.now() < deadline) {
+      const winner = await Promise.race([
+        healthWinner,
+        sleep(Math.min(pollMs, deadline - Date.now())).then(() => null),
+      ]);
+      if (winner) {
+        if (winner.outcome.healthy) return winner.outcome.health;
+        throw failureOf(winner.outcome);
+      }
+      const restarts = await settleRestarts(getServiceRestarts);
+      if (restarts !== undefined) {
+        baseline ??= restarts;
+        restartsSince = Math.max(restartsSince, restarts - baseline);
+        if (restartsSince >= CRASH_LOOP_RESTARTS) {
+          throw new Error(
+            `The background service restarted ${restartsSince} times while ` +
+              "waiting for it to become healthy; it is crash-looping. " +
+              "Inspect `journalctl --user -u codex-router.service` and the " +
+              `router log in ${STATE_DIR}.`,
+          );
+        }
+      }
+    }
     const winner = await healthWinner;
     if (winner.outcome.healthy) return winner.outcome.health;
     throw failureOf(winner.outcome);

--- a/src/service-readiness.mjs
+++ b/src/service-readiness.mjs
@@ -29,10 +29,13 @@ async function settleHealth(waitForHealth, timeoutMs) {
 }
 
 // A restart-count query failure is inconclusive, exactly like a failed Task
-// Scheduler query on Windows, and never fails the wait by itself.
-async function settleRestarts(getServiceRestarts) {
+// Scheduler query on Windows, and never fails the wait by itself. The query
+// receives the wait's remaining budget so a slow counter source (spawnSync on
+// the Linux path) can bound itself inside the deadline instead of stretching
+// it.
+async function settleRestarts(getServiceRestarts, remainingMs) {
   try {
-    const restarts = await getServiceRestarts();
+    const restarts = await getServiceRestarts(Math.max(0, remainingMs));
     return Number.isSafeInteger(restarts) && restarts >= 0 ? restarts : undefined;
   } catch {
     return undefined;
@@ -85,7 +88,7 @@ export async function waitForServiceReadiness({
     // Restart counts are compared against the value at wait start, not
     // absolute: a unit can carry restarts from before this install touched
     // it, and only restarts this wait observes are evidence of a loop.
-    let baseline = await settleRestarts(getServiceRestarts);
+    let baseline = await settleRestarts(getServiceRestarts, deadline - Date.now());
     let restartsSince = 0;
     while (Date.now() < deadline) {
       const winner = await Promise.race([
@@ -96,11 +99,23 @@ export async function waitForServiceReadiness({
         if (winner.outcome.healthy) return winner.outcome.health;
         throw failureOf(winner.outcome);
       }
-      const restarts = await settleRestarts(getServiceRestarts);
+      const restarts = await settleRestarts(getServiceRestarts, deadline - Date.now());
       if (restarts !== undefined) {
         baseline ??= restarts;
         restartsSince = Math.max(restartsSince, restarts - baseline);
         if (restartsSince >= CRASH_LOOP_RESTARTS) {
+          // The counter query itself takes time, and health may settle while
+          // it runs -- the poll race above gave up a tick ago. The counter
+          // never overrides a verdict health has already reached, so the
+          // crash-loop finding is reported only after one last bounded look.
+          const finalWinner = await Promise.race([
+            healthWinner,
+            sleep(pollMs).then(() => null),
+          ]);
+          if (finalWinner) {
+            if (finalWinner.outcome.healthy) return finalWinner.outcome.health;
+            throw failureOf(finalWinner.outcome);
+          }
           throw new Error(
             `The background service restarted ${restartsSince} times while ` +
               "waiting for it to become healthy; it is crash-looping. " +

--- a/src/service.mjs
+++ b/src/service.mjs
@@ -28,6 +28,10 @@ const shutdownCommands = new Set(["stop", "uninstall"]);
 // service and reverts the app config out from under a router that goes on to
 // come up healthy seconds later.
 const READINESS_TIMEOUT_MS = 300_000;
+// One restart-count query runs on every readiness poll, synchronously. A
+// systemctl that never answers must cost the wait a bounded slice, not the
+// whole readiness budget, so the query is killed and read as inconclusive.
+const RESTART_QUERY_TIMEOUT_MS = 5_000;
 
 async function runServiceCommand() {
   // The wrapper below is a separate Node process, so a direct
@@ -58,11 +62,19 @@ async function runServiceCommand() {
     // guard, and launchd has no equivalent counter.
     ...(script === "service-linux.mjs"
       ? {
-          getServiceRestarts: () => {
+          // The readiness guard passes whatever budget it has left, so the
+          // fixed slice below can never stretch the wait past its deadline.
+          getServiceRestarts: (remainingMs) => {
+            if (!(remainingMs > 0)) return undefined;
             const counter = spawnSync(
               process.execPath,
               [path.join(SOURCE_ROOT, "src", script), "restart-count"],
-              { encoding: "utf8", env: childEnvironment },
+              {
+                encoding: "utf8",
+                env: childEnvironment,
+                timeout: Math.min(RESTART_QUERY_TIMEOUT_MS, remainingMs),
+                killSignal: "SIGKILL",
+              },
             );
             if (counter.error || counter.status !== 0) return undefined;
             try {

--- a/src/service.mjs
+++ b/src/service.mjs
@@ -51,7 +51,30 @@ async function runServiceCommand() {
   if (shutdownCommands.has(command)) await stopManagedOllama();
   if (!readinessCommands.has(command)) return 0;
 
-  const health = await waitForServiceReadiness({ timeoutMs: READINESS_TIMEOUT_MS });
+  const health = await waitForServiceReadiness({
+    timeoutMs: READINESS_TIMEOUT_MS,
+    // Only the Linux service manager exposes an automatic-restart counter
+    // this guard can read; Windows readiness carries its own task-state
+    // guard, and launchd has no equivalent counter.
+    ...(script === "service-linux.mjs"
+      ? {
+          getServiceRestarts: () => {
+            const counter = spawnSync(
+              process.execPath,
+              [path.join(SOURCE_ROOT, "src", script), "restart-count"],
+              { encoding: "utf8", env: childEnvironment },
+            );
+            if (counter.error || counter.status !== 0) return undefined;
+            try {
+              const parsed = JSON.parse(counter.stdout);
+              return typeof parsed.restarts === "number" ? parsed.restarts : undefined;
+            } catch {
+              return undefined;
+            }
+          },
+        }
+      : {}),
+  });
   if (health.ok) return 0;
   console.error(
     `Router did not become healthy within ${READINESS_TIMEOUT_MS / 1_000} seconds: ${health.error}`,

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -765,3 +765,66 @@ test("both installers record the manifest before waiting on health", () => {
     "Windows must record the manifest before installing the service",
   );
 });
+
+// The foreign-state override is what lets a checkout rebuild state that
+// another checkout owns. It must be scoped to a full ownership-transferring
+// install and to nothing else: a --prepare-only run rewrites the same
+// generated state but exits before the manifest record, so an override there
+// would let a second checkout rebuild foreign-owned state with no ownership
+// transfer ever recorded. On Windows the same override is what makes a full
+// cross-checkout install possible at all, and because it manipulates the
+// caller's environment it must be restored whatever the run's outcome.
+test("the foreign-state override is scoped to a full ownership-transferring install", () => {
+  const posix = readFileSync(path.join(root, "bin", "install"), "utf8");
+  const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
+
+  // POSIX: exported only after the arguments are known, and only for a full
+  // install -- a prepare-only run must meet the guard like any other writer.
+  const parseIndex = posix.indexOf("--prepare-only) prepare_only=true ;;");
+  const exportIndex = posix.indexOf("MODEL_ROUTER_ALLOW_FOREIGN_STATE=1");
+  assert.notEqual(parseIndex, -1, "bin/install must parse --prepare-only");
+  assert.notEqual(exportIndex, -1, "bin/install must export the override");
+  assert.ok(
+    exportIndex > parseIndex,
+    "the override must be exported only after --prepare-only is parsed",
+  );
+  assert.match(
+    posix,
+    /if \[ "\$prepare_only" != true \]; then\n  MODEL_ROUTER_ALLOW_FOREIGN_STATE=1\n  export MODEL_ROUTER_ALLOW_FOREIGN_STATE\nfi/,
+    "the override must be guarded on a full install",
+  );
+  const syntax = spawnSync("sh", ["-n", path.join(root, "bin", "install")], {
+    encoding: "utf8",
+  });
+  assert.equal(syntax.status, 0, syntax.stderr);
+
+  // Windows: set only when -PrepareOnly is off, in place before the generated
+  // state is rebuilt, and restored in the outer finally -- removed when the
+  // caller had none, put back verbatim when they did.
+  assert.match(
+    windows,
+    /if \(-not \$PrepareOnly\) \{[\s\S]{0,600}?\$env:MODEL_ROUTER_ALLOW_FOREIGN_STATE = "1"/,
+    "the override must be set only for a full install",
+  );
+  const setIndex = windows.indexOf('$env:MODEL_ROUTER_ALLOW_FOREIGN_STATE = "1"');
+  assert.ok(
+    setIndex !== -1 && setIndex < windows.indexOf("src/catalog.mjs"),
+    "the override must be in place before the generated state is rebuilt",
+  );
+  const finallyBody = windows.slice(windows.lastIndexOf("} finally {"));
+  assert.match(
+    finallyBody,
+    /\$env:MODEL_ROUTER_ALLOW_FOREIGN_STATE = \$SavedForeignStateOverride/,
+    "a pre-existing override value must be restored",
+  );
+  assert.match(
+    finallyBody,
+    /Remove-Item Env:\\MODEL_ROUTER_ALLOW_FOREIGN_STATE/,
+    "an override the caller never had must be removed",
+  );
+  assert.ok(
+    finallyBody.indexOf("Pop-Location") >
+      finallyBody.indexOf("MODEL_ROUTER_ALLOW_FOREIGN_STATE"),
+    "the environment restore belongs in the same finally as the location restore",
+  );
+});

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -739,7 +739,10 @@ test("installer rollback undoes only what the run created", () => {
 // The manifest names the checkout that owns the generated state, and the
 // desktop app resolves its source root from it. Recording it only after the
 // health wait meant a timeout left the manifest naming the previous owner
-// while the installed service pointed at the new one.
+// while the installed service pointed at the new one. It must also precede
+// the service step itself: the service refuses to boot while the manifest
+// still names another checkout, so a record that runs after the service step
+// -- which contains the health wait -- can never run at all.
 test("both installers record the manifest before waiting on health", () => {
   const posix = readFileSync(path.join(root, "bin", "install"), "utf8");
   const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
@@ -751,5 +754,14 @@ test("both installers record the manifest before waiting on health", () => {
   assert.ok(
     windows.indexOf("install-manifest.mjs record") < windows.indexOf("wait-health.mjs"),
     "Windows must record the manifest before the health wait",
+  );
+  assert.ok(
+    posix.indexOf("install-manifest.mjs record") < posix.indexOf("node src/service.mjs install"),
+    "POSIX must record the manifest before installing the service",
+  );
+  assert.ok(
+    windows.indexOf("install-manifest.mjs record") <
+      windows.indexOf("& node src/service.mjs install"),
+    "Windows must record the manifest before installing the service",
   );
 });

--- a/test/service-readiness.test.mjs
+++ b/test/service-readiness.test.mjs
@@ -163,6 +163,62 @@ test("a restart count that never climbs keeps the wait alive until health answer
   assert.ok(queries > 1);
 });
 
+test("health that settles as the restart threshold is reached wins over the crash-loop verdict", async () => {
+  // The poll race has already given up the tick by the time the counter query
+  // runs, so health can arrive inside that very query. The counter must never
+  // override a verdict health has reached; this exact interleaving used to
+  // throw crash-looping for a router that was already healthy.
+  let restarts = 0;
+  let resolveHealth;
+  const healthSettled = new Promise((resolve) => {
+    resolveHealth = resolve;
+  });
+  const health = await waitForServiceReadiness({
+    platform: "linux",
+    timeoutMs: 10_000,
+    pollMs: 10,
+    getServiceRestarts: () => {
+      restarts += 1;
+      if (restarts === 4) resolveHealth({ ok: true });
+      return restarts;
+    },
+    waitForHealth: () => healthSettled,
+  });
+  assert.equal(restarts, 4);
+  assert.deepEqual(health, { ok: true });
+});
+
+test("a restart-count query is given the remaining budget and cannot stretch the wait", async () => {
+  const budgets = [];
+  const startedAt = Date.now();
+  await assert.rejects(
+    waitForServiceReadiness({
+      platform: "linux",
+      timeoutMs: 150,
+      pollMs: 10,
+      getServiceRestarts: (remainingMs) => {
+        budgets.push(remainingMs);
+        return 7; // present but never climbing: no loop evidence, no early verdict
+      },
+      waitForHealth: () =>
+        new Promise((resolve) =>
+          setTimeout(resolve, 200, { ok: false, error: "router never answered" }),
+        ),
+    }),
+    /router never answered/,
+  );
+  assert.ok(budgets.length > 1, "the counter must be polled while the wait runs");
+  assert.ok(
+    budgets.every((budget) => budget >= 0 && budget <= 150),
+    "each query must receive a budget inside the wait's own timeout",
+  );
+  assert.ok(budgets[0] > 0, "the baseline query must still have budget");
+  assert.ok(
+    Date.now() - startedAt < 5_000,
+    "the wait must end at its deadline, not stretch past it",
+  );
+});
+
 test("a failed health result object is a failure, never a resolution", async () => {
   // `waitForRouterHealth` resolves `{ ok: false, error }` instead of
   // rejecting; the guard must surface that as a thrown failure.
@@ -197,4 +253,15 @@ test("the Linux service manager feeds its restart counter to the readiness guard
   const linux = readFileSync(path.join(root, "src", "service-linux.mjs"), "utf8");
   assert.match(linux, /"restart-count"/);
   assert.match(linux, /NRestarts/);
+});
+
+test("the Linux restart-count query is bounded inside the readiness deadline", () => {
+  const service = readFileSync(path.join(root, "src", "service.mjs"), "utf8");
+  assert.match(service, /RESTART_QUERY_TIMEOUT_MS = /);
+  // A blocked systemctl is killed after a fixed slice capped by the wait's
+  // remaining budget, and a killed query reads as inconclusive -- it can
+  // never stretch the outer readiness deadline.
+  assert.match(service, /timeout: Math\.min\(RESTART_QUERY_TIMEOUT_MS, remainingMs\)/);
+  assert.match(service, /killSignal: "SIGKILL"/);
+  assert.match(service, /if \(!\(remainingMs > 0\)\) return undefined;/);
 });

--- a/test/service-readiness.test.mjs
+++ b/test/service-readiness.test.mjs
@@ -103,6 +103,66 @@ test("non-Windows readiness uses only router health", async () => {
   assert.equal(queried, false);
 });
 
+test("a crash-looping Linux service fails readiness early with the log locations", async () => {
+  let restarts = 0;
+  const startedAt = Date.now();
+  await assert.rejects(
+    waitForServiceReadiness({
+      platform: "linux",
+      timeoutMs: 60_000,
+      pollMs: 10,
+      getServiceRestarts: () => ++restarts,
+      waitForHealth: () => new Promise(() => {}),
+    }),
+    /restarted 3 times.*journalctl --user -u codex-router\.service/s,
+  );
+  // The early verdict must land well inside the budget, or the guard has
+  // bought nothing over waiting for health to time out.
+  assert.ok(Date.now() - startedAt < 30_000);
+});
+
+test("restarts counted from the value at wait start, not absolute counts", async () => {
+  // A unit can carry restarts from before this install; only an increase is
+  // evidence of a loop this wait observed.
+  const health = await waitForServiceReadiness({
+    platform: "linux",
+    timeoutMs: 1_000,
+    pollMs: 10,
+    getServiceRestarts: () => 50,
+    waitForHealth: () => new Promise((resolve) => setTimeout(resolve, 40, { ok: true })),
+  });
+  assert.deepEqual(health, { ok: true });
+});
+
+test("an unavailable restart count cannot make readiness fail closed", async () => {
+  const health = await waitForServiceReadiness({
+    platform: "linux",
+    timeoutMs: 1_000,
+    pollMs: 10,
+    getServiceRestarts: () => {
+      throw new Error("no systemd session");
+    },
+    waitForHealth: () => new Promise((resolve) => setTimeout(resolve, 40, { ok: true })),
+  });
+  assert.deepEqual(health, { ok: true });
+});
+
+test("a restart count that never climbs keeps the wait alive until health answers", async () => {
+  let queries = 0;
+  const health = await waitForServiceReadiness({
+    platform: "linux",
+    timeoutMs: 1_000,
+    pollMs: 10,
+    getServiceRestarts: () => {
+      queries += 1;
+      return 1;
+    },
+    waitForHealth: () => new Promise((resolve) => setTimeout(resolve, 40, { ok: true })),
+  });
+  assert.deepEqual(health, { ok: true });
+  assert.ok(queries > 1);
+});
+
 test("a failed health result object is a failure, never a resolution", async () => {
   // `waitForRouterHealth` resolves `{ ok: false, error }` instead of
   // rejecting; the guard must surface that as a thrown failure.
@@ -127,4 +187,14 @@ test("the service delegates its full readiness budget to the guarded wait", () =
   assert.match(source, /waitForServiceReadiness/);
   assert.match(source, /timeoutMs: READINESS_TIMEOUT_MS/);
   assert.doesNotMatch(source, /waitForRouterHealth/);
+});
+
+test("the Linux service manager feeds its restart counter to the readiness guard", () => {
+  const service = readFileSync(path.join(root, "src", "service.mjs"), "utf8");
+  assert.match(service, /getServiceRestarts/);
+  assert.match(service, /restart-count/);
+  assert.match(service, /service-linux\.mjs"\s*\n?\s*\?\s*\{/);
+  const linux = readFileSync(path.join(root, "src", "service-linux.mjs"), "utf8");
+  assert.match(linux, /"restart-count"/);
+  assert.match(linux, /NRestarts/);
 });


### PR DESCRIPTION
## Why

Reinstalling over a state directory owned by a different checkout
(`foreign_state_owner`) deadlocked on every retry, and the only escape was
deleting the whole state directory -- every stored provider key with it.

The deadlock chain, as observed on a real install:

1. `bin/install` runs with `MODEL_ROUTER_ALLOW_FOREIGN_STATE=1`, so the
   installer itself writes the generated catalog and gateway config fine
   (`state-owner.mjs` documents `bin/install` as the sanctioned ownership
   transfer).
2. The background service it installs does **not** get that override. On
   every boot, `start.mjs` calls `writeLiteLlmConfig()`, which
   `assertStateOwnership` refuses while `install-manifest.json` still names
   another checkout -- so the service crash-loops forever.
3. `service.mjs install` contains the readiness wait (up to 300 s), and the
   manifest was recorded only *after* it returned. Ownership therefore
   never transferred: the service cannot boot until the record updates, and
   the record cannot update until the service is healthy. The installer
   looks hung for the full budget, then rolls back, and the next retry
   repeats the cycle.

The crash loop also had no fast signal on Linux: with `Restart=always`, the
unit cycles back to "active" after every crash, so a crash-looping service
and a slow cold start are indistinguishable for the whole 300-second wait.

Triggering this requires having installed from two different checkouts
(e.g. a development checkout once, then the managed `install.sh` checkout)
-- exactly the cross-checkout scenario the ownership guard exists to manage
safely, and whose documented recovery ("reinstall from here") deadlocked.

## What

- **`bin/install` / `install.ps1`: record the manifest before the service
  step.** The generated state is already written by this checkout at that
  point, so the record is truthful, and the service boots against its own
  ownership instead of a stale one. The `--prepare-only` path is unchanged
  and still does not record. An install that previously deadlocked recovers
  by re-running the installer; no state migration is needed, since the next
  install overwrites the manifest.
- **`service-readiness.mjs`: fail fast on a Linux crash loop.** When the
  caller supplies a restart counter, the wait polls it alongside health and
  aborts once the count climbs 3 restarts above the value observed at wait
  start, with an error naming `journalctl --user -u codex-router.service`
  and the router log. The comparison is relative to the wait's own
  baseline, so residue from before the install cannot trigger it, and a
  failed query is inconclusive -- the wait stays health-only, which is the
  shape macOS launchd has (Windows already has its task-state guard).
- **`service-linux.mjs` / `service.mjs`: feed the counter to the guard.**
  New `restart-count` verb reading systemd's `NRestarts`; `service.mjs`
  injects it only for the Linux script.

## Test

- `test/installer-scripts.test.mjs` extends the manifest-ordering test:
  the record must now precede `service.mjs install` on both installers,
  not only the health wait.
- `test/service-readiness.test.mjs` gains five cases: the crash loop
  rejects early (well inside the budget) with the journal hint; a steady
  count and a high-but-static count both keep the wait alive; a throwing
  counter cannot fail the wait; the threshold is measured against the
  wait's own baseline. A source-level test pins the `restart-count` verb
  and the `service.mjs` wiring.
- `npm run check` passes; `sh -n bin/install` passes.
- `npm test`: 2824/2854 pass. The 12 failures reproduce on the unmodified
  branch and are environmental: most disappear under `umask 077` (fixture
  directories created 0775), one file needs the not-installed `playwright`
  devDependency, and two are source-root-discovery / `rmSync` quirks of
  this machine. None of the failing files import the changed modules.

## Design notes

- **Transfer semantics are unchanged.** `bin/install` was already the
  sanctioned ownership transfer: it runs with the override and rewrites the
  generated state either way. This PR only reorders the steps inside that
  same run, so the record lands before the service that depends on it. The
  guard's behavior on the unattended paths -- service boot, non-override
  rewrites -- is untouched.
- **Output surface is unchanged.** The readiness error names the state
  directory path and the unit name, the same identifiers doctor already
  reports. The `restart-count` verb emits a single integer, and
  `install-manifest.mjs record` output stays suppressed on both platforms,
  as before.
- **systemctl is invoked the same way as the existing verbs**: fixed argv
  arrays, a constant unit name, no shell. Unparseable counter output
  degrades to "unknown".
- **The guard degrades to the previous behavior.** With no counter
  available -- no systemd session, a non-zero exit, unparseable output --
  the wait is health-only, which is what this platform did before. A query
  failure can never fail an install, matching the existing Task Scheduler
  precedent on Windows.
- **A record failure now stops earlier.** If recording the manifest fails,
  the install aborts before the service step, so no service is started into
  a state it cannot boot in.

Compatibility: `systemctl --value` needs systemd >= 236 (2018). Older
builds yield an empty value, which reads as "unknown" and only disables the
early abort.