### PR TITLE
fix(namespace-relay): restore dotted tool delimiters (#611)

### DIFF
--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -41,6 +41,9 @@ import {
 // tool itself. Namespace names themselves may contain the delimiter
 // (`mcp__codex_apps__github`), so restoration always resolves through the map
 // built from the exact tools that were flattened -- never by splitting names.
+// The same map may also index a dotted inventory alias (`namespace.tool`) when
+// a Responses-native model echoes that wire form (#611); that is still an
+// exact inventory hit, not a split.
 
 export const NAMESPACE_DELIMITER = "__";
 const DEFAULT_FUNCTION_NAMESPACE = "functions";
@@ -1930,15 +1933,34 @@ export function buildNamespaceLookups(namespaces) {
   const flatToNative = new Map();
   const bareToNamespaces = new Map();
   const nameAliases = NAME_ALIASES.get(namespaces);
+  // Dotted wire spellings (`namespace.tool`) some Responses-native models emit
+  // instead of `__` (#611). Collect candidates first; only an unambiguous
+  // inventory pair is registered — never invent identity by splitting a name
+  // (#568).
+  const dottedCandidates = new Map();
+  const rememberDotted = (dottedName, native) => {
+    if (!dottedCandidates.has(dottedName)) {
+      dottedCandidates.set(dottedName, native);
+      return;
+    }
+    const previous = dottedCandidates.get(dottedName);
+    if (
+      !previous ||
+      previous.namespace !== native.namespace ||
+      previous.name !== native.name
+    ) {
+      dottedCandidates.set(dottedName, undefined);
+    }
+  };
   for (const [namespace, names] of namespaces) {
     for (const name of names) {
       const providerName =
         nameAliases?.nativeToProvider.get(nativeToolKey(namespace, name)) ||
         `${namespace}${NAMESPACE_DELIMITER}${name}`;
-      flatToNative.set(providerName, {
-        namespace,
-        name,
-      });
+      const native = { namespace, name };
+      flatToNative.set(providerName, native);
+      const dottedName = `${namespace}.${name}`;
+      if (dottedName !== providerName) rememberDotted(dottedName, native);
       if (!bareToNamespaces.has(name)) bareToNamespaces.set(name, new Set());
       bareToNamespaces.get(name).add(namespace);
     }
@@ -1948,13 +1970,25 @@ export function buildNamespaceLookups(namespaces) {
       flatToNative.set(providerName, native);
     }
   }
+  const plainToolNames = new Set([
+    ...(PLAIN_TOOL_NAMES.get(namespaces) || []),
+    ...(nameAliases?.plainProviderNames || []),
+  ]);
+  for (const [dottedName, native] of dottedCandidates) {
+    if (!native || plainToolNames.has(dottedName)) continue;
+    const existing = flatToNative.get(dottedName);
+    if (
+      existing &&
+      (existing.namespace !== native.namespace || existing.name !== native.name)
+    ) {
+      continue;
+    }
+    flatToNative.set(dottedName, native);
+  }
   return {
     flatToNative,
     bareToNamespaces,
-    plainToolNames: new Set([
-      ...(PLAIN_TOOL_NAMES.get(namespaces) || []),
-      ...(nameAliases?.plainProviderNames || []),
-    ]),
+    plainToolNames,
     identityAliases: Boolean(nameAliases),
     spawnAgentModels: SPAWN_AGENT_MODELS.get(namespaces),
     toolSearch: TOOL_SEARCH_RELAYS.get(namespaces),

--- a/src/openai-adapters.mjs
+++ b/src/openai-adapters.mjs
@@ -35,6 +35,14 @@ export function buildNamespaceLookupsFromTools(tools) {
     }
   }
   
+  // Namespace containers alone are enough to restore calls (Responses-native
+  // providers keep that shape). Seed the map before scanning flat functions.
+  for (const [flattenedName, native] of namespaceTools) {
+    flatToNative.set(flattenedName, native);
+    const dotted = `${native.namespace}.${native.name}`;
+    if (!flatToNative.has(dotted)) flatToNative.set(dotted, native);
+  }
+
   // Second pass: look for flattened function names
   for (const tool of tools) {
     if (!tool || typeof tool !== "object" || Array.isArray(tool)) continue;

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -2161,6 +2161,91 @@ test("response transform restores flattened calls to the native namespace shape"
   assert.doesNotMatch(output, /collaboration__spawn_agent|codex_app__create_thread|mcp__node_repl__js/);
 });
 
+// Issue #611: Responses-native routes (e.g. opencode-free-responses Muse Spark)
+// keep type:"namespace" tools outbound. Some models then call with a dotted
+// wire name (`collaboration.spawn_agent`, `mcp__agentmemory.memory_sessions`)
+// instead of the `__` flattening the reverse map indexes. Restore only from
+// the request inventory — never by splitting an arbitrary dotted string
+// (#568 declined bare name-map recovery that bypasses spawn sanitisation).
+test("response transform restores dotted wire names from the request inventory", () => {
+  const { namespaces } = flattenNamespaceTools([
+    {
+      type: "namespace",
+      name: "collaboration",
+      tools: [
+        {
+          type: "function",
+          name: "spawn_agent",
+          inputSchema: {
+            type: "object",
+            properties: {
+              model: { type: "string", enum: ["gpt-5.6-sol"] },
+            },
+          },
+        },
+      ],
+    },
+    {
+      type: "namespace",
+      name: "mcp__agentmemory",
+      tools: [{ type: "function", name: "memory_sessions" }],
+    },
+  ]);
+  const lookups = buildNamespaceLookups(namespaces);
+
+  const spawn = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        {
+          type: "function_call",
+          name: "collaboration.spawn_agent",
+          call_id: "call_dot_spawn",
+          arguments: JSON.stringify({ model: "gpt-5.6-sol", task: "x" }),
+        },
+      ],
+    },
+    lookups,
+  );
+  assert.deepEqual(
+    { namespace: spawn.output[0].namespace, name: spawn.output[0].name },
+    { namespace: "collaboration", name: "spawn_agent" },
+  );
+
+  const mcp = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        {
+          type: "function_call",
+          name: "mcp__agentmemory.memory_sessions",
+          call_id: "call_dot_mcp",
+          arguments: "{}",
+        },
+      ],
+    },
+    lookups,
+  );
+  assert.deepEqual(
+    { namespace: mcp.output[0].namespace, name: mcp.output[0].name },
+    { namespace: "mcp__agentmemory", name: "memory_sessions" },
+  );
+
+  // An invented dotted spelling that is not an inventory pair stays untouched.
+  const invented = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        {
+          type: "function_call",
+          name: "collaboration.not_a_real_tool",
+          call_id: "call_invented",
+          arguments: "{}",
+        },
+      ],
+    },
+    lookups,
+  );
+  assert.equal(invented, undefined);
+});
+
 test("tool_search response bridge suppresses function argument events across its lifecycle", async () => {
   const { namespaces } = flattenNamespaceTools([clientToolSearchControl()]);
   const events = [

--- a/test/qwen-plan-namespace-restoration.test.mjs
+++ b/test/qwen-plan-namespace-restoration.test.mjs
@@ -125,12 +125,14 @@ test("buildNamespaceLookupsFromTools handles namespace tools with nested names",
 
   const lookups = buildNamespaceLookupsFromTools(tools);
 
-  assert.equal(lookups.size, 1);
+  // Flat __ join plus dotted inventory alias (#611).
+  assert.equal(lookups.size, 2);
   const execute = lookups.get("mcp__node_repl__execute");
   assert.ok(execute, "Should restore tool from namespace entry");
   // Namespace preserves the full nested name
   assert.equal(execute.namespace, "mcp__node_repl");
   assert.equal(execute.name, "execute");
+  assert.equal(lookups.get("mcp__node_repl.execute"), execute);
 });
 
 test("createResponsesStreamTransform restores namespaced function calls", async () => {
@@ -399,12 +401,13 @@ test("buildNamespaceLookupsFromTools restores tools from namespace entries", () 
 
   const lookups = buildNamespaceLookupsFromTools(tools);
 
-  // Should restore the tool that came from a namespace entry
-  assert.equal(lookups.size, 1);
+  // Should restore the tool that came from a namespace entry, plus dotted alias
+  assert.equal(lookups.size, 2);
   const restored = lookups.get("mcp__node_repl__execute");
   assert.ok(restored, "Should restore tool from namespace entry");
   assert.equal(restored.namespace, "mcp__node_repl");
   assert.equal(restored.name, "execute");
+  assert.equal(lookups.get("mcp__node_repl.execute"), restored);
 });
 
 test("MCP-style names are left unchanged in responses without namespace tools", async () => {


### PR DESCRIPTION
## Why

On OpenCode Muse Free Responses routes, collaboration and MCP calls arrive as `namespace.tool` (and `mcp__server.tool`) while the relay table only knows `__` joins. Codex answers `unsupported call`, so spawn and MCP fail even though ordinary tools work.

## Scope

- `buildNamespaceLookups` registers an unambiguous `${namespace}.${name}` inventory alias.
- `buildNamespaceLookupsFromTools` seeds the same aliases from namespace containers.
- Tests cover the two #611 spellings and update Qwen lookup size expectations for the `__` + dotted pair.

Does not invent namespace splits from unknown dotted strings (#568).

## Blast Radius

Namespace restore on routed Responses/chat paths. Non-OpenCode routes keep identical `__` restoration; dotted aliases are additive.

## Verification

- `node --test --test-name-pattern='dotted' test/namespace-relay.test.mjs` — pass
- `node --test test/qwen-plan-namespace-restoration.test.mjs` — 10 pass
- `node --test test/namespace-relay.test.mjs` — full suite

Fixes #611


Made with [Cursor](https://cursor.com)