### PR TITLE
feat(openclaw): add routed client target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ These instructions apply when a user asks an agent to install this repository.
 
 - `codex` (the Codex CLI and desktop app), `dsh` (DeepSeek Harness), `gemini`
   (Gemini CLI), `cursor` (Cursor Agent plus Cursor App), and `claude` (Claude
-  Code through the router-owned launcher) are supported
+  Code through the router-owned launcher), and `openclaw` (OpenClaw through a
+  router-owned Responses provider) are supported
   targets. OpenCode remains a provider rather than a client target.
 - Cursor is asymmetric: Cursor Agent uses the router's authenticated loopback
   Connect adapter, while retail Cursor App sends BYOK traffic through Cursor's
@@ -261,6 +262,46 @@ and keep every turn on the shared canonical Responses path.
 7. Anthropic officially supports Claude Code gateways for Claude models. Using
    non-Claude models through this compatibility surface is functional but not
    an Anthropic-supported product configuration; do not describe it otherwise.
+
+## OpenClaw outcome
+
+Install OpenClaw when it is missing, publish every selected and credentialed
+routed model under one router-owned `codex-router` provider, preserve all other
+OpenClaw configuration, and leave the next agent run to read the new route.
+
+1. OpenClaw's current releases require Node 22.22.3+, 24.15+, 25.9+, or 26+;
+   Node 23 is unsupported. The target installer must refuse an unsupported
+   runtime before invoking npm. With npm 11.16+ or 12+, install the official
+   package as `npm install -g openclaw@latest --allow-scripts=openclaw`; older
+   npm 11 releases omit the scoped lifecycle flag they do not understand.
+2. Run `./install.sh --target openclaw --auto --providers IDS` on macOS/Linux
+   or `./install.ps1 -Target openclaw -Auto -Providers IDS` on Windows. The
+   Control Center Harness action calls the same install-if-missing and publish
+   sequence. Do not start onboarding, a gateway, or an agent as a setup side
+   effect.
+3. Own exactly `models.providers.codex-router`. Write it through `openclaw
+   config patch --stdin --replace-path models.providers.codex-router`; never
+   put the caller capability in argv, logs, or status output. Refuse a
+   pre-existing provider with that id when no router publication marker proves
+   ownership, or when its base URL is not a managed loopback caller URL.
+4. Publish router slugs as `codex-router/SLUG` over `openai-responses`, with
+   each model's context window, input modalities, and exact supported reasoning
+   efforts. If no OpenClaw default exists on the first publish, set the
+   highest-priority route and record ownership. Preserve any existing default,
+   stop owning a default the user changes, and remove it on uninstall only
+   while it still equals the router-owned value.
+5. The caller URL and API key are local capabilities and make both the
+   OpenClaw config and `openclaw-models.json` private state. Caller-key rotation
+   must republish OpenClaw inside the same transaction as other credentialed
+   clients. Status, doctor, errors, and support material must redact the URL.
+6. Run `bin/model-router openclaw doctor`. OpenClaw routing config, CLI,
+   config privacy, catalog freshness, caller capability, service, router
+   health, and selected credentials must be `OK`.
+7. AgentHarnessV2 is OpenClaw's native runtime-plugin boundary, not another
+   HTTP provider protocol. A normal Responses endpoint belongs in the provider
+   catalog and uses OpenClaw's embedded runtime when no native plugin claims
+   it. Do not register a harness plugin or describe this integration as a
+   native V2 harness. No restart is needed; tell the user to run `openclaw`.
 
 ## What the Gemini integration writes, and what it must never touch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **OpenClaw is now a one-click routed client.** The Harness page can install
+  the official `openclaw@latest` package when it is missing and publish every
+  selected router model through a private `codex-router` Responses provider.
+  The integration preserves unrelated OpenClaw config and user-selected
+  defaults, participates in shared catalog refresh and caller-key rotation,
+  and is available as `--target openclaw` on POSIX and Windows.
+
 - **Muse Spark 1.2 Contributor no longer fails on recursive Codex tool
   schemas through OpenCode Go.** Console Go rejects the whole Responses turn
   before inference when this model receives a recursive local JSON-Schema

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Use Anthropic, Kimi, DeepSeek, xAI, GitHub Copilot, and other external models
 inside the Codex App and CLI. One local installation can also serve
 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) and
 [Gemini CLI](https://github.com/google-gemini/gemini-cli), plus Cursor Agent
-and Cursor App. Your provider
+and Cursor App, Claude Code, and [OpenClaw](https://github.com/openclaw/openclaw).
+Your provider
 credentials stay on your computer.
 
 ### Subscription agent bridges (experimental)
@@ -1866,7 +1867,7 @@ codex login
 ./bin/model-router codex chatgpt-session enable
 ```
 
-DeepSeek Harness, Gemini CLI, and future clients installed for this same OS
+DeepSeek Harness, Gemini CLI, OpenClaw, and future clients installed for this same OS
 user then reuse that one authorization over the loopback; there is no login per
 harness and the marker stores no credential. Native models are withheld until
 both the authorization and a usable Codex session exist, and disappear again
@@ -2234,6 +2235,46 @@ Claude.ai subscription login is not converted into a reusable API credential.
 ./bin/model-router claude disable
 ```
 
+## Make models appear in OpenClaw
+
+The `openclaw` target is the one-click path from the Control Center's Harness
+page. **Set up** installs the official `openclaw@latest` npm package when it is
+missing, then publishes every selected, credentialed router model under one
+OpenClaw provider:
+
+```sh
+./install.sh --target openclaw --auto --providers configured
+# or add OpenClaw to an existing router
+./bin/model-router openclaw enable
+
+openclaw
+```
+
+The router owns only `models.providers.codex-router` and a private publication
+marker. It writes the provider through `openclaw config patch --stdin`, so the
+local caller capability never appears in command arguments. Existing OpenClaw
+agents, channels, plugins, and other providers stay untouched. If no default
+model exists on first setup, the router selects its highest-priority route; an
+existing default or a later user override is preserved.
+
+OpenClaw model references use `codex-router/<router-slug>` and speak
+`openai-responses` to the same authenticated loopback path as the other local
+clients. Context windows, text/image input, and the router's exact reasoning
+effort ladder are published with each model. Disable removes only the managed
+provider and removes the default only when it is still the value the router
+set:
+
+```sh
+./bin/model-router openclaw doctor
+./bin/model-router openclaw status
+./bin/model-router openclaw disable
+```
+
+OpenClaw's AgentHarnessV2 API is a native runtime-plugin boundary, not a new
+HTTP model protocol. The router therefore remains an ordinary Responses model
+provider; when no native plugin claims the route, OpenClaw correctly uses its
+embedded runtime. No restart is required after publication.
+
 The optional live check makes one small request per selected provider and may
 consume paid quota:
 
@@ -2241,7 +2282,8 @@ consume paid quota:
 ./bin/model-router codex smoke-test --yes
 ```
 
-`disable` removes only the Codex integration and its current service.
+`disable` removes only the selected client integration and retires the shared
+service only when no installed client still uses it.
 `uninstall` intentionally retains the checkout, logs, backups, internal keys,
 and provider credentials so routine removal cannot destroy authentication or
 recovery data.

--- a/apps/control-center/README.md
+++ b/apps/control-center/README.md
@@ -19,11 +19,15 @@ credentials, or service logic in the renderer.
   without an explicit model selection.
 - Local: Ollama runtime controls, installable and installed models, downloads,
   enablement, removal, benchmarks, and local image readers.
-- Harness: one row each for Cursor, Claude Code, Gemini CLI, DeepSeek Harness, and Codex. Every row
+- Harness: one row each for OpenClaw, Cursor, Claude Code, Gemini CLI, DeepSeek Harness, and Codex. Every row
   reports client detection, router publication, routed models, and indexed
-  sessions, then exposes fixed setup, launch, terminal, session, and
-  documentation actions. Setup publishes the same shared router plane into the
-  selected client instead of creating another credential or service store.
+  sessions. An unconfigured row exposes setup; a configured row has one Open
+  action that launches the desktop app when present and otherwise opens the
+  official client site. Terminal and document access stay in their dedicated
+  surfaces. Setup publishes the same shared router plane into the selected
+  client instead of creating another credential or service store.
+  OpenClaw setup installs the official npm package when absent and publishes
+  the router-owned `codex-router` provider in the same click.
   Claude Code publishes routed models through `claude-router`. Claude Code,
   Cursor Agent, and Gemini CLI show optional official-client agent availability
   inside the matching row, separate from the routed-model count.

--- a/apps/control-center/electron/api.d.ts
+++ b/apps/control-center/electron/api.d.ts
@@ -3,13 +3,13 @@ export type SubagentMode = "all" | "selected" | "proven";
 export type VisionEffort = "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra" | "default";
 export type ServiceAction = "status" | "start";
 export type TrayAction = "enable" | "disable" | "status" | "restart";
-export type HarnessId = "codex" | "dsh" | "gemini" | "cursor" | "claude";
+export type HarnessId = "codex" | "dsh" | "gemini" | "cursor" | "claude" | "openclaw";
 export type HarnessSurface = "app" | "terminal";
 
 export interface HarnessDescriptor {
   id: HarnessId;
   displayName: string;
-  ownership: "openai" | "deepseek" | "google" | "cursor" | "anthropic";
+  ownership: "openai" | "deepseek" | "google" | "cursor" | "anthropic" | "openclaw";
   description: string;
   cliInstalled: boolean;
   cliVersion?: string;
@@ -75,7 +75,7 @@ export interface HarnessSession {
 export interface ContextSessionsSnapshot {
   fetchedAt: string;
   sessions: HarnessSession[];
-  counts: { total: number; codex: number; dsh: number; cursor: number; claude: number; gemini: number; archived: number };
+  counts: { total: number; codex: number; dsh: number; cursor: number; claude: number; gemini: number; openclaw: number; archived: number };
 }
 
 export interface ChatGptSessionStatus {

--- a/apps/control-center/electron/ipc.mjs
+++ b/apps/control-center/electron/ipc.mjs
@@ -49,7 +49,7 @@ const SESSION_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3
 const CURSOR_SESSION_ID = /^(?:(?:draft|bc)-)?[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SESSION_UUID_IN_FILENAME = /[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
 const DSH_SESSION_ID = /^session-[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const HARNESS_IDS = ["codex", "dsh", "gemini", "cursor", "claude"];
+const HARNESS_IDS = ["codex", "dsh", "gemini", "cursor", "claude", "openclaw"];
 const HARNESS_SURFACES = ["app", "terminal"];
 const AGENT_BRIDGE_IDS = ["anthropic", "cursor", "gemini"];
 const SESSION_INDEX_LIMIT = 16 * 1024 * 1024;
@@ -84,6 +84,15 @@ const CLOUDFLARED_INSTALL_DOCS = "https://developers.cloudflare.com/cloudflare-o
 const CODEX_DOCS = "https://developers.openai.com/codex/cli/";
 const CLAUDE_CODE_DOCS = "https://code.claude.com/docs/en/overview";
 const GEMINI_CLI_DOCS = "https://github.com/google-gemini/gemini-cli";
+const OPENCLAW_DOCS = "https://docs.openclaw.ai/";
+const HARNESS_SITES = Object.freeze({
+  openclaw: "https://openclaw.ai/",
+  codex: "https://openai.com/codex/",
+  dsh: DSH_DOCS,
+  cursor: "https://cursor.com/",
+  claude: "https://claude.com/product/claude-code",
+  gemini: "https://google-gemini.github.io/gemini-cli/",
+});
 const OAUTH_LOGIN_COMMANDS = Object.freeze({
   "kimi-oauth": { executable: "kimi", args: ["login"] },
   "grok-oauth": { executable: "grok", args: ["login", "--oauth"] },
@@ -180,6 +189,31 @@ function cursorDesktopPath() {
   ].find((candidate) => existsSync(candidate));
 }
 
+function openclawDesktopPath() {
+  const localAppData = process.env.LOCALAPPDATA;
+  const programFiles = process.env.PROGRAMFILES;
+  return [
+    "/Applications/OpenClaw.app",
+    path.join(os.homedir(), "Applications", "OpenClaw.app"),
+    ...(process.platform === "linux"
+      ? [
+          executablePath("openclaw-desktop"),
+          "/usr/bin/openclaw-desktop",
+          "/usr/local/bin/openclaw-desktop",
+          path.join(os.homedir(), ".local", "bin", "openclaw-desktop"),
+        ]
+      : []),
+    ...(process.platform === "win32"
+      ? [
+          localAppData && path.join(localAppData, "Programs", "OpenClaw Companion", "OpenClaw Companion.exe"),
+          localAppData && path.join(localAppData, "Programs", "OpenClawCompanion", "OpenClawCompanion.exe"),
+          localAppData && path.join(localAppData, "Programs", "OpenClaw", "OpenClaw.exe"),
+          programFiles && path.join(programFiles, "OpenClaw Companion", "OpenClaw Companion.exe"),
+        ]
+      : []),
+  ].filter(Boolean).find((candidate) => existsSync(candidate));
+}
+
 function cursorConnectorInstallSpec() {
   if (process.platform === "darwin") {
     const brew = executablePath("brew");
@@ -242,16 +276,20 @@ export function getHarnessSnapshot() {
   const claude = executablePath("claude");
   const claudeLauncher = executablePath("claude-router");
   const gemini = executablePath("gemini");
+  const openclaw = executablePath("openclaw");
   const codexVersion = executableVersion(codex);
   const dshVersion = executableVersion(dsh);
   const cursorVersion = executableVersion(cursorAgent);
   const claudeVersion = executableVersion(claude);
   const geminiVersion = executableVersion(gemini);
+  const openclawVersion = executableVersion(openclaw);
+  const openclawApp = openclawDesktopPath();
   const stateDirectory = routerStateDirectory();
   const codexConfig = readBounded(path.join(process.env.CODEX_HOME || path.join(os.homedir(), ".codex"), "config.toml"), 2 * 1024 * 1024);
   const cursorState = readJsonObject(path.join(stateDirectory, "cursor-models.json"), 2 * 1024 * 1024);
   const claudeState = readJsonObject(path.join(stateDirectory, "claude-models.json"), 2 * 1024 * 1024);
   const geminiState = readJsonObject(path.join(stateDirectory, "gemini-models.json"), 2 * 1024 * 1024);
+  const openclawState = readJsonObject(path.join(stateDirectory, "openclaw-models.json"), 2 * 1024 * 1024);
   const cursorTunnel = readJsonObject(path.join(stateDirectory, "cursor-tunnel.json"), 512 * 1024);
   const cloudflared = executablePath("cloudflared");
   const cloudflareLoggedIn = existsSync(
@@ -265,6 +303,21 @@ export function getHarnessSnapshot() {
     platform: process.platform,
     terminalAvailable: terminalAvailable(),
     harnesses: [
+      {
+        id: "openclaw",
+        displayName: "OpenClaw",
+        ownership: "openclaw",
+        description: "OpenClaw's current agent runtime using every model selected in this router.",
+        cliInstalled: Boolean(openclaw),
+        ...(openclawVersion ? { cliVersion: openclawVersion } : {}),
+        appInstalled: Boolean(openclawApp),
+        configured: Boolean(openclawState?.models?.length),
+        canInstall: true,
+        installRequirement: openclaw
+          ? "Publishes every routed model into OpenClaw's router-owned provider. Other OpenClaw settings remain untouched."
+          : "Setup installs openclaw@latest and publishes every routed model in one action.",
+        docsUrl: OPENCLAW_DOCS,
+      },
       {
         id: "codex",
         displayName: "Codex",
@@ -797,6 +850,7 @@ export function getContextSessionsSnapshot() {
       cursor: sessions.filter((session) => session.harnessId === "cursor").length,
       claude: sessions.filter((session) => session.harnessId === "claude").length,
       gemini: sessions.filter((session) => session.harnessId === "gemini").length,
+      openclaw: 0,
       archived: sessions.filter((session) => session.archived).length,
     },
   };
@@ -983,6 +1037,7 @@ export function registerIpcHandlers({
   harnessSnapshotReader = getHarnessSnapshot,
   harnessExecutableResolver = executablePath,
   cursorAppPath = cursorDesktopPath,
+  openclawAppPath = openclawDesktopPath,
   senderGuard = () => true,
 } = {}) {
   if (!ipcMain?.handle) throw new TypeError("ipcMain.handle is required.");
@@ -1440,40 +1495,57 @@ export function registerIpcHandlers({
   handleAction("launchHarness", async ({ harnessId, surface } = {}) => {
     const harness = oneOf(harnessId, HARNESS_IDS, "Harness");
     const destination = oneOf(surface, HARNESS_SURFACES, "Harness surface");
+    const openOfficialSite = async () => {
+      if (!shell?.openExternal) throw new Error("Opening the official client site is unavailable.");
+      await shell.openExternal(HARNESS_SITES[harness]);
+      return { opened: true, surface: "site" };
+    };
     if (harness === "codex" && destination === "app") {
       const appPath = codexDesktopPath();
-      if (!appPath) throw new Error("Codex desktop is not installed. Open the official Codex documentation to download it.");
+      if (!appPath) return openOfficialSite();
       if (!shell?.openPath) throw new Error("Opening desktop apps is unavailable.");
       const failure = await shell.openPath(appPath);
       if (failure) throw new Error("Could not open the Codex desktop app.");
       return { opened: true, surface: "app" };
     }
     if (harness === "cursor" && destination === "app") {
-      const appPath = cursorDesktopPath();
-      if (!appPath) throw new Error("Cursor App is not installed.");
+      const appPath = cursorAppPath();
+      if (!appPath) return openOfficialSite();
       if (!shell?.openPath) throw new Error("Opening desktop apps is unavailable.");
       const failure = await shell.openPath(appPath);
       if (failure) throw new Error("Could not open Cursor App.");
       return { opened: true, surface: "app" };
     }
+    if (harness === "openclaw" && destination === "app") {
+      const appPath = openclawAppPath();
+      if (!appPath) return openOfficialSite();
+      if (!shell?.openPath) throw new Error("Opening desktop apps is unavailable.");
+      const failure = await shell.openPath(appPath);
+      if (failure) throw new Error("Could not open OpenClaw.");
+      return { opened: true, surface: "app" };
+    }
     if (harness === "dsh" && destination === "app") {
+      if (!harnessExecutableResolver("dsh")) return openOfficialSite();
       if (!shell?.openExternal) throw new Error("Opening DeepSeek Harness is unavailable.");
       const state = await runControlJson(["harness", "start"], { timeoutMs: 120_000 });
       if (!state?.url) throw new Error("DeepSeek Harness started without a browser URL.");
       await shell.openExternal(state.url);
       return { opened: true, surface: "app" };
     }
+    if (destination === "app") return openOfficialSite();
     const executable = executablePath(
       harness === "codex" ? "codex"
         : harness === "dsh" ? "dsh"
           : harness === "claude" ? "claude-router"
             : harness === "gemini" ? "gemini"
+              : harness === "openclaw" ? "openclaw"
               : "cursor-router-agent",
     );
     const label = harness === "codex" ? "Codex"
       : harness === "dsh" ? "DeepSeek Harness"
         : harness === "claude" ? "Claude Code Router"
           : harness === "gemini" ? "Gemini CLI"
+            : harness === "openclaw" ? "OpenClaw"
             : "Cursor Router Agent";
     if (!executable) throw new Error(`${label} CLI is not installed or configured.`);
     return openTerminalCommand(executable, [], discoverSourceRoot());
@@ -1524,6 +1596,10 @@ export function registerIpcHandlers({
         throw new Error("Claude Code is not installed. Install the official Claude Code CLI, then refresh Harness.");
       }
       environmentOverrides.CLAUDE_CODE_BIN = claude;
+    }
+    if (harness === "openclaw") {
+      const openclaw = harnessExecutableResolver("openclaw");
+      if (openclaw) environmentOverrides.OPENCLAW_BIN = openclaw;
     }
     return controlJsonRunner(args, {
       timeoutMs: REPAIR_TIMEOUT_MS,

--- a/apps/control-center/src/App.tsx
+++ b/apps/control-center/src/App.tsx
@@ -75,7 +75,7 @@ const NAV_ITEMS: Array<{
   { id: "status", label: "Status", description: "Agents, speed, savings, requests", icon: Activity },
   { id: "models", label: "Models", description: "Providers, credentials, and catalog", icon: Boxes },
   { id: "local", label: "Local", description: "Runtime and on-device models", icon: HardDrive },
-  { id: "harness", label: "Harness", description: "Cursor, Claude, Gemini, DeepSeek, Codex", icon: Braces, experimental: true },
+  { id: "harness", label: "Harness", description: "OpenClaw, Cursor, Claude, Gemini, DeepSeek, Codex", icon: Braces, experimental: true },
   { id: "context", label: "Context Manager", description: "Sessions across harnesses", icon: BrainCircuit },
   { id: "settings", label: "Settings", description: "Routing and desktop", icon: Settings },
 ];

--- a/apps/control-center/src/assets/clients/SOURCES.md
+++ b/apps/control-center/src/assets/clients/SOURCES.md
@@ -10,6 +10,7 @@ Research was refreshed on 2026-08-30.
 | `deepseek-harness.svg` | DeepSeek Harness | https://github.com/deepseek-ai/deepseek-harness | `packages/client/ui-primitives/src/FishLogo.tsx` from the official DeepSeek Harness repository |
 | `codex-light.svg`, `codex-dark.svg` | Codex | https://developers.openai.com/ | Dedicated `icon-codex-light.png` and `icon-codex-dark-color.png` product assets bundled in the installed official OpenAI desktop app, mechanically downsampled for this 23px surface |
 | `claude.svg` | Claude Code | https://claude.com/product/claude-code | Exact orange Claude mark bundled in the installed official Anthropic Claude app (`ion-dist/assets/v1/cd02a42d9-Vq_H3mgS.svg`) |
+| `openclaw.svg` | OpenClaw | https://github.com/openclaw/openclaw | Official `docs/assets/pixel-lobster.svg` from the OpenClaw repository |
 
 DeepSeek Harness's official component is rendered as a current-colour mask.
 Cursor and Codex retain their official light/dark artwork. All names, logos, and trademarks remain

--- a/apps/control-center/src/assets/clients/openclaw.svg
+++ b/apps/control-center/src/assets/clients/openclaw.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 16 16" role="img" aria-label="Pixel lobster">
+  <rect width="16" height="16" fill="none"/>
+  <!-- outline -->
+  <g fill="#3a0a0d">
+    <rect x="1" y="5" width="1" height="3"/>
+    <rect x="2" y="4" width="1" height="1"/>
+    <rect x="2" y="8" width="1" height="1"/>
+    <rect x="3" y="3" width="1" height="1"/>
+    <rect x="3" y="9" width="1" height="1"/>
+    <rect x="4" y="2" width="1" height="1"/>
+    <rect x="4" y="10" width="1" height="1"/>
+    <rect x="5" y="2" width="6" height="1"/>
+    <rect x="11" y="2" width="1" height="1"/>
+    <rect x="12" y="3" width="1" height="1"/>
+    <rect x="12" y="9" width="1" height="1"/>
+    <rect x="13" y="4" width="1" height="1"/>
+    <rect x="13" y="8" width="1" height="1"/>
+    <rect x="14" y="5" width="1" height="3"/>
+    <rect x="5" y="11" width="6" height="1"/>
+    <rect x="4" y="12" width="1" height="1"/>
+    <rect x="11" y="12" width="1" height="1"/>
+    <rect x="3" y="13" width="1" height="1"/>
+    <rect x="12" y="13" width="1" height="1"/>
+    <rect x="5" y="14" width="6" height="1"/>
+  </g>
+
+  <!-- body -->
+  <g fill="#ff4f40">
+    <rect x="5" y="3" width="6" height="1"/>
+    <rect x="4" y="4" width="8" height="1"/>
+    <rect x="3" y="5" width="10" height="1"/>
+    <rect x="3" y="6" width="10" height="1"/>
+    <rect x="3" y="7" width="10" height="1"/>
+    <rect x="4" y="8" width="8" height="1"/>
+    <rect x="5" y="9" width="6" height="1"/>
+    <rect x="5" y="12" width="6" height="1"/>
+    <rect x="6" y="13" width="4" height="1"/>
+  </g>
+
+  <!-- claws -->
+  <g fill="#ff775f">
+    <rect x="1" y="6" width="2" height="1"/>
+    <rect x="2" y="5" width="1" height="1"/>
+    <rect x="2" y="7" width="1" height="1"/>
+    <rect x="13" y="6" width="2" height="1"/>
+    <rect x="13" y="5" width="1" height="1"/>
+    <rect x="13" y="7" width="1" height="1"/>
+  </g>
+
+  <!-- eyes -->
+  <g fill="#081016">
+    <rect x="6" y="5" width="1" height="1"/>
+    <rect x="9" y="5" width="1" height="1"/>
+  </g>
+  <g fill="#f5fbff">
+    <rect x="6" y="4" width="1" height="1"/>
+    <rect x="9" y="4" width="1" height="1"/>
+  </g>
+</svg>

--- a/apps/control-center/src/pages/HarnessPage.tsx
+++ b/apps/control-center/src/pages/HarnessPage.tsx
@@ -1,14 +1,12 @@
 import { useCallback, useEffect, useMemo, useState, type CSSProperties, type ReactNode } from "react";
 import {
   AppWindow,
-  BookOpen,
   Boxes,
   BrainCircuit,
   Globe2,
   LoaderCircle,
   Route,
   Settings2,
-  SquareTerminal,
 } from "lucide-react";
 import cursorLogo from "../assets/clients/cursor.svg";
 import cursorDarkLogo from "../assets/clients/cursor-dark.svg";
@@ -17,6 +15,7 @@ import codexLightLogo from "../assets/clients/codex-light.svg";
 import deepSeekHarnessLogo from "../assets/clients/deepseek-harness.svg";
 import claudeLogo from "../assets/clients/claude.svg";
 import geminiLogo from "../assets/providers/gemini.svg";
+import openclawLogo from "../assets/clients/openclaw.svg";
 import { Badge, Button, InlineNotice, PageHeader, PanelSkeleton, SectionHeading, StatStrip } from "../components";
 import type {
   AgentBridgeDescriptor,
@@ -44,13 +43,14 @@ interface HarnessPageProps {
   onNavigate: (view: ViewId) => void;
 }
 
-const CLIENT_ORDER: HarnessId[] = ["cursor", "claude", "gemini", "dsh", "codex"];
+const CLIENT_ORDER: HarnessId[] = ["openclaw", "cursor", "claude", "gemini", "dsh", "codex"];
 const CLIENT_LOGOS: Record<HarnessId, { light: string; dark?: string; mode: "artwork" | "mask" }> = {
   cursor: { light: cursorLogo, dark: cursorDarkLogo, mode: "artwork" },
   dsh: { light: deepSeekHarnessLogo, mode: "mask" },
   codex: { light: codexLightLogo, dark: codexDarkLogo, mode: "artwork" },
   claude: { light: claudeLogo, mode: "artwork" },
   gemini: { light: geminiLogo, mode: "artwork" },
+  openclaw: { light: openclawLogo, mode: "artwork" },
 };
 
 export function HarnessPage({ target, api, refreshing, operation, onRefresh, runAction, onNavigate }: HarnessPageProps) {
@@ -124,18 +124,12 @@ export function HarnessPage({ target, api, refreshing, operation, onRefresh, run
   const sessionCount = (id: HarnessId) => sessions?.counts[id] ?? 0;
   const setup = async (harness: HarnessDescriptor) => {
     if (!api) return;
-    if (harness.id === "cursor" && harness.configured) {
-      if (harness.appInstalled && harness.appConfigured) {
-        await act("Open Cursor", () => api.launchHarness("cursor", "app"));
-      } else {
-        await act("Open Cursor Agent", () => api.launchHarness("cursor", "terminal"));
-      }
+    if (harness.configured) {
+      await act(`Open ${harness.displayName}`, () => api.launchHarness(harness.id, "app"));
       return;
     }
     if (harness.id === "cursor") {
       await runCursorSetup("Connect Cursor", () => api.connectCursor(cursorHostname.trim() || undefined));
-    } else if (harness.id === "claude" && harness.configured) {
-      await act("Open Claude Code", () => api.launchHarness("claude", "terminal"));
     } else {
       await act(`Configure ${harness.displayName}`, () => api.setupHarness(harness.id));
     }
@@ -162,7 +156,7 @@ export function HarnessPage({ target, api, refreshing, operation, onRefresh, run
       {error ? <InlineNotice tone="warning" title="Client detection is incomplete">{error}</InlineNotice> : null}
 
       <div className="lhc-harness-list">
-        {!snapshot && !error ? <PanelSkeleton label="Detecting coding clients" variant="list" count={5} /> : null}
+        {!snapshot && !error ? <PanelSkeleton label="Detecting coding clients" variant="list" count={6} /> : null}
         {clients.length ? (
           <div className="lhc-harness-table-head" aria-hidden>
             <span>Client</span>
@@ -211,74 +205,28 @@ export function HarnessPage({ target, api, refreshing, operation, onRefresh, run
               </div>
             ) : undefined}
             actions={
-              <>
-                <div className={`lhc-harness-actions${harness.id === "cursor" ? " is-cursor" : ""}`}>
-                  <Button
-                    variant="primary"
-                    disabled={
-                      !api || !harness.canInstall || cursorOperationActive
-                    }
-                    title={harness.installRequirement}
-                    onClick={() => void setup(harness)}
-                  >
-                    {harness.id === "cursor" && cursorOperationActive
-                      ? <><LoaderCircle aria-hidden size={14} strokeWidth={1.7} className="spin" /> Working…</>
-                      : harness.id === "cursor" && harness.configured
-                      ? harness.appInstalled && harness.appConfigured
-                        ? <><AppWindow aria-hidden size={14} strokeWidth={1.7} /> Open Cursor</>
-                        : <><SquareTerminal aria-hidden size={14} strokeWidth={1.7} /> Open agent</>
-                      : harness.id === "claude" && harness.configured
-                        ? <><SquareTerminal aria-hidden size={14} strokeWidth={1.7} /> Open Claude Code</>
-                        : <><Settings2 aria-hidden size={14} strokeWidth={1.7} /> {harness.id === "cursor" ? "Connect Cursor" : harness.configured ? "Refresh" : "Set up"}</>}
-                  </Button>
-                  {harness.id === "cursor" ? (
-                    <Button
-                      variant="ghost"
-                      aria-label="Open Cursor Agent"
-                      title="Open Cursor Agent"
-                      disabled={!api || !harness.configured || !harness.agentConfigured || !snapshot?.terminalAvailable}
-                      onClick={() => api && void act("Open Cursor Agent", () => api.launchHarness("cursor", "terminal"))}
-                    >
-                      <SquareTerminal aria-hidden size={14} strokeWidth={1.7} />
-                    </Button>
-                  ) : (
-                    <Button
-                      variant="secondary"
-                      disabled={!api || !harness.appInstalled}
-                      onClick={() => api && void act(`Open ${harness.displayName}`, () => api.launchHarness(harness.id, "app"))}
-                    >
-                      <AppWindow aria-hidden size={14} strokeWidth={1.7} /> Open
-                    </Button>
-                  )}
-                  {harness.id !== "cursor" ? (
-                    <Button
-                      variant="ghost"
-                      aria-label={`Open ${harness.displayName} terminal`}
-                      title={`Open ${harness.displayName} terminal`}
-                      disabled={!api || !snapshot?.terminalAvailable || !harness.cliInstalled}
-                      onClick={() => api && void act(`Open ${harness.displayName} terminal`, () => api.launchHarness(harness.id, "terminal"))}
-                    >
-                      <SquareTerminal aria-hidden size={14} strokeWidth={1.7} />
-                    </Button>
-                  ) : null}
-                  <Button
-                    variant="ghost"
-                    aria-label={`Open ${harness.displayName} documentation`}
-                    title={`Open ${harness.displayName} documentation`}
-                    disabled={!api}
-                    onClick={() => api && void act(`Open ${harness.displayName} documentation`, () => api.openExternal(harness.docsUrl))}
-                  >
-                    <BookOpen aria-hidden size={14} strokeWidth={1.7} />
-                  </Button>
-                </div>
-              </>
+              <div className="lhc-harness-actions">
+                <Button
+                  variant="primary"
+                  aria-label={harness.configured ? `Open ${harness.displayName}` : undefined}
+                  disabled={!api || cursorOperationActive || (!harness.configured && !harness.canInstall)}
+                  title={harness.configured ? `Open ${harness.displayName} or its official site` : harness.installRequirement}
+                  onClick={() => void setup(harness)}
+                >
+                  {harness.id === "cursor" && cursorOperationActive
+                    ? <><LoaderCircle aria-hidden size={14} strokeWidth={1.7} className="spin" /> Working…</>
+                    : harness.configured
+                      ? <><AppWindow aria-hidden size={14} strokeWidth={1.7} /> Open</>
+                      : <><Settings2 aria-hidden size={14} strokeWidth={1.7} /> {harness.id === "cursor" ? "Connect Cursor" : "Set up"}</>}
+                </Button>
+              </div>
             }
           />
         ))}
       </div>
 
       <section className="panel-section">
-        <SectionHeading title="One router plane, five client stores" description="Model routes and provider credentials are shared; sessions and client-owned settings remain separate." />
+        <SectionHeading title="One router plane, six client stores" description="Model routes and provider credentials are shared; sessions and client-owned settings remain separate." />
         <div className="lhc-continuity-map">
           <article>
             <Route aria-hidden size={18} strokeWidth={1.7} />

--- a/apps/control-center/src/pages/local-harness-context.css
+++ b/apps/control-center/src/pages/local-harness-context.css
@@ -698,23 +698,14 @@
 
 .lhc-harness-actions {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 62px 32px 32px;
+  grid-template-columns: minmax(84px, 110px);
+  justify-content: end;
   width: 260px;
-  gap: 6px;
-}
-
-.lhc-harness-actions.is-cursor {
-  grid-template-columns: minmax(0, 1fr) 32px 32px;
 }
 
 .lhc-harness-actions .button {
   width: 100%;
   justify-content: center;
-}
-
-.lhc-harness-actions .button:nth-child(n + 3) {
-  min-height: 28px;
-  padding-inline: 0;
 }
 
 .lhc-harness-row footer .button,
@@ -976,14 +967,6 @@
   .lhc-harness-row > footer,
   .lhc-harness-actions {
     width: 242px;
-  }
-
-  .lhc-harness-actions {
-    grid-template-columns: minmax(0, 1fr) 58px 30px 30px;
-  }
-
-  .lhc-harness-actions.is-cursor {
-    grid-template-columns: minmax(0, 1fr) 58px 30px;
   }
 
   .lhc-session-row {

--- a/apps/control-center/src/types.ts
+++ b/apps/control-center/src/types.ts
@@ -566,13 +566,13 @@ export interface OperationEvent {
   error?: string;
 }
 
-export type HarnessId = "codex" | "dsh" | "gemini" | "cursor" | "claude";
+export type HarnessId = "codex" | "dsh" | "gemini" | "cursor" | "claude" | "openclaw";
 export type HarnessSurface = "app" | "terminal";
 
 export interface HarnessDescriptor {
   id: HarnessId;
   displayName: string;
-  ownership: "openai" | "deepseek" | "google" | "cursor" | "anthropic";
+  ownership: "openai" | "deepseek" | "google" | "cursor" | "anthropic" | "openclaw";
   description: string;
   cliInstalled: boolean;
   cliVersion?: string;
@@ -650,6 +650,7 @@ export interface ContextSessionsSnapshot {
     cursor: number;
     claude: number;
     gemini: number;
+    openclaw: number;
     archived: number;
   };
 }

--- a/apps/control-center/test/renderer.test.mjs
+++ b/apps/control-center/test/renderer.test.mjs
@@ -18,6 +18,7 @@ const bridgeSource = String.raw`
   const searchParams = new URLSearchParams(location.search);
   let usageDelayMs = Number(searchParams.get("usageDelayMs")) || 0;
   let cursorHarnessState = "configured";
+  let openclawHarnessConfigured = true;
   const snapshotDelayMs = Number(searchParams.get("snapshotDelayMs")) || 0;
   const providerDelayMs = Number(searchParams.get("providerDelayMs")) || 0;
   const accountDelay = searchParams.has("accountDelayMs")
@@ -221,6 +222,12 @@ const bridgeSource = String.raw`
       terminalAvailable: true,
       harnesses: [
         {
+          id: "openclaw", displayName: "OpenClaw", ownership: "openclaw",
+          description: "OpenClaw's current agent runtime.", cliInstalled: true, appInstalled: false,
+          configured: openclawHarnessConfigured, canInstall: true, installRequirement: "Publish shared config.",
+          docsUrl: "https://docs.openclaw.ai/",
+        },
+        {
           id: "codex", displayName: "Codex", ownership: "openai",
           description: "OpenAI coding client.", cliInstalled: true, appInstalled: true,
           configured: true, canInstall: true, installRequirement: "Publish shared config.",
@@ -271,14 +278,18 @@ const bridgeSource = String.raw`
     }),
     getContextSessions: async () => ({
       fetchedAt: "2026-08-30T08:00:00.000Z",
-      counts: { total: 3, codex: 1, dsh: 1, cursor: 1, archived: 0 },
+      counts: { total: 3, codex: 1, dsh: 1, cursor: 1, claude: 0, gemini: 0, openclaw: 0, archived: 0 },
       sessions: [
         { id: "11111111-1111-4111-8111-111111111111", harnessId: "cursor", title: "Cursor routing task", updatedAt: "2026-08-30T08:00:00.000Z", archived: false, resumable: true },
         { id: "session-22222222-2222-4222-8222-222222222222", harnessId: "dsh", title: "DeepSeek routing task", updatedAt: "2026-08-30T07:00:00.000Z", archived: false, resumable: true },
         { id: "33333333-3333-4333-8333-333333333333", harnessId: "codex", title: "Codex routing task", updatedAt: "2026-08-30T06:00:00.000Z", archived: false, resumable: true },
       ],
     }),
-    setupHarness: async () => ({ configured: true }),
+    setupHarness: async (harnessId) => {
+      record("setupHarness", harnessId);
+      if (harnessId === "openclaw") openclawHarnessConfigured = true;
+      return { configured: true };
+    },
     prepareCursorTunnel: async () => {
       record("prepareCursorTunnel");
       operationListener?.({ action: "prepareCursorTunnel", status: "started", message: "Downloading Cloudflare connector…" });
@@ -295,7 +306,10 @@ const bridgeSource = String.raw`
       operationListener?.({ action: "connectCursor", status: "completed", message: "Cursor routing verified." });
       return { configured: true, opened: true };
     },
-    launchHarness: async () => ({ opened: true }),
+    launchHarness: async (harnessId, surface) => {
+      record("launchHarness", harnessId, surface);
+      return { opened: true };
+    },
     probeAgentBridge: async (bridgeId) => { record("probeAgentBridge", bridgeId); return { handshake: "ok" }; },
     loginAgentBridge: async (bridgeId) => { record("loginAgentBridge", bridgeId); return { opened: true }; },
     openHarnessSession: async () => ({ opened: true }),
@@ -416,6 +430,7 @@ const bridgeSource = String.raw`
     usageReads: () => ({ account: accountUsageReads, provider: providerUsageReads }),
     healthReads: () => healthReads,
     setCursorHarnessState: (state) => { cursorHarnessState = state; },
+    setOpenClawHarnessConfigured: (configured) => { openclawHarnessConfigured = configured; },
   });
 })();
 `;
@@ -546,26 +561,51 @@ test("the production renderer exposes model discovery and picker actions", { tim
     assert.equal(await page.locator(".page-scroll-harness").evaluate((element) => getComputedStyle(element).display), "block");
     const harnessRows = page.locator(".lhc-harness-row");
     await harnessRows.first().waitFor();
-    assert.equal(await harnessRows.count(), 5);
+    assert.equal(await harnessRows.count(), 6);
     assert.deepEqual(
       (await harnessRows.locator("h2").allTextContents()).map((value) => value.trim()),
-      ["Cursor", "Claude Code", "Gemini CLI", "DeepSeek Harness", "Codex"],
+      ["OpenClaw", "Cursor", "Claude Code", "Gemini CLI", "DeepSeek Harness", "Codex"],
     );
-    assert.equal(await harnessRows.nth(0).locator('[data-client-logo="cursor"]').count(), 1);
-    assert.equal(await harnessRows.nth(1).locator('[data-client-logo="claude"]').count(), 1);
-    assert.equal(await harnessRows.nth(2).locator('[data-client-logo="gemini"]').count(), 1);
-    assert.equal(await harnessRows.nth(3).locator('[data-client-logo="dsh"]').count(), 1);
-    assert.equal(await harnessRows.nth(4).locator('[data-client-logo="codex"]').count(), 1);
+    assert.equal(await harnessRows.nth(0).locator('[data-client-logo="openclaw"]').count(), 1);
+    assert.equal(await harnessRows.nth(1).locator('[data-client-logo="cursor"]').count(), 1);
+    assert.equal(await harnessRows.nth(2).locator('[data-client-logo="claude"]').count(), 1);
+    assert.equal(await harnessRows.nth(3).locator('[data-client-logo="gemini"]').count(), 1);
+    assert.equal(await harnessRows.nth(4).locator('[data-client-logo="dsh"]').count(), 1);
+    assert.equal(await harnessRows.nth(5).locator('[data-client-logo="codex"]').count(), 1);
     assert.deepEqual(
       await page.locator(".lhc-harness-table-head span").allTextContents(),
       ["Client", "Runtime", "Models", "Sessions", "Actions"],
     );
-    assert.equal(await page.getByText("1 published", { exact: true }).count(), 4);
+    assert.equal(await page.getByText("1 published", { exact: true }).count(), 5);
     assert.equal(await page.getByText("1 available", { exact: true }).count(), 1);
     assert.equal(await page.getByLabel("Stable public HTTPS origin").count(), 0);
-    assert.equal(await page.getByRole("button", { name: "Open Cursor", exact: true }).count(), 1);
-    assert.equal(await page.getByRole("button", { name: "Open agent" }).count(), 0);
-    assert.equal(await page.getByRole("button", { name: "Open Cursor documentation" }).count(), 1);
+    assert.deepEqual(
+      (await page.locator(".lhc-harness-actions button").allTextContents()).map((label) => label.trim()),
+      ["Open", "Open", "Open", "Open", "Open", "Open"],
+    );
+    for (const client of ["OpenClaw", "Cursor", "Claude Code", "Gemini CLI", "DeepSeek Harness", "Codex"]) {
+      assert.equal(await page.getByRole("button", { name: `Open ${client}`, exact: true }).count(), 1);
+    }
+    assert.deepEqual(
+      await harnessRows.evaluateAll((rows) => rows.map((row) => row.querySelectorAll(".lhc-harness-actions button").length)),
+      [1, 1, 1, 1, 1, 1],
+    );
+    assert.equal(await page.getByRole("button", { name: /documentation|terminal|agent/i }).count(), 0);
+    await harnessRows.nth(0).getByRole("button", { name: "Open OpenClaw", exact: true }).click();
+    assert.deepEqual(
+      await page.evaluate(() => window.routerControlTest.calls().find((call) => call.name === "launchHarness")),
+      { name: "launchHarness", args: ["openclaw", "app"] },
+    );
+    await page.evaluate(() => window.routerControlTest.setOpenClawHarnessConfigured(false));
+    await page.getByRole("button", { name: "Context Manager", exact: true }).click();
+    await page.getByRole("button", { name: "Harness Experimental", exact: true }).click();
+    await harnessRows.nth(0).getByRole("button", { name: "Set up", exact: true }).click();
+    await harnessRows.nth(0).getByRole("button", { name: "Open OpenClaw", exact: true }).waitFor();
+    assert.equal(
+      await page.evaluate(() => window.routerControlTest.calls()
+        .filter((call) => call.name === "setupHarness" && call.args[0] === "openclaw").length),
+      1,
+    );
     assert.equal(await page.locator(".lhc-agent-bridges").count(), 0);
     assert.deepEqual(
       await page.locator(".lhc-harness-bridge strong").allTextContents(),
@@ -615,8 +655,8 @@ test("the production renderer exposes model discovery and picker actions", { tim
     await page.getByRole("button", { name: "Connect Cursor", exact: true }).click();
     const cursorProgress = page.getByRole("progressbar", { name: "Cursor setup progress" });
     await cursorProgress.waitFor();
-    assert.match(await harnessRows.first().innerText(), /Installing Cloudflare connector/);
-    await page.getByRole("button", { name: "Open Cursor", exact: true }).waitFor();
+    assert.match(await harnessRows.nth(1).innerText(), /Installing Cloudflare connector/);
+    await harnessRows.nth(1).getByRole("button", { name: "Open Cursor", exact: true }).waitFor();
     assert.equal(await cursorProgress.count(), 0);
     assert.equal(
       await page.evaluate(() => window.routerControlTest.calls().filter((call) => call.name === "connectCursor").length),

--- a/bin/disable
+++ b/bin/disable
@@ -53,5 +53,10 @@ case "${MODEL_ROUTER_TARGET:-codex}" in
     retire_service_if_unused
     echo "The router-owned claude-router launcher was removed; Claude Code settings were untouched."
     ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, or claude." >&2; exit 2 ;;
+  openclaw)
+    node src/openclaw-config-manager.mjs uninstall >/dev/null
+    retire_service_if_unused
+    echo "The router-owned provider was removed from OpenClaw; every other OpenClaw setting was preserved."
+    ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;
 esac

--- a/bin/doctor
+++ b/bin/doctor
@@ -3,6 +3,6 @@ set -eu
 
 repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 case "${MODEL_ROUTER_TARGET:-codex}" in
-  codex|dsh|gemini|cursor|claude) exec node "$repo_dir/src/doctor.mjs" "$@" ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, or claude." >&2; exit 2 ;;
+  codex|dsh|gemini|cursor|claude|openclaw) exec node "$repo_dir/src/doctor.mjs" "$@" ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;
 esac

--- a/bin/enable
+++ b/bin/enable
@@ -5,11 +5,14 @@ repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 cd "$repo_dir"
 target=${MODEL_ROUTER_TARGET:-codex}
 case "$target" in
-  codex|dsh|gemini|cursor|claude) ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, or claude." >&2; exit 2 ;;
+  codex|dsh|gemini|cursor|claude|openclaw) ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;
 esac
 CODEX_ROUTER_NODE_BIN=${CODEX_ROUTER_NODE_BIN:-$(command -v node)}
 export CODEX_ROUTER_NODE_BIN
+if [ "$target" = openclaw ]; then
+  node src/openclaw-install.mjs preflight >/dev/null
+fi
 adopt_native_catalog=false
 cursor_public_url=
 cursor_tunnel_hostname=
@@ -60,6 +63,10 @@ elif [ "$target" = claude ]; then
   config_manager=src/claude-code-config-manager.mjs
   config_enable_command=install
   config_disable_command=uninstall
+elif [ "$target" = openclaw ]; then
+  config_manager=src/openclaw-config-manager.mjs
+  config_enable_command=install
+  config_disable_command=uninstall
 else
   config_manager=src/config-manager.mjs
   config_enable_command=enable
@@ -106,6 +113,12 @@ fi
 if [ "$target" != claude ] && [ -s "$state_dir/claude-models.json" ]; then
   node src/claude-code-config-manager.mjs install >/dev/null
 fi
+if [ "$target" != openclaw ] && [ -s "$state_dir/openclaw-models.json" ]; then
+  node src/openclaw-config-manager.mjs install >/dev/null
+fi
+if [ "$target" = openclaw ]; then
+  node src/openclaw-install.mjs install >/dev/null
+fi
 config_enabled=true
 if [ "$adopt_native_catalog" = true ]; then
   node "$config_manager" "$config_enable_command" --adopt-native-catalog
@@ -130,6 +143,8 @@ elif [ "$target" = cursor ]; then
   echo "Fully quit and reopen Cursor before using the new app models."
 elif [ "$target" = claude ]; then
   echo "External model routes published to Claude Code. Run claude-router and choose a codex_router/anthropic/... model."
+elif [ "$target" = openclaw ]; then
+  echo "OpenClaw is installed and its codex-router provider now exposes every routed model. Run openclaw to start."
 else
   echo "External model routes enabled. Fully quit and reopen Codex."
 fi

--- a/bin/install
+++ b/bin/install
@@ -9,8 +9,8 @@ force_deps=false
 target=${MODEL_ROUTER_TARGET:-codex}
 
 case "$target" in
-  codex|dsh|gemini|cursor|claude) ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, or claude." >&2; exit 2 ;;
+  codex|dsh|gemini|cursor|claude|openclaw) ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;
 esac
 
 for argument in "$@"; do
@@ -115,6 +115,9 @@ for tool in node npm; do
 done
 
 node -e 'const [a,b]=process.versions.node.split(".").map(Number); if (!(a>22 || (a===22 && b>=19))) { console.error("Node.js 22.19 or newer is required."); process.exit(1) }'
+if [ "$target" = openclaw ]; then
+  node "$repo_dir/src/openclaw-install.mjs" preflight >/dev/null
+fi
 
 # Preserve the launcher selected by the operator. A compatibility wrapper may
 # delegate to another runtime, so process.execPath is not necessarily the
@@ -252,6 +255,10 @@ elif [ "$target" = claude ]; then
   config_manager=src/claude-code-config-manager.mjs
   config_enable_command=install
   config_disable_command=uninstall
+elif [ "$target" = openclaw ]; then
+  config_manager=src/openclaw-config-manager.mjs
+  config_enable_command=install
+  config_disable_command=uninstall
 else
   config_manager=src/config-manager.mjs
   config_enable_command=enable
@@ -288,6 +295,9 @@ elif [ "$target" = cursor ]; then
   config_state_field=appConfigured
   config_state_enabled=true
 elif [ "$target" = claude ]; then
+  config_state_field=installed
+  config_state_enabled=true
+elif [ "$target" = openclaw ]; then
   config_state_field=installed
   config_state_enabled=true
 else
@@ -359,10 +369,17 @@ fi
 if [ "$target" != claude ] && [ -s "$state_dir/claude-models.json" ]; then
   node src/claude-code-config-manager.mjs install >/dev/null
 fi
+if [ "$target" != openclaw ] && [ -s "$state_dir/openclaw-models.json" ]; then
+  node src/openclaw-config-manager.mjs install >/dev/null
+fi
 
 if [ "$prepare_only" = true ]; then
   echo "Dependencies and local Codex router files are prepared. Application configuration was not changed."
   exit 0
+fi
+
+if [ "$target" = openclaw ]; then
+  node src/openclaw-install.mjs install >/dev/null
 fi
 
 config_enabled=true
@@ -462,6 +479,9 @@ elif [ "$target" = gemini ]; then
   echo "Published all routed models to Gemini CLI. The next gemini run picks them up."
 elif [ "$target" = claude ]; then
   echo "Published all routed models to Claude Code. Run claude-router and choose a codex_router/anthropic/... model."
+elif [ "$target" = openclaw ]; then
+  echo "Installed OpenClaw and published every routed model under its codex-router provider."
+  echo "Run openclaw to start; OpenClaw reads the route on the next agent run."
 else
   echo "Installed the selected external model routes for Codex."
   # The configuration this install just rewrote is read once, at client start.

--- a/bin/model-router
+++ b/bin/model-router
@@ -13,6 +13,7 @@ Targets:
   gemini  Gemini CLI (its ~/.gemini/.env, read at startup)
   cursor  Cursor Agent CLI and Cursor desktop app
   claude  Claude Code through the local Anthropic-compatible gateway
+  openclaw OpenClaw through a router-owned Responses provider
 
 Every target shares one router: one service, one set of provider credentials,
 one provider selection. The target chooses which client's configuration a
@@ -41,6 +42,8 @@ Examples:
   ./bin/model-router cursor status
   ./bin/model-router claude enable
   ./bin/model-router claude status
+  ./bin/model-router openclaw enable
+  ./bin/model-router openclaw status
 EOF
 }
 
@@ -53,7 +56,7 @@ if [ "$#" -eq 1 ] && [ "$1" = "--version" ]; then
   exit 0
 fi
 
-if [ "$#" -eq 2 ] && { [ "$1" = "codex" ] || [ "$1" = "dsh" ] || [ "$1" = "gemini" ] || [ "$1" = "cursor" ] || [ "$1" = "claude" ]; } && [ "$2" = "--version" ]; then
+if [ "$#" -eq 2 ] && { [ "$1" = "codex" ] || [ "$1" = "dsh" ] || [ "$1" = "gemini" ] || [ "$1" = "cursor" ] || [ "$1" = "claude" ] || [ "$1" = "openclaw" ]; } && [ "$2" = "--version" ]; then
   version
   exit 0
 fi
@@ -68,7 +71,7 @@ command=$2
 shift 2
 
 case "$target" in
-  codex|dsh|gemini|cursor|claude) ;;
+  codex|dsh|gemini|cursor|claude|openclaw) ;;
   *) echo "Unknown target: $target" >&2; usage >&2; exit 2 ;;
 esac
 

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,6 @@ set -eu
 
 repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 case "${MODEL_ROUTER_TARGET:-codex}" in
-  codex|dsh|gemini|cursor|claude) exec node "$repo_dir/src/setup.mjs" "$@" ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, or claude." >&2; exit 2 ;;
+  codex|dsh|gemini|cursor|claude|openclaw) exec node "$repo_dir/src/setup.mjs" "$@" ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;
 esac

--- a/bin/smoke-test
+++ b/bin/smoke-test
@@ -5,6 +5,6 @@ repo_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 # The smoke test spends provider quota against the shared router plane, so it
 # proves the same routes whichever client asked for it.
 case "${MODEL_ROUTER_TARGET:-codex}" in
-  codex|dsh|gemini|cursor) exec node "$repo_dir/src/smoke-test.mjs" "$@" ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, or cursor." >&2; exit 2 ;;
+  codex|dsh|gemini|cursor|claude|openclaw) exec node "$repo_dir/src/smoke-test.mjs" "$@" ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;
 esac

--- a/bin/status
+++ b/bin/status
@@ -9,7 +9,8 @@ case "${MODEL_ROUTER_TARGET:-codex}" in
   gemini) node src/gemini-config-manager.mjs status ;;
   cursor) node src/cursor-config-manager.mjs status ;;
   claude) node src/claude-code-config-manager.mjs status ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, or claude." >&2; exit 2 ;;
+  openclaw) node src/openclaw-config-manager.mjs status ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;
 esac
 node src/service.mjs status
 node --input-type=module -e 'import { PORTS } from "./src/paths.mjs"; fetch(`http://127.0.0.1:${PORTS.router}/health`).then(async r=>{console.log(await r.text()); process.exitCode=r.ok?0:1}).catch(()=>{console.log(JSON.stringify({ok:false,router:"unavailable"})); process.exitCode=1})'

--- a/bin/uninstall
+++ b/bin/uninstall
@@ -56,6 +56,11 @@ case "${MODEL_ROUTER_TARGET:-codex}" in
     retire_service_if_unused
     echo "The Claude Code integration was removed."
     ;;
-  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, or claude." >&2; exit 2 ;;
+  openclaw)
+    node src/openclaw-config-manager.mjs uninstall >/dev/null
+    retire_service_if_unused
+    echo "The OpenClaw integration was removed. OpenClaw itself and all unrelated settings were retained."
+    ;;
+  *) echo "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw." >&2; exit 2 ;;
 esac
 echo "The repository, cached native catalog, logs, and provider credentials were retained."

--- a/codex-router.ps1
+++ b/codex-router.ps1
@@ -1,8 +1,8 @@
 $ErrorActionPreference = "Stop"
 $Root = $PSScriptRoot
 $Target = if ($env:MODEL_ROUTER_TARGET) { $env:MODEL_ROUTER_TARGET } else { "codex" }
-if ($Target -notin @("codex", "dsh", "gemini", "cursor", "claude")) {
-  throw "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, or claude."
+if ($Target -notin @("codex", "dsh", "gemini", "cursor", "claude", "openclaw")) {
+  throw "MODEL_ROUTER_TARGET must be codex, dsh, gemini, cursor, claude, or openclaw."
 }
 $Command = if ($args.Count) { [string]$args[0] } else { "status" }
 # The @() wraps the whole `if`, not its branches. PowerShell enumerates a
@@ -34,6 +34,7 @@ function Remove-TargetIntegration {
     "gemini" { Invoke-RouterNode "src\gemini-config-manager.mjs" @("uninstall") }
     "cursor" { Invoke-RouterNode "src\cursor-config-manager.mjs" @("uninstall") }
     "claude" { Invoke-RouterNode "src\claude-code-config-manager.mjs" @("uninstall") }
+    "openclaw" { Invoke-RouterNode "src\openclaw-config-manager.mjs" @("uninstall") }
     default { Invoke-RouterNode "src\config-manager.mjs" @("disable") }
   }
   $Remaining = [string](& node (Join-Path $Root "src\target-integration.mjs") "installed-targets")

--- a/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
+++ b/docs/OPENCODEX_IMPLEMENTATION_ROADMAP.md
@@ -20,7 +20,7 @@ current `main`:
 
 | Area | Shipped behavior | Evidence |
 | --- | --- | --- |
-| Client integrations | One shared router plane can publish routed models for Codex, DeepSeek Harness, Gemini CLI, and Cursor. OpenCode is not a shipped client target. | `src/paths.mjs`, `src/target-integration.mjs`, `src/cursor-surface.mjs`, `README.md` |
+| Client integrations | One shared router plane can publish routed models for Codex, DeepSeek Harness, Gemini CLI, Cursor, Claude Code, and OpenClaw. OpenCode is not a shipped client target. | `src/paths.mjs`, `src/target-integration.mjs`, `src/cursor-surface.mjs`, `src/openclaw-config-manager.mjs`, `README.md` |
 | Native Codex path | Native GPT catalog and login remain client-owned. The native default model, reasoning metadata, and speed controls remain client-owned by default; a routed default requires an explicit opt-in. | `src/native-catalog-source.mjs`, `src/catalog.mjs`, `src/config-manager.mjs`, `test/native-catalog-source.test.mjs`, `test/config-manager.test.mjs`, `README.md` |
 | Routed inference | Codex requests use the local Responses route. Supported providers are translated through Responses, Chat Completions, or Anthropic Messages adapters where their registry entry declares that protocol. | `src/router.mjs`, `src/api-forwarder.mjs`, `test/routing.test.mjs`, `test/anthropic-api-integration.test.mjs` |
 | Provider registry | Providers and model metadata are checked in under `config/`; local model files and explicit curation extend the catalog without adding request-path branches. | `src/model-registry.mjs`, `src/user-models.mjs`, `src/curate-models.mjs`, `README.md` |

--- a/install.ps1
+++ b/install.ps1
@@ -3,7 +3,7 @@ param(
   [switch]$CheckoutInstall,
   [switch]$PrepareOnly,
   [switch]$ForceDeps,
-  [ValidateSet("codex", "dsh", "gemini", "cursor", "claude")]
+  [ValidateSet("codex", "dsh", "gemini", "cursor", "claude", "openclaw")]
   [string]$Target = "codex",
   [string]$CursorPublicUrl,
   [string]$CursorHostname,
@@ -241,6 +241,10 @@ if ([int]$VersionParts[0] -lt 22 -or
     ([int]$VersionParts[0] -eq 22 -and [int]$VersionParts[1] -lt 19)) {
   throw "Node.js 22.19 or newer is required; Node.js 24 LTS is recommended."
 }
+if ($Target -eq "openclaw") {
+  & node (Join-Path $ScriptDirectory "src\openclaw-install.mjs") preflight | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw "OpenClaw requires a supported Node.js release." }
+}
 
 # Each target enables its own client configuration; everything around that one
 # step is the shared router plane.
@@ -249,6 +253,7 @@ $ConfigManager = switch ($Target) {
   "gemini" { "src\gemini-config-manager.mjs" }
   "cursor" { "src\cursor-config-manager.mjs" }
   "claude" { "src\claude-code-config-manager.mjs" }
+  "openclaw" { "src\openclaw-config-manager.mjs" }
   default { "src\config-manager.mjs" }
 }
 $ConfigEnableCommand = if ($Target -eq "codex") { "enable" } else { "install" }
@@ -289,6 +294,7 @@ try {
     "gemini" { (Get-InstallerStateField @($ConfigManager, "status") "installed") -eq $true }
     "cursor" { (Get-InstallerStateField @($ConfigManager, "status") "appConfigured") -eq $true }
     "claude" { (Get-InstallerStateField @($ConfigManager, "status") "installed") -eq $true }
+    "openclaw" { (Get-InstallerStateField @($ConfigManager, "status") "installed") -eq $true }
     default { (Get-InstallerStateField @($ConfigManager, "status") "mode") -eq "router" }
   }
   $ServiceWasInstalled = (Get-InstallerStateField @("src\service.mjs", "status") "installed") -eq $true
@@ -487,6 +493,10 @@ try {
     & node src/claude-code-config-manager.mjs install | Out-Null
     if ($LASTEXITCODE -ne 0) { throw "Claude Code republish failed." }
   }
+  if ($Target -ne "openclaw" -and (Test-NonEmptyFile (Join-Path $StateRoot "openclaw-models.json"))) {
+    & node src/openclaw-config-manager.mjs install | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "OpenClaw republish failed." }
+  }
 
   if ($PrepareOnly) {
     Write-Host "Dependencies and generated files are prepared; application configuration was not changed."
@@ -495,6 +505,11 @@ try {
     # an invoked prepare-only install must hand control back so its caller can
     # observe that restoration.
     return
+  }
+
+  if ($Target -eq "openclaw") {
+    & node src/openclaw-install.mjs install | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "OpenClaw installation failed." }
   }
 
   $ConfigEnabled = $true
@@ -576,6 +591,8 @@ try {
     Write-Host "Run cursor-router-agent for the CLI; fully quit and reopen Cursor for the app."
   } elseif ($Target -eq "claude") {
     Write-Host "Published all routed models to Claude Code. Run claude-router and choose a codex_router/anthropic/... model."
+  } elseif ($Target -eq "openclaw") {
+    Write-Host "Installed OpenClaw and published every routed model under its codex-router provider. Run openclaw to start."
   } else {
     Write-Host "Installed the selected external model routes. Fully quit and reopen Codex."
   }

--- a/install.sh
+++ b/install.sh
@@ -24,12 +24,12 @@ usage() {
   cat <<'EOF'
 Usage: install.sh [options]
 
-Install external model routes for Codex, DeepSeek Harness, Gemini CLI, or Cursor.
+Install external model routes for Codex, DeepSeek Harness, Gemini CLI, Cursor, Claude Code, or OpenClaw.
 
 Options:
   --install-dir PATH  Stable checkout used by the background service
   --target APP        Install for "codex" (default), "dsh" (DeepSeek Harness),
-                      "gemini" (Gemini CLI), or "cursor"
+                      "gemini" (Gemini CLI), "cursor", "claude", or "openclaw"
   --cursor-public-url URL
                       Stable HTTPS tunnel origin for Cursor App; forward it
                       to the local Cursor edge port printed during setup
@@ -121,7 +121,7 @@ local_modifications_message() {
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --target)
-      [ "$#" -ge 2 ] || die "--target requires codex, dsh, gemini, cursor, or claude"
+      [ "$#" -ge 2 ] || die "--target requires codex, dsh, gemini, cursor, claude, or openclaw"
       target=$2
       shift 2
       ;;
@@ -217,8 +217,8 @@ while [ "$#" -gt 0 ]; do
 done
 
 case "$target" in
-  codex|dsh|gemini|cursor|claude) ;;
-  *) die "--target must be codex, dsh, gemini, cursor, or claude" ;;
+  codex|dsh|gemini|cursor|claude|openclaw) ;;
+  *) die "--target must be codex, dsh, gemini, cursor, claude, or openclaw" ;;
 esac
 if [ -n "$cursor_public_url" ]; then
   [ "$target" = cursor ] || die "--cursor-public-url applies to --target cursor only"
@@ -374,6 +374,9 @@ case "$target" in
     ;;
   claude)
     printf '\nCodex Router is installed for Claude Code. Run claude-router and choose a codex_router/anthropic/... model.\n'
+    ;;
+  openclaw)
+    printf '\nCodex Router installed OpenClaw and published every routed model under its codex-router provider. Run openclaw to start.\n'
     ;;
   *)
     printf '\nCodex Router is installed. Fully quit Codex, reopen it, and start a new task.\n'

--- a/model-router.ps1
+++ b/model-router.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param(
   [Parameter(Position = 0, Mandatory = $true)]
-  [ValidateSet("codex", "dsh", "gemini", "cursor", "claude")]
+  [ValidateSet("codex", "dsh", "gemini", "cursor", "claude", "openclaw")]
   [string]$Target,
 
   [Parameter(Position = 1, Mandatory = $true)]

--- a/src/caller-key-rotation-journal.mjs
+++ b/src/caller-key-rotation-journal.mjs
@@ -6,7 +6,7 @@ import { STATE_DIR } from "./paths.mjs";
 
 export const CALLER_KEY_ROTATION_JOURNAL_PATH = path.join(STATE_DIR, "caller-key-rotation.json");
 const PHASES = new Set(["prepared", "service-stopped", "secret-swapped", "clients-refreshed", "service-started", "verified"]);
-const TARGETS = new Set(["codex", "dsh", "gemini"]);
+const TARGETS = new Set(["codex", "dsh", "gemini", "openclaw"]);
 const TRANSITIONS = Object.freeze({
   prepared: new Set(["service-stopped", "secret-swapped"]),
   "service-stopped": new Set(["secret-swapped"]),

--- a/src/caller-key.mjs
+++ b/src/caller-key.mjs
@@ -31,6 +31,7 @@ const refreshCommand = Object.freeze({
   codex: ["src/config-manager.mjs", ["caller-capability-refresh"]],
   dsh: ["src/dsh-config-manager.mjs", ["caller-capability-refresh"]],
   gemini: ["src/gemini-config-manager.mjs", ["caller-capability-refresh"]],
+  openclaw: ["src/openclaw-config-manager.mjs", ["caller-capability-refresh"]],
 });
 
 function secretDigest(secret) {
@@ -41,7 +42,7 @@ function partialClient(label) {
   throw new Error(`Refusing caller capability rotation while ${label} has partial managed state; run its doctor/repair path first.`);
 }
 
-export function installedTargetsFromStatus({ codex = {}, dsh = {}, gemini = {} } = {}) {
+export function installedTargetsFromStatus({ codex = {}, dsh = {}, gemini = {}, openclaw = {} } = {}) {
   const targets = [];
   const codexStatePresent = codex.provider_mode_state_present === true || codex.signed_provider_state_present === true;
   const codexManagedArtifacts = codex.managed_router_artifacts_present === true;
@@ -76,6 +77,20 @@ export function installedTargetsFromStatus({ codex = {}, dsh = {}, gemini = {} }
     }
     targets.push("gemini");
   }
+
+  const openclawEvidence = openclaw.installed === true || openclaw.providerInstalled === true;
+  if (openclawEvidence) {
+    if (
+      openclaw.installed !== true ||
+      openclaw.providerInstalled !== true ||
+      openclaw.baseUrlManaged !== true ||
+      openclaw.configValid !== true ||
+      openclaw.configProtected !== true
+    ) {
+      partialClient("OpenClaw");
+    }
+    targets.push("openclaw");
+  }
   return targets;
 }
 
@@ -104,6 +119,7 @@ export async function readManagedClientStatuses({ runNode = runNodeCommand } = {
     codex: parseJsonCommand("src/config-manager.mjs", ["status"], runNode),
     dsh: parseJsonCommand("src/dsh-config-manager.mjs", ["status"], runNode),
     gemini: parseJsonCommand("src/gemini-config-manager.mjs", ["status"], runNode),
+    openclaw: parseJsonCommand("src/openclaw-config-manager.mjs", ["status"], runNode),
   };
 }
 

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -20,6 +20,7 @@ import {
   CLAUDE_CATALOG_PATH,
   CURSOR_CATALOG_PATH,
   GEMINI_CATALOG_PATH,
+  OPENCLAW_CATALOG_PATH,
   PROVIDER_API_KEY_POOL_PATH,
   PROVIDER_CREDENTIAL_STORE_PATH,
   PROVIDER_SELECTION_PATH,
@@ -65,12 +66,14 @@ const DSH_PUBLISHED = DSH_CATALOG_PATH;
 const GEMINI_PUBLISHED = GEMINI_CATALOG_PATH;
 const CURSOR_PUBLISHED = CURSOR_CATALOG_PATH;
 const CLAUDE_PUBLISHED = CLAUDE_CATALOG_PATH;
+const OPENCLAW_PUBLISHED = OPENCLAW_CATALOG_PATH;
 const TARGETS = [
   "codex",
   ...(existsSync(DSH_PUBLISHED) ? ["dsh"] : []),
   ...(existsSync(GEMINI_PUBLISHED) ? ["gemini"] : []),
   ...(existsSync(CURSOR_PUBLISHED) ? ["cursor"] : []),
   ...(existsSync(CLAUDE_PUBLISHED) ? ["claude"] : []),
+  ...(existsSync(OPENCLAW_PUBLISHED) ? ["openclaw"] : []),
 ];
 const args = process.argv.slice(2);
 
@@ -84,6 +87,7 @@ function targetIsActive(target) {
   if (target === "gemini") return existsSync(GEMINI_PUBLISHED);
   if (target === "cursor") return existsSync(CURSOR_PUBLISHED);
   if (target === "claude") return existsSync(CLAUDE_PUBLISHED);
+  if (target === "openclaw") return existsSync(OPENCLAW_PUBLISHED);
   const result = spawnSync(process.execPath, [path.join(REPO_ROOT, "src", "service.mjs"), "status"], {
     env: { ...process.env, MODEL_ROUTER_TARGET: target },
     encoding: "utf8",
@@ -590,6 +594,8 @@ function refreshActiveTarget(target) {
             ? [process.execPath, [path.join(REPO_ROOT, "src", "cursor-config-manager.mjs"), "install"]]
           : target === "claude"
             ? [process.execPath, [path.join(REPO_ROOT, "src", "claude-code-config-manager.mjs"), "install"]]
+          : target === "openclaw"
+            ? [process.execPath, [path.join(REPO_ROOT, "src", "openclaw-config-manager.mjs"), "install"]]
           : undefined;
   if (!command) return;
   const result = spawnSync(command[0], command[1], {
@@ -2865,10 +2871,11 @@ async function handleHarness(action) {
 // Center exposes this as a fixed client-row setup surface; no executable, cwd,
 // or arbitrary argv crosses the renderer boundary. DeepSeek Harness retains
 // its install-if-missing path, while Codex and Cursor use the same transactional
-// enable entrypoint operators run from the terminal.
+// enable entrypoint operators run from the terminal. OpenClaw's enable path
+// installs the official CLI when missing before it publishes the provider.
 async function handleClientSetup(target, publicUrl, hostname) {
-  if (!["codex", "dsh", "cursor", "claude"].includes(target)) {
-    throw new Error("Usage: control client-setup codex|dsh|cursor|claude [--hostname PUBLIC_HOSTNAME|--public-url HTTPS_ORIGIN]");
+  if (!["codex", "dsh", "cursor", "claude", "openclaw"].includes(target)) {
+    throw new Error("Usage: control client-setup codex|dsh|cursor|claude|openclaw [--hostname PUBLIC_HOSTNAME|--public-url HTTPS_ORIGIN]");
   }
   if (target === "dsh") {
     if (publicUrl || hostname) throw new Error("--hostname and --public-url apply to Cursor only.");
@@ -3039,7 +3046,7 @@ if (args.includes("--probe")) {
   const publicUrl = optionValue("--public-url");
   const hostname = optionValue("--hostname");
   if ((publicUrl && hostname) || ((publicUrl || hostname) && args.length !== 4) || (!publicUrl && !hostname && args.length !== 2)) {
-    throw new Error("Usage: control client-setup codex|dsh|cursor [--hostname PUBLIC_HOSTNAME|--public-url HTTPS_ORIGIN]");
+    throw new Error("Usage: control client-setup codex|dsh|cursor|claude|openclaw [--hostname PUBLIC_HOSTNAME|--public-url HTTPS_ORIGIN]");
   }
   await handleClientSetup(args[1], publicUrl, hostname);
 } else if (args[0] === "client-export") {

--- a/src/cursor-cloudflare-tunnel.mjs
+++ b/src/cursor-cloudflare-tunnel.mjs
@@ -11,7 +11,6 @@ import {
   PORTS,
 } from "./paths.mjs";
 import { writePrivateFile, writePrivateJson } from "./file-security.mjs";
-import { spawnableCommand } from "./spawnable-command.mjs";
 
 function readJson(target) {
   if (!existsSync(target)) return undefined;
@@ -121,13 +120,11 @@ export async function discoverCursorTunnelHostname({
 }
 
 function commandResult(binary, args, { runner = spawnSync, environment = process.env } = {}) {
-  const spawnable = spawnableCommand(binary, args);
-  const result = runner(spawnable.command, spawnable.args, {
+  const result = runner(binary, args, {
     encoding: "utf8",
     env: environment,
     windowsHide: true,
     timeout: 120_000,
-    ...spawnable.options,
   });
   if (result.error) throw result.error;
   if (result.status !== 0) {

--- a/src/doctor.mjs
+++ b/src/doctor.mjs
@@ -53,6 +53,7 @@ import {
   LITELLM_CONFIG_PATH,
   MERGED_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
+  OPENCLAW_CATALOG_PATH,
   PORTS,
   SEARCH_SIDECARS_PATH,
   SOURCE_ROOT,
@@ -271,7 +272,12 @@ function repair() {
   // environment. Homebrew has already validated its package-owned tree above,
   // so its repair only regenerates configuration and services.
   const posixArguments = homebrewManaged ? [] : ["--force-deps"];
-  const windowsArguments = homebrewManaged ? ["-CheckoutInstall"] : ["-CheckoutInstall", "-ForceDeps"];
+  const windowsArguments = [
+    "-CheckoutInstall",
+    "-Target",
+    TARGET,
+    ...(homebrewManaged ? [] : ["-ForceDeps"]),
+  ];
   const result = process.platform === "win32"
     ? spawnSync(
         "powershell.exe",
@@ -389,6 +395,8 @@ const privacyTarget = codexTarget
       ? CURSOR_CATALOG_PATH
       : TARGET === "claude"
         ? CLAUDE_CATALOG_PATH
+        : TARGET === "openclaw"
+          ? OPENCLAW_CATALOG_PATH
       : DSH_SETTINGS_PATH;
 const cursorAgentOnly = TARGET === "cursor" &&
   !existsSync(CURSOR_CATALOG_PATH) && existsSync(CURSOR_LAUNCHER_PATH);
@@ -414,6 +422,8 @@ add(
         ? "Cursor router-state privacy"
         : TARGET === "claude"
           ? "Claude router-state privacy"
+          : TARGET === "openclaw"
+            ? "OpenClaw router-state privacy"
       : "Harness settings privacy",
   cursorAgentOnly
     ? "agent-only; no Cursor App router-state document"
@@ -447,6 +457,8 @@ const routedTransportActive = codexTarget
       ? existsSync(CURSOR_CATALOG_PATH) || existsSync(CURSOR_LAUNCHER_PATH)
       : TARGET === "claude"
         ? existsSync(CLAUDE_CATALOG_PATH) && existsSync(CLAUDE_LAUNCHER_PATH)
+        : TARGET === "openclaw"
+          ? existsSync(OPENCLAW_CATALOG_PATH)
       : existsSync(DSH_CATALOG_PATH);
 // An install made with --no-provider --no-discovery is idle on purpose: the
 // selection is an explicit empty list and the discovery marker is set. That
@@ -1326,6 +1338,45 @@ if (TARGET === "gemini") {
     );
   } catch (error) {
     add("fail", "Claude Code routing config", error instanceof Error ? error.message : String(error), "Run ./bin/model-router claude enable.");
+  }
+} else if (TARGET === "openclaw") {
+  try {
+    const openclaw = childJson("openclaw-config-manager.mjs", ["status"]);
+    add(
+      openclaw.installed && openclaw.providerInstalled && openclaw.baseUrlManaged && openclaw.configValid ? "ok" : "fail",
+      "OpenClaw routing config",
+      openclaw.configError
+        ? openclaw.configError
+        : openclaw.providerInstalled
+        ? `${openclaw.publishedModels} models in models.providers.codex-router; ${openclaw.baseUrl || "unmanaged endpoint"}`
+        : "the router-owned OpenClaw provider is missing",
+      "Run ./bin/model-router openclaw enable.",
+    );
+    add(
+      openclaw.cliInstalled ? "ok" : "fail",
+      "OpenClaw CLI",
+      openclaw.cliInstalled ? openclaw.cli || "openclaw" : "not installed",
+      "Use Harness > OpenClaw > Set up, or run ./bin/model-router openclaw enable.",
+    );
+    add(
+      openclaw.configProtected ? "ok" : "fail",
+      "OpenClaw config privacy",
+      openclaw.configProtected ? `${openclaw.config} is private` : openclaw.config || "config path unavailable",
+      "Run ./bin/model-router openclaw enable; its provider carries the local caller capability.",
+    );
+    add(
+      openclaw.catalogFresh ? "ok" : "warn",
+      "OpenClaw catalog freshness",
+      `published ${openclaw.publishedModels}, routable ${openclaw.routableModels}`,
+      "Run ./bin/model-router openclaw enable to republish.",
+    );
+  } catch (error) {
+    add(
+      "fail",
+      "OpenClaw routing config",
+      error instanceof Error ? error.message : String(error),
+      "Run ./bin/model-router openclaw enable.",
+    );
   }
 } else try {
   const config = childJson("config-manager.mjs", ["status"]);

--- a/src/npm-global-install.mjs
+++ b/src/npm-global-install.mjs
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
+import { commandOnPath, preferSpawnablePath, spawnableCommand } from "./spawnable-command.mjs";
 import { inheritedProxyEnvironment } from "./proxy-environment.mjs";
 
 // Installing a third-party CLI globally through npm, and finding the binary
@@ -81,13 +81,24 @@ export function readNpmGlobalBinDir() {
   }
 }
 
+export function npmGlobalBinaryAt(
+  directory,
+  executable,
+  { platform = process.platform, exists = existsSync } = {},
+) {
+  const base = path.join(directory, executable);
+  const candidates = platform === "win32"
+    ? [".exe", ".com", ".cmd", ".bat", ""].map((extension) => `${base}${extension}`)
+    : [base];
+  return preferSpawnablePath(candidates.filter((candidate) => exists(candidate)), platform) || undefined;
+}
+
 export function npmGlobalBinary(executable) {
   if (npmGlobalBinDir === undefined) {
     npmGlobalBinDir = readNpmGlobalBinDir() ?? "";
   }
   if (!npmGlobalBinDir) return undefined;
-  const candidate = path.join(npmGlobalBinDir, executable);
-  return existsSync(candidate) ? candidate : undefined;
+  return npmGlobalBinaryAt(npmGlobalBinDir, executable);
 }
 
 // npm prints its diagnosis over several lines and ends with log-file paths
@@ -105,10 +116,13 @@ export function installFailureDetail(result) {
 // Throws with the reason rather than the fact: "EACCES on /usr/local/lib" and
 // "network unreachable" need opposite fixes, and a bare "could not install"
 // sent the last one of these into a debugging session.
-export function npmInstallGlobal(npmPackage, { label = npmPackage, timeoutMs } = {}) {
+export function npmInstallGlobal(
+  npmPackage,
+  { label = npmPackage, timeoutMs, extraArgs = [] } = {},
+) {
   const npm = npmPath();
   if (!npm) throw new Error("Node.js and npm are required to install this CLI.");
-  const install = spawnableCommand(npm, ["install", "-g", npmPackage]);
+  const install = spawnableCommand(npm, ["install", "-g", npmPackage, ...extraArgs]);
   const result = spawnSync(install.command, install.args, {
     ...install.options,
     windowsHide: true,

--- a/src/openclaw-config-manager.mjs
+++ b/src/openclaw-config-manager.mjs
@@ -1,0 +1,404 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, unlinkSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+
+import {
+  assertCallerSecret,
+  callerBaseUrl,
+  isManagedCallerBaseUrl,
+  redactCallerUrl,
+} from "./caller-auth.mjs";
+import { privateFileIsProtected, protectPrivateFile, writePrivateJson } from "./file-security.mjs";
+import { openclawCliPath } from "./openclaw-install.mjs";
+import {
+  CALLER_SECRET_PATH,
+  LEGACY_PORTS,
+  OPENCLAW_CATALOG_PATH,
+  PORTS,
+} from "./paths.mjs";
+import { routedClientModels } from "./routed-client-models.mjs";
+import { spawnEnvironment } from "./npm-global-install.mjs";
+import { spawnableCommand } from "./spawnable-command.mjs";
+import { assertStateOwnership } from "./state-owner.mjs";
+
+export const OPENCLAW_PROVIDER_ID = "codex-router";
+const PROVIDER_PATH = `models.providers.${OPENCLAW_PROVIDER_ID}`;
+const DEFAULT_MODEL_PATH = "agents.defaults.model.primary";
+const CLI_TIMEOUT_MS = 30_000;
+const OPENCLAW_EFFORTS = new Set([
+  "off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max", "ultra",
+]);
+
+function readJsonFile(target) {
+  if (!existsSync(target)) return undefined;
+  try { return JSON.parse(readFileSync(target, "utf8")); } catch {
+    throw new Error("The OpenClaw router publication marker is not valid JSON; refusing to change client state.");
+  }
+}
+
+function currentSecret(secretPath = CALLER_SECRET_PATH) {
+  if (!existsSync(secretPath)) {
+    throw new Error("The local router caller key is missing; run ./bin/doctor --fix.");
+  }
+  return assertCallerSecret(readFileSync(secretPath, "utf8").trim());
+}
+
+function redactFailure(value, secret) {
+  const redacted = redactCallerUrl(String(value || ""));
+  return secret ? redacted.replaceAll(String(secret), "[REDACTED]") : redacted;
+}
+
+function parseJsonOutput(output, label) {
+  try { return JSON.parse(String(output || "").trim()); } catch {
+    throw new Error(`OpenClaw returned invalid JSON for ${label}.`);
+  }
+}
+
+export function createOpenClawCli(binary = openclawCliPath(), { spawn = spawnSync } = {}) {
+  if (!binary) throw new Error("OpenClaw is not installed. Run the OpenClaw setup action first.");
+
+  function run(args, { input, missingOkay = false, secret } = {}) {
+    const command = spawnableCommand(binary, args);
+    const result = spawn(command.command, command.args, {
+      ...command.options,
+      encoding: "utf8",
+      env: spawnEnvironment(),
+      input,
+      timeout: CLI_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    if (!result.error && result.status === 0) return String(result.stdout || "");
+    const detail = redactFailure(result.error?.message || result.stderr || result.stdout, secret).trim();
+    if (missingOkay && /(?:not found|does not exist|unknown (?:config )?path|no value|undefined|valid but unset)/i.test(detail)) {
+      return undefined;
+    }
+    throw new Error(detail ? `OpenClaw config command failed: ${detail}` : "OpenClaw config command failed.");
+  }
+
+  return {
+    binary,
+    get(configPath) {
+      const output = run(["config", "get", configPath, "--json"], { missingOkay: true });
+      return output === undefined ? undefined : parseJsonOutput(output, configPath);
+    },
+    configFile() {
+      const value = parseJsonOutput(run(["config", "file", "--json"]), "config file");
+      return typeof value === "string" ? value : value?.path;
+    },
+    patch(value, replacePaths, secret) {
+      const args = ["config", "patch", "--stdin"];
+      for (const configPath of replacePaths) args.push("--replace-path", configPath);
+      run(args, { input: `${JSON.stringify(value)}\n`, secret });
+    },
+    unset(configPath) {
+      run(["config", "unset", configPath], { missingOkay: true });
+    },
+  };
+}
+
+export function openclawModelProfile(model) {
+  const input = (model.inputModalities || ["text"])
+    .map(String)
+    .filter((modality) => modality === "text" || modality === "image");
+  const efforts = [...new Set((model.reasoningLevels || [])
+    .map((level) => String(level?.effort || ""))
+    .filter((effort) => OPENCLAW_EFFORTS.has(effort)))];
+  const profile = {
+    id: String(model.slug),
+    name: String(model.displayName || model.slug),
+    reasoning: efforts.length > 0,
+    input: input.length ? input : ["text"],
+  };
+  if (Number.isInteger(model.contextWindow) && model.contextWindow > 0) {
+    profile.contextWindow = model.contextWindow;
+  }
+  if (efforts.length) profile.compat = { supportedReasoningEfforts: efforts };
+  return profile;
+}
+
+export function openclawDefaultModel(models) {
+  const model = [...models].sort(
+    (left, right) =>
+      (right.priority ?? 0) - (left.priority ?? 0) ||
+      String(left.slug).localeCompare(String(right.slug)),
+  )[0];
+  return model ? `${OPENCLAW_PROVIDER_ID}/${model.slug}` : undefined;
+}
+
+function buildProvider(models, baseUrl, secret) {
+  return {
+    baseUrl,
+    apiKey: secret,
+    api: "openai-responses",
+    authHeader: true,
+    timeoutSeconds: 300,
+    models: models.map(openclawModelProfile),
+  };
+}
+
+function providerManaged(provider, port = PORTS.router, legacyPort = LEGACY_PORTS.router) {
+  return Boolean(provider && (
+    isManagedCallerBaseUrl(provider.baseUrl, port) ||
+    (legacyPort !== undefined && isManagedCallerBaseUrl(provider.baseUrl, legacyPort))
+  ));
+}
+
+function readCatalogState(target, port, legacyPort) {
+  const state = readJsonFile(target);
+  if (state === undefined) return undefined;
+  const objectState = Boolean(state && typeof state === "object" && !Array.isArray(state));
+  const defaultValid = objectState && state.defaultOwned === true
+    ? typeof state.defaultModel === "string" && state.defaultModel.startsWith(`${OPENCLAW_PROVIDER_ID}/`)
+    : objectState && state.defaultOwned === false && state.defaultModel === null;
+  const valid = objectState &&
+    state.version === 1 && state.provider === OPENCLAW_PROVIDER_ID &&
+    typeof state.baseUrl === "string" && providerManaged({ baseUrl: state.baseUrl }, port, legacyPort) &&
+    Array.isArray(state.models) && state.models.length > 0 &&
+    state.models.every((model) => typeof model === "string" && model.length > 0) &&
+    new Set(state.models).size === state.models.length &&
+    (state.visionBridgeEngine === null || typeof state.visionBridgeEngine === "string") &&
+    defaultValid && typeof state.updatedAt === "string" && Number.isFinite(Date.parse(state.updatedAt));
+  if (!valid) {
+    throw new Error("The OpenClaw router publication marker has an unsupported or malformed shape; refusing to change client state.");
+  }
+  return state;
+}
+
+function normalizedDefault(value) {
+  return typeof value === "string" && value ? value : undefined;
+}
+
+export function createOpenClawManager({
+  client,
+  catalogPath = OPENCLAW_CATALOG_PATH,
+  secretPath = CALLER_SECRET_PATH,
+  port = PORTS.router,
+  legacyPort = LEGACY_PORTS.router,
+  modelSource = routedClientModels,
+  assertOwnership = assertStateOwnership,
+  protectConfig = protectPrivateFile,
+  writeCatalog = writePrivateJson,
+} = {}) {
+  const cli = () => client || createOpenClawCli();
+
+  function install() {
+    assertOwnership("write the OpenClaw model catalog");
+    const { models, engine } = modelSource();
+    if (!models.length) {
+      throw new Error(
+        "No routed models are selected, credentialed, and listed. Enable a provider first, then publish again.",
+      );
+    }
+    const state = readCatalogState(catalogPath, port, legacyPort);
+    const openclaw = cli();
+    const existingProvider = openclaw.get(PROVIDER_PATH);
+    if (existingProvider && !state) {
+      throw new Error(
+        `OpenClaw already has an unmanaged ${OPENCLAW_PROVIDER_ID} provider; rename or remove it before setup.`,
+      );
+    }
+    if (existingProvider && !providerManaged(existingProvider, port, legacyPort)) {
+      throw new Error("Refusing to replace an OpenClaw provider whose base URL is not managed by this router.");
+    }
+
+    const secret = currentSecret(secretPath);
+    const baseUrl = callerBaseUrl(port, secret);
+    const currentDefault = normalizedDefault(openclaw.get(DEFAULT_MODEL_PATH));
+    const desiredDefault = openclawDefaultModel(models);
+    const previouslyOwned = Boolean(
+      state?.defaultOwned && state.defaultModel && currentDefault === state.defaultModel,
+    );
+    const claimFreshDefault = !state && !currentDefault;
+    const defaultOwned = previouslyOwned || claimFreshDefault;
+    const defaultModel = defaultOwned ? desiredDefault : currentDefault;
+    const patch = { models: { providers: { [OPENCLAW_PROVIDER_ID]: buildProvider(models, baseUrl, secret) } } };
+    const replacePaths = [PROVIDER_PATH];
+    if (defaultOwned && defaultModel) {
+      patch.agents = { defaults: { model: { primary: defaultModel } } };
+      replacePaths.push(DEFAULT_MODEL_PATH);
+    }
+    const configPath = openclaw.configFile();
+    if (configPath && existsSync(configPath)) protectConfig(configPath);
+    let patched = false;
+    try {
+      openclaw.patch(patch, replacePaths, secret);
+      patched = true;
+      if (configPath && existsSync(configPath)) protectConfig(configPath);
+      writeCatalog(catalogPath, {
+        version: 1,
+        provider: OPENCLAW_PROVIDER_ID,
+        baseUrl,
+        models: models.map((model) => String(model.slug)),
+        visionBridgeEngine: engine?.slug || null,
+        defaultOwned,
+        defaultModel: defaultOwned ? defaultModel : null,
+        updatedAt: new Date().toISOString(),
+      }, { directoryMode: 0o700 });
+    } catch (error) {
+      if (patched) {
+        try {
+          if (existingProvider) {
+            openclaw.patch(
+              { models: { providers: { [OPENCLAW_PROVIDER_ID]: existingProvider } } },
+              [PROVIDER_PATH],
+              secret,
+            );
+          } else {
+            openclaw.unset(PROVIDER_PATH);
+          }
+          if (defaultOwned) {
+            if (currentDefault) {
+              openclaw.patch(
+                { agents: { defaults: { model: { primary: currentDefault } } } },
+                [DEFAULT_MODEL_PATH],
+                secret,
+              );
+            } else {
+              openclaw.unset(DEFAULT_MODEL_PATH);
+            }
+          }
+        } catch (rollbackError) {
+          throw new Error(
+            `${redactFailure(error instanceof Error ? error.message : error, secret)} ` +
+            `OpenClaw rollback also failed: ${redactFailure(rollbackError instanceof Error ? rollbackError.message : rollbackError, secret)}`,
+          );
+        }
+      }
+      throw new Error(redactFailure(error instanceof Error ? error.message : error, secret));
+    }
+    return {
+      provider: OPENCLAW_PROVIDER_ID,
+      models: models.length,
+      visionBridgeEngine: engine?.slug || null,
+      defaultOwned,
+      defaultModel: defaultOwned ? defaultModel : null,
+      config: configPath,
+    };
+  }
+
+  function uninstall() {
+    assertOwnership("remove the OpenClaw integration");
+    const state = readCatalogState(catalogPath, port, legacyPort);
+    if (!state && !client && !openclawCliPath()) {
+      return { removed: false, provider: OPENCLAW_PROVIDER_ID };
+    }
+    const openclaw = cli();
+    const provider = openclaw.get(PROVIDER_PATH);
+    if (!state) {
+      if (provider) {
+        throw new Error(`Refusing to remove an unmanaged OpenClaw ${OPENCLAW_PROVIDER_ID} provider.`);
+      }
+      return { removed: false, provider: OPENCLAW_PROVIDER_ID };
+    }
+    if (provider && !providerManaged(provider, port, legacyPort)) {
+      throw new Error("Refusing to remove an OpenClaw provider whose base URL is not managed by this router.");
+    }
+    const currentDefault = normalizedDefault(openclaw.get(DEFAULT_MODEL_PATH));
+    const defaultRemoved = Boolean(
+      state.defaultOwned && state.defaultModel && currentDefault === state.defaultModel,
+    );
+    if (defaultRemoved) openclaw.unset(DEFAULT_MODEL_PATH);
+    if (provider) openclaw.unset(PROVIDER_PATH);
+    if (existsSync(catalogPath)) unlinkSync(catalogPath);
+    return { removed: Boolean(provider), provider: OPENCLAW_PROVIDER_ID, defaultRemoved };
+  }
+
+  function status() {
+    const { models } = modelSource();
+    let state;
+    try {
+      state = readCatalogState(catalogPath, port, legacyPort);
+    } catch (error) {
+      return {
+        installed: existsSync(catalogPath),
+        cliInstalled: Boolean(client || openclawCliPath()),
+        providerInstalled: false,
+        stateValid: false,
+        configValid: false,
+        configError: redactFailure(error instanceof Error ? error.message : error),
+        publishedModels: 0,
+        routableModels: models.length,
+        catalogFresh: false,
+      };
+    }
+    if (!openclawCliPath() && !client) {
+      return {
+        installed: Boolean(state), cliInstalled: false, providerInstalled: false,
+        publishedModels: state?.models?.length ?? 0, routableModels: models.length,
+      };
+    }
+    try {
+      const openclaw = cli();
+      const provider = openclaw.get(PROVIDER_PATH);
+      const configPath = openclaw.configFile();
+      const secret = currentSecret(secretPath);
+      const expectedBaseUrl = callerBaseUrl(port, secret);
+      const expectedProvider = buildProvider(models, expectedBaseUrl, secret);
+      const providerValid = isDeepStrictEqual(provider, expectedProvider);
+      const markerFresh = Boolean(state) && state.baseUrl === expectedBaseUrl &&
+        isDeepStrictEqual(state.models, models.map((model) => String(model.slug)));
+      return {
+        installed: Boolean(state),
+        stateValid: true,
+        cliInstalled: true,
+        cli: openclaw.binary,
+        provider: OPENCLAW_PROVIDER_ID,
+        providerInstalled: Boolean(provider),
+        baseUrlManaged: providerManaged(provider, port, legacyPort),
+        callerCapabilityCurrent: Boolean(
+          provider?.baseUrl === expectedBaseUrl && provider?.apiKey === secret,
+        ),
+        baseUrl: provider?.baseUrl ? redactCallerUrl(provider.baseUrl) : null,
+        config: configPath || null,
+        configExists: Boolean(configPath && existsSync(configPath)),
+        configProtected: Boolean(configPath && existsSync(configPath) && privateFileIsProtected(configPath)),
+        configValid: providerValid,
+        ...(provider && !providerValid
+          ? { configError: "the live OpenClaw provider differs from the router-owned protocol, models, or caller capability" }
+          : {}),
+        publishedModels: state?.models?.length ?? 0,
+        routableModels: models.length,
+        catalogFresh: markerFresh && providerValid,
+        defaultModel: normalizedDefault(openclaw.get(DEFAULT_MODEL_PATH)) || null,
+        defaultOwned: Boolean(state?.defaultOwned),
+      };
+    } catch (error) {
+      return {
+        installed: Boolean(state), cliInstalled: true, providerInstalled: false,
+        configValid: false, configError: redactFailure(error instanceof Error ? error.message : error),
+        publishedModels: state?.models?.length ?? 0, routableModels: models.length,
+      };
+    }
+  }
+
+  return { install, uninstall, status, refreshCallerCapability: install };
+}
+
+const manager = createOpenClawManager();
+export const install = manager.install;
+export const uninstall = manager.uninstall;
+export const status = manager.status;
+export const refreshCallerCapability = manager.refreshCallerCapability;
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const command = process.argv[2] || "status";
+  const handlers = {
+    install,
+    uninstall,
+    status,
+    "caller-capability-refresh": refreshCallerCapability,
+  };
+  const handler = handlers[command];
+  if (!handler) {
+    console.error(`Usage: openclaw-config-manager ${Object.keys(handlers).join("|")}`);
+    process.exit(2);
+  }
+  try {
+    process.stdout.write(`${JSON.stringify(handler(), null, 2)}\n`);
+  } catch (error) {
+    console.error(redactFailure(error instanceof Error ? error.message : error));
+    process.exit(1);
+  }
+}

--- a/src/openclaw-install.mjs
+++ b/src/openclaw-install.mjs
@@ -1,0 +1,155 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  npmGlobalBinary,
+  npmInstallGlobal,
+  npmPath,
+  spawnEnvironment,
+} from "./npm-global-install.mjs";
+import { commandOnPath, spawnableCommand } from "./spawnable-command.mjs";
+
+export const OPENCLAW_NPM_PACKAGE = "openclaw@latest";
+export const OPENCLAW_EXECUTABLE = "openclaw";
+
+const INSTALL_TIMEOUT_MS = 10 * 60_000;
+const VERSION_TIMEOUT_MS = 20_000;
+
+function parseVersion(value) {
+  const match = String(value || "").match(/^(\d+)\.(\d+)(?:\.(\d+))?/);
+  return match ? match.slice(1).map((part) => Number.parseInt(part || "0", 10)) : undefined;
+}
+
+export function nodeMeetsOpenClawMinimum(version = process.versions.node) {
+  const parsed = parseVersion(version);
+  if (!parsed) return false;
+  const [major, minor, patch] = parsed;
+  if (major >= 26) return true;
+  if (major === 25) return minor > 9 || (minor === 9 && patch >= 0);
+  if (major === 24) return minor > 15 || (minor === 15 && patch >= 0);
+  if (major === 23) return false;
+  if (major === 22) return minor > 22 || (minor === 22 && patch >= 3);
+  return false;
+}
+
+export function assertOpenClawNodeSupported(version = process.versions.node) {
+  if (!nodeMeetsOpenClawMinimum(version)) {
+    throw new Error(
+      `OpenClaw needs Node 22.22.3+, 24.15+, 25.9+, or 26+; this router is running Node ${version}. Upgrade Node, then install again.`,
+    );
+  }
+  return version;
+}
+
+export function npmSupportsOpenClawAllowScripts(version) {
+  const parsed = parseVersion(version);
+  if (!parsed) return false;
+  const [major, minor] = parsed;
+  return major >= 12 || (major === 11 && minor >= 16);
+}
+
+export function npmVersion(binary = npmPath()) {
+  if (!binary) return undefined;
+  try {
+    const command = spawnableCommand(binary, ["--version"]);
+    return String(execFileSync(command.command, command.args, {
+      ...command.options,
+      encoding: "utf8",
+      env: spawnEnvironment(),
+      timeout: VERSION_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    })).trim().split(/\r?\n/, 1)[0] || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function openclawCliPath() {
+  const configured = process.env.OPENCLAW_BIN;
+  if (configured && existsSync(configured)) return configured;
+  return commandOnPath(OPENCLAW_EXECUTABLE) || npmGlobalBinary(OPENCLAW_EXECUTABLE);
+}
+
+export function openclawVersion(binary = openclawCliPath()) {
+  if (!binary) return undefined;
+  try {
+    const command = spawnableCommand(binary, ["--version"]);
+    const output = execFileSync(command.command, command.args, {
+      ...command.options,
+      encoding: "utf8",
+      env: spawnEnvironment(),
+      timeout: VERSION_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    return String(output || "").split(/\r?\n/).map((line) => line.trim())
+      .find((line) => /\d+\.\d+\.\d+/.test(line)) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function openclawSnapshot() {
+  const binary = openclawCliPath();
+  return {
+    package: OPENCLAW_NPM_PACKAGE,
+    installed: Boolean(binary),
+    binary,
+    version: openclawVersion(binary),
+    nodeVersion: process.versions.node,
+    nodeSupported: nodeMeetsOpenClawMinimum(),
+  };
+}
+
+export function installOpenClaw({
+  force = false,
+  find = openclawCliPath,
+  install = npmInstallGlobal,
+  nodeVersion = process.versions.node,
+  detectedNpmVersion,
+} = {}) {
+  assertOpenClawNodeSupported(nodeVersion);
+  const existing = find();
+  if (existing && !force) return { installed: true, binary: existing, changed: false };
+
+  const effectiveNpmVersion = detectedNpmVersion ?? npmVersion();
+
+  install(OPENCLAW_NPM_PACKAGE, {
+    label: "OpenClaw",
+    timeoutMs: INSTALL_TIMEOUT_MS,
+    extraArgs: npmSupportsOpenClawAllowScripts(effectiveNpmVersion)
+      ? ["--allow-scripts=openclaw"]
+      : [],
+  });
+  const binary = find();
+  if (!binary) {
+    throw new Error(
+      `npm installed ${OPENCLAW_NPM_PACKAGE}, but no \`${OPENCLAW_EXECUTABLE}\` was found on PATH or in npm's global bin directory.`,
+    );
+  }
+  return { installed: true, binary, changed: true };
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const command = process.argv[2] || "status";
+  try {
+    const value = command === "install"
+      ? installOpenClaw({ force: process.argv.includes("--force") })
+      : command === "status"
+        ? openclawSnapshot()
+        : command === "preflight"
+          ? { nodeVersion: assertOpenClawNodeSupported(), nodeSupported: true }
+        : undefined;
+    if (!value) {
+      console.error("Usage: openclaw-install install [--force]|status|preflight");
+      process.exit(2);
+    }
+    process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url";
 
 import { trayBundleDir } from "./tray-install.mjs";
 
-const supportedTargets = new Set(["codex", "dsh", "gemini", "cursor", "claude"]);
+const supportedTargets = new Set(["codex", "dsh", "gemini", "cursor", "claude", "openclaw"]);
 
 export const TARGET = process.env.MODEL_ROUTER_TARGET || "codex";
 if (!supportedTargets.has(TARGET)) {
@@ -30,6 +30,7 @@ const TARGET_DISPLAY_NAMES = Object.freeze({
   gemini: "Gemini CLI Router",
   cursor: "Cursor Router",
   claude: "Claude Code Router",
+  openclaw: "OpenClaw Router",
   codex: "Codex Router",
 });
 export const TARGET_DISPLAY_NAME = TARGET_DISPLAY_NAMES[TARGET] || TARGET_DISPLAY_NAMES.codex;
@@ -133,6 +134,7 @@ export const DSH_CATALOG_PATH = path.join(STATE_DIR, "dsh-models.json");
 export const GEMINI_CATALOG_PATH = path.join(STATE_DIR, "gemini-models.json");
 export const CURSOR_CATALOG_PATH = path.join(STATE_DIR, "cursor-models.json");
 export const CLAUDE_CATALOG_PATH = path.join(STATE_DIR, "claude-models.json");
+export const OPENCLAW_CATALOG_PATH = path.join(STATE_DIR, "openclaw-models.json");
 // Router-owned Cloudflare named-tunnel metadata. The tunnel exposes only the
 // separately keyed Cursor App edge on 4214; it never points at the main router.
 export const CURSOR_TUNNEL_STATE_PATH = path.join(STATE_DIR, "cursor-tunnel.json");

--- a/src/router-health.mjs
+++ b/src/router-health.mjs
@@ -14,7 +14,7 @@ const SERVICE_BY_TARGET = {
 // alongside `supportedTargets` in paths.mjs; a target missing here fails
 // `doctor` and `wait-health` with "Unknown router target" long before anything
 // about the integration itself is exercised.
-const SUPPORTED_TARGETS = new Set(["codex", "dsh", "gemini", "cursor", "claude"]);
+const SUPPORTED_TARGETS = new Set(["codex", "dsh", "gemini", "cursor", "claude", "openclaw"]);
 const MAX_ERROR_GRAPH_DEPTH = 8;
 
 function transportCodes(error) {

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -580,6 +580,7 @@ async function main() {
   // the ChatGPT-plan model set Codex publishes for itself.
   const geminiTarget = TARGET === "gemini";
   const claudeTarget = TARGET === "claude";
+  const openclawTarget = TARGET === "openclaw";
   if (guided) {
     process.stdout.write(
       `\nReady to install:\n` +
@@ -595,6 +596,8 @@ async function main() {
                 `  Public edge: ${cursorPublicUrl} -> 127.0.0.1:${(await import("./paths.mjs")).PORTS.cursorPublic}\n`
             : claudeTarget
               ? `  Changes: per-user background service and a router-owned claude-router launcher; Claude settings stay untouched\n`
+            : openclawTarget
+              ? `  Changes: installs OpenClaw when missing, starts the shared background service, and owns only models.providers.codex-router\n`
             : `  Native catalog: ${adoptNativeCatalog ? "adopt existing user catalog" : "capture from Codex"}\n` +
               `  Changes: per-user background service and the managed Codex config block\n`),
     );
@@ -621,6 +624,8 @@ async function main() {
         "-File",
         path.join(SOURCE_ROOT, "install.ps1"),
         "-CheckoutInstall",
+        "-Target",
+        TARGET,
         ...(adoptNativeCatalog ? ["-AdoptNativeCatalog"] : []),
       ]);
     } else {
@@ -672,6 +677,9 @@ async function main() {
         : claudeTarget
           ? `\nClaude Code is ready with: ${providerSummary}\n` +
             `Run \`claude-router\`, then choose any \`codex_router/anthropic/...\` model from /model.\n`
+        : openclawTarget
+          ? `\nOpenClaw is ready with: ${providerSummary}\n` +
+            `Run \`openclaw\`; every routed model is available under the \`codex-router\` provider.\n`
         : `\nCodex Router is ready with: ${providerSummary}\nFully quit Codex, reopen it, and start a new task.\n`,
   );
   if (visionBridge?.enabled && visionBridge.engine) {

--- a/src/target-integration.mjs
+++ b/src/target-integration.mjs
@@ -9,6 +9,7 @@ import {
   CURSOR_CATALOG_PATH,
   CLAUDE_CATALOG_PATH,
   GEMINI_CATALOG_PATH,
+  OPENCLAW_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
   SOURCE_ROOT,
   TARGET,
@@ -40,6 +41,7 @@ const PICKER_NAMES = Object.freeze({
   gemini: "Gemini CLI",
   cursor: "Cursor",
   claude: "Claude Code",
+  openclaw: "OpenClaw",
   codex: "Codex",
 });
 
@@ -70,6 +72,9 @@ export function targetRestartHint() {
   }
   if (TARGET === "claude") {
     return "Claude Code reads the router environment at launch; the next `claude-router` run picks this up.";
+  }
+  if (TARGET === "openclaw") {
+    return "OpenClaw reloads its configuration for the next agent run.";
   }
   return `Fully quit and reopen ${targetPickerName()} to refresh the model picker.`;
 }
@@ -102,6 +107,7 @@ export function installedTargets() {
   if (existsSync(GEMINI_CATALOG_PATH)) installed.push("gemini");
   if (existsSync(CURSOR_CATALOG_PATH)) installed.push("cursor");
   if (existsSync(CLAUDE_CATALOG_PATH)) installed.push("claude");
+  if (existsSync(OPENCLAW_CATALOG_PATH)) installed.push("openclaw");
   return installed;
 }
 
@@ -160,6 +166,10 @@ export function refreshTargetPickerIfInstalled() {
   }
   if (existsSync(CLAUDE_CATALOG_PATH)) {
     run("claude-code-config-manager.mjs", ["install"]);
+    refreshed = true;
+  }
+  if (existsSync(OPENCLAW_CATALOG_PATH)) {
+    run("openclaw-config-manager.mjs", ["install"]);
     refreshed = true;
   }
   return refreshed;

--- a/test/caller-key-cli.test.mjs
+++ b/test/caller-key-cli.test.mjs
@@ -19,6 +19,15 @@ test("caller-key rotation selects only complete managed integrations", () => {
     gemini: { installed: true, baseUrlManaged: true, envExists: true, documentReadable: true, conflicts: [], managedBlockPresent: true },
   }), ["codex", "dsh", "gemini"]);
   assert.deepEqual(installedTargetsFromStatus({
+    openclaw: {
+      installed: true, providerInstalled: true, baseUrlManaged: true,
+      configValid: true, configProtected: true,
+    },
+  }), ["openclaw"]);
+  assert.throws(() => installedTargetsFromStatus({
+    openclaw: { installed: true, providerInstalled: true, baseUrlManaged: false },
+  }), /OpenClaw.*partial/i);
+  assert.deepEqual(installedTargetsFromStatus({
     codex: { mode: "native" }, dsh: {}, gemini: {},
   }), []);
   assert.throws(() => installedTargetsFromStatus({

--- a/test/caller-key-maintenance.test.mjs
+++ b/test/caller-key-maintenance.test.mjs
@@ -31,6 +31,15 @@ test("managed target detection refuses partial client state", () => {
     dsh: { routeInstalled: true, credentialInstalled: true },
     gemini: { installed: true, baseUrlManaged: true, envExists: true, documentReadable: true, conflicts: [], managedBlockPresent: true },
   }), ["codex", "dsh", "gemini"]);
+  assert.deepEqual(cli.installedTargetsFromStatus({
+    openclaw: {
+      installed: true, providerInstalled: true, baseUrlManaged: true,
+      configValid: true, configProtected: true,
+    },
+  }), ["openclaw"]);
+  assert.throws(() => cli.installedTargetsFromStatus({
+    openclaw: { installed: true, providerInstalled: false },
+  }), /OpenClaw.*partial/i);
   assert.throws(() => cli.installedTargetsFromStatus({
     codex: { mode: "native" },
     dsh: { routeInstalled: true, credentialInstalled: false },

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -1479,7 +1479,7 @@ test("control center focus feedback uses state changes without focus rings", asy
 
 test("harness and context IPC remain fixed and session-scoped", async () => {
   const source = await readFile(new URL("../apps/control-center/electron/ipc.mjs", import.meta.url), "utf8");
-  assert.match(source, /const HARNESS_IDS = \["codex", "dsh", "gemini", "cursor", "claude"\]/);
+  assert.match(source, /const HARNESS_IDS = \["codex", "dsh", "gemini", "cursor", "claude", "openclaw"\]/);
   assert.match(source, /const HARNESS_SURFACES = \["app", "terminal"\]/);
   assert.match(source, /const SESSION_UUID = \/\^\[0-9a-f\]/);
   assert.match(source, /const DSH_SESSION_ID = \/\^session-/);
@@ -1501,7 +1501,7 @@ test("Harness page renders fixed client rows backed by the shared session index"
     "utf8",
   );
 
-  assert.match(harness, /const CLIENT_ORDER: HarnessId\[\] = \["cursor", "claude", "gemini", "dsh", "codex"\]/);
+  assert.match(harness, /const CLIENT_ORDER: HarnessId\[\] = \["openclaw", "cursor", "claude", "gemini", "dsh", "codex"\]/);
   assert.match(harness, /api\.getContextSessions\(\)/);
   assert.match(harness, /api\.getAgentBridges\(\)/);
   assert.match(harness, /Official-client agent/);
@@ -1512,8 +1512,9 @@ test("Harness page renders fixed client rows backed by the shared session index"
   assert.match(harness, /Connect Cursor/);
   assert.match(harness, /One guided setup/);
   assert.match(harness, /Cursor setup progress/);
-  assert.match(harness, /Open Cursor/);
-  assert.match(harness, /Open agent/);
+  assert.match(harness, /api\.launchHarness\(harness\.id, "app"\)/);
+  assert.match(harness, /<AppWindow[^>]*\/> Open/);
+  assert.doesNotMatch(harness, /BookOpen|SquareTerminal|Open agent/);
   assert.doesNotMatch(harness, /Stable public HTTPS origin|127\.0\.0\.1:4214/);
   assert.match(harness, /assets\/clients\/cursor\.svg/);
   assert.match(harness, /assets\/clients\/deepseek-harness\.svg/);
@@ -1521,7 +1522,7 @@ test("Harness page renders fixed client rows backed by the shared session index"
   assert.match(harness, /assets\/clients\/claude\.svg/);
   assert.match(harness, /assets\/providers\/gemini\.svg/);
   assert.match(harness, /model\.visible && \(model\.enabled \|\| model\.native\)/);
-  assert.match(app, /Cursor, Claude, Gemini, DeepSeek, Codex/);
+  assert.match(app, /OpenClaw, Cursor, Claude, Gemini, DeepSeek, Codex/);
   assert.match(styles, /\.lhc-harness-list/);
   assert.match(styles, /\.lhc-harness-row/);
   assert.match(styles, /\.lhc-harness-logo/);

--- a/test/control-center-harness.test.mjs
+++ b/test/control-center-harness.test.mjs
@@ -77,7 +77,7 @@ test("context manager reads bounded metadata without returning conversation mess
     process.env.CODEX_ROUTER_CURSOR_AGENT_CHATS = cursorAgentChats;
     const snapshot = getContextSessionsSnapshot();
 
-    assert.deepEqual(snapshot.counts, { total: 4, codex: 1, dsh: 1, cursor: 2, claude: 0, gemini: 0, archived: 0 });
+    assert.deepEqual(snapshot.counts, { total: 4, codex: 1, dsh: 1, cursor: 2, claude: 0, gemini: 0, openclaw: 0, archived: 0 });
     assert.equal(snapshot.sessions.find((session) => session.id === CODEX_ID)?.model, "deepseek/deepseek-v4-pro");
     assert.equal(snapshot.sessions.find((session) => session.id === DSH_ID)?.workspaceLabel, "DeepSeek workspace");
     assert.equal(snapshot.sessions.find((session) => session.id === CURSOR_ID)?.title, "Cursor session");
@@ -210,9 +210,9 @@ test("health IPC reads in-process and preserves the injected fetch boundary", as
   assert.doesNotMatch(source, /handle\("getHealth"[\s\S]{0,100}runJson\(\["health"\]\)/);
 });
 
-test("client setup is fixed to the five supported targets and keeps session bodies unread", async () => {
+test("client setup is fixed to the six supported targets and keeps session bodies unread", async () => {
   const source = await readFile(new URL("../apps/control-center/electron/ipc.mjs", import.meta.url), "utf8");
-  assert.match(source, /const HARNESS_IDS = \["codex", "dsh", "gemini", "cursor", "claude"\]/);
+  assert.match(source, /const HARNESS_IDS = \["codex", "dsh", "gemini", "cursor", "claude", "openclaw"\]/);
   assert.match(source, /const args = \["client-setup", harness\]/);
   assert.match(source, /Cursor public URL/);
   assert.match(source, /cursorConnectorRunner\(installer\.executable, installer\.args/);
@@ -282,6 +282,87 @@ test("Claude setup refuses a missing CLI before starting the router installer", 
     /Claude Code is not installed.*refresh Harness/,
   );
   assert.equal(called, false);
+});
+
+test("OpenClaw setup stays a fixed one-click router command even when the CLI is missing", async () => {
+  const handlers = new Map();
+  const calls = [];
+  registerIpcHandlers({
+    ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+    BrowserWindow: { getAllWindows: () => [] },
+    shell: {},
+    harnessExecutableResolver: () => undefined,
+    controlJsonRunner: async (args, options) => {
+      calls.push({ args, options });
+      return { installedNow: true, configured: true };
+    },
+    senderGuard: () => true,
+  });
+
+  const setup = handlers.get("router-control:setupHarness");
+  assert.deepEqual(
+    await setup({}, { harnessId: "openclaw" }),
+    { installedNow: true, configured: true },
+  );
+  assert.deepEqual(calls, [{
+    args: ["client-setup", "openclaw"],
+    options: { timeoutMs: 11 * 60_000 },
+  }]);
+});
+
+test("app actions open the official site when a client has no app surface", async () => {
+  const handlers = new Map();
+  const opened = [];
+  registerIpcHandlers({
+    ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+    BrowserWindow: { getAllWindows: () => [] },
+    shell: { openExternal: async (url) => { opened.push(url); } },
+    cursorAppPath: () => undefined,
+    openclawAppPath: () => undefined,
+    harnessExecutableResolver: () => undefined,
+    senderGuard: () => true,
+  });
+
+  const launch = handlers.get("router-control:launchHarness");
+  assert.deepEqual(
+    await launch({}, { harnessId: "openclaw", surface: "app" }),
+    { opened: true, surface: "site" },
+  );
+  assert.deepEqual(
+    await launch({}, { harnessId: "cursor", surface: "app" }),
+    { opened: true, surface: "site" },
+  );
+  assert.deepEqual(
+    await launch({}, { harnessId: "dsh", surface: "app" }),
+    { opened: true, surface: "site" },
+  );
+  assert.deepEqual(opened, [
+    "https://openclaw.ai/",
+    "https://cursor.com/",
+    "https://github.com/deepseek-ai/deepseek-harness",
+  ]);
+});
+
+test("OpenClaw app actions prefer the installed desktop companion", async () => {
+  const handlers = new Map();
+  const opened = [];
+  registerIpcHandlers({
+    ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+    BrowserWindow: { getAllWindows: () => [] },
+    shell: {
+      openExternal: async (url) => { opened.push({ type: "site", value: url }); },
+      openPath: async (appPath) => { opened.push({ type: "app", value: appPath }); return ""; },
+    },
+    openclawAppPath: () => "/Applications/OpenClaw.app",
+    senderGuard: () => true,
+  });
+
+  const launch = handlers.get("router-control:launchHarness");
+  assert.deepEqual(
+    await launch({}, { harnessId: "openclaw", surface: "app" }),
+    { opened: true, surface: "app" },
+  );
+  assert.deepEqual(opened, [{ type: "app", value: "/Applications/OpenClaw.app" }]);
 });
 
 test("Cursor connector installation reports in-app progress and refresh-ready completion", async () => {

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -609,6 +609,17 @@ test("set-apply keeps provider mutation, publication, and rollback in one transa
   assert.match(source, /args\[0\] === "set-apply"[\s\S]{0,260}runSetApply\(args\[1\], args\[2\]\)/);
 });
 
+test("OpenClaw client setup uses the shared transactional enable path", () => {
+  const source = readFileSync(path.join(root, "src", "control.mjs"), "utf8");
+  const setup = source.match(
+    /async function handleClientSetup[\s\S]*?\r?\n}\r?\n\r?\nasync function handleClientExport/,
+  )?.[0];
+  assert.ok(setup, "client setup helper should be readable");
+  assert.match(setup, /"openclaw"/);
+  assert.match(setup, /currentCheckoutInstaller\(process\.platform, target, \{ posixScript: "enable" \}\)/);
+  assert.doesNotMatch(setup, /setupOpenClaw/);
+});
+
 test("login-free control selects a ready external model and restores Codex defaults", () => {
   const stateDir = mkdtempSync(path.join(os.tmpdir(), "control-login-free-"));
   const signedOutCodex = writeSignedOutCodexStub(stateDir);

--- a/test/cursor-cloudflare-tunnel.test.mjs
+++ b/test/cursor-cloudflare-tunnel.test.mjs
@@ -63,14 +63,15 @@ function fixture() {
   const state = path.join(root, "state");
   const cloudflare = path.join(root, "cloudflare");
   const log = path.join(root, "cloudflared.log");
-  const binary = path.join(root, process.platform === "win32" ? "cloudflared.cmd" : "cloudflared");
+  const binary = path.join(root, "cloudflared");
   mkdirSync(state, { recursive: true });
   mkdirSync(cloudflare, { recursive: true });
   writeFileSync(path.join(cloudflare, "cert.pem"), "test-certificate\n", { mode: 0o600 });
-  const stub = `const fs = require("node:fs");
+  writeFileSync(binary, `#!/usr/bin/env node
+const fs = require("node:fs");
 const path = require("node:path");
 const args = process.argv.slice(2);
-fs.appendFileSync(process.env.TEST_CLOUDFLARED_LOG, JSON.stringify(args) + String.fromCharCode(10));
+fs.appendFileSync(process.env.TEST_CLOUDFLARED_LOG, JSON.stringify(args) + "\\n");
 if (args[0] === "tunnel" && args[1] === "create") {
   fs.writeFileSync(path.join(process.env.MODEL_ROUTER_CLOUDFLARED_HOME, "${TUNNEL_ID}.json"), "{}", { mode: 0o600 });
   process.stdout.write(JSON.stringify({ id: "${TUNNEL_ID}" }));
@@ -78,14 +79,8 @@ if (args[0] === "tunnel" && args[1] === "create") {
   process.stderr.write("route refused");
   process.exitCode = 1;
 }
-`;
-  if (process.platform === "win32") {
-    writeFileSync(binary, `@echo off\r\n"${process.execPath}" "${path.join(root, "cloudflared-stub.cjs")}" %*\r\n`);
-    writeFileSync(path.join(root, "cloudflared-stub.cjs"), stub, { mode: 0o600 });
-  } else {
-    writeFileSync(binary, `#!/usr/bin/env node\n${stub}`, { mode: 0o700 });
-    chmodSync(binary, 0o700);
-  }
+`, { mode: 0o700 });
+  chmodSync(binary, 0o700);
   return {
     root,
     state,
@@ -106,7 +101,14 @@ function run(env, ...args) {
   return spawnSync(process.execPath, [MODULE, ...args], { cwd: SOURCE, env, encoding: "utf8" });
 }
 
-test("managed Cursor tunnel is private, edge-only, and idempotent", () => {
+// The cloudflared stand-in is an extensionless `#!/usr/bin/env node` script,
+// which only a shebang-honouring platform can spawn: Windows answers ENOENT.
+// A .cmd shim is not an alternative, because Node refuses to spawn one without
+// `shell: true`. Skip the two tests that actually execute the fake binary; the
+// pure-logic tests above still run everywhere.
+const SPAWNS_SHEBANG = process.platform !== "win32";
+
+test("managed Cursor tunnel is private, edge-only, and idempotent", { skip: !SPAWNS_SHEBANG }, () => {
   const item = fixture();
   try {
     const first = run(item.env, "setup", "cursor-router.example.com");
@@ -140,7 +142,7 @@ test("managed Cursor tunnel is private, edge-only, and idempotent", () => {
   }
 });
 
-test("managed Cursor tunnel rolls back the exact new tunnel when DNS routing fails", () => {
+test("managed Cursor tunnel rolls back the exact new tunnel when DNS routing fails", { skip: !SPAWNS_SHEBANG }, () => {
   const item = fixture();
   try {
     const result = run({ ...item.env, TEST_FAIL_ROUTE: "1" }, "setup", "cursor-router.example.com");

--- a/test/cursor-config-manager.test.mjs
+++ b/test/cursor-config-manager.test.mjs
@@ -55,15 +55,22 @@ test("Cursor Agent setup is local, one-step, and does not require Cursor App sta
 });
 
 test("packaged setup writes a real Node runtime instead of the Electron host", () => {
-  const nodeName = process.platform === "win32" ? "node.exe" : "node";
-  const runtime = "/test/runtime/bin";
+  // nodeRuntimePath looks for the platform's own executable name, so the
+  // fixture has to name the same one. Hard-coding the POSIX "node" made this
+  // assert that Windows finds a file it never looks for, and the lookup then
+  // failed as "Node.js is unavailable" on a runner that has Node installed.
+  const runtimeDir = process.platform === "win32" ? "C:\\test\\runtime\\bin" : "/test/runtime/bin";
+  const runtime = path.join(runtimeDir, process.platform === "win32" ? "node.exe" : "node");
   const node = nodeRuntimePath({
-    execPath: "/Applications/Codex Router.app/Contents/MacOS/Codex Router",
+    execPath:
+      process.platform === "win32"
+        ? "C:\\Program Files\\Codex Router\\Codex Router.exe"
+        : "/Applications/Codex Router.app/Contents/MacOS/Codex Router",
     electron: true,
-    environment: { PATH: runtime },
-    exists: (candidate) => candidate === path.join(runtime, nodeName),
+    environment: { PATH: runtimeDir },
+    exists: (candidate) => candidate === runtime,
   });
-  assert.equal(node, path.join(runtime, nodeName));
+  assert.equal(node, runtime);
 });
 
 test("Cursor doctor recognizes the launcher as a complete agent-only integration", () => {

--- a/test/installer-scripts.test.mjs
+++ b/test/installer-scripts.test.mjs
@@ -151,9 +151,45 @@ test("POSIX updates republish every installed companion client", () => {
   const installer = readScript("bin", "install");
   assert.match(installer, /\$target" != dsh[\s\S]*dsh-models\.json[\s\S]*dsh-config-manager\.mjs install/);
   assert.match(installer, /\$target" != gemini[\s\S]*gemini-models\.json[\s\S]*gemini-config-manager\.mjs install/);
+  assert.match(installer, /\$target" != cursor[\s\S]*cursor-models\.json[\s\S]*cursor-config-manager\.mjs install/);
+  assert.match(installer, /\$target" != claude[\s\S]*claude-models\.json[\s\S]*claude-code-config-manager\.mjs install/);
+  assert.match(installer, /\$target" != openclaw[\s\S]*openclaw-models\.json[\s\S]*openclaw-config-manager\.mjs install/);
   const windows = readScript("install.ps1");
   assert.match(windows, /\$Target -ne "dsh"[\s\S]*dsh-models\.json[\s\S]*dsh-config-manager\.mjs install/);
   assert.match(windows, /\$Target -ne "gemini"[\s\S]*gemini-models\.json[\s\S]*gemini-config-manager\.mjs install/);
+  assert.match(windows, /\$Target -ne "cursor"[\s\S]*cursor-models\.json[\s\S]*cursor-config-manager\.mjs install/);
+  assert.match(windows, /\$Target -ne "claude"[\s\S]*claude-models\.json[\s\S]*claude-code-config-manager\.mjs install/);
+  assert.match(windows, /\$Target -ne "openclaw"[\s\S]*openclaw-models\.json[\s\S]*openclaw-config-manager\.mjs install/);
+});
+
+test("guided Windows setup forwards the selected client target to the installer", () => {
+  const setup = readScript("src", "setup.mjs");
+  assert.match(setup, /"-File",[\s\S]*"install\.ps1"[\s\S]*"-CheckoutInstall",[\s\S]*"-Target",[\s\S]*TARGET/);
+});
+
+test("OpenClaw installers enforce its Node matrix before dependency or catalog work", () => {
+  const posixInstall = withoutComments(readScript("bin", "install"));
+  assert.ok(
+    posixInstall.indexOf("openclaw-install.mjs\" preflight") < posixInstall.indexOf("npm ci --omit=dev"),
+  );
+  const windowsInstall = withoutComments(readScript("install.ps1"));
+  assert.ok(
+    windowsInstall.indexOf("openclaw-install.mjs\") preflight") < windowsInstall.indexOf("npm ci --omit=dev"),
+  );
+  const enable = withoutComments(readScript("bin", "enable"));
+  assert.ok(
+    enable.indexOf("openclaw-install.mjs preflight") < enable.indexOf("provider-selection.mjs ensure-configured"),
+  );
+});
+
+test("Windows doctor repair forwards the active client target", () => {
+  const doctor = readScript("src", "doctor.mjs");
+  assert.match(doctor, /const windowsArguments = \[[\s\S]*"-Target",[\s\S]*TARGET/);
+});
+
+test("client-independent smoke tests accept every supported target", () => {
+  const smoke = readScript("bin", "smoke-test");
+  assert.match(smoke, /codex\|dsh\|gemini\|cursor\|claude\|openclaw/);
 });
 
 test("both installers preflight pending login-free refreshes before catalog publication", () => {

--- a/test/model-router-cli.test.mjs
+++ b/test/model-router-cli.test.mjs
@@ -95,7 +95,7 @@ test(
   },
 );
 
-for (const args of [["--version"], ["codex", "--version"]]) {
+for (const args of [["--version"], ["codex", "--version"], ["openclaw", "--version"]]) {
   test(
     `model-router ${args.join(" ")} reports the package version`,
     { skip: process.platform === "win32" },

--- a/test/openclaw-config-manager.test.mjs
+++ b/test/openclaw-config-manager.test.mjs
@@ -1,0 +1,289 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  OPENCLAW_PROVIDER_ID,
+  createOpenClawCli,
+  createOpenClawManager,
+  openclawModelProfile,
+} from "../src/openclaw-config-manager.mjs";
+
+const SECRET = "openclaw-test-caller-secret-with-length-123";
+
+function models(first = "fast-model") {
+  return {
+    engine: { slug: first },
+    models: [
+      {
+        slug: first,
+        displayName: "Fast Model",
+        priority: 20,
+        contextWindow: 131072,
+        inputModalities: ["text", "image"],
+        reasoningLevels: [{ effort: "low" }, { effort: "ultra" }],
+      },
+      { slug: "steady-model", displayName: "Steady Model", priority: 10, reasoningLevels: [] },
+    ],
+  };
+}
+
+function fakeClient({ provider, defaultModel, configPath = "/tmp/openclaw.json" } = {}) {
+  const state = { provider, defaultModel, patches: [], unsets: [] };
+  return {
+    binary: "/tmp/openclaw",
+    state,
+    get(configPath) {
+      if (configPath === `models.providers.${OPENCLAW_PROVIDER_ID}`) return state.provider;
+      if (configPath === "agents.defaults.model.primary") return state.defaultModel;
+      return undefined;
+    },
+    configFile() { return configPath; },
+    patch(value, replacePaths) {
+      state.patches.push({ value, replacePaths });
+      state.provider = value.models.providers[OPENCLAW_PROVIDER_ID];
+      if (value.agents) state.defaultModel = value.agents.defaults.model.primary;
+    },
+    unset(configPath) {
+      state.unsets.push(configPath);
+      if (configPath === `models.providers.${OPENCLAW_PROVIDER_ID}`) state.provider = undefined;
+      if (configPath === "agents.defaults.model.primary") state.defaultModel = undefined;
+    },
+  };
+}
+
+function fixture(options = {}, managerOptions = {}) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "openclaw-manager-"));
+  const secretPath = path.join(directory, "caller-secret");
+  const catalogPath = path.join(directory, "openclaw-models.json");
+  const configPath = path.join(directory, "openclaw.json");
+  writeFileSync(secretPath, `${SECRET}\n`, { mode: 0o600 });
+  writeFileSync(configPath, "{}\n", { mode: 0o644 });
+  const client = fakeClient({ ...options, configPath });
+  const manager = createOpenClawManager({
+    client,
+    catalogPath,
+    secretPath,
+    port: 4299,
+    legacyPort: 4199,
+    modelSource: () => models(),
+    assertOwnership() {},
+    ...managerOptions,
+  });
+  return { directory, secretPath, catalogPath, configPath, client, manager };
+}
+
+test("OpenClaw profiles preserve router capabilities and exact reasoning efforts", () => {
+  assert.deepEqual(openclawModelProfile(models().models[0]), {
+    id: "fast-model",
+    name: "Fast Model",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 131072,
+    compat: { supportedReasoningEfforts: ["low", "ultra"] },
+  });
+  assert.deepEqual(openclawModelProfile(models().models[1]), {
+    id: "steady-model",
+    name: "Steady Model",
+    reasoning: false,
+    input: ["text"],
+  });
+});
+
+test("OpenClaw config publication keeps the caller key off argv and redacts failures", () => {
+  const calls = [];
+  const cli = createOpenClawCli("/fixed/openclaw", {
+    spawn: (command, args, options) => {
+      calls.push({ command, args, input: options.input });
+      return { status: 0, stdout: "", stderr: "" };
+    },
+  });
+  cli.patch({ apiKey: SECRET }, ["models.providers.codex-router"], SECRET);
+  assert.equal(calls[0].args.includes(SECRET), false);
+  assert.equal(calls[0].input.includes(SECRET), true);
+
+  const failing = createOpenClawCli("/fixed/openclaw", {
+    spawn: () => ({ status: 1, stdout: "", stderr: `rejected ${SECRET}` }),
+  });
+  assert.throws(
+    () => failing.patch({ apiKey: SECRET }, ["models.providers.codex-router"], SECRET),
+    (error) => !error.message.includes(SECRET) && error.message.includes("[REDACTED]"),
+  );
+});
+
+test("OpenClaw treats a schema-valid unset path as missing on first publish", () => {
+  const cli = createOpenClawCli("/fixed/openclaw", {
+    spawn: () => ({
+      status: 1,
+      stdout: "",
+      stderr: "Config path is valid but unset: models.providers.codex-router\n",
+    }),
+  });
+  assert.equal(cli.get("models.providers.codex-router"), undefined);
+});
+
+test("first publish owns an empty default and writes a private catalog marker", () => {
+  const { manager, client, catalogPath } = fixture();
+  const result = manager.install();
+  assert.equal(result.models, 2);
+  assert.equal(result.defaultModel, "codex-router/fast-model");
+  assert.equal(client.state.defaultModel, "codex-router/fast-model");
+  assert.equal(client.state.provider.api, "openai-responses");
+  assert.equal(client.state.provider.apiKey, SECRET);
+  assert.match(client.state.provider.baseUrl, /_codex-router\/openclaw-test-caller-secret-with-length-123\/v1$/);
+  assert.deepEqual(client.state.provider.models.map((model) => model.id), ["fast-model", "steady-model"]);
+  assert.deepEqual(client.state.patches[0].replacePaths, [
+    "models.providers.codex-router",
+    "agents.defaults.model.primary",
+  ]);
+  assert.equal(readFileSync(catalogPath, "utf8").includes(SECRET), true);
+  if (process.platform !== "win32") {
+    const mode = statSync(catalogPath).mode & 0o777;
+    assert.equal(mode, 0o600);
+  }
+});
+
+test("publish preserves an existing user default", () => {
+  const { manager, client } = fixture({ defaultModel: "other/model" });
+  const result = manager.install();
+  assert.equal(result.defaultOwned, false);
+  assert.equal(client.state.defaultModel, "other/model");
+  assert.deepEqual(client.state.patches[0].replacePaths, ["models.providers.codex-router"]);
+});
+
+test("refresh follows a router-owned default but stops after a user override", () => {
+  const { manager, client, catalogPath, secretPath } = fixture();
+  manager.install();
+  writeFileSync(secretPath, "rotated-openclaw-caller-secret-with-length-456\n", { mode: 0o600 });
+  const refreshed = createOpenClawManager({
+    client,
+    catalogPath,
+    secretPath,
+    port: 4299,
+    legacyPort: 4199,
+    modelSource: () => models("new-fast-model"),
+    assertOwnership() {},
+  });
+  refreshed.refreshCallerCapability();
+  assert.equal(client.state.defaultModel, "codex-router/new-fast-model");
+  assert.equal(client.state.provider.apiKey, "rotated-openclaw-caller-secret-with-length-456");
+
+  client.state.defaultModel = "other/user-choice";
+  const result = refreshed.install();
+  assert.equal(result.defaultOwned, false);
+  assert.equal(client.state.defaultModel, "other/user-choice");
+});
+
+test("publish refuses an unmanaged provider collision", () => {
+  const { manager } = fixture({ provider: { baseUrl: "https://example.com/v1" } });
+  assert.throws(() => manager.install(), /unmanaged codex-router provider/);
+});
+
+test("publish stops before mutation when the OpenClaw config cannot be protected", () => {
+  const { manager, client, catalogPath } = fixture({}, {
+    protectConfig() { throw new Error("planned privacy failure"); },
+  });
+  assert.throws(() => manager.install(), /planned privacy failure/);
+  assert.equal(client.state.patches.length, 0);
+  assert.equal(client.state.provider, undefined);
+  assert.equal(client.state.defaultModel, undefined);
+  assert.equal(existsSync(catalogPath), false);
+});
+
+test("publish rolls back provider and default when the marker write fails", () => {
+  const { manager, client, catalogPath } = fixture({}, {
+    writeCatalog() { throw new Error("planned marker failure"); },
+  });
+  assert.throws(() => manager.install(), /planned marker failure/);
+  assert.equal(client.state.provider, undefined);
+  assert.equal(client.state.defaultModel, undefined);
+  assert.deepEqual(client.state.unsets, [
+    "models.providers.codex-router",
+    "agents.defaults.model.primary",
+  ]);
+  assert.equal(existsSync(catalogPath), false);
+});
+
+test("malformed publication markers fail closed before install or uninstall mutation", () => {
+  const { manager, client, catalogPath } = fixture({
+    provider: {
+      baseUrl: `http://127.0.0.1:4299/_codex-router/${SECRET}/v1`,
+      apiKey: SECRET,
+      api: "openai-responses",
+    },
+    defaultModel: "other/user-choice",
+  });
+  writeFileSync(catalogPath, JSON.stringify({
+    version: 999,
+    provider: OPENCLAW_PROVIDER_ID,
+    defaultOwned: "yes",
+    defaultModel: "other/user-choice",
+  }));
+
+  assert.throws(() => manager.install(), /unsupported or malformed shape/);
+  assert.throws(() => manager.uninstall(), /unsupported or malformed shape/);
+  assert.equal(client.state.patches.length, 0);
+  assert.equal(client.state.unsets.length, 0);
+  const value = manager.status();
+  assert.equal(value.stateValid, false);
+  assert.equal(value.configValid, false);
+  assert.match(value.configError, /unsupported or malformed shape/);
+
+  writeFileSync(catalogPath, "null\n");
+  assert.match(manager.status().configError, /unsupported or malformed shape/);
+});
+
+test("uninstall refuses a provider that has no router ownership marker", () => {
+  const { manager, client } = fixture({
+    provider: { baseUrl: `http://127.0.0.1:4299/_codex-router/${SECRET}/v1` },
+  });
+  assert.throws(() => manager.uninstall(), /unmanaged OpenClaw codex-router provider/);
+  assert.notEqual(client.state.provider, undefined);
+  assert.equal(client.state.unsets.length, 0);
+});
+
+test("publish and uninstall both enforce router state ownership", () => {
+  const actions = [];
+  const { manager } = fixture({}, { assertOwnership: (action) => actions.push(action) });
+  manager.install();
+  manager.uninstall();
+  assert.deepEqual(actions, [
+    "write the OpenClaw model catalog",
+    "remove the OpenClaw integration",
+  ]);
+});
+
+test("uninstall removes only a default the router still owns", () => {
+  const owned = fixture();
+  owned.manager.install();
+  assert.equal(owned.manager.uninstall().defaultRemoved, true);
+  assert.equal(owned.client.state.defaultModel, undefined);
+  assert.equal(existsSync(owned.catalogPath), false);
+
+  const overridden = fixture();
+  overridden.manager.install();
+  overridden.client.state.defaultModel = "other/user-choice";
+  assert.equal(overridden.manager.uninstall().defaultRemoved, false);
+  assert.equal(overridden.client.state.defaultModel, "other/user-choice");
+});
+
+test("status redacts the caller capability", () => {
+  const { manager } = fixture();
+  manager.install();
+  const value = manager.status();
+  assert.equal(value.baseUrl.includes(SECRET), false);
+  assert.match(value.baseUrl, /\[REDACTED\]/);
+  assert.equal(value.catalogFresh, true);
+});
+
+test("status detects live OpenClaw provider drift", () => {
+  const { manager, client } = fixture();
+  manager.install();
+  client.state.provider.api = "openai-completions";
+  const value = manager.status();
+  assert.equal(value.configValid, false);
+  assert.equal(value.catalogFresh, false);
+  assert.match(value.configError, /differs from the router-owned protocol/);
+});

--- a/test/openclaw-install.test.mjs
+++ b/test/openclaw-install.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  OPENCLAW_NPM_PACKAGE,
+  assertOpenClawNodeSupported,
+  installOpenClaw,
+  nodeMeetsOpenClawMinimum,
+  npmSupportsOpenClawAllowScripts,
+} from "../src/openclaw-install.mjs";
+import { npmGlobalBinaryAt } from "../src/npm-global-install.mjs";
+
+test("OpenClaw Node support follows the current release matrix", () => {
+  for (const version of ["22.22.3", "22.23.0", "24.15.0", "25.9.0", "26.0.0", "27.1.0"]) {
+    assert.equal(nodeMeetsOpenClawMinimum(version), true, version);
+  }
+  for (const version of ["22.22.2", "23.9.0", "24.14.9", "25.8.9", "21.99.0", "bad"]) {
+    assert.equal(nodeMeetsOpenClawMinimum(version), false, version);
+  }
+  assert.equal(assertOpenClawNodeSupported("26.0.0"), "26.0.0");
+  assert.throws(() => assertOpenClawNodeSupported("23.9.0"), /needs Node/);
+});
+
+test("Windows npm fallback prefers a spawnable OpenClaw shim", () => {
+  const directory = path.join("C:\\Users\\test", "AppData", "Roaming", "npm");
+  const extensionless = path.join(directory, "openclaw");
+  const commandShim = `${extensionless}.cmd`;
+  const present = new Set([extensionless, commandShim]);
+  assert.equal(
+    npmGlobalBinaryAt(directory, "openclaw", {
+      platform: "win32",
+      exists: (candidate) => present.has(candidate),
+    }),
+    commandShim,
+  );
+});
+
+test("OpenClaw npm allow-scripts flag starts at npm 11.16", () => {
+  assert.equal(npmSupportsOpenClawAllowScripts("11.15.9"), false);
+  assert.equal(npmSupportsOpenClawAllowScripts("11.16.0"), true);
+  assert.equal(npmSupportsOpenClawAllowScripts("12.0.0"), true);
+});
+
+test("OpenClaw install is a no-op when the CLI already exists", () => {
+  let calls = 0;
+  const result = installOpenClaw({
+    find: () => "/usr/local/bin/openclaw",
+    install: () => { calls += 1; },
+    nodeVersion: "26.0.0",
+    detectedNpmVersion: "12.0.0",
+  });
+  assert.equal(result.changed, false);
+  assert.equal(calls, 0);
+});
+
+test("OpenClaw install uses the official package and scoped lifecycle permission", () => {
+  let binary;
+  let invocation;
+  const result = installOpenClaw({
+    find: () => binary,
+    install: (npmPackage, options) => {
+      invocation = { npmPackage, options };
+      binary = "/npm/bin/openclaw";
+    },
+    nodeVersion: "24.15.0",
+    detectedNpmVersion: "11.16.1",
+  });
+  assert.equal(result.changed, true);
+  assert.equal(invocation.npmPackage, OPENCLAW_NPM_PACKAGE);
+  assert.deepEqual(invocation.options.extraArgs, ["--allow-scripts=openclaw"]);
+});
+
+test("OpenClaw install refuses unsupported Node before touching npm", () => {
+  let called = false;
+  assert.throws(() => installOpenClaw({
+    find: () => undefined,
+    install: () => { called = true; },
+    nodeVersion: "23.9.0",
+  }), /needs Node/);
+  assert.equal(called, false);
+});

--- a/test/packaged-install.test.mjs
+++ b/test/packaged-install.test.mjs
@@ -170,7 +170,12 @@ test("doctor --fix rebuilds dependencies in a checkout", () => {
   // everyone in the course of exempting packaged installs.
   const { result, argv } = runFix({ CODEX_ROUTER_PACKAGE_MANAGER: "" });
   assert.notEqual(argv, undefined, `installer was never invoked: ${result.stderr}`);
-  assert.deepEqual(argv, process.platform === "win32" ? ["-CheckoutInstall", "-ForceDeps"] : ["--force-deps"]);
+  assert.deepEqual(
+    argv,
+    process.platform === "win32"
+      ? ["-CheckoutInstall", "-Target", "codex", "-ForceDeps"]
+      : ["--force-deps"],
+  );
 });
 
 test("doctor --fix repairs a packaged install without rebuilding dependencies", () => {
@@ -179,7 +184,10 @@ test("doctor --fix repairs a packaged install without rebuilding dependencies", 
   // is dropped rather than the whole repair being refused.
   const { result, argv } = runFix({ CODEX_ROUTER_PACKAGE_MANAGER: "homebrew" });
   assert.notEqual(argv, undefined, `installer was never invoked: ${result.stderr}`);
-  assert.deepEqual(argv, process.platform === "win32" ? ["-CheckoutInstall"] : []);
+  assert.deepEqual(
+    argv,
+    process.platform === "win32" ? ["-CheckoutInstall", "-Target", "codex"] : [],
+  );
   assert.match(result.stdout, /brew reinstall codex-router/);
 });
 

--- a/test/provider-credential-store.test.mjs
+++ b/test/provider-credential-store.test.mjs
@@ -357,7 +357,7 @@ test("credential references written by every client resolve through the shared r
       resolved: credential?.value === "TEST_SHARED_PLANE_SECRET",
     }));
   `;
-  for (const client of ["codex", "dsh", "gemini", "cursor"]) {
+  for (const client of ["codex", "dsh", "gemini", "cursor", "claude", "openclaw"]) {
     const result = JSON.parse(execFileSync(process.execPath, [
       "--input-type=module",
       "--eval",
@@ -377,7 +377,7 @@ test("credential references written by every client resolve through the shared r
     });
   }
   const stored = JSON.parse(readFileSync(storePath, "utf8"));
-  assert.equal(stored.credentials.length, 4);
+  assert.equal(stored.credentials.length, 6);
   assert.deepEqual(new Set(stored.credentials.map((entry) => entry.secretRef.target)), new Set(["codex"]));
 });
 

--- a/test/target-integration.test.mjs
+++ b/test/target-integration.test.mjs
@@ -15,6 +15,7 @@ const {
   CURSOR_CATALOG_PATH,
   DSH_CATALOG_PATH,
   NATIVE_CATALOG_PATH,
+  OPENCLAW_CATALOG_PATH,
 } = await import("../src/paths.mjs");
 
 function stageFile(filePath, contents) {
@@ -23,7 +24,7 @@ function stageFile(filePath, contents) {
 }
 
 function clearStagedFiles() {
-  for (const filePath of [CONFIG_PATH, CLAUDE_CATALOG_PATH, CURSOR_CATALOG_PATH, DSH_CATALOG_PATH, NATIVE_CATALOG_PATH]) {
+  for (const filePath of [CONFIG_PATH, CLAUDE_CATALOG_PATH, CURSOR_CATALOG_PATH, DSH_CATALOG_PATH, NATIVE_CATALOG_PATH, OPENCLAW_CATALOG_PATH]) {
     rmSync(filePath, { force: true });
   }
 }
@@ -107,6 +108,17 @@ test("the Claude publication snapshot marks the Claude Code integration", () => 
     assert.deepEqual(installedTargets(), ["claude"]);
     stageFile(CONFIG_PATH, "# BEGIN codex-router-managed\n# END codex-router-managed\n");
     assert.deepEqual(installedTargets(), ["codex", "claude"]);
+  } finally {
+    clearStagedFiles();
+  }
+});
+
+test("the OpenClaw publication snapshot marks the OpenClaw integration", () => {
+  try {
+    stageFile(OPENCLAW_CATALOG_PATH, "{}");
+    assert.deepEqual(installedTargets(), ["openclaw"]);
+    stageFile(CONFIG_PATH, "# BEGIN codex-router-managed\n# END codex-router-managed\n");
+    assert.deepEqual(installedTargets(), ["codex", "openclaw"]);
   } finally {
     clearStagedFiles();
   }

--- a/test/target-isolation.test.mjs
+++ b/test/target-isolation.test.mjs
@@ -81,7 +81,7 @@ test("operators can keep an explicitly configured legacy block during migration"
 });
 
 test("all client targets share the same port block", () => {
-  for (const target of ["dsh", "gemini", "cursor", "claude"]) {
+  for (const target of ["dsh", "gemini", "cursor", "claude", "openclaw"]) {
     assert.deepEqual(JSON.parse(pathsForTarget(target)), JSON.parse(pathsForTarget("codex")));
   }
 });


### PR DESCRIPTION
## Summary
- add OpenClaw as a first-class routed client target with install-if-missing setup and a router-owned `codex-router` Responses provider
- publish selected models with exact context, modality, and reasoning metadata while preserving unrelated OpenClaw configuration and defaults
- add the one-click Harness row and one `Open` action with native-app-first and official-site fallback
- integrate POSIX and Windows installers, doctor, uninstall, shared catalog refresh, and caller-key rotation

## Safety
- owns only `models.providers.codex-router` plus a private publication marker
- keeps the caller capability off argv and logs, validates live drift, and rolls back incomplete publication
- uses the ordinary OpenClaw Responses provider catalog, not AgentHarnessV2
- does not start onboarding, a gateway, or an agent during setup

## Verification
- `npm run check`
- `npm test`: 3,225 tests, 3,205 passed, 20 skipped, 0 failed
- `cd apps/control-center && npm run check && npm test`: 80 passed
- rendered and interacted with the Harness page at desktop width
- live quota smoke test not run because it spends provider quota
- native Windows execution not run on this macOS host; Windows source and fixture coverage is included

## Stack
This PR is stacked on #555 (`codex/routed-client-harnesses`) so the diff stays limited to the OpenClaw target. Retarget it to `main` after #555 merges.