### PR TITLE
fix(antigravity): fail closed on unsafe Claude refs

### DIFF
--- a/src/antigravity-oauth-shape.mjs
+++ b/src/antigravity-oauth-shape.mjs
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 
 import { foldInterveningAssistantMessages } from "./http-utils.mjs";
 import {
@@ -312,6 +313,91 @@ function dereferenceAntigravitySchema(schema, root = schema, stack = new Set(), 
   return next;
 }
 
+// Claude's compatibility path may narrow schemas, but it must never turn a
+// reference it cannot represent into a wider schema. Resolve the full local
+// ref chain before protobuf cleaning, and reject the tool if a ref is dangling,
+// cyclic, or carries an assertion that conflicts with its target. Annotation
+// siblings may override annotations because they do not change accepted input.
+function dereferenceClaudeSchema(schema, root = schema, stack = new Set(), depth = 0) {
+  if (!isPlainObject(schema) || depth > MAX_SCHEMA_DEPTH) {
+    return { ok: true, schema };
+  }
+
+  let source = schema;
+  let nextStack = stack;
+  if (typeof schema.$ref === "string") {
+    const resolved = resolveLocalSchemaRef(schema.$ref, root);
+    if (!resolved || stack.has(schema.$ref)) return { ok: false };
+    nextStack = new Set(stack);
+    nextStack.add(schema.$ref);
+    const target = dereferenceClaudeSchema(resolved, root, nextStack, depth + 1);
+    if (!target.ok || !isPlainObject(target.schema)) return { ok: false };
+    const { $ref: _ref, ...siblings } = schema;
+    const conflicts = Object.entries(siblings).some(([key, value]) =>
+      !CLAUDE_REF_OVERRIDE_ANNOTATIONS.has(key) &&
+      Object.hasOwn(target.schema, key) &&
+      !isDeepStrictEqual(value, target.schema[key]),
+    );
+    if (conflicts) return { ok: false };
+    source = { ...target.schema, ...siblings };
+  }
+
+  const next = { ...source };
+  // Definitions are lookup tables, not constraints on their own. Walk them
+  // only when an active ref resolves into one; otherwise an unused recursive
+  // definition would make a safe tool disappear.
+  for (const keyword of ["properties", "patternProperties"]) {
+    if (!isPlainObject(source[keyword])) continue;
+    const entries = [];
+    for (const [name, child] of Object.entries(source[keyword])) {
+      const result = dereferenceClaudeSchema(child, root, nextStack, depth + 1);
+      if (!result.ok) return result;
+      entries.push([name, result.schema]);
+    }
+    next[keyword] = Object.fromEntries(entries);
+  }
+  for (const keyword of [
+    "items",
+    "additionalProperties",
+    "contains",
+    "not",
+    "if",
+    "then",
+    "else",
+    "propertyNames",
+  ]) {
+    if (isPlainObject(source[keyword])) {
+      const result = dereferenceClaudeSchema(
+        source[keyword],
+        root,
+        nextStack,
+        depth + 1,
+      );
+      if (!result.ok) return result;
+      next[keyword] = result.schema;
+    } else if (Array.isArray(source[keyword])) {
+      const children = [];
+      for (const child of source[keyword]) {
+        const result = dereferenceClaudeSchema(child, root, nextStack, depth + 1);
+        if (!result.ok) return result;
+        children.push(result.schema);
+      }
+      next[keyword] = children;
+    }
+  }
+  for (const keyword of ["anyOf", "oneOf", "allOf", "prefixItems"]) {
+    if (!Array.isArray(source[keyword])) continue;
+    const children = [];
+    for (const child of source[keyword]) {
+      const result = dereferenceClaudeSchema(child, root, nextStack, depth + 1);
+      if (!result.ok) return result;
+      children.push(result.schema);
+    }
+    next[keyword] = children;
+  }
+  return { ok: true, schema: next };
+}
+
 const UNSUPPORTED_SCHEMA_KEYWORDS = Object.freeze([
   "$schema",
   "$id",
@@ -366,6 +452,16 @@ const UNSUPPORTED_SCHEMA_KEYWORDS = Object.freeze([
 ]);
 
 const CLAUDE_UNSUPPORTED_SCHEMA_ANNOTATIONS = new Set(["id", "discriminator"]);
+const CLAUDE_REF_OVERRIDE_ANNOTATIONS = new Set([
+  "$comment",
+  "default",
+  "deprecated",
+  "description",
+  "examples",
+  "readOnly",
+  "title",
+  "writeOnly",
+]);
 const CLAUDE_UNION_SIBLINGS = new Set([
   "$schema",
   "$id",
@@ -714,8 +810,9 @@ function cleanAntigravitySchema(schema, depth = 0, { sanitizeClaude = false } = 
 function antigravityToolSchema(schema, options) {
   const normalized = normalizeSchemaLiterals(schema);
   if (options?.sanitizeClaude) {
-    const dereferenced = dereferenceAntigravitySchema(normalized);
-    const translated = claudeSchemaResult(dereferenced);
+    const dereferenced = dereferenceClaudeSchema(normalized);
+    if (!dereferenced.ok) return undefined;
+    const translated = claudeSchemaResult(dereferenced.schema);
     if (!translated.ok) return undefined;
     const root = translated.schema;
     const objectRoot =

--- a/test/antigravity-oauth-shape.test.mjs
+++ b/test/antigravity-oauth-shape.test.mjs
@@ -223,6 +223,107 @@ test("omits only Claude tools whose false schemas or conjunctions cannot be repr
   );
 });
 
+test("omits Claude tools whose refs cannot be dereferenced without widening", () => {
+  const request = toAntigravityRequest({
+    model: "claude-opus-4-6-thinking",
+    messages: [{ role: "user", content: "inspect" }],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "safe",
+          parameters: { type: "object", properties: { value: { type: "string" } } },
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "safe_ref",
+          parameters: {
+            type: "object",
+            properties: {
+              value: { $ref: "#/$defs/alias", description: "Alias value." },
+            },
+            required: ["value"],
+            $defs: {
+              base: { type: "string", enum: ["a"] },
+              alias: { $ref: "#/$defs/base" },
+            },
+          },
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "safe_unused_defs",
+          parameters: {
+            type: "object",
+            properties: { value: { type: "string" } },
+            $defs: { node: { $ref: "#/$defs/node" } },
+          },
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "dangling_ref",
+          parameters: {
+            type: "object",
+            properties: { value: { $ref: "#/$defs/missing" } },
+            required: ["value"],
+            $defs: {},
+          },
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "recursive_ref",
+          parameters: {
+            type: "object",
+            properties: { node: { $ref: "#/$defs/node" } },
+            $defs: {
+              node: {
+                type: "object",
+                properties: { child: { $ref: "#/$defs/node" } },
+              },
+            },
+          },
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "conflicting_ref",
+          parameters: {
+            type: "object",
+            properties: {
+              base: { type: "string", enum: ["a"] },
+              alias: { $ref: "#/properties/base", enum: ["a", "b"] },
+            },
+            required: ["alias"],
+          },
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    request.request.tools[0].functionDeclarations.map((declaration) => declaration.name),
+    ["safe", "safe_ref", "safe_unused_defs"],
+  );
+  const safeRef = request.request.tools[0].functionDeclarations.find(
+    (declaration) => declaration.name === "safe_ref",
+  );
+  assert.deepEqual(safeRef.parameters, {
+    type: "object",
+    properties: {
+      value: { type: "string", enum: ["a"], description: "Alias value." },
+    },
+    required: ["value"],
+  });
+});
+
 test("narrows Claude anyOf and provably disjoint oneOf branches deterministically", () => {
   const request = toAntigravityRequest({
     model: "claude-opus-4-6-thinking",


### PR DESCRIPTION
## Summary

Make the Claude Antigravity schema path fail closed when a local `$ref` cannot be dereferenced without changing validation semantics.

This is a follow-up to #494. Gemini keeps the existing dereference path unchanged.

## Reproduced defects on current main

Two Claude tools that #494 intends to omit as unrepresentable were instead published with wider schemas:

1. **Dangling ref**
   - input property: `{ $ref: "#/$defs/missing" }`
   - previous Claude payload: `{}`
   - effect: the entire referenced constraint disappeared.

2. **Conflicting ref sibling**
   - target: `{ type: "string", enum: ["a"] }`
   - sibling: `{ $ref: "#/properties/base", enum: ["a", "b"] }`
   - previous Claude payload: `{ type: "string", enum: ["a", "b"] }`
   - effect: value `"b"` became accepted even though the original schema rejected it.

A pure local alias chain is also covered as a positive control, including an annotation sibling, and an active recursive ref is treated as unrepresentable rather than truncated to an object shell. Unused recursive `$defs` remain harmless because definitions are only traversed when an active ref reaches them.

## Fix

- add a Claude-only strict local-ref dereferencer;
- follow complete local alias chains;
- reject dangling or cyclic active refs;
- reject overlapping non-annotation sibling assertions when they differ from the resolved target;
- permit annotation overrides such as `description`, `default`, `title`, and examples;
- return `undefined` for unsafe Claude tool schemas so the existing omission / forced-tool 400 logic handles them;
- leave the existing Gemini dereferencer unchanged.

## Verification

TDD:
- RED: regression observed `dangling_ref` and `conflicting_ref` both being published;
- GREEN: only the safe plain tool, safe alias-chain tool, and safe tool with unused recursive definitions remain.

Fresh local verification on base `10abced`:
- all `test/antigravity*.test.mjs`: **79 passed, 0 failed, 1 expected Windows ACL skip**;
- includes the forwarder's local rejection-before-OAuth/upstream test;
- existing Gemini ref-heavy test remains green;
- `npm run check`: pass (`v2-agent applications valid (6)`, syntax checks passed);
- `git diff --check` and staged diff check: clean.

The temporary dependency junction used to run the clean worktree against the matching lockfile was removed afterward; the canonical dependency tree remains intact. No live provider or quota-consuming request was made.