### PR TITLE
fix: label routed assistant messages with Codex message phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2046,6 +2046,33 @@ xAI and Codex has its own idle limit. The router's post-prologue stall guard
    `test/responses-heartbeat.test.mjs`, `test/fetch-transport.test.mjs`, and the
    Grok cases in `test/empty-completion-router.test.mjs`.
 
+## Routed assistant messages carry a phase label
+
+Native models label every assistant message `commentary` or `final_answer`.
+Codex folds commentary into its "Worked for ..." group, renders the final
+answer below it, and finds a thread's answer with
+`json_extract(item_json, '$.phase') = 'final_answer'`. Routed providers send no
+label, so `src/message-phase.mjs` assigns one.
+
+1. **The rule is the one native turns follow, read from item order.** A message
+   that another output item follows is commentary; the last message of a
+   `response.completed`, `response.incomplete`, or `response.done` is the final
+   answer. Never infer it from the text.
+2. **A provider's phase always wins.** Only an absent or null phase is filled,
+   so a Responses provider that already labels messages passes through
+   unchanged.
+3. **Hold one frame, briefly.** Only the message's `output_item.done` waits,
+   until the next item opens or the response settles; deltas stream live and
+   every frame held behind it is replayed in order. A failed, errored, or
+   unterminated response, invalid UTF-8, or an exhausted hold bound releases the
+   original bytes unlabelled.
+4. **It is metadata, not transcript.** It adds no text, costs no model tokens,
+   and LiteLLM rebuilds chat history from role and content, so a replayed label
+   never reaches a chat-completions provider.
+5. **Routed streams only, after the item-lifecycle normalizer**, so items are
+   already sequential. Coverage lives in `test/message-phase.test.mjs` and the
+   routed case in `test/namespace-relay-routing.test.mjs`.
+
 ## Routed subagent regression prevention
 
 - A normal `/responses` smoke test does not cover Codex collaboration. Current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Routed models' turns now render like native ones in Codex.** Native models
+  label each assistant message `commentary` (a progress note before more tool
+  calls) or `final_answer`, and Codex folds commentary into "Worked for ..."
+  and shows the final answer below it. Routed providers never send the label,
+  so every progress note rendered as a standalone answer. The router now labels
+  routed messages from the stream's item order: a message another item follows
+  is commentary, and the last message of a completed response is the final
+  answer. A phase the provider sent always wins, text still streams live, and
+  failed or unterminated responses are relayed unlabelled. The label costs no
+  model tokens, and LiteLLM drops it from history before any chat-completions
+  provider sees it.
 - **Switching a conversation back to OpenAI no longer fails on routed item IDs.**
   Routed providers mint their own item IDs (`call_...`, `tool_...`,
   `chatcmpl-...`), Codex saves them, and OpenAI rejects them on replay with

--- a/src/message-phase.mjs
+++ b/src/message-phase.mjs
@@ -1,0 +1,255 @@
+import { Transform } from "node:stream";
+
+// Native Codex models label every assistant message with a `phase`:
+// `commentary` for a progress note written before more tool calls, and
+// `final_answer` for the message that ends the turn. Codex keys its display on
+// that label -- commentary folds into the collapsible "Worked for ..." group
+// and the final answer renders below it -- and its thread history looks the
+// answer up by `phase = 'final_answer'`. Routed providers never send the label,
+// so every progress note rendered as a standalone answer.
+//
+// This stage assigns the label from the item order the stream already carries,
+// using the rule native turns follow: a message that another output item
+// follows is commentary, and the last message of a successfully completed
+// response is the final answer. It spends no model tokens, and a replayed label
+// never reaches a chat-completions provider: LiteLLM rebuilds assistant history
+// from role and content alone.
+//
+// Only a message's `output_item.done` is rewritten, and only while its phase is
+// absent; a phase the provider sent always wins. Text deltas stream unchanged.
+// The done frame is held just until the next item opens (commentary) or the
+// response completes (final answer), and every frame that arrived in between is
+// replayed in order behind it. A failed, errored, or unterminated response
+// releases the held frame untouched, as does anything this stage cannot parse.
+// It runs after the item-lifecycle normalizer, so items are already sequential.
+const CRLF_SEP = Buffer.from("\r\n\r\n");
+const LF_SEP = Buffer.from("\n\n");
+const COMMENTARY = "commentary";
+const FINAL_ANSWER = "final_answer";
+// Terminals that settle a delivered response: its last message is the answer.
+const ANSWER_TERMINALS = new Set(["response.completed", "response.incomplete", "response.done"]);
+// Terminals that end the turn without an answer.
+const FAILURE_TERMINALS = new Set(["response.failed", "error"]);
+const DECISION_HINTS = [
+  "response.output_item.added",
+  "response.output_item.done",
+  ...ANSWER_TERMINALS,
+  ...FAILURE_TERMINALS,
+];
+// The window between a message closing and the next item opening normally holds
+// a few small frames. Past this bound the frame is released unlabelled.
+const DEFAULT_MAX_HELD_BYTES = 1024 * 1024;
+// A terminal can echo the whole request. Larger terminals still decide the
+// pending label but are relayed without patching their output snapshot.
+const MAX_PARSE_CHARS = 8 * 1024 * 1024;
+
+function fatalUtf8(buffer) {
+  return new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(buffer);
+}
+
+function findFrameEnd(buffer) {
+  const crlf = buffer.indexOf(CRLF_SEP);
+  const lf = buffer.indexOf(LF_SEP);
+  if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+    return { index: crlf, separator: CRLF_SEP };
+  }
+  if (lf !== -1) return { index: lf, separator: LF_SEP };
+  return undefined;
+}
+
+function dataTextOf(text) {
+  const dataLines = [];
+  for (const line of text.split(/\r?\n/)) {
+    if (line.startsWith("data:")) {
+      const value = line.slice(5);
+      dataLines.push(value.startsWith(" ") ? value.slice(1) : value);
+    }
+  }
+  return dataLines.length ? dataLines.join("\n") : undefined;
+}
+
+// Returns { done: true } for `[DONE]`, { type, event? } for a JSON event, or
+// undefined for comments and frames that are not Responses events.
+function parseFrame(text) {
+  const dataText = dataTextOf(text);
+  if (dataText === undefined) return undefined;
+  if (dataText === "[DONE]") return { done: true };
+  if (!DECISION_HINTS.some((hint) => dataText.includes(`"${hint}"`))) return undefined;
+  if (dataText.length > MAX_PARSE_CHARS) {
+    const type = /"type"\s*:\s*"([^"]{1,64})"/.exec(dataText.slice(0, 256))?.[1];
+    return type ? { type } : undefined;
+  }
+  try {
+    const event = JSON.parse(dataText);
+    return typeof event?.type === "string" ? { type: event.type, event } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function unlabelledAssistantMessage(item) {
+  return (
+    item !== null &&
+    typeof item === "object" &&
+    !Array.isArray(item) &&
+    item.type === "message" &&
+    item.role === "assistant" &&
+    (item.phase === undefined || item.phase === null)
+  );
+}
+
+// Replaces the frame's data lines with one line carrying `event`, keeping every
+// other field line (event:, id:, comments) and the original separator.
+function rewrittenFrame(text, separator, event) {
+  const lineEnding = text.includes("\r\n") ? "\r\n" : "\n";
+  const lines = [];
+  let wroteData = false;
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) {
+      lines.push(line);
+    } else if (!wroteData) {
+      lines.push(`data: ${JSON.stringify(event)}`);
+      wroteData = true;
+    }
+  }
+  return Buffer.concat([Buffer.from(lines.join(lineEnding), "utf8"), separator]);
+}
+
+// Labels the terminal snapshot's messages by the same rule the stream used.
+export function labelResponseOutput(output) {
+  if (!Array.isArray(output)) return undefined;
+  let changed = false;
+  const labelled = output.map((item, index) => {
+    if (!unlabelledAssistantMessage(item)) return item;
+    changed = true;
+    return { ...item, phase: index < output.length - 1 ? COMMENTARY : FINAL_ANSWER };
+  });
+  return changed ? labelled : undefined;
+}
+
+export class MessagePhaseTransform extends Transform {
+  #buffer = Buffer.alloc(0);
+  #passthrough = false;
+  #maxHeldBytes;
+  // The unlabelled message done frame awaiting its label, and the frames that
+  // arrived after it.
+  #pending;
+  #held = [];
+  #heldBytes = 0;
+
+  constructor({ maxHeldBytes = DEFAULT_MAX_HELD_BYTES } = {}) {
+    super();
+    this.#maxHeldBytes = maxHeldBytes;
+  }
+
+  _transform(chunk, encoding, callback) {
+    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+    if (this.#passthrough) {
+      this.push(piece);
+      callback();
+      return;
+    }
+    this.#buffer = this.#buffer.length ? Buffer.concat([this.#buffer, piece]) : piece;
+    this.#drain(false);
+    callback();
+  }
+
+  _flush(callback) {
+    if (!this.#passthrough) this.#drain(true);
+    // A stream that ended without a terminal has no answer to label.
+    this.#release(undefined);
+    if (this.#buffer.length) this.push(this.#buffer);
+    this.#buffer = Buffer.alloc(0);
+    callback();
+  }
+
+  #drain(flush) {
+    while (this.#buffer.length && !this.#passthrough) {
+      const found = findFrameEnd(this.#buffer);
+      if (!found) {
+        if (!flush) return;
+        const original = this.#buffer;
+        this.#buffer = Buffer.alloc(0);
+        this.#frame(original, original, Buffer.alloc(0));
+        return;
+      }
+      const block = this.#buffer.subarray(0, found.index);
+      const original = this.#buffer.subarray(0, found.index + found.separator.length);
+      this.#buffer = this.#buffer.subarray(found.index + found.separator.length);
+      this.#frame(Buffer.from(original), block, found.separator);
+    }
+  }
+
+  #frame(original, block, separator) {
+    let text;
+    try {
+      text = fatalUtf8(block);
+    } catch {
+      // Invalid UTF-8 disables labelling for the rest of the stream.
+      this.#release(undefined);
+      this.push(original);
+      if (this.#buffer.length) this.push(this.#buffer);
+      this.#buffer = Buffer.alloc(0);
+      this.#passthrough = true;
+      return;
+    }
+    const parsed = parseFrame(text);
+    const type = parsed?.type;
+
+    if (this.#pending) {
+      if (type === "response.output_item.added" || type === "response.output_item.done") {
+        // Another item follows the held message, so it was commentary.
+        this.#release(COMMENTARY);
+      } else if (ANSWER_TERMINALS.has(type)) {
+        this.#release(FINAL_ANSWER);
+      } else if (FAILURE_TERMINALS.has(type) || parsed?.done) {
+        this.#release(undefined);
+      } else {
+        this.#held.push(original);
+        this.#heldBytes += original.length;
+        if (this.#heldBytes > this.#maxHeldBytes) this.#release(undefined);
+        return;
+      }
+    }
+
+    if (type === "response.output_item.done" && unlabelledAssistantMessage(parsed.event?.item)) {
+      this.#pending = { text, separator, original, event: parsed.event };
+      return;
+    }
+    if (ANSWER_TERMINALS.has(type) && parsed.event) {
+      const output = labelResponseOutput(parsed.event.response?.output);
+      if (output) {
+        this.push(rewrittenFrame(text, separator, {
+          ...parsed.event,
+          response: { ...parsed.event.response, output },
+        }));
+        return;
+      }
+    }
+    this.push(original);
+  }
+
+  // Emits the held message frame -- labelled with `phase`, or untouched when
+  // `phase` is undefined -- followed by every frame held behind it.
+  #release(phase) {
+    const pending = this.#pending;
+    if (!pending) return;
+    this.#pending = undefined;
+    this.push(
+      phase
+        ? rewrittenFrame(pending.text, pending.separator, {
+            ...pending.event,
+            item: { ...pending.event.item, phase },
+          })
+        : pending.original,
+    );
+    for (const frame of this.#held) this.push(frame);
+    this.#held = [];
+    this.#heldBytes = 0;
+  }
+}
+
+export function messagePhaseTransform(contentType = "") {
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
+  return new MessagePhaseTransform();
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -64,6 +64,7 @@ import {
 } from "./zai-responses-compat.mjs";
 import { grokReasoningSummaryCompatTransform } from "./grok-reasoning-summary-compat.mjs";
 import { ResponsesHeartbeatTransform } from "./responses-heartbeat.mjs";
+import { messagePhaseTransform } from "./message-phase.mjs";
 import { translatedToolMessageCompatTransform } from "./deepseek-tool-message-compat.mjs";
 import {
   deepSeekCustomToolNames,
@@ -4370,6 +4371,12 @@ async function handleResponses(request, response, requestUrl) {
         ? itemLifecycleNormalizerTransform(contentType)
         : undefined;
       if (itemNormalizer) transforms.push(itemNormalizer);
+      // Routed providers never label assistant messages, so Codex could not
+      // fold progress notes into "Worked for ..." or find the final answer.
+      // Label them from the now-sequential item order; a provider's own phase
+      // always wins. Native streams already carry the label and gain no stage.
+      const messagePhase = route ? messagePhaseTransform(contentType) : undefined;
+      if (messagePhase) transforms.push(messagePhase);
       // Last, so no router stage ever parses a heartbeat: while a Grok stream is
       // silent, keep the client's idle timer from abandoning a live turn.
       if (

--- a/test/message-phase.test.mjs
+++ b/test/message-phase.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import { Readable, Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import test from "node:test";
+
+import {
+  labelResponseOutput,
+  MessagePhaseTransform,
+  messagePhaseTransform,
+} from "../src/message-phase.mjs";
+
+function block(event, sep = "\n\n") {
+  return `event: ${event.type}\ndata: ${JSON.stringify(event)}${sep}`;
+}
+
+async function label(input, { chunkSize = 0, maxHeldBytes } = {}) {
+  const transform = new MessagePhaseTransform(maxHeldBytes ? { maxHeldBytes } : {});
+  const chunks = [];
+  const collector = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.from(chunk));
+      callback();
+    },
+  });
+  const buffer = Buffer.from(input);
+  const source = [];
+  if (chunkSize > 0) {
+    for (let at = 0; at < buffer.length; at += chunkSize) source.push(buffer.subarray(at, at + chunkSize));
+  } else {
+    source.push(buffer);
+  }
+  await pipeline(Readable.from(source), transform, collector);
+  return Buffer.concat(chunks);
+}
+
+function events(body) {
+  return body
+    .toString("utf8")
+    .split(/\r?\n\r?\n/)
+    .map((frame) => frame.split(/\r?\n/).filter((line) => line.startsWith("data:")).map((line) => line.slice(5).trim()).join("\n"))
+    .filter((data) => data && data !== "[DONE]")
+    .map((data) => JSON.parse(data));
+}
+
+const message = (id, text, extra = {}) => ({
+  id,
+  type: "message",
+  role: "assistant",
+  status: "completed",
+  content: [{ type: "output_text", text, annotations: [] }],
+  ...extra,
+});
+const call = (id) => ({ id, type: "function_call", call_id: id, name: "exec_command", arguments: "{}" });
+
+function messageFrames(index, item) {
+  return [
+    block({ type: "response.output_item.added", output_index: index, item: { ...item, content: [] } }),
+    block({ type: "response.output_text.delta", output_index: index, item_id: item.id, delta: item.content[0].text }),
+    block({ type: "response.output_item.done", output_index: index, item }),
+  ];
+}
+
+function callFrames(index, item) {
+  return [
+    block({ type: "response.output_item.added", output_index: index, item: { ...item, arguments: "" } }),
+    block({ type: "response.function_call_arguments.done", output_index: index, item_id: item.id, arguments: "{}" }),
+    block({ type: "response.output_item.done", output_index: index, item }),
+  ];
+}
+
+function donePhases(body) {
+  return events(body)
+    .filter((event) => event.type === "response.output_item.done" && event.item.type === "message")
+    .map((event) => `${event.item.id}:${event.item.phase}`);
+}
+
+const TOOL_TURN = [
+  block({ type: "response.created", response: { id: "r1" } }),
+  ...messageFrames(0, message("m1", "Checking the config.")),
+  ...callFrames(1, call("c1")),
+  block({ type: "response.completed", response: { id: "r1", output: [message("m1", "Checking the config."), call("c1")] } }),
+  "data: [DONE]\n\n",
+].join("");
+
+const ANSWER_TURN = [
+  block({ type: "response.created", response: { id: "r2" } }),
+  ...messageFrames(0, message("m2", "Done.")),
+  block({ type: "response.completed", response: { id: "r2", output: [message("m2", "Done.")] } }),
+  "data: [DONE]\n\n",
+].join("");
+
+test("a message followed by a tool call is commentary", async () => {
+  const out = await label(TOOL_TURN);
+  assert.deepEqual(donePhases(out), ["m1:commentary"]);
+  const completed = events(out).find((event) => event.type === "response.completed");
+  assert.equal(completed.response.output[0].phase, "commentary");
+  assert.equal(completed.response.output[1].phase, undefined);
+});
+
+test("the last message of a completed response is the final answer", async () => {
+  const out = await label(ANSWER_TURN);
+  assert.deepEqual(donePhases(out), ["m2:final_answer"]);
+  const completed = events(out).find((event) => event.type === "response.completed");
+  assert.equal(completed.response.output[0].phase, "final_answer");
+});
+
+test("consecutive messages: only the last one is the final answer", async () => {
+  const input = [
+    ...messageFrames(0, message("m1", "First.")),
+    ...messageFrames(1, message("m2", "Second.")),
+    block({ type: "response.completed", response: { id: "r", output: [message("m1", "First."), message("m2", "Second.")] } }),
+  ].join("");
+  const out = await label(input);
+  assert.deepEqual(donePhases(out), ["m1:commentary", "m2:final_answer"]);
+  const completed = events(out).find((event) => event.type === "response.completed");
+  assert.deepEqual(completed.response.output.map((item) => item.phase), ["commentary", "final_answer"]);
+});
+
+test("labels only message done frames; every other frame and the order are unchanged", async () => {
+  const out = await label(TOOL_TURN);
+  const before = events(Buffer.from(TOOL_TURN));
+  const after = events(out);
+  assert.equal(after.length, before.length);
+  after.forEach((event, index) => {
+    assert.equal(event.type, before[index].type, `event ${index} type`);
+    if (event.type === "response.output_item.done" && event.item.type === "message") {
+      assert.deepEqual({ ...event.item, phase: undefined }, { ...before[index].item, phase: undefined });
+    } else if (event.type !== "response.completed") {
+      assert.deepEqual(event, before[index], `event ${index}`);
+    }
+  });
+});
+
+test("labels identically regardless of upstream chunk boundaries", async () => {
+  const whole = await label(TOOL_TURN);
+  for (const chunkSize of [1, 7, 64, 500]) {
+    assert.deepEqual(await label(TOOL_TURN, { chunkSize }), whole, `chunkSize=${chunkSize}`);
+  }
+});
+
+test("a phase the provider already sent is never overwritten", async () => {
+  const input = [
+    ...messageFrames(0, message("m1", "Native.", { phase: "commentary" })),
+    block({ type: "response.completed", response: { id: "r", output: [message("m1", "Native.", { phase: "commentary" })] } }),
+    "data: [DONE]\n\n",
+  ].join("");
+  assert.equal((await label(input)).toString("utf8"), input);
+});
+
+test("tool-only and message-free streams pass through byte-for-byte", async () => {
+  const input = [
+    block({ type: "response.created", response: { id: "r" } }),
+    ...callFrames(0, call("c1")),
+    block({ type: "response.completed", response: { id: "r", output: [call("c1")] } }),
+    "data: [DONE]\n\n",
+  ].join("");
+  assert.equal((await label(input)).toString("utf8"), input);
+});
+
+test("failed, errored, and unterminated responses release the message unlabelled", async () => {
+  const head = messageFrames(0, message("m1", "Partial.")).join("");
+  for (const tail of [
+    block({ type: "response.failed", response: { id: "r", error: { message: "boom" } } }),
+    block({ type: "error", error: { message: "boom" } }),
+    "data: [DONE]\n\n",
+    "",
+  ]) {
+    const input = head + tail;
+    assert.equal((await label(input)).toString("utf8"), input, JSON.stringify(tail.slice(0, 40)));
+  }
+});
+
+test("frames held behind the message keep their order and bytes", async () => {
+  const input = [
+    ...messageFrames(0, message("m1", "Wait.")),
+    ": keep-alive\n\n",
+    block({ type: "response.in_progress", response: { id: "r" } }),
+    ...callFrames(1, call("c1")),
+  ].join("");
+  const out = (await label(input)).toString("utf8");
+  const labelledDone = out.indexOf('"phase":"commentary"');
+  const comment = out.indexOf(": keep-alive");
+  const progress = out.indexOf('"response.in_progress"');
+  const callAdded = out.indexOf('"type":"function_call"');
+  assert.ok(labelledDone !== -1 && labelledDone < comment && comment < progress && progress < callAdded);
+  assert.equal(out.replace(',"phase":"commentary"', ""), input);
+});
+
+test("exceeding the hold bound releases the message unlabelled", async () => {
+  const input = [
+    ...messageFrames(0, message("m1", "Slow.")),
+    ...Array.from({ length: 20 }, (_, index) => `: filler ${"x".repeat(32)} ${index}\n\n`),
+    ...callFrames(1, call("c1")),
+  ].join("");
+  assert.equal((await label(input, { maxHeldBytes: 256 })).toString("utf8"), input);
+});
+
+test("CRLF framing and extra field lines are preserved when labelling", async () => {
+  const crlfBlock = (event, prefix = "") =>
+    `${prefix}event: ${event.type}\r\ndata: ${JSON.stringify(event)}\r\n\r\n`;
+  const input = [
+    crlfBlock({ type: "response.output_item.added", output_index: 0, item: { ...message("m1", "x"), content: [] } }),
+    crlfBlock({ type: "response.output_item.done", output_index: 0, item: message("m1", "x") }, "id: 7\r\n"),
+    crlfBlock({ type: "response.completed", response: { id: "r", output: [] } }),
+  ].join("");
+  const out = (await label(input)).toString("utf8");
+  assert.deepEqual(donePhases(Buffer.from(out)), ["m1:final_answer"]);
+  assert.ok(out.includes("id: 7\r\nevent: response.output_item.done\r\ndata: "));
+  assert.ok(!/[^\r]\n/.test(out), "every line ending stays CRLF");
+});
+
+test("invalid UTF-8 disables labelling and relays the original bytes", async () => {
+  const invalid = Buffer.concat([
+    Buffer.from(messageFrames(0, message("m1", "x")).join("")),
+    Buffer.from([0x64, 0x61, 0x74, 0x61, 0x3a, 0x20, 0xff, 0x0a, 0x0a]),
+    Buffer.from(ANSWER_TURN),
+  ]);
+  assert.deepEqual(await label(invalid), invalid);
+});
+
+test("labelResponseOutput leaves labelled and non-message output alone", () => {
+  assert.equal(labelResponseOutput([call("c1")]), undefined);
+  assert.equal(labelResponseOutput([message("m1", "x", { phase: "final_answer" })]), undefined);
+  assert.equal(labelResponseOutput(undefined), undefined);
+});
+
+test("the factory attaches only to event streams", () => {
+  assert.ok(messagePhaseTransform("text/event-stream; charset=utf-8") instanceof MessagePhaseTransform);
+  assert.equal(messagePhaseTransform("application/json"), undefined);
+});

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -2583,3 +2583,53 @@ test("real Router requires both hook opt-ins and exact model, without affecting 
     if (old) assert.equal(JSON.parse(result.clientBody).output[0].input, serializeStructuredPatch(STRUCTURED_OPERATIONS));
   }
 });
+
+test("routed turns label assistant messages the way native turns do", async () => {
+  const assistantMessage = (id, text) => ({
+    id,
+    type: "message",
+    role: "assistant",
+    status: "completed",
+    content: [{ type: "output_text", text, annotations: [] }],
+  });
+  const messageEvents = (index, item) => [
+    sseEvent({ type: "response.output_item.added", output_index: index, item: { ...item, content: [] } }),
+    sseEvent({ type: "response.output_text.delta", output_index: index, item_id: item.id, delta: item.content[0].text }),
+    sseEvent({ type: "response.output_item.done", output_index: index, item }),
+  ];
+  const lastMessage = (body, id) =>
+    responseItemsFromSse(body).filter((item) => item.type === "message" && item.id === id).at(-1);
+
+  const toolTurn = await scenario(true, {
+    model: "opencode-go/deepseek-v4.1-flash",
+    sseBody: () => [
+      sseEvent({ type: "response.created", response: { id: "resp_note" } }),
+      ...messageEvents(0, assistantMessage("msg_note", "Checking the config.")),
+      sseEvent({
+        type: "response.output_item.added",
+        output_index: 1,
+        item: { type: "function_call", name: "exec_command", call_id: "call_exec", arguments: "" },
+      }),
+      sseEvent({
+        type: "response.output_item.done",
+        output_index: 1,
+        item: { type: "function_call", name: "exec_command", call_id: "call_exec", arguments: "{}" },
+      }),
+      sseEvent({ type: "response.completed", response: { id: "resp_note", output: [] } }),
+      "data: [DONE]\n\n",
+    ].join(""),
+  });
+  assert.equal(lastMessage(toolTurn.clientBody, "msg_note").phase, "commentary");
+  assert.equal(functionCallsFromSse(toolTurn.clientBody).get("call_exec").phase, undefined);
+
+  const answerTurn = await scenario(true, {
+    model: "opencode-go/deepseek-v4.1-flash",
+    sseBody: () => [
+      sseEvent({ type: "response.created", response: { id: "resp_answer" } }),
+      ...messageEvents(0, assistantMessage("msg_answer", "Done.")),
+      sseEvent({ type: "response.completed", response: { id: "resp_answer", output: [] } }),
+      "data: [DONE]\n\n",
+    ].join(""),
+  });
+  assert.equal(lastMessage(answerTurn.clientBody, "msg_answer").phase, "final_answer");
+});

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -10056,7 +10056,8 @@ test("router compacts translated OpenCode routes and pins subagents on both rout
     );
     assert.deepEqual(
       nativeEvents.find((event) => event.type === "response.completed").response.output,
-      [terminalBlank, restoredTool("opencode-go-responses/gpt-5.6-luna")],
+      // The kept blank message precedes a tool call, so it is labelled commentary.
+      [{ ...terminalBlank, phase: "commentary" }, restoredTool("opencode-go-responses/gpt-5.6-luna")],
     );
   } finally {
     await stopChild(router);
@@ -10357,7 +10358,8 @@ test("router enables the terminal-only bridge repair only for Messages routes", 
     );
     assert.deepEqual(
       openai.events.find((event) => event.type === "response.completed").response.output,
-      [blank, tool],
+      // The kept blank message precedes a tool call, so it is labelled commentary.
+      [{ ...blank, phase: "commentary" }, tool],
     );
   } finally {
     await stopChild(router);


### PR DESCRIPTION
## Problem

Routed models' turns render differently from native ones in Codex Desktop. Their progress notes appear as full, standalone answers instead of folding into the "Worked for …" group, and the final answer isn't set apart.

## Cause

Native models label every assistant message with a `phase`. Codex keys its display on that label, and its thread history looks up a turn's answer with `json_extract(item_json, '$.phase') = 'final_answer'`. Completed native turns follow one pattern:

```
commentary → tool calls… → commentary → tool calls… → final_answer
```

Routed providers never send `phase`. The router never set it either: no routed assistant message in the local rollouts carries one.

## Fix

`src/message-phase.mjs` is a new routed-stream stage that runs after the item-lifecycle normalizer, where output items are already sequential.

- **Commentary:** a message that another output item follows.
- **Final answer:** the last message of a `response.completed`, `response.incomplete`, or `response.done`.
- **Terminal snapshot:** its `response.output` messages are labelled by the same rule.
- **Provider label wins:** a phase the provider already sent is never overwritten. Native streams get no stage.
- **Holding:** only the message's `output_item.done` is held, and only until the next item opens or the response settles. Text deltas stream live. Frames that arrive during the hold are replayed in order behind it.
- **Fail open:** a failed, errored, or unterminated response, invalid UTF-8, or an exhausted 1 MiB hold bound relays the original bytes unlabelled.

## Cost

No model tokens. The label is item metadata and adds no text. On replay, LiteLLM rebuilds chat-completions history from `role` and `content`, so the label never reaches a chat provider.

## Not included

Routed models still get `gpt-5.5`'s instruction template (`src/catalog.mjs`, `buildMergedCatalog`), not the current native one. That also changes how their final answers are formatted. It affects every routed model, so it needs its own change and review.

## Testing

- `test/message-phase.test.mjs` (14 tests) covers:
  - commentary before tool calls, and final answer on completion
  - consecutive messages
  - a provider phase left untouched
  - byte-identical passthrough for message-free streams
  - invariance to chunk boundaries
  - failed, errored, and unterminated responses
  - order of held frames
  - the hold bound
  - CRLF framing and extra field lines
  - invalid UTF-8
- `test/namespace-relay-routing.test.mjs`: through a real router process, `opencode-go/deepseek-v4.1-flash` returns `commentary` before a tool call and `final_answer` on an answer-only turn.
- `npm run check` passes.
- `test/item-lifecycle-normalizer`, `deepseek-tool-message-compat`, and `responses-websocket` pass, 130/130.
- Local loopback tests needed the TIME_WAIT backlog to drain first (Astrill VPN port exhaustion). CI is the full-suite proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
