### PR TITLE
fix: preserve native models under signed routing

### DIFF
--- a/src/catalog.mjs
+++ b/src/catalog.mjs
@@ -22,6 +22,7 @@ import {
   NATIVE_ALIAS_PATH,
   NATIVE_CATALOG_PATH,
   PORTS,
+  SIGNED_PROVIDER_MODE_PATH,
 } from "./paths.mjs";
 import {
   codexAuthStatus,
@@ -504,16 +505,42 @@ function selectedModel() {
 // GPT slugs are unusable there even when a ChatGPT credential file exists.
 // Mode toggles pass the desired state via MODEL_ROUTER_LOGIN_FREE because they
 // rebuild the catalog before rewriting the Codex config.
+//
+// Signed routing also sets `model_provider = "codex-router"`. That is not
+// login-free: official GPT slugs must stay on the ChatGPT account.
+export function loginFreeFromSignals({
+  envLoginFree,
+  modelProvider,
+  signedRoutingStatePresent,
+  loginFreeStatePresent,
+}) {
+  if (envLoginFree === "1") return true;
+  if (envLoginFree === "0") return false;
+  if (signedRoutingStatePresent && !loginFreeStatePresent) return false;
+  if (modelProvider === "codex-router") return true;
+  return undefined;
+}
+
 function loginFreeConfigured() {
   const override = process.env.MODEL_ROUTER_LOGIN_FREE;
-  if (override === "1") return true;
-  if (override === "0") return false;
-  if (!existsSync(CONFIG_PATH)) return false;
+  if (!existsSync(CONFIG_PATH)) {
+    const fromSignals = loginFreeFromSignals({
+      envLoginFree: override,
+      modelProvider: undefined,
+      signedRoutingStatePresent: existsSync(SIGNED_PROVIDER_MODE_PATH),
+      loginFreeStatePresent: existsSync(CODEX_PROVIDER_MODE_PATH),
+    });
+    return fromSignals === true;
+  }
   try {
     const document = scanTomlDocument(readFileSync(CONFIG_PATH, "utf8"));
-    if (tomlStringValue(document, [], "model_provider") === "codex-router") {
-      return true;
-    }
+    const fromSignals = loginFreeFromSignals({
+      envLoginFree: override,
+      modelProvider: tomlStringValue(document, [], "model_provider"),
+      signedRoutingStatePresent: existsSync(SIGNED_PROVIDER_MODE_PATH),
+      loginFreeStatePresent: existsSync(CODEX_PROVIDER_MODE_PATH),
+    });
+    if (fromSignals !== undefined) return fromSignals;
     if (!existsSync(CODEX_PROVIDER_MODE_PATH)) return false;
     // Identity-preserving login-free mode deliberately leaves model_provider
     // unchanged, so the root assignment alone can no longer identify it.

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -734,6 +734,10 @@ function signedProviderSlot(state, index) {
   return `${signedProviderSlotPrefix} ${state.ownershipId} ${index}`;
 }
 
+function signedProviderUsesTable(state) {
+  return state.mode === "provider-table" || state.mode === "provider-switch";
+}
+
 function replaceProviderTreeWithManaged(contents, state) {
   const lines = contents.split("\n");
   const ranges = providerTableRanges(contents, state.managedProvider);
@@ -749,7 +753,7 @@ function replaceProviderTreeWithManaged(contents, state) {
         end: range.end,
         text: [
           signedProviderSlot(state, index),
-          ...(state.mode === "provider-table" && index === 0
+          ...(signedProviderUsesTable(state) && index === 0
             ? [blockGenerator(state.managedProvider, state.managedBaseUrl)]
             : []),
         ].join("\n"),
@@ -768,7 +772,7 @@ function replaceProviderTreeWithManaged(contents, state) {
     }
   }
   let next = output.join("\n");
-  if (state.mode === "provider-table" && ranges.length === 0) {
+  if (signedProviderUsesTable(state) && ranges.length === 0) {
     next = `${next.trimEnd()}\n\n${signedProviderSlot(state, 0)}\n${blockGenerator(
       state.managedProvider,
       state.managedBaseUrl,
@@ -802,9 +806,11 @@ function signedProviderBlockIsOwned(contents, state) {
     const actual = range.lines.slice(range.start, range.end).join("\n");
     return managedSignedProviderBlockMatches(actual, state.managedProvider, state.managedBaseUrl);
   }
-  if (state.version !== 3) return false;
+  if (state.version !== 3 && state.version !== 4) return false;
   const sections = state.previousProviderSections;
-  const expectedSlots = state.mode === "provider-table" ? Math.max(1, sections.length) : sections.length;
+  const expectedSlots = signedProviderUsesTable(state)
+    ? Math.max(1, sections.length)
+    : sections.length;
   const lines = contents.split("\n");
   const slots = lines.filter((line) => line.startsWith(`${signedProviderSlotPrefix} `));
   if (
@@ -841,7 +847,7 @@ function restoreSignedProviderTable(contents, state) {
       `Signed routing lost ownership of model_providers.${state.managedProvider}; refusing to replace it.`,
     );
   }
-  if (state.version === 3) {
+  if (state.version === 3 || state.version === 4) {
     let restored = contents;
     for (let index = state.previousProviderSections.length - 1; index >= 1; index -= 1) {
       restored = restored.replace(
@@ -870,6 +876,22 @@ function restoreSignedProviderTable(contents, state) {
     range,
     state.previousProviderTablePresent ? state.previousProviderTable : "",
   );
+}
+
+function restoreSignedRootProvider(contents, state) {
+  if (state.version !== 4) return contents;
+  const { rootLines } = splitRoot(contents);
+  const activeProvider = rootValue(rootLines, "model_provider") || "openai";
+  if (activeProvider !== state.managedProvider) {
+    throw new Error(
+      `Signed routing lost ownership to model_provider ${activeProvider}; refusing to replace it.`,
+    );
+  }
+  return `${replaceRootValue(
+    contents,
+    "model_provider",
+    state.previousProviderPresent ? state.previousModelProvider : undefined,
+  )}\n`;
 }
 
 function managedSignedProviderContents(
@@ -903,6 +925,41 @@ function managedSignedProviderContents(
   return {
     state,
     contents: replaceProviderTreeWithManaged(prepared, state),
+  };
+}
+
+function managedSignedProviderSwitchContents(
+  contents,
+  rootLines,
+  managedBaseUrl,
+  { ownershipId, restoreState } = {},
+) {
+  const managed = managedSignedProviderContents(
+    contents,
+    routerProviderId,
+    managedBaseUrl,
+    { ownershipId },
+  );
+  const previousProviderPresent =
+    restoreState?.previousProviderPresent ?? rootHasValue(rootLines, "model_provider");
+  return {
+    state: {
+      ...managed.state,
+      version: 4,
+      mode: "provider-switch",
+      previousProviderPresent,
+      ...(previousProviderPresent
+        ? {
+            previousModelProvider:
+              restoreState?.previousModelProvider ?? rootValue(rootLines, "model_provider"),
+          }
+        : {}),
+    },
+    contents: `${replaceRootValue(
+      managed.contents,
+      "model_provider",
+      routerProviderId,
+    )}\n`,
   };
 }
 
@@ -1049,7 +1106,21 @@ function readSignedProviderModeState() {
       /^[0-9a-f]{32}$/.test(parsed.ownershipId) &&
       Array.isArray(parsed.previousProviderSections) &&
       parsed.previousProviderSections.every((section) => typeof section === "string");
-    if (!recognizedV1 && !recognizedV2 && !recognizedV3) throw new Error("invalid state");
+    const recognizedV4 =
+      parsed?.version === 4 &&
+      parsed.mode === "provider-switch" &&
+      parsed.managedProvider === routerProviderId &&
+      typeof parsed.managedBaseUrl === "string" &&
+      isManagedRouterBaseUrl(parsed.managedBaseUrl) &&
+      typeof parsed.ownershipId === "string" &&
+      /^[0-9a-f]{32}$/.test(parsed.ownershipId) &&
+      Array.isArray(parsed.previousProviderSections) &&
+      parsed.previousProviderSections.every((section) => typeof section === "string") &&
+      typeof parsed.previousProviderPresent === "boolean" &&
+      (!parsed.previousProviderPresent || typeof parsed.previousModelProvider === "string");
+    if (!recognizedV1 && !recognizedV2 && !recognizedV3 && !recognizedV4) {
+      throw new Error("invalid state");
+    }
     return parsed;
   } catch {
     throw new Error(`Invalid signed router provider state at ${SIGNED_PROVIDER_MODE_PATH}.`);
@@ -1566,14 +1637,23 @@ if (command === "enable") {
         }; refusing to update it.`,
       );
     }
-    const restored = restoreSignedProviderTable(current, signedState);
+    let restored = restoreSignedProviderTable(current, signedState);
+    restored = restoreSignedRootProvider(restored, signedState);
     const enabled = enabledContents(restored);
-    const refreshed = managedSignedProviderContents(
-      enabled,
-      signedState.managedProvider,
-      configuredRouterBaseUrl(),
-      { ownershipId: signedState.ownershipId },
-    );
+    const restoredRootLines = splitRoot(restored).rootLines;
+    const refreshed = signedState.version === 4 || signedState.mode === "root-openai"
+      ? managedSignedProviderSwitchContents(
+          enabled,
+          restoredRootLines,
+          configuredRouterBaseUrl(),
+          { ownershipId: signedState.ownershipId, restoreState: signedState },
+        )
+      : managedSignedProviderContents(
+          enabled,
+          signedState.managedProvider,
+          configuredRouterBaseUrl(),
+          { ownershipId: signedState.ownershipId },
+        );
     next = refreshed.contents;
     pendingSignedProviderModeState = refreshed.state;
   } else if (providerState?.version === 1) {
@@ -1820,15 +1900,24 @@ if (command === "enable") {
         `Signed routing lost ownership while model_provider is ${currentProvider}; turn it off before enabling it again.`,
       );
     }
-    if (state.version === 2) {
-      const restored = restoreSignedProviderTable(current, state);
+    if (state.version === 2 || state.mode === "root-openai") {
+      let restored = restoreSignedProviderTable(current, state);
+      restored = restoreSignedRootProvider(restored, state);
       const enabled = enabledContents(restored);
-      const upgraded = managedSignedProviderContents(
-        enabled,
-        state.managedProvider,
-        configuredRouterBaseUrl(),
-        { ownershipId: state.ownershipId },
-      );
+      const restoredRootLines = splitRoot(restored).rootLines;
+      const upgraded = state.mode === "root-openai"
+        ? managedSignedProviderSwitchContents(
+            enabled,
+            restoredRootLines,
+            configuredRouterBaseUrl(),
+            { ownershipId: state.ownershipId, restoreState: state },
+          )
+        : managedSignedProviderContents(
+            enabled,
+            state.managedProvider,
+            configuredRouterBaseUrl(),
+            { ownershipId: state.ownershipId },
+          );
       next = upgraded.contents;
       pendingSignedProviderModeState = upgraded.state;
     } else {
@@ -1837,7 +1926,9 @@ if (command === "enable") {
   } else {
     const enabled = enabledContents(current);
     const routerBaseUrl = configuredRouterBaseUrl();
-    const managed = managedSignedProviderContents(enabled, currentProvider, routerBaseUrl);
+    const managed = currentProvider === "openai"
+      ? managedSignedProviderSwitchContents(enabled, rootLines, routerBaseUrl)
+      : managedSignedProviderContents(enabled, currentProvider, routerBaseUrl);
     pendingSignedProviderModeState = managed.state;
     next = managed.contents;
   }
@@ -1888,6 +1979,7 @@ if (command === "enable") {
         );
       }
       restored = restoreSignedProviderTable(current, signedState);
+      restored = restoreSignedRootProvider(restored, signedState);
     }
   } else if (state) {
     if (state.version === 1) {
@@ -1938,7 +2030,11 @@ if (command === "enable") {
         "model_provider",
         signedState.previousPresent ? signedState.previousModelProvider : undefined,
       )}\n`;
-    } else if (signedState?.version === 2 || signedState?.version === 3) {
+    } else if (
+      signedState?.version === 2 ||
+      signedState?.version === 3 ||
+      signedState?.version === 4
+    ) {
       const restoredRoot = splitRoot(restored).rootLines;
       const restoredProvider = rootValue(restoredRoot, "model_provider") || "openai";
       if (restoredProvider !== signedState.managedProvider) {
@@ -1947,6 +2043,7 @@ if (command === "enable") {
         );
       }
       restored = restoreSignedProviderTable(restored, signedState);
+      restored = restoreSignedRootProvider(restored, signedState);
     }
     const nativeCatalogContents = restoreNativeCatalog(restored);
     if (nativeCatalogContents) {

--- a/src/native-alias.mjs
+++ b/src/native-alias.mjs
@@ -1,6 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 
-import { NATIVE_ALIAS_PATH } from "./paths.mjs";
+import {
+  NATIVE_ALIAS_PATH,
+  NATIVE_CATALOG_PATH,
+  SIGNED_PROVIDER_MODE_PATH,
+} from "./paths.mjs";
 
 // Signed-out Codex surfaces (notably the ChatGPT desktop app) only display
 // models whose slugs pass a server-delivered allowlist of native GPT slugs.
@@ -50,4 +54,31 @@ export function readNativeAliases() {
 export function nativeAliasFor(externalSlug) {
   const aliases = readNativeAliases();
   return Object.keys(aliases).find((nativeSlug) => aliases[nativeSlug] === externalSlug);
+}
+
+function nativeCatalogSlugs() {
+  if (!existsSync(NATIVE_CATALOG_PATH)) return new Set();
+  try {
+    const parsed = JSON.parse(readFileSync(NATIVE_CATALOG_PATH, "utf8"));
+    const models = Array.isArray(parsed?.models) ? parsed.models : [];
+    return new Set(
+      models
+        .map((model) => (typeof model?.slug === "string" ? model.slug : ""))
+        .filter(Boolean),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+// Official ChatGPT models are unprefixed GPT slugs. Routed copies keep a
+// provider prefix (`private/gpt-5.6-sol`) and must still be remappable.
+export function isOfficialNativeSlug(slug) {
+  if (typeof slug !== "string" || !slug || slug.includes("/")) return false;
+  if (nativeCatalogSlugs().has(slug)) return true;
+  return /^gpt-/i.test(slug);
+}
+
+export function officialModelsMustPassthrough() {
+  return existsSync(SIGNED_PROVIDER_MODE_PATH);
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -78,7 +78,11 @@ import {
 } from "./model-registry.mjs";
 import { createHealthCache } from "./health-cache.mjs";
 import { discoveryDisabled } from "./discovery-mode.mjs";
-import { readNativeAliases } from "./native-alias.mjs";
+import {
+  isOfficialNativeSlug,
+  officialModelsMustPassthrough,
+  readNativeAliases,
+} from "./native-alias.mjs";
 import { nativeContextVariantBase } from "./native-context-variants.mjs";
 import { readNativeRedirect } from "./native-redirect.mjs";
 import {
@@ -1323,6 +1327,22 @@ async function healthPayload() {
 function routeProviderEnabled(providerId) {
   const provider = RUNTIME_PROVIDERS.get(providerId);
   return provider?.generic === true || readProviderSelection().includes(providerId);
+}
+
+function resolveRegisteredRoute(requestedModel) {
+  const exact = MODEL_BY_SLUG.get(requestedModel);
+  if (exact) return exact;
+  // Signed-in official GPT slugs stay on ChatGPT. Aliases and native-redirect
+  // exist for login-free or exhausted-quota installs; they must not steal a
+  // model the operator selected as official.
+  if (officialModelsMustPassthrough() && isOfficialNativeSlug(requestedModel)) {
+    return undefined;
+  }
+  const aliased = MODEL_BY_SLUG.get(readNativeAliases()[requestedModel]);
+  if (aliased) return aliased;
+  const redirect = MODEL_BY_SLUG.get(readNativeRedirect());
+  if (redirect && routeProviderEnabled(redirect.provider)) return redirect;
+  return undefined;
 }
 
 function messageItem(text) {
@@ -2869,14 +2889,19 @@ async function handleRoutedCompaction(
 }
 
 async function handleModels(response) {
-  const data = catalogModels().map((model) => ({
+  const models = catalogModels();
+  const data = models.map((model) => ({
     id: model.slug,
     object: "model",
     owned_by: MODEL_BY_SLUG.has(model.slug)
       ? providerForModel(MODEL_BY_SLUG.get(model.slug)).ownedBy
       : "openai",
   }));
-  writeJson(response, 200, { object: "list", data });
+  // OpenAI-compatible clients read `data`; Codex 0.153.4's custom-provider
+  // discovery reads its native account-catalog shape from the same endpoint.
+  // Keep both views in one response so selecting the signed router provider
+  // does not trade request compatibility for a model-refresh decode error.
+  writeJson(response, 200, { object: "list", data, models });
 }
 
 // What the Gemini surface will accept a turn for.
@@ -3608,21 +3633,7 @@ async function handleResponses(request, response, requestUrl) {
     let payload = await parseBodyAsync(body);
     controller.signal.throwIfAborted();
     requestedModel = typeof payload.model === "string" ? payload.model : "";
-    let registeredRoute =
-      MODEL_BY_SLUG.get(requestedModel) ??
-      MODEL_BY_SLUG.get(readNativeAliases()[requestedModel]);
-    // An unregistered model on this endpoint is native GPT traffic -- Codex's
-    // background agent sessions arrive here hardwired to a native slug no
-    // matter which model the user picked. With the redirect opted in, send
-    // them to the configured routed model; a target that is unknown or whose
-    // provider is hidden leaves the turn native rather than trading a quota
-    // failure for a routing error.
-    if (!registeredRoute && requestedModel) {
-      const redirect = MODEL_BY_SLUG.get(readNativeRedirect());
-      if (redirect && routeProviderEnabled(redirect.provider)) {
-        registeredRoute = redirect;
-      }
-    }
+    let registeredRoute = resolveRegisteredRoute(requestedModel);
     route = registeredRoute && routeProviderEnabled(registeredRoute.provider)
       ? registeredRoute
       : undefined;
@@ -3836,12 +3847,18 @@ async function handleResponses(request, response, requestUrl) {
       if (variantBase) native.model = variantBase;
       normalizeNativePromptCacheCompatibility(native);
       if (Array.isArray(payload.input)) {
+        // Official ChatGPT turns are stateless on this hop. A mixed thread can
+        // still carry `rs_` ids from a private/Grok turn (`encrypted_content`
+        // null). Looking those up returns 404: "Items are not persisted when
+        // store is set to false." Signed-in official passthrough therefore uses
+        // the same provenance cleanup as a substituted caller, except V1
+        // compact which still has a stored-reference contract.
+        const officialPassthrough =
+          officialModelsMustPassthrough() && isOfficialNativeSlug(requestedModel);
+        const statelessNative = substitutedCaller || officialPassthrough;
         native.input = normalizeNativeInput(payload.input, {
-          // Every substituted caller needs provenance-safe full reasoning.
-          // V1 compaction alone has a stored-reference contract, so it keeps
-          // bare rs_ references while ordinary/V2 stateless replay drops them.
-          statelessReasoning: substitutedCaller,
-          dropUnstoredReasoningReferences: substitutedCaller && !compactV1,
+          statelessReasoning: statelessNative,
+          dropUnstoredReasoningReferences: statelessNative && !compactV1,
         });
         // Native turns leave here as stateless full conversations (the
         // previous_response_id below is stripped), so an old tool result costs

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -29,6 +29,7 @@ import {
   mergeNativeModel,
   nativeSubagentCertification,
   promoteNativeMultiAgent,
+  loginFreeFromSignals,
   routedCatalogConfigured,
   routedModel,
 } from "../src/catalog.mjs";
@@ -114,6 +115,36 @@ test("signed-in picker overlay cannot hide Codex native base entries", () => {
   assert.deepEqual(
     [...effectivePickerHiddenModels(hidden, native, { loginFree: true })].sort(),
     [...hidden].sort(),
+  );
+});
+
+test("signed routing is not treated as login-free just because the provider id is the router", () => {
+  assert.equal(
+    loginFreeFromSignals({
+      envLoginFree: undefined,
+      modelProvider: "codex-router",
+      signedRoutingStatePresent: true,
+      loginFreeStatePresent: false,
+    }),
+    false,
+  );
+  assert.equal(
+    loginFreeFromSignals({
+      envLoginFree: undefined,
+      modelProvider: "codex-router",
+      signedRoutingStatePresent: false,
+      loginFreeStatePresent: false,
+    }),
+    true,
+  );
+  assert.equal(
+    loginFreeFromSignals({
+      envLoginFree: "0",
+      modelProvider: "codex-router",
+      signedRoutingStatePresent: false,
+      loginFreeStatePresent: false,
+    }),
+    false,
   );
 });
 

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -2071,10 +2071,105 @@ test("signed routing restores an originally unset provider", () => {
   const configPath = path.join(codexHome, "config.toml");
   writeFileSync(configPath, 'model = "gpt-5.6-sol"\n', { mode: 0o600 });
   try {
-    run("signed-enable", codexHome, stateDir);
-    assert.doesNotMatch(readFileSync(configPath, "utf8"), /^model_provider\s*=/m);
+    const enabled = run("signed-enable", codexHome, stateDir);
+    assert.equal(enabled.model_provider, "codex-router");
+    assert.equal(enabled.signed_routing, true);
+    assert.equal(enabled.login_free, false);
+    const configured = readFileSync(configPath, "utf8");
+    assert.match(configured, /^model_provider = "codex-router"$/m);
+    assert.match(configured, /^requires_openai_auth = true$/m);
+    assert.doesNotMatch(configured, /caller-key-auth-command\.mjs/);
+    const state = JSON.parse(
+      readFileSync(path.join(stateDir, "signed-provider-mode.json"), "utf8"),
+    );
+    assert.equal(state.version, 4);
+    assert.equal(state.mode, "provider-switch");
+    assert.equal(state.previousProviderPresent, false);
+
     run("signed-disable", codexHome, stateDir);
     assert.doesNotMatch(readFileSync(configPath, "utf8"), /^model_provider\s*=/m);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("signed routing keeps ChatGPT auth while routing an explicit openai provider", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-signed-openai-"));
+  const stateDir = path.join(codexHome, "router-state");
+  const configPath = path.join(codexHome, "config.toml");
+  const original = `model = "private/gpt-6-astra"
+model_provider = "openai"
+`;
+  writeFileSync(configPath, original, { mode: 0o600 });
+
+  try {
+    run("enable", codexHome, stateDir);
+    const routerBaseline = readFileSync(configPath, "utf8");
+    const enabled = run("signed-enable", codexHome, stateDir);
+    assert.equal(enabled.model_provider, "codex-router");
+    assert.equal(enabled.signed_routing, true);
+    assert.equal(enabled.signed_routing_managed, true);
+    assert.equal(enabled.login_free, false);
+    let active = readFileSync(configPath, "utf8");
+    assert.match(active, /^model_provider = "codex-router"$/m);
+    assert.match(active, /^requires_openai_auth = true$/m);
+    assert.doesNotMatch(active, /caller-key-auth-command\.mjs/);
+
+    const state = JSON.parse(
+      readFileSync(path.join(stateDir, "signed-provider-mode.json"), "utf8"),
+    );
+    assert.equal(state.version, 4);
+    assert.equal(state.mode, "provider-switch");
+    assert.equal(state.previousProviderPresent, true);
+    assert.equal(state.previousModelProvider, "openai");
+    assert.equal(privateFileIsProtected(path.join(stateDir, "signed-provider-mode.json")), true);
+
+    const updated = run("enable", codexHome, stateDir);
+    assert.equal(updated.model_provider, "codex-router");
+    assert.equal(updated.signed_routing_managed, true);
+    active = readFileSync(configPath, "utf8");
+    assert.equal((active.match(/^model_provider = "codex-router"$/gm) || []).length, 1);
+    assert.equal(
+      JSON.parse(readFileSync(path.join(stateDir, "signed-provider-mode.json"), "utf8")).version,
+      4,
+    );
+
+    const disabled = run("signed-disable", codexHome, stateDir);
+    assert.equal(disabled.model_provider, "openai");
+    assert.equal(disabled.signed_provider_state_present, false);
+    const restored = readFileSync(configPath, "utf8");
+    assert.match(restored, /^model = "private\/gpt-6-astra"$/m);
+    assert.match(restored, /^model_provider = "openai"$/m);
+    assert.match(restored, /# BEGIN codex-router-managed/);
+    assert.match(restored, /# BEGIN codex-router-provider-managed/);
+    assert.doesNotMatch(restored, /codex-router-signed-provider-managed/);
+    assert.equal(
+      restored.replace(/\s+/g, " ").trim(),
+      routerBaseline.replace(/\s+/g, " ").trim(),
+    );
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("signed routing refuses to overwrite root-provider ownership drift", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-signed-root-drift-"));
+  const stateDir = path.join(codexHome, "router-state");
+  const configPath = path.join(codexHome, "config.toml");
+  writeFileSync(configPath, 'model_provider = "openai"\n', { mode: 0o600 });
+
+  try {
+    run("signed-enable", codexHome, stateDir);
+    const drifted = readFileSync(configPath, "utf8").replace(
+      /^model_provider = "codex-router"$/m,
+      'model_provider = "custom"',
+    );
+    writeFileSync(configPath, drifted, { mode: 0o600 });
+    assert.throws(
+      () => run("signed-disable", codexHome, stateDir),
+      /lost ownership to model_provider custom/i,
+    );
+    assert.equal(readFileSync(configPath, "utf8"), drifted);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }

--- a/test/native-alias.test.mjs
+++ b/test/native-alias.test.mjs
@@ -7,10 +7,14 @@ import test from "node:test";
 const stateDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-alias-"));
 process.env.MODEL_ROUTER_STATE_DIR = stateDir;
 
-const { buildNativeAliasAssignments, nativeAliasFor, readNativeAliases } = await import(
-  "../src/native-alias.mjs"
-);
-const { NATIVE_ALIAS_PATH } = await import("../src/paths.mjs");
+const {
+  buildNativeAliasAssignments,
+  isOfficialNativeSlug,
+  nativeAliasFor,
+  officialModelsMustPassthrough,
+  readNativeAliases,
+} = await import("../src/native-alias.mjs");
+const { NATIVE_ALIAS_PATH, SIGNED_PROVIDER_MODE_PATH } = await import("../src/paths.mjs");
 
 test.after(() => rmSync(stateDir, { recursive: true, force: true }));
 
@@ -65,4 +69,19 @@ test("alias reads see a same-size rewrite made within one clock tick", () => {
   // difference distinguishes the two revisions.
   write("kimi-oauth/k9");
   assert.deepEqual(readNativeAliases(), { "gpt-5.5": "kimi-oauth/k9" });
+});
+
+test("official native slugs are unprefixed GPT ids", () => {
+  assert.equal(isOfficialNativeSlug("gpt-5.6-sol"), true);
+  assert.equal(isOfficialNativeSlug("gpt-5.6-sol-1m"), true);
+  assert.equal(isOfficialNativeSlug("private/gpt-5.6-sol"), false);
+  assert.equal(isOfficialNativeSlug("grok-oauth/grok-4.6"), false);
+});
+
+test("signed routing keeps official models on passthrough", () => {
+  assert.equal(officialModelsMustPassthrough(), false);
+  writeFileSync(SIGNED_PROVIDER_MODE_PATH, `${JSON.stringify({ version: 4, mode: "provider-switch" })}\n`, {
+    mode: 0o600,
+  });
+  assert.equal(officialModelsMustPassthrough(), true);
 });

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -276,6 +276,17 @@ test("router requires the configured path capability before any model route", as
   try {
     await waitFor(`${routerBase(routerPort)}/models`, router);
 
+    const modelResponse = await fetch(`${routerBase(routerPort)}/models`);
+    assert.equal(modelResponse.status, 200);
+    const modelCatalog = await modelResponse.json();
+    assert.equal(modelCatalog.object, "list");
+    assert.ok(Array.isArray(modelCatalog.data));
+    assert.ok(Array.isArray(modelCatalog.models));
+    assert.deepEqual(
+      modelCatalog.data.map((model) => model.id),
+      modelCatalog.models.map((model) => model.slug),
+    );
+
     const oldRoute = await fetch(`http://127.0.0.1:${routerPort}/v1/responses`, {
       method: "POST",
       headers: {
@@ -7481,6 +7492,138 @@ test("native redirect falls back to native when the target cannot route", async 
     });
     assert.equal(response.status, 200);
     assert.equal(nativeRequests.at(-1).model, "gpt-5.6-luna");
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("signed routing keeps official slugs off aliases and native redirect", async () => {
+  const nativeRequests = [];
+  const native = await mockServer(async (request, response) => {
+    nativeRequests.push(await bodyJson(request));
+    json(response, 200, { route: "native" });
+  });
+  const gatewayRequests = [];
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, { route: "external" });
+  });
+  const routerPort = await openPort();
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-official-passthrough-"));
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, "signed-provider-mode.json"),
+    `${JSON.stringify({ version: 4, mode: "provider-switch" })}\n`,
+  );
+  writeFileSync(
+    path.join(stateDir, "native-aliases.json"),
+    `${JSON.stringify({ version: 1, aliases: { "gpt-5.6-sol": "grok-oauth/grok-4.6" } })}\n`,
+  );
+  writeFileSync(
+    path.join(stateDir, "native-redirect.json"),
+    `${JSON.stringify({ version: 1, model: "kimi-oauth/k3" })}\n`,
+  );
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ model: "gpt-5.6-sol", input: "official turn" }),
+    });
+    assert.equal(response.status, 200);
+    assert.equal(gatewayRequests.length, 0);
+    assert.equal(nativeRequests.at(-1).model, "gpt-5.6-sol");
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    await closeServer(gateway.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
+test("official passthrough drops unstored private rs_ ids before ChatGPT compact", async () => {
+  const nativeRequests = [];
+  const native = await mockServer(async (request, response) => {
+    nativeRequests.push({ url: request.url, body: await bodyJson(request) });
+    json(response, 200, { route: "native" });
+  });
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-official-rs-drop-"));
+  const stateDir = path.join(testRoot, "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(
+    path.join(stateDir, "signed-provider-mode.json"),
+    `${JSON.stringify({ version: 4, mode: "provider-switch" })}\n`,
+  );
+  const authPath = path.join(testRoot, "auth.json");
+  writeFileSync(
+    authPath,
+    JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: {
+        access_token: "test-native-session-token",
+        account_id: "test-native-account",
+      },
+    }),
+    { mode: 0o600 },
+  );
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    MODEL_ROUTER_CODEX_AUTH: authPath,
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const staleReasoning = {
+      type: "reasoning",
+      id: "rs_1765922398201381146",
+      summary: [{ type: "summary_text", text: "Continue the packaging work." }],
+      content: null,
+      encrypted_content: null,
+    };
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-native-session-token",
+        "chatgpt-account-id": "test-native-account",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-5.6-sol",
+        input: [
+          staleReasoning,
+          { type: "item_reference", id: "rs_1765922398201381146" },
+          { type: "message", role: "user", content: [{ type: "input_text", text: "start" }] },
+          { type: "compaction_trigger" },
+        ],
+      }),
+    });
+    assert.equal(response.status, 200, await response.text());
+    assert.equal(nativeRequests.at(-1).url, "/backend-api/codex/responses");
+    const sent = nativeRequests.at(-1).body.input;
+    assert.equal(sent.some((item) => item?.id === "rs_1765922398201381146"), false);
+    assert.equal(
+      sent.some((item) => item?.type === "item_reference" && item.id === "rs_1765922398201381146"),
+      false,
+    );
+    assert.deepEqual(sent.at(-1), { type: "compaction_trigger" });
   } finally {
     await stopChild(router);
     await closeServer(native.server);


### PR DESCRIPTION
## Summary

Fix signed ChatGPT coexistence after Codex tightened custom-provider model validation, while preventing native subscription models from being captured by external aliases or native redirect rules.

## Problem

Recent Codex builds reject an explicit routed model such as `private/gpt-6-astra` when signed routing leaves the root provider as `openai`:

> The 'private/gpt-6-astra' model is not supported when using Codex with a ChatGPT account.

Switching the root provider to the router satisfies custom-provider validation, but exposed three compatibility bugs:

1. Catalog construction treated every `model_provider = "codex-router"` configuration as login-free, even when the provider still required the operator's ChatGPT authentication.
2. Native aliases and `native-redirect` could capture an unprefixed official GPT slug and route it to an external provider (for example Grok), independently of model failover.
3. A thread switched from a routed model back to an official ChatGPT model could replay an unstored private-provider `rs_` reasoning reference and receive a persistence-related 404.

## Fix

- Add a versioned `provider-switch` signed-routing state that:
  - selects the router as the root provider required by current Codex validation;
  - keeps `requires_openai_auth = true` so ChatGPT account authentication remains active;
  - snapshots and exactly restores the previous root provider and provider table;
  - fails closed if either root-provider or table ownership drifts.
- Distinguish signed routing from login-free routing when building the catalog.
- Resolve exact routed slugs first, then force unprefixed official GPT slugs through native ChatGPT before consulting aliases or native redirect.
- Return both OpenAI-compatible `data` and Codex-native `models` arrays from `/models` for custom-provider discovery.
- Treat official passthrough as stateless for mixed-thread reasoning provenance, dropping only unstored `rs_` references outside the existing V1 compact contract.

Explicit external selections such as `private/gpt-6-astra` and `grok-oauth/grok-4.6` continue to route normally. Model failover behavior is unchanged.

## Validation

- `npm run check` — passed.
- Focused catalog/config/alias tests — 130/130 passed.
- Focused routing regressions — 5/5 passed, covering dual-shape discovery, official passthrough before aliases/redirect, explicit external routes, and mixed-thread reasoning cleanup.
- `npm test` — 3,670 passed, 25 skipped, 4 failed. The exact same four failures reproduce on an unmodified `origin/main` worktree in this environment:
  - one locale-dependent panel text assertion;
  - two doctor JSON-output truncation assertions;
  - one install rollback test affected by the user's global ECC pre-commit hook in the temporary fixture repository.
- Live smoke observation with failover disabled showed official `gpt-5.6-sol` requests using `provider=openai`, private models using `provider=private`, and router health reporting no degraded routes.

## Scope and security

This PR contains only generic source and regression-test changes. It does not include local provider configuration, API keys, tunnel identifiers, private endpoints, generated catalogs, or runtime state.
