### PR TITLE
fix(dashboard): cover the full rolling 24h window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **The dashboard 24H chart now covers the exact rolling 24-hour window.** The
+  hourly rollup added in #644 aligned bars to clock hours but began at the
+  next whole hour after `now - 24h`, dropping up to almost one hour of valid
+  traffic. The router and legacy renderer fallback now retain both partial edge
+  hours while filtering events to the exact half-open `[now - 24h, now)` window.
 - **Command Code no longer rejects a routed turn over a long tool name or a
   recursive schema.** A Codex turn carrying a client tool such as
   `mcp__openai_api_key_local_confirmation__confirm_openai_api_key_local_destination`

--- a/apps/control-center/src/pages/DashboardPage.tsx
+++ b/apps/control-center/src/pages/DashboardPage.tsx
@@ -1161,16 +1161,22 @@ function buildHourlyTrafficBuckets(
   now: number,
 ): TrafficBucket[] {
   if (hours?.length) return hourlyBucketsFromRollup(hours);
-  const anchor = new Date(now);
-  anchor.setMinutes(0, 0, 0);
-  const first = anchor.getTime() - (23 * HOUR_MS);
+  const windowStart = now - 24 * HOUR_MS;
+  const firstAnchor = new Date(windowStart);
+  firstAnchor.setMinutes(0, 0, 0);
+  const lastAnchor = new Date(now);
+  lastAnchor.setMinutes(0, 0, 0);
+  const first = firstAnchor.getTime();
+  const lastHour = lastAnchor.getTime();
+  const lastBucket = now === lastHour ? lastHour - HOUR_MS : lastHour;
+  const bucketCount = Math.floor((lastBucket - first) / HOUR_MS) + 1;
   const formatter = new Intl.DateTimeFormat("en-US", { hour: "numeric" });
   const fullFormatter = new Intl.DateTimeFormat("en-US", {
     month: "short",
     day: "numeric",
     hour: "numeric",
   });
-  const buckets = Array.from({ length: 24 }, (_, index) => {
+  const buckets = Array.from({ length: bucketCount }, (_, index) => {
     const start = new Date(first + index * HOUR_MS);
     return {
       key: start.toISOString(),
@@ -1187,7 +1193,7 @@ function buildHourlyTrafficBuckets(
   });
   for (const event of events ?? []) {
     const at = Date.parse(event.at);
-    if (!Number.isFinite(at) || at < first || at >= anchor.getTime() + HOUR_MS) continue;
+    if (!Number.isFinite(at) || at < windowStart || at >= now) continue;
     const index = Math.floor((at - first) / HOUR_MS);
     if (index < 0 || index >= buckets.length) continue;
     const bucket = buckets[index];

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -584,12 +584,19 @@ export function hourlyUsageRollup({
   readEvents = recentUsageEvents,
 } = {}) {
   const span = Math.max(1, Math.min(24 * 31, Math.floor(hours) || 0));
-  // Bucket edges are local hour boundaries, matching the labels the chart
-  // formats from each bucket's own start.
-  const anchor = new Date(now);
-  anchor.setMinutes(0, 0, 0);
-  const first = anchor.getTime() - (span - 1) * HOUR_MS;
-  const buckets = Array.from({ length: span }, (_, index) => ({
+  // Keep clock-hour labels, but cover the exact rolling window. When `now`
+  // sits between hour boundaries, the window touches both an oldest partial
+  // hour and the current partial hour, so it can span `hours + 1` clock buckets.
+  const windowStart = now - span * HOUR_MS;
+  const firstAnchor = new Date(windowStart);
+  firstAnchor.setMinutes(0, 0, 0);
+  const lastAnchor = new Date(now);
+  lastAnchor.setMinutes(0, 0, 0);
+  const first = firstAnchor.getTime();
+  const lastHour = lastAnchor.getTime();
+  const lastBucket = now === lastHour ? lastHour - HOUR_MS : lastHour;
+  const bucketCount = Math.floor((lastBucket - first) / HOUR_MS) + 1;
+  const buckets = Array.from({ length: bucketCount }, (_, index) => ({
     startedAt: new Date(first + index * HOUR_MS).toISOString(),
     tokens: 0,
     requests: 0,
@@ -601,12 +608,12 @@ export function hourlyUsageRollup({
   }));
   // Reading the whole window is the point: the cap this replaces is the defect.
   const events = readEvents({
-    sinceMs: Math.max(HOUR_MS, Date.now() - first),
+    sinceMs: Math.max(HOUR_MS, now - first),
     limit: Number.POSITIVE_INFINITY,
   });
   for (const event of events) {
     const at = Date.parse(event?.at);
-    if (!Number.isFinite(at)) continue;
+    if (!Number.isFinite(at) || at < windowStart || at >= now) continue;
     const index = Math.floor((at - first) / HOUR_MS);
     if (index < 0 || index >= buckets.length) continue;
     const bucket = buckets[index];

--- a/test/router-dashboard-ui.test.mjs
+++ b/test/router-dashboard-ui.test.mjs
@@ -54,6 +54,9 @@ test("the hourly traffic chart reads the router rollup instead of the capped eve
   assert.match(page, /function hourlyBucketsFromRollup/);
   assert.match(page, /buildTrafficBuckets\(events, providerUsage, eventHours, trafficRange/);
   assert.match(page, /target\?\.usageEventHours/);
+  assert.match(hourly, /const windowStart = now - 24 \* HOUR_MS/);
+  assert.match(hourly, /Array\.from\(\{ length: bucketCount \}/);
+  assert.match(hourly, /at < windowStart \|\| at >= now/);
 
   const control = (await readFile(new URL("../src/control.mjs", import.meta.url), "utf8"))
     .replace(/\r\n/g, "\n");

--- a/test/usage-events.test.mjs
+++ b/test/usage-events.test.mjs
@@ -440,7 +440,7 @@ test("the aging benchmark classifies shaped-only turns as compacted", () => {
 
 test("the hourly rollup aggregates the whole window, not a capped sample", async () => {
   const { hourlyUsageRollup } = await import("../src/usage-events.mjs");
-  const now = Date.parse("2026-09-06T17:30:00.000Z");
+  const now = Date.parse("2026-09-06T17:30:37.000Z");
   const hour = 3_600_000;
   // 4,000 rows across the window: many more than recentUsageEvents' 1,000-row
   // default, and the reason the chart could not be built from that sample.
@@ -458,20 +458,41 @@ test("the hourly rollup aggregates the whole window, not a capped sample", async
 
   assert.equal(seen.length, 1);
   assert.equal(seen[0].limit, Number.POSITIVE_INFINITY);
-  assert.equal(buckets.length, 24);
+  assert.equal(buckets.length, 25);
   assert.equal(buckets.reduce((sum, bucket) => sum + bucket.requests, 0), 4_000);
   assert.equal(buckets.reduce((sum, bucket) => sum + bucket.tokens, 0), 400_000);
-  assert.ok(buckets.every((bucket) => bucket.requests > 0), "every hour should be filled");
+  assert.equal(buckets.filter((bucket) => bucket.requests > 0).length, 24);
+  assert.ok(seen[0].sinceMs >= 24 * hour && seen[0].sinceMs < 25 * hour);
   assert.deepEqual(
     buckets.map((bucket) => bucket.startedAt).slice().sort(),
     buckets.map((bucket) => bucket.startedAt),
   );
 });
 
+test("the hourly rollup keeps the oldest partial hour inside the rolling window", async () => {
+  const { hourlyUsageRollup } = await import("../src/usage-events.mjs");
+  const now = Date.parse("2026-09-06T17:30:37.000Z");
+  const hour = 3_600_000;
+  const buckets = hourlyUsageRollup({
+    now,
+    readEvents: () => [
+      { at: new Date(now - 24 * hour).toISOString(), model: "m", provider: "p", totalTokens: 20 },
+      { at: new Date(now - (23 * hour + 45 * 60_000)).toISOString(), model: "m", provider: "p", totalTokens: 10 },
+      { at: new Date(now - (24 * hour + 15 * 60_000)).toISOString(), model: "m", provider: "p", totalTokens: 1000 },
+      { at: new Date(now).toISOString(), model: "m", provider: "p", totalTokens: 1000 },
+    ],
+  });
+
+  assert.equal(buckets.length, 25);
+  assert.equal(buckets.reduce((sum, bucket) => sum + bucket.requests, 0), 2);
+  assert.equal(buckets.reduce((sum, bucket) => sum + bucket.tokens, 0), 30);
+  assert.equal(buckets[0].requests, 2, "the oldest partial clock hour is retained");
+});
+
 test("the hourly rollup mirrors the renderer's billed-token and cache-share math", async () => {
   const { hourlyUsageRollup } = await import("../src/usage-events.mjs");
-  const now = Date.parse("2026-09-06T17:30:00.000Z");
-  const at = new Date(now - 60_000).toISOString();
+  const now = Date.parse("2026-09-06T17:30:37.000Z");
+  const at = new Date(now - 1_000).toISOString();
   const buckets = hourlyUsageRollup({
     now,
     readEvents: () => [
@@ -498,10 +519,10 @@ test("the hourly rollup mirrors the renderer's billed-token and cache-share math
 test("an empty ledger still returns a full, honest set of hours", async () => {
   const { hourlyUsageRollup } = await import("../src/usage-events.mjs");
   const buckets = hourlyUsageRollup({
-    now: Date.parse("2026-09-06T17:30:00.000Z"),
+    now: Date.parse("2026-09-06T17:30:37.000Z"),
     readEvents: () => [],
   });
-  assert.equal(buckets.length, 24);
+  assert.equal(buckets.length, 25);
   assert.ok(buckets.every((bucket) => bucket.requests === 0 && bucket.tokens === 0));
   assert.ok(buckets.every((bucket) => !bucket.measuredTokens && !bucket.measuredBreakdown));
 });


### PR DESCRIPTION
## Problem

Follow-up to merged #644. The new uncapped hourly rollup used clock-hour buckets anchored at the start of the current hour. At e.g. 17:30 that covered only 23.5 hours, so traffic in the oldest partial hour (for example a request 23h45m old) was still dropped even though the dashboard and provider summary both say "last 24 hours".

## Fix

- Keep clock-hour labels, but measure the exact rolling half-open window `[now - 24h, now)`.
- When the rolling window crosses two partial clock hours, keep both edge buckets instead of forcing the data into only 24 clock buckets.
- Apply the same window semantics to the legacy Control Center fallback used when talking to an older router.
- Use the injected `now` consistently while reading/bucketing so tests and snapshots do not mix clocks.

## Verification

- Hourly usage rollup tests: **4/4 pass**, including the 23h45m-old boundary regression.
- Dashboard contract tests: **5/5 pass**.
- Root `npm run check`: pass.
- Control Center `tsc --noEmit`: pass.
- Electron JS syntax checks: pass.
- Direct Vite production build: pass (1,863 modules transformed).
- `git diff --check`: pass.