### PR TITLE
fix: decompress request bodies off the event loop and refuse oversize zstd frames early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Request bodies are decompressed off the event loop, and an oversize zstd
+  frame is refused from its header.** Codex zstd-compresses every request, so
+  the router inflated a buffer that grows with the conversation on the thread
+  serving every other request, through the one-shot synchronous decoder. That
+  path is the one implicated in an intermittent native abort on Windows
+  (#465: exit `0xC0000409` with no JavaScript frame, always late in a long
+  session, always right after a successful turn), which took every listener
+  down with it. The router now reads the size a Zstandard frame declares and
+  answers 413 before any native decoder runs when it exceeds the decode cap,
+  and inflates everything else through the asynchronous decoder under the same
+  cap. The crash has not been reproduced outside Windows, so this is
+  defensive hardening rather than a confirmed fix; the issue stays open for a
+  crash dump.
 - **Antigravity OAuth now uses an operator-owned, fail-closed sign-in.** The
   router requires one matching Google Desktop-app client ID/secret pair,
   collects it through an ephemeral IPv4 loopback listener, and stores the pair

--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -547,6 +547,38 @@ function readWithAbort(reader, signal) {
   });
 }
 
+// The decompressed size a Zstandard frame header declares, or undefined when
+// the frame omits it (streaming encoders may) or the bytes are not a zstd frame
+// at all. Only the header is read; nothing is decoded, so this is safe to run
+// on an untrusted body before any native decompressor sees it.
+//
+// Layout, RFC 8878 §3.1.1: the magic number 0xFD2FB528 (little-endian), then
+// a Frame_Header_Descriptor byte whose top two bits size the content-size
+// field (0, 2, 4, or 8 bytes -- with 0 meaning a 1-byte field only when the
+// Single_Segment bit, bit 5, is set), and whose low two bits size the
+// Dictionary_ID (0, 1, 2, or 4 bytes). A Window_Descriptor byte sits between
+// them unless Single_Segment is set. The 2-byte size form stores the value
+// minus 256.
+export function zstdFrameContentSize(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 6) return undefined;
+  if (buffer.readUInt32LE(0) !== 0xfd2fb528) return undefined;
+  const descriptor = buffer[4];
+  const singleSegment = (descriptor & 0x20) !== 0;
+  const sizeFlag = descriptor >> 6;
+  const sizeBytes = sizeFlag === 0 ? (singleSegment ? 1 : 0) : [0, 2, 4, 8][sizeFlag];
+  if (sizeBytes === 0) return undefined;
+  const dictionaryBytes = [0, 1, 2, 4][descriptor & 0x03];
+  const offset = 5 + (singleSegment ? 0 : 1) + dictionaryBytes;
+  if (buffer.length < offset + sizeBytes) return undefined;
+  if (sizeBytes === 1) return buffer[offset];
+  if (sizeBytes === 2) return buffer.readUInt16LE(offset) + 256;
+  if (sizeBytes === 4) return buffer.readUInt32LE(offset);
+  const declared = buffer.readBigUInt64LE(offset);
+  return declared > BigInt(Number.MAX_SAFE_INTEGER)
+    ? Number.MAX_SAFE_INTEGER
+    : Number(declared);
+}
+
 export async function readRequestBody(
   request,
   { maxBytes = MAX_BODY_BYTES, signal } = {},

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -6,7 +6,7 @@ import {
   gunzipSync,
   inflateSync,
   zstdCompress,
-  zstdDecompressSync,
+  zstdDecompress,
 } from "node:zlib";
 import { promisify } from "node:util";
 
@@ -49,6 +49,7 @@ import {
   writeEventStreamHead,
   writeJson,
   writeStreamErrorEvent,
+  zstdFrameContentSize,
 } from "./http-utils.mjs";
 import {
   EmptyCompletionGuard,
@@ -552,7 +553,19 @@ function bindClientAbort(request, response, onAbort) {
   if (request.aborted || response.destroyed) abort();
 }
 
-function decodeBody(
+// Codex zstd-compresses every request body, so this runs on every turn and
+// the buffer grows with the conversation. The one-shot synchronous decoder
+// inflated it on the event loop, and that path is the one implicated in an
+// intermittent native abort on Windows (issue #465: exit 0xC0000409 with no JS
+// frame, always at the end of a long session with a large accumulated
+// context, always right after a successful turn). It has not been reproduced
+// here, so the change is defensive rather than a confirmed fix: the declared
+// frame size is checked before any native code runs, and the decoder itself is
+// the asynchronous one, which keeps a multi-megabyte inflate off the thread
+// that is serving every other request.
+const decompressZstd = promisify(zstdDecompress);
+
+async function decodeBody(
   body,
   contentEncoding,
   { maxBytes = MAX_DECODED_BODY_BYTES } = {},
@@ -569,8 +582,18 @@ function decodeBody(
   try {
     for (const encoding of encodings) {
       const options = { maxOutputLength: maxBytes };
-      if (encoding === "zstd") decoded = zstdDecompressSync(decoded, options);
-      else if (encoding === "gzip" || encoding === "x-gzip") {
+      if (encoding === "zstd") {
+        // A frame that announces an oversize payload gets the same 413 the
+        // output cap would produce, reached without handing the native decoder
+        // a body it was never going to be allowed to finish.
+        const declared = zstdFrameContentSize(decoded);
+        if (declared !== undefined && declared > maxBytes) {
+          const error = new Error(`Decoded request body exceeds ${maxBytes} bytes.`);
+          error.status = 413;
+          throw error;
+        }
+        decoded = await decompressZstd(decoded, options);
+      } else if (encoding === "gzip" || encoding === "x-gzip") {
         decoded = gunzipSync(decoded, options);
       } else if (encoding === "deflate") decoded = inflateSync(decoded, options);
       else if (encoding === "br") decoded = brotliDecompressSync(decoded, options);
@@ -3475,7 +3498,7 @@ async function handleResponses(request, response, requestUrl) {
     if (!requireCodexTransport(request, response)) return;
     const exactRouteProbe = exactRouteProbeRequested(request.headers);
     const encoded = await readRequestBody(request, { signal: controller.signal });
-    const body = decodeBody(encoded, request.headers["content-encoding"]);
+    const body = await decodeBody(encoded, request.headers["content-encoding"]);
     let payload = await parseBodyAsync(body);
     controller.signal.throwIfAborted();
     requestedModel = typeof payload.model === "string" ? payload.model : "";
@@ -4541,7 +4564,7 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
     // and leak the request to ChatGPT. Image requests keep their old ordering.
     if (searchRequest) {
       const encoded = await readRequestBody(request, { signal: controller.signal });
-      body = decodeBody(encoded, request.headers["content-encoding"]);
+      body = await decodeBody(encoded, request.headers["content-encoding"]);
       payload = await parseBodyAsync(body);
       requestedModel = typeof payload.model === "string" ? payload.model : defaultModel;
       const binding = searchSidecarBindingForModel(requestedModel);
@@ -4619,7 +4642,7 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
     }
     if (!payload) {
       const encoded = await readRequestBody(request, { signal: controller.signal });
-      body = decodeBody(encoded, request.headers["content-encoding"]);
+      body = await decodeBody(encoded, request.headers["content-encoding"]);
       payload = await parseBodyAsync(body);
     }
     controller.signal.throwIfAborted();
@@ -4775,7 +4798,7 @@ async function handleEmbeddings(request, response, requestUrl) {
       maxBytes: EMBEDDINGS_MAX_BODY_BYTES,
       signal: controller.signal,
     });
-    const body = decodeBody(encoded, request.headers["content-encoding"], {
+    const body = await decodeBody(encoded, request.headers["content-encoding"], {
       maxBytes: EMBEDDINGS_MAX_BODY_BYTES,
     });
     const payload = await parseBodyAsync(body);

--- a/test/http-utils-zstd-frame.test.mjs
+++ b/test/http-utils-zstd-frame.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { zstdCompressSync } from "node:zlib";
+
+import { zstdFrameContentSize } from "../src/http-utils.mjs";
+
+const MAGIC = Buffer.from([0x28, 0xb5, 0x2f, 0xfd]);
+
+// Hand-built frame headers, so every field width the parser understands is
+// exercised regardless of which shape Node's encoder happens to emit.
+function frame({ sizeFlag, singleSegment = false, dictionaryFlag = 0, size }) {
+  const descriptor = (sizeFlag << 6) | (singleSegment ? 0x20 : 0) | dictionaryFlag;
+  const parts = [MAGIC, Buffer.from([descriptor])];
+  if (!singleSegment) parts.push(Buffer.from([0x00]));
+  parts.push(Buffer.alloc([0, 1, 2, 4][dictionaryFlag]));
+  const width = sizeFlag === 0 ? (singleSegment ? 1 : 0) : [0, 2, 4, 8][sizeFlag];
+  if (width === 1) parts.push(Buffer.from([size]));
+  else if (width === 2) {
+    const field = Buffer.alloc(2);
+    field.writeUInt16LE(size - 256);
+    parts.push(field);
+  } else if (width === 4) {
+    const field = Buffer.alloc(4);
+    field.writeUInt32LE(size);
+    parts.push(field);
+  } else if (width === 8) {
+    const field = Buffer.alloc(8);
+    field.writeBigUInt64LE(BigInt(size));
+    parts.push(field);
+  }
+  return Buffer.concat(parts);
+}
+
+test("a real encoder's frame declares exactly the size it will inflate to", () => {
+  // Spans the 1-byte, 2-byte, and 4-byte size forms an encoder picks by
+  // payload length. The declared value is what the router compares against
+  // its cap, so it has to equal the true length, not merely bound it.
+  for (const length of [0, 1, 200, 255, 256, 300, 70_000, 2 * 1024 * 1024]) {
+    const compressed = zstdCompressSync(Buffer.alloc(length, 0x61));
+    assert.equal(zstdFrameContentSize(compressed), length, `length ${length}`);
+  }
+});
+
+test("every header layout the format allows is read at the right offset", () => {
+  assert.equal(zstdFrameContentSize(frame({ sizeFlag: 0, singleSegment: true, size: 200 })), 200);
+  assert.equal(zstdFrameContentSize(frame({ sizeFlag: 1, size: 300 })), 300);
+  assert.equal(zstdFrameContentSize(frame({ sizeFlag: 1, singleSegment: true, size: 300 })), 300);
+  assert.equal(zstdFrameContentSize(frame({ sizeFlag: 2, size: 5_000_000 })), 5_000_000);
+  assert.equal(zstdFrameContentSize(frame({ sizeFlag: 3, size: 7_000_000_000 })), 7_000_000_000);
+  // A dictionary id shifts the size field by its own width.
+  for (const dictionaryFlag of [1, 2, 3]) {
+    assert.equal(
+      zstdFrameContentSize(frame({ sizeFlag: 2, dictionaryFlag, size: 123_456 })),
+      123_456,
+      `dictionary flag ${dictionaryFlag}`,
+    );
+  }
+});
+
+test("a frame that omits its content size reports nothing rather than guessing", () => {
+  // Size flag 0 without Single_Segment means no field at all, the shape a
+  // streaming encoder produces.
+  assert.equal(zstdFrameContentSize(frame({ sizeFlag: 0, size: 0 })), undefined);
+});
+
+test("bytes that are not a zstd frame, or not a whole header, report nothing", () => {
+  assert.equal(zstdFrameContentSize(Buffer.from("{\"model\":\"x\"}")), undefined);
+  assert.equal(zstdFrameContentSize(Buffer.alloc(0)), undefined);
+  assert.equal(zstdFrameContentSize("not a buffer"), undefined);
+  const whole = frame({ sizeFlag: 2, size: 4096 });
+  for (let cut = 0; cut < whole.length; cut += 1) {
+    assert.equal(zstdFrameContentSize(whole.subarray(0, cut)), undefined, `cut at ${cut}`);
+  }
+});
+
+test("a declared size beyond the safe-integer range clamps instead of overflowing", () => {
+  const header = frame({ sizeFlag: 3, size: 1 });
+  header.writeBigUInt64LE(0xffffffffffffffffn, header.length - 8);
+  assert.equal(zstdFrameContentSize(header), Number.MAX_SAFE_INTEGER);
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -10668,3 +10668,74 @@ test("API forwarder clamps proven Flash routes onto the ladder the model accepts
     await closeServer(upstream.server);
   }
 });
+
+test("an oversize zstd body is refused with 413 before decoding and the router stays up", async () => {
+  // Issue #465: on Windows the router intermittently died with a native abort
+  // (0xC0000409, no JS frame) inflating a large zstd request body on the
+  // event loop, taking every listener down with it. Decoding now runs through
+  // the asynchronous decoder, and a frame whose declared size exceeds the cap
+  // is refused from its header alone. The assertion that matters is the last
+  // one: the process that just refused the body is still serving.
+  const nativeRequests = [];
+  const routedRequests = [];
+  const native = await mockServer(async (request, response) => {
+    nativeRequests.push(request.url);
+    json(response, 200, { route: "native" });
+  });
+  const gateway = await mockServer(async (request, response) => {
+    routedRequests.push(request.url);
+    json(response, 200, { route: "external" });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_MAX_DECODED_BODY_BYTES: "4096",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const headers = {
+      Authorization: "Bearer CODEX_CALLER_SECRET",
+      "Content-Type": "application/json",
+      "Content-Encoding": "zstd",
+    };
+    // Compresses to well under the 64 MB transport cap while declaring an
+    // inflated size far past the 4 KB decode cap set above.
+    const oversize = zstdCompressSync(
+      Buffer.from(JSON.stringify({ model: "gpt-5.6-sol", input: "x".repeat(200_000) })),
+    );
+    const refused = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: oversize,
+    });
+    assert.equal(refused.status, 413);
+    // The handler keeps internal messages out of response bodies by design;
+    // the status is the contract, and the specific cause goes to the log.
+    assert.equal((await refused.json()).error.type, "local_router_error");
+    assert.equal(nativeRequests.length, 0, "an oversize body must never reach upstream");
+    assert.equal(routedRequests.length, 0);
+
+    // A body inside the cap still decodes and routes on the asynchronous path.
+    const small = zstdCompressSync(
+      Buffer.from(JSON.stringify({ model: "gpt-5.6-sol", input: "small" })),
+    );
+    const accepted = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: small,
+    });
+    assert.equal(accepted.status, 200);
+    assert.equal(nativeRequests.length, 1);
+
+    const alive = await fetch(`${routerBase(routerPort)}/models`);
+    assert.equal(alive.status, 200, "the router that refused the body must still be serving");
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    await closeServer(gateway.server);
+  }
+});


### PR DESCRIPTION
## Problem

#465 reports `router.mjs` intermittently dying on Windows with exit `0xC0000409`
(`STATUS_STACK_BUFFER_OVERRUN`) and no JavaScript stack — always late in a long
session with 100k–200k cached tokens, always immediately after a successful
turn. Every child (LiteLLM gateway, OAuth forwarders) dies with it and the
router stays down.

The reporter's hypothesis points at `decodeBody()`, which inflated every request
body through `zstdDecompressSync` on the event loop. Codex zstd-compresses every
request, and the body grows with the conversation.

## Change

1. **Refuse an oversize frame from its header.** A Zstandard frame declares its
   decompressed size when the encoder knew it (Node's one-shot encoder always
   does). `zstdFrameContentSize()` in `http-utils.mjs` reads only the header —
   it never decodes, so it is safe on untrusted input — and `decodeBody` answers
   413 before any native decoder runs if the declared size exceeds the cap.
2. **Inflate through the asynchronous decoder.** Everything else goes through
   promisified `zstdDecompress` under the same `maxOutputLength`, keeping a
   multi-megabyte inflate off the thread that serves every other request.

gzip, deflate, and brotli are untouched; they are not implicated.

## Honesty about scope

I could not reproduce the crash on macOS, so this is defensive hardening on the
implicated path rather than a confirmed root-cause fix. The issue stays open
pending the WER crash dump the reporter offered.

## Tests

- `test/http-utils-zstd-frame.test.mjs` — 5 cases covering every header layout
  the format allows (1/2/4/8-byte size widths, Single_Segment, dictionary-id
  offset, the 2-byte form's +256), a real encoder's frames at sizes spanning all
  widths, frames that omit the size, non-zstd bytes, every truncation point of a
  header, and the safe-integer clamp.
- `test/routing.test.mjs` — end-to-end: with the decode cap set to 4 KB, a real
  zstd body that inflates to ~200 KB gets **413 with zero upstream requests**, a
  body inside the cap still routes on the async path, and **the router that just
  refused the body is still serving** — which is the actual failure mode in #465.

Full suite: **3407 tests, 3382 pass, 0 real failures, 24 skipped.** The one
failing test (`5-level owner SIGINT cleanup`, a process-tree timing test from
#542) passes 3/3 in isolation and is untouched by this change. `npm run check`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)