### PR TITLE
fix(router): omit foreign item IDs when replaying history to OpenAI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2063,6 +2063,16 @@ xAI and Codex has its own idle limit. The router's post-prologue stall guard
   value that passes byte-identical. Do not gate this on a router-written
   sentinel: the router never authors these items, and a marker would strand
   the already-broken conversations this recovers.
+- The native endpoint also checks an optional item `id` against the prefix it
+  mints for that item type: `fc` for function calls, `ctc` for custom tool
+  calls, `msg` for messages. Codex saves and replays the IDs routed providers
+  minted (`call_...`, `tool_...`, `chatcmpl-...`), so a conversation moved back
+  to a native model fails with "Expected an ID that begins with 'fc'" once one
+  is in its history. `normalizeNativeInput` omits only a string `id` without
+  that prefix, on `/responses` and `/responses/compact` alike. `call_id` still
+  pairs each call with its result, a native-only history is forwarded
+  unchanged, and routed requests keep their IDs. The `native replay omits
+  incompatible item IDs` case in `test/routing.test.mjs` holds both sides.
 - Never log relay response bodies, decrypted task text, or exception messages
   that can echo either. Regressions require fragmented/mislabeled SSE tests and
   real marker-return probes through every installed routed agent plus a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **OpenAI requests omit incompatible IDs from saved function calls.**
+  Before sending saved conversation history to OpenAI, the router now omits
+  optional `function_call.id` strings that do not start with `fc`, which OpenAI
+  rejects. It preserves `call_id`, matching results, compatible IDs, and requests
+  to external providers. Tests cover continuing and shortening a conversation,
+  sessions supplied by the caller or the router, and sending saved history again.
 - **Preserve tool calls after large fragmented response preludes.** Allow one
   unfinished initial event within the existing 10 MiB bound and match the
   namespace relay's limit, so later MCP calls retain their client identities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unreleased
 
-- **OpenAI requests omit incompatible IDs from saved function calls.**
-  Before sending saved conversation history to OpenAI, the router now omits
-  optional `function_call.id` strings that do not start with `fc`, which OpenAI
-  rejects. It preserves `call_id`, matching results, compatible IDs, and requests
-  to external providers. Tests cover continuing and shortening a conversation,
-  sessions supplied by the caller or the router, and sending saved history again.
+- **Switching a conversation back to OpenAI no longer fails on routed item IDs.**
+  Routed providers mint their own item IDs (`call_...`, `tool_...`,
+  `chatcmpl-...`), Codex saves them, and OpenAI rejects them on replay with
+  "Expected an ID that begins with 'fc'". Before sending saved history to
+  OpenAI, the router now omits an optional `id` that lacks the native prefix for
+  its item type: `fc` for function calls, `ctc` for custom tool calls such as
+  `apply_patch`, and `msg` for messages. It preserves `call_id`, matching
+  results, native IDs, and requests to external providers, so a native-only
+  history is unchanged. Tests cover continuing and compacting a conversation,
+  sessions supplied by the caller or the router, and replaying normalized
+  history. Based on #664 by @webhype.
 - **Preserve tool calls after large fragmented response preludes.** Allow one
   unfinished initial event within the existing 10 MiB bound and match the
   namespace relay's limit, so later MCP calls retain their client identities.

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -2438,6 +2438,17 @@ function sanitizeCollaborationForNative(item) {
   };
 }
 
+// The native endpoint validates an item's optional `id` against the prefix it
+// mints for that item type ("Expected an ID that begins with 'fc'"). Routed
+// providers mint their own (`call_...`, `tool_...`, `chatcmpl-...`), and Codex
+// saves and replays them. Native-minted IDs always carry these prefixes, so a
+// native-only history is forwarded unchanged.
+const NATIVE_ITEM_ID_PREFIXES = new Map([
+  ["function_call", "fc"],
+  ["custom_tool_call", "ctc"],
+  ["message", "msg"],
+]);
+
 function normalizeNativeInput(
   input,
   { statelessReasoning = false, dropUnstoredReasoningReferences = false } = {},
@@ -2463,14 +2474,15 @@ function normalizeNativeInput(
     }
 
     // ------------------------------------------------------------
-    // External providers can reuse their call_id as an item ID that OpenAI
-    // rejects. Omit only that optional ID on native replay, including saved
-    // history and compaction; call_id must still pair the call with its result.
+    // Omit only a foreign optional item ID on native replay, including saved
+    // history and compaction. call_id is separate and must still pair each
+    // call with its result.
     // ------------------------------------------------------------
 
-    if (item?.type === "function_call" && typeof item.id === "string" && !item.id.startsWith("fc")) {
-      const { id: _providerId, ...call } = item;
-      item = call;
+    const nativeIdPrefix = NATIVE_ITEM_ID_PREFIXES.get(item?.type);
+    if (nativeIdPrefix && typeof item.id === "string" && !item.id.startsWith(nativeIdPrefix)) {
+      const { id: _providerId, ...rest } = item;
+      item = rest;
     }
     if (item?.type !== "compaction") return [sanitizeCollaborationForNative(item)];
     return [isRouterCompactionValue(item.encrypted_content)

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -2461,6 +2461,17 @@ function normalizeNativeInput(
       // remain above; bare references cannot be made stateless and are dropped.
       return [];
     }
+
+    // ------------------------------------------------------------
+    // External providers can reuse their call_id as an item ID that OpenAI
+    // rejects. Omit only that optional ID on native replay, including saved
+    // history and compaction; call_id must still pair the call with its result.
+    // ------------------------------------------------------------
+
+    if (item?.type === "function_call" && typeof item.id === "string" && !item.id.startsWith("fc")) {
+      const { id: _providerId, ...call } = item;
+      item = call;
+    }
     if (item?.type !== "compaction") return [sanitizeCollaborationForNative(item)];
     return [isRouterCompactionValue(item.encrypted_content)
       ? messageItem(renderCompactionValue(item.encrypted_content))

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -2601,6 +2601,157 @@ test("compaction never treats reasoning as final text and falls back to chat con
   }
 });
 
+// ------------------------------------------------------------
+// Saved external calls must remain replayable on native turns and compaction.
+// The optional item ID is separate from the call_id that pairs each result.
+// ------------------------------------------------------------
+
+test("native function-call IDs omit incompatible IDs without changing call-result pairs", async (t) => {
+  const nativeRequests = [];
+  const gatewayRequests = [];
+  const native = await mockServer(async (request, response) => {
+    const body = await bodyJson(request);
+    nativeRequests.push({ url: request.url, headers: request.headers, body });
+    const invalid = body.input.find((item) =>
+      item?.type === "function_call" && typeof item.id === "string" && !item.id.startsWith("fc")
+    );
+    if (invalid) {
+      json(response, 400, { error: { type: "invalid_request_error", message: "Expected an ID that begins with 'fc'." } });
+      return;
+    }
+    json(response, 200, { route: "native" });
+  });
+  const gateway = await mockServer(async (request, response) => {
+    gatewayRequests.push(await bodyJson(request));
+    json(response, 200, { route: "external" });
+  });
+  const testRoot = mkdtempSync(path.join(os.tmpdir(), "native-function-call-ids-"));
+  const authPath = path.join(testRoot, "auth.json");
+  writeFileSync(authPath, JSON.stringify({
+    auth_mode: "chatgpt",
+    tokens: { access_token: "test-native-session-token", account_id: "test-native-account" },
+  }), { mode: 0o600 });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_NATIVE_BASE_URL: `http://127.0.0.1:${native.port}/backend-api/codex`,
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_NATIVE_SESSION_FALLBACK: "1",
+    MODEL_ROUTER_CODEX_AUTH: authPath,
+    MODEL_ROUTER_STATE_DIR: path.join(testRoot, "state"),
+    CODEX_HOME: path.join(testRoot, "codex"),
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  // ------------------------------------------------------------
+  // Explicit expected fields keep the test independent of the prefix check.
+  // Non-string IDs are outside this repair, not accepted by a full validator.
+  // ------------------------------------------------------------
+
+  const idCases = [
+    { input: { id: "tool_example_foreign" }, expected: {} },
+    { input: { id: "call_example_foreign" }, expected: {} },
+    { input: { id: "" }, expected: {} },
+    { input: { id: "fc_native_example" }, expected: { id: "fc_native_example" } },
+    { input: { id: "fcFutureFormat" }, expected: { id: "fcFutureFormat" } },
+    { input: {}, expected: {} },
+    { input: { id: null }, expected: { id: null } },
+    { input: { id: 42 }, expected: { id: 42 } },
+  ];
+  const input = [];
+  const expected = [];
+  for (const [index, fields] of idCases.entries()) {
+    const call = {
+      type: "function_call",
+      call_id: index === 0 ? "tool_example_foreign" : `call_pair_${index}`,
+      name: "read_fixture",
+      namespace: "functions",
+      arguments: JSON.stringify({ path: `fixture-${index}.txt` }),
+      status: "completed",
+    };
+    const output = {
+      type: "function_call_output",
+      id: `fco_result_${index}`,
+      call_id: call.call_id,
+      output: `fixture contents ${index}`,
+    };
+    input.push({ ...call, ...fields.input }, output);
+    expected.push({ ...call, ...fields.expected }, output);
+  }
+  const untouched = [
+    { type: "custom_tool_call", id: "tool_custom", call_id: "custom_pair", name: "custom_fixture", input: "fixture" },
+    { type: "custom_tool_call_output", id: "custom_result", call_id: "custom_pair", output: "fixture result" },
+    { type: "item_reference", id: "tool_reference" },
+    { type: "message", id: "tool_message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+  ];
+  input.push(...untouched);
+  expected.push(...untouched);
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    // ------------------------------------------------------------
+    // Each caller and endpoint receives old full history with no prior turn.
+    // Replaying the normalized result must not change the history again.
+    // ------------------------------------------------------------
+
+    for (const suppliedCredential of [true, false]) {
+      for (const [label, endpoint, trigger] of [
+        ["continuation", "/responses", []],
+        ["compaction V1", "/responses/compact", []],
+        ["compaction V2", "/responses", [{ type: "compaction_trigger" }]],
+      ]) {
+        await t.test(`${suppliedCredential ? "caller session" : "substituted session"}: ${label}`, async () => {
+          const expectedInput = [...expected, ...trigger];
+          for (const history of [[...input, ...trigger], expectedInput]) {
+            const requestCount = nativeRequests.length;
+            const response = await fetch(`${routerBase(routerPort)}${endpoint}`, {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${suppliedCredential ? "test-caller-session" : CALLER_KEY}`,
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({ model: "gpt-5.6-sol", input: history, previous_response_id: "resp_previous" }),
+            });
+            const result = await response.json();
+            assert.equal(nativeRequests.length, requestCount + 1);
+            assert.equal(response.status, 200, JSON.stringify(result));
+            const sent = nativeRequests.at(-1);
+            assert.equal(sent.url, `/backend-api/codex${endpoint}`);
+            assert.equal(sent.headers.authorization, `Bearer ${suppliedCredential ? "test-caller-session" : "test-native-session-token"}`);
+            assert.deepEqual(sent.body.input, expectedInput);
+            assert.equal(sent.body.previous_response_id, endpoint === "/responses/compact" ? "resp_previous" : undefined);
+          }
+        });
+      }
+    }
+
+    // ------------------------------------------------------------
+    // Native preparation must not rewrite history sent to an external model.
+    // Use the original full call, not the already-normalized native result.
+    // ------------------------------------------------------------
+
+    await t.test("external replay preserves its provider item ID", async () => {
+      const nativeCount = nativeRequests.length;
+      const response = await fetch(`${routerBase(routerPort)}/responses`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${CALLER_KEY}`, "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "kimi-oauth/k3", input: input.slice(0, 2) }),
+      });
+      await response.json();
+      assert.equal(response.status, 200);
+      assert.equal(nativeRequests.length, nativeCount);
+      assert.equal(gatewayRequests.length, 1);
+      assert.deepEqual(gatewayRequests[0].input, input.slice(0, 2));
+    });
+  } finally {
+    await stopChild(router);
+    await closeServer(native.server);
+    await closeServer(gateway.server);
+    rmSync(testRoot, { recursive: true, force: true });
+  }
+});
+
 test("router drops foreign reasoning items before stateless native replay", async () => {
   const nativeRequests = [];
   const native = await mockServer(async (request, response) => {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -2606,17 +2606,25 @@ test("compaction never treats reasoning as final text and falls back to chat con
 // The optional item ID is separate from the call_id that pairs each result.
 // ------------------------------------------------------------
 
-test("native function-call IDs omit incompatible IDs without changing call-result pairs", async (t) => {
+test("native replay omits incompatible item IDs without changing call-result pairs", async (t) => {
   const nativeRequests = [];
   const gatewayRequests = [];
+  const nativePrefixes = { function_call: "fc", custom_tool_call: "ctc", message: "msg" };
   const native = await mockServer(async (request, response) => {
     const body = await bodyJson(request);
     nativeRequests.push({ url: request.url, headers: request.headers, body });
     const invalid = body.input.find((item) =>
-      item?.type === "function_call" && typeof item.id === "string" && !item.id.startsWith("fc")
+      Object.hasOwn(nativePrefixes, item?.type) &&
+      typeof item.id === "string" &&
+      !item.id.startsWith(nativePrefixes[item.type])
     );
     if (invalid) {
-      json(response, 400, { error: { type: "invalid_request_error", message: "Expected an ID that begins with 'fc'." } });
+      json(response, 400, {
+        error: {
+          type: "invalid_request_error",
+          message: `Expected an ID that begins with '${nativePrefixes[invalid.type]}'.`,
+        },
+      });
       return;
     }
     json(response, 200, { route: "native" });
@@ -2678,14 +2686,28 @@ test("native function-call IDs omit incompatible IDs without changing call-resul
     input.push({ ...call, ...fields.input }, output);
     expected.push({ ...call, ...fields.expected }, output);
   }
-  const untouched = [
-    { type: "custom_tool_call", id: "tool_custom", call_id: "custom_pair", name: "custom_fixture", input: "fixture" },
-    { type: "custom_tool_call_output", id: "custom_result", call_id: "custom_pair", output: "fixture result" },
-    { type: "item_reference", id: "tool_reference" },
-    { type: "message", id: "tool_message", role: "user", content: [{ type: "input_text", text: "continue" }] },
+  // Custom tool calls and messages are validated against their own prefixes.
+  // Outputs and item references are not, and must stay byte-identical.
+  const withoutId = ({ id: _id, ...item }) => item;
+  const customCall = { type: "custom_tool_call", call_id: "custom_pair", name: "custom_fixture", input: "fixture" };
+  const nativeCustomCall = { ...customCall, id: "ctc_native_example", call_id: "custom_native" };
+  const userMessage = { type: "message", id: "tool_message", role: "user", content: [{ type: "input_text", text: "continue" }] };
+  const routedReply = { type: "message", id: "chatcmpl-example", role: "assistant", content: [{ type: "output_text", text: "routed" }] };
+  const nativeReply = { ...routedReply, id: "msg_native_example", content: [{ type: "output_text", text: "native" }] };
+  const otherItems = [
+    [{ ...customCall, id: "tool_custom" }, customCall],
+    [{ type: "custom_tool_call_output", id: "custom_result", call_id: "custom_pair", output: "fixture result" }],
+    [nativeCustomCall],
+    [{ type: "custom_tool_call_output", id: "custom_native_result", call_id: "custom_native", output: "native result" }],
+    [{ type: "item_reference", id: "tool_reference" }],
+    [routedReply, withoutId(routedReply)],
+    [nativeReply],
+    [userMessage, withoutId(userMessage)],
   ];
-  input.push(...untouched);
-  expected.push(...untouched);
+  for (const [original, normalized = original] of otherItems) {
+    input.push(original);
+    expected.push(normalized);
+  }
 
   try {
     await waitFor(`${routerBase(routerPort)}/models`, router);


### PR DESCRIPTION
Supersedes #664 (thanks @webhype, whose commit is kept as-is).

## Problem

Routed providers mint their own item IDs (`call_...`, `tool_...`, `chatcmpl-...`). Codex saves them, and when a conversation moves back to an OpenAI model the native endpoint rejects the replay: `Expected an ID that begins with 'fc'`. The same prefix check applies per item type: `msg` for messages ([openai/codex#27928](https://github.com/openai/codex/issues/27928)) and `ctc` for custom tool calls.

#664 fixed `function_call` only. Custom tool calls (e.g. `apply_patch` through the custom-tool bridge) and routed assistant messages are saved with foreign IDs too, so they hit the same 400.

## Change

- `normalizeNativeInput` omits an optional `id` that lacks the native prefix for its type: `fc` for `function_call`, `ctc` for `custom_tool_call`, `msg` for `message`.
- Applies to `/responses` and `/responses/compact`, for caller-supplied and substituted sessions.
- Preserves `call_id`, outputs, item references, native IDs, and routed requests, so a native-only history is unchanged.
- Drops #664's docs/PNG commit; AGENTS.md gets a short boundary note instead.

## Verification

- Extended `native replay omits incompatible item IDs` test: 8/8 pass. Against the function-call-only fix, 7/8 fail with `Expected an ID that begins with 'ctc'`.
- `npm run check` and `git diff --check` pass.
- Full local suite was inconclusive: the machine hit loopback port exhaustion (`EADDRNOTAVAIL`), and clean `main` failed and timed out the same way. Relying on CI for the full run.
- Not exercised live against OpenAI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
