### PR TITLE
fix: avoid widening Moonshot ref siblings

### DIFF
--- a/src/tool-schema-root.mjs
+++ b/src/tool-schema-root.mjs
@@ -239,6 +239,16 @@ export function nonRecursiveToolSchema(schema) {
 // list. Copy-on-write throughout: a schema with no foreign ref keeps identity,
 // and the client's object is never mutated.
 const DEFS_REF_PREFIX = "#/$defs/";
+const REF_OVERRIDE_ANNOTATIONS = new Set([
+  "$comment",
+  "default",
+  "deprecated",
+  "description",
+  "examples",
+  "readOnly",
+  "title",
+  "writeOnly",
+]);
 const MAX_INLINE_DEPTH = 32;
 const MAX_INLINE_EXPANSIONS = 512;
 const MAX_INLINE_BYTES = 256 * 1024;
@@ -376,6 +386,17 @@ function inlineNodeRefs(
   // keep the decorated node intact and let the provider fail closed if it
   // cannot represent that conjunction.
   if (strictDefsRef && expanded.$ref !== undefined) return node;
+  if (foreignRef) {
+    const conflicts = Object.keys(rewrittenSiblings).some((key) => (
+      !REF_OVERRIDE_ANNOTATIONS.has(key) &&
+      Object.hasOwn(expanded, key) &&
+      !isDeepStrictEqual(rewrittenSiblings[key], expanded[key])
+    ));
+    // `$ref` siblings are conjunctive. Object spread is lossless when the
+    // assertions are distinct or identical, but a different value for the
+    // same assertion would overwrite one side and can widen the schema.
+    if (conflicts) return node;
+  }
   if (strictDefsRef) {
     const conflicts = Object.keys(rewrittenSiblings).some((key) => (
       Object.hasOwn(expanded, key) && !isDeepStrictEqual(rewrittenSiblings[key], expanded[key])

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -552,6 +552,26 @@ test("a sibling-property ref is inlined with the target's constraints", () => {
   assert.deepEqual(schema, flightsSearchSchema());
 });
 
+// A foreign `$ref` plus a validation sibling is a conjunction. Blind object
+// spread is only lossless when overlapping keywords agree: replacing the
+// target's tighter maxLength with the sibling's looser value would widen what
+// the caller's tool accepts. When that conjunction cannot be represented by a
+// simple inline, keep the original ref and let the strict provider fail closed.
+test("a conflicting foreign ref validation sibling is not widened", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      base: { type: "string", maxLength: 5 },
+      alias: { $ref: "#/properties/base", maxLength: 10 },
+    },
+  };
+  const inlined = inlineForeignRefs(schema);
+  assert.equal(inlined, schema);
+  assert.deepEqual(inlined.properties.alias, {
+    $ref: "#/properties/base",
+    maxLength: 10,
+  });
+});
 test("a $defs ref is the form Moonshot asks for and survives untouched", () => {
   const schema = {
     type: "object",


### PR DESCRIPTION
## Summary

Fail closed when Moonshot foreign-`$ref` inlining would overwrite a different validation/schema keyword from the referenced target.

## Root cause

`inlineForeignRefs()` expands non-`#/$defs/` refs for Moonshot-compatible routes. It merged the referenced target and the `$ref` node's siblings with object spread. That is lossless for distinct keywords and harmless annotation overrides, but `$ref` siblings are conjunctive: if both sides define the same validation keyword with different values, overwriting one side can widen the caller schema.

Concrete example on current main:

- target: `{ type: "string", maxLength: 5 }`
- sibling ref: `{ $ref: "#/properties/base", maxLength: 10 }`
- old output: `{ type: "string", maxLength: 10 }`

The rewritten tool now accepts strings of length 6–10 that the original schema rejected.

#490 extends this shared Moonshot repair to the exact Console Go Kimi K2.7 Code route, so the edge now affects both the existing Kimi routes and that newly measured route.

## Fix

- allow normal merge when overlapping schema keywords are identical;
- preserve known annotation overrides such as `description`, `default`, `title`, and examples;
- if a foreign ref and its target provide different values for the same non-annotation keyword, keep the original `$ref` node and let the strict provider fail closed rather than altering validation semantics;
- leave the existing stricter `$defs` conflict behavior unchanged.

## Verification

Red/green regression:
- before: the new test observed the widened `{ maxLength: 10 }` output and failed;
- after: the conflicting foreign ref is preserved by identity.

Post-merge verification against current main `10abced`:
- `test/tool-schema-root.test.mjs` — **45 passed, 0 failed**;
- targeted Kimi namespace-relay cases — **4 passed, 0 failed**;
- #490 exact Console Go Kimi route regression — **1 passed, 0 failed**;
- `npm.cmd run check` — pass (`v2-agent applications valid (6)`, syntax checks passed);
- `git diff --check` / staged diff check — clean.

The temporary dependency junction used for local tests was removed before commit; the canonical dependency tree remains intact. No provider or quota-consuming request was made.