### PR TITLE
fix: report native vision engines in doctor

### DIFF
--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -544,7 +544,7 @@ add(
 // The same installed-native gate used by catalog/control keeps this diagnostic
 // aligned with what the running Codex route can actually resolve.
 const visionSettings = readVisionBridgeSettings();
-const visionCandidates = codexTarget
+const visionCandidates = codexTarget && codexAuth?.authenticated === true
   ? [...requiredRoutedModels, ...installedNativeVisionEngines({ hidden: readHiddenModels() })]
   : requiredRoutedModels;
 const visionEngine = resolveVisionEngine(() => visionCandidates, visionSettings);

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -72,6 +72,7 @@ import {
   selectedConfiguredListedModels,
 } from "./provider-selection.mjs";
 import { resolveVisionEngine } from "./vision-bridge.mjs";
+import { installedNativeVisionEngines } from "./vision-engines.mjs";
 import {
   readVisionBridgeSettings,
   visionBridgeConfigured,
@@ -539,21 +540,24 @@ add(
 // DeepSeek-only install for a feature nobody switched on. It still reports what
 // is true, just at the severity the situation has.
 //
-// This check sees routed models only, so a native (ChatGPT-plan) engine is
-// invisible to it and a signed-in install may well read images fine while this
-// says nothing resolves.
+// Codex may spend a signed-in native vision engine on the caller's behalf.
+// The same installed-native gate used by catalog/control keeps this diagnostic
+// aligned with what the running Codex route can actually resolve.
 const visionSettings = readVisionBridgeSettings();
-const visionEngine = resolveVisionEngine(() => requiredRoutedModels, visionSettings);
+const visionCandidates = codexTarget
+  ? [...requiredRoutedModels, ...installedNativeVisionEngines({ hidden: readHiddenModels() })]
+  : requiredRoutedModels;
+const visionEngine = resolveVisionEngine(() => visionCandidates, visionSettings);
 if (visionSettings.enabled && !visionEngine) {
   const asked = visionBridgeConfigured();
   add(
     asked ? "warn" : "ok",
     "Vision bridge",
-    visionSettings.engine
+    visionSettings.engine && !visionSettings.defaulted
       ? `pinned engine ${visionSettings.engine} is not an enabled model that reads images`
       : asked
-        ? "enabled, but no enabled provider offers a model that reads images"
-        : "on by default, but no enabled provider offers a model that reads images yet",
+        ? "enabled, but no enabled vision engine is available"
+        : "on by default, but no enabled vision engine is available yet",
     "Enable a provider with a vision model, sign in to ChatGPT, or run ./bin/model-router codex control vision-bridge setup for a local reader.",
   );
 } else if (visionEngine?.local) {

--- a/test/doctor-vision-status.test.mjs
+++ b/test/doctor-vision-status.test.mjs
@@ -9,20 +9,43 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const callerSecret = "doctor-vision-caller-capability-with-sufficient-length";
 
-function writeCodexStub(directory, models) {
+function writeCodexStub(directory, models, { authenticated = true } = {}) {
   const windows = process.platform === "win32";
   const target = path.join(directory, windows ? "codex-vision.cmd" : "codex-vision");
   const payload = JSON.stringify({ models });
   writeFileSync(
     target,
     windows
-      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" exit /b 0\r\nif "%1"=="debug" (echo ${payload}& exit /b 0)\r\nexit /b 1\r\n`
-      : `#!/bin/sh\ncase "$1" in\n  --version) echo 'codex-cli 99.0.0' ;;\n  login) exit 0 ;;\n  debug) printf '%s\\n' '${payload}' ;;\n  *) exit 1 ;;\nesac\n`,
+      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" exit /b ${authenticated ? 0 : 1}\r\nif "%1"=="debug" (echo ${payload}& exit /b 0)\r\nexit /b 1\r\n`
+      : `#!/bin/sh\ncase "$1" in\n  --version) echo 'codex-cli 99.0.0' ;;\n  login) exit ${authenticated ? 0 : 1} ;;\n  debug) printf '%s\\n' '${payload}' ;;\n  *) exit 1 ;;\nesac\n`,
     { mode: 0o755 },
   );
   return target;
 }
-test("Codex doctor resolves a default bridge through an installed native vision engine", { timeout: 30_000 }, () => {
+
+function isolatedEnvironment(codexHome, stateDir, launchAgents, codexBin) {
+  return {
+    PATH: path.dirname(process.execPath),
+    HOME: codexHome,
+    USERPROFILE: codexHome,
+    TEMP: codexHome,
+    TMP: codexHome,
+    ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+    ...(process.platform === "win32"
+      ? { ComSpec: process.env.ComSpec || path.join(process.env.SystemRoot || "C:\\Windows", "System32", "cmd.exe") }
+      : {}),
+    CODEX_BIN: codexBin,
+    CODEX_HOME: codexHome,
+    CODEX_ROUTER_SERVICE_PLATFORM: process.platform === "win32" ? "darwin" : "win32",
+    MODEL_ROUTER_LAUNCH_AGENTS_DIR: launchAgents,
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_TARGET: "codex",
+    MODEL_ROUTER_PORT: "46993",
+  };
+}
+
+test("Codex doctor gates installed native vision engines on the live sign-in probe", { timeout: 30_000 }, () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-doctor-vision-"));
   const stateDir = path.join(codexHome, "router-state");
   const launchAgents = path.join(codexHome, "launch-agents");
@@ -49,18 +72,8 @@ test("Codex doctor resolves a default bridge through an installed native vision 
   );
   writeFileSync(path.join(stateDir, "merged-models.json"), `${JSON.stringify({ models: [luna] })}\n`, { mode: 0o600 });
   writeFileSync(path.join(stateDir, "native-models.json"), `${JSON.stringify({ models: [luna] })}\n`, { mode: 0o600 });
-  const env = {
-    ...process.env,
-    CODEX_BIN: writeCodexStub(codexHome, [luna]),
-    CODEX_HOME: codexHome,
-    CODEX_ROUTER_NO_DISCOVERY: "1",
-    CODEX_ROUTER_SERVICE_PLATFORM: "darwin",
-    MODEL_ROUTER_LAUNCH_AGENTS_DIR: launchAgents,
-    CODEX_ROUTER_STATE_DIR: stateDir,
-    MODEL_ROUTER_STATE_DIR: stateDir,
-    MODEL_ROUTER_TARGET: "codex",
-    MODEL_ROUTER_PORT: "46993",
-  };
+  const codexBin = writeCodexStub(codexHome, [luna]);
+  const env = isolatedEnvironment(codexHome, stateDir, launchAgents, codexBin);
 
   try {
     const doctor = spawnSync(process.execPath, [path.join(root, "src", "doctor.mjs"), "--json"], {
@@ -70,23 +83,30 @@ test("Codex doctor resolves a default bridge through an installed native vision 
     });
     assert.ok(doctor.stdout.trim(), doctor.stderr);
     const report = JSON.parse(doctor.stdout);
-    const vision = report.checks.find((check) => check.name === "Vision bridge");
-    assert.equal(vision.status, "ok");
-    assert.equal(vision.detail, "text-only models read images via gpt-5.6-luna");
+    const byName = new Map(report.checks.map((check) => [check.name, check]));
+    assert.equal(byName.get("Codex sign-in probe").detail, "authenticated");
+    assert.equal(byName.get("Vision bridge").status, "ok");
+    assert.equal(byName.get("Vision bridge").detail, "text-only models read images via gpt-5.6-luna");
 
-    writeFileSync(path.join(stateDir, "merged-models.json"), `${JSON.stringify({ models: [] })}\n`, { mode: 0o600 });
-    writeFileSync(path.join(stateDir, "native-models.json"), `${JSON.stringify({ models: [] })}\n`, { mode: 0o600 });
-    const withoutEngine = spawnSync(
+    // Keep both native catalog files stale on disk but make the live sign-in probe fail.
+    // The request path cannot spend a native engine without a live session, so doctor
+    // must not treat catalog membership alone as evidence that the engine is usable.
+    writeCodexStub(codexHome, [luna], { authenticated: false });
+    const signedOut = spawnSync(
       process.execPath,
       [path.join(root, "src", "doctor.mjs"), "--json"],
       { cwd: root, env, encoding: "utf8" },
     );
-    assert.ok(withoutEngine.stdout.trim(), withoutEngine.stderr);
-    const noEngineReport = JSON.parse(withoutEngine.stdout);
-    const noEngineVision = noEngineReport.checks.find((check) => check.name === "Vision bridge");
-    assert.equal(noEngineVision.status, "ok");
-    assert.equal(noEngineVision.detail, "on by default, but no enabled vision engine is available yet");
-    assert.doesNotMatch(noEngineVision.detail, /pinned engine/);
+    assert.ok(signedOut.stdout.trim(), signedOut.stderr);
+    const signedOutReport = JSON.parse(signedOut.stdout);
+    const signedOutByName = new Map(signedOutReport.checks.map((check) => [check.name, check]));
+    assert.equal(signedOutByName.get("Codex sign-in probe").detail, "signed-out");
+    assert.equal(signedOutByName.get("Vision bridge").status, "ok");
+    assert.equal(
+      signedOutByName.get("Vision bridge").detail,
+      "on by default, but no enabled vision engine is available yet",
+    );
+    assert.doesNotMatch(signedOutByName.get("Vision bridge").detail, /pinned engine/);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }

--- a/test/doctor-vision-status.test.mjs
+++ b/test/doctor-vision-status.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const callerSecret = "doctor-vision-caller-capability-with-sufficient-length";
+
+function writeCodexStub(directory, models) {
+  const windows = process.platform === "win32";
+  const target = path.join(directory, windows ? "codex-vision.cmd" : "codex-vision");
+  const payload = JSON.stringify({ models });
+  writeFileSync(
+    target,
+    windows
+      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" exit /b 0\r\nif "%1"=="debug" (echo ${payload}& exit /b 0)\r\nexit /b 1\r\n`
+      : `#!/bin/sh\ncase "$1" in\n  --version) echo 'codex-cli 99.0.0' ;;\n  login) exit 0 ;;\n  debug) printf '%s\\n' '${payload}' ;;\n  *) exit 1 ;;\nesac\n`,
+    { mode: 0o755 },
+  );
+  return target;
+}
+test("Codex doctor resolves a default bridge through an installed native vision engine", { timeout: 30_000 }, () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-doctor-vision-"));
+  const stateDir = path.join(codexHome, "router-state");
+  const launchAgents = path.join(codexHome, "launch-agents");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  mkdirSync(launchAgents, { recursive: true, mode: 0o700 });
+  const luna = {
+    slug: "gpt-5.6-luna",
+    display_name: "GPT-5.6-Luna",
+    visibility: "list",
+    priority: 10,
+    input_modalities: ["text", "image"],
+  };
+  writeFileSync(path.join(codexHome, "config.toml"), 'model = "gpt-5.6-luna"\n', { mode: 0o600 });
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    `${JSON.stringify({ version: 1, providers: [] })}\n`,
+    { mode: 0o600 },
+  );
+  writeFileSync(path.join(stateDir, "caller-secret"), `${callerSecret}\n`, { mode: 0o600 });
+  writeFileSync(
+    path.join(stateDir, "internal-secret"),
+    "doctor-vision-internal-service-key-with-sufficient-length\n",
+    { mode: 0o600 },
+  );
+  writeFileSync(path.join(stateDir, "merged-models.json"), `${JSON.stringify({ models: [luna] })}\n`, { mode: 0o600 });
+  writeFileSync(path.join(stateDir, "native-models.json"), `${JSON.stringify({ models: [luna] })}\n`, { mode: 0o600 });
+  const env = {
+    ...process.env,
+    CODEX_BIN: writeCodexStub(codexHome, [luna]),
+    CODEX_HOME: codexHome,
+    CODEX_ROUTER_NO_DISCOVERY: "1",
+    CODEX_ROUTER_SERVICE_PLATFORM: "darwin",
+    MODEL_ROUTER_LAUNCH_AGENTS_DIR: launchAgents,
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_TARGET: "codex",
+    MODEL_ROUTER_PORT: "46993",
+  };
+
+  try {
+    const doctor = spawnSync(process.execPath, [path.join(root, "src", "doctor.mjs"), "--json"], {
+      cwd: root,
+      env,
+      encoding: "utf8",
+    });
+    assert.ok(doctor.stdout.trim(), doctor.stderr);
+    const report = JSON.parse(doctor.stdout);
+    const vision = report.checks.find((check) => check.name === "Vision bridge");
+    assert.equal(vision.status, "ok");
+    assert.equal(vision.detail, "text-only models read images via gpt-5.6-luna");
+
+    writeFileSync(path.join(stateDir, "merged-models.json"), `${JSON.stringify({ models: [] })}\n`, { mode: 0o600 });
+    writeFileSync(path.join(stateDir, "native-models.json"), `${JSON.stringify({ models: [] })}\n`, { mode: 0o600 });
+    const withoutEngine = spawnSync(
+      process.execPath,
+      [path.join(root, "src", "doctor.mjs"), "--json"],
+      { cwd: root, env, encoding: "utf8" },
+    );
+    assert.ok(withoutEngine.stdout.trim(), withoutEngine.stderr);
+    const noEngineReport = JSON.parse(withoutEngine.stdout);
+    const noEngineVision = noEngineReport.checks.find((check) => check.name === "Vision bridge");
+    assert.equal(noEngineVision.status, "ok");
+    assert.equal(noEngineVision.detail, "on by default, but no enabled vision engine is available yet");
+    assert.doesNotMatch(noEngineVision.detail, /pinned engine/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- make the Codex doctor evaluate the same gated native + routed vision-engine set used by the runtime/control paths
- count installed native vision engines only when the doctor's fresh Codex sign-in probe is authenticated
- preserve routed-only evaluation for non-Codex targets
- stop describing the built-in default engine as an operator pin when it is unavailable

## Reproduction

A signed-in Codex install can have `gpt-5.6-luna` present in both the merged and captured native catalogs while no routed provider exposes vision. Before this patch the doctor reports:

`OK Vision bridge: pinned engine gpt-5.6-luna is not an enabled model that reads images`

while the control/runtime resolver correctly resolves `gpt-5.6-luna`.

The inverse edge case matters too: after sign-out, those native catalog files can remain stale on disk while the request path refuses native vision without a live caller session. Doctor must not treat stale catalog membership alone as a usable engine.

## Verification

- isolated regression was RED on current main with the exact false diagnostic, then GREEN after the fix
- regression proves authenticated native Luna resolves, then the same stale catalogs are ignored after the live sign-in probe becomes signed-out
- adjacent doctor/vision/catalog set: 152 passed, 0 failed
- `npm run check`: passed
- `git diff --check`: clean
- repo-maintainer analyzer: local/targeted impact

No provider/model inference calls were used.
