### PR TITLE
fix: strip empty tools/tool_choice for all routes, not only qwen38-community

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Empty `tools: []` and dangling `tool_choice` are now stripped for all
+  API-forwarder routes, not only `qwen38-community`.** Strict upstreams (vLLM
+  >=0.20 Pydantic) refuse both an empty tools array and `tool_choice` with no
+  tools present. Codex sends `tools: []` on compaction and plain chat, so
+  without this strip every compaction against strict providers 400s. The
+  repair was previously applied only to the `qwen38-community` profile;
+  it is now applied to all routes so compaction and plain chat work against
+  any strict provider. Real non-empty tool arrays and their tool_choice are
+  forwarded unchanged. (Fixes #588)
 - **A `Retry-After` expressed as a date is now honored.** RFC 9110 allows
   `Retry-After` to carry either delay-seconds or an HTTP-date. The router read
   the header as a bare number, so a dated value became `NaN` and every consumer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,17 @@
 
 ## Unreleased
 
-- **Empty `tools: []` and dangling `tool_choice` are now stripped for all
-  API-forwarder routes, not only `qwen38-community`.** Strict upstreams (vLLM
-  >=0.20 Pydantic) refuse both an empty tools array and `tool_choice` with no
-  tools present. Codex sends `tools: []` on compaction and plain chat, so
-  without this strip every compaction against strict providers 400s. The
-  repair was previously applied only to the `qwen38-community` profile;
-  it is now applied to all routes so compaction and plain chat work against
-  any strict provider. Real non-empty tool arrays and their tool_choice are
-  forwarded unchanged. (Fixes #588)
+- **Empty `tools: []` is now stripped for all API-forwarder routes, not only
+  `qwen38-community`.** Strict upstreams (vLLM >=0.20 Pydantic) refuse an empty
+  tools array. Codex sends `tools: []` on compaction and plain chat, so without
+  this strip every compaction against strict providers 400s. The repair was
+  previously applied only to the `qwen38-community` profile; it is now applied
+  to all routes so compaction and plain chat work against any strict provider.
+  Dangling `tool_choice` is dropped only after stripping an empty `tools: []`
+  array (not when tools was never present). The `qwen38-community` profile
+  additionally drops tool_choice when tools is absent, as that endpoint refuses
+  "When using `tool_choice`, `tools` must be set". Real non-empty tool arrays
+  and their tool_choice are forwarded unchanged. (Fixes #588)
 - **A `Retry-After` expressed as a date is now honored.** RFC 9110 allows
   `Retry-After` to carry either delay-seconds or an HTTP-date. The router read
   the header as a bare number, so a dated value became `NaN` and every consumer

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -589,6 +589,35 @@ function stripSearchContentTypes(tools) {
   return stripped ? repaired : tools;
 }
 
+/**
+ * Strip empty `tools: []` and dangling `tool_choice` from a payload.
+ * Returns whether the payload was changed.
+ * 
+ * The vLLM build in qwen38-community and other strict upstreams (>=0.20 Pydantic)
+ * refuse an empty tools array and tool_choice with no tools present. Codex sends
+ * `tools: []` on compaction and plain chat, so without this strip every compaction
+ * against strict providers 400s. An empty tools array is valid for lenient providers
+ * and explicitly permitted by OpenAI's schema, so the repair belongs at this last
+ * hop rather than in the compaction path. Omitting the empty field is also valid for
+ * providers like OpenCode Go.
+ */
+function stripEmptyTools(payload) {
+  let changed = false;
+  if (Array.isArray(payload.tools) && payload.tools.length === 0) {
+    delete payload.tools;
+    changed = true;
+  }
+  // Delete dangling tool_choice only after tools is gone or known absent.
+  // Keep tool_choice when a real non-empty tools array is present.
+  if (!Array.isArray(payload.tools) || payload.tools.length === 0) {
+    if ("tool_choice" in payload) {
+      delete payload.tool_choice;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 function normalizeBody(buffer, contentType, route) {
   if (!buffer.length || !String(contentType || "").includes("application/json")) {
     const error = new Error("API-provider requests require a JSON body.");
@@ -721,6 +750,16 @@ function normalizeBody(buffer, contentType, route) {
   // one tool this endpoint accepts it on.
   if (provider.id === "meta" && Array.isArray(payload.tools)) {
     payload.tools = stripSearchContentTypes(payload.tools);
+  }
+  // Strip empty tools array and dangling tool_choice for all routes.
+  // Strict upstreams (vLLM >=0.20 Pydantic) refuse both, and Codex sends
+  // tools: [] on compaction and plain chat. Log when a request is changed.
+  if (stripEmptyTools(payload)) {
+    if (!QUIET) {
+      console.error(
+        `[api-forwarder] model=${model.gatewayModel} stripped empty tools/tool_choice`,
+      );
+    }
   }
   if (Array.isArray(payload.messages)) {
     payload.messages = sanitizeChatToolHistory(payload.messages, provider, model);
@@ -906,22 +945,6 @@ function normalizeBody(buffer, contentType, route) {
     // and it folds onto `max` because that is the tier it is asking for.
     // Everything else passes through as the literal the endpoint accepts.
     if (payload.reasoning_effort === "ultra") payload.reasoning_effort = "max";
-    // The same build refuses two tool shapes Codex sends routinely, both
-    // measured live: an empty list answers "`tools` must not be an empty
-    // array. Either provide at least one tool or omit the field entirely",
-    // and a choice with nothing to choose from answers "When using
-    // `tool_choice`, `tools` must be set". `summarize()` in the router sends
-    // `tools: []` on every compaction, and this model auto-compacts at 230K of
-    // its 262K window, so left alone every compaction against it 400s. Strip
-    // the empty list first, then drop the tool choice that strip leaves
-    // dangling -- the order is what keeps the second rejection from replacing
-    // the first. The repair belongs at this last hop rather than in the
-    // compaction path because an empty tool list is legal on every other
-    // forwarder, and it is exactly how compaction disables tool use there.
-    if (Array.isArray(payload.tools) && payload.tools.length === 0) delete payload.tools;
-    if (!Array.isArray(payload.tools) || payload.tools.length === 0) {
-      delete payload.tool_choice;
-    }
     // Third measured refusal on the same endpoint: "System message must be at
     // the beginning." A conversation that already satisfies the rule is left
     // byte-identical -- see normalizeQwen38SystemMessages for the rule, the

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -594,22 +594,22 @@ function stripSearchContentTypes(tools) {
  * Returns whether the payload was changed.
  * 
  * The vLLM build in qwen38-community and other strict upstreams (>=0.20 Pydantic)
- * refuse an empty tools array and tool_choice with no tools present. Codex sends
- * `tools: []` on compaction and plain chat, so without this strip every compaction
- * against strict providers 400s. An empty tools array is valid for lenient providers
- * and explicitly permitted by OpenAI's schema, so the repair belongs at this last
- * hop rather than in the compaction path. Omitting the empty field is also valid for
- * providers like OpenCode Go.
+ * refuse an empty tools array. Codex sends `tools: []` on compaction and plain chat,
+ * so without this strip every compaction against strict providers 400s. An empty tools
+ * array is valid for lenient providers and explicitly permitted by OpenAI's schema, so
+ * the repair belongs at this last hop rather than in the compaction path. Omitting the
+ * empty field is also valid for providers like OpenCode Go.
+ * 
+ * Drops tool_choice only when an empty tools: [] was actually stripped, not when tools
+ * was never present. Requests with tool_choice but no tools field are forwarded as-is
+ * for profiles that need them.
  */
 function stripEmptyTools(payload) {
   let changed = false;
-  if (Array.isArray(payload.tools) && payload.tools.length === 0) {
+  const hadEmptyTools = Array.isArray(payload.tools) && payload.tools.length === 0;
+  if (hadEmptyTools) {
     delete payload.tools;
     changed = true;
-  }
-  // Delete dangling tool_choice only after tools is gone or known absent.
-  // Keep tool_choice when a real non-empty tools array is present.
-  if (!Array.isArray(payload.tools) || payload.tools.length === 0) {
     if ("tool_choice" in payload) {
       delete payload.tool_choice;
       changed = true;
@@ -945,6 +945,12 @@ function normalizeBody(buffer, contentType, route) {
     // and it folds onto `max` because that is the tier it is asking for.
     // Everything else passes through as the literal the endpoint accepts.
     if (payload.reasoning_effort === "ultra") payload.reasoning_effort = "max";
+    // The same endpoint also refuses tool_choice when tools is absent or still
+    // empty after the global strip ("When using `tool_choice`, `tools` must be
+    // set"). Drop dangling tool_choice for this profile only.
+    if (!Array.isArray(payload.tools) || payload.tools.length === 0) {
+      delete payload.tool_choice;
+    }
     // Third measured refusal on the same endpoint: "System message must be at
     // the beginning." A conversation that already satisfies the rule is left
     // byte-identical -- see normalizeQwen38SystemMessages for the rule, the

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5107,6 +5107,26 @@ test("API forwarder strips empty tools for all routes, not only qwen38-community
     const forwarded = upstreamRequests.at(-1).body;
     assert.deepEqual(forwarded.tools, realTools);
     assert.equal(forwarded.tool_choice, "auto");
+
+    // A request with tool_choice but no tools field is forwarded as-is for
+    // non-qwen38 routes. The strip only drops tool_choice when it actually
+    // stripped an empty tools: [] array.
+    const choiceWithoutTools = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "opencode-go-mimo-v2-5",
+        tool_choice: "auto",
+        messages: [{ role: "user", content: "test" }],
+      }),
+    });
+    assert.equal(choiceWithoutTools.status, 200);
+    const choiceForwarded = upstreamRequests.at(-1).body;
+    assert.equal("tools" in choiceForwarded, false);
+    assert.equal(choiceForwarded.tool_choice, "auto");
   } finally {
     await stopChild(forwarder);
     await closeServer(upstream.server);

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -5033,6 +5033,86 @@ test("API forwarder omits the empty tool list the free Qwen3.8 endpoint rejects"
   }
 });
 
+// Empty tools stripping is not qwen38-specific -- strict upstreams (vLLM >=0.20
+// Pydantic) refuse both empty tools arrays and dangling tool_choice, and Codex
+// sends tools: [] on every compaction and plain chat. The strip applies to all
+// routes so compaction works against any strict provider.
+test("API forwarder strips empty tools for all routes, not only qwen38-community", async () => {
+  const upstreamRequests = [];
+  const upstream = await mockServer(async (request, response) => {
+    upstreamRequests.push({ headers: request.headers, body: await bodyJson(request) });
+    json(response, 200, { choices: [] });
+  });
+  const forwarderPort = await openPort();
+  const forwarder = run("api-forwarder.mjs", {
+    CODEX_ROUTER_API_PORT: String(forwarderPort),
+    OPENCODE_GO_BASE_URL: `http://127.0.0.1:${upstream.port}`,
+    OPENCODE_GO_API_KEY: "TEST_OPENCODE_GO_API_KEY",
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`http://127.0.0.1:${forwarderPort}/health`, forwarder, {
+      Authorization: `Bearer ${INTERNAL_KEY}`,
+    });
+    // OpenCode Go mimo is a Chat Completions route, not qwen38-community.
+    // Compaction sends empty tools + tool_choice, and both must be stripped.
+    const compaction = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "opencode-go-mimo-v2-5",
+        tools: [],
+        tool_choice: "none",
+        messages: [{ role: "user", content: "summarize" }],
+      }),
+    });
+    assert.equal(compaction.status, 200);
+    const compacted = upstreamRequests.at(-1).body;
+    assert.equal("tools" in compacted, false);
+    assert.equal("tool_choice" in compacted, false);
+
+    // A real tool list is untouched: the strip is only for empty arrays.
+    const realTools = [
+      {
+        type: "function",
+        function: {
+          name: "test",
+          description: "Test function.",
+          parameters: {
+            type: "object",
+            properties: { arg: { type: "string" } },
+            required: ["arg"],
+          },
+        },
+      },
+    ];
+    const turn = await fetch(`http://127.0.0.1:${forwarderPort}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${INTERNAL_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "opencode-go-mimo-v2-5",
+        tools: realTools,
+        tool_choice: "auto",
+        messages: [{ role: "user", content: "test" }],
+      }),
+    });
+    assert.equal(turn.status, 200);
+    const forwarded = upstreamRequests.at(-1).body;
+    assert.deepEqual(forwarded.tools, realTools);
+    assert.equal(forwarded.tool_choice, "auto");
+  } finally {
+    await stopChild(forwarder);
+    await closeServer(upstream.server);
+  }
+});
+
 // The third refusal measured on the same endpoint: "System message must be at
 // the beginning." Probing it with one-token requests pinned the rule to at most
 // one `system` message, sitting ahead of the first user/assistant/tool turn --
@@ -5900,8 +5980,9 @@ test("API forwarder opts streamed Chat Completions into usage without changing l
     assert.equal(nonstream.status, 200);
     const nonstreamBody = upstreamRequests.at(-1).body;
     assert.deepEqual(nonstreamBody.stream_options, { custom_option: "keep" });
-    assert.deepEqual(nonstreamBody.tools, []);
-    assert.equal(nonstreamBody.tool_choice, "none");
+    // Empty tools and dangling tool_choice are stripped for all routes.
+    assert.equal(nonstreamBody.tools, undefined);
+    assert.equal(nonstreamBody.tool_choice, undefined);
 
     // An omitted stream flag is non-streaming too; it must not inherit the
     // streamed usage opt-in merely because the route is Chat Completions.
@@ -5919,8 +6000,9 @@ test("API forwarder opts streamed Chat Completions into usage without changing l
     assert.equal(implicitNonstream.status, 200);
     const implicitNonstreamBody = upstreamRequests.at(-1).body;
     assert.deepEqual(implicitNonstreamBody.stream_options, { custom_option: "keep" });
-    assert.deepEqual(implicitNonstreamBody.tools, []);
-    assert.equal(implicitNonstreamBody.tool_choice, "none");
+    // Empty tools and dangling tool_choice are stripped for all routes.
+    assert.equal(implicitNonstreamBody.tools, undefined);
+    assert.equal(implicitNonstreamBody.tool_choice, undefined);
 
     // Streamed Chat Completions requests opt in and retain every other option.
     const streamed = await fetch(`${base}/v1/chat/completions`, {
@@ -5942,8 +6024,9 @@ test("API forwarder opts streamed Chat Completions into usage without changing l
       custom_option: "keep",
       include_usage: true,
     });
-    assert.deepEqual(streamedBody.tools, []);
-    assert.equal(streamedBody.tool_choice, "none");
+    // Empty tools and dangling tool_choice are stripped for all routes.
+    assert.equal(streamedBody.tools, undefined);
+    assert.equal(streamedBody.tool_choice, undefined);
 
     // An explicit all-zero usage chunk is still relayed; only the request
     // option is normalized, not provider accounting.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #588

## Problem

On current main, `src/api-forwarder.mjs` only strips empty `tools: []` and dangling `tool_choice` inside the `qwen38-community` request profile. Every other profile forwards Codex's compaction/plain-chat `tools: []` + `tool_choice`, which breaks against strict upstreams.

**Evidence:** `test/routing.test.mjs` ~5895-5904 (OpenCode Go mimo Chat Completions test) POSTs `tools: []` + `tool_choice: "none"` and **asserts they are forwarded** (`assert.deepEqual(nonstreamBody.tools, [])`). Strict upstreams (vLLM >=0.20 Pydantic) 400 that with: "tools must not be an empty array" / "When using tool_choice, tools must be set".

## Solution

Extract `stripEmptyTools(payload)` helper that:
- Deletes `tools` when it's an empty array
- Deletes dangling `tool_choice` (only when tools is absent or empty)
- Returns whether the payload was changed

Call `stripEmptyTools()` once in `normalizeBody` for **all** JSON routes, after the Meta `stripSearchContentTypes` block and before profile-specific branches (so qwen38-community still gets it). Log when a request is changed (respecting `CODEX_ROUTER_QUIET`).

Remove duplicate stripping code from the qwen38-community profile branch.

**Real non-empty tool arrays and their tool_choice are forwarded unchanged.**

## Tests

- Updated OpenCode Go `stream_options`/`include_usage` test to assert `tools`/`tool_choice` are **absent**, not `[]`/`none`
- Added focused test that non-qwen38 routes strip empty tools
- Existing qwen38 empty-tools test passes unchanged
- GLM/Qwen3.8 Flash test passes

## CHANGELOG

Added entry in Unreleased section describing the fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c1458be-248d-4f72-81f1-1f88869f9efe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c1458be-248d-4f72-81f1-1f88869f9efe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

