### PR TITLE
test(windows): isolate doctor routing test from live scheduler

### DIFF
--- a/test/doctor-routing-mode.test.mjs
+++ b/test/doctor-routing-mode.test.mjs
@@ -48,10 +48,22 @@ esac
 }
 
 function child(script, args, env) {
+  const childEnv = {
+    ...env,
+    // This test redirects Codex/router state, but Windows service status reads
+    // the machine-wide Task Scheduler. A developer with the real router
+    // running would otherwise make fixture doctor calls wait on the live task.
+    ...(process.platform === "win32" && script === "doctor.mjs"
+      ? { CODEX_ROUTER_SERVICE_PLATFORM: "test-fixture" }
+      : {}),
+  };
   return spawnSync(process.execPath, [path.join(root, "src", script), ...args], {
     cwd: root,
-    env,
+    env: childEnv,
     encoding: "utf8",
+    // node:test cannot interrupt a synchronous child while the event loop is
+    // blocked, so bound the subprocess itself as the final isolation guard.
+    timeout: 20_000,
   });
 }
 


### PR DESCRIPTION
## Problem

`test/doctor-routing-mode.test.mjs` redirects `CODEX_HOME` and router state, but on Windows its `doctor.mjs` child still reaches the machine-wide `Codex Router` scheduled task through service status.

On a developer machine with the real router running, the fixture doctor therefore sees `serviceLoaded=true` and waits up to 30 seconds for router health on the test fixture port, where no router is running. Because the test helper uses `spawnSync`, the enclosing `node:test` timeout cannot interrupt the blocked child. The test can appear hung for minutes across repeated doctor calls.

I reproduced this on Windows with current `main`: the first filtered test emitted only `TAP version 13` and remained inside `doctor.mjs` until the maintenance-owned runner was terminated.

## Fix

- For Windows `doctor.mjs` subprocesses in this test only, use the existing `CODEX_ROUTER_SERVICE_PLATFORM` seam with a non-host fixture value so the doctor cannot observe the developer's real Task Scheduler state.
- Add a 20-second `spawnSync` timeout to the shared test child helper, so synchronous children are bounded even though the outer test timeout cannot interrupt them.
- No production service/router behavior changes.

## Verification

On the same Windows machine where unpatched `main` hangs:

- `node --test test/doctor-routing-mode.test.mjs` — 2/2 passed
- `npm run check` — passed
- `git diff --check` — passed

The change is limited to `test/doctor-routing-mode.test.mjs`.