### PR TITLE
fix(widget): publish router-filled days with their provenance, not as zero

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/RouterWidgetPublishing.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterWidgetPublishing.swift
@@ -1,15 +1,17 @@
 import Foundation
 import WidgetKit
 
-// The current widget schema has no provenance field and labels the default
-// source as Codex account usage. Until the schema and widget presentation can
-// disclose provenance together, publish an absent account date as zero rather
-// than misrepresenting this Mac's router-only fallback as global account use.
+// Publish the measured number together with where it came from. Zeroing the
+// router-only dates kept the snapshot from overstating account usage, but it
+// understated it instead: an account stream that has not reported today yet
+// rendered as a confident "0". The schema now carries provenance per point and
+// the widget marks the router-only ones, so neither side has to lie.
 func routerWidgetDailyPoints(_ points: [DailyUsagePoint]) -> [RouterWidgetDailyPoint] {
   points.map {
     RouterWidgetDailyPoint(
       date: $0.date,
-      tokens: $0.isRouterFallback ? 0 : RouterWidgetTokenCount.from($0.tokens)
+      tokens: RouterWidgetTokenCount.from($0.tokens),
+      isRouterFallback: $0.isRouterFallback
     )
   }
 }

--- a/apps/macos/ModelRouterTray/Sources/RouterWidgetSnapshot.swift
+++ b/apps/macos/ModelRouterTray/Sources/RouterWidgetSnapshot.swift
@@ -23,9 +23,46 @@ enum RouterWidgetTokenCount {
   }
 }
 
+/// An account stream can omit a date entirely -- OpenAI does not publish a
+/// bucket for the current day until it settles, and it drops quiet days
+/// outright. Router telemetry fills those gaps, but it only measures this Mac,
+/// so a filled point is not a global account total. This used to be published
+/// as a flat zero, which the widget then rendered as a confident "0 tokens
+/// today" on a day the account simply had not reported yet. Carry the
+/// provenance instead and let the presentation say which one it is showing.
 struct RouterWidgetDailyPoint: Codable, Equatable, Identifiable {
   let date: Date
   let tokens: Int64
+  let isRouterFallback: Bool
+
+  init(date: Date, tokens: Int64, isRouterFallback: Bool = false) {
+    self.date = date
+    self.tokens = tokens
+    self.isRouterFallback = isRouterFallback
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case date
+    case tokens
+    case isRouterFallback
+  }
+
+  // The flag is additive within schema 1: it is omitted for account points, so
+  // a host and an extension on either side of an app update keep reading each
+  // other's snapshots instead of falling back to "Waiting for router data".
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    date = try container.decode(Date.self, forKey: .date)
+    tokens = try container.decode(Int64.self, forKey: .tokens)
+    isRouterFallback = try container.decodeIfPresent(Bool.self, forKey: .isRouterFallback) ?? false
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(date, forKey: .date)
+    try container.encode(tokens, forKey: .tokens)
+    if isRouterFallback { try container.encode(true, forKey: .isRouterFallback) }
+  }
 
   var id: Date { date }
 }
@@ -40,12 +77,22 @@ struct RouterWidgetUsageSource: Codable, Equatable, Identifiable {
     var total: Int64 = 0
     return daily.map { point in
       total = RouterWidgetTokenCount.adding(total, point.tokens)
-      return RouterWidgetDailyPoint(date: point.date, tokens: total)
+      return RouterWidgetDailyPoint(
+        date: point.date,
+        tokens: total,
+        isRouterFallback: point.isRouterFallback
+      )
     }
   }
 
   var periodTokens: Int64 {
     daily.reduce(0) { RouterWidgetTokenCount.adding($0, $1.tokens) }
+  }
+
+  /// Today is the point most likely to be router-only: the account stream lags
+  /// the current day, so a headline number for it usually measures this Mac.
+  var todayIsRouterFallback: Bool {
+    daily.last?.isRouterFallback ?? false
   }
 }
 

--- a/apps/macos/ModelRouterTray/Tests/DailyUsageFallbackTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/DailyUsageFallbackTests.swift
@@ -37,8 +37,8 @@ struct DailyUsageFallbackTests {
     ])
   }
 
-  @Test("widget projection never publishes local fallback as account usage")
-  func widgetProjectionExcludesFallbackTokens() {
+  @Test("widget projection labels local fallback instead of publishing it as zero")
+  func widgetProjectionCarriesFallbackProvenance() {
     let accountDate = Date(timeIntervalSince1970: 1_777_500_000)
     let fallbackDate = accountDate.addingTimeInterval(86_400)
     let projected = routerWidgetDailyPoints([
@@ -48,8 +48,54 @@ struct DailyUsageFallbackTests {
 
     #expect(projected == [
       RouterWidgetDailyPoint(date: accountDate, tokens: 280),
-      RouterWidgetDailyPoint(date: fallbackDate, tokens: 0),
+      RouterWidgetDailyPoint(date: fallbackDate, tokens: 27_000, isRouterFallback: true),
     ])
+  }
+
+  @Test("a fallback point survives one encode and decode without its flag defaulting away")
+  func fallbackProvenanceSurvivesTheSnapshotFile() throws {
+    let date = Date(timeIntervalSince1970: 1_777_500_000)
+    let points = [
+      RouterWidgetDailyPoint(date: date, tokens: 280),
+      RouterWidgetDailyPoint(date: date.addingTimeInterval(86_400), tokens: 27_000, isRouterFallback: true),
+    ]
+    let encoded = try JSONEncoder.routerWidget.encode(points)
+    #expect(try JSONDecoder.routerWidget.decode([RouterWidgetDailyPoint].self, from: encoded) == points)
+
+    // Account points stay byte-identical to a schema-1 snapshot written before
+    // provenance existed, so an extension on either side of an app update can
+    // still read the host's file.
+    let text = String(decoding: encoded, as: UTF8.self)
+    #expect(text.components(separatedBy: "isRouterFallback").count - 1 == 1)
+  }
+
+  @Test("a snapshot written before provenance existed decodes as account data")
+  func legacyPointsDecodeWithoutTheFlag() throws {
+    let legacy = Data(#"[{"date":"2026-04-29T18:00:00Z","tokens":280}]"#.utf8)
+    let decoded = try JSONDecoder.routerWidget.decode([RouterWidgetDailyPoint].self, from: legacy)
+
+    #expect(decoded.count == 1)
+    #expect(decoded[0].tokens == 280)
+    #expect(decoded[0].isRouterFallback == false)
+  }
+
+  @Test("a usage source reports which of its days came from router telemetry")
+  func usageSourceSummarizesFallbackDays() {
+    let date = Date(timeIntervalSince1970: 1_777_500_000)
+    let source = RouterWidgetUsageSource(
+      id: "openai",
+      name: "Codex",
+      todayTokens: 27_000,
+      daily: [
+        RouterWidgetDailyPoint(date: date, tokens: 280),
+        RouterWidgetDailyPoint(date: date.addingTimeInterval(86_400), tokens: 0, isRouterFallback: true),
+        RouterWidgetDailyPoint(date: date.addingTimeInterval(172_800), tokens: 27_000, isRouterFallback: true),
+      ]
+    )
+
+    #expect(source.todayIsRouterFallback)
+    #expect(source.cumulativeDaily.map(\.tokens) == [280, 280, 27_280])
+    #expect(source.cumulativeDaily.map(\.isRouterFallback) == [false, true, true])
   }
 
   @Test("dailyUsagePoints fills missing days and preserves fallback flags")

--- a/apps/macos/RouterUsageWidget/RouterUsageWidget/RouterUsageWidget.swift
+++ b/apps/macos/RouterUsageWidget/RouterUsageWidget/RouterUsageWidget.swift
@@ -307,7 +307,9 @@ struct RouterUsageWidgetView: View {
       Text(Self.todayTokenLabel(for: source))
         .font(.caption2)
         .foregroundStyle(.secondary)
-        .lineLimit(1)
+        .lineLimit(2)
+        .minimumScaleFactor(0.8)
+        .fixedSize(horizontal: false, vertical: true)
       Spacer(minLength: 7)
       cumulativeLabel(source, compact: true)
       RouterWidgetCumulativeLineChart(points: source.cumulativeDaily)
@@ -333,6 +335,12 @@ struct RouterUsageWidgetView: View {
             .monospacedDigit()
             .lineLimit(1)
             .minimumScaleFactor(0.64)
+          Text(Self.todayTokenLabel(for: source))
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .lineLimit(2)
+            .minimumScaleFactor(0.8)
+            .fixedSize(horizontal: false, vertical: true)
           Spacer(minLength: 4)
           cumulativeLabel(source)
           RouterWidgetCumulativeLineChart(points: source.cumulativeDaily)
@@ -416,7 +424,11 @@ struct RouterUsageWidgetView: View {
   }
 
   static func todayTokenLabel(for source: RouterWidgetUsageSource) -> String {
-    source.id == RouterWidgetSnapshot.defaultUsageSourceID ? "account tokens" : "tokens routed"
+    // A router-only day is this Mac's traffic, not the account total, and
+    // saying so is the whole point of carrying provenance into the snapshot.
+    // Without it a lagging account stream reads as a real zero.
+    if source.todayIsRouterFallback { return "this Mac · account not reported yet" }
+    return source.id == RouterWidgetSnapshot.defaultUsageSourceID ? "account tokens" : "tokens routed"
   }
 }
 
@@ -684,9 +696,15 @@ private struct RouterWidgetQuotaRow: View {
 private struct RouterWidgetCumulativeLineChart: View {
   let points: [RouterWidgetDailyPoint]
 
+  private var visiblePoints: [RouterWidgetDailyPoint] { Array(points.suffix(7)) }
+
+  private var endsOnRouterFallback: Bool {
+    visiblePoints.last?.isRouterFallback == true
+  }
+
   var body: some View {
     GeometryReader { geometry in
-      let values = Array(points.suffix(7))
+      let values = visiblePoints
       let maximum = max(values.map(\.tokens).max() ?? 0, 1)
       let width = geometry.size.width
       let height = geometry.size.height
@@ -695,6 +713,17 @@ private struct RouterWidgetCumulativeLineChart: View {
         CGPoint(
           x: CGFloat(index) * step,
           y: height - height * CGFloat(Double(max(0, point.tokens)) / Double(maximum))
+        )
+      }
+      // A segment is drawn dashed when the day it arrives at was filled from
+      // router telemetry, matching how the tray hatches those bars. The line
+      // stays continuous so the shape still reads, while the dashes keep a
+      // router-only stretch from passing as account history.
+      let segments = coordinates.indices.dropFirst().map { index in
+        (
+          start: coordinates[index - 1],
+          end: coordinates[index],
+          isRouterFallback: values[index].isRouterFallback
         )
       }
 
@@ -723,16 +752,33 @@ private struct RouterWidgetCumulativeLineChart: View {
         ))
 
         Path { path in
-          guard let first = coordinates.first else { return }
-          path.move(to: first)
-          for point in coordinates.dropFirst() { path.addLine(to: point) }
+          for segment in segments where !segment.isRouterFallback {
+            path.move(to: segment.start)
+            path.addLine(to: segment.end)
+          }
         }
         .stroke(widgetAccent, style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
         .widgetAccentable()
 
+        Path { path in
+          for segment in segments where segment.isRouterFallback {
+            path.move(to: segment.start)
+            path.addLine(to: segment.end)
+          }
+        }
+        .stroke(widgetAccent, style: StrokeStyle(
+          lineWidth: 2,
+          lineCap: .round,
+          lineJoin: .round,
+          dash: [2.5, 2.5]
+        ))
+        .widgetAccentable()
+
         if let last = coordinates.last {
+          // A hollow cap says the newest point is this Mac's own count, which
+          // is the usual state: the account stream settles a day behind.
           Circle()
-            .fill(widgetAccent)
+            .strokeBorder(widgetAccent, lineWidth: endsOnRouterFallback ? 1.5 : 2.5)
             .frame(width: 5, height: 5)
             .position(last)
             .widgetAccentable()
@@ -740,7 +786,11 @@ private struct RouterWidgetCumulativeLineChart: View {
       }
     }
     .accessibilityElement(children: .ignore)
-    .accessibilityLabel("Seven day cumulative token usage")
+    .accessibilityLabel(
+      endsOnRouterFallback
+        ? "Seven day cumulative token usage, most recent day measured locally"
+        : "Seven day cumulative token usage"
+    )
   }
 }
 

--- a/apps/macos/RouterUsageWidget/RouterUsageWidgetTests/RouterUsageWidgetTests.swift
+++ b/apps/macos/RouterUsageWidget/RouterUsageWidgetTests/RouterUsageWidgetTests.swift
@@ -192,6 +192,24 @@ final class RouterUsageWidgetTests: XCTestCase {
     )
   }
 
+  func testRouterOnlyDaysAreNamedInsteadOfPassingAsAccountTotals() {
+    let snapshot = RouterWidgetSnapshot.previewWithRouterOnlyToday
+    let source = snapshot.usageSource(id: "openai")
+
+    XCTAssertTrue(source.todayIsRouterFallback)
+    XCTAssertEqual(
+      RouterUsageWidgetView.todayTokenLabel(for: source),
+      "this Mac · account not reported yet"
+    )
+    // The headline number is the measured one, not the zero this used to
+    // publish, and every earlier day keeps its account provenance.
+    XCTAssertEqual(source.todayTokens, 917_968_864)
+    XCTAssertEqual(source.daily.dropLast().filter(\.isRouterFallback).count, 0)
+    XCTAssertFalse(
+      RouterWidgetSnapshot.preview.usageSource(id: "openai").todayIsRouterFallback
+    )
+  }
+
   func testResetCountdownUsesCompactStableUnits() {
     let now = Date(timeIntervalSince1970: 1_000)
     XCTAssertEqual(RouterResetWidgetView.countdown(to: now.addingTimeInterval(59), now: now), "<1m")
@@ -242,6 +260,22 @@ final class RouterUsageWidgetTests: XCTestCase {
       family: .systemMedium,
       size: CGSize(width: 364, height: 170),
       entry: RouterUsageEntry(date: now, snapshot: .preview),
+      colorScheme: .light,
+      directory: directory
+    )
+    try render(
+      name: "router-widget-medium-router-only",
+      family: .systemMedium,
+      size: CGSize(width: 364, height: 170),
+      entry: RouterUsageEntry(date: now, snapshot: .previewWithRouterOnlyToday),
+      colorScheme: .light,
+      directory: directory
+    )
+    try render(
+      name: "router-widget-small-router-only",
+      family: .systemSmall,
+      size: CGSize(width: 170, height: 170),
+      entry: RouterUsageEntry(date: now, snapshot: .previewWithRouterOnlyToday),
       colorScheme: .light,
       directory: directory
     )
@@ -344,5 +378,43 @@ final class RouterUsageWidgetTests: XCTestCase {
       return
     }
     try png.write(to: directory.appendingPathComponent("\(name).png"), options: .atomic)
+  }
+}
+
+/// The state the widget is in most of the day: OpenAI has not published a
+/// bucket for today yet, so the newest point is this Mac's own router count.
+private extension RouterWidgetSnapshot {
+  static var previewWithRouterOnlyToday: RouterWidgetSnapshot {
+    let base = RouterWidgetSnapshot.preview
+    var daily = base.daily
+    if let last = daily.last {
+      daily[daily.count - 1] = RouterWidgetDailyPoint(
+        date: last.date,
+        tokens: 917_968_864,
+        isRouterFallback: true
+      )
+    }
+    let todayTokens = daily.last?.tokens ?? 0
+    return RouterWidgetSnapshot(
+      schemaVersion: base.schemaVersion,
+      generatedAt: base.generatedAt,
+      activityState: base.activityState,
+      activeChatCount: base.activeChatCount,
+      selectedProviderID: base.selectedProviderID,
+      selectedProviderName: base.selectedProviderName,
+      todayTokens: todayTokens,
+      daily: daily,
+      quotas: base.quotas,
+      usageSources: base.usageSources?.map { source in
+        source.id == RouterWidgetSnapshot.defaultUsageSourceID
+          ? RouterWidgetUsageSource(
+              id: source.id,
+              name: source.name,
+              todayTokens: todayTokens,
+              daily: daily
+            )
+          : source
+      }
+    )
   }
 }


### PR DESCRIPTION
## Problem

`RouterWidgetDailyPoint` had no provenance, so `routerWidgetDailyPoints()` published a router-only day as a flat **zero** rather than misreport this Mac's traffic as a global account total. That traded overstating for understating.

OpenAI does not publish a bucket for the current day until it settles, and it omits quiet days outright. So a normal working day rendered as a confident "0 tokens today" on the desktop widget while the router had measured **128,567,735** tokens for that same day.

## Fix

Carry the flag and let the presentation say which number it is showing.

- `RouterWidgetDailyPoint` gains `isRouterFallback`, **encoded only when true** and decoded as `false` when absent. The flag is additive within schema 1, so a host and an extension on either side of an app update keep reading each other's snapshots instead of falling back to "Waiting for router data".
- `RouterWidgetUsageSource.todayIsRouterFallback` exposes the case that matters for a headline number: today is the point most likely to be router-only, because the account stream lags the current day.
- The widget labels a router-filled today **"this Mac · account not reported yet"** in place of "account tokens".
- The cumulative chart dashes any segment arriving at a router-filled day, matching how the tray already hatches those bars. The line stays continuous so the shape still reads, while the dashes keep a router-only stretch from passing as account history.

## Verification

Built and installed on a live machine. The widget snapshot before and after, for the same day:

```
before:  todayTokens 0
after:   todayTokens 128,567,735   isRouterFallback true
```

Tray suite: 127 tests pass, including the widget-fallback cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)