### PR TITLE
test: wait for Codex app-server teardown

### DIFF
--- a/test/login-free-app-server.test.mjs
+++ b/test/login-free-app-server.test.mjs
@@ -173,9 +173,19 @@ function runAppServerTurn(binary, env, model, modelProvider) {
       settled = true;
       clearTimeout(timer);
       lines.close();
+      const complete = () => {
+        child.stdin.destroy();
+        child.stdout.destroy();
+        child.stderr.destroy();
+        if (error) reject(error);
+        else resolve(value);
+      };
+      if (child.exitCode !== null || child.signalCode !== null) {
+        complete();
+        return;
+      }
+      child.once("exit", complete);
       child.kill();
-      if (error) reject(error);
-      else resolve(value);
     };
     const send = (message) => child.stdin.write(`${JSON.stringify(message)}\n`);
     const timer = setTimeout(
@@ -316,7 +326,7 @@ async function verifySignedOutTurn(binary, { initialProvider = "openai" } = {}) 
     assert.match(JSON.stringify(notifications), new RegExp(MARKER));
   } finally {
     await new Promise((resolve) => server.close(resolve));
-    rmSync(codexHome, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true, maxRetries: 20, retryDelay: 50 });
   }
 }
 


### PR DESCRIPTION
## Summary

Codex App CLI 0.151 keeps temporary SQLite resources and inherited stdio handles alive slightly longer during `app-server` shutdown than the previous bundled build. The real installed-Codex login-free integration test completed both mock turns, then either failed cleanup with `EBUSY` on `goals_1.sqlite` or left the Node test runner alive.

This changes only the test helper lifecycle:

- wait for the spawned Codex process to emit `exit` before resolving the turn;
- destroy child stdio pipes after exit so inherited handles cannot keep the Node test runner alive;
- give recursive temporary-home cleanup a bounded Windows retry window for SQLite handle release.

Routing assertions and production code are unchanged.

## Verification

- reproduced on installed `codex-cli 0.151.0-alpha.7.1`: both subtests reached cleanup but failed with `EBUSY` before the fix;
- real installed-Codex app-server test: 3/3 passed and the runner exited naturally;
- `npm.cmd run check` passed;
- `git diff --check` clean;
- `npm.cmd audit --audit-level=high`: 0 vulnerabilities.
