### PR TITLE
fix: read and label usage days in the UTC day space they are written in

### DIFF
--- a/apps/control-center/src/lib.ts
+++ b/apps/control-center/src/lib.ts
@@ -74,14 +74,20 @@ export function remainingPercent(metric: UsageMetric): number | null {
   return null;
 }
 
+// The window has to be walked in UTC days, because that is the day space every
+// bucket key is written in -- the router keys its own buckets that way and
+// OpenAI's account stream reports them that way. Walking local days asked for
+// "the local day of the same name", which east of UTC is a different window
+// than the bucket measured, and left the newest slot with no bucket to match
+// until the offset had elapsed: an account mid-session read as zero all morning.
 export function bucketRange(buckets: UsageBucket[] = [], days: number): UsageBucket[] {
   const index = new Map(buckets.map((bucket) => [bucket.startDate, bucket]));
   const anchor = new Date();
-  anchor.setHours(12, 0, 0, 0);
+  anchor.setUTCHours(12, 0, 0, 0);
   return Array.from({ length: days }, (_, offset) => {
     const date = new Date(anchor);
-    date.setDate(anchor.getDate() - (days - offset - 1));
-    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    date.setUTCDate(anchor.getUTCDate() - (days - offset - 1));
+    const key = date.toISOString().slice(0, 10);
     const existing = index.get(key);
     return existing
       ? { ...existing, startDate: key, tokens: Number(existing.tokens) || 0 }

--- a/apps/control-center/src/pages/DashboardPage.tsx
+++ b/apps/control-center/src/pages/DashboardPage.tsx
@@ -959,9 +959,9 @@ function buildTokenActivity(
   now: number,
 ): { days: TokenActivityDay[]; months: TokenActivityMonth[]; today: number } {
   const today = new Date(now);
-  today.setHours(0, 0, 0, 0);
+  today.setUTCHours(0, 0, 0, 0);
   const first = new Date(today);
-  first.setDate(first.getDate() - first.getDay() - ((TOKEN_ACTIVITY_WEEKS - 1) * 7));
+  first.setUTCDate(first.getUTCDate() - first.getUTCDay() - ((TOKEN_ACTIVITY_WEEKS - 1) * 7));
 
   const tokensByDay = new Map<string, number>();
   const measuredDays = new Set<string>();
@@ -985,7 +985,7 @@ function buildTokenActivity(
     for (const event of events ?? []) {
       const at = new Date(event.at);
       if (!Number.isFinite(at.getTime())) continue;
-      const dateKey = localDateKey(at);
+      const dateKey = usageDateKey(at);
       const tokens = tokenCountFromEvent(event);
       if (tokens === null) continue;
       measuredDays.add(dateKey);
@@ -995,26 +995,26 @@ function buildTokenActivity(
 
   const days = Array.from({ length: TOKEN_ACTIVITY_WEEKS * 7 }, (_, index) => {
     const date = new Date(first);
-    date.setDate(first.getDate() + index);
-    const dateKey = localDateKey(date);
+    date.setUTCDate(first.getUTCDate() + index);
+    const dateKey = usageDateKey(date);
     return {
       date,
       dateKey,
       tokens: tokensByDay.get(dateKey) ?? 0,
       measured: measuredDays.has(dateKey),
       weekIndex: Math.floor(index / 7),
-      dayIndex: date.getDay(),
+      dayIndex: date.getUTCDay(),
     };
   });
 
-  const monthFormatter = new Intl.DateTimeFormat("en-US", { month: "short" });
+  const monthFormatter = new Intl.DateTimeFormat("en-US", { month: "short", timeZone: "UTC" });
   const months: TokenActivityMonth[] = [];
   let previousMonth = -1;
   for (const day of days) {
-    const month = day.date.getMonth();
+    const month = day.date.getUTCMonth();
     if (month === previousMonth) continue;
     previousMonth = month;
-    if (day.date.getDate() > 7) continue;
+    if (day.date.getUTCDate() > 7) continue;
     months.push({ label: monthFormatter.format(day.date), weekIndex: day.weekIndex });
   }
 
@@ -1029,6 +1029,7 @@ function tokenActivityForMode(
     month: "short",
     day: "numeric",
     year: "numeric",
+    timeZone: "UTC",
   });
   const weeklyTotals = new Map<number, number>();
   for (const day of days) {
@@ -1077,10 +1078,13 @@ function normalizeDateKey(value: string): string | null {
   return match ? `${match[1]}-${match[2]}-${match[3]}` : null;
 }
 
-function localDateKey(date: Date): string {
-  const year = date.getFullYear();
-  const month = `${date.getMonth() + 1}`.padStart(2, "0");
-  const day = `${date.getDate()}`.padStart(2, "0");
+// Usage day keys are UTC days wherever they come from -- the router writes them
+// that way and OpenAI's account stream reports them that way -- so the grid this
+// compares them against has to be built in the same day space.
+function usageDateKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getUTCDate()}`.padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 
@@ -1163,14 +1167,25 @@ function buildDailyTrafficBuckets(
   range: Exclude<TrafficRange, 24>,
   now: number,
 ): TrafficBucket[] {
+  // Daily buckets are keyed by UTC day, both by the router and by OpenAI's
+  // account stream. Anchoring this grid on local midnight put each bucket on
+  // the local day of the same name -- a different window than the one it
+  // measured, by the machine's offset -- and left the newest local day with no
+  // bucket to match until that offset had elapsed. Grid and labels are UTC so a
+  // bar names the day its number is from.
   const anchor = new Date(now);
-  anchor.setHours(0, 0, 0, 0);
+  anchor.setUTCHours(0, 0, 0, 0);
   const first = anchor.getTime() - (range - 1) * DAY_MS;
-  const labelFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" });
+  const labelFormatter = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
   const fullFormatter = new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
     year: range === 30 ? "numeric" : undefined,
+    timeZone: "UTC",
   });
   const buckets = Array.from({ length: range }, (_, index) => {
     const start = new Date(first + index * DAY_MS);
@@ -1195,7 +1210,7 @@ function buildDailyTrafficBuckets(
   let providerBuckets = 0;
   for (const provider of providers) {
     for (const usageBucket of provider.dailyUsageBuckets ?? []) {
-      const index = indexForLocalDay(usageBucket.startDate, first, range);
+      const index = indexForUsageDay(usageBucket.startDate, first, range);
       if (index === null) continue;
       const bucket = buckets[index];
       providerBuckets += 1;
@@ -1244,8 +1259,9 @@ function buildDailyTrafficBuckets(
   return buckets;
 }
 
-function indexForLocalDay(value: string, first: number, count: number): number | null {
-  const date = new Date(`${value}T00:00:00`);
+function indexForUsageDay(value: string, first: number, count: number): number | null {
+  // `T00:00:00` with no zone is local midnight; the key is a UTC day.
+  const date = new Date(`${value}T00:00:00Z`);
   if (!Number.isFinite(date.getTime())) return null;
   const index = Math.floor((date.getTime() - first) / DAY_MS);
   return index >= 0 && index < count ? index : null;

--- a/apps/control-center/src/pages/StatusPage.tsx
+++ b/apps/control-center/src/pages/StatusPage.tsx
@@ -919,13 +919,14 @@ function cachedTokensForCalendarDays(
   hasTelemetry: boolean,
 ): number | null {
   if (!daily.length) return hasTelemetry ? 0 : null;
+  // Bucket keys are UTC days, so the window bounding them has to be as well.
   const start = new Date();
-  start.setHours(0, 0, 0, 0);
-  start.setDate(start.getDate() - Math.max(0, days - 1));
+  start.setUTCHours(0, 0, 0, 0);
+  start.setUTCDate(start.getUTCDate() - Math.max(0, days - 1));
   const startTimestamp = start.getTime();
   const now = Date.now();
   return daily.reduce((total, bucket) => {
-    const timestamp = Date.parse(`${bucket.startDate}T00:00:00`);
+    const timestamp = Date.parse(`${bucket.startDate}T00:00:00Z`);
     if (!Number.isFinite(timestamp) || timestamp < startTimestamp || timestamp > now) return total;
     return total + Math.max(0, Number(bucket.cachedInputTokens) || 0);
   }, 0);

--- a/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
+++ b/apps/macos/ModelRouterTray/Sources/IslandOverlay.swift
@@ -346,7 +346,7 @@ private struct IslandOverlayView: View {
         }
         Spacer()
         HStack(spacing: 12) {
-          IslandHeaderMetric(value: todayTokenValue, label: routerLocalized("TODAY TOKENS"))
+          IslandHeaderMetric(value: todayTokenValue, label: "\(routerLocalized("TODAY TOKENS")) · UTC")
           if let accountHeaderValue {
             IslandHeaderMetric(value: accountHeaderValue, label: accountHeaderLabel)
           }
@@ -377,7 +377,7 @@ private struct IslandOverlayView: View {
         }
         Spacer()
         HStack(spacing: 12) {
-          IslandHeaderMetric(value: todayTokenValue, label: routerLocalized("TODAY TOKENS"))
+          IslandHeaderMetric(value: todayTokenValue, label: "\(routerLocalized("TODAY TOKENS")) · UTC")
           if let accountHeaderValue {
             IslandHeaderMetric(value: accountHeaderValue, label: accountHeaderLabel)
           }
@@ -941,13 +941,13 @@ private struct IslandUsageLineChart: View {
 
   private func axisLabel(for point: DailyUsagePoint) -> String {
     if points.count <= 7 {
-      return point.date.formatted(.dateTime.weekday(.abbreviated))
+      return point.date.usageDayLabel(.dateTime.weekday(.abbreviated))
     }
-    return point.date.formatted(.dateTime.month(.defaultDigits).day())
+    return point.date.usageDayLabel(.dateTime.month(.defaultDigits).day())
   }
 
   private func hoverText(for point: DailyUsagePoint) -> String {
-    let date = point.date.formatted(.dateTime.month(.abbreviated).day())
+    let date = point.date.usageDayLabel(.dateTime.month(.abbreviated).day())
     let tokens = Int64(point.tokens).formatted(.number.grouping(.automatic))
     let text = RouterLanguage.isSimplifiedChinese ? "\(date) · \(tokens) token" : "\(date) · \(tokens) tok"
     guard point.isRouterFallback else { return text }

--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -2358,7 +2358,7 @@ final class RouterStore: ObservableObject {
         )
       } ?? []
     }
-    let calendar = Calendar.current
+    let calendar = usageDayCalendar
     return dailyUsagePoints(
       from: buckets,
       days: days,
@@ -2373,7 +2373,7 @@ final class RouterStore: ObservableObject {
 
   func localUsageTotals(for providerID: String, days: Int) -> (tokens: Double, requests: Int) {
     guard providerID != "openai", let usage = providerUsage(for: providerID) else { return (0, 0) }
-    let calendar = Calendar.current
+    let calendar = usageDayCalendar
     return sumLocalUsageTotals(
       from: usage.dailyUsageBuckets,
       days: days,
@@ -4521,13 +4521,42 @@ struct DailyUsageDisplayBucket: Equatable {
   let isRouterFallback: Bool
 }
 
+// Usage days are UTC days. OpenAI's account stream reports dailyUsageBuckets on
+// UTC calendar boundaries and the router keys its own buckets the same way, so
+// this formatter has to read and write that one day space. Leaving it on the
+// device zone made every key mean "the local day of the same name", which east
+// of UTC is a different window than the bucket measured -- and left the current
+// local day with no account bucket to match until the offset elapsed, so an
+// account mid-session reported "today: 0" every morning.
+let usageDayTimeZone = TimeZone(secondsFromGMT: 0) ?? .gmt
+
 let dailyUsageDayKeyFormatter: DateFormatter = {
   let formatter = DateFormatter()
   formatter.locale = Locale(identifier: "en_US_POSIX")
   formatter.calendar = Calendar(identifier: .gregorian)
+  formatter.timeZone = usageDayTimeZone
   formatter.dateFormat = "yyyy-MM-dd"
   return formatter
 }()
+
+/// The calendar every usage-day walk and label must use, so a point's date, the
+/// key it looks up, and the day it is labelled with all name the same window.
+var usageDayCalendar: Calendar = {
+  var calendar = Calendar(identifier: .gregorian)
+  calendar.timeZone = usageDayTimeZone
+  return calendar
+}()
+
+/// Day labels for a usage chart. A usage point's date is the start of a UTC
+/// day, so formatting it in the device zone can name the day before or after
+/// the one the bucket measured. Label the day the number is actually from.
+extension Date {
+  func usageDayLabel(_ style: Date.FormatStyle) -> String {
+    var dayStyle = style
+    dayStyle.timeZone = usageDayTimeZone
+    return formatted(dayStyle)
+  }
+}
 
 func mergeAccountUsageBuckets(
   account: [CodexDailyUsageBucket],
@@ -4556,7 +4585,7 @@ func dailyUsagePoints(
   from buckets: [DailyUsageDisplayBucket],
   days: Int,
   today: Date,
-  calendar: Calendar = .current
+  calendar: Calendar = usageDayCalendar
 ) -> [DailyUsagePoint] {
   let indexed = Dictionary(uniqueKeysWithValues: buckets.map { ($0.startDate, $0) })
   return (0..<days).map { offset in
@@ -4571,11 +4600,14 @@ func dailyUsagePoints(
 }
 
 /// Pure 7/30-day total. Safe to call from SwiftUI view bodies.
+/// The window boundaries have to be UTC days like the keys they are compared
+/// against; a local window against UTC-parsed keys drops or admits one day at
+/// the edge, by the machine's offset.
 func sumLocalUsageTotals(
   from buckets: [ProviderDailyUsageBucket],
   days: Int,
   today: Date,
-  calendar: Calendar = .current
+  calendar: Calendar = usageDayCalendar
 ) -> (tokens: Double, requests: Int) {
   let firstDay = calendar.date(byAdding: .day, value: -(days - 1), to: today) ?? today
   return buckets.reduce(into: (tokens: 0.0, requests: 0)) { totals, bucket in
@@ -10146,13 +10178,13 @@ struct UsageBarChart: View {
 
   private func axisLabel(for point: DailyUsagePoint) -> String {
     if points.count <= 7 {
-      return point.date.formatted(.dateTime.weekday(.abbreviated))
+      return point.date.usageDayLabel(.dateTime.weekday(.abbreviated))
     }
-    return point.date.formatted(.dateTime.month(.defaultDigits).day())
+    return point.date.usageDayLabel(.dateTime.month(.defaultDigits).day())
   }
 
   private func hoverText(for point: DailyUsagePoint) -> String {
-    let date = point.date.formatted(.dateTime.weekday(.abbreviated).month(.abbreviated).day())
+    let date = point.date.usageDayLabel(.dateTime.weekday(.abbreviated).month(.abbreviated).day())
     let tokens = self.tokenDisplayUnit.format(point.tokens)
     let text = RouterLanguage.isSimplifiedChinese ? "\(date) · \(tokens) token" : "\(date) · \(tokens) tokens"
     guard point.isRouterFallback else { return text }

--- a/apps/macos/ModelRouterTray/Tests/DailyUsageFallbackTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/DailyUsageFallbackTests.swift
@@ -54,7 +54,7 @@ struct DailyUsageFallbackTests {
 
   @Test("dailyUsagePoints fills missing days and preserves fallback flags")
   func dailyUsagePointsArePureProjection() {
-    let calendar = Calendar.current
+    let calendar = usageDayCalendar
     let today = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_777_500_000))
     let dayMinus2 = calendar.date(byAdding: .day, value: -2, to: today)!
     let keyToday = dailyUsageDayKeyFormatter.string(from: today)
@@ -75,7 +75,10 @@ struct DailyUsageFallbackTests {
 
   @Test("sumLocalUsageTotals ignores buckets outside the requested window")
   func localUsageTotalsHonorDayWindow() {
-    let calendar = Calendar.current
+    // Usage days are UTC days, so the window this filters on has to be built in
+    // that calendar too; a local window against UTC keys admits or drops a day
+    // at the edge, by the machine's offset from UTC.
+    let calendar = usageDayCalendar
     let today = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_777_500_000))
     let dayMinus1 = calendar.date(byAdding: .day, value: -1, to: today)!
     let dayMinus8 = calendar.date(byAdding: .day, value: -8, to: today)!
@@ -104,5 +107,44 @@ struct DailyUsageFallbackTests {
 
     #expect(totals.tokens == 150)
     #expect(totals.requests == 3)
+  }
+}
+
+@Suite("Usage day space")
+struct UsageDaySpaceTests {
+  @Test("account buckets are read in the UTC day space they are written in")
+  func accountBucketsUseUTCDays() {
+    #expect(dailyUsageDayKeyFormatter.timeZone.secondsFromGMT() == 0)
+    #expect(usageDayCalendar.timeZone.secondsFromGMT() == 0)
+    // 2026-09-06T18:00Z is already 2026-09-07 for anyone at +07:00 or further
+    // east. The account stream's newest bucket is still 2026-09-06, so a local
+    // day walk asked for "2026-09-07", found nothing, and drew the account's
+    // busiest hours as a confident zero -- every morning, until the offset
+    // elapsed.
+    let now = Date(timeIntervalSince1970: 1_788_724_800)
+    #expect(dailyUsageDayKeyFormatter.string(from: now) == "2026-09-06")
+
+    let points = dailyUsagePoints(
+      from: [
+        DailyUsageDisplayBucket(startDate: "2026-09-05", tokens: 515_184_784, isRouterFallback: false),
+        DailyUsageDisplayBucket(startDate: "2026-09-06", tokens: 422_897_472, isRouterFallback: false),
+      ],
+      days: 3,
+      today: usageDayCalendar.startOfDay(for: now),
+      calendar: usageDayCalendar
+    )
+
+    #expect(points.count == 3)
+    #expect(points.map(\.tokens) == [0, 515_184_784, 422_897_472])
+    // The newest point is today's UTC day, and it carries today's number.
+    #expect(dailyUsageDayKeyFormatter.string(from: points[2].date) == "2026-09-06")
+  }
+
+  @Test("a usage day is labelled with the day its number is from")
+  func labelsNameTheMeasuredDay() {
+    // The start of UTC 2026-09-06. Formatted in a zone west of UTC this instant
+    // falls on the 5th, so a device-zone label would name the wrong day.
+    let dayStart = Date(timeIntervalSince1970: 1_788_652_800)
+    #expect(dayStart.usageDayLabel(.dateTime.month(.defaultDigits).day()) == "9/6")
   }
 }

--- a/apps/macos/RouterUsageWidget/RouterUsageWidget/RouterUsageWidget.swift
+++ b/apps/macos/RouterUsageWidget/RouterUsageWidget/RouterUsageWidget.swift
@@ -293,7 +293,7 @@ struct RouterUsageWidgetView: View {
     VStack(alignment: .leading, spacing: 0) {
       WidgetHeader(snapshot: snapshot, compact: true)
       Spacer(minLength: 9)
-      Text("Today · \(source.name)")
+      Text("Today · \(source.name) · UTC")
         .font(.caption2.weight(.semibold))
         .textCase(.uppercase)
         .tracking(0.35)
@@ -321,7 +321,7 @@ struct RouterUsageWidgetView: View {
       WidgetHeader(snapshot: snapshot)
       HStack(alignment: .top, spacing: 15) {
         VStack(alignment: .leading, spacing: 1) {
-          Text("Today · \(source.name)")
+          Text("Today · \(source.name) · UTC")
             .font(.caption2.weight(.semibold))
             .textCase(.uppercase)
             .tracking(0.35)

--- a/src/provider-usage.mjs
+++ b/src/provider-usage.mjs
@@ -3,11 +3,19 @@ import { providerAccountUsageSnapshot } from "./provider-account-usage.mjs";
 import { canonicalProviderId, readProviderSelection } from "./provider-selection.mjs";
 import { allUsageEvents } from "./usage-events.mjs";
 
+// OpenAI's account stream reports dailyUsageBuckets keyed by UTC calendar day.
+// These router-derived buckets were keyed by the machine's local day, so the
+// two day spaces were merged by string in mergeAccountUsageBuckets() and drawn
+// on one chart as if they described the same window. East of UTC that silently
+// misattributed every bar by the zone's offset, and the current local day had
+// no account bucket to match at all until the offset elapsed -- a Pro account
+// mid-session showed "today: 0" every morning. One day space, and it has to be
+// the one the authoritative stream already uses.
 function dateKey(value) {
   const date = new Date(value);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 

--- a/test/control-center-usage.test.mjs
+++ b/test/control-center-usage.test.mjs
@@ -87,3 +87,19 @@ test("fallback provenance is translated in every control-center language", () =>
     }
   }
 });
+
+test("the daily window is walked in UTC days, the day space every bucket key uses", async () => {
+  const { bucketRange } = await import("../apps/control-center/src/lib.ts");
+  const utcToday = new Date().toISOString().slice(0, 10);
+  const range = bucketRange([{ startDate: utcToday, tokens: 4_242 }], 7);
+
+  assert.equal(range.length, 7);
+  // Keys must be plain UTC calendar days, ascending, ending on the current one.
+  assert.ok(range.every((bucket) => /^\d{4}-\d{2}-\d{2}$/.test(bucket.startDate)));
+  assert.deepEqual(range.map((bucket) => bucket.startDate).slice().sort(), range.map((bucket) => bucket.startDate));
+  assert.equal(range.at(-1).startDate, utcToday);
+  // The newest slot has to find today's account bucket. Walking local days
+  // asked for a key the UTC-keyed stream has not written yet whenever the
+  // machine is east of UTC, which read as a confident zero all morning.
+  assert.equal(range.at(-1).tokens, 4_242);
+});

--- a/test/provider-usage.test.mjs
+++ b/test/provider-usage.test.mjs
@@ -170,13 +170,10 @@ test("reports a rolling 24-hour window separately from calendar-day buckets", ()
 });
 
 test("publishes prefix-cache telemetry for the dashboard without inflating it", () => {
-  const localDateKey = (value) => {
-    const date = new Date(value);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, "0");
-    const day = String(date.getDate()).padStart(2, "0");
-    return `${year}-${month}-${day}`;
-  };
+  // Buckets are keyed by UTC calendar day, the same day space OpenAI's account
+  // stream uses, so a chart can merge the two without misattributing a bar by
+  // the machine's offset from UTC.
+  const utcDateKey = (value) => new Date(value).toISOString().slice(0, 10);
   const now = Date.parse("2026-07-21T18:00:00Z");
   const snapshot = aggregateProviderUsage(
     [
@@ -215,8 +212,8 @@ test("publishes prefix-cache telemetry for the dashboard without inflating it", 
     // request exactly one day earlier is still part of the window.
     last24hCachedInputTokens: 130,
     dailyCachedInputTokens: [
-      { startDate: localDateKey("2026-07-20T18:00:00Z"), cachedInputTokens: 80 },
-      { startDate: localDateKey("2026-07-21T17:00:00Z"), cachedInputTokens: 50 },
+      { startDate: utcDateKey("2026-07-20T18:00:00Z"), cachedInputTokens: 80 },
+      { startDate: utcDateKey("2026-07-21T17:00:00Z"), cachedInputTokens: 50 },
     ],
   });
   const deepseek = snapshot.providers.find((provider) => provider.id === "deepseek");
@@ -227,8 +224,8 @@ test("publishes prefix-cache telemetry for the dashboard without inflating it", 
   assert.equal(deepseek.last24hCachedInputTokens, 130);
   assert.equal(deepseek.regularInputTokens + deepseek.cachedInputTokens, deepseek.inputTokens);
   assert.deepEqual(deepseek.dailyUsageBuckets, [
-    { startDate: localDateKey("2026-07-20T18:00:00Z"), tokens: 100, requests: 1, inputTokens: 100, cachedInputTokens: 80, outputTokens: 0 },
-    { startDate: localDateKey("2026-07-21T17:00:00Z"), tokens: 50, requests: 2, inputTokens: 50, cachedInputTokens: 50, outputTokens: 0 },
+    { startDate: utcDateKey("2026-07-20T18:00:00Z"), tokens: 100, requests: 1, inputTokens: 100, cachedInputTokens: 80, outputTokens: 0 },
+    { startDate: utcDateKey("2026-07-21T17:00:00Z"), tokens: 50, requests: 2, inputTokens: 50, cachedInputTokens: 50, outputTokens: 0 },
   ]);
 });
 


### PR DESCRIPTION
## Problem

OpenAI's account stream reports `dailyUsageBuckets` on **UTC** calendar days. The router keyed its own buckets by the machine's **local** day, and every surface then walked local days to look them up. Two day spaces, merged by string key in `mergeAccountUsageBuckets()` and drawn on one chart as though they described the same window.

East of UTC this misattributed every bar by the zone's offset, and left the newest slot with no bucket to match at all until that offset had elapsed. On a UTC+8 machine, a Pro account mid-session read **"today: 0"** from midnight until 08:00 — in the tray, the desktop widget, and the Control Center — while the account had already reported **422,897,472** tokens for the UTC day in progress.

## Which day space is right

Measured against the router's own event ledger, the account's buckets match its **UTC**-day totals and never its local-day totals:

| day | account bucket | router, UTC day | router, local day |
|---|---:|---:|---:|
| 2026-08-29 | 738,661,403 | **735,616,791** | 1,574,715,327 |
| 2026-08-30 | 1,228,446,701 | **1,225,612,061** | 840,959,733 |
| 2026-08-31 | 1,213,130,731 | **1,209,584,660** | 838,962,230 |
| 2026-09-01 | 520,631,933 | **520,393,459** | 1,339,619,483 |
| 2026-09-04 | 1,876,811 | **1,876,811** (exact) | 0 |
| 2026-09-05 | 515,184,784 | **514,065,262** | 1,876,811 |

Every completed day lands within 0.4% of the UTC window and nowhere near the local one. There is one correct day space, and the authoritative stream already picks it.

## Change

Router buckets are keyed by UTC day (`provider-usage.mjs`), and every consumer reads and labels them there:

- **Tray** — `dailyUsageDayKeyFormatter` and a shared `usageDayCalendar` on UTC; `dailyUsagePoints` and `sumLocalUsageTotals` default to it, so a point's date, the key it looks up, and its label all name the same window
- **Tray + island** — axis and hover labels go through `usageDayLabel`, so a bar is labelled with the day its number is from rather than the device-zone day that instant falls in
- **Widget** — inherits the corrected points
- **Control Center** — daily traffic grid, token-activity heatmap, `bucketRange` usage window, and the status-page cache window

Both single-day headlines now say UTC outright (`TODAY TOKENS · UTC`, `Today · Codex · UTC`) rather than implying a local day the data cannot describe.

## Verification

- Swift: **124 tests pass**, tray builds clean. New tests cover the UTC formatter/calendar, an account bucket landing on the right point at `2026-09-06T18:00Z` (already the 7th east of +07), and a day label naming the measured day.
- `tsc --noEmit` clean; new test pins `bucketRange` to ascending UTC keys ending on the current UTC day.
- Live check: the router's openai buckets now agree with the account's — 2026-09-04 exact, 2026-09-05 within 0.2%.

### On the JS suite

The full suite reports intermittent failures on this machine in oauth-session, streaming and shim tests. They are not from this change:

- All four affected files pass **53/53 in isolation** with the change applied.
- They import only `file-security.mjs` and the antigravity probe modules — nothing this PR touches.
- Unmodified `main` in a clean worktree failed *more* of them (73), on the same loaded machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)