### PR TITLE
fix: keep Codex router credentials out of config

### DIFF
--- a/src/caller-auth.mjs
+++ b/src/caller-auth.mjs
@@ -105,6 +105,26 @@ export function isManagedCallerBaseUrl(value, port) {
   return isManagedLeafBaseUrl(value, port, "v1");
 }
 
+// Codex can authenticate the router either with the legacy path capability or
+// with a bearer sent to the plain loopback Responses endpoint.
+export function isManagedCodexBaseUrl(value, port) {
+  if (isManagedCallerBaseUrl(value, port)) return true;
+  if (typeof value !== "string" || !value) return false;
+  try {
+    const url = new URL(value);
+    const expectedPort = port === undefined ? undefined : Number(port) === 80 ? "" : String(port);
+    return (
+      url.protocol === "http:" &&
+      url.hostname === "127.0.0.1" &&
+      (port === undefined || url.port === expectedPort) &&
+      !url.username && !url.password && !url.search && !url.hash &&
+      /^\/v1\/?$/.test(url.pathname)
+    );
+  } catch {
+    return false;
+  }
+}
+
 // The base URL the Gemini integration writes. Checked separately from the
 // Responses one because the two are not interchangeable: a client pointed at
 // `/v1` speaks Responses and a client pointed at `/gemini` speaks Gemini, so
@@ -122,7 +142,7 @@ export function isManagedGeminiBaseUrl(value, port) {
 export function redactCallerUrl(value) {
   if (typeof value !== "string") return value;
   return value.replace(
-    new RegExp(`(${CALLER_PATH_PREFIX}/)[A-Za-z0-9_-]+(?=/(?:v1|panel|gemini)(?:/|$))`, "g"),
+    new RegExp(`(${CALLER_PATH_PREFIX}/)[A-Za-z0-9_-]+(?=/(?:v1|panel|gemini)(?:/|$|[^A-Za-z0-9_-]))`, "g"),
     "$1[REDACTED]",
   );
 }

--- a/src/caller-key-auth-command.mjs
+++ b/src/caller-key-auth-command.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+
+import { assertCallerSecret } from "./caller-auth.mjs";
+
+const secretPath = process.argv[2];
+if (!secretPath) {
+  process.stderr.write("Caller key path is required.\n");
+  process.exit(2);
+}
+
+try {
+  const secret = assertCallerSecret(readFileSync(secretPath, "utf8").trim());
+  process.stdout.write(secret);
+} catch {
+  process.stderr.write("The local router caller key is unavailable.\n");
+  process.exit(1);
+}

--- a/src/caller-key-client-refresh.mjs
+++ b/src/caller-key-client-refresh.mjs
@@ -1,4 +1,9 @@
-import { assertCallerSecret, isManagedCallerBaseUrl, isManagedGeminiBaseUrl } from "./caller-auth.mjs";
+import {
+  assertCallerSecret,
+  isManagedCallerBaseUrl,
+  isManagedCodexBaseUrl,
+  isManagedGeminiBaseUrl,
+} from "./caller-auth.mjs";
 import { DSH_CREDENTIAL_REF, DSH_ROUTE_ID } from "./dsh-catalog.mjs";
 import { geminiManagedBlockPresent, spliceGeminiEnvBlock } from "./gemini-env.mjs";
 import { scanYamlDocument, yamlNode } from "./yaml-structure.mjs";
@@ -37,6 +42,11 @@ function assignmentValue(line, key, separator = "=") {
   return match ? decodeScalar(match[1]) : undefined;
 }
 
+function managedCodexBase(value, port, legacyPort) {
+  return isManagedCodexBaseUrl(value, port) ||
+    (legacyPort !== undefined && isManagedCodexBaseUrl(value, legacyPort));
+}
+
 function managedCallerBase(value, port, legacyPort) {
   return isManagedCallerBaseUrl(value, port) ||
     (legacyPort !== undefined && isManagedCallerBaseUrl(value, legacyPort));
@@ -54,8 +64,8 @@ function replaceRootCallerBase(contents, nextBase, port, legacyPort) {
     throw new Error("Codex caller capability refresh requires exactly one managed openai_base_url.");
   }
   const oldBase = assignmentValue(lines[matches[0]], "openai_base_url");
-  if (!managedCallerBase(oldBase, port, legacyPort)) {
-    throw new Error("Codex openai_base_url is not a managed caller capability.");
+  if (!managedCodexBase(oldBase, port, legacyPort)) {
+    throw new Error("Codex openai_base_url is not a managed router URL.");
   }
   lines[matches[0]] = replaceAssignmentLine(lines[matches[0]], "openai_base_url", nextBase);
   return lines.join("\n");
@@ -77,16 +87,16 @@ function replaceMarkedBase(contents, begin, end, nextBase, port, legacyPort) {
     throw new Error(`Managed caller capability block ${begin} has no unique base_url.`);
   }
   const oldBase = assignmentValue(lines[matches[0]], "base_url");
-  if (!managedCallerBase(oldBase, port, legacyPort)) {
-    throw new Error(`Managed caller capability block ${begin} has an unmanaged base_url.`);
+  if (!managedCodexBase(oldBase, port, legacyPort)) {
+    throw new Error(`Managed Codex block ${begin} has an unmanaged base_url.`);
   }
   lines[matches[0]] = replaceAssignmentLine(lines[matches[0]], "base_url", nextBase);
   return lines.join("\n");
 }
 
 export function refreshCodexCallerCapabilityContents(contents, nextBase, { port, legacyPort } = {}) {
-  if (!isManagedCallerBaseUrl(nextBase, port)) {
-    throw new Error("Refusing an invalid Codex caller capability URL.");
+  if (!isManagedCodexBaseUrl(nextBase, port)) {
+    throw new Error("Refusing an invalid Codex router URL.");
   }
   let next = replaceRootCallerBase(String(contents ?? ""), nextBase, port, legacyPort);
   next = replaceMarkedBase(next, CODEX_PROVIDER_BEGIN, CODEX_PROVIDER_END, nextBase, port, legacyPort);
@@ -97,8 +107,8 @@ export function refreshCodexCallerCapabilityContents(contents, nextBase, { port,
 export function refreshCodexCallerCapabilityState(state, nextBase, { port, legacyPort } = {}) {
   if (!state || typeof state !== "object") return state;
   if (!("managedBaseUrl" in state)) return { ...state };
-  if (!managedCallerBase(state.managedBaseUrl, port, legacyPort) || !isManagedCallerBaseUrl(nextBase, port)) {
-    throw new Error("Codex managed provider state contains an invalid caller capability URL.");
+  if (!managedCodexBase(state.managedBaseUrl, port, legacyPort) || !isManagedCodexBaseUrl(nextBase, port)) {
+    throw new Error("Codex managed provider state contains an invalid router URL.");
   }
   return { ...state, managedBaseUrl: nextBase };
 }

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -12,16 +12,18 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { protectPrivateFile } from "./file-security.mjs";
-import { isManagedCallerBaseUrl } from "./caller-auth.mjs";
+import { isManagedCodexBaseUrl } from "./caller-auth.mjs";
 import { applyInstructionOverlay } from "./instruction-overlays.mjs";
 import {
   ANNOUNCED_MODELS_PATH,
   CODEX_PROVIDER_MODE_PATH,
   CONFIG_PATH,
+  LEGACY_PORTS,
   MERGED_CATALOG_PATH,
   MODELS_CACHE_PATH,
   NATIVE_ALIAS_PATH,
   NATIVE_CATALOG_PATH,
+  PORTS,
 } from "./paths.mjs";
 import { codexAuthStatus, codexVersion, runCodex } from "./codex-binary.mjs";
 import { readUserModels } from "./user-models.mjs";
@@ -477,6 +479,11 @@ function loginFreeConfigured() {
 // the dedicated signed provider carries the same URL explicitly. Any other
 // custom provider (for example a configuration switcher) owns the endpoint and
 // would make external picker entries misleading.
+function managedCodexRouterBaseUrl(value) {
+  return isManagedCodexBaseUrl(value, PORTS.router) ||
+    isManagedCodexBaseUrl(value, LEGACY_PORTS.router);
+}
+
 export function routedCatalogConfigured(contents, override = process.env.MODEL_ROUTER_SIGNED_ROUTING) {
   if (override === "1") return true;
   if (override === "0") return false;
@@ -488,7 +495,7 @@ export function routedCatalogConfigured(contents, override = process.env.MODEL_R
       // Before first install there is no managed URL yet, but the catalog
       // still has to be buildable. Once an URL is present, only the caller-
       // capability endpoint proves that OpenAI traffic reaches this router.
-      return baseUrl === undefined || isManagedCallerBaseUrl(baseUrl);
+      return baseUrl === undefined || managedCodexRouterBaseUrl(baseUrl);
     }
 
     const providerPath = ["model_providers", provider];
@@ -499,7 +506,7 @@ export function routedCatalogConfigured(contents, override = process.env.MODEL_R
     );
     if (directTables.length !== 1) return false;
     const baseUrl = tomlStringValue(document, providerPath, "base_url");
-    return Boolean(baseUrl && isManagedCallerBaseUrl(baseUrl));
+    return Boolean(baseUrl && managedCodexRouterBaseUrl(baseUrl));
   } catch {
     return false;
   }

--- a/src/codex-native-session.mjs
+++ b/src/codex-native-session.mjs
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 
+import { secretEqual } from "./caller-auth.mjs";
 import { discoveryDisabled } from "./discovery-mode.mjs";
 import { writePrivateJson } from "./file-security.mjs";
 import { CODEX_HOME, NATIVE_SESSION_CONSENT_PATH } from "./paths.mjs";
@@ -103,6 +104,15 @@ function readSession() {
     // the way it did before, with the upstream's own 401.
     return undefined;
   }
+}
+
+// Authenticate a bearer that claims to be the already-signed-in Codex client.
+// This never enables session sharing; it only verifies the caller's own token.
+export function nativeSessionTokenMatches(token) {
+  if (typeof token !== "string" || !token) return false;
+  const session = readSession();
+  const actuallyExpired = session?.expiresAtMs !== undefined && session.expiresAtMs <= Date.now();
+  return Boolean(session && !actuallyExpired && secretEqual(token, session.accessToken));
 }
 
 /**

--- a/src/codex-native-session.mjs
+++ b/src/codex-native-session.mjs
@@ -79,13 +79,20 @@ export function tokenExpiryMs(accessToken) {
 // turn, and there is nothing to gain from spending the last seconds of one.
 const EXPIRY_SKEW_MS = 120_000;
 
-function readSession() {
+function readAuthDocument() {
   // Under --no-discovery the Codex auth file is never opened; status readers
   // above report it absent rather than pretending to know what is inside.
   if (discoveryDisabled()) return undefined;
   if (!existsSync(CODEX_AUTH_PATH)) return undefined;
   try {
-    const parsed = JSON.parse(readFileSync(CODEX_AUTH_PATH, "utf8"));
+    return JSON.parse(readFileSync(CODEX_AUTH_PATH, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function sessionFromAuthDocument(parsed) {
+  try {
     const tokens = parsed?.tokens;
     const accessToken = typeof tokens?.access_token === "string" ? tokens.access_token : "";
     const accountId = typeof tokens?.account_id === "string" ? tokens.account_id : "";
@@ -106,13 +113,27 @@ function readSession() {
   }
 }
 
+function readSession() {
+  return sessionFromAuthDocument(readAuthDocument());
+}
+
 // Authenticate a bearer that claims to be the already-signed-in Codex client.
 // This never enables session sharing; it only verifies the caller's own token.
 export function nativeSessionTokenMatches(token) {
   if (typeof token !== "string" || !token) return false;
-  const session = readSession();
+  const auth = readAuthDocument();
+  const session = sessionFromAuthDocument(auth);
   const actuallyExpired = session?.expiresAtMs !== undefined && session.expiresAtMs <= Date.now();
-  return Boolean(session && !actuallyExpired && secretEqual(token, session.accessToken));
+  if (session && !actuallyExpired && secretEqual(token, session.accessToken)) return true;
+
+  // API-key login is an official Codex auth mode too. It uses the same bearer
+  // header on a requires_openai_auth provider, but stores the credential at the
+  // top level rather than under `tokens`. Matching it authenticates this one
+  // request only; session sharing below remains ChatGPT-token-only.
+  const apiKey = auth?.auth_mode === "apikey" && typeof auth?.OPENAI_API_KEY === "string"
+    ? auth.OPENAI_API_KEY
+    : "";
+  return Boolean(apiKey && secretEqual(token, apiKey));
 }
 
 /**

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -18,7 +18,6 @@ import { findCodexBinary, spawnableCommand } from "./codex-binary.mjs";
 
 import {
   assertCallerSecret,
-  callerBaseUrl,
   isManagedCallerBaseUrl,
   redactCallerUrl,
 } from "./caller-auth.mjs";
@@ -52,6 +51,7 @@ import {
   MERGED_CATALOG_PATH,
   PORTS,
   SIGNED_PROVIDER_MODE_PATH,
+  SOURCE_ROOT,
   loopback,
 } from "./paths.mjs";
 import { scanTomlDocument } from "./toml-structure.mjs";
@@ -105,13 +105,34 @@ const defaultRealtimeWebsocketBaseUrl = "https://api.openai.com/v1";
 function tomlValue(value) {
   return JSON.stringify(value);
 }
+
+function managedCallerAuthBlock(providerId) {
+  const headerId = /^[A-Za-z0-9_-]+$/.test(providerId)
+    ? providerId
+    : JSON.stringify(providerId);
+  return [
+    `[model_providers.${headerId}.auth]`,
+    `command = ${tomlValue(process.execPath)}`,
+    `args = [${tomlValue(path.join(SOURCE_ROOT, "src", "caller-key-auth-command.mjs"))}, ${tomlValue(CALLER_SECRET_PATH)}]`,
+    "timeout_ms = 5000",
+    "refresh_interval_ms = 0",
+  ].join("\n");
+}
 const realtimeCallBaseUrlKey = "experimental_realtime_webrtc_call_base_url";
 const realtimeWebsocketBaseUrlKey = "experimental_realtime_ws_base_url";
 const markerPairs = [
   // The legacy layout parked the managed provider table inside the root
   // block, so the root pair recognizes that header as managed too.
-  [startMarker, endMarker, "[model_providers.codex-router]"],
-  [providerStartMarker, providerEndMarker, "[model_providers.codex-router]"],
+  [
+    startMarker,
+    endMarker,
+    ["[model_providers.codex-router]", "[model_providers.codex-router.auth]"],
+  ],
+  [
+    providerStartMarker,
+    providerEndMarker,
+    ["[model_providers.codex-router]", "[model_providers.codex-router.auth]"],
+  ],
   [
     signedProviderStartMarker,
     signedProviderEndMarker,
@@ -131,8 +152,8 @@ function configuredRouterBaseUrl() {
   if (!existsSync(CALLER_SECRET_PATH)) {
     throw new Error("The local router caller key is missing; run ./bin/doctor --fix.");
   }
-  const secret = assertCallerSecret(readFileSync(CALLER_SECRET_PATH, "utf8").trim());
-  return callerBaseUrl(PORTS.router, secret);
+  assertCallerSecret(readFileSync(CALLER_SECRET_PATH, "utf8").trim());
+  return loopback(PORTS.router, "/v1");
 }
 
 function isManagedRouterBaseUrl(value) {
@@ -175,10 +196,13 @@ function foreignTableSegments(innerLines, managedHeader) {
   // the scanner throw, which aborts the rewrite before anything is written —
   // the same fail-closed posture the signed-routing path takes.
   const { headers } = scanTomlDocument(innerLines.join("\n"));
+  const managedHeaders = new Set(
+    (Array.isArray(managedHeader) ? managedHeader : [managedHeader]).filter(Boolean),
+  );
   const hoisted = [];
   for (let position = 0; position < headers.length; position += 1) {
     const start = headers[position].index;
-    if (managedHeader && innerLines[start].trim() === managedHeader) continue;
+    if (managedHeaders.has(innerLines[start].trim())) continue;
     const end =
       position + 1 < headers.length ? headers[position + 1].index : innerLines.length;
     hoisted.push(...innerLines.slice(start, end));
@@ -607,6 +631,7 @@ function managedLoginFreeProviderBlock(providerId, baseUrl) {
     "requires_openai_auth = false",
     "supports_standalone_web_search = true",
     "supports_websockets = false",
+    managedCallerAuthBlock(providerId),
     signedProviderEndMarker,
   ].join("\n");
 }
@@ -753,11 +778,14 @@ function signedProviderBlockIsOwned(contents, state) {
   const blockMatches = state.loginFree
     ? managedLoginFreeProviderBlockMatches(actual, state.managedProvider, state.managedBaseUrl)
     : managedSignedProviderBlockMatches(actual, state.managedProvider, state.managedBaseUrl);
+  const providerTreeInsideManagedBlock =
+    providerRanges.length >= 1 &&
+    providerRanges[0].start === range.start + 1 &&
+    providerRanges.every(({ start }) => start > range.start && start < range.end);
   return (
     blockMatches &&
     slotIndex + 1 === range.start &&
-    providerRanges.length === 1 &&
-    providerRanges[0].start === range.start + 1
+    providerTreeInsideManagedBlock
   );
 }
 
@@ -1055,7 +1083,12 @@ function legacyManagedRouterProvider(contents) {
     fields.get("wire_api") === "responses";
   const currentShape =
     (fields.size === 3 ||
-      (fields.size === 4 && fields.get("supports_standalone_web_search") === "true")) &&
+      (fields.size === 4 &&
+        (fields.get("supports_standalone_web_search") === "true" ||
+          fields.get("requires_openai_auth") === "true")) ||
+      (fields.size === 5 &&
+        fields.get("supports_standalone_web_search") === "true" &&
+        fields.get("requires_openai_auth") === "true")) &&
     fields.get("name") === "Codex Router (external models)";
   const prototypeShape =
     (fields.size === 4 ||
@@ -1225,7 +1258,7 @@ function restoreRouterDefault(contents, state = readCodexRouterDefault()) {
   )}\n`;
 }
 
-function enabledContents(contents) {
+function enabledContents(contents, { loginFreeProvider = false } = {}) {
   const { rootLines: currentRoot } = splitRoot(contents);
   const currentProvider = rootValue(currentRoot, "model_provider");
   const preparedSource = adoptNativeCatalog
@@ -1313,6 +1346,9 @@ function enabledContents(contents) {
     // selected catalog model's supports_search_tool value before exposing the
     // standalone web-search client tool.
     "supports_standalone_web_search = true",
+    ...(loginFreeProvider
+      ? ["requires_openai_auth = false", managedCallerAuthBlock(routerProviderId)]
+      : ["requires_openai_auth = true"]),
     providerEndMarker,
   ];
   return withManagedAgentConcurrency(
@@ -1476,7 +1512,10 @@ if (command === "enable") {
     }
     // Keep the v1 state intact so login-free-disable can still restore the
     // provider and model captured by the older router.
-    next = enabledContents(resumable ? applyRefreshJournalModel(current, journal) : current);
+    next = enabledContents(
+      resumable ? applyRefreshJournalModel(current, journal) : current,
+      { loginFreeProvider: true },
+    );
     if (resumable) {
       next = `${replaceRootValueInPlace(next, "model_provider", routerProviderId)}\n`;
     }
@@ -1501,6 +1540,7 @@ if (command === "enable") {
       : current;
     const enabled = enabledContents(
       resumable ? applyRefreshJournalModel(restored, journal) : restored,
+      { loginFreeProvider: providerState.mode === "root-openai" },
     );
     if (providerState.mode === "root-openai") {
       // Current Codex Desktop builds reserve the built-in `openai` provider id,
@@ -1623,7 +1663,9 @@ if (command === "enable") {
     // A v1 install already selected codex-router. Refresh it without changing
     // the old restore record; disabling remains able to put both original
     // root assignments back exactly.
-    next = enabledContents(withLoginFreeModel(defaultRestored));
+    next = enabledContents(withLoginFreeModel(defaultRestored), {
+      loginFreeProvider: true,
+    });
     if (!active) next = `${replaceRootValue(next, "model_provider", routerProviderId)}\n`;
   } else if (state) {
     const active = providerModeStateIsOwned(current, state);
@@ -1642,7 +1684,9 @@ if (command === "enable") {
     const restored = active
       ? restoreSignedProviderTable(defaultRestored, state)
       : defaultRestored;
-    const enabled = enabledContents(withLoginFreeModel(restored));
+    const enabled = enabledContents(withLoginFreeModel(restored), {
+      loginFreeProvider: state.mode === "root-openai",
+    });
     if (state.mode === "root-openai") {
       pendingProviderModeState = switchedProviderModeState(rootLines, state);
       next = `${replaceRootValue(enabled, "model_provider", routerProviderId)}\n`;
@@ -1657,7 +1701,9 @@ if (command === "enable") {
       pendingProviderModeState = providerModeStateFromManaged(refreshed.state, state);
     }
   } else {
-    const enabled = enabledContents(withLoginFreeModel(defaultRestored));
+    const enabled = enabledContents(withLoginFreeModel(defaultRestored), {
+      loginFreeProvider: currentProvider === "openai",
+    });
     if (currentProvider === "openai") {
       pendingProviderModeState = switchedProviderModeState(rootLines);
       next = `${replaceRootValue(enabled, "model_provider", routerProviderId)}\n`;

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -2,7 +2,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
-import { validCallerSecret } from "./caller-auth.mjs";
+import { redactCallerUrl, validCallerSecret } from "./caller-auth.mjs";
 import { codexAuthStatus, codexVersion, findCodexBinary, runCodex } from "./codex-binary.mjs";
 import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
 import { routedCodexAgentStatus } from "./codex-agent-catalog.mjs";
@@ -372,8 +372,9 @@ if (codexTarget) {
       : undefined,
   );
 }
-// Both clients hold the managed base URL, which is a local caller capability,
-// so both documents are held to the same privacy bound.
+// Gemini and DSH still carry the caller capability in their private documents.
+// Modern Codex providers obtain it from an auth command instead, so Codex's
+// config does not need to be a credential store. Legacy capability configs do.
 const privacyTarget = codexTarget
   ? CONFIG_PATH
   : TARGET === "gemini"
@@ -382,7 +383,14 @@ const privacyTarget = codexTarget
 const configMode = existsSync(privacyTarget)
   ? statSync(privacyTarget).mode & 0o777
   : undefined;
-const configProtected = privateFileIsProtected(privacyTarget);
+const codexConfigText = codexTarget && existsSync(CONFIG_PATH)
+  ? readFileSync(CONFIG_PATH, "utf8")
+  : "";
+const codexConfigCarriesCallerCapability =
+  codexTarget && redactCallerUrl(codexConfigText) !== codexConfigText;
+const privacyRequired = !codexTarget || codexConfigCarriesCallerCapability;
+const configProtected =
+  configMode !== undefined && (!privacyRequired || privateFileIsProtected(privacyTarget));
 add(
   configProtected ? "ok" : "fail",
   codexTarget
@@ -392,10 +400,16 @@ add(
       : "Harness settings privacy",
   configMode === undefined
     ? "missing"
-    : process.platform === "win32"
-      ? "current-user Windows ACL"
-      : `mode ${configMode.toString(8)}`,
-  "Run ./bin/doctor --fix; the managed router URL contains a local caller capability.",
+    : codexTarget && !privacyRequired
+      ? "router credentials stay outside config.toml"
+      : process.platform === "win32"
+        ? configProtected
+          ? "current-user Windows ACL"
+          : "Windows ACL is broader than the current user"
+        : `mode ${configMode.toString(8)}`,
+  configProtected
+    ? undefined
+    : "Run ./bin/doctor --fix; the managed router URL contains a local caller capability.",
 );
 
 let selection = { providers: [], explicit: false };

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -171,7 +171,10 @@ import {
   toolResultAgingEnabled,
 } from "./tool-result-aging-state.mjs";
 import { VERSION } from "./version.mjs";
-import { nativeSessionHeaders } from "./codex-native-session.mjs";
+import {
+  nativeSessionHeaders,
+  nativeSessionTokenMatches,
+} from "./codex-native-session.mjs";
 import {
   installStableFetchTransport,
   loopbackProbeFetch,
@@ -642,6 +645,16 @@ function callerBroughtNoUpstreamCredential(request) {
   const presented = bearerToken(request.headers.authorization);
   if (presented === undefined) return request.headers.authorization === undefined;
   return secretEqual(presented, CALLER_KEY || "") || secretEqual(presented, INTERNAL_KEY || "");
+}
+
+function authenticatedDirectV1Route(request, pathname) {
+  if (pathname !== "/v1" && !pathname.startsWith("/v1/")) return undefined;
+  const presented = bearerToken(request.headers.authorization);
+  if (presented === undefined) return undefined;
+  if (secretEqual(presented, CALLER_KEY || "") || nativeSessionTokenMatches(presented)) {
+    return pathname;
+  }
+  return undefined;
 }
 
 // ChatGPT's own backend accepts a narrower request than the public Responses
@@ -4407,7 +4420,9 @@ async function handleRequest(request, response) {
     return;
   }
 
-  const route = authenticatedRoute(requestUrl.pathname, CALLER_KEY);
+  const route =
+    authenticatedRoute(requestUrl.pathname, CALLER_KEY) ||
+    authenticatedDirectV1Route(request, requestUrl.pathname);
   if (!route) {
     writeJson(response, 401, {
       error: {

--- a/test/caller-auth.test.mjs
+++ b/test/caller-auth.test.mjs
@@ -16,6 +16,7 @@ import {
   callerBaseUrl,
   geminiBaseUrl,
   isManagedCallerBaseUrl,
+  isManagedCodexBaseUrl,
   isManagedGeminiBaseUrl,
   redactCallerUrl,
 } from "../src/caller-auth.mjs";
@@ -53,6 +54,20 @@ test("caller capability helpers accept only the secret-bearing path and redact i
   );
 });
 
+test("managed Codex base accepts secret-bearing and plain authenticated loopback endpoints", () => {
+  assert.equal(isManagedCodexBaseUrl(callerBaseUrl(46192, CALLER_KEY), 46192), true);
+  assert.equal(isManagedCodexBaseUrl("http://127.0.0.1:46192/v1", 46192), true);
+  assert.equal(isManagedCodexBaseUrl("http://127.0.0.1:46192/v1/", 46192), true);
+  assert.equal(isManagedCodexBaseUrl("http://127.0.0.1:4102/v1", 46192), false);
+  assert.equal(isManagedCodexBaseUrl("https://127.0.0.1:46192/v1", 46192), false);
+  assert.equal(isManagedCodexBaseUrl("http://127.0.0.1:46192/gemini", 46192), false);
+});
+
+test("caller capability redaction works inside quoted config documents", () => {
+  const baseUrl = callerBaseUrl(46192, CALLER_KEY);
+  const document = `openai_base_url = ${JSON.stringify(baseUrl)}\n`;
+  assert.equal(redactCallerUrl(document), 'openai_base_url = "http://127.0.0.1:46192/_codex-router/[REDACTED]/v1"\n');
+});
 test("the gemini leaf sits behind the same capability and is redacted with it", () => {
   // Gemini CLI appends `/v1beta/models/...` to whatever base URL it is given,
   // so the capability has to be a path prefix here exactly as it is for `/v1`.

--- a/test/caller-key-auth-command.test.mjs
+++ b/test/caller-key-auth-command.test.mjs
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const command = path.join(root, "src", "caller-key-auth-command.mjs");
+const callerKey = "test-command-caller-capability-with-sufficient-length";
+
+test("Codex auth command reads the protected caller key without embedding it in config", () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "caller-key-auth-command-"));
+  const secretPath = path.join(directory, "caller-secret");
+  writeFileSync(secretPath, `${callerKey}\n`, { mode: 0o600 });
+  try {
+    const result = spawnSync(process.execPath, [command, secretPath], { encoding: "utf8" });
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(result.stdout.trim(), callerKey);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/test/caller-key-client-refresh.test.mjs
+++ b/test/caller-key-client-refresh.test.mjs
@@ -15,6 +15,7 @@ const oldSecret = "o".repeat(48);
 const newSecret = "n".repeat(48);
 const oldBase = callerBaseUrl(4202, oldSecret);
 const newBase = callerBaseUrl(4202, newSecret);
+const secretFreeBase = "http://127.0.0.1:4202/v1";
 
 test("Codex capability refresh changes only managed caller URLs", () => {
   const before = [
@@ -49,6 +50,29 @@ test("Codex capability state refresh preserves policy and ownership", () => {
   assert.deepEqual(refreshCodexCallerCapabilityState(before, newBase, { port: 4202 }), {
     ...before, managedBaseUrl: newBase,
   });
+});
+
+test("Codex capability refresh leaves secret-free auth-command routes unchanged", () => {
+  const before = [
+    `openai_base_url = ${JSON.stringify(secretFreeBase)}`,
+    "",
+    "# BEGIN codex-router-provider-managed",
+    "[model_providers.codex-router]",
+    `base_url = ${JSON.stringify(secretFreeBase)}`,
+    "[model_providers.codex-router.auth]",
+    'command = "/usr/bin/node"',
+    '# END codex-router-provider-managed',
+    "",
+  ].join("\n");
+  assert.equal(
+    refreshCodexCallerCapabilityContents(before, secretFreeBase, { port: 4202 }),
+    before,
+  );
+  const state = { managedBaseUrl: secretFreeBase, loginFree: true, ownershipId: "a".repeat(32) };
+  assert.deepEqual(
+    refreshCodexCallerCapabilityState(state, secretFreeBase, { port: 4202 }),
+    state,
+  );
 });
 
 test("DSH capability refresh preserves route models and default policy byte-for-byte", () => {

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -102,6 +102,12 @@ openai_base_url = "http://127.0.0.1:4102/_codex-router/test-caller-secret-with-s
   );
   assert.equal(
     routedCatalogConfigured(`model_provider = "openai"
+openai_base_url = "http://127.0.0.1:4202/v1"
+`),
+    true,
+  );
+  assert.equal(
+    routedCatalogConfigured(`model_provider = "openai"
 note = """
 [fake.table]
 """
@@ -124,6 +130,15 @@ openai_base_url = "https://foreign.invalid/v1"
 
 [model_providers.custom]
 base_url = "http://127.0.0.1:4102/_codex-router/test-caller-secret-with-sufficient-length/v1"
+wire_api = "responses"
+`),
+    true,
+  );
+  assert.equal(
+    routedCatalogConfigured(`model_provider = "custom"
+
+[model_providers.custom]
+base_url = "http://127.0.0.1:4202/v1"
 wire_api = "responses"
 `),
     true,

--- a/test/codex-native-session.test.mjs
+++ b/test/codex-native-session.test.mjs
@@ -39,9 +39,14 @@ const { dshNativeModels } = await import("../src/dsh-catalog.mjs");
 
 const ACCESS = "sk-test-access-token";
 const ACCOUNT = "acct-0123456789";
+const API_KEY = "sk-test-codex-api-key";
 
 function writeAuth(tokens) {
   writeFileSync(authPath, JSON.stringify({ auth_mode: "chatgpt", tokens }), "utf8");
+}
+
+function writeAuthDocument(document) {
+  writeFileSync(authPath, JSON.stringify(document), "utf8");
 }
 
 function clearAuth() {
@@ -88,6 +93,27 @@ test("the current Codex session authenticates only its own bearer without enabli
   assert.equal(nativeSessionTokenMatches("different-session-token"), false);
   clearAuth();
   assert.equal(nativeSessionTokenMatches(ACCESS), false);
+});
+
+test("the current Codex API key authenticates requests but never becomes a shared session", () => {
+  writeAuthDocument({ auth_mode: "apikey", OPENAI_API_KEY: API_KEY });
+  assert.equal(nativeSessionTokenMatches(API_KEY), true);
+  assert.equal(nativeSessionTokenMatches("sk-different-api-key"), false);
+  assert.equal(nativeSessionHeaders(), undefined);
+  assert.equal(nativeSessionAvailable(), false);
+  const status = nativeSessionStatus();
+  assert.deepEqual(
+    {
+      present: status.present,
+      usable: status.usable,
+      hasAccountId: status.hasAccountId,
+    },
+    { present: true, usable: false, hasAccountId: false },
+  );
+
+  // A top-level key in another auth mode is not authority for this route.
+  writeAuthDocument({ auth_mode: "chatgpt", OPENAI_API_KEY: API_KEY });
+  assert.equal(nativeSessionTokenMatches(API_KEY), false);
 });
 
 test("direct Codex authentication uses actual expiry rather than fallback skew", () => {

--- a/test/codex-native-session.test.mjs
+++ b/test/codex-native-session.test.mjs
@@ -28,6 +28,7 @@ const {
   nativeSessionSharingEnabled,
   nativeSessionAvailable,
   nativeSessionHeaders,
+  nativeSessionTokenMatches,
   nativeSessionStatus,
   setNativeSessionSharingEnabled,
   tokenExpiryMs,
@@ -80,6 +81,25 @@ test("a signed-in session stays private until the user authorizes sharing once",
   assert.doesNotMatch(readFileSync(NATIVE_SESSION_CONSENT_PATH, "utf8"), /access|account/i);
 });
 
+test("the current Codex session authenticates only its own bearer without enabling sharing", () => {
+  writeAuth({ access_token: ACCESS, account_id: ACCOUNT });
+  assert.equal(nativeSessionSharingEnabled(), false);
+  assert.equal(nativeSessionTokenMatches(ACCESS), true);
+  assert.equal(nativeSessionTokenMatches("different-session-token"), false);
+  clearAuth();
+  assert.equal(nativeSessionTokenMatches(ACCESS), false);
+});
+
+test("direct Codex authentication uses actual expiry rather than fallback skew", () => {
+  const seconds = Math.floor(Date.now() / 1000);
+  const nearlyExpired = jwtWithExp(seconds + 30);
+  writeAuth({ access_token: nearlyExpired, account_id: ACCOUNT });
+  assert.equal(nativeSessionTokenMatches(nearlyExpired), true);
+  assert.equal(nativeSessionHeaders(), undefined, "fallback still withholds the near-expiry token");
+  const expired = jwtWithExp(seconds - 1);
+  writeAuth({ access_token: expired, account_id: ACCOUNT });
+  assert.equal(nativeSessionTokenMatches(expired), false);
+});
 test("sharing cannot be enabled before the user signs in", () => {
   assert.throws(
     () => setNativeSessionSharingEnabled(true),

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -154,7 +154,7 @@ approval_policy = "never"
     assert.equal(enabled.config_protected, true);
     assert.equal(
       enabled.openai_base_url,
-      "http://127.0.0.1:46192/_codex-router/[REDACTED]/v1",
+      "http://127.0.0.1:46192/v1",
     );
     assert.doesNotMatch(JSON.stringify(enabled), new RegExp(CALLER_KEY));
 
@@ -174,11 +174,12 @@ approval_policy = "never"
     assert.match(configured, /\[model_providers\.codex-router\]/);
     assert.match(configured, /wire_api = "responses"/);
     assert.match(configured, /^supports_standalone_web_search = true$/m);
-    assert.ok(
-      configured.includes(
-        `openai_base_url = "http://127.0.0.1:46192/_codex-router/${CALLER_KEY}/v1"`,
-      ),
-    );
+    assert.match(configured, /^requires_openai_auth = true$/m);
+    assert.doesNotMatch(configured, /\[model_providers\.codex-router\.auth\]/);
+    assert.doesNotMatch(configured, /caller-key-auth-command\.mjs/);
+    assert.match(configured, /^openai_base_url = "http:\/\/127\.0\.0\.1:46192\/v1"$/m);
+    assert.doesNotMatch(configured, new RegExp(CALLER_KEY));
+    assert.doesNotMatch(configured, /\/_codex-router\/[A-Za-z0-9_-]+\/v1/);
     assert.match(
       configured,
       /^experimental_realtime_webrtc_call_base_url = "https:\/\/chatgpt\.com\/backend-api\/codex"$/m,
@@ -625,6 +626,9 @@ approval_policy = "never"
     assert.match(loginFreeConfig, /^model_provider = "custom"$/m);
     assert.match(loginFreeConfig, /name = "Codex Router \(external models\)"/);
     assert.match(loginFreeConfig, /requires_openai_auth = false/);
+    assert.match(loginFreeConfig, /\[model_providers\.custom\.auth\]/);
+    assert.match(loginFreeConfig, /caller-key-auth-command\.mjs/);
+    assert.doesNotMatch(loginFreeConfig, new RegExp(CALLER_KEY));
     assert.match(loginFreeConfig, /model = "deepseek\/deepseek-v4-pro"/);
     assert.match(loginFreeConfig, /model_reasoning_effort = "high"/);
     assert.match(loginFreeConfig, /\[profiles\.work\]/);
@@ -864,9 +868,12 @@ test("disabling the router from login-free mode restores an originally unset pro
     const enabledConfig = readFileSync(configPath, "utf8");
     // Built-in provider ids cannot be overridden on current Codex builds, so
     // the implicit OpenAI provider takes the proven provider-switch fallback.
-    assert.match(enabledConfig, /^openai_base_url = "http:\/\/127\.0\.0\.1:\d+\/_codex-router\/[^"]+\/v1"$/m);
+    assert.match(enabledConfig, /^openai_base_url = "http:\/\/127\.0\.0\.1:\d+\/v1"$/m);
     assert.match(enabledConfig, /^model_provider = "codex-router"$/m);
     assert.match(enabledConfig, /\[model_providers\.codex-router\]/);
+    assert.match(enabledConfig, /\[model_providers\.codex-router\.auth\]/);
+    assert.match(enabledConfig, /caller-key-auth-command\.mjs/);
+    assert.doesNotMatch(enabledConfig, new RegExp(CALLER_KEY));
 
     const disabled = run("disable", codexHome, stateDir);
     assert.equal(disabled.mode, "native");
@@ -911,8 +918,11 @@ model_provider = "openai"
 
     const loginFreeConfig = readFileSync(configPath, "utf8");
     assert.match(loginFreeConfig, /^model_provider = "codex-router"$/m);
-    assert.match(loginFreeConfig, /^openai_base_url = "http:\/\/127\.0\.0\.1:\d+\/_codex-router\/[^"]+\/v1"$/m);
+    assert.match(loginFreeConfig, /^openai_base_url = "http:\/\/127\.0\.0\.1:\d+\/v1"$/m);
     assert.match(loginFreeConfig, /\[model_providers\.codex-router\]/);
+    assert.match(loginFreeConfig, /\[model_providers\.codex-router\.auth\]/);
+    assert.match(loginFreeConfig, /caller-key-auth-command\.mjs/);
+    assert.doesNotMatch(loginFreeConfig, new RegExp(CALLER_KEY));
 
     const drifted = loginFreeConfig.replace(
       'model_provider = "codex-router"',
@@ -1170,7 +1180,7 @@ test("config manager adopts the exact legacy router-owned provider table", () =>
         'name = "Codex Router (external models)"',
         'name = "Codex Router (extra providers)"',
       )
-      .replace('wire_api = "responses"', 'wire_api = "responses"\nrequires_openai_auth = true');
+      ;
     writeFileSync(configPath, legacy, { mode: 0o600 });
 
     const enabled = run("login-free-enable", codexHome, stateDir, ["kimi-oauth/kimi-k2.5"]);
@@ -1349,8 +1359,9 @@ model = "gpt-5.6-terra"
   try {
     assert.equal(run("enable", codexHome, stateDir).mode, "router");
     const configured = readFileSync(configPath, "utf8");
-    assert.ok(configured.includes("http://127.0.0.1:46192/_codex-router/"));
+    assert.ok(configured.includes("http://127.0.0.1:46192/v1"));
     assert.doesNotMatch(configured, /127\.0\.0\.1:4102/);
+    assert.doesNotMatch(configured, new RegExp(CALLER_KEY));
     assert.match(configured, /\[profiles\.work\]/);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
@@ -1508,7 +1519,8 @@ Authorization = "Bearer PROVIDER_HEADER_SECRET"
     assert.match(configured, /# BEGIN codex-router-signed-provider-managed/);
     assert.match(configured, /\[model_providers\.custom\]/);
     assert.doesNotMatch(configured, /\[model_providers\.codex-router-signed\]/);
-    assert.match(configured, new RegExp(`base_url = "http://127\\.0\\.0\\.1:46192/_codex-router/${CALLER_KEY}/v1"`));
+    assert.match(configured, /base_url = "http:\/\/127\.0\.0\.1:46192\/v1"/);
+    assert.doesNotMatch(configured, new RegExp(CALLER_KEY));
     assert.match(configured, /requires_openai_auth = true/);
     assert.match(configured, /supports_websockets = false/);
     assert.match(configured, /^supports_standalone_web_search = true$/m);

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -2187,7 +2187,7 @@ accent = "#4e96d1"
   }
 });
 
-test("caller capability refresh preserves Codex policy while replacing managed URLs", () => {
+test("caller capability refresh preserves Codex policy without embedding the rotated key", () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-caller-refresh-"));
   const stateDir = path.join(codexHome, "router-state");
   const configPath = path.join(codexHome, "config.toml");
@@ -2201,7 +2201,9 @@ test("caller capability refresh preserves Codex policy while replacing managed U
     const result = run("caller-capability-refresh", codexHome, stateDir);
     assert.equal(result.refreshed, true);
     const after = readFileSync(configPath, "utf8");
-    assert.equal(after, before.replaceAll(CALLER_KEY, nextSecret));
+    assert.equal(after, before);
+    assert.doesNotMatch(after, new RegExp(CALLER_KEY));
+    assert.doesNotMatch(after, new RegExp(nextSecret));
     assert.match(after, /model = "keep-model"/);
     assert.match(after, /ambient-suggestions-enabled = false/);
   } finally {

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -99,7 +99,7 @@ function probe(target, providers, usageEvents = [], options = {}) {
     const ownershipId = "00000000000000000000000000000000";
     writeFileSync(
       path.join(stateDir, "config.toml"),
-      `model = ${JSON.stringify(options.selectedModel || "deepseek/deepseek-v4-pro")}\nmodel_provider = ${JSON.stringify(loginFreeProvider)}\n\n# codex-router-signed-provider-tree-slot ${ownershipId} 0\n# BEGIN codex-router-signed-provider-managed\n[model_providers.${loginFreeProvider}]\nname = "Codex Router (external models)"\nbase_url = "http://127.0.0.1:4202/v1"\nwire_api = "responses"\nrequires_openai_auth = false\nsupports_standalone_web_search = true\nsupports_websockets = false\n# END codex-router-signed-provider-managed\n`,
+      `model = ${JSON.stringify(options.selectedModel || "deepseek/deepseek-v4-pro")}\nmodel_provider = ${JSON.stringify(loginFreeProvider)}\n\n# codex-router-signed-provider-tree-slot ${ownershipId} 0\n# BEGIN codex-router-signed-provider-managed\n[model_providers.${loginFreeProvider}]\nname = "Codex Router (external models)"\nbase_url = "http://127.0.0.1:4202/v1"\nwire_api = "responses"\nrequires_openai_auth = false\nsupports_standalone_web_search = true\nsupports_websockets = false\n[model_providers.${loginFreeProvider}.auth]\ncommand = ${JSON.stringify(process.execPath)}\nargs = [${JSON.stringify(path.join(root, "src", "caller-key-auth-command.mjs"))}, ${JSON.stringify(path.join(stateDir, "caller-secret"))}]\ntimeout_ms = 5000\nrefresh_interval_ms = 0\n# END codex-router-signed-provider-managed\n`,
       { mode: 0o600 },
     );
     writePrivateJson(

--- a/test/doctor-routing-mode.test.mjs
+++ b/test/doctor-routing-mode.test.mjs
@@ -155,6 +155,42 @@ wire_api = "responses"
       assert.equal(byName.get("Routed model agents").status, "ok");
       assert.match(byName.get("Routed model agents").detail, /^0 current definitions/);
       assert.equal(byName.get("Signed router coexistence").status, "ok");
+
+      if (process.platform === "win32") {
+        // Codex Desktop writes config.toml atomically. Recreate the resulting
+        // inherited-ACL shape without changing the temporary directory ACL.
+        const configured = readFileSync(configPath, "utf8");
+        unlinkSync(configPath);
+        writeFileSync(configPath, configured, { mode: 0o600 });
+
+        const privacyDoctor = child("doctor.mjs", ["--json"], env);
+        const privacyReport = JSON.parse(privacyDoctor.stdout);
+        const privacy = privacyReport.checks.find((check) => check.name === "Codex config privacy");
+        assert.deepEqual(privacy, {
+          status: "ok",
+          name: "Codex config privacy",
+          detail: "router credentials stay outside config.toml",
+        });
+
+        const legacy = configured.replace(
+          /^openai_base_url\s*=.*$/m,
+          `openai_base_url = "http://127.0.0.1:46192/_codex-router/${callerSecret}/v1"`,
+        );
+        assert.notEqual(legacy, configured, "legacy fixture must replace the managed root URL");
+        assert.match(legacy, /\/_codex-router\/[A-Za-z0-9_-]+\/v1/);
+        unlinkSync(configPath);
+        writeFileSync(configPath, legacy, { mode: 0o600 });
+        assert.equal(readFileSync(configPath, "utf8"), legacy);
+        const legacyDoctor = child("doctor.mjs", ["--json"], env);
+        const legacyReport = JSON.parse(legacyDoctor.stdout);
+        const legacyPrivacy = legacyReport.checks.find((check) => check.name === "Codex config privacy");
+        assert.deepEqual(legacyPrivacy, {
+          status: "fail",
+          name: "Codex config privacy",
+          detail: "Windows ACL is broader than the current user",
+          fix: "Run ./bin/doctor --fix; the managed router URL contains a local caller capability.",
+        });
+      }
     } finally {
       rmSync(codexHome, { recursive: true, force: true });
     }

--- a/test/login-free-app-server.test.mjs
+++ b/test/login-free-app-server.test.mjs
@@ -313,6 +313,9 @@ async function verifySignedOutTurn(binary, { initialProvider = "openai" } = {}) 
     assert.match(config, new RegExp(`^model_provider = ${JSON.stringify(expectedProvider)}$`, "m"));
     assert.match(config, new RegExp(`\\[model_providers\\.${expectedProvider}\\]`));
     assert.doesNotMatch(config, /\[model_providers\.openai\]/);
+    assert.match(config, new RegExp(`\\[model_providers\\.${expectedProvider}\\.auth\\]`));
+    assert.match(config, /caller-key-auth-command\.mjs/);
+    assert.doesNotMatch(config, new RegExp(CALLER_KEY));
     if (initialProvider !== "openai") {
       assert.match(config, /requires_openai_auth = false/);
       assert.doesNotMatch(config, /direct\.invalid/);
@@ -320,8 +323,8 @@ async function verifySignedOutTurn(binary, { initialProvider = "openai" } = {}) 
 
     const notifications = await runAppServerTurn(binary, env, model, expectedProvider);
     assert.equal(requests.length, 1);
-    assert.match(requests[0].url, /\/_codex-router\/[^/]+\/v1\/responses$/);
-    assert.equal(requests[0].headers.authorization, undefined);
+    assert.equal(requests[0].url, "/v1/responses");
+    assert.equal(requests[0].headers.authorization, `Bearer ${CALLER_KEY}`);
     assert.equal(requests[0].body.model, model);
     assert.match(JSON.stringify(notifications), new RegExp(MARKER));
   } finally {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -450,9 +450,63 @@ test("plain Codex provider routes accept the caller key as a bearer token", asyn
     assert.equal(response.status, 200, await response.text());
     assert.equal(gatewayRequests.length, 1);
     assert.equal(gatewayRequests[0].headers.authorization, `Bearer ${INTERNAL_KEY}`);
+
+    const rejected = await fetch(`http://127.0.0.1:${routerPort}/v1/responses`, {
+      method: "POST",
+      headers: { Authorization: "Bearer unrelated-token", "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "deepseek/deepseek-v4-pro", input: "rejected" }),
+    });
+    assert.equal(rejected.status, 401);
+    assert.equal(gatewayRequests.length, 1, "an unrelated bearer reached the gateway");
   } finally {
     await stopChild(router);
     await closeServer(gateway.server);
+  }
+});
+
+test("plain signed Codex routes accept the current Codex API key", async () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "signed-codex-api-key-route-"));
+  const authPath = path.join(testRoot, "auth.json");
+  const apiKey = "sk-test-signed-codex-api-key";
+  writeFileSync(authPath, JSON.stringify({
+    auth_mode: "apikey",
+    OPENAI_API_KEY: apiKey,
+  }), { mode: 0o600 });
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      json(response, 200, { ok: true, credential_present: true });
+      return;
+    }
+    gatewayRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { route: "external" });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    MODEL_ROUTER_CODEX_AUTH: authPath,
+    MODEL_ROUTER_STATE_DIR: path.join(testRoot, "state"),
+    CODEX_ROUTER_QUIET: "1",
+  });
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`http://127.0.0.1:${routerPort}/v1/responses`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "deepseek/deepseek-v4-pro", input: "allowed" }),
+    });
+    assert.equal(response.status, 200, await response.text());
+    assert.equal(gatewayRequests.length, 1);
+    assert.equal(gatewayRequests[0].headers.authorization, `Bearer ${INTERNAL_KEY}`);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(testRoot, { recursive: true, force: true });
   }
 });
 

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -420,6 +420,88 @@ test("router requires the configured path capability before any model route", as
   }
 });
 
+test("plain Codex provider routes accept the caller key as a bearer token", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      json(response, 200, { ok: true, credential_present: true });
+      return;
+    }
+    gatewayRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { route: "external" });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`http://127.0.0.1:${routerPort}/v1/responses`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${CALLER_KEY}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "deepseek/deepseek-v4-pro", input: "allowed" }),
+    });
+    assert.equal(response.status, 200, await response.text());
+    assert.equal(gatewayRequests.length, 1);
+    assert.equal(gatewayRequests[0].headers.authorization, `Bearer ${INTERNAL_KEY}`);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
+test("plain signed Codex routes accept only the current Codex session bearer", async () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "signed-codex-route-"));
+  const authPath = path.join(testRoot, "auth.json");
+  const sessionToken = "test-signed-codex-session-token";
+  writeFileSync(authPath, JSON.stringify({
+    auth_mode: "chatgpt",
+    tokens: { access_token: sessionToken, account_id: "test-account" },
+  }), { mode: 0o600 });
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      json(response, 200, { ok: true, credential_present: true });
+      return;
+    }
+    gatewayRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { route: "external" });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    MODEL_ROUTER_CODEX_AUTH: authPath,
+    MODEL_ROUTER_STATE_DIR: path.join(testRoot, "state"),
+    CODEX_ROUTER_QUIET: "1",
+  });
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`http://127.0.0.1:${routerPort}/v1/responses`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${sessionToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "deepseek/deepseek-v4-pro", input: "allowed" }),
+    });
+    assert.equal(response.status, 200, await response.text());
+    assert.equal(gatewayRequests.length, 1);
+    assert.equal(gatewayRequests[0].headers.authorization, `Bearer ${INTERNAL_KEY}`);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("a canceled request does not flip activity into the error state", async () => {
   const gateway = await mockServer(async (request, response) => {
     if (request.method === "GET" && request.url === "/health") {


### PR DESCRIPTION
## Summary

Keep the router's caller capability out of Codex `config.toml` while preserving signed-in and explicit login-free routing.

- publish managed Codex providers on plain loopback `/v1` instead of embedding `/_codex-router/<caller-key>/v1`;
- authenticate normal signed-in Codex traffic by verifying the bearer Codex already presents against its current protected `auth.json` session;
- keep explicit login-free mode supported through a provider `auth.command` that reads the protected caller-secret file at runtime;
- keep legacy capability URLs recognized for migration and redaction;
- make doctor require a private Codex config ACL only while a legacy caller capability is actually present;
- keep Gemini/DSH capability-bearing documents on their existing strict privacy boundary.

## Root cause

Codex Desktop can atomically rewrite `~/.codex/config.toml` on Windows. A replacement file can inherit the parent `.codex` ACL, which may intentionally grant Codex sandbox users read access. When codex-router stores its caller capability directly inside `openai_base_url` / provider `base_url`, that otherwise-normal Desktop rewrite can expose the local router capability.

The durable boundary is therefore to keep the credential outside `config.toml`, rather than relying on re-hardening every replacement file.

This is related to the Windows config-rewrite/ACL behavior tracked in `openai/codex#41382`, but this PR hardens codex-router independently of whether Codex changes that behavior.

## Security properties

- plain `/v1` accepts only the configured caller key or the currently signed-in Codex access token;
- arbitrary bearer tokens still return 401;
- direct Codex authentication does not enable shared-session fallback consent;
- direct bearer matching uses actual token expiry, while the existing two-minute safety skew remains unchanged for shared-session fallback;
- login-free config stores only the path to the protected caller-secret file, never its contents;
- normal signed-in config contains neither the caller key nor an auth-command helper;
- legacy secret-bearing configs continue to fail doctor privacy checks when their ACL is broad.

## Verification

Exact head: `e8a19abb8b39f214505f60a03a04d501c232aab6`.

Fresh Windows verification:

- caller-auth / auth-command / native-session / catalog full files: **88 passed, 0 failed**;
- router capability + plain caller-bearer + current Codex-bearer integration: **3 passed, 0 failed**;
- config compatibility/migration set (login-free restore/switch, legacy adoption/refusal, port migration, signed restore, v2 state upgrade): **7 passed, 0 failed**;
- Windows doctor regression covering secret-free inherited ACL vs legacy capability-bearing inherited ACL: **1 passed, 0 failed**;
- `npm.cmd run check`: passed (`v2-agent applications valid (6)`, syntax checks passed);
- `git diff --cached --check` / `git diff origin/main...HEAD --check`: clean;
- patch-only sensitive-literal scan found no real Context7/Google/GitHub/OpenAI credentials, no real `~/.codex` path, and no hard-coded caller capability.

No provider/model inference calls were used.