### PR TITLE
fix: allow larger Codex request bodies

### DIFF
--- a/src/http-utils.mjs
+++ b/src/http-utils.mjs
@@ -317,7 +317,7 @@ export const MAX_BODY_BYTES = Number(
     (TARGET === "codex"
       ? process.env.CODEX_ROUTER_MAX_BODY_BYTES || process.env.KIMI_PROXY_MAX_BODY_BYTES
       : undefined) ||
-    64 * 1024 * 1024,
+    128 * 1024 * 1024,
 );
 
 export const MAX_BUFFERED_RESPONSE_BYTES = Number(

--- a/test/http-utils-resilience.test.mjs
+++ b/test/http-utils-resilience.test.mjs
@@ -8,8 +8,8 @@ import {
   readResponseBody,
 } from "../src/http-utils.mjs";
 
-test("request body handling keeps the established 64 MiB compatibility ceiling", () => {
-  assert.equal(MAX_BODY_BYTES, 64 * 1024 * 1024);
+test("request body handling permits large Codex histories up to 128 MiB", () => {
+  assert.equal(MAX_BODY_BYTES, 128 * 1024 * 1024);
 });
 
 test("an oversized request is rejected without retaining or abandoning its tail", async () => {


### PR DESCRIPTION
﻿## Summary

Fixes #614.

Long Codex sessions with large retained tool outputs can exceed the router's 64 MiB encoded request-body ceiling while still being inside the active model context window. The router then returns local HTTP 413 before parsing the request or reaching the provider.

This raises the default request-body ceiling to 128 MiB while leaving the independent 256 MiB decoded-body limit and zstd preflight unchanged.

## Evidence

The real Codex 0.153.1 task remained on the normal native `gpt-5.6-sol` route. It was not using the router's synthetic `gpt-5.6-sol-1m` slug.

A global Codex long-context override requested 1,000,000 tokens; the current ChatGPT catalog capped that at 872,000 raw / 828,400 effective. The task failed at ~252.7k input tokens, so it was still well inside its active context budget. Its rollout was ~103 MB and contained several 10–20 MiB custom-tool outputs. The router logged six repeated failures:

`Request body exceeds 67108864 bytes.`

## Verification

- `node --test test/http-utils-resilience.test.mjs` — 4/4 pass
- targeted routing tests for large compressed context + oversize zstd preflight — 2/2 pass
- `npm run check` — pass
- `git diff --check` — pass
