### PR TITLE
fix: correct Muse Spark metadata, effort labels, and defaults

### DIFF
--- a/config/commandcode/muse-spark-1.2.json
+++ b/config/commandcode/muse-spark-1.2.json
@@ -20,10 +20,11 @@
       "contextWindow": 1048576,
       "autoCompact": 900000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "commandcode-muse-spark-1-2-v2"
+      "compHash": "commandcode-muse-spark-1-2-v3"
     }
   ]
 }

--- a/config/meta/muse-spark-1.1.json
+++ b/config/meta/muse-spark-1.1.json
@@ -30,7 +30,7 @@
         },
         {
           "effort": "xhigh",
-          "description": "Maximum reasoning"
+          "description": "Extra deep reasoning"
         }
       ],
       "contextWindow": 1000000,
@@ -40,7 +40,7 @@
         "image"
       ],
       "supportsApplyPatchTool": false,
-      "compHash": "meta-muse-spark-1-1-v1"
+      "compHash": "meta-muse-spark-1-1-v2"
     }
   ]
 }

--- a/config/meta/muse-spark-1.2-contributor.json
+++ b/config/meta/muse-spark-1.2-contributor.json
@@ -30,7 +30,7 @@
         },
         {
           "effort": "xhigh",
-          "description": "Maximum reasoning"
+          "description": "Extra deep reasoning"
         }
       ],
       "supportsReasoningSummaries": true,
@@ -43,7 +43,7 @@
       ],
       "supportsApplyPatchTool": false,
       "requestProfile": "auto-tool-choice",
-      "compHash": "meta-muse-spark-1-2-contributor-v2"
+      "compHash": "meta-muse-spark-1-2-contributor-v3"
     }
   ]
 }

--- a/config/meta/muse-spark-1.2.json
+++ b/config/meta/muse-spark-1.2.json
@@ -31,7 +31,7 @@
         },
         {
           "effort": "xhigh",
-          "description": "Maximum reasoning"
+          "description": "Extra deep reasoning"
         }
       ],
       "supportsReasoningSummaries": true,
@@ -44,7 +44,7 @@
       ],
       "supportsApplyPatchTool": false,
       "requestProfile": "auto-tool-choice",
-      "compHash": "meta-muse-spark-1-2-v2"
+      "compHash": "meta-muse-spark-1-2-v3"
     }
   ]
 }

--- a/config/nousresearch/muse-spark-1.2-contributor.json
+++ b/config/nousresearch/muse-spark-1.2-contributor.json
@@ -36,10 +36,11 @@
       "contextWindow": 1048576,
       "autoCompact": 943000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "nousresearch-muse-spark-1-2-contributor-v2"
+      "compHash": "nousresearch-muse-spark-1-2-contributor-v3"
     }
   ]
 }

--- a/config/nousresearch/muse-spark-1.2-contributor.json
+++ b/config/nousresearch/muse-spark-1.2-contributor.json
@@ -10,7 +10,7 @@
       "displayName": "Muse Spark 1.2 Contributor (Nous Research)",
       "description": "Meta Muse Spark 1.2 Contributor through the Nous Portal.",
       "priority": 72,
-      "defaultEffort": "medium",
+      "defaultEffort": "high",
       "reasoningLevels": [
         {
           "effort": "minimal",
@@ -40,7 +40,7 @@
         "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "nousresearch-muse-spark-1-2-contributor-v3"
+      "compHash": "nousresearch-muse-spark-1-2-contributor-v4"
     }
   ]
 }

--- a/config/nousresearch/muse-spark-1.3-contributor.json
+++ b/config/nousresearch/muse-spark-1.3-contributor.json
@@ -36,10 +36,11 @@
       "contextWindow": 1048576,
       "autoCompact": 943000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "nousresearch-muse-spark-1-3-contributor-v1"
+      "compHash": "nousresearch-muse-spark-1-3-contributor-v2"
     }
   ]
 }

--- a/config/nousresearch/muse-spark-1.3-contributor.json
+++ b/config/nousresearch/muse-spark-1.3-contributor.json
@@ -10,7 +10,7 @@
       "displayName": "Muse Spark 1.3 Contributor (Nous Research)",
       "description": "Meta Muse Spark 1.3 Contributor through the Nous Portal.",
       "priority": 73,
-      "defaultEffort": "medium",
+      "defaultEffort": "high",
       "reasoningLevels": [
         {
           "effort": "minimal",
@@ -40,7 +40,7 @@
         "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "nousresearch-muse-spark-1-3-contributor-v2"
+      "compHash": "nousresearch-muse-spark-1-3-contributor-v3"
     }
   ]
 }

--- a/config/nousresearch/muse-spark-1.3.json
+++ b/config/nousresearch/muse-spark-1.3.json
@@ -10,7 +10,7 @@
       "displayName": "Muse Spark 1.3 (Nous Research)",
       "description": "Meta Muse Spark 1.3 through the Nous Portal.",
       "priority": 73,
-      "defaultEffort": "medium",
+      "defaultEffort": "high",
       "reasoningLevels": [
         {
           "effort": "minimal",
@@ -40,7 +40,7 @@
         "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "nousresearch-muse-spark-1-3-v2"
+      "compHash": "nousresearch-muse-spark-1-3-v3"
     }
   ]
 }

--- a/config/nousresearch/muse-spark-1.3.json
+++ b/config/nousresearch/muse-spark-1.3.json
@@ -36,10 +36,11 @@
       "contextWindow": 1048576,
       "autoCompact": 943000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "nousresearch-muse-spark-1-3-v1"
+      "compHash": "nousresearch-muse-spark-1-3-v2"
     }
   ]
 }

--- a/config/opencode/go-responses/muse-spark-1.2-contributor.json
+++ b/config/opencode/go-responses/muse-spark-1.2-contributor.json
@@ -30,7 +30,7 @@
         },
         {
           "effort": "xhigh",
-          "description": "Maximum reasoning"
+          "description": "Extra deep reasoning"
         }
       ],
       "supportsReasoningSummaries": true,
@@ -43,7 +43,7 @@
       ],
       "supportsApplyPatchTool": false,
       "requestProfile": "auto-tool-choice",
-      "compHash": "opencode-go-responses-muse-spark-1-2-contributor-v2"
+      "compHash": "opencode-go-responses-muse-spark-1-2-contributor-v3"
     }
   ]
 }

--- a/config/opencode/go-responses/muse-spark-1.3-contributor.json
+++ b/config/opencode/go-responses/muse-spark-1.3-contributor.json
@@ -30,7 +30,7 @@
         },
         {
           "effort": "xhigh",
-          "description": "Maximum reasoning"
+          "description": "Extra deep reasoning"
         }
       ],
       "supportsReasoningSummaries": true,
@@ -43,7 +43,7 @@
       ],
       "supportsApplyPatchTool": false,
       "requestProfile": "auto-tool-choice",
-      "compHash": "opencode-go-responses-muse-spark-1-3-contributor-v2"
+      "compHash": "opencode-go-responses-muse-spark-1-3-contributor-v3"
     }
   ]
 }

--- a/config/openrouter/muse-spark-1.2-contributor.json
+++ b/config/openrouter/muse-spark-1.2-contributor.json
@@ -2,14 +2,14 @@
   "version": 1,
   "models": [
     {
-      "slug": "openrouter/muse-spark-1.3-contributor",
-      "gatewayModel": "openrouter-muse-spark-1-3-contributor",
-      "upstreamModel": "meta/muse-spark-1.3-contributor",
+      "slug": "openrouter/muse-spark-1.2-contributor",
+      "gatewayModel": "openrouter-muse-spark-1-2-contributor",
+      "upstreamModel": "meta/muse-spark-1.2-contributor",
       "provider": "openrouter",
       "listed": true,
-      "displayName": "Muse Spark 1.3 Contributor (OpenRouter)",
-      "description": "Meta Muse Spark 1.3 Contributor through OpenRouter.",
-      "priority": 73,
+      "displayName": "Muse Spark 1.2 Contributor (OpenRouter)",
+      "description": "Meta Muse Spark 1.2 Contributor through OpenRouter. Meta may use inputs and outputs for training.",
+      "priority": 72,
       "defaultEffort": "medium",
       "reasoningLevels": [
         {
@@ -40,7 +40,7 @@
         "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "openrouter-muse-spark-1-3-contributor-v2"
+      "compHash": "openrouter-muse-spark-1-2-contributor-v1"
     }
   ]
 }

--- a/config/openrouter/muse-spark-1.2-contributor.json
+++ b/config/openrouter/muse-spark-1.2-contributor.json
@@ -10,7 +10,7 @@
       "displayName": "Muse Spark 1.2 Contributor (OpenRouter)",
       "description": "Meta Muse Spark 1.2 Contributor through OpenRouter. Meta may use inputs and outputs for training.",
       "priority": 72,
-      "defaultEffort": "medium",
+      "defaultEffort": "high",
       "reasoningLevels": [
         {
           "effort": "minimal",
@@ -40,7 +40,7 @@
         "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "openrouter-muse-spark-1-2-contributor-v1"
+      "compHash": "openrouter-muse-spark-1-2-contributor-v2"
     }
   ]
 }

--- a/config/openrouter/muse-spark-1.2.json
+++ b/config/openrouter/muse-spark-1.2.json
@@ -10,7 +10,7 @@
       "displayName": "Muse Spark 1.2 (OpenRouter)",
       "description": "Meta Muse Spark 1.2 through OpenRouter.",
       "priority": 72,
-      "defaultEffort": "medium",
+      "defaultEffort": "high",
       "reasoningLevels": [
         {
           "effort": "minimal",
@@ -40,7 +40,7 @@
         "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "openrouter-muse-spark-1-2-v1"
+      "compHash": "openrouter-muse-spark-1-2-v2"
     }
   ]
 }

--- a/config/openrouter/muse-spark-1.2.json
+++ b/config/openrouter/muse-spark-1.2.json
@@ -2,14 +2,14 @@
   "version": 1,
   "models": [
     {
-      "slug": "openrouter/muse-spark-1.3-contributor",
-      "gatewayModel": "openrouter-muse-spark-1-3-contributor",
-      "upstreamModel": "meta/muse-spark-1.3-contributor",
+      "slug": "openrouter/muse-spark-1.2",
+      "gatewayModel": "openrouter-muse-spark-1-2",
+      "upstreamModel": "meta/muse-spark-1.2",
       "provider": "openrouter",
       "listed": true,
-      "displayName": "Muse Spark 1.3 Contributor (OpenRouter)",
-      "description": "Meta Muse Spark 1.3 Contributor through OpenRouter.",
-      "priority": 73,
+      "displayName": "Muse Spark 1.2 (OpenRouter)",
+      "description": "Meta Muse Spark 1.2 through OpenRouter.",
+      "priority": 72,
       "defaultEffort": "medium",
       "reasoningLevels": [
         {
@@ -40,7 +40,7 @@
         "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "openrouter-muse-spark-1-3-contributor-v2"
+      "compHash": "openrouter-muse-spark-1-2-v1"
     }
   ]
 }

--- a/config/openrouter/muse-spark-1.3-contributor.json
+++ b/config/openrouter/muse-spark-1.3-contributor.json
@@ -10,7 +10,7 @@
       "displayName": "Muse Spark 1.3 Contributor (OpenRouter)",
       "description": "Meta Muse Spark 1.3 Contributor through OpenRouter.",
       "priority": 73,
-      "defaultEffort": "medium",
+      "defaultEffort": "high",
       "reasoningLevels": [
         {
           "effort": "minimal",
@@ -40,7 +40,7 @@
         "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "openrouter-muse-spark-1-3-contributor-v2"
+      "compHash": "openrouter-muse-spark-1-3-contributor-v3"
     }
   ]
 }

--- a/config/openrouter/muse-spark-1.3.json
+++ b/config/openrouter/muse-spark-1.3.json
@@ -36,10 +36,11 @@
       "contextWindow": 1048576,
       "autoCompact": 943000,
       "inputModalities": [
-        "text"
+        "text",
+        "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "openrouter-muse-spark-1-3-v1"
+      "compHash": "openrouter-muse-spark-1-3-v2"
     }
   ]
 }

--- a/config/openrouter/muse-spark-1.3.json
+++ b/config/openrouter/muse-spark-1.3.json
@@ -10,7 +10,7 @@
       "displayName": "Muse Spark 1.3 (OpenRouter)",
       "description": "Meta Muse Spark 1.3 through OpenRouter.",
       "priority": 73,
-      "defaultEffort": "medium",
+      "defaultEffort": "high",
       "reasoningLevels": [
         {
           "effort": "minimal",
@@ -40,7 +40,7 @@
         "image"
       ],
       "requestProfile": "auto-tool-choice",
-      "compHash": "openrouter-muse-spark-1-3-v2"
+      "compHash": "openrouter-muse-spark-1-3-v3"
     }
   ]
 }

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -51,6 +51,7 @@ const OPENCODE_FREE_MODELS = Object.freeze({
     outputLimit: 131_072,
     reasoningLevels: Object.freeze(["minimal", "low", "medium", "high", "xhigh"]),
     requestProfile: "auto-tool-choice",
+    displayName: "Muse Spark 1.2 Contributor Free (OpenCode Free)",
     summary:
       "Muse Spark 1.2 Contributor Free through OpenCode Zen's anonymous Responses route.",
     contextNote:
@@ -67,6 +68,7 @@ const OPENCODE_FREE_MODELS = Object.freeze({
     outputLimit: 131_072,
     reasoningLevels: Object.freeze(["minimal", "low", "medium", "high", "xhigh"]),
     requestProfile: "auto-tool-choice",
+    displayName: "Muse Spark 1.3 Contributor Free (OpenCode Free)",
     summary:
       "Muse Spark 1.3 Contributor Free through OpenCode Zen's anonymous Responses route.",
     contextNote:
@@ -400,6 +402,13 @@ export function curatedModelReasoningLevels(providerId, upstreamModel) {
 // provider-wide would weaken forced tool choices for unrelated models.
 export function curatedModelRequestProfile(providerId, upstreamModel) {
   return curatedModelRecord(providerId, upstreamModel)?.requestProfile;
+}
+
+// A stable picker label for ids whose upstream name is opaque. Curation reads
+// this when building user-model entries, and the registry applies it to
+// existing curated rows that still carry the generic "(curated)" fallback.
+export function curatedModelDisplayName(providerId, upstreamModel) {
+  return curatedModelRecord(providerId, upstreamModel)?.displayName;
 }
 
 // The picker text that carries the sourcing for every value this module knows

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import { writePrivateJson } from "./file-security.mjs";
+import { curatedModelDisplayName } from "./opencode-curation.mjs";
 import { STATE_DIR } from "./paths.mjs";
 
 // User-curated models live outside the checked-in config/ registry tree so a checkout update
@@ -79,7 +80,10 @@ const OFFICIAL_MODEL_DISPLAY_NAMES = new Map([
 ]);
 
 export function officialModelDisplayName(providerId, upstreamId) {
-  return OFFICIAL_MODEL_DISPLAY_NAMES.get(`${providerId}/${upstreamId}`);
+  return (
+    OFFICIAL_MODEL_DISPLAY_NAMES.get(`${providerId}/${upstreamId}`) ||
+    curatedModelDisplayName(providerId, upstreamId)
+  );
 }
 
 function gatewaySafe(value) {

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -1031,6 +1031,28 @@ test("the Responses variant resolves the same sourcing as its base provider", ()
   );
 });
 
+test("OpenCode Free Muse Spark routes publish stable picker labels", async () => {
+  const { curatedModelDisplayName } = await import("../src/opencode-curation.mjs");
+  const { officialModelDisplayName } = await import("../src/user-models.mjs");
+  for (const [providerId, upstreamId, label] of [
+    [
+      "opencode-free",
+      "muse-spark-1.2-contributor-free",
+      "Muse Spark 1.2 Contributor Free (OpenCode Free)",
+    ],
+    [
+      "opencode-free",
+      "muse-spark-1.3-contributor-free",
+      "Muse Spark 1.3 Contributor Free (OpenCode Free)",
+    ],
+  ]) {
+    assert.equal(curatedModelDisplayName(providerId, upstreamId), label);
+    assert.equal(officialModelDisplayName(providerId, upstreamId), label);
+    assert.equal(curatedModelDisplayName("opencode-free-responses", upstreamId), label);
+    assert.equal(officialModelDisplayName("opencode-free-responses", upstreamId), label);
+  }
+});
+
 test("scripted OpenCode Free curation stores the documented window and its sourcing", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "curate-opencode-free-sourcing-"));
   const file = path.join(dir, "user-models.json");

--- a/test/gemini-3.8-muse-1.3-fable-5.1.test.mjs
+++ b/test/gemini-3.8-muse-1.3-fable-5.1.test.mjs
@@ -159,6 +159,29 @@ test("Muse Spark 1.3 reasoning ladders have minimal/low/medium/high/xhigh", () =
   }
 });
 
+test("Muse Spark xhigh is labeled as extra deep, not max, and defaults to high", () => {
+  const museSlugs = [
+    ...MUSE_13_ROUTES.map(([slug]) => slug),
+    ...MUSE_12_ROUTES.map(([slug]) => slug),
+    "meta/muse-spark-1.2",
+    "meta/muse-spark-1.2-contributor",
+    "meta/muse-spark-1.1",
+  ];
+  for (const slug of museSlugs) {
+    const model = MODEL_BY_SLUG.get(slug);
+    assert.ok(model, `${slug} is missing from the registry`);
+    assert.equal(model.defaultEffort, "high", slug);
+    const xhigh = model.reasoningLevels.find((level) => level.effort === "xhigh");
+    assert.ok(xhigh, `${slug} is missing xhigh`);
+    assert.equal(xhigh.description, "Extra deep reasoning", slug);
+    assert.notEqual(xhigh.description, "Maximum reasoning");
+    assert.ok(
+      !model.reasoningLevels.some((level) => level.effort === "max"),
+      `${slug} must not advertise Meta's unreleased max tier yet`,
+    );
+  }
+});
+
 test("Gemini 3.8 Flash reasoning matches provider patterns", () => {
   // Nous has low/medium/high
   const nousModel = MODEL_BY_SLUG.get("nousresearch/gemini-3.8-flash");

--- a/test/gemini-3.8-muse-1.3-fable-5.1.test.mjs
+++ b/test/gemini-3.8-muse-1.3-fable-5.1.test.mjs
@@ -21,6 +21,11 @@ const GEMINI_38_FLASH_ROUTES = [
 ];
 
 // Muse Spark 1.3 routes confirmed 2026-09-03.
+const MUSE_12_ROUTES = [
+  ["openrouter/muse-spark-1.2", "meta/muse-spark-1.2", 1_048_576, 943_000],
+  ["openrouter/muse-spark-1.2-contributor", "meta/muse-spark-1.2-contributor", 1_048_576, 943_000],
+];
+
 const MUSE_13_ROUTES = [
   ["openrouter/muse-spark-1.3", "meta/muse-spark-1.3", 1_048_576, 943_000],
   ["openrouter/muse-spark-1.3-contributor", "meta/muse-spark-1.3-contributor", 1_048_576, 943_000],
@@ -46,6 +51,17 @@ const ADDITIONAL_ROUTES = [
 
 test("every Gemini 3.8 Flash route records the upstream id and window", () => {
   for (const [slug, upstreamModel, contextWindow, autoCompact] of GEMINI_38_FLASH_ROUTES) {
+    const model = MODEL_BY_SLUG.get(slug);
+    assert.ok(model, `${slug} is missing from the registry`);
+    assert.equal(model.upstreamModel, upstreamModel);
+    assert.equal(model.listed, true);
+    assert.equal(model.contextWindow, contextWindow);
+    assert.equal(model.autoCompact, autoCompact);
+  }
+});
+
+test("every Muse Spark 1.2 OpenRouter route records the upstream id and window", () => {
+  for (const [slug, upstreamModel, contextWindow, autoCompact] of MUSE_12_ROUTES) {
     const model = MODEL_BY_SLUG.get(slug);
     assert.ok(model, `${slug} is missing from the registry`);
     assert.equal(model.upstreamModel, upstreamModel);
@@ -108,6 +124,27 @@ test("Muse Spark 1.3 routes use auto-tool-choice request profile", () => {
   for (const [slug] of MUSE_13_ROUTES) {
     const model = MODEL_BY_SLUG.get(slug);
     assert.equal(model.requestProfile, "auto-tool-choice");
+  }
+});
+
+test("Muse Spark reseller routes advertise text and image input", () => {
+  const visionSlugs = [
+    "meta/muse-spark-1.2",
+    "meta/muse-spark-1.2-contributor",
+    "commandcode/muse-spark-1.2",
+    "openrouter/muse-spark-1.2",
+    "openrouter/muse-spark-1.2-contributor",
+    "openrouter/muse-spark-1.3",
+    "openrouter/muse-spark-1.3-contributor",
+    "nousresearch/muse-spark-1.3",
+    "nousresearch/muse-spark-1.3-contributor",
+    "nousresearch/muse-spark-1.2-contributor",
+    "opencode-go-responses/muse-spark-1.2-contributor",
+    "opencode-go-responses/muse-spark-1.3-contributor",
+  ];
+  for (const slug of visionSlugs) {
+    const model = MODEL_BY_SLUG.get(slug);
+    assert.deepEqual(model.inputModalities, ["text", "image"], slug);
   }
 });
 
@@ -185,6 +222,7 @@ test("Command Code gemini-3.8-flash has requiresTrailingUserTurn", () => {
 test("no new route sets multiAgentVersion v2 without v2_agent/ artifact", () => {
   const allNewSlugs = [
     ...GEMINI_38_FLASH_ROUTES.map(([slug]) => slug),
+    ...MUSE_12_ROUTES.map(([slug]) => slug),
     ...MUSE_13_ROUTES.map(([slug]) => slug),
     ...FABLE_51_ROUTES.map(([slug]) => slug),
     ...ADDITIONAL_ROUTES.map(([slug]) => slug),

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -189,6 +189,8 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "openrouter/glm-5.3",
       "openrouter/grok-4.6",
       "openrouter/tencent/hy4-preview",
+      "openrouter/muse-spark-1.2-contributor",
+      "openrouter/muse-spark-1.2",
       "openrouter/muse-spark-1.3-contributor",
       "openrouter/muse-spark-1.3",
       "openrouter/qwen3.8-flash",
@@ -1727,6 +1729,8 @@ test("Muse Spark 1.2 routes normalize forced tool choices model-by-model", () =>
     "meta/muse-spark-1.2-contributor",
     "nousresearch/muse-spark-1.2-contributor",
     "opencode-go-responses/muse-spark-1.2-contributor",
+    "openrouter/muse-spark-1.2",
+    "openrouter/muse-spark-1.2-contributor",
   ]) {
     assert.equal(MODEL_BY_SLUG.get(slug)?.requestProfile, "auto-tool-choice", slug);
   }

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -41,6 +41,16 @@ test("userModelEntry fills conservative picker metadata", () => {
 });
 
 
+test("OpenCode Free Muse Spark curation uses the official picker label", () => {
+  const entry = userModelEntry({
+    providerId: "opencode-free-responses",
+    upstreamId: "muse-spark-1.3-contributor-free",
+    priority: 100,
+    metadata: { isFree: true },
+  });
+  assert.equal(entry.displayName, "Muse Spark 1.3 Contributor Free (OpenCode Free)");
+});
+
 test("curation metadata can set sizing and the effort ladder", () => {
   const entry = userModelEntry({
     providerId: "deepseek",


### PR DESCRIPTION
## Problem

1. **Effort labeling:** Several Muse routes labeled `xhigh` as **"Maximum reasoning"**, but Meta treats **`max` as a separate tier above xhigh** that is still gated behind safety testing. That made the picker look like it already offered max.
2. **Wrong default:** OpenRouter/Nous Muse Spark 1.2/1.3 routes defaulted to **`medium`** while Meta direct and opencode Go routes default to **`high`**.
3. **Missing metadata:** Reseller Muse routes omitted image input; OpenRouter lacked 1.2/1.2-contributor registry entries; OpenCode Free Muse models lacked human-readable picker labels.

## Change

- Rename Muse `xhigh` descriptions to **"Extra deep reasoning"** (do **not** publish `max` until upstream accepts it).
- Set **`defaultEffort: high`** on OpenRouter/Nous Muse Spark routes.
- Advertise **text+image** on reseller Muse Spark routes where models.dev documents vision.
- Add OpenRouter Muse Spark 1.2 / 1.2-contributor registry entries.
- Add OpenCode Free display names for Muse contributor-free models (1.2 + 1.3).

## Live verification (install)

| Route | Result |
|---|---|
| `opencode-free-responses/muse-spark-1.3-contributor-free` | Curated + listed; upstream returns **RegionError** in this region (OpenCode/Zen geo gate, not a router bug) |
| `opencode-free-responses/muse-spark-1.2-contributor-free` | **5/5 pass** |
| `opencode-go-responses/muse-spark-1.3-contributor` | **4/5 pass** (compaction covered separately in #593) |

## Testing

- `node --test test/gemini-3.8-muse-1.3-fable-5.1.test.mjs` → 20/20
- `npm run check` → clean