### PR TITLE
fix: keep the account answer that arrived when the other never does

### DIFF
--- a/src/codex-account-usage.mjs
+++ b/src/codex-account-usage.mjs
@@ -185,8 +185,27 @@ export function readCodexAccountUsage({
     const send = (message) => {
       processHandle.stdin.write(`${JSON.stringify(message)}\n`);
     };
+    // An absent answer is the same class of event as a refused one, and the
+    // refused case is already tolerated below. Waiting for both meant one read
+    // that never came back discarded the other one's answer: on a machine where
+    // account/rateLimits/read hung and account/usage/read returned a full daily
+    // ledger, this rejected, the caller had no account usage at all, and every
+    // surface fell back to publishing zero. Keep whatever arrived; only a window
+    // that produced nothing is a failure.
+    const emptyResponse = (id) => (
+      id === 2 ? { rateLimits: {} } : { summary: {}, dailyUsageBuckets: [] }
+    );
     const timer = setTimeout(
-      () => finish(new Error("Codex account usage request timed out.")),
+      () => {
+        if (responses.size === 0) {
+          finish(new Error("Codex account usage request timed out."));
+          return;
+        }
+        finish(undefined, normalizeCodexAccountUsage(
+          responses.get(2) ?? emptyResponse(2),
+          responses.get(3) ?? emptyResponse(3),
+        ));
+      },
       timeoutMs,
     );
 
@@ -219,10 +238,7 @@ export function readCodexAccountUsage({
       // app-server races). Hard-failing rateLimits used to paint the whole
       // Models page with a stack trace while the snapshot itself was fine.
       if (message.error) {
-        responses.set(
-          message.id,
-          message.id === 2 ? { rateLimits: {} } : { summary: {}, dailyUsageBuckets: [] },
-        );
+        responses.set(message.id, emptyResponse(message.id));
       } else {
         responses.set(message.id, message.result);
       }

--- a/test/codex-account-usage.test.mjs
+++ b/test/codex-account-usage.test.mjs
@@ -286,3 +286,47 @@ test("a refused usage read still returns rate limits instead of failing the pane
   assert.deepEqual(value.dailyUsageBuckets, []);
   assert.equal(value.summary.lifetimeTokens, null);
 });
+
+test("a rateLimits read that never answers still returns the usage that did", async () => {
+  const value = await readCodexAccountUsage({
+    binary: "/fake/codex",
+    platform: "darwin",
+    timeoutMs: 300,
+    spawnImpl: () => fakeAppServer((message) => {
+      if (message.id === 1) return { id: 1, result: {} };
+      // Silence, not a refusal. Observed in the field: account/rateLimits/read
+      // hung past 20 seconds while account/usage/read answered immediately, and
+      // requiring both discarded a full daily ledger -- which every surface then
+      // published as a confident zero.
+      if (message.id === 2) return undefined;
+      if (message.id === 3) {
+        return {
+          id: 3,
+          result: {
+            summary: { lifetimeTokens: 50_316_410_695, peakDailyTokens: 3_138_996_331, currentStreakDays: 2 },
+            dailyUsageBuckets: [{ startDate: "2026-09-06", tokens: 557_115_160 }],
+          },
+        };
+      }
+      return undefined;
+    }),
+  });
+
+  assert.deepEqual(value.dailyUsageBuckets, [{ startDate: "2026-09-06", tokens: 557_115_160 }]);
+  assert.equal(value.summary.lifetimeTokens, 50_316_410_695);
+  // The half that never answered stays absent rather than becoming a zero.
+  assert.equal(value.planType, null);
+  assert.equal(value.primary, null);
+});
+
+test("a window that produced no answer at all is still a failure", async () => {
+  await assert.rejects(
+    readCodexAccountUsage({
+      binary: "/fake/codex",
+      platform: "darwin",
+      timeoutMs: 300,
+      spawnImpl: () => fakeAppServer((message) => (message.id === 1 ? { id: 1, result: {} } : undefined)),
+    }),
+    /timed out/,
+  );
+});


### PR DESCRIPTION
## Problem

`readCodexAccountUsage()` issues `account/rateLimits/read` and `account/usage/read` together and resolved only once **both** had answered. A *refused* read was already tolerated — the comment above that branch says both reads are optional and one login can answer one and refuse the other — but an *absent* one was not, and silence is the same class of event as a refusal.

Observed on a live install, instrumenting both reads:

```
elapsed 20001ms   answered: [{"id":3 (usage), ok:true}]
                  id 2 (rateLimits) never answered at all
```

`account/usage/read` returned a complete 130-day ledger immediately. Requiring both threw it away, rejected on the 10-second timeout, and left the caller with no account usage at all — so the tray, the desktop widget, and the Control Center each fell back to publishing **0** for an account mid-session with a live Pro plan.

## Fix

On timeout, resolve with whatever arrived and leave the missing half absent rather than zero. Only a window that produced no answer at all is still a failure. The empty-response shape used for a refusal is now shared with the timeout path, so the two cases cannot drift apart.

## Verification

```
before:  planType: null | buckets: 0   (rejected: "Codex account usage request timed out")
after:   planType: pro  | buckets: 130 | weekly 59%
             2026-09-05  515,184,784
             2026-09-06  557,115,160
```

`codex-account-usage` suite: 12 pass / 0 fail, including two new cases — a rateLimits read that never answers still returns the usage that did (leaving the missing half `null`, not `0`), and a window that produced no answer at all still rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)