### PR TITLE
test: remove timer race from Grok post-reasoning bound tests

### DIFF
--- a/test/empty-completion-router.test.mjs
+++ b/test/empty-completion-router.test.mjs
@@ -1477,21 +1477,49 @@ function writeReasoningDelta(response) {
   response.write(REASONING_DELTA_SSE);
 }
 
-function delayedAfterReasoning(later, delayMs, onPost) {
+// Holds `later` until `delayMs` passes, or until the router closes the upstream
+// first. A route whose bound fires closes the attempt, so content can never win
+// a race against that timer on a loaded runner: the delay only decides when a
+// route that is *not* bounded receives its content. `onSettled` is called
+// exactly once, with "content" or "closed" for whichever happened first; the
+// upstream close can reach the gateway after the client's response has ended,
+// so tests await it rather than reading a flag.
+function delayedAfterReasoning(later, delayMs, onPost, onSettled) {
   return (_request, response) => {
     onPost?.();
     writeReasoningDelta(response);
-    const timer = setTimeout(() => response.end(later), delayMs);
-    response.once("close", () => clearTimeout(timer));
+    const timer = setTimeout(() => {
+      onSettled?.("content");
+      response.end(later);
+    }, delayMs);
+    response.once("close", () => {
+      clearTimeout(timer);
+      if (!response.writableEnded) onSettled?.("closed");
+    });
   };
+}
+
+function upstreamOutcome() {
+  let settle;
+  const settled = new Promise((resolve) => {
+    settle = resolve;
+  });
+  return { settle, settled };
 }
 
 for (const model of [GROK_OAUTH_MODEL, GROK_API_MODEL, "deepseek/deepseek-v4-pro"]) {
   test(`${model} uses its own bound after reasoning starts`, async () => {
+    const oauth = model === GROK_OAUTH_MODEL;
     let posts = 0;
-    const gw = await gateway(delayedAfterReasoning(CONTENT_SSE, 150, () => {
+    const upstream = upstreamOutcome();
+    // Grok OAuth gets its content a whole second after reasoning -- forty times
+    // the 25ms prelude -- so a route that wrongly applied the prelude closes the
+    // attempt long before it arrives. Bounded routes are held until the router
+    // closes them; the ten-second fallback only turns a missing bound into a
+    // failed assertion instead of a hung test.
+    const gw = await gateway(delayedAfterReasoning(CONTENT_SSE, oauth ? 1_000 : 10_000, () => {
       posts += 1;
-    }));
+    }, upstream.settle));
     const routerPort = await openPort();
     const router = run({
       ...routerEnv(gw.port, routerPort),
@@ -1502,14 +1530,16 @@ for (const model of [GROK_OAUTH_MODEL, GROK_API_MODEL, "deepseek/deepseek-v4-pro
       const result = await readRouted(routerPort, { ...TURN_BODY, model });
       const [event] = await waitForUsageEvents(router.stateDir, 1, router);
       assert.equal(posts, 1, "never replay a visible stream");
-      if (model === GROK_OAUTH_MODEL) {
+      if (oauth) {
         assert.match(result.body, /Recovered/);
         assert.doesNotMatch(result.body, /event: error/);
+        assert.equal(await upstream.settled, "content");
         assert.equal(event.status, 200);
         assert.equal(event.emptyCompletionPreludeLimit, undefined);
       } else {
         assert.doesNotMatch(result.body, /Recovered/);
         assert.match(result.body, /precontent_limit/);
+        assert.equal(await upstream.settled, "closed", "the router's bound closed the attempt");
         assert.equal(event.status, 502);
       }
     } finally {
@@ -1521,9 +1551,11 @@ for (const model of [GROK_OAUTH_MODEL, GROK_API_MODEL, "deepseek/deepseek-v4-pro
 
 test("invalid Grok stall env keeps the ten-minute default instead of the prelude", async () => {
   let posts = 0;
-  const gw = await gateway(delayedAfterReasoning(CONTENT_SSE, 150, () => {
+  const upstream = upstreamOutcome();
+  // Forty times the prelude, for the same reason as the bound test above.
+  const gw = await gateway(delayedAfterReasoning(CONTENT_SSE, 1_000, () => {
     posts += 1;
-  }));
+  }, upstream.settle));
   const routerPort = await openPort();
   const router = run({
     ...routerEnv(gw.port, routerPort),
@@ -1536,6 +1568,7 @@ test("invalid Grok stall env keeps the ten-minute default instead of the prelude
     assert.equal(posts, 1);
     assert.match(result.body, /Recovered/);
     assert.doesNotMatch(result.body, /precontent_limit/);
+    assert.equal(await upstream.settled, "content");
   } finally {
     await stopChild(router);
     await closeServer(gw.server);
@@ -1563,7 +1596,9 @@ test("a Grok headers-only attempt still uses the 30-second prelude, not the stal
     await waitFor(`${callerBaseUrl(routerPort, CALLER_KEY)}/models`, router);
     const started = Date.now();
     const result = await readRouted(routerPort, { ...TURN_BODY, model: GROK_OAUTH_MODEL });
-    assert.ok(Date.now() - started < 900, "Grok headers-only still uses the prelude");
+    // The alternative is the ten-minute stall bound, so a generous ceiling still
+    // tells the two apart without timing a loaded runner to the millisecond.
+    assert.ok(Date.now() - started < 5_000, "Grok headers-only still uses the prelude");
     assert.match(result.body, /Recovered/);
     assert.equal(result.headers["x-upstream-attempt"], "retry");
     assert.equal(posts, 2);
@@ -1585,14 +1620,16 @@ test("a genuinely stalled Grok stream respects the separate bound without replay
   const routerPort = await openPort();
   const router = run({
     ...routerEnv(gw.port, routerPort),
-    CODEX_ROUTER_EMPTY_COMPLETION_PRELUDE_MS: "1000",
+    // The prelude sits far above the ceiling below, so the stall bound is the
+    // only timer that can end this stream inside it, even on a loaded runner.
+    CODEX_ROUTER_EMPTY_COMPLETION_PRELUDE_MS: "10000",
     CODEX_ROUTER_GROK_STREAM_STALL_MS: "50",
   });
   try {
     await waitFor(`${callerBaseUrl(routerPort, CALLER_KEY)}/models`, router);
     const started = Date.now();
     const result = await readRouted(routerPort, { ...TURN_BODY, model: GROK_OAUTH_MODEL });
-    assert.ok(Date.now() - started < 900, "uses the independent stall bound");
+    assert.ok(Date.now() - started < 5_000, "uses the independent stall bound");
     assert.match(result.body, /precontent_limit/);
     assert.equal(posts, 1);
     const [event] = await waitForUsageEvents(router.stateDir, 1, router);


### PR DESCRIPTION
## Summary

`grok-api/grok-4.5 uses its own bound after reasoning starts` failed intermittently on `windows-latest` (PR #698, run 34580221401, job 103201801438): the body carried the whole `CONTENT_SSE` instead of a `precontent_limit` error. main passed the same test on c6fd6f5b.

The cause was a race in the test. The stand-in gateway sent a reasoning delta and then content on a fixed 150 ms timer, and the router's post-reasoning bound was 25 ms. On a loaded runner the router's timer didn't fire until after the content had arrived, so the bounded route looked like it had recovered. The same failure reproduced locally on untouched `origin/main` while the machine was busy.

This PR changes only the test (`test/empty-completion-router.test.mjs`). No router code changes.

- **Bounded routes (Grok API, DeepSeek):** the gateway holds content until the router closes the upstream. When the stall bound fires, the guard destroys the pipeline and that cancels the upstream fetch, so content can no longer arrive before the timer however slow the runner is. A 10-second fallback turns a missing bound into a failed assertion instead of a hung test.
- **Which happened first is now checked.** The gateway settles a promise exactly once, with `"closed"` or `"content"`. Bounded routes must see `"closed"` and Grok OAuth must see `"content"`. The test awaits the promise instead of reading a flag, because the upstream close can reach the gateway after the client's response has already ended. A flag version of this check flaked once locally.
- **Grok OAuth** (both the loop case and `invalid Grok stall env keeps the ten-minute default…`): content arrives 1 s after reasoning instead of 150 ms, which is 40× the 25 ms prelude. A route that wrongly used the prelude would close the attempt well before the content arrives. Before this change, the same kind of starvation could let that regression pass.
- **Sibling wall-clock ceilings:**
  - `a Grok headers-only attempt still uses the 30-second prelude…`: ceiling raised from 900 ms to 5 s. The alternative it rules out is the ten-minute stall bound, so 5 s still tells the two apart.
  - `a genuinely stalled Grok stream respects the separate bound…`: the prelude it compares against was only 100 ms above the 900 ms ceiling. The prelude is now 10 s and the ceiling 5 s, so the 50 ms stall bound is the only timer that can end the stream in time.

What the tests prove is unchanged: Grok API and DeepSeek use the prelude bound after reasoning starts, and Grok OAuth uses its own stall bound.

## Verification

- `npm run check`: passes.
- **Focused Grok bound tests (the 6 above), repeated locally:** 7 of 8 rounds passed 6/6, including rounds with 1,000–11,700 sockets in TIME_WAIT. Every failure in the eighth round was `connect EADDRNOTAVAIL` (loopback port exhaustion from a local VPN tunnel), not an assertion.
- **Negative controls**, each in a scratch worktree with this test file:
  - **Control A:** changed `src/router.mjs` so non-OAuth routes also used `GROK_STREAM_STALL_MS`. Both bounded cases failed on `/Recovered/` after the 10 s fallback, and the Grok OAuth case still passed. It was run twice, once against each version of the check. In the second run the invalid-env test also failed, but with a router startup timeout from the same port exhaustion, not an assertion.
  - **Control B:** changed Grok OAuth to use `EMPTY_COMPLETION_PRELUDE_MS`. Both OAuth tests failed with `precontent_limit` in the body, and the bounded cases still passed.
- **Full file (`node --test test/empty-completion-router.test.mjs`):** I couldn't get a clean local run. The machine's loopback ports were exhausted, so the router child never became reachable (`EADDRNOTAVAIL` / `waitFor` timeouts) in tests this PR doesn't touch as well. I didn't run the full file on `origin/main` for comparison. CI on the three OS runners is the full-file check for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
