### PR TITLE
fix: preserve orphan Codex app tool outputs during routed replay

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1248,6 +1248,33 @@ function messageItem(text) {
   };
 }
 
+function normalizeOrphanAppToolOutput(item) {
+  if (
+    item?.type !== "function_call_output" ||
+    item.namespace !== "codex_app" ||
+    typeof item.name !== "string" ||
+    !item.name ||
+    (typeof item.call_id === "string" && item.call_id) ||
+    item.output === undefined
+  ) {
+    return item;
+  }
+  // Codex app-server can persist a standalone app-tool result without the
+  // originating call. A synthetic call_id would still have no matching call,
+  // while strict Responses providers reject the original item outright.
+  // Preserve the result as ordinary readable history instead. Scope the
+  // recovery to named codex_app outputs so every other malformed tool item
+  // continues to fail closed at the provider adapter.
+  const output =
+    typeof item.output === "string" ? item.output : JSON.stringify(item.output);
+  return messageItem(`[Codex app tool result: codex_app.${item.name}]\n${output}`);
+}
+
+function normalizeProviderAppToolOutputs(input) {
+  if (!Array.isArray(input)) return input;
+  return input.map(normalizeOrphanAppToolOutput);
+}
+
 function normalizeRoutedInput(input) {
   if (!Array.isArray(input)) return input;
   return input
@@ -2351,7 +2378,10 @@ async function summarizeWith(
   signal,
   { searchContract } = {},
 ) {
-  const compatibleInput = zenFreeCompatibleInput(aged.input, route);
+  const compatibleInput = zenFreeCompatibleInput(
+    normalizeProviderAppToolOutputs(aged.input),
+    route,
+  );
   const providerInput = needsConsoleGoResponsesToolCompatibility(route)
     ? strictOpenCodeCompactionInput(compatibleInput, payload.tools, {
         maxNameLength: 64,
@@ -2834,7 +2864,10 @@ async function buildRoutedRequest({ request, payload, route, agedInput, tokenMax
   const provider = providerForModel(route);
   const chatCompletionsProvider = provider?.protocol !== "openai-responses";
   const consoleGoResponsesCompatibility = needsConsoleGoResponsesToolCompatibility(route);
-  const compatibleInput = zenFreeCompatibleInput(agedInput, route);
+  const compatibleInput = zenFreeCompatibleInput(
+    normalizeProviderAppToolOutputs(agedInput),
+    route,
+  );
   // Image substitution may spend another provider's quota. Every Groq tool
   // limit that is already knowable from the client request and stored history
   // must fail locally before that work starts; the normal post-bridge pass

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -6031,6 +6031,100 @@ test("router strips empty text parts and drops the messages left with nothing", 
   }
 });
 
+test("router preserves orphan Codex app outputs as readable history", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, {
+      id: "resp-app-output",
+      object: "response",
+      output: [
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "ok" }],
+        },
+      ],
+    });
+  });
+  const native = await mockServer(async (_request, response) => {
+    json(response, 200, { id: "unused", output: [] });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const delegation = "<codex_delegation>child finished</codex_delegation>";
+  const input = [
+    {
+      type: "function_call_output",
+      id: "fco_app_without_call_id",
+      call_id: null,
+      name: "send_message_to_thread",
+      namespace: "codex_app",
+      output: delegation,
+    },
+    { type: "function_call", call_id: "call-valid", name: "lookup", arguments: "{}" },
+    { type: "function_call_output", call_id: "call-valid", output: "kept byte-for-byte" },
+  ];
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    for (const endpoint of ["/responses", "/responses/compact"]) {
+      const response = await fetch(`${routerBase(routerPort)}${endpoint}`, {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer CHATGPT_SESSION_TOKEN",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "kimi-oauth/k3",
+          stream: false,
+          input,
+        }),
+      });
+      assert.equal(response.status, 200, await response.text());
+    }
+
+    assert.equal(gatewayRequests.length, 2);
+    const recovered = gatewayRequests[0].input[0];
+    assert.equal(recovered.type, "message");
+    assert.equal(recovered.role, "user");
+    assert.deepEqual(recovered.content, [
+      {
+        type: "input_text",
+        text: `[Codex app tool result: codex_app.send_message_to_thread]\n${delegation}`,
+      },
+    ]);
+    assert.deepEqual(gatewayRequests[0].input.slice(-2), input.slice(-2));
+
+    for (const request of gatewayRequests) {
+      assert.equal(
+        request.input.some(
+          (item) => item?.type === "function_call_output" && !item.call_id,
+        ),
+        false,
+      );
+    }
+    assert.match(
+      JSON.stringify(gatewayRequests[1].input),
+      /Codex app tool result: codex_app\.send_message_to_thread/u,
+    );
+    assert.match(JSON.stringify(gatewayRequests[1].input), /child finished/u);
+    const catalog = gatewayRequests[1].input.at(-2).content[0].text;
+    assert.match(catalog, /"kind":"tool_result"/u);
+    assert.match(catalog, /"tool":"send_message_to_thread"/u);
+    assert.doesNotMatch(catalog, /"kind":"user_message"/u);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    await closeServer(native.server);
+  }
+});
+
 function curatedFireworksModel() {
   const dir = mkdtempSync(path.join(os.tmpdir(), "routing-fireworks-model-"));
   const file = path.join(dir, "user-models.json");


### PR DESCRIPTION
## Problem

Codex app-server can persist a standalone native app-tool result without the originating call, for example a `function_call_output` in the `codex_app` namespace whose `call_id` is null.

When that history is replayed through a routed Responses provider, the strict provider adapter correctly rejects the unpaired result. The same history can be replayed during `/responses/compact`, so the rejection surfaces as `invalid_responses_request` (and may be wrapped by a gateway as `provider_api_proxy_error`), interrupting ordinary turns or automatic compaction.

## Fix

- Recover only named `codex_app` outputs that have a defined result and a missing or empty `call_id`.
- Preserve those results as tagged, readable history at the final provider boundary.
- Do not synthesize a `call_id` and do not relax strict Responses validation; unrelated malformed lifecycle items still fail closed.
- Leave well-formed `function_call` / `function_call_output` pairs unchanged.
- Normalize after compaction analysis so the original record remains classified as a tool result rather than a user requirement.

## Tests

- `node --test test/routing.test.mjs test/openai-adapters.test.mjs test/compaction-checkpoint.test.mjs` (144 passed)
- `npm run check`

The regression test covers both `/responses` and `/responses/compact`, verifies paired tool results remain unchanged, and verifies compaction evidence still classifies the orphan record as `tool_result`.
