### PR TITLE
Group OpenCode Free Muse Spark routes with paid family; flatten recursive tool schemas

### DIFF
--- a/config/opencode/go-responses/muse-spark-1.2-contributor.json
+++ b/config/opencode/go-responses/muse-spark-1.2-contributor.json
@@ -43,7 +43,8 @@
       ],
       "supportsApplyPatchTool": false,
       "requestProfile": "auto-tool-choice",
-      "compHash": "opencode-go-responses-muse-spark-1-2-contributor-v3"
+      "compHash": "opencode-go-responses-muse-spark-1-2-contributor-v3",
+      "toolSchemaRecursion": "flatten"
     }
   ]
 }

--- a/config/opencode/go-responses/muse-spark-1.3-contributor.json
+++ b/config/opencode/go-responses/muse-spark-1.3-contributor.json
@@ -43,7 +43,8 @@
       ],
       "supportsApplyPatchTool": false,
       "requestProfile": "auto-tool-choice",
-      "compHash": "opencode-go-responses-muse-spark-1-3-contributor-v3"
+      "compHash": "opencode-go-responses-muse-spark-1-3-contributor-v3",
+      "toolSchemaRecursion": "flatten"
     }
   ]
 }

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -68,7 +68,10 @@ import {
 import {
   runProviderApiKeyAttempts,
 } from "./provider-api-key-pool.mjs";
-import { stripCodexEncryptedSchemaAnnotation } from "./tool-schema-root.mjs";
+import {
+  nonRecursiveToolSchema,
+  stripCodexEncryptedSchemaAnnotation,
+} from "./tool-schema-root.mjs";
 import { requestGenericProvider } from "./generic-providers.mjs";
 import { genericProviderConfigured } from "./generic-provider-readiness.mjs";
 import { providerTransportError } from "./transport-failure.mjs";
@@ -381,6 +384,42 @@ function stripEncryptedToolSchemaAnnotations(payload, protocol) {
     return { ...tool, function: { ...fn, parameters: repaired } };
   });
   if (changed) payload.tools = tools;
+}
+
+// Meta's Console API behind opencode answers a self-referencing tool schema
+// with a bare 400 naming neither the tool nor the definition, and the turn is
+// lost. Measured against that endpoint, an ordinary `$ref`/`$defs` pair is
+// accepted and only a reference re-entering its own ancestor is refused, so
+// `nonRecursiveToolSchema` -- which blanks exactly the cycle-closing edge and
+// returns any other schema by identity -- is the whole fix. The namespace relay
+// already uses it for the same reason.
+function flattenRecursiveToolSchemas(payload, protocol) {
+  if (!Array.isArray(payload.tools)) return;
+  let changed = false;
+  const tools = payload.tools.map((tool) => {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool) || tool.type !== "function") {
+      return tool;
+    }
+    if (protocol === "openai-responses") {
+      const flattened = nonRecursiveToolSchema(tool.parameters);
+      if (flattened === tool.parameters) return tool;
+      changed = true;
+      return { ...tool, parameters: flattened };
+    }
+    const fn = tool.function;
+    if (!fn || typeof fn !== "object" || Array.isArray(fn)) return tool;
+    const flattened = nonRecursiveToolSchema(fn.parameters);
+    if (flattened === fn.parameters) return tool;
+    changed = true;
+    return { ...tool, function: { ...fn, parameters: flattened } };
+  });
+  if (!changed) return;
+  payload.tools = tools;
+  // Never quieted: a tool the model may call has lost part of its argument
+  // shape, and an unattended service is exactly where that must not be silent.
+  console.error(
+    "[api-forwarder] broke recursive $ref cycles in tool schema(s) for this request",
+  );
 }
 
 // A trailing model turn is a destructive rewrite: it discards part of the
@@ -801,6 +840,13 @@ function normalizeBody(buffer, contentType, route) {
   }
   if (model.requestProfile === "codex-encrypted-schema") {
     stripEncryptedToolSchemaAnnotations(payload, provider.protocol);
+  }
+  // Deliberately its own statement rather than a branch of the profile chain
+  // below: this is an upstream limitation, and every route that has it also
+  // needs a request profile of its own, which the single-valued field cannot
+  // express.
+  if (model.toolSchemaRecursion === "flatten") {
+    flattenRecursiveToolSchemas(payload, provider.protocol);
   }
   if (model.requestProfile === "clinepass") {
     delete payload.reasoning_effort;

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -9,6 +9,7 @@ import {
   normalizeSupportedEndpoints,
   providerModelEndpoint,
 } from "./openai-endpoint-policy.mjs";
+import { curatedModelIsFree } from "./opencode-curation.mjs";
 import { instructionOverlayExists } from "./instruction-overlays.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import { officialModelDisplayName, readUserModels } from "./user-models.mjs";
@@ -545,9 +546,18 @@ function normalizedModel(model, provider, { curated = false } = {}) {
   const officialDisplayName = curated
     ? officialModelDisplayName(model.provider, model.upstreamModel)
     : undefined;
-  const presented = officialDisplayName && model.displayName !== officialDisplayName
+  // A documented free tier is applied for the same reason the name is: an entry
+  // curated before the tag existed carries neither, and re-curating is not
+  // something an installed machine should have to do to be told the price.
+  const documentedFree = curated
+    ? curatedModelIsFree(model.provider, model.upstreamModel)
+    : undefined;
+  const renamed = officialDisplayName && model.displayName !== officialDisplayName
     ? { ...model, displayName: officialDisplayName }
     : model;
+  const presented = documentedFree === true && renamed.isFree !== true
+    ? { ...renamed, isFree: true }
+    : renamed;
   if (!provider?.perModelEndpoint) return Object.freeze(presented);
   return Object.freeze({
     ...presented,

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -9,7 +9,10 @@ import {
   normalizeSupportedEndpoints,
   providerModelEndpoint,
 } from "./openai-endpoint-policy.mjs";
-import { curatedModelIsFree } from "./opencode-curation.mjs";
+import {
+  curatedModelIsFree,
+  curatedModelToolSchemaRecursion,
+} from "./opencode-curation.mjs";
 import { instructionOverlayExists } from "./instruction-overlays.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import { officialModelDisplayName, readUserModels } from "./user-models.mjs";
@@ -555,9 +558,18 @@ function normalizedModel(model, provider, { curated = false } = {}) {
   const renamed = officialDisplayName && model.displayName !== officialDisplayName
     ? { ...model, displayName: officialDisplayName }
     : model;
-  const presented = documentedFree === true && renamed.isFree !== true
+  const priced = documentedFree === true && renamed.isFree !== true
     ? { ...renamed, isFree: true }
     : renamed;
+  // Same rule again, and this one costs turns rather than clarity: without it
+  // an entry curated before the upstream's limitation was documented keeps
+  // sending cycles that come back as a 400 naming nothing.
+  const documentedRecursion = curated
+    ? curatedModelToolSchemaRecursion(model.provider, model.upstreamModel)
+    : undefined;
+  const presented = documentedRecursion && !priced.toolSchemaRecursion
+    ? { ...priced, toolSchemaRecursion: documentedRecursion }
+    : priced;
   if (!provider?.perModelEndpoint) return Object.freeze(presented);
   return Object.freeze({
     ...presented,
@@ -692,6 +704,18 @@ function modelProblem(model, providers, slugs, gatewayModels) {
   // never needs it, so only false is accepted.
   if (model.visionBridge !== undefined && model.visionBridge !== false) {
     return `model ${model.slug} may only set visionBridge to false`;
+  }
+  // An upstream that refuses a tool schema whose `$ref`s cycle needs the cycle
+  // broken before dispatch. This is a property of the upstream, not of the
+  // model's abilities, and it is deliberately separate from `requestProfile`:
+  // that field holds one value, and every route needing this so far also needs
+  // a profile of its own. `flatten` is the only verb, because rejecting the
+  // turn is what already happens without it.
+  if (
+    model.toolSchemaRecursion !== undefined &&
+    model.toolSchemaRecursion !== "flatten"
+  ) {
+    return `model ${model.slug} may only set toolSchemaRecursion to "flatten"`;
   }
   if (model.isFree !== undefined && typeof model.isFree !== "boolean") {
     return `model ${model.slug} has an invalid isFree flag`;

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -51,7 +51,12 @@ const OPENCODE_FREE_MODELS = Object.freeze({
     outputLimit: 131_072,
     reasoningLevels: Object.freeze(["minimal", "low", "medium", "high", "xhigh"]),
     requestProfile: "auto-tool-choice",
-    displayName: "Muse Spark 1.2 Contributor Free (OpenCode Free)",
+    // The `-free` suffix is the tier, not the model. Carrying it in the label
+    // put this route in a family of its own, apart from the paid routes to the
+    // same model. `isFree` is where the price distinction belongs; the picker
+    // already renders it as a badge on the route.
+    displayName: "Muse Spark 1.2 Contributor (OpenCode Free)",
+    isFree: true,
     summary:
       "Muse Spark 1.2 Contributor Free through OpenCode Zen's anonymous Responses route.",
     contextNote:
@@ -68,7 +73,8 @@ const OPENCODE_FREE_MODELS = Object.freeze({
     outputLimit: 131_072,
     reasoningLevels: Object.freeze(["minimal", "low", "medium", "high", "xhigh"]),
     requestProfile: "auto-tool-choice",
-    displayName: "Muse Spark 1.3 Contributor Free (OpenCode Free)",
+    displayName: "Muse Spark 1.3 Contributor (OpenCode Free)",
+    isFree: true,
     summary:
       "Muse Spark 1.3 Contributor Free through OpenCode Zen's anonymous Responses route.",
     contextNote:
@@ -409,6 +415,14 @@ export function curatedModelRequestProfile(providerId, upstreamModel) {
 // existing curated rows that still carry the generic "(curated)" fallback.
 export function curatedModelDisplayName(providerId, upstreamModel) {
   return curatedModelRecord(providerId, upstreamModel)?.displayName;
+}
+
+// Whether this module documents the id as a free tier. Read alongside the
+// display name so an entry curated before the tag existed still shows the
+// badge: the price is a fact about the route, not about when it was curated.
+// Undefined rather than false for an undocumented id, so a stored flag stands.
+export function curatedModelIsFree(providerId, upstreamModel) {
+  return curatedModelRecord(providerId, upstreamModel)?.isFree;
 }
 
 // The picker text that carries the sourcing for every value this module knows

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -51,6 +51,9 @@ const OPENCODE_FREE_MODELS = Object.freeze({
     outputLimit: 131_072,
     reasoningLevels: Object.freeze(["minimal", "low", "medium", "high", "xhigh"]),
     requestProfile: "auto-tool-choice",
+    // Meta's Console upstream refuses a tool schema whose $refs cycle,
+    // losing the whole turn to a 400 that names no tool.
+    toolSchemaRecursion: "flatten",
     // The `-free` suffix is the tier, not the model. Carrying it in the label
     // put this route in a family of its own, apart from the paid routes to the
     // same model. `isFree` is where the price distinction belongs; the picker
@@ -73,6 +76,9 @@ const OPENCODE_FREE_MODELS = Object.freeze({
     outputLimit: 131_072,
     reasoningLevels: Object.freeze(["minimal", "low", "medium", "high", "xhigh"]),
     requestProfile: "auto-tool-choice",
+    // Meta's Console upstream refuses a tool schema whose $refs cycle,
+    // losing the whole turn to a 400 that names no tool.
+    toolSchemaRecursion: "flatten",
     displayName: "Muse Spark 1.3 Contributor (OpenCode Free)",
     isFree: true,
     summary:
@@ -423,6 +429,13 @@ export function curatedModelDisplayName(providerId, upstreamModel) {
 // Undefined rather than false for an undocumented id, so a stored flag stands.
 export function curatedModelIsFree(providerId, upstreamModel) {
   return curatedModelRecord(providerId, upstreamModel)?.isFree;
+}
+
+// Applied for the same reason the name and the free tag are: an entry curated
+// before this was documented carries none of them, and re-curating is not
+// something an installed machine should have to do to stop losing turns.
+export function curatedModelToolSchemaRecursion(providerId, upstreamModel) {
+  return curatedModelRecord(providerId, upstreamModel)?.toolSchemaRecursion;
 }
 
 // The picker text that carries the sourcing for every value this module knows

--- a/src/user-models.mjs
+++ b/src/user-models.mjs
@@ -69,6 +69,7 @@ const METADATA_FIELDS = new Set([
   "upgradeTo",
   "requiresTrailingUserTurn",
   "isFree",
+  "toolSchemaRecursion",
   "supportedEndpoints",
 ]);
 

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -1031,26 +1031,44 @@ test("the Responses variant resolves the same sourcing as its base provider", ()
   );
 });
 
+// The label names the route, not the tier. A "Free" in the name put this route
+// in a family of its own, away from the paid routes to the same model, because
+// the picker builds its grouping key from the display name.
 test("OpenCode Free Muse Spark routes publish stable picker labels", async () => {
-  const { curatedModelDisplayName } = await import("../src/opencode-curation.mjs");
+  const { curatedModelDisplayName, curatedModelIsFree } =
+    await import("../src/opencode-curation.mjs");
   const { officialModelDisplayName } = await import("../src/user-models.mjs");
-  for (const [providerId, upstreamId, label] of [
+  for (const [providerId, upstreamId, label, family] of [
     [
       "opencode-free",
       "muse-spark-1.2-contributor-free",
-      "Muse Spark 1.2 Contributor Free (OpenCode Free)",
+      "Muse Spark 1.2 Contributor (OpenCode Free)",
+      "Muse Spark 1.2 Contributor",
     ],
     [
       "opencode-free",
       "muse-spark-1.3-contributor-free",
-      "Muse Spark 1.3 Contributor Free (OpenCode Free)",
+      "Muse Spark 1.3 Contributor (OpenCode Free)",
+      "Muse Spark 1.3 Contributor",
     ],
   ]) {
     assert.equal(curatedModelDisplayName(providerId, upstreamId), label);
     assert.equal(officialModelDisplayName(providerId, upstreamId), label);
     assert.equal(curatedModelDisplayName("opencode-free-responses", upstreamId), label);
     assert.equal(officialModelDisplayName("opencode-free-responses", upstreamId), label);
+    // The grouping key the Control Center derives: strip the trailing provider
+    // qualifier and what is left must equal the paid routes' family name.
+    assert.equal(label.replace(/\s+\([^()]+\)\s*$/u, "").trim(), family);
+    assert.equal(curatedModelIsFree(providerId, upstreamId), true);
+    assert.equal(curatedModelIsFree("opencode-free-responses", upstreamId), true);
   }
+});
+
+// An id this module documents nothing about must not be tagged: `undefined`
+// leaves a stored flag standing, where `false` would erase one.
+test("curated free tagging is undefined for an undocumented id", async () => {
+  const { curatedModelIsFree } = await import("../src/opencode-curation.mjs");
+  assert.equal(curatedModelIsFree("opencode-free", "not-a-documented-id"), undefined);
 });
 
 test("scripted OpenCode Free curation stores the documented window and its sourcing", () => {

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -1311,6 +1311,55 @@ test("isFree is a boolean model tag", async () => {
   }
 });
 
+test("toolSchemaRecursion accepts only \"flatten\"", async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const nodePath = (await import("node:path")).default;
+  const { spawnSync } = await import("node:child_process");
+  const dir = mkdtempSync(nodePath.join(tmpdir(), "registry-schema-recursion-test-"));
+  const load = (toolSchemaRecursion) => {
+    const registry = readRegistryDocument("config");
+    registry.models = [
+      { ...registry.models[0], toolSchemaRecursion },
+      ...registry.models.slice(1),
+    ];
+    const registryPath = nodePath.join(dir, "providers.json");
+    writeFileSync(registryPath, JSON.stringify(registry));
+    return spawnSync(
+      process.execPath,
+      ["-e", "import('./src/model-registry.mjs').catch((e)=>{console.error(e.message);process.exit(1);})"],
+      { encoding: "utf8", env: { ...process.env, MODEL_ROUTER_REGISTRY: registryPath } },
+    );
+  };
+  try {
+    // The field names an executable behavior, so an unrecognized verb has to
+    // fail the load rather than be ignored into a silently unrepaired route.
+    assert.match(load("sometimes").stderr, /may only set toolSchemaRecursion to "flatten"/);
+    assert.match(load(true).stderr, /may only set toolSchemaRecursion to "flatten"/);
+    assert.equal(load("flatten").status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("every Muse Spark route on opencode flattens recursive tool schemas", () => {
+  // Meta's Console upstream refuses a $ref cycle on the free and the Go route
+  // alike -- both were measured returning the same 400 -- so a route added to
+  // one surface without the field would lose whole turns to a bare rejection.
+  const muse = MODELS.filter(
+    (model) =>
+      model.provider.startsWith("opencode") && /muse-spark/u.test(model.upstreamModel),
+  );
+  assert.ok(muse.length >= 2, "expected checked-in Muse Spark routes on opencode");
+  for (const model of muse) {
+    assert.equal(
+      model.toolSchemaRecursion,
+      "flatten",
+      `${model.slug} must flatten recursive tool schemas`,
+    );
+  }
+});
+
 test("Nous Research free models are tagged isFree, Hermes 4 is not", () => {
   // Six free portal routes via :free upstream ids should be tagged isFree: true
   const freeModels = [

--- a/test/user-models.test.mjs
+++ b/test/user-models.test.mjs
@@ -48,7 +48,7 @@ test("OpenCode Free Muse Spark curation uses the official picker label", () => {
     priority: 100,
     metadata: { isFree: true },
   });
-  assert.equal(entry.displayName, "Muse Spark 1.3 Contributor Free (OpenCode Free)");
+  assert.equal(entry.displayName, "Muse Spark 1.3 Contributor (OpenCode Free)");
 });
 
 test("curation metadata can set sizing and the effort ladder", () => {


### PR DESCRIPTION
Rebased onto main (03fe4d0).

Commits:
1. Group OpenCode Free Muse Spark routes with their paid family - curated label carried the upstream -free tier suffix, splitting the family grouping; carry price in isFree and apply the documented flag in normalizedModel so older curated entries pick it up.
2. fix: flatten recursive tool schemas for Muse Spark opencode routes - Meta Console upstream answers a self-referencing tool schema with a bare 400; add per-model toolSchemaRecursion=flatten that runs nonRecursiveToolSchema over outgoing tool params in api-forwarder, documented in opencode-curation, applied in normalizedModel, allowed through user-models metadata, validated in modelProblem, set on checked-in Go-responses configs.

Verification: registry (38), curate-models (50), user-models (11), target-integration (12), tool-schema-root (46) all pass; node --check clean on changed files and configs parse. Full suite left to CI.