### PR TITLE
fix(homebrew): restore v0.5.0 source checksum

### DIFF
--- a/Formula/codex-router.rb
+++ b/Formula/codex-router.rb
@@ -4,7 +4,7 @@ class CodexRouter < Formula
   desc "Use external coding models inside the Codex App and CLI"
   homepage "https://github.com/duolahypercho/codex-router"
   url "https://github.com/duolahypercho/codex-router/releases/download/v0.5.0/codex-router-0.5.0.tar.gz"
-  sha256 "89f6765ccfd78a7ca9931507f17945d520080939d632572429c1f15dff61b529"
+  sha256 "89f494a21399c3c2a54f6f25531e10b0d64e7e5a238f17cb8f8f7f2c9222e076"
   license "MIT"
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
Fixes the checksum regression merged by #506.

The formula URL still points to the published v0.5.0 tarball, whose SHA-256 is:
`89f494a21399c3c2a54f6f25531e10b0d64e7e5a238f17cb8f8f7f2c9222e076`.
The merged formula had `89f676…`, so a real Homebrew download fails verification.

Verification:
- downloaded the release asset and computed the SHA-256
- `npm run check`
- 61 focused Homebrew/release/installer tests passed, 2 platform skips
- `git diff --check`
