### PR TITLE
fix: call partialUsage when both Codex account reads answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **Control Center loads Codex account usage again when both account reads
+  answer.** The conflict resolution that merged #662 onto #648 renamed the
+  shared normalizer to `partialUsage` but left the both-answered call site on
+  the removed `usageFromReplies`, so every healthy poll threw a
+  `ReferenceError` and Control Center painted "Some router data could not
+  load" over the snapshot. The test fake answered synchronously from inside
+  the probe's guarded stdin write, whose `catch` swallowed the error; it now
+  has a `deferred` mode that answers on a later tick like a real pipe, and a
+  both-answered test that fails without the fix.
+
 - **Tok/s counts reasoning tokens exactly when they were generated inside the
   timed window.** The Sep 5 change subtracted `reasoning_tokens` from the
   numerator on every route, but the first-token clock already started on the

--- a/src/codex-account-usage.mjs
+++ b/src/codex-account-usage.mjs
@@ -261,7 +261,7 @@ export function readCodexAccountUsage({
         responses.set(message.id, message.result);
       }
       if (responses.size === 2) {
-        finish(undefined, usageFromReplies());
+        finish(undefined, partialUsage());
       }
     });
 

--- a/test/codex-account-usage.test.mjs
+++ b/test/codex-account-usage.test.mjs
@@ -11,7 +11,11 @@ import {
   readCodexAccountUsage,
 } from "../src/codex-account-usage.mjs";
 
-function fakeAppServer(replies) {
+// `deferred` answers on a later tick, the way a real app-server's pipe does.
+// Answering synchronously runs the probe's line handler inside its own guarded
+// stdin write, whose catch swallowed a ReferenceError on the both-answered
+// path, so every test here stayed green while Control Center failed each poll.
+function fakeAppServer(replies, { deferred = false } = {}) {
   const stdout = new PassThrough();
   const stdin = new PassThrough();
   const child = new EventEmitter();
@@ -26,6 +30,10 @@ function fakeAppServer(replies) {
   };
   child.kill = () => end(0);
   stdin.on("data", (chunk) => {
+    if (deferred) setImmediate(() => answer(chunk));
+    else answer(chunk);
+  });
+  const answer = (chunk) => {
     for (const line of String(chunk).split("\n").filter(Boolean)) {
       let message;
       try {
@@ -43,7 +51,7 @@ function fakeAppServer(replies) {
       for (const item of outbound) stdout.write(`${JSON.stringify(item)}\n`);
       if (exitAfter || exitBeforeWrite) end(1, { exited: Boolean(exitBeforeWrite) });
     }
-  });
+  };
   return child;
 }
 
@@ -234,6 +242,35 @@ test("the usage panel names a missing Codex instead of blaming the app-server", 
   // machine with Codex installed. It only looked green because CI runners have
   // none -- which is the one environment where this assertion cannot fail.
   await assert.rejects(readCodexAccountUsage({ binary: null }), /no Codex binary was found/);
+});
+
+test("a healthy app-server that answers both account reads returns full usage", async () => {
+  const value = await readCodexAccountUsage({
+    binary: "/fake/codex",
+    platform: "darwin",
+    timeoutMs: 2_000,
+    spawnImpl: () => fakeAppServer((message) => {
+      if (message.id === 1) return { id: 1, result: {} };
+      if (message.id === 2) {
+        return { id: 2, result: { rateLimits: { planType: "pro", primary: { usedPercent: 12 } } } };
+      }
+      if (message.id === 3) {
+        return {
+          id: 3,
+          result: {
+            summary: { lifetimeTokens: 99 },
+            dailyUsageBuckets: [{ startDate: "2026-09-11", tokens: 5 }],
+          },
+        };
+      }
+      return undefined;
+    }, { deferred: true }),
+  });
+
+  assert.equal(value.planType, "pro");
+  assert.equal(value.primary.usedPercent, 12);
+  assert.equal(value.summary.lifetimeTokens, 99);
+  assert.deepEqual(value.dailyUsageBuckets, [{ startDate: "2026-09-11", tokens: 5 }]);
 });
 
 test("a refused rateLimits read still returns usage instead of failing the panel", async () => {


### PR DESCRIPTION
## Problem

Control Center shows **"Some router data could not load"** on every poll:

```
Error invoking remote method 'router-control:getAccountUsage':
ReferenceError: usageFromReplies is not defined
    at Interface.<anonymous> (src/codex-account-usage.mjs:264:16)
```

The conflict resolution in 3f577777 (merging #662 onto #648) renamed the shared normalizer from `usageFromReplies` to `partialUsage` and updated the timeout and `close` paths, but left the both-answered call site on the removed name. That is the healthy path — both `account/rateLimits/read` and `account/usage/read` answer — so any working ChatGPT login hits it.

## Why CI stayed green

`fakeAppServer` wrote replies synchronously from inside the probe's own `send()`. The line handler therefore ran within `processHandle.stdin.write(...)`, and `send()`'s guarded `try/catch` swallowed the `ReferenceError`. A real app-server answers over a pipe on a later tick, where nothing catches it.

## Fix

- `src/codex-account-usage.mjs`: call `partialUsage()` on the both-answered path.
- `test/codex-account-usage.test.mjs`: add a `deferred` option to `fakeAppServer` that answers on `setImmediate`, and a test where a healthy app-server answers both reads.
- `CHANGELOG.md`: Unreleased entry.

## Verification

- New test fails on `origin/main` (`✖ a healthy app-server that answers both account reads returns full usage`) and passes with the fix; `test/codex-account-usage.test.mjs` + `test/discovery-mode.test.mjs`: 20/20 pass.
- Live: `node src/control.mjs account` against a real Codex app-server returns plan type, the primary rate-limit window, and daily usage buckets with no error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
