### PR TITLE
fix: harden routed Responses egress — double-render on text+tool turns, and inline reasoning-tag leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Routed turns that mix assistant text and a tool call no longer render
+  twice.** LiteLLM's chat-completions-to-Responses bridge
+  (`use_chat_completions_api`) could leave the assistant `message` item open
+  across a `function_call` item and emit its `output_item.done` late, so Codex
+  committed the streamed text once while it was live and again when the delayed
+  close arrived — the same sentence appeared twice, with the tool call after it.
+  It surfaced intermittently on qwen-plan turns that both speak and call a tool.
+  A new `ItemLifecycleNormalizer` egress transform (`src/item-lifecycle-normalizer.mjs`),
+  added last in the routed-provider response pipeline, holds events for a
+  newly-opened output item until the currently-open item closes, restoring the
+  Responses contract that every item is `done` before the next
+  `output_item.added`. It reorders only — no event body is added, dropped, or
+  rewritten — and engages only when the upstream actually interleaves; clean
+  streams and native OpenAI streams pass through unchanged.
+
 - **A Grok OAuth outage now terminates streamed Codex turns instead of leaving
   a stale Working badge.** After the local gateway has exhausted its bounded
   retries, a final Grok 5xx on an explicitly streamed Responses request is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Routed reasoning models no longer leak `<think>` chains into the visible
+  answer.** Qwen (and other reasoning models bridged through LiteLLM's
+  chat-completions path) sometimes emit their chain-of-thought inline in the
+  content channel as `<think>...</think>` instead of on the reasoning channel,
+  so LiteLLM relays it as `output_text` and the answer renders behind the
+  model's reasoning — or behind a bare `</think>` when the open tag is consumed
+  upstream but the close is not. A new `ReasoningTagStripper` egress transform
+  (`src/reasoning-tag-stripper.mjs`) removes `<think>...</think>` spans and
+  orphan tags from the message text across the streamed `output_text.delta`s
+  (buffering a tag split across deltas), the terminal `output_text.done`, and
+  the stored message item. It covers the reasoning-delimiter family the model
+  varies to (`think`/`thinking`/`reason`/`reasoning`), leaves the structured
+  reasoning channel and every non-message item untouched, and passes clean
+  answers through unchanged. Routed providers only.
+
 - **Routed turns that mix assistant text and a tool call no longer render
   twice.** LiteLLM's chat-completions-to-Responses bridge
   (`use_chat_completions_api`) could leave the assistant `message` item open

--- a/src/item-lifecycle-normalizer.mjs
+++ b/src/item-lifecycle-normalizer.mjs
@@ -1,5 +1,4 @@
 import { Transform } from "node:stream";
-import { StringDecoder } from "node:string_decoder";
 
 // LiteLLM's chat-completions -> Responses bridge (use_chat_completions_api) can
 // emit output items with overlapping lifecycles when one Qwen turn carries both
@@ -18,6 +17,14 @@ import { StringDecoder } from "node:string_decoder";
 // closed in full before the next one begins. Blocks pass through byte-for-byte;
 // only their order changes, and only when the upstream actually interleaves.
 // Clean streams (each item added -> done before the next added) emit unchanged.
+// Invalid UTF-8 frames disable rewriting and relay the original bytes.
+const CRLF_SEP = Buffer.from("\r\n\r\n");
+const LF_SEP = Buffer.from("\n\n");
+
+function fatalUtf8(buffer) {
+  return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
+}
+
 function parseBlock(block) {
   // The SSE spec joins repeated `data:` fields with a line feed before dispatch;
   // overwriting them would truncate valid multiline JSON.
@@ -42,9 +49,19 @@ function parseBlock(block) {
 // output item, so any held item events are flushed ahead of them.
 const TERMINAL_TYPES = new Set(["response.completed", "response.done"]);
 
+function findFrameEnd(buffer) {
+  const crlf = buffer.indexOf(CRLF_SEP);
+  const lf = buffer.indexOf(LF_SEP);
+  if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+    return { index: crlf, separator: CRLF_SEP };
+  }
+  if (lf !== -1) return { index: lf, separator: LF_SEP };
+  return undefined;
+}
+
 export class ItemLifecycleNormalizer extends Transform {
-  #decoder = new StringDecoder("utf8");
-  #buffer = "";
+  #buffer = Buffer.alloc(0);
+  #passthrough = false;
   // Output index of the item currently open in the *emitted* stream (its
   // `output_item.added` was pushed but its `output_item.done` has not), or
   // undefined when no item is open.
@@ -53,14 +70,25 @@ export class ItemLifecycleNormalizer extends Transform {
   // still open. Each group collects the blocks for one output index.
   #queue = [];
 
-  _transform(chunk, _encoding, callback) {
-    this.#buffer += this.#decoder.write(chunk);
+  _transform(chunk, encoding, callback) {
+    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+    if (this.#passthrough) {
+      this.push(piece);
+      callback();
+      return;
+    }
+    this.#buffer = this.#buffer.length ? Buffer.concat([this.#buffer, piece]) : piece;
     this.#drainBuffer(false);
     callback();
   }
 
   _flush(callback) {
-    this.#buffer += this.#decoder.end();
+    if (this.#passthrough) {
+      if (this.#buffer.length) this.push(this.#buffer);
+      this.#buffer = Buffer.alloc(0);
+      callback();
+      return;
+    }
     this.#drainBuffer(true);
     // Anything still held (an upstream that ended without closing its open item)
     // is emitted rather than dropped.
@@ -68,69 +96,82 @@ export class ItemLifecycleNormalizer extends Transform {
     callback();
   }
 
+  #disable(original) {
+    this.#flushHeld();
+    if (original?.length) this.push(original);
+    if (this.#buffer.length) {
+      this.push(this.#buffer);
+      this.#buffer = Buffer.alloc(0);
+    }
+    this.#passthrough = true;
+  }
+
   #drainBuffer(flush) {
-    while (this.#buffer.length) {
-      const crlf = this.#buffer.indexOf("\r\n\r\n");
-      const lf = this.#buffer.indexOf("\n\n");
-      let index = -1;
-      let separator = "";
-      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
-        index = crlf;
-        separator = "\r\n\r\n";
-      } else if (lf !== -1) {
-        index = lf;
-        separator = "\n\n";
-      }
-      if (index === -1) {
+    while (this.#buffer.length && !this.#passthrough) {
+      const found = findFrameEnd(this.#buffer);
+      if (!found) {
         if (!flush) return;
-        const block = this.#buffer;
-        this.#buffer = "";
-        this.#handle(block, "");
+        const original = this.#buffer;
+        this.#buffer = Buffer.alloc(0);
+        this.#handleFrame(original, Buffer.alloc(0));
         return;
       }
-      const block = this.#buffer.slice(0, index);
-      this.#buffer = this.#buffer.slice(index + separator.length);
-      this.#handle(block, separator);
+      const block = this.#buffer.subarray(0, found.index);
+      const separator = found.separator;
+      const original = this.#buffer.subarray(0, found.index + separator.length);
+      this.#buffer = this.#buffer.subarray(found.index + separator.length);
+      this.#handleFrame(original, separator, block);
     }
   }
 
-  #emit(text, separator) {
-    this.push(Buffer.from(`${text}${separator}`));
+  #handleFrame(original, separator, block = original) {
+    let text;
+    try {
+      text = fatalUtf8(block);
+    } catch {
+      this.#disable(original);
+      return;
+    }
+    this.#handle(text, separator, original, parseBlock(text));
   }
 
-  #handle(text, separator, parsed = parseBlock(text)) {
+  #emitOriginal(original) {
+    this.push(Buffer.from(original));
+  }
+
+  #handle(text, separator, original, parsed = parseBlock(text)) {
     // Comments, heartbeats, and unparseable blocks are not item-scoped; relay
     // them in place.
     if (!parsed) {
-      this.#emit(text, separator);
+      this.#emitOriginal(original);
       return;
     }
     if (parsed.terminal) {
       this.#flushHeld();
-      this.#emit(text, separator);
+      this.#emitOriginal(original);
       return;
     }
     const event = parsed.event;
     const type = event?.type;
     if (TERMINAL_TYPES.has(type)) {
       this.#flushHeld();
-      this.#emit(text, separator);
+      this.#emitOriginal(original);
       return;
     }
     const idx = Number.isInteger(event?.output_index) ? event.output_index : undefined;
     // Stream-level events (`response.created`, `response.in_progress`, error
     // frames) carry no output index and are relayed in order.
     if (idx === undefined) {
-      this.#emit(text, separator);
+      this.#emitOriginal(original);
       return;
     }
     if (this.#openIndex === undefined) {
-      this.#emit(text, separator);
+      this.#emitOriginal(original);
       if (type === "response.output_item.added") this.#openIndex = idx;
       return;
     }
     if (idx === this.#openIndex) {
-      this.#emit(text, separator);
+      this.#emitOriginal(original);
       if (type === "response.output_item.done") {
         this.#openIndex = undefined;
         this.#drainHeld();
@@ -139,7 +180,7 @@ export class ItemLifecycleNormalizer extends Transform {
     }
     // An event for a different item while one is still open: hold it until the
     // open item closes, preserving arrival order within its own index.
-    this.#hold(idx, { text, separator, type, index: idx });
+    this.#hold(idx, { original, type, index: idx });
   }
 
   #hold(idx, block) {
@@ -159,7 +200,7 @@ export class ItemLifecycleNormalizer extends Transform {
     while (this.#openIndex === undefined && this.#queue.length) {
       const group = this.#queue.shift();
       for (const block of group.blocks) {
-        this.#emit(block.text, block.separator);
+        this.#emitOriginal(block.original);
         if (block.type === "response.output_item.added") this.#openIndex = block.index;
         else if (block.type === "response.output_item.done") this.#openIndex = undefined;
       }
@@ -171,7 +212,7 @@ export class ItemLifecycleNormalizer extends Transform {
   // terminal event and at end of stream so no item events are lost.
   #flushHeld() {
     for (const group of this.#queue) {
-      for (const block of group.blocks) this.#emit(block.text, block.separator);
+      for (const block of group.blocks) this.#emitOriginal(block.original);
     }
     this.#queue = [];
     this.#openIndex = undefined;

--- a/src/item-lifecycle-normalizer.mjs
+++ b/src/item-lifecycle-normalizer.mjs
@@ -1,0 +1,184 @@
+import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+// LiteLLM's chat-completions -> Responses bridge (use_chat_completions_api) can
+// emit output items with overlapping lifecycles when one Qwen turn carries both
+// assistant text and a tool call: the `message` item is opened and its text
+// streamed, then a `function_call` item is opened AND closed, and only then does
+// the message item's `output_item.done` arrive. The Responses contract requires
+// each output item to be `done` before the next `output_item.added`. Codex's TUI
+// finalizes the streamed message into a committed cell when the function_call
+// barges in, then commits it a second time when the delayed message
+// `output_item.done` lands at the end -- the same assistant sentence renders
+// twice, with the tool call after it.
+//
+// This transform restores sequential item lifecycles without rewriting any event
+// body: while an item is open, events for a *different* output index are held and
+// replayed once the open item closes, so every item is opened, streamed, and
+// closed in full before the next one begins. Blocks pass through byte-for-byte;
+// only their order changes, and only when the upstream actually interleaves.
+// Clean streams (each item added -> done before the next added) emit unchanged.
+function parseBlock(block) {
+  // The SSE spec joins repeated `data:` fields with a line feed before dispatch;
+  // overwriting them would truncate valid multiline JSON.
+  const dataLines = [];
+  for (const line of block.split(/\r?\n/)) {
+    if (line.startsWith("data:")) {
+      const value = line.slice(5);
+      dataLines.push(value.startsWith(" ") ? value.slice(1) : value);
+    }
+  }
+  if (!dataLines.length) return undefined;
+  const dataText = dataLines.join("\n");
+  if (dataText === "[DONE]") return { terminal: true };
+  try {
+    return { event: JSON.parse(dataText) };
+  } catch {
+    return undefined;
+  }
+}
+
+// `response.completed`/`response.done` close the turn and must follow every
+// output item, so any held item events are flushed ahead of them.
+const TERMINAL_TYPES = new Set(["response.completed", "response.done"]);
+
+export class ItemLifecycleNormalizer extends Transform {
+  #decoder = new StringDecoder("utf8");
+  #buffer = "";
+  // Output index of the item currently open in the *emitted* stream (its
+  // `output_item.added` was pushed but its `output_item.done` has not), or
+  // undefined when no item is open.
+  #openIndex;
+  // FIFO groups of blocks held for indices that opened while a different item was
+  // still open. Each group collects the blocks for one output index.
+  #queue = [];
+
+  _transform(chunk, _encoding, callback) {
+    this.#buffer += this.#decoder.write(chunk);
+    this.#drainBuffer(false);
+    callback();
+  }
+
+  _flush(callback) {
+    this.#buffer += this.#decoder.end();
+    this.#drainBuffer(true);
+    // Anything still held (an upstream that ended without closing its open item)
+    // is emitted rather than dropped.
+    this.#flushHeld();
+    callback();
+  }
+
+  #drainBuffer(flush) {
+    while (this.#buffer.length) {
+      const crlf = this.#buffer.indexOf("\r\n\r\n");
+      const lf = this.#buffer.indexOf("\n\n");
+      let index = -1;
+      let separator = "";
+      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+        index = crlf;
+        separator = "\r\n\r\n";
+      } else if (lf !== -1) {
+        index = lf;
+        separator = "\n\n";
+      }
+      if (index === -1) {
+        if (!flush) return;
+        const block = this.#buffer;
+        this.#buffer = "";
+        this.#handle(block, "");
+        return;
+      }
+      const block = this.#buffer.slice(0, index);
+      this.#buffer = this.#buffer.slice(index + separator.length);
+      this.#handle(block, separator);
+    }
+  }
+
+  #emit(text, separator) {
+    this.push(Buffer.from(`${text}${separator}`));
+  }
+
+  #handle(text, separator, parsed = parseBlock(text)) {
+    // Comments, heartbeats, and unparseable blocks are not item-scoped; relay
+    // them in place.
+    if (!parsed) {
+      this.#emit(text, separator);
+      return;
+    }
+    if (parsed.terminal) {
+      this.#flushHeld();
+      this.#emit(text, separator);
+      return;
+    }
+    const event = parsed.event;
+    const type = event?.type;
+    if (TERMINAL_TYPES.has(type)) {
+      this.#flushHeld();
+      this.#emit(text, separator);
+      return;
+    }
+    const idx = Number.isInteger(event?.output_index) ? event.output_index : undefined;
+    // Stream-level events (`response.created`, `response.in_progress`, error
+    // frames) carry no output index and are relayed in order.
+    if (idx === undefined) {
+      this.#emit(text, separator);
+      return;
+    }
+    if (this.#openIndex === undefined) {
+      this.#emit(text, separator);
+      if (type === "response.output_item.added") this.#openIndex = idx;
+      return;
+    }
+    if (idx === this.#openIndex) {
+      this.#emit(text, separator);
+      if (type === "response.output_item.done") {
+        this.#openIndex = undefined;
+        this.#drainHeld();
+      }
+      return;
+    }
+    // An event for a different item while one is still open: hold it until the
+    // open item closes, preserving arrival order within its own index.
+    this.#hold(idx, { text, separator, type, index: idx });
+  }
+
+  #hold(idx, block) {
+    let group = this.#queue.find((g) => g.index === idx);
+    if (!group) {
+      group = { index: idx, blocks: [] };
+      this.#queue.push(group);
+    }
+    group.blocks.push(block);
+  }
+
+  // Promote held groups now that no item is open. A group whose events include
+  // its own `output_item.done` closes and lets the next group promote; a group
+  // still mid-stream becomes the open item, and its remaining live events relay
+  // in place until it closes.
+  #drainHeld() {
+    while (this.#openIndex === undefined && this.#queue.length) {
+      const group = this.#queue.shift();
+      for (const block of group.blocks) {
+        this.#emit(block.text, block.separator);
+        if (block.type === "response.output_item.added") this.#openIndex = block.index;
+        else if (block.type === "response.output_item.done") this.#openIndex = undefined;
+      }
+      if (this.#openIndex !== undefined) return;
+    }
+  }
+
+  // Emit every held block in FIFO order, regardless of open state. Used before a
+  // terminal event and at end of stream so no item events are lost.
+  #flushHeld() {
+    for (const group of this.#queue) {
+      for (const block of group.blocks) this.#emit(block.text, block.separator);
+    }
+    this.#queue = [];
+    this.#openIndex = undefined;
+  }
+}
+
+export function itemLifecycleNormalizerTransform(contentType = "") {
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
+  return new ItemLifecycleNormalizer();
+}

--- a/src/reasoning-tag-stripper.mjs
+++ b/src/reasoning-tag-stripper.mjs
@@ -1,0 +1,268 @@
+import { Transform } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+// Qwen (and other reasoning models bridged through LiteLLM's chat-completions
+// -> Responses path) sometimes emit their chain-of-thought inline in the
+// content channel as `<think>...</think>` instead of on the structured
+// reasoning channel. LiteLLM relays that inline block as ordinary
+// `output_text`, so the visible answer is prefixed with the model's reasoning
+// and, when the opening tag is consumed upstream but the close is not, with a
+// bare `</think>`:
+//
+//   output_text = "<think>The capital of France is Paris.</think>\nParis"
+//   output_text = "\n</think>\n\nThe real answer starts here"
+//
+// The tags also split across streamed deltas (`"<th"` then `"ink>..."`), so a
+// naive per-delta replace misses them. This transform strips `<think>...</think>`
+// spans and orphan `<think>`/`</think>` tags from the message text -- across the
+// streamed `output_text.delta`s (buffering a possible partial tag), the
+// terminal `output_text.done`, and the message item in `output_item.done` (the
+// form that gets stored in the rollout). Reasoning that arrives on the proper
+// channel (`reasoning_summary_text`) is untouched; so is every non-message item.
+
+// Reasoning-delimiter names a model may leak inline. `<think>` is Qwen's and
+// DeepSeek's native form and the only one seen in real sessions, but the same
+// model varies the spelling (`<thinking>`, `<reason>`, `<reasoning>` observed
+// live), so the whole family is stripped. These names are reasoning scaffolding,
+// never prose a caller wants verbatim; the tradeoff is that a routed answer
+// which deliberately prints a literal `<reason>` tag would lose it.
+const TAG_NAMES = ["thinking", "reasoning", "think", "reason"]; // longest-first
+const OPEN_TAGS = TAG_NAMES.map((name) => `<${name}>`);
+const CLOSE_TAGS = TAG_NAMES.map((name) => `</${name}>`);
+const ALL_TAGS = [...OPEN_TAGS, ...CLOSE_TAGS];
+const MAX_TAG_LEN = Math.max(...ALL_TAGS.map((tag) => tag.length));
+const NAMES_ALT = TAG_NAMES.join("|");
+// Open-to-nearest-close, any name to any name (non-greedy) -- matches the
+// streaming machine, which closes on the first close tag it sees.
+const SPAN_RE = new RegExp(`<(?:${NAMES_ALT})>[\\s\\S]*?</(?:${NAMES_ALT})>`, "g");
+const ORPHAN_RE = new RegExp(`</?(?:${NAMES_ALT})>`, "g");
+
+function hasAnyTag(text) {
+  return TAG_NAMES.some((name) => text.includes(`<${name}>`) || text.includes(`</${name}>`));
+}
+
+// The earliest tag in `s`: its index, length, and whether it opens a span.
+function firstTag(s, tags) {
+  let at = -1;
+  let tag;
+  for (const candidate of tags) {
+    const i = s.indexOf(candidate);
+    if (i !== -1 && (at === -1 || i < at)) {
+      at = i;
+      tag = candidate;
+    }
+  }
+  return at === -1 ? undefined : { at, tag, opening: OPEN_TAGS.includes(tag) };
+}
+
+// Strip reasoning tags from a complete string. Used for `output_text.done` and
+// stored message content, where the whole text is in hand.
+export function stripThinkTags(text) {
+  if (typeof text !== "string" || !hasAnyTag(text)) return text;
+  let stripped = text.replace(SPAN_RE, "").replace(ORPHAN_RE, "");
+  // A stripped leading block leaves the whitespace that framed it; drop it so the
+  // answer does not render behind a blank line. Only when something was removed.
+  if (stripped !== text) stripped = stripped.replace(/^\s+/, "");
+  return stripped;
+}
+
+// Incremental stripper for the streamed delta channel. `feed` returns the text
+// safe to emit so far; `flush` returns whatever remains once the stream ends.
+// The concatenation of every `feed`/`flush` return equals `stripThinkTags` of
+// the concatenated input.
+class ThinkStreamStripper {
+  #mode = "normal";
+  #carry = "";
+  #emittedVisible = false;
+
+  // Longest suffix of `s` that is a proper prefix of any tag, so a tag split
+  // across deltas is held back rather than emitted as literal text.
+  #partialHold(s) {
+    const max = Math.min(s.length, MAX_TAG_LEN - 1);
+    for (let k = max; k >= 1; k--) {
+      const suffix = s.slice(s.length - k);
+      if (ALL_TAGS.some((tag) => tag.startsWith(suffix))) return k;
+    }
+    return 0;
+  }
+
+  feed(chunk) {
+    this.#carry += chunk;
+    let out = "";
+    for (;;) {
+      if (this.#mode === "normal") {
+        const found = firstTag(this.#carry, ALL_TAGS);
+        if (found) {
+          out += this.#carry.slice(0, found.at);
+          this.#carry = this.#carry.slice(found.at + found.tag.length);
+          // Opening a span enters think mode; an orphan close is just dropped.
+          if (found.opening) this.#mode = "think";
+          continue;
+        }
+        const hold = this.#partialHold(this.#carry);
+        out += this.#carry.slice(0, this.#carry.length - hold);
+        this.#carry = this.#carry.slice(this.#carry.length - hold);
+        break;
+      }
+      // think mode: discard until the first close tag, holding a possible partial.
+      const close = firstTag(this.#carry, CLOSE_TAGS);
+      if (close) {
+        this.#carry = this.#carry.slice(close.at + close.tag.length);
+        this.#mode = "normal";
+        continue;
+      }
+      const hold = this.#partialHold(this.#carry);
+      this.#carry = this.#carry.slice(this.#carry.length - hold);
+      break;
+    }
+    return this.#leadTrim(out);
+  }
+
+  flush() {
+    // Unterminated reasoning (still in think mode) is discarded; normal-mode
+    // remainder -- including a lone `<` that never became a tag -- is emitted.
+    const out = this.#mode === "normal" ? this.#carry : "";
+    this.#carry = "";
+    return this.#leadTrim(out);
+  }
+
+  // Trim leading whitespace only until the first visible character of the whole
+  // message, matching `stripThinkTags`'s single leading trim.
+  #leadTrim(out) {
+    if (this.#emittedVisible) return out;
+    const trimmed = out.replace(/^\s+/, "");
+    if (trimmed.length > 0) this.#emittedVisible = true;
+    return trimmed;
+  }
+}
+
+function eventBlock(block) {
+  const newline = block.includes("\r\n") ? "\r\n" : "\n";
+  const lines = block.split(/\r?\n/);
+  const dataLineIndex = lines.findIndex((line) => line.startsWith("data:"));
+  if (dataLineIndex === -1) return undefined;
+  const dataText = lines[dataLineIndex].slice(5).replace(/^ /, "");
+  if (!dataText || dataText === "[DONE]") return undefined;
+  try {
+    return { lines, dataLineIndex, newline, event: JSON.parse(dataText) };
+  } catch {
+    return undefined;
+  }
+}
+
+function rewrittenBlock(parsed, event) {
+  const lines = [...parsed.lines];
+  lines[parsed.dataLineIndex] = `data: ${JSON.stringify(event)}`;
+  return lines.join(parsed.newline);
+}
+
+function cleanMessageItem(item) {
+  if (item?.type !== "message" || !Array.isArray(item.content)) return item;
+  let changed = false;
+  const content = item.content.map((part) => {
+    if (part?.type === "output_text" && typeof part.text === "string") {
+      const cleaned = stripThinkTags(part.text);
+      if (cleaned !== part.text) {
+        changed = true;
+        return { ...part, text: cleaned };
+      }
+    }
+    return part;
+  });
+  return changed ? { ...item, content } : item;
+}
+
+export class ReasoningTagStripper extends Transform {
+  #decoder = new StringDecoder("utf8");
+  #buffer = "";
+  // One streaming stripper per message output index.
+  #streams = new Map();
+
+  _transform(chunk, _encoding, callback) {
+    this.#buffer += this.#decoder.write(chunk);
+    this.#emitBlocks(false);
+    callback();
+  }
+
+  _flush(callback) {
+    this.#buffer += this.#decoder.end();
+    this.#emitBlocks(true);
+    callback();
+  }
+
+  #streamFor(index) {
+    const key = Number.isInteger(index) ? index : 0;
+    let stream = this.#streams.get(key);
+    if (!stream) {
+      stream = new ThinkStreamStripper();
+      this.#streams.set(key, stream);
+    }
+    return stream;
+  }
+
+  #emitBlocks(flush) {
+    while (this.#buffer.length) {
+      const crlf = this.#buffer.indexOf("\r\n\r\n");
+      const lf = this.#buffer.indexOf("\n\n");
+      let index = -1;
+      let separator = "";
+      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+        index = crlf;
+        separator = "\r\n\r\n";
+      } else if (lf !== -1) {
+        index = lf;
+        separator = "\n\n";
+      }
+      if (index === -1) {
+        if (!flush) return;
+        const block = this.#buffer;
+        this.#buffer = "";
+        const piece = this.#rewrite(block);
+        if (piece !== null) this.push(Buffer.from(piece));
+        return;
+      }
+      const block = this.#buffer.slice(0, index);
+      this.#buffer = this.#buffer.slice(index + separator.length);
+      const piece = this.#rewrite(block);
+      if (piece !== null) this.push(Buffer.from(`${piece}${separator}`));
+    }
+  }
+
+  // Returns the (possibly rewritten) block text, or null to drop it (an
+  // `output_text.delta` whose entire payload was reasoning).
+  #rewrite(block) {
+    const parsed = eventBlock(block);
+    if (!parsed) return block;
+    const event = parsed.event;
+    const type = event?.type;
+
+    if (type === "response.output_text.delta" && typeof event.delta === "string") {
+      const cleaned = this.#streamFor(event.output_index).feed(event.delta);
+      if (cleaned === event.delta) return block;
+      if (cleaned.length === 0) return null;
+      return rewrittenBlock(parsed, { ...event, delta: cleaned });
+    }
+
+    if (type === "response.output_text.done" && typeof event.text === "string") {
+      // Settle the streaming state so a trailing partial tag is resolved, and
+      // rewrite the terminal full-text snapshot to the cleaned form.
+      this.#streamFor(event.output_index).flush();
+      const cleaned = stripThinkTags(event.text);
+      if (cleaned === event.text) return block;
+      return rewrittenBlock(parsed, { ...event, text: cleaned });
+    }
+
+    if (type === "response.output_item.done" && event?.item?.type === "message") {
+      const item = cleanMessageItem(event.item);
+      if (item === event.item) return block;
+      return rewrittenBlock(parsed, { ...event, item });
+    }
+
+    return block;
+  }
+}
+
+export function reasoningTagStripperTransform(contentType = "") {
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
+  return new ReasoningTagStripper();
+}

--- a/src/reasoning-tag-stripper.mjs
+++ b/src/reasoning-tag-stripper.mjs
@@ -1,5 +1,4 @@
 import { Transform } from "node:stream";
-import { StringDecoder } from "node:string_decoder";
 
 // Qwen (and other reasoning models bridged through LiteLLM's chat-completions
 // -> Responses path) sometimes emit their chain-of-thought inline in the
@@ -172,22 +171,59 @@ function cleanMessageItem(item) {
   return changed ? { ...item, content } : item;
 }
 
+const CRLF_SEP = Buffer.from("\r\n\r\n");
+const LF_SEP = Buffer.from("\n\n");
+
+function fatalUtf8(buffer) {
+  return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
+}
+
+function findFrameEnd(buffer) {
+  const crlf = buffer.indexOf(CRLF_SEP);
+  const lf = buffer.indexOf(LF_SEP);
+  if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+    return { index: crlf, separator: CRLF_SEP };
+  }
+  if (lf !== -1) return { index: lf, separator: LF_SEP };
+  return undefined;
+}
+
 export class ReasoningTagStripper extends Transform {
-  #decoder = new StringDecoder("utf8");
-  #buffer = "";
+  #buffer = Buffer.alloc(0);
+  #passthrough = false;
   // One streaming stripper per message output index.
   #streams = new Map();
 
-  _transform(chunk, _encoding, callback) {
-    this.#buffer += this.#decoder.write(chunk);
+  _transform(chunk, encoding, callback) {
+    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+    if (this.#passthrough) {
+      this.push(piece);
+      callback();
+      return;
+    }
+    this.#buffer = this.#buffer.length ? Buffer.concat([this.#buffer, piece]) : piece;
     this.#emitBlocks(false);
     callback();
   }
 
   _flush(callback) {
-    this.#buffer += this.#decoder.end();
+    if (this.#passthrough) {
+      if (this.#buffer.length) this.push(this.#buffer);
+      this.#buffer = Buffer.alloc(0);
+      callback();
+      return;
+    }
     this.#emitBlocks(true);
     callback();
+  }
+
+  #disable(original) {
+    if (original?.length) this.push(original);
+    if (this.#buffer.length) {
+      this.push(this.#buffer);
+      this.#buffer = Buffer.alloc(0);
+    }
+    this.#passthrough = true;
   }
 
   #streamFor(index) {
@@ -201,31 +237,38 @@ export class ReasoningTagStripper extends Transform {
   }
 
   #emitBlocks(flush) {
-    while (this.#buffer.length) {
-      const crlf = this.#buffer.indexOf("\r\n\r\n");
-      const lf = this.#buffer.indexOf("\n\n");
-      let index = -1;
-      let separator = "";
-      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
-        index = crlf;
-        separator = "\r\n\r\n";
-      } else if (lf !== -1) {
-        index = lf;
-        separator = "\n\n";
-      }
-      if (index === -1) {
+    while (this.#buffer.length && !this.#passthrough) {
+      const found = findFrameEnd(this.#buffer);
+      if (!found) {
         if (!flush) return;
-        const block = this.#buffer;
-        this.#buffer = "";
-        const piece = this.#rewrite(block);
-        if (piece !== null) this.push(Buffer.from(piece));
+        const original = this.#buffer;
+        this.#buffer = Buffer.alloc(0);
+        this.#emitFrame(original, Buffer.alloc(0));
         return;
       }
-      const block = this.#buffer.slice(0, index);
-      this.#buffer = this.#buffer.slice(index + separator.length);
-      const piece = this.#rewrite(block);
-      if (piece !== null) this.push(Buffer.from(`${piece}${separator}`));
+      const block = this.#buffer.subarray(0, found.index);
+      const separator = found.separator;
+      const original = this.#buffer.subarray(0, found.index + separator.length);
+      this.#buffer = this.#buffer.subarray(found.index + separator.length);
+      this.#emitFrame(original, separator, block);
     }
+  }
+
+  #emitFrame(original, separator, block = original) {
+    let text;
+    try {
+      text = fatalUtf8(block);
+    } catch {
+      this.#disable(original);
+      return;
+    }
+    const piece = this.#rewrite(text);
+    if (piece === null) return;
+    if (piece === text) {
+      this.push(Buffer.from(original));
+      return;
+    }
+    this.push(Buffer.concat([Buffer.from(piece), separator]));
   }
 
   // Returns the (possibly rewritten) block text, or null to drop it (an

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -56,6 +56,7 @@ import {
   EmptyCompletionTerminalGuard,
   isEmptyCompletionPreludeLimitError,
 } from "./empty-completion-guard.mjs";
+import { itemLifecycleNormalizerTransform } from "./item-lifecycle-normalizer.mjs";
 import {
   ZaiResponsesCompatTransform,
   zaiResponsesCompatTransform,
@@ -4048,6 +4049,16 @@ async function handleResponses(request, response, requestUrl) {
           }),
         );
       }
+      // Restore sequential output-item lifecycles for routed providers, whose
+      // chat-completions -> Responses bridge can leave an assistant `message`
+      // item open across a `function_call` item and close it late, making Codex
+      // render the same turn's text twice. Runs last so it normalizes the final
+      // egress stream after every other rewrite/injection. Native OpenAI streams
+      // (no route) are already well-formed and left untouched.
+      const itemNormalizer = route
+        ? itemLifecycleNormalizerTransform(contentType)
+        : undefined;
+      if (itemNormalizer) transforms.push(itemNormalizer);
       return { transforms, usageObserver, guard };
     };
     const firstPipeline = createResponsePipeline(upstreamContentType);

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -57,6 +57,7 @@ import {
   isEmptyCompletionPreludeLimitError,
 } from "./empty-completion-guard.mjs";
 import { itemLifecycleNormalizerTransform } from "./item-lifecycle-normalizer.mjs";
+import { reasoningTagStripperTransform } from "./reasoning-tag-stripper.mjs";
 import {
   ZaiResponsesCompatTransform,
   zaiResponsesCompatTransform,
@@ -4049,6 +4050,14 @@ async function handleResponses(request, response, requestUrl) {
           }),
         );
       }
+      // Strip inline `<think>...</think>` reasoning that routed providers leak
+      // into the visible answer, when their chat-completions -> Responses bridge
+      // relays the model's chain-of-thought as `output_text` instead of on the
+      // reasoning channel. Runs before the lifecycle normalizer so the reorder
+      // sees already-cleaned message text. Native OpenAI streams (no route) never
+      // carry these tags and are left untouched.
+      const tagStripper = route ? reasoningTagStripperTransform(contentType) : undefined;
+      if (tagStripper) transforms.push(tagStripper);
       // Restore sequential output-item lifecycles for routed providers, whose
       // chat-completions -> Responses bridge can leave an assistant `message`
       // item open across a `function_call` item and close it late, making Codex

--- a/test/item-lifecycle-normalizer.test.mjs
+++ b/test/item-lifecycle-normalizer.test.mjs
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import test from "node:test";
+
+import { ItemLifecycleNormalizer } from "../src/item-lifecycle-normalizer.mjs";
+
+// Build an SSE block for a Responses event. `sep` lets a test exercise both LF
+// and CRLF framing without changing the events.
+function block(event, sep = "\n\n") {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}${sep}`;
+}
+
+async function normalize(input, { chunkSize = 0 } = {}) {
+  const norm = new ItemLifecycleNormalizer();
+  const chunks = [];
+  const collector = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.from(chunk));
+      callback();
+    },
+  });
+  const source = [];
+  if (chunkSize > 0) {
+    const buf = Buffer.from(input);
+    for (let at = 0; at < buf.length; at += chunkSize) {
+      source.push(buf.subarray(at, at + chunkSize));
+    }
+  } else {
+    source.push(Buffer.from(input));
+  }
+  await pipeline(Readable.from(source), norm, collector);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+// The ordered list of item lifecycle boundaries, for asserting sequence.
+function itemBoundaries(body) {
+  const out = [];
+  for (const chunk of body.split(/\r?\n\r?\n/)) {
+    const dataLines = chunk
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim());
+    if (!dataLines.length) continue;
+    const dataText = dataLines.join("\n");
+    if (dataText === "[DONE]") continue;
+    let event;
+    try {
+      event = JSON.parse(dataText);
+    } catch {
+      continue;
+    }
+    if (
+      event.type === "response.output_item.added" ||
+      event.type === "response.output_item.done"
+    ) {
+      out.push(`${event.output_index}:${event.type.split(".").pop()}`);
+    }
+  }
+  return out;
+}
+
+// The sorted multiset of data payloads, to prove events are only reordered --
+// never added, dropped, or mutated.
+function payloadMultiset(body) {
+  return body
+    .split(/\r?\n\r?\n/)
+    .map((chunk) =>
+      chunk
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5))
+        .join("\n"),
+    )
+    .filter(Boolean)
+    .sort();
+}
+
+// The failure JD reported: a `message` item stays open while a `function_call`
+// item opens and closes, then the message closes late. This is the exact shape
+// captured live from the router's Qwen path via LiteLLM.
+const INTERLEAVED = [
+  block({ type: "response.created", response: { id: "r1" } }),
+  block({ type: "response.in_progress", response: { id: "r1" } }),
+  block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { id: "m1", type: "message", role: "assistant", content: [] },
+  }),
+  block({
+    type: "response.content_part.added",
+    output_index: 0,
+    item_id: "m1",
+    part: { type: "output_text", text: "" },
+  }),
+  block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "I'll check." }),
+  block({
+    type: "response.output_item.added",
+    output_index: 1,
+    item: { id: "f1", type: "function_call", name: "get_weather", arguments: "" },
+  }),
+  block({ type: "response.function_call_arguments.delta", output_index: 1, item_id: "f1", delta: "{\"city\"" }),
+  block({ type: "response.function_call_arguments.done", output_index: 1, item_id: "f1", arguments: "{\"city\":\"Tokyo\"}" }),
+  block({
+    type: "response.output_item.done",
+    output_index: 1,
+    item: { id: "f1", type: "function_call", name: "get_weather", arguments: "{\"city\":\"Tokyo\"}" },
+  }),
+  block({ type: "response.output_text.done", output_index: 0, item_id: "m1", text: "I'll check." }),
+  block({ type: "response.content_part.done", output_index: 0, item_id: "m1", part: { type: "output_text", text: "I'll check." } }),
+  block({
+    type: "response.output_item.done",
+    output_index: 0,
+    item: {
+      id: "m1",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "I'll check." }],
+    },
+  }),
+  block({ type: "response.completed", response: { id: "r1", output: [] } }),
+  "data: [DONE]\n\n",
+].join("");
+
+test("reorders an interleaved message/function_call turn into sequential items", async () => {
+  const before = itemBoundaries(INTERLEAVED);
+  assert.deepEqual(before, ["0:added", "1:added", "1:done", "0:done"]);
+
+  const out = await normalize(INTERLEAVED);
+  assert.deepEqual(itemBoundaries(out), ["0:added", "0:done", "1:added", "1:done"]);
+});
+
+test("reorders identically regardless of upstream chunk boundaries", async () => {
+  for (const chunkSize of [1, 7, 40, 200]) {
+    const out = await normalize(INTERLEAVED, { chunkSize });
+    assert.deepEqual(
+      itemBoundaries(out),
+      ["0:added", "0:done", "1:added", "1:done"],
+      `chunkSize=${chunkSize}`,
+    );
+  }
+});
+
+test("only reorders -- never adds, drops, or mutates an event", async () => {
+  const out = await normalize(INTERLEAVED);
+  assert.deepEqual(payloadMultiset(out), payloadMultiset(INTERLEAVED));
+});
+
+test("the function_call is fully emitted before response.completed", async () => {
+  const out = await normalize(INTERLEAVED);
+  const idxFn = out.indexOf('"id":"f1","type":"function_call"');
+  const idxDone = out.indexOf('"type":"response.completed"');
+  assert.ok(idxFn !== -1 && idxDone !== -1);
+  assert.ok(idxFn < idxDone, "function_call item must precede response.completed");
+});
+
+test("a clean sequential stream passes through byte-for-byte", async () => {
+  const clean = [
+    block({ type: "response.created", response: { id: "r1" } }),
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { id: "m1", type: "message", role: "assistant", content: [] },
+    }),
+    block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "hi" }),
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { id: "m1", type: "message", role: "assistant", content: [{ type: "output_text", text: "hi" }] },
+    }),
+    block({
+      type: "response.output_item.added",
+      output_index: 1,
+      item: { id: "f1", type: "function_call", name: "t", arguments: "{}" },
+    }),
+    block({
+      type: "response.output_item.done",
+      output_index: 1,
+      item: { id: "f1", type: "function_call", name: "t", arguments: "{}" },
+    }),
+    block({ type: "response.completed", response: { id: "r1", output: [] } }),
+    "data: [DONE]\n\n",
+  ].join("");
+  assert.equal(await normalize(clean), clean);
+  assert.equal(await normalize(clean, { chunkSize: 13 }), clean);
+});
+
+test("a tool-only turn (single item) passes through unchanged", async () => {
+  const toolOnly = [
+    block({ type: "response.created", response: { id: "r1" } }),
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { id: "f1", type: "function_call", name: "t", arguments: "" },
+    }),
+    block({ type: "response.function_call_arguments.done", output_index: 0, item_id: "f1", arguments: "{}" }),
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { id: "f1", type: "function_call", name: "t", arguments: "{}" },
+    }),
+    block({ type: "response.completed", response: { id: "r1", output: [] } }),
+    "data: [DONE]\n\n",
+  ].join("");
+  assert.equal(await normalize(toolOnly), toolOnly);
+});
+
+test("preserves CRLF framing while reordering", async () => {
+  const crlf = [
+    block(
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: { id: "m1", type: "message", role: "assistant", content: [] },
+      },
+      "\r\n\r\n",
+    ),
+    block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "x" }, "\r\n\r\n"),
+    block(
+      {
+        type: "response.output_item.added",
+        output_index: 1,
+        item: { id: "f1", type: "function_call", name: "t", arguments: "{}" },
+      },
+      "\r\n\r\n",
+    ),
+    block(
+      {
+        type: "response.output_item.done",
+        output_index: 1,
+        item: { id: "f1", type: "function_call", name: "t", arguments: "{}" },
+      },
+      "\r\n\r\n",
+    ),
+    block(
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: { id: "m1", type: "message", role: "assistant", content: [{ type: "output_text", text: "x" }] },
+      },
+      "\r\n\r\n",
+    ),
+  ].join("");
+  const out = await normalize(crlf);
+  assert.deepEqual(itemBoundaries(out), ["0:added", "0:done", "1:added", "1:done"]);
+  assert.ok(out.includes("\r\n\r\n"), "CRLF separators must be preserved");
+  assert.ok(!out.includes("\n\n\n"), "must not corrupt separators");
+});

--- a/test/reasoning-tag-stripper.test.mjs
+++ b/test/reasoning-tag-stripper.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import test from "node:test";
+
+import {
+  ReasoningTagStripper,
+  reasoningTagStripperTransform,
+  stripThinkTags,
+} from "../src/reasoning-tag-stripper.mjs";
+
+function block(event, sep = "\n\n") {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}${sep}`;
+}
+
+async function run(input, { chunkSize = 0 } = {}) {
+  const t = new ReasoningTagStripper();
+  const chunks = [];
+  const sink = new Writable({
+    write(chunk, _e, cb) {
+      chunks.push(Buffer.from(chunk));
+      cb();
+    },
+  });
+  const source = [];
+  if (chunkSize > 0) {
+    const buf = Buffer.from(input);
+    for (let at = 0; at < buf.length; at += chunkSize) source.push(buf.subarray(at, at + chunkSize));
+  } else {
+    source.push(Buffer.from(input));
+  }
+  await pipeline(Readable.from(source), t, sink);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function collect(body) {
+  let deltas = "";
+  const done = [];
+  const messages = [];
+  for (const chunk of body.split(/\r?\n\r?\n/)) {
+    const dl = chunk.split(/\r?\n/).find((l) => l.startsWith("data:"));
+    if (!dl) continue;
+    let e;
+    try {
+      e = JSON.parse(dl.slice(5).trim());
+    } catch {
+      continue;
+    }
+    if (e.type === "response.output_text.delta") deltas += e.delta;
+    if (e.type === "response.output_text.done") done.push(e.text);
+    if (e.type === "response.output_item.done" && e.item?.type === "message") {
+      messages.push((e.item.content || []).map((c) => c.text || "").join(""));
+    }
+  }
+  return { deltas, done, messages };
+}
+
+test("stripThinkTags handles the real leak shapes", () => {
+  assert.equal(stripThinkTags("<think>The capital of France is Paris.</think>\nParis"), "Paris");
+  assert.equal(stripThinkTags("\n</think>\n\nThe real answer."), "The real answer.");
+  assert.equal(stripThinkTags("\n</think>\n\n"), "");
+  assert.equal(stripThinkTags("A<think>hidden</think>B"), "AB");
+  assert.equal(stripThinkTags("Paris"), "Paris"); // no tags -> unchanged (identity)
+  assert.equal(stripThinkTags("less < than, not a tag"), "less < than, not a tag");
+});
+
+test("stripThinkTags covers the reasoning-delimiter family the model varies to", () => {
+  // Captured live from qwen3.8-flash when nudged: it varies the tag name.
+  assert.equal(stripThinkTags("<thinking>The capital of France is Paris.</thinking>\nParis"), "Paris");
+  assert.equal(stripThinkTags("<reason>The capital of France is Paris.</reason>\nParis"), "Paris");
+  assert.equal(stripThinkTags("<reasoning>x</reasoning>\nAnswer"), "Answer");
+  assert.equal(stripThinkTags("\n</thinking>\n\nOrphan close variant."), "Orphan close variant.");
+  // `<think>` must not be mis-detected inside `<thinking>`.
+  assert.equal(stripThinkTags("<thinking>a</thinking>B"), "B");
+});
+
+// The tag opening is split across deltas exactly as captured from the router
+// ("<th" then "ink>..."), which a naive per-delta replace would miss.
+const SPLIT_DELTAS = ["<th", "ink>The capital of", " France is", " Paris.</think>", "\nParis"];
+const FULL = SPLIT_DELTAS.join("");
+
+function streamCase(deltas) {
+  return (
+    deltas.map((d) => block({ type: "response.output_text.delta", output_index: 0, delta: d })).join("") +
+    block({ type: "response.output_text.done", output_index: 0, text: deltas.join("") }) +
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { id: "m1", type: "message", role: "assistant", content: [{ type: "output_text", text: deltas.join("") }] },
+    })
+  );
+}
+
+test("strips a think span split across deltas; delta concat == done == message == full strip", async () => {
+  const out = await run(streamCase(SPLIT_DELTAS));
+  const { deltas, done, messages } = collect(out);
+  const expected = stripThinkTags(FULL);
+  assert.equal(expected, "Paris");
+  assert.equal(deltas, expected);
+  assert.deepEqual(done, [expected]);
+  assert.deepEqual(messages, [expected]);
+});
+
+test("convergence holds across every chunk boundary", async () => {
+  for (const chunkSize of [1, 2, 3, 5, 11, 50]) {
+    const out = await run(streamCase(SPLIT_DELTAS), { chunkSize });
+    const { deltas } = collect(out);
+    assert.equal(deltas, "Paris", `chunkSize=${chunkSize}`);
+  }
+});
+
+test("streams a split <thinking> variant identically to a full strip", async () => {
+  const deltas = ["<thi", "nking>The capital", " is Paris.</thin", "king>", "\nParis"];
+  const expected = stripThinkTags(deltas.join(""));
+  assert.equal(expected, "Paris");
+  for (const chunkSize of [0, 1, 4, 13]) {
+    const { deltas: d } = collect(await run(streamCase(deltas), { chunkSize }));
+    assert.equal(d, expected, `chunkSize=${chunkSize}`);
+  }
+});
+
+test("strips an orphan leading </think> from the streamed answer", async () => {
+  const deltas = ["\n</think>\n\n", "The real ", "answer."];
+  const out = await run(streamCase(deltas));
+  const { deltas: d, done, messages } = collect(out);
+  assert.equal(d, "The real answer.");
+  assert.deepEqual(done, ["The real answer."]);
+  assert.deepEqual(messages, ["The real answer."]);
+});
+
+test("a clean answer with no tags passes through byte-for-byte", async () => {
+  const clean = streamCase(["Paris", " is the ", "capital."]);
+  assert.equal(await run(clean), clean);
+  assert.equal(await run(clean, { chunkSize: 9 }), clean);
+});
+
+test("does not touch reasoning_summary or function_call items", async () => {
+  const input =
+    block({ type: "response.reasoning_summary_text.delta", output_index: 0, delta: "<think>internal</think>" }) +
+    block({ type: "response.output_item.done", output_index: 1, item: { id: "f1", type: "function_call", name: "t", arguments: "{}" } });
+  assert.equal(await run(input), input);
+});
+
+test("keeps per-index state so two message items strip independently", async () => {
+  const input =
+    block({ type: "response.output_text.delta", output_index: 0, delta: "<think>a</think>Zero" }) +
+    block({ type: "response.output_text.delta", output_index: 2, delta: "<think>b</think>Two" }) +
+    block({ type: "response.output_text.done", output_index: 0, text: "<think>a</think>Zero" }) +
+    block({ type: "response.output_text.done", output_index: 2, text: "<think>b</think>Two" });
+  const out = await run(input);
+  const { deltas } = collect(out);
+  assert.equal(deltas, "ZeroTwo");
+});
+
+test("factory gates on event-stream content type", () => {
+  assert.ok(reasoningTagStripperTransform("text/event-stream") instanceof ReasoningTagStripper);
+  assert.equal(reasoningTagStripperTransform("application/json"), undefined);
+});


### PR DESCRIPTION
Two independent streaming artifacts that both originate in LiteLLM's chat-completions → Responses bridge (`use_chat_completions_api`) for routed providers, each fixed by a small egress SSE transform. Both are scoped to routed providers (`route` set) and leave native OpenAI Responses streams untouched. Two atomic commits.

---

## 1. Text+tool-call turns render twice (`ItemLifecycleNormalizer`)

**Symptom:** on a routed turn that contains **both assistant text and a tool call**, the assistant's sentence renders **twice** in the Codex TUI, with the tool call after it. Intermittent — only the text+tool-call shape triggers it.

**Root cause:** the bridge emits output items with overlapping lifecycles. Captured live from `qwen-plan/qwen3.8-flash`:

| wire order | event | output_index |
|---|---|---|
| 1 | `output_item.added` (message) | **0** |
| 2 | `output_text.delta` ×N | 0 |
| 3 | `output_item.added` (function_call) | **1** ← opens while item 0 still open |
| 4 | `function_call_arguments.*` + `output_item.done` | 1 |
| 5 | `output_text.done` | 0 |
| 6 | `output_item.done` (message) | **0** ← closes *after* item 1 |

The Responses contract requires each item to be `done` before the next `output_item.added`. Codex finalizes item 0's streamed text into a committed cell when item 1 barges in, then commits it **again** when item 0's delayed `output_item.done` lands — the same sentence twice.

**Fix:** `src/item-lifecycle-normalizer.mjs`, added last in the routed pipeline. While an item is open it holds events for a different index and replays them once the open item closes:

```
before:  0:added → 1:added → 1:done → 0:done      (contract violation)
after:   0:added → 0:done → 1:added → 1:done       (sequential)
```

Reorder-only — identical multiset of event payloads before/after; nothing synthesized or mutated. No-op on clean and native streams (verified byte-for-byte). Preserves LF/CRLF framing; correct across arbitrary chunk boundaries.

---

## 2. Inline `<think>` reasoning leaks into the answer (`ReasoningTagStripper`)

**Symptom:** the visible answer is prefixed with the model's chain-of-thought, or with a bare `</think>`:

```
output_text = "<think>The capital of France is Paris.</think>\nParis"
output_text = "\n</think>\n\nThe real answer starts here"
```

**Root cause:** reasoning models sometimes emit `<think>...</think>` inline in the content channel instead of on the reasoning channel; LiteLLM relays it as `output_text`. The tags also split across streamed deltas (`"<th"` then `"ink>..."`), so a per-delta replace misses them.

**Fix:** `src/reasoning-tag-stripper.mjs`, run before the lifecycle normalizer. Removes `<think>...</think>` spans and orphan tags across the streamed `output_text.delta`s (buffering a tag split across deltas), the terminal `output_text.done`, and the stored message item. Covers the reasoning-delimiter family the model varies to (`think`/`thinking`/`reason`/`reasoning` — all observed live). The structured reasoning channel and every non-message item are untouched; clean answers pass through unchanged. Tradeoff: a routed answer that deliberately prints a literal reasoning tag would lose it.

---

## Testing

- `test/item-lifecycle-normalizer.test.mjs` and `test/reasoning-tag-stripper.test.mjs` (new): interleave reorder, tag-strip across split deltas with delta/done/message convergence, chunk-boundary invariance, orphan-close stripping, the tag-name family, per-index independence, CRLF framing, and byte-faithful passthrough of clean/tool-only streams.
- `npm run check` passes; streaming-transform suites pass.
- Verified live end-to-end against a local router: after the change, a `qwen3.8-flash` tool-call turn emits sequential items, and reasoning-tag leaks (including varied tag names) are gone across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
