### PR TITLE
fix: grant Users read access to checkout so Limited task can start

### DIFF
--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -326,6 +326,62 @@ export async function writePrivateJsonAsync(target, value, { space = 2, director
   return value;
 }
 
+// Ensure a directory and its contents are readable by the Limited-level
+// scheduled task. On Windows, an elevated installer creates directories and
+// files with ACLs that only allow the elevated account to read them. The
+// scheduled task runs at Limited level (issue #548), so it cannot read a
+// checkout created by an elevated shell. This function grants Users read and
+// execute access to the directory tree, so the Limited task can load modules.
+//
+// Only the checkout directory needs this treatment: STATE_DIR files are
+// deliberately owner-only and are never loaded by the task directly.
+export function ensureCheckoutReadable(checkoutPath) {
+  if (process.platform !== "win32") return;
+  // The script grants Users (BUILTIN\Users) ReadAndExecute on the checkout
+  // directory, recursively. This allows the Limited-level task to traverse
+  // directories and read files while keeping write access restricted.
+  const script = [
+    "$ErrorActionPreference = 'Stop'",
+    "try {",
+    "  $path = $env:CODEX_ROUTER_CHECKOUT_PATH",
+    "  $usersId = [Security.Principal.SecurityIdentifier]::new('S-1-5-32-545')",
+    "  $readExecute = [System.Security.AccessControl.FileSystemRights]::ReadAndExecute",
+    "  $containerInherit = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit",
+    "  $objectInherit = [System.Security.AccessControl.InheritanceFlags]::ObjectInherit",
+    "  $propagationNone = [System.Security.AccessControl.PropagationFlags]::None",
+    "  $allow = [System.Security.AccessControl.AccessControlType]::Allow",
+    "  $acl = [System.IO.Directory]::GetAccessControl($path)",
+    "  $rule = [System.Security.AccessControl.FileSystemAccessRule]::new($usersId, $readExecute, ($containerInherit -bor $objectInherit), $propagationNone, $allow)",
+    "  $acl.AddAccessRule($rule)",
+    "  [System.IO.Directory]::SetAccessControl($path, $acl)",
+    "} catch {",
+    "  [Console]::Error.WriteLine($_.Exception.Message)",
+    "  exit 1",
+    "}",
+  ].join("\n");
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
+  try {
+    execFileSync(
+      "powershell.exe",
+      ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
+      {
+        env: { CODEX_ROUTER_CHECKOUT_PATH: checkoutPath },
+        stdio: ["ignore", "ignore", "pipe"],
+        timeout: 15_000,
+        windowsHide: true,
+      },
+    );
+  } catch (error) {
+    const detail = String(error?.stderr?.trim?.() || error?.message || "").trim();
+    // This is a best-effort operation: if PowerShell is unavailable or the
+    // ACL cannot be modified, the operator can still fix it manually per the
+    // diagnostic message. Do not fail the install outright.
+    if (detail) {
+      console.warn(`Warning: Could not grant Users read access to checkout: ${detail}`);
+    }
+  }
+}
+
 export function privateFileIsProtected(target) {
   if (!existsSync(target)) return false;
   if (process.platform !== "win32") return (statSync(target).mode & 0o777) === 0o600;

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -365,7 +365,7 @@ export function ensureCheckoutReadable(checkoutPath) {
       "powershell.exe",
       ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
       {
-        env: { CODEX_ROUTER_CHECKOUT_PATH: checkoutPath },
+        env: { ...process.env, CODEX_ROUTER_CHECKOUT_PATH: checkoutPath },
         stdio: ["ignore", "ignore", "pipe"],
         timeout: 15_000,
         windowsHide: true,

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -21,7 +21,7 @@ import {
   readServiceProcessState,
   serviceProcessOwns,
 } from "./service-process.mjs";
-import { protectPrivateFile } from "./file-security.mjs";
+import { ensureCheckoutReadable, protectPrivateFile } from "./file-security.mjs";
 import { providerApiKeyServiceEnvironment } from "./provider-api-key-service-environment.mjs";
 import { serviceProxyEnvironment } from "./proxy-environment.mjs";
 import {
@@ -460,6 +460,11 @@ if (command === "render") {
   // failure, and must exit non-zero without touching the host filesystem.
   guardLauncherWrite();
   try {
+    // Ensure the checkout directory is readable by the Limited-level scheduled
+    // task. An elevated installer creates files with ACLs that only allow the
+    // elevated account to read them, while the task runs at Limited level
+    // (issue #548). Grant Users read access so the task can load modules.
+    ensureCheckoutReadable(SOURCE_ROOT);
     // Writing the launchers belongs inside the try: renameSync over the .vbs
     // raises a sharing violation while a running wscript.exe still holds it
     // open, and that used to throw out of install with nothing to catch it.

--- a/test/file-security.test.mjs
+++ b/test/file-security.test.mjs
@@ -1,12 +1,13 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  ensureCheckoutReadable,
   privateFileIsProtected,
   protectPrivateFile,
   writePrivateJson,
@@ -273,6 +274,47 @@ test(
       await writePrivateJsonAsync(target, { version: 1, value: "second" });
       assert.deepEqual(JSON.parse(readFileSync(target, "utf8")), { version: 1, value: "second" });
       assert.equal(privateFileIsProtected(target), true);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "ensureCheckoutReadable grants Users read access to the checkout directory on Windows",
+  { skip: process.platform !== "win32" },
+  () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "codex-router-checkout-"));
+    const file = path.join(directory, "src", "start.mjs");
+    try {
+      mkdirSync(path.join(directory, "src"), { recursive: true });
+      writeFileSync(file, "// test file\n");
+      // Call ensureCheckoutReadable to grant Users read access
+      ensureCheckoutReadable(directory);
+      // Verify that Users (S-1-5-32-545) has ReadAndExecute access
+      const script = [
+        "$acl = [System.IO.Directory]::GetAccessControl($env:CODEX_ROUTER_CHECKOUT)",
+        "$usersId = [Security.Principal.SecurityIdentifier]::new('S-1-5-32-545')",
+        "$rules = @($acl.GetAccessRules($true, $false, [Security.Principal.SecurityIdentifier]))",
+        "$usersRule = $rules | Where-Object { $_.IdentityReference.Value -eq $usersId.Value -and $_.AccessControlType -eq 'Allow' } | Select-Object -First 1",
+        "if ($null -ne $usersRule) {",
+        "  $readExecute = [System.Security.AccessControl.FileSystemRights]::ReadAndExecute",
+        "  $hasReadExecute = ($usersRule.FileSystemRights -band $readExecute) -eq $readExecute",
+        "  [Console]::Out.Write($hasReadExecute.ToString())",
+        "} else {",
+        "  [Console]::Out.Write('False')",
+        "}",
+      ].join("\n");
+      const result = execFileSync(
+        "powershell.exe",
+        ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
+        {
+          encoding: "utf8",
+          env: { ...process.env, CODEX_ROUTER_CHECKOUT: directory },
+          stdio: ["ignore", "pipe", "ignore"],
+        },
+      ).trim().toLowerCase();
+      assert.equal(result, "true", "Users should have ReadAndExecute access to the checkout");
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Issue

Fixes #548 

Windows scheduled tasks run at Limited level, but an elevated installer creates the checkout directory with ACLs that only allow the elevated account to read it. This made the task's attempt to load `src/start.mjs` fail with `MODULE_NOT_FOUND` even though the file exists.

## Analysis

The problem occurs when:
1. The installer runs in an elevated shell
2. The checkout directory and files are created with restrictive ACLs (only readable by the elevated account)
3. The scheduled task is created with `-RunLevel Limited` (line 208 in `src/service-windows.mjs`)
4. The Limited-level task cannot read files owned by the elevated account
5. Node.js reports this as `MODULE_NOT_FOUND`, which is indistinguishable from a truly missing file

Commit 1476c60 improved the diagnostic message to explain this ACL problem and suggest running `icacls` manually, but did not fix the underlying cause.

## Solution

This PR makes service installation automatically grant `BUILTIN\Users` ReadAndExecute access to the checkout directory. This allows the Limited-level scheduled task to traverse directories and read source files.

The fix preserves the security boundary:
- **STATE_DIR files remain owner-only protected** (credentials, secrets, private state)
- **Only the checkout tree becomes readable by all users** (contains no secrets)
- This matches the installer's documented advice to either grant the task's account access or run the installer non-elevated

## Changes

1. **Added `ensureCheckoutReadable()` to `src/file-security.mjs`**
   - Grants BUILTIN\Users (S-1-5-32-545) ReadAndExecute permission on the checkout directory
   - Uses inheritance flags so permissions apply recursively
   - Best-effort operation: warns but doesn't fail if ACL modification fails
   - Only runs on Windows

2. **Updated `src/service-windows.mjs`**
   - Calls `ensureCheckoutReadable(SOURCE_ROOT)` during service installation
   - Ensures the checkout is readable before writing launchers and installing the task

3. **Added test coverage in `test/file-security.test.mjs`**
   - Verifies that `ensureCheckoutReadable()` grants Users ReadAndExecute access
   - Skipped on non-Windows platforms

## Testing Note

**This agent runs on Linux and cannot live-test the Windows scheduled task.** The implementation:
- Uses the same PowerShell ACL pattern as existing `protectPrivateFile` code
- Adds a test that verifies the ACL is correctly set (Windows-only)
- Follows the documented SID for BUILTIN\Users (S-1-5-32-545)
- Uses `DirectorySecurity` rather than `FileSecurity` for directory ACLs

A Windows maintainer should verify that:
1. An elevated `install.ps1` followed by scheduled task start succeeds
2. The task can read `src/start.mjs` and start the router
3. Private files in STATE_DIR remain owner-only protected

## Verification

The fix should allow the exact failure scenario from #548 to succeed:
1. Run `install.ps1` from an elevated PowerShell
2. The service installs and grants Users read access to the checkout
3. The scheduled task (running at Limited level) can now read `src\start.mjs`
4. The router starts successfully instead of failing with `MODULE_NOT_FOUND`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1de7167e-c29d-4b09-a333-b5e46b8cc22e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1de7167e-c29d-4b09-a333-b5e46b8cc22e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

