### PR TITLE
fix: keep router health inside its deadline

### DIFF
--- a/src/router-health.mjs
+++ b/src/router-health.mjs
@@ -27,7 +27,8 @@ export async function waitForRouterHealth({
   if (!SUPPORTED_TARGETS.has(target)) throw new Error(`Unknown router target: ${target}`);
   const expectedService = SERVICE_BY_TARGET[ROUTER_PLANE_TARGET];
 
-  const deadline = Date.now() + Math.max(0, timeoutMs);
+  const overallTimeoutMs = Math.max(0, timeoutMs);
+  const deadline = Date.now() + overallTimeoutMs;
   let lastError = "service unavailable";
   // A router that answers but reports a dependency down is a different failure
   // from a router that is not listening, and only the first one is survivable
@@ -35,9 +36,18 @@ export async function waitForRouterHealth({
   // caller can say which of the two happened instead of "not ready".
   let lastPayload;
   do {
+    // The overall health budget is authoritative. A slow TCP/HTTP attempt near
+    // its end must not consume a fresh full request timeout and make callers
+    // wait past the deadline they supplied. Keep timeoutMs=0 as the existing
+    // one-shot probe: tests and diagnostic callers use it to sample once.
+    const remainingRequestMs = deadline - Date.now();
+    const attemptTimeoutMs =
+      overallTimeoutMs === 0
+        ? requestTimeoutMs
+        : Math.max(1, Math.min(requestTimeoutMs, remainingRequestMs));
     try {
       const response = await fetchImpl(url, {
-        signal: AbortSignal.timeout(requestTimeoutMs),
+        signal: AbortSignal.timeout(attemptTimeoutMs),
       });
       const body = await response.text();
       let payload = {};

--- a/test/router-health.test.mjs
+++ b/test/router-health.test.mjs
@@ -52,3 +52,28 @@ test("router health rejects a different service on the configured port", async (
   assert.equal(health.ok, false);
   assert.match(health.error, /different service/);
 });
+
+test("router health bounds a request by the remaining overall deadline", async () => {
+  const startedAt = Date.now();
+  const health = await waitForRouterHealth({
+    target: "codex",
+    timeoutMs: 80,
+    requestTimeoutMs: 500,
+    intervalMs: 1,
+    fetchImpl: (_url, { signal }) =>
+      new Promise((resolve, reject) => {
+        const fallback = setTimeout(() => reject(new Error("request was never aborted")), 1_000);
+        signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(fallback);
+            reject(signal.reason);
+          },
+          { once: true },
+        );
+      }),
+  });
+
+  assert.equal(health.ok, false);
+  assert.ok(Date.now() - startedAt < 250, "health request exceeded the overall timeout budget");
+});


### PR DESCRIPTION
## Summary

Keep `waitForRouterHealth({ timeoutMs })` inside the overall timeout budget instead of allowing the final HTTP attempt to consume a fresh full `requestTimeoutMs` window.

## Root cause

Each health request always used `AbortSignal.timeout(requestTimeoutMs)`. If the overall health deadline was shorter than that request timeout, or nearly exhausted before a later request, the request could continue well past the deadline supplied by doctor/readiness callers.

A direct reproduction on current `main` used an 80 ms overall timeout and 500 ms request timeout. The existing code returned after about **508 ms**.

## Fix

- cap each positive-budget request timeout by the remaining overall deadline;
- preserve the existing `timeoutMs: 0` one-shot probe behavior;
- leave retry/backoff, degraded-health reporting, and service identity checks unchanged.

## Verification

- red/green regression: the new deadline test failed at ~508 ms before the implementation and passes at ~88 ms after it;
- `node --test test/router-health.test.mjs test/service-readiness.test.mjs test/doctor-idle.test.mjs test/health-probe.test.mjs` — **35 passed, 0 failed**;
- `npm.cmd run check` — pass (`v2-agent applications valid (6)`, syntax checks passed);
- `git diff --check` — clean;
- repo-maintainer analyzer classifies the final two-file diff as local/targeted risk.

No live provider or quota-consuming checks were used.