### PR TITLE
fix: refresh native catalog without rewriting config when safe

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -202,6 +202,21 @@ function readModelsCache() {
   }
 }
 
+// A routed custom catalog never rewrites Codex's account cache. When that cache
+// is valid and contains no routed slugs, it remains a safe native source even
+// while model_catalog_json points at the merged router catalog.
+export function nativeCacheCanRefreshInPlace(cache = readModelsCache()) {
+  const catalog = cache?.catalog;
+  return (
+    Boolean(validNativeCatalog(catalog)) &&
+    !catalog.models.some((model) => MODEL_BY_SLUG.has(String(model.slug)))
+  );
+}
+
+export function nativeCatalogCanRefreshInPlace() {
+  return discoveryDisabled() || nativeCacheCanRefreshInPlace();
+}
+
 function atomicContents(target, contents) {
   mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
   const temporary = `${target}.tmp.${process.pid}`;

--- a/src/refresh-catalog.mjs
+++ b/src/refresh-catalog.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { nativeCatalogCanRefreshInPlace } from "./catalog.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import {
   beginLoginFreeRefresh,
@@ -85,6 +86,7 @@ function restoreTransport(
 
 async function refreshCatalogUnlocked({
   run = nodeRunner,
+  canRefreshInPlace = nativeCatalogCanRefreshInPlace,
   aliases = readNativeAliases,
   aliasFor = nativeAliasFor,
   journal = {
@@ -126,6 +128,15 @@ async function refreshCatalogUnlocked({
   };
   let restoreNeeded = false;
   let catalogResult;
+  // Signed-in Codex keeps its account cache separate from model_catalog_json.
+  // When that cache is known-native, refresh the catalog without rewriting
+  // config.toml; this also avoids needless failures when another Windows
+  // process has the config open without delete sharing. Login-free mode still
+  // requires the journaled transport transition below.
+  if (routed && !loginFree && canRefreshInPlace()) {
+    catalogResult = checked(run, "catalog.mjs", ["--refresh-native"]);
+    return { catalogOutput: catalogResult.stdout || "" };
+  }
   try {
     if (routed) {
       if (loginFree) {

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -21,6 +21,7 @@ import {
   codexEffortVocabulary,
   effectivePickerHiddenModels,
   liveAccountCatalogProbeAllowed,
+  nativeCacheCanRefreshInPlace,
   nativeCatalogIsReusable,
   deriveBaseInstructions,
   mergeNativeCatalogs,
@@ -911,6 +912,20 @@ test("models stay untouched when the installed build understands their efforts",
   };
   const [unchanged] = clampModelEfforts([original], vocabulary);
   assert.equal(unchanged, original);
+});
+
+test("native cache permits in-place refresh only when it contains native models", () => {
+  assert.equal(
+    nativeCacheCanRefreshInPlace({ catalog: { models: [template] } }),
+    true,
+  );
+  assert.equal(
+    nativeCacheCanRefreshInPlace({
+      catalog: { models: [template, { ...template, slug: grok.slug }] },
+    }),
+    false,
+  );
+  assert.equal(nativeCacheCanRefreshInPlace({}), false);
 });
 
 test("native catalog cache is reusable only for the codex build that captured it", () => {

--- a/test/refresh-catalog.test.mjs
+++ b/test/refresh-catalog.test.mjs
@@ -41,9 +41,27 @@ function recordingRunner({ signed = true, loginFree = false, model, failAt } = {
   };
 }
 
+test("ordinary routed refresh avoids config mutation when the native cache is safe", async () => {
+  const runner = recordingRunner();
+  const result = await refreshCatalog({
+    canRefreshInPlace: () => true,
+    run: runner.run,
+    lock: noLock,
+  });
+  assert.deepEqual(runner.calls, [
+    ["config-manager.mjs", ["status"]],
+    ["catalog.mjs", ["--refresh-native"]],
+  ]);
+  assert.equal(result.catalogOutput, '{"models":1}\n');
+});
+
 test("refresh orchestration restores signed routing and republishes the routed catalog", async () => {
   const runner = recordingRunner();
-  const result = await refreshCatalog({ run: runner.run, lock: noLock });
+  const result = await refreshCatalog({
+    canRefreshInPlace: () => false,
+    run: runner.run,
+    lock: noLock,
+  });
   assert.deepEqual(runner.calls, [
     ["config-manager.mjs", ["status"]],
     ["config-manager.mjs", ["disable"]],
@@ -58,7 +76,11 @@ test("refresh orchestration restores signed routing and republishes the routed c
 test("refresh orchestration restores the active transport after catalog failure", async () => {
   const runner = recordingRunner({ failAt: 3 });
   await assert.rejects(
-    refreshCatalog({ run: runner.run, lock: noLock }),
+    refreshCatalog({
+      canRefreshInPlace: () => false,
+      run: runner.run,
+      lock: noLock,
+    }),
     /catalog\.mjs exited with status 75.*forced catalog failure/s,
   );
   assert.deepEqual(runner.calls, [
@@ -73,7 +95,11 @@ test("refresh orchestration restores the active transport after catalog failure"
 
 test("ordinary routed refresh also republishes external models after restore", async () => {
   const runner = recordingRunner({ signed: false });
-  await refreshCatalog({ run: runner.run, lock: noLock });
+  await refreshCatalog({
+    canRefreshInPlace: () => false,
+    run: runner.run,
+    lock: noLock,
+  });
   assert.deepEqual(runner.calls, [
     ["config-manager.mjs", ["status"]],
     ["config-manager.mjs", ["disable"]],
@@ -90,6 +116,7 @@ test("refresh orchestration restores identity-preserving login-free mode and its
     model: "gpt-5.6-sol",
   });
   await refreshCatalog({
+    canRefreshInPlace: () => true,
     run: runner.run,
     aliases: () => ({ "gpt-5.6-sol": "deepseek/deepseek-v4-pro" }),
     aliasFor: (slug) => slug === "deepseek/deepseek-v4-pro" ? "gpt-5.6-terra" : undefined,
@@ -130,6 +157,7 @@ test("pending refresh resumes and completes only with an alias for the same cano
     displayModel: "old-alias",
   };
   await refreshCatalog({
+    canRefreshInPlace: () => true,
     run: runner.run,
     aliases: () => ({ "old-alias": pending.canonicalModel }),
     aliasFor: (slug) => slug === pending.canonicalModel ? "fresh-alias" : undefined,


### PR DESCRIPTION
## Summary

Make `refresh-catalog` avoid rewriting `~/.codex/config.toml` when the signed-in Codex account cache is already a valid native-only source.

## Problem

`refresh-catalog` currently always disables the routed transport before recapturing native models. On Windows that first config mutation can fail with `EPERM` if another local process has `config.toml` open without delete sharing, even though `catalog.mjs --refresh-native` can safely refresh from Codex's separate native `models_cache.json`.

I reproduced this after updating Codex Desktop to 26.901.5003.0 / `codex-cli 0.153.3`: the wrapper failed on the atomic `config.toml` rename, while the catalog-only refresh succeeded from a native-only account cache and cleared the stale-catalog warning without changing routing.

## Fix

- Add a fail-closed preflight that permits in-place refresh only when `models_cache.json` is valid and contains no checked-in routed slugs, or when discovery is disabled and capture is bundled-only.
- In ordinary signed-in routed mode, use that safe in-place catalog refresh without touching `config.toml`.
- Preserve the existing disable/restore transaction when the cache is missing, invalid, or contaminated.
- Preserve the existing journaled transport flow for login-free mode even when the preflight would otherwise pass.

## Verification

- `node --test test/catalog.test.mjs test/refresh-catalog.test.mjs` — 75/75 passed
- `npm run check` — passed
- `git diff --check` — passed

No login-free safety behavior or credential handling is weakened.