### PR TITLE
fix: preserve MCP calls after large response preludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Preserve tool calls after large fragmented response preludes.** Allow one
+  unfinished initial event within the existing 10 MiB bound and match the
+  namespace relay's limit, so later MCP calls retain their client identities.
+  Prelude timeouts, empty-completion checks and retry safety remain intact.
 - **DeepSeek empty-completion guard allows large reasoning after liveness
   release.** Issue #684: Direct DeepSeek V4.1 Flash MCP turns with large
   reasoning deltas no longer hit the empty-completion byte limit prematurely.

--- a/src/empty-completion-guard.mjs
+++ b/src/empty-completion-guard.mjs
@@ -5,10 +5,9 @@ import { HeaderlessSseDetector } from "./sse-prefix.mjs";
 
 const MAX_PRECONTENT_BYTES = 1024 * 1024;
 const MAX_PRECONTENT_MS = 30_000;
-// After liveness is established, allow much larger incomplete SSE blocks to
-// accommodate legitimate large reasoning deltas (issue #684), while still
-// protecting against unbounded/malformed streams.
-const MAX_POST_LIVENESS_INCOMPLETE_BYTES = 10 * 1024 * 1024; // 10MB
+// An individual event can echo tool schemas or carry a large reasoning delta.
+// Bound its unfinished frame separately from the accumulated prelude hold.
+const MAX_INCOMPLETE_EVENT_BYTES = 10 * 1024 * 1024;
 
 export class EmptyCompletionPreludeLimitError extends Error {
   constructor(kind) {
@@ -500,7 +499,7 @@ export class EmptyCompletionGuard extends Transform {
         this.#consumeBlocks();
         if (
           !this.#settled() &&
-          Buffer.byteLength(this.#parseBuffer) > MAX_POST_LIVENESS_INCOMPLETE_BYTES
+          Buffer.byteLength(this.#parseBuffer) > MAX_INCOMPLETE_EVENT_BYTES
         ) {
           this.#failPrelude("bytes");
         }
@@ -513,15 +512,27 @@ export class EmptyCompletionGuard extends Transform {
     this.#parseBuffer += this.#decoder.write(bytes);
     this.#consumeBlocks();
     if (!this.#released && this.#bufferedBytes > this.#maxPreludeBytes) {
+      const pendingBytes = Buffer.byteLength(this.#parseBuffer);
+      // Let a fragmented first event finish before classifying it. Retain at
+      // most one bounded unfinished frame beyond the prelude budget; completed
+      // malformed blocks cannot accumulate behind a small unfinished tail.
+      if (
+        !this.#sawTerminal &&
+        pendingBytes > 0 &&
+        pendingBytes <= MAX_INCOMPLETE_EVENT_BYTES &&
+        this.#bufferedBytes - pendingBytes <= this.#maxPreludeBytes
+      ) {
+        return;
+      }
       // A large but well-framed prologue is not a broken stream. Providers can
       // echo substantial response metadata before the first delta; relaying a
       // completed JSON event bounds our staging memory while parsing behind
-      // the relay preserves the eventual empty/content verdict. An unframed or
-      // unparseable body still fails closed at the same byte limit.
+      // the relay preserves the eventual empty/content verdict. Oversized
+      // unfinished frames and unparseable completed bodies still fail closed.
       if (
         this.#sawParseableEvent &&
         !this.#sawTerminal &&
-        Buffer.byteLength(this.#parseBuffer) <= this.#maxPreludeBytes
+        pendingBytes <= MAX_INCOMPLETE_EVENT_BYTES
       ) {
         this.#release({ preludeLimit: "bytes" });
       } else {

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -587,7 +587,7 @@ const TRACKED_STATE_FIXED_BYTES = 512;
 // a later terminal event may carry the complete response and therefore shares
 // the non-streaming JSON capture bound. Crossing either phase's bound releases
 // raw bytes before a commit and terminates the stream after one.
-const MAX_SSE_FRAME_BYTES = 256 * 1024;
+const MAX_SSE_FRAME_BYTES = 10 * 1024 * 1024;
 const MAX_COMMITTED_SSE_FRAME_BYTES = MAX_JSON_CAPTURE_BYTES;
 const LINE_FEED = 0x0a;
 const CARRIAGE_RETURN = 0x0d;

--- a/test/empty-completion-guard.test.mjs
+++ b/test/empty-completion-guard.test.mjs
@@ -677,6 +677,53 @@ test("a large parseable prologue is relayed at the byte budget and later content
   assert.equal(Buffer.concat(chunks).toString("utf8"), prologue + answer);
 });
 
+test("a fragmented initial event can finish before the prelude verdict", async () => {
+  const prologue = `event: response.created\ndata: ${JSON.stringify({
+    type: "response.created",
+    response: { id: "r1", tools: Array.from({ length: 32 }, (_, index) => ({
+      type: "function", name: `tool_${index}`, description: "x".repeat(45_000),
+      parameters: { type: "object", properties: {} },
+    })) },
+  })}\n\n`;
+  const answer = 'event: response.output_item.added\n'
+    + 'data: {"type":"response.output_item.added","item":{"type":"function_call","name":"tool_0","call_id":"call_1","arguments":"{}"}}\n\n';
+  assert.ok(Buffer.byteLength(prologue) > 1024 * 1024);
+  for (const chunkSize of [0, 1024, 64 * 1024]) {
+    const result = await runGuard(prologue + answer, { chunkSize });
+    assert.equal(result.body, prologue + answer);
+    assert.equal(result.empty, false);
+    assert.equal(result.suppressed, false);
+  }
+});
+
+test("a fragmented prelude still hides empty terminal events after release", async () => {
+  const prologue = `event: response.created\ndata: ${JSON.stringify({
+    type: "response.created", response: { id: "r1", metadata: "x".repeat(256) },
+  })}\n\n`;
+  const terminal = 'event: response.completed\n'
+    + 'data: {"type":"response.completed","response":{"id":"r1","output":[]}}\n\n';
+  async function* fragmentedTurn() {
+    for (let at = 0; at < prologue.length; at += 32) yield prologue.slice(at, at + 32);
+    yield terminal;
+  }
+  const guard = new EmptyCompletionGuard("text/event-stream", { maxPreludeBytes: 64 });
+  const chunks = [];
+  await pipeline(
+    Readable.from(fragmentedTurn()),
+    guard,
+    new EmptyCompletionTerminalGuard(guard, "text/event-stream"),
+    new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(Buffer.from(chunk));
+        callback();
+      },
+    }),
+  );
+  assert.equal(Buffer.concat(chunks).toString("utf8"), prologue);
+  assert.equal(guard.isEmpty(), true);
+  assert.equal(guard.suppressedPrologue(), false);
+});
+
 test("a valid event does not excuse a later oversized unterminated event", async () => {
   const created = [
     "event: response.created",
@@ -692,7 +739,7 @@ test("a valid event does not excuse a later oversized unterminated event", async
   await assert.rejects(
     pipeline(
       Readable.from([
-        Buffer.from(created + `event: response.in_progress\ndata: ${"x".repeat(128)}`),
+        Buffer.from(created + `event: response.in_progress\ndata: ${"x".repeat(11 * 1024 * 1024)}`),
       ]),
       guard,
       new Writable({
@@ -707,6 +754,13 @@ test("a valid event does not excuse a later oversized unterminated event", async
   );
   assert.equal(guard.suppressedPrologue(), true);
   assert.equal(Buffer.concat(chunks).length, 0);
+});
+
+test("malformed completed blocks cannot accumulate behind an unfinished event", async () => {
+  await assert.rejects(
+    runGuard("data: invalid\n\n".repeat(16) + 'data: {', { maxPreludeBytes: 64 }),
+    (error) => error instanceof EmptyCompletionPreludeLimitError && error.kind === "bytes",
+  );
 });
 
 test("a time limit relays the staged stream but keeps its empty verdict", async () => {

--- a/test/empty-completion-router.test.mjs
+++ b/test/empty-completion-router.test.mjs
@@ -74,7 +74,7 @@ const CONTENT_SSE = [
   "",
 ].join("\n");
 
-// Large enough to force the guard past its 1 MiB pre-content hold budget
+// Large enough to exceed the guard's 10 MiB incomplete-event ceiling
 // before any client-visible output arrives. Deliberately not a reasoning event:
 // reasoning releases the hold on liveness long before the byte cap, so a
 // reasoning prelude would exercise the wrong release path.
@@ -85,7 +85,7 @@ const BUDGET_RELEASE_REASONING_SSE = [
   "event: response.in_progress",
   `data: ${JSON.stringify({
     type: "response.in_progress",
-    response: { id: "r-budget", status: "x".repeat(2 * 1024 * 1024) },
+    response: { id: "r-budget", status: "x".repeat(11 * 1024 * 1024) },
   })}`,
   "",
 ].join("\n");
@@ -432,6 +432,59 @@ const TURN_BODY = {
   input: "hello",
   stream: true,
 };
+
+test("a large initial event preserves a namespaced tool call without retrying", async () => {
+  const tool = {
+    type: "function_call", id: "fc_1", call_id: "call_1",
+    name: "fixture__probe", arguments: "{}",
+  };
+  const prologue = `event: response.created\ndata: ${JSON.stringify({
+    type: "response.created", response: { id: "r-large", metadata: "x".repeat(1_440_000) },
+  })}\n\n`;
+  const answer = [
+    { type: "response.output_item.added", output_index: 0, item: tool },
+    { type: "response.output_item.done", output_index: 0, item: tool },
+    { type: "response.completed", response: { id: "r-large", output: [tool] } },
+  ].map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`).join("");
+  for (const model of [TURN_BODY.model, "deepseek/deepseek-v4.1-flash"]) {
+    const paths = [];
+    const gw = await gateway((request, response) => {
+      paths.push(request.url);
+      response.writeHead(200, { "Content-Type": "text/event-stream" });
+      for (let at = 0; at < prologue.length; at += 4096) {
+        response.write(prologue.slice(at, at + 4096));
+      }
+      response.end(answer);
+    });
+    const routerPort = await openPort();
+    const router = run({
+      ...routerEnv(gw.port, routerPort),
+      CODEX_ROUTER_API_BASE_URL: `http://127.0.0.1:${gw.port}/native`,
+    });
+    try {
+      await waitFor(`${callerBaseUrl(routerPort, CALLER_KEY)}/models`, router);
+      const result = await readRouted(routerPort, {
+        ...TURN_BODY, model,
+        tools: [{ type: "namespace", name: "fixture", tools: [{ type: "function", name: "probe" }] }],
+      });
+      assert.equal(result.status, 200);
+      assert.equal(result.complete, true);
+      const calls = result.body.split("\n")
+        .filter((line) => line.startsWith("data: {"))
+        .map((line) => JSON.parse(line.slice(6)))
+        .flatMap((event) => event.item ? [event.item] : event.response?.output || []);
+      assert.deepEqual(
+        calls.map(({ name, namespace }) => ({ name, namespace })),
+        Array.from({ length: 3 }, () => ({ name: "probe", namespace: "fixture" })),
+      );
+      assert.ok(!result.body.includes("event: error"));
+      assert.deepEqual(paths, [model === TURN_BODY.model ? "/v1/responses" : "/native/responses"]);
+    } finally {
+      await stopChild(router);
+      await closeServer(gw.server);
+    }
+  }
+});
 
 // An empty completion used to reach the client as a clean 200 the app
 // recorded as a successful turn with no content. The router must retry the


### PR DESCRIPTION
Large fragmented initial Responses events can exceed the prelude limit before liveness starts. They can also disable namespace restoration, leaving later MCP calls with flattened tool names.

Allow one unfinished event within the existing 10 MiB bound and align the namespace relay's frame limit. The accumulated-prelude budget, timeout, empty-completion checks and prohibition on retries after relaying bytes remain intact.

Validation:

- **263 focused tests pass**, including a fragmented 1.44 MB initial event followed by a correctly restored MCP call without retry, plus malformed and oversized-event cases.
- **Live DeepSeek check passes** through the candidate router and official `/responses` endpoint: one request, HTTP 200, one completed response, and the expected tool name, namespace and arguments. Used `deepseek-flash` at `max` effort; 70 output tokens.
- `npm run check` and `git diff --check` pass.

The live response's largest event was about 32 KiB. It verifies live streaming and tool compatibility; the oversized-event boundary is covered by deterministic regressions. The reporter's original stream was unavailable.

Two runtime files, two test files and a short changelog entry, in one commit. Extends #686 and replaces #687 after its base branch was deleted. Related to #684.
