### PR TITLE
refactor(deepseek): rename direct V4.1 Flash slug to deepseek/deepseek-v4.1-flash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **DeepSeek V4.1 Flash is available on four providers, alongside V4.**
   DeepSeek released V4.1 Flash on 2026-09-10. New routes:
-  `deepseek/deepseek-flash` (1M window, image input, thinking with
+  `deepseek/deepseek-v4.1-flash` (1M window, image input, thinking with
   low/high/max), `opencode-go/deepseek-v4.1-flash` (OpenCode's renamed id;
   the launch-day `deepseek-flash` id is deprecated and not routed),
   `nousresearch/deepseek-v4.1-flash` (sized to the Portal's served 262,144

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Linux installations support the Codex CLI.
 | Kimi K3 (China API) | `kimi-api-cn/kimi-k3` | Separately billed Moonshot **China** platform key |
 | DeepSeek V4 Flash (API) | `deepseek/deepseek-v4-flash` | DeepSeek API key |
 | DeepSeek V4 Pro (API) | `deepseek/deepseek-v4-pro` | DeepSeek API key |
-| DeepSeek V4.1 Flash (API) | `deepseek/deepseek-flash` | DeepSeek API key |
+| DeepSeek V4.1 Flash (API) | `deepseek/deepseek-v4.1-flash` | DeepSeek API key |
 | Grok 4.5 (OAuth) | `grok-oauth/grok-4.5` | Official Grok CLI OAuth session |
 | Grok 4.5 (API) | `grok-api/grok-4.5` | Separately billed xAI API key |
 | Claude Opus 4.8 (API) | `anthropic-api/claude-opus-4.8` | Separately billed Anthropic API key |

--- a/config/deepseek/deepseek-v4.1-flash.json
+++ b/config/deepseek/deepseek-v4.1-flash.json
@@ -2,8 +2,8 @@
   "version": 1,
   "models": [
     {
-      "slug": "deepseek/deepseek-flash",
-      "gatewayModel": "deepseek-flash",
+      "slug": "deepseek/deepseek-v4.1-flash",
+      "gatewayModel": "deepseek-v4-1-flash",
       "upstreamModel": "deepseek-flash",
       "provider": "deepseek",
       "listed": true,
@@ -33,7 +33,7 @@
       ],
       "requestProfile": "deepseek-thinking",
       "supportsReasoningSummaries": true,
-      "compHash": "deepseek-flash-v1"
+      "compHash": "deepseek-v4-1-flash-v1"
     }
   ]
 }

--- a/docs/research/deepseek-v4-1-flash-2026-09-11.md
+++ b/docs/research/deepseek-v4-1-flash-2026-09-11.md
@@ -30,7 +30,7 @@ https://api-docs.deepseek.com/quick_start/agent_integrations/codex/.
   Completions. The `deepseek-thinking` profile already downgrades them to
   `auto`.
 
-Route: `deepseek/deepseek-flash` with `deepseek-thinking`. Standalone web
+Route: `deepseek/deepseek-v4.1-flash` with `deepseek-thinking`. Standalone web
 search is not declared, because that capability is only listed for routes
 verified against Codex's replay path.
 

--- a/test/catalog.test.mjs
+++ b/test/catalog.test.mjs
@@ -1574,7 +1574,7 @@ test(
       const visibility = new Map(
         merged.models.map((model) => [String(model.slug), model.visibility]),
       );
-      assert.equal(visibility.get("deepseek/deepseek-flash"), "list");
+      assert.equal(visibility.get("deepseek/deepseek-v4.1-flash"), "list");
       assert.equal(visibility.get("deepseek/deepseek-v4-flash"), "list");
       assert.equal(visibility.get("deepseek/deepseek-v4-flash-vision-exp"), "list");
       assert.equal(visibility.get("deepseek/deepseek-v4-pro"), "hide");
@@ -1584,9 +1584,9 @@ test(
         readFileSync(path.join(stateDir, "model-picker.json"), "utf8"),
       );
       assert.deepEqual(picker.visible, [
-        "deepseek/deepseek-flash",
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-vision-exp",
+        "deepseek/deepseek-v4.1-flash",
       ]);
     } finally {
       rmSync(codexHome, { recursive: true, force: true });

--- a/test/control.test.mjs
+++ b/test/control.test.mjs
@@ -698,7 +698,7 @@ test("login-free control selects a ready external model and restores Codex defau
         ["deepseek/deepseek-v4-flash", "hide"],
         ["deepseek/deepseek-v4-flash-vision-exp", "list"],
         ["deepseek/deepseek-v4-pro", "list"],
-        ["deepseek/deepseek-flash", "list"],
+        ["deepseek/deepseek-v4.1-flash", "list"],
       ],
     );
     const aliases = JSON.parse(readFileSync(path.join(stateDir, "native-aliases.json"), "utf8"));

--- a/test/deepseek-responses-routing.test.mjs
+++ b/test/deepseek-responses-routing.test.mjs
@@ -89,7 +89,7 @@ test("native DeepSeek receives delegated tasks as supported user messages", () =
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const INTERNAL_KEY = "test-internal-service-key-with-sufficient-length";
 const CALLER_KEY = "test-router-caller-capability-with-sufficient-length";
-const MODEL = "deepseek/deepseek-flash";
+const MODEL = "deepseek/deepseek-v4.1-flash";
 const TEXT = "Both checks pass. Final content check complete.";
 const REASONING = "The synthetic pixel was inspected.";
 const IMAGE = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAY0lEQVR4nO3PQQ3AIADAQEALAhGJsIngcVnSU9DOfe74s6UDXjWgNaA1oDWgNaA1oDWgNaA1oDWgNaA1oDWgNaA1oDWgNaA1oDWgNaA1oDWgNaA1oDWgNaA1oDWgNaA1oDWgfRdzAdh+IIyPAAAAAElFTkSuQmCC";
@@ -186,7 +186,7 @@ test("direct DeepSeek Responses preserves images, reasoning, tools and stream bo
   const codexHome = path.join(state, "codex");
   mkdirSync(codexHome);
   const legacy = JSON.parse(readFileSync(path.join(root, "config/deepseek/deepseek-v4-flashvision-exp.json"))).models[0];
-  writeFileSync(path.join(state, "user-models.json"), JSON.stringify({ version: 1, models: [{ ...legacy, slug: MODEL, gatewayModel: "deepseek-flash", upstreamModel: "deepseek-flash", compHash: "native-responses-test" }] }));
+  writeFileSync(path.join(state, "user-models.json"), JSON.stringify({ version: 1, models: [{ ...legacy, slug: MODEL, gatewayModel: "deepseek-v4-1-flash", upstreamModel: "deepseek-flash", compHash: "native-responses-test" }] }));
   writeFileSync(path.join(state, "enabled-providers.json"), JSON.stringify({ version: 1, providers: ["deepseek"] }));
   const requests = [];
   let gatewayRequests = 0;

--- a/test/deepseek-v4-1-flash.test.mjs
+++ b/test/deepseek-v4-1-flash.test.mjs
@@ -9,7 +9,7 @@ import { curatedModelBlockReason, curatedModelProviderId } from "../src/opencode
 const MAX_EFFORT_DEFAULT_OUTPUT = 128_000;
 
 test("DeepSeek V4.1 Flash on the direct API publishes its documented capabilities", () => {
-  const model = MODEL_BY_SLUG.get("deepseek/deepseek-flash");
+  const model = MODEL_BY_SLUG.get("deepseek/deepseek-v4.1-flash");
   assert.ok(model);
   assert.equal(model.provider, "deepseek");
   assert.equal(model.upstreamModel, "deepseek-flash");

--- a/test/provider-selection.test.mjs
+++ b/test/provider-selection.test.mjs
@@ -103,7 +103,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-vision-exp",
         "deepseek/deepseek-v4-pro",
-        "deepseek/deepseek-flash",
+        "deepseek/deepseek-v4.1-flash",
       ],
     );
     assert.deepEqual(
@@ -112,7 +112,7 @@ test("provider selection keeps backward compatibility and can hide the final pro
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-vision-exp",
         "deepseek/deepseek-v4-pro",
-        "deepseek/deepseek-flash",
+        "deepseek/deepseek-v4.1-flash",
       ],
     );
 
@@ -275,7 +275,7 @@ test("an unknown provider id in the selection file is filtered out, not fatal", 
         "deepseek/deepseek-v4-flash",
         "deepseek/deepseek-v4-flash-vision-exp",
         "deepseek/deepseek-v4-pro",
-        "deepseek/deepseek-flash",
+        "deepseek/deepseek-v4.1-flash",
       ],
     );
     // Doctor and the support bundle read through this, so the damage is

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -99,7 +99,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "deepseek/deepseek-v4-flash",
       "deepseek/deepseek-v4-flash-vision-exp",
       "deepseek/deepseek-v4-pro",
-      "deepseek/deepseek-flash",
+      "deepseek/deepseek-v4.1-flash",
       "grok-api/grok-4.5",
       "grok-oauth/grok-4.5",
       "grok-oauth/grok-4.6",

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -7769,8 +7769,8 @@ test("direct DeepSeek screenshots do not saturate the prompt-token estimate", as
   const userModels = path.join(stateDir, "user-models.json");
   writeFileSync(userModels, JSON.stringify({ version: 1, models: [{
     ...legacy,
-    slug: "deepseek/deepseek-flash",
-    gatewayModel: "deepseek-flash",
+    slug: "deepseek/deepseek-v4.1-flash",
+    gatewayModel: "deepseek-v4-1-flash",
     upstreamModel: "deepseek-flash",
     compHash: "deepseek-flash-image-estimate-fixture",
   }] }));
@@ -7784,7 +7784,7 @@ test("direct DeepSeek screenshots do not saturate the prompt-token estimate", as
   });
   const image_url = `data:image/png;base64,${"A".repeat(3_600_000)}`;
   const body = JSON.stringify({
-    model: "deepseek/deepseek-flash",
+    model: "deepseek/deepseek-v4.1-flash",
     input: [{ role: "user", content: [
       { type: "input_text", text: "Inspect this screenshot." },
       { type: "input_image", image_url },
@@ -7814,7 +7814,7 @@ test("direct DeepSeek screenshots do not saturate the prompt-token estimate", as
         .filter((part) => part.type === "input_image");
       assert.equal(images.length, 1);
       assert.equal(images[0].image_url, image_url);
-      assert.equal(gatewayBodies.at(-1).model, "deepseek-flash");
+      assert.equal(gatewayBodies.at(-1).model, "deepseek-v4-1-flash");
     }
   } finally {
     await stopChild(router);


### PR DESCRIPTION
## Summary

This renames the direct DeepSeek API V4.1 Flash route from `deepseek/deepseek-flash` to **`deepseek/deepseek-v4.1-flash`**. That matches the other V4.1 Flash routes added in #682:

| Route | Upstream id |
|---|---|
| `deepseek/deepseek-v4.1-flash` (renamed) | `deepseek-flash` (unchanged) |
| `opencode-go/deepseek-v4.1-flash` | `deepseek-v4.1-flash` |
| `nousresearch/deepseek-v4.1-flash` | `deepseek/deepseek-v4.1-flash` |
| `commandcode/deepseek-v4.1-flash` | `deepseek/deepseek-v4.1-flash` |

- **What changes:** the slug, gateway id (`deepseek-v4-1-flash`), and comp hash follow the new name.
- **What stays the same:** the upstream id is still `deepseek-flash`, DeepSeek's documented API id. #681's native Responses routing (`usesDeepSeekResponses`) and the direct-DeepSeek image token bound both key on provider plus upstream id, so their behavior is unchanged.
- **No upgrade mapping.** The old slug landed after `v0.5.1` and has not shipped in a release.
- **Docs and tests:** README, CHANGELOG, the research note and the tests are updated. #681's DeepSeek Responses fixtures now mirror the renamed route's slug and gateway id. The catalog picker assertion moves the entry to its new alphabetical position.

## Testing

- `npm run check` passes.
- `node --test` passed for `deepseek-v4-1-flash`, `registry`, `catalog`, `control`, `provider-selection`, `model-discovery`, and `deepseek-responses-routing`.
- The `routing.test.mjs` image tests (6/6) pass, including the direct DeepSeek image-estimate test.
- The one failure from the first run (the catalog picker order) was caused by the rename and is fixed. The same test passes on plain `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
