### PR TITLE
fix: advertise image input for OpenCode Free Muse Spark

### DIFF
--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -26,6 +26,7 @@ import {
   curationProviderIds,
   curatedModelContextLength,
   curatedModelDescription,
+  curatedModelInputModalities,
   curatedModelProviderId,
   curatedModelReasoningLevels,
   curatedModelRequestProfile,
@@ -505,6 +506,14 @@ async function main() {
     if (!flagEfforts && documentedEfforts) {
       Object.assign(metadata, parseEfforts(documentedEfforts.join(",")) || {});
     }
+    // Zen's /models catalog publishes ids only, so image input has to come
+    // from the same documented free-id table as the window and effort ladder.
+    // Without this, scripted `--models` curation keeps the generic text-only
+    // default even when OpenCode publishes attachment/image for the id.
+    const documentedModalities = curatedModelInputModalities(providerId, id);
+    if (documentedModalities) {
+      metadata.inputModalities = [...documentedModalities];
+    }
     // A documented window or effort ladder is not a conservative default, and
     // this repository records where such a value came from in the entry's own
     // description rather than only in a source comment. The same note names
@@ -540,8 +549,13 @@ async function main() {
       // replaced it, so that clause no longer matches what is stored.
       if (context !== documented?.contextWindow) omitContextNote = true;
     }
-    if (confirm(`  Does ${id} accept image input?`)) {
+    const defaultImage = (metadata.inputModalities || []).includes("image");
+    if (confirm(`  Does ${id} accept image input?`, defaultImage)) {
       metadata.inputModalities = ["text", "image"];
+    } else if (documentedModalities) {
+      // Documented modalities were pre-filled above; an explicit no has to
+      // clear them or the stored entry would still advertise image paste.
+      metadata.inputModalities = ["text"];
     }
     if (!flagEfforts) {
       const ladder = metadata.reasoningLevels?.map((level) => level.effort).join(",") || "high";

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -10,6 +10,7 @@ import {
   providerModelEndpoint,
 } from "./openai-endpoint-policy.mjs";
 import {
+  curatedModelInputModalities,
   curatedModelIsFree,
   curatedModelToolSchemaRecursion,
 } from "./opencode-curation.mjs";
@@ -567,9 +568,26 @@ function normalizedModel(model, provider, { curated = false } = {}) {
   const documentedRecursion = curated
     ? curatedModelToolSchemaRecursion(model.provider, model.upstreamModel)
     : undefined;
-  const presented = documentedRecursion && !priced.toolSchemaRecursion
+  const withRecursion = documentedRecursion && !priced.toolSchemaRecursion
     ? { ...priced, toolSchemaRecursion: documentedRecursion }
     : priced;
+  // Image input is another published free-id fact Zen's catalog omits. A
+  // text-only stored default would keep Codex refusing paste forever; widen
+  // only when the documented set includes image and the entry still lacks it,
+  // so an already-correct text+image row stays byte-identical.
+  const documentedModalities = curated
+    ? curatedModelInputModalities(model.provider, model.upstreamModel)
+    : undefined;
+  const modalitiesMissingImage =
+    Array.isArray(documentedModalities) &&
+    documentedModalities.includes("image") &&
+    !(
+      Array.isArray(withRecursion.inputModalities) &&
+      withRecursion.inputModalities.includes("image")
+    );
+  const presented = modalitiesMissingImage
+    ? { ...withRecursion, inputModalities: [...documentedModalities] }
+    : withRecursion;
   if (!provider?.perModelEndpoint) return Object.freeze(presented);
   return Object.freeze({
     ...presented,

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -54,6 +54,11 @@ const OPENCODE_FREE_MODELS = Object.freeze({
     // Meta's Console upstream refuses a tool schema whose $refs cycle,
     // losing the whole turn to a 400 that names no tool.
     toolSchemaRecursion: "flatten",
+    // OpenCode's models.dev record for this exact free id publishes
+    // modalities.input including image (plus video/pdf/audio the picker does
+    // not name) and attachment: true. Without this, scripted curation keeps
+    // the generic text-only default and Codex refuses image paste.
+    inputModalities: Object.freeze(["text", "image"]),
     // The `-free` suffix is the tier, not the model. Carrying it in the label
     // put this route in a family of its own, apart from the paid routes to the
     // same model. `isFree` is where the price distinction belongs; the picker
@@ -79,6 +84,11 @@ const OPENCODE_FREE_MODELS = Object.freeze({
     // Meta's Console upstream refuses a tool schema whose $refs cycle,
     // losing the whole turn to a 400 that names no tool.
     toolSchemaRecursion: "flatten",
+    // OpenCode's models.dev record for this exact free id publishes
+    // modalities.input including image (plus video/pdf/audio the picker does
+    // not name) and attachment: true. Without this, scripted curation keeps
+    // the generic text-only default and Codex refuses image paste.
+    inputModalities: Object.freeze(["text", "image"]),
     displayName: "Muse Spark 1.3 Contributor (OpenCode Free)",
     isFree: true,
     summary:
@@ -436,6 +446,13 @@ export function curatedModelIsFree(providerId, upstreamModel) {
 // something an installed machine should have to do to stop losing turns.
 export function curatedModelToolSchemaRecursion(providerId, upstreamModel) {
   return curatedModelRecord(providerId, upstreamModel)?.toolSchemaRecursion;
+}
+
+// Same overlay rule as the free tag: Zen's id-only /models catalog never
+// advertises modalities, so scripted curation stored text-only until this
+// module carried OpenCode's published image input for the free Muse ids.
+export function curatedModelInputModalities(providerId, upstreamModel) {
+  return curatedModelRecord(providerId, upstreamModel)?.inputModalities;
 }
 
 // The picker text that carries the sourcing for every value this module knows

--- a/test/curate-models.test.mjs
+++ b/test/curate-models.test.mjs
@@ -30,6 +30,7 @@ const {
   curatedModelContextLength,
   curatedModelDescription,
   curatedModelIds,
+  curatedModelInputModalities,
   curatedModelOutputLimit,
   curatedModelProviderId,
   curatedModelReasoningLevels,
@@ -1071,6 +1072,36 @@ test("curated free tagging is undefined for an undocumented id", async () => {
   assert.equal(curatedModelIsFree("opencode-free", "not-a-documented-id"), undefined);
 });
 
+// Zen's catalog never advertises modalities, so free Muse image input has to
+// live in the same documented table as the window and effort ladder. Both
+// free ids publish attachment/image on models.dev; every other free id stays
+// on the conservative text-only default until measured the same way.
+test("OpenCode Free Muse Spark routes document text and image input", () => {
+  for (const id of [
+    "muse-spark-1.2-contributor-free",
+    "muse-spark-1.3-contributor-free",
+  ]) {
+    assert.deepEqual(
+      curatedModelInputModalities("opencode-free", id),
+      ["text", "image"],
+      id,
+    );
+    assert.deepEqual(
+      curatedModelInputModalities("opencode-free-responses", id),
+      ["text", "image"],
+      `${id} responses variant`,
+    );
+  }
+  assert.equal(
+    curatedModelInputModalities("opencode-free", "nemotron-3-ultra-free"),
+    undefined,
+  );
+  assert.equal(
+    curatedModelInputModalities("opencode-free", "not-a-documented-id"),
+    undefined,
+  );
+});
+
 test("scripted OpenCode Free curation stores the documented window and its sourcing", () => {
   const dir = mkdtempSync(path.join(os.tmpdir(), "curate-opencode-free-sourcing-"));
   const file = path.join(dir, "user-models.json");
@@ -1313,7 +1344,11 @@ test("a non-interactive OpenCode Free curation stores documented metadata and pr
     const muse = find(museId);
     assert.equal(muse.provider, "opencode-free-responses");
     assert.equal(muse.requestProfile, "auto-tool-choice");
+    // OpenCode publishes image input for this free id; without the documented
+    // modalities table, scripted curation would keep the text-only default.
+    assert.deepEqual(muse.inputModalities, ["text", "image"]);
     assert.equal(laguna.requestProfile, undefined);
+    assert.deepEqual(laguna.inputModalities, ["text"]);
 
     // Nothing documented: every value stays a conservative default, and the
     // stock description keeps saying exactly that.

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -1360,6 +1360,71 @@ test("every Muse Spark route on opencode flattens recursive tool schemas", () =>
   }
 });
 
+test("curated OpenCode Free Muse overlay upgrades text-only image modalities", async () => {
+  // An entry curated before modalities were documented keeps ["text"]. The
+  // registry overlay must widen it on load the same way it applies isFree and
+  // toolSchemaRecursion, or every installed machine would need a re-curate
+  // before Codex accepts image paste.
+  const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const nodePath = (await import("node:path")).default;
+  const { spawnSync } = await import("node:child_process");
+  const dir = mkdtempSync(nodePath.join(tmpdir(), "registry-muse-modalities-"));
+  const userModelsPath = nodePath.join(dir, "user-models.json");
+  const museId = "muse-spark-1.3-contributor-free";
+  writeFileSync(
+    userModelsPath,
+    JSON.stringify({
+      version: 1,
+      models: [
+        {
+          slug: `opencode-free-responses/${museId}`,
+          gatewayModel: "opencode-free-responses-muse-spark-1-3-contributor-free",
+          upstreamModel: museId,
+          provider: "opencode-free-responses",
+          listed: true,
+          displayName: "Muse Spark 1.3 Contributor (OpenCode Free)",
+          description: "text-only curated before modalities were documented",
+          priority: 148,
+          defaultEffort: "high",
+          reasoningLevels: [{ effort: "high", description: "Deep reasoning" }],
+          contextWindow: 1_048_576,
+          autoCompact: 900_000,
+          inputModalities: ["text"],
+          isFree: true,
+          requestProfile: "auto-tool-choice",
+          compHash: "opencode-free-responses-muse-spark-1-3-contributor-free-user-v1",
+        },
+      ],
+    }),
+  );
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "-e",
+        `
+          const { MODEL_BY_SLUG } = await import('./src/model-registry.mjs');
+          const model = MODEL_BY_SLUG.get('opencode-free-responses/${museId}');
+          if (!model) { console.error('missing'); process.exit(2); }
+          console.log(JSON.stringify(model.inputModalities));
+        `,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          MODEL_ROUTER_USER_MODELS: userModelsPath,
+        },
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout.trim()), ["text", "image"]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("Nous Research free models are tagged isFree, Hermes 4 is not", () => {
   // Six free portal routes via :free upstream ids should be tagged isFree: true
   const freeModels = [


### PR DESCRIPTION
## Summary
- Document `inputModalities: ["text", "image"]` for OpenCode Free `muse-spark-1.2-contributor-free` and `muse-spark-1.3-contributor-free` from OpenCode's models.dev metadata (Zen's `/models` catalog still publishes ids only).
- Apply those modalities on scripted curation and, for already-curated overlay rows that are still text-only, at registry load — same overlay pattern as `isFree` / `toolSchemaRecursion`.
- Interactive curation defaults the image prompt to yes when the id documents image, and an explicit no clears the pre-filled modalities.

## Test plan
- [x] `node --test test/curate-models.test.mjs test/registry.test.mjs` (90 pass)
- [ ] Re-open Codex after update; confirm OpenCode Free Muse 1.2/1.3 advertise image paste without re-curating
- [ ] Optional: `bin/curate-models opencode-free --models muse-spark-1.3-contributor-free --no-apply` stores `["text","image"]`


Made with [Cursor](https://cursor.com)