### PR TITLE
fix: warn on stale native Codex catalog

### DIFF
--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -3,13 +3,15 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
 import { validCallerSecret } from "./caller-auth.mjs";
-import { codexAuthStatus, findCodexBinary, runCodex } from "./codex-binary.mjs";
+import { codexAuthStatus, codexVersion, findCodexBinary, runCodex } from "./codex-binary.mjs";
 import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
 import { routedCodexAgentStatus } from "./codex-agent-catalog.mjs";
 import { privateFileIsProtected } from "./file-security.mjs";
 import { grokCliPreflight } from "./grok-cli.mjs";
 import { detectLegacyInstallations } from "./legacy-migration.mjs";
 import { routedCatalogConfigured } from "./catalog.mjs";
+import { nativeCatalogVersionDrift } from "./native-catalog-freshness.mjs";
+import { readNativeCatalogSource } from "./native-catalog-source.mjs";
 import {
   MODEL_BY_SLUG,
   MODELS,
@@ -44,6 +46,7 @@ import {
   INTERNAL_SECRET_PATH,
   LITELLM_CONFIG_PATH,
   MERGED_CATALOG_PATH,
+  NATIVE_CATALOG_PATH,
   PORTS,
   SEARCH_SIDECARS_PATH,
   SOURCE_ROOT,
@@ -467,22 +470,44 @@ const catalogOk =
     ? requiredModels.size > 0 &&
       [...requiredModels].every((slug) => catalogModels.some((model) => model.slug === slug))
     : !catalogModels.some((model) => MODEL_BY_SLUG.has(String(model.slug))));
+let nativeCaptureDrift;
+if (codexTarget && codex && existsSync(NATIVE_CATALOG_PATH)) {
+  let adopted = false;
+  try {
+    adopted = Boolean(readNativeCatalogSource());
+  } catch {
+    // Invalid source state is not adoption proof; keep checking the router-owned capture.
+  }
+  try {
+    nativeCaptureDrift = nativeCatalogVersionDrift(
+      JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8")),
+      codexVersion(),
+      { adopted },
+    );
+  } catch {
+    // The merged-catalog check below remains authoritative for unreadable files.
+  }
+}
 // The merged catalog is the file Codex reads. A harness install has no
 // equivalent: its offer is the settings route, checked by "Harness routing
 // config" below. An idle install deliberately publishes no routed models, so
 // its catalog is held to the same standard as inactive transport: nothing
 // routable may be offered.
 if (codexTarget) add(
-  catalogOk ? "ok" : "fail",
+  !catalogOk ? "fail" : nativeCaptureDrift ? "warn" : "ok",
   "Merged catalog",
-  catalogOk
-    ? idleInstall
-      ? "idle install; no routed models"
-      : routedTransportActive
-        ? `${requiredModels.size} routed models`
-        : "native-only; routed transport is inactive"
-    : MERGED_CATALOG_PATH,
-  "Run ./bin/refresh-catalog, or ./bin/doctor --fix if files are missing.",
+  !catalogOk
+    ? MERGED_CATALOG_PATH
+    : nativeCaptureDrift
+      ? `native catalog captured by ${nativeCaptureDrift.captured}; installed ${nativeCaptureDrift.current}`
+      : idleInstall
+        ? "idle install; no routed models"
+        : routedTransportActive
+          ? `${requiredModels.size} routed models`
+          : "native-only; routed transport is inactive",
+  nativeCaptureDrift
+    ? "Run ./bin/refresh-catalog, then fully quit and reopen Codex."
+    : "Run ./bin/refresh-catalog, or ./bin/doctor --fix if files are missing.",
 );
 // The catalog tells Codex which models to offer; the gateway config decides
 // which it can actually route. When a second checkout writes one of them the

--- a/src/native-catalog-freshness.mjs
+++ b/src/native-catalog-freshness.mjs
@@ -1,0 +1,19 @@
+export function nativeCatalogVersionDrift(
+  catalog,
+  currentVersion,
+  { adopted = false } = {},
+) {
+  if (adopted || !currentVersion) return undefined;
+  if (!catalog || !Array.isArray(catalog.models) || catalog.models.length === 0) {
+    return undefined;
+  }
+  const captured =
+    typeof catalog.captured_with === "string" && catalog.captured_with.trim()
+      ? catalog.captured_with.trim()
+      : undefined;
+  if (captured === currentVersion) return undefined;
+  return {
+    captured: captured || "unknown build",
+    current: currentVersion,
+  };
+}

--- a/test/doctor-routing-mode.test.mjs
+++ b/test/doctor-routing-mode.test.mjs
@@ -136,14 +136,19 @@ wire_api = "responses"
         0,
       );
 
+      const nativeCapturePath = path.join(stateDir, "native-models.json");
+      const nativeCapture = JSON.parse(readFileSync(nativeCapturePath, "utf8"));
+      nativeCapture.captured_with = "codex-cli 98.0.0";
+      writeFileSync(nativeCapturePath, `${JSON.stringify(nativeCapture)}\n`, { mode: 0o600 });
+
       const doctor = child("doctor.mjs", ["--json"], env);
       const report = JSON.parse(doctor.stdout);
       const byName = new Map(report.checks.map((check) => [check.name, check]));
       assert.deepEqual(byName.get("Merged catalog"), {
-        status: "ok",
+        status: "warn",
         name: "Merged catalog",
-        detail: "native-only; routed transport is inactive",
-        fix: "Run ./bin/refresh-catalog, or ./bin/doctor --fix if files are missing.",
+        detail: "native catalog captured by codex-cli 98.0.0; installed codex-cli 99.0.0",
+        fix: "Run ./bin/refresh-catalog, then fully quit and reopen Codex.",
       });
       assert.equal(byName.get("Catalog matches gateway routes").status, "ok");
       assert.equal(byName.get("Catalog matches gateway routes").detail, "0 routed models");

--- a/test/native-catalog-freshness.test.mjs
+++ b/test/native-catalog-freshness.test.mjs
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { nativeCatalogVersionDrift } from "../src/native-catalog-freshness.mjs";
+
+const catalog = (captured_with) => ({
+  ...(captured_with === undefined ? {} : { captured_with }),
+  models: [{ slug: "gpt-5.6-sol" }],
+});
+
+test("native catalog version drift follows router capture ownership", () => {
+  assert.equal(nativeCatalogVersionDrift(catalog("codex-cli 0.151.0"), "codex-cli 0.151.0"), undefined);
+  assert.deepEqual(nativeCatalogVersionDrift(catalog("codex-cli 0.150.0"), "codex-cli 0.151.0"), {
+    captured: "codex-cli 0.150.0",
+    current: "codex-cli 0.151.0",
+  });
+  assert.deepEqual(nativeCatalogVersionDrift(catalog(), "codex-cli 0.151.0"), {
+    captured: "unknown build",
+    current: "codex-cli 0.151.0",
+  });
+  assert.equal(nativeCatalogVersionDrift(catalog("codex-cli 0.150.0"), undefined), undefined);
+  assert.equal(nativeCatalogVersionDrift(catalog("codex-cli 0.150.0"), "codex-cli 0.151.0", { adopted: true }), undefined);
+});


### PR DESCRIPTION
## Summary
- warn when the router-owned native Codex catalog was captured by a different installed Codex build
- treat a missing `captured_with` stamp as stale when the installed version is known
- exempt explicitly adopted user-owned native catalogs from the router capture-version contract
- keep missing/unreadable merged catalogs as failures and preserve existing healthy/native-only statuses

## Why
After a Codex Desktop update from `0.150.0-alpha.12.2` to `0.151.0-alpha.7.1`, doctor reported the merged/model catalog as healthy even though `native-models.json` was still stamped for the old build. `catalog.mjs` already treats captures as build-bound, but doctor only checked routed-model visibility, so a stale native schema could remain invisible until a manual refresh.

## Verification
- RED integration reproduced the stale capture being reported `ok`
- focused freshness unit test passes
- doctor routing-mode regression passes with the stale capture reported as `warn`
- `npm.cmd run check` passes
- `git diff --check` clean
- `npm.cmd audit --audit-level=high`: 0 vulnerabilities

No provider/model inference calls are involved.