### PR TITLE
Improve Control Center loading responsiveness

### DIFF
--- a/apps/control-center/src/App.tsx
+++ b/apps/control-center/src/App.tsx
@@ -124,19 +124,25 @@ export default function App() {
   const downloadPollInFlight = useRef(false);
   const healthPollInFlight = useRef(false);
   const previousActivityState = useRef<string | undefined>(undefined);
+  const readGenerations = useRef<Partial<Record<keyof RouterDataReady, number>>>({});
 
   const settleRead = useCallback(async <T,>(
     key: keyof RouterDataReady,
     request: Promise<T>,
     commit: (value: T) => void,
   ) => {
+    const generation = (readGenerations.current[key] ?? 0) + 1;
+    readGenerations.current[key] = generation;
     try {
-      commit(await request);
+      const value = await request;
+      if (readGenerations.current[key] === generation) commit(value);
     } finally {
-      // "Ready" means the first attempt settled, not necessarily succeeded.
-      // Errors are rendered separately, while this prevents an unreachable
-      // optional source from leaving its skeleton on screen forever.
-      setDataReady((current) => current[key] ? current : { ...current, [key]: true });
+      if (readGenerations.current[key] === generation) {
+        // "Ready" means the latest attempt settled, not necessarily succeeded.
+        // Errors are rendered separately, while this prevents an unreachable
+        // optional source from leaving its skeleton on screen forever.
+        setDataReady((current) => current[key] ? current : { ...current, [key]: true });
+      }
     }
   }, []);
 
@@ -178,7 +184,10 @@ export default function App() {
       settleRead("providerUsage", api.getProviderUsage(), setProviderUsage),
     ]);
     const failure = results.find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
-    if (failure) throw failure.reason;
+    // Background polling deliberately starts this callback without awaiting it.
+    // Surface a partial usage failure here so every caller, including the timer,
+    // receives a settled promise instead of producing an unhandled rejection.
+    if (failure) setLoadError(readableError(failure.reason));
   }, [api, settleRead]);
 
   const refreshDownloadProgress = useCallback(async () => {

--- a/apps/control-center/src/App.tsx
+++ b/apps/control-center/src/App.tsx
@@ -18,7 +18,7 @@ import {
   Settings,
   Sun,
 } from "lucide-react";
-import { Badge, Button, InlineNotice, LoadingState } from "./components";
+import { Badge, Button, InlineNotice } from "./components";
 import { classNames } from "./lib";
 import { ContextPage } from "./pages/ContextPage";
 import { DashboardPage } from "./pages/DashboardPage";
@@ -47,12 +47,21 @@ import type {
   ProviderUsageSnapshot,
   RouterHealth,
   RouterSnapshot,
+  RouterDataReady,
   ViewId,
 } from "./types";
 
 const THEME_KEY = "model-router-control-center-theme";
 const VIEW_KEY = "model-router-control-center-view";
 const ACTIVE_MLX_STATES = new Set(["preparing", "downloading", "loading", "starting-server", "verifying", "publishing"]);
+const INITIAL_DATA_READY: RouterDataReady = {
+  snapshot: false,
+  providers: false,
+  presence: false,
+  health: false,
+  accountUsage: false,
+  providerUsage: false,
+};
 
 const NAV_ITEMS: Array<{
   id: ViewId;
@@ -107,7 +116,7 @@ export default function App() {
   const [accountUsage, setAccountUsage] = useState<AccountUsage>();
   const [providerUsage, setProviderUsage] = useState<ProviderUsageSnapshot>();
   const [presence, setPresence] = useState<PresenceSnapshot>();
-  const [loading, setLoading] = useState(true);
+  const [dataReady, setDataReady] = useState<RouterDataReady>(INITIAL_DATA_READY);
   const [refreshing, setRefreshing] = useState(false);
   const [operation, setOperation] = useState<OperationEvent | null>(null);
   const [toast, setToast] = useState<{ tone: "neutral" | "success" | "danger"; message: string } | null>(null);
@@ -115,6 +124,21 @@ export default function App() {
   const downloadPollInFlight = useRef(false);
   const healthPollInFlight = useRef(false);
   const previousActivityState = useRef<string | undefined>(undefined);
+
+  const settleRead = useCallback(async <T,>(
+    key: keyof RouterDataReady,
+    request: Promise<T>,
+    commit: (value: T) => void,
+  ) => {
+    try {
+      commit(await request);
+    } finally {
+      // "Ready" means the first attempt settled, not necessarily succeeded.
+      // Errors are rendered separately, while this prevents an unreachable
+      // optional source from leaving its skeleton on screen forever.
+      setDataReady((current) => current[key] ? current : { ...current, [key]: true });
+    }
+  }, []);
 
   const target = snapshot?.targets.codex;
   const localDownloadActive = target?.modelSettings?.localModels?.download?.status === "downloading";
@@ -137,26 +161,25 @@ export default function App() {
   const refreshCore = useCallback(async () => {
     if (!api) return;
     const [nextSnapshot, nextProviders, nextPresence, nextHealth] = await Promise.allSettled([
-      api.getSnapshot(),
-      api.getProviders(),
-      api.getPresence(),
-      api.getHealth(),
+      settleRead("snapshot", api.getSnapshot(), setSnapshot),
+      settleRead("providers", api.getProviders(), setProviders),
+      settleRead("presence", api.getPresence(), setPresence),
+      settleRead("health", api.getHealth(), setHealth),
     ]);
-    if (nextSnapshot.status === "fulfilled") setSnapshot(nextSnapshot.value);
-    if (nextProviders.status === "fulfilled") setProviders(nextProviders.value);
-    if (nextPresence.status === "fulfilled") setPresence(nextPresence.value);
-    if (nextHealth.status === "fulfilled") setHealth(nextHealth.value);
     const failure = [nextSnapshot, nextProviders, nextPresence, nextHealth]
       .find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
     if (failure) throw failure.reason;
-  }, [api]);
+  }, [api, settleRead]);
 
   const refreshUsage = useCallback(async () => {
     if (!api) return;
-    const [account, provider] = await Promise.allSettled([api.getAccountUsage(), api.getProviderUsage()]);
-    if (account.status === "fulfilled") setAccountUsage(account.value);
-    if (provider.status === "fulfilled") setProviderUsage(provider.value);
-  }, [api]);
+    const results = await Promise.allSettled([
+      settleRead("accountUsage", api.getAccountUsage(), setAccountUsage),
+      settleRead("providerUsage", api.getProviderUsage(), setProviderUsage),
+    ]);
+    const failure = results.find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
+    if (failure) throw failure.reason;
+  }, [api, settleRead]);
 
   const refreshDownloadProgress = useCallback(async () => {
     if (!api || downloadPollInFlight.current) return;
@@ -196,7 +219,14 @@ export default function App() {
 
   const refreshAll = useCallback(async () => {
     if (!api) {
-      setLoading(false);
+      setDataReady({
+        snapshot: true,
+        providers: true,
+        presence: true,
+        health: true,
+        accountUsage: true,
+        providerUsage: true,
+      });
       setLoadError("The Electron bridge is unavailable. Open this UI through the Codex Router desktop app.");
       return;
     }
@@ -205,7 +235,6 @@ export default function App() {
     const results = await Promise.allSettled([refreshCore(), refreshUsage()]);
     const failure = results.find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
     if (failure) setLoadError(readableError(failure.reason));
-    setLoading(false);
     setRefreshing(false);
   }, [api, refreshCore, refreshUsage]);
 
@@ -363,10 +392,10 @@ export default function App() {
     window.setTimeout(() => searchTriggerRef.current?.focus(), 0);
   }, []);
   const page = (() => {
-    const shared = { target, api, refreshing, onRefresh: () => void refreshAll(), runAction };
+    const shared = { target, api, refreshing, dataReady, onRefresh: () => void refreshAll(), runAction };
     switch (view) {
-      case "dashboard": return <DashboardPage target={target} dashboard={snapshot?.catalog?.dashboard} health={health} account={accountUsage} providerUsage={providerUsage} setup={providers} presence={presence} api={api} runAction={runAction} refreshing={refreshing} onRefresh={() => void refreshAll()} onNavigate={navigateTo} />;
-      case "usage": return <UsagePage target={target} account={accountUsage} providerUsage={providerUsage} api={api} refreshing={refreshing} onRefresh={() => void refreshAll()} focusRequest={usageFocusRequest} />;
+      case "dashboard": return <DashboardPage target={target} dashboard={snapshot?.catalog?.dashboard} health={health} account={accountUsage} providerUsage={providerUsage} setup={providers} presence={presence} api={api} runAction={runAction} refreshing={refreshing} dataReady={dataReady} onRefresh={() => void refreshAll()} onNavigate={navigateTo} />;
+      case "usage": return <UsagePage target={target} account={accountUsage} providerUsage={providerUsage} api={api} refreshing={refreshing} dataReady={dataReady} onRefresh={() => void refreshAll()} focusRequest={usageFocusRequest} />;
       case "status": return <StatusPage {...shared} health={health} account={accountUsage} providerUsage={providerUsage} />;
       case "models": return <ModelsPage {...shared} catalog={snapshot?.catalog} setup={providers} usage={providerUsage} focusRequest={modelFocusRequest} />;
       case "local": return <LocalPage {...shared} operation={operation} />;
@@ -432,7 +461,7 @@ export default function App() {
         </div>
         <div className={classNames("page-scroll", `page-scroll-${view}`)}>
           {loadError ? <InlineNotice tone="warning" title="Some router data could not load">{loadError}</InlineNotice> : null}
-          {loading ? <LoadingState /> : page}
+          {page}
         </div>
       </main>
 

--- a/apps/control-center/src/App.tsx
+++ b/apps/control-center/src/App.tsx
@@ -121,6 +121,7 @@ export default function App() {
   const [operation, setOperation] = useState<OperationEvent | null>(null);
   const [toast, setToast] = useState<{ tone: "neutral" | "success" | "danger"; message: string } | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [readErrors, setReadErrors] = useState<Partial<Record<keyof RouterDataReady, string>>>({});
   const downloadPollInFlight = useRef(false);
   const healthPollInFlight = useRef(false);
   const previousActivityState = useRef<string | undefined>(undefined);
@@ -130,12 +131,25 @@ export default function App() {
     key: keyof RouterDataReady,
     request: Promise<T>,
     commit: (value: T) => void,
+    recover?: (error: unknown) => T,
   ) => {
     const generation = (readGenerations.current[key] ?? 0) + 1;
     readGenerations.current[key] = generation;
     try {
       const value = await request;
-      if (readGenerations.current[key] === generation) commit(value);
+      if (readGenerations.current[key] !== generation) return;
+      commit(value);
+      setReadErrors((current) => {
+        if (current[key] === undefined) return current;
+        const next = { ...current };
+        delete next[key];
+        return next;
+      });
+    } catch (error) {
+      if (readGenerations.current[key] !== generation) return;
+      if (recover) commit(recover(error));
+      const message = readableError(error);
+      setReadErrors((current) => current[key] === message ? current : { ...current, [key]: message });
     } finally {
       if (readGenerations.current[key] === generation) {
         // "Ready" means the latest attempt settled, not necessarily succeeded.
@@ -156,38 +170,36 @@ export default function App() {
     if (!api || healthPollInFlight.current || document.visibilityState !== "visible") return;
     healthPollInFlight.current = true;
     try {
-      setHealth(await api.getHealth());
-    } catch (error) {
-      setHealth({ ok: false, error: readableError(error), activity: { state: "offline", active: [], activeCount: 0 } });
+      await settleRead("health", api.getHealth(), setHealth, (error) => ({
+        ok: false,
+        error: readableError(error),
+        activity: { state: "offline", active: [], activeCount: 0 },
+      }));
     } finally {
       healthPollInFlight.current = false;
     }
-  }, [api]);
+  }, [api, settleRead]);
 
   const refreshCore = useCallback(async () => {
     if (!api) return;
-    const [nextSnapshot, nextProviders, nextPresence, nextHealth] = await Promise.allSettled([
+    await Promise.allSettled([
       settleRead("snapshot", api.getSnapshot(), setSnapshot),
       settleRead("providers", api.getProviders(), setProviders),
       settleRead("presence", api.getPresence(), setPresence),
-      settleRead("health", api.getHealth(), setHealth),
+      settleRead("health", api.getHealth(), setHealth, (error) => ({
+        ok: false,
+        error: readableError(error),
+        activity: { state: "offline", active: [], activeCount: 0 },
+      })),
     ]);
-    const failure = [nextSnapshot, nextProviders, nextPresence, nextHealth]
-      .find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
-    if (failure) throw failure.reason;
   }, [api, settleRead]);
 
   const refreshUsage = useCallback(async () => {
     if (!api) return;
-    const results = await Promise.allSettled([
+    await Promise.allSettled([
       settleRead("accountUsage", api.getAccountUsage(), setAccountUsage),
       settleRead("providerUsage", api.getProviderUsage(), setProviderUsage),
     ]);
-    const failure = results.find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
-    // Background polling deliberately starts this callback without awaiting it.
-    // Surface a partial usage failure here so every caller, including the timer,
-    // receives a settled promise instead of producing an unhandled rejection.
-    if (failure) setLoadError(readableError(failure.reason));
   }, [api, settleRead]);
 
   const refreshDownloadProgress = useCallback(async () => {
@@ -241,9 +253,7 @@ export default function App() {
     }
     setRefreshing(true);
     setLoadError(null);
-    const results = await Promise.allSettled([refreshCore(), refreshUsage()]);
-    const failure = results.find((result) => result.status === "rejected") as PromiseRejectedResult | undefined;
-    if (failure) setLoadError(readableError(failure.reason));
+    await Promise.allSettled([refreshCore(), refreshUsage()]);
     setRefreshing(false);
   }, [api, refreshCore, refreshUsage]);
 
@@ -362,6 +372,7 @@ export default function App() {
     [language],
   );
   const activeMeta = useMemo(() => navItems.find((item) => item.id === view) ?? navItems[0], [navItems, view]);
+  const readError = Object.values(readErrors).find((message): message is string => Boolean(message));
   const navigateTo = useCallback((next: ViewId, modelFocus?: ModelViewFocus) => {
     if (next === "models" && modelFocus) {
       modelFocusSequence.current += 1;
@@ -469,7 +480,7 @@ export default function App() {
           <button className="title-refresh" type="button" aria-label="Refresh all data" disabled={refreshing} onClick={() => void refreshAll()}><RefreshCw aria-hidden size={13} strokeWidth={1.7} className={refreshing ? "spin" : ""} /></button>
         </div>
         <div className={classNames("page-scroll", `page-scroll-${view}`)}>
-          {loadError ? <InlineNotice tone="warning" title="Some router data could not load">{loadError}</InlineNotice> : null}
+          {loadError || readError ? <InlineNotice tone="warning" title="Some router data could not load">{loadError || readError}</InlineNotice> : null}
           {page}
         </div>
       </main>

--- a/apps/control-center/src/pages/DashboardPage.tsx
+++ b/apps/control-center/src/pages/DashboardPage.tsx
@@ -9,7 +9,7 @@ import {
   Server,
   Waypoints,
 } from "lucide-react";
-import { Badge, Button, EmptyState, InlineNotice, PageHeader, SectionHeading } from "../components";
+import { Badge, Button, EmptyState, InlineNotice, PageHeader, PanelSkeleton, SectionHeading, SkeletonBlock } from "../components";
 import { ProviderLogo } from "../provider-branding";
 import { ServiceHealthPanel } from "../ServiceHealth";
 import { useOptimisticValues, type RunAction } from "../useOptimisticValues";
@@ -28,6 +28,7 @@ import type {
   ProviderSetupSnapshot,
   ProviderUsageSnapshot,
   RouterControlApi,
+  RouterDataReady,
   RouterDashboardSnapshot,
   RouterHealth,
   RouterTarget,
@@ -51,6 +52,7 @@ interface SummaryTile {
   meter?: number;
   view: ViewId;
   viewLabel: string;
+  pending?: boolean;
 }
 
 interface MetricEntry {
@@ -132,6 +134,7 @@ export function DashboardPage({
   providerUsage,
   api,
   refreshing,
+  dataReady,
   onRefresh,
   onNavigate,
   runAction,
@@ -146,10 +149,16 @@ export function DashboardPage({
   api?: RouterControlApi;
   runAction?: RunAction;
   refreshing: boolean;
+  dataReady: RouterDataReady;
   onRefresh: () => void;
   onNavigate: (view: ViewId, modelFocus?: ModelViewFocus) => void;
 }) {
   const [trafficRange, setTrafficRange] = useState<TrafficRange>(24);
+  const healthPending = !dataReady.health && !health;
+  const snapshotPending = !dataReady.snapshot && !target;
+  const routesPending = !dataReady.snapshot && !dashboard;
+  const usagePending = (!dataReady.accountUsage && !account)
+    || (!dataReady.providerUsage && !providerUsage);
   // Every prop can be undefined on first paint and after a failed refresh, so
   // each tile below separates three cases: still loading, reported-but-absent,
   // and a genuine zero. A missing field must never render as 0.
@@ -241,6 +250,7 @@ export function DashboardPage({
       tone: health ? health.ok ? "success" : "danger" : undefined,
       view: "status",
       viewLabel: "Status",
+      pending: healthPending,
     },
     {
       id: "live",
@@ -255,6 +265,7 @@ export function DashboardPage({
       tone: activityMeasured && (liveCount || 0) > 0 ? "accent" : undefined,
       view: "status",
       viewLabel: "Status",
+      pending: healthPending,
     },
     {
       id: "tokens",
@@ -268,6 +279,7 @@ export function DashboardPage({
           : `${exactNumber(tokens24h)} router tokens${requests24h === null ? "" : ` · ${exactNumber(requests24h)} ${plural(requests24h, "request")}`} · ${reportedTokens24h !== null ? "sum of provider rows" : "sum of recent event details"}`,
       view: "usage",
       viewLabel: "Usage",
+      pending: snapshotPending && !providerUsage,
     },
     {
       id: "reset",
@@ -281,6 +293,7 @@ export function DashboardPage({
           : "No connected account exposed a reset timestamp",
       view: "usage",
       viewLabel: "Usage",
+      pending: usagePending,
     },
     {
       id: "allowance",
@@ -298,6 +311,7 @@ export function DashboardPage({
       meter: lowestAllowance ? lowestAllowance.percent : undefined,
       view: "usage",
       viewLabel: "Usage",
+      pending: usagePending,
     },
   ];
 
@@ -319,13 +333,18 @@ export function DashboardPage({
         <InlineNotice tone="danger" title="Router health check failed">{health.error}</InlineNotice>
       ) : null}
 
-      <ServiceHealthPanel health={health} compact onOpen={() => onNavigate("status")} />
+      {healthPending ? (
+        <SkeletonBlock className="db-skeleton-health" />
+      ) : (
+        <ServiceHealthPanel health={health} compact onOpen={() => onNavigate("status")} />
+      )}
 
       <RouteDashboardPanel
         providers={routeProviders}
         routeMutations={routeMutations}
         api={api}
         onNavigate={onNavigate}
+        loading={routesPending}
       />
 
       <div className="db-summary-grid" role="list" aria-label="Router summary">
@@ -344,13 +363,17 @@ export function DashboardPage({
                 <Icon aria-hidden size={12} strokeWidth={1.8} />
                 {tile.label}
               </span>
-              <strong className="db-summary-value">{tile.value}</strong>
+              {tile.pending ? (
+                <SkeletonBlock className="db-skeleton-summary-value" />
+              ) : <strong className="db-summary-value">{tile.value}</strong>}
               {tile.meter === undefined ? null : (
                 <span className="db-summary-meter" aria-hidden="true">
                   <i style={{ width: `${Math.max(2, Math.min(100, tile.meter))}%` }} />
                 </span>
               )}
-              <small className="db-summary-detail">{tile.detail}</small>
+              {tile.pending ? (
+                <SkeletonBlock className="db-skeleton-summary-detail" />
+              ) : <small className="db-summary-detail">{tile.detail}</small>}
               <span className="db-summary-link" aria-hidden="true">
                 View {tile.viewLabel}
                 <ArrowUpRight aria-hidden size={11} strokeWidth={1.9} />
@@ -375,7 +398,9 @@ export function DashboardPage({
               </div>
             )}
           />
-          {!events ? (
+          {snapshotPending ? (
+            <PanelSkeleton label="Loading router traffic" count={4} />
+          ) : !events ? (
             <EmptyState
               icon={<BarChart3 size={20} />}
               title={refreshing ? "Reading router telemetry" : "Router telemetry unavailable"}
@@ -407,6 +432,7 @@ export function DashboardPage({
         events={events}
         providerUsage={providerUsage}
         refreshing={refreshing}
+        loading={snapshotPending && !providerUsage}
       />
 
       <div className="db-panel-grid db-dashboard-details">
@@ -421,7 +447,9 @@ export function DashboardPage({
               </Button>
             )}
           />
-          <div className="db-breakdown-stack">
+          {usagePending ? (
+            <PanelSkeleton label="Loading provider and model usage" count={4} />
+          ) : <div className="db-breakdown-stack">
             <BreakdownGroup
               title="Providers"
               emptyTitle={providerUsage ? "No metered provider traffic" : refreshing ? "Reading providers" : "Provider usage unavailable"}
@@ -435,7 +463,7 @@ export function DashboardPage({
               emptyBody={modelBreakdown.length ? "" : "A model appears after it serves a request with usage metadata."}
               rows={modelBreakdown}
             />
-          </div>
+          </div>}
         </section>
       </div>
 
@@ -450,7 +478,9 @@ export function DashboardPage({
             </Button>
           )}
         />
-        {recentEvents.length ? (
+        {snapshotPending ? (
+          <PanelSkeleton label="Loading recent router activity" count={5} />
+        ) : recentEvents.length ? (
           <div className="db-event-list">
             {recentEvents.map((event, index) => (
               <DashboardEventRow key={`${event.at}-${event.model || "model"}-${index}`} event={event} />
@@ -475,6 +505,7 @@ function RouteDashboardPanel({
   routeMutations,
   api,
   onNavigate,
+  loading,
 }: {
   providers: RouterDashboardSnapshot["providers"];
   routeMutations: {
@@ -483,6 +514,7 @@ function RouteDashboardPanel({
   };
   api?: RouterControlApi;
   onNavigate: (view: ViewId, modelFocus?: ModelViewFocus) => void;
+  loading: boolean;
 }) {
   const visible = providers.filter((provider) => provider.kind !== "per-model");
   return (
@@ -492,7 +524,9 @@ function RouteDashboardPanel({
         description="Enable or disable validated provider routes. Changes are saved atomically and shared with the tray."
         action={<Button variant="ghost" onClick={() => onNavigate("models")}>Manage models</Button>}
       />
-      {visible.length === 0 ? (
+      {loading ? (
+        <PanelSkeleton label="Loading provider routes" count={3} />
+      ) : visible.length === 0 ? (
         <EmptyState title="No provider routes" body="Connect a provider to make a route available here." />
       ) : (
         <div className="db-route-list" role="list" aria-label="Provider routes">
@@ -538,10 +572,12 @@ function TokenActivity({
   events,
   providerUsage,
   refreshing,
+  loading,
 }: {
   events?: UsageEvent[];
   providerUsage?: ProviderUsageSnapshot;
   refreshing: boolean;
+  loading: boolean;
 }) {
   const [mode, setMode] = useState<TokenActivityMode>("daily");
   const activity = useMemo(
@@ -590,7 +626,9 @@ function TokenActivity({
         </div>
       </div>
 
-      <div className="db-token-calendar-scroll">
+      {loading ? (
+        <PanelSkeleton label="Loading retained token activity" count={2} />
+      ) : <><div className="db-token-calendar-scroll">
         <div className="db-token-calendar">
           <div className="db-token-cells" role="grid" aria-label={`${capitalize(mode)} token activity for the last year`}>
             {viewDays.map((day) => {
@@ -639,7 +677,7 @@ function TokenActivity({
           {[0, 1, 2, 3, 4].map((level) => <i key={level} className={`level-${level}`} />)}
           More
         </span>
-      </div>
+      </div></>}
     </section>
   );
 }

--- a/apps/control-center/src/pages/DashboardPage.tsx
+++ b/apps/control-center/src/pages/DashboardPage.tsx
@@ -157,8 +157,9 @@ export function DashboardPage({
   const healthPending = !dataReady.health && !health;
   const snapshotPending = !dataReady.snapshot && !target;
   const routesPending = !dataReady.snapshot && !dashboard;
-  const usagePending = (!dataReady.accountUsage && !account)
-    || (!dataReady.providerUsage && !providerUsage);
+  const accountPending = !dataReady.accountUsage && !account;
+  const providerUsagePending = !dataReady.providerUsage && !providerUsage;
+  const quotaPending = !account && !providerUsage && (accountPending || providerUsagePending);
   // Every prop can be undefined on first paint and after a failed refresh, so
   // each tile below separates three cases: still loading, reported-but-absent,
   // and a genuine zero. A missing field must never render as 0.
@@ -293,7 +294,7 @@ export function DashboardPage({
           : "No connected account exposed a reset timestamp",
       view: "usage",
       viewLabel: "Usage",
-      pending: usagePending,
+      pending: quotaPending,
     },
     {
       id: "allowance",
@@ -311,7 +312,7 @@ export function DashboardPage({
       meter: lowestAllowance ? lowestAllowance.percent : undefined,
       view: "usage",
       viewLabel: "Usage",
-      pending: usagePending,
+      pending: quotaPending,
     },
   ];
 
@@ -447,7 +448,7 @@ export function DashboardPage({
               </Button>
             )}
           />
-          {usagePending ? (
+          {providerUsagePending ? (
             <PanelSkeleton label="Loading provider and model usage" count={4} />
           ) : <div className="db-breakdown-stack">
             <BreakdownGroup

--- a/apps/control-center/src/pages/LocalPage.tsx
+++ b/apps/control-center/src/pages/LocalPage.tsx
@@ -17,6 +17,7 @@ import {
   EmptyState,
   InlineNotice,
   PageHeader,
+  PanelSkeleton,
   SearchField,
   SectionHeading,
   StatStrip,
@@ -24,7 +25,7 @@ import {
 } from "../components";
 import { compactNumber, formatBytesGb } from "../lib";
 import { BrandLogo, brandForLocalModel } from "../provider-branding";
-import type { LocalModel, LocalModelsSnapshot, OperationEvent, RouterControlApi, RouterTarget, VisionEngine } from "../types";
+import type { LocalModel, LocalModelsSnapshot, OperationEvent, RouterControlApi, RouterDataReady, RouterTarget, VisionEngine } from "../types";
 import { useOptimisticValues, type RunAction } from "../useOptimisticValues";
 import "./local-harness-context.css";
 
@@ -32,12 +33,13 @@ interface LocalPageProps {
   target?: RouterTarget;
   api?: RouterControlApi;
   refreshing: boolean;
+  dataReady: RouterDataReady;
   operation?: OperationEvent | null;
   onRefresh: () => void;
   runAction: RunAction;
 }
 
-export function LocalPage({ target, api, refreshing, operation, onRefresh, runAction }: LocalPageProps) {
+export function LocalPage({ target, api, refreshing, dataReady, operation, onRefresh, runAction }: LocalPageProps) {
   const [installRef, setInstallRef] = useState("");
   const [forceInstall, setForceInstall] = useState(false);
   const [pendingRemoval, setPendingRemoval] = useState<string | null>(null);
@@ -117,7 +119,24 @@ export function LocalPage({ target, api, refreshing, operation, onRefresh, runAc
   }
 
   if (!target) {
-    return <EmptyState icon={<SearchX size={22} />} title="Local runtime unavailable" body="Start the router or refresh after setup completes." />;
+    return (
+      <div className="local-page">
+        <PageHeader
+          eyebrow="On-device inference"
+          title="Local"
+          description="Run, install, measure, and expose Ollama and curated MLX models without leaving the control center."
+          onRefresh={onRefresh}
+          refreshing={refreshing}
+        />
+        {!dataReady.snapshot ? (
+          <section className="panel-section" aria-label="Loading local models" aria-busy="true">
+            <PanelSkeleton label="Loading local model runtime" count={5} />
+          </section>
+        ) : (
+          <EmptyState icon={<SearchX size={22} />} title="Local runtime unavailable" body="Start the router or refresh after setup completes." />
+        )}
+      </div>
+    );
   }
 
   return (

--- a/apps/control-center/src/pages/ModelsPage.tsx
+++ b/apps/control-center/src/pages/ModelsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from "react";
 import { Check, ChevronDown, Filter, KeyRound, Link2, LogIn, MoreHorizontal, Plus, SearchX, ShieldCheck, Trash2 } from "lucide-react";
-import { Badge, Button, CatalogSkeleton, Dialog, EmptyState, PageHeader, SearchField, SkeletonBlock, Toggle } from "../components";
+import { Badge, Button, CatalogSkeleton, Dialog, EmptyState, PageHeader, PanelSkeleton, SearchField, SkeletonBlock, Toggle } from "../components";
 import { BrandLogo, ProviderLogo, brandForModel } from "../provider-branding";
 import { formatContext, formatDateTime } from "../lib";
 import {
@@ -25,6 +25,7 @@ import type {
   ProviderUsageSnapshot,
   RouterCatalogSnapshot,
   RouterControlApi,
+  RouterDataReady,
   RouterKnownModel,
   RouterModel,
   RouterTarget,
@@ -82,6 +83,7 @@ interface ModelsPageProps {
   usage?: ProviderUsageSnapshot;
   api?: RouterControlApi;
   refreshing: boolean;
+  dataReady: RouterDataReady;
   onRefresh: () => void;
   runAction: RunAction;
   focusRequest?: ModelViewFocusRequest;
@@ -139,7 +141,7 @@ function routeUsable(model: RouterModel): boolean {
   return model.available !== false;
 }
 
-export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onRefresh, runAction, focusRequest }: ModelsPageProps) {
+export function ModelsPage({ target, catalog, setup, usage, api, refreshing, dataReady, onRefresh, runAction, focusRequest }: ModelsPageProps) {
   const [modelSearch, setModelSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
@@ -466,7 +468,24 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
   }, [focusRequest]);
 
   if (!target) {
-    return <EmptyState icon={<SearchX size={22} />} title="Router snapshot unavailable" body="Start the router or refresh after setup completes." />;
+    return (
+      <div className="providers-models-page models-page">
+        <PageHeader
+          eyebrow="Models"
+          title="Models"
+          description="Choose which models your installed clients can use, and connect the accounts that serve them."
+          onRefresh={onRefresh}
+          refreshing={refreshing}
+        />
+        {!dataReady.snapshot ? (
+          <section className="panel-section pm-models-loading" aria-label="Loading models" aria-busy="true">
+            <PanelSkeleton label="Loading model routes" count={6} />
+          </section>
+        ) : (
+          <EmptyState icon={<SearchX size={22} />} title="Router snapshot unavailable" body="Start the router or refresh after setup completes." />
+        )}
+      </div>
+    );
   }
 
   const connectedProviderCount = directory.filter((entry) => providerConnected(entry, enabledProviders)).length;
@@ -548,7 +567,13 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
           refreshing={refreshing}
         />
 
-        <ConnectionsBar
+        {!dataReady.providers && !setup ? (
+          <section className="pm-connections pm-connections-loading" aria-label="Loading provider connections" aria-busy="true">
+            <SkeletonBlock />
+            <SkeletonBlock />
+            <SkeletonBlock />
+          </section>
+        ) : <ConnectionsBar
           directory={directory}
           enabledProviders={enabledProviders}
           usageById={usageById}
@@ -570,7 +595,7 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, onR
           }}
           onKey={(entry) => entry.setup && setCredentialProvider(entry.setup)}
           onRemove={(entry) => entry.setup && setRemoveProvider(entry.setup)}
-        />
+        />}
 
         <section className="panel-section pm-model-catalog" id="model-catalog-controls">
           <div className="pm-model-toolbar">

--- a/apps/control-center/src/pages/ModelsPage.tsx
+++ b/apps/control-center/src/pages/ModelsPage.tsx
@@ -431,6 +431,56 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, dat
     setManagedProviderId((current) => (current === providerId ? null : providerId));
   };
 
+  const renderConnections = () => !dataReady.providers && !setup ? (
+    <section className="pm-connections pm-connections-loading" aria-label="Loading provider connections" aria-busy="true">
+      <SkeletonBlock />
+      <SkeletonBlock />
+      <SkeletonBlock />
+    </section>
+  ) : (
+    <ConnectionsBar
+      directory={directory}
+      enabledProviders={enabledProviders}
+      usageById={usageById}
+      apiAvailable={Boolean(api)}
+      platform={api?.platform}
+      openProviderId={managedProviderId}
+      onOpenProvider={openProviderMenu}
+      onCloseProvider={() => setManagedProviderId(null)}
+      connectMenuOpen={connectMenuOpen}
+      onConnectMenuOpen={setConnectMenuOpen}
+      isEnabled={(entry) => optimisticProviders.value(entry.id, enabledProviders.has(entry.id) || entry.models.some((model) => model.native))}
+      onEnabledChange={(entry, checked) => {
+        if (!api) return;
+        void optimisticProviders.mutate(entry.id, checked, `${checked ? "Enable" : "Disable"} ${entry.displayName}`, () => api.setProviderEnabled(entry.id, checked));
+      }}
+      onSignIn={(entry) => {
+        if (!api || !entry.setup) return;
+        void runProviderCredentialAction(entry.setup, `Start ${entry.displayName} sign-in`, () => api.connectProvider(entry.id));
+      }}
+      onKey={(entry) => entry.setup && setCredentialProvider(entry.setup)}
+      onRemove={(entry) => entry.setup && setRemoveProvider(entry.setup)}
+    />
+  );
+  const renderConnectionDialogs = () => (
+    <>
+      <CredentialDialog
+        provider={credentialProvider}
+        onSave={(provider, secret) => api
+          ? runProviderCredentialAction(provider, `Save ${provider.displayName} credential`, () => api.saveProviderCredential(provider.id, secret))
+          : Promise.resolve()}
+        onClose={() => setCredentialProvider(null)}
+      />
+      <Dialog open={Boolean(removeProvider)} title="Disconnect provider" description="The provider is withdrawn from installed clients before its managed credential is deleted." onClose={() => setRemoveProvider(null)}>
+        <div className="pm-credential-warning"><ShieldCheck aria-hidden size={17} strokeWidth={1.7} /><p>If a credential also exists in the environment or Keychain, the router will still report it as connected.</p></div>
+        <div className="dialog-actions">
+          <Button variant="secondary" onClick={() => setRemoveProvider(null)}>Cancel</Button>
+          <Button variant="danger" onClick={() => { const provider = removeProvider; setRemoveProvider(null); if (provider && api) void runProviderCredentialAction(provider, `Remove ${provider.displayName} credential`, () => api.removeProviderCredential(provider.id)); }}><Trash2 aria-hidden size={14} strokeWidth={1.7} /> Disconnect</Button>
+        </div>
+      </Dialog>
+    </>
+  );
+
   const filteredFamilies = useMemo(() => {
     const needle = modelSearch.trim().toLowerCase();
     if (!needle && activeProviderFilter === "all") return families;
@@ -469,22 +519,26 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, dat
 
   if (!target) {
     return (
-      <div className="providers-models-page models-page">
-        <PageHeader
-          eyebrow="Models"
-          title="Models"
-          description="Choose which models your installed clients can use, and connect the accounts that serve them."
-          onRefresh={onRefresh}
-          refreshing={refreshing}
-        />
-        {!dataReady.snapshot ? (
-          <section className="panel-section pm-models-loading" aria-label="Loading models" aria-busy="true">
-            <PanelSkeleton label="Loading model routes" count={6} />
-          </section>
-        ) : (
-          <EmptyState icon={<SearchX size={22} />} title="Router snapshot unavailable" body="Start the router or refresh after setup completes." />
-        )}
-      </div>
+      <>
+        <div className="providers-models-page models-page">
+          <PageHeader
+            eyebrow="Models"
+            title="Models"
+            description="Choose which models your installed clients can use, and connect the accounts that serve them."
+            onRefresh={onRefresh}
+            refreshing={refreshing}
+          />
+          {renderConnections()}
+          {!dataReady.snapshot ? (
+            <section className="panel-section pm-models-loading" aria-label="Loading models" aria-busy="true">
+              <PanelSkeleton label="Loading model routes" count={6} />
+            </section>
+          ) : (
+            <EmptyState icon={<SearchX size={22} />} title="Router snapshot unavailable" body="Start the router or refresh after setup completes." />
+          )}
+        </div>
+        {renderConnectionDialogs()}
+      </>
     );
   }
 
@@ -567,35 +621,7 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, dat
           refreshing={refreshing}
         />
 
-        {!dataReady.providers && !setup ? (
-          <section className="pm-connections pm-connections-loading" aria-label="Loading provider connections" aria-busy="true">
-            <SkeletonBlock />
-            <SkeletonBlock />
-            <SkeletonBlock />
-          </section>
-        ) : <ConnectionsBar
-          directory={directory}
-          enabledProviders={enabledProviders}
-          usageById={usageById}
-          apiAvailable={Boolean(api)}
-          platform={api?.platform}
-          openProviderId={managedProviderId}
-          onOpenProvider={openProviderMenu}
-          onCloseProvider={() => setManagedProviderId(null)}
-          connectMenuOpen={connectMenuOpen}
-          onConnectMenuOpen={setConnectMenuOpen}
-          isEnabled={(entry) => optimisticProviders.value(entry.id, enabledProviders.has(entry.id) || entry.models.some((model) => model.native))}
-          onEnabledChange={(entry, checked) => {
-            if (!api) return;
-            void optimisticProviders.mutate(entry.id, checked, `${checked ? "Enable" : "Disable"} ${entry.displayName}`, () => api.setProviderEnabled(entry.id, checked));
-          }}
-          onSignIn={(entry) => {
-            if (!api || !entry.setup) return;
-            void runProviderCredentialAction(entry.setup, `Start ${entry.displayName} sign-in`, () => api.connectProvider(entry.id));
-          }}
-          onKey={(entry) => entry.setup && setCredentialProvider(entry.setup)}
-          onRemove={(entry) => entry.setup && setRemoveProvider(entry.setup)}
-        />}
+        {renderConnections()}
 
         <section className="panel-section pm-model-catalog" id="model-catalog-controls">
           <div className="pm-model-toolbar">
@@ -775,20 +801,7 @@ export function ModelsPage({ target, catalog, setup, usage, api, refreshing, dat
         onAdd={(selection) => void addCatalogModels(selection)}
         onClose={() => setAddModelsOpen(false)}
       />
-      <CredentialDialog
-        provider={credentialProvider}
-        onSave={(provider, secret) => api
-          ? runProviderCredentialAction(provider, `Save ${provider.displayName} credential`, () => api.saveProviderCredential(provider.id, secret))
-          : Promise.resolve()}
-        onClose={() => setCredentialProvider(null)}
-      />
-      <Dialog open={Boolean(removeProvider)} title="Disconnect provider" description="The provider is withdrawn from installed clients before its managed credential is deleted." onClose={() => setRemoveProvider(null)}>
-        <div className="pm-credential-warning"><ShieldCheck aria-hidden size={17} strokeWidth={1.7} /><p>If a credential also exists in the environment or Keychain, the router will still report it as connected.</p></div>
-        <div className="dialog-actions">
-          <Button variant="secondary" onClick={() => setRemoveProvider(null)}>Cancel</Button>
-          <Button variant="danger" onClick={() => { const provider = removeProvider; setRemoveProvider(null); if (provider && api) void runProviderCredentialAction(provider, `Remove ${provider.displayName} credential`, () => api.removeProviderCredential(provider.id)); }}><Trash2 aria-hidden size={14} strokeWidth={1.7} /> Disconnect</Button>
-        </div>
-      </Dialog>
+      {renderConnectionDialogs()}
     </>
   );
 }

--- a/apps/control-center/src/pages/StatusPage.tsx
+++ b/apps/control-center/src/pages/StatusPage.tsx
@@ -9,7 +9,7 @@ import {
   Server,
   Timer,
 } from "lucide-react";
-import { Badge, Button, EmptyState, PageHeader, SectionHeading } from "../components";
+import { Badge, Button, EmptyState, PageHeader, PanelSkeleton, SectionHeading, SkeletonBlock } from "../components";
 import { ProviderLogo } from "../provider-branding";
 import { ServiceHealthPanel } from "../ServiceHealth";
 import {
@@ -25,6 +25,7 @@ import type {
   ProviderUsageSnapshot,
   ProviderModelUsage,
   RouterControlApi,
+  RouterDataReady,
   RouterHealth,
   RouterTarget,
   UsageEvent,
@@ -88,6 +89,7 @@ export function StatusPage({
   providerUsage,
   api,
   refreshing,
+  dataReady,
   onRefresh,
   runAction,
 }: {
@@ -97,6 +99,7 @@ export function StatusPage({
   providerUsage?: ProviderUsageSnapshot;
   api?: RouterControlApi;
   refreshing: boolean;
+  dataReady: RouterDataReady;
   onRefresh: () => void;
   runAction: RunAction;
 }) {
@@ -105,6 +108,10 @@ export function StatusPage({
   const [repairing, setRepairing] = useState(false);
   const [contextSavingsRange, setContextSavingsRange] = useState<ContextSavingsRangeKey>("24h");
   const [contextSavingsRangeSelectedByUser, setContextSavingsRangeSelectedByUser] = useState(false);
+  const healthPending = !dataReady.health && !health;
+  const snapshotPending = !dataReady.snapshot && !target;
+  const usagePending = (!dataReady.accountUsage && !account)
+    || (!dataReady.providerUsage && !providerUsage);
   // The same repair Settings runs, reached from the panel where a stopped
   // service first becomes visible. Settings stays the only page that renders
   // the diagnostic report; here the toast plus the refreshed health rows are
@@ -236,36 +243,43 @@ export function StatusPage({
       value: health ? health.ok ? "Online" : "Offline" : refreshing ? "Checking" : "Unavailable",
       detail: health?.version ? `Version ${health.version}` : health?.error || "Local health endpoint",
       tone: health?.ok ? "success" : "danger",
+      pending: healthPending,
     },
     {
       label: "Running chats",
       value: exactNumber(chatCount),
       detail: "Unique active sessions",
+      pending: healthPending,
     },
     {
       label: "Running agents",
       value: exactNumber(runningAgentCount),
       detail: "Named subagents currently in flight",
+      pending: healthPending,
     },
     {
       label: "Live requests",
       value: exactNumber(activeRequestCount),
       detail: "Concurrent router work",
+      pending: healthPending,
     },
     {
       label: "Model speed",
       value: fastest ? Number(fastest.observedTokensPerSecond).toFixed(1) : "Unmeasured",
       detail: fastest ? `tok/s · ${fastest.displayName || fastest.slug || "fastest sample"}` : "After a metered reply",
+      pending: !dataReady.providerUsage && !providerUsage,
     },
     {
       label: "Context reused",
       value: hasCacheTelemetry ? compactNumber(cachedInputTokens) : "Not reported",
       detail: "Cached input, recent 24h",
+      pending: snapshotPending && !providerUsage,
     },
     {
       label: "Quota reset",
       value: nextReset ? resetCountdown(nextReset.resetAt) : "Not reported",
       detail: nextReset ? `${nextReset.provider}, ${nextReset.label}` : "No reset timestamp exposed",
+      pending: usagePending,
     },
   ];
 
@@ -281,10 +295,17 @@ export function StatusPage({
 
       <StatusSummary items={summary} />
 
-      <ServiceHealthPanel health={health} onRepair={api ? () => void repair() : undefined} repairing={repairing} />
+      {healthPending ? (
+        <section className="panel-section st-service-loading" aria-label="Loading service health" aria-busy="true">
+          <PanelSkeleton label="Loading service health" count={2} />
+        </section>
+      ) : (
+        <ServiceHealthPanel health={health} onRepair={api ? () => void repair() : undefined} repairing={repairing} />
+      )}
 
       <div className="st-primary-grid">
-        <section className="panel-section st-live-panel">
+        <section className={`panel-section st-live-panel${healthPending ? " is-partition-loading" : ""}`} aria-busy={healthPending}>
+          {healthPending ? <div className="st-partition-skeleton"><PanelSkeleton label="Loading live router activity" count={4} /></div> : null}
           <SectionHeading
             title="Router activity"
             description="Live work from the local health endpoint, grouped by chat and named agent."
@@ -355,7 +376,8 @@ export function StatusPage({
           )}
         </section>
 
-        <section className="panel-section st-context-panel">
+        <section className={`panel-section st-context-panel${snapshotPending && !providerUsage ? " is-partition-loading" : ""}`} aria-busy={snapshotPending && !providerUsage}>
+          {snapshotPending && !providerUsage ? <div className="st-partition-skeleton"><PanelSkeleton label="Loading context efficiency" count={4} /></div> : null}
           <SectionHeading
             title="Context efficiency"
             description="Accumulated cached input tokens saved across the last 24 hours, 7 days, and 30 days."
@@ -465,7 +487,9 @@ export function StatusPage({
             </label>
           ) : undefined}
         />
-        {visibleModels.length ? (
+        {!dataReady.providerUsage && !providerUsage ? (
+          <PanelSkeleton label="Loading model usage" count={6} />
+        ) : visibleModels.length ? (
           <>
             <div className="st-model-list" aria-label="Model usage">
               {visibleModels.map((model) => (
@@ -514,7 +538,9 @@ export function StatusPage({
             title="Quota resets"
             description="Reset timestamps from ChatGPT and connected provider account APIs."
           />
-          {resetRows.length ? (
+          {usagePending ? (
+            <PanelSkeleton label="Loading quota resets" count={3} />
+          ) : resetRows.length ? (
             <div className="st-reset-list">
               {resetRows.slice(0, 10).map((row) => (
                 <article key={row.id}>
@@ -549,7 +575,9 @@ export function StatusPage({
             title="Speed leaders"
             description="Fastest observed output rates from successful requests, not synthetic benchmarks."
           />
-          {speedRows.length ? (
+          {!dataReady.providerUsage && !providerUsage ? (
+            <PanelSkeleton label="Loading model speed" count={3} />
+          ) : speedRows.length ? (
             <div className="st-speed-list">
               {speedRows.slice(0, 12).map((model) => (
                 <article key={`${model.providerId}/${model.slug || model.displayName}`}>
@@ -588,7 +616,9 @@ export function StatusPage({
           title="Recent router activity"
           description="Privacy-safe events from the recent 24-hour telemetry window."
         />
-        {recentEvents.length ? (
+        {snapshotPending ? (
+          <PanelSkeleton label="Loading recent router activity" count={5} />
+        ) : recentEvents.length ? (
           <div className="st-event-list">
             {recentEvents.map((event, index) => (
               <EventRow key={`${event.at}-${event.model}-${index}`} event={event} />
@@ -660,15 +690,15 @@ function StatusModelRow({ model, peak }: { model: StatusModelUsage; peak: number
 }
 
 function StatusSummary({ items }: {
-  items: Array<{ label: string; value: string; detail: string; tone?: string }>;
+  items: Array<{ label: string; value: string; detail: string; tone?: string; pending?: boolean }>;
 }) {
   return (
     <dl className="st-summary-grid">
       {items.map((item) => (
         <div key={item.label} className={item.tone ? `tone-${item.tone}` : ""}>
           <dt>{item.label}</dt>
-          <dd>{item.value}</dd>
-          <small>{item.detail}</small>
+          {item.pending ? <SkeletonBlock className="st-skeleton-summary-value" /> : <dd>{item.value}</dd>}
+          {item.pending ? <SkeletonBlock className="st-skeleton-summary-detail" /> : <small>{item.detail}</small>}
         </div>
       ))}
     </dl>

--- a/apps/control-center/src/pages/UsagePage.tsx
+++ b/apps/control-center/src/pages/UsagePage.tsx
@@ -5,7 +5,7 @@ import {
   Coins,
   Gauge,
 } from "lucide-react";
-import { Badge, Button, EmptyState, PageHeader, SectionHeading, SkeletonBlock } from "../components";
+import { Badge, Button, EmptyState, PageHeader, PanelSkeleton, SectionHeading, SkeletonBlock } from "../components";
 import {
   bucketRange,
   compactNumber,
@@ -19,6 +19,7 @@ import type {
   ProviderUsage,
   ProviderUsageSnapshot,
   RouterControlApi,
+  RouterDataReady,
   RouterTarget,
   UsageBucket,
   UsageEvent,
@@ -82,6 +83,7 @@ export function UsagePage({
   providerUsage,
   api,
   refreshing,
+  dataReady,
   onRefresh,
   focusRequest,
 }: {
@@ -90,6 +92,7 @@ export function UsagePage({
   providerUsage?: ProviderUsageSnapshot;
   api?: RouterControlApi;
   refreshing: boolean;
+  dataReady: RouterDataReady;
   onRefresh: () => void;
   focusRequest?: { id: number; sourceId?: string; allowance: boolean };
 }) {
@@ -248,7 +251,7 @@ export function UsagePage({
       />
 
       {!source ? (
-        refreshing ? <UsageLoading /> : (
+        !dataReady.snapshot || !dataReady.accountUsage || !dataReady.providerUsage ? <UsageLoading /> : (
           <EmptyState
             icon={<BarChart3 size={22} />}
             title="No usage sources available"
@@ -331,7 +334,12 @@ export function UsagePage({
                       navigationFocused={allowanceFocused && row.id === targetAllowanceRowId}
                     />
                   ))}
+                  {!dataReady.accountUsage || !dataReady.providerUsage ? (
+                    <SkeletonBlock className="us-loading-metric" />
+                  ) : null}
                 </div>
+              ) : !dataReady.accountUsage || !dataReady.providerUsage ? (
+                <PanelSkeleton label="Loading account allowances" count={2} />
               ) : (
                 <EmptyState
                   icon={<Gauge size={20} />}
@@ -372,6 +380,12 @@ export function UsagePage({
                     onSelect={() => setSelected(entry.id)}
                   />
                 ))}
+                {!dataReady.providerUsage ? (
+                  <>
+                    <SkeletonBlock className="us-loading-source" />
+                    <SkeletonBlock className="us-loading-source" />
+                  </>
+                ) : null}
               </div>
               {sources.some((entry) => entry.kind === "subscription") ? (
                 <>

--- a/apps/control-center/src/pages/dashboard.css
+++ b/apps/control-center/src/pages/dashboard.css
@@ -24,6 +24,27 @@
   user-select: text;
 }
 
+.dashboard-page .db-skeleton-health {
+  min-height: 78px;
+  border-radius: 18px;
+}
+
+.dashboard-page .db-skeleton-summary-value {
+  width: 58%;
+  height: 24px;
+  margin-top: 10px;
+}
+
+.dashboard-page .db-skeleton-summary-detail {
+  width: 88%;
+  height: 20px;
+  margin-top: 8px;
+}
+
+.dashboard-page .panel-skeleton-item {
+  min-height: 52px;
+}
+
 /* ---------------------------------------------------------------- summary */
 
 .dashboard-page .db-summary-grid {

--- a/apps/control-center/src/pages/providers-models.css
+++ b/apps/control-center/src/pages/providers-models.css
@@ -61,6 +61,14 @@
   padding: 0;
 }
 
+.pm-models-loading {
+  min-height: 430px;
+}
+
+.pm-models-loading .panel-skeleton-item {
+  min-height: 58px;
+}
+
 .pm-model-toolbar {
   display: flex;
   min-width: 0;
@@ -750,6 +758,15 @@
   gap: 16px;
   flex-wrap: wrap;
   padding: 12px 14px;
+}
+
+.pm-connections-loading {
+  display: grid;
+  grid-template-columns: minmax(140px, 0.7fr) repeat(2, minmax(120px, 1fr));
+}
+
+.pm-connections-loading .skeleton-block {
+  min-height: 34px;
 }
 
 .pm-connections-label {

--- a/apps/control-center/src/pages/usage-status.css
+++ b/apps/control-center/src/pages/usage-status.css
@@ -963,6 +963,15 @@
 
 .usage-page .us-loading-panels .skeleton-block { min-height: 340px; }
 
+.usage-page .us-loading-metric {
+  min-height: 86px;
+}
+
+.usage-page .us-loading-source {
+  min-height: 52px;
+  border-radius: 8px;
+}
+
 /* Status */
 
 .status-page .st-primary-grid {
@@ -975,6 +984,39 @@
 .status-page {
   display: grid;
   gap: 24px;
+}
+
+.status-page .st-skeleton-summary-value {
+  width: 64%;
+  height: 24px;
+}
+
+.status-page .st-skeleton-summary-detail {
+  width: 84%;
+  height: 10px;
+  margin-top: 7px;
+}
+
+.status-page .st-service-loading {
+  min-height: 96px;
+}
+
+.status-page .is-partition-loading {
+  position: relative;
+  min-height: 280px;
+}
+
+.status-page .is-partition-loading > :not(.st-partition-skeleton) {
+  visibility: hidden;
+}
+
+.status-page .st-partition-skeleton {
+  position: absolute;
+  inset: 22px;
+}
+
+.status-page .st-partition-skeleton .panel-skeleton-item {
+  min-height: 48px;
 }
 
 .status-page .st-operations-column {

--- a/apps/control-center/src/types.ts
+++ b/apps/control-center/src/types.ts
@@ -10,6 +10,17 @@ export type ViewId =
 
 export type ModelViewFocus = "providers" | "models";
 
+/** Startup reads settle independently so a slow ledger or provider probe does
+ * not hold every page behind one application-wide loading state. */
+export interface RouterDataReady {
+  snapshot: boolean;
+  providers: boolean;
+  presence: boolean;
+  health: boolean;
+  accountUsage: boolean;
+  providerUsage: boolean;
+}
+
 export interface ModelViewFocusRequest {
   region: ModelViewFocus;
   id: number;

--- a/apps/control-center/test/renderer.test.mjs
+++ b/apps/control-center/test/renderer.test.mjs
@@ -14,7 +14,8 @@ const bridgeSource = String.raw`
 (() => {
   const calls = [];
   let navigationListener;
-  let usageDelayMs = 0;
+  let usageDelayMs = Number(new URLSearchParams(location.search).get("usageDelayMs")) || 0;
+  const providerDelayMs = Number(new URLSearchParams(location.search).get("providerDelayMs")) || 0;
   const subagents = { mode: "all", enabled: [], disabled: [], efforts: {}, proofs: {} };
   const selectedModel = {
     slug: "deepseek/deepseek-chat",
@@ -143,7 +144,10 @@ const bridgeSource = String.raw`
   window.routerControl = Object.freeze({
     platform: navigator.platform.toLowerCase().includes("mac") ? "darwin" : "linux",
     getSnapshot: async () => snapshot,
-    getProviders: async () => providers,
+    getProviders: async () => {
+      await new Promise((resolve) => setTimeout(resolve, providerDelayMs));
+      return providers;
+    },
     getPresence: async () => ({ mode: "always" }),
     getHealth: async () => ({ ok: true, activity: { state: "idle", active: [], activeCount: 0 } }),
     getAccountUsage: async () => {
@@ -458,6 +462,45 @@ test("the production renderer exposes model discovery and picker actions", { tim
       ["catalog-addable"],
     ]);
     assert.equal(calls.some((call) => call.name === "setPickerModels" && call.args[0] === true), true);
+    assert.deepEqual(pageErrors, [], `renderer errors: ${pageErrors.join("; ")}`);
+  } finally {
+    await browser.close();
+    await close();
+  }
+});
+
+test("slow usage reads do not block dashboard, health, or models", { timeout: 120_000 }, async () => {
+  assert.equal(existsSync(path.join(dist, "index.html")), true, "npm test must build the renderer first");
+  assert.ok(chromiumPath, "No Chromium executable is available for the Control Center renderer test.");
+
+  const { url, close } = await serveRenderer();
+  const browser = await chromium.launch({
+    executablePath: chromiumPath,
+    headless: true,
+    args: process.platform === "linux" ? ["--no-sandbox"] : [],
+  });
+  const pageErrors = [];
+  try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 840 } });
+    page.setDefaultTimeout(1_500);
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error") pageErrors.push(message.text());
+    });
+
+    await page.goto(`${url}?usageDelayMs=4000&providerDelayMs=3000`, { waitUntil: "domcontentloaded" });
+    await page.getByRole("heading", { name: "Dashboard", exact: true }).waitFor();
+    await page.locator(".service-health-strip").waitFor();
+    await page.locator(".db-breakdown-panel .panel-skeleton").waitFor();
+
+    await page.getByRole("button", { name: "Models", exact: true }).click();
+    await page.getByRole("heading", { name: "Models", exact: true }).waitFor();
+    await page.locator(".pm-family-row").filter({ hasText: "DeepSeek Chat" }).waitFor();
+    await page.locator(".pm-connections-loading").waitFor();
+
+    page.setDefaultTimeout(7_000);
+    await page.getByRole("button", { name: "Dashboard", exact: true }).click();
+    await page.locator(".db-breakdown-panel .panel-skeleton").waitFor({ state: "detached" });
     assert.deepEqual(pageErrors, [], `renderer errors: ${pageErrors.join("; ")}`);
   } finally {
     await browser.close();

--- a/apps/control-center/test/renderer.test.mjs
+++ b/apps/control-center/test/renderer.test.mjs
@@ -24,16 +24,22 @@ const bridgeSource = String.raw`
   const providerUsageDelay = searchParams.has("providerUsageDelayMs")
     ? Number(searchParams.get("providerUsageDelayMs")) || 0
     : null;
-  const rejectAccountUsageAfter = Number(searchParams.get("rejectAccountUsageAfter")) || 0;
+  const rejectAccountUsageRead = Number(searchParams.get("rejectAccountUsageRead")) || 0;
+  const staleAccountFailure = searchParams.get("staleAccountFailure") === "1";
   const staleProviderUsage = searchParams.get("staleProviderUsage") === "1";
   const pollOnceMs = Number(searchParams.get("pollOnceMs")) || 0;
+  const healthPollOnceMs = Number(searchParams.get("healthPollOnceMs")) || 0;
+  const staleHealth = searchParams.get("staleHealth") === "1";
   let accountUsageReads = 0;
   let providerUsageReads = 0;
-  if (pollOnceMs > 0) {
+  let healthReads = 0;
+  if (pollOnceMs > 0 || healthPollOnceMs > 0) {
     const nativeSetInterval = window.setInterval.bind(window);
-    window.setInterval = (callback, delay, ...args) => delay === 5 * 60_000
-      ? window.setTimeout(callback, pollOnceMs, ...args)
-      : nativeSetInterval(callback, delay, ...args);
+    window.setInterval = (callback, delay, ...args) => {
+      if (delay === 5 * 60_000 && pollOnceMs > 0) return window.setTimeout(callback, pollOnceMs, ...args);
+      if (delay === 1_000 && healthPollOnceMs > 0) return window.setTimeout(callback, healthPollOnceMs, ...args);
+      return nativeSetInterval(callback, delay, ...args);
+    };
   }
   const subagents = { mode: "all", enabled: [], disabled: [], efforts: {}, proofs: {} };
   const selectedModel = {
@@ -171,11 +177,22 @@ const bridgeSource = String.raw`
       return providers;
     },
     getPresence: async () => ({ mode: "always" }),
-    getHealth: async () => ({ ok: true, activity: { state: "idle", active: [], activeCount: 0 } }),
+    getHealth: async () => {
+      healthReads += 1;
+      const read = healthReads;
+      await new Promise((resolve) => setTimeout(resolve, staleHealth && read === 1 ? 400 : 0));
+      return staleHealth && read === 1
+        ? { ok: false, error: "Stale health response", activity: { state: "offline", active: [], activeCount: 0 } }
+        : { ok: true, version: "health-" + read, activity: { state: "idle", active: [], activeCount: 0 } };
+    },
     getAccountUsage: async () => {
       accountUsageReads += 1;
-      await new Promise((resolve) => setTimeout(resolve, accountDelay ?? usageDelayMs));
-      if (rejectAccountUsageAfter && accountUsageReads >= rejectAccountUsageAfter) {
+      const read = accountUsageReads;
+      await new Promise((resolve) => setTimeout(
+        resolve,
+        staleAccountFailure && read > 1 ? 0 : accountDelay ?? usageDelayMs,
+      ));
+      if ((staleAccountFailure && read === 1) || rejectAccountUsageRead === read) {
         throw new Error("Account usage poll failed");
       }
       return {
@@ -261,6 +278,7 @@ const bridgeSource = String.raw`
     },
     setUsageDelay: (milliseconds) => { usageDelayMs = milliseconds; },
     usageReads: () => ({ account: accountUsageReads, provider: providerUsageReads }),
+    healthReads: () => healthReads,
   });
 })();
 `;
@@ -553,7 +571,7 @@ test("independent control-center reads reveal each ready page region", { timeout
   }
 });
 
-test("usage polling surfaces rejections and ignores older overlapping results", { timeout: 120_000 }, async () => {
+test("usage polling surfaces current rejections, recovers, and ignores older results", { timeout: 120_000 }, async () => {
   assert.equal(existsSync(path.join(dist, "index.html")), true, "npm test must build the renderer first");
   assert.ok(chromiumPath, "No Chromium executable is available for the Control Center renderer test.");
 
@@ -572,7 +590,7 @@ test("usage polling surfaces rejections and ignores older overlapping results", 
       if (message.type() === "error") pageErrors.push(message.text());
     });
 
-    await page.goto(`${url}?providerUsageDelayMs=400&staleProviderUsage=1&rejectAccountUsageAfter=2&pollOnceMs=50`, {
+    await page.goto(`${url}?providerUsageDelayMs=400&staleProviderUsage=1&rejectAccountUsageRead=2&pollOnceMs=50`, {
       waitUntil: "domcontentloaded",
       timeout: 30_000,
     });
@@ -585,6 +603,78 @@ test("usage polling surfaces rejections and ignores older overlapping results", 
     assert.equal(
       await page.locator('.db-breakdown-list[aria-label="Providers usage breakdown"] .db-breakdown-value').innerText(),
       "24k",
+    );
+    await page.getByRole("button", { name: "Refresh all data", exact: true }).click();
+    await page.getByText("Account usage poll failed", { exact: true }).waitFor({ state: "detached" });
+    assert.deepEqual(pageErrors, [], `renderer errors: ${pageErrors.join("; ")}`);
+  } finally {
+    await browser.close();
+    await close();
+  }
+});
+
+test("an older rejected usage read cannot replace a newer success with a warning", { timeout: 120_000 }, async () => {
+  assert.equal(existsSync(path.join(dist, "index.html")), true, "npm test must build the renderer first");
+  assert.ok(chromiumPath, "No Chromium executable is available for the Control Center renderer test.");
+
+  const { url, close } = await serveRenderer();
+  const browser = await chromium.launch({
+    executablePath: chromiumPath,
+    headless: true,
+    args: process.platform === "linux" ? ["--no-sandbox"] : [],
+  });
+  const pageErrors = [];
+  try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 840 } });
+    page.setDefaultTimeout(10_000);
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error") pageErrors.push(message.text());
+    });
+
+    await page.goto(`${url}?accountDelayMs=400&staleAccountFailure=1&pollOnceMs=50`, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000,
+    });
+    await page.waitForFunction(() => window.routerControlTest.usageReads().account >= 2);
+    await page.waitForTimeout(450);
+    assert.equal(await page.getByText("Account usage poll failed", { exact: true }).count(), 0);
+    assert.deepEqual(pageErrors, [], `renderer errors: ${pageErrors.join("; ")}`);
+  } finally {
+    await browser.close();
+    await close();
+  }
+});
+
+test("health polling and core refresh share latest-wins ordering", { timeout: 120_000 }, async () => {
+  assert.equal(existsSync(path.join(dist, "index.html")), true, "npm test must build the renderer first");
+  assert.ok(chromiumPath, "No Chromium executable is available for the Control Center renderer test.");
+
+  const { url, close } = await serveRenderer();
+  const browser = await chromium.launch({
+    executablePath: chromiumPath,
+    headless: true,
+    args: process.platform === "linux" ? ["--no-sandbox"] : [],
+  });
+  const pageErrors = [];
+  try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 840 } });
+    page.setDefaultTimeout(10_000);
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error") pageErrors.push(message.text());
+    });
+
+    await page.goto(`${url}?staleHealth=1&healthPollOnceMs=50`, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000,
+    });
+    await page.waitForFunction(() => window.routerControlTest.healthReads() >= 2);
+    await page.waitForTimeout(450);
+    assert.match(await page.locator(".service-health-strip").innerText(), /ALL CLEAR/);
+    assert.match(
+      await page.getByRole("listitem", { name: /^Router state:/ }).getAttribute("aria-label"),
+      /version health-2/,
     );
     assert.deepEqual(pageErrors, [], `renderer errors: ${pageErrors.join("; ")}`);
   } finally {

--- a/apps/control-center/test/renderer.test.mjs
+++ b/apps/control-center/test/renderer.test.mjs
@@ -14,8 +14,27 @@ const bridgeSource = String.raw`
 (() => {
   const calls = [];
   let navigationListener;
-  let usageDelayMs = Number(new URLSearchParams(location.search).get("usageDelayMs")) || 0;
-  const providerDelayMs = Number(new URLSearchParams(location.search).get("providerDelayMs")) || 0;
+  const searchParams = new URLSearchParams(location.search);
+  let usageDelayMs = Number(searchParams.get("usageDelayMs")) || 0;
+  const snapshotDelayMs = Number(searchParams.get("snapshotDelayMs")) || 0;
+  const providerDelayMs = Number(searchParams.get("providerDelayMs")) || 0;
+  const accountDelay = searchParams.has("accountDelayMs")
+    ? Number(searchParams.get("accountDelayMs")) || 0
+    : null;
+  const providerUsageDelay = searchParams.has("providerUsageDelayMs")
+    ? Number(searchParams.get("providerUsageDelayMs")) || 0
+    : null;
+  const rejectAccountUsageAfter = Number(searchParams.get("rejectAccountUsageAfter")) || 0;
+  const staleProviderUsage = searchParams.get("staleProviderUsage") === "1";
+  const pollOnceMs = Number(searchParams.get("pollOnceMs")) || 0;
+  let accountUsageReads = 0;
+  let providerUsageReads = 0;
+  if (pollOnceMs > 0) {
+    const nativeSetInterval = window.setInterval.bind(window);
+    window.setInterval = (callback, delay, ...args) => delay === 5 * 60_000
+      ? window.setTimeout(callback, pollOnceMs, ...args)
+      : nativeSetInterval(callback, delay, ...args);
+  }
   const subagents = { mode: "all", enabled: [], disabled: [], efforts: {}, proofs: {} };
   const selectedModel = {
     slug: "deepseek/deepseek-chat",
@@ -143,7 +162,10 @@ const bridgeSource = String.raw`
 
   window.routerControl = Object.freeze({
     platform: navigator.platform.toLowerCase().includes("mac") ? "darwin" : "linux",
-    getSnapshot: async () => snapshot,
+    getSnapshot: async () => {
+      await new Promise((resolve) => setTimeout(resolve, snapshotDelayMs));
+      return snapshot;
+    },
     getProviders: async () => {
       await new Promise((resolve) => setTimeout(resolve, providerDelayMs));
       return providers;
@@ -151,7 +173,11 @@ const bridgeSource = String.raw`
     getPresence: async () => ({ mode: "always" }),
     getHealth: async () => ({ ok: true, activity: { state: "idle", active: [], activeCount: 0 } }),
     getAccountUsage: async () => {
-      await new Promise((resolve) => setTimeout(resolve, usageDelayMs));
+      accountUsageReads += 1;
+      await new Promise((resolve) => setTimeout(resolve, accountDelay ?? usageDelayMs));
+      if (rejectAccountUsageAfter && accountUsageReads >= rejectAccountUsageAfter) {
+        throw new Error("Account usage poll failed");
+      }
       return {
         fetchedAt: "2026-08-27T08:00:00.000Z",
         planType: "pro",
@@ -166,16 +192,24 @@ const bridgeSource = String.raw`
       };
     },
     getProviderUsage: async () => {
-      await new Promise((resolve) => setTimeout(resolve, usageDelayMs));
+      providerUsageReads += 1;
+      const read = providerUsageReads;
+      await new Promise((resolve) => setTimeout(
+        resolve,
+        staleProviderUsage && read > 1 ? 0 : providerUsageDelay ?? usageDelayMs,
+      ));
+      const totalTokens = staleProviderUsage && read > 1 ? 24000 : 12000;
       return {
         fetchedAt: "2026-08-27T08:00:00.000Z",
         providers: [{
           id: "deepseek",
           displayName: "DeepSeek",
           credentialType: "api",
-          totalTokens: 12000,
+          totalTokens,
           requests: 8,
-          dailyUsageBuckets: [{ startDate: "2026-08-27", tokens: 12000, requests: 8 }],
+          last24hTokens: totalTokens,
+          last24hRequests: 8,
+          dailyUsageBuckets: [{ startDate: "2026-08-27", tokens: totalTokens, requests: 8 }],
           account: {
             status: "available",
             metrics: [
@@ -226,6 +260,7 @@ const bridgeSource = String.raw`
       return true;
     },
     setUsageDelay: (milliseconds) => { usageDelayMs = milliseconds; },
+    usageReads: () => ({ account: accountUsageReads, provider: providerUsageReads }),
   });
 })();
 `;
@@ -469,7 +504,7 @@ test("the production renderer exposes model discovery and picker actions", { tim
   }
 });
 
-test("slow usage reads do not block dashboard, health, or models", { timeout: 120_000 }, async () => {
+test("independent control-center reads reveal each ready page region", { timeout: 120_000 }, async () => {
   assert.equal(existsSync(path.join(dist, "index.html")), true, "npm test must build the renderer first");
   assert.ok(chromiumPath, "No Chromium executable is available for the Control Center renderer test.");
 
@@ -482,25 +517,75 @@ test("slow usage reads do not block dashboard, health, or models", { timeout: 12
   const pageErrors = [];
   try {
     const page = await browser.newPage({ viewport: { width: 1280, height: 840 } });
-    page.setDefaultTimeout(1_500);
+    page.setDefaultTimeout(10_000);
     page.on("pageerror", (error) => pageErrors.push(error.message));
     page.on("console", (message) => {
       if (message.type() === "error") pageErrors.push(message.text());
     });
 
-    await page.goto(`${url}?usageDelayMs=4000&providerDelayMs=3000`, { waitUntil: "domcontentloaded" });
+    await page.goto(`${url}?snapshotDelayMs=3000&accountDelayMs=4000`, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000,
+    });
+    // Only the responsiveness checks use the tight budget. A cold browser
+    // navigation includes process and module startup and needs a normal timeout.
+    page.setDefaultTimeout(1_500);
     await page.getByRole("heading", { name: "Dashboard", exact: true }).waitFor();
     await page.locator(".service-health-strip").waitFor();
-    await page.locator(".db-breakdown-panel .panel-skeleton").waitFor();
+    await page.locator('.db-breakdown-list[aria-label="Providers usage breakdown"]')
+      .getByText("DeepSeek", { exact: true })
+      .waitFor();
+    assert.equal(await page.locator(".db-breakdown-panel .panel-skeleton").count(), 0);
 
     await page.getByRole("button", { name: "Models", exact: true }).click();
     await page.getByRole("heading", { name: "Models", exact: true }).waitFor();
-    await page.locator(".pm-family-row").filter({ hasText: "DeepSeek Chat" }).waitFor();
-    await page.locator(".pm-connections-loading").waitFor();
+    const connections = page.locator(".pm-connections:not(.pm-connections-loading)");
+    await connections.waitFor();
+    assert.match(await connections.innerText(), /DeepSeek/);
+    await page.locator(".pm-models-loading").waitFor();
 
     page.setDefaultTimeout(7_000);
-    await page.getByRole("button", { name: "Dashboard", exact: true }).click();
-    await page.locator(".db-breakdown-panel .panel-skeleton").waitFor({ state: "detached" });
+    await page.locator(".pm-family-row").filter({ hasText: "DeepSeek Chat" }).waitFor();
+    assert.deepEqual(pageErrors, [], `renderer errors: ${pageErrors.join("; ")}`);
+  } finally {
+    await browser.close();
+    await close();
+  }
+});
+
+test("usage polling surfaces rejections and ignores older overlapping results", { timeout: 120_000 }, async () => {
+  assert.equal(existsSync(path.join(dist, "index.html")), true, "npm test must build the renderer first");
+  assert.ok(chromiumPath, "No Chromium executable is available for the Control Center renderer test.");
+
+  const { url, close } = await serveRenderer();
+  const browser = await chromium.launch({
+    executablePath: chromiumPath,
+    headless: true,
+    args: process.platform === "linux" ? ["--no-sandbox"] : [],
+  });
+  const pageErrors = [];
+  try {
+    const page = await browser.newPage({ viewport: { width: 1280, height: 840 } });
+    page.setDefaultTimeout(10_000);
+    page.on("pageerror", (error) => pageErrors.push(error.message));
+    page.on("console", (message) => {
+      if (message.type() === "error") pageErrors.push(message.text());
+    });
+
+    await page.goto(`${url}?providerUsageDelayMs=400&staleProviderUsage=1&rejectAccountUsageAfter=2&pollOnceMs=50`, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000,
+    });
+    await page.waitForFunction(() => {
+      const reads = window.routerControlTest.usageReads();
+      return reads.account >= 2 && reads.provider >= 2;
+    });
+    await page.getByText("Account usage poll failed", { exact: true }).waitFor();
+    await page.waitForTimeout(450);
+    assert.equal(
+      await page.locator('.db-breakdown-list[aria-label="Providers usage breakdown"] .db-breakdown-value').innerText(),
+      "24k",
+    );
     assert.deepEqual(pageErrors, [], `renderer errors: ${pageErrors.join("; ")}`);
   } finally {
     await browser.close();

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -858,6 +858,10 @@ test("background usage polling is conservative while manual refresh stays immedi
   assert.doesNotMatch(source, /usageTimer = window\.setInterval\(\(\) => void refreshUsage\(\), 30_000\)/);
   assert.match(source, /Promise\.allSettled\(\[refreshCore\(\), refreshUsage\(\)\]\)/);
   assert.match(source, /Promise\.allSettled\(\[[\s\S]*api\.getSnapshot\(\)[\s\S]*api\.getHealth\(\)/);
+  assert.match(source, /settleRead\("snapshot", api\.getSnapshot\(\), setSnapshot\)/);
+  assert.match(source, /settleRead\("providers", api\.getProviders\(\), setProviders\)/);
+  assert.match(source, /settleRead\("providerUsage", api\.getProviderUsage\(\), setProviderUsage\)/);
+  assert.doesNotMatch(source, /loading \? <LoadingState \/> : page/);
   assert.match(source, /downloadPollInFlight\.current/);
   assert.match(source, /healthPollInFlight\.current/);
   assert.match(source, /document\.visibilityState !== "visible"/);


### PR DESCRIPTION
## Summary
- replace the application-wide startup gate with independently settling data reads
- render layout-matched loading skeletons for Dashboard, Status, Usage, Models, and Local sections
- keep resolved sections interactive while slower provider and usage reads finish
- preserve existing content during manual refreshes and surface partial read failures

## Verification
- `npm run check` in `apps/control-center`
- `npm test` in `apps/control-center` (58 tests)
- production Vite build
- renderer regression with provider setup delayed 3s and usage delayed 4s
- visual browser checks for Dashboard, Models, Usage, and Status with delayed partitions and no console errors