### PR TITLE
Make full desktop install the default

### DIFF
--- a/Formula/codex-router.rb
+++ b/Formula/codex-router.rb
@@ -4,7 +4,7 @@ class CodexRouter < Formula
   desc "Use external coding models inside the Codex App and CLI"
   homepage "https://github.com/duolahypercho/codex-router"
   url "https://github.com/duolahypercho/codex-router/releases/download/v0.5.0/codex-router-0.5.0.tar.gz"
-  sha256 "89f494a21399c3c2a54f6f25531e10b0d64e7e5a238f17cb8f8f7f2c9222e076"
+  sha256 "89f6765ccfd78a7ca9931507f17945d520080939d632572429c1f15dff61b529"
   license "MIT"
 
   depends_on "pkgconf" => :build
@@ -654,6 +654,11 @@ class CodexRouter < Formula
     <<~EOS
       Finish the one-time Codex integration with:
         codex-router setup --guided
+
+      This formula installs the router and CLI only. It does not build or
+      download the Electron Control Center, tray/menu-bar app, or macOS desktop
+      widget. Use the recommended installer on the project homepage for the
+      complete desktop experience.
 
       List every available command, including `codex-router curate-models`
       for adding a custom provider's models, with:

--- a/README.md
+++ b/README.md
@@ -1,30 +1,55 @@
 # Codex Router
 
-Use Anthropic, Kimi, DeepSeek, xAI, GitHub Copilot, opencode Go, Command Code,
-and future external models inside the Codex App and CLI — or inside
-[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) or
-[Gemini CLI](https://github.com/google-gemini/gemini-cli) — through
-one local, credential-isolating router.
-The integration speaks the Responses API and merges external entries into
-Codex's native model catalog, so routed models appear in the normal picker
-next to the native GPT models. The same routed models publish into the
-harness as one provider route, so they appear in its Models page too, and into
-Gemini CLI through a Gemini-shaped endpoint the router serves for it.
+## Install everything (recommended)
 
-Every client shares one installation: one background service, one gateway, one
-set of provider credentials, one provider selection. Installing a second or
-third integration does not ask for a single key again.
+This is the default setup: **guided provider setup + Electron Control Center +
+tray/menu-bar app + macOS desktop widget**.
 
-The router is also the source of truth for routed model policy. Provider/model
-selection and external picker visibility are stored locally in the router state
-directory (`model-picker.json` is an explicit allowlist: only router models you
-show or select during curation are published), then republished to every
-installed client. A signed-in Codex
-installation keeps its native GPT catalog and native visibility client-owned;
-the router never lets an external overlay erase that original picker. Codex's
-active task remains in Codex configuration. Its default model does too unless
-you explicitly opt into a router-owned routed default; that choice is saved
-locally, survives rebuilds, and can be restored to the prior Codex default.
+### macOS or Linux
+
+Copy and paste this into Terminal:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/duolahypercho/codex-router/main/install.sh \
+  | sh -s -- --target codex --guided --with-tray
+```
+
+### Windows
+
+Copy and paste this into PowerShell:
+
+```powershell
+$installer = Join-Path $env:TEMP "codex-router-install.ps1"
+Invoke-WebRequest https://raw.githubusercontent.com/duolahypercho/codex-router/main/install.ps1 -OutFile $installer
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer -Target codex -Guided -WithTray
+```
+
+That is the complete installation. It asks which providers you want and keeps
+credential entry in private local prompts.
+
+When it finishes:
+
+1. Fully quit and reopen Codex.
+2. Start a new task and choose a routed model.
+3. Open **Codex Router** to use the Control Center.
+
+On macOS, open **Codex Router** from Spotlight or `~/Applications`; its icon
+stays in the menu bar when the Control Center is closed. The desktop widget is
+already included: choose **Settings → Dynamic Island → Desktop** from the
+menu-bar app to show it. It is a movable Codex Router panel rather than an item
+in macOS's **Edit Widgets** gallery.
+
+macOS does not have a public `.dmg` yet; the command above builds and installs
+the app locally. If it asks for the Xcode Command Line Tools, run
+`xcode-select --install` and repeat the command.
+
+## What Codex Router does
+
+Use Anthropic, Kimi, DeepSeek, xAI, GitHub Copilot, and other external models
+inside the Codex App and CLI. One local installation can also serve
+[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) and
+[Gemini CLI](https://github.com/google-gemini/gemini-cli). Your provider
+credentials stay on your computer.
 
 Codex Router is an independent community project. It is not affiliated with or
 endorsed by OpenAI, GitHub, Anthropic, Moonshot AI, DeepSeek, OpenRouter,
@@ -48,11 +73,12 @@ If compatible authentication already exists, an agent can finish everything
 except the final app restart. Provider credentials are entered only through a
 hidden local terminal prompt.
 
-## Install
+## Other installation methods
 
-### Homebrew
+### Homebrew (macOS or Linux)
 
-If you already use Homebrew, install Codex Router from this repository's tap:
+Codex Router is not in `homebrew/core` yet, so `brew install codex-router` by
+itself does not work. For now, add this repository as a tap once:
 
 ```sh
 brew tap duolahypercho/codex-router https://github.com/duolahypercho/codex-router
@@ -65,6 +91,11 @@ Python, and build dependencies; `codex-router setup --guided` performs the
 one-time provider selection, credential-safe authentication, background
 service installation, and Codex integration. When setup finishes, fully quit
 and reopen Codex, create a new task, and choose a routed model from the picker.
+
+Homebrew is the **router/CLI-only** installation. It deliberately does not
+build or download the Electron Control Center, tray/menu-bar app, or macOS
+desktop widget during setup. If you want those, use the recommended installer
+at the top of this README instead.
 
 Upgrade an existing Homebrew installation with:
 
@@ -114,6 +145,13 @@ source. The release workflow generates `Formula/codex-router.rb` from
 
 Maintainers preparing the eventual `homebrew/core` submission should follow
 [`docs/HOMEBREW_CORE.md`](docs/HOMEBREW_CORE.md).
+
+### npm
+
+This project does not publish an npm-installable CLI yet. Do not use
+`npm install codex-router` for this project. Use the recommended installer or
+Homebrew above; a future npm package should use the scoped name
+`@duolahypercho/codex-router` so it cannot be confused with existing packages.
 
 ### Guided installer
 
@@ -252,18 +290,27 @@ npm install -g @xai-official/grok
 grok login --oauth
 ```
 
-Antigravity OAuth uses the router's own browser sign-in and the Google AI
-Pro/Ultra entitlement on the signed-in account. It needs neither a Gemini API
-key nor a separate Antigravity CLI. Signing in and enabling are separate so a
-re-authentication never replaces the rest of the provider selection:
+> [!WARNING]
+> **Antigravity OAuth is not a self-service provider in public builds today.**
+> It requires the client secret paired with the integration's OAuth client ID.
+> This project does not distribute that secret, and a Google AI Pro/Ultra
+> subscription, Gemini API key, Google account, or existing `agy` CLI login
+> does not provide a way to retrieve it. Do not use the old
+> `your-integration-client-secret` placeholder: it cannot work.
 
-Antigravity OAuth requires an integration client secret. Set
-`ANTIGRAVITY_CLIENT_SECRET` in the environment used for installation and
-sign-in; the generated background-service definition preserves it for token
-refreshes. The command fails before opening Google consent when it is absent.
+Only enable `antigravity-oauth` if the operator of a provisioned integration
+has privately supplied its matching `ANTIGRAVITY_CLIENT_SECRET`. Set it in the
+private environment used for both installation and sign-in, and re-run the
+installer with that environment so the generated background-service definition
+can refresh tokens. Never paste the secret into chat, an issue, a command
+argument, or a tracked file. The login may provision a Google Cloud project for
+the signed-in account when none exists.
+
+If the secret is already set in the current private shell, sign in and enable
+the provider with:
 
 ```sh
-export ANTIGRAVITY_CLIENT_SECRET='your-integration-client-secret'
+test -n "$ANTIGRAVITY_CLIENT_SECRET"
 ./bin/model-router codex providers login antigravity-oauth
 ./bin/model-router codex providers enable antigravity-oauth
 ```
@@ -271,13 +318,19 @@ export ANTIGRAVITY_CLIENT_SECRET='your-integration-client-secret'
 On Windows PowerShell, use the matching wrapper:
 
 ```powershell
-$env:ANTIGRAVITY_CLIENT_SECRET = 'your-integration-client-secret'
+if (-not $env:ANTIGRAVITY_CLIENT_SECRET) {
+  throw 'ANTIGRAVITY_CLIENT_SECRET is not set'
+}
 .\model-router.ps1 codex providers login antigravity-oauth
 .\model-router.ps1 codex providers enable antigravity-oauth
 ```
 
-The credential stays in the router's owner-only state directory. This is an
-unofficial compatibility route over Google's internal Antigravity service,
+There is currently no router-managed acquisition path for that secret.
+Bring-your-own OAuth client overrides exist for development, but are not yet a
+supported persistent installation flow. Follow
+[#393](https://github.com/duolahypercho/codex-router/issues/393) for that gap.
+The resulting token stays in the router's owner-only state directory. This is
+an unofficial compatibility route over Google's internal Antigravity service,
 not a public Gemini API contract, so availability and wire behavior can change.
 
 MiMo (Xiaomi API) uses Xiaomi's official OpenAI-compatible endpoint at
@@ -1677,9 +1730,10 @@ and rebuild notes.
 The app can also place a Dynamic-Island-style overlay at the top center of the
 active display. It follows the provider handling the latest request, reveals
 usage on hover, and expands on click. It is off on a new install; enable it
-under **Dynamic Island** in the tray Settings. The menu-bar panel is the
+under **Dynamic Island** in the tray Settings. Choose **Desktop** there instead
+for the movable quota-and-activity desktop widget. The menu-bar panel is the
 primary surface for the all-provider overview and configuration, and stays
-available whether or not the overlay is on.
+available whether or not either optional surface is on.
 
 ## Unified desktop app
 
@@ -1704,8 +1758,9 @@ the window.
 .\codex-router.ps1 tray install
 ```
 
-Tagged releases provide unsigned Windows and Linux tester packages for this
-unified application family: `model-router-<version>-windows-x64.exe` and
+[Download the latest Windows or Linux desktop package](https://github.com/duolahypercho/codex-router/releases/latest).
+Tagged releases provide unsigned tester packages for this unified application
+family: `model-router-<version>-windows-x64.exe` and
 `model-router-<version>-linux-x64.tar.gz` (containing the executable AppImage).
 They are frontends, so install the matching Codex Router version first. The
 universal macOS bundle remains an ad-hoc-signed CI artifact until Developer ID

--- a/apps/control-center/package-lock.json
+++ b/apps/control-center/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@codex-router/control-center",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@codex-router/control-center",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "lucide-react": "1.31.0",
         "react": "19.2.8",

--- a/apps/control-center/package.json
+++ b/apps/control-center/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codex-router/control-center",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Electron control center for Codex Router",
   "author": "Codex Router contributors",
   "private": true,

--- a/bin/model-router-tray
+++ b/bin/model-router-tray
@@ -2,6 +2,12 @@
 set -eu
 
 repo_dir=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+if [ "${CODEX_ROUTER_PACKAGE_MANAGER:-}" = homebrew ]; then
+  printf '%s\n' \
+    'codex-router: the desktop companion is not packaged by Homebrew.' \
+    'Use the recommended curl installer in the README for the Electron Control Center, tray/menu-bar app, and macOS desktop widget.' >&2
+  exit 2
+fi
 launch_mode=${1:-interactive}
 case "$launch_mode" in
   interactive|--preserve-window|--tray-only) ;;

--- a/docs/HOMEBREW_CORE.md
+++ b/docs/HOMEBREW_CORE.md
@@ -1,17 +1,36 @@
 # Homebrew core submission
 
-Codex Router can be proposed to `Homebrew/homebrew-core` after the upstream
-project and its formula meet Homebrew's acceptance requirements. There is no
-application form: the submission is a pull request adding
-`Formula/c/codex-router.rb` to `homebrew-core`.
+Codex Router is eligible to be proposed to `Homebrew/homebrew-core`. There is
+no application form: the submission is a pull request adding
+`Formula/c/codex-router.rb` to `homebrew-core`. It has **not** been accepted
+yet, so the public install remains the explicit tap until that pull request is
+merged.
+
+As checked on August 28, 2026, the repository is more than 30 days old and its
+stars and forks exceed Homebrew's self-submission notability threshold. v0.5.0
+is stable but predates the Homebrew desktop-build guard; submit v0.5.1 or newer.
+Recheck those facts immediately before opening the pull request instead of
+treating this note as permanent approval.
+
+The formula is intentionally CLI-first. It installs the router, provider
+setup, background service, and browser panel; it does not build or download the
+Electron Control Center, native tray/menu-bar app, or macOS desktop widget.
+Those remain part of the recommended source installer. Keeping desktop builds
+out of Homebrew setup avoids mutating the keg or downloading application code
+at runtime, and keeps the formula aligned with `homebrew/core` rather than a
+native-app cask.
+
+Do not submit the formula while its source URL still points at v0.5.0. Publish
+v0.5.1 from the commit containing this change, then let the release workflow
+regenerate the formula URL and checksum before copying it into `homebrew-core`.
 
 ## Before submitting
 
-- Wait until the upstream repository is at least 30 days old. The repository
-  was created on July 19, 2026, so submit no earlier than August 19, 2026.
-- Publish a release that upstream explicitly identifies as stable. A beta or
-  release candidate is not eligible. The tag, `package.json` version, source
-  archive name, formula version, and release URL must agree.
+- Confirm the upstream repository is still at least 30 days old.
+- Publish the next release containing the Homebrew desktop-build guard and
+  identify it explicitly as stable. A beta or release candidate is not
+  eligible. The tag, `package.json` version, source archive name, formula
+  version, and release URL must agree.
 - Confirm the repository still meets Homebrew's self-submission notability
   threshold: 90 forks, 90 watchers, or 225 stars.
 - Confirm the release archive is immutable and that the formula contains its

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -45,7 +45,8 @@ definition stores the checkout's absolute path.
 macOS or Linux:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/duolahypercho/codex-router/main/install.sh | sh -s -- --guided
+curl -fsSL https://raw.githubusercontent.com/duolahypercho/codex-router/main/install.sh \
+  | sh -s -- --target codex --guided --with-tray
 ```
 
 Windows PowerShell:
@@ -53,7 +54,7 @@ Windows PowerShell:
 ```powershell
 $installer = Join-Path $env:TEMP "codex-router-install.ps1"
 Invoke-WebRequest https://raw.githubusercontent.com/duolahypercho/codex-router/main/install.ps1 -OutFile $installer
-powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer -Guided
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installer -Target codex -Guided -WithTray
 ```
 
 Clone-and-review installation is also supported:
@@ -61,19 +62,20 @@ Clone-and-review installation is also supported:
 ```sh
 git clone https://github.com/duolahypercho/codex-router.git
 cd codex-router
-./install.sh --guided
+./install.sh --target codex --guided --with-tray
 ```
 
 ```powershell
 git clone https://github.com/duolahypercho/codex-router.git
 Set-Location codex-router
-./install.ps1 -Guided
+./install.ps1 -Target codex -Guided -WithTray
 ```
 
-Guided setup also offers to build and launch the desktop companion (the macOS
-menu bar app, or the Windows/Linux tray). `--with-tray` installs it without
-asking, `--no-tray` never offers it, and automatic mode skips it. On Windows
-the same choice is `-WithTray` / `-NoTray`.
+The recommended commands install the complete desktop experience without an
+extra question: the macOS menu-bar app with its Electron Control Center and
+desktop widget, or the Windows/Linux Electron Control Center and tray.
+`--no-tray` omits it; leaving out both tray flags makes guided setup ask. On
+Windows the matching options are `-WithTray` and `-NoTray`.
 
 On macOS one `Codex Router.app` bundle is placed in `~/Applications`. It keeps
 the Swift-native menu-bar tray and embeds the Electron Control Center, so the
@@ -138,18 +140,30 @@ The OAuth token remains in `~/.grok/auth.json` and is sent only to xAI's Grok
 CLI inference proxy. The separate `grok-api` provider continues to use a
 separately billed xAI API key.
 
-Antigravity OAuth uses a router-managed browser sign-in; it does not require a
-Gemini API key or a separate CLI. Sign in first, then enable the provider; the
-login command does not replace or disable any provider already selected.
+Antigravity OAuth is not self-service in public builds. It requires the client
+secret paired with the integration's OAuth client ID; the project does not
+distribute that secret, and a Google AI Pro/Ultra subscription, Gemini API key,
+Google account, or existing `agy` CLI login cannot retrieve it. Do not use a
+made-up placeholder. See
+[#393](https://github.com/duolahypercho/codex-router/issues/393) for the missing
+acquisition path.
+
+Proceed only when the operator of a provisioned integration has supplied its
+matching `ANTIGRAVITY_CLIENT_SECRET` privately. Never paste it into chat, an
+issue, a command argument, or a tracked file. Sign in first, then enable the
+provider; the login command does not replace or disable any provider already
+selected. The login may provision a Google Cloud project for the signed-in
+account when none exists.
 
 macOS/Linux:
 
-Set the integration client secret before installing/signing in. The generated
-service definition preserves it for token refreshes, and login fails before
-opening Google consent if it is absent.
+Set the supplied integration client secret in the private environment used for
+both installation and sign-in. Re-run the installer with that environment so
+the generated service definition preserves it for token refreshes. Login fails
+before opening Google consent if it is absent.
 
 ```sh
-export ANTIGRAVITY_CLIENT_SECRET='your-integration-client-secret'
+test -n "$ANTIGRAVITY_CLIENT_SECRET"
 ./bin/model-router codex providers login antigravity-oauth
 ./bin/model-router codex providers enable antigravity-oauth
 ```
@@ -157,10 +171,15 @@ export ANTIGRAVITY_CLIENT_SECRET='your-integration-client-secret'
 Windows PowerShell:
 
 ```powershell
-$env:ANTIGRAVITY_CLIENT_SECRET = 'your-integration-client-secret'
+if (-not $env:ANTIGRAVITY_CLIENT_SECRET) {
+  throw 'ANTIGRAVITY_CLIENT_SECRET is not set'
+}
 .\model-router.ps1 codex providers login antigravity-oauth
 .\model-router.ps1 codex providers enable antigravity-oauth
 ```
+
+Bring-your-own OAuth client overrides exist for development, but are not yet a
+supported persistent installation flow.
 
 The access and refresh tokens are stored in the router's owner-only state
 directory and can be removed from the desktop connection panel. This is an
@@ -509,6 +528,12 @@ Windows). Homebrew owns the dependency tree in its formula prefix: its normal
 doctor repair regenerates config and services without mutating that tree, and a
 missing or broken package file must be repaired with `brew reinstall
 codex-router`.
+
+Homebrew packages only the router and CLI. Guided setup does not offer the
+Electron Control Center, tray/menu-bar app, or macOS desktop widget, and an
+explicit `--with-tray` is refused with guidance back to the complete source
+installer. This keeps setup from downloading or compiling desktop application
+code inside a Homebrew-managed installation.
 
 When upgrading from a release without caller capabilities, the installer
 generates one, replaces only the marked managed URL, tightens config permissions,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-model-router",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-model-router",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "proper-lockfile": "4.1.2",
         "undici": "8.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codex-model-router",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "type": "module",
   "description": "Extensible local model router for Codex and Cursor",

--- a/packaging/homebrew/generate-formula.mjs
+++ b/packaging/homebrew/generate-formula.mjs
@@ -355,6 +355,11 @@ ${exclusionComment}${resourceBlocks}
       Finish the one-time Codex integration with:
         codex-router setup --guided
 
+      This formula installs the router and CLI only. It does not build or
+      download the Electron Control Center, tray/menu-bar app, or macOS desktop
+      widget. Use the recommended installer on the project homepage for the
+      complete desktop experience.
+
       List every available command, including \`codex-router curate-models\`
       for adding a custom provider's models, with:
         codex-router help

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -32,7 +32,7 @@ import {
   writeProviderSelection,
 } from "./provider-selection.mjs";
 import { writeDiscoveryMode } from "./discovery-mode.mjs";
-import { trayDecision } from "./tray-install.mjs";
+import { trayDecision, traySetupError } from "./tray-install.mjs";
 import { resolveVisionEngine } from "./vision-bridge.mjs";
 import {
   readVisionBridgeSettings,
@@ -106,6 +106,13 @@ if (!setupArgumentError && TARGET !== "codex" && (migrateKnown || adoptNativeCat
     migrateKnown ? "--migrate-known" : "--adopt-native-catalog"
   } applies only to the Codex target.`;
 }
+if (!setupArgumentError) {
+  setupArgumentError = traySetupError({
+    packageManager: process.env.CODEX_ROUTER_PACKAGE_MANAGER,
+    withTray,
+    noTray,
+  });
+}
 
 function option(name) {
   const index = args.indexOf(name);
@@ -141,7 +148,7 @@ Options:
   --adopt-native-catalog  Use an existing user-owned native Codex catalog as the merge base
   --smoke-test         Make one small live request per enabled provider
   --selection-only     Save provider selection without installing (development)
-  --with-tray          Also build and launch the desktop companion app
+  --with-tray          Also build and launch the desktop companion app (source installs only)
   --no-tray            Never offer the desktop companion app
   --no-provider        Install idle, with no provider selected or configured
   --no-discovery       With --no-provider: never read credentials, the
@@ -595,7 +602,13 @@ async function main() {
     throw error;
   }
 
-  const trayStep = trayDecision({ platform: process.platform, withTray, noTray, guided });
+  const trayStep = trayDecision({
+    platform: process.platform,
+    withTray,
+    noTray,
+    guided,
+    packageManager: process.env.CODEX_ROUTER_PACKAGE_MANAGER,
+  });
   if (trayStep !== "skip") {
     const wanted =
       trayStep === "install" ||

--- a/src/tray-install.mjs
+++ b/src/tray-install.mjs
@@ -6,14 +6,29 @@ import path from "node:path";
 
 const TRAY_PLATFORMS = new Set(["darwin", "linux", "win32"]);
 
-export function trayDecision({ platform, withTray, noTray, guided }) {
+export function trayDecision({ platform, withTray, noTray, guided, packageManager }) {
   if (noTray) return "skip";
+  // Package-manager installs must stay inside the files their package manager
+  // owns. The desktop companions are built from separate Swift/Electron trees,
+  // so offering that build here would either mutate a Homebrew keg or download
+  // an Electron toolchain during first-run setup. The source installer remains
+  // the supported all-in-one desktop path.
+  if (packageManager === "homebrew") return "skip";
   // Windows was excluded here while it had no tray build, which left the
   // installer silently skipping the one platform whose tray has to be built by
   // hand -- so nothing ever appeared and nothing said why.
   if (!TRAY_PLATFORMS.has(platform)) return "skip";
   if (withTray) return "install";
   return guided ? "ask" : "skip";
+}
+
+export function traySetupError({ packageManager, withTray, noTray }) {
+  if (packageManager !== "homebrew" || !withTray || noTray) return undefined;
+  return (
+    "--with-tray is unavailable for Homebrew installations. Homebrew installs " +
+    "the router and CLI only; use the recommended curl installer in the README " +
+    "for the Electron Control Center, tray/menu-bar app, and macOS desktop widget."
+  );
 }
 
 // Legacy Tauri release path retained only to recognize and migrate older

--- a/test/homebrew-formula.test.mjs
+++ b/test/homebrew-formula.test.mjs
@@ -170,6 +170,8 @@ test("the generated formula owns upgrades and preserves one-time setup", () => {
   assert.match(formula, /exec "\$source_root\/bin\/install" "\$@"/);
   assert.match(formula, /manifest\.dig\("current", "packageManager"\) != "homebrew"/);
   assert.match(formula, /codex-router setup --guided/);
+  assert.match(formula, /router and CLI only/);
+  assert.match(formula, /does not build or\s+download the Electron Control Center/);
   assert.match(formula, /codex-router uninstall/);
   assert.match(formula, /codex-router providers list --json/);
   assert.match(formula, /resource "litellm" do/);

--- a/test/setup-exit-codes.test.mjs
+++ b/test/setup-exit-codes.test.mjs
@@ -16,7 +16,7 @@ const SETUP = path.join(root, "src", "setup.mjs");
 // drifting away from install.sh and install.ps1, which read the number.
 const SETUP_INCOMPLETE_EXIT = 2;
 
-function runSetup(args) {
+function runSetup(args, extraEnv = {}) {
   const stateDir = mkdtempSync(path.join(os.tmpdir(), "setup-exit-"));
   try {
     return spawnSync(process.execPath, [SETUP, ...args], {
@@ -26,6 +26,7 @@ function runSetup(args) {
         ...process.env,
         MODEL_ROUTER_STATE_DIR: stateDir,
         CODEX_HOME: stateDir,
+        ...extraEnv,
       },
     });
   } finally {
@@ -66,6 +67,16 @@ test("--no-discovery alone leaves the checkout update in place", () => {
   const result = runSetup(["--no-discovery"]);
   assert.equal(result.status, SETUP_INCOMPLETE_EXIT);
   assert.match(result.stderr, /--no-discovery requires --no-provider/);
+});
+
+test("Homebrew refuses the source-only desktop companion before setup changes anything", () => {
+  const result = runSetup(
+    ["--with-tray", "--selection-only", "--no-provider"],
+    { CODEX_ROUTER_PACKAGE_MANAGER: "homebrew" },
+  );
+  assert.equal(result.status, SETUP_INCOMPLETE_EXIT);
+  assert.match(result.stderr, /Homebrew installs the router and CLI only/);
+  assert.match(result.stderr, /recommended curl installer/);
 });
 
 // Deliberately absent: a "no configured provider" case driven through

--- a/test/tray-install.test.mjs
+++ b/test/tray-install.test.mjs
@@ -1,8 +1,17 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
-import { desktopTrayBinary, trayBundleDir, trayDecision } from "../src/tray-install.mjs";
+import {
+  desktopTrayBinary,
+  trayBundleDir,
+  trayDecision,
+  traySetupError,
+} from "../src/tray-install.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 test("trayDecision skips when --no-tray is passed", () => {
   assert.equal(
@@ -59,6 +68,39 @@ test("trayDecision skips silently in automatic mode", () => {
     trayDecision({ platform: "darwin", withTray: false, noTray: false, guided: false }),
     "skip",
   );
+});
+
+test("Homebrew setup never offers or installs a desktop companion", () => {
+  for (const withTray of [false, true]) {
+    assert.equal(
+      trayDecision({
+        platform: "darwin",
+        withTray,
+        noTray: false,
+        guided: true,
+        packageManager: "homebrew",
+      }),
+      "skip",
+    );
+  }
+  assert.match(
+    traySetupError({ packageManager: "homebrew", withTray: true, noTray: false }),
+    /router and CLI only/,
+  );
+  assert.equal(
+    traySetupError({ packageManager: "homebrew", withTray: false, noTray: false }),
+    undefined,
+  );
+});
+
+test("the tray launcher refuses to build inside a Homebrew installation", () => {
+  const result = spawnSync(path.join(root, "bin", "model-router-tray"), [], {
+    encoding: "utf8",
+    env: { ...process.env, CODEX_ROUTER_PACKAGE_MANAGER: "homebrew" },
+  });
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /not packaged by Homebrew/);
+  assert.match(result.stderr, /recommended curl installer/);
 });
 
 test("trayBundleDir places the macOS bundle in the user's Applications folder", () => {

--- a/test/tray-install.test.mjs
+++ b/test/tray-install.test.mjs
@@ -93,15 +93,19 @@ test("Homebrew setup never offers or installs a desktop companion", () => {
   );
 });
 
-test("the tray launcher refuses to build inside a Homebrew installation", () => {
-  const result = spawnSync(path.join(root, "bin", "model-router-tray"), [], {
-    encoding: "utf8",
-    env: { ...process.env, CODEX_ROUTER_PACKAGE_MANAGER: "homebrew" },
-  });
-  assert.equal(result.status, 2);
-  assert.match(result.stderr, /not packaged by Homebrew/);
-  assert.match(result.stderr, /recommended curl installer/);
-});
+test(
+  "the POSIX tray launcher refuses to build inside a Homebrew installation",
+  { skip: process.platform === "win32" },
+  () => {
+    const result = spawnSync(path.join(root, "bin", "model-router-tray"), [], {
+      encoding: "utf8",
+      env: { ...process.env, CODEX_ROUTER_PACKAGE_MANAGER: "homebrew" },
+    });
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /not packaged by Homebrew/);
+    assert.match(result.stderr, /recommended curl installer/);
+  },
+);
 
 test("trayBundleDir places the macOS bundle in the user's Applications folder", () => {
   assert.equal(


### PR DESCRIPTION
## Summary

- put the one-command full desktop install at the top of the README
- install the Control Center, tray/menu-bar app, and macOS desktop-widget capability by default through the recommended installer
- keep Homebrew CLI/router-only and refuse desktop builds inside Homebrew-managed installs
- document the unavailable Antigravity client-secret acquisition path from issue #393
- document that this project does not yet publish an npm-installable CLI
- prepare v0.5.1 and the Homebrew Core submission workflow

## Verification

- `npm run check`
- full Node suite: 2,736 passed, 17 skipped, 0 failed
- Control Center typecheck, build, and tests: 55 passed
- focused installer/release/Homebrew tests: 58 passed, 2 skipped
- `packaging/homebrew/check-core-readiness.sh`
- formula regeneration drift check and Ruby syntax check

AI assistance was used to implement and review this change; the maintainer reviewed the resulting diff and verification evidence.
