### PR TITLE
fix(commandcode): align forced tool choice with bounded aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Command Code forced tool choices now use the same bounded alias as the tool definition.**
+  The 64-character compatibility added in #643 shortened provider-facing tool names but
+  left an object `tool_choice` at the client's original spelling, so a forced long tool
+  could still be rejected as unknown. Forced choices for both Command Code variants now
+  pass through the same reversible namespace alias map as the advertised tools.
 - **Command Code no longer rejects a routed turn over a long tool name or a
   recursive schema.** A Codex turn carrying a client tool such as
   `mcp__openai_api_key_local_confirmation__confirm_openai_api_key_local_destination`

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -3171,11 +3171,15 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
       tools = repairToolSchemaRoots(tools, { nonRecursive: true });
     }
   }
-  // The stored call history must use the same tool names as the tool list, or
-  // the model copies the bare names out of its own transcript.
+  // Stored call history and forced choices must use the same tool names as the
+  // provider-facing list, or the model/request validator sees two identities.
   if (namespacesFlattened) {
     routedInput = flattenNamespacedHistory(routedInput, flattenedNamespaces);
-    if (provider?.id === "groq") {
+    if (
+      provider?.id === "groq" ||
+      provider?.id === "commandcode" ||
+      provider?.id === "commandcode-messages"
+    ) {
       routedToolChoice = flattenToolChoice(
         routedToolChoice,
         flattenedNamespaces,

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -1538,6 +1538,44 @@ test("Command Code models restore MCP calls Codex pre-flattened before the route
   }
 });
 
+test("Command Code forced tool choice uses the same bounded alias as its tool", async () => {
+  const longName =
+    "mcp__openai_api_key_local_confirmation__confirm_openai_api_key_local_destination";
+  assert.equal(longName.length, 80);
+
+  for (const model of [
+    "commandcode/deepseek-v4-flash",
+    "commandcode-messages/claude-fable-5.1",
+  ]) {
+    const result = await scenario(false, {
+      model,
+      requestPayload: (stream, routeModel) => ({
+        model: routeModel,
+        stream,
+        input: "Call the required tool.",
+        tools: [{
+          type: "function",
+          name: longName,
+          parameters: { type: "object", properties: {}, additionalProperties: false },
+        }],
+        tool_choice: { type: "function", name: longName },
+      }),
+      jsonBody: () => ({ id: "commandcode_choice", output: [] }),
+    });
+
+    assert.equal(result.gatewayBodies.length, 1, model);
+    const outgoing = result.gatewayBodies[0];
+    const providerTool = outgoing.tools.find((tool) => tool.name !== "web_search");
+    assert.ok(providerTool.name.length <= 64, model);
+    assert.notEqual(providerTool.name, longName, model);
+    assert.deepEqual(
+      outgoing.tool_choice,
+      { type: "function", name: providerTool.name },
+      model,
+    );
+  }
+});
+
 test("bounded routes preserve one alias for pre-flattened MCP definitions and history", async () => {
   const namespace = "mcp__neon__apm__production__snapshot__read_only";
   const name = "get_monitor_snapshot_with_complete_context";


### PR DESCRIPTION
## Problem

Follow-up to merged #643. Command Code now bounds provider-facing tool names to 64 characters, but `buildRoutedRequest()` only rewrote `tool_choice` aliases for Groq (and the separate Console Go path). A forced Command Code choice could therefore keep the client's original 80-character name while the advertised tool used a hashed <=64-character alias, producing two identities in one request.

## Fix

- When namespace/tool names are flattened for `commandcode` or `commandcode-messages`, pass object `tool_choice` through the same reversible alias map as the tool list and stored history.
- Keep all other provider behavior unchanged.
- Add an end-to-end router regression for both Command Code provider variants using the exact 80-character tool from #626/#643.

## Verification

After normally merging current upstream `main` (`c2b2bd1`, including #658, #659, and #660) into this branch without rebasing or force-pushing:

- `test/namespace-relay-routing.test.mjs`: **23/23 pass**, including the forced Command Code alias regression.
- `node scripts-check.mjs`: pass (`v2-agent applications valid (6)`, syntax checks passed).
- `git diff --check` against current `main`: pass.
- Resulting PR diff remains isolated to the original three files.
- Current branch head: `cb9991d66120880a4ab0203547037d9923838d3b`.