### PR TITLE
fix: make signed ChatGPT routing rollback-safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1633,13 +1633,17 @@ about it.
   `model_catalog_json` block plus its marked `model_providers.codex-router`
   table and, when the user has no concurrency preference, its marked
   `[agents].max_concurrent_threads_per_session` default. It may change the root
-  `model_provider` only when the user explicitly
-  enables the tray's login-free mode. In that mode it may also select an
-  enabled external `model`; snapshot both previous values in protected router
-  state and restore them exactly when the mode is disabled.
+  `model_provider` only when the user explicitly enables either login-free mode
+  or signed routing from a root-OpenAI configuration. Signed routing selects
+  the dedicated, ChatGPT-authenticated `codex-router-signed` provider; ordinary
+  install, update, repair, and catalog refresh must never create or migrate that
+  switch implicitly. Keep its state readable by the previous release and
+  restore the prior provider exactly when it is disabled. Login-free mode may
+  also select an enabled external `model`; snapshot both previous values in
+  protected router state and restore them exactly when the mode is disabled.
 - Preserve reasoning settings, profiles, projects, trust, MCP configuration,
   features, and ChatGPT authentication. Preserve `model` and `model_provider`
-  outside the explicitly enabled login-free mode.
+  outside those explicitly enabled routing modes.
 - A user-initiated macOS tray login-mode change may gracefully restart only the
   registered Codex desktop app. This does not authorize an installation task to
   quit Codex, and the tray must never force-terminate it.

--- a/README.md
+++ b/README.md
@@ -1355,6 +1355,22 @@ When the Codex runtime is executing inside WSL, a Windows-style path such as
 If setup appears successful but the Desktop model picker does not change, check
 which Codex home was modified before rerunning setup.
 
+### Use external models while signed in to ChatGPT
+
+The Control Center's **Use Router with ChatGPT** switch keeps ChatGPT
+authentication available while external provider models remain selectable. On
+current Codex builds, an explicit switch from the built-in OpenAI provider
+selects the managed `codex-router-signed` transport so Codex validates prefixed
+model ids against the router before sending them. The prior provider is stored
+in protected state and restored when the switch is turned off. Normal updates
+and catalog refreshes do not silently opt an existing installation into this
+provider switch.
+
+The optional native redirect is independent of this switch and of model
+failover. If native redirect is set, every unmatched native GPT turn that
+reaches the router continues to use its configured external route until
+`./bin/control native-redirect clear` is run.
+
 ### Use Codex without an OpenAI login
 
 The tray's **Use without OpenAI login** switch selects the managed custom

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -121,8 +121,10 @@ credentials.
 The config manager:
 
 - Writes only a marked `openai_base_url` and `model_catalog_json` block.
-- Preserves `model`, `model_provider`, reasoning settings, profiles, and ChatGPT
-  authentication.
+- Preserves `model`, reasoning settings, profiles, and ChatGPT authentication.
+  It changes `model_provider` only for an explicit login-free or signed-routing
+  toggle, records the previous value in protected state, and restores it after
+  an ownership check.
 - Refuses to replace an unmarked user-owned base URL or catalog.
 - Creates `~/.codex/config.toml.pre-codex-router` before its first change.
 - Atomically rewrites the config and restricts it to the current user.

--- a/apps/control-center/electron/ipc.mjs
+++ b/apps/control-center/electron/ipc.mjs
@@ -817,6 +817,15 @@ function readFileEdges(filePath) {
   }
 }
 
+export function codexSessionProvider(model, sessionProvider) {
+  if (model?.includes("/")) return model.split("/", 1)[0];
+  // Signed routing uses a dedicated transport provider so current Codex can
+  // validate external slugs while keeping ChatGPT authentication. Native GPT
+  // turns still go to OpenAI unless the operator separately enabled native
+  // redirect, so do not label them as router traffic in the session list.
+  return sessionProvider === "codex-router-signed" ? "openai" : sessionProvider;
+}
+
 function codexRolloutMetadata(filePath) {
   let sessionMeta;
   let turnContext;
@@ -843,7 +852,7 @@ function codexRolloutMetadata(filePath) {
     workspace,
     workspaceLabel: workspace ? cleanText(path.basename(workspace), workspace, 100) : undefined,
     model,
-    provider: cleanText(model?.includes("/") ? model.split("/", 1)[0] : sessionMeta?.model_provider, "", 100) || undefined,
+    provider: cleanText(codexSessionProvider(model, sessionMeta?.model_provider), "", 100) || undefined,
     effort: cleanText(turnContext?.effort, "", 40) || undefined,
     originator: cleanText(sessionMeta?.originator, "", 80) || undefined,
     createdAt: safeTimestamp(sessionMeta?.timestamp),

--- a/docs/HOW-IT-WORKS.md
+++ b/docs/HOW-IT-WORKS.md
@@ -122,6 +122,22 @@ The integration deliberately keeps the built-in `openai` provider and points
 it at a loopback `openai_base_url`. This makes named models appear in the normal
 picker instead of replacing the provider with a generic `Custom` entry.
 
+Current Codex builds validate a prefixed external model against the selected
+provider before sending the request. When the user explicitly enables signed
+routing from a root-OpenAI configuration, the router therefore snapshots the
+root provider and selects its dedicated `codex-router-signed` provider. That
+provider still requires ChatGPT authentication and sends both native and
+external Responses requests to the local router. The switch uses the signed
+state format already understood by the previous release, so downgrading can
+still disable it and restore the prior provider. Ordinary install, update,
+repair, and catalog refresh maintain an existing signed mode but never convert
+one implicitly; changing modes requires an explicit off/on toggle.
+
+Native redirect is a separate, all-or-nothing control. If configured, it still
+redirects unmatched native GPT turns while signed routing is enabled, and
+turning model failover off does not disable it. Clear native redirect separately
+when selected native GPT models should remain on OpenAI.
+
 For a selected custom provider, the tray's login-free switch keeps the provider
 id unchanged and temporarily replaces its complete table with a router-owned,
 auth-free table that points Responses requests at the local router. The

--- a/docs/SUBAGENT-CERTIFICATION.md
+++ b/docs/SUBAGENT-CERTIFICATION.md
@@ -69,35 +69,44 @@ What is **not** a fourth way: the legacy diagnostic statuses in the proofs file
 > definition on disk. If you are changing that function, the modes are the
 > feature, not a formality — and `subagent-report.mjs` is how you check.
 
-## A ChatGPT account cannot certify a routed model
+## Signed routing is not itself subagent certification
 
-Checks 3–5 cannot complete while Codex is signed in with a ChatGPT account.
-Codex says so in the parent's own message:
+An older root-OpenAI signed-routing run could not complete checks 3–5 while
+Codex was signed in with a ChatGPT account. Codex rejected the routed child in
+the parent's own message:
 
 ```
 The '<provider>/<model>' model is not supported when using Codex with a
 ChatGPT account.
 ```
 
-This is a property of the harness and the account, not of the route, so it
-records as **deferred** — never as a refusal. Do not "fix" it by relaxing the
+That result records as **deferred** — never as a refusal — because it did not
+exercise the route's collaboration transport. Do not "fix" it by relaxing the
 promotion gate.
 
-Two things that look like a way out and are not:
+Current Codex validates an external model id against the selected provider
+before it sends an ordinary request. On Codex CLI 0.153.4, with `codex login
+status` reporting `Logged in using ChatGPT`, the explicit signed-routing switch
+uses the dedicated `codex-router-signed` provider and clears that top-level
+provider/model validation while retaining `requires_openai_auth = true`. The
+ordinary request then reaches the router's `/v1/responses` edge. This is useful
+request-routing evidence, but it is not evidence for any of checks 3–5.
 
-- **Signed routing** (`set_signed_routing`) declares a provider block with
-  `requires_openai_auth = true`. That is the same ChatGPT-account auth, so it
-  changes nothing here.
+Two things still do not constitute certification:
+
+- **Signed routing** (`set_signed_routing`) establishes the provider/transport
+  precondition for ordinary routed turns. No route becomes v2 merely because
+  that switch is on; a complete five-check run is still required.
 - **Marking the candidate v2 in the catalog** is already done: Codex only
   offers a subagent for a route its catalog marks v2, so the run builds a
   private catalog copy with just the candidate marked. That clears an earlier
   "not supported with the current ChatGPT account" error and gets as far as the
-  refusal above — it does not get past it.
+  older root-OpenAI refusal above. A catalog claim alone does not get past it.
 
-The remaining untested path is running Codex under `auth_mode: "apikey"` rather
-than `"chatgpt"`. The wording of the refusal implies an API key would be
-accepted, but that has not been verified, and it bills separately from a
-ChatGPT plan. Verify before promising anyone this works.
+The dedicated signed-provider path has not yet completed all five checks under
+a ChatGPT account, and the API-key path has not been verified either. Both
+remain uncertified and may spend separate quota. Verify before promising either
+one works.
 
 ## What has already been verified, and what has not
 
@@ -108,9 +117,9 @@ Do not re-run these. They cost quota and the answers are recorded here.
 | Does the caller endpoint serve `chat/completions`? | **No.** It answers Responses at `<callerBase>/responses` and takes the caller key as a bearer. | A 404 was once reported to the operator as "this model cannot run subagents". |
 | Can a route stream through the router? | **Yes** for every route tried. | `deepseek/deepseek-v4-flash-vision-exp` returned HTTP 200 with a real SSE stream. |
 | Does a forced `tool_choice` work everywhere? | **No.** A reasoning route can reject the forcing mode itself — *"Thinking mode does not support this tool_choice"* — while calling the tool correctly when simply offered it. | `opencode-go/deepseek-v4-flash-vision-exp`: forced → 400, `auto` → 200 with `{"token": "ok"}`. Codex does not force tool_choice in ordinary use. |
-| Can checks 3-5 complete under a ChatGPT account? | **No.** See the section above. | Codex states it in the parent's own message. |
+| Can checks 3-5 complete under a ChatGPT account? | **Not established.** The older root-OpenAI attempt was deferred; the dedicated signed-provider path has no complete five-check record. | See the versioned evidence above. |
 | Does marking the candidate v2 in a private catalog help? | **Partly.** It clears an earlier "not supported with the current ChatGPT account" error and gets as far as the refusal above. It does not get past it. | Already implemented in the runner. |
-| Is signed routing a way around that? | **No.** Its provider block is `requires_openai_auth = true` — the same account. | `managedSignedProviderBlock` in `config-manager.mjs`. |
+| Is signed routing enough to certify a route? | **No.** It fixes ordinary provider/model validation only; promotion still requires all five checks. | `managedSignedProviderBlock` and `verifiedForRoute`. |
 | Do Ox Alpha, Fugu Ultra or Inkling have a registry certification? | **No.** The registry has seven v2 routes and none of them is one of these. | They reach v2 through operator selection instead. |
 
 Statuses that answer about the account or the moment — 401, 402, 403, 408, 429,

--- a/src/config-manager.mjs
+++ b/src/config-manager.mjs
@@ -152,6 +152,7 @@ const markerPairs = [
 ];
 const command = process.argv[2] || "status";
 const adoptNativeCatalog = process.argv.includes("--adopt-native-catalog");
+const preserveRootOpenaiSignedMode = process.argv.includes("--preserve-root-openai");
 let nativeCatalogNeedsActivation = false;
 
 function configuredRouterBaseUrl() {
@@ -631,6 +632,57 @@ function managedSignedProviderBlock(providerId, baseUrl) {
   ].join("\n");
 }
 
+function signedProviderSwitchState(rootLines) {
+  const previousPresent = rootHasValue(rootLines, "model_provider");
+  return {
+    version: 1,
+    managedProvider: signedProviderId,
+    previousPresent,
+    ...(previousPresent
+      ? { previousModelProvider: rootValue(rootLines, "model_provider") }
+      : {}),
+  };
+}
+
+function managedSignedProviderSwitchContents(contents, baseUrl) {
+  const withoutPriorBlock = removeMarkerPair(
+    contents,
+    signedProviderStartMarker,
+    signedProviderEndMarker,
+    `[model_providers.${signedProviderId}]`,
+  );
+  const withProvider = `${withoutPriorBlock.trimEnd()}\n\n${managedSignedProviderBlock(
+    signedProviderId,
+    baseUrl,
+  )}\n`;
+  return `${replaceRootValue(withProvider, "model_provider", signedProviderId)}\n`;
+}
+
+function withoutManagedSignedProviderSwitch(contents) {
+  return removeMarkerPair(
+    contents,
+    signedProviderStartMarker,
+    signedProviderEndMarker,
+    `[model_providers.${signedProviderId}]`,
+  );
+}
+
+function signedProviderSwitchBlockStatus(contents) {
+  const range = signedManagedRange(contents);
+  if (!range) {
+    const hasArtifacts =
+      contents.includes(signedProviderStartMarker) ||
+      contents.includes(signedProviderEndMarker) ||
+      providerTableRanges(contents, signedProviderId).length > 0;
+    return hasArtifacts ? "drift" : "absent";
+  }
+  const actual = range.lines.slice(range.start, range.end).join("\n");
+  const baseUrl = rootValue(splitRoot(contents).rootLines, "openai_base_url");
+  return managedSignedProviderBlockMatches(actual, signedProviderId, baseUrl)
+    ? "owned"
+    : "drift";
+}
+
 function managedLoginFreeProviderBlock(providerId, baseUrl) {
   const headerId = /^[A-Za-z0-9_-]+$/.test(providerId)
     ? providerId
@@ -963,7 +1015,12 @@ function signedProviderStateIsOwned(contents, state) {
   const { rootLines } = splitRoot(contents);
   const activeProvider = rootValue(rootLines, "model_provider") || "openai";
   if (activeProvider !== state.managedProvider) return false;
-  if (state.version === 1) return activeProvider === signedProviderId;
+  if (state.version === 1) {
+    return (
+      activeProvider === signedProviderId &&
+      signedProviderSwitchBlockStatus(contents) === "owned"
+    );
+  }
   if (state.mode === "root-openai") {
     return (
       isManagedRouterBaseUrl(rootValue(rootLines, "openai_base_url")) &&
@@ -1303,6 +1360,9 @@ function snapshot(contents) {
       signedActive && privateFileIsProtected(SIGNED_PROVIDER_MODE_PATH),
     ),
     signed_provider_state_present: existsSync(SIGNED_PROVIDER_MODE_PATH),
+    signed_provider_state_version: signedState?.version ?? null,
+    signed_provider_mode:
+      signedState?.version === 1 ? "provider-switch" : signedState?.mode ?? null,
     managed_router_artifacts_present: managedRouterArtifactsPresent,
     router_default_model: routerDefault?.model || null,
     router_default_managed: Boolean(routerDefault),
@@ -1564,8 +1624,16 @@ if (command === "enable") {
     );
   }
   if (signedState?.version === 1) {
-    throw new Error(
-      "A recognized older signed-routing mode is still active; turn it off before updating the router.",
+    if (!signedProviderStateIsOwned(current, signedState)) {
+      throw new Error(
+        `Signed routing lost ownership while model_provider is ${
+          rootValue(splitRoot(current).rootLines, "model_provider") || "openai"
+        }; refusing to update it.`,
+      );
+    }
+    next = managedSignedProviderSwitchContents(
+      enabledContents(current),
+      configuredRouterBaseUrl(),
     );
   } else if (signedState) {
     if (!signedProviderStateIsOwned(current, signedState)) {
@@ -1819,9 +1887,20 @@ if (command === "enable") {
   const { rootLines } = splitRoot(current);
   const currentProvider = rootValue(rootLines, "model_provider") || "openai";
   const state = readSignedProviderModeState();
-  if (state?.version === 1) {
+  if (preserveRootOpenaiSignedMode && currentProvider !== "openai") {
     throw new Error(
-      "A recognized older signed-routing mode is still active; turn it off before enabling the task-preserving mode.",
+      "The root-OpenAI signed mode can only be restored from the OpenAI provider.",
+    );
+  }
+  if (state?.version === 1) {
+    if (!signedProviderStateIsOwned(current, state)) {
+      throw new Error(
+        `Signed routing lost ownership while model_provider is ${currentProvider}; turn it off before enabling it again.`,
+      );
+    }
+    next = managedSignedProviderSwitchContents(
+      enabledContents(current),
+      configuredRouterBaseUrl(),
     );
   } else if (state) {
     if (!signedProviderStateIsOwned(current, state)) {
@@ -1846,9 +1925,14 @@ if (command === "enable") {
   } else {
     const enabled = enabledContents(current);
     const routerBaseUrl = configuredRouterBaseUrl();
-    const managed = managedSignedProviderContents(enabled, currentProvider, routerBaseUrl);
-    pendingSignedProviderModeState = managed.state;
-    next = managed.contents;
+    if (currentProvider === "openai" && !preserveRootOpenaiSignedMode) {
+      pendingSignedProviderModeState = signedProviderSwitchState(rootLines);
+      next = managedSignedProviderSwitchContents(enabled, routerBaseUrl);
+    } else {
+      const managed = managedSignedProviderContents(enabled, currentProvider, routerBaseUrl);
+      pendingSignedProviderModeState = managed.state;
+      next = managed.contents;
+    }
   }
   next = applyRouterDefault(next);
 } else {
@@ -1883,12 +1967,27 @@ if (command === "enable") {
           `Refusing to replace user-owned model_provider: ${currentProvider || "unset"}.`,
         );
       }
+      const blockStatus = signedProviderSwitchBlockStatus(current);
+      if (blockStatus === "drift") {
+        throw new Error(
+          `Signed routing lost ownership of model_providers.${signedProviderId}; refusing to replace it.`,
+        );
+      }
+      restored = blockStatus === "owned"
+        ? withoutManagedSignedProviderSwitch(current)
+        : current;
     } else if (signedState.version === 1) {
+      if (!signedProviderStateIsOwned(current, signedState)) {
+        throw new Error(
+          `Signed routing lost ownership of model_providers.${signedProviderId}; refusing to replace it.`,
+        );
+      }
       restored = `${replaceRootValue(
         current,
         "model_provider",
         signedState.previousPresent ? signedState.previousModelProvider : undefined,
       )}\n`;
+      restored = withoutManagedSignedProviderSwitch(restored);
     } else {
       const effectiveProvider = currentProvider || "openai";
       if (effectiveProvider !== signedState.managedProvider) {

--- a/src/control.mjs
+++ b/src/control.mjs
@@ -1247,6 +1247,16 @@ async function setSignedRouting(desired) {
     throw new Error("Signed router mode could not be changed.");
   }
   process.stdout.write(result.stdout);
+  if (desired === "on") {
+    const { readNativeRedirect } = await import("./native-redirect.mjs");
+    const redirect = readNativeRedirect();
+    if (redirect) {
+      process.stderr.write(
+        `Native redirect remains active for ${redirect}; it is independent of signed routing ` +
+          "and failover. Clear it separately if native GPT turns should stay on OpenAI.\n",
+      );
+    }
+  }
 }
 
 async function setLoginFreeModel(slug) {
@@ -3046,6 +3056,11 @@ async function handleNativeRedirect(action, value) {
     throw new Error(`Unknown routed model slug: ${value}`);
   }
   process.stdout.write(`${JSON.stringify(setNativeRedirect(value))}\n`);
+  process.stderr.write(
+    `Native redirect now sends every unmatched native GPT turn to ${value}. ` +
+      "This setting is independent of signed routing and failover; clear it with " +
+      "control native-redirect clear.\n",
+  );
 }
 
 // One action for "give me a working harness": install the CLI if it is absent,

--- a/src/refresh-catalog.mjs
+++ b/src/refresh-catalog.mjs
@@ -45,7 +45,7 @@ export function refreshCatalogCompletionMessage(status) {
 
 function restoreTransport(
   run,
-  { signed, loginFree, loginFreeModel, loginFreeDisplayModel },
+  { signed, signedProviderMode, loginFree, loginFreeModel, loginFreeDisplayModel },
   aliasFor,
 ) {
   if (loginFree) {
@@ -60,7 +60,12 @@ function restoreTransport(
     );
   } else {
     checked(run, "config-manager.mjs", ["enable"]);
-    if (signed) checked(run, "config-manager.mjs", ["signed-enable"]);
+    if (signed) {
+      checked(run, "config-manager.mjs", [
+        "signed-enable",
+        ...(signedProviderMode === "root-openai" ? ["--preserve-root-openai"] : []),
+      ]);
+    }
   }
   try {
     checked(run, "catalog.mjs", []);
@@ -131,6 +136,7 @@ async function refreshCatalogUnlocked({
   }
   const transport = {
     signed,
+    signedProviderMode: signed ? status.signed_provider_mode : undefined,
     loginFree,
     loginFreeDisplayModel: loginFree
       ? pendingJournal?.displayModel || status.model

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -2443,15 +2443,32 @@ function normalizeNativeInput(
   { statelessReasoning = false, dropUnstoredReasoningReferences = false } = {},
 ) {
   if (!Array.isArray(input)) return input;
+  // A routed turn can leave its full reasoning item and a following rs_
+  // reference in the next native request even though that item was produced
+  // with store=false. A null/empty encrypted payload on the full item is
+  // request-local proof that native storage cannot resolve the paired id.
+  // Keep unrelated bare references intact for credential-bearing native
+  // callers; they may still name items that ChatGPT actually stored.
+  const explicitlyUnstoredReasoningIds = new Set(
+    input
+      .filter((item) =>
+        item?.type === "reasoning" &&
+        typeof item.id === "string" &&
+        item.id.startsWith("rs_") &&
+        Object.hasOwn(item, "encrypted_content") &&
+        (typeof item.encrypted_content !== "string" || item.encrypted_content.length === 0)
+      )
+      .map((item) => item.id),
+  );
   return input.flatMap((item) => {
     if (item?.type === "reasoning") {
       const reasoning = sanitizeReasoningForNative(item, {
-        stateless: statelessReasoning,
+        stateless: statelessReasoning || explicitlyUnstoredReasoningIds.has(item.id),
       });
       return reasoning === undefined ? [] : [reasoning];
     }
     if (
-      dropUnstoredReasoningReferences &&
+      (dropUnstoredReasoningReferences || explicitlyUnstoredReasoningIds.has(item?.id)) &&
       item?.type === "item_reference" &&
       typeof item.id === "string" &&
       item.id.startsWith("rs_")
@@ -2978,14 +2995,19 @@ async function handleRoutedCompaction(
 }
 
 async function handleModels(response) {
-  const data = catalogModels().map((model) => ({
+  const models = catalogModels();
+  const data = models.map((model) => ({
     id: model.slug,
     object: "model",
     owned_by: MODEL_BY_SLUG.has(model.slug)
       ? providerForModel(MODEL_BY_SLUG.get(model.slug)).ownedBy
       : "openai",
   }));
-  writeJson(response, 200, { object: "list", data });
+  // OpenAI-compatible clients read `data`; current Codex custom-provider
+  // discovery reads its account-catalog shape from `models` on the same
+  // endpoint. Serving both keeps the provider switch compatible with either
+  // reader without duplicating discovery work.
+  writeJson(response, 200, { object: "list", data, models });
 }
 
 // What the Gemini surface will accept a turn for.

--- a/test/caller-key-client-refresh.test.mjs
+++ b/test/caller-key-client-refresh.test.mjs
@@ -41,6 +41,40 @@ test("Codex capability refresh changes only managed caller URLs", () => {
   assert.ok(after.includes(`# copied example must stay ${oldBase}`));
 });
 
+test("Codex capability refresh updates the rollback-compatible signed provider block", () => {
+  const before = [
+    `openai_base_url = ${JSON.stringify(oldBase)}`,
+    "",
+    "# BEGIN codex-router-provider-managed",
+    "[model_providers.codex-router]",
+    `base_url = ${JSON.stringify(oldBase)}`,
+    "# END codex-router-provider-managed",
+    "",
+    "# BEGIN codex-router-signed-provider-managed",
+    "[model_providers.codex-router-signed]",
+    `base_url = ${JSON.stringify(oldBase)}`,
+    "# END codex-router-signed-provider-managed",
+    "",
+  ].join("\n");
+  const after = refreshCodexCallerCapabilityContents(before, newBase, { port: 4202 });
+  assert.equal((after.match(new RegExp(newSecret, "g")) || []).length, 3);
+  assert.doesNotMatch(after, new RegExp(oldSecret));
+  assert.deepEqual(
+    refreshCodexCallerCapabilityState({
+      version: 1,
+      managedProvider: "codex-router-signed",
+      previousPresent: true,
+      previousModelProvider: "openai",
+    }, newBase, { port: 4202 }),
+    {
+      version: 1,
+      managedProvider: "codex-router-signed",
+      previousPresent: true,
+      previousModelProvider: "openai",
+    },
+  );
+});
+
 test("Codex capability state refresh preserves policy and ownership", () => {
   const before = {
     version: 3, mode: "provider-table", managedProvider: "example-provider",

--- a/test/config-manager.test.mjs
+++ b/test/config-manager.test.mjs
@@ -2102,12 +2102,143 @@ test("signed routing restores an originally unset provider", () => {
   const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-signed-unset-"));
   const stateDir = path.join(codexHome, "router-state");
   const configPath = path.join(codexHome, "config.toml");
+  const statePath = path.join(stateDir, "signed-provider-mode.json");
   writeFileSync(configPath, 'model = "gpt-5.6-sol"\n', { mode: 0o600 });
   try {
-    run("signed-enable", codexHome, stateDir);
-    assert.doesNotMatch(readFileSync(configPath, "utf8"), /^model_provider\s*=/m);
+    const enabled = run("signed-enable", codexHome, stateDir);
+    assert.equal(enabled.model_provider, "codex-router-signed");
+    assert.equal(enabled.signed_routing, true);
+    assert.equal(enabled.login_free, false);
+    const active = readFileSync(configPath, "utf8");
+    assert.match(active, /^model_provider = "codex-router-signed"$/m);
+    assert.match(active, /\[model_providers\.codex-router-signed\]/);
+    assert.match(active, /^requires_openai_auth = true$/m);
+    assert.doesNotMatch(active, /caller-key-auth-command\.mjs/);
+    assert.deepEqual(JSON.parse(readFileSync(statePath, "utf8")), {
+      version: 1,
+      managedProvider: "codex-router-signed",
+      previousPresent: false,
+    });
+
+    // Ordinary updates keep the rollback-compatible v1 record byte-for-byte;
+    // only an explicit off/on cycle may change signed-routing modes.
+    const stateBeforeUpdate = readFileSync(statePath, "utf8");
+    const updated = run("enable", codexHome, stateDir);
+    assert.equal(updated.model_provider, "codex-router-signed");
+    assert.equal(readFileSync(statePath, "utf8"), stateBeforeUpdate);
+
     run("signed-disable", codexHome, stateDir);
-    assert.doesNotMatch(readFileSync(configPath, "utf8"), /^model_provider\s*=/m);
+    const restored = readFileSync(configPath, "utf8");
+    assert.doesNotMatch(restored, /^model_provider\s*=/m);
+    assert.doesNotMatch(restored, /model_providers\.codex-router-signed/);
+    assert.equal(existsSync(statePath), false);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("signed routing switches an explicit OpenAI provider and restores it exactly", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-signed-openai-"));
+  const stateDir = path.join(codexHome, "router-state");
+  const configPath = path.join(codexHome, "config.toml");
+  const statePath = path.join(stateDir, "signed-provider-mode.json");
+  writeFileSync(
+    configPath,
+    'model = "deepseek/deepseek-v4-pro"\nmodel_provider = "openai"\n',
+    { mode: 0o600 },
+  );
+  try {
+    const enabled = run("signed-enable", codexHome, stateDir);
+    assert.equal(enabled.model_provider, "codex-router-signed");
+    assert.equal(enabled.signed_routing_managed, true);
+    assert.equal(enabled.login_free, false);
+    assert.deepEqual(JSON.parse(readFileSync(statePath, "utf8")), {
+      version: 1,
+      managedProvider: "codex-router-signed",
+      previousPresent: true,
+      previousModelProvider: "openai",
+    });
+
+    const disabled = run("signed-disable", codexHome, stateDir);
+    assert.equal(disabled.model_provider, "openai");
+    const restored = readFileSync(configPath, "utf8");
+    assert.match(restored, /^model = "deepseek\/deepseek-v4-pro"$/m);
+    assert.match(restored, /^model_provider = "openai"$/m);
+    assert.doesNotMatch(restored, /model_providers\.codex-router-signed/);
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("ordinary refresh does not migrate an existing root-OpenAI v3 signed state", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-signed-v3-stable-"));
+  const stateDir = path.join(codexHome, "router-state");
+  const configPath = path.join(codexHome, "config.toml");
+  const statePath = path.join(stateDir, "signed-provider-mode.json");
+  writeFileSync(configPath, 'model_provider = "openai"\n', { mode: 0o600 });
+  try {
+    run("enable", codexHome, stateDir);
+    const legacyState = {
+      version: 3,
+      mode: "root-openai",
+      managedProvider: "openai",
+      managedBaseUrl: "http://127.0.0.1:46192/v1",
+      ownershipId: "0123456789abcdef0123456789abcdef",
+      previousProviderSections: [],
+    };
+    writeFileSync(statePath, `${JSON.stringify(legacyState, null, 2)}\n`, { mode: 0o600 });
+
+    const explicitlyReapplied = run("signed-enable", codexHome, stateDir);
+    assert.equal(explicitlyReapplied.model_provider, "openai");
+    assert.deepEqual(JSON.parse(readFileSync(statePath, "utf8")), legacyState);
+
+    const refreshed = run("enable", codexHome, stateDir);
+    assert.equal(refreshed.model_provider, "openai");
+    assert.equal(refreshed.signed_routing, true);
+    assert.deepEqual(JSON.parse(readFileSync(statePath, "utf8")), legacyState);
+
+    // A full native-catalog refresh temporarily disables the transport. Its
+    // internal restore hint recreates the prior root-openai mode instead of
+    // treating the refresh as a user off/on toggle.
+    run("disable", codexHome, stateDir);
+    assert.equal(existsSync(statePath), false);
+    run("enable", codexHome, stateDir);
+    const restored = run(
+      "signed-enable",
+      codexHome,
+      stateDir,
+      ["--preserve-root-openai"],
+    );
+    assert.equal(restored.model_provider, "openai");
+    const restoredState = JSON.parse(readFileSync(statePath, "utf8"));
+    assert.equal(restoredState.version, 3);
+    assert.equal(restoredState.mode, "root-openai");
+  } finally {
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("signed provider switch fails closed after its managed table drifts", () => {
+  const codexHome = mkdtempSync(path.join(os.tmpdir(), "codex-router-signed-switch-drift-"));
+  const stateDir = path.join(codexHome, "router-state");
+  const configPath = path.join(codexHome, "config.toml");
+  writeFileSync(configPath, 'model_provider = "openai"\n', { mode: 0o600 });
+  try {
+    run("signed-enable", codexHome, stateDir);
+    const drifted = readFileSync(configPath, "utf8").replace(
+      'name = "Codex Router (with ChatGPT)"',
+      'name = "User-managed provider"',
+    );
+    writeFileSync(configPath, drifted, { mode: 0o600 });
+    assert.throws(
+      () => run("enable", codexHome, stateDir),
+      /lost ownership.*codex-router-signed/i,
+    );
+    assert.throws(
+      () => run("signed-disable", codexHome, stateDir),
+      /lost ownership.*codex-router-signed/i,
+    );
+    assert.equal(readFileSync(configPath, "utf8"), drifted);
   } finally {
     rmSync(codexHome, { recursive: true, force: true });
   }

--- a/test/control-center-harness.test.mjs
+++ b/test/control-center-harness.test.mjs
@@ -7,6 +7,7 @@ import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
 
 import {
+  codexSessionProvider,
   getContextSessionsSnapshot,
   registerIpcHandlers,
 } from "../apps/control-center/electron/ipc.mjs";
@@ -15,6 +16,15 @@ const CODEX_ID = "019f7432-43d9-7413-8f18-5f964587f58e";
 const DSH_ID = "session-123e4567-e89b-42d3-a456-426614174000";
 const CURSOR_ID = "223e4567-e89b-42d3-a456-426614174000";
 const CURSOR_AGENT_ID = "323e4567-e89b-42d3-a456-426614174000";
+
+test("signed routing does not label native Codex sessions as router traffic", () => {
+  assert.equal(codexSessionProvider("gpt-6-astra", "codex-router-signed"), "openai");
+  assert.equal(
+    codexSessionProvider("deepseek/deepseek-v4-pro", "codex-router-signed"),
+    "deepseek",
+  );
+  assert.equal(codexSessionProvider("gpt-6-astra", "openai"), "openai");
+});
 
 test("context manager reads bounded metadata without returning conversation messages", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "router-context-sessions-"));

--- a/test/refresh-catalog.test.mjs
+++ b/test/refresh-catalog.test.mjs
@@ -14,7 +14,13 @@ const noJournal = {
 const noLock = (operation) => operation();
 const noAccountRefresh = async () => ({ status: "unavailable" });
 
-function recordingRunner({ signed = true, loginFree = false, model, failAt } = {}) {
+function recordingRunner({
+  signed = true,
+  signedProviderMode = signed ? "root-openai" : undefined,
+  loginFree = false,
+  model,
+  failAt,
+} = {}) {
   const calls = [];
   return {
     calls,
@@ -30,6 +36,7 @@ function recordingRunner({ signed = true, loginFree = false, model, failAt } = {
           stdout: `${JSON.stringify({
             mode: "router",
             signed_routing: signed,
+            signed_provider_mode: signedProviderMode,
             login_free: loginFree,
             model: model || null,
           })}\n`,
@@ -96,7 +103,7 @@ test("refresh orchestration restores signed routing and republishes the routed c
     ["config-manager.mjs", ["disable"]],
     ["catalog.mjs", ["--refresh-native"]],
     ["config-manager.mjs", ["enable"]],
-    ["config-manager.mjs", ["signed-enable"]],
+    ["config-manager.mjs", ["signed-enable", "--preserve-root-openai"]],
     ["catalog.mjs", []],
   ]);
   assert.equal(result.catalogOutput, '{"models":1}\n');
@@ -113,6 +120,24 @@ test("refresh orchestration restores the active transport after catalog failure"
     }),
     /catalog\.mjs exited with status 75.*forced catalog failure/s,
   );
+  assert.deepEqual(runner.calls, [
+    ["config-manager.mjs", ["status"]],
+    ["config-manager.mjs", ["disable"]],
+    ["catalog.mjs", ["--refresh-native"]],
+    ["config-manager.mjs", ["enable"]],
+    ["config-manager.mjs", ["signed-enable", "--preserve-root-openai"]],
+    ["catalog.mjs", []],
+  ]);
+});
+
+test("refresh restores a provider-switch signed mode without changing its mode", async () => {
+  const runner = recordingRunner({ signedProviderMode: "provider-switch" });
+  await refreshCatalog({
+    canRefreshInPlace: () => false,
+    refreshAccountCatalog: noAccountRefresh,
+    run: runner.run,
+    lock: noLock,
+  });
   assert.deepEqual(runner.calls, [
     ["config-manager.mjs", ["status"]],
     ["config-manager.mjs", ["disable"]],

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -276,6 +276,17 @@ test("router requires the configured path capability before any model route", as
   try {
     await waitFor(`${routerBase(routerPort)}/models`, router);
 
+    const modelResponse = await fetch(`${routerBase(routerPort)}/models`);
+    assert.equal(modelResponse.status, 200);
+    const modelCatalog = await modelResponse.json();
+    assert.equal(modelCatalog.object, "list");
+    assert.ok(Array.isArray(modelCatalog.data));
+    assert.ok(Array.isArray(modelCatalog.models));
+    assert.deepEqual(
+      modelCatalog.data.map((model) => model.id),
+      modelCatalog.models.map((model) => model.slug),
+    );
+
     const oldRoute = await fetch(`http://127.0.0.1:${routerPort}/v1/responses`, {
       method: "POST",
       headers: {
@@ -2792,6 +2803,17 @@ test("router drops foreign reasoning items before stateless native replay", asyn
       type: "item_reference",
       id: "rs_external_reference",
     };
+    const explicitlyUnstoredReasoning = {
+      type: "reasoning",
+      id: "rs_private_unstored",
+      summary: [{ type: "summary_text", text: "private draft" }],
+      content: null,
+      encrypted_content: null,
+    };
+    const explicitlyUnstoredReference = {
+      type: "item_reference",
+      id: "rs_private_unstored",
+    };
     const nonReasoningReference = {
       type: "item_reference",
       id: "msg_native_reference",
@@ -2930,6 +2952,8 @@ test("router drops foreign reasoning items before stateless native replay", asyn
           mixedSummaryReasoning,
           missingStatelessPayload,
           staleReasoningReference,
+          explicitlyUnstoredReasoning,
+          explicitlyUnstoredReference,
           userMessage,
         ],
         store: true,
@@ -2953,6 +2977,10 @@ test("router drops foreign reasoning items before stateless native replay", asyn
     assert.deepEqual(
       stored.input.find((item) => item?.id === "rs_external_reference"),
       staleReasoningReference,
+    );
+    assert.equal(
+      stored.input.some((item) => item?.id === explicitlyUnstoredReasoning.id),
+      false,
     );
     assert.deepEqual(
       stored.input.find((item) => item?.id === unknownOpaqueReasoning.id),
@@ -7526,6 +7554,18 @@ test("router redirects native background turns to the configured routed model", 
   writeFileSync(
     path.join(stateDir, "native-redirect.json"),
     `${JSON.stringify({ version: 1, model: "kimi-oauth/k3" })}\n`,
+  );
+  // Signed routing and native redirect are independent controls. Enabling the
+  // former must not silently disable an explicit redirect selected by the
+  // operator.
+  writeFileSync(
+    path.join(stateDir, "signed-provider-mode.json"),
+    `${JSON.stringify({
+      version: 1,
+      managedProvider: "codex-router-signed",
+      previousPresent: true,
+      previousModelProvider: "openai",
+    })}\n`,
   );
   const router = run("router.mjs", {
     CODEX_ROUTER_PORT: String(routerPort),


### PR DESCRIPTION
## Summary

Supersedes #673 and reworks it from the current `main` branch in response to the maintainer review at https://github.com/duolahypercho/codex-router/pull/673#issuecomment-5629821547.

Current Codex validates a prefixed external model against the selected provider before sending the request. Under a ChatGPT login, the root `openai` provider therefore rejects a routed slug before it can reach the local router. This change makes the explicit **Use Router with ChatGPT** toggle select a dedicated ChatGPT-authenticated `codex-router-signed` provider, while keeping the change opt-in, rollback-safe, ownership-checked, and independent from native redirect.

## What changed after #673

1. **Documented and constrained the root-provider exception**
   - Updated `AGENTS.md`, `SECURITY.md`, the README, and the architecture guide.
   - Only an explicit signed-routing toggle from root OpenAI may select `codex-router-signed`.
   - Install, update, repair, and catalog refresh do not silently opt users into or migrate this switch.

2. **Kept the state readable by the previous release**
   - Reused the existing version-1 provider-switch state instead of introducing version 4.
   - Ordinary update preserves active v1 state byte-for-byte.
   - Catalog refresh remembers whether it parked `root-openai` or `provider-switch` mode and restores that same mode.
   - The managed provider block is validated exactly before update or disable; drift fails closed.
   - A cross-version check confirmed that current `main` can disable state written by this branch, restore `model_provider = "openai"`, and clear the state file.

3. **Preserved native redirect as a separate operator control**
   - Removed the #673 behavior that implicitly bypassed aliases and native redirect for signed sessions.
   - Native redirect remains active until explicitly cleared, regardless of signed routing or failover.
   - Both controls now warn about that independence where the operator changes them.

4. **Corrected the subagent documentation without overclaiming**
   - Recorded the exact ordinary-routing evidence: Codex CLI 0.153.4, `codex login status` reporting ChatGPT login, and the request reaching `/v1/responses` through the dedicated provider.
   - Explicitly states that this does **not** certify subagent checks 3-5 and that no quota-consuming subagent certification run was performed.

5. **Addressed the smaller review points**
   - Control Center no longer labels an unprefixed native GPT session as router traffic solely because its transport provider is `codex-router-signed`.
   - The signed-routing path adds no synchronous state or catalog reads to `/responses`; reasoning cleanup relies on request-local evidence.

6. **Retained the accepted fixes from #673**
   - `/models` serves both the OpenAI-compatible `data` array and the Codex account-catalog `models` array.
   - Mixed routed/native turns drop only an explicitly unstored reasoning item and its paired `rs_` reference, using request-local evidence rather than reading router state on the hot path.

## Verification

- `npm run check`
- Focused config, refresh, catalog, caller-key, routing, native-alias, and Control Center harness tests
- Control Center: `npm run check`, all 99 tests (98 passed, one Windows-only skip), and production build
- Full root test suite: all failures were limited to two environment-specific baseline failures reproduced unchanged on unmodified `main`:
  - the local browser test rendered the Chinese `路由在线` label while the test expected English `Router online`
  - the user's global pre-commit hook rejected the repository's literal environment-variable example in an installer rollback fixture
- Cross-version downgrade: enable with this branch, disable with unmodified current `main`, verify provider restoration/state removal, and confirm Codex parses the restored config
- `git diff --check`
- Secret scan of the complete PR diff

## Security and scope

This PR contains no local router configuration, API keys, tunnel identifiers, private endpoints, credentials, generated catalogs, or runtime state. It changes only the general routing bug, rollback behavior, documentation, and tests.
