### PR TITLE
Fix Command Code MCP namespace restoration

### DIFF
--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -43,6 +43,7 @@ import {
 // built from the exact tools that were flattened -- never by splitting names.
 
 export const NAMESPACE_DELIMITER = "__";
+const DEFAULT_FUNCTION_NAMESPACE = "functions";
 
 // Metadata derived from the request's exact tool schema. Keeping it beside the
 // Map in a WeakMap preserves the Map's public shape for existing callers while
@@ -1041,6 +1042,131 @@ export function flattenNamespaceTools(
   if (spawnAgentModels.size > 0) SPAWN_AGENT_MODELS.set(namespaces, spawnAgentModels);
   if (toolSearchRelay) TOOL_SEARCH_RELAYS.set(namespaces, toolSearchRelay);
   return { tools: flattened, flattened: changed, namespaces };
+}
+
+// A Codex custom-provider request can arrive with MCP tools already
+// flattened. In that shape the tool list no longer contains a
+// `type: "namespace"` entry, so flattenNamespaceTools cannot build the reverse
+// map needed when the provider returns the ordinary function call. Codex keeps
+// the canonical native identities in its reserved turn metadata. Recover only
+// direct functions whose exact flattened spelling is present in this request.
+//
+// The metadata also inventories ordinary functions under the default
+// `functions` namespace. Treat that entry, and any delimiter collision between
+// two native identities, as ambiguous rather than reinterpreting a legitimate
+// plain function as an MCP call. Keep this recovery MCP-scoped: app and
+// collaboration tools carry additional router-side behavior that a bare name
+// map cannot reconstruct safely.
+export function recoverPreflattenedMcpTools(tools, clientMetadata, namespaces) {
+  if (!Array.isArray(tools) || !(namespaces instanceof Map)) return false;
+  const encoded = clientMetadata?.["x-codex-turn-metadata"];
+  if (typeof encoded !== "string") return false;
+  let metadata;
+  try {
+    metadata = JSON.parse(encoded);
+  } catch {
+    return false;
+  }
+  const inventory = metadata?.tool_namespaces_info;
+  if (!inventory || typeof inventory !== "object" || Array.isArray(inventory)) {
+    return false;
+  }
+
+  const providerNames = new Set();
+  for (const tool of tools) {
+    if (tool?.type !== "function") continue;
+    const name = providerFunctionName(tool);
+    if (typeof name === "string" && name) providerNames.add(name);
+  }
+
+  const ordinaryNames = new Set();
+  const ordinary = inventory[DEFAULT_FUNCTION_NAMESPACE];
+  if (
+    ordinary?.name === DEFAULT_FUNCTION_NAMESPACE &&
+    ordinary.functions &&
+    typeof ordinary.functions === "object" &&
+    !Array.isArray(ordinary.functions)
+  ) {
+    for (const [name, info] of Object.entries(ordinary.functions)) {
+      if (name && info?.name === name) ordinaryNames.add(name);
+    }
+  }
+
+  // `undefined` marks a wire spelling with more than one native owner.
+  const candidates = new Map();
+  const rememberCandidate = (wireName, native) => {
+    if (!candidates.has(wireName)) {
+      candidates.set(wireName, native);
+      return;
+    }
+    const previous = candidates.get(wireName);
+    if (
+      previous?.namespace !== native.namespace ||
+      previous?.name !== native.name
+    ) {
+      candidates.set(wireName, undefined);
+    }
+  };
+
+  for (const [namespace, namespaceInfo] of Object.entries(inventory)) {
+    if (
+      !namespace ||
+      namespace === DEFAULT_FUNCTION_NAMESPACE ||
+      namespaceInfo?.name !== namespace
+    ) {
+      continue;
+    }
+    const functions = namespaceInfo?.functions;
+    if (!functions || typeof functions !== "object" || Array.isArray(functions)) continue;
+    for (const [name, info] of Object.entries(functions)) {
+      if (
+        !name ||
+        info?.name !== name ||
+        info.direct !== true ||
+        info.source?.kind !== "mcp" ||
+        typeof info.source.server_name !== "string" ||
+        !info.source.server_name
+      ) {
+        continue;
+      }
+      const wireName = `${namespace}${NAMESPACE_DELIMITER}${name}`;
+      if (!providerNames.has(wireName) || ordinaryNames.has(wireName)) continue;
+      rememberCandidate(wireName, { namespace, name });
+    }
+  }
+
+  const existingOwners = new Map();
+  for (const [namespace, names] of namespaces) {
+    for (const name of names) {
+      rememberCandidate(
+        `${namespace}${NAMESPACE_DELIMITER}${name}`,
+        { namespace, name },
+      );
+      existingOwners.set(`${namespace}${NAMESPACE_DELIMITER}${name}`, { namespace, name });
+    }
+  }
+
+  let recovered = false;
+  for (const [wireName, native] of candidates) {
+    if (!native || !providerNames.has(wireName)) continue;
+    const existing = existingOwners.get(wireName);
+    if (
+      existing &&
+      (existing.namespace !== native.namespace || existing.name !== native.name)
+    ) {
+      continue;
+    }
+    let names = namespaces.get(native.namespace);
+    if (!names) {
+      names = new Set();
+      namespaces.set(native.namespace, names);
+    }
+    if (!names.has(native.name)) {
+      names.add(native.name);
+      recovered = true;
+    }
+  }
+  return recovered;
 }
 
 function plainObject(value) {

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -44,6 +44,7 @@ import {
 
 export const NAMESPACE_DELIMITER = "__";
 const DEFAULT_FUNCTION_NAMESPACE = "functions";
+const MCP_NAMESPACE_PREFIX = "mcp__";
 
 // Metadata derived from the request's exact tool schema. Keeping it beside the
 // Map in a WeakMap preserves the Map's public shape for existing callers while
@@ -639,7 +640,7 @@ function trackedStateBytes(state) {
 // Audit the complete JSON grammar before parsing, compare decoded key values
 // so spellings such as `"name"` and `"\u006eame"` collide, and reject numeric
 // values whose parse/stringify semantics are known to be lossy.
-function jsonIsUnambiguousForRewrite(text) {
+function jsonIsUnambiguousForRewrite(text, { allowLossyNumbers = false } = {}) {
   if (typeof text !== "string") return false;
   let offset = 0;
 
@@ -697,7 +698,12 @@ function jsonIsUnambiguousForRewrite(text) {
     JSON_NUMBER_AT_OFFSET.lastIndex = offset;
     const match = JSON_NUMBER_AT_OFFSET.exec(text);
     if (!match) return false;
-    if (!jsonNumberIsStableForRewrite(match[0])) return false;
+    // Turn metadata is inspected only for string/bool namespace identities and
+    // is never reserialized here. Its unrelated numeric fields may therefore
+    // be lossy without changing the identity decision. Duplicate object keys
+    // remain forbidden in every mode: JSON.parse's last-wins behavior would
+    // otherwise let ambiguous metadata hide an ordinary-function collision.
+    if (!allowLossyNumbers && !jsonNumberIsStableForRewrite(match[0])) return false;
     offset = JSON_NUMBER_AT_OFFSET.lastIndex;
     return true;
   };
@@ -1061,6 +1067,7 @@ export function recoverPreflattenedMcpTools(tools, clientMetadata, namespaces) {
   if (!Array.isArray(tools) || !(namespaces instanceof Map)) return false;
   const encoded = clientMetadata?.["x-codex-turn-metadata"];
   if (typeof encoded !== "string") return false;
+  if (!jsonIsUnambiguousForRewrite(encoded, { allowLossyNumbers: true })) return false;
   let metadata;
   try {
     metadata = JSON.parse(encoded);
@@ -1080,15 +1087,21 @@ export function recoverPreflattenedMcpTools(tools, clientMetadata, namespaces) {
   }
 
   const ordinaryNames = new Set();
-  const ordinary = inventory[DEFAULT_FUNCTION_NAMESPACE];
-  if (
-    ordinary?.name === DEFAULT_FUNCTION_NAMESPACE &&
-    ordinary.functions &&
-    typeof ordinary.functions === "object" &&
-    !Array.isArray(ordinary.functions)
-  ) {
+  if (Object.hasOwn(inventory, DEFAULT_FUNCTION_NAMESPACE)) {
+    const ordinary = inventory[DEFAULT_FUNCTION_NAMESPACE];
+    if (
+      ordinary?.name !== DEFAULT_FUNCTION_NAMESPACE ||
+      !ordinary.functions ||
+      typeof ordinary.functions !== "object" ||
+      Array.isArray(ordinary.functions)
+    ) {
+      return false;
+    }
     for (const [name, info] of Object.entries(ordinary.functions)) {
-      if (name && info?.name === name) ordinaryNames.add(name);
+      if (!name || !info || typeof info !== "object" || Array.isArray(info) || info.name !== name) {
+        return false;
+      }
+      ordinaryNames.add(name);
     }
   }
 
@@ -1125,13 +1138,17 @@ export function recoverPreflattenedMcpTools(tools, clientMetadata, namespaces) {
         info.direct !== true ||
         info.source?.kind !== "mcp" ||
         typeof info.source.server_name !== "string" ||
-        !info.source.server_name
+        !info.source.server_name ||
+        namespace !== `${MCP_NAMESPACE_PREFIX}${info.source.server_name}`
       ) {
         continue;
       }
       const wireName = `${namespace}${NAMESPACE_DELIMITER}${name}`;
-      if (!providerNames.has(wireName) || ordinaryNames.has(wireName)) continue;
-      rememberCandidate(wireName, { namespace, name });
+      const plainIdentity = nativeToolKey(undefined, wireName);
+      const providerName =
+        NAME_ALIASES.get(namespaces)?.nativeToProvider.get(plainIdentity) || wireName;
+      if (!providerNames.has(providerName) || ordinaryNames.has(wireName)) continue;
+      rememberCandidate(wireName, { namespace, name, providerName });
     }
   }
 
@@ -1146,9 +1163,15 @@ export function recoverPreflattenedMcpTools(tools, clientMetadata, namespaces) {
     }
   }
 
-  let recovered = false;
+  // Validate every ownership transfer before mutating any request-local map.
+  // flattenNamespaceTools has already registered these definitions as plain
+  // functions, including any provider-bounded alias. Move that exact provider
+  // spelling to the canonical MCP identity rather than allocating a second
+  // alias that no live definition uses.
+  const recoveries = [];
+  const recoveryProviderNames = new Set();
   for (const [wireName, native] of candidates) {
-    if (!native || !providerNames.has(wireName)) continue;
+    if (!native || !providerNames.has(native.providerName)) continue;
     const existing = existingOwners.get(wireName);
     if (
       existing &&
@@ -1156,17 +1179,59 @@ export function recoverPreflattenedMcpTools(tools, clientMetadata, namespaces) {
     ) {
       continue;
     }
-    let names = namespaces.get(native.namespace);
+    if (namespaces.get(native.namespace)?.has(native.name)) continue;
+
+    const relay = NAME_ALIASES.get(namespaces);
+    const plainIdentity = nativeToolKey(undefined, wireName);
+    const nativeIdentity = nativeToolKey(native.namespace, native.name);
+    if (relay) {
+      if (
+        relay.nativeToProvider.get(plainIdentity) !== native.providerName ||
+        relay.providerOwners.get(native.providerName) !== plainIdentity ||
+        (relay.nativeToProvider.has(nativeIdentity) &&
+          relay.nativeToProvider.get(nativeIdentity) !== native.providerName)
+      ) {
+        return false;
+      }
+    }
+    if (recoveryProviderNames.has(native.providerName)) return false;
+    recoveryProviderNames.add(native.providerName);
+    recoveries.push({
+      wireName,
+      providerName: native.providerName,
+      namespace: native.namespace,
+      name: native.name,
+      plainIdentity,
+      nativeIdentity,
+    });
+  }
+
+  for (const recovery of recoveries) {
+    const relay = NAME_ALIASES.get(namespaces);
+    if (relay) {
+      relay.nativeToProvider.delete(recovery.plainIdentity);
+      relay.nativeToProvider.set(recovery.nativeIdentity, recovery.providerName);
+      relay.providerOwners.set(recovery.providerName, recovery.nativeIdentity);
+      relay.providerToNative.set(recovery.providerName, {
+        namespace: recovery.namespace,
+        name: recovery.name,
+      });
+      relay.plainProviderNames.delete(recovery.providerName);
+      const wireOwners = relay.wireOwners.get(recovery.wireName);
+      if (wireOwners) {
+        wireOwners.delete(recovery.plainIdentity);
+        wireOwners.add(recovery.nativeIdentity);
+      }
+    }
+    PLAIN_TOOL_NAMES.get(namespaces)?.delete(recovery.providerName);
+    let names = namespaces.get(recovery.namespace);
     if (!names) {
       names = new Set();
-      namespaces.set(native.namespace, names);
+      namespaces.set(recovery.namespace, names);
     }
-    if (!names.has(native.name)) {
-      names.add(native.name);
-      recovered = true;
-    }
+    names.add(recovery.name);
   }
-  return recovered;
+  return recoveries.length > 0;
 }
 
 function plainObject(value) {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -100,6 +100,7 @@ import {
   flattenNamespaceTools,
   flattenToolChoice,
   flattenToolSearchHistory,
+  recoverPreflattenedMcpTools,
   repairToolSchemaRoots,
   strictOpenCodeCompactionInput,
   stripSearchContentTypes,
@@ -2827,6 +2828,19 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     // strict Responses providers may reject. Run the shared root repair on the
     // tools alone without flattening their native representation.
     tools = repairToolSchemaRoots(tools);
+  }
+  // Recent Codex clients flatten namespace tools before sending them to a
+  // custom Responses provider. Their canonical turn metadata is the only
+  // request-local source that can distinguish that MCP identity from an
+  // ordinary function whose literal name happens to contain `__`.
+  if (
+    recoverPreflattenedMcpTools(
+      tools,
+      payload.client_metadata,
+      flattenedNamespaces,
+    )
+  ) {
+    namespacesFlattened = true;
   }
   if (needsZenFreeToolCompatibility(route)) {
     // Zen Free's measured schema boundary rejects recursive definition edges.

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -246,6 +246,58 @@ function preflattenedCommandCodeMcpPayload(
   };
 }
 
+function preflattenedBoundedMcpPayload(
+  stream = true,
+  model = "opencode-go-responses/gpt-5.6-luna",
+) {
+  const serverName = "neon__apm__production__snapshot__read_only";
+  const namespace = `mcp__${serverName}`;
+  const name = "get_monitor_snapshot_with_complete_context";
+  return {
+    model,
+    stream,
+    input: [
+      { type: "message", role: "user", content: "Call the monitor snapshot tool." },
+      {
+        type: "function_call",
+        namespace,
+        name,
+        call_id: "call_previous_snapshot",
+        arguments: "{}",
+      },
+      {
+        type: "function_call_output",
+        call_id: "call_previous_snapshot",
+        output: "previous snapshot",
+      },
+    ],
+    tools: [{
+      type: "function",
+      name: `${namespace}__${name}`,
+      description: "Long preflattened MCP fixture.",
+      parameters: { type: "object", properties: {}, additionalProperties: false },
+    }],
+    client_metadata: {
+      "x-codex-turn-metadata": JSON.stringify({
+        tool_namespaces_info: {
+          [namespace]: {
+            name: namespace,
+            functions: {
+              [name]: {
+                name,
+                direct: true,
+                code_mode_name: null,
+                deferred: false,
+                source: { kind: "mcp", server_name: serverName },
+              },
+            },
+          },
+        },
+      }),
+    },
+  };
+}
+
 function routedToolSearchHistoryPayload(
   stream = true,
   model = "opencode-go/deepseek-v4-flash",
@@ -1482,6 +1534,71 @@ test("Command Code models restore MCP calls Codex pre-flattened before the route
       { name: call.name, namespace: call.namespace },
       { name: "get_monitor_snapshot", namespace: "mcp__apmneonsnapshotro" },
       model,
+    );
+  }
+});
+
+test("bounded routes preserve one alias for pre-flattened MCP definitions and history", async () => {
+  const namespace = "mcp__neon__apm__production__snapshot__read_only";
+  const name = "get_monitor_snapshot_with_complete_context";
+  const wireName = `${namespace}__${name}`;
+  for (const stream of [true, false]) {
+    const result = await scenario(stream, {
+      model: "opencode-go-responses/gpt-5.6-luna",
+      requestPayload: preflattenedBoundedMcpPayload,
+      sseBody: (outgoing) => {
+        const providerName = outgoing.tools.find(
+          (tool) => tool.description === "Long preflattened MCP fixture.",
+        ).name;
+        return [
+          sseEvent({
+            type: "response.output_item.done",
+            item: {
+              type: "function_call",
+              name: providerName,
+              call_id: "call_snapshot",
+              arguments: "{}",
+            },
+          }),
+          sseEvent({ type: "response.completed" }),
+          "data: [DONE]\n\n",
+        ].join("");
+      },
+      jsonBody: (outgoing) => {
+        const providerName = outgoing.tools.find(
+          (tool) => tool.description === "Long preflattened MCP fixture.",
+        ).name;
+        return {
+          id: "resp_preflattened_bounded",
+          output: [{
+            type: "function_call",
+            name: providerName,
+            call_id: "call_snapshot",
+            arguments: "{}",
+          }],
+        };
+      },
+    });
+    assert.equal(result.gatewayBodies.length, 1);
+    const outgoing = result.gatewayBodies[0];
+    assert.equal(outgoing.client_metadata, undefined);
+    const providerTool = outgoing.tools.find(
+      (tool) => tool.description === "Long preflattened MCP fixture.",
+    );
+    assert.notEqual(providerTool.name, wireName);
+    assert.ok(providerTool.name.length <= 64);
+    const historyCall = outgoing.input.find(
+      (item) => item.call_id === "call_previous_snapshot",
+    );
+    assert.equal(historyCall.name, providerTool.name);
+    assert.equal(historyCall.namespace, undefined);
+
+    const call = stream
+      ? functionCallsFromSse(result.clientBody).get("call_snapshot")
+      : JSON.parse(result.clientBody).output[0];
+    assert.deepEqual(
+      { namespace: call.namespace, name: call.name },
+      { namespace, name },
     );
   }
 });

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -207,6 +207,45 @@ function routedRequestPayload(stream = true, model = "opencode-go/deepseek-v4-fl
   };
 }
 
+// Reproduce the reported Codex 0.149.1 custom-provider shape: namespace tools
+// are already flat when they reach the router, while canonical turn metadata
+// still carries the native identity Codex will use for dispatch.
+function preflattenedCommandCodeMcpPayload(
+  stream = true,
+  model = "commandcode/deepseek-v4-flash",
+) {
+  const namespace = "mcp__apmneonsnapshotro";
+  const name = "get_monitor_snapshot";
+  return {
+    model,
+    stream,
+    input: "Call the monitor snapshot tool.",
+    tools: [{
+      type: "function",
+      name: `${namespace}__${name}`,
+      parameters: { type: "object", properties: {}, additionalProperties: false },
+    }],
+    client_metadata: {
+      "x-codex-turn-metadata": JSON.stringify({
+        tool_namespaces_info: {
+          [namespace]: {
+            name: namespace,
+            functions: {
+              [name]: {
+                name,
+                direct: true,
+                code_mode_name: null,
+                deferred: false,
+                source: { kind: "mcp", server_name: "apmneonsnapshotro" },
+              },
+            },
+          },
+        },
+      }),
+    },
+  };
+}
+
 function routedToolSearchHistoryPayload(
   stream = true,
   model = "opencode-go/deepseek-v4-flash",
@@ -1407,6 +1446,44 @@ test("routed request flattens every namespace to the gateway and restores calls 
   // The router never executed any app tool: the gateway saw exactly one
   // request and the client saw exactly the relayed calls.
   assert.equal(first.gatewayBodies.length, 1);
+});
+
+test("Command Code models restore MCP calls Codex pre-flattened before the router", async () => {
+  const flatName = "mcp__apmneonsnapshotro__get_monitor_snapshot";
+  for (const model of [
+    "commandcode/deepseek-v4-flash",
+    "commandcode/hy4-preview",
+  ]) {
+    const streamed = await scenario(true, {
+      model,
+      requestPayload: preflattenedCommandCodeMcpPayload,
+      sseBody: () => [
+        sseEvent({
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            name: flatName,
+            call_id: "call_snapshot",
+            arguments: "{}",
+          },
+        }),
+        sseEvent({ type: "response.completed" }),
+        "data: [DONE]\n\n",
+      ].join(""),
+    });
+    assert.equal(streamed.gatewayBodies.length, 1, model);
+    assert.equal(streamed.gatewayBodies[0].client_metadata, undefined, model);
+    assert.ok(
+      streamed.gatewayBodies[0].tools.some((tool) => tool.name === flatName),
+      model,
+    );
+    const call = functionCallsFromSse(streamed.clientBody).get("call_snapshot");
+    assert.deepEqual(
+      { name: call.name, namespace: call.namespace },
+      { name: "get_monitor_snapshot", namespace: "mcp__apmneonsnapshotro" },
+      model,
+    );
+  }
 });
 
 test("non-streaming routed responses restore namespace calls before client dispatch", async () => {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -14,6 +14,7 @@ import {
   flattenNamespaceTools,
   flattenToolChoice,
   flattenToolSearchHistory,
+  recoverPreflattenedMcpTools,
   rewriteNamespaceFunctionCall,
   rewriteNamespaceResponsePayload,
   repairToolSchemaRoots,
@@ -161,6 +162,130 @@ test("flattenNamespaceTools flattens every namespace, including MCP ones", () =>
   assert.deepEqual([...namespaces.get("collaboration")].sort(), ["spawn_agent", "wait_agent"]);
   assert.deepEqual([...namespaces.get("mcp__node_repl")].sort(), ["js", "js_reset"]);
   assert.deepEqual([...namespaces.get("mcp__codex_apps__github")], ["fetch_issue"]);
+});
+
+test("turn metadata recovers a namespace Codex flattened before the router", () => {
+  const wireName = "mcp__neon__apm__staging__snapshot__ro__get_monitor_snapshot";
+  const tools = [{ type: "function", name: wireName, parameters: { type: "object" } }];
+  const { namespaces } = flattenNamespaceTools(tools);
+  const clientMetadata = {
+    "x-codex-turn-metadata": JSON.stringify({
+      tool_namespaces_info: {
+        "mcp__neon__apm__staging__snapshot__ro": {
+          name: "mcp__neon__apm__staging__snapshot__ro",
+          functions: {
+            get_monitor_snapshot: {
+              name: "get_monitor_snapshot",
+              direct: true,
+              code_mode_name: null,
+              deferred: false,
+              source: { kind: "mcp", server_name: "neon__apm__staging__snapshot__ro" },
+            },
+          },
+        },
+      },
+    }),
+  };
+
+  assert.equal(
+    recoverPreflattenedMcpTools(tools, clientMetadata, namespaces),
+    true,
+  );
+  assert.deepEqual(
+    rewriteNamespaceResponsePayload(
+      {
+        output: [{
+          type: "function_call",
+          name: wireName,
+          call_id: "call_snapshot",
+          arguments: "{}",
+        }],
+      },
+      buildNamespaceLookups(namespaces),
+    ).output[0],
+    {
+      type: "function_call",
+      name: "get_monitor_snapshot",
+      namespace: "mcp__neon__apm__staging__snapshot__ro",
+      call_id: "call_snapshot",
+      arguments: "{}",
+    },
+  );
+});
+
+test("pre-flattened recovery does not reinterpret an ordinary function collision", () => {
+  const wireName = "mcp__calendar__create_event";
+  const tools = [{ type: "function", name: wireName }];
+  const { namespaces } = flattenNamespaceTools(tools);
+  const clientMetadata = {
+    "x-codex-turn-metadata": JSON.stringify({
+      tool_namespaces_info: {
+        functions: {
+          name: "functions",
+          functions: {
+            [wireName]: {
+              name: wireName,
+              direct: true,
+              source: { kind: "harness" },
+            },
+          },
+        },
+        mcp__calendar: {
+          name: "mcp__calendar",
+          functions: {
+            create_event: {
+              name: "create_event",
+              direct: true,
+              source: { kind: "mcp", server_name: "calendar" },
+            },
+          },
+        },
+      },
+    }),
+  };
+
+  assert.equal(
+    recoverPreflattenedMcpTools(tools, clientMetadata, namespaces),
+    false,
+  );
+  assert.equal(namespaces.size, 0);
+});
+
+test("pre-flattened recovery fails closed on ambiguous delimiter ownership", () => {
+  const tools = [{ type: "function", name: "mcp__calendar__admin__create" }];
+  const { namespaces } = flattenNamespaceTools(tools);
+  const clientMetadata = {
+    "x-codex-turn-metadata": JSON.stringify({
+      tool_namespaces_info: {
+        mcp__calendar: {
+          name: "mcp__calendar",
+          functions: {
+            admin__create: {
+              name: "admin__create",
+              direct: true,
+              source: { kind: "mcp", server_name: "calendar" },
+            },
+          },
+        },
+        mcp__calendar__admin: {
+          name: "mcp__calendar__admin",
+          functions: {
+            create: {
+              name: "create",
+              direct: true,
+              source: { kind: "mcp", server_name: "calendar__admin" },
+            },
+          },
+        },
+      },
+    }),
+  };
+
+  assert.equal(
+    recoverPreflattenedMcpTools(tools, clientMetadata, namespaces),
+    false,
+  );
+  assert.equal(namespaces.size, 0);
 });
 
 test("flattenNamespaceTools keeps the full tool schema on flattened entries", () => {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -288,6 +288,198 @@ test("pre-flattened recovery fails closed on ambiguous delimiter ownership", () 
   assert.equal(namespaces.size, 0);
 });
 
+test("pre-flattened recovery transfers a bounded provider alias to the MCP identity", () => {
+  const serverName = "neon__apm__production__snapshot__read_only";
+  const namespace = `mcp__${serverName}`;
+  const name = "get_monitor_snapshot_with_complete_context";
+  const wireName = `${namespace}__${name}`;
+  const flattened = flattenNamespaceTools(
+    [{ type: "function", name: wireName, parameters: { type: "object" } }],
+    { maxNameLength: 64 },
+  );
+  const providerName = flattened.tools[0].name;
+  assert.notEqual(providerName, wireName);
+  assert.ok(providerName.length <= 64);
+
+  assert.equal(
+    recoverPreflattenedMcpTools(
+      flattened.tools,
+      {
+        "x-codex-turn-metadata": JSON.stringify({
+          tool_namespaces_info: {
+            [namespace]: {
+              name: namespace,
+              functions: {
+                [name]: {
+                  name,
+                  direct: true,
+                  source: { kind: "mcp", server_name: serverName },
+                },
+              },
+            },
+          },
+        }),
+      },
+      flattened.namespaces,
+    ),
+    true,
+  );
+  assert.equal(
+    flattenNamespacedHistory(
+      [{ type: "function_call", namespace, name, call_id: "call_history", arguments: "{}" }],
+      flattened.namespaces,
+    )[0].name,
+    providerName,
+  );
+  assert.deepEqual(
+    rewriteNamespaceResponsePayload(
+      {
+        output: [{
+          type: "function_call",
+          name: providerName,
+          call_id: "call_live",
+          arguments: "{}",
+        }],
+      },
+      buildNamespaceLookups(flattened.namespaces),
+    ).output[0],
+    {
+      type: "function_call",
+      namespace,
+      name,
+      call_id: "call_live",
+      arguments: "{}",
+    },
+  );
+});
+
+test("pre-flattened recovery transfers collision-only alias ownership", () => {
+  const namespace = "mcp__calendar";
+  const name = "create_event";
+  const wireName = `${namespace}__${name}`;
+  const flattened = flattenNamespaceTools(
+    [{ type: "function", name: wireName }],
+    { aliasCollisions: true },
+  );
+  assert.equal(flattened.tools[0].name, wireName);
+  assert.equal(
+    recoverPreflattenedMcpTools(
+      flattened.tools,
+      {
+        "x-codex-turn-metadata": JSON.stringify({
+          tool_namespaces_info: {
+            [namespace]: {
+              name: namespace,
+              functions: {
+                [name]: {
+                  name,
+                  direct: true,
+                  source: { kind: "mcp", server_name: "calendar" },
+                },
+              },
+            },
+          },
+        }),
+      },
+      flattened.namespaces,
+    ),
+    true,
+  );
+  assert.equal(
+    flattenNamespacedHistory(
+      [{ type: "function_call", namespace, name, call_id: "call_history", arguments: "{}" }],
+      flattened.namespaces,
+    )[0].name,
+    wireName,
+  );
+  const restored = rewriteNamespaceResponsePayload(
+    {
+      output: [{
+        type: "function_call",
+        name: wireName,
+        call_id: "call_live",
+        arguments: "{}",
+      }],
+    },
+    buildNamespaceLookups(flattened.namespaces),
+  ).output[0];
+  assert.deepEqual(
+    { namespace: restored.namespace, name: restored.name },
+    { namespace, name },
+  );
+});
+
+test("pre-flattened recovery rejects malformed, duplicated, and non-MCP metadata", () => {
+  const namespace = "mcp__calendar";
+  const name = "create_event";
+  const wireName = `${namespace}__${name}`;
+  const mcpInfo = {
+    name: namespace,
+    functions: {
+      [name]: {
+        name,
+        direct: true,
+        source: { kind: "mcp", server_name: "calendar" },
+      },
+    },
+  };
+  const duplicateOrdinaryInventory =
+    `{"tool_namespaces_info":{` +
+    `"functions":{"name":"functions","functions":{"${wireName}":{"name":"${wireName}"}}},` +
+    `"functions":{"name":"functions","functions":{}},` +
+    `"${namespace}":${JSON.stringify(mcpInfo)}}}`;
+  const cases = [
+    JSON.stringify({
+      tool_namespaces_info: {
+        functions: { name: "functions", functions: [] },
+        [namespace]: mcpInfo,
+      },
+    }),
+    duplicateOrdinaryInventory,
+    JSON.stringify({
+      tool_namespaces_info: {
+        codex_app: {
+          name: "codex_app",
+          functions: {
+            create_thread: {
+              name: "create_thread",
+              direct: true,
+              source: { kind: "mcp", server_name: "calendar" },
+            },
+          },
+        },
+      },
+    }),
+    JSON.stringify({
+      tool_namespaces_info: {
+        [namespace]: {
+          ...mcpInfo,
+          functions: {
+            [name]: {
+              ...mcpInfo.functions[name],
+              source: { kind: "mcp", server_name: "different" },
+            },
+          },
+        },
+      },
+    }),
+  ];
+
+  for (const encoded of cases) {
+    const toolName = encoded.includes("codex_app") ? "codex_app__create_thread" : wireName;
+    const { namespaces } = flattenNamespaceTools([{ type: "function", name: toolName }]);
+    assert.equal(
+      recoverPreflattenedMcpTools(
+        [{ type: "function", name: toolName }],
+        { "x-codex-turn-metadata": encoded },
+        namespaces,
+      ),
+      false,
+    );
+    assert.equal(namespaces.size, 0);
+  }
+});
+
 test("flattenNamespaceTools keeps the full tool schema on flattened entries", () => {
   const schema = {
     type: "object",


### PR DESCRIPTION
## Summary

- rebuild the request-local MCP namespace reverse map from Codex canonical turn metadata when tools arrive already flattened
- keep recovery MCP-scoped and fail closed for plain-function collisions or ambiguous delimiter ownership
- cover the reported DeepSeek V4 Flash and Hy4 Preview Command Code paths, including MCP server names containing `__`

## Testing

- `npm run check`
- `npm test` (3,102 tests; 3,082 passed, 20 skipped, 0 failed)
- focused namespace relay, router, and Responses WebSocket suites (158 passed, 0 failed)
- quota-free Codex 0.149.1 local mock control for structured MCP dispatch