### PR TITLE
fix(windows): relaunch router via minute heartbeat trigger (#581)

### DIFF
--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -103,11 +103,13 @@ function wrapper() {
 // window style of 0. Without it the wrapper owned a console window that stayed
 // on screen for the router's lifetime and reappeared on every watchdog restart.
 //
-// The `True` wait flag is what keeps Task Scheduler's restart settings alive:
-// Run then blocks until the wrapper exits and returns its exit code, which the
-// script re-raises through WScript.Quit. Quitting with a fixed 0 (or letting the
-// script fall off the end) would report every crash as a clean exit and silently
-// disable RestartCount/RestartInterval.
+// The `True` wait flag keeps the task instance alive for the router's lifetime
+// so Task Scheduler state and `schtasks /End` track the real process tree.
+// Propagating the wrapper exit code still matters for diagnostics
+// (`LastTaskResult`), but it does not drive relaunch: Task Scheduler's
+// RestartOnFailure only covers actions that fail to start, not a non-zero
+// exit after a successful start (issue #581). Relaunch after exit or a power
+// event comes from the minute heartbeat trigger in installTask().
 function launcher() {
   // A Windows path cannot contain a double quote, but escape it anyway so a
   // hand-edited state directory can never break out of the string literal.
@@ -203,10 +205,15 @@ function installTask() {
     // around the launcher path never pass through powershell.exe's -Command
     // reparse or the schtasks argument escaper.
     "$action = New-ScheduledTaskAction -Execute $env:CODEX_ROUTER_TASK_EXECUTE -Argument $env:CODEX_ROUTER_TASK_ARGUMENT",
-    "$trigger = New-ScheduledTaskTrigger -AtLogOn -User ([Security.Principal.WindowsIdentity]::GetCurrent().Name)",
-    "$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew",
+    // Logon alone never re-fires on wake/fast-startup, and RestartOnFailure
+    // does not relaunch after a started action exits (issue #581). The minute
+    // heartbeat is the supervisor: MultipleInstances IgnoreNew drops it while
+    // the router is alive, and StartWhenAvailable catches ticks missed in sleep.
+    "$logon = New-ScheduledTaskTrigger -AtLogOn -User ([Security.Principal.WindowsIdentity]::GetCurrent().Name)",
+    "$heartbeat = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 1) -RepetitionDuration (New-TimeSpan -Days 9999)",
+    "$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew -StartWhenAvailable",
     "$principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited",
-    "Register-ScheduledTask -TaskName $env:CODEX_ROUTER_TASK -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Force | Out-Null",
+    "Register-ScheduledTask -TaskName $env:CODEX_ROUTER_TASK -Action $action -Trigger @($logon, $heartbeat) -Settings $settings -Principal $principal -Force | Out-Null",
   ].join("; ");
   try {
     execFileSync(

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -370,8 +370,7 @@ test("the Windows launcher starts the wrapper hidden and propagates its exit cod
       ),
       `launcher did not embed the wrapper path correctly:\n${script}`,
     );
-    // Without this line Task Scheduler reads every crash as a clean exit and
-    // the RestartCount/RestartInterval settings never fire again.
+    // LastTaskResult still needs the real exit code for doctor/readiness.
     assert.match(script, /\r\nWScript\.Quit status\r\n$/);
     // A failure to even start the wrapper must also surface as a failure.
     assert.match(script, /\r\nIf Err\.Number <> 0 Then\r\n {2}WScript\.Quit 1\r\nEnd If\r\n/);
@@ -409,10 +408,27 @@ test("the Windows scheduled task runs the VBS launcher through wscript.exe", () 
   }
 });
 
-// The scheduled task's restart policy is the reason the exit code matters:
-// Task Scheduler only re-triggers RestartCount/RestartInterval when the action
-// reports a failure, so a launcher that swallowed the wrapper's exit code would
-// trade a console window for a router that stays dead after its first crash.
+test("Windows installTask registers a minute heartbeat beside logon", () => {
+  // RestartOnFailure does not relaunch after a started action exits (issue #581).
+  // The heartbeat trigger is the supervisor; IgnoreNew drops it while Running.
+  const source = readFileSync(path.join(root, "src", "service-windows.mjs"), "utf8");
+  const install = source.slice(
+    source.indexOf("function installTask()"),
+    source.indexOf("function waitForTaskToStop()"),
+  );
+  assert.match(install, /New-ScheduledTaskTrigger -AtLogOn/);
+  assert.match(
+    install,
+    /New-ScheduledTaskTrigger -Once -At \(Get-Date\) -RepetitionInterval \(New-TimeSpan -Minutes 1\)/,
+  );
+  assert.match(install, /-Trigger @\(\$logon, \$heartbeat\)/);
+  assert.match(install, /-MultipleInstances IgnoreNew -StartWhenAvailable/);
+});
+
+// Propagating the wrapper exit code keeps LastTaskResult honest for doctor
+// and readiness. It is not what relaunches a dead router: RestartOnFailure
+// only covers actions that fail to start (issue #581). The minute heartbeat
+// trigger in installTask() is the supervisor.
 // Nothing off Windows can execute a .vbs, so -- exactly like
 // `install.ps1 parses under powershell.exe` in test/installer-scripts.test.mjs --
 // this is the only place that link is executed rather than reasoned about.


### PR DESCRIPTION
## Why

Task Scheduler `RestartOnFailure` only covers actions that fail to *start*. After a silent process exit or power event, the LogonTrigger task stays Ready forever and the router never comes back.

## Scope

Register a repeating minute heartbeat trigger with `MultipleInstances IgnoreNew` and `StartWhenAvailable` so a dead instance is relaunched without stacking duplicates while one is still running.

## Blast Radius

Windows service task XML only. macOS/Linux LaunchAgent/systemd unchanged.

## Verification

- `node --test test/service-render.test.mjs` (focused assertions for the heartbeat trigger)

Fixes #581


Made with [Cursor](https://cursor.com)