### PR TITLE
fix: allow large DeepSeek reasoning after liveness release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **DeepSeek empty-completion guard allows large reasoning after liveness
+  release.** Issue #684: Direct DeepSeek V4.1 Flash MCP turns with large
+  reasoning deltas no longer hit the empty-completion byte limit prematurely.
+  After liveness is established (by initial reasoning or content), the guard
+  uses a 10MB limit for incomplete SSE blocks instead of the 1MB pre-liveness
+  limit. This accommodates legitimate large reasoning events delivered in
+  small network chunks while still protecting against unbounded/malformed
+  streams. Fixes #684.
 - **DeepSeek V4.1 Flash is available on four providers, alongside V4.**
   DeepSeek released V4.1 Flash on 2026-09-10. New routes:
   `deepseek/deepseek-v4.1-flash` (1M window, image input, thinking with

--- a/src/empty-completion-guard.mjs
+++ b/src/empty-completion-guard.mjs
@@ -5,6 +5,10 @@ import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 
 const MAX_PRECONTENT_BYTES = 1024 * 1024;
 const MAX_PRECONTENT_MS = 30_000;
+// After liveness is established, allow much larger incomplete SSE blocks to
+// accommodate legitimate large reasoning deltas (issue #684), while still
+// protecting against unbounded/malformed streams.
+const MAX_POST_LIVENESS_INCOMPLETE_BYTES = 10 * 1024 * 1024; // 10MB
 
 export class EmptyCompletionPreludeLimitError extends Error {
   constructor(kind) {
@@ -488,12 +492,15 @@ export class EmptyCompletionGuard extends Transform {
       // A liveness or time-limit release ends the hold, not the question. Keep
       // parsing from behind the relay so a turn that later produces nothing is
       // still recognized — it just gets reported instead of retried.
+      // After release, use a much higher limit for incomplete SSE blocks to allow
+      // legitimate large reasoning deltas (issue #684) while still protecting
+      // against unbounded/malformed streams.
       if (!this.#settled()) {
         this.#parseBuffer += this.#decoder.write(bytes);
         this.#consumeBlocks();
         if (
           !this.#settled() &&
-          Buffer.byteLength(this.#parseBuffer) > this.#maxPreludeBytes
+          Buffer.byteLength(this.#parseBuffer) > MAX_POST_LIVENESS_INCOMPLETE_BYTES
         ) {
           this.#failPrelude("bytes");
         }

--- a/test/empty-completion-guard-deepseek.test.mjs
+++ b/test/empty-completion-guard-deepseek.test.mjs
@@ -1,0 +1,348 @@
+import assert from "node:assert/strict";
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import test from "node:test";
+
+import {
+  EmptyCompletionGuard,
+  EmptyCompletionTerminalGuard,
+} from "../src/empty-completion-guard.mjs";
+
+async function runGuard(
+  input,
+  {
+    contentType = "text/event-stream; charset=utf-8",
+    chunkSize = 0,
+    maxPreludeBytes,
+    maxPreludeMs,
+  } = {},
+) {
+  const guard = new EmptyCompletionGuard(contentType, {
+    ...(maxPreludeBytes === undefined ? {} : { maxPreludeBytes }),
+    ...(maxPreludeMs === undefined ? {} : { maxPreludeMs }),
+  });
+  const chunks = [];
+  const collector = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.from(chunk));
+      callback();
+    },
+  });
+  const source = [];
+  if (chunkSize > 0) {
+    for (let at = 0; at < input.length; at += chunkSize) {
+      source.push(Buffer.from(input.slice(at, at + chunkSize)));
+    }
+  } else {
+    source.push(Buffer.from(input));
+  }
+  await pipeline(Readable.from(source), guard, collector);
+  return {
+    body: Buffer.concat(chunks).toString("utf8"),
+    empty: guard.isEmpty(),
+    suppressed: guard.suppressedPrologue(),
+    live: guard.releasedForLiveness(),
+    preludeLimit: guard.preludeLimitKind(),
+  };
+}
+
+function block(...parts) {
+  return parts.join("\n") + "\n\n";
+}
+
+// DeepSeek V4 Flash with many MCP tools: large tool declarations in prologue
+// plus reasoning can exceed byte limit before tool call content appears.
+test("Large MCP tool declarations plus reasoning before tool call should not hit byte limit prematurely", async () => {
+  // Simulate many MCP tools with large schemas (each ~50KB)
+  const largeToolSchema = JSON.stringify({
+    properties: {
+      param1: { type: "string", description: "x".repeat(10000) },
+      param2: { type: "string", description: "y".repeat(10000) },
+      param3: { type: "string", description: "z".repeat(10000) },
+      param4: { type: "string", description: "w".repeat(10000) },
+      param5: { type: "string", description: "v".repeat(10000) },
+    }
+  });
+  
+  // Build a large response.created event with many tools
+  const manyTools = [];
+  for (let i = 0; i < 15; i++) {
+    manyTools.push({ name: `mcp_tool_${i}`, schema: largeToolSchema });
+  }
+  
+  const createdEvent = {
+    type: "response.created",
+    response: {
+      id: "r_mcp",
+      tools: manyTools,
+      metadata: { large_field: "x".repeat(50000) }
+    }
+  };
+  
+  // ~800KB in response.created
+  const createdBlock = block(
+    'event: response.created',
+    `data: ${JSON.stringify(createdEvent)}`
+  );
+  
+  // Add reasoning that pushes total over 1MB
+  const reasoning = "thinking".repeat(30000); // ~240KB
+  
+  const input = [
+    createdBlock,
+    block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_mcp"}}'
+    ),
+    block(
+      'event: response.reasoning_text.delta',
+      `data: {"type":"response.reasoning_text.delta","delta":"${reasoning}"}`
+    ),
+    block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","id":"fc_mcp","name":"mcp_tool_0"}}'
+    ),
+    block(
+      'event: response.function_call_arguments.done',
+      'data: {"type":"response.function_call_arguments.done","item_id":"fc_mcp","arguments":"{}"}'
+    ),
+    block(
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"r_mcp","output":[]}}'
+    ),
+  ].join("");
+
+  const result = await runGuard(input, { maxPreludeBytes: 1024 * 1024 });
+  assert.equal(result.empty, false, "turn with tool call should not be empty");
+  // If this fails with preludeLimit: "bytes", that's the bug
+  assert.equal(result.preludeLimit, undefined, "should not hit prelude byte limit before tool call");
+  assert.match(result.body, /response\.function_call_arguments\.done/);
+});
+
+// Bug #684 reproduction: DeepSeek V4.1 Flash with incremental delivery of
+// massive reasoning can hit parse buffer limit if reasoning delta arrives
+// in many small network chunks, causing buffer to accumulate.
+test("Bug #684: incremental delivery of massive reasoning should not kill stream", async () => {
+  // Simulate realistic network chunking: large reasoning arrives in small pieces
+  const massiveReasoning = "x".repeat(1100000); // 1.1 MB reasoning
+  
+  const input = [
+    block(
+      'event: response.created',
+      'data: {"type":"response.created","response":{"id":"r_684"}}'
+    ),
+    block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_684"}}'
+    ),
+    // Trigger liveness release
+    block(
+      'event: response.reasoning_text.delta',
+      'data: {"type":"response.reasoning_text.delta","delta":"initial"}'
+    ),
+    // Large reasoning event that will be chunked
+    block(
+      'event: response.reasoning_text.delta',
+      `data: {"type":"response.reasoning_text.delta","delta":"${massiveReasoning}"}`
+    ),
+    // Tool call arrives after reasoning
+    block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","id":"fc_684","name":"exec"}}'
+    ),
+    block(
+      'event: response.function_call_arguments.done',
+      'data: {"type":"response.function_call_arguments.done","item_id":"fc_684","arguments":"{}"}'
+    ),
+    block(
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"r_684","output":[]}}"}'
+    ),
+  ].join("");
+
+  try {
+    // Use small chunks (1KB) to simulate incremental network delivery
+    const result = await runGuard(input, {
+      maxPreludeBytes: 1024 * 1024,
+      chunkSize: 1024
+    });
+    assert.equal(result.empty, false, "turn with tool call should not be empty");
+    assert.equal(result.preludeLimit, undefined, "Bug #684: should not hit parse buffer limit with chunked delivery");
+    assert.match(result.body, /response\.function_call_arguments\.done/);
+  } catch (error) {
+    // This is bug #684: guard throws when massive reasoning is delivered in chunks
+    assert.fail(`Bug #684: Guard threw error with chunked massive reasoning: ${error.message}`);
+  }
+});
+
+// DeepSeek V4 Flash with incomplete massive reasoning event should not kill
+// stream. This tests the parse buffer limit when an SSE event is very large
+// and hasn't been fully received yet.
+test("Incomplete massive reasoning event should not hit parse buffer limit", async () => {
+  // Create a massive data payload that will be incomplete (no double newline yet)
+  const massiveReasoning = "x".repeat(1100000); // 1.1 MB
+  
+  const input = [
+    block(
+      'event: response.created',
+      'data: {"type":"response.created","response":{"id":"r_incomplete"}}'
+    ),
+    block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_incomplete"}}'
+    ),
+    // Trigger liveness release
+    block(
+      'event: response.reasoning_text.delta',
+      'data: {"type":"response.reasoning_text.delta","delta":"initial"}'
+    ),
+    // Now send an incomplete SSE block (no double newline yet) that exceeds the limit
+    `event: response.reasoning_text.delta\ndata: {"type":"response.reasoning_text.delta","delta":"${massiveReasoning}"}`,
+    // No double newline yet - this makes the parse buffer exceed 1MB
+    // Then complete it and add the tool call
+    '\n\n',
+    ...block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","id":"fc_incomplete","name":"exec"}}'
+    ),
+    ...block(
+      'event: response.function_call_arguments.done',
+      'data: {"type":"response.function_call_arguments.done","item_id":"fc_incomplete","arguments":"{}"}'
+    ),
+    ...block(
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"r_incomplete","output":[]}}"}'
+    ),
+  ].join("");
+
+  try {
+    const result = await runGuard(input, { maxPreludeBytes: 1024 * 1024 });
+    assert.equal(result.empty, false, "turn with tool call should not be empty");
+    assert.equal(result.preludeLimit, undefined, "should not hit parse buffer limit with incomplete block");
+    assert.match(result.body, /response\.function_call_arguments\.done/);
+  } catch (error) {
+    // This is the bug! The guard throws when parse buffer exceeds limit
+    assert.fail(`Guard threw error with incomplete massive reasoning: ${error.message}`);
+  }
+});
+
+// DeepSeek V4 Flash with massive reasoning AFTER liveness release should not
+// hit parse buffer byte limit before tool call content appears. This is the
+// actual bug from #684: reasoning releases for liveness, but continued parsing
+// behind the relay can hit the byte limit if reasoning is large enough.
+test("Massive reasoning after liveness release should not kill stream before tool call", async () => {
+  // First, release for liveness with initial reasoning
+  const initialReasoning = "initial thinking...";
+  
+  // Then add MASSIVE reasoning that will exceed parse buffer limit (>1MB)
+  // while parsing behind the relay AFTER the stream was released for liveness
+  const massiveReasoning = "x".repeat(1100000); // 1.1 MB
+  
+  const input = [
+    block(
+      'event: response.created',
+      'data: {"type":"response.created","response":{"id":"r_bug"}}'
+    ),
+    block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_bug"}}'
+    ),
+    // This triggers liveness release
+    block(
+      'event: response.reasoning_text.delta',
+      `data: {"type":"response.reasoning_text.delta","delta":"${initialReasoning}"}`
+    ),
+    // Now stream is released, but guard keeps parsing behind relay.
+    // This massive reasoning delta will cause parse buffer to exceed 1MB
+    block(
+      'event: response.reasoning_text.delta',
+      `data: {"type":"response.reasoning_text.delta","delta":"${massiveReasoning}"}`
+    ),
+    // Tool call arrives after the massive reasoning
+    block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","id":"fc_bug","name":"exec"}}'
+    ),
+    block(
+      'event: response.function_call_arguments.done',
+      'data: {"type":"response.function_call_arguments.done","item_id":"fc_bug","arguments":"{}"}'
+    ),
+    block(
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"r_bug","output":[]}}"}'
+    ),
+  ].join("");
+
+  try {
+    const result = await runGuard(input, { maxPreludeBytes: 1024 * 1024 });
+    assert.equal(result.empty, false, "turn with tool call should not be empty");
+    // This is the bug: result.preludeLimit should be undefined but it's "bytes"
+    assert.equal(result.preludeLimit, undefined, "should not hit parse buffer limit after liveness release");
+    assert.match(result.body, /response\.function_call_arguments\.done/);
+  } catch (error) {
+    // This catch block should NOT trigger - if it does, that's the bug!
+    assert.fail(`Guard threw error after liveness release: ${error.message}`);
+  }
+});
+
+// The guard should still detect truly empty turns (reasoning only, no tool calls)
+test("DeepSeek reasoning without any content is still recognized as empty", async () => {
+  const input = [
+    block(
+      'event: response.created',
+      'data: {"type":"response.created","response":{"id":"r2"}}'
+    ),
+    block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"reasoning","id":"rs_2"}}'
+    ),
+    block(
+      'event: response.reasoning_text.delta',
+      'data: {"type":"response.reasoning_text.delta","delta":"thinking..."}'
+    ),
+    block(
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"r2","output":[]}}'
+    ),
+    block(
+      'event: response.done',
+      'data: {"type":"response.done","response":{"id":"r2"}}'
+    ),
+  ].join("");
+
+  const result = await runGuard(input);
+  assert.equal(result.empty, true, "turn with only reasoning should be empty");
+  assert.equal(result.suppressed, false, "reasoning delta ends the hold");
+  assert.equal(result.live, true, "reasoning proves liveness");
+});
+
+// Verify the guard recognizes tool call opening event as content immediately
+test("response.output_item.added with function_call type is recognized as content", async () => {
+  const input = [
+    block(
+      'event: response.created',
+      'data: {"type":"response.created","response":{"id":"r3"}}'
+    ),
+    block(
+      'event: response.output_item.added',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_immediate","name":"test"}}'
+    ),
+    block(
+      'event: response.function_call_arguments.done',
+      'data: {"type":"response.function_call_arguments.done","item_id":"fc_immediate","arguments":"{}"}'
+    ),
+    block(
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"r3","output":[]}}'
+    ),
+    block(
+      'event: response.done',
+      'data: {"type":"response.done","response":{"id":"r3"}}'
+    ),
+  ].join("");
+
+  const result = await runGuard(input);
+  assert.equal(result.empty, false, "function_call item should be content");
+  // When the content event and terminal are adjacent, the terminal may be
+  // processed before the guard releases, so suppressed can be either true or false
+});

--- a/test/empty-completion-guard.test.mjs
+++ b/test/empty-completion-guard.test.mjs
@@ -772,15 +772,17 @@ test("post-release parsing is bounded for an unterminated event", async () => {
     "",
   ].join("\n");
   const guard = new EmptyCompletionGuard("text/event-stream", {
-    maxPreludeBytes: 64,
+    maxPreludeBytes: 1024 * 1024, // 1MB pre-release limit
     maxPreludeMs: 1_000,
   });
   const chunks = [];
+  // Post-release limit is 10MB, so send >10MB in an unterminated event
+  const hugeUnterminated = `event: response.in_progress\ndata: ${"x".repeat(11 * 1024 * 1024)}`;
   await assert.rejects(
     pipeline(
       Readable.from([
         Buffer.from(reasoning),
-        Buffer.from(`event: response.in_progress\ndata: ${"x".repeat(128)}`),
+        Buffer.from(hugeUnterminated),
       ]),
       guard,
       new Writable({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #684

## Summary
Direct DeepSeek V4.1 Flash MCP turns were hitting the empty-completion byte limit prematurely when large reasoning deltas arrived in small network chunks. This fix raises the post-liveness limit to 10MB to accommodate legitimate large reasoning events.

## The Bug
The `EmptyCompletionGuard` was enforcing a 1MB limit on the incomplete SSE block parse buffer **both** before and after liveness was established. When large reasoning deltas (e.g., 1.1MB) arrived in small network chunks:

1. Initial reasoning delta triggers liveness release → stream starts flowing
2. More reasoning continues arriving in small chunks (e.g., 1KB each)
3. Each chunk is buffered in `#parseBuffer` until the complete SSE event is found
4. Before the event completes with `\n\n`, the buffer exceeds 1MB
5. Guard throws `EmptyCompletionPreludeLimitError` with `emptyCompletionPreludeLimit=bytes`

## The Fix
After liveness is established, use a much higher limit (10MB) for incomplete SSE blocks:
- **Pre-liveness**: Keep strict 1MB limit to catch broken upstreams quickly
- **Post-liveness**: Use 10MB limit to accommodate legitimate large reasoning
- Still protects against unbounded/malformed streams with the higher limit

## Changes
- `src/empty-completion-guard.mjs`: Add `MAX_POST_LIVENESS_INCOMPLETE_BYTES` constant and apply it after liveness release
- `test/empty-completion-guard-deepseek.test.mjs`: New focused regression tests for issue #684
- `test/empty-completion-guard.test.mjs`: Updated existing test to use realistic 10MB+ unterminated event
- `CHANGELOG.md`: Added Unreleased entry

## Testing
All new tests pass, including:
- ✅ Bug reproduction with incremental 1.1MB reasoning delivery in 1KB chunks
- ✅ Large MCP tool declarations + reasoning before tool calls
- ✅ Incomplete massive reasoning events
- ✅ Proper empty turn detection still works
- ✅ Tool call recognition as content

The pre-existing flaky test in `deepseek-responses-routing.test.mjs` ("direct DeepSeek Responses preserves") was already failing before these changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-361ed72c-11e9-4ccb-9beb-f966481ac1b8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-361ed72c-11e9-4ccb-9beb-f966481ac1b8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

