### PR TITLE
fix: restore client-declared native tool identities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1944,6 +1944,14 @@ retry rules on the shared path.
   is not delivered. Flatten namespaces/deferred tools through the existing
   adapters; retain native top-level `apply_patch` and bridge other custom tools.
   Restore exact namespace/name identities, including plain-name collisions.
+- Codex can flatten native and MCP function/custom declarations before sending
+  them to a routed provider. Restore namespaces only for live, directly exposed
+  tools identified by the request's canonical turn metadata, and only on routes
+  that flatten tools. Responses-native routes that skip flattening retain the
+  client's declaration shape. Restore before app expansion and normal flattening
+  so client schemas, custom formats and collaboration model constraints use the
+  existing adapters. Never infer tools from name prefixes or create declarations
+  from metadata alone; ambiguous and ordinary-name collisions remain unchanged.
 - GLM thinking, legacy DeepSeek thinking and Command Code's DeepSeek Flash Chat
   route carry reasoning through LiteLLM as assistant `thinking` parts, restored
   by the forwarder to `reasoning_content`. Remove only successfully carried

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -297,7 +297,30 @@ export function bridgeCustomTools(
   }
   const requested = new Set(names);
   const shouldBridge = (name) => bridgeAll || requested.has(name);
-  const identityOf = (reference) => CUSTOM_TOOL_IDENTITIES.get(reference) || {
+  // Stored custom calls may use the client's already-flat spelling. Resolve
+  // only exact live definitions, before registering history or forced choices,
+  // so they share the declaration's identity and bounded provider alias.
+  const customWireIdentities = new Map();
+  const otherWireNames = new Set();
+  for (const tool of Array.isArray(tools) ? tools : []) {
+    const native = CUSTOM_TOOL_IDENTITIES.get(tool);
+    if (native) {
+      const wireName = `${native.namespace}${NAMESPACE_DELIMITER}${native.name}`;
+      const previous = customWireIdentities.get(wireName);
+      customWireIdentities.set(wireName,
+        !customWireIdentities.has(wireName) ||
+        (previous?.namespace === native.namespace && previous?.name === native.name)
+          ? native : undefined);
+    } else {
+      const name = providerFunctionName(tool);
+      const original = NAME_ALIASES.get(namespaces)?.providerToNative.get(name);
+      otherWireNames.add(original?.namespace === undefined ? original?.name ?? name
+        : `${original.namespace}${NAMESPACE_DELIMITER}${original.name}`);
+    }
+  }
+  const identityOf = (reference) => CUSTOM_TOOL_IDENTITIES.get(reference) ||
+    (reference.namespace === undefined && !otherWireNames.has(reference.name)
+      ? customWireIdentities.get(reference.name) : undefined) || {
     name: reference.name,
     ...(typeof reference.namespace === "string" && reference.namespace
       ? { namespace: reference.namespace } : {}),
@@ -1073,7 +1096,8 @@ export function flattenNamespaceTools(
         );
         names.add(fn.name);
         if (tool.name === "collaboration" && fn.name === "spawn_agent") {
-          schemaStringValues(fn.inputSchema?.properties?.model, spawnAgentModels);
+          const schema = fn.parameters ?? fn.inputSchema;
+          schemaStringValues(schema?.properties?.model, spawnAgentModels);
         }
       }
       if (names.size > 0) {
@@ -1105,188 +1129,123 @@ export function flattenNamespaceTools(
   return { tools: flattened, flattened: changed, namespaces };
 }
 
-// A Codex custom-provider request can arrive with MCP tools already
-// flattened. In that shape the tool list no longer contains a
-// `type: "namespace"` entry, so flattenNamespaceTools cannot build the reverse
-// map needed when the provider returns the ordinary function call. Codex keeps
-// the canonical native identities in its reserved turn metadata. Recover only
-// direct functions whose exact flattened spelling is present in this request.
-//
-// The metadata also inventories ordinary functions under the default
-// `functions` namespace. Treat that entry, and any delimiter collision between
-// two native identities, as ambiguous rather than reinterpreting a legitimate
-// plain function as an MCP call. Keep this recovery MCP-scoped: app and
-// collaboration tools carry additional router-side behavior that a bare name
-// map cannot reconstruct safely.
-export function recoverPreflattenedMcpTools(tools, clientMetadata, namespaces) {
-  if (!Array.isArray(tools) || !(namespaces instanceof Map)) return false;
+// Codex may flatten native function/custom names before sending a custom-provider
+// request. Recover only declarations backed by its canonical turn metadata, then
+// let the normal namespace pipeline handle aliases, schemas, custom tools and
+// response restoration. Metadata alone must never add an executable tool.
+export function restorePreflattenedToolNamespaces(tools, clientMetadata) {
+  if (!Array.isArray(tools)) return tools;
   const encoded = clientMetadata?.["x-codex-turn-metadata"];
-  if (typeof encoded !== "string") return false;
-  if (!jsonIsUnambiguousForRewrite(encoded, { allowLossyNumbers: true })) return false;
+  if (typeof encoded !== "string" ||
+      !jsonIsUnambiguousForRewrite(encoded, { allowLossyNumbers: true })) return tools;
   let metadata;
   try {
     metadata = JSON.parse(encoded);
   } catch {
-    return false;
+    return tools;
   }
   const inventory = metadata?.tool_namespaces_info;
-  if (!inventory || typeof inventory !== "object" || Array.isArray(inventory)) {
-    return false;
-  }
+  if (!plainObject(inventory)) return tools;
 
-  const providerNames = new Set();
-  for (const tool of tools) {
-    if (tool?.type !== "function") continue;
-    const name = providerFunctionName(tool);
-    if (typeof name === "string" && name) providerNames.add(name);
-  }
-
+  // Default-namespace entries are already plain tools. Never reinterpret a
+  // literal name containing __ merely because another namespace claims it.
   const ordinaryNames = new Set();
   if (Object.hasOwn(inventory, DEFAULT_FUNCTION_NAMESPACE)) {
     const ordinary = inventory[DEFAULT_FUNCTION_NAMESPACE];
-    if (
-      ordinary?.name !== DEFAULT_FUNCTION_NAMESPACE ||
-      !ordinary.functions ||
-      typeof ordinary.functions !== "object" ||
-      Array.isArray(ordinary.functions)
-    ) {
-      return false;
-    }
+    if (ordinary?.name !== DEFAULT_FUNCTION_NAMESPACE ||
+        !plainObject(ordinary.functions)) return tools;
     for (const [name, info] of Object.entries(ordinary.functions)) {
-      if (!name || !info || typeof info !== "object" || Array.isArray(info) || info.name !== name) {
-        return false;
-      }
+      if (!name || !plainObject(info) || info.name !== name) return tools;
       ordinaryNames.add(name);
     }
   }
 
-  // `undefined` marks a wire spelling with more than one native owner.
   const candidates = new Map();
-  const rememberCandidate = (wireName, native) => {
+  const remember = (wireName, native) => {
     if (!candidates.has(wireName)) {
       candidates.set(wireName, native);
       return;
     }
     const previous = candidates.get(wireName);
-    if (
-      previous?.namespace !== native.namespace ||
-      previous?.name !== native.name
-    ) {
-      candidates.set(wireName, undefined);
-    }
+    if (!previous || previous.namespace !== native.namespace ||
+        previous.name !== native.name) candidates.set(wireName, undefined);
   };
-
   for (const [namespace, namespaceInfo] of Object.entries(inventory)) {
-    if (
-      !namespace ||
-      namespace === DEFAULT_FUNCTION_NAMESPACE ||
-      namespaceInfo?.name !== namespace
-    ) {
-      continue;
+    if (!namespace || namespace === DEFAULT_FUNCTION_NAMESPACE ||
+        namespaceInfo?.name !== namespace || !plainObject(namespaceInfo.functions)) continue;
+    for (const [name, info] of Object.entries(namespaceInfo.functions)) {
+      const mcp = info?.source?.kind === "mcp" &&
+        typeof info.source.server_name === "string" && info.source.server_name &&
+        namespace === `${MCP_NAMESPACE_PREFIX}${info.source.server_name}`;
+      if (!name || info?.name !== name || info.direct !== true ||
+          (!mcp && info.source?.kind !== "harness")) continue;
+      remember(`${namespace}${NAMESPACE_DELIMITER}${name}`, { namespace, name });
     }
-    const functions = namespaceInfo?.functions;
-    if (!functions || typeof functions !== "object" || Array.isArray(functions)) continue;
-    for (const [name, info] of Object.entries(functions)) {
-      if (
-        !name ||
-        info?.name !== name ||
-        info.direct !== true ||
-        info.source?.kind !== "mcp" ||
-        typeof info.source.server_name !== "string" ||
-        !info.source.server_name ||
-        namespace !== `${MCP_NAMESPACE_PREFIX}${info.source.server_name}`
-      ) {
-        continue;
+  }
+
+  const existingNamespaces = new Map();
+  const existingIdentities = new Set();
+  const repeatedNamespaces = new Set();
+  const declarations = new Map();
+  for (const tool of tools) {
+    if (tool?.type === "namespace" && Array.isArray(tool.tools)) {
+      if (existingNamespaces.has(tool.name)) repeatedNamespaces.add(tool.name);
+      existingNamespaces.set(tool.name, tool);
+      for (const child of tool.tools) {
+        if (typeof child?.name !== "string" || !child.name) continue;
+        remember(`${tool.name}${NAMESPACE_DELIMITER}${child.name}`,
+          { namespace: tool.name, name: child.name });
+        existingIdentities.add(nativeToolKey(tool.name, child.name));
       }
-      const wireName = `${namespace}${NAMESPACE_DELIMITER}${name}`;
-      const plainIdentity = nativeToolKey(undefined, wireName);
-      const providerName =
-        NAME_ALIASES.get(namespaces)?.nativeToProvider.get(plainIdentity) || wireName;
-      if (!providerNames.has(providerName) || ordinaryNames.has(wireName)) continue;
-      rememberCandidate(wireName, { namespace, name, providerName });
+    } else if (tool?.type === "function" || tool?.type === "custom") {
+      const name = providerFunctionName(tool);
+      // Metadata has no function/custom discriminator. Repeated wire names
+      // cannot be safely assigned to one declaration, even across those types.
+      declarations.set(name, declarations.has(name) ? undefined : tool);
     }
   }
 
-  const existingOwners = new Map();
-  for (const [namespace, names] of namespaces) {
-    for (const name of names) {
-      rememberCandidate(
-        `${namespace}${NAMESPACE_DELIMITER}${name}`,
-        { namespace, name },
-      );
-      existingOwners.set(`${namespace}${NAMESPACE_DELIMITER}${name}`, { namespace, name });
-    }
-  }
-
-  // Validate every ownership transfer before mutating any request-local map.
-  // flattenNamespaceTools has already registered these definitions as plain
-  // functions, including any provider-bounded alias. Move that exact provider
-  // spelling to the canonical MCP identity rather than allocating a second
-  // alias that no live definition uses.
-  const recoveries = [];
-  const recoveryProviderNames = new Set();
+  const recovered = new Map();
+  const groups = new Map();
   for (const [wireName, native] of candidates) {
-    if (!native || !providerNames.has(native.providerName)) continue;
-    const existing = existingOwners.get(wireName);
-    if (
-      existing &&
-      (existing.namespace !== native.namespace || existing.name !== native.name)
-    ) {
+    const tool = declarations.get(wireName);
+    if (!native || !tool || ordinaryNames.has(wireName) ||
+        repeatedNamespaces.has(native.namespace) ||
+        existingIdentities.has(nativeToolKey(native.namespace, native.name))) continue;
+    recovered.set(tool, native);
+    if (!groups.has(native.namespace)) {
+      const existing = existingNamespaces.get(native.namespace);
+      groups.set(native.namespace, existing
+        ? { ...existing, tools: [] }
+        : { type: "namespace", name: native.namespace, tools: [] });
+    }
+  }
+  if (!recovered.size) return tools;
+
+  // One declaration per namespace lets app expansion prefer the complete client
+  // schema without injecting the same deferred snapshot into multiple fragments.
+  const restored = [];
+  const emitted = new Set();
+  for (const tool of tools) {
+    const native = recovered.get(tool);
+    const group = native ? groups.get(native.namespace)
+      : tool?.type === "namespace" ? groups.get(tool.name) : undefined;
+    if (!group) {
+      restored.push(tool);
       continue;
     }
-    if (namespaces.get(native.namespace)?.has(native.name)) continue;
-
-    const relay = NAME_ALIASES.get(namespaces);
-    const plainIdentity = nativeToolKey(undefined, wireName);
-    const nativeIdentity = nativeToolKey(native.namespace, native.name);
-    if (relay) {
-      if (
-        relay.nativeToProvider.get(plainIdentity) !== native.providerName ||
-        relay.providerOwners.get(native.providerName) !== plainIdentity ||
-        (relay.nativeToProvider.has(nativeIdentity) &&
-          relay.nativeToProvider.get(nativeIdentity) !== native.providerName)
-      ) {
-        return false;
-      }
+    if (!emitted.has(group)) {
+      emitted.add(group);
+      restored.push(group);
     }
-    if (recoveryProviderNames.has(native.providerName)) return false;
-    recoveryProviderNames.add(native.providerName);
-    recoveries.push({
-      wireName,
-      providerName: native.providerName,
-      namespace: native.namespace,
-      name: native.name,
-      plainIdentity,
-      nativeIdentity,
-    });
+    if (native) {
+      const { function: definition, ...rest } = tool;
+      group.tools.push({ ...rest, ...definition, name: native.name });
+    } else {
+      group.tools.push(...tool.tools);
+    }
   }
-
-  for (const recovery of recoveries) {
-    const relay = NAME_ALIASES.get(namespaces);
-    if (relay) {
-      relay.nativeToProvider.delete(recovery.plainIdentity);
-      relay.nativeToProvider.set(recovery.nativeIdentity, recovery.providerName);
-      relay.providerOwners.set(recovery.providerName, recovery.nativeIdentity);
-      relay.providerToNative.set(recovery.providerName, {
-        namespace: recovery.namespace,
-        name: recovery.name,
-      });
-      relay.plainProviderNames.delete(recovery.providerName);
-      const wireOwners = relay.wireOwners.get(recovery.wireName);
-      if (wireOwners) {
-        wireOwners.delete(recovery.plainIdentity);
-        wireOwners.add(recovery.nativeIdentity);
-      }
-    }
-    PLAIN_TOOL_NAMES.get(namespaces)?.delete(recovery.providerName);
-    let names = namespaces.get(recovery.namespace);
-    if (!names) {
-      names = new Set();
-      namespaces.set(recovery.namespace, names);
-    }
-    names.add(recovery.name);
-  }
-  return recoveries.length > 0;
+  return restored;
 }
 
 function plainObject(value) {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -133,7 +133,7 @@ import {
   flattenNamespaceTools,
   flattenToolChoice,
   flattenToolSearchHistory,
-  recoverPreflattenedMcpTools,
+  restorePreflattenedToolNamespaces,
   repairToolSchemaRoots,
   strictOpenCodeCompactionInput,
   stripSearchContentTypes,
@@ -3126,6 +3126,11 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   const chatCompletionsProvider = provider?.protocol !== "openai-responses";
   const deepSeekResponses = usesDeepSeekResponses(route);
   const consoleGoResponsesCompatibility = needsConsoleGoResponsesToolCompatibility(route);
+  // Restore only where the existing adapter flattens tools again. Native
+  // Responses routes retain the client's original declaration shape.
+  const clientTools = chatCompletionsProvider || deepSeekResponses || consoleGoResponsesCompatibility
+    ? restorePreflattenedToolNamespaces(payload.tools, payload.client_metadata)
+    : payload.tools;
   const compatibleInput = zenFreeCompatibleInput(
     normalizeProviderAppToolOutputs(agedInput),
     route,
@@ -3135,7 +3140,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   // must fail locally before that work starts; the normal post-bridge pass
   // below runs again so any later transformation cannot bypass the invariant.
   if (provider?.id === "groq" && chatCompletionsProvider) {
-    const preflight = chatProviderToolSurface(payload.tools, provider.id, {
+    const preflight = chatProviderToolSurface(clientTools, provider.id, {
       input: compatibleInput,
       toolChoice: payload.tool_choice,
     });
@@ -3201,7 +3206,7 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
       input.pop();
     }
   }
-  let tools = payload.tools;
+  let tools = clientTools;
   // LiteLLM's Responses -> Chat Completions bridge drops namespace tools, which
   // is how the client ships the collaboration runtime, the app toolset
   // (threads, automations, navigation), and every MCP server (node_repl,
@@ -3249,19 +3254,6 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     // strict Responses providers may reject. Run the shared root repair on the
     // tools alone without flattening their native representation.
     tools = repairToolSchemaRoots(tools);
-  }
-  // Recent Codex clients flatten namespace tools before sending them to a
-  // custom Responses provider. Their canonical turn metadata is the only
-  // request-local source that can distinguish that MCP identity from an
-  // ordinary function whose literal name happens to contain `__`.
-  if (
-    recoverPreflattenedMcpTools(
-      tools,
-      payload.client_metadata,
-      flattenedNamespaces,
-    )
-  ) {
-    namespacesFlattened = true;
   }
   if (needsNonRecursiveToolSchemaCompatibility(route)) {
     // Run after namespace flattening so both native children and ordinary

--- a/test/deepseek-responses-routing.test.mjs
+++ b/test/deepseek-responses-routing.test.mjs
@@ -211,7 +211,8 @@ test("direct DeepSeek Responses preserves images, reasoning, tools and stream bo
       response.writeHead(400, { "Content-Type": "application/json" });
       response.end(JSON.stringify({ error: { type: "invalid_request_error", message: "fixture rejection" } })); return;
     }
-    const name = mode === "tool" ? "fixture__probe" : mode === "custom" ? "apply_patch"
+    const name = mode === "registered-tool" ? body.tools.find((tool) => tool.description === "Registered client tool").name
+      : mode === "tool" ? "fixture__probe" : mode === "custom" ? "apply_patch"
       : mode === "unsupported-custom" ? "exec"
         : mode === "namespaced-custom" ? body.tools.find((tool) => tool.description === "Synthetic namespaced freeform tool.").name
           : undefined;
@@ -370,6 +371,40 @@ test("direct DeepSeek Responses preserves images, reasoning, tools and stream bo
       }
       assert.equal(events.filter((event) => event.type === "response.custom_tool_call_input.delta")
         .map((event) => event.delta).join(""), "synthetic raw input");
+    }
+    mode = "registered-tool";
+    for (const [namespace, name, source] of [
+      ["image_gen", "imagegen", { kind: "harness" }],
+      ["clock", "curr_time", { kind: "harness" }],
+      ["codex_app", "list_projects", { kind: "harness" }],
+      ["mcp__node_repl", "js", { kind: "mcp", server_name: "node_repl" }],
+    ]) {
+      const result = await send("Use the explicitly registered tool.", {
+        tools: [{ type: "function", name: `${namespace}__${name}`, description: "Registered client tool", parameters: { type: "object" } }],
+        client_metadata: {
+          "x-codex-turn-metadata": JSON.stringify({
+            tool_namespaces_info: {
+              [namespace]: {
+                name: namespace,
+                functions: { [name]: { name, direct: true, source } },
+              },
+            },
+          }),
+        },
+      });
+      assert.equal(result.status, 200);
+      const events = parseEvents(await result.text());
+      assertTranscript(events);
+      assert.ok(events.some((event) =>
+        event.type === "response.output_item.done" && event.item.type === "function_call"));
+      for (const event of events) {
+        for (const item of event.item ? [event.item] : event.response?.output || []) {
+          if (item.type !== "function_call") continue;
+          assert.equal(item.namespace, namespace);
+          assert.equal(item.name, name);
+          if (item.status === "completed") assert.equal(item.arguments, '{"ok":true}');
+        }
+      }
     }
     mode = "normal";
     const compact = await fetch(`${base}/responses/compact`, {

--- a/test/namespace-relay-custom.test.mjs
+++ b/test/namespace-relay-custom.test.mjs
@@ -11,6 +11,7 @@ import {
   flattenToolChoice,
   NamespaceToolCallTransform,
   rewriteNamespaceResponsePayload,
+  restorePreflattenedToolNamespaces,
   strictOpenCodeCompactionInput,
 } from "../src/namespace-relay.mjs";
 import { deepSeekCustomToolNames } from "../src/deepseek-responses.mjs";
@@ -89,6 +90,39 @@ test("namespaced custom tools preserve exact input, choice and output identity",
   }
 });
 
+test("flat custom history does not hijack an ordinary tool with the same wire name", () => {
+  const wireName = "functions__exec";
+  for (const plainType of ["custom", "function"]) {
+    const tools = [
+      { type: "namespace", name: "functions", tools: [{ type: "custom", name: "exec" }] },
+      { type: plainType, name: wireName, ...(plainType === "function" ? { parameters: { type: "object" } } : {}) },
+    ];
+    const input = [{ type: "custom_tool_call", name: wireName, call_id: "plain_prior", input: "plain input" }];
+    const choice = { type: "custom", name: wireName };
+    const flattened = flattenNamespaceTools(tools, { maxNameLength: 64 });
+    const bridged = bridgeCustomTools(flattened.tools, input, flattened.namespaces, choice,
+      deepSeekCustomToolNames(flattened.tools, input, choice), { maxNameLength: 64 });
+    const lookups = buildNamespaceLookups(flattened.namespaces);
+    const history = flattenNamespacedHistory(bridged.input, flattened.namespaces);
+    assert.notEqual(history[0].name, bridged.tools[0].name,
+      "the unqualified prior call must not use the namespaced exec alias");
+    assert.equal(bridged.toolChoice.name, history[0].name);
+    const restored = rewriteNamespaceResponsePayload({ output: [sourceCall(history[0].name, "plain input")] }, lookups).output[0];
+    assert.equal(restored.type, "custom_tool_call");
+    assert.equal(restored.name, wireName);
+    assert.equal(restored.namespace, undefined);
+    assert.equal(restored.input, "plain input");
+    const native = rewriteNamespaceResponsePayload({ output: [sourceCall(bridged.tools[0].name)] }, lookups).output[0];
+    assert.equal(native.name, "exec");
+    assert.equal(native.namespace, "functions");
+    if (plainType === "function") {
+      const call = sourceCall(bridged.tools[1].name);
+      const payload = { output: [call] };
+      assert.deepEqual((rewriteNamespaceResponsePayload(payload, lookups) || payload).output[0], call);
+    }
+  }
+});
+
 test("bounded namespaced custom aliases remain consistent in allowed-tools choices", () => {
   const namespace = "namespace_with_a_long_but_valid_native_identity";
   const name = "freeform_tool_with_a_long_native_name";
@@ -108,6 +142,64 @@ test("bounded namespaced custom aliases remain consistent in allowed-tools choic
     buildNamespaceLookups(flattened.namespaces)).output[0];
   assert.equal(output.name, name);
   assert.equal(output.namespace, namespace);
+});
+
+test("pre-flattened custom exec preserves bounded aliases, history, choices and exact input", () => {
+  const namespace = "native_runtime_with_a_long_but_valid_client_namespace";
+  const name = "exec";
+  const wireName = `${namespace}__${name}`;
+  const definition = { type: "custom", name: wireName, description: "Execute supplied text.",
+    format: { type: "grammar", syntax: "lark", definition: "start: /[\\s\\S]+/" } };
+  const metadata = { "x-codex-turn-metadata": JSON.stringify({ tool_namespaces_info: {
+    [namespace]: { name: namespace, functions: { [name]: { name, direct: true, source: { kind: "harness" } } } },
+  } }) };
+  const rawInput = 'text("مرحبا");\n// Preserve \\ and "quotes" exactly.\n';
+  const history = [
+    { type: "custom_tool_call", namespace, name, call_id: "prior_exec", input: rawInput },
+    { type: "custom_tool_call_output", call_id: "prior_exec", output: "done" },
+  ];
+  const choice = { type: "custom", namespace, name };
+  let firstProviderName;
+  for (const [collision, preflattened] of [[false, false], [true, false], [false, true], [true, true]]) {
+    const extra = collision ? [{ type: "function", name: firstProviderName, parameters: { type: "object" } }] : [];
+    const tools = [definition, ...extra];
+    const original = structuredClone(tools);
+    const restored = restorePreflattenedToolNamespaces(tools, metadata);
+    assert.deepEqual(restored[0].tools[0], { ...definition, name });
+    assert.deepEqual(tools, original);
+    const flattened = flattenNamespaceTools(restored, { maxNameLength: 64 });
+    const prior = preflattened
+      ? [{ type: "custom_tool_call", name: wireName, call_id: "prior_exec", input: rawInput }, history[1]]
+      : history;
+    const forced = preflattened ? { type: "custom", name: wireName } : choice;
+    const bridged = bridgeCustomTools(flattened.tools, prior, flattened.namespaces, forced,
+      deepSeekCustomToolNames(flattened.tools, prior, forced), { maxNameLength: 64 });
+    const providerName = bridged.tools[0].name;
+    assert.ok(providerName.length <= 64);
+    if (collision) assert.notEqual(providerName, firstProviderName);
+    else firstProviderName = providerName;
+    assert.equal(new Set(bridged.tools.map((tool) => tool.name)).size, bridged.tools.length);
+    const sent = flattenNamespacedHistory(bridged.input, flattened.namespaces);
+    assert.equal(sent[0].name, providerName);
+    assert.equal(sent[0].namespace, undefined);
+    assert.equal(JSON.parse(sent[0].arguments).input, rawInput);
+    assert.deepEqual(sent[1], { type: "function_call_output", call_id: "prior_exec", output: "done" });
+    assert.deepEqual(flattenToolChoice(bridged.toolChoice, flattened.namespaces), { type: "function", name: providerName });
+    const output = rewriteNamespaceResponsePayload({ output: [sourceCall(providerName, rawInput)] },
+      buildNamespaceLookups(flattened.namespaces)).output[0];
+    assert.equal(output.type, "custom_tool_call");
+    assert.equal(output.namespace, namespace);
+    assert.equal(output.name, name);
+    assert.equal(output.input, rawInput);
+    if (collision) {
+      const plainCall = sourceCall(bridged.tools[1].name, "ordinary function");
+      const payload = { output: [plainCall] };
+      const rewritten = rewriteNamespaceResponsePayload(payload, buildNamespaceLookups(flattened.namespaces)) || payload;
+      assert.deepEqual(rewritten.output[0], plainCall, "an ordinary function must not become a custom exec");
+    }
+  }
+  assert.equal(history[0].input, rawInput);
+  assert.deepEqual(choice, { type: "custom", namespace, name });
 });
 
 test("namespaced custom apply_patch history remains paired during compaction", () => {

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -1794,6 +1794,41 @@ test("routed tool_search history declares discovered tools and restores their ca
   }
 });
 
+test("Responses-native routes preserve pre-flattened tools and call identities", async () => {
+  for (const stream of [true, false]) {
+    const payload = preflattenedCommandCodeMcpPayload(stream, "meta/muse-spark-1.2");
+    const name = payload.tools[0].name;
+    const prior = { type: "function_call", name, call_id: "call_prior", arguments: "{}" };
+    payload.input = [
+      { type: "message", role: "user", content: "Call the monitor snapshot tool again." },
+      prior,
+      { type: "function_call_output", call_id: prior.call_id, output: "{}" },
+    ];
+    payload.tool_choice = { type: "function", name };
+    const call = { ...prior, call_id: "call_flat_response" };
+    const result = await scenario(stream, {
+      model: payload.model,
+      requestPayload: () => payload,
+      sseBody: () => [
+        sseEvent({ type: "response.output_item.done", item: call }),
+        sseEvent({ type: "response.completed" }),
+        "data: [DONE]\n\n",
+      ].join(""),
+      jsonBody: () => ({ id: "resp_flat_json", output: [call] }),
+    });
+    assert.equal(result.gatewayBodies.length, 1);
+    const outgoing = result.gatewayBodies[0];
+    assert.equal(outgoing.model, "meta-muse-spark-1-2");
+    assert.deepEqual(outgoing.tools, payload.tools, "do not synthesize namespace declarations");
+    assert.deepEqual(outgoing.input, payload.input);
+    assert.equal(outgoing.tool_choice, "auto", "retain Meta's existing tool-choice policy");
+    const returned = stream
+      ? functionCallsFromSse(result.clientBody).get(call.call_id)
+      : JSON.parse(result.clientBody).output[0];
+    assert.deepEqual(returned, call, "preserve the flat response identity");
+  }
+});
+
 test("Responses-native routed providers inherit the model on fresh local thread calls", async () => {
   const options = {
     model: "meta/muse-spark-1.2",

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -14,7 +14,7 @@ import {
   flattenNamespaceTools,
   flattenToolChoice,
   flattenToolSearchHistory,
-  recoverPreflattenedMcpTools,
+  restorePreflattenedToolNamespaces,
   rewriteNamespaceFunctionCall,
   rewriteNamespaceResponsePayload,
   repairToolSchemaRoots,
@@ -173,252 +173,150 @@ test("flattenNamespaceTools flattens every namespace, including MCP ones", () =>
   assert.deepEqual([...namespaces.get("mcp__codex_apps__github")], ["fetch_issue"]);
 });
 
-test("turn metadata recovers a namespace Codex flattened before the router", () => {
-  const wireName = "mcp__neon__apm__staging__snapshot__ro__get_monitor_snapshot";
-  const tools = [{ type: "function", name: wireName, parameters: { type: "object" } }];
-  const { namespaces } = flattenNamespaceTools(tools);
-  const clientMetadata = {
-    "x-codex-turn-metadata": JSON.stringify({
-      tool_namespaces_info: {
-        "mcp__neon__apm__staging__snapshot__ro": {
-          name: "mcp__neon__apm__staging__snapshot__ro",
-          functions: {
-            get_monitor_snapshot: {
-              name: "get_monitor_snapshot",
-              direct: true,
-              code_mode_name: null,
-              deferred: false,
-              source: { kind: "mcp", server_name: "neon__apm__staging__snapshot__ro" },
-            },
-          },
-        },
-      },
-    }),
-  };
+function turnToolMetadata(namespace, names, source = { kind: "harness" }) {
+  return { "x-codex-turn-metadata": JSON.stringify({ tool_namespaces_info: {
+    [namespace]: { name: namespace, functions: Object.fromEntries(names.map((name) =>
+      [name, { name, direct: true, source }])) },
+  } }) };
+}
 
-  assert.equal(
-    recoverPreflattenedMcpTools(tools, clientMetadata, namespaces),
-    true,
-  );
-  assert.deepEqual(
-    rewriteNamespaceResponsePayload(
-      {
-        output: [{
-          type: "function_call",
-          name: wireName,
-          call_id: "call_snapshot",
-          arguments: "{}",
-        }],
-      },
-      buildNamespaceLookups(namespaces),
-    ).output[0],
-    {
-      type: "function_call",
-      name: "get_monitor_snapshot",
-      namespace: "mcp__neon__apm__staging__snapshot__ro",
-      call_id: "call_snapshot",
-      arguments: "{}",
-    },
-  );
+test("turn metadata restores directly registered harness and MCP namespaces", () => {
+  for (const [namespace, name, source] of [
+    ["image_gen", "imagegen", { kind: "harness" }],
+    ["clock", "sleep", { kind: "harness" }],
+    ["browser", "open", { kind: "harness" }],
+    ["codex_app", "list_projects", { kind: "harness" }],
+    ["mcp__neon__apm__staging__snapshot__ro", "get_monitor_snapshot",
+      { kind: "mcp", server_name: "neon__apm__staging__snapshot__ro" }],
+  ]) {
+    const wireName = `${namespace}__${name}`;
+    const definition = { type: "function", name: wireName, description: "Client-owned tool.",
+      parameters: { type: "object", properties: { prompt: { type: "string" } }, required: ["prompt"] } };
+    const tools = [definition];
+    const original = structuredClone(tools);
+    const restored = restorePreflattenedToolNamespaces(tools, turnToolMetadata(namespace, [name], source));
+    assert.deepEqual(restored, [{ type: "namespace", name: namespace, tools: [{ ...definition, name }] }]);
+    assert.deepEqual(tools, original, "reconstruction must not mutate the client's definitions");
+    const { namespaces } = flattenNamespaceTools(restored);
+    const call = { type: "function_call", name: wireName, call_id: "call_native", arguments: '{"prompt":"fixture"}' };
+    assert.deepEqual(rewriteNamespaceResponsePayload({ output: [call] }, buildNamespaceLookups(namespaces)).output[0],
+      { ...call, namespace, name });
+  }
 });
 
-test("pre-flattened recovery does not reinterpret an ordinary function collision", () => {
+test("pre-flattened recovery requires unambiguous live direct definitions", () => {
+  const namespace = "image_gen";
+  const name = "imagegen";
+  const wireName = `${namespace}__${name}`;
+  const tools = [{ type: "function", name: wireName }];
+  const registered = JSON.parse(turnToolMetadata(namespace, [name])["x-codex-turn-metadata"]).tool_namespaces_info;
+  const notDirect = structuredClone(registered);
+  notDirect[namespace].functions[name].direct = false;
+  const wrongSource = structuredClone(registered);
+  wrongSource[namespace].functions[name].source = { kind: "mcp", server_name: namespace };
+  const ordinaryCollision = { ...registered,
+    functions: { name: "functions", functions: { [wireName]: { name: wireName } } } };
+  for (const inventory of [{}, notDirect, wrongSource, ordinaryCollision]) {
+    assert.equal(restorePreflattenedToolNamespaces(tools, {
+      "x-codex-turn-metadata": JSON.stringify({ tool_namespaces_info: inventory }),
+    }), tools);
+  }
+  const absent = [];
+  assert.equal(restorePreflattenedToolNamespaces(absent, turnToolMetadata(namespace, [name])), absent,
+    "metadata must not invent unadvertised tools");
+  assert.equal(restorePreflattenedToolNamespaces(tools, {}), tools);
+  const ordinary = [{ type: "function", name: "exec_command" }];
+  assert.equal(restorePreflattenedToolNamespaces(ordinary, turnToolMetadata("functions", ["exec_command"])), ordinary);
+  const explicit = [...tools, { type: "namespace", name: namespace, tools: [{ type: "function", name }] }];
+  assert.equal(restorePreflattenedToolNamespaces(explicit, turnToolMetadata(namespace, [name])), explicit,
+    "an existing native identity must not absorb a conflicting flat declaration");
+});
+
+test("pre-flattened recovery does not reinterpret an ordinary MCP function collision", () => {
   const wireName = "mcp__calendar__create_event";
   const tools = [{ type: "function", name: wireName }];
-  const { namespaces } = flattenNamespaceTools(tools);
-  const clientMetadata = {
-    "x-codex-turn-metadata": JSON.stringify({
-      tool_namespaces_info: {
-        functions: {
-          name: "functions",
-          functions: {
-            [wireName]: {
-              name: wireName,
-              direct: true,
-              source: { kind: "harness" },
-            },
-          },
-        },
-        mcp__calendar: {
-          name: "mcp__calendar",
-          functions: {
-            create_event: {
-              name: "create_event",
-              direct: true,
-              source: { kind: "mcp", server_name: "calendar" },
-            },
-          },
-        },
-      },
-    }),
+  const metadata = JSON.parse(turnToolMetadata("mcp__calendar", ["create_event"],
+    { kind: "mcp", server_name: "calendar" })["x-codex-turn-metadata"]);
+  metadata.tool_namespaces_info.functions = {
+    name: "functions", functions: { [wireName]: { name: wireName, direct: true, source: { kind: "harness" } } },
   };
-
-  assert.equal(
-    recoverPreflattenedMcpTools(tools, clientMetadata, namespaces),
-    false,
-  );
-  assert.equal(namespaces.size, 0);
+  assert.equal(restorePreflattenedToolNamespaces(tools, {
+    "x-codex-turn-metadata": JSON.stringify(metadata),
+  }), tools);
 });
 
 test("pre-flattened recovery fails closed on ambiguous delimiter ownership", () => {
   const tools = [{ type: "function", name: "mcp__calendar__admin__create" }];
-  const { namespaces } = flattenNamespaceTools(tools);
-  const clientMetadata = {
-    "x-codex-turn-metadata": JSON.stringify({
-      tool_namespaces_info: {
-        mcp__calendar: {
-          name: "mcp__calendar",
-          functions: {
-            admin__create: {
-              name: "admin__create",
-              direct: true,
-              source: { kind: "mcp", server_name: "calendar" },
-            },
-          },
-        },
-        mcp__calendar__admin: {
-          name: "mcp__calendar__admin",
-          functions: {
-            create: {
-              name: "create",
-              direct: true,
-              source: { kind: "mcp", server_name: "calendar__admin" },
-            },
-          },
-        },
-      },
-    }),
-  };
-
-  assert.equal(
-    recoverPreflattenedMcpTools(tools, clientMetadata, namespaces),
-    false,
-  );
-  assert.equal(namespaces.size, 0);
+  const inventory = {};
+  for (const [server, name] of [["calendar", "admin__create"], ["calendar__admin", "create"]]) {
+    Object.assign(inventory, JSON.parse(turnToolMetadata(`mcp__${server}`, [name],
+      { kind: "mcp", server_name: server })["x-codex-turn-metadata"]).tool_namespaces_info);
+  }
+  assert.equal(restorePreflattenedToolNamespaces(tools, {
+    "x-codex-turn-metadata": JSON.stringify({ tool_namespaces_info: inventory }),
+  }), tools);
 });
 
-test("pre-flattened recovery transfers a bounded provider alias to the MCP identity", () => {
-  const serverName = "neon__apm__production__snapshot__read_only";
-  const namespace = `mcp__${serverName}`;
-  const name = "get_monitor_snapshot_with_complete_context";
-  const wireName = `${namespace}__${name}`;
-  const flattened = flattenNamespaceTools(
-    [{ type: "function", name: wireName, parameters: { type: "object" } }],
-    { maxNameLength: 64 },
-  );
-  const providerName = flattened.tools[0].name;
-  assert.notEqual(providerName, wireName);
-  assert.ok(providerName.length <= 64);
-
-  assert.equal(
-    recoverPreflattenedMcpTools(
-      flattened.tools,
-      {
-        "x-codex-turn-metadata": JSON.stringify({
-          tool_namespaces_info: {
-            [namespace]: {
-              name: namespace,
-              functions: {
-                [name]: {
-                  name,
-                  direct: true,
-                  source: { kind: "mcp", server_name: serverName },
-                },
-              },
-            },
-          },
-        }),
-      },
-      flattened.namespaces,
-    ),
-    true,
-  );
-  assert.equal(
-    flattenNamespacedHistory(
-      [{ type: "function_call", namespace, name, call_id: "call_history", arguments: "{}" }],
-      flattened.namespaces,
-    )[0].name,
-    providerName,
-  );
-  assert.deepEqual(
-    rewriteNamespaceResponsePayload(
-      {
-        output: [{
-          type: "function_call",
-          name: providerName,
-          call_id: "call_live",
-          arguments: "{}",
-        }],
-      },
-      buildNamespaceLookups(flattened.namespaces),
-    ).output[0],
-    {
-      type: "function_call",
-      namespace,
-      name,
-      call_id: "call_live",
-      arguments: "{}",
-    },
-  );
+test("restored MCP identities retain bounded and collision-only provider aliases", () => {
+  for (const [serverName, name, options] of [
+    ["neon__apm__production__snapshot__read_only", "get_monitor_snapshot_with_complete_context", { maxNameLength: 64 }],
+    ["calendar", "create_event", { aliasCollisions: true }],
+  ]) {
+    const namespace = `mcp__${serverName}`;
+    const wireName = `${namespace}__${name}`;
+    const tools = [{ type: "function", name: wireName, parameters: { type: "object" } }];
+    const restored = restorePreflattenedToolNamespaces(tools,
+      turnToolMetadata(namespace, [name], { kind: "mcp", server_name: serverName }));
+    const flattened = flattenNamespaceTools(restored, options);
+    const providerName = flattened.tools[0].name;
+    if (options.maxNameLength) {
+      assert.notEqual(providerName, wireName);
+      assert.ok(providerName.length <= 64);
+    } else assert.equal(providerName, wireName);
+    const call = { type: "function_call", namespace, name, call_id: "call_history", arguments: "{}" };
+    assert.equal(flattenNamespacedHistory([call], flattened.namespaces)[0].name, providerName);
+    const { namespace: _namespace, ...providerCall } = call;
+    assert.deepEqual(rewriteNamespaceResponsePayload({ output: [{ ...providerCall, name: providerName }] },
+      buildNamespaceLookups(flattened.namespaces)).output[0], call);
+  }
 });
 
-test("pre-flattened recovery transfers collision-only alias ownership", () => {
-  const namespace = "mcp__calendar";
-  const name = "create_event";
-  const wireName = `${namespace}__${name}`;
-  const flattened = flattenNamespaceTools(
-    [{ type: "function", name: wireName }],
-    { aliasCollisions: true },
-  );
-  assert.equal(flattened.tools[0].name, wireName);
-  assert.equal(
-    recoverPreflattenedMcpTools(
-      flattened.tools,
-      {
-        "x-codex-turn-metadata": JSON.stringify({
-          tool_namespaces_info: {
-            [namespace]: {
-              name: namespace,
-              functions: {
-                [name]: {
-                  name,
-                  direct: true,
-                  source: { kind: "mcp", server_name: "calendar" },
-                },
-              },
-            },
-          },
-        }),
-      },
-      flattened.namespaces,
-    ),
-    true,
-  );
-  assert.equal(
-    flattenNamespacedHistory(
-      [{ type: "function_call", namespace, name, call_id: "call_history", arguments: "{}" }],
-      flattened.namespaces,
-    )[0].name,
-    wireName,
-  );
-  const restored = rewriteNamespaceResponsePayload(
-    {
-      output: [{
-        type: "function_call",
-        name: wireName,
-        call_id: "call_live",
-        arguments: "{}",
-      }],
-    },
-    buildNamespaceLookups(flattened.namespaces),
-  ).output[0];
-  assert.deepEqual(
-    { namespace: restored.namespace, name: restored.name },
-    { namespace, name },
-  );
+test("restored app tools group once and preserve client schemas before expansion", () => {
+  const definitions = ["list_projects", "create_thread"].map((name) => ({
+    type: "function", name: `codex_app__${name}`, description: `Current ${name} contract`,
+    parameters: { type: "object", properties: { clientOnly: { type: "string" } }, required: ["clientOnly"] },
+  }));
+  const restored = restorePreflattenedToolNamespaces(definitions,
+    turnToolMetadata("codex_app", ["list_projects", "create_thread"]));
+  assert.equal(restored.length, 1);
+  assert.equal(restored[0].tools.length, 2);
+  const expanded = mergeCodexAppTools(restored).tools;
+  const app = expanded.filter((tool) => tool.type === "namespace" && tool.name === "codex_app");
+  assert.equal(app.length, 1);
+  assert.equal(new Set(app[0].tools.map((tool) => tool.name)).size, app[0].tools.length);
+  for (const definition of definitions) {
+    const name = definition.name.slice("codex_app__".length);
+    assert.deepEqual(app[0].tools.find((tool) => tool.name === name), { ...definition, name });
+  }
 });
 
-test("pre-flattened recovery rejects malformed, duplicated, and non-MCP metadata", () => {
+test("restored collaboration tools derive spawn model validation from parameters", () => {
+  const definition = { type: "function", name: "collaboration__spawn_agent", parameters: {
+    type: "object", properties: { model: { type: "string", enum: ["deepseek/deepseek-flash"] }, message: { type: "string" } },
+  } };
+  const restored = restorePreflattenedToolNamespaces([definition], turnToolMetadata("collaboration", ["spawn_agent"]));
+  const { namespaces } = flattenNamespaceTools(restored);
+  const lookups = buildNamespaceLookups(namespaces);
+  for (const model of ["deepseek/deepseek-flash", "unavailable-model"]) {
+    const call = { type: "function_call", name: definition.name, arguments: JSON.stringify({ model, message: "bounded task" }) };
+    const output = rewriteNamespaceResponsePayload({ output: [call] }, lookups).output[0];
+    assert.equal(output.namespace, "collaboration");
+    assert.equal(output.name, "spawn_agent");
+    assert.deepEqual(JSON.parse(output.arguments), model === "unavailable-model" ? { message: "bounded task" } : { model, message: "bounded task" });
+  }
+});
+
+test("pre-flattened recovery rejects malformed, duplicated, and mismatched-source metadata", () => {
   const namespace = "mcp__calendar";
   const name = "create_event";
   const wireName = `${namespace}__${name}`;
@@ -476,16 +374,11 @@ test("pre-flattened recovery rejects malformed, duplicated, and non-MCP metadata
 
   for (const encoded of cases) {
     const toolName = encoded.includes("codex_app") ? "codex_app__create_thread" : wireName;
-    const { namespaces } = flattenNamespaceTools([{ type: "function", name: toolName }]);
+    const tools = [{ type: "function", name: toolName }];
     assert.equal(
-      recoverPreflattenedMcpTools(
-        [{ type: "function", name: toolName }],
-        { "x-codex-turn-metadata": encoded },
-        namespaces,
-      ),
-      false,
+      restorePreflattenedToolNamespaces(tools, { "x-codex-turn-metadata": encoded }),
+      tools,
     );
-    assert.equal(namespaces.size, 0);
   }
 });
 


### PR DESCRIPTION
Codex can send native tools with already-flattened names such as `image_gen__imagegen`. MCP-only recovery leaves other registered tools with a provider name that Codex cannot dispatch. Restore the client-declared namespace and name before the existing tool adapters run.

Recovery requires live, directly exposed function or custom declarations backed by canonical turn metadata. It reuses existing schema, alias, history and response handling; ambiguous identities and ordinary-name collisions remain unchanged.

Restoration runs only on routes that flatten tools: Chat Completions, direct DeepSeek Responses and Console Go's compatibility path. Other Responses-native routes retain the client's declaration shape. A router-level Meta regression checks flat definitions, history, existing tool-choice policy and returned call identities in streaming and non-streaming modes; it fails on the previously unguarded restore.

Follow-up to merged #681, based on `main` at `da395a1`. One commit across seven files.

Validation:
- All 166 tests in the four affected namespace/custom-tool/Responses test files pass.
- `npm run check`, whitespace checks and final diff review pass.
- Full Linux run: 3,882 passed, 27 skipped; nine desktop tests initially failed because the local checkout control script was group-writable. After correcting that local permission, both affected test files pass (86 passed, one skipped). No source change was needed.
- Tests use synthetic loopback requests. Live provider execution and ImageGen generation were not exercised; cross-platform CI is tracked separately.
