### PR TITLE
fix: keep injected interrupt call ids unique across turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Router-injected subagent interrupts now keep unique call IDs across turns.**
+  Streamed collaboration cleanup previously numbered injected `interrupt_agent`
+  calls from `call_router_interrupt_1` inside each request-scoped transform, so
+  a later turn could reuse an ID still present in Codex conversation history.
+  Stream and non-stream injection now share a UUID-backed call-ID generator,
+  preserving call/output pairing across long multi-turn agent sessions.
 - **OpenCode Go Muse Responses routes can continue after a completed web search.**
   Live replay probes for Muse Spark 1.2 and 1.3 Contributor confirmed that the
   Responses upstream accepts completed `web_search_call` history even though

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -2434,7 +2434,6 @@ export class NamespaceToolCallTransform extends Transform {
   #injectOnly = false;
   #interruptedTargets = new Set();
   #lastSequence = 0;
-  #interruptSeq = 0;
   #injectQueue = [];
   #injectionsDone = false;
   #lastInjectedCalls = [];
@@ -3736,9 +3735,10 @@ export class NamespaceToolCallTransform extends Transform {
     const blocks = [];
     const injectedCalls = [];
     for (const target of remaining) {
-      this.#interruptSeq += 1;
-      const callId = `call_router_interrupt_${this.#interruptSeq}`;
-      const call = buildInterruptAgentCall(target, { callId });
+      // Each transform is request-scoped, so a local counter would restart on
+      // every turn and reuse call IDs that remain in Codex conversation history.
+      // Use the same fresh-ID helper as the non-stream injection path instead.
+      const call = buildInterruptAgentCall(target);
       this.#interruptedTargets.add(target);
       injectedCalls.push(call);
       const addedSeq = this.#lastSequence + 1;

--- a/src/subagent-completion.mjs
+++ b/src/subagent-completion.mjs
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 // Codex 0.147 keeps a finished child visually Working after FINAL_ANSWER while
 // the parent turn is still live. close_agent is not in the v2 toolset;
 // interrupt_agent is the only model-callable close path. Parents frequently
@@ -196,7 +198,7 @@ export function buildInterruptAgentCall(target, { callId, flattened = false } = 
   const id =
     typeof callId === "string" && callId
       ? callId
-      : `call_router_interrupt_${Math.random().toString(16).slice(2, 10)}`;
+      : `call_router_interrupt_${randomUUID().replaceAll("-", "")}`;
   if (flattened) {
     return {
       type: "function_call",

--- a/test/subagent-completion.test.mjs
+++ b/test/subagent-completion.test.mjs
@@ -223,6 +223,32 @@ test("stream transform injects interrupt_agent before response.completed", async
   assert.equal((output.match(/\/root\/visual_critic/g) || []).length >= 1, true);
 });
 
+test("separate stream transforms give router-injected interrupts distinct call ids", async () => {
+  const namespaces = collaborationNamespaces();
+  const event = `data: ${JSON.stringify({
+    type: "response.completed",
+    sequence_number: 1,
+    response: { output: [] },
+  })}\n\n`;
+
+  async function injectedCallId() {
+    const transform = new NamespaceToolCallTransform(
+      namespaces,
+      "text/event-stream",
+      "kimi-oauth/k3",
+      { pendingInterrupts: ["/root/visual_critic"] },
+    );
+    const output = await collect(Readable.from([event]).pipe(transform));
+    const match = output.match(/"call_id":"(call_router_interrupt_[^"]+)"/);
+    assert.ok(match, output);
+    return match[1];
+  }
+
+  const first = await injectedCallId();
+  const second = await injectedCallId();
+  assert.notEqual(first, second);
+});
+
 test("stream transform does not re-interrupt a target the model already closed", async () => {
   const namespaces = collaborationNamespaces();
   const events = [


### PR DESCRIPTION
## Problem

Codex Router injects `collaboration.interrupt_agent` calls after completed subagents. The streaming path generated IDs with a `#interruptSeq` counter owned by `NamespaceToolCallTransform`:

```text
call_router_interrupt_1
call_router_interrupt_2
...
```

The transform is request-scoped, so the counter restarts on each turn. In a real long-running Codex Desktop session, two different turns therefore recorded the same router-generated `call_router_interrupt_1` ID, each with its own `function_call_output`. Those IDs remain in conversation history, so reuse makes call/output identity ambiguous on later replay and is inconsistent with the non-stream injection path, which already generates fresh IDs.

No private prompt, project content, credentials, or raw log is included here.

## Fix

- Remove the request-local streaming interrupt counter.
- Route streamed injected interrupts through the same `buildInterruptAgentCall()` fresh-ID path used by non-stream injection.
- Upgrade that default generator from short `Math.random()` hex to UUID-backed IDs.
- Keep caller-supplied IDs unchanged.
- Add a regression creating two separate stream transforms and requiring distinct router-generated interrupt IDs.

Model-authored call IDs and sequence numbers are unchanged.

## Verification

- `node --test test/subagent-completion.test.mjs test/namespace-relay.test.mjs`: **130/130 pass**.
- `node scripts-check.mjs`: pass (`v2-agent applications valid (6)`, syntax checks passed).
- `git diff --check`: pass.
- Commit: `a3e0daf`.