### PR TITLE
fix: keep Grok compaction on Grok transport bounds and meter delivered failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2012,10 +2012,13 @@ xAI and Codex has its own idle limit. The router's post-prologue stall guard
 (`CODEX_ROUTER_GROK_STREAM_STALL_MS`, ten minutes) is the one meant to decide.
 
 1. **Every transport hop outlasts the guard.** `src/grok-stream-timeouts.mjs`
-   sizes the router's Grok gateway pool, the gateway's per-deployment
-   `stream_timeout`, and the forwarder's xAI pool from that one value. A new hop
-   on the Grok path takes its bound from there. The shared Undici pool keeps its
-   default for every other provider.
+   sizes the router's Grok gateway pool (its headers and body bounds), the
+   gateway's per-deployment `stream_timeout` and non-streaming `timeout`, and
+   the forwarder's xAI pool from that one value. Compaction is a hop too: it is
+   not streamed, so its headers arrive only after the whole generation, and it
+   uses the same pool and deployment bound as a turn. A new hop on the Grok path
+   takes its bound from there. The shared Undici pool keeps its default for
+   every other provider.
 2. **Codex's idle timer is fed a lifecycle event, never a comment.** Codex
    abandons a stream after five minutes without a parsed data event and sends
    the whole turn again, which bills the provider twice; an SSE comment or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Grok compaction keeps the Grok transport bounds, and a failed Grok turn
+  stays a failure when the client leaves.** A Grok OAuth compaction now uses
+  the same long-idle router pool and gateway `timeout` as a streamed turn, so a
+  long summary is no longer cut off by the 300-second Undici or 600-second
+  gateway defaults. A Grok turn that already delivered a terminal error is
+  metered and reported in `/activity` as a failure even if the client then
+  closes the still-open stream, which the WebSocket edge does five seconds
+  after a failure; it used to read as a user cancellation.
 - **DeepSeek V4.1 Flash is available on four providers, alongside V4.**
   DeepSeek released V4.1 Flash on 2026-09-10. New routes:
   `deepseek/deepseek-v4.1-flash` (1M window, image input, thinking with

--- a/src/fetch-transport.mjs
+++ b/src/fetch-transport.mjs
@@ -54,7 +54,10 @@ export function installStableFetchTransport({
 // pool keeps Undici's 300s body idle bound for every other provider; a hop that
 // carries a Grok stream uses this separate pool instead, whose bound outlasts
 // the router's stall guard. The dispatcher class and proxy decision match the
-// shared pool, so only the idle bound differs.
+// shared pool, so only the idle bounds differ. The headers bound moves with the
+// body bound: a Grok compaction is not streamed, so the gateway answers its
+// headers only after the whole generation, and Undici's 300s headers default
+// would end a long compaction before the stall guard's allowance.
 const longIdleStreamDispatchers = new Map();
 
 export function longIdleStreamDispatcher(bodyTimeoutMs, {
@@ -70,6 +73,7 @@ export function longIdleStreamDispatcher(bodyTimeoutMs, {
       : AgentClass;
     dispatcher = new DispatcherClass({
       ...fetchDispatcherOptions(),
+      headersTimeout: bodyTimeoutMs,
       bodyTimeout: bodyTimeoutMs,
     });
     longIdleStreamDispatchers.set(bodyTimeoutMs, dispatcher);

--- a/src/litellm-config.mjs
+++ b/src/litellm-config.mjs
@@ -65,10 +65,15 @@ export function renderLiteLlmConfig() {
       '      api_key: "os.environ/CODEX_ROUTER_INTERNAL_KEY"',
       ...(responsesSurface ? [] : ["      use_chat_completions_api: true"]),
       // A Grok OAuth turn can be silent for minutes while it reasons, so its
-      // stream timeout outlasts the router's stall guard. Every other
-      // deployment keeps the global request_timeout below.
+      // stream timeout outlasts the router's stall guard. Compaction reaches
+      // the same deployment without streaming, where `timeout` applies
+      // instead, so it gets the same bound. Every other deployment keeps the
+      // global request_timeout below.
       ...(model.provider === "grok-oauth"
-        ? [`      stream_timeout: ${grokGatewayStreamTimeoutSeconds()}`]
+        ? [
+            `      stream_timeout: ${grokGatewayStreamTimeoutSeconds()}`,
+            `      timeout: ${grokGatewayStreamTimeoutSeconds()}`,
+          ]
         : []),
       "",
     );

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -2687,7 +2687,9 @@ async function summarizeWith(
   ) {
     return { searchCapabilityChanged: true };
   }
-  const upstream = await fetch(routedResponsesTarget(route), {
+  // Compaction is another hop on the route's transport: a Grok summary can
+  // reason for as long as a turn, so it uses the same long-idle pool.
+  const upstream = await fetchForRoute(route, routedResponsesTarget(route), {
     method: "POST",
     headers: routedHeaders(),
     body: serialized,
@@ -4407,13 +4409,15 @@ async function handleResponses(request, response, requestUrl) {
       !nativeCompletedBeforeClose;
     finalStatus = clientWalkedAway ? 0 : upstream.status;
     if (
-      !clientWalkedAway &&
       route?.provider === "grok-oauth" &&
       usageTransform?.terminalErrorObserved?.() === true
     ) {
       // The Grok forwarder has already committed the HTTP 200 SSE head when a
       // post-tool repair can fail. Keep the client-visible terminal event, but
-      // account for the turn as a provider failure rather than a success.
+      // account for the turn as a provider failure rather than a success. That
+      // holds when the client leaves afterwards too: the WebSocket edge aborts
+      // a stream the gateway keeps open after its failure, and a failure that
+      // already happened is not a canceled generation.
       finalStatus = 502;
     }
     if (streamedPreludeFailureKind && !clientWalkedAway) finalStatus = 502;

--- a/test/fetch-transport.test.mjs
+++ b/test/fetch-transport.test.mjs
@@ -91,7 +91,12 @@ test("a Grok long-idle pool raises only the body idle bound and keeps the proxy 
   const classes = { AgentClass: FakeAgent, EnvHttpProxyAgentClass: FakeEnvHttpProxyAgent, execArgv: [] };
   const direct = longIdleStreamDispatcher(660_001, { ...classes, environment: {} });
   assert.equal(direct.kind, "direct");
-  assert.deepEqual(direct.options, { allowH2: false, pipelining: 1, bodyTimeout: 660_001 });
+  assert.deepEqual(direct.options, {
+    allowH2: false,
+    pipelining: 1,
+    headersTimeout: 660_001,
+    bodyTimeout: 660_001,
+  });
   assert.equal(longIdleStreamDispatcher(660_001), direct, "one pool per bound, not one per request");
   const proxied = longIdleStreamDispatcher(660_002, {
     ...classes,
@@ -119,6 +124,33 @@ test("the long-idle fetch honors its body idle bound on a real socket", async ()
     const impatient = await longIdleStreamFetch(url, {}, { bodyTimeoutMs: 100 });
     await assert.rejects(impatient.text(), (error) =>
       [error?.code, error?.cause?.code].includes("UND_ERR_BODY_TIMEOUT"));
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test("the long-idle fetch honors the same bound for response headers", async () => {
+  // A non-streaming Grok compaction receives its headers only after the whole
+  // generation, so a pause before the head must be bounded like a pause
+  // between body chunks rather than by Undici's 300s headers default.
+  const server = http.createServer((_request, response) => {
+    const timer = setTimeout(() => {
+      response.writeHead(200, { "Content-Type": "text/plain" });
+      response.end("late head");
+    }, 2_500);
+    response.once("close", () => clearTimeout(timer));
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const url = `http://127.0.0.1:${server.address().port}/`;
+  try {
+    const patient = await longIdleStreamFetch(url, {}, { bodyTimeoutMs: 10_000 });
+    assert.equal(await patient.text(), "late head");
+    // Negative control: the same delay before the head trips a shorter bound.
+    await assert.rejects(
+      longIdleStreamFetch(url, {}, { bodyTimeoutMs: 100 }),
+      (error) => [error?.code, error?.cause?.code].includes("UND_ERR_HEADERS_TIMEOUT"),
+    );
   } finally {
     server.closeAllConnections?.();
     await new Promise((resolve) => server.close(resolve));

--- a/test/grok-fast-config.test.mjs
+++ b/test/grok-fast-config.test.mjs
@@ -126,3 +126,18 @@ test("rendered catalog keeps Fast opt-in on grok-oauth/grok-4.6 and leaves Grok 
   assert.deepEqual(grok45.service_tiers, []);
   assert.equal(grok45.default_service_tier, null);
 });
+
+// Compaction reaches the Grok deployment without streaming, where LiteLLM
+// applies `timeout` rather than `stream_timeout`. Both must outlast the router's
+// stall guard, and no other deployment may pick up either bound.
+test("Grok deployments bound non-streaming calls like streams and other deployments keep the global timeout", () => {
+  const blocks = renderLiteLlmConfig().split("\n  - model_name: ").slice(1);
+  const grok = blocks.find((block) => block.startsWith('"grok-oauth-grok-4-6"'));
+  assert.ok(grok, "the grok-oauth/grok-4.6 deployment is rendered");
+  assert.match(grok, /\n {6}stream_timeout: 660\n/);
+  assert.match(grok, /\n {6}timeout: 660\n/);
+
+  const others = blocks.filter((block) => !block.includes("stream_timeout"));
+  assert.ok(others.length > 0, "a non-Grok deployment is rendered");
+  for (const block of others) assert.doesNotMatch(block, /\n {6}timeout: /);
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -820,6 +820,103 @@ test("a routed Grok terminal SSE error is recorded as a failed turn", async () =
   }
 });
 
+test("a Grok terminal SSE error stays a failed turn when the client leaves the still-open stream", { timeout: 30_000 }, async () => {
+  let gatewayRequests = 0;
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    gatewayRequests += 1;
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.write(
+      'event: response.reasoning_summary_text.delta\n' +
+        'data: {"type":"response.reasoning_summary_text.delta","delta":"Checking the tool result."}\n\n',
+    );
+    if (gatewayRequests === 1) {
+      response.write(
+        'event: error\n' +
+          'data: {"type":"error","code":"local_router_stream_failed","message":"Grok stopped after a tool result and its repair request failed upstream.","param":null}\n\n',
+      );
+    }
+    // A gateway can keep the stream open after its terminal; the WebSocket
+    // edge then aborts it. Hold it until the router lets go.
+    await new Promise((resolve) => {
+      request.once("close", resolve);
+      response.once("close", resolve);
+    });
+  });
+  const routerPort = await openPort();
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "codex-router-grok-open-error-"));
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_STATE_DIR: stateDir,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const request = (signal) =>
+    fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer CODEX_CALLER_SECRET",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "grok-oauth/grok-4.6",
+        input: "continue after the tool result",
+        stream: true,
+      }),
+      signal,
+    });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    // The terminal error reaches the client, which then leaves the open stream.
+    const leaver = new AbortController();
+    const failed = await request(leaver.signal);
+    assert.equal(failed.status, 200);
+    const reader = failed.body.getReader();
+    const decoder = new TextDecoder();
+    let body = "";
+    while (!body.includes("local_router_stream_failed")) {
+      const { value, done } = await reader.read();
+      assert.equal(done, false, `the stream ended before its terminal error: ${body}`);
+      body += decoder.decode(value, { stream: true });
+    }
+    leaver.abort();
+    const [failure] = await waitForUsageEvents(stateDir, 1, router);
+    assert.equal(failure.model, "grok-oauth/grok-4.6");
+    assert.equal(failure.status, 502);
+
+    // Negative control: leaving an open Grok stream that reported no failure
+    // is still a cancellation, not a provider failure. Leave only once the
+    // stream is flowing, the same point the failed turn above was left at;
+    // reasoning is liveness, so it reaches the client without a terminal.
+    const within = (promise, label) => {
+      let timer;
+      return Promise.race([
+        promise,
+        new Promise((_, reject) => {
+          timer = setTimeout(() => reject(new Error(`${label} did not arrive`)), 10_000);
+        }),
+      ]).finally(() => clearTimeout(timer));
+    };
+    const canceler = new AbortController();
+    const flowing = await within(request(canceler.signal), "the open stream's head");
+    assert.equal(flowing.status, 200);
+    const firstChunk = await within(flowing.body.getReader().read(), "the open stream's reasoning");
+    assert.equal(firstChunk.done, false);
+    canceler.abort();
+    const events = await waitForUsageEvents(stateDir, 2, router);
+    assert.equal(events[1].model, "grok-oauth/grok-4.6", JSON.stringify(events));
+    assert.equal(events[1].status, 0, JSON.stringify(events));
+    assert.equal(gatewayRequests, 2);
+  } finally {
+    await stopChild(router);
+    gateway.server.closeAllConnections?.();
+    await closeServer(gateway.server);
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
 test("router dispatches aliased native slugs to the mapped external model", async () => {
   const gatewayRequests = [];
   const gateway = await mockServer(async (request, response) => {


### PR DESCRIPTION
## Summary

Two follow-ups found while reviewing #678 after it merged.

### 1. Grok compaction was the one hop left on the default timeouts

AGENTS.md ("A silent Grok stream is kept alive, never replayed", rule 1) says every Grok transport hop takes its bound from `src/grok-stream-timeouts.mjs`. Routed compaction (`summarizeWith`) broke that rule on two layers:

- **Router pool:** compaction called the global `fetch`, so it was on the shared pool with Undici's 300 s defaults. Compaction sends `stream: false`, so the gateway sends headers only after the whole generation. `longIdleStreamDispatcher` raised only `bodyTimeout`, so even the Grok pool would have ended a long compaction at Undici's 300 s `headersTimeout`.
- **Gateway:** LiteLLM applies the per-deployment `stream_timeout` only to streaming calls. For non-streaming calls it falls back to `timeout` and then `litellm_settings.request_timeout` (600 s). This was checked in `litellm/router.py` 1.96, `_get_timeout` / `_get_non_stream_timeout`.

Result: a Grok 4.6 compaction that reasoned for more than about five minutes failed, while the same pause in a streamed turn was allowed up to 11 minutes.

**Fix:**
- `summarizeWith` sends through `fetchForRoute`. Every non-Grok route still gets the global `fetch`.
- The long-idle Grok pool sets `headersTimeout` to the same bound as `bodyTimeout`. The shared pool and the forwarder's xAI pool are unchanged.
- Grok OAuth deployments render `timeout:` with the same value as `stream_timeout:`. No other deployment gets either.

### 2. A failed Grok turn could be metered as a user cancel

Since #678, the WebSocket edge aborts the internal `/v1/responses` request 5 s after a terminal `error`/`response.failed` if the gateway leaves the stream open. The router's Grok failure accounting skipped the 502 whenever the client had already left. So that turn was recorded with usage status 0, and `/activity` showed it as `canceled`, even though the provider failure had already reached the client.

**Fix:** once the router has seen a terminal `error` on a `grok-oauth` stream, the turn is metered as 502 even if the client leaves afterwards. Leaving a Grok stream that reported no failure still meters as 0.

### Not changed: `response.incomplete` on a first attempt

My review of #678 also flagged the forwarder turning a first-attempt `response.incomplete` into a terminal error. I didn't change it. Native Codex handles `response.incomplete` as a stream error too, and the old behaviour showed a truncated answer as `stop`, so #678 now matches native behaviour.

## Validation

- `node scripts-check.mjs` passes, and `git diff --check` is clean.
- **Proof the new tests catch the bugs:** I ran them against an untouched `da395a13` worktree.
  - `the long-idle fetch honors the same bound for response headers` fails there (`UND_ERR_HEADERS_TIMEOUT` not raised under the long bound).
  - `Grok deployments bound non-streaming calls like streams…` fails there.
  - `a Grok terminal SSE error stays a failed turn when the client leaves the still-open stream` fails there (`actual: 0, expected: 502`).
- **On this branch:**
  - `fetch-transport`, `grok-fast-config`, `grok-stream-timeouts`: 20/20.
  - The new router test: 10/10 consecutive runs.
  - `empty-completion-router`, `responses-websocket`, `model-failover-router`, `router-resilience`, `request-diagnostics-router`, config-rendering and AGENTS.md-reading suites: pass. Failures seen during a high-TIME_WAIT run reproduced on the untouched baseline as `EADDRNOTAVAIL` and passed on this branch once sockets drained.
  - `routing.test.mjs` Grok/cancel/compaction subset (20 tests): 17 passed on the first run. The other 3 hit `connect EADDRNOTAVAIL`, and all 3 passed on rerun once sockets drained. The untouched baseline failed the same tests with the same error. Both compaction tests use Kimi/DeepSeek routes, whose fetch is unchanged. The full suite is left to CI.
- **Not verified locally:** a live compaction longer than five minutes. The bound is covered by the headers-timeout socket test and the rendered-config test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
