### PR TITLE
fix: retry marked routed transport failures once

### DIFF
--- a/src/model-failover.mjs
+++ b/src/model-failover.mjs
@@ -82,9 +82,10 @@ function isoOrUndefined(value) {
 // request all produce the same answer from every other provider too, so a swap
 // would spend two more round trips to reprint the same failure with a different
 // model's name on it -- and for a credential in particular it would hide the one
-// fact the operator needs. A 5xx is excluded because upstream-retry.mjs already
-// absorbs the transient shapes and because masking a provider outage costs the
-// operator an incident they would want to see.
+// fact the operator needs. A generic 5xx is excluded because the routed turn
+// path retries only the forwarder's reserved pre-response transport marker;
+// masking any other provider outage costs the operator an incident they would
+// want to see.
 export function classifyRoutedFailure({ status, bodyText, retryAfterSeconds, now } = {}) {
   const code = Number(status);
   if (!Number.isFinite(code) || code < 400) return { swap: false };

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -3886,12 +3886,51 @@ async function handleResponses(request, response, requestUrl) {
         MAX_BUFFERED_RESPONSE_BYTES,
         controller.signal,
       );
-      const verdict = classifyRoutedFailure({
+      let verdict = classifyRoutedFailure({
         status: upstream.status,
         bodyText: failedBodyText,
         retryAfterSeconds: retryAfterSeconds(upstream.headers),
       });
-      if (verdict.swap && !exactRouteProbe) {
+      // The provider forwarder emits the reserved transport marker only when
+      // it failed before any provider response was available. Cross-model
+      // failover already treats that marker as replay-safe, but an ordinary
+      // turn (or a single-provider install) has no fallback candidate. Retry
+      // the exact same materialized request once before changing models or
+      // surfacing the 502. Generic provider 5xx bodies never enter this branch,
+      // and nothing can be replayed after caller bytes have been sent.
+      if (
+        verdict.reason === "transport" &&
+        nothingRelayed(response) &&
+        !controller.signal.aborted
+      ) {
+        console.error(
+          `[codex-router] routed transport retry 1/1 model=${route.slug} path=${requestUrl.pathname}`,
+        );
+        upstream = await fetch(target, {
+          method: "POST",
+          headers,
+          body: routedBody,
+          signal: controller.signal,
+        });
+        upstreamRetries = (upstreamRetries || 0) + 1;
+        upstreamStatus = upstream.status;
+        upstreamLatencyMs = Date.now() - startedAt;
+        failedBodyText = upstream.ok
+          ? undefined
+          : await boundedResponseText(
+              upstream,
+              MAX_BUFFERED_RESPONSE_BYTES,
+              controller.signal,
+            );
+        verdict = upstream.ok
+          ? { swap: false }
+          : classifyRoutedFailure({
+              status: upstream.status,
+              bodyText: failedBodyText,
+              retryAfterSeconds: retryAfterSeconds(upstream.headers),
+            });
+      }
+      if (!upstream.ok && verdict.swap && !exactRouteProbe) {
         // Believe the provider about when it will be back before trying anyone
         // else, so the next turn skips it instead of paying for the same
         // rejection again.

--- a/test/model-failover-router.test.mjs
+++ b/test/model-failover-router.test.mjs
@@ -492,6 +492,7 @@ test("a marked provider transport failure moves a subagent to a checked-in v2 ro
 
     assert.deepEqual(seen.map((body) => body.model), [
       V2_PRIMARY.gatewayModel,
+      V2_PRIMARY.gatewayModel,
       V2_FALLBACK.gatewayModel,
     ]);
     assert.equal(result.status, 200);
@@ -528,9 +529,76 @@ test("subagent transport failover preserves search history execution mode", asyn
       { headers: { "x-openai-subagent": "review-child" } },
     );
 
-    assert.deepEqual(seen.map((body) => body.model), [V2_THIRD.gatewayModel]);
+    assert.deepEqual(seen.map((body) => body.model), [
+      V2_THIRD.gatewayModel,
+      V2_THIRD.gatewayModel,
+    ]);
     assert.equal(result.status, 502);
     assert.match(child.testErrors(), /reason=transport -> none outcome=no-candidate/);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("a marked provider transport failure retries the same ordinary route once", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    const body = await bodyJson(request);
+    seen.push(body);
+    if (seen.length === 1) {
+      response.writeHead(502, { "Content-Type": "application/json" });
+      response.end(TRANSPORT_BODY);
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(contentSse("same-route-transport-retry"));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), {
+    chain: [V2_FALLBACK.slug],
+    v2Credentials: true,
+  });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, { ...TURN_BODY, model: V2_PRIMARY.slug });
+
+    assert.deepEqual(seen.map((body) => body.model), [
+      V2_PRIMARY.gatewayModel,
+      V2_PRIMARY.gatewayModel,
+    ]);
+    assert.equal(result.status, 200);
+    assert.match(result.body, /answered-by-same-route-transport-retry/);
+    assert.match(child.testErrors(), /routed transport retry 1\/1/);
+    const [event] = await waitForUsageEvents(child.stateDir, 1, child);
+    assert.equal(event.model, V2_PRIMARY.slug);
+    assert.equal(event.status, 200);
+    assert.equal(event.retries, 1);
+  } finally {
+    await stopChild(child);
+    await closeServer(gw.server);
+  }
+});
+
+test("an unmarked provider 502 is never retried", async () => {
+  const seen = [];
+  const gw = await gateway(async (request, response) => {
+    seen.push(await bodyJson(request));
+    response.writeHead(502, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "provider unavailable" } }));
+  });
+  const routerPort = await openPort();
+  const child = run(routerEnv(gw.port, routerPort), {
+    chain: [V2_FALLBACK.slug],
+    v2Credentials: true,
+  });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
+    const result = await readRouted(routerPort, { ...TURN_BODY, model: V2_PRIMARY.slug });
+
+    assert.deepEqual(seen.map((body) => body.model), [V2_PRIMARY.gatewayModel]);
+    assert.equal(result.status, 502);
+    assert.doesNotMatch(child.testErrors(), /routed transport retry/);
   } finally {
     await stopChild(child);
     await closeServer(gw.server);
@@ -553,7 +621,10 @@ test("a marked provider transport failure does not move an ordinary turn", async
     await waitFor(`http://127.0.0.1:${routerPort}/health`, child);
     const result = await readRouted(routerPort, { ...TURN_BODY, model: V2_PRIMARY.slug });
 
-    assert.deepEqual(seen.map((body) => body.model), [V2_PRIMARY.gatewayModel]);
+    assert.deepEqual(seen.map((body) => body.model), [
+      V2_PRIMARY.gatewayModel,
+      V2_PRIMARY.gatewayModel,
+    ]);
     assert.equal(result.status, 502);
     assert.match(child.testErrors(), /reason=transport -> none outcome=no-candidate/);
   } finally {
@@ -582,7 +653,10 @@ test("a subagent header cannot grant fallback authority to an unverified route",
       { headers: { "x-openai-subagent": "caller-claimed-child" } },
     );
 
-    assert.deepEqual(seen.map((body) => body.model), [PRIMARY.gatewayModel]);
+    assert.deepEqual(seen.map((body) => body.model), [
+      PRIMARY.gatewayModel,
+      PRIMARY.gatewayModel,
+    ]);
     assert.equal(result.status, 502);
     assert.match(child.testErrors(), /reason=transport -> none outcome=no-candidate/);
   } finally {
@@ -623,6 +697,7 @@ test("subagent transport failover stops on the first application response", asyn
     );
 
     assert.deepEqual(seen.map((body) => body.model), [
+      V2_PRIMARY.gatewayModel,
       V2_PRIMARY.gatewayModel,
       V2_FALLBACK.gatewayModel,
     ]);


### PR DESCRIPTION
## Problem

The provider forwarder already distinguishes pre-response transport failures with the reserved `provider_transport_error` marker, and model failover treats that marker as replay-safe. However, the main routed request path explicitly disables `fetchWithRetry` (`retries: 0`).

That leaves ordinary routed turns and single-provider installs with no recovery path: an intermittent provider `ECONNRESET`/connect failure is translated to a marked 502 and returned immediately when there is no eligible cross-model fallback.

A current Windows maintenance run reproduced repeated marked 502s on routed GLM traffic, interspersed with successful requests, matching a transient transport failure rather than a deterministic provider rejection.

## Fix

- When a routed failure body carries the reserved transport marker, retry the exact same already-materialized request once on the same route before model failover or surfacing the 502.
- Require that no caller bytes have been relayed and that the caller has not aborted.
- Reclassify the retry response normally:
  - success continues on the original route;
  - another marked transport failure can use the existing verified subagent failover path;
  - an application response is returned normally.
- Keep generic/unmarked provider 5xx responses single-shot.
- Keep partial-stream failures non-retryable.
- Record the successful same-route retry in existing retry telemetry.

## Verification

- Added red/green regression: marked transport 502 -> same route -> success.
- Added negative regression: unmarked provider 502 is never retried.
- Updated existing transport/failover call-count assertions to include the bounded same-route retry.
- Focused adjacent suites: **101/101 pass** (`model-failover-router`, `model-failover`, `native-retry`, `transport-failure`).
- `node scripts-check.mjs`: pass (`v2-agent applications valid (6)`, syntax checks passed).
- `git diff --check`: pass.

No provider response bodies, credentials, private prompts, or thread identifiers are included.