### PR TITLE
Fix native collaboration relay quota errors and retry storms

### DIFF
--- a/src/router.mjs
+++ b/src/router.mjs
@@ -359,8 +359,20 @@ const AGENT_PAYLOAD_CACHE_TTL_MS =
     : 15 * 60 * 1_000;
 const AGENT_PAYLOAD_CACHE_MAX_BYTES = 8 * 1024 * 1024;
 const AGENT_PAYLOAD_CACHE_MAX_ENTRIES = 256;
+const configuredAgentRelayBackoffMs = Number(
+  process.env.MODEL_ROUTER_AGENT_RELAY_BACKOFF_MS ||
+    process.env.CODEX_ROUTER_AGENT_RELAY_BACKOFF_MS ||
+    60_000,
+);
+const AGENT_RELAY_BACKOFF_MS =
+  Number.isFinite(configuredAgentRelayBackoffMs) && configuredAgentRelayBackoffMs > 0
+    ? Math.floor(configuredAgentRelayBackoffMs)
+    : 60_000;
+const AGENT_RELAY_BACKOFF_MAX_MS = 5 * 60_000;
+const AGENT_RELAY_BACKOFF_MAX_ACCOUNTS = 64;
 const agentPayloadCache = new Map();
 const agentPayloadCacheInFlight = new Map();
+const agentRelayBackoffs = new Map();
 let agentPayloadCacheBytes = 0;
 const agentPayloadCacheMetrics = {
   hits: 0,
@@ -368,6 +380,8 @@ const agentPayloadCacheMetrics = {
   expirations: 0,
   evictions: 0,
   coalesced: 0,
+  rateLimitBackoffs: 0,
+  rateLimitRejects: 0,
 };
 
 let requestSequence = 0;
@@ -415,6 +429,7 @@ function activityPayload() {
 
 function resourceLimitsPayload() {
   purgeExpiredAgentPayloads();
+  purgeExpiredAgentRelayBackoffs();
   return {
     inFlightRequests: inFlightRequests.size,
     maxActiveRequests: MAX_ACTIVE_REQUESTS,
@@ -429,6 +444,8 @@ function resourceLimitsPayload() {
       maxBytes: AGENT_PAYLOAD_CACHE_MAX_BYTES,
       ttlMs: AGENT_PAYLOAD_CACHE_TTL_MS,
       inFlight: agentPayloadCacheInFlight.size,
+      rateLimitedAccounts: agentRelayBackoffs.size,
+      maxRateLimitedAccounts: AGENT_RELAY_BACKOFF_MAX_ACCOUNTS,
       ...agentPayloadCacheMetrics,
     },
   };
@@ -1596,8 +1613,57 @@ function rememberAgentPayload(key, plaintext) {
   }
 }
 
+function purgeExpiredAgentRelayBackoffs(now = Date.now()) {
+  for (const [accountScope, backoff] of agentRelayBackoffs) {
+    if (backoff.expiresAt <= now) agentRelayBackoffs.delete(accountScope);
+  }
+}
+
+function agentRelayRateLimitError(retryAfterMs, advertisedRetrySeconds) {
+  const retryAfterSeconds =
+    advertisedRetrySeconds > 0
+      ? advertisedRetrySeconds
+      : Math.max(1, Math.ceil(retryAfterMs / 1_000));
+  const error = new Error(
+    "The signed-in Codex account is rate limited, so the router cannot decrypt a native collaboration payload.",
+  );
+  error.status = 429;
+  error.code = "native_collaboration_relay_rate_limited";
+  error.publicMessage =
+    "The private model needs the signed-in Codex account to decrypt an existing collaboration payload, but that account is currently rate limited. Retry after the indicated delay or start a task without native collaboration history.";
+  error.retryAfterSeconds = retryAfterSeconds;
+  return error;
+}
+
+function cachedAgentRelayBackoff(accountScope, now = Date.now()) {
+  const backoff = agentRelayBackoffs.get(accountScope);
+  if (!backoff) return undefined;
+  if (backoff.expiresAt <= now) {
+    agentRelayBackoffs.delete(accountScope);
+    return undefined;
+  }
+  agentPayloadCacheMetrics.rateLimitRejects += 1;
+  return agentRelayRateLimitError(backoff.expiresAt - now);
+}
+
+function rememberAgentRelayBackoff(accountScope, headers, now = Date.now()) {
+  const retrySeconds = retryAfterSeconds(headers, { now });
+  const requestedMs = retrySeconds > 0 ? retrySeconds * 1_000 : AGENT_RELAY_BACKOFF_MS;
+  const backoffMs = Math.min(requestedMs, AGENT_RELAY_BACKOFF_MAX_MS);
+  agentRelayBackoffs.delete(accountScope);
+  agentRelayBackoffs.set(accountScope, { expiresAt: now + backoffMs });
+  while (agentRelayBackoffs.size > AGENT_RELAY_BACKOFF_MAX_ACCOUNTS) {
+    agentRelayBackoffs.delete(agentRelayBackoffs.keys().next().value);
+  }
+  agentPayloadCacheMetrics.rateLimitBackoffs += 1;
+  return agentRelayRateLimitError(backoffMs, retrySeconds);
+}
+
 const agentPayloadCachePurgeTimer = setInterval(
-  () => purgeExpiredAgentPayloads(),
+  () => {
+    purgeExpiredAgentPayloads();
+    purgeExpiredAgentRelayBackoffs();
+  },
   Math.min(AGENT_PAYLOAD_CACHE_TTL_MS, 60_000),
 );
 agentPayloadCachePurgeTimer.unref?.();
@@ -1625,6 +1691,7 @@ nativeCatalogDriftCheckTimer.unref?.();
 async function relayEncryptedAgentPayloadOnce(
   item,
   cacheKey,
+  accountScope,
   headers,
   signal,
 ) {
@@ -1664,6 +1731,9 @@ async function relayEncryptedAgentPayloadOnce(
     signal,
   });
   if (!upstream.ok) {
+    if (upstream.status === 429) {
+      throw rememberAgentRelayBackoff(accountScope, upstream.headers);
+    }
     const error = new Error(
       `Native collaboration payload relay failed with HTTP ${upstream.status}.`,
     );
@@ -1737,6 +1807,8 @@ async function relayEncryptedAgentPayload(request, item, encrypted, signal) {
   const key = agentPayloadCacheKey(encrypted, accountScope);
   const cached = cachedAgentPayload(key);
   if (cached !== undefined) return cached;
+  const rateLimit = cachedAgentRelayBackoff(accountScope);
+  if (rateLimit) throw rateLimit;
   const pending = agentPayloadCacheInFlight.get(key);
   if (pending) {
     agentPayloadCacheMetrics.coalesced += 1;
@@ -1752,6 +1824,7 @@ async function relayEncryptedAgentPayload(request, item, encrypted, signal) {
   operation.promise = relayEncryptedAgentPayloadOnce(
     item,
     key,
+    accountScope,
     headers,
     controller.signal,
   ).finally(() => {
@@ -5169,13 +5242,16 @@ const server = http.createServer((request, response) => {
     // and an unreachable upstream is indistinguishable from a router bug.
     const transport = describeTransportFailure(error);
     if (!response.headersSent) {
+      if (Number.isFinite(error?.retryAfterSeconds)) {
+        response.setHeader("Retry-After", String(error.retryAfterSeconds));
+      }
       writeJson(response, status, {
         error: {
           type: "local_router_error",
           code: transport?.code || error?.code,
           message: transport
             ? `The local router could not complete the request: ${transport.cause}.${transport.hint}`
-            : "The local router could not complete the request.",
+            : error?.publicMessage || "The local router could not complete the request.",
         },
       });
     } else {

--- a/test/router-resilience.test.mjs
+++ b/test/router-resilience.test.mjs
@@ -533,6 +533,144 @@ test("same encrypted payload shares one relay and expiry removes the retained pl
   }
 });
 
+test("native collaboration 429 is explicit and backs off only the limited account", async () => {
+  const nativeRequests = [];
+  let gatewayRequests = 0;
+  const native = await mockServer(async (request, response) => {
+    nativeRequests.push(request.headers["chatgpt-account-id"]);
+    if (request.headers["chatgpt-account-id"] === "account-a") {
+      response.writeHead(429, {
+        "Content-Type": "application/json",
+        "Retry-After": "120",
+      });
+      response.end(JSON.stringify({ error: { message: "usage exhausted" } }));
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(relayEventStream("account-b payload"));
+  });
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    gatewayRequests += 1;
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ id: "r-account-b", output: [] }));
+  });
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+  });
+  const requestFor = (account, encrypted) =>
+    fetch(`${callerBaseUrl(routerPort, CALLER_KEY)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer session-${account}`,
+        "ChatGPT-Account-Id": account,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(encryptedRelayBody(encrypted)),
+    });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, router);
+
+    const first = await requestFor("account-a", "gAAAAA-limited-first=");
+    const firstBody = await first.json();
+    assert.equal(first.status, 429, JSON.stringify(firstBody));
+    assert.equal(first.headers.get("retry-after"), "120");
+    assert.equal(firstBody.error.code, "native_collaboration_relay_rate_limited");
+    assert.match(firstBody.error.message, /signed-in Codex account/i);
+
+    const blocked = await requestFor("account-a", "gAAAAA-limited-different=");
+    assert.equal(blocked.status, 429, await blocked.text());
+    assert.equal(nativeRequests.filter((account) => account === "account-a").length, 1);
+
+    const otherAccount = await requestFor("account-b", "gAAAAA-other-account=");
+    assert.equal(otherAccount.status, 200, await otherAccount.text());
+    assert.equal(nativeRequests.filter((account) => account === "account-b").length, 1);
+    assert.equal(gatewayRequests, 1);
+
+    const health = await fetch(`${callerBaseUrl(routerPort, CALLER_KEY)}/health`).then((r) => r.json());
+    assert.equal(health.resources.agentPayloadCache.rateLimitedAccounts, 1);
+    assert.equal(health.resources.agentPayloadCache.rateLimitBackoffs, 1);
+    assert.equal(health.resources.agentPayloadCache.rateLimitRejects, 1);
+  } finally {
+    await stopChild(router);
+    await Promise.all([closeServer(native.server), closeServer(gateway.server)]);
+  }
+});
+
+test("native collaboration relay retries after a headerless 429 backoff expires", async () => {
+  let nativeRequests = 0;
+  let gatewayRequests = 0;
+  const native = await mockServer(async (_request, response) => {
+    nativeRequests += 1;
+    if (nativeRequests === 1) {
+      response.writeHead(429, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ error: { message: "temporarily limited" } }));
+      return;
+    }
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(relayEventStream("recovered payload"));
+  });
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify({ ok: true }));
+      return;
+    }
+    gatewayRequests += 1;
+    response.writeHead(200, { "Content-Type": "application/json" });
+    response.end(JSON.stringify({ id: "r-recovered", output: [] }));
+  });
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_AGENT_RELAY_BACKOFF_MS: "50",
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+  });
+  const send = (encrypted) =>
+    fetch(`${callerBaseUrl(routerPort, CALLER_KEY)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer session-account-a",
+        "ChatGPT-Account-Id": "account-a",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(encryptedRelayBody(encrypted)),
+    });
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, router);
+    const limited = await send("gAAAAA-backoff-first=");
+    assert.equal(limited.status, 429, await limited.text());
+    const blocked = await send("gAAAAA-backoff-second=");
+    assert.equal(blocked.status, 429, await blocked.text());
+    assert.equal(nativeRequests, 1);
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    const recovered = await send("gAAAAA-backoff-third=");
+    assert.equal(recovered.status, 200, await recovered.text());
+    assert.equal(nativeRequests, 2);
+    assert.equal(gatewayRequests, 1);
+  } finally {
+    await stopChild(router);
+    await Promise.all([closeServer(native.server), closeServer(gateway.server)]);
+  }
+});
+
 test("same ciphertext never coalesces or caches across native accounts", async () => {
   const nativeRequests = [];
   const native = await mockServer(async (request, response) => {


### PR DESCRIPTION
## Problem

A routed private-model turn can contain a native Codex collaboration payload encrypted by the signed-in ChatGPT backend. The router must relay that opaque payload to the native `/responses` endpoint before the private provider can continue.

When the signed-in Codex account is out of usage or rate limited, that relay returns HTTP 429. The router currently rewrites every non-success relay response to a generic 502. Codex therefore reports `The local router could not complete the request`, incorrectly suggesting a crashed local service or failed private provider.

Because successful payloads are cached but relay failures are not, rapid retries and multiple tasks can repeatedly hit the already-limited native account while the private provider itself remains healthy.

## Root cause

`relayEncryptedAgentPayloadOnce()` discarded the native response status and always threw status 502. Relay coalescing covered one identical ciphertext only; there was no short-lived account-scoped backoff after a native 429.

## Fix

- Preserve native relay 429 as HTTP 429 with stable code `native_collaboration_relay_rate_limited`.
- Return an actionable explanation instead of blaming the local router.
- Propagate a safe `Retry-After` value.
- Add bounded in-memory account-scoped backoff after a native relay 429: honor the upstream window with a five-minute local cap, default to 60 seconds without a usable window, isolate accounts, cap entries at 64, and expire automatically.
- Expose only aggregate backoff counters in `/health`; retain no account identity, authorization value, ciphertext, or plaintext there.
- Leave successful plaintext caching and ordinary private-provider routing unchanged.

## Verification

- `npm run check` passes.
- Focused native-relay tests: 4/4 pass.
- Complete `test/router-resilience.test.mjs`: 14/14 pass.
- Adversarial coverage proves the 429 is not mislabeled as 502, `Retry-After` reaches the caller, a different ciphertext for the same limited account does not reach native upstream, another account remains unaffected, and a headerless backoff expires before a later successful relay.

A local full-suite run reached 3,659 passing and 25 skipped tests. Four unrelated environment/baseline failures remained: one browser assertion expected English while the machine rendered Chinese; two doctor fixture failures reproduce unchanged on `origin/main`; and an installer test was intercepted by a machine-wide pre-commit hook and passes when that external hook is suppressed.

## Privacy and scope

The commit contains only `src/router.mjs` and `test/router-resilience.test.mjs`. It contains no local provider configuration, model overlay, API key, account identifier, usage log, cache, or generated artifact.