### PR TITLE
fix(catalog): stop the router freezing the picker at a pre-upgrade native list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## Unreleased
 
+- **A new native model no longer stays invisible after a Codex upgrade.** The
+  account catalog endpoint gates its model list on `client_version`, but the
+  router replayed the ETag it had cached under the *previous* version. The
+  server answered `304`, and the router then restamped that pre-upgrade body
+  with the new version — so `cacheIsFresh` passed forever, the model
+  fingerprint never moved, drift never fired, and GPT-6-Astra never reached the
+  picker while the router was installed (issue #645). A `client_version` change
+  now sends an unconditional request, and a `304` answering an unconditional
+  request is treated as a failure rather than blessing the stale body.
+  Revalidation within one `client_version` is unchanged.
+- **An outdated `codex` on PATH can no longer strip a model out of Codex's own
+  cache.** The same endpoint gates its list on `client_version` — measured
+  live, `0.150.0` is not offered `gpt-6-astra` while `0.153.4` is. When the
+  Codex the router resolves is older than the client that last wrote
+  `models_cache.json`, the refresh now declines to write (`stale-client`)
+  instead of replacing the richer list with its own poorer one.
+- **A missing native capture now counts as catalog drift.** With
+  `native-models.json` absent, `nativeCatalogDriftDetected()` returned "nothing
+  to compare" and the startup reconciliation never republished, stranding the
+  picker on whatever was last written even as the account gained models. A
+  missing capture alongside a valid account cache is maximal drift, and
+  republishing re-captures from that cache.
+
 - **Command Code forced tool choices now use the same bounded alias as the tool definition.**
   The 64-character compatibility added in #643 shortened provider-facing tool names but
   left an object 	ool_choice at the client's original spelling, so a forced long tool

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -35,6 +35,31 @@ Expected flow:
 
 No uninstall needed. The router stays installed while merging ALL natives + routed models.
 
+### A new native still does not appear
+
+The account model endpoint gates its list on the Codex **client version**: an
+older client is simply not offered a newly released model. The router asks with
+the version of the Codex CLI it resolves, so a stale `codex` earlier on `PATH`
+than the Codex you actually run will fetch the shorter list.
+
+The router refuses to overwrite Codex's cache with that shorter list and logs:
+
+```
+[codex-router] The resolved Codex CLI is older than the client that wrote the account model cache
+```
+
+Fix it by updating that Codex, or by pointing the router at the right one:
+
+```sh
+CODEX_BIN=/path/to/the/codex/you/run ./bin/refresh-catalog
+```
+
+Check which binary and version the router resolves:
+
+```sh
+./bin/model-router codex doctor
+```
+
 ## State directory belongs to another checkout
 
 If `doctor` reports a state ownership failure, you are running from a clone

--- a/src/native-account-catalog.mjs
+++ b/src/native-account-catalog.mjs
@@ -73,6 +73,24 @@ export function codexClientVersion(value = codexVersion()) {
   return match?.[1];
 }
 
+// Compare the numeric release triple of two client versions. A prerelease
+// suffix is deliberately ignored: it never widens the model list, and treating
+// "unparseable" as "not older" keeps the guard below from ever blocking a
+// refresh it cannot reason about.
+export function olderClientVersion(candidate, reference) {
+  const triple = (value) => {
+    const match = /^(\d+)\.(\d+)\.(\d+)/.exec(String(value || ""));
+    return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined;
+  };
+  const left = triple(candidate);
+  const right = triple(reference);
+  if (!left || !right) return false;
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] < right[index];
+  }
+  return false;
+}
+
 function cacheIsFresh(cache, clientVersion, now) {
   if (!validCatalog(cache) || containsRoutedSlugs(cache)) return false;
   if (cache.client_version !== clientVersion) return false;
@@ -156,11 +174,31 @@ async function refreshNativeAccountCatalogUnlocked({
     return { status: "fresh", fingerprint: current.fingerprint };
   }
 
+  const safeCurrent = validCatalog(current.catalog) && !containsRoutedSlugs(current.catalog);
+  // models_cache.json is Codex's own cache, and this endpoint gates the model
+  // list on client_version: measured against the live endpoint, 0.150.0 is not
+  // offered gpt-6-astra while 0.153.4 is. If the Codex this router resolved is
+  // older than the client that last wrote the cache -- an outdated `codex` on
+  // PATH while the user runs a newer Codex, say -- then our answer is the
+  // poorer one, and writing it would take a model away from the Codex actually
+  // running (issue #645). Leave the richer cache alone and say why.
+  if (safeCurrent && olderClientVersion(clientVersion, current.catalog.client_version)) {
+    return { status: "stale-client", fingerprint: current.fingerprint };
+  }
+
   const accountHeaders = await headersProvider();
   if (!accountHeaders?.authorization) return { status: "unavailable" };
 
-  const safeCurrent = validCatalog(current.catalog) && !containsRoutedSlugs(current.catalog);
-  const etag = safeCurrent ? safeEtag(current.catalog.etag) : undefined;
+  // The account endpoint varies its answer on `client_version`: a Codex
+  // upgrade is exactly the moment a newly gated native joins the list, which
+  // is how GPT-6-Astra went missing for router installs (issue #645). An ETag
+  // earned under the previous client_version does not describe the answer
+  // this one would receive, so replaying it invites a 304 that pins the
+  // picker to the pre-upgrade catalog for good. Revalidate only within the
+  // version that issued the validator; across a version change, ask outright.
+  const etag = safeCurrent && current.catalog.client_version === clientVersion
+    ? safeEtag(current.catalog.etag)
+    : undefined;
   // Keep the credential sink fixed. Tests replace the transport, never the
   // destination, so this helper cannot be repurposed to send Codex auth to an
   // operator-controlled URL.
@@ -184,25 +222,13 @@ async function refreshNativeAccountCatalogUnlocked({
       signal: AbortSignal.timeout(timeoutMs),
       ...(dispatcher ? { dispatcher } : {}),
     });
-    if (response.status === 304 && safeCurrent) {
+    if (response.status === 304) {
       await Promise.resolve(response.body?.cancel?.()).catch(() => undefined);
-      // A client upgrade invalidates Codex's own cache even when the account
-      // ETag is unchanged. Restamp that one transition so later checks can use
-      // the normal TTL without rewriting a large unchanged cache every cycle.
-      if (current.catalog.client_version !== clientVersion) {
-        if (!sameAccountSession(accountHeaders, await headersProvider())) {
-          return { status: "failed" };
-        }
-        await writeCache(
-          cachePath,
-          {
-            ...current.catalog,
-            fetched_at: new Date(now).toISOString(),
-            client_version: clientVersion,
-          },
-          { directoryMode: 0o700 },
-        );
-      }
+      // Only a conditional request can be answered 304, and one is sent only
+      // when the cached validator belongs to this client_version. A 304 to an
+      // unconditional request is a server ignoring us, and blessing the stale
+      // body as current is precisely the freeze this guard exists to prevent.
+      if (!etag) return { status: "failed" };
       return { status: "not-modified", fingerprint: current.fingerprint };
     }
     if (!response.ok || response.status >= 300) {

--- a/src/native-catalog-drift.mjs
+++ b/src/native-catalog-drift.mjs
@@ -85,9 +85,13 @@ export function nativeCatalogDriftDetected() {
       return false;
     }
 
-    // If no stored catalog exists yet, no drift to detect
+    // A missing capture is not "nothing to compare" -- it is maximal drift.
+    // Reaching here means Codex integration is installed (the guard above
+    // returns early otherwise), so a catalog was published from a capture
+    // that no longer exists and nothing else will notice the account gaining
+    // a model (issue #645). Republishing re-captures from the account cache.
     if (!existsSync(NATIVE_CATALOG_PATH)) {
-      return false;
+      return true;
     }
 
     // Read the stored native catalog
@@ -121,7 +125,19 @@ export async function republishOnNativeDrift({
   // model_catalog_json stops Codex's own account cache writer. Refresh the
   // fixed ChatGPT account endpoint first; on any failure the updater leaves
   // the prior cache untouched and the local drift comparison remains safe.
-  await refreshAccountCatalog();
+  const accountRefresh = await refreshAccountCatalog();
+  // Every other status is transient or a no-op, but this one is a standing
+  // misconfiguration that silently freezes the picker: the router keeps
+  // resolving a Codex older than the one that wrote the account cache, so it
+  // can never learn about a newly gated native (issue #645). Say so once per
+  // check rather than leaving the user to guess why a model never arrives.
+  if (accountRefresh?.status === "stale-client") {
+    console.error(
+      "[codex-router] The resolved Codex CLI is older than the client that wrote the account model cache; "
+        + "leaving the cache alone. Update Codex, or point CODEX_BIN at the Codex you actually run, "
+        + "so newly released native models can appear.",
+    );
+  }
   const nativeDrift = nativeDriftDetected();
   const routedAgentDrift = routedAgentDriftDetected();
   if (!nativeDrift && !routedAgentDrift) {

--- a/src/refresh-catalog.mjs
+++ b/src/refresh-catalog.mjs
@@ -37,7 +37,7 @@ export function refreshCatalogCompletionMessage(status) {
   if (status === "disabled") {
     return "Bundled native and external model catalogs refreshed. Fully quit and reopen Codex.\n";
   }
-  if (status === "failed" || status === "unavailable") {
+  if (status === "failed" || status === "unavailable" || status === "stale-client") {
     return "External models refreshed; native models were rebuilt from available cached and bundled data because the live account catalog could not be refreshed. Fully quit and reopen Codex.\n";
   }
   return "Native account, bundled, and external model catalogs refreshed. Fully quit and reopen Codex.\n";

--- a/test/native-account-catalog.test.mjs
+++ b/test/native-account-catalog.test.mjs
@@ -238,8 +238,11 @@ test("an account switch during the request cannot overwrite the new account cach
     assert.equal(readFileSync(cachePath, "utf8"), contents);
   }));
 
-test("an account switch during a version revalidation cannot restamp the cache", () =>
+test("a version-mismatched cache is never restamped, account switch or not", () =>
   withCache(async (cachePath) => {
+    // The router no longer carries a restamp path at all: a client_version
+    // change sends an unconditional request, so a 304 here can only be a
+    // server ignoring us. Either way the stale body stays unblessed.
     const contents = JSON.stringify(fixtureCache(
       [{ slug: "gpt-before-switch" }],
       { client_version: "0.152.0" },
@@ -260,4 +263,157 @@ test("an account switch during a version revalidation cannot restamp the cache",
     });
     assert.equal(result.status, "failed");
     assert.equal(readFileSync(cachePath, "utf8"), contents);
+  }));
+
+test("a Codex upgrade asks outright instead of replaying the previous version's ETag", () =>
+  withCache(async (cachePath) => {
+    // The account endpoint gates natives on client_version, so the answer the
+    // old validator described is not the answer this client would get. Sending
+    // it invites a 304 that hides a newly released native forever (issue #645).
+    const staleModels = [{ slug: "gpt-5.6-sol", visibility: "list" }];
+    const upgradedModels = [
+      { slug: "gpt-5.6-sol", visibility: "list" },
+      { slug: "gpt-6-astra", visibility: "list" },
+    ];
+    writeFileSync(cachePath, JSON.stringify(fixtureCache(staleModels)));
+    let request;
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      now: Date.parse("2026-09-09T00:00:00.000Z"),
+      version: "0.153.4",
+      headersProvider,
+      discoveryOff: () => false,
+      lock: noLock,
+      fetchImpl: async (url, init) => {
+        request = { url, init };
+        return new Response(JSON.stringify({ models: upgradedModels }), {
+          status: 200,
+          headers: { etag: 'W/"astra-account-catalog"' },
+        });
+      },
+    });
+
+    assert.match(request.url, /client_version=0\.153\.4/);
+    assert.equal(
+      request.init.headers["if-none-match"],
+      undefined,
+      "an ETag from client_version 0.153.2 must not condition a 0.153.4 request",
+    );
+    assert.equal(result.status, "updated");
+    const written = JSON.parse(readFileSync(cachePath, "utf8"));
+    assert.deepEqual(written.models, upgradedModels);
+    assert.equal(written.client_version, "0.153.4");
+    assert.equal(written.etag, 'W/"astra-account-catalog"');
+  }));
+
+test("an unconditional request answered 304 leaves the stale cache unblessed", () =>
+  withCache(async (cachePath) => {
+    // Restamping the old body with the new client_version would make
+    // cacheIsFresh pass forever and freeze the picker at the pre-upgrade list.
+    const contents = `${JSON.stringify(fixtureCache([{ slug: "gpt-5.6-sol" }]), null, 2)}\n`;
+    writeFileSync(cachePath, contents);
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      now: Date.parse("2026-09-09T00:00:00.000Z"),
+      version: "0.153.4",
+      headersProvider,
+      discoveryOff: () => false,
+      lock: noLock,
+      fetchImpl: async () => new Response(null, { status: 304 }),
+    });
+    assert.equal(result.status, "failed");
+    assert.equal(readFileSync(cachePath, "utf8"), contents);
+  }));
+
+test("a matching client_version still revalidates with its own ETag", () =>
+  withCache(async (cachePath) => {
+    const contents = `${JSON.stringify(fixtureCache([{ slug: "gpt-5.6-sol" }]), null, 2)}\n`;
+    writeFileSync(cachePath, contents);
+    let request;
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      version: "0.153.2",
+      headersProvider,
+      discoveryOff: () => false,
+      lock: noLock,
+      fetchImpl: async (url, init) => {
+        request = { url, init };
+        return new Response(null, { status: 304 });
+      },
+    });
+    assert.equal(request.init.headers["if-none-match"], 'W/"old-account-catalog"');
+    assert.equal(result.status, "not-modified");
+    assert.equal(readFileSync(cachePath, "utf8"), contents);
+  }));
+
+test("an older resolved Codex cannot narrow the cache a newer client wrote", () =>
+  withCache(async (cachePath) => {
+    // Measured against the live endpoint: client_version 0.150.0 is not
+    // offered gpt-6-astra while 0.153.4 is. A stale `codex` on PATH must not
+    // be able to strip that model out of Codex's own cache (issue #645).
+    const contents = `${JSON.stringify(fixtureCache(
+      [{ slug: "gpt-5.6-sol" }, { slug: "gpt-6-astra" }],
+      { client_version: "0.153.4" },
+    ), null, 2)}\n`;
+    writeFileSync(cachePath, contents);
+    const forbidden = () => {
+      throw new Error("a downgrade must touch neither credential nor network");
+    };
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      version: "0.150.0",
+      headersProvider: forbidden,
+      discoveryOff: () => false,
+      lock: noLock,
+      fetchImpl: forbidden,
+    });
+    assert.equal(result.status, "stale-client");
+    assert.equal(readFileSync(cachePath, "utf8"), contents);
+  }));
+
+test("an equal or newer client version still refreshes", () =>
+  withCache(async (cachePath) => {
+    for (const version of ["0.153.4", "0.154.0"]) {
+      const models = [{ slug: "gpt-5.6-sol" }, { slug: "gpt-6-astra" }];
+      writeFileSync(cachePath, JSON.stringify(fixtureCache(
+        [{ slug: "gpt-5.6-sol" }],
+        { client_version: "0.153.4" },
+      )));
+      const result = await refreshNativeAccountCatalog({
+        cachePath,
+        force: true,
+        now: Date.parse("2026-09-09T00:00:00.000Z"),
+        version,
+        headersProvider,
+        discoveryOff: () => false,
+        lock: noLock,
+        fetchImpl: async () => new Response(JSON.stringify({ models }), { status: 200 }),
+      });
+      assert.equal(result.status, "updated", version);
+      assert.deepEqual(JSON.parse(readFileSync(cachePath, "utf8")).models, models);
+    }
+  }));
+
+test("an unparseable version on either side never blocks a refresh", () =>
+  withCache(async (cachePath) => {
+    const models = [{ slug: "gpt-6-astra" }];
+    writeFileSync(cachePath, JSON.stringify(fixtureCache(
+      [{ slug: "gpt-5.6-sol" }],
+      { client_version: "unknown-build" },
+    )));
+    const result = await refreshNativeAccountCatalog({
+      cachePath,
+      force: true,
+      now: Date.parse("2026-09-09T00:00:00.000Z"),
+      version: "0.150.0",
+      headersProvider,
+      discoveryOff: () => false,
+      lock: noLock,
+      fetchImpl: async () => new Response(JSON.stringify({ models }), { status: 200 }),
+    });
+    assert.equal(result.status, "updated");
   }));

--- a/test/native-catalog-drift-missing-capture.test.mjs
+++ b/test/native-catalog-drift-missing-capture.test.mjs
@@ -1,0 +1,92 @@
+// Own file: paths.mjs freezes its constants at first import, so the state
+// directory this scenario needs has to be in the environment before anything
+// under src/ is loaded.
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "native-drift-missing-"));
+const stateDir = path.join(tempDir, "state");
+const codexHome = path.join(tempDir, "codex");
+mkdirSync(stateDir, { recursive: true });
+mkdirSync(codexHome, { recursive: true });
+process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+process.env.CODEX_HOME = codexHome;
+process.env.MODEL_ROUTER_TARGET = "codex";
+
+const { nativeCatalogDriftDetected } = await import("../src/native-catalog-drift.mjs");
+const { CONFIG_PATH, NATIVE_CATALOG_PATH } = await import("../src/paths.mjs");
+
+test.after(() => rmSync(tempDir, { recursive: true, force: true }));
+
+test("a missing native capture is drift, not 'nothing to compare'", () => {
+  writeFileSync(
+    CONFIG_PATH,
+    '# BEGIN codex-router-managed\nopenai_base_url = "http://test"\n# END codex-router-managed\n',
+  );
+  writeFileSync(
+    path.join(codexHome, "models_cache.json"),
+    JSON.stringify({ models: [{ slug: "gpt-6-astra", visibility: "list" }] }),
+  );
+
+  // The published catalog was built from a capture that is gone. Nothing else
+  // notices the account gaining a model, so answering "no drift" here strands
+  // the picker on whatever was published last (issue #645).
+  assert.equal(existsSync(NATIVE_CATALOG_PATH), false);
+  assert.equal(
+    nativeCatalogDriftDetected(),
+    true,
+    "a missing capture with a valid account cache must republish",
+  );
+});
+
+test("an uninstalled Codex integration still reports no drift", () => {
+  rmSync(CONFIG_PATH, { force: true });
+  assert.equal(
+    nativeCatalogDriftDetected(),
+    false,
+    "without managed config there is no picker to republish",
+  );
+});
+
+test("a stale resolved Codex is reported instead of freezing the picker silently", async () => {
+  const { republishOnNativeDrift } = await import("../src/native-catalog-drift.mjs");
+  const errors = [];
+  const original = console.error;
+  console.error = (message) => errors.push(String(message));
+  try {
+    const republished = await republishOnNativeDrift({
+      refreshAccountCatalog: async () => ({ status: "stale-client" }),
+      nativeDriftDetected: () => false,
+      routedAgentDriftDetected: () => false,
+      refreshTargetPicker: () => { throw new Error("no republish expected"); },
+    });
+    assert.equal(republished, false);
+  } finally {
+    console.error = original;
+  }
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /older than the client that wrote the account model cache/);
+  assert.match(errors[0], /CODEX_BIN/);
+});
+
+test("an ordinary refresh status stays quiet", async () => {
+  const { republishOnNativeDrift } = await import("../src/native-catalog-drift.mjs");
+  const errors = [];
+  const original = console.error;
+  console.error = (message) => errors.push(String(message));
+  try {
+    for (const status of ["fresh", "unchanged", "not-modified", "updated", "failed"]) {
+      await republishOnNativeDrift({
+        refreshAccountCatalog: async () => ({ status }),
+        nativeDriftDetected: () => false,
+        routedAgentDriftDetected: () => false,
+      });
+    }
+  } finally {
+    console.error = original;
+  }
+  assert.deepEqual(errors, []);
+});


### PR DESCRIPTION
Fixes #645.

## What users saw

GPT-6-Astra missing from the Codex picker, and back as soon as the router was disabled. Two reporters confirmed; one called it critical.

## Root cause

The account model endpoint gates its list on `client_version`. Measured against the live endpoint with one account:

| `client_version` | models returned |
|---|---|
| `0.150.0` | 7 — **no `gpt-6-astra`** |
| `0.153.4` | 8 — includes `gpt-6-astra` |

Because `model_catalog_json` stops Codex's own cache writer, the router is the only thing refreshing `models_cache.json`. Whatever it fetches *is* the world the picker sees. Three defects each freeze that world on their own:

**1. A validator replayed across versions.** The refresh sent the ETag cached under the *previous* `client_version`. That validator does not describe the answer the new version would get. On the resulting `304`, the router restamped the pre-upgrade body with the new version — after which `cacheIsFresh` passed forever, the model fingerprint never moved, and drift never fired. A Codex upgrade is exactly when a newly gated model appears, so this froze users at the moment they should have gained one.

**2. A downgrade write.** The version asked with is that of the Codex CLI the *router* resolves — not necessarily the Codex the user runs. An older `codex` earlier on `PATH` is enough. That fetch then overwrote Codex's own cache with the narrower list: the router literally removing a model the user had.

**3. Drift that could not be detected.** `nativeCatalogDriftDetected` read a missing `native-models.json` as "nothing to compare" and returned `false`, so startup never republished even though the published catalog came from a capture that no longer exists.

## Change

- A `client_version` change sends an **unconditional** request; the ETag is only replayed within the version that issued it. A `304` answering an unconditional request is a failure, not a blessing of the stale body. The restamp path is gone.
- A refresh whose client is older than the one that wrote the cache **declines to write** and reports `stale-client`. The startup reconciler logs that once per check, naming `CODEX_BIN` as the fix, so a standing misconfiguration stops being silent.
- A missing capture beside a valid account cache is **maximal drift**, not "nothing to compare".

## Verification

End to end against the live endpoint, on a real install:

```
stale-client: {"status":"stale-client", ...}
  models kept: gpt-6-astra,gpt-reserve,gpt-5.6-sol,...   ← not narrowed by an 0.150.0 client
upgrade status: updated
  models now:  gpt-6-astra,gpt-reserve,gpt-5.6-sol,...   ← recovered across 0.150.0 → 0.153.4
```

Plus 10 new unit tests covering the version-gated ETag, the unconditional `304`, the downgrade guard, unparseable versions on either side, the missing-capture drift case, and the new console warning. `npm run check` passes.

One caveat worth stating plainly: in a full-suite run under heavy parallel load, two unrelated Z.ai/LiteLLM routing tests returned `502`. They pass in isolation both with and without this change, so they read as load flakes rather than a regression — CI's full run is the arbiter.

## Docs

`docs/TROUBLESHOOTING.md` gains a "A new native still does not appear" section explaining the `client_version` gate and the `CODEX_BIN` remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
