### PR TITLE
fix: count reasoning tokens in tok/s only when generated inside the timed window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+- **Tok/s counts reasoning tokens exactly when they were generated inside the
+  timed window.** The Sep 5 change subtracted `reasoning_tokens` from the
+  numerator on every route, but the first-token clock already started on the
+  first reasoning delta, so on the OpenAI, Grok, and Command Code routes the
+  reasoning time stayed in the denominator while its tokens left the
+  numerator. A fit of generation time against visible and reasoning tokens
+  over the local usage log put the cost of a reasoning token at roughly the
+  cost of a visible one on those routes (gpt-5.6-sol 21 vs 25 ms, grok-4.6 18
+  vs 16 ms), proving the thinking ran inside the window; the meter read
+  gpt-5.6-luna at 21 tok/s against about 80 measured, and grok-4.5 at 16
+  against about 67. Only Muse Spark on the OpenCode Responses route thinks in
+  silence before its first token (0.02 ms per reasoning token in the same
+  fit), which is the route the subtraction had been measured on. The stream
+  transform now records `reasoningStreamed` -- whether any reasoning delta
+  (Responses summary or text deltas, chat `reasoning_content` / `reasoning`)
+  was relayed -- and reasoning deltas and chat tool-call deltas start the
+  first-token clock like visible text does. `aggregateProviderUsage` and the
+  Control Center per-event rate keep reasoning tokens when the marker is true
+  or absent (rows written before it existed), and subtract them only when it
+  is false. A reasoning count larger than the output count proves a provider
+  reports visible tokens only (Command Code's DeepSeek V4 Pro: 62 of 146 rows,
+  e.g. 150 output against 499 reasoning), so the inclusive total is rebuilt
+  first instead of clamping the sample to zero and silently dropping it.
+  Provider totals and billing are unchanged.
+
 - **DeepSeek V4.1 Flash is available on four providers, alongside V4.**
   DeepSeek released V4.1 Flash on 2026-09-10. New routes:
   `deepseek/deepseek-v4.1-flash` (1M window, image input, thinking with

--- a/apps/control-center/src/pages/DashboardPage.tsx
+++ b/apps/control-center/src/pages/DashboardPage.tsx
@@ -1575,11 +1575,16 @@ function tokensPerSecondFromEvent(event: UsageEvent): number | null {
   ) return null;
   const generationDurationMs = durationMs - firstTokenMs;
   if (generationDurationMs <= 0) return null;
-  // Subtract reasoning tokens from output for tok/s numerator (same as provider-usage).
-  // Industry TTFT measures time to first visible token; reasoning tokens are generated
-  // during silent thinking before any visible output.
-  const reasoningTokens = optionalNumber(event.reasoningTokens) ?? 0;
-  const speedOutput = Math.max(0, output - reasoningTokens);
+  // Same rule as provider-usage.mjs: count the tokens generated inside the
+  // timed window. Reasoning that was streamed started the clock, so it stays
+  // in; reasoning that ran silently before the first visible token belongs to
+  // TTFT and is subtracted. A reasoning count above the output count means the
+  // provider reports visible tokens only, so the inclusive total is rebuilt.
+  const reasoningTokens = Math.max(0, optionalNumber(event.reasoningTokens) ?? 0);
+  const inclusiveOutput = reasoningTokens > output ? output + reasoningTokens : output;
+  const speedOutput = event.reasoningStreamed === false
+    ? Math.max(0, inclusiveOutput - reasoningTokens)
+    : inclusiveOutput;
   const rate = (speedOutput * 1_000) / generationDurationMs;
   return Number.isFinite(rate) && rate <= 500 ? Math.round(rate * 10) / 10 : null;
 }

--- a/apps/control-center/src/types.ts
+++ b/apps/control-center/src/types.ts
@@ -560,6 +560,7 @@ export interface UsageEvent {
   billedOutputTokens?: number;
   /** Reasoning tokens (silent thinking) included in outputTokens. */
   reasoningTokens?: number;
+  reasoningStreamed?: boolean;
   totalTokens?: number;
   estimatedInputTokens?: number;
   retries?: number;

--- a/src/provider-usage.mjs
+++ b/src/provider-usage.mjs
@@ -231,12 +231,14 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
     // 426-token one at 69 on the same model.
     const firstTokenMs = optionalNonnegative(event.firstTokenMs);
     const generationDurationMs = durationMs - (firstTokenMs ?? durationMs);
-    // Industry TTFT measures time to first *visible* token. Reasoning tokens
-    // are generated during silent thinking before any visible output. When the
-    // provider reports the split, subtract reasoning from output to get the
-    // tok/s numerator. Provider totals still count full output for billing.
-    const reasoningTokens = optionalNonnegative(event.reasoningTokens) ?? 0;
-    const speedOutputTokens = Math.max(0, selectedOutputTokens - reasoningTokens);
+    // The numerator must count exactly the tokens generated inside that
+    // window. Reasoning tokens are generated inside it when the provider
+    // streamed reasoning deltas (the clock started on the first of them), and
+    // before it when the provider thought in silence until the first visible
+    // token. Only the second case subtracts them; without the marker (rows
+    // written before it existed) the inclusive count is the closer answer on
+    // every route seen so far. Provider totals still count full output.
+    const speedOutputTokens = tokensGeneratedAfterFirstToken(event, selectedOutputTokens);
     // A long Codex turn can trip the empty-completion hold budget and still
     // finish as a normal 200 with streamed tokens. That flag means "we
     // stopped waiting to classify emptiness", not "this rate is unusable".
@@ -331,6 +333,19 @@ export function aggregateProviderUsage(events, { days = 90, now = Date.now() } =
         ),
     })),
   };
+}
+
+// Some providers report output tokens that already exclude reasoning (a
+// reasoning count larger than the output count proves it), so the inclusive
+// total is rebuilt before deciding whether to subtract.
+export function tokensGeneratedAfterFirstToken(event, outputTokens) {
+  const reasoningTokens = optionalNonnegative(event.reasoningTokens) ?? 0;
+  const inclusiveOutputTokens =
+    reasoningTokens > outputTokens ? outputTokens + reasoningTokens : outputTokens;
+  if (event.reasoningStreamed === false) {
+    return Math.max(0, inclusiveOutputTokens - reasoningTokens);
+  }
+  return inclusiveOutputTokens;
 }
 
 export async function providerUsageSnapshot(options = {}) {

--- a/src/response-usage.mjs
+++ b/src/response-usage.mjs
@@ -332,6 +332,10 @@ export function substituteZeroInputUsage(payload, estimate) {
 
 const LINE_FEED = 0x0a;
 
+function nonEmptyString(value) {
+  return typeof value === "string" && value.length > 0;
+}
+
 export class ResponseUsageTransform extends Transform {
   #eventStream;
   #decoder = new StringDecoder("utf8");
@@ -352,6 +356,12 @@ export class ResponseUsageTransform extends Transform {
   // first token appears, and counting that silence as generation is what makes
   // a fast model read as slow. See #192.
   #firstTokenAt;
+  // Whether the stream carried reasoning deltas (summary or raw text). When it
+  // did, the reasoning tokens were generated after the first token and belong
+  // in the tokens-per-second numerator; when it did not, the provider thought
+  // in silence before the first visible token and those tokens belong to
+  // time-to-first-token instead. The aggregator picks the numerator from this.
+  #reasoningStreamed = false;
   #onEvent;
   #grokServiceTier;
   #completedResponseObserved = false;
@@ -571,34 +581,44 @@ export class ResponseUsageTransform extends Transform {
     }
   }
 
-  // The first event that carries visible generated text. Reasoning summaries
-  // and tool-call argument deltas are output the model is producing, so they
-  // count too -- what must not count is the wait before any of it starts.
+  // The first event that carries generated output of any kind. Reasoning
+  // deltas, visible text, and tool-call arguments all count -- what must not
+  // count is the wait before any of it starts. Reasoning is also remembered on
+  // its own, at any point in the stream, because the tokens-per-second
+  // numerator has to include reasoning exactly when its generation time sits
+  // inside the measured window (see aggregateProviderUsage).
   #noteFirstToken(payload) {
-    if (this.#firstTokenAt !== undefined) return;
-    // Chat-completions bridges stream choices[].delta instead of typed events.
-    // Check this first because chat.completion.chunk often has no `type` field.
+    // Chat-completions bridges stream choices[].delta instead of typed events;
+    // chat.completion.chunk often has no `type` field, so check the delta
+    // shape independently of the type.
     const chatDelta = payload?.choices?.[0]?.delta;
-    const chatProducesOutput =
-      typeof chatDelta?.content === "string" && chatDelta.content.length > 0;
-    if (chatProducesOutput) {
-      this.#firstTokenAt = Date.now();
-      return;
-    }
-    const type = payload?.type;
-    if (typeof type !== "string") return;
-    const producesOutput =
-      type === "response.output_text.delta" ||
+    const type = typeof payload?.type === "string" ? payload.type : undefined;
+    const reasoningDelta =
+      nonEmptyString(chatDelta?.reasoning_content) ||
+      nonEmptyString(chatDelta?.reasoning) ||
       type === "response.reasoning_summary_text.delta" ||
+      type === "response.reasoning_text.delta";
+    if (reasoningDelta) this.#reasoningStreamed = true;
+    if (this.#firstTokenAt !== undefined) return;
+    const visibleDelta =
+      nonEmptyString(chatDelta?.content) ||
+      (Array.isArray(chatDelta?.tool_calls) && chatDelta.tool_calls.length > 0) ||
+      type === "response.output_text.delta" ||
       type === "response.function_call_arguments.delta" ||
       type === "response.audio_transcript.delta";
-    if (producesOutput) this.#firstTokenAt = Date.now();
+    if (reasoningDelta || visibleDelta) this.#firstTokenAt = Date.now();
   }
 
   // Epoch milliseconds of the first generated token, or undefined when the
   // response never streamed one (a non-streaming reply, or an error).
   firstTokenAt() {
     return this.#firstTokenAt;
+  }
+
+  // True when at least one reasoning delta was relayed, so the reasoning
+  // tokens in the final usage were generated inside the timed window.
+  reasoningStreamed() {
+    return this.#reasoningStreamed;
   }
 
   completedResponseObserved() {

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -3732,6 +3732,7 @@ async function handleResponses(request, response, requestUrl) {
   let upstreamStatus;
   let upstreamLatencyMs;
   let firstTokenMs;
+  let reasoningStreamed;
   let usageTransform;
   let emptyCompletionGuard;
   let retryUsageTransform;
@@ -4228,6 +4229,7 @@ async function handleResponses(request, response, requestUrl) {
         durationMs: Date.now() - startedAt,
         responseStartMs: upstreamLatencyMs,
         firstTokenMs,
+        reasoningStreamed,
       }, diagnostics);
       observeSubagentOutcome(request, route, upstream.status);
       finalStatus = translatedStatus;
@@ -4395,6 +4397,7 @@ async function handleResponses(request, response, requestUrl) {
     // silent thinking that would otherwise be charged to the generation rate.
     const firstTokenAt = usageTransform?.firstTokenAt?.();
     if (firstTokenAt !== undefined) firstTokenMs = firstTokenAt - startedAt;
+    reasoningStreamed = usageTransform?.reasoningStreamed?.();
     estimatedInputTokens = usageTransform?.substitutedInputTokens();
     // The `close` listener above sets `clientGone` when the client's socket
     // goes away, but `pipeResponse` can resolve before that event fires: the
@@ -4643,6 +4646,7 @@ async function handleResponses(request, response, requestUrl) {
       durationMs: Date.now() - startedAt,
       responseStartMs: upstreamLatencyMs,
       firstTokenMs,
+      reasoningStreamed,
       ...usage,
       estimatedInputTokens,
       ...toolResultAging,
@@ -4786,6 +4790,7 @@ async function handleResponses(request, response, requestUrl) {
       );
       const firstTokenAt = usageTransform.firstTokenAt?.();
       if (firstTokenAt !== undefined) firstTokenMs = firstTokenAt - startedAt;
+      reasoningStreamed = usageTransform.reasoningStreamed?.();
     }
     // Codex may close a native stream immediately after response.completed.
     // That is a successful terminal turn, not a canceled generation.
@@ -4800,6 +4805,7 @@ async function handleResponses(request, response, requestUrl) {
           durationMs: Date.now() - startedAt,
           responseStartMs: upstreamLatencyMs,
           firstTokenMs,
+          reasoningStreamed,
           ...usage,
           estimatedInputTokens,
           ...toolResultAging,
@@ -4833,6 +4839,7 @@ async function handleResponses(request, response, requestUrl) {
           durationMs: Date.now() - startedAt,
           responseStartMs: upstreamLatencyMs,
         firstTokenMs,
+        reasoningStreamed,
           retries: upstreamRetries,
           ...usage,
           estimatedInputTokens,
@@ -4858,6 +4865,7 @@ async function handleResponses(request, response, requestUrl) {
         durationMs: Date.now() - startedAt,
         responseStartMs: upstreamLatencyMs,
         firstTokenMs,
+        reasoningStreamed,
         retries: upstreamRetries,
         ...usage,
         estimatedInputTokens,

--- a/src/usage-events.mjs
+++ b/src/usage-events.mjs
@@ -80,6 +80,10 @@ export function recordUsageEvent({
   // reports it: tokens after the first token, with the wait before it counted
   // separately as time-to-first-token.
   firstTokenMs,
+  // Whether reasoning deltas were relayed in the stream. Measured booleans
+  // only: absent means the row predates the field and the aggregator falls
+  // back to the inclusive token count.
+  reasoningStreamed,
   inputTokens,
   billedInputTokens,
   cachedInputTokens,
@@ -197,6 +201,7 @@ export function recordUsageEvent({
     ...(safeTokenCount(firstTokenMs) !== undefined
       ? { firstTokenMs: safeTokenCount(firstTokenMs) }
       : {}),
+    ...(typeof reasoningStreamed === "boolean" ? { reasoningStreamed } : {}),
     ...(streamAborted === true ? { streamAborted: true } : {}),
     ...(emptyCompletion === true ? { emptyCompletion: true } : {}),
     ...(emptyCompletionRetried === true ? { emptyCompletionRetried: true } : {}),
@@ -518,6 +523,9 @@ export function recentUsageEvents({
             : {}),
           ...(safeTokenCount(event.firstTokenMs) !== undefined
             ? { firstTokenMs: safeTokenCount(event.firstTokenMs) }
+            : {}),
+          ...(typeof event.reasoningStreamed === "boolean"
+            ? { reasoningStreamed: event.reasoningStreamed }
             : {}),
           ...(event.streamAborted === true ? { streamAborted: true } : {}),
           ...(event.emptyCompletion === true ? { emptyCompletion: true } : {}),

--- a/test/provider-usage.test.mjs
+++ b/test/provider-usage.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { aggregateProviderUsage } from "../src/provider-usage.mjs";
+import { aggregateProviderUsage, tokensGeneratedAfterFirstToken } from "../src/provider-usage.mjs";
 
 test("protocol variants never appear as separate usage providers", () => {
   const snapshot = aggregateProviderUsage([], { now: Date.parse("2026-07-21T18:00:00Z") });
@@ -420,51 +420,49 @@ test("uses only the latest 20 clean generation timings for observed speed", () =
   assert.equal(model.observedTokensPerSecond, 50);
 });
 
-test("excludes reasoning tokens from speed numerator while keeping totals", () => {
+test("tok/s counts reasoning tokens exactly when they were generated inside the timed window", () => {
   const now = Date.parse("2026-07-21T18:00:00Z");
-  // Two events: same duration/firstToken/output, but one has reasoning tokens.
+  // Every event: 4 s total, first token at 1 s, so a 3 s generation window.
+  const base = (model, extra) => ({
+    meteringVersion: 1,
+    at: new Date(now).toISOString(),
+    provider: "opencode-go",
+    model,
+    status: 200,
+    durationMs: 4_000,
+    firstTokenMs: 1_000,
+    ...extra,
+  });
   const events = [
-    {
-      meteringVersion: 1,
-      at: new Date(now - 60_000).toISOString(),
-      provider: "opencode-go",
-      model: "opencode-go/glm-5.3-flash",
-      status: 200,
-      durationMs: 4_000,
-      firstTokenMs: 1_000,
-      outputTokens: 404,
-      totalTokens: 504,
-    },
-    {
-      meteringVersion: 1,
-      at: new Date(now).toISOString(),
-      provider: "opencode-go",
-      model: "opencode-go/glm-5.3-flash",
-      status: 200,
-      durationMs: 4_000,
-      firstTokenMs: 1_000,
-      outputTokens: 502,
-      reasoningTokens: 98,
-      totalTokens: 602,
-    },
+    // Reasoning deltas were relayed: the clock started on them, so the 98
+    // reasoning tokens were produced inside the window and stay in the count.
+    base("opencode-go/streamed", { outputTokens: 502, reasoningTokens: 98, totalTokens: 602, reasoningStreamed: true }),
+    // No reasoning delta was relayed: the model thought in silence before the
+    // first visible token, so those 98 tokens belong to TTFT, not the rate.
+    base("opencode-go/silent", { outputTokens: 502, reasoningTokens: 98, totalTokens: 602, reasoningStreamed: false }),
+    // Rows written before the marker existed use the inclusive count.
+    base("opencode-go/legacy", { outputTokens: 502, reasoningTokens: 98, totalTokens: 602 }),
+    // A reasoning count above the output count proves the provider reports
+    // visible tokens only; the inclusive total is rebuilt before deciding.
+    base("opencode-go/exclusive-streamed", { outputTokens: 150, reasoningTokens: 499, totalTokens: 150, reasoningStreamed: true }),
+    base("opencode-go/exclusive-silent", { outputTokens: 150, reasoningTokens: 499, totalTokens: 150, reasoningStreamed: false }),
   ];
   const snapshot = aggregateProviderUsage(events, { days: 7, now });
-  const model = snapshot.providers
-    .find((provider) => provider.id === "opencode-go")
-    .models[0];
-  
-  // Provider totals still count full output (404 + 502 = 906).
-  assert.equal(
-    snapshot.providers.find((provider) => provider.id === "opencode-go").outputTokens,
-    906,
-  );
-  // Model totals also count full output.
-  assert.equal(model.outputTokens, 906);
-  // But speed uses non-reasoning output: (404 + (502-98)) / 2 = 404 tok per 3s = 134.7 tok/s.
-  // First event: 404 tok / 3000 ms = 134.7 tok/s.
-  // Second event: (502-98) tok / 3000 ms = 404 tok / 3000 ms = 134.7 tok/s.
-  // Median of [134.7, 134.7] = 134.7.
-  assert.equal(model.observedTokensPerSecond, 134.7);
+  const provider = snapshot.providers.find((candidate) => candidate.id === "opencode-go");
+  const rate = (slug) => provider.models.find((model) => model.slug === slug).observedTokensPerSecond;
+  assert.equal(rate("opencode-go/streamed"), 167.3); // 502 / 3 s
+  assert.equal(rate("opencode-go/silent"), 134.7); // (502 - 98) / 3 s
+  assert.equal(rate("opencode-go/legacy"), 167.3); // 502 / 3 s
+  assert.equal(rate("opencode-go/exclusive-streamed"), 216.3); // (150 + 499) / 3 s
+  assert.equal(rate("opencode-go/exclusive-silent"), 50); // 150 / 3 s
+  // Provider totals still count the reported output, not the speed numerator.
+  assert.equal(provider.outputTokens, 502 * 3 + 150 * 2);
+});
+
+test("tokensGeneratedAfterFirstToken treats a missing reasoning count as zero", () => {
+  assert.equal(tokensGeneratedAfterFirstToken({}, 40), 40);
+  assert.equal(tokensGeneratedAfterFirstToken({ reasoningStreamed: false }, 40), 40);
+  assert.equal(tokensGeneratedAfterFirstToken({ reasoningTokens: 0, reasoningStreamed: false }, 40), 40);
 });
 
 test("accepts a response that starts within the first measured millisecond", () => {

--- a/test/response-usage.test.mjs
+++ b/test/response-usage.test.mjs
@@ -1015,3 +1015,60 @@ test("Grok tier-only terminal metadata preserves earlier measured token counters
   assert.equal(transform.tokenUsage().totalTokens, 18);
   assert.equal(transform.tokenUsage().serviceTier, "priority");
 });
+
+test("reasoning deltas start the first-token clock and mark reasoning as streamed", async () => {
+  // Responses API: the summary delta arrives while the model is still
+  // thinking, so the window opened here contains the reasoning tokens.
+  const responses = new ResponseUsageTransform("text/event-stream");
+  await passThrough(responses, [
+    'event: response.reasoning_summary_text.delta\ndata: {"type":"response.reasoning_summary_text.delta","delta":"Thinking"}\n\n',
+    'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"hi"}\n\n',
+    "data: [DONE]\n\n",
+  ]);
+  assert.equal(typeof responses.firstTokenAt(), "number");
+  assert.equal(responses.reasoningStreamed(), true);
+
+  // Chat bridges relay reasoning as delta.reasoning_content, often with no
+  // type field on the chunk at all.
+  const chat = new ResponseUsageTransform("text/event-stream");
+  await passThrough(chat, [
+    'data: {"choices":[{"delta":{"reasoning_content":"Let me"}}]}\n\n',
+    'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+    "data: [DONE]\n\n",
+  ]);
+  assert.equal(typeof chat.firstTokenAt(), "number");
+  assert.equal(chat.reasoningStreamed(), true);
+
+  // Reasoning relayed after the first visible token still counts: its
+  // generation time sits inside the window either way.
+  const interleaved = new ResponseUsageTransform("text/event-stream");
+  await passThrough(interleaved, [
+    'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+    'data: {"choices":[{"delta":{"reasoning":"then again"}}]}\n\n',
+    "data: [DONE]\n\n",
+  ]);
+  assert.equal(interleaved.reasoningStreamed(), true);
+});
+
+test("a stream with only visible output reports reasoning as not streamed", async () => {
+  const transform = new ResponseUsageTransform("text/event-stream");
+  await passThrough(transform, [
+    'data: {"choices":[{"delta":{"reasoning_content":""}}]}\n\n',
+    'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{"}}]}}]}\n\n',
+    "data: [DONE]\n\n",
+  ]);
+  assert.equal(typeof transform.firstTokenAt(), "number");
+  assert.equal(transform.reasoningStreamed(), false);
+});
+
+test("a chat tool-call delta counts as the first token", async () => {
+  const transform = new ResponseUsageTransform("text/event-stream");
+  await passThrough(transform, [
+    'data: {"choices":[{"delta":{"role":"assistant","content":null}}]}\n\n',
+    'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"shell","arguments":""}}]}}]}\n\n',
+    "data: [DONE]\n\n",
+  ]);
+  assert.equal(typeof transform.firstTokenAt(), "number");
+  assert.equal(transform.reasoningStreamed(), false);
+});

--- a/test/usage-events.test.mjs
+++ b/test/usage-events.test.mjs
@@ -571,3 +571,45 @@ test("records known actual serviceTier without echoing the requested value", asy
     rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+test("the reasoning-streamed marker persists both measured values and drops anything else", async () => {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), "model-router-usage-"));
+  const previousStateDir = process.env.MODEL_ROUTER_STATE_DIR;
+  process.env.MODEL_ROUTER_STATE_DIR = stateDir;
+  try {
+    const usage = await import(`../src/usage-events.mjs?reasoning-streamed=1&ts=${Date.now()}`);
+    const record = (status, reasoningStreamed) =>
+      usage.recordUsageEvent({
+        model: "openai/reasoning-streamed-probe",
+        provider: "openai",
+        status,
+        durationMs: 4_000,
+        firstTokenMs: 1_000,
+        outputTokens: 502,
+        reasoningTokens: 98,
+        reasoningStreamed,
+      });
+    record(200, true);
+    record(201, false);
+    record(202, "yes");
+    record(203, undefined);
+    // The module caches its state path from the first import in this process,
+    // so earlier tests may have left rows in the same file: match on this
+    // test-only model slug, not on status alone.
+    const byStatus = (status) =>
+      usage
+        .recentUsageEvents()
+        .find((event) => event.model === "openai/reasoning-streamed-probe" && event.status === status);
+    assert.equal(byStatus(200).reasoningStreamed, true);
+    // False is a measurement (no reasoning delta was relayed), not an absence,
+    // so it must survive the round trip: it is what selects the subtraction.
+    assert.equal(byStatus(201).reasoningStreamed, false);
+    assert.equal("reasoningStreamed" in byStatus(202), false);
+    assert.equal("reasoningStreamed" in byStatus(203), false);
+    assert.equal(byStatus(200).reasoningTokens, 98);
+  } finally {
+    if (previousStateDir === undefined) delete process.env.MODEL_ROUTER_STATE_DIR;
+    else process.env.MODEL_ROUTER_STATE_DIR = previousStateDir;
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

The Sep 5 tok/s change subtracted `reasoning_tokens` from the numerator on every route, but the first-token clock already starts on the first reasoning delta. On the OpenAI, Grok, and Command Code routes the reasoning time stayed in the denominator while its tokens left the numerator, so the meter undercounted by 2x to 60x (gpt-5.6-luna 21 tok/s displayed vs ~80 measured, grok-4.5 16 vs ~67).

Verified by fitting generation time against visible and reasoning tokens over the local usage log: a reasoning token costs about the same as a visible one on those routes (gpt-5.6-sol 21 vs 25 ms, grok-4.6 18 vs 16 ms), so the thinking runs inside the timed window. Only Muse Spark on the OpenCode Responses route thinks silently before its first token (0.02 ms per reasoning token), which is the route the subtraction had been measured on.

## Changes

- `ResponseUsageTransform` records `reasoningStreamed` (any Responses summary/text reasoning delta or chat `reasoning_content` / `reasoning` delta). Reasoning deltas and chat tool-call deltas now start the first-token clock like visible text.
- The usage event persists the marker as a measured boolean; historical rows lack it.
- `aggregateProviderUsage` and the Control Center per-event rate keep reasoning tokens when the marker is true or absent, and subtract them only when it is false.
- A reasoning count above the output count proves a provider reports visible tokens only (Command Code DeepSeek V4 Pro: 62 of 146 rows), so the inclusive total is rebuilt instead of clamping the sample to zero and silently dropping it.
- Provider totals and billing are unchanged.

## Effect on the live log

| Model | Before | After |
|---|---|---|
| openai/gpt-5.6-luna | 20.8 | 81.0 |
| openai/gpt-5.6-sol | 22.9 | 37.4 |
| grok-oauth/grok-4.5 | 16.0 | 69.2 |
| grok-oauth/grok-4.6 | 53.4 | 74.4 |

Muse Spark free on OpenCode reads high until 20 new turns carry the marker, since its historical rows fall back to the inclusive count.

## Verification

- `node --test` on provider-usage, response-usage, usage-events: 80 pass
- `npm run check`, Control Center `tsc --noEmit`: pass
- Full suite failures were loopback `EADDRNOTAVAIL` / fixture-port contention from concurrent runs; the one other failure passes 3/3 alone and on baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
