### PR TITLE
Fix model controls overflow and Hy4 branding

### DIFF
--- a/apps/control-center/src/pages/ModelsPage.tsx
+++ b/apps/control-center/src/pages/ModelsPage.tsx
@@ -1155,7 +1155,10 @@ function ModelDetails({
       {routeUsable(model) ? (
         <div>
           <dt>Subagents</dt>
-          <dd>
+          {/* The effort popup extends below this definition-list cell. Keep
+              this cell visibly overflowing; the generic text cells still
+              ellipsize long ids and route descriptions. */}
+          <dd className="pm-model-details-controls">
             <div className="pm-subagent-controls">
               <SubagentToggle
                 model={model}

--- a/apps/control-center/src/pages/providers-models.css
+++ b/apps/control-center/src/pages/providers-models.css
@@ -1091,6 +1091,10 @@
   font-size: 9.5px !important;
 }
 
+.pm-model-details dd.pm-model-details-controls {
+  overflow: visible;
+}
+
 .pm-model-details .pm-subagent-controls {
   margin-top: -2px;
 }

--- a/apps/control-center/src/provider-branding.tsx
+++ b/apps/control-center/src/provider-branding.tsx
@@ -177,7 +177,7 @@ export function brandForModel(model: BrandableModel): ProviderBrand {
   if (/\b(?:gpt|codex)\b/.test(identity) || /^openai\//.test(model.slug.toLowerCase())) return BRANDS.openai;
   if (/\bmimo(?:-|\b)/.test(identity)) return BRANDS.xiaomi;
   if (/\bstep(?:-|\s)/.test(identity)) return BRANDS.stepfun;
-  if (/\bhy3(?:-|\b)/.test(identity)) return BRANDS.tencent;
+  if (/\bhy(?:3|4)(?:-|\b)/.test(identity)) return BRANDS.tencent;
   if (/\blaguna(?:-|\b)/.test(identity)) return BRANDS.poolside;
   if (/\b(?:llama|muse spark)\b/.test(identity)) return BRANDS.meta;
   if (/\b(?:mistral|mixtral|codestral)\b/.test(identity)) return BRANDS.mistral;

--- a/apps/control-center/test/renderer.test.mjs
+++ b/apps/control-center/test/renderer.test.mjs
@@ -23,8 +23,8 @@ const bridgeSource = String.raw`
     provider: "deepseek",
     enabled: true,
     visible: true,
-    multiAgentVersion: "v1",
-    subagentCertification: "v1",
+    multiAgentVersion: "v2",
+    subagentCertification: "v2",
     reasoningLevels: ["low", "medium", "high"],
     contextWindow: 128000,
     inputModalities: ["text"],
@@ -362,6 +362,31 @@ test("the production renderer exposes model discovery and picker actions", { tim
     assert.match(await connectMenu.innerText(), /Kilo Free/);
     assert.equal(await connectMenu.getByRole("menuitem").count(), 5);
     await page.keyboard.press("Escape");
+
+    // A single-route model's thinking menu opens below its definition-list
+    // cell. The menu used to be clipped by that cell's generic text-overflow
+    // rule, leaving only its top edge visible.
+    const selectedFamily = page.locator(".pm-family-row").filter({ hasText: "DeepSeek Chat" });
+    await selectedFamily.locator(".pm-family-open").click();
+    const thinkingTrigger = selectedFamily.getByRole("button", {
+      name: "DeepSeek Chat DeepSeek subagent thinking effort",
+    });
+    await thinkingTrigger.click();
+    const thinkingMenu = selectedFamily.locator(".pm-effort-menu");
+    await thinkingMenu.waitFor();
+    const detailsCell = selectedFamily.locator(".pm-model-details-controls");
+    assert.equal(await detailsCell.evaluate((element) => getComputedStyle(element).overflow), "visible");
+    const [cellBox, menuBox] = await Promise.all([detailsCell.boundingBox(), thinkingMenu.boundingBox()]);
+    assert.ok(cellBox && menuBox);
+    assert.ok(menuBox.y + menuBox.height > cellBox.y + cellBox.height);
+    assert.equal(await page.evaluate(({ x, y }) => (
+      Boolean(document.elementFromPoint(x, y)?.closest(".pm-effort-menu"))
+    ), {
+      x: menuBox.x + menuBox.width / 2,
+      y: menuBox.y + menuBox.height - 2,
+    }), true);
+    await page.keyboard.press("Escape");
+    await selectedFamily.locator(".pm-family-open").click();
 
     // A route that is only known to the registry still has to be findable, and
     // has to say which connection it is waiting for.

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -1242,6 +1242,11 @@ test("the model directory combines provider setup with de-duplicated model-famil
   assert.doesNotMatch(models, /<select[\s\S]{0,200}subagent thinking effort/);
   assert.match(models, /<dt>Model id<\/dt>/);
   assert.match(providerModelsCss, /\.pm-model-details\s*\{/);
+  assert.match(models, /<dd className="pm-model-details-controls">/);
+  assert.match(
+    providerModelsCss,
+    /\.pm-model-details dd\.pm-model-details-controls\s*\{[^}]*overflow:\s*visible/,
+  );
 
   // Adding republishes the whole catalog to every installed client and is the
   // slowest thing this page starts. Placeholder rows carrying the chosen slugs
@@ -1345,7 +1350,7 @@ test("the model directory combines provider setup with de-duplicated model-famil
   }
   assert.match(branding, /"lmstudio": "lmstudio"/);
   assert.match(branding, /ornith[^\n]+BRANDS\.deepreinforce/);
-  assert.match(branding, /hy3[^\n]+BRANDS\.tencent/);
+  assert.match(branding, /hy\(\?:3\|4\)[^\n]+BRANDS\.tencent/);
   assert.match(branding, /laguna[^\n]+BRANDS\.poolside/);
   assert.match(branding, /export function brandForLocalModel/);
   const sources = await readFile(new URL("../apps/control-center/src/assets/providers/SOURCES.md", import.meta.url), "utf8");

--- a/test/provider-branding.test.mjs
+++ b/test/provider-branding.test.mjs
@@ -23,7 +23,7 @@ test("provider and model-maker branding covers remote and local catalog families
 
   assert.match(branding, /muse spark[^\n]+BRANDS\.meta/);
   assert.match(branding, /ornith[^\n]+BRANDS\.deepreinforce/);
-  assert.match(branding, /hy3[^\n]+BRANDS\.tencent/);
+  assert.match(branding, /hy\(\?:3\|4\)[^\n]+BRANDS\.tencent/);
   assert.match(branding, /laguna[^\n]+BRANDS\.poolside/);
   assert.match(branding, /export function brandForLocalModel/);
   assert.match(local, /brandForLocalModel/);


### PR DESCRIPTION
## Summary
- keep subagent effort menus visible outside model-detail cells
- recognize Hy4 models as Tencent-branded
- add renderer and source-level regression coverage

## Verification
- npm run check
- node --test test/provider-branding.test.mjs test/control-center-electron.test.mjs
- cd apps/control-center && npm test