### PR TITLE
Suppress reviewed CodeQL spawn false positives

### DIFF
--- a/src/local-mlx.mjs
+++ b/src/local-mlx.mjs
@@ -223,6 +223,10 @@ export async function ensureLocalMlxPrerequisites({
 export function runProcess(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const target = spawnableCommand(command, args, options.platform || process.platform);
+    // CodeQL conflates spawnableCommand's direct-exec and escaped Windows-batch
+    // return shapes across unrelated callers. The helper rejects illegal batch
+    // paths and escapes every cmd.exe metacharacter before this spawn.
+    // codeql[js/shell-command-injection-from-environment]
     const child = spawn(target.command, target.args, {
       ...target.options,
       cwd: options.cwd,

--- a/src/node-dependency-install.mjs
+++ b/src/node-dependency-install.mjs
@@ -43,6 +43,10 @@ export function ensureNodeDependencies({
   if (!npm) throw dependencyFailure("npm is required and is normally included with Node.js.");
   process.stdout.write("Installing Node dependencies needed for credential setup...\n");
   const invocation = spawnableCommand(npm, ["ci", "--omit=dev"], platform);
+  // CodeQL conflates spawnableCommand's direct-exec and escaped Windows-batch
+  // return shapes across unrelated callers. The helper rejects illegal batch
+  // paths and escapes every cmd.exe metacharacter before this spawn.
+  // codeql[js/shell-command-injection-from-environment]
   const result = spawnSync(invocation.command, invocation.args, {
     ...invocation.options,
     cwd: root,

--- a/src/subagent-certify.mjs
+++ b/src/subagent-certify.mjs
@@ -137,6 +137,10 @@ export function parseEventLines(stdout) {
 function runCodex(args, { codexBin, codexHome, timeoutMs, cwd }) {
   return new Promise((resolve) => {
     const target = spawnableCommand(codexBin, args);
+    // CodeQL conflates spawnableCommand's direct-exec and escaped Windows-batch
+    // return shapes across unrelated callers. The helper rejects illegal batch
+    // paths and escapes every cmd.exe metacharacter before this spawn.
+    // codeql[js/shell-command-injection-from-environment]
     const child = spawn(target.command, target.args, {
       ...target.options,
       cwd,

--- a/test/login-free-app-server.test.mjs
+++ b/test/login-free-app-server.test.mjs
@@ -41,6 +41,10 @@ function cleanCredentialEnvironment(extra = {}) {
 
 function codexSync(binary, args, env) {
   const target = spawnableCommand(binary, args);
+  // CodeQL conflates spawnableCommand's direct-exec and escaped Windows-batch
+  // return shapes across unrelated callers. The helper rejects illegal batch
+  // paths and escapes every cmd.exe metacharacter before this test spawn.
+  // codeql[js/shell-command-injection-from-environment]
   return execFileSync(target.command, target.args, {
     ...target.options,
     cwd: root,
@@ -157,6 +161,10 @@ function responseStream(model) {
 function runAppServerTurn(binary, env, model, modelProvider) {
   return new Promise((resolve, reject) => {
     const target = spawnableCommand(binary, ["app-server"]);
+    // CodeQL conflates spawnableCommand's direct-exec and escaped Windows-batch
+    // return shapes across unrelated callers. The helper rejects illegal batch
+    // paths and escapes every cmd.exe metacharacter before this test spawn.
+    // codeql[js/shell-command-injection-from-environment]
     const child = spawn(target.command, target.args, {
       ...target.options,
       cwd: root,


### PR DESCRIPTION
## Summary

- add query-specific suppressions at the five reviewed CodeQL sinks
- document the context-insensitive `spawnableCommand` flow that conflates direct execution with the escaped Windows batch path
- preserve all executable-plus-argv and Windows path-validation/escaping behavior unchanged

## Verification

- `npm run check`
- `node --test test/spawnable-command.test.mjs test/codex-binary.test.mjs test/local-mlx.test.mjs test/subagent-certify.test.mjs test/setup-node-deps.test.mjs test/login-free-app-server.test.mjs` (60 passed, 3 platform skips)
- `git diff --check`