### PR TITLE
fix: preserve Windows foreign-state override

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -464,7 +464,11 @@ try {
 
   if ($PrepareOnly) {
     Write-Host "Dependencies and generated files are prepared; application configuration was not changed."
-    exit 0
+    # Return from the script instead of terminating the caller's PowerShell
+    # host. The outer finally still has to restore the caller environment, and
+    # an invoked prepare-only install must hand control back so its caller can
+    # observe that restoration.
+    return
   }
 
   $ConfigEnabled = $true

--- a/install.ps1
+++ b/install.ps1
@@ -243,11 +243,11 @@ $ConfigDisableCommand = if ($Target -eq "codex") { "disable" } else { "uninstall
 $ConfigEnabled = $false
 $ServiceInstalled = $false
 $AdoptionPending = $false
-# The foreign-state override below is set inside the try and must be undone in
-# the finally even when a step throws first, so both halves of the caller's
-# environment are captured up front.
-$SavedForeignStateOverride = $null
-$HadForeignStateOverride = $false
+# The foreign-state override below is set only for a full install, but the
+# finally runs for prepare-only and for failures that happen before that point
+# too. Snapshot the caller's environment before any installer step can throw.
+$HadForeignStateOverride = $null -ne (Get-Item Env:\MODEL_ROUTER_ALLOW_FOREIGN_STATE -ErrorAction SilentlyContinue)
+$SavedForeignStateOverride = $env:MODEL_ROUTER_ALLOW_FOREIGN_STATE
 $ConfigWasEnabled = $false
 $ServiceWasInstalled = $false
 $TrayWasInstalled = $false
@@ -407,8 +407,6 @@ try {
   # let a second checkout rebuild foreign-owned state with no ownership
   # transfer ever recorded. The caller's own value is restored in the finally.
   if (-not $PrepareOnly) {
-    $HadForeignStateOverride = $null -ne (Get-Item Env:\MODEL_ROUTER_ALLOW_FOREIGN_STATE -ErrorAction SilentlyContinue)
-    $SavedForeignStateOverride = $env:MODEL_ROUTER_ALLOW_FOREIGN_STATE
     $env:MODEL_ROUTER_ALLOW_FOREIGN_STATE = "1"
   }
   & node src/secret.mjs ensure

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -850,3 +850,88 @@ test("the foreign-state override is scoped to a full ownership-transferring inst
     "the environment restore belongs in the same finally as the location restore",
   );
 });
+
+test("Windows prepare-only restores the caller foreign-state override live", {
+  skip: process.platform !== "win32" && "requires Windows PowerShell",
+}, () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-windows-env-"));
+  try {
+    const shimDir = path.join(testRoot, "shims");
+    mkdirSync(shimDir, { recursive: true });
+    writeFileSync(
+      path.join(shimDir, "node.cmd"),
+      [
+        "@echo off",
+        'if /I "%~1"=="-p" (',
+        "  echo 24.0.0",
+        "  exit /b 0",
+        ")",
+        'if defined CODEX_ROUTER_TEST_FAIL_LEGACY if /I "%~1"=="src\\legacy-migration.mjs" exit /b 17',
+        'if defined CODEX_ROUTER_TEST_FAIL_LEGACY if /I "%~1"=="src/legacy-migration.mjs" exit /b 17',
+        'if /I "%~1"=="src/install-plan.mjs" if /I "%~2"=="status" (',
+        "  echo skip",
+        "  exit /b 0",
+        ")",
+        "exit /b 0",
+        "",
+      ].join("\r\n"),
+    );
+    writeFileSync(path.join(shimDir, "npm.cmd"), "@echo off\r\nexit /b 0\r\n");
+
+    const harnessPath = path.join(testRoot, "assert-restore.ps1");
+    writeFileSync(
+      harnessPath,
+      [
+        "param([string] $Installer, [string] $FixtureRoot, [string] $ShimDir)",
+        '$env:PATH = "$ShimDir;$env:PATH"',
+        '$env:CODEX_HOME = Join-Path $FixtureRoot "codex-home"',
+        '$env:CODEX_ROUTER_STATE_DIR = Join-Path $FixtureRoot "router-state"',
+        '$env:MODEL_ROUTER_STATE_DIR = Join-Path $FixtureRoot "router-state"',
+        '$env:MODEL_ROUTER_ALLOW_FOREIGN_STATE = "caller-value"',
+        "& $Installer -CheckoutInstall -PrepareOnly",
+        'if ($env:MODEL_ROUTER_ALLOW_FOREIGN_STATE -ne "caller-value") {',
+        '  throw "prepare-only did not preserve the caller override"',
+        "}",
+        "Remove-Item Env:\\MODEL_ROUTER_ALLOW_FOREIGN_STATE",
+        "& $Installer -CheckoutInstall -PrepareOnly",
+        "if (Test-Path Env:\\MODEL_ROUTER_ALLOW_FOREIGN_STATE) {",
+        '  throw "prepare-only introduced an override the caller did not have"',
+        "}",
+        '$env:MODEL_ROUTER_ALLOW_FOREIGN_STATE = "early-failure-value"',
+        '$env:CODEX_ROUTER_TEST_FAIL_LEGACY = "1"',
+        "$SawExpectedFailure = $false",
+        "try {",
+        "  & $Installer -CheckoutInstall -PrepareOnly",
+        "} catch {",
+        "  $SawExpectedFailure = $true",
+        "} finally {",
+        "  Remove-Item Env:\\CODEX_ROUTER_TEST_FAIL_LEGACY",
+        "}",
+        'if (-not $SawExpectedFailure) { throw "expected the legacy probe to fail" }',
+        'if ($env:MODEL_ROUTER_ALLOW_FOREIGN_STATE -ne "early-failure-value") {',
+        '  throw "early failure did not restore the caller override"',
+        "}",
+        "",
+      ].join("\r\n"),
+    );
+
+    const result = spawnSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        harnessPath,
+        path.join(root, "install.ps1"),
+        testRoot,
+        shimDir,
+      ],
+      { cwd: root, encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -777,6 +777,26 @@ test("both installers record the manifest before waiting on health", () => {
 test("the foreign-state override is scoped to a full ownership-transferring install", () => {
   const posix = readFileSync(path.join(root, "bin", "install"), "utf8");
   const windows = readFileSync(path.join(root, "install.ps1"), "utf8");
+  // Snapshot the caller environment before any installer step can fail. A
+  // prepare-only run never sets the override, but its finally still restores
+  // this snapshot, so capturing it only inside the full-install branch would
+  // delete a value the caller already had.
+  const pushIndex = windows.indexOf("Push-Location $ScriptDirectory");
+  const outerTryIndex = windows.indexOf("try {", pushIndex);
+  const hadSnapshotIndex = windows.indexOf(
+    "$HadForeignStateOverride = $null -ne (Get-Item Env:\\MODEL_ROUTER_ALLOW_FOREIGN_STATE",
+  );
+  const valueSnapshotIndex = windows.indexOf(
+    "$SavedForeignStateOverride = $env:MODEL_ROUTER_ALLOW_FOREIGN_STATE",
+  );
+  assert.ok(
+    hadSnapshotIndex !== -1 && hadSnapshotIndex < outerTryIndex,
+    "Windows must snapshot whether the caller had the override before the installer can fail",
+  );
+  assert.ok(
+    valueSnapshotIndex !== -1 && valueSnapshotIndex < outerTryIndex,
+    "Windows must snapshot the caller's override value before the installer can fail",
+  );
 
   // POSIX: exported only after the arguments are known, and only for a full
   // install -- a prepare-only run must meet the guard like any other writer.


### PR DESCRIPTION
## Summary

Preserve the caller's `MODEL_ROUTER_ALLOW_FOREIGN_STATE` value across every Windows installer path, including `-PrepareOnly` and failures that occur before the full-install ownership override is set.

## Root cause

#497 initialized `$HadForeignStateOverride = $false` / `$SavedForeignStateOverride = $null`, then captured the real caller environment only inside `if (-not $PrepareOnly)` deep in the main `try`. The outer `finally` always restores/removes the variable.

That means:
- a successful `-PrepareOnly` run never captures the caller value, then `finally` removes it;
- any failure before the capture block does the same.

This violates the installer's stated contract that the caller environment is restored exactly as found.

## Fix

Snapshot both presence and value before `Push-Location` / the outer `try`. The full-install branch now only sets the temporary value to `1`; the existing `finally` restores the pre-run snapshot.

POSIX needs no matching change because its exported override exists only in the installer child shell and cannot mutate the caller environment.

## Verification

- red/green regression: the ownership test failed before the fix because the snapshot occurred after the outer `try`, then passed after moving the snapshot;
- focused installer group (`install.ps1` parse, rollback, manifest ordering, foreign-state override) — **4 passed, 0 failed**;
- `npm.cmd run check` — pass (`v2-agent applications valid (6)`, syntax checks passed);
- direct PowerShell parser check — pass;
- `git diff --check` / staged diff check — clean.

I also attempted the entire installer policy file with Git's POSIX shell manually added to this Windows PATH. One unrelated POSIX fixture test became active and failed because that artificial PATH changes its platform assumptions; the changed regression itself passed. I did not broaden this PR to that separate test issue (#500 already addresses the native-Windows shell portability regression).

No service mutation, provider request, or quota-consuming check was used.