### PR TITLE
Fix Homebrew Core source installation

### DIFF
--- a/Formula/codex-router.rb
+++ b/Formula/codex-router.rb
@@ -16,6 +16,7 @@ class CodexRouter < Formula
   depends_on "libsodium"
   depends_on "libyaml"
   depends_on "node"
+  depends_on "numpy"
   depends_on "python@3.14"
 
   # Optional LiteLLM resources omitted because PyPI publishes no portable source:
@@ -300,11 +301,6 @@ class CodexRouter < Formula
   resource "multidict" do
     url "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz"
     sha256 "ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d"
-  end
-
-  resource "numpy" do
-    url "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz"
-    sha256 "a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3"
   end
 
   resource "oauthlib" do

--- a/packaging/homebrew/generate-formula.mjs
+++ b/packaging/homebrew/generate-formula.mjs
@@ -22,6 +22,16 @@ const sourceRoot = path.resolve(
 // Homebrew's superenv shim appends -Os after the crate's own -O0.
 export const EXCLUDED_OPTIONAL_RESOURCES = new Set(["pyroscope-io", "hf-xet"]);
 
+// Homebrew builds every Python resource from its source distribution. NumPy's
+// isolated build recursively tries to build Meson, Ninja, and Cython, which is
+// both wasteful and currently fails before NumPy itself is configured. Core
+// already ships a universal `numpy` formula for the same Python interpreter,
+// and virtualenv_create exposes formula dependencies through
+// --system-site-packages. Keep this mapping narrow and evidence-based: unlike
+// optional resources, these packages remain required at runtime and are owned
+// by an explicit Homebrew dependency instead of a bundled PyPI resource.
+export const HOMEBREW_PROVIDED_RESOURCES = new Map([["numpy", "numpy"]]);
+
 function versionTuple(value) {
   const match = /^(\d+)\.(\d+)(?:\.(\d+))?$/.exec(String(value));
   if (!match) throw new Error(`Invalid Python version: ${value}`);
@@ -206,6 +216,7 @@ export function renderFormula({
   pythonVersion,
   resources,
   excludedResources = [],
+  homebrewProvidedResources = [],
 }) {
   const resourceBlocks = resources
     .map(
@@ -220,6 +231,9 @@ export function renderFormula({
         .map((resource) => `  # - ${resource.name}==${resource.version}`)
         .join("\n")}\n\n`
     : "";
+  const homebrewPythonDependencies = homebrewProvidedResources
+    .map((resource) => `  depends_on ${rubyString(resource.formula)}`)
+    .join("\n");
   return `class CodexRouter < Formula
   include Language::Python::Virtualenv
 
@@ -238,7 +252,7 @@ export function renderFormula({
   depends_on "libsodium"
   depends_on "libyaml"
   depends_on "node"
-  depends_on ${rubyString(pythonFormula)}
+${homebrewPythonDependencies ? `${homebrewPythonDependencies}\n` : ""}  depends_on ${rubyString(pythonFormula)}
 
 ${exclusionComment}${resourceBlocks}
 
@@ -404,8 +418,23 @@ export async function buildFormula({
   const locked = lockedRequirements(readFileSync(lockPath, "utf8"), pythonVersion);
   const isExcluded = (requirement) =>
     EXCLUDED_OPTIONAL_RESOURCES.has(requirement.name.toLowerCase());
+  const homebrewProvidedResources = locked
+    .filter((requirement) =>
+      HOMEBREW_PROVIDED_RESOURCES.has(requirement.name.toLowerCase()),
+    )
+    .map((requirement) => ({
+      ...requirement,
+      formula: HOMEBREW_PROVIDED_RESOURCES.get(requirement.name.toLowerCase()),
+    }));
+  const isHomebrewProvided = (requirement) =>
+    HOMEBREW_PROVIDED_RESOURCES.has(requirement.name.toLowerCase());
   const excludedResources = locked.filter(isExcluded);
-  const resources = await resolveResources(locked.filter((r) => !isExcluded(r)));
+  const resources = await resolveResources(
+    locked.filter(
+      (requirement) =>
+        !isExcluded(requirement) && !isHomebrewProvided(requirement),
+    ),
+  );
   const formula = renderFormula({
     version,
     sourceUrl,
@@ -414,8 +443,11 @@ export async function buildFormula({
     pythonVersion,
     resources,
     excludedResources,
+    homebrewProvidedResources,
   });
-  return detailed ? { formula, resources, excludedResources } : formula;
+  return detailed
+    ? { formula, resources, excludedResources, homebrewProvidedResources }
+    : formula;
 }
 
 function option(args, name) {
@@ -447,14 +479,15 @@ async function main() {
   if (!/^[A-Za-z0-9@._+-]+$/.test(pythonFormula)) {
     throw new Error(`Invalid Python formula name: ${pythonFormula}`);
   }
-  const { formula, resources, excludedResources } = await buildFormula({
-    version,
-    sourceUrl,
-    sourceSha256,
-    pythonFormula,
-    pythonVersion,
-    detailed: true,
-  });
+  const { formula, resources, excludedResources, homebrewProvidedResources } =
+    await buildFormula({
+      version,
+      sourceUrl,
+      sourceSha256,
+      pythonFormula,
+      pythonVersion,
+      detailed: true,
+    });
   writeFileSync(path.resolve(output), formula, "utf8");
   process.stdout.write(
     `${JSON.stringify({
@@ -462,6 +495,9 @@ async function main() {
       resources: resources.length,
       excluded: excludedResources.map(({ name, version: resourceVersion }) =>
         `${name}==${resourceVersion}`,
+      ),
+      homebrewProvided: homebrewProvidedResources.map(
+        ({ name, formula: formulaName }) => `${name}:${formulaName}`,
       ),
     })}\n`,
   );

--- a/test/homebrew-formula.test.mjs
+++ b/test/homebrew-formula.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import {
   lockedRequirements,
   EXCLUDED_OPTIONAL_RESOURCES,
+  HOMEBREW_PROVIDED_RESOURCES,
   markerApplies,
   pypiResource,
   renderFormula,
@@ -36,6 +37,7 @@ test("Homebrew lock selection follows its declared Python version", () => {
   assert.equal(versions.has("pywin32"), false);
   assert.equal(versions.has("uvloop"), true);
   assert.equal(EXCLUDED_OPTIONAL_RESOURCES.has("pyroscope-io"), true);
+  assert.equal(HOMEBREW_PROVIDED_RESOURCES.get("numpy"), "numpy");
 });
 
 test("PyPI resource resolution requires a checksummed source distribution", async () => {
@@ -142,10 +144,14 @@ test("the generated formula owns upgrades and preserves one-time setup", () => {
       },
     ],
     excludedResources: [{ name: "pyroscope-io", version: "0.8.16" }],
+    homebrewProvidedResources: [
+      { name: "numpy", version: "2.5.1", formula: "numpy" },
+    ],
   });
   assert.match(formula, /class CodexRouter < Formula/);
   assert.doesNotMatch(formula, /^\s*version\s+/m);
   assert.match(formula, /depends_on "libyaml"/);
+  assert.match(formula, /depends_on "numpy"/);
   assert.match(formula, /if OS\.mac\?/);
   assert.doesNotMatch(formula, /Formula\["node"\]\.opt_bin/);
   assert.match(formula, /install_plan\.exist\?/);
@@ -175,5 +181,6 @@ test("the generated formula owns upgrades and preserves one-time setup", () => {
   assert.match(formula, /codex-router uninstall/);
   assert.match(formula, /codex-router providers list --json/);
   assert.match(formula, /resource "litellm" do/);
+  assert.doesNotMatch(formula, /resource "numpy" do/);
   assert.match(formula, /pyroscope-io==0\.8\.16/);
 });


### PR DESCRIPTION
## Summary

- use Homebrew's `numpy` formula instead of rebuilding NumPy as a PyPI resource
- keep the generated formula derived from the Python lock while recording Homebrew-provided runtime dependencies explicitly
- cover the dependency/resource split in the generator tests

## Why

The initial Homebrew/Core readiness install exposed that NumPy 2.5.1's isolated source build recursively tries to build Meson/Ninja and fails before NumPy is configured. Homebrew already provides a universal NumPy formula for the same Python interpreter, and the router's virtualenv uses system site packages.

## Verification

- `npm run check`
- focused Homebrew/release/tray tests: 22 passed
- formula drift check
- Ruby syntax and Homebrew style
- `brew audit --new --formula`
- full `brew install --build-from-source`, `brew test`, and cleanup: passed (12,510 files; built in 22 minutes)

## AI assistance

This change was prepared with AI assistance. I reviewed the generated formula, inspected the failing Homebrew build, and verified the corrected formula with a complete from-source install and test.
