### PR TITLE
test: stop the Electron control center suite from starving itself

### DIFF
--- a/apps/control-center/package.json
+++ b/apps/control-center/package.json
@@ -16,7 +16,7 @@
     "electron:dev": "concurrently -k \"vite --host 127.0.0.1\" \"wait-on http://127.0.0.1:5173 && cross-env VITE_DEV_SERVER_URL=http://127.0.0.1:5173 electron .\"",
     "electron:build": "npm run build && electron-builder",
     "check": "tsc --noEmit && node --check main.mjs && node --check electron/main.mjs && node --check electron/preload.cjs && node --check electron/ipc.mjs && node --check electron/command-runner.mjs",
-    "test": "npm run build && node --test ../../test/control-center-electron.test.mjs ../../test/control-center-harness.test.mjs ../../test/control-center-usage.test.mjs test/renderer.test.mjs"
+    "test": "npm run build && node --test --test-concurrency=1 ../../test/control-center-electron.test.mjs ../../test/control-center-harness.test.mjs ../../test/control-center-usage.test.mjs test/renderer.test.mjs"
   },
   "dependencies": {
     "lucide-react": "1.31.0",

--- a/test/control-center-electron.test.mjs
+++ b/test/control-center-electron.test.mjs
@@ -223,7 +223,9 @@ test("ChatGPT browser login has a bounded post-handoff completion deadline", asy
       onExit: (value) => { outcome = value; },
     });
     assert.deepEqual(opened, { opened: true, surface: "browser" });
-    const deadline = Date.now() + 2_000;
+    // The 40 ms completion deadline above is what is under test; this is only
+    // how long we are willing to wait for the process to report it.
+    const deadline = Date.now() + 20_000;
     while (!outcome && Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, 20));
     }
@@ -633,6 +635,25 @@ test("Linux tray-only mode trusts only a positively registered StatusNotifier ho
   }), false);
 });
 
+// The fixture records its descendant as soon as it is spawned, but the whole
+// command can be terminated before that write lands on a busy machine. Wait
+// briefly and say what happened: reading the file directly reported a bare
+// ENOENT that read as a missing temp directory rather than a descendant that
+// never started.
+async function readPidFile(pidFile, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try { return await readFile(pidFile, "utf8"); }
+    catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+      if (Date.now() >= deadline) {
+        assert.fail(`the command fixture never recorded a descendant pid in ${pidFile}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+}
+
 async function waitForProcessExit(pid, timeoutMs = 4_000) {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
@@ -661,8 +682,14 @@ async function makeProcessTreeControlRoot() {
       // Hold the command's stdout/stderr pipes open after its leader exits, so
       // the runner has to act on `exit` rather than waiting forever for `close`.
       'const descendant = spawn(process.execPath, ["-e", worker], { stdio: ["ignore", "inherit", "inherit", "ipc"] });',
+      // The timeout mode is killed on a deadline, so record the descendant as
+      // soon as it has a pid. Waiting for its IPC "ready" first put a second
+      // Node startup inside that deadline, and a loaded runner spent it: the
+      // tree was terminated correctly and the test then read no pid file at
+      // all. The other modes still report after the handshake.
+      'if (mode === "timeout") writeFileSync(pidFile, String(descendant.pid));',
       'descendant.once("message", () => {',
-      '  writeFileSync(pidFile, String(descendant.pid));',
+      '  if (mode !== "timeout") writeFileSync(pidFile, String(descendant.pid));',
       '  if (mode === "success") process.exit(0);',
       '  if (mode === "failure") process.exit(7);',
       '  if (mode === "overflow") process.stdout.write("x".repeat(4096));',
@@ -2177,11 +2204,15 @@ for (const mode of ["timeout", "overflow"]) {
       const command = runControl(
         [pidFile, mode],
         mode === "timeout"
-          ? { timeoutMs: process.platform === "win32" ? 2_000 : 250 }
+          // Long enough that the fixture's own Node startup fits inside it on
+          // a loaded runner -- the deadline is what is under test, not how
+          // fast a process can boot. A 250 ms budget failed outright once the
+          // machine was busy, and the tree was never the reason.
+          ? { timeoutMs: process.platform === "win32" ? 6_000 : 3_000 }
           : { timeoutMs: 5_000, maxOutputBytes: 32 },
       );
       await assert.rejects(command, mode === "timeout" ? /timed out/ : /output exceeded/);
-      descendantPid = Number.parseInt(await readFile(pidFile, "utf8"), 10);
+      descendantPid = Number.parseInt(await readPidFile(pidFile), 10);
       assert.ok(Number.isInteger(descendantPid) && descendantPid > 0);
       await waitForProcessExit(descendantPid);
     } finally {
@@ -2208,11 +2239,13 @@ for (const { mode, expectedCode } of [
     try {
       process.env.CODEX_ROUTER_SOURCE_ROOT = root;
       const result = await runControl([pidFile, mode], {
-        timeoutMs: 5_000,
+        // Only has to outlast two Node startups on a busy runner; a passing
+        // command returns as soon as it is done and never spends this.
+        timeoutMs: 30_000,
         allowNonZero: true,
       });
       assert.equal(result.code, expectedCode);
-      descendantPid = Number.parseInt(await readFile(pidFile, "utf8"), 10);
+      descendantPid = Number.parseInt(await readPidFile(pidFile), 10);
       assert.ok(Number.isInteger(descendantPid) && descendantPid > 0);
       await waitForProcessExit(descendantPid);
       await new Promise((resolve) => setTimeout(resolve, 700));


### PR DESCRIPTION
## The symptom

`Electron control center (Windows)` fails intermittently with nine tests dying
at once across unrelated suites — router commands hitting their 30 s bound,
Playwright waits expiring, and:

```
Error: ENOENT: no such file or directory, open '...\router-control-tree-qpcJVe\timeout.pid'
Error: Router command timed out.
```

It failed [#710](https://github.com/duolahypercho/codex-router/pull/710) this way while the same suite passed on Linux for the
identical commit, and `main` has failed it on its own (`6da246fd`).

## The cause

Everything failing at once, across suites that share nothing, is starvation
rather than a bad test. `apps/control-center`'s `npm test` passes four heavy
files to one `node --test`, and node runs *files* in parallel up to the core
count — so the process-tree suite and the Playwright renderer suite fight over
a 4-core runner. The budgets that lose are the ones measured in milliseconds.

Three of those budgets were unrealistic regardless:

| test | budget | what had to fit in it |
| --- | --- | --- |
| `command timeout terminates its full descendant process tree` | 250 ms (2 s Windows) | Node startup, spawning a second Node, an IPC handshake, then a pid write |
| `retires descendants holding inherited pipes` | 5 s | a command that spawns two processes |
| `bounded post-handoff completion deadline` | 2 s | a process reporting a 40 ms deadline |

The first one is the ENOENT: the command's deadline fired *before* the fixture
recorded its descendant, so the tree was terminated exactly as intended and the
test then read a file nobody had written.

## The fix

- Run the four files one at a time (`--test-concurrency=1`).
- Record the descendant's pid as soon as it exists in timeout mode, instead of
  after an IPC round trip, and give the command enough time to boot a process.
- Raise the two budgets that a passing path never spends.
- Wait for the pid file and fail with what happened, rather than a bare ENOENT.

No assertion is weakened: the 40 ms completion deadline, the `timed out`
rejection, the exit codes, and the descendant-exit checks are all unchanged.

## Verification

Reproduced deliberately by loading this machine to a load average of ~150:

| | result |
| --- | --- |
| `origin/main` | **7 of 8 runs failed**, with the exact CI signature (`ENOENT ... timeout.pid`) |
| this branch | **8 of 8 passed** |

Unloaded: `control-center-electron` 69/69, `control-center-harness` 17/17,
`control-center-usage` 5/5, `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
