### PR TITLE
fix(grok-oauth): suppress repeated progress after stream abort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Grok OAuth no longer replays a known progress-only sentence after an
+  aborted follow-up.** The first affected turn remains fully live. Once a
+  conversation has actually produced the progress-only shape, later
+  user-message turns buffer only a short visible prefix while leaving the
+  response head and preceding reasoning live. A real tool call or longer
+  answer releases that prefix immediately; an upstream abort reports its terminal
+  stream error without first committing the same status sentence to Codex
+  again. Evidence is retained in a bounded in-memory conversation set.
+
 - **Request bodies are decompressed off the event loop, and an oversize zstd
   frame is refused from its header.** Codex zstd-compresses every request, so
   the router inflated a buffer that grows with the conversation on the thread

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -330,6 +330,13 @@ message, attempt 1 still streams live; when the client offered tools and the
 short-text/token trigger fires, the forwarder retries once and appends a
 retry tool call onto the same stream. On turns following a tool result, the
 stricter certified-repair path below stages the response before sending it.
+After a conversation has exhibited that shape once, later user-message turns
+buffer only a short visible prefix up to the same text threshold. Headers and
+preceding reasoning remain live, and a tool call or longer answer releases the
+prefix; if the upstream stream aborts instead, Codex receives the terminal
+stream error without first recording another partial progress sentence. Unaffected
+conversation IDs retain the fully live path, and the evidence set is bounded
+in memory.
 
 The trigger is a shape, not a diagnosis, and it is worth knowing which turns
 pay for it. After a tool result, every no-tool prose response is held and

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -68,10 +68,23 @@ const PROGRESS_ONLY_MIN_OUTPUT_TOKENS = envNonNegativeInt(
   "CODEX_ROUTER_GROK_PROGRESS_ONLY_MIN_OUTPUT_TOKENS",
   DEFAULT_PROGRESS_ONLY_MIN_OUTPUT_TOKENS,
 );
+const MAX_PROGRESS_ONLY_CONVERSATIONS = 1_024;
+const progressOnlyConversations = new Set();
 
 function envNonNegativeInt(name, fallback) {
   const parsed = Number(process.env[name]);
   return Number.isFinite(parsed) && parsed >= 0 ? Math.floor(parsed) : fallback;
+}
+
+function rememberProgressOnlyConversation(id) {
+  if (!id) return;
+  // Refresh insertion order so the bounded set retains recently affected
+  // conversations rather than the first conversations seen by the process.
+  progressOnlyConversations.delete(id);
+  progressOnlyConversations.add(id);
+  while (progressOnlyConversations.size > MAX_PROGRESS_ONLY_CONVERSATIONS) {
+    progressOnlyConversations.delete(progressOnlyConversations.values().next().value);
+  }
 }
 
 async function drainUpstreamBody(body) {
@@ -511,6 +524,16 @@ async function handleChatCompletions(request, response) {
   const mayRetry =
     PROGRESS_ONLY_RETRY && (afterToolResult || requestOffersClientTools(chat));
   const strictAfterToolRepair = PROGRESS_ONLY_RETRY && afterToolResult;
+  const conversationKey = conversationId(chat?.messages);
+  // Attempt 1 normally stays live. Once this exact conversation has actually
+  // produced a progress-only stop, buffer only its next short visible prefix.
+  // That prevents an aborted/retried turn from committing the same status
+  // sentence again without imposing the old first-byte hold on healthy chats.
+  let bufferShortProgress =
+    wantsStream &&
+    mayRetry &&
+    !strictAfterToolRepair &&
+    progressOnlyConversations.has(conversationKey);
 
   const controller = new AbortController();
   request.once("aborted", () => controller.abort());
@@ -597,8 +620,17 @@ async function handleChatCompletions(request, response) {
   const emitPendingDeltas = () => {
     if (!wantsStream || !streamStarted) return;
     while (emittedDeltaCount < turnState.deltas.length) {
+      const delta = turnState.deltas[emittedDeltaCount];
+      if (
+        bufferShortProgress &&
+        Object.hasOwn(delta, "content") &&
+        turnState.toolCalls.length === 0 &&
+        turnState.contentText.length <= PROGRESS_ONLY_MAX_TEXT
+      ) {
+        return;
+      }
       response.write(
-        OPENAI_ROLE_CHUNK(id, created, model, turnState.deltas[emittedDeltaCount]),
+        OPENAI_ROLE_CHUNK(id, created, model, delta),
       );
       emittedDeltaCount += 1;
     }
@@ -615,6 +647,7 @@ async function handleChatCompletions(request, response) {
   let repairFailure;
 
   const progressOnly = isProgressOnlyStop(turn, { ...holdOptions, afterToolResult });
+  if (progressOnly) rememberProgressOnlyConversation(conversationKey);
   if (progressOnly && strictAfterToolRepair && !mayRetry) {
     repairFailure = {
       code: "progress_only_no_client_tools",
@@ -719,6 +752,11 @@ async function handleChatCompletions(request, response) {
     });
     return;
   }
+
+  // A normal short answer, a failed optional repair, or the keep-first branch
+  // must still deliver attempt 1. The retry-tools branch has already advanced
+  // emittedDeltaCount past the suppressed prefix, so releasing is a no-op there.
+  bufferShortProgress = false;
 
   if (wantsStream) {
     const wasStarted = streamStarted;

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -917,6 +917,93 @@ const TOOL_EVENTS = [
   },
 ];
 
+test("buffers a proven progress-only prefix without losing a healthy short answer", async () => {
+  let inbound = 0;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    if (inbound <= 2) {
+      res.end(sse(PROGRESS_EVENTS));
+      return;
+    }
+    if (inbound === 3) {
+      res.end(
+        sse([
+          { type: "response.output_text.delta", delta: "Done." },
+          { type: "response.completed", response: { usage: { input_tokens: 20, output_tokens: 5 } } },
+        ]),
+      );
+      return;
+    }
+    res.write(sse([{ type: "response.output_text.delta", delta: "Next I will update the deck." }]));
+    setImmediate(() => res.destroy());
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-repeat-abort-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  const opening = [
+    { role: "system", content: "You are Codex." },
+    { role: "user", content: "update the deck" },
+  ];
+  const tools = [
+    { type: "function", function: { name: "exec_command", parameters: { type: "object" } } },
+  ];
+  try {
+    await waitHealth(base, child);
+    const first = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({ model: "grok-4.6", messages: opening, tools, stream: false }),
+    });
+    assert.equal(first.status, 200);
+    assert.equal(inbound, 2);
+
+    const followUpMessages = [
+      ...opening,
+      { role: "assistant", content: "Next I will update the deck." },
+      { role: "user", content: "continue" },
+    ];
+    const healthy = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: followUpMessages,
+        tools,
+        stream: true,
+      }),
+    });
+    const healthyBody = await readAll(healthy);
+    assert.equal(healthy.status, 200);
+    assert.equal(inbound, 3);
+    assert.match(healthyBody, /"content":"Done\."/);
+    assert.match(healthyBody, /data: \[DONE\]/);
+
+    const repeated = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: followUpMessages,
+        tools,
+        stream: true,
+      }),
+    });
+    const body = await readAll(repeated);
+    assert.equal(repeated.status, 200);
+    assert.equal(inbound, 4);
+    assert.doesNotMatch(body, /Next I will update the deck/);
+    assert.equal((body.match(/event: error/g) || []).length, 1);
+    assert.match(body, /local_router_stream_failed/);
+    assert.doesNotMatch(body, /data: \[DONE\]/);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("does not retry a short reasoning-heavy answer when the client offered no tools", async () => {
   let inbound = 0;
   const backend = await mockBackend(async (_req, res) => {


### PR DESCRIPTION
## Why

After a Grok conversation has produced a progress-only stop, a later turn can emit another short progress prefix and then abort upstream. Because that prefix is already committed to the Codex stream, the chat can look stuck in a loop even though the terminal stream error is reported correctly.

This implements the evidence-gated buffering alternative discussed in #295: keep the first affected turn fully live, and change streaming behavior only after the same stable Grok conversation ID has exhibited the progress-only shape.

## What changed

- remember affected conversation IDs in a bounded in-memory set
- on later eligible user turns, buffer only the short visible prefix while keeping headers and preceding reasoning live
- release the prefix for healthy short answers, longer answers, and tool calls
- suppress that prefix when the upstream stream aborts, while preserving the terminal SSE error
- document the behavior and add regression coverage for both the healthy and aborted paths

## Verification

- `npm run check`
- `node --test test/grok-oauth-turn.test.mjs test/grok-oauth-forwarder.test.mjs` — 58 passed
- `npm audit --omit=dev` — 0 vulnerabilities
- autoreview on the final dirty patch — no P0/P1 findings; secret scan clean

The full `npm test` run reported 3,377 passed, 24 skipped, and 7 failures in `test/control-center-harness.test.mjs`. The same 7 failures reproduce on a clean worktree at `origin/main` (`44029b8`), so they are not introduced by this patch.
