### PR TITLE
fix(dashboard): total 24h traffic from every provider, not a capped sample

### DIFF
--- a/apps/control-center/src/pages/DashboardPage.tsx
+++ b/apps/control-center/src/pages/DashboardPage.tsx
@@ -33,6 +33,7 @@ import type {
   RouterHealth,
   RouterTarget,
   UsageEvent,
+  UsageEventHour,
   UsageBucket,
   UsageMetric,
   ViewId,
@@ -191,17 +192,26 @@ export function DashboardPage({
     authoritativeRoutes,
     runAction ?? (async (_label, action) => { await action(); }),
   );
+  const eventHours: UsageEventHour[] | undefined = target?.usageEventHours;
   const telemetryEvents24h = recentWindowEvents(target?.usageEvents, Date.now());
   const eventTokens24h = sumEventTokens(telemetryEvents24h);
   const eventRequests24h = eventsCountOrNull(target?.usageEvents, telemetryEvents24h);
+  const rollupTokens24h = eventHours?.some((hour) => hour.measuredTokens)
+    ? eventHours.reduce((sum, hour) => sum + hour.tokens, 0)
+    : null;
+  const rollupRequests24h = eventHours?.length
+    ? eventHours.reduce((sum, hour) => sum + hour.requests, 0)
+    : null;
   const reportedTokens24h = sumReported(providers.map((provider) => provider.last24hTokens));
   const reportedRequests24h = sumReported(providers.map((provider) => provider.last24hRequests));
   // Older installed routers expose the same bounded event stream but predate
   // the provider-level rolling counters. Use it as a presentation fallback so
   // a real day of traffic is not painted as empty during an app/router update.
-  const tokens24h = reportedTokens24h ?? eventTokens24h;
-  const requests24h = reportedRequests24h ?? eventRequests24h;
-  const usageMeasured = Boolean(providerUsage || target?.usageEvents);
+  // The rollup sits between the two: it covers the whole window, where the
+  // event sample is capped and understates a busy day by an order of magnitude.
+  const tokens24h = reportedTokens24h ?? rollupTokens24h ?? eventTokens24h;
+  const requests24h = reportedRequests24h ?? rollupRequests24h ?? eventRequests24h;
+  const usageMeasured = Boolean(providerUsage || target?.usageEvents || eventHours?.length);
 
   const metrics = useMemo(() => collectMetrics(account, providerUsage), [account, providerUsage]);
   const quotaLoaded = Boolean(account || providerUsage);
@@ -231,7 +241,7 @@ export function DashboardPage({
   // event stream gives the dashboard an honest hourly shape. Keep this local to
   // the renderer: it is a presentation view and must not become a second
   // accounting ledger in the router.
-  const trafficBuckets = buildTrafficBuckets(events, providerUsage, trafficRange, Date.now());
+  const trafficBuckets = buildTrafficBuckets(events, providerUsage, eventHours, trafficRange, Date.now());
   const providerBreakdown = buildProviderBreakdown(providerUsage, events, Date.now());
   const modelBreakdown = buildModelBreakdown(providerUsage, events, Date.now());
   const trafficHasRequests = trafficBuckets.some((bucket) => bucket.requests > 0);
@@ -277,7 +287,7 @@ export function DashboardPage({
         ? "Waiting for router usage telemetry"
         : tokens24h === null
           ? "No provider or event reports a rolling 24-hour window"
-          : `${exactNumber(tokens24h)} router tokens${requests24h === null ? "" : ` · ${exactNumber(requests24h)} ${plural(requests24h, "request")}`} · ${reportedTokens24h !== null ? "sum of provider rows" : "sum of recent event details"}`,
+          : `${exactNumber(tokens24h)} router tokens${requests24h === null ? "" : ` · ${exactNumber(requests24h)} ${plural(requests24h, "request")}`} · ${reportedTokens24h !== null ? "sum of provider rows" : rollupTokens24h !== null ? "sum of the router's hourly rollup" : "sum of recent event details"}`,
       view: "usage",
       viewLabel: "Usage",
       pending: snapshotPending && !providerUsage,
@@ -405,7 +415,7 @@ export function DashboardPage({
           {events ? (
             <p className="db-panel-note db-traffic-note">
               {trafficHasTokens
-                ? `${exactNumber(trafficBuckets.reduce((sum, bucket) => sum + bucket.tokens, 0))} measured tokens across ${exactNumber(trafficBuckets.reduce((sum, bucket) => sum + bucket.requests, 0))} requests in ${trafficRangeLabel(trafficRange)}. ${trafficRange === 24 ? "Hourly bars use the latest 1,000 event details." : "Daily bars use the retained provider ledger when available."}`
+                ? `${exactNumber(trafficBuckets.reduce((sum, bucket) => sum + bucket.tokens, 0))} measured tokens across ${exactNumber(trafficBuckets.reduce((sum, bucket) => sum + bucket.requests, 0))} requests in ${trafficRangeLabel(trafficRange)}. ${trafficRange === 24 ? eventHours?.length ? "Hourly bars use the router's full 24-hour rollup." : "Hourly bars use the latest 1,000 event details; this router does not publish an hourly rollup." : "Daily bars use the retained provider ledger when available."}`
                 : trafficHasRequests
                   ? `${exactNumber(trafficBuckets.reduce((sum, bucket) => sum + bucket.requests, 0))} requests observed in ${trafficRangeLabel(trafficRange)}, but token counts were not reported by the upstream responses.`
                   : `The router returned an empty ${trafficRangeLabel(trafficRange)} telemetry window; this is different from a failed health check.`}
@@ -1101,15 +1111,56 @@ function trafficDescription(range: TrafficRange): string {
 function buildTrafficBuckets(
   events: UsageEvent[] | undefined,
   providerUsage: ProviderUsageSnapshot | undefined,
+  hours: UsageEventHour[] | undefined,
   range: TrafficRange,
   now: number,
 ): TrafficBucket[] {
   return range === 24
-    ? buildHourlyTrafficBuckets(events, now)
+    ? buildHourlyTrafficBuckets(events, hours, now)
     : buildDailyTrafficBuckets(events, providerUsage, range, now);
 }
 
-function buildHourlyTrafficBuckets(events: UsageEvent[] | undefined, now: number): TrafficBucket[] {
+const HOUR_LABEL_FORMATTER = new Intl.DateTimeFormat("en-US", { hour: "numeric" });
+const HOUR_FULL_LABEL_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+});
+
+// `events` is a bounded sample -- the router caps it at 1,000 rows -- so on a
+// busy day it covers a couple of hours, not twenty-four. Summing it drew most
+// of the day empty and printed a fraction of the day's tokens as the day's
+// total, right next to a summary tile that added up every provider row. The
+// router now publishes an hourly rollup over the uncapped window; the sample
+// remains the fallback for a router that predates it.
+function hourlyBucketsFromRollup(hours: UsageEventHour[]): TrafficBucket[] {
+  // Label each bar from the hour the router actually measured rather than from
+  // a grid anchored on the renderer's clock. The two agree until the hour turns
+  // over between the snapshot and the render, and then this keeps the newest
+  // measured hour on the chart instead of blanking it until the next poll.
+  return hours.map((hour) => {
+    const start = new Date(hour.startedAt);
+    return {
+      key: hour.startedAt,
+      label: HOUR_LABEL_FORMATTER.format(start),
+      fullLabel: HOUR_FULL_LABEL_FORMATTER.format(start),
+      tokens: hour.tokens,
+      requests: hour.requests,
+      measuredTokens: hour.measuredTokens,
+      regularInputTokens: hour.regularInputTokens,
+      cachedInputTokens: hour.cachedInputTokens,
+      outputTokens: hour.outputTokens,
+      measuredBreakdown: hour.measuredBreakdown,
+    };
+  });
+}
+
+function buildHourlyTrafficBuckets(
+  events: UsageEvent[] | undefined,
+  hours: UsageEventHour[] | undefined,
+  now: number,
+): TrafficBucket[] {
+  if (hours?.length) return hourlyBucketsFromRollup(hours);
   const anchor = new Date(now);
   anchor.setMinutes(0, 0, 0);
   const first = anchor.getTime() - (23 * HOUR_MS);

--- a/apps/control-center/src/types.ts
+++ b/apps/control-center/src/types.ts
@@ -242,6 +242,7 @@ export interface RouterTarget {
   routerDefaultModel?: string;
   routerDefaultManaged?: boolean;
   usageEvents?: UsageEvent[];
+  usageEventHours?: UsageEventHour[];
   modelSettings?: {
     subagents: SubagentSettings;
     picker: { hidden: string[]; visible?: string[]; hasExplicitVisibility?: boolean; path?: string };
@@ -524,6 +525,21 @@ export interface ProviderUsageSnapshot {
     }>;
   };
   providers: ProviderUsage[];
+}
+
+// One local hour of router traffic, aggregated by the router over the whole
+// window rather than over the capped `usageEvents` sample. `usageEvents` still
+// carries the per-request detail the recent-activity list needs; these buckets
+// carry the totals a 24-hour chart cannot get from a bounded sample.
+export interface UsageEventHour {
+  startedAt: string;
+  tokens: number;
+  requests: number;
+  measuredTokens: boolean;
+  regularInputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  measuredBreakdown: boolean;
 }
 
 export interface UsageEvent {

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -314,8 +314,20 @@ async function emitProbe() {
   const hiddenModels = new Set(picker.hidden);
   const visibleModels = new Set(picker.visible);
   const subagentSettings = subagentSettingsSnapshot();
-  const usageEvents = TARGET === "codex"
-    ? (await import("./usage-events.mjs")).recentUsageEvents()
+  const usageEventsModule = TARGET === "codex" ? await import("./usage-events.mjs") : undefined;
+  // The tray polls this probe constantly and the ledger is large, so read the
+  // window once and derive both views from it. The recent-activity list still
+  // gets the same bounded tail it always got; the hourly rollup needs the whole
+  // window, because a capped sample cannot answer "how much traffic did this
+  // router carry today" -- on a busy day 1,000 events is under two hours.
+  const windowEvents = usageEventsModule
+    ? usageEventsModule.recentUsageEvents({ limit: Number.POSITIVE_INFINITY })
+    : [];
+  const usageEvents = usageEventsModule
+    ? windowEvents.slice(-usageEventsModule.RECENT_USAGE_EVENT_LIMIT)
+    : [];
+  const usageEventHours = usageEventsModule
+    ? usageEventsModule.hourlyUsageRollup({ readEvents: () => windowEvents })
     : [];
   // Local proof records are surfaced for status only. They never alter the
   // registry capability sent to Codex.
@@ -398,6 +410,7 @@ async function emitProbe() {
       ...(TARGET === "codex"
         ? {
             usageEvents,
+            usageEventHours,
             nativeAliases: readNativeAliases(),
             modelSettings: {
               subagents: subagentSettings,

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -411,7 +411,15 @@ function lineOlderThan(line, cutoffIso) {
   return at < cutoffIso;
 }
 
-export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000 } = {}) {
+// The cap a caller gets when it does not choose one. Exported so a consumer
+// that reads the window once and derives several views from it can apply the
+// same bound without restating the number.
+export const RECENT_USAGE_EVENT_LIMIT = 1_000;
+
+export function recentUsageEvents({
+  sinceMs = 24 * 60 * 60 * 1000,
+  limit = RECENT_USAGE_EVENT_LIMIT,
+} = {}) {
   if (!existsSync(USAGE_EVENTS_PATH)) return [];
   const cutoff = Date.now() - sinceMs;
   let cutoffIso = "";
@@ -529,6 +537,94 @@ export function recentUsageEvents({ sinceMs = 24 * 60 * 60 * 1000, limit = 1_000
   } catch {
     return [];
   }
+}
+
+// The Control Center's hourly traffic chart was built entirely from
+// recentUsageEvents(), whose default cap is 1,000 rows. An ordinary busy day is
+// many times that -- 9,000 events in 24 hours is routine -- so the most recent
+// 1,000 covered under two hours: twenty-two of the twenty-four bars were drawn
+// empty, and the caption reported that truncated sum as the day's total while
+// the summary tile beside it added up every provider row. Aggregate the whole
+// window here and ship 24 small buckets instead. The chart gets an honest shape
+// and a total that agrees with the tile, and the payload stays bounded however
+// busy the router was.
+export const HOURLY_USAGE_ROLLUP_HOURS = 24;
+
+// Both helpers mirror the renderer's tokenCountFromEvent/trafficPartsFromEvent
+// exactly, including the billed-over-raw preference and the cached-share clamp.
+// recentUsageEvents() omits an absent count rather than writing a zero, so an
+// unreported field stays distinguishable from a measured zero.
+function rollupTokenCount(event) {
+  if (event.totalTokens !== undefined) return event.totalTokens;
+  const input = event.billedInputTokens ?? event.inputTokens;
+  const output = event.billedOutputTokens ?? event.outputTokens;
+  if (input === undefined && output === undefined) return undefined;
+  return (input ?? 0) + (output ?? 0);
+}
+
+function rollupTokenParts(event) {
+  const input = event.billedInputTokens ?? event.inputTokens;
+  const cached = event.cachedInputTokens;
+  const output = event.billedOutputTokens ?? event.outputTokens;
+  if (input === undefined && cached === undefined && output === undefined) return undefined;
+  const inputTokens = input ?? 0;
+  const cachedInputTokens = input === undefined
+    ? cached ?? 0
+    : Math.min(inputTokens, cached ?? 0);
+  return {
+    regularInputTokens: Math.max(0, inputTokens - cachedInputTokens),
+    cachedInputTokens,
+    outputTokens: output ?? 0,
+  };
+}
+
+export function hourlyUsageRollup({
+  hours = HOURLY_USAGE_ROLLUP_HOURS,
+  now = Date.now(),
+  readEvents = recentUsageEvents,
+} = {}) {
+  const span = Math.max(1, Math.min(24 * 31, Math.floor(hours) || 0));
+  // Bucket edges are local hour boundaries, matching the labels the chart
+  // formats from each bucket's own start.
+  const anchor = new Date(now);
+  anchor.setMinutes(0, 0, 0);
+  const first = anchor.getTime() - (span - 1) * HOUR_MS;
+  const buckets = Array.from({ length: span }, (_, index) => ({
+    startedAt: new Date(first + index * HOUR_MS).toISOString(),
+    tokens: 0,
+    requests: 0,
+    measuredTokens: false,
+    regularInputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    measuredBreakdown: false,
+  }));
+  // Reading the whole window is the point: the cap this replaces is the defect.
+  const events = readEvents({
+    sinceMs: Math.max(HOUR_MS, Date.now() - first),
+    limit: Number.POSITIVE_INFINITY,
+  });
+  for (const event of events) {
+    const at = Date.parse(event?.at);
+    if (!Number.isFinite(at)) continue;
+    const index = Math.floor((at - first) / HOUR_MS);
+    if (index < 0 || index >= buckets.length) continue;
+    const bucket = buckets[index];
+    bucket.requests += 1;
+    const tokens = rollupTokenCount(event);
+    if (tokens !== undefined) {
+      bucket.tokens += tokens;
+      bucket.measuredTokens = true;
+    }
+    const parts = rollupTokenParts(event);
+    if (parts) {
+      bucket.regularInputTokens += parts.regularInputTokens;
+      bucket.cachedInputTokens += parts.cachedInputTokens;
+      bucket.outputTokens += parts.outputTokens;
+      bucket.measuredBreakdown = true;
+    }
+  }
+  return buckets;
 }
 
 // The append-only ledger is the source of truth for "everything this router

--- a/test/router-dashboard-ui.test.mjs
+++ b/test/router-dashboard-ui.test.mjs
@@ -39,3 +39,27 @@ test("tray consumes only the dashboard route summary", async () => {
   const contract = source.match(/struct RouterDashboardSnapshot[\s\S]*?struct RouterDashboardModel[\s\S]*?\n}/)?.[0] || "";
   assert.doesNotMatch(contract, /credential|endpoint|session|accountId/);
 });
+
+test("the hourly traffic chart reads the router rollup instead of the capped event sample", async () => {
+  const page = (await readFile(new URL("../apps/control-center/src/pages/DashboardPage.tsx", import.meta.url), "utf8"))
+    .replace(/\r\n/g, "\n");
+  const hourly = page.match(/function buildHourlyTrafficBuckets[\s\S]*?\n}\n/)?.[0] || "";
+  assert.ok(hourly, "hourly traffic builder should be present");
+  // The rollup must be taken before the sample, and the sample must remain the
+  // fallback for a router that predates the rollup.
+  assert.ok(
+    hourly.indexOf("hourlyBucketsFromRollup(hours)") < hourly.indexOf("for (const event of events ?? [])"),
+    "the rollup should be preferred over the bounded event sample",
+  );
+  assert.match(page, /function hourlyBucketsFromRollup/);
+  assert.match(page, /buildTrafficBuckets\(events, providerUsage, eventHours, trafficRange/);
+  assert.match(page, /target\?\.usageEventHours/);
+
+  const control = (await readFile(new URL("../src/control.mjs", import.meta.url), "utf8"))
+    .replace(/\r\n/g, "\n");
+  // One ledger read per probe: the tray polls this constantly.
+  assert.match(control, /recentUsageEvents\(\{ limit: Number\.POSITIVE_INFINITY \}\)/);
+  assert.match(control, /hourlyUsageRollup\(\{ readEvents: \(\) => windowEvents \}\)/);
+  assert.match(control, /windowEvents\.slice\(-usageEventsModule\.RECENT_USAGE_EVENT_LIMIT\)/);
+  assert.match(control, /\n\s+usageEventHours,\n/);
+});

--- a/test/usage-events.test.mjs
+++ b/test/usage-events.test.mjs
@@ -437,3 +437,71 @@ test("the aging benchmark classifies shaped-only turns as compacted", () => {
     rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test("the hourly rollup aggregates the whole window, not a capped sample", async () => {
+  const { hourlyUsageRollup } = await import("../src/usage-events.mjs");
+  const now = Date.parse("2026-09-06T17:30:00.000Z");
+  const hour = 3_600_000;
+  // 4,000 rows across the window: many more than recentUsageEvents' 1,000-row
+  // default, and the reason the chart could not be built from that sample.
+  const events = Array.from({ length: 4_000 }, (_, index) => ({
+    at: new Date(now - (index % 24) * hour - 60_000).toISOString(),
+    model: "m",
+    provider: "openai",
+    totalTokens: 100,
+  }));
+  const seen = [];
+  const buckets = hourlyUsageRollup({
+    now,
+    readEvents: (options) => { seen.push(options); return events; },
+  });
+
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].limit, Number.POSITIVE_INFINITY);
+  assert.equal(buckets.length, 24);
+  assert.equal(buckets.reduce((sum, bucket) => sum + bucket.requests, 0), 4_000);
+  assert.equal(buckets.reduce((sum, bucket) => sum + bucket.tokens, 0), 400_000);
+  assert.ok(buckets.every((bucket) => bucket.requests > 0), "every hour should be filled");
+  assert.deepEqual(
+    buckets.map((bucket) => bucket.startedAt).slice().sort(),
+    buckets.map((bucket) => bucket.startedAt),
+  );
+});
+
+test("the hourly rollup mirrors the renderer's billed-token and cache-share math", async () => {
+  const { hourlyUsageRollup } = await import("../src/usage-events.mjs");
+  const now = Date.parse("2026-09-06T17:30:00.000Z");
+  const at = new Date(now - 60_000).toISOString();
+  const buckets = hourlyUsageRollup({
+    now,
+    readEvents: () => [
+      // Billed counts win over raw ones, and a cached share larger than the
+      // input it belongs to is clamped rather than double counted.
+      { at, model: "m", provider: "p", inputTokens: 10, billedInputTokens: 40, cachedInputTokens: 90, outputTokens: 3, billedOutputTokens: 7 },
+      // No totalTokens: the sum falls back to billed input plus billed output.
+      { at, model: "m", provider: "p", inputTokens: 5, outputTokens: 5 },
+      // A request with no token fields at all is counted but not measured.
+      { at, model: "m", provider: "p" },
+    ],
+  });
+  const last = buckets[buckets.length - 1];
+
+  assert.equal(last.requests, 3);
+  assert.equal(last.tokens, 47 + 10);
+  assert.equal(last.measuredTokens, true);
+  assert.equal(last.cachedInputTokens, 40 + 0);
+  assert.equal(last.regularInputTokens, 0 + 5);
+  assert.equal(last.outputTokens, 7 + 5);
+  assert.equal(last.measuredBreakdown, true);
+});
+
+test("an empty ledger still returns a full, honest set of hours", async () => {
+  const { hourlyUsageRollup } = await import("../src/usage-events.mjs");
+  const buckets = hourlyUsageRollup({
+    now: Date.parse("2026-09-06T17:30:00.000Z"),
+    readEvents: () => [],
+  });
+  assert.equal(buckets.length, 24);
+  assert.ok(buckets.every((bucket) => bucket.requests === 0 && bucket.tokens === 0));
+  assert.ok(buckets.every((bucket) => !bucket.measuredTokens && !bucket.measuredBreakdown));
+});


### PR DESCRIPTION
## Problem

The Dashboard reported two different totals for the same 24-hour window, on the same screen:

| Element | Showed | Source |
|---|---|---|
| "Tokens, last 24h" tile | **991,777,637** | sums all 42 provider rows ✓ |
| 24H traffic chart caption | **68,702,024** | newest 1,000 events ✗ |
| actual traffic in that window | 992,005,114 across 9,033 events | |

`buildHourlyTrafficBuckets` was built entirely from the probe's `usageEvents`, which `recentUsageEvents()` caps at 1,000 rows. An ordinary busy day is many times that — 9,000 events in 24 hours is routine — so the newest 1,000 covered **under two hours**. Twenty-two of the twenty-four bars were drawn empty, and the caption printed that truncated sum with the words "in the last 24 hours" next to a tile that had added up every provider row.

The 7D/30D views never had this bug: `buildDailyTrafficBuckets` aggregates `retained.providers[].dailyUsageBuckets`. Only the hourly view was missing an equivalent aggregation.

## Fix

`hourlyUsageRollup()` aggregates the **uncapped** window into 24 fixed buckets, published on the probe as `usageEventHours`, and the chart is built from it.

- **Cheaper as well as correct.** 24 buckets serialize to 5 KB; the capped event sample is 233 KB.
- **Bars carry the rollup's own hour stamps** rather than a grid anchored on the renderer's clock, so the newest measured hour stays on the chart when the hour turns over between the snapshot and the render.
- **One ledger read per probe.** `emitProbe()` reads the window once and derives both views — the tray polls it constantly and the ledger is large, so the rollup must not cost a second pass.
- **The rollup is also the middle rung of the summary tile's fallback**, between provider rows and the capped sample, so a router without provider counters no longer understates a busy day by an order of magnitude.
- **The capped sample remains the fallback** for a router that predates the rollup, and the caption says which one is in use.

The rollup's token math mirrors the renderer's `tokenCountFromEvent` / `trafficPartsFromEvent` exactly — billed counts preferred over raw, cached share clamped to the input it belongs to, an unreported field kept distinct from a measured zero — and a test pins that.

## Verification

Against the affected install, the same window now reads **1,001,119,088 tokens across 9,101 requests over 21 non-empty hours**, in agreement with the provider-row tile, where the chart previously said 68.7M across 2 hours.

- Full suite: 3,672 tests, **3,646 pass, 0 fail**, 26 skipped
- `tsc --noEmit` clean
- New tests: rollup aggregates past the 1,000-row cap and requests the window uncapped; token/cache-share math matches the renderer's; an empty ledger still returns a full, honest set of hours; contract tests pin the renderer preference order and the single-read probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)