### PR TITLE
fix: bound final readiness grace by deadline

### DIFF
--- a/src/service-readiness.mjs
+++ b/src/service-readiness.mjs
@@ -108,9 +108,12 @@ export async function waitForServiceReadiness({
           // it runs -- the poll race above gave up a tick ago. The counter
           // never overrides a verdict health has already reached, so the
           // crash-loop finding is reported only after one last bounded look.
+          // That grace still belongs to the original readiness budget; a
+          // threshold reached near the deadline must not add a fresh poll.
+          const finalGraceMs = Math.max(0, Math.min(pollMs, deadline - Date.now()));
           const finalWinner = await Promise.race([
             healthWinner,
-            sleep(pollMs).then(() => null),
+            sleep(finalGraceMs).then(() => null),
           ]);
           if (finalWinner) {
             if (finalWinner.outcome.healthy) return finalWinner.outcome.health;

--- a/test/service-readiness.test.mjs
+++ b/test/service-readiness.test.mjs
@@ -188,6 +188,25 @@ test("health that settles as the restart threshold is reached wins over the cras
   assert.deepEqual(health, { ok: true });
 });
 
+test("the final crash-loop health grace stays inside the readiness deadline", async () => {
+  let queries = 0;
+  const startedAt = Date.now();
+  await assert.rejects(
+    waitForServiceReadiness({
+      platform: "linux",
+      timeoutMs: 80,
+      pollMs: 200,
+      getServiceRestarts: () => (queries++ === 0 ? 0 : 3),
+      waitForHealth: () => new Promise(() => {}),
+    }),
+    /crash-looping/,
+  );
+  assert.ok(
+    Date.now() - startedAt < 180,
+    "the final health grace must not add a fresh poll interval after the deadline",
+  );
+});
+
 test("a restart-count query is given the remaining budget and cannot stretch the wait", async () => {
   const budgets = [];
   const startedAt = Date.now();


### PR DESCRIPTION
## Summary

Keep the Linux crash-loop guard's final health grace inside the original readiness deadline.

## Root cause

#497 correctly gives health one last chance to win when the systemd restart counter reaches the crash-loop threshold. That final race slept a fresh full `pollMs`, even when the overall readiness deadline had already expired or had less than one poll remaining.

A direct reproduction on current `main` used an 80 ms readiness timeout and 200 ms poll interval with the restart threshold reached at the deadline. The function returned after about **289 ms** instead of the requested budget.

## Fix

Cap the final health grace to `min(pollMs, deadline - now)`, floored at zero. The existing race where a healthy router settles at the restart threshold is preserved.

## Verification

- red/green regression: the new edge test failed at ~289 ms before the fix and passes at ~90 ms after it;
- focused threshold tests — **2 passed, 0 failed**;
- `node --test test/service-readiness.test.mjs test/service-lifecycle.test.mjs` with the repository's existing dependency tree — **19 passed, 0 failed, 2 intentional platform skips**;
- the existing `health settles as the restart threshold is reached` regression remains green;
- `npm.cmd run check` — pass (`v2-agent applications valid (6)`, syntax checks passed);
- `git diff --check` — clean;
- repo-maintainer analyzer classifies the final two-file change as local/targeted risk.

No live service mutation or provider/quota-consuming check was used.