### PR TITLE
feat(ollama-cloud): route DeepSeek V4.1 Flash

### DIFF
--- a/config/ollama/cloud/deepseek-v4.1-flash.json
+++ b/config/ollama/cloud/deepseek-v4.1-flash.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "models": [
+    {
+      "slug": "ollama-cloud/deepseek-v4.1-flash",
+      "gatewayModel": "ollama-cloud-deepseek-v4-1-flash",
+      "upstreamModel": "deepseek-v4.1-flash:cloud",
+      "provider": "ollama-cloud",
+      "listed": true,
+      "displayName": "DeepSeek V4.1 Flash (Ollama Cloud)",
+      "description": "DeepSeek V4.1 Flash hosted on Ollama Cloud, a 552B Mixture-of-Experts model with tool support, image input, reasoning, and a 1M-token context window.",
+      "priority": 27,
+      "defaultEffort": "high",
+      "reasoningLevels": [
+        {
+          "effort": "low",
+          "description": "Faster reasoning"
+        },
+        {
+          "effort": "high",
+          "description": "Deep reasoning"
+        },
+        {
+          "effort": "max",
+          "description": "Maximum reasoning depth"
+        }
+      ],
+      "contextWindow": 1048576,
+      "autoCompact": 900000,
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "requestProfile": "ollama-cloud",
+      "compHash": "ollama-cloud-deepseek-v4-1-flash-v1"
+    }
+  ]
+}

--- a/docs/research/deepseek-v4-1-flash-2026-09-11.md
+++ b/docs/research/deepseek-v4-1-flash-2026-09-11.md
@@ -102,11 +102,29 @@ Route: `nousresearch/deepseek-v4.1-flash`, window 262,144 compacting at
 Sources: https://ollama.com/search?c=cloud, https://ollama.com/api/tags,
 https://github.com/ollama/ollama/issues/18360.
 
-- No V4.1 Flash as of 2026-09-11; `library/deepseek-v4.1-flash` returns 404
-  and the cloud API lists only `deepseek-v4-flash:0731` and
-  `deepseek-v4-pro:0813`. An open request asks for it.
-- No route added. The library page now lists V4 Pro at 1M context while the
-  checked-in route declares 524,288; not changed here.
+- Not served on 2026-09-11: `library/deepseek-v4.1-flash` returned 404 and the
+  cloud API listed only `deepseek-v4-flash:0731` and `deepseek-v4-pro:0813`.
+- **Rechecked 2026-09-12: it is served now.** The library publishes
+  `deepseek-v4.1-flash:cloud` (digest `72434d5a621f`, 1M context, text and
+  image input, tools, 552B MoE backbone), and `https://ollama.com/api/tags`
+  lists `deepseek-v4.1-flash` beside the two V4 ids. The cloud catalog shows
+  ~7.2K pulls against V4 Flash's 448K, so it landed within the last day.
+- Route: `ollama-cloud/deepseek-v4.1-flash`, window 1,048,576 compacting at
+  900,000, text and image, efforts low/high/max. It takes the plain
+  `ollama-cloud` profile rather than `ollama-cloud-auto-tool-choice`: Ollama
+  serves the weights itself, so the DeepSeek API's thinking-mode rejection of
+  forced tool choices is not known to apply, and the V4 Flash route on this
+  provider already runs without that exception. Move both if a live request
+  proves otherwise.
+- Not verified live. `ollama-cloud` has no stored credential here, so neither
+  `bin/discover-models ollama-cloud` nor `bin/test-model --live` could run, and
+  the `:cloud` tag is taken from the library page rather than from a served
+  response. Ollama's own `/api/tags` answers under the bare name, and the
+  checked-in V4 routes disagree with each other on this point already
+  (`deepseek-v4-flash:cloud` against a served `deepseek-v4-flash:0731`,
+  `deepseek-v4-pro` against `deepseek-v4-pro:0813`).
+- The library page now lists V4 Pro at 1M context while the checked-in route
+  declares 524,288; not changed here.
 
 ## Command Code (`commandcode`)
 

--- a/test/deepseek-v4-1-flash.test.mjs
+++ b/test/deepseek-v4-1-flash.test.mjs
@@ -93,6 +93,34 @@ test("DeepSeek V4.1 Flash on OpenRouter takes the catalog window and DeepSeek's 
   assert.ok(model.priority > MODEL_BY_SLUG.get("deepseek/deepseek-v4.1-flash").priority);
 });
 
+test("DeepSeek V4.1 Flash on Ollama Cloud uses the cloud tag and the shared serving profile", () => {
+  const model = MODEL_BY_SLUG.get("ollama-cloud/deepseek-v4.1-flash");
+  assert.ok(model);
+  assert.equal(model.provider, "ollama-cloud");
+  // The library page publishes this as a cloud-only tag, the same shape every
+  // other cloud-only route on this provider already carries.
+  assert.equal(model.upstreamModel, "deepseek-v4.1-flash:cloud");
+  assert.equal(model.listed, true);
+  // Ollama serves the weights itself, so the DeepSeek API's thinking-mode
+  // tool_choice rejection is not known to apply here. The V4 Flash sibling on
+  // this provider carries the same plain profile; if a live request shows a
+  // forced tool choice failing, both move to ollama-cloud-auto-tool-choice.
+  assert.equal(model.requestProfile, "ollama-cloud");
+  assert.equal(
+    MODEL_BY_SLUG.get("ollama-cloud/deepseek-v4-flash").requestProfile,
+    "ollama-cloud",
+  );
+  assert.equal(model.defaultEffort, "high");
+  assert.deepEqual(model.reasoningLevels.map(({ effort }) => effort), ["low", "high", "max"]);
+  assert.equal(model.contextWindow, 1_048_576);
+  assert.equal(model.autoCompact, 900_000);
+  assert.ok(model.contextWindow - model.autoCompact >= MAX_EFFORT_DEFAULT_OUTPUT);
+  assert.deepEqual(model.inputModalities, ["text", "image"]);
+  assert.notEqual(model.multiAgentVersion, "v2");
+  // Appended after the V4 routes rather than displacing them in the picker.
+  assert.ok(model.priority > MODEL_BY_SLUG.get("ollama-cloud/deepseek-v4-flash").priority);
+});
+
 test("V4.1 Flash is added alongside the V4 routes rather than replacing them", () => {
   for (const [slug, upstreamModel] of [
     ["deepseek/deepseek-v4-flash", "deepseek-v4-flash"],
@@ -100,6 +128,8 @@ test("V4.1 Flash is added alongside the V4 routes rather than replacing them", (
     ["deepseek/deepseek-v4-pro", "deepseek-v4-pro"],
     ["opencode-go/deepseek-v4-flash", "deepseek-v4-flash"],
     ["opencode-go/deepseek-v4-pro", "deepseek-v4-pro"],
+    ["ollama-cloud/deepseek-v4-flash", "deepseek-v4-flash:cloud"],
+    ["ollama-cloud/deepseek-v4-pro", "deepseek-v4-pro"],
   ]) {
     const model = MODEL_BY_SLUG.get(slug);
     assert.ok(model, slug);

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -152,6 +152,7 @@ test("provider registry exposes configured API and OAuth model families", () => 
       "nousresearch/step-3.7-flash-free",
       "ollama-cloud/deepseek-v4-flash",
       "ollama-cloud/deepseek-v4-pro",
+      "ollama-cloud/deepseek-v4.1-flash",
       "ollama-cloud/glm-5.2",
       "ollama-cloud/glm-5.3-flash",
       "ollama-cloud/glm-5.3",


### PR DESCRIPTION
Ollama Cloud began serving DeepSeek V4.1 Flash after the 2026-09-11 research
pass recorded it as absent, so #682 shipped every other provider's route but
not this one. This adds it.

## Evidence

- The library publishes `deepseek-v4.1-flash:cloud` — digest `72434d5a621f`,
  1M context, text and image input, agentic tools, 552B MoE backbone.
- `https://ollama.com/api/tags` lists `deepseek-v4.1-flash` beside the two
  already-routed ids, `deepseek-v4-flash:0731` and `deepseek-v4-pro:0813`.
- The cloud catalog shows ~7.2K pulls against V4 Flash's 448K, so it landed
  within a day of this change.

## The route

`ollama-cloud/deepseek-v4.1-flash`, window 1,048,576 compacting at 900,000,
text and image, efforts low/high/max defaulting to high, priority 27 — appended
after the V4 siblings, the placement #682 gave the direct route. Every existing
V4 route stays listed.

It takes the plain `ollama-cloud` profile rather than
`ollama-cloud-auto-tool-choice`. That variant is a model-scoped exception for
MiniMax M3's malformed arguments under a forced tool choice, not a DeepSeek
rule: Ollama serves the weights itself, so the DeepSeek API's thinking-mode
rejection of forced tool choices is not known to apply here, and the V4 Flash
route on this provider already runs without the exception. Forcing `auto`
without cause would disable Codex's forced-tool probe and the subagent payload
relay where they work. The test and the research note both say to move both
routes if a live request proves otherwise.

## Verification

`npm run check` passes. `npm test` reports 3937 pass / 0 fail once the twelve
unrelated process-tree and timing flakes are re-run on their own (309 tests
across those eight files: 308 pass, 1 skipped, 0 fail). The one real failure in
the first full run was the ordered slug list in `test/registry.test.mjs`, fixed
here.

**Not verified live.** No `ollama-cloud` credential is available, so neither
`bin/discover-models ollama-cloud` nor
`bin/test-model 'ollama-cloud/deepseek-v4.1-flash' --live --yes` could run, and
AGENTS.md's live compatibility test is therefore outstanding. The `:cloud`
suffix comes from the library page rather than a served response — Ollama's own
`/api/tags` answers under the bare name, and the two checked-in V4 routes
already disagree on this point (`deepseek-v4-flash:cloud` against a served
`deepseek-v4-flash:0731`, and a bare `deepseek-v4-pro` against
`deepseek-v4-pro:0813`). A live request should settle it before this is relied
on.

Also left alone: the library now lists V4 Pro at 1M context while
`ollama-cloud/deepseek-v4-pro` declares 524,288. Recorded in the research note,
not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
