### PR TITLE
fix: refresh native account catalog directly

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -23,13 +23,13 @@ Neither command prints credential values. Repair refuses unknown router owners.
 
 ## New native models (GPT-6 Astra, GPT-7, etc.)
 
-**Uninstall is never required** to see new OpenAI/Codex native models. The router watches both `~/.codex/models_cache.json` and a lightweight fingerprint of the resolved Codex executable, then republishes when either source changes. This also catches Desktop primary-runtime replacements that keep the same `codex --version` string. Drift is checked on startup and periodically while the router stays running.
+**Uninstall is never required** to see new OpenAI/Codex native models. While its merged catalog is installed, the router conditionally refreshes the signed-in account catalog itself, watches the resulting model fingerprint plus a lightweight fingerprint of the resolved Codex executable, and republishes when either source changes. A failed or unavailable account request leaves the prior cache untouched and falls back to that cache plus the bundled catalog. Discovery-disabled installs make no account request. Drift is checked on startup and periodically while the router stays running.
 
 **Codex full quit/reopen is still required** to reload the catalog file. Codex reads `model_catalog_json` once at startup; the router cannot make Codex hot-reload.
 
 Expected flow:
 1. OpenAI releases new native (e.g., GPT-7)
-2. Codex updates `models_cache.json` or replaces its bundled/runtime executable
+2. Router observes a changed account catalog, or Codex replaces its bundled/runtime executable
 3. Router detects drift on startup or a periodic check → republishes automatically
 4. Fully quit and reopen Codex → new native appears in picker
 

--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -1,5 +1,4 @@
 import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -20,7 +19,6 @@ import {
   CONFIG_PATH,
   LEGACY_PORTS,
   MERGED_CATALOG_PATH,
-  MODELS_CACHE_PATH,
   NATIVE_ALIAS_PATH,
   NATIVE_CATALOG_PATH,
   PORTS,
@@ -67,6 +65,11 @@ import {
 import { discoveryDisabled } from "./discovery-mode.mjs";
 import { withCatalogPublicationLock } from "./catalog-publication-lock.mjs";
 import { routedModelSearchAvailable } from "./search-capability.mjs";
+import {
+  readModelsCache,
+} from "./native-account-catalog.mjs";
+
+export { readModelsCache } from "./native-account-catalog.mjs";
 
 const refresh = process.argv.includes("--refresh-native");
 
@@ -188,28 +191,10 @@ export function mergeNativeModel(accountModel, bundledModel) {
   return merged;
 }
 
-// One read serves both the catalog contents and the fingerprint; reading the
-// file twice would hash a possibly different snapshot than the one merged.
-export function readModelsCache() {
-  const missing = { catalog: undefined, fingerprint: undefined };
-  if (!existsSync(MODELS_CACHE_PATH)) return missing;
-  try {
-    const parsed = JSON.parse(readFileSync(MODELS_CACHE_PATH, "utf8"));
-    if (!validNativeCatalog(parsed)) return missing;
-    return {
-      catalog: parsed,
-      fingerprint: createHash("sha256")
-        .update(JSON.stringify(parsed.models))
-        .digest("hex"),
-    };
-  } catch {
-    return missing;
-  }
-}
-
-// A routed custom catalog never rewrites Codex's account cache. When that cache
-// is valid and contains no routed slugs, it remains a safe native source even
-// while model_catalog_json points at the merged router catalog.
+// A valid account cache containing no routed slugs can be refreshed directly
+// and remains a safe native source while model_catalog_json points at the
+// merged router catalog. A missing or contaminated cache still takes the
+// conservative transport-transition path in refresh-catalog.
 export function nativeCacheCanRefreshInPlace(cache = readModelsCache()) {
   const catalog = cache?.catalog;
   return (

--- a/src/codex-native-session.mjs
+++ b/src/codex-native-session.mjs
@@ -133,6 +133,28 @@ function readSession() {
   return sessionFromAuthDocument(readAuthDocument());
 }
 
+/**
+ * Headers for the read-only ChatGPT account catalog request.
+ *
+ * This is deliberately separate from nativeSessionHeaders(): reading the
+ * catalog is part of Codex's own signed-in model discovery and does not widen
+ * the router caller capability to spend the subscription. The returned
+ * credential must only be used for that fixed account-catalog endpoint.
+ */
+export async function nativeAccountCatalogHeaders() {
+  if (discoveryDisabled()) return undefined;
+  let session = readSession();
+  if (session?.expired) {
+    await refreshViaCodex();
+    session = readSession();
+  }
+  if (!session || session.expired) return undefined;
+  return {
+    authorization: `Bearer ${session.accessToken}`,
+    ...(session.accountId ? { "chatgpt-account-id": session.accountId } : {}),
+  };
+}
+
 // Authenticate a bearer that claims to be the already-signed-in Codex client.
 // This never enables session sharing; it only verifies the caller's own token.
 export function nativeSessionTokenMatches(token) {

--- a/src/native-account-catalog.mjs
+++ b/src/native-account-catalog.mjs
@@ -1,0 +1,270 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+
+import { Agent, EnvHttpProxyAgent, fetch as undiciFetch } from "undici";
+
+import { nativeAccountCatalogHeaders } from "./codex-native-session.mjs";
+import { codexVersion } from "./codex-binary.mjs";
+import { secretEqual } from "./caller-auth.mjs";
+import { withCatalogPublicationLock } from "./catalog-publication-lock.mjs";
+import { discoveryDisabled } from "./discovery-mode.mjs";
+import { writePrivateJsonAsync } from "./file-security.mjs";
+import { MODEL_BY_SLUG } from "./model-registry.mjs";
+import { MODELS_CACHE_PATH } from "./paths.mjs";
+import { environmentHttpProxyConfigured } from "./proxy-environment.mjs";
+
+export const NATIVE_ACCOUNT_CATALOG_TTL_MS = 5 * 60_000;
+const MAX_ACCOUNT_CATALOG_BYTES = 32 * 1024 * 1024;
+const ACCOUNT_CATALOG_TIMEOUT_MS = 5_000;
+const ACCOUNT_CATALOG_BASE_URL = "https://chatgpt.com/backend-api/codex/models";
+
+function validCatalog(value) {
+  return value && Array.isArray(value.models) && value.models.length > 0;
+}
+
+function containsRoutedSlugs(catalog) {
+  return Boolean(
+    catalog?.models?.some((model) => MODEL_BY_SLUG.has(String(model?.slug || ""))),
+  );
+}
+
+function modelsFingerprint(models) {
+  return createHash("sha256").update(JSON.stringify(models)).digest("hex");
+}
+
+function safeEtag(value) {
+  return typeof value === "string"
+    && value.length > 0
+    && value.length <= 1024
+    && !/[\0\r\n]/.test(value)
+    ? value
+    : undefined;
+}
+
+function sameAccountSession(before, after) {
+  if (!after?.authorization) return false;
+  const beforeAccount = before?.["chatgpt-account-id"];
+  const afterAccount = after?.["chatgpt-account-id"];
+  if (beforeAccount || afterAccount) {
+    return Boolean(beforeAccount && beforeAccount === afterAccount);
+  }
+  return secretEqual(before.authorization, after.authorization);
+}
+
+export function readModelsCache(cachePath = MODELS_CACHE_PATH) {
+  const missing = { catalog: undefined, fingerprint: undefined };
+  if (!existsSync(cachePath)) return missing;
+  try {
+    const parsed = JSON.parse(readFileSync(cachePath, "utf8"));
+    if (!validCatalog(parsed)) return missing;
+    return {
+      catalog: parsed,
+      fingerprint: modelsFingerprint(parsed.models),
+    };
+  } catch {
+    return missing;
+  }
+}
+
+export function codexClientVersion(value = codexVersion()) {
+  const match = /(?:^|\s)(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)(?:\s|$)/.exec(
+    String(value || ""),
+  );
+  return match?.[1];
+}
+
+function cacheIsFresh(cache, clientVersion, now) {
+  if (!validCatalog(cache) || containsRoutedSlugs(cache)) return false;
+  if (cache.client_version !== clientVersion) return false;
+  const fetchedAt = Date.parse(cache.fetched_at);
+  const age = now - fetchedAt;
+  return Number.isFinite(fetchedAt) && age >= 0 && age < NATIVE_ACCOUNT_CATALOG_TTL_MS;
+}
+
+async function boundedJson(response, maxBytes = MAX_ACCOUNT_CATALOG_BYTES) {
+  const declared = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    await Promise.resolve(response.body?.cancel?.()).catch(() => undefined);
+    return undefined;
+  }
+  if (!response.body) return undefined;
+  const reader = response.body.getReader();
+  const chunks = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        return undefined;
+      }
+      chunks.push(Buffer.from(value));
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+function accountCatalogDispatcher({
+  environment = process.env,
+  execArgv = process.execArgv,
+  AgentClass = Agent,
+  EnvHttpProxyAgentClass = EnvHttpProxyAgent,
+} = {}) {
+  const DispatcherClass = environmentHttpProxyConfigured(environment, execArgv)
+    ? EnvHttpProxyAgentClass
+    : AgentClass;
+  return new DispatcherClass({
+    allowH2: false,
+    pipelining: 1,
+    headersTimeout: ACCOUNT_CATALOG_TIMEOUT_MS,
+    bodyTimeout: ACCOUNT_CATALOG_TIMEOUT_MS,
+  });
+}
+
+/**
+ * Refresh Codex's account cache without depending on Codex to ignore its
+ * configured static router catalog. HTTP, schema, and cache-write failures are
+ * intentionally represented as status only: the caller keeps the last cache
+ * and bundled catalog. Lock failures still surface because proceeding across
+ * an account-switch transaction would be unsafe.
+ */
+async function refreshNativeAccountCatalogUnlocked({
+  cachePath = MODELS_CACHE_PATH,
+  force = false,
+  now = Date.now(),
+  version,
+  versionProvider = codexClientVersion,
+  fetchImpl = undiciFetch,
+  headersProvider = nativeAccountCatalogHeaders,
+  dispatcherFactory = accountCatalogDispatcher,
+  writeCache = writePrivateJsonAsync,
+  timeoutMs = ACCOUNT_CATALOG_TIMEOUT_MS,
+} = {}) {
+  const clientVersion = version || versionProvider();
+  if (!clientVersion) return { status: "unavailable" };
+
+  const current = readModelsCache(cachePath);
+  if (!force && cacheIsFresh(current.catalog, clientVersion, now)) {
+    return { status: "fresh", fingerprint: current.fingerprint };
+  }
+
+  const accountHeaders = await headersProvider();
+  if (!accountHeaders?.authorization) return { status: "unavailable" };
+
+  const safeCurrent = validCatalog(current.catalog) && !containsRoutedSlugs(current.catalog);
+  const etag = safeCurrent ? safeEtag(current.catalog.etag) : undefined;
+  // Keep the credential sink fixed. Tests replace the transport, never the
+  // destination, so this helper cannot be repurposed to send Codex auth to an
+  // operator-controlled URL.
+  const url = new URL(ACCOUNT_CATALOG_BASE_URL);
+  url.searchParams.set("client_version", clientVersion);
+  const headers = {
+    ...accountHeaders,
+    accept: "application/json",
+    originator: "codex_router",
+    "user-agent": `codex-router/${clientVersion}`,
+    ...(etag ? { "if-none-match": etag } : {}),
+  };
+  const useDispatcher = fetchImpl === undiciFetch;
+  let dispatcher;
+  try {
+    dispatcher = useDispatcher ? dispatcherFactory() : undefined;
+    const response = await fetchImpl(url.toString(), {
+      method: "GET",
+      headers,
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+      ...(dispatcher ? { dispatcher } : {}),
+    });
+    if (response.status === 304 && safeCurrent) {
+      await Promise.resolve(response.body?.cancel?.()).catch(() => undefined);
+      // A client upgrade invalidates Codex's own cache even when the account
+      // ETag is unchanged. Restamp that one transition so later checks can use
+      // the normal TTL without rewriting a large unchanged cache every cycle.
+      if (current.catalog.client_version !== clientVersion) {
+        if (!sameAccountSession(accountHeaders, await headersProvider())) {
+          return { status: "failed" };
+        }
+        await writeCache(
+          cachePath,
+          {
+            ...current.catalog,
+            fetched_at: new Date(now).toISOString(),
+            client_version: clientVersion,
+          },
+          { directoryMode: 0o700 },
+        );
+      }
+      return { status: "not-modified", fingerprint: current.fingerprint };
+    }
+    if (!response.ok || response.status >= 300) {
+      await Promise.resolve(response.body?.cancel?.()).catch(() => undefined);
+      return { status: "failed" };
+    }
+    const parsed = await boundedJson(response);
+    if (!validCatalog(parsed) || containsRoutedSlugs(parsed)) {
+      return { status: "failed" };
+    }
+    // Account switching also owns models_cache.json. The publication lock
+    // serializes router-managed switches; this second identity read closes the
+    // remaining race with an official Codex login change during the request.
+    if (!sameAccountSession(accountHeaders, await headersProvider())) {
+      return { status: "failed" };
+    }
+    const fingerprint = modelsFingerprint(parsed.models);
+    const responseEtag = safeEtag(response.headers.get("etag"));
+    if (
+      safeCurrent
+      && fingerprint === current.fingerprint
+      && (!responseEtag || responseEtag === etag)
+    ) {
+      return { status: "unchanged", fingerprint };
+    }
+    await writeCache(
+      cachePath,
+      {
+        fetched_at: new Date(now).toISOString(),
+        ...(responseEtag ? { etag: responseEtag } : {}),
+        client_version: clientVersion,
+        models: parsed.models,
+      },
+      { directoryMode: 0o700 },
+    );
+    return {
+      status: safeCurrent && fingerprint === current.fingerprint
+        ? "revalidated"
+        : "updated",
+      fingerprint,
+    };
+  } catch {
+    return { status: "failed" };
+  } finally {
+    await dispatcher?.close().catch(() => undefined);
+  }
+}
+
+export async function refreshNativeAccountCatalog({
+  discoveryOff = discoveryDisabled,
+  lock = withCatalogPublicationLock,
+  lockOptions,
+  ...options
+} = {}) {
+  // This guard precedes the lock, cache read, auth read, Codex spawn, and
+  // network request. --no-discovery promises that all account-derived
+  // artifacts stay untouched, including models_cache.json.
+  if (discoveryOff()) return { status: "disabled" };
+  return lock(
+    () => discoveryOff()
+      ? { status: "disabled" }
+      : refreshNativeAccountCatalogUnlocked(options),
+    lockOptions,
+  );
+}

--- a/src/native-catalog-drift.mjs
+++ b/src/native-catalog-drift.mjs
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { NATIVE_CATALOG_PATH, CONFIG_PATH } from "./paths.mjs";
 import { nativeCatalogIsReusable, readModelsCache } from "./catalog.mjs";
 import { codexBinaryFingerprint, codexVersion } from "./codex-binary.mjs";
+import { refreshNativeAccountCatalog } from "./native-account-catalog.mjs";
+import { discoveryDisabled } from "./discovery-mode.mjs";
 
 // Marker pattern from config-manager.mjs to detect managed Codex config
 const managedMarkerPattern = /^# BEGIN codex-router$/m;
@@ -27,6 +29,9 @@ function codexIntegrationInstalled() {
  * Returns true if drift detected (fingerprint/version mismatch).
  */
 export function nativeCatalogDriftDetected() {
+  // models_cache.json is account-derived. The discovery kill-switch applies
+  // to the comparison just as it does to the live refresh that precedes it.
+  if (discoveryDisabled()) return false;
   // Only applies when Codex integration is active
   if (!codexIntegrationInstalled() && !existsSync(NATIVE_CATALOG_PATH)) {
     return false;
@@ -66,15 +71,24 @@ export function nativeCatalogDriftDetected() {
  * Asynchronously republish catalog if native drift detected.
  * Runs in background after startup, does not block.
  */
-export async function republishOnNativeDrift() {
+export async function republishOnNativeDrift({
+  refreshAccountCatalog = refreshNativeAccountCatalog,
+  refreshTargetPicker,
+} = {}) {
+  // model_catalog_json stops Codex's own account cache writer. Refresh the
+  // fixed ChatGPT account endpoint first; on any failure the updater leaves
+  // the prior cache untouched and the local drift comparison remains safe.
+  await refreshAccountCatalog();
   if (!nativeCatalogDriftDetected()) {
     return false;
   }
 
   try {
     // Dynamic import to avoid startup dependency
-    const { refreshTargetPickerIfInstalled } = await import("./target-integration.mjs");
-    await refreshTargetPickerIfInstalled();
+    const refresh = refreshTargetPicker || (
+      await import("./target-integration.mjs")
+    ).refreshTargetPickerIfInstalled;
+    await refresh();
     console.error(
       "[codex-router] Native catalog drift detected and republished automatically."
     );

--- a/src/refresh-catalog.mjs
+++ b/src/refresh-catalog.mjs
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { nativeCatalogCanRefreshInPlace } from "./catalog.mjs";
+import { refreshNativeAccountCatalog } from "./native-account-catalog.mjs";
 import { SOURCE_ROOT } from "./paths.mjs";
 import {
   beginLoginFreeRefresh,
@@ -30,6 +31,16 @@ function checked(run, script, args) {
     );
   }
   return result;
+}
+
+export function refreshCatalogCompletionMessage(status) {
+  if (status === "disabled") {
+    return "Bundled native and external model catalogs refreshed. Fully quit and reopen Codex.\n";
+  }
+  if (status === "failed" || status === "unavailable") {
+    return "External models refreshed; native models were rebuilt from available cached and bundled data because the live account catalog could not be refreshed. Fully quit and reopen Codex.\n";
+  }
+  return "Native account, bundled, and external model catalogs refreshed. Fully quit and reopen Codex.\n";
 }
 
 function restoreTransport(
@@ -87,6 +98,7 @@ function restoreTransport(
 async function refreshCatalogUnlocked({
   run = nodeRunner,
   canRefreshInPlace = nativeCatalogCanRefreshInPlace,
+  refreshAccountCatalog = refreshNativeAccountCatalog,
   aliases = readNativeAliases,
   aliasFor = nativeAliasFor,
   journal = {
@@ -95,6 +107,7 @@ async function refreshCatalogUnlocked({
     read: readLoginFreeRefreshJournal,
   },
 } = {}) {
+  const nativeAccountRefresh = await refreshAccountCatalog({ force: true });
   // A killed refresh can leave the exact direct provider source parked while
   // the login-free provider state is intentionally retained. Only the private
   // journal written by this operation makes that otherwise ambiguous pair
@@ -128,14 +141,17 @@ async function refreshCatalogUnlocked({
   };
   let restoreNeeded = false;
   let catalogResult;
-  // Signed-in Codex keeps its account cache separate from model_catalog_json.
-  // When that cache is known-native, refresh the catalog without rewriting
-  // config.toml; this also avoids needless failures when another Windows
-  // process has the config open without delete sharing. Login-free mode still
-  // requires the journaled transport transition below.
+  // The router refreshes a known-native account cache directly, independently
+  // of model_catalog_json. Rebuild from it without rewriting config.toml; this
+  // also avoids needless failures when another Windows process has the config
+  // open without delete sharing. Login-free mode still requires the journaled
+  // transport transition below.
   if (routed && !loginFree && canRefreshInPlace()) {
     catalogResult = checked(run, "catalog.mjs", ["--refresh-native"]);
-    return { catalogOutput: catalogResult.stdout || "" };
+    return {
+      catalogOutput: catalogResult.stdout || "",
+      nativeAccountRefresh: nativeAccountRefresh.status,
+    };
   }
   try {
     if (routed) {
@@ -179,7 +195,10 @@ async function refreshCatalogUnlocked({
     }
     throw error;
   }
-  return { catalogOutput: catalogResult.stdout || "" };
+  return {
+    catalogOutput: catalogResult.stdout || "",
+    nativeAccountRefresh: nativeAccountRefresh.status,
+  };
 }
 
 export async function refreshCatalog({
@@ -191,9 +210,9 @@ export async function refreshCatalog({
 }
 
 async function main() {
-  const { catalogOutput } = await refreshCatalog();
+  const { catalogOutput, nativeAccountRefresh } = await refreshCatalog();
   if (catalogOutput) process.stdout.write(catalogOutput);
-  process.stdout.write("Native and external model catalogs refreshed. Fully quit and reopen Codex.\n");
+  process.stdout.write(refreshCatalogCompletionMessage(nativeAccountRefresh));
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -1597,9 +1597,10 @@ const agentPayloadCachePurgeTimer = setInterval(
 );
 agentPayloadCachePurgeTimer.unref?.();
 
-// Periodically check for native catalog drift (new models in models_cache.json).
-// When Codex updates its cache while router is running, detect and republish
-// automatically without waiting for user to restart router or run provider commands.
+// Periodically refresh the native account catalog, compare it with the last
+// capture, and republish changes. Codex stops updating models_cache.json while
+// model_catalog_json points at the router, so the refresh cannot depend on
+// Codex rewriting that file itself.
 const nativeCatalogDriftCheckTimer = setInterval(
   async () => {
     try {

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -410,8 +410,8 @@ async function main() {
     router,
   );
 
-  // After router is healthy, check for native catalog drift in background.
-  // If Codex updated models_cache.json (new native model), republish automatically.
+  // After router is healthy, refresh the native account catalog and check its
+  // cache plus the installed Codex binary for drift in the background.
   // This runs async without blocking further startup or waiting for user commands.
   import("./native-catalog-drift.mjs")
     .then(({ republishOnNativeDrift }) => republishOnNativeDrift())

--- a/test/codex-native-session.test.mjs
+++ b/test/codex-native-session.test.mjs
@@ -28,6 +28,7 @@ const {
   nativeSessionSharingEnabled,
   nativeSessionAvailable,
   nativeSessionHeaders,
+  nativeAccountCatalogHeaders,
   nativeSessionTokenMatches,
   nativeSessionStatus,
   setNativeSessionSharingEnabled,
@@ -93,6 +94,16 @@ test("the current Codex session authenticates only its own bearer without enabli
   assert.equal(nativeSessionTokenMatches("different-session-token"), false);
   clearAuth();
   assert.equal(nativeSessionTokenMatches(ACCESS), false);
+});
+
+test("account catalog discovery uses the signed-in session without enabling route sharing", async () => {
+  writeAuth({ access_token: ACCESS, account_id: ACCOUNT });
+  assert.equal(nativeSessionSharingEnabled(), false);
+  assert.deepEqual(await nativeAccountCatalogHeaders(), {
+    authorization: `Bearer ${ACCESS}`,
+    "chatgpt-account-id": ACCOUNT,
+  });
+  assert.equal(nativeSessionHeaders(), undefined);
 });
 
 test("the current Codex API key authenticates requests but never becomes a shared session", () => {

--- a/test/native-account-catalog.test.mjs
+++ b/test/native-account-catalog.test.mjs
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  refreshNativeAccountCatalog,
+} from "../src/native-account-catalog.mjs";
+
+const ACCESS = "test-native-account-access-token";
+const ACCOUNT = "test-native-account-id";
+const headersProvider = async () => ({
+  authorization: `Bearer ${ACCESS}`,
+  "chatgpt-account-id": ACCOUNT,
+});
+const noLock = (operation) => operation();
+
+function fixtureCache(models, overrides = {}) {
+  return {
+    fetched_at: "2026-08-01T00:00:00.000Z",
+    etag: 'W/"old-account-catalog"',
+    client_version: "0.153.2",
+    models,
+    ...overrides,
+  };
+}
+
+function withCache(run) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "native-account-catalog-"));
+  const cachePath = path.join(directory, "models_cache.json");
+  return Promise.resolve(run(cachePath)).finally(() => {
+    rmSync(directory, { recursive: true, force: true });
+  });
+}
+
+test("a changed live account catalog atomically replaces the frozen Codex cache", () =>
+  withCache(async (cachePath) => {
+    const oldModels = [{ slug: "gpt-old", visibility: "list" }];
+    const newModels = [
+      { slug: "gpt-old", visibility: "list" },
+      { slug: "gpt-new-account-model", visibility: "list" },
+    ];
+    writeFileSync(cachePath, JSON.stringify(fixtureCache(oldModels)));
+    let request;
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      now: Date.parse("2026-09-06T00:00:00.000Z"),
+      version: "0.153.2",
+      headersProvider,
+      discoveryOff: () => false,
+      lock: noLock,
+      fetchImpl: async (url, init) => {
+        request = { url, init };
+        return new Response(JSON.stringify({ models: newModels }), {
+          status: 200,
+          headers: { etag: 'W/"new-account-catalog"' },
+        });
+      },
+    });
+
+    assert.equal(result.status, "updated");
+    assert.match(request.url, /client_version=0\.153\.2/);
+    assert.equal(request.init.headers.authorization, `Bearer ${ACCESS}`);
+    assert.equal(request.init.headers["chatgpt-account-id"], ACCOUNT);
+    assert.equal(request.init.headers["if-none-match"], 'W/"old-account-catalog"');
+    const written = JSON.parse(readFileSync(cachePath, "utf8"));
+    assert.deepEqual(written.models, newModels);
+    assert.equal(written.etag, 'W/"new-account-catalog"');
+    assert.equal(written.client_version, "0.153.2");
+    assert.equal(written.fetched_at, "2026-09-06T00:00:00.000Z");
+    assert.doesNotMatch(JSON.stringify(result), new RegExp(ACCESS));
+    assert.doesNotMatch(readFileSync(cachePath, "utf8"), new RegExp(ACCESS));
+    assert.doesNotMatch(readFileSync(cachePath, "utf8"), new RegExp(ACCOUNT));
+  }));
+
+test("a matching ETag leaves the account cache byte-identical", () =>
+  withCache(async (cachePath) => {
+    const contents = `${JSON.stringify(fixtureCache([{ slug: "gpt-stable" }]), null, 2)}\n`;
+    writeFileSync(cachePath, contents);
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      version: "0.153.2",
+      headersProvider,
+      discoveryOff: () => false,
+      lock: noLock,
+      fetchImpl: async () => new Response(null, { status: 304 }),
+    });
+    assert.equal(result.status, "not-modified");
+    assert.equal(readFileSync(cachePath, "utf8"), contents);
+  }));
+
+test("a changed ETag with identical models is persisted once without reporting model drift", () =>
+  withCache(async (cachePath) => {
+    const models = [{ slug: "gpt-stable" }];
+    writeFileSync(cachePath, JSON.stringify(fixtureCache(models)));
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      now: Date.parse("2026-09-06T00:00:00.000Z"),
+      version: "0.153.2",
+      headersProvider,
+      discoveryOff: () => false,
+      lock: noLock,
+      fetchImpl: async () => new Response(JSON.stringify({ models }), {
+        status: 200,
+        headers: { etag: 'W/"revalidated-account-catalog"' },
+      }),
+    });
+    assert.equal(result.status, "revalidated");
+    const written = JSON.parse(readFileSync(cachePath, "utf8"));
+    assert.deepEqual(written.models, models);
+    assert.equal(written.etag, 'W/"revalidated-account-catalog"');
+  }));
+
+test("network and schema failures preserve the last usable account cache", () =>
+  withCache(async (cachePath) => {
+    const contents = JSON.stringify(fixtureCache([{ slug: "gpt-stable" }]));
+    writeFileSync(cachePath, contents);
+    for (const fetchImpl of [
+      async () => { throw new Error(`request failed with ${ACCESS}`); },
+      async () => new Response('{"models":[]}', { status: 200 }),
+      async () => new Response("denied", { status: 401 }),
+    ]) {
+      const result = await refreshNativeAccountCatalog({
+        cachePath,
+        force: true,
+        version: "0.153.2",
+        headersProvider,
+        discoveryOff: () => false,
+        lock: noLock,
+        fetchImpl,
+      });
+      assert.equal(result.status, "failed");
+      assert.equal(readFileSync(cachePath, "utf8"), contents);
+      assert.doesNotMatch(JSON.stringify(result), new RegExp(ACCESS));
+    }
+  }));
+
+test("proxy dispatcher setup failure falls back without exposing credentials", () =>
+  withCache(async (cachePath) => {
+    const contents = JSON.stringify(fixtureCache([{ slug: "gpt-stable" }]));
+    writeFileSync(cachePath, contents);
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      version: "0.153.2",
+      headersProvider,
+      discoveryOff: () => false,
+      lock: noLock,
+      dispatcherFactory: () => {
+        throw new Error(`invalid proxy carrying ${ACCESS}`);
+      },
+    });
+    assert.equal(result.status, "failed");
+    assert.equal(readFileSync(cachePath, "utf8"), contents);
+    assert.doesNotMatch(JSON.stringify(result), new RegExp(ACCESS));
+  }));
+
+test("discovery-disabled refresh reads no cache, credential, version, or network", async () => {
+  const forbidden = () => { throw new Error("account-derived operation ran"); };
+  const result = await refreshNativeAccountCatalog({
+    cachePath: new Proxy({}, { get: forbidden }),
+    discoveryOff: () => true,
+    lock: forbidden,
+    versionProvider: forbidden,
+    headersProvider: forbidden,
+    fetchImpl: forbidden,
+  });
+  assert.deepEqual(result, { status: "disabled" });
+});
+
+test("a fresh current-version cache avoids account auth and network reads", () =>
+  withCache(async (cachePath) => {
+    writeFileSync(cachePath, JSON.stringify(fixtureCache(
+      [{ slug: "gpt-current" }],
+      { fetched_at: "2026-09-06T00:00:00.000Z" },
+    )));
+    const forbidden = () => { throw new Error("unexpected live refresh"); };
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      now: Date.parse("2026-09-06T00:04:59.999Z"),
+      version: "0.153.2",
+      discoveryOff: () => false,
+      lock: noLock,
+      headersProvider: forbidden,
+      fetchImpl: forbidden,
+    });
+    assert.equal(result.status, "fresh");
+  }));
+
+test("a future-dated cache is revalidated instead of remaining fresh indefinitely", () =>
+  withCache(async (cachePath) => {
+    const models = [{ slug: "gpt-current" }];
+    writeFileSync(cachePath, JSON.stringify(fixtureCache(
+      models,
+      { fetched_at: "2026-09-07T00:00:00.000Z" },
+    )));
+    let requested = false;
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      now: Date.parse("2026-09-06T00:00:00.000Z"),
+      version: "0.153.2",
+      discoveryOff: () => false,
+      lock: noLock,
+      headersProvider,
+      fetchImpl: async () => {
+        requested = true;
+        return new Response(JSON.stringify({ models }), { status: 200 });
+      },
+    });
+    assert.equal(requested, true);
+    assert.equal(result.status, "unchanged");
+  }));
+
+test("an account switch during the request cannot overwrite the new account cache", () =>
+  withCache(async (cachePath) => {
+    const contents = JSON.stringify(fixtureCache([{ slug: "gpt-before-switch" }]));
+    writeFileSync(cachePath, contents);
+    let reads = 0;
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      version: "0.153.2",
+      discoveryOff: () => false,
+      lock: noLock,
+      headersProvider: async () => ({
+        authorization: `Bearer ${ACCESS}`,
+        "chatgpt-account-id": reads++ === 0 ? ACCOUNT : "different-account",
+      }),
+      fetchImpl: async () => new Response(JSON.stringify({
+        models: [{ slug: "gpt-from-old-account" }],
+      }), { status: 200 }),
+    });
+    assert.equal(result.status, "failed");
+    assert.equal(readFileSync(cachePath, "utf8"), contents);
+  }));
+
+test("an account switch during a version revalidation cannot restamp the cache", () =>
+  withCache(async (cachePath) => {
+    const contents = JSON.stringify(fixtureCache(
+      [{ slug: "gpt-before-switch" }],
+      { client_version: "0.152.0" },
+    ));
+    writeFileSync(cachePath, contents);
+    let reads = 0;
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      version: "0.153.2",
+      discoveryOff: () => false,
+      lock: noLock,
+      headersProvider: async () => ({
+        authorization: `Bearer ${ACCESS}`,
+        "chatgpt-account-id": reads++ === 0 ? ACCOUNT : "different-account",
+      }),
+      fetchImpl: async () => new Response(null, { status: 304 }),
+    });
+    assert.equal(result.status, "failed");
+    assert.equal(readFileSync(cachePath, "utf8"), contents);
+  }));

--- a/test/native-catalog-drift.test.mjs
+++ b/test/native-catalog-drift.test.mjs
@@ -91,9 +91,45 @@ test("drift detection triggers republish with new arbitrary native in merged out
       .digest("hex");
     assert.notEqual(newFingerprint, oldFingerprint, "fingerprint changed");
 
+    // Put the frozen input back. The automatic path must refresh it before it
+    // checks drift; comparing first would reproduce issue #628 forever.
+    writeFileSync(
+      path.join(codexHome, "models_cache.json"),
+      JSON.stringify(modelsCache),
+    );
+    assert.equal(nativeCatalogDriftDetected(), false, "frozen cache alone has no drift");
+
+    process.env.CODEX_ROUTER_NO_DISCOVERY = "1";
+    try {
+      writeFileSync(
+        path.join(codexHome, "models_cache.json"),
+        JSON.stringify(updatedCache),
+      );
+      assert.equal(
+        nativeCatalogDriftDetected(),
+        false,
+        "discovery-disabled drift checks do not read account-cache changes",
+      );
+    } finally {
+      delete process.env.CODEX_ROUTER_NO_DISCOVERY;
+      writeFileSync(
+        path.join(codexHome, "models_cache.json"),
+        JSON.stringify(modelsCache),
+      );
+    }
+
     // NOW TEST ACTUAL REPUBLISH: Call republishOnNativeDrift()
-    // This should detect drift and run the full publish path
-    const republished = await republishOnNativeDrift();
+    // This should refresh the account cache, detect drift, and run the full
+    // publish path in that order.
+    const republished = await republishOnNativeDrift({
+      refreshAccountCatalog: async () => {
+        writeFileSync(
+          path.join(codexHome, "models_cache.json"),
+          JSON.stringify(updatedCache),
+        );
+        return { status: "updated" };
+      },
+    });
     
     // Republish should have succeeded
     assert.equal(republished, true, "republish succeeded");

--- a/test/refresh-catalog.test.mjs
+++ b/test/refresh-catalog.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { refreshCatalog } from "../src/refresh-catalog.mjs";
+import {
+  refreshCatalog,
+  refreshCatalogCompletionMessage,
+} from "../src/refresh-catalog.mjs";
 
 const noJournal = {
   begin() {},
@@ -9,6 +12,7 @@ const noJournal = {
   read() { return undefined; },
 };
 const noLock = (operation) => operation();
+const noAccountRefresh = async () => ({ status: "unavailable" });
 
 function recordingRunner({ signed = true, loginFree = false, model, failAt } = {}) {
   const calls = [];
@@ -45,6 +49,7 @@ test("ordinary routed refresh avoids config mutation when the native cache is sa
   const runner = recordingRunner();
   const result = await refreshCatalog({
     canRefreshInPlace: () => true,
+    refreshAccountCatalog: noAccountRefresh,
     run: runner.run,
     lock: noLock,
   });
@@ -55,10 +60,34 @@ test("ordinary routed refresh avoids config mutation when the native cache is sa
   assert.equal(result.catalogOutput, '{"models":1}\n');
 });
 
+test("refresh orchestration carries the account refresh outcome to its completion message", async () => {
+  const runner = recordingRunner();
+  const result = await refreshCatalog({
+    canRefreshInPlace: () => true,
+    refreshAccountCatalog: async () => ({ status: "failed" }),
+    run: runner.run,
+    lock: noLock,
+  });
+  assert.equal(result.nativeAccountRefresh, "failed");
+  assert.match(
+    refreshCatalogCompletionMessage(result.nativeAccountRefresh),
+    /live account catalog could not be refreshed/,
+  );
+});
+
+test("refresh completion distinguishes live account success, fallback, and disabled discovery", () => {
+  assert.match(refreshCatalogCompletionMessage("updated"), /Native account, bundled/);
+  assert.match(refreshCatalogCompletionMessage("not-modified"), /Native account, bundled/);
+  assert.match(refreshCatalogCompletionMessage("failed"), /live account catalog could not be refreshed/);
+  assert.match(refreshCatalogCompletionMessage("unavailable"), /cached and bundled data/);
+  assert.match(refreshCatalogCompletionMessage("disabled"), /^Bundled native and external/);
+});
+
 test("refresh orchestration restores signed routing and republishes the routed catalog", async () => {
   const runner = recordingRunner();
   const result = await refreshCatalog({
     canRefreshInPlace: () => false,
+    refreshAccountCatalog: noAccountRefresh,
     run: runner.run,
     lock: noLock,
   });
@@ -78,6 +107,7 @@ test("refresh orchestration restores the active transport after catalog failure"
   await assert.rejects(
     refreshCatalog({
       canRefreshInPlace: () => false,
+      refreshAccountCatalog: noAccountRefresh,
       run: runner.run,
       lock: noLock,
     }),
@@ -97,6 +127,7 @@ test("ordinary routed refresh also republishes external models after restore", a
   const runner = recordingRunner({ signed: false });
   await refreshCatalog({
     canRefreshInPlace: () => false,
+    refreshAccountCatalog: noAccountRefresh,
     run: runner.run,
     lock: noLock,
   });
@@ -117,6 +148,7 @@ test("refresh orchestration restores identity-preserving login-free mode and its
   });
   await refreshCatalog({
     canRefreshInPlace: () => true,
+    refreshAccountCatalog: noAccountRefresh,
     run: runner.run,
     aliases: () => ({ "gpt-5.6-sol": "deepseek/deepseek-v4-pro" }),
     aliasFor: (slug) => slug === "deepseek/deepseek-v4-pro" ? "gpt-5.6-terra" : undefined,
@@ -158,6 +190,7 @@ test("pending refresh resumes and completes only with an alias for the same cano
   };
   await refreshCatalog({
     canRefreshInPlace: () => true,
+    refreshAccountCatalog: noAccountRefresh,
     run: runner.run,
     aliases: () => ({ "old-alias": pending.canonicalModel }),
     aliasFor: (slug) => slug === pending.canonicalModel ? "fresh-alias" : undefined,


### PR DESCRIPTION
Closes #628.

## Summary
- refresh the signed-in Codex account catalog directly before native drift detection
- preserve ETag caching, private atomic writes, discovery-disabled behavior, and cached/bundled fallback
- serialize cache updates with catalog publication and reject account-switch races
- report manual refresh fallback accurately and document the new behavior

## Verification
- 39 focused catalog/session/drift/refresh tests pass
- npm run check passes
- full suite: 3,635 passed, 26 skipped, with one unrelated Electron timing test that passed on isolated rerun
- git diff --check passes