### PR TITLE
fix(macos): select full Xcode for tray builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,18 @@ menu-bar app to show it. It is a movable Codex Router panel rather than an item
 in macOS's **Edit Widgets** gallery.
 
 macOS does not have a public `.dmg` yet; the command above builds and installs
-the app locally. If it asks for the Xcode Command Line Tools, run
-`xcode-select --install` and repeat the command.
+the app locally. That build requires the full Xcode app, not only the standalone
+Command Line Tools, because it contains SwiftUI macro and WidgetKit targets. The
+installer honors `DEVELOPER_DIR` or the Xcode selected under **Xcode → Settings
+→ Locations → Command Line Tools**. If that selection still points at the
+standalone tools, it uses `/Applications/Xcode.app` or
+`/Applications/Xcode-beta.app` for this build only without changing the global
+selection. For an Xcode app in another location, retry the companion with:
+
+```sh
+env DEVELOPER_DIR="/path/to/Xcode.app/Contents/Developer" \
+  ~/.local/share/codex-router/bin/model-router-tray
+```
 
 ## What Codex Router does
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -82,13 +82,21 @@ Windows the matching options are `-WithTray` and `-NoTray`.
 
 On macOS one `Codex Router.app` bundle is placed in `~/Applications`. It keeps
 the Swift-native menu-bar tray and embeds the Electron Control Center, so the
-build needs the Swift toolchain plus the Node runtime the router already
-requires; a missing toolchain skips the step with guidance instead of failing
-setup. Opening the app shows the Control Center, while a supervised login start
-keeps only the native tray visible. On Windows the packaged Electron Control
-Center owns both the native tray and the full window and is registered as the
-single `Codex Router Tray` logon task. Linux uses the same packaged Control
-Center and native Electron tray. Neither platform requires Rust.
+build needs the full Xcode app plus the Node runtime the router already
+requires. The standalone Command Line Tools are insufficient for the SwiftUI
+macro plug-ins used by recent macOS SDKs and do not provide the `xcodebuild`
+needed by the WidgetKit extension. The build honors `DEVELOPER_DIR` and the
+Xcode selected under **Xcode → Settings → Locations → Command Line Tools**. If
+that selection names the standalone tools, a standard
+`/Applications/Xcode.app` or `/Applications/Xcode-beta.app` is used for this
+build only; nonstandard installations can be selected with `DEVELOPER_DIR`.
+A missing full Xcode installation skips the companion with guidance instead of
+failing the already-installed router. Opening the app shows the Control Center,
+while a supervised login start keeps only the native tray visible. On Windows
+the packaged Electron Control Center owns both the native tray and the full
+window and is registered as the single `Codex Router Tray` logon task. Linux
+uses the same packaged Control Center and native Electron tray. Neither
+platform requires Rust.
 Guided setup walks through numbered steps: a provider list you toggle by
 number (`a` selects all, `n` clears, Enter continues) with a live
 ready/needs-key/needs-sign-in status per provider, credential onboarding for

--- a/scripts/build-macos-tray-app.sh
+++ b/scripts/build-macos-tray-app.sh
@@ -5,6 +5,13 @@ repo_dir=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
 tray_dir="$repo_dir/apps/macos/ModelRouterTray"
 widget_dir="$repo_dir/apps/macos/RouterUsageWidget"
 control_center_dir="$repo_dir/apps/control-center"
+# The macOS 27 SDK exposes SwiftUI state through platform macro plug-ins that
+# the standalone Command Line Tools do not ship. The bundled widget has always
+# needed xcodebuild as well. Honor an explicit or selected full Xcode first,
+# then use a standard Xcode installation for this child build only; never
+# change the machine-wide xcode-select setting as an installer side effect.
+developer_dir=$(node "$repo_dir/src/macos-developer-tools.mjs")
+export DEVELOPER_DIR="$developer_dir"
 signing_identity=${MODEL_ROUTER_CODESIGN_IDENTITY:--}
 if [ "$signing_identity" = "-" ]; then
   widget_storage_mode=local

--- a/src/install-plan.mjs
+++ b/src/install-plan.mjs
@@ -254,6 +254,7 @@ const TRAY_PLATFORMS = {
       return [
         path.join(root, "scripts", "build-macos-tray-app.sh"),
         path.join(root, "scripts", "build-macos-widget.sh"),
+        path.join(root, "src", "macos-developer-tools.mjs"),
         path.join(base, "Package.swift"),
         path.join(base, "Resources", "Info.plist"),
         path.join(base, "Resources", "ModelRouterTray.entitlements"),

--- a/src/macos-developer-tools.mjs
+++ b/src/macos-developer-tools.mjs
@@ -1,0 +1,97 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const STANDARD_XCODE_DEVELOPER_DIRS = [
+  "/Applications/Xcode.app/Contents/Developer",
+  "/Applications/Xcode-beta.app/Contents/Developer",
+];
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+export function selectFullXcodeDeveloperDir({
+  explicitDeveloperDir,
+  activeDeveloperDir,
+  standardDeveloperDirs = STANDARD_XCODE_DEVELOPER_DIRS,
+  isUsable,
+}) {
+  if (typeof isUsable !== "function") throw new TypeError("isUsable must be a function.");
+
+  const explicit = nonEmpty(explicitDeveloperDir);
+  if (explicit) {
+    if (isUsable(explicit)) {
+      return { developerDir: explicit, source: "environment", activeDeveloperDir };
+    }
+    throw new Error(
+      `DEVELOPER_DIR points to ${JSON.stringify(explicit)}, but that developer directory does not provide xcodebuild. ` +
+        "The macOS companion requires the full Xcode app; the standalone Command Line Tools cannot build " +
+        "the SwiftUI macro and WidgetKit targets.",
+    );
+  }
+
+  const active = nonEmpty(activeDeveloperDir);
+  for (const developerDir of unique([active, ...standardDeveloperDirs.map(nonEmpty)])) {
+    if (isUsable(developerDir)) {
+      return {
+        developerDir,
+        source: developerDir === active ? "active" : "standard-location",
+        activeDeveloperDir: active,
+      };
+    }
+  }
+
+  throw new Error(
+    "No usable full Xcode installation was selected or found at /Applications/Xcode.app or " +
+      "/Applications/Xcode-beta.app. The standalone Command Line Tools cannot build the SwiftUI macro " +
+      "and WidgetKit targets. Select Xcode in Xcode > Settings > Locations > Command Line Tools, or retry " +
+      'with env DEVELOPER_DIR="/path/to/Xcode.app/Contents/Developer" ./bin/model-router-tray.',
+  );
+}
+
+function selectedDeveloperDir() {
+  const result = spawnSync("/usr/bin/xcode-select", ["--print-path"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  return result.status === 0 ? nonEmpty(result.stdout) : undefined;
+}
+
+function providesXcodebuild(developerDir) {
+  const result = spawnSync("/usr/bin/xcrun", ["--find", "xcodebuild"], {
+    env: { ...process.env, DEVELOPER_DIR: developerDir },
+    stdio: "ignore",
+  });
+  return !result.error && result.status === 0;
+}
+
+export function resolveFullXcodeDeveloperDir({ environment = process.env } = {}) {
+  return selectFullXcodeDeveloperDir({
+    explicitDeveloperDir: environment.DEVELOPER_DIR,
+    activeDeveloperDir: selectedDeveloperDir(),
+    isUsable: providesXcodebuild,
+  });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const selection = resolveFullXcodeDeveloperDir();
+    if (selection.source === "standard-location") {
+      const active = selection.activeDeveloperDir
+        ? `Active developer directory ${selection.activeDeveloperDir} is not full Xcode; `
+        : "No active full Xcode developer directory was found; ";
+      process.stderr.write(
+        `codex-router: ${active}using ${selection.developerDir} for this build only.\n`,
+      );
+    }
+    process.stdout.write(`${selection.developerDir}\n`);
+  } catch (error) {
+    process.stderr.write(`codex-router: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/src/setup.mjs
+++ b/src/setup.mjs
@@ -429,14 +429,6 @@ async function configureProvider(provider) {
 function installTray() {
   try {
     if (process.platform === "darwin") {
-      try {
-        execFileSync("xcrun", ["--find", "swift"], { stdio: "ignore" });
-      } catch {
-        process.stdout.write(
-          "The Swift toolchain is missing; run `xcode-select --install`, then `./bin/model-router-tray` to add the companion later.\n",
-        );
-        return;
-      }
       // One canonical transaction stages the signed bundle, drains any
       // running embedded Control Center, swaps atomically, stamps the build,
       // and hands the native host to launchd.
@@ -467,7 +459,7 @@ function installTray() {
     process.stdout.write(
       `Desktop companion install did not finish: ${error instanceof Error ? error.message : String(error)}\n` +
         (process.platform === "darwin"
-          ? "Recent macOS SDKs need the full Xcode app (not only the Command Line Tools) to build the menu-bar companion's SwiftUI macros.\n"
+          ? "The macOS companion needs the full Xcode app for its SwiftUI macros and WidgetKit extension. Select Xcode under Xcode > Settings > Locations > Command Line Tools, or set DEVELOPER_DIR for ./bin/model-router-tray.\n"
           : "") +
         (process.platform === "win32"
           ? "The router itself is installed; retry later with .\\codex-router.ps1 tray.\n"

--- a/test/control-center-harness.test.mjs
+++ b/test/control-center-harness.test.mjs
@@ -99,9 +99,11 @@ test("context manager reads bounded metadata without returning conversation mess
 test("a busy Codex history cannot crowd Cursor sessions out of the shared index", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "router-context-fairness-"));
   const codexHome = path.join(root, "codex");
+  const dshHome = path.join(root, "dsh");
   const cursorDatabase = path.join(root, "conversation-search.db");
   const cursorAgentChats = path.join(root, "cursor-agent-chats");
   const priorCodexHome = process.env.CODEX_HOME;
+  const priorDshHome = process.env.DSH_HOME;
   const priorCursorDatabase = process.env.CODEX_ROUTER_CURSOR_CONVERSATION_DB;
   const priorCursorAgentChats = process.env.CODEX_ROUTER_CURSOR_AGENT_CHATS;
   try {
@@ -122,6 +124,10 @@ test("a busy Codex history cannot crowd Cursor sessions out of the shared index"
     cursor.close();
 
     process.env.CODEX_HOME = codexHome;
+    // Keep the aggregate count independent of the developer's real ~/.dsh.
+    // This test supplies only Codex and Cursor fixtures; every other client
+    // index must therefore resolve inside the same empty test root.
+    process.env.DSH_HOME = dshHome;
     process.env.CODEX_ROUTER_CURSOR_CONVERSATION_DB = cursorDatabase;
     process.env.CODEX_ROUTER_CURSOR_AGENT_CHATS = cursorAgentChats;
     const snapshot = getContextSessionsSnapshot();
@@ -134,6 +140,8 @@ test("a busy Codex history cannot crowd Cursor sessions out of the shared index"
   } finally {
     if (priorCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = priorCodexHome;
+    if (priorDshHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = priorDshHome;
     if (priorCursorDatabase === undefined) delete process.env.CODEX_ROUTER_CURSOR_CONVERSATION_DB;
     else process.env.CODEX_ROUTER_CURSOR_CONVERSATION_DB = priorCursorDatabase;
     if (priorCursorAgentChats === undefined) delete process.env.CODEX_ROUTER_CURSOR_AGENT_CHATS;

--- a/test/macos-developer-tools.test.mjs
+++ b/test/macos-developer-tools.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { selectFullXcodeDeveloperDir } from "../src/macos-developer-tools.mjs";
+
+test("an explicit usable DEVELOPER_DIR wins without probing fallback Xcodes", () => {
+  const probed = [];
+  const selection = selectFullXcodeDeveloperDir({
+    explicitDeveloperDir: "/opt/Xcode-custom.app/Contents/Developer",
+    activeDeveloperDir: "/Library/Developer/CommandLineTools",
+    standardDeveloperDirs: ["/Applications/Xcode.app/Contents/Developer"],
+    isUsable(candidate) {
+      probed.push(candidate);
+      return candidate.startsWith("/opt/");
+    },
+  });
+
+  assert.deepEqual(selection, {
+    developerDir: "/opt/Xcode-custom.app/Contents/Developer",
+    source: "environment",
+    activeDeveloperDir: "/Library/Developer/CommandLineTools",
+  });
+  assert.deepEqual(probed, ["/opt/Xcode-custom.app/Contents/Developer"]);
+});
+
+test("an explicit unusable DEVELOPER_DIR fails instead of silently changing toolchains", () => {
+  const probed = [];
+  assert.throws(
+    () =>
+      selectFullXcodeDeveloperDir({
+        explicitDeveloperDir: "/Library/Developer/CommandLineTools",
+        activeDeveloperDir: "/Applications/Xcode.app/Contents/Developer",
+        standardDeveloperDirs: ["/Applications/Xcode.app/Contents/Developer"],
+        isUsable(candidate) {
+          probed.push(candidate);
+          return candidate.includes("Xcode.app");
+        },
+      }),
+    /DEVELOPER_DIR.*does not provide xcodebuild/,
+  );
+  assert.deepEqual(probed, ["/Library/Developer/CommandLineTools"]);
+});
+
+test("the active full Xcode remains selected", () => {
+  const selection = selectFullXcodeDeveloperDir({
+    activeDeveloperDir: "/Applications/Xcode-selected.app/Contents/Developer",
+    standardDeveloperDirs: ["/Applications/Xcode.app/Contents/Developer"],
+    isUsable: () => true,
+  });
+
+  assert.equal(selection.developerDir, "/Applications/Xcode-selected.app/Contents/Developer");
+  assert.equal(selection.source, "active");
+});
+
+test("standalone Command Line Tools fall back to a usable standard Xcode for this build", () => {
+  const probed = [];
+  const selection = selectFullXcodeDeveloperDir({
+    activeDeveloperDir: "/Library/Developer/CommandLineTools",
+    standardDeveloperDirs: [
+      "/Applications/Xcode.app/Contents/Developer",
+      "/Applications/Xcode-beta.app/Contents/Developer",
+    ],
+    isUsable(candidate) {
+      probed.push(candidate);
+      return candidate.includes("Xcode-beta.app");
+    },
+  });
+
+  assert.equal(selection.developerDir, "/Applications/Xcode-beta.app/Contents/Developer");
+  assert.equal(selection.source, "standard-location");
+  assert.deepEqual(probed, [
+    "/Library/Developer/CommandLineTools",
+    "/Applications/Xcode.app/Contents/Developer",
+    "/Applications/Xcode-beta.app/Contents/Developer",
+  ]);
+});
+
+test("missing full Xcode fails with an actionable non-global override", () => {
+  assert.throws(
+    () =>
+      selectFullXcodeDeveloperDir({
+        activeDeveloperDir: "/Library/Developer/CommandLineTools",
+        standardDeveloperDirs: [],
+        isUsable: () => false,
+      }),
+    /DEVELOPER_DIR=.*model-router-tray/,
+  );
+});

--- a/test/tray-rebuild.test.mjs
+++ b/test/tray-rebuild.test.mjs
@@ -443,6 +443,20 @@ test("each companion fingerprints its own sources", () => {
   assert.equal(traySourceFingerprint(root, "aix"), "");
 });
 
+test("the macOS tray fingerprint includes its full-Xcode resolver", () => {
+  const fakeRoot = scratch();
+  try {
+    const resolver = path.join(fakeRoot, "src", "macos-developer-tools.mjs");
+    mkdirSync(path.dirname(resolver), { recursive: true });
+    writeFileSync(resolver, "before\n", "utf8");
+    const before = traySourceFingerprint(fakeRoot, "darwin");
+    writeFileSync(resolver, "after\n", "utf8");
+    assert.notEqual(traySourceFingerprint(fakeRoot, "darwin"), before);
+  } finally {
+    rmSync(fakeRoot, { recursive: true, force: true });
+  }
+});
+
 test("one companion location: the Node and shell sides name the same directory", () => {
   // Three copies of this path drifted apart before -- paths.mjs, the build
   // script default, and trayBundleDir -- which is how a machine ends up with a


### PR DESCRIPTION
## Summary

- make macOS tray builds select a usable full Xcode toolchain instead of accepting standalone Command Line Tools
- honor an explicit `DEVELOPER_DIR`, then the active full Xcode selection, then standard stable/beta Xcode locations
- keep the selection scoped to the child build without changing the user's global `xcode-select` setting
- document the full-Xcode requirement and include the resolver in tray source fingerprints
- isolate the Control Center session-index test from a developer's real `DSH_HOME`

## Problem

On macOS 27 beta, guided installation with `--with-tray` could invoke Swift from `/Library/Developer/CommandLineTools` even when the full Xcode beta app was installed.

The standalone tools include `swift`, so the previous preflight passed, but they do not include the SwiftUI platform macro plug-in or the `xcodebuild` needed by the bundled WidgetKit extension. The first useful Swift diagnostic is:

```text
external macro implementation type 'SwiftUIMacros.StateMacro'
could not be found for macro 'State()';
plugin for module 'SwiftUIMacros' not found
```

That failed `@State` expansion then produces misleading cascades such as `cannot find '$state' in scope` and `self is immutable` throughout `ModelRouterTrayApp.swift`.

The existing setup preflight only checked `xcrun --find swift`, so it could not distinguish standalone Command Line Tools from a full Xcode installation and suggested installing more Command Line Tools for a failure they cannot fix.

## Solution

The new resolver:

1. uses an explicit `DEVELOPER_DIR` when it provides `xcodebuild`;
2. otherwise keeps the active `xcode-select` directory when it is full Xcode;
3. otherwise tries `/Applications/Xcode.app/Contents/Developer` and `/Applications/Xcode-beta.app/Contents/Developer`;
4. fails with an actionable full-Xcode message when none is usable.

An explicitly invalid `DEVELOPER_DIR` fails closed rather than silently selecting a different toolchain. Automatic fallback is exported only inside the tray build process and does not mutate machine-wide developer-tool settings.

The resolver is part of the Darwin tray fingerprint, so changes to toolchain-selection behavior invalidate an installed bundle as expected.

During full bundle validation, the Control Center test suite exposed an independent fixture leak: the shared session-count test isolated Codex and Cursor homes but still read the developer's real `~/.dsh`. The second commit scopes `DSH_HOME` to the same temporary fixture root and restores it in cleanup.

## Validation

- reproduced the SwiftUI macro failure with standalone Command Line Tools
- confirmed the same minimal SwiftUI `@State` probe succeeds with Xcode 27 beta
- confirmed the resolver selects Xcode-beta while global `xcode-select` still points to `/Library/Developer/CommandLineTools`
- `node --test test/macos-developer-tools.test.mjs test/control-center-harness.test.mjs test/tray-install.test.mjs test/tray-rebuild.test.mjs` — 85 passed
- `swift test --package-path apps/macos/ModelRouterTray` — 116 passed
- complete macOS companion bundle build — Swift release build passed, WidgetKit reported `BUILD SUCCEEDED`, and `codesign --verify --deep --strict` passed
- `npm run check` — passed
- `npm test` — 3,589 passed, 27 platform/integration skips, 0 failed
- `git diff --check origin/main...HEAD` — passed

## Commits

- `fix(macos): select full Xcode for tray builds`
- `test(control-center): isolate DSH session fixtures`
