### PR TITLE
fix: keep routed final answers labelled and correct message-phase replay docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2065,23 +2065,49 @@ answer below it, and finds a thread's answer with
 label, so `src/message-phase.mjs` assigns one.
 
 1. **The rule is the one native turns follow, read from item order.** A message
-   that another output item follows is commentary; the last message of a
-   `response.completed`, `response.incomplete`, or `response.done` is the final
-   answer. Never infer it from the text.
+   that a tool call or another message follows is commentary; the last message
+   of a `response.completed` or `response.done` is the final answer, even when
+   reasoning items follow it. Reasoning decides nothing: labelling that message
+   commentary left the turn without an answer, and Codex's thread-history
+   fallback reads only messages whose phase is null. `response.failed`,
+   `response.incomplete` (a stream error to Codex), and `error` leave the last
+   message unlabelled. Never infer the label from the text.
 2. **A provider's phase always wins.** Only an absent or null phase is filled,
    so a Responses provider that already labels messages passes through
    unchanged.
-3. **Hold one frame, briefly.** Only the message's `output_item.done` waits,
-   until the next item opens or the response settles; deltas stream live and
-   every frame held behind it is replayed in order. A failed, errored, or
-   unterminated response, invalid UTF-8, or an exhausted hold bound releases the
-   original bytes unlabelled.
-4. **It is metadata, not transcript.** It adds no text, costs no model tokens,
-   and LiteLLM rebuilds chat history from role and content, so a replayed label
-   never reaches a chat-completions provider.
+3. **Hold one message frame, briefly.** Only the message's `output_item.done`
+   waits, until a tool call or message opens or the response settles. A
+   reasoning item in between is held with it, deltas included, inside the
+   1 MiB bound; text deltas before the done frame stream live, and everything
+   held is replayed in order. A failed, incomplete, errored, or
+   `[DONE]`-terminated response, a clean end of stream without a terminal,
+   invalid UTF-8, or an exhausted hold bound releases the original bytes
+   unlabelled. An upstream error does not: `pipeResponse` destroys the stage, a
+   destroyed stream cannot push, and the held frames are lost with the stream
+   -- as they are in the item-lifecycle normalizer and the other holding stages
+   -- before the router ends the body with `local_router_stream_failed`.
+4. **It is metadata, not transcript, but Codex replays it.** It adds no text and
+   costs no model tokens. Codex stores the label and sends it back with the
+   message on every later turn. Chat-translated routes drop it: LiteLLM
+   rebuilds chat history from role and content, Anthropic-protocol routes are
+   rebuilt the same way, and Antigravity builds its messages from text and tool
+   calls. Providers with `protocol: "openai-responses"` receive it. Their
+   `openai/responses/<model>` deployments pass input items through, as do
+   `normalizeRoutedInput`, `normalizeResponsesRequest`,
+   `deepSeekResponsesInput`, and WebSocket continuation state. That covers Meta,
+   OpenCode, OpenCode free, GitHub Copilot, and DeepSeek Responses. OpenAI's
+   Responses schema defines the field, and native passthrough keeps it. Local
+   rollouts show OpenCode's Responses surface accepting it (Muse Spark emits it
+   itself); the other built-in Responses providers are unverified. An
+   operator-configured `--adapter openai-responses` endpoint is an unknown
+   validator, so `src/api-forwarder.mjs` omits `phase` from its message input
+   items with `withoutInputMessagePhase`. A built-in provider shown to reject
+   the field needs the same narrow input strip and a test, not a change to the
+   label.
 5. **Routed streams only, after the item-lifecycle normalizer**, so items are
-   already sequential. Coverage lives in `test/message-phase.test.mjs` and the
-   routed case in `test/namespace-relay-routing.test.mjs`.
+   already sequential. Coverage lives in `test/message-phase.test.mjs`, the
+   routed case in `test/namespace-relay-routing.test.mjs`, and the generic
+   Responses input case in `test/generic-routing.test.mjs`.
 
 ## Routed subagent regression prevention
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,18 @@
   calls) or `final_answer`, and Codex folds commentary into "Worked for ..."
   and shows the final answer below it. Routed providers never send the label,
   so every progress note rendered as a standalone answer. The router now labels
-  routed messages from the stream's item order: a message another item follows
-  is commentary, and the last message of a completed response is the final
-  answer. A phase the provider sent always wins, text still streams live, and
-  failed or unterminated responses are relayed unlabelled. The label costs no
-  model tokens, and LiteLLM drops it from history before any chat-completions
-  provider sees it.
+  routed messages from the stream's item order: a message a tool call or
+  another message follows is commentary, and the last message of a completed
+  response is the final answer, even when only reasoning follows it. A phase
+  the provider sent always wins, text still streams live, and failed,
+  incomplete, or unterminated responses are relayed unlabelled; a stream the
+  upstream breaks off loses the held message frame along with the rest of the
+  turn. The label costs no model tokens, but Codex sends it back on later
+  turns. Chat-translated routes drop it from history. Responses-surface
+  providers (Meta, OpenCode, OpenCode free, GitHub Copilot, DeepSeek Responses)
+  receive it, as OpenAI's Responses schema allows. Endpoints added with
+  `--adapter openai-responses` have it removed before the request leaves the
+  router, since nothing shows that their validators accept it.
 - **`apply_patch` calls no longer abort routed turns mid-stream when a model
   skips LiteLLM's wrapper.** LiteLLM sends native custom tools such as
   `apply_patch` to Chat Completions providers as a function with one `content`

--- a/src/api-forwarder.mjs
+++ b/src/api-forwarder.mjs
@@ -81,6 +81,7 @@ import {
 } from "./tool-schema-root.mjs";
 import { requestGenericProvider } from "./generic-providers.mjs";
 import { genericProviderConfigured } from "./generic-provider-readiness.mjs";
+import { withoutInputMessagePhase } from "./message-phase.mjs";
 import { providerTransportError } from "./transport-failure.mjs";
 import {
   endpointCapabilityError,
@@ -741,6 +742,13 @@ function normalizeBody(buffer, contentType, route) {
       delete payload.thinking;
     }
     payload = normalizeOpenAIRequest(payload);
+    // The router labels routed assistant messages with Codex's `phase`, and
+    // Codex replays it on every later turn. An operator-configured Responses
+    // endpoint is an unknown validator, so it gets the pre-label history
+    // shape. Built-in Responses providers keep the field.
+    if (provider.generic === true) {
+      payload.input = withoutInputMessagePhase(payload.input);
+    }
   }
 
   // OpenAI Chat Completions providers place terminal usage in a final empty

--- a/src/message-phase.mjs
+++ b/src/message-phase.mjs
@@ -9,27 +9,40 @@ import { Transform } from "node:stream";
 // so every progress note rendered as a standalone answer.
 //
 // This stage assigns the label from the item order the stream already carries,
-// using the rule native turns follow: a message that another output item
-// follows is commentary, and the last message of a successfully completed
-// response is the final answer. It spends no model tokens, and a replayed label
-// never reaches a chat-completions provider: LiteLLM rebuilds assistant history
-// from role and content alone.
+// using the rule native turns follow: a message that a tool call or another
+// message follows is commentary, and the last message of a completed response
+// is the final answer. A reasoning item after a message decides nothing, so a
+// message followed only by reasoning is still the answer. It spends no model
+// tokens. Codex replays the label with the message on later turns: a
+// Chat-translated route drops it (LiteLLM rebuilds chat history from role and
+// content), but a Responses-surface provider receives it -- see
+// `withoutInputMessagePhase` for the one route that strips it.
 //
 // Only a message's `output_item.done` is rewritten, and only while its phase is
 // absent; a phase the provider sent always wins. Text deltas stream unchanged.
-// The done frame is held just until the next item opens (commentary) or the
-// response completes (final answer), and every frame that arrived in between is
-// replayed in order behind it. A failed, errored, or unterminated response
-// releases the held frame untouched, as does anything this stage cannot parse.
-// It runs after the item-lifecycle normalizer, so items are already sequential.
+// The done frame is held until a tool call or message opens (commentary) or the
+// response completes (final answer); a reasoning item in between is held with
+// it, and every held frame is replayed in order behind it. A failed, errored,
+// incomplete, or `[DONE]`-terminated response, a clean end of stream without a
+// terminal, or anything this stage cannot parse releases the held frame
+// untouched. An upstream error is different: the pipeline destroys this stage,
+// a destroyed stream cannot push, and the held frames are lost with the stream
+// -- as they are in every other holding stage -- before the router ends the
+// body with a stream error. It runs after the item-lifecycle normalizer, so
+// items are already sequential.
 const CRLF_SEP = Buffer.from("\r\n\r\n");
 const LF_SEP = Buffer.from("\n\n");
 const COMMENTARY = "commentary";
 const FINAL_ANSWER = "final_answer";
 // Terminals that settle a delivered response: its last message is the answer.
-const ANSWER_TERMINALS = new Set(["response.completed", "response.incomplete", "response.done"]);
-// Terminals that end the turn without an answer.
-const FAILURE_TERMINALS = new Set(["response.failed", "error"]);
+const ANSWER_TERMINALS = new Set(["response.completed", "response.done"]);
+// Terminals that end the turn without an answer. Codex treats
+// `response.incomplete` as a stream error, like `response.failed`.
+const FAILURE_TERMINALS = new Set(["response.failed", "response.incomplete", "error"]);
+// Output items that neither make a preceding message commentary nor end it as
+// the answer. Native turns never place one after a message; a routed provider
+// can, and labelling the message commentary then left the turn with no answer.
+const NEUTRAL_ITEM_TYPES = new Set(["reasoning"]);
 const DECISION_HINTS = [
   "response.output_item.added",
   "response.output_item.done",
@@ -115,16 +128,41 @@ function rewrittenFrame(text, separator, event) {
   return Buffer.concat([Buffer.from(lines.join(lineEnding), "utf8"), separator]);
 }
 
-// Labels the terminal snapshot's messages by the same rule the stream used.
+// Labels the terminal snapshot's messages by the same rule the stream used: a
+// message before the last non-reasoning item is commentary.
 export function labelResponseOutput(output) {
   if (!Array.isArray(output)) return undefined;
+  const lastDecisive = output.findLastIndex((item) => !NEUTRAL_ITEM_TYPES.has(item?.type));
   let changed = false;
   const labelled = output.map((item, index) => {
     if (!unlabelledAssistantMessage(item)) return item;
     changed = true;
-    return { ...item, phase: index < output.length - 1 ? COMMENTARY : FINAL_ANSWER };
+    return { ...item, phase: index < lastDecisive ? COMMENTARY : FINAL_ANSWER };
   });
   return changed ? labelled : undefined;
+}
+
+// Omits `phase` from replayed message input items. Used only for an
+// operator-configured Responses endpoint, whose validator nothing has shown to
+// accept the field; returns the input itself when no item carries one.
+export function withoutInputMessagePhase(input) {
+  if (!Array.isArray(input)) return input;
+  let changed = false;
+  const next = input.map((item) => {
+    if (
+      item === null ||
+      typeof item !== "object" ||
+      Array.isArray(item) ||
+      !Object.hasOwn(item, "phase") ||
+      !(item.type === "message" || (item.type === undefined && typeof item.role === "string"))
+    ) {
+      return item;
+    }
+    changed = true;
+    const { phase: _phase, ...rest } = item;
+    return rest;
+  });
+  return changed ? next : input;
 }
 
 export class MessagePhaseTransform extends Transform {
@@ -197,8 +235,10 @@ export class MessagePhaseTransform extends Transform {
     const type = parsed?.type;
 
     if (this.#pending) {
-      if (type === "response.output_item.added" || type === "response.output_item.done") {
-        // Another item follows the held message, so it was commentary.
+      const itemFrame = type === "response.output_item.added" || type === "response.output_item.done";
+      if (itemFrame && !NEUTRAL_ITEM_TYPES.has(parsed.event?.item?.type)) {
+        // A tool call or another message follows the held message, so it was
+        // commentary. An item this stage could not parse counts as one.
         this.#release(COMMENTARY);
       } else if (ANSWER_TERMINALS.has(type)) {
         this.#release(FINAL_ANSWER);

--- a/test/deepseek-responses-routing.test.mjs
+++ b/test/deepseek-responses-routing.test.mjs
@@ -304,7 +304,7 @@ test("direct DeepSeek Responses preserves images, reasoning, tools and stream bo
     const history = [
       { type: "message", role: "user", content: "Review the image." },
       { type: "reasoning", content: [{ type: "reasoning_text", text: "PRIOR_REASONING" }] },
-      { type: "message", role: "assistant", content: [{ type: "output_text", text: "PRIOR_ANSWER" }] },
+      { type: "message", role: "assistant", phase: "commentary", content: [{ type: "output_text", text: "PRIOR_ANSWER" }] },
       { type: "function_call", name: "probe", namespace: "fixture", call_id: "call_previous", arguments: "{}" },
       { type: "function_call_output", call_id: "call_previous", output: [{ type: "input_text", text: "fixture" }, { type: "input_image", image_url: IMAGE, detail: "original" }] },
     ];
@@ -317,6 +317,9 @@ test("direct DeepSeek Responses preserves images, reasoning, tools and stream bo
     assert.equal(requestText.split("PRIOR_REASONING").length - 1, 1);
     assert.equal(requestText.split("PRIOR_ANSWER").length - 1, 1);
     assert.deepEqual(requests.at(-1).body.input.find((item) => item.type === "reasoning"), history[1]);
+    // Built-in Responses providers keep Codex's message phase; only
+    // operator-configured Responses endpoints have it removed.
+    assert.equal(requests.at(-1).body.input.find((item) => item.role === "assistant")?.phase, "commentary");
     assert.deepEqual(requests.at(-1).body.input.at(-1).output, history.at(-1).output);
     const legacyHistory = structuredClone(history);
     legacyHistory[1] = { type: "reasoning", summary: [{ type: "summary_text", text: "PRIOR_REASONING" }], content: null };

--- a/test/generic-routing.test.mjs
+++ b/test/generic-routing.test.mjs
@@ -223,3 +223,91 @@ test("one generic gateway routes ordinary and explicitly profiled models without
     rmSync(directory, { recursive: true, force: true });
   }
 });
+
+test("a generic Responses gateway receives replayed messages without Codex's phase label", async () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "generic-responses-phase-"));
+  const providersFile = path.join(directory, "generic-providers.json");
+  const userModelsFile = path.join(directory, "user-models.json");
+  const stateDir = path.join(directory, "state");
+  const upstreamRequests = [];
+  const upstream = await listen(async (request, response) => {
+    upstreamRequests.push({ url: request.url, body: await requestJson(request) });
+    json(response, 200, {
+      id: "resp_generic_1",
+      object: "response",
+      status: "completed",
+      model: upstreamRequests.at(-1).body.model,
+      output: [{
+        id: "msg_generic_1",
+        type: "message",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "ok", annotations: [] }],
+      }],
+    });
+  });
+  const model = userModelEntry({
+    providerId: "responses-gateway",
+    upstreamId: "responses-model",
+    priority: 100,
+  });
+  writeFileSync(providersFile, `${JSON.stringify({
+    version: 1,
+    providers: [{
+      id: "responses-gateway",
+      displayName: "Responses Gateway",
+      baseUrl: `http://127.0.0.1:${upstream.port}/v1`,
+      adapter: "openai-responses",
+      headers: {},
+      allowPrivate: true,
+      enabled: true,
+    }],
+  }, null, 2)}\n`);
+  writeFileSync(userModelsFile, `${JSON.stringify({ version: 1, models: [model] }, null, 2)}\n`);
+  const forwarderPort = await openPort();
+  const forwarder = runForwarder({
+    MODEL_ROUTER_API_PORT: String(forwarderPort),
+    MODEL_ROUTER_STATE_DIR: stateDir,
+    MODEL_ROUTER_GENERIC_PROVIDERS: providersFile,
+    MODEL_ROUTER_USER_MODELS: userModelsFile,
+  });
+  const commentary = {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "output_text", text: "Checking." }],
+  };
+  const answer = {
+    type: "message",
+    role: "assistant",
+    content: [{ type: "output_text", text: "Done." }],
+  };
+  const input = [
+    { type: "message", role: "user", content: [{ type: "input_text", text: "Inspect it." }] },
+    { ...commentary, phase: "commentary" },
+    { type: "function_call", call_id: "call_1", name: "inspect", arguments: "{}" },
+    { type: "function_call_output", call_id: "call_1", output: "fine" },
+    { ...answer, phase: "final_answer" },
+    { type: "message", role: "user", content: [{ type: "input_text", text: "Again." }] },
+  ];
+
+  try {
+    await waitForForwarder(forwarderPort, forwarder);
+    const response = await fetch(`http://127.0.0.1:${forwarderPort}/v1/responses`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${INTERNAL_KEY}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ model: `responses/${model.gatewayModel}`, input }),
+    });
+    assert.equal(response.status, 200, forwarder.testErrors());
+    assert.equal((await response.json()).output[0].content[0].text, "ok");
+
+    assert.equal(upstreamRequests.length, 1);
+    assert.equal(upstreamRequests[0].url, "/v1/responses");
+    const sent = upstreamRequests[0].body;
+    assert.equal(sent.model, model.upstreamModel);
+    assert.deepEqual(sent.input, [input[0], commentary, input[2], input[3], answer, input[5]]);
+  } finally {
+    await stop(forwarder);
+    await close(upstream.server);
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/test/message-phase.test.mjs
+++ b/test/message-phase.test.mjs
@@ -7,6 +7,7 @@ import {
   labelResponseOutput,
   MessagePhaseTransform,
   messagePhaseTransform,
+  withoutInputMessagePhase,
 } from "../src/message-phase.mjs";
 
 function block(event, sep = "\n\n") {
@@ -51,6 +52,21 @@ const message = (id, text, extra = {}) => ({
   ...extra,
 });
 const call = (id) => ({ id, type: "function_call", call_id: id, name: "exec_command", arguments: "{}" });
+const reasoning = (id) => ({ id, type: "reasoning", summary: [{ type: "summary_text", text: "Thinking." }] });
+
+function reasoningFrames(index, item) {
+  return [
+    block({ type: "response.output_item.added", output_index: index, item: { ...item, summary: [] } }),
+    block({
+      type: "response.reasoning_summary_text.delta",
+      output_index: index,
+      item_id: item.id,
+      summary_index: 0,
+      delta: item.summary[0].text,
+    }),
+    block({ type: "response.output_item.done", output_index: index, item }),
+  ];
+}
 
 function messageFrames(index, item) {
   return [
@@ -157,10 +173,11 @@ test("tool-only and message-free streams pass through byte-for-byte", async () =
   assert.equal((await label(input)).toString("utf8"), input);
 });
 
-test("failed, errored, and unterminated responses release the message unlabelled", async () => {
+test("failed, incomplete, errored, and unterminated responses release the message unlabelled", async () => {
   const head = messageFrames(0, message("m1", "Partial.")).join("");
   for (const tail of [
     block({ type: "response.failed", response: { id: "r", error: { message: "boom" } } }),
+    block({ type: "response.incomplete", response: { id: "r", status: "incomplete", output: [] } }),
     block({ type: "error", error: { message: "boom" } }),
     "data: [DONE]\n\n",
     "",
@@ -222,6 +239,130 @@ test("labelResponseOutput leaves labelled and non-message output alone", () => {
   assert.equal(labelResponseOutput([call("c1")]), undefined);
   assert.equal(labelResponseOutput([message("m1", "x", { phase: "final_answer" })]), undefined);
   assert.equal(labelResponseOutput(undefined), undefined);
+});
+
+test("labelResponseOutput lets only tool calls and messages make a message commentary", () => {
+  const phases = (output) => labelResponseOutput(output).map((item) => item.phase);
+  assert.deepEqual(phases([message("m1", "x"), reasoning("rs1")]), ["final_answer", undefined]);
+  assert.deepEqual(phases([message("m1", "x"), reasoning("rs1"), call("c1")]), ["commentary", undefined, undefined]);
+  assert.deepEqual(phases([message("m1", "x"), reasoning("rs1"), message("m2", "y"), reasoning("rs2")]), [
+    "commentary",
+    undefined,
+    "final_answer",
+    undefined,
+  ]);
+});
+
+test("a message followed only by reasoning is still the final answer", async () => {
+  const input = [
+    block({ type: "response.created", response: { id: "r" } }),
+    ...messageFrames(0, message("m1", "Done.")),
+    ...reasoningFrames(1, reasoning("rs1")),
+    block({ type: "response.completed", response: { id: "r", output: [message("m1", "Done."), reasoning("rs1")] } }),
+    "data: [DONE]\n\n",
+  ].join("");
+  const out = await label(input);
+  assert.deepEqual(donePhases(out), ["m1:final_answer"]);
+  const completed = events(out).find((event) => event.type === "response.completed");
+  assert.deepEqual(completed.response.output.map((item) => item.phase), ["final_answer", undefined]);
+  assert.equal(out.toString("utf8").replaceAll(',"phase":"final_answer"', ""), input);
+});
+
+test("reasoning between a message and a tool call is held, and the message stays commentary", async () => {
+  const input = [
+    ...messageFrames(0, message("m1", "Checking.")),
+    ...reasoningFrames(1, reasoning("rs1")),
+    ...callFrames(2, call("c1")),
+    block({
+      type: "response.completed",
+      response: { id: "r", output: [message("m1", "Checking."), reasoning("rs1"), call("c1")] },
+    }),
+  ].join("");
+  const out = await label(input);
+  assert.deepEqual(donePhases(out), ["m1:commentary"]);
+  const completed = events(out).find((event) => event.type === "response.completed");
+  assert.deepEqual(completed.response.output.map((item) => item.phase), ["commentary", undefined, undefined]);
+  assert.equal(out.toString("utf8").replaceAll(',"phase":"commentary"', ""), input);
+  for (const chunkSize of [1, 13, 256]) {
+    assert.deepEqual(await label(input, { chunkSize }), out, `chunkSize=${chunkSize}`);
+  }
+});
+
+test("an incomplete response keeps earlier commentary but labels neither its last message nor its snapshot", async () => {
+  const output = [message("m1", "Checking."), call("c1"), message("m2", "Truncat")];
+  const input = [
+    ...messageFrames(0, output[0]),
+    ...callFrames(1, output[1]),
+    ...messageFrames(2, output[2]),
+    block({
+      type: "response.incomplete",
+      response: { id: "r", status: "incomplete", incomplete_details: { reason: "max_output_tokens" }, output },
+    }),
+  ].join("");
+  const out = await label(input);
+  assert.deepEqual(donePhases(out), ["m1:commentary", "m2:undefined"]);
+  const incomplete = events(out).find((event) => event.type === "response.incomplete");
+  assert.deepEqual(incomplete.response.output.map((item) => item.phase), [undefined, undefined, undefined]);
+});
+
+test("reasoning held behind a message still respects the hold bound", async () => {
+  const input = [
+    ...messageFrames(0, message("m1", "Slow.")),
+    block({ type: "response.output_item.added", output_index: 1, item: { ...reasoning("rs1"), summary: [] } }),
+    ...Array.from({ length: 20 }, (_, index) =>
+      block({
+        type: "response.reasoning_summary_text.delta",
+        output_index: 1,
+        item_id: "rs1",
+        summary_index: 0,
+        delta: `${"x".repeat(32)} ${index}`,
+      })),
+    block({ type: "response.output_item.done", output_index: 1, item: reasoning("rs1") }),
+    block({ type: "response.completed", response: { id: "r", output: [] } }),
+  ].join("");
+  assert.equal((await label(input, { maxHeldBytes: 512 })).toString("utf8"), input);
+});
+
+test("an upstream error destroys the stage with its held frame; a clean end releases it", async () => {
+  const head = messageFrames(0, message("m1", "Partial.")).join("");
+  const chunks = [];
+  const source = new Readable({ read() {} });
+  const collector = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(Buffer.from(chunk));
+      callback();
+    },
+  });
+  const run = pipeline(source, new MessagePhaseTransform(), collector);
+  source.push(head);
+  for (let turn = 0; turn < 1000 && !Buffer.concat(chunks).includes("response.output_text.delta"); turn += 1) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  source.destroy(new Error("upstream reset"));
+  await assert.rejects(run, /upstream reset/);
+  const relayed = Buffer.concat(chunks).toString("utf8");
+  assert.ok(relayed.includes('"response.output_text.delta"'), "frames before the message done were relayed");
+  assert.ok(!relayed.includes('"response.output_item.done"'), "the held done frame is lost with the stream");
+  // Control: the same frames ending cleanly release the held frame untouched.
+  assert.equal((await label(head)).toString("utf8"), head);
+});
+
+test("withoutInputMessagePhase omits phase from message input items only", () => {
+  const input = [
+    { type: "message", role: "user", content: [{ type: "input_text", text: "hi" }] },
+    message("m1", "Checking.", { phase: "commentary" }),
+    { ...call("c1"), phase: "commentary" },
+    { role: "assistant", content: "Done.", phase: "final_answer" },
+  ];
+  const out = withoutInputMessagePhase(input);
+  assert.deepEqual(out.map((item) => Object.hasOwn(item, "phase")), [false, false, true, false]);
+  assert.equal(out[0], input[0]);
+  assert.deepEqual(out[1], message("m1", "Checking."));
+  assert.equal(input[1].phase, "commentary", "the caller's input is not mutated");
+  const clean = [input[0], call("c1")];
+  assert.equal(withoutInputMessagePhase(clean), clean);
+  assert.equal(withoutInputMessagePhase("text"), "text");
+  assert.equal(withoutInputMessagePhase(undefined), undefined);
 });
 
 test("the factory attaches only to event streams", () => {


### PR DESCRIPTION
Follow-up to #702 (merge f020afbc). A review after the merge found two wrong documentation claims and two labelling bugs.

## What #702 got wrong

1. **It said the label never reaches a provider, but Responses providers receive it.** AGENTS.md item 4 and the CHANGELOG entry said LiteLLM rebuilds history from role and content. That is only true for Chat-translated routes: LiteLLM's chat transformation, Anthropic-protocol routes, and Antigravity, which builds its messages from text and tool calls.
   - Providers with `protocol: "openai-responses"` render as `openai/responses/<model>`: Meta, OpenCode, OpenCode free, GitHub Copilot, DeepSeek Responses, and generic `--adapter openai-responses` endpoints.
   - On that path, LiteLLM 1.96.0 only strips `cache_control` from input items. `normalizeRoutedInput`, `normalizeResponsesRequest`, `deepSeekResponsesInput`, and WebSocket continuation state all pass `phase` through too, so these providers get it on every later turn.
   - The OpenAI SDK's Responses types define `phase` on input messages and say to resend it.
   - Local rollouts show OpenCode Responses accepting it (gpt-5.6-luna, muse-spark). Nothing shows it either way for the other built-in Responses providers, or for endpoints users configure themselves.
2. **It said an unterminated response releases the held frame. On an upstream error it doesn't.** `pipeResponse` destroys every stage when the upstream errors. A destroyed Transform can't push, so the held `output_item.done` is lost. Only a clean end of stream releases it.
3. **A trailing reasoning item demoted the final answer.** A turn of message, then reasoning item, then `response.completed` labelled the message `commentary`, so the turn had no `final_answer`. Codex's thread-history SQL falls back only to `phase IS NULL` messages, so it found nothing.
4. **`response.incomplete` was labelled `final_answer`.** Codex 0.153 treats it as a stream error ("Incomplete response returned, reason:").

## Fixes

- **Reasoning no longer decides the label** (`src/message-phase.mjs`). A message is commentary only when a tool call or another message follows it. While a message's done frame is held, a reasoning item's frames are held with it, inside the existing 1 MiB bound, until a tool call, a message, or a terminal decides. The terminal snapshot follows the same rule: a message before the last non-reasoning item is commentary. Item types the stage can't parse still count as decisive, as before.
- **`response.incomplete` joins `response.failed` and `error`.** The last message and the snapshot stay unlabelled. Commentary labels decided earlier in the stream are kept.
- **Generic Responses endpoints have `phase` removed.** `src/api-forwarder.mjs` applies `withoutInputMessagePhase` to message input items, but only when `provider.generic === true` on the Responses surface. Built-in Responses providers keep the field.
- **Docs.** AGENTS.md's message-phase section, the CHANGELOG entry, and the stage comment now describe the replay exposure and the teardown behaviour accurately.

## Decisions

- **Strip `phase` only for generic endpoints.** For an endpoint a user configures, we can't see its validator. If it rejected the field, every later turn of every thread would fail with a 400. Stripping there costs little: history goes back to its pre-#702 shape. One side effect: in a thread that switched from a native model, native-authored labels are also dropped before reaching that endpoint.
  - Built-in providers keep `phase`. OpenAI's schema defines it, OpenCode is observed accepting it, and removing it from providers that honour it could hurt answer quality. A built-in provider shown to reject it should get the same narrow strip and a test.
- **No flush on upstream error.** In Node 24.16, `pipeline(source, holdingTransform, sink, { end: false })` delivers nothing the transform pushes from `_destroy`; the sink got only the bytes sent before the hold.
  - The item-lifecycle normalizer, the DeepSeek compat stages, and the empty-completion guard all drop held data the same way.
  - Flushing would mean the router draining every stage before `endStreamedResponse`, which changes `pipeResponse` semantics for all of them.
  - So I corrected the docs and comment, and added a test that pins the behaviour, with a clean-end control.
- **Incomplete stays unlabelled.** The Codex 0.153.2 binary picks the latest `phase = 'final_answer'` message first. Otherwise, for turns in status `completed`, `interrupted`, or `failed`, it takes the latest `agentMessage` with `phase IS NULL`. I found nothing that stores incomplete-turn answers by phase. The router's WebSocket continuation already counts `response.incomplete` as a terminal failure.

## Testing

- `test/message-phase.test.mjs`: 21/21 passed (14 before). New tests cover:
  - trailing reasoning stays the final answer, in both stream and snapshot, with bytes otherwise unchanged
  - reasoning between a message and a tool call is held, the message stays commentary, and output is identical at chunk sizes 1, 13, and 256
  - an incomplete response keeps earlier commentary but labels neither its last message nor its snapshot
  - the hold bound still applies while reasoning is held
  - an upstream error drops the held frame, with a clean-end control
  - snapshot labelling rules
  - `withoutInputMessagePhase`
  - `response.incomplete` added to the unlabelled-terminal cases
- `test/generic-routing.test.mjs`: 2/2 passed. The new test sends a generic `openai-responses` gateway input with `commentary` and `final_answer` messages, and the upstream receives the same input without `phase`.
- `test/deepseek-responses-routing.test.mjs`: 7/7 passed. New assertion: the built-in DeepSeek Responses route still sends `phase` (control for the strip).
- `test/item-lifecycle-normalizer.test.mjs`, `test/deepseek-tool-message-compat.test.mjs`, `test/responses-websocket.test.mjs`: 130/130 passed.
- Run one at a time: `test/namespace-relay-routing.test.mjs` 31/31; the phase-asserting cases in `test/routing.test.mjs` ("router compacts translated OpenCode routes and pins subagents on both route types", "router enables the terminal-only bridge repair only for Messages routes") 2/2.
- `npm run check`: passed.

Negative controls:
- Offline repro script, run before and after the change:
  - message → reasoning → completed: `commentary` before, `final_answer` after
  - `response.incomplete`: `final_answer` before, unlabelled after
  - upstream error while holding: held done frame lost both before and after (expected)
  - message, message, tool: `commentary`, `commentary` both before and after
- On an origin/main worktree, the new generic-routing test fails because the upstream receives `phase`. The new message-phase file fails there on the missing export; the repro above covers its behaviour.

## Not changed

- `pipeResponse` teardown, and how every other stage handles errors.
- The hold still has no time bound. A message followed by long reasoning now holds its done frame and the reasoning deltas until a tool call, a message, or a terminal arrives, or 1 MiB is held.
- `phase` for built-in Responses providers. Meta direct, GitHub Copilot, OpenCode free, and DeepSeek Responses remain unverified; no live probes were run.
- Chat-translated, Anthropic-protocol, and Antigravity routes, and native passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
