### PR TITLE
fix: preserve completed Responses WebSocket results

### DIFF
--- a/src/responses-websocket.mjs
+++ b/src/responses-websocket.mjs
@@ -7,6 +7,7 @@ import {
   MAX_BUFFERED_RESPONSE_BYTES,
   readResponseBody,
 } from "./http-utils.mjs";
+import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 
 export const RESPONSES_WEBSOCKET_BETA = "responses_websockets=2026-02-06";
 
@@ -587,6 +588,42 @@ function errorShape(body, fallback) {
   };
 }
 
+function responseWithBody(upstream, body) {
+  return new Response(body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers: upstream.headers,
+  });
+}
+
+async function sniffUndeclaredResponse(upstream, signal) {
+  if (!upstream.body) return { kind: "other", response: upstream };
+  const [probe, relay] = upstream.body.tee();
+  const reader = probe.getReader();
+  const detector = new HeaderlessSseDetector();
+  let decision = "pending";
+  try {
+    while (decision === "pending") {
+      signal?.throwIfAborted();
+      const result = await reader.read();
+      if (result.done) {
+        decision = detector.end().decision;
+        break;
+      }
+      decision = detector.write(result.value).decision;
+    }
+  } catch (error) {
+    void relay.cancel().catch(() => {});
+    throw error;
+  } finally {
+    void reader.cancel().catch(() => {});
+  }
+  return {
+    kind: decision === "event-stream" ? "event-stream" : "other",
+    response: responseWithBody(upstream, relay),
+  };
+}
+
 async function relaySse(body, onEvent, { signal, maxEventBytes }) {
   if (!body) throw new Error("The internal Responses endpoint returned no stream.");
   const reader = body.getReader();
@@ -999,15 +1036,72 @@ class ResponsesWebSocketPeer {
       ) {
         this.turnState = { value: responseTurnState, turnId: currentTurnId };
       }
-      if (!String(upstream.headers.get("content-type") || "").toLowerCase().includes("text/event-stream")) {
-        await readResponseBody(upstream, {
-          maxBytes: this.options.maxErrorBytes,
+      let contentType = String(upstream.headers.get("content-type") || "").toLowerCase();
+      const declaredMediaType = contentType.split(";", 1)[0].trim();
+      const declaredJson =
+        declaredMediaType === "application/json" || declaredMediaType.endsWith("+json");
+      if (!contentType.includes("text/event-stream") && !declaredJson) {
+        // A completed internal request must not be discarded solely because a
+        // loopback hop omitted or misdeclared Content-Type. Sniff only enough
+        // bytes to prove SSE framing; otherwise retain the untouched body and
+        // validate it through the bounded completed-JSON path below.
+        const detected = await sniffUndeclaredResponse(upstream, controller.signal);
+        upstream = detected.response;
+        if (detected.kind === "event-stream") contentType = "text/event-stream";
+      }
+      if (!contentType.includes("text/event-stream")) {
+        const body = await readResponseBody(upstream, {
+          maxBytes: this.options.maxEventBytes,
           signal: controller.signal,
         });
-        this.sendError(502, {
-          type: "local_router_protocol_error",
-          message: "The internal Responses endpoint returned a non-streaming response.",
-        });
+        let completedResponse;
+        try {
+          completedResponse = JSON.parse(body.toString("utf8"));
+        } catch {
+          this.sendError(502, {
+            type: "local_router_protocol_error",
+            message: "The internal Responses endpoint returned invalid response JSON.",
+          });
+          return;
+        }
+        if (
+          !completedResponse ||
+          typeof completedResponse !== "object" ||
+          Array.isArray(completedResponse) ||
+          typeof completedResponse.id !== "string" ||
+          completedResponse.id.length === 0 ||
+          completedResponse.status !== "completed" ||
+          !Array.isArray(completedResponse.output)
+        ) {
+          this.sendError(502, {
+            type: "local_router_protocol_error",
+            message: "The internal Responses endpoint returned an invalid completed response.",
+          });
+          return;
+        }
+        if (!(await sendSuccessfulResponseHeaders(this, upstream))) return;
+        if (!(await this.sendJsonWithBackpressure({
+          type: "response.created",
+          response: { ...completedResponse, status: "in_progress", output: [] },
+        }))) return;
+        for (const [outputIndex, item] of completedResponse.output.entries()) {
+          if (!(await this.sendJsonWithBackpressure({
+            type: "response.output_item.done",
+            output_index: outputIndex,
+            item,
+          }))) return;
+        }
+        if (!(await this.sendJsonWithBackpressure({
+          type: "response.completed",
+          response: completedResponse,
+        }))) return;
+        this.continuations.clear();
+        const continuation = continuationState(
+          fullRequest.input,
+          completedResponse.output,
+          this.options.maxContinuationBytes,
+        );
+        if (continuation) this.continuations.set(completedResponse.id, continuation);
         return;
       }
       if (!(await sendSuccessfulResponseHeaders(this, upstream))) return;

--- a/src/responses-websocket.mjs
+++ b/src/responses-websocket.mjs
@@ -558,6 +558,35 @@ function continuationState(input, output, maxBytes) {
   return encoded.length <= maxBytes ? { input, output } : undefined;
 }
 
+function continuationItemKey(item) {
+  if (typeof item?.call_id === "string" && item.call_id) return `call:${item.call_id}`;
+  if (typeof item?.id === "string" && item.id) return `id:${item.id}`;
+  return undefined;
+}
+
+function reconciledContinuationOutput(completedOutput, outputItems) {
+  if (!Array.isArray(completedOutput)) return outputItems;
+  if (!Array.isArray(outputItems) || outputItems.length === 0) return completedOutput;
+
+  const doneByKey = new Map();
+  for (const item of outputItems) {
+    const key = continuationItemKey(item);
+    if (key) doneByKey.set(key, item);
+  }
+
+  const used = new Set();
+  const reconciled = completedOutput.map((item) => {
+    const key = continuationItemKey(item);
+    const done = key ? doneByKey.get(key) : undefined;
+    if (!done) return item;
+    used.add(done);
+    return done;
+  });
+  for (const item of outputItems) {
+    if (!used.has(item)) reconciled.push(item);
+  }
+  return reconciled;
+}
 function errorShape(body, fallback) {
   let parsed;
   try {
@@ -1156,7 +1185,7 @@ class ResponsesWebSocketPeer {
         },
       );
       if (completed?.id && !terminalFailure) {
-        const output = Array.isArray(completed.output) ? completed.output : outputItems;
+        const output = reconciledContinuationOutput(completed.output, outputItems);
         this.continuations.clear();
         const continuation = !continuationOverflow
           ? continuationState(

--- a/test/responses-websocket.test.mjs
+++ b/test/responses-websocket.test.mjs
@@ -481,6 +481,141 @@ test("keeps unbounded tool inventory in the body and bounds its compatibility he
   peer.close();
 });
 
+test("relays a bounded successful JSON response without retrying the completed request", async (t) => {
+  let calls = 0;
+  const outputItem = {
+    type: "message",
+    id: "msg-json",
+    role: "assistant",
+    content: [{ type: "output_text", text: "ok" }],
+  };
+  const { server, port } = await startServer(async (request, response) => {
+    for await (const _chunk of request) {}
+    calls += 1;
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({
+      id: "resp-json",
+      object: "response",
+      status: "completed",
+      output: [outputItem],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    }));
+  });
+  t.after(() => server.close());
+
+  const { peer } = await connect(port);
+  t.after(() => peer.socket.destroy());
+  peer.sendJson(createRequest());
+
+  const created = await peer.nextJson();
+  assert.equal(created.type, "response.created");
+  assert.equal(created.response.id, "resp-json");
+  const outputDone = await peer.nextJson();
+  assert.equal(outputDone.type, "response.output_item.done");
+  assert.equal(outputDone.item.id, "msg-json");
+  const completed = await peer.nextJson();
+  assert.equal(completed.type, "response.completed");
+  assert.equal(completed.response.id, "resp-json");
+  assert.equal(calls, 1, "a completed internal request must not be repeated by the adapter");
+  peer.close();
+});
+test("recognizes a headerless completed JSON response after inference", async (t) => {
+  let calls = 0;
+  const { server, port } = await startServer(async (request, response) => {
+    for await (const _chunk of request) {}
+    calls += 1;
+    response.end(JSON.stringify({
+      id: "resp-headerless-json",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 },
+    }));
+  });
+  t.after(() => server.close());
+
+  const { peer } = await connect(port);
+  t.after(() => peer.socket.destroy());
+  peer.sendJson(createRequest());
+  assert.equal((await peer.nextJson()).type, "response.created");
+  const completed = await peer.nextJson();
+  assert.equal(completed.type, "response.completed");
+  assert.equal(completed.response.id, "resp-headerless-json");
+  assert.equal(calls, 1);
+  peer.close();
+});
+
+test("recognizes a headerless SSE response after inference", async (t) => {
+  let calls = 0;
+  const { server, port } = await startServer(async (request, response) => {
+    for await (const _chunk of request) {}
+    calls += 1;
+    const events = [
+      { type: "response.created", response: { id: "resp-headerless-sse" } },
+      { type: "response.completed", response: { id: "resp-headerless-sse", usage: {} } },
+    ];
+    response.end(events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join(""));
+  });
+  t.after(() => server.close());
+
+  const { peer } = await connect(port);
+  t.after(() => peer.socket.destroy());
+  peer.sendJson(createRequest());
+  assert.equal((await peer.nextJson()).type, "response.created");
+  const completed = await peer.nextJson();
+  assert.equal(completed.type, "response.completed");
+  assert.equal(completed.response.id, "resp-headerless-sse");
+  assert.equal(calls, 1);
+  peer.close();
+});
+
+test("recognizes a misdeclared completed JSON response after inference", async (t) => {
+  let calls = 0;
+  const { server, port } = await startServer(async (request, response) => {
+    for await (const _chunk of request) {}
+    calls += 1;
+    response.writeHead(200, { "content-type": "text/plain; charset=utf-8" });
+    response.end(JSON.stringify({
+      id: "resp-misdeclared-json",
+      object: "response",
+      status: "completed",
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 0, total_tokens: 1 },
+    }));
+  });
+  t.after(() => server.close());
+
+  const { peer } = await connect(port);
+  t.after(() => peer.socket.destroy());
+  peer.sendJson(createRequest());
+  assert.equal((await peer.nextJson()).type, "response.created");
+  const completed = await peer.nextJson();
+  assert.equal(completed.type, "response.completed");
+  assert.equal(completed.response.id, "resp-misdeclared-json");
+  assert.equal(calls, 1);
+  peer.close();
+});
+
+test("rejects an undeclared arbitrary body after one completed internal call", async (t) => {
+  let calls = 0;
+  const { server, port } = await startServer(async (request, response) => {
+    for await (const _chunk of request) {}
+    calls += 1;
+    response.writeHead(200, { "content-type": "text/plain" });
+    response.end("not a Responses payload");
+  });
+  t.after(() => server.close());
+
+  const { peer } = await connect(port);
+  t.after(() => peer.socket.destroy());
+  peer.sendJson(createRequest());
+  const error = await peer.nextJson();
+  assert.equal(error.type, "error");
+  assert.equal(error.error.type, "local_router_protocol_error");
+  assert.equal(calls, 1);
+  peer.close();
+});
+
 test("prewarms locally and reconstructs incremental turns without losing history", async (t) => {
   const bodies = [];
   const requestHeaders = [];

--- a/test/responses-websocket.test.mjs
+++ b/test/responses-websocket.test.mjs
@@ -735,6 +735,58 @@ test("prewarms locally and reconstructs incremental turns without losing history
   peer.close();
 });
 
+test("continuation replay prefers the complete custom tool item over a conflicting completion snapshot", async (t) => {
+  const bodies = [];
+  const customCall = {
+    type: "custom_tool_call",
+    id: "ctc_custom",
+    status: "completed",
+    call_id: "call_custom",
+    name: "exec",
+    input: "text(await tools.exec_command({cmd: 'echo ok'}));",
+  };
+  const { server, port } = await startServer(async (request, response) => {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    bodies.push(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+    const id = bodies.length === 1 ? "resp-custom" : "resp-after-tool";
+    sse(response, [
+      { type: "response.created", response: { id } },
+      ...(bodies.length === 1
+        ? [
+            { type: "response.output_item.done", item: customCall },
+            {
+              type: "response.completed",
+              response: {
+                id,
+                output: [{ type: "function_call", call_id: "call_custom", name: "exec" }],
+                usage: {},
+              },
+            },
+          ]
+        : [{ type: "response.completed", response: { id, usage: {} } }]),
+    ]);
+  });
+  t.after(() => server.close());
+  const { peer } = await connect(port);
+  t.after(() => peer.socket.destroy());
+
+  peer.sendJson(createRequest());
+  assert.equal((await peer.nextJson()).type, "response.created");
+  assert.equal((await peer.nextJson()).type, "response.output_item.done");
+  assert.equal((await peer.nextJson()).type, "response.completed");
+
+  const toolResult = {
+    type: "custom_tool_call_output",
+    call_id: "call_custom",
+    output: [{ type: "input_text", text: "ok" }],
+  };
+  peer.sendJson(createRequest({ previous_response_id: "resp-custom", input: [toolResult] }));
+  assert.equal((await peer.nextJson()).type, "response.created");
+  assert.equal((await peer.nextJson()).type, "response.completed");
+  assert.deepEqual(bodies[1].input, [...bodies[0].input, customCall, toolResult]);
+  peer.close();
+});
 test("wraps HTTP failures and serializes requests on a reused connection", async (t) => {
   let calls = 0;
   let active = 0;


### PR DESCRIPTION
## Summary

Fixes #546 and #554 by hardening the authenticated Responses WebSocket adapter against two post-inference failure modes:

- preserve a successful internal Responses result even when HTTP 200 is returned as completed JSON rather than declared SSE;
- reconcile continuation output so a complete streamed `response.output_item.done` item wins over a conflicting/incomplete `response.completed.output` snapshot with the same `call_id` or item `id`.

The latter matters for Codex custom tools such as `exec`: if a completed custom call is cached as an incomplete `function_call`, the next `custom_tool_call_output` becomes orphaned and the native Responses backend rejects the turn with `No tool call found for custom tool call output with call_id ...`.

## Changes

- relay declared SSE unchanged;
- normalize a bounded, structurally valid completed Responses JSON object into `response.created` / `response.output_item.done` / `response.completed` WebSocket events;
- recognize headerless SSE with the existing bounded `HeaderlessSseDetector`;
- accept headerless or misdeclared completed JSON only after bounded structural validation;
- keep arbitrary/malformed bodies fail-closed with a bounded protocol error;
- rebuild continuation state from completed responses;
- reconcile streamed completed output items with the terminal response snapshot by stable `call_id`/`id`, preserving completion-only items and appending streamed items omitted by the snapshot.

## Why

The internal request can complete successfully before the adapter inspects the response representation. Returning a 502 after that point can retry an already-completed inference.

A second real Windows Codex turn exposed the continuation-side variant: Codex persisted a valid completed `custom_tool_call`, executed it successfully, then persisted the matching `custom_tool_call_output` with the same `call_id`; the following model request nevertheless received HTTP 400 saying no tool call existed for that output. A deterministic two-turn regression reproduced the break by streaming a complete custom call while the terminal snapshot carried a conflicting incomplete function-call representation. Before the fix the cached replay contained the wrong item; after reconciliation it contains the original complete custom call followed by its output.

## Verification

- RED before the continuation fix: the synthetic two-turn custom-tool regression replayed `function_call` instead of the complete `custom_tool_call` and failed the pairing assertion;
- GREEN after the fix: the focused regression passes;
- `node --test test/responses-websocket.test.mjs` — 32 passed, 0 failed;
- `node --test test/namespace-relay-routing.test.mjs test/namespace-relay.test.mjs test/routing.test.mjs` — 237 passed, 0 failed on the canonical Windows checkout;
- `npm.cmd run check` — passed;
- `node --check src/responses-websocket.mjs` — passed;
- `git diff --check` — clean;
- router-only reload on Windows succeeded; `/health` remained 200 and the post-reload log boundary contained no WebSocket/protocol/tool-pairing errors;
- the originally failing Codex thread subsequently completed 9 additional custom-tool call/output pairs with zero repeated pairing/502 errors.

No provider/model inference was generated solely for these regression tests.