### PR TITLE
fix(grok-oauth): preserve worker progress and reject unsuccessful turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Routed workers expose read-only request progress.** `bin/control activity
+  [thread-id]` reports active requests and bounded recent outcomes behind the
+  caller capability, including observed stream events and cancellation causes.
+  Quiet polling never ends a request, and the shipped agent guidance separates
+  polling intervals from worker deadlines.
+- **Grok repairs require a successful response terminal.** Failed, incomplete,
+  and truncated streams return a terminal error without releasing withheld
+  client actions or private final answers. Reasoning remains live.
 - **The ChatGPT Web provider is removed: using it risked an OpenAI account
   ban.** `chatgpt-web` routed Codex turns into an unofficial browser automation
   of chatgpt.com, driven through a separately installed launcher on loopback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - **Grok repairs require a successful response terminal.** Failed, incomplete,
   and truncated streams return a terminal error without releasing withheld
   client actions or private final answers. Reasoning remains live.
+- **Grok gateway stream errors reach Codex as terminal failures.** Untyped
+  gateway errors are normalized without exposing upstream diagnostics or
+  appending empty message closes, and request activity records the failure.
 - **The ChatGPT Web provider is removed: using it risked an OpenAI account
   ban.** `chatgpt-web` routed Codex turns into an unofficial browser automation
   of chatgpt.com, driven through a separately installed launcher on loopback

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -393,6 +393,24 @@ is correct." is not talked into a call the client would then run. Raise
 `CODEX_ROUTER_GROK_PROGRESS_ONLY_MAX_TEXT` to fire less often on that
 user-message path; those settings do not weaken the post-tool invariant.
 
+For a quiet worker, run `bin/control activity <thread-id>` from the installed
+checkout. The command reads the capability-protected `/v1/activity` endpoint;
+unauthenticated `/health` keeps its existing compact contract. Active requests
+remain visible until their handlers release resources, independently of tray
+record retention. The snapshot includes router-upstream attempt count, byte/event
+timestamps, observed phase, and recent outcomes (128 entries, ten minutes, in
+memory). These observations do not identify raw provider timing or retries inside
+LiteLLM/xAI. Metrics cover the main Responses dispatch/stream; uninstrumented
+subpaths such as compaction/embeddings show `unobserved` and omit attempt count.
+An HTTP 200 envelope with a failed/incomplete response event is still `failed`.
+No prompt, answer, tool arguments, or credentials are retained.
+An unavailable probe reports `unknown`, not an empty/completed worker. A changed
+instance ID means the router restarted and lost its recent history. A cancellation
+records a client disconnect or an execution deadline; a disconnect cannot identify
+whether the user or a parent agent initiated it. Wait timeouts and quiet streams
+are not authorization to replace a worker. Consult its native task state and
+confirm that the old writer has stopped before starting another.
+
 Both attempts are billed. The usage returned to Codex reports only the
 selected attempt's context size, while the local ledger retains the aggregate
 as billed input/output tokens. The response sets

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -397,12 +397,14 @@ For a quiet worker, run `bin/control activity <thread-id>` from the installed
 checkout. The command reads the capability-protected `/v1/activity` endpoint;
 unauthenticated `/health` keeps its existing compact contract. Active requests
 remain visible until their handlers release resources, independently of tray
-record retention. The snapshot includes router-upstream attempt count, byte/event
-timestamps, observed phase, and recent outcomes (128 entries, ten minutes, in
-memory). These observations do not identify raw provider timing or retries inside
+record retention. The snapshot includes router-upstream attempt count, raw byte
+timestamps, normalized Responses event timestamps, observed phase, and recent
+outcomes (128 entries, ten minutes, in memory). These observations do not identify raw provider timing or retries inside
 LiteLLM/xAI. Metrics cover the main Responses dispatch/stream; uninstrumented
 subpaths such as compaction/embeddings show `unobserved` and omit attempt count.
 An HTTP 200 envelope with a failed/incomplete response event is still `failed`.
+Untyped Grok gateway error envelopes become a safe terminal `error` event;
+later empty message closes or success markers are discarded.
 No prompt, answer, tool arguments, or credentials are retained.
 An unavailable probe reports `unknown`, not an empty/completed worker. A changed
 instance ID means the router restarted and lost its recent history. A cancellation

--- a/skills/codex-router/SKILL.md
+++ b/skills/codex-router/SKILL.md
@@ -66,8 +66,9 @@ never overlap two writers for the same work.
 When shell access is available, inspect the installed router with
 `~/.local/share/codex-router/bin/control activity <thread-id>` (omit the ID for
 all requests). This is read-only. It reports active requests and up to 128 recent
-results retained for ten minutes. `lastEventAt`/`lastByteAt` describe events
-received at the router's upstream boundary, not raw xAI progress. An open request
+results retained for ten minutes. `lastByteAt` describes raw bytes received at
+the router's upstream boundary; `lastEventAt` describes normalized Responses
+events, not raw xAI progress. An open request
 alone does not prove generation. An empty result, an offline probe, or a changed
 `instanceId` does not prove the worker finished; check the native task status.
 `canceling` stays active until cleanup; `client_disconnected` cannot identify

--- a/skills/codex-router/SKILL.md
+++ b/skills/codex-router/SKILL.md
@@ -63,17 +63,15 @@ cancellation, or a task deadline established independently of the polling interv
 Before replacement, check the worker's current state and confirm it has stopped;
 never overlap two writers for the same work.
 
-When shell access is available, inspect the installed router with
-`~/.local/share/codex-router/bin/control activity <thread-id>` (omit the ID for
-all requests). This is read-only. It reports active requests and up to 128 recent
-results retained for ten minutes. `lastByteAt` describes raw bytes received at
-the router's upstream boundary; `lastEventAt` describes normalized Responses
-events, not raw xAI progress. An open request
-alone does not prove generation. An empty result, an offline probe, or a changed
-`instanceId` does not prove the worker finished; check the native task status.
-`canceling` stays active until cleanup; `client_disconnected` cannot identify
-whether the user or an orchestrator initiated cancellation. Polling never changes
-these states or restarts a task.
+Use the read-only `~/.local/share/codex-router/bin/control activity <thread-id>`
+when shell access is available; omit the ID for all requests. It reports active
+requests and up to 128 recent results retained for ten minutes. `lastByteAt`
+tracks raw bytes at the router boundary; `lastEventAt` tracks normalized Responses
+events, not raw xAI progress. An open request alone does not prove generation.
+Empty/offline results or a changed `instanceId` do not prove worker completion;
+check native task status. `canceling` stays active until cleanup, and
+`client_disconnected` cannot distinguish user cancellation from an orchestrator's.
+Polling never changes these states or restarts a task.
 
 ## What the token and usage numbers mean
 

--- a/skills/codex-router/SKILL.md
+++ b/skills/codex-router/SKILL.md
@@ -54,6 +54,26 @@ arguments are model-generated and must not silently cross a provider or billing
 boundary. Follow-up messages retain the target thread's settings, and cloud
 tasks choose their model outside this relay.
 
+## Waiting for a routed worker
+
+A wait/poll timeout or quiet stream is not a failed worker. Keep its task ID
+and wait again; do not interrupt, resend its assignment, or spawn a replacement
+only because a poll returned. End waiting on an explicit terminal result, user
+cancellation, or a task deadline established independently of the polling interval.
+Before replacement, check the worker's current state and confirm it has stopped;
+never overlap two writers for the same work.
+
+When shell access is available, inspect the installed router with
+`~/.local/share/codex-router/bin/control activity <thread-id>` (omit the ID for
+all requests). This is read-only. It reports active requests and up to 128 recent
+results retained for ten minutes. `lastEventAt`/`lastByteAt` describe events
+received at the router's upstream boundary, not raw xAI progress. An open request
+alone does not prove generation. An empty result, an offline probe, or a changed
+`instanceId` does not prove the worker finished; check the native task status.
+`canceling` stays active until cleanup; `client_disconnected` cannot identify
+whether the user or an orchestrator initiated cancellation. Polling never changes
+these states or restarts a task.
+
 ## What the token and usage numbers mean
 
 - The router meter records provider-reported counts verbatim. When the

--- a/src/control-activity.mjs
+++ b/src/control-activity.mjs
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { assertCallerSecret, callerBaseUrl } from "./caller-auth.mjs";
+import { CALLER_SECRET_PATH, PORTS } from "./paths.mjs";
+
+// No provider request, model invocation, or task mutation is made by this probe.
+// Keep capability URLs out of both errors and the JSON returned to an agent.
+export async function readControlActivity({
+  threadId,
+  fetchImpl = globalThis.fetch,
+  readCallerSecret = () => readFileSync(CALLER_SECRET_PATH, "utf8"),
+  routerPort = PORTS.router,
+  timeoutMs = 3_000,
+} = {}) {
+  const unavailable = (error) => ({ ok: false, state: "unknown", error });
+  if (threadId !== undefined && !/^[A-Za-z0-9_-]{1,160}$/.test(threadId)) {
+    return unavailable("Invalid thread ID.");
+  }
+  let callerSecret;
+  try { callerSecret = assertCallerSecret(readCallerSecret().trim()); }
+  catch { return unavailable("The local router caller key is unavailable."); }
+  try {
+    const query = threadId ? `?threadId=${encodeURIComponent(threadId)}` : "";
+    const response = await fetchImpl(`${callerBaseUrl(routerPort, callerSecret)}/activity${query}`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+      redirect: "error",
+    });
+    if (!response.ok) return unavailable("Router activity is unavailable; the router may need updating.");
+    const body = await response.json();
+    if (body?.version !== 1 || !Array.isArray(body.active) || !Array.isArray(body.recent)) {
+      return unavailable("Router activity returned an unsupported response.");
+    }
+    return {
+      ok: true,
+      version: 1,
+      instanceId: body.instanceId,
+      observedAt: body.observedAt,
+      observationPoint: "router_upstream",
+      active: body.active.map(safeRecord),
+      recent: body.recent.map(safeRecord),
+    };
+  } catch {
+    return unavailable("Router activity could not be read.");
+  }
+}
+
+function safeRecord(record) {
+  const result = {};
+  if (!record || typeof record !== "object") return result;
+  for (const key of ["requestId", "state", "phase", "provider", "model", "threadId", "parentThreadId", "sessionId", "agentName", "cancelReason", "terminalEvent", "observationPoint"]) {
+    if (typeof record[key] === "string" && record[key].length <= 160) result[key] = record[key];
+  }
+  for (const key of ["startedAt", "endedAt", "status", "upstreamAttempts", "receivedBytes", "receivedEvents", "lastHeadersAt", "lastEventAt", "lastByteAt", "cancelRequestedAt"]) {
+    if (Number.isFinite(record[key]) && record[key] >= 0) result[key] = record[key];
+  }
+  if (typeof record.isSubagent === "boolean") result.isSubagent = record.isSubagent;
+  return result;
+}

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { pickerCommandArgs } from "./control-args.mjs";
 import { readControlHealth } from "./control-health.mjs";
+import { readControlActivity } from "./control-activity.mjs";
 import { nativeSubagentCertification, promoteNativeMultiAgent } from "./catalog.mjs";
 import {
   applyModelOverlayPublication,
@@ -3450,6 +3451,9 @@ if (args.includes("--probe")) {
   await handleChatGptSession(args[1]);
 } else if (args[0] === "chatgpt-account-pool") {
   await handleChatGptAccountSwitch(args[1], args[2], args[3]);
+} else if (args[0] === "activity") {
+  if (args.length > 2) throw new Error("Usage: control activity [thread-id]");
+  process.stdout.write(`${JSON.stringify(await readControlActivity({ threadId: args[1] }))}\n`);
 } else if (args[0] === "health") {
   await printHealth();
 } else if (args[0] === "maintenance") {

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -664,6 +664,25 @@ async function handleChatCompletions(request, response) {
   // Once the head is committed, a failed repair becomes one terminal SSE error.
   if (wantsStream) startStream();
 
+  const rejectUnsuccessfulTurn = (turn, phase, attempt) => {
+    if (turn.terminalStatus === "completed") return false;
+    const status = turn.terminalStatus;
+    const message = status === "missing"
+      ? "Grok ended the upstream response stream without a successful terminal event."
+      : `Grok returned an unsuccessful upstream response (${status}).`;
+    console.error(
+      `[grok-oauth] upstream-terminal-failed=true phase=${phase} model=${model} terminal=${status} ${upstreamAttemptTiming(phase, attempt)}`,
+    );
+    if (wantsStream && streamStarted) {
+      endStreamedResponse(response, { message });
+    } else {
+      writeJson(response, 502, {
+        error: { type: "api_error", code: `grok_upstream_response_${status}`, message },
+      });
+    }
+    return true;
+  };
+
   const emitHeldStrictContent = () => {
     if (!wantsStream || !streamStarted || heldStrictContentDeltas.length === 0) return;
     for (const delta of heldStrictContentDeltas) {
@@ -720,6 +739,10 @@ async function handleChatCompletions(request, response) {
   }
 
   let turn = finalizeTurn(turnState);
+  // Never repair or replay an unsuccessful first attempt. Its live tool
+  // deltas may already have reached the client; only one terminal error is
+  // legal now. Withheld/backfilled deltas stay withheld on failure.
+  if (rejectUnsuccessfulTurn(turn, "attempt", firstAttempt)) return;
   emitPendingDeltas();
   let retried = false;
   let repairFailure;
@@ -786,6 +809,10 @@ async function handleChatCompletions(request, response) {
         throw error;
       }
       const second = finalizeTurn(secondState);
+      // Keep both client tools and the private final answer withheld until
+      // response.completed. An item.done followed by EOF/failure is not a
+      // certified repair, even when its arguments look complete.
+      if (rejectUnsuccessfulTurn(second, "repair", repairAttempt)) return;
       retried = true;
       const repair = strictAfterToolRepair
         ? classifyAfterToolRepair(second)
@@ -814,6 +841,7 @@ async function handleChatCompletions(request, response) {
             ? toolCallDeltas(second)
             : [...turn.deltas, ...toolCallDeltas(second)],
           finishReason: "tool_calls",
+          terminalStatus: "completed",
         };
         if (streamStarted) emittedDeltaCount = turn.deltas.length;
       } else if (repair.action === "final") {
@@ -830,6 +858,7 @@ async function handleChatCompletions(request, response) {
           usage: selectedRetryUsage(turn.usage, second.usage),
           deltas: [{ content: repair.contentText }],
           finishReason: "stop",
+          terminalStatus: "completed",
         };
         emittedDeltaCount = 0;
       } else if (repair.action === "fail") {

--- a/src/grok-oauth-turn.mjs
+++ b/src/grok-oauth-turn.mjs
@@ -95,7 +95,7 @@ export function isProgressOnlyStop(
     afterToolResult = false,
   } = {},
 ) {
-  if (!turn || (turn.toolCalls && turn.toolCalls.length > 0)) return false;
+  if (turn?.terminalStatus !== "completed" || turn.toolCalls?.length > 0) return false;
   // After a tool result, prose alone is never accepted as proof of completion.
   // It is repaired into either another client tool call or an internal final
   // answer, regardless of length. This is the invariant that prevents a long
@@ -110,7 +110,7 @@ export function isProgressOnlyStop(
 // Prefer the retry only when it actually called a tool. A second short
 // status sentence is not an improvement; keep the first answer.
 export function shouldPreferRetryTurn(second) {
-  return Boolean(second?.toolCalls?.length);
+  return second?.terminalStatus === "completed" && Boolean(second.toolCalls?.length);
 }
 
 // A repair turn after a tool result is a protocol decision, not a prose
@@ -118,6 +118,10 @@ export function shouldPreferRetryTurn(second) {
 // answer tool call requested above. Anything else is an invalid repair
 // and must become a visible router error rather than a clean `stop`.
 export function classifyAfterToolRepair(second) {
+  // An item-level close only finishes that call's arguments. It does not
+  // certify the response: failed, incomplete, and truncated attempts can all
+  // contain a complete-looking client call or private final-answer call.
+  if (second?.terminalStatus !== "completed") return { action: "fail" };
   const calls = Array.isArray(second?.toolCalls) ? second.toolCalls : [];
   if (calls.length !== 1) return { action: "fail" };
   const [call] = calls;
@@ -230,6 +234,7 @@ export function createTurnState({ toolNameMapper = (name) => name } = {}) {
     toolCalls: [],
     toolByItemId: new Map(),
     usage: undefined,
+    terminalStatus: undefined,
     deltas: [],
     toolNameMapper,
   };
@@ -330,6 +335,9 @@ function ensureToolCall(state, item, itemId, { complete = false } = {}) {
 
 export function applyResponsesEvent(state, event) {
   if (!event || typeof event !== "object") return state;
+  // Once an upstream failure is known, later frames cannot revive this turn
+  // or add actions to it. In particular, [DONE] is never success evidence.
+  if (state.terminalStatus === "failed" || state.terminalStatus === "incomplete") return state;
   switch (event.type) {
     case "response.output_text.delta": {
       if (event.delta) {
@@ -381,6 +389,21 @@ export function applyResponsesEvent(state, event) {
       break;
     }
     case "response.completed": {
+      const status = event.response?.status;
+      state.terminalStatus = !status || status === "completed"
+        ? "completed"
+        : status === "failed" ? "failed" : "incomplete";
+      state.usage = mapUpstreamUsage(event.response?.usage);
+      break;
+    }
+    case "response.failed":
+    case "error": {
+      state.terminalStatus = "failed";
+      state.usage = mapUpstreamUsage(event.response?.usage);
+      break;
+    }
+    case "response.incomplete": {
+      state.terminalStatus = "incomplete";
       state.usage = mapUpstreamUsage(event.response?.usage);
       break;
     }
@@ -391,14 +414,18 @@ export function applyResponsesEvent(state, event) {
 }
 
 export function finalizeTurn(state) {
-  backfillToolArgumentDeltas(state);
+  const terminalStatus = state.terminalStatus || "missing";
+  if (terminalStatus === "completed") backfillToolArgumentDeltas(state);
   return {
     contentText: state.contentText,
     reasoningText: state.reasoningText,
     toolCalls: state.toolCalls,
     usage: state.usage,
     deltas: state.deltas,
-    finishReason: state.toolCalls.length ? "tool_calls" : "stop",
+    terminalStatus,
+    finishReason: terminalStatus === "completed"
+      ? state.toolCalls.length ? "tool_calls" : "stop"
+      : null,
   };
 }
 

--- a/src/grok-reasoning-summary-compat.mjs
+++ b/src/grok-reasoning-summary-compat.mjs
@@ -154,6 +154,12 @@ function summaryText(item) {
     .join("");
 }
 
+function isGatewayErrorEnvelope(event) {
+  return event !== null && typeof event === "object" && !Array.isArray(event)
+    && !Object.hasOwn(event, "type")
+    && event.error !== null && typeof event.error === "object" && !Array.isArray(event.error);
+}
+
 // LiteLLM's Chat Completions -> Responses bridge can open an empty message
 // before Grok starts reasoning, and it hashes every reasoning delta into a
 // different item_id. Codex drops those orphaned deltas, so the user sees
@@ -172,6 +178,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
   #nextSequenceNumber;
   #repairedReasoningItems = [];
   #canonicalReasoningId;
+  #gatewayErrorTerminal = false;
 
   constructor({
     maxFrameBytes = MAX_FRAME_BYTES,
@@ -191,6 +198,10 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
 
   _transform(chunk, _encoding, callback) {
     try {
+      if (this.#gatewayErrorTerminal) {
+        callback();
+        return;
+      }
       const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       if (this.#disabled) {
         this.push(Buffer.from(piece));
@@ -201,7 +212,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
         this.#emitFrame(block, separator, original)
       ));
       if (outcome?.oversized) this.#unsafeFrame(outcome.oversized, "SSE frame byte limit");
-      if (outcome?.remainder?.length) this.push(outcome.remainder);
+      if (!this.#gatewayErrorTerminal && outcome?.remainder?.length) this.push(outcome.remainder);
       callback();
     } catch (error) {
       callback(error);
@@ -210,6 +221,11 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
 
   _flush(callback) {
     try {
+      if (this.#gatewayErrorTerminal) {
+        this.#frames.take();
+        callback();
+        return;
+      }
       if (this.#disabled) {
         const pending = this.#frames.take();
         if (pending.length) this.push(pending);
@@ -238,13 +254,17 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     const pieces = this.#rewriteBlock(text);
     const inferredSeparator = Buffer.from(text.includes("\r\n") ? "\r\n\r\n" : "\n\n");
     for (let index = 0; index < pieces.length; index += 1) {
-      const trailing = separator.length || index === pieces.length - 1
+      // The normalized terminal must be dispatchable even if the gateway
+      // closed its last JSON frame without a blank line.
+      const trailing = this.#gatewayErrorTerminal && !separator.length
+        ? inferredSeparator
+        : separator.length || index === pieces.length - 1
         ? separator
         : inferredSeparator;
       this.push(Buffer.concat([Buffer.from(pieces[index]), trailing]));
     }
     this.#currentSeparator = "";
-    return !this.#disabled;
+    return !this.#disabled && !this.#gatewayErrorTerminal;
   }
 
   #disable(original) {
@@ -412,6 +432,27 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     if (!parsed) return [block];
     const event = parsed.event;
     const type = event?.type;
+
+    // LiteLLM can turn a forwarder SSE error into an untyped gateway error,
+    // then append empty message closes. Recognize only the top-level envelope;
+    // text containing error-shaped JSON and canonical typed events stay intact.
+    if (isGatewayErrorEnvelope(event)) {
+      this.#commitMutation(parsed);
+      const prefix = this.#finishReasoning(parsed, "incomplete");
+      this.#pendingMessage = [];
+      this.#gatewayErrorTerminal = true;
+      // Gateway messages may contain stack traces or request payloads. Emit a
+      // fixed safe error and suppress the rest of this upstream stream.
+      return [...prefix, this.#syntheticBlock("error", {
+        code: "local_router_stream_failed",
+        message: "The Grok gateway could not complete the upstream response stream.",
+        param: null,
+      }, {
+        ...parsed,
+        lines: ["event: error"],
+        newline: this.#currentSeparator === "\r\n\r\n" ? "\r\n" : parsed.newline,
+      })];
+    }
 
     if (!this.#reasoning && type === "response.output_item.added" && event?.item?.type === "message") {
       this.#message = {

--- a/src/request-progress.mjs
+++ b/src/request-progress.mjs
@@ -1,0 +1,104 @@
+import { randomUUID } from "node:crypto";
+import { Transform } from "node:stream";
+
+const METADATA = ["provider", "model", "threadId", "parentThreadId", "sessionId", "agentName"];
+
+// Diagnostics are independent of the tray's expiring presentation records.
+// A live request stays live until its handler settles; reading never cancels it.
+export function createRequestProgress({ now = Date.now, recentLimit = 128, recentTtlMs = 600_000 } = {}) {
+  const active = new Map();
+  const recent = [];
+  const instanceId = randomUUID();
+  let sequence = 0;
+  const prune = () => {
+    while (recent.length && (recent.length > recentLimit || now() - recent[0].endedAt > recentTtlMs)) {
+      recent.shift();
+    }
+  };
+  return {
+    begin() {
+      const record = {
+        requestId: `${instanceId}:${++sequence}`,
+        state: "running",
+        phase: "unobserved",
+        startedAt: now(),
+        observationPoint: "router_upstream",
+        receivedBytes: 0,
+        receivedEvents: 0,
+      };
+      active.set(record.requestId, record);
+      let finished = false;
+      const update = (fields) => { if (!finished) Object.assign(record, fields); };
+      return {
+        setRoute(metadata = {}) {
+          for (const key of METADATA) {
+            const value = metadata[key];
+            if (typeof value === "string" && value.length <= 160) update({ [key]: value });
+          }
+          if (typeof metadata.isSubagent === "boolean") update({ isSubagent: metadata.isSubagent });
+        },
+        attempt() {
+          if (record.state !== "running") return;
+          update({ upstreamAttempts: (record.upstreamAttempts || 0) + 1, phase: "awaiting_upstream", terminalEvent: undefined });
+        },
+        headers() {
+          update({ lastHeadersAt: now(), ...(record.state === "running" ? { phase: "awaiting_event" } : {}) });
+        },
+        event(payload) {
+          if (!payload || typeof payload !== "object") return;
+          const type = payload.type;
+          let phase;
+          if (typeof type === "string" && type.startsWith("response.reasoning")) phase = "reasoning";
+          else if (type === "response.output_text.delta") phase = "text";
+          else if (type === "response.function_call_arguments.delta" ||
+            type === "response.custom_tool_call_input.delta" ||
+            ["function_call", "custom_tool_call"].includes(payload.item?.type)) phase = "tool_call";
+          else if (["response.completed", "response.failed", "response.incomplete", "error"].includes(type)) phase = "finishing";
+          const failed = ["response.failed", "response.incomplete", "error"].includes(type);
+          update({
+            ...(failed ? { terminalEvent: type } : {}),
+            lastEventAt: now(),
+            receivedEvents: record.receivedEvents + 1,
+            ...(record.state === "running" && phase ? { phase } : {}),
+          });
+        },
+        byteObserver() {
+          return new Transform({
+            transform(chunk, _encoding, callback) {
+              update({ lastByteAt: now(), receivedBytes: record.receivedBytes + chunk.length });
+              callback(null, chunk);
+            },
+          });
+        },
+        cancel(reason) {
+          if (record.state !== "running") return;
+          if (!["client_disconnected", "execution_deadline"].includes(reason)) return;
+          update({ state: "canceling", phase: "canceling", cancelReason: reason, cancelRequestedAt: now() });
+        },
+        finish(status) {
+          if (finished) return;
+          const state = status === 0 ? "canceled" : status >= 200 && status < 400 && !record.terminalEvent ? "completed" : "failed";
+          update({ state, phase: "settled", status, endedAt: now() });
+          finished = true;
+          active.delete(record.requestId);
+          recent.push({ ...record });
+          prune();
+        },
+      };
+    },
+    snapshot({ threadId } = {}) {
+      prune();
+      const matches = (entry) => !threadId || entry.threadId === threadId;
+      return {
+        version: 1,
+        instanceId,
+        observedAt: now(),
+        // No raw xAI timings, provider-internal retries, or worker lifecycle
+        // can be inferred from this local transport observation.
+        observationPoint: "router_upstream",
+        active: [...active.values()].filter(matches).map((entry) => ({ ...entry })),
+        recent: recent.filter(matches).map((entry) => ({ ...entry })),
+      };
+    },
+  };
+}

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -334,14 +334,16 @@ export class ResponseUsageTransform extends Transform {
   // first token appears, and counting that silence as generation is what makes
   // a fast model read as slow. See #192.
   #firstTokenAt;
+  #onEvent;
   #completedResponseObserved = false;
   #terminalErrorObserved = false;
 
   // `estimatedInputTokens` arrives only on routed requests large enough that a
   // reported zero cannot be true. Without it this transform observes and
   // forwards the response byte for byte, exactly as it always did.
-  constructor(contentType = "", { estimatedInputTokens } = {}) {
+  constructor(contentType = "", { estimatedInputTokens, onEvent } = {}) {
     super();
+    this.#onEvent = typeof onEvent === "function" ? onEvent : undefined;
     const declared = String(contentType).toLowerCase();
     this.#eventStream = declared.includes("text/event-stream");
     // The ChatGPT backend answers /responses with an SSE body and no
@@ -536,6 +538,8 @@ export class ResponseUsageTransform extends Transform {
   }
 
   #observe(payload) {
+    // Diagnostics must not change parsing, metering, or the relayed bytes.
+    try { this.#onEvent?.(payload); } catch { /* Observer failure is non-fatal. */ }
     this.#noteFirstToken(payload);
     if (payload?.type === "response.completed") this.#completedResponseObserved = true;
     const usage = tokenUsageFromPayload(payload);

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -164,6 +164,7 @@ import {
   supportsOpenAIModelEndpoint,
 } from "./openai-endpoint-policy.mjs";
 import { recordUsageEvent } from "./usage-events.mjs";
+import { createRequestProgress } from "./request-progress.mjs";
 import {
   classifySsePrefix,
   HEADERLESS_SSE_SNIFF_BYTES,
@@ -376,6 +377,7 @@ const agentPayloadCacheMetrics = {
   coalesced: 0,
 };
 
+const requestProgress = createRequestProgress();
 let requestSequence = 0;
 const activityRecords = new Map();
 const inFlightRequests = new Map();
@@ -451,6 +453,7 @@ function beginRequestActivity({ request, response, controller } = {}) {
     error.code = "ERR_ROUTER_ACTIVE_REQUEST_LIMIT";
     throw error;
   }
+  const progress = requestProgress.begin();
   const requestId = ++requestSequence;
   const startedAt = Date.now();
   let finished = false;
@@ -459,6 +462,7 @@ function beginRequestActivity({ request, response, controller } = {}) {
   const finish = (status) => {
     if (finished) return;
     finished = true;
+    progress.finish(status);
     if (executionTimer) clearTimeout(executionTimer);
     activityRecords.delete(requestId);
     inFlightRequests.delete(requestId);
@@ -467,6 +471,7 @@ function beginRequestActivity({ request, response, controller } = {}) {
   const abortAtExecutionDeadline = () => {
     if (finished || deadlineExceeded) return;
     deadlineExceeded = true;
+    progress.cancel("execution_deadline");
     const error = new Error("Router request exceeded its execution deadline.");
     error.code = "ERR_ROUTER_REQUEST_TIMEOUT";
     error.status = 504;
@@ -484,8 +489,10 @@ function beginRequestActivity({ request, response, controller } = {}) {
   inFlightRequests.set(requestId, { startedAt });
   activityRecords.set(requestId, { startedAt });
   return {
+    progress,
     setRoute({ provider, model, sessionName, ...metadata } = {}) {
       if (!provider || finished) return;
+      progress.setRoute({ provider, model, ...metadata });
       // Once presentation bookkeeping expires, later route updates must not
       // resurrect it. The operation remains counted in `inFlightRequests`.
       if (!activityRecords.has(requestId)) return;
@@ -3440,6 +3447,7 @@ async function attemptModelFailover({
   normalizedInput,
   agingEnabled,
   searchContract,
+  progress,
 }) {
   const settings = readFailoverSettings();
   if (!settings.enabled) return undefined;
@@ -3494,12 +3502,14 @@ async function attemptModelFailover({
         logFailover(route, model, verdict.reason, status, "search-capability-changed");
         continue;
       }
+      progress?.attempt();
       upstream = await fetch(built.target, {
         method: "POST",
         headers: built.headers,
         body: built.body,
         signal,
       });
+      progress?.headers();
     } catch (error) {
       if (signal.aborted) throw error;
       const compatibilityCode = candidateBuildCompatibilityCode(error);
@@ -3565,6 +3575,12 @@ async function handleResponses(request, response, requestUrl) {
   const startedAt = Date.now();
   const controller = new AbortController();
   const activity = beginRequestActivity({ request, response, controller });
+  const fetchObservedUpstream = async (...args) => {
+    activity.progress.attempt();
+    const upstream = await fetch(...args);
+    activity.progress.headers();
+    return upstream;
+  };
   let clientGone = false;
   let requestedModel = "";
   let route;
@@ -3598,6 +3614,7 @@ async function handleResponses(request, response, requestUrl) {
   let usageRecorded = false;
   bindClientAbort(request, response, () => {
     clientGone = true;
+    activity.progress.cancel("client_disconnected");
     controller.abort();
   });
   try {
@@ -3902,6 +3919,7 @@ async function handleResponses(request, response, requestUrl) {
         // Routed traffic terminates at the local gateway, which has its own
         // error translation and Retry-After handling below; leave it exactly
         // as it was.
+        fetchImpl: fetchObservedUpstream,
         retries: route ? 0 : undefined,
         canRetry: () => nothingRelayed(response),
         onRetry: (event) => logUpstreamRetry(event, requestedModel, requestUrl.pathname),
@@ -3975,6 +3993,7 @@ async function handleResponses(request, response, requestUrl) {
         // rejection again.
         recordProviderCooldown(route.provider, verdict);
         const moved = await attemptModelFailover({
+          progress: activity.progress,
           request,
           response,
           payload,
@@ -4075,12 +4094,13 @@ async function handleResponses(request, response, requestUrl) {
     const upstreamContentType = upstream.headers.get("content-type") || "";
     const createResponsePipeline = (contentType) => {
       const usageObserver = new ResponseUsageTransform(contentType, {
+        onEvent: (payload) => activity.progress.event(payload),
         estimatedInputTokens:
           ZERO_INPUT_ESTIMATE && route
             ? estimateInputTokens(routedBody, { contextWindow: route.contextWindow })
             : undefined,
       });
-      const transforms = [usageObserver];
+      const transforms = [activity.progress.byteObserver(), usageObserver];
       let envelopeCompat = route
         ? zaiResponsesCompatTransform(route.provider, contentType)
         : undefined;
@@ -4274,6 +4294,7 @@ async function handleResponses(request, response, requestUrl) {
             signal: controller.signal,
           },
           {
+            fetchImpl: fetchObservedUpstream,
             retries: 0,
             canRetry: () => nothingRelayed(response),
             onRetry: (event) => logUpstreamRetry(event, requestedModel, requestUrl.pathname),
@@ -5123,6 +5144,15 @@ async function handleRequest(request, response) {
   ) {
     const health = await healthPayload();
     writeJson(response, health.ok ? 200 : 503, health);
+    return;
+  }
+  if (request.method === "GET" && ["/activity", "/v1/activity"].includes(requestUrl.pathname)) {
+    const threadId = requestUrl.searchParams.get("threadId") || undefined;
+    if (threadId && !/^[A-Za-z0-9_-]{1,160}$/.test(threadId)) {
+      writeJson(response, 400, { error: { type: "invalid_thread_id" } });
+      return;
+    }
+    writeJson(response, 200, requestProgress.snapshot({ threadId }));
     return;
   }
   if (request.method === "GET" && ["/models", "/v1/models"].includes(requestUrl.pathname)) {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -4117,7 +4117,10 @@ async function handleResponses(request, response, requestUrl) {
       const grokReasoningSummaryCompat = route
         ? grokReasoningSummaryCompatTransform(providerForModel(route), contentType)
         : undefined;
-      if (grokReasoningSummaryCompat) transforms.push(grokReasoningSummaryCompat);
+      // Grok gateway error envelopes are normalized along with its reasoning
+      // lifecycle. Observe the canonical terminal for metering and activity;
+      // the leading byte observer still measures the original upstream bytes.
+      if (grokReasoningSummaryCompat) transforms.splice(1, 0, grokReasoningSummaryCompat);
       // LiteLLM can add blank assistant envelopes while translating either
       // Chat Completions or Messages. The factory refuses native traffic and
       // providers that already speak Responses, so those paths gain no stage.

--- a/test/control-activity.test.mjs
+++ b/test/control-activity.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readControlActivity } from "../src/control-activity.mjs";
+
+const KEY = "test-caller-secret-0123456789abcdef";
+test("activity probe keeps credentials and payloads out of its projection", async () => {
+  const value = await readControlActivity({
+    threadId: "worker-1", routerPort: 43210, readCallerSecret: () => KEY,
+    fetchImpl: async (url, options) => {
+      assert.equal(url, `http://127.0.0.1:43210/_codex-router/${KEY}/v1/activity?threadId=worker-1`);
+      assert.equal(options.redirect, "error");
+      return { ok: true, json: async () => ({
+        version: 1, instanceId: "instance", observedAt: 123,
+        active: [{ requestId: "request", phase: "reasoning", lastEventAt: 122, credential: KEY, content: "private" }],
+        recent: [], credential: KEY,
+      }) };
+    },
+  });
+  assert.equal(value.ok, true);
+  assert.deepEqual(value.active, [{ requestId: "request", phase: "reasoning", lastEventAt: 122 }]);
+  assert.doesNotMatch(JSON.stringify(value), /private|test-caller-secret/);
+});
+
+test("offline, missing endpoint, bad ID and missing key are unknown, never a completed worker", async () => {
+  for (const options of [
+    { readCallerSecret: () => "invalid" },
+    { threadId: "bad/id" },
+    { fetchImpl: async () => ({ ok: false }) },
+    { fetchImpl: async () => { throw new Error(`failed ${KEY}`); } },
+    { fetchImpl: async () => ({ ok: true, json: async () => ({}) }) },
+  ]) {
+    const result = await readControlActivity({ readCallerSecret: () => KEY, ...options });
+    assert.equal(result.ok, false);
+    assert.equal(result.state, "unknown");
+    assert.equal(result.active, undefined);
+    assert.doesNotMatch(JSON.stringify(result), /test-caller-secret/);
+  }
+});

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -850,7 +850,7 @@ test("streams visible output before the upstream turn completes", async () => {
   }
 });
 
-test("streams a function call that appears only in a final unterminated SSE block", async () => {
+test("streams a done-only function call with an unterminated successful terminal SSE block", async () => {
   let inbound = 0;
   const backend = await mockBackend(async (_req, res) => {
     inbound += 1;
@@ -865,7 +865,8 @@ test("streams a function call that appears only in a final unterminated SSE bloc
         arguments: '{"cmd":"dir"}',
       },
     };
-    res.end(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n`);
+    res.write(sse([event]));
+    res.end('event: response.completed\ndata: {"type":"response.completed"}\n');
   });
   const port = await openPort();
   const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-final-block-"));
@@ -1362,6 +1363,210 @@ test("a streamed post-tool repair exposes reasoning and only the certified tool 
     assert.match(body, /"name":"exec_command"/);
     assert.match(body, /"finish_reason":"tool_calls"/);
     assert.match(body, /data: \[DONE\]/);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("post-tool repair releases held actions only after a successful terminal", async (t) => {
+  let scenario;
+  const backend = await mockBackend(async (_req, res) => {
+    const current = scenario;
+    current.inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    if (current.inbound === 1) {
+      res.end(sse([
+        { type: "response.output_text.delta", delta: "Uncertified progress." },
+        { type: "response.completed", response: { usage: { input_tokens: 100, output_tokens: 20 } } },
+      ]));
+      return;
+    }
+    const name = current.privateFinal ? "__codex_router_submit_final" : "exec_command";
+    const args = JSON.stringify(current.privateFinal
+      ? { answer: "Certified repair answer." }
+      : { cmd: "repair-command" });
+    res.write(sse([
+      { type: "response.output_item.added", item: { type: "function_call", id: "fc_repair", call_id: "call_repair", name } },
+      { type: "response.function_call_arguments.delta", item_id: "fc_repair", delta: args },
+      { type: "response.output_item.done", item: { type: "function_call", id: "fc_repair", call_id: "call_repair", name, arguments: args } },
+      // Reading this marker proves the preceding call frames were processed
+      // before the terminal gate is released; reasoning must remain live.
+      { type: "response.reasoning_summary_text.delta", delta: "Repair call prepared." },
+    ]));
+    current.repairReady.resolve();
+    await current.terminalGate.promise;
+    if (current.terminal === "eof") {
+      res.end("data: [DONE]\n\n");
+    } else if (current.terminal === "truncated") {
+      res.end('event: response.completed\ndata: {"type":"response.comp');
+    } else {
+      res.end(sse([{
+        type: `response.${current.terminal}`,
+        response: {
+          status: current.terminal,
+          usage: { input_tokens: 110, output_tokens: 30 },
+          ...(current.terminal === "failed" ? { error: { message: "private upstream failure detail" } } : {}),
+        },
+      }]));
+    }
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-repair-terminal-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  const within = async (promise, message) => {
+    let timeout;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise((_, reject) => { timeout = setTimeout(() => reject(new Error(message)), 2_000); }),
+      ]);
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+  try {
+    await waitHealth(base, child);
+    for (const stream of [false, true]) {
+      for (const privateFinal of [false, true]) {
+        for (const terminal of ["completed", "failed", "incomplete", "eof", "truncated"]) {
+          await t.test(`${stream ? "SSE" : "JSON"} ${privateFinal ? "private final" : "client tool"}: ${terminal}`, async () => {
+            scenario = { stream, privateFinal, terminal, inbound: 0,
+              repairReady: Promise.withResolvers(), terminalGate: Promise.withResolvers() };
+            const responsePromise = fetch(`${base}/v1/chat/completions`, {
+              method: "POST", headers: auth,
+              body: JSON.stringify({
+                model: "grok-4.6",
+                messages: [
+                  { role: "assistant", tool_calls: [{ id: "c1", type: "function", function: { name: "exec_command", arguments: "{}" } }] },
+                  { role: "tool", tool_call_id: "c1", content: "rendered page" },
+                ],
+                tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+                stream,
+              }),
+            });
+            try {
+              await within(scenario.repairReady.promise, "repair attempt did not start");
+              let resp;
+              let reader;
+              let body = "";
+              const decoder = new TextDecoder();
+              if (stream) {
+                resp = await within(responsePromise, "SSE response head stayed buffered");
+                reader = resp.body.getReader();
+                await within((async () => {
+                  while (!body.includes("Repair call prepared.")) {
+                    const { value, done } = await reader.read();
+                    if (done) throw new Error("response ended before the terminal gate");
+                    body += decoder.decode(value, { stream: true });
+                  }
+                })(), "repair reasoning stayed buffered");
+                assert.doesNotMatch(body, /Uncertified progress|tool_calls|repair-command|Certified repair answer|__codex_router_submit_final|\[DONE\]/);
+              }
+              scenario.terminalGate.resolve();
+              resp ??= await responsePromise;
+              if (reader) {
+                for (;;) {
+                  const { value, done } = await reader.read();
+                  if (done) break;
+                  body += decoder.decode(value, { stream: true });
+                }
+                body += decoder.decode();
+              } else {
+                body = await resp.text();
+              }
+              assert.equal(scenario.inbound, 2, "a failed repair must never replay");
+              assert.doesNotMatch(body, /Uncertified progress|__codex_router_submit_final|private upstream failure detail/);
+              if (terminal === "completed") {
+                assert.equal(resp.status, 200);
+                if (stream) {
+                  assert.equal((body.match(/data: \[DONE\]/g) || []).length, 1);
+                  assert.doesNotMatch(body, /event: error/);
+                  assert.equal((body.match(privateFinal ? /"content":"Certified repair answer\."/g : /"name":"exec_command"/g) || []).length, 1);
+                  assert.match(body, privateFinal ? /"finish_reason":"stop"/ : /"finish_reason":"tool_calls"/);
+                } else {
+                  const json = JSON.parse(body);
+                  assert.equal(json.choices[0].finish_reason, privateFinal ? "stop" : "tool_calls");
+                  if (privateFinal) assert.equal(json.choices[0].message.content, "Certified repair answer.");
+                  else assert.equal(json.choices[0].message.tool_calls[0].function.arguments, '{"cmd":"repair-command"}');
+                }
+              } else {
+                assert.doesNotMatch(body, /repair-command|Certified repair answer|"name":"exec_command"|"finish_reason":"(?:stop|tool_calls)"|\[DONE\]/);
+                if (stream) {
+                  assert.equal(resp.status, 200);
+                  assert.equal((body.match(/event: error/g) || []).length, 1);
+                  assert.match(body, /local_router_stream_failed/);
+                } else {
+                  assert.equal(resp.status, 502);
+                  assert.equal(JSON.parse(body).error.code, `grok_upstream_response_${["eof", "truncated"].includes(terminal) ? "missing" : terminal}`);
+                  assert.doesNotMatch(body, /choices|tool_calls/);
+                }
+              }
+            } finally {
+              scenario.terminalGate.resolve();
+              await responsePromise.then((resp) => resp.body?.cancel().catch(() => {})).catch(() => {});
+            }
+          });
+        }
+      }
+    }
+  } finally {
+    scenario?.terminalGate.resolve();
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an unsuccessful first turn emits one error without replaying its live client tool", async (t) => {
+  let terminal;
+  let inbound;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.write(sse(TOOL_EVENTS.filter((event) => event.type !== "response.completed")));
+    res.end(terminal === "missing" ? "data: [DONE]\n\n" : sse([{ type: `response.${terminal}` }]));
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-terminal-no-replay-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    for (terminal of ["failed", "incomplete", "missing"]) {
+      for (const stream of [false, true]) {
+        await t.test(`${stream ? "SSE" : "JSON"}: ${terminal}`, async () => {
+          inbound = 0;
+          const resp = await fetch(`${base}/v1/chat/completions`, {
+            method: "POST", headers: auth,
+            body: JSON.stringify({
+              model: "grok-4.6",
+              messages: [
+                { role: "assistant", tool_calls: [{ id: "c1", type: "function", function: { name: "exec_command", arguments: "{}" } }] },
+                { role: "tool", tool_call_id: "c1", content: "rendered page" },
+              ],
+              tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+              stream,
+            }),
+          });
+          const body = await resp.text();
+          assert.equal(inbound, 1);
+          assert.doesNotMatch(body, /"finish_reason":"(?:stop|tool_calls)"|\[DONE\]/);
+          if (stream) {
+            assert.equal(resp.status, 200);
+            assert.equal((body.match(/"name":"exec_command"/g) || []).length, 1);
+            assert.equal((body.match(/event: error/g) || []).length, 1);
+            assert.match(body, /local_router_stream_failed/);
+          } else {
+            assert.equal(resp.status, 502);
+            assert.equal(JSON.parse(body).error.code, `grok_upstream_response_${terminal}`);
+            assert.doesNotMatch(body, /tool_calls/);
+          }
+        });
+      }
+    }
   } finally {
     await stop(child);
     await new Promise((r) => backend.server.close(r));

--- a/test/grok-oauth-turn.test.mjs
+++ b/test/grok-oauth-turn.test.mjs
@@ -55,6 +55,7 @@ test("createTurnState can restore a provider-facing tool alias", () => {
       arguments: '{"path":"C:\\\\image.jpg"}',
     },
   });
+  applyResponsesEvent(state, { type: "response.completed" });
   const turn = finalizeTurn(state);
   assert.equal(turn.toolCalls[0].function.name, "view_image");
   assert.equal(turn.deltas[0].tool_calls[0].function.name, "view_image");
@@ -76,6 +77,7 @@ test("finalizeTurn backfills streamed arguments when added is followed by done w
         arguments: '{"cmd":"dir"}',
       },
     },
+    { type: "response.completed" },
   ]);
   const streamedArgs = turn.deltas
     .flatMap((delta) => delta.tool_calls || [])
@@ -102,6 +104,7 @@ test("collectResponsesEvents maps custom_tool_call onto a function tool call", (
         input: '{"x":1}',
       },
     },
+    { type: "response.completed" },
   ]);
   assert.equal(turn.toolCalls[0].id, "call_9");
   assert.equal(turn.toolCalls[0].function.name, "exec");
@@ -155,6 +158,7 @@ test("collectResponsesEvents maps xAI reasoning deltas onto reasoning_content", 
     { type: "response.reasoning_summary_text.delta", delta: "先想" },
     { type: "response.reasoning_text.delta", delta: "再想" },
     { type: "response.output_text.delta", delta: "答案" },
+    { type: "response.completed" },
   ]);
   assert.equal(turn.reasoningText, "先想再想");
   assert.equal(turn.contentText, "答案");
@@ -193,6 +197,7 @@ test("parseSseBlockEvent skips malformed JSON and leaves handlers to throw", () 
 
 test("isProgressOnlyStop requires short text, no tools, and enough output tokens", () => {
   const progress = {
+    terminalStatus: "completed",
     contentText: "Still thinking about it.",
     toolCalls: [],
     usage: { completion_tokens: 1660 },
@@ -211,6 +216,7 @@ test("isProgressOnlyStop requires short text, no tools, and enough output tokens
 
 test("isProgressOnlyStop retries a cheap stop after a tool result", () => {
   const stop = {
+    terminalStatus: "completed",
     contentText: "The figures are ready.",
     toolCalls: [],
     usage: { completion_tokens: 95 },
@@ -224,6 +230,7 @@ test("isProgressOnlyStop requires certification for long prose after a tool resu
   assert.equal(
     isProgressOnlyStop(
       {
+        terminalStatus: "completed",
         contentText: "This may look final, but the router cannot infer task completion. ".repeat(4),
         toolCalls: [],
         usage: { completion_tokens: 20 },
@@ -270,8 +277,8 @@ test("requestOffersClientTools ignores hosted-only or empty tool lists", () => {
 });
 
 test("shouldPreferRetryTurn keeps the first answer when the retry also has no tools", () => {
-  assert.equal(shouldPreferRetryTurn({ toolCalls: [] }), false);
-  assert.equal(shouldPreferRetryTurn({ toolCalls: [{ id: "c1" }] }), true);
+  assert.equal(shouldPreferRetryTurn({ terminalStatus: "completed", toolCalls: [] }), false);
+  assert.equal(shouldPreferRetryTurn({ terminalStatus: "completed", toolCalls: [{ id: "c1" }] }), true);
 });
 
 test("withProgressOnlyNudge appends a user message so the instructions prefix stays put", () => {
@@ -308,6 +315,7 @@ test("withProgressOnlyNudge leads with continue after a tool result", () => {
 test("classifyAfterToolRepair accepts only tools or a certified non-empty final answer", () => {
   assert.deepEqual(
     classifyAfterToolRepair({
+      terminalStatus: "completed",
       toolCalls: [{ id: "c1", function: { name: "exec_command", arguments: "{}" } }],
       contentText: "status",
     }),
@@ -315,17 +323,19 @@ test("classifyAfterToolRepair accepts only tools or a certified non-empty final 
   );
   assert.deepEqual(
     classifyAfterToolRepair({
+      terminalStatus: "completed",
       toolCalls: [
         { function: { name: REPAIR_FINAL_TOOL, arguments: JSON.stringify({ answer: "Done." }) } },
       ],
     }),
     { action: "final", contentText: "Done." },
   );
-  assert.deepEqual(classifyAfterToolRepair({ toolCalls: [], contentText: "Still working." }), {
+  assert.deepEqual(classifyAfterToolRepair({ terminalStatus: "completed", toolCalls: [], contentText: "Still working." }), {
     action: "fail",
   });
   assert.deepEqual(
     classifyAfterToolRepair({
+      terminalStatus: "completed",
       toolCalls: [
         { function: { name: REPAIR_FINAL_TOOL, arguments: JSON.stringify({ answer: "   " }) } },
       ],
@@ -333,10 +343,62 @@ test("classifyAfterToolRepair accepts only tools or a certified non-empty final 
     { action: "fail" },
   );
   assert.deepEqual(classifyAfterToolRepair({
+    terminalStatus: "completed",
     toolCalls: [{ function: { name: REPAIR_FINAL_TOOL, arguments: "{" } }],
   }), {
     action: "fail",
   });
+});
+
+test("only response.completed certifies a tool call or private final answer", () => {
+  for (const name of ["exec_command", REPAIR_FINAL_TOOL]) {
+    const call = {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call", id: "fc_terminal", call_id: "call_terminal", name,
+        arguments: JSON.stringify(name === REPAIR_FINAL_TOOL ? { answer: "Done." } : { cmd: "dir" }),
+      },
+    };
+    for (const terminalStatus of ["completed", "failed", "incomplete", "missing"]) {
+      const turn = collectResponsesEvents([
+        call,
+        ...(terminalStatus === "missing" ? [] : [{ type: `response.${terminalStatus}` }]),
+      ]);
+      assert.equal(turn.terminalStatus, terminalStatus);
+      assert.equal(turn.finishReason, terminalStatus === "completed" ? "tool_calls" : null);
+      assert.deepEqual(classifyAfterToolRepair(turn), terminalStatus === "completed"
+        ? name === REPAIR_FINAL_TOOL ? { action: "final", contentText: "Done." } : { action: "tools" }
+        : { action: "fail" });
+      assert.equal(shouldPreferRetryTurn(turn), terminalStatus === "completed");
+    }
+  }
+});
+
+test("a failed or missing terminal cannot become a progress-only retry", () => {
+  for (const terminalStatus of [undefined, "failed", "incomplete", "missing"]) {
+    const turn = { terminalStatus, contentText: "Continuing.", usage: { completion_tokens: 1660 } };
+    assert.equal(isProgressOnlyStop(turn), false);
+    assert.equal(isProgressOnlyStop(turn, { afterToolResult: true }), false);
+  }
+});
+
+test("an upstream failure cannot be revived by later completed or tool events", () => {
+  for (const failure of [
+    { type: "response.failed" },
+    { type: "response.incomplete" },
+    { type: "error" },
+    { type: "response.completed", response: { status: "failed" } },
+    { type: "response.completed", response: { status: "incomplete" } },
+  ]) {
+    const turn = collectResponsesEvents([
+      failure,
+      { type: "response.output_item.done", item: { type: "function_call", id: "late", name: "exec_command", arguments: "{}" } },
+      { type: "response.completed" },
+    ]);
+    assert.equal(turn.finishReason, null);
+    assert.equal(turn.toolCalls.length, 0);
+    assert.deepEqual(classifyAfterToolRepair(turn), { action: "fail" });
+  }
 });
 
 test("selectedRetryUsage reports selected context and separate aggregate billing", () => {

--- a/test/grok-reasoning-summary-compat.test.mjs
+++ b/test/grok-reasoning-summary-compat.test.mjs
@@ -703,6 +703,139 @@ test("resolves held lifecycles before failure terminals", async () => {
   ]);
 });
 
+const GATEWAY_ERROR = {
+  error: {
+    message: "list index out of range; private upstream payload",
+    type: "None", param: "None", code: "500",
+    stack: "private gateway stack",
+  },
+};
+
+function pendingGatewayMessage(newline = "\n", { reasoning = true } = {}) {
+  return [
+    block({ type: "response.created", sequence_number: 0, response: { id: "resp_gateway_error", status: "in_progress", output: [] } }, newline),
+    block({ type: "response.output_item.added", sequence_number: 1, output_index: 0, item: { id: "msg_gateway_error", type: "message", role: "assistant", status: "in_progress", content: [] } }, newline),
+    block({ type: "response.content_part.added", sequence_number: 2, item_id: "msg_gateway_error", output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }, newline),
+    ...(reasoning ? [block({ type: "response.reasoning_summary_text.delta", sequence_number: 3, item_id: "rs_gateway_error", output_index: 0, delta: "Проверка ещё идёт." }, newline)] : []),
+  ].join("");
+}
+
+function assertCanonicalGatewayError(raw, { reasoning = true } = {}) {
+  const output = events(raw);
+  const failures = output.filter((event) => event.type === "error");
+  assert.equal(failures.length, 1);
+  assert.equal(output.at(-1), failures[0]);
+  assert.equal(failures[0].code, "local_router_stream_failed");
+  assert.equal(failures[0].message, "The Grok gateway could not complete the upstream response stream.");
+  assert.equal(failures[0].param, null);
+  assert.match(raw, /event: error\r?\ndata:/u);
+  assert.doesNotMatch(raw, /private upstream payload|list index out of range|private gateway stack|msg_gateway_error|response.completed|\[DONE\]/u);
+  assert.equal(output.some((event) => event.item?.type === "message"), false);
+  const reasoningDone = output.filter((event) => event.type === "response.output_item.done");
+  assert.equal(reasoningDone.length, reasoning ? 1 : 0);
+  if (reasoning) {
+    assert.equal(reasoningDone[0].item.status, "incomplete");
+    assert.deepEqual(reasoningDone[0].item.summary, [{ type: "summary_text", text: "Проверка ещё идёт." }]);
+  }
+  return output;
+}
+
+test("normalizes fragmented Grok gateway error envelopes and drops every later frame", async () => {
+  for (const newline of ["\n", "\r\n"]) {
+    for (const chunkSize of [0, 1, 17]) {
+      const input = [
+        pendingGatewayMessage(newline),
+        block(GATEWAY_ERROR, newline),
+        block({ type: "response.output_text.done", item_id: "msg_gateway_error", output_index: 0, text: "" }, newline),
+        block({ type: "response.output_item.done", output_index: 0, item: { id: "msg_gateway_error", type: "message", status: "completed", content: [] } }, newline),
+        block({ type: "response.completed", response: { status: "completed", output: [] } }, newline),
+        block(GATEWAY_ERROR, newline),
+        `data: [DONE]${newline}${newline}`,
+        'data: {"unterminated":"pending gateway tail"}',
+      ].join("");
+      const raw = await transformed(input, chunkSize);
+      const output = assertCanonicalGatewayError(raw);
+      assert.deepEqual(output.map((event) => event.sequence_number), output.map((_event, index) => index));
+      if (newline === "\r\n") assert.equal(raw.replaceAll("\r\n", "").includes("\n"), false);
+    }
+  }
+});
+
+test("normalizes an unterminated gateway error and never flushes its pending message", async () => {
+  for (const newline of ["\n", "\r\n"]) {
+    for (const reasoning of [false, true]) {
+      const input = pendingGatewayMessage(newline, { reasoning })
+        + `event: message${newline}data: ${JSON.stringify(GATEWAY_ERROR)}`;
+      const raw = await transformed(input, 1);
+      assertCanonicalGatewayError(raw, { reasoning });
+      assert.ok(raw.endsWith(`${newline}${newline}`), "the canonical error must be a dispatchable SSE frame");
+    }
+  }
+});
+
+test("emits a gated gateway error before EOF and ignores later invalid or oversized bytes", async () => {
+  const stream = new GrokReasoningSummaryCompatTransform({ maxFrameBytes: 256, maxCommittedFrameBytes: 1024 });
+  let raw = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { raw += chunk; });
+  const ended = once(stream, "end");
+  stream.write(pendingGatewayMessage());
+  assert.match(raw, /Проверка ещё идёт/u);
+  assert.doesNotMatch(raw, /event: error/u);
+  stream.write(`data: ${JSON.stringify(GATEWAY_ERROR)}\n`);
+  assert.doesNotMatch(raw, /event: error/u);
+  stream.write("\n");
+  assertCanonicalGatewayError(raw);
+  const terminal = raw;
+  stream.write(Buffer.from([0xff, 0xfe]));
+  stream.write("x".repeat(2048));
+  stream.end(block(GATEWAY_ERROR) + "data: [DONE]\n\n");
+  await ended;
+  assert.equal(raw, terminal);
+});
+
+test("does not mistake error-shaped prose, nested data, or typed events for gateway errors", async () => {
+  const input = [
+    block({ type: "response.output_text.delta", delta: JSON.stringify(GATEWAY_ERROR) }),
+    block({ type: "response.output_text.done", text: JSON.stringify(GATEWAY_ERROR), error: { code: "annotation" } }),
+    block({ content: GATEWAY_ERROR }),
+    block({ text: JSON.stringify(GATEWAY_ERROR) }),
+    block({ error: "plain text" }),
+    block({ error: null }),
+    block({ error: [GATEWAY_ERROR] }),
+    block([{ error: { code: "nested" } }]),
+    block({ type: null, error: { code: "not an untyped envelope" } }),
+    block({ type: "error", code: "already_canonical", message: "known error", param: null }),
+    block({ type: "response.failed", response: { status: "failed", error: { code: "typed_failure" } } }),
+    "data: [DONE]\n\n",
+  ].join("");
+  assert.equal(await transformed(input, 1), input);
+});
+
+test("gateway error recognition retains invalid UTF-8 and frame-limit safety", async () => {
+  const invalid = Buffer.concat([
+    Buffer.from('data: {"error":{"message":"'), Buffer.from([0xff]), Buffer.from('"}}\n\n'),
+  ]);
+  const stream = new GrokReasoningSummaryCompatTransform();
+  const chunks = [];
+  stream.on("data", (chunk) => chunks.push(chunk));
+  const ended = once(stream, "end");
+  const raw = Buffer.concat([invalid, Buffer.from(block(GATEWAY_ERROR))]);
+  stream.end(raw);
+  await ended;
+  assert.deepEqual(Buffer.concat(chunks), raw, "invalid pre-mutation UTF-8 must still disable repair without changing bytes");
+  await assert.rejects(
+    transformed(Buffer.concat([Buffer.from(pendingGatewayMessage()), invalid]), 1),
+    /failed after stream mutation: invalid UTF-8/u,
+  );
+  const oversized = block({ error: { message: "x".repeat(2048) } });
+  assert.equal(await transformed(oversized + block(GATEWAY_ERROR), 1, { maxFrameBytes: 256 }), oversized + block(GATEWAY_ERROR));
+  await assert.rejects(
+    transformed(pendingGatewayMessage() + oversized, 1, { maxFrameBytes: 256, maxCommittedFrameBytes: 1024 }),
+    /failed after stream mutation: SSE frame byte limit/u,
+  );
+});
+
 test("an oversized unterminated frame fails open without unbounded buffering", async () => {
   const input = `${block({ type: "response.output_item.added", output_index: 0, item: { id: "msg_limit", type: "message", role: "assistant", status: "in_progress", content: [] } })}data: ${"x".repeat(512)}`;
   assert.equal(await transformed(input, 1, { maxFrameBytes: 256 }), input);

--- a/test/request-progress.test.mjs
+++ b/test/request-progress.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRequestProgress } from "../src/request-progress.mjs";
+
+test("silence and repeated polls retain live requests without inventing progress", () => {
+  let time = 100;
+  const tracker = createRequestProgress({ now: () => time, recentTtlMs: 10 });
+  const request = tracker.begin();
+  request.setRoute({ threadId: "worker-1", model: "grok-oauth/grok-4.6", secret: "never" });
+  request.attempt();
+  const initial = tracker.snapshot().active[0];
+  time += 1_000_000;
+  const silent = tracker.snapshot({ threadId: "worker-1" }).active[0];
+  assert.deepEqual(silent, initial);
+  assert.equal(silent.phase, "awaiting_upstream");
+  assert.equal(silent.lastEventAt, undefined);
+  assert.equal(silent.secret, undefined);
+  assert.equal(tracker.snapshot({ threadId: "other" }).active.length, 0);
+  request.headers();
+  request.event({ type: "response.reasoning_summary_text.delta", delta: "private reasoning" });
+  const progress = tracker.snapshot().active[0];
+  assert.equal(progress.phase, "reasoning");
+  assert.equal(progress.lastEventAt, time);
+  assert.equal(progress.receivedEvents, 1);
+  assert.doesNotMatch(JSON.stringify(progress), /private reasoning/);
+  progress.state = "tampered";
+  assert.equal(tracker.snapshot().active[0].state, "running");
+});
+
+test("cancel remains active until cleanup and recent results are bounded and expire", () => {
+  let time = 0;
+  const tracker = createRequestProgress({ now: () => time, recentLimit: 2, recentTtlMs: 10 });
+  const request = tracker.begin();
+  request.attempt();
+  request.cancel("client_disconnected");
+  request.headers();
+  request.event({ type: "response.output_text.delta", delta: "late" });
+  assert.equal(tracker.snapshot().active[0].phase, "canceling");
+  request.finish(0);
+  request.finish(200);
+  assert.equal(tracker.snapshot().active.length, 0);
+  const canceled = tracker.snapshot().recent[0];
+  assert.equal(canceled.state, "canceled");
+  assert.equal(canceled.cancelReason, "client_disconnected");
+  tracker.begin().finish(200);
+  const deadline = tracker.begin();
+  deadline.cancel("execution_deadline");
+  deadline.finish(504);
+  assert.deepEqual(tracker.snapshot().recent.map((r) => r.state), ["completed", "failed"]);
+  time = 11;
+  assert.deepEqual(tracker.snapshot().recent, []);
+});
+
+test("byte observer is transparent and counts only received bytes", async () => {
+  const tracker = createRequestProgress();
+  const request = tracker.begin();
+  const observer = request.byteObserver();
+  const bytes = Buffer.from('data: {"type":"response.created"}\n\n');
+  observer.end(bytes);
+  const output = [];
+  for await (const chunk of observer) output.push(chunk);
+  assert.deepEqual(Buffer.concat(output), bytes);
+  assert.equal(tracker.snapshot().active[0].receivedBytes, bytes.length);
+  assert.equal(tracker.snapshot().active[0].receivedEvents, 0);
+});
+
+
+test("unsuccessful response terminal is failed even under an HTTP 200 envelope", () => {
+  for (const type of ["response.failed", "response.incomplete", "error"]) {
+    const tracker = createRequestProgress();
+    const request = tracker.begin();
+    assert.equal(tracker.snapshot().active[0].phase, "unobserved");
+    assert.equal(tracker.snapshot().active[0].upstreamAttempts, undefined);
+    request.event({ type });
+    request.event({ type: "response.completed" });
+    request.finish(200);
+    assert.equal(tracker.snapshot().recent[0].state, "failed");
+    assert.equal(tracker.snapshot().recent[0].status, 200);
+    assert.equal(tracker.snapshot().recent[0].terminalEvent, type);
+  }
+});
+
+
+test("a successful new attempt replaces an unsuccessful earlier terminal", () => {
+  const tracker = createRequestProgress();
+  const request = tracker.begin();
+  request.attempt();
+  request.event({ type: "response.failed" });
+  request.attempt();
+  request.event({ type: "response.completed" });
+  request.finish(200);
+  assert.equal(tracker.snapshot().recent[0].state, "completed");
+  assert.equal(tracker.snapshot().recent[0].upstreamAttempts, 2);
+});

--- a/test/router-resilience.test.mjs
+++ b/test/router-resilience.test.mjs
@@ -1112,3 +1112,89 @@ test("an idle keep-alive connection survives past Node's default timeout", async
     await closeServer(gateway.server);
   }
 });
+
+test("protected activity follows a quiet stream through reasoning and client cancellation", async () => {
+  const threadId = "11111111-1111-4111-8111-111111111111";
+  let upstreamResponse;
+  let upstreamClosed = false;
+  let requestCount = 0;
+  let signalStarted;
+  const started = new Promise((resolve) => { signalStarted = resolve; });
+  const gateway = await mockServer((request, response) => {
+    if (request.method === "GET") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end('{"ok":true}');
+      return;
+    }
+    requestCount += 1;
+    upstreamResponse = response;
+    response.once("close", () => { upstreamClosed = true; });
+    signalStarted();
+  });
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_ACTIVITY_RECORD_RETENTION_MS: "40",
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+  });
+  const base = callerBaseUrl(routerPort, CALLER_KEY);
+  const controller = new AbortController();
+  const snapshot = () => fetch(`${base}/activity?threadId=${threadId}`).then((r) => r.json());
+  async function until(predicate) {
+    const end = Date.now() + 3_000;
+    while (Date.now() < end) {
+      const state = await snapshot();
+      if (predicate(state)) return state;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.fail(`activity did not reach expected state: ${JSON.stringify(await snapshot())}`);
+  }
+  let pending;
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, router);
+    assert.equal((await fetch(`http://127.0.0.1:${routerPort}/v1/activity`)).status, 401);
+    assert.equal((await fetch(`${base}/activity?threadId=invalid%2Fid`)).status, 400);
+    pending = fetch(`${base}/responses`, {
+      method: "POST", signal: controller.signal,
+      headers: { "Content-Type": "application/json", session_id: threadId },
+      body: JSON.stringify({ model: "grok-oauth/grok-4.6", stream: true, input: "private-prompt-marker" }),
+    }).then(async (response) => { await response.text(); }).catch(() => {});
+    await started;
+    const quiet = await snapshot();
+    assert.equal(quiet.active.length, 1);
+    assert.equal(quiet.active[0].phase, "awaiting_upstream");
+    assert.equal(quiet.active[0].upstreamAttempts, 1);
+    assert.equal(quiet.active[0].lastEventAt, undefined);
+    const requestId = quiet.active[0].requestId;
+    // Presentation retention must not hide a still-pending operation.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.equal((await snapshot()).active[0].requestId, requestId);
+    upstreamResponse.writeHead(200, { "Content-Type": "text/event-stream" });
+    upstreamResponse.write('data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_live","output_index":0,"summary_index":0,"delta":"private-output-marker"}\n\n');
+    const generating = await until((s) => s.active[0]?.phase === "reasoning");
+    assert.equal(generating.active[0].receivedEvents, 1);
+    assert.ok(generating.active[0].lastByteAt >= quiet.active[0].startedAt);
+    assert.doesNotMatch(JSON.stringify(generating), /private-prompt-marker|private-output-marker/);
+    assert.equal((await fetch(`${base}/activity?threadId=other`).then((r) => r.json())).active.length, 0);
+    controller.abort();
+    await pending;
+    const settled = await until((s) => s.recent.some((r) => r.requestId === requestId));
+    assert.equal(settled.active.length, 0);
+    assert.equal(settled.recent[0].state, "canceled");
+    assert.equal(settled.recent[0].cancelReason, "client_disconnected");
+    const closeDeadline = Date.now() + 1_000;
+    while (!upstreamClosed && Date.now() < closeDeadline) await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(upstreamClosed, true);
+    assert.equal(requestCount, 1);
+  } finally {
+    controller.abort();
+    await pending;
+    await stopChild(router);
+    gateway.server.closeAllConnections?.();
+    await closeServer(gateway.server);
+  }
+});


### PR DESCRIPTION
After a tool result, a Grok repair could contain a complete-looking tool call and then fail, become incomplete, or end without a successful response terminal. The forwarder could still release the held action or private final answer. LiteLLM can also translate a forwarder stream error into an untyped error envelope followed by empty message closes, obscuring the failure at the Responses boundary.

Require a successful response terminal before releasing held repair output, and normalize recognized Grok gateway error envelopes to one safe terminal error. Reasoning stays live; unsuccessful first attempts are not repaired or replayed, and failed repairs do not release held client actions. The Grok normalizer closes repaired reasoning as incomplete, drops subsequent frames, and runs before usage observation so activity records the failure.

Add capability-protected `GET /v1/activity` and `bin/control activity [thread-id]` for diagnosing quiet routed workers. Live requests remain visible until handler cleanup, independently of tray retention; the snapshot exposes dispatch counts, byte/event timestamps, observed phase, cancellation cause, and bounded recent outcomes. Shipped agent guidance distinguishes a polling timeout from an execution deadline and requires checking the existing worker before replacement.

### Validation

Current head: `f00a8382b91c0315e47167b09e1e65a9f2a24818`, refreshed onto upstream `7e0a2b72ebb85ed497d9df8529ac251262261d51`. Conflict resolution was checked with range-diff. `npm run check`, `git diff --check` and 143 focused local tests pass. Full Linux, macOS and Windows CI passes on this head. The full-suite evidence for the refreshed revision is hosted CI; earlier pre-rebase local results are not substituted for it.

The focused tests cover successful/failed terminal gating, normalized gateway errors, activity lifecycle, cancellation, no replay after client output, and capability-protected metadata without content.

### Scope and limits

- Activity describes Router HTTP requests, not native Codex worker lifecycle or retries inside LiteLLM/xAI. An empty/unknown snapshot is not evidence that a worker finished. Uninstrumented subpaths remain `unobserved`.
- No prompts, response text, tool arguments, or credentials are retained in activity. `/health` retains its existing contract; activity requires the caller capability.
- The existing bounded-parser fallback for oversized or invalid UTF-8 frames before stream mutation is preserved. Other providers retain their existing stream transforms.
- Live pilot timings belong to downstream stacked variants, not an isolated evaluation of this PR. No generation-speed improvement is claimed.
