### PR TITLE
fix: land unmerged local fixes for ChatGPT Web, usage reads, and tray appearance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ user.
 4. Determine which provider IDs the user requested: `anthropic-api`,
     `kimi-oauth`, `antigravity-oauth`, `kimi-api`, `kimi-api-cn`, `deepseek`, `grok-oauth`, `grok-api`, `qwen-plan`,
     `zai-coding`, `ollama-cloud`, `minimax-token-plan`, `meta`, `clinepass`,
-    `venice`, `nousresearch`, and/or
+    `venice`, `nousresearch`, `chatgpt-web`, and/or
    `opencode-go`
    (shown to users as "opencode Go/Zen"; its `opencode-go-messages`,
    `opencode-go-responses`, and `opencode-zen` variants share its stored key
@@ -92,6 +92,12 @@ user.
    enabling it asks for nothing and curating it is unnecessary. All three must
    be selected explicitly; never select one on the user's behalf just because
    it can authenticate without a key.
+   `chatgpt-web` is also explicit and catalog-only, but local: it requires the
+   separately installed codex-chatgpt-web launcher, an in-launcher ChatGPT
+   sign-in, its browser smoke test, and `bin/curate-models chatgpt-web`. Never
+   run that launcher's Install models action, because Codex Router alone owns
+   `openai_base_url`; leave the launcher running as the loopback browser
+   sidecar. It is Codex-only and must not be published into DSH or Gemini.
    `kimi-api` and `kimi-api-cn` are two different Moonshot platforms, not a
    fallback pair: the global console at platform.moonshot.ai and the mainland
    one at platform.moonshot.cn have separate accounts, separate billing, and

--- a/README.md
+++ b/README.md
@@ -1279,6 +1279,49 @@ and are not available while signed out. The equivalent local control command is
 `./bin/control auth-mode on` or `./bin/control auth-mode off`; when using the
 command directly, restart Codex yourself.
 
+### Use ChatGPT Web models through Codex Router
+
+Codex Router can use the account-gated browser models exposed by
+[codex-chatgpt-web](https://github.com/miuuyy/codex-chatgpt-web) without letting
+the two projects compete for Codex's `openai_base_url`. The browser launcher
+owns its private Electron profile, ChatGPT sign-in, browser automation, and
+optional MCP tunnel. Codex Router remains the only owner of Codex routing,
+provider selection, model publication, usage records, and the background router
+plane.
+
+Install and open the upstream launcher, sign in inside its embedded browser,
+and pass its browser smoke test. **Do not press its Install models action**:
+that action points Codex directly at port 17841 and replaces the router's
+managed base URL. Leave the launcher running, then enable and curate the live,
+account-specific rows through this repository:
+
+```sh
+./bin/model-router codex providers enable chatgpt-web
+./bin/curate-models chatgpt-web --refresh
+```
+
+Curation reads the launcher's loopback `/v1/models` catalog, discards every
+native GPT row, and offers only the `chatgpt-web/*` models the signed-in account
+currently exposes. A chosen route keeps its fixed ChatGPT effort and advertised
+context/image metadata. The request path goes directly from the router to the
+loopback bridge so Codex's native tool, collaboration, image, and compaction
+envelope is not translated by LiteLLM. The user's Codex/ChatGPT bearer token is
+never sent to the launcher; the local hop receives only a non-secret placeholder.
+
+Browser-only mode works with no additional router credential. For the full
+Codex harness, finish the upstream launcher's MCP/tunnel setup and permissions;
+the router does not read or store that tunnel key. Browser/UI drift and
+account-gated model refusals are relayed exactly and are never retried or failed
+over to another provider, and the route is never recruited as another model's
+vision helper, because any of those actions could duplicate a browser turn.
+
+This provider is deliberately Codex-only and is not published into DeepSeek
+Harness or Gemini CLI. Its endpoint defaults to
+`http://127.0.0.1:17841/v1`; `MODEL_ROUTER_CHATGPT_WEB_BASE_URL` may change the
+port but a non-loopback override is refused. The upstream project is unofficial
+browser automation, so its own security notes, platform support, OpenAI terms,
+and workspace policies still apply.
+
 ### Use a local model in Codex (experimental)
 
 LM Studio can run as a second local backend alongside Ollama. Its models use

--- a/apps/control-center/electron/ipc.mjs
+++ b/apps/control-center/electron/ipc.mjs
@@ -56,6 +56,13 @@ const SESSION_LIST_LIMIT = 500;
 // lock wait and the build itself; killing the lock holder at the old 30/120s
 // limits would strand a stale lock and force a rollback to race recovery.
 const CATALOG_MUTATION_TIMEOUT_MS = 330_000;
+// Provider usage combines the local retained ledger with optional account
+// quota reads. OAuth refreshes alone may take 30 seconds, and a rejected token
+// can require a second refresh before the provider answers. Keep this aligned
+// with the control command's 120-second default: timing it out at 20 seconds
+// discards the already-computed ledger and makes the dashboard fall back to
+// its latest 1,000 event details.
+const PROVIDER_USAGE_TIMEOUT_MS = 120_000;
 // Five live checks, two of them a full Codex parent-and-child turn. The
 // catalog ceiling is not enough headroom for a slow provider, and a timeout
 // here reads to the operator as "your model failed" when it did not.
@@ -713,7 +720,10 @@ export function registerIpcHandlers({
     }
   });
   handle("getAccountUsage", async () => runJson(["account"], { timeoutMs: 20_000 }));
-  handle("getProviderUsage", async () => runJson(["provider-usage"], { timeoutMs: 20_000 }));
+  handle("getProviderUsage", async () => runJson(
+    ["provider-usage"],
+    { timeoutMs: PROVIDER_USAGE_TIMEOUT_MS },
+  ));
   handle("getLocalModels", async () => runJson(["local-models", "list", "--json"], { timeoutMs: 20_000 }));
   handle("getVisionBridge", async () => runJson(["vision-bridge", "status"], { timeoutMs: 20_000 }));
   handle("getToolResultAging", async () => runJson(["tool-result-aging", "status"], { timeoutMs: 20_000 }));
@@ -773,7 +783,10 @@ export function registerIpcHandlers({
     snapshot: await snapshot(),
     providers: await runJson(["providers"]),
     accountUsage: await runJson(["account"], { timeoutMs: 20_000 }),
-    providerUsage: await runJson(["provider-usage"], { timeoutMs: 20_000 }),
+    providerUsage: await runJson(
+      ["provider-usage"],
+      { timeoutMs: PROVIDER_USAGE_TIMEOUT_MS },
+    ),
     localModels: await runJson(["local-models", "list", "--json"], { timeoutMs: 20_000 }),
     visionBridge: await runJson(["vision-bridge", "status"]),
     presence: await runJson(["presence", "status"]),

--- a/apps/control-center/src/pages/DashboardPage.tsx
+++ b/apps/control-center/src/pages/DashboardPage.tsx
@@ -334,12 +334,6 @@ export function DashboardPage({
         <InlineNotice tone="danger" title="Router health check failed">{health.error}</InlineNotice>
       ) : null}
 
-      {healthPending ? (
-        <SkeletonBlock className="db-skeleton-health" />
-      ) : (
-        <ServiceHealthPanel health={health} compact onOpen={() => onNavigate("status")} />
-      )}
-
       <div className="db-summary-grid" role="list" aria-label="Router summary">
         {tiles.map((tile) => {
           const Icon = tile.icon;
@@ -428,14 +422,6 @@ export function DashboardPage({
         loading={snapshotPending && !providerUsage}
       />
 
-      <RouteDashboardPanel
-        providers={routeProviders}
-        routeMutations={routeMutations}
-        api={api}
-        onNavigate={onNavigate}
-        loading={routesPending}
-      />
-
       <div className="db-panel-grid db-dashboard-details">
         <section className="panel-section db-breakdown-panel">
           <SectionHeading
@@ -497,6 +483,20 @@ export function DashboardPage({
           />
         )}
       </section>
+
+      <RouteDashboardPanel
+        providers={routeProviders}
+        routeMutations={routeMutations}
+        api={api}
+        onNavigate={onNavigate}
+        loading={routesPending}
+      />
+
+      {healthPending ? (
+        <SkeletonBlock className="db-skeleton-health" />
+      ) : (
+        <ServiceHealthPanel health={health} compact onOpen={() => onNavigate("status")} />
+      )}
     </div>
   );
 }

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -5401,7 +5401,6 @@ private struct TrayView: View {
       }
       .padding(14)
     }
-    .preferredColorScheme(.dark)
     .foregroundStyle(routerText)
     .task {
       await store.refresh()

--- a/apps/panel/styles.css
+++ b/apps/panel/styles.css
@@ -519,6 +519,11 @@ h2 {
   r: 4.5;
 }
 
+.chart-point.router-fallback {
+  stroke: var(--amber);
+  stroke-dasharray: 2 2;
+}
+
 .chart-tooltip {
   position: absolute;
   z-index: 3;

--- a/config/chatgpt-web/chatgpt-web.json
+++ b/config/chatgpt-web/chatgpt-web.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "providers": [
+    {
+      "id": "chatgpt-web",
+      "displayName": "ChatGPT Web",
+      "kind": "openai-compatible",
+      "ownedBy": "openai",
+      "protocol": "openai-responses",
+      "baseUrl": "http://127.0.0.1:17841/v1",
+      "baseUrlEnv": "MODEL_ROUTER_CHATGPT_WEB_BASE_URL",
+      "keyless": true,
+      "directResponses": true,
+      "codexOnly": true,
+      "explicitSelection": true,
+      "planNote": "Requires the codex-chatgpt-web launcher, its private ChatGPT sign-in, and its browser smoke test. Do not use that launcher's Install models action; Codex Router owns openai_base_url."
+    }
+  ]
+}

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -63,6 +63,18 @@ injecting the selected provider key. It supports the registry's tested
 OpenAI-compatible and Anthropic protocols; do not create a new listener merely
 to add another provider using one of those protocols.
 
+The narrow exception is a checked-in `directResponses` provider. It is for a
+Codex-specific loopback bridge whose contract depends on the unflattened native
+Responses body and `x-codex-*` authority headers. Registry validation requires
+that provider to be keyless, loopback-only, `openai-responses`, and `codexOnly`.
+`src/direct-responses-provider.mjs` strips caller/account credentials, preserves
+the native authority envelope, and supplies only a non-secret local bearer.
+The router must not apply gateway failover, empty-completion replay, namespace
+translation, or error-body rewriting to this path: those can duplicate a
+browser turn or erase the bridge's actionable UI/login failure. It must also be
+excluded from indirect vision-engine ranking. Add a direct provider only with
+an end-to-end router test proving all of those boundaries.
+
 OAuth schemes usually need a dedicated adapter because refresh and identity
 rules are provider-specific. Never infer that an API key can replace an OAuth
 credential or vice versa.

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -78,6 +78,7 @@ const EFFORT_DESCRIPTIONS = {
   high: "Deep reasoning",
   xhigh: "Extended reasoning",
   max: "Maximum reasoning",
+  ultra: "Pro reasoning",
 };
 
 // Request profiles a curated model may opt into. The vendor profiles in
@@ -123,7 +124,7 @@ function usage() {
   console.error(
     "Usage: curate-models.mjs PROVIDER [--models id1,id2 | interactive] " +
       "[--free-only] [--remove id1,id2] [--refresh] [--apply|--no-apply] " +
-      "[--efforts minimal,low,medium,high,xhigh] " +
+      `[--efforts ${Object.keys(EFFORT_DESCRIPTIONS).join(",")}] ` +
       `[--request-profile ${Object.keys(REQUEST_PROFILE_DESCRIPTIONS).join("|")}]`,
   );
   process.exit(2);
@@ -465,6 +466,21 @@ async function main() {
       ...(flagEfforts || {}),
       ...(discovery.free?.includes(id) ? { isFree: true } : {}),
     };
+    // The ChatGPT Web launcher owns these catalog rows and derives them from
+    // the signed-in account. Its clean labels and input modalities are part of
+    // the same local contract as the account-gated model ids, so preserve them
+    // instead of turning every row into a generic text-only curated model.
+    if (providerId === "chatgpt-web") {
+      const live = Array.isArray(discovery.modelMetadata)
+        ? discovery.modelMetadata.find((entry) => entry?.upstreamId === id)
+        : discovery.modelMetadata?.[id];
+      if (typeof live?.displayName === "string" && live.displayName) {
+        metadata.displayName = live.displayName;
+      }
+      if (Array.isArray(live?.inputModalities) && live.inputModalities.length) {
+        metadata.inputModalities = live.inputModalities;
+      }
+    }
     // The served catalog value wins when present. OpenCode's exact documented
     // free-model size is the fallback for its id-only Zen catalog; every other
     // silent catalog still gets the conservative generic default.

--- a/src/direct-responses-provider.mjs
+++ b/src/direct-responses-provider.mjs
@@ -1,0 +1,64 @@
+import { HOP_BY_HOP_HEADERS } from "./http-utils.mjs";
+import { resolveProviderBaseUrl } from "./model-registry.mjs";
+
+const DIRECT_REQUEST_HEADERS = new Set([
+  "accept",
+  "openai-beta",
+  "originator",
+  "session_id",
+  "session-id",
+  "thread-id",
+  "traceparent",
+  "tracestate",
+  "user-agent",
+  "x-client-request-id",
+  "x-openai-internal-codex-responses-lite",
+  "x-openai-subagent",
+  "x-responsesapi-include-timing-metrics",
+]);
+
+export function isDirectResponsesProvider(provider) {
+  return provider?.directResponses === true;
+}
+
+// The bridge needs Codex's native x-codex turn metadata and tool envelope,
+// but it never needs the caller's ChatGPT bearer token. Replace every upstream
+// credential with a local placeholder that satisfies the bridge's loopback
+// Responses contract without disclosing an account credential to another
+// same-user process.
+export function directResponsesHeaders(source = {}) {
+  const headers = {};
+  for (const [name, raw] of Object.entries(source)) {
+    const lower = name.toLowerCase();
+    if (HOP_BY_HOP_HEADERS.has(lower)) continue;
+    if (!DIRECT_REQUEST_HEADERS.has(lower) && !lower.startsWith("x-codex-")) continue;
+    if (raw !== undefined) headers[name] = Array.isArray(raw) ? raw.join(", ") : raw;
+  }
+  headers.Authorization = "Bearer local";
+  headers["Content-Type"] = "application/json";
+  headers["Accept-Encoding"] = "identity";
+  return headers;
+}
+
+export function directResponsesTarget(provider, pathname, search = "") {
+  if (!isDirectResponsesProvider(provider)) {
+    throw new Error("Provider does not declare the direct Responses contract.");
+  }
+  const suffix = /\/responses\/compact$/.test(String(pathname || ""))
+    ? "/responses/compact"
+    : /\/responses$/.test(String(pathname || ""))
+      ? "/responses"
+      : undefined;
+  if (!suffix) throw new Error("Direct Responses providers accept only Responses routes.");
+  const { baseUrl } = resolveProviderBaseUrl(provider);
+  return `${baseUrl}${suffix}${search || ""}`;
+}
+
+export function directResponsesBody(payload, route) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Direct Responses request body must be an object.");
+  }
+  const upstreamModel = String(route?.upstreamModel || "").trim();
+  if (!upstreamModel) throw new Error("Direct Responses route requires an upstream model.");
+  return Buffer.from(JSON.stringify({ ...payload, model: upstreamModel }), "utf8");
+}

--- a/src/model-capabilities.mjs
+++ b/src/model-capabilities.mjs
@@ -155,7 +155,7 @@ export function modelMetadataFromProviderRecord(record, { trusted = false } = {}
   if (!record || typeof record !== "object" || Array.isArray(record)) {
     throw new Error("Provider model metadata must be an object.");
   }
-  const upstreamId = first(record, ["id", "model", "upstreamId"]);
+  const upstreamId = first(record, ["id", "model", "upstreamId", "slug"]);
   if (typeof upstreamId !== "string" || !upstreamId.trim()) {
     throw new Error("Provider model metadata is missing id.");
   }

--- a/src/model-catalog-metadata.mjs
+++ b/src/model-catalog-metadata.mjs
@@ -173,11 +173,11 @@ function openCodeFreeMetadata(item) {
 }
 
 export function modelCatalogMetadata(payload, provider) {
-  const data = Array.isArray(payload) ? payload : payload?.data;
+  const data = Array.isArray(payload) ? payload : payload?.data ?? payload?.models;
   if (!Array.isArray(data)) return {};
   const metadata = Object.create(null);
   for (const item of data) {
-    const id = String(item?.id || "").trim();
+    const id = String(item?.id ?? item?.slug ?? "").trim();
     if (!id || Object.hasOwn(metadata, id)) continue;
     const value = provider?.id === "venice"
       ? veniceMetadata(item)

--- a/src/model-discovery.mjs
+++ b/src/model-discovery.mjs
@@ -41,9 +41,11 @@ function option(name) {
 }
 
 export function modelIds(payload, provider) {
-  const data = Array.isArray(payload) ? payload : payload?.data;
+  const data = Array.isArray(payload) ? payload : payload?.data ?? payload?.models;
   if (!Array.isArray(data)) throw new Error("The provider returned an invalid model list.");
-  const candidates = provider?.authMode === "anonymous"
+  const candidates = provider?.id === "chatgpt-web"
+    ? data.filter((item) => modelRecordId(item).startsWith("chatgpt-web/"))
+    : provider?.authMode === "anonymous"
     ? data.filter((item) => anonymousModelAllowed(provider, item?.id))
     : provider?.id === "orca"
     ? data.filter((item) => {
@@ -84,11 +86,11 @@ export function modelIds(payload, provider) {
 // `upstreamId`). Keep discovery provider-agnostic without changing the
 // filtering policy for built-in providers.
 function modelRecordId(item) {
-  return String(item?.id ?? item?.model ?? item?.upstreamId ?? "").trim();
+  return String(item?.id ?? item?.model ?? item?.upstreamId ?? item?.slug ?? "").trim();
 }
 
 function modelRecords(payload, provider) {
-  const data = Array.isArray(payload) ? payload : payload?.data;
+  const data = Array.isArray(payload) ? payload : payload?.data ?? payload?.models;
   if (!Array.isArray(data)) throw new Error("The provider returned an invalid model list.");
   const ids = new Set(modelIds(payload, provider));
   return data.filter((item) => ids.has(modelRecordId(item)));
@@ -157,7 +159,7 @@ function zeroPrice(value) {
 // price, or zero input and output token prices.
 export function freeModelIds(payload, provider) {
   if (provider?.id !== "orca") return [];
-  const data = Array.isArray(payload) ? payload : payload?.data;
+  const data = Array.isArray(payload) ? payload : payload?.data ?? payload?.models;
   if (!Array.isArray(data)) throw new Error("The provider returned an invalid model list.");
   const callable = new Set(modelIds(payload, provider));
   return data
@@ -203,7 +205,7 @@ function advertisedContextLength(item) {
 // the provider sized in silence is absent rather than guessed: curation falls
 // back to its conservative default only when nothing was advertised.
 export function modelContextLengths(payload, provider) {
-  const data = Array.isArray(payload) ? payload : payload?.data;
+  const data = Array.isArray(payload) ? payload : payload?.data ?? payload?.models;
   if (!Array.isArray(data)) return {};
   const kept = new Set(modelIds(payload, provider));
   const lengths = {};

--- a/src/model-failover.mjs
+++ b/src/model-failover.mjs
@@ -397,6 +397,7 @@ export function rankFailoverCandidates(
   const cooled = new Set(Object.keys(readProviderCooldowns({ now })));
   const available = (Array.isArray(models) ? models : []).filter(
     (model) =>
+      PROVIDERS.get(model.provider)?.directResponses !== true &&
       model.slug !== from?.slug &&
       eligible(model, {
         fromProvider,

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -248,6 +248,11 @@ function loadRegistry() {
       if (provider.keyless !== undefined && typeof provider.keyless !== "boolean") {
         fail(`provider ${provider.id} has an invalid keyless flag`);
       }
+      for (const field of ["directResponses", "codexOnly", "explicitSelection"]) {
+        if (provider[field] !== undefined && typeof provider[field] !== "boolean") {
+          fail(`provider ${provider.id} has an invalid ${field} flag`);
+        }
+      }
       if (provider.keyless && provider.credential !== undefined) {
         fail(`keyless provider ${provider.id} must not declare a credential`);
       }
@@ -341,6 +346,21 @@ function loadRegistry() {
       }
       if (provider.transport === "ollama" && !provider.keyless) {
         fail(`provider ${provider.id} Ollama transport must be keyless`);
+      }
+      // A direct Responses provider bypasses LiteLLM so a Codex-native request
+      // envelope reaches a reviewed local bridge intact. Keep that exception
+      // narrower than the ordinary keyless-provider contract: no remote host,
+      // no protocol translation, and no publication to non-Codex clients.
+      if (
+        provider.directResponses &&
+        (!provider.keyless || provider.protocol !== "openai-responses" || !provider.codexOnly)
+      ) {
+        fail(
+          `direct Responses provider ${provider.id} must be keyless, openai-responses, and Codex-only`,
+        );
+      }
+      if (provider.codexOnly && !provider.directResponses) {
+        fail(`Codex-only provider ${provider.id} must use the direct Responses contract`);
       }
     }
     providers.set(provider.id, Object.freeze(provider));

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -120,6 +120,51 @@ const OPENCODE_FREE_MODELS = Object.freeze({
 });
 
 const CURATION_ROUTES = Object.freeze({
+  "chatgpt-web": Object.freeze({
+    providers: Object.freeze(["chatgpt-web"]),
+    protocols: Object.freeze(["Responses"]),
+    messagesModels: Object.freeze([]),
+    responsesModels: Object.freeze([]),
+    primaryModels: Object.freeze([
+      "chatgpt-web/luna",
+      "chatgpt-web/think",
+      "chatgpt-web/light",
+      "chatgpt-web/medium",
+      "chatgpt-web/high",
+      "chatgpt-web/extra-high",
+      "chatgpt-web/pro",
+    ]),
+    models: Object.freeze({
+      "chatgpt-web/luna": Object.freeze({
+        reasoningLevels: Object.freeze(["low"]),
+        summary: "ChatGPT Web Luna through the account-bound local browser bridge.",
+      }),
+      "chatgpt-web/think": Object.freeze({
+        reasoningLevels: Object.freeze(["low"]),
+        summary: "ChatGPT Web Think through the account-bound local browser bridge.",
+      }),
+      "chatgpt-web/light": Object.freeze({
+        reasoningLevels: Object.freeze(["low"]),
+        summary: "ChatGPT Web Instant through the account-bound local browser bridge.",
+      }),
+      "chatgpt-web/medium": Object.freeze({
+        reasoningLevels: Object.freeze(["medium"]),
+        summary: "ChatGPT Web Medium through the account-bound local browser bridge.",
+      }),
+      "chatgpt-web/high": Object.freeze({
+        reasoningLevels: Object.freeze(["high"]),
+        summary: "ChatGPT Web High through the account-bound local browser bridge.",
+      }),
+      "chatgpt-web/extra-high": Object.freeze({
+        reasoningLevels: Object.freeze(["xhigh"]),
+        summary: "ChatGPT Web Extra High through the account-bound local browser bridge.",
+      }),
+      "chatgpt-web/pro": Object.freeze({
+        reasoningLevels: Object.freeze(["ultra"]),
+        summary: "ChatGPT Web Pro through the account-bound local browser bridge.",
+      }),
+    }),
+  }),
   "commandcode": Object.freeze({
     providers: Object.freeze(["commandcode", "commandcode-messages"]),
     protocols: Object.freeze(["Chat", "Messages"]),

--- a/src/provider-selection.mjs
+++ b/src/provider-selection.mjs
@@ -141,7 +141,9 @@ export function defaultProviderIds() {
   return configuredProviderIds().filter(
     (id) => {
       const provider = RUNTIME_PROVIDERS.get(id);
-      return provider?.generic !== true && !["anonymous", "per-model"].includes(provider?.authMode);
+      return provider?.generic !== true &&
+        provider?.explicitSelection !== true &&
+        !["anonymous", "per-model"].includes(provider?.authMode);
     },
   );
 }

--- a/src/routed-client-models.mjs
+++ b/src/routed-client-models.mjs
@@ -11,7 +11,7 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { NATIVE_CATALOG_PATH } from "./paths.mjs";
 import { nativeSessionAvailable } from "./codex-native-session.mjs";
-import { MODEL_SLUG_ALIASES } from "./model-registry.mjs";
+import { MODEL_SLUG_ALIASES, providerForModel } from "./model-registry.mjs";
 import { migrateModelVisibility } from "./model-picker-state.mjs";
 import { readMultiAgentSettings } from "./multi-agent-state.mjs";
 import { selectedConfiguredListedModels } from "./provider-selection.mjs";
@@ -79,7 +79,9 @@ export function routedClientModels() {
   const selected = applySubagentProofs(
     selectedConfiguredListedModels().filter((model) => {
       const slug = String(model.slug);
-      return !hidden.has(slug) && (!picker.hasExplicitVisibility || visible.has(slug));
+      return providerForModel(model)?.codexOnly !== true &&
+        !hidden.has(slug) &&
+        (!picker.hasExplicitVisibility || visible.has(slug));
     }),
     subagentProofSnapshot(),
     { hidden, disabled: readMultiAgentSettings().disabled },

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -189,6 +189,12 @@ import {
   loopbackProbeFetch,
 } from "./fetch-transport.mjs";
 import { handleResponsesWebSocketUpgrade } from "./responses-websocket.mjs";
+import {
+  directResponsesBody,
+  directResponsesHeaders,
+  directResponsesTarget,
+  isDirectResponsesProvider,
+} from "./direct-responses-provider.mjs";
 
 installStableFetchTransport();
 
@@ -2313,7 +2319,10 @@ function compactionAttempts(route, aged, searchContract, { allowFailover = true 
   const settings = readFailoverSettings();
   if (!settings.enabled) return [route];
   const candidates = rankFailoverCandidates(
-    selectedConfiguredListedModels().filter((model) => !readHiddenModels().has(model.slug)),
+    selectedConfiguredListedModels().filter((model) => (
+      !readHiddenModels().has(model.slug) &&
+      !isDirectResponsesProvider(providerForModel(model))
+    )),
     {
       from: route,
       // The transcript being summarized is nearly all of the request, so its
@@ -3142,7 +3151,10 @@ async function prepareRoutedRequest({
 function failoverCandidates({ route, agedInput, flattenedNamespaces, searchContract, chain }) {
   const hidden = readHiddenModels();
   return rankFailoverCandidates(
-    selectedConfiguredListedModels().filter((model) => !hidden.has(model.slug)),
+    selectedConfiguredListedModels().filter((model) => (
+      !hidden.has(model.slug) &&
+      !isDirectResponsesProvider(providerForModel(model))
+    )),
     {
       from: route,
       // Context fit is checked after rebuilding the request for each
@@ -3174,7 +3186,10 @@ function subagentTransportFailoverCandidates({ request, route, agedInput, search
   if (subagentEligibility(route)) return [];
   const hidden = readHiddenModels();
   let ranked = rankSubagentCandidates(
-    selectedConfiguredListedModels().filter((model) => !hidden.has(model.slug)),
+    selectedConfiguredListedModels().filter((model) => (
+      !hidden.has(model.slug) &&
+      !isDirectResponsesProvider(providerForModel(model))
+    )),
     {
       chain,
       requiredCapabilities: [
@@ -3373,6 +3388,7 @@ async function handleResponses(request, response, requestUrl) {
   let clientGone = false;
   let requestedModel = "";
   let route;
+  let directResponses = false;
   let upstreamRetries;
   let upstreamStatus;
   let upstreamLatencyMs;
@@ -3455,6 +3471,9 @@ async function handleResponses(request, response, requestUrl) {
       model: route?.slug || requestedModel || undefined,
       ...activityMetadataFromHeaders(request.headers),
     });
+    directResponses = route
+      ? isDirectResponsesProvider(providerForModel(route))
+      : false;
     const compactV1 = /\/responses\/compact$/.test(requestUrl.pathname);
     // Codex remote compaction V2 uses the ordinary Responses endpoint with a
     // terminal trigger. Detect the protocol shape before route dispatch so the
@@ -3463,7 +3482,7 @@ async function handleResponses(request, response, requestUrl) {
       Array.isArray(payload.input) &&
       payload.input.at(-1)?.type === "compaction_trigger";
 
-    if (route && (compactV1 || compactV2)) {
+    if (route && !directResponses && (compactV1 || compactV2)) {
       const compaction = await handleRoutedCompaction(
         request,
         response,
@@ -3532,7 +3551,12 @@ async function handleResponses(request, response, requestUrl) {
         ...activityMetadataFromHeaders(request.headers),
       });
     };
-    if (route) {
+    if (route && directResponses) {
+      const provider = providerForModel(route);
+      target = directResponsesTarget(provider, requestUrl.pathname, requestUrl.search);
+      headers = directResponsesHeaders(request.headers);
+      routedBody = directResponsesBody(payload, route);
+    } else if (route) {
       // Resolve the selected route's search contract once, before encrypted
       // handoff normalization or any other external work. A later failover may
       // not reintroduce ambient search that this route never advertised.
@@ -3692,7 +3716,9 @@ async function handleResponses(request, response, requestUrl) {
     // live capability contract as every fallback. This catches unsupported
     // search history and sidecar changes after normalization before any
     // provider-bound bytes leave the router.
-    if (route) assertRoutedSearchContract(route, builtSearchMode, searchContract);
+    if (route && !directResponses) {
+      assertRoutedSearchContract(route, builtSearchMode, searchContract);
+    }
     let { response: upstream, retries } = await fetchWithRetry(
       target,
       {
@@ -3722,7 +3748,7 @@ async function handleResponses(request, response, requestUrl) {
     // and the error translation below both need it, and it can only be read
     // once. Nothing is relayed either way, so reading it is free.
     let failedBodyText;
-    if (route && !upstream.ok) {
+    if (route && !directResponses && !upstream.ok) {
       failedBodyText = await boundedResponseText(
         upstream,
         MAX_BUFFERED_RESPONSE_BYTES,
@@ -3775,7 +3801,25 @@ async function handleResponses(request, response, requestUrl) {
     // recorded earlier: a quota that refilled early, a limit the operator
     // raised, or a reset time the provider got wrong all end the same way, and
     // a real answer is better evidence than anything on disk.
-    if (route && upstream.ok) clearProviderCooldown(route.provider);
+    if (route && !directResponses && upstream.ok) clearProviderCooldown(route.provider);
+    // The direct bridge owns its own explicit failure vocabulary. It has not
+    // passed through LiteLLM, so translating the body as a gateway exception
+    // would erase the actionable browser/login/UI-drift error it produced.
+    if (route && directResponses && !upstream.ok) {
+      await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS);
+      recordUsageEvent({
+        model: route.slug,
+        provider: canonicalProviderId(route.provider),
+        status: upstream.status,
+        durationMs: Date.now() - startedAt,
+        responseStartMs: upstreamLatencyMs,
+      });
+      observeSubagentOutcome(request, route, upstream.status);
+      finalStatus = upstream.status;
+      activityStatus = upstream.status;
+      usageRecorded = true;
+      return;
+    }
     // Gateway error bodies leak LiteLLM's internal exception chain, which
     // reads like a router bug. Rewrite them to name the provider that failed.
     // Native traffic passes through untouched: OpenAI errors are already clear.
@@ -3842,12 +3886,12 @@ async function handleResponses(request, response, requestUrl) {
     const createResponsePipeline = (contentType) => {
       const usageObserver = new ResponseUsageTransform(contentType, {
         estimatedInputTokens:
-          ZERO_INPUT_ESTIMATE && route
+          ZERO_INPUT_ESTIMATE && route && !directResponses
             ? estimateInputTokens(routedBody, { contextWindow: route.contextWindow })
             : undefined,
       });
       const transforms = [usageObserver];
-      let envelopeCompat = route
+      let envelopeCompat = !directResponses && route
         ? zaiResponsesCompatTransform(route.provider, contentType)
         : undefined;
       // Z.ai Responses streams from GLM-5.3 can start assistant text after
@@ -3863,14 +3907,14 @@ async function handleResponses(request, response, requestUrl) {
       // LiteLLM can add blank assistant envelopes while translating either
       // Chat Completions or Messages. The factory refuses native traffic and
       // providers that already speak Responses, so those paths gain no stage.
-      const translatedToolMessageCompat = route
+      const translatedToolMessageCompat = !directResponses && route
         ? translatedToolMessageCompatTransform(providerForModel(route), contentType)
         : undefined;
       if (translatedToolMessageCompat) transforms.push(translatedToolMessageCompat);
       // Restore flattened namespace calls for routed chat-completions providers,
       // and inject missing finished-child interrupts for both routed and native
       // multi-agent parents (San Francisco uses native GPT).
-      if (route || pendingInterrupts.length > 0) {
+      if (!directResponses && (route || pendingInterrupts.length > 0)) {
         transforms.push(
           new NamespaceToolCallTransform(
             flattenedNamespaces,
@@ -3883,7 +3927,7 @@ async function handleResponses(request, response, requestUrl) {
         );
       }
       const guard =
-        route && EMPTY_COMPLETION_RETRY
+        route && !directResponses && EMPTY_COMPLETION_RETRY
           ? new EmptyCompletionGuard(contentType, {
               maxPreludeBytes: EMPTY_COMPLETION_PRELUDE_BYTES,
               maxPreludeMs: EMPTY_COMPLETION_PRELUDE_MS,
@@ -3992,7 +4036,9 @@ async function handleResponses(request, response, requestUrl) {
       // discarded attempt's staged headers are no longer authoritative even
       // when this check fails and the router writes its own local response.
       clearStagedResponseHead(response);
-      if (route) assertRoutedSearchContract(route, builtSearchMode, searchContract);
+      if (route && !directResponses) {
+        assertRoutedSearchContract(route, builtSearchMode, searchContract);
+      }
       emptyCompletionRetried = true;
       try {
         const retried = await fetchWithRetry(

--- a/src/untrusted-model-discovery.mjs
+++ b/src/untrusted-model-discovery.mjs
@@ -249,7 +249,7 @@ function validateRecordShape(record, index, maxRecordBytes) {
   if (Buffer.byteLength(serialized, "utf8") > maxRecordBytes) {
     throw new Error(`Provider model catalog record ${index} exceeds the record size limit.`);
   }
-  const id = record.id ?? record.model ?? record.upstreamId;
+  const id = record.id ?? record.model ?? record.upstreamId ?? record.slug;
   if (typeof id !== "string" || !id.trim() || id.length > 512 || /[\u0000-\u001f\u007f]/.test(id)) {
     throw new Error(`Provider model catalog record ${index} has an invalid model id.`);
   }
@@ -259,7 +259,7 @@ export function validateModelCatalogPayload(payload, {
   maxModels = MODEL_DISCOVERY_MAX_MODELS,
   maxRecordBytes = MODEL_DISCOVERY_MAX_RECORD_BYTES,
 } = {}) {
-  const data = Array.isArray(payload) ? payload : payload?.data;
+  const data = Array.isArray(payload) ? payload : payload?.data ?? payload?.models;
   if (!Array.isArray(data) || data.length > maxModels) throw new Error("Provider returned an invalid or oversized model catalog.");
   data.forEach((record, index) => validateRecordShape(record, index, maxRecordBytes));
   return data;

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -53,6 +53,7 @@ export function hasDefaultUserModelReasoning(entry) {
 // identity and routing fields always come from the provider id and the
 // discovered model id.
 const METADATA_FIELDS = new Set([
+  "displayName",
   "description",
   "contextWindow",
   "autoCompact",
@@ -94,6 +95,9 @@ function gatewaySafe(value) {
 // who serves the call and the `isFree` tag carries the price distinction.
 // Keep the exact catalog id in `upstreamModel`, where the forwarder reads it.
 export function userModelPublicId(providerId, upstreamId, metadata) {
+  if (providerId === "chatgpt-web" && String(upstreamId).startsWith("chatgpt-web/")) {
+    return String(upstreamId).slice("chatgpt-web/".length);
+  }
   if (providerId !== "orca" || metadata?.isFree !== true) return upstreamId;
   const modelId = String(upstreamId).split("/").filter(Boolean).at(-1) || String(upstreamId);
   return modelId.replace(/-free$/, "");

--- a/src/vision-bridge.mjs
+++ b/src/vision-bridge.mjs
@@ -191,7 +191,14 @@ export function supportsImageInput(model) {
 }
 
 export function visionCapableModels(models) {
-  return (Array.isArray(models) ? models : []).filter(supportsImageInput);
+  // A direct bridge is a visible, account-bound browser turn, not a generic
+  // caption backend. Its own selected route may still accept images, but it
+  // must never be recruited indirectly to read one for another provider.
+  return (Array.isArray(models) ? models : []).filter(
+    (model) =>
+      supportsImageInput(model) &&
+      PROVIDERS.get(String(model?.provider || ""))?.directResponses !== true,
+  );
 }
 
 function engineCostRank(model) {

--- a/test/chatgpt-web-provider.test.mjs
+++ b/test/chatgpt-web-provider.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test, { after } from "node:test";
+
+const root = mkdtempSync(path.join(os.tmpdir(), "chatgpt-web-provider-"));
+const userModelsPath = path.join(root, "user-models.json");
+process.env.MODEL_ROUTER_STATE_DIR = path.join(root, "state");
+process.env.MODEL_ROUTER_USER_MODELS = userModelsPath;
+delete process.env.MODEL_ROUTER_CHATGPT_WEB_BASE_URL;
+writeFileSync(userModelsPath, JSON.stringify({
+  version: 1,
+  models: [{
+    slug: "chatgpt-web/light",
+    gatewayModel: "chatgpt-web-light",
+    upstreamModel: "chatgpt-web/light",
+    provider: "chatgpt-web",
+    listed: true,
+    displayName: "ChatGPT Web — Instant",
+    description: "Test ChatGPT Web route.",
+    priority: 100,
+    reasoningLevels: [{ effort: "low", description: "Quick reasoning" }],
+    defaultEffort: "low",
+    contextWindow: 41_000,
+    autoCompact: 32_000,
+    inputModalities: ["text", "image"],
+    compHash: "chatgpt-web-light-test-v1"
+  }],
+}));
+
+after(() => rmSync(root, { recursive: true, force: true }));
+
+const {
+  directResponsesBody,
+  directResponsesHeaders,
+  directResponsesTarget,
+} = await import("../src/direct-responses-provider.mjs");
+const { modelIds } = await import("../src/model-discovery.mjs");
+const { MODEL_BY_SLUG, PROVIDERS } = await import("../src/model-registry.mjs");
+const { routedClientModels } = await import("../src/routed-client-models.mjs");
+const { userModelIdentity } = await import("../src/user-models.mjs");
+
+test("ChatGPT Web is an explicit Codex-only direct Responses provider", () => {
+  const provider = PROVIDERS.get("chatgpt-web");
+  assert.equal(provider.protocol, "openai-responses");
+  assert.equal(provider.keyless, true);
+  assert.equal(provider.directResponses, true);
+  assert.equal(provider.codexOnly, true);
+  assert.equal(provider.explicitSelection, true);
+  assert.equal(MODEL_BY_SLUG.get("chatgpt-web/light").upstreamModel, "chatgpt-web/light");
+  assert.equal(
+    userModelIdentity({ providerId: "chatgpt-web", upstreamId: "chatgpt-web/pro" }).slug,
+    "chatgpt-web/pro",
+  );
+});
+
+test("ChatGPT Web discovery accepts a Codex catalog and withholds native rows", () => {
+  const payload = {
+    models: [
+      { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol" },
+      { slug: "chatgpt-web/light", display_name: "ChatGPT Web — Instant" },
+      { slug: "chatgpt-web/high", display_name: "ChatGPT Web — High" },
+    ],
+  };
+  assert.deepEqual(modelIds(payload, PROVIDERS.get("chatgpt-web")), [
+    "chatgpt-web/high",
+    "chatgpt-web/light",
+  ]);
+});
+
+test("direct Responses requests retain Codex authority but strip account credentials", () => {
+  const provider = PROVIDERS.get("chatgpt-web");
+  const headers = directResponsesHeaders({
+    authorization: "Bearer CHATGPT_ACCOUNT_TOKEN",
+    "chatgpt-account-id": "acct-secret",
+    cookie: "session=secret",
+    "content-encoding": "zstd",
+    "content-length": "999",
+    "openai-project": "project-secret",
+    "x-oai-attestation": "attestation-secret",
+    "x-codex-turn-metadata": "turn-authority",
+    "x-openai-subagent": "review",
+  });
+  assert.equal(headers.Authorization, "Bearer local");
+  assert.equal(headers["x-codex-turn-metadata"], "turn-authority");
+  assert.equal(headers["x-openai-subagent"], "review");
+  assert.equal(headers["chatgpt-account-id"], undefined);
+  assert.equal(headers.cookie, undefined);
+  assert.equal(headers["openai-project"], undefined);
+  assert.equal(headers["x-oai-attestation"], undefined);
+  assert.equal(headers["content-encoding"], undefined);
+  assert.equal(
+    directResponsesTarget(provider, "/v1/responses/compact", "?mode=test"),
+    "http://127.0.0.1:17841/v1/responses/compact?mode=test",
+  );
+  assert.deepEqual(
+    JSON.parse(directResponsesBody(
+      { model: "chatgpt-web/light", client_metadata: { authority: "kept" } },
+      MODEL_BY_SLUG.get("chatgpt-web/light"),
+    )),
+    { model: "chatgpt-web/light", client_metadata: { authority: "kept" } },
+  );
+});
+
+test("non-Codex client publication omits ChatGPT Web routes", () => {
+  assert.ok(!routedClientModels().models.some((model) => model.slug.startsWith("chatgpt-web/")));
+});

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -871,6 +871,38 @@ test("background usage polling is conservative while manual refresh stays immedi
   assert.doesNotMatch(source, /downloadTimer = window\.setInterval\([\s\S]{0,160}refreshCore/);
 });
 
+test("provider usage reads outlive optional account refreshes", async () => {
+  const source = await readFile(new URL("../apps/control-center/electron/ipc.mjs", import.meta.url), "utf8");
+  assert.match(source, /const PROVIDER_USAGE_TIMEOUT_MS = 120_000/);
+  assert.match(
+    source,
+    /handle\("getProviderUsage"[\s\S]{0,180}\["provider-usage"\][\s\S]{0,120}PROVIDER_USAGE_TIMEOUT_MS/,
+  );
+  assert.match(
+    source,
+    /providerUsage: await runJson\([\s\S]{0,120}\["provider-usage"\][\s\S]{0,120}PROVIDER_USAGE_TIMEOUT_MS/,
+  );
+  assert.doesNotMatch(source, /\["provider-usage"\], \{ timeoutMs: 20_000 \}/);
+});
+
+test("dashboard presents traffic statistics before route and service controls", async () => {
+  const source = await readFile(new URL("../apps/control-center/src/pages/DashboardPage.tsx", import.meta.url), "utf8");
+  const positions = {
+    summary: source.indexOf('className="db-summary-grid"'),
+    traffic: source.indexOf('className="db-traffic-grid"'),
+    activity: source.indexOf("<TokenActivity"),
+    breakdown: source.indexOf('className="db-panel-grid db-dashboard-details"'),
+    events: source.indexOf('className="panel-section db-events-panel"'),
+    routes: source.indexOf("<RouteDashboardPanel"),
+    health: source.indexOf("<ServiceHealthPanel"),
+  };
+  assert.ok(Object.values(positions).every((position) => position >= 0), "every dashboard section should be present");
+  assert.deepEqual(
+    Object.entries(positions).sort((left, right) => left[1] - right[1]).map(([name]) => name),
+    ["summary", "traffic", "activity", "breakdown", "events", "routes", "health"],
+  );
+});
+
 test("preload exposes only the named control operations", async () => {
   const source = await readFile(new URL("../apps/control-center/electron/preload.cjs", import.meta.url), "utf8");
   for (const method of [

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -42,6 +42,7 @@ const {
   defaultUserModelDescription,
   hasDefaultUserModelReasoning,
   userModelEntry,
+  userModelIdentity,
 } = await import("../src/user-models.mjs");
 process.argv = savedArgv;
 process.exitCode = 0;
@@ -123,6 +124,68 @@ test("OpenCode curation keeps each endpoint family on its documented protocol", 
     }),
     "opencode-go-responses",
   );
+});
+
+test("ChatGPT Web curation keeps the upstream slug and immutable account effort", () => {
+  assert.deepEqual(curationProviderIds("chatgpt-web"), ["chatgpt-web"]);
+  assert.equal(
+    userModelIdentity({ providerId: "chatgpt-web", upstreamId: "chatgpt-web/pro" }).slug,
+    "chatgpt-web/pro",
+  );
+  assert.deepEqual(curatedModelReasoningLevels("chatgpt-web", "chatgpt-web/light"), ["low"]);
+  assert.deepEqual(curatedModelReasoningLevels("chatgpt-web", "chatgpt-web/pro"), ["ultra"]);
+  assert.equal(parseEfforts("ultra").defaultEffort, "ultra");
+});
+
+test("ChatGPT Web curation preserves its live Codex catalog metadata", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "curate-chatgpt-web-"));
+  const file = path.join(dir, "user-models.json");
+  const fixture = path.join(dir, "models.json");
+  writeFileSync(fixture, JSON.stringify({
+    models: [
+      { slug: "gpt-5.6-sol", display_name: "Native row must stay out" },
+      {
+        slug: "chatgpt-web/pro",
+        display_name: "ChatGPT Web — Pro",
+        context_window: 112_193,
+        input_modalities: ["text", "image"],
+      },
+    ],
+  }));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(root, "src", "curate-models.mjs"),
+        "chatgpt-web",
+        "--models",
+        "chatgpt-web/pro",
+        "--fixture",
+        fixture,
+        "--no-apply",
+      ],
+      {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          MODEL_ROUTER_STATE_DIR: path.join(dir, "state"),
+          MODEL_ROUTER_USER_MODELS: file,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    const [model] = JSON.parse(readFileSync(file, "utf8")).models;
+    assert.equal(model.slug, "chatgpt-web/pro");
+    assert.equal(model.upstreamModel, "chatgpt-web/pro");
+    assert.equal(model.displayName, "ChatGPT Web — Pro");
+    assert.equal(model.contextWindow, 112_193);
+    assert.deepEqual(model.inputModalities, ["text", "image"]);
+    assert.deepEqual(model.reasoningLevels, [{ effort: "ultra", description: "Pro reasoning" }]);
+    assert.equal(model.defaultEffort, "ultra");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test("Command Code curation accepts only its exact certified Chat and Messages routes", () => {

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -411,6 +411,14 @@ test("rankFailoverCandidates returns nothing rather than something unsuitable", 
   assert.deepEqual(rankFailoverCandidates(undefined, { from: FROM }), []);
 });
 
+test("rankFailoverCandidates never turns a failure into a browser-automation turn", () => {
+  const browser = model("chatgpt-web/light", "chatgpt-web", { contextWindow: 41_000 });
+  assert.deepEqual(
+    rankFailoverCandidates([browser], { from: FROM, chain: [browser.slug] }),
+    [],
+  );
+});
+
 test("a named chain is used verbatim, minus entries this build cannot route to", () => {
   const ranked = rankFailoverCandidates(
     [

--- a/test/panel-ui.test.mjs
+++ b/test/panel-ui.test.mjs
@@ -372,6 +372,21 @@ test("the macOS tray tool-result-aging switch mirrors the same off default", () 
   assert.doesNotMatch(source, /toolResultAging\?\.enabled \?\? true/);
 });
 
+test("the macOS tray panel follows the system appearance", () => {
+  const source = readFileSync(
+    path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),
+    "utf8",
+  );
+  const trayStart = source.indexOf("private struct TrayView");
+  const trayEnd = source.indexOf("private struct ProviderSetupRow", trayStart);
+  assert.ok(trayStart > 0 && trayEnd > trayStart, "TrayView should remain readable");
+  assert.doesNotMatch(
+    source.slice(trayStart, trayEnd),
+    /\.preferredColorScheme\(\.dark\)/,
+    "the menu-bar panel must not override the operator's macOS appearance",
+  );
+});
+
 test("the macOS tray provider toggle uses the atomic selection command", () => {
   const swift = readFileSync(
     path.join(root, "apps", "macos", "ModelRouterTray", "Sources", "ModelRouterTrayApp.swift"),

--- a/test/provider-catalogs.test.mjs
+++ b/test/provider-catalogs.test.mjs
@@ -11,8 +11,8 @@ import {
 
 test("every selectable provider remains a canonical UI family", () => {
   const canonical = [...PROVIDERS.values()].filter((provider) => !provider.variantOf);
-  assert.equal(canonical.length, 40);
-  assert.equal(PROVIDERS.size, 45);
+  assert.equal(canonical.length, 41);
+  assert.equal(PROVIDERS.size, 46);
 });
 
 test("catalog capability comes from backend provider definitions", () => {
@@ -22,6 +22,7 @@ test("catalog capability comes from backend provider definitions", () => {
   assert.equal(providerCatalogKind(PROVIDERS.get("grok-oauth")), undefined);
   assert.equal(providerCatalogKind(PROVIDERS.get("local")), undefined);
   assert.equal(providerCatalogKind(PROVIDERS.get("lmstudio")), undefined);
+  assert.equal(providerCatalogKind(PROVIDERS.get("chatgpt-web")), "models-endpoint");
   assert.equal(providerCatalogKind(PROVIDERS.get("custom")), undefined);
 });
 

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -67,6 +67,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
     // credential to configure and they are always available. Everything else
     // has to authenticate before it counts.
     assert.deepEqual(configuredProviderIds(), [
+      "chatgpt-web",
       "custom",
       "kilo-free",
       "lmstudio",
@@ -78,6 +79,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
     delete process.env.KIMI_API_KEY;
     writeProviderCredential("deepseek", "TEST_DEEPSEEK_SELECTION_KEY");
     assert.deepEqual(configuredProviderIds(), [
+      "chatgpt-web",
       "custom",
       "deepseek",
       "kilo-free",

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -464,6 +464,106 @@ test("plain Codex provider routes accept the caller key as a bearer token", asyn
   }
 });
 
+test("ChatGPT Web routes bypass the gateway and preserve the native Codex envelope", async () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "chatgpt-web-direct-route-"));
+  const userModelsPath = path.join(testRoot, "user-models.json");
+  writeFileSync(userModelsPath, JSON.stringify({
+    version: 1,
+    models: [{
+      slug: "chatgpt-web/light",
+      gatewayModel: "chatgpt-web-light",
+      upstreamModel: "chatgpt-web/light",
+      provider: "chatgpt-web",
+      listed: true,
+      displayName: "ChatGPT Web — Instant",
+      description: "Test ChatGPT Web direct Responses route.",
+      priority: 100,
+      reasoningLevels: [{ effort: "low", description: "Quick reasoning" }],
+      defaultEffort: "low",
+      contextWindow: 41_000,
+      autoCompact: 32_000,
+      inputModalities: ["text", "image"],
+      compHash: "chatgpt-web-light-routing-test-v1"
+    }],
+  }));
+  const bridgeRequests = [];
+  const exactTurnResponse = '{ "id": "resp_chatgpt_web_test", "object": "response", "status": "completed", "model": "chatgpt-web/light", "output": [], "usage": { "input_tokens": 12, "output_tokens": 3, "total_tokens": 15 } }\n';
+  const bridge = await mockServer(async (request, response) => {
+    const body = await bodyJson(request);
+    bridgeRequests.push({ url: request.url, headers: request.headers, body });
+    if (request.url.startsWith("/v1/responses/compact")) {
+      json(response, 409, {
+        error: {
+          type: "invalid_request_error",
+          message: "browser bridge retained-source compaction is unavailable",
+        },
+      });
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(exactTurnResponse);
+  });
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(request.url);
+    json(response, 200, { object: "response", status: "completed", output: [] });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_STATE_DIR: path.join(testRoot, "state"),
+    MODEL_ROUTER_USER_MODELS: userModelsPath,
+    MODEL_ROUTER_CHATGPT_WEB_BASE_URL: `http://127.0.0.1:${bridge.port}/v1`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const turnPayload = {
+      model: "chatgpt-web/light",
+      input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "hello" }] }],
+      tools: [{ type: "function", name: "workspace_tool", parameters: { type: "object" } }],
+      client_metadata: { "x-codex-turn-metadata": "body-turn-authority" },
+      stream: false,
+    };
+    const turn = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CHATGPT_SESSION_MUST_NOT_LEAK",
+        "Content-Type": "application/json",
+        "X-Codex-Turn-Metadata": "header-turn-authority",
+      },
+      body: JSON.stringify(turnPayload),
+    });
+    const turnText = await turn.text();
+    assert.equal(turn.status, 200, turnText);
+    assert.equal(turnText, exactTurnResponse);
+    assert.equal(bridgeRequests.length, 1);
+    assert.equal(bridgeRequests[0].url, "/v1/responses");
+    assert.equal(bridgeRequests[0].headers.authorization, "Bearer local");
+    assert.equal(bridgeRequests[0].headers["x-codex-turn-metadata"], "header-turn-authority");
+    assert.deepEqual(bridgeRequests[0].body, turnPayload);
+    assert.deepEqual(gatewayRequests, []);
+
+    const compact = await fetch(`${routerBase(routerPort)}/responses/compact`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...turnPayload, stream: false }),
+    });
+    assert.equal(compact.status, 409);
+    assert.match(await compact.text(), /retained-source compaction is unavailable/);
+    assert.equal(bridgeRequests.length, 2, "a failed browser compaction was sent more than once");
+    assert.equal(bridgeRequests[1].url, "/v1/responses/compact");
+    assert.deepEqual(gatewayRequests, []);
+  } finally {
+    await stopChild(router);
+    await closeServer(bridge.server);
+    await closeServer(gateway.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("plain signed Codex routes accept the current Codex API key", async () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "signed-codex-api-key-route-"));
   const authPath = path.join(testRoot, "auth.json");

--- a/test/untrusted-model-discovery.test.mjs
+++ b/test/untrusted-model-discovery.test.mjs
@@ -170,6 +170,17 @@ test("the response schema has bounded records and safe model identities", async 
   assert.deepEqual(result.data, [{ id: "provider/model" }]);
 });
 
+test("a bounded Codex model catalog is accepted for the local ChatGPT Web bridge", () => {
+  assert.deepEqual(
+    validateModelCatalogPayload({ models: [{ slug: "chatgpt-web/light" }] }),
+    [{ slug: "chatgpt-web/light" }],
+  );
+  assert.throws(
+    () => validateModelCatalogPayload({ models: [{ slug: "chatgpt-web/\u0000bad" }] }),
+    /invalid model id/,
+  );
+});
+
 test("explicitly configured private providers remain available", async () => {
   const result = await fetchUntrustedModelCatalog("http://127.0.0.1:8000/models", {
     allowPrivate: true,

--- a/test/vision-bridge.test.mjs
+++ b/test/vision-bridge.test.mjs
@@ -61,6 +61,14 @@ const FLAGSHIP_VISION = {
   inputModalities: ["text", "image"],
   priority: 1,
 };
+const CHATGPT_WEB_VISION = {
+  slug: "chatgpt-web/light",
+  displayName: "ChatGPT Web — Instant",
+  provider: "chatgpt-web",
+  gatewayModel: "chatgpt-web-light",
+  inputModalities: ["text", "image"],
+  priority: 0,
+};
 
 function userTurn(parts) {
   return [{ type: "message", role: "user", content: parts }];
@@ -78,6 +86,17 @@ test("a cheap vision tier outranks a higher-priority flagship", () => {
   assert.deepEqual(
     ranked.map((model) => model.slug),
     [FLASH_VISION.slug, FLAGSHIP_VISION.slug],
+  );
+});
+
+test("browser-automation routes never become indirect vision engines", () => {
+  assert.deepEqual(rankVisionEngines([CHATGPT_WEB_VISION, FLASH_VISION]), [FLASH_VISION]);
+  assert.equal(
+    resolveVisionEngine(
+      () => [CHATGPT_WEB_VISION],
+      { enabled: true, engine: CHATGPT_WEB_VISION.slug },
+    ),
+    undefined,
   );
 });
 


### PR DESCRIPTION
Four commits had accumulated on a local `main` and were never pushed or
opened as a PR. They are extracted here unchanged, rebased onto current
`main`, and applied without conflicts.

- `feat: integrate ChatGPT Web sidecar provider`
- `style: distinguish local fallback points in usage charts`
- `fix: keep provider usage reads alive through account refreshes`
- `fix(macOS): follow system appearance in tray panel`

Two further commits from the same local branch — `Fix Claude setup from
desktop PATH` and `fix(cursor): publish BYOK-safe effort aliases` — are
**not** included. They build on the `ipc.mjs` rewrite in #555 and on
#547/#538, so they cannot be applied to `main` until those land. They are
parked on the `codex/main-local-snapshot` branch and will be rebased once
their dependencies merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)