### PR TITLE
fix(windows): preserve explicit service stop with heartbeat

### DIFF
--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -394,6 +394,13 @@ function taskExists() {
   }
 }
 
+function setTaskEnabled(enabled) {
+  schtasks(
+    ["/Change", "/TN", taskName, enabled ? "/ENABLE" : "/DISABLE"],
+    { quiet: true, mutating: true },
+  );
+}
+
 function taskState() {
   const script =
     "try { [Console]::Out.Write((Get-ScheduledTask -TaskName $env:CODEX_ROUTER_TASK).State.ToString()) } catch { exit 1 }";
@@ -537,12 +544,17 @@ if (command === "render") {
     `${JSON.stringify({ installed, loaded, state })}\n`,
   );
 } else if (command === "stop") {
-  // Stopping is idempotent, like uninstall and restart: a task that is missing
-  // or already idle is the state the caller asked for, not an error to raise.
-  endTask();
+  // A heartbeat trigger must not undo an explicit stop. Disable the task before
+  // ending the active instance so scheduled ticks stay inert until start/restart.
+  // If the task is already missing, stopping remains idempotent.
+  if (taskExists()) {
+    setTaskEnabled(false);
+    endTask();
+  }
   process.stdout.write(`${JSON.stringify({ state: "stopped" })}\n`);
 } else {
   if (command === "restart") endTask();
+  setTaskEnabled(true);
   schtasks(["/Run", "/TN", taskName], { quiet: true, mutating: true });
   process.stdout.write(`${JSON.stringify({ state: "running" })}\n`);
 }

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -425,6 +425,19 @@ test("Windows installTask registers a minute heartbeat beside logon", () => {
   assert.match(install, /-MultipleInstances IgnoreNew -StartWhenAvailable/);
 });
 
+test("Windows explicit stop disables heartbeat while start and restart re-enable it", () => {
+  const source = readFileSync(path.join(root, "src", "service-windows.mjs"), "utf8");
+  assert.match(source, /function setTaskEnabled\(enabled\)/);
+  assert.match(
+    source,
+    /command === "stop"\) \{[\s\S]*?setTaskEnabled\(false\);[\s\S]*?endTask\(\);/,
+  );
+  assert.match(
+    source,
+    /if \(command === "restart"\) endTask\(\);[\s\S]*?setTaskEnabled\(true\);[\s\S]*?schtasks\(\["\/Run"/,
+  );
+});
+
 // Propagating the wrapper exit code keeps LastTaskResult honest for doctor
 // and readiness. It is not what relaunches a dead router: RestartOnFailure
 // only covers actions that fail to start (issue #581). The minute heartbeat
@@ -671,6 +684,59 @@ function runWindowsService(testRoot, command, extraEnv = {}) {
     },
   );
 }
+
+test(
+  "Windows stop disables the heartbeat before ending the active task",
+  { skip: process.platform === "win32" },
+  () => {
+    const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-win-explicit-stop-"));
+    try {
+      const stubs = schedulerStubs(path.join(testRoot, "scheduler"));
+      const result = runWindowsService(testRoot, "stop", { PATH: stubs.path });
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), { state: "stopped" });
+
+      const calls = stubs.calls();
+      const disable = calls.findIndex((line) => line.includes("/Change") && line.includes("/DISABLE"));
+      const end = calls.findIndex((line) => line.includes("/End"));
+      assert.ok(disable >= 0, `explicit stop did not disable the task:\n${calls.join("\n")}`);
+      assert.ok(end > disable, `task must be disabled before /End:\n${calls.join("\n")}`);
+      assert.equal(calls.some((line) => line.includes("/Run")), false);
+    } finally {
+      rmSync(testRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "Windows start and restart re-enable heartbeat recovery before running",
+  { skip: process.platform === "win32" },
+  async (context) => {
+    for (const command of ["start", "restart"]) {
+      await context.test(command, () => {
+        const testRoot = mkdtempSync(path.join(os.tmpdir(), `codex-router-win-${command}-enable-`));
+        try {
+          const stubs = schedulerStubs(path.join(testRoot, "scheduler"));
+          const result = runWindowsService(testRoot, command, { PATH: stubs.path });
+          assert.equal(result.status, 0, result.stderr);
+          assert.deepEqual(JSON.parse(result.stdout), { state: "running" });
+
+          const calls = stubs.calls();
+          const enable = calls.findIndex((line) => line.includes("/Change") && line.includes("/ENABLE"));
+          const run = calls.findIndex((line) => line.includes("/Run"));
+          assert.ok(enable >= 0, `${command} did not re-enable the task:\n${calls.join("\n")}`);
+          assert.ok(run > enable, `${command} must enable before /Run:\n${calls.join("\n")}`);
+          if (command === "restart") {
+            const end = calls.findIndex((line) => line.includes("/End"));
+            assert.ok(end >= 0 && end < enable, `restart must end before enabling:\n${calls.join("\n")}`);
+          }
+        } finally {
+          rmSync(testRoot, { recursive: true, force: true });
+        }
+      });
+    }
+  },
+);
 
 test(
   "Windows status trusts a live launcher when Task Scheduler reports Ready",


### PR DESCRIPTION
## Why

Follow-up to #618. The minute heartbeat correctly recovers a dead Windows router, but it also re-fires after an intentional `service stop` because the scheduled task remains enabled.

On a live Windows install I reproduced this sequence:

1. `service stop` returned `{"state":"stopped"}` and router health went down.
2. The scheduled task remained enabled.
3. The next minute heartbeat relaunched the router automatically.

That makes explicit stop non-persistent.

## Fix

- Disable the scheduled task before ending the active instance on explicit `stop`.
- Re-enable the task before `start` or `restart` runs it.
- Keep stop idempotent when the task is already missing.
- Leave the heartbeat itself unchanged, so crash/power-event recovery still works whenever the service is intentionally enabled.

## Verification

- Added a regression that fails on current `main` before the fix.
- `node --test test/service-render.test.mjs` — pass on Windows (platform-safe scheduler stub cases skip on win32 by repository design).
- Adjacent service/process/task-state/hidden-console tests — 35 total, 19 pass / 16 intentional platform skips, 0 fail.
- `npm run check` — pass.
- `git diff --check` — pass.
- Live Windows validation of the same service semantics:
  - after `stop`: task `Disabled`, no router start process, health down;
  - after waiting 63 seconds across the heartbeat boundary: task still `Disabled`, no router process, health still down;
  - after `start`: task `Running`, two triggers present, `StartWhenAvailable=True`, router health restored;
  - Codex `config.toml` hash remained unchanged.

This preserves #618's self-healing behavior without overriding an explicit user stop.