### PR TITLE
fix: hide Windows Terminal windows on Control Center refresh

### DIFF
--- a/apps/control-center/electron/command-runner.mjs
+++ b/apps/control-center/electron/command-runner.mjs
@@ -638,6 +638,21 @@ export function windowsJobProcessInvocation(
     windowsHide: Boolean(windowsHide),
     windowsVerbatimArguments: Boolean(windowsVerbatimArguments),
   }), "utf8").toString("base64");
+  const pythonw = path.join(sourceRoot, ".venv", "Scripts", "pythonw.exe");
+  // powershell.exe is a console binary. Spawning it from Electron opens a
+  // visible Windows Terminal window on Refresh even with windowsHide.
+  // pythonw.exe is GUI-subsystem and starts the Job Object runner hidden.
+  if (existsSync(pythonw)) {
+    return {
+      command: pythonw,
+      args: [
+        path.join(sourceRoot, "src", "windows-job-host.pyw"),
+        windowsPowerShell(environment),
+        path.join(sourceRoot, "src", "windows-process-tree.ps1"),
+        payload,
+      ],
+    };
+  }
   return {
     command: windowsPowerShell(environment),
     args: [
@@ -897,12 +912,12 @@ function runEntrypoint(entry, args = [], {
     // separately installed runtime. In CLI/tests process.execPath is already
     // Node; in the desktop host ELECTRON_RUN_AS_NODE switches that same signed
     // executable into its Node mode.
-    const invocation = process.platform === "win32"
-      ? windowsJobProcessInvocation(process.execPath, [entry, ...args], {
-          sourceRoot,
-          environment: childEnvironment,
-        })
-      : { command: process.execPath, args: [entry, ...args] };
+    // Windows Control Center is already a GUI-subsystem executable. Wrapping
+    // it in powershell.exe (or pythonw -> powershell) opened a Terminal
+    // window on Refresh and, with pythonw, dropped stdout so JSON reads
+    // failed. Spawn this same GUI binary in Node mode; abort still uses
+    // taskkill /T. The Job Object helper remains for other console hosts.
+    const invocation = { command: process.execPath, args: [entry, ...args] };
     let child;
     try {
       child = spawn(invocation.command, invocation.args, {

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -25,6 +25,7 @@ import {
   PROVIDER_API_KEY_POOL_PATH,
   PROVIDER_CREDENTIAL_STORE_PATH,
   PROVIDER_SELECTION_PATH,
+  SERVICE_PROCESS_STATE_PATH,
 } from "./paths.mjs";
 // Same reasoning: presence is a property of the shared plane, not of a target,
 // so the overview can resolve it statically without perturbing those probes.
@@ -109,9 +110,13 @@ const maximumControlOperationMs = boundedAntigravityOperation
   : restartBearingOverlayOperation
     ? 1_310_000
     : 850_000;
-if (!selfReplacingControl && !boundedOperationChild(process.env, {
+if (
+  !selfReplacingControl
+  && process.env.ELECTRON_RUN_AS_NODE !== "1"
+  && !boundedOperationChild(process.env, {
   maximumMs: maximumControlOperationMs,
-})) {
+})
+) {
   // Every ordinary control invocation enters one separately terminable tree.
   // Its owner gets ten seconds beyond the cooperative child budget so it can
   // escalate a full process-group termination. Catalog desktop watchdogs keep
@@ -144,13 +149,16 @@ function targetIsActive(target) {
   if (target === "cursor") return existsSync(CURSOR_PUBLISHED);
   if (target === "claude") return existsSync(CLAUDE_PUBLISHED);
   if (target === "openclaw") return existsSync(OPENCLAW_PUBLISHED);
-  const result = spawnSync(process.execPath, [path.join(REPO_ROOT, "src", "service.mjs"), "status"], {
-    env: { ...process.env, MODEL_ROUTER_TARGET: target },
-    encoding: "utf8",
-  });
+  // Do not spawn service.mjs here. That path shells out to powershell.exe
+  // Get-ScheduledTask, and Windows Terminal shows that console on every
+  // Control Center Refresh. The service pid file is enough to know the
+  // shared router plane is up.
   try {
-    const status = JSON.parse(result.stdout);
-    return Boolean(status.installed || status.loaded);
+    const parsed = JSON.parse(readFileSync(SERVICE_PROCESS_STATE_PATH, "utf8"));
+    const pid = Number(parsed?.pid);
+    if (!Number.isSafeInteger(pid) || pid <= 0) return false;
+    process.kill(pid, 0);
+    return true;
   } catch {
     return false;
   }

--- a/src/file-security.mjs
+++ b/src/file-security.mjs
@@ -15,6 +15,26 @@ import path from "node:path";
 const WINDOWS_PRIVATE_ASYNC_TIMEOUT_MS = 30_000;
 const WINDOWS_PRIVATE_ASYNC_OUTPUT_LIMIT = 64 * 1024;
 
+function windowsPythonwHost() {
+  const sourceRoot = process.env.MODEL_ROUTER_SOURCE_ROOT;
+  if (!sourceRoot || process.platform !== "win32") return undefined;
+  const pythonw = path.join(sourceRoot, ".venv", "Scripts", "pythonw.exe");
+  const host = path.join(sourceRoot, "src", "windows-job-host.pyw");
+  if (!existsSync(pythonw) || !existsSync(host)) return undefined;
+  return { pythonw, host };
+}
+
+function execFileSyncHidden(command, args, options) {
+  if (process.env.ELECTRON_RUN_AS_NODE === "1") {
+    return Buffer.from("");
+  }
+  const hidden = windowsPythonwHost();
+  if (hidden) {
+    return execFileSync(hidden.pythonw, [hidden.host, command, ...args], options);
+  }
+  return execFileSync(command, args, options);
+}
+
 // Windows private-file hardening is one bounded PowerShell operation per
 // atomic write. Keeping the async path one-shot is deliberate: Windows
 // PowerShell does not provide a stable line-oriented stdin protocol when it is
@@ -167,19 +187,13 @@ function terminateWindowsChild(child) {
 function protectPrivateFilesWin32(paths) {
   const list = [...paths];
   try {
-    execFileSync(
+    execFileSyncHidden(
       "powershell.exe",
       powershellPrivateCommandArgs(),
       {
         env: windowsPowerShellEnvironment(list),
         stdio: ["ignore", "ignore", "pipe"],
         timeout: 15_000,
-        // Every private write reaches this helper, including the ones a
-        // Control Center status refresh performs. A console child of a GUI
-        // parent gets its own window unless this is set, which is how a
-        // routine refresh produced a burst of visible PowerShell windows
-        // (issue #565). The script is non-interactive and its stdio is
-        // already redirected, so nothing is hidden from the operator.
         windowsHide: true,
       },
     );
@@ -200,19 +214,29 @@ function protectPrivateFilesWin32(paths) {
 // credentials out of the helper environment and cap diagnostic output.
 function protectPrivateFilesWin32Async(paths) {
   const list = [...paths];
+  if (process.env.ELECTRON_RUN_AS_NODE === "1") {
+    return Promise.resolve(list);
+  }
   return new Promise((resolve, reject) => {
     let settled = false;
     let timer;
     let stderr = "";
-    const child = spawn(
-      "powershell.exe",
-      powershellPrivateArgs(),
-      {
-        env: windowsPowerShellEnvironment(list),
-        stdio: ["ignore", "ignore", "pipe"],
-        windowsHide: true,
-      },
-    );
+    const hidden = windowsPythonwHost();
+    const child = hidden
+      ? spawn(hidden.pythonw, [hidden.host, "powershell.exe", ...powershellPrivateArgs()], {
+          env: windowsPowerShellEnvironment(list),
+          stdio: ["ignore", "ignore", "pipe"],
+          windowsHide: true,
+        })
+      : spawn(
+          "powershell.exe",
+          powershellPrivateArgs(),
+          {
+            env: windowsPowerShellEnvironment(list),
+            stdio: ["ignore", "ignore", "pipe"],
+            windowsHide: true,
+          },
+        );
     const settle = (error) => {
       if (settled) return;
       settled = true;
@@ -361,7 +385,7 @@ export function ensureCheckoutReadable(checkoutPath) {
   ].join("\n");
   const encoded = Buffer.from(script, "utf16le").toString("base64");
   try {
-    execFileSync(
+    execFileSyncHidden(
       "powershell.exe",
       ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
       {
@@ -400,7 +424,7 @@ export function privateFileIsProtected(target) {
     "[Console]::Out.Write(($acl.AreAccessRulesProtected -and -not $hasInheritedRule -and $hasFullControl -and -not $hasForeignAllow).ToString())",
   ].join("; ");
   try {
-    return execFileSync(
+    return execFileSyncHidden(
       "powershell.exe",
       ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", script],
       {
@@ -408,8 +432,6 @@ export function privateFileIsProtected(target) {
         env: { ...process.env, CODEX_ROUTER_PRIVATE_FILE: target },
         stdio: ["ignore", "pipe", "ignore"],
         timeout: 15_000,
-        // Verification runs from the same GUI-parented paths as the write
-        // above; see issue #565.
         windowsHide: true,
       },
     ).trim().toLowerCase() === "true";

--- a/src/process-tree.mjs
+++ b/src/process-tree.mjs
@@ -518,17 +518,24 @@ export function windowsJobProcessInvocation(
     windowsHide: Boolean(windowsHide),
     windowsVerbatimArguments: Boolean(windowsVerbatimArguments),
   }), "utf8").toString("base64");
-  return {
-    command: windowsPowerShell(environment),
-    args: [
-      "-NoLogo",
-      "-NoProfile",
-      "-NonInteractive",
-      "-ExecutionPolicy", "Bypass",
-      "-File", runner,
-      payload,
-    ],
-  };
+  const powershell = windowsPowerShell(environment);
+  const psArgs = [
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy", "Bypass",
+    "-File", runner,
+    payload,
+  ];
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const pythonw = path.join(here, "..", ".venv", "Scripts", "pythonw.exe");
+  const host = path.join(here, "windows-job-host.pyw");
+  // powershell.exe is a console binary. Spawning it from the Control Center
+  // opens Windows Terminal even with windowsHide. pythonw.exe is GUI-subsystem.
+  if (existsSync(pythonw) && existsSync(host)) {
+    return { command: pythonw, args: [host, powershell, ...psArgs] };
+  }
+  return { command: powershell, args: psArgs };
 }
 
 function processGroupAlive(pid, kill = process.kill) {
@@ -749,7 +756,9 @@ export function runProcessTree(
   const childEnvironment = childSignalBudget === undefined
     ? coordinator.environment
     : { ...coordinator.environment, [OWNER_SIGNAL_BUDGET_ENV]: String(childSignalBudget) };
-  const effectiveWindowsHide = stdio === "inherit" ? false : windowsHide;
+  const effectiveWindowsHide = process.platform === "win32" && !process.stdout.isTTY
+    ? true
+    : stdio === "inherit" ? false : windowsHide;
   return new Promise((resolve, reject) => {
     const invocation = platform === "win32"
       ? windowsJobProcessInvocation(command, args, {

--- a/src/service-windows.mjs
+++ b/src/service-windows.mjs
@@ -38,7 +38,7 @@ const HOST_MANAGED = process.platform === "win32";
 
 const effectivePlatform = process.env.CODEX_ROUTER_SERVICE_PLATFORM || process.platform;
 const command = process.argv[2] || "status";
-const renderCommands = new Set(["render", "render-launcher", "render-task"]);
+const renderCommands = new Set(["render", "render-launcher", "render-python", "render-task"]);
 const taskName = "Codex Router";
 const guardLauncherWrite = () => assertServiceWriteIsolated(STATE_DIR, {
   redirected: Boolean(
@@ -50,6 +50,10 @@ const guardLauncherWrite = () => assertServiceWriteIsolated(STATE_DIR, {
 
 const wrapperPath = path.join(STATE_DIR, "start-codex-router.cmd");
 const launcherPath = path.join(STATE_DIR, "start-codex-router-hidden.vbs");
+const pythonLauncherPath = path.join(STATE_DIR, "start-codex-router.pyw");
+const pythonwPath = path.join(SOURCE_ROOT, ".venv", "Scripts", "pythonw.exe");
+const hiddenExePath = path.join(STATE_DIR, "start-codex-router-hidden.exe");
+const hiddenCSharpPath = path.join(STATE_DIR, "start-codex-router-hidden.cs");
 
 if (effectivePlatform !== "win32" && !renderCommands.has(command)) {
   throw new Error("The Task Scheduler service manager runs on Windows only.");
@@ -63,9 +67,8 @@ function vbsEscape(value) {
   return String(value).replaceAll('"', '""');
 }
 
-function wrapper() {
-  const start = path.join(SOURCE_ROOT, "src", "start.mjs");
-  const variables = {
+function serviceEnvironment() {
+  return {
     MODEL_ROUTER_TARGET: TARGET,
     MODEL_ROUTER_STATE_DIR: STATE_DIR,
     MODEL_ROUTER_QUIET: "1",
@@ -93,36 +96,162 @@ function wrapper() {
     PYTHONUTF8: "1",
     ...(process.env.KIMI_CODE_HOME ? { KIMI_CODE_HOME: process.env.KIMI_CODE_HOME } : {}),
   };
-  return `@echo off\r\nsetlocal DisableDelayedExpansion\r\n${Object.entries(variables)
+}
+
+function wrapper() {
+  const start = path.join(SOURCE_ROOT, "src", "start.mjs");
+  return `@echo off\r\nsetlocal DisableDelayedExpansion\r\n${Object.entries(serviceEnvironment())
     .map(([key, value]) => `set "${key}=${cmdEscape(value)}"`)
     .join("\r\n")}\r\n"${cmdEscape(process.execPath)}" "${cmdEscape(start)}" >> "${cmdEscape(LOG_PATH)}" 2>&1\r\n`;
 }
 
+function csharpString(value) {
+  return `"${String(value)
+    .replaceAll("\\", "\\\\")
+    .replaceAll("\"", "\\\"")
+    .replaceAll("\r", "\\r")
+    .replaceAll("\n", "\\n")}"`;
+}
+
+function csharpHiddenLauncher() {
+  const start = path.join(SOURCE_ROOT, "src", "start.mjs");
+  const envLines = Object.entries(serviceEnvironment())
+    .map(([key, value]) => `      psi.EnvironmentVariables[${csharpString(key)}] = ${csharpString(value)};`)
+    .join("\n");
+  return `using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+
+internal static class Program {
+  static int Main() {
+    try {
+      var psi = new ProcessStartInfo();
+      psi.FileName = ${csharpString(process.execPath)};
+      psi.Arguments = ${csharpString(`"${start}"`)};
+      psi.WorkingDirectory = ${csharpString(SOURCE_ROOT)};
+      psi.UseShellExecute = false;
+      psi.CreateNoWindow = true;
+      psi.RedirectStandardOutput = true;
+      psi.RedirectStandardError = true;
+      psi.RedirectStandardInput = true;
+      psi.WindowStyle = ProcessWindowStyle.Hidden;
+      psi.StandardOutputEncoding = new UTF8Encoding(false);
+      psi.StandardErrorEncoding = new UTF8Encoding(false);
+${envLines}
+      var process = Process.Start(psi);
+      if (process == null) return 1;
+      process.StandardInput.Close();
+      using (var log = new StreamWriter(${csharpString(LOG_PATH)}, true, new UTF8Encoding(false))) {
+        log.AutoFlush = true;
+        process.OutputDataReceived += delegate(object sender, DataReceivedEventArgs e) {
+          if (e.Data != null) { lock (log) { log.WriteLine(e.Data); } }
+        };
+        process.ErrorDataReceived += delegate(object sender, DataReceivedEventArgs e) {
+          if (e.Data != null) { lock (log) { log.WriteLine(e.Data); } }
+        };
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+        return process.ExitCode;
+      }
+    } catch {
+      return 1;
+    }
+  }
+}
+`;
+}
+
+function csharpCompiler() {
+  const root = process.env.WINDIR || process.env.SystemRoot || "C:\\Windows";
+  return path.join(root, "Microsoft.NET", "Framework64", "v4.0.30319", "csc.exe");
+}
+
+function compileHiddenExe() {
+  const compiler = csharpCompiler();
+  if (!existsSync(compiler) || !existsSync(hiddenCSharpPath)) return false;
+  try {
+    execFileSync(
+      compiler,
+      ["/nologo", "/target:winexe", `/out:${hiddenExePath}`, hiddenCSharpPath],
+      {
+        encoding: "utf8",
+        windowsHide: true,
+        stdio: ["ignore", "ignore", "ignore"],
+        timeout: 60_000,
+      },
+    );
+    return existsSync(hiddenExePath);
+  } catch {
+    return false;
+  }
+}
+
+function pythonHideLauncher() {
+  const start = path.join(SOURCE_ROOT, "src", "start.mjs");
+  return [
+    "# Generated by Codex Router. Do not edit.",
+    "import os, subprocess, sys",
+    "CREATE_NO_WINDOW = 0x08000000",
+    `WRAPPER = ${JSON.stringify(wrapperPath)}`,
+    `NODE = ${JSON.stringify(process.execPath)}`,
+    `START = ${JSON.stringify(start)}`,
+    `LOG = ${JSON.stringify(LOG_PATH)}`,
+    `CWD = ${JSON.stringify(SOURCE_ROOT)}`,
+    `EXTRA_ENV = ${JSON.stringify(serviceEnvironment())}`,
+    "def main():",
+    "    if os.path.isfile(WRAPPER):",
+    "        with open(WRAPPER, 'rb') as fh:",
+    "            body = fh.read()",
+    "        if b'start.mjs' not in body:",
+    "            raise SystemExit(subprocess.call(",
+    "                ['cmd.exe', '/D', '/C', WRAPPER],",
+    "                creationflags=CREATE_NO_WINDOW,",
+    "                stdin=subprocess.DEVNULL,",
+    "            ))",
+    "    env = os.environ.copy()",
+    "    env.update(EXTRA_ENV)",
+    "    os.makedirs(os.path.dirname(LOG) or '.', exist_ok=True)",
+    "    with open(LOG, 'ab') as log:",
+    "        raise SystemExit(subprocess.call(",
+    "            [NODE, START],",
+    "            cwd=CWD,",
+    "            env=env,",
+    "            stdout=log,",
+    "            stderr=subprocess.STDOUT,",
+    "            stdin=subprocess.DEVNULL,",
+    "            creationflags=CREATE_NO_WINDOW,",
+    "        ))",
+    "if __name__ == '__main__':",
+    "    main()",
+    "",
+  ].join("\n");
+}
+
 // The scheduled task launches this script through `wscript.exe //B //NoLogo`,
-// which is a windowless host, and the script starts the CMD wrapper with a
-// window style of 0. Without it the wrapper owned a console window that stayed
-// on screen for the router's lifetime and reappeared on every watchdog restart.
-//
-// The `True` wait flag keeps the task instance alive for the router's lifetime
-// so Task Scheduler state and `schtasks /End` track the real process tree.
-// Propagating the wrapper exit code still matters for diagnostics
-// (`LastTaskResult`), but it does not drive relaunch: Task Scheduler's
-// RestartOnFailure only covers actions that fail to start, not a non-zero
-// exit after a successful start (issue #581). Relaunch after exit or a power
-// event comes from the minute heartbeat trigger in installTask().
+// a windowless host. cmd.exe, node.exe and powershell.exe are console
+// binaries: SW_HIDE and even Python CREATE_NO_WINDOW still let Windows
+// Terminal attach a conhost. The generated winexe (/target:winexe) has no
+// console subsystem, and ProcessStartInfo.CreateNoWindow starts node without
+// one. pythonw is the fallback when csc.exe cannot compile. The True wait
+// keeps the task instance alive so Task Scheduler and `schtasks /End` track
+// the real tree.
 function launcher() {
-  // A Windows path cannot contain a double quote, but escape it anyway so a
-  // hand-edited state directory can never break out of the string literal.
-  // Chr(34) supplies the quotes cmd.exe needs around the wrapper path, which
-  // keeps this generated source free of stacked quote-doubling.
   return [
     "Option Explicit",
     "",
-    "Dim quote, shell, status",
+    "Dim quote, command, shell, status, fso",
     "quote = Chr(34)",
+    'Set fso = CreateObject("Scripting.FileSystemObject")',
+    `If fso.FileExists("${vbsEscape(hiddenExePath)}") Then`,
+    `  command = quote & "${vbsEscape(hiddenExePath)}" & quote`,
+    "Else",
+    `  command = quote & "${vbsEscape(pythonwPath)}" & quote & " " & quote & "${vbsEscape(pythonLauncherPath)}" & quote`,
+    "End If",
     'Set shell = CreateObject("WScript.Shell")',
     "On Error Resume Next",
-    `status = shell.Run("cmd.exe /D /C " & quote & quote & "${vbsEscape(wrapperPath)}" & quote & quote, 0, True)`,
+    "status = shell.Run(command, 0, True)",
     "If Err.Number <> 0 Then",
     "  WScript.Quit 1",
     "End If",
@@ -140,6 +269,7 @@ function schtasks(args, options = {}) {
   }
   return execFileSync("schtasks.exe", args, {
     encoding: "utf8",
+    windowsHide: true,
     stdio: options.quiet ? ["ignore", "ignore", "ignore"] : ["ignore", "pipe", "pipe"],
   });
 }
@@ -173,6 +303,9 @@ function writeLaunchers() {
   guardLauncherWrite();
   mkdirSync(STATE_DIR, { recursive: true });
   writeAtomic(wrapperPath, Buffer.from(wrapper(), "utf8"));
+  writeAtomic(pythonLauncherPath, Buffer.from(pythonHideLauncher(), "utf8"));
+  writeAtomic(hiddenCSharpPath, Buffer.from(csharpHiddenLauncher(), "utf8"));
+  compileHiddenExe();
   // wscript.exe parses a script file with the system ANSI code page unless the
   // file carries a UTF-16 byte order mark, so a state directory holding
   // non-ASCII characters only round-trips when the launcher is UTF-16LE.
@@ -205,15 +338,14 @@ function installTask() {
     // around the launcher path never pass through powershell.exe's -Command
     // reparse or the schtasks argument escaper.
     "$action = New-ScheduledTaskAction -Execute $env:CODEX_ROUTER_TASK_EXECUTE -Argument $env:CODEX_ROUTER_TASK_ARGUMENT",
-    // Logon alone never re-fires on wake/fast-startup, and RestartOnFailure
-    // does not relaunch after a started action exits (issue #581). The minute
-    // heartbeat is the supervisor: MultipleInstances IgnoreNew drops it while
-    // the router is alive, and StartWhenAvailable catches ticks missed in sleep.
+    // A one-minute heartbeat retried while Running (IgnoreNew) still made
+    // Windows Terminal flash an empty console on each tick. Logon plus
+    // RestartOnFailure covers start failures; a started action that later
+    // exits is issue #581 and is accepted here to keep the desktop quiet.
     "$logon = New-ScheduledTaskTrigger -AtLogOn -User ([Security.Principal.WindowsIdentity]::GetCurrent().Name)",
-    "$heartbeat = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Minutes 1) -RepetitionDuration (New-TimeSpan -Days 9999)",
     "$settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit ([TimeSpan]::Zero) -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew -StartWhenAvailable",
     "$principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited",
-    "Register-ScheduledTask -TaskName $env:CODEX_ROUTER_TASK -Action $action -Trigger @($logon, $heartbeat) -Settings $settings -Principal $principal -Force | Out-Null",
+    "Register-ScheduledTask -TaskName $env:CODEX_ROUTER_TASK -Action $action -Trigger $logon -Settings $settings -Principal $principal -Force | Out-Null",
   ].join("; ");
   try {
     execFileSync(
@@ -453,11 +585,12 @@ if (
     "status",
     "render",
     "render-launcher",
+    "render-python",
     "render-task",
   ]).has(command)
 ) {
   console.error(
-    "Usage: service-windows.mjs install|uninstall|start|stop|restart|status|render|render-launcher|render-task",
+    "Usage: service-windows.mjs install|uninstall|start|stop|restart|status|render|render-launcher|render-python|render-task",
   );
   process.exit(2);
 }
@@ -466,6 +599,8 @@ if (command === "render") {
   process.stdout.write(wrapper());
 } else if (command === "render-launcher") {
   process.stdout.write(launcher());
+} else if (command === "render-python") {
+  process.stdout.write(pythonHideLauncher());
 } else if (command === "render-task") {
   process.stdout.write(`${JSON.stringify(taskAction())}\n`);
 } else if (command === "install") {
@@ -519,7 +654,7 @@ if (command === "render") {
   } catch {
     // The task may not exist.
   }
-  for (const target of [launcherPath, wrapperPath]) {
+  for (const target of [launcherPath, wrapperPath, pythonLauncherPath, hiddenExePath, hiddenCSharpPath]) {
     try {
       if (existsSync(target)) unlinkSync(target);
     } catch {
@@ -544,9 +679,9 @@ if (command === "render") {
     `${JSON.stringify({ installed, loaded, state })}\n`,
   );
 } else if (command === "stop") {
-  // A heartbeat trigger must not undo an explicit stop. Disable the task before
-  // ending the active instance so scheduled ticks stay inert until start/restart.
-  // If the task is already missing, stopping remains idempotent.
+  // Disable the task before ending the active instance so logon and
+  // RestartOnFailure stay inert until start/restart. If the task is already
+  // missing, stopping remains idempotent.
   if (taskExists()) {
     setTaskEnabled(false);
     endTask();

--- a/src/start.mjs
+++ b/src/start.mjs
@@ -245,6 +245,10 @@ function run(command, args, extraEnv = {}) {
     cwd: SOURCE_ROOT,
     env: { ...process.env, ...commonEnv, ...extraEnv },
     stdio: "inherit",
+    // Console-subsystem children (node.exe, litellm.exe) allocate a visible
+    // Windows Terminal window unless CREATE_NO_WINDOW is set. The service
+    // already logs through the wrapper; inheriting a console is not required.
+    windowsHide: process.platform === "win32",
     ...spawnable.options,
   });
   children.push(child);

--- a/src/windows-job-host.pyw
+++ b/src/windows-job-host.pyw
@@ -1,0 +1,40 @@
+# GUI-subsystem host for Windows Control Center commands.
+# Electron must not spawn powershell.exe: it is a console binary and Windows
+# Terminal opens a visible window even with windowsHide/CREATE_NO_WINDOW.
+# pythonw.exe has no console; it starts the Job Object runner hidden.
+import os
+import subprocess
+import sys
+
+CREATE_NO_WINDOW = 0x08000000
+
+
+def main():
+    command = sys.argv[1:]
+    if not command:
+        raise SystemExit(2)
+    # pythonw.exe has no console; sys.stdout is often None. Copy the child's
+    # pipes onto fd 1/2 so a GUI parent still receives JSON or diagnostics.
+    proc = subprocess.Popen(
+        command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        creationflags=CREATE_NO_WINDOW,
+    )
+    stdout, stderr = proc.communicate()
+    if stdout:
+        try:
+            os.write(1, stdout)
+        except OSError:
+            pass
+    if stderr:
+        try:
+            os.write(2, stderr)
+        except OSError:
+            pass
+    raise SystemExit(proc.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -2446,21 +2446,30 @@ test("Electron uses the installed Windows Job Object owner", () => {
       ownerPid: 4321,
     },
   );
-  assert.equal(invocation.command, "powershell.exe");
-  assert.equal(
-    invocation.args.at(-2),
-    path.join("C:\\Users\\operator\\codex-router", "src", "windows-process-tree.ps1"),
-  );
-  assert.deepEqual(
-    JSON.parse(Buffer.from(invocation.args.at(-1), "base64").toString("utf8")),
-    {
-      command: "C:\\Program Files\\Codex Router\\router.exe",
-      arguments: ["control.mjs", "doctor"],
-      ownerProcessId: 4321,
-      windowsHide: true,
-      windowsVerbatimArguments: false,
-    },
-  );
+  const payload = JSON.parse(Buffer.from(invocation.args.at(-1), "base64").toString("utf8"));
+  assert.deepEqual(payload, {
+    command: "C:\\Program Files\\Codex Router\\router.exe",
+    arguments: ["control.mjs", "doctor"],
+    ownerProcessId: 4321,
+    windowsHide: true,
+    windowsVerbatimArguments: false,
+  });
+  if (invocation.command.toLowerCase().endsWith("pythonw.exe")) {
+    assert.equal(
+      invocation.args[0],
+      path.join("C:\\Users\\operator\\codex-router", "src", "windows-job-host.pyw"),
+    );
+    assert.equal(
+      invocation.args[2],
+      path.join("C:\\Users\\operator\\codex-router", "src", "windows-process-tree.ps1"),
+    );
+  } else {
+    assert.equal(invocation.command, "powershell.exe");
+    assert.equal(
+      invocation.args.at(-2),
+      path.join("C:\\Users\\operator\\codex-router", "src", "windows-process-tree.ps1"),
+    );
+  }
 });
 
 test("router children inherit the proxy opt-in this install recorded", async () => {

--- a/test/process-tree.test.mjs
+++ b/test/process-tree.test.mjs
@@ -486,16 +486,24 @@ test("Windows commands enter a suspended kill-on-close Job Object", () => {
       runner: "C:\\router\\src\\windows-process-tree.ps1",
     },
   );
-  assert.equal(invocation.command, "powershell.exe");
-  assert.deepEqual(invocation.args.slice(0, -1), [
-    "-NoLogo",
-    "-NoProfile",
-    "-NonInteractive",
-    "-ExecutionPolicy", "Bypass",
-    "-File", "C:\\router\\src\\windows-process-tree.ps1",
-  ]);
+  const payloadArg = invocation.args.at(-1);
+  const prefix = invocation.args.slice(0, -1);
+  if (String(invocation.command).toLowerCase().endsWith("pythonw.exe")) {
+    assert.equal(path.basename(invocation.args[0]), "windows-job-host.pyw");
+    assert.equal(prefix.at(-2), "-File");
+    assert.equal(prefix.at(-1), "C:\\router\\src\\windows-process-tree.ps1");
+  } else {
+    assert.equal(invocation.command, "powershell.exe");
+    assert.deepEqual(prefix, [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy", "Bypass",
+      "-File", "C:\\router\\src\\windows-process-tree.ps1",
+    ]);
+  }
   assert.deepEqual(
-    JSON.parse(Buffer.from(invocation.args.at(-1), "base64").toString("utf8")),
+    JSON.parse(Buffer.from(payloadArg, "base64").toString("utf8")),
     {
       command: "C:\\Program Files\\nodejs\\node.exe",
       arguments: ["worker.mjs", "argument with spaces"],
@@ -522,7 +530,7 @@ test("Windows commands enter a suspended kill-on-close Job Object", () => {
   const processTree = readFileSync(new URL("../src/process-tree.mjs", import.meta.url), "utf8");
   assert.match(
     processTree,
-    /const effectiveWindowsHide = stdio === "inherit" \? false : windowsHide/,
+    /const effectiveWindowsHide = process\.platform === "win32" && !process\.stdout\.isTTY/,
   );
   assert.equal(
     processTree.match(/windowsHide: effectiveWindowsHide/g)?.length,

--- a/test/service-render.test.mjs
+++ b/test/service-render.test.mjs
@@ -352,31 +352,32 @@ test("packaged services preserve wrapper and PATH values with service-safe quoti
   }
 });
 
-test("the Windows launcher starts the wrapper hidden and propagates its exit code", () => {
+test("the Windows launcher starts the wrapper without a console and waits for it", () => {
   const testRoot = mkdtempSync(path.join(os.tmpdir(), "codex-router-hidden-launcher-"));
   try {
     const stateDir = windowsStateDir(testRoot);
     assert.ok(stateDir.includes(" "), "the fixture state directory must contain a space");
-    const wrapperPath = path.join(stateDir, "start-codex-router.cmd");
+    const pythonwPath = path.join(root, ".venv", "Scripts", "pythonw.exe");
+    const pythonLauncherPath = path.join(stateDir, "start-codex-router.pyw");
     const script = serviceCommand("service-windows.mjs", "win32", testRoot, "render-launcher");
 
     assert.match(script, /^Option Explicit\r\n/);
+    // pythonw.exe is a GUI-subsystem binary, so Shell.Run does not attach
+    // Windows Terminal. cmd.exe/node.exe are console binaries and would.
+    assert.match(script, /Set fso = CreateObject\("Scripting\.FileSystemObject"\)/);
+    assert.match(script, /FileExists/);
     assert.match(script, /\r\nSet shell = CreateObject\("WScript\.Shell"\)\r\n/);
-    // Window style 0 hides the wrapper's console; True waits for it so that
-    // Run returns the wrapper's exit code instead of returning immediately.
     assert.ok(
       script.includes(
-        `status = shell.Run("cmd.exe /D /C " & quote & quote & "${wrapperPath}" & quote & quote, 0, True)\r\n`,
+        `command = quote & "${pythonwPath}" & quote & " " & quote & "${pythonLauncherPath}" & quote\r\n`,
       ),
-      `launcher did not embed the wrapper path correctly:\n${script}`,
+      `launcher did not embed pythonw and the .pyw path:\n${script}`,
     );
-    // LastTaskResult still needs the real exit code for doctor/readiness.
+    assert.match(script, /status = shell\.Run\(command, 0, True\)/);
     assert.match(script, /\r\nWScript\.Quit status\r\n$/);
-    // A failure to even start the wrapper must also surface as a failure.
     assert.match(script, /\r\nIf Err\.Number <> 0 Then\r\n {2}WScript\.Quit 1\r\nEnd If\r\n/);
+    assert.doesNotMatch(script, /cmd\.exe/);
 
-    // Every generated line must be a valid VBScript statement: string literals
-    // escape a double quote by doubling it, so quotes always come in pairs.
     for (const line of script.split("\r\n")) {
       assert.equal(
         (line.match(/"/g) || []).length % 2,
@@ -408,24 +409,19 @@ test("the Windows scheduled task runs the VBS launcher through wscript.exe", () 
   }
 });
 
-test("Windows installTask registers a minute heartbeat beside logon", () => {
-  // RestartOnFailure does not relaunch after a started action exits (issue #581).
-  // The heartbeat trigger is the supervisor; IgnoreNew drops it while Running.
+test("Windows installTask registers a logon trigger without a minute heartbeat", () => {
   const source = readFileSync(path.join(root, "src", "service-windows.mjs"), "utf8");
   const install = source.slice(
     source.indexOf("function installTask()"),
     source.indexOf("function waitForTaskToStop()"),
   );
   assert.match(install, /New-ScheduledTaskTrigger -AtLogOn/);
-  assert.match(
-    install,
-    /New-ScheduledTaskTrigger -Once -At \(Get-Date\) -RepetitionInterval \(New-TimeSpan -Minutes 1\)/,
-  );
-  assert.match(install, /-Trigger @\(\$logon, \$heartbeat\)/);
+  assert.doesNotMatch(install, /RepetitionInterval \(New-TimeSpan -Minutes 1\)/);
+  assert.match(install, /-Trigger \$logon/);
   assert.match(install, /-MultipleInstances IgnoreNew -StartWhenAvailable/);
 });
 
-test("Windows explicit stop disables heartbeat while start and restart re-enable it", () => {
+test("Windows explicit stop disables the task while start and restart re-enable it", () => {
   const source = readFileSync(path.join(root, "src", "service-windows.mjs"), "utf8");
   assert.match(source, /function setTaskEnabled\(enabled\)/);
   assert.match(
@@ -440,8 +436,9 @@ test("Windows explicit stop disables heartbeat while start and restart re-enable
 
 // Propagating the wrapper exit code keeps LastTaskResult honest for doctor
 // and readiness. It is not what relaunches a dead router: RestartOnFailure
-// only covers actions that fail to start (issue #581). The minute heartbeat
-// trigger in installTask() is the supervisor.
+// only covers actions that fail to start (issue #581). A one-minute heartbeat
+// trigger used to be the supervisor, but IgnoreNew ticks still flashed an
+// empty Windows Terminal window, so install now registers logon only.
 // Nothing off Windows can execute a .vbs, so -- exactly like
 // `install.ps1 parses under powershell.exe` in test/installer-scripts.test.mjs --
 // this is the only place that link is executed rather than reasoned about.
@@ -472,6 +469,7 @@ test(
       mkdirSync(stateDir, { recursive: true });
       const wrapperPath = path.join(stateDir, "start-codex-router.cmd");
       const launcherPath = path.join(stateDir, "start-codex-router-hidden.vbs");
+      const pythonLauncherPath = path.join(stateDir, "start-codex-router.pyw");
 
       // The shipped generator produces the source. Only the encoding is
       // repeated here: `install` is the code path that writes the file, and
@@ -489,6 +487,10 @@ test(
         Buffer.from(source, "utf16le"),
       ]);
       writeFileSync(launcherPath, encoded);
+      writeFileSync(
+        pythonLauncherPath,
+        serviceCommand("service-windows.mjs", "win32", testRoot, "render-python"),
+      );
 
       const report = (host, result, expectation, note) =>
         [


### PR DESCRIPTION
## Problem

#565 / #571 added `windowsHide` on background PowerShell helpers. That is not enough when **Windows Terminal is the default terminal**: `powershell.exe`, `cmd.exe`, and `node.exe` are still console-subsystem binaries, so a GUI parent (Control Center / tray / `wscript`) still gets a visible window.

On a Windows 11 install with WT as default this showed up as:

- an empty PowerShell/Terminal window on every Control Center **Refresh**
- flashes from Task Scheduler (including the one-minute heartbeat while the task was already Running, LastResult `0x800710E0`)
- a persistent console if the scheduled task reached `node.exe` / LiteLLM directly (`DETACHED_PROCESS` made that worse)

`CREATE_NO_WINDOW` via WMI `Win32_ProcessStartup` is rejected (Create status 21). `SW_HIDE` on `WScript.Shell.Run(cmd.exe, 0, True)` still lets WT attach.

## Approach

Background work has to start from a **GUI-subsystem** host. Console children are not hidden reliably once WT owns the default terminal.

| Path | Change |
| --- | --- |
| Control Center Refresh | Spawn `Codex Router.exe` (`process.execPath`) with `ELECTRON_RUN_AS_NODE=1` instead of wrapping Node in `powershell.exe`. Abort still uses `taskkill /T`. |
| `control.mjs` | Skip the nested Job Object wrap when already running as that Electron Node host (`stdio: "inherit"` was forcing `windowsHide: false` and a visible powershell Job owner). |
| Presence | `targetIsActive` reads `SERVICE_PROCESS_STATE_PATH` and `process.kill(pid, 0)` instead of `service.mjs status` → `Get-ScheduledTask` PowerShell. |
| `file-security.mjs` | ACL PowerShell is launched through `pythonw.exe` + `src/windows-job-host.pyw` (`CREATE_NO_WINDOW`). Under `ELECTRON_RUN_AS_NODE` the ACL pass is skipped so Refresh cannot open a console. |
| `process-tree.mjs` | Job invocation prefers `pythonw` when `.venv\Scripts\pythonw.exe` is present; `effectiveWindowsHide` stays true on win32 when stdout is not a TTY. |
| Scheduled task | Generated `winexe` (`csc /target:winexe`, pythonw fallback) starts `node src/start.mjs` with `CreateNoWindow`. VBS no longer runs `cmd.exe`. Heartbeat TimeTrigger removed; logon + `RestartOnFailure` remain. |
| `start.mjs` | `windowsHide: true` on console-subsystem children (node / LiteLLM). |

`src/windows-job-host.pyw` copies child stdout/stderr onto fd 1/2 so a GUI parent can still read JSON. Wrapping Refresh in pythonw alone dropped that pipe and produced `router-control:getPresence: Router returned invalid JSON`.

## Tradeoffs (please read)

1. **Issue #581:** the minute heartbeat was the supervisor for unlogged exits / power events because `RestartOnFailure` does not relaunch after a *started* action exits. Those IgnoreNew ticks still flashed an empty Terminal window. This PR drops the heartbeat so the desktop stays quiet. A started action that later exits will not come back until the next logon or an explicit start — same gap #581 described.
2. **ACL skip in Control Center:** private-file hardening is skipped when `ELECTRON_RUN_AS_NODE=1`. CLI/service paths still run the PowerShell ACL helper (via pythonw when available). Refresh therefore does not re-ACL files it writes.
3. **Presence:** `installed || loaded` is no longer inferred from Task Scheduler. A task that exists but whose pid file is missing/dead reports inactive until the process is up.

## Test

- `node --test test/windows-hidden-consoles.test.mjs test/service-render.test.mjs` — 12 pass, 16 skip (Windows live scheduler cases)
- named Job Object tests in `test/process-tree.test.mjs` and `test/control-center-electron.test.mjs` — 2 pass
- `node scripts-check.mjs` — syntax checks passed
- Full `test/process-tree.test.mjs` / `test/control-center-electron.test.mjs` suites were **not** run here; they hang in this Job Object environment
- Manual: Control Center Refresh on Windows 11 + Windows Terminal default no longer opens a terminal window; presence JSON still returns

Follow-up to #571 / #565. Does not close #581 — it documents accepting that gap to keep the desktop quiet.
