### PR TITLE
fix: preserve native custom tool streams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -564,7 +564,19 @@ and every client saw a bare "Connection error" naming nothing.
    live probe is the regression oracle: no `OutputTextDelta without active
    item` warnings and the message occupies the next output index after
    reasoning.
-10. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
+10. **LiteLLM custom-tool streaming uses a mixed lifecycle.** LiteLLM 1.96
+   converts Responses `type: "custom"` tools into Chat Completions functions
+   whose one required string property is `content`. On the return stream it can
+   already restore `response.output_item.added` / `done` as native
+   `custom_tool_call` items while still emitting legacy
+   `response.function_call_arguments.delta` / `done` events whose JSON wrapper
+   is `{ "content": "..." }`. `NamespaceToolCallTransform` may decode that
+   wrapper only when the source opening itself was already a native custom call;
+   the router's own custom-function bridge keeps its `{ "input": "..." }`
+   contract. Keep the streamed-input fingerprint check and fail closed when the
+   delta, terminal arguments, or output-item close disagree. The focused
+   namespace-relay test and Z.ai router fixture hold both sides of this boundary.
+11. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
    security floor and a wheel-availability decision (see the lock section
    above), any change to it has to be proven by booting the proxy rather than by
    a successful resolve, and a router that survives its gateway is worth having

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -1845,16 +1845,18 @@ function rewriteToolSearchFunctionCallItem(item, lookups, allowPlaceholder) {
   };
 }
 
-function customToolInput(value, allowPlaceholder = false) {
+function customToolInput(
+  value,
+  allowPlaceholder = false,
+  property = CUSTOM_TOOL_INPUT_PROPERTY,
+) {
   if (allowPlaceholder && (value === undefined || value === "")) return "";
   const argumentsText = coerceFunctionCallArguments(value);
   if (typeof argumentsText !== "string") return undefined;
   if (!jsonArgumentsAreUnambiguous(argumentsText)) return undefined;
   try {
     const parsed = JSON.parse(argumentsText);
-    return typeof parsed?.[CUSTOM_TOOL_INPUT_PROPERTY] === "string"
-      ? parsed[CUSTOM_TOOL_INPUT_PROPERTY]
-      : undefined;
+    return typeof parsed?.[property] === "string" ? parsed[property] : undefined;
   } catch {
     return undefined;
   }
@@ -2051,6 +2053,11 @@ function appendInterruptCallsToOutput(output, pending, interrupted) {
 }
 
 const CUSTOM_TOOL_OPENING_LIMIT = 1024;
+const LITELLM_CUSTOM_TOOL_INPUT_PROPERTY = "content";
+const CUSTOM_TOOL_OPENING_PATTERNS = Object.freeze({
+  [CUSTOM_TOOL_INPUT_PROPERTY]: /^\s*\{\s*"input"\s*:\s*"/,
+  [LITELLM_CUSTOM_TOOL_INPUT_PROPERTY]: /^\s*\{\s*"content"\s*:\s*"/,
+});
 const JSON_ESCAPES = Object.freeze({
   '"': '"',
   "\\": "\\",
@@ -2067,12 +2074,22 @@ const JSON_ESCAPES = Object.freeze({
 // once. Only an incomplete escape (at most six characters) is retained between
 // calls, avoiding the quadratic full-patch rescans that large streamed patches
 // would otherwise trigger.
-function customToolInputDelta(state, fragment) {
+function customToolInputDelta(
+  state,
+  fragment,
+  property = CUSTOM_TOOL_INPUT_PROPERTY,
+) {
   if (typeof fragment !== "string" || state.invalid || state.closed) return undefined;
   let encoded = fragment;
   if (!state.opened) {
     state.opening += encoded;
-    const opening = state.opening.match(/^\s*\{\s*"input"\s*:\s*"/);
+    const openingPattern = CUSTOM_TOOL_OPENING_PATTERNS[property];
+    if (!openingPattern) {
+      state.opening = "";
+      state.invalid = true;
+      return undefined;
+    }
+    const opening = state.opening.match(openingPattern);
     if (!opening) {
       if (state.opening.length > CUSTOM_TOOL_OPENING_LIMIT) {
         state.opening = "";
@@ -3301,7 +3318,15 @@ export class NamespaceToolCallTransform extends Transform {
             return [];
           }
           matched.state.sawArgumentDelta = true;
-          const delta = customToolInputDelta(matched.state.deltaState, event.delta);
+          const argumentProperty =
+            matched.state.sourceType === "custom_tool_call"
+              ? LITELLM_CUSTOM_TOOL_INPUT_PROPERTY
+              : CUSTOM_TOOL_INPUT_PROPERTY;
+          const delta = customToolInputDelta(
+            matched.state.deltaState,
+            event.delta,
+            argumentProperty,
+          );
           if (delta === undefined) {
             this.#commitSemanticMutation();
             return [];
@@ -3338,7 +3363,11 @@ export class NamespaceToolCallTransform extends Transform {
             this.#commitSemanticMutation();
             return [];
           }
-          const input = customToolInput(event.arguments);
+          const argumentProperty =
+            matched.state.sourceType === "custom_tool_call"
+              ? LITELLM_CUSTOM_TOOL_INPUT_PROPERTY
+              : CUSTOM_TOOL_INPUT_PROPERTY;
+          const input = customToolInput(event.arguments, false, argumentProperty);
           if (input === undefined) {
             return this.#unsafeSseFrame(frame, "invalid custom tool arguments done");
           }

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -3723,6 +3723,108 @@ test("one-byte fragmented SSE preserves escaped and multibyte custom input", asy
   assert.match(output, /event: response\.custom_tool_call_input\.done/);
 });
 
+test("native custom-tool streams accept LiteLLM content-wrapped legacy argument events", async () => {
+  const input = "console.log(6 * 7);\n";
+  const argumentsText = JSON.stringify({ content: input });
+  const events = [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        type: "custom_tool_call",
+        id: "call_native_custom",
+        call_id: "call_native_custom",
+        name: "exec",
+        status: "in_progress",
+        input: "",
+      },
+    },
+    ...[...argumentsText].map((delta) => ({
+      type: "response.function_call_arguments.delta",
+      item_id: "call_native_custom",
+      output_index: 0,
+      delta,
+    })),
+    {
+      type: "response.function_call_arguments.done",
+      item_id: "call_native_custom",
+      output_index: 0,
+      arguments: argumentsText,
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        type: "custom_tool_call",
+        id: "call_native_custom",
+        call_id: "call_native_custom",
+        name: "exec",
+        status: "completed",
+        input,
+      },
+    },
+  ];
+  const source = events
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+  const transform = new NamespaceToolCallTransform(new Map(), "text/event-stream");
+  const output = await collect(Readable.from([source]).pipe(transform));
+  const payloads = output.split(/\n\n/).filter(Boolean).map((block) => {
+    const data = block.split("\n").find((line) => line.startsWith("data: "));
+    return JSON.parse(data.slice(6));
+  });
+  assert.equal(payloads[0].item.type, "custom_tool_call");
+  assert.equal(
+    payloads.filter((event) => event.type === "response.custom_tool_call_input.delta")
+      .map((event) => event.delta).join(""),
+    input,
+  );
+  assert.equal(
+    payloads.find((event) => event.type === "response.custom_tool_call_input.done")?.input,
+    input,
+  );
+  assert.equal(payloads.at(-1).item.input, input);
+  assert.doesNotMatch(output, /response\.function_call_arguments/u);
+});
+
+test("native custom-tool legacy arguments still fail closed when streamed input changes", async () => {
+  const opening = {
+    type: "response.output_item.added",
+    output_index: 0,
+    item: {
+      type: "custom_tool_call",
+      id: "call_native_mismatch",
+      call_id: "call_native_mismatch",
+      name: "exec",
+      status: "in_progress",
+      input: "",
+    },
+  };
+  const streamed = JSON.stringify({ content: "first" });
+  const completed = JSON.stringify({ content: "second" });
+  const frames = [
+    opening,
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: "call_native_mismatch",
+      output_index: 0,
+      delta: streamed,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: "call_native_mismatch",
+      output_index: 0,
+      arguments: completed,
+    },
+  ].map((event) => `data: ${JSON.stringify(event)}\n\n`);
+  const { error } = await collectUntilPipelineError(
+    frames,
+    new NamespaceToolCallTransform(new Map(), "text/event-stream"),
+  );
+  assert.equal(error.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM");
+  assert.match(error.message, /custom tool argument deltas disagree with completed input/u);
+});
+
 test("a bridged custom tool without a grammar carries only what it was given", () => {
   const namespaces = new Map();
   const described = bridgeCustomTools(

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -8484,6 +8484,111 @@ test("router repairs malformed Z.ai message envelopes after LiteLLM Responses tr
   }
 });
 
+test("router repairs LiteLLM legacy argument events for native Z.ai custom tools", async () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "zai-custom-tool-router-"));
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    `${JSON.stringify({ version: 1, providers: ["zai-coding"] })}\n`,
+  );
+  const input = "console.log(6 * 7);\n";
+  const argumentsText = JSON.stringify({ content: input });
+  const customItem = {
+    type: "custom_tool_call",
+    id: "call_custom",
+    call_id: "call_custom",
+    name: "exec",
+    status: "completed",
+    input,
+  };
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET") {
+      json(response, 200, { ok: true, credential_present: true, credential_source: "test" });
+      return;
+    }
+    const outgoing = await bodyJson(request);
+    assert.equal(outgoing.model, "zai-coding-glm-5-3");
+    assert.equal(outgoing.tools?.some((tool) => tool?.type === "custom" && tool.name === "exec"), true);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    const events = [
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { ...customItem, status: "in_progress", input: "" },
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: "call_custom",
+        output_index: 0,
+        delta: argumentsText,
+      },
+      {
+        type: "response.function_call_arguments.done",
+        item_id: "call_custom",
+        output_index: 0,
+        arguments: argumentsText,
+      },
+      { type: "response.output_item.done", output_index: 0, item: customItem },
+      {
+        type: "response.completed",
+        response: {
+          id: "resp_custom",
+          status: "completed",
+          output: [customItem],
+          usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+        },
+      },
+    ];
+    response.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_SHOW_ALL_MODELS: "0",
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "zai-coding/glm-5.3",
+        input: "test",
+        stream: true,
+        tools: [{ type: "custom", name: "exec", description: "Run JavaScript." }],
+      }),
+    });
+    assert.equal(response.status, 200);
+    const body = await response.text();
+    const events = body.split(/\r?\n/)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+    assert.equal(
+      events.filter((event) => event.type === "response.custom_tool_call_input.delta")
+        .map((event) => event.delta).join(""),
+      input,
+    );
+    assert.equal(
+      events.find((event) => event.type === "response.custom_tool_call_input.done")?.input,
+      input,
+    );
+    assert.equal(events.find((event) => event.type === "response.output_item.done")?.item?.input, input);
+    assert.equal(events.at(-1)?.type, "response.completed");
+    assert.doesNotMatch(body, /response\.function_call_arguments/u);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 function curatedMuseCompatibilityModel() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "routing-opencode-tool-model-"));
   const file = path.join(dir, "user-models.json");


### PR DESCRIPTION
## Summary

Fixes the mixed custom-tool stream lifecycle produced by the pinned LiteLLM 1.96 Responses-to-Chat-Completions bridge.

LiteLLM can restore `response.output_item.added` as a native `custom_tool_call` while still emitting legacy `response.function_call_arguments.delta/done` events whose JSON wrapper uses its `content` property. The namespace relay previously decoded those events only with codex-router's own `input` wrapper, so the terminal event failed after output had been committed and the client saw EOF before `response.completed`.

This change:

- decodes `content` only when the source opening was already a native `custom_tool_call`;
- keeps codex-router's own bridged custom-function contract on `input`;
- preserves streamed/final/close fingerprint validation and fail-closed behavior;
- adds a one-byte fragmented regression for the LiteLLM lifecycle;
- adds a negative mismatch regression proving the safety guard remains active;
- adds a full router fixture for the Z.ai GLM route using a mocked gateway, with no provider spend;
- documents the pinned LiteLLM 1.96 boundary in `AGENTS.md`.

## Verification

- `npm run check`
- `node --test test/namespace-relay.test.mjs` — 109/109 passed
- `node --test test/zai-responses-compat.test.mjs` — 9/9 passed
- `node --test test/namespace-relay-routing.test.mjs` — 19/19 passed
- focused real-router Z.ai custom-tool fixture passed with a mocked LiteLLM event stream
- existing Z.ai message-envelope real-router fixture passed independently

No live provider/model calls were used.

Closes #522