### PR TITLE
fix: show Chat Completions reasoning in Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2083,6 +2083,39 @@ label, so `src/message-phase.mjs` assigns one.
    already sequential. Coverage lives in `test/message-phase.test.mjs` and the
    routed case in `test/namespace-relay-routing.test.mjs`.
 
+## Chat Completions reasoning reaches Codex as one reasoning item
+
+LiteLLM 1.96's Chat Completions to Responses bridge opens the assistant message
+first, then streams `response.reasoning_summary_text.delta` under a fresh
+hashed `rs_…` id per delta (or the message's id), with no reasoning
+`output_item.added` or `reasoning_summary_part.added` and on the message's
+`output_index`. Codex drops deltas that belong to no open item, so reasoning
+never rendered and no reasoning item was saved to the thread. That held for
+every Chat Completions route (measured on `commandcode/hy4-preview` and
+`opencode-go/deepseek-v4.1-flash`), not only Grok.
+
+1. **One repair, scoped by protocol.** `reasoningSummaryCompatTransform` in
+   `src/grok-reasoning-summary-compat.mjs` attaches the lifecycle repair to
+   every provider whose `protocol` is Chat Completions (`openai`, the default).
+   Direct `deepseek` is excluded because `DeepseekToolMessageCompatTransform`
+   already repairs its bridge, and `anthropic` and `openai-responses`
+   providers do not reach this bridge. Widening it to another protocol needs a
+   captured stream from that protocol first.
+2. **Grok's gateway-error wording stays on Grok OAuth.** Only `grok-oauth`
+   replaces an untyped LiteLLM error envelope with the fixed local error. Other
+   routes relay that envelope byte-identical, after closing the reasoning item
+   as `incomplete` and releasing any message the repair was holding.
+3. **The pre-commit frame bound is 10 MiB, like the namespace relay's.**
+   LiteLLM echoes the request's `instructions` and full `tools` array in
+   `response.created`, and a Codex Desktop tool list exceeds 256 KiB. A smaller
+   bound releases that frame raw and disables the repair for the whole stream,
+   which no mock gateway with a tiny prelude reproduces. Any fixture for this
+   path must echo a Desktop-sized tool list.
+4. **Canonical streams pass byte-identical.** Coverage lives in
+   `test/grok-reasoning-summary-compat.test.mjs` and the Grok and Desktop-sized
+   Chat Completions router cases in `test/routing.test.mjs`. The regression
+   oracle is a live Codex turn whose rollout records a `reasoning` item.
+
 ## Routed subagent regression prevention
 
 - A normal `/responses` smoke test does not cover Codex collaboration. Current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Reasoning from Chat Completions models now shows in Codex.** LiteLLM's
+  Chat Completions to Responses bridge opens the assistant message first and
+  streams the model's reasoning under a fresh hashed item id per delta, with no
+  reasoning item around it. Codex drops deltas that belong to no open item, so
+  routed models such as Hy4 Preview (Command Code), DeepSeek V4.1 Flash on
+  opencode Go, and every other Chat Completions route showed no reasoning at
+  all, and none was saved to the thread. The repair that already rebuilt one
+  reasoning item for Grok OAuth now runs for every Chat Completions route.
+  Direct DeepSeek keeps its own bridge repair, Responses and Messages providers
+  are untouched, canonical streams pass byte-identical, and the Grok-specific
+  gateway-error wording stays on Grok OAuth. Its first-frame bound also rises
+  from 256 KiB to 10 MiB: LiteLLM echoes the whole Codex tool list in
+  `response.created`, and in Codex Desktop that frame used to switch the repair
+  off for the entire stream.
 - **A routed model the router has not loaded now fails locally, not at
   ChatGPT.** A model added to or renamed in `user-models.json` shows up in the
   Codex picker as soon as the catalog is rebuilt, but the running router reads

--- a/src/grok-reasoning-summary-compat.mjs
+++ b/src/grok-reasoning-summary-compat.mjs
@@ -1,14 +1,18 @@
 import { Transform } from "node:stream";
 import { TextDecoder } from "node:util";
 
-const MAX_FRAME_BYTES = 256 * 1024;
+// LiteLLM's bridge echoes the request's instructions and full tool list in
+// response.created, and a Codex Desktop tool list is larger than 256 KiB. A
+// smaller pre-commit bound releases that first frame and turns the repair off
+// for the whole stream, so match the namespace relay's prelude bound.
+const MAX_FRAME_BYTES = 10 * 1024 * 1024;
 const MAX_COMMITTED_FRAME_BYTES = 64 * 1024 * 1024;
 const LF_FRAME_SEPARATOR = Buffer.from("\n\n");
 const CRLF_FRAME_SEPARATOR = Buffer.from("\r\n\r\n");
 
 class GrokReasoningSummaryCommittedStreamError extends Error {
   constructor(reason) {
-    super(`Grok reasoning summary repair failed after stream mutation: ${reason}`);
+    super(`Reasoning summary repair failed after stream mutation: ${reason}`);
     this.name = "GrokReasoningSummaryCommittedStreamError";
   }
 }
@@ -161,12 +165,15 @@ function isGatewayErrorEnvelope(event) {
 }
 
 // LiteLLM's Chat Completions -> Responses bridge can open an empty message
-// before Grok starts reasoning, and it hashes every reasoning delta into a
-// different item_id. Codex drops those orphaned deltas, so the user sees
-// silence while Grok is already streaming a summary. Normalize only that
-// summary lifecycle; other providers and non-SSE responses never enter here.
+// before the model starts reasoning, and it hashes every reasoning delta into a
+// different item_id. Codex drops those orphaned deltas, so the user sees no
+// reasoning while the model is already streaming a summary. This was found on
+// Grok and holds for every Chat Completions route through that bridge (Hy4,
+// DeepSeek on resellers, ...). Normalize only that summary lifecycle; canonical
+// streams pass byte-identical and non-SSE responses never enter here.
 export class GrokReasoningSummaryCompatTransform extends Transform {
   #frames;
+  #normalizeGatewayErrors;
   #disabled = false;
   #reasoning;
   #pendingMessage = [];
@@ -183,8 +190,10 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
   constructor({
     maxFrameBytes = MAX_FRAME_BYTES,
     maxCommittedFrameBytes = MAX_COMMITTED_FRAME_BYTES,
+    normalizeGatewayErrors = true,
   } = {}) {
     super();
+    this.#normalizeGatewayErrors = normalizeGatewayErrors === true;
     const limit = Number.isInteger(maxFrameBytes) && maxFrameBytes > 0
       ? maxFrameBytes
       : MAX_FRAME_BYTES;
@@ -354,7 +363,7 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
       ?? (Number.isInteger(event.output_index) ? event.output_index : 0);
     this.#shiftOutputIndexes = this.#pendingMessage.length > 0;
     this.#reasoning = {
-      id: typeof event.item_id === "string" && event.item_id ? event.item_id : "rs_grok_summary",
+      id: typeof event.item_id === "string" && event.item_id ? event.item_id : "rs_reasoning_summary",
       outputIndex,
       text: "",
       partStarted: false,
@@ -436,6 +445,15 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
     // LiteLLM can turn a forwarder SSE error into an untyped gateway error,
     // then append empty message closes. Recognize only the top-level envelope;
     // text containing error-shaped JSON and canonical typed events stay intact.
+    // The Grok OAuth wording is proven for that route alone, so other routes
+    // relay the envelope byte-identical, after closing anything held here.
+    if (isGatewayErrorEnvelope(event) && !this.#normalizeGatewayErrors) {
+      return [
+        ...this.#finishReasoning(parsed, "incomplete"),
+        ...this.#flushPendingMessage(),
+        block,
+      ];
+    }
     if (isGatewayErrorEnvelope(event)) {
       this.#commitMutation(parsed);
       const prefix = this.#finishReasoning(parsed, "incomplete");
@@ -716,9 +734,16 @@ export class GrokReasoningSummaryCompatTransform extends Transform {
   }
 }
 
-export function grokReasoningSummaryCompatTransform(provider, contentType = "") {
-  const providerId = typeof provider === "string" ? provider : provider?.id;
-  if (providerId !== "grok-oauth") return undefined;
+// Grok OAuth keeps its gateway-error normalization. Every other provider whose
+// turns LiteLLM translates from Chat Completions gets the summary repair only.
+// Direct DeepSeek has its own reasoning bridge repair in
+// deepseek-tool-message-compat.mjs, and Responses and Messages providers do not
+// come through this bridge, so none of those gain a stage.
+export function reasoningSummaryCompatTransform(provider, contentType = "") {
   if (!String(contentType).toLowerCase().includes("text/event-stream")) return undefined;
-  return new GrokReasoningSummaryCompatTransform();
+  const providerId = typeof provider === "string" ? provider : provider?.id;
+  if (providerId === "grok-oauth") return new GrokReasoningSummaryCompatTransform();
+  if (!provider || typeof provider !== "object" || providerId === "deepseek") return undefined;
+  if ((provider.protocol ?? "openai") !== "openai") return undefined;
+  return new GrokReasoningSummaryCompatTransform({ normalizeGatewayErrors: false });
 }

--- a/src/router.mjs
+++ b/src/router.mjs
@@ -62,7 +62,7 @@ import {
   ZaiResponsesCompatTransform,
   zaiResponsesCompatTransform,
 } from "./zai-responses-compat.mjs";
-import { grokReasoningSummaryCompatTransform } from "./grok-reasoning-summary-compat.mjs";
+import { reasoningSummaryCompatTransform } from "./grok-reasoning-summary-compat.mjs";
 import { ResponsesHeartbeatTransform } from "./responses-heartbeat.mjs";
 import { messagePhaseTransform } from "./message-phase.mjs";
 import { translatedToolMessageCompatTransform } from "./deepseek-tool-message-compat.mjs";
@@ -4327,13 +4327,15 @@ async function handleResponses(request, response, requestUrl) {
         envelopeCompat = new ZaiResponsesCompatTransform();
       }
       if (envelopeCompat) transforms.push(envelopeCompat);
-      const grokReasoningSummaryCompat = route
-        ? grokReasoningSummaryCompatTransform(providerForModel(route), contentType)
+      // LiteLLM's Chat Completions bridge streams reasoning under hashed
+      // per-delta ids that Codex drops; rebuild one reasoning item. Grok OAuth
+      // also normalizes gateway error envelopes here. Observe the canonical
+      // terminal for metering and activity; the leading byte observer still
+      // measures the original upstream bytes.
+      const reasoningSummaryCompat = route
+        ? reasoningSummaryCompatTransform(providerForModel(route), contentType)
         : undefined;
-      // Grok gateway error envelopes are normalized along with its reasoning
-      // lifecycle. Observe the canonical terminal for metering and activity;
-      // the leading byte observer still measures the original upstream bytes.
-      if (grokReasoningSummaryCompat) transforms.splice(1, 0, grokReasoningSummaryCompat);
+      if (reasoningSummaryCompat) transforms.splice(1, 0, reasoningSummaryCompat);
       // LiteLLM can add blank assistant envelopes while translating either
       // Chat Completions or Messages. The factory refuses native traffic and
       // providers that already speak Responses, so those paths gain no stage.

--- a/test/grok-reasoning-summary-compat.test.mjs
+++ b/test/grok-reasoning-summary-compat.test.mjs
@@ -4,7 +4,7 @@ import test from "node:test";
 
 import {
   GrokReasoningSummaryCompatTransform,
-  grokReasoningSummaryCompatTransform,
+  reasoningSummaryCompatTransform,
 } from "../src/grok-reasoning-summary-compat.mjs";
 
 function block(event, newline = "\n") {
@@ -863,9 +863,79 @@ test("flushes a pending message-only envelope byte-identically at EOF", async ()
   assert.equal(await transformed(input), input);
 });
 
-test("compatibility factory is scoped to Grok OAuth event streams", () => {
-  assert.ok(grokReasoningSummaryCompatTransform({ id: "grok-oauth" }, "text/event-stream"));
-  assert.ok(grokReasoningSummaryCompatTransform("grok-oauth", "text/event-stream; charset=utf-8"));
-  assert.equal(grokReasoningSummaryCompatTransform("grok-api", "text/event-stream"), undefined);
-  assert.equal(grokReasoningSummaryCompatTransform("grok-oauth", "application/json"), undefined);
+test("compatibility factory covers LiteLLM Chat Completions event streams", () => {
+  assert.ok(reasoningSummaryCompatTransform({ id: "grok-oauth" }, "text/event-stream"));
+  assert.ok(reasoningSummaryCompatTransform("grok-oauth", "text/event-stream; charset=utf-8"));
+  assert.ok(reasoningSummaryCompatTransform({ id: "commandcode" }, "text/event-stream"));
+  assert.ok(reasoningSummaryCompatTransform({ id: "opencode-go", protocol: "openai" }, "text/event-stream"));
+  assert.ok(reasoningSummaryCompatTransform({ id: "grok-api" }, "text/event-stream"));
+  assert.equal(reasoningSummaryCompatTransform("grok-oauth", "application/json"), undefined);
+  assert.equal(reasoningSummaryCompatTransform({ id: "commandcode" }, "application/json"), undefined);
+  // Direct DeepSeek repairs its own bridge; Messages and Responses providers
+  // never pass through LiteLLM's Chat Completions translation.
+  assert.equal(reasoningSummaryCompatTransform({ id: "deepseek" }, "text/event-stream"), undefined);
+  assert.equal(reasoningSummaryCompatTransform({ id: "commandcode-messages", protocol: "anthropic" }, "text/event-stream"), undefined);
+  assert.equal(reasoningSummaryCompatTransform({ id: "opencode-go-responses", protocol: "openai-responses" }, "text/event-stream"), undefined);
+  assert.equal(reasoningSummaryCompatTransform(undefined, "text/event-stream"), undefined);
+  assert.equal(reasoningSummaryCompatTransform("commandcode", "text/event-stream"), undefined);
+});
+
+test("non-Grok routes relay gateway error envelopes instead of rewriting them", async () => {
+  const input = [
+    pendingGatewayMessage(),
+    block(GATEWAY_ERROR),
+    block({ type: "response.completed", response: { status: "completed", output: [] } }),
+  ].join("");
+  const raw = await transformed(input, 1, { normalizeGatewayErrors: false });
+  assert.doesNotMatch(raw, /local_router_stream_failed/u);
+  assert.ok(raw.includes(block(GATEWAY_ERROR)), "the envelope must be relayed byte-identical");
+  const output = events(raw);
+  assert.equal(output.some((event) => event.type === "error"), false);
+  const envelope = output.findIndex((event) => event.error?.stack === GATEWAY_ERROR.error.stack);
+  const reasoningDone = output.findIndex(
+    (event) => event.type === "response.output_item.done" && event.item?.type === "reasoning",
+  );
+  const messageAdded = output.findIndex(
+    (event) => event.type === "response.output_item.added" && event.item?.type === "message",
+  );
+  assert.ok(reasoningDone >= 0 && reasoningDone < envelope);
+  assert.ok(messageAdded >= 0 && messageAdded < envelope);
+  assert.equal(output[reasoningDone].item.status, "incomplete");
+  assert.deepEqual(output[reasoningDone].item.summary, [{ type: "summary_text", text: "Проверка ещё идёт." }]);
+  assert.ok(output.slice(envelope).some((event) => event.type === "response.completed"));
+});
+
+test("repairs reasoning after a response.created that echoes a Codex Desktop tool list", async () => {
+  // LiteLLM copies instructions and every tool into response.created. Desktop's
+  // MCP tool list pushes that frame past 256 KiB, which used to switch the
+  // repair off for the rest of the stream.
+  const tools = Array.from({ length: 400 }, (_, index) => ({
+    type: "function",
+    name: `mcp__server__tool_${index}`,
+    description: "d".repeat(900),
+    parameters: { type: "object", properties: {} },
+  }));
+  const created = block({
+    type: "response.created",
+    response: { id: "resp_desktop", status: "in_progress", output: [], tools },
+  });
+  assert.ok(Buffer.byteLength(created) > 256 * 1024);
+  const message = { id: "msg_desktop", type: "message", role: "assistant", status: "in_progress", content: [] };
+  const input = [
+    created,
+    block({ type: "response.output_item.added", output_index: 0, item: message }),
+    block({ type: "response.content_part.added", item_id: message.id, output_index: 0, content_index: 0, part: { type: "output_text", text: "", annotations: [] } }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_101", output_index: 0, delta: "Think " }),
+    block({ type: "response.reasoning_summary_text.delta", item_id: "rs_-202", output_index: 0, delta: "first." }),
+    block({ type: "response.output_text.delta", item_id: message.id, output_index: 0, content_index: 0, delta: "Done." }),
+  ].join("");
+  const output = events(await transformed(input, 65_536));
+  assert.equal(output[0].type, "response.created");
+  const reasoningEvents = output.filter(
+    (event) => event.item?.type === "reasoning" || event.type.startsWith("response.reasoning_"),
+  );
+  assert.equal(reasoningEvents[0].type, "response.output_item.added");
+  assert.ok(reasoningEvents.every((event) => (event.item_id ?? event.item?.id) === "rs_101"));
+  assert.equal(reasoningEvents.at(-1).item.summary[0].text, "Think first.");
+  assert.equal(output.find((event) => event.type === "response.output_text.delta").output_index, 1);
 });

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -9850,6 +9850,131 @@ test("router exposes Grok summaries as one canonical Codex reasoning item", asyn
   }
 });
 
+test("router exposes Chat Completions reasoning behind a Desktop-sized prelude", async () => {
+  // Shape captured from commandcode/hy4-preview through pinned LiteLLM: the
+  // message opens first, every reasoning delta carries a fresh hashed id, and
+  // response.created echoes the whole Codex tool list.
+  const model = "commandcode-hy4-preview";
+  const tools = Array.from({ length: 400 }, (_, index) => ({
+    type: "function",
+    name: `mcp__server__tool_${index}`,
+    description: "d".repeat(900),
+    parameters: { type: "object", properties: {} },
+  }));
+  const message = {
+    id: "msg_hy4_live",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "17 × 23 = 391", annotations: [] }],
+  };
+  const deltas = ["We need ", "to multiply ", "17 by 23."];
+  const events = [
+    {
+      type: "response.created",
+      response: { id: "resp_hy4_live", object: "response", status: "in_progress", output: [], tools },
+    },
+    { type: "response.output_item.added", output_index: 0, item: { ...message, status: "in_progress", content: [] } },
+    {
+      type: "response.content_part.added",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "", annotations: [] },
+    },
+    ...deltas.map((delta, index) => ({
+      type: "response.reasoning_summary_text.delta",
+      item_id: `rs_${index % 2 ? "-" : ""}${8812 + index}`,
+      output_index: 0,
+      delta,
+    })),
+    { type: "response.output_text.delta", item_id: message.id, output_index: 0, content_index: 0, delta: "17 × 23 = 391" },
+    { type: "response.output_text.done", item_id: message.id, output_index: 0, content_index: 0, text: "17 × 23 = 391" },
+    {
+      type: "response.content_part.done",
+      item_id: message.id,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: "17 × 23 = 391", annotations: [] },
+    },
+    { type: "response.output_item.done", output_index: 0, item: message },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_hy4_live",
+        object: "response",
+        status: "completed",
+        output: [
+          {
+            type: "reasoning",
+            id: "rs_-3845156871622966097",
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "output_text", text: deltas.join(""), annotations: [] }],
+          },
+          { ...message, id: "bc79c12a-17eb-40cf-a7a4-c36547db556d" },
+        ],
+        usage: { input_tokens: 5, output_tokens: 8, total_tokens: 13 },
+      },
+    },
+  ];
+  const source = events.map((event) => `data: ${JSON.stringify({ ...event, model })}\n\n`).join("");
+  assert.ok(Buffer.byteLength(source.split("\n\n", 1)[0]) > 256 * 1024);
+  const gateway = await mockServer(async (request, response) => {
+    await bodyJson(request);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(`${source}data: [DONE]\n\n`);
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "commandcode/hy4-preview", input: "17*23?", stream: true }),
+    });
+    const text = await response.text();
+    assert.equal(response.status, 200, text);
+    const output = text.split(/\r?\n/u)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trimStart()));
+    const reasoningEvents = output.filter(
+      (event) => event.item?.type === "reasoning" || event.type.startsWith("response.reasoning_"),
+    );
+    assert.deepEqual(reasoningEvents.map((event) => event.type), [
+      "response.output_item.added",
+      "response.reasoning_summary_part.added",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.delta",
+      "response.reasoning_summary_text.done",
+      "response.reasoning_summary_part.done",
+      "response.output_item.done",
+    ]);
+    assert.ok(reasoningEvents.every((event) => (event.item_id ?? event.item?.id) === "rs_8812"));
+    assert.ok(reasoningEvents.every((event) => event.output_index === 0));
+    assert.ok(output
+      .filter((event) => event.item_id === message.id || event.item?.id === message.id)
+      .every((event) => event.output_index === 1));
+    const completed = output.find((event) => event.type === "response.completed").response.output;
+    assert.deepEqual(completed.map((item) => [item.type, item.id]), [
+      ["reasoning", "rs_8812"],
+      ["message", message.id],
+    ]);
+    assert.deepEqual(completed[0].summary, [{ type: "summary_text", text: deltas.join("") }]);
+    assert.equal(completed[1].content[0].text, "17 × 23 = 391");
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 test("router normalizes direct DeepSeek's live reasoning bridge and removes its blank", async () => {
   const model = "deepseek-v4-flash";
   const reasoningText = "Inspect the request, then call the tool exactly once.";


### PR DESCRIPTION
## Problem

Codex showed no reasoning for Chat Completions routes. That includes `commandcode/hy4-preview`, `opencode-go/deepseek-v4.1-flash` and every other route that goes through LiteLLM's Chat Completions → Responses bridge. The models were reasoning, but Codex threw the reasoning away:

- Recent Codex Desktop rollouts on `opencode-go/deepseek-v4.1-flash` contain **0 reasoning items across 204 assistant messages**.
- `grok-oauth/grok-4.6` (which has the existing repair) and `zai-coding/glm-5.3-flash` (a Responses-native provider) do record reasoning.

A live capture through the router shows the broken bridge shape:

```text
response.output_item.added            id=msg_…   out=0 message
response.content_part.added           id=msg_…   out=0
response.reasoning_summary_text.delta id=rs_127734569…  out=0
response.reasoning_summary_text.delta id=rs_547957579…  out=0
response.reasoning_summary_text.delta id=rs_-6290613820… out=0   (×45, a fresh hashed id each)
response.output_text.delta            id=msg_…   out=0
```

The stream never sends a reasoning `output_item.added` or `reasoning_summary_part.added`, and the deltas sit on the message's `output_index`. Codex drops deltas that don't belong to an open item. This is the same failure #597 fixed for Grok OAuth only.

A second problem sits on top of the first. LiteLLM echoes the request's `instructions` and full `tools` array in `response.created` (`streaming_iterator.py`). In Codex Desktop that frame is larger than the repair's 256 KiB pre-commit bound, which switches the repair off for the whole stream. This is the same prelude that #690 fixed for the namespace relay.

## Fix

- `reasoningSummaryCompatTransform` attaches the existing lifecycle repair to every provider whose `protocol` is Chat Completions (`openai`, the default):
  - Direct `deepseek` is excluded because `DeepseekToolMessageCompatTransform` already repairs its bridge.
  - `anthropic` and `openai-responses` providers never pass through this bridge, so they get no new stage.
- Grok OAuth keeps its gateway-error normalization. Other routes relay an untyped LiteLLM error envelope byte-identical, after closing the reasoning item as `incomplete` and releasing any message the repair was holding.
- The pre-commit frame bound rises from 256 KiB to 10 MiB, matching the namespace relay's. The committed bound stays at 64 MiB.
- AGENTS.md records the scope, the error-envelope rule and the prelude bound. CHANGELOG entry added.

## Verification

- **Offline replay of a real Hy4 stream.** A `commandcode/hy4-preview` stream captured through the live router went through `repair → TranslatedToolMessageCompatTransform`. It came out as one reasoning item with a stable id and all 45 deltas, the message moved to `output_index` 1, and `response.completed.output` = `[reasoning, message]`. A tool-call turn in the DeepSeek live-fixture shape came out with reasoning at index 0 ahead of the call.
- **New tests:**
  - A router case with a Desktop-sized (>256 KiB) `response.created` on `commandcode/hy4-preview`.
  - Unit cases for that prelude, the factory scope and non-Grok error envelopes.
  - The existing Grok, direct-DeepSeek and translated-OpenCode router cases still pass.
- `npm run check` passes.
- `npm test`: 3,979 tests, 3,952 passed, 0 failed, 27 skipped.

Not yet done: a live Codex Desktop turn on the patched service showing a `reasoning` item in its rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
