### PR TITLE
fix: avoid repeated routed compaction prefixes

### DIFF
--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -81,6 +81,7 @@ const standaloneWebSearchEndMarker =
   "# END codex-router-standalone-web-search-managed";
 const createdAgentsTableMarker = "# codex-router-created-agents-table";
 const managedAgentMaxConcurrency = 6;
+const managedAutoCompactTokenLimitScope = "body_after_prefix";
 // Codex 0.147 records a child's FINAL_ANSWER as subAgentActivity
 // `interacted` and keeps that child visually working for the whole live
 // parent turn. close_agent is not in the v2 toolset; interrupt_agent is the
@@ -358,6 +359,48 @@ ${managedMultiAgentV2FeatureLine()}
     const probe = spawnableCommand(binary, ["login", "status"]);
     // `login status` exits non-zero when signed out, so the exit code says
     // nothing about the config; only the load-error message does.
+    const result = spawnSync(probe.command, probe.args, {
+      ...probe.options,
+      encoding: "utf8",
+      timeout: 10_000,
+      windowsHide: true,
+      env: { ...process.env, CODEX_HOME: probeHome },
+    });
+    if (result.error) return false;
+    return !/Error loading configuration/i.test(
+      `${result.stdout || ""}\n${result.stderr || ""}`,
+    );
+  } catch {
+    return false;
+  } finally {
+    rmSync(probeHome, { recursive: true, force: true });
+  }
+}
+
+// The compaction scope was added after the root-level token limit itself.
+// Older Codex builds reject unknown config keys and would become unusable if
+// the router wrote it unconditionally, so ask the installed binary before we
+// add the managed default.
+let codexSupportsBodyAfterPrefixScope;
+function installedCodexSupportsBodyAfterPrefixScope() {
+  if (codexSupportsBodyAfterPrefixScope !== undefined) {
+    return codexSupportsBodyAfterPrefixScope;
+  }
+  codexSupportsBodyAfterPrefixScope = probeBodyAfterPrefixScopeSupport();
+  return codexSupportsBodyAfterPrefixScope;
+}
+
+function probeBodyAfterPrefixScopeSupport() {
+  const binary = findCodexBinary();
+  if (!binary) return false;
+  const probeHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-scope-probe-"));
+  try {
+    writeFileSync(
+      path.join(probeHome, "config.toml"),
+      `model_auto_compact_token_limit_scope = ${tomlValue(managedAutoCompactTokenLimitScope)}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    const probe = spawnableCommand(binary, ["login", "status"]);
     const result = spawnSync(probe.command, probe.args, {
       ...probe.options,
       encoding: "utf8",
@@ -1371,6 +1414,20 @@ function enabledContents(contents, { loginFreeProvider = false } = {}) {
     nativeCatalogNeedsActivation = preparedSource.status === "pending";
   }
   const managedRealtimeOverrides = [];
+  // A routed compaction carries a large, stable prefix: system/developer
+  // instructions, tool schemas, and the router checkpoint. Counting that
+  // prefix again after every compaction can immediately retrigger compaction
+  // before the model has made meaningful progress. Codex's body-after-prefix
+  // scope exists for this exact window shape. Respect an explicit user value;
+  // otherwise own the safer routed-model default inside our managed block.
+  const managedAutoCompactScope = rootHasValue(
+    rootLines,
+    "model_auto_compact_token_limit_scope",
+  ) || !installedCodexSupportsBodyAfterPrefixScope()
+    ? []
+    : [
+        `model_auto_compact_token_limit_scope = ${tomlValue(managedAutoCompactTokenLimitScope)}`,
+      ];
   // Codex Voice uses a WebRTC call plus a sideband WebSocket. Keep both on
   // Codex's native endpoints instead of inheriting the Responses-only router URL.
   if (!rootHasValue(rootLines, realtimeCallBaseUrlKey)) {
@@ -1388,6 +1445,7 @@ function enabledContents(contents, { loginFreeProvider = false } = {}) {
     startMarker,
     `openai_base_url = ${JSON.stringify(routerBaseUrl)}`,
     `model_catalog_json = ${tomlValue(MERGED_CATALOG_PATH)}`,
+    ...managedAutoCompactScope,
     ...managedRealtimeOverrides,
     endMarker,
   );

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -62,6 +62,26 @@ exit 1
   return file;
 })();
 
+const preBodyScopeCodex = (() => {
+  const isWindows = process.platform === "win32";
+  const file = path.join(
+    codexStubDir,
+    isWindows ? "codex-pre-body-scope.cmd" : "codex-pre-body-scope",
+  );
+  const contents = isWindows
+    ? `@echo off\r\nfindstr /c:"model_auto_compact_token_limit_scope" "%CODEX_HOME%\\config.toml" >nul 2>&1\r\nif %errorlevel% equ 0 (\r\n  echo Error loading configuration: unknown field model_auto_compact_token_limit_scope 1>&2\r\n  exit /b 1\r\n)\r\necho Not logged in 1>&2\r\nexit /b 1\r\n`
+    : `#!/bin/sh
+if grep -q model_auto_compact_token_limit_scope "$CODEX_HOME/config.toml" 2>/dev/null; then
+  echo 'Error loading configuration: unknown field model_auto_compact_token_limit_scope' >&2
+  exit 1
+fi
+echo 'Not logged in' >&2
+exit 1
+`;
+  writeFileSync(file, contents, { mode: 0o755 });
+  return file;
+})();
+
 function writeCatalogCodexStub(directory) {
   const isWindows = process.platform === "win32";
   const file = path.join(directory, isWindows ? "codex-catalog.cmd" : "codex-catalog");
@@ -178,6 +198,10 @@ approval_policy = "never"
     assert.doesNotMatch(configured, /\[model_providers\.codex-router\.auth\]/);
     assert.doesNotMatch(configured, /caller-key-auth-command\.mjs/);
     assert.match(configured, /^openai_base_url = "http:\/\/127\.0\.0\.1:46192\/v1"$/m);
+    assert.match(
+      configured,
+      /^model_auto_compact_token_limit_scope = "body_after_prefix"$/m,
+    );
     assert.doesNotMatch(configured, new RegExp(CALLER_KEY));
     assert.doesNotMatch(configured, /\/_codex-router\/[A-Za-z0-9_-]+\/v1/);
     assert.match(
@@ -216,13 +240,57 @@ approval_policy = "never"
     const restored = readFileSync(configPath, "utf8");
     assert.doesNotMatch(
       restored,
-      /codex-router-(?:(?:provider|agent-concurrency|multi-agent-v2|standalone-web-search)-)?managed|codex-router-created-agents-table|openai_base_url|model_catalog_json|experimental_realtime_(?:webrtc_call|ws)_base_url/,
+      /codex-router-(?:(?:provider|agent-concurrency|multi-agent-v2|standalone-web-search)-)?managed|codex-router-created-agents-table|openai_base_url|model_catalog_json|model_auto_compact_token_limit_scope|experimental_realtime_(?:webrtc_call|ws)_base_url/,
     );
     assert.doesNotMatch(restored, /\[agents\]|max_concurrent_threads_per_session/);
     assert.match(restored, /model = "gpt-5\.6-sol"/);
     assert.match(restored, /model_provider = "openai"/);
     assert.match(restored, /model_reasoning_effort = "xhigh"/);
     assert.match(restored, /\[profiles\.work\]/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager preserves an explicit auto-compaction scope", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-config-"));
+  const configPath = path.join(codexHome, "config.toml");
+  writeFileSync(
+    configPath,
+    'model_auto_compact_token_limit_scope = "total"\nmodel = "gpt-5.6-sol"\n',
+    { mode: 0o600 },
+  );
+
+  try {
+    run("enable", codexHome);
+    const configured = readFileSync(configPath, "utf8");
+    assert.equal(
+      (configured.match(/^model_auto_compact_token_limit_scope\s*=/gm) || []).length,
+      1,
+    );
+    assert.match(configured, /^model_auto_compact_token_limit_scope = "total"$/m);
+
+    run("disable", codexHome);
+    assert.match(
+      readFileSync(configPath, "utf8"),
+      /^model_auto_compact_token_limit_scope = "total"$/m,
+    );
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("config manager skips body-after-prefix scope on older Codex builds", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-config-"));
+  const configPath = path.join(codexHome, "config.toml");
+  writeFileSync(configPath, 'model = "gpt-5.6-sol"\n', { mode: 0o600 });
+
+  try {
+    run("enable", codexHome, undefined, [], { CODEX_BIN: preBodyScopeCodex });
+    assert.doesNotMatch(
+      readFileSync(configPath, "utf8"),
+      /^model_auto_compact_token_limit_scope\s*=/m,
+    );
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- configure Codex to count only post-prefix growth toward automatic compaction while routing is enabled
- preserve an explicit user-owned `model_auto_compact_token_limit_scope` value
- probe the installed Codex binary before writing the newer scope key, so older builds keep loading normally
- remove the router-owned value again during the normal disable lifecycle

## Problem

A routed compaction does not begin with an empty context. Codex carries a large stable prefix into the next compaction window, including system/developer instructions, tool schemas, and the router's rendered checkpoint.

With Codex's default `total` scope, that carried prefix is charged against `model_auto_compact_token_limit` again. On models whose routed session already has a large fixed prefix, the next window can therefore reach the threshold after little or no meaningful new work. In practice this presents as an agent compacting after nearly every round and failing to make sustained progress.

Codex now exposes `model_auto_compact_token_limit_scope = "body_after_prefix"` for this window shape. Its context-window implementation snapshots the carried prefill and charges only subsequent growth against the configured automatic-compaction limit, while the full context-window safety check remains active:

- https://github.com/openai/codex/blob/main/codex-rs/core/src/session/context_window.rs
- https://github.com/openai/codex/blob/main/codex-rs/protocol/src/config_types.rs

## Implementation

When the router enables its managed Codex configuration, it now writes:

```toml
model_auto_compact_token_limit_scope = "body_after_prefix"
```

The setting lives inside the existing `codex-router-managed` root block, so the established enable/disable lifecycle owns it.

Two guardrails keep the change conservative:

1. If the user already configured any scope explicitly, the router leaves that value unchanged.
2. The config manager asks the installed Codex binary to parse a minimal probe config before adding the key. A build that reports a configuration-load error, cannot be probed, or is not installed does not receive the managed setting.

This PR does not change model context windows, per-model compaction limits, checkpoint contents, or provider request payloads.

## Verification

Focused config-manager tests (3 passed, 0 failed):

- managed installs add `body_after_prefix` and remove it on disable
- an explicit user-owned `total` scope survives enable and disable unchanged
- a simulated older Codex build that rejects the key does not receive it

Also checked:

- branch rebased onto current `main`
- `git diff --check`
- PR diff contains only `src/config-manager.mjs` and `test/config-manager.test.mjs`

Per the repository testing policy, no broad full-suite run was performed for this isolated config-manager change.
