### PR TITLE
fix: preserve custom per-model endpoint routing

### DIFF
--- a/src/provider-api-key-routing.mjs
+++ b/src/provider-api-key-routing.mjs
@@ -184,6 +184,21 @@ export async function resolveProviderApiKeyForRequest(
     staleMs,
   } = {},
 ) {
+  // API-key pools are provider-level authority. Per-model endpoint descriptors
+  // deliberately derive their id from the model slug (for example
+  // `custom/foo`) so each model keeps a distinct credential; those ids are not
+  // registry provider ids and must stay on the existing endpoint credential
+  // path instead of being parsed as pool provider identities. Generic runtime
+  // providers are handled by their separate request boundary before this call.
+  if (!PROVIDERS.has(provider.id)) {
+    return {
+      credential: resolveLegacy(),
+      pooled: false,
+      configured: false,
+      fallbackAllowed: true,
+    };
+  }
+
   const status = providerApiKeyPoolStatus(provider.id, {
     filePath: poolStatePath,
     now,

--- a/src/provider-api-key-routing.mjs
+++ b/src/provider-api-key-routing.mjs
@@ -190,7 +190,9 @@ export async function resolveProviderApiKeyForRequest(
   // registry provider ids and must stay on the existing endpoint credential
   // path instead of being parsed as pool provider identities. Generic runtime
   // providers are handled by their separate request boundary before this call.
-  if (!PROVIDERS.has(provider.id)) {
+  const perModelEndpointId =
+    typeof provider?.id === "string" && provider.id.includes("/");
+  if (perModelEndpointId) {
     return {
       credential: resolveLegacy(),
       pooled: false,

--- a/test/provider-api-key-routing.test.mjs
+++ b/test/provider-api-key-routing.test.mjs
@@ -11,7 +11,7 @@ process.env.MODEL_ROUTER_PROVIDER_CREDENTIAL_STORE = path.join(root, "state", "p
 process.env.MODEL_ROUTER_PROVIDER_CREDENTIAL_MIGRATIONS = path.join(root, "state", "migrations", "provider-credentials");
 delete process.env.OPENROUTER_API_KEY;
 
-const { PROVIDERS } = await import("../src/model-registry.mjs");
+const { MODEL_BY_SLUG, PROVIDERS, endpointForModel } = await import("../src/model-registry.mjs");
 const { writeProviderCredential } = await import("../src/provider-credentials.mjs");
 const { addCredentialReference, migrateProviderCredentialStore } = await import("../src/provider-credential-store.mjs");
 const { resolveProviderApiKeyForRequest } = await import("../src/provider-api-key-routing.mjs");
@@ -30,6 +30,21 @@ test.before(async () => {
   const store = migrateProviderCredentialStore(credentialStorePath).store;
   credentialId = store.credentials.find((entry) => entry.providerId === provider.id).id;
   await upsertProviderApiKey(provider.id, { id: credentialId }, { filePath: statePath });
+});
+
+test("per-model endpoint identities bypass provider-level API-key pools", async () => {
+  const endpoint = endpointForModel(MODEL_BY_SLUG.get("custom/qwen3.8-27b"));
+  assert.equal(endpoint.id, "custom/qwen3.8-27b");
+
+  const routing = await resolveProviderApiKeyForRequest(endpoint, {
+    poolStatePath: statePath,
+    credentialStorePath,
+  });
+
+  assert.equal(routing.pooled, false);
+  assert.equal(routing.configured, false);
+  assert.equal(routing.fallbackAllowed, true);
+  assert.equal(routing.credential?.source, "official anonymous endpoint");
 });
 
 test("credential-store ids resolve through registry-bound references", async () => {


### PR DESCRIPTION
## Summary

Restore custom per-model endpoint routing after the provider API-key pool integration.

## Root cause

`endpointForModel()` deliberately derives a per-model endpoint id from the model slug, e.g. `custom/qwen3.8-27b`, so different custom models keep separate credential identities.

#507 made `resolveProviderApiKeyForRequest()` consult the provider-level pool for every non-generic endpoint. Pool provider ids accept provider syntax only and reject `/`, so a custom endpoint now throws `Invalid provider id` before credential resolution or any upstream request.

## Fix

- recognize the reserved per-model endpoint id shape (`provider/model`) before provider-level pool lookup;
- leave those per-model endpoint descriptors on their existing endpoint credential path;
- keep malformed/non-per-model identities on the existing pool validation path rather than broadly bypassing validation;
- keep generic runtime providers on their separate request boundary;
- preserve pool behavior for checked-in providers and protocol variants.

## Verification

Red/green regression on current main `49d1579`:
- before: `custom/qwen3.8-27b` fails with `Invalid provider id: custom/qwen3.8-27b`;
- after: the real derived endpoint bypasses provider-level pool lookup and resolves through the existing anonymous endpoint credential path.

Fresh local checks after the final narrowing:
- `node --test test/provider-api-key-routing.test.mjs test/provider-api-key-forwarder.test.mjs test/provider-credentials.test.mjs test/registry.test.mjs` — 39 passed, 1 intentional platform skip, 0 failed;
- `npm run check` — pass;
- `git diff --check` — clean.

Additional bounded maintenance verification on current main:
- generic-provider confinement/CRUD/registry/doctor: 16/16 passed;
- Windows/default-installer/tray surface: 44 passed, 9 platform-inapplicable skips, 0 failed;
- Windows private-file ACL surface: 6/6 passed.

No live provider or quota-consuming request was made.