### PR TITLE
fix: honor a Retry-After that names a date instead of seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,16 @@
   `resetAt` parser the `x-ratelimit-*` snapshot already used, which reads
   delay-seconds, an HTTP-date, and a Go-style duration alike, and
   `api-forwarder`'s private copy of that conversion is gone in favor of the
-  shared one, so there is one place the header is read. A header that is
-  absent, unparseable, or already in the past now records nothing rather than
-  inventing a window — including the empty case, where `Number(null)` is `0`
-  and a rate-limit error consequently advised retrying "in about 0s" instead
-  of waiting.
+  shared one, so there is one place the header is read.
+- **A 429 that named no wait no longer advises retrying "in about 0s".**
+  `headers.get` answers null for a header that was never sent and
+  `Number(null)` is `0` — a finite value, so the rate-limit message quoted a
+  zero-second wait as though the provider had asked for one. Absence and an
+  unparseable value now read as no window at all, while a delay of `0` (which
+  RFC 9110 permits) and a date that has already passed are kept as the zero
+  they are, because a provider saying "now" is not a provider saying nothing.
+  Only a positive wait is worth wording, so both zeroes reach the operator as
+  "Wait a bit and retry."
 - **The Windows Control Center no longer flashes PowerShell windows.** A console
   process spawned by a parent that has no console of its own — the Electron
   Control Center and the tray — gets its own window unless `windowsHide` is set,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- **A `Retry-After` expressed as a date is now honored.** RFC 9110 allows
+  `Retry-After` to carry either delay-seconds or an HTTP-date. The router read
+  the header as a bare number, so a dated value became `NaN` and every consumer
+  discarded it: a burst 429 that named its own window did not qualify for
+  failover, no provider cooldown was recorded, and the translated error lost
+  its "retry in about Ns" hint. The turn therefore died on a provider that had
+  said exactly when it would be back, and each later turn paid the same refusal
+  again for the length of the window. The header now goes through the same
+  `resetAt` parser the `x-ratelimit-*` snapshot already used, which reads
+  delay-seconds, an HTTP-date, and a Go-style duration alike, and
+  `api-forwarder`'s private copy of that conversion is gone in favor of the
+  shared one, so there is one place the header is read. A header that is
+  absent, unparseable, or already in the past now records nothing rather than
+  inventing a window — including the empty case, where `Number(null)` is `0`
+  and a rate-limit error consequently advised retrying "in about 0s" instead
+  of waiting.
 - **The Windows Control Center no longer flashes PowerShell windows.** A console
   process spawned by a parent that has no console of its own — the Electron
   Control Center and the tray — gets its own window unless `windowsHide` is set,

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -28,6 +28,7 @@ import {
   cooldownUntil,
   parseRateLimitHeaders,
   requestQuotaFromRateLimitHeaders,
+  retryAfterSeconds,
 } from "./rate-limit-headers.mjs";
 import { recordRateLimitSnapshot } from "./rate-limit-state.mjs";
 import { recordProviderCooldown } from "./model-failover.mjs";
@@ -1122,12 +1123,6 @@ function recordUpstreamLimits(normalized, upstream) {
   });
 }
 
-function responseRetryAfterSeconds(headers, now = Date.now()) {
-  const retryAt = Date.parse(parseRateLimitHeaders(headers, { now })?.retryAt || "");
-  if (!Number.isFinite(retryAt) || retryAt <= now) return undefined;
-  return Math.max(1, Math.ceil((retryAt - now) / 1_000));
-}
-
 function healthPayload() {
   const providers = {};
   let ok = true;
@@ -1371,7 +1366,7 @@ async function handleRequest(request, response) {
             ...outcome,
             headers: outcome.responseHeaders || upstreamHeaders,
             upstreamHeaders,
-            retryAfterSeconds: responseRetryAfterSeconds(upstreamHeaders),
+            retryAfterSeconds: retryAfterSeconds(upstreamHeaders),
             quota: requestQuotaFromRateLimitHeaders(upstreamHeaders),
             committed: outcome.committed === true,
             route: "plan",
@@ -1441,7 +1436,7 @@ async function handleRequest(request, response) {
                 ...outcome,
                 headers: outcome.responseHeaders || upstreamHeaders,
                 upstreamHeaders,
-                retryAfterSeconds: responseRetryAfterSeconds(upstreamHeaders),
+                retryAfterSeconds: retryAfterSeconds(upstreamHeaders),
                 quota: requestQuotaFromRateLimitHeaders(upstreamHeaders),
                 committed: outcome.committed === true,
                 route: "plan",
@@ -1453,7 +1448,7 @@ async function handleRequest(request, response) {
             status: attemptResponse.status,
             ok: false,
             committed: false,
-            retryAfterSeconds: responseRetryAfterSeconds(attemptResponse.headers),
+            retryAfterSeconds: retryAfterSeconds(attemptResponse.headers),
             quota: requestQuotaFromRateLimitHeaders(attemptResponse.headers),
             bodyText,
             headers: attemptResponse.headers,
@@ -1543,7 +1538,7 @@ async function handleRequest(request, response) {
         ok: upstream.ok,
         committed: false,
         error: upstream.ok ? undefined : `upstream status ${upstream.status}`,
-        retryAfterSeconds: responseRetryAfterSeconds(upstream.headers),
+        retryAfterSeconds: retryAfterSeconds(upstream.headers),
         quota: requestQuotaFromRateLimitHeaders(upstream.headers),
       });
     }

--- a/src/error-translation.mjs
+++ b/src/error-translation.mjs
@@ -242,7 +242,11 @@ function describeFailure({
     };
   }
   if (status === 429) {
-    const hint = Number.isFinite(retryAfterSeconds)
+    // A named window is quoted; anything else asks for patience. `Retry-After:
+    // 0` is a real answer ("now") but not a useful sentence -- "retry in about
+    // 0s" reads as a rounding bug, and a provider that just refused this turn
+    // is not owed an instant second one.
+    const hint = Number.isFinite(retryAfterSeconds) && retryAfterSeconds > 0
       ? `Retry in about ${retryAfterSeconds}s.`
       : "Wait a bit and retry.";
     return {

--- a/src/rate-limit-headers.mjs
+++ b/src/rate-limit-headers.mjs
@@ -115,6 +115,25 @@ export function requestQuotaFromRateLimitHeaders(headers, { now = Date.now() } =
   };
 }
 
+// `Retry-After` in seconds-from-now, whichever of its two legal forms the
+// provider chose. RFC 9110 allows an HTTP-date as well as delay-seconds, so
+// reading the header as a bare number answers NaN for a value that is perfectly
+// valid. Every caller that turns this header into behavior -- a failover
+// decision, a provider cooldown, the "retry in about Ns" hint -- discards NaN,
+// so a dated header reads as "the provider said nothing" and the window it
+// named is spent re-asking a provider that already answered the question.
+//
+// `undefined` when the header is absent, unparseable, or already in the past;
+// otherwise at least 1, because a sub-second wait rounded to 0 would be
+// indistinguishable from no wait at all. Absence matters as much as the date
+// form: `headers.get` answers null there, and `Number(null)` is 0.
+export function retryAfterSeconds(headers, { now = Date.now() } = {}) {
+  if (!headers || typeof headers.get !== "function") return undefined;
+  const at = resetAt(headers.get("retry-after"), now);
+  if (at === undefined || at <= now) return undefined;
+  return Math.max(1, Math.ceil((at - now) / 1_000));
+}
+
 // The soonest moment a provider is worth retrying, or undefined when nothing in
 // the response says the caller is currently limited. A cooldown map reads this.
 export function cooldownUntil(snapshot) {

--- a/src/rate-limit-headers.mjs
+++ b/src/rate-limit-headers.mjs
@@ -123,15 +123,27 @@ export function requestQuotaFromRateLimitHeaders(headers, { now = Date.now() } =
 // so a dated header reads as "the provider said nothing" and the window it
 // named is spent re-asking a provider that already answered the question.
 //
-// `undefined` when the header is absent, unparseable, or already in the past;
-// otherwise at least 1, because a sub-second wait rounded to 0 would be
-// indistinguishable from no wait at all. Absence matters as much as the date
-// form: `headers.get` answers null there, and `Number(null)` is 0.
+// `undefined` means the provider named no window at all -- the header is
+// absent or unparseable -- and every caller treats that as "decide for
+// yourself". A number is what it said, including `0`: RFC 9110's
+// delay-seconds is a non-negative integer, so `Retry-After: 0` is a provider
+// answering "now", not a provider staying silent, and a date whose instant has
+// already passed says the same thing. Distinguishing the two is this
+// function's whole job; whether a zero-length wait is worth wording is the
+// caller's, and `translateGatewayError` decides it there.
+//
+// Absence is the case that made this worth a shared helper alongside the date
+// form: `headers.get` answers null for a header that was never sent, and
+// `Number(null)` is 0 -- a finite value the old call sites could not tell from
+// a real zero.
 export function retryAfterSeconds(headers, { now = Date.now() } = {}) {
   if (!headers || typeof headers.get !== "function") return undefined;
   const at = resetAt(headers.get("retry-after"), now);
-  if (at === undefined || at <= now) return undefined;
-  return Math.max(1, Math.ceil((at - now) / 1_000));
+  if (at === undefined) return undefined;
+  // `ceil` keeps a sub-second wait at 1 rather than rounding it into the zero
+  // that means "no wait"; the clamp keeps an elapsed window there instead of
+  // reporting a negative one.
+  return Math.max(0, Math.ceil((at - now) / 1_000));
 }
 
 // The soonest moment a provider is worth retrying, or undefined when nothing in

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -134,6 +134,7 @@ import {
   readFailoverSettings,
   recordProviderCooldown,
 } from "./model-failover.mjs";
+import { retryAfterSeconds } from "./rate-limit-headers.mjs";
 import {
   awaitingSpawnProof,
   recordSpawnFailure,
@@ -2628,7 +2629,7 @@ async function summarize(request, payload, route, signal, { allowFailover = true
     const verdict = classifyRoutedFailure({
       status: sent.upstream.status,
       bodyText: bytes.toString("utf8"),
-      retryAfterSeconds: Number(sent.upstream.headers.get("retry-after")),
+      retryAfterSeconds: retryAfterSeconds(sent.upstream.headers),
     });
     if (!allowFailover) return { ...last, failed };
     if (!verdict.swap) return { ...last, failed };
@@ -3422,7 +3423,7 @@ async function attemptModelFailover({
     const hopVerdict = classifyRoutedFailure({
       status: upstream.status,
       bodyText: hopBodyText,
-      retryAfterSeconds: Number(upstream.headers.get("retry-after")),
+      retryAfterSeconds: retryAfterSeconds(upstream.headers),
     });
     // A transport retry stops as soon as another provider gives any real HTTP
     // answer. Walking onward would turn an application failure into a silent
@@ -3830,7 +3831,7 @@ async function handleResponses(request, response, requestUrl) {
       const verdict = classifyRoutedFailure({
         status: upstream.status,
         bodyText: failedBodyText,
-        retryAfterSeconds: Number(upstream.headers.get("retry-after")),
+        retryAfterSeconds: retryAfterSeconds(upstream.headers),
       });
       if (verdict.swap && !exactRouteProbe) {
         // Believe the provider about when it will be back before trying anyone
@@ -3899,7 +3900,7 @@ async function handleResponses(request, response, requestUrl) {
     if (route && !upstream.ok) {
       const provider = providerForModel(route);
       const retryAfterHeader = upstream.headers.get("retry-after");
-      const retryAfterSeconds = Number(retryAfterHeader);
+      const retrySeconds = retryAfterSeconds(upstream.headers);
       const translatedStatus = gatewayErrorStatus({
         status: upstream.status,
         bodyText: failedBodyText,
@@ -3920,9 +3921,7 @@ async function handleResponses(request, response, requestUrl) {
               : provider?.ownedBy || provider?.displayName || route.provider,
           providerKind: provider?.kind,
           providerAuthMode: provider?.authMode,
-          retryAfterSeconds: Number.isFinite(retryAfterSeconds)
-            ? retryAfterSeconds
-            : undefined,
+          retryAfterSeconds: retrySeconds,
         }),
       );
       recordUsageEvent({

--- a/test/error-translation.test.mjs
+++ b/test/error-translation.test.mjs
@@ -117,6 +117,24 @@ test("a 429 mentions rate limiting and the retry hint", () => {
   assert.equal(payload.error.type, "rate_limit_error");
 });
 
+test("a zero-second window asks for patience rather than quoting 0s", () => {
+  // `Retry-After: 0` parses to a real 0 rather than to "no window", which is
+  // the distinction the header parser exists to keep. It still must not become
+  // "retry in about 0s": that reads as a rounding bug, and it is the same
+  // advice as no window at all.
+  const payload = translateGatewayError({
+    status: 429,
+    bodyText: "",
+    modelName: "Kimi K3",
+    providerName: "kimi",
+    retryAfterSeconds: 0,
+  });
+  assert.equal(
+    payload.error.message,
+    "kimi is rate-limiting Kimi K3. Wait a bit and retry. (HTTP 429)",
+  );
+});
+
 test("a 429 without retry-after still reads cleanly", () => {
   const payload = translateGatewayError({
     status: 429,

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -1582,16 +1582,21 @@ test("a rate limit that names its window as an HTTP-date still fails over", asyn
   }
 });
 
-test("a rate limit with no window does not advise retrying in 0s", async () => {
-  // `headers.get()` answers null for a header that was never sent, and
-  // `Number(null)` is 0 -- a finite number, so the translated error read as if
-  // the provider had named an immediate retry.
+test("a rate limit with no usable window asks for patience", async () => {
+  // Two ways a 429 can carry no wait worth quoting, and they used to be the
+  // same bug in opposite directions. `headers.get()` answers null for a header
+  // that was never sent and `Number(null)` is 0 -- finite, so the translated
+  // error advised retrying "in about 0s". An explicit `Retry-After: 0` is a
+  // real answer the parser now keeps as 0, and it must reach the operator as
+  // the same patient sentence rather than as that rounding-bug wording.
   const gw = await gateway(async (request, response) => {
-    await bodyJson(request);
+    const body = await bodyJson(request);
     const payload = Buffer.from(BURST_RATE_LIMIT_BODY, "utf8");
     response.writeHead(429, {
       "Content-Type": "application/json",
       "Content-Length": String(payload.length),
+      // The first turn sends no header at all; the second names zero.
+      ...(body.instructions === "zero" ? { "Retry-After": "0" } : {}),
     });
     response.end(payload);
   });
@@ -1599,11 +1604,13 @@ test("a rate limit with no window does not advise retrying in 0s", async () => {
   const child = run(routerEnv(gw.port, routerPort), { enabled: false, chain: [] });
   try {
     await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
-    const result = await readRouted(routerPort, TURN_BODY);
-    assert.equal(result.status, 429);
-    const message = JSON.parse(result.body).error.message;
-    assert.match(message, /Wait a bit and retry\./);
-    assert.doesNotMatch(message, /Retry in about 0s/);
+    for (const instructions of ["absent", "zero"]) {
+      const result = await readRouted(routerPort, { ...TURN_BODY, instructions });
+      assert.equal(result.status, 429);
+      const message = JSON.parse(result.body).error.message;
+      assert.match(message, /Wait a bit and retry\./);
+      assert.doesNotMatch(message, /Retry in about 0s/);
+    }
   } finally {
     await stopChild(child);
     await closeServer(gw.server);

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -102,6 +102,17 @@ const QUOTA_BODY = JSON.stringify({
   },
 });
 
+// A burst rate limit rather than an exhausted plan: nothing here reads as
+// quota, so the window the provider names in `Retry-After` is the only reason
+// the turn is allowed to move.
+const BURST_RATE_LIMIT_BODY = JSON.stringify({
+  error: {
+    message: "Rate limit reached for requests. Please slow down and try again.",
+    type: "rate_limit_error",
+    code: "429",
+  },
+});
+
 const FREE_USAGE_BODY = JSON.stringify({
   error: {
     type: "FreeUsageLimitError",
@@ -1515,6 +1526,84 @@ test("a client that leaves mid-failover does not hang or crash the router", asyn
     const events = await waitForUsageEvents(child.stateDir, 1, child);
     assert.ok(events.length >= 1);
     assert.doesNotMatch(child.testErrors(), /UnhandledPromiseRejection|FATAL/);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a rate limit that names its window as an HTTP-date still fails over", async () => {
+  // RFC 9110 lets `Retry-After` be an HTTP-date as well as delay-seconds, and a
+  // gateway in front of an origin sends the date form. Read as a bare number it
+  // is NaN, which the classifier discards -- so the turn used to die on a
+  // provider that had said exactly when it would be back, and every later turn
+  // paid the same refusal again because no cooldown was recorded either.
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    if (body.model === PRIMARY.gatewayModel) {
+      const payload = Buffer.from(BURST_RATE_LIMIT_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Retry-After": new Date(Date.now() + 30 * 60_000).toUTCString(),
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("fallback"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort));
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, TURN_BODY);
+    assert.equal(result.status, 200);
+    assert.match(result.body, /answered-by-fallback/);
+    assert.equal(seen.length, 2);
+    assert.equal(seen[1].model, FALLBACK.gatewayModel);
+
+    // The named window is believed, so the next turn skips the limited
+    // provider instead of spending another round trip on the same refusal.
+    const cooldowns = JSON.parse(
+      readFileSync(path.join(child.stateDir, "provider-cooldowns.json"), "utf8"),
+    );
+    assert.equal(cooldowns.deepseek.reason, "rate_limited");
+    assert.ok(Date.parse(cooldowns.deepseek.until) > Date.now());
+    const second = await readRouted(routerPort, TURN_BODY);
+    assert.equal(second.status, 200);
+    assert.equal(seen.length, 3);
+    assert.equal(seen[2].model, FALLBACK.gatewayModel);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a rate limit with no window does not advise retrying in 0s", async () => {
+  // `headers.get()` answers null for a header that was never sent, and
+  // `Number(null)` is 0 -- a finite number, so the translated error read as if
+  // the provider had named an immediate retry.
+  const gw = await gateway(async (request, response) => {
+    await bodyJson(request);
+    const payload = Buffer.from(BURST_RATE_LIMIT_BODY, "utf8");
+    response.writeHead(429, {
+      "Content-Type": "application/json",
+      "Content-Length": String(payload.length),
+    });
+    response.end(payload);
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), { enabled: false, chain: [] });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, TURN_BODY);
+    assert.equal(result.status, 429);
+    const message = JSON.parse(result.body).error.message;
+    assert.match(message, /Wait a bit and retry\./);
+    assert.doesNotMatch(message, /Retry in about 0s/);
   } finally {
     await stopChild(child);
     await closeServer(gw.server);

--- a/test/rate-limit-headers.test.mjs
+++ b/test/rate-limit-headers.test.mjs
@@ -141,7 +141,7 @@ test("cooldown only triggers on real exhaustion", () => {
   assert.equal(cooldownUntil(undefined), undefined);
 });
 
-test("retry-after reads every form RFC 9110 allows", () => {
+test("retry-after reads RFC forms and the extensions providers actually send", () => {
   const seconds = (value) =>
     retryAfterSeconds(new Headers(value === undefined ? {} : { "retry-after": value }), {
       now: NOW,
@@ -150,16 +150,21 @@ test("retry-after reads every form RFC 9110 allows", () => {
   assert.equal(seconds("120"), 120);
   // HTTP-date, equally legal and what a gateway in front of the origin sends.
   assert.equal(seconds("Sat, 25 Jul 2026 12:05:00 GMT"), 300);
-  // Sub-second waits round up: a caller that saw 0 could not tell it apart
-  // from a header that was never sent.
+  // Zero is a non-negative integer, so it is a provider saying "now" rather
+  // than a provider saying nothing. The two must stay distinguishable here;
+  // whether "now" is worth wording belongs to the caller.
+  assert.equal(seconds("0"), 0);
+  // A window that elapsed before the response was read says the same thing.
+  assert.equal(seconds("Sat, 25 Jul 2026 11:59:00 GMT"), 0);
+  // Not RFC grammar -- delay-seconds is an integer -- but providers do send
+  // fractions, and `resetAt` has always read them. A sub-second wait keeps its
+  // second rather than rounding into the zero that means "no wait".
   assert.equal(seconds("0.2"), 1);
   // Nothing usable, so the caller keeps its own judgement rather than
   // inheriting a window the provider never named.
   assert.equal(seconds(undefined), undefined);
   assert.equal(seconds("soon"), undefined);
-  assert.equal(seconds("0"), undefined);
-  // Already elapsed by the time the response was read.
-  assert.equal(seconds("Sat, 25 Jul 2026 11:59:00 GMT"), undefined);
+  assert.equal(seconds("-5"), undefined);
   assert.equal(retryAfterSeconds(undefined, { now: NOW }), undefined);
   assert.equal(retryAfterSeconds({}, { now: NOW }), undefined);
 });

--- a/test/rate-limit-headers.test.mjs
+++ b/test/rate-limit-headers.test.mjs
@@ -6,6 +6,7 @@ const {
   parseRateLimitHeaders,
   requestQuotaFromRateLimitHeaders,
   resetAt,
+  retryAfterSeconds,
 } = await import(
   "../src/rate-limit-headers.mjs"
 );
@@ -138,4 +139,27 @@ test("cooldown only triggers on real exhaustion", () => {
   // An explicit retry-after is honored on its own.
   assert.equal(cooldownUntil({ retryAt: "2026-07-25T12:09:00.000Z" }), "2026-07-25T12:09:00.000Z");
   assert.equal(cooldownUntil(undefined), undefined);
+});
+
+test("retry-after reads every form RFC 9110 allows", () => {
+  const seconds = (value) =>
+    retryAfterSeconds(new Headers(value === undefined ? {} : { "retry-after": value }), {
+      now: NOW,
+    });
+  // delay-seconds, the form most OpenAI-compatible providers send.
+  assert.equal(seconds("120"), 120);
+  // HTTP-date, equally legal and what a gateway in front of the origin sends.
+  assert.equal(seconds("Sat, 25 Jul 2026 12:05:00 GMT"), 300);
+  // Sub-second waits round up: a caller that saw 0 could not tell it apart
+  // from a header that was never sent.
+  assert.equal(seconds("0.2"), 1);
+  // Nothing usable, so the caller keeps its own judgement rather than
+  // inheriting a window the provider never named.
+  assert.equal(seconds(undefined), undefined);
+  assert.equal(seconds("soon"), undefined);
+  assert.equal(seconds("0"), undefined);
+  // Already elapsed by the time the response was read.
+  assert.equal(seconds("Sat, 25 Jul 2026 11:59:00 GMT"), undefined);
+  assert.equal(retryAfterSeconds(undefined, { now: NOW }), undefined);
+  assert.equal(retryAfterSeconds({}, { now: NOW }), undefined);
 });


### PR DESCRIPTION
## Why

`Retry-After` is the only reason `classifyRoutedFailure` ever learns a window for a burst rate limit, and RFC 9110 §10.2.3 lets a provider express it two ways: `delay-seconds` **or** an `HTTP-date`. The router reads it with `Number()`:

```js
retryAfterSeconds: Number(upstream.headers.get("retry-after")),
```

so `Retry-After: Sat, 25 Jul 2026 12:05:00 GMT` becomes `NaN`, and every consumer discards `NaN`:

- `classifyRoutedFailure` returns `{ swap: false }` for a 429, so the turn does **not** fail over — it dies on a provider that had just said when it would be back, with other credentialed models sitting right there.
- No `provider-cooldowns.json` entry is written, so the next turn asks the same limited provider again, and the one after that — for the whole window. That is the same shape as the "225 quota refusals against one window" the module's own comments describe.
- `translateGatewayError` loses the "Retry in about Ns." hint and falls back to "Wait a bit and retry."

The repo already has a parser that handles all of this: `resetAt()` in `src/rate-limit-headers.mjs` reads delay-seconds, an HTTP-date, and a Go-style duration, and `api-forwarder` had a private helper wrapping it. The router just never used either.

The same expression has a second, smaller defect: `headers.get()` answers `null` for a header that was never sent, and `Number(null)` is `0` — finite, so `Number.isFinite` accepts it and a 429 with no `Retry-After` at all told the operator to "Retry in about 0s.". Absence and a real zero are different answers, and neither one is worth quoting as a wait; the second commit separates them at the parser and settles the wording at the message.

## What changed

- add `retryAfterSeconds(headers, { now })` to `src/rate-limit-headers.mjs`, built on the existing `resetAt()`. It reports what the header said and nothing more: `undefined` only when the value is absent or unparseable, a number otherwise — including the `0` that RFC 9110's `delay-seconds` permits, and an already-elapsed date, which is the same zero wait. A sub-second value still ceils to 1 rather than rounding into the zero that means "no wait"
- quote a wait in the 429 message only when it is positive. `Retry in about 0s.` was the wording a *missing* header produced, and it is no better as advice when a provider really did send zero, so both cases read as `Wait a bit and retry.`
- use it at the four `Retry-After` reads in `src/router.mjs` (compaction failover, the failover hop, the primary failure classification, and the translated error)
- delete `api-forwarder`'s private `responseRetryAfterSeconds` in favor of the shared helper — same semantics, one definition
- regression coverage: a 429 whose window is an HTTP-date now fails over and records a `rate_limited` cooldown that the next turn honors; a 429 with no window no longer advises "in about 0s"; unit coverage for each accepted and rejected header form

No registry, catalog, or subagent surface is touched.

## Verification

- `npm run check` — passes
- `npm test` — 3,414 passed, 0 failed, 25 skipped. 66 tests in `test/control-center-electron.test.mjs` are `cancelledByParent` in this environment; they reproduce identically on the unmodified tree, so they are not from this patch.
- `node --test test/model-failover-router.test.mjs test/rate-limit-headers.test.mjs test/error-translation.test.mjs` — 70 passed
- `node --test test/provider-api-key-forwarder.test.mjs test/commandcode-forwarder.test.mjs test/rate-limit-quota.test.mjs test/model-failover.test.mjs` — 51 passed (the `api-forwarder` call sites)
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- Both new integration tests were confirmed red before the fix: the HTTP-date turn returned 429 instead of failing over, and the zero-wait turn produced `Retry in about 0s.` — each half of that test was re-checked against a reverted tree so neither passes vacuously.
