### PR TITLE
fix(tray): read health natively instead of spawning control every second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **The macOS tray no longer spawns a Node process every second to read
+  health.** `refreshActivity()` polls health once a second and ran
+  `bin/control health --json` each time, which boots Node and control.mjs's
+  whole module graph to make one loopback GET: about a second of CPU per call,
+  so an idle tray pegged a core for as long as it ran (measured 93.6% CPU,
+  1450 ms wall and 1000 ms CPU per poll, against 1.4 ms for the same GET over
+  plain HTTP). The tray now reads the protected health leaf directly with
+  `URLSession`, behind the same caller key and the same 3 s timeout. It decodes
+  every HTTP response, so a 503 still carries the degraded list and service
+  rows; transport failures throw and are recorded exactly as a failed
+  `control health` was. `control-health.mjs` remains the contract for the CLI
+  and the Control Center. The bounded one-second polls during MLX install,
+  runtime update, and vision-bridge pull still shell out and are unchanged.
+
 - **Tok/s meter now excludes reasoning tokens and hides during generation.**
   `observedTokensPerSecond` used full `outputTokens` while TTFT waited for the
   first *visible* token. Providers often include `reasoning_tokens` (silent

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -3890,15 +3890,19 @@ enum RouterHealthProbe {
   }()
 
   // paths.mjs `port()`: the first non-empty alias wins, and an invalid value is
-  // an error rather than a fallback to the default.
+  // an error rather than a fallback to the default. Node parses the value with
+  // `Number()`, which accepts surrounding whitespace, `4202.0`, and `4.202e3`;
+  // parse as a Double first so a port the router accepted is accepted here.
   static func routerPort(environment: [String: String]) throws -> Int {
     let value = ["MODEL_ROUTER_PORT", "CODEX_ROUTER_PORT", "KIMI_ROUTER_PORT"]
       .compactMap { environment[$0] }
       .first { !$0.isEmpty } ?? "4202"
-    guard let port = Int(value), (1...65_535).contains(port) else {
+    guard let number = Double(value.trimmingCharacters(in: .whitespacesAndNewlines)),
+      number.isFinite, number == number.rounded(), number >= 1, number <= 65_535
+    else {
       throw RouterError("MODEL_ROUTER_PORT must be a TCP port between 1 and 65535.")
     }
-    return port
+    return Int(number)
   }
 
   // caller-auth.mjs `validCallerSecret`: at least 32 characters of [A-Za-z0-9_-].

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -3264,11 +3264,10 @@ final class RouterStore: ObservableObject {
 
   private func refreshActivity() async {
     do {
-      // `control health` uses the protected health leaf and projects away the
-      // forwarders' credential metadata. The public `/health` endpoint is
-      // intentionally too small for the service rows below.
-      let data = try await runControl(arguments: ["health", "--json"])
-      let health = try JSONDecoder().decode(RouterHealth.self, from: data)
+      // The protected health leaf, read natively. The public `/health` endpoint
+      // is intentionally too small for the service rows below, and this poll
+      // runs once a second, so it must not spawn a process: see RouterHealthProbe.
+      let health = try await RouterHealthProbe.read()
       let previousActivityState = activityState
       let nextActiveRequests = health.activity.active ?? []
       let nextActiveRequestCount = health.activity.activeCount ?? nextActiveRequests.count
@@ -3830,21 +3829,10 @@ final class RouterStore: ObservableObject {
   }
 
   private func recordedInstallSourceRoot() -> URL? {
-    let environment = ProcessInfo.processInfo.environment
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let stateDirectory: URL
-    if let configured = environment["MODEL_ROUTER_STATE_DIR"]
-      ?? environment["CODEX_ROUTER_STATE_DIR"]
-      ?? environment["KIMI_CODEX_STATE_DIR"],
-      !configured.isEmpty
-    {
-      stateDirectory = URL(fileURLWithPath: configured, isDirectory: true)
-    } else {
-      let codexHome = environment["CODEX_HOME"].flatMap { $0.isEmpty ? nil : $0 }
-        .map { URL(fileURLWithPath: $0, isDirectory: true) }
-        ?? home.appendingPathComponent(".codex", isDirectory: true)
-      stateDirectory = codexHome.appendingPathComponent("codex-router", isDirectory: true)
-    }
+    let stateDirectory = RouterStateDirectory.resolve(
+      environment: ProcessInfo.processInfo.environment,
+      home: FileManager.default.homeDirectoryForCurrentUser
+    )
     return RouterInstallManifestPolicy.sourceRoot(stateDirectory: stateDirectory)
   }
 }
@@ -3863,6 +3851,93 @@ private struct RouterHealth: Decodable, Equatable {
 private struct RouterServiceHealth: Decodable, Equatable {
   let reachable: Bool?
   let enabled: Bool?
+}
+
+// paths.mjs: MODEL_ROUTER_STATE_DIR, then the managed aliases, then
+// `$CODEX_HOME/codex-router` with CODEX_HOME defaulting to `~/.codex`. An empty
+// value falls through exactly as `||` does in Node.
+enum RouterStateDirectory {
+  static func resolve(environment: [String: String], home: URL) -> URL {
+    let configured = ["MODEL_ROUTER_STATE_DIR", "CODEX_ROUTER_STATE_DIR", "KIMI_CODEX_STATE_DIR"]
+      .compactMap { environment[$0] }
+      .first { !$0.isEmpty }
+    if let configured {
+      return URL(fileURLWithPath: configured, isDirectory: true)
+    }
+    let codexHome = environment["CODEX_HOME"].flatMap { $0.isEmpty ? nil : $0 }
+      .map { URL(fileURLWithPath: $0, isDirectory: true) }
+      ?? home.appendingPathComponent(".codex", isDirectory: true)
+    return codexHome.appendingPathComponent("codex-router", isDirectory: true)
+  }
+}
+
+// The tray polls health once a second. `bin/control health --json` boots Node
+// and control.mjs's whole module graph to make one loopback GET: about a second
+// of CPU per call, so the poll alone kept a core busy for as long as the tray
+// ran. This is the same GET against the same protected leaf, natively, in about
+// a millisecond. control-health.mjs stays the contract for the CLI and the
+// Control Center; RouterHealth's Decodable keys are that same projection, so the
+// forwarders' credential metadata still never reaches tray state.
+enum RouterHealthProbe {
+  private static let session: URLSession = {
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.timeoutIntervalForRequest = 3
+    configuration.timeoutIntervalForResource = 3
+    // The caller key is a path segment. This request never leaves loopback, so
+    // never hand it to a system proxy that claims 127.0.0.1.
+    configuration.connectionProxyDictionary = [kCFNetworkProxiesHTTPEnable as AnyHashable: 0]
+    return URLSession(configuration: configuration)
+  }()
+
+  // paths.mjs `port()`: the first non-empty alias wins, and an invalid value is
+  // an error rather than a fallback to the default.
+  static func routerPort(environment: [String: String]) throws -> Int {
+    let value = ["MODEL_ROUTER_PORT", "CODEX_ROUTER_PORT", "KIMI_ROUTER_PORT"]
+      .compactMap { environment[$0] }
+      .first { !$0.isEmpty } ?? "4202"
+    guard let port = Int(value), (1...65_535).contains(port) else {
+      throw RouterError("MODEL_ROUTER_PORT must be a TCP port between 1 and 65535.")
+    }
+    return port
+  }
+
+  // caller-auth.mjs `validCallerSecret`: at least 32 characters of [A-Za-z0-9_-].
+  static func callerSecret(stateDirectory: URL) -> String? {
+    let path = stateDirectory.appendingPathComponent("caller-secret", isDirectory: false)
+    guard let secret = (try? String(contentsOf: path, encoding: .utf8))?
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+      secret.range(of: "^[A-Za-z0-9_-]{32,}$", options: .regularExpression) != nil
+    else { return nil }
+    return secret
+  }
+
+  static func healthURL(environment: [String: String], home: URL) throws -> URL {
+    let port = try routerPort(environment: environment)
+    let stateDirectory = RouterStateDirectory.resolve(environment: environment, home: home)
+    guard let secret = callerSecret(stateDirectory: stateDirectory) else {
+      throw RouterError("The local router caller key is missing or invalid; run ./bin/doctor --fix.")
+    }
+    guard let url = URL(string: "http://127.0.0.1:\(port)/_codex-router/\(secret)/v1/health") else {
+      throw RouterError("The local router health URL could not be built.")
+    }
+    return url
+  }
+
+  fileprivate static func read() async throws -> RouterHealth {
+    var request = URLRequest(
+      url: try healthURL(
+        environment: ProcessInfo.processInfo.environment,
+        home: FileManager.default.homeDirectoryForCurrentUser
+      )
+    )
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    // A 503 still carries the degraded list and the service rows, so decode
+    // every response and let the body's own `ok` say whether the router is
+    // ready. Transport failures throw, which the caller records as a health
+    // failure exactly as it did when `control health` could not run.
+    let (data, _) = try await session.data(for: request)
+    return try JSONDecoder().decode(RouterHealth.self, from: data)
+  }
 }
 
 private enum TrayServiceHealthState: Equatable {

--- a/apps/macos/ModelRouterTray/Tests/RouterHealthProbeTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/RouterHealthProbeTests.swift
@@ -45,8 +45,13 @@ struct RouterHealthProbeTests {
         environment: ["MODEL_ROUTER_PORT": "", "KIMI_ROUTER_PORT": "4300"]
       ) == 4300
     )
+    #expect(try RouterHealthProbe.routerPort(environment: ["MODEL_ROUTER_PORT": " 4.202e3 "]) == 4202)
+    #expect(try RouterHealthProbe.routerPort(environment: ["MODEL_ROUTER_PORT": "4202.0"]) == 4202)
     #expect(throws: (any Error).self) {
       try RouterHealthProbe.routerPort(environment: ["MODEL_ROUTER_PORT": "80000"])
+    }
+    #expect(throws: (any Error).self) {
+      try RouterHealthProbe.routerPort(environment: ["MODEL_ROUTER_PORT": "4202.5"])
     }
   }
 

--- a/apps/macos/ModelRouterTray/Tests/RouterHealthProbeTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/RouterHealthProbeTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+
+@testable import ModelRouterTray
+
+@Suite("Router health probe")
+struct RouterHealthProbeTests {
+  private func stateDirectory(secret: String?) throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("router-health-probe-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    if let secret {
+      try Data(secret.utf8).write(to: directory.appendingPathComponent("caller-secret"))
+    }
+    return directory
+  }
+
+  @Test("the probe reads the protected leaf behind the caller key in the state directory")
+  func buildsTheProtectedHealthURL() throws {
+    let secret = String(repeating: "a", count: 32)
+    let directory = try stateDirectory(secret: "\(secret)\n")
+    let url = try RouterHealthProbe.healthURL(
+      environment: ["MODEL_ROUTER_STATE_DIR": directory.path, "CODEX_ROUTER_PORT": "4999"],
+      home: URL(fileURLWithPath: "/nonexistent", isDirectory: true)
+    )
+    #expect(url.absoluteString == "http://127.0.0.1:4999/_codex-router/\(secret)/v1/health")
+  }
+
+  @Test("a short, malformed, or missing caller key is rejected the way caller-auth.mjs rejects it")
+  func rejectsInvalidCallerSecrets() throws {
+    let short = String(repeating: "a", count: 31)
+    let tooShort = try stateDirectory(secret: short)
+    let malformed = try stateDirectory(secret: "\(short)!")
+    let missing = try stateDirectory(secret: nil)
+    #expect(RouterHealthProbe.callerSecret(stateDirectory: tooShort) == nil)
+    #expect(RouterHealthProbe.callerSecret(stateDirectory: malformed) == nil)
+    #expect(RouterHealthProbe.callerSecret(stateDirectory: missing) == nil)
+  }
+
+  @Test("the port follows paths.mjs: first non-empty alias, default 4202, invalid is an error")
+  func resolvesTheRouterPort() throws {
+    #expect(try RouterHealthProbe.routerPort(environment: [:]) == 4202)
+    #expect(
+      try RouterHealthProbe.routerPort(
+        environment: ["MODEL_ROUTER_PORT": "", "KIMI_ROUTER_PORT": "4300"]
+      ) == 4300
+    )
+    #expect(throws: (any Error).self) {
+      try RouterHealthProbe.routerPort(environment: ["MODEL_ROUTER_PORT": "80000"])
+    }
+  }
+
+  @Test("the state directory defaults to $CODEX_HOME/codex-router under ~/.codex")
+  func resolvesTheStateDirectory() {
+    let home = URL(fileURLWithPath: "/Users/example", isDirectory: true)
+    #expect(
+      RouterStateDirectory.resolve(environment: [:], home: home).path
+        == "/Users/example/.codex/codex-router"
+    )
+    #expect(
+      RouterStateDirectory.resolve(
+        environment: ["MODEL_ROUTER_STATE_DIR": "", "KIMI_CODEX_STATE_DIR": "/tmp/state"],
+        home: home
+      ).path == "/tmp/state"
+    )
+  }
+}


### PR DESCRIPTION
## Problem

The macOS tray (`ModelRouterTray`) pegs a core while idle.

`refreshActivity()` polls health once a second (`startActivityPolling`). Each poll ran `bin/control health --json`, which boots Node and loads `control.mjs`'s whole module graph to make a single loopback GET.

Measured on an M-series Mac, macOS 26, router idle:

| path | wall | CPU |
|---|---|---|
| `bin/control health --json` | 1450 ms | ~1000 ms |
| same GET over plain HTTP | 1.4 ms | ~0 |

1 CPU-second per 1-second tick = one core, permanently. Observed as `ModelRouterTray` at 93.6% CPU with 723 CPU-minutes accumulated. The router's Node processes sat at 0%.

This is a different root cause from #305 / #601 (SwiftUI layout spin). Those fixes are in and this still reproduces on current `main`.

## Fix

`RouterHealthProbe` reads the protected `/_codex-router/<secret>/v1/health` leaf with `URLSession`:

- same caller key (`<state>/caller-secret`, validated as `[A-Za-z0-9_-]{32,}` like `caller-auth.mjs`)
- same port aliases and default (`MODEL_ROUTER_PORT` / `CODEX_ROUTER_PORT` / `KIMI_ROUTER_PORT` / 4202, invalid value is an error like `paths.mjs`)
- same 3 s timeout as `control-health.mjs`
- loopback only: system proxy disabled on the session so the key never leaves 127.0.0.1

Every HTTP response is decoded, so a 503 still carries `degraded` and the service rows and the tray keeps showing "Degraded". Transport failures throw and hit `recordActivityHealthFailure()` exactly as a failed `control health` did. `RouterHealth`'s `Decodable` keys are the same projection `control-health.mjs` applies, so forwarder credential metadata still never reaches tray state.

`control-health.mjs` is untouched and remains the contract for the CLI and Control Center.

The inline state-directory resolution in `recordedInstallSourceRoot()` moves to `RouterStateDirectory.resolve` so both callers share it.

## Not changed

The bounded 1 s polls during MLX install, runtime update, and vision-bridge pull still shell out. They only run while that operation is in progress.

## Tests

- `Tests/RouterHealthProbeTests.swift`: URL construction, secret validation, port aliases and rejection, state-directory defaults.
- `test/panel-ui.test.mjs` (source assertions on the tray file): 29/29 pass.
- App target builds clean with Swift 6.3.3. Swift test target needs Xcode's `Testing` module, which this machine lacks, so CI covers it.
