### PR TITLE
fix: prune unconfigured providers from enabled-providers.json (#589)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Startup prunes `enabled-providers.json` entries that cannot authenticate.**
+  Unknown ids (version skew) and recognised providers without a credential
+  were left in the selection file forever, so the dispatcher still treated
+  them as enabled and answered `provider_api_key_missing`. Startup now
+  rewrites the file to the configured subset (and deletes a file that named
+  only unknown ids, preserving the no-file show-all fallback). Idempotent;
+  discovery-disabled and show-all modes are left alone.
 - **macOS KeepAlive no longer uses launchd `Adaptive`, which starved startup.**
   Adaptive only boosts on XPC transactions; the router is localhost HTTP, so
   the job stayed at Background. Node OAuth/API forwarders then missed the 30s

--- a/src/provider-selection.mjs
+++ b/src/provider-selection.mjs
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
@@ -245,6 +246,54 @@ export function disableProvider(providerId) {
   return writeProviderSelection(
     current.filter((id) => canonicalProviderId(id) !== target),
   );
+}
+
+// Reconcile the on-disk enable list with what this build can authenticate.
+// Reads the file directly rather than readProviderSelectionDetail(): that
+// helper falls back to "every provider" when the file is missing, when
+// SHOW_ALL_MODELS is set, or when every stored id is unknown, and feeding
+// those virtual lists into disableProvider would create or rewrite policy
+// the operator never wrote. Discovery-disabled installs are left alone so
+// the kill-switch does not empty a stored selection by reporting nothing
+// configured. Idempotent: a second call finds nothing to remove.
+export function pruneUnconfiguredProviders() {
+  if (discoveryDisabled()) return [];
+  if (
+    process.env.MODEL_ROUTER_SHOW_ALL_MODELS === "1" ||
+    (TARGET === "codex" && process.env.CODEX_ROUTER_SHOW_ALL_MODELS === "1")
+  ) {
+    return [];
+  }
+  if (!existsSync(PROVIDER_SELECTION_PATH)) return [];
+
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(PROVIDER_SELECTION_PATH, "utf8"));
+  } catch {
+    return [];
+  }
+  if (parsed?.version !== 1 || !Array.isArray(parsed.providers)) return [];
+
+  const { known, unknown } = filterKnownProviderIds(parsed.providers);
+  const configured = new Set(configuredProviderIds());
+  const keep = known.filter((id) => configured.has(id));
+  const removed = [
+    ...unknown.map((id) => ({ id, reason: "unrecognised" })),
+    ...known
+      .filter((id) => !configured.has(id))
+      .map((id) => ({ id, reason: "no credential" })),
+  ];
+  if (removed.length === 0) return [];
+
+  // Only-unknown files currently read as the no-file default (show all).
+  // Deleting the file preserves that; writing [] would idle the install.
+  if (keep.length === 0 && known.length === 0) {
+    unlinkSync(PROVIDER_SELECTION_PATH);
+    return removed;
+  }
+
+  writeProviderSelection(keep);
+  return removed;
 }
 
 export function selectedListedModels() {

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -10,6 +10,7 @@ import {
   LITELLM_CONFIG_PATH,
   MERGED_CATALOG_PATH,
   PORTS,
+  PROVIDER_SELECTION_PATH,
   SOURCE_ROOT,
   STATE_DIR,
   TARGET,
@@ -35,6 +36,8 @@ import {
 } from "./proxy-environment.mjs";
 import { antigravityOAuthStatus } from "./antigravity-oauth-status.mjs";
 import { cursorTunnelRunSpec } from "./cursor-cloudflare-tunnel.mjs";
+import { pruneUnconfiguredProviders } from "./provider-selection.mjs";
+import { targetCli } from "./target-integration.mjs";
 
 // Before anything reads the environment or spawns a child. A service manager
 // hands this process the proxy the install recorded; a shell hands it whatever
@@ -121,6 +124,25 @@ const callerKey = assertCallerSecret(
   readFileSync(CALLER_SECRET_PATH, "utf8").trim(),
 );
 writeLiteLlmConfig();
+
+// Drop enabled providers this build cannot authenticate (missing credential,
+// retired/unknown id). Without this, enabled-providers.json accrues dead
+// entries and the next turn against them returns provider_api_key_missing
+// while the picker can still advertise a stale catalog row. Runs after the
+// gateway config write so a prune that rewrites selection cannot race a
+// concurrent config reader mid-start; forwarders spawned below see the
+// reconciled file.
+const prunedProviders = pruneUnconfiguredProviders();
+if (prunedProviders.length) {
+  console.error(
+    `[codex-router] pruned ${prunedProviders.length} provider(s) from ${PROVIDER_SELECTION_PATH}: ${
+      prunedProviders.map(({ id, reason }) => `${id} (${reason})`).join(", ")
+    }`,
+  );
+  console.error(
+    `[codex-router] restore with: ${targetCli("setup --guided")} or ${targetCli("providers enable <id>")} after storing a credential`,
+  );
+}
 
 // A checked local model means the operator intends to route through Ollama,
 // so keep its daemon available for the gateway. This never installs software

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -25,6 +25,7 @@ const {
   disableProvider,
   enableProvider,
   providerSelectionStatus,
+  pruneUnconfiguredProviders,
   readProviderSelection,
   readProviderSelectionDetail,
   selectedConfiguredListedModels,
@@ -401,6 +402,82 @@ test("the write path still rejects an unknown provider id", () => {
       ["deepseek", "kimi-api"],
     );
     assert.deepEqual(readProviderSelectionDetail().ignored, []);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("pruneUnconfiguredProviders drops unknown and uncredentialed ids from the file", () => {
+  try {
+    writeProviderCredential("deepseek", "TEST_DEEPSEEK_PRUNE_KEY");
+    stageSelectionFile(
+      `${JSON.stringify({
+        version: 1,
+        providers: ["deepseek", "kimi-api", "provider-from-a-newer-build"],
+      })}\n`,
+    );
+
+    const removed = pruneUnconfiguredProviders();
+    assert.deepEqual(
+      removed.map(({ id, reason }) => [id, reason]).sort(),
+      [
+        ["kimi-api", "no credential"],
+        ["provider-from-a-newer-build", "unrecognised"],
+      ],
+    );
+    assert.deepEqual(
+      JSON.parse(readFileSync(PROVIDER_SELECTION_PATH, "utf8")).providers,
+      ["deepseek"],
+    );
+    assert.deepEqual(pruneUnconfiguredProviders(), []);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("pruneUnconfiguredProviders does not invent a selection file", () => {
+  try {
+    rmSync(testRoot, { recursive: true, force: true });
+    assert.equal(existsSync(PROVIDER_SELECTION_PATH), false);
+    assert.deepEqual(pruneUnconfiguredProviders(), []);
+    assert.equal(existsSync(PROVIDER_SELECTION_PATH), false);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("pruneUnconfiguredProviders deletes a file that names only unknown providers", () => {
+  try {
+    stageSelectionFile(
+      `${JSON.stringify({
+        version: 1,
+        providers: ["provider-from-a-newer-build", "provider-that-was-removed"],
+      })}\n`,
+    );
+
+    const removed = pruneUnconfiguredProviders();
+    assert.deepEqual(
+      removed.map(({ id }) => id).sort(),
+      ["provider-from-a-newer-build", "provider-that-was-removed"],
+    );
+    assert.equal(existsSync(PROVIDER_SELECTION_PATH), false);
+    // Same coherent state as a fresh install: no explicit file means show all,
+    // and the credential-aware catalog still hides anything that cannot auth.
+    assert.deepEqual(readProviderSelection(), [...PROVIDERS.keys()]);
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("pruneUnconfiguredProviders keeps anonymous and keyless selections", () => {
+  try {
+    writeProviderSelection(["opencode-free", "local", "kimi-api"]);
+    const removed = pruneUnconfiguredProviders();
+    assert.deepEqual(removed, [{ id: "kimi-api", reason: "no credential" }]);
+    assert.deepEqual(
+      JSON.parse(readFileSync(PROVIDER_SELECTION_PATH, "utf8")).providers,
+      ["opencode-free", "local"],
+    );
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Why

`enabled-providers.json` accrued unknown and credentialless ids with no reconcile path. The picker kept advertising them; every request answered `provider_api_key_missing`.

## Scope

- `pruneUnconfiguredProviders()` walks the on-disk selection and drops ids the current build cannot authenticate.
- Startup calls it after LiteLLM config write.
- Empty/`anonymous`/`keyless` selections stay intentional.

Does **not** include the empty-`tools` strip (#588/#594 already landed).

## Blast Radius

Provider selection file at service start. Operators who enabled a provider before storing a key will see it disappear from the enabled set until they credential and re-enable.

## Verification

- `node --test test/provider-selection.test.mjs` — 16 pass

Fixes #589


Made with [Cursor](https://cursor.com)