### PR TITLE
fix: cool down a provider that named its reset in the body

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1652,7 +1652,12 @@ purpose; several of them exist because the obvious wider version is wrong.
    `canonicalProviderId`: protocol variants share one credential and therefore
    one quota, so a sibling is guaranteed to fail the same way.
 5. **A cooldown is only ever a window the provider itself named.** Derived from
-   `Retry-After` and `cooldownUntil`, never invented, capped at six hours, and
+   `Retry-After`, `cooldownUntil`, or a wall-clock reset the provider stated in
+   its own refusal body — Z.ai's Coding Plan sends "Your limit will reset at
+   2026-09-01 21:32:15" and no header, and without reading it an exhausted plan
+   is re-attempted once per turn for the whole window. A bare stamp carries no
+   zone, so it is read as local time and ignored outright if it has already
+   passed. Never invented, capped at six hours, and
    cleared on that provider's next successful answer. A provider under cooldown
    is skipped before dispatch, which is the entire saving — so a cooldown that
    is wrong strands the operator's chosen model, and that is why nothing may

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1656,8 +1656,12 @@ purpose; several of them exist because the obvious wider version is wrong.
    its own refusal body — Z.ai's Coding Plan sends "Your limit will reset at
    2026-09-01 21:32:15" and no header, and without reading it an exhausted plan
    is re-attempted once per turn for the whole window. A bare stamp carries no
-   zone, so it is read as local time and ignored outright if it has already
-   passed. Never invented, capped at six hours, and
+   zone, so it is resolved to the **earliest** instant any real UTC offset
+   allows that has not already passed, and ignored outright when no offset can
+   place it ahead. Waking early costs one refusal; waking late withholds a model
+   the operator is paying for, and reading a zoneless stamp as local time does
+   exactly that for anyone whose clock does not match the plan's. Never
+   invented, capped at six hours, and
    cleared on that provider's next successful answer. A provider under cooldown
    is skipped before dispatch, which is the entire saving — so a cooldown that
    is wrong strands the operator's chosen model, and that is why nothing may

--- a/src/model-failover.mjs
+++ b/src/model-failover.mjs
@@ -109,13 +109,17 @@ export function classifyRoutedFailure({ status, bodyText, retryAfterSeconds, now
     // is not a reason to invent a window: the turn still fails over, and the
     // next turn tries the operator's chosen model again, which is the honest
     // behaviour when nothing is known.
-    return {
-      swap: true,
-      reason: "out_of_usage",
-      ...(Number.isFinite(retryAfter) && retryAfter > 0
-        ? { until: cappedUntil(at, retryAfter * 1_000) }
-        : {}),
-    };
+    //
+    // Some do say, in the body rather than a header, and that sentence is the
+    // provider naming its own window exactly as `Retry-After` would. Reading it
+    // is what stops an exhausted plan from being re-attempted once per turn for
+    // the whole window -- observed as 225 quota refusals against one Z.ai
+    // Coding Plan window, each one a full round trip before the failover.
+    const until =
+      Number.isFinite(retryAfter) && retryAfter > 0
+        ? cappedUntil(at, retryAfter * 1_000)
+        : providerNamedResetUntil(bodyText, at);
+    return { swap: true, reason: "out_of_usage", ...(until ? { until } : {}) };
   }
 
   if (code === 429 && Number.isFinite(retryAfter) && retryAfter > MIN_RATE_LIMIT_COOLDOWN_SECONDS) {
@@ -127,6 +131,55 @@ export function classifyRoutedFailure({ status, bodyText, retryAfterSeconds, now
 
 function cappedUntil(at, durationMs) {
   return new Date(at + Math.min(durationMs, MAX_COOLDOWN_MS)).toISOString();
+}
+
+// Z.ai's Coding Plan refuses an exhausted window with code 1308 and the
+// sentence "Usage limit reached for 5 hour. Your limit will reset at
+// 2026-09-01 21:32:15", carrying no `Retry-After` at all. Narrow on purpose:
+// only a wall-clock stamp immediately after "reset at" counts, so prose that
+// merely mentions a reset never becomes a window.
+const PROVIDER_NAMED_RESET = /\breset(?:s)?\s+at\s+(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})/i;
+
+// Every real UTC offset, in minutes, including the quarter-hour ones. The
+// provider's stamp carries no zone, so this is the set of instants it could
+// possibly denote.
+const UTC_OFFSET_MINUTES = Object.freeze([
+  -720, -660, -600, -570, -540, -480, -420, -360, -300, -240, -210, -180, -120, -60, 0, 60, 120,
+  180, 210, 240, 270, 300, 330, 345, 360, 390, 420, 480, 525, 540, 570, 600, 630, 660, 720, 765,
+  780, 840,
+]);
+
+// Which instant a zoneless stamp names depends on a zone neither side states.
+// Reading it as this host's local time is right only when the operator's clock
+// happens to match the plan's, and wrong by up to a day for everyone else --
+// in the direction that stops the router dispatching to a model that is in fact
+// available again.
+//
+// The two errors are not symmetric. Waking early costs one extra refusal and
+// re-records the window. Waking late withholds a model the operator chose and
+// is paying for, for as long as the misreading runs. So take the *earliest*
+// instant the stamp could denote that has not already passed: the true reset is
+// always one of these candidates, so the window can never outlast it.
+//
+// This also makes the reading independent of the host's own timezone, which is
+// why these assertions hold wherever `TZ` is set.
+//
+// A stamp with no future candidate at all records nothing rather than a window
+// in the past. `cappedUntil` keeps the far side bounded by the same six hours
+// every other source is held to.
+function providerNamedResetUntil(bodyText, at) {
+  if (typeof bodyText !== "string") return undefined;
+  const match = PROVIDER_NAMED_RESET.exec(bodyText);
+  if (!match) return undefined;
+  const wallMs = Date.parse(`${match[1]}T${match[2]}Z`);
+  if (!Number.isFinite(wallMs)) return undefined;
+  let earliest;
+  for (const offsetMinutes of UTC_OFFSET_MINUTES) {
+    const instant = wallMs - offsetMinutes * 60_000;
+    if (instant <= at) continue;
+    if (earliest === undefined || instant < earliest) earliest = instant;
+  }
+  return earliest === undefined ? undefined : cappedUntil(at, earliest - at);
 }
 
 // -- how long an empty provider is believed ----------------------------------

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -32,6 +32,10 @@ function quotaBody(message) {
   return JSON.stringify({ error: { message } });
 }
 
+function quotaResetBody(stamp) {
+  return quotaBody(`Usage limit reached for 5 hour. Your limit will reset at ${stamp}.`);
+}
+
 // -- classification ----------------------------------------------------------
 
 test("classifyRoutedFailure swaps on exhausted usage across provider dialects", () => {
@@ -84,6 +88,79 @@ test("classifyRoutedFailure recognizes the observed Z.ai five-hour window messag
     status: 429,
     bodyText: quotaBody(
       "Usage limit reached for 5 hour. Your limit will reset at 2026-08-21 04:40:42.",
+    ),
+    now: NOW,
+  });
+  // This body names a reset nearly a week out, so the window it produces is the
+  // shared six-hour cap rather than the stamp itself.
+  assert.deepEqual(verdict, {
+    swap: true,
+    reason: "out_of_usage",
+    until: new Date(NOW + MAX_COOLDOWN_MS).toISOString(),
+  });
+});
+
+test("classifyRoutedFailure honours a reset time the provider named in the body", () => {
+  // Z.ai sends no `Retry-After`; the window is a sentence. Without this the
+  // exhausted plan was re-attempted on every turn for the whole window.
+  // NOW is 12:00Z, so the earliest zone in which "13:00" is still ahead is
+  // UTC+0 itself.
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaResetBody("2026-08-15 13:00:00"),
+    now: NOW,
+  });
+  assert.deepEqual(verdict, {
+    swap: true,
+    reason: "out_of_usage",
+    until: "2026-08-15T13:00:00.000Z",
+  });
+});
+
+test("classifyRoutedFailure never waits longer than the earliest zone the stamp allows", () => {
+  // The stamp names no zone. Read as this host's local time it could sit most
+  // of a day out and withhold a model that is already available again -- the
+  // one error worth engineering against, since waking early only costs a
+  // second refusal. "20:00" against a 12:00Z now is soonest in UTC+7, an hour
+  // away, and that is the window recorded no matter where the host runs.
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaResetBody("2026-08-15 20:00:00"),
+    now: NOW,
+  });
+  assert.equal(verdict.until, "2026-08-15T13:00:00.000Z");
+  assert.ok(
+    Date.parse(verdict.until) - NOW <= 8 * 60 * 60_000,
+    "a zoneless stamp must never strand a model for the full offset spread",
+  );
+});
+
+test("classifyRoutedFailure prefers Retry-After over a reset named in the body", () => {
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaResetBody("2026-08-15 13:00:00"),
+    retryAfterSeconds: 300,
+    now: NOW,
+  });
+  assert.equal(verdict.until, new Date(NOW + 300_000).toISOString());
+});
+
+test("classifyRoutedFailure ignores a named reset no zone can place ahead", () => {
+  // Two days behind `now` is past in every offset, so there is no window to
+  // record and the model stays reachable.
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaResetBody("2026-08-13 00:00:00"),
+    now: NOW,
+  });
+  assert.deepEqual(verdict, { swap: true, reason: "out_of_usage" });
+});
+
+test("classifyRoutedFailure reads no window from prose that never names a time", () => {
+  const verdict = classifyRoutedFailure({
+    status: 429,
+    bodyText: quotaBody(
+      "usage limit reached for your GLM Coding Plan. Your limit will reset at the top of the hour.",
     ),
     now: NOW,
   });


### PR DESCRIPTION
## Problem

Z.ai's GLM Coding Plan refuses an exhausted window with `429` code `1308`:

> Usage limit reached for 5 hour. Your limit will reset at 2026-09-01 21:32:15

It sends **no `Retry-After` header** — the window is stated in the body. Cooldowns
were derived from that header alone, so nothing was ever recorded and
`provider-cooldowns.json` stayed `{}`. Every turn re-attempted the exhausted
model, paid the 429, and failed over again.

Observed in one live router log: **225 quota refusals against a single window**,
one of them stalling a turn for **305 seconds** against a 4.7s upstream response.

## Change

`classifyRoutedFailure` now falls back to a reset time the provider stated in its
own refusal body when no `Retry-After` is present. This stays inside the AGENTS.md
rule that *"a cooldown is only ever a window the provider itself named"* — the
source is the provider's own sentence, not a guess.

### The zoneless stamp

The stamp names no timezone, and the two ways of getting that wrong are not
symmetric:

- **Waking early** costs one extra refusal, and the window is re-recorded.
- **Waking late** withholds a model the operator chose and is paying for.

Reading it as the host's local time does the second thing to every operator whose
clock does not match the plan's — most of a day out at the extremes, clamped to
the six-hour cap, against a reset that may be minutes away.

So the stamp resolves to the **earliest instant any real UTC offset allows that
has not already passed**. The true reset is always one of those candidates, so a
recorded window can never outlast it. This also makes the reading independent of
the host's timezone.

### Other guards

- `Retry-After` still wins when both are present.
- The match is narrow: only a wall-clock stamp directly after `reset at`, so
  prose merely mentioning a reset never becomes a window.
- A stamp no offset can place ahead records nothing.
- The same six-hour `MAX_COOLDOWN_MS` cap as every other source.

## Effect

The first 429 parks the provider until its stated reset; later turns skip
straight to the fallback. No repeated quota round trips, no multi-minute stall.

## Tests

Six cases in `test/model-failover.test.mjs`, including one asserting a zoneless
stamp can never strand a model across the offset spread. Verified identical under
`TZ=UTC`, `America/Los_Angeles`, `Asia/Shanghai`, `Pacific/Kiritimati` (+14) and
`Asia/Kathmandu` (+5:45).

The existing test asserting that exact Z.ai message produces *no* window is
updated — that was the behavior being fixed. Its stamp is nearly a week out, so
it now covers the cap.

Full suite: 3127 tests, 3107 pass, 0 fail. `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)