### PR TITLE
fix: detect same-version Codex runtime replacement

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -23,14 +23,14 @@ Neither command prints credential values. Repair refuses unknown router owners.
 
 ## New native models (GPT-6 Astra, GPT-7, etc.)
 
-**Uninstall is never required** to see new OpenAI/Codex native models. When Codex updates `~/.codex/models_cache.json` (new native model released), the router automatically detects fingerprint drift on next startup and republishes the catalog.
+**Uninstall is never required** to see new OpenAI/Codex native models. The router watches both `~/.codex/models_cache.json` and a lightweight fingerprint of the resolved Codex executable, then republishes when either source changes. This also catches Desktop primary-runtime replacements that keep the same `codex --version` string. Drift is checked on startup and periodically while the router stays running.
 
 **Codex full quit/reopen is still required** to reload the catalog file. Codex reads `model_catalog_json` once at startup; the router cannot make Codex hot-reload.
 
 Expected flow:
 1. OpenAI releases new native (e.g., GPT-7)
-2. Codex updates `models_cache.json`
-3. Router detects drift on next startup/refresh → republishes automatically
+2. Codex updates `models_cache.json` or replaces its bundled/runtime executable
+3. Router detects drift on startup or a periodic check → republishes automatically
 4. Fully quit and reopen Codex → new native appears in picker
 
 No uninstall needed. The router stays installed while merging ALL natives + routed models.

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -25,7 +25,12 @@ import {
   NATIVE_CATALOG_PATH,
   PORTS,
 } from "./paths.mjs";
-import { codexAuthStatus, codexVersion, runCodex } from "./codex-binary.mjs";
+import {
+  codexAuthStatus,
+  codexBinaryFingerprint,
+  codexVersion,
+  runCodex,
+} from "./codex-binary.mjs";
 import { readUserModels } from "./user-models.mjs";
 import { syncRoutedCodexAgents } from "./codex-agent-catalog.mjs";
 import {
@@ -329,9 +334,11 @@ function captureNative(cache) {
   }
   const capturedWith = codexVersion();
   const sourceFingerprint = cache.fingerprint;
+  const binaryFingerprint = codexBinaryFingerprint();
   atomicJson(NATIVE_CATALOG_PATH, {
     ...(capturedWith ? { captured_with: capturedWith } : {}),
     ...(sourceFingerprint ? { native_source_fingerprint: sourceFingerprint } : {}),
+    ...(binaryFingerprint ? { native_binary_fingerprint: binaryFingerprint } : {}),
     models: parsed.models,
   });
   return parsed;
@@ -346,6 +353,7 @@ export function nativeCatalogIsReusable(
   parsed,
   currentVersion,
   currentSourceFingerprint = undefined,
+  currentBinaryFingerprint = undefined,
 ) {
   if (!parsed || !Array.isArray(parsed.models) || parsed.models.length === 0) {
     return false;
@@ -354,6 +362,12 @@ export function nativeCatalogIsReusable(
   if (
     currentSourceFingerprint &&
     parsed.native_source_fingerprint !== currentSourceFingerprint
+  ) {
+    return false;
+  }
+  if (
+    currentBinaryFingerprint &&
+    parsed.native_binary_fingerprint !== currentBinaryFingerprint
   ) {
     return false;
   }
@@ -404,7 +418,14 @@ function nativeCatalog({ refreshNative = refresh } = {}) {
     }
   }
   const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
-  if (nativeCatalogIsReusable(parsed, codexVersion(), cache.fingerprint)) {
+  if (
+    nativeCatalogIsReusable(
+      parsed,
+      codexVersion(),
+      cache.fingerprint,
+      codexBinaryFingerprint(),
+    )
+  ) {
     return parsed;
   }
   try {

--- a/src/codex-binary.mjs
+++ b/src/codex-binary.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -100,6 +101,23 @@ export function findCodexBinary() {
   return resolveRealCodex()?.file;
 }
 
+export function codexBinaryFingerprint(binary = findCodexBinary()) {
+  if (!binary) return undefined;
+  try {
+    const stats = statSync(binary);
+    return createHash("sha256")
+      .update(JSON.stringify({
+        path: path.resolve(binary),
+        size: stats.size,
+        mtimeMs: stats.mtimeMs,
+        ctimeMs: stats.ctimeMs,
+      }))
+      .digest("hex");
+  } catch {
+    return undefined;
+  }
+}
+
 export function requireCodexBinary() {
   const binary = findCodexBinary();
   if (!binary) {
@@ -119,9 +137,11 @@ export function runCodex(args, options = {}) {
   });
 }
 
-// The version tells catalog code whether a cached native capture came from
-// the currently installed build. Undefined means "could not ask", which
-// callers must treat as unknown rather than as a mismatch.
+// The version is one compatibility signal for native catalog reuse, but
+// Desktop can replace its version-hashed runtime binary without changing this
+// string. codexBinaryFingerprint() supplies the complementary build identity.
+// Undefined means "could not ask", which callers treat as unknown rather than
+// as a mismatch.
 export function codexVersion() {
   try {
     const output = runCodex(["--version"], {

--- a/src/native-catalog-drift.mjs
+++ b/src/native-catalog-drift.mjs
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { NATIVE_CATALOG_PATH, CONFIG_PATH } from "./paths.mjs";
 import { nativeCatalogIsReusable, readModelsCache } from "./catalog.mjs";
-import { codexVersion } from "./codex-binary.mjs";
+import { codexBinaryFingerprint, codexVersion } from "./codex-binary.mjs";
 
 // Marker pattern from config-manager.mjs to detect managed Codex config
 const managedMarkerPattern = /^# BEGIN codex-router$/m;
@@ -47,9 +47,15 @@ export function nativeCatalogDriftDetected() {
     // Read the stored native catalog
     const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
 
-    // Check if reusable (fingerprint + version match)
+    // Check account-cache, CLI-version, and installed-binary identity.
     const version = codexVersion();
-    return !nativeCatalogIsReusable(parsed, version, cache.fingerprint);
+    const binaryFingerprint = codexBinaryFingerprint();
+    return !nativeCatalogIsReusable(
+      parsed,
+      version,
+      cache.fingerprint,
+      binaryFingerprint,
+    );
   } catch {
     // Any error means we can't reliably detect drift
     return false;

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1041,6 +1041,34 @@ test("native catalog cache is reusable only for the codex build that captured it
   assert.equal(nativeCatalogIsReusable({ models: [] }, "codex-cli 0.146.1"), false);
 });
 
+test("native catalog cache is invalidated when the Codex binary changes without a version change", () => {
+  const captured = {
+    captured_with: "codex-cli 0.153.3",
+    native_source_fingerprint: "account-a",
+    native_binary_fingerprint: "binary-a",
+    models: [template],
+  };
+
+  assert.equal(
+    nativeCatalogIsReusable(
+      captured,
+      "codex-cli 0.153.3",
+      "account-a",
+      "binary-a",
+    ),
+    true,
+  );
+  assert.equal(
+    nativeCatalogIsReusable(
+      captured,
+      "codex-cli 0.153.3",
+      "account-a",
+      "binary-b",
+    ),
+    false,
+  );
+});
+
 test("native catalog merge preserves account visibility and bundled-only models", () => {
   const accountMini = {
     slug: "gpt-mini",

--- a/test/codex-binary.test.mjs
+++ b/test/codex-binary.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  codexBinaryFingerprint,
   codexCandidatePaths,
   findCodexBinary,
   linuxDesktopAppBundledCodex,
@@ -73,6 +74,31 @@ test("prefers the Linux desktop app's bundled CLI over a standalone CLI", () => 
     );
     const candidates = codexCandidatePaths({ platform: "linux", linuxDesktopRoots: [testRoot] });
     assert.ok(candidates.indexOf(bundled) < candidates.indexOf("/usr/local/bin/codex"));
+  } finally {
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("Codex binary fingerprint changes when the executable identity changes", () => {
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-binary-fingerprint-"));
+  const firstPath = path.join(testRoot, "first", "codex.exe");
+  const secondPath = path.join(testRoot, "second", "codex.exe");
+  mkdirSync(path.dirname(firstPath), { recursive: true });
+  mkdirSync(path.dirname(secondPath), { recursive: true });
+  writeFileSync(firstPath, "same bytes");
+  writeFileSync(secondPath, "same bytes");
+
+  try {
+    const first = codexBinaryFingerprint(firstPath);
+    const second = codexBinaryFingerprint(secondPath);
+    assert.match(first, /^[a-f0-9]{64}$/);
+    assert.match(second, /^[a-f0-9]{64}$/);
+    assert.notEqual(first, second, "version-hashed install path contributes to identity");
+
+    const beforeMutation = codexBinaryFingerprint(firstPath);
+    writeFileSync(firstPath, "different bytes");
+    const afterMutation = codexBinaryFingerprint(firstPath);
+    assert.notEqual(beforeMutation, afterMutation, "replaced binary invalidates identity");
   } finally {
     rmSync(testRoot, { recursive: true, force: true });
   }

--- a/test/native-catalog-drift.test.mjs
+++ b/test/native-catalog-drift.test.mjs
@@ -26,6 +26,7 @@ test("drift detection triggers republish with new arbitrary native in merged out
 
     // Import after env is set
     const { nativeCatalogDriftDetected, republishOnNativeDrift } = await import("../src/native-catalog-drift.mjs");
+    const { codexBinaryFingerprint, codexVersion } = await import("../src/codex-binary.mjs");
     const { NATIVE_CATALOG_PATH, MERGED_CATALOG_PATH, CONFIG_PATH } = await import("../src/paths.mjs");
 
     // Create minimal managed config so codexIntegrationInstalled returns true
@@ -49,10 +50,17 @@ test("drift detection triggers republish with new arbitrary native in merged out
       JSON.stringify(modelsCache),
     );
 
-    // Simulate stored native-models.json with old fingerprint
+    // Simulate stored native-models.json with old fingerprint. Match a real
+    // installed Codex when the test host has one; CI hosts without Codex keep
+    // the historical fallback fixture.
+    const currentVersion = codexVersion();
+    const currentBinaryFingerprint = codexBinaryFingerprint();
     const storedCatalog = {
-      captured_with: "codex-cli 0.146.1",
+      captured_with: currentVersion || "codex-cli 0.146.1",
       native_source_fingerprint: oldFingerprint,
+      ...(currentBinaryFingerprint
+        ? { native_binary_fingerprint: currentBinaryFingerprint }
+        : {}),
       models: [oldNative],
     };
     writeFileSync(NATIVE_CATALOG_PATH, JSON.stringify(storedCatalog));


### PR DESCRIPTION
## Summary
- stamp native catalog captures with a lightweight fingerprint of the resolved Codex executable
- invalidate/re-publish native captures when the Desktop/runtime binary changes even if `codex --version` and the account-cache fingerprint stay unchanged
- preserve existing fail-safe behavior when the executable cannot be identified
- document same-version Desktop primary-runtime replacement handling

## Why
Codex Desktop can replace its version-hashed runtime binary while both `codex --version` and `~/.codex/models_cache.json` remain unchanged. PR #624 correctly added automatic native-catalog drift detection, but that combination can make a stale capture look reusable even when the bundled runtime contains newer native model metadata.

## Verification
- `node --test test/catalog.test.mjs test/codex-binary.test.mjs test/native-catalog-drift.test.mjs` — 85/85 passed
- `npm run check` — passed
- `git diff --check` — passed

A broader local suite run also progressed through hundreds of tests; one unrelated Windows fixture failed at direct `symlinkSync()` setup with `EPERM` before router code executed, so this PR does not alter that test infrastructure.