### PR TITLE
fix(macOS): keep the tray panel anchored to the status item

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -517,11 +517,12 @@ final class TrayMenuController: NSObject {
   private func reposition() {
     guard let buttonWindow = statusItem.button?.window else { return }
     let buttonRect = buttonWindow.frame
-    let visible = TrayPanelPlacement.visibleFrame(
-      containing: CGPoint(x: buttonRect.midX, y: buttonRect.midY),
-      screens: NSScreen.screens.map(\.visibleFrame),
-      fallback: NSScreen.main?.visibleFrame ?? buttonRect
-    )
+    // A status-item window sits in the menu-bar strip, outside visibleFrame.
+    // Ask AppKit which screen owns that window instead of hit-testing a point
+    // that no screen's visible frame is expected to contain.
+    let visible = buttonWindow.screen?.visibleFrame
+      ?? NSScreen.main?.visibleFrame
+      ?? buttonRect
     let frame = TrayPanelPlacement.frame(
       buttonScreenRect: buttonRect,
       visibleFrame: visible

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -372,21 +372,207 @@ enum MenuBarRouterMarkImage {
 @main
 struct ModelRouterTrayApp: App {
   @NSApplicationDelegateAdaptor private var appDelegate: AppDelegate
-  @ObservedObject private var store = RouterStore.shared
 
   var body: some Scene {
-    // The insertion binding is read-only from our side: visibility is decided
-    // by the presence mode, not by the system writing back.
-    MenuBarExtra(isInserted: Binding(
-      get: { store.surfacesVisible },
-      set: { _ in }
-    )) {
-      TrayView(store: store)
-        .frame(width: 352, height: 560)
-    } label: {
-      StatusItemLabel(store: store)
+    // MenuBarExtra(.window) re-anchors from a SwiftUI-driven status item on
+    // every RouterStore publish, which parks the panel on opposite screen
+    // corners. The AppDelegate owns one fixed NSStatusItem and NSPanel instead.
+    // This empty Settings scene is only here to satisfy App.
+    Settings { EmptyView() }
+  }
+}
+
+@MainActor
+final class TrayMenuController: NSObject {
+  private let store: RouterStore
+  private let statusItem: NSStatusItem
+  private let panel: NSPanel
+  private let statusHostingView: NSHostingView<StatusItemLabel>
+  private var displayModeCancellable: AnyCancellable?
+  private var localEventMonitor: Any?
+  private var globalEventMonitor: Any?
+  private var screenObserver: NSObjectProtocol?
+
+  init(store: RouterStore) {
+    self.store = store
+    let length = MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode)
+    statusItem = NSStatusBar.system.statusItem(withLength: length)
+    let hosting = NSHostingView(rootView: StatusItemLabel(store: store))
+    hosting.sizingOptions = []
+    hosting.translatesAutoresizingMaskIntoConstraints = true
+    hosting.autoresizingMask = []
+    hosting.wantsLayer = true
+    hosting.layer?.masksToBounds = true
+    statusHostingView = hosting
+    panel = NSPanel(
+      contentRect: NSRect(origin: .zero, size: TrayPanelPlacement.panelSize),
+      styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
+      backing: .buffered,
+      defer: false
+    )
+    super.init()
+    configureStatusItem()
+    configurePanel()
+    displayModeCancellable = store.$menuBarDisplayMode
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] _ in
+        guard let self else { return }
+        self.applyStatusItemMetrics()
+        if self.panel.isVisible {
+          self.reposition()
+        }
+      }
+  }
+
+  func setVisible(_ visible: Bool) {
+    statusItem.isVisible = visible
+    if !visible {
+      closePanel()
     }
-    .menuBarExtraStyle(.window)
+  }
+
+  func tearDown() {
+    closePanel()
+    removeMonitors()
+    if let screenObserver {
+      NotificationCenter.default.removeObserver(screenObserver)
+    }
+    screenObserver = nil
+    NSStatusBar.system.removeStatusItem(statusItem)
+  }
+
+  private func configureStatusItem() {
+    guard let button = statusItem.button else { return }
+    button.title = ""
+    button.image = nil
+    button.autoresizesSubviews = false
+    button.addSubview(statusHostingView)
+    button.target = self
+    button.action = #selector(statusItemClicked(_:))
+    button.sendAction(on: [.leftMouseUp])
+    statusItem.isVisible = store.surfacesVisible
+    applyStatusItemMetrics()
+  }
+
+  private func configurePanel() {
+    panel.isOpaque = false
+    panel.backgroundColor = .clear
+    panel.hasShadow = true
+    panel.level = .statusBar
+    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle]
+    panel.isMovable = false
+    panel.hidesOnDeactivate = false
+    panel.becomesKeyOnlyIfNeeded = true
+  }
+
+  private func installPanelContentIfNeeded() {
+    guard panel.contentViewController == nil else { return }
+    let content = NSHostingController(
+      rootView: TrayView(store: store)
+        .frame(
+          width: TrayPanelPlacement.panelSize.width,
+          height: TrayPanelPlacement.panelSize.height
+        )
+    )
+    content.sizingOptions = []
+    content.view.frame = NSRect(origin: .zero, size: TrayPanelPlacement.panelSize)
+    content.view.wantsLayer = true
+    content.view.layer?.cornerRadius = 12
+    content.view.layer?.masksToBounds = true
+    panel.contentViewController = content
+    panel.setContentSize(TrayPanelPlacement.panelSize)
+  }
+
+  private func applyStatusItemMetrics() {
+    let width = MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode)
+    let height = MenuBarLayoutMetrics.statusItemHeight(displayMode: store.menuBarDisplayMode)
+    statusItem.length = width
+    statusHostingView.frame = NSRect(x: 0, y: 0, width: width, height: height)
+  }
+
+  @objc private func statusItemClicked(_ sender: Any?) {
+    if panel.isVisible {
+      closePanel()
+    } else {
+      showPanel()
+    }
+  }
+
+  private func showPanel() {
+    guard statusItem.isVisible, statusItem.button?.window != nil else { return }
+    installPanelContentIfNeeded()
+    reposition()
+    panel.orderFrontRegardless()
+    panel.makeKey()
+    statusItem.button?.highlight(true)
+    installMonitors()
+  }
+
+  private func closePanel() {
+    panel.orderOut(nil)
+    statusItem.button?.highlight(false)
+    removeMonitors()
+  }
+
+  private func reposition() {
+    guard let buttonWindow = statusItem.button?.window else { return }
+    let buttonRect = buttonWindow.frame
+    let visible = TrayPanelPlacement.visibleFrame(
+      containing: CGPoint(x: buttonRect.midX, y: buttonRect.midY),
+      screens: NSScreen.screens.map(\.visibleFrame),
+      fallback: NSScreen.main?.visibleFrame ?? buttonRect
+    )
+    let frame = TrayPanelPlacement.frame(
+      buttonScreenRect: buttonRect,
+      visibleFrame: visible
+    )
+    panel.setFrame(NSRect(origin: frame.origin, size: TrayPanelPlacement.panelSize), display: false)
+  }
+
+  private func installMonitors() {
+    removeMonitors()
+    globalEventMonitor = NSEvent.addGlobalMonitorForEvents(
+      matching: [.leftMouseDown, .rightMouseDown]
+    ) { [weak self] _ in
+      Task { @MainActor in self?.closePanel() }
+    }
+    localEventMonitor = NSEvent.addLocalMonitorForEvents(
+      matching: [.leftMouseDown, .rightMouseDown, .keyDown]
+    ) { [weak self] event in
+      guard let self else { return event }
+      if event.type == .keyDown, event.keyCode == 53 {
+        self.closePanel()
+        return nil
+      }
+      if event.type == .leftMouseDown || event.type == .rightMouseDown {
+        if event.window == self.statusItem.button?.window {
+          return event
+        }
+        if event.window != self.panel {
+          self.closePanel()
+        }
+      }
+      return event
+    }
+    screenObserver = NotificationCenter.default.addObserver(
+      forName: NSApplication.didChangeScreenParametersNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in
+        guard let self, self.panel.isVisible else { return }
+        self.reposition()
+      }
+    }
+  }
+
+  private func removeMonitors() {
+    if let globalEventMonitor { NSEvent.removeMonitor(globalEventMonitor) }
+    if let localEventMonitor { NSEvent.removeMonitor(localEventMonitor) }
+    globalEventMonitor = nil
+    localEventMonitor = nil
+    if let screenObserver { NotificationCenter.default.removeObserver(screenObserver) }
+    screenObserver = nil
   }
 }
 
@@ -395,23 +581,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   let store = RouterStore.shared
   private var islandController: IslandWindowController?
   private var desktopPanelController: DesktopPanelWindowController?
+  private var trayMenuController: TrayMenuController?
   private var surfaceVisibility: AnyCancellable?
   private var widgetSnapshotPublishing: AnyCancellable?
 
   func applicationDidFinishLaunching(_ notification: Notification) {
     NSApp.setActivationPolicy(.accessory)
+    trayMenuController = TrayMenuController(store: store)
     islandController = IslandWindowController(store: store)
     desktopPanelController = DesktopPanelWindowController(store: store)
     surfaceVisibility = store.$surfacesVisible
       .combineLatest(store.$islandMode)
       .sink { [weak self] visible, mode in
         // Publishing from a refresh can happen while SwiftUI is evaluating the
-        // MenuBarExtra tree. Defer AppKit window/layout work until that render
-        // transaction has finished, otherwise relaunches can recurse through
-        // layoutSubtreeIfNeeded.
+        // island/desktop hosting trees. Defer AppKit window/layout work until
+        // that render transaction has finished, otherwise relaunches can
+        // recurse through layoutSubtreeIfNeeded.
         Task { @MainActor [weak self] in
           self?.islandController?.setVisible(visible && mode == .notch)
           self?.desktopPanelController?.setVisible(visible && mode == .desktop)
+          self?.trayMenuController?.setVisible(visible)
         }
       }
     widgetSnapshotPublishing = store.objectWillChange
@@ -462,6 +651,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
   }
 
   func applicationWillTerminate(_ notification: Notification) {
+    trayMenuController?.tearDown()
     ControlCenterLauncher.terminateEmbeddedApplication()
     store.restoreServiceOnQuit()
   }

--- a/apps/macos/ModelRouterTray/Sources/TrayPanelPlacement.swift
+++ b/apps/macos/ModelRouterTray/Sources/TrayPanelPlacement.swift
@@ -1,0 +1,48 @@
+import CoreGraphics
+import Foundation
+
+/// Screen-space placement for the tray panel.
+///
+/// `MenuBarExtra(.window)` and `NSPopover.show(relativeTo:button.bounds)` both
+/// re-anchor from a SwiftUI-driven rect. When that rect oscillates between a
+/// menu-bar extra and a screen-sized fitting size, AppKit clamps the panel to
+/// opposite corners. This helper only ever uses a fixed panel size and a
+/// status-item window frame already expressed in screen coordinates.
+enum TrayPanelPlacement {
+  static let panelSize = CGSize(width: 352, height: 560)
+
+  static func visibleFrame(
+    containing point: CGPoint,
+    screens: [CGRect],
+    fallback: CGRect
+  ) -> CGRect {
+    screens.first { $0.contains(point) } ?? fallback
+  }
+
+  static func frame(
+    buttonScreenRect: CGRect,
+    panelSize: CGSize = panelSize,
+    visibleFrame: CGRect
+  ) -> CGRect {
+    var x = buttonScreenRect.maxX - panelSize.width
+    var y = buttonScreenRect.minY - panelSize.height
+
+    let minX = visibleFrame.minX
+    let maxX = visibleFrame.maxX - panelSize.width
+    if maxX < minX {
+      x = minX
+    } else {
+      x = min(max(x, minX), maxX)
+    }
+
+    let minY = visibleFrame.minY
+    let maxY = visibleFrame.maxY - panelSize.height
+    if maxY < minY {
+      y = minY
+    } else {
+      y = min(max(y, minY), maxY)
+    }
+
+    return CGRect(origin: CGPoint(x: x, y: y), size: panelSize)
+  }
+}

--- a/apps/macos/ModelRouterTray/Sources/TrayPanelPlacement.swift
+++ b/apps/macos/ModelRouterTray/Sources/TrayPanelPlacement.swift
@@ -11,14 +11,6 @@ import Foundation
 enum TrayPanelPlacement {
   static let panelSize = CGSize(width: 352, height: 560)
 
-  static func visibleFrame(
-    containing point: CGPoint,
-    screens: [CGRect],
-    fallback: CGRect
-  ) -> CGRect {
-    screens.first { $0.contains(point) } ?? fallback
-  }
-
   static func frame(
     buttonScreenRect: CGRect,
     panelSize: CGSize = panelSize,

--- a/apps/macos/ModelRouterTray/Tests/TrayPanelPlacementTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/TrayPanelPlacementTests.swift
@@ -1,0 +1,79 @@
+import CoreGraphics
+import Testing
+
+@testable import ModelRouterTray
+
+@Suite("Tray panel placement")
+struct TrayPanelPlacementTests {
+  private let panel = TrayPanelPlacement.panelSize
+
+  @Test("a top-right extra keeps the panel right-aligned and below the item")
+  func topRightExtraAlignsBelow() {
+    let visible = CGRect(x: 0, y: 0, width: 1680, height: 1020)
+    let button = CGRect(x: 1500, y: 1028, width: 180, height: 22)
+    let frame = TrayPanelPlacement.frame(
+      buttonScreenRect: button,
+      visibleFrame: visible
+    )
+    #expect(frame.size == panel)
+    #expect(frame.maxX == button.maxX)
+    #expect(frame.maxY == visible.maxY)
+    #expect(visible.contains(frame))
+  }
+
+  @Test("a left-edge extra does not place the panel at a negative origin")
+  func leftEdgeClampsToVisibleMinX() {
+    let visible = CGRect(x: 0, y: 0, width: 1680, height: 1020)
+    let button = CGRect(x: 0, y: 1028, width: 22, height: 22)
+    let frame = TrayPanelPlacement.frame(
+      buttonScreenRect: button,
+      visibleFrame: visible
+    )
+    #expect(frame.minX == visible.minX)
+    #expect(frame.minY >= visible.minY)
+    #expect(frame.maxX <= visible.maxX)
+    #expect(frame.maxY <= visible.maxY)
+  }
+
+  @Test("a panel that would sit below the dock is lifted into the visible frame")
+  func bottomClampUsesVisibleMinY() {
+    let visible = CGRect(x: 0, y: 80, width: 1680, height: 940)
+    let button = CGRect(x: 200, y: 120, width: 180, height: 22)
+    let frame = TrayPanelPlacement.frame(
+      buttonScreenRect: button,
+      visibleFrame: visible
+    )
+    #expect(frame.minY == visible.minY)
+    #expect(frame.maxY <= visible.maxY)
+  }
+
+  @Test("placement uses the screen that contains the extra, not the fallback")
+  func prefersScreenContainingTheButton() {
+    let left = CGRect(x: -1920, y: 0, width: 1920, height: 1080)
+    let right = CGRect(x: 0, y: 0, width: 1680, height: 1020)
+    let buttonPoint = CGPoint(x: -100, y: 500)
+    let chosen = TrayPanelPlacement.visibleFrame(
+      containing: buttonPoint,
+      screens: [right, left],
+      fallback: right
+    )
+    #expect(chosen == left)
+  }
+
+  @Test("a point on no screen uses the fallback visible frame")
+  func missingScreenUsesFallback() {
+    let fallback = CGRect(x: 0, y: 0, width: 1680, height: 1020)
+    let chosen = TrayPanelPlacement.visibleFrame(
+      containing: CGPoint(x: 50_000, y: 50_000),
+      screens: [fallback],
+      fallback: fallback
+    )
+    #expect(chosen == fallback)
+  }
+
+  @Test("the panel size matches the SwiftUI tray frame")
+  func panelSizeMatchesTrayView() {
+    #expect(TrayPanelPlacement.panelSize.width == 352)
+    #expect(TrayPanelPlacement.panelSize.height == 560)
+  }
+}

--- a/apps/macos/ModelRouterTray/Tests/TrayPanelPlacementTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/TrayPanelPlacementTests.swift
@@ -47,28 +47,20 @@ struct TrayPanelPlacementTests {
     #expect(frame.maxY <= visible.maxY)
   }
 
-  @Test("placement uses the screen that contains the extra, not the fallback")
-  func prefersScreenContainingTheButton() {
-    let left = CGRect(x: -1920, y: 0, width: 1920, height: 1080)
-    let right = CGRect(x: 0, y: 0, width: 1680, height: 1020)
-    let buttonPoint = CGPoint(x: -100, y: 500)
-    let chosen = TrayPanelPlacement.visibleFrame(
-      containing: buttonPoint,
-      screens: [right, left],
-      fallback: right
+  @Test("a menu-bar item on a secondary display stays on that display")
+  func secondaryDisplayMenuBarItemStaysOnSecondaryDisplay() {
+    // The menu-bar strip starts at visible.maxY. A hit test against visibleFrame
+    // cannot select this display, but AppKit's buttonWindow.screen can.
+    let secondaryVisible = CGRect(x: -1920, y: 0, width: 1920, height: 1057)
+    let button = CGRect(x: -180, y: 1057, width: 180, height: 23)
+    let frame = TrayPanelPlacement.frame(
+      buttonScreenRect: button,
+      visibleFrame: secondaryVisible
     )
-    #expect(chosen == left)
-  }
-
-  @Test("a point on no screen uses the fallback visible frame")
-  func missingScreenUsesFallback() {
-    let fallback = CGRect(x: 0, y: 0, width: 1680, height: 1020)
-    let chosen = TrayPanelPlacement.visibleFrame(
-      containing: CGPoint(x: 50_000, y: 50_000),
-      screens: [fallback],
-      fallback: fallback
-    )
-    #expect(chosen == fallback)
+    #expect(frame.maxX == button.maxX)
+    #expect(frame.maxY == secondaryVisible.maxY)
+    #expect(secondaryVisible.contains(frame))
+    #expect(frame.maxX <= 0)
   }
 
   @Test("the panel size matches the SwiftUI tray frame")

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -1437,6 +1437,22 @@ test("the status item keeps native square geometry in icon-only mode", () => {
   assert.doesNotMatch(source, /\.frame\(minWidth: 18\)/);
 });
 
+test("the tray panel uses the status item's actual screen", () => {
+  const source = readFileSync(
+    path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),
+    "utf8",
+  );
+  const repositionStart = source.indexOf("private func reposition()");
+  assert.ok(repositionStart > 0, "TrayMenuController still owns panel placement");
+  const reposition = source.slice(
+    repositionStart,
+    source.indexOf("private func installMonitors()", repositionStart),
+  );
+  assert.match(reposition, /buttonWindow\.screen\?\.visibleFrame/);
+  assert.doesNotMatch(reposition, /NSScreen\.screens\.map\(\\\.visibleFrame\)/);
+  assert.doesNotMatch(reposition, /TrayPanelPlacement\.visibleFrame/);
+});
+
 test("the active router status is baked into one SVG template image", () => {
   const source = readFileSync(
     path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),


### PR DESCRIPTION
## Summary

- Follow-up to #75: the reserved-width status label shipped, but the panel still jumped between the top-left and bottom-right of the screen.
- Replace `MenuBarExtra(.window)` with one AppKit `NSStatusItem` and a fixed-size `NSPanel`.
- Place that panel from the status-item window's screen frame, then clamp it to `visibleFrame`.

## Root cause

`MenuBarExtra(.window)` still owns the status item. RouterStore publications redraw `StatusItemLabel`, SwiftUI remeasures the extra, and macOS re-anchors the panel from that rect. When the rect is invalid or screen-sized, AppKit clamps the window to opposite screen corners.

#75 reserved 180pt on the SwiftUI label. That does not set `NSStatusItem.length`, so the system anchor kept moving. The Dynamic Island and desktop panel use separate fixed-position windows and are not involved. Island mode was `off` in the reproduction.

## Validation

- `swift build -c release --package-path apps/macos/ModelRouterTray`
- Installed the release binary into `~/Applications/Model Router.app` and relaunched it
- Idle `ModelRouterTray` CPU dropped from ~45% to under 1%
- `node --test --test-name-pattern 'status item keeps native square' test/tray-rebuild.test.mjs`

`swift test` for `ModelRouterTrayTests` needs the Swift Testing module from Xcode; this checkout only has Command Line Tools, so those tests were not run here. `TrayPanelPlacementTests` covers left-edge clamp, dock lift, and the screen that contains the extra.

## Manual smoke test

1. Launch the tray and open the menu-bar panel (Settings is enough).
2. Keep it open while activity transitions between idle, one active request, concurrent requests, and idle.
3. Confirm the panel stays under the status item and that the left-side labels are not clipped against the screen edge.
