### PR TITLE
fix: keep Control Center in Dock after close

### DIFF
--- a/apps/control-center/electron/lifecycle-state.mjs
+++ b/apps/control-center/electron/lifecycle-state.mjs
@@ -206,8 +206,9 @@ export function shouldQuitOnLastWindowClosed({
   nativeTrayOwnedByHost,
   trayAvailable = true,
 }) {
-  // The embedded macOS child delegates its lifetime to the outer native host.
-  if (platform === "darwin" && nativeTrayOwnedByHost === true) return true;
+  // The embedded macOS child stays alive after the window hides so Dock and
+  // Command-Tab can return to it. The outer Swift host owns process exit.
+  if (platform === "darwin" && nativeTrayOwnedByHost === true) return false;
   // On Windows/Linux a usable Electron tray is what makes a windowless
   // lifetime recoverable. If construction failed (or it was later destroyed),
   // closing the fallback window must not strand an invisible process.

--- a/apps/control-center/electron/main.mjs
+++ b/apps/control-center/electron/main.mjs
@@ -33,6 +33,7 @@ let mutationLifecycle = {
   whenMutationsIdle: () => Promise.resolve(),
 };
 let deferredQuit;
+let isQuitting = false;
 let applicationReady = false;
 let windowVisible = false;
 let windowContentReady = false;
@@ -188,7 +189,15 @@ function createWindow() {
   createdWindow.on("hide", () => {
     windowVisible = false;
     publishLifecycleState();
-    hideDockForHiddenWindow();
+    // Keep the Dock / Command-Tab tile while Control Center is merely hidden.
+    // Retiring it made Cmd+Tab and the Dock look like the app had quit.
+  });
+  createdWindow.on("close", (event) => {
+    // Close means hide: the menu-bar host (or an explicit quit) owns process
+    // lifetime. Destroying here removed the app from Dock and Command-Tab.
+    if (isQuitting || createdWindow.isDestroyed()) return;
+    event.preventDefault();
+    createdWindow.hide();
   });
   createdWindow.once("closed", () => {
     if (mainWindow !== createdWindow) return;
@@ -197,7 +206,7 @@ function createWindow() {
     showWhenContentReady = false;
     windowVisible = false;
     publishLifecycleState();
-    hideDockForHiddenWindow();
+    if (isQuitting) hideDockForHiddenWindow();
   });
   const loading = RENDERER.development
     ? createdWindow.loadURL(RENDERER.url)
@@ -211,8 +220,8 @@ function revealWindow() {
   if (mainWindow.isMinimized()) mainWindow.restore();
   // The native host is an LSUIElement and never owns a Dock tile. Let its
   // embedded Control Center represent the product in the Dock and Command-Tab
-  // while the actual application window is visible, then retire that tile
-  // when the window closes so the menu-bar host remains unobtrusive.
+  // for as long as this process is alive, including while the window is hidden,
+  // so switching away and back does not make the app look like it quit.
   showDockForVisibleWindow();
   mainWindow.show();
   mainWindow.focus();
@@ -389,26 +398,32 @@ if (primaryInstance) app.on("second-instance", (_event, commandLine) => {
 });
 
 if (primaryInstance) app.on("before-quit", (event) => {
+  isQuitting = true;
   if (!mutationLifecycle.hasActiveMutations()) return;
   event.preventDefault();
+  isQuitting = false;
   if (!deferredQuit) {
     deferredQuit = mutationLifecycle.whenMutationsIdle().then(() => {
       deferredQuit = undefined;
+      isQuitting = true;
       app.quit();
     });
   }
 });
 
 if (primaryInstance) app.on("will-quit", () => {
+  isQuitting = true;
   applicationReady = false;
   windowVisible = false;
   publishLifecycleState();
+  hideDockForHiddenWindow();
 });
 
 if (primaryInstance) app.on("window-all-closed", () => {
-  // The outer Swift app owns the only macOS tray, so its embedded Electron
-  // child has no useful tray-only lifetime. Windows/Linux (and standalone macOS
-  // development) retain their Electron tray and can reopen the window.
+  // Prefer close-to-hide above. If the window is destroyed anyway, keep the
+  // embedded macOS process (and Windows/Linux tray builds) alive so Dock,
+  // Command-Tab, or the tray can reopen it. Only quit when no recoverable
+  // owner remains.
   if (shouldQuitOnLastWindowClosed({
     platform: process.platform,
     nativeTrayOwnedByHost,

--- a/apps/control-center/electron/main.mjs
+++ b/apps/control-center/electron/main.mjs
@@ -193,9 +193,11 @@ function createWindow() {
     // Retiring it made Cmd+Tab and the Dock look like the app had quit.
   });
   createdWindow.on("close", (event) => {
-    // Close means hide: the menu-bar host (or an explicit quit) owns process
-    // lifetime. Destroying here removed the app from Dock and Command-Tab.
+    // Close means hide only while a recoverable owner can bring the window
+    // back (embedded macOS host or a live tray). Without that owner, destroy
+    // so window-all-closed can quit instead of stranding an invisible process.
     if (isQuitting || createdWindow.isDestroyed()) return;
+    if (!(nativeTrayOwnedByHost || trayIsAvailable())) return;
     event.preventDefault();
     createdWindow.hide();
   });

--- a/docs/MACOS-TRAY.md
+++ b/docs/MACOS-TRAY.md
@@ -60,12 +60,14 @@ assets are committed rather than rasterized during a normal tray build.
 
 The Swift host stays `LSUIElement`, so it does not add a Dock icon. A person
 opening `Codex Router.app` gets the embedded Control Center as a normal window;
-that window supplies the product's Dock and Command-Tab entry only while it is
-open. Opening the app also reveals the native tray surfaces for 20 seconds if
-**With Codex** would otherwise hide them. Closing the Control Center window
-leaves the native host running; reopen the app or choose **Control Center**
-from the menu-bar panel to restore it. The temporary reveal also starts the
-router and pulses the status dot, then follow mode resumes on its own.
+that process supplies the product's Dock and Command-Tab entry while Control
+Center is running, including after the window is closed or you switch away.
+Closing the window hides it rather than quitting, so Cmd+Tab and the Dock can
+bring it back. Opening the app also reveals the native tray surfaces for 20
+seconds if **With Codex** would otherwise hide them. The menu-bar host keeps
+running either way; choose **Control Center** from the panel to reopen if the
+Dock tile is not showing yet. The temporary reveal also starts the router and
+pulses the status dot, then follow mode resumes on its own.
 
 launchd passes `--supervised` when it starts the native host at login. That
 starts the menu-bar host without opening the Control Center window or forcing

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -569,7 +569,8 @@ test("Electron lifecycle state is durable, queryable, and fail-closed", async ()
 });
 
 test("a windowless desktop process survives only while a real tray owner exists", () => {
-  assert.equal(shouldQuitOnLastWindowClosed({ platform: "darwin", nativeTrayOwnedByHost: true }), true);
+  // Embedded macOS keeps the Electron process so Dock / Command-Tab can return.
+  assert.equal(shouldQuitOnLastWindowClosed({ platform: "darwin", nativeTrayOwnedByHost: true }), false);
   assert.equal(shouldQuitOnLastWindowClosed({ platform: "darwin", nativeTrayOwnedByHost: false, trayAvailable: false }), false);
   assert.equal(shouldQuitOnLastWindowClosed({ platform: "win32", nativeTrayOwnedByHost: false, trayAvailable: true }), false);
   assert.equal(shouldQuitOnLastWindowClosed({ platform: "win32", nativeTrayOwnedByHost: false, trayAvailable: false }), true);
@@ -1095,8 +1096,11 @@ test("electron boundary does not enable node integration or shell argv", async (
   assert.match(main, /app\.dock\?\.setIcon\(appIconPath\(\)\)/);
   assert.match(main, /function showDockForVisibleWindow\(\)[\s\S]*app\.dock\.setIcon\(appIconPath\(\)\)[\s\S]*app\.dock\.show\(\)/);
   assert.match(main, /function hideDockForHiddenWindow\(\)[\s\S]*app\.dock\.hide\(\)/);
-  assert.match(main, /function revealWindow\(\)[\s\S]{0,420}showDockForVisibleWindow\(\)[\s\S]{0,120}mainWindow\.show\(\)/);
-  assert.match(main, /createdWindow\.on\("hide"[\s\S]{0,180}hideDockForHiddenWindow\(\)/);
+  assert.match(main, /function revealWindow\(\)[\s\S]{0,700}showDockForVisibleWindow\(\)[\s\S]{0,120}mainWindow\.show\(\)/);
+  assert.match(main, /createdWindow\.on\("close"[\s\S]{0,400}event\.preventDefault\(\)[\s\S]{0,80}createdWindow\.hide\(\)/);
+  assert.match(main, /let isQuitting = false/);
+  assert.match(main, /app\.on\("will-quit"[\s\S]{0,220}hideDockForHiddenWindow\(\)/);
+  assert.doesNotMatch(main, /createdWindow\.on\("hide"[\s\S]{0,180}hideDockForHiddenWindow\(\)/);
   assert.match(main, /setWindowOpenHandler\(\(\) => \(\{ action: "deny" \}\)\)/);
   assert.match(main, /if \(app\.isPackaged \|\| !requested\)/);
   assert.match(main, /\["127\.0\.0\.1", "localhost", "\[::1\]"\]\.includes\(parsed\.hostname\)/);

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -1097,7 +1097,13 @@ test("electron boundary does not enable node integration or shell argv", async (
   assert.match(main, /function showDockForVisibleWindow\(\)[\s\S]*app\.dock\.setIcon\(appIconPath\(\)\)[\s\S]*app\.dock\.show\(\)/);
   assert.match(main, /function hideDockForHiddenWindow\(\)[\s\S]*app\.dock\.hide\(\)/);
   assert.match(main, /function revealWindow\(\)[\s\S]{0,700}showDockForVisibleWindow\(\)[\s\S]{0,120}mainWindow\.show\(\)/);
-  assert.match(main, /createdWindow\.on\("close"[\s\S]{0,400}event\.preventDefault\(\)[\s\S]{0,80}createdWindow\.hide\(\)/);
+  assert.match(
+    main,
+    /createdWindow\.on\("close"[\s\S]{0,500}nativeTrayOwnedByHost \|\| trayIsAvailable\(\)[\s\S]{0,120}event\.preventDefault\(\)[\s\S]{0,80}createdWindow\.hide\(\)/,
+  );
+  // Suppressing destroy without a recoverable owner strands Win/Linux when
+  // tray construction failed; the gate above is what keeps window-all-closed reachable.
+  assert.match(main, /if \(!\(nativeTrayOwnedByHost \|\| trayIsAvailable\(\)\)\) return;/);
   assert.match(main, /let isQuitting = false/);
   assert.match(main, /app\.on\("will-quit"[\s\S]{0,220}hideDockForHiddenWindow\(\)/);
   assert.doesNotMatch(main, /createdWindow\.on\("hide"[\s\S]{0,180}hideDockForHiddenWindow\(\)/);


### PR DESCRIPTION
## Summary
- Closing the embedded macOS Control Center window now **hides** it instead of destroying the Electron process and retiring the Dock tile.
- Dock / Command-Tab stay available while Control Center is running so switching away no longer makes the app look like it quit.
- Dock hide is deferred until an explicit quit (`will-quit` / host terminate). Docs and Electron lifecycle tests updated.

## Test plan
- [x] `node --test test/control-center-electron.test.mjs` (69 pass, 1 skipped)
- [ ] Rebuild/open Codex Router Control Center on macOS
- [ ] Close the window (red traffic light) → Dock icon remains
- [ ] Cmd+Tab back (or click Dock) → window reappears
- [ ] Quit from the menu-bar host → Control Center and Dock tile go away


Made with [Cursor](https://cursor.com)