### PR TITLE
Fix strict generic provider search capability leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Strict generic providers no longer receive unadvertised hosted-search
+  extensions.** Codex may attach `web_search`, `web_search_preview`,
+  `web_search_options`, and search-only `include` entries even when the chosen
+  routed model does not advertise search. The router now removes only those
+  hosted-search artifacts at its managed Responses boundary for unsupported
+  runtime-generic routes, while preserving ordinary functions (including one
+  named `web_search`), capable models, and direct gateway traffic. An explicit
+  request that can no longer satisfy `tool_choice` fails locally with a named
+  400 instead of reaching a strict upstream as an ambiguous request. Failover
+  also preserves the source model's hosted-versus-standalone search mode for
+  search-capable turns and refuses to guess after search history exists.
+
 - **Reinstalling over a state directory owned by another checkout no longer
   deadlocks.** The installers recorded the state directory's new owner only
   after the background service reported healthy, while the service itself

--- a/README.md
+++ b/README.md
@@ -286,10 +286,14 @@ the selected model has been verified for it. DeepSeek V4 Flash is enabled on
 its direct API and opencode Go routes. A compatible model declares
 `"searchTool": { "mode": "standalone" }` in its registry or user-model
 metadata. This capability is resolved from the selected model/provider pair;
-the router does not enable a global web-search switch or infer compatibility
-from an OpenAI-compatible endpoint. A model is advertised only after its
+the managed Codex provider block enables the provider half of standalone
+search so verified models can use it, while the merged catalog remains the
+per-model gate. The router never infers compatibility from an
+OpenAI-compatible endpoint. A model is advertised only after its exact
 provider path has been verified to preserve Codex search-result items and
-tool-call history.
+tool-call history. If Codex attaches hosted-search fields to an unsupported
+runtime-generic route anyway, the managed Responses boundary removes only
+those search extensions before the strict upstream sees them.
 
 For a routed model that has no verified standalone or provider-hosted search,
 Codex can instead use an explicit Perplexity Search sidecar. This is not a
@@ -480,9 +484,19 @@ but answer HTTP 400 when one is required, which fails the compatibility check
 and the routed-subagent handoff even though tool calling works. Answering yes
 stores `"requestProfile": "auto-tool-choice"`, and the router downgrades the
 forced choice for that model only (`--request-profile auto-tool-choice` in the
-`--models` form). The provider's own `/v1/models` endpoint always decides
-which models exist. Curated models are local to your machine and are not
-vetted by the repository's compatibility tests.
+`--models` form), for example:
+
+```sh
+./bin/curate-models PROVIDER --models MODEL_ID --request-profile auto-tool-choice
+```
+
+For an already-curated model, edit only that entry's `requestProfile` in the
+protected `user-models.json`, preserving its existing context, modalities,
+efforts, and other hand-tuned metadata; do not remove and re-add it or apply a
+broader vendor profile just to repair `tool_choice`. The provider's own
+`/v1/models` endpoint always decides which models exist. Curated models are
+local to your machine and are not vetted by the repository's compatibility
+tests.
 
 The same managed OpenAI base URL also serves `/v1/embeddings`, but only for a
 model whose local or checked-in metadata explicitly names the capability. A

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -221,18 +221,24 @@ Codex sends the search result back through the normal routed Responses turn.
 This is a per-model compatibility declaration, not a claim that the upstream
 provider hosts search. Only enable it after verifying that the provider's
 model accepts Codex's web-search result items and preserves tool/function-call
-history. Do not enable a global Codex feature or provider flag for this: Codex
-does not use those settings to gate the tool per model, so they would expose
-`web.run` to unrelated routed models and could select a native OpenAI search
-path without the required ChatGPT session. The registry declaration is the
-only capability switch, and it is scoped to the exact model/provider route.
+history. The managed Codex provider block sets
+`supports_standalone_web_search = true` because Codex requires that provider
+half before any verified routed model can execute standalone search. It is not
+the advertisement gate: the merged catalog exposes search only for an exact
+model/provider route with a `searchTool` declaration (or a ready exact sidecar
+binding). An OpenAI-compatible endpoint proves neither capability. If Codex
+still sends ambient hosted-search extensions to an unsupported runtime-generic
+route, the router strips those extensions at its managed Responses boundary;
+it does not mutate direct gateway calls or ordinary caller-owned functions.
 
 The checked-in registry currently enables this mode for DeepSeek V4 Flash on
 its direct API and opencode Go routes, DeepSeek V4 Flash Vision Exp, Xiaomi
 MiMo v2.5, and GLM-5.3 on the Z.ai Coding Plan. Other provider/model pairs
 stay off until verified -- including GLM-5.3 on the opencode Go relay, which
-is a different transport from the Z.ai route the capability was proven on. User-model curation can opt in locally without changing the
-shared registry.
+is a different transport from the Z.ai route the capability was proven on. An
+operator can opt in locally only by adding `searchTool` to that exact entry in
+the protected `user-models.json` after verifying the route. The curation CLI
+does not ask for or infer search mode from an upstream catalog claim.
 
 ### Per-model search sidecar
 

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -31,7 +31,6 @@ import { syncRoutedCodexAgents } from "./codex-agent-catalog.mjs";
 import {
   MODEL_BY_SLUG,
   MODEL_SLUG_ALIASES,
-  RUNTIME_PROVIDERS,
 } from "./model-registry.mjs";
 import {
   applyMultiAgentCapabilities,
@@ -62,25 +61,7 @@ import {
 } from "./native-catalog-source.mjs";
 import { discoveryDisabled } from "./discovery-mode.mjs";
 import { withCatalogPublicationLock } from "./catalog-publication-lock.mjs";
-import { genericProviderConfigured } from "./generic-provider-readiness.mjs";
-import { searchSidecarBindingForModel } from "./search-sidecar-state.mjs";
-import { trustedSearchProviderDescriptor } from "./search-sidecar-policy.mjs";
-
-export function sidecarSearchAvailable(model, {
-  bindingForModel = searchSidecarBindingForModel,
-  providers = RUNTIME_PROVIDERS,
-  providerReady = genericProviderConfigured,
-} = {}) {
-  let binding;
-  try {
-    binding = bindingForModel(model.slug);
-  } catch {
-    return false;
-  }
-  if (!binding || model.searchTool !== undefined) return false;
-  const provider = providers.get(binding.providerId);
-  return trustedSearchProviderDescriptor(provider, { requireGeneric: true }) && providerReady(provider.id);
-}
+import { routedModelSearchAvailable } from "./search-capability.mjs";
 
 const refresh = process.argv.includes("--refresh-native");
 
@@ -648,9 +629,7 @@ export function routedModel(template, model, behaviorTemplate = template) {
     // executed by the provider backend; standalone search is executed by
     // Codex and its result is replayed through the routed conversation. An
     // absent declaration remains the conservative default.
-    supports_search_tool:
-      ["hosted", "standalone"].includes(model.searchTool?.mode) ||
-      sidecarSearchAvailable(model),
+    supports_search_tool: routedModelSearchAvailable(model),
     supports_image_detail_original: model.supportsImageDetailOriginal === true,
     // A routed model must never inherit a native template's capability. Codex
     // now requires the key, and `false` is both schema-valid and conservative

--- a/src/model-failover.mjs
+++ b/src/model-failover.mjs
@@ -7,6 +7,10 @@ import { upstreamFailureKind } from "./error-translation.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { canonicalProviderId } from "./provider-selection.mjs";
 import { hasProviderTransportError } from "./transport-failure.mjs";
+import {
+  routedModelPreservesSearchContract,
+  routedModelSearchMode,
+} from "./search-capability.mjs";
 
 // Keeping a turn alive when the provider it was routed to has no usage left.
 //
@@ -322,7 +326,18 @@ function supportsImageInput(model) {
 // (estimateInputTokens), which errs high by design -- the safe direction here,
 // because trading a quota failure for a context-window rejection is a strictly
 // worse turn than the one it replaced.
-function eligible(model, { fromProvider, estimatedTokens, needsImage, needsMultiAgentV2, cooled }) {
+function eligible(
+  model,
+  {
+    fromProvider,
+    estimatedTokens,
+    needsImage,
+    needsMultiAgentV2,
+    requiredSearchMode,
+    hasSearchHistory,
+    cooled,
+  },
+) {
   if (!model?.slug) return false;
   if (canonicalProviderId(model.provider) === fromProvider) return false;
   if (cooled.has(canonicalProviderId(model.provider))) return false;
@@ -334,6 +349,15 @@ function eligible(model, { fromProvider, estimatedTokens, needsImage, needsMulti
   // is the registry saying this model must never be handed transcribed images.
   if (needsImage && !supportsImageInput(model) && model.visionBridge === false) return false;
   if (needsMultiAgentV2 && (model.multiAgentVersion || "v1") !== "v2") return false;
+  // Search is an execution contract, not just another tool label. Crossing
+  // from hosted to standalone search (or to no search) can strand an active
+  // call or replay history a destination never proved it accepts. If the
+  // original capability has disappeared while history still uses it, no
+  // candidate is safer than guessing.
+  if (!routedModelPreservesSearchContract(model, {
+    requiredMode: requiredSearchMode,
+    hasSearchHistory,
+  })) return false;
   return true;
 }
 
@@ -348,14 +372,41 @@ function eligible(model, { fromProvider, estimatedTokens, needsImage, needsMulti
 // caller, which is the only place that knows whether a session exists.
 export function rankFailoverCandidates(
   models,
-  { from, estimatedTokens, needsImage = false, needsMultiAgentV2 = false, chain = [], now } = {},
+  options = {},
 ) {
+  const {
+    from,
+    estimatedTokens,
+    needsImage = false,
+    needsMultiAgentV2 = false,
+    needsSearch = false,
+    hasSearchHistory = false,
+    requiredSearchMode: requiredSearchModeOverride,
+    chain = [],
+    now,
+  } = options;
   const fromProvider = canonicalProviderId(from?.provider || "");
+  // An explicitly captured absence is part of the request contract. `??`
+  // would mistake it for an omitted override and re-read mutable sidecar
+  // state after the source snapshot.
+  const requiredSearchMode = Object.hasOwn(options, "requiredSearchMode")
+    ? requiredSearchModeOverride
+    : needsSearch || hasSearchHistory
+      ? routedModelSearchMode(from)
+      : undefined;
   const cooled = new Set(Object.keys(readProviderCooldowns({ now })));
   const available = (Array.isArray(models) ? models : []).filter(
     (model) =>
       model.slug !== from?.slug &&
-      eligible(model, { fromProvider, estimatedTokens, needsImage, needsMultiAgentV2, cooled }),
+      eligible(model, {
+        fromProvider,
+        estimatedTokens,
+        needsImage,
+        needsMultiAgentV2,
+        requiredSearchMode,
+        hasSearchHistory,
+        cooled,
+      }),
   );
 
   if (chain.length) {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -80,6 +80,13 @@ import {
 } from "./search-sidecar.mjs";
 import { searchSidecarBindingForModel } from "./search-sidecar-state.mjs";
 import {
+  routedModelPreservesSearchContract,
+  routedModelSearchMode,
+  searchModePreservesSearchContract,
+  stripUnsupportedHostedSearch,
+  unsupportedSearchContractError,
+} from "./search-capability.mjs";
+import {
   canonicalProviderId,
   readProviderSelection,
   selectedConfiguredListedModels,
@@ -796,6 +803,59 @@ function normalizeAutoToolChoice(payload, route) {
   ) {
     payload.tool_choice = "auto";
   }
+}
+
+function routedSearchCompatibility(payload, route) {
+  const searchMode = routedModelSearchMode(route);
+  const provider = providerForModel(route);
+  const compatiblePayload = provider?.generic !== true || searchMode !== undefined
+    ? payload
+    : stripUnsupportedHostedSearch(payload, { model: route.slug });
+  return { payload: compatiblePayload, searchMode };
+}
+
+function inputHasWebSearchHistory(input) {
+  return Array.isArray(input) && input.some((item) => item?.type === "web_search_call");
+}
+
+function payloadHasHostedSearchIntent(payload) {
+  const tools = Array.isArray(payload?.tools) ? payload.tools : [];
+  const include = Array.isArray(payload?.include) ? payload.include : [];
+  return Boolean(
+    payload?.web_search_options !== undefined ||
+    tools.some((tool) => ["web_search", "web_search_preview"].includes(tool?.type)) ||
+    ["web_search", "web_search_preview"].includes(payload?.tool_choice?.type) ||
+    include.some(
+      (entry) => typeof entry === "string" && entry.startsWith("web_search_call."),
+    )
+  );
+}
+
+function snapshotRoutedSearch(payload, route) {
+  const compatible = routedSearchCompatibility(payload, route);
+  payload = compatible.payload;
+  return {
+    payload,
+    searchMode: compatible.searchMode,
+    needsSearch: payloadHasHostedSearchIntent(payload),
+  };
+}
+
+function routedSearchContract(snapshot, input) {
+  const hasSearchHistory = inputHasWebSearchHistory(input);
+  return {
+    needsSearch: snapshot.needsSearch,
+    hasSearchHistory,
+    requiredMode: snapshot.needsSearch || hasSearchHistory ? snapshot.searchMode : undefined,
+  };
+}
+
+function assertRoutedSearchContract(route, builtSearchMode, contract) {
+  if (
+    searchModePreservesSearchContract(builtSearchMode, contract) &&
+    routedModelPreservesSearchContract(route, contract)
+  ) return;
+  throw unsupportedSearchContractError(route?.slug);
 }
 
 // The documented Zen Free pair has two different wire contracts: Ox uses Chat
@@ -2248,7 +2308,7 @@ function extractResponseText(payload) {
 // The models a compaction may be tried on, best first, without sending
 // anything. The conversation's own model leads unless it has already said it
 // is empty, in which case asking it again only buys the same rejection.
-function compactionAttempts(route, aged, { allowFailover = true } = {}) {
+function compactionAttempts(route, aged, searchContract, { allowFailover = true } = {}) {
   if (!allowFailover) return [route];
   const settings = readFailoverSettings();
   if (!settings.enabled) return [route];
@@ -2260,6 +2320,9 @@ function compactionAttempts(route, aged, { allowFailover = true } = {}) {
       // serialized size is the honest measure of what a candidate must hold.
       estimatedTokens: estimateInputTokens(JSON.stringify(aged.input ?? [])),
       needsImage: inputHasImage(aged.input),
+      needsSearch: searchContract.needsSearch,
+      hasSearchHistory: searchContract.hasSearchHistory,
+      requiredSearchMode: searchContract.requiredMode,
       // Compaction sends `tools: []`, so no candidate needs the collaboration
       // proof to serve one.
       chain: settings.chain,
@@ -2275,7 +2338,15 @@ function compactionAttempts(route, aged, { allowFailover = true } = {}) {
 // here so a compaction can be moved to another model exactly like an ordinary
 // turn -- a compaction that fails ends the session just as hard, because the
 // conversation cannot get under its context limit without one.
-async function summarizeWith(request, payload, route, aged, prepared, signal) {
+async function summarizeWith(
+  request,
+  payload,
+  route,
+  aged,
+  prepared,
+  signal,
+  { searchContract } = {},
+) {
   const compatibleInput = zenFreeCompatibleInput(aged.input, route);
   const providerInput = needsConsoleGoResponsesToolCompatibility(route)
     ? strictOpenCodeCompactionInput(compatibleInput, payload.tools, {
@@ -2314,7 +2385,18 @@ async function summarizeWith(request, payload, route, aged, prepared, signal) {
   // Compaction re-enters the same provider as the routed turn; Fireworks
   // rejects this OpenAI search parameter at that boundary too.
   if (providerForModel(route)?.id === "fireworks") delete body.web_search_options;
-  const serialized = JSON.stringify(body);
+  const searchCompatibility = routedSearchCompatibility(body, route);
+  const serialized = JSON.stringify(searchCompatibility.payload);
+  // Candidate capability may depend on a sidecar credential or binding that
+  // changed while image bridging was in flight. Preserve both the mode used
+  // to construct this exact body and the live mode at the send boundary: a
+  // disappear/reappear cycle must not authorize an already-stripped request.
+  if (
+    !searchModePreservesSearchContract(searchCompatibility.searchMode, searchContract) ||
+    !routedModelPreservesSearchContract(route, searchContract)
+  ) {
+    return { searchCapabilityChanged: true };
+  }
   const upstream = await fetch(`${GATEWAY_BASE}/responses`, {
     method: "POST",
     headers: routedHeaders(),
@@ -2325,6 +2407,16 @@ async function summarizeWith(request, payload, route, aged, prepared, signal) {
 }
 
 async function summarize(request, payload, route, signal, { allowFailover = true } = {}) {
+  // The conversation's selected route owns the capability contract. Resolve
+  // it before normalization so a fallback cannot add back ambient search that
+  // the selected model never advertised. Compaction itself sends no tools or
+  // tool choice, so discard those turn-only declarations before checking the
+  // provider-bound compact shape; an impossible ordinary turn must fail, but
+  // an ambient choice that compaction never forwards must not end the session.
+  payload = { ...payload, tools: [] };
+  delete payload.tool_choice;
+  const searchSnapshot = snapshotRoutedSearch(payload, route);
+  payload = searchSnapshot.payload;
   const originalInput = Array.isArray(payload.input) ? payload.input : [];
   // Compaction replays the whole conversation, so any image still in it would
   // reach the text-only model unbridged and fail the compaction rather than
@@ -2336,6 +2428,7 @@ async function summarize(request, payload, route, signal, { allowFailover = true
   // is cached by ciphertext, so a conversation whose turns already resolved
   // costs nothing extra here.
   const normalized = await normalizeRoutedAgentInput(request, originalInput, signal);
+  const searchContract = routedSearchContract(searchSnapshot, normalized);
   // Evidence is extracted before tool-result aging rewrites old output bytes.
   // The summarizer may select source IDs, but only this deterministic pass can
   // decide which source types and machine outcomes enter a kcr2 checkpoint.
@@ -2353,13 +2446,35 @@ async function summarize(request, payload, route, signal, { allowFailover = true
   // the conversation is on. A provider already known to be empty is dropped
   // rather than asked, exactly as on the turn path. Nothing is sent while this
   // list is built.
-  const attempts = compactionAttempts(route, aged, { allowFailover });
+  const attempts = compactionAttempts(route, aged, searchContract, { allowFailover });
   // Attempts that were sent and rejected, kept so the caller can meter each one.
   const failed = [];
   let last;
   for (let index = 0; index < attempts.length; index += 1) {
     const attemptRoute = attempts[index];
-    const sent = await summarizeWith(request, payload, attemptRoute, aged, prepared, signal);
+    if (
+      !routedModelPreservesSearchContract(attemptRoute, searchContract)
+    ) {
+      if (attemptRoute === route) throw unsupportedSearchContractError(route.slug);
+      logFailover(route, attemptRoute, "compaction/search-capability-changed", "not-sent", "skipped");
+      if (index + 1 === attempts.length && !attempts.includes(route)) attempts.push(route);
+      continue;
+    }
+    const sent = await summarizeWith(
+      request,
+      payload,
+      attemptRoute,
+      aged,
+      prepared,
+      signal,
+      { searchContract },
+    );
+    if (sent.searchCapabilityChanged) {
+      if (attemptRoute === route) throw unsupportedSearchContractError(route.slug);
+      logFailover(route, attemptRoute, "compaction/search-capability-changed", "not-sent", "skipped");
+      if (index + 1 === attempts.length && !attempts.includes(route)) attempts.push(route);
+      continue;
+    }
     let bytes;
     try {
       bytes = await readResponseBody(sent.upstream, {
@@ -2707,6 +2822,8 @@ function observeSubagentOutcome(request, route, status, options = {}) {
 // `agedInput`. The tool list is a local, and the input array is copied before
 // anything rewrites it.
 async function buildRoutedRequest({ request, payload, route, agedInput, tokenMaxxing = false }) {
+  const searchCompatibility = routedSearchCompatibility(payload, route);
+  payload = searchCompatibility.payload;
   let namespacesFlattened = false;
   let flattenedNamespaces = new Map();
   const provider = providerForModel(route);
@@ -2976,6 +3093,10 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     body: Buffer.from(JSON.stringify(routed), "utf8"),
     target: `${GATEWAY_BASE}/responses`,
     headers: routedHeaders(),
+    // The exact mode used while constructing this body. Failover compares it
+    // with the immutable source contract as well as live state immediately
+    // before send, so transient sidecar changes cannot validate stale bytes.
+    searchMode: searchCompatibility.searchMode,
     namespacesFlattened,
     flattenedNamespaces,
     // Close finished children the parent left Working. Only when the
@@ -3037,7 +3158,7 @@ async function prepareRoutedRequest({
 // probes every provider's credential synchronously and spawns
 // `/usr/bin/security` per keychain service on macOS, which would cost every
 // healthy turn about 250ms of blocked event loop for nothing.
-function failoverCandidates({ route, agedInput, flattenedNamespaces, chain }) {
+function failoverCandidates({ route, agedInput, flattenedNamespaces, searchContract, chain }) {
   const hidden = readHiddenModels();
   return rankFailoverCandidates(
     selectedConfiguredListedModels().filter((model) => !hidden.has(model.slug)),
@@ -3052,6 +3173,9 @@ function failoverCandidates({ route, agedInput, flattenedNamespaces, chain }) {
       // been through the collaboration proof. A child answering its own turn
       // does not.
       needsMultiAgentV2: collaborationToolAvailable(flattenedNamespaces),
+      needsSearch: searchContract.needsSearch,
+      hasSearchHistory: searchContract.hasSearchHistory,
+      requiredSearchMode: searchContract.requiredMode,
       chain,
     },
   );
@@ -3061,14 +3185,14 @@ function failoverCandidates({ route, agedInput, flattenedNamespaces, chain }) {
 // every destination must be the exact checked-in v2 route Codex was allowed to
 // spawn as an agent. Runtime health may remove a route, but it cannot certify
 // one or change its provider identity.
-function subagentTransportFailoverCandidates({ request, route, agedInput, chain }) {
+function subagentTransportFailoverCandidates({ request, route, agedInput, searchContract, chain }) {
   if (!request.headers["x-openai-subagent"]) return [];
   // The header describes the caller's turn; it is not certification evidence.
   // Require the failed route itself to carry the repository's exact v2 proof
   // before that metadata can select this stricter recovery path.
   if (subagentEligibility(route)) return [];
   const hidden = readHiddenModels();
-  const ranked = rankSubagentCandidates(
+  let ranked = rankSubagentCandidates(
     selectedConfiguredListedModels().filter((model) => !hidden.has(model.slug)),
     {
       chain,
@@ -3077,6 +3201,9 @@ function subagentTransportFailoverCandidates({ request, route, agedInput, chain 
         ...(inputHasImage(agedInput) ? ["vision"] : []),
       ],
     },
+  );
+  ranked = ranked.filter(
+    (candidate) => routedModelPreservesSearchContract(candidate.model, searchContract),
   );
   return subagentFallbackPlan(ranked, {
     failureKind: "transport",
@@ -3092,6 +3219,12 @@ function routedRequestFits(route, body) {
     !Number.isFinite(route?.contextWindow) ||
     route.contextWindow >= estimatedTokens
   );
+}
+
+function candidateBuildCompatibilityCode(error) {
+  if (error?.code === "model_search_not_supported") return error.code;
+  if (error?.code === GROQ_TOOL_LIMIT_CODE && error?.provider === "groq") return error.code;
+  return undefined;
 }
 
 // `status` is always what the *asked-for* model said; `outcome` is what the
@@ -3130,6 +3263,7 @@ async function attemptModelFailover({
   signal,
   normalizedInput,
   agingEnabled,
+  searchContract,
 }) {
   const settings = readFailoverSettings();
   if (!settings.enabled) return undefined;
@@ -3139,12 +3273,14 @@ async function attemptModelFailover({
         request,
         route,
         agedInput,
+        searchContract,
         chain: settings.chain,
       })
     : failoverCandidates({
         route,
         agedInput,
         flattenedNamespaces,
+        searchContract,
         chain: settings.chain,
       }).slice(0, MAX_FAILOVER_HOPS);
   if (!candidates.length) {
@@ -3175,6 +3311,13 @@ async function attemptModelFailover({
         logFailover(route, model, verdict.reason, status, "context-too-small");
         continue;
       }
+      if (
+        !searchModePreservesSearchContract(built.searchMode, searchContract) ||
+        !routedModelPreservesSearchContract(model, searchContract)
+      ) {
+        logFailover(route, model, verdict.reason, status, "search-capability-changed");
+        continue;
+      }
       upstream = await fetch(built.target, {
         method: "POST",
         headers: built.headers,
@@ -3183,7 +3326,16 @@ async function attemptModelFailover({
       });
     } catch (error) {
       if (signal.aborted) throw error;
-      logFailover(route, model, verdict.reason, status, `transport/${error?.name || "Error"}`);
+      const compatibilityCode = candidateBuildCompatibilityCode(error);
+      logFailover(
+        route,
+        model,
+        verdict.reason,
+        status,
+        compatibilityCode
+          ? `compatibility/${compatibilityCode}`
+          : `transport/${error?.name || "Error"}`,
+      );
       continue;
     }
     if (upstream.ok) {
@@ -3277,7 +3429,7 @@ async function handleResponses(request, response, requestUrl) {
     const exactRouteProbe = exactRouteProbeRequested(request.headers);
     const encoded = await readRequestBody(request, { signal: controller.signal });
     const body = decodeBody(encoded, request.headers["content-encoding"]);
-    const payload = await parseBodyAsync(body);
+    let payload = await parseBodyAsync(body);
     controller.signal.throwIfAborted();
     requestedModel = typeof payload.model === "string" ? payload.model : "";
     let registeredRoute =
@@ -3365,6 +3517,7 @@ async function handleResponses(request, response, requestUrl) {
     let target;
     let headers;
     let routedBody;
+    let builtSearchMode;
     let namespacesFlattened = false;
     let flattenedNamespaces = new Map();
     // The route-independent half of the input, computed once. Failing the turn
@@ -3374,6 +3527,7 @@ async function handleResponses(request, response, requestUrl) {
     let normalizedInput;
     let agingEnabled = false;
     let agedInput;
+    let searchContract;
     // Adopts a rebuilt request for a different model. Everything downstream --
     // the response transforms, the prompt-token estimate, the empty-completion
     // retry -- reads these, so all of them have to move together or the turn
@@ -3390,6 +3544,7 @@ async function handleResponses(request, response, requestUrl) {
       target = built.target;
       headers = built.headers;
       routedBody = built.body;
+      builtSearchMode = built.searchMode;
       // The tray Island has to name the model that is actually answering.
       activity.setRoute({
         provider: canonicalProviderId(route.provider),
@@ -3398,11 +3553,17 @@ async function handleResponses(request, response, requestUrl) {
       });
     };
     if (route) {
+      // Resolve the selected route's search contract once, before encrypted
+      // handoff normalization or any other external work. A later failover may
+      // not reintroduce ambient search that this route never advertised.
+      const searchSnapshot = snapshotRoutedSearch(payload, route);
+      payload = searchSnapshot.payload;
       normalizedInput = await normalizeRoutedAgentInput(
         request,
         payload.input,
         controller.signal,
       );
+      searchContract = routedSearchContract(searchSnapshot, normalizedInput);
       agingEnabled = toolResultAgingEnabled();
       const built = await prepareRoutedRequest({
         request,
@@ -3419,6 +3580,7 @@ async function handleResponses(request, response, requestUrl) {
       target = built.target;
       headers = built.headers;
       routedBody = built.body;
+      builtSearchMode = built.searchMode;
       // This provider has already said it would be empty until a named time.
       // Sending anyway buys one guaranteed rejection per turn for as long as
       // the window lasts, so move now and skip the dead round trip. The body
@@ -3434,6 +3596,7 @@ async function handleResponses(request, response, requestUrl) {
           route,
           agedInput,
           flattenedNamespaces,
+          searchContract,
           chain: settings.chain,
         }).slice(0, MAX_FAILOVER_HOPS);
         for (const next of candidates) {
@@ -3447,17 +3610,29 @@ async function handleResponses(request, response, requestUrl) {
               agingEnabled,
             });
           } catch (error) {
-            if (error?.code !== GROQ_TOOL_LIMIT_CODE || error?.provider !== "groq") throw error;
+            const compatibilityCode = candidateBuildCompatibilityCode(error);
+            if (!compatibilityCode) throw error;
             logFailover(
               route,
               next.model,
               `cooled_until_${cooled.until}`,
               "not-sent",
-              `compatibility/${error.code}`,
+              `compatibility/${compatibilityCode}`,
             );
             continue;
           }
-          if (routedRequestFits(next.model, candidate.body)) {
+          if (
+            !searchModePreservesSearchContract(candidate.searchMode, searchContract) ||
+            !routedModelPreservesSearchContract(next.model, searchContract)
+          ) {
+            logFailover(
+              route,
+              next.model,
+              `cooled_until_${cooled.until}`,
+              "not-sent",
+              "search-capability-changed",
+            );
+          } else if (routedRequestFits(next.model, candidate.body)) {
             logFailover(route, next.model, `cooled_until_${cooled.until}`, "not-sent", "swapped");
             adoptRoute(next.model, candidate);
             break;
@@ -3533,6 +3708,11 @@ async function handleResponses(request, response, requestUrl) {
     // attempt replays the identical bytes under the identical encoding. Nothing
     // here consumes a stream, which is what makes the request replayable at
     // all.
+    // The selected route is subject to the same immutable built-bytes and
+    // live capability contract as every fallback. This catches unsupported
+    // search history and sidecar changes after normalization before any
+    // provider-bound bytes leave the router.
+    if (route) assertRoutedSearchContract(route, builtSearchMode, searchContract);
     let { response: upstream, retries } = await fetchWithRetry(
       target,
       {
@@ -3590,6 +3770,7 @@ async function handleResponses(request, response, requestUrl) {
           signal: controller.signal,
           normalizedInput,
           agingEnabled,
+          searchContract,
         });
         if (moved) {
           // The attempt that failed is still a turn that happened and still
@@ -3823,8 +4004,16 @@ async function handleResponses(request, response, requestUrl) {
       // same bytes, same headers, same signal. The discarded first stream means
       // the retry supplies the only head, response id, sequence space,
       // reasoning, and output the client ever receives.
-      emptyCompletionRetried = true;
       let upstream2;
+      // The held first response creates another asynchronous boundary: a
+      // sidecar can be disabled or lose its credential while that stream is
+      // being classified. Revalidate immediately before replaying the exact
+      // bytes so the repair path cannot outlive the contract they encode. The
+      // discarded attempt's staged headers are no longer authoritative even
+      // when this check fails and the router writes its own local response.
+      clearStagedResponseHead(response);
+      if (route) assertRoutedSearchContract(route, builtSearchMode, searchContract);
+      emptyCompletionRetried = true;
       try {
         const retried = await fetchWithRetry(
           target,
@@ -4105,6 +4294,33 @@ async function handleResponses(request, response, requestUrl) {
         status: error.status,
         durationMs: Date.now() - startedAt,
         responseStartMs: upstreamLatencyMs,
+      });
+      usageRecorded = true;
+      return;
+    }
+    if (error?.code === "model_search_not_supported" && !response.headersSent) {
+      finalStatus = error.status;
+      activityStatus = error.status;
+      writeJson(response, error.status, {
+        error: {
+          type: error.code,
+          message: error.message,
+        },
+      });
+      recordUsageEvent({
+        model: route?.slug || requestedModel,
+        provider: route ? canonicalProviderId(route.provider) : "openai",
+        status: error.status,
+        durationMs: Date.now() - startedAt,
+        responseStartMs: upstreamLatencyMs,
+        ...usage,
+        estimatedInputTokens,
+        ...toolResultAging,
+        ...(emptyCompletion ? { emptyCompletion: true } : {}),
+        ...(emptyCompletionPreludeLimit
+          ? { emptyCompletionPreludeLimit }
+          : {}),
+        ...(failoverFrom ? { failoverFrom } : {}),
       });
       usageRecorded = true;
       return;

--- a/src/search-capability.mjs
+++ b/src/search-capability.mjs
@@ -1,0 +1,125 @@
+import { genericProviderConfigured } from "./generic-provider-readiness.mjs";
+import { RUNTIME_PROVIDERS } from "./model-registry.mjs";
+import { trustedSearchProviderDescriptor } from "./search-sidecar-policy.mjs";
+import { searchSidecarBindingForModel } from "./search-sidecar-state.mjs";
+
+export function sidecarSearchAvailable(model, {
+  bindingForModel = searchSidecarBindingForModel,
+  providers = RUNTIME_PROVIDERS,
+  providerReady = genericProviderConfigured,
+} = {}) {
+  let binding;
+  try {
+    binding = bindingForModel(model?.slug);
+  } catch {
+    return false;
+  }
+  if (!binding || model?.searchTool !== undefined) return false;
+  const provider = providers.get(binding.providerId);
+  return trustedSearchProviderDescriptor(provider, { requireGeneric: true }) && providerReady(provider.id);
+}
+
+// The catalog and the last provider-facing hop must answer this question from
+// the same evidence. A checked-in/user model can own search directly, while a
+// separately credentialed sidecar can add it to one exact routed slug. An
+// OpenAI-compatible endpoint alone proves neither capability.
+export function routedModelSearchAvailable(model, options) {
+  return routedModelSearchMode(model, options) !== undefined;
+}
+
+export function routedModelSearchMode(model, options) {
+  if (["hosted", "standalone"].includes(model?.searchTool?.mode)) {
+    return model.searchTool.mode;
+  }
+  return sidecarSearchAvailable(model, options) ? "standalone" : undefined;
+}
+
+export function routedModelPreservesSearchContract(
+  model,
+  { requiredMode, hasSearchHistory = false } = {},
+  options,
+) {
+  return searchModePreservesSearchContract(
+    routedModelSearchMode(model, options),
+    { requiredMode, hasSearchHistory },
+  );
+}
+
+export function searchModePreservesSearchContract(
+  searchMode,
+  { requiredMode, hasSearchHistory = false } = {},
+) {
+  if (hasSearchHistory && !requiredMode) return false;
+  return !requiredMode || searchMode === requiredMode;
+}
+
+const HOSTED_SEARCH_TOOL_TYPES = new Set(["web_search", "web_search_preview"]);
+
+function hostedSearchTool(tool) {
+  return HOSTED_SEARCH_TOOL_TYPES.has(tool?.type);
+}
+
+function unsupportedSearchError(message) {
+  const error = new Error(message);
+  error.status = 400;
+  error.code = "model_search_not_supported";
+  return error;
+}
+
+export function unsupportedSearchContractError(model) {
+  const label = model ? `Model ${model}` : "The selected model";
+  return unsupportedSearchError(
+    `${label} can no longer preserve this turn's web-search execution contract.`,
+  );
+}
+
+// Codex can attach provider-hosted search fields to a routed turn even when
+// the selected catalog entry advertises supports_search_tool=false. Remove
+// only those ambient hosted-search extensions. Function tools -- including a
+// function literally named web_search -- are ordinary caller-owned tools and
+// remain byte-for-byte intact.
+export function stripUnsupportedHostedSearch(payload, { model } = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return payload;
+  const tools = Array.isArray(payload.tools) ? payload.tools : undefined;
+  const strippedTools = tools?.filter((tool) => !hostedSearchTool(tool));
+  const removedTools = Boolean(tools && strippedTools.length !== tools.length);
+  const include = Array.isArray(payload.include) ? payload.include : undefined;
+  const strippedInclude = include?.filter(
+    (entry) => typeof entry !== "string" || !entry.startsWith("web_search_call."),
+  );
+  const removedInclude = Boolean(include && strippedInclude.length !== include.length);
+  const removedOptions = payload.web_search_options !== undefined;
+  const explicitHostedChoice = hostedSearchTool(payload.tool_choice);
+  if (!removedTools && !removedInclude && !removedOptions && !explicitHostedChoice) return payload;
+
+  const label = model ? `Model ${model}` : "The selected model";
+  if (explicitHostedChoice) {
+    throw unsupportedSearchError(
+      `${label} does not advertise web search, but tool_choice explicitly selects it.`,
+    );
+  }
+  if (removedTools && payload.tool_choice === "required" && strippedTools.length === 0) {
+    throw unsupportedSearchError(
+      `${label} does not advertise web search, and no supported tool remains for tool_choice required.`,
+    );
+  }
+
+  const next = { ...payload };
+  delete next.web_search_options;
+  if (removedTools) {
+    if (strippedTools.length) next.tools = strippedTools;
+    else delete next.tools;
+  }
+  if (removedInclude) {
+    if (strippedInclude.length) next.include = strippedInclude;
+    else delete next.include;
+  }
+  if (
+    removedTools &&
+    strippedTools.length === 0 &&
+    ["auto", "none"].includes(next.tool_choice)
+  ) {
+    delete next.tool_choice;
+  }
+  return next;
+}

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -28,8 +28,8 @@ import {
   promoteNativeMultiAgent,
   routedCatalogConfigured,
   routedModel,
-  sidecarSearchAvailable,
 } from "../src/catalog.mjs";
+import { sidecarSearchAvailable } from "../src/search-capability.mjs";
 
 const template = {
   slug: "gpt-5.5",

--- a/test/empty-completion-router.test.mjs
+++ b/test/empty-completion-router.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -281,8 +282,9 @@ async function mockServer(handler) {
   return { server, port: server.address().port };
 }
 
-function run(env) {
+function run(env, setupState) {
   const stateDir = mkdtempSync(path.join(os.tmpdir(), "empty-completion-router-state-"));
+  setupState?.(stateDir);
   const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
     cwd: root,
     env: {
@@ -481,6 +483,119 @@ test("an empty completion is retried once and the retry's content reaches the cl
   } finally {
     await stopChild(router);
     await closeServer(gw.server);
+  }
+});
+
+test("an empty-completion retry stops when its search sidecar disappears", async () => {
+  const providerId = "perplexity-sidecar";
+  const credentialRef = "cred_perplexity_sidecar_01";
+  const model = "deepseek/deepseek-v4-pro";
+  let sidecarsFile;
+  let stateDir;
+  let posts = 0;
+  const gw = await gateway((_request, response) => {
+    posts += 1;
+    if (posts === 1) {
+      writeFileSync(
+        sidecarsFile,
+        `${JSON.stringify({ version: 1, bindings: [] })}\n`,
+        { mode: 0o600 },
+      );
+    }
+    response.writeHead(200, {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+      "X-Upstream-Attempt": "discarded-first",
+    });
+    response.end(posts === 1 ? EMPTY_SSE_METERED : CONTENT_SSE);
+  });
+  const routerPort = await openPort();
+  const router = run(routerEnv(gw.port, routerPort), (directory) => {
+    stateDir = directory;
+    sidecarsFile = path.join(directory, "search-sidecars.json");
+    writeFileSync(
+      path.join(directory, "generic-providers.json"),
+      `${JSON.stringify({
+        version: 1,
+        providers: [{
+          id: providerId,
+          displayName: "Perplexity Search",
+          baseUrl: "https://api.perplexity.ai",
+          adapter: "openai-chat",
+          headers: {},
+          credentialRef,
+          allowPrivate: false,
+          enabled: true,
+        }],
+      })}\n`,
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      sidecarsFile,
+      `${JSON.stringify({
+        version: 1,
+        bindings: [{
+          model,
+          providerId,
+          adapter: "perplexity-search",
+          enabled: true,
+          timeoutMs: 1_000,
+          maxResults: 8,
+          cacheTtlMs: 60_000,
+          cacheMaxEntries: 128,
+          maxAttempts: 2,
+          retryDelayMs: 100,
+        }],
+      })}\n`,
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      path.join(directory, "provider-credentials.json"),
+      `${JSON.stringify({
+        schemaVersion: 2,
+        credentials: [{
+          id: credentialRef,
+          providerId,
+          providerType: "generic",
+          kind: "api_key",
+          secretRef: { type: "provider-file", providerId, target: "codex" },
+          state: "active",
+          createdAt: "2026-08-31T00:00:00.000Z",
+          updatedAt: "2026-08-31T00:00:00.000Z",
+        }],
+      })}\n`,
+      { mode: 0o600 },
+    );
+    mkdirSync(path.join(directory, "generic-provider-credentials"), { mode: 0o700 });
+    writeFileSync(
+      path.join(directory, "generic-provider-credentials", `${providerId}.key`),
+      "pplx-0123456789abcdefghijklmnopqrstuv\n",
+      { mode: 0o600 },
+    );
+  });
+
+  try {
+    await waitFor(`${callerBaseUrl(routerPort, CALLER_KEY)}/models`, router);
+    const result = await readRouted(routerPort, {
+      ...TURN_BODY,
+      tools: [{ type: "web_search" }],
+    });
+
+    assert.equal(result.status, 400, router.testErrors());
+    assert.equal(JSON.parse(result.body).error.type, "model_search_not_supported");
+    assert.equal(result.headers["cache-control"], undefined);
+    assert.equal(result.headers["x-upstream-attempt"], undefined);
+    assert.equal(posts, 1, "the retry must not reach the gateway after sidecar removal");
+    const [event] = await waitForUsageEvents(router.stateDir, 1, router);
+    assert.equal(event.status, 400);
+    assert.equal(event.inputTokens, 100);
+    assert.equal(event.cachedInputTokens, 60);
+    assert.equal(event.emptyCompletion, true);
+    assert.equal(event.emptyCompletionRetried, undefined);
+  } finally {
+    await stopChild(router);
+    await closeServer(gw.server);
+    rmSync(stateDir, { recursive: true, force: true });
   }
 });
 

--- a/test/generic-routing.test.mjs
+++ b/test/generic-routing.test.mjs
@@ -119,6 +119,12 @@ test("one generic gateway routes ordinary and explicitly profiled models without
     requestProfile: "codex-encrypted-schema",
     priority: 101,
   });
+  const autoToolChoice = userModelEntry({
+    providerId: "mixed-gateway",
+    upstreamId: "auto-tool-choice-model",
+    requestProfile: "auto-tool-choice",
+    priority: 102,
+  });
   writeFileSync(providersFile, `${JSON.stringify({
     version: 1,
     providers: [{
@@ -133,7 +139,7 @@ test("one generic gateway routes ordinary and explicitly profiled models without
   }, null, 2)}\n`);
   writeFileSync(userModelsFile, `${JSON.stringify({
     version: 1,
-    models: [ordinary, profiled],
+    models: [ordinary, profiled, autoToolChoice],
   }, null, 2)}\n`);
   const forwarderPort = await openPort();
   const forwarder = runForwarder({
@@ -166,7 +172,7 @@ test("one generic gateway routes ordinary and explicitly profiled models without
       credential_present: true,
       credential_source: "not required",
     });
-    for (const model of [ordinary, profiled]) {
+    for (const model of [ordinary, profiled, autoToolChoice]) {
       const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
         method: "POST",
         headers: {
@@ -178,22 +184,28 @@ test("one generic gateway routes ordinary and explicitly profiled models without
         body: JSON.stringify({
           model: model.gatewayModel,
           messages: [{ role: "user", content: "Use the tool." }],
+          web_search_options: { search_context_size: "medium" },
           tools: [{
             type: "function",
             function: { name: "inspect", description: "Inspect data.", parameters: schema },
-          }],
+          }, { type: "web_search" }],
+          tool_choice: "required",
         }),
       });
       assert.equal(response.status, 200, forwarder.testErrors());
       assert.equal((await response.json()).choices[0].message.content, "ok");
     }
 
-    assert.equal(upstreamRequests.length, 2);
+    assert.equal(upstreamRequests.length, 3);
     assert.ok(upstreamRequests.every((entry) => entry.url === "/v1/chat/completions"));
     assert.ok(upstreamRequests.every((entry) => entry.headers.authorization === undefined));
     assert.ok(upstreamRequests.every((entry) => entry.headers["x-tenant"] === "operator-owned"));
     assert.ok(upstreamRequests.every((entry) => entry.headers["x-ordinary-metadata"] === "kept"));
     assert.equal(upstreamRequests[0].body.model, ordinary.upstreamModel);
+    assert.deepEqual(upstreamRequests[0].body.web_search_options, {
+      search_context_size: "medium",
+    });
+    assert.deepEqual(upstreamRequests[0].body.tools[1], { type: "web_search" });
     assert.deepEqual(upstreamRequests[0].body.tools[0].function.parameters, schema);
     assert.equal(upstreamRequests[1].body.model, profiled.upstreamModel);
     const normalized = upstreamRequests[1].body.tools[0].function.parameters;
@@ -201,6 +213,10 @@ test("one generic gateway routes ordinary and explicitly profiled models without
     assert.equal("encrypted" in normalized.properties.value, false);
     assert.deepEqual(normalized.properties.encrypted, schema.properties.encrypted);
     assert.deepEqual(normalized.required, ["value", "encrypted"]);
+    assert.equal(upstreamRequests[0].body.tool_choice, "required");
+    assert.equal(upstreamRequests[1].body.tool_choice, "required");
+    assert.equal(upstreamRequests[2].body.model, autoToolChoice.upstreamModel);
+    assert.equal(upstreamRequests[2].body.tool_choice, "auto");
   } finally {
     await stop(forwarder);
     await close(upstream.server);

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -39,6 +39,31 @@ const GROQ_CANDIDATE = {
   inputModalities: ["text"],
   compHash: "groq-tool-limit-failover-fixture-v1",
 };
+const GENERIC_SEARCH_INCOMPATIBLE = {
+  slug: "strict-generic/plain-search-incompatible",
+  gatewayModel: "strict-generic-plain-search-incompatible",
+  upstreamModel: "plain-search-incompatible",
+  provider: "strict-generic",
+  listed: true,
+  displayName: "Strict generic search-incompatible fixture",
+  description: "Local routing test fixture.",
+  priority: 501,
+  defaultEffort: "high",
+  reasoningLevels: [{ effort: "high", description: "Adaptive reasoning" }],
+  contextWindow: 131_072,
+  autoCompact: 111_411,
+  inputModalities: ["text"],
+  compHash: "strict-generic-search-incompatible-fixture-v1",
+};
+const STRICT_GENERIC_PROVIDER = {
+  id: "strict-generic",
+  displayName: "Strict generic fixture",
+  baseUrl: "https://strict.example.test/v1",
+  adapter: "openai-chat",
+  headers: {},
+  allowPrivate: false,
+  enabled: true,
+};
 
 const TURN_BODY = { model: PRIMARY.slug, input: "hello", stream: true };
 
@@ -142,6 +167,7 @@ function run(
     cooldowns,
     toolResultAging = false,
     userModels,
+    genericProviders,
     v2Credentials = false,
   } = {},
 ) {
@@ -171,6 +197,13 @@ function run(
     writeFileSync(
       path.join(stateDir, "user-models.json"),
       JSON.stringify({ version: 1, models: userModels }),
+      "utf8",
+    );
+  }
+  if (Array.isArray(genericProviders)) {
+    writeFileSync(
+      path.join(stateDir, "generic-providers.json"),
+      JSON.stringify({ version: 1, providers: genericProviders }),
       "utf8",
     );
   }
@@ -435,6 +468,39 @@ test("a marked provider transport failure moves a subagent to a checked-in v2 ro
     assert.match(result.body, /answered-by-subagent-transport-fallback/);
     assert.doesNotMatch(result.body, /provider_transport_error/);
     assert.match(child.testErrors(), /reason=transport/);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("subagent transport failover preserves search history execution mode", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    seen.push(await bodyJson(request));
+    response.writeHead(502, { "Content-Type": "application/json" });
+    response.end(TRANSPORT_BODY);
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), {
+    chain: [V2_FALLBACK.slug],
+    v2Credentials: true,
+  });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(
+      routerPort,
+      {
+        ...TURN_BODY,
+        model: V2_THIRD.slug,
+        input: [{ type: "web_search_call", id: "search-history" }],
+      },
+      { headers: { "x-openai-subagent": "review-child" } },
+    );
+
+    assert.deepEqual(seen.map((body) => body.model), [V2_THIRD.gatewayModel]);
+    assert.equal(result.status, 502);
+    assert.match(child.testErrors(), /reason=transport -> none outcome=no-candidate/);
   } finally {
     await stopChild(child);
     await closeServer(gw.server);
@@ -888,6 +954,50 @@ test("cooldown failover skips a locally incompatible Groq candidate", async () =
     assert.equal(events[0].provider, "zai-api");
     assert.equal(events[0].failoverFrom, PRIMARY.slug);
     assert.equal(events[0].status, 200);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("cooldown failover skips a generic candidate rejected by search compatibility", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("safe-candidate"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), {
+    chain: [GENERIC_SEARCH_INCOMPATIBLE.slug, FALLBACK.slug],
+    cooldowns: {
+      deepseek: {
+        until: new Date(Date.now() + 30 * 60_000).toISOString(),
+        reason: "out_of_usage",
+      },
+    },
+    userModels: [GENERIC_SEARCH_INCOMPATIBLE],
+    genericProviders: [STRICT_GENERIC_PROVIDER],
+  });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, {
+      ...TURN_BODY,
+      tools: [{ type: "web_search" }],
+      tool_choice: "required",
+    });
+    assert.equal(result.status, 200);
+    assert.match(result.body, /answered-by-safe-candidate/);
+    assert.equal(seen.length, 1, "neither the cooled route nor rejected generic candidate is sent");
+    assert.equal(seen[0].model, FALLBACK.gatewayModel);
+
+    const logs = child.testErrors();
+    assert.match(
+      logs,
+      /-> strict-generic\/plain-search-incompatible outcome=compatibility\/model_search_not_supported/,
+    );
+    assert.match(logs, /-> zai-api\/glm-5\.2 outcome=swapped/);
   } finally {
     await stopChild(child);
     await closeServer(gw.server);

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -331,6 +331,65 @@ test("rankFailoverCandidates keeps a collaboration turn on a v2 model", () => {
   );
 });
 
+test("rankFailoverCandidates preserves the selected search execution mode", () => {
+  const from = model("source/hosted", "source", {
+    searchTool: { mode: "hosted" },
+  });
+  const ranked = rankFailoverCandidates(
+    [
+      model("hosted/compatible", "hosted", { searchTool: { mode: "hosted" } }),
+      model("standalone/incompatible", "standalone", {
+        searchTool: { mode: "standalone" },
+      }),
+      model("plain/incompatible", "plain"),
+    ],
+    { from, needsSearch: true },
+  );
+  assert.deepEqual(ranked.map((entry) => entry.model.slug), ["hosted/compatible"]);
+});
+
+test("rankFailoverCandidates leaves a search-capable model's ordinary turn unrestricted", () => {
+  const ranked = rankFailoverCandidates(
+    [model("plain/candidate", "plain")],
+    {
+      from: model("source/hosted", "source", { searchTool: { mode: "hosted" } }),
+    },
+  );
+  assert.deepEqual(ranked.map((entry) => entry.model.slug), ["plain/candidate"]);
+});
+
+test("rankFailoverCandidates ignores ambient search intent without source capability", () => {
+  const ranked = rankFailoverCandidates(
+    [model("plain/candidate", "plain")],
+    {
+      from: model("source/plain", "source"),
+      needsSearch: true,
+    },
+  );
+  assert.deepEqual(ranked.map((entry) => entry.model.slug), ["plain/candidate"]);
+});
+
+test("rankFailoverCandidates does not guess after search capability disappears", () => {
+  const ranked = rankFailoverCandidates(
+    [model("hosted/candidate", "hosted", { searchTool: { mode: "hosted" } })],
+    { from: model("source/plain", "source"), hasSearchHistory: true },
+  );
+  assert.deepEqual(ranked, []);
+});
+
+test("rankFailoverCandidates preserves an explicitly snapshotted absent mode", () => {
+  const ranked = rankFailoverCandidates(
+    [model("hosted/candidate", "hosted", { searchTool: { mode: "hosted" } })],
+    {
+      from: model("source/hosted", "source", { searchTool: { mode: "hosted" } }),
+      needsSearch: true,
+      hasSearchHistory: true,
+      requiredSearchMode: undefined,
+    },
+  );
+  assert.deepEqual(ranked, []);
+});
+
 test("rankFailoverCandidates refuses a model the registry bars from the vision bridge", () => {
   const ranked = rankFailoverCandidates(
     [

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -6062,6 +6062,233 @@ function curatedFireworksModel() {
   return { dir, file, gatewayModel: "fireworks-test-model" };
 }
 
+function genericSearchModelFixture() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "routing-generic-search-"));
+  const providersFile = path.join(dir, "generic-providers.json");
+  const userModelsFile = path.join(dir, "user-models.json");
+  const entry = (upstreamModel, priority) => ({
+    slug: `strict-gateway/${upstreamModel}`,
+    gatewayModel: `strict-gateway-${upstreamModel}`,
+    compHash: `strict-gateway-${upstreamModel}-user-v1`,
+    upstreamModel,
+    provider: "strict-gateway",
+    listed: true,
+    displayName: `${upstreamModel} (curated)`,
+    description: "Strict generic search routing fixture.",
+    priority,
+    defaultEffort: "high",
+    reasoningLevels: [{ effort: "high", description: "Adaptive reasoning" }],
+    contextWindow: 131_072,
+    autoCompact: 110_000,
+    inputModalities: ["text"],
+  });
+  const plain = entry("plain-model", 100);
+  const searchable = {
+    ...entry("search-model", 101),
+    searchTool: { mode: "hosted" },
+  };
+  writeFileSync(providersFile, `${JSON.stringify({
+    version: 1,
+    providers: [{
+      id: "strict-gateway",
+      displayName: "Strict Gateway",
+      baseUrl: "https://strict.example.test/v1",
+      adapter: "openai-chat",
+      headers: {},
+      allowPrivate: false,
+      enabled: true,
+    }],
+  })}\n`);
+  writeFileSync(userModelsFile, `${JSON.stringify({
+    version: 1,
+    models: [plain, searchable],
+  })}\n`);
+  return { dir, providersFile, userModelsFile, plain, searchable };
+}
+
+test("router enforces generic model search capability on ordinary and compact turns", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, {
+      id: `resp-${gatewayRequests.length}`,
+      object: "response",
+      status: "completed",
+      output: [{
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "ok" }],
+      }],
+    });
+  });
+  const fixture = genericSearchModelFixture();
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    MODEL_ROUTER_STATE_DIR: fixture.dir,
+    MODEL_ROUTER_GENERIC_PROVIDERS: fixture.providersFile,
+    MODEL_ROUTER_USER_MODELS: fixture.userModelsFile,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const headers = {
+    Authorization: `Bearer ${CALLER_KEY}`,
+    "Content-Type": "application/json",
+  };
+  const shell = { type: "function", name: "shell", parameters: { type: "object" } };
+  const functionNamedSearch = {
+    type: "function",
+    name: "web_search",
+    parameters: { type: "object" },
+  };
+  const webSearch = { type: "web_search", search_context_size: "medium" };
+  const preview = { type: "web_search_preview" };
+  const ambientSearch = {
+    web_search_options: { search_context_size: "medium" },
+    include: ["reasoning.encrypted_content", "web_search_call.action.sources"],
+    tools: [webSearch, shell, preview, functionNamedSearch],
+    tool_choice: "required",
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    for (const model of [fixture.plain, fixture.searchable]) {
+      const response = await fetch(`${routerBase(routerPort)}/responses`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ model: model.slug, input: "test", ...ambientSearch }),
+      });
+      assert.equal(response.status, 200, router.testErrors());
+    }
+
+    assert.equal(gatewayRequests[0].web_search_options, undefined);
+    assert.deepEqual(gatewayRequests[0].include, ["reasoning.encrypted_content"]);
+    assert.deepEqual(
+      gatewayRequests[0].tools.slice(0, 2).map((tool) => tool.name),
+      ["shell", "web_search"],
+    );
+    assert.equal(
+      gatewayRequests[0].tools.some((tool) => ["web_search", "web_search_preview"].includes(tool.type)),
+      false,
+    );
+    assert.equal(gatewayRequests[0].tool_choice, "required");
+    assert.deepEqual(gatewayRequests[1].web_search_options, ambientSearch.web_search_options);
+    assert.deepEqual(gatewayRequests[1].include, ambientSearch.include);
+    assert.deepEqual(gatewayRequests[1].tools.slice(0, ambientSearch.tools.length), ambientSearch.tools);
+
+    const compact = await fetch(`${routerBase(routerPort)}/responses/compact`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: fixture.plain.slug,
+        input: [{
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: "remember this" }],
+        }],
+        web_search_options: ambientSearch.web_search_options,
+        include: ambientSearch.include,
+        tools: [webSearch],
+        tool_choice: "required",
+      }),
+    });
+    assert.equal(compact.status, 200, router.testErrors());
+    assert.equal(gatewayRequests[2].web_search_options, undefined);
+    assert.deepEqual(gatewayRequests[2].include, ["reasoning.encrypted_content"]);
+    assert.deepEqual(gatewayRequests[2].tools, []);
+
+    for (const toolChoice of [{ type: "web_search" }, "required"]) {
+      const before = gatewayRequests.length;
+      const response = await fetch(`${routerBase(routerPort)}/responses`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          model: fixture.plain.slug,
+          input: "test",
+          tools: [webSearch],
+          tool_choice: toolChoice,
+        }),
+      });
+      assert.equal(response.status, 400);
+      assert.equal((await response.json()).error.type, "model_search_not_supported");
+      assert.equal(gatewayRequests.length, before);
+    }
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("router refuses unsupported search history on selected generic turns and compaction", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, {
+      id: `resp-${gatewayRequests.length}`,
+      object: "response",
+      status: "completed",
+      output: [{
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "ok" }],
+      }],
+    });
+  });
+  const fixture = genericSearchModelFixture();
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    MODEL_ROUTER_STATE_DIR: fixture.dir,
+    MODEL_ROUTER_GENERIC_PROVIDERS: fixture.providersFile,
+    MODEL_ROUTER_USER_MODELS: fixture.userModelsFile,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const headers = {
+    Authorization: `Bearer ${CALLER_KEY}`,
+    "Content-Type": "application/json",
+  };
+  const history = [{
+    type: "web_search_call",
+    id: "search-history",
+    status: "completed",
+    action: { type: "search", query: "router contract" },
+  }];
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    for (const suffix of ["", "/compact"]) {
+      const beforeUnsupported = gatewayRequests.length;
+      const unsupported = await fetch(`${routerBase(routerPort)}/responses${suffix}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ model: fixture.plain.slug, input: history }),
+      });
+      assert.equal(unsupported.status, 400);
+      assert.equal((await unsupported.json()).error.type, "model_search_not_supported");
+      assert.equal(
+        gatewayRequests.length,
+        beforeUnsupported,
+        "unsupported history must fail before the gateway",
+      );
+
+      const supported = await fetch(`${routerBase(routerPort)}/responses${suffix}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ model: fixture.searchable.slug, input: history }),
+      });
+      assert.equal(supported.status, 200, router.testErrors());
+    }
+    assert.equal(gatewayRequests.length, 2);
+    assert.ok(gatewayRequests.every((request) => request.model === fixture.searchable.gatewayModel));
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
 test("API forwarder strips web_search_options for Fireworks", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {

--- a/test/search-capability.test.mjs
+++ b/test/search-capability.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  routedModelPreservesSearchContract,
+  routedModelSearchAvailable,
+  routedModelSearchMode,
+  stripUnsupportedHostedSearch,
+} from "../src/search-capability.mjs";
+
+test("effective search mode follows exact model or ready sidecar evidence", () => {
+  const model = { slug: "generic/plain" };
+  const sidecarOptions = {
+    bindingForModel: () => ({ providerId: "perplexity" }),
+    providers: new Map([["perplexity", {
+      id: "perplexity",
+      generic: true,
+      enabled: true,
+      adapter: "openai-chat",
+      allowPrivate: false,
+      credentialRef: "credential",
+      baseUrl: "https://api.perplexity.ai",
+    }]]),
+    providerReady: () => true,
+  };
+
+  assert.equal(routedModelSearchMode(model, { ...sidecarOptions, providerReady: () => false }), undefined);
+  assert.equal(routedModelSearchMode(model, sidecarOptions), "standalone");
+  assert.equal(routedModelSearchAvailable(model, sidecarOptions), true);
+  assert.equal(
+    routedModelSearchMode({ ...model, searchTool: { mode: "hosted" } }, sidecarOptions),
+    "hosted",
+  );
+  assert.equal(
+    routedModelSearchMode({ ...model, searchTool: { mode: "standalone" } }, sidecarOptions),
+    "standalone",
+  );
+});
+
+test("a disappearing sidecar invalidates a snapshotted failover contract", () => {
+  let ready = true;
+  const model = { slug: "generic/plain" };
+  const options = {
+    bindingForModel: () => ({ providerId: "perplexity" }),
+    providers: new Map([["perplexity", {
+      id: "perplexity",
+      generic: true,
+      enabled: true,
+      adapter: "openai-chat",
+      allowPrivate: false,
+      credentialRef: "credential",
+      baseUrl: "https://api.perplexity.ai",
+    }]]),
+    providerReady: () => ready,
+  };
+  const contract = { requiredMode: "standalone", hasSearchHistory: true };
+
+  assert.equal(routedModelPreservesSearchContract(model, contract, options), true);
+  ready = false;
+  assert.equal(routedModelPreservesSearchContract(model, contract, options), false);
+});
+
+test("unsupported hosted search is removed without touching caller function tools", () => {
+  const functionNamedSearch = {
+    type: "function",
+    name: "web_search",
+    parameters: { type: "object" },
+  };
+  const shell = { type: "function", name: "shell", parameters: { type: "object" } };
+  const payload = {
+    web_search_options: { search_context_size: "medium" },
+    include: ["reasoning.encrypted_content", "web_search_call.action.sources"],
+    tools: [
+      { type: "web_search", search_context_size: "medium" },
+      shell,
+      { type: "web_search_preview" },
+      functionNamedSearch,
+    ],
+    tool_choice: "required",
+  };
+  const normalized = stripUnsupportedHostedSearch(payload, { model: "generic/plain" });
+
+  assert.notEqual(normalized, payload);
+  assert.equal(normalized.web_search_options, undefined);
+  assert.deepEqual(normalized.include, ["reasoning.encrypted_content"]);
+  assert.deepEqual(normalized.tools, [shell, functionNamedSearch]);
+  assert.equal(normalized.tool_choice, "required");
+  assert.deepEqual(payload.tools.length, 4, "the caller payload must remain untouched");
+});
+
+test("empty ambient search declarations leave no dangling tool choice", () => {
+  const normalized = stripUnsupportedHostedSearch({
+    tools: [{ type: "web_search" }],
+    tool_choice: "auto",
+  });
+  assert.equal("tools" in normalized, false);
+  assert.equal("tool_choice" in normalized, false);
+});
+
+test("an explicit or otherwise impossible search choice fails locally", () => {
+  assert.throws(
+    () => stripUnsupportedHostedSearch({
+      tools: [{ type: "web_search" }, { type: "function", name: "shell" }],
+      tool_choice: { type: "web_search" },
+    }, { model: "generic/plain" }),
+    (error) => error?.status === 400 && error?.code === "model_search_not_supported",
+  );
+  assert.throws(
+    () => stripUnsupportedHostedSearch({
+      tools: [{ type: "web_search_preview" }],
+      tool_choice: "required",
+    }),
+    (error) => error?.status === 400 && error?.code === "model_search_not_supported",
+  );
+  assert.throws(
+    () => stripUnsupportedHostedSearch({
+      web_search_options: {},
+      tool_choice: { type: "web_search" },
+    }),
+    (error) => error?.status === 400 && error?.code === "model_search_not_supported",
+  );
+});


### PR DESCRIPTION
Fixes #539.

Codex can attach hosted search fields even when a routed model does not advertise search. This change enforces the selected runtime-generic model capability at the router-owned Responses boundary. Unsupported routes lose only hosted web_search artifacts; ordinary function tools, capable routes, and direct gateway traffic remain unchanged. Unsatisfiable explicit tool choices fail locally with a named 400. Search-aware failover preserves hosted versus standalone execution for active or historical search turns while ordinary turns retain normal failover.

The selected route, compaction, cooldown adoption, ordinary/subagent failover, and empty-completion replay all compare the immutable mode that built the provider bytes with current live capability. If sidecar readiness disappears after a metered empty first response, the retry is blocked before a second POST, discarded upstream headers are cleared, and first-attempt usage remains accounted without a false retry marker.

Verification on exact remote head 6e246e81cfef4f9c3adfddb0960caf088ad9b1a6 (tree 94b9dc9b9205e0fc03bc7b90b480a061975bcaed):
- npm run check
- git diff --check
- empty-completion router suite: 26/26
- routing suite: 107/107
- model-failover router suite: 25/25
- catalog/search-capability suite: 69/69
- full repository suite: 3,101 passed, 20 skipped, 0 failed
- repo-maintainer final audit: 78/78 hunks covered, no findings
- three independent exact-head intent, correctness/security, and integration reviews: no findings
- hosted Ubuntu, desktop Linux/Windows/macOS, discovery, Homebrew formula, CodeQL language, and GitGuardian checks green; remaining required macOS/Windows/Swift jobs must settle before merge

No live provider/quota request was run; deterministic local fixtures prove the boundary without spending account quota.