### PR TITLE
Fix OpenCode route context windows

### DIFF
--- a/config/opencode/go-messages/minimax-m2.5.json
+++ b/config/opencode/go-messages/minimax-m2.5.json
@@ -17,8 +17,8 @@
           "description": "Deep reasoning"
         }
       ],
-      "contextWindow": 131072,
-      "autoCompact": 110000,
+      "contextWindow": 200000,
+      "autoCompact": 180000,
       "inputModalities": [
         "text"
       ],

--- a/config/opencode/go-messages/minimax-m2.5.json
+++ b/config/opencode/go-messages/minimax-m2.5.json
@@ -17,12 +17,12 @@
           "description": "Deep reasoning"
         }
       ],
-      "contextWindow": 200000,
-      "autoCompact": 180000,
+      "contextWindow": 204800,
+      "autoCompact": 174000,
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-messages-minimax-m2-5-v1"
+      "compHash": "opencode-go-messages-minimax-m2-5-v2"
     }
   ]
 }

--- a/config/opencode/go-messages/minimax-m2.7.json
+++ b/config/opencode/go-messages/minimax-m2.7.json
@@ -12,7 +12,7 @@
       "priority": 41,
       "upgradeTo": {
         "model": "opencode-go-messages/minimax-m3",
-        "markdown": "MiniMax M3 is available on your opencode Go subscription\n\n{model_to} succeeds {model_from} and grows the context window from 128K to 1M tokens. Accept to switch your default model; MiniMax M2.7 stays available in the picker."
+        "markdown": "MiniMax M3 is available on your opencode Go subscription\n\n{model_to} succeeds {model_from} and grows the context window from 200K to 1M tokens. Accept to switch your default model; MiniMax M2.7 stays available in the picker."
       },
       "defaultEffort": "high",
       "reasoningLevels": [
@@ -21,8 +21,8 @@
           "description": "Deep reasoning"
         }
       ],
-      "contextWindow": 131072,
-      "autoCompact": 110000,
+      "contextWindow": 200000,
+      "autoCompact": 180000,
       "inputModalities": [
         "text"
       ],

--- a/config/opencode/go-messages/minimax-m2.7.json
+++ b/config/opencode/go-messages/minimax-m2.7.json
@@ -21,12 +21,12 @@
           "description": "Deep reasoning"
         }
       ],
-      "contextWindow": 200000,
-      "autoCompact": 180000,
+      "contextWindow": 204800,
+      "autoCompact": 174000,
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-messages-minimax-m2-7-v1"
+      "compHash": "opencode-go-messages-minimax-m2-7-v2"
     }
   ]
 }

--- a/config/opencode/go/hy3.json
+++ b/config/opencode/go/hy3.json
@@ -21,8 +21,8 @@
           "description": "Deep reasoning"
         }
       ],
-      "contextWindow": 131072,
-      "autoCompact": 110000,
+      "contextWindow": 262144,
+      "autoCompact": 235000,
       "inputModalities": [
         "text"
       ],

--- a/config/opencode/go/hy3.json
+++ b/config/opencode/go/hy3.json
@@ -22,11 +22,11 @@
         }
       ],
       "contextWindow": 262144,
-      "autoCompact": 235000,
+      "autoCompact": 223000,
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-hy3-v1"
+      "compHash": "opencode-go-hy3-v2"
     }
   ]
 }

--- a/config/opencode/go/mimo-v2.5-pro.json
+++ b/config/opencode/go/mimo-v2.5-pro.json
@@ -18,11 +18,11 @@
         }
       ],
       "contextWindow": 1000000,
-      "autoCompact": 900000,
+      "autoCompact": 850000,
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-mimo-v2-5-pro-v1"
+      "compHash": "opencode-go-mimo-v2-5-pro-v2"
     }
   ]
 }

--- a/config/opencode/go/mimo-v2.5-pro.json
+++ b/config/opencode/go/mimo-v2.5-pro.json
@@ -17,8 +17,8 @@
           "description": "Deep reasoning"
         }
       ],
-      "contextWindow": 131072,
-      "autoCompact": 110000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],

--- a/config/opencode/go/mimo-v2.5.json
+++ b/config/opencode/go/mimo-v2.5.json
@@ -18,11 +18,11 @@
         }
       ],
       "contextWindow": 1000000,
-      "autoCompact": 900000,
+      "autoCompact": 850000,
       "inputModalities": [
         "text"
       ],
-      "compHash": "opencode-go-mimo-v2-5-v1"
+      "compHash": "opencode-go-mimo-v2-5-v2"
     }
   ]
 }

--- a/config/opencode/go/mimo-v2.5.json
+++ b/config/opencode/go/mimo-v2.5.json
@@ -17,8 +17,8 @@
           "description": "Deep reasoning"
         }
       ],
-      "contextWindow": 131072,
-      "autoCompact": 110000,
+      "contextWindow": 1000000,
+      "autoCompact": 900000,
       "inputModalities": [
         "text"
       ],

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -787,17 +787,18 @@ test("GLM-5.3-Flash replaces OpenCode Go's withdrawn Ox Alpha route", () => {
 
 test("OpenCode Go routes retain upstream windows instead of the generic fallback", () => {
   const expected = new Map([
-    ["opencode-go/mimo-v2.5", [1_000_000, 900_000]],
-    ["opencode-go/mimo-v2.5-pro", [1_000_000, 900_000]],
-    ["opencode-go/hy3", [262_144, 235_000]],
-    ["opencode-go-messages/minimax-m2.5", [200_000, 180_000]],
-    ["opencode-go-messages/minimax-m2.7", [200_000, 180_000]],
+    ["opencode-go/mimo-v2.5", [1_000_000, 850_000, "opencode-go-mimo-v2-5-v2"]],
+    ["opencode-go/mimo-v2.5-pro", [1_000_000, 850_000, "opencode-go-mimo-v2-5-pro-v2"]],
+    ["opencode-go/hy3", [262_144, 223_000, "opencode-go-hy3-v2"]],
+    ["opencode-go-messages/minimax-m2.5", [204_800, 174_000, "opencode-go-messages-minimax-m2-5-v2"]],
+    ["opencode-go-messages/minimax-m2.7", [204_800, 174_000, "opencode-go-messages-minimax-m2-7-v2"]],
   ]);
 
-  for (const [slug, [contextWindow, autoCompact]] of expected) {
+  for (const [slug, [contextWindow, autoCompact, compHash]] of expected) {
     const model = MODEL_BY_SLUG.get(slug);
     assert.equal(model?.contextWindow, contextWindow, slug);
     assert.equal(model?.autoCompact, autoCompact, slug);
+    assert.equal(model?.compHash, compHash, slug);
     assert.ok(autoCompact < contextWindow, slug);
   }
   assert.match(

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -785,6 +785,27 @@ test("GLM-5.3-Flash replaces OpenCode Go's withdrawn Ox Alpha route", () => {
   assert.equal(MODEL_BY_SLUG.get("opencode-go/ox-alpha"), model);
 });
 
+test("OpenCode Go routes retain upstream windows instead of the generic fallback", () => {
+  const expected = new Map([
+    ["opencode-go/mimo-v2.5", [1_000_000, 900_000]],
+    ["opencode-go/mimo-v2.5-pro", [1_000_000, 900_000]],
+    ["opencode-go/hy3", [262_144, 235_000]],
+    ["opencode-go-messages/minimax-m2.5", [200_000, 180_000]],
+    ["opencode-go-messages/minimax-m2.7", [200_000, 180_000]],
+  ]);
+
+  for (const [slug, [contextWindow, autoCompact]] of expected) {
+    const model = MODEL_BY_SLUG.get(slug);
+    assert.equal(model?.contextWindow, contextWindow, slug);
+    assert.equal(model?.autoCompact, autoCompact, slug);
+    assert.ok(autoCompact < contextWindow, slug);
+  }
+  assert.match(
+    MODEL_BY_SLUG.get("opencode-go-messages/minimax-m2.7")?.upgradeTo?.markdown,
+    /from 200K to 1M tokens/,
+  );
+});
+
 test("four additional OpenCode Go Chat routes retain their documented limits and conservative controls", () => {
   const expected = {
     "opencode-go/glm-5": {


### PR DESCRIPTION
Closes #505.

Restores reviewed upstream context windows for the five OpenCode Go routes that were still pinned to the generic 131,072-token fallback, and updates the stale MiniMax M2.7 upgrade copy. The routes now use the official context windows with conservative issue-proposed compaction thresholds.

Verification:
- `npm run check`
- `node --test test/registry.test.mjs test/model-discovery.test.mjs` (49/49)
- `git diff --check`

No live provider or quota-consuming request was used.