### PR TITLE
fix: strip unsupported Console Go search options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **OpenCode Console Go chat models no longer reject ambient hosted-search
+  options.** Codex can attach `web_search_options` even when the selected
+  OpenCode Go model does not advertise hosted search; Console Go forwards the
+  unknown field to its strict Chat Completions backend, which rejects the
+  entire turn with HTTP 400. The router now removes only that unsupported
+  option for the `opencode-go` provider on ordinary and compaction requests,
+  with the API forwarder enforcing the same boundary. Other search payloads
+  and providers that accept the option remain unchanged.
+
 - **Strict generic providers no longer receive unadvertised hosted-search
   extensions.** Codex may attach `web_search`, `web_search_preview`,
   `web_search_options`, and search-only `include` entries even when the chosen

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -691,9 +691,12 @@ function normalizeBody(buffer, contentType, route) {
     delete payload.store;
     delete payload.logit_bias;
   }
-  // Fireworks rejects this OpenAI search parameter instead of ignoring it.
-  // Other provider payloads keep it unchanged.
-  if (provider.id === "fireworks") delete payload.web_search_options;
+  // Fireworks and OpenCode Console Go reject this OpenAI search parameter
+  // instead of ignoring it. Keep the repair provider-scoped: other compatible
+  // chat surfaces use the option and must retain it.
+  if (["fireworks", "opencode-go"].includes(provider.id)) {
+    delete payload.web_search_options;
+  }
   // Meta refuses `search_content_types` on anything but a `web_search_preview`
   // tool, and Codex only ever sends the current spelling: its hosted search
   // tool is `type: "web_search"`, carrying search_content_types beside

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -879,6 +879,10 @@ function needsConsoleGoResponsesToolCompatibility(route) {
   return providerForModel(route)?.id === "opencode-go-responses";
 }
 
+function rejectsWebSearchOptions(route) {
+  return ["fireworks", "opencode-go"].includes(providerForModel(route)?.id);
+}
+
 function needsStrictOpenCodeToolCompatibility(route) {
   return (
     needsZenFreeToolCompatibility(route) ||
@@ -2382,9 +2386,10 @@ async function summarizeWith(
   normalizeAutoToolChoice(body, route);
   delete body.previous_response_id;
   delete body.client_metadata;
-  // Compaction re-enters the same provider as the routed turn; Fireworks
-  // rejects this OpenAI search parameter at that boundary too.
-  if (providerForModel(route)?.id === "fireworks") delete body.web_search_options;
+  // Compaction re-enters the same provider as the routed turn. Strict Chat
+  // Completions surfaces reject this OpenAI search parameter even though it
+  // is unrelated to the compaction body.
+  if (rejectsWebSearchOptions(route)) delete body.web_search_options;
   const searchCompatibility = routedSearchCompatibility(body, route);
   const serialized = JSON.stringify(searchCompatibility.payload);
   // Candidate capability may depend on a sidecar credential or binding that
@@ -3085,7 +3090,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     delete routed.reasoning;
     delete routed.reasoning_effort;
   }
-  if (provider?.id === "fireworks") delete routed.web_search_options;
+  if (rejectsWebSearchOptions(route)) delete routed.web_search_options;
   routed.instructions = applyTokenMaxxingOverlay(routed.instructions, {
     active: tokenMaxxing,
   });

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -6336,6 +6336,49 @@ test("API forwarder strips web_search_options for Fireworks", async () => {
   }
 });
 
+test("API forwarder strips web_search_options for OpenCode Go chat models", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push(await bodyJson(request));
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    OPENCODE_GO_BASE_URL: `http://127.0.0.1:${upstream.port}/v1`,
+    OPENCODE_API_KEY: "TEST_OPENCODE_GO_API_KEY",
+    OPENCODE_GO_API_KEY: "TEST_OPENCODE_GO_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    const response = await fetch(
+      `http://127.0.0.1:${forwarderPort}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${INTERNAL_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "opencode-go-glm-5-3",
+          web_search_options: { search_context_size: "medium" },
+          messages: [{ role: "user", content: "test" }],
+        }),
+      },
+    );
+    assert.equal(response.status, 200, forwarder.testErrors());
+    assert.equal(upstreamRequests[0].model, "glm-5.3");
+    assert.equal(upstreamRequests[0].web_search_options, undefined);
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 test("API forwarder keeps Xiaomi MiMo web search options on chat completions", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {
@@ -6549,6 +6592,70 @@ test("router strips Fireworks web_search_options on routed and compaction reques
     await stopChild(router);
     await closeServer(gateway.server);
     rmSync(curated.dir, { recursive: true, force: true });
+  }
+});
+
+test("router strips unsupported web_search_options from OpenCode Go turns", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, {
+      id: "resp-summary",
+      object: "response",
+      output: [
+        {
+          type: "message",
+          content: [{ type: "output_text", text: "compact summary" }],
+        },
+      ],
+    });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const headers = {
+    Authorization: `Bearer ${CALLER_KEY}`,
+    "Content-Type": "application/json",
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const routed = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "opencode-go/glm-5.3",
+        input: "routed test",
+        web_search_options: { search_context_size: "medium" },
+      }),
+    });
+    assert.equal(routed.status, 200, router.testErrors());
+    assert.equal(gatewayRequests[0].model, "opencode-go-glm-5-3");
+    assert.equal(gatewayRequests[0].web_search_options, undefined);
+
+    const compact = await fetch(`${routerBase(routerPort)}/responses/compact`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        model: "opencode-go/glm-5.3",
+        input: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "keep me" }],
+          },
+        ],
+        web_search_options: { search_context_size: "medium" },
+      }),
+    });
+    assert.equal(compact.status, 200, router.testErrors());
+    assert.equal(gatewayRequests[1].web_search_options, undefined);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
   }
 });
 


### PR DESCRIPTION
## Summary

- remove `web_search_options` from ordinary and compaction requests routed to the fixed `opencode-go` Chat Completions provider
- enforce the same provider boundary in the API forwarder before Console Go receives the upstream request
- preserve the option for providers that accept it and retain all other search/tool payload fields
- document the compatibility repair in the Unreleased changelog

## Reproduction

Selecting `opencode-go/glm-5.3` in Codex can fail before generation with:

```text
opencode rejected the request for GLM-5.3 (opencode Go).
HTTP 400: Error from provider (Console Go): Upstream request failed:
[invalid_request_error] Extra inputs are not permitted,
field: 'web_search_options'
```

Codex can attach `web_search_options` to a Responses request even when the selected routed model does not advertise hosted search. LiteLLM translates the routed request to Chat Completions, and Console Go forwards the unsupported OpenAI extension to its strict model backend instead of ignoring it. The backend rejects the complete turn.

## Relationship to #540

This branch is based on current `main` at `43deff5` and preserves #540's runtime-generic search-capability contract unchanged.

#540 strips unadvertised hosted-search artifacts for **runtime-generic** providers. OpenCode Go is a fixed registry provider (`provider.generic !== true`), so it intentionally bypasses that generic compatibility path. On current `main`, its `web_search_options` still reaches both the gateway request and the downstream API forwarder.

This PR adds the narrower fixed-provider repair at the two existing Fireworks compatibility boundaries rather than broadening or weakening #540.

## Implementation

At the outer router boundary, `rejectsWebSearchOptions(route)` identifies only:

- `fireworks` (existing behavior)
- `opencode-go` (new measured behavior)

The field is removed from both ordinary routed turns and `/responses/compact` requests before serialization. The latter matters because compaction re-enters the same provider with the caller payload and can otherwise fail on an option unrelated to summarization.

The API forwarder repeats the provider-scoped removal immediately before sending OpenCode Go Chat Completions upstream. This keeps direct/internal forwarder traffic safe and follows the existing Fireworks defense-in-depth pattern.

The repair deliberately does **not**:

- remove `web_search` function tools or tool results
- change standalone/client-side search capability
- alter `include`, `tools`, or `tool_choice`
- affect OpenCode Responses or Messages variants
- strip the option from compatible providers

## Verification

Red/green reproduction was established for both boundaries: before the production change, the focused router and API-forwarder tests received the original `{ search_context_size: "medium" }`; after the change, both receive no `web_search_options`.

Fresh verification on exact head `9ef8907`:

- `npm run check` — syntax and v2-agent application checks passed
- focused routing tests — 5 passed, 0 failed:
  - current-main generic capability enforcement from #540 remains intact
  - OpenCode Go API forwarder strips the unsupported option
  - OpenCode Go ordinary and compaction requests strip the option
  - Fireworks retains its existing repair
  - Xiaomi MiMo retains the option as a compatible-provider counterexample
- `git diff --check`

Per the repository testing policy, no broad full-suite run was performed for this isolated provider-compatibility change. No live provider/quota request was made; deterministic upstream fixtures reproduce the exact rejected field without spending account quota.
