### PR TITLE
fix: move Cursor-managed composer models onto a routed alias on enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2072,8 +2072,12 @@ cursor-router-agent --model 'PASTE_ID_FROM_THE_LIST' --print "Reply with OK"
 ```
 
 Reopen Cursor App and choose a `codex_router/...` model. Cursor's base-URL override
-is global, so Cursor-managed models can also be sent to the custom endpoint
-while it is enabled; turn it off when switching back to Cursor's own models.
+is global, so Cursor-managed models (`Auto`/`default`, `grok-4.6`, Claude, Composer,
+and other first-party ids) are also sent to the custom endpoint while it is enabled
+and then rejected with “This model does not support custom API keys.” Turn the
+override off when switching back to Cursor's own models. `cursor enable` switches
+the composer selection away from those Cursor-managed ids onto a published
+`codex_router/...` alias.
 
 Cursor Agent text turns are supported and verified against the official CLI.
 Its local read/shell/edit/write loop is also mapped onto Cursor's controlled-

--- a/src/cursor-config-manager.mjs
+++ b/src/cursor-config-manager.mjs
@@ -147,6 +147,21 @@ function setComposerAlias(state, alias) {
   config.selectedModels = [{ modelId: alias, parameters: [] }];
 }
 
+function defaultPublishedAlias(selections, previousSelection) {
+  return preferredSelection(selections, previousSelection)?.alias
+    || selections.find((selection) => selection.effort === selection.model?.defaultEffort)?.alias
+    || selections[0]?.alias;
+}
+
+function composerNeedsByokSafeAlias(selectedAlias, { aliases, oldOwned, originallyAdded }) {
+  if (!selectedAlias) return true;
+  if (aliases.includes(selectedAlias) || oldOwned.includes(selectedAlias)) return false;
+  // Preserve the user's own pre-existing custom models. Cursor-managed ids
+  // (Auto/default, grok-4.6, Claude, Composer, …) reject the global OpenAI
+  // BYOK override with "This model does not support custom API keys."
+  return !originallyAdded.has(selectedAlias);
+}
+
 function launcherContents() {
   const nodeBinary = nodeRuntimePath();
   const launcher = path.join(SOURCE_ROOT, "src", "cursor-agent-launcher.mjs");
@@ -301,11 +316,11 @@ export function publishCursorIntegration({
     );
     state.aiSettings.modelOverrideDisabled = without(state.aiSettings.modelOverrideDisabled, aliases);
     const selectedAlias = selectedComposerAlias(state);
+    const previousSelection = selectionForPreviousAlias(selectedAlias, previous);
     if (oldOwned.includes(selectedAlias)) {
-      setComposerAlias(
-        state,
-        preferredSelection(selections, selectionForPreviousAlias(selectedAlias, previous))?.alias,
-      );
+      setComposerAlias(state, defaultPublishedAlias(selections, previousSelection));
+    } else if (composerNeedsByokSafeAlias(selectedAlias, { aliases, oldOwned, originallyAdded })) {
+      setComposerAlias(state, defaultPublishedAlias(selections, previousSelection));
     }
     state.useOpenAIKey = true;
     state.openAIBaseUrl = publicBaseUrl;

--- a/test/cursor-config-manager.test.mjs
+++ b/test/cursor-config-manager.test.mjs
@@ -217,3 +217,51 @@ test("Cursor publication is additive, private, reversible, and records every rou
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("Cursor publication switches Cursor-managed composer models to a BYOK-safe alias", () => {
+  mkdirSync(path.dirname(dbPath), { recursive: true });
+  mkdirSync(stateDir, { recursive: true });
+  mkdirSync(path.dirname(launcherPath), { recursive: true });
+  writeFileSync(path.join(stateDir, "caller-secret"), `${CALLER}\n`, { mode: 0o600 });
+  writeFileSync(path.join(stateDir, "cursor-public-secret"), `${PUBLIC}\n`, { mode: 0o600 });
+  const db = new DatabaseSync(dbPath);
+  db.exec("CREATE TABLE ItemTable (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB)");
+  db.prepare("INSERT INTO ItemTable(key, value) VALUES(?, ?)").run(APPLICATION_STATE_KEY, JSON.stringify({
+    useOpenAIKey: false,
+    openAIBaseUrl: "",
+    aiSettings: {
+      userAddedModels: [],
+      modelOverrideEnabled: [],
+      modelOverrideDisabled: [],
+      modelConfig: {
+        composer: {
+          modelName: "default",
+          selectedModels: [{ modelId: "default", parameters: [] }],
+        },
+      },
+    },
+  }));
+  db.close();
+
+  try {
+    const result = publishCursorIntegration({
+      origin: "https://cursor.example",
+      assertStopped: () => {},
+      routedModels: () => ({
+        engine: "test",
+        models: [
+          { slug: "provider/one", defaultEffort: "high", reasoningLevels: [{ effort: "low" }, { effort: "high" }] },
+        ],
+      }),
+    });
+    const published = readApplicationState();
+    const expected = cursorModelId("provider/one", "high");
+    assert.equal(result.aliases.includes(expected), true);
+    assert.equal(published.aiSettings.modelConfig.composer.modelName, expected);
+    assert.deepEqual(published.aiSettings.modelConfig.composer.selectedModels, [
+      { modelId: expected, parameters: [] },
+    ]);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

Cursor's OpenAI base-URL override is **global**. Once `cursor enable` points it at the router, every request leaves through the custom endpoint — including ones for Cursor-managed model ids (`default`/`Auto`, `grok-4.6`, Claude, Composer). Cursor rejects those with:

> This model does not support custom API keys.

`publishCursorIntegration` already moved the composer when it was sitting on a *stale router alias* (`oldOwned`), but left every other id alone. So the most common path — a first-time enable, composer still on `default` — finished "successfully" and landed the user on a model that cannot work.

## Change

Publication now also switches the composer away from Cursor-managed ids onto a published `codex_router/...` alias:

- `defaultPublishedAlias()` — picks the preferred selection, else the model's `defaultEffort` entry, else the first alias.
- `composerNeedsByokSafeAlias()` — returns false for aliases we own and for ids in `originallyAdded`, so a user's own pre-existing custom model is preserved rather than hijacked.

README documents the rejection message and the new behavior.

## Testing

- New regression test: composer on `default` → publication moves it to the routed alias, and `selectedModels` is rewritten to match.
- `node --test test/cursor-*.test.mjs test/target-integration.test.mjs test/target-isolation.test.mjs` → 34/34 pass.
- `npm run check` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)