### PR TITLE
fix(commandcode): bound tool names and repair recursive schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Command Code no longer rejects a routed turn over a long tool name or a
+  recursive schema.** A Codex turn carrying a client tool such as
+  `mcp__openai_api_key_local_confirmation__confirm_openai_api_key_local_destination`
+  (80 characters) was refused before generation with ``HTTP 400: `name` must be
+  at most 64 characters, got 80``, and the turn behind it then hit
+  `Recursive JSON schemas are not currently supported` (issue #626).
+  `chatProviderToolSurface()` now sends both `commandcode` and
+  `commandcode-messages` through the router's existing bounded alias route at
+  64 characters, and both variants join the non-recursive schema repair. The
+  aliases stay deterministic and reversible, so a call the model makes under
+  the bounded spelling is restored to the client's own tool identity. Every
+  other non-Groq provider keeps its tool surface byte for byte.
+
 - **The macOS tray no longer spawns a Node process every second to read
   health.** `refreshActivity()` polls health once a second and ran
   `bin/control health --json` each time, which boots Node and control.mjs's

--- a/src/chat-tool-surface.mjs
+++ b/src/chat-tool-surface.mjs
@@ -212,13 +212,31 @@ function withRequiredAppTools(tools, required) {
 // definition is required; those definitions are added back before the request
 // is admitted. A client surface (or client + required definitions) over the cap
 // is refused locally rather than truncated.
+// Command Code validates the provider-facing tool `name` at 64 characters and
+// refuses the whole request over a longer one, so a client tool such as
+// `mcp__openai_api_key_local_confirmation__confirm_openai_api_key_local_destination`
+// (80 characters) fails the turn before generation (issue #626). Both provider
+// variants front the same validator. They opt into the router's existing
+// bounded alias route, which is deterministic and reversible, so
+// `rewriteNamespaceResponsePayload()` still restores the client's own identity.
+// Every other non-Groq provider keeps the unbounded surface byte for byte.
+const BOUNDED_TOOL_NAME_PROVIDERS = new Set(["commandcode", "commandcode-messages"]);
+const BOUNDED_TOOL_NAME_LENGTH = 64;
+
 export function chatProviderToolSurface(
   tools,
   providerId,
   { input, toolChoice } = {},
 ) {
   const merged = mergeCodexAppTools(tools);
-  if (providerId !== "groq") return flattenNamespaceTools(merged.tools);
+  if (providerId !== "groq") {
+    return flattenNamespaceTools(
+      merged.tools,
+      BOUNDED_TOOL_NAME_PROVIDERS.has(providerId)
+        ? { maxNameLength: BOUNDED_TOOL_NAME_LENGTH }
+        : {},
+    );
+  }
 
   // Groq has no OpenCode-style length bound, but it still needs deterministic
   // aliases when two distinct native identities have the same flattened wire

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -928,10 +928,15 @@ function needsStrictOpenCodeToolCompatibility(route) {
 // recursive local JSON-Schema reference before the model sees the request.
 // Keep the paid Console Go gate model-specific: its other Responses models
 // retain recursive schemas until their own endpoint establishes the same
-// restriction.
-function needsNonRecursiveOpenCodeToolCompatibility(route) {
+// restriction. Command Code answers the identical `Recursive JSON schemas are
+// not currently supported` on every model behind either of its provider
+// variants (issue #626), so it is gated provider-wide rather than per model.
+const NON_RECURSIVE_SCHEMA_PROVIDER_IDS = new Set(["commandcode", "commandcode-messages"]);
+
+function needsNonRecursiveToolSchemaCompatibility(route) {
   const providerId = providerForModel(route)?.id;
   return (
+    NON_RECURSIVE_SCHEMA_PROVIDER_IDS.has(providerId) ||
     needsZenFreeToolCompatibility(route) ||
     (providerId === "opencode-go-responses" &&
       route.upstreamModel === "muse-spark-1.2-contributor")
@@ -3096,7 +3101,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   ) {
     namespacesFlattened = true;
   }
-  if (needsNonRecursiveOpenCodeToolCompatibility(route)) {
+  if (needsNonRecursiveToolSchemaCompatibility(route)) {
     // Run after namespace flattening so both native children and ordinary
     // function tools are repaired in the exact shape the endpoint validates.
     tools = repairToolSchemaRoots(tools, { nonRecursive: true });
@@ -3160,7 +3165,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     ) {
       namespacesFlattened = true;
     }
-    if (needsNonRecursiveOpenCodeToolCompatibility(route)) {
+    if (needsNonRecursiveToolSchemaCompatibility(route)) {
       // Stored tool-search results can introduce definitions after the first
       // repair pass, so enforce the same boundary on the expanded inventory.
       tools = repairToolSchemaRoots(tools, { nonRecursive: true });

--- a/test/chat-tool-surface.test.mjs
+++ b/test/chat-tool-surface.test.mjs
@@ -343,3 +343,67 @@ test("non-Groq providers preserve the normally expanded tool surface", () => {
   assert.deepEqual(routed.tools, expected.tools);
   assert.deepEqual([...routed.namespaces], [...expected.namespaces]);
 });
+
+// Issue #626: Command Code answers `HTTP 400: \`name\` must be at most 64
+// characters, got 80` before generation, so the exact reported tool has to
+// reach the provider under a bounded alias and come back as its client
+// identity. The tool below is the 80-character name from that report.
+const COMMAND_CODE_LONG_TOOL =
+  "mcp__openai_api_key_local_confirmation__confirm_openai_api_key_local_destination";
+
+function commandCodeSurface() {
+  return [
+    {
+      type: "function",
+      name: COMMAND_CODE_LONG_TOOL,
+      parameters: { type: "object" },
+    },
+    { type: "namespace", name: "codex_app", tools: [{ type: "function", name: "create_thread" }] },
+  ];
+}
+
+for (const providerId of ["commandcode", "commandcode-messages"]) {
+  test(`${providerId} bounds provider-facing tool names to 64 characters`, () => {
+    assert.equal(COMMAND_CODE_LONG_TOOL.length, 80, "regression fixture reproduces issue #626");
+    const routed = chatProviderToolSurface(commandCodeSurface(), providerId);
+    const names = routed.tools.map((tool) => tool.name);
+    for (const name of names) {
+      assert.ok(
+        name.length <= 64,
+        `${name} is ${name.length} characters, which Command Code rejects`,
+      );
+    }
+    const alias = names.find((name) => name !== "codex_app__create_thread");
+    assert.ok(alias, "the long client tool must still be offered");
+    assert.notEqual(alias, COMMAND_CODE_LONG_TOOL, "the alias must differ from the client name");
+
+    // The alias is only safe because it is reversible: a call the model makes
+    // under the bounded spelling has to come back as the client's own tool.
+    const restored = rewriteNamespaceResponsePayload(
+      {
+        output: [
+          { type: "function_call", name: alias, arguments: "{}" },
+        ],
+      },
+      buildNamespaceLookups(routed.namespaces),
+    );
+    assert.equal(restored.output[0].name, COMMAND_CODE_LONG_TOOL);
+  });
+
+  test(`${providerId} keeps the bounded alias deterministic across identical surfaces`, () => {
+    const first = chatProviderToolSurface(commandCodeSurface(), providerId);
+    const second = chatProviderToolSurface(commandCodeSurface(), providerId);
+    assert.deepEqual(
+      first.tools.map((tool) => tool.name),
+      second.tools.map((tool) => tool.name),
+    );
+  });
+}
+
+test("a non-Command Code chat provider keeps the unbounded 80-character name", () => {
+  const routed = chatProviderToolSurface(commandCodeSurface(), "openrouter");
+  assert.ok(
+    routed.tools.some((tool) => tool.name === COMMAND_CODE_LONG_TOOL),
+    "only Command Code opts into the 64-character bound",
+  );
+});


### PR DESCRIPTION
Closes #626.

## Problem

A Codex turn routed to a Command Code model is rejected before generation when the attached tool surface contains a function name longer than 64 characters:

```text
HTTP 400: `name` must be at most 64 characters, got 80
```

The reported tool was `mcp__openai_api_key_local_confirmation__confirm_openai_api_key_local_destination` — exactly 80 characters.

`buildRoutedRequest()` sends chat-completions providers through `chatProviderToolSurface()`, which flattened namespaces with no name-length bound for Command Code. The router already has deterministic, reversible bounded aliases behind `flattenNamespaceTools(..., { maxNameLength: 64 })`; Command Code simply was not opting into that existing path.

Behind that error sits a second one from the same validator: `Recursive JSON schemas are not currently supported`. Both had to be fixed for the turn to complete.

## Fix

- `chatProviderToolSurface()` sends `commandcode` and `commandcode-messages` through the existing 64-character bounded alias route. Every other non-Groq provider keeps its tool surface byte for byte.
- Both variants join the non-recursive schema repair. The gate is provider-wide rather than per model because the validator is the endpoint's, not the model's.
- `needsNonRecursiveOpenCodeToolCompatibility` is renamed to `needsNonRecursiveToolSchemaCompatibility`: it no longer names one vendor now that a second, unrelated validator shares it.

The aliases stay deterministic and reversible, so `rewriteNamespaceResponsePayload()` restores a call the model makes under the bounded spelling to the client's own tool identity.

## Tests

Five regression tests in `test/chat-tool-surface.test.mjs`, covering both provider variants:

- the exact 80-character tool from the report reaches the provider under a 64-character alias;
- the alias differs from the client name and round-trips back to it through `rewriteNamespaceResponsePayload()`;
- the alias is stable across identical surfaces;
- a non-Command Code chat provider still receives the unbounded 80-character name.

Full suite: **3668 tests, 0 failures** (26 skipped, all platform-gated).

## Credit

The diagnosis, the root cause, and the shape of this patch are [@erc-dev-pm](https://github.com/erc-dev-pm)'s, recorded in #626 after they were unable to push their local commits. They verified the fix end to end against the live route (`codex exec -m commandcode/meta/muse-spark-1.3-contributor` completing normally). This PR implements that patch with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)