### PR TITLE
Document Command Code plan fallback and harness boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,11 +715,14 @@ Provider accounts use the API. Everything appears as one
 `commandcode` for Chat Completions models and `commandcode-messages` for
 models that require the Messages protocol (Claude).
 
-**The Go plan is the exception.** A Go-plan account is refused by `/provider/v1`
-with `Your Go plan doesn't include API access`. That is an entitlement, not a
-credential problem: no key or reinstall changes it. Check the plan
-at [commandcode.ai/billing](https://commandcode.ai/billing) before enabling
-this provider.
+**The Go plan uses the coding-plan route.** A Go-plan account is refused by
+`/provider/v1` with `403 upgrade_required` even though its key is valid. When
+that exact entitlement response arrives before any response byte has been
+relayed, the router retries the turn through Command Code's `/alpha/generate`
+transport and remembers the result for that credential. Other 403s, timeouts,
+rate limits, and server failures do not trigger the fallback. The route is
+rechecked periodically so an upgraded account returns to the documented
+Provider API. Both paths use the same stored key and provider family.
 
 **Store an API key.** Create one in Command Code Studio and save it here:
 
@@ -730,8 +733,17 @@ this provider.
 
 When multiple API-key sources exist, the exported environment variable wins,
 then the key stored here, then the macOS Keychain. `doctor` names whichever
-source is live. The router does not install, launch, or read a Command Code
-CLI session.
+source is live. The router does not install, launch, or read a Command Code CLI
+session; `/alpha/generate` is called directly as an inference transport.
+
+Command Code's [headless CLI](https://commandcode.ai/docs/headless) is a
+complete autonomous coding agent with its own workspace, tools, permission
+decisions, sessions, and compaction. Launching it behind one Codex Responses
+request would create a second, hidden tool loop and would bypass Codex's tool
+events and approvals. It therefore cannot transparently replace the Codex
+harness or transfer CLI-only AST/context/taste optimizations into the Codex
+app. Codex remains the harness; this router only adapts the model transport and
+preserves Command Code's reported cached-token usage.
 
 | Picker label | Model ID |
 | --- | --- |


### PR DESCRIPTION
## Summary

- document the existing exact `403 upgrade_required` fallback from Command Code's Provider API to `/alpha/generate` for Go-plan credentials;
- clarify that the fallback is a direct inference transport and does not install, launch, or read the Command Code CLI;
- explain why Command Code's autonomous headless harness cannot transparently replace Codex's workspace, tool, event, permission, and session loop.

## Why

The previous README still described the Go plan as unusable through the router even though current main already implements the guarded plan transport. That stale text also made issue #524's proposed CLI shell-out appear like the missing implementation. A shell-out would instead create a nested autonomous agent whose tool mutations and approvals are invisible to Codex.

## Validation

- `npm run check`
- 85 focused Command Code, provider-family, and DSH publication tests
- `git diff --check`
- repository-maintainer final impact: documentation-only, two reviewed hunks

Closes #524 as not planned: the useful transport adaptation already exists, while transparent harness substitution is not a safe router boundary.
