### PR TITLE
Fix verified search-history replay for routed models

### DIFF
--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -243,6 +243,14 @@ operator can opt in locally only by adding `searchTool` to that exact entry in
 the protected `user-models.json` after verifying the route. The curation CLI
 does not ask for or infer search mode from an upstream catalog claim.
 
+Accepting a completed `web_search_call` in conversation history is a narrower
+input-compatibility capability than executing a new search. A route that has
+been live-tested for history replay may declare `supportsSearchHistory: true`
+without a `searchTool`; this keeps new search unavailable while allowing that
+route to continue or compact an existing searched conversation. The flag is
+false by default and, like `searchTool`, belongs to the exact model/provider
+route rather than to an OpenAI-compatible protocol family.
+
 ### Per-model search sidecar
 
 A model without `searchTool` can be opted into the Perplexity Search sidecar.

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -655,6 +655,12 @@ function modelProblem(model, providers, slugs, gatewayModels) {
     return `model ${model.slug} has an invalid supportsParallelToolCalls`;
   }
   if (
+    model.supportsSearchHistory !== undefined &&
+    typeof model.supportsSearchHistory !== "boolean"
+  ) {
+    return `model ${model.slug} has an invalid supportsSearchHistory`;
+  }
+  if (
     model.experimentalSupportedTools !== undefined &&
     (!Array.isArray(model.experimentalSupportedTools) ||
       model.experimentalSupportedTools.some(

--- a/src/search-capability.mjs
+++ b/src/search-capability.mjs
@@ -39,17 +39,23 @@ export function routedModelPreservesSearchContract(
   { requiredMode, hasSearchHistory = false } = {},
   options,
 ) {
+  // Replaying a completed search call is a provider-input compatibility
+  // question, not proof that the destination can execute a new search. Keep
+  // that narrower capability separate so a model can accept prior
+  // `web_search_call` items without advertising a search tool to Codex.
+  if (hasSearchHistory && !requiredMode) {
+    return model?.supportsSearchHistory === true;
+  }
   return searchModePreservesSearchContract(
     routedModelSearchMode(model, options),
-    { requiredMode, hasSearchHistory },
+    { requiredMode },
   );
 }
 
 export function searchModePreservesSearchContract(
   searchMode,
-  { requiredMode, hasSearchHistory = false } = {},
+  { requiredMode } = {},
 ) {
-  if (hasSearchHistory && !requiredMode) return false;
   return !requiredMode || searchMode === requiredMode;
 }
 

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -61,6 +61,7 @@ const METADATA_FIELDS = new Set([
   "reasoningLevels",
   "defaultEffort",
   "serviceTiers",
+  "supportsSearchHistory",
   "supportsReasoningSummaries",
   "defaultReasoningSummary",
   "availabilityNux",

--- a/test/model-failover.test.mjs
+++ b/test/model-failover.test.mjs
@@ -502,6 +502,17 @@ test("rankFailoverCandidates does not guess after search capability disappears",
   assert.deepEqual(ranked, []);
 });
 
+test("rankFailoverCandidates admits only verified search-history replay routes", () => {
+  const ranked = rankFailoverCandidates(
+    [
+      model("verified/candidate", "verified", { supportsSearchHistory: true }),
+      model("plain/incompatible", "plain"),
+    ],
+    { from: model("source/plain", "source"), hasSearchHistory: true },
+  );
+  assert.deepEqual(ranked.map((entry) => entry.model.slug), ["verified/candidate"]);
+});
+
 test("rankFailoverCandidates preserves an explicitly snapshotted absent mode", () => {
   const ranked = rankFailoverCandidates(
     [model("hosted/candidate", "hosted", { searchTool: { mode: "hosted" } })],

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -6319,8 +6319,12 @@ function genericSearchModelFixture() {
     inputModalities: ["text"],
   });
   const plain = entry("plain-model", 100);
+  const historyCompatible = {
+    ...entry("history-compatible-model", 101),
+    supportsSearchHistory: true,
+  };
   const searchable = {
-    ...entry("search-model", 101),
+    ...entry("search-model", 102),
     searchTool: { mode: "hosted" },
   };
   writeFileSync(providersFile, `${JSON.stringify({
@@ -6337,9 +6341,9 @@ function genericSearchModelFixture() {
   })}\n`);
   writeFileSync(userModelsFile, `${JSON.stringify({
     version: 1,
-    models: [plain, searchable],
+    models: [plain, historyCompatible, searchable],
   })}\n`);
-  return { dir, providersFile, userModelsFile, plain, searchable };
+  return { dir, providersFile, userModelsFile, plain, historyCompatible, searchable };
 }
 
 test("router enforces generic model search capability on ordinary and compact turns", async () => {
@@ -6518,6 +6522,64 @@ test("router refuses unsupported search history on selected generic turns and co
     }
     assert.equal(gatewayRequests.length, 2);
     assert.ok(gatewayRequests.every((request) => request.model === fixture.searchable.gatewayModel));
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(fixture.dir, { recursive: true, force: true });
+  }
+});
+
+test("router replays verified search history without exposing a new search tool", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, {
+      id: `resp-${gatewayRequests.length}`,
+      object: "response",
+      status: "completed",
+      output: [{
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "ok" }],
+      }],
+    });
+  });
+  const fixture = genericSearchModelFixture();
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    MODEL_ROUTER_STATE_DIR: fixture.dir,
+    MODEL_ROUTER_GENERIC_PROVIDERS: fixture.providersFile,
+    MODEL_ROUTER_USER_MODELS: fixture.userModelsFile,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const headers = {
+    Authorization: `Bearer ${CALLER_KEY}`,
+    "Content-Type": "application/json",
+  };
+  const history = [{
+    type: "web_search_call",
+    id: "completed-search-history",
+    status: "completed",
+    action: { type: "search", query: "router contract" },
+  }];
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    for (const suffix of ["", "/compact"]) {
+      const response = await fetch(`${routerBase(routerPort)}/responses${suffix}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ model: fixture.historyCompatible.slug, input: history }),
+      });
+      assert.equal(response.status, 200, router.testErrors());
+    }
+    assert.equal(gatewayRequests.length, 2);
+    assert.ok(gatewayRequests.every((request) => (
+      request.model === fixture.historyCompatible.gatewayModel &&
+      (!Array.isArray(request.tools) || request.tools.every((tool) => tool.type !== "web_search"))
+    )));
   } finally {
     await stopChild(router);
     await closeServer(gateway.server);

--- a/test/search-capability.test.mjs
+++ b/test/search-capability.test.mjs
@@ -60,6 +60,22 @@ test("a disappearing sidecar invalidates a snapshotted failover contract", () =>
   assert.equal(routedModelPreservesSearchContract(model, contract, options), false);
 });
 
+test("verified models replay search history without advertising new search", () => {
+  const contract = { requiredMode: undefined, hasSearchHistory: true };
+
+  assert.equal(
+    routedModelPreservesSearchContract(
+      { slug: "generic/history-compatible", supportsSearchHistory: true },
+      contract,
+    ),
+    true,
+  );
+  assert.equal(
+    routedModelPreservesSearchContract({ slug: "generic/plain" }, contract),
+    false,
+  );
+});
+
 test("unsupported hosted search is removed without touching caller function tools", () => {
   const functionNamedSearch = {
     type: "function",

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -57,6 +57,7 @@ test("curation metadata can set sizing and the effort ladder", () => {
       ],
       defaultEffort: "medium",
       serviceTiers: [{ id: "priority", name: "Fast" }],
+      supportsSearchHistory: true,
       requiresTrailingUserTurn: true,
       isFree: true,
     },
@@ -66,6 +67,7 @@ test("curation metadata can set sizing and the effort ladder", () => {
   assert.equal(entry.reasoningLevels.length, 3);
   assert.equal(entry.defaultEffort, "medium");
   assert.deepEqual(entry.serviceTiers, [{ id: "priority", name: "Fast" }]);
+  assert.equal(entry.supportsSearchHistory, true);
   assert.equal(entry.requiresTrailingUserTurn, true);
   assert.equal(entry.isFree, true);
 });
@@ -233,6 +235,10 @@ test("registry merges valid user models and skips collisions", async () => {
       ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-bad-search", priority: 106 }),
       searchTool: { mode: "emulated" },
     },
+    {
+      ...userModelEntry({ providerId: "deepseek", upstreamId: "deepseek-bad-search-history", priority: 120 }),
+      supportsSearchHistory: "yes",
+    },
     // Standalone search is Codex-side execution; it remains an explicit
     // per-model opt-in rather than a provider-wide default.
     {
@@ -321,6 +327,7 @@ test("registry merges valid user models and skips collisions", async () => {
   assert.ok(!slugs.includes("no-such-provider/x-model"));
   assert.ok(!slugs.includes("deepseek/deepseek-blank-nux"));
   assert.ok(!slugs.includes("deepseek/deepseek-bad-search"));
+  assert.ok(!slugs.includes("deepseek/deepseek-bad-search-history"));
   assert.ok(slugs.includes("deepseek/deepseek-standalone-search"));
   assert.ok(!slugs.includes("deepseek/deepseek-bad-detail"));
   assert.ok(!slugs.includes("deepseek/deepseek-bad-trailing-turn"));


### PR DESCRIPTION
## Summary

- distinguish replaying completed `web_search_call` history from advertising or executing a new web search
- add an exact-route, fail-closed `supportsSearchHistory` capability for models that have been verified to accept completed search items
- enforce the same distinction during selected routing, compaction, retries, and model failover
- validate and preserve the new boolean in user-model overlays, with regression coverage and documentation

## Problem

This is a follow-up to #540, which correctly fixed #539 by preventing ambient hosted-search fields from reaching routes that do not support search.

That change also made every completed search-history item depend on an active search execution mode. In the history-only case, a routed model without `searchTool` produces a contract with:

```js
{
  hasSearchHistory: true,
  requiredMode: undefined,
}
```

`searchModePreservesSearchContract` previously rejected that shape unconditionally. As a result, a conversation that had already used web search could not continue on an otherwise compatible routed Responses model, even when the upstream accepted completed `web_search_call` input. The router failed locally, before sending the request upstream, with:

```text
Model <route> can no longer preserve this turn's web-search execution contract.
```

This conflated two different capabilities:

1. executing a new hosted or standalone search; and
2. accepting a completed search call as conversation history.

Using `searchTool` for both would be unsafe because it would advertise a new search capability to Codex merely to permit history replay.

## Reproduction and live evidence

A bounded Responses request containing a completed `web_search_call`, followed by an ordinary user message and no new search requirement, was sent through both paths:

- direct to a verified OpenAI-compatible upstream: HTTP 200, completed response
- through the router before this patch: HTTP 400 `model_search_not_supported`, with no upstream request
- through the router after setting the exact route's `supportsSearchHistory: true`: HTTP 200, completed response

The originally failing Codex conversation was then continued through the patched router and the execution-contract error did not recur.

Provider URLs, credentials, tunnel identifiers, and local provider configuration are intentionally not included in this branch or PR.

## Fix

`routedModelPreservesSearchContract` now handles history-only replay as an explicit model input-compatibility decision:

- `supportsSearchHistory: true` permits completed search history when no active search mode is required
- an absent or false flag remains fail-closed
- an active search still requires the exact snapshotted hosted/standalone mode
- the flag does not create a `searchTool`, alter the Codex model catalog's search advertisement, or inject a new search tool into the forwarded request

The field is boolean-validated by the model registry and preserved by `userModelEntry`, so malformed hand-edited metadata is skipped instead of trusted. Failover ranking uses the same contract and admits only explicitly verified history-replay destinations.

## Tests

- `npm run check`
- `git diff --check`
- `node --test test/search-capability.test.mjs test/user-models.test.mjs test/model-failover.test.mjs test/model-failover-router.test.mjs test/empty-completion-router.test.mjs test/routing.test.mjs`
  - 229 passed, 0 failed
- clean detached-worktree `npm test`
  - 3,516 passed, 25 skipped
  - two suite-wide process/deadline timing failures passed when rerun in isolation
  - the remaining browser assertion expected English `Router online` while the macOS browser rendered the Chinese translation `路由在线`

The focused suites cover ordinary Responses requests, `/responses/compact`, fail-closed unverified routes, preservation of the absence of a new search tool, metadata validation, and failover eligibility.
