### PR TITLE
fix: treat refused Codex account reads as empty instead of failing the panel

### DIFF
--- a/src/codex-account-usage.mjs
+++ b/src/codex-account-usage.mjs
@@ -214,12 +214,15 @@ export function readCodexAccountUsage({
         return;
       }
       if (message.id !== 2 && message.id !== 3) return;
+      // Both account reads are optional for the Control Center. A ChatGPT login
+      // can answer one and refuse the other (API-key sessions, transient
+      // app-server races). Hard-failing rateLimits used to paint the whole
+      // Models page with a stack trace while the snapshot itself was fine.
       if (message.error) {
-        if (message.id === 2) {
-          finish(new Error("Codex account limits are unavailable for this login."));
-          return;
-        }
-        responses.set(3, { summary: {}, dailyUsageBuckets: [] });
+        responses.set(
+          message.id,
+          message.id === 2 ? { rateLimits: {} } : { summary: {}, dailyUsageBuckets: [] },
+        );
       } else {
         responses.set(message.id, message.result);
       }

--- a/test/codex-account-usage.test.mjs
+++ b/test/codex-account-usage.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import test from "node:test";
 
 import {
@@ -8,6 +10,31 @@ import {
   normalizeCodexAccountUsage,
   readCodexAccountUsage,
 } from "../src/codex-account-usage.mjs";
+
+function fakeAppServer(replies) {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  const child = new EventEmitter();
+  child.stdout = stdout;
+  child.stdin = stdin;
+  child.kill = () => {
+    stdout.end();
+    child.emit("exit", 0);
+  };
+  stdin.on("data", (chunk) => {
+    for (const line of String(chunk).split("\n").filter(Boolean)) {
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const reply = replies(message);
+      if (reply) stdout.write(`${JSON.stringify(reply)}\n`);
+    }
+  });
+  return child;
+}
 
 test("64 slow account probes stay within one capped concurrent usage budget", async () => {
   const accounts = Object.fromEntries(Array.from({ length: 64 }, (_, index) => [
@@ -196,4 +223,66 @@ test("the usage panel names a missing Codex instead of blaming the app-server", 
   // machine with Codex installed. It only looked green because CI runners have
   // none -- which is the one environment where this assertion cannot fail.
   await assert.rejects(readCodexAccountUsage({ binary: null }), /no Codex binary was found/);
+});
+
+test("a refused rateLimits read still returns usage instead of failing the panel", async () => {
+  const value = await readCodexAccountUsage({
+    binary: "/fake/codex",
+    platform: "darwin",
+    timeoutMs: 2_000,
+    spawnImpl: () => fakeAppServer((message) => {
+      if (message.id === 1) return { id: 1, result: {} };
+      if (message.id === 2) {
+        return { id: 2, error: { code: -32000, message: "limits unavailable" } };
+      }
+      if (message.id === 3) {
+        return {
+          id: 3,
+          result: {
+            summary: { lifetimeTokens: 42, peakDailyTokens: 7, currentStreakDays: 1 },
+            dailyUsageBuckets: [{ startDate: "2026-09-01", tokens: 9 }],
+          },
+        };
+      }
+      return undefined;
+    }),
+  });
+
+  assert.equal(value.planType, null);
+  assert.equal(value.primary, null);
+  assert.equal(value.secondary, null);
+  assert.equal(value.summary.lifetimeTokens, 42);
+  assert.deepEqual(value.dailyUsageBuckets, [{ startDate: "2026-09-01", tokens: 9 }]);
+});
+
+test("a refused usage read still returns rate limits instead of failing the panel", async () => {
+  const value = await readCodexAccountUsage({
+    binary: "/fake/codex",
+    platform: "darwin",
+    timeoutMs: 2_000,
+    spawnImpl: () => fakeAppServer((message) => {
+      if (message.id === 1) return { id: 1, result: {} };
+      if (message.id === 2) {
+        return {
+          id: 2,
+          result: {
+            rateLimits: {
+              planType: "pro",
+              limitId: "codex",
+              primary: { usedPercent: 10, windowDurationMins: 300, resetsAt: 1_800_000_000 },
+            },
+          },
+        };
+      }
+      if (message.id === 3) {
+        return { id: 3, error: { code: -32000, message: "usage unavailable" } };
+      }
+      return undefined;
+    }),
+  });
+
+  assert.equal(value.planType, "pro");
+  assert.equal(value.primary.usedPercent, 10);
+  assert.deepEqual(value.dailyUsageBuckets, []);
+  assert.equal(value.summary.lifetimeTokens, null);
 });


### PR DESCRIPTION
## Problem

Control Center shows **Some router data could not load** when `router-control:getAccountUsage` fails with:

> Codex account limits are unavailable for this login.

`readCodexAccountUsage` already treated a refused `account/usage/read` as empty usage, but a refused `account/rateLimits/read` hard-failed the whole call. Some ChatGPT logins answer one RPC and refuse the other.

## Change

When either read returns an error, store an empty payload for that side and continue once both replies arrive. The panel renders whatever partial data is available instead of throwing.

## Testing

- `node --test test/codex-account-usage.test.mjs` → 10/10
- New tests: refused rateLimits with good usage; refused usage with good rateLimits

Made with [Cursor](https://cursor.com)