### PR TITLE
feat: passively refresh mirrored native models

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,29 @@ broader vendor profile just to repair `tool_choice`. The provider's own
 local to your machine and are not vetted by the repository's compatibility
 tests.
 
+A private OpenAI Responses gateway can opt into automatic native-model
+mirroring in its local registry fragment:
+
+```json
+{
+  "protocol": "openai-responses",
+  "allowPrivate": true,
+  "mirrorNativeModels": true
+}
+```
+
+`allowPrivate` is required only for a private or loopback discovery endpoint.
+During `./bin/refresh-catalog`, the router asks the signed-in Codex account for
+its current native catalog and asks each opted-in provider for `/models`. It
+automatically adds or updates only exact model-id matches that are visible to
+the account and advertised by that provider. Provider-only ids, hidden native
+models, and manually curated entries are left untouched. Automatically
+mirrored routes remain conservative: client-only `ultra` reasoning is not advertised
+for an automatically mirrored upstream whose `/models` response cannot certify
+it. A manually curated route remains authoritative. Codex still loads the
+resulting `model_catalog_json` at startup, so fully quit and reopen the app to
+see a newly mirrored model.
+
 The same managed OpenAI base URL also serves `/v1/embeddings`, but only for a
 model whose local or checked-in metadata explicitly names the capability. A
 model that is both conversational and embedding-capable declares its normal

--- a/README.md
+++ b/README.md
@@ -612,7 +612,11 @@ the account and advertised by that provider. Provider-only ids, hidden native
 models, and manually curated entries are left untouched. Automatically
 mirrored routes remain conservative: client-only `ultra` reasoning is not advertised
 for an automatically mirrored upstream whose `/models` response cannot certify
-it. A manually curated route remains authoritative. Codex still loads the
+it, and search-history replay is not inferred from another model or from
+Responses compatibility alone. After live-testing one exact managed route, an
+operator may set its `supportsSearchHistory` boolean in the protected
+`user-models.json`; later mirror refreshes preserve that route-specific proof.
+A manually curated route remains authoritative. Codex still loads the
 resulting `model_catalog_json` at startup, so fully quit and reopen the app to
 see a newly mirrored model.
 

--- a/README.md
+++ b/README.md
@@ -610,12 +610,14 @@ its current native catalog and asks each opted-in provider for `/models`. It
 automatically adds or updates only exact model-id matches that are visible to
 the account and advertised by that provider. Provider-only ids, hidden native
 models, and manually curated entries are left untouched. Automatically
-mirrored routes remain conservative: client-only `ultra` reasoning is not advertised
-for an automatically mirrored upstream whose `/models` response cannot certify
-it, and search-history replay is not inferred from another model or from
-Responses compatibility alone. After live-testing one exact managed route, an
-operator may set its `supportsSearchHistory` boolean in the protected
-`user-models.json`; later mirror refreshes preserve that route-specific proof.
+mirrored routes remain conservative: client-only `ultra` reasoning is not
+advertised when a route is first created because the provider's `/models`
+response cannot certify it, and search-history replay is not inferred from
+another model or from Responses compatibility alone. After live-testing one
+exact managed route, an operator may add its native-advertised `ultra` rung or
+set its `supportsSearchHistory` boolean in the protected `user-models.json`.
+Later mirror refreshes preserve only those route-specific proofs; `ultra` is
+dropped again if the native catalog stops advertising it.
 A manually curated route remains authoritative. Codex still loads the
 resulting `model_catalog_json` at startup, so fully quit and reopen the app to
 see a newly mirrored model.

--- a/README.md
+++ b/README.md
@@ -616,6 +616,18 @@ it. A manually curated route remains authoritative. Codex still loads the
 resulting `model_catalog_json` at startup, so fully quit and reopen the app to
 see a newly mirrored model.
 
+An opted-in mirror is also refreshed passively without a polling loop. Router
+startup and the end of normal traffic are local trigger points only: after 30
+seconds of continuous idle time, the first trigger whose durable cooldown has
+expired starts one detached refresh. Successful checks cool down for 24 hours,
+concurrent triggers coalesce, and failures back off for 1, 2, 4, 8, then at
+most 24 hours. A new request during the idle grace period cancels the pending
+check. No Router use means no repeated network checks, and an unchanged model
+intersection neither republishes routes nor restarts the service. An explicit
+`./bin/refresh-catalog` remains the immediate override and resets the success
+cooldown. Set `CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH=1` on the Router
+service to disable this behavior.
+
 The same managed OpenAI base URL also serves `/v1/embeddings`, but only for a
 model whose local or checked-in metadata explicitly names the capability. A
 model that is both conversational and embedding-capable declares its normal

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -68,6 +68,15 @@ than guessing it. Existing manual curation is authoritative and is never
 overwritten; missing provider ids are retained so a transiently incomplete
 catalog cannot delete a working route.
 
+Passive mirroring is event-driven rather than periodic. The Router keeps only
+an in-memory next-eligible timestamp on the request path, resets one unref'ed
+idle timer when traffic resumes, and hands due work to a detached process.
+That worker reserves the attempt in an owner-private state document before any
+network IO. This durable reservation is the cross-process singleflight and the
+crash backstop; success uses a 24-hour cooldown and failures use capped
+exponential backoff. Never move provider discovery into the synchronous request
+path or let a failed worker retry on every turn.
+
 The shared API forwarder strips host and internal authentication before
 injecting the selected provider key. It supports the registry's tested
 OpenAI-compatible and Anthropic protocols; do not create a new listener merely

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -58,6 +58,16 @@ live miss.
    calls, and compaction before setting `listed: true`.
 8. Update the README model table and provider-specific setup documentation.
 
+Credentialed providers on a private network must explicitly declare
+`allowPrivate: true` before discovery may contact their `/models` endpoint.
+An `openai-responses` provider may also declare `mirrorNativeModels: true` when
+it intentionally serves the same GPT model ids as the signed-in Codex account.
+The refresh path then mirrors only the intersection of the live provider list
+and account-visible native catalog, using native capability metadata rather
+than guessing it. Existing manual curation is authoritative and is never
+overwritten; missing provider ids are retained so a transiently incomplete
+catalog cannot delete a working route.
+
 The shared API forwarder strips host and internal authentication before
 injecting the selected provider key. It supports the registry's tested
 OpenAI-compatible and Anthropic protocols; do not create a new listener merely

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -64,6 +64,7 @@ import { withCatalogPublicationLock } from "./catalog-publication-lock.mjs";
 import { routedModelSearchAvailable } from "./search-capability.mjs";
 
 const refresh = process.argv.includes("--refresh-native");
+const routerTransportParked = process.argv.includes("--router-transport-parked");
 
 function validNativeCatalog(parsed) {
   return parsed && Array.isArray(parsed.models) && parsed.models.length > 0;
@@ -202,6 +203,13 @@ function readModelsCache() {
   }
 }
 
+function nativeCatalogFingerprint(catalog) {
+  if (!validNativeCatalog(catalog)) return undefined;
+  return createHash("sha256")
+    .update(JSON.stringify(catalog.models))
+    .digest("hex");
+}
+
 function atomicContents(target, contents) {
   mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
   const temporary = `${target}.tmp.${process.pid}`;
@@ -250,7 +258,7 @@ function catalogContainsRoutedSlugs(catalog) {
   );
 }
 
-function captureNative(cache) {
+function captureNative(cache, { preferLive = false } = {}) {
   // A discovery-disabled install promised that nothing account-derived is
   // read: `debug models` without --bundled reflects the signed-in account's
   // catalog, and `models_cache.json` is that same catalog written to disk, so
@@ -258,12 +266,17 @@ function captureNative(cache) {
   // This is the gate SECURITY.md's "the one Codex spawn that remains is
   // `codex debug models --bundled`" claim rests on.
   const idle = discoveryDisabled();
-  const routedActive = routedCatalogActive();
+  // Only refresh-catalog may assert that it transactionally parked the router
+  // transport. A direct `catalog --refresh-native` keeps probing disabled when
+  // routing ownership is active or ambiguous, so it cannot capture its own
+  // merged model_catalog_json as an account catalog.
+  const routedActive = routerTransportParked ? false : routedCatalogActive();
   const resolved = cache ?? (idle ? {} : readModelsCache());
   // This is the account-aware catalog Codex itself cached after signing in.
   // Reading it directly also avoids asking `codex debug models` while the
   // router catalog is active, which would merely return our own merged output.
-  let account = resolved.catalog;
+  const cachedAccount = resolved.catalog;
+  let account = cachedAccount;
   let fallback;
   let accountError;
   let fallbackError;
@@ -274,10 +287,18 @@ function captureNative(cache) {
       "models_cache.json contains routed model slugs; refusing to treat it as native.",
     );
   }
-  if (!account && liveAccountCatalogProbeAllowed({
+  const liveAllowed = liveAccountCatalogProbeAllowed({
     discoveryDisabled: idle,
     routedCatalogActive: routedActive,
-  })) {
+  });
+  // `--refresh-native` is an explicit request for the account's current
+  // catalog. A syntactically valid models_cache.json can still predate a
+  // server-side rollout by days, so it is a fallback here, not the authority.
+  // The refresh orchestrator parks the routed config before this call; direct
+  // refreshes made while routing is active remain cache-only so `debug models`
+  // cannot echo the merged router catalog back into the native capture.
+  if (preferLive && liveAllowed) account = undefined;
+  if (!account && liveAllowed) {
     try {
       account = JSON.parse(runCodex(["debug", "models"], {
         encoding: "utf8",
@@ -286,6 +307,9 @@ function captureNative(cache) {
       }));
     } catch (error) {
       accountError = error;
+      if (cachedAccount && !catalogContainsRoutedSlugs(cachedAccount)) {
+        account = cachedAccount;
+      }
     }
   }
   // The bundled source supplies schema fields that the remote cache is allowed
@@ -313,7 +337,7 @@ function captureNative(cache) {
     );
   }
   const capturedWith = codexVersion();
-  const sourceFingerprint = cache.fingerprint;
+  const sourceFingerprint = nativeCatalogFingerprint(account) || resolved.fingerprint;
   atomicJson(NATIVE_CATALOG_PATH, {
     ...(capturedWith ? { captured_with: capturedWith } : {}),
     ...(sourceFingerprint ? { native_source_fingerprint: sourceFingerprint } : {}),
@@ -374,7 +398,7 @@ function nativeCatalog({ refreshNative = refresh } = {}) {
   };
   if (!existsSync(NATIVE_CATALOG_PATH) || refreshNative) {
     try {
-      return captureNative(cache);
+      return captureNative(cache, { preferLive: refreshNative });
     } catch (error) {
       // Account switching refreshes native while the router still owns
       // model_catalog_json. Prefer a prior capture over aborting the switch.

--- a/src/model-discovery.mjs
+++ b/src/model-discovery.mjs
@@ -243,6 +243,10 @@ function sameProviderDiscoveryIdentity(left, right) {
     === providerDiscoveryIdentityFingerprint(right);
 }
 
+export function providerAllowsPrivateDiscovery(provider) {
+  return Boolean(provider?.keyless || provider?.allowPrivate);
+}
+
 function discoveryEndpoint(identity) {
   const baseUrl = identity?.baseUrl || identity?.session?.apiServerUrl;
   return typeof baseUrl === "string" && baseUrl.trim() ? `${baseUrl.replace(/\/+$/, "")}/models` : undefined;
@@ -324,7 +328,11 @@ async function providerPayload(provider, identity) {
   }
   return fetchUntrustedModelCatalog(`${baseUrl}/models`, {
     headers,
-    allowPrivate: Boolean(provider.keyless),
+    // A credentialed LAN gateway is allowed only when its registry descriptor
+    // opts into the same private-network exception generic providers expose.
+    // Keeping the default false preserves the SSRF boundary for every existing
+    // public provider and for private fragments that did not make the choice.
+    allowPrivate: providerAllowsPrivateDiscovery(provider),
   });
 }
 

--- a/src/model-registry.mjs
+++ b/src/model-registry.mjs
@@ -253,10 +253,21 @@ function loadRegistry() {
       if (provider.keyless !== undefined && typeof provider.keyless !== "boolean") {
         fail(`provider ${provider.id} has an invalid keyless flag`);
       }
-      for (const field of ["directResponses", "codexOnly", "explicitSelection"]) {
+      for (const field of [
+        "directResponses",
+        "codexOnly",
+        "explicitSelection",
+        "allowPrivate",
+        "mirrorNativeModels",
+      ]) {
         if (provider[field] !== undefined && typeof provider[field] !== "boolean") {
           fail(`provider ${provider.id} has an invalid ${field} flag`);
         }
+      }
+      if (provider.mirrorNativeModels && provider.protocol !== "openai-responses") {
+        fail(
+          `provider ${provider.id} may mirror native models only through openai-responses`,
+        );
       }
       if (provider.keyless && provider.credential !== undefined) {
         fail(`keyless provider ${provider.id} must not declare a credential`);

--- a/src/native-model-mirror.mjs
+++ b/src/native-model-mirror.mjs
@@ -1,0 +1,229 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { discoverProviderModels } from "./model-discovery.mjs";
+import { RUNTIME_PROVIDERS } from "./model-registry.mjs";
+import { readNativeCatalogFile } from "./native-catalog-source.mjs";
+import {
+  applyModelOverlayPublication,
+  transactModelOverlayMutation,
+} from "./model-overlay-publication.mjs";
+import { MODEL_PICKER_STATE_PATH, setModelsVisible } from "./model-picker-state.mjs";
+import { NATIVE_CATALOG_PATH } from "./paths.mjs";
+import {
+  USER_MODELS_PATH,
+  readUserModels,
+  userModelEntry,
+  writeUserModels,
+} from "./user-models.mjs";
+
+export const NATIVE_MODEL_MIRROR_MARKER = "codex-router/native-model-mirror/v1";
+
+function mirroredDisplayName(provider, nativeModel) {
+  const nativeName = String(nativeModel?.display_name || nativeModel?.slug || "").trim();
+  return `${provider.displayName} · ${nativeName}`;
+}
+
+function mirroredMetadata(provider, nativeModel) {
+  const contextWindow = Number.isInteger(nativeModel?.context_window) && nativeModel.context_window > 0
+    ? nativeModel.context_window
+    : undefined;
+  const reasoningLevels = Array.isArray(nativeModel?.supported_reasoning_levels) &&
+      nativeModel.supported_reasoning_levels.length
+    ? nativeModel.supported_reasoning_levels
+      // The account catalog may expose client-only quota modes such as ultra.
+      // `/models` certifies the id, not those private-upstream capabilities;
+      // keep automatic routes on the portable Responses effort vocabulary.
+      .filter((level) => level.effort !== "ultra")
+      .map((level) => ({
+          effort: level.effort,
+          description: level.description || `${level.effort} reasoning`,
+        }))
+    : undefined;
+  const defaultEffort = reasoningLevels?.some(
+    (level) => level.effort === nativeModel.default_reasoning_level,
+  )
+    ? nativeModel.default_reasoning_level
+    : reasoningLevels?.at(-1)?.effort;
+  return {
+    displayName: mirroredDisplayName(provider, nativeModel),
+    description:
+      `Automatically mirrored from native ${nativeModel.slug} metadata after ` +
+      `${provider.displayName} advertised the same model id.`,
+    ...(contextWindow
+      ? { contextWindow, autoCompact: Math.floor(contextWindow * 0.85) }
+      : {}),
+    ...(Array.isArray(nativeModel?.input_modalities) && nativeModel.input_modalities.length
+      ? { inputModalities: [...nativeModel.input_modalities] }
+      : {}),
+    ...(reasoningLevels ? { reasoningLevels, defaultEffort } : {}),
+    ...(Array.isArray(nativeModel?.service_tiers) && nativeModel.service_tiers.length
+      ? {
+          serviceTiers: nativeModel.service_tiers.map((tier) => ({
+            id: tier.id,
+            name: tier.name,
+            ...(tier.description ? { description: tier.description } : {}),
+          })),
+        }
+      : {}),
+  };
+}
+
+export function mirroredNativeModelEntry({ provider, nativeModel, priority }) {
+  return {
+    ...userModelEntry({
+      providerId: provider.id,
+      upstreamId: nativeModel.slug,
+      priority,
+      metadata: mirroredMetadata(provider, nativeModel),
+    }),
+    managedBy: NATIVE_MODEL_MIRROR_MARKER,
+    nativeModelSlug: nativeModel.slug,
+  };
+}
+
+export function planNativeModelMirror({
+  provider,
+  nativeModels,
+  discovered,
+  existing,
+}) {
+  const advertised = new Set(discovered || []);
+  const candidates = (nativeModels || []).filter((model) => (
+    model?.visibility === "list" &&
+    model?.supported_in_api !== false &&
+    typeof model?.slug === "string" &&
+    advertised.has(model.slug)
+  ));
+  const models = [...(existing || [])];
+  const owned = new Map();
+  let nextPriority = 100;
+  for (let index = 0; index < models.length; index += 1) {
+    const model = models[index];
+    if (model?.provider === provider.id && typeof model?.upstreamModel === "string") {
+      owned.set(model.upstreamModel, index);
+      if (Number.isInteger(model.priority)) nextPriority = Math.max(nextPriority, model.priority + 1);
+    }
+  }
+
+  const added = [];
+  const updated = [];
+  const preserved = [];
+  for (const nativeModel of candidates) {
+    const index = owned.get(nativeModel.slug);
+    const current = index === undefined ? undefined : models[index];
+    if (current && current.managedBy !== NATIVE_MODEL_MIRROR_MARKER) {
+      preserved.push(current.slug);
+      continue;
+    }
+    const generated = mirroredNativeModelEntry({
+      provider,
+      nativeModel,
+      priority: current?.priority ?? nextPriority,
+    });
+    if (current) {
+      if (JSON.stringify(current) !== JSON.stringify(generated)) {
+        models[index] = generated;
+        updated.push(generated.slug);
+      }
+      continue;
+    }
+    nextPriority += 1;
+    owned.set(nativeModel.slug, models.length);
+    models.push(generated);
+    added.push(generated.slug);
+  }
+  return { models, added, updated, preserved };
+}
+
+export async function syncNativeModelMirrors({
+  providers = RUNTIME_PROVIDERS,
+  discover = discoverProviderModels,
+  readNative = () => readNativeCatalogFile(NATIVE_CATALOG_PATH),
+  readModels = readUserModels,
+  writeModels = writeUserModels,
+  showModels = (slugs) => setModelsVisible(slugs, true),
+  transact = transactModelOverlayMutation,
+  applyPublication = applyModelOverlayPublication,
+  restartService,
+} = {}) {
+  const mirroredProviders = [...providers.values()].filter(
+    (provider) => provider.mirrorNativeModels === true,
+  );
+  if (!mirroredProviders.length) {
+    return { providers: 0, added: [], updated: [], preserved: [], changed: false };
+  }
+  const native = readNative();
+  if (!native?.models?.length) {
+    throw new Error("Native model mirroring requires a valid refreshed native catalog.");
+  }
+
+  // Network IO stays outside the model-overlay lock. The commit below re-reads
+  // user state under that lock, so concurrent manual curation is preserved.
+  const discoveries = new Map();
+  for (const provider of mirroredProviders) {
+    const discovery = await discover(provider.id, { refresh: true });
+    discoveries.set(provider.id, discovery.discovered);
+  }
+
+  const planAll = (existing) => {
+    let models = existing;
+    const summary = {
+      providers: mirroredProviders.length,
+      added: [],
+      updated: [],
+      preserved: [],
+    };
+    for (const provider of mirroredProviders) {
+      const plan = planNativeModelMirror({
+        provider,
+        nativeModels: native.models,
+        discovered: discoveries.get(provider.id),
+        existing: models,
+      });
+      models = plan.models;
+      summary.added.push(...plan.added);
+      summary.updated.push(...plan.updated);
+      summary.preserved.push(...plan.preserved);
+    }
+    return {
+      ...summary,
+      models,
+      changed: summary.added.length > 0 || summary.updated.length > 0,
+    };
+  };
+
+  // Avoid publishing or restarting when discovery did not change the managed
+  // overlay. The transaction re-plans under its lock before committing so a
+  // concurrent manual edit is never overwritten by this preview.
+  const preview = planAll(readModels());
+  if (!preview.changed) {
+    const { models: _models, ...summary } = preview;
+    return summary;
+  }
+
+  let result;
+  await transact({
+    files: [USER_MODELS_PATH, MODEL_PICKER_STATE_PATH],
+    restart: true,
+    applyPublication,
+    restartService,
+    mutate: () => {
+      const plan = planAll(readModels());
+      if (plan.changed) writeModels(plan.models);
+      if (plan.added.length) showModels(plan.added);
+      const { models: _models, ...summary } = plan;
+      result = summary;
+    },
+  });
+  return result;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.stdout.write(`${JSON.stringify(await syncNativeModelMirrors())}\n`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/src/native-model-mirror.mjs
+++ b/src/native-model-mirror.mjs
@@ -121,6 +121,13 @@ export function planNativeModelMirror({
       nativeModel,
       priority: current?.priority ?? nextPriority,
     });
+    // Discovery can refresh presentation metadata, but it cannot certify
+    // whether this exact provider/model route accepts completed search items.
+    // Preserve an operator's route-specific proof without inferring it for a
+    // newly mirrored model or copying it from another route.
+    if (typeof current?.supportsSearchHistory === "boolean") {
+      generated.supportsSearchHistory = current.supportsSearchHistory;
+    }
     if (current) {
       if (JSON.stringify(current) !== JSON.stringify(generated)) {
         models[index] = generated;

--- a/src/native-model-mirror.mjs
+++ b/src/native-model-mirror.mjs
@@ -128,6 +128,21 @@ export function planNativeModelMirror({
     if (typeof current?.supportsSearchHistory === "boolean") {
       generated.supportsSearchHistory = current.supportsSearchHistory;
     }
+    // `/models` only certifies the model id, so new mirrors stay conservative.
+    // Once an operator verifies ultra on this exact route, preserve that rung
+    // while the signed-in native catalog continues to advertise it.
+    const currentUltra = Array.isArray(current?.reasoningLevels)
+      ? current.reasoningLevels.find((level) => (
+          level?.effort === "ultra" &&
+          typeof level.description === "string" &&
+          level.description.trim()
+        ))
+      : undefined;
+    const nativeHasUltra = Array.isArray(nativeModel.supported_reasoning_levels) &&
+      nativeModel.supported_reasoning_levels.some((level) => level?.effort === "ultra");
+    if (currentUltra && nativeHasUltra && Array.isArray(generated.reasoningLevels)) {
+      generated.reasoningLevels = [...generated.reasoningLevels, { ...currentUltra }];
+    }
     if (current) {
       if (JSON.stringify(current) !== JSON.stringify(generated)) {
         models[index] = generated;

--- a/src/passive-catalog-refresh.mjs
+++ b/src/passive-catalog-refresh.mjs
@@ -1,0 +1,382 @@
+import { spawn, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { withAtomicStateLock } from "./atomic-state-lock.mjs";
+import { writePrivateJson } from "./file-security.mjs";
+import { RUNTIME_PROVIDERS } from "./model-registry.mjs";
+import {
+  PASSIVE_CATALOG_REFRESH_PATH,
+  SOURCE_ROOT,
+  TARGET,
+} from "./paths.mjs";
+import { detachedOperationEnvironment } from "./process-tree.mjs";
+
+const SELF = fileURLToPath(import.meta.url);
+const STATE_VERSION = 1;
+const MAX_STATE_BYTES = 64 * 1024;
+const MIN_CONFIGURED_DELAY_MS = 60_000;
+const MAX_CONFIGURED_DELAY_MS = 7 * 24 * 60 * 60_000;
+
+export const PASSIVE_CATALOG_REFRESH_INTERVAL_MS = 24 * 60 * 60_000;
+export const PASSIVE_CATALOG_REFRESH_FAILURE_BASE_MS = 60 * 60_000;
+export const PASSIVE_CATALOG_REFRESH_FAILURE_MAX_MS = 24 * 60 * 60_000;
+export const PASSIVE_CATALOG_REFRESH_IDLE_MS = 30_000;
+
+function boundedDelay(value, fallback, { minimum = MIN_CONFIGURED_DELAY_MS } = {}) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < minimum) return fallback;
+  return Math.min(MAX_CONFIGURED_DELAY_MS, Math.floor(parsed));
+}
+
+export function passiveCatalogRefreshOptions(environment = process.env) {
+  return {
+    disabled: environment.CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH === "1",
+    intervalMs: boundedDelay(
+      environment.CODEX_ROUTER_PASSIVE_CATALOG_REFRESH_INTERVAL_MS,
+      PASSIVE_CATALOG_REFRESH_INTERVAL_MS,
+    ),
+    failureBaseMs: boundedDelay(
+      environment.CODEX_ROUTER_PASSIVE_CATALOG_REFRESH_FAILURE_BASE_MS,
+      PASSIVE_CATALOG_REFRESH_FAILURE_BASE_MS,
+    ),
+    failureMaxMs: boundedDelay(
+      environment.CODEX_ROUTER_PASSIVE_CATALOG_REFRESH_FAILURE_MAX_MS,
+      PASSIVE_CATALOG_REFRESH_FAILURE_MAX_MS,
+    ),
+    idleMs: boundedDelay(
+      environment.CODEX_ROUTER_PASSIVE_CATALOG_REFRESH_IDLE_MS,
+      PASSIVE_CATALOG_REFRESH_IDLE_MS,
+      { minimum: 1_000 },
+    ),
+  };
+}
+
+function finiteTimestamp(value) {
+  return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function normalizedState(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  if (value.version !== STATE_VERSION) return undefined;
+  const nextEligibleAt = finiteTimestamp(value.nextEligibleAt);
+  if (nextEligibleAt === undefined) return undefined;
+  const consecutiveFailures = Number.isSafeInteger(value.consecutiveFailures) &&
+      value.consecutiveFailures >= 0 && value.consecutiveFailures <= 64
+    ? value.consecutiveFailures
+    : undefined;
+  if (consecutiveFailures === undefined) return undefined;
+  return {
+    version: STATE_VERSION,
+    nextEligibleAt,
+    consecutiveFailures,
+    ...(finiteTimestamp(value.lastAttemptAt) !== undefined
+      ? { lastAttemptAt: value.lastAttemptAt }
+      : {}),
+    ...(finiteTimestamp(value.lastSuccessAt) !== undefined
+      ? { lastSuccessAt: value.lastSuccessAt }
+      : {}),
+    ...(finiteTimestamp(value.lastFailureAt) !== undefined
+      ? { lastFailureAt: value.lastFailureAt }
+      : {}),
+    ...(typeof value.lastChanged === "boolean"
+      ? { lastChanged: value.lastChanged }
+      : {}),
+    ...(Number.isSafeInteger(value.lastChangedCount) && value.lastChangedCount >= 0
+      ? { lastChangedCount: Math.min(value.lastChangedCount, 10_000) }
+      : {}),
+  };
+}
+
+export function readPassiveCatalogRefreshState({
+  file = PASSIVE_CATALOG_REFRESH_PATH,
+} = {}) {
+  try {
+    if (!existsSync(file)) return undefined;
+    const link = lstatSync(file);
+    if (!link.isFile() || link.isSymbolicLink() || statSync(file).size > MAX_STATE_BYTES) {
+      return undefined;
+    }
+    return normalizedState(JSON.parse(readFileSync(file, "utf8")));
+  } catch {
+    // This is scheduling metadata, never an authority. A corrupt, oversized,
+    // or foreign file becomes one due check; the worker atomically replaces it
+    // before any network request so it cannot create a request loop.
+    return undefined;
+  }
+}
+
+function writeState(file, state) {
+  writePrivateJson(file, state, { directoryMode: 0o700 });
+  return state;
+}
+
+function withStateLock(file, operation, lock = withAtomicStateLock) {
+  return lock(file, operation, { waitMs: 2_000 });
+}
+
+export function passiveCatalogRefreshConfigured(providers = RUNTIME_PROVIDERS) {
+  return [...providers.values()].some((provider) => provider.mirrorNativeModels === true);
+}
+
+export function reservePassiveCatalogRefresh({
+  file = PASSIVE_CATALOG_REFRESH_PATH,
+  now = Date.now(),
+  failureBaseMs = PASSIVE_CATALOG_REFRESH_FAILURE_BASE_MS,
+  readState = readPassiveCatalogRefreshState,
+  lock,
+} = {}) {
+  return withStateLock(file, () => {
+    const current = readState({ file });
+    if (current && current.nextEligibleAt > now) {
+      return { reserved: false, state: current };
+    }
+    const state = writeState(file, {
+      version: STATE_VERSION,
+      ...(current || {}),
+      lastAttemptAt: now,
+      nextEligibleAt: now + failureBaseMs,
+      consecutiveFailures: current?.consecutiveFailures || 0,
+    });
+    return { reserved: true, state };
+  }, lock);
+}
+
+export function recordPassiveCatalogRefreshSuccess({
+  changed = false,
+  changedCount = 0,
+} = {}, {
+  file = PASSIVE_CATALOG_REFRESH_PATH,
+  now = Date.now(),
+  intervalMs = PASSIVE_CATALOG_REFRESH_INTERVAL_MS,
+  readState = readPassiveCatalogRefreshState,
+  lock,
+} = {}) {
+  return withStateLock(file, () => {
+    const current = readState({ file });
+    return writeState(file, {
+      version: STATE_VERSION,
+      ...(current?.lastAttemptAt !== undefined
+        ? { lastAttemptAt: current.lastAttemptAt }
+        : {}),
+      lastSuccessAt: now,
+      nextEligibleAt: now + intervalMs,
+      consecutiveFailures: 0,
+      lastChanged: changed === true,
+      lastChangedCount: Number.isSafeInteger(changedCount) && changedCount > 0
+        ? Math.min(changedCount, 10_000)
+        : 0,
+    });
+  }, lock);
+}
+
+export function recordPassiveCatalogRefreshFailure({
+  file = PASSIVE_CATALOG_REFRESH_PATH,
+  now = Date.now(),
+  failureBaseMs = PASSIVE_CATALOG_REFRESH_FAILURE_BASE_MS,
+  failureMaxMs = PASSIVE_CATALOG_REFRESH_FAILURE_MAX_MS,
+  readState = readPassiveCatalogRefreshState,
+  lock,
+} = {}) {
+  return withStateLock(file, () => {
+    const current = readState({ file });
+    const failures = Math.min(64, (current?.consecutiveFailures || 0) + 1);
+    const multiplier = 2 ** Math.min(30, failures - 1);
+    const delay = Math.min(failureMaxMs, failureBaseMs * multiplier);
+    return writeState(file, {
+      version: STATE_VERSION,
+      ...(current?.lastAttemptAt !== undefined
+        ? { lastAttemptAt: current.lastAttemptAt }
+        : {}),
+      ...(current?.lastSuccessAt !== undefined
+        ? { lastSuccessAt: current.lastSuccessAt }
+        : {}),
+      lastFailureAt: now,
+      nextEligibleAt: now + delay,
+      consecutiveFailures: failures,
+      ...(current?.lastChanged !== undefined
+        ? { lastChanged: current.lastChanged }
+        : {}),
+      ...(current?.lastChangedCount !== undefined
+        ? { lastChangedCount: current.lastChangedCount }
+        : {}),
+    });
+  }, lock);
+}
+
+export function passiveMirrorSummary(output) {
+  for (const line of String(output || "").split(/\r?\n/)) {
+    if (!line.trim().startsWith("{")) continue;
+    try {
+      const value = JSON.parse(line);
+      if (
+        Number.isSafeInteger(value?.providers) &&
+        typeof value?.changed === "boolean" &&
+        Array.isArray(value?.added) &&
+        Array.isArray(value?.updated)
+      ) {
+        return {
+          changed: value.changed,
+          changedCount: value.added.length + value.updated.length,
+        };
+      }
+    } catch {
+      // Other refresh output is human-readable or belongs to catalog status.
+    }
+  }
+  return { changed: false, changedCount: 0 };
+}
+
+export function runPassiveCatalogRefreshWorker({
+  providers = RUNTIME_PROVIDERS,
+  reserve = reservePassiveCatalogRefresh,
+  recordSuccess = recordPassiveCatalogRefreshSuccess,
+  recordFailure = recordPassiveCatalogRefreshFailure,
+  runner = spawnSync,
+  executable = process.execPath,
+  sourceRoot = SOURCE_ROOT,
+  environment = process.env,
+  options = passiveCatalogRefreshOptions(environment),
+} = {}) {
+  if (options.disabled || !passiveCatalogRefreshConfigured(providers)) {
+    return { ran: false, reason: "disabled" };
+  }
+  const reservation = reserve({
+    failureBaseMs: options.failureBaseMs,
+  });
+  if (!reservation.reserved) return { ran: false, reason: "cooldown" };
+
+  let result;
+  try {
+    result = runner(
+      executable,
+      [path.join(sourceRoot, "src", "refresh-catalog.mjs")],
+      {
+        cwd: sourceRoot,
+        env: detachedOperationEnvironment(environment, {
+          MODEL_ROUTER_TARGET: "codex",
+          CODEX_ROUTER_PASSIVE_REFRESH_WORKER: "1",
+        }),
+        encoding: "utf8",
+        maxBuffer: 32 * 1024 * 1024,
+        timeout: 15 * 60_000,
+        windowsHide: true,
+      },
+    );
+  } catch {
+    result = { status: null, error: true };
+  }
+  if (result.error || result.status !== 0) {
+    recordFailure({
+      failureBaseMs: options.failureBaseMs,
+      failureMaxMs: options.failureMaxMs,
+    });
+    return { ran: true, ok: false };
+  }
+  const summary = passiveMirrorSummary(result.stdout);
+  recordSuccess(summary, { intervalMs: options.intervalMs });
+  return { ran: true, ok: true, ...summary };
+}
+
+function defaultSpawnWorker({ environment = process.env } = {}) {
+  const child = spawn(process.execPath, [SELF, "--worker"], {
+    cwd: SOURCE_ROOT,
+    env: detachedOperationEnvironment(environment, { MODEL_ROUTER_TARGET: TARGET }),
+    detached: true,
+    stdio: ["ignore", "ignore", "inherit"],
+    windowsHide: true,
+  });
+  child.unref();
+  return child;
+}
+
+export function createPassiveCatalogRefreshScheduler({
+  enabled = passiveCatalogRefreshConfigured(),
+  options = passiveCatalogRefreshOptions(),
+  now = Date.now,
+  activeRequests = () => 0,
+  readState = readPassiveCatalogRefreshState,
+  spawnWorker = defaultSpawnWorker,
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+} = {}) {
+  let timer;
+  let child;
+  let nextEligibleAt = enabled && !options.disabled
+    ? readState()?.nextEligibleAt || 0
+    : Number.POSITIVE_INFINITY;
+
+  const childFinished = () => {
+    child = undefined;
+    nextEligibleAt = readState()?.nextEligibleAt ||
+      (now() + options.failureBaseMs);
+  };
+
+  const schedule = () => {
+    if (!enabled || options.disabled) return false;
+    if (child || timer || now() < nextEligibleAt || activeRequests() > 0) return false;
+    timer = setTimer(() => {
+      timer = undefined;
+      if (activeRequests() > 0) return;
+      const current = readState();
+      nextEligibleAt = current?.nextEligibleAt || 0;
+      if (now() < nextEligibleAt) return;
+      // A worker that dies before reserving its durable attempt must still be
+      // coalesced in this process. The worker writes the same provisional
+      // cooldown before making any network request, which covers restarts.
+      nextEligibleAt = now() + options.failureBaseMs;
+      try {
+        child = spawnWorker({ environment: process.env });
+        let finished = false;
+        const finish = () => {
+          if (finished) return;
+          finished = true;
+          childFinished();
+        };
+        child.once("error", finish);
+        child.once("exit", finish);
+      } catch {
+        childFinished();
+      }
+    }, options.idleMs);
+    timer.unref?.();
+    return true;
+  };
+
+  const noteActivityStarted = () => {
+    if (!timer) return;
+    clearTimer(timer);
+    timer = undefined;
+  };
+
+  const noteActivityFinished = () => {
+    if (activeRequests() === 0) schedule();
+  };
+
+  return Object.freeze({ schedule, noteActivityStarted, noteActivityFinished });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === SELF && process.argv[2] === "--worker") {
+  try {
+    const result = runPassiveCatalogRefreshWorker();
+    if (result.ran && !result.ok) {
+      console.error("[codex-router] passive model-catalog refresh failed; retry is backed off.");
+      process.exitCode = 1;
+    } else if (result.changed) {
+      console.error(
+        `[codex-router] passive model-catalog refresh published ${result.changedCount} change(s); fully quit and reopen Codex to reload its picker.`,
+      );
+    }
+  } catch {
+    // Never print a discovery error here: an upstream error can contain a URL
+    // or provider response. The durable failure state is enough to back off.
+    console.error("[codex-router] passive model-catalog refresh failed; retry is backed off.");
+    process.exitCode = 1;
+  }
+}

--- a/src/paths.mjs
+++ b/src/paths.mjs
@@ -167,6 +167,10 @@ export const NATIVE_SESSION_CONSENT_PATH = path.join(
 // cache for the curation surfaces, never an authority: what is registered
 // locally is always recomputed from the live registry.
 export const PROVIDER_CATALOG_CACHE_PATH = path.join(STATE_DIR, "provider-catalog-cache.json");
+export const PASSIVE_CATALOG_REFRESH_PATH = path.join(
+  STATE_DIR,
+  "passive-catalog-refresh.json",
+);
 export const PROVIDER_API_KEY_POOL_PATH =
   process.env.MODEL_ROUTER_API_KEY_POOL_PATH ||
   path.join(STATE_DIR, "provider-api-key-pools.json");

--- a/src/refresh-catalog.mjs
+++ b/src/refresh-catalog.mjs
@@ -126,6 +126,7 @@ async function refreshCatalogUnlocked({
   };
   let restoreNeeded = false;
   let catalogResult;
+  let mirrorResult;
   try {
     if (routed) {
       if (loginFree) {
@@ -147,12 +148,20 @@ async function refreshCatalogUnlocked({
         process.exit(86);
       }
     }
-    catalogResult = checked(run, "catalog.mjs", ["--refresh-native"]);
+    catalogResult = checked(run, "catalog.mjs", [
+      "--refresh-native",
+      "--router-transport-parked",
+    ]);
     if (restoreNeeded) {
       restoreTransport(run, transport, aliasFor);
       restoreNeeded = false;
       if (loginFree) journal.clear();
     }
+    // Restore transport before committing a discovered model. The mirror owns
+    // one overlay transaction that regenerates gateway routes, republishes all
+    // installed model pickers, and restarts the service only when its managed
+    // entries changed. Ordinary providers remain a zero-network no-op.
+    mirrorResult = checked(run, "native-model-mirror.mjs", []);
   } catch (error) {
     if (restoreNeeded) {
       try {
@@ -168,7 +177,10 @@ async function refreshCatalogUnlocked({
     }
     throw error;
   }
-  return { catalogOutput: catalogResult.stdout || "" };
+  return {
+    catalogOutput: catalogResult.stdout || "",
+    mirrorOutput: mirrorResult?.stdout || "",
+  };
 }
 
 export async function refreshCatalog({
@@ -180,8 +192,9 @@ export async function refreshCatalog({
 }
 
 async function main() {
-  const { catalogOutput } = await refreshCatalog();
+  const { catalogOutput, mirrorOutput } = await refreshCatalog();
   if (catalogOutput) process.stdout.write(catalogOutput);
+  if (mirrorOutput) process.stdout.write(mirrorOutput);
   process.stdout.write("Native and external model catalogs refreshed. Fully quit and reopen Codex.\n");
 }
 

--- a/src/refresh-catalog.mjs
+++ b/src/refresh-catalog.mjs
@@ -10,6 +10,10 @@ import {
 } from "./login-free-refresh-journal.mjs";
 import { withLoginFreeRefreshLock } from "./login-free-refresh-lock.mjs";
 import { nativeAliasFor, readNativeAliases } from "./native-alias.mjs";
+import {
+  passiveMirrorSummary,
+  recordPassiveCatalogRefreshSuccess,
+} from "./passive-catalog-refresh.mjs";
 
 function nodeRunner(script, args) {
   return spawnSync(process.execPath, [path.join(SOURCE_ROOT, "src", script), ...args], {
@@ -193,6 +197,18 @@ export async function refreshCatalog({
 
 async function main() {
   const { catalogOutput, mirrorOutput } = await refreshCatalog();
+  if (process.env.CODEX_ROUTER_PASSIVE_REFRESH_WORKER !== "1") {
+    try {
+      recordPassiveCatalogRefreshSuccess(passiveMirrorSummary(mirrorOutput));
+    } catch {
+      // Scheduling metadata is not part of the catalog transaction. A failed
+      // bookkeeping write must not turn a successfully published model update
+      // into a reported failure or trigger rollback of an already-ready route.
+      console.error(
+        "Passive model-catalog cooldown could not be recorded; a later idle trigger may check again.",
+      );
+    }
+  }
   if (catalogOutput) process.stdout.write(catalogOutput);
   if (mirrorOutput) process.stdout.write(mirrorOutput);
   process.stdout.write("Native and external model catalogs refreshed. Fully quit and reopen Codex.\n");

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -204,6 +204,7 @@ import {
   directResponsesTarget,
   isDirectResponsesProvider,
 } from "./direct-responses-provider.mjs";
+import { createPassiveCatalogRefreshScheduler } from "./passive-catalog-refresh.mjs";
 
 installStableFetchTransport();
 
@@ -373,6 +374,15 @@ const agentPayloadCacheMetrics = {
 let requestSequence = 0;
 const activityRecords = new Map();
 const inFlightRequests = new Map();
+const passiveCatalogRefresh = createPassiveCatalogRefreshScheduler({
+  enabled: (() => {
+    const selected = new Set(readProviderSelection());
+    return [...RUNTIME_PROVIDERS.values()].some(
+      (provider) => provider.mirrorNativeModels === true && selected.has(provider.id),
+    );
+  })(),
+  activeRequests: () => inFlightRequests.size,
+});
 let lastUsedProvider;
 let lastUsedModel;
 let lastUsedSessionName;
@@ -435,6 +445,7 @@ function resourceLimitsPayload() {
 }
 
 function beginRequestActivity({ request, response, controller } = {}) {
+  passiveCatalogRefresh.noteActivityStarted();
   pruneExpiredActivityRecords();
   if (inFlightRequests.size >= MAX_ACTIVE_REQUESTS) {
     request?.resume?.();
@@ -457,6 +468,7 @@ function beginRequestActivity({ request, response, controller } = {}) {
     activityRecords.delete(requestId);
     inFlightRequests.delete(requestId);
     if (status >= 400) errorStatusUntil = Date.now() + ERROR_STATUS_DURATION_MS;
+    passiveCatalogRefresh.noteActivityFinished();
   };
   const abortAtExecutionDeadline = () => {
     if (finished || deadlineExceeded) return;
@@ -5184,6 +5196,7 @@ server.requestTimeout = 0;
 applyKeepAliveTimeouts(server);
 server.listen(LISTEN_PORT, LISTEN_HOST, () => {
   console.error("[codex-router] listening");
+  passiveCatalogRefresh.schedule();
 });
 
 installGracefulShutdown(server, { label: "codex-router" });

--- a/src/service-linux.mjs
+++ b/src/service-linux.mjs
@@ -79,6 +79,9 @@ function unit() {
     CODEX_ROUTER_OAUTH_PORT: String(PORTS.oauth),
     CODEX_ROUTER_PORT: String(PORTS.router),
     CODEX_ROUTER_API_PORT: String(PORTS.api),
+    ...(process.env.CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH === "1"
+      ? { CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH: "1" }
+      : {}),
     ...serviceProxyEnvironment(),
     ...providerApiKeyServiceEnvironment(),
     ...(process.env.KIMI_CODE_HOME ? { KIMI_CODE_HOME: process.env.KIMI_CODE_HOME } : {}),

--- a/src/service-macos.mjs
+++ b/src/service-macos.mjs
@@ -85,6 +85,9 @@ function environmentEntries() {
     CODEX_ROUTER_OAUTH_PORT: String(PORTS.oauth),
     CODEX_ROUTER_PORT: String(PORTS.router),
     CODEX_ROUTER_API_PORT: String(PORTS.api),
+    ...(process.env.CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH === "1"
+      ? { CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH: "1" }
+      : {}),
     ...serviceProxyEnvironment(),
     ...providerApiKeyServiceEnvironment(),
     ...(process.env.CODEX_ROUTER_SOURCE_ROOT

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -83,6 +83,9 @@ function wrapper() {
     CODEX_ROUTER_OAUTH_PORT: String(PORTS.oauth),
     CODEX_ROUTER_PORT: String(PORTS.router),
     CODEX_ROUTER_API_PORT: String(PORTS.api),
+    ...(process.env.CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH === "1"
+      ? { CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH: "1" }
+      : {}),
     ...serviceProxyEnvironment(),
     ...providerApiKeyServiceEnvironment(),
     // The LiteLLM gateway is a Python process. Force UTF-8 output so its

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1378,7 +1378,7 @@ function writeCatalogCodexStub(directory, options = {}) {
   writeFileSync(
     target,
     windows
-      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" exit /b 0\r\nif "%1"=="debug" (if "%3"=="--bundled" (echo ${bundledModels}) else (echo ${liveModels})& exit /b 0)\r\nexit /b 1\r\n`
+      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" exit /b 0\r\nif "%1"=="debug" if "%3"=="--bundled" (echo ${bundledModels}& exit /b 0)\r\nif "%1"=="debug" (echo ${liveModels}& exit /b 0)\r\nexit /b 1\r\n`
       : `#!/bin/sh
 case "$1" in
   --version) echo 'codex-cli 99.0.0' ;;

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1365,23 +1365,25 @@ test("efficient routed execution silently substitutes routine missing tools", ()
 // picker after an update (issue #338).
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
-function writeCatalogCodexStub(directory) {
+function writeCatalogCodexStub(directory, options = {}) {
   const windows = process.platform === "win32";
   const target = path.join(directory, windows ? "codex-picker.cmd" : "codex-picker");
-  const models = JSON.stringify({
+  const defaultCatalog = {
     models: [
       { slug: "gpt-5.6-sol", display_name: "GPT-5.6 Sol", visibility: "list", priority: 10 },
     ],
-  });
+  };
+  const liveModels = JSON.stringify(options.live || defaultCatalog);
+  const bundledModels = JSON.stringify(options.bundled || options.live || defaultCatalog);
   writeFileSync(
     target,
     windows
-      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" exit /b 0\r\nif "%1"=="debug" (echo ${models}& exit /b 0)\r\nexit /b 1\r\n`
+      ? `@echo off\r\nif "%1"=="--version" (echo codex-cli 99.0.0& exit /b 0)\r\nif "%1"=="login" exit /b 0\r\nif "%1"=="debug" (if "%3"=="--bundled" (echo ${bundledModels}) else (echo ${liveModels})& exit /b 0)\r\nexit /b 1\r\n`
       : `#!/bin/sh
 case "$1" in
   --version) echo 'codex-cli 99.0.0' ;;
   login) exit 0 ;;
-  debug) printf '%s\\n' '${models}' ;;
+  debug) if [ "$3" = "--bundled" ]; then printf '%s\\n' '${bundledModels}'; else printf '%s\\n' '${liveModels}'; fi ;;
   *) exit 1 ;;
 esac
 `,
@@ -1389,6 +1391,53 @@ esac
   );
   return target;
 }
+
+test(
+  "explicit native refresh prefers the live account catalog over a valid stale cache",
+  { timeout: 30_000 },
+  () => {
+    const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-live-native-refresh-"));
+    const stateDir = path.join(codexHome, "router-state");
+    mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    writeFileSync(path.join(codexHome, "config.toml"), 'model = "gpt-live"\n', { mode: 0o600 });
+    writeFileSync(
+      path.join(codexHome, "models_cache.json"),
+      `${JSON.stringify({ models: [{ slug: "gpt-stale", display_name: "Stale", visibility: "list", priority: 2 }] })}\n`,
+      { mode: 0o600 },
+    );
+    const live = {
+      models: [{ slug: "gpt-live", display_name: "Live", visibility: "list", priority: 1 }],
+    };
+    try {
+      const catalog = spawnSync(
+        process.execPath,
+        [
+          path.join(repoRoot, "src", "catalog.mjs"),
+          "--refresh-native",
+          "--router-transport-parked",
+        ],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            CODEX_BIN: writeCatalogCodexStub(codexHome, { live }),
+            CODEX_HOME: codexHome,
+            CODEX_ROUTER_STATE_DIR: stateDir,
+            MODEL_ROUTER_STATE_DIR: stateDir,
+            MODEL_ROUTER_TARGET: "codex",
+          },
+        },
+      );
+      assert.equal(catalog.status, 0, catalog.stderr);
+      const captured = JSON.parse(readFileSync(path.join(stateDir, "native-models.json"), "utf8"));
+      assert.deepEqual(captured.models.map((model) => model.slug), ["gpt-live"]);
+      assert.ok(captured.native_source_fingerprint);
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true });
+    }
+  },
+);
 
 test(
   "an update publishes the models a pre-allowlist picker was already showing",

--- a/test/model-discovery.test.mjs
+++ b/test/model-discovery.test.mjs
@@ -22,7 +22,18 @@ after(() => {
 
 const { MODELS, PROVIDERS } = await import("../src/model-registry.mjs");
 const { modelCatalogMetadata } = await import("../src/model-catalog-metadata.mjs");
-const { discoverProviderModels, modelContextLengths, modelIds } = await import("../src/model-discovery.mjs");
+const {
+  discoverProviderModels,
+  modelContextLengths,
+  modelIds,
+  providerAllowsPrivateDiscovery,
+} = await import("../src/model-discovery.mjs");
+
+test("private model discovery requires an explicit provider opt-in", () => {
+  assert.equal(providerAllowsPrivateDiscovery({}), false);
+  assert.equal(providerAllowsPrivateDiscovery({ allowPrivate: true }), true);
+  assert.equal(providerAllowsPrivateDiscovery({ keyless: true }), true);
+});
 
 test("model discovery compares fixtures without needing or exposing a key", () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-discovery-"));

--- a/test/native-model-mirror.test.mjs
+++ b/test/native-model-mirror.test.mjs
@@ -49,6 +49,7 @@ test("native mirroring adds only account-visible models advertised by the provid
     provider: "private",
     priority: 100,
     supportsSearchHistory: true,
+    reasoningLevels: [{ effort: "ultra", description: "Verified elsewhere" }],
   };
   const result = planNativeModelMirror({
     provider,
@@ -85,7 +86,14 @@ test("native mirroring updates its own entries and preserves manual curation", (
     discovered: [astra.slug],
     existing: [],
   });
-  const managed = { ...first.models[0], supportsSearchHistory: true };
+  const managed = {
+    ...first.models[0],
+    supportsSearchHistory: true,
+    reasoningLevels: [
+      ...first.models[0].reasoningLevels,
+      { effort: "ultra", description: "Verified on this route" },
+    ],
+  };
   const updated = planNativeModelMirror({
     provider,
     nativeModels: [{ ...astra, context_window: 300_000 }],
@@ -96,6 +104,14 @@ test("native mirroring updates its own entries and preserves manual curation", (
   assert.deepEqual(updated.updated, ["private/gpt-6-astra"]);
   assert.equal(updated.models[0].contextWindow, 300_000);
   assert.equal(updated.models[0].supportsSearchHistory, true);
+  assert.deepEqual(
+    updated.models[0].reasoningLevels.map((level) => level.effort),
+    ["low", "medium", "high", "xhigh", "max", "ultra"],
+  );
+  assert.equal(
+    updated.models[0].reasoningLevels.at(-1).description,
+    "Verified on this route",
+  );
 
   const manual = { ...managed, managedBy: undefined, contextWindow: 123_456 };
   const preserved = planNativeModelMirror({
@@ -106,6 +122,38 @@ test("native mirroring updates its own entries and preserves manual curation", (
   });
   assert.deepEqual(preserved.preserved, ["private/gpt-6-astra"]);
   assert.equal(preserved.models[0].contextWindow, 123_456);
+});
+
+test("native mirroring drops a verified ultra rung when native metadata withdraws it", () => {
+  const current = planNativeModelMirror({
+    provider,
+    nativeModels: [astra],
+    discovered: [astra.slug],
+    existing: [],
+  }).models[0];
+  current.reasoningLevels = [
+    ...current.reasoningLevels,
+    { effort: "ultra", description: "Verified on this route" },
+  ];
+
+  const nativeWithoutUltra = {
+    ...astra,
+    supported_reasoning_levels: astra.supported_reasoning_levels.filter(
+      (level) => level.effort !== "ultra",
+    ),
+  };
+  const result = planNativeModelMirror({
+    provider,
+    nativeModels: [nativeWithoutUltra],
+    discovered: [astra.slug],
+    existing: [current],
+  });
+
+  assert.deepEqual(result.updated, ["private/gpt-6-astra"]);
+  assert.deepEqual(
+    result.models[0].reasoningLevels.map((level) => level.effort),
+    ["low", "medium", "high", "xhigh", "max"],
+  );
 });
 
 test("sync discovers opted-in providers, persists additions, and selects them", async () => {

--- a/test/native-model-mirror.test.mjs
+++ b/test/native-model-mirror.test.mjs
@@ -48,6 +48,7 @@ test("native mirroring adds only account-visible models advertised by the provid
     upstreamModel: "gpt-5.6-sol",
     provider: "private",
     priority: 100,
+    supportsSearchHistory: true,
   };
   const result = planNativeModelMirror({
     provider,
@@ -65,6 +66,7 @@ test("native mirroring adds only account-visible models advertised by the provid
   assert.equal(result.models[0], manual);
   const mirrored = result.models[1];
   assert.equal(mirrored.managedBy, NATIVE_MODEL_MIRROR_MARKER);
+  assert.equal(mirrored.supportsSearchHistory, undefined);
   assert.equal(mirrored.contextWindow, 272_000);
   assert.equal(mirrored.autoCompact, 231_200);
   assert.deepEqual(mirrored.inputModalities, ["text", "image"]);
@@ -83,7 +85,7 @@ test("native mirroring updates its own entries and preserves manual curation", (
     discovered: [astra.slug],
     existing: [],
   });
-  const managed = first.models[0];
+  const managed = { ...first.models[0], supportsSearchHistory: true };
   const updated = planNativeModelMirror({
     provider,
     nativeModels: [{ ...astra, context_window: 300_000 }],
@@ -93,6 +95,7 @@ test("native mirroring updates its own entries and preserves manual curation", (
   assert.deepEqual(updated.added, []);
   assert.deepEqual(updated.updated, ["private/gpt-6-astra"]);
   assert.equal(updated.models[0].contextWindow, 300_000);
+  assert.equal(updated.models[0].supportsSearchHistory, true);
 
   const manual = { ...managed, managedBy: undefined, contextWindow: 123_456 };
   const preserved = planNativeModelMirror({

--- a/test/native-model-mirror.test.mjs
+++ b/test/native-model-mirror.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+process.env.MODEL_ROUTER_USER_MODELS = path.join(
+  mkdtempSync(path.join(os.tmpdir(), "native-model-mirror-test-")),
+  "user-models.json",
+);
+
+const {
+  NATIVE_MODEL_MIRROR_MARKER,
+  planNativeModelMirror,
+  syncNativeModelMirrors,
+} = await import("../src/native-model-mirror.mjs");
+
+const provider = {
+  id: "private",
+  displayName: "Private",
+  kind: "openai-compatible",
+  protocol: "openai-responses",
+  mirrorNativeModels: true,
+};
+
+const astra = {
+  slug: "gpt-6-astra",
+  display_name: "GPT-6-Astra",
+  visibility: "list",
+  supported_in_api: true,
+  context_window: 272_000,
+  input_modalities: ["text", "image"],
+  default_reasoning_level: "medium",
+  supported_reasoning_levels: [
+    { effort: "low", description: "Fast" },
+    { effort: "medium", description: "Balanced" },
+    { effort: "high", description: "Deep" },
+    { effort: "xhigh", description: "Deeper" },
+    { effort: "max", description: "Maximum" },
+    { effort: "ultra", description: "Delegated" },
+  ],
+  service_tiers: [{ id: "priority", name: "Fast", description: "Higher speed" }],
+};
+
+test("native mirroring adds only account-visible models advertised by the provider", () => {
+  const manual = {
+    slug: "private/gpt-5.6-sol",
+    upstreamModel: "gpt-5.6-sol",
+    provider: "private",
+    priority: 100,
+  };
+  const result = planNativeModelMirror({
+    provider,
+    nativeModels: [
+      astra,
+      { ...astra, slug: "gpt-hidden", visibility: "hide" },
+      { ...astra, slug: "gpt-not-served" },
+    ],
+    discovered: ["gpt-6-astra", "gpt-hidden", "upstream-only"],
+    existing: [manual],
+  });
+
+  assert.deepEqual(result.added, ["private/gpt-6-astra"]);
+  assert.deepEqual(result.updated, []);
+  assert.equal(result.models[0], manual);
+  const mirrored = result.models[1];
+  assert.equal(mirrored.managedBy, NATIVE_MODEL_MIRROR_MARKER);
+  assert.equal(mirrored.contextWindow, 272_000);
+  assert.equal(mirrored.autoCompact, 231_200);
+  assert.deepEqual(mirrored.inputModalities, ["text", "image"]);
+  assert.equal(mirrored.defaultEffort, "medium");
+  assert.deepEqual(
+    mirrored.reasoningLevels.map((level) => level.effort),
+    ["low", "medium", "high", "xhigh", "max"],
+  );
+  assert.deepEqual(mirrored.serviceTiers, astra.service_tiers);
+});
+
+test("native mirroring updates its own entries and preserves manual curation", () => {
+  const first = planNativeModelMirror({
+    provider,
+    nativeModels: [astra],
+    discovered: [astra.slug],
+    existing: [],
+  });
+  const managed = first.models[0];
+  const updated = planNativeModelMirror({
+    provider,
+    nativeModels: [{ ...astra, context_window: 300_000 }],
+    discovered: [astra.slug],
+    existing: [managed],
+  });
+  assert.deepEqual(updated.added, []);
+  assert.deepEqual(updated.updated, ["private/gpt-6-astra"]);
+  assert.equal(updated.models[0].contextWindow, 300_000);
+
+  const manual = { ...managed, managedBy: undefined, contextWindow: 123_456 };
+  const preserved = planNativeModelMirror({
+    provider,
+    nativeModels: [astra],
+    discovered: [astra.slug],
+    existing: [manual],
+  });
+  assert.deepEqual(preserved.preserved, ["private/gpt-6-astra"]);
+  assert.equal(preserved.models[0].contextWindow, 123_456);
+});
+
+test("sync discovers opted-in providers, persists additions, and selects them", async () => {
+  let written;
+  let shown;
+  let transaction;
+  const result = await syncNativeModelMirrors({
+    providers: new Map([[provider.id, provider]]),
+    discover: async (providerId, options) => {
+      assert.equal(providerId, "private");
+      assert.deepEqual(options, { refresh: true });
+      return { discovered: [astra.slug] };
+    },
+    readNative: () => ({ models: [astra] }),
+    readModels: () => [],
+    writeModels: (models) => { written = models; },
+    showModels: (slugs) => { shown = slugs; },
+    transact: async (options) => {
+      transaction = options;
+      return options.mutate();
+    },
+  });
+  assert.equal(result.changed, true);
+  assert.deepEqual(result.added, ["private/gpt-6-astra"]);
+  assert.equal(written[0].slug, "private/gpt-6-astra");
+  assert.deepEqual(shown, ["private/gpt-6-astra"]);
+  assert.equal(transaction.restart, true);
+  assert.equal(typeof transaction.applyPublication, "function");
+});
+
+test("sync does not publish or restart when managed metadata is current", async () => {
+  const current = planNativeModelMirror({
+    provider,
+    nativeModels: [astra],
+    discovered: [astra.slug],
+    existing: [],
+  }).models;
+  let transacted = false;
+  const result = await syncNativeModelMirrors({
+    providers: new Map([[provider.id, provider]]),
+    discover: async () => ({ discovered: [astra.slug] }),
+    readNative: () => ({ models: [astra] }),
+    readModels: () => current,
+    transact: async () => { transacted = true; },
+  });
+  assert.equal(result.changed, false);
+  assert.equal(transacted, false);
+});
+
+test("sync is a no-network no-op without an opted-in provider", async () => {
+  let discovered = false;
+  const result = await syncNativeModelMirrors({
+    providers: new Map([[provider.id, { ...provider, mirrorNativeModels: false }]]),
+    discover: async () => { discovered = true; },
+  });
+  assert.equal(discovered, false);
+  assert.equal(result.changed, false);
+});

--- a/test/passive-catalog-refresh.test.mjs
+++ b/test/passive-catalog-refresh.test.mjs
@@ -1,0 +1,393 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import {
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const {
+  createPassiveCatalogRefreshScheduler,
+  passiveMirrorSummary,
+  readPassiveCatalogRefreshState,
+  recordPassiveCatalogRefreshFailure,
+  recordPassiveCatalogRefreshSuccess,
+  reservePassiveCatalogRefresh,
+  runPassiveCatalogRefreshWorker,
+} = await import("../src/passive-catalog-refresh.mjs");
+const passiveCatalogRefreshModule = new URL(
+  "../src/passive-catalog-refresh.mjs",
+  import.meta.url,
+).href;
+
+function temporaryState() {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "passive-catalog-refresh-test-"));
+  return {
+    directory,
+    file: path.join(directory, "passive-catalog-refresh.json"),
+    close: () => rmSync(directory, { recursive: true, force: true }),
+  };
+}
+
+const mirrorProviders = new Map([["private", {
+  id: "private",
+  protocol: "openai-responses",
+  mirrorNativeModels: true,
+}]]);
+
+test("a durable reservation coalesces attempts and success starts a fresh cooldown", () => {
+  const state = temporaryState();
+  try {
+    const first = reservePassiveCatalogRefresh({
+      file: state.file,
+      now: 1_000,
+      failureBaseMs: 500,
+    });
+    assert.equal(first.reserved, true);
+    assert.equal(first.state.nextEligibleAt, 1_500);
+    assert.equal(lstatSync(state.file).mode & 0o777, 0o600);
+
+    const duplicate = reservePassiveCatalogRefresh({
+      file: state.file,
+      now: 1_100,
+      failureBaseMs: 500,
+    });
+    assert.equal(duplicate.reserved, false);
+
+    const success = recordPassiveCatalogRefreshSuccess(
+      { changed: true, changedCount: 2 },
+      { file: state.file, now: 1_200, intervalMs: 10_000 },
+    );
+    assert.equal(success.nextEligibleAt, 11_200);
+    assert.equal(success.consecutiveFailures, 0);
+    assert.equal(success.lastChanged, true);
+    assert.equal(success.lastChangedCount, 2);
+  } finally {
+    state.close();
+  }
+});
+
+test("concurrent processes share one durable refresh reservation", async () => {
+  const state = temporaryState();
+  const script = `
+    import { reservePassiveCatalogRefresh } from ${JSON.stringify(passiveCatalogRefreshModule)};
+    const result = reservePassiveCatalogRefresh({
+      file: process.argv[1],
+      now: 1_000,
+      failureBaseMs: 60_000,
+    });
+    process.stdout.write(result.reserved ? "reserved" : "cooldown");
+  `;
+  try {
+    const attempts = Array.from({ length: 12 }, () => new Promise((resolve, reject) => {
+      const child = spawn(process.execPath, [
+        "--input-type=module",
+        "--eval",
+        script,
+        state.file,
+      ], {
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => { stdout += chunk; });
+      child.stderr.on("data", (chunk) => { stderr += chunk; });
+      child.once("error", reject);
+      child.once("exit", (code, signal) => {
+        if (code !== 0) {
+          reject(new Error(`reservation child exited ${code ?? signal}: ${stderr}`));
+          return;
+        }
+        resolve(stdout);
+      });
+    }));
+    const results = await Promise.all(attempts);
+    assert.equal(results.filter((result) => result === "reserved").length, 1);
+    assert.equal(results.filter((result) => result === "cooldown").length, 11);
+  } finally {
+    state.close();
+  }
+});
+
+test("failures back off exponentially, cap, and never persist an error body", () => {
+  const state = temporaryState();
+  try {
+    reservePassiveCatalogRefresh({ file: state.file, now: 1, failureBaseMs: 100 });
+    const first = recordPassiveCatalogRefreshFailure({
+      file: state.file,
+      now: 100,
+      failureBaseMs: 100,
+      failureMaxMs: 250,
+    });
+    const second = recordPassiveCatalogRefreshFailure({
+      file: state.file,
+      now: 200,
+      failureBaseMs: 100,
+      failureMaxMs: 250,
+    });
+    const third = recordPassiveCatalogRefreshFailure({
+      file: state.file,
+      now: 300,
+      failureBaseMs: 100,
+      failureMaxMs: 250,
+    });
+    assert.equal(first.nextEligibleAt, 200);
+    assert.equal(second.nextEligibleAt, 400);
+    assert.equal(third.nextEligibleAt, 550);
+    assert.equal(third.consecutiveFailures, 3);
+    assert.doesNotMatch(readFileSync(state.file, "utf8"), /error|response|url|key/i);
+  } finally {
+    state.close();
+  }
+});
+
+test("a corrupt or symlinked state is replaced before a second attempt can run", {
+  skip: process.platform === "win32" ? "symlink permissions vary on Windows" : false,
+}, () => {
+  const state = temporaryState();
+  try {
+    const foreign = path.join(state.directory, "foreign.json");
+    writeFileSync(foreign, '{"secret":"must-not-be-read"}\n', { mode: 0o600 });
+    symlinkSync(foreign, state.file);
+    assert.equal(readPassiveCatalogRefreshState({ file: state.file }), undefined);
+
+    const first = reservePassiveCatalogRefresh({
+      file: state.file,
+      now: 10,
+      failureBaseMs: 100,
+    });
+    const second = reservePassiveCatalogRefresh({
+      file: state.file,
+      now: 11,
+      failureBaseMs: 100,
+    });
+    assert.equal(first.reserved, true);
+    assert.equal(second.reserved, false);
+    assert.equal(lstatSync(state.file).isSymbolicLink(), false);
+    assert.equal(readFileSync(foreign, "utf8"), '{"secret":"must-not-be-read"}\n');
+  } finally {
+    state.close();
+  }
+});
+
+test("idle scheduling cancels on traffic and coalesces an adversarial trigger burst", () => {
+  let now = 10_000;
+  let active = 0;
+  let spawns = 0;
+  const timers = [];
+  const children = [];
+  const scheduler = createPassiveCatalogRefreshScheduler({
+    enabled: true,
+    options: {
+      disabled: false,
+      intervalMs: 10_000,
+      failureBaseMs: 1_000,
+      failureMaxMs: 10_000,
+      idleMs: 30,
+    },
+    now: () => now,
+    activeRequests: () => active,
+    readState: () => undefined,
+    setTimer(callback, delay) {
+      const timer = { callback, delay, canceled: false, unref() {} };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimer(timer) { timer.canceled = true; },
+    spawnWorker() {
+      spawns += 1;
+      const child = new EventEmitter();
+      children.push(child);
+      return child;
+    },
+  });
+
+  assert.equal(scheduler.schedule(), true);
+  for (let index = 0; index < 1_000; index += 1) {
+    assert.equal(scheduler.schedule(), false);
+  }
+  scheduler.noteActivityStarted();
+  assert.equal(timers[0].canceled, true);
+
+  active = 1;
+  scheduler.noteActivityFinished();
+  assert.equal(timers.length, 1);
+  active = 0;
+  scheduler.noteActivityFinished();
+  assert.equal(timers.length, 2);
+  timers[1].callback();
+  assert.equal(spawns, 1);
+  for (let index = 0; index < 1_000; index += 1) scheduler.schedule();
+  assert.equal(spawns, 1);
+
+  children[0].emit("exit", 0);
+  assert.equal(scheduler.schedule(), false, "a crashed worker receives an in-memory backoff");
+  now += 1_001;
+  assert.equal(scheduler.schedule(), true);
+});
+
+test("a durable cooldown written during the idle grace wins before spawn", () => {
+  let timer;
+  let reads = 0;
+  let spawned = false;
+  const scheduler = createPassiveCatalogRefreshScheduler({
+    enabled: true,
+    options: {
+      disabled: false,
+      intervalMs: 10_000,
+      failureBaseMs: 1_000,
+      failureMaxMs: 10_000,
+      idleMs: 30,
+    },
+    now: () => 1_000,
+    readState: () => (++reads === 1 ? undefined : {
+      version: 1,
+      nextEligibleAt: 9_000,
+      consecutiveFailures: 0,
+    }),
+    setTimer(callback) {
+      timer = { callback, unref() {} };
+      return timer;
+    },
+    spawnWorker() { spawned = true; },
+  });
+  assert.equal(scheduler.schedule(), true);
+  timer.callback();
+  assert.equal(spawned, false);
+});
+
+test("the detached worker reserves before running and records only a bounded summary", () => {
+  const calls = [];
+  let summary;
+  const result = runPassiveCatalogRefreshWorker({
+    providers: mirrorProviders,
+    options: {
+      disabled: false,
+      intervalMs: 10_000,
+      failureBaseMs: 1_000,
+      failureMaxMs: 10_000,
+      idleMs: 30,
+    },
+    reserve: (options) => {
+      calls.push(["reserve", options]);
+      return { reserved: true };
+    },
+    runner: (_command, args, options) => {
+      calls.push(["run", args, options]);
+      return {
+        status: 0,
+        stdout: '{"providers":1,"added":["private/new"],"updated":[],"preserved":[],"changed":true}\n',
+        stderr: "provider detail must not be persisted",
+      };
+    },
+    recordSuccess: (value, options) => {
+      summary = { value, options };
+    },
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(result, { ran: true, ok: true, changed: true, changedCount: 1 });
+  assert.deepEqual(calls.map(([name]) => name), ["reserve", "run"]);
+  assert.equal(calls[1][2].env.CODEX_ROUTER_PASSIVE_REFRESH_WORKER, "1");
+  assert.deepEqual(summary.value, { changed: true, changedCount: 1 });
+  assert.equal(summary.options.intervalMs, 10_000);
+  assert.doesNotMatch(JSON.stringify(summary), /provider detail/);
+});
+
+test("worker failures record backoff without retaining stderr", () => {
+  let failureOptions;
+  let successCalled = false;
+  const result = runPassiveCatalogRefreshWorker({
+    providers: mirrorProviders,
+    options: {
+      disabled: false,
+      intervalMs: 10_000,
+      failureBaseMs: 1_000,
+      failureMaxMs: 10_000,
+      idleMs: 30,
+    },
+    reserve: () => ({ reserved: true }),
+    runner: () => ({ status: 1, stdout: "", stderr: "secret upstream response" }),
+    recordSuccess: () => { successCalled = true; },
+    recordFailure: (options) => { failureOptions = options; },
+  });
+  assert.deepEqual(result, { ran: true, ok: false });
+  assert.equal(successCalled, false);
+  assert.deepEqual(failureOptions, { failureBaseMs: 1_000, failureMaxMs: 10_000 });
+  assert.doesNotMatch(JSON.stringify(result), /secret|upstream/);
+});
+
+test("a synchronously throwing process launcher follows the same bounded failure path", () => {
+  let failures = 0;
+  const result = runPassiveCatalogRefreshWorker({
+    providers: mirrorProviders,
+    options: {
+      disabled: false,
+      intervalMs: 10_000,
+      failureBaseMs: 1_000,
+      failureMaxMs: 10_000,
+      idleMs: 30,
+    },
+    reserve: () => ({ reserved: true }),
+    runner: () => { throw new Error("launcher included sensitive detail"); },
+    recordFailure: () => { failures += 1; },
+  });
+  assert.deepEqual(result, { ran: true, ok: false });
+  assert.equal(failures, 1);
+  assert.doesNotMatch(JSON.stringify(result), /sensitive|launcher/);
+});
+
+test("a disabled scheduler performs no state IO, timer, or spawn", () => {
+  let touched = false;
+  const scheduler = createPassiveCatalogRefreshScheduler({
+    enabled: false,
+    options: {
+      disabled: false,
+      intervalMs: 10_000,
+      failureBaseMs: 1_000,
+      failureMaxMs: 10_000,
+      idleMs: 30,
+    },
+    readState: () => { touched = true; },
+    setTimer: () => { touched = true; },
+    spawnWorker: () => { touched = true; },
+  });
+  assert.equal(scheduler.schedule(), false);
+  scheduler.noteActivityStarted();
+  scheduler.noteActivityFinished();
+  assert.equal(touched, false);
+});
+
+test("refresh output parsing ignores unrelated and malformed JSON lines", () => {
+  assert.deepEqual(
+    passiveMirrorSummary([
+      "not json",
+      '{"models":31}',
+      "{broken",
+      '{"providers":1,"added":[],"updated":["private/new"],"changed":true}',
+    ].join("\n")),
+    { changed: true, changedCount: 1 },
+  );
+});
+
+test("the router lifecycle wires startup and idle triggers without a polling interval", () => {
+  const source = readFileSync(new URL("../src/router.mjs", import.meta.url), "utf8");
+  const schedulerSource = readFileSync(
+    new URL("../src/passive-catalog-refresh.mjs", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /passiveCatalogRefresh\.noteActivityStarted\(\)/);
+  assert.match(source, /passiveCatalogRefresh\.noteActivityFinished\(\)/);
+  assert.match(source, /passiveCatalogRefresh\.schedule\(\)/);
+  assert.match(source, /provider\.mirrorNativeModels === true && selected\.has\(provider\.id\)/);
+  assert.doesNotMatch(schedulerSource, /setInterval\s*\(/);
+});

--- a/test/passive-catalog-refresh.test.mjs
+++ b/test/passive-catalog-refresh.test.mjs
@@ -52,7 +52,9 @@ test("a durable reservation coalesces attempts and success starts a fresh cooldo
     });
     assert.equal(first.reserved, true);
     assert.equal(first.state.nextEligibleAt, 1_500);
-    assert.equal(lstatSync(state.file).mode & 0o777, 0o600);
+    if (process.platform !== "win32") {
+      assert.equal(lstatSync(state.file).mode & 0o777, 0o600);
+    }
 
     const duplicate = reservePassiveCatalogRefresh({
       file: state.file,

--- a/test/refresh-catalog.test.mjs
+++ b/test/refresh-catalog.test.mjs
@@ -10,7 +10,7 @@ const noJournal = {
 };
 const noLock = (operation) => operation();
 
-function recordingRunner({ signed = true, loginFree = false, model, failAt } = {}) {
+function recordingRunner({ mode = "router", signed = true, loginFree = false, model, failAt } = {}) {
   const calls = [];
   return {
     calls,
@@ -24,7 +24,7 @@ function recordingRunner({ signed = true, loginFree = false, model, failAt } = {
         return {
           status: 0,
           stdout: `${JSON.stringify({
-            mode: "router",
+            mode,
             signed_routing: signed,
             login_free: loginFree,
             model: model || null,
@@ -47,10 +47,11 @@ test("refresh orchestration restores signed routing and republishes the routed c
   assert.deepEqual(runner.calls, [
     ["config-manager.mjs", ["status"]],
     ["config-manager.mjs", ["disable"]],
-    ["catalog.mjs", ["--refresh-native"]],
+    ["catalog.mjs", ["--refresh-native", "--router-transport-parked"]],
     ["config-manager.mjs", ["enable"]],
     ["config-manager.mjs", ["signed-enable"]],
     ["catalog.mjs", []],
+    ["native-model-mirror.mjs", []],
   ]);
   assert.equal(result.catalogOutput, '{"models":1}\n');
 });
@@ -64,7 +65,7 @@ test("refresh orchestration restores the active transport after catalog failure"
   assert.deepEqual(runner.calls, [
     ["config-manager.mjs", ["status"]],
     ["config-manager.mjs", ["disable"]],
-    ["catalog.mjs", ["--refresh-native"]],
+    ["catalog.mjs", ["--refresh-native", "--router-transport-parked"]],
     ["config-manager.mjs", ["enable"]],
     ["config-manager.mjs", ["signed-enable"]],
     ["catalog.mjs", []],
@@ -77,9 +78,20 @@ test("ordinary routed refresh also republishes external models after restore", a
   assert.deepEqual(runner.calls, [
     ["config-manager.mjs", ["status"]],
     ["config-manager.mjs", ["disable"]],
-    ["catalog.mjs", ["--refresh-native"]],
+    ["catalog.mjs", ["--refresh-native", "--router-transport-parked"]],
     ["config-manager.mjs", ["enable"]],
     ["catalog.mjs", []],
+    ["native-model-mirror.mjs", []],
+  ]);
+});
+
+test("native-only refresh republishes models added by automatic mirroring", async () => {
+  const runner = recordingRunner({ mode: "native", signed: false });
+  await refreshCatalog({ run: runner.run, lock: noLock });
+  assert.deepEqual(runner.calls, [
+    ["config-manager.mjs", ["status"]],
+    ["catalog.mjs", ["--refresh-native", "--router-transport-parked"]],
+    ["native-model-mirror.mjs", []],
   ]);
 });
 
@@ -102,7 +114,7 @@ test("refresh orchestration restores identity-preserving login-free mode and its
       "config-manager.mjs",
       ["disable", "--preserve-login-free-state", "--park-login-free-refresh"],
     ],
-    ["catalog.mjs", ["--refresh-native"]],
+    ["catalog.mjs", ["--refresh-native", "--router-transport-parked"]],
     [
       "config-manager.mjs",
       [
@@ -116,6 +128,7 @@ test("refresh orchestration restores identity-preserving login-free mode and its
       "config-manager.mjs",
       ["login-free-enable", "gpt-5.6-terra", "--complete-login-free-refresh"],
     ],
+    ["native-model-mirror.mjs", []],
   ]);
 });
 
@@ -147,7 +160,7 @@ test("pending refresh resumes and completes only with an alias for the same cano
       "config-manager.mjs",
       ["disable", "--preserve-login-free-state", "--park-login-free-refresh"],
     ],
-    ["catalog.mjs", ["--refresh-native"]],
+    ["catalog.mjs", ["--refresh-native", "--router-transport-parked"]],
     [
       "config-manager.mjs",
       [
@@ -161,5 +174,6 @@ test("pending refresh resumes and completes only with an alias for the same cano
       "config-manager.mjs",
       ["login-free-enable", "fresh-alias", "--complete-login-free-refresh"],
     ],
+    ["native-model-mirror.mjs", []],
   ]);
 });

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -1497,6 +1497,59 @@ test("a keyless provider must be loopback and must not carry a credential", asyn
   }
 });
 
+test("native model mirroring is an explicit Responses-provider contract", async () => {
+  const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const nodePath = (await import("node:path")).default;
+  const { spawnSync } = await import("node:child_process");
+  const dir = mkdtempSync(nodePath.join(tmpdir(), "registry-native-mirror-test-"));
+  const load = (mutate) => {
+    const registry = readRegistryDocument("config");
+    mutate(registry);
+    const registryPath = nodePath.join(dir, `providers-${Math.random()}.json`);
+    writeFileSync(registryPath, JSON.stringify(registry));
+    return spawnSync(
+      process.execPath,
+      ["-e", "import('./src/model-registry.mjs').catch((e)=>{console.error(e.message);process.exit(1);})"],
+      { encoding: "utf8", env: { ...process.env, MODEL_ROUTER_REGISTRY: registryPath } },
+    );
+  };
+  try {
+    const invalidFlag = load((registry) => {
+      registry.providers = registry.providers.map((provider) =>
+        provider.id === "deepseek" ? { ...provider, allowPrivate: "yes" } : provider,
+      );
+    });
+    assert.equal(invalidFlag.status, 1);
+    assert.match(invalidFlag.stderr, /invalid allowPrivate flag/);
+
+    const wrongProtocol = load((registry) => {
+      registry.providers = registry.providers.map((provider) =>
+        provider.id === "deepseek" ? { ...provider, mirrorNativeModels: true } : provider,
+      );
+    });
+    assert.equal(wrongProtocol.status, 1);
+    assert.match(wrongProtocol.stderr, /may mirror native models only through openai-responses/);
+
+    const accepted = load((registry) => {
+      registry.providers.push({
+        id: "private-mirror",
+        displayName: "Private Mirror",
+        ownedBy: "operator",
+        kind: "openai-compatible",
+        protocol: "openai-responses",
+        baseUrl: "http://10.0.0.2:8000/v1",
+        credential: { file: "private-mirror.secret", environment: [] },
+        allowPrivate: true,
+        mirrorNativeModels: true,
+      });
+    });
+    assert.equal(accepted.status, 0, accepted.stderr);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("credential-free endpoints are allowlisted addresses, at the provider and at the model", async () => {
   const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
   const { tmpdir } = await import("node:os");

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -174,6 +174,46 @@ test("background services never copy the Antigravity client secret", () => {
   }
 });
 
+test("background services preserve only an enabled passive-refresh kill switch", () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-passive-service-"));
+  const scripts = [
+    [
+      "service-macos.mjs",
+      "darwin",
+      /CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH<\/key>\s*<string>1<\/string>/,
+    ],
+    ["service-linux.mjs", "linux", /CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH=1/],
+    ["service-windows.mjs", "win32", /CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH=1/],
+  ];
+  try {
+    for (const [script, platform, enabledPattern] of scripts) {
+      const enabled = serviceCommand(
+        script,
+        platform,
+        testRoot,
+        "render",
+        "codex",
+        root,
+        { CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH: "1" },
+      );
+      assert.match(enabled, enabledPattern);
+
+      const rejected = serviceCommand(
+        script,
+        platform,
+        testRoot,
+        "render",
+        "codex",
+        root,
+        { CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH: "1 & unsafe" },
+      );
+      assert.doesNotMatch(rejected, /CODEX_ROUTER_DISABLE_PASSIVE_CATALOG_REFRESH/);
+    }
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("background services preserve only environment credentials referenced by a pool", () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-pool-environment-service-"));
   const secret = "test-pooled-opencode-secret";


### PR DESCRIPTION
## Problem

An OpenAI Responses-compatible gateway can expose new native-compatible model
ids before codex-router's checked-in registry knows about them. The existing
refresh command updates the native catalog, but operators still have to notice
the provider change and curate another route manually. A periodic polling loop
would solve freshness at the cost of repeated network traffic and could restart
the router while Codex turns are active.

A managed mirror also regenerated its full metadata record. If an operator had
live-tested one exact provider/model route and set
`supportsSearchHistory: true`, the next catalog refresh removed that proof.
Continuing a conversation containing a completed `web_search_call` then failed
locally with `model_search_not_supported`, even though that exact upstream
route accepted the history.

The native catalog can also expose the client-only `ultra` reasoning rung for a
model whose exact private route has been live-tested. Managed refreshes
previously removed that route-specific override, forcing the operator to add it
back after every metadata refresh.

## Solution

- Allow an OpenAI Responses provider to opt in to private model discovery and
  native-model mirroring.
- Mirror only the exact intersection of the signed-in Codex catalog and the
  provider's live `/models` response. Generated entries carry an ownership
  marker; manually curated entries remain authoritative, and a transiently
  incomplete provider response never deletes a working route.
- Refresh passively from local lifecycle events rather than a polling loop.
  Router startup and the end of traffic schedule one check after 30 seconds of
  continuous idle time. A new request cancels that idle grace period.
- Coalesce triggers across processes with an owner-private durable reservation.
  Successful checks cool down for 24 hours; failures back off exponentially
  from 1 hour to a 24-hour cap. The worker is detached, time-bounded, and never
  performs provider discovery on the synchronous request path.
- Skip route publication and service restart when the mirrored intersection is
  unchanged. The explicit `refresh-catalog` command remains the immediate
  override and resets the cooldown.
- Preserve an operator-supplied boolean `supportsSearchHistory` only on the
  same managed provider/model route. New models remain conservative: the flag
  is neither inferred from Responses compatibility nor copied from another
  model.
- Preserve an operator-added `ultra` rung only on the same managed route and
  only while the signed-in native catalog continues to advertise `ultra`. New
  mirrors stay conservative, and another route cannot donate this capability.
- Preserve an exact boolean kill switch in the generated macOS, Linux, and
  Windows service definitions.

Codex still reads its picker catalog at application startup, so a newly
published model becomes visible after fully quitting and reopening Codex.

## Safety properties

- Provider opt-in is limited to the OpenAI Responses protocol.
- Scheduling state is bounded, schema-validated, mode `0600`, and written
  atomically without upstream errors, response bodies, URLs, or credentials.
- A reservation is persisted before network I/O, preventing restart storms if
  the worker crashes.
- Existing user routes and unrelated provider configuration are not rewritten.
- Search-history replay and `ultra` remain exact-route, explicitly verified
  capabilities; a stale native `ultra` declaration is removed rather than kept.
- No private provider configuration or credentials are part of this branch.

## Verification

- `npm run check` — passed.
- Related regression suite — 174 passed, 1 platform skip, 0 failed.
- Passive-refresh adversarial suite — 12 passed, including 1,000 competing
  in-process triggers, 12 concurrent processes sharing one reservation, traffic
  cancellation, corrupt/symlink state, launcher failures, and secret-retention
  checks.
- Search-history/mirror focused suites — 15 passed, 0 failed: capabilities on
  a different route are not inherited, exact verified overrides survive managed
  metadata refresh, unsupported routes remain rejected, verified replay is
  forwarded, and `ultra` is withdrawn when native metadata no longer exposes it.
- GitHub Actions is green across the full Ubuntu, macOS, and Windows test
  suites, the unified native macOS lifecycle, both Electron packages,
  deterministic provider discovery, and GitGuardian.
- Installed from this branch on macOS: service readiness passed and the router
  PID stayed stable. With active Codex traffic present, the idle gate correctly
  withheld the refresh worker.
- The complete PR diff passed targeted private-value and credential-shape
  scans.
