### PR TITLE
test(doctor): isolate fixture doctor runs from the machine's real service

### DIFF
--- a/test/doctor-routing-mode.test.mjs
+++ b/test/doctor-routing-mode.test.mjs
@@ -50,12 +50,15 @@ esac
 function child(script, args, env) {
   const childEnv = {
     ...env,
-    // This test redirects Codex/router state, but Windows service status reads
-    // the machine-wide Task Scheduler. A developer with the real router
-    // running would otherwise make fixture doctor calls wait on the live task.
-    ...(process.platform === "win32" && script === "doctor.mjs"
-      ? { CODEX_ROUTER_SERVICE_PLATFORM: "test-fixture" }
-      : {}),
+    // This test redirects Codex/router state, but service status is read from
+    // the machine, not from that state: launchd on macOS, systemd on Linux and
+    // Task Scheduler on Windows all answer for the developer's real install.
+    // A maintainer with the router running therefore made the fixture report a
+    // loaded service, and doctor waits 30s rather than 2s for a router that
+    // will never appear on the fixture's port -- past this child's own bound,
+    // leaving empty stdout for the JSON parse below. CI has no service
+    // installed, so it only ever reproduced locally.
+    ...(script === "doctor.mjs" ? { CODEX_ROUTER_SERVICE_PLATFORM: "test-fixture" } : {}),
   };
   return spawnSync(process.execPath, [path.join(root, "src", script), ...args], {
     cwd: root,


### PR DESCRIPTION
Found while auditing local test failures. These two tests fail on any developer machine with the router installed, and pass in CI — which is why they have gone unnoticed.

## Diagnosis

`test/doctor-routing-mode.test.mjs` redirects `CODEX_HOME` and both state directories, but the **Background service** check reads the machine, not that state. `launchctl list` reports the developer's real `io.github.codex-router` job, so the fixture believes a service is loaded.

`doctor.mjs:1505` then waits:

```js
const health = await waitForRouterHealth({ timeoutMs: serviceLoaded ? 30_000 : 2_000 });
```

…30 seconds for a router that will never appear on the fixture's dead port 46192. The `child()` helper bounds the subprocess at 20 s, so the child is killed, `doctor.stdout` is empty, and the `JSON.parse` below it throws:

```
SyntaxError: Unexpected end of JSON input
    at test/doctor-routing-mode.test.mjs:157:27
```

An error that names neither the service nor the timeout, which is what makes this expensive to chase.

## Measured on the fixture

| condition | `doctor --json` |
|---|---|
| router reachable (live port) | **2 s** |
| router unreachable, real service visible | **31 s** ← over the 20 s child bound |
| router unreachable, service lookup stubbed | **4 s** |

Diffing the two runs' check lists shows exactly one difference — `Router health`, ok vs fail — confirming the whole delta is that one wait.

## Fix

The helper already guarded this hazard, but only for Windows and Task Scheduler:

```js
...(process.platform === "win32" && script === "doctor.mjs" ? ... : {})
```

launchd and systemd leak in exactly the same way, so the guard applies on every platform. Both tests now pass locally (13.1 s and 10.0 s, inside the bound).

No other test shares the mistake: `doctor-vision-status.test.mjs` pins the *opposite* platform, which isolates correctly everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)