### PR TITLE
feat: correlate Grok requests and export private run metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Routed workers expose read-only request progress.** `bin/control activity
+  [thread-id]` reports active requests and bounded recent outcomes behind the
+  caller capability, including observed stream events and cancellation causes.
+  Quiet polling never ends a request, and the shipped agent guidance separates
+  polling intervals from worker deadlines.
+- **Grok repairs require a successful response terminal.** Failed, incomplete,
+  and truncated streams return a terminal error without releasing withheld
+  client actions or private final answers. Reasoning remains live.
 - **The ChatGPT Web provider is removed: using it risked an OpenAI account
   ban.** `chatgpt-web` routed Codex turns into an unofficial browser automation
   of chatgpt.com, driven through a separately installed launcher on loopback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - **Grok repairs require a successful response terminal.** Failed, incomplete,
   and truncated streams return a terminal error without releasing withheld
   client actions or private final answers. Reasoning remains live.
+- **Grok gateway stream errors reach Codex as terminal failures.** Untyped
+  gateway errors are normalized without exposing upstream diagnostics or
+  appending empty message closes, and request activity records the failure.
 - **The ChatGPT Web provider is removed: using it risked an OpenAI account
   ban.** `chatgpt-web` routed Codex turns into an unofficial browser automation
   of chatgpt.com, driven through a separately installed launcher on loopback

--- a/docs/GROK_RUN_REPORT.md
+++ b/docs/GROK_RUN_REPORT.md
@@ -1,0 +1,73 @@
+# Local Grok run reports
+
+`src/grok-run-report.mjs` creates a metrics-only JSON report from existing local
+event files. It makes no network requests and does not change model behavior.
+Keep source logs private: they may contain prompts, tool contents and credentials.
+The exported report explicitly projects counters and timings; it never copies
+prompts, instructions, tool arguments or results, session titles or reasoning text.
+
+For Codex, collect `/activity` snapshots throughout the run using the authenticated
+local control interface, save those JSON objects as JSONL, and retain the run's
+rollout and Router usage events. Activity is bounded in memory: a snapshot only
+after a long run can miss early requests.
+
+```sh
+node src/grok-run-report.mjs \
+  --codex-rollout generated/run/rollout.jsonl \
+  --activity generated/run/activity.jsonl \
+  --usage generated/run/usage-events.jsonl \
+  --thread-id WORKER_THREAD_ID \
+  --started-at 2026-09-09T09:00:00Z \
+  --ended-at 2026-09-09T09:10:00Z \
+  --out generated/run/report.json
+```
+
+Usage joins activity by exact `requestId`. Old records remain usable, but cannot
+be correlated by guessing from timestamps or token totals. Complete correlated
+Router counters take priority; otherwise the report can use Codex usage events.
+Missing reasoning counters stay missing, and explicitly reported zero stays zero.
+
+For Grok CLI, supply one invocation's `--output-format streaming-json` output,
+the local unified log, and the session events. Select its session ID and exact
+time window; logs from other sessions are excluded.
+
+```sh
+node src/grok-run-report.mjs \
+  --grok-events generated/run/cli-events.jsonl \
+  --grok-log generated/run/unified.jsonl \
+  --grok-session-events generated/run/session-events.jsonl \
+  --session-id GROK_SESSION_ID \
+  --started-at 2026-09-09T09:00:00Z \
+  --ended-at 2026-09-09T09:10:00Z \
+  --outcome completed \
+  --out generated/run/report.json
+```
+
+The output parent directory must already exist. New output files use mode 0600
+on POSIX. A terminal outcome can be `completed`, `failed`, `cancelled` or
+`timeout`; a quiet stream alone does not justify a terminal outcome. Malformed
+complete JSONL records fail the report; an incomplete final line is ignored so
+live files can be inspected. Prefer complete files for final comparisons.
+
+Interpretation:
+
+- Token fields include `reported` and `missing` coverage. Input totals include
+  cache reads and writes for both harnesses. Reasoning is part of output tokens,
+  not an extra amount to add to the output total.
+- Request throughput divides output tokens by full request duration only when
+  request/count coverage matches. It is not a decoding-speed estimate. Text
+  time-to-first-token is never subtracted from reasoning-inclusive token timing.
+- Tool duration is the union of observed tool intervals, avoiding double counting
+  parallel tools. `firstTestAfterMs` recognizes common test-runner commands;
+  indirect wrapper scripts may not be recognized.
+- `unobservedMs` is wall time outside observed requests/tools, including scheduling
+  and uninstrumented work. It cannot establish a specific cause of delay.
+- `contextBytes` separates UTF-8 JSON sizes of Router ingress instructions, tool
+  definitions and input history. These are bytes, not exact token counts.
+- Worker completion does not prove code correctness. Record external test exit
+  statuses, independent review, source SHA, environment, deadline and any
+  interruption separately. Keep failed and interrupted runs in comparisons.
+
+This report does not instrument arbitrary tool wrappers or capture internal
+reasoning. Grok CLI events must come from a single invocation; concatenating
+multiple resumed invocations would defeat the timestamp-free usage boundary.

--- a/docs/GROK_RUN_REPORT.md
+++ b/docs/GROK_RUN_REPORT.md
@@ -59,8 +59,12 @@ Interpretation:
   time-to-first-token is never subtracted from reasoning-inclusive token timing.
 - Tool duration is the union of observed tool intervals, avoiding double counting
   parallel tools. `firstTestAfterMs` recognizes common test-runner commands;
-  only direct command positions are recognized. Quoted examples, filenames and
+  only direct command positions are recognized. This measures the first attempt,
+  which may fail before the test runner starts. Quoted examples, filenames and
   comments do not count; heredocs and indirect wrapper scripts are omitted.
+- CLI tool failures include terminal shell exit codes, signals and timeouts,
+  even when the surrounding tool reports `completed`. Repeated updates for one
+  tool call are counted once; interim shell output is not a terminal result.
 - `unobservedMs` is wall time outside observed requests/tools, including scheduling
   and uninstrumented work. It cannot establish a specific cause of delay.
 - `contextBytes` separates UTF-8 JSON sizes of Router ingress instructions, tool

--- a/docs/GROK_RUN_REPORT.md
+++ b/docs/GROK_RUN_REPORT.md
@@ -59,7 +59,8 @@ Interpretation:
   time-to-first-token is never subtracted from reasoning-inclusive token timing.
 - Tool duration is the union of observed tool intervals, avoiding double counting
   parallel tools. `firstTestAfterMs` recognizes common test-runner commands;
-  indirect wrapper scripts may not be recognized.
+  only direct command positions are recognized. Quoted examples, filenames and
+  comments do not count; heredocs and indirect wrapper scripts are omitted.
 - `unobservedMs` is wall time outside observed requests/tools, including scheduling
   and uninstrumented work. It cannot establish a specific cause of delay.
 - `contextBytes` separates UTF-8 JSON sizes of Router ingress instructions, tool

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -393,6 +393,24 @@ is correct." is not talked into a call the client would then run. Raise
 `CODEX_ROUTER_GROK_PROGRESS_ONLY_MAX_TEXT` to fire less often on that
 user-message path; those settings do not weaken the post-tool invariant.
 
+For a quiet worker, run `bin/control activity <thread-id>` from the installed
+checkout. The command reads the capability-protected `/v1/activity` endpoint;
+unauthenticated `/health` keeps its existing compact contract. Active requests
+remain visible until their handlers release resources, independently of tray
+record retention. The snapshot includes router-upstream attempt count, byte/event
+timestamps, observed phase, and recent outcomes (128 entries, ten minutes, in
+memory). These observations do not identify raw provider timing or retries inside
+LiteLLM/xAI. Metrics cover the main Responses dispatch/stream; uninstrumented
+subpaths such as compaction/embeddings show `unobserved` and omit attempt count.
+An HTTP 200 envelope with a failed/incomplete response event is still `failed`.
+No prompt, answer, tool arguments, or credentials are retained.
+An unavailable probe reports `unknown`, not an empty/completed worker. A changed
+instance ID means the router restarted and lost its recent history. A cancellation
+records a client disconnect or an execution deadline; a disconnect cannot identify
+whether the user or a parent agent initiated it. Wait timeouts and quiet streams
+are not authorization to replace a worker. Consult its native task state and
+confirm that the old writer has stopped before starting another.
+
 Both attempts are billed. The usage returned to Codex reports only the
 selected attempt's context size, while the local ledger retains the aggregate
 as billed input/output tokens. The response sets

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -397,12 +397,14 @@ For a quiet worker, run `bin/control activity <thread-id>` from the installed
 checkout. The command reads the capability-protected `/v1/activity` endpoint;
 unauthenticated `/health` keeps its existing compact contract. Active requests
 remain visible until their handlers release resources, independently of tray
-record retention. The snapshot includes router-upstream attempt count, byte/event
-timestamps, observed phase, and recent outcomes (128 entries, ten minutes, in
-memory). These observations do not identify raw provider timing or retries inside
+record retention. The snapshot includes router-upstream attempt count, raw byte
+timestamps, normalized Responses event timestamps, observed phase, and recent
+outcomes (128 entries, ten minutes, in memory). These observations do not identify raw provider timing or retries inside
 LiteLLM/xAI. Metrics cover the main Responses dispatch/stream; uninstrumented
 subpaths such as compaction/embeddings show `unobserved` and omit attempt count.
 An HTTP 200 envelope with a failed/incomplete response event is still `failed`.
+Untyped Grok gateway error envelopes become a safe terminal `error` event;
+later empty message closes or success markers are discarded.
 No prompt, answer, tool arguments, or credentials are retained.
 An unavailable probe reports `unknown`, not an empty/completed worker. A changed
 instance ID means the router restarted and lost its recent history. A cancellation

--- a/skills/codex-router/SKILL.md
+++ b/skills/codex-router/SKILL.md
@@ -66,8 +66,9 @@ never overlap two writers for the same work.
 When shell access is available, inspect the installed router with
 `~/.local/share/codex-router/bin/control activity <thread-id>` (omit the ID for
 all requests). This is read-only. It reports active requests and up to 128 recent
-results retained for ten minutes. `lastEventAt`/`lastByteAt` describe events
-received at the router's upstream boundary, not raw xAI progress. An open request
+results retained for ten minutes. `lastByteAt` describes raw bytes received at
+the router's upstream boundary; `lastEventAt` describes normalized Responses
+events, not raw xAI progress. An open request
 alone does not prove generation. An empty result, an offline probe, or a changed
 `instanceId` does not prove the worker finished; check the native task status.
 `canceling` stays active until cleanup; `client_disconnected` cannot identify

--- a/skills/codex-router/SKILL.md
+++ b/skills/codex-router/SKILL.md
@@ -63,17 +63,15 @@ cancellation, or a task deadline established independently of the polling interv
 Before replacement, check the worker's current state and confirm it has stopped;
 never overlap two writers for the same work.
 
-When shell access is available, inspect the installed router with
-`~/.local/share/codex-router/bin/control activity <thread-id>` (omit the ID for
-all requests). This is read-only. It reports active requests and up to 128 recent
-results retained for ten minutes. `lastByteAt` describes raw bytes received at
-the router's upstream boundary; `lastEventAt` describes normalized Responses
-events, not raw xAI progress. An open request
-alone does not prove generation. An empty result, an offline probe, or a changed
-`instanceId` does not prove the worker finished; check the native task status.
-`canceling` stays active until cleanup; `client_disconnected` cannot identify
-whether the user or an orchestrator initiated cancellation. Polling never changes
-these states or restarts a task.
+Use the read-only `~/.local/share/codex-router/bin/control activity <thread-id>`
+when shell access is available; omit the ID for all requests. It reports active
+requests and up to 128 recent results retained for ten minutes. `lastByteAt`
+tracks raw bytes at the router boundary; `lastEventAt` tracks normalized Responses
+events, not raw xAI progress. An open request alone does not prove generation.
+Empty/offline results or a changed `instanceId` do not prove worker completion;
+check native task status. `canceling` stays active until cleanup, and
+`client_disconnected` cannot distinguish user cancellation from an orchestrator's.
+Polling never changes these states or restarts a task.
 
 ## What the token and usage numbers mean
 

--- a/skills/codex-router/SKILL.md
+++ b/skills/codex-router/SKILL.md
@@ -54,6 +54,26 @@ arguments are model-generated and must not silently cross a provider or billing
 boundary. Follow-up messages retain the target thread's settings, and cloud
 tasks choose their model outside this relay.
 
+## Waiting for a routed worker
+
+A wait/poll timeout or quiet stream is not a failed worker. Keep its task ID
+and wait again; do not interrupt, resend its assignment, or spawn a replacement
+only because a poll returned. End waiting on an explicit terminal result, user
+cancellation, or a task deadline established independently of the polling interval.
+Before replacement, check the worker's current state and confirm it has stopped;
+never overlap two writers for the same work.
+
+When shell access is available, inspect the installed router with
+`~/.local/share/codex-router/bin/control activity <thread-id>` (omit the ID for
+all requests). This is read-only. It reports active requests and up to 128 recent
+results retained for ten minutes. `lastEventAt`/`lastByteAt` describe events
+received at the router's upstream boundary, not raw xAI progress. An open request
+alone does not prove generation. An empty result, an offline probe, or a changed
+`instanceId` does not prove the worker finished; check the native task status.
+`canceling` stays active until cleanup; `client_disconnected` cannot identify
+whether the user or an orchestrator initiated cancellation. Polling never changes
+these states or restarts a task.
+
 ## What the token and usage numbers mean
 
 - The router meter records provider-reported counts verbatim. When the

--- a/src/control-activity.mjs
+++ b/src/control-activity.mjs
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { assertCallerSecret, callerBaseUrl } from "./caller-auth.mjs";
+import { CALLER_SECRET_PATH, PORTS } from "./paths.mjs";
+
+// No provider request, model invocation, or task mutation is made by this probe.
+// Keep capability URLs out of both errors and the JSON returned to an agent.
+export async function readControlActivity({
+  threadId,
+  fetchImpl = globalThis.fetch,
+  readCallerSecret = () => readFileSync(CALLER_SECRET_PATH, "utf8"),
+  routerPort = PORTS.router,
+  timeoutMs = 3_000,
+} = {}) {
+  const unavailable = (error) => ({ ok: false, state: "unknown", error });
+  if (threadId !== undefined && !/^[A-Za-z0-9_-]{1,160}$/.test(threadId)) {
+    return unavailable("Invalid thread ID.");
+  }
+  let callerSecret;
+  try { callerSecret = assertCallerSecret(readCallerSecret().trim()); }
+  catch { return unavailable("The local router caller key is unavailable."); }
+  try {
+    const query = threadId ? `?threadId=${encodeURIComponent(threadId)}` : "";
+    const response = await fetchImpl(`${callerBaseUrl(routerPort, callerSecret)}/activity${query}`, {
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+      redirect: "error",
+    });
+    if (!response.ok) return unavailable("Router activity is unavailable; the router may need updating.");
+    const body = await response.json();
+    if (body?.version !== 1 || !Array.isArray(body.active) || !Array.isArray(body.recent)) {
+      return unavailable("Router activity returned an unsupported response.");
+    }
+    return {
+      ok: true,
+      version: 1,
+      instanceId: body.instanceId,
+      observedAt: body.observedAt,
+      observationPoint: "router_upstream",
+      active: body.active.map(safeRecord),
+      recent: body.recent.map(safeRecord),
+    };
+  } catch {
+    return unavailable("Router activity could not be read.");
+  }
+}
+
+function safeRecord(record) {
+  const result = {};
+  if (!record || typeof record !== "object") return result;
+  for (const key of ["requestId", "state", "phase", "provider", "model", "threadId", "parentThreadId", "sessionId", "agentName", "cancelReason", "terminalEvent", "observationPoint"]) {
+    if (typeof record[key] === "string" && record[key].length <= 160) result[key] = record[key];
+  }
+  for (const key of ["startedAt", "endedAt", "status", "upstreamAttempts", "receivedBytes", "receivedEvents", "lastHeadersAt", "lastEventAt", "lastByteAt", "cancelRequestedAt"]) {
+    if (Number.isFinite(record[key]) && record[key] >= 0) result[key] = record[key];
+  }
+  if (typeof record.isSubagent === "boolean") result.isSubagent = record.isSubagent;
+  return result;
+}

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 
 import { pickerCommandArgs } from "./control-args.mjs";
 import { readControlHealth } from "./control-health.mjs";
+import { readControlActivity } from "./control-activity.mjs";
 import { nativeSubagentCertification, promoteNativeMultiAgent } from "./catalog.mjs";
 import {
   applyModelOverlayPublication,
@@ -3450,6 +3451,9 @@ if (args.includes("--probe")) {
   await handleChatGptSession(args[1]);
 } else if (args[0] === "chatgpt-account-pool") {
   await handleChatGptAccountSwitch(args[1], args[2], args[3]);
+} else if (args[0] === "activity") {
+  if (args.length > 2) throw new Error("Usage: control activity [thread-id]");
+  process.stdout.write(`${JSON.stringify(await readControlActivity({ threadId: args[1] }))}\n`);
 } else if (args[0] === "health") {
   await printHealth();
 } else if (args[0] === "maintenance") {

--- a/src/grok-oauth-forwarder.mjs
+++ b/src/grok-oauth-forwarder.mjs
@@ -664,6 +664,25 @@ async function handleChatCompletions(request, response) {
   // Once the head is committed, a failed repair becomes one terminal SSE error.
   if (wantsStream) startStream();
 
+  const rejectUnsuccessfulTurn = (turn, phase, attempt) => {
+    if (turn.terminalStatus === "completed") return false;
+    const status = turn.terminalStatus;
+    const message = status === "missing"
+      ? "Grok ended the upstream response stream without a successful terminal event."
+      : `Grok returned an unsuccessful upstream response (${status}).`;
+    console.error(
+      `[grok-oauth] upstream-terminal-failed=true phase=${phase} model=${model} terminal=${status} ${upstreamAttemptTiming(phase, attempt)}`,
+    );
+    if (wantsStream && streamStarted) {
+      endStreamedResponse(response, { message });
+    } else {
+      writeJson(response, 502, {
+        error: { type: "api_error", code: `grok_upstream_response_${status}`, message },
+      });
+    }
+    return true;
+  };
+
   const emitHeldStrictContent = () => {
     if (!wantsStream || !streamStarted || heldStrictContentDeltas.length === 0) return;
     for (const delta of heldStrictContentDeltas) {
@@ -720,6 +739,10 @@ async function handleChatCompletions(request, response) {
   }
 
   let turn = finalizeTurn(turnState);
+  // Never repair or replay an unsuccessful first attempt. Its live tool
+  // deltas may already have reached the client; only one terminal error is
+  // legal now. Withheld/backfilled deltas stay withheld on failure.
+  if (rejectUnsuccessfulTurn(turn, "attempt", firstAttempt)) return;
   emitPendingDeltas();
   let retried = false;
   let repairFailure;
@@ -786,6 +809,10 @@ async function handleChatCompletions(request, response) {
         throw error;
       }
       const second = finalizeTurn(secondState);
+      // Keep both client tools and the private final answer withheld until
+      // response.completed. An item.done followed by EOF/failure is not a
+      // certified repair, even when its arguments look complete.
+      if (rejectUnsuccessfulTurn(second, "repair", repairAttempt)) return;
       retried = true;
       const repair = strictAfterToolRepair
         ? classifyAfterToolRepair(second)
@@ -814,6 +841,7 @@ async function handleChatCompletions(request, response) {
             ? toolCallDeltas(second)
             : [...turn.deltas, ...toolCallDeltas(second)],
           finishReason: "tool_calls",
+          terminalStatus: "completed",
         };
         if (streamStarted) emittedDeltaCount = turn.deltas.length;
       } else if (repair.action === "final") {
@@ -830,6 +858,7 @@ async function handleChatCompletions(request, response) {
           usage: selectedRetryUsage(turn.usage, second.usage),
           deltas: [{ content: repair.contentText }],
           finishReason: "stop",
+          terminalStatus: "completed",
         };
         emittedDeltaCount = 0;
       } else if (repair.action === "fail") {

--- a/src/grok-oauth-turn.mjs
+++ b/src/grok-oauth-turn.mjs
@@ -95,7 +95,7 @@ export function isProgressOnlyStop(
     afterToolResult = false,
   } = {},
 ) {
-  if (!turn || (turn.toolCalls && turn.toolCalls.length > 0)) return false;
+  if (turn?.terminalStatus !== "completed" || turn.toolCalls?.length > 0) return false;
   // After a tool result, prose alone is never accepted as proof of completion.
   // It is repaired into either another client tool call or an internal final
   // answer, regardless of length. This is the invariant that prevents a long
@@ -110,7 +110,7 @@ export function isProgressOnlyStop(
 // Prefer the retry only when it actually called a tool. A second short
 // status sentence is not an improvement; keep the first answer.
 export function shouldPreferRetryTurn(second) {
-  return Boolean(second?.toolCalls?.length);
+  return second?.terminalStatus === "completed" && Boolean(second.toolCalls?.length);
 }
 
 // A repair turn after a tool result is a protocol decision, not a prose
@@ -118,6 +118,10 @@ export function shouldPreferRetryTurn(second) {
 // answer tool call requested above. Anything else is an invalid repair
 // and must become a visible router error rather than a clean `stop`.
 export function classifyAfterToolRepair(second) {
+  // An item-level close only finishes that call's arguments. It does not
+  // certify the response: failed, incomplete, and truncated attempts can all
+  // contain a complete-looking client call or private final-answer call.
+  if (second?.terminalStatus !== "completed") return { action: "fail" };
   const calls = Array.isArray(second?.toolCalls) ? second.toolCalls : [];
   if (calls.length !== 1) return { action: "fail" };
   const [call] = calls;
@@ -230,6 +234,7 @@ export function createTurnState({ toolNameMapper = (name) => name } = {}) {
     toolCalls: [],
     toolByItemId: new Map(),
     usage: undefined,
+    terminalStatus: undefined,
     deltas: [],
     toolNameMapper,
   };
@@ -330,6 +335,9 @@ function ensureToolCall(state, item, itemId, { complete = false } = {}) {
 
 export function applyResponsesEvent(state, event) {
   if (!event || typeof event !== "object") return state;
+  // Once an upstream failure is known, later frames cannot revive this turn
+  // or add actions to it. In particular, [DONE] is never success evidence.
+  if (state.terminalStatus === "failed" || state.terminalStatus === "incomplete") return state;
   switch (event.type) {
     case "response.output_text.delta": {
       if (event.delta) {
@@ -381,6 +389,21 @@ export function applyResponsesEvent(state, event) {
       break;
     }
     case "response.completed": {
+      const status = event.response?.status;
+      state.terminalStatus = !status || status === "completed"
+        ? "completed"
+        : status === "failed" ? "failed" : "incomplete";
+      state.usage = mapUpstreamUsage(event.response?.usage);
+      break;
+    }
+    case "response.failed":
+    case "error": {
+      state.terminalStatus = "failed";
+      state.usage = mapUpstreamUsage(event.response?.usage);
+      break;
+    }
+    case "response.incomplete": {
+      state.terminalStatus = "incomplete";
       state.usage = mapUpstreamUsage(event.response?.usage);
       break;
     }
@@ -391,14 +414,18 @@ export function applyResponsesEvent(state, event) {
 }
 
 export function finalizeTurn(state) {
-  backfillToolArgumentDeltas(state);
+  const terminalStatus = state.terminalStatus || "missing";
+  if (terminalStatus === "completed") backfillToolArgumentDeltas(state);
   return {
     contentText: state.contentText,
     reasoningText: state.reasoningText,
     toolCalls: state.toolCalls,
     usage: state.usage,
     deltas: state.deltas,
-    finishReason: state.toolCalls.length ? "tool_calls" : "stop",
+    terminalStatus,
+    finishReason: terminalStatus === "completed"
+      ? state.toolCalls.length ? "tool_calls" : "stop"
+      : null,
   };
 }
 

--- a/src/grok-reasoning-summary-compat.mjs
+++ b/src/grok-reasoning-summary-compat.mjs
@@ -154,6 +154,12 @@ function summaryText(item) {
     .join("");
 }
 
+function isGatewayErrorEnvelope(event) {
+  return event !== null && typeof event === "object" && !Array.isArray(event)
+    && !Object.hasOwn(event, "type")
+    && event.error !== null && typeof event.error === "object" && !Array.isArray(event.error);
+}
+
 // LiteLLM's Chat Completions -> Responses bridge can open an empty message
 // before Grok starts reasoning, and it hashes every reasoning delta into a
 // different item_id. Codex drops those orphaned deltas, so the user sees
@@ -172,6 +178,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
   #nextSequenceNumber;
   #repairedReasoningItems = [];
   #canonicalReasoningId;
+  #gatewayErrorTerminal = false;
 
   constructor({
     maxFrameBytes = MAX_FRAME_BYTES,
@@ -191,6 +198,10 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
 
   _transform(chunk, _encoding, callback) {
     try {
+      if (this.#gatewayErrorTerminal) {
+        callback();
+        return;
+      }
       const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       if (this.#disabled) {
         this.push(Buffer.from(piece));
@@ -201,7 +212,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
         this.#emitFrame(block, separator, original)
       ));
       if (outcome?.oversized) this.#unsafeFrame(outcome.oversized, "SSE frame byte limit");
-      if (outcome?.remainder?.length) this.push(outcome.remainder);
+      if (!this.#gatewayErrorTerminal && outcome?.remainder?.length) this.push(outcome.remainder);
       callback();
     } catch (error) {
       callback(error);
@@ -210,6 +221,11 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
 
   _flush(callback) {
     try {
+      if (this.#gatewayErrorTerminal) {
+        this.#frames.take();
+        callback();
+        return;
+      }
       if (this.#disabled) {
         const pending = this.#frames.take();
         if (pending.length) this.push(pending);
@@ -238,13 +254,17 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     const pieces = this.#rewriteBlock(text);
     const inferredSeparator = Buffer.from(text.includes("\r\n") ? "\r\n\r\n" : "\n\n");
     for (let index = 0; index < pieces.length; index += 1) {
-      const trailing = separator.length || index === pieces.length - 1
+      // The normalized terminal must be dispatchable even if the gateway
+      // closed its last JSON frame without a blank line.
+      const trailing = this.#gatewayErrorTerminal && !separator.length
+        ? inferredSeparator
+        : separator.length || index === pieces.length - 1
         ? separator
         : inferredSeparator;
       this.push(Buffer.concat([Buffer.from(pieces[index]), trailing]));
     }
     this.#currentSeparator = "";
-    return !this.#disabled;
+    return !this.#disabled && !this.#gatewayErrorTerminal;
   }
 
   #disable(original) {
@@ -412,6 +432,27 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     if (!parsed) return [block];
     const event = parsed.event;
     const type = event?.type;
+
+    // LiteLLM can turn a forwarder SSE error into an untyped gateway error,
+    // then append empty message closes. Recognize only the top-level envelope;
+    // text containing error-shaped JSON and canonical typed events stay intact.
+    if (isGatewayErrorEnvelope(event)) {
+      this.#commitMutation(parsed);
+      const prefix = this.#finishReasoning(parsed, "incomplete");
+      this.#pendingMessage = [];
+      this.#gatewayErrorTerminal = true;
+      // Gateway messages may contain stack traces or request payloads. Emit a
+      // fixed safe error and suppress the rest of this upstream stream.
+      return [...prefix, this.#syntheticBlock("error", {
+        code: "local_router_stream_failed",
+        message: "The Grok gateway could not complete the upstream response stream.",
+        param: null,
+      }, {
+        ...parsed,
+        lines: ["event: error"],
+        newline: this.#currentSeparator === "\r\n\r\n" ? "\r\n" : parsed.newline,
+      })];
+    }
 
     if (!this.#reasoning && type === "response.output_item.added" && event?.item?.type === "message") {
       this.#message = {

--- a/src/grok-run-report.mjs
+++ b/src/grok-run-report.mjs
@@ -96,13 +96,19 @@ export function buildGrokRunReport({ usageEvents = [], activityEvents = [], code
   if (cliEnd) inferredOutcome = cliEnd.stopReason === 'end_turn' ? 'completed' : cliEnd.stopReason === 'cancelled' ? 'cancelled' : 'failed';
   const cliToolIds = new Set();
   const cliTestIds = new Set();
-  let cliToolFailures = 0;
+  const cliToolFailures = new Set();
   for (const row of grokEvents) {
     if (row.type === 'tool_call' && typeof row.toolCallId === 'string') {
       cliToolIds.add(row.toolCallId);
       if (testCommand(row.rawInput?.command)) cliTestIds.add(row.toolCallId);
     }
-    if (row.type === 'tool_call_update' && row.status === 'failed') cliToolFailures++;
+    if (row.type === 'tool_call_update' && typeof row.toolCallId === 'string') {
+      const result = row.rawOutput;
+      const shellFailed = row.status === 'completed' && result?.type === 'Bash' &&
+        (Number.isInteger(result.exit_code) && result.exit_code !== 0 || result.timed_out === true ||
+          typeof result.signal === 'string' && result.signal.length > 0);
+      if (row.status === 'failed' || shellFailed) cliToolFailures.add(row.toolCallId);
+    }
   }
   for (const row of grokSessionEvents) {
     if (!within(row.ts) || row.type !== 'tool_completed') continue;
@@ -146,7 +152,7 @@ export function buildGrokRunReport({ usageEvents = [], activityEvents = [], code
     // Timing is not interchangeable with reasoning-inclusive token counts. Do not
     // subtract text TTFT and present that quotient as decoding throughput.
     firstTokenMs: cli ? total(cliRequests, 'ttft_ms') : total(usage, 'firstTokenMs'),
-    tools: { calls: cli ? cliToolIds.size : toolCount, failures: cli ? cliToolFailures : toolFailures,
+    tools: { calls: cli ? cliToolIds.size : toolCount, failures: cli ? cliToolFailures.size : toolFailures,
       patchFailures: cli ? null : patchFailures, durationMs: toolIntervals.length ? unionMs(toolIntervals) : null,
       firstTestAfterMs: start !== undefined && firstTestAt !== undefined ? firstTestAt - start : null },
     contextBytes: { unit: 'utf8_json_bytes', first: bytes[0] ?? null, last: bytes.at(-1) ?? null },

--- a/src/grok-run-report.mjs
+++ b/src/grok-run-report.mjs
@@ -1,0 +1,192 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const count = (value) => typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+const timestamp = (value) => typeof value === 'string' && Number.isFinite(Date.parse(value)) ? Date.parse(value) : count(value);
+const total = (rows, key) => {
+  const values = rows.map((row) => count(row[key]));
+  return { value: values.some((v) => v !== undefined) ? values.reduce((sum, v) => sum + (v ?? 0), 0) : null,
+    reported: values.filter((v) => v !== undefined).length, missing: values.filter((v) => v === undefined).length };
+};
+const completeValue = (aggregate) => aggregate.missing === 0 ? aggregate.value : null;
+const testCommand = (command) => /(?:\bvitest\b|\bjest\b|\bnpm\s+(?:run\s+)?test\b|\bnode\s+--test\b)/u.test(command ?? '');
+const terminal = new Set(['completed', 'failed', 'cancelled', 'timeout']);
+
+function unionMs(intervals) {
+  const merged = [];
+  for (const [a, b] of intervals.filter(([a, b]) => a !== undefined && b >= a).sort(([a], [b]) => a - b)) {
+    const previous = merged.at(-1);
+    if (previous && a <= previous[1]) previous[1] = Math.max(previous[1], b);
+    else merged.push([a, b]);
+  }
+  return merged.reduce((sum, [a, b]) => sum + b - a, 0);
+}
+
+// Explicit projection only: never copy prompts, tool arguments/results, reasoning,
+// session titles, signatures, or arbitrary provider fields into an exported report.
+export function buildGrokRunReport({ usageEvents = [], activityEvents = [], codexEvents = [],
+  grokEvents = [], grokLog = [], grokSessionEvents = [], threadId, sessionId, startedAt, endedAt, outcome } = {}) {
+  const start = timestamp(startedAt);
+  const end = timestamp(endedAt);
+  const within = (at) => {
+    const t = timestamp(at);
+    return t !== undefined && (start === undefined || t >= start) && (end === undefined || t <= end);
+  };
+  const activity = new Map();
+  for (const snapshot of activityEvents) {
+    for (const row of [...(snapshot.active ?? []), ...(snapshot.recent ?? [])]) {
+      if (!threadId || row.threadId !== threadId || !within(row.startedAt) || typeof row.requestId !== 'string') continue;
+      activity.set(row.requestId, row);
+    }
+  }
+  const requests = [...activity.values()];
+  const settled = requests.filter((row) => count(row.endedAt) !== undefined);
+  const usage = [...new Map(usageEvents.filter((row) => typeof row.requestId === 'string' && activity.has(row.requestId)).map((row) => [row.requestId, row])).values()];
+  const nativeCounts = [];
+  const toolCalls = new Map();
+  const toolIntervals = [];
+  let toolCount = 0, toolFailures = 0, patchFailures = 0, firstTestAt;
+  let inferredOutcome = 'running';
+  for (const event of codexEvents) {
+    if (!within(event.timestamp)) continue;
+    const p = event.payload ?? {};
+    if (event.type === 'event_msg' && p.type === 'token_count' && p.info?.last_token_usage) {
+      const n = p.info.last_token_usage;
+      nativeCounts.push({ inputTokens: n.input_tokens, cachedInputTokens: n.cached_input_tokens,
+        outputTokens: n.output_tokens, reasoningTokens: n.reasoning_output_tokens });
+    }
+    if (event.type === 'event_msg' && ['task_complete', 'task_completed'].includes(p.type)) inferredOutcome = 'completed';
+    if (event.type === 'event_msg' && p.type === 'turn_aborted') inferredOutcome = 'cancelled';
+    if (event.type !== 'response_item') continue;
+    if (['function_call', 'custom_tool_call'].includes(p.type)) {
+      let command;
+      try { command = JSON.parse(p.arguments ?? '{}').cmd; } catch { /* only inspect valid command envelopes */ }
+      toolCalls.set(p.call_id, { at: timestamp(event.timestamp), patch: p.name === 'apply_patch' });
+      toolCount++;
+      if (typeof command === 'string' && testCommand(command)) firstTestAt ??= timestamp(event.timestamp);
+    }
+    if (['function_call_output', 'custom_tool_call_output'].includes(p.type) && toolCalls.has(p.call_id)) {
+      const call = toolCalls.get(p.call_id);
+      toolCalls.delete(p.call_id);
+      toolIntervals.push([call.at, timestamp(event.timestamp)]);
+      const output = typeof p.output === 'string' ? p.output : '';
+      const failedPatch = call.patch && /(?:verification failed|invalid patch)/iu.test(output);
+      if (failedPatch) patchFailures++;
+      if (failedPatch || /(?:Process exited with code|Exit code:)\s*[1-9]\d*/u.test(output)) toolFailures++;
+    }
+  }
+  const cliRequestRows = grokLog.filter((row) => sessionId && row.sid === sessionId && within(row.ts) && row.msg === 'shell.turn.inference_done');
+  const cliRequests = cliRequestRows.map((row) => row.ctx ?? {});
+  const cliUsage = grokEvents.filter((row) => row.type === 'usage').map((row) => ({
+    // CLI usage uses the Messages convention: input_tokens excludes cache.
+    inputTokens: count(row.usage?.input_tokens) === undefined ? undefined : row.usage.input_tokens + (count(row.usage?.cache_read_input_tokens) ?? 0) + (count(row.usage?.cache_creation_input_tokens) ?? 0),
+    cachedInputTokens: row.usage?.cache_read_input_tokens,
+    outputTokens: row.usage?.output_tokens, reasoningTokens: row.usage?.reasoning_tokens,
+  }));
+  const cliEnd = grokEvents.findLast((row) => row.type === 'end');
+  if (cliEnd) inferredOutcome = cliEnd.stopReason === 'end_turn' ? 'completed' : cliEnd.stopReason === 'cancelled' ? 'cancelled' : 'failed';
+  const cliToolIds = new Set();
+  const cliTestIds = new Set();
+  let cliToolFailures = 0;
+  for (const row of grokEvents) {
+    if (row.type === 'tool_call' && typeof row.toolCallId === 'string') {
+      cliToolIds.add(row.toolCallId);
+      if (testCommand(row.rawInput?.command)) cliTestIds.add(row.toolCallId);
+    }
+    if (row.type === 'tool_call_update' && row.status === 'failed') cliToolFailures++;
+  }
+  for (const row of grokSessionEvents) {
+    if (!within(row.ts) || row.type !== 'tool_completed') continue;
+    const finish = timestamp(row.ts), duration = count(row.duration_ms);
+    if (finish !== undefined && duration !== undefined) {
+      toolIntervals.push([finish - duration, finish]);
+      if (cliTestIds.has(row.tool_call_id)) firstTestAt = Math.min(firstTestAt ?? Infinity, finish - duration);
+    }
+  }
+  const cli = grokEvents.length > 0 || cliRequests.length > 0;
+  const routerCountsComplete = usage.length === settled.length && usage.length > 0 && usage.every((row) => count(row.outputTokens) !== undefined);
+  const counts = cli ? cliUsage : routerCountsComplete ? usage : nativeCounts.length ? nativeCounts : usage;
+  const tokens = Object.fromEntries(['inputTokens', 'cachedInputTokens', 'outputTokens', 'reasoningTokens'].map((key) => [key, total(counts, key)]));
+  const durations = cli ? cliRequests.map((row) => count(row.model_elapsed_ms)).filter((v) => v !== undefined)
+    : settled.map((row) => row.endedAt - row.startedAt).filter((v) => v >= 0);
+  const requestMs = durations.length ? durations.reduce((a, b) => a + b, 0) : null;
+  const requestIntervals = cli ? cliRequestRows.flatMap((row) => {
+    const duration = count(row.ctx?.model_elapsed_ms), finish = timestamp(row.ts);
+    return duration === undefined ? [] : [[finish - duration, finish]];
+  }) : settled.map((row) => [row.startedAt, row.endedAt]);
+  const elapsedMs = start !== undefined && end !== undefined && end >= start ? end - start : null;
+  const observedIntervals = [...requestIntervals, ...toolIntervals].map(([a, b]) => [Math.max(start ?? a, a), Math.min(end ?? b, b)]);
+  const outputTokens = completeValue(tokens.outputTokens);
+  const bytes = usage.filter((row) => row.contextBytes?.observationPoint === 'router_ingress').map((row) => {
+    const result = { observationPoint: 'router_ingress' };
+    for (const key of ['instructionsBytes', 'toolsBytes', 'historyBytes']) if (count(row.contextBytes[key]) !== undefined) result[key] = row.contextBytes[key];
+    return result;
+  });
+  return {
+    version: 1, harness: cli ? 'grok-cli' : 'codex', outcome: terminal.has(outcome) ? outcome : inferredOutcome,
+    elapsedMs,
+    unobservedMs: elapsedMs !== null && requestIntervals.length ? Math.max(0, elapsedMs - unionMs(observedIntervals)) : null,
+    requests: { completed: durations.length, active: cli ? (cliEnd ? 0 : null) : requests.length - settled.length,
+      durationMs: requestMs, correlation: usage.length ? 'request_id' : 'unavailable',
+      correlatedUsageRecords: usage.length, statuses: settled.reduce((all, row) => { const key = Number.isInteger(row.status) ? String(row.status) : 'unknown'; all[key] = (all[key] ?? 0) + 1; return all; }, {}) },
+    tokens, tokenSource: cli ? 'grok_usage_events' : routerCountsComplete ? 'router_usage' : nativeCounts.length ? 'codex_usage_events' : 'router_usage',
+    outputTokensPerRequestSecond: requestMs > 0 && outputTokens !== null && durations.length === counts.length ? outputTokens / (requestMs / 1000) : null,
+    // Timing is not interchangeable with reasoning-inclusive token counts. Do not
+    // subtract text TTFT and present that quotient as decoding throughput.
+    firstTokenMs: cli ? total(cliRequests, 'ttft_ms') : total(usage, 'firstTokenMs'),
+    tools: { calls: cli ? cliToolIds.size : toolCount, failures: cli ? cliToolFailures : toolFailures,
+      patchFailures: cli ? null : patchFailures, durationMs: toolIntervals.length ? unionMs(toolIntervals) : null,
+      firstTestAfterMs: start !== undefined && firstTestAt !== undefined ? firstTestAt - start : null },
+    contextBytes: { unit: 'utf8_json_bytes', first: bytes[0] ?? null, last: bytes.at(-1) ?? null },
+    limitations: ['Completion is the worker status; test success and independent review must be recorded separately.',
+      'Byte sizes are not token estimates. Partial or unmatched counters do not establish throughput.',
+      'Unobserved time includes scheduling and uninstrumented work; it is not proven provider waiting time.',
+      'Input totals include cache reads and writes; reasoning counts are never inferred from text or durations.',
+      'Grok event inputs must contain one invocation; timestamped inputs are filtered to the selected run.'],
+  };
+}
+
+export async function readJsonLines(file) {
+  if (!file) return [];
+  const text = await readFile(file, 'utf8');
+  const rows = [];
+  const lines = text.split('\n');
+  for (const [index, line] of lines.entries()) {
+    if (!line.trim()) continue;
+    let row;
+    try { row = JSON.parse(line); } catch {
+      if (index === lines.length - 1 && !text.endsWith('\n')) break;
+      throw new Error('Invalid JSONL record.');
+    }
+    if (!row || typeof row !== 'object' || Array.isArray(row)) throw new Error('Expected a JSONL object.');
+    rows.push(row);
+  }
+  return rows;
+}
+
+async function main(args) {
+  if (args.includes('--help')) {
+    process.stdout.write('Usage: node src/grok-run-report.mjs --codex-rollout FILE --activity FILE --usage FILE --thread-id ID --started-at ISO --ended-at ISO [--out FILE]\nGrok: --grok-events FILE --grok-log FILE --grok-session-events FILE --session-id ID\nOptional: --outcome completed|failed|cancelled|timeout. Inputs are local JSONL; output contains metrics only.\n');
+    return;
+  }
+  const allowed = new Set(['usage', 'activity', 'codex-rollout', 'grok-events', 'grok-log', 'grok-session-events', 'thread-id', 'session-id', 'started-at', 'ended-at', 'out', 'outcome']);
+  const options = {};
+  for (let i = 0; i < args.length; i += 2) {
+    const key = args[i]?.replace(/^--/u, '');
+    if (!args[i]?.startsWith('--') || !allowed.has(key) || !args[i + 1] || args[i + 1].startsWith('--')) throw new Error('Invalid report arguments. Use --help.');
+    options[key] = args[i + 1];
+  }
+  if (!options['codex-rollout'] && !options['grok-events']) throw new Error('A run event input is required.');
+  for (const key of ['started-at', 'ended-at']) if (options[key] && timestamp(options[key]) === undefined) throw new Error('Invalid run timestamp.');
+  if (options.outcome && !terminal.has(options.outcome)) throw new Error('Invalid terminal outcome.');
+  const [usageEvents, activityEvents, codexEvents, grokEvents, grokLog, grokSessionEvents] = await Promise.all(
+    ['usage', 'activity', 'codex-rollout', 'grok-events', 'grok-log', 'grok-session-events'].map((key) => readJsonLines(options[key])));
+  const report = buildGrokRunReport({ usageEvents, activityEvents, codexEvents, grokEvents, grokLog, grokSessionEvents,
+    threadId: options['thread-id'], sessionId: options['session-id'], startedAt: options['started-at'], endedAt: options['ended-at'], outcome: options.outcome });
+  const output = `${JSON.stringify(report, null, 2)}\n`;
+  if (options.out) await writeFile(options.out, output, { mode: 0o600 });
+  else process.stdout.write(output);
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main(process.argv.slice(2)).catch(() => { process.stderr.write('Could not create run report. Check arguments and readable JSONL inputs; use --help.\n'); process.exitCode = 1; });
+}

--- a/src/grok-run-report.mjs
+++ b/src/grok-run-report.mjs
@@ -41,7 +41,9 @@ export function buildGrokRunReport({ usageEvents = [], activityEvents = [], code
   }
   const requests = [...activity.values()];
   const settled = requests.filter((row) => count(row.endedAt) !== undefined);
-  const usage = [...new Map(usageEvents.filter((row) => typeof row.requestId === 'string' && activity.has(row.requestId)).map((row) => [row.requestId, row])).values()];
+  // One client request may meter multiple charged provider attempts. Never
+  // collapse those records merely because their requestId matches.
+  const usage = usageEvents.filter((row) => typeof row.requestId === 'string' && activity.has(row.requestId));
   const nativeCounts = [];
   const toolCalls = new Map();
   const toolIntervals = [];
@@ -104,7 +106,9 @@ export function buildGrokRunReport({ usageEvents = [], activityEvents = [], code
     }
   }
   const cli = grokEvents.length > 0 || cliRequests.length > 0;
-  const routerCountsComplete = usage.length === settled.length && usage.length > 0 && usage.every((row) => count(row.outputTokens) !== undefined);
+  const usageIds = new Set(usage.map((row) => row.requestId));
+  const routerCountsComplete = settled.length > 0 && usageIds.size === settled.length &&
+    settled.every((row) => usageIds.has(row.requestId)) && usage.every((row) => count(row.outputTokens) !== undefined);
   const counts = cli ? cliUsage : routerCountsComplete ? usage : nativeCounts.length ? nativeCounts : usage;
   const tokens = Object.fromEntries(['inputTokens', 'cachedInputTokens', 'outputTokens', 'reasoningTokens'].map((key) => [key, total(counts, key)]));
   const durations = cli ? cliRequests.map((row) => count(row.model_elapsed_ms)).filter((v) => v !== undefined)
@@ -130,7 +134,8 @@ export function buildGrokRunReport({ usageEvents = [], activityEvents = [], code
       durationMs: requestMs, correlation: usage.length ? 'request_id' : 'unavailable',
       correlatedUsageRecords: usage.length, statuses: settled.reduce((all, row) => { const key = Number.isInteger(row.status) ? String(row.status) : 'unknown'; all[key] = (all[key] ?? 0) + 1; return all; }, {}) },
     tokens, tokenSource: cli ? 'grok_usage_events' : routerCountsComplete ? 'router_usage' : nativeCounts.length ? 'codex_usage_events' : 'router_usage',
-    outputTokensPerRequestSecond: requestMs > 0 && outputTokens !== null && durations.length === counts.length ? outputTokens / (requestMs / 1000) : null,
+    outputTokensPerRequestSecond: requestMs > 0 && outputTokens !== null &&
+      (routerCountsComplete && !cli || durations.length === counts.length) ? outputTokens / (requestMs / 1000) : null,
     // Timing is not interchangeable with reasoning-inclusive token counts. Do not
     // subtract text TTFT and present that quotient as decoding throughput.
     firstTokenMs: cli ? total(cliRequests, 'ttft_ms') : total(usage, 'firstTokenMs'),

--- a/src/grok-run-report.mjs
+++ b/src/grok-run-report.mjs
@@ -9,7 +9,14 @@ const total = (rows, key) => {
     reported: values.filter((v) => v !== undefined).length, missing: values.filter((v) => v === undefined).length };
 };
 const completeValue = (aggregate) => aggregate.missing === 0 ? aggregate.value : null;
-const testCommand = (command) => /(?:\bvitest\b|\bjest\b|\bnpm\s+(?:run\s+)?test\b|\bnode\s+--test\b)/u.test(command ?? '');
+function testCommand(command) {
+  if (typeof command !== 'string') return false;
+  // Recognize direct commands conservatively, not filenames or quoted examples.
+  // This is not a shell interpreter: heredocs and indirect wrappers are omitted.
+  const source = command.replace(/'(?:[^']*)'|"(?:\\.|[^"\\])*"|`(?:\\.|[^`\\])*`|#[^\r\n]*/gu, ' ');
+  if (source.includes('<<')) return false;
+  return /(?:^|&&|\|\||;|\n)\s*(?:(?:[^\s;|&]+\/)?(?:vitest|jest)(?=\s|$)|npm\s+(?:run\s+)?test(?=\s|:|$)|npx\s+(?:vitest|jest)(?=\s|$)|node\s+--test(?=\s|$))/u.test(source);
+}
 const terminal = new Set(['completed', 'failed', 'cancelled', 'timeout']);
 
 function unionMs(intervals) {

--- a/src/request-diagnostics.mjs
+++ b/src/request-diagnostics.mjs
@@ -1,0 +1,79 @@
+// Bounded request diagnostics for usage events. Counts, billing, routes, and
+// retries stay in usage-events.mjs; this module only names a request and the
+// Grok OAuth 4.6 ingress byte split. It never stores headers, bodies, thread
+// titles, or paths.
+//
+// The request ID is created by the /activity observer and includes its process
+// instance ID, so a service restart cannot accidentally join unrelated requests.
+
+export const ROUTER_INGRESS_OBSERVATION_POINT = "router_ingress";
+export const GROK_OAUTH_46_SLUG = "grok-oauth/grok-4.6";
+
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9:_-]{1,160}$/;
+const MAX_CONTEXT_FIELD_BYTES = 1024 * 1024 * 1024;
+
+export function safeDiagnosticRequestId(value) {
+  if (typeof value !== "string") {
+    if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+      value = String(value);
+    } else {
+      return undefined;
+    }
+  }
+  const text = value.trim();
+  return REQUEST_ID_PATTERN.test(text) ? text : undefined;
+}
+
+function safeByteCount(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) return undefined;
+  return Math.min(MAX_CONTEXT_FIELD_BYTES, Math.round(number));
+}
+
+export function utf8JsonBytes(value) {
+  if (value === undefined) return 0;
+  try {
+    const encoded = JSON.stringify(value);
+    if (typeof encoded !== "string") return 0;
+    return Buffer.byteLength(encoded, "utf8");
+  } catch {
+    return 0;
+  }
+}
+
+export function measureIngressContextBytes(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return undefined;
+  }
+  return {
+    observationPoint: ROUTER_INGRESS_OBSERVATION_POINT,
+    instructionsBytes: utf8JsonBytes(payload.instructions),
+    toolsBytes: utf8JsonBytes(payload.tools),
+    historyBytes: utf8JsonBytes(payload.input),
+  };
+}
+
+export function grokOauth46IngressContextBytes(payload, route) {
+  if (route?.slug !== GROK_OAUTH_46_SLUG) return undefined;
+  return measureIngressContextBytes(payload);
+}
+
+export function sanitizeContextBytes(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  if (value.observationPoint !== ROUTER_INGRESS_OBSERVATION_POINT) return undefined;
+  return {
+    observationPoint: ROUTER_INGRESS_OBSERVATION_POINT,
+    instructionsBytes: safeByteCount(value.instructionsBytes) ?? 0,
+    toolsBytes: safeByteCount(value.toolsBytes) ?? 0,
+    historyBytes: safeByteCount(value.historyBytes) ?? 0,
+  };
+}
+
+export function usageDiagnosticMetadata({ requestId, contextBytes } = {}) {
+  const safeRequestId = safeDiagnosticRequestId(requestId);
+  const safeContextBytes = sanitizeContextBytes(contextBytes);
+  return {
+    ...(safeRequestId ? { requestId: safeRequestId } : {}),
+    ...(safeContextBytes ? { contextBytes: safeContextBytes } : {}),
+  };
+}

--- a/src/request-progress.mjs
+++ b/src/request-progress.mjs
@@ -1,0 +1,104 @@
+import { randomUUID } from "node:crypto";
+import { Transform } from "node:stream";
+
+const METADATA = ["provider", "model", "threadId", "parentThreadId", "sessionId", "agentName"];
+
+// Diagnostics are independent of the tray's expiring presentation records.
+// A live request stays live until its handler settles; reading never cancels it.
+export function createRequestProgress({ now = Date.now, recentLimit = 128, recentTtlMs = 600_000 } = {}) {
+  const active = new Map();
+  const recent = [];
+  const instanceId = randomUUID();
+  let sequence = 0;
+  const prune = () => {
+    while (recent.length && (recent.length > recentLimit || now() - recent[0].endedAt > recentTtlMs)) {
+      recent.shift();
+    }
+  };
+  return {
+    begin() {
+      const record = {
+        requestId: `${instanceId}:${++sequence}`,
+        state: "running",
+        phase: "unobserved",
+        startedAt: now(),
+        observationPoint: "router_upstream",
+        receivedBytes: 0,
+        receivedEvents: 0,
+      };
+      active.set(record.requestId, record);
+      let finished = false;
+      const update = (fields) => { if (!finished) Object.assign(record, fields); };
+      return {
+        setRoute(metadata = {}) {
+          for (const key of METADATA) {
+            const value = metadata[key];
+            if (typeof value === "string" && value.length <= 160) update({ [key]: value });
+          }
+          if (typeof metadata.isSubagent === "boolean") update({ isSubagent: metadata.isSubagent });
+        },
+        attempt() {
+          if (record.state !== "running") return;
+          update({ upstreamAttempts: (record.upstreamAttempts || 0) + 1, phase: "awaiting_upstream", terminalEvent: undefined });
+        },
+        headers() {
+          update({ lastHeadersAt: now(), ...(record.state === "running" ? { phase: "awaiting_event" } : {}) });
+        },
+        event(payload) {
+          if (!payload || typeof payload !== "object") return;
+          const type = payload.type;
+          let phase;
+          if (typeof type === "string" && type.startsWith("response.reasoning")) phase = "reasoning";
+          else if (type === "response.output_text.delta") phase = "text";
+          else if (type === "response.function_call_arguments.delta" ||
+            type === "response.custom_tool_call_input.delta" ||
+            ["function_call", "custom_tool_call"].includes(payload.item?.type)) phase = "tool_call";
+          else if (["response.completed", "response.failed", "response.incomplete", "error"].includes(type)) phase = "finishing";
+          const failed = ["response.failed", "response.incomplete", "error"].includes(type);
+          update({
+            ...(failed ? { terminalEvent: type } : {}),
+            lastEventAt: now(),
+            receivedEvents: record.receivedEvents + 1,
+            ...(record.state === "running" && phase ? { phase } : {}),
+          });
+        },
+        byteObserver() {
+          return new Transform({
+            transform(chunk, _encoding, callback) {
+              update({ lastByteAt: now(), receivedBytes: record.receivedBytes + chunk.length });
+              callback(null, chunk);
+            },
+          });
+        },
+        cancel(reason) {
+          if (record.state !== "running") return;
+          if (!["client_disconnected", "execution_deadline"].includes(reason)) return;
+          update({ state: "canceling", phase: "canceling", cancelReason: reason, cancelRequestedAt: now() });
+        },
+        finish(status) {
+          if (finished) return;
+          const state = status === 0 ? "canceled" : status >= 200 && status < 400 && !record.terminalEvent ? "completed" : "failed";
+          update({ state, phase: "settled", status, endedAt: now() });
+          finished = true;
+          active.delete(record.requestId);
+          recent.push({ ...record });
+          prune();
+        },
+      };
+    },
+    snapshot({ threadId } = {}) {
+      prune();
+      const matches = (entry) => !threadId || entry.threadId === threadId;
+      return {
+        version: 1,
+        instanceId,
+        observedAt: now(),
+        // No raw xAI timings, provider-internal retries, or worker lifecycle
+        // can be inferred from this local transport observation.
+        observationPoint: "router_upstream",
+        active: [...active.values()].filter(matches).map((entry) => ({ ...entry })),
+        recent: recent.filter(matches).map((entry) => ({ ...entry })),
+      };
+    },
+  };
+}

--- a/src/request-progress.mjs
+++ b/src/request-progress.mjs
@@ -30,6 +30,7 @@ export function createRequestProgress({ now = Date.now, recentLimit = 128, recen
       let finished = false;
       const update = (fields) => { if (!finished) Object.assign(record, fields); };
       return {
+        requestId: record.requestId,
         setRoute(metadata = {}) {
           for (const key of METADATA) {
             const value = metadata[key];

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -334,14 +334,16 @@ export class ResponseUsageTransform extends Transform {
   // first token appears, and counting that silence as generation is what makes
   // a fast model read as slow. See #192.
   #firstTokenAt;
+  #onEvent;
   #completedResponseObserved = false;
   #terminalErrorObserved = false;
 
   // `estimatedInputTokens` arrives only on routed requests large enough that a
   // reported zero cannot be true. Without it this transform observes and
   // forwards the response byte for byte, exactly as it always did.
-  constructor(contentType = "", { estimatedInputTokens } = {}) {
+  constructor(contentType = "", { estimatedInputTokens, onEvent } = {}) {
     super();
+    this.#onEvent = typeof onEvent === "function" ? onEvent : undefined;
     const declared = String(contentType).toLowerCase();
     this.#eventStream = declared.includes("text/event-stream");
     // The ChatGPT backend answers /responses with an SSE body and no
@@ -536,6 +538,8 @@ export class ResponseUsageTransform extends Transform {
   }
 
   #observe(payload) {
+    // Diagnostics must not change parsing, metering, or the relayed bytes.
+    try { this.#onEvent?.(payload); } catch { /* Observer failure is non-fatal. */ }
     this.#noteFirstToken(payload);
     if (payload?.type === "response.completed") this.#completedResponseObserved = true;
     const usage = tokenUsageFromPayload(payload);

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -162,11 +162,14 @@ export function normalizeTokenUsage(value) {
   // Reasoning tokens are the silent thinking tokens generated before visible
   // output. Providers report them in output_tokens_details.reasoning_tokens,
   // completion_tokens_details.reasoning_tokens, or reasoning_tokens directly.
-  const reasoningTokens = tokenCount(
+  // A missing or non-numeric value stays absent; only an actual number 0 is a
+  // measured zero. `tokenCount(null)` would otherwise coerce null to 0.
+  const reasoningRaw =
     value.output_tokens_details?.reasoning_tokens ??
-      value.completion_tokens_details?.reasoning_tokens ??
-      value.reasoning_tokens,
-  );
+    value.completion_tokens_details?.reasoning_tokens ??
+    value.reasoning_tokens;
+  const reasoningTokens =
+    typeof reasoningRaw === "number" ? tokenCount(reasoningRaw) : undefined;
   const retries = tokenCount(value.retries);
   const progressOnlyRetried =
     value.progress_only_retried === true || value.progressOnlyRetried === true;

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -166,6 +166,10 @@ import {
 import { recordUsageEvent } from "./usage-events.mjs";
 import { createRequestProgress } from "./request-progress.mjs";
 import {
+  grokOauth46IngressContextBytes,
+  usageDiagnosticMetadata,
+} from "./request-diagnostics.mjs";
+import {
   classifySsePrefix,
   HEADERLESS_SSE_SNIFF_BYTES,
   HEADERLESS_SSE_SNIFF_MS,
@@ -455,6 +459,8 @@ function beginRequestActivity({ request, response, controller } = {}) {
   }
   const progress = requestProgress.begin();
   const requestId = ++requestSequence;
+  // Use the observer's instance-scoped ID so usage joins /activity across restarts.
+  const requestIdText = progress.requestId;
   const startedAt = Date.now();
   let finished = false;
   let deadlineExceeded = false;
@@ -499,6 +505,7 @@ function beginRequestActivity({ request, response, controller } = {}) {
       const entry = {
         ...(activityRecords.get(requestId) || {}),
         id: String(requestId),
+        requestId: requestIdText,
         provider,
         ...(model ? { model } : {}),
         ...(sessionName ? { sessionName } : {}),
@@ -510,9 +517,17 @@ function beginRequestActivity({ request, response, controller } = {}) {
       if (model) lastUsedModel = model;
       if (sessionName) lastUsedSessionName = sessionName;
     },
+    requestId: requestIdText,
     finish,
     deadlineExceeded: () => deadlineExceeded,
   };
+}
+
+function recordObservedUsage(fields, diagnostics) {
+  recordUsageEvent({
+    ...fields,
+    ...usageDiagnosticMetadata(diagnostics),
+  });
 }
 
 const FORWARD_HEADERS = new Set([
@@ -2762,27 +2777,33 @@ async function summarize(request, payload, route, signal, { allowFailover = true
   return last && { ...last, failed };
 }
 
-function recordCompactionUsage(result, route, startedAt) {
+function recordCompactionUsage(result, route, startedAt, diagnostics) {
   const servedRoute = result?.route || route;
   const failed = (result?.failed || []).filter((entry) => entry.route !== servedRoute);
   for (const attempt of failed) {
-    recordUsageEvent({
-      model: attempt.route.slug,
-      provider: canonicalProviderId(attempt.route.provider),
-      status: attempt.status,
-      durationMs: Date.now() - startedAt,
-      ...attempt.usage,
-    });
+    recordObservedUsage(
+      {
+        model: attempt.route.slug,
+        provider: canonicalProviderId(attempt.route.provider),
+        status: attempt.status,
+        durationMs: Date.now() - startedAt,
+        ...attempt.usage,
+      },
+      diagnostics,
+    );
   }
-  recordUsageEvent({
-    model: servedRoute.slug,
-    provider: canonicalProviderId(servedRoute.provider),
-    status: result?.ok ? 200 : result?.status || 502,
-    durationMs: Date.now() - startedAt,
-    ...result?.usage,
-    ...result?.toolResultAging,
-    ...(result?.failoverFrom ? { failoverFrom: result.failoverFrom } : {}),
-  });
+  recordObservedUsage(
+    {
+      model: servedRoute.slug,
+      provider: canonicalProviderId(servedRoute.provider),
+      status: result?.ok ? 200 : result?.status || 502,
+      durationMs: Date.now() - startedAt,
+      ...result?.usage,
+      ...result?.toolResultAging,
+      ...(result?.failoverFrom ? { failoverFrom: result.failoverFrom } : {}),
+    },
+    diagnostics,
+  );
 }
 
 function compactionSnapshot(model, item, status = "completed") {
@@ -3581,6 +3602,7 @@ async function handleResponses(request, response, requestUrl) {
     activity.progress.headers();
     return upstream;
   };
+  const diagnostics = { requestId: activity.requestId };
   let clientGone = false;
   let requestedModel = "";
   let route;
@@ -3667,6 +3689,7 @@ async function handleResponses(request, response, requestUrl) {
       model: route?.slug || requestedModel || undefined,
       ...activityMetadataFromHeaders(request.headers),
     });
+    diagnostics.contextBytes = grokOauth46IngressContextBytes(payload, route);
     const compactV1 = /\/responses\/compact$/.test(requestUrl.pathname);
     // Codex remote compaction V2 uses the ordinary Responses endpoint with a
     // terminal trigger. Detect the protocol shape before route dispatch so the
@@ -3686,7 +3709,7 @@ async function handleResponses(request, response, requestUrl) {
         { allowFailover: !exactRouteProbe },
       );
       const compacted = compaction.route || route;
-      recordCompactionUsage(compaction, route, startedAt);
+      recordCompactionUsage(compaction, route, startedAt, diagnostics);
       usage = compaction.usage;
       finalStatus = compaction.status;
       activityStatus = compaction.status;
@@ -4012,13 +4035,13 @@ async function handleResponses(request, response, requestUrl) {
           // cost the provider something, so it is metered on its own row. The
           // serving row below carries `failoverFrom`, which is what makes a
           // rescued turn distinguishable from one that never failed.
-          recordUsageEvent({
+          recordObservedUsage({
             model: route.slug,
             provider: canonicalProviderId(route.provider),
             status: upstream.status,
             durationMs: Date.now() - startedAt,
             responseStartMs: upstreamLatencyMs,
-          });
+          }, diagnostics);
           adoptRoute(moved.route, moved.built);
           upstream = moved.upstream;
           upstreamStatus = upstream.status;
@@ -4061,14 +4084,14 @@ async function handleResponses(request, response, requestUrl) {
         provider: route.provider,
         stream: payload.stream === true,
       });
-      recordUsageEvent({
+      recordObservedUsage({
         model: route.slug,
         provider: canonicalProviderId(route.provider),
         status: upstream.status,
         durationMs: Date.now() - startedAt,
         responseStartMs: upstreamLatencyMs,
         firstTokenMs,
-      });
+      }, diagnostics);
       observeSubagentOutcome(request, route, upstream.status);
       finalStatus = translatedStatus;
       activityStatus = translatedStatus;
@@ -4461,7 +4484,7 @@ async function handleResponses(request, response, requestUrl) {
     // is already gone) and only rejects for an upstream that actually failed.
     // A cancel is not a router failure, so it meters as 0 rather than the
     // committed 200 that the client never finished reading.
-    recordUsageEvent({
+    recordObservedUsage({
       model: route?.slug || requestedModel,
       provider: route ? canonicalProviderId(route.provider) : "openai",
       status: finalStatus,
@@ -4480,7 +4503,7 @@ async function handleResponses(request, response, requestUrl) {
         ? { emptyCompletionPreludeLimit }
         : {}),
       ...(failoverFrom ? { failoverFrom } : {}),
-    });
+    }, diagnostics);
     // The same usage this turn just metered, and the same two disqualifiers
     // context-window-drift.mjs applies to it: a substituted estimate and a
     // retry-doubled count are not measurements of what the child sent.
@@ -4522,14 +4545,14 @@ async function handleResponses(request, response, requestUrl) {
       finalStatus = 504;
       activityStatus = 504;
       if (!usageRecorded) {
-        recordUsageEvent({
+        recordObservedUsage({
           model: route?.slug || requestedModel,
           provider: route ? canonicalProviderId(route.provider) : "openai",
           status: 504,
           durationMs: Date.now() - startedAt,
           responseStartMs: upstreamLatencyMs,
           requestDeadlineExceeded: true,
-        });
+        }, diagnostics);
         usageRecorded = true;
       }
       if (!response.headersSent) {
@@ -4562,13 +4585,13 @@ async function handleResponses(request, response, requestUrl) {
           message: error.message,
         },
       });
-      recordUsageEvent({
+      recordObservedUsage({
         model: route?.slug || requestedModel,
         provider: route ? canonicalProviderId(route.provider) : "openai",
         status: error.status,
         durationMs: Date.now() - startedAt,
         responseStartMs: upstreamLatencyMs,
-      });
+      }, diagnostics);
       usageRecorded = true;
       return;
     }
@@ -4581,7 +4604,7 @@ async function handleResponses(request, response, requestUrl) {
           message: error.message,
         },
       });
-      recordUsageEvent({
+      recordObservedUsage({
         model: route?.slug || requestedModel,
         provider: route ? canonicalProviderId(route.provider) : "openai",
         status: error.status,
@@ -4595,7 +4618,7 @@ async function handleResponses(request, response, requestUrl) {
           ? { emptyCompletionPreludeLimit }
           : {}),
         ...(failoverFrom ? { failoverFrom } : {}),
-      });
+      }, diagnostics);
       usageRecorded = true;
       return;
     }
@@ -4618,7 +4641,7 @@ async function handleResponses(request, response, requestUrl) {
       finalStatus = upstreamStatus ?? response.statusCode;
       activityStatus = finalStatus;
       if (!usageRecorded) {
-        recordUsageEvent({
+        recordObservedUsage({
           model: requestedModel,
           provider: "openai",
           status: finalStatus,
@@ -4629,7 +4652,7 @@ async function handleResponses(request, response, requestUrl) {
           estimatedInputTokens,
           ...toolResultAging,
           retries: (upstreamRetries || 0) + (usage?.retries || 0) || undefined,
-        });
+        }, diagnostics);
         usageRecorded = true;
       }
       if (!QUIET) {
@@ -4651,7 +4674,7 @@ async function handleResponses(request, response, requestUrl) {
       finalStatus = 0;
       activityStatus = 0;
       if (!usageRecorded) {
-        recordUsageEvent({
+        recordObservedUsage({
           model: route?.slug || requestedModel,
           provider: route ? canonicalProviderId(route.provider) : "openai",
           status: 0,
@@ -4664,7 +4687,7 @@ async function handleResponses(request, response, requestUrl) {
           ...toolResultAging,
           ...(emptyCompletion ? { emptyCompletion: true } : {}),
           ...(emptyCompletionRetried ? { emptyCompletionRetried: true } : {}),
-        });
+        }, diagnostics);
         usageRecorded = true;
       }
       return;
@@ -4676,7 +4699,7 @@ async function handleResponses(request, response, requestUrl) {
     finalStatus = response.headersSent ? 502 : httpErrorStatus(error);
     activityStatus = finalStatus;
     if (!usageRecorded) {
-      recordUsageEvent({
+      recordObservedUsage({
         model: route?.slug || requestedModel,
         provider: route ? canonicalProviderId(route.provider) : "openai",
         status: finalStatus,
@@ -4693,7 +4716,7 @@ async function handleResponses(request, response, requestUrl) {
         ...(emptyCompletionPreludeLimit
           ? { emptyCompletionPreludeLimit }
           : {}),
-      });
+      }, diagnostics);
       usageRecorded = true;
     }
     throw error;
@@ -4721,6 +4744,7 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
   const startedAt = Date.now();
   const controller = new AbortController();
   const activity = beginRequestActivity({ request, response, controller });
+  const diagnostics = { requestId: activity.requestId };
   let clientGone = false;
   let requestedModel = defaultModel;
   let servingProvider = "openai";
@@ -4780,7 +4804,7 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
           signal: controller.signal,
         });
         writeJson(response, 200, sidecar.response);
-        recordUsageEvent({
+        recordObservedUsage({
           model: requestedModel,
           provider: servingProvider,
           status: 200,
@@ -4789,7 +4813,7 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
           searchSidecar: true,
           searchCacheHit: sidecar.telemetry?.cacheHit === true,
           searchResults: sidecar.telemetry?.results,
-        });
+        }, diagnostics);
         if (!QUIET) {
           console.error(
             `[codex-router] model=${requestedModel} provider=${servingProvider} status=200 attempts=${sidecar.telemetry?.attempts || 0} cache_hit=${sidecar.telemetry?.cacheHit === true}`,
@@ -4865,13 +4889,13 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
       },
     );
     await pipeResponse(upstream, response, HOP_BY_HOP_HEADERS);
-    recordUsageEvent({
+    recordObservedUsage({
       model: requestedModel,
       provider: "openai",
       status: upstream.status,
       durationMs: Date.now() - startedAt,
       retries: upstreamRetries,
-    });
+    }, diagnostics);
     if (!QUIET) {
       console.error(
         `[codex-router] model=${requestedModel} provider=openai status=${upstream.status}${upstreamRetries ? ` retries=${upstreamRetries}` : ""}`,
@@ -4892,14 +4916,14 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
           message: "The router canceled a request that exceeded its execution deadline.",
         });
       }
-      recordUsageEvent({
+      recordObservedUsage({
         model: requestedModel,
         provider: servingProvider,
         status,
         durationMs: Date.now() - startedAt,
         ...(response.headersSent ? { streamAborted: true } : {}),
         requestDeadlineExceeded: true,
-      });
+      }, diagnostics);
       activity.finish(status);
       return;
     }
@@ -4908,12 +4932,12 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
     // router" — the distinction #171 turned on. Meter this path the way the
     // turn path does: a departed client as 0, everything else by its status.
     if (clientGone) {
-      recordUsageEvent({
+      recordObservedUsage({
         model: requestedModel,
         provider: servingProvider,
         status: 0,
         durationMs: Date.now() - startedAt,
-      });
+      }, diagnostics);
       activity.finish(0);
       return;
     }
@@ -4925,7 +4949,7 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
           message: error.message,
         },
       });
-      recordUsageEvent({
+      recordObservedUsage({
         model: requestedModel,
         provider: servingProvider,
         status,
@@ -4933,18 +4957,18 @@ async function handleNativeRequest(request, response, requestUrl, defaultModel) 
         retries: Math.max(0, (error.telemetry?.attempts || 1) - 1),
         searchSidecar: true,
         searchCacheHit: false,
-      });
+      }, diagnostics);
       activity.finish(status);
       return;
     }
     const status = response.headersSent ? 502 : httpErrorStatus(error);
-    recordUsageEvent({
+    recordObservedUsage({
       model: requestedModel,
       provider: servingProvider,
       status,
       durationMs: Date.now() - startedAt,
       ...(response.headersSent ? { streamAborted: true } : {}),
-    });
+    }, diagnostics);
     activity.finish(status);
     throw error;
   } finally {
@@ -4956,6 +4980,7 @@ async function handleEmbeddings(request, response, requestUrl) {
   const startedAt = Date.now();
   const controller = new AbortController();
   const activity = beginRequestActivity({ request, response, controller });
+  const diagnostics = { requestId: activity.requestId };
   let clientGone = false;
   let requestedModel = "";
   let route;
@@ -5071,12 +5096,12 @@ async function handleEmbeddings(request, response, requestUrl) {
     throw error;
   } finally {
     if (requestedModel) {
-      recordUsageEvent({
+      recordObservedUsage({
         model: route?.slug || requestedModel,
         provider: route ? canonicalProviderId(route.provider) : "unknown",
         status,
         durationMs: Date.now() - startedAt,
-      });
+      }, diagnostics);
     }
     activity.finish(status);
   }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -164,6 +164,7 @@ import {
   supportsOpenAIModelEndpoint,
 } from "./openai-endpoint-policy.mjs";
 import { recordUsageEvent } from "./usage-events.mjs";
+import { createRequestProgress } from "./request-progress.mjs";
 import {
   classifySsePrefix,
   HEADERLESS_SSE_SNIFF_BYTES,
@@ -376,6 +377,7 @@ const agentPayloadCacheMetrics = {
   coalesced: 0,
 };
 
+const requestProgress = createRequestProgress();
 let requestSequence = 0;
 const activityRecords = new Map();
 const inFlightRequests = new Map();
@@ -451,6 +453,7 @@ function beginRequestActivity({ request, response, controller } = {}) {
     error.code = "ERR_ROUTER_ACTIVE_REQUEST_LIMIT";
     throw error;
   }
+  const progress = requestProgress.begin();
   const requestId = ++requestSequence;
   const startedAt = Date.now();
   let finished = false;
@@ -459,6 +462,7 @@ function beginRequestActivity({ request, response, controller } = {}) {
   const finish = (status) => {
     if (finished) return;
     finished = true;
+    progress.finish(status);
     if (executionTimer) clearTimeout(executionTimer);
     activityRecords.delete(requestId);
     inFlightRequests.delete(requestId);
@@ -467,6 +471,7 @@ function beginRequestActivity({ request, response, controller } = {}) {
   const abortAtExecutionDeadline = () => {
     if (finished || deadlineExceeded) return;
     deadlineExceeded = true;
+    progress.cancel("execution_deadline");
     const error = new Error("Router request exceeded its execution deadline.");
     error.code = "ERR_ROUTER_REQUEST_TIMEOUT";
     error.status = 504;
@@ -484,8 +489,10 @@ function beginRequestActivity({ request, response, controller } = {}) {
   inFlightRequests.set(requestId, { startedAt });
   activityRecords.set(requestId, { startedAt });
   return {
+    progress,
     setRoute({ provider, model, sessionName, ...metadata } = {}) {
       if (!provider || finished) return;
+      progress.setRoute({ provider, model, ...metadata });
       // Once presentation bookkeeping expires, later route updates must not
       // resurrect it. The operation remains counted in `inFlightRequests`.
       if (!activityRecords.has(requestId)) return;
@@ -3440,6 +3447,7 @@ async function attemptModelFailover({
   normalizedInput,
   agingEnabled,
   searchContract,
+  progress,
 }) {
   const settings = readFailoverSettings();
   if (!settings.enabled) return undefined;
@@ -3494,12 +3502,14 @@ async function attemptModelFailover({
         logFailover(route, model, verdict.reason, status, "search-capability-changed");
         continue;
       }
+      progress?.attempt();
       upstream = await fetch(built.target, {
         method: "POST",
         headers: built.headers,
         body: built.body,
         signal,
       });
+      progress?.headers();
     } catch (error) {
       if (signal.aborted) throw error;
       const compatibilityCode = candidateBuildCompatibilityCode(error);
@@ -3565,6 +3575,12 @@ async function handleResponses(request, response, requestUrl) {
   const startedAt = Date.now();
   const controller = new AbortController();
   const activity = beginRequestActivity({ request, response, controller });
+  const fetchObservedUpstream = async (...args) => {
+    activity.progress.attempt();
+    const upstream = await fetch(...args);
+    activity.progress.headers();
+    return upstream;
+  };
   let clientGone = false;
   let requestedModel = "";
   let route;
@@ -3598,6 +3614,7 @@ async function handleResponses(request, response, requestUrl) {
   let usageRecorded = false;
   bindClientAbort(request, response, () => {
     clientGone = true;
+    activity.progress.cancel("client_disconnected");
     controller.abort();
   });
   try {
@@ -3902,6 +3919,7 @@ async function handleResponses(request, response, requestUrl) {
         // Routed traffic terminates at the local gateway, which has its own
         // error translation and Retry-After handling below; leave it exactly
         // as it was.
+        fetchImpl: fetchObservedUpstream,
         retries: route ? 0 : undefined,
         canRetry: () => nothingRelayed(response),
         onRetry: (event) => logUpstreamRetry(event, requestedModel, requestUrl.pathname),
@@ -3975,6 +3993,7 @@ async function handleResponses(request, response, requestUrl) {
         // rejection again.
         recordProviderCooldown(route.provider, verdict);
         const moved = await attemptModelFailover({
+          progress: activity.progress,
           request,
           response,
           payload,
@@ -4075,12 +4094,13 @@ async function handleResponses(request, response, requestUrl) {
     const upstreamContentType = upstream.headers.get("content-type") || "";
     const createResponsePipeline = (contentType) => {
       const usageObserver = new ResponseUsageTransform(contentType, {
+        onEvent: (payload) => activity.progress.event(payload),
         estimatedInputTokens:
           ZERO_INPUT_ESTIMATE && route
             ? estimateInputTokens(routedBody, { contextWindow: route.contextWindow })
             : undefined,
       });
-      const transforms = [usageObserver];
+      const transforms = [activity.progress.byteObserver(), usageObserver];
       let envelopeCompat = route
         ? zaiResponsesCompatTransform(route.provider, contentType)
         : undefined;
@@ -4274,6 +4294,7 @@ async function handleResponses(request, response, requestUrl) {
             signal: controller.signal,
           },
           {
+            fetchImpl: fetchObservedUpstream,
             retries: 0,
             canRetry: () => nothingRelayed(response),
             onRetry: (event) => logUpstreamRetry(event, requestedModel, requestUrl.pathname),
@@ -5123,6 +5144,15 @@ async function handleRequest(request, response) {
   ) {
     const health = await healthPayload();
     writeJson(response, health.ok ? 200 : 503, health);
+    return;
+  }
+  if (request.method === "GET" && ["/activity", "/v1/activity"].includes(requestUrl.pathname)) {
+    const threadId = requestUrl.searchParams.get("threadId") || undefined;
+    if (threadId && !/^[A-Za-z0-9_-]{1,160}$/.test(threadId)) {
+      writeJson(response, 400, { error: { type: "invalid_thread_id" } });
+      return;
+    }
+    writeJson(response, 200, requestProgress.snapshot({ threadId }));
     return;
   }
   if (request.method === "GET" && ["/models", "/v1/models"].includes(requestUrl.pathname)) {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -4117,7 +4117,10 @@ async function handleResponses(request, response, requestUrl) {
       const grokReasoningSummaryCompat = route
         ? grokReasoningSummaryCompatTransform(providerForModel(route), contentType)
         : undefined;
-      if (grokReasoningSummaryCompat) transforms.push(grokReasoningSummaryCompat);
+      // Grok gateway error envelopes are normalized along with its reasoning
+      // lifecycle. Observe the canonical terminal for metering and activity;
+      // the leading byte observer still measures the original upstream bytes.
+      if (grokReasoningSummaryCompat) transforms.splice(1, 0, grokReasoningSummaryCompat);
       // LiteLLM can add blank assistant envelopes while translating either
       // Chat Completions or Messages. The factory refuses native traffic and
       // providers that already speak Responses, so those paths gain no stage.

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -11,6 +11,7 @@ import path from "node:path";
 import { STATE_DIR } from "./paths.mjs";
 import { canonicalProviderId } from "./provider-selection.mjs";
 import { acceptedInputTokens } from "./context-window-drift.mjs";
+import { usageDiagnosticMetadata } from "./request-diagnostics.mjs";
 
 export const USAGE_EVENTS_PATH = path.join(STATE_DIR, "usage-events.jsonl");
 
@@ -163,8 +164,15 @@ export function recordUsageEvent({
   searchSidecar,
   searchCacheHit,
   searchResults,
+  // Router-generated correlation id. Matches /activity's `requestId`. Optional so
+  // historical rows keep their exact shape.
+  requestId,
+  // Grok OAuth 4.6 ingress UTF-8 JSON byte split. Optional, bounded, and never
+  // a token estimate. Missing payload fields measure as zero.
+  contextBytes,
   at = Date.now(),
 }) {
+  const diagnostics = usageDiagnosticMetadata({ requestId, contextBytes });
   const event = {
     meteringVersion: 1,
     at: new Date(at).toISOString(),
@@ -252,6 +260,7 @@ export function recordUsageEvent({
     ...(safeTokenCount(toolResultBytesLargest) !== undefined
       ? { toolResultBytesLargest: safeTokenCount(toolResultBytesLargest) }
       : {}),
+    ...diagnostics,
   };
   try {
     mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 });
@@ -475,6 +484,10 @@ export function recentUsageEvents({
         const toolResultBytesSaved = safeTokenCount(event.toolResultBytesSaved);
         const toolResultShapeBytesSaved = safeTokenCount(event.toolResultShapeBytesSaved);
         const searchResults = safeTokenCount(event.searchResults);
+        const diagnostics = usageDiagnosticMetadata({
+          requestId: event.requestId,
+          contextBytes: event.contextBytes,
+        });
         return {
           ...(event.meteringVersion === 1 ? { meteringVersion: 1 } : {}),
           at: event.at,
@@ -531,6 +544,7 @@ export function recentUsageEvents({
           ...(toolResultBytesAfter ? { toolResultBytesAfter } : {}),
           ...(toolResultBytesSaved ? { toolResultBytesSaved } : {}),
           ...(toolResultShapeBytesSaved ? { toolResultShapeBytesSaved } : {}),
+          ...diagnostics,
         };
       });
     return events;

--- a/test/control-activity.test.mjs
+++ b/test/control-activity.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readControlActivity } from "../src/control-activity.mjs";
+
+const KEY = "test-caller-secret-0123456789abcdef";
+test("activity probe keeps credentials and payloads out of its projection", async () => {
+  const value = await readControlActivity({
+    threadId: "worker-1", routerPort: 43210, readCallerSecret: () => KEY,
+    fetchImpl: async (url, options) => {
+      assert.equal(url, `http://127.0.0.1:43210/_codex-router/${KEY}/v1/activity?threadId=worker-1`);
+      assert.equal(options.redirect, "error");
+      return { ok: true, json: async () => ({
+        version: 1, instanceId: "instance", observedAt: 123,
+        active: [{ requestId: "request", phase: "reasoning", lastEventAt: 122, credential: KEY, content: "private" }],
+        recent: [], credential: KEY,
+      }) };
+    },
+  });
+  assert.equal(value.ok, true);
+  assert.deepEqual(value.active, [{ requestId: "request", phase: "reasoning", lastEventAt: 122 }]);
+  assert.doesNotMatch(JSON.stringify(value), /private|test-caller-secret/);
+});
+
+test("offline, missing endpoint, bad ID and missing key are unknown, never a completed worker", async () => {
+  for (const options of [
+    { readCallerSecret: () => "invalid" },
+    { threadId: "bad/id" },
+    { fetchImpl: async () => ({ ok: false }) },
+    { fetchImpl: async () => { throw new Error(`failed ${KEY}`); } },
+    { fetchImpl: async () => ({ ok: true, json: async () => ({}) }) },
+  ]) {
+    const result = await readControlActivity({ readCallerSecret: () => KEY, ...options });
+    assert.equal(result.ok, false);
+    assert.equal(result.state, "unknown");
+    assert.equal(result.active, undefined);
+    assert.doesNotMatch(JSON.stringify(result), /test-caller-secret/);
+  }
+});

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -850,7 +850,7 @@ test("streams visible output before the upstream turn completes", async () => {
   }
 });
 
-test("streams a function call that appears only in a final unterminated SSE block", async () => {
+test("streams a done-only function call with an unterminated successful terminal SSE block", async () => {
   let inbound = 0;
   const backend = await mockBackend(async (_req, res) => {
     inbound += 1;
@@ -865,7 +865,8 @@ test("streams a function call that appears only in a final unterminated SSE bloc
         arguments: '{"cmd":"dir"}',
       },
     };
-    res.end(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n`);
+    res.write(sse([event]));
+    res.end('event: response.completed\ndata: {"type":"response.completed"}\n');
   });
   const port = await openPort();
   const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-final-block-"));
@@ -1362,6 +1363,210 @@ test("a streamed post-tool repair exposes reasoning and only the certified tool 
     assert.match(body, /"name":"exec_command"/);
     assert.match(body, /"finish_reason":"tool_calls"/);
     assert.match(body, /data: \[DONE\]/);
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("post-tool repair releases held actions only after a successful terminal", async (t) => {
+  let scenario;
+  const backend = await mockBackend(async (_req, res) => {
+    const current = scenario;
+    current.inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    if (current.inbound === 1) {
+      res.end(sse([
+        { type: "response.output_text.delta", delta: "Uncertified progress." },
+        { type: "response.completed", response: { usage: { input_tokens: 100, output_tokens: 20 } } },
+      ]));
+      return;
+    }
+    const name = current.privateFinal ? "__codex_router_submit_final" : "exec_command";
+    const args = JSON.stringify(current.privateFinal
+      ? { answer: "Certified repair answer." }
+      : { cmd: "repair-command" });
+    res.write(sse([
+      { type: "response.output_item.added", item: { type: "function_call", id: "fc_repair", call_id: "call_repair", name } },
+      { type: "response.function_call_arguments.delta", item_id: "fc_repair", delta: args },
+      { type: "response.output_item.done", item: { type: "function_call", id: "fc_repair", call_id: "call_repair", name, arguments: args } },
+      // Reading this marker proves the preceding call frames were processed
+      // before the terminal gate is released; reasoning must remain live.
+      { type: "response.reasoning_summary_text.delta", delta: "Repair call prepared." },
+    ]));
+    current.repairReady.resolve();
+    await current.terminalGate.promise;
+    if (current.terminal === "eof") {
+      res.end("data: [DONE]\n\n");
+    } else if (current.terminal === "truncated") {
+      res.end('event: response.completed\ndata: {"type":"response.comp');
+    } else {
+      res.end(sse([{
+        type: `response.${current.terminal}`,
+        response: {
+          status: current.terminal,
+          usage: { input_tokens: 110, output_tokens: 30 },
+          ...(current.terminal === "failed" ? { error: { message: "private upstream failure detail" } } : {}),
+        },
+      }]));
+    }
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-repair-terminal-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  const within = async (promise, message) => {
+    let timeout;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise((_, reject) => { timeout = setTimeout(() => reject(new Error(message)), 2_000); }),
+      ]);
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
+  try {
+    await waitHealth(base, child);
+    for (const stream of [false, true]) {
+      for (const privateFinal of [false, true]) {
+        for (const terminal of ["completed", "failed", "incomplete", "eof", "truncated"]) {
+          await t.test(`${stream ? "SSE" : "JSON"} ${privateFinal ? "private final" : "client tool"}: ${terminal}`, async () => {
+            scenario = { stream, privateFinal, terminal, inbound: 0,
+              repairReady: Promise.withResolvers(), terminalGate: Promise.withResolvers() };
+            const responsePromise = fetch(`${base}/v1/chat/completions`, {
+              method: "POST", headers: auth,
+              body: JSON.stringify({
+                model: "grok-4.6",
+                messages: [
+                  { role: "assistant", tool_calls: [{ id: "c1", type: "function", function: { name: "exec_command", arguments: "{}" } }] },
+                  { role: "tool", tool_call_id: "c1", content: "rendered page" },
+                ],
+                tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+                stream,
+              }),
+            });
+            try {
+              await within(scenario.repairReady.promise, "repair attempt did not start");
+              let resp;
+              let reader;
+              let body = "";
+              const decoder = new TextDecoder();
+              if (stream) {
+                resp = await within(responsePromise, "SSE response head stayed buffered");
+                reader = resp.body.getReader();
+                await within((async () => {
+                  while (!body.includes("Repair call prepared.")) {
+                    const { value, done } = await reader.read();
+                    if (done) throw new Error("response ended before the terminal gate");
+                    body += decoder.decode(value, { stream: true });
+                  }
+                })(), "repair reasoning stayed buffered");
+                assert.doesNotMatch(body, /Uncertified progress|tool_calls|repair-command|Certified repair answer|__codex_router_submit_final|\[DONE\]/);
+              }
+              scenario.terminalGate.resolve();
+              resp ??= await responsePromise;
+              if (reader) {
+                for (;;) {
+                  const { value, done } = await reader.read();
+                  if (done) break;
+                  body += decoder.decode(value, { stream: true });
+                }
+                body += decoder.decode();
+              } else {
+                body = await resp.text();
+              }
+              assert.equal(scenario.inbound, 2, "a failed repair must never replay");
+              assert.doesNotMatch(body, /Uncertified progress|__codex_router_submit_final|private upstream failure detail/);
+              if (terminal === "completed") {
+                assert.equal(resp.status, 200);
+                if (stream) {
+                  assert.equal((body.match(/data: \[DONE\]/g) || []).length, 1);
+                  assert.doesNotMatch(body, /event: error/);
+                  assert.equal((body.match(privateFinal ? /"content":"Certified repair answer\."/g : /"name":"exec_command"/g) || []).length, 1);
+                  assert.match(body, privateFinal ? /"finish_reason":"stop"/ : /"finish_reason":"tool_calls"/);
+                } else {
+                  const json = JSON.parse(body);
+                  assert.equal(json.choices[0].finish_reason, privateFinal ? "stop" : "tool_calls");
+                  if (privateFinal) assert.equal(json.choices[0].message.content, "Certified repair answer.");
+                  else assert.equal(json.choices[0].message.tool_calls[0].function.arguments, '{"cmd":"repair-command"}');
+                }
+              } else {
+                assert.doesNotMatch(body, /repair-command|Certified repair answer|"name":"exec_command"|"finish_reason":"(?:stop|tool_calls)"|\[DONE\]/);
+                if (stream) {
+                  assert.equal(resp.status, 200);
+                  assert.equal((body.match(/event: error/g) || []).length, 1);
+                  assert.match(body, /local_router_stream_failed/);
+                } else {
+                  assert.equal(resp.status, 502);
+                  assert.equal(JSON.parse(body).error.code, `grok_upstream_response_${["eof", "truncated"].includes(terminal) ? "missing" : terminal}`);
+                  assert.doesNotMatch(body, /choices|tool_calls/);
+                }
+              }
+            } finally {
+              scenario.terminalGate.resolve();
+              await responsePromise.then((resp) => resp.body?.cancel().catch(() => {})).catch(() => {});
+            }
+          });
+        }
+      }
+    }
+  } finally {
+    scenario?.terminalGate.resolve();
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an unsuccessful first turn emits one error without replaying its live client tool", async (t) => {
+  let terminal;
+  let inbound;
+  const backend = await mockBackend(async (_req, res) => {
+    inbound += 1;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.write(sse(TOOL_EVENTS.filter((event) => event.type !== "response.completed")));
+    res.end(terminal === "missing" ? "data: [DONE]\n\n" : sse([{ type: `response.${terminal}` }]));
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-terminal-no-replay-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    for (terminal of ["failed", "incomplete", "missing"]) {
+      for (const stream of [false, true]) {
+        await t.test(`${stream ? "SSE" : "JSON"}: ${terminal}`, async () => {
+          inbound = 0;
+          const resp = await fetch(`${base}/v1/chat/completions`, {
+            method: "POST", headers: auth,
+            body: JSON.stringify({
+              model: "grok-4.6",
+              messages: [
+                { role: "assistant", tool_calls: [{ id: "c1", type: "function", function: { name: "exec_command", arguments: "{}" } }] },
+                { role: "tool", tool_call_id: "c1", content: "rendered page" },
+              ],
+              tools: [{ type: "function", function: { name: "exec_command", parameters: { type: "object" } } }],
+              stream,
+            }),
+          });
+          const body = await resp.text();
+          assert.equal(inbound, 1);
+          assert.doesNotMatch(body, /"finish_reason":"(?:stop|tool_calls)"|\[DONE\]/);
+          if (stream) {
+            assert.equal(resp.status, 200);
+            assert.equal((body.match(/"name":"exec_command"/g) || []).length, 1);
+            assert.equal((body.match(/event: error/g) || []).length, 1);
+            assert.match(body, /local_router_stream_failed/);
+          } else {
+            assert.equal(resp.status, 502);
+            assert.equal(JSON.parse(body).error.code, `grok_upstream_response_${terminal}`);
+            assert.doesNotMatch(body, /tool_calls/);
+          }
+        });
+      }
+    }
   } finally {
     await stop(child);
     await new Promise((r) => backend.server.close(r));

--- a/test/grok-oauth-turn.test.mjs
+++ b/test/grok-oauth-turn.test.mjs
@@ -55,6 +55,7 @@ test("createTurnState can restore a provider-facing tool alias", () => {
       arguments: '{"path":"C:\\\\image.jpg"}',
     },
   });
+  applyResponsesEvent(state, { type: "response.completed" });
   const turn = finalizeTurn(state);
   assert.equal(turn.toolCalls[0].function.name, "view_image");
   assert.equal(turn.deltas[0].tool_calls[0].function.name, "view_image");
@@ -76,6 +77,7 @@ test("finalizeTurn backfills streamed arguments when added is followed by done w
         arguments: '{"cmd":"dir"}',
       },
     },
+    { type: "response.completed" },
   ]);
   const streamedArgs = turn.deltas
     .flatMap((delta) => delta.tool_calls || [])
@@ -102,6 +104,7 @@ test("collectResponsesEvents maps custom_tool_call onto a function tool call", (
         input: '{"x":1}',
       },
     },
+    { type: "response.completed" },
   ]);
   assert.equal(turn.toolCalls[0].id, "call_9");
   assert.equal(turn.toolCalls[0].function.name, "exec");
@@ -155,6 +158,7 @@ test("collectResponsesEvents maps xAI reasoning deltas onto reasoning_content", 
     { type: "response.reasoning_summary_text.delta", delta: "先想" },
     { type: "response.reasoning_text.delta", delta: "再想" },
     { type: "response.output_text.delta", delta: "答案" },
+    { type: "response.completed" },
   ]);
   assert.equal(turn.reasoningText, "先想再想");
   assert.equal(turn.contentText, "答案");
@@ -193,6 +197,7 @@ test("parseSseBlockEvent skips malformed JSON and leaves handlers to throw", () 
 
 test("isProgressOnlyStop requires short text, no tools, and enough output tokens", () => {
   const progress = {
+    terminalStatus: "completed",
     contentText: "Still thinking about it.",
     toolCalls: [],
     usage: { completion_tokens: 1660 },
@@ -211,6 +216,7 @@ test("isProgressOnlyStop requires short text, no tools, and enough output tokens
 
 test("isProgressOnlyStop retries a cheap stop after a tool result", () => {
   const stop = {
+    terminalStatus: "completed",
     contentText: "The figures are ready.",
     toolCalls: [],
     usage: { completion_tokens: 95 },
@@ -224,6 +230,7 @@ test("isProgressOnlyStop requires certification for long prose after a tool resu
   assert.equal(
     isProgressOnlyStop(
       {
+        terminalStatus: "completed",
         contentText: "This may look final, but the router cannot infer task completion. ".repeat(4),
         toolCalls: [],
         usage: { completion_tokens: 20 },
@@ -270,8 +277,8 @@ test("requestOffersClientTools ignores hosted-only or empty tool lists", () => {
 });
 
 test("shouldPreferRetryTurn keeps the first answer when the retry also has no tools", () => {
-  assert.equal(shouldPreferRetryTurn({ toolCalls: [] }), false);
-  assert.equal(shouldPreferRetryTurn({ toolCalls: [{ id: "c1" }] }), true);
+  assert.equal(shouldPreferRetryTurn({ terminalStatus: "completed", toolCalls: [] }), false);
+  assert.equal(shouldPreferRetryTurn({ terminalStatus: "completed", toolCalls: [{ id: "c1" }] }), true);
 });
 
 test("withProgressOnlyNudge appends a user message so the instructions prefix stays put", () => {
@@ -308,6 +315,7 @@ test("withProgressOnlyNudge leads with continue after a tool result", () => {
 test("classifyAfterToolRepair accepts only tools or a certified non-empty final answer", () => {
   assert.deepEqual(
     classifyAfterToolRepair({
+      terminalStatus: "completed",
       toolCalls: [{ id: "c1", function: { name: "exec_command", arguments: "{}" } }],
       contentText: "status",
     }),
@@ -315,17 +323,19 @@ test("classifyAfterToolRepair accepts only tools or a certified non-empty final 
   );
   assert.deepEqual(
     classifyAfterToolRepair({
+      terminalStatus: "completed",
       toolCalls: [
         { function: { name: REPAIR_FINAL_TOOL, arguments: JSON.stringify({ answer: "Done." }) } },
       ],
     }),
     { action: "final", contentText: "Done." },
   );
-  assert.deepEqual(classifyAfterToolRepair({ toolCalls: [], contentText: "Still working." }), {
+  assert.deepEqual(classifyAfterToolRepair({ terminalStatus: "completed", toolCalls: [], contentText: "Still working." }), {
     action: "fail",
   });
   assert.deepEqual(
     classifyAfterToolRepair({
+      terminalStatus: "completed",
       toolCalls: [
         { function: { name: REPAIR_FINAL_TOOL, arguments: JSON.stringify({ answer: "   " }) } },
       ],
@@ -333,10 +343,62 @@ test("classifyAfterToolRepair accepts only tools or a certified non-empty final 
     { action: "fail" },
   );
   assert.deepEqual(classifyAfterToolRepair({
+    terminalStatus: "completed",
     toolCalls: [{ function: { name: REPAIR_FINAL_TOOL, arguments: "{" } }],
   }), {
     action: "fail",
   });
+});
+
+test("only response.completed certifies a tool call or private final answer", () => {
+  for (const name of ["exec_command", REPAIR_FINAL_TOOL]) {
+    const call = {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call", id: "fc_terminal", call_id: "call_terminal", name,
+        arguments: JSON.stringify(name === REPAIR_FINAL_TOOL ? { answer: "Done." } : { cmd: "dir" }),
+      },
+    };
+    for (const terminalStatus of ["completed", "failed", "incomplete", "missing"]) {
+      const turn = collectResponsesEvents([
+        call,
+        ...(terminalStatus === "missing" ? [] : [{ type: `response.${terminalStatus}` }]),
+      ]);
+      assert.equal(turn.terminalStatus, terminalStatus);
+      assert.equal(turn.finishReason, terminalStatus === "completed" ? "tool_calls" : null);
+      assert.deepEqual(classifyAfterToolRepair(turn), terminalStatus === "completed"
+        ? name === REPAIR_FINAL_TOOL ? { action: "final", contentText: "Done." } : { action: "tools" }
+        : { action: "fail" });
+      assert.equal(shouldPreferRetryTurn(turn), terminalStatus === "completed");
+    }
+  }
+});
+
+test("a failed or missing terminal cannot become a progress-only retry", () => {
+  for (const terminalStatus of [undefined, "failed", "incomplete", "missing"]) {
+    const turn = { terminalStatus, contentText: "Continuing.", usage: { completion_tokens: 1660 } };
+    assert.equal(isProgressOnlyStop(turn), false);
+    assert.equal(isProgressOnlyStop(turn, { afterToolResult: true }), false);
+  }
+});
+
+test("an upstream failure cannot be revived by later completed or tool events", () => {
+  for (const failure of [
+    { type: "response.failed" },
+    { type: "response.incomplete" },
+    { type: "error" },
+    { type: "response.completed", response: { status: "failed" } },
+    { type: "response.completed", response: { status: "incomplete" } },
+  ]) {
+    const turn = collectResponsesEvents([
+      failure,
+      { type: "response.output_item.done", item: { type: "function_call", id: "late", name: "exec_command", arguments: "{}" } },
+      { type: "response.completed" },
+    ]);
+    assert.equal(turn.finishReason, null);
+    assert.equal(turn.toolCalls.length, 0);
+    assert.deepEqual(classifyAfterToolRepair(turn), { action: "fail" });
+  }
 });
 
 test("selectedRetryUsage reports selected context and separate aggregate billing", () => {

--- a/test/grok-reasoning-summary-compat.test.mjs
+++ b/test/grok-reasoning-summary-compat.test.mjs
@@ -703,6 +703,139 @@ test("resolves held lifecycles before failure terminals", async () => {
   ]);
 });
 
+const GATEWAY_ERROR = {
+  error: {
+    message: "list index out of range; private upstream payload",
+    type: "None", param: "None", code: "500",
+    stack: "private gateway stack",
+  },
+};
+
+function pendingGatewayMessage(newline = "\n", { reasoning = true } = {}) {
+  return [
+    block({ type: "response.created", sequence_number: 0, response: { id: "resp_gateway_error", status: "in_progress", output: [] } }, newline),
+    block({ type: "response.output_item.added", sequence_number: 1, output_index: 0, item: { id: "msg_gateway_error", type: "message", role: "assistant", status: "in_progress", content: [] } }, newline),
+    block({ type: "response.content_part.added", sequence_number: 2, item_id: "msg_gateway_error", output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }, newline),
+    ...(reasoning ? [block({ type: "response.reasoning_summary_text.delta", sequence_number: 3, item_id: "rs_gateway_error", output_index: 0, delta: "Проверка ещё идёт." }, newline)] : []),
+  ].join("");
+}
+
+function assertCanonicalGatewayError(raw, { reasoning = true } = {}) {
+  const output = events(raw);
+  const failures = output.filter((event) => event.type === "error");
+  assert.equal(failures.length, 1);
+  assert.equal(output.at(-1), failures[0]);
+  assert.equal(failures[0].code, "local_router_stream_failed");
+  assert.equal(failures[0].message, "The Grok gateway could not complete the upstream response stream.");
+  assert.equal(failures[0].param, null);
+  assert.match(raw, /event: error\r?\ndata:/u);
+  assert.doesNotMatch(raw, /private upstream payload|list index out of range|private gateway stack|msg_gateway_error|response.completed|\[DONE\]/u);
+  assert.equal(output.some((event) => event.item?.type === "message"), false);
+  const reasoningDone = output.filter((event) => event.type === "response.output_item.done");
+  assert.equal(reasoningDone.length, reasoning ? 1 : 0);
+  if (reasoning) {
+    assert.equal(reasoningDone[0].item.status, "incomplete");
+    assert.deepEqual(reasoningDone[0].item.summary, [{ type: "summary_text", text: "Проверка ещё идёт." }]);
+  }
+  return output;
+}
+
+test("normalizes fragmented Grok gateway error envelopes and drops every later frame", async () => {
+  for (const newline of ["\n", "\r\n"]) {
+    for (const chunkSize of [0, 1, 17]) {
+      const input = [
+        pendingGatewayMessage(newline),
+        block(GATEWAY_ERROR, newline),
+        block({ type: "response.output_text.done", item_id: "msg_gateway_error", output_index: 0, text: "" }, newline),
+        block({ type: "response.output_item.done", output_index: 0, item: { id: "msg_gateway_error", type: "message", status: "completed", content: [] } }, newline),
+        block({ type: "response.completed", response: { status: "completed", output: [] } }, newline),
+        block(GATEWAY_ERROR, newline),
+        `data: [DONE]${newline}${newline}`,
+        'data: {"unterminated":"pending gateway tail"}',
+      ].join("");
+      const raw = await transformed(input, chunkSize);
+      const output = assertCanonicalGatewayError(raw);
+      assert.deepEqual(output.map((event) => event.sequence_number), output.map((_event, index) => index));
+      if (newline === "\r\n") assert.equal(raw.replaceAll("\r\n", "").includes("\n"), false);
+    }
+  }
+});
+
+test("normalizes an unterminated gateway error and never flushes its pending message", async () => {
+  for (const newline of ["\n", "\r\n"]) {
+    for (const reasoning of [false, true]) {
+      const input = pendingGatewayMessage(newline, { reasoning })
+        + `event: message${newline}data: ${JSON.stringify(GATEWAY_ERROR)}`;
+      const raw = await transformed(input, 1);
+      assertCanonicalGatewayError(raw, { reasoning });
+      assert.ok(raw.endsWith(`${newline}${newline}`), "the canonical error must be a dispatchable SSE frame");
+    }
+  }
+});
+
+test("emits a gated gateway error before EOF and ignores later invalid or oversized bytes", async () => {
+  const stream = new GrokReasoningSummaryCompatTransform({ maxFrameBytes: 256, maxCommittedFrameBytes: 1024 });
+  let raw = "";
+  stream.setEncoding("utf8");
+  stream.on("data", (chunk) => { raw += chunk; });
+  const ended = once(stream, "end");
+  stream.write(pendingGatewayMessage());
+  assert.match(raw, /Проверка ещё идёт/u);
+  assert.doesNotMatch(raw, /event: error/u);
+  stream.write(`data: ${JSON.stringify(GATEWAY_ERROR)}\n`);
+  assert.doesNotMatch(raw, /event: error/u);
+  stream.write("\n");
+  assertCanonicalGatewayError(raw);
+  const terminal = raw;
+  stream.write(Buffer.from([0xff, 0xfe]));
+  stream.write("x".repeat(2048));
+  stream.end(block(GATEWAY_ERROR) + "data: [DONE]\n\n");
+  await ended;
+  assert.equal(raw, terminal);
+});
+
+test("does not mistake error-shaped prose, nested data, or typed events for gateway errors", async () => {
+  const input = [
+    block({ type: "response.output_text.delta", delta: JSON.stringify(GATEWAY_ERROR) }),
+    block({ type: "response.output_text.done", text: JSON.stringify(GATEWAY_ERROR), error: { code: "annotation" } }),
+    block({ content: GATEWAY_ERROR }),
+    block({ text: JSON.stringify(GATEWAY_ERROR) }),
+    block({ error: "plain text" }),
+    block({ error: null }),
+    block({ error: [GATEWAY_ERROR] }),
+    block([{ error: { code: "nested" } }]),
+    block({ type: null, error: { code: "not an untyped envelope" } }),
+    block({ type: "error", code: "already_canonical", message: "known error", param: null }),
+    block({ type: "response.failed", response: { status: "failed", error: { code: "typed_failure" } } }),
+    "data: [DONE]\n\n",
+  ].join("");
+  assert.equal(await transformed(input, 1), input);
+});
+
+test("gateway error recognition retains invalid UTF-8 and frame-limit safety", async () => {
+  const invalid = Buffer.concat([
+    Buffer.from('data: {"error":{"message":"'), Buffer.from([0xff]), Buffer.from('"}}\n\n'),
+  ]);
+  const stream = new GrokReasoningSummaryCompatTransform();
+  const chunks = [];
+  stream.on("data", (chunk) => chunks.push(chunk));
+  const ended = once(stream, "end");
+  const raw = Buffer.concat([invalid, Buffer.from(block(GATEWAY_ERROR))]);
+  stream.end(raw);
+  await ended;
+  assert.deepEqual(Buffer.concat(chunks), raw, "invalid pre-mutation UTF-8 must still disable repair without changing bytes");
+  await assert.rejects(
+    transformed(Buffer.concat([Buffer.from(pendingGatewayMessage()), invalid]), 1),
+    /failed after stream mutation: invalid UTF-8/u,
+  );
+  const oversized = block({ error: { message: "x".repeat(2048) } });
+  assert.equal(await transformed(oversized + block(GATEWAY_ERROR), 1, { maxFrameBytes: 256 }), oversized + block(GATEWAY_ERROR));
+  await assert.rejects(
+    transformed(pendingGatewayMessage() + oversized, 1, { maxFrameBytes: 256, maxCommittedFrameBytes: 1024 }),
+    /failed after stream mutation: SSE frame byte limit/u,
+  );
+});
+
 test("an oversized unterminated frame fails open without unbounded buffering", async () => {
   const input = `${block({ type: "response.output_item.added", output_index: 0, item: { id: "msg_limit", type: "message", role: "assistant", status: "in_progress", content: [] } })}data: ${"x".repeat(512)}`;
   assert.equal(await transformed(input, 1, { maxFrameBytes: 256 }), input);

--- a/test/grok-run-report.test.mjs
+++ b/test/grok-run-report.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { buildGrokRunReport, readJsonLines } from '../src/grok-run-report.mjs';
+
+const at = (s) => new Date(Date.UTC(2026, 8, 9) + s * 1000).toISOString();
+const event = (s, type, payload) => ({ timestamp: at(s), type, payload });
+const usage = (input, output, reasoning) => ({ type: 'token_count', info: { last_token_usage: {
+  input_tokens: input, output_tokens: output, ...(reasoning === undefined ? {} : { reasoning_output_tokens: reasoning }),
+} } });
+
+test('joins only exact request IDs; token rate includes complete request time', () => {
+  const a = { requestId: 'instance:1', threadId: 'worker', startedAt: Date.parse(at(0)), endedAt: Date.parse(at(10)), status: 200 };
+  const report = buildGrokRunReport({ startedAt: at(0), endedAt: at(12), threadId: 'worker',
+    activityEvents: [{ active: [a], recent: [] }, { active: [], recent: [a] }],
+    usageEvents: [{ requestId: 'instance:1', firstTokenMs: 9000 }, { requestId: 'foreign', outputTokens: 999999 }],
+    codexEvents: [event(10, 'event_msg', usage(200, 100, 90))] });
+  assert.equal(report.requests.completed, 1);
+  assert.equal(report.requests.correlatedUsageRecords, 1);
+  assert.equal(report.outputTokensPerRequestSecond, 10);
+  assert.equal(report.firstTokenMs.value, 9000);
+  assert.equal(report.tokens.reasoningTokens.value, 90);
+});
+
+test('missing reasoning stays missing while explicit zero is counted', () => {
+  const report = buildGrokRunReport({ codexEvents: [event(1, 'event_msg', usage(20, 3)), event(2, 'event_msg', usage(30, 4, 0))] });
+  assert.deepEqual(report.tokens.reasoningTokens, { value: 0, reported: 1, missing: 1 });
+  assert.equal(report.requests.correlation, 'unavailable');
+  assert.equal(report.outputTokensPerRequestSecond, null);
+});
+
+test('measures overlapping tool intervals once and counts patch failure without exporting text', () => {
+  const secret = 'PRIVATE_USER_CONTENT_CANARY';
+  const report = buildGrokRunReport({ startedAt: at(0), endedAt: at(10), codexEvents: [
+    event(1, 'response_item', { type: 'function_call', call_id: 'test', name: 'exec_command', arguments: JSON.stringify({ cmd: `vitest run ${secret}` }) }),
+    event(2, 'response_item', { type: 'custom_tool_call', call_id: 'patch', name: 'apply_patch', input: secret }),
+    event(3, 'response_item', { type: 'custom_tool_call_output', call_id: 'patch', output: `apply_patch verification failed: ${secret}` }),
+    event(4, 'response_item', { type: 'function_call_output', call_id: 'test', output: `Process exited with code 1\n${secret}` }),
+    event(5, 'response_item', { type: 'reasoning', text: secret }),
+    event(6, 'event_msg', { type: 'task_complete', last_agent_message: secret }),
+  ] });
+  assert.deepEqual(report.tools, { calls: 2, failures: 2, patchFailures: 1, durationMs: 3000, firstTestAfterMs: 1000 });
+  assert.equal(report.outcome, 'completed');
+  assert.ok(!JSON.stringify(report).includes(secret));
+});
+
+test('separates invocation timings and byte metadata without admitting arbitrary content', () => {
+  const report = buildGrokRunReport({ threadId: 'worker', startedAt: at(5), endedAt: at(15),
+    activityEvents: [{ recent: [
+      { requestId: 'old', threadId: 'worker', startedAt: Date.parse(at(1)), endedAt: Date.parse(at(4)) },
+      { requestId: 'new', threadId: 'worker', startedAt: Date.parse(at(6)), endedAt: Date.parse(at(8)), status: 'SECRET' },
+    ] }], usageEvents: [{ requestId: 'new', contextBytes: { observationPoint: 'router_ingress', instructionsBytes: 0, toolsBytes: 24, historyBytes: 99, secret: 'SECRET' } }] });
+  assert.equal(report.requests.completed, 1);
+  assert.deepEqual(report.requests.statuses, { unknown: 1 });
+  assert.equal(report.contextBytes.unit, 'utf8_json_bytes');
+  assert.equal(report.contextBytes.first.instructionsBytes, 0);
+  assert.ok(!JSON.stringify(report).includes('SECRET'));
+});
+
+test('Grok completion is not a test-success claim and cancelled runs stay cancelled', () => {
+  const report = buildGrokRunReport({ sessionId: 'cli', startedAt: at(0), endedAt: at(10),
+    grokEvents: [{ type: 'usage', usage: { output_tokens: 100, reasoning_tokens: 80 }, signature: 'SECRET' },
+      { type: 'thought', data: 'SECRET' }, { type: 'tool_call', toolCallId: 't', rawInput: { command: 'vitest run' } },
+      { type: 'end', stopReason: 'cancelled', usage: { output_tokens: 100 } }],
+    grokLog: [{ sid: 'cli', ts: at(9), msg: 'shell.turn.inference_done', ctx: { model_elapsed_ms: 9000, ttft_ms: 8000 } },
+      { sid: 'other', ts: at(9), msg: 'shell.turn.inference_done', ctx: { model_elapsed_ms: 999999 } }],
+    grokSessionEvents: [{ ts: at(10), type: 'tool_completed', duration_ms: 1000, tool_call_id: 't' }] });
+  assert.equal(report.outcome, 'cancelled');
+  assert.equal(report.tokens.outputTokens.value, 100);
+  assert.equal(report.outputTokensPerRequestSecond, 100 / 9);
+  assert.equal(report.tools.firstTestAfterMs, 9000);
+  assert.ok(!JSON.stringify(report).includes('SECRET'));
+});
+
+test('partial usage coverage cannot produce an inflated throughput', () => {
+  const report = buildGrokRunReport({ sessionId: 'cli', startedAt: at(0), endedAt: at(10),
+    grokEvents: [{ type: 'usage', usage: { output_tokens: 100 } }],
+    grokLog: [1, 2].map((s) => ({ sid: 'cli', ts: at(s), msg: 'shell.turn.inference_done', ctx: { model_elapsed_ms: 1000 } })) });
+  assert.equal(report.outputTokensPerRequestSecond, null);
+  assert.equal(report.outcome, 'running');
+});
+
+test('CLI input totals include separately reported cached tokens', () => {
+  const report = buildGrokRunReport({ grokEvents: [{ type: 'usage', usage: {
+    input_tokens: 10, cache_read_input_tokens: 80, cache_creation_input_tokens: 5, output_tokens: 7,
+  } }] });
+  assert.equal(report.tokens.inputTokens.value, 95);
+  assert.equal(report.tokens.cachedInputTokens.value, 80);
+  assert.equal(report.tokens.reasoningTokens.value, null);
+});
+
+test('authoritative correlated usage wins over client counters and duplicate exports', () => {
+  const row = { requestId: 'r1', inputTokens: 20, outputTokens: 30 };
+  const report = buildGrokRunReport({ threadId: 'worker', startedAt: at(0), endedAt: at(10),
+    activityEvents: [{ recent: [{ requestId: 'r1', threadId: 'worker', startedAt: Date.parse(at(1)), endedAt: Date.parse(at(5)) }] }],
+    usageEvents: [row, row], codexEvents: [event(5, 'event_msg', usage(20, 30, 0))] });
+  assert.equal(report.requests.correlatedUsageRecords, 1);
+  assert.equal(report.tokens.outputTokens.value, 30);
+  assert.equal(report.tokens.reasoningTokens.value, null);
+  assert.equal(report.tokenSource, 'router_usage');
+  assert.equal(report.unobservedMs, 6000);
+});
+
+test('JSONL rejects corrupt completed records while allowing an unfinished tail', async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), 'router-report-input-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const file = join(dir, 'events.jsonl');
+  await writeFile(file, '{"type":"usage"}\n{"partial":');
+  assert.deepEqual(await readJsonLines(file), [{ type: 'usage' }]);
+  for (const invalid of ['not-json\n{}\n', 'null\n', '[]\n', '{"partial":\n']) {
+    await writeFile(file, invalid);
+    await assert.rejects(readJsonLines(file), /JSONL/u);
+  }
+});
+
+test('CLI exports metrics without input contents and creates an owner-only report', async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), 'router-report-cli-'));
+  t.after(() => rm(dir, { recursive: true, force: true }));
+  const file = join(dir, 'events.jsonl'), out = join(dir, 'report.json');
+  const script = fileURLToPath(new URL('../src/grok-run-report.mjs', import.meta.url));
+  await writeFile(file, `${JSON.stringify(event(2, 'event_msg', { type: 'task_complete', last_agent_message: 'CANARY_PRIVATE_TEXT' }))}\n`);
+  const result = spawnSync(process.execPath, [script, '--codex-rollout', file, '--started-at', at(0), '--ended-at', at(3), '--out', out], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+  const text = await readFile(out, 'utf8');
+  assert.ok(!text.includes('CANARY'));
+  assert.equal(JSON.parse(text).outcome, 'completed');
+  if (process.platform !== 'win32') assert.equal((await stat(out)).mode & 0o777, 0o600);
+  const invalid = spawnSync(process.execPath, [script, '--codex-rollout', join(dir, 'CANARY_MISSING')], { encoding: 'utf8' });
+  assert.equal(invalid.status, 1);
+  assert.ok(!invalid.stderr.includes('CANARY'));
+});

--- a/test/grok-run-report.test.mjs
+++ b/test/grok-run-report.test.mjs
@@ -33,6 +33,28 @@ test('missing reasoning stays missing while explicit zero is counted', () => {
   assert.equal(report.outputTokensPerRequestSecond, null);
 });
 
+test('first test timing ignores filenames, quoted examples and shell comments', () => {
+  const reads = [
+    'cat frontend/vitest.config.ts',
+    'rg vitest package.json',
+    'echo "vitest run; npm test"',
+    "printf '%s\\n' 'jest run'",
+    'cat package.json # ; npm test',
+    'node -e "console.log(\'vitest run\')"',
+    "cat <<'EOF'\nvitest run\nEOF",
+  ];
+  const commands = [...reads, 'cd frontend && ./node_modules/.bin/vitest run src/example.spec.ts'];
+  const report = buildGrokRunReport({ startedAt: at(0), codexEvents: commands.map((cmd, i) =>
+    event(i + 1, 'response_item', { type: 'function_call', name: 'exec_command', call_id: String(i), arguments: JSON.stringify({ cmd }) })) });
+  assert.equal(report.tools.firstTestAfterMs, commands.length * 1000);
+  for (const cmd of ['npm test', 'npm run test:unit', 'npx vitest run', 'node --test test/example.mjs', 'jest', 'cd frontend\n./node_modules/.bin/vitest run']) {
+    const direct = buildGrokRunReport({ startedAt: at(0), codexEvents: [event(2, 'response_item', {
+      type: 'function_call', name: 'exec_command', call_id: 'test', arguments: JSON.stringify({ cmd }),
+    })] });
+    assert.equal(direct.tools.firstTestAfterMs, 2000, cmd);
+  }
+});
+
 test('measures overlapping tool intervals once and counts patch failure without exporting text', () => {
   const secret = 'PRIVATE_USER_CONTENT_CANARY';
   const report = buildGrokRunReport({ startedAt: at(0), endedAt: at(10), codexEvents: [

--- a/test/grok-run-report.test.mjs
+++ b/test/grok-run-report.test.mjs
@@ -93,16 +93,17 @@ test('CLI input totals include separately reported cached tokens', () => {
   assert.equal(report.tokens.reasoningTokens.value, null);
 });
 
-test('authoritative correlated usage wins over client counters and duplicate exports', () => {
+test('authoritative usage wins over client counters and retains multiple charged attempts', () => {
   const row = { requestId: 'r1', inputTokens: 20, outputTokens: 30 };
   const report = buildGrokRunReport({ threadId: 'worker', startedAt: at(0), endedAt: at(10),
     activityEvents: [{ recent: [{ requestId: 'r1', threadId: 'worker', startedAt: Date.parse(at(1)), endedAt: Date.parse(at(5)) }] }],
     usageEvents: [row, row], codexEvents: [event(5, 'event_msg', usage(20, 30, 0))] });
-  assert.equal(report.requests.correlatedUsageRecords, 1);
-  assert.equal(report.tokens.outputTokens.value, 30);
+  assert.equal(report.requests.correlatedUsageRecords, 2);
+  assert.equal(report.tokens.outputTokens.value, 60);
   assert.equal(report.tokens.reasoningTokens.value, null);
   assert.equal(report.tokenSource, 'router_usage');
   assert.equal(report.unobservedMs, 6000);
+  assert.equal(report.outputTokensPerRequestSecond, 15);
 });
 
 test('JSONL rejects corrupt completed records while allowing an unfinished tail', async (t) => {

--- a/test/grok-run-report.test.mjs
+++ b/test/grok-run-report.test.mjs
@@ -106,6 +106,22 @@ test('partial usage coverage cannot produce an inflated throughput', () => {
   assert.equal(report.outcome, 'running');
 });
 
+test('CLI counts terminal shell failures once even when the tool completed', () => {
+  const report = buildGrokRunReport({ grokEvents: [
+    { type: 'tool_call_update', toolCallId: 'bash', status: 'in_progress', rawOutput: { type: 'Bash', exit_code: 1 } },
+    { type: 'tool_call_update', toolCallId: 'bash', status: 'completed', rawOutput: { type: 'Bash', exit_code: 127, command: 'PRIVATE', output_for_prompt: 'PRIVATE' } },
+    { type: 'tool_call_update', toolCallId: 'bash', status: 'completed', rawOutput: { type: 'Bash', exit_code: 127 } },
+    { type: 'tool_call_update', toolCallId: 'timeout', status: 'completed', rawOutput: { type: 'Bash', exit_code: 0, timed_out: true } },
+    { type: 'tool_call_update', toolCallId: 'signal', status: 'completed', rawOutput: { type: 'Bash', exit_code: 0, signal: 'SIGTERM' } },
+    { type: 'tool_call_update', toolCallId: 'tool', status: 'failed' },
+    { type: 'tool_call_update', toolCallId: 'tool', status: 'failed' },
+    { type: 'tool_call_update', toolCallId: 'success', status: 'completed', rawOutput: { type: 'Bash', exit_code: 0 } },
+    { type: 'tool_call_update', toolCallId: 'unknown', status: 'completed', rawOutput: { type: 'Bash', exit_code: '1' } },
+  ] });
+  assert.equal(report.tools.failures, 4);
+  assert.ok(!JSON.stringify(report).includes('PRIVATE'));
+});
+
 test('CLI input totals include separately reported cached tokens', () => {
   const report = buildGrokRunReport({ grokEvents: [{ type: 'usage', usage: {
     input_tokens: 10, cache_read_input_tokens: 80, cache_creation_input_tokens: 5, output_tokens: 7,

--- a/test/request-diagnostics-router.test.mjs
+++ b/test/request-diagnostics-router.test.mjs
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import http from "node:http";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { callerBaseUrl } from "../src/caller-auth.mjs";
+import {
+  measureIngressContextBytes,
+  utf8JsonBytes,
+} from "../src/request-diagnostics.mjs";
+import { openPort } from "./port-pool.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
+const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
+
+function routerBase(port) {
+  return callerBaseUrl(port, CALLER_KEY);
+}
+
+function json(response, status, payload) {
+  const body = Buffer.from(JSON.stringify(payload), "utf8");
+  response.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": String(body.length),
+  });
+  response.end(body);
+}
+
+async function bodyJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+async function mockServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  return { server, port: server.address().port };
+}
+
+function run(env) {
+  const stateDir =
+    env?.MODEL_ROUTER_STATE_DIR ||
+    mkdtempSync(path.join(os.tmpdir(), "request-diagnostics-state-"));
+  const child = spawn(process.execPath, [path.join(root, "src", "router.mjs")], {
+    cwd: root,
+    env: {
+      ...process.env,
+      MODEL_ROUTER_STATE_DIR: stateDir,
+      CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
+      CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+      KIMI_INTERNAL_KEY: INTERNAL_KEY,
+      CODEX_ROUTER_SHOW_ALL_MODELS: "1",
+      CODEX_ROUTER_QUIET: "1",
+      ...env,
+    },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  child.stderr.setEncoding("utf8");
+  let errors = "";
+  child.stderr.on("data", (chunk) => {
+    errors += chunk;
+  });
+  child.testErrors = () => errors;
+  child.stateDir = stateDir;
+  return child;
+}
+
+async function waitFor(url, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Child exited early (${child.exitCode}): ${child.testErrors()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Not bound yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`Timed out waiting for ${url}: ${child.testErrors()}`);
+}
+
+async function stopChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await new Promise((resolve) => child.once("exit", resolve));
+}
+
+async function closeServer(server) {
+  await new Promise((resolve) => server.close(resolve));
+}
+
+function usageEvents(stateDir) {
+  const file = path.join(stateDir, "usage-events.jsonl");
+  if (!existsSync(file)) return [];
+  const lines = readFileSync(file, "utf8").split("\n");
+  if (lines.at(-1) !== "") lines.pop();
+  return lines.filter(Boolean).map((line) => JSON.parse(line));
+}
+
+async function waitForUsageEvents(stateDir, count, child) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const events = usageEvents(stateDir);
+    if (events.length >= count) return events;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`Timed out waiting for ${count} usage events: ${child.testErrors()}`);
+}
+
+const GROK_PAYLOAD = {
+  model: "grok-oauth/grok-4.6",
+  instructions: "Stay concise.",
+  tools: [{ type: "function", name: "read_file" }],
+  input: [{ type: "message", role: "user", content: "hello" }],
+};
+
+const EXPECTED_CONTEXT = measureIngressContextBytes(GROK_PAYLOAD);
+
+test("Grok 4.6 usage rows correlate with activity id across success, failure, and cancel", async () => {
+  let hang;
+  let turns = 0;
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      json(response, 200, { ok: true, credential_present: true });
+      return;
+    }
+    await bodyJson(request);
+    turns += 1;
+    if (turns === 3) {
+      hang = new Promise((resolve) => {
+        request.once("close", resolve);
+        response.once("close", resolve);
+      });
+      return;
+    }
+    if (turns === 2) {
+      json(response, 502, { error: { message: "upstream refused" } });
+      return;
+    }
+    json(response, 200, {
+      id: "resp_grok",
+      output: [{ type: "message", content: [{ type: "output_text", text: "ok" }] }],
+      usage: {
+        input_tokens: 11,
+        output_tokens: 4,
+        output_tokens_details: { reasoning_tokens: 3 },
+      },
+    });
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "request-diagnostics-router-"));
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  });
+  const headers = { "Content-Type": "application/json" };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    const ok = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(GROK_PAYLOAD),
+    });
+    assert.equal(ok.status, 200, await ok.text());
+    const [success] = await waitForUsageEvents(stateDir, 1, router);
+    assert.equal(success.model, "grok-oauth/grok-4.6");
+    assert.equal(success.provider, "grok-oauth");
+    assert.equal(success.status, 200);
+    assert.equal(success.reasoningTokens, 3);
+    assert.equal(success.inputTokens, 11);
+    assert.equal(success.outputTokens, 4);
+    assert.match(success.requestId, /^[a-f0-9-]+:[0-9]+$/);
+    const completedActivity = await (await fetch(`${routerBase(routerPort)}/activity`)).json();
+    assert.ok(completedActivity.recent.some((entry) => entry.requestId === success.requestId && entry.status === 200));
+    assert.deepEqual(success.contextBytes, EXPECTED_CONTEXT);
+    assert.equal(success.contextBytes.instructionsBytes, utf8JsonBytes("Stay concise."));
+    assert.equal("reasoningOutputTokens" in success, false);
+
+    const failed = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(GROK_PAYLOAD),
+    });
+    assert.equal(failed.status, 502);
+    const events = await waitForUsageEvents(stateDir, 2, router);
+    const failure = events.at(-1);
+    assert.equal(failure.status, 502);
+    assert.notEqual(failure.requestId, success.requestId);
+    const failedActivity = await (await fetch(`${routerBase(routerPort)}/activity`)).json();
+    assert.ok(failedActivity.recent.some((entry) => entry.requestId === failure.requestId && entry.status === 502));
+    assert.deepEqual(failure.contextBytes, EXPECTED_CONTEXT);
+    assert.equal("reasoningTokens" in failure, false);
+
+    const canceler = new AbortController();
+    const held = fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(GROK_PAYLOAD),
+      signal: canceler.signal,
+    }).catch(() => undefined);
+    const deadline = Date.now() + 3_000;
+    let activityId;
+    while (!activityId && Date.now() < deadline) {
+      const activity = await fetch(`${routerBase(routerPort)}/activity`);
+      const payload = await activity.json();
+      const active = payload.active?.find(
+        (entry) => entry.model === "grok-oauth/grok-4.6",
+      );
+      activityId = active?.requestId || active?.id;
+      if (!activityId) await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.ok(activityId, "in-flight activity did not publish a request id");
+    canceler.abort();
+    await held;
+    if (hang) await hang;
+    const afterCancel = await waitForUsageEvents(stateDir, 3, router);
+    const canceled = afterCancel.at(-1);
+    assert.equal(canceled.status, 0);
+    assert.equal(canceled.requestId, activityId);
+    assert.deepEqual(canceled.contextBytes, EXPECTED_CONTEXT);
+
+    const raw = readFileSync(path.join(stateDir, "usage-events.jsonl"), "utf8");
+    assert.equal(raw.includes("Stay concise."), false);
+    assert.equal(raw.includes("read_file"), false);
+    assert.equal(raw.includes("hello"), false);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("a non-Grok-4.6 turn still records requestId and omits contextBytes", async () => {
+  const gateway = await mockServer(async (request, response) => {
+    if (request.method === "GET" && request.url === "/health") {
+      json(response, 200, { ok: true, credential_present: true });
+      return;
+    }
+    await bodyJson(request);
+    json(response, 200, {
+      id: "resp_ds",
+      usage: { input_tokens: 2, output_tokens: 1 },
+    });
+  });
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "request-diagnostics-other-"));
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "deepseek/deepseek-v4-pro",
+        instructions: "should not be measured",
+        input: "go",
+      }),
+    });
+    assert.equal(response.status, 200, await response.text());
+    const [event] = await waitForUsageEvents(stateDir, 1, router);
+    assert.match(event.requestId, /^[a-f0-9-]+:[0-9]+$/);
+    assert.equal("contextBytes" in event, false);
+    const raw = readFileSync(path.join(stateDir, "usage-events.jsonl"), "utf8");
+    assert.equal(raw.includes("should not be measured"), false);
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/test/request-diagnostics.test.mjs
+++ b/test/request-diagnostics.test.mjs
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  grokOauth46IngressContextBytes,
+  measureIngressContextBytes,
+  ROUTER_INGRESS_OBSERVATION_POINT,
+  safeDiagnosticRequestId,
+  sanitizeContextBytes,
+  utf8JsonBytes,
+  usageDiagnosticMetadata,
+} from "../src/request-diagnostics.mjs";
+
+test("missing payload fields measure as zero JSON bytes, present empties do not", () => {
+  assert.equal(utf8JsonBytes(undefined), 0);
+  assert.equal(utf8JsonBytes(""), Buffer.byteLength(JSON.stringify(""), "utf8"));
+  assert.equal(utf8JsonBytes([]), Buffer.byteLength("[]", "utf8"));
+  assert.equal(utf8JsonBytes({}), Buffer.byteLength("{}", "utf8"));
+
+  const measured = measureIngressContextBytes({
+    model: "grok-oauth/grok-4.6",
+    instructions: "system prompt",
+    tools: [{ type: "function", name: "read_file" }],
+    input: [{ type: "message", role: "user", content: "hello" }],
+  });
+  assert.equal(measured.observationPoint, ROUTER_INGRESS_OBSERVATION_POINT);
+  assert.equal(measured.instructionsBytes, utf8JsonBytes("system prompt"));
+  assert.equal(
+    measured.toolsBytes,
+    utf8JsonBytes([{ type: "function", name: "read_file" }]),
+  );
+  assert.equal(
+    measured.historyBytes,
+    utf8JsonBytes([{ type: "message", role: "user", content: "hello" }]),
+  );
+
+  const missing = measureIngressContextBytes({ model: "grok-oauth/grok-4.6" });
+  assert.deepEqual(missing, {
+    observationPoint: ROUTER_INGRESS_OBSERVATION_POINT,
+    instructionsBytes: 0,
+    toolsBytes: 0,
+    historyBytes: 0,
+  });
+});
+
+test("UTF-8 JSON bytes count serialized payload fields, never token estimates", () => {
+  const text = "café — 月";
+  assert.equal(utf8JsonBytes(text), Buffer.byteLength(JSON.stringify(text), "utf8"));
+  assert.notEqual(utf8JsonBytes(text), text.length);
+  const circular = {};
+  circular.self = circular;
+  assert.equal(utf8JsonBytes(circular), 0);
+});
+
+test("contextBytes is only measured for Grok OAuth 4.6 ingress", () => {
+  const payload = { instructions: "x", tools: [], input: "hi" };
+  assert.equal(
+    grokOauth46IngressContextBytes(payload, { slug: "grok-oauth/grok-4.5" }),
+    undefined,
+  );
+  assert.equal(
+    grokOauth46IngressContextBytes(payload, { slug: "openrouter/grok-4.6" }),
+    undefined,
+  );
+  assert.deepEqual(
+    grokOauth46IngressContextBytes(payload, { slug: "grok-oauth/grok-4.6" }),
+    measureIngressContextBytes(payload),
+  );
+});
+
+test("diagnostic metadata keeps only bounded requestId and contextBytes", () => {
+  assert.equal(safeDiagnosticRequestId("12"), "12");
+  assert.equal(safeDiagnosticRequestId(7), "7");
+  assert.equal(
+    safeDiagnosticRequestId("6f1c2a3b-4d5e-6789-abcd-ef0123456789:3"),
+    "6f1c2a3b-4d5e-6789-abcd-ef0123456789:3",
+  );
+  assert.equal(safeDiagnosticRequestId("../secret"), undefined);
+  assert.equal(safeDiagnosticRequestId("thread title with spaces"), undefined);
+  assert.equal(safeDiagnosticRequestId("/Users/me/.codex/sessions/foo.jsonl"), undefined);
+  assert.equal(safeDiagnosticRequestId("https://x.ai/thread"), undefined);
+
+  const leaked = usageDiagnosticMetadata({
+    requestId: "thread:Title/with path",
+    contextBytes: {
+      observationPoint: ROUTER_INGRESS_OBSERVATION_POINT,
+      instructionsBytes: 4,
+      toolsBytes: 0,
+      historyBytes: 8,
+      prompt: "never persist",
+      headers: { authorization: "secret" },
+    },
+  });
+  assert.deepEqual(leaked, {
+    contextBytes: {
+      observationPoint: ROUTER_INGRESS_OBSERVATION_POINT,
+      instructionsBytes: 4,
+      toolsBytes: 0,
+      historyBytes: 8,
+    },
+  });
+  assert.equal("requestId" in leaked, false);
+
+  assert.equal(
+    sanitizeContextBytes({ observationPoint: "router_upstream", instructionsBytes: 1 }),
+    undefined,
+  );
+});
+
+test("usage events persist requestId and contextBytes without content leakage", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-router-diagnostics-"));
+  const previousStateDir = process.env.MODEL_ROUTER_STATE_DIR;
+  process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+  try {
+    const usage = await import(`../src/usage-events.mjs?diag=${Date.now()}`);
+    usage.recordUsageEvent({
+      model: "grok-oauth/grok-4.6",
+      provider: "grok-oauth",
+      status: 200,
+      durationMs: 10,
+      requestId: "42",
+      contextBytes: measureIngressContextBytes({
+        instructions: "keep this out of the ledger",
+        tools: [{ name: "read_file", path: "/secret/notes.md" }],
+        input: [{ type: "message", role: "user", content: "private turn" }],
+      }),
+      prompt: "never persisted",
+      headers: { authorization: "secret" },
+      threadTitle: "Secret thread",
+      path: "/Users/me/.codex/sessions/thread.jsonl",
+    });
+    const [event] = usage.recentUsageEvents();
+    assert.equal(event.requestId, "42");
+    assert.deepEqual(event.contextBytes, {
+      observationPoint: ROUTER_INGRESS_OBSERVATION_POINT,
+      instructionsBytes: utf8JsonBytes("keep this out of the ledger"),
+      toolsBytes: utf8JsonBytes([{ name: "read_file", path: "/secret/notes.md" }]),
+      historyBytes: utf8JsonBytes([
+        { type: "message", role: "user", content: "private turn" },
+      ]),
+    });
+    const raw = readFileSync(usage.USAGE_EVENTS_PATH, "utf8");
+    assert.equal(raw.includes("keep this out of the ledger"), false);
+    assert.equal(raw.includes("/secret/notes.md"), false);
+    assert.equal(raw.includes("private turn"), false);
+    assert.equal(raw.includes("never persisted"), false);
+    assert.equal(raw.includes("Secret thread"), false);
+    assert.equal(raw.includes("/Users/me/.codex"), false);
+    assert.equal("prompt" in event, false);
+    assert.equal("headers" in event, false);
+    assert.equal("threadTitle" in event, false);
+    assert.equal("path" in event, false);
+    assert.equal("reasoningOutputTokens" in event, false);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.MODEL_ROUTER_STATE_DIR;
+    else process.env.MODEL_ROUTER_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("legacy usage rows without diagnostics keep their exact shape", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-router-diagnostics-legacy-"));
+  const previousStateDir = process.env.MODEL_ROUTER_STATE_DIR;
+  process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+  try {
+    const usage = await import(`../src/usage-events.mjs?legacy=${Date.now()}`);
+    usage.recordUsageEvent({
+      model: "grok-oauth/grok-4.5",
+      provider: "grok-oauth",
+      status: 200,
+      durationMs: 11,
+      inputTokens: 3,
+      outputTokens: 1,
+      totalTokens: 4,
+    });
+    const [event] = usage.recentUsageEvents();
+    assert.equal("requestId" in event, false);
+    assert.equal("contextBytes" in event, false);
+    assert.equal("reasoningTokens" in event, false);
+    assert.deepEqual(Object.keys(event).sort(), [
+      "at",
+      "durationMs",
+      "inputTokens",
+      "meteringVersion",
+      "model",
+      "outputTokens",
+      "provider",
+      "status",
+      "totalTokens",
+    ]);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.MODEL_ROUTER_STATE_DIR;
+    else process.env.MODEL_ROUTER_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+test("reasoningTokens zero is distinct from an absent count on the ledger", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-router-reasoning-"));
+  const previousStateDir = process.env.MODEL_ROUTER_STATE_DIR;
+  process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+  try {
+    const usage = await import(`../src/usage-events.mjs?reasoning=${Date.now()}`);
+    usage.recordUsageEvent({
+      model: "grok-oauth/grok-4.6",
+      provider: "grok-oauth",
+      status: 200,
+      durationMs: 8,
+      outputTokens: 10,
+      reasoningTokens: 0,
+    });
+    usage.recordUsageEvent({
+      model: "grok-oauth/grok-4.6",
+      provider: "grok-oauth",
+      status: 200,
+      durationMs: 9,
+      outputTokens: 10,
+    });
+    const events = usage.recentUsageEvents();
+    const zero = events.find((event) => event.durationMs === 8);
+    const absent = events.find((event) => event.durationMs === 9);
+    assert.equal(zero.reasoningTokens, 0);
+    assert.equal("reasoningTokens" in absent, false);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.MODEL_ROUTER_STATE_DIR;
+    else process.env.MODEL_ROUTER_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/test/request-progress.test.mjs
+++ b/test/request-progress.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRequestProgress } from "../src/request-progress.mjs";
+
+test("silence and repeated polls retain live requests without inventing progress", () => {
+  let time = 100;
+  const tracker = createRequestProgress({ now: () => time, recentTtlMs: 10 });
+  const request = tracker.begin();
+  request.setRoute({ threadId: "worker-1", model: "grok-oauth/grok-4.6", secret: "never" });
+  request.attempt();
+  const initial = tracker.snapshot().active[0];
+  time += 1_000_000;
+  const silent = tracker.snapshot({ threadId: "worker-1" }).active[0];
+  assert.deepEqual(silent, initial);
+  assert.equal(silent.phase, "awaiting_upstream");
+  assert.equal(silent.lastEventAt, undefined);
+  assert.equal(silent.secret, undefined);
+  assert.equal(tracker.snapshot({ threadId: "other" }).active.length, 0);
+  request.headers();
+  request.event({ type: "response.reasoning_summary_text.delta", delta: "private reasoning" });
+  const progress = tracker.snapshot().active[0];
+  assert.equal(progress.phase, "reasoning");
+  assert.equal(progress.lastEventAt, time);
+  assert.equal(progress.receivedEvents, 1);
+  assert.doesNotMatch(JSON.stringify(progress), /private reasoning/);
+  progress.state = "tampered";
+  assert.equal(tracker.snapshot().active[0].state, "running");
+});
+
+test("cancel remains active until cleanup and recent results are bounded and expire", () => {
+  let time = 0;
+  const tracker = createRequestProgress({ now: () => time, recentLimit: 2, recentTtlMs: 10 });
+  const request = tracker.begin();
+  request.attempt();
+  request.cancel("client_disconnected");
+  request.headers();
+  request.event({ type: "response.output_text.delta", delta: "late" });
+  assert.equal(tracker.snapshot().active[0].phase, "canceling");
+  request.finish(0);
+  request.finish(200);
+  assert.equal(tracker.snapshot().active.length, 0);
+  const canceled = tracker.snapshot().recent[0];
+  assert.equal(canceled.state, "canceled");
+  assert.equal(canceled.cancelReason, "client_disconnected");
+  tracker.begin().finish(200);
+  const deadline = tracker.begin();
+  deadline.cancel("execution_deadline");
+  deadline.finish(504);
+  assert.deepEqual(tracker.snapshot().recent.map((r) => r.state), ["completed", "failed"]);
+  time = 11;
+  assert.deepEqual(tracker.snapshot().recent, []);
+});
+
+test("byte observer is transparent and counts only received bytes", async () => {
+  const tracker = createRequestProgress();
+  const request = tracker.begin();
+  const observer = request.byteObserver();
+  const bytes = Buffer.from('data: {"type":"response.created"}\n\n');
+  observer.end(bytes);
+  const output = [];
+  for await (const chunk of observer) output.push(chunk);
+  assert.deepEqual(Buffer.concat(output), bytes);
+  assert.equal(tracker.snapshot().active[0].receivedBytes, bytes.length);
+  assert.equal(tracker.snapshot().active[0].receivedEvents, 0);
+});
+
+
+test("unsuccessful response terminal is failed even under an HTTP 200 envelope", () => {
+  for (const type of ["response.failed", "response.incomplete", "error"]) {
+    const tracker = createRequestProgress();
+    const request = tracker.begin();
+    assert.equal(tracker.snapshot().active[0].phase, "unobserved");
+    assert.equal(tracker.snapshot().active[0].upstreamAttempts, undefined);
+    request.event({ type });
+    request.event({ type: "response.completed" });
+    request.finish(200);
+    assert.equal(tracker.snapshot().recent[0].state, "failed");
+    assert.equal(tracker.snapshot().recent[0].status, 200);
+    assert.equal(tracker.snapshot().recent[0].terminalEvent, type);
+  }
+});
+
+
+test("a successful new attempt replaces an unsuccessful earlier terminal", () => {
+  const tracker = createRequestProgress();
+  const request = tracker.begin();
+  request.attempt();
+  request.event({ type: "response.failed" });
+  request.attempt();
+  request.event({ type: "response.completed" });
+  request.finish(200);
+  assert.equal(tracker.snapshot().recent[0].state, "completed");
+  assert.equal(tracker.snapshot().recent[0].upstreamAttempts, 2);
+});

--- a/test/response-usage.test.mjs
+++ b/test/response-usage.test.mjs
@@ -115,6 +115,24 @@ test("extracts reasoning tokens from output_tokens_details when present", () => 
     normalizeTokenUsage({ input_tokens: 10, output_tokens: 5 }),
     { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
   );
+  // An explicit zero is a measured zero and must survive.
+  assert.deepEqual(
+    normalizeTokenUsage({
+      input_tokens: 10,
+      output_tokens: 5,
+      output_tokens_details: { reasoning_tokens: 0 },
+    }),
+    { inputTokens: 10, outputTokens: 5, totalTokens: 15, reasoningTokens: 0 },
+  );
+  // null/string are not source-provided counts; they stay absent.
+  assert.deepEqual(
+    normalizeTokenUsage({
+      input_tokens: 10,
+      output_tokens: 5,
+      output_tokens_details: { reasoning_tokens: null },
+    }),
+    { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+  );
 });
 
 test("adds up the usage of two attempts at one turn", () => {
@@ -141,6 +159,13 @@ test("adds up the usage of two attempts at one turn", () => {
       { inputTokens: 50, outputTokens: 100, totalTokens: 150, reasoningTokens: 30 },
     ),
     { inputTokens: 100, outputTokens: 200, totalTokens: 300, reasoningTokens: 50 },
+  );
+  assert.deepEqual(
+    mergeTokenUsage(
+      { inputTokens: 10, outputTokens: 2, totalTokens: 12, reasoningTokens: 0 },
+      { inputTokens: 10, outputTokens: 2, totalTokens: 12 },
+    ),
+    { inputTokens: 20, outputTokens: 4, totalTokens: 24, reasoningTokens: 0 },
   );
   // One-sided merges are the ordinary case: an attempt whose provider reported
   // nothing must not erase the one that did.
@@ -179,6 +204,77 @@ test("detects first token from chat.completion.chunk without type field", async 
   await passThrough(transform, body);
   // First token should be detected from the first delta with content.
   assert.equal(typeof transform.firstTokenAt(), "number");
+});
+
+test("stream, JSON, and headerless readers preserve reasoning absent vs zero", async () => {
+  const withReasoning = {
+    input_tokens: 21,
+    output_tokens: 8,
+    output_tokens_details: { reasoning_tokens: 5 },
+  };
+  const zeroReasoning = {
+    input_tokens: 21,
+    output_tokens: 8,
+    output_tokens_details: { reasoning_tokens: 0 },
+  };
+  const absentReasoning = { input_tokens: 21, output_tokens: 8 };
+
+  const sse = (usage) => [
+    "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n\n",
+    `event: response.completed\ndata: ${JSON.stringify({
+      type: "response.completed",
+      response: { usage },
+    })}\n\n`,
+    "data: [DONE]\n\n",
+  ];
+
+  const stream = new ResponseUsageTransform("text/event-stream");
+  assert.equal(await passThrough(stream, sse(withReasoning)), sse(withReasoning).join(""));
+  assert.deepEqual(stream.tokenUsage(), {
+    inputTokens: 21,
+    outputTokens: 8,
+    totalTokens: 29,
+    reasoningTokens: 5,
+  });
+
+  const streamZero = new ResponseUsageTransform("text/event-stream");
+  await passThrough(streamZero, sse(zeroReasoning));
+  assert.equal(streamZero.tokenUsage().reasoningTokens, 0);
+
+  const streamAbsent = new ResponseUsageTransform("text/event-stream");
+  await passThrough(streamAbsent, sse(absentReasoning));
+  assert.equal("reasoningTokens" in streamAbsent.tokenUsage(), false);
+
+  const jsonBody = JSON.stringify({ usage: withReasoning });
+  const json = new ResponseUsageTransform("application/json");
+  assert.equal(await passThrough(json, [jsonBody]), jsonBody);
+  assert.equal(json.tokenUsage().reasoningTokens, 5);
+
+  const jsonZero = new ResponseUsageTransform("application/json");
+  await passThrough(jsonZero, [JSON.stringify({ usage: zeroReasoning })]);
+  assert.equal(jsonZero.tokenUsage().reasoningTokens, 0);
+
+  const jsonAbsent = new ResponseUsageTransform("application/json");
+  await passThrough(jsonAbsent, [JSON.stringify({ usage: absentReasoning })]);
+  assert.equal("reasoningTokens" in jsonAbsent.tokenUsage(), false);
+
+  const headerless = new ResponseUsageTransform("");
+  await passThrough(headerless, sse(withReasoning).map((part) => Buffer.from(part, "utf8")));
+  assert.equal(headerless.tokenUsage().reasoningTokens, 5);
+
+  const headerlessZero = new ResponseUsageTransform("");
+  await passThrough(
+    headerlessZero,
+    sse(zeroReasoning).map((part) => Buffer.from(part, "utf8")),
+  );
+  assert.equal(headerlessZero.tokenUsage().reasoningTokens, 0);
+
+  const headerlessAbsent = new ResponseUsageTransform("");
+  await passThrough(
+    headerlessAbsent,
+    sse(absentReasoning).map((part) => Buffer.from(part, "utf8")),
+  );
+  assert.equal("reasoningTokens" in headerlessAbsent.tokenUsage(), false);
 });
 
 test("captures JSON usage without changing the response", async () => {

--- a/test/router-resilience.test.mjs
+++ b/test/router-resilience.test.mjs
@@ -1112,3 +1112,89 @@ test("an idle keep-alive connection survives past Node's default timeout", async
     await closeServer(gateway.server);
   }
 });
+
+test("protected activity follows a quiet stream through reasoning and client cancellation", async () => {
+  const threadId = "11111111-1111-4111-8111-111111111111";
+  let upstreamResponse;
+  let upstreamClosed = false;
+  let requestCount = 0;
+  let signalStarted;
+  const started = new Promise((resolve) => { signalStarted = resolve; });
+  const gateway = await mockServer((request, response) => {
+    if (request.method === "GET") {
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end('{"ok":true}');
+      return;
+    }
+    requestCount += 1;
+    upstreamResponse = response;
+    response.once("close", () => { upstreamClosed = true; });
+    signalStarted();
+  });
+  const routerPort = await openPort();
+  const router = run({
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_ACTIVITY_RECORD_RETENTION_MS: "40",
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_API_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gateway.port}/health`,
+  });
+  const base = callerBaseUrl(routerPort, CALLER_KEY);
+  const controller = new AbortController();
+  const snapshot = () => fetch(`${base}/activity?threadId=${threadId}`).then((r) => r.json());
+  async function until(predicate) {
+    const end = Date.now() + 3_000;
+    while (Date.now() < end) {
+      const state = await snapshot();
+      if (predicate(state)) return state;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.fail(`activity did not reach expected state: ${JSON.stringify(await snapshot())}`);
+  }
+  let pending;
+  try {
+    await waitFor(`http://127.0.0.1:${routerPort}/health`, router);
+    assert.equal((await fetch(`http://127.0.0.1:${routerPort}/v1/activity`)).status, 401);
+    assert.equal((await fetch(`${base}/activity?threadId=invalid%2Fid`)).status, 400);
+    pending = fetch(`${base}/responses`, {
+      method: "POST", signal: controller.signal,
+      headers: { "Content-Type": "application/json", session_id: threadId },
+      body: JSON.stringify({ model: "grok-oauth/grok-4.6", stream: true, input: "private-prompt-marker" }),
+    }).then(async (response) => { await response.text(); }).catch(() => {});
+    await started;
+    const quiet = await snapshot();
+    assert.equal(quiet.active.length, 1);
+    assert.equal(quiet.active[0].phase, "awaiting_upstream");
+    assert.equal(quiet.active[0].upstreamAttempts, 1);
+    assert.equal(quiet.active[0].lastEventAt, undefined);
+    const requestId = quiet.active[0].requestId;
+    // Presentation retention must not hide a still-pending operation.
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.equal((await snapshot()).active[0].requestId, requestId);
+    upstreamResponse.writeHead(200, { "Content-Type": "text/event-stream" });
+    upstreamResponse.write('data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_live","output_index":0,"summary_index":0,"delta":"private-output-marker"}\n\n');
+    const generating = await until((s) => s.active[0]?.phase === "reasoning");
+    assert.equal(generating.active[0].receivedEvents, 1);
+    assert.ok(generating.active[0].lastByteAt >= quiet.active[0].startedAt);
+    assert.doesNotMatch(JSON.stringify(generating), /private-prompt-marker|private-output-marker/);
+    assert.equal((await fetch(`${base}/activity?threadId=other`).then((r) => r.json())).active.length, 0);
+    controller.abort();
+    await pending;
+    const settled = await until((s) => s.recent.some((r) => r.requestId === requestId));
+    assert.equal(settled.active.length, 0);
+    assert.equal(settled.recent[0].state, "canceled");
+    assert.equal(settled.recent[0].cancelReason, "client_disconnected");
+    const closeDeadline = Date.now() + 1_000;
+    while (!upstreamClosed && Date.now() < closeDeadline) await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.equal(upstreamClosed, true);
+    assert.equal(requestCount, 1);
+  } finally {
+    controller.abort();
+    await pending;
+    await stopChild(router);
+    gateway.server.closeAllConnections?.();
+    await closeServer(gateway.server);
+  }
+});


### PR DESCRIPTION
Usage records can now be joined to `/activity` by the same instance-scoped `requestId`, including success, failure and cancellation. Grok OAuth 4.6 records separate UTF-8 JSON byte sizes for ingress instructions, tools and input history. Existing usage records remain readable; provider reasoning counters preserve the distinction between missing and explicit zero.

The local report exports request/token/timing totals, observed tool and patch failures, the first test-command attempt and terminal outcome. It projects metrics only, never prompts, tool arguments/results, credentials or reasoning text. It retains multiple charged attempts per request, reports counter coverage and does not treat byte sizes or text TTFT as decoding throughput. Filename reads, quoted examples and comments do not count as test attempts. CLI shell failures remain visible even when the tool reports completed; repeated updates are counted once.

Stacked on #652: its first three commits supply the existing `/activity` observer. This changes observation, not routing, billing, retries or tool availability. Live comparative runs remain outside ordinary CI.

Validation: request correlation fails on the parent without the wiring. Focused tests cover exact correlation, old records, absent/zero reasoning counters, terminal paths, other-model controls, UTF-8 sizes and content-leakage canaries. All 12 report tests and `npm run check` pass at `cf7e9d6420833778aeec681594f6441d5e35044d`. The two report corrections each fail their regression before the fix. Full local and current-head hosted CI results are recorded separately; the local full suite had two host-service doctor timeouts, which passed with the existing service-platform isolation setting.
