### PR TITLE
fix: run macOS KeepAlive as launchd Standard, not Adaptive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **macOS KeepAlive no longer uses launchd `Adaptive`, which starved startup.**
+  Adaptive only boosts on XPC transactions; the router is localhost HTTP, so
+  the job stayed at Background. Node OAuth/API forwarders then missed the 30s
+  health budget, `KeepAlive` restart-looped, and tray Update / doctor --fix
+  waited 300s on `/health` and rolled the checkout back. The LaunchAgent now
+  renders `ProcessType=Standard`. Do not revert to `Background` (LiteLLM
+  starved to ~4% CPU in `fb40f8c`).
+
 - **Routed reasoning models no longer leak `<think>` chains into the visible
   answer.** Qwen (and other reasoning models bridged through LiteLLM's
   chat-completions path) sometimes emit their chain-of-thought inline in the

--- a/src/service-macos.mjs
+++ b/src/service-macos.mjs
@@ -105,6 +105,11 @@ function environmentEntries() {
 
 function plist() {
   const start = path.join(SOURCE_ROOT, "src", "start.mjs");
+  // Background starved LiteLLM to ~4% CPU (fb40f8c). Adaptive was meant to
+  // boost under load, but it only does so on XPC transactions; this job is
+  // localhost HTTP, so Adaptive stays at Background. Node forwarders then miss
+  // the 30s OAuth health budget, KeepAlive crash-loops, and tray Update /
+  // doctor --fix wait 300s on /health. Standard is a normal user-agent class.
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -127,7 +132,7 @@ ${environmentEntries()}
   <key>KeepAlive</key>
   <true/>
   <key>ProcessType</key>
-  <string>Adaptive</string>
+  <string>Standard</string>
   <key>ThrottleInterval</key>
   <integer>10</integer>
   <key>StandardOutPath</key>

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -119,6 +119,11 @@ test("background service definitions render for macOS, Linux, and Windows", () =
     assert.match(launchd, /<string>io\.github\.codex-router<\/string>/);
     assert.match(launchd, /<key>PATH<\/key>/);
     assert.match(launchd, /CODEX_ROUTER_STATE_DIR/);
+    // Background starves LiteLLM; Adaptive is a no-op without XPC and starves
+    // Node forwarders past the 30s OAuth health budget. Keep Standard.
+    assert.match(launchd, /<key>ProcessType<\/key>\s*<string>Standard<\/string>/);
+    assert.doesNotMatch(launchd, /<key>ProcessType<\/key>\s*<string>Adaptive<\/string>/);
+    assert.doesNotMatch(launchd, /<key>ProcessType<\/key>\s*<string>Background<\/string>/);
 
     const systemd = render("service-linux.mjs", "linux", testRoot);
     assert.match(systemd, /\[Service\]/);


### PR DESCRIPTION
## Why

`fb40f8c` moved the macOS LaunchAgent from `Background` to `Adaptive` because Background starved LiteLLM to ~4% CPU and blew the (then 30s) gateway health window.

Adaptive only boosts to Interactive on **XPC transactions**. This job is localhost HTTP (`127.0.0.1:4202`), not an XPC daemon, so Adaptive stays at Background.

Under load (tray Update compiling Swift, Control Center, Codex), Node OAuth/API/Grok forwarders stay in V8 init and never bind `:4201` / `:4203` / `:4208`. `start.mjs` fails the **30s** OAuth health budget:

```
[model-router] startup failed: Timed out waiting for OAuth forwarder to become healthy (the connection was refused).
```

`KeepAlive` restart-loops. Tray Update / `doctor --fix` wait up to 300s on `/health`, hold `service-operation.lock`, then roll the git checkout back.

Isolated `oauth-forwarder` binds in ~0.3s. The same binary under Adaptive may not bind in 30s. Setting the live plist to `Standard` recovered a machine: `/health` ok in 9–13s, `runs=1`.

## What

- Render `ProcessType=Standard` from `src/service-macos.mjs`.
- Comment why `Background` and `Adaptive` are both wrong for this job.
- Changelog note. Do not extend the 30s OAuth budget (that only slows the crash loop).

## Tests

`node --test test/service-render.test.mjs` — 23 passed, 1 skipped.

The macOS render test now requires `ProcessType=Standard` and rejects `Adaptive` / `Background`.

Fixes #608