### PR TITLE
docs: document ChatGPT account blocking for GPT-6-like custom model slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,20 @@
 
 ## Unreleased
 
-- **Custom provider model slugs resembling native OpenAI models are blocked
-  server-side when using a ChatGPT account.** Issue #689: Recent Codex builds
-  validate custom-provider model slugs server-side and reject slugs that
-  resemble native OpenAI model names (particularly `gpt-6-*` patterns, such as
-  `unorouter/gpt-6-astra` or `private/gpt-6-astra`) when the user is signed in
-  with a ChatGPT account. The error `"The '<provider>/<model>' model is not
-  supported when using Codex with a ChatGPT account."` originates from Codex
-  itself, not from the router. Models with different naming patterns from the
-  same provider (such as `unorouter/grok-4.6`) work correctly because they do
-  not trigger this validation. Workarounds: (1) sign out of ChatGPT in Codex
-  and use the router's login-free mode; (2) use custom provider model slugs
-  that do not resemble native OpenAI names; or (3) wait for PR #673 which
-  implements a provider-switch mechanism. This limitation is now documented in
-  `docs/TROUBLESHOOTING.md` with detailed explanation and workarounds.
-  Fixes #689.
+- **Document known Codex-side blocking of custom provider GPT-6-like slugs.**
+  Issue #689: Recent Codex builds validate custom-provider model slugs
+  server-side and reject slugs that resemble native OpenAI model names
+  (particularly `gpt-6-*` patterns, such as `unorouter/gpt-6-astra` or
+  `private/gpt-6-astra`) when the user is signed in with a ChatGPT account.
+  The error `"The '<provider>/<model>' model is not supported when using Codex
+  with a ChatGPT account."` originates from Codex itself, not from the router.
+  Models with different naming patterns from the same provider (such as
+  `unorouter/grok-4.6`) work correctly because they do not trigger this
+  validation. **This router release does not fix the block** — the actual code
+  fix is in PR #673's provider-switch mechanism, which allows signed routing to
+  coexist with ChatGPT authentication. Until that lands, sign out of ChatGPT in
+  Codex and use the router's login-free mode. This limitation is now documented
+  in `docs/TROUBLESHOOTING.md` with detailed explanation. Related #689, #673.
 - **DeepSeek empty-completion guard allows large reasoning after liveness
   release.** Issue #684: Direct DeepSeek V4.1 Flash MCP turns with large
   reasoning deltas no longer hit the empty-completion byte limit prematurely.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Custom provider model slugs resembling native OpenAI models are blocked
+  server-side when using a ChatGPT account.** Issue #689: Recent Codex builds
+  validate custom-provider model slugs server-side and reject slugs that
+  resemble native OpenAI model names (particularly `gpt-6-*` patterns, such as
+  `unorouter/gpt-6-astra` or `private/gpt-6-astra`) when the user is signed in
+  with a ChatGPT account. The error `"The '<provider>/<model>' model is not
+  supported when using Codex with a ChatGPT account."` originates from Codex
+  itself, not from the router. Models with different naming patterns from the
+  same provider (such as `unorouter/grok-4.6`) work correctly because they do
+  not trigger this validation. Workarounds: (1) sign out of ChatGPT in Codex
+  and use the router's login-free mode; (2) use custom provider model slugs
+  that do not resemble native OpenAI names; or (3) wait for PR #673 which
+  implements a provider-switch mechanism. This limitation is now documented in
+  `docs/TROUBLESHOOTING.md` with detailed explanation and workarounds.
+  Fixes #689.
 - **DeepSeek empty-completion guard allows large reasoning after liveness
   release.** Issue #684: Direct DeepSeek V4.1 Flash MCP turns with large
   reasoning deltas no longer hit the empty-completion byte limit prematurely.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -89,6 +89,49 @@ To deliberately switch ownership to the checkout you are running from:
 MODEL_ROUTER_ALLOW_FOREIGN_STATE=1 ./bin/model-router codex doctor --fix
 ```
 
+## Custom provider models blocked with ChatGPT account
+
+**Symptom:** A custom OpenAI-compatible provider model (for example,
+`unorouter/gpt-6-astra` or `private/gpt-6-astra`) is rejected with:
+
+```
+The '<provider>/<model>' model is not supported when using Codex with a
+ChatGPT account.
+```
+
+**Root cause:** This error originates from the **Codex client/server**, not from
+the router. Recent Codex builds validate custom-provider model slugs and reject
+slugs that resemble native OpenAI model names (particularly `gpt-6-*` patterns)
+when the user is signed in with a ChatGPT account.
+
+**Why it happens:**
+- Codex performs server-side validation on model slugs to prevent custom
+  providers from impersonating native OpenAI models.
+- The validation triggers for slug patterns like `gpt-6-astra`, `gpt-6-*`,
+  and other names that look like official OpenAI models.
+- Models with different naming patterns from the same provider (such as
+  `unorouter/grok-4.6`) work correctly because they do not trigger this
+  validation.
+
+**Workarounds:**
+1. **Sign out of ChatGPT** in Codex to use custom providers with GPT-6-like
+   model names. The router's login-free mode still provides access to external
+   providers without requiring ChatGPT authentication.
+2. **Use different model slugs** that do not resemble native OpenAI names. For
+   example, rename `unorouter/gpt-6-astra` to `unorouter/astra-model` in your
+   custom provider configuration (though the upstream model ID sent to the
+   provider can remain `gpt-6-astra`).
+3. **Wait for PR #673** which implements a provider-switch mechanism to work
+   around Codex's validation while keeping ChatGPT authentication active.
+
+**What the router cannot do:**
+- The router cannot bypass or disable this validation because it occurs in the
+  Codex client/server before the request reaches the router.
+- Model slug renaming in the router configuration does not help if the renamed
+  slug still resembles a native OpenAI model name.
+
+Related issues: #645, #673, #689.
+
 ## External models are missing from the picker
 
 ```sh

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -112,23 +112,24 @@ when the user is signed in with a ChatGPT account.
 - Models with different naming patterns from the same provider (such as
   `unorouter/grok-4.6`) work correctly because they do not trigger this
   validation.
+- **Renaming the slug does not reliably bypass the block**: Issue #689 reported
+  that renaming `unorouter/gpt-6-astra` to `unorouter/agi-1` still triggered
+  the same ChatGPT account error, indicating Codex's validation may examine more
+  than just the public slug.
 
-**Workarounds:**
-1. **Sign out of ChatGPT** in Codex to use custom providers with GPT-6-like
-   model names. The router's login-free mode still provides access to external
-   providers without requiring ChatGPT authentication.
-2. **Use different model slugs** that do not resemble native OpenAI names. For
-   example, rename `unorouter/gpt-6-astra` to `unorouter/astra-model` in your
-   custom provider configuration (though the upstream model ID sent to the
-   provider can remain `gpt-6-astra`).
-3. **Wait for PR #673** which implements a provider-switch mechanism to work
-   around Codex's validation while keeping ChatGPT authentication active.
+**Current workaround:**
+1. **Sign out of ChatGPT** in Codex to use custom providers with blocked model
+   names. The router's login-free mode provides access to external providers
+   without requiring ChatGPT authentication.
+2. **Wait for PR #673** which implements a provider-switch mechanism to work
+   around Codex's validation while keeping ChatGPT authentication active. This
+   is the planned code fix.
 
 **What the router cannot do:**
 - The router cannot bypass or disable this validation because it occurs in the
   Codex client/server before the request reaches the router.
-- Model slug renaming in the router configuration does not help if the renamed
-  slug still resembles a native OpenAI model name.
+- Model slug renaming in the router configuration may not help — the reporter
+  observed the same block after renaming.
 
 Related issues: #645, #673, #689.
 

--- a/test/subagent-certify.test.mjs
+++ b/test/subagent-certify.test.mjs
@@ -5,6 +5,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+  accountRefusal,
   CHECK_LABELS,
   checksComplete,
   firstFailure,
@@ -46,6 +47,41 @@ test("the first failure is reported in reviewer order", () => {
   };
   assert.equal(firstFailure(checks).check, "toolCall");
   assert.equal(firstFailure(checks).detail, "no tool call");
+});
+
+test("account refusal detects ChatGPT blocking for custom provider models", () => {
+  // Issue #689: Custom provider models with GPT-6-like slugs are blocked by
+  // Codex server when signed in with a ChatGPT account.
+  const errorResponse = {
+    detail: "The 'unorouter/gpt-6-astra' model is not supported when using Codex with a ChatGPT account.",
+  };
+  const events = [errorResponse];
+  const refusal = accountRefusal(events);
+  assert.equal(typeof refusal, "string");
+  assert.match(refusal, /Codex will not spawn this route/i);
+  assert.match(refusal, /ChatGPT account/i);
+});
+
+test("account refusal detects renamed slug variants", () => {
+  // Issue #689: Even renaming the slug (e.g., unorouter/agi-1) doesn't help if
+  // the upstream model ID still triggers the pattern.
+  const errorResponse = {
+    detail: "The 'unorouter/agi-1' model is not supported when using Codex with a ChatGPT account.",
+  };
+  const events = [errorResponse];
+  const refusal = accountRefusal(events);
+  assert.equal(typeof refusal, "string");
+  assert.match(refusal, /Codex will not spawn this route/i);
+});
+
+test("account refusal does not trigger for other provider errors", () => {
+  const events = [
+    { error: "Rate limit exceeded" },
+    { error: "Invalid API key" },
+    { detail: "Model not found" },
+  ];
+  const refusal = accountRefusal(events);
+  assert.equal(refusal, undefined);
 });
 
 test("markers are unique per run so a stale transcript cannot pass a route", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents a known Codex-side limitation where recent Codex builds reject custom provider model slugs that resemble native OpenAI model names when using a ChatGPT account.

**This PR does not fix the block** — it provides documentation until the actual code fix (PR #673's provider-switch mechanism) lands.

Related to #689.

## Problem

Users reported that custom OpenAI-compatible provider models with GPT-6-like slugs (such as `unorouter/gpt-6-astra`) are blocked with:

```
The '<provider>/<model>' model is not supported when using Codex with a ChatGPT account.
```

Other models from the same provider (like `unorouter/grok-4.6`) work correctly. The reporter also confirmed that renaming the slug to `unorouter/agi-1` still triggered the same block, indicating Codex's validation examines more than just the public slug.

## Root Cause

Investigation revealed that:
- The error message originates from **Codex/OpenAI server-side validation**, not from this router
- Recent Codex builds validate custom-provider model slugs to prevent impersonation of native OpenAI models
- The validation triggers for slug patterns like `gpt-6-*` and other names resembling official OpenAI models
- This happens **before** the request reaches the router, so the router cannot bypass it

Evidence:
- The error string is only *matched* in this codebase (in `subagent-certify.mjs`) to detect when Codex rejects a model
- It is never *generated* by the router
- PR #673 explains this is a Codex server-side validation requiring a provider-switch code fix
- Issue #645 reported similar problems with native Astra access

## What This PR Does

Since the actual fix requires code changes in PR #673, this PR provides documentation:

1. **Adds troubleshooting documentation** in `docs/TROUBLESHOOTING.md`:
   - Explains the root cause clearly (Codex server-side validation)
   - Notes that renaming slugs does not reliably work (confirmed by reporter)
   - Provides current workaround: sign out of ChatGPT to use login-free mode
   - Points to PR #673 as the planned code fix
   - Explains what the router cannot do (bypass occurs before router is reached)

2. **Updates CHANGELOG.md**:
   - Clearly states "This router release does not fix the block"
   - Points to PR #673's provider-switch mechanism as the actual fix
   - Uses "Related #689" instead of "Fixes #689"

3. **Adds regression tests** verifying that `accountRefusal()` correctly detects this error pattern:
   - Test for original slug pattern (`unorouter/gpt-6-astra`)
   - Test for renamed variants that still trigger the block (`unorouter/agi-1`)
   - Test that other errors don't trigger false positives

## Testing

```bash
node --test test/subagent-certify.test.mjs --test-name-pattern="account refusal"
```

All three new tests pass:
- `account refusal detects ChatGPT blocking for custom provider models` ✓
- `account refusal detects renamed slug variants` ✓
- `account refusal does not trigger for other provider errors` ✓

## Status

This PR should remain open as a documentation companion until PR #673 lands with the provider-switch code fix. Once #673 is merged, this documentation will help users understand the limitation and workaround that existed before the fix.

## Scope

- Documentation only - no code behavior changes
- Clarifies that this is a known Codex-side limitation outside the router's control
- Correctly positions login-free mode as the current workaround
- Points users to PR #673 for the upcoming code fix
- Does not claim to fix the underlying issue

Related: #645, #673, #689
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13b9086a-7cc2-4fcd-b665-10c669ffea47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13b9086a-7cc2-4fcd-b665-10c669ffea47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

