### PR TITLE
fix(tray): size the Standard menu-bar slot to its content

### DIFF
--- a/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
+++ b/apps/macos/ModelRouterTray/Sources/ModelRouterTrayApp.swift
@@ -458,7 +458,10 @@ final class TrayMenuController: NSObject {
 
   init(store: RouterStore) {
     self.store = store
-    let length = MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode)
+    let length = MenuBarLayoutMetrics.statusItemWidth(
+      displayMode: store.menuBarDisplayMode,
+      standardContentWidth: store.menuBarStandardWidth()
+    )
     statusItem = NSStatusBar.system.statusItem(withLength: length)
     let hosting = NSHostingView(rootView: StatusItemLabel(store: store))
     hosting.sizingOptions = []
@@ -476,11 +479,19 @@ final class TrayMenuController: NSObject {
     super.init()
     configureStatusItem()
     configurePanel()
-    displayModeCancellable = store.$menuBarDisplayMode
+    // Standard mode is measured from the label, so the slot has to follow the
+    // provider name, the usage text and the icon style -- not just the display
+    // mode. objectWillChange fires before the store mutates, and hopping to the
+    // main queue lands after it, so the measurement reads the new values.
+    // applyStatusItemMetrics() is a no-op when the width is unchanged.
+    displayModeCancellable = store.objectWillChange
       .receive(on: DispatchQueue.main)
       .sink { [weak self] _ in
         guard let self else { return }
-        self.applyStatusItemMetrics()
+        // Only a slot that actually resized can have moved the panel's anchor.
+        // Repositioning on every store tick would drag AppKit through a window
+        // frame change once a second while the panel is open.
+        guard self.applyStatusItemMetrics() else { return }
         if self.panel.isVisible {
           self.reposition()
         }
@@ -555,11 +566,24 @@ final class TrayMenuController: NSObject {
     panel.setContentSize(TrayPanelPlacement.panelSize)
   }
 
-  private func applyStatusItemMetrics() {
-    let width = MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode)
+  /// Returns whether the slot actually changed size.
+  @discardableResult
+  private func applyStatusItemMetrics() -> Bool {
+    let width = MenuBarLayoutMetrics.statusItemWidth(
+      displayMode: store.menuBarDisplayMode,
+      standardContentWidth: store.menuBarStandardWidth()
+    )
     let height = MenuBarLayoutMetrics.statusItemHeight(displayMode: store.menuBarDisplayMode)
+    // Standard mode is now content-sized, so this runs on every label change,
+    // not just a mode switch. Assigning an unchanged length still makes AppKit
+    // relayout the menu bar, and the activity poll ticks once a second.
+    guard statusItem.length != width
+      || statusHostingView.frame.width != width
+      || statusHostingView.frame.height != height
+    else { return false }
     statusItem.length = width
     statusHostingView.frame = NSRect(x: 0, y: 0, width: width, height: height)
+    return true
   }
 
   @objc private func statusItemClicked(_ sender: Any?) {
@@ -1690,6 +1714,26 @@ final class RouterStore: ObservableObject {
     if names.count == 1 { return names[0] }
     if names.count == 2 { return "\(names[0]) + \(names[1])" }
     return "\(names[0]) +\(names.count - 1)"
+  }
+
+  // The exact strings StatusItemLabel draws. The status item is sized from
+  // these, so the measurement and the render cannot drift apart.
+  var menuBarNameText: String {
+    hasConcurrentActivity ? activitySummaryLabel : selectedUsageProvider.shortName
+  }
+
+  var menuBarDetailText: String {
+    hasConcurrentActivity ? compactActivityProvidersLabel : (selectedUsageText ?? "")
+  }
+
+  func menuBarStandardWidth(pulsing: Bool = false) -> CGFloat {
+    MenuBarLayoutMetrics.standardContentWidth(
+      iconStyle: menuBarIconStyle,
+      showModelName: menuBarShowModelName,
+      nameText: menuBarNameText,
+      detailText: menuBarDetailText,
+      pulsing: pulsing
+    )
   }
 
   var uniqueActiveProviderShortNames: [String] {
@@ -5177,20 +5221,94 @@ struct MenuBarSettings: Equatable {
 }
 
 enum MenuBarLayoutMetrics {
-  static let standardReservedWidth: CGFloat = 180
+  // A cap, not a reservation. Standard mode used to hand this width back for
+  // every state, so a short label -- or a hidden model name -- left the unused
+  // remainder as blank menu-bar space before the next item. The slot is now
+  // measured from what is actually drawn and only clamped here, which keeps
+  // long labels truncating exactly as they did.
+  static let standardMaximumWidth: CGFloat = 180
+  // Below this the item is too small to be a comfortable click target, and an
+  // icon that touches both edges reads as clipped rather than compact.
+  static let standardMinimumWidth: CGFloat = 30
   static let standardHeight: CGFloat = 22
   static let standardIconSize: CGFloat = 15
+  // The indicator style draws a 6pt dot instead of the 15pt mark.
+  static let standardIndicatorSize: CGFloat = 6
+  // Mirrors the HStack spacing and the breathing room the fixed slot used to
+  // provide incidentally; measuring has to agree with StatusItemLabel or the
+  // text clips one glyph early.
+  static let standardContentSpacing: CGFloat = 5
+  static let standardHorizontalInset: CGFloat = 6
   static let iconOnlyWidth: CGFloat = standardHeight
   static let iconOnlyHeight: CGFloat = 22
   static let iconOnlyIconSize: CGFloat = standardIconSize
   static let attentionPulseScale: CGFloat = 1.4
   static let standardIndicatorPulseScale: CGFloat = 2.1
 
-  nonisolated static func statusItemWidth(
-    displayMode: TrayMenuBarDisplayMode,
+  // SwiftUI renders these with `.system(size:weight:design:)`; measuring with a
+  // different face would size the slot for text the menu bar never draws.
+  nonisolated static func standardNameFont() -> NSFont {
+    let base = NSFont.systemFont(ofSize: 11, weight: .medium)
+    guard let descriptor = base.fontDescriptor.withDesign(.rounded),
+      let rounded = NSFont(descriptor: descriptor, size: 11)
+    else { return base }
+    return rounded
+  }
+
+  nonisolated static func standardDetailFont() -> NSFont {
+    NSFont.monospacedSystemFont(ofSize: 10, weight: .medium)
+  }
+
+  nonisolated static func standardTextWidth(_ text: String, font: NSFont) -> CGFloat {
+    guard !text.isEmpty else { return 0 }
+    return ceil((text as NSString).size(withAttributes: [.font: font]).width)
+  }
+
+  /// The width Standard mode needs for the content it is about to draw, capped
+  /// at `standardMaximumWidth` so an overlong label still truncates instead of
+  /// pushing every other menu-bar item aside.
+  nonisolated static func standardContentWidth(
+    iconStyle: TrayMenuBarIconStyle,
+    showModelName: Bool,
+    nameText: String,
+    detailText: String,
     pulsing: Bool = false
   ) -> CGFloat {
-    guard displayMode == .iconOnly else { return standardReservedWidth }
+    var segments: [CGFloat] = [standardLeadingGlyphWidth(iconStyle: iconStyle, pulsing: pulsing)]
+    if showModelName, !nameText.isEmpty {
+      segments.append(standardTextWidth(nameText, font: standardNameFont()))
+    }
+    if !detailText.isEmpty {
+      segments.append(standardTextWidth(detailText, font: standardDetailFont()))
+    }
+    let spacing = standardContentSpacing * CGFloat(max(0, segments.count - 1))
+    let content = segments.reduce(0, +) + spacing + standardHorizontalInset * 2
+    return min(standardMaximumWidth, max(standardMinimumWidth, ceil(content)))
+  }
+
+  // A pulse scales the glyph in place. The slot has to grow with it or the
+  // animation is clipped against its own status item.
+  nonisolated static func standardLeadingGlyphWidth(
+    iconStyle: TrayMenuBarIconStyle,
+    pulsing: Bool
+  ) -> CGFloat {
+    if iconStyle == .indicator {
+      let size = pulsing ? standardIndicatorSize * standardIndicatorPulseScale : standardIndicatorSize
+      return ceil(size)
+    }
+    let size = pulsing ? standardIconSize * attentionPulseScale : standardIconSize
+    return ceil(size)
+  }
+
+  nonisolated static func statusItemWidth(
+    displayMode: TrayMenuBarDisplayMode,
+    pulsing: Bool = false,
+    standardContentWidth: CGFloat? = nil
+  ) -> CGFloat {
+    // No measurement supplied means the caller cannot know the label yet, so
+    // fall back to the historical full slot rather than guessing small and
+    // clipping.
+    guard displayMode == .iconOnly else { return standardContentWidth ?? standardMaximumWidth }
     guard pulsing else { return iconOnlyWidth }
     let iconWidth = iconOnlyIconSize * attentionPulseScale
     return max(iconOnlyWidth, ceil(iconWidth))
@@ -5492,12 +5610,18 @@ private struct StatusItemLabel: View {
         }
       }
       .frame(
-        width: MenuBarLayoutMetrics.statusItemWidth(displayMode: store.menuBarDisplayMode, pulsing: pulsing),
+        width: MenuBarLayoutMetrics.statusItemWidth(
+          displayMode: store.menuBarDisplayMode,
+          pulsing: pulsing,
+          standardContentWidth: store.menuBarStandardWidth(pulsing: pulsing)
+        ),
         height: MenuBarLayoutMetrics.statusItemHeight(
           displayMode: store.menuBarDisplayMode,
           pulsing: pulsing
         ),
-        alignment: .leading
+        // The slot is measured from this content now, so centring it keeps the
+        // inset even on both sides instead of banking it all as a trailing gap.
+        alignment: .center
       )
       .clipped()
       .help(tooltipText)

--- a/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
+++ b/apps/macos/ModelRouterTray/Tests/MenuBarSettingsTests.swift
@@ -188,21 +188,87 @@ struct MenuBarSettingsTests {
     #expect(settings.customIconPath == nil)
   }
 
-  @Test("standard mode keeps a reserved width even when the name is hidden")
-  func standardWidthIsReserved() {
+  @Test("standard mode sizes to its content instead of reserving the full slot")
+  func standardWidthTracksContent() {
     #expect(MenuBarLayoutMetrics.standardIconSize == 15)
     #expect(MenuBarLayoutMetrics.iconOnlyIconSize == MenuBarLayoutMetrics.standardIconSize)
-    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard) == 180)
-    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .iconOnly) == 22)
     #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .standard) == 22)
     #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .iconOnly) == 22)
+    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .iconOnly) == 22)
+
+    // Hiding the model name is the case issue #646 called out: the slot used to
+    // stay 180 points wide around a single 15pt mark.
+    let iconOnlyContent = MenuBarLayoutMetrics.standardContentWidth(
+      iconStyle: .router,
+      showModelName: false,
+      nameText: "Sonnet",
+      detailText: ""
+    )
+    #expect(iconOnlyContent < MenuBarLayoutMetrics.standardMaximumWidth)
+    #expect(iconOnlyContent >= MenuBarLayoutMetrics.standardMinimumWidth)
+
+    // A short label must still be narrower than a long one.
+    let short = MenuBarLayoutMetrics.standardContentWidth(
+      iconStyle: .router,
+      showModelName: true,
+      nameText: "GPT",
+      detailText: ""
+    )
+    let long = MenuBarLayoutMetrics.standardContentWidth(
+      iconStyle: .router,
+      showModelName: true,
+      nameText: "Claude Opus 4.1 Extended Thinking",
+      detailText: "88% · 4h"
+    )
+    #expect(short > iconOnlyContent)
+    #expect(long > short)
+
+    // ...and an overlong one still truncates rather than growing without bound.
+    #expect(long == MenuBarLayoutMetrics.standardMaximumWidth)
+    #expect(
+      MenuBarLayoutMetrics.statusItemWidth(
+        displayMode: .standard,
+        standardContentWidth: long
+      ) == MenuBarLayoutMetrics.standardMaximumWidth
+    )
+
+    // A caller that cannot measure yet keeps the historical full slot.
+    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard) == 180)
+  }
+
+  @Test("the indicator style measures its dot, not the full mark")
+  func indicatorStyleMeasuresTheDot() {
+    let indicator = MenuBarLayoutMetrics.standardContentWidth(
+      iconStyle: .indicator,
+      showModelName: true,
+      nameText: "GPT",
+      detailText: ""
+    )
+    let mark = MenuBarLayoutMetrics.standardContentWidth(
+      iconStyle: .router,
+      showModelName: true,
+      nameText: "GPT",
+      detailText: ""
+    )
+    #expect(indicator < mark)
+    // A pulse scales the glyph in place, so the slot has to grow with it.
+    let pulsing = MenuBarLayoutMetrics.standardContentWidth(
+      iconStyle: .indicator,
+      showModelName: true,
+      nameText: "GPT",
+      detailText: "",
+      pulsing: true
+    )
+    #expect(pulsing > indicator)
   }
 
   @Test("the icon-only mark stays inside the native square during a pulse")
   func iconOnlyPulseKeepsScaledContentInsideBounds() {
     #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .iconOnly, pulsing: true) == 22)
     #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .iconOnly, pulsing: true) == 22)
-    #expect(MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard, pulsing: true) == 180)
+    #expect(
+      MenuBarLayoutMetrics.statusItemWidth(displayMode: .standard, pulsing: true) == 180
+    )
     #expect(MenuBarLayoutMetrics.statusItemHeight(displayMode: .standard, pulsing: true) == 22)
   }
 


### PR DESCRIPTION
Fixes #646.

## Problem

`standardReservedWidth` was a flat 180 points and every Standard-mode state returned it. The label was drawn `.leading` inside that fixed frame, so whenever the content was shorter — a short provider name, or **Show model name** off, which leaves a single 15pt mark — the unused remainder showed up as a conspicuous blank gap before the next menu-bar item. The mode looked padded or broken, and it consumed far more of the menu bar than it drew.

## Change

The slot is measured from exactly what `StatusItemLabel` is about to draw:

- the leading glyph — 6pt dot for the `indicator` style, 15pt mark otherwise, scaled when a pulse is running so the animation is not clipped against its own status item;
- the model name in its rounded 11pt face and the usage text in its monospaced 10pt face, measured with the same `.system(size:weight:design:)` faces SwiftUI renders, so the measurement cannot size for text the menu bar never draws;
- the `HStack` spacing plus an even horizontal inset.

`standardMaximumWidth` (still 180) becomes a **cap rather than a reservation**, so an overlong label truncates exactly as it did instead of pushing the rest of the bar aside. `standardMinimumWidth` keeps the item a comfortable click target. The content is centred now that the frame fits it, rather than banking the slack as a trailing gap.

`statusItemWidth(displayMode:pulsing:standardContentWidth:)` falls back to the historical full slot when no measurement is supplied, so a caller that cannot know the label yet sizes large rather than clipping.

## Not regressing the tray's cost

The width now follows the label, so the controller can no longer resize on display-mode changes alone — it observes the store. To keep that from becoming the sort of per-tick work recently removed from this panel:

- `applyStatusItemMetrics()` returns whether the slot actually moved and exits early when it did not, so the once-a-second activity tick does not drag AppKit through a menu-bar relayout;
- the open panel is repositioned only when its anchor genuinely changed.

## Tests

`MenuBarSettingsTests` pinned the old behavior (`statusItemWidth(displayMode: .standard) == 180`, explicitly "even when the name is hidden"). Replaced with coverage of the new contract: hiding the name is narrower than the cap, a short label is narrower than a long one, an overlong label still clamps to 180, the indicator style measures its dot rather than the full mark, and a pulse grows the slot. The unmeasured fallback is still asserted at 180.

Full tray suite: **128 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)