### PR TITLE
test(grok): keep the Grok cancellation check strict and time the close

### DIFF
--- a/scripts/verify-grok-apply-patch-guidance.mjs
+++ b/scripts/verify-grok-apply-patch-guidance.mjs
@@ -752,23 +752,35 @@ try {
     const canceled = await held;
     assert.ok(cancelStreamClosed, "the canceled request must have reached the mock upstream");
     assert.equal(canceled?.name, "AbortError");
-    // On hosted macOS runners the disconnect sometimes fails to reach the mock
-    // within 10 s (4 of ~51 runs by 2026-09-12; Linux and Windows never). The
-    // lagging hop is unproven, so macOS waits longer and then warns instead of
-    // failing, and the remaining protocol checks in this run still execute.
-    const cancelStrict = process.platform !== "darwin";
-    const cancelCloseMs = cancelStrict ? 10_000 : 30_000;
+    // Check the replay invariant before waiting for the close. A late teardown
+    // must never pre-empt it: a cancelled turn that quietly issues a second
+    // upstream request is the costlier failure of the two.
+    assert.equal(capturedGrok.length, 4, "client cancellation must not trigger a replay");
+    // A client abort has to tear down the whole local path -- Router, LiteLLM,
+    // Grok forwarder, upstream -- because that is what stops the provider
+    // generating (and billing) once the user cancels. Hosted macOS runners have
+    // needed more than the original 10 s for the mock to see that close (4 of
+    // ~51 runs by 2026-09-12; Linux and Windows never). Waiting longer keeps the
+    // guarantee on every platform instead of trading it away for quiet CI: the
+    // extra budget costs time only when teardown is late, and a close that never
+    // arrives still fails the run. Runs slower than the old budget report the
+    // measured time, so the lagging hop can be diagnosed from CI output.
+    const CANCEL_CLOSE_BUDGET_MS = 60_000;
+    const CANCEL_CLOSE_EXPECTED_MS = 10_000;
+    const cancelCloseStarted = Date.now();
     let closeTimer;
     const cancelClosed = await Promise.race([
       cancelStreamClosed.then(() => true),
-      new Promise((resolve) => { closeTimer = setTimeout(() => resolve(false), cancelCloseMs); }),
+      new Promise((resolve) => { closeTimer = setTimeout(() => resolve(false), CANCEL_CLOSE_BUDGET_MS); }),
     ]).finally(() => clearTimeout(closeTimer));
+    const cancelCloseMs = Date.now() - cancelCloseStarted;
     if (!cancelClosed) {
-      if (cancelStrict) throw new Error("cancellation did not reach mock upstream");
-      process.stdout.write(`::warning title=Grok cancellation::cancellation did not reach mock upstream within ${cancelCloseMs} ms on macOS\n`);
+      throw new Error(`cancellation did not reach mock upstream within ${CANCEL_CLOSE_BUDGET_MS} ms on ${process.platform}`);
     }
-    assert.equal(capturedGrok.length, 4, "client cancellation must not trigger a replay");
-    process.stdout.write(`ok semantic errors ${nativeHook ? "reach the client hook" : "fail closed"} without a hidden request; client cancellation ${cancelClosed ? "closes the complete local upstream path" : "did not replay (upstream close unconfirmed)"}\n`);
+    if (cancelCloseMs > CANCEL_CLOSE_EXPECTED_MS) {
+      process.stdout.write(`::warning title=Grok cancellation::upstream close took ${cancelCloseMs} ms on ${process.platform}, over the ${CANCEL_CLOSE_EXPECTED_MS} ms this path used to need\n`);
+    }
+    process.stdout.write(`ok semantic errors ${nativeHook ? "reach the client hook" : "fail closed"} without a hidden request; client cancellation closes the complete local upstream path in ${cancelCloseMs} ms\n`);
   }
   if (nativeHook) {
     // Preserve original argument bytes, including whitespace, duplicate keys and

--- a/scripts/verify-grok-apply-patch-guidance.mjs
+++ b/scripts/verify-grok-apply-patch-guidance.mjs
@@ -752,13 +752,23 @@ try {
     const canceled = await held;
     assert.ok(cancelStreamClosed, "the canceled request must have reached the mock upstream");
     assert.equal(canceled?.name, "AbortError");
+    // On hosted macOS runners the disconnect sometimes fails to reach the mock
+    // within 10 s (4 of ~51 runs by 2026-09-12; Linux and Windows never). The
+    // lagging hop is unproven, so macOS waits longer and then warns instead of
+    // failing, and the remaining protocol checks in this run still execute.
+    const cancelStrict = process.platform !== "darwin";
+    const cancelCloseMs = cancelStrict ? 10_000 : 30_000;
     let closeTimer;
-    await Promise.race([
-      cancelStreamClosed,
-      new Promise((_, reject) => { closeTimer = setTimeout(() => reject(new Error("cancellation did not reach mock upstream")), 10_000); }),
+    const cancelClosed = await Promise.race([
+      cancelStreamClosed.then(() => true),
+      new Promise((resolve) => { closeTimer = setTimeout(() => resolve(false), cancelCloseMs); }),
     ]).finally(() => clearTimeout(closeTimer));
+    if (!cancelClosed) {
+      if (cancelStrict) throw new Error("cancellation did not reach mock upstream");
+      process.stdout.write(`::warning title=Grok cancellation::cancellation did not reach mock upstream within ${cancelCloseMs} ms on macOS\n`);
+    }
     assert.equal(capturedGrok.length, 4, "client cancellation must not trigger a replay");
-    process.stdout.write(`ok semantic errors ${nativeHook ? "reach the client hook" : "fail closed"} without a hidden request; client cancellation closes the complete local upstream path\n`);
+    process.stdout.write(`ok semantic errors ${nativeHook ? "reach the client hook" : "fail closed"} without a hidden request; client cancellation ${cancelClosed ? "closes the complete local upstream path" : "did not replay (upstream close unconfirmed)"}\n`);
   }
   if (nativeHook) {
     // Preserve original argument bytes, including whitespace, duplicate keys and


### PR DESCRIPTION
## Problem

The `Grok apply_patch protocol` workflow fails intermittently on macOS only:

```
Error: cancellation did not reach mock upstream
    at scripts/verify-grok-apply-patch-guidance.mjs:758
```

4 of ~51 runs by 2026-09-12, including main's push run for #707. Ubuntu and Windows have never hit it. The check aborts a held stream through Router → LiteLLM → Grok forwarder and waits for the mock upstream's `close`; on those runs the close did not arrive within 10 s.

## What the check is worth

It is not cosmetic. A client abort must tear down the whole local path, which is what stops the provider generating — and billing — once the user cancels. This workflow is also the only CI that exercises the hash-locked Python/LiteLLM Grok path, because `ci.yml` is Node-only.

So the fix keeps the guarantee rather than trading it for quiet CI. An earlier revision of this branch let macOS warn instead of failing; in a workflow that is not a required check, a macOS-only regression would have become an annotation nobody reads.

## Change

- **Strict on every platform.** A close that never arrives still fails the run, on macOS as well.
- **Budget raised from 10 s to 60 s.** The wait costs time only when teardown is late, so a slow-but-correct close passes instead of flaking.
- **Slow closes are measured, not hidden.** Anything past the 10 s this path used to need prints `::warning` with the elapsed time and platform, which is the evidence needed to find the lagging hop.
- **The no-replay assertion runs first.** Previously a late close threw before `capturedGrok.length === 4` was ever checked. A cancelled turn that quietly issues a second upstream request is the costlier failure, so it is now checked unconditionally.

## Testing

- The edited block was extracted from the file and run against three cases with shortened budgets: fast close → passes and reports the time; close past the expected budget → passes and emits the warning with the measured time; close that never arrives → throws.
- `node --check` and `npm run check` pass.
- CI runs the protocol workflow on ubuntu / macOS / windows with python 3.12.

Local verification of the full script is not possible on this machine: it needs the hash-locked `uv` environment, and the repo `.venv` is not functional for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)