### PR TITLE
fix(opencode): replay verified Muse search history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **OpenCode Go Muse Responses routes can continue after a completed web search.**
+  Live replay probes for Muse Spark 1.2 and 1.3 Contributor confirmed that the
+  Responses upstream accepts completed `web_search_call` history even though
+  neither route advertises a new search tool. Both exact routes now declare
+  `supportsSearchHistory: true`, so follow-up and compact turns preserve that
+  verified history instead of failing locally with `model_search_not_supported`
+  (issue #639).
 - **Startup now repairs drifted routed-agent definitions.** The post-health
   native-catalog reconciliation also compares Codex Router's managed agent
   files with the current routed-model, visibility, and subagent settings. A

--- a/config/opencode/go-responses/muse-spark-1.2-contributor.json
+++ b/config/opencode/go-responses/muse-spark-1.2-contributor.json
@@ -41,9 +41,10 @@
         "text",
         "image"
       ],
+      "supportsSearchHistory": true,
       "supportsApplyPatchTool": false,
       "requestProfile": "auto-tool-choice",
-      "compHash": "opencode-go-responses-muse-spark-1-2-contributor-v3",
+      "compHash": "opencode-go-responses-muse-spark-1-2-contributor-v4",
       "toolSchemaRecursion": "flatten"
     }
   ]

--- a/config/opencode/go-responses/muse-spark-1.3-contributor.json
+++ b/config/opencode/go-responses/muse-spark-1.3-contributor.json
@@ -41,9 +41,10 @@
         "text",
         "image"
       ],
+      "supportsSearchHistory": true,
       "supportsApplyPatchTool": false,
       "requestProfile": "auto-tool-choice",
-      "compHash": "opencode-go-responses-muse-spark-1-3-contributor-v3",
+      "compHash": "opencode-go-responses-muse-spark-1-3-contributor-v4",
       "toolSchemaRecursion": "flatten"
     }
   ]

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -6815,6 +6815,69 @@ test("router replays verified search history without exposing a new search tool"
   }
 });
 
+test("checked-in opencode Muse Responses routes replay completed search history without advertising search", async () => {
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, {
+      id: `resp-${gatewayRequests.length}`,
+      object: "response",
+      status: "completed",
+      output: [{
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "ok" }],
+      }],
+    });
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const history = [{
+    type: "web_search_call",
+    id: "completed-search-history",
+    status: "completed",
+    action: { type: "search", query: "router contract" },
+  }];
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    for (const slug of [
+      "opencode-go-responses/muse-spark-1.2-contributor",
+      "opencode-go-responses/muse-spark-1.3-contributor",
+    ]) {
+      const response = await fetch(`${routerBase(routerPort)}/responses`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${CALLER_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ model: slug, input: history }),
+      });
+      assert.equal(response.status, 200, router.testErrors());
+    }
+
+    assert.deepEqual(
+      gatewayRequests.map((request) => request.model),
+      [
+        "opencode-go-responses-muse-spark-1-2-contributor",
+        "opencode-go-responses-muse-spark-1-3-contributor",
+      ],
+    );
+    assert.ok(gatewayRequests.every((request) => (
+      Array.isArray(request.input) &&
+      request.input.some((item) => item.type === "web_search_call") &&
+      (!Array.isArray(request.tools) || request.tools.every((tool) => tool.type !== "web_search"))
+    )));
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 test("API forwarder strips web_search_options for Fireworks", async () => {
   const upstreamRequests = [];
   const upstream = await mockServer(async (request, response) => {

--- a/test/search-capability.test.mjs
+++ b/test/search-capability.test.mjs
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { MODEL_BY_SLUG } from "../src/model-registry.mjs";
+
 import {
   routedModelPreservesSearchContract,
   routedModelSearchAvailable,
@@ -58,6 +60,20 @@ test("a disappearing sidecar invalidates a snapshotted failover contract", () =>
   assert.equal(routedModelPreservesSearchContract(model, contract, options), true);
   ready = false;
   assert.equal(routedModelPreservesSearchContract(model, contract, options), false);
+});
+
+test("checked-in opencode Muse Responses routes replay verified search history without advertising search", () => {
+  const contract = { requiredMode: undefined, hasSearchHistory: true };
+  for (const slug of [
+    "opencode-go-responses/muse-spark-1.2-contributor",
+    "opencode-go-responses/muse-spark-1.3-contributor",
+  ]) {
+    const model = MODEL_BY_SLUG.get(slug);
+    assert.ok(model, slug);
+    assert.equal(model.searchTool, undefined, `${slug} must not advertise a new search tool`);
+    assert.equal(routedModelSearchAvailable(model), false, slug);
+    assert.equal(routedModelPreservesSearchContract(model, contract), true, slug);
+  }
 });
 
 test("verified models replay search history without advertising new search", () => {


### PR DESCRIPTION
## Problem

Fixes #639.

The checked-in OpenCode Go Responses routes for Muse Spark 1.2/1.3 Contributor reject subsequent turns after a completed built-in web search because the router's history-compatibility gate requires `supportsSearchHistory === true`.

The issue includes direct upstream replay probes showing both exact routes accept completed `web_search_call` items, including streaming replay.

## Fix

- Mark only the two live-verified exact Muse Responses routes with `supportsSearchHistory: true`.
- Keep `searchTool` absent, so these routes do not advertise or gain the ability to execute a new hosted search.
- Bump both route comp hashes.
- Add exact checked-in capability and router-level regressions.

## Verification

- Exact router replay regression: 1/1 pass.
- `test/search-capability.test.mjs` + `test/registry.test.mjs`: 46/46 pass.
- `node scripts-check.mjs`: pass (`v2-agent applications valid (6)`, syntax checks passed).
- `git diff --check`: pass.