### PR TITLE
Surface Antigravity 403 SERVICE_DISABLED body and document allowlist requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,35 +119,43 @@ user.
    For Antigravity OAuth, never read or reuse the official `agy`/IDE credential
    store and never use the vendor's OAuth client or identity. Require one
    coherent operator-owned Google OAuth client ID and secret pair: the operator
-   must create a Google OAuth **Desktop app** client they own. Run
-   `bin/model-router codex providers login antigravity-oauth`; the router first
-   binds `127.0.0.1` on an OS-assigned port, then opens a loopback-only setup
-   page where the client ID and matching secret are submitted without entering
-   shell history. Open only the local URL through the OS browser command and
-   redirect to Google inside that listener, so neither client value reaches
-   argv or terminal logs. The coherent pair and resulting tokens are stored together
-   in the router's owner-only credential file and used for refresh on macOS,
-   Linux, and Windows; they never belong in a service environment. Sign-in does
-   not call the private Antigravity service or enable the route. Run the
-   explicitly quota-consuming `providers probe antigravity-oauth --live --yes`
-   next; add `--provision-project` only when the operator separately authorizes
-   creation of a Google Cloud project. Provisioning still requires a successful,
-   schema-valid bootstrap response that explicitly advertises the selected tier;
-   auth errors, server errors, malformed responses, and missing tiers fail closed.
-   The probe identifies itself truthfully
-   as Codex Router, and only a successful proof makes the provider enableable.
-   The Antigravity forwarder is not spawned or health-gated before that proof,
-   so an unused provider port cannot fail the whole router. A passing probe
-   records a generation-bound `pending_activation` that every configured and
-   publication reader rejects. Startup alone may boot its exact pending proof;
-   only after the whole local stack is healthy does it atomically promote that
-   generation active. A failed restart, an early process death, a credential
-   replacement, or a disconnect leaves it nonpublishable. The probe restarts
-   an installed service through that sequence, and a foreground operator must
-   restart that process before enabling the provider. A v2 proof record with
-   no activation metadata is not grandfathered: it was written by the unsafe
-   pre-readiness path and must pass the explicit live probe again.
-   If Google accepts only an impersonated vendor client, leave it disabled.
+   must create a Google OAuth **Desktop app** client they own. **The Google
+   Cloud project behind that OAuth client must be allowlisted for
+   `cloudcode-pa.googleapis.com`, a private Google API.** Most projects are not
+   allowlisted, and operators cannot enable this API themselves: it requires
+   the producer-side `servicemanagement.services.bind` permission.
+   Run `bin/model-router codex providers login antigravity-oauth`; the router
+   first binds `127.0.0.1` on an OS-assigned port, then opens a loopback-only
+   setup page where the client ID and matching secret are submitted without
+   entering shell history. Open only the local URL through the OS browser
+   command and redirect to Google inside that listener, so neither client value
+   reaches argv or terminal logs. The coherent pair and resulting tokens are
+   stored together in the router's owner-only credential file and used for
+   refresh on macOS, Linux, and Windows; they never belong in a service
+   environment. Sign-in does not call the private Antigravity service or enable
+   the route. Run the explicitly quota-consuming
+   `providers probe antigravity-oauth --live --yes` next; add
+   `--provision-project` only when the operator separately authorizes creation
+   of a Google Cloud project. The live probe will fail with `SERVICE_DISABLED`
+   if the OAuth client's project is not allowlisted. Provisioning still
+   requires a successful, schema-valid bootstrap response that explicitly
+   advertises the selected tier; auth errors, server errors, malformed
+   responses, and missing tiers fail closed. The probe identifies itself
+   truthfully as Codex Router, and only a successful proof makes the provider
+   enableable. The Antigravity forwarder is not spawned or health-gated before
+   that proof, so an unused provider port cannot fail the whole router. A
+   passing probe records a generation-bound `pending_activation` that every
+   configured and publication reader rejects. Startup alone may boot its exact
+   pending proof; only after the whole local stack is healthy does it
+   atomically promote that generation active. A failed restart, an early
+   process death, a credential replacement, or a disconnect leaves it
+   nonpublishable. The probe restarts an installed service through that
+   sequence, and a foreground operator must restart that process before
+   enabling the provider. A v2 proof record with no activation metadata is not
+   grandfathered: it was written by the unsafe pre-readiness path and must pass
+   the explicit live probe again. If Google accepts only an impersonated vendor
+   client, leave it disabled. If the project is not allowlisted, this provider
+   cannot currently be used.
    A key does not mean every account may use the Provider API: the Go plan is
    refused with "Your Go plan doesn't include API access". GOAT, Pro, Max, Team,
    and Provider plans do have API access and meter against their own credits.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -144,7 +144,14 @@ CLI inference proxy. The separate `grok-api` provider continues to use a
 separately billed xAI API key.
 
 Antigravity OAuth uses a router-managed browser sign-in; it does not require a
-Gemini API key or a separate CLI. Sign in, run the explicit live compatibility
+Gemini API key or a separate CLI. **The Google Cloud project behind your OAuth
+client must be allowlisted for `cloudcode-pa.googleapis.com`, a private Google
+API.** Most projects are not allowlisted, and you cannot enable this API
+yourself: it requires the producer-side `servicemanagement.services.bind`
+permission, so `gcloud services enable` fails even for the project owner.
+Sign-in will succeed, but the live probe will fail with `SERVICE_DISABLED` if
+your project is not allowlisted. If your project is not allowlisted, this
+provider cannot currently be used. Sign in, run the explicit live compatibility
 probe, then enable the provider; these commands do not replace or disable any
 other provider already selected.
 

--- a/test/antigravity-project.test.mjs
+++ b/test/antigravity-project.test.mjs
@@ -137,6 +137,32 @@ test("bootstrap fails closed on auth errors, server errors, and malformed succes
   }
 });
 
+test("a 403 SERVICE_DISABLED body appears in the operator-visible error (issue #566)", async () => {
+  const serviceDisabledBody = JSON.stringify({
+    error: {
+      code: 403,
+      status: "PERMISSION_DENIED",
+      message: "Cloud Code Private API has not been used in project 123456789012...",
+      details: [{ reason: "SERVICE_DISABLED", metadata: { service: "cloudcode-pa.googleapis.com" } }],
+    },
+  });
+  let caughtError;
+  try {
+    await loadAntigravityProject("access", {
+      fetchImpl: async () => new Response(serviceDisabledBody, { status: 403 }),
+    });
+    assert.fail("should have thrown");
+  } catch (error) {
+    caughtError = error;
+  }
+  assert.equal(caughtError.code, "project_bootstrap_failed");
+  // The parsed body must reach the operator, not only HTTP 403
+  assert.match(caughtError.message, /not allowlisted/);
+  assert.match(caughtError.message, /cloudcode-pa\.googleapis\.com/);
+  assert.match(caughtError.message, /private Google API/);
+  assert.match(caughtError.message, /sign-in succeeded/);
+});
+
 test("project provisioning requires an explicitly advertised tier", async () => {
   let onboardCalls = 0;
   await assert.rejects(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #566

## Problem

Antigravity BYO OAuth sign-in with an operator-owned Desktop OAuth client succeeds and writes credential record v3, but the live probe fails with a bare `HTTP 403` error message. The actual Google response body contains `SERVICE_DISABLED` for `cloudcode-pa.googleapis.com`, which is the actionable information that explains the project is not allowlisted for this private API.

Additionally, README/INSTALL/AGENTS documentation currently **require** a BYO Desktop client but do not mention the private-API allowlist prerequisite upfront, so the documented happy path dead-ends for non-allowlisted projects.

## Solution

The code already correctly calls `antigravityBootstrapFailure()` which parses the error body and surfaces the structured Google error. No code changes were needed.

This PR adds:

1. **Test**: Added regression test in `test/antigravity-project.test.mjs` verifying that a 403 response with `SERVICE_DISABLED` body appears in the operator-visible error message with the allowlist explanation
2. **AGENTS.md**: Updated Antigravity OAuth setup section to state upfront that the OAuth client's Google Cloud project must be allowlisted for `cloudcode-pa.googleapis.com`, clarify that operators cannot enable this private API themselves, and note that the live probe will fail with `SERVICE_DISABLED` if not allowlisted
3. **INSTALL.md**: Added warning before Antigravity setup instructions stating the allowlist requirement and that sign-in will succeed but probe will fail if project is not allowlisted

## Testing

- ✅ New test `a 403 SERVICE_DISABLED body appears in the operator-visible error (issue #566)` passes
- ✅ All existing `antigravity-bootstrap-failure.test.mjs` tests pass
- ✅ All existing `antigravity-project.test.mjs` tests pass

## Documentation Changes

Documentation now honestly states that BYO Desktop client OAuth requires a project already allowlisted for the private `cloudcode-pa.googleapis.com` API, which ordinary project owners cannot enable themselves (requires producer-side `servicemanagement.services.bind` permission).

No invented unofficial allowlist signup URL - this is a Google allowlist that operators cannot self-service.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49084f6f-df14-4446-acac-9971975d7c42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49084f6f-df14-4446-acac-9971975d7c42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

