### PR TITLE
Fix Homebrew Core post-install serialization

### DIFF
--- a/Formula/codex-router.rb
+++ b/Formula/codex-router.rb
@@ -617,9 +617,8 @@ class CodexRouter < Formula
 
     # bin/codex-router deliberately refuses "install": a packaged install has
     # no writable checkout to rewrite, so it must never be a user-facing verb.
-    # post_install still legitimately needs the installer after brew upgrade,
-    # so it gets its own private entry point rather than a hole in the
-    # dispatcher.
+    # Upgrade reconciliation still legitimately needs the installer, so it
+    # gets its own private entry point rather than a hole in the dispatcher.
     (libexec/"packaged-install").write <<~SH
       #!/bin/sh
       source_root=$(CDPATH= cd -- "#{opt_libexec}" && pwd -P)
@@ -630,20 +629,34 @@ class CodexRouter < Formula
       exec "$source_root/bin/install" "$@"
     SH
     chmod 0755, libexec/"packaged-install"
+
+    # Official Homebrew taps require serialisable post_install_steps instead of
+    # arbitrary Ruby. Keep the manifest-dependent decision in a private helper
+    # and let the declarative step runner invoke it after install or upgrade.
+    (libexec/"packaged-post-install").write <<~SH
+      #!/bin/sh
+      state_root="${MODEL_ROUTER_STATE_DIR:-${CODEX_ROUTER_STATE_DIR:-${KIMI_CODEX_STATE_DIR:-$HOME/.codex/codex-router}}}"
+      manifest_path="$state_root/install-manifest.json"
+      [ -f "$manifest_path" ] || exit 0
+
+      package_manager=$("#{formula_opt_bin("node")}/node" --input-type=module -e '
+        import { readFileSync } from "node:fs";
+        const manifest = JSON.parse(readFileSync(process.argv[1], "utf8"));
+        process.stdout.write(manifest?.current?.packageManager || "");
+      ' "$manifest_path" 2>/dev/null) || {
+        printf '%s\n' 'Warning: Existing Codex Router install manifest is invalid; run `codex-router setup`.' >&2
+        exit 0
+      }
+      [ "$package_manager" = homebrew ] || exit 0
+
+      helper_root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+      exec "$helper_root/packaged-install"
+    SH
+    chmod 0755, libexec/"packaged-post-install"
   end
 
-  def post_install
-    state_root = ENV["MODEL_ROUTER_STATE_DIR"] || ENV["CODEX_ROUTER_STATE_DIR"] ||
-                 ENV["KIMI_CODEX_STATE_DIR"] || (Pathname(Dir.home)/".codex/codex-router")
-    manifest_path = Pathname(state_root)/"install-manifest.json"
-    return unless manifest_path.exist?
-
-    manifest = JSON.parse(manifest_path.read)
-    return if manifest.dig("current", "packageManager") != "homebrew"
-
-    system libexec/"packaged-install"
-  rescue JSON::ParserError
-    opoo "Existing Codex Router install manifest is invalid; run `codex-router setup`."
+  post_install_steps do
+    run "packaged-post-install", base: :libexec
   end
 
   def caveats

--- a/packaging/homebrew/check-core-readiness.sh
+++ b/packaging/homebrew/check-core-readiness.sh
@@ -6,6 +6,7 @@ formula_path="$source_root/Formula/codex-router.rb"
 tap_name="local/codex-router-readiness"
 install_formula=false
 installed_by_check=false
+official_probe_root=""
 
 case "${1:-}" in
   "") ;;
@@ -31,6 +32,9 @@ cleanup() {
     brew uninstall "$tap_name/codex-router" >/dev/null 2>&1 || true
   fi
   brew untap "$tap_name" >/dev/null 2>&1 || true
+  if [ -n "$official_probe_root" ]; then
+    rm -rf -- "$official_probe_root"
+  fi
 }
 trap cleanup EXIT
 trap 'exit 129' HUP
@@ -41,8 +45,19 @@ brew tap-new --no-git "$tap_name" >/dev/null
 tap_root=$(brew --repository "$tap_name")
 cp "$formula_path" "$tap_root/Formula/codex-router.rb"
 
+# Homebrew applies additional formula rules only when the path belongs to an
+# official tap. The temporary third-party tap below is still needed for install
+# and audit commands, but it cannot catch those rules by itself. Mirror the
+# formula into an isolated official-looking path so local checks exercise the
+# same style policy as homebrew/core CI.
+official_probe_root=$(mktemp -d "${TMPDIR:-/tmp}/codex-router-homebrew-core.XXXXXX")
+official_formula_dir="$official_probe_root/Taps/homebrew/homebrew-core/Formula/c"
+mkdir -p "$official_formula_dir"
+cp "$formula_path" "$official_formula_dir/codex-router.rb"
+
+brew style "$official_formula_dir/codex-router.rb"
 brew style "$tap_root/Formula/codex-router.rb"
-brew audit --new --formula "$tap_name/codex-router"
+brew audit --strict --new --online --formula "$tap_name/codex-router"
 
 if [ "$install_formula" = true ]; then
   if brew list --formula codex-router >/dev/null 2>&1; then

--- a/packaging/homebrew/generate-formula.mjs
+++ b/packaging/homebrew/generate-formula.mjs
@@ -335,9 +335,8 @@ ${exclusionComment}${resourceBlocks}
 
     # bin/codex-router deliberately refuses "install": a packaged install has
     # no writable checkout to rewrite, so it must never be a user-facing verb.
-    # post_install still legitimately needs the installer after brew upgrade,
-    # so it gets its own private entry point rather than a hole in the
-    # dispatcher.
+    # Upgrade reconciliation still legitimately needs the installer, so it
+    # gets its own private entry point rather than a hole in the dispatcher.
     (libexec/"packaged-install").write <<~SH
       #!/bin/sh
       source_root=$(CDPATH= cd -- "#{opt_libexec}" && pwd -P)
@@ -348,20 +347,34 @@ ${exclusionComment}${resourceBlocks}
       exec "$source_root/bin/install" "$@"
     SH
     chmod 0755, libexec/"packaged-install"
+
+    # Official Homebrew taps require serialisable post_install_steps instead of
+    # arbitrary Ruby. Keep the manifest-dependent decision in a private helper
+    # and let the declarative step runner invoke it after install or upgrade.
+    (libexec/"packaged-post-install").write <<~SH
+      #!/bin/sh
+      state_root="\${MODEL_ROUTER_STATE_DIR:-\${CODEX_ROUTER_STATE_DIR:-\${KIMI_CODEX_STATE_DIR:-$HOME/.codex/codex-router}}}"
+      manifest_path="$state_root/install-manifest.json"
+      [ -f "$manifest_path" ] || exit 0
+
+      package_manager=$("#{formula_opt_bin("node")}/node" --input-type=module -e '
+        import { readFileSync } from "node:fs";
+        const manifest = JSON.parse(readFileSync(process.argv[1], "utf8"));
+        process.stdout.write(manifest?.current?.packageManager || "");
+      ' "$manifest_path" 2>/dev/null) || {
+        printf '%s\\n' 'Warning: Existing Codex Router install manifest is invalid; run \`codex-router setup\`.' >&2
+        exit 0
+      }
+      [ "$package_manager" = homebrew ] || exit 0
+
+      helper_root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+      exec "$helper_root/packaged-install"
+    SH
+    chmod 0755, libexec/"packaged-post-install"
   end
 
-  def post_install
-    state_root = ENV["MODEL_ROUTER_STATE_DIR"] || ENV["CODEX_ROUTER_STATE_DIR"] ||
-                 ENV["KIMI_CODEX_STATE_DIR"] || (Pathname(Dir.home)/".codex/codex-router")
-    manifest_path = Pathname(state_root)/"install-manifest.json"
-    return unless manifest_path.exist?
-
-    manifest = JSON.parse(manifest_path.read)
-    return if manifest.dig("current", "packageManager") != "homebrew"
-
-    system libexec/"packaged-install"
-  rescue JSON::ParserError
-    opoo "Existing Codex Router install manifest is invalid; run \`codex-router setup\`."
+  post_install_steps do
+    run "packaged-post-install", base: :libexec
   end
 
   def caveats

--- a/test/homebrew-formula.test.mjs
+++ b/test/homebrew-formula.test.mjs
@@ -168,13 +168,21 @@ test("the generated formula owns upgrades and preserves one-time setup", () => {
   // print the wrong usage. It must go through the packaged dispatcher.
   assert.match(formula, /exec "\$source_root\/bin\/codex-router" "\$@"/);
   assert.doesNotMatch(formula, /bin\/model-router" codex/);
-  // bin/codex-router refuses `install` on purpose, so post_install must not
-  // reach the installer through the dispatcher -- that pairing would break
-  // every `brew upgrade` the moment the shim was repointed.
-  assert.match(formula, /system libexec\/"packaged-install"/);
+  // bin/codex-router refuses `install` on purpose, so upgrade reconciliation
+  // must not reach the installer through the dispatcher -- that pairing would
+  // break every `brew upgrade` the moment the shim was repointed.
   assert.doesNotMatch(formula, /system bin\/"codex-router", "install"/);
   assert.match(formula, /exec "\$source_root\/bin\/install" "\$@"/);
-  assert.match(formula, /manifest\.dig\("current", "packageManager"\) != "homebrew"/);
+  // Official Homebrew taps reject arbitrary Ruby post_install methods. The
+  // declarative step invokes a private helper that retains the existing
+  // manifest gate and warning without putting Ruby logic in the formula hook.
+  assert.doesNotMatch(formula, /^\s*def post_install\b/m);
+  assert.match(formula, /post_install_steps do/);
+  assert.match(formula, /run "packaged-post-install", base: :libexec/);
+  assert.match(formula, /manifest\?\.current\?\.packageManager/);
+  assert.match(formula, /\[ "\$package_manager" = homebrew \] \|\| exit 0/);
+  assert.match(formula, /exec "\$helper_root\/packaged-install"/);
+  assert.match(formula, /install manifest is invalid/);
   assert.match(formula, /codex-router setup --guided/);
   assert.match(formula, /router and CLI only/);
   assert.match(formula, /does not build or\s+download the Electron Control Center/);


### PR DESCRIPTION
Official Homebrew taps require serialisable `post_install_steps` rather than
arbitrary Ruby in `post_install`. The formula still used a Ruby `post_install`
block that read the install manifest and shelled out, which Homebrew Core will
not accept.

Move the manifest-dependent decision into a private `packaged-post-install`
helper and let the declarative step runner invoke it after install or upgrade.
The existing rule that `bin/codex-router` never exposes `install` as a
user-facing verb is preserved — upgrade reconciliation keeps its own private
entry point rather than opening a hole in the dispatcher.

An invalid manifest still warns and exits zero instead of failing the install.

### Provenance

Recovered from a local branch that was never pushed. Every other commit across
those local branches was verified as already present in `main` — applied against
current `main`, this was the only one still missing.

### Verification

`test/homebrew-formula.test.mjs` 5 pass 0 fail. Full suite 3122 tests, 3102 pass,
0 fail. `npm run check` clean.

Related to the Homebrew Core submission work in #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)