### PR TITLE
fix: hide the console windows Windows background PowerShell helpers create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **The Windows Control Center no longer flashes PowerShell windows.** A console
+  process spawned by a parent that has no console of its own — the Electron
+  Control Center and the tray — gets its own window unless `windowsHide` is set,
+  and four background helpers were missing it. The one every private write
+  reaches meant a burst of visible windows on each status refresh, which is why
+  it showed up on every message sent (#565). The private-file ACL writer and its
+  verifier, scheduled-task registration, and the tray's task-state poll now all
+  hide. Interactive prompts are untouched: they inherit a console the operator is
+  already looking at, and hiding it would ask for input through a window nobody
+  can see. A source-level test holds the line, since the failure is invisible off
+  Windows.
 - **Request bodies are decompressed off the event loop, and an oversize zstd
   frame is refused from its header.** Codex zstd-compresses every request, so
   the router inflated a buffer that grows with the conversation on the thread

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -174,6 +174,13 @@ function protectPrivateFilesWin32(paths) {
         env: windowsPowerShellEnvironment(list),
         stdio: ["ignore", "ignore", "pipe"],
         timeout: 15_000,
+        // Every private write reaches this helper, including the ones a
+        // Control Center status refresh performs. A console child of a GUI
+        // parent gets its own window unless this is set, which is how a
+        // routine refresh produced a burst of visible PowerShell windows
+        // (issue #565). The script is non-interactive and its stdio is
+        // already redirected, so nothing is hidden from the operator.
+        windowsHide: true,
       },
     );
   } catch (error) {
@@ -345,6 +352,9 @@ export function privateFileIsProtected(target) {
         env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target },
         stdio: ["ignore", "pipe", "ignore"],
         timeout: 15_000,
+        // Verification runs from the same GUI-parented paths as the write
+        // above; see issue #565.
+        windowsHide: true,
       },
     ).trim().toLowerCase() === "true";
   } catch {

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -219,6 +219,9 @@ function installTask() {
           CODEX_ROUTER_TASK_EXECUTE: execute,
           CODEX_ROUTER_TASK_ARGUMENT: argument,
         },
+        // Registration also runs from the GUI installer and the Control
+        // Center, where a console child gets its own window (issue #565).
+        windowsHide: true,
         stdio: ["ignore", "ignore", "ignore"],
       },
     );
@@ -397,6 +400,9 @@ function taskState() {
           env: { ...process.env, CODEX_ROUTER_TASK: taskName },
           stdio: ["ignore", "pipe", "ignore"],
           timeout: TASK_STATE_TIMEOUT_MS,
+          // Status is polled from the tray on a timer, so an unhidden console
+          // here is a window that reappears on its own (issue #565).
+          windowsHide: true,
         },
       ).trim().toLowerCase();
     } catch {

--- a/test/windows-hidden-consoles.test.mjs
+++ b/test/windows-hidden-consoles.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// A console process spawned by a parent that has no console of its own -- the
+// Electron Control Center and the tray -- gets its own window unless
+// `windowsHide` is set. The helpers those parents reach run on routine
+// refreshes, so one missing flag produced a burst of visible PowerShell
+// windows every time a message was sent (issue #565).
+//
+// A source assertion is the only cheap guard here: the failure is invisible on
+// macOS and Linux, and reproducing it needs a Windows desktop session.
+//
+// The exemption is a property of the call, not a list of files: a process that
+// inherits stdin is prompting the operator through a console that already
+// exists, and `windowsHide` is not what governs that case. Everything else --
+// stdio `ignore` or `pipe` -- is a background helper with nothing to show.
+function sourceFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(full);
+    return entry.isFile() && entry.name.endsWith(".mjs") ? [full] : [];
+  });
+}
+
+// Balanced-paren slice of the call's argument list, so a nested object or a
+// trailing callback cannot truncate it.
+function callArguments(source, callIndex) {
+  const open = source.indexOf("(", callIndex);
+  if (open === -1) return "";
+  let depth = 0;
+  for (let index = open; index < source.length; index += 1) {
+    if (source[index] === "(") depth += 1;
+    else if (source[index] === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open, index + 1);
+    }
+  }
+  return source.slice(open);
+}
+
+// Options, and `stdio` within them, are sometimes variables rather than
+// literals. Resolve one level of each so a hoisted options object or a
+// computed stdio still counts; anything deeper is out of scope for a guard
+// whose job is to catch a forgotten flag at the call site.
+function resolvedOptions(source, argumentText) {
+  const objectNames = [...argumentText.matchAll(/\b([A-Za-z_$][\w$]*)\s*(?:,|\))/g)].map(
+    (match) => match[1],
+  );
+  const objects = objectNames
+    .map((name) => {
+      const declared = new RegExp(`\\b(?:const|let|var)\\s+${name}\\s*=\\s*\\{`).exec(source);
+      return declared ? callObject(source, declared.index) : "";
+    })
+    .join("\n");
+  const withObjects = `${argumentText}\n${objects}`;
+  const stdioNames = [...withObjects.matchAll(/stdio:\s*([A-Za-z_$][\w$]*)/g)].map(
+    (match) => match[1],
+  );
+  const stdioValues = stdioNames
+    .map((name) => {
+      const declared = new RegExp(
+        `\\b(?:const|let|var)\\s+${name}\\s*=\\s*([^;\\n]*(?:\\n[^;\\n]*)*?);`,
+      ).exec(source);
+      return declared ? `stdio: ${declared[1]}` : "";
+    })
+    .join("\n");
+  return `${withObjects}\n${stdioValues}`;
+}
+
+function callObject(source, index) {
+  const open = source.indexOf("{", index);
+  if (open === -1) return "";
+  let depth = 0;
+  for (let cursor = open; cursor < source.length; cursor += 1) {
+    if (source[cursor] === "{") depth += 1;
+    else if (source[cursor] === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open, cursor + 1);
+    }
+  }
+  return source.slice(open);
+}
+
+function powershellCalls() {
+  const calls = [];
+  for (const file of sourceFiles(path.join(root, "src"))) {
+    const source = readFileSync(file, "utf8");
+    const pattern = /\b(execFileSync|execFile|spawnSync|spawn)\s*\(/g;
+    let match;
+    while ((match = pattern.exec(source))) {
+      const argumentText = callArguments(source, match.index);
+      if (!/powershell|pwsh/i.test(argumentText)) continue;
+      const options = resolvedOptions(source, argumentText);
+      calls.push({
+        where: `${path.relative(root, file)}:${source.slice(0, match.index).split("\n").length}`,
+        // The stdio value may be a literal, a variable, or a ternary over
+        // both; what matters is whether any branch inherits a console.
+        interactive: /stdio:[^\n]*inherit/.test(options),
+        hidden: /windowsHide\s*:\s*true/.test(options),
+      });
+    }
+  }
+  return calls;
+}
+
+test("every background PowerShell invocation hides its console window", () => {
+  const offenders = powershellCalls()
+    .filter((call) => !call.interactive && !call.hidden)
+    .map((call) => call.where);
+  assert.deepEqual(
+    offenders,
+    [],
+    `PowerShell launched without windowsHide: true:\n  ${offenders.join("\n  ")}`,
+  );
+});
+
+test("the scan actually finds the PowerShell call sites it is guarding", () => {
+  // A regex that silently stops matching would make the guard above pass for
+  // the wrong reason, so assert the population it inspects.
+  const calls = powershellCalls();
+  assert.ok(calls.length >= 8, `expected the scan to find call sites, saw ${calls.length}`);
+  assert.ok(
+    calls.some((call) => call.where.startsWith("src/file-security.mjs")),
+    "the helper every private write reaches must be covered",
+  );
+  assert.ok(
+    calls.some((call) => call.interactive),
+    "the interactive prompts must still be recognised as interactive",
+  );
+});

--- a/test/windows-hidden-consoles.test.mjs
+++ b/test/windows-hidden-consoles.test.mjs
@@ -97,7 +97,12 @@ function powershellCalls() {
       if (!/powershell|pwsh/i.test(argumentText)) continue;
       const options = resolvedOptions(source, argumentText);
       calls.push({
-        where: `${path.relative(root, file)}:${source.slice(0, match.index).split("\n").length}`,
+        // path.relative yields backslashes on Windows; normalise so the
+        // reported location and the assertions below read the same on every
+        // platform.
+        where: `${path.relative(root, file).split(path.sep).join("/")}:${
+          source.slice(0, match.index).split("\n").length
+        }`,
         // The stdio value may be a literal, a variable, or a ternary over
         // both; what matters is whether any branch inherits a console.
         interactive: /stdio:[^\n]*inherit/.test(options),


### PR DESCRIPTION
## Problem

#565 reports a burst of visible **Windows PowerShell** windows during routine
Control Center status refreshes — noticeable on every message sent — with a
`Win32_ProcessStartTrace` showing them as children of Control Center command
invocations launched by the tray.

A console process spawned by a parent that has **no console of its own** (the
Electron Control Center, the tray) gets its own window unless `windowsHide` is
set.

## Four call sites, not one

The reporter's trace pointed at the child-process path; auditing every
PowerShell launch in `src/` found four background helpers missing the flag:

| Call site | Why it fires |
| --- | --- |
| `file-security.mjs` ACL writer | **every private write** — this is the one that made it constant |
| `file-security.mjs` ACL verifier | same GUI-parented paths |
| `service-windows.mjs` task registration | GUI installer and Control Center |
| `service-windows.mjs` task-state poll | tray timer, so the window **returns on its own** |

`file-security`'s own *async* path already hid correctly, which is why this was
easy to miss.

## What is deliberately left visible

`setup.mjs`, `setup-shared.mjs`, `secret-prompt.mjs`, and the `doctor --fix`
repair all inherit stdio — they prompt or stream through a console the operator
is already looking at. Hiding those would ask for input through a window nobody
can see, so the rule is a **property of the call**, not an allowlist: a
PowerShell child whose stdio inherits is exempt; every other one must hide.

## Test

`test/windows-hidden-consoles.test.mjs` asserts that rule over `src/`. It scans
source because the failure is invisible on macOS and Linux and reproducing it
needs a Windows desktop session.

Three things keep it from passing vacuously:

- It resolves an options object **or** an stdio value held in a variable, so a
  hoisted `options` or a ternary `repairStdio` is read correctly rather than
  reported as a false positive.
- A second test asserts the population it inspects is non-empty and includes
  both `file-security.mjs` and at least one interactive call.
- I verified it fails — naming the exact file and line — when a `windowsHide`
  flag is deleted.

Full suite: **3490 tests, 3465 pass, 0 fail.** `npm run check` clean.

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)