### PR TITLE
fix: keep managed multi-agent config idempotent

### DIFF
--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -375,7 +375,15 @@ function withManagedMultiAgentV2(input) {
   }
   let tableEnd = featuresHeader + 1;
   while (tableEnd < lines.length && !/^\s*\[/.test(lines[tableEnd])) tableEnd += 1;
-  lines.splice(tableEnd, 0, ...managedLines, "");
+  // Keep the managed feature inside the table content and reuse the table's
+  // existing trailing separator. Inserting after those blanks and appending
+  // another one made every disable -> enable cycle grow the config by one line.
+  let insertionIndex = tableEnd;
+  while (insertionIndex > featuresHeader + 1 && !lines[insertionIndex - 1].trim()) {
+    insertionIndex -= 1;
+  }
+  const hasTableSeparator = insertionIndex < tableEnd;
+  lines.splice(insertionIndex, 0, ...managedLines, ...(hasTableSeparator ? [] : [""]));
   return `${lines.join("\n").trimEnd()}\n`;
 }
 

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -448,6 +448,37 @@ test("config manager enables multi_agent_v2 and skips the legacy agents scalar w
   }
 });
 
+test("multi_agent_v2 management is byte-idempotent around an existing features table", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-v2-idempotence-"));
+  const configPath = path.join(codexHome, "config.toml");
+  const original = `model = "gpt-5.5"
+
+[features]
+multi_agent = true
+memories = true
+js_repl = false
+
+[plugins."example"]
+enabled = true
+`;
+  writeFileSync(configPath, original, { mode: 0o600 });
+
+  try {
+    run("enable", codexHome);
+    const first = readFileSync(configPath, "utf8");
+    run("disable", codexHome);
+    run("enable", codexHome);
+    const second = readFileSync(configPath, "utf8");
+    run("disable", codexHome);
+    run("enable", codexHome);
+    const third = readFileSync(configPath, "utf8");
+
+    assert.equal(second, first);
+    assert.equal(third, first);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
 test("the managed multi_agent_v2 line tells the parent to interrupt finished children", () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-v2-hint-"));
   const configPath = path.join(codexHome, "config.toml");


### PR DESCRIPTION
## Summary

Repeated Codex catalog refreshes use a managed disable -> enable cycle. When a user already has a non-empty `[features]` table, `withManagedMultiAgentV2()` previously inserted the router block after that table's trailing blank separator and appended another blank. Removing the marked block left that added blank behind, so every later refresh grew `config.toml` by one line.

This patch inserts the managed feature before existing trailing separators and adds a separator only when the next TOML table is immediately adjacent. Existing user spacing is reused instead of accumulating router-owned blank lines.

## Reproduction

A clean current-main fixture with an existing `[features]` table is enabled, disabled, and enabled repeatedly. Before the source change the second publication differs from the first by exactly one extra blank line before `# BEGIN codex-router-multi-agent-v2-managed`; a third cycle adds another.

## Verification

- TDD regression: RED on current `main`, GREEN after the fix.
- focused + adjacent `multi_agent_v2` tests: 3 passed, 0 failed.
- `npm.cmd run check`: passed (`v2-agent applications valid (6)`, syntax checks passed).
- `git diff --check`: clean.
- `npm.cmd audit --audit-level=high`: 0 vulnerabilities.

Found while refreshing the native model catalog after Codex App bundled CLI updated to `0.151.0-alpha.7.1`; no provider/model inference calls were used.