### PR TITLE
fix: explain a Windows scheduled-task launch that cannot read its own checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **A failed Windows scheduled-task launch now explains itself.** Node reports a
+  module it cannot *read* exactly as it reports one that is not there —
+  `Cannot find module` with `MODULE_NOT_FOUND` — so an install whose checkout
+  the task's own token cannot read looked like a missing `src\start.mjs` that
+  the operator could open in front of them (#548). Readiness failure now checks
+  whether the path the loader named exists: if it does, it reports a permission
+  or token problem and how to confirm it, and if it does not, it reports an
+  incomplete checkout. When the log carries no such evidence the original
+  wording is kept rather than a cause being invented. This improves the
+  diagnosis only; the underlying ACL condition is not yet reproduced.
 - **Request bodies are decompressed off the event loop, and an oversize zstd
   frame is refused from its header.** Codex zstd-compresses every request, so
   the router inflated a buffer that grows with the conversation on the thread

--- a/src/service-readiness.mjs
+++ b/src/service-readiness.mjs
@@ -1,6 +1,7 @@
 import { waitForRouterHealth } from "./router-health.mjs";
-import { STATE_DIR } from "./paths.mjs";
+import { LOG_PATH, STATE_DIR } from "./paths.mjs";
 import { windowsScheduledTaskState } from "./windows-task-state.mjs";
+import { diagnoseWindowsLaunchFailure, readLogTail } from "./windows-launch-diagnosis.mjs";
 
 const TASK_LAUNCH_GRACE_MS = 15_000;
 const TASK_STATE_POLL_MS = 1_000;
@@ -67,6 +68,7 @@ export async function waitForServiceReadiness({
   getWindowsTaskState = windowsScheduledTaskState,
   getServiceRestarts,
   waitForHealth = waitForRouterHealth,
+  logPath = LOG_PATH,
 } = {}) {
   const deadline = Date.now() + Math.max(0, timeoutMs);
   // Keep exactly one health attempt in flight for the whole operation; the
@@ -161,8 +163,14 @@ export async function waitForServiceReadiness({
         const result = Number.isSafeInteger(taskState.lastTaskResult)
           ? `0x${taskState.lastTaskResult.toString(16)}`
           : "unknown";
+        // The task's own result is a bare exit code. When the router log
+        // explains why the launch died, say that instead of leaving the
+        // operator to reconcile "no running launcher" against a Node error
+        // that names a file they can open (issue #548).
+        const diagnosis = diagnoseWindowsLaunchFailure({ logText: readLogTail(logPath) });
         throw new Error(
-          `Windows Scheduled Task has no running launcher process (LastTaskResult=${result}); router cannot become healthy.`,
+          `Windows Scheduled Task has no running launcher process (LastTaskResult=${result}); router cannot become healthy.` +
+            (diagnosis ? `\n${diagnosis}` : ""),
         );
       }
     } else if (launcherAlive) {

--- a/src/windows-launch-diagnosis.mjs
+++ b/src/windows-launch-diagnosis.mjs
@@ -1,0 +1,83 @@
+import { closeSync, existsSync, openSync, readSync, statSync } from "node:fs";
+
+// Node reports a module it cannot *read* the same way it reports one that is
+// not there: `Cannot find module '<path>'` with code MODULE_NOT_FOUND. On
+// Windows that collapses two very different failures into one message, and a
+// scheduled task hits the readable-only-to-someone-else case (issue #548):
+// the installer creates the managed checkout, the task exits 1, the router log
+// names `src\start.mjs` as missing, and the operator can open that exact file.
+//
+// The distinguishing evidence is cheap and local: does the path the loader
+// named exist right now? If it does, absence was never the problem, and
+// repeating Node's wording sends the operator looking for a missing file that
+// is sitting in front of them.
+const MISSING_MODULE = /Cannot find module '([^']+)'/g;
+
+// The tail is enough: the loader fails within the first lines of a launch, and
+// only the most recent launch is being diagnosed.
+const LOG_TAIL_BYTES = 64 * 1024;
+
+// Seeks to the window rather than loading the file: this runs on a failure
+// path that is already reporting an outage, and the router log is long-lived.
+export function readLogTail(logPath, { maxBytes = LOG_TAIL_BYTES } = {}) {
+  let descriptor;
+  try {
+    if (!existsSync(logPath)) return "";
+    const { size } = statSync(logPath);
+    if (size === 0) return "";
+    const length = Math.min(size, maxBytes);
+    const buffer = Buffer.alloc(length);
+    descriptor = openSync(logPath, "r");
+    const read = readSync(descriptor, buffer, 0, length, size - length);
+    // A window that starts mid-character would corrupt the first rune; the
+    // patterns this feeds are anchored well inside the tail, so the partial
+    // leading line is simply not worth reconstructing.
+    return buffer.subarray(0, read).toString("utf8");
+  } catch {
+    // A log the router cannot read is not evidence of anything; the caller
+    // falls back to its generic message.
+    return "";
+  } finally {
+    if (descriptor !== undefined) {
+      try {
+        closeSync(descriptor);
+      } catch {
+        // Nothing actionable; the diagnosis is best-effort by design.
+      }
+    }
+  }
+}
+
+/**
+ * Explain a Windows scheduled-task launch failure, or return undefined when
+ * the log carries no evidence worth adding.
+ *
+ * Deliberately narrow. This only speaks when the loader named a module *and*
+ * that path exists, because that combination has exactly one meaning: the
+ * launch could not read a file that is present, which is a permission or
+ * token problem rather than a broken checkout. Every other shape returns
+ * undefined so the caller keeps its own wording instead of guessing.
+ */
+export function diagnoseWindowsLaunchFailure({ logText, exists = existsSync } = {}) {
+  if (typeof logText !== "string" || !logText) return undefined;
+  const named = [...logText.matchAll(MISSING_MODULE)].map((match) => match[1]);
+  if (named.length === 0) return undefined;
+  const modulePath = named.at(-1);
+  if (!exists(modulePath)) {
+    return (
+      `The scheduled task could not start: Node reported ${modulePath} missing, ` +
+      "and it is in fact absent. The managed checkout is incomplete — re-run the " +
+      "installer to restore it."
+    );
+  }
+  return (
+    `The scheduled task could not start: Node reported ${modulePath} missing, ` +
+    "but that file exists. The task's own token could not read it, which Node " +
+    "surfaces as MODULE_NOT_FOUND. An installer run elevated can leave the " +
+    "managed checkout readable only to the elevated identity, while the task " +
+    "itself runs at Limited level.\n" +
+    "Confirm with `icacls \"<checkout>\"` and grant the task's account read and " +
+    "execute on it, or re-run the installer from a non-elevated shell so the " +
+    "checkout and the task share one identity."
+  );
+}

--- a/test/service-readiness.test.mjs
+++ b/test/service-readiness.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -27,6 +27,66 @@ test("a persistently dead Windows task fails readiness early with its result", a
     /no running launcher process \(LastTaskResult=0x1\)/,
   );
   assert.equal(stateQueries > 1, true);
+});
+
+test("a dead Windows task explains a MODULE_NOT_FOUND whose file exists", async () => {
+  // Issue #548: the bare LastTaskResult left the operator reconciling "no
+  // running launcher" against a Node error naming a file they can open. The
+  // readiness failure now carries the reason.
+  const logRoot = mkdtempSync(path.join(os.tmpdir(), "readiness-log-"));
+  const logPath = path.join(logRoot, "router.log");
+  const modulePath = path.join(logRoot, "start.mjs");
+  writeFileSync(modulePath, "// present but unreadable by the task token\n");
+  writeFileSync(logPath, `Error: Cannot find module '${modulePath}'\n  code: 'MODULE_NOT_FOUND'\n`);
+  try {
+    await assert.rejects(
+      waitForServiceReadiness({
+        platform: "win32",
+        timeoutMs: 60_000,
+        launchGraceMs: 20,
+        pollMs: 10,
+        logPath,
+        getWindowsTaskState: () => ({ instanceCount: 0, lastTaskResult: 1, launcherAlive: false }),
+        waitForHealth: () => new Promise(() => {}),
+      }),
+      (error) => {
+        // The original verdict is preserved; the diagnosis is added to it.
+        assert.match(error.message, /no running launcher process \(LastTaskResult=0x1\)/);
+        assert.match(error.message, /but that file exists/);
+        assert.match(error.message, /token could not read it/);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(logRoot, { recursive: true, force: true });
+  }
+});
+
+test("a dead Windows task with no explanatory log keeps the original wording", async () => {
+  const logRoot = mkdtempSync(path.join(os.tmpdir(), "readiness-log-"));
+  const logPath = path.join(logRoot, "router.log");
+  writeFileSync(logPath, "[codex-router] listening on 127.0.0.1:4202\n");
+  try {
+    await assert.rejects(
+      waitForServiceReadiness({
+        platform: "win32",
+        timeoutMs: 60_000,
+        launchGraceMs: 20,
+        pollMs: 10,
+        logPath,
+        getWindowsTaskState: () => ({ instanceCount: 0, lastTaskResult: 1, launcherAlive: false }),
+        waitForHealth: () => new Promise(() => {}),
+      }),
+      (error) => {
+        assert.match(error.message, /no running launcher process \(LastTaskResult=0x1\)/);
+        // Nothing invented when the log carries no evidence.
+        assert.doesNotMatch(error.message, /token could not read it|in fact absent/);
+        return true;
+      },
+    );
+  } finally {
+    rmSync(logRoot, { recursive: true, force: true });
+  }
 });
 
 test("a stale instance entry with no live launcher process also fails readiness early", async () => {

--- a/test/windows-launch-diagnosis.test.mjs
+++ b/test/windows-launch-diagnosis.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { diagnoseWindowsLaunchFailure, readLogTail } from "../src/windows-launch-diagnosis.mjs";
+
+const CHECKOUT = "C:\\Users\\operator\\AppData\\Local\\codex-router";
+const START = `${CHECKOUT}\\src\\start.mjs`;
+
+function moduleError(modulePath) {
+  return [
+    "Error: Cannot find module '" + modulePath + "'",
+    "    at Function._resolveFilename (node:internal/modules/cjs/loader)",
+    "  code: 'MODULE_NOT_FOUND'",
+  ].join("\n");
+}
+
+test("a module the loader named but that exists is reported as a permission failure", () => {
+  // Issue #548: the installer creates the checkout, the task exits 1, and the
+  // log names a file the operator can open. Node reports an unreadable module
+  // exactly as it reports an absent one, so the existence check is the only
+  // thing that separates them.
+  const message = diagnoseWindowsLaunchFailure({
+    logText: moduleError(START),
+    exists: (candidate) => candidate === START,
+  });
+  assert.match(message, /but that file exists/);
+  assert.match(message, /token could not read it/);
+  assert.match(message, /Limited level/);
+  assert.match(message, /icacls/);
+  assert.ok(message.includes(START), "the operator needs the exact path named");
+});
+
+test("a module that really is absent is reported as an incomplete checkout", () => {
+  const message = diagnoseWindowsLaunchFailure({
+    logText: moduleError(START),
+    exists: () => false,
+  });
+  assert.match(message, /it is in fact absent/);
+  assert.match(message, /re-run the installer/);
+  assert.doesNotMatch(message, /token could not read it/);
+});
+
+test("the most recent launch decides the verdict", () => {
+  // A long-lived log holds older failures; only the newest launch is being
+  // diagnosed, so an earlier absent module must not outvote a present one.
+  const older = `${CHECKOUT}\\src\\gone.mjs`;
+  const message = diagnoseWindowsLaunchFailure({
+    logText: `${moduleError(older)}\n${moduleError(START)}`,
+    exists: (candidate) => candidate === START,
+  });
+  assert.match(message, /but that file exists/);
+  assert.ok(message.includes(START));
+  assert.ok(!message.includes(older));
+});
+
+test("a log with no module error adds nothing, so the caller keeps its own wording", () => {
+  for (const logText of [
+    "",
+    "[codex-router] listening on 127.0.0.1:4202\n",
+    "Error: listen EADDRINUSE: address already in use 127.0.0.1:4202\n",
+  ]) {
+    assert.equal(diagnoseWindowsLaunchFailure({ logText }), undefined, JSON.stringify(logText));
+  }
+  assert.equal(diagnoseWindowsLaunchFailure({ logText: undefined }), undefined);
+  assert.equal(diagnoseWindowsLaunchFailure({}), undefined);
+});
+
+test("the log tail is read from the end and a missing or empty log is silent", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "launch-diagnosis-"));
+  try {
+    const absent = path.join(root, "nothing.log");
+    assert.equal(readLogTail(absent), "");
+
+    const empty = path.join(root, "empty.log");
+    writeFileSync(empty, "");
+    assert.equal(readLogTail(empty), "");
+
+    // Only the window at the end is read, and the newest line survives it.
+    const large = path.join(root, "router.log");
+    writeFileSync(large, `${"filler line\n".repeat(20_000)}${moduleError(START)}\n`);
+    const tail = readLogTail(large, { maxBytes: 4096 });
+    assert.ok(tail.length <= 4096);
+    assert.match(tail, /Cannot find module/);
+    assert.equal(
+      diagnoseWindowsLaunchFailure({ logText: tail, exists: () => true }).includes(START),
+      true,
+    );
+
+    // A file smaller than the window is returned whole.
+    const small = path.join(root, "small.log");
+    writeFileSync(small, moduleError(START));
+    assert.match(readLogTail(small, { maxBytes: 4096 }), /MODULE_NOT_FOUND/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

#548 reports a Windows install where the scheduled task exits `1` and the router
log names an existing file as missing:

```
Error: Cannot find module 'C:\Users\<user>\AppData\Local\codex-router\src\start.mjs'
code: 'MODULE_NOT_FOUND'
```

The operator can read that file. Readiness reported only
`no running launcher process (LastTaskResult=0x1)`, leaving them to reconcile
two messages that each point somewhere else.

## Diagnosis

The reporter's own evidence rules out the launcher: swapping the generated VBS
wrapper for a direct `cmd.exe /D /C ...start-codex-router.cmd` action reproduced
the **identical** result and message, while running the same launcher from an
**elevated** interactive shell started the router normally. The task principal
ran at **Limited** level.

That points at the task token's access to the managed checkout, not at how the
task invokes it. Node surfaces an unreadable module and an absent one
identically, which is what made the log misleading.

## Change

`diagnoseWindowsLaunchFailure()` checks the one piece of local evidence that
separates the two cases — whether the path the loader named exists right now:

- **Exists** → a permission or token problem, with the likely cause (an elevated
  install leaving the checkout readable only to the elevated identity while the
  task runs Limited) and how to confirm it.
- **Absent** → an incomplete checkout; re-run the installer.
- **No module error in the log** → nothing added, original wording kept.

The log tail is read by seeking to a 64 KB window rather than loading a
long-lived log on a path that is already reporting an outage.

## Scope — please read

**This improves the diagnosis, not the underlying condition.** I could not
reproduce the ACL failure from macOS, so the fix makes the failure name itself
instead of guessing at a remedy I cannot verify. The issue should stay open for
the ACL work, and the `icacls` output the reporter can capture would confirm the
cause.

## Tests

`test/windows-launch-diagnosis.test.mjs` (5 cases): the exists/absent split, that
the **most recent** launch decides the verdict when an older failure sits in the
same log, that a log without a module error stays silent, and that the tail read
handles a missing, empty, oversized, and undersized log.

`test/service-readiness.test.mjs` (2 new): the diagnosis reaches the operator's
error **appended to** the original `LastTaskResult=0x1` verdict rather than
replacing it, and an uninformative log leaves that verdict untouched.

Full suite: **3495 tests, 3470 pass, 0 fail.** `npm run check` clean.

Refs #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)