### PR TITLE
fix: allow ChatGPT account switches without disabling the router

### DIFF
--- a/apps/control-center/src/pages/SettingsPage.tsx
+++ b/apps/control-center/src/pages/SettingsPage.tsx
@@ -3,7 +3,17 @@ import { AppWindow, Check, Eye, LogIn, Moon, Plus, RefreshCw, Server, ShieldChec
 import { Badge, Button, Dialog, InlineNotice, PageHeader, SectionHeading, Toggle } from "../components";
 import { compactNumber } from "../lib";
 import { LANGUAGE_OPTIONS, type LanguageId, type Translate } from "../i18n";
-import type { ChatGptAccountPool, ChatGptSessionStatus, DoctorSnapshot, PresenceSnapshot, RouterControlApi, RouterHealth, RouterTarget, VisionEngine } from "../types";
+import type {
+  ChatGptAccountPool,
+  ChatGptSessionStatus,
+  ChatGptSubscriptionAccount,
+  DoctorSnapshot,
+  PresenceSnapshot,
+  RouterControlApi,
+  RouterHealth,
+  RouterTarget,
+  VisionEngine,
+} from "../types";
 import { useOptimisticValues, type RunAction } from "../useOptimisticValues";
 
 // Mirrors RETENTION_MIN/MAX/DEFAULT_TTL_DAYS in src/tool-result-retention.mjs.
@@ -12,6 +22,27 @@ import { useOptimisticValues, type RunAction } from "../useOptimisticValues";
 // than being folded in with the default.
 const RETENTION_DEFAULT_TTL_DAYS = 7;
 const RETENTION_CHOICES = [1, 3, 7, 14, 30, 90];
+
+type AccountOverlay =
+  | { kind: "add"; clientId: string; account: ChatGptSubscriptionAccount }
+  | { kind: "remove"; accountId: string };
+
+function isOptimisticAccountId(id: string): boolean {
+  return id.startsWith("pending:");
+}
+
+function optimisticAccountPlaceholder(label: string, clientId: string): ChatGptSubscriptionAccount {
+  return {
+    id: clientId,
+    state: "active",
+    paused: false,
+    priority: 50,
+    label: label || "New account",
+    subscription: { status: "pending", authenticated: false, usable: false, expired: false },
+    turns: 0,
+    requests: 0,
+  };
+}
 
 function formatBytes(value: number | null | undefined): string {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return "0 B";
@@ -52,6 +83,7 @@ export function SettingsPage({ target, health, presence, chatgptSession, account
   const [loginPendingId, setLoginPendingId] = useState<string | null>(null);
   const [loginRetryingId, setLoginRetryingId] = useState<string | null>(null);
   const [loginError, setLoginError] = useState<string | null>(null);
+  const [accountOverlays, setAccountOverlays] = useState<AccountOverlay[]>([]);
   const refreshRef = useRef(onRefresh);
   refreshRef.current = onRefresh;
   const [trayCapability, setTrayCapability] = useState<{ supported?: boolean; why?: string }>();
@@ -131,11 +163,101 @@ export function SettingsPage({ target, health, presence, chatgptSession, account
   // Revoked records are cleanup tombstones from older router versions. They
   // are not usable accounts and must never reappear as "Account 1/2" rows.
   // Keep paused records visible so a future resume control can explain them.
-  const subscriptionAccounts = Object.values(accountPoolError ? {} : accountPool?.accounts || {})
-    .filter((account) => account.state !== "revoked");
+  // Add/remove overlays paint immediately; runAction's later refresh replaces
+  // them with authoritative pool state and clears the matching overlays.
+  useEffect(() => {
+    if (accountPoolError || !accountPool) return;
+    setAccountOverlays((current) => {
+      if (!current.length) return current;
+      const next = current.filter((entry) => {
+        if (entry.kind === "add") {
+          return !accountPool.accounts?.[entry.account.id];
+        }
+        const remaining = accountPool.accounts?.[entry.accountId];
+        return Boolean(remaining && remaining.state !== "revoked");
+      });
+      return next.length === current.length ? current : next;
+    });
+  }, [accountPool, accountPoolError]);
+  const subscriptionAccounts = useMemo(() => {
+    const base = Object.values(accountPoolError ? {} : accountPool?.accounts || {})
+      .filter((account) => account.state !== "revoked");
+    const removedIds = new Set(
+      accountOverlays
+        .filter((entry): entry is Extract<AccountOverlay, { kind: "remove" }> => entry.kind === "remove")
+        .map((entry) => entry.accountId),
+    );
+    const visible = base.filter((account) => !removedIds.has(account.id));
+    const visibleIds = new Set(visible.map((account) => account.id));
+    const pendingAdds = accountOverlays
+      .filter((entry): entry is Extract<AccountOverlay, { kind: "add" }> => entry.kind === "add")
+      .map((entry) => entry.account)
+      .filter((account) => !visibleIds.has(account.id));
+    return [...visible, ...pendingAdds];
+  }, [accountOverlays, accountPool, accountPoolError]);
   const usableSubscriptionAccounts = subscriptionAccounts.filter((account) => account.state === "active" && account.subscription?.usable === true);
   const activeAccountId = accountPool?.profile?.active;
   const accountSelection = accountPool?.profile?.desired || activeAccountId || usableSubscriptionAccounts[0]?.id || "";
+
+  const addSubscriptionAccount = async () => {
+    if (!api || accountPoolError) return;
+    const label = newAccountLabel.trim();
+    const clientId = `pending:${crypto.randomUUID()}`;
+    setAccountOverlays((current) => [
+      ...current,
+      { kind: "add", clientId, account: optimisticAccountPlaceholder(label, clientId) },
+    ]);
+    setNewAccountLabel("");
+    let saved = false;
+    try {
+      await runAction("Add ChatGPT subscription account", async () => {
+        const result = await api.addChatGptSubscriptionAccount(label) as {
+          account?: ChatGptSubscriptionAccount;
+        };
+        const created = result?.account;
+        if (created?.id) {
+          setAccountOverlays((current) => current.map((entry) => (
+            entry.kind === "add" && entry.clientId === clientId
+              ? { kind: "add", clientId, account: created }
+              : entry
+          )));
+        } else {
+          // The durable write succeeded but returned no row. Drop the
+          // placeholder so refreshCore's authoritative pool is the only source.
+          setAccountOverlays((current) => current.filter((entry) => !(
+            entry.kind === "add" && entry.clientId === clientId
+          )));
+        }
+        saved = true;
+        return result;
+      });
+    } finally {
+      if (!saved) {
+        setAccountOverlays((current) => current.filter((entry) => !(
+          entry.kind === "add" && entry.clientId === clientId
+        )));
+      }
+    }
+  };
+
+  const removeSubscriptionAccount = async (accountId: string) => {
+    if (!api || !accountId || loginPendingId === accountId) return;
+    setRemoveAccountId(null);
+    setAccountOverlays((current) => [...current, { kind: "remove", accountId }]);
+    let saved = false;
+    try {
+      await runAction("Remove ChatGPT subscription account", async () => {
+        await api.removeChatGptSubscriptionAccount(accountId);
+        saved = true;
+      });
+    } finally {
+      if (!saved) {
+        setAccountOverlays((current) => current.filter((entry) => !(
+          entry.kind === "remove" && entry.accountId === accountId
+        )));
+      }
+    }
+  };
 
   // Repair reinstalls and restarts the service, so it can outlast several
   // ordinary actions. `runAction` owns the toast and the refresh; the report
@@ -266,28 +388,30 @@ export function SettingsPage({ target, health, presence, chatgptSession, account
               <Button
                 variant="secondary"
                 disabled={!api || Boolean(accountPoolError)}
-                onClick={() => {
-                  if (!api) return;
-                  void runAction("Add ChatGPT subscription account", async () => {
-                    const result = await api.addChatGptSubscriptionAccount(newAccountLabel.trim());
-                    setNewAccountLabel("");
-                    return result;
-                  });
-                }}
+                onClick={() => void addSubscriptionAccount()}
               ><Plus aria-hidden size={14} strokeWidth={1.7} /> Add account</Button>
             </div>
             <div className="settings-list">
               {subscriptionAccounts.map((account) => {
+                const optimisticPending = isOptimisticAccountId(account.id);
                 const accountLoginAttempt = accountPool?.loginAttempts?.[account.id];
-                const status = account.subscription?.usable ? "Ready" : account.subscription?.expired ? "Session expired" : "Sign-in required";
+                const status = optimisticPending
+                  ? "Adding…"
+                  : account.subscription?.usable ? "Ready" : account.subscription?.expired ? "Session expired" : "Sign-in required";
                 const title = account.subscription?.email || account.label || "ChatGPT account";
                 const label = account.subscription?.email && account.label ? `${account.label} · ` : "";
                 const usage = account.subscription?.usage;
-                const usageLabel = usage && Number.isFinite(usage.remainingPercent)
-                  ? `${usage.period} · ${Math.round(usage.remainingPercent)}% remaining`
-                  : "Usage unavailable";
+                const usageLabel = optimisticPending
+                  ? "Saving account"
+                  : usage && Number.isFinite(usage.remainingPercent)
+                    ? `${usage.period} · ${Math.round(usage.remainingPercent)}% remaining`
+                    : "Usage unavailable";
                 return (
-                  <div className="setting-row subscription-account-row" key={account.id}>
+                  <div
+                    className="setting-row subscription-account-row"
+                    key={account.id}
+                    data-optimistic={optimisticPending ? "true" : undefined}
+                  >
                     <div>
                       <strong><UserRound aria-hidden size={14} strokeWidth={1.7} /> {title} {accountSelection === account.id ? <Badge tone="accent">Selected</Badge> : null}</strong>
                       <small>{label}{status}{account.subscription?.expiresInHours !== undefined ? ` · ${account.subscription.expiresInHours}h token` : ""} · {usageLabel}</small>
@@ -298,11 +422,12 @@ export function SettingsPage({ target, health, presence, chatgptSession, account
                         variant={accountSelection === account.id ? "secondary" : "ghost"}
                         aria-pressed={accountSelection === account.id}
                         aria-label={accountSelection === account.id ? `Selected ChatGPT account: ${title}` : `Select ChatGPT account: ${title}`}
+                        disabled={!api || optimisticPending}
                         onClick={() => api && void runAction("Switch ChatGPT account", () => api.setChatGptAccountSelection(account.id))}
                       >{accountSelection === account.id ? <><Check aria-hidden size={13} strokeWidth={1.9} /> Selected</> : <><Check aria-hidden size={13} strokeWidth={1.9} /> Select</>}</Button>
                       <Button
                         variant="ghost"
-                        disabled={!api || account.state !== "active" || accountLoginAttempt?.retryable === false || (account.subscription?.usable === true && accountLoginAttempt?.status !== "failed") || loginPendingId === account.id}
+                        disabled={!api || optimisticPending || account.state !== "active" || accountLoginAttempt?.retryable === false || (account.subscription?.usable === true && accountLoginAttempt?.status !== "failed") || loginPendingId === account.id}
                         onClick={() => {
                           if (!api) return;
                           setLoginError(null);
@@ -324,7 +449,11 @@ export function SettingsPage({ target, health, presence, chatgptSession, account
                           });
                         }}
                       ><LogIn aria-hidden size={13} strokeWidth={1.7} /> Login</Button>
-                      <Button variant="ghost" disabled={!api || account.state === "revoked" || accountLoginAttempt?.retryable === false || accountLoginAttempt?.removable === false || loginPendingId === account.id} onClick={() => setRemoveAccountId(account.id)}><Trash2 aria-hidden size={13} strokeWidth={1.7} /> Remove</Button>
+                      <Button
+                        variant="ghost"
+                        disabled={!api || optimisticPending || account.state === "revoked" || accountLoginAttempt?.retryable === false || accountLoginAttempt?.removable === false || loginPendingId === account.id}
+                        onClick={() => setRemoveAccountId(account.id)}
+                      ><Trash2 aria-hidden size={13} strokeWidth={1.7} /> Remove</Button>
                     </div>
                   </div>
                 );
@@ -590,8 +719,7 @@ export function SettingsPage({ target, health, presence, chatgptSession, account
           <Button variant="secondary" onClick={() => setRemoveAccountId(null)}>Cancel</Button>
           <Button variant="danger" disabled={!api || !removeAccountId || loginPendingId === removeAccountId} onClick={() => {
             const id = removeAccountId;
-            setRemoveAccountId(null);
-            if (api && id) void runAction("Remove ChatGPT subscription account", () => api.removeChatGptSubscriptionAccount(id));
+            if (id) void removeSubscriptionAccount(id);
           }}>Remove account</Button>
         </div>
       </Dialog>

--- a/apps/control-center/test/renderer.test.mjs
+++ b/apps/control-center/test/renderer.test.mjs
@@ -29,6 +29,7 @@ const bridgeSource = String.raw`
     : null;
   const rejectAccountUsageRead = Number(searchParams.get("rejectAccountUsageRead")) || 0;
   const rejectAccountPool = searchParams.get("rejectAccountPool") === "1";
+  const accountMutationDelayMs = Number(searchParams.get("accountMutationDelayMs")) || 0;
   const terminalLoginFailure = searchParams.get("terminalLoginFailure") === "1";
   const rejectLoginImmediately = searchParams.get("rejectLoginImmediately") === "1";
   const loginStaysPending = searchParams.get("loginStaysPending") === "1";
@@ -204,6 +205,24 @@ const bridgeSource = String.raw`
     };
   };
 
+  let accountSeq = 0;
+  const accountPoolState = {
+    version: 1,
+    policy: { enabled: true, mode: "switch", selectedAccountId: "active" },
+    accounts: {
+      revoked: { id: "revoked", state: "revoked", paused: true, priority: 50, label: "Removed account", health: { state: "healthy" }, turns: 0, requests: 0 },
+      active: { id: "active", state: "active", paused: false, priority: 50, label: "Secondary account", subscription: { status: "usable", authenticated: true, usable: true, expired: false, email: "secondary@example.com" }, health: { state: "healthy" }, turns: 0, requests: 0 },
+      current: { id: "current", state: "active", paused: false, priority: 50, label: "Current account", subscription: terminalLoginFailure || loginStaysPending ? { status: "invalid", authenticated: false, usable: false, expired: false, email: "primary@example.com" } : { status: "usable", authenticated: true, usable: true, expired: false, email: "primary@example.com" }, health: { state: "healthy" }, turns: 0, requests: 0 },
+    },
+    get loginAttempts() {
+      return terminalLoginFailure && subscriptionLoginRequested
+        ? { current: { status: "failed", error: "Codex login closed before this account became usable.", retryable: true } }
+        : undefined;
+    },
+    sessions: { count: 0 },
+    profile: { desired: "active", active: "active", pending: false, running: false },
+  };
+
   window.routerControl = Object.freeze({
     platform: navigator.platform.toLowerCase().includes("mac") ? "darwin" : "linux",
     getSnapshot: async () => {
@@ -215,18 +234,7 @@ const bridgeSource = String.raw`
       if (rejectAccountPool) throw new Error("The saved ChatGPT account list could not be read as JSON.");
       accountPoolReads += 1;
       if (terminalLoginFailure) record("getChatGptAccountPool", accountPoolReads);
-      return {
-        version: 1,
-        policy: { enabled: true, mode: "switch", selectedAccountId: "active" },
-        accounts: {
-          revoked: { id: "revoked", state: "revoked", paused: true, priority: 50, label: "Removed account", health: { state: "healthy" }, turns: 0, requests: 0 },
-          active: { id: "active", state: "active", paused: false, priority: 50, label: "Secondary account", subscription: { status: "usable", authenticated: true, usable: true, expired: false, email: "secondary@example.com" }, health: { state: "healthy" }, turns: 0, requests: 0 },
-          current: { id: "current", state: "active", paused: false, priority: 50, label: "Current account", subscription: terminalLoginFailure || loginStaysPending ? { status: "invalid", authenticated: false, usable: false, expired: false, email: "primary@example.com" } : { status: "usable", authenticated: true, usable: true, expired: false, email: "primary@example.com" }, health: { state: "healthy" }, turns: 0, requests: 0 },
-        },
-        ...(terminalLoginFailure && subscriptionLoginRequested ? { loginAttempts: { current: { status: "failed", error: "Codex login closed before this account became usable.", retryable: true } } } : {}),
-        sessions: { count: 0 },
-        profile: { desired: "active", active: "active", pending: false, running: false },
-      };
+      return JSON.parse(JSON.stringify(accountPoolState));
     },
     getProviders: async () => {
       await new Promise((resolve) => setTimeout(resolve, providerDelayMs));
@@ -435,6 +443,34 @@ const bridgeSource = String.raw`
     setChatGptAccountSelection: async (selection) => {
       record("setChatGptAccountSelection", selection);
       return { ok: true };
+    },
+    addChatGptSubscriptionAccount: async (label = "") => {
+      record("addChatGptSubscriptionAccount", label);
+      if (accountMutationDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, accountMutationDelayMs));
+      accountSeq += 1;
+      const id = "acct_test_" + String(accountSeq).padStart(8, "0");
+      const account = {
+        id,
+        state: "active",
+        paused: false,
+        priority: 50,
+        label: String(label || "").trim() || ("Account " + accountSeq),
+        subscription: { status: "pending", authenticated: false, usable: false, expired: false },
+        health: { state: "healthy" },
+        turns: 0,
+        requests: 0,
+      };
+      accountPoolState.accounts[id] = account;
+      return { account, loginRequired: true };
+    },
+    removeChatGptSubscriptionAccount: async (accountId) => {
+      record("removeChatGptSubscriptionAccount", accountId);
+      if (accountMutationDelayMs > 0) await new Promise((resolve) => setTimeout(resolve, accountMutationDelayMs));
+      delete accountPoolState.accounts[accountId];
+      if (accountPoolState.policy.selectedAccountId === accountId) {
+        delete accountPoolState.policy.selectedAccountId;
+      }
+      return { id: accountId };
     },
     loginChatGptSubscriptionAccount: async (accountId) => {
       record("loginChatGptSubscriptionAccount", accountId);
@@ -831,6 +867,43 @@ test("the production renderer exposes model discovery and picker actions", { tim
     await page.getByRole("button", { name: "Select ChatGPT account: primary@example.com", exact: true }).click();
     await page.waitForFunction(() => window.routerControlTest.calls()
       .some((call) => call.name === "setChatGptAccountSelection" && call.args[0] === "current"));
+
+    // Add/remove must paint before the durable control round-trip finishes.
+    const optimisticPage = await browser.newPage({ viewport: { width: 1280, height: 840 } });
+    optimisticPage.setDefaultTimeout(10_000);
+    await optimisticPage.goto(`${url}?accountMutationDelayMs=1500`, { waitUntil: "domcontentloaded" });
+    await optimisticPage.getByRole("button", { name: "Settings", exact: true }).click();
+    await optimisticPage.getByText("ChatGPT accounts", { exact: true }).waitFor();
+    const optimisticRows = optimisticPage.locator(".subscription-account-row");
+    const rowsBeforeAdd = await optimisticRows.count();
+    await optimisticPage.getByRole("textbox", { name: "New ChatGPT account label" }).fill("Optimistic Work");
+    const optimisticAdd = optimisticRows.filter({ hasText: "Optimistic Work" });
+    const addStartedAt = Date.now();
+    await optimisticPage.getByRole("button", { name: "Add account", exact: true }).click();
+    await optimisticAdd.waitFor();
+    assert.ok(Date.now() - addStartedAt < 1200, "add row must appear before the delayed control returns");
+    assert.equal(await optimisticAdd.getAttribute("data-optimistic"), "true");
+    assert.equal(await optimisticRows.count(), rowsBeforeAdd + 1, "added account appears before the control returns");
+    await optimisticPage.waitForFunction(() => {
+      const row = [...document.querySelectorAll(".subscription-account-row")]
+        .find((node) => (node.textContent || "").includes("Optimistic Work"));
+      return Boolean(row && row.getAttribute("data-optimistic") !== "true");
+    });
+    assert.equal(await optimisticAdd.getByText("Sign-in required", { exact: false }).count(), 1);
+
+    await optimisticAdd.getByRole("button", { name: "Remove", exact: true }).click();
+    const removeStartedAt = Date.now();
+    await optimisticPage.getByRole("button", { name: "Remove account", exact: true }).click();
+    await optimisticAdd.waitFor({ state: "detached" });
+    assert.ok(Date.now() - removeStartedAt < 1200, "removed row must disappear before the delayed control returns");
+    assert.equal(
+      await optimisticRows.filter({ hasText: "Optimistic Work" }).count(),
+      0,
+      "removed account disappears before the control returns",
+    );
+    await optimisticPage.waitForFunction(() => window.routerControlTest.calls()
+      .some((call) => call.name === "removeChatGptSubscriptionAccount"));
+    await optimisticPage.close();
 
     // Huge community GGUFs stay guarded, but the explicit oversized-model
     // acknowledgement must make their exact Ollama tag selectable. Otherwise

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -232,6 +232,24 @@ function restoreFileSnapshot(target, snapshot) {
   }
 }
 
+// Live `codex debug models` (no --bundled) reads whatever model_catalog_json
+// Codex currently points at. While this router owns that path, the answer is
+// our merged catalog — never a native capture source. Account switching and
+// other in-place refreshes must not force operators to disable the router
+// just to rebuild native-models.json.
+export function liveAccountCatalogProbeAllowed({
+  discoveryDisabled: idle = false,
+  routedCatalogActive: routedActive = false,
+} = {}) {
+  return !idle && !routedActive;
+}
+
+function catalogContainsRoutedSlugs(catalog) {
+  return Boolean(
+    catalog?.models?.some((model) => MODEL_BY_SLUG.has(String(model.slug))),
+  );
+}
+
 function captureNative(cache) {
   // A discovery-disabled install promised that nothing account-derived is
   // read: `debug models` without --bundled reflects the signed-in account's
@@ -240,6 +258,7 @@ function captureNative(cache) {
   // This is the gate SECURITY.md's "the one Codex spawn that remains is
   // `codex debug models --bundled`" claim rests on.
   const idle = discoveryDisabled();
+  const routedActive = routedCatalogActive();
   const resolved = cache ?? (idle ? {} : readModelsCache());
   // This is the account-aware catalog Codex itself cached after signing in.
   // Reading it directly also avoids asking `codex debug models` while the
@@ -248,7 +267,17 @@ function captureNative(cache) {
   let fallback;
   let accountError;
   let fallbackError;
-  if (!account && !idle) {
+  if (account && catalogContainsRoutedSlugs(account)) {
+    // A prior merged echo written into models_cache.json is not native.
+    account = undefined;
+    accountError = new Error(
+      "models_cache.json contains routed model slugs; refusing to treat it as native.",
+    );
+  }
+  if (!account && liveAccountCatalogProbeAllowed({
+    discoveryDisabled: idle,
+    routedCatalogActive: routedActive,
+  })) {
     try {
       account = JSON.parse(runCodex(["debug", "models"], {
         encoding: "utf8",
@@ -331,7 +360,34 @@ function nativeCatalog({ refreshNative = refresh } = {}) {
   // so a discovery-disabled install leaves it unread like every other
   // account-derived artifact.
   const cache = discoveryDisabled() ? {} : readModelsCache();
-  if (!existsSync(NATIVE_CATALOG_PATH) || refreshNative) return captureNative(cache);
+  const readCachedNative = () => {
+    if (!existsSync(NATIVE_CATALOG_PATH)) return undefined;
+    try {
+      const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
+      if (parsed && Array.isArray(parsed.models) && parsed.models.length > 0) {
+        return parsed;
+      }
+    } catch {
+      // Unreadable cache is treated as missing below.
+    }
+    return undefined;
+  };
+  if (!existsSync(NATIVE_CATALOG_PATH) || refreshNative) {
+    try {
+      return captureNative(cache);
+    } catch (error) {
+      // Account switching refreshes native while the router still owns
+      // model_catalog_json. Prefer a prior capture over aborting the switch.
+      const cached = readCachedNative();
+      if (cached) {
+        console.error(
+          `Could not refresh the native model catalog (${error.message}); reusing the cached capture.`,
+        );
+        return cached;
+      }
+      throw error;
+    }
+  }
   const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
   if (nativeCatalogIsReusable(parsed, codexVersion(), cache.fingerprint)) {
     return parsed;

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -20,6 +20,7 @@ import {
   clampModelEfforts,
   codexEffortVocabulary,
   effectivePickerHiddenModels,
+  liveAccountCatalogProbeAllowed,
   nativeCatalogIsReusable,
   deriveBaseInstructions,
   mergeNativeCatalogs,
@@ -63,6 +64,41 @@ const grok = {
   compHash: "grok-oauth-grok-4-5-v1",
   multiAgentVersion: "v2",
 };
+
+test("live account catalog probes stay off while the router owns the catalog", () => {
+  assert.equal(
+    liveAccountCatalogProbeAllowed({ discoveryDisabled: false, routedCatalogActive: false }),
+    true,
+  );
+  assert.equal(
+    liveAccountCatalogProbeAllowed({ discoveryDisabled: true, routedCatalogActive: false }),
+    false,
+  );
+  assert.equal(
+    liveAccountCatalogProbeAllowed({ discoveryDisabled: false, routedCatalogActive: true }),
+    false,
+  );
+  // ChatGPT account switching refreshes native while openai_base_url still
+  // points at this router. A live `debug models` probe would echo the merged
+  // catalog and abort the switch with "already-merged catalog".
+  assert.equal(
+    liveAccountCatalogProbeAllowed({ discoveryDisabled: false, routedCatalogActive: true }),
+    false,
+  );
+});
+
+test("native capture refuses to probe a live account catalog under a routed config", () => {
+  const source = readFileSync(new URL("../src/catalog.mjs", import.meta.url), "utf8");
+  assert.match(
+    source,
+    /liveAccountCatalogProbeAllowed\(\{\s*discoveryDisabled: idle,\s*routedCatalogActive: routedActive,\s*\}\)/,
+  );
+  assert.match(source, /catalogContainsRoutedSlugs\(account\)/);
+  assert.match(
+    source,
+    /Could not refresh the native model catalog \(\$\{error\.message\}\); reusing the cached capture\./,
+  );
+});
 
 test("signed-in picker overlay cannot hide Codex native base entries", () => {
   const hidden = new Set(["gpt-5.6-luna", "gpt-5.6-sol-1m", "grok-oauth/grok-4.5"]);


### PR DESCRIPTION
## Summary
- ChatGPT account selection in Control Center was forcing a native catalog refresh while the router still owned `model_catalog_json`, so live `codex debug models` echoed the merged picker and aborted with “already-merged catalog.”
- Native capture now skips that live probe while the routed catalog is active, discards polluted `models_cache` entries that already contain routed slugs, and reuses a prior native capture when a forced refresh still fails.
- Control Center ChatGPT account add/remove now paints optimistically: new rows appear immediately as “Adding…”, removed rows disappear on confirm, and failures roll the list back when the durable write does not land.

## Test plan
- [x] `node --test test/catalog.test.mjs` (includes new live-probe / capture-path assertions)
- [x] `node --test apps/control-center/test/renderer.test.mjs` (includes delayed add/remove optimistic UI coverage)
- [ ] In Control Center Settings, add a ChatGPT account and confirm the row appears immediately
- [ ] Select / switch accounts while the router is running and confirm no “already-merged catalog” error
- [ ] Remove an account and confirm it disappears immediately; confirm a failed remove restores the row


Made with [Cursor](https://cursor.com)