### PR TITLE
fix(grok-oauth): expose reasoning summaries in Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
   additionally drops tool_choice when tools is absent, as that endpoint refuses
   "When using `tool_choice`, `tools` must be set". Real non-empty tool arrays
   and their tool_choice are forwarded unchanged. (Fixes #588)
+- **Grok OAuth reasoning summaries now appear in Codex while the model is
+  thinking.** LiteLLM can open an empty assistant message before Grok's first
+  reasoning delta, then assign a different item id to every delta and return
+  the terminal reasoning item in Chat Completions shape. Codex discarded that
+  orphaned lifecycle and showed no progress until answer text arrived. The
+  router now repairs only Grok OAuth event streams into one canonical Responses
+  reasoning item, preserves valid streams, and keeps the following message and
+  tool output indexes consistent.
 - **A `Retry-After` expressed as a date is now honored.** RFC 9110 allows
   `Retry-After` to carry either delay-seconds or an HTTP-date. The router read
   the header as a bare number, so a dated value became `NaN` and every consumer

--- a/src/grok-reasoning-summary-compat.mjs
+++ b/src/grok-reasoning-summary-compat.mjs
@@ -2,8 +2,16 @@ import { Transform } from "node:stream";
 import { TextDecoder } from "node:util";
 
 const MAX_FRAME_BYTES = 256 * 1024;
+const MAX_COMMITTED_FRAME_BYTES = 64 * 1024 * 1024;
 const LF_FRAME_SEPARATOR = Buffer.from("\n\n");
 const CRLF_FRAME_SEPARATOR = Buffer.from("\r\n\r\n");
+
+class GrokReasoningSummaryCommittedStreamError extends Error {
+  constructor(reason) {
+    super(`Grok reasoning summary repair failed after stream mutation: ${reason}`);
+    this.name = "GrokReasoningSummaryCommittedStreamError";
+  }
+}
 
 // Grow geometrically and inspect each byte once so fragmented or unterminated
 // frames cannot trigger repeated whole-buffer copies and delimiter scans.
@@ -13,6 +21,10 @@ class SseFrameAccumulator {
   #maxFrameBytes;
 
   constructor(maxFrameBytes) {
+    this.#maxFrameBytes = maxFrameBytes;
+  }
+
+  setMaxFrameBytes(maxFrameBytes) {
     this.#maxFrameBytes = maxFrameBytes;
   }
 
@@ -129,10 +141,15 @@ function syntheticBlock(type, event, parsed) {
   return lines.join(parsed.newline);
 }
 
+function summaryParts(item) {
+  if (!Array.isArray(item?.summary)) return [];
+  return item.summary.filter(
+    (part) => part?.type === "summary_text" && typeof part.text === "string",
+  );
+}
+
 function summaryText(item) {
-  if (!Array.isArray(item?.summary)) return "";
-  return item.summary
-    .filter((part) => part?.type === "summary_text" && typeof part.text === "string")
+  return summaryParts(item)
     .map((part) => part.text)
     .join("");
 }
@@ -150,42 +167,61 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
   #currentSeparator = "";
   #message;
   #shiftOutputIndexes = false;
+  #maxCommittedFrameBytes;
+  #mutationCommitted = false;
+  #nextSequenceNumber;
 
-  constructor({ maxFrameBytes = MAX_FRAME_BYTES } = {}) {
+  constructor({
+    maxFrameBytes = MAX_FRAME_BYTES,
+    maxCommittedFrameBytes = MAX_COMMITTED_FRAME_BYTES,
+  } = {}) {
     super();
     const limit = Number.isInteger(maxFrameBytes) && maxFrameBytes > 0
       ? maxFrameBytes
       : MAX_FRAME_BYTES;
+    const committedLimit = Number.isInteger(maxCommittedFrameBytes)
+      && maxCommittedFrameBytes > 0
+      ? maxCommittedFrameBytes
+      : MAX_COMMITTED_FRAME_BYTES;
+    this.#maxCommittedFrameBytes = Math.max(limit, committedLimit);
     this.#frames = new SseFrameAccumulator(limit);
   }
 
   _transform(chunk, _encoding, callback) {
-    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    if (this.#disabled) {
-      this.push(Buffer.from(piece));
+    try {
+      const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      if (this.#disabled) {
+        this.push(Buffer.from(piece));
+        callback();
+        return;
+      }
+      const outcome = this.#frames.write(piece, (block, separator, original) => (
+        this.#emitFrame(block, separator, original)
+      ));
+      if (outcome?.oversized) this.#unsafeFrame(outcome.oversized, "SSE frame byte limit");
+      if (outcome?.remainder?.length) this.push(outcome.remainder);
       callback();
-      return;
+    } catch (error) {
+      callback(error);
     }
-    const outcome = this.#frames.write(piece, (block, separator, original) => (
-      this.#emitFrame(block, separator, original)
-    ));
-    if (outcome?.oversized) this.#disable(outcome.oversized);
-    if (outcome?.remainder?.length) this.push(outcome.remainder);
-    callback();
   }
 
   _flush(callback) {
-    if (this.#disabled) {
-      const pending = this.#frames.take();
-      if (pending.length) this.push(pending);
+    try {
+      if (this.#disabled) {
+        const pending = this.#frames.take();
+        if (pending.length) this.push(pending);
+        callback();
+        return;
+      }
+      this.#frames.flush((block, separator, original) => {
+        this.#emitFrame(block, separator, original);
+      });
+      for (const piece of this.#flushPendingMessage(true)) this.push(Buffer.from(piece));
       callback();
-      return;
+    } catch (error) {
+      callback(error);
     }
-    this.#frames.flush((block, separator, original) => {
-      this.#emitFrame(block, separator, original);
-    });
-    for (const piece of this.#flushPendingMessage(true)) this.push(Buffer.from(piece));
-    callback();
   }
 
   #emitFrame(block, separator, original) {
@@ -193,7 +229,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     try {
       text = fatalUtf8(block);
     } catch {
-      this.#disable(original);
+      this.#unsafeFrame(original, "invalid UTF-8");
       return false;
     }
     this.#currentSeparator = separator.toString("ascii");
@@ -208,6 +244,39 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     for (const piece of this.#flushPendingMessage(true)) this.push(Buffer.from(piece));
     if (original?.length) this.push(original);
     this.#disabled = true;
+  }
+
+  #unsafeFrame(original, reason) {
+    if (this.#mutationCommitted) {
+      throw new GrokReasoningSummaryCommittedStreamError(reason);
+    }
+    this.#disable(original);
+  }
+
+  #commitMutation(parsed) {
+    if (this.#mutationCommitted) return;
+    const sequenceNumbers = [
+      ...this.#pendingMessage.map(({ parsed: pending }) => pending.event?.sequence_number),
+      parsed?.event?.sequence_number,
+    ].filter(Number.isSafeInteger);
+    if (sequenceNumbers.length) this.#nextSequenceNumber = Math.min(...sequenceNumbers);
+    this.#mutationCommitted = true;
+    this.#frames.setMaxFrameBytes(this.#maxCommittedFrameBytes);
+  }
+
+  #sequencedEvent(event) {
+    if (!Number.isSafeInteger(this.#nextSequenceNumber)) return event;
+    const next = { ...event, sequence_number: this.#nextSequenceNumber };
+    this.#nextSequenceNumber += 1;
+    return next;
+  }
+
+  #rewrittenBlock(parsed, event) {
+    return rewrittenBlock(parsed, this.#sequencedEvent(event));
+  }
+
+  #syntheticBlock(type, event, parsed) {
+    return syntheticBlock(type, this.#sequencedEvent(event), parsed);
   }
 
   #common(parsed) {
@@ -239,12 +308,13 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     const pending = this.#pendingMessage;
     this.#pendingMessage = [];
     return pending.map(({ parsed, separator }) => (
-      rewrittenBlock(parsed, this.#shiftedEvent(parsed.event))
+      this.#rewrittenBlock(parsed, this.#shiftedEvent(parsed.event))
       + (preserveSeparators ? separator : "")
     ));
   }
 
   #startOrphanReasoning(parsed) {
+    this.#commitMutation(parsed);
     const event = parsed.event;
     const outputIndex = this.#message?.outputIndex
       ?? (Number.isInteger(event.output_index) ? event.output_index : 0);
@@ -259,7 +329,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       itemDone: false,
       synthetic: true,
     };
-    return [syntheticBlock(
+    return [this.#syntheticBlock(
       "response.output_item.added",
       {
         output_index: outputIndex,
@@ -273,7 +343,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
   #startSummaryPart(parsed) {
     if (this.#reasoning.partStarted) return [];
     this.#reasoning.partStarted = true;
-    return [syntheticBlock(
+    return [this.#syntheticBlock(
       "response.reasoning_summary_part.added",
       {
         ...this.#common(parsed),
@@ -289,7 +359,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     output.push(...this.#startSummaryPart(parsed));
     if (!this.#reasoning.textDone) {
       this.#reasoning.textDone = true;
-      output.push(syntheticBlock(
+      output.push(this.#syntheticBlock(
         "response.reasoning_summary_text.done",
         { ...this.#common(parsed), text: this.#reasoning.text },
         parsed,
@@ -297,7 +367,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     }
     if (!this.#reasoning.partDone) {
       this.#reasoning.partDone = true;
-      output.push(syntheticBlock(
+      output.push(this.#syntheticBlock(
         "response.reasoning_summary_part.done",
         {
           ...this.#common(parsed),
@@ -307,7 +377,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       ));
     }
     this.#reasoning.itemDone = true;
-    output.push(syntheticBlock(
+    output.push(this.#syntheticBlock(
       "response.output_item.done",
       {
         output_index: this.#reasoning.outputIndex,
@@ -361,6 +431,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       // A canonical Responses item already has an array-valued summary. Leave
       // that lifecycle byte-identical, including any additional summary parts.
       if (!id || Array.isArray(event.item.summary)) return [block];
+      this.#commitMutation(parsed);
       this.#reasoning = {
         id,
         outputIndex: Number.isInteger(event.output_index) ? event.output_index : 0,
@@ -371,10 +442,8 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
         itemDone: false,
         synthetic: false,
       };
-      const item = Array.isArray(event.item.summary)
-        ? event.item
-        : { ...event.item, summary: [] };
-      return [rewrittenBlock(parsed, item === event.item ? event : { ...event, item })];
+      const item = { ...event.item, summary: [] };
+      return [this.#rewrittenBlock(parsed, { ...event, item })];
     }
 
     if (!this.#reasoning) return [block];
@@ -382,7 +451,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     if (type === "response.reasoning_summary_part.added") {
       if (this.#reasoning.partStarted) return [];
       this.#reasoning.partStarted = true;
-      return [rewrittenBlock(parsed, {
+      return [this.#rewrittenBlock(parsed, {
         ...event,
         ...this.#common(parsed),
         part: { type: "summary_text", text: "" },
@@ -393,7 +462,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       if (this.#reasoning.itemDone) return [];
       prefix.push(...this.#startSummaryPart(parsed));
       this.#reasoning.text += event.delta;
-      return [...prefix, rewrittenBlock(parsed, {
+      return [...prefix, this.#rewrittenBlock(parsed, {
         ...event,
         ...this.#common(parsed),
       })];
@@ -404,7 +473,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       const prefix = this.#startSummaryPart(parsed);
       if (typeof event.text === "string") this.#reasoning.text = event.text;
       this.#reasoning.textDone = true;
-      return [...prefix, rewrittenBlock(parsed, {
+      return [...prefix, this.#rewrittenBlock(parsed, {
         ...event,
         ...this.#common(parsed),
         text: this.#reasoning.text,
@@ -419,7 +488,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
         : this.#reasoning.text;
       this.#reasoning.text = text;
       this.#reasoning.partDone = true;
-      return [...prefix, rewrittenBlock(parsed, {
+      return [...prefix, this.#rewrittenBlock(parsed, {
         ...event,
         ...this.#common(parsed),
         part: { type: "summary_text", text },
@@ -429,9 +498,14 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     if (type === "response.output_item.done" && event?.item?.type === "reasoning") {
       if (this.#reasoning.itemDone) return [];
       const prefix = [];
+      const terminalParts = summaryParts(event.item);
+      if (!this.#reasoning.partStarted && terminalParts.length) {
+        this.#reasoning.text = terminalParts.map((part) => part.text).join("");
+        prefix.push(...this.#startSummaryPart(parsed));
+      }
       if (this.#reasoning.partStarted && !this.#reasoning.textDone) {
         this.#reasoning.textDone = true;
-        prefix.push(syntheticBlock(
+        prefix.push(this.#syntheticBlock(
           "response.reasoning_summary_text.done",
           { ...this.#common(parsed), text: this.#reasoning.text },
           parsed,
@@ -439,7 +513,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       }
       if (this.#reasoning.partStarted && !this.#reasoning.partDone) {
         this.#reasoning.partDone = true;
-        prefix.push(syntheticBlock(
+        prefix.push(this.#syntheticBlock(
           "response.reasoning_summary_part.done",
           {
             ...this.#common(parsed),
@@ -457,7 +531,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
           : [],
       };
       this.#reasoning.itemDone = true;
-      return [...prefix, rewrittenBlock(parsed, {
+      return [...prefix, this.#rewrittenBlock(parsed, {
         ...event,
         output_index: this.#reasoning.outputIndex,
         item,
@@ -468,8 +542,9 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       || type === "response.output_text.done"
       || (type === "response.output_item.added" && event?.item?.type !== "reasoning")
       || type === "response.function_call_arguments.delta";
-    if (startsVisibleOutput && !this.#reasoning.itemDone) {
-      prefix.push(...this.#finishReasoning(parsed), ...this.#flushPendingMessage());
+    if (startsVisibleOutput) {
+      if (!this.#reasoning.itemDone) prefix.push(...this.#finishReasoning(parsed));
+      prefix.push(...this.#flushPendingMessage());
     }
 
     if (
@@ -477,7 +552,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       && event.item_id === this.#message?.id
       && event.part?.type === "reasoning_text"
     ) {
-      return [...prefix, rewrittenBlock(parsed, this.#shiftedEvent({
+      return [...prefix, this.#rewrittenBlock(parsed, this.#shiftedEvent({
         ...event,
         part: {
           type: "output_text",
@@ -493,7 +568,8 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       if (typeof event.text === "string") this.#message.text = event.text;
     }
 
-    if (type === "response.completed" && Array.isArray(event.response?.output)) {
+    const terminalResponse = type === "response.completed" || type === "response.incomplete";
+    if (terminalResponse && Array.isArray(event.response?.output)) {
       prefix.push(...this.#finishReasoning(parsed), ...this.#flushPendingMessage());
       const nonReasoning = event.response.output
         .filter((item) => item?.type !== "reasoning")
@@ -508,12 +584,13 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       const next = unchanged
         ? event
         : { ...event, response: { ...event.response, output } };
+      const rewritten = this.#rewrittenBlock(parsed, next);
       this.#reasoning = undefined;
       this.#shiftOutputIndexes = false;
-      return [...prefix, rewrittenBlock(parsed, next)];
+      return [...prefix, rewritten];
     }
 
-    return [...prefix, rewrittenBlock(parsed, this.#shiftedEvent(event))];
+    return [...prefix, this.#rewrittenBlock(parsed, this.#shiftedEvent(event))];
   }
 }
 

--- a/src/grok-reasoning-summary-compat.mjs
+++ b/src/grok-reasoning-summary-compat.mjs
@@ -1,0 +1,403 @@
+import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+function eventBlock(block) {
+  const newline = block.includes("\r\n") ? "\r\n" : "\n";
+  const lines = block.split(/\r?\n/u);
+  const dataLineIndex = lines.findIndex((line) => line.startsWith("data:"));
+  if (dataLineIndex === -1) return undefined;
+  const dataText = lines[dataLineIndex].slice(5).trimStart();
+  if (!dataText || dataText === "[DONE]") return undefined;
+  try {
+    return { lines, dataLineIndex, dataText, newline, event: JSON.parse(dataText) };
+  } catch {
+    return undefined;
+  }
+}
+
+function rewrittenBlock(parsed, event) {
+  const dataText = JSON.stringify(event);
+  if (dataText === parsed.dataText) return parsed.lines.join(parsed.newline);
+  const lines = [...parsed.lines];
+  lines[parsed.dataLineIndex] = `data: ${dataText}`;
+  return lines.join(parsed.newline);
+}
+
+function syntheticBlock(type, event, parsed) {
+  const hasEventLine = parsed.lines.some((line) => line.startsWith("event:"));
+  const lines = hasEventLine ? [`event: ${type}`] : [];
+  lines.push(`data: ${JSON.stringify({ type, ...event })}`);
+  return lines.join(parsed.newline);
+}
+
+function summaryText(item) {
+  if (!Array.isArray(item?.summary)) return "";
+  return item.summary
+    .filter((part) => part?.type === "summary_text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("");
+}
+
+// LiteLLM's Chat Completions -> Responses bridge can open an empty message
+// before Grok starts reasoning, and it hashes every reasoning delta into a
+// different item_id. Codex drops those orphaned deltas, so the user sees
+// silence while Grok is already streaming a summary. Normalize only that
+// summary lifecycle; other providers and non-SSE responses never enter here.
+export class GrokReasoningSummaryCompatTransform extends Transform {
+  #decoder = new StringDecoder("utf8");
+  #buffer = "";
+  #reasoning;
+  #pendingMessage = [];
+  #currentSeparator = "";
+  #message;
+  #shiftOutputIndexes = false;
+
+  _transform(chunk, _encoding, callback) {
+    this.#buffer += this.#decoder.write(chunk);
+    this.#emitCompleteBlocks();
+    callback();
+  }
+
+  _flush(callback) {
+    this.#buffer += this.#decoder.end();
+    this.#emitCompleteBlocks(true);
+    for (const piece of this.#flushPendingMessage(true)) this.push(Buffer.from(piece));
+    callback();
+  }
+
+  #emitCompleteBlocks(flush = false) {
+    while (this.#buffer.length) {
+      const crlf = this.#buffer.indexOf("\r\n\r\n");
+      const lf = this.#buffer.indexOf("\n\n");
+      let index = -1;
+      let separator = "";
+      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+        index = crlf;
+        separator = "\r\n\r\n";
+      } else if (lf !== -1) {
+        index = lf;
+        separator = "\n\n";
+      }
+      if (index === -1) {
+        if (!flush) return;
+        const block = this.#buffer;
+        this.#buffer = "";
+        for (const piece of this.#rewriteBlock(block)) this.push(Buffer.from(piece));
+        return;
+      }
+      const block = this.#buffer.slice(0, index);
+      this.#buffer = this.#buffer.slice(index + separator.length);
+      this.#currentSeparator = separator;
+      for (const piece of this.#rewriteBlock(block)) {
+        this.push(Buffer.from(`${piece}${separator}`));
+      }
+      this.#currentSeparator = "";
+    }
+  }
+
+  #common(parsed) {
+    return {
+      item_id: this.#reasoning.id,
+      output_index: this.#reasoning.outputIndex,
+      summary_index: 0,
+      ...(typeof parsed.event.model === "string" ? { model: parsed.event.model } : {}),
+    };
+  }
+
+  #reasoningItem(status = "completed") {
+    return {
+      id: this.#reasoning.id,
+      type: "reasoning",
+      status,
+      summary: status === "completed" && this.#reasoning.partStarted
+        ? [{ type: "summary_text", text: this.#reasoning.text }]
+        : [],
+    };
+  }
+
+  #shiftedEvent(event) {
+    if (!this.#shiftOutputIndexes || !Number.isInteger(event?.output_index)) return event;
+    return { ...event, output_index: event.output_index + 1 };
+  }
+
+  #flushPendingMessage(preserveSeparators = false) {
+    const pending = this.#pendingMessage;
+    this.#pendingMessage = [];
+    return pending.map(({ parsed, separator }) => (
+      rewrittenBlock(parsed, this.#shiftedEvent(parsed.event))
+      + (preserveSeparators ? separator : "")
+    ));
+  }
+
+  #startOrphanReasoning(parsed) {
+    const event = parsed.event;
+    const outputIndex = this.#message?.outputIndex
+      ?? (Number.isInteger(event.output_index) ? event.output_index : 0);
+    this.#shiftOutputIndexes = this.#pendingMessage.length > 0;
+    this.#reasoning = {
+      id: typeof event.item_id === "string" && event.item_id ? event.item_id : "rs_grok_summary",
+      outputIndex,
+      text: "",
+      partStarted: false,
+      textDone: false,
+      partDone: false,
+      itemDone: false,
+      synthetic: true,
+    };
+    return [syntheticBlock(
+      "response.output_item.added",
+      {
+        output_index: outputIndex,
+        item: this.#reasoningItem("in_progress"),
+        ...(typeof event.model === "string" ? { model: event.model } : {}),
+      },
+      parsed,
+    )];
+  }
+
+  #startSummaryPart(parsed) {
+    if (this.#reasoning.partStarted) return [];
+    this.#reasoning.partStarted = true;
+    return [syntheticBlock(
+      "response.reasoning_summary_part.added",
+      {
+        ...this.#common(parsed),
+        part: { type: "summary_text", text: "" },
+      },
+      parsed,
+    )];
+  }
+
+  #finishReasoning(parsed) {
+    if (!this.#reasoning || this.#reasoning.itemDone) return [];
+    const output = [];
+    output.push(...this.#startSummaryPart(parsed));
+    if (!this.#reasoning.textDone) {
+      this.#reasoning.textDone = true;
+      output.push(syntheticBlock(
+        "response.reasoning_summary_text.done",
+        { ...this.#common(parsed), text: this.#reasoning.text },
+        parsed,
+      ));
+    }
+    if (!this.#reasoning.partDone) {
+      this.#reasoning.partDone = true;
+      output.push(syntheticBlock(
+        "response.reasoning_summary_part.done",
+        {
+          ...this.#common(parsed),
+          part: { type: "summary_text", text: this.#reasoning.text },
+        },
+        parsed,
+      ));
+    }
+    this.#reasoning.itemDone = true;
+    output.push(syntheticBlock(
+      "response.output_item.done",
+      {
+        output_index: this.#reasoning.outputIndex,
+        item: this.#reasoningItem(),
+        ...(typeof parsed.event.model === "string" ? { model: parsed.event.model } : {}),
+      },
+      parsed,
+    ));
+    return output;
+  }
+
+  #rewriteBlock(block) {
+    const parsed = eventBlock(block);
+    if (!parsed) return [block];
+    const event = parsed.event;
+    const type = event?.type;
+
+    if (!this.#reasoning && type === "response.output_item.added" && event?.item?.type === "message") {
+      this.#message = {
+        id: event.item.id,
+        outputIndex: Number.isInteger(event.output_index) ? event.output_index : 0,
+        text: "",
+      };
+      this.#pendingMessage.push({ parsed, separator: this.#currentSeparator });
+      return [];
+    }
+
+    if (
+      !this.#reasoning
+      && this.#pendingMessage.length > 0
+      && type === "response.content_part.added"
+      && event.item_id === this.#message?.id
+    ) {
+      this.#pendingMessage.push({ parsed, separator: this.#currentSeparator });
+      return [];
+    }
+
+    let prefix = [];
+    if (!this.#reasoning && type === "response.reasoning_summary_text.delta") {
+      prefix = this.#startOrphanReasoning(parsed);
+    } else if (!this.#reasoning && this.#pendingMessage.length > 0) {
+      return [...this.#flushPendingMessage(), block];
+    }
+
+    if (type === "response.output_item.added" && event?.item?.type === "reasoning") {
+      const id = typeof event.item.id === "string" ? event.item.id : "";
+      if (!id) return [block];
+      this.#reasoning = {
+        id,
+        outputIndex: Number.isInteger(event.output_index) ? event.output_index : 0,
+        text: summaryText(event.item),
+        partStarted: false,
+        textDone: false,
+        partDone: false,
+        itemDone: false,
+        synthetic: false,
+      };
+      const item = Array.isArray(event.item.summary)
+        ? event.item
+        : { ...event.item, summary: [] };
+      return [rewrittenBlock(parsed, item === event.item ? event : { ...event, item })];
+    }
+
+    if (!this.#reasoning) return [block];
+
+    if (type === "response.reasoning_summary_part.added") {
+      if (this.#reasoning.partStarted) return [];
+      this.#reasoning.partStarted = true;
+      return [rewrittenBlock(parsed, {
+        ...event,
+        ...this.#common(parsed),
+        part: { type: "summary_text", text: "" },
+      })];
+    }
+
+    if (type === "response.reasoning_summary_text.delta" && typeof event.delta === "string") {
+      if (this.#reasoning.itemDone) return [];
+      prefix.push(...this.#startSummaryPart(parsed));
+      this.#reasoning.text += event.delta;
+      return [...prefix, rewrittenBlock(parsed, {
+        ...event,
+        ...this.#common(parsed),
+      })];
+    }
+
+    if (type === "response.reasoning_summary_text.done") {
+      if (this.#reasoning.itemDone) return [];
+      const prefix = this.#startSummaryPart(parsed);
+      if (typeof event.text === "string") this.#reasoning.text = event.text;
+      this.#reasoning.textDone = true;
+      return [...prefix, rewrittenBlock(parsed, {
+        ...event,
+        ...this.#common(parsed),
+        text: this.#reasoning.text,
+      })];
+    }
+
+    if (type === "response.reasoning_summary_part.done") {
+      if (this.#reasoning.itemDone) return [];
+      const prefix = this.#startSummaryPart(parsed);
+      const text = typeof event.part?.text === "string"
+        ? event.part.text
+        : this.#reasoning.text;
+      this.#reasoning.text = text;
+      this.#reasoning.partDone = true;
+      return [...prefix, rewrittenBlock(parsed, {
+        ...event,
+        ...this.#common(parsed),
+        part: { type: "summary_text", text },
+      })];
+    }
+
+    if (type === "response.output_item.done" && event?.item?.type === "reasoning") {
+      const prefix = [];
+      if (this.#reasoning.partStarted && !this.#reasoning.textDone) {
+        this.#reasoning.textDone = true;
+        prefix.push(syntheticBlock(
+          "response.reasoning_summary_text.done",
+          { ...this.#common(parsed), text: this.#reasoning.text },
+          parsed,
+        ));
+      }
+      if (this.#reasoning.partStarted && !this.#reasoning.partDone) {
+        this.#reasoning.partDone = true;
+        prefix.push(syntheticBlock(
+          "response.reasoning_summary_part.done",
+          {
+            ...this.#common(parsed),
+            part: { type: "summary_text", text: this.#reasoning.text },
+          },
+          parsed,
+        ));
+      }
+      const item = {
+        ...event.item,
+        id: this.#reasoning.id,
+        status: "completed",
+        summary: this.#reasoning.partStarted
+          ? [{ type: "summary_text", text: this.#reasoning.text }]
+          : [],
+      };
+      this.#reasoning.itemDone = true;
+      return [...prefix, rewrittenBlock(parsed, {
+        ...event,
+        output_index: this.#reasoning.outputIndex,
+        item,
+      })];
+    }
+
+    const startsVisibleOutput = type === "response.output_text.delta"
+      || type === "response.output_text.done"
+      || (type === "response.output_item.added" && event?.item?.type !== "reasoning")
+      || type === "response.function_call_arguments.delta";
+    if (startsVisibleOutput && !this.#reasoning.itemDone) {
+      prefix.push(...this.#finishReasoning(parsed), ...this.#flushPendingMessage());
+    }
+
+    if (
+      type === "response.content_part.done"
+      && event.item_id === this.#message?.id
+      && event.part?.type === "reasoning_text"
+    ) {
+      return [...prefix, rewrittenBlock(parsed, this.#shiftedEvent({
+        ...event,
+        part: {
+          type: "output_text",
+          text: this.#message.text,
+          annotations: [],
+        },
+      }))];
+    }
+
+    if (type === "response.output_text.delta" && event.item_id === this.#message?.id) {
+      this.#message.text += typeof event.delta === "string" ? event.delta : "";
+    } else if (type === "response.output_text.done" && event.item_id === this.#message?.id) {
+      if (typeof event.text === "string") this.#message.text = event.text;
+    }
+
+    if (type === "response.completed" && Array.isArray(event.response?.output)) {
+      prefix.push(...this.#finishReasoning(parsed), ...this.#flushPendingMessage());
+      const nonReasoning = event.response.output
+        .filter((item) => item?.type !== "reasoning")
+        .map((item) => (
+          item?.type === "message" && this.#message?.id
+            ? { ...item, id: this.#message.id }
+            : item
+        ));
+      const output = [this.#reasoningItem(), ...nonReasoning];
+      const unchanged = !this.#reasoning.synthetic
+        && JSON.stringify(output) === JSON.stringify(event.response.output);
+      const next = unchanged
+        ? event
+        : { ...event, response: { ...event.response, output } };
+      this.#reasoning = undefined;
+      this.#shiftOutputIndexes = false;
+      return [...prefix, rewrittenBlock(parsed, next)];
+    }
+
+    return [...prefix, rewrittenBlock(parsed, this.#shiftedEvent(event))];
+  }
+}
+
+export function grokReasoningSummaryCompatTransform(provider, contentType = "") {
+  const providerId = typeof provider === "string" ? provider : provider?.id;
+  if (providerId !== "grok-oauth") return undefined;
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
+  return new GrokReasoningSummaryCompatTransform();
+}

--- a/src/grok-reasoning-summary-compat.mjs
+++ b/src/grok-reasoning-summary-compat.mjs
@@ -171,6 +171,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
   #mutationCommitted = false;
   #nextSequenceNumber;
   #repairedReasoningItems = [];
+  #canonicalReasoningId;
 
   constructor({
     maxFrameBytes = MAX_FRAME_BYTES,
@@ -447,7 +448,17 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       const id = typeof event.item.id === "string" ? event.item.id : "";
       // A canonical Responses item already has an array-valued summary. Leave
       // that lifecycle byte-identical, including any additional summary parts.
-      if (!id || Array.isArray(event.item.summary)) return [block];
+      if (!id) return [block];
+      if (Array.isArray(event.item.summary)) {
+        const output = this.#reasoning && !this.#reasoning.itemDone
+          ? this.#finishReasoning(parsed)
+          : [];
+        if (this.#reasoning?.itemDone) {
+          this.#canonicalReasoningId = id;
+          return [...output, this.#rewrittenBlock(parsed, this.#shiftedEvent(event))];
+        }
+        return [block];
+      }
       this.#commitMutation(parsed);
       this.#reasoning = {
         id,
@@ -465,6 +476,22 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     }
 
     if (!this.#reasoning) return [block];
+
+    if (this.#canonicalReasoningId) {
+      const canonicalLifecycle = (
+        typeof type === "string"
+        && type.startsWith("response.reasoning_summary_")
+        && event.item_id === this.#canonicalReasoningId
+      ) || (
+        type === "response.output_item.done"
+        && event.item?.type === "reasoning"
+        && event.item.id === this.#canonicalReasoningId
+      );
+      if (canonicalLifecycle) {
+        if (type === "response.output_item.done") this.#canonicalReasoningId = undefined;
+        return [this.#rewrittenBlock(parsed, this.#shiftedEvent(event))];
+      }
+    }
 
     if (type === "response.reasoning_summary_part.added") {
       if (this.#reasoning.partStarted) return [];
@@ -565,6 +592,8 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
 
     const startsVisibleOutput = type === "response.output_text.delta"
       || type === "response.output_text.done"
+      || type === "response.refusal.delta"
+      || type === "response.refusal.done"
       || (type === "response.output_item.added" && event?.item?.type !== "reasoning")
       || (type === "response.output_item.done" && event?.item?.type !== "reasoning")
       || type === "response.function_call_arguments.delta";
@@ -603,6 +632,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       const rewritten = this.#rewrittenBlock(parsed, event);
       this.#reasoning = undefined;
       this.#repairedReasoningItems = [];
+      this.#canonicalReasoningId = undefined;
       this.#shiftOutputIndexes = false;
       return [...prefix, rewritten];
     }
@@ -636,6 +666,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       const rewritten = this.#rewrittenBlock(parsed, next);
       this.#reasoning = undefined;
       this.#repairedReasoningItems = [];
+      this.#canonicalReasoningId = undefined;
       this.#shiftOutputIndexes = false;
       return [...prefix, rewritten];
     }

--- a/src/grok-reasoning-summary-compat.mjs
+++ b/src/grok-reasoning-summary-compat.mjs
@@ -1,5 +1,104 @@
 import { Transform } from "node:stream";
-import { StringDecoder } from "node:string_decoder";
+import { TextDecoder } from "node:util";
+
+const MAX_FRAME_BYTES = 256 * 1024;
+const LF_FRAME_SEPARATOR = Buffer.from("\n\n");
+const CRLF_FRAME_SEPARATOR = Buffer.from("\r\n\r\n");
+
+// Grow geometrically and inspect each byte once so fragmented or unterminated
+// frames cannot trigger repeated whole-buffer copies and delimiter scans.
+class SseFrameAccumulator {
+  #storage = Buffer.alloc(0);
+  #length = 0;
+  #maxFrameBytes;
+
+  constructor(maxFrameBytes) {
+    this.#maxFrameBytes = maxFrameBytes;
+  }
+
+  write(value, onFrame) {
+    const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value);
+    for (let index = 0; index < bytes.length; index += 1) {
+      this.#append(bytes[index]);
+      const separator = this.#separator();
+      if (separator) {
+        const original = this.take();
+        if (original.length > this.#maxFrameBytes) {
+          return {
+            oversized: original,
+            remainder: Buffer.from(bytes.subarray(index + 1)),
+          };
+        }
+        const block = original.subarray(0, original.length - separator.length);
+        if (onFrame(block, separator, original) === false) {
+          return {
+            stopped: true,
+            remainder: Buffer.from(bytes.subarray(index + 1)),
+          };
+        }
+        continue;
+      }
+      if (this.#length > this.#maxFrameBytes) {
+        return {
+          oversized: this.take(),
+          remainder: Buffer.from(bytes.subarray(index + 1)),
+        };
+      }
+    }
+    return undefined;
+  }
+
+  flush(onFrame) {
+    if (!this.#length) return;
+    const original = this.take();
+    onFrame(original, Buffer.alloc(0), original);
+  }
+
+  take() {
+    if (!this.#length) return Buffer.alloc(0);
+    const value = Buffer.from(this.#storage.subarray(0, this.#length));
+    this.#length = 0;
+    return value;
+  }
+
+  #append(byte) {
+    const required = this.#length + 1;
+    if (required > this.#storage.length) {
+      const maximum = this.#maxFrameBytes + 1;
+      const doubled = this.#storage.length ? this.#storage.length * 2 : 1024;
+      const capacity = Math.min(maximum, Math.max(required, doubled));
+      const next = Buffer.allocUnsafe(capacity);
+      if (this.#length) this.#storage.copy(next, 0, 0, this.#length);
+      this.#storage = next;
+    }
+    this.#storage[this.#length] = byte;
+    this.#length = required;
+  }
+
+  #separator() {
+    if (
+      this.#length >= LF_FRAME_SEPARATOR.length
+      && this.#storage[this.#length - 2] === 0x0a
+      && this.#storage[this.#length - 1] === 0x0a
+    ) {
+      return LF_FRAME_SEPARATOR;
+    }
+    if (
+      this.#length >= CRLF_FRAME_SEPARATOR.length
+      && this.#storage[this.#length - 4] === 0x0d
+      && this.#storage[this.#length - 3] === 0x0a
+      && this.#storage[this.#length - 2] === 0x0d
+      && this.#storage[this.#length - 1] === 0x0a
+    ) {
+      return CRLF_FRAME_SEPARATOR;
+    }
+    return undefined;
+  }
+}
+
+function fatalUtf8(buffer) {
+  return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
+}
 
 function eventBlock(block) {
   const newline = block.includes("\r\n") ? "\r\n" : "\n";
@@ -44,55 +143,71 @@ function summaryText(item) {
 // silence while Grok is already streaming a summary. Normalize only that
 // summary lifecycle; other providers and non-SSE responses never enter here.
 export class GrokReasoningSummaryCompatTransform extends Transform {
-  #decoder = new StringDecoder("utf8");
-  #buffer = "";
+  #frames;
+  #disabled = false;
   #reasoning;
   #pendingMessage = [];
   #currentSeparator = "";
   #message;
   #shiftOutputIndexes = false;
 
+  constructor({ maxFrameBytes = MAX_FRAME_BYTES } = {}) {
+    super();
+    const limit = Number.isInteger(maxFrameBytes) && maxFrameBytes > 0
+      ? maxFrameBytes
+      : MAX_FRAME_BYTES;
+    this.#frames = new SseFrameAccumulator(limit);
+  }
+
   _transform(chunk, _encoding, callback) {
-    this.#buffer += this.#decoder.write(chunk);
-    this.#emitCompleteBlocks();
+    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    if (this.#disabled) {
+      this.push(Buffer.from(piece));
+      callback();
+      return;
+    }
+    const outcome = this.#frames.write(piece, (block, separator, original) => (
+      this.#emitFrame(block, separator, original)
+    ));
+    if (outcome?.oversized) this.#disable(outcome.oversized);
+    if (outcome?.remainder?.length) this.push(outcome.remainder);
     callback();
   }
 
   _flush(callback) {
-    this.#buffer += this.#decoder.end();
-    this.#emitCompleteBlocks(true);
+    if (this.#disabled) {
+      const pending = this.#frames.take();
+      if (pending.length) this.push(pending);
+      callback();
+      return;
+    }
+    this.#frames.flush((block, separator, original) => {
+      this.#emitFrame(block, separator, original);
+    });
     for (const piece of this.#flushPendingMessage(true)) this.push(Buffer.from(piece));
     callback();
   }
 
-  #emitCompleteBlocks(flush = false) {
-    while (this.#buffer.length) {
-      const crlf = this.#buffer.indexOf("\r\n\r\n");
-      const lf = this.#buffer.indexOf("\n\n");
-      let index = -1;
-      let separator = "";
-      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
-        index = crlf;
-        separator = "\r\n\r\n";
-      } else if (lf !== -1) {
-        index = lf;
-        separator = "\n\n";
-      }
-      if (index === -1) {
-        if (!flush) return;
-        const block = this.#buffer;
-        this.#buffer = "";
-        for (const piece of this.#rewriteBlock(block)) this.push(Buffer.from(piece));
-        return;
-      }
-      const block = this.#buffer.slice(0, index);
-      this.#buffer = this.#buffer.slice(index + separator.length);
-      this.#currentSeparator = separator;
-      for (const piece of this.#rewriteBlock(block)) {
-        this.push(Buffer.from(`${piece}${separator}`));
-      }
-      this.#currentSeparator = "";
+  #emitFrame(block, separator, original) {
+    let text;
+    try {
+      text = fatalUtf8(block);
+    } catch {
+      this.#disable(original);
+      return false;
     }
+    this.#currentSeparator = separator.toString("ascii");
+    for (const piece of this.#rewriteBlock(text)) {
+      this.push(Buffer.concat([Buffer.from(piece), separator]));
+    }
+    this.#currentSeparator = "";
+    return !this.#disabled;
+  }
+
+  #disable(original) {
+    for (const piece of this.#flushPendingMessage(true)) this.push(Buffer.from(piece));
+    if (original?.length) this.push(original);
+    this.#disabled = true;
   }
 
   #common(parsed) {
@@ -231,7 +346,11 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     }
 
     let prefix = [];
-    if (!this.#reasoning && type === "response.reasoning_summary_text.delta") {
+    if (
+      !this.#reasoning
+      && this.#pendingMessage.length > 0
+      && type === "response.reasoning_summary_text.delta"
+    ) {
       prefix = this.#startOrphanReasoning(parsed);
     } else if (!this.#reasoning && this.#pendingMessage.length > 0) {
       return [...this.#flushPendingMessage(), block];
@@ -239,7 +358,9 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
 
     if (type === "response.output_item.added" && event?.item?.type === "reasoning") {
       const id = typeof event.item.id === "string" ? event.item.id : "";
-      if (!id) return [block];
+      // A canonical Responses item already has an array-valued summary. Leave
+      // that lifecycle byte-identical, including any additional summary parts.
+      if (!id || Array.isArray(event.item.summary)) return [block];
       this.#reasoning = {
         id,
         outputIndex: Number.isInteger(event.output_index) ? event.output_index : 0,
@@ -306,6 +427,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     }
 
     if (type === "response.output_item.done" && event?.item?.type === "reasoning") {
+      if (this.#reasoning.itemDone) return [];
       const prefix = [];
       if (this.#reasoning.partStarted && !this.#reasoning.textDone) {
         this.#reasoning.textDone = true;

--- a/src/grok-reasoning-summary-compat.mjs
+++ b/src/grok-reasoning-summary-compat.mjs
@@ -170,6 +170,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
   #maxCommittedFrameBytes;
   #mutationCommitted = false;
   #nextSequenceNumber;
+  #repairedReasoningItems = [];
 
   constructor({
     maxFrameBytes = MAX_FRAME_BYTES,
@@ -233,8 +234,13 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       return false;
     }
     this.#currentSeparator = separator.toString("ascii");
-    for (const piece of this.#rewriteBlock(text)) {
-      this.push(Buffer.concat([Buffer.from(piece), separator]));
+    const pieces = this.#rewriteBlock(text);
+    const inferredSeparator = Buffer.from(text.includes("\r\n") ? "\r\n\r\n" : "\n\n");
+    for (let index = 0; index < pieces.length; index += 1) {
+      const trailing = separator.length || index === pieces.length - 1
+        ? separator
+        : inferredSeparator;
+      this.push(Buffer.concat([Buffer.from(pieces[index]), trailing]));
     }
     this.#currentSeparator = "";
     return !this.#disabled;
@@ -288,15 +294,22 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     };
   }
 
-  #reasoningItem(status = "completed") {
+  #reasoningItem(status = this.#reasoning.status || "completed") {
     return {
       id: this.#reasoning.id,
       type: "reasoning",
       status,
-      summary: status === "completed" && this.#reasoning.partStarted
+      summary: status !== "in_progress" && this.#reasoning.partStarted
         ? [{ type: "summary_text", text: this.#reasoning.text }]
         : [],
     };
+  }
+
+  #rememberReasoningItem(item) {
+    this.#repairedReasoningItems.push({
+      outputIndex: this.#reasoning.outputIndex,
+      item,
+    });
   }
 
   #shiftedEvent(event) {
@@ -327,6 +340,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       textDone: false,
       partDone: false,
       itemDone: false,
+      status: "in_progress",
       synthetic: true,
     };
     return [this.#syntheticBlock(
@@ -353,8 +367,9 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     )];
   }
 
-  #finishReasoning(parsed) {
+  #finishReasoning(parsed, status = "completed") {
     if (!this.#reasoning || this.#reasoning.itemDone) return [];
+    this.#reasoning.status = status;
     const output = [];
     output.push(...this.#startSummaryPart(parsed));
     if (!this.#reasoning.textDone) {
@@ -377,15 +392,17 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       ));
     }
     this.#reasoning.itemDone = true;
+    const item = this.#reasoningItem();
     output.push(this.#syntheticBlock(
       "response.output_item.done",
       {
         output_index: this.#reasoning.outputIndex,
-        item: this.#reasoningItem(),
+        item,
         ...(typeof parsed.event.model === "string" ? { model: parsed.event.model } : {}),
       },
       parsed,
     ));
+    this.#rememberReasoningItem(item);
     return output;
   }
 
@@ -440,6 +457,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
         textDone: false,
         partDone: false,
         itemDone: false,
+        status: "in_progress",
         synthetic: false,
       };
       const item = { ...event.item, summary: [] };
@@ -499,8 +517,10 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       if (this.#reasoning.itemDone) return [];
       const prefix = [];
       const terminalParts = summaryParts(event.item);
-      if (!this.#reasoning.partStarted && terminalParts.length) {
+      if (terminalParts.length && !this.#reasoning.textDone) {
         this.#reasoning.text = terminalParts.map((part) => part.text).join("");
+      }
+      if (!this.#reasoning.partStarted && terminalParts.length) {
         prefix.push(...this.#startSummaryPart(parsed));
       }
       if (this.#reasoning.partStarted && !this.#reasoning.textDone) {
@@ -522,15 +542,20 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
           parsed,
         ));
       }
+      const status = ["completed", "incomplete"].includes(event.item.status)
+        ? event.item.status
+        : "completed";
+      this.#reasoning.status = status;
       const item = {
         ...event.item,
         id: this.#reasoning.id,
-        status: "completed",
+        status,
         summary: this.#reasoning.partStarted
           ? [{ type: "summary_text", text: this.#reasoning.text }]
           : [],
       };
       this.#reasoning.itemDone = true;
+      this.#rememberReasoningItem(item);
       return [...prefix, this.#rewrittenBlock(parsed, {
         ...event,
         output_index: this.#reasoning.outputIndex,
@@ -541,6 +566,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     const startsVisibleOutput = type === "response.output_text.delta"
       || type === "response.output_text.done"
       || (type === "response.output_item.added" && event?.item?.type !== "reasoning")
+      || (type === "response.output_item.done" && event?.item?.type !== "reasoning")
       || type === "response.function_call_arguments.delta";
     if (startsVisibleOutput) {
       if (!this.#reasoning.itemDone) prefix.push(...this.#finishReasoning(parsed));
@@ -568,17 +594,40 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       if (typeof event.text === "string") this.#message.text = event.text;
     }
 
-    const terminalResponse = type === "response.completed" || type === "response.incomplete";
+    const failureTerminal = type === "response.failed"
+      || type === "response.error"
+      || type === "error";
+    if (failureTerminal && !Array.isArray(event.response?.output)) {
+      prefix.push(...this.#finishReasoning(parsed, "incomplete"));
+      this.#pendingMessage = [];
+      const rewritten = this.#rewrittenBlock(parsed, event);
+      this.#reasoning = undefined;
+      this.#repairedReasoningItems = [];
+      this.#shiftOutputIndexes = false;
+      return [...prefix, rewritten];
+    }
+
+    const terminalResponse = type === "response.completed"
+      || type === "response.incomplete"
+      || failureTerminal;
     if (terminalResponse && Array.isArray(event.response?.output)) {
-      prefix.push(...this.#finishReasoning(parsed), ...this.#flushPendingMessage());
-      const nonReasoning = event.response.output
-        .filter((item) => item?.type !== "reasoning")
-        .map((item) => (
-          item?.type === "message" && this.#message?.id
-            ? { ...item, id: this.#message.id }
-            : item
-        ));
-      const output = [this.#reasoningItem(), ...nonReasoning];
+      const itemStatus = type === "response.completed" ? "completed" : "incomplete";
+      prefix.push(
+        ...this.#finishReasoning(parsed, itemStatus),
+        ...this.#flushPendingMessage(),
+      );
+      const repaired = [...this.#repairedReasoningItems]
+        .sort((left, right) => left.outputIndex - right.outputIndex);
+      const output = event.response.output.map((item) => (
+        item?.type === "message" && this.#message?.id
+          ? { ...item, id: this.#message.id }
+          : item
+      ));
+      for (const repair of repaired) {
+        const index = Math.min(Math.max(repair.outputIndex, 0), output.length);
+        if (output[index]?.type === "reasoning") output[index] = repair.item;
+        else output.splice(index, 0, repair.item);
+      }
       const unchanged = !this.#reasoning.synthetic
         && JSON.stringify(output) === JSON.stringify(event.response.output);
       const next = unchanged
@@ -586,6 +635,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
         : { ...event, response: { ...event.response, output } };
       const rewritten = this.#rewrittenBlock(parsed, next);
       this.#reasoning = undefined;
+      this.#repairedReasoningItems = [];
       this.#shiftOutputIndexes = false;
       return [...prefix, rewritten];
     }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -60,6 +60,7 @@ import {
   ZaiResponsesCompatTransform,
   zaiResponsesCompatTransform,
 } from "./zai-responses-compat.mjs";
+import { grokReasoningSummaryCompatTransform } from "./grok-reasoning-summary-compat.mjs";
 import { translatedToolMessageCompatTransform } from "./deepseek-tool-message-compat.mjs";
 import { exactRouteProbeRequested } from "./exact-route-probe.mjs";
 import {
@@ -3980,6 +3981,10 @@ async function handleResponses(request, response, requestUrl) {
         envelopeCompat = new ZaiResponsesCompatTransform();
       }
       if (envelopeCompat) transforms.push(envelopeCompat);
+      const grokReasoningSummaryCompat = !directResponses && route
+        ? grokReasoningSummaryCompatTransform(providerForModel(route), contentType)
+        : undefined;
+      if (grokReasoningSummaryCompat) transforms.push(grokReasoningSummaryCompat);
       // LiteLLM can add blank assistant envelopes while translating either
       // Chat Completions or Messages. The factory refuses native traffic and
       // providers that already speak Responses, so those paths gain no stage.

--- a/test/grok-reasoning-summary-compat.test.mjs
+++ b/test/grok-reasoning-summary-compat.test.mjs
@@ -25,6 +25,7 @@ async function transformed(input, chunkSize = 0, options) {
   let output = "";
   stream.setEncoding("utf8");
   stream.on("data", (chunk) => { output += chunk; });
+  const ended = once(stream, "end");
   const bytes = Buffer.from(input);
   if (chunkSize > 0) {
     for (let at = 0; at < bytes.length; at += chunkSize) {
@@ -34,7 +35,7 @@ async function transformed(input, chunkSize = 0, options) {
     stream.write(bytes);
   }
   stream.end();
-  await once(stream, "end");
+  await ended;
   return output;
 }
 
@@ -262,6 +263,160 @@ test("drops a late upstream reasoning close after a synthetic close", async () =
     1,
   );
   assert.equal(output.at(-1).type, "response.output_text.done");
+});
+
+test("flushes the held message after a real reasoning close", async () => {
+  const message = {
+    id: "msg_after_close",
+    type: "message",
+    role: "assistant",
+    status: "in_progress",
+    content: [],
+  };
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: message }),
+    block({ type: "response.content_part.added", item_id: message.id, output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_after_close", output_index: 0, delta: "Проверил." }),
+    block({ type: "response.output_item.done", output_index: 0, item: { id: "rs_final", type: "reasoning", status: "completed", summary: [{ type: "summary_text", text: "Проверил." }] } }),
+    block({ type: "response.output_text.delta", item_id: message.id, output_index: 0, content_index: 0, delta: "Готово." }),
+  ].join("");
+  const output = events(await transformed(input));
+  const messageAdded = output.findIndex(
+    (event) => event.type === "response.output_item.added" && event.item?.type === "message",
+  );
+  const textDelta = output.findIndex((event) => event.type === "response.output_text.delta");
+  assert.ok(messageAdded >= 0 && messageAdded < textDelta);
+  assert.equal(output[messageAdded].output_index, 1);
+  assert.equal(output[textDelta].output_index, 1);
+});
+
+test("normalizes a completed frame larger than the pre-commit limit", async () => {
+  const longText = "x".repeat(600);
+  const message = {
+    id: "msg_large",
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: longText, annotations: [] }],
+  };
+  const terminal = {
+    type: "response.completed",
+    response: {
+      id: "resp_large",
+      status: "completed",
+      output: [
+        { id: "rs_large_final", type: "reasoning", status: "completed", content: [] },
+        { ...message, id: "chatcmpl_large" },
+      ],
+    },
+  };
+  assert.ok(Buffer.byteLength(block(terminal)) > 256);
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { ...message, status: "in_progress", content: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_large", output_index: 0, delta: "Проверяю." }),
+    block({ type: "response.output_text.delta", item_id: message.id, output_index: 0, content_index: 0, delta: longText }),
+    block(terminal),
+  ].join("");
+  const output = events(await transformed(input, 1, {
+    maxFrameBytes: 256,
+    maxCommittedFrameBytes: 4_096,
+  }));
+  const completed = output.find((event) => event.type === "response.completed");
+  assert.deepEqual(completed.response.output.map((item) => item.id), [
+    "rs_large",
+    message.id,
+  ]);
+  assert.deepEqual(completed.response.output[0].summary, [
+    { type: "summary_text", text: "Проверяю." },
+  ]);
+});
+
+test("fails closed when a post-mutation frame exceeds the committed limit", async () => {
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "msg_hard_limit", type: "message", role: "assistant", status: "in_progress", content: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_hard_limit", output_index: 0, delta: "Начал." }),
+    `data: ${"x".repeat(512)}\n\n`,
+  ].join("");
+  await assert.rejects(
+    transformed(input, 1, { maxFrameBytes: 256, maxCommittedFrameBytes: 320 }),
+    /failed after stream mutation: SSE frame byte limit/u,
+  );
+});
+
+test("normalizes incomplete response output while preserving truncation details", async () => {
+  const message = {
+    id: "msg_incomplete",
+    type: "message",
+    role: "assistant",
+    status: "incomplete",
+    content: [{ type: "output_text", text: "Частичный ответ", annotations: [] }],
+  };
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { ...message, status: "in_progress", content: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_incomplete", output_index: 0, delta: "Не успел." }),
+    block({ type: "response.output_text.delta", item_id: message.id, output_index: 0, content_index: 0, delta: "Частичный ответ" }),
+    block({
+      type: "response.incomplete",
+      response: {
+        id: "resp_incomplete",
+        status: "incomplete",
+        incomplete_details: { reason: "max_output_tokens" },
+        output: [
+          { id: "rs_incomplete_final", type: "reasoning", status: "completed", content: [] },
+          { ...message, id: "chatcmpl_incomplete" },
+        ],
+      },
+    }),
+  ].join("");
+  const output = events(await transformed(input));
+  const incomplete = output.find((event) => event.type === "response.incomplete");
+  assert.equal(incomplete.response.status, "incomplete");
+  assert.deepEqual(incomplete.response.incomplete_details, { reason: "max_output_tokens" });
+  assert.deepEqual(incomplete.response.output.map((item) => item.id), [
+    "rs_incomplete",
+    message.id,
+  ]);
+});
+
+test("renumbers a moved message and synthetic reasoning monotonically", async () => {
+  const message = {
+    id: "msg_sequence",
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: "Да.", annotations: [] }],
+  };
+  const input = [
+    block({ type: "response.created", sequence_number: 0, response: { id: "resp_sequence", status: "in_progress", output: [] } }),
+    block({ type: "response.output_item.added", sequence_number: 1, output_index: 0, item: { ...message, status: "in_progress", content: [] } }),
+    block({ type: "response.content_part.added", sequence_number: 2, item_id: message.id, output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", sequence_number: 3, item_id: "rs_sequence", output_index: 0, delta: "Думаю." }),
+    block({ type: "response.output_text.delta", sequence_number: 4, item_id: message.id, output_index: 0, content_index: 0, delta: "Да." }),
+    block({ type: "response.completed", sequence_number: 5, response: { id: "resp_sequence", status: "completed", output: [{ id: "rs_final", type: "reasoning", status: "completed", content: [] }, message] } }),
+  ].join("");
+  const output = events(await transformed(input));
+  assert.deepEqual(
+    output.map((event) => event.sequence_number),
+    output.map((_event, index) => index),
+  );
+});
+
+test("recovers a reasoning summary supplied only by the terminal item", async () => {
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "rs_terminal_only", type: "reasoning", status: "in_progress", summary: null } }),
+    block({ type: "response.output_item.done", output_index: 0, item: { id: "rs_terminal_only", type: "reasoning", status: "completed", summary: [{ type: "summary_text", text: "Только в конце." }] } }),
+  ].join("");
+  const output = events(await transformed(input));
+  assert.deepEqual(output.map((event) => event.type), [
+    "response.output_item.added",
+    "response.reasoning_summary_part.added",
+    "response.reasoning_summary_text.done",
+    "response.reasoning_summary_part.done",
+    "response.output_item.done",
+  ]);
+  assert.deepEqual(output.at(-1).item.summary, [
+    { type: "summary_text", text: "Только в конце." },
+  ]);
 });
 
 test("an oversized unterminated frame fails open without unbounded buffering", async () => {

--- a/test/grok-reasoning-summary-compat.test.mjs
+++ b/test/grok-reasoning-summary-compat.test.mjs
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import test from "node:test";
+
+import {
+  GrokReasoningSummaryCompatTransform,
+  grokReasoningSummaryCompatTransform,
+} from "../src/grok-reasoning-summary-compat.mjs";
+
+function block(event, newline = "\n") {
+  return `data: ${JSON.stringify(event)}${newline}${newline}`;
+}
+
+function events(text) {
+  return text
+    .split(/\r?\n\r?\n/u)
+    .filter(Boolean)
+    .map((frame) => frame.split(/\r?\n/u).find((line) => line.startsWith("data:")))
+    .filter((line) => line && line !== "data: [DONE]")
+    .map((line) => JSON.parse(line.slice(5).trimStart()));
+}
+
+async function transformed(input, chunkSize = 0) {
+  const stream = new GrokReasoningSummaryCompatTransform();
+  let output = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { output += chunk; });
+  const bytes = Buffer.from(input);
+  if (chunkSize > 0) {
+    for (let at = 0; at < bytes.length; at += chunkSize) {
+      stream.write(bytes.subarray(at, at + chunkSize));
+    }
+  } else {
+    stream.write(bytes);
+  }
+  stream.end();
+  await once(stream, "end");
+  return output;
+}
+
+function malformedReasoningStream(newline = "\n") {
+  const reasoning = {
+    id: "rs_open",
+    type: "reasoning",
+    status: "in_progress",
+    summary: null,
+  };
+  const completedReasoning = {
+    ...reasoning,
+    status: "completed",
+    summary: [{ type: "summary_text", text: "Проверяю контекст." }],
+  };
+  const message = {
+    id: "msg_answer",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "Готово.", annotations: [] }],
+  };
+  return [
+    block({ type: "response.output_item.added", output_index: 0, item: reasoning }, newline),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_hash_1", output_index: 0, delta: "Проверяю " }, newline),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_hash_2", output_index: 0, delta: "контекст." }, newline),
+    block({ type: "response.reasoning_summary_text.done", item_id: "rs_open", output_index: 0, summary_index: 0, text: "Проверяю контекст." }, newline),
+    block({ type: "response.reasoning_summary_part.done", item_id: "rs_open", output_index: 0, summary_index: 0, part: { type: "summary_text", text: "Проверяю контекст." } }, newline),
+    block({ type: "response.output_item.done", output_index: 0, item: completedReasoning }, newline),
+    block({ type: "response.output_text.delta", item_id: "msg_answer", output_index: 1, content_index: 0, delta: "Готово." }, newline),
+    block({ type: "response.completed", response: { id: "resp_1", status: "completed", output: [completedReasoning, message] } }, newline),
+  ].join("");
+}
+
+test("repairs LiteLLM's mismatched Grok reasoning ids into one Codex lifecycle", async () => {
+  const output = events(await transformed(malformedReasoningStream()));
+  const reasoningEvents = output.filter(
+    (event) => event.item?.type === "reasoning" || event.type.startsWith("response.reasoning_"),
+  );
+  assert.deepEqual(reasoningEvents.map((event) => event.type), [
+    "response.output_item.added",
+    "response.reasoning_summary_part.added",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_summary_text.done",
+    "response.reasoning_summary_part.done",
+    "response.output_item.done",
+  ]);
+  assert.ok(reasoningEvents.every(
+    (event) => (event.item_id ?? event.item?.id) === "rs_open",
+  ));
+  assert.deepEqual(reasoningEvents[0].item.summary, []);
+  assert.deepEqual(reasoningEvents.at(-1).item.summary, [
+    { type: "summary_text", text: "Проверяю контекст." },
+  ]);
+  assert.equal(
+    output.find((event) => event.type === "response.output_text.delta").delta,
+    "Готово.",
+  );
+  assert.deepEqual(
+    output.find((event) => event.type === "response.completed").response.output[0],
+    reasoningEvents.at(-1).item,
+  );
+});
+
+test("repairs the live LiteLLM message-first Grok stream", async () => {
+  const message = {
+    id: "msg_live",
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: "Готово.", annotations: [] }],
+  };
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { ...message, status: "in_progress", content: [] } }),
+    block({ type: "response.content_part.added", item_id: message.id, output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_hash_1", output_index: 0, delta: "Проверяю " }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_hash_2", output_index: 0, delta: "контекст." }),
+    block({ type: "response.output_text.delta", item_id: message.id, output_index: 0, content_index: 0, delta: "Готово." }),
+    block({ type: "response.output_text.done", item_id: message.id, output_index: 0, content_index: 0, text: "Готово." }),
+    block({ type: "response.content_part.done", item_id: message.id, output_index: 0, content_index: 0, part: { type: "reasoning_text", reasoning: "Проверяю контекст." } }),
+    block({ type: "response.output_item.done", output_index: 0, item: message }),
+    block({
+      type: "response.completed",
+      response: {
+        id: "resp_live",
+        status: "completed",
+        output: [
+          { type: "reasoning", id: "rs_final_hash", status: "completed", role: "assistant", content: [{ type: "output_text", text: "Проверяю контекст.", annotations: [] }] },
+          { ...message, id: "chatcmpl_final" },
+        ],
+      },
+    }),
+  ].join("");
+  const output = events(await transformed(input));
+  const reasoningEvents = output.filter(
+    (event) => event.item?.type === "reasoning" || event.type.startsWith("response.reasoning_"),
+  );
+  assert.deepEqual(reasoningEvents.map((event) => event.type), [
+    "response.output_item.added",
+    "response.reasoning_summary_part.added",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_summary_text.done",
+    "response.reasoning_summary_part.done",
+    "response.output_item.done",
+  ]);
+  assert.ok(reasoningEvents.every(
+    (event) => (event.item_id ?? event.item?.id) === "rs_hash_1",
+  ));
+  const messageEvents = output.filter(
+    (event) => event.item_id === message.id || event.item?.id === message.id,
+  );
+  assert.ok(messageEvents.every((event) => event.output_index === 1));
+  assert.deepEqual(
+    output.find((event) => event.type === "response.content_part.done").part,
+    { type: "output_text", text: "Готово.", annotations: [] },
+  );
+  assert.deepEqual(
+    output.find((event) => event.type === "response.completed").response.output,
+    [
+      {
+        id: "rs_hash_1",
+        type: "reasoning",
+        status: "completed",
+        summary: [{ type: "summary_text", text: "Проверяю контекст." }],
+      },
+      message,
+    ],
+  );
+});
+
+test("repairs one-byte CRLF chunks without changing their framing", async () => {
+  const output = await transformed(malformedReasoningStream("\r\n"), 1);
+  assert.ok(output.includes("\r\n\r\n"));
+  assert.equal(output.replace(/\r\n\r\n/gu, "").includes("\n\n"), false);
+  assert.ok(events(output).every((event) => !String(event.item_id || "").startsWith("rs_hash_")));
+});
+
+test("adds missing reasoning terminal events before closing the item", async () => {
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "rs_1", type: "reasoning", status: "in_progress", summary: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "wrong", output_index: 0, delta: "Жду ответ." }),
+    block({ type: "response.output_item.done", output_index: 0, item: { id: "rs_1", type: "reasoning", status: "completed", summary: [] } }),
+  ].join("");
+  const output = events(await transformed(input));
+  assert.deepEqual(output.map((event) => event.type), [
+    "response.output_item.added",
+    "response.reasoning_summary_part.added",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_summary_text.done",
+    "response.reasoning_summary_part.done",
+    "response.output_item.done",
+  ]);
+  assert.deepEqual(output.at(-1).item.summary, [
+    { type: "summary_text", text: "Жду ответ." },
+  ]);
+});
+
+test("closes reasoning before a terminal-only assistant answer", async () => {
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "msg_terminal", type: "message", role: "assistant", status: "in_progress", content: [] } }),
+    block({ type: "response.content_part.added", item_id: "msg_terminal", output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_terminal", output_index: 0, delta: "Готовлю ответ." }),
+    block({ type: "response.output_text.done", item_id: "msg_terminal", output_index: 0, content_index: 0, text: "" }),
+  ].join("");
+  const output = events(await transformed(input));
+  assert.deepEqual(output.map((event) => event.type), [
+    "response.output_item.added",
+    "response.reasoning_summary_part.added",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_summary_text.done",
+    "response.reasoning_summary_part.done",
+    "response.output_item.done",
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.output_text.done",
+  ]);
+  assert.equal(output[5].item.type, "reasoning");
+  assert.equal(output[6].output_index, 1);
+  assert.equal(output.at(-1).output_index, 1);
+});
+
+test("leaves an already canonical Grok reasoning stream byte-identical", async () => {
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "rs_ok", type: "reasoning", status: "in_progress", summary: [] } }),
+    block({ type: "response.reasoning_summary_part.added", item_id: "rs_ok", output_index: 0, summary_index: 0, part: { type: "summary_text", text: "" } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_ok", output_index: 0, summary_index: 0, delta: "Готовлю ответ." }),
+    block({ type: "response.reasoning_summary_text.done", item_id: "rs_ok", output_index: 0, summary_index: 0, text: "Готовлю ответ." }),
+    block({ type: "response.reasoning_summary_part.done", item_id: "rs_ok", output_index: 0, summary_index: 0, part: { type: "summary_text", text: "Готовлю ответ." } }),
+    block({ type: "response.output_item.done", output_index: 0, item: { id: "rs_ok", type: "reasoning", status: "completed", summary: [{ type: "summary_text", text: "Готовлю ответ." }] } }),
+  ].join("");
+  assert.equal(await transformed(input), input);
+});
+
+test("leaves malformed and non-reasoning SSE frames unchanged", async () => {
+  const input = [
+    "data: {not-json}\n\n",
+    block({ type: "response.output_text.delta", item_id: "msg_1", delta: "ok" }),
+    "data: [DONE]\n\n",
+  ].join("");
+  assert.equal(await transformed(input), input);
+});
+
+test("flushes a pending message-only envelope byte-identically at EOF", async () => {
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "msg_eof", type: "message", role: "assistant", status: "in_progress", content: [] } }, "\r\n"),
+    block({ type: "response.content_part.added", item_id: "msg_eof", output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }, "\r\n"),
+  ].join("");
+  assert.equal(await transformed(input), input);
+});
+
+test("compatibility factory is scoped to Grok OAuth event streams", () => {
+  assert.ok(grokReasoningSummaryCompatTransform({ id: "grok-oauth" }, "text/event-stream"));
+  assert.ok(grokReasoningSummaryCompatTransform("grok-oauth", "text/event-stream; charset=utf-8"));
+  assert.equal(grokReasoningSummaryCompatTransform("grok-api", "text/event-stream"), undefined);
+  assert.equal(grokReasoningSummaryCompatTransform("grok-oauth", "application/json"), undefined);
+});

--- a/test/grok-reasoning-summary-compat.test.mjs
+++ b/test/grok-reasoning-summary-compat.test.mjs
@@ -419,6 +419,220 @@ test("recovers a reasoning summary supplied only by the terminal item", async ()
   ]);
 });
 
+test("separates synthesized lifecycle frames at an unterminated EOF", async () => {
+  const terminal = {
+    type: "response.output_item.done",
+    output_index: 0,
+    item: {
+      id: "rs_unterminated",
+      type: "reasoning",
+      status: "completed",
+      summary: [{ type: "summary_text", text: "Готово." }],
+    },
+  };
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { ...terminal.item, status: "in_progress", summary: null } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_unterminated", output_index: 0, delta: "Готово." }),
+    `data: ${JSON.stringify(terminal)}`,
+  ].join("");
+  const raw = await transformed(input);
+  const output = events(raw);
+  assert.equal(raw.endsWith("\n\n"), false);
+  assert.deepEqual(output.map((event) => event.type), [
+    "response.output_item.added",
+    "response.reasoning_summary_part.added",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_summary_text.done",
+    "response.reasoning_summary_part.done",
+    "response.output_item.done",
+  ]);
+});
+
+test("preserves an incomplete reasoning status in stream and terminal output", async () => {
+  const repaired = {
+    id: "rs_incomplete_item",
+    type: "reasoning",
+    status: "incomplete",
+    summary: [{ type: "summary_text", text: "Оборвалось." }],
+  };
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { ...repaired, status: "in_progress", summary: null } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "wrong", output_index: 0, delta: "Оборвалось." }),
+    block({ type: "response.output_item.done", output_index: 0, item: repaired }),
+    block({
+      type: "response.incomplete",
+      response: {
+        id: "resp_incomplete_item",
+        status: "incomplete",
+        output: [{ ...repaired, id: "rs_incomplete_final" }],
+      },
+    }),
+  ].join("");
+  const output = events(await transformed(input));
+  const itemDone = output.find((event) => event.type === "response.output_item.done");
+  const incomplete = output.find((event) => event.type === "response.incomplete");
+  assert.equal(itemDone.item.status, "incomplete");
+  assert.equal(incomplete.response.output[0].status, "incomplete");
+  assert.equal(incomplete.response.output[0].id, repaired.id);
+});
+
+test("uses the terminal summary when streamed close events are missing", async () => {
+  const fullText = "Проверяю контекст полностью.";
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "rs_partial", type: "reasoning", status: "in_progress", summary: null } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_partial_hash", output_index: 0, delta: "Проверяю " }),
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        id: "rs_partial_final",
+        type: "reasoning",
+        status: "completed",
+        summary: [{ type: "summary_text", text: fullText }],
+      },
+    }),
+  ].join("");
+  const output = events(await transformed(input));
+  assert.equal(
+    output.find((event) => event.type === "response.reasoning_summary_text.done").text,
+    fullText,
+  );
+  assert.equal(
+    output.find((event) => event.type === "response.reasoning_summary_part.done").part.text,
+    fullText,
+  );
+  assert.deepEqual(output.at(-1).item.summary, [{ type: "summary_text", text: fullText }]);
+});
+
+test("flushes the held message before a terminal-only message close", async () => {
+  const message = {
+    id: "msg_terminal_close",
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text: "Ответ.", annotations: [] }],
+  };
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { ...message, status: "in_progress", content: [] } }),
+    block({ type: "response.content_part.added", item_id: message.id, output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_before_message_close", output_index: 0, delta: "Решил." }),
+    block({ type: "response.output_item.done", output_index: 0, item: message }),
+  ].join("");
+  const output = events(await transformed(input));
+  const reasoningDone = output.findIndex(
+    (event) => event.type === "response.output_item.done" && event.item?.type === "reasoning",
+  );
+  const messageAdded = output.findIndex(
+    (event) => event.type === "response.output_item.added" && event.item?.type === "message",
+  );
+  const messageDone = output.findIndex(
+    (event) => event.type === "response.output_item.done" && event.item?.type === "message",
+  );
+  assert.ok(reasoningDone < messageAdded && messageAdded < messageDone);
+  assert.equal(output[messageAdded].output_index, 1);
+  assert.equal(output[messageDone].output_index, 1);
+});
+
+test("retains every repaired reasoning item in terminal output order", async () => {
+  const reasoning = [
+    { id: "rs_first", text: "Первый итог." },
+    { id: "rs_second", text: "Второй итог." },
+  ];
+  const input = [
+    ...reasoning.flatMap(({ id, text }, index) => {
+      const outputIndex = index + 1;
+      return [
+        block({ type: "response.output_item.added", output_index: outputIndex, item: { id, type: "reasoning", status: "in_progress", summary: null } }),
+        block({ type: "response.reasoning_summary_text.delta", item_id: `${id}_hash`, output_index: outputIndex, delta: text }),
+        block({ type: "response.output_item.done", output_index: outputIndex, item: { id: `${id}_final`, type: "reasoning", status: "completed", summary: [{ type: "summary_text", text }] } }),
+      ];
+    }),
+    block({
+      type: "response.completed",
+      response: {
+        id: "resp_multiple_reasoning",
+        status: "completed",
+        output: [
+          { id: "rs_unstreamed", type: "reasoning", status: "completed", summary: [] },
+          { id: "raw_first", type: "reasoning", status: "completed", summary: [] },
+          { id: "raw_second", type: "reasoning", status: "completed", summary: [] },
+          { id: "msg_multiple", type: "message", role: "assistant", status: "completed", content: [] },
+        ],
+      },
+    }),
+  ].join("");
+  const output = events(await transformed(input));
+  const completed = output.find((event) => event.type === "response.completed");
+  assert.deepEqual(completed.response.output.map((item) => item.id), [
+    "rs_unstreamed",
+    "rs_first",
+    "rs_second",
+    "msg_multiple",
+  ]);
+  assert.deepEqual(
+    completed.response.output.slice(1, 3).map((item) => item.summary[0].text),
+    reasoning.map(({ text }) => text),
+  );
+});
+
+test("resolves held lifecycles before failure terminals", async () => {
+  for (const terminal of [
+    { type: "response.failed", response: { id: "resp_failed", status: "failed" } },
+    { type: "response.error", error: { code: "upstream_error", message: "failed" } },
+    { type: "error", code: "upstream_error", message: "failed", param: null },
+  ]) {
+    const messageId = `msg_${terminal.type}`;
+    const input = [
+      block({ type: "response.output_item.added", output_index: 0, item: { id: messageId, type: "message", role: "assistant", status: "in_progress", content: [] } }),
+      block({ type: "response.content_part.added", item_id: messageId, output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }),
+      block({ type: "response.reasoning_summary_text.delta", item_id: `rs_${terminal.type}`, output_index: 0, delta: "Не завершено." }),
+      block(terminal),
+    ].join("");
+    const output = events(await transformed(input));
+    assert.equal(output.at(-1).type, terminal.type);
+    assert.equal(output.some((event) => event.item?.type === "message"), false);
+    assert.equal(output.some((event) => event.item_id === messageId), false);
+    const reasoningDone = output.find(
+      (event) => event.type === "response.output_item.done" && event.item?.type === "reasoning",
+    );
+    assert.equal(reasoningDone.item.status, "incomplete");
+  }
+
+  const message = {
+    id: "msg_failed_output",
+    type: "message",
+    role: "assistant",
+    status: "incomplete",
+    content: [],
+  };
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { ...message, status: "in_progress" } }),
+    block({ type: "response.content_part.added", item_id: message.id, output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_failed_output", output_index: 0, delta: "Не завершено." }),
+    block({
+      type: "response.failed",
+      response: {
+        id: "resp_failed_output",
+        status: "failed",
+        output: [
+          { id: "rs_failed_final", type: "reasoning", status: "incomplete", summary: [] },
+          { ...message, id: "msg_failed_final" },
+        ],
+      },
+    }),
+  ].join("");
+  const output = events(await transformed(input));
+  const failedIndex = output.findIndex((event) => event.type === "response.failed");
+  const messageAddedIndex = output.findIndex(
+    (event) => event.type === "response.output_item.added" && event.item?.type === "message",
+  );
+  assert.ok(messageAddedIndex >= 0 && messageAddedIndex < failedIndex);
+  assert.deepEqual(output[failedIndex].response.output.map((item) => item.id), [
+    "rs_failed_output",
+    message.id,
+  ]);
+});
+
 test("an oversized unterminated frame fails open without unbounded buffering", async () => {
   const input = `${block({ type: "response.output_item.added", output_index: 0, item: { id: "msg_limit", type: "message", role: "assistant", status: "in_progress", content: [] } })}data: ${"x".repeat(512)}`;
   assert.equal(await transformed(input, 1, { maxFrameBytes: 256 }), input);

--- a/test/grok-reasoning-summary-compat.test.mjs
+++ b/test/grok-reasoning-summary-compat.test.mjs
@@ -20,8 +20,8 @@ function events(text) {
     .map((line) => JSON.parse(line.slice(5).trimStart()));
 }
 
-async function transformed(input, chunkSize = 0) {
-  const stream = new GrokReasoningSummaryCompatTransform();
+async function transformed(input, chunkSize = 0, options) {
+  const stream = new GrokReasoningSummaryCompatTransform(options);
   let output = "";
   stream.setEncoding("utf8");
   stream.on("data", (chunk) => { output += chunk; });
@@ -176,7 +176,7 @@ test("repairs one-byte CRLF chunks without changing their framing", async () => 
 
 test("adds missing reasoning terminal events before closing the item", async () => {
   const input = [
-    block({ type: "response.output_item.added", output_index: 0, item: { id: "rs_1", type: "reasoning", status: "in_progress", summary: [] } }),
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "rs_1", type: "reasoning", status: "in_progress", summary: null } }),
     block({ type: "response.reasoning_summary_text.delta", item_id: "wrong", output_index: 0, delta: "Жду ответ." }),
     block({ type: "response.output_item.done", output_index: 0, item: { id: "rs_1", type: "reasoning", status: "completed", summary: [] } }),
   ].join("");
@@ -228,6 +228,50 @@ test("leaves an already canonical Grok reasoning stream byte-identical", async (
     block({ type: "response.output_item.done", output_index: 0, item: { id: "rs_ok", type: "reasoning", status: "completed", summary: [{ type: "summary_text", text: "Готовлю ответ." }] } }),
   ].join("");
   assert.equal(await transformed(input), input);
+});
+
+test("leaves canonical multi-part reasoning byte-identical", async () => {
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "rs_parts", type: "reasoning", status: "in_progress", summary: [] } }),
+    block({ type: "response.reasoning_summary_part.added", item_id: "rs_parts", output_index: 0, summary_index: 0, part: { type: "summary_text", text: "" } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_parts", output_index: 0, summary_index: 0, delta: "Первый." }),
+    block({ type: "response.reasoning_summary_text.done", item_id: "rs_parts", output_index: 0, summary_index: 0, text: "Первый." }),
+    block({ type: "response.reasoning_summary_part.done", item_id: "rs_parts", output_index: 0, summary_index: 0, part: { type: "summary_text", text: "Первый." } }),
+    block({ type: "response.reasoning_summary_part.added", item_id: "rs_parts", output_index: 0, summary_index: 1, part: { type: "summary_text", text: "" } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_parts", output_index: 0, summary_index: 1, delta: "Второй." }),
+    block({ type: "response.reasoning_summary_text.done", item_id: "rs_parts", output_index: 0, summary_index: 1, text: "Второй." }),
+    block({ type: "response.reasoning_summary_part.done", item_id: "rs_parts", output_index: 0, summary_index: 1, part: { type: "summary_text", text: "Второй." } }),
+    block({ type: "response.output_item.done", output_index: 0, item: { id: "rs_parts", type: "reasoning", status: "completed", summary: [{ type: "summary_text", text: "Первый." }, { type: "summary_text", text: "Второй." }] } }),
+  ].join("");
+  assert.equal(await transformed(input, 1), input);
+});
+
+test("drops a late upstream reasoning close after a synthetic close", async () => {
+  const message = { id: "msg_late", type: "message", role: "assistant", status: "completed", content: [{ type: "output_text", text: "Готово.", annotations: [] }] };
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { ...message, status: "in_progress", content: [] } }),
+    block({ type: "response.content_part.added", item_id: message.id, output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_late", output_index: 0, delta: "Проверяю." }),
+    block({ type: "response.output_text.delta", item_id: message.id, output_index: 0, content_index: 0, delta: "Готово." }),
+    block({ type: "response.output_item.done", output_index: 0, item: { id: "rs_late_final", type: "reasoning", status: "completed", summary: [{ type: "summary_text", text: "Проверяю." }] } }),
+    block({ type: "response.output_text.done", item_id: message.id, output_index: 0, content_index: 0, text: "Готово." }),
+  ].join("");
+  const output = events(await transformed(input));
+  assert.equal(
+    output.filter((event) => event.type === "response.output_item.done" && event.item?.type === "reasoning").length,
+    1,
+  );
+  assert.equal(output.at(-1).type, "response.output_text.done");
+});
+
+test("an oversized unterminated frame fails open without unbounded buffering", async () => {
+  const input = `${block({ type: "response.output_item.added", output_index: 0, item: { id: "msg_limit", type: "message", role: "assistant", status: "in_progress", content: [] } })}data: ${"x".repeat(512)}`;
+  assert.equal(await transformed(input, 1, { maxFrameBytes: 256 }), input);
+});
+
+test("an oversized delimited frame and its tail pass through byte-identically", async () => {
+  const input = `data: ${"x".repeat(512)}\r\n\r\n${block({ type: "response.output_text.delta", item_id: "msg_tail", output_index: 0, delta: "ok" }, "\r\n")}`;
+  assert.equal(await transformed(input, 1, { maxFrameBytes: 256 }), input);
 });
 
 test("leaves malformed and non-reasoning SSE frames unchanged", async () => {

--- a/test/grok-reasoning-summary-compat.test.mjs
+++ b/test/grok-reasoning-summary-compat.test.mjs
@@ -575,6 +575,76 @@ test("retains every repaired reasoning item in terminal output order", async () 
   );
 });
 
+test("passes a canonical reasoning lifecycle after a repaired item", async () => {
+  const canonical = {
+    id: "rs_canonical_after_repair",
+    type: "reasoning",
+    status: "completed",
+    summary: [{ type: "summary_text", text: "Канонический итог." }],
+  };
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: "rs_repaired_first", type: "reasoning", status: "in_progress", summary: null } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_repaired_hash", output_index: 0, delta: "Исправленный итог." }),
+    block({ type: "response.output_item.done", output_index: 0, item: { id: "rs_repaired_final", type: "reasoning", status: "completed", summary: [{ type: "summary_text", text: "Исправленный итог." }] } }),
+    block({ type: "response.output_item.added", output_index: 1, item: { ...canonical, status: "in_progress", summary: [] } }),
+    block({ type: "response.reasoning_summary_part.added", item_id: canonical.id, output_index: 1, summary_index: 0, part: { type: "summary_text", text: "" } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: canonical.id, output_index: 1, summary_index: 0, delta: "Канонический итог." }),
+    block({ type: "response.reasoning_summary_text.done", item_id: canonical.id, output_index: 1, summary_index: 0, text: "Канонический итог." }),
+    block({ type: "response.reasoning_summary_part.done", item_id: canonical.id, output_index: 1, summary_index: 0, part: canonical.summary[0] }),
+    block({ type: "response.output_item.done", output_index: 1, item: canonical }),
+    block({
+      type: "response.completed",
+      response: {
+        id: "resp_canonical_after_repair",
+        status: "completed",
+        output: [
+          { id: "rs_repaired_terminal", type: "reasoning", status: "completed", summary: [] },
+          canonical,
+        ],
+      },
+    }),
+  ].join("");
+  const output = events(await transformed(input));
+  const canonicalEvents = output.filter(
+    (event) => (event.item_id ?? event.item?.id) === canonical.id,
+  );
+  assert.deepEqual(canonicalEvents.map((event) => event.type), [
+    "response.output_item.added",
+    "response.reasoning_summary_part.added",
+    "response.reasoning_summary_text.delta",
+    "response.reasoning_summary_text.done",
+    "response.reasoning_summary_part.done",
+    "response.output_item.done",
+  ]);
+  assert.deepEqual(
+    output.find((event) => event.type === "response.completed").response.output.map((item) => item.id),
+    ["rs_repaired_first", canonical.id],
+  );
+});
+
+test("flushes the held message before refusal events", async () => {
+  const messageId = "msg_refusal";
+  const input = [
+    block({ type: "response.output_item.added", output_index: 0, item: { id: messageId, type: "message", role: "assistant", status: "in_progress", content: [] } }),
+    block({ type: "response.content_part.added", item_id: messageId, output_index: 0, content_index: 0, part: { type: "refusal", refusal: "" } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_before_refusal", output_index: 0, delta: "Проверил." }),
+    block({ type: "response.refusal.delta", item_id: messageId, output_index: 0, content_index: 0, delta: "Не могу." }),
+    block({ type: "response.refusal.done", item_id: messageId, output_index: 0, content_index: 0, refusal: "Не могу." }),
+  ].join("");
+  const output = events(await transformed(input));
+  const reasoningDone = output.findIndex(
+    (event) => event.type === "response.output_item.done" && event.item?.type === "reasoning",
+  );
+  const messageAdded = output.findIndex(
+    (event) => event.type === "response.output_item.added" && event.item?.type === "message",
+  );
+  const refusalDelta = output.findIndex((event) => event.type === "response.refusal.delta");
+  assert.ok(reasoningDone < messageAdded && messageAdded < refusalDelta);
+  assert.equal(output[messageAdded].output_index, 1);
+  assert.equal(output[refusalDelta].output_index, 1);
+  assert.equal(output.at(-1).output_index, 1);
+});
+
 test("resolves held lifecycles before failure terminals", async () => {
   for (const terminal of [
     { type: "response.failed", response: { id: "resp_failed", status: "failed" } },

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -8966,6 +8966,160 @@ test("a plain follow-up after a thinking turn replays its reasoning", async () =
   }
 });
 
+test("router exposes Grok summaries as one canonical Codex reasoning item", async () => {
+  const model = "grok-oauth-grok-4-6";
+  const summary = "Проверяю контекст.";
+  const reasoning = {
+    id: "rs_grok_live",
+    type: "reasoning",
+    status: "completed",
+    summary: [{ type: "summary_text", text: summary }],
+  };
+  const message = {
+    id: "msg_grok_live",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "Готово.", annotations: [] }],
+  };
+  const source = [
+    {
+      type: "response.created",
+      response: { id: "resp_grok_live", object: "response", status: "in_progress", output: [] },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...message, status: "in_progress", content: [] },
+    },
+    {
+      type: "response.content_part.added",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    },
+    {
+      type: "response.reasoning_summary_text.delta",
+      item_id: "rs_hash_first_delta",
+      output_index: 0,
+      delta: "Проверяю ",
+    },
+    {
+      type: "response.reasoning_summary_text.delta",
+      item_id: "rs_hash_second_delta",
+      output_index: 0,
+      delta: "контекст.",
+    },
+    {
+      type: "response.reasoning_summary_text.done",
+      item_id: "rs_hash_final",
+      output_index: 0,
+      summary_index: 0,
+      text: summary,
+    },
+    {
+      type: "response.reasoning_summary_part.done",
+      item_id: "rs_hash_final",
+      output_index: 0,
+      summary_index: 0,
+      part: { type: "summary_text", text: summary },
+    },
+    {
+      type: "response.output_text.delta",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      delta: "Готово.",
+    },
+    {
+      type: "response.output_text.done",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      text: "Готово.",
+    },
+    {
+      type: "response.content_part.done",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "reasoning_text", reasoning: summary },
+    },
+    { type: "response.output_item.done", output_index: 0, item: message },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_grok_live",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "reasoning",
+            id: "rs_final_hash",
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "output_text", text: summary, annotations: [] }],
+          },
+          { ...message, id: "chatcmpl_final" },
+        ],
+        usage: { input_tokens: 5, output_tokens: 8, total_tokens: 13 },
+      },
+    },
+  ].map((event) => `data: ${JSON.stringify({ ...event, model })}\n\n`).join("");
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(`${source}data: [DONE]\n\n`);
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "grok-oauth/grok-4.6",
+        input: "проверь",
+        stream: true,
+      }),
+    });
+    const text = await response.text();
+    assert.equal(response.status, 200, text);
+    const output = text.split(/\r?\n/u)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trimStart()));
+    const reasoningEvents = output.filter(
+      (event) => event.item?.type === "reasoning" || event.type.startsWith("response.reasoning_"),
+    );
+    assert.deepEqual(reasoningEvents.map((event) => event.type), [
+      "response.output_item.added",
+      "response.reasoning_summary_part.added",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.done",
+      "response.reasoning_summary_part.done",
+      "response.output_item.done",
+    ]);
+    assert.ok(reasoningEvents.every(
+      (event) => (event.item_id ?? event.item?.id) === "rs_hash_first_delta",
+    ));
+    assert.deepEqual(
+      output.find((event) => event.type === "response.completed").response.output[0],
+      { ...reasoning, id: "rs_hash_first_delta" },
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 test("router normalizes direct DeepSeek's live reasoning bridge and removes its blank", async () => {
   const model = "deepseek-v4-flash";
   const reasoningText = "Inspect the request, then call the tool exactly once.";


### PR DESCRIPTION
## Why

LiteLLM's Chat Completions to Responses bridge can open an empty message before Grok's first reasoning chunk. It then assigns each `response.reasoning_summary_text.delta` a different hash-derived `item_id`, and returns terminal reasoning in Chat Completions shape. Codex sees no valid reasoning lifecycle and drops the summaries, so a Grok turn appears silent until answer text starts.

A live Codex turn reproduced this: xAI emitted reasoning deltas, while the rollout contained no reasoning item.

## What changed

- add a Grok OAuth-only SSE compatibility transform
- synthesize one canonical reasoning lifecycle for message-first streams
- normalize delta and terminal item IDs plus completed response output
- defer and reindex the premature message envelope, including the malformed `reasoning_text` close
- bound buffered SSE frames and fail open byte-identically on oversized or invalid input
- keep post-mutation terminal frames bounded while preserving normalized output
- leave canonical multi-part, non-Grok, non-SSE, malformed, and message-only streams unchanged
- suppress a late upstream reasoning close after a synthetic close
- normalize incomplete and failed responses while preserving coherent event sequence numbers
- recover authoritative terminal summaries when streamed close events are missing
- preserve multiple repaired reasoning items and their terminal output order
- close or discard held lifecycles before message-only and failure terminals
- preserve a canonical reasoning lifecycle that follows a repaired item
- flush held message envelopes before refusal events
- keep synthesized SSE frames parseable at unterminated EOF
- add unit and router-level regression coverage

## Verification

- `npm run check`
- `node --test test/grok-reasoning-summary-compat.test.mjs test/deepseek-tool-message-compat.test.mjs test/zai-responses-compat.test.mjs` - 126 passed
- `node --test --test-name-pattern='router exposes Grok summaries' test/routing.test.mjs` - 1 passed
- `npm test` - 3551 passed, 0 failed, 26 skipped
- `npm audit --omit=dev` - 0 vulnerabilities
- `sh -n install.sh`
- shell syntax checks for `bin/*`
- Node syntax checks for `bin/*.mjs`
- live verification through the installed Router: Codex emitted a separate reasoning item before the final assistant message
