### PR TITLE
fix: name the Antigravity allowlist failure instead of reporting a bare 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,22 @@ grok login --oauth
 > official `agy` identity or credential store. Do not use the old
 > `your-integration-client-secret` placeholder: it cannot work.
 
+> [!IMPORTANT]
+> **The Cloud project behind your OAuth client must be allowlisted for
+> `cloudcode-pa.googleapis.com`, and most projects are not.** The bootstrap call
+> is billed to the project that owns the calling OAuth client, so an
+> operator-owned client bills your project rather than Google's. That service is
+> a private API: binding it needs the producer-side
+> `servicemanagement.services.bind` permission, so `gcloud services enable`
+> fails even for the project owner, and it has no API Library entry to enable
+> through the console.
+>
+> Sign-in still succeeds; the live probe is what fails, with
+> `PERMISSION_DENIED` / `SERVICE_DISABLED`. If your project is not allowlisted,
+> **this provider cannot currently be used** — there is no operator-side
+> workaround, and no configuration in this repository changes it. See
+> [#566](https://github.com/duolahypercho/codex-router/issues/566).
+
 Create a Google OAuth **Desktop app** client in a Google Cloud project you own:
 
 1. In Google Cloud Console, open **APIs & Services > OAuth consent screen** and

--- a/src/antigravity-project.mjs
+++ b/src/antigravity-project.mjs
@@ -50,6 +50,49 @@ function projectUnavailable(message, { code = "project_required", status = 502 }
   return error;
 }
 
+// Google answers a disabled private API with a structured reason that names
+// the service. Discarding the body reduced that to `HTTP 403`, which reads as
+// a credential problem and sends the operator back through sign-in that is
+// already working (issue #566).
+//
+// Only the structured fields are read. The free-text `message` embeds the
+// caller's project number and a console URL built from it, and an error string
+// the router prints and logs is the wrong place for either.
+const PRIVATE_BOOTSTRAP_SERVICE = "cloudcode-pa.googleapis.com";
+const MAX_ERROR_BODY_BYTES = 16 * 1024;
+
+export function antigravityBootstrapFailure(status, bodyText) {
+  const base = `HTTP ${status}`;
+  if (typeof bodyText !== "string" || bodyText.length === 0) return base;
+  let parsed;
+  try {
+    parsed = JSON.parse(bodyText.slice(0, MAX_ERROR_BODY_BYTES));
+  } catch {
+    return base;
+  }
+  const error = parsed?.error;
+  if (!error || typeof error !== "object") return base;
+  const details = Array.isArray(error.details) ? error.details : [];
+  const disabled = details.find((detail) => detail?.reason === "SERVICE_DISABLED");
+  const service = String(disabled?.metadata?.service || "");
+  if (disabled && service === PRIVATE_BOOTSTRAP_SERVICE) {
+    // Binding this service is gated by a producer-side permission
+    // (`servicemanagement.services.bind`), so no IAM role an operator can
+    // grant themselves enables it. Saying "enable the API" here would send
+    // them to a console page that does not exist for a private API.
+    return (
+      `${base}: the OAuth client's Google Cloud project is not allowlisted for ` +
+      `${service}, which is a private Google API that an ordinary project cannot ` +
+      "enable. Antigravity sign-in succeeded; only the project behind the " +
+      "operator-owned OAuth client is unauthorized"
+    );
+  }
+  const status_ = typeof error.status === "string" ? error.status : undefined;
+  const reason = typeof disabled?.reason === "string" ? disabled.reason : undefined;
+  const detail = [status_, reason, service].filter(Boolean).join(", ");
+  return detail ? `${base} (${detail})` : base;
+}
+
 function projectIdFrom(payload) {
   const project = payload?.cloudaicompanionProject;
   if (typeof project === "string" && project) return project;
@@ -180,7 +223,11 @@ export async function loadAntigravityProject(
         signal: combinedSignal(signal, timeoutMs),
       });
       if (!response.ok) {
-        failures.push(`HTTP ${response.status}`);
+        // The body carries the only actionable part of this failure; a bare
+        // status cannot distinguish "your project is not allowlisted" from
+        // "your credential is bad".
+        const bodyText = await response.text().catch(() => "");
+        failures.push(antigravityBootstrapFailure(response.status, bodyText));
         continue;
       }
       const payload = await response.json().catch(() => undefined);

--- a/test/antigravity-bootstrap-failure.test.mjs
+++ b/test/antigravity-bootstrap-failure.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { antigravityBootstrapFailure } from "../src/antigravity-project.mjs";
+
+const PROJECT_NUMBER = "123456789012";
+
+// The exact shape Google returns for a private API the caller's project is not
+// allowlisted for, reproduced from issue #566.
+function serviceDisabledBody(service = "cloudcode-pa.googleapis.com") {
+  return JSON.stringify({
+    error: {
+      code: 403,
+      status: "PERMISSION_DENIED",
+      message:
+        `Cloud Code Private API has not been used in project ${PROJECT_NUMBER} before ` +
+        "or it is disabled. Enable it by visiting " +
+        `https://console.developers.google.com/apis/api/${service}/overview?project=${PROJECT_NUMBER}` +
+        " then retry.",
+      details: [{ reason: "SERVICE_DISABLED", metadata: { service } }],
+    },
+  });
+}
+
+test("a disabled private API is named as an allowlist problem, not a credential one", () => {
+  const message = antigravityBootstrapFailure(403, serviceDisabledBody());
+  assert.match(message, /HTTP 403/);
+  assert.match(message, /not allowlisted/);
+  assert.match(message, /cloudcode-pa\.googleapis\.com/);
+  assert.match(message, /private Google API that an ordinary project cannot enable/);
+  // Sign-in works; saying otherwise sends the operator back through a flow
+  // that is not broken.
+  assert.match(message, /sign-in succeeded/);
+});
+
+test("the operator's project number and console URL never reach the message", () => {
+  // The free-text message embeds both, and this string is printed and logged.
+  const message = antigravityBootstrapFailure(403, serviceDisabledBody());
+  assert.doesNotMatch(message, new RegExp(PROJECT_NUMBER));
+  assert.doesNotMatch(message, /console\.developers\.google\.com/);
+  assert.doesNotMatch(message, /https?:\/\//);
+});
+
+test("another disabled service is reported without the allowlist explanation", () => {
+  // The explanation is true of the private API specifically; an ordinary
+  // service really can be enabled, and claiming otherwise would misdirect.
+  const message = antigravityBootstrapFailure(403, serviceDisabledBody("translate.googleapis.com"));
+  assert.match(message, /HTTP 403/);
+  assert.match(message, /PERMISSION_DENIED/);
+  assert.match(message, /SERVICE_DISABLED/);
+  assert.match(message, /translate\.googleapis\.com/);
+  assert.doesNotMatch(message, /cannot enable/);
+});
+
+test("a structured error without SERVICE_DISABLED still surfaces its status", () => {
+  const body = JSON.stringify({
+    error: { code: 401, status: "UNAUTHENTICATED", message: "Invalid credentials." },
+  });
+  const message = antigravityBootstrapFailure(401, body);
+  assert.match(message, /HTTP 401/);
+  assert.match(message, /UNAUTHENTICATED/);
+});
+
+test("a body that is absent, empty, malformed, or not an error object degrades to the bare status", () => {
+  for (const body of [
+    undefined,
+    "",
+    "<html>502 Bad Gateway</html>",
+    "{ not json",
+    JSON.stringify({ ok: true }),
+    JSON.stringify({ error: "a string, not an object" }),
+    JSON.stringify({ error: { details: "not an array" } }),
+  ]) {
+    assert.equal(antigravityBootstrapFailure(403, body), "HTTP 403", JSON.stringify(body));
+  }
+});
+
+test("an oversized body cannot make the parser do unbounded work", () => {
+  const padded = `{"error":{"status":"X","details":[]},"pad":"${"a".repeat(64 * 1024)}"}`;
+  // Truncation makes it unparseable, which degrades to the bare status rather
+  // than parsing megabytes of an untrusted response.
+  assert.equal(antigravityBootstrapFailure(403, padded), "HTTP 403");
+});


### PR DESCRIPTION
## Problem

#566 shows the operator-owned Antigravity OAuth client completing sign-in and
then failing the live probe with:

```
Antigravity project bootstrap failed (HTTP 403; HTTP 403).
```

That reads as a credential problem, so the operator re-runs a sign-in that is
already working. Google was returning the actual reason and
`loadAntigravityProject()` discarded the body, pushing only `HTTP ${status}`.

## What is actually happening

The reporter established this thoroughly. `loadCodeAssist` is billed to the
project owning the calling OAuth client. With the bundled vendor client that was
Google's own allowlisted project; with an operator-owned client it is the
operator's, which is not allowlisted for `cloudcode-pa.googleapis.com`.

That service is a **private API**. Binding it needs the producer-side
`servicemanagement.services.bind` permission, so `gcloud services enable` fails
even when run by the project owner through gcloud's own first-party client, and
the service has no API Library entry to enable through the console.

**There is no operator-side workaround**, so the message should not imply one.

## Change

`antigravityBootstrapFailure()` reads the structured error and, for
`SERVICE_DISABLED` on that specific service, explains that the project is not
allowlisted and that **sign-in succeeded** — the part that stops the operator
retrying the wrong thing.

Deliberate restraint in three places:

- **Only structured fields are read.** Google's free-text `message` embeds the
  caller's project number and a console URL built from it, and this string is
  printed and logged. A test asserts neither appears.
- **The allowlist explanation is specific to the private API.** A different
  disabled service reports its status, reason, and name without it, because an
  ordinary service really can be enabled and saying otherwise would misdirect.
- **Every unexpected body degrades to the bare status** — absent, empty, HTML,
  malformed, non-error JSON, or oversized.

README now states the prerequisite, including plainly that the provider cannot
currently be used without an allowlisted project.

## Scope

This makes the failure legible. It does **not** make the provider work — nothing
in this repository can, since the allowlist is Google's. #566 should stay open
for the question of whether a supported path exists at all.

## Tests

`test/antigravity-bootstrap-failure.test.mjs`, 6 cases, using the exact response
shape from the issue.

Full suite: **3494 tests, 3469 pass, 0 fail.** `npm run check` clean.

Refs #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)