### PR TITLE
fix: keep routed subagents on parent model

### DIFF
--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -464,26 +464,33 @@ function schemaStringValues(schema, values = new Set()) {
   return values;
 }
 
-// A fresh local thread inherits the routed session model when the caller did
-// not choose one. Follow-up messages intentionally keep the target thread's
-// settings, and cloud tasks require model omission, so neither is rewritten.
-export const SPAWN_MODEL_TOOLS = new Set(["create_thread"]);
-const SPAWN_TOOL_PREFIX = `codex_app${NAMESPACE_DELIMITER}`;
+// A fresh local thread or in-session subagent inherits the routed session
+// model when the caller did not choose one. Follow-up messages intentionally
+// keep the target thread's settings, and cloud tasks require model omission,
+// so neither is rewritten.
+export const SPAWN_MODEL_TOOLS = new Set(["create_thread", "spawn_agent"]);
+const SPAWN_MODEL_NAMESPACES = new Map([
+  ["codex_app", new Set(["create_thread"])],
+  ["collaboration", new Set(["spawn_agent"])],
+]);
 
 function isSpawnModelCall(item) {
   if (!item || typeof item.name !== "string") return false;
-  // Flattened form the router sends to chat-completions bridges:
-  // `codex_app__create_thread`.
-  if (item.name.startsWith(SPAWN_TOOL_PREFIX)) {
-    return SPAWN_MODEL_TOOLS.has(item.name.slice(SPAWN_TOOL_PREFIX.length));
+  // Flattened forms the router sends to chat-completions bridges, such as
+  // `codex_app__create_thread` and `collaboration__spawn_agent`.
+  for (const [namespace, names] of SPAWN_MODEL_NAMESPACES) {
+    const prefix = `${namespace}${NAMESPACE_DELIMITER}`;
+    if (item.name.startsWith(prefix)) return names.has(item.name.slice(prefix.length));
   }
-  // Native namespace form openai-responses providers keep:
-  // `{ name: "create_thread", namespace: "codex_app" }`.
-  if (item.namespace === "codex_app") return SPAWN_MODEL_TOOLS.has(item.name);
-  return false;
+  // Native namespace form openai-responses providers keep.
+  return SPAWN_MODEL_NAMESPACES.get(item.namespace)?.has(item.name) === true;
 }
 
-// Inject the session model into local create_thread calls that omitted it.
+// Inject the session model into local create_thread and spawn_agent calls that
+// omitted it. For spawn_agent this runs after an unsupported explicit override
+// has been removed, so the child returns to its routed parent rather than the
+// client's native default. A parent not offered by the client then fails
+// closed at tool validation instead of silently crossing a billing boundary.
 // `model` is the routed session's model (route.slug). Returns a rewritten
 // item when the call is one of SPAWN_MODEL_TOOLS, carries no explicit model,
 // and a session model is available; otherwise returns the item untouched.

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -4039,10 +4039,12 @@ async function handleResponses(request, response, requestUrl) {
         ? translatedToolMessageCompatTransform(providerForModel(route), contentType)
         : undefined;
       if (translatedToolMessageCompat) transforms.push(translatedToolMessageCompat);
-      // Restore flattened namespace calls for routed chat-completions providers,
-      // and inject missing finished-child interrupts for both routed and native
-      // multi-agent parents (San Francisco uses native GPT).
-      if (!directResponses && (route || pendingInterrupts.length > 0)) {
+      // Restore flattened namespace calls for routed chat-completions providers
+      // and pin an omitted spawn_agent model to every routed parent, including
+      // providers that already speak Responses. Also inject missing finished-
+      // child interrupts for both routed and native multi-agent parents (San
+      // Francisco uses native GPT).
+      if (route || pendingInterrupts.length > 0) {
         transforms.push(
           new NamespaceToolCallTransform(
             flattenedNamespaces,

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -2444,6 +2444,80 @@ test("response transform drops a spawn-agent model override not offered by the t
     message: "verify",
     model: "gpt-5.6-terra",
   });
+
+  const inherited = rewriteNamespaceResponsePayload(
+    {
+      output: [
+        {
+          type: "function_call",
+          name: "collaboration__spawn_agent",
+          arguments: JSON.stringify({ message: "verify", model: "gpt-5.6-luna" }),
+        },
+      ],
+    },
+    lookups,
+    "opencode-go/deepseek-v4-flash",
+  );
+  assert.deepEqual(JSON.parse(inherited.output[0].arguments), {
+    message: "verify",
+    model: "opencode-go/deepseek-v4-flash",
+  });
+});
+
+test("stream response keeps an omitted spawn-agent model on its routed parent", async () => {
+  const { namespaces } = flattenNamespaceTools(clientRoutedTools());
+  const event = {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      name: "collaboration__spawn_agent",
+      call_id: "call_parent_model",
+      arguments: JSON.stringify({ message: "verify" }),
+    },
+  };
+  const transform = new NamespaceToolCallTransform(
+    namespaces,
+    "text/event-stream",
+    "opencode-go/deepseek-v4-flash",
+  );
+  const output = await collect(
+    Readable.from([`data: ${JSON.stringify(event)}\n\n`]).pipe(transform),
+  );
+  const payload = JSON.parse(output.toString("utf8").trim().slice(5));
+  assert.equal(payload.item.namespace, "collaboration");
+  assert.equal(payload.item.name, "spawn_agent");
+  assert.deepEqual(JSON.parse(payload.item.arguments), {
+    message: "verify",
+    model: "opencode-go/deepseek-v4-flash",
+  });
+});
+
+test("Responses-native stream keeps an omitted spawn-agent model on its routed parent", async () => {
+  const event = {
+    type: "response.output_item.done",
+    item: {
+      type: "function_call",
+      namespace: "collaboration",
+      name: "spawn_agent",
+      call_id: "call_native_parent_model",
+      arguments: JSON.stringify({ message: "verify" }),
+    },
+  };
+  const transform = new NamespaceToolCallTransform(
+    new Map(),
+    "text/event-stream",
+    "opencode-go/deepseek-v4-flash",
+  );
+  const output = await collect(
+    Readable.from([`data: ${JSON.stringify(event)}\n\n`]).pipe(transform),
+  );
+  const payload = JSON.parse(output.toString("utf8").trim().slice(5));
+  assert.equal(payload.item.namespace, "collaboration");
+  assert.equal(payload.item.name, "spawn_agent");
+  assert.deepEqual(JSON.parse(payload.item.arguments), {
+    message: "verify",
+    model: "opencode-go/deepseek-v4-flash",
+  });
 });
 
 test("response transform detects headerless SSE after split framing prelude", async () => {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -9463,7 +9463,7 @@ test("router normalizes direct DeepSeek's live reasoning bridge and removes its 
   }
 });
 
-test("router compacts translated OpenCode routes but leaves Responses-native routes unchanged", async () => {
+test("router compacts translated OpenCode routes and pins subagents on both route types", async () => {
   const blank = {
     id: "msg_blank",
     type: "message",
@@ -9484,11 +9484,12 @@ test("router compacts translated OpenCode routes but leaves Responses-native rou
     arguments: "{}",
     status: "completed",
   };
-  const restoredTool = {
+  const restoredTool = (model) => ({
     ...tool,
     name: "spawn_agent",
     namespace: "collaboration",
-  };
+    arguments: JSON.stringify({ model }),
+  });
   const tools = [{
     type: "namespace",
     name: "collaboration",
@@ -9574,7 +9575,7 @@ test("router compacts translated OpenCode routes but leaves Responses-native rou
     );
     assert.deepEqual(
       translatedEvents.find((event) => event.type === "response.completed").response.output,
-      [restoredTool],
+      [restoredTool("opencode-go/deepseek-v4-flash")],
     );
 
     const nativeResponse = await fetch(`${routerBase(routerPort)}/responses`, {
@@ -9599,7 +9600,7 @@ test("router compacts translated OpenCode routes but leaves Responses-native rou
     );
     assert.deepEqual(
       nativeEvents.find((event) => event.type === "response.completed").response.output,
-      [terminalBlank, restoredTool],
+      [terminalBlank, restoredTool("opencode-go-responses/gpt-5.6-luna")],
     );
   } finally {
     await stopChild(router);

--- a/test/subagent-model-inherit.test.mjs
+++ b/test/subagent-model-inherit.test.mjs
@@ -19,8 +19,8 @@ function spawnCall(name, namespace, argumentsText) {
   return item;
 }
 
-test("only create_thread is eligible for routed model inheritance", () => {
-  assert.deepEqual([...SPAWN_MODEL_TOOLS], ["create_thread"]);
+test("local thread and subagent spawns are eligible for routed model inheritance", () => {
+  assert.deepEqual([...SPAWN_MODEL_TOOLS], ["create_thread", "spawn_agent"]);
 });
 
 test("routed session + omitted model injects the session model (flattened form)", () => {
@@ -30,6 +30,35 @@ test("routed session + omitted model injects the session model (flattened form)"
   assert.deepEqual(JSON.parse(next.arguments), {
     prompt: "hi",
     target: { type: "projectless" },
+    model: SESSION_MODEL,
+  });
+});
+
+test("routed session + omitted model keeps a flattened subagent on its parent model", () => {
+  const item = spawnCall(
+    "collaboration__spawn_agent",
+    undefined,
+    JSON.stringify({ task_name: "review", message: "inspect" }),
+  );
+  const next = injectSessionModelForSpawnCalls(item, SESSION_MODEL);
+  assert.notEqual(next, item);
+  assert.deepEqual(JSON.parse(next.arguments), {
+    task_name: "review",
+    message: "inspect",
+    model: SESSION_MODEL,
+  });
+});
+
+test("routed session + omitted model keeps a native subagent on its parent model", () => {
+  const item = spawnCall(
+    "spawn_agent",
+    "collaboration",
+    JSON.stringify({ task_name: "review", message: "inspect" }),
+  );
+  const next = injectSessionModelForSpawnCalls(item, SESSION_MODEL);
+  assert.deepEqual(JSON.parse(next.arguments), {
+    task_name: "review",
+    message: "inspect",
     model: SESSION_MODEL,
   });
 });
@@ -60,6 +89,13 @@ test("explicit model always wins and stays untouched", () => {
     JSON.stringify({ threadId: "t1", prompt: "continue", model: "gpt-5.5" }),
   );
   assert.equal(injectSessionModelForSpawnCalls(namespaced, SESSION_MODEL), namespaced);
+
+  const subagent = spawnCall(
+    "spawn_agent",
+    "collaboration",
+    JSON.stringify({ task_name: "review", message: "inspect", model: "gpt-5.6-terra" }),
+  );
+  assert.equal(injectSessionModelForSpawnCalls(subagent, SESSION_MODEL), subagent);
 });
 
 test("chatgptWorkCloud create_thread calls omit model", () => {
@@ -85,10 +121,12 @@ test("non-spawn tools are never touched", () => {
   for (const item of [
     spawnCall("codex_app__list_threads", undefined, "{}"),
     spawnCall("codex_app__read_thread", undefined, JSON.stringify({ threadId: "t1" })),
-    spawnCall("collaboration__spawn_agent", undefined, JSON.stringify({ task_name: "x" })),
     spawnCall("mcp__node_repl__js", undefined, "{}"),
     // A different namespace with the same tool name is not the app's tool.
     spawnCall("mcp__other__create_thread", undefined, JSON.stringify({ prompt: "hi" })),
+    spawnCall("mcp__other__spawn_agent", undefined, JSON.stringify({ task_name: "x" })),
+    // A bare spelling carries no namespace authority and stays untouched.
+    spawnCall("spawn_agent", undefined, JSON.stringify({ task_name: "x" })),
   ]) {
     assert.equal(injectSessionModelForSpawnCalls(item, SESSION_MODEL), item, item.name);
   }


### PR DESCRIPTION
## Problem

When a routed parent model emits `collaboration.spawn_agent` without a `model`, Codex may select its native/default model for the child. That silently crosses the provider and billing boundary: the parent uses the routed provider, while the child can consume the signed-in OpenAI subscription.

The router already inherited the active routed model for `codex_app.create_thread`, but excluded `collaboration.spawn_agent`. Direct Responses routes also skipped the response transformation that performs model inheritance.

## Fix

- Treat exact `collaboration.spawn_agent` identities as model-spawning calls.
- Inject the active routed parent slug only when the child omitted `model`.
- Preserve valid explicit model overrides.
- Sanitize unsupported explicit overrides first, then fall back to the routed parent.
- Apply the response transform to direct Responses routes as well as translated routes.
- Keep native OpenAI traffic and unrelated same-named tools unchanged.

This is fail-closed for a parent model that is not eligible for client-side spawning: injecting that slug lets the existing client schema reject it instead of silently selecting a native child.

## Verification

- `node --test test/subagent-model-inherit.test.mjs test/namespace-relay.test.mjs` — 129 passed.
- `node --test test/routing.test.mjs` — 116 passed.
- `npm run check` — passed.
- `git diff --check` — passed.
- Full `npm test` reached 3,611 passed and 25 skipped out of 3,640. Four unrelated host/state-sensitive failures remain: an Antigravity SSE timing assertion, localized desktop-panel text, current native-catalog drift, and the repository setup test inheriting the operators global Git hook.

No provider credentials, private endpoint configuration, tunnel state, or user model catalog files are included.