### PR TITLE
fix: relay LiteLLM custom-tool arguments that skip the content wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -725,6 +725,16 @@ and every client saw a bare "Connection error" naming nothing.
    contract. Keep the streamed-input fingerprint check and fail closed when the
    delta, terminal arguments, or output-item close disagree. The focused
    namespace-relay test and Z.ai router fixture hold both sides of this boundary.
+   The wrapper is a request, not a guarantee: models put `content` after another
+   key, answer `{ "input": ... }` or `{}`, or send raw patch text, and LiteLLM
+   relays those rather than rejecting them. For a native custom call the relay
+   therefore derives the input exactly as LiteLLM's
+   `unwrap_custom_tool_arguments` does -- a string `content` from a JSON
+   object, otherwise the arguments verbatim -- and never a stricter reading;
+   rejecting a shape LiteLLM accepted aborts a committed stream and Codex
+   retries the identical turn until it fails. A present non-string `content`
+   stays unsupported, and the delta check is skipped only when the decoder
+   emitted no input text for the client to contradict.
 11. **Do not answer a gateway crash by moving the litellm pin.** The pin is a
    security floor and a wheel-availability decision (see the lock section
    above), any change to it has to be proven by booting the proxy rather than by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **`apply_patch` calls no longer abort routed turns mid-stream when a model
+  skips LiteLLM's wrapper.** LiteLLM sends native custom tools such as
+  `apply_patch` to Chat Completions providers as a function with one `content`
+  string, and relays whatever arguments come back. Models do not always comply:
+  they put `content` after another key, answer `{"input": ...}` or `{}`, or send
+  the raw patch. The router accepted only a leading `{"content": "..."}` and
+  aborted the already-streaming response, and Codex retried the identical turn
+  until it failed ("stream closed before response.completed"). The router log
+  showed "invalid custom tool arguments done" or "incomplete custom tool
+  argument delta sequence" on DeepSeek V4.1 Flash, DeepSeek V4 Flash, GLM-5.3,
+  and Grok 4.5. The relay now derives the input exactly as LiteLLM does, so
+  Codex receives the same call LiteLLM produced and a malformed patch comes
+  back to the model as an ordinary tool error. A non-string `content`, a
+  completed item that disagrees, and streamed text contradicted by the final
+  input still fail closed. Reproduced offline against pinned LiteLLM 1.96.0.
 - **Switching a conversation back to OpenAI no longer fails on routed item IDs.**
   Routed providers mint their own item IDs (`call_...`, `tool_...`,
   `chatcmpl-...`), Codex saves them, and OpenAI rejects them on replay with

--- a/src/namespace-relay.mjs
+++ b/src/namespace-relay.mjs
@@ -2117,6 +2117,31 @@ function customToolInput(
   }
 }
 
+// LiteLLM decides a native custom call's input itself: it unwraps a string
+// `content` from a JSON object and otherwise keeps the provider's arguments
+// verbatim (`unwrap_custom_tool_arguments` in its custom_tools module). Its
+// completed item carries that decision, so the relay must derive the same
+// input rather than a stricter one. A present non-string `content` has no
+// faithful equivalent of Python's str() and stays unsupported.
+const LITELLM_MAX_CUSTOM_ARGUMENTS_LENGTH = 1_000_000;
+
+function litellmCustomToolInput(argumentsText) {
+  if (typeof argumentsText !== "string") return undefined;
+  if (argumentsText === "") return "";
+  if (argumentsText.length > LITELLM_MAX_CUSTOM_ARGUMENTS_LENGTH) return argumentsText;
+  let parsed;
+  try {
+    parsed = JSON.parse(argumentsText);
+  } catch {
+    return argumentsText;
+  }
+  if (!plainObject(parsed) || !Object.hasOwn(parsed, LITELLM_CUSTOM_TOOL_INPUT_PROPERTY)) {
+    return argumentsText;
+  }
+  const content = parsed[LITELLM_CUSTOM_TOOL_INPUT_PROPERTY];
+  return typeof content === "string" ? content : undefined;
+}
+
 function rewriteCustomToolFunctionCallItem(item, lookups, allowPlaceholder) {
   if (
     item?.type !== "function_call" ||
@@ -3348,6 +3373,10 @@ export class NamespaceToolCallTransform extends Transform {
   #customDeltaMismatch(state, inputFingerprint) {
     if (state.codec) return undefined; // Source JSON is checked separately; no patch delta was emitted.
     if (!state.sawArgumentDelta) return undefined;
+    // LiteLLM keeps arguments that are not a leading `content` wrapper verbatim,
+    // so the incremental decoder cannot follow them. When it emitted no input
+    // text, the client saw nothing the completed input could contradict.
+    if (state.sourceType === "custom_tool_call" && state.deltaCharacters === 0) return undefined;
     if (
       state.deltaState.invalid ||
       !state.deltaState.opened ||
@@ -3640,7 +3669,15 @@ export class NamespaceToolCallTransform extends Transform {
       }
       const rawDoneMatch = event?.type === "response.function_call_arguments.done"
         ? this.#specialCallForArgumentsEvent(event) : undefined;
-      const rawArgumentsDone = !rawDoneMatch?.reason && rawDoneMatch?.state?.codec?.preserveRawArguments === true;
+      // LiteLLM's native custom lifecycle keeps provider arguments verbatim when
+      // they are not its JSON wrapper. They are not function arguments to
+      // rewrite; the custom-tool check below validates them instead.
+      const rawArgumentsDone = !rawDoneMatch?.reason && (
+        rawDoneMatch?.state?.codec?.preserveRawArguments === true ||
+        (rawDoneMatch?.state?.kind === "custom" &&
+          rawDoneMatch.state.sourceType === "custom_tool_call" &&
+          !rawDoneMatch.state.codec)
+      );
       if (!embeddedFunctionArgumentsAreUnambiguous(event, this.#lookups, rawArgumentsDone)) {
         return this.#unsafeSseFrame(frame, "ambiguous function arguments");
       }
@@ -3742,7 +3779,9 @@ export class NamespaceToolCallTransform extends Transform {
             matched.state.sourceType === "custom_tool_call"
               ? LITELLM_CUSTOM_TOOL_INPUT_PROPERTY
               : CUSTOM_TOOL_INPUT_PROPERTY;
-          const input = customToolInput(event.arguments, false, argumentProperty, matched.state.codec);
+          const input = matched.state.sourceType === "custom_tool_call" && !matched.state.codec
+            ? litellmCustomToolInput(event.arguments)
+            : customToolInput(event.arguments, false, argumentProperty, matched.state.codec);
           if (input === undefined) {
             return this.#unsafeSseFrame(frame, "invalid custom tool arguments done");
           }

--- a/test/namespace-relay-routing.test.mjs
+++ b/test/namespace-relay-routing.test.mjs
@@ -2583,3 +2583,77 @@ test("real Router requires both hook opt-ins and exact model, without affecting 
     if (old) assert.equal(JSON.parse(result.clientBody).output[0].input, serializeStructuredPatch(STRUCTURED_OPERATIONS));
   }
 });
+
+test("routed native apply_patch relays LiteLLM arguments that are not a leading content wrapper", async () => {
+  const patch = "*** Begin Patch\n*** Update File: src/a.js\n@@\n-const a = 1;\n+const re = /\\d+/;\n*** End Patch";
+  // What pinned LiteLLM 1.96 emits when the provider's arguments are not a
+  // leading {"content": ...} wrapper: legacy argument events carry the
+  // provider text verbatim, and the completed custom_tool_call carries
+  // unwrap_custom_tool_arguments() of it.
+  const calls = [
+    { id: "call_input_key", arguments: JSON.stringify({ input: patch }), input: JSON.stringify({ input: patch }) },
+    { id: "call_content_second", arguments: JSON.stringify({ path: "src/a.js", content: patch }), input: patch },
+  ];
+  const sseBody = () => [
+    sseEvent({ type: "response.created", response: { id: "resp_litellm_custom" } }),
+    ...calls.flatMap((call, index) => [
+      sseEvent({
+        type: "response.output_item.added",
+        output_index: index,
+        item: { type: "custom_tool_call", id: call.id, call_id: call.id, name: "apply_patch", input: "", status: "in_progress" },
+      }),
+      ...call.arguments.match(/[\s\S]{1,10}/g).map((delta) => sseEvent({
+        type: "response.function_call_arguments.delta",
+        output_index: index,
+        item_id: call.id,
+        delta,
+      })),
+      sseEvent({
+        type: "response.function_call_arguments.done",
+        output_index: index,
+        item_id: call.id,
+        arguments: call.arguments,
+      }),
+      sseEvent({
+        type: "response.output_item.done",
+        output_index: index,
+        item: { type: "custom_tool_call", id: call.id, call_id: call.id, name: "apply_patch", input: call.input, status: "completed" },
+      }),
+    ]),
+    sseEvent({ type: "response.completed", response: { id: "resp_litellm_custom", output: [] } }),
+    "data: [DONE]\n\n",
+  ].join("");
+  const result = await scenario(true, {
+    model: "opencode-go/deepseek-v4.1-flash",
+    requestPayload: (stream, model) => ({
+      model,
+      stream,
+      input: "Apply the patch.",
+      tools: [{
+        type: "custom",
+        name: "apply_patch",
+        description: "Apply a patch.",
+        format: { type: "grammar", syntax: "lark", definition: "start: /[\\s\\S]+/" },
+      }],
+    }),
+    sseBody,
+  });
+  assert.ok(
+    result.gatewayBodies[0].tools.some((tool) => tool.type === "custom" && tool.name === "apply_patch"),
+    "native apply_patch still reaches LiteLLM as a custom tool",
+  );
+  const events = result.clientBody.split(/\r?\n/)
+    .filter((line) => line.startsWith("data: {"))
+    .map((line) => JSON.parse(line.slice(6)));
+  assert.equal(events.some((event) => event.type === "error" || event.type === "response.failed"), false);
+  assert.ok(events.some((event) => event.type === "response.completed"), "the turn completes instead of aborting");
+  for (const call of calls) {
+    const inputDone = events.find((event) =>
+      event.type === "response.custom_tool_call_input.done" && event.item_id === call.id);
+    assert.equal(inputDone?.input, call.input, `${call.id} input.done`);
+    const closed = events.find((event) =>
+      event.type === "response.output_item.done" && event.item?.call_id === call.id);
+    assert.equal(closed.item.type, "custom_tool_call");
+    assert.equal(closed.item.input, call.input, `${call.id} item input`);
+  }
+});

--- a/test/namespace-relay.test.mjs
+++ b/test/namespace-relay.test.mjs
@@ -4323,6 +4323,84 @@ test("native custom-tool legacy arguments still fail closed when streamed input 
   assert.match(error.message, /custom tool argument deltas disagree with completed input/u);
 });
 
+function litellmNativeCustomEvents(id, argumentsText, completedInput) {
+  return [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { type: "custom_tool_call", id, call_id: id, name: "apply_patch", status: "in_progress", input: "" },
+    },
+    ...[...argumentsText].map((delta) => ({
+      type: "response.function_call_arguments.delta",
+      item_id: id,
+      output_index: 0,
+      delta,
+    })),
+    { type: "response.function_call_arguments.done", item_id: id, output_index: 0, arguments: argumentsText },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { type: "custom_tool_call", id, call_id: id, name: "apply_patch", status: "completed", input: completedInput },
+    },
+  ].map((event) => `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+}
+
+// LiteLLM 1.96 unwrap_custom_tool_arguments(): a string `content` from a JSON
+// object, otherwise the provider arguments verbatim. Each case pairs the
+// provider arguments with the input LiteLLM puts on the completed item.
+const PATCH_FIXTURE = "*** Begin Patch\n*** Update File: src/a.js\n@@\n-const a = 1;\n+const re = /\\d+/;\n*** End Patch";
+
+test("native custom-tool arguments LiteLLM keeps verbatim relay as its completed input", async () => {
+  for (const [name, argumentsText, completedInput] of [
+    ["content after another key", JSON.stringify({ path: "src/a.js", content: PATCH_FIXTURE }), PATCH_FIXTURE],
+    ["input key instead of content", JSON.stringify({ input: PATCH_FIXTURE }), JSON.stringify({ input: PATCH_FIXTURE })],
+    ["empty object", "{}", "{}"],
+    ["raw patch text", PATCH_FIXTURE, PATCH_FIXTURE],
+    ["bare JSON string", JSON.stringify(PATCH_FIXTURE), JSON.stringify(PATCH_FIXTURE)],
+  ]) {
+    const id = `call_${name.replaceAll(" ", "_")}`;
+    const output = await collect(
+      Readable.from(litellmNativeCustomEvents(id, argumentsText, completedInput))
+        .pipe(new NamespaceToolCallTransform(new Map(), "text/event-stream")),
+    );
+    const payloads = output.split(/\n\n/).filter(Boolean)
+      .map((block) => JSON.parse(block.split("\n").find((line) => line.startsWith("data: ")).slice(6)));
+    assert.equal(
+      payloads.find((event) => event.type === "response.custom_tool_call_input.done")?.input,
+      completedInput,
+      name,
+    );
+    assert.equal(payloads.at(-1).item.input, completedInput, name);
+    // The decoder follows only a leading content wrapper; nothing it could not
+    // decode reaches the client as streamed input.
+    assert.equal(
+      payloads.some((event) => event.type === "response.custom_tool_call_input.delta"),
+      false,
+      name,
+    );
+    assert.doesNotMatch(output, /response\.function_call_arguments/u, name);
+  }
+});
+
+test("native custom-tool arguments still fail closed where LiteLLM's input cannot be matched", async () => {
+  for (const [name, argumentsText, completedInput, reason] of [
+    // Python str() of a non-string content has no faithful JavaScript form.
+    ["non-string content", JSON.stringify({ content: null }), "None", /invalid custom tool arguments done/u],
+    // The completed item must carry the input the relay already committed.
+    ["completed item disagrees", JSON.stringify({ input: "one" }), "two", /custom tool call input changed before close/u],
+    // Decoded text already streamed cannot be contradicted by the final input.
+    ["streamed text then invalid", '{"content": "*** Begin Patch"}', '{"content": "*** Begin Patch"}',
+      /incomplete custom tool argument delta sequence/u],
+  ]) {
+    const { error } = await collectUntilPipelineError(
+      litellmNativeCustomEvents(`call_${name.replaceAll(" ", "_")}`, argumentsText, completedInput),
+      new NamespaceToolCallTransform(new Map(), "text/event-stream"),
+    );
+    assert.equal(error?.code, "ERR_NAMESPACE_RELAY_COMMITTED_STREAM", name);
+    assert.match(error.message, reason, name);
+  }
+});
+
 test("a bridged custom tool without a grammar carries only what it was given", () => {
   const namespaces = new Map();
   const described = bridgeCustomTools(


### PR DESCRIPTION
## Problem

Routed turns that call `apply_patch` sometimes end with an HTTP 502 after output has already streamed. The router log shows:

```
NamespaceRelayCommittedStreamError: The provider response became unsafe to relay after namespace output was committed (invalid custom tool arguments done).
```

and, less often, `(incomplete custom tool argument delta sequence)`. Codex sees "stream closed before response.completed". Because the history is unchanged, it retries the identical turn five times and then fails the turn.

This isn't DeepSeek-specific. The live router log shows it for `opencode-go/deepseek-v4.1-flash` (2026-09-11), `opencode-go/deepseek-v4-flash` (2026-09-01), `zai-coding/glm-5.3` (2026-08-31, 2026-09-01), and `grok-oauth/grok-4.5` (2026-08-30, 2026-09-01). All of these routes send native `apply_patch` to LiteLLM as a `custom` tool.

## Cause

LiteLLM 1.96 converts a custom tool into a Chat Completions function with one `content` string property. It then streams the provider's arguments back as legacy `response.function_call_arguments.*` events on a native `custom_tool_call` item. Its `unwrap_custom_tool_arguments()` takes a string `content` from a JSON object and otherwise keeps the arguments verbatim. That final input is what LiteLLM puts on the completed item.

`NamespaceToolCallTransform` was stricter than LiteLLM:

- At `arguments.done` it accepted only JSON whose `content` is a string, and otherwise returned "invalid custom tool arguments done".
- Its incremental delta decoder only follows a *leading* `content` key. When `content` comes later, the final JSON is valid but the decoder never opened, so it returned "incomplete custom tool argument delta sequence".
- Non-JSON arguments were rejected earlier as "ambiguous function arguments".

## Reproduction (offline, no provider calls)

A probe ran pinned LiteLLM 1.96.0 against a mock OpenAI-compatible provider streaming 23 tool-call shapes, then fed LiteLLM's Responses events through `NamespaceToolCallTransform`. It reproduced both production messages exactly:

| Provider arguments | LiteLLM's completed input | Before | After |
|---|---|---|---|
| `{"input": "*** Begin Patch…"}`, `{"patch": …}`, `{}`, bare JSON string | arguments verbatim | invalid custom tool arguments done | relayed |
| `{"path": …, "content": "…"}` (content not first) | unwrapped patch | incomplete custom tool argument delta sequence | relayed |
| raw patch text | patch verbatim | ambiguous function arguments | relayed |
| leading `content` wrapper, extra trailing keys, whitespace, emoji, 34 KB patch, text before call, parallel calls on distinct indexes | unwrapped patch | relayed | relayed |
| `{"content": null}` / `{"content": 5}` | Python `str()` (`"None"`, `"5"`) | abort | abort (unchanged) |
| invalid escape or raw control character after decoded text was streamed | wrapper verbatim | abort | abort (unchanged) |
| parallel calls sharing one index, arguments repeated in the final chunk | inconsistent | abort | abort (unchanged) |

## Fix

For a native `custom_tool_call` lifecycle without a codec (LiteLLM's path):

1. **Same input as LiteLLM:** `arguments.done` derives the input exactly as LiteLLM does. A string `content` comes from a JSON object; otherwise the arguments are kept verbatim.
2. **Skip the function-argument check:** these arguments aren't function arguments to rewrite, so the "ambiguous function arguments" check doesn't apply at `arguments.done`.
3. **Narrow delta exemption:** the delta-agreement check is skipped only when the decoder emitted no input text, so Codex never saw anything the final input could contradict.

The router's own `{"input": …}` custom-function bridge, codec-backed tools, and every other path are unchanged. Unsupported or inconsistent streams still fail closed:

- a present non-string `content`;
- a completed item whose input disagrees with the committed input;
- decoded text already streamed and then contradicted.

The practical result: Codex receives the call LiteLLM produced. A malformed patch reaches the model as an ordinary `apply_patch` error it can correct, instead of a 502 retry loop.

## Testing

- **Unit (`test/namespace-relay.test.mjs`):** `content` after another key, `{"input": …}`, `{}`, raw patch text, and a bare JSON string relay with LiteLLM's completed input and no undecodable deltas. A non-string `content`, a disagreeing completed item, and streamed text followed by an invalid wrapper still fail closed.
- **Router (`test/namespace-relay-routing.test.mjs`):** through a real router process, `opencode-go/deepseek-v4.1-flash` relays two LiteLLM-shaped `apply_patch` streams (`{"input": …}` and `content` not first) to a completed turn with the right `custom_tool_call` inputs.
- **Negative control:** the new unit and router tests fail against unfixed `origin/main`, with the production error.
- **Suites:** `namespace-relay` and `namespace-relay-custom` pass (132/132), `npm run check` passes, and the wider suites pass (159/159): the full router-level namespace-relay tests plus the Z.ai, Grok, and DeepSeek relay suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
