### PR TITLE
fix: replay Chat reasoning for DeepSeek reached through a reseller

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1991,6 +1991,32 @@ pinned LiteLLM and run `node --test test/chat-reasoning.test.mjs`. It uses only
 loopback services and synthetic credentials, with duplicate negative controls.
 See the provider's [Responses contract](https://api-docs.deepseek.com/guides/responses_api/).
 
+## A duplicated assistant block is collapsed at egress
+
+LiteLLM's chat-completions bridge can emit a turn's answer text twice inside one
+assistant `message` item: the same token run, then the same run again, with the
+terminal `output_text.done` carrying both copies. It is observable on routed
+Chat routes and it is in the wire bytes, not a client rendering artifact and not
+an item-lifecycle reorder. `src/duplicate-block-collapse.mjs` rewrites a message
+whose entire text is a run of identical blank-line-separated blocks (`A\n\nA`,
+`A\n\nA\n\nB\n\nB`) down to one copy each, and relays everything else
+byte-for-byte.
+
+- The rewrite inspects only the visible answer text. An output item also carries
+  the model's reasoning, which on a thinking route is routinely an order of
+  magnitude larger; bounding the hold by total item bytes made the guard trip on
+  long reasoning and release the item verbatim, so the duplicate survived
+  exactly where it was most common. Keep the text bound and the memory bound
+  separate.
+- It runs after `ItemLifecycleNormalizer`, which guarantees an item is opened,
+  streamed, and closed before the next one begins, so holding one message item's
+  events cannot reorder the stream. If a different output index arrives while an
+  item is held, release everything verbatim rather than reordering.
+- Captures that prove a rewrite must be taken on both sides of this transform.
+  A post-transform-only capture cannot distinguish "the duplicate never
+  arrived" from "the transform removed it", which is how the reasoning-volume
+  defect above stayed hidden behind an apparently clean stream.
+
 ## Substituting a prompt-token count a provider reported as zero
 
 Codex decides when to compact from the `input_tokens` each response reports, so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1972,6 +1972,16 @@ retry rules on the shared path.
   source items or change other native Responses routes. Keep this policy shared
   between hops without applying direct DeepSeek sampling parameters to resellers.
   Command Code's schema-strict `/alpha/generate` fallback remains separate.
+- A reseller's DeepSeek routes carry reasoning the same way regardless of the
+  route's own request profile, because the rule belongs to the upstream model
+  and not to the profile or the reseller. OpenCode Go's DeepSeek routes carry
+  `auto-tool-choice`, which no profile check matches, so a profile-only policy
+  left them unprotected and the provider rejected the turn after any prose
+  reply with "The `reasoning_content` in the thinking mode must be passed back
+  to the API". Scope this to the DeepSeek upstream: the same endpoint serves
+  GLM, Qwen, Kimi, MiniMax, Longcat and MiMo thinking models, and moving their
+  replay from visible text to `reasoning_content` without evidence that they
+  require it would be a silent behaviour change.
 
 Regression coverage lives in `test/deepseek-responses-routing.test.mjs`,
 `test/namespace-relay-custom.test.mjs`, `test/chat-reasoning.test.mjs` and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,22 @@
   back to the model as an ordinary tool error. A non-string `content`, a
   completed item that disagrees, and streamed text contradicted by the final
   input still fail closed. Reproduced offline against pinned LiteLLM 1.96.0.
+- **A reseller's DeepSeek routes replay Chat reasoning again.** The Chat
+  reasoning carry was scoped to the vendor request profiles (`glm-thinking`,
+  `deepseek-thinking`) plus Command Code's single DeepSeek Flash slug, so any
+  DeepSeek route reached through a reseller was left unprotected. On
+  `opencode-go/deepseek-v4.1-flash` -- whose profile is `auto-tool-choice` --
+  neither hop ran. The provider rejects a follow-up whose prior assistant turn
+  is missing its `reasoning_content`, and that failure needs a prior turn, so
+  the error surfaced on the turn *after* any reply: HTTP 400 "The
+  `reasoning_content` in the thinking mode must be passed back to the API." A
+  subagent hand-off always ends in prose, which is why spawning one broke every
+  following request in the conversation. The check now keys on the upstream
+  model for reseller Chat routes. Only the DeepSeek upstream is covered -- the
+  same endpoint's GLM, Qwen, Kimi, MiniMax, Longcat and MiMo thinking models
+  keep their existing replay channel, because flipping theirs without evidence
+  would be a silent behaviour change. Regression coverage reads the shipped
+  registry in `test/chat-reasoning.test.mjs`.
 - **Switching a conversation back to OpenAI no longer fails on routed item IDs.**
   Routed providers mint their own item IDs (`call_...`, `tool_...`,
   `chatcmpl-...`), Codex saves them, and OpenAI rejects them on replay with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,20 @@
   back to the model as an ordinary tool error. A non-string `content`, a
   completed item that disagrees, and streamed text contradicted by the final
   input still fail closed. Reproduced offline against pinned LiteLLM 1.96.0.
+- **A doubled assistant block is collapsed at egress.** On routed Chat routes the
+  bridge can emit a turn's answer text twice inside one assistant `message`
+  item -- the same token run and then the same run again, with
+  `output_text.done` carrying both copies. It lands in the wire bytes, so it is
+  not a client rendering artifact and not an item-lifecycle reorder. A new
+  `src/duplicate-block-collapse.mjs` egress transform rewrites a message whose
+  entire text is a run of identical blank-line-separated blocks (`A\n\nA`,
+  `A\n\nA\n\nB\n\nB`) down to one copy each and relays everything else
+  byte-for-byte. It runs after `ItemLifecycleNormalizer`, so no held item can
+  reorder the stream. The held-item bound deliberately weighs the visible text
+  rather than total item bytes: a captured turn held 138 KB for one message item
+  of which 113 KB was reasoning, so a single byte budget tripped on long
+  reasoning and released the item verbatim, leaving the duplicate in place on
+  exactly the thinking routes where it was most common.
 - **A reseller's DeepSeek routes replay Chat reasoning again.** The Chat
   reasoning carry was scoped to the vendor request profiles (`glm-thinking`,
   `deepseek-thinking`) plus Command Code's single DeepSeek Flash slug, so any

--- a/src/chat-reasoning.mjs
+++ b/src/chat-reasoning.mjs
@@ -3,11 +3,35 @@
 // it the direct DeepSeek profile would also change tool choice and sampling.
 // Both hops must agree: the router carries `thinking` parts through LiteLLM,
 // then the API forwarder restores the assistant's `reasoning_content` field.
+//
+// DeepSeek reached through a reseller keeps the vendor's replay rule while the
+// route carries a reseller-shaped request profile, so the profile checks above
+// leave it unprotected. `opencode-go/deepseek-v4.1-flash` is the measured case:
+// its profile is `auto-tool-choice`, so neither hop ran, and the provider
+// answered the next turn with HTTP 400 "The `reasoning_content` in the thinking
+// mode must be passed back to the API." The failure needs a prior assistant
+// turn, so it surfaced on the turn after any reply -- including every subagent
+// hand-off, which always ends in prose.
+//
+// Keyed on the upstream model, because the rule belongs to the upstream and not
+// to the profile or the reseller. Deliberately scoped to DeepSeek: OpenCode Go
+// also serves GLM, Qwen, Kimi, MiniMax, Longcat, and MiMo thinking models over
+// the same endpoint, and moving their replay from visible text to
+// `reasoning_content` without evidence that they require it would be a silent
+// behaviour change on routes this issue was never reported against.
+const RESELLER_DEEPSEEK_CHAT_PROVIDERS = new Set(["opencode-go"]);
+
+function isResellerDeepSeekChatRoute(model) {
+  if (!RESELLER_DEEPSEEK_CHAT_PROVIDERS.has(model?.provider)) return false;
+  return /(^|\/)deepseek/i.test(String(model?.upstreamModel ?? ""));
+}
+
 export function usesNativeChatReasoning(model) {
   return (
     model?.requestProfile === "glm-thinking" ||
     model?.requestProfile === "deepseek-thinking" ||
     (model?.provider === "commandcode" &&
-      model?.upstreamModel === "deepseek/deepseek-v4-flash")
+      model?.upstreamModel === "deepseek/deepseek-v4-flash") ||
+    isResellerDeepSeekChatRoute(model)
   );
 }

--- a/src/duplicate-block-collapse.mjs
+++ b/src/duplicate-block-collapse.mjs
@@ -1,0 +1,279 @@
+import { Transform } from "node:stream";
+
+// Collapse a run of identical consecutive blocks inside one assistant message.
+//
+// Observed on routed chat-completions turns: a short pre-tool progress line
+// arrives twice in the streamed text -- as two clean, identically tokenized
+// delta runs -- and the terminal `output_text.done` carries both copies. The
+// capture proves the duplicate is in the wire bytes, so it is not a client
+// rendering artifact and not a lifecycle reorder (every captured stream opens
+// and closes each output item sequentially).
+//
+// The transform is deliberately narrow: it rewrites a message only when its
+// entire text is a run of identical block repeats (`A\n\nA`, `A\n\nA\n\nB\n\nB`).
+// Ordinary prose, which repeats a paragraph for emphasis at most rarely, is
+// relayed byte-for-byte. It is a mitigation for an exact, measured shape, not a
+// claim about the origin of the duplication.
+//
+// Ordering: this runs AFTER ItemLifecycleNormalizer, which guarantees an item is
+// opened, streamed, and closed before the next one. Holding one message item's
+// events is therefore safe. If any event from a different output index arrives
+// while holding -- which the normalizer should have made impossible -- the hold
+// is released verbatim rather than reordered.
+
+// Two separate bounds, because the two things being measured differ by orders
+// of magnitude. The collapse only ever inspects the visible answer text, which
+// is small; the same item also carries the model's reasoning, which is
+// routinely an order of magnitude larger and has nothing to do with the
+// rewrite. Accounting them together made the guard fire on any thinking model
+// that reasoned at length: a captured turn held 138 KB for its message item, of
+// which 113 KB was reasoning, so the transform released the item verbatim and
+// the duplicate survived. The absolute bound still exists, but it is a memory
+// guard rather than the deciding factor for whether a collapse is attempted.
+const MAX_HELD_TEXT_BYTES = 256 * 1024;
+const MAX_HELD_BYTES = 4 * 1024 * 1024;
+// A message item is held until it closes, and a long reasoning pass can easily
+// outlast a short deadline. This bounds a genuinely stuck stream instead.
+const MAX_HELD_MS = 120_000;
+
+// Split on blank-line separators while keeping the separators, so rejoining is
+// byte-exact for text the transform does not change.
+function splitBlocks(text) {
+  const parts = text.split(/(\n{2,})/);
+  const out = [];
+  for (let i = 0; i < parts.length; i += 2) {
+    out.push({ block: parts[i], separator: parts[i + 1] ?? "" });
+  }
+  return out;
+}
+
+export function collapseRepeatedBlocks(text) {
+  if (typeof text !== "string" || !text) return text;
+  const blocks = splitBlocks(text);
+  let previous;
+  let out = "";
+  let dropped = 0;
+  let first = true;
+  // The separator that connects the last surviving block to the next one. When a
+  // duplicate is dropped, its own separator is retained as the connector, so
+  // `A\n\nA\n\nB` keeps one blank line rather than collapsing to `AB`.
+  let pendingSeparator = "";
+  for (const { block, separator } of blocks) {
+    if (!first && block === previous) {
+      dropped += 1;
+      pendingSeparator = separator;
+      continue;
+    }
+    out += first ? block : pendingSeparator + block;
+    previous = block;
+    pendingSeparator = separator;
+    first = false;
+  }
+  return dropped ? out : text;
+}
+
+class DuplicateBlockCollapse extends Transform {
+  #buffer = Buffer.alloc(0);
+  #passthrough = false;
+  #holding;
+  #startedAt = 0;
+
+  _transform(chunk, encoding, callback) {
+    const piece = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+    if (this.#passthrough) {
+      this.push(piece);
+      callback();
+      return;
+    }
+    this.#buffer = this.#buffer.length ? Buffer.concat([this.#buffer, piece]) : piece;
+    this.#drain(false);
+    callback();
+  }
+
+  _flush(callback) {
+    this.#releaseHeld();
+    if (this.#buffer.length) {
+      this.push(this.#buffer);
+      this.#buffer = Buffer.alloc(0);
+    }
+    callback();
+  }
+
+  #disable(original) {
+    this.#releaseHeld();
+    if (original?.length) this.push(Buffer.from(original));
+    if (this.#buffer.length) {
+      this.push(this.#buffer);
+      this.#buffer = Buffer.alloc(0);
+    }
+    this.#passthrough = true;
+  }
+
+  #drain(flush) {
+    while (this.#buffer.length && !this.#passthrough) {
+      const lf = this.#buffer.indexOf("\n\n");
+      const crlf = this.#buffer.indexOf("\r\n\r\n");
+      let end = -1;
+      let sep = "";
+      if (crlf !== -1 && (lf === -1 || crlf <= lf)) {
+        end = crlf;
+        sep = "\r\n\r\n";
+      } else if (lf !== -1) {
+        end = lf;
+        sep = "\n\n";
+      }
+      if (end === -1) {
+        if (!flush) return;
+        const rest = this.#buffer;
+        this.#buffer = Buffer.alloc(0);
+        this.#handle(rest.toString("utf8"), "", rest);
+        return;
+      }
+      const block = this.#buffer.subarray(0, end);
+      const original = this.#buffer.subarray(0, end + sep.length);
+      this.#buffer = this.#buffer.subarray(end + sep.length);
+      this.#handle(block.toString("utf8"), sep, original);
+    }
+  }
+
+  #handle(text, separator, original) {
+    let event;
+    try {
+      const data = [];
+      for (const line of text.split(/\r?\n/)) {
+        if (line.startsWith("data:")) {
+          const v = line.slice(5);
+          data.push(v.startsWith(" ") ? v.slice(1) : v);
+        }
+      }
+      if (!data.length) {
+        this.#emit(original);
+        return;
+      }
+      const dataText = data.join("\n");
+      if (dataText === "[DONE]") {
+        this.#releaseHeld();
+        this.#emit(original);
+        return;
+      }
+      event = JSON.parse(dataText);
+    } catch {
+      // Unparseable framing: relaying it untouched is always the safe answer.
+      this.#emit(original);
+      return;
+    }
+
+    const type = event?.type;
+    const index = Number.isInteger(event?.output_index) ? event.output_index : undefined;
+
+    if (type === "response.output_item.added" && event.item?.type === "message") {
+      this.#releaseHeld();
+      // The opening event belongs to the held item: it is replayed on release
+      // (or carried into the rewrite), so it must be recorded, not swallowed.
+      this.#holding = {
+        index,
+        events: [{ event, original, separator }],
+        bytes: original.length,
+        textBytes: 0,
+      };
+      this.#startedAt = Date.now();
+      return;
+    }
+
+    if (this.#holding) {
+      // A different item's events must never be reordered behind a held item.
+      if (index !== undefined && index !== this.#holding.index) {
+        this.#releaseHeld();
+      } else if (
+        this.#holding.textBytes > MAX_HELD_TEXT_BYTES ||
+        this.#holding.bytes > MAX_HELD_BYTES ||
+        Date.now() - this.#startedAt > MAX_HELD_MS
+      ) {
+        this.#releaseHeld();
+      }
+    }
+
+    if (this.#holding && (index === this.#holding.index || index === undefined)) {
+      this.#holding.events.push({ event, original, separator });
+      this.#holding.bytes += original.length;
+      if (
+        type === "response.output_text.delta" &&
+        typeof event.delta === "string"
+      ) {
+        this.#holding.textBytes += event.delta.length;
+      }
+      if (type === "response.output_item.done") this.#releaseHeld();
+      return;
+    }
+
+    this.#emit(original);
+  }
+
+  #emit(buf) {
+    this.push(Buffer.from(buf));
+  }
+
+  // Rebuild the held item: if its text is a pure block-repeat, emit one corrected
+  // delta plus a corrected done event; otherwise replay the held bytes verbatim.
+  #releaseHeld() {
+    const held = this.#holding;
+    this.#holding = undefined;
+    if (!held) return;
+
+    let text = "";
+    for (const entry of held.events) {
+      if (entry.event.type === "response.output_text.delta" && typeof entry.event.delta === "string") {
+        text += entry.event.delta;
+      }
+    }
+    const collapsed = collapseRepeatedBlocks(text);
+    if (collapsed === text) {
+      for (const entry of held.events) this.#emit(entry.original);
+      return;
+    }
+
+    // Rewrite: keep the item's own open/done framing and drop the delta run,
+    // replacing it with a single delta carrying the collapsed text.
+    const rewritten = [];
+    for (const entry of held.events) {
+      const e = entry.event;
+      if (e.type === "response.output_text.delta") continue;
+      if (e.type === "response.output_text.done") rewritten.push({ ...e, text: collapsed });
+      else if (e.type === "response.output_item.done" && e.item?.content) {
+        rewritten.push({
+          ...e,
+          item: {
+            ...e.item,
+            content: e.item.content.map((part) =>
+              part?.type === "output_text" ? { ...part, text: collapsed } : part,
+            ),
+          },
+        });
+      } else rewritten.push(e);
+    }
+
+    let inserted = false;
+    for (const e of rewritten) {
+      if (e.type === "response.output_text.done" && !inserted) {
+        const delta = {
+          type: "response.output_text.delta",
+          output_index: e.output_index,
+          item_id: e.item_id,
+          content_index: e.content_index,
+          delta: collapsed,
+        };
+        for (const key of Object.keys(delta)) {
+          if (delta[key] === undefined) delete delta[key];
+        }
+        this.#emit(`data: ${JSON.stringify(delta)}\n\n`);
+        inserted = true;
+      }
+      this.#emit(`data: ${JSON.stringify(e)}\n\n`);
+    }
+  }
+}
+
+export function duplicateBlockCollapseTransform(contentType = "") {
+  if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
+  return new DuplicateBlockCollapse();
+}

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -57,6 +57,7 @@ import {
   isEmptyCompletionPreludeLimitError,
 } from "./empty-completion-guard.mjs";
 import { itemLifecycleNormalizerTransform } from "./item-lifecycle-normalizer.mjs";
+import { duplicateBlockCollapseTransform } from "./duplicate-block-collapse.mjs";
 import { reasoningTagStripperTransform } from "./reasoning-tag-stripper.mjs";
 import {
   ZaiResponsesCompatTransform,
@@ -4400,6 +4401,14 @@ async function handleResponses(request, response, requestUrl) {
       // always wins. Native streams already carry the label and gain no stage.
       const messagePhase = route ? messagePhaseTransform(contentType) : undefined;
       if (messagePhase) transforms.push(messagePhase);
+      // Runs after the normalizer, which guarantees each item is opened,
+      // streamed, and closed before the next begins -- so holding one message
+      // item's events cannot reorder anything. Collapses a message whose whole
+      // text is a run of identical block repeats, the measured duplicate shape.
+      const blockCollapse = route
+        ? duplicateBlockCollapseTransform(contentType)
+        : undefined;
+      if (blockCollapse) transforms.push(blockCollapse);
       // Last, so no router stage ever parses a heartbeat: while a Grok stream is
       // silent, keep the client's idle timer from abandoning a live turn.
       if (

--- a/test/chat-reasoning.test.mjs
+++ b/test/chat-reasoning.test.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 
 import { usesNativeChatReasoning } from "../src/chat-reasoning.mjs";
 import { childOutput, waitForListeners } from "./listener-readiness.mjs";
+import { MODEL_BY_SLUG } from "../src/model-registry.mjs";
 
 test("native chat reasoning stays scoped to established history contracts", () => {
   assert.equal(usesNativeChatReasoning({ requestProfile: "glm-thinking" }), true);
@@ -16,15 +17,56 @@ test("native chat reasoning stays scoped to established history contracts", () =
   assert.equal(usesNativeChatReasoning({
     provider: "commandcode", upstreamModel: "deepseek/deepseek-v4-flash",
   }), true);
+  // OpenCode Go reaches its DeepSeek, GLM, and Qwen thinking models over Chat
+  // Completions with reseller-shaped profiles. Its DeepSeek routes keep the
+  // vendor replay rule, which the profile checks alone cannot see: the measured
+  // `opencode-go/deepseek-v4.1-flash` carries `auto-tool-choice`, so the carry
+  // never ran and the provider rejected the following turn.
+  for (const model of [
+    { provider: "opencode-go", upstreamModel: "deepseek-v4.1-flash", requestProfile: "auto-tool-choice" },
+    { provider: "opencode-go", upstreamModel: "deepseek-v4-flash" },
+    { provider: "opencode-go", upstreamModel: "deepseek/deepseek-v4-pro" },
+  ]) {
+    assert.equal(usesNativeChatReasoning(model), true);
+  }
   for (const model of [
     undefined,
     { provider: "deepseek", requestProfile: "deepseek-nonthinking" },
-    { provider: "opencode-go", upstreamModel: "deepseek-v4-flash" },
     { provider: "custom", upstreamModel: "deepseek/deepseek-v4-flash" },
     { provider: "commandcode", upstreamModel: "moonshotai/kimi-k2.6" },
     { provider: "commandcode-messages", upstreamModel: "deepseek/deepseek-v4-flash" },
+    // Other OpenCode Go thinking models keep their existing replay channel:
+    // only the DeepSeek upstream's requirement is established.
+    { provider: "opencode-go", upstreamModel: "glm-5.3", requestProfile: "ox-alpha" },
+    { provider: "opencode-go", upstreamModel: "kimi-k3", requestProfile: "kimi-k3" },
+    // Anthropic-protocol variant: reasoning travels as thinking blocks, so the
+    // `reasoning_content` restore must not be applied.
+    { provider: "opencode-go-messages", requestProfile: "auto-tool-choice" },
   ]) {
     assert.equal(usesNativeChatReasoning(model), false);
+  }
+});
+
+// The contract is per-upstream, not per-profile: the shipped OpenCode Go
+// DeepSeek route carries `auto-tool-choice`, which no profile check in this
+// module matches. Reading the registry keeps the assertion tied to the real
+// configuration instead of hand-built objects that could drift away from it.
+test("every shipped OpenCode Go DeepSeek route replays its reasoning", () => {
+  const deepseekRoutes = [...MODEL_BY_SLUG.values()].filter(
+    (model) => model.provider === "opencode-go" && /deepseek/i.test(model.upstreamModel ?? ""),
+  );
+  assert.ok(deepseekRoutes.length > 0, "expected shipped OpenCode Go DeepSeek routes");
+  for (const route of deepseekRoutes) {
+    assert.equal(usesNativeChatReasoning(route), true, route.slug);
+  }
+
+  // Everything else on that endpoint keeps its existing replay channel, and the
+  // Anthropic-protocol variant is a different wire contract entirely, so a slug
+  // that merely sits next to the Chat routes must not be swept in.
+  for (const [slug, model] of MODEL_BY_SLUG) {
+    if (model.provider !== "opencode-go" && model.provider !== "opencode-go-messages") continue;
+    if (model.provider === "opencode-go" && /deepseek/i.test(model.upstreamModel ?? "")) continue;
+    assert.equal(usesNativeChatReasoning(model), false, slug);
   }
 });
 

--- a/test/duplicate-block-collapse.test.mjs
+++ b/test/duplicate-block-collapse.test.mjs
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import test from "node:test";
+
+import {
+  collapseRepeatedBlocks,
+  duplicateBlockCollapseTransform,
+} from "../src/duplicate-block-collapse.mjs";
+
+function block(event) {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+function eventsFrom(body) {
+  const out = [];
+  for (const chunk of body.split(/\n\n/)) {
+    const data = chunk
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .join("\n");
+    if (!data || data === "[DONE]") continue;
+    try {
+      out.push(JSON.parse(data));
+    } catch {
+      /* ignore */
+    }
+  }
+  return out;
+}
+
+async function normalize(body, { chunkSize } = {}) {
+  const transform = duplicateBlockCollapseTransform("text/event-stream; charset=utf-8");
+  const chunks = [];
+  const source =
+    chunkSize === undefined
+      ? [Buffer.from(body)]
+      : (() => {
+          const raw = Buffer.from(body);
+          const parts = [];
+          for (let i = 0; i < raw.length; i += chunkSize) {
+            parts.push(raw.subarray(i, i + chunkSize));
+          }
+          return parts;
+        })();
+  for await (const chunk of Readable.from(source).pipe(transform)) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+// The exact captured shape: a short line, then the same line again.
+const DUPLICATED = [
+  block({ type: "response.created", response: { id: "r1" } }),
+  block({
+    type: "response.output_item.added",
+    output_index: 0,
+    item: { id: "m1", type: "message", role: "assistant", content: [] },
+  }),
+  block({
+    type: "response.content_part.added",
+    output_index: 0,
+    item_id: "m1",
+    part: { type: "output_text", text: "" },
+  }),
+  block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "checking the second one now." }),
+  block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "\n\n" }),
+  block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "checking the second one now." }),
+  block({
+    type: "response.output_text.done",
+    output_index: 0,
+    item_id: "m1",
+    text: "checking the second one now.\n\nchecking the second one now.",
+  }),
+  block({ type: "response.content_part.done", output_index: 0, item_id: "m1" }),
+  block({
+    type: "response.output_item.done",
+    output_index: 0,
+    item: {
+      id: "m1",
+      type: "message",
+      role: "assistant",
+      content: [{ type: "output_text", text: "checking the second one now.\n\nchecking the second one now." }],
+    },
+  }),
+  block({ type: "response.completed", response: { id: "r1", output: [] } }),
+  "data: [DONE]\n\n",
+].join("");
+
+test("collapseRepeatedBlocks collapses only runs of identical adjacent blocks", () => {
+  assert.equal(collapseRepeatedBlocks("A\n\nA"), "A");
+  assert.equal(collapseRepeatedBlocks("A\n\nA\n\nB\n\nB"), "A\n\nB");
+  assert.equal(collapseRepeatedBlocks("A\n\nB"), "A\n\nB");
+  assert.equal(collapseRepeatedBlocks("A\n\nA\n\nB"), "A\n\nB");
+  // Distinct blocks that merely resemble each other are untouched.
+  assert.equal(collapseRepeatedBlocks("A\n\nA!"), "A\n\nA!");
+  assert.equal(collapseRepeatedBlocks(""), "");
+});
+
+test("a duplicated message is collapsed in the streamed output", async () => {
+  const out = await normalize(DUPLICATED);
+  const events = eventsFrom(out);
+
+  const deltas = events.filter((e) => e.type === "response.output_text.delta");
+  const streamed = deltas.map((e) => e.delta).join("");
+  assert.equal(streamed, "checking the second one now.");
+
+  const done = events.find((e) => e.type === "response.output_text.done");
+  assert.equal(done.text, "checking the second one now.");
+
+  const itemDone = events.find(
+    (e) => e.type === "response.output_item.done" && e.item?.type === "message",
+  );
+  assert.equal(itemDone.item.content[0].text, "checking the second one now.");
+
+  // The duplicate must not survive anywhere in the emitted bytes.
+  assert.equal(out.split("checking the second one now.").length - 1, 3, "one per carrier");
+});
+
+test("collapsing is independent of upstream chunk boundaries", async () => {
+  for (const chunkSize of [1, 3, 17, 64, 4096]) {
+    const out = await normalize(DUPLICATED, { chunkSize });
+    const streamed = eventsFrom(out)
+      .filter((e) => e.type === "response.output_text.delta")
+      .map((e) => e.delta)
+      .join("");
+    assert.equal(streamed, "checking the second one now.", `chunkSize=${chunkSize}`);
+  }
+});
+
+test("a normal message passes through byte-for-byte", async () => {
+  const clean = [
+    block({ type: "response.created", response: { id: "r1" } }),
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { id: "m1", type: "message", role: "assistant", content: [] },
+    }),
+    block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "Hello " }),
+    block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "world." }),
+    block({
+      type: "response.output_text.done",
+      output_index: 0,
+      item_id: "m1",
+      text: "Hello world.",
+    }),
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        id: "m1",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Hello world." }],
+      },
+    }),
+    block({ type: "response.completed", response: { id: "r1", output: [] } }),
+    "data: [DONE]\n\n",
+  ].join("");
+
+  const out = await normalize(clean);
+  assert.equal(out, clean);
+});
+
+test("a tool-only turn with no message text passes through unchanged", async () => {
+  const toolOnly = [
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { id: "f1", type: "function_call", name: "probe", arguments: "" },
+    }),
+    block({ type: "response.function_call_arguments.delta", output_index: 0, item_id: "f1", delta: "{}" }),
+    block({ type: "response.output_item.done", output_index: 0, item: { id: "f1", type: "function_call" } }),
+    block({ type: "response.completed", response: { id: "r1", output: [] } }),
+    "data: [DONE]\n\n",
+  ].join("");
+
+  const out = await normalize(toolOnly);
+  assert.equal(out, toolOnly);
+});
+
+test("a non-streaming content type is not wrapped", () => {
+  assert.equal(duplicateBlockCollapseTransform("application/json"), undefined);
+});
+
+// The shape that shipped broken. A thinking model emits a large reasoning pass
+// into the same output item as the visible answer -- a captured turn held
+// 138 KB for one message item, 113 KB of it reasoning. When the held-byte guard
+// counted that reasoning against the same budget as the answer text, it tripped
+// and the item was replayed verbatim, so the duplicate survived on thinking
+// routes exactly where it mattered. The guard must weigh the answer text, not
+// the reasoning, while still bounding total memory.
+test("a large reasoning preamble does not defeat the collapse", async () => {
+  const REASONING_CHUNKS = 1200;
+  const chunk = "considering the next step carefully and weighing options ";
+  const reasoning = [];
+  for (let i = 0; i < REASONING_CHUNKS; i += 1) {
+    reasoning.push(
+      block({
+        type: "response.reasoning_summary_text.delta",
+        output_index: 0,
+        item_id: "m1",
+        delta: chunk,
+      }),
+    );
+  }
+
+  const body = [
+    block({ type: "response.created", response: { id: "r1" } }),
+    block({
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { id: "m1", type: "message", role: "assistant", content: [] },
+    }),
+    block({
+      type: "response.content_part.added",
+      output_index: 0,
+      item_id: "m1",
+      part: { type: "output_text", text: "" },
+    }),
+    ...reasoning,
+    block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "checking the second one now." }),
+    block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "\n\n" }),
+    block({ type: "response.output_text.delta", output_index: 0, item_id: "m1", delta: "checking the second one now." }),
+    block({
+      type: "response.output_text.done",
+      output_index: 0,
+      item_id: "m1",
+      text: "checking the second one now.\n\nchecking the second one now.",
+    }),
+    block({ type: "response.content_part.done", output_index: 0, item_id: "m1" }),
+    block({
+      type: "response.output_item.done",
+      output_index: 0,
+      item: {
+        id: "m1",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "checking the second one now.\n\nchecking the second one now." }],
+      },
+    }),
+    block({ type: "response.completed", response: { id: "r1", output: [] } }),
+    "data: [DONE]\n\n",
+  ].join("");
+
+  // Guard the premise: this fixture must actually exceed the old 64 KiB bound,
+  // otherwise it would pass even with the defect present.
+  const reasoningBytes = REASONING_CHUNKS * chunk.length;
+  assert.ok(reasoningBytes > 64 * 1024, `fixture must exceed the old cap (${reasoningBytes})`);
+
+  const out = await normalize(body);
+  const streamed = eventsFrom(out)
+    .filter((e) => e.type === "response.output_text.delta")
+    .map((e) => e.delta)
+    .join("");
+  assert.equal(streamed, "checking the second one now.");
+
+  // Reasoning must still reach the client untouched.
+  const reasoningOut = eventsFrom(out).filter((e) =>
+    String(e.type).includes("reasoning"),
+  );
+  assert.equal(reasoningOut.length, REASONING_CHUNKS);
+});


### PR DESCRIPTION
This branch carries two independent fixes that came out of the same debugging
session. They are unrelated, so if you would rather review them separately, say
so and I will split the second into its own PR -- the collapse commit
(`f43990c`) stands alone.

---

## 1. `fix: replay Chat reasoning for DeepSeek reached through a reseller`

### What breaks

`usesNativeChatReasoning` gates both halves of the Chat reasoning replay: the
carry in `carryReasoningThroughInput` (`src/router.mjs`) and the restore in
`restoreNativeReasoningContent` (`src/api-forwarder.mjs`). It matched on the
vendor request profiles (`glm-thinking`, `deepseek-thinking`) plus a single
Command Code slug. A DeepSeek route reached through a reseller carries a
reseller-shaped profile instead, matched none of those, and so ran neither hop.

The measured case is `opencode-go/deepseek-v4.1-flash`, whose profile is
`auto-tool-choice`. DeepSeek rejects a follow-up whose prior assistant turn is
missing its `reasoning_content`:

```
HTTP 400  The `reasoning_content` in the thinking mode must be passed back to the API.
```

The rejection needs a prior assistant turn, so it lands on the turn *after* a
reply rather than on the reply itself. That makes it read as a poisoned
conversation -- every subsequent request fails -- while the turn that produced
the offending assistant message looked completely healthy.

A subagent hand-off always ends in prose, so spawning one was enough to start
it. From the local usage meter, on `opencode-go/deepseek-v4.1-flash`, with 200s
either side:

```
{"status":200, ... "requestId":"...:45"}
{"status":400, ... "requestId":"...:46"}
{"status":200, ... "requestId":"...:47"}
```

and the gateway log for those same rows names the route and the reason:

```
16:17:16 - LiteLLM Proxy:ERROR - litellm.BadRequestError: OpenAIException -
Error from provider (Console Go): Upstream request failed: [invalid_request_error]
The `reasoning_content` in the thinking mode must be passed back to the API.
Received Model Group=opencode-go-deepseek-v4-1-flash
```

repeated at 16:17:41, which is the second 400 row. The rejection is the
provider's; the profile mismatch is what leaves the router unable to satisfy it.

### The fix

Key the check on the upstream model for reseller Chat routes, because the replay
rule belongs to the upstream and not to the route's profile or its reseller:

```js
const RESELLER_DEEPSEEK_CHAT_PROVIDERS = new Set(["opencode-go"]);

function isResellerDeepSeekChatRoute(model) {
  if (!RESELLER_DEEPSEEK_CHAT_PROVIDERS.has(model?.provider)) return false;
  return /(^|\/)deepseek/i.test(String(model?.upstreamModel ?? ""));
}
```

The existing profile checks and the Command Code clause are unchanged, so no
currently-covered route changes behaviour.

### Why it is scoped to DeepSeek

`opencode-go` exposes 21 reasoning-capable Chat routes: DeepSeek, GLM, Qwen,
Kimi, MiniMax, Longcat and MiMo. A provider-wide rule would move the replay
channel for all of them from visible assistant text to `reasoning_content`, and
only the DeepSeek requirement is established here. Routes that neither need nor
expect that field would lose the reasoning they currently receive as text, which
is a silent behaviour change on models this issue was never reported against, so
the fix is deliberately narrow.

**Open question for maintainers:** GLM on the same endpoint (`glm-5.3`,
`glm-5.3-flash`) reaches z.ai, whose direct routes are already covered through
`glm-thinking`. If the reseller routes share that upstream's requirement, they
belong in the same set. I did not add them without a reproduction -- if that
evidence exists or is easy to gather, the predicate is the place to extend.
`opencode-go-messages` is excluded in any case: it speaks the Anthropic
protocol, where reasoning travels as thinking blocks, so the
`reasoning_content` restore does not apply.

---

## 2. `fix: collapse a doubled assistant block at egress`

### What breaks

On routed Chat routes the bridge can emit a turn's answer text twice inside a
single assistant `message` item -- the same token run and then the same run
again, with `output_text.done` carrying both copies. On a real session it
affected roughly one message in five, and the affected messages were
consistently the short progress lines a model writes immediately before a tool
call.

The duplicate is in the wire bytes. Instrumenting the egress on both sides of
the router's transforms shows the pre-transform stream already containing it,
so it is not a client rendering artifact and not an item-lifecycle reorder;
every captured stream opened and closed each output item sequentially.

Honest scoping: the **origin is not established**. Only the shape is. This
removes a measured duplicate at the wire rather than explaining why the upstream
repeats it.

### The fix

A new egress transform, `src/duplicate-block-collapse.mjs`, rewrites a message
whose entire text is a run of identical blank-line-separated blocks:

```
A\n\nA            ->  A
A\n\nA\n\nB\n\nB  ->  A\n\nB
```

Everything else is relayed byte-for-byte. It runs after
`ItemLifecycleNormalizer`, which guarantees the item being held is opened,
streamed, and closed before the next one begins, so holding an item cannot
reorder the stream. A different output index arriving mid-hold releases
everything verbatim instead.

### The bug in the first version of this fix, and why it is worth reading

The first version bounded the held item at 64 KB of total bytes. That was wrong,
and it failed in the field while passing every synthetic test. An output item
also carries the model's **reasoning**, which on a thinking route dwarfs the
answer. A captured turn held 138 KB for one message item, of which 113 KB was
reasoning against a ~300-byte answer:

```
held bytes for the message item: 138030
  of which reasoning:            113578
  MAX_HELD_BYTES:                 65536   <- tripped
```

The guard tripped mid-item, released it verbatim, and the duplicate survived in
exactly the place it was most common. The bound now weighs the visible answer
text separately from total memory, and the regression test asserts its fixture
exceeds the old budget so it fails against the defect rather than merely
passing alongside the fix.

---

## Testing

- `node --test test/chat-reasoning.test.mjs` -- 2 pass, 1 skipped (the optional
  LiteLLM proof, which needs `MODEL_ROUTER_TEST_LITELLM_PYTHON`).
- `node --test test/duplicate-block-collapse.test.mjs` -- 7 pass, including a
  chunk-boundary sweep (1/3/17/64/4096 bytes) and the reasoning-volume
  regression above.
- Focused set across `duplicate-block-collapse`, `item-lifecycle-normalizer`,
  `chat-reasoning`, `routing`, `deepseek-v4-1-flash` and `subagent-routing`:
  **163 tests, 162 pass, 1 skipped, 0 fail**.
- `npm run check` clean.

Both fixes were additionally reproduced against captured live traffic before
and after their respective transforms, rather than only through fixtures.

I did not run the optional offline LiteLLM replay proof locally.

## Docs

`AGENTS.md` gains the reseller reasoning rule and a section on the egress
duplicate collapse, including the text-versus-total bound and the requirement
to capture on both sides of the transform. `CHANGELOG.md` has Unreleased entries
for both.
