### PR TITLE
fix: label failover model counts accurately

### DIFF
--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -614,8 +614,8 @@ if (!failoverSettings.enabled) {
     "ok",
     "Model failover",
     failoverCounts.free
-      ? `on, ${failoverCounts.free} free model(s) first then ${failoverCounts.subscription} of your own`
-      : `on, ${failoverCounts.subscription} of your own providers -- no free model is curated, so nothing cheaper is tried first`,
+      ? `on, ${failoverCounts.free} free model(s) first then ${failoverCounts.subscription} model(s) on your own providers`
+      : `on, ${failoverCounts.subscription} model(s) on your own providers -- no free model is curated, so nothing cheaper is tried first`,
     failoverCounts.free
       ? "Run ./bin/model-router codex control failover chain <model-slug,...> to choose the order yourself."
       : "Free catalogs change without notice so none are checked in. Run ./bin/model-router codex curate-models opencode-free to give failover a free first stop.",

--- a/test/model-router-cli.test.mjs
+++ b/test/model-router-cli.test.mjs
@@ -23,6 +23,12 @@ test("both dispatchers accept the stop command", () => {
   assert.match(windows, /"stop"\s*\{\s*Invoke-RouterNode "src\\service\.mjs" @\("stop"\)/);
 });
 
+test("doctor labels automatic failover counts as models rather than providers", () => {
+  const doctor = readFileSync(path.join(root, "src", "doctor.mjs"), "utf8");
+  assert.match(doctor, /failoverCounts\.subscription\} model\(s\) on your own providers/);
+  assert.doesNotMatch(doctor, /failoverCounts\.subscription\} of your own providers/);
+});
+
 test("both dispatchers expose reviewed external skill management", () => {
   const posix = readFileSync(path.join(root, "bin", "model-router"), "utf8");
   assert.match(posix, /\|chatgpt-session\|skills\|/);


### PR DESCRIPTION
﻿## Summary

`doctor` currently reports automatic failover as, for example, `3 of your own providers`, but the value comes from `failoverTierCounts()`, which increments once per routed model. That can directly contradict the adjacent `Enabled providers` row and makes a single provider with several routed models look like several providers.

This patch changes only the diagnostic wording:

- free tier present: reports the paid count as `model(s) on your own providers`;
- no free tier: reports the same model count accurately instead of calling it a provider count;
- adds a regression tying the doctor wording to the model-count contract.

No ranking, provider selection, cooldown, or failover behavior changes.

## Reproduction

On an installation with one enabled routed provider and three eligible paid models, `doctor` can currently show both:

- `Enabled providers: <one provider>`
- `Model failover: on, 3 of your own providers ...`

`failoverTierCounts()` and its existing tests confirm that `subscription` is a model count, not a distinct-provider count.

## Verification

- TDD regression observed failing before the wording change.
- `node --test test/model-router-cli.test.mjs test/model-failover.test.mjs` — 39 total: 35 passed, 4 Windows-inapplicable skips, 0 failures.
- `npm run check` — syntax checks passed; v2-agent applications valid (6).
- `git diff --check` — clean.
