### PR TITLE
test: skip unavailable POSIX shell check on Windows

### DIFF
--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -793,10 +793,12 @@ test("the foreign-state override is scoped to a full ownership-transferring inst
     /if \[ "\$prepare_only" != true \]; then\n  MODEL_ROUTER_ALLOW_FOREIGN_STATE=1\n  export MODEL_ROUTER_ALLOW_FOREIGN_STATE\nfi/,
     "the override must be guarded on a full install",
   );
-  const syntax = spawnSync("sh", ["-n", path.join(root, "bin", "install")], {
-    encoding: "utf8",
-  });
-  assert.equal(syntax.status, 0, syntax.stderr);
+  if (POSIX_SHELL_AVAILABLE) {
+    const syntax = spawnSync("sh", ["-n", path.join(root, "bin", "install")], {
+      encoding: "utf8",
+    });
+    assert.equal(syntax.status, 0, syntax.stderr);
+  }
 
   // Windows: set only when -PrepareOnly is off, in place before the generated
   // state is rebuilt, and restored in the outer finally -- removed when the


### PR DESCRIPTION
## Summary

Make #497's mixed installer policy test honor the file's existing `POSIX_SHELL_AVAILABLE` guard before invoking `sh -n`.

## Root cause

`test/installer-scripts.test.mjs` already detects whether `sh` exists and skips executable POSIX-shell assertions when it does not. The new foreign-state-override test added by #497 invoked `spawnSync("sh", ...)` unconditionally inside a test that also contains Windows source assertions.

On a normal native Windows checkout without `sh.exe` on PATH, that subprocess returns `status: null`, so the test fails even though the Windows assertions and the shipped installer source are valid.

## Fix

Run only that POSIX syntax sub-check when `POSIX_SHELL_AVAILABLE` is true. The Windows assertions remain active and unchanged.

## Verification

- reproduced on current `main`: the exact test failed with `null !== 0` at the unconditional `sh -n` assertion;
- after the fix, the exact regression passes;
- full `test/installer-scripts.test.mjs` on this Windows host — **24 passed, 0 failed, 8 intentional skips**;
- `npm.cmd run check` — pass (`v2-agent applications valid (6)`, syntax checks passed);
- `git diff --check` — clean.

No production code changed and no live/provider checks were used.