### PR TITLE
fix(grok-oauth): keep post-tool repair streams live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
   waited 300s on `/health` and rolled the checkout back. The LaunchAgent now
   renders `ProcessType=Standard`. Do not revert to `Background` (LiteLLM
   starved to ~4% CPU in `fb40f8c`).
+- **Grok OAuth post-tool turns no longer stay silent while their repair is
+  certified.** The forwarder now opens a streamed Chat Completions response as
+  soon as xAI returns its headers and relays reasoning immediately, while still
+  withholding the short visible sentence that may be a progress-only stop.
+  A certified retry supplies the final answer or tool call; an invalid repair
+  ends the already-open stream with one terminal error and never emits
+  `[DONE]`. Retry and failure logs now include per-attempt header, first-event,
+  and total timings plus the safe `x-grok-req-id`, so upstream silence can be
+  distinguished from router-side staging without logging prompt or output.
 
 - **Routed reasoning models no longer leak `<think>` chains into the visible
   answer.** Qwen (and other reasoning models bridged through LiteLLM's

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -329,7 +329,9 @@ emits a status sentence, and never calls a tool. On turns following a user
 message, attempt 1 still streams live; when the client offered tools and the
 short-text/token trigger fires, the forwarder retries once and appends a
 retry tool call onto the same stream. On turns following a tool result, the
-stricter certified-repair path below stages the response before sending it.
+stricter certified-repair path opens the response as soon as xAI returns its
+headers and relays reasoning, but stages the short visible answer until the
+terminal event proves it is safe.
 After a conversation has exhibited that shape once, later user-message turns
 buffer only a short visible prefix up to the same text threshold. Headers and
 preceding reasoning remain live, and a tool call or longer answer releases the
@@ -356,7 +358,13 @@ Both attempts are billed. The usage returned to Codex reports only the
 selected attempt's context size, while the local ledger retains the aggregate
 as billed input/output tokens. The response sets
 `progress_only_retried: true`, and the log line `progress-only-retried=true`
-is never gated on `MODEL_ROUTER_QUIET`. To disable the invariant and see the
+is never gated on `MODEL_ROUTER_QUIET`. That line includes `attempt_*` and
+`repair_*` header, first-event, and total durations plus each request's
+`x-grok-req-id`. A failure while reading either stream emits
+`upstream-phase-failed=true` with the same safe fields. `headers_ms` shows how
+long xAI took to accept the request; `first_event_ms` separates an upstream
+that emitted nothing from output the forwarder deliberately withheld. Prompt
+and response content are never logged. To disable the invariant and see the
 raw first attempt, set `CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY=0`; this kill
 switch is intentionally unsafe for unattended tool loops.
 

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -645,6 +645,7 @@ async function handleChatCompletions(request, response) {
     toolNameMapper: (name) => toolNameForCodex(name, { viewImageAlias }),
   });
   let emittedDeltaCount = 0;
+  const heldStrictContentDeltas = [];
   let streamStarted = false;
 
   const startStream = () => {
@@ -658,15 +659,38 @@ async function handleChatCompletions(request, response) {
   };
 
   // A post-tool turn can only be classified after its terminal event. Open the
-  // SSE response immediately, but hold its short visible text so Codex sees
-  // liveness and reasoning without accepting an uncertified progress sentence.
+  // SSE response immediately, but hold all visible text so Codex sees liveness
+  // and reasoning without accepting an uncertified progress sentence.
   // Once the head is committed, a failed repair becomes one terminal SSE error.
   if (wantsStream) startStream();
+
+  const emitHeldStrictContent = () => {
+    if (!wantsStream || !streamStarted || heldStrictContentDeltas.length === 0) return;
+    for (const delta of heldStrictContentDeltas) {
+      response.write(OPENAI_ROLE_CHUNK(id, created, model, delta));
+    }
+    heldStrictContentDeltas.length = 0;
+  };
 
   const emitPendingDeltas = () => {
     if (!wantsStream || !streamStarted) return;
     while (emittedDeltaCount < turnState.deltas.length) {
       const delta = turnState.deltas[emittedDeltaCount];
+      if (
+        strictAfterToolRepair &&
+        Object.hasOwn(delta, "content") &&
+        turnState.toolCalls.length === 0
+      ) {
+        heldStrictContentDeltas.push(delta);
+        emittedDeltaCount += 1;
+        continue;
+      }
+      // A client tool call certifies attempt 1 as actionable. Release any
+      // earlier prose before its tool delta so the original event order stays
+      // intact; a no-tool attempt remains held through terminal classification.
+      if (strictAfterToolRepair && turnState.toolCalls.length > 0) {
+        emitHeldStrictContent();
+      }
       if (
         bufferShortProgress &&
         Object.hasOwn(delta, "content") &&
@@ -853,6 +877,7 @@ async function handleChatCompletions(request, response) {
     startStream();
     if (wasStarted && !strictRepairOutputEmitted) {
       emitPendingDeltas();
+      emitHeldStrictContent();
     } else if (!wasStarted) {
       for (const delta of turn.deltas || []) {
         response.write(OPENAI_ROLE_CHUNK(id, created, model, delta));

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -444,7 +444,7 @@ function conversationId(messages) {
   ].join("-");
 }
 
-function upstreamHeaders(accessToken, model, messages) {
+function upstreamHeaders(accessToken, model, messages, requestId = randomUUID()) {
   const sessionId = conversationId(messages);
   return {
     Authorization: `Bearer ${accessToken}`,
@@ -456,13 +456,31 @@ function upstreamHeaders(accessToken, model, messages) {
     "x-grok-client-identifier": "grok-shell",
     "x-grok-client-mode": "headless",
     "x-grok-conv-id": sessionId,
-    "x-grok-req-id": randomUUID(),
+    "x-grok-req-id": requestId,
     "x-grok-model-override": model,
     "x-grok-session-id": sessionId,
     "x-grok-agent-id": randomUUID(),
     "x-grok-turn-idx": "1",
     "User-Agent": grokUserAgent(),
   };
+}
+
+function upstreamAttemptTiming(label, attempt, endedAt = Date.now()) {
+  if (!attempt) return "";
+  const sinceStart = (value) =>
+    Number.isFinite(value) ? Math.max(0, value - attempt.startedAt) : "none";
+  return [
+    `${label}_req=${attempt.requestId}`,
+    `${label}_headers_ms=${sinceStart(attempt.headersAt)}`,
+    `${label}_first_event_ms=${sinceStart(attempt.firstEventAt)}`,
+    `${label}_total_ms=${sinceStart(attempt.endedAt ?? endedAt)}`,
+  ].join(" ");
+}
+
+function logUpstreamPhaseFailure(label, model, attempt, error) {
+  console.error(
+    `[grok-oauth] upstream-phase-failed=true phase=${label} model=${model} ${upstreamAttemptTiming(label, attempt)} error=${error?.name || "Error"}`,
+  );
 }
 
 // Parse the upstream Responses SSE and invoke callbacks per normalized event.
@@ -532,8 +550,7 @@ async function handleChatCompletions(request, response) {
   let bufferShortProgress =
     wantsStream &&
     mayRetry &&
-    !strictAfterToolRepair &&
-    progressOnlyConversations.has(conversationKey);
+    (strictAfterToolRepair || progressOnlyConversations.has(conversationKey));
 
   const controller = new AbortController();
   request.once("aborted", () => controller.abort());
@@ -541,12 +558,32 @@ async function handleChatCompletions(request, response) {
     if (!response.writableEnded) controller.abort();
   });
 
-  const requestUpstream = (accessToken, body) => fetch(`${GROK_BASE}/responses`, {
-    method: "POST",
-    headers: upstreamHeaders(accessToken, model, chat?.messages),
-    body: JSON.stringify(body),
-    signal: controller.signal,
-  });
+  const requestUpstream = async (accessToken, body) => {
+    const attempt = {
+      requestId: randomUUID(),
+      startedAt: Date.now(),
+    };
+    try {
+      attempt.response = await fetch(`${GROK_BASE}/responses`, {
+        method: "POST",
+        headers: upstreamHeaders(accessToken, model, chat?.messages, attempt.requestId),
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+      attempt.headersAt = Date.now();
+      return attempt;
+    } catch (error) {
+      attempt.endedAt = Date.now();
+      if (error && typeof error === "object") {
+        try {
+          error.grokUpstreamAttempt = attempt;
+        } catch {
+          // A non-extensible transport error still keeps its original cause.
+        }
+      }
+      throw error;
+    }
+  };
   let accessToken;
   try {
     accessToken = await ensureFreshGrokOAuthToken();
@@ -560,12 +597,20 @@ async function handleChatCompletions(request, response) {
     });
     return;
   }
-  let upstream = await requestUpstream(accessToken, responsesRequest);
+  let firstAttempt;
+  try {
+    firstAttempt = await requestUpstream(accessToken, responsesRequest);
+  } catch (error) {
+    logUpstreamPhaseFailure("attempt", model, error?.grokUpstreamAttempt, error);
+    throw error;
+  }
+  let upstream = firstAttempt.response;
   if (upstream.status === 401) {
     await upstream.arrayBuffer();
     try {
       accessToken = await ensureFreshGrokOAuthToken({ force: true });
-      upstream = await requestUpstream(accessToken, responsesRequest);
+      firstAttempt = await requestUpstream(accessToken, responsesRequest);
+      upstream = firstAttempt.response;
     } catch {
       writeJson(response, 401, {
         error: {
@@ -612,10 +657,11 @@ async function handleChatCompletions(request, response) {
     streamStarted = true;
   };
 
-  // A post-tool turn can only be classified after its terminal event. Hold it
-  // so an invalid repair can still become an HTTP error instead of a 200 that
-  // Codex records as completed. Ordinary turns keep their live streaming.
-  if (wantsStream && !strictAfterToolRepair) startStream();
+  // A post-tool turn can only be classified after its terminal event. Open the
+  // SSE response immediately, but hold its short visible text so Codex sees
+  // liveness and reasoning without accepting an uncertified progress sentence.
+  // Once the head is committed, a failed repair becomes one terminal SSE error.
+  if (wantsStream) startStream();
 
   const emitPendingDeltas = () => {
     if (!wantsStream || !streamStarted) return;
@@ -636,15 +682,25 @@ async function handleChatCompletions(request, response) {
     }
   };
 
-  await consumeResponsesStream(upstream.body, (event) => {
-    applyResponsesEvent(turnState, event);
-    emitPendingDeltas();
-  });
+  try {
+    await consumeResponsesStream(upstream.body, (event) => {
+      firstAttempt.firstEventAt ??= Date.now();
+      applyResponsesEvent(turnState, event);
+      emitPendingDeltas();
+    });
+    firstAttempt.endedAt = Date.now();
+  } catch (error) {
+    firstAttempt.endedAt = Date.now();
+    logUpstreamPhaseFailure("attempt", model, firstAttempt, error);
+    throw error;
+  }
 
   let turn = finalizeTurn(turnState);
   emitPendingDeltas();
   let retried = false;
   let repairFailure;
+  let repairAttempt;
+  let strictRepairOutputEmitted = false;
 
   const progressOnly = isProgressOnlyStop(turn, { ...holdOptions, afterToolResult });
   if (progressOnly) rememberProgressOnlyConversation(conversationKey);
@@ -659,17 +715,20 @@ async function handleChatCompletions(request, response) {
     const retryRequest = toResponsesRequest(retryChat, { hostedSearchEnabled });
     let secondUpstream;
     try {
-      secondUpstream = await requestUpstream(accessToken, retryRequest);
+      repairAttempt = await requestUpstream(accessToken, retryRequest);
+      secondUpstream = repairAttempt.response;
     } catch (error) {
+      repairAttempt = error?.grokUpstreamAttempt;
       console.error(
-        `[grok-oauth] progress-only-retry-failed=true model=${model} error=${error?.name || "Error"}`,
+        `[grok-oauth] progress-only-retry-failed=true model=${model} ${upstreamAttemptTiming("repair", repairAttempt)} error=${error?.name || "Error"}`,
       );
       secondUpstream = undefined;
     }
     if (secondUpstream && (!secondUpstream.ok || !secondUpstream.body)) {
       await drainUpstreamBody(secondUpstream.body);
+      repairAttempt.endedAt = Date.now();
       console.error(
-        `[grok-oauth] progress-only-retry-failed=true model=${model} status=${secondUpstream.status}`,
+        `[grok-oauth] progress-only-retry-failed=true model=${model} status=${secondUpstream.status} ${upstreamAttemptTiming("repair", repairAttempt)}`,
       );
       if (strictAfterToolRepair) {
         repairFailure = {
@@ -681,25 +740,46 @@ async function handleChatCompletions(request, response) {
       const secondState = createTurnState({
         toolNameMapper: (name) => toolNameForCodex(name, { viewImageAlias }),
       });
-      await consumeResponsesStream(secondUpstream.body, (event) => {
-        applyResponsesEvent(secondState, event);
-      });
+      let emittedRepairDeltaCount = 0;
+      try {
+        await consumeResponsesStream(secondUpstream.body, (event) => {
+          repairAttempt.firstEventAt ??= Date.now();
+          applyResponsesEvent(secondState, event);
+          if (wantsStream && streamStarted && strictAfterToolRepair) {
+            while (emittedRepairDeltaCount < secondState.deltas.length) {
+              const delta = secondState.deltas[emittedRepairDeltaCount];
+              if (Object.hasOwn(delta, "reasoning_content")) {
+                response.write(OPENAI_ROLE_CHUNK(id, created, model, delta));
+              }
+              emittedRepairDeltaCount += 1;
+            }
+          }
+        });
+        repairAttempt.endedAt = Date.now();
+      } catch (error) {
+        repairAttempt.endedAt = Date.now();
+        logUpstreamPhaseFailure("repair", model, repairAttempt, error);
+        throw error;
+      }
       const second = finalizeTurn(secondState);
       retried = true;
       const repair = strictAfterToolRepair
         ? classifyAfterToolRepair(second)
         : { action: shouldPreferRetryTurn(second) ? "tools" : "first" };
       console.error(
-        `[grok-oauth] progress-only-retried=true retries=1 model=${model} prefer=${repair.action}`,
+        `[grok-oauth] progress-only-retried=true retries=1 model=${model} prefer=${repair.action} ${upstreamAttemptTiming("attempt", firstAttempt)} ${upstreamAttemptTiming("repair", repairAttempt)}`,
       );
       if (repair.action === "tools") {
         const usage = strictAfterToolRepair
           ? selectedRetryUsage(turn.usage, second.usage)
           : mergeMappedUsage(turn.usage, second.usage);
         if (wantsStream && streamStarted) {
+          // The repair stayed reasoning-only on the wire until certification.
+          // Its tool deltas are now safe and are emitted exactly once here.
           for (const delta of toolCallDeltas(second)) {
             response.write(OPENAI_ROLE_CHUNK(id, created, model, delta));
           }
+          strictRepairOutputEmitted = strictAfterToolRepair;
         }
         turn = {
           contentText: strictAfterToolRepair ? "" : turn.contentText,
@@ -713,6 +793,12 @@ async function handleChatCompletions(request, response) {
         };
         if (streamStarted) emittedDeltaCount = turn.deltas.length;
       } else if (repair.action === "final") {
+        if (wantsStream && streamStarted && strictAfterToolRepair) {
+          response.write(
+            OPENAI_ROLE_CHUNK(id, created, model, { content: repair.contentText }),
+          );
+          strictRepairOutputEmitted = true;
+        }
         turn = {
           contentText: repair.contentText,
           reasoningText: second.reasoningText,
@@ -741,8 +827,12 @@ async function handleChatCompletions(request, response) {
 
   if (repairFailure) {
     console.error(
-      `[grok-oauth] progress-only-unrepairable=true model=${model} code=${repairFailure.code}`,
+      `[grok-oauth] progress-only-unrepairable=true model=${model} code=${repairFailure.code} ${upstreamAttemptTiming("attempt", firstAttempt)} ${upstreamAttemptTiming("repair", repairAttempt)}`,
     );
+    if (wantsStream && streamStarted) {
+      endStreamedResponse(response, { message: repairFailure.message });
+      return;
+    }
     writeJson(response, 502, {
       error: {
         message: repairFailure.message,
@@ -761,9 +851,9 @@ async function handleChatCompletions(request, response) {
   if (wantsStream) {
     const wasStarted = streamStarted;
     startStream();
-    if (wasStarted) {
+    if (wasStarted && !strictRepairOutputEmitted) {
       emitPendingDeltas();
-    } else {
+    } else if (!wasStarted) {
       for (const delta of turn.deltas || []) {
         response.write(OPENAI_ROLE_CHUNK(id, created, model, delta));
       }

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -321,6 +321,7 @@ export class ResponseUsageTransform extends Transform {
   // a fast model read as slow. See #192.
   #firstTokenAt;
   #completedResponseObserved = false;
+  #terminalErrorObserved = false;
 
   // `estimatedInputTokens` arrives only on routed requests large enough that a
   // reported zero cannot be true. Without it this transform observes and
@@ -511,6 +512,7 @@ export class ResponseUsageTransform extends Transform {
     if (!data || data === "[DONE]") return undefined;
     try {
       const payload = JSON.parse(data);
+      if (payload?.type === "error") this.#terminalErrorObserved = true;
       this.#observe(payload);
       return payload;
     } catch {
@@ -553,5 +555,9 @@ export class ResponseUsageTransform extends Transform {
 
   completedResponseObserved() {
     return this.#completedResponseObserved;
+  }
+
+  terminalErrorObserved() {
+    return this.#terminalErrorObserved;
   }
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -4121,6 +4121,16 @@ async function handleResponses(request, response, requestUrl) {
       (clientGone || (response.destroyed && !response.writableFinished)) &&
       !nativeCompletedBeforeClose;
     finalStatus = clientWalkedAway ? 0 : upstream.status;
+    if (
+      !clientWalkedAway &&
+      route?.provider === "grok-oauth" &&
+      usageTransform?.terminalErrorObserved?.() === true
+    ) {
+      // The Grok forwarder has already committed the HTTP 200 SSE head when a
+      // post-tool repair can fail. Keep the client-visible terminal event, but
+      // account for the turn as a provider failure rather than a success.
+      finalStatus = 502;
+    }
     if (streamedPreludeFailureKind && !clientWalkedAway) finalStatus = 502;
     emptyCompletion = emptyCompletionGuard?.isEmpty() === true && !clientWalkedAway;
     emptyCompletionPreludeLimit ||=

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -1197,6 +1197,8 @@ test("a short stop after a tool result is nudged to continue, regardless of word
 
 test("opens a post-tool stream before classification while holding uncertified text", async () => {
   let inbound = 0;
+  const uncertifiedProgress = "I will inspect the figure next. ".repeat(8);
+  assert.ok(uncertifiedProgress.length > 120);
   let releaseFirstAttempt;
   const firstAttemptGate = new Promise((resolve) => {
     releaseFirstAttempt = resolve;
@@ -1209,7 +1211,7 @@ test("opens a post-tool stream before classification while holding uncertified t
       res.write(
         sse([
           { type: "response.reasoning_summary_text.delta", delta: "Checking the tool result." },
-          { type: "response.output_text.delta", delta: "I will inspect the figure next." },
+          { type: "response.output_text.delta", delta: uncertifiedProgress },
         ]),
       );
       await firstAttemptGate;

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -328,6 +328,10 @@ test("emits one terminal SSE error when the upstream stream fails mid-turn", asy
     assert.equal((result.body.match(/event: error/g) || []).length, 1);
     assert.match(result.body, /local_router_stream_failed/);
     assert.doesNotMatch(result.body, /data: \[DONE\]/);
+    assert.match(
+      child.testErrors(),
+      /upstream-phase-failed=true phase=attempt model=grok-4\.6 attempt_req=[0-9a-f-]{36} attempt_headers_ms=\d+ attempt_first_event_ms=\d+ attempt_total_ms=\d+ error=(?:TypeError|AbortError)/,
+    );
   } finally {
     await stop(child);
     await new Promise((r) => backend.server.close(r));
@@ -1180,6 +1184,178 @@ test("a short stop after a tool result is nudged to continue, regardless of word
   }
 });
 
+test("opens a post-tool stream before classification while holding uncertified text", async () => {
+  let inbound = 0;
+  let releaseFirstAttempt;
+  const firstAttemptGate = new Promise((resolve) => {
+    releaseFirstAttempt = resolve;
+  });
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    if (inbound === 1) {
+      res.flushHeaders();
+      res.write(
+        sse([
+          { type: "response.reasoning_summary_text.delta", delta: "Checking the tool result." },
+          { type: "response.output_text.delta", delta: "I will inspect the figure next." },
+        ]),
+      );
+      await firstAttemptGate;
+      res.end(
+        sse([
+          { type: "response.completed", response: { usage: { input_tokens: 150_000, output_tokens: 180 } } },
+        ]),
+      );
+      return;
+    }
+    res.end(
+      sse([
+        { type: "response.reasoning_summary_text.delta", delta: "Certifying the final answer." },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_final",
+            call_id: "call_final",
+            name: "__codex_router_submit_final",
+            arguments: JSON.stringify({ answer: "The chart axis is months." }),
+          },
+        },
+        { type: "response.completed", response: { usage: { input_tokens: 151_000, output_tokens: 90 } } },
+      ]),
+    );
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-post-tool-live-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  try {
+    await waitHealth(`http://127.0.0.1:${port}`, child);
+    let responseTimeout;
+    const resp = await Promise.race([
+      fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+        method: "POST",
+        headers: auth,
+        body: JSON.stringify({
+          model: "grok-4.6",
+          messages: [
+            { role: "assistant", tool_calls: [{ id: "c1", type: "function", function: { name: "exec_command", arguments: "{}" } }] },
+            { role: "tool", tool_call_id: "c1", content: "rendered page" },
+          ],
+          tools: [{ type: "function", function: { name: "view_image", parameters: { type: "object" } } }],
+          stream: true,
+        }),
+      }),
+      new Promise((_, reject) => {
+        responseTimeout = setTimeout(
+          () => reject(new Error("post-tool response head stayed buffered")),
+          2_000,
+        );
+      }),
+    ]);
+    clearTimeout(responseTimeout);
+    assert.equal(resp.status, 200);
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let body = "";
+    let reasoningTimeout;
+    await Promise.race([
+      (async () => {
+        while (!body.includes("Checking the tool result.")) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          body += decoder.decode(value, { stream: true });
+        }
+      })(),
+      new Promise((_, reject) => {
+        reasoningTimeout = setTimeout(
+          () => reject(new Error("post-tool reasoning stayed buffered")),
+          2_000,
+        );
+      }),
+    ]);
+    clearTimeout(reasoningTimeout);
+    assert.match(body, /"role":"assistant"/);
+    assert.match(body, /"reasoning_content":"Checking the tool result\."/);
+    assert.doesNotMatch(body, /I will inspect the figure next/);
+
+    releaseFirstAttempt();
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      body += decoder.decode(value, { stream: true });
+    }
+    assert.equal(inbound, 2);
+    assert.doesNotMatch(body, /I will inspect the figure next/);
+    assert.match(body, /"reasoning_content":"Certifying the final answer\."/);
+    assert.match(body, /"content":"The chart axis is months\."/);
+    assert.doesNotMatch(body, /__codex_router_submit_final/);
+    assert.match(body, /data: \[DONE\]/);
+    assert.match(
+      child.testErrors(),
+      /progress-only-retried=true retries=1 model=grok-4\.6 prefer=final attempt_req=[0-9a-f-]{36} attempt_headers_ms=\d+ attempt_first_event_ms=\d+ attempt_total_ms=\d+ repair_req=[0-9a-f-]{36} repair_headers_ms=\d+ repair_first_event_ms=\d+ repair_total_ms=\d+/,
+    );
+  } finally {
+    releaseFirstAttempt?.();
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a streamed post-tool repair exposes reasoning and only the certified tool call", async () => {
+  let inbound = 0;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(
+      sse(
+        inbound === 1
+          ? [
+              { type: "response.output_text.delta", delta: "I will inspect the figure next." },
+              { type: "response.completed", response: { usage: { input_tokens: 150_000, output_tokens: 180 } } },
+            ]
+          : [
+              { type: "response.reasoning_summary_text.delta", delta: "Selecting the next tool." },
+              ...TOOL_EVENTS,
+            ],
+      ),
+    );
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-post-tool-live-call-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  try {
+    await waitHealth(`http://127.0.0.1:${port}`, child);
+    const resp = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [
+          { role: "assistant", tool_calls: [{ id: "c1", type: "function", function: { name: "exec_command", arguments: "{}" } }] },
+          { role: "tool", tool_call_id: "c1", content: "rendered page" },
+        ],
+        tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+        stream: true,
+      }),
+    });
+    const body = await readAll(resp);
+    assert.equal(resp.status, 200);
+    assert.equal(inbound, 2);
+    assert.doesNotMatch(body, /I will inspect the figure next/);
+    assert.match(body, /"reasoning_content":"Selecting the next tool\."/);
+    assert.match(body, /"name":"exec_command"/);
+    assert.match(body, /"finish_reason":"tool_calls"/);
+    assert.match(body, /data: \[DONE\]/);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("after-tool retry returns a certified final answer without leaking the internal tool", async () => {
   let inbound = 0;
   const backend = await mockBackend(async (_req, res) => {
@@ -1241,7 +1417,7 @@ test("after-tool retry returns a certified final answer without leaking the inte
   }
 });
 
-test("double-empty after a tool result is an explicit 502, never a clean stop", async () => {
+test("double-empty after a tool result is an explicit terminal error, never a clean stop", async () => {
   let inbound = 0;
   const backend = await mockBackend(async (_req, res) => {
     inbound += 1;
@@ -1274,10 +1450,18 @@ test("double-empty after a tool result is an explicit 502, never a clean stop", 
         }),
       });
       const body = await resp.text();
-      assert.equal(resp.status, 502);
       assert.equal(inbound, 2);
-      assert.match(body, /progress_only_unrepairable/);
-      assert.doesNotMatch(body, /finish_reason|\[DONE\]/);
+      if (stream) {
+        assert.equal(resp.status, 200);
+        assert.equal((body.match(/event: error/g) || []).length, 1);
+        assert.match(body, /local_router_stream_failed/);
+        assert.match(body, /Grok stopped after a tool result/);
+        assert.doesNotMatch(body, /"finish_reason":"(?:stop|tool_calls)"|\[DONE\]/);
+      } else {
+        assert.equal(resp.status, 502);
+        assert.match(body, /progress_only_unrepairable/);
+        assert.doesNotMatch(body, /finish_reason|\[DONE\]/);
+      }
     }
   } finally {
     await stop(child);

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -68,6 +68,17 @@ async function waitHealth(base, child) {
   throw new Error(`health timeout: ${child.testErrors()}`);
 }
 
+async function waitChildError(child, pattern, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const errors = child.testErrors();
+    if (pattern.test(errors)) return errors;
+    if (child.exitCode !== null) throw new Error(`exited before log marker: ${errors}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`stderr marker timeout: ${child.testErrors()}`);
+}
+
 async function stop(child) {
   if (child.exitCode !== null) return;
   child.kill("SIGTERM");
@@ -1292,8 +1303,8 @@ test("opens a post-tool stream before classification while holding uncertified t
     assert.match(body, /"content":"The chart axis is months\."/);
     assert.doesNotMatch(body, /__codex_router_submit_final/);
     assert.match(body, /data: \[DONE\]/);
-    assert.match(
-      child.testErrors(),
+    await waitChildError(
+      child,
       /progress-only-retried=true retries=1 model=grok-4\.6 prefer=final attempt_req=[0-9a-f-]{36} attempt_headers_ms=\d+ attempt_first_event_ms=\d+ attempt_total_ms=\d+ repair_req=[0-9a-f-]{36} repair_headers_ms=\d+ repair_first_event_ms=\d+ repair_total_ms=\d+/,
     );
   } finally {

--- a/test/response-usage.test.mjs
+++ b/test/response-usage.test.mjs
@@ -390,6 +390,17 @@ test("a response with no estimate behind it is forwarded untouched", async () =>
   assert.equal(transform.substitutedInputTokens(), undefined);
 });
 
+test("observes a terminal SSE error without rewriting the stream", async () => {
+  const body = [
+    'event: error\n',
+    'data: {"type":"error","code":"local_router_stream_failed","message":"repair failed"}\n\n',
+  ];
+  const transform = new ResponseUsageTransform("text/event-stream");
+  assert.equal(await passThrough(transform, body), body.join(""));
+  assert.equal(transform.terminalErrorObserved(), true);
+  assert.equal(transform.completedResponseObserved(), false);
+});
+
 test("bytes the router is not rewriting survive rewrite mode exactly", async () => {
   // Only the one substituted line is re-encoded. Everything else -- including a
   // byte sequence that is not valid UTF-8 at all -- has to leave as it arrived,

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -864,6 +864,62 @@ test("a routed Grok 502 terminates a streamed turn with one SSE error", async ()
   }
 });
 
+test("a routed Grok terminal SSE error is recorded as a failed turn", async () => {
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(
+      [
+        'event: response.reasoning_summary_text.delta\n',
+        'data: {"type":"response.reasoning_summary_text.delta","delta":"Checking the tool result."}\n\n',
+        'event: error\n',
+        'data: {"type":"error","code":"local_router_stream_failed","message":"Grok stopped after a tool result and its repair request failed upstream.","param":null}\n\n',
+      ].join(""),
+    );
+  });
+  const routerPort = await openPort();
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-grok-terminal-error-"));
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "grok-oauth/grok-4.6",
+        input: "continue after the tool result",
+        stream: true,
+      }),
+    });
+    const body = await response.text();
+    assert.equal(response.status, 200, body);
+    assert.equal((body.match(/event: error/g) || []).length, 1);
+    assert.match(body, /local_router_stream_failed/);
+
+    const event = await waitForUsageEvent(
+      stateDir,
+      (candidate) => candidate.model === "grok-oauth/grok-4.6",
+      router,
+    );
+    assert.equal(event.provider, "grok-oauth");
+    assert.equal(event.status, 502);
+    assert.equal("streamAborted" in event, false);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
 test("router dispatches aliased native slugs to the mapped external model", async () => {
   const gatewayRequests = [];
   const gateway = await mockServer(async (request, response) => {

--- a/test/service-readiness.test.mjs
+++ b/test/service-readiness.test.mjs
@@ -127,7 +127,9 @@ test("brief Task Scheduler launch lag does not reject a healthy start", async ()
   const health = await waitForServiceReadiness({
     platform: "win32",
     timeoutMs: 1_000,
-    launchGraceMs: 25,
+    // Leave a real scheduling margin between the healthy response and the
+    // dead-task verdict. Loaded Windows runners can coalesce 25ms/30ms timers.
+    launchGraceMs: 100,
     pollMs: 10,
     getWindowsTaskState: () => ({
       instanceCount: 0,


### PR DESCRIPTION
## Summary

- open strict Grok OAuth post-tool streams as soon as xAI returns response headers
- relay reasoning live while withholding only the short visible answer that still needs progress-only certification
- emit the certified retry's final answer or tool call exactly once, and terminate an invalid repair with one SSE error instead of a clean completion
- add safe per-attempt `headers_ms`, `first_event_ms`, and `total_ms` diagnostics keyed by the existing `x-grok-req-id`

## Why

The strict post-tool repair path buffered the complete first xAI Responses stream and, when it looked progress-only, the complete repair stream before sending any Chat Completions bytes to LiteLLM. On a large high-reasoning turn, those two sequential attempts could outlive Codex's roughly 300-second no-response window. The caller then canceled the request and usage recorded status `0`, even when xAI had already emitted reasoning that the forwarder was holding.

This is separate from #602: that change converts a final Grok gateway 5xx into terminal SSE. Here the upstream request is accepted and the client cancels while the forwarder is still staging a post-tool repair.

The fix preserves the post-tool correctness invariant. A short visible progress sentence is still never accepted as the completed task, and the internal final-answer tool never crosses the provider boundary.

## Verification

- `node --test test/grok-oauth-forwarder.test.mjs` — 36/36 passed
- `npm run check` — passed
- synthetic end-to-end through the installed LiteLLM adapter — early 200/SSE prefix relayed before attempt completion; certified final relayed; double-empty repair relayed as terminal error without `response.completed` or `[DONE]`
- `npm test` — 3,585 passed, 26 skipped; one unrelated `process-tree` readiness timing test missed its 2-second fixture deadline, and its exact isolated rerun passed
- autoreview (`--mode local --max-priority P1`) — clean after one rejected false positive; TruffleHog clean
- `npm audit --audit-level=high` — not available: the npm advisory endpoint timed out on both ordinary and explicitly bounded network attempts

No live xAI request was made; the repository requires separate quota consent for that check.
