### PR TITLE
test: wait for the API forwarder before direct DeepSeek turns

### DIFF
--- a/test/chat-reasoning.test.mjs
+++ b/test/chat-reasoning.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { usesNativeChatReasoning } from "../src/chat-reasoning.mjs";
+import { childOutput, waitForListeners } from "./listener-readiness.mjs";
 
 test("native chat reasoning stays scoped to established history contracts", () => {
   assert.equal(usesNativeChatReasoning({ requestProfile: "glm-thinking" }), true);
@@ -164,22 +165,22 @@ asyncio.run(main())
       ZAI_CODING_BASE_URL: `http://127.0.0.1:${upstream.address().port}/v1`, ZAI_API_KEY: "TEST_ZAI_KEY",
       COMMANDCODE_BASE_URL: `http://127.0.0.1:${upstream.address().port}/v1`, COMMAND_CODE_API_KEY: "TEST_COMMANDCODE_KEY",
     };
-    for (const script of ["api-forwarder.mjs", "router.mjs"]) {
-      const child = spawn(process.execPath, [path.join(root, "src", script)], { cwd: root, env, stdio: "ignore" });
-      children.push(child);
-    }
+    const output = childOutput();
+    const services = ["api-forwarder.mjs", "router.mjs"].map((script) => output.capture(script,
+      spawn(process.execPath, [path.join(root, "src", script)], { cwd: root, env, stdio: ["ignore", "ignore", "pipe"] })));
+    children.push(...services);
     const base = `http://127.0.0.1:${routerPort}/_codex-router/${caller}/v1`;
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try { if ((await fetch(`${base}/models`)).ok) break; } catch { /* starting */ }
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
+    await waitForListeners([
+      { name: "api-forwarder /health", url: `http://127.0.0.1:${forwarderPort}/health`, headers: { Authorization: `Bearer ${internal}` } },
+      { name: "router /models", url: `${base}/models` },
+    ], { children: services, output });
     for (const model of ["zai-coding/glm-5.3", "deepseek/deepseek-v4-flash", "commandcode/deepseek-v4-flash"]) {
       for (negativeControl of [false, true]) {
         const response = await fetch(`${base}/responses`, {
           method: "POST", headers: { "Content-Type": "application/json" }, signal: AbortSignal.timeout(30000),
           body: JSON.stringify({ model, input, stream: false, tools: [{ type: "function", name: "probe", parameters: { type: "object", properties: {} } }] }),
         });
-        assert.equal(response.status, 200, await response.text());
+        assert.equal(response.status, 200, `${await response.text()}\n${output}`);
         if (negativeControl) assert.throws(() => assertHistory(requests.at(-1).messages), /must occur exactly once/);
         else assertHistory(requests.at(-1).messages);
         t.diagnostic(JSON.stringify({ model, litellm: version, negativeControl, status: "passed" }));

--- a/test/deepseek-responses-routing.test.mjs
+++ b/test/deepseek-responses-routing.test.mjs
@@ -8,6 +8,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import { callerBaseUrl } from "../src/caller-auth.mjs";
+import { childOutput, waitForListeners } from "./listener-readiness.mjs";
 import { openPort } from "./port-pool.mjs";
 
 import {
@@ -249,10 +250,11 @@ test("direct DeepSeek Responses preserves images, reasoning, tools and stream bo
     DEEPSEEK_API_BASE_URL: `http://127.0.0.1:${upstream.address().port}`,
     DEEPSEEK_API_KEY: "TEST_DEEPSEEK_API_KEY",
   };
-  const children = ["api-forwarder.mjs", "router.mjs"].map((script) => {
-    const child = spawn(process.execPath, [path.join(root, "src", script)], { cwd: root, env, stdio: ["ignore", "ignore", "pipe"] });
-    child.stderr.resume(); return child;
-  });
+  // The router names a failed upstream connection only on stderr, so a
+  // discarded stream turned a CI failure into a bare "502 !== 200".
+  const output = childOutput();
+  const children = ["api-forwarder.mjs", "router.mjs"].map((script) => output.capture(script,
+    spawn(process.execPath, [path.join(root, "src", script)], { cwd: root, env, stdio: ["ignore", "ignore", "pipe"] })));
   const base = callerBaseUrl(routerPort, CALLER_KEY);
   const send = (input, options = {}) => fetch(`${base}/responses`, {
     method: "POST", headers: { "Content-Type": "application/json", "x-openai-subagent": "fixture" },
@@ -264,14 +266,14 @@ test("direct DeepSeek Responses preserves images, reasoning, tools and stream bo
     });
     assert.equal(rejectedString.status, 400, "the provider fixture must reject the shape rejected by the live API");
     await rejectedString.text();
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      try { if ((await fetch(`${base}/models`)).ok) break; } catch { /* starting */ }
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
+    await waitForListeners([
+      { name: "api-forwarder /health", url: `http://127.0.0.1:${forwarderPort}/health`, headers: { Authorization: `Bearer ${INTERNAL_KEY}` } },
+      { name: "router /models", url: `${base}/models` },
+    ], { children, output });
     for (const imagePart of [undefined, { type: "input_image", image_url: IMAGE, detail: "original" }, { type: "input_image", file_id: "file-api-fixture" }]) {
       const input = [{ type: "message", role: "user", content: [{ type: "input_text", text: "Inspect the synthetic pixel." }, ...(imagePart ? [imagePart] : [])] }];
       const result = await send(input);
-      assert.equal(result.status, 200);
+      assert.equal(result.status, 200, String(output));
       assertTranscript(parseEvents(await result.text()));
       assert.deepEqual(requests.at(-1).body.input, input);
       assert.equal(requests.at(-1).path, "/responses");

--- a/test/listener-readiness.mjs
+++ b/test/listener-readiness.mjs
@@ -30,9 +30,11 @@ export async function waitForListeners(targets, { children, output, timeoutMs = 
   const deadline = Date.now() + timeoutMs;
   const pending = new Map(targets.map((target) => [target.url, target]));
   while (pending.size > 0) {
-    const exited = children.find((child) => child.exitCode !== null);
+    // A child killed by a signal reports exitCode null and signalCode set.
+    const exited = children.find((child) => child.exitCode !== null || child.signalCode !== null);
     if (exited) {
-      throw new Error(`A router child exited before it was ready (${exited.exitCode}):\n${output}`);
+      const status = exited.exitCode ?? exited.signalCode;
+      throw new Error(`A router child exited before it was ready (${status}):\n${output}`);
     }
     if (Date.now() > deadline) {
       const names = [...pending.values()].map((target) => target.name).join(", ");
@@ -40,7 +42,13 @@ export async function waitForListeners(targets, { children, output, timeoutMs = 
     }
     for (const target of [...pending.values()]) {
       try {
-        const response = await fetch(target.url, { headers: target.headers });
+        // Bound each poll so a listener that accepts but never answers cannot
+        // hold the loop past its deadline.
+        const remaining = Math.max(1, Math.min(2_000, deadline - Date.now()));
+        const response = await fetch(target.url, {
+          headers: target.headers,
+          signal: AbortSignal.timeout(remaining),
+        });
         await response.arrayBuffer();
         if (response.ok) pending.delete(target.url);
       } catch {

--- a/test/listener-readiness.mjs
+++ b/test/listener-readiness.mjs
@@ -1,0 +1,52 @@
+// Readiness for tests that spawn the router beside the API forwarder it
+// proxies through. Nothing orders those processes' startup, so the router can
+// already serve /models while the forwarder has not bound its port. A test that
+// polled only the router could send its first turn to that closed port and get
+// back the router's own opaque 502, and a bounded loop that ran out of attempts
+// started the turn anyway. Wait for every listener, and fail with the
+// children's output instead of proceeding.
+
+const STDERR_TAIL = 8_000;
+
+/** Keeps a bounded stderr tail per child; interpolates as a labelled report. */
+export function childOutput() {
+  const tails = new Map();
+  return {
+    capture(label, child) {
+      tails.set(label, "");
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk) => {
+        tails.set(label, `${tails.get(label)}${chunk}`.slice(-STDERR_TAIL));
+      });
+      return child;
+    },
+    toString() {
+      return [...tails].map(([label, text]) => `[${label}]\n${text}`).join("\n");
+    },
+  };
+}
+
+export async function waitForListeners(targets, { children, output, timeoutMs = 15_000 }) {
+  const deadline = Date.now() + timeoutMs;
+  const pending = new Map(targets.map((target) => [target.url, target]));
+  while (pending.size > 0) {
+    const exited = children.find((child) => child.exitCode !== null);
+    if (exited) {
+      throw new Error(`A router child exited before it was ready (${exited.exitCode}):\n${output}`);
+    }
+    if (Date.now() > deadline) {
+      const names = [...pending.values()].map((target) => target.name).join(", ");
+      throw new Error(`Timed out waiting for ${names}:\n${output}`);
+    }
+    for (const target of [...pending.values()]) {
+      try {
+        const response = await fetch(target.url, { headers: target.headers });
+        await response.arrayBuffer();
+        if (response.ok) pending.delete(target.url);
+      } catch {
+        // Not listening yet.
+      }
+    }
+    if (pending.size > 0) await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}


### PR DESCRIPTION
## Problem

`direct DeepSeek Responses preserves images, reasoning, tools and stream boundaries` failed on #698's `test (ubuntu-latest)` job ([run 34584701210](https://github.com/duolahypercho/codex-router/actions/runs/34584701210/job/103216099608)) with `502 !== 200` at the first image-part turn, then passed on rerun. `main` was green on the same base, and #698 only touched `src/codex-account-usage.mjs`, which neither the router nor the forwarder imports.

The test spawns `src/api-forwarder.mjs` and `src/router.mjs` together, but its readiness loop polled only the router's `/models`. Direct DeepSeek turns go through the forwarder. Nothing orders the two processes' startup, and the loop started the turn even if it ran out of attempts. The children's stderr, the only place the router names a failed upstream connection, was `resume()`d and discarded, so the CI failure cannot be diagnosed after the fact.

## What is and isn't proven

- **Proven:** with the router running and no forwarder listening, the old readiness loop passes and the test fails at exactly that assertion. The router returns `502 local_router_error` (`connect ECONNREFUSED` on its stderr).
- **Not proven:** that this race is what failed on Ubuntu. That run's stderr was discarded. Local repeat runs on macOS were no help: every failure there was `connect EADDRNOTAVAIL` on the router→forwarder hop, from this machine's VPN client exhausting ephemeral ports while other test suites ran, not a startup race.

So this PR removes the one ordering hole the test had and makes the next failure self-explaining. If it recurs, the assertion message will now carry both children's stderr.

## Change

- `test/listener-readiness.mjs` (new):
  - `childOutput()` keeps a bounded stderr tail per child.
  - `waitForListeners()` polls every listener until it answers `ok`. It throws with that output if a child exits or 15 s pass, rather than proceeding.
- `test/deepseek-responses-routing.test.mjs`: waits for the forwarder's authenticated `/health` as well as the router's `/models`, and attaches child stderr to the first status assertion.
- `test/chat-reasoning.test.mjs`: the optional pinned-LiteLLM proof spawned the same pair with the same router-only wait. It uses the helper too, and its status assertion now includes child stderr.

Test-only; no CHANGELOG entry (matches #700).

## Verification

- **Negative control:** the fixed DeepSeek test with the forwarder never started now fails with `Timed out waiting for api-forwarder /health`, not a 502.
- `node --test test/deepseek-responses-routing.test.mjs`, final code:
  - 9 clean passes (7/7 tests each).
  - All other local failures were `EADDRNOTAVAIL` from port exhaustion, confirmed by the newly captured stderr.
  - A clean 30× local loop was not achievable on this machine.
- `MODEL_ROUTER_TEST_LITELLM_PYTHON=<venv with litellm 1.96.0> node --test test/chat-reasoning.test.mjs`: 2/2 passes, 0 skipped.
- `npm run check`: syntax checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
