### PR TITLE
Add local GLM-5.3 and GLM-5.3-Flash models

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,11 +1224,11 @@ For reading images only — cannot code:
   moondream            1.7 GB  captions-only
 ```
 
-The tray's **View more** panel also exposes the full 201-tag snapshot captured
-from the official Ollama pages for Gemma 4, Qwen 3.5/3.6/3.8, Nemotron 3 Super,
-Ornith, Nemotron 3, and Muse Glimmer, including quantized and MLX variants.
-Cloud aliases are listed for completeness but marked cloud-only and cannot be
-downloaded as local weights.
+The tray's **View more** panel also exposes the full 213-tag snapshot: official
+Ollama tags for Gemma 4, Qwen 3.5/3.6/3.8, Nemotron 3 Super, Ornith, Nemotron 3,
+and Muse Glimmer, plus the Ollama-compatible Unsloth GGUF variants of GLM-5.3
+and GLM-5.3-Flash. Cloud aliases are listed for completeness but marked
+cloud-only and cannot be downloaded as local weights.
 
 A tool template is a floor, not a prediction — it has been wrong in both
 directions here. What settles it is running the real client:

--- a/apps/control-center/src/pages/LocalPage.tsx
+++ b/apps/control-center/src/pages/LocalPage.tsx
@@ -290,7 +290,7 @@ export function LocalPage({ target, api, refreshing, operation, onRefresh, runAc
                       {family.researchNote ? <p className="lhc-catalog-note">{family.researchNote}</p> : null}
                       <div className="lhc-catalog-model-list">
                         {family.models.map((model) => (
-                          <CatalogModelRow key={model.tag} model={model} onSelect={() => setInstallRef(model.tag)} />
+                          <CatalogModelRow key={model.tag} model={model} allowOversized={forceInstall} onSelect={() => setInstallRef(model.tag)} />
                         ))}
                       </div>
                     </div>
@@ -472,7 +472,7 @@ function familySummary(models: LocalModel[]): string {
   return "no local variant fits";
 }
 
-function CatalogModelRow({ model, onSelect }: { model: LocalModel; onSelect: () => void }) {
+function CatalogModelRow({ model, allowOversized, onSelect }: { model: LocalModel; allowOversized: boolean; onSelect: () => void }) {
   const downloadable = model.downloadable !== false;
   const tooLarge = model.fit === "too-large" || model.diskFit === "too-large";
   const fitLabel = model.downloadable === false
@@ -491,7 +491,7 @@ function CatalogModelRow({ model, onSelect }: { model: LocalModel; onSelect: () 
         <small>{model.tag}{model.sizeGb !== undefined ? ` · ${formatBytesGb(model.sizeGb)}` : ""}{model.context ? ` · ${compactNumber(model.context)} context` : ""}</small>
       </div>
       <Badge tone={tone}>{fitLabel}</Badge>
-      <Button variant="ghost" disabled={!downloadable || tooLarge} onClick={onSelect}>
+      <Button variant="ghost" disabled={!downloadable || (tooLarge && !allowOversized)} onClick={onSelect}>
         <Download aria-hidden size={13} strokeWidth={1.7} /> Select
       </Button>
     </article>

--- a/apps/control-center/src/pages/local-harness-context.css
+++ b/apps/control-center/src/pages/local-harness-context.css
@@ -191,6 +191,7 @@
 }
 
 .lhc-catalog-family-trigger > div {
+  flex: 1;
   min-width: 0;
 }
 

--- a/apps/control-center/test/renderer.test.mjs
+++ b/apps/control-center/test/renderer.test.mjs
@@ -67,7 +67,35 @@ const bridgeSource = String.raw`
     modelSettings: {
       subagents,
       picker: { hidden: [], visible: [selectedModel.slug], hasExplicitVisibility: true },
-      localModels: {},
+      localModels: {
+        available: [],
+        availableVision: [],
+        availableExplore: [{
+          tag: "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-IQ1_S",
+          family: "hf.co/unsloth/GLM-5.3-Flash-GGUF",
+          variant: "UD-IQ1_S",
+          displayName: "GLM-5.3-Flash · UD-IQ1_S",
+          sizeGb: 93.1,
+          context: 1048576,
+          fit: "too-large",
+          diskFit: "fits",
+          downloadable: true,
+          researchStatus: "Unsloth GGUF · 7 local quants",
+          researchCapabilities: ["vision", "tools", "thinking"],
+          researchNote: "Community quantization; capability and Codex checks run after pull.",
+        }],
+        families: [{
+          family: "hf.co/unsloth/GLM-5.3-Flash-GGUF",
+          displayName: "GLM-5.3-Flash",
+          variants: ["UD-IQ1_S"],
+        }],
+        installed: 0,
+        enabled: 0,
+        models: [],
+        totalGb: 0,
+        machine: "16 GB unified memory",
+        runtime: { installed: true, running: true, managed: true, version: "test" },
+      },
       visionBridge: { enabled: false },
     },
   };
@@ -458,6 +486,24 @@ test("the production renderer exposes model discovery and picker actions", { tim
       ["catalog-addable"],
     ]);
     assert.equal(calls.some((call) => call.name === "setPickerModels" && call.args[0] === true), true);
+
+    // Huge community GGUFs stay guarded, but the explicit oversized-model
+    // acknowledgement must make their exact Ollama tag selectable. Otherwise
+    // the catalog advertises GLM while forcing the operator to retype it.
+    await page.getByRole("button", { name: "Local", exact: true }).click();
+    await page.getByRole("heading", { name: "Local", exact: true }).waitFor();
+    const glmFamily = page.locator(".lhc-catalog-family").filter({ hasText: "GLM-5.3-Flash" });
+    await glmFamily.locator(".lhc-catalog-family-trigger").click();
+    const glmRow = glmFamily.locator(".lhc-catalog-model").filter({ hasText: "UD-IQ1_S" });
+    const glmSelect = glmRow.getByRole("button", { name: "Select", exact: true });
+    assert.equal(await glmSelect.isDisabled(), true);
+    await page.getByRole("checkbox", { name: "Allow a model larger than the router recommends for this machine" }).check();
+    assert.equal(await glmSelect.isEnabled(), true);
+    await glmSelect.click();
+    assert.equal(
+      await page.getByRole("textbox", { name: "Model tag or Ollama URL" }).inputValue(),
+      "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-IQ1_S",
+    );
     assert.deepEqual(pageErrors, [], `renderer errors: ${pageErrors.join("; ")}`);
   } finally {
     await browser.close();

--- a/docs/LOCAL-MODELS.md
+++ b/docs/LOCAL-MODELS.md
@@ -33,11 +33,13 @@ not start a second Ollama pull or removal.
 The native macOS tray's **View more** panel and the Windows/Linux panel's
 **Discover Ollama** section include the complete tag inventories captured from
 the official Ollama pages for Gemma 4, Qwen 3.5/3.6/3.8, Nemotron 3 Super,
-Ornith, Nemotron 3, and Muse Glimmer. That includes quantized, MLX, BF16, and other
-published variants—not only the family aliases. Cloud aliases are shown for
-completeness but are labelled **cloud only** and cannot be downloaded as local
-weights. The manifest is a dated snapshot, so arbitrary Ollama tags and model
-URLs remain supported even when a newly published tag has not been added yet.
+Ornith, Nemotron 3, and Muse Glimmer. They also include the Ollama-compatible
+Unsloth GGUF variants of GLM-5.3 and GLM-5.3-Flash. That includes quantized,
+MLX, BF16, and other published variants—not only the family aliases. Cloud
+aliases are shown for completeness but are labelled **cloud only** and cannot
+be downloaded as local weights. The manifest is a dated snapshot, so arbitrary
+Ollama tags and ollama.com model URLs remain supported even when a newly
+published tag has not been added yet.
 An installed model's generation speed is measured on demand with the **Speed**
 button and reported as tokens/second; unmeasured models never receive a guessed
 number.
@@ -45,10 +47,10 @@ number.
 Every model in the catalog is listed and installable, including ones this
 machine is rated too small for. The two shortlists above the catalog—the coding
 quick picks and the image readers—are recommendations and only show what fits,
-but nothing is ever removed from the catalog itself: a model that will not fit
-is labelled **won't fit**, and its button reads **Anyway** and asks for
-confirmation before spending the gigabytes. Hiding those entries previously left
-them with no install path at all on a small machine.
+but nothing is ever removed from the catalog itself. A model that will not fit
+is labelled **won't fit**; acknowledge **Allow a model larger than the router
+recommends for this machine** before selecting it. The install still asks for
+confirmation before spending the gigabytes.
 
 Useful commands:
 

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -2266,9 +2266,20 @@ async function handleLocalModels(action, value, ...rest) {
     }
     const cancelled = () => readLocalDownload()?.status === "cancelled";
     try {
-      const { fetchRegistryCapabilities, detectMachine, fitAdvisory, rateDiskFit, rateModelFit } =
-        await import("./local-models.mjs");
-      const advertised = await fetchRegistryCapabilities(tag);
+      const {
+        EXPLORE_LOCAL_MODELS,
+        fetchRegistryCapabilities,
+        detectMachine,
+        fitAdvisory,
+        rateDiskFit,
+        rateModelFit,
+      } = await import("./local-models.mjs");
+      // Hugging Face namespaced tags are pulled directly by Ollama and do not
+      // have a registry.ollama.ai manifest. Their checked-in catalog size is
+      // still authoritative enough for the safety gate: without this fallback
+      // a 93-467 GB GLM download could bypass the explicit --force consent.
+      const advertised = await fetchRegistryCapabilities(tag)
+        || EXPLORE_LOCAL_MODELS.find((entry) => entry.tag === tag);
       if (cancelled()) return;
       // A missing tool template costs nothing to discover afterwards; gigabytes
       // that cannot run cost the download and the disk. So the tool note stays

--- a/src/local-models.mjs
+++ b/src/local-models.mjs
@@ -524,7 +524,7 @@ export function localModelsSnapshot({
     }
     const current = families.get(identity.family) || {
       family: identity.family,
-      displayName: localModelDisplayName(tag),
+      displayName: LOCAL_FAMILY_RESEARCH[identity.family]?.displayName || localModelDisplayName(tag),
       variants: [],
     };
     if (!current.variants.includes(identity.variant)) current.variants.push(identity.variant);

--- a/src/local-ollama-catalog.mjs
+++ b/src/local-ollama-catalog.mjs
@@ -1,9 +1,12 @@
-// Official Ollama tag-page capture for the model families surfaced in
-// the local-model tray. Cloud aliases stay discoverable but are explicitly
-// non-downloadable: they route through Ollama cloud and have no local weights.
-// Refresh this manifest when the upstream tag pages change; arbitrary tags
-// and model-page URLs remain supported by the install field.
-// Captured from the official pages on 2026-08-11; qwen3.8 captured 2026-08-15.
+// Ollama-compatible model capture for the families surfaced in the local-model
+// tray. Most entries come from official Ollama tag pages. The namespaced GLM
+// entries come from Unsloth's Hugging Face GGUF repositories, whose model cards
+// publish exact `ollama run hf.co/...` commands. Cloud aliases stay discoverable
+// but are explicitly non-downloadable: they route through Ollama cloud and have
+// no local weights. Refresh this manifest when those upstream pages change;
+// arbitrary tags and model-page URLs remain supported by the install field.
+// Official pages captured 2026-08-11; qwen3.8 captured 2026-08-15; GLM GGUFs
+// captured 2026-08-29.
 
 // The tag list is intentionally exhaustive, but the tray should not make a
 // first-time user choose between every quantization and accelerator build.
@@ -54,6 +57,18 @@ export const LOCAL_FAMILY_RESEARCH = Object.freeze({
     status: "Official Ollama · 15 tags",
     capabilities: Object.freeze(["vision", "tools", "thinking"]),
     note: "Meta's 30B open model for long-running local agents and tool use.",
+  }),
+  "hf.co/unsloth/GLM-5.3-GGUF": Object.freeze({
+    displayName: "GLM-5.3",
+    status: "Unsloth GGUF · 5 local quants",
+    capabilities: Object.freeze(["tools", "thinking"]),
+    note: "Community quantizations of Z.ai's 754B model. Even the smallest build is about 217 GB; capability and Codex checks run after pull.",
+  }),
+  "hf.co/unsloth/GLM-5.3-Flash-GGUF": Object.freeze({
+    displayName: "GLM-5.3-Flash",
+    status: "Unsloth GGUF · 7 local quants",
+    capabilities: Object.freeze(["vision", "tools", "thinking"]),
+    note: "Community quantizations of Z.ai's 321B multimodal model. The smallest build is about 93.1 GB; capability and Codex checks run after pull.",
   }),
 });
 
@@ -260,6 +275,17 @@ export const EXPLORE_LOCAL_MODELS = Object.freeze(
     {"tag": "muse-glimmer:30b-q4_K_M", "sizeGb": 18, "tools": false, "context": 131072, "codex": "unverified", "displayName": "Muse Glimmer · 30b q4_K_M", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
     {"tag": "muse-glimmer:30b-q8_0", "sizeGb": 31, "tools": false, "context": 131072, "codex": "unverified", "displayName": "Muse Glimmer · 30b q8_0", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
     {"tag": "muse-glimmer:30b-bf16", "sizeGb": 57, "tools": false, "context": 131072, "codex": "unverified", "displayName": "Muse Glimmer · 30b bf16", "note": "Official Ollama tag; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-GGUF:UD-IQ1_S", "sizeGb": 217, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3 · UD-IQ1_S", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-GGUF:UD-IQ1_M", "sizeGb": 228, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3 · UD-IQ1_M", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-GGUF:UD-Q2_K_XL", "sizeGb": 254, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3 · UD-Q2_K_XL", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-GGUF:UD-Q3_K_XL", "sizeGb": 343, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3 · UD-Q3_K_XL", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-GGUF:UD-Q4_K_XL", "sizeGb": 467, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3 · UD-Q4_K_XL", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-IQ1_S", "sizeGb": 93.1, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3-Flash · UD-IQ1_S", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-IQ1_M", "sizeGb": 97.6, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3-Flash · UD-IQ1_M", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-Q2_K_XL", "sizeGb": 109, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3-Flash · UD-Q2_K_XL", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-IQ3_XXS", "sizeGb": 120, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3-Flash · UD-IQ3_XXS", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-Q3_K_XL", "sizeGb": 148, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3-Flash · UD-Q3_K_XL", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-IQ4_XS", "sizeGb": 157, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3-Flash · UD-IQ4_XS", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
+    {"tag": "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-Q4_K_XL", "sizeGb": 200, "tools": false, "context": 1048576, "codex": "unverified", "displayName": "GLM-5.3-Flash · UD-Q4_K_XL", "note": "Unsloth community GGUF for local Ollama; capabilities are checked after pull.", "downloadable": true},
   ].map((entry) => Object.freeze(entry)),
 );
-

--- a/test/local-llm.test.mjs
+++ b/test/local-llm.test.mjs
@@ -714,6 +714,16 @@ test("install accepts --yes and --force together, in either order", () => {
   }
 });
 
+test("cataloged Hugging Face GGUFs require the oversized-model override", () => {
+  const tag = "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-IQ1_S";
+  const refused = runLocalModels("install", tag, "--yes");
+  assert.notEqual(refused.status, 0);
+  const state = JSON.parse(readFileSync(path.join(refused.childState, "download.json"), "utf8"));
+  assert.equal(state.status, "error");
+  assert.match(state.error, /Pass --force to download it anyway/);
+  assert.match(state.error, /needs about 112 GB to run/);
+});
+
 test("a missing Ollama is named as installable rather than reported as absent", () => {
   // Without --yes the command must say what to do next, not just that Ollama is
   // missing: one flag installs the runtime headlessly and then the model.

--- a/test/local-models.test.mjs
+++ b/test/local-models.test.mjs
@@ -505,11 +505,15 @@ test("the explore catalog groups the requested Ollama families and keeps fit vis
     "nemotron3:33b-q8",
     "muse-glimmer:30b",
     "muse-glimmer:30b-mlx-bf16-dflash",
+    "hf.co/unsloth/GLM-5.3-GGUF:UD-IQ1_S",
+    "hf.co/unsloth/GLM-5.3-GGUF:UD-Q4_K_XL",
+    "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-IQ1_S",
+    "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-Q4_K_XL",
   ]) assert.ok(tags.has(tag), tag);
   assert.equal(entries.find((entry) => entry.tag === "nemotron-3-super:120b").fit, "too-large");
   assert.equal(entries.find((entry) => entry.tag === "gemma4:12b").tools, false);
-  assert.equal(EXPLORE_LOCAL_MODELS.length, 201);
-  assert.equal(new Set(EXPLORE_LOCAL_MODELS.map((entry) => entry.tag)).size, 201);
+  assert.equal(EXPLORE_LOCAL_MODELS.length, 213);
+  assert.equal(new Set(EXPLORE_LOCAL_MODELS.map((entry) => entry.tag)).size, 213);
   // The qwen3.8 capture (2026-08-15): 12 official 27B tags, 256K context.
   assert.equal(
     entries.find((entry) => entry.tag === "qwen3.8:27b").researchStatus,
@@ -549,6 +553,34 @@ test("the explore catalog groups the requested Ollama families and keeps fit vis
   assert.deepEqual(
     entries.find((entry) => entry.tag === "nemotron-3.5-lightning:latest").researchCapabilities,
     ["tools", "thinking"],
+  );
+  const glm = entries.find((entry) => entry.tag === "hf.co/unsloth/GLM-5.3-GGUF:UD-IQ1_S");
+  assert.equal(glm.sizeGb, 217);
+  assert.equal(glm.context, 1_048_576);
+  assert.equal(glm.fit, "too-large");
+  assert.equal(glm.downloadable, true);
+  assert.equal(glm.researchStatus, "Unsloth GGUF · 5 local quants");
+  assert.deepEqual(glm.researchCapabilities, ["tools", "thinking"]);
+  const glmFlash = entries.find((entry) => entry.tag === "hf.co/unsloth/GLM-5.3-Flash-GGUF:UD-IQ1_S");
+  assert.equal(glmFlash.sizeGb, 93.1);
+  assert.equal(glmFlash.context, 1_048_576);
+  assert.equal(glmFlash.fit, "too-large");
+  assert.equal(glmFlash.downloadable, true);
+  assert.equal(glmFlash.researchStatus, "Unsloth GGUF · 7 local quants");
+  assert.deepEqual(glmFlash.researchCapabilities, ["vision", "tools", "thinking"]);
+  const snapshot = localModelsSnapshot({
+    inventory: [],
+    running: [],
+    selection: { version: 1, enabled: [] },
+    runtime: { installed: true, running: true },
+  });
+  assert.equal(
+    snapshot.families.find((family) => family.family === "hf.co/unsloth/GLM-5.3-GGUF")?.displayName,
+    "GLM-5.3",
+  );
+  assert.equal(
+    snapshot.families.find((family) => family.family === "hf.co/unsloth/GLM-5.3-Flash-GGUF")?.displayName,
+    "GLM-5.3-Flash",
   );
 });
 
@@ -660,4 +692,3 @@ test("the listing says how little room Codex leaves in the window", () => {
   assert.match(rendered, new RegExp(`${Math.round(CODEX_PROMPT_TOKENS / 1000)}K of the 32K window`));
   assert.match(rendered, /agent-check/);
 });
-


### PR DESCRIPTION
## Summary

- Add Ollama-compatible Unsloth GGUF variants for GLM-5.3 and GLM-5.3-Flash to the local model catalog.
- Show clean family names, documented provenance, sizes, and context metadata in the Control Center.
- Keep these very large models out of Quick Picks and require the existing oversized-model acknowledgement before selection.
- Enforce the checked-in size preflight for Hugging Face tags that have no registry.ollama.ai manifest, then verify actual Ollama capabilities after the pull before publishing a Codex route.
- Update local-model documentation and retain the left-aligned family layout.

## Verification

- npm run check
- node --test test/local-models.test.mjs test/local-llm.test.mjs (52 passed)
- npm --prefix apps/control-center run check
- npm --prefix apps/control-center test (57 passed, including real-browser renderer coverage)
- npm test (2,985 tests; 2,966 passed, 19 skipped, 0 failed)
- git diff --check

## Notes

The smallest published GGUFs are still enormous: about 93.1 GB for GLM-5.3-Flash and 217 GB for GLM-5.3. No model weights were downloaded as part of verification; catalog selection, refusal without the explicit override, and post-pull capability gating are covered deterministically.