### PR TITLE
fix: keep a separately billed variant out of its parent's cooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,22 @@
   Command Code Qwen3.8 Max 0902 and GLM-5.3-Flash; opencode Go Messages
   Qwen3.8 Flash. No new `multiAgentVersion: "v2"` stamps. Updated Command Code
   curation allowlists for the new Chat and Messages ids.
-
-- **The Windows Control Center no longer flashes PowerShell windows.** A console
-  process spawned by a parent that has no console of its own — the Electron
+- **An exhausted opencode Go plan no longer withdraws opencode Zen, or the
+  reverse.** Provider cooldowns were keyed by the canonical provider id, which
+  is the right identity for a protocol variant — opencode's Messages and
+  Responses routes are one subscription behind two wire formats, so one being
+  empty means all of them are. Zen is the exception the code already names in
+  `cooldownScope`: it shares Go's credential and selection toggle but is billed
+  separately at its own endpoint. Filing both windows under the parent meant a
+  closed Go plan silently answered a Zen turn from a different provider
+  (`reason=cooled_until_...`), and an exhausted Zen balance withdrew the whole
+  Go subscription — in both directions a paid route taken away for a window its
+  provider never named for it. Windows are now keyed by cooldown scope
+  wherever they are recorded, read, cleared, or ranked — including the vision
+  bridge's engine selection, which read a window its own writer files under a
+  different key — and `api-forwarder` passes the provider id through
+  unresolved so the scope is decided in one place. Protocol variants still
+  share a window, which is what the existing family test holds.
   Control Center and the tray — gets its own window unless `windowsHide` is set,
   and four background helpers were missing it. The one every private write
   reaches meant a burst of visible windows on each status refresh, which is why

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -1117,7 +1117,11 @@ function recordUpstreamLimits(normalized, upstream) {
   if (upstream.ok) return;
   const until = cooldownUntil(rateLimit);
   if (!until) return;
-  recordProviderCooldown(canonicalProviderId(normalized.provider.id), {
+  // The provider id is passed through unresolved: `recordProviderCooldown`
+  // keys the window by cooldown scope, and pre-canonicalizing here would file
+  // a separately billed variant's window under the subscription it does not
+  // share.
+  recordProviderCooldown(normalized.provider.id, {
     until,
     reason: upstream.status === 429 ? "rate_limited" : "out_of_usage",
   });

--- a/src/model-failover.mjs
+++ b/src/model-failover.mjs
@@ -5,6 +5,7 @@ import { writePrivateJson } from "./file-security.mjs";
 import { STATE_DIR } from "./paths.mjs";
 import { upstreamFailureKind } from "./error-translation.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
+import { cooldownScope } from "./provider-cooldown.mjs";
 import { canonicalProviderId } from "./provider-selection.mjs";
 import { hasProviderTransportError } from "./transport-failure.mjs";
 import {
@@ -183,6 +184,17 @@ function providerNamedResetUntil(bodyText, at) {
 }
 
 // -- how long an empty provider is believed ----------------------------------
+//
+// Windows are keyed by `cooldownScope`, not by the canonical provider id.
+// Protocol variants of one subscription do share an allowance -- opencode's
+// Messages and Responses variants are the same plan behind a different wire
+// format, so one being empty means all of them are. opencode Zen is not:
+// it shares a credential and a selection toggle with Go, and is billed
+// separately at its own endpoint. Keying its window under the canonical parent
+// made a closed Go plan withdraw a Zen route the operator can still pay for,
+// and an exhausted Zen balance withdraw the whole Go subscription -- in both
+// directions a paid route silently swapped away for a window the provider
+// never named for it.
 
 function readCooldownDocument() {
   if (!existsSync(PROVIDER_COOLDOWNS_PATH)) return {};
@@ -223,7 +235,7 @@ export function readProviderCooldowns({ now } = {}) {
 // `undefined` once the window the provider named has passed, so expiry needs no
 // sweeper and a provider comes back by itself.
 export function providerCooldown(providerId, { now } = {}) {
-  const id = canonicalProviderId(String(providerId || "").trim());
+  const id = cooldownScope(String(providerId || "").trim());
   return id ? readProviderCooldowns({ now })[id] : undefined;
 }
 
@@ -240,7 +252,7 @@ export function providerCooldown(providerId, { now } = {}) {
 // window of its own may sharpen the reason on a window that already exists.
 // It may never create one.
 export function recordProviderCooldown(providerId, { until, reason, now } = {}) {
-  const id = canonicalProviderId(String(providerId || "").trim());
+  const id = cooldownScope(String(providerId || "").trim());
   if (!id) return undefined;
   const at = nowMs(now);
   const document = readCooldownDocument();
@@ -269,7 +281,7 @@ export function recordProviderCooldown(providerId, { until, reason, now } = {}) 
 // end the same way, with a real answer, and that answer is better evidence than
 // anything this file recorded.
 export function clearProviderCooldown(providerId) {
-  const id = canonicalProviderId(String(providerId || "").trim());
+  const id = cooldownScope(String(providerId || "").trim());
   if (!id) return false;
   const document = readCooldownDocument();
   if (!(id in document)) return false;
@@ -393,7 +405,7 @@ function eligible(
 ) {
   if (!model?.slug) return false;
   if (canonicalProviderId(model.provider) === fromProvider) return false;
-  if (cooled.has(canonicalProviderId(model.provider))) return false;
+  if (cooled.has(cooldownScope(model.provider))) return false;
   if (Number.isFinite(estimatedTokens) && Number(model.contextWindow) < estimatedTokens) {
     return false;
   }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -134,6 +134,7 @@ import {
   readFailoverSettings,
   recordProviderCooldown,
 } from "./model-failover.mjs";
+import { cooldownScope } from "./provider-cooldown.mjs";
 import { retryAfterSeconds } from "./rate-limit-headers.mjs";
 import {
   awaitingSpawnProof,
@@ -2073,7 +2074,9 @@ async function bridgeVisionInput(input, route, request) {
   const readWithAnyEngine = async (url, question) => {
     let lastError;
     for (const [index, engine] of engines.entries()) {
-      const provider = canonicalProviderId(visionEngineProvider(engine));
+      // The same identity the window was recorded under: a separately billed
+      // variant shares this account's credential but not its allowance.
+      const provider = cooldownScope(visionEngineProvider(engine));
       const cooled = providerCooldown(provider);
       if (cooled || exhaustedProviders.has(provider)) {
         lastError ??= new Error(

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -55,6 +55,25 @@ const GENERIC_SEARCH_INCOMPATIBLE = {
   inputModalities: ["text"],
   compHash: "strict-generic-search-incompatible-fixture-v1",
 };
+// The Go plan route the Zen fixture must stay independent of: a checked-in
+// model on the parent provider, credentialed by the same key file.
+const GO_PLAN_MODEL = { slug: "opencode-go/glm-5.3", gatewayModel: "opencode-go-glm-5-3" };
+const ZEN_CANDIDATE = {
+  slug: "opencode-zen/glm-5.3",
+  gatewayModel: "opencode-zen-glm-5-3",
+  upstreamModel: "glm-5.3",
+  provider: "opencode-zen",
+  listed: true,
+  displayName: "opencode Zen GLM 5.3",
+  description: "Local routing test fixture.",
+  priority: 502,
+  defaultEffort: "high",
+  reasoningLevels: [{ effort: "high", description: "Adaptive reasoning" }],
+  contextWindow: 131_072,
+  autoCompact: 111_411,
+  inputModalities: ["text"],
+  compHash: "opencode-zen-failover-fixture-v1",
+};
 const STRICT_GENERIC_PROVIDER = {
   id: "strict-generic",
   displayName: "Strict generic fixture",
@@ -1576,6 +1595,93 @@ test("a rate limit that names its window as an HTTP-date still fails over", asyn
     assert.equal(second.status, 200);
     assert.equal(seen.length, 3);
     assert.equal(seen[2].model, FALLBACK.gatewayModel);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a closed Go plan window does not withdraw the separately billed Zen route", async () => {
+  // opencode Zen shares Go's credential and selection toggle, so its provider
+  // id resolves to `opencode-go` everywhere selection is concerned. Its bill
+  // does not: Zen is metered at its own endpoint. A window recorded for the Go
+  // plan used to withdraw Zen too, and the operator's chosen model was
+  // silently answered by a different provider.
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body.model);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse(body.model));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), {
+    userModels: [ZEN_CANDIDATE],
+    cooldowns: {
+      "opencode-go": {
+        until: new Date(Date.now() + 30 * 60_000).toISOString(),
+        reason: "out_of_usage",
+      },
+    },
+  });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const zen = await readRouted(routerPort, { ...TURN_BODY, model: ZEN_CANDIDATE.slug });
+    assert.equal(zen.status, 200);
+    assert.match(zen.body, new RegExp(`answered-by-${ZEN_CANDIDATE.gatewayModel}`));
+    assert.deepEqual(seen, [ZEN_CANDIDATE.gatewayModel]);
+    assert.doesNotMatch(child.testErrors(), /cooled_until_/);
+
+    // The plan the window was actually recorded for is still skipped: a
+    // protocol variant is the same subscription, and this test must not pass
+    // by disabling cooldowns.
+    const go = await readRouted(routerPort, { ...TURN_BODY, model: GO_PLAN_MODEL.slug });
+    assert.equal(go.status, 200);
+    assert.equal(seen.length, 2);
+    assert.equal(seen[1], FALLBACK.gatewayModel);
+    assert.match(child.testErrors(), /cooled_until_/);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("an exhausted Zen balance cools Zen rather than the Go subscription", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body.model);
+    if (body.model === ZEN_CANDIDATE.gatewayModel) {
+      const payload = Buffer.from(QUOTA_BODY, "utf8");
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Retry-After": "1800",
+        "Content-Length": String(payload.length),
+      });
+      response.end(payload);
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse(body.model));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), { userModels: [ZEN_CANDIDATE] });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const zen = await readRouted(routerPort, { ...TURN_BODY, model: ZEN_CANDIDATE.slug });
+    assert.equal(zen.status, 200);
+    assert.deepEqual(seen, [ZEN_CANDIDATE.gatewayModel, FALLBACK.gatewayModel]);
+
+    const cooldowns = JSON.parse(
+      readFileSync(path.join(child.stateDir, "provider-cooldowns.json"), "utf8"),
+    );
+    assert.equal(cooldowns["opencode-zen"].reason, "out_of_usage");
+    assert.equal(cooldowns["opencode-go"], undefined);
+
+    // The Go plan was never asked about, so it is still served.
+    const go = await readRouted(routerPort, { ...TURN_BODY, model: GO_PLAN_MODEL.slug });
+    assert.equal(go.status, 200);
+    assert.equal(seen.at(-1), GO_PLAN_MODEL.gatewayModel);
   } finally {
     await stopChild(child);
     await closeServer(gw.server);

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -281,6 +281,32 @@ test("a cooldown is recorded against the whole variant family", (t) => {
   assert.ok(providerCooldown("opencode-go", { now: NOW }));
 });
 
+test("a separately billed variant keeps its own window", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  // opencode Zen shares Go's credential and selection toggle but is billed at
+  // its own endpoint, so neither one being empty says anything about the
+  // other. Keying both under the canonical parent withdrew a paid route for a
+  // window its provider never named.
+  recordProviderCooldown("opencode-go", {
+    until: new Date(NOW + 1_800_000).toISOString(),
+    reason: "out_of_usage",
+    now: NOW,
+  });
+  assert.ok(providerCooldown("opencode-go-messages", { now: NOW }));
+  assert.equal(providerCooldown("opencode-zen", { now: NOW }), undefined);
+
+  recordProviderCooldown("opencode-zen", {
+    until: new Date(NOW + 1_800_000).toISOString(),
+    reason: "out_of_usage",
+    now: NOW,
+  });
+  assert.ok(providerCooldown("opencode-zen", { now: NOW }));
+  // Clearing one leaves the other exactly as it was.
+  clearProviderCooldown("opencode-zen");
+  assert.equal(providerCooldown("opencode-zen", { now: NOW }), undefined);
+  assert.ok(providerCooldown("opencode-go", { now: NOW }));
+});
+
 test("a later hop may sharpen the reason but never invent the window", (t) => {
   t.after(() => clearAllProviderCooldowns());
   // api-forwarder sees the provider's Retry-After but not its body, so it can
@@ -391,6 +417,28 @@ test("rankFailoverCandidates skips a provider that is already cooled down", (t) 
   assert.deepEqual(
     ranked.map((entry) => entry.model.slug),
     ["deepseek/v4"],
+  );
+});
+
+test("rankFailoverCandidates still offers a separately billed variant", (t) => {
+  t.after(() => clearAllProviderCooldowns());
+  // The Go plan is empty. Its protocol variants are empty with it; Zen is a
+  // different bill at a different endpoint and remains a candidate.
+  recordProviderCooldown("opencode-go", {
+    until: new Date(NOW + 600_000).toISOString(),
+    now: NOW,
+  });
+  const ranked = rankFailoverCandidates(
+    [
+      model("opencode-go/glm-5.3", "opencode-go"),
+      model("opencode-go-responses/glm-5.3", "opencode-go-responses"),
+      model("opencode-zen/glm-5.3", "opencode-zen"),
+    ],
+    { from: FROM, now: NOW },
+  );
+  assert.deepEqual(
+    ranked.map((entry) => entry.model.slug),
+    ["opencode-zen/glm-5.3"],
   );
 });
 


### PR DESCRIPTION
## Why

`opencode-zen` is declared `variantOf: "opencode-go"` because it shares Go's credential and selection toggle. It does not share Go's bill — it is a different endpoint (`/zen/v1` vs `/zen/go/v1`), and it is the only variant in the registry whose `baseUrl` differs from its parent's. `src/provider-cooldown.mjs` already names this exactly:

> opencode Zen is the exception: it shares a credential and selection toggle with Go, but it uses the separately billed /zen endpoint. Exhausting Go must not disable a route the operator can still pay for through Zen.

The live failover path never used that scope. `providerCooldown`, `recordProviderCooldown`, `clearProviderCooldown`, and `eligible()` all keyed windows by `canonicalProviderId`, which folds Zen into `opencode-go`. Both directions cost the operator a paid route:

- **Go's window withdraws Zen.** With `{"opencode-go": {...}}` in `provider-cooldowns.json`, a turn on a curated `opencode-zen/...` model is never sent. It is silently answered by a different provider — reproduced against the existing harness before the fix:

  ```
  [codex-router] failover model=opencode-zen/glm-5.3 status=not-sent
    reason=cooled_until_2026-09-02T19:00:19.932Z -> zai-api/glm-5.2 outcome=swapped
  ```

- **Zen's window withdraws Go.** An exhausted Zen balance is filed under `opencode-go`, so the whole Go subscription is skipped for up to six hours over a balance that has nothing to do with it.

Zen models are curated locally (nothing is checked in for that provider), so this hits any operator who curated one and then hit either limit.

## What changed

- `src/model-failover.mjs` keys windows by `cooldownScope` when recording, reading, clearing, and ranking candidates
- `src/router.mjs`'s vision-bridge engine selection uses the same scope: it pre-canonicalized before reading a window its own writer (a few lines above, `recordProviderCooldown(visionEngineProvider(engine), …)`) files by raw provider id, so after this change the two halves would otherwise disagree
- `src/api-forwarder.mjs` passes `normalized.provider.id` through unresolved, so the scope is decided in one place instead of being pre-collapsed at the call site
- regression coverage in both directions, unit and end-to-end

Deliberately unchanged: `eligible()` still refuses a candidate whose canonical provider is the one that just failed, so an exhausted Go plan does not automatically fail over onto separately billed Zen credits. Spending a second balance on the operator's behalf is a different decision from not withdrawing a route they chose. Usage-event attribution also keeps `canonicalProviderId` — usage rolls up to the account.

## Verification

- All four new tests confirmed red before the fix and green after:
  - `a closed Go plan window does not withdraw the separately billed Zen route` (also asserts a Go route *is* still skipped by the same window, so the test cannot pass by disabling cooldowns)
  - `an exhausted Zen balance cools Zen rather than the Go subscription`
  - `a separately billed variant keeps its own window`
  - `rankFailoverCandidates still offers a separately billed variant`
- The existing `a cooldown is recorded against the whole variant family` test passes unchanged — protocol variants still share one window.
- `npm run check` — passes
- `npm test` — 3,415 passed, 0 failed, 25 skipped. 67 tests are `cancelledByParent` in this environment (66 in `test/control-center-electron.test.mjs`, 1 in `test/search-sidecar.test.mjs`); both reproduce identically on a clean tree, so they are not from this patch.
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities

Independent of #573 (both branch from `main`; no overlapping lines).