### PR TITLE
fix: preserve zero-argument wrapper commands

### DIFF
--- a/model-router.ps1
+++ b/model-router.ps1
@@ -13,5 +13,9 @@ param(
 
 $ErrorActionPreference = "Stop"
 $env:MODEL_ROUTER_TARGET = $Target
+# ValueFromRemainingArguments binds no remainder as $null. Splatting that value
+# contributes one empty positional argument, which breaks strict zero-argument
+# commands such as `start`. Normalize only the absent remainder to an empty array.
+if ($null -eq $CommandArguments) { $CommandArguments = @() }
 & (Join-Path $PSScriptRoot "codex-router.ps1") $Command @CommandArguments
 exit $LASTEXITCODE

--- a/test/codex-router-args.test.mjs
+++ b/test/codex-router-args.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -54,4 +56,27 @@ test("an action is never truncated, whatever its length", { skip }, () => {
 test("multi-argument subcommands are still passed through whole", { skip }, () => {
   const result = runCli("panel", "--help");
   assert.match(result.stdout, /--print/, "the flag did not reach panel.mjs");
+});
+
+test("model-router wrapper does not invent an empty trailing argument", { skip }, () => {
+  const fixture = mkdtempSync(path.join(os.tmpdir(), "model-router-args-"));
+  try {
+    copyFileSync(path.join(root, "model-router.ps1"), path.join(fixture, "model-router.ps1"));
+    writeFileSync(
+      path.join(fixture, "codex-router.ps1"),
+      'Write-Output ("ARG_COUNT=" + $args.Count)\n' +
+        'for ($i = 0; $i -lt $args.Count; $i += 1) { Write-Output ("ARG_" + $i + "=<" + [string]$args[$i] + ">") }\n',
+      "utf8",
+    );
+    const result = spawnSync(
+      "powershell.exe",
+      ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", path.join(fixture, "model-router.ps1"), "codex", "start"],
+      { encoding: "utf8", cwd: fixture },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /ARG_COUNT=1/);
+    assert.match(result.stdout, /ARG_0=<start>/);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

Fixes #552 by making the Windows `model-router.ps1` convenience wrapper forward exactly the arguments supplied by the caller.

`ValueFromRemainingArguments` binds an absent remainder as `$null`. PowerShell splatting of that null value contributes an empty positional argument, so:

```powershell
.\model-router.ps1 codex start
```

reaches `codex-router.ps1` as `start` plus one empty argument and is rejected by the strict `start` parser.

The wrapper now normalizes only the absent remainder to an empty array before splatting. Non-empty argument forwarding is unchanged.

## Verification

- isolated Windows regression fixture copies the wrapper and replaces `codex-router.ps1` with an argument-reporting stub;
- before the fix, `codex start` produced `ARG_COUNT=2` with an empty trailing argument;
- after the fix, it produces exactly `ARG_COUNT=1`, `ARG_0=<start>`;
- `node --test test/codex-router-args.test.mjs` — 4 passed, 0 failed;
- direct PowerShell parser check — passed;
- `npm.cmd run check` — passed;
- `git diff --check` — clean.

No live router/Codex service mutation or provider request is required for the regression.