### PR TITLE
feat(opencode): add DeepSeek V4.1 Flash support

### DIFF
--- a/config/opencode/go/deepseek-flash.json
+++ b/config/opencode/go/deepseek-flash.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "opencode-go/deepseek-flash",
+      "gatewayModel": "opencode-go-deepseek-flash",
+      "upstreamModel": "deepseek-flash",
+      "provider": "opencode-go",
+      "listed": true,
+      "displayName": "DeepSeek V4.1 Flash (opencode Go)",
+      "description": "DeepSeek V4.1 Flash through the opencode Go subscription, with image input and low/high/max reasoning.",
+      "priority": 37,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning depth"
+        }
+      ],
+      "contextWindow": 1000000,
+      "autoCompact": 600000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "requestProfile": "auto-tool-choice",
+      "compHash": "opencode-go-deepseek-flash-v1"
+    }
+  ]
+}

--- a/docs/research/opencode-deepseek-v4-1-flash.md
+++ b/docs/research/opencode-deepseek-v4-1-flash.md
@@ -1,0 +1,13 @@
+# DeepSeek V4.1 Flash on OpenCode Go
+
+Verified 2026-09-10:
+
+- OpenCode's [Go endpoint table](https://opencode.ai/docs/go/#endpoints) names `deepseek-flash` as DeepSeek V4.1 Flash and routes it to `/zen/go/v1/chat/completions`. This is a separate ID from `deepseek-v4-flash`.
+- Read-only `node src/model-discovery.mjs opencode-go` returned the new ID.
+- The `opencode-go.models.deepseek-flash` record in [models.dev](https://models.dev/api.json) publishes text/image input, tool calls, interleaved `reasoning_content`, low/high/max effort, a 1,000,000-token context and a 384,000-token output limit. Auto-compaction at 600,000 reserves 400,000 tokens; copying V4 Flash's 900,000 threshold would not reserve the documented output limit.
+- A live Chat Completions request at low effort with `tool_choice: required` returned HTTP 400: thinking mode does not support that choice. The same probe with `auto` returned HTTP 200 and a `probe` tool call with the requested `{"value":"ok"}` arguments. The model therefore uses the existing model-scoped `auto-tool-choice` profile.
+
+- A live image-input request using the repository's synthetic invoice fixture returned HTTP 200 and the exact invoice number `INV-7734-QX`.
+- Live streaming requests at both high and max effort returned HTTP 200 and the requested response marker. Together with the low-effort tool and image probes, all three advertised effort values were accepted.
+
+Native Codex collaboration certification is not claimed; the entry omits `multiAgentVersion: v2`. Existing V4 Flash remains available. No service lifecycle change is needed to develop or run the isolated regression tests.

--- a/src/opencode-curation.mjs
+++ b/src/opencode-curation.mjs
@@ -242,6 +242,7 @@ const CURATION_ROUTES = Object.freeze({
       "muse-spark-1.3-contributor",
     ]),
     primaryModels: Object.freeze([
+      "deepseek-flash",
       "deepseek-v4-flash",
       "deepseek-v4-flash-vision-exp",
       "deepseek-v4-pro",

--- a/test/model-discovery.test.mjs
+++ b/test/model-discovery.test.mjs
@@ -270,6 +270,7 @@ test("the current OpenCode catalogs remain fully fetchable without preselecting 
 
 test("the checked-in OpenCode Go set matches the official current-model table", () => {
   const documented = [
+    "deepseek-flash",
     "deepseek-v4-flash", "deepseek-v4-flash-vision-exp", "deepseek-v4-pro", "glm-5", "glm-5.1", "glm-5.2", "glm-5.3", "glm-5.3-flash",
     "gpt-5.6-luna", "grok-4.5", "grok-4.6", "hy3", "hy4-preview", "kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code", "kimi-k3", "longcat-2.0",
     "mimo-v2.5", "mimo-v2.5-pro", "minimax-m2.5", "minimax-m2.7", "minimax-m3",

--- a/test/opencode-deepseek-flash.test.mjs
+++ b/test/opencode-deepseek-flash.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { MODEL_BY_SLUG, PROVIDERS } from "../src/model-registry.mjs";
+import { routedModel } from "../src/catalog.mjs";
+import { curatedModelBlockReason, curatedModelProviderId } from "../src/opencode-curation.mjs";
+
+test("DeepSeek V4.1 Flash publishes the documented Go route and capabilities", () => {
+  const model = MODEL_BY_SLUG.get("opencode-go/deepseek-flash");
+  assert.ok(model);
+  assert.equal(model.upstreamModel, "deepseek-flash");
+  assert.equal(model.gatewayModel, "opencode-go-deepseek-flash");
+  assert.equal(model.provider, "opencode-go");
+  assert.equal(PROVIDERS.get(model.provider).protocol, undefined);
+  assert.equal(model.listed, true);
+  assert.equal(model.contextWindow, 1_000_000);
+  assert.ok(model.contextWindow - model.autoCompact >= 384_000);
+  assert.deepEqual(model.inputModalities, ["text", "image"]);
+  assert.deepEqual(model.reasoningLevels.map(({ effort }) => effort), ["low", "high", "max"]);
+  assert.equal(model.requestProfile, "auto-tool-choice");
+  assert.notEqual(model.multiAgentVersion, "v2");
+  assert.equal(curatedModelProviderId("opencode-go", "deepseek-flash"), "opencode-go");
+  assert.equal(curatedModelBlockReason("opencode-go", "deepseek-flash"), undefined);
+  assert.ok(curatedModelBlockReason("opencode-go", "unverified-future-deepseek"));
+  const published = routedModel({ slug: "gpt-5.5" }, model);
+  assert.equal(published.display_name, "DeepSeek V4.1 Flash (opencode Go)");
+  assert.equal(published.context_window, 1_000_000);
+  assert.deepEqual(published.input_modalities, ["text", "image"]);
+  assert.equal(MODEL_BY_SLUG.get("opencode-go/deepseek-v4-flash").upstreamModel, "deepseek-v4-flash");
+});

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -152,6 +152,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "ollama-cloud/kimi-k2.7-code",
       "ollama-cloud/kimi-k3",
       "ollama-cloud/minimax-m3",
+      "opencode-go/deepseek-flash",
       "opencode-go/deepseek-v4-flash-vision-exp",
       "opencode-go/deepseek-v4-flash",
       "opencode-go/deepseek-v4-pro",

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -7283,6 +7283,7 @@ test("router normalizes forced tool choices before LiteLLM for auto-tool-choice 
     // LiteLLM does its Responses -> Chat Completions translation after the
     // router, so this must already be auto when it reaches the gateway.
     for (const [slug, gatewayModel] of [
+      ["opencode-go/deepseek-flash", "opencode-go-deepseek-flash"],
       ["ollama-cloud/minimax-m3", "ollama-cloud-minimax-m3"],
       ["commandcode/muse-spark-1.2", "commandcode-muse-spark-1-2"],
       [


### PR DESCRIPTION
OpenCode Go now documents DeepSeek V4.1 Flash as `deepseek-flash`, but the router does not list it and discovery blocks it as an unverified protocol. Add the separate `opencode-go/deepseek-flash` route using the documented Chat Completions endpoint, preserving V4 Flash.

The entry publishes text/image input and low/high/max effort. Its 1,000,000-token context compacts at 600,000 to reserve the documented 384,000-token output allowance. Live testing confirmed that forced tool choice returns HTTP 400 while `auto` calls the requested tool, so this model uses the existing model-scoped `auto-tool-choice` profile.

Validation:
- `npm run check` passed.
- Registry, curation, and model/picker suites: 89 passed; focused router-to-gateway forced-tool integration passed.
- Final discovery and desktop suites: 30 passed, 1 browser test skipped because Chromium is unavailable.
- Live OpenCode Go: low-effort tool call and image reading passed; high/max streaming markers passed.
- Full `npm test` completed: 3,561 passed, 108 skipped, 15 failed. The missing discovery snapshot was corrected and passed on rerun. Three dependency-related failures (Antigravity onboarding, desktop panel, exact-slug search transport) passed after installing the worktree dependencies. The remaining 11 failures are Windows symlink-permission errors (9) and legacy-migration path handling (2); the symlink restriction and both migration failures were reproduced on unchanged upstream. The full suite is therefore not green on this host.

Capability sources and probe evidence are recorded in `docs/research/opencode-deepseek-v4-1-flash.md`, including the official Go endpoint table and models.dev record. Native Codex collaboration certification is not claimed, and no v2 promotion is added. The installed router service was not changed or restarted.
