### PR TITLE
feat(deepseek): add DeepSeek V4.1 Flash direct API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Linux installations support the Codex CLI.
 | Kimi K3 (China API) | `kimi-api-cn/kimi-k3` | Separately billed Moonshot **China** platform key |
 | DeepSeek V4 Flash (API) | `deepseek/deepseek-v4-flash` | DeepSeek API key |
 | DeepSeek V4 Pro (API) | `deepseek/deepseek-v4-pro` | DeepSeek API key |
+| DeepSeek V4.1 Flash (API) | `deepseek/deepseek-flash` | DeepSeek API key |
 | Grok 4.5 (OAuth) | `grok-oauth/grok-4.5` | Official Grok CLI OAuth session |
 | Grok 4.5 (API) | `grok-api/grok-4.5` | Separately billed xAI API key |
 | Claude Opus 4.8 (API) | `anthropic-api/claude-opus-4.8` | Separately billed Anthropic API key |

--- a/config/deepseek/deepseek-v4.1-flash.json
+++ b/config/deepseek/deepseek-v4.1-flash.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "deepseek/deepseek-flash",
+      "gatewayModel": "deepseek-flash",
+      "upstreamModel": "deepseek-flash",
+      "provider": "deepseek",
+      "listed": true,
+      "displayName": "DeepSeek V4.1 Flash (API)",
+      "description": "DeepSeek V4.1 Flash through the official DeepSeek API. The live catalog exposes the model ID but not capability metadata, so Codex uses conservative text-only sizing and a live-verified non-thinking profile for tool-compatible stateless turns.",
+      "priority": 8,
+      "defaultEffort": "minimal",
+      "reasoningLevels": [
+        {
+          "effort": "minimal",
+          "description": "Tool-compatible non-thinking mode"
+        }
+      ],
+      "contextWindow": 131072,
+      "autoCompact": 110000,
+      "inputModalities": [
+        "text"
+      ],
+      "requestProfile": "deepseek-nonthinking",
+      "compHash": "deepseek-flash-v1"
+    }
+  ]
+}

--- a/docs/research/deepseek-v4-1-flash-api.md
+++ b/docs/research/deepseek-v4-1-flash-api.md
@@ -1,0 +1,39 @@
+# DeepSeek V4.1 Flash direct API — 2026-09-10
+
+## Sources
+
+- DeepSeek model-list contract: https://api-docs.deepseek.com/api/list-models/
+- DeepSeek API quick start: https://api-docs.deepseek.com/
+- DeepSeek model details and pricing: https://api-docs.deepseek.com/quick_start/pricing/
+- DeepSeek Responses API integration: https://api-docs.deepseek.com/quick_start/agent_integrations/codex/
+- DeepSeek API change log: https://api-docs.deepseek.com/updates/
+
+## Findings
+
+The configured DeepSeek API account's live `/models` response included the
+model ID `deepseek-flash` on 2026-09-10. The public documentation currently
+describes the same V4 Flash API family as `deepseek-v4-flash`; the existing
+`deepseek/deepseek-v4-flash` route is therefore preserved rather than renamed.
+This fragment adds only the live ID and does not infer a second provider or
+replace the documented route.
+
+DeepSeek documents an OpenAI-compatible base URL at
+`https://api.deepseek.com`, Responses API support, tool calls, and a V4 Flash
+context/output envelope of 1M/384K. The live `deepseek-flash` catalog record
+does not expose capability metadata, so the checked-in route deliberately uses
+conservative text-only 131,072-token sizing and reserves 21,072 tokens for
+output compaction instead of copying undocumented limits onto the new ID.
+
+The exact route was exercised through the router with the stored provider
+credential and failover disabled. Basic response, streaming, forced tool
+call, stateless tool-result replay, and compaction all returned HTTP 200.
+Thinking mode was also probed: its stateless tool-result replay returned HTTP
+400 because the upstream required `reasoning_content` to be echoed. The route
+therefore uses the existing `deepseek-nonthinking` request profile and exposes
+only the `minimal` effort. No image input, standalone search, native v2
+subagent certification, or reasoning-summary capability is claimed.
+
+The filename `deepseek-v4.1-flash.json` sorts after the existing
+`deepseek-v4-*` fragments. That preserves the established login-free fallback
+on `deepseek/deepseek-v4-flash` while making the live `deepseek-flash` ID
+available as a separate picker entry.

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1546,6 +1546,7 @@ test(
       const visibility = new Map(
         merged.models.map((model) => [String(model.slug), model.visibility]),
       );
+      assert.equal(visibility.get("deepseek/deepseek-flash"), "list");
       assert.equal(visibility.get("deepseek/deepseek-v4-flash"), "list");
       assert.equal(visibility.get("deepseek/deepseek-v4-flash-vision-exp"), "list");
       assert.equal(visibility.get("deepseek/deepseek-v4-pro"), "hide");
@@ -1555,6 +1556,7 @@ test(
         readFileSync(path.join(stateDir, "model-picker.json"), "utf8"),
       );
       assert.deepEqual(picker.visible, [
+        "deepseek/deepseek-flash",
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-vision-exp",
       ]);

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -698,6 +698,7 @@ test("login-free control selects a ready external model and restores Codex defau
         ["deepseek/deepseek-v4-flash", "hide"],
         ["deepseek/deepseek-v4-flash-vision-exp", "list"],
         ["deepseek/deepseek-v4-pro", "list"],
+        ["deepseek/deepseek-flash", "list"],
       ],
     );
     const aliases = JSON.parse(readFileSync(path.join(stateDir, "native-aliases.json"), "utf8"));

--- a/test/model-discovery.test.mjs
+++ b/test/model-discovery.test.mjs
@@ -29,7 +29,13 @@ test("model discovery compares fixtures without needing or exposing a key", () =
   const fixture = path.join(testRoot, "models.json");
   writeFileSync(
     fixture,
-    JSON.stringify({ data: [{ id: "deepseek-v4-pro" }, { id: "deepseek-v5-preview" }] }),
+    JSON.stringify({
+      data: [
+        { id: "deepseek-flash" },
+        { id: "deepseek-v4-pro" },
+        { id: "deepseek-v5-preview" },
+      ],
+    }),
   );
   try {
     const output = execFileSync(
@@ -41,6 +47,7 @@ test("model discovery compares fixtures without needing or exposing a key", () =
     assert.deepEqual(result.unregistered, ["deepseek-v5-preview"]);
     assert.deepEqual(result.addable, ["deepseek-v5-preview"]);
     assert.deepEqual(result.blocked, {});
+    assert.ok(result.registered.includes("deepseek-flash"));
     assert.ok(result.unavailable.includes("deepseek-v4-flash"));
     assert.doesNotMatch(output, /Bearer|api[_-]?key/i);
   } finally {

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -105,6 +105,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-vision-exp",
         "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-flash",
       ],
     );
     assert.deepEqual(
@@ -113,6 +114,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-vision-exp",
         "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-flash",
       ],
     );
 
@@ -275,6 +277,7 @@ test("an unknown provider id in the selection file is filtered out, not fatal", 
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-vision-exp",
         "deepseek/deepseek-v4-pro",
+        "deepseek/deepseek-flash",
       ],
     );
     // Doctor and the support bundle read through this, so the damage is

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -98,6 +98,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "deepseek/deepseek-v4-flash",
       "deepseek/deepseek-v4-flash-vision-exp",
       "deepseek/deepseek-v4-pro",
+      "deepseek/deepseek-flash",
       "grok-api/grok-4.5",
       "grok-oauth/grok-4.5",
       "grok-oauth/grok-4.6",
@@ -774,6 +775,25 @@ test("DeepSeek V4 Flash Vision Exp advertises only verified direct-API capabilit
   assert.deepEqual(model.searchTool, { mode: "standalone" });
   assert.equal(model.supportsReasoningSummaries, true);
   assert.equal(endpointForModel(model), PROVIDERS.get("deepseek"));
+  assert.ok(API_MODELS.includes(model));
+});
+
+test("DeepSeek V4.1 Flash exposes only conservative, live-verified direct-API capabilities", () => {
+  const model = MODEL_BY_SLUG.get("deepseek/deepseek-flash");
+  assert.ok(model);
+  assert.equal(model.provider, "deepseek");
+  assert.equal(model.gatewayModel, "deepseek-flash");
+  assert.equal(model.upstreamModel, "deepseek-flash");
+  assert.equal(model.listed, true);
+  assert.equal(model.requestProfile, "deepseek-nonthinking");
+  assert.equal(model.defaultEffort, "minimal");
+  assert.deepEqual(model.reasoningLevels, [
+    { effort: "minimal", description: "Tool-compatible non-thinking mode" },
+  ]);
+  assert.equal(model.contextWindow, 131072);
+  assert.equal(model.autoCompact, 110000);
+  assert.deepEqual(model.inputModalities, ["text"]);
+  assert.equal(model.searchTool, undefined);
   assert.ok(API_MODELS.includes(model));
 });
 


### PR DESCRIPTION
## Summary

- add the live `deepseek/deepseek-flash` route through the official DeepSeek API
- preserve the existing `deepseek/deepseek-v4-flash` route and login-free fallback
- keep the new route conservative: text-only, non-thinking, and no native-v2 claim
- document the live API evidence and add registry/catalog/discovery regression coverage

This PR intentionally covers the official DeepSeek API only. OpenCode Go support
is already being handled separately in #679.

## Evidence

The configured DeepSeek API account's live `/models` response exposed
`deepseek-flash` on 2026-09-10. DeepSeek's public documentation currently
describes the same V4 Flash family under `deepseek-v4-flash`, so this adds the
live ID without renaming or replacing the existing documented route.

Official sources:

- https://api-docs.deepseek.com/api/list-models/
- https://api-docs.deepseek.com/
- https://api-docs.deepseek.com/quick_start/pricing/
- https://api-docs.deepseek.com/quick_start/agent_integrations/codex/
- https://api-docs.deepseek.com/updates/

The exact route was exercised through the router with the stored provider
credential and failover disabled. Basic response, streaming, forced tool call,
stateless tool-result replay, and compaction returned HTTP 200. Thinking mode's
stateless tool-result replay returned HTTP 400 because the upstream required
`reasoning_content` to be echoed, so the route uses the existing
`deepseek-nonthinking` profile and exposes only `minimal` effort.

## Validation

- `npm run check` passed.
- Focused registry, catalog, control, provider-selection, and discovery suite:
  **173 passed, 0 failed**.
- `git diff --check` passed.
- The full `npm test` wrapper was attempted but produced no output for five
  minutes on this host and was stopped; no full-suite pass is claimed.

No credentials, Codex settings, installed router service, or Codex process were
changed.
