### PR TITLE
fix(opencode): send x-opencode-session on outbound hops

### DIFF
--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -1122,12 +1122,14 @@ function upstreamHeaders(requestHeaders, body, apiKey, provider, extraHeaders = 
   }
   headers["User-Agent"] = `codex-router/${VERSION}`;
   headers["Accept-Encoding"] = "identity";
+  Object.assign(headers, extraHeaders);
+  // OpenCode Go/Zen affinity must win over any session.headers merge above:
+  // starting 2026-09-06 their edge may refuse requests without this header.
   applyOpenCodeSessionHeaders(headers, {
     provider,
     requestHeaders,
     body,
   });
-  Object.assign(headers, extraHeaders);
   // Content-Length is fetch's to compute. An explicit copy is at best
   // redundant, and the HTTP/1.1 dispatcher rejects the request outright
   // (UND_ERR_INVALID_ARG) when a caller-supplied value accompanies a body.

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -58,6 +58,7 @@ import {
   normalizeOpenAIRequest,
 } from "./openai-adapters.mjs";
 import { threadIdFromHeaders } from "./codex-session-names.mjs";
+import { applyOpenCodeSessionHeaders } from "./opencode-session.mjs";
 import {
   effectiveProviderCredentialStatus,
   providerApiKeyAuthoritySnapshot,
@@ -1121,6 +1122,11 @@ function upstreamHeaders(requestHeaders, body, apiKey, provider, extraHeaders = 
   }
   headers["User-Agent"] = `codex-router/${VERSION}`;
   headers["Accept-Encoding"] = "identity";
+  applyOpenCodeSessionHeaders(headers, {
+    provider,
+    requestHeaders,
+    body,
+  });
   Object.assign(headers, extraHeaders);
   // Content-Length is fetch's to compute. An explicit copy is at best
   // redundant, and the HTTP/1.1 dispatcher rejects the request outright

--- a/src/model-discovery.mjs
+++ b/src/model-discovery.mjs
@@ -23,9 +23,15 @@ import {
   resolveProviderBaseUrl,
 } from "./model-registry.mjs";
 import { curatedModelBlockReason } from "./opencode-curation.mjs";
+import {
+  OPENCODE_SESSION_FALLBACKS,
+  applyOpenCodeSessionHeaders,
+  isOpenCodeProvider,
+} from "./opencode-session.mjs";
 import { providerCatalogRouteIds } from "./provider-catalogs.mjs";
 import { readUserModels } from "./user-models.mjs";
 import { credentialStatus, resolveProviderCredential } from "./provider-credentials.mjs";
+import { VERSION } from "./version.mjs";
 import {
   fetchUntrustedModelCatalog,
   validateModelCatalogPayload,
@@ -308,6 +314,13 @@ async function providerPayload(provider, identity) {
     headers = {
       ...githubCopilotCatalogHeaders(session.token),
     };
+  }
+  if (isOpenCodeProvider(provider)) {
+    headers["User-Agent"] = `codex-router/${VERSION}`;
+    applyOpenCodeSessionHeaders(headers, {
+      provider,
+      fallback: OPENCODE_SESSION_FALLBACKS.discovery,
+    });
   }
   return fetchUntrustedModelCatalog(`${baseUrl}/models`, {
     headers,

--- a/src/opencode-session.mjs
+++ b/src/opencode-session.mjs
@@ -1,0 +1,108 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { threadIdFromHeaders } from "./codex-session-names.mjs";
+
+export const OPENCODE_SESSION_HEADER = "x-opencode-session";
+
+export const OPENCODE_SESSION_FALLBACKS = Object.freeze({
+  discovery: "codex-router-discovery",
+  usage: "codex-router-usage",
+});
+
+const OPENCODE_PROVIDER_IDS = new Set([
+  "opencode-go",
+  "opencode-go-messages",
+  "opencode-go-responses",
+  "opencode-zen",
+  "opencode-free",
+  "opencode-free-responses",
+]);
+
+export function isOpenCodeProvider(provider) {
+  if (!provider || typeof provider !== "object") return false;
+  if (provider.ownedBy === "opencode") return true;
+  return OPENCODE_PROVIDER_IDS.has(provider.id);
+}
+
+export function resolveOpenCodeSessionId({ headers = {}, body, fallback } = {}) {
+  const fromThread = threadIdFromHeaders(headers);
+  if (fromThread) return fromThread;
+
+  const fromBody = conversationAnchorId(body);
+  if (fromBody) return fromBody;
+
+  if (typeof fallback === "string" && fallback) return fallback;
+  return randomUUID();
+}
+
+export function openCodeSessionHeaders({ headers, body, fallback } = {}) {
+  return {
+    [OPENCODE_SESSION_HEADER]: resolveOpenCodeSessionId({ headers, body, fallback }),
+  };
+}
+
+export function applyOpenCodeSessionHeaders(
+  target,
+  { provider, requestHeaders, body, fallback } = {},
+) {
+  if (!isOpenCodeProvider(provider)) return false;
+  Object.assign(
+    target,
+    openCodeSessionHeaders({ headers: requestHeaders, body, fallback }),
+  );
+  return true;
+}
+
+function parseBody(body) {
+  if (body == null) return undefined;
+  if (Buffer.isBuffer(body) || body instanceof Uint8Array) {
+    try {
+      return JSON.parse(Buffer.from(body).toString("utf8"));
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body);
+    } catch {
+      return undefined;
+    }
+  }
+  if (typeof body === "object") return body;
+  return undefined;
+}
+
+function conversationItems(payload) {
+  if (!payload || typeof payload !== "object") return [];
+  if (Array.isArray(payload.messages)) return payload.messages;
+  if (Array.isArray(payload.input)) return payload.input;
+  return [];
+}
+
+function itemAnchor(item) {
+  if (typeof item === "string") return `text:${item}`;
+  if (!item || typeof item !== "object") return `value:${JSON.stringify(item)}`;
+  const role = item.role || item.type || "item";
+  const content =
+    typeof item.content === "string" ? item.content : JSON.stringify(item.content ?? item);
+  return `${role}:${content}`;
+}
+
+function conversationAnchorId(body) {
+  const payload = parseBody(body);
+  const anchor = [];
+  for (const item of conversationItems(payload)) {
+    anchor.push(itemAnchor(item));
+    if (anchor.length === 2) break;
+  }
+  if (anchor.length === 0) return undefined;
+  const digest = createHash("sha256").update(anchor.join("\n")).digest("hex");
+  return [
+    digest.slice(0, 8),
+    digest.slice(8, 12),
+    digest.slice(12, 16),
+    digest.slice(16, 20),
+    digest.slice(20, 32),
+  ].join("-");
+}

--- a/src/provider-account-usage.mjs
+++ b/src/provider-account-usage.mjs
@@ -10,6 +10,10 @@ import {
 import { kimiOAuthStatus } from "./oauth-status.mjs";
 import { PROVIDERS } from "./model-registry.mjs";
 import { resolveProviderCredential } from "./provider-credentials.mjs";
+import {
+  OPENCODE_SESSION_FALLBACKS,
+  openCodeSessionHeaders,
+} from "./opencode-session.mjs";
 import { cooldownUntil } from "./rate-limit-headers.mjs";
 import { rateLimitSnapshotFor } from "./rate-limit-state.mjs";
 import { VERSION } from "./version.mjs";
@@ -546,7 +550,10 @@ async function opencodeGoAccount(fetchImpl) {
   if (new URL(baseURL).origin !== "https://opencode.ai") {
     return localOnly("Plan usage is unavailable for a custom opencode endpoint");
   }
-  const payload = await requestJson(`${baseURL}/usage`, credential.value, {}, fetchImpl);
+  const payload = await requestJson(`${baseURL}/usage`, credential.value, {
+    "User-Agent": `codex-router/${VERSION}`,
+    ...openCodeSessionHeaders({ fallback: OPENCODE_SESSION_FALLBACKS.usage }),
+  }, fetchImpl);
   const metrics = opencodeGoUsageMetrics(payload);
   if (!metrics.length) throw new Error("opencode usage response was incomplete");
   return { status: "available", source: "official-api", metrics };

--- a/test/opencode-session.test.mjs
+++ b/test/opencode-session.test.mjs
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  OPENCODE_SESSION_FALLBACKS,
+  OPENCODE_SESSION_HEADER,
+  applyOpenCodeSessionHeaders,
+  isOpenCodeProvider,
+  openCodeSessionHeaders,
+  resolveOpenCodeSessionId,
+} from "../src/opencode-session.mjs";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+test("isOpenCodeProvider prefers ownedBy and accepts known ids", () => {
+  assert.equal(isOpenCodeProvider({ ownedBy: "opencode", id: "anything" }), true);
+  assert.equal(isOpenCodeProvider({ id: "opencode-go" }), true);
+  assert.equal(isOpenCodeProvider({ id: "opencode-go-messages" }), true);
+  assert.equal(isOpenCodeProvider({ id: "opencode-go-responses" }), true);
+  assert.equal(isOpenCodeProvider({ id: "opencode-zen" }), true);
+  assert.equal(isOpenCodeProvider({ id: "opencode-free" }), true);
+  assert.equal(isOpenCodeProvider({ id: "opencode-free-responses" }), true);
+  assert.equal(isOpenCodeProvider({ ownedBy: "openrouter", id: "openrouter" }), false);
+  assert.equal(isOpenCodeProvider({ id: "deepseek" }), false);
+  assert.equal(isOpenCodeProvider(null), false);
+});
+
+test("same conversation body yields the same session id", () => {
+  const body = {
+    messages: [
+      { role: "system", content: "You are Codex." },
+      { role: "user", content: "run the thing" },
+    ],
+  };
+  const first = resolveOpenCodeSessionId({ body });
+  const second = resolveOpenCodeSessionId({
+    body: {
+      messages: [
+        ...body.messages,
+        { role: "assistant", content: "ok" },
+        { role: "user", content: "and again" },
+      ],
+    },
+  });
+  assert.equal(first, second);
+  assert.match(first, UUID_RE);
+});
+
+test("different conversation bodies yield different session ids", () => {
+  const left = resolveOpenCodeSessionId({
+    body: {
+      messages: [
+        { role: "system", content: "You are Codex." },
+        { role: "user", content: "one" },
+      ],
+    },
+  });
+  const right = resolveOpenCodeSessionId({
+    body: {
+      messages: [
+        { role: "system", content: "You are Codex." },
+        { role: "user", content: "two" },
+      ],
+    },
+  });
+  assert.notEqual(left, right);
+});
+
+test("Responses input and Anthropic messages use the same anchor rules", () => {
+  const responses = resolveOpenCodeSessionId({
+    body: {
+      input: [
+        { role: "user", content: [{ type: "input_text", text: "hello" }] },
+        { type: "message", role: "assistant", content: "hi" },
+      ],
+    },
+  });
+  const anthropic = resolveOpenCodeSessionId({
+    body: {
+      messages: [
+        { role: "user", content: [{ type: "text", text: "hello" }] },
+        { role: "assistant", content: "hi" },
+      ],
+    },
+  });
+  assert.match(responses, UUID_RE);
+  assert.match(anthropic, UUID_RE);
+  assert.notEqual(responses, anthropic);
+});
+
+test("thread-id header wins over body anchor", () => {
+  const threadId = "11111111-2222-3333-4444-555555555555";
+  const fromHeader = resolveOpenCodeSessionId({
+    headers: { "thread-id": threadId },
+    body: {
+      messages: [
+        { role: "system", content: "You are Codex." },
+        { role: "user", content: "run the thing" },
+      ],
+    },
+  });
+  assert.equal(fromHeader, threadId);
+});
+
+test("stable fallbacks cover discovery and usage", () => {
+  assert.equal(
+    resolveOpenCodeSessionId({ fallback: OPENCODE_SESSION_FALLBACKS.discovery }),
+    "codex-router-discovery",
+  );
+  assert.equal(
+    resolveOpenCodeSessionId({ fallback: OPENCODE_SESSION_FALLBACKS.usage }),
+    "codex-router-usage",
+  );
+});
+
+test("empty chat body falls back to a one-shot UUID", () => {
+  const id = resolveOpenCodeSessionId({ body: { messages: [] } });
+  assert.match(id, UUID_RE);
+});
+
+test("applyOpenCodeSessionHeaders attaches only for OpenCode providers", () => {
+  const body = Buffer.from(
+    JSON.stringify({
+      messages: [
+        { role: "system", content: "You are Codex." },
+        { role: "user", content: "run the thing" },
+      ],
+    }),
+    "utf8",
+  );
+  const openHeaders = { "User-Agent": "codex-router/test" };
+  assert.equal(
+    applyOpenCodeSessionHeaders(openHeaders, {
+      provider: { id: "opencode-go", ownedBy: "opencode" },
+      body,
+    }),
+    true,
+  );
+  assert.match(openHeaders[OPENCODE_SESSION_HEADER], UUID_RE);
+
+  const otherHeaders = { "User-Agent": "codex-router/test" };
+  assert.equal(
+    applyOpenCodeSessionHeaders(otherHeaders, {
+      provider: { id: "deepseek", ownedBy: "deepseek" },
+      body,
+    }),
+    false,
+  );
+  assert.equal(OPENCODE_SESSION_HEADER in otherHeaders, false);
+});
+
+test("openCodeSessionHeaders returns the wire header shape", () => {
+  const headers = openCodeSessionHeaders({
+    fallback: OPENCODE_SESSION_FALLBACKS.discovery,
+  });
+  assert.deepEqual(headers, {
+    [OPENCODE_SESSION_HEADER]: "codex-router-discovery",
+  });
+});

--- a/test/provider-account-usage.test.mjs
+++ b/test/provider-account-usage.test.mjs
@@ -552,6 +552,8 @@ test("opencode Go usage reads the Zen usage API", async () => {
       fetchImpl: async (url, options) => {
         assert.equal(url, "https://opencode.ai/zen/go/v1/usage");
         assert.equal(options.headers.Authorization, "Bearer TEST_OPENCODE_USAGE_KEY");
+        assert.equal(options.headers["x-opencode-session"], "codex-router-usage");
+        assert.match(options.headers["User-Agent"], /^codex-router\//);
         return new Response(JSON.stringify({
           usage: {
             rolling: { status: "ok", percent: 5, resetsAt: "2026-08-13T01:00:00Z" },


### PR DESCRIPTION
## Why

OpenCode Go emailed that requests missing `x-opencode-session` may error starting 2026-09-06. The router never sent that header on chat, discovery, or usage hops. Without it, Go/Zen routes risk hard failures tomorrow.

## Scope

- Add `src/opencode-session.mjs` to resolve a stable opaque id: `thread-id` when present, else a Grok-style hash of the first conversation items, else a named fallback for discovery/usage.
- Attach `x-opencode-session` in `src/api-forwarder.mjs` `upstreamHeaders` for every `ownedBy: "opencode"` provider (Go, Messages, Responses, Zen, Free).
- Attach the same header plus an honest `codex-router/...` User-Agent on OpenCode catalog fetches and the Zen usage probe.
- Cover resolution order and provider gating in `test/opencode-session.test.mjs`; assert the usage probe sends the header.

## Tradeoffs

Body-hash affinity is used when Codex `thread-id` does not survive LiteLLM, because `routedHeaders()` does not forward thread identity today. That keeps one id stable across turns of the same conversation without a larger gateway header-passthrough change.

## Blast Radius

Touches only OpenCode family outbound HTTP. Other providers keep previous headers. No CLI impersonation headers are added.

## Verification

- `node --test test/opencode-session.test.mjs` — 9/9 pass
- `node --test test/provider-account-usage.test.mjs` — pass, including the new usage-header assertion
- `node --test test/provider-api-key-forwarder.test.mjs` — pass


Made with [Cursor](https://cursor.com)