### PR TITLE
fix: restore pre-flattened call identities on Responses-native routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1946,12 +1946,15 @@ retry rules on the shared path.
   Restore exact namespace/name identities, including plain-name collisions.
 - Codex can flatten native and MCP function/custom declarations before sending
   them to a routed provider. Restore namespaces only for live, directly exposed
-  tools identified by the request's canonical turn metadata, and only on routes
-  that flatten tools. Responses-native routes that skip flattening retain the
-  client's declaration shape. Restore before app expansion and normal flattening
-  so client schemas, custom formats and collaboration model constraints use the
-  existing adapters. Never infer tools from name prefixes or create declarations
-  from metadata alone; ambiguous and ordinary-name collisions remain unchanged.
+  tools identified by the request's canonical turn metadata. Rewrite declarations
+  only on routes that flatten tools. Responses-native routes that skip
+  flattening send the client's declarations unchanged, but build their response
+  lookup from the restored inventory so a returned flat call still reaches Codex
+  under its `{namespace, name}` identity. Restore before app expansion and
+  normal flattening so client schemas, custom formats and collaboration model
+  constraints use the existing adapters. Never infer tools from name prefixes or
+  create declarations from metadata alone; ambiguous and ordinary-name
+  collisions remain unchanged.
 - GLM thinking, legacy DeepSeek thinking and Command Code's DeepSeek Flash Chat
   route carry reasoning through LiteLLM as assistant `thinking` parts, restored
   by the forwarder to `reasoning_content`. Remove only successfully carried

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -3126,8 +3126,9 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
   const chatCompletionsProvider = provider?.protocol !== "openai-responses";
   const deepSeekResponses = usesDeepSeekResponses(route);
   const consoleGoResponsesCompatibility = needsConsoleGoResponsesToolCompatibility(route);
-  // Restore only where the existing adapter flattens tools again. Native
-  // Responses routes retain the client's original declaration shape.
+  // Restore declarations only where the existing adapter flattens tools again.
+  // Native Responses routes retain the client's original declaration shape and
+  // restore only their response lookup below.
   const clientTools = chatCompletionsProvider || deepSeekResponses || consoleGoResponsesCompatibility
     ? restorePreflattenedToolNamespaces(payload.tools, payload.client_metadata)
     : payload.tools;
@@ -3246,10 +3247,15 @@ async function buildRoutedRequest({ request, payload, route, agedInput }) {
     // is flattened and the list is left alone. The inventory is still built,
     // because the response transform reads the exact spawn_agent model enum off
     // it to drop an invented or stale optional override before Codex validates
-    // the call.
-    flattenedNamespaces = flattenNamespaceTools(tools, {
+    // the call. When Codex pre-flattened namespace tools, build that inventory
+    // from the restored declarations so a call returned under the flat wire
+    // name reaches Codex under the identity it dispatches by. The
+    // provider-facing list itself stays exactly as the client sent it.
+    const inventoryTools = restorePreflattenedToolNamespaces(tools, payload.client_metadata);
+    flattenedNamespaces = flattenNamespaceTools(inventoryTools, {
       bridgeToolSearch: false,
     }).namespaces;
+    namespacesFlattened = inventoryTools !== tools;
     // Keeping the namespace shape is not the same as keeping a parameter root
     // strict Responses providers may reject. Run the shared root repair on the
     // tools alone without flattening their native representation.

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -1794,9 +1794,14 @@ test("routed tool_search history declares discovered tools and restores their ca
   }
 });
 
-test("Responses-native routes preserve pre-flattened tools and call identities", async () => {
-  for (const stream of [true, false]) {
+// Codex dispatches by the native identity whichever upstream answers, so a
+// route that forwards the flat declarations unchanged must still restore the
+// call. Without turn metadata nothing identifies an MCP tool, and the flat
+// name stays exactly as the provider returned it.
+test("Responses-native routes preserve pre-flattened tools and restore call identities", async () => {
+  for (const [stream, metadata] of [[true, true], [false, true], [true, false], [false, false]]) {
     const payload = preflattenedCommandCodeMcpPayload(stream, "meta/muse-spark-1.2");
+    if (!metadata) delete payload.client_metadata;
     const name = payload.tools[0].name;
     const prior = { type: "function_call", name, call_id: "call_prior", arguments: "{}" };
     payload.input = [
@@ -1819,13 +1824,23 @@ test("Responses-native routes preserve pre-flattened tools and call identities",
     assert.equal(result.gatewayBodies.length, 1);
     const outgoing = result.gatewayBodies[0];
     assert.equal(outgoing.model, "meta-muse-spark-1-2");
-    assert.deepEqual(outgoing.tools, payload.tools, "do not synthesize namespace declarations");
-    assert.deepEqual(outgoing.input, payload.input);
+    assert.equal(
+      JSON.stringify(outgoing.tools),
+      JSON.stringify(payload.tools),
+      "do not synthesize namespace declarations",
+    );
+    assert.equal(JSON.stringify(outgoing.input), JSON.stringify(payload.input));
     assert.equal(outgoing.tool_choice, "auto", "retain Meta's existing tool-choice policy");
     const returned = stream
       ? functionCallsFromSse(result.clientBody).get(call.call_id)
       : JSON.parse(result.clientBody).output[0];
-    assert.deepEqual(returned, call, "preserve the flat response identity");
+    assert.deepEqual(
+      returned,
+      metadata
+        ? { ...call, namespace: "mcp__apmneonsnapshotro", name: "get_monitor_snapshot" }
+        : call,
+      metadata ? "restore the identity Codex dispatches by" : "never infer from a name prefix",
+    );
   }
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #683. That PR removed #537's `recoverPreflattenedMcpTools`. On `main` that recovery ran after the whole tool-handling branch in `buildRoutedRequest`, so it also applied to Responses-native routes (Meta, GitHub Copilot, OpenCode Responses, generic Responses). Its replacement, `restorePreflattenedToolNamespaces`, runs only on routes that flatten tools, and nothing took the recovery's place in the Responses-native branch.

On current `main`, Codex can send pre-flattened MCP tools (the Codex 0.149.1 custom-provider shape). When a Responses-native route such as `meta/muse-spark-1.2` returns a call under that flat wire name, the router now relays `mcp__apmneonsnapshotro__get_monitor_snapshot`. Before #683 it relayed `{namespace: "mcp__apmneonsnapshotro", name: "get_monitor_snapshot"}`.

### Why Codex needs the structured identity

- Codex reaches every routed model through the same `codex-router` provider, and the published catalog has no namespace capability field. The request shape Codex sends and the call shape it dispatches do not depend on which upstream the router picks. The Command Code routed test from #537 already requires `{namespace, name}` for the identical payload.
- #537 was validated with a quota-free Codex 0.149.1 local mock control for structured MCP dispatch. The shared fixture's comment says turn metadata "carries the native identity Codex will use for dispatch".
- #683's own description calls flat provider names ones "Codex cannot dispatch".
- The installed Codex binary's `ToolInfo` carries both `callable_namespace` and `callable_name`.

## Change

- `src/router.mjs`, Responses-native branch:
  - Still sends `payload.tools` unchanged.
  - Builds only the response lookup inventory from `flattenNamespaceTools(restorePreflattenedToolNamespaces(tools, client_metadata), { bridgeToolSearch: false }).namespaces`.
  - Sets `namespacesFlattened` only when restoration recovered something. As before #683, this also rewrites stored `{namespace, name}` history to the flat spelling the provider was declared.
- `test/namespace-relay-routing.test.mjs`: the Meta regression now expects the restored `{namespace, name}` on the returned call, in both streaming and non-streaming modes.
  - It asserts that outgoing `tools` and `input` serialize byte-identically to the client's, and that Meta's tool-choice policy is kept.
  - A new negative control checks that without turn metadata the call stays flat, so nothing is inferred from a name prefix.
- `AGENTS.md`: corrects the #683 bullet. Declarations are rewritten only on flattening routes, but Responses-native routes still restore the returned call identity.

## Verification

All runs used the existing router test harness with loopback mocks only: no live providers, no credentials.

- **Before and after:**
  - #683's original Meta test fails on pre-#683 code (`da395a13`): the actual result is `{namespace, name}`.
  - The updated test fails on unfixed `main` (`dad992c8`): the actual result is the flat name.
  - The updated test passes with this change.
- **Unit suites:**
  - `test/namespace-relay.test.mjs`: 124/124.
  - `test/namespace-relay-custom.test.mjs`: 6/6.
- **`test/deepseek-responses-routing.test.mjs`:** 7/7.
- **`test/namespace-relay-routing.test.mjs`:** partly verified locally, CI needed. Across three runs on this change, 23 of 29 tests passed at least once, including every pre-flattened, Command Code, bounded-alias and Meta case.
  - The other six are the Grok 4.6 `apply_patch`, structured-patch and hook cases, plus "Responses-native routed providers inherit the model on fresh local thread calls". They failed only with `connect EADDRNOTAVAIL` on loopback, or the router 502s it causes, and they failed the same way on an untouched `main` worktree.
  - The development machine's ephemeral ports were exhausted by a VPN client.
  - None of those six sends `x-codex-turn-metadata`. For them `restorePreflattenedToolNamespaces` returns the same tools array, so their request path matches `main`.
  - Please rely on CI for a clean run of this file.
- **Checks:** `npm run check` passes and `git diff --check` is clean.
- **Not done:** no live provider request, and no end-to-end Codex dispatch probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
