### PR TITLE
feat: add Muse Spark OpenCode free model

### DIFF
--- a/config/opencode-free/responses/muse-spark-1.3-contributor-free.json
+++ b/config/opencode-free/responses/muse-spark-1.3-contributor-free.json
@@ -1,0 +1,49 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "opencode-free-responses/muse-spark-1.3-contributor-free",
+      "gatewayModel": "opencode-free-responses-muse-spark-1-3-contributor-free",
+      "upstreamModel": "muse-spark-1.3-contributor-free",
+      "provider": "opencode-free-responses",
+      "listed": true,
+      "displayName": "Muse Spark 1.3 Contributor (OpenCode Free)",
+      "description": "Muse Spark 1.3 Contributor Free through OpenCode Zen's anonymous Responses route. No API key is required; the free catalog and limits can change without notice, and Meta may use inputs and outputs for training.",
+      "priority": 48,
+      "defaultEffort": "xhigh",
+      "reasoningLevels": [
+        {
+          "effort": "minimal",
+          "description": "Fastest responses"
+        },
+        {
+          "effort": "low",
+          "description": "Quick reasoning"
+        },
+        {
+          "effort": "medium",
+          "description": "Balanced reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "xhigh",
+          "description": "Extra deep reasoning"
+        }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 900000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "isFree": true,
+      "supportsApplyPatchTool": false,
+      "requestProfile": "auto-tool-choice",
+      "toolSchemaRecursion": "flatten",
+      "compHash": "opencode-free-responses-muse-spark-1-3-contributor-free-v1"
+    }
+  ]
+}

--- a/src/curate-models.mjs
+++ b/src/curate-models.mjs
@@ -460,10 +460,12 @@ async function main() {
     }
   }
 
-  const inheritedProfile = uniformProviderFamilyRequestProfile(
-    CHECKED_IN_MODELS,
-    familyProviderIds,
-  );
+  // Zen Free mixes unrelated upstream models behind one anonymous catalog.
+  // Its two Muse Responses ids have a documented model-specific profile, so a
+  // checked-in Muse pin must not lend that profile to every other free model.
+  const inheritedProfile = providerId === "opencode-free"
+    ? undefined
+    : uniformProviderFamilyRequestProfile(CHECKED_IN_MODELS, familyProviderIds);
 
   // Which models exist is decided by the provider's own /v1/models endpoint.
   // Metadata comes from that catalog, the interactive user, or the narrow

--- a/test/gemini-3.8-muse-1.3-fable-5.1.test.mjs
+++ b/test/gemini-3.8-muse-1.3-fable-5.1.test.mjs
@@ -11,6 +11,10 @@ process.env.MODEL_ROUTER_USER_MODELS = path.join(testRoot, "user-models.json");
 process.env.MODEL_ROUTER_STATE_DIR = path.join(testRoot, "state");
 
 const { MODEL_BY_SLUG } = await import("../src/model-registry.mjs");
+const { routedModel } = await import("../src/catalog.mjs");
+
+const OPENCODE_FREE_MUSE_SLUG =
+  "opencode-free-responses/muse-spark-1.3-contributor-free";
 
 // Gemini 3.8 Flash routes confirmed 2026-09-03.
 const GEMINI_38_FLASH_ROUTES = [
@@ -32,6 +36,7 @@ const MUSE_13_ROUTES = [
   ["nousresearch/muse-spark-1.3", "meta/muse-spark-1.3", 1_048_576, 943_000],
   ["nousresearch/muse-spark-1.3-contributor", "meta/muse-spark-1.3-contributor", 1_048_576, 943_000],
   ["opencode-go-responses/muse-spark-1.3-contributor", "muse-spark-1.3-contributor", 1_048_576, 900_000],
+  [OPENCODE_FREE_MUSE_SLUG, "muse-spark-1.3-contributor-free", 1_048_576, 900_000],
 ];
 
 // Claude Fable 5.1 routes confirmed 2026-09-03.
@@ -141,6 +146,7 @@ test("Muse Spark reseller routes advertise text and image input", () => {
     "nousresearch/muse-spark-1.2-contributor",
     "opencode-go-responses/muse-spark-1.2-contributor",
     "opencode-go-responses/muse-spark-1.3-contributor",
+    OPENCODE_FREE_MUSE_SLUG,
   ];
   for (const slug of visionSlugs) {
     const model = MODEL_BY_SLUG.get(slug);
@@ -161,7 +167,9 @@ test("Muse Spark 1.3 reasoning ladders have minimal/low/medium/high/xhigh", () =
 
 test("Muse Spark xhigh is labeled as extra deep, not max, and defaults to high", () => {
   const museSlugs = [
-    ...MUSE_13_ROUTES.map(([slug]) => slug),
+    ...MUSE_13_ROUTES.map(([slug]) => slug).filter(
+      (slug) => slug !== OPENCODE_FREE_MUSE_SLUG,
+    ),
     ...MUSE_12_ROUTES.map(([slug]) => slug),
     "meta/muse-spark-1.2",
     "meta/muse-spark-1.2-contributor",
@@ -180,6 +188,36 @@ test("Muse Spark xhigh is labeled as extra deep, not max, and defaults to high",
       `${slug} must not advertise Meta's unreleased max tier yet`,
     );
   }
+});
+
+test("OpenCode Free Muse Spark 1.3 is a native picker entry that defaults to xhigh", () => {
+  const model = MODEL_BY_SLUG.get(OPENCODE_FREE_MUSE_SLUG);
+  assert.ok(model, `${OPENCODE_FREE_MUSE_SLUG} is missing from the registry`);
+  const picker = routedModel(
+    {
+      slug: "gpt-template",
+      display_name: "Template",
+      description: "Template",
+      priority: 10,
+      visibility: "list",
+      apply_patch_tool_type: "freeform",
+    },
+    model,
+  );
+
+  assert.equal(picker.slug, OPENCODE_FREE_MUSE_SLUG);
+  assert.equal(picker.display_name, "Muse Spark 1.3 Contributor (OpenCode Free)");
+  assert.equal(picker.visibility, "list");
+  assert.equal(picker.default_reasoning_level, "xhigh");
+  assert.deepEqual(
+    picker.supported_reasoning_levels.map((level) => level.effort),
+    ["minimal", "low", "medium", "high", "xhigh"],
+  );
+  assert.equal(picker.context_window, 1_048_576);
+  assert.equal(picker.auto_compact_token_limit, 900_000);
+  assert.deepEqual(picker.input_modalities, ["text", "image"]);
+  assert.equal(picker.apply_patch_tool_type, null);
+  assert.equal(picker.multi_agent_version, "v1");
 });
 
 test("Gemini 3.8 Flash reasoning matches provider patterns", () => {

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -183,6 +183,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "opencode-go-responses/grok-4.6",
       "opencode-go-responses/muse-spark-1.2-contributor",
       "opencode-go-responses/muse-spark-1.3-contributor",
+      "opencode-free-responses/muse-spark-1.3-contributor-free",
       "openrouter/claude-fable-5.1",
       "openrouter/gemini-3.8-flash",
       "openrouter/glm-5.3-flash",


### PR DESCRIPTION
OpenCode's anonymous Zen catalog exposes Muse Spark 1.3 Contributor Free, but codex-router does not currently surface it in the native model picker. This adds the exact Responses route as a listed, credential-free model with xhigh as its highest/default picker effort, the documented context/compaction limits, and no native apply_patch claim.

The curation guard keeps Muse's model-specific `auto-tool-choice` repair from being inherited by unrelated models in OpenCode's mixed free catalog.

Validation:
- `node --test test/gemini-3.8-muse-1.3-fable-5.1.test.mjs test/registry.test.mjs test/curate-models.test.mjs` (111/111)
- `npm run check`
