### PR TITLE
Fix Muse recursive tool schemas on OpenCode Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Muse Spark 1.2 Contributor no longer fails on recursive Codex tool
+  schemas through OpenCode Go.** Console Go rejects the whole Responses turn
+  before inference when this model receives a recursive local JSON-Schema
+  reference. The router now breaks only cycle-closing reference edges for the
+  paid Muse route, preserving definitions, acyclic references, and sibling
+  constraints. Other Console Go Responses models retain their existing schema
+  payloads until they demonstrate the same restriction.
+
 - **OpenCode Console Go chat models no longer reject ambient hosted-search
   options.** Codex can attach `web_search_options` even when the selected
   OpenCode Go model does not advertise hosted search; Console Go forwards the

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -890,6 +890,20 @@ function needsStrictOpenCodeToolCompatibility(route) {
   );
 }
 
+// Both Muse Contributor Responses routes reject a tool list containing a
+// recursive local JSON-Schema reference before the model sees the request.
+// Keep the paid Console Go gate model-specific: its other Responses models
+// retain recursive schemas until their own endpoint establishes the same
+// restriction.
+function needsNonRecursiveOpenCodeToolCompatibility(route) {
+  const providerId = providerForModel(route)?.id;
+  return (
+    needsZenFreeToolCompatibility(route) ||
+    (providerId === "opencode-go-responses" &&
+      route.upstreamModel === "muse-spark-1.2-contributor")
+  );
+}
+
 // Moonshot accepts only pure `$ref` pointers into `#/$defs/`, and rejects the
 // whole request -- not the one tool -- over any other pointer (issue #353) or a
 // definition reference carrying sibling keywords. The OAuth and platform-key
@@ -2964,11 +2978,9 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
   ) {
     namespacesFlattened = true;
   }
-  if (needsZenFreeToolCompatibility(route)) {
-    // Zen Free's measured schema boundary rejects recursive definition edges.
-    // Console Go's evidence establishes different tool discriminators and
-    // fields only, so it must retain recursive refs until that endpoint proves
-    // otherwise.
+  if (needsNonRecursiveOpenCodeToolCompatibility(route)) {
+    // Run after namespace flattening so both native children and ordinary
+    // function tools are repaired in the exact shape the endpoint validates.
     tools = repairToolSchemaRoots(tools, { nonRecursive: true });
   }
   if (needsStrictOpenCodeToolCompatibility(route)) {
@@ -3030,7 +3042,9 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
     ) {
       namespacesFlattened = true;
     }
-    if (needsZenFreeToolCompatibility(route)) {
+    if (needsNonRecursiveOpenCodeToolCompatibility(route)) {
+      // Stored tool-search results can introduce definitions after the first
+      // repair pass, so enforce the same boundary on the expanded inventory.
       tools = repairToolSchemaRoots(tools, { nonRecursive: true });
     }
   }

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -2014,7 +2014,7 @@ test("OpenCode Go Responses uses one bounded function-tool contract in both resp
     assert.equal(
       longTool.parameters.$defs.node.properties.child.$ref,
       "#/$defs/node",
-      "Console Go keeps recursive refs because no upstream rejection established otherwise",
+      "other Console Go models keep recursive refs without model-specific evidence",
     );
     assert.equal(
       outgoing.input.find((item) => item.call_id === "history-long").name,
@@ -2066,6 +2066,64 @@ test("OpenCode Go Responses uses one bounded function-tool contract in both resp
       name: "apply_patch",
       call_id: "call-patch",
       input: GO_PATCH,
+    });
+  }
+});
+
+test("OpenCode Go Muse removes recursive tool refs in both response modes", async () => {
+  for (const stream of [true, false]) {
+    const result = await scenario(stream, {
+      model: "opencode-go-responses/muse-spark-1.2-contributor",
+      requestPayload: (requestStream, model) => {
+        const payload = goCompatibilityRequestPayload(requestStream, model);
+        const discovered = payload.input
+          .find((item) => item.type === "tool_search_output")
+          .tools[0].tools[0];
+        discovered.description = "MUSE_RECURSIVE_DISCOVERED_SENTINEL";
+        discovered.inputSchema = {
+          type: "object",
+          properties: { node: { $ref: "#/$defs/node" } },
+          $defs: {
+            node: {
+              type: "object",
+              properties: {
+                label: { type: "string" },
+                child: {
+                  $ref: "#/$defs/node",
+                  description: "optional child",
+                },
+              },
+            },
+          },
+        };
+        return payload;
+      },
+      sseBody: goCompatibilitySseBody,
+      jsonBody: goCompatibilityJsonBody,
+    });
+    const outgoing = result.gatewayBodies[0];
+    assert.equal(
+      outgoing.model,
+      "opencode-go-responses-muse-spark-1-2-contributor",
+    );
+
+    const liveTool = outgoing.tools.find(
+      (tool) => tool.name === outgoing.tool_choice.name,
+    );
+    assert.equal(liveTool.parameters.properties.node.$ref, "#/$defs/node");
+    assert.deepEqual(liveTool.parameters.$defs.node.properties.child, {});
+    assert.deepEqual(liveTool.inputSchema.$defs.node.properties.child, {});
+
+    const discovered = outgoing.tools.find(
+      (tool) => tool.description === "MUSE_RECURSIVE_DISCOVERED_SENTINEL",
+    );
+    assert.ok(discovered, "stored tool-search definitions remain available");
+    assert.equal(discovered.parameters.properties.node.$ref, "#/$defs/node");
+    assert.deepEqual(discovered.parameters.$defs.node.properties.child, {
+      description: "optional child",
+    });
+    assert.deepEqual(discovered.inputSchema.$defs.node.properties.child, {
+      description: "optional child",
     });
   }
 });

--- a/test/tool-schema-root.test.mjs
+++ b/test/tool-schema-root.test.mjs
@@ -74,6 +74,11 @@ test("recursive local refs keep definitions and only the cycle edge becomes perm
   assert.deepEqual(repaired.$defs.node.properties.child, {
     description: "optional child",
   });
+  assert.equal(
+    schema.$defs.node.properties.child.$ref,
+    "#/$defs/node",
+    "the caller's recursive schema is not mutated",
+  );
 });
 
 test("mutually recursive refs retain their shared definitions and break one back edge", () => {


### PR DESCRIPTION
## Summary

- apply the existing non-recursive tool-schema compatibility pass to the paid OpenCode Go Responses route for Muse Spark 1.2 Contributor
- rerun the pass after stored tool-search definitions are expanded
- preserve definitions, acyclic references, sibling constraints, caller-owned schemas, and the existing payloads of other OpenCode Go Responses models

## Verification

- reproduced the installed failure before deployment: HTTP 400 with Recursive JSON schemas are not currently supported
- verified the deployed non-streaming recursive-schema request: HTTP 200 with the expected marker
- verified the deployed streaming $defs-recursive request: HTTP 200, expected marker, and response.completed
- npm run check
- node --test test/tool-schema-root.test.mjs test/namespace-relay-routing.test.mjs test/registry.test.mjs (101 passed)
- npm test (3,124 tests; 3,104 passed, 20 skipped, 0 failed)
- git diff --check

Two intermediate streaming probes hit provider transport connect timeouts; a no-tool streaming control, a non-recursive tool streaming control, and the final recursive tool streaming retry all completed successfully. The recursive-schema rejection did not recur after deployment.