### PR TITLE
fix(grok-oauth): terminate streamed gateway failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **A Grok OAuth outage now terminates streamed Codex turns instead of leaving
+  a stale Working badge.** After the local gateway has exhausted its bounded
+  retries, a final Grok 5xx on an explicitly streamed Responses request is
+  returned as one terminal SSE `error` event. Non-streaming Grok calls,
+  actionable 4xx failures, and every other provider retain their HTTP status
+  and JSON body, while usage metering still records Grok's real failure status.
+
 - **Empty `tools: []` is now stripped for all API-forwarder routes, not only
   `qwen38-community`.** Strict upstreams (vLLM >=0.20 Pydantic) refuse an empty
   tools array. Codex sends `tools: []` on compaction and plain chat, so without

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1174,6 +1174,32 @@ function writeEmptyCompletionError(response, code, message) {
   });
 }
 
+// Codex treats a streamed Responses `error` event as terminal, but can keep a
+// Grok OAuth turn open while its HTTP client retries a bare gateway 5xx. The
+// local Grok gateway has already exhausted its bounded retries by the time this
+// branch runs, so a second retry loop in the client only turns a stated outage
+// into a stale Working badge. Preserve every other provider's existing HTTP
+// contract, plus ordinary JSON errors for non-streaming Grok calls and its
+// actionable 4xx responses; only the observed terminal Grok shape crosses the
+// Responses SSE boundary this way.
+function writeTranslatedGatewayError(
+  response,
+  status,
+  payload,
+  { provider, stream = false } = {},
+) {
+  if (provider === "grok-oauth" && stream && status >= 500) {
+    writeEventStreamHead(response);
+    writeStreamErrorEvent(response, {
+      code: payload?.error?.type || "server_error",
+      message: payload?.error?.message || "The routed provider could not complete the request.",
+    });
+    response.end();
+    return;
+  }
+  writeJson(response, status, payload);
+}
+
 function timingMetric(value) {
   return Number.isFinite(value) ? String(value) : "unknown";
 }
@@ -3911,24 +3937,24 @@ async function handleResponses(request, response, requestUrl) {
         bodyText: failedBodyText,
       });
       if (retryAfterHeader) response.setHeader("Retry-After", retryAfterHeader);
-      writeJson(
-        response,
-        translatedStatus,
-        translateGatewayError({
-          status: upstream.status,
-          // Already drained above so the failover classifier could read it; a
-          // second `.text()` on the same response yields "".
-          bodyText: failedBodyText ?? "",
-          modelName: route.displayName || route.slug,
-          providerName:
-            provider?.transport === "ollama"
-              ? "Ollama"
-              : provider?.ownedBy || provider?.displayName || route.provider,
-          providerKind: provider?.kind,
-          providerAuthMode: provider?.authMode,
-          retryAfterSeconds: retrySeconds,
-        }),
-      );
+      const translatedError = translateGatewayError({
+        status: upstream.status,
+        // Already drained above so the failover classifier could read it; a
+        // second `.text()` on the same response yields "".
+        bodyText: failedBodyText ?? "",
+        modelName: route.displayName || route.slug,
+        providerName:
+          provider?.transport === "ollama"
+            ? "Ollama"
+            : provider?.ownedBy || provider?.displayName || route.provider,
+        providerKind: provider?.kind,
+        providerAuthMode: provider?.authMode,
+        retryAfterSeconds: retrySeconds,
+      });
+      writeTranslatedGatewayError(response, translatedStatus, translatedError, {
+        provider: route.provider,
+        stream: payload.stream === true,
+      });
       recordUsageEvent({
         model: route.slug,
         provider: canonicalProviderId(route.provider),

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -795,6 +795,75 @@ test("router rewrites gateway errors to name the failing provider", async () => 
   }
 });
 
+test("a routed Grok 502 terminates a streamed turn with one SSE error", async () => {
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    json(response, 502, {
+      error: {
+        message:
+          "litellm.BadGatewayError: BadGatewayError: OpenAIException - The Grok OAuth forwarder could not complete the request. Received Model Group=grok-oauth-grok-4-6\nAvailable Model Group Fallbacks=None LiteLLM Retried: 2 times, LiteLLM Max Retries: 2",
+        type: null,
+        param: null,
+        code: "502",
+      },
+    });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const jsonResponse = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "grok-oauth/grok-4.6",
+        input: "ordinary non-streaming request",
+        stream: false,
+      }),
+    });
+    assert.equal(jsonResponse.status, 502);
+    assert.equal((await jsonResponse.json()).error.type, "server_error");
+
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "grok-oauth/grok-4.6",
+        input: "continue after the tool result",
+        stream: true,
+      }),
+    });
+    const body = await response.text();
+    assert.equal(response.status, 200, body);
+    assert.match(response.headers.get("content-type"), /text\/event-stream/);
+    assert.equal((body.match(/event: error/g) || []).length, 1);
+    const eventData = body.split(/\r?\n/).find((line) => line.startsWith("data: {"));
+    assert.ok(eventData, body);
+    const event = JSON.parse(eventData.slice(5).trim());
+    assert.equal(event.type, "error");
+    assert.equal(event.code, "server_error");
+    assert.match(event.message, /Grok 4\.6 \(OAuth\).*unavailable/);
+    assert.match(event.message, /HTTP 502/);
+    assert.doesNotMatch(event.message, /litellm/i);
+    assert.doesNotMatch(body, /response\.completed/);
+    assert.doesNotMatch(body, /data: \[DONE\]/);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 test("router dispatches aliased native slugs to the mapped external model", async () => {
   const gatewayRequests = [];
   const gateway = await mockServer(async (request, response) => {


### PR DESCRIPTION
## Why

When the Grok OAuth forwarder exhausts its bounded retries before a stream
starts, it can return a bare HTTP 5xx to Codex. Codex may then enter its own HTTP
retry loop and leave the turn looking active instead of receiving a terminal
Responses event.

The observed failure involved consecutive gateway 502 responses after long
upstream connection attempts. The router itself remained healthy, so the stale
turn was caused by the final error contract rather than a router crash.

## What changed

For an explicitly streamed Responses request routed to `grok-oauth`, a final
translated 5xx is now returned as HTTP 200 SSE with exactly one terminal
`error` event. The event uses the router's sanitized provider-specific message,
so LiteLLM internals are not exposed.

| Request path | Final error contract |
| --- | --- |
| Grok OAuth, `stream: true`, translated 5xx | HTTP 200 SSE with one terminal `error` event |
| Grok OAuth, non-streaming | Existing translated HTTP status and JSON body |
| Grok OAuth, actionable 4xx | Existing translated HTTP status and JSON body |
| Every other provider | Unchanged |

The router and gateway retry counts are unchanged. Usage and activity telemetry
still record the real upstream 5xx status.

## Tests

- `npm test` — 3,589 tests; 3,563 passed, 0 failed, 26 skipped
- Focused routing and failover compatibility tests — 6/6 passed
- `npm run check`
- `npm audit --omit=dev` — 0 vulnerabilities
- Autoreview and secret scan — clean; no actionable P0/P1 findings

