### PR TITLE
fix(namespace-relay): restore dotted tool delimiters (#611)

### DIFF
--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -41,6 +41,9 @@ import {
 // tool itself. Namespace names themselves may contain the delimiter
 // (`mcp__codex_apps__github`), so restoration always resolves through the map
 // built from the exact tools that were flattened -- never by splitting names.
+// The same map may also index a dotted inventory alias (`namespace.tool`) when
+// a Responses-native model echoes that wire form (#611); that is still an
+// exact inventory hit, not a split.
 
 export const NAMESPACE_DELIMITER = "__";
 const DEFAULT_FUNCTION_NAMESPACE = "functions";
@@ -1930,15 +1933,34 @@ export function buildNamespaceLookups(namespaces) {
   const flatToNative = new Map();
   const bareToNamespaces = new Map();
   const nameAliases = NAME_ALIASES.get(namespaces);
+  // Dotted wire spellings (`namespace.tool`) some Responses-native models emit
+  // instead of `__` (#611). Collect candidates first; only an unambiguous
+  // inventory pair is registered — never invent identity by splitting a name
+  // (#568).
+  const dottedCandidates = new Map();
+  const rememberDotted = (dottedName, native) => {
+    if (!dottedCandidates.has(dottedName)) {
+      dottedCandidates.set(dottedName, native);
+      return;
+    }
+    const previous = dottedCandidates.get(dottedName);
+    if (
+      !previous ||
+      previous.namespace !== native.namespace ||
+      previous.name !== native.name
+    ) {
+      dottedCandidates.set(dottedName, undefined);
+    }
+  };
   for (const [namespace, names] of namespaces) {
     for (const name of names) {
       const providerName =
         nameAliases?.nativeToProvider.get(nativeToolKey(namespace, name)) ||
         `${namespace}${NAMESPACE_DELIMITER}${name}`;
-      flatToNative.set(providerName, {
-        namespace,
-        name,
-      });
+      const native = { namespace, name };
+      flatToNative.set(providerName, native);
+      const dottedName = `${namespace}.${name}`;
+      if (dottedName !== providerName) rememberDotted(dottedName, native);
       if (!bareToNamespaces.has(name)) bareToNamespaces.set(name, new Set());
       bareToNamespaces.get(name).add(namespace);
     }
@@ -1948,13 +1970,25 @@ export function buildNamespaceLookups(namespaces) {
       flatToNative.set(providerName, native);
     }
   }
+  const plainToolNames = new Set([
+    ...(PLAIN_TOOL_NAMES.get(namespaces) || []),
+    ...(nameAliases?.plainProviderNames || []),
+  ]);
+  for (const [dottedName, native] of dottedCandidates) {
+    if (!native || plainToolNames.has(dottedName)) continue;
+    const existing = flatToNative.get(dottedName);
+    if (
+      existing &&
+      (existing.namespace !== native.namespace || existing.name !== native.name)
+    ) {
+      continue;
+    }
+    flatToNative.set(dottedName, native);
+  }
   return {
     flatToNative,
     bareToNamespaces,
-    plainToolNames: new Set([
-      ...(PLAIN_TOOL_NAMES.get(namespaces) || []),
-      ...(nameAliases?.plainProviderNames || []),
-    ]),
+    plainToolNames,
     identityAliases: Boolean(nameAliases),
     spawnAgentModels: SPAWN_AGENT_MODELS.get(namespaces),
     toolSearch: TOOL_SEARCH_RELAYS.get(namespaces),

--- a/src/openai-adapters.mjs
+++ b/src/openai-adapters.mjs
@@ -35,6 +35,14 @@ export function buildNamespaceLookupsFromTools(tools) {
     }
   }
   
+  // Namespace containers alone are enough to restore calls (Responses-native
+  // providers keep that shape). Seed the map before scanning flat functions.
+  for (const [flattenedName, native] of namespaceTools) {
+    flatToNative.set(flattenedName, native);
+    const dotted = `${native.namespace}.${native.name}`;
+    if (!flatToNative.has(dotted)) flatToNative.set(dotted, native);
+  }
+
   // Second pass: look for flattened function names
   for (const tool of tools) {
     if (!tool || typeof tool !== "object" || Array.isArray(tool)) continue;

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -103,11 +103,13 @@ function wrapper() {
 // window style of 0. Without it the wrapper owned a console window that stayed
 // on screen for the router's lifetime and reappeared on every watchdog restart.
 //
-// The `True` wait flag is what keeps Task Scheduler's restart settings alive:
-// Run then blocks until the wrapper exits and returns its exit code, which the
-// script re-raises through WScript.Quit. Quitting with a fixed 0 (or letting the
-// script fall off the end) would report every crash as a clean exit and silently
-// disable RestartCount/RestartInterval.
+// The `True` wait flag keeps the task instance alive for the router's lifetime
+// so Task Scheduler state and `schtasks /End` track the real process tree.
+// Propagating the wrapper exit code still matters for diagnostics
+// (`LastTaskResult`), but it does not drive relaunch: Task Scheduler's
+// RestartOnFailure only covers actions that fail to start, not a non-zero
+// exit after a successful start (issue #581). Relaunch after exit or a power
+// event comes from the minute heartbeat trigger in installTask().
 function launcher() {
   // A Windows path cannot contain a double quote, but escape it anyway so a
   // hand-edited state directory can never break out of the string literal.
@@ -203,10 +205,15 @@ function installTask() {
     // around the launcher path never pass through powershell.exe's -Command
     // reparse or the schtasks argument escaper.
     "$action = New-ScheduledTaskAction -Execute $env:CODEX_ROUTER_TASK_EXECUTE -Argument $env:CODEX_ROUTER_TASK_ARGUMENT",
-    "$trigger = New-ScheduledTaskTrigger -AtLogOn -User ([Security.Principal.WindowsIdentity]::GetCurrent().Name)",
-    "$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew",
+    // Logon alone never re-fires on wake/fast-startup, and RestartOnFailure
+    // does not relaunch after a started action exits (issue #581). The minute
+    // heartbeat is the supervisor: MultipleInstances IgnoreNew drops it while
+    // the router is alive, and StartWhenAvailable catches ticks missed in sleep.
+    "$logon = New-ScheduledTaskTrigger -AtLogOn -User ([Security.Principal.WindowsIdentity]::GetCurrent().Name)",
+    "$heartbeat = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 1) -RepetitionDuration (New-TimeSpan -Days 9999)",
+    "$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew -StartWhenAvailable",
     "$principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited",
-    "Register-ScheduledTask -TaskName $env:CODEX_ROUTER_TASK -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Force | Out-Null",
+    "Register-ScheduledTask -TaskName $env:CODEX_ROUTER_TASK -Action $action -Trigger @($logon, $heartbeat) -Settings $settings -Principal $principal -Force | Out-Null",
   ].join("; ");
   try {
     execFileSync(

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -370,8 +370,7 @@ test("the Windows launcher starts the wrapper hidden and propagates its exit cod
       ),
       `launcher did not embed the wrapper path correctly:\n${script}`,
     );
-    // Without this line Task Scheduler reads every crash as a clean exit and
-    // the RestartCount/RestartInterval settings never fire again.
+    // LastTaskResult still needs the real exit code for doctor/readiness.
     assert.match(script, /\r\nWScript\.Quit status\r\n$/);
     // A failure to even start the wrapper must also surface as a failure.
     assert.match(script, /\r\nIf Err\.Number <> 0 Then\r\n {2}WScript\.Quit 1\r\nEnd If\r\n/);
@@ -409,10 +408,27 @@ test("the Windows scheduled task runs the VBS launcher through wscript.exe", () 
   }
 });
 
-// The scheduled task's restart policy is the reason the exit code matters:
-// Task Scheduler only re-triggers RestartCount/RestartInterval when the action
-// reports a failure, so a launcher that swallowed the wrapper's exit code would
-// trade a console window for a router that stays dead after its first crash.
+test("Windows installTask registers a minute heartbeat beside logon", () => {
+  // RestartOnFailure does not relaunch after a started action exits (issue #581).
+  // The heartbeat trigger is the supervisor; IgnoreNew drops it while Running.
+  const source = readFileSync(path.join(root, "src", "service-windows.mjs"), "utf8");
+  const install = source.slice(
+    source.indexOf("function installTask()"),
+    source.indexOf("function waitForTaskToStop()"),
+  );
+  assert.match(install, /New-ScheduledTaskTrigger -AtLogOn/);
+  assert.match(
+    install,
+    /New-ScheduledTaskTrigger -Once -At \(Get-Date\) -RepetitionInterval \(New-TimeSpan -Minutes 1\)/,
+  );
+  assert.match(install, /-Trigger @\(\$logon, \$heartbeat\)/);
+  assert.match(install, /-MultipleInstances IgnoreNew -StartWhenAvailable/);
+});
+
+// Propagating the wrapper exit code keeps LastTaskResult honest for doctor
+// and readiness. It is not what relaunches a dead router: RestartOnFailure
+// only covers actions that fail to start (issue #581). The minute heartbeat
+// trigger in installTask() is the supervisor.
 // Nothing off Windows can execute a .vbs, so -- exactly like
 // `install.ps1 parses under powershell.exe` in test/installer-scripts.test.mjs --
 // this is the only place that link is executed rather than reasoned about.


### PR DESCRIPTION
## Why

On OpenCode Muse Free Responses routes, collaboration and MCP calls arrive as `namespace.tool` (and `mcp__server.tool`) while the relay table only knows `__` joins. Codex answers `unsupported call`, so spawn and MCP fail even though ordinary tools work.

## Scope

- `buildNamespaceLookups` registers `${namespace}.${name}` as an alias only when that spelling is not already owned.
- `buildNamespaceLookupsFromTools` seeds the same aliases from namespace containers and collaboration flats.
- Test covers the two #611 spellings against the request map.

Does not invent namespace splits from unknown dotted strings (#568).

## Blast Radius

Namespace restore on routed Responses/chat paths. Non-OpenCode routes keep identical `__` restoration; dotted aliases are additive.

## Verification

- `node --test --test-name-pattern='issue #611' test/namespace-relay.test.mjs` — pass
- `node --test test/namespace-relay.test.mjs` — 115 pass
- `node --test test/qwen-plan-namespace-restoration.test.mjs` — run in CI

Fixes #611


Made with [Cursor](https://cursor.com)