### PR TITLE
feat: add scoped Grok apply_patch examples with full protocol verification

### DIFF
--- a/.github/workflows/grok-apply-patch-guidance.yml
+++ b/.github/workflows/grok-apply-patch-guidance.yml
@@ -1,0 +1,116 @@
+# Ordinary `npm test` in ci.yml is Node-only. LiteLLM custom-tool translation
+# for grok-oauth/grok-4.6 is proven here against the hash-locked Python tree
+# and a mock xAI Responses server — never against a machine-local install and
+# never against live credentials.
+name: Grok apply_patch protocol
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - "requirements/**"
+      - "bin/install"
+      - "install.ps1"
+      - "src/install-plan.mjs"
+      - "src/grok-apply-patch-guidance.mjs"
+      - "src/grok-oauth-forwarder.mjs"
+      - "src/grok-oauth-turn.mjs"
+      - "src/router.mjs"
+      - "scripts/verify-grok-apply-patch-guidance.mjs"
+      - ".github/workflows/grok-apply-patch-guidance.yml"
+  pull_request:
+    paths:
+      - "requirements/**"
+      - "bin/install"
+      - "install.ps1"
+      - "src/install-plan.mjs"
+      - "src/grok-apply-patch-guidance.mjs"
+      - "src/grok-oauth-forwarder.mjs"
+      - "src/grok-oauth-turn.mjs"
+      - "src/router.mjs"
+      - "scripts/verify-grok-apply-patch-guidance.mjs"
+      - ".github/workflows/grok-apply-patch-guidance.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: grok-apply-patch-guidance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  protocol:
+    name: ${{ matrix.os }} / python ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.12"]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python }}
+
+      - run: npm ci
+
+      - name: Install uv
+        shell: bash
+        run: python -m pip install uv
+
+      - name: Report the toolchain
+        shell: bash
+        run: |
+          python --version
+          node --version
+          uv --version
+          if [ "${{ runner.os }}" = macOS ]; then rustc --version || echo "rustc not on PATH"; fi
+
+      - name: Read the installer's own install command
+        id: installer
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = Windows ]; then platform=windows; else platform=posix; fi
+          install_command=$(node src/install-plan.mjs python-install-command uv "$platform")
+          echo "Extracted from the installer: $install_command"
+          echo "command=$install_command" >> "$GITHUB_OUTPUT"
+
+      - name: Create the environment the way the installer does
+        shell: bash
+        run: uv venv --python 3.12 .venv
+
+      - name: Install the lock (POSIX installer command)
+        if: runner.os != 'Windows'
+        shell: bash
+        env:
+          INSTALL_COMMAND: ${{ steps.installer.outputs.command }}
+        run: sh -c "$INSTALL_COMMAND"
+
+      - name: Install the lock (PowerShell installer command)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          INSTALL_COMMAND: ${{ steps.installer.outputs.command }}
+        run: |
+          $Python = Join-Path $PWD ".venv\Scripts\python.exe"
+          Invoke-Expression $env:INSTALL_COMMAND
+          if ($LASTEXITCODE -ne 0) { throw "The locked install failed with $LASTEXITCODE." }
+
+      - name: Verify Grok apply_patch guidance through Router, LiteLLM, and the Grok forwarder
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" = Windows ]; then
+            venv_python=.venv/Scripts/python.exe
+          else
+            venv_python=.venv/bin/python
+          fi
+          node scripts/verify-grok-apply-patch-guidance.mjs "$venv_python"

--- a/scripts/verify-grok-apply-patch-guidance.mjs
+++ b/scripts/verify-grok-apply-patch-guidance.mjs
@@ -36,6 +36,15 @@ const V4A_GRAMMAR = [
   "",
   "hunk: add_hunk | delete_hunk | update_hunk",
   'add_hunk: "*** Add File: " filename LF add_line+',
+  'delete_hunk: "*** Delete File: " filename LF',
+  'update_hunk: "*** Update File: " filename LF change_move? change?',
+  "filename: /(.+)/",
+  'add_line: "+" /(.+)/ LF -> line',
+  'change_move: "*** Move to: " filename LF',
+  "change: (change_context | change_line)+ eof_line?",
+  'change_context: ("@@" | "@@ " /(.+)/) LF',
+  'change_line: ("+" | "-" | " ") /(.+)/ LF',
+  'eof_line: "*** End of File" LF',
   "%import common.LF",
 ].join("\n");
 
@@ -94,7 +103,7 @@ function spawnChild(command, args, env, { detached = false } = {}) {
   });
   let output = "";
   const collect = (chunk) => {
-    output += redact(chunk.toString("utf8"));
+    output = (output + redact(chunk.toString("utf8"))).slice(-128 * 1024);
   };
   child.stdout.on("data", collect);
   child.stderr.on("data", collect);
@@ -136,7 +145,7 @@ async function waitHttp(url, child, { headers = {}, timeoutMs = SERVICE_HEALTH_M
       throw new Error(`exited before ${url}: ${child.testOutput()}`);
     }
     try {
-      const response = await fetch(url, { headers });
+      const response = await fetch(url, { headers, signal: AbortSignal.timeout(1_000) });
       if (response.ok) return;
     } catch {
       // not bound yet
@@ -218,11 +227,11 @@ function mockFunctionCall(callId, argumentsText) {
         name: APPLY_PATCH_TOOL_NAME,
       },
     },
-    {
+    ...[argumentsText.slice(0, 13), argumentsText.slice(13, 29), argumentsText.slice(29)].map((delta) => ({
       type: "response.function_call_arguments.delta",
       item_id: `fc_${callId}`,
-      delta: argumentsText,
-    },
+      delta,
+    })),
     {
       type: "response.output_item.done",
       item: {
@@ -256,140 +265,141 @@ const mockXai = http.createServer(async (request, response) => {
   response.end(mockFunctionCall(callId, outgoingArgs));
 });
 
-await new Promise((resolve, reject) => {
-  mockXai.once("error", reject);
-  mockXai.listen(0, "127.0.0.1", resolve);
-});
-const xaiPort = mockXai.address().port;
-
-const grokPort = await openPort();
-const gatewayPort = await openPort();
-const routerPort = await openPort();
-const pythonDir = path.dirname(python);
-const litellmBin = path.join(
-  pythonDir,
-  process.platform === "win32" ? "litellm.exe" : "litellm",
-);
-assert.ok(existsSync(python), `venv python missing: ${python}`);
-assert.ok(existsSync(litellmBin), `litellm entry point missing: ${litellmBin}`);
-
-const authPath = path.join(workspace, "auth.json");
-writeFileSync(
-  authPath,
-  JSON.stringify({ "https://auth.x.ai::test-client-id": { key: "fake-access" } }),
-  { mode: 0o600 },
-);
-const litellmConfig = path.join(workspace, "litellm.yaml");
-writeFileSync(
-  litellmConfig,
-  [
-    "model_list:",
-    '  - model_name: "grok-oauth-grok-4-6"',
-    "    litellm_params:",
-    '      model: "openai/grok-4.6"',
-    "      api_base: os.environ/GROK_OAUTH_FORWARD_BASE_URL",
-    '      api_key: "os.environ/CODEX_ROUTER_INTERNAL_KEY"',
-    "      use_chat_completions_api: true",
-    "      num_retries: 0",
-    "",
-    "litellm_settings:",
-    "  drop_params: true",
-    "  request_timeout: 60",
-    "",
-    "router_settings:",
-    "  disable_cooldowns: true",
-    "",
-    "general_settings:",
-    "  disable_spend_logs: true",
-    "",
-  ].join("\n"),
-  { mode: 0o600 },
-);
-
-const sharedEnv = {
-  MODEL_ROUTER_TARGET: "codex",
-  MODEL_ROUTER_QUIET: "1",
-  MODEL_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
-  CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
-  CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
-  CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY: "0",
-  LITELLM_MASTER_KEY: INTERNAL_KEY,
-  LITELLM_LOG: "ERROR",
-  LITELLM_TELEMETRY: "False",
-  LITELLM_LOCAL_MODEL_COST_MAP: "True",
-  NO_COLOR: "1",
-  PYTHONIOENCODING: "utf-8",
-  PYTHONUTF8: "1",
-  PATH: `${pythonDir}${path.delimiter}${process.env.PATH || ""}`,
-};
-
-const grokChild = spawnChild(
-  process.execPath,
-  [path.join(root, "src", "grok-oauth-forwarder.mjs")],
-  {
-    ...sharedEnv,
-    MODEL_ROUTER_GROK_OAUTH_PORT: String(grokPort),
-    GROK_CLI_CHAT_PROXY_BASE_URL: `http://127.0.0.1:${xaiPort}`,
-    GROK_CLI: path.join(root, "test", "fixtures", "missing-grok-cli"),
-    GROK_AUTH_PATH: authPath,
-  },
-);
-await waitHttp(`http://127.0.0.1:${grokPort}/health`, grokChild, {
-  headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
-});
-
-const litellmChild = spawnChild(
-  litellmBin,
-  ["--config", litellmConfig, "--host", "127.0.0.1", "--port", String(gatewayPort)],
-  {
-    ...sharedEnv,
-    GROK_OAUTH_FORWARD_BASE_URL: `http://127.0.0.1:${grokPort}/v1`,
-  },
-  { detached: process.platform !== "win32" },
-);
-await waitHttp(`http://127.0.0.1:${gatewayPort}/health/liveliness`, litellmChild, {
-  timeoutMs: LITELLM_HEALTH_MS,
-});
-
-const stateDir = path.join(workspace, "state");
-const codexHome = path.join(workspace, "codex-home");
-mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-mkdirSync(codexHome, { recursive: true, mode: 0o700 });
-writeFileSync(
-  path.join(stateDir, "enabled-providers.json"),
-  `${JSON.stringify({ version: 1, providers: ["grok-oauth"] }, null, 2)}\n`,
-  { mode: 0o600 },
-);
-const routerChild = spawnChild(process.execPath, [path.join(root, "src", "router.mjs")], {
-  ...sharedEnv,
-  MODEL_ROUTER_STATE_DIR: stateDir,
-  CODEX_ROUTER_STATE_DIR: stateDir,
-  CODEX_HOME: codexHome,
-  CODEX_ROUTER_PORT: String(routerPort),
-  CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
-  CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health/liveliness`,
-  CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${grokPort}/health`,
-  MODEL_ROUTER_GROK_OAUTH_PORT: String(grokPort),
-});
-await waitHttp(`http://127.0.0.1:${routerPort}/health`, routerChild);
-
-const routerUrl = `${callerBaseUrl(routerPort, CALLER_KEY)}/responses`;
-
-async function postTurn(payload) {
-  const response = await fetch(routerUrl, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${CALLER_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(payload),
-  });
-  const body = await response.text();
-  assert.equal(response.status, 200, redact(body));
-  return body;
-}
-
 try {
+  await new Promise((resolve, reject) => {
+    mockXai.once("error", reject);
+    mockXai.listen(0, "127.0.0.1", resolve);
+  });
+  const xaiPort = mockXai.address().port;
+
+  const grokPort = await openPort();
+  const gatewayPort = await openPort();
+  const routerPort = await openPort();
+  const pythonDir = path.dirname(python);
+  const litellmBin = path.join(
+    pythonDir,
+    process.platform === "win32" ? "litellm.exe" : "litellm",
+  );
+  assert.ok(existsSync(python), `venv python missing: ${python}`);
+  assert.ok(existsSync(litellmBin), `litellm entry point missing: ${litellmBin}`);
+
+  const authPath = path.join(workspace, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({ "https://auth.x.ai::test-client-id": { key: "fake-access" } }),
+    { mode: 0o600 },
+  );
+  const litellmConfig = path.join(workspace, "litellm.yaml");
+  writeFileSync(
+    litellmConfig,
+    [
+      "model_list:",
+      '  - model_name: "grok-oauth-grok-4-6"',
+      "    litellm_params:",
+      '      model: "openai/grok-4.6"',
+      "      api_base: os.environ/GROK_OAUTH_FORWARD_BASE_URL",
+      '      api_key: "os.environ/CODEX_ROUTER_INTERNAL_KEY"',
+      "      use_chat_completions_api: true",
+      "      num_retries: 0",
+      "",
+      "litellm_settings:",
+      "  drop_params: true",
+      "  request_timeout: 60",
+      "",
+      "router_settings:",
+      "  disable_cooldowns: true",
+      "",
+      "general_settings:",
+      "  disable_spend_logs: true",
+      "",
+    ].join("\n"),
+    { mode: 0o600 },
+  );
+
+  const sharedEnv = {
+    MODEL_ROUTER_TARGET: "codex",
+    MODEL_ROUTER_QUIET: "1",
+    MODEL_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+    CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+    CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
+    CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY: "0",
+    LITELLM_MASTER_KEY: INTERNAL_KEY,
+    LITELLM_LOG: "ERROR",
+    LITELLM_TELEMETRY: "False",
+    LITELLM_LOCAL_MODEL_COST_MAP: "True",
+    NO_COLOR: "1",
+    PYTHONIOENCODING: "utf-8",
+    PYTHONUTF8: "1",
+    PATH: `${pythonDir}${path.delimiter}${process.env.PATH || ""}`,
+  };
+
+  const grokChild = spawnChild(
+    process.execPath,
+    [path.join(root, "src", "grok-oauth-forwarder.mjs")],
+    {
+      ...sharedEnv,
+      MODEL_ROUTER_GROK_OAUTH_PORT: String(grokPort),
+      GROK_CLI_CHAT_PROXY_BASE_URL: `http://127.0.0.1:${xaiPort}`,
+      GROK_CLI: path.join(root, "test", "fixtures", "missing-grok-cli"),
+      GROK_AUTH_PATH: authPath,
+    },
+  );
+  await waitHttp(`http://127.0.0.1:${grokPort}/health`, grokChild, {
+    headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
+  });
+
+  const litellmChild = spawnChild(
+    litellmBin,
+    ["--config", litellmConfig, "--host", "127.0.0.1", "--port", String(gatewayPort)],
+    {
+      ...sharedEnv,
+      GROK_OAUTH_FORWARD_BASE_URL: `http://127.0.0.1:${grokPort}/v1`,
+    },
+    { detached: process.platform !== "win32" },
+  );
+  await waitHttp(`http://127.0.0.1:${gatewayPort}/health/liveliness`, litellmChild, {
+    timeoutMs: LITELLM_HEALTH_MS,
+  });
+
+  const stateDir = path.join(workspace, "state");
+  const codexHome = path.join(workspace, "codex-home");
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  mkdirSync(codexHome, { recursive: true, mode: 0o700 });
+  writeFileSync(
+    path.join(stateDir, "enabled-providers.json"),
+    `${JSON.stringify({ version: 1, providers: ["grok-oauth"] }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  const routerChild = spawnChild(process.execPath, [path.join(root, "src", "router.mjs")], {
+    ...sharedEnv,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_HOME: codexHome,
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
+    CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health/liveliness`,
+    CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${grokPort}/health`,
+    MODEL_ROUTER_GROK_OAUTH_PORT: String(grokPort),
+  });
+  await waitHttp(`http://127.0.0.1:${routerPort}/health`, routerChild);
+
+  const routerUrl = `${callerBaseUrl(routerPort, CALLER_KEY)}/responses`;
+
+  async function postTurn(payload) {
+    const response = await fetch(routerUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${CALLER_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(90_000),
+    });
+    const body = await response.text();
+    assert.equal(response.status, 200, redact(body));
+    return body;
+  }
+
   const unicodeBody = await postTurn(
     applyPatchRequest({ historyInput: HISTORY_PATCH, historyId: "ctc_history" }),
   );
@@ -437,7 +447,8 @@ try {
   assert.equal(malformedItem.input, MALFORMED_PATCH);
 } finally {
   await Promise.all(children.map((child) => stopChild(child)));
-  await new Promise((resolve) => mockXai.close(resolve));
+  mockXai.closeAllConnections();
+  if (mockXai.listening) await new Promise((resolve) => mockXai.close(resolve));
   rmSync(workspace, { recursive: true, force: true });
 }
 

--- a/scripts/verify-grok-apply-patch-guidance.mjs
+++ b/scripts/verify-grok-apply-patch-guidance.mjs
@@ -1,0 +1,444 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { callerBaseUrl } from "../src/caller-auth.mjs";
+import {
+  APPLY_PATCH_TOOL_NAME,
+  GROK_APPLY_PATCH_CREATE_EXAMPLE,
+  GROK_APPLY_PATCH_GUIDANCE_MARKER,
+  GROK_APPLY_PATCH_UPDATE_EXAMPLE,
+} from "../src/grok-apply-patch-guidance.mjs";
+import { spawnableCommand } from "../src/spawnable-command.mjs";
+
+const python = process.argv[2] || process.env.LITELLM_PYTHON;
+if (!python) {
+  throw new Error(
+    "usage: node scripts/verify-grok-apply-patch-guidance.mjs <venv-python>",
+  );
+}
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
+const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
+const LITELLM_HEALTH_MS = 300_000;
+const SERVICE_HEALTH_MS = 15_000;
+
+const V4A_GRAMMAR = [
+  "start: begin_patch hunk+ end_patch",
+  'begin_patch: "*** Begin Patch" LF',
+  'end_patch: "*** End Patch" LF?',
+  "",
+  "hunk: add_hunk | delete_hunk | update_hunk",
+  'add_hunk: "*** Add File: " filename LF add_line+',
+  "%import common.LF",
+].join("\n");
+
+const HISTORY_PATCH = [
+  "*** Begin Patch",
+  "*** Add File: seed.txt",
+  "+before",
+  "*** End Patch",
+].join("\n");
+
+const UNICODE_PATCH = [
+  "*** Begin Patch",
+  '*** Add File: café "quotes".txt',
+  "+hello “unicode”",
+  "*** End Patch",
+].join("\n");
+
+const MALFORMED_PATCH = "*** Begin Patch\nnot-a-json-object";
+
+const children = [];
+const workspace = mkdtempSync(path.join(os.tmpdir(), "grok-apply-patch-guidance-"));
+const capturedGrok = [];
+
+function redact(text) {
+  return String(text || "")
+    .replaceAll(CALLER_KEY, "[caller-key]")
+    .replaceAll(INTERNAL_KEY, "[internal-key]")
+    .replaceAll("fake-access", "[session-key]");
+}
+
+function sse(events) {
+  return `${events
+    .map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("")}data: [DONE]\n\n`;
+}
+
+async function openPort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+function spawnChild(command, args, env, { detached = false } = {}) {
+  const spawnable = spawnableCommand(command, args);
+  const child = spawn(spawnable.command, spawnable.args, {
+    cwd: root,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+    detached,
+    ...spawnable.options,
+  });
+  let output = "";
+  const collect = (chunk) => {
+    output += redact(chunk.toString("utf8"));
+  };
+  child.stdout.on("data", collect);
+  child.stderr.on("data", collect);
+  child.testOutput = () => output;
+  children.push(child);
+  return child;
+}
+
+function stopChild(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const done = () => resolve();
+    child.once("exit", done);
+    if (process.platform === "win32") {
+      spawn("taskkill", ["/T", "/F", "/PID", String(child.pid)], { stdio: "ignore" });
+    } else if (child.pid) {
+      try {
+        process.kill(-child.pid, "SIGTERM");
+      } catch {
+        child.kill("SIGTERM");
+      }
+    }
+    setTimeout(() => {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // already gone
+      }
+    }, 5_000).unref();
+  });
+}
+
+async function waitHttp(url, child, { headers = {}, timeoutMs = SERVICE_HEALTH_MS } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (child && (child.exitCode !== null || child.signalCode !== null)) {
+      throw new Error(`exited before ${url}: ${child.testOutput()}`);
+    }
+    try {
+      const response = await fetch(url, { headers });
+      if (response.ok) return;
+    } catch {
+      // not bound yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`timeout waiting for ${url}: ${child?.testOutput?.() || ""}`);
+}
+
+function itemsByCallId(sseBody) {
+  const byCallId = new Map();
+  for (const line of sseBody.split(/\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const data = line.slice(5).trim();
+    if (!data || data === "[DONE]") continue;
+    let event;
+    try {
+      event = JSON.parse(data);
+    } catch {
+      continue;
+    }
+    const item = event.item;
+    if (item?.call_id) byCallId.set(item.call_id, item);
+  }
+  return byCallId;
+}
+
+function larkFence(description) {
+  const match = String(description || "").match(/Format:\n```lark\n([\s\S]*?)\n```/);
+  return match ? match[1] : undefined;
+}
+
+function applyPatchRequest({ historyInput, historyId }) {
+  return {
+    model: "grok-oauth/grok-4.6",
+    stream: true,
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "patch notes" }] },
+      {
+        type: "custom_tool_call",
+        id: historyId,
+        call_id: "call_history",
+        name: APPLY_PATCH_TOOL_NAME,
+        input: historyInput,
+      },
+      { type: "custom_tool_call_output", call_id: "call_history", output: "Done!" },
+    ],
+    tools: [
+      {
+        type: "custom",
+        name: APPLY_PATCH_TOOL_NAME,
+        description: "Apply a patch.",
+        format: { type: "grammar", syntax: "lark", definition: V4A_GRAMMAR },
+      },
+      {
+        type: "function",
+        name: APPLY_PATCH_TOOL_NAME,
+        description: "ordinary same-name function",
+        parameters: { type: "object", properties: { path: { type: "string" } } },
+      },
+      {
+        type: "function",
+        name: "read_file",
+        description: "unrelated ordinary function",
+        parameters: { type: "object", properties: { path: { type: "string" } } },
+      },
+    ],
+  };
+}
+
+function mockFunctionCall(callId, argumentsText) {
+  return sse([
+    {
+      type: "response.output_item.added",
+      item: {
+        type: "function_call",
+        id: `fc_${callId}`,
+        call_id: callId,
+        name: APPLY_PATCH_TOOL_NAME,
+      },
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: `fc_${callId}`,
+      delta: argumentsText,
+    },
+    {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: `fc_${callId}`,
+        call_id: callId,
+        name: APPLY_PATCH_TOOL_NAME,
+        arguments: argumentsText,
+      },
+    },
+    { type: "response.completed", response: { usage: { input_tokens: 12, output_tokens: 9 } } },
+  ]);
+}
+
+const mockXai = http.createServer(async (request, response) => {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  capturedGrok.push({
+    authorizationPresent: Boolean(request.headers.authorization),
+    body,
+  });
+  const history = (body.input || []).find(
+    (item) => item?.type === "function_call" && item.name === APPLY_PATCH_TOOL_NAME,
+  );
+  const historyArgs = typeof history?.arguments === "string" ? history.arguments : "";
+  const malformed = historyArgs.includes("not-a-json-object");
+  const outgoingArgs = malformed ? historyArgs : JSON.stringify({ content: UNICODE_PATCH });
+  const callId = malformed ? "call_malformed" : "call_unicode";
+  response.writeHead(200, { "Content-Type": "text/event-stream" });
+  response.end(mockFunctionCall(callId, outgoingArgs));
+});
+
+await new Promise((resolve, reject) => {
+  mockXai.once("error", reject);
+  mockXai.listen(0, "127.0.0.1", resolve);
+});
+const xaiPort = mockXai.address().port;
+
+const grokPort = await openPort();
+const gatewayPort = await openPort();
+const routerPort = await openPort();
+const pythonDir = path.dirname(python);
+const litellmBin = path.join(
+  pythonDir,
+  process.platform === "win32" ? "litellm.exe" : "litellm",
+);
+assert.ok(existsSync(python), `venv python missing: ${python}`);
+assert.ok(existsSync(litellmBin), `litellm entry point missing: ${litellmBin}`);
+
+const authPath = path.join(workspace, "auth.json");
+writeFileSync(
+  authPath,
+  JSON.stringify({ "https://auth.x.ai::test-client-id": { key: "fake-access" } }),
+  { mode: 0o600 },
+);
+const litellmConfig = path.join(workspace, "litellm.yaml");
+writeFileSync(
+  litellmConfig,
+  [
+    "model_list:",
+    '  - model_name: "grok-oauth-grok-4-6"',
+    "    litellm_params:",
+    '      model: "openai/grok-4.6"',
+    "      api_base: os.environ/GROK_OAUTH_FORWARD_BASE_URL",
+    '      api_key: "os.environ/CODEX_ROUTER_INTERNAL_KEY"',
+    "      use_chat_completions_api: true",
+    "      num_retries: 0",
+    "",
+    "litellm_settings:",
+    "  drop_params: true",
+    "  request_timeout: 60",
+    "",
+    "router_settings:",
+    "  disable_cooldowns: true",
+    "",
+    "general_settings:",
+    "  disable_spend_logs: true",
+    "",
+  ].join("\n"),
+  { mode: 0o600 },
+);
+
+const sharedEnv = {
+  MODEL_ROUTER_TARGET: "codex",
+  MODEL_ROUTER_QUIET: "1",
+  MODEL_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+  CODEX_ROUTER_INTERNAL_KEY: INTERNAL_KEY,
+  CODEX_ROUTER_CALLER_KEY: CALLER_KEY,
+  CODEX_ROUTER_GROK_PROGRESS_ONLY_RETRY: "0",
+  LITELLM_MASTER_KEY: INTERNAL_KEY,
+  LITELLM_LOG: "ERROR",
+  LITELLM_TELEMETRY: "False",
+  LITELLM_LOCAL_MODEL_COST_MAP: "True",
+  NO_COLOR: "1",
+  PYTHONIOENCODING: "utf-8",
+  PYTHONUTF8: "1",
+  PATH: `${pythonDir}${path.delimiter}${process.env.PATH || ""}`,
+};
+
+const grokChild = spawnChild(
+  process.execPath,
+  [path.join(root, "src", "grok-oauth-forwarder.mjs")],
+  {
+    ...sharedEnv,
+    MODEL_ROUTER_GROK_OAUTH_PORT: String(grokPort),
+    GROK_CLI_CHAT_PROXY_BASE_URL: `http://127.0.0.1:${xaiPort}`,
+    GROK_CLI: path.join(root, "test", "fixtures", "missing-grok-cli"),
+    GROK_AUTH_PATH: authPath,
+  },
+);
+await waitHttp(`http://127.0.0.1:${grokPort}/health`, grokChild, {
+  headers: { Authorization: `Bearer ${INTERNAL_KEY}` },
+});
+
+const litellmChild = spawnChild(
+  litellmBin,
+  ["--config", litellmConfig, "--host", "127.0.0.1", "--port", String(gatewayPort)],
+  {
+    ...sharedEnv,
+    GROK_OAUTH_FORWARD_BASE_URL: `http://127.0.0.1:${grokPort}/v1`,
+  },
+  { detached: process.platform !== "win32" },
+);
+await waitHttp(`http://127.0.0.1:${gatewayPort}/health/liveliness`, litellmChild, {
+  timeoutMs: LITELLM_HEALTH_MS,
+});
+
+const stateDir = path.join(workspace, "state");
+const codexHome = path.join(workspace, "codex-home");
+mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+mkdirSync(codexHome, { recursive: true, mode: 0o700 });
+writeFileSync(
+  path.join(stateDir, "enabled-providers.json"),
+  `${JSON.stringify({ version: 1, providers: ["grok-oauth"] }, null, 2)}\n`,
+  { mode: 0o600 },
+);
+const routerChild = spawnChild(process.execPath, [path.join(root, "src", "router.mjs")], {
+  ...sharedEnv,
+  MODEL_ROUTER_STATE_DIR: stateDir,
+  CODEX_ROUTER_STATE_DIR: stateDir,
+  CODEX_HOME: codexHome,
+  CODEX_ROUTER_PORT: String(routerPort),
+  CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gatewayPort}/v1`,
+  CODEX_ROUTER_GATEWAY_HEALTH_URL: `http://127.0.0.1:${gatewayPort}/health/liveliness`,
+  CODEX_ROUTER_GROK_OAUTH_HEALTH_URL: `http://127.0.0.1:${grokPort}/health`,
+  MODEL_ROUTER_GROK_OAUTH_PORT: String(grokPort),
+});
+await waitHttp(`http://127.0.0.1:${routerPort}/health`, routerChild);
+
+const routerUrl = `${callerBaseUrl(routerPort, CALLER_KEY)}/responses`;
+
+async function postTurn(payload) {
+  const response = await fetch(routerUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${CALLER_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  const body = await response.text();
+  assert.equal(response.status, 200, redact(body));
+  return body;
+}
+
+try {
+  const unicodeBody = await postTurn(
+    applyPatchRequest({ historyInput: HISTORY_PATCH, historyId: "ctc_history" }),
+  );
+  assert.equal(capturedGrok.length, 1);
+  const grokRequest = capturedGrok[0].body;
+  const grokTools = grokRequest.tools || [];
+  const grokApply = grokTools.filter((tool) => tool.type === "function" && tool.name === APPLY_PATCH_TOOL_NAME);
+  assert.equal(grokApply.length, 1);
+  assert.equal(grokApply[0].description.includes("Apply a patch."), true);
+  assert.equal(grokApply[0].description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), true);
+  assert.equal(grokApply[0].description.includes(GROK_APPLY_PATCH_CREATE_EXAMPLE), true);
+  assert.equal(grokApply[0].description.includes(GROK_APPLY_PATCH_UPDATE_EXAMPLE), true);
+  assert.equal(larkFence(grokApply[0].description), V4A_GRAMMAR);
+  assert.deepEqual(grokApply[0].parameters?.required, ["content"]);
+  assert.equal(grokApply[0].parameters?.properties?.path, undefined);
+  const readFile = grokTools.find((tool) => tool.type === "function" && tool.name === "read_file");
+  assert.equal(readFile?.description, "unrelated ordinary function");
+  assert.equal(String(readFile?.description || "").includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), false);
+
+  const historyCall = (grokRequest.input || []).find(
+    (item) => item?.type === "function_call" && item.call_id === "call_history",
+  );
+  assert.ok(historyCall, "history call_id must survive LiteLLM and the Grok forwarder");
+  assert.equal(historyCall.name, APPLY_PATCH_TOOL_NAME);
+  assert.deepEqual(JSON.parse(historyCall.arguments), { content: HISTORY_PATCH });
+  const historyResult = (grokRequest.input || []).find(
+    (item) => item?.type === "function_call_output" && item.call_id === "call_history",
+  );
+  assert.equal(historyResult?.output, "Done!");
+
+  const unicodeItem = itemsByCallId(unicodeBody).get("call_unicode");
+  assert.equal(unicodeItem?.type, "custom_tool_call");
+  assert.equal(unicodeItem.input, UNICODE_PATCH);
+
+  const malformedBody = await postTurn(
+    applyPatchRequest({ historyInput: MALFORMED_PATCH, historyId: "ctc_malformed" }),
+  );
+  assert.equal(capturedGrok.length, 2);
+  const malformedHistory = (capturedGrok[1].body.input || []).find(
+    (item) => item?.type === "function_call" && item.call_id === "call_history",
+  );
+  assert.deepEqual(JSON.parse(malformedHistory.arguments), { content: MALFORMED_PATCH });
+  const malformedItem = itemsByCallId(malformedBody).get("call_malformed");
+  assert.equal(malformedItem?.type, "custom_tool_call");
+  assert.equal(malformedItem.input, MALFORMED_PATCH);
+} finally {
+  await Promise.all(children.map((child) => stopChild(child)));
+  await new Promise((resolve) => mockXai.close(resolve));
+  rmSync(workspace, { recursive: true, force: true });
+}
+
+process.stdout.write("ok grok apply_patch guidance through Router, LiteLLM, Grok forwarder, and mock xAI\n");

--- a/src/grok-apply-patch-guidance.mjs
+++ b/src/grok-apply-patch-guidance.mjs
@@ -41,7 +41,7 @@ function isNativeCustomApplyPatch(tool) {
 }
 
 function alreadyGuided(value) {
-  return typeof value === "string" && value.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER);
+  return typeof value === "string" && value.includes(GROK_APPLY_PATCH_GUIDANCE);
 }
 
 function appendGuidance(prefix) {

--- a/src/grok-apply-patch-guidance.mjs
+++ b/src/grok-apply-patch-guidance.mjs
@@ -1,0 +1,71 @@
+// grok-oauth/grok-4.6 receives two small V4A examples on the native custom
+// apply_patch description before LiteLLM translates that tool into a function.
+// LiteLLM 1.96 already copies format.definition into the bridged function
+// description (wrapped in a Format fence); this module does not compensate for
+// a lost grammar and must not rewrite format or format.definition.
+
+export const GROK_APPLY_PATCH_GUIDANCE_ROUTE = "grok-oauth/grok-4.6";
+export const APPLY_PATCH_TOOL_NAME = "apply_patch";
+
+export const GROK_APPLY_PATCH_CREATE_EXAMPLE = [
+  "*** Begin Patch",
+  "*** Add File: notes.txt",
+  "+hello",
+  "*** End Patch",
+].join("\n");
+
+export const GROK_APPLY_PATCH_UPDATE_EXAMPLE = [
+  "*** Begin Patch",
+  "*** Update File: notes.txt",
+  "@@",
+  "-hello",
+  "+hello world",
+  "*** End Patch",
+].join("\n");
+
+export const GROK_APPLY_PATCH_GUIDANCE_MARKER =
+  "Do not wrap the payload in markdown fences";
+
+export const GROK_APPLY_PATCH_GUIDANCE = [
+  "The apply_patch input is raw V4A text. Use these exact delimiters. Do not wrap the payload in markdown fences or any other wrapper:",
+  GROK_APPLY_PATCH_CREATE_EXAMPLE,
+  GROK_APPLY_PATCH_UPDATE_EXAMPLE,
+].join("\n\n");
+
+export function shouldGuideGrokApplyPatch(route) {
+  return route?.slug === GROK_APPLY_PATCH_GUIDANCE_ROUTE;
+}
+
+function isNativeCustomApplyPatch(tool) {
+  return tool?.type === "custom" && tool.name === APPLY_PATCH_TOOL_NAME;
+}
+
+function alreadyGuided(value) {
+  return typeof value === "string" && value.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER);
+}
+
+function appendGuidance(prefix) {
+  if (typeof prefix !== "string" || prefix.length === 0) return GROK_APPLY_PATCH_GUIDANCE;
+  if (alreadyGuided(prefix)) return prefix;
+  return prefix.endsWith("\n")
+    ? `${prefix}\n${GROK_APPLY_PATCH_GUIDANCE}`
+    : `${prefix}\n\n${GROK_APPLY_PATCH_GUIDANCE}`;
+}
+
+function annotateNativeApplyPatch(tool) {
+  const originalDescription = typeof tool.description === "string" ? tool.description : "";
+  if (alreadyGuided(originalDescription)) return tool;
+  return { ...tool, description: appendGuidance(originalDescription) };
+}
+
+export function applyGrokApplyPatchGuidance(tools, route) {
+  if (!shouldGuideGrokApplyPatch(route) || !Array.isArray(tools)) return tools;
+  let changed = false;
+  const next = tools.map((tool) => {
+    if (!isNativeCustomApplyPatch(tool)) return tool;
+    const annotated = annotateNativeApplyPatch(tool);
+    if (annotated !== tool) changed = true;
+    return annotated;
+  });
+  return changed ? next : tools;
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -105,6 +105,7 @@ import {
   tokenUsageFromPayload,
 } from "./response-usage.mjs";
 import { fetchWithRetry } from "./upstream-retry.mjs";
+import { applyGrokApplyPatchGuidance } from "./grok-apply-patch-guidance.mjs";
 import {
   NamespaceToolCallTransform,
   agentMessagesAsUserMessages,
@@ -3239,6 +3240,9 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   if (consoleGoResponsesCompatibility) {
     routedToolChoice = flattenToolChoice(routedToolChoice, flattenedNamespaces);
   }
+  // Append V4A examples to the native custom apply_patch description for
+  // grok-oauth/grok-4.6 only, before LiteLLM translates that custom tool.
+  tools = applyGrokApplyPatchGuidance(tools, route);
   const routed = {
     ...payload,
     tools,

--- a/test/grok-apply-patch-guidance-ci.test.mjs
+++ b/test/grok-apply-patch-guidance-ci.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { INSTALLER_SCRIPTS, PYTHON_LOCK, pythonInstallCommand } from "../src/install-plan.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const WORKFLOW = ".github/workflows/grok-apply-patch-guidance.yml";
+const VERIFY = "scripts/verify-grok-apply-patch-guidance.mjs";
+
+function repoFile(relative) {
+  return path.join(root, ...relative.split("/"));
+}
+
+test("ordinary Node grok tests do not import a home LiteLLM python", () => {
+  for (const relative of [
+    "test/grok-oauth-forwarder.test.mjs",
+    "test/namespace-relay.test.mjs",
+    "test/namespace-relay-routing.test.mjs",
+  ]) {
+    const source = readFileSync(repoFile(relative), "utf8");
+    assert.doesNotMatch(source, /\.local\/share\/codex-router/);
+    assert.doesNotMatch(source, /homedir\(\)[\s\S]{0,80}codex-router/);
+    assert.doesNotMatch(source, /convert_custom_tool_to_function_tool/);
+  }
+});
+
+test("the Grok protocol workflow installs the lock with the installer command", () => {
+  const workflow = readFileSync(repoFile(WORKFLOW), "utf8");
+  assert.match(workflow, /install-plan\.mjs python-install-command/);
+  const handWritten = workflow
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("#"))
+    .filter((line) => /(uv\s+pip|-m\s+pip)\s+install\s/.test(line))
+    .filter((line) => line.includes(PYTHON_LOCK));
+  assert.deepEqual(handWritten, [], "the workflow must not spell the install command itself");
+  assert.match(workflow, /node-version: "24"/);
+  assert.match(workflow, /python: \["3\.12"\]/);
+  for (const os of ["ubuntu-latest", "macos-latest", "windows-latest"]) {
+    assert.ok(workflow.includes(os), `${WORKFLOW} must run on ${os}`);
+  }
+});
+
+test("the Grok protocol workflow is gated on the guidance path and never skips LiteLLM", () => {
+  const workflow = readFileSync(repoFile(WORKFLOW), "utf8");
+  for (const input of [
+    "requirements/**",
+    ...Object.values(INSTALLER_SCRIPTS),
+    "src/install-plan.mjs",
+    "src/grok-apply-patch-guidance.mjs",
+    "src/grok-oauth-forwarder.mjs",
+    "src/router.mjs",
+    VERIFY,
+    WORKFLOW,
+  ]) {
+    assert.ok(workflow.includes(`"${input}"`), `${WORKFLOW} does not run when ${input} changes`);
+  }
+  assert.match(
+    workflow,
+    /node scripts\/verify-grok-apply-patch-guidance\.mjs "\$venv_python"/,
+    "the installed LiteLLM path must be exercised after the lock is installed",
+  );
+  const verifyStep = workflow.split("Verify Grok apply_patch guidance")[1] || "";
+  assert.match(verifyStep, /node scripts\/verify-grok-apply-patch-guidance\.mjs "\$venv_python"/);
+  assert.doesNotMatch(verifyStep, /continue-on-error:\s*true/);
+  assert.doesNotMatch(verifyStep, /skip/i);
+});
+
+test("the Grok protocol verifier requires an explicit python and does not skip", () => {
+  const source = readFileSync(repoFile(VERIFY), "utf8");
+  assert.match(source, /usage: node scripts\/verify-grok-apply-patch-guidance\.mjs <venv-python>/);
+  assert.doesNotMatch(source, /\.local\/share\/codex-router/);
+  assert.doesNotMatch(source, /process\.exit\(0\).*skip/);
+  pythonInstallCommand("uv", { platform: "posix" });
+});

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { spawn, spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import http from "node:http";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -1959,49 +1959,35 @@ const V4A_GRAMMAR = [
   "%import common.LF",
 ].join("\n");
 
-const INSTALLED_LITELLM_PYTHON = path.join(
-  os.homedir(),
-  ".local/share/codex-router/.venv/bin/python",
-);
-
-function installedLiteLlmPython() {
-  const candidates = [
-    INSTALLED_LITELLM_PYTHON,
-    path.join(root, ".venv", "bin", "python"),
-    path.join(root, ".venv", "Scripts", "python.exe"),
-  ];
-  return candidates.find((candidate) => existsSync(candidate));
+// Hand-built LiteLLM 1.96 custom-tool function shape. Live conversion through
+// the installed proxy is scripts/verify-grok-apply-patch-guidance.mjs.
+function litellmCustomToolFunctionShape(tool) {
+  const syntax = typeof tool.format?.syntax === "string" && tool.format.syntax ? tool.format.syntax : "lark";
+  const definition = typeof tool.format?.definition === "string" ? tool.format.definition : "";
+  const description = `${tool.description || ""}\n\nFormat:\n\`\`\`${syntax}\n${definition}\n\`\`\``;
+  return {
+    type: "function",
+    function: {
+      name: tool.name,
+      description,
+      parameters: {
+        type: "object",
+        properties: {
+          content: {
+            type: "string",
+            description: `The ${tool.name} content following the specified format`,
+          },
+        },
+        required: ["content"],
+      },
+    },
+  };
 }
 
-function convertCustomToolThroughInstalledLiteLlm(tool) {
-  const python = installedLiteLlmPython();
-  assert.ok(python, `installed LiteLLM python is required at ${INSTALLED_LITELLM_PYTHON}`);
-  const script = [
-    "import json, sys",
-    "from litellm.responses.litellm_completion_transformation.custom_tools import convert_custom_tool_to_function_tool",
-    "tool = json.load(sys.stdin)",
-    "converted = convert_custom_tool_to_function_tool(tool)",
-    "if hasattr(converted, 'model_dump'):",
-    "    converted = converted.model_dump(mode='json')",
-    "json.dump(converted, sys.stdout)",
-  ].join("\n");
-  const result = spawnSync(python, ["-c", script], {
-    input: JSON.stringify(tool),
-    encoding: "utf8",
-    timeout: 20_000,
-  });
-  assert.equal(result.status, 0, result.stderr || result.error?.message || "LiteLLM convert failed");
-  return JSON.parse(result.stdout);
-}
-
-function chatToolFromLiteLlm(converted) {
-  if (converted?.type === "function" && converted.function) return converted;
-  return { type: "function", function: converted };
-}
-
-test("Grok 4.6 apply_patch guidance survives Router-shaped LiteLLM translation and the forwarder", () => {
+test("Grok 4.6 apply_patch guidance reaches the forwarder in LiteLLM's custom-tool function shape", () => {
   const originalDescription = "Apply a patch.";
   const originalFormat = { type: "grammar", syntax: "lark", definition: V4A_GRAMMAR };
+  const ordinary = { type: "function", name: APPLY_PATCH_TOOL_NAME, parameters: { type: "object" } };
   const native = applyGrokApplyPatchGuidance(
     [
       {
@@ -2010,7 +1996,7 @@ test("Grok 4.6 apply_patch guidance survives Router-shaped LiteLLM translation a
         description: originalDescription,
         format: originalFormat,
       },
-      { type: "function", name: APPLY_PATCH_TOOL_NAME, parameters: { type: "object" } },
+      ordinary,
     ],
     { slug: GROK_APPLY_PATCH_GUIDANCE_ROUTE },
   )[0];
@@ -2021,30 +2007,36 @@ test("Grok 4.6 apply_patch guidance survives Router-shaped LiteLLM translation a
     syntax: "lark",
     definition: V4A_GRAMMAR,
   });
+  assert.equal(native.description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), true);
+  assert.equal(native.description.includes(GROK_APPLY_PATCH_CREATE_EXAMPLE), true);
+  assert.equal(native.description.includes(GROK_APPLY_PATCH_UPDATE_EXAMPLE), true);
 
-  const converted = convertCustomToolThroughInstalledLiteLlm(native);
-  const chatTool = chatToolFromLiteLlm(converted);
-  assert.equal(chatTool.type, "function");
-  assert.equal(chatTool.function.name, APPLY_PATCH_TOOL_NAME);
-  const description = chatTool.function.description;
-  assert.match(description, new RegExp(originalDescription));
-  assert.ok(description.includes(V4A_GRAMMAR), "installed LiteLLM retains the original lark grammar");
-  assert.ok(description.includes(GROK_APPLY_PATCH_CREATE_EXAMPLE));
-  assert.ok(description.includes(GROK_APPLY_PATCH_UPDATE_EXAMPLE));
-  assert.equal(description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), true);
+  const chatTool = litellmCustomToolFunctionShape(native);
+  const formatFence = chatTool.function.description.match(/Format:\n```lark\n([\s\S]*)\n```$/);
+  assert.ok(formatFence, "LiteLLM-shaped description keeps grammar in a Format fence");
+  assert.equal(formatFence[1], V4A_GRAMMAR);
+  const beforeFormat = chatTool.function.description.slice(
+    0,
+    chatTool.function.description.indexOf("\n\nFormat:"),
+  );
+  assert.equal(beforeFormat.includes(originalDescription), true);
+  assert.equal(beforeFormat.includes(GROK_APPLY_PATCH_CREATE_EXAMPLE), true);
   assert.deepEqual(chatTool.function.parameters.required, ["content"]);
-  assert.equal(chatTool.function.parameters.properties.content.type, "string");
 
   const forwarded = toResponsesRequest({
     model: "grok-4.6",
     messages: [{ role: "user", content: "patch notes.txt" }],
-    tools: [chatTool],
+    tools: [chatTool, { type: "function", function: { name: APPLY_PATCH_TOOL_NAME, description: "ordinary same-name function", parameters: ordinary.parameters } }],
   });
   const applyPatch = forwarded.tools.find((tool) => tool.type === "function" && tool.name === APPLY_PATCH_TOOL_NAME);
   assert.ok(applyPatch);
-  assert.equal(applyPatch.description, description);
-  assert.ok(applyPatch.description.includes(V4A_GRAMMAR));
+  assert.equal(applyPatch.description, chatTool.function.description);
   assert.deepEqual(applyPatch.parameters.required, ["content"]);
+  assert.equal(
+    forwarded.tools.filter((tool) => tool.type === "function" && tool.name === APPLY_PATCH_TOOL_NAME).length,
+    1,
+    "the Grok forwarder keeps one apply_patch definition and does not merge guidance onto a same-named ordinary function",
+  );
 });
 
 test("Grok forwarder keeps apply_patch call ids and streamed unicode quotes newlines verbatim", async () => {

--- a/test/grok-oauth-forwarder.test.mjs
+++ b/test/grok-oauth-forwarder.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import http from "node:http";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -13,6 +13,14 @@ import {
   mergeHostedSearchTools,
   toResponsesRequest,
 } from "../src/grok-oauth-forwarder.mjs";
+import {
+  APPLY_PATCH_TOOL_NAME,
+  GROK_APPLY_PATCH_CREATE_EXAMPLE,
+  GROK_APPLY_PATCH_GUIDANCE_MARKER,
+  GROK_APPLY_PATCH_GUIDANCE_ROUTE,
+  GROK_APPLY_PATCH_UPDATE_EXAMPLE,
+  applyGrokApplyPatchGuidance,
+} from "../src/grok-apply-patch-guidance.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const INTERNAL_KEY = "test-grok-internal-service-key-with-sufficient-length";
@@ -1928,4 +1936,287 @@ test("keeps the first streamed answer when the retry also has no tools", async (
     await new Promise((r) => backend.server.close(r));
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+const V4A_GRAMMAR = [
+  "start: begin_patch hunk+ end_patch",
+  'begin_patch: "*** Begin Patch" LF',
+  'end_patch: "*** End Patch" LF?',
+  "",
+  "hunk: add_hunk | delete_hunk | update_hunk",
+  'add_hunk: "*** Add File: " filename LF add_line+',
+  'delete_hunk: "*** Delete File: " filename LF',
+  'update_hunk: "*** Update File: " filename LF change_move? change?',
+  "filename: /(.+)/",
+  'add_line: "+" /(.+)/ LF -> line',
+  "",
+  'change_move: "*** Move to: " filename LF',
+  "change: (change_context | change_line)+ eof_line?",
+  'change_context: ("@@" | "@@ " /(.+)/) LF',
+  'change_line: ("+" | "-" | " ") /(.+)/ LF',
+  'eof_line: "*** End of File" LF',
+  "",
+  "%import common.LF",
+].join("\n");
+
+const INSTALLED_LITELLM_PYTHON = path.join(
+  os.homedir(),
+  ".local/share/codex-router/.venv/bin/python",
+);
+
+function installedLiteLlmPython() {
+  const candidates = [
+    INSTALLED_LITELLM_PYTHON,
+    path.join(root, ".venv", "bin", "python"),
+    path.join(root, ".venv", "Scripts", "python.exe"),
+  ];
+  return candidates.find((candidate) => existsSync(candidate));
+}
+
+function convertCustomToolThroughInstalledLiteLlm(tool) {
+  const python = installedLiteLlmPython();
+  assert.ok(python, `installed LiteLLM python is required at ${INSTALLED_LITELLM_PYTHON}`);
+  const script = [
+    "import json, sys",
+    "from litellm.responses.litellm_completion_transformation.custom_tools import convert_custom_tool_to_function_tool",
+    "tool = json.load(sys.stdin)",
+    "converted = convert_custom_tool_to_function_tool(tool)",
+    "if hasattr(converted, 'model_dump'):",
+    "    converted = converted.model_dump(mode='json')",
+    "json.dump(converted, sys.stdout)",
+  ].join("\n");
+  const result = spawnSync(python, ["-c", script], {
+    input: JSON.stringify(tool),
+    encoding: "utf8",
+    timeout: 20_000,
+  });
+  assert.equal(result.status, 0, result.stderr || result.error?.message || "LiteLLM convert failed");
+  return JSON.parse(result.stdout);
+}
+
+function chatToolFromLiteLlm(converted) {
+  if (converted?.type === "function" && converted.function) return converted;
+  return { type: "function", function: converted };
+}
+
+test("Grok 4.6 apply_patch guidance survives Router-shaped LiteLLM translation and the forwarder", () => {
+  const originalDescription = "Apply a patch.";
+  const originalFormat = { type: "grammar", syntax: "lark", definition: V4A_GRAMMAR };
+  const native = applyGrokApplyPatchGuidance(
+    [
+      {
+        type: "custom",
+        name: APPLY_PATCH_TOOL_NAME,
+        description: originalDescription,
+        format: originalFormat,
+      },
+      { type: "function", name: APPLY_PATCH_TOOL_NAME, parameters: { type: "object" } },
+    ],
+    { slug: GROK_APPLY_PATCH_GUIDANCE_ROUTE },
+  )[0];
+  assert.equal(native.type, "custom");
+  assert.equal(native.format, originalFormat);
+  assert.deepEqual(native.format, {
+    type: "grammar",
+    syntax: "lark",
+    definition: V4A_GRAMMAR,
+  });
+
+  const converted = convertCustomToolThroughInstalledLiteLlm(native);
+  const chatTool = chatToolFromLiteLlm(converted);
+  assert.equal(chatTool.type, "function");
+  assert.equal(chatTool.function.name, APPLY_PATCH_TOOL_NAME);
+  const description = chatTool.function.description;
+  assert.match(description, new RegExp(originalDescription));
+  assert.ok(description.includes(V4A_GRAMMAR), "installed LiteLLM retains the original lark grammar");
+  assert.ok(description.includes(GROK_APPLY_PATCH_CREATE_EXAMPLE));
+  assert.ok(description.includes(GROK_APPLY_PATCH_UPDATE_EXAMPLE));
+  assert.equal(description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), true);
+  assert.deepEqual(chatTool.function.parameters.required, ["content"]);
+  assert.equal(chatTool.function.parameters.properties.content.type, "string");
+
+  const forwarded = toResponsesRequest({
+    model: "grok-4.6",
+    messages: [{ role: "user", content: "patch notes.txt" }],
+    tools: [chatTool],
+  });
+  const applyPatch = forwarded.tools.find((tool) => tool.type === "function" && tool.name === APPLY_PATCH_TOOL_NAME);
+  assert.ok(applyPatch);
+  assert.equal(applyPatch.description, description);
+  assert.ok(applyPatch.description.includes(V4A_GRAMMAR));
+  assert.deepEqual(applyPatch.parameters.required, ["content"]);
+});
+
+test("Grok forwarder keeps apply_patch call ids and streamed unicode quotes newlines verbatim", async () => {
+  const rawPatch = [
+    "*** Begin Patch",
+    '*** Add File: café "quotes".txt',
+    "+hello “unicode”",
+    "*** End Patch",
+  ].join("\n");
+  const wrapped = JSON.stringify({ content: rawPatch });
+  const malformed = "*** Begin Patch\nnot-a-json-object";
+  let captured;
+  const backend = await mockBackend(async (req, res) => {
+    const chunks = [];
+    for await (const c of req) chunks.push(c);
+    captured = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+    const call = captured.input.find((item) => item.type === "function_call");
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    res.end(
+      sse([
+        {
+          type: "response.output_item.added",
+          item: {
+            type: "function_call",
+            id: "fc_unicode",
+            call_id: "call_unicode",
+            name: APPLY_PATCH_TOOL_NAME,
+          },
+        },
+        {
+          type: "response.function_call_arguments.delta",
+          item_id: "fc_unicode",
+          delta: call?.arguments === malformed ? malformed : wrapped,
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "function_call",
+            id: "fc_unicode",
+            call_id: "call_unicode",
+            name: APPLY_PATCH_TOOL_NAME,
+            arguments: call?.arguments === malformed ? malformed : wrapped,
+          },
+        },
+        { type: "response.completed", response: { usage: { input_tokens: 11, output_tokens: 9 } } },
+      ]),
+    );
+  });
+  const port = await openPort();
+  const dir = mkdtempSync(path.join(os.tmpdir(), "grok-oauth-patch-guidance-"));
+  const child = startForwarder(port, backend.port, writeSession(dir));
+  const base = `http://127.0.0.1:${port}`;
+  try {
+    await waitHealth(base, child);
+    const tools = [
+      {
+        type: "function",
+        function: {
+          name: APPLY_PATCH_TOOL_NAME,
+          description: `Apply a patch.\n\n${GROK_APPLY_PATCH_GUIDANCE_MARKER}`,
+          parameters: {
+            type: "object",
+            properties: { content: { type: "string" } },
+            required: ["content"],
+          },
+        },
+      },
+    ];
+    const streamed = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [
+          { role: "user", content: "edit café" },
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_history",
+                type: "function",
+                function: { name: APPLY_PATCH_TOOL_NAME, arguments: wrapped },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_history", content: "Done!" },
+        ],
+        tools,
+        stream: true,
+      }),
+    });
+    const streamBody = await streamed.text();
+    assert.equal(captured.input.find((item) => item.type === "function_call").call_id, "call_history");
+    assert.equal(captured.input.find((item) => item.type === "function_call").arguments, wrapped);
+    assert.match(streamBody, /"id":"call_unicode"/);
+    const streamedArguments = [];
+    for (const line of streamBody.split(/\n/)) {
+      if (!line.startsWith("data:")) continue;
+      const data = line.slice(5).trim();
+      if (!data || data === "[DONE]") continue;
+      let parsed;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        continue;
+      }
+      const deltaArgs = parsed.choices?.[0]?.delta?.tool_calls?.[0]?.function?.arguments;
+      if (typeof deltaArgs === "string") streamedArguments.push(deltaArgs);
+    }
+    assert.equal(streamedArguments.join(""), wrapped);
+    assert.equal(JSON.parse(streamedArguments.join("")).content, rawPatch);
+
+    const malformedResp = await fetch(`${base}/v1/chat/completions`, {
+      method: "POST",
+      headers: auth,
+      body: JSON.stringify({
+        model: "grok-4.6",
+        messages: [
+          { role: "user", content: "edit again" },
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call_malformed",
+                type: "function",
+                function: { name: APPLY_PATCH_TOOL_NAME, arguments: malformed },
+              },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_malformed", content: "Failed" },
+        ],
+        tools,
+        stream: false,
+      }),
+    });
+    const malformedJson = await malformedResp.json();
+    assert.equal(captured.input.find((item) => item.type === "function_call").arguments, malformed);
+    assert.equal(
+      malformedJson.choices[0].message.tool_calls[0].function.arguments,
+      malformed,
+    );
+  } finally {
+    await stop(child);
+    await new Promise((r) => backend.server.close(r));
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("Grok 4.5 does not receive apply_patch V4A guidance from this route", () => {
+  const tools = [
+    {
+      type: "custom",
+      name: APPLY_PATCH_TOOL_NAME,
+      format: { type: "grammar", syntax: "lark", definition: V4A_GRAMMAR },
+    },
+  ];
+  assert.equal(applyGrokApplyPatchGuidance(tools, { slug: "grok-oauth/grok-4.5" }), tools);
+  const forwarded = toResponsesRequest({
+    model: "grok-4.5",
+    messages: [{ role: "user", content: "patch" }],
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: APPLY_PATCH_TOOL_NAME,
+          description: "Apply a patch.",
+          parameters: { type: "object", properties: { content: { type: "string" } } },
+        },
+      },
+    ],
+  });
+  const applyPatch = forwarded.tools.find((tool) => tool.name === APPLY_PATCH_TOOL_NAME);
+  assert.equal(applyPatch.description, "Apply a patch.");
+  assert.equal(applyPatch.description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), false);
 });

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -9,6 +9,12 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
+import {
+  APPLY_PATCH_TOOL_NAME,
+  GROK_APPLY_PATCH_CREATE_EXAMPLE,
+  GROK_APPLY_PATCH_GUIDANCE_MARKER,
+  GROK_APPLY_PATCH_UPDATE_EXAMPLE,
+} from "../src/grok-apply-patch-guidance.mjs";
 
 // End-to-end proof of the namespace relay through the REAL router: a routed
 // request carrying the client's namespace toolset must reach the (mock)
@@ -2249,4 +2255,141 @@ test("OpenCode Go compaction removes native tool history before the strict endpo
     outgoing.input.some((item) => item.call_id === "orphan-custom-output"),
     false,
   );
+});
+
+const GROK_V4A_GRAMMAR = [
+  "start: begin_patch hunk+ end_patch",
+  'begin_patch: "*** Begin Patch" LF',
+  'end_patch: "*** End Patch" LF?',
+  "",
+  "hunk: add_hunk | delete_hunk | update_hunk",
+  'add_hunk: "*** Add File: " filename LF add_line+',
+  "%import common.LF",
+].join("\n");
+
+const GROK_PATCH_UNICODE = [
+  "*** Begin Patch",
+  '*** Add File: café "quotes".txt',
+  "+hello “unicode”",
+  "*** End Patch",
+].join("\n");
+
+function grokApplyPatchPayload(stream, model) {
+  return {
+    model,
+    stream,
+    input: [
+      { type: "message", role: "user", content: [{ type: "input_text", text: "patch notes" }] },
+      {
+        type: "custom_tool_call",
+        id: "ctc_history",
+        call_id: "call_history",
+        name: APPLY_PATCH_TOOL_NAME,
+        input: "*** Begin Patch\n*** Add File: seed.txt\n+before\n*** End Patch",
+      },
+      { type: "custom_tool_call_output", call_id: "call_history", output: "Done!" },
+    ],
+    tools: [
+      {
+        type: "custom",
+        name: APPLY_PATCH_TOOL_NAME,
+        description: "Apply a patch.",
+        format: { type: "grammar", syntax: "lark", definition: GROK_V4A_GRAMMAR },
+      },
+      {
+        type: "function",
+        name: APPLY_PATCH_TOOL_NAME,
+        description: "ordinary same-name function",
+        parameters: { type: "object", properties: { path: { type: "string" } } },
+      },
+      { type: "custom", name: "future_custom", description: "leave me" },
+    ],
+  };
+}
+
+function grokApplyPatchSseBody() {
+  return [
+    sseEvent({
+      type: "response.output_item.added",
+      item: {
+        type: "custom_tool_call",
+        id: "ctc_unicode",
+        call_id: "call_unicode",
+        name: APPLY_PATCH_TOOL_NAME,
+        input: "",
+      },
+    }),
+    sseEvent({
+      type: "response.custom_tool_call_input.delta",
+      item_id: "ctc_unicode",
+      delta: GROK_PATCH_UNICODE,
+    }),
+    sseEvent({
+      type: "response.output_item.done",
+      item: {
+        type: "custom_tool_call",
+        id: "ctc_unicode",
+        call_id: "call_unicode",
+        name: APPLY_PATCH_TOOL_NAME,
+        input: GROK_PATCH_UNICODE,
+      },
+    }),
+    sseEvent({ type: "response.completed" }),
+    "data: [DONE]\n\n",
+  ].join("");
+}
+
+test("Grok 4.6 OAuth annotates native custom apply_patch and leaves history, collisions, and other models alone", async () => {
+  const guided = await scenario(true, {
+    model: "grok-oauth/grok-4.6",
+    requestPayload: grokApplyPatchPayload,
+    sseBody: grokApplyPatchSseBody,
+  });
+  const outgoing = guided.gatewayBodies[0];
+  const custom = outgoing.tools.find((tool) => tool.type === "custom" && tool.name === APPLY_PATCH_TOOL_NAME);
+  const ordinary = outgoing.tools.find((tool) => tool.type === "function" && tool.name === APPLY_PATCH_TOOL_NAME);
+  const otherCustom = outgoing.tools.find((tool) => tool.type === "custom" && tool.name === "future_custom");
+  assert.ok(custom, "native custom apply_patch still reaches LiteLLM as a custom tool");
+  assert.equal(custom.description.startsWith("Apply a patch."), true);
+  assert.equal(custom.description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), true);
+  assert.equal(custom.description.includes(GROK_APPLY_PATCH_CREATE_EXAMPLE), true);
+  assert.equal(custom.description.includes(GROK_APPLY_PATCH_UPDATE_EXAMPLE), true);
+  assert.doesNotMatch(custom.description, /```/);
+  assert.deepEqual(custom.format, {
+    type: "grammar",
+    syntax: "lark",
+    definition: GROK_V4A_GRAMMAR,
+  });
+  assert.deepEqual(ordinary.description, "ordinary same-name function");
+  assert.equal(ordinary.description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), false);
+  assert.deepEqual(otherCustom.description, "leave me");
+  const history = outgoing.input.find((item) => item.call_id === "call_history");
+  assert.equal(history.type, "custom_tool_call");
+  assert.equal(history.id, "ctc_history");
+  assert.equal(history.name, APPLY_PATCH_TOOL_NAME);
+  assert.equal(history.input, "*** Begin Patch\n*** Add File: seed.txt\n+before\n*** End Patch");
+  const restoredByCallId = new Map();
+  for (const item of responseItemsFromSse(guided.clientBody)) {
+    if (item?.call_id) restoredByCallId.set(item.call_id, item);
+  }
+  const restored = restoredByCallId.get("call_unicode");
+  assert.equal(restored.type, "custom_tool_call");
+  assert.equal(restored.id, "ctc_unicode");
+  assert.equal(restored.input, GROK_PATCH_UNICODE);
+
+  const unguided = await scenario(true, {
+    model: "grok-oauth/grok-4.5",
+    requestPayload: grokApplyPatchPayload,
+    sseBody: grokApplyPatchSseBody,
+  });
+  const control = unguided.gatewayBodies[0].tools.find(
+    (tool) => tool.type === "custom" && tool.name === APPLY_PATCH_TOOL_NAME,
+  );
+  assert.equal(control.description, "Apply a patch.");
+  assert.deepEqual(control.format, {
+    type: "grammar",
+    syntax: "lark",
+    definition: GROK_V4A_GRAMMAR,
+  });
+  assert.equal(control.description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), false);
 });

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -22,6 +22,15 @@ import {
   ToolSearchHistoryCapacityError,
 } from "../src/namespace-relay.mjs";
 import { CODEX_APP_TOOLS, mergeCodexAppTools } from "../src/codex-app-tools.mjs";
+import {
+  APPLY_PATCH_TOOL_NAME,
+  GROK_APPLY_PATCH_CREATE_EXAMPLE,
+  GROK_APPLY_PATCH_GUIDANCE,
+  GROK_APPLY_PATCH_GUIDANCE_MARKER,
+  GROK_APPLY_PATCH_GUIDANCE_ROUTE,
+  GROK_APPLY_PATCH_UPDATE_EXAMPLE,
+  applyGrokApplyPatchGuidance,
+} from "../src/grok-apply-patch-guidance.mjs";
 
 function collect(stream) {
   return new Promise((resolve, reject) => {
@@ -3926,6 +3935,100 @@ test("custom-tool bridge maps apply_patch definitions and paired history lossles
   assert.equal(bridged.input[1].type, "function_call_output");
   assert.deepEqual(bridged.input[2], unrelatedCall);
   assert.equal(buildNamespaceLookups(namespaces).customTools.get("apply_patch"), "apply_patch");
+});
+
+const GROK_46_ROUTE = { slug: GROK_APPLY_PATCH_GUIDANCE_ROUTE };
+const GROK_45_ROUTE = { slug: "grok-oauth/grok-4.5" };
+const GROK_API_46_ROUTE = { slug: "grok-api/grok-4.6" };
+const COMMANDCODE_46_ROUTE = { slug: "commandcode/grok-4.6" };
+
+function nativeApplyPatch(extra = {}) {
+  return {
+    type: "custom",
+    name: APPLY_PATCH_TOOL_NAME,
+    format: { type: "grammar", syntax: "lark", definition: V4A_GRAMMAR },
+    ...extra,
+  };
+}
+
+test("Grok 4.6 OAuth appends V4A examples to native custom apply_patch before translation", () => {
+  assert.equal(GROK_APPLY_PATCH_GUIDANCE.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), true);
+  const description = "Apply a patch.";
+  const ordinary = { type: "function", name: APPLY_PATCH_TOOL_NAME, parameters: { type: "object" } };
+  const otherCustom = { type: "custom", name: "future_custom", description: "leave me" };
+  const tools = [nativeApplyPatch({ description }), ordinary, otherCustom];
+  const originalFormat = tools[0].format;
+  const input = [
+    {
+      type: "custom_tool_call",
+      id: "ctc_keep",
+      call_id: "call_keep",
+      name: APPLY_PATCH_TOOL_NAME,
+      input: "*** Begin Patch\n*** End Patch",
+    },
+  ];
+  const annotated = applyGrokApplyPatchGuidance(tools, GROK_46_ROUTE);
+  assert.notEqual(annotated, tools);
+  assert.equal(annotated[0].type, "custom");
+  assert.equal(annotated[0].name, APPLY_PATCH_TOOL_NAME);
+  assert.equal(annotated[0].description.startsWith(description), true);
+  assert.equal(annotated[0].description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), true);
+  assert.equal(annotated[0].description.includes(GROK_APPLY_PATCH_CREATE_EXAMPLE), true);
+  assert.equal(annotated[0].description.includes(GROK_APPLY_PATCH_UPDATE_EXAMPLE), true);
+  assert.doesNotMatch(annotated[0].description, /```/);
+  assert.equal(annotated[0].format, originalFormat);
+  assert.deepEqual(annotated[0].format, {
+    type: "grammar",
+    syntax: "lark",
+    definition: V4A_GRAMMAR,
+  });
+  assert.deepEqual(annotated[1], ordinary);
+  assert.deepEqual(annotated[2], otherCustom);
+  assert.deepEqual(input, [
+    {
+      type: "custom_tool_call",
+      id: "ctc_keep",
+      call_id: "call_keep",
+      name: APPLY_PATCH_TOOL_NAME,
+      input: "*** Begin Patch\n*** End Patch",
+    },
+  ]);
+
+  const bridged = bridgeCustomTools(annotated, input, new Map());
+  assert.equal(bridged.tools[0].name, "codex_custom_apply_patch");
+  assert.deepEqual(bridged.tools[1], ordinary);
+  assert.ok(bridged.tools[0].description.includes(V4A_GRAMMAR));
+  assert.ok(bridged.tools[0].description.includes(GROK_APPLY_PATCH_CREATE_EXAMPLE));
+  assert.equal(bridged.input[0].id, "ctc_keep");
+  assert.equal(bridged.input[0].call_id, "call_keep");
+  assert.equal(bridged.input[0].name, "codex_custom_apply_patch");
+  assert.deepEqual(JSON.parse(bridged.input[0].arguments), {
+    input: "*** Begin Patch\n*** End Patch",
+  });
+});
+
+test("Grok apply_patch guidance is idempotent and ignores a same-named ordinary function", () => {
+  const ordinary = { type: "function", name: APPLY_PATCH_TOOL_NAME, parameters: { type: "object" } };
+  const native = nativeApplyPatch();
+  const originalFormat = native.format;
+  const once = applyGrokApplyPatchGuidance([ordinary, native], GROK_46_ROUTE);
+  assert.deepEqual(once[0], ordinary);
+  assert.equal(once[1].format, originalFormat);
+  assert.deepEqual(once[1].format, originalFormat);
+  const twice = applyGrokApplyPatchGuidance(once, GROK_46_ROUTE);
+  assert.equal(twice, once);
+  assert.equal(twice[1].description.includes(GROK_APPLY_PATCH_GUIDANCE_MARKER), true);
+  assert.equal(
+    twice[1].description.split(GROK_APPLY_PATCH_GUIDANCE_MARKER).length - 1,
+    1,
+  );
+});
+
+test("Grok apply_patch guidance is confined to grok-oauth/grok-4.6", () => {
+  const tools = [nativeApplyPatch({ description: "Apply a patch." })];
+  for (const route of [GROK_45_ROUTE, GROK_API_46_ROUTE, COMMANDCODE_46_ROUTE, undefined]) {
+    assert.equal(applyGrokApplyPatchGuidance(tools, route), tools);
+  }
 });
 
 test("custom-tool bridge avoids hijacking an ordinary apply_patch function", () => {

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -4031,6 +4031,14 @@ test("Grok apply_patch guidance is confined to grok-oauth/grok-4.6", () => {
   }
 });
 
+test("a delimiter reminder in the original description does not suppress the examples", () => {
+  const tools = [nativeApplyPatch({ description: GROK_APPLY_PATCH_GUIDANCE_MARKER })];
+  const guided = applyGrokApplyPatchGuidance(tools, GROK_46_ROUTE);
+  assert.ok(guided[0].description.includes(GROK_APPLY_PATCH_CREATE_EXAMPLE));
+  assert.ok(guided[0].description.includes(GROK_APPLY_PATCH_UPDATE_EXAMPLE));
+  assert.equal(applyGrokApplyPatchGuidance(guided, GROK_46_ROUTE), guided);
+});
+
 test("custom-tool bridge avoids hijacking an ordinary apply_patch function", () => {
   const namespaces = new Map();
   const ordinary = { type: "function", name: "apply_patch", parameters: { type: "object" } };


### PR DESCRIPTION
Only `grok-oauth/grok-4.6` receives two short create/update examples in the native custom `apply_patch` description before LiteLLM translation. The original description and grammar format remain intact. Other routes, same-named ordinary functions, tool calls/results and patch application rules retain their existing behavior. No new write tools, automatic patch repairs or additional model requests are introduced.

LiteLLM already preserves the grammar. This is an experimental description change, not a repair for lost grammar. The live pilot did not qualify the package for expansion: malformed delimiters still occurred in an uncontaminated run, and some other runs lacked read isolation. No speedup or quality improvement is claimed; this PR remains a draft.

Deterministic validation covers route/collision controls, immutable grammar, streamed Unicode/quotes/newlines, malformed content, and call/result identity. A standalone verifier exercises Router → hash-locked LiteLLM proxy → Grok forwarder → local mock xAI → restored Codex response. Ordinary Node tests need no personal Python installation; live model calls are excluded from CI. The stock Codex patch tool passes create/update/delete and rejects invalid format/unmatched context without mutation.

`npm run check`, focused Node suites and the real proxy roundtrip pass. Full Linux/macOS/Windows tests and the three-OS protocol matrix pass on the same head `75914f1a05960ae4c9e2010fec693ae724aec73c` in the [independent validation run](https://github.com/Leshabeats/codex-router/pull/2/checks). The original upstream Windows job is still in progress; that run has not been discarded or represented as passed.
