### PR TITLE
fix: admit LiteLLM's echoed prelude in the DeepSeek stream repairs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1970,10 +1970,16 @@ the most tools, and no mock gateway with a bare envelope shows it.
    skip part of a frame to fit a budget. Accumulator storage grown past an
    ordinary event is released once its frame is taken, so one large prelude
    does not pin that capacity for the whole stream.
-4. **The scan costs CPU in proportion to the frame.** Every byte of a large
-   prelude is scanned synchronously on the router's event loop. Raising a bound
-   again, or adding another pre-commit parser on the routed path, needs a
-   measurement against a frame at the new bound, not only a passing test.
+4. **The scan costs CPU in proportion to the frame, so keep it bulk.** A
+   pre-commit frame is decoded, uniqueness-scanned, and parsed synchronously on
+   the router's event loop. Measured on the 409 KiB prelude that prompted this:
+   3-6 ms, scaling at roughly 7 ms per MiB to 53 ms at 7.5 MiB. The frame
+   scanner reaches that by jumping between line feeds rather than walking every
+   byte -- the per-byte loop it replaced cost 49 ms on an 8 MiB frame on its
+   own. Raising a bound again, or adding another pre-commit parser to the
+   routed path, needs a measurement at the new bound rather than only a passing
+   test. Measure uncontended: on a loaded machine these numbers inflate by more
+   than an order of magnitude and invite a fix for a cost that is not there.
 5. **Fixtures for this path echo a large, dense tool list.** "router keeps
    DeepSeek message repairs behind a Desktop-sized prelude" in
    `test/routing.test.mjs` asserts that its echoed prelude crosses both old

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1937,6 +1937,49 @@ cheap plans means speaking that route.
    and it is why the note stays on the registry entry now that the plan no
    longer blocks access outright.
 
+## LiteLLM's echoed prelude sets the pre-commit frame bounds
+
+LiteLLM 1.96's Chat Completions to Responses bridge copies the request's
+`instructions` and whole `tools` array into both `response.created` and
+`response.in_progress` (`_default_response_created_event_data` in
+`litellm/responses/litellm_completion_transformation/streaming_iterator.py`);
+its `response.completed` does not echo them. Measured against the pinned
+LiteLLM offline, with no provider quota: a 300-tool list and a 16 KiB
+`instructions` string make `response.created` and `response.in_progress`
+409 KiB each, while `response.completed` stays at 716 bytes and carries
+`tools: []`. A stream repair that meets a frame over any of its pre-commit
+budgets releases the bytes raw and switches itself off for the rest of the
+response, so a small budget disables the repair in exactly the sessions with
+the most tools, and no mock gateway with a bare envelope shows it.
+
+1. **The frame bound is 10 MiB**, matching `MAX_SSE_FRAME_BYTES` in
+   `src/namespace-relay.mjs`. `DeepseekToolMessageCompatTransform` and
+   `TranslatedToolMessageCompatTransform` in
+   `src/deepseek-tool-message-compat.mjs` use it, so the blank-message cleanup
+   and direct DeepSeek's reasoning-bridge repair survive a large prelude.
+2. **Every per-frame budget moves with it.** The strict JSON scan also counts
+   object members and key code units per frame, and tool schemas are
+   member-dense: with only the byte bound raised, the 8 KiB member budget still
+   failed the same frame open. Both scan budgets are derived from the frame
+   bound at the density the 256 KiB bound allowed. The 64 KiB candidate hold
+   budget is deliberately unchanged, because the prelude is relayed as soon as
+   it parses and is never held.
+3. **A bound moves where failure happens, never what it does.** An over-budget
+   frame is still released byte-identical, after any capture held ahead of it,
+   and the repair stays off for that response. Never truncate, re-serialize, or
+   skip part of a frame to fit a budget. Accumulator storage grown past an
+   ordinary event is released once its frame is taken, so one large prelude
+   does not pin that capacity for the whole stream.
+4. **The scan costs CPU in proportion to the frame.** Every byte of a large
+   prelude is scanned synchronously on the router's event loop. Raising a bound
+   again, or adding another pre-commit parser on the routed path, needs a
+   measurement against a frame at the new bound, not only a passing test.
+5. **Fixtures for this path echo a large, dense tool list.** "router keeps
+   DeepSeek message repairs behind a Desktop-sized prelude" in
+   `test/routing.test.mjs` asserts that its echoed prelude crosses both old
+   budgets before it asserts either repair; the small-limit cases in
+   `test/deepseek-tool-message-compat.test.mjs` hold the fail-open semantics.
+
 ## DeepSeek Responses and Chat reasoning replay
 
 Only direct provider `deepseek` with upstream model `deepseek-flash` uses the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Blank tool-call messages and direct DeepSeek reasoning are repaired behind
+  large tool lists.** LiteLLM echoes the request's instructions and whole tool
+  list in `response.created` and `response.in_progress`. The stream repairs
+  that remove LiteLLM's blank assistant message before a tool call (every Chat
+  Completions and Messages route) and rebuild direct DeepSeek's reasoning item
+  gave up on any frame over 256 KiB or with more than 8,192 JSON members, so a
+  session whose tool list crossed either had both repairs switched off from
+  its first event. Mock gateways send a bare envelope and never showed it. The
+  frame bound now matches the namespace relay's 10 MiB, the JSON scan budgets
+  grow with it, and malformed, ambiguous, or over-budget streams still pass
+  through byte-identical.
 - **A routed model the router has not loaded now fails locally, not at
   ChatGPT.** A model added to or renamed in `user-models.json` shows up in the
   Codex picker as soon as the catalog is rebuilt, but the running router reads

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -6,13 +6,25 @@ import { jsonNumberIsStableForRewrite } from "./json-number-rewrite.mjs";
 const MAX_CANDIDATE_BYTES = 64 * 1024;
 const MAX_CANDIDATE_MS = 1_000;
 const MAX_DIRECT_CAPTURE_MS = 60_000;
-const MAX_FRAME_BYTES = 256 * 1024;
+// LiteLLM's Chat Completions bridge echoes the request's instructions and full
+// tools array in response.created and response.in_progress: measured against
+// the pinned 1.96.0, a 300-tool list makes each of those frames 409 KiB. A
+// frame over this pre-commit bound is released raw and turns the repair off
+// for the rest of the stream, so match the namespace relay's prelude bound.
+const MAX_FRAME_BYTES = 10 * 1024 * 1024;
 const MAX_JSON_BYTES = 8 * 1024 * 1024;
 const MAX_JSON_MS = 1_000;
 const MAX_JSON_DEPTH = 256;
-const MAX_FRAME_JSON_MEMBERS = 8 * 1024;
+// The uniqueness scan's per-frame budgets scale with the frame bound, at the
+// density the 256 KiB bound allowed: one member per 32 bytes and one key code
+// unit per 2 bytes. A Desktop tool list is member-dense JSON Schema, so a
+// fixed 8 KiB member budget would fail that same frame open.
+const MAX_FRAME_JSON_MEMBERS = MAX_FRAME_BYTES / 32;
 const MAX_BODY_JSON_MEMBERS = 64 * 1024;
-const MAX_FRAME_JSON_KEY_CODE_UNITS = 128 * 1024;
+const MAX_FRAME_JSON_KEY_CODE_UNITS = MAX_FRAME_BYTES / 2;
+// Frame storage above an ordinary event's size is dropped once its frame is
+// taken, so one large prelude does not pin that capacity for the whole stream.
+const RETAINED_FRAME_STORAGE_BYTES = 256 * 1024;
 const MAX_BODY_JSON_KEY_CODE_UNITS = 1024 * 1024;
 const LF_FRAME_SEPARATOR = Buffer.from("\n\n");
 const CRLF_FRAME_SEPARATOR = Buffer.from("\r\n\r\n");
@@ -222,6 +234,9 @@ class SseFrameAccumulator {
     if (!this.#length) return Buffer.alloc(0);
     const value = Buffer.from(this.#storage.subarray(0, this.#length));
     this.#length = 0;
+    if (this.#storage.length > RETAINED_FRAME_STORAGE_BYTES) {
+      this.#storage = Buffer.alloc(0);
+    }
     return value;
   }
 

--- a/src/deepseek-tool-message-compat.mjs
+++ b/src/deepseek-tool-message-compat.mjs
@@ -193,31 +193,40 @@ class SseFrameAccumulator {
 
   write(value, onFrame) {
     const bytes = Buffer.isBuffer(value) ? value : Buffer.from(value);
-    for (let index = 0; index < bytes.length; index += 1) {
-      this.#append(bytes[index]);
-      const separator = this.#separator();
-      if (separator) {
-        const original = this.take();
-        if (original.length > this.#maxFrameBytes) {
+    let from = 0;
+    while (from < bytes.length) {
+      // The most this frame may still take before it crosses the bound. The
+      // byte at that position is the one a per-byte scan would refuse on, so
+      // never look for a separator past it: an oversized frame must be
+      // reported from there, with the rest of the chunk as the remainder.
+      const room = this.#maxFrameBytes + 1 - this.#length;
+      const limit = Math.min(bytes.length, from + room);
+      const found = this.#separatorEnd(bytes, from, limit);
+      if (!found) {
+        this.#appendRange(bytes, from, limit);
+        if (this.#length > this.#maxFrameBytes) {
           return {
-            oversized: original,
-            remainder: Buffer.from(bytes.subarray(index + 1)),
+            oversized: this.take(),
+            remainder: Buffer.from(bytes.subarray(limit)),
           };
         }
-        const block = original.subarray(0, original.length - separator.length);
-        if (onFrame(block, separator, original) === false) {
-          return {
-            stopped: true,
-            remainder: Buffer.from(bytes.subarray(index + 1)),
-          };
-        }
+        from = limit;
         continue;
       }
-      if (this.#length > this.#maxFrameBytes) {
-        const original = this.take();
+      this.#appendRange(bytes, from, found.end + 1);
+      from = found.end + 1;
+      const original = this.take();
+      if (original.length > this.#maxFrameBytes) {
         return {
           oversized: original,
-          remainder: Buffer.from(bytes.subarray(index + 1)),
+          remainder: Buffer.from(bytes.subarray(from)),
+        };
+      }
+      const block = original.subarray(0, original.length - found.separator.length);
+      if (onFrame(block, found.separator, original) === false) {
+        return {
+          stopped: true,
+          remainder: Buffer.from(bytes.subarray(from)),
         };
       }
     }
@@ -240,8 +249,10 @@ class SseFrameAccumulator {
     return value;
   }
 
-  #append(byte) {
-    const required = this.#length + 1;
+  #appendRange(bytes, start, end) {
+    const length = end - start;
+    if (length <= 0) return;
+    const required = this.#length + length;
     if (required > this.#storage.length) {
       const maximum = this.#maxFrameBytes + 1;
       const doubled = this.#storage.length ? this.#storage.length * 2 : 1024;
@@ -250,26 +261,42 @@ class SseFrameAccumulator {
       if (this.#length) this.#storage.copy(next, 0, 0, this.#length);
       this.#storage = next;
     }
-    this.#storage[this.#length] = byte;
+    bytes.copy(this.#storage, this.#length, start, end);
     this.#length = required;
   }
 
-  #separator() {
-    if (
-      this.#length >= LF_FRAME_SEPARATOR.length &&
-      this.#storage[this.#length - 2] === 0x0a &&
-      this.#storage[this.#length - 1] === 0x0a
+  // Every separator ends with LF, so jump between line feeds instead of
+  // touching each byte: the prelude LiteLLM echoes is hundreds of kilobytes,
+  // and a per-byte loop over it stalls the router's event loop. The bytes
+  // before a candidate may still sit in storage from an earlier chunk, so
+  // read those from there and keep the "first end wins" order a per-byte scan
+  // had. A trailing CRLF pair cannot also end with LF LF, so the two
+  // separators never match at the same position.
+  #separatorEnd(bytes, from, limit) {
+    for (
+      let newline = bytes.indexOf(0x0a, from);
+      newline !== -1 && newline < limit;
+      newline = bytes.indexOf(0x0a, newline + 1)
     ) {
-      return LF_FRAME_SEPARATOR;
-    }
-    if (
-      this.#length >= CRLF_FRAME_SEPARATOR.length &&
-      this.#storage[this.#length - 4] === 0x0d &&
-      this.#storage[this.#length - 3] === 0x0a &&
-      this.#storage[this.#length - 2] === 0x0d &&
-      this.#storage[this.#length - 1] === 0x0a
-    ) {
-      return CRLF_FRAME_SEPARATOR;
+      const accumulated = this.#length + (newline - from) + 1;
+      const byteBefore = (back) => {
+        const index = newline - back;
+        return index >= from ? bytes[index] : this.#storage[this.#length - (from - index)];
+      };
+      if (
+        accumulated >= LF_FRAME_SEPARATOR.length &&
+        byteBefore(1) === 0x0a
+      ) {
+        return { end: newline, separator: LF_FRAME_SEPARATOR };
+      }
+      if (
+        accumulated >= CRLF_FRAME_SEPARATOR.length &&
+        byteBefore(1) === 0x0d &&
+        byteBefore(2) === 0x0a &&
+        byteBefore(3) === 0x0d
+      ) {
+        return { end: newline, separator: CRLF_FRAME_SEPARATOR };
+      }
     }
     return undefined;
   }

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -2069,6 +2069,68 @@ test("delimiter-terminated frames and single-frame cap crossings are bounded", a
   );
 });
 
+// LiteLLM echoes the request's instructions and whole tools array in
+// response.created and response.in_progress. Measured against the pinned
+// 1.96.0, a 300-tool list makes each of those frames 409 KiB: larger than the
+// old 256 KiB frame bound, and denser than its fixed 8 KiB member budget.
+// Either one released that prelude raw and switched the repair off for the
+// rest of the stream, which a bare mock envelope never reproduces.
+function echoedDesktopPrelude() {
+  return {
+    instructions: `You are Codex. ${"i".repeat(16 * 1024)}`,
+    tools: Array.from({ length: 300 }, (_, index) => ({
+      type: "function",
+      name: `mcp__server_${index % 12}__tool_${index}`,
+      description: `Tool ${index}. ${"d".repeat(600)}`,
+      parameters: {
+        type: "object",
+        properties: Object.fromEntries(Array.from({ length: 8 }, (_, field) => [
+          `field_${field}`,
+          { type: "string", description: `Field ${field} of tool ${index}.` },
+        ])),
+        required: ["field_0"],
+        additionalProperties: false,
+      },
+    })),
+  };
+}
+
+test("default bounds admit LiteLLM's echoed Desktop-sized prelude", async () => {
+  const echo = echoedDesktopPrelude();
+  const plain = responseCreated("resp_1", { sequenceNumber: 0 });
+  const echoed = responseCreated("resp_1", { sequenceNumber: 0, response: echo });
+  assert.ok(Buffer.byteLength(echoed) > 256 * 1024);
+  const source = phantomToolStream().replace(plain, echoed);
+
+  const translated = await transformed(source, { maxCandidateMs: 60_000 });
+  assert.ok(translated.startsWith(echoed));
+  assert.equal(translated.includes(blankMessage.id), false);
+  assert.deepEqual(
+    events(translated).find((event) => event.type === "response.completed").response.output,
+    [functionCall],
+  );
+
+  const direct = await transformedDirect(
+    currentDirectDeepseekStream((wireEvents) => {
+      for (const event of wireEvents.slice(0, 2)) Object.assign(event.response, echo);
+    }),
+    { maxCandidateMs: 60_000 },
+  );
+  assert.equal(direct.includes("msg_direct_live"), false);
+  const reasoning = events(direct)
+    .find((event) => event.type === "response.completed").response.output[0];
+  assert.equal(reasoning.type, "reasoning");
+  assert.ok(reasoning.summary[0].text.length > 0);
+
+  // The member budget is the second bound, and it is the one the byte bound
+  // alone does not cover: the old fixed 8 KiB budget fails this same prelude
+  // open byte-for-byte even though it fits the raised frame bound.
+  assert.equal(
+    await transformed(source, { maxJsonMembers: 8 * 1024, maxCandidateMs: 60_000 }),
+    source,
+  );
+});
+
 test("one-byte fragmented frames use bounded concatenation in both SSE paths", async () => {
   const source = `event: opaque\ndata: ${"x".repeat(128 * 1024)}`;
   const options = {

--- a/test/deepseek-tool-message-compat.test.mjs
+++ b/test/deepseek-tool-message-compat.test.mjs
@@ -2131,6 +2131,43 @@ test("default bounds admit LiteLLM's echoed Desktop-sized prelude", async () => 
   );
 });
 
+// The frame scanner jumps between line feeds instead of walking every byte,
+// so the bytes before a candidate separator can still sit in storage from an
+// earlier chunk. Splitting the same stream at every offset is what proves that
+// boundary: a CRLF separator can be cut in three places, and a missed frame
+// end silently changes what the repair sees.
+test("a frame split at any byte boundary repairs identically", async () => {
+  for (const newline of ["\n", "\r\n"]) {
+    for (const [label, build, make] of [
+      [
+        "translated",
+        () => phantomToolStream(newline),
+        () => new TranslatedToolMessageCompatTransform({ maxCandidateMs: 60_000 }),
+      ],
+      [
+        "direct",
+        () => currentDirectDeepseekStream().replaceAll("\n", newline),
+        () => new DeepseekToolMessageCompatTransform({ maxCandidateMs: 60_000 }),
+      ],
+    ]) {
+      const source = build();
+      const bytes = Buffer.from(source);
+      const whole = await transformedBy(make(), bytes);
+      for (let at = 1; at < bytes.length; at += 1) {
+        const stream = make();
+        let output = "";
+        stream.setEncoding("utf8");
+        stream.on("data", (chunk) => { output += chunk; });
+        stream.write(bytes.subarray(0, at));
+        stream.write(bytes.subarray(at));
+        stream.end();
+        await once(stream, "end");
+        assert.equal(output, whole, `${label} ${JSON.stringify(newline)} split at ${at}`);
+      }
+    }
+  }
+});
+
 test("one-byte fragmented frames use bounded concatenation in both SSE paths", async () => {
   const source = `event: opaque\ndata: ${"x".repeat(128 * 1024)}`;
   const options = {

--- a/test/routing.test.mjs
+++ b/test/routing.test.mjs
@@ -10214,6 +10214,297 @@ test("router compacts translated OpenCode routes and pins subagents on both rout
   }
 });
 
+// LiteLLM's Chat Completions bridge echoes the request's instructions and full
+// tools array in response.created and response.in_progress. A Codex Desktop
+// tool list makes that frame larger than 256 KiB and denser than 8 KiB JSON
+// members; a mock gateway with a bare envelope never exercises either bound.
+function desktopSizedToolList() {
+  return Array.from({ length: 300 }, (_, index) => ({
+    type: "function",
+    name: index === 0 ? "exec_command" : `mcp__server_${index % 12}__tool_${index}`,
+    description: `Tool ${index}. ${"d".repeat(600)}`,
+    strict: false,
+    parameters: {
+      type: "object",
+      properties: Object.fromEntries(Array.from({ length: 8 }, (_, field) => [
+        `field_${field}`,
+        { type: "string", description: `Field ${field} of tool ${index}.` },
+      ])),
+      required: ["field_0"],
+      additionalProperties: false,
+    },
+  }));
+}
+
+function jsonMemberCount(value) {
+  if (Array.isArray(value)) {
+    return value.reduce((count, entry) => count + jsonMemberCount(entry), 0);
+  }
+  if (value === null || typeof value !== "object") return 0;
+  return Object.values(value)
+    .reduce((count, entry) => count + 1 + jsonMemberCount(entry), 0);
+}
+
+test("router keeps DeepSeek message repairs behind a Desktop-sized prelude", async () => {
+  const model = "deepseek-v4-flash";
+  const reasoningText = "Inspect the request, then call the tool exactly once.";
+  const blankMessage = {
+    id: "msg_desktop_blank",
+    type: "message",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: "", annotations: [] }],
+  };
+  const functionCall = {
+    id: "call_desktop",
+    type: "function_call",
+    call_id: "call_desktop",
+    name: "exec_command",
+    arguments: "{}",
+    status: "completed",
+  };
+  const terminalReasoning = {
+    id: "rs_-8853496868378332836",
+    type: "reasoning",
+    status: "completed",
+    role: "assistant",
+    content: [{ type: "output_text", text: reasoningText, annotations: [] }],
+  };
+  const terminalBlank = {
+    ...blankMessage,
+    id: "04847f40-ed33-4239-80d2-d392fe38fcc3",
+    content: [{ type: "output_text", annotations: [] }],
+  };
+  const sources = new Map();
+  const gateway = await mockServer(async (request, response) => {
+    const body = await bodyJson(request);
+    const direct = body.input === "direct";
+    // Echo what the router forwarded, exactly where LiteLLM puts it.
+    const envelope = (id, extra = {}) => ({
+      id,
+      ...extra,
+      object: "response",
+      status: "in_progress",
+      error: null,
+      instructions: body.instructions ?? null,
+      output: [],
+      tool_choice: "auto",
+      tools: body.tools ?? [],
+    });
+    const events = direct
+      ? [
+          { type: "response.created", response: envelope("resp_desktop_open", { model }), model },
+          { type: "response.in_progress", response: envelope("resp_desktop_open", { model }), model },
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { ...blankMessage, status: "in_progress", content: [] },
+            model,
+          },
+          {
+            type: "response.content_part.added",
+            item_id: blankMessage.id,
+            output_index: 0,
+            content_index: 0,
+            part: { type: "output_text", text: "", annotations: [] },
+            model,
+          },
+          {
+            type: "response.reasoning_summary_text.delta",
+            item_id: blankMessage.id,
+            output_index: 0,
+            delta: "Inspect the request, then ",
+            model,
+          },
+          {
+            type: "response.reasoning_summary_text.delta",
+            item_id: blankMessage.id,
+            output_index: 0,
+            delta: "call the tool exactly once.",
+            model,
+          },
+          {
+            type: "response.output_item.added",
+            output_index: 1,
+            item: { ...functionCall, arguments: "", status: "in_progress" },
+            model,
+          },
+          {
+            type: "response.function_call_arguments.delta",
+            item_id: functionCall.id,
+            output_index: 1,
+            delta: "{}",
+            model,
+          },
+          {
+            type: "response.function_call_arguments.done",
+            item_id: functionCall.id,
+            output_index: 1,
+            arguments: "{}",
+            model,
+          },
+          {
+            type: "response.output_item.done",
+            output_index: 1,
+            sequence_number: 16,
+            item: functionCall,
+            model,
+          },
+          {
+            type: "response.output_text.done",
+            item_id: blankMessage.id,
+            output_index: 0,
+            content_index: 0,
+            text: "",
+            model,
+          },
+          {
+            type: "response.content_part.done",
+            item_id: blankMessage.id,
+            output_index: 0,
+            content_index: 0,
+            part: { type: "reasoning_text", reasoning: reasoningText },
+            model,
+          },
+          {
+            type: "response.output_item.done",
+            output_index: 0,
+            sequence_number: 1,
+            item: blankMessage,
+            model,
+          },
+          {
+            type: "response.completed",
+            response: {
+              id: "resp_desktop_closed",
+              model,
+              object: "response",
+              status: "completed",
+              error: null,
+              output: [terminalReasoning, terminalBlank, functionCall],
+              usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+            },
+            model,
+          },
+        ]
+      : [
+          { type: "response.created", response: envelope("resp_desktop_tool_only") },
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { ...blankMessage, status: "in_progress", content: [] },
+          },
+          {
+            type: "response.output_item.added",
+            output_index: 1,
+            item: { ...functionCall, arguments: "", status: "in_progress" },
+          },
+          { type: "response.output_item.done", output_index: 1, item: functionCall },
+          { type: "response.output_item.done", output_index: 0, item: blankMessage },
+          {
+            type: "response.completed",
+            response: {
+              id: "resp_desktop_tool_only",
+              object: "response",
+              status: "completed",
+              error: null,
+              output: [terminalBlank, functionCall],
+              usage: { input_tokens: 5, output_tokens: 2, total_tokens: 7 },
+            },
+          },
+        ];
+    const source = events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+    sources.set(body.input, source);
+    response.writeHead(200, { "Content-Type": "text/event-stream" });
+    response.end(source);
+  });
+  const routerPort = await openPort();
+  const router = run("router.mjs", {
+    CODEX_ROUTER_PORT: String(routerPort),
+    CODEX_ROUTER_GATEWAY_BASE_URL: `http://127.0.0.1:${gateway.port}/v1`,
+    CODEX_ROUTER_QUIET: "1",
+  });
+  const turn = async (slug, input) => {
+    const response = await fetch(`${routerBase(routerPort)}/responses`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: slug,
+        input,
+        stream: true,
+        instructions: `You are Codex. ${"i".repeat(16 * 1024)}`,
+        tools: desktopSizedToolList(),
+      }),
+    });
+    const text = await response.text();
+    assert.equal(response.status, 200, text);
+    // The fixture only proves something if the echoed prelude crossed both
+    // pre-commit bounds that used to switch the repair off.
+    const [prelude] = sources.get(input).split("\n\n", 1);
+    assert.ok(Buffer.byteLength(prelude) > 256 * 1024, "prelude is not Desktop-sized");
+    assert.ok(
+      jsonMemberCount(JSON.parse(prelude.slice(5))) > 8 * 1024,
+      "prelude is not Desktop-dense",
+    );
+    const events = text.split(/\r?\n/)
+      .filter((line) => line.startsWith("data: {"))
+      .map((line) => JSON.parse(line.slice(5).trim()));
+    return { text, events };
+  };
+
+  try {
+    await waitFor(`${routerBase(routerPort)}/models`, router);
+
+    const translated = await turn("opencode-go/deepseek-v4-flash", "translated");
+    assert.equal(translated.text.includes(blankMessage.id), false);
+    assert.equal(translated.text.includes(terminalBlank.id), false);
+    assert.equal(
+      translated.events.find((event) => event.item?.id === functionCall.id).output_index,
+      0,
+    );
+    assert.deepEqual(
+      translated.events.find((event) => event.type === "response.completed").response.output,
+      [functionCall],
+    );
+
+    const direct = await turn("deepseek/deepseek-v4-flash-vision-exp", "direct");
+    assert.equal(direct.text.includes(blankMessage.id), false);
+    assert.equal(direct.text.includes(terminalBlank.id), false);
+    assert.deepEqual(
+      direct.events
+        .filter((event) => (event.item_id ?? event.item?.id) === terminalReasoning.id)
+        .map((event) => [event.type, event.output_index]),
+      [
+        ["response.output_item.added", 0],
+        ["response.reasoning_summary_part.added", 0],
+        ["response.reasoning_summary_text.delta", 0],
+        ["response.reasoning_summary_text.delta", 0],
+        ["response.reasoning_summary_text.done", 0],
+        ["response.reasoning_summary_part.done", 0],
+        ["response.output_item.done", 0],
+      ],
+    );
+    assert.ok(direct.events
+      .filter((event) => (event.item_id ?? event.item?.id) === functionCall.id)
+      .every((event) => event.output_index === 1));
+    assert.deepEqual(
+      direct.events.find((event) => event.type === "response.completed").response.output,
+      [
+        {
+          id: terminalReasoning.id,
+          type: "reasoning",
+          status: "completed",
+          summary: [{ type: "summary_text", text: reasoningText }],
+        },
+        functionCall,
+      ],
+    );
+  } finally {
+    await stopChild(router);
+    await closeServer(gateway.server);
+  }
+});
+
 test("router response pipelines preserve ambiguous provider bytes exactly", async () => {
   const validNamespaceEvent = Buffer.from(
     'data: {"type":"response.output_item.done","item":{"type":"function_call","name":"collaboration__spawn_agent","arguments":"{}"}}\r\n\r\n',


### PR DESCRIPTION
## The bug

LiteLLM's Chat Completions to Responses bridge echoes the request's
`instructions` and whole `tools` array in `response.created` **and**
`response.in_progress`. Both SSE repairs in
`src/deepseek-tool-message-compat.mjs` — the blank-assistant-message cleanup
that serves every translated route, and direct DeepSeek's reasoning-bridge
repair — bounded a pre-commit frame at 256 KiB. A frame over that bound is
released raw and the repair disables itself for the rest of the response, so a
session with a large tool list kept LiteLLM's blank assistant message in the
turn and never got its DeepSeek reasoning item rebuilt. Mock gateways answer
with a bare envelope, so nothing in the suite crossed the bound.

This is the same prelude PR #690 raised `MAX_SSE_FRAME_BYTES` to 10 MiB for in
`src/namespace-relay.mjs`.

## Measured, not inferred

Probed offline against the repository's pinned LiteLLM 1.96.0
(`litellm.aresponses(..., use_chat_completions_api=True, stream=True)` against
a loopback mock upstream, synthetic credentials, no provider quota), with 300
tools and a 16 KiB `instructions` string:

| event | bytes | tools echoed |
| --- | --- | --- |
| `response.created` | 409,568 | 300 |
| `response.in_progress` | 409,572 | 300 |
| `response.completed` | 716 | `[]` |

## The byte bound was not the only one

Raising `MAX_FRAME_BYTES` alone left the new test failing on the same
assertion. `strictJsonPreflight` also budgets **object members per frame**
(8 KiB) and key code units (128 KiB), and a tool list is member-dense JSON
Schema. Both scan budgets are now derived from the frame bound at the density
the 256 KiB bound allowed — one member per 32 bytes, one key code unit per
2 bytes — so the previous values fall out unchanged at the old bound.

`maxCandidateBytes` (64 KiB) is deliberately **not** raised: a prelude frame is
relayed as soon as it parses and is never held, and `response.completed`, which
*is* held, echoes nothing (see the table).

Accumulator storage grown past an ordinary event is released once its frame is
taken, so one large prelude no longer pins that capacity for the whole stream.

## Tests

Written failing first, then fixed:

- `test/routing.test.mjs` — "router keeps DeepSeek message repairs behind a
  Desktop-sized prelude": one router, a translated `opencode-go/deepseek-v4-flash`
  turn and a direct `deepseek/...` turn, with the mock gateway echoing the
  request's real tool list the way LiteLLM does. It asserts the echoed prelude
  crosses **both** old budgets before asserting either repair.
- `test/deepseek-tool-message-compat.test.mjs` — "default bounds admit
  LiteLLM's echoed Desktop-sized prelude", covering both transforms directly,
  and pinning the member budget as a distinct bound by showing the same prelude
  still fails open byte-for-byte under a small `maxJsonMembers`.

Fail-open semantics are unchanged, and the existing small-limit cases still
pass.

## Verification

`npm run check` plus `deepseek-tool-message-compat` (91), `routing` (133),
`namespace-relay-routing` (31), `namespace-relay-custom` (6),
`deepseek-responses-routing` (7), `message-phase` (14), and
`empty-completion-router` (39) all pass on the rebased branch.

Failures seen earlier were machine load, not this diff: with other suites
saturating the host (load average >200), scattered Grok/health tests failed on
an **untouched `origin/main` worktree** identically, and each one passed 3-5/5
on both trees once load dropped.

## Cost, measured and then fixed

My first estimate here was wrong and is worth flagging: I measured ~80 ms per
MiB while another process had this machine at load average >200. Uncontended,
the honest numbers are much smaller, and the second commit removes most of what
was left.

The frame accumulator walked the prelude one byte at a time, which cost 49 ms
on an 8 MiB frame by itself. It now jumps between line feeds with `indexOf` and
copies each run in one `Buffer.copy`: 5.3 ms for the same frame.

End to end through the transform, uncontended:

| prelude | cost |
| --- | --- |
| 409 KiB (300 tools, the real case) | 3-6 ms |
| 1.5 MiB | ~11 ms |
| 7.6 MiB (near the bound) | ~53 ms |

The bulk scanner is verified against the previous per-byte implementation over
60,000 randomized streams and chunk boundaries — frames, separators, oversize
cuts, stop requests and remainders all identical — and a new test splits the
same stream at every byte offset, in both newline spellings, through both
transforms, since a separator can be cut across chunks in three places.

A regex fast path for the JSON uniqueness scan was also prototyped and
**dropped**: 400,000 differential cases passed but it was no faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
